### PR TITLE
frontend: full symbol names and inlined sources for wasm/js stack traces

### DIFF
--- a/scripts/flutterbuildweb.sh
+++ b/scripts/flutterbuildweb.sh
@@ -17,8 +17,18 @@ python3 scripts/import_dart_plugins.py
 # can still override the binary; defaults to `flutter` on PATH (nix toolchain).
 FLUTTER="${KLANGK_WEB_FLUTTER:-flutter}"
 
-cd src/frontend && "$FLUTTER" --disable-analytics && "$FLUTTER" pub get && "$FLUTTER" build web --wasm --release --base-href=/ --no-web-resources-cdn --source-maps --no-strip-wasm
+cd src/frontend && "$FLUTTER" --disable-analytics && "$FLUTTER" pub get && "$FLUTTER" build web --wasm --release --base-href=/ --no-web-resources-cdn --source-maps --no-strip-wasm --no-minify-wasm --no-minify-js
 rm -f build/web/flutter_service_worker.js
+
+# Inline `sourcesContent` into the source maps so devtools (especially
+# Firefox, which doesn't handle the org-dartlang-sdk:/// scheme dart2js/
+# dart2wasm emit) can resolve every frame without network fetches. Resolves
+# 100% of sources from the on-disk Dart SDK, Flutter Engine, pub-cache, and
+# app tree; the .map files grow (~25MB each) but the .wasm/.js artifacts are
+# unaffected.
+FLUTTER_SDK_DIR="$(cd "$(dirname "$(readlink -f "$(command -v "$FLUTTER")")")/.." && pwd)"
+python3 "$SCRIPT_DIR/inline_sources_in_map.py" "$FLUTTER_SDK_DIR" \
+  build/web/main.dart.wasm.map build/web/main.dart.js.map
 
 # Cache-busting: append a content hash to flutter_bootstrap.js reference
 # in index.html. Since index.html is served with no-cache headers, browsers

--- a/scripts/inline_sources_in_map.py
+++ b/scripts/inline_sources_in_map.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Inline `sourcesContent` into Flutter web source maps.
+
+dart2wasm and dart2js emit source maps whose `sources` array uses
+`org-dartlang-sdk:///` (Dart SDK / engine sources) and `file:///` (nix-store
+Flutter framework) URIs that browsers can't fetch. Without `sourcesContent`,
+Firefox/Chrome devtools fail to resolve those frames and you get a wall of
+"unsupported protocol for sourcemap request" errors.
+
+This rewrites the .map files to embed the actual source text inline. After
+this runs, devtools resolve traces with no network fetches.
+
+Usage:
+    inline_sources_in_map.py <flutter-sdk> <map-file> [<map-file> ...]
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def resolve(uri: str, flutter_sdk: Path, map_dir: Path) -> Path | None:
+    """Map a sourcemap URI to an on-disk path, or None if unresolvable."""
+    if uri.startswith("file:///"):
+        return Path(uri[len("file://") :])
+    if uri.startswith("org-dartlang-sdk:///dart-sdk/"):
+        rel = uri[len("org-dartlang-sdk:///dart-sdk/") :]
+        return flutter_sdk / "bin" / "cache" / "dart-sdk" / rel
+    if uri.startswith("org-dartlang-sdk:///lib/"):
+        rel = uri[len("org-dartlang-sdk:///lib/") :]
+        return flutter_sdk / "bin" / "cache" / "flutter_web_sdk" / "lib" / rel
+    if "://" not in uri:
+        # dart2js emits paths relative to where it was invoked, but with one
+        # too many `../` for the actual map-file directory; the relative form
+        # treats `web/main.dart.js.map` as if it were nested an extra level
+        # deeper. Try map-dir-relative first; if that misses, strip the leading
+        # `../` segments and try project-root- and $HOME-relative as fallbacks.
+        direct = (map_dir / uri).resolve()
+        if direct.is_file():
+            return direct
+        # Strip leading `../` parts to get the inner path (e.g.
+        # `.pub-cache/hosted/pub.dev/...` or `lib/auth/...`).
+        stripped = uri
+        while stripped.startswith("../"):
+            stripped = stripped[3:]
+        # Try every directory between map_dir and `/`, plus $HOME. dart2js
+        # emits paths with a `../` depth that doesn't quite match the map
+        # file's directory (app `lib/` paths are off by one, pub-cache paths
+        # by several), so walk up and try each candidate base — the first
+        # one where stripped resolves is the source.
+        bases: list[Path] = []
+        cur = map_dir
+        while True:
+            bases.append(cur)
+            if cur.parent == cur:
+                break
+            cur = cur.parent
+        if Path.home() not in bases:
+            bases.append(Path.home())
+        for base in bases:
+            cand = (base / stripped).resolve()
+            if cand.is_file():
+                return cand
+        # Bare filename fallback: dart2js emits `main.dart` and
+        # `web_plugin_registrant.dart` without a directory prefix. Search the
+        # Flutter project (map_dir's grandparent) for the first match.
+        if "/" not in stripped:
+            project = map_dir.parent.parent
+            for candidate in project.rglob(stripped):
+                if candidate.is_file():
+                    return candidate
+    return None
+
+
+def inline_map(map_path: Path, flutter_sdk: Path) -> tuple[int, int]:
+    """Returns (resolved, total) source counts."""
+    data = json.loads(map_path.read_text())
+    sources = data.get("sources", [])
+    map_dir = map_path.parent.resolve()
+    contents: list[str | None] = []
+    resolved = 0
+    for uri in sources:
+        path = resolve(uri, flutter_sdk, map_dir)
+        if path is not None and path.is_file():
+            contents.append(path.read_text(errors="replace"))
+            resolved += 1
+        else:
+            contents.append(None)
+    data["sourcesContent"] = contents
+    map_path.write_text(json.dumps(data, separators=(",", ":")))
+    return resolved, len(sources)
+
+
+def main() -> int:
+    if len(sys.argv) < 3:
+        print(__doc__, file=sys.stderr)
+        return 2
+    flutter_sdk = Path(sys.argv[1]).resolve()
+    if not flutter_sdk.is_dir():
+        print(f"flutter SDK not found: {flutter_sdk}", file=sys.stderr)
+        return 1
+    for arg in sys.argv[2:]:
+        map_path = Path(arg)
+        if not map_path.is_file():
+            print(f"skipping (missing): {map_path}", file=sys.stderr)
+            continue
+        resolved, total = inline_map(map_path, flutter_sdk)
+        print(f"{map_path.name}: inlined {resolved}/{total} sources")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

(Replaces #4, whose head ref got detached from this branch on GitHub's side after a rebase + force-push. Same branch, same single commit — rebased onto the current `main`.)

Wasm/js stack traces from the `--wasm --release` build were unreadable in two ways:

1. **Mangled function names** — dart2wasm runs with `--minify` by default in release mode, renaming every Dart function to 2–3 letter symbols like `aMR`, `k7`, `cr`. Traces showed file:line correctly (from the wasm `names` section preserved by `--no-strip-wasm`) but the function names were noise.

2. **Unfetchable source URIs** — source maps reference SDK and engine code via `org-dartlang-sdk:///dart-sdk/...` and nix-store framework files via `file:///nix/store/...`. Chrome handles `org-dartlang-sdk:///` via the Dart Debug Extension; Firefox doesn't, and logs `unsupported protocol for sourcemap request` for every frame, dropping back to the unsymbolicated function name.

## Changes

- `scripts/flutterbuildweb.sh`: add the hidden `--no-minify-wasm` and `--no-minify-js` flags. They override release-mode's default `--minify` so original Dart method names land in the wasm `names` section and the JS bundle.
- `scripts/inline_sources_in_map.py`: new post-processing step. Walks each `sources[]` URI in `main.dart.wasm.map` and `main.dart.js.map`, resolves it via the on-disk Dart SDK, Flutter engine, pub-cache, and app tree, and embeds the actual source text under `sourcesContent`. After this, devtools resolve every frame with no network fetches.

Tested locally:
```
main.dart.wasm.map: inlined 1099/1099 sources
main.dart.js.map:   inlined 1013/1013 sources
```

## Trade-offs

- `.map` files grow from ~3 MB to ~28 MB each (the source text is now embedded). The runtime `.wasm` and `.js` artifacts are unchanged — maps are loaded on demand by devtools, not by the app.
- Unminified names slightly grow the wasm `names` section (debug info) but the wasm CODE section is unaffected.

## Test plan

- [ ] Open the deployed app in Firefox, trigger an exception (e.g. the previously-reported `Null check operator used on a null value`), confirm the trace shows real Dart method names and devtools opens the original .dart source for every frame.
- [ ] Same in Chrome — should still work via Chrome's protocol handler, now also via inlined `sourcesContent`.
- [ ] Confirm bundle size for `main.dart.wasm` / `main.dart.js` is unchanged (only `.map` files grow).
