### PR TITLE
Fix flaky waitForTerminalReady E2E tests

### DIFF
--- a/src/frontend/e2e-tests/e2e/helpers.ts
+++ b/src/frontend/e2e-tests/e2e/helpers.ts
@@ -254,23 +254,38 @@ export async function openWorkspace(
   page: Page,
   email: string,
   workspaceId: string,
+  { waitForTerminal = false }: { waitForTerminal?: boolean } = {},
 ) {
-  // Set up WebSocket listener before login so we catch all WebSocket connections
-  const readyPromise = new Promise<void>((resolve, reject) => {
-    const timeout = setTimeout(
+  // Set up WebSocket listener before login so we catch all WebSocket
+  // connections.  A single framereceived handler watches for both
+  // container_ready and (optionally) terminal_started, avoiding the
+  // race where a separate waitForTerminalReady listener misses the frame.
+  let resolveContainer: () => void;
+  let resolveTerminal: (() => void) | null = null;
+  const containerPromise = new Promise<void>((resolve, reject) => {
+    resolveContainer = resolve;
+    setTimeout(
       () => reject(new Error("Container did not become ready within 120s")),
       120_000,
     );
-    const listenForReady = (ws: { on: Function }) => {
-      ws.on("framereceived", (frame: { payload: string | Buffer }) => {
-        if (frame.payload.toString().includes("container_ready")) {
-          clearTimeout(timeout);
-          resolve();
-        }
-      });
-    };
-    // Listen on any new WebSocket connections
-    page.on("websocket", listenForReady);
+  });
+  const terminalPromise = waitForTerminal
+    ? new Promise<void>((resolve, reject) => {
+        resolveTerminal = resolve;
+        setTimeout(
+          () => reject(new Error("Terminal did not become ready within 120s")),
+          120_000,
+        );
+      })
+    : Promise.resolve();
+
+  page.on("websocket", (ws: { on: Function }) => {
+    ws.on("framereceived", (frame: { payload: string | Buffer }) => {
+      const text = frame.payload.toString();
+      if (text.includes("container_ready")) resolveContainer!();
+      if (resolveTerminal && text.includes("terminal_started"))
+        resolveTerminal();
+    });
   });
 
   await loginViaUI(page, email, TEST_PASSWORD);
@@ -278,12 +293,8 @@ export async function openWorkspace(
   // WebSocket — a hash-only change is handled internally by Flutter's router
   // without opening a new WebSocket, so our listener would never fire.
   await page.goto(`/#/workspace/${workspaceId}`);
-  await readyPromise;
-
-  // Extra settle time for the UI to render after container ready.
-  // WebKit on CI needs more time for Flutter to fully process the
-  // container_ready event and establish bidirectional chat.
-  // await page.waitForTimeout(4000);
+  await containerPromise;
+  await terminalPromise;
 }
 
 /** Convenience: register user, create workspace, open it. */
@@ -291,6 +302,7 @@ export async function createAndOpenWorkspace(
   page: Page,
   request: APIRequestContext,
   namePrefix: string,
+  { waitForTerminal = false }: { waitForTerminal?: boolean } = {},
 ): Promise<{
   workspaceId: string;
   email: string;
@@ -305,35 +317,8 @@ export async function createAndOpenWorkspace(
     headers,
     namePrefix,
   );
-  await openWorkspace(page, email, workspaceId);
+  await openWorkspace(page, email, workspaceId, { waitForTerminal });
   return { workspaceId, email, token, headers, cleanup };
-}
-
-/** Set up a WebSocket listener that resolves when a `terminal_started`
- *  frame is received. Call this BEFORE the action that triggers terminal
- *  start (e.g. openWorkspace), then await the returned promise. */
-export function waitForTerminalReady(
-  page: Page,
-  timeout = 30_000,
-): Promise<void> {
-  return new Promise<void>((resolve, reject) => {
-    const timer = setTimeout(
-      () =>
-        reject(
-          new Error("Terminal did not become ready within " + timeout + "ms"),
-        ),
-      timeout,
-    );
-    const handler = (ws: { on: Function }) => {
-      ws.on("framereceived", (frame: { payload: string | Buffer }) => {
-        if (frame.payload.toString().includes("terminal_started")) {
-          clearTimeout(timer);
-          resolve();
-        }
-      });
-    };
-    page.on("websocket", handler);
-  });
 }
 
 export function dockerContainersForWorkspace(workspaceId: string): string[] {

--- a/src/frontend/e2e-tests/e2e/klangk.spec.ts
+++ b/src/frontend/e2e-tests/e2e/klangk.spec.ts
@@ -17,7 +17,6 @@ import {
   createAndOpenWorkspace,
   dockerContainersForWorkspace,
   tryLogin,
-  waitForTerminalReady,
 } from "./helpers";
 
 test.describe("Klangk E2E", () => {
@@ -85,13 +84,12 @@ test.describe("Klangk E2E", () => {
   });
 
   test("terminal accepts keyboard input", async ({ page, request }) => {
-    const termReady = waitForTerminalReady(page);
     const { workspaceId, headers, cleanup } = await createAndOpenWorkspace(
       page,
       request,
       "term-input",
+      { waitForTerminal: true },
     );
-    await termReady;
 
     try {
       const { width, height } = vp(page);
@@ -127,13 +125,12 @@ test.describe("Klangk E2E", () => {
     // copied text, so Ctrl/Cmd+V silently failed. The fix reads the browser's
     // native `paste` event instead. This exercises the real keypress path so
     // it catches a regression on any browser.
-    const termReady = waitForTerminalReady(page);
     const { workspaceId, headers, cleanup } = await createAndOpenWorkspace(
       page,
       request,
       "term-paste",
+      { waitForTerminal: true },
     );
-    await termReady;
 
     try {
       // chromium needs explicit clipboard permission; firefox/webkit don't
@@ -183,13 +180,12 @@ test.describe("Klangk E2E", () => {
     // string with no escaping done by Flutter's text-input — this regression-
     // tests that the byte boundary stays clean for typical messy content
     // (single quotes, double quotes, whitespace, multi-byte UTF-8).
-    const termReady = waitForTerminalReady(page);
     const { workspaceId, headers, cleanup } = await createAndOpenWorkspace(
       page,
       request,
       "term-paste-utf8",
+      { waitForTerminal: true },
     );
-    await termReady;
 
     try {
       try {
@@ -239,13 +235,12 @@ test.describe("Klangk E2E", () => {
     // the Files tab active (or any other widget focused), pasting must NOT
     // route the clipboard into the PTY — otherwise a paste meant for
     // another input would silently fire shell commands.
-    const termReady = waitForTerminalReady(page);
     const { workspaceId, headers, cleanup } = await createAndOpenWorkspace(
       page,
       request,
       "term-paste-isolation",
+      { waitForTerminal: true },
     );
-    await termReady;
 
     try {
       try {
@@ -352,13 +347,12 @@ test.describe("Klangk E2E", () => {
     page,
     request,
   }) => {
-    const termReady = waitForTerminalReady(page);
     const { workspaceId, headers, cleanup } = await createAndOpenWorkspace(
       page,
       request,
       "term-file",
+      { waitForTerminal: true },
     );
-    await termReady;
 
     try {
       const { width, height } = vp(page);
@@ -619,13 +613,12 @@ test.describe("Klangk E2E", () => {
     page,
     request,
   }) => {
-    const termReady = waitForTerminalReady(page);
     const { workspaceId, headers, cleanup } = await createAndOpenWorkspace(
       page,
       request,
       "term-seq",
+      { waitForTerminal: true },
     );
-    await termReady;
 
     try {
       const { width, height } = vp(page);
@@ -660,13 +653,12 @@ test.describe("Klangk E2E", () => {
   });
 
   test("terminal works after tab switching", async ({ page, request }) => {
-    const termReady = waitForTerminalReady(page);
     const { workspaceId, headers, cleanup } = await createAndOpenWorkspace(
       page,
       request,
       "tab-switch",
+      { waitForTerminal: true },
     );
-    await termReady;
 
     try {
       const { width, height } = vp(page);
@@ -824,13 +816,12 @@ test.describe("Klangk E2E", () => {
     page,
     request,
   }) => {
-    const termReady = waitForTerminalReady(page);
     const { workspaceId, headers, cleanup } = await createAndOpenWorkspace(
       page,
       request,
       "subdir-nav",
+      { waitForTerminal: true },
     );
-    await termReady;
 
     try {
       // Create nested directory structure via terminal
@@ -910,13 +901,12 @@ test.describe("Klangk E2E", () => {
     page,
     request,
   }) => {
-    const termReady = waitForTerminalReady(page);
     const { workspaceId, headers, cleanup } = await createAndOpenWorkspace(
       page,
       request,
       "home-persist",
+      { waitForTerminal: true },
     );
-    await termReady;
 
     try {
       // File API roots at home, so create a file in ~ and read it directly
@@ -1347,15 +1337,13 @@ test.describe("Klangk E2E", () => {
     const page1 = await ctx1.newPage();
     const page2 = await ctx2.newPage();
 
-    // Set up terminal_started listeners before opening workspaces
-    const termReady1 = waitForTerminalReady(page1);
-    const termReady2 = waitForTerminalReady(page2);
-
     // Open workspace as owner in page1, member in page2
-    await openWorkspace(page1, ownerEmail, workspaceId);
-    await openWorkspace(page2, memberEmail, workspaceId);
-    await termReady1;
-    await termReady2;
+    await openWorkspace(page1, ownerEmail, workspaceId, {
+      waitForTerminal: true,
+    });
+    await openWorkspace(page2, memberEmail, workspaceId, {
+      waitForTerminal: true,
+    });
 
     // Get bridge tokens for each connection
     const tokensResp = await request.get(
@@ -1554,12 +1542,12 @@ test.describe("Klangk E2E", () => {
       });
     });
 
-    const termReady1 = waitForTerminalReady(page1);
-    const termReady2 = waitForTerminalReady(page2);
-    await openWorkspace(page1, ownerEmail, workspaceId);
-    await openWorkspace(page2, memberEmail, workspaceId);
-    await termReady1;
-    await termReady2;
+    await openWorkspace(page1, ownerEmail, workspaceId, {
+      waitForTerminal: true,
+    });
+    await openWorkspace(page2, memberEmail, workspaceId, {
+      waitForTerminal: true,
+    });
 
     // Send chat message from page1 via the captured WebSocket
     await page1.evaluate(() => {


### PR DESCRIPTION
## Summary
- Integrate `terminal_started` detection into `openWorkspace`'s existing WebSocket listener via `{ waitForTerminal: true }` option
- Remove standalone `waitForTerminalReady` function that was racing with the WebSocket lifecycle
- Update all call sites in E2E tests

## Problem
The separate `waitForTerminalReady` listener attached to a different WebSocket than the one carrying `terminal_started` frames, causing intermittent 30s timeouts on CI.

## Test plan
- [x] 34/34 chromium E2E tests pass locally (3 runs)
- [ ] CI checks pass on this PR