### PR TITLE
Fix export throughput and progress bar accuracy

### DIFF
--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -652,17 +652,28 @@ async def export_workspace(
 
     chunk_queue: queue.Queue[bytes | None] = queue.Queue(maxsize=32)
 
+    _WRITE_BUF_SIZE = 256 * 1024  # 256 KB chunks
+
     class _QueueWriter:
-        """File-like object that puts writes into a queue."""
+        """File-like object that buffers writes and flushes to a queue."""
+
+        def __init__(self):
+            self._buf = bytearray()
 
         def write(self, data):
-            chunk_queue.put(data)
+            self._buf.extend(data)
+            while len(self._buf) >= _WRITE_BUF_SIZE:
+                chunk_queue.put(bytes(self._buf[:_WRITE_BUF_SIZE]))
+                del self._buf[:_WRITE_BUF_SIZE]
             return len(data)
 
-        def flush(self):  # pragma: no cover — called by gzip internals
-            pass
+        def flush(self):
+            if self._buf:
+                chunk_queue.put(bytes(self._buf))
+                self._buf.clear()
 
         def close(self):
+            self.flush()
             chunk_queue.put(None)  # sentinel
 
     def _build_tar():
@@ -705,8 +716,9 @@ async def export_workspace(
             thread.join(timeout=5)
 
     safe_name = ws_name.replace("/", "_").replace("\\", "_")
-    # Rough estimate: gzip typically compresses to ~40% of original.
-    estimated_compressed = max(int(estimated_size * 0.4), 1)
+    # Rough estimate: gzip typically compresses to ~20% of original
+    # for text-heavy home dirs (source code, dotfiles, configs).
+    estimated_compressed = max(int(estimated_size * 0.2), 1)
     return StreamingResponse(
         _stream(),
         media_type="application/gzip",

--- a/src/backend/klangk_backend/cli/main.py
+++ b/src/backend/klangk_backend/cli/main.py
@@ -274,6 +274,10 @@ def export_workspace(
         spinner = Spinner("dots", text="Building archive on server...")
         with Live(spinner, refresh_per_second=10) as live:
             client.export_workspace(ws.id, out_path, on_progress=_update)
+            # Ensure progress bar hits 100% regardless of estimate accuracy
+            if started[0]:
+                final = progress.tasks[task_id].completed
+                progress.update(task_id, total=final, completed=final)
     except httpx.HTTPStatusError as e:
         _err.print(f"[red]Export failed:[/red] {e.response.text}")
         raise typer.Exit(code=1) from None

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -2438,6 +2438,40 @@ class TestWorkspaceExportImport:
             assert "workspace.json" in names
             assert any("file.txt" in n for n in names)
 
+    async def test_export_large_file_chunks(self, client, admin_user, user):
+        """Export with large files triggers the write buffer flush path."""
+        headers = await self._user_headers(client)
+        resp = await client.post(
+            "/workspaces", headers=headers, json={"name": "large-export"}
+        )
+        ws = resp.json()
+
+        import klangk_backend.workspaces as ws_mod
+
+        home = ws_mod.home_path(user["id"], ws["id"])
+        home.mkdir(parents=True, exist_ok=True)
+        (home / "work").mkdir(exist_ok=True)
+        # Write a large file with random data (incompressible, so gzip
+        # passes it through in large writes that trigger buffer flushes)
+        import random
+
+        rng = random.Random(42)
+        (home / "work" / "big.bin").write_bytes(
+            bytes(rng.getrandbits(8) for _ in range(512 * 1024))
+        )
+
+        admin_headers = await self._admin_headers(client)
+        resp = await client.get(
+            f"/workspaces/{ws['id']}/export", headers=admin_headers
+        )
+        assert resp.status_code == 200
+
+        import tarfile
+
+        buf = io.BytesIO(resp.content)
+        with tarfile.open(fileobj=buf, mode="r:gz") as tar:
+            assert any("big.bin" in n for n in tar.getnames())
+
     async def test_export_du_failure_falls_back(
         self, client, admin_user, user, monkeypatch
     ):


### PR DESCRIPTION
Buffer writes in 256KB chunks (was per-write), lower compression estimate to 0.2, finalize progress bar to 100% on completion.