### PR TITLE
frontend: fix Firefox Ctrl/Cmd+V paste + symbolized wasm builds + CI inputs

### DIFF
--- a/scripts/flutterbuildweb.sh
+++ b/scripts/flutterbuildweb.sh
@@ -17,7 +17,7 @@ python3 scripts/import_dart_plugins.py
 # can still override the binary; defaults to `flutter` on PATH (nix toolchain).
 FLUTTER="${KLANGK_WEB_FLUTTER:-flutter}"
 
-cd src/frontend && "$FLUTTER" --disable-analytics && "$FLUTTER" pub get && "$FLUTTER" build web --wasm --release --base-href=/ --no-web-resources-cdn
+cd src/frontend && "$FLUTTER" --disable-analytics && "$FLUTTER" pub get && "$FLUTTER" build web --wasm --release --base-href=/ --no-web-resources-cdn --source-maps --no-strip-wasm
 rm -f build/web/flutter_service_worker.js
 
 # Cache-busting: append a content hash to flutter_bootstrap.js reference

--- a/src/frontend/e2e-tests/e2e/klangk.spec.ts
+++ b/src/frontend/e2e-tests/e2e/klangk.spec.ts
@@ -174,6 +174,119 @@ test.describe("Klangk E2E", () => {
     }
   });
 
+  test("terminal paste preserves quotes, spaces, and unicode", async ({
+    page,
+    request,
+  }) => {
+    // Pasted text must reach the PTY byte-for-byte. The native `paste` path
+    // pulls from event.clipboardData.getData('text/plain'), which is a raw
+    // string with no escaping done by Flutter's text-input — this regression-
+    // tests that the byte boundary stays clean for typical messy content
+    // (single quotes, double quotes, whitespace, multi-byte UTF-8).
+    const termReady = waitForTerminalReady(page);
+    const { workspaceId, headers, cleanup } = await createAndOpenWorkspace(
+      page,
+      request,
+      "term-paste-utf8",
+    );
+    await termReady;
+
+    try {
+      try {
+        await page
+          .context()
+          .grantPermissions(["clipboard-read", "clipboard-write"]);
+      } catch {
+        /* unsupported on firefox/webkit — fine */
+      }
+
+      // Quotes, spaces, an emoji, and a non-Latin character. Wrap in a
+      // heredoc so the shell preserves the payload exactly.
+      const payload = `Hello "world" 'with' spaces — 🦋 中文`;
+      const cmd = `cat > /home/klangk/work/.paste-utf8 <<'EOF'\n${payload}\nEOF`;
+      await page.evaluate((t) => navigator.clipboard.writeText(t), cmd);
+
+      const { width, height } = vp(page);
+      const f = fv(page);
+      await f.click({
+        position: { x: width / 2, y: height / 2 },
+        force: true,
+      });
+      await page.waitForTimeout(1000);
+      await page.keyboard.press("ControlOrMeta+KeyV");
+      await page.waitForTimeout(500);
+      await page.keyboard.press("Enter");
+
+      await waitForFile(request, workspaceId, "work/.paste-utf8", headers);
+      const readResp = await request.get(
+        `${API_BASE}/workspaces/${workspaceId}/files/content?path=work/.paste-utf8`,
+        { headers },
+      );
+      expect(readResp.ok()).toBeTruthy();
+      const data = await readResp.json();
+      expect(data.content.trimEnd()).toBe(payload);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("paste shortcut is ignored when terminal isn't focused", async ({
+    page,
+    request,
+  }) => {
+    // installPasteListener is wired at the document level and only consumes
+    // the event when the terminal's focus node has focus. If the user has
+    // the Files tab active (or any other widget focused), pasting must NOT
+    // route the clipboard into the PTY — otherwise a paste meant for
+    // another input would silently fire shell commands.
+    const termReady = waitForTerminalReady(page);
+    const { workspaceId, headers, cleanup } = await createAndOpenWorkspace(
+      page,
+      request,
+      "term-paste-isolation",
+    );
+    await termReady;
+
+    try {
+      try {
+        await page
+          .context()
+          .grantPermissions(["clipboard-read", "clipboard-write"]);
+      } catch {
+        /* unsupported on firefox/webkit — fine */
+      }
+
+      const cmd =
+        "echo paste-leak-canary > /home/klangk/work/.paste-leak-canary";
+      await page.evaluate((t) => navigator.clipboard.writeText(t), cmd);
+
+      const { width } = vp(page);
+      const f = fv(page);
+      // Switch to the Files tab so the terminal isn't focused. Tabs span
+      // full width: Terminal on the left half, Files on the right.
+      const filesTabX = (width * 3) / 4;
+      await f.click({ position: { x: filesTabX, y: 76 }, force: true });
+      await page.waitForTimeout(500);
+
+      // Fire the paste shortcut and Enter. If the terminal listener
+      // mistakenly consumed the event, the canary file would appear; if it
+      // correctly returned false, nothing reaches the PTY.
+      await page.keyboard.press("ControlOrMeta+KeyV");
+      await page.waitForTimeout(500);
+      await page.keyboard.press("Enter");
+      await page.waitForTimeout(2000);
+
+      const readResp = await request.get(
+        `${API_BASE}/workspaces/${workspaceId}/files/content?path=work/.paste-leak-canary`,
+        { headers },
+      );
+      // 404 (or any non-2xx) is the expected outcome: file shouldn't exist.
+      expect(readResp.ok()).toBeFalsy();
+    } finally {
+      await cleanup();
+    }
+  });
+
   test("navigate back to workspaces", async ({ page, request }) => {
     const { cleanup } = await createAndOpenWorkspace(page, request, "nav-back");
 

--- a/src/frontend/e2e-tests/e2e/klangk.spec.ts
+++ b/src/frontend/e2e-tests/e2e/klangk.spec.ts
@@ -118,6 +118,62 @@ test.describe("Klangk E2E", () => {
     }
   });
 
+  test("terminal pastes via keyboard shortcut (native paste event)", async ({
+    page,
+    request,
+  }) => {
+    // Regression: on Firefox, paste went through Flutter's Clipboard.getData
+    // (navigator.clipboard.readText), which returns nothing for externally
+    // copied text, so Ctrl/Cmd+V silently failed. The fix reads the browser's
+    // native `paste` event instead. This exercises the real keypress path so
+    // it catches a regression on any browser.
+    const termReady = waitForTerminalReady(page);
+    const { workspaceId, headers, cleanup } = await createAndOpenWorkspace(
+      page,
+      request,
+      "term-paste",
+    );
+    await termReady;
+
+    try {
+      // chromium needs explicit clipboard permission; firefox/webkit don't
+      // support granting it and don't need it for the paste-event read.
+      try {
+        await page
+          .context()
+          .grantPermissions(["clipboard-read", "clipboard-write"]);
+      } catch {
+        /* unsupported on firefox/webkit — fine */
+      }
+
+      const cmd = "echo playwright-paste-test > /home/klangk/work/.paste-test";
+      await page.evaluate((t) => navigator.clipboard.writeText(t), cmd);
+
+      const { width, height } = vp(page);
+      const f = fv(page);
+      await f.click({
+        position: { x: width / 2, y: height / 2 },
+        force: true,
+      });
+      await page.waitForTimeout(1000);
+      // ControlOrMeta → Cmd on macOS, Ctrl elsewhere (CI is Linux).
+      await page.keyboard.press("ControlOrMeta+KeyV");
+      await page.waitForTimeout(500);
+      await page.keyboard.press("Enter");
+
+      await waitForFile(request, workspaceId, "work/.paste-test", headers);
+      const readResp = await request.get(
+        `${API_BASE}/workspaces/${workspaceId}/files/content?path=work/.paste-test`,
+        { headers },
+      );
+      expect(readResp.ok()).toBeTruthy();
+      const data = await readResp.json();
+      expect(data.content).toContain("playwright-paste-test");
+    } finally {
+      await cleanup();
+    }
+  });
+
   test("navigate back to workspaces", async ({ page, request }) => {
     const { cleanup } = await createAndOpenWorkspace(page, request, "nav-back");
 

--- a/src/frontend/e2e-tests/playwright.config.ts
+++ b/src/frontend/e2e-tests/playwright.config.ts
@@ -18,7 +18,18 @@ const chromiumUse = {
 const firefoxUse = {
   browserName: "firefox" as const,
   launchOptions: {
-    executablePath: `${BROWSERS}/firefox-1511/firefox/firefox`,
+    // CI (Linux) uses the default path; FIREFOX_PATH overrides it for local
+    // runs (e.g. macOS, where the binary is firefox/Nightly.app/...), mirroring
+    // CHROME_PATH above.
+    executablePath:
+      process.env.FIREFOX_PATH || `${BROWSERS}/firefox-1511/firefox/firefox`,
+    // Allow navigator.clipboard read/write in automation without a prompt, so
+    // the paste e2e can seed the clipboard. (The fix's own read path uses the
+    // native `paste` event and needs no permission.)
+    firefoxUserPrefs: {
+      "dom.events.asyncClipboard.readText": true,
+      "dom.events.testing.asyncClipboard": true,
+    },
   },
 };
 

--- a/src/frontend/lib/terminal/ghostty_terminal.dart
+++ b/src/frontend/lib/terminal/ghostty_terminal.dart
@@ -75,12 +75,23 @@ class GhosttyTerminalState extends State<GhosttyTerminal> {
     // Paste arrives via the browser's native `paste` event (works on Firefox
     // too, unlike Clipboard.getData). Only consume it when the terminal is
     // focused, so pastes into other inputs (e.g. chat) are left untouched.
-    _removePasteListener = installPasteListener((text) {
-      if (!_focusNode.hasFocus) return false;
-      _terminal.paste(text);
-      return true;
-    });
+    _removePasteListener = installPasteListener(routeNativePaste);
     _loadFont();
+  }
+
+  /// Handles a payload from a browser `paste` event. Only routes it into
+  /// the terminal when the terminal has focus; otherwise leaves the event
+  /// alone so other inputs paste normally. Returns whether the paste was
+  /// consumed.
+  ///
+  /// Public + @visibleForTesting so the focus-gated logic is reachable from
+  /// VM tests; in production this is only invoked from the DOM listener
+  /// installed by [installPasteListener].
+  @visibleForTesting
+  bool routeNativePaste(String text) {
+    if (!_focusNode.hasFocus) return false;
+    _terminal.paste(text);
+    return true;
   }
 
   // flterm measures cell width by laying out 'M' in [_fontFamily]; if the font

--- a/src/frontend/lib/terminal/ghostty_terminal.dart
+++ b/src/frontend/lib/terminal/ghostty_terminal.dart
@@ -32,6 +32,7 @@ class GhosttyTerminalState extends State<GhosttyTerminal> {
   final _scrollController = TerminalScrollController();
   StreamSubscription<String>? _outputSub;
   StreamSubscription<Map<String, dynamic>>? _eventSub;
+  void Function()? _removePasteListener;
   bool _started = false;
 
   // Raw bytes of the bundled monospace font. flterm measures cell width from
@@ -71,6 +72,14 @@ class GhosttyTerminalState extends State<GhosttyTerminal> {
       _terminal.write(utf8.encode(data));
     });
     _eventSub = widget.wsClient.customEvents.listen(_handleEvent);
+    // Paste arrives via the browser's native `paste` event (works on Firefox
+    // too, unlike Clipboard.getData). Only consume it when the terminal is
+    // focused, so pastes into other inputs (e.g. chat) are left untouched.
+    _removePasteListener = installPasteListener((text) {
+      if (!_focusNode.hasFocus) return false;
+      _terminal.paste(text);
+      return true;
+    });
     _loadFont();
   }
 
@@ -109,6 +118,7 @@ class GhosttyTerminalState extends State<GhosttyTerminal> {
     _scrollController.dispose();
     _outputSub?.cancel();
     _eventSub?.cancel();
+    _removePasteListener?.call();
     if (_started) {
       widget.wsClient.sendTerminalStop();
     }
@@ -126,9 +136,10 @@ class GhosttyTerminalState extends State<GhosttyTerminal> {
   }
 
   void _paste() {
-    Clipboard.getData(Clipboard.kTextPlain).then((data) {
-      final text = data?.text;
-      if (text != null) _terminal.paste(text);
+    // A menu click isn't a native paste gesture, so the `paste` listener can't
+    // fire here — read the clipboard directly. (May prompt on Firefox.)
+    readClipboardText().then((text) {
+      if (text != null && text.isNotEmpty) _terminal.paste(text);
     });
   }
   // coverage:ignore-end
@@ -148,70 +159,98 @@ class GhosttyTerminalState extends State<GhosttyTerminal> {
       return const ColoredBox(color: Color(0xFF0D1117));
     }
 
-    return GestureDetector(
-      // Right-click only — primary/selection gestures stay with flterm's own
-      // detector inside TerminalView.
-      onSecondaryTapDown: (details) {
-        suppressContextMenuBriefly();
-        final hasSelection =
-            _terminal.selection != null; // coverage:ignore-line
-        final items = <PopupMenuEntry<String>>[
-          // coverage:ignore-start
-          if (hasSelection)
+    return Actions(
+      // The default DoNothingAction has consumesKey: true, so mapping
+      // Cmd/Ctrl+V to DoNothingIntent in [_disableFltermPaste] would still
+      // make flterm's Shortcuts return KeyEventResult.handled, prompting the
+      // engine to preventDefault the keydown — the textarea never sees the
+      // paste, no native `paste` event fires, and installPasteListener never
+      // runs. Override DoNothingAction here with consumesKey: false so the
+      // key propagates to the textarea and the browser pastes natively.
+      actions: <Type, Action<Intent>>{
+        DoNothingIntent: DoNothingAction(consumesKey: false),
+      },
+      child: GestureDetector(
+        // Right-click only — primary/selection gestures stay with flterm's own
+        // detector inside TerminalView.
+        onSecondaryTapDown: (details) {
+          suppressContextMenuBriefly();
+          final hasSelection =
+              _terminal.selection != null; // coverage:ignore-line
+          final items = <PopupMenuEntry<String>>[
+            // coverage:ignore-start
+            if (hasSelection)
+              const PopupMenuItem(
+                  value: 'copy',
+                  child: ListTile(
+                      dense: true,
+                      leading: Icon(Icons.copy, size: 18),
+                      title: Text('Copy'))),
+            // coverage:ignore-end
             const PopupMenuItem(
-                value: 'copy',
+                value: 'paste',
                 child: ListTile(
                     dense: true,
-                    leading: Icon(Icons.copy, size: 18),
-                    title: Text('Copy'))),
-          // coverage:ignore-end
-          const PopupMenuItem(
-              value: 'paste',
-              child: ListTile(
-                  dense: true,
-                  leading: Icon(Icons.paste, size: 18),
-                  title: Text('Paste'))),
-        ];
-        final pos = details.globalPosition;
-        showMenu<String>(
-          context: context,
-          position: RelativeRect.fromLTRB(pos.dx, pos.dy, pos.dx, pos.dy),
-          items: items,
-        ).then((action) {
-          // coverage:ignore-start
-          if (action == 'copy') {
-            _copySelection();
-          } else if (action == 'paste') {
-            _paste();
-          }
-          // coverage:ignore-end
-        });
-      },
-      child: TerminalView(
-        controller: _terminal,
-        theme: _theme,
-        fontData: _fontData,
-        focusNode: _focusNode,
-        scrollController: _scrollController,
-        autofocus: false,
-        padding: EdgeInsets.zero,
-        // Keep mouse selection (drag/word/line/long-press) but drop the
-        // keyboard select-all gesture, so Ctrl+A falls through to the shell
-        // (readline beginning-of-line / tmux prefix) instead of selecting the
-        // buffer. Ctrl+C already passes through (flterm's copy is selection-
-        // conditional); copy stays on Ctrl+Shift+C and the right-click menu.
-        gestureSettings: const TerminalGestureSettings(
-          enabledSelections: {
-            SelectionGesture.drag,
-            SelectionGesture.word,
-            SelectionGesture.line,
-            SelectionGesture.longPress,
-          },
+                    leading: Icon(Icons.paste, size: 18),
+                    title: Text('Paste'))),
+          ];
+          final pos = details.globalPosition;
+          showMenu<String>(
+            context: context,
+            position: RelativeRect.fromLTRB(pos.dx, pos.dy, pos.dx, pos.dy),
+            items: items,
+          ).then((action) {
+            // coverage:ignore-start
+            if (action == 'copy') {
+              _copySelection();
+            } else if (action == 'paste') {
+              _paste();
+            }
+            // coverage:ignore-end
+          });
+        },
+        child: TerminalView(
+          controller: _terminal,
+          theme: _theme,
+          fontData: _fontData,
+          focusNode: _focusNode,
+          scrollController: _scrollController,
+          autofocus: false,
+          padding: EdgeInsets.zero,
+          // Disable flterm's built-in Ctrl/Cmd+V paste (it reads via
+          // Clipboard.getData, which fails on Firefox). These override flterm's
+          // platform defaults, so paste flows solely through the native
+          // `paste` event in [installPasteListener] — one path, no double-paste.
+          shortcuts: _disableFltermPaste,
+          // Keep mouse selection (drag/word/line/long-press) but drop the
+          // keyboard select-all gesture, so Ctrl+A falls through to the shell
+          // (readline beginning-of-line / tmux prefix) instead of selecting the
+          // buffer. Ctrl+C already passes through (flterm's copy is selection-
+          // conditional); copy stays on Ctrl+Shift+C and the right-click menu.
+          gestureSettings: const TerminalGestureSettings(
+            enabledSelections: {
+              SelectionGesture.drag,
+              SelectionGesture.word,
+              SelectionGesture.line,
+              SelectionGesture.longPress,
+            },
+          ),
         ),
       ),
     );
   }
 }
+
+/// Overrides flterm's default paste shortcuts with no-ops, across every
+/// platform binding (macOS Cmd+V, Windows/Android Ctrl+V, Linux Ctrl+Shift+V),
+/// so its Clipboard.getData paste never runs. Paste is handled by the native
+/// `paste` event instead — see [GhosttyTerminalState.initState].
+const Map<ShortcutActivator, Intent> _disableFltermPaste = {
+  SingleActivator(LogicalKeyboardKey.keyV, meta: true): DoNothingIntent(),
+  SingleActivator(LogicalKeyboardKey.keyV, control: true): DoNothingIntent(),
+  SingleActivator(LogicalKeyboardKey.keyV, control: true, shift: true):
+      DoNothingIntent(),
+};
 
 /// klangk's terminal palette (matches the xterm `ContainerTerminal` theme).
 final TerminalTheme _theme = TerminalTheme(

--- a/src/frontend/lib/utils/web_helpers_stub.dart
+++ b/src/frontend/lib/utils/web_helpers_stub.dart
@@ -14,3 +14,10 @@ Widget buildSuppressor(Widget child) => child;
 
 /// Stub — return empty hash in VM tests.
 String getLocationHash() => '';
+
+/// Stub — no DOM paste events outside the browser; returns a no-op disposer.
+void Function() installPasteListener(bool Function(String text) onPaste) =>
+    () {};
+
+/// Stub — no system clipboard outside the browser.
+Future<String?> readClipboardText() async => null;

--- a/src/frontend/lib/utils/web_helpers_web.dart
+++ b/src/frontend/lib/utils/web_helpers_web.dart
@@ -35,6 +35,47 @@ void suppressContextMenuBriefly() {
 /// Get the browser's location hash fragment.
 String getLocationHash() => web.window.location.hash;
 
+/// Routes the browser's native `paste` ClipboardEvent text to [onPaste].
+///
+/// Why this exists: Flutter's `Clipboard.getData` — and flterm's built-in
+/// Ctrl/Cmd+V handler that calls it — read the clipboard via
+/// `navigator.clipboard.readText()`. On Firefox that path yields nothing for
+/// externally-copied text, so paste silently fails (Chrome/WebKit are fine).
+/// The native `paste` event carries the payload in `clipboardData` with no
+/// permission prompt on any browser, so we read it there instead.
+///
+/// [onPaste] returns whether it consumed the text. When it does, the event's
+/// default is prevented so the text isn't also inserted into Flutter's hidden
+/// text-input (which would double-paste); when it doesn't (e.g. the terminal
+/// isn't focused), the event is left alone so other inputs paste normally.
+/// Runs in the capture phase. Returns a disposer that removes the listener.
+void Function() installPasteListener(bool Function(String text) onPaste) {
+  final handler = ((web.Event event) {
+    final data = (event as web.ClipboardEvent).clipboardData;
+    final text = data?.getData('text/plain') ?? '';
+    if (text.isEmpty) return;
+    if (onPaste(text)) event.preventDefault();
+  }).toJS;
+  web.document.addEventListener('paste', handler, true.toJS);
+  return () => web.document.removeEventListener('paste', handler, true.toJS);
+}
+
+/// Reads the system clipboard as plain text via the async Clipboard API.
+///
+/// Used only by the right-click "Paste" menu item: a synthetic button click is
+/// not a native paste gesture, so no `paste` event fires and [installPasteListener]
+/// can't cover it. On Firefox this may surface the browser's paste-confirmation
+/// UI; the keyboard path stays prompt-free via the native event. Returns null
+/// if the clipboard is empty or the read is denied.
+Future<String?> readClipboardText() async {
+  try {
+    final text = await web.window.navigator.clipboard.readText().toDart;
+    return text.toDart;
+  } catch (_) {
+    return null;
+  }
+}
+
 /// Web implementation — suppresses native browser context menu on right-click.
 Widget buildSuppressor(Widget child) {
   return Listener(

--- a/src/frontend/test/ghostty_terminal_test.dart
+++ b/src/frontend/test/ghostty_terminal_test.dart
@@ -217,5 +217,49 @@ void main() {
       expect(find.text('Paste'), findsOneWidget);
       client.close();
     });
+
+    testWidgets('routeNativePaste drops the payload when not focused',
+        (tester) async {
+      final client = _MockWsClient();
+      final key = GlobalKey<GhosttyTerminalState>();
+      await tester.pumpWidget(_build(client, key: key));
+      await tester.pumpAndSettle();
+      client.sentCommands.clear();
+
+      final consumed = key.currentState!.routeNativePaste('hello\n');
+      await tester.pump();
+
+      expect(consumed, isFalse);
+      expect(
+        client.sentCommands.where((c) => c.startsWith('terminal_input')),
+        isEmpty,
+      );
+      client.close();
+    });
+
+    testWidgets('routeNativePaste forwards the payload when focused',
+        (tester) async {
+      final client = _MockWsClient();
+      final key = GlobalKey<GhosttyTerminalState>();
+      await tester.pumpWidget(_build(client, key: key));
+      await tester.pumpAndSettle();
+      key.currentState!.requestFocus();
+      await tester.pump();
+      client.sentCommands.clear();
+
+      final consumed = key.currentState!.routeNativePaste('clipboard-payload');
+      await tester.pump();
+
+      expect(consumed, isTrue);
+      // flterm wraps in bracketed-paste markers (\e[200~ ... \e[201~) when
+      // the terminal program has requested them, but always emits the
+      // payload bytes — assert on a substring rather than equality so the
+      // test isn't coupled to bracketed-paste mode.
+      final pasted =
+          client.sentCommands.where((c) => c.startsWith('terminal_input:'));
+      expect(pasted, isNotEmpty);
+      expect(pasted.join(), contains('clipboard-payload'));
+      client.close();
+    });
   });
 }


### PR DESCRIPTION
## Summary

Three commits stacked on the merged flterm work:

1. **`ci(e2e): add optional project/grep inputs for scoped firefox runs`** — workflow_dispatch inputs so we can run a fast firefox-only iteration during cross-browser debugging without burning ~15 min on chromium + webkit. Empty inputs (cron, zero-arg dispatch) keep the full suite running unchanged. `--no-deps` is required when scoping because the firefox project has `dependencies: ['chromium']` in playwright.config.ts.

2. **`frontend: build web with sourcemaps and unstripped wasm`** — `--source-maps --no-strip-wasm` so wasm/js stack traces in browser consoles and CI artifacts symbolize. Bundle size grows slightly; the readable-traces trade is worth it for CI, dev, and field reports.

3. **`frontend: paste via native ClipboardEvent so Firefox Ctrl/Cmd+V works`** — the real fix. Flutter's `Clipboard.getData` (and flterm's built-in Cmd/Ctrl+V handler that calls it) reads `navigator.clipboard.readText()`, which on Firefox returns nothing for externally-copied text. Switched to listening for the browser's native `paste` event, which is the actual user gesture and needs no permission anywhere.

### The non-obvious bit

`_disableFltermPaste` maps Cmd/Ctrl+V to `DoNothingIntent()`, but the default `DoNothingAction` has `consumesKey: true` — flterm's `Shortcuts` widget still returns `KeyEventResult.handled`, which makes the engine `preventDefault` the keydown, so the textarea never receives the paste and no native `paste` event fires. Fix: register `DoNothingAction(consumesKey: false)` in an `Actions` widget wrapping the terminal, so Shortcuts returns `.skipRemainingHandlers` and the keystroke propagates.

## Test plan

- [ ] Manual: Cmd+V (mac) and Ctrl+V (linux/windows) paste clipboard text into the terminal on Chrome, Firefox, and Safari/WebKit.
- [ ] Right-click → Paste menu still works (uses `readClipboardText` for the click-isn't-a-paste-gesture case).
- [ ] Chat panel and other inputs still paste normally (terminal listener only consumes when the terminal has focus).
- [ ] Flutter E2E `terminal pastes via keyboard shortcut (native paste event)` passes on all three browsers in CI.
- [ ] Existing terminal tests (input, file creation, tab switching, etc.) stay green.

## Known follow-up

User reported a `Null check operator used on a null value` at `js_util_patch.dart:83` when first clicking into the terminal on Firefox — surfaced by the symbolized build flags above. Likely separate from this PR (the trace originates from an async chain that may have been silently swallowed pre-fix). Investigation ongoing.