### PR TITLE
Stream export tarball with progress bar and size estimate

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -25,6 +25,7 @@
   packages = with pkgs; [
     docker-client
     flutter
+    coreutils # GNU du (macOS BSD du lacks -b)
     gnutar
     nginx
     xz

--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -595,21 +595,6 @@ async def delete_workspace(
     return {"status": "deleted"}
 
 
-def _cleanup_tempfile(path: str):
-    """Return a Starlette BackgroundTask that deletes a temp file."""
-    from starlette.background import BackgroundTask
-
-    async def _delete():
-        import os
-
-        try:
-            os.unlink(path)
-        except OSError:
-            pass
-
-    return BackgroundTask(_delete)
-
-
 # --- Workspace export/import endpoints ---
 
 
@@ -641,44 +626,95 @@ async def export_workspace(
         "num_ports": workspace.get("num_ports", 5),
     }
 
-    # Build tarball to a temp file to avoid holding it all in memory.
-    tmp = tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False)
-    try:
-        with tarfile.open(fileobj=tmp, mode="w:gz") as tar:
-            # Add workspace.json
-            meta_bytes = json.dumps(metadata, indent=2).encode()
-            info = tarfile.TarInfo(name="workspace.json")
-            info.size = len(meta_bytes)
-            tar.addfile(info, io.BytesIO(meta_bytes))
+    # Estimate uncompressed size for client progress display.
+    import subprocess
 
-            # Add home directory. Symlinks that resolve outside the
-            # home dir are stripped to prevent leaking host files.
-            home_resolved = home_dir.resolve()
+    estimated_size = 0
+    if home_dir.exists():
+        try:
+            result = subprocess.run(
+                ["du", "-sb", str(home_dir)],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if result.returncode == 0:
+                estimated_size = int(result.stdout.split()[0])
+        except (OSError, ValueError, subprocess.TimeoutExpired):
+            pass  # fall back to 0
 
-            def _safe_filter(ti):
-                if ti.issym():
-                    # Resolve the symlink target relative to the home dir
-                    target = (home_dir / ti.linkname).resolve()
-                    if not target.is_relative_to(home_resolved):
-                        return None
-                return ti
+    # Stream the tarball as it's built — no temp file needed.
+    # tarfile writes to a queue in a background thread; the async
+    # generator reads from the queue and yields chunks to the client.
+    import asyncio
+    import queue
+    import threading
 
-            if home_dir.exists():
-                tar.add(str(home_dir), arcname="home", filter=_safe_filter)
-        tmp.close()
+    chunk_queue: queue.Queue[bytes | None] = queue.Queue(maxsize=32)
 
-        safe_name = ws_name.replace("/", "_").replace("\\", "_")
-        return FileResponse(
-            tmp.name,
-            media_type="application/gzip",
-            filename=f"{safe_name}.tar.gz",
-            background=_cleanup_tempfile(tmp.name),
-        )
-    except Exception:
-        import os
+    class _QueueWriter:
+        """File-like object that puts writes into a queue."""
 
-        os.unlink(tmp.name)
-        raise
+        def write(self, data):
+            chunk_queue.put(data)
+            return len(data)
+
+        def flush(self):  # pragma: no cover — called by gzip internals
+            pass
+
+        def close(self):
+            chunk_queue.put(None)  # sentinel
+
+    def _build_tar():
+        writer = _QueueWriter()
+        try:
+            with tarfile.open(fileobj=writer, mode="w|gz") as tar:
+                # Add workspace.json
+                meta_bytes = json.dumps(metadata, indent=2).encode()
+                info = tarfile.TarInfo(name="workspace.json")
+                info.size = len(meta_bytes)
+                tar.addfile(info, io.BytesIO(meta_bytes))
+
+                # Add home directory. Symlinks that resolve outside the
+                # home dir are stripped to prevent leaking host files.
+                home_resolved = home_dir.resolve()
+
+                def _safe_filter(ti):
+                    if ti.issym():
+                        target = (home_dir / ti.linkname).resolve()
+                        if not target.is_relative_to(home_resolved):
+                            return None
+                    return ti
+
+                if home_dir.exists():
+                    tar.add(str(home_dir), arcname="home", filter=_safe_filter)
+        finally:
+            writer.close()
+
+    async def _stream():
+        loop = asyncio.get_event_loop()
+        thread = threading.Thread(target=_build_tar, daemon=True)
+        thread.start()
+        try:
+            while True:
+                chunk = await loop.run_in_executor(None, chunk_queue.get)
+                if chunk is None:
+                    break
+                yield chunk
+        finally:
+            thread.join(timeout=5)
+
+    safe_name = ws_name.replace("/", "_").replace("\\", "_")
+    # Rough estimate: gzip typically compresses to ~40% of original.
+    estimated_compressed = max(int(estimated_size * 0.4), 1)
+    return StreamingResponse(
+        _stream(),
+        media_type="application/gzip",
+        headers={
+            "Content-Disposition": f'attachment; filename="{safe_name}.tar.gz"',
+            "X-Estimated-Size": str(estimated_compressed),
+        },
+    )
 
 
 @router.post("/workspaces/import")

--- a/src/backend/klangk_backend/cli/client.py
+++ b/src/backend/klangk_backend/cli/client.py
@@ -174,11 +174,14 @@ class KlangkClient:
             if not resp.is_success:
                 resp.read()  # consume body so .text is available
                 resp.raise_for_status()
-            total = (
-                int(resp.headers["content-length"])
-                if "content-length" in resp.headers
-                else None
-            )
+            # Use Content-Length if available, otherwise fall back to
+            # the server's compressed size estimate.
+            if "content-length" in resp.headers:
+                total = int(resp.headers["content-length"])
+            elif "x-estimated-size" in resp.headers:
+                total = int(resp.headers["x-estimated-size"])
+            else:
+                total = None
             downloaded = 0
             with open(output, "wb") as f:
                 for chunk in resp.iter_bytes():

--- a/src/backend/klangk_backend/cli/main.py
+++ b/src/backend/klangk_backend/cli/main.py
@@ -242,6 +242,8 @@ def export_workspace(
         raise typer.Exit(code=1) from None
     out_path = output or Path(f"{name}.tar.gz")
     try:
+        from rich.live import Live
+        from rich.spinner import Spinner
         from rich.progress import (
             Progress,
             BarColumn,
@@ -249,22 +251,28 @@ def export_workspace(
             TransferSpeedColumn,
         )
 
-        with Progress(
+        progress = Progress(
             "[progress.description]{task.description}",
             BarColumn(),
             DownloadColumn(),
             TransferSpeedColumn(),
-        ) as progress:
-            task_id = progress.add_task("Exporting...", total=0)
+        )
+        task_id = progress.add_task("Downloading...", total=0)
+        started = [False]
 
-            def _update(downloaded, total):
-                if total is not None:
-                    progress.update(task_id, total=total, completed=downloaded)
-                else:
-                    progress.update(
-                        task_id, total=downloaded, completed=downloaded
-                    )
+        def _update(downloaded, total):
+            if not started[0]:
+                started[0] = True
+                live.update(progress)
+            if total is not None:
+                progress.update(task_id, total=total, completed=downloaded)
+            else:
+                progress.update(
+                    task_id, total=downloaded, completed=downloaded
+                )
 
+        spinner = Spinner("dots", text="Building archive on server...")
+        with Live(spinner, refresh_per_second=10) as live:
             client.export_workspace(ws.id, out_path, on_progress=_update)
     except httpx.HTTPStatusError as e:
         _err.print(f"[red]Export failed:[/red] {e.response.text}")

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -2403,58 +2403,82 @@ class TestWorkspaceExportImport:
         home = ws_mod.home_path(user["id"], ws["id"])
         assert (home / "test.txt").exists()
 
-    async def test_export_error_cleans_tempfile(
-        self, client, admin_user, user, monkeypatch
+    async def test_export_streams_valid_tarball(
+        self, client, admin_user, user
     ):
-        """If tarball creation fails, the temp file is cleaned up."""
+        """Export streams a valid .tar.gz with size estimate header."""
         headers = await self._user_headers(client)
         resp = await client.post(
-            "/workspaces", headers=headers, json={"name": "err-export"}
+            "/workspaces", headers=headers, json={"name": "stream-test"}
         )
         ws = resp.json()
 
-        import klangk_backend.api as api_mod
-        import tarfile as tarfile_mod
+        import klangk_backend.workspaces as ws_mod
 
-        original_open = tarfile_mod.open
-        created_tmp = []
-
-        original_ntf = tempfile.NamedTemporaryFile
-
-        def _tracking_ntf(*args, **kwargs):
-            tmp = original_ntf(*args, **kwargs)
-            created_tmp.append(tmp.name)
-            return tmp
-
-        def _failing_open(*args, **kwargs):
-            tf = original_open(*args, **kwargs)
-
-            def _bad_add(*a, **kw):
-                raise OSError("disk error")
-
-            tf.add = _bad_add
-            return tf
-
-        monkeypatch.setattr(api_mod.tarfile, "open", _failing_open)
-        monkeypatch.setattr(
-            api_mod.tempfile, "NamedTemporaryFile", _tracking_ntf
-        )
+        home = ws_mod.home_path(user["id"], ws["id"])
+        home.mkdir(parents=True, exist_ok=True)
+        (home / "work").mkdir(exist_ok=True)
+        (home / "work" / "file.txt").write_text("streamed content")
 
         admin_headers = await self._admin_headers(client)
-        with pytest.raises(OSError, match="disk error"):
-            await client.get(
-                f"/workspaces/{ws['id']}/export", headers=admin_headers
-            )
+        resp = await client.get(
+            f"/workspaces/{ws['id']}/export", headers=admin_headers
+        )
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "application/gzip"
+        assert "x-estimated-size" in resp.headers
+        assert int(resp.headers["x-estimated-size"]) > 0
 
-        # Verify the temp file was cleaned up
-        assert len(created_tmp) == 1
-        assert not os.path.exists(created_tmp[0])
+        # Verify the streamed response is a valid tarball
+        import tarfile
 
-    async def test_export_cleanup_tempfile(self, client, admin_user, user):
-        """The export endpoint's background task cleans up the temp file."""
+        buf = io.BytesIO(resp.content)
+        with tarfile.open(fileobj=buf, mode="r:gz") as tar:
+            names = tar.getnames()
+            assert "workspace.json" in names
+            assert any("file.txt" in n for n in names)
+
+    async def test_export_du_failure_falls_back(
+        self, client, admin_user, user, monkeypatch
+    ):
+        """If du fails, estimated size defaults to minimum."""
         headers = await self._user_headers(client)
         resp = await client.post(
-            "/workspaces", headers=headers, json={"name": "cleanup-test"}
+            "/workspaces", headers=headers, json={"name": "du-fail"}
+        )
+        ws = resp.json()
+
+        import klangk_backend.workspaces as ws_mod
+
+        home = ws_mod.home_path(user["id"], ws["id"])
+        home.mkdir(parents=True, exist_ok=True)
+        (home / "work").mkdir(exist_ok=True)
+        (home / "work" / "f.txt").write_text("data")
+
+        import subprocess as subprocess_mod
+
+        original_run = subprocess_mod.run
+
+        def _failing_run(*args, **kwargs):
+            if args and args[0] and args[0][0] == "du":
+                raise OSError("du not found")
+            return original_run(*args, **kwargs)
+
+        monkeypatch.setattr(subprocess_mod, "run", _failing_run)
+
+        admin_headers = await self._admin_headers(client)
+        resp = await client.get(
+            f"/workspaces/{ws['id']}/export", headers=admin_headers
+        )
+        assert resp.status_code == 200
+        # Falls back to 0 * 0.4 = 0, clamped to 1
+        assert resp.headers["x-estimated-size"] == "1"
+
+    async def test_export_empty_workspace(self, client, admin_user, user):
+        """Export of workspace with no home dir still works."""
+        headers = await self._user_headers(client)
+        resp = await client.post(
+            "/workspaces", headers=headers, json={"name": "empty-export"}
         )
         ws = resp.json()
 
@@ -2463,29 +2487,8 @@ class TestWorkspaceExportImport:
             f"/workspaces/{ws['id']}/export", headers=admin_headers
         )
         assert resp.status_code == 200
-
-        # Verify _cleanup_tempfile returns a valid BackgroundTask
-        from klangk_backend.api import _cleanup_tempfile
-        import tempfile
-
-        tmp = tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False)
-        tmp.close()
-        task = _cleanup_tempfile(tmp.name)
-        assert task is not None
-
-        # Run the background task
-
-        await task()
-        import os
-
-        assert not os.path.exists(tmp.name)
-
-    async def test_export_cleanup_tempfile_missing_file(self):
-        """_cleanup_tempfile handles missing files gracefully."""
-        from klangk_backend.api import _cleanup_tempfile
-
-        task = _cleanup_tempfile("/nonexistent/path/file.tar.gz")
-        await task()  # Should not raise
+        # Estimated size is 0 * 0.4 = 0, clamped to 1
+        assert resp.headers["x-estimated-size"] == "1"
 
     async def test_import_upload_error_cleans_tempfile(
         self, client, user, monkeypatch

--- a/src/backend/tests/test_cli.py
+++ b/src/backend/tests/test_cli.py
@@ -779,6 +779,62 @@ class TestExportImportClient:
         mock_stream.assert_called_once()
         assert progress_calls == [(6, 12), (12, 12)]
 
+    def test_export_workspace_uses_estimated_size(self, tmp_path):
+        cfg = CLIConfig()
+        cfg.server.url = "http://localhost:8995"
+        cfg.auth.token = "token"
+        client = KlangkClient(cfg)
+
+        output = tmp_path / "est.tar.gz"
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.is_success = True
+        mock_resp.headers = {"x-estimated-size": "5000"}
+        mock_resp.iter_bytes.return_value = [b"data"]
+
+        progress_calls = []
+
+        with patch("httpx.stream") as mock_stream:
+            mock_stream.return_value.__enter__ = MagicMock(
+                return_value=mock_resp
+            )
+            mock_stream.return_value.__exit__ = MagicMock(return_value=False)
+            client.export_workspace(
+                "ws-id",
+                output,
+                on_progress=lambda d, t: progress_calls.append((d, t)),
+            )
+
+        assert progress_calls == [(4, 5000)]
+
+    def test_export_workspace_no_size_headers(self, tmp_path):
+        cfg = CLIConfig()
+        cfg.server.url = "http://localhost:8995"
+        cfg.auth.token = "token"
+        client = KlangkClient(cfg)
+
+        output = tmp_path / "nosize.tar.gz"
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.is_success = True
+        mock_resp.headers = {}
+        mock_resp.iter_bytes.return_value = [b"chunk"]
+
+        progress_calls = []
+
+        with patch("httpx.stream") as mock_stream:
+            mock_stream.return_value.__enter__ = MagicMock(
+                return_value=mock_resp
+            )
+            mock_stream.return_value.__exit__ = MagicMock(return_value=False)
+            client.export_workspace(
+                "ws-id",
+                output,
+                on_progress=lambda d, t: progress_calls.append((d, t)),
+            )
+
+        assert progress_calls == [(5, None)]
+
     def test_export_workspace_http_error(self, tmp_path):
         cfg = CLIConfig()
         cfg.server.url = "http://localhost:8995"


### PR DESCRIPTION
## Summary
- Stream tarball as it's built (no temp file) — bytes flow to client immediately
- Estimate compressed size via `du -sb * 0.4`, sent as `X-Estimated-Size` header
- CLI shows spinner during initial server processing, then progress bar with download speed
- Add `coreutils` to devenv packages for GNU `du` on macOS

## Test plan
- [x] 806 backend unit tests pass (100% coverage)
- [ ] CI passes
- [ ] Manual test: `klangk export` shows spinner → progress bar