### PR TITLE
Remove scheduled E2E runs

### DIFF
--- a/.github/workflows/cli-e2e-tests.yml
+++ b/.github/workflows/cli-e2e-tests.yml
@@ -4,42 +4,9 @@ on:
   workflow_dispatch:
   pull_request:
     branches: [main]
-  schedule:
-    - cron: "45 * * * *"
 
 jobs:
-  check:
-    # For scheduled triggers, skip if no commits in the last hour.
-    # Always run for workflow_dispatch.
-    runs-on: ubuntu-latest
-    outputs:
-      should_run: ${{ steps.check.outputs.should_run }}
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Check for recent commits
-        id: check
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          if [ "${{ github.event_name }}" != "schedule" ]; then
-            echo "should_run=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          LAST_COMMIT=$(git log -1 --format=%ct)
-          NOW=$(date +%s)
-          DIFF=$((NOW - LAST_COMMIT))
-          if [ "$DIFF" -le 3600 ]; then
-            echo "Commits found in the last hour"
-            echo "should_run=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "No commits in the last hour, cancelling"
-            gh run cancel ${{ github.run_id }}
-          fi
-
   test-cli-e2e:
-    needs: check
-    if: needs.check.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:

--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -13,42 +13,9 @@ on:
         default: ""
   pull_request:
     branches: [main]
-  schedule:
-    - cron: "15 * * * *"
 
 jobs:
-  check:
-    # Determine if tests should run. For scheduled triggers, skip
-    # if no commits in the last hour. Always run for workflow_dispatch.
-    runs-on: ubuntu-latest
-    outputs:
-      should_run: ${{ steps.check.outputs.should_run }}
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Check for recent commits
-        id: check
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          if [ "${{ github.event_name }}" != "schedule" ]; then
-            echo "should_run=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          LAST_COMMIT=$(git log -1 --format=%ct)
-          NOW=$(date +%s)
-          DIFF=$((NOW - LAST_COMMIT))
-          if [ "$DIFF" -le 3600 ]; then
-            echo "Commits found in the last hour"
-            echo "should_run=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "No commits in the last hour, cancelling"
-            gh run cancel ${{ github.run_id }}
-          fi
-
   test-flutter-e2e:
-    needs: check
-    if: needs.check.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:


### PR DESCRIPTION
## Summary
- Remove hourly schedule triggers from both E2E workflows
- Remove the `check` job that was only needed to gate scheduled runs
- Keep `workflow_dispatch` for manual runs and `pull_request` for CI gating

Now that PRs are required and all 4 checks run on every PR, the scheduled runs are redundant.