### PR TITLE
Add CLI end-to-end tests

### DIFF
--- a/.github/workflows/cli-e2e-tests.yml
+++ b/.github/workflows/cli-e2e-tests.yml
@@ -1,0 +1,46 @@
+name: CLI E2E Tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "src/backend/**"
+      - "src/cli-e2e/**"
+      - "src/dockerimage/**"
+      - ".github/workflows/cli-e2e-tests.yml"
+  push:
+    branches: [main]
+    paths:
+      - "src/backend/**"
+      - "src/cli-e2e/**"
+      - "src/dockerimage/**"
+      - ".github/workflows/cli-e2e-tests.yml"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -e src/backend/
+
+      - name: Pull base image
+        run: docker pull ghcr.io/mcdonc/bark/bark-pi-base:latest
+
+      - name: Build workspace image
+        run: |
+          STAGING=$(mktemp -d)
+          mkdir -p "$STAGING/extensions" "$STAGING/tools"
+          docker build --platform linux/amd64 \
+            --build-context plugin-extensions="$STAGING/extensions" \
+            --build-context plugin-tools="$STAGING/tools" \
+            -t bark-pi src/dockerimage/
+
+      - name: Run CLI E2E tests
+        run: python -m pytest src/cli-e2e -v -p no:xdist --no-cov

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -102,10 +102,11 @@ bark/
     pyproject.toml              # Python deps: fastapi, aiodocker, aiosqlite, bcrypt, python-jose
     bark_backend/
       cli/                      # CLI tool (bark command) — typer app, thin HTTP+WebSocket client
-        main.py                 # Typer app: login, logout, status, ws {list,create,delete,shell}
+        main.py                 # Typer app: login, logout, status, ws {list,create,delete,shell,exec,sync}
         auth.py                 # Login/logout with token reuse, rich prompts, --password-file
-        client.py               # BarkClient (HTTP), WebSocket shell session with PTY forwarding
+        client.py               # BarkClient (HTTP), WebSocket shell/exec session forwarding
         config.py               # Config storage (~/.config/bark/cli.toml)
+      exec_session.py           # Raw docker exec subprocess (no PTY) for piped commands (rsync transport)
       main.py                   # FastAPI app, lifespan, default user seeding, static file serving
       api.py                    # API route handlers (health, auth, workspaces, files, messages, admin) via APIRouter
       auth.py                   # Register/login/logout, JWT with roles, bcrypt, require_role(), email validation, verification tokens
@@ -115,10 +116,13 @@ bark/
       container_manager.py      # Docker lifecycle, port allocation, idle timeout, session resume env, shutdown cleanup
       pi_rpc_client.py          # docker attach subprocess for Pi stdin/stdout JSON-RPC (chunked reads for large events)
       agui_translator.py        # Pi RPC events → AG-UI events mapping, file-change detection
-      ws_handler.py             # WebSocket auth, workspace routing, AG-UI streaming, session resume, auto-restart
+      ws_handler.py             # WebSocket auth, workspace routing, AG-UI streaming, exec sessions, session resume, auto-restart
       file_service.py           # Host-side file read/write/delete/rename with path traversal protection
       terminal_manager.py      # Docker exec PTY subprocess for interactive shell access
     tests/                      # pytest unit tests (100% coverage, parallel via xdist)
+
+  src/cli-e2e/
+    test_cli_e2e.py             # CLI E2E tests (real server + Docker, run with test-cli-e2e)
 
   src/frontend/
     pubspec.yaml                # Flutter deps: flutter_markdown_plus, flutter_highlight, go_router, etc.

--- a/CLI.md
+++ b/CLI.md
@@ -51,6 +51,8 @@ Add to `pyproject.toml`:
 | `bark ws create NAME`                                      | Create a workspace                                                               |
 | `bark ws delete NAME`                                      | Delete a workspace                                                               |
 | `bark ws shell [WORKSPACE]`                                | **Main command.** Connect to workspace, drop into bash inside the container.     |
+| `bark ws exec WORKSPACE COMMAND...`                        | Run a command in a container. Also usable as an rsync transport.                 |
+| `bark ws sync SRC DEST`                                    | Sync files to/from a container via rsync (wraps `bark ws exec`).                 |
 
 ## `bark ws shell` — The Core Flow
 
@@ -129,23 +131,18 @@ email = "admin@example.com"
 - CLI impact: add `--image` flag to `bark ws create`, no other commands change
 - Note: Phase 1 CLI commands are pure REST/WebSocket clients with no Docker or image references, so no refactoring needed
 
-### Phase 5 (future): File copy command
+### Phase 5 (done): Exec, sync, and E2E tests
 
-- `bark cp LOCAL WORKSPACE:PATH` and `bark cp WORKSPACE:PATH LOCAL` for copying files to/from containers
-- Upload uses the existing REST file upload API (`POST /workspaces/{id}/files/upload`)
-- Download uses the existing download API (`GET /workspaces/{id}/files/download`); for directories the backend returns a zip — the CLI automatically unzips it to the local destination
+- `bark ws exec WORKSPACE COMMAND...` — raw command execution in containers via WebSocket (`ExecSession` with piped stdin/stdout, no PTY)
+- `bark ws sync SRC DEST` — rsync wrapper using `bark ws exec` as the transport
+- Uses `os.read(0)`/`os.write(1)` for unbuffered I/O (Python's buffered I/O breaks rsync pipe protocol)
+- `select()` with timeout in stdin_forward for prompt exit
+- Base64 encoding for binary-safe WebSocket transport
+- Container image includes rsync
+- CLI E2E tests (`src/cli-e2e/`) — 16 tests against real server + Docker containers
+- GitHub Actions workflow for CI
 
-### Phase 6 (future): File sync via rsync transport
-
-- `bark transport` command that acts as an rsync transport (like `ssh` in `rsync -e ssh`)
-- Usage: `rsync -avz -e "bark transport" ~/foo my-workspace:/bar`
-- Transport connects to Bark backend via WebSocket, spawns `docker exec rsync --server ...` in the target container, pipes stdin/stdout over the WebSocket
-- Backend needs a new raw exec WebSocket message type (like `terminal_start` but without PTY — raw byte stream)
-- Container image needs `rsync` installed
-- Works locally and remotely through the same WebSocket path — no SSH required
-- rsync handles all diffing, compression, and incremental transfer
-
-### Phase 7 (future): Local Docker exec optimization
+### Phase 6 (future): Local Docker exec optimization
 
 - Detect when backend is local
 - Use `docker exec` directly instead of WebSocket PTY for native performance
@@ -157,20 +154,21 @@ email = "admin@example.com"
 | ---------------------------------------------- | ---------------------------------------------- |
 | `src/backend/bark_backend/cli/main.py`         | Typer app, top-level + `ws` subcommand group   |
 | `src/backend/bark_backend/cli/auth.py`         | Login/logout with token reuse and rich prompts |
-| `src/backend/bark_backend/cli/client.py`       | HTTP + WebSocket client, shell PTY forwarding  |
+| `src/backend/bark_backend/cli/client.py`       | HTTP + WebSocket client, shell/exec forwarding |
 | `src/backend/bark_backend/cli/config.py`       | Config storage (~/.config/bark/cli.toml)       |
+| `src/backend/bark_backend/exec_session.py`     | Backend raw exec session (no PTY)              |
 | `src/backend/bark_backend/terminal_manager.py` | Backend PTY session (docker exec)              |
-| `src/backend/bark_backend/ws_handler.py`       | WebSocket terminal protocol                    |
+| `src/backend/bark_backend/ws_handler.py`       | WebSocket terminal + exec protocol             |
+| `src/cli-e2e/test_cli_e2e.py`                  | CLI E2E tests against real server              |
 
 ## Verification
 
-1. `devenv shell -- test-backend` — all tests pass with 100% coverage
-2. Start Bark normally (`devenv up`), then in another terminal:
+1. `devenv shell -- test-backend` — unit tests pass with 100% coverage
+2. `devenv shell -- test-cli-e2e` — E2E tests pass against real server + Docker
+3. Manual smoke test:
    - `bark login admin@example.com` — authenticate
-   - `bark ws list` — lists workspaces
    - `bark ws create cli-test` — creates a workspace
    - `bark ws shell cli-test` — drops into bash inside container
-   - Verify: `ls /work` shows workspace files, `git status` works, `pi` is available
-   - Ctrl+D exits cleanly, terminal is restored
+   - `bark ws exec cli-test ls /work` — runs a command
+   - `bark ws sync ~/project cli-test:/work/project` — syncs files
    - `bark ws delete cli-test` — cleans up
-3. Resize terminal window during `bark ws shell` — verify the shell adapts

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ bark login admin@example.com        # authenticate (prompts for password)
 bark ws list                         # list workspaces
 bark ws create my-project            # create a workspace
 bark ws shell my-project             # drop into bash inside the container
+bark ws exec my-project ls /work     # run a command in the container
+bark ws sync ~/src my-project:/work  # sync files to/from the container
 bark ws delete my-project            # delete a workspace
 ```
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -149,6 +149,12 @@
     exec python -m pytest src/backend/tests -v -n auto "$@"
   '';
 
+  # CLI E2E tests: start real server, run bark commands, need Docker
+  scripts.test-cli-e2e.exec = ''
+    cd $DEVENV_ROOT
+    exec python -m pytest src/cli-e2e -v -p no:xdist --no-cov "$@"
+  '';
+
   scripts.test-e2e.exec = ''
     cd $DEVENV_ROOT
     devenv tasks run bark:flutter-build bark:docker-build

--- a/src/cli-e2e/test_cli_e2e.py
+++ b/src/cli-e2e/test_cli_e2e.py
@@ -1,0 +1,332 @@
+"""CLI end-to-end tests against a real Bark server.
+
+These tests start a real uvicorn server, run bark CLI commands as
+subprocesses, and verify behavior against real Docker containers.
+
+Requires: Docker running, bark-pi image built.
+
+Run with: devenv shell -- test-cli-e2e
+"""
+
+import os
+import shutil
+import signal
+import subprocess
+import tempfile
+import time
+
+import pytest
+
+
+def _run(args, timeout=30, input=None, **kwargs):
+    """Run a CLI command, return CompletedProcess."""
+    return subprocess.run(
+        args,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        input=input,
+        **kwargs,
+    )
+
+
+@pytest.fixture(scope="session")
+def server():
+    """Start a real Bark server for the test session."""
+    data_dir = tempfile.mkdtemp(prefix="bark-cli-e2e-")
+    port = "18995"
+    env = {
+        **os.environ,
+        "BARK_PORT": port,
+        "BARK_DATA_DIR": data_dir,
+        "BARK_JWT_SECRET": "cli-e2e-test-secret",
+        "BARK_DEFAULT_USER": "test@example.com",
+        "BARK_DEFAULT_PASSWORD": "testpass",
+        "BARK_TEST_MODE": "1",
+        "BARK_INSTANCE_ID": "cli-e2e",
+        "BARK_IDLE_TIMEOUT_SECONDS": "300",
+        "LOGFIRE_TOKEN": "",
+    }
+    proc = subprocess.Popen(
+        ["uvicorn", "bark_backend.main:app", "--host", "0.0.0.0", "--port", port],
+        cwd=os.path.join(os.path.dirname(__file__), ".."),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    # Wait for server to be ready
+    base_url = f"http://localhost:{port}"
+    for _ in range(60):
+        try:
+            import httpx
+
+            resp = httpx.get(f"{base_url}/health", timeout=2)
+            if resp.status_code == 200:
+                break
+        except Exception:
+            pass
+        time.sleep(1)
+    else:
+        proc.kill()
+        stdout = proc.stdout.read().decode() if proc.stdout else ""
+        raise RuntimeError(f"Server failed to start:\n{stdout}")
+
+    yield {"url": base_url, "port": port, "data_dir": data_dir, "proc": proc}
+
+    # Cleanup
+    proc.send_signal(signal.SIGTERM)
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+    # Clean up containers
+    subprocess.run(
+        [
+            "docker",
+            "ps",
+            "-a",
+            "--filter",
+            "label=bark.instance=cli-e2e",
+            "-q",
+        ],
+        capture_output=True,
+    )
+    result = subprocess.run(
+        [
+            "docker",
+            "ps",
+            "-a",
+            "--filter",
+            "label=bark.instance=cli-e2e",
+            "-q",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.stdout.strip():
+        subprocess.run(
+            ["docker", "rm", "-f", *result.stdout.strip().split()],
+            capture_output=True,
+        )
+    shutil.rmtree(data_dir, ignore_errors=True)
+
+
+@pytest.fixture(scope="session")
+def cli_config(server, tmp_path_factory):
+    """Create a CLI config pointing at the test server."""
+    config_dir = tmp_path_factory.mktemp("bark-cli-config")
+    env = {**os.environ, "HOME": str(config_dir)}
+    # The CLI reads from ~/.config/bark/cli.toml
+    bark_config_dir = config_dir / ".config" / "bark"
+    bark_config_dir.mkdir(parents=True)
+    return {
+        "env": env,
+        "config_dir": bark_config_dir,
+        "config_file": bark_config_dir / "cli.toml",
+        "server_url": server["url"],
+    }
+
+
+class TestLogin:
+    def test_login_with_email_arg(self, server, cli_config):
+        result = _run(
+            [
+                "bark",
+                "login",
+                "test@example.com",
+                "--server",
+                server["url"],
+                "--password-file",
+                "-",
+            ],
+            input="testpass\n",
+            env=cli_config["env"],
+        )
+        assert result.returncode == 0
+        assert "Logged in" in result.stdout or "Already logged in" in result.stdout
+        # Config file should exist now
+        assert cli_config["config_file"].exists()
+
+    def test_login_reuses_token(self, server, cli_config):
+        result = _run(
+            [
+                "bark",
+                "login",
+                "test@example.com",
+                "--server",
+                server["url"],
+                "--password-file",
+                "-",
+            ],
+            input="testpass\n",
+            env=cli_config["env"],
+        )
+        assert result.returncode == 0
+        assert "Already logged in" in result.stdout
+
+    def test_status_shows_logged_in(self, cli_config):
+        result = _run(
+            ["bark", "status", "--plain"],
+            env=cli_config["env"],
+        )
+        assert result.returncode == 0
+        assert "status=logged_in" in result.stdout
+        assert "test@example.com" in result.stdout
+
+
+class TestWorkspaceCRUD:
+    def test_create_workspace(self, cli_config):
+        result = _run(
+            ["bark", "ws", "create", "e2e-test"],
+            env=cli_config["env"],
+        )
+        assert result.returncode == 0
+        assert "e2e-test" in result.stdout
+
+    def test_list_workspaces(self, cli_config):
+        result = _run(
+            ["bark", "ws", "list", "--plain"],
+            env=cli_config["env"],
+        )
+        assert result.returncode == 0
+        assert "e2e-test" in result.stdout
+
+    def test_create_duplicate_fails(self, cli_config):
+        result = _run(
+            ["bark", "ws", "create", "e2e-test"],
+            env=cli_config["env"],
+        )
+        assert result.returncode != 0
+
+    def test_delete_nonexistent_fails(self, cli_config):
+        result = _run(
+            ["bark", "ws", "delete", "nonexistent-ws"],
+            env=cli_config["env"],
+        )
+        assert result.returncode != 0
+
+
+class TestExec:
+    def test_exec_echo(self, cli_config):
+        result = _run(
+            ["bark", "ws", "exec", "e2e-test", "echo", "hello from exec"],
+            env=cli_config["env"],
+            timeout=60,
+        )
+        assert result.returncode == 0
+        assert "hello from exec" in result.stdout
+
+    def test_exec_piped_stdin(self, cli_config):
+        result = _run(
+            ["bark", "ws", "exec", "e2e-test", "cat"],
+            input="piped data\n",
+            env=cli_config["env"],
+            timeout=60,
+        )
+        assert result.returncode == 0
+        assert "piped data" in result.stdout
+
+    def test_exec_exit_code(self, cli_config):
+        result = _run(
+            ["bark", "ws", "exec", "e2e-test", "false"],
+            env=cli_config["env"],
+            timeout=60,
+        )
+        assert result.returncode != 0
+
+
+class TestSync:
+    def test_sync_to_container(self, cli_config, tmp_path):
+        # Create local files
+        src = tmp_path / "sync-src"
+        src.mkdir()
+        (src / "file1.txt").write_text("content one")
+        (src / "file2.txt").write_text("content two")
+
+        result = _run(
+            [
+                "bark",
+                "ws",
+                "sync",
+                str(src) + "/",
+                "e2e-test:/work/synced/",
+            ],
+            env=cli_config["env"],
+            timeout=60,
+        )
+        assert result.returncode == 0
+
+        # Verify files arrived
+        verify = _run(
+            ["bark", "ws", "exec", "e2e-test", "cat", "/work/synced/file1.txt"],
+            env=cli_config["env"],
+            timeout=60,
+        )
+        assert verify.returncode == 0
+        assert "content one" in verify.stdout
+
+    def test_sync_from_container(self, cli_config, tmp_path):
+        # Create a file in the container
+        _run(
+            [
+                "bark",
+                "ws",
+                "exec",
+                "e2e-test",
+                "bash",
+                "-c",
+                "echo remote-data > /work/remote-file.txt",
+            ],
+            env=cli_config["env"],
+            timeout=60,
+        )
+
+        dest = tmp_path / "sync-dest"
+        dest.mkdir()
+
+        result = _run(
+            [
+                "bark",
+                "ws",
+                "sync",
+                "e2e-test:/work/remote-file.txt",
+                str(dest) + "/",
+            ],
+            env=cli_config["env"],
+            timeout=60,
+        )
+        assert result.returncode == 0
+        assert (dest / "remote-file.txt").read_text().strip() == "remote-data"
+
+
+class TestDeleteWorkspace:
+    def test_delete_workspace(self, cli_config):
+        result = _run(
+            ["bark", "ws", "delete", "e2e-test"],
+            env=cli_config["env"],
+        )
+        assert result.returncode == 0
+        assert "Deleted" in result.stdout
+
+    def test_list_after_delete(self, cli_config):
+        result = _run(
+            ["bark", "ws", "list", "--plain"],
+            env=cli_config["env"],
+        )
+        assert "e2e-test" not in result.stdout
+
+
+class TestLogout:
+    def test_logout(self, cli_config):
+        result = _run(
+            ["bark", "logout"],
+            env=cli_config["env"],
+        )
+        assert result.returncode == 0
+
+    def test_status_after_logout(self, cli_config):
+        result = _run(
+            ["bark", "status", "--plain"],
+            env=cli_config["env"],
+        )
+        assert "not_logged_in" in result.stdout


### PR DESCRIPTION
## Summary
- 16 CLI E2E tests covering full workflow against a real Bark server with Docker containers
- Tests: login (with token reuse), status, workspace CRUD, exec (echo, piped stdin, exit codes), rsync sync (push and pull), logout
- New `test-cli-e2e` devenv script and GitHub Actions workflow
- Tests live in `src/cli-e2e/` separate from unit tests

## Test plan
- [x] `devenv shell -- test-cli-e2e` passes locally (16/16)
- [x] `devenv shell -- test-backend` still passes (643/643, 100% coverage)
- [ ] GitHub Actions workflow runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)