### PR TITLE
Fix login settle time after accessibility timeout reduction

### DIFF
--- a/src/frontend/e2e-tests/e2e/helpers.ts
+++ b/src/frontend/e2e-tests/e2e/helpers.ts
@@ -98,7 +98,9 @@ export async function waitForFlutter(page: Page) {
     () => !document.body.textContent?.includes("Loading, please wait"),
     { timeout: 90_000 },
   );
-  await page.waitForTimeout(200);
+  // Wait for flutter-view to be present and rendered
+  await page.waitForSelector("flutter-view", { timeout: 10_000 });
+  await page.waitForTimeout(500);
 }
 
 export function fv(page: Page) {


### PR DESCRIPTION
The accessibility button timeout reduction removed an implicit settle time. Wait for flutter-view element plus 500ms before interacting with the login form.