### PR TITLE
Use GNU tar for import extraction

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -26,6 +26,7 @@
     docker-client
     flutter
     coreutils # GNU du (macOS BSD du lacks -b)
+    gzip
     gnutar
     nginx
     xz

--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -1,10 +1,13 @@
 """API route handlers for Klangk backend."""
 
+import asyncio
 import io
 import json
 import logging
+import os
 import posixpath
 import sqlite3
+import subprocess
 import tarfile
 import tempfile
 import time
@@ -627,8 +630,6 @@ async def export_workspace(
     }
 
     # Estimate uncompressed size for client progress display.
-    import subprocess
-
     estimated_size = 0
     if home_dir.exists():
         try:
@@ -646,7 +647,6 @@ async def export_workspace(
     # Stream the tarball as it's built — no temp file needed.
     # tarfile writes to a queue in a background thread; the async
     # generator reads from the queue and yields chunks to the client.
-    import asyncio
     import queue
     import threading
 
@@ -755,114 +755,113 @@ async def import_workspace(
             tmp.write(chunk)
         tmp.close()
     except HTTPException:
-        import os
-
         os.unlink(tmp.name)
         raise
     except Exception:
-        import os
-
         os.unlink(tmp.name)
         raise
+
+    # Extract workspace.json from the archive using tar (fast, no Python parsing).
     ws = None
     try:
-        with tarfile.open(tmp.name, mode="r:gz") as tar:
-            # Validate: no path traversal
-            for member in tar.getmembers():
-                if member.name.startswith("/") or ".." in member.name:
-                    raise HTTPException(
-                        status_code=400,
-                        detail=f"Invalid path in archive: {member.name}",
-                    )
+        result = subprocess.run(
+            ["tar", "xzf", tmp.name, "-O", "workspace.json"],
+            capture_output=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            raise HTTPException(
+                status_code=400,
+                detail="Archive missing workspace.json or is corrupt",
+            )
+        metadata = json.loads(result.stdout)
 
-            # Extract workspace.json
-            try:
-                meta_file = tar.extractfile("workspace.json")
-            except KeyError:
-                raise HTTPException(
-                    status_code=400,
-                    detail="Archive missing workspace.json",
-                )
-            if meta_file is None:  # pragma: no cover — defensive
-                raise HTTPException(
-                    status_code=400,
-                    detail="Archive missing workspace.json",
-                )
-            metadata = json.loads(meta_file.read())
-
-            ws_name = name or metadata.get("name")
-            if not ws_name:
-                raise HTTPException(
-                    status_code=400,
-                    detail="No workspace name in archive or request",
-                )
-
-            image = metadata.get("image")
-            if image and image not in container.ALLOWED_IMAGES:
-                image = None  # fall back to default
-
-            mounts = metadata.get("mounts")
-            if mounts and container.validate_mounts(mounts):
-                mounts = None  # invalid mounts, drop them
-
-            # Sanitize env: drop keys that could interfere with
-            # container startup (KLANGK_*, LD_*, PATH, etc.)
-            raw_env = metadata.get("env")
-            if isinstance(raw_env, dict):
-                blocked = {"LD_PRELOAD", "LD_LIBRARY_PATH", "PATH"}
-                env = {
-                    k: v
-                    for k, v in raw_env.items()
-                    if not k.startswith("KLANGK_") and k not in blocked
-                }
-            else:
-                env = None
-
-            try:
-                ws = await workspaces.create_workspace(
-                    user["id"],
-                    ws_name,
-                    image=image,
-                    default_command=metadata.get("default_command"),
-                    mounts=mounts,
-                    env=env,
-                )
-            except sqlite3.IntegrityError:
-                raise HTTPException(
-                    status_code=409,
-                    detail=f"A workspace named {ws_name!r} already exists",
-                )
-
-            # Extract home directory using filter='data' for safety
-            # (strips permissions, blocks devices/special files).
-            home_dir = workspaces.home_path(user["id"], ws["id"])
-            home_dir.mkdir(parents=True, exist_ok=True)
-            home_members = [
-                m for m in tar.getmembers() if m.name.startswith("home/")
-            ]
-            for member in home_members:
-                # Strip the "home/" prefix
-                member.name = member.name[5:]  # len("home/") == 5
-            home_members = [m for m in home_members if m.name]
-            tar.extractall(
-                path=str(home_dir), members=home_members, filter="data"
+        ws_name = name or metadata.get("name")
+        if not ws_name:
+            raise HTTPException(
+                status_code=400,
+                detail="No workspace name in archive or request",
             )
 
-    except tarfile.TarError:
-        # Clean up the workspace if extraction failed after creation
+        image = metadata.get("image")
+        if image and image not in container.ALLOWED_IMAGES:
+            image = None  # fall back to default
+
+        mounts = metadata.get("mounts")
+        if mounts and container.validate_mounts(mounts):
+            mounts = None  # invalid mounts, drop them
+
+        # Sanitize env: drop keys that could interfere with
+        # container startup (KLANGK_*, LD_*, PATH, etc.)
+        raw_env = metadata.get("env")
+        if isinstance(raw_env, dict):
+            blocked = {"LD_PRELOAD", "LD_LIBRARY_PATH", "PATH"}
+            env = {
+                k: v
+                for k, v in raw_env.items()
+                if not k.startswith("KLANGK_") and k not in blocked
+            }
+        else:
+            env = None
+
+        try:
+            ws = await workspaces.create_workspace(
+                user["id"],
+                ws_name,
+                image=image,
+                default_command=metadata.get("default_command"),
+                mounts=mounts,
+                env=env,
+            )
+        except sqlite3.IntegrityError:
+            raise HTTPException(
+                status_code=409,
+                detail=f"A workspace named {ws_name!r} already exists",
+            )
+
+        # Extract home directory using tar (much faster than Python tarfile
+        # for archives with many members). --strip-components=1 removes
+        # the "home/" prefix. Only extract if home/ exists in the archive.
+        home_dir = workspaces.home_path(user["id"], ws["id"])
+        home_dir.mkdir(parents=True, exist_ok=True)
+        check = subprocess.run(
+            ["tar", "tzf", tmp.name, "home/"],
+            capture_output=True,
+            timeout=30,
+        )
+        if check.returncode == 0:
+            result = await asyncio.to_thread(
+                subprocess.run,
+                [
+                    "tar",
+                    "xzf",
+                    tmp.name,
+                    "--strip-components=1",
+                    "--no-same-owner",
+                    "--no-same-permissions",
+                    "-C",
+                    str(home_dir),
+                    "home/",
+                ],
+                capture_output=True,
+                timeout=300,
+            )
+            if result.returncode != 0:
+                await workspaces.delete_workspace(ws["id"], user["id"])
+                raise HTTPException(
+                    status_code=400,
+                    detail="Failed to extract home directory from archive",
+                )
+
+    except HTTPException:
+        raise
+    except (json.JSONDecodeError, subprocess.TimeoutExpired):
         if ws:
             await workspaces.delete_workspace(ws["id"], user["id"])
         raise HTTPException(
             status_code=400, detail="Invalid or corrupt archive"
         )
-    except HTTPException:
-        # Clean up the workspace if validation failed after creation
-        if ws:
-            await workspaces.delete_workspace(ws["id"], user["id"])
-        raise
     finally:
-        import os
-
         os.unlink(tmp.name)
 
     return ws

--- a/src/backend/klangk_backend/cli/client.py
+++ b/src/backend/klangk_backend/cli/client.py
@@ -191,17 +191,47 @@ class KlangkClient:
                         on_progress(downloaded, total)
 
     def import_workspace(
-        self, archive: Path, name: str | None = None
+        self, archive: Path, name: str | None = None, on_progress=None
     ) -> Workspace:
-        """Upload a workspace archive and create a new workspace."""
+        """Upload a workspace archive and create a new workspace.
+
+        on_progress(bytes_so_far, total_bytes) is called as bytes are read.
+        """
         params = {}
         if name:
             params["name"] = name
+        total = archive.stat().st_size
+
+        class _ProgressFile:
+            """Wraps a file to track read progress."""
+
+            def __init__(self, f):
+                self._f = f
+                self._read = 0
+
+            def read(self, size=-1):
+                data = self._f.read(size)
+                if data:
+                    self._read += len(data)
+                    if on_progress:
+                        on_progress(self._read, total)
+                return data
+
+            def seek(
+                self, *args
+            ):  # pragma: no cover — called by httpx multipart
+                self._read = 0
+                return self._f.seek(*args)
+
+            def tell(self):  # pragma: no cover — called by httpx multipart
+                return self._f.tell()
+
         with open(archive, "rb") as f:
+            pf = _ProgressFile(f) if on_progress else f
             resp = httpx.post(
                 f"{self.cfg.server.url}/workspaces/import",
                 headers=self._headers(),
-                files={"file": (archive.name, f, "application/gzip")},
+                files={"file": (archive.name, pf, "application/gzip")},
                 params=params,
                 timeout=300.0,
             )

--- a/src/backend/klangk_backend/cli/main.py
+++ b/src/backend/klangk_backend/cli/main.py
@@ -321,7 +321,30 @@ def import_workspace(
         raise typer.Exit(code=1)
     client = _client()
     try:
-        ws = client.import_workspace(archive, name=name)
+        from rich.progress import (
+            Progress,
+            BarColumn,
+            DownloadColumn,
+            TransferSpeedColumn,
+        )
+
+        progress = Progress(
+            "[progress.description]{task.description}",
+            BarColumn(),
+            DownloadColumn(),
+            TransferSpeedColumn(),
+        )
+        task_id = progress.add_task(
+            "Uploading...", total=archive.stat().st_size
+        )
+
+        def _update(uploaded, total):
+            progress.update(task_id, completed=uploaded)
+
+        with progress:
+            ws = client.import_workspace(
+                archive, name=name, on_progress=_update
+            )
     except httpx.HTTPStatusError as e:
         _err.print(f"[red]Import failed:[/red] {e.response.text}")
         raise typer.Exit(code=1) from None

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -2664,12 +2664,10 @@ class TestWorkspaceExportImport:
     async def test_import_cleanup_on_extraction_failure(
         self, client, user, monkeypatch
     ):
-        """If extraction fails after workspace creation, the workspace is cleaned up."""
+        """If tar extraction fails, the workspace is cleaned up."""
         import json
         import tarfile
 
-        # Build an archive with valid metadata but a home member that
-        # will fail extraction due to filter='data' rejecting it.
         buf = io.BytesIO()
         with tarfile.open(fileobj=buf, mode="w:gz") as tar:
             meta = json.dumps({"name": "fail-extract"}).encode()
@@ -2677,28 +2675,28 @@ class TestWorkspaceExportImport:
             info.size = len(meta)
             tar.addfile(info, io.BytesIO(meta))
 
-            # Add a home file that will pass initial validation
             data = b"content"
             file_info = tarfile.TarInfo(name="home/test.txt")
             file_info.size = len(data)
             tar.addfile(file_info, io.BytesIO(data))
         buf.seek(0)
 
-        # Monkeypatch extractall to raise after workspace is created
-        import klangk_backend.api as api_mod
+        import subprocess as subprocess_mod
 
-        original_open = tarfile.open
+        original_run = subprocess_mod.run
+        call_count = [0]
 
-        def _patched_open(*args, **kwargs):
-            tf = original_open(*args, **kwargs)
+        def _failing_run(args, **kwargs):
+            call_count[0] += 1
+            # Let the first calls (tar xzf -O workspace.json, tar tzf home/)
+            # succeed, but fail on the extraction call (tar xzf ... -C ...)
+            if "-C" in args:
+                return subprocess_mod.CompletedProcess(
+                    args=args, returncode=1, stdout=b"", stderr=b"failed"
+                )
+            return original_run(args, **kwargs)
 
-            def _failing_extractall(*a, **kw):
-                raise tarfile.TarError("corrupt data")
-
-            tf.extractall = _failing_extractall
-            return tf
-
-        monkeypatch.setattr(api_mod.tarfile, "open", _patched_open)
+        monkeypatch.setattr(subprocess_mod, "run", _failing_run)
 
         headers = await self._user_headers(client)
         resp = await client.post(
@@ -2715,17 +2713,40 @@ class TestWorkspaceExportImport:
         names = [w["name"] for w in resp.json()]
         assert "fail-extract" not in names
 
-    async def test_import_cleanup_on_http_exception_after_creation(
-        self, client, user, monkeypatch
-    ):
-        """If an HTTPException occurs after workspace creation, workspace is cleaned up."""
-        import json
+    async def test_import_invalid_json_in_metadata(self, client, user):
+        """If workspace.json contains invalid JSON, import fails cleanly."""
         import tarfile
-        import klangk_backend.api as api_mod
 
         buf = io.BytesIO()
         with tarfile.open(fileobj=buf, mode="w:gz") as tar:
-            meta = json.dumps({"name": "fail-http"}).encode()
+            bad_json = b"not valid json {"
+            info = tarfile.TarInfo(name="workspace.json")
+            info.size = len(bad_json)
+            tar.addfile(info, io.BytesIO(bad_json))
+        buf.seek(0)
+
+        headers = await self._user_headers(client)
+        resp = await client.post(
+            "/workspaces/import",
+            headers=headers,
+            files={
+                "file": ("archive.tar.gz", buf.getvalue(), "application/gzip")
+            },
+        )
+        assert resp.status_code == 400
+        assert "corrupt" in resp.json()["detail"].lower()
+
+    async def test_import_timeout_cleans_up_workspace(
+        self, client, user, monkeypatch
+    ):
+        """If tar extraction times out after workspace creation, cleanup occurs."""
+        import json
+        import tarfile
+        import subprocess as subprocess_mod
+
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            meta = json.dumps({"name": "timeout-test"}).encode()
             info = tarfile.TarInfo(name="workspace.json")
             info.size = len(meta)
             tar.addfile(info, io.BytesIO(meta))
@@ -2736,18 +2757,14 @@ class TestWorkspaceExportImport:
             tar.addfile(file_info, io.BytesIO(data))
         buf.seek(0)
 
-        original_open = tarfile.open
+        original_run = subprocess_mod.run
 
-        def _patched_open(*args, **kwargs):
-            tf = original_open(*args, **kwargs)
+        def _timeout_run(args, **kwargs):
+            if "-C" in args:
+                raise subprocess_mod.TimeoutExpired(args, 300)
+            return original_run(args, **kwargs)
 
-            def _failing_extractall(*a, **kw):
-                raise HTTPException(status_code=400, detail="bad data")
-
-            tf.extractall = _failing_extractall
-            return tf
-
-        monkeypatch.setattr(api_mod.tarfile, "open", _patched_open)
+        monkeypatch.setattr(subprocess_mod, "run", _timeout_run)
 
         headers = await self._user_headers(client)
         resp = await client.post(
@@ -2759,13 +2776,12 @@ class TestWorkspaceExportImport:
         )
         assert resp.status_code == 400
 
-        # Workspace should have been cleaned up
         resp = await client.get("/workspaces", headers=headers)
         names = [w["name"] for w in resp.json()]
-        assert "fail-http" not in names
+        assert "timeout-test" not in names
 
     async def test_import_path_traversal_rejected(self, client, user):
-        import io
+        """GNU tar rejects members with '..' in their path."""
         import json
         import tarfile
 
@@ -2777,7 +2793,7 @@ class TestWorkspaceExportImport:
             tar.addfile(info, io.BytesIO(meta))
 
             evil = b"pwned"
-            info = tarfile.TarInfo(name="../../../etc/passwd")
+            info = tarfile.TarInfo(name="home/../../../etc/passwd")
             info.size = len(evil)
             tar.addfile(info, io.BytesIO(evil))
         buf.seek(0)
@@ -2790,5 +2806,10 @@ class TestWorkspaceExportImport:
                 "file": ("archive.tar.gz", buf.getvalue(), "application/gzip")
             },
         )
+        # GNU tar refuses to extract members with '..' — returns non-zero
         assert resp.status_code == 400
-        assert "Invalid path" in resp.json()["detail"]
+
+        # Workspace should have been cleaned up
+        resp = await client.get("/workspaces", headers=headers)
+        names = [w["name"] for w in resp.json()]
+        assert "traversal-test" not in names

--- a/src/backend/tests/test_cli.py
+++ b/src/backend/tests/test_cli.py
@@ -897,6 +897,47 @@ class TestExportImportClient:
         assert ws.name == "imported-ws"
         assert ws.id == "new-id"
 
+    def test_import_workspace_with_progress(self, tmp_path):
+        cfg = CLIConfig()
+        cfg.server.url = "http://localhost:8995"
+        cfg.auth.token = "token"
+        client = KlangkClient(cfg)
+
+        archive = tmp_path / "test.tar.gz"
+        archive.write_bytes(b"fake archive data")
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "id": "prog-id",
+            "name": "prog-ws",
+            "created_at": "2025-01-01",
+        }
+
+        progress_calls = []
+
+        def _mock_post(*args, **kwargs):
+            # Simulate httpx reading the file (which triggers progress)
+            files = kwargs.get("files", {})
+            if files:
+                _, file_tuple = next(iter(files.items()))
+                _, fobj, _ = file_tuple
+                while fobj.read(8192):
+                    pass
+            return mock_resp
+
+        with patch("httpx.post", side_effect=_mock_post):
+            ws = client.import_workspace(
+                archive,
+                name="prog-ws",
+                on_progress=lambda d, t: progress_calls.append((d, t)),
+            )
+
+        assert ws.name == "prog-ws"
+        assert len(progress_calls) > 0
+        assert all(t == 17 for _, t in progress_calls)
+        assert progress_calls[-1][0] == 17
+
     def test_import_workspace_auth_error(self, tmp_path):
         cfg = CLIConfig()
         cfg.auth.token = "bad"

--- a/src/backend/tests/test_cli_main.py
+++ b/src/backend/tests/test_cli_main.py
@@ -1490,16 +1490,24 @@ class TestExportImportCLI:
         ws = Workspace(
             id="ws-imp-id", name="imported", created_at="2025-01-01"
         )
+
+        def _fake_import(a, name=None, on_progress=None):
+            if on_progress:
+                on_progress(2, 4)
+                on_progress(4, 4)
+            return ws
+
         client = MagicMock()
-        client.import_workspace.return_value = ws
+        client.import_workspace.side_effect = _fake_import
         monkeypatch.setattr(main, "_client", lambda: client)
 
         archive = tmp_path / "test.tar.gz"
         archive.write_bytes(b"fake")
         main.import_workspace(archive=archive, name="imported")
-        client.import_workspace.assert_called_once_with(
-            archive, name="imported"
-        )
+        client.import_workspace.assert_called_once()
+        args = client.import_workspace.call_args
+        assert args[0][0] == archive
+        assert args[1]["name"] == "imported"
 
     def test_import_file_not_found(self, logged_in_cfg, monkeypatch, tmp_path):
         from klangk_backend.cli import main


### PR DESCRIPTION
## Summary
Replace Python's tarfile with GNU tar CLI for import extraction. Python tarfile was pegging all CPUs on a 160MB archive with 93K members.

- Shell out to `tar` for metadata extraction, home dir check, and extraction
- GNU tar natively rejects path traversal (`..` members)
- Import progress bar shows upload speed
- Add gzip to devenv packages
- 810 tests, 100% coverage

## Test plan
- [x] Backend unit tests pass (100% coverage)
- [x] CLI E2E export/import round-trip passes
- [ ] CI passes