### PR TITLE
Cache Nix store between CI runs with cache-nix-action

### DIFF
--- a/.github/actions/devenv-setup/action.yml
+++ b/.github/actions/devenv-setup/action.yml
@@ -25,6 +25,13 @@ runs:
           /usr/local/powershell /usr/local/.ghcup \
           /usr/local/julia* &
 
+    - name: Cache Nix store
+      uses: nix-community/cache-nix-action@v7
+      with:
+        primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock', 'devenv.nix', 'devenv.yaml') }}
+        restore-prefixes-first-match: nix-${{ runner.os }}-
+        gc-max-store-size-linux: 8000000000
+
     - name: Bootstrap
       shell: bash
       run: ./bootstrap --unattended --cachix-version v1.11.1


### PR DESCRIPTION
## Summary
Add `nix-community/cache-nix-action@v7` to the devenv-setup composite action to persist `/nix/store` between CI runs.

- Primary key: hash of `flake.lock`, `devenv.nix`, `devenv.yaml`
- Fallback: any previous `nix-$OS-` prefixed cache
- GC limit: 8GB (under the 10GB GitHub Actions cache limit)

First run populates the cache. Subsequent runs restore from cache, skipping most Nix fetches/builds. Expected to save several minutes on warm runs.