### PR TITLE
Security hardening for workspaces.py

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -23,6 +23,7 @@
   };
 
   packages = with pkgs; [
+    bash # explicit bash for shell scripts (CI /bin/sh may be dash)
     docker-client
     flutter
     coreutils # GNU du (macOS BSD du lacks -b)

--- a/src/backend/e2e-tests/test_cli_e2e.py
+++ b/src/backend/e2e-tests/test_cli_e2e.py
@@ -762,6 +762,96 @@ class TestLogout:
         assert "not_logged_in" in result.stdout
 
 
+class TestExportSymlinks:
+    @pytest.fixture(autouse=True)
+    def _login(self, cli_config):
+        """Ensure logged in for this test class."""
+        _run(
+            [
+                "klangk",
+                "login",
+                "test@example.com",
+                "--server",
+                cli_config["server_url"],
+                "--password-file",
+                "-",
+            ],
+            input="testpass\n",
+            env=cli_config["env"],
+        )
+
+    def _get_home_dir(self, server, cli_config):
+        """Get the host-side home directory for a workspace.
+
+        Finds the workspace home dir by scanning the data directory
+        for workspace ID subdirectories.
+        """
+        from pathlib import Path
+
+        import httpx
+
+        resp = httpx.post(
+            f"{server['url']}/auth/login",
+            json={"email": "test@example.com", "password": "testpass"},
+        )
+        token = resp.json()["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
+
+        resp = httpx.get(f"{server['url']}/workspaces", headers=headers)
+        ws = [w for w in resp.json() if w["name"] == "e2e-symlink"][0]
+        ws_id = ws["id"]
+
+        # Find the user directory — it's the only subdirectory of workspaces/
+        ws_root = Path(server["data_dir"]) / "workspaces"
+        user_dirs = [d for d in ws_root.iterdir() if d.is_dir()]
+        assert len(user_dirs) == 1
+        return user_dirs[0] / "home" / ws_id
+
+    def test_export_keeps_internal_strips_external_symlinks(
+        self, server, cli_config, tmp_path
+    ):
+        """Internal symlinks are kept, external symlinks are stripped."""
+        env = cli_config["env"]
+
+        result = _run(["klangk", "create", "e2e-symlink"], env=env)
+        assert result.returncode == 0
+
+        try:
+            # Place files and symlinks directly on the host filesystem
+            # (the workspace home dir is what gets archived by export).
+            home_dir = self._get_home_dir(server, cli_config)
+            home_dir.mkdir(parents=True, exist_ok=True)
+
+            (home_dir / "real.txt").write_text("real content")
+            # Internal: relative symlink to a file within home (kept)
+            (home_dir / "good_link").symlink_to("real.txt")
+            # External: absolute symlink to /etc/hostname (stripped)
+            (home_dir / "bad_link").symlink_to("/etc/hostname")
+
+            archive = tmp_path / "symlink-test.tar.gz"
+            result = _run(
+                ["klangk", "export", "e2e-symlink", "-o", str(archive)],
+                env=env,
+                timeout=60,
+            )
+            assert result.returncode == 0, result.stderr or result.stdout
+
+            import tarfile
+
+            with tarfile.open(archive, "r:gz") as tar:
+                names = tar.getnames()
+                # Internal symlink preserved
+                assert any("real.txt" in n for n in names)
+                assert any("good_link" in n for n in names)
+                good = [m for m in tar.getmembers() if "good_link" in m.name]
+                assert len(good) == 1
+                assert good[0].issym()
+                # External symlink stripped
+                assert not any("bad_link" in n for n in names)
+        finally:
+            _run(["klangk", "rm", "e2e-symlink"], env=env)
+
+
 class TestExportImport:
     @pytest.fixture(autouse=True)
     def _login(self, cli_config):

--- a/src/backend/klangk_backend/workspaces.py
+++ b/src/backend/klangk_backend/workspaces.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+import re
 import shutil
 import tempfile
 from pathlib import Path
@@ -17,6 +18,43 @@ _data_dir = Path(
 )
 WORKSPACES_ROOT = _data_dir / "workspaces"
 
+# Characters allowed in sanitized filenames (alphanumeric, dash,
+# underscore, dot, @).  Everything else is replaced with underscore.
+_SAFE_FILENAME_RE = re.compile(r"[^a-zA-Z0-9._@-]")
+
+
+def _sanitize_filename(name: str) -> str:
+    """Replace unsafe characters in a filename component."""
+    return _SAFE_FILENAME_RE.sub("_", name)
+
+
+def _safe_path(*segments: str) -> Path:
+    """Build a path under WORKSPACES_ROOT, raising ValueError on traversal."""
+    path = WORKSPACES_ROOT.joinpath(*segments)
+    if not path.resolve().is_relative_to(WORKSPACES_ROOT.resolve()):
+        raise ValueError(f"Path traversal blocked: {'/'.join(segments)}")
+    return path
+
+
+def _rmtree(path: Path | str, label: str = "") -> None:
+    """Remove a directory tree, logging individual errors."""
+
+    def _on_error(fn, fpath, exc):
+        logger.warning(
+            "rmtree %s: %s(%s) failed: %s",
+            label or path,
+            fn.__name__,
+            fpath,
+            exc,
+        )
+
+    shutil.rmtree(path, onexc=_on_error)
+
+
+async def _async_rmtree(path: Path | str, label: str = "") -> None:
+    """Remove a directory tree in a thread, logging errors."""
+    await asyncio.to_thread(_rmtree, path, label)
+
 
 def workspace_metadata(ws: dict) -> dict:
     """Extract export metadata from a workspace dict."""
@@ -30,14 +68,60 @@ def workspace_metadata(ws: dict) -> dict:
     }
 
 
+async def _find_external_symlinks(home_dir: Path) -> list[str]:
+    """Use find to list symlinks under home_dir that point outside it.
+
+    Returns relative paths (from home_dir's parent) suitable for
+    tar --exclude arguments.
+    """
+    home_resolved = home_dir.resolve()
+    # find -type l prints all symlinks; we filter in the shell using
+    # realpath to check whether each target is under home_dir.
+    # This avoids a Python walk over potentially huge directory trees.
+    script = (
+        f'find "{home_dir}" -type l -print0 | '
+        f'while IFS= read -r -d "" link; do '
+        f'target=$(realpath "$link" 2>/dev/null || echo "///broken"); '
+        f'case "$target" in "{home_resolved}/"*) ;; *) '
+        f'echo "$link" ;; esac; done'
+    )
+    proc = await asyncio.create_subprocess_shell(
+        script,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=30)
+    if not stdout.strip():
+        return []
+    # Convert absolute paths to relative (from home_dir's parent)
+    parent = home_dir.parent
+    result = []
+    for line in stdout.decode("utf-8", errors="replace").strip().split("\n"):
+        try:
+            result.append(str(Path(line).relative_to(parent)))
+        except ValueError:
+            pass
+    return result
+
+
 async def build_workspace_archive(
     metadata: dict, home_dir: Path, archive_path: Path
 ) -> bool:
     """Build a .tar.gz archive in the export/import format.
 
     The archive contains workspace.json (metadata) and home/ (the home
-    directory tree).  Returns True on success, False on failure.
+    directory tree).  Symlinks pointing outside home_dir are excluded.
+    Both home_dir and archive_path must resolve under WORKSPACES_ROOT.
+    Returns True on success, False on failure.
     """
+    # Validate that paths stay within the data directory.
+    for label, p in [("home_dir", home_dir), ("archive_path", archive_path)]:
+        if p.exists() or p.parent.exists():
+            resolved = (p if p.exists() else p.parent).resolve()
+            if not resolved.is_relative_to(WORKSPACES_ROOT.resolve()):
+                logger.error("Path validation failed for %s: %s", label, p)
+                return False
+
     tmpdir = tempfile.mkdtemp()
     try:
         meta_file = Path(tmpdir) / "workspace.json"
@@ -51,11 +135,18 @@ async def build_workspace_archive(
             tmpdir,
             "workspace.json",
         ]
+
         if home_dir.exists():
+            # Exclude symlinks that point outside the home directory.
+            bad_links = await _find_external_symlinks(home_dir)
+            for link in bad_links:
+                tar_args.extend(["--exclude", link])
+
             ws_dir_name = home_dir.name
+            escaped = re.escape(ws_dir_name)
             tar_args.extend(
                 [
-                    f"--transform=s/^{ws_dir_name}/home/",
+                    f"--transform=s/^{escaped}/home/",
                     "-C",
                     str(home_dir.parent),
                     ws_dir_name,
@@ -81,7 +172,7 @@ async def build_workspace_archive(
         logger.error("Failed to build archive %s: %s", archive_path.name, e)
         return False
     finally:
-        await asyncio.to_thread(shutil.rmtree, tmpdir, True)
+        await _async_rmtree(tmpdir, "build_workspace_archive tmpdir")
 
 
 async def archive_user_data(user_id: str, email: str) -> list[Path]:
@@ -99,11 +190,11 @@ async def archive_user_data(user_id: str, email: str) -> list[Path]:
     if not user_dir.exists():
         return []
 
-    safe_email = email.replace("/", "_").replace("\\", "_").replace("..", "_")
+    safe_email = _sanitize_filename(email)
     archives: list[Path] = []
 
     for ws in user_workspaces:
-        ws_name = ws["name"].replace("/", "_").replace("\\", "_")
+        ws_name = _sanitize_filename(ws["name"])
         archive_name = f"{user_id}-{safe_email}-{ws_name}.tar.gz"
         archive_path = WORKSPACES_ROOT / archive_name
         if not archive_path.resolve().is_relative_to(
@@ -125,7 +216,7 @@ async def archive_user_data(user_id: str, email: str) -> list[Path]:
 
     # Remove the user's data directory after all archives are created.
     if archives:
-        await asyncio.to_thread(shutil.rmtree, user_dir, True)
+        await _async_rmtree(user_dir, f"user data {user_id}")
     return archives
 
 
@@ -134,11 +225,11 @@ def workspace_path(user_id: str, workspace_id: str) -> Path:
 
 
 def home_path(user_id: str, workspace_id: str) -> Path:
-    return WORKSPACES_ROOT / user_id / "home" / workspace_id
+    return _safe_path(user_id, "home", workspace_id)
 
 
 def config_path(user_id: str, workspace_id: str) -> Path:
-    return WORKSPACES_ROOT / user_id / "config" / workspace_id
+    return _safe_path(user_id, "config", workspace_id)
 
 
 def get_config_host_path(user_id: str, workspace_id: str) -> Path:
@@ -190,7 +281,7 @@ async def create_workspace(
     except Exception:
         # Clean up the DB record and directories on port allocation failure
         await model.delete_workspace(workspace["id"], user_id)
-        await asyncio.to_thread(shutil.rmtree, home, True)
+        await _async_rmtree(home, f"workspace {workspace['id']} rollback")
         raise
     return workspace
 
@@ -211,7 +302,7 @@ async def delete_workspace(workspace_id: str, user_id: str) -> bool:
     deleted = await model.delete_workspace(workspace_id, user_id)
     if deleted:
         p = home_path(user_id, workspace_id)
-        await asyncio.to_thread(shutil.rmtree, p, True)
+        await _async_rmtree(p, f"workspace {workspace_id}")
     return deleted
 
 

--- a/src/backend/klangk_backend/workspaces.py
+++ b/src/backend/klangk_backend/workspaces.py
@@ -85,7 +85,9 @@ async def _find_external_symlinks(home_dir: Path) -> list[str]:
         f'case "$target" in "{home_resolved}/"*) ;; *) '
         f'echo "$link" ;; esac; done'
     )
-    proc = await asyncio.create_subprocess_shell(
+    proc = await asyncio.create_subprocess_exec(
+        "bash",
+        "-c",
         script,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -2073,7 +2073,7 @@ class TestFindExternalSymlinks:
         )
         mock_proc.returncode = 0
 
-        with patch("asyncio.create_subprocess_shell", return_value=mock_proc):
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
             result = await ws_mod._find_external_symlinks(home_dir)
         assert result == []
 

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -2,6 +2,7 @@
 
 import io
 import os
+import shutil
 import tempfile
 import zipfile
 
@@ -2007,18 +2008,90 @@ class TestAdminEndpoints:
         assert resp.status_code == 404
 
 
+class TestSafePath:
+    def test_valid_path(self, temp_data_dir):
+        path = ws_mod._safe_path("user1", "home", "ws1")
+        assert path == ws_mod.WORKSPACES_ROOT / "user1" / "home" / "ws1"
+
+    def test_traversal_raises(self, temp_data_dir):
+        with pytest.raises(ValueError, match="Path traversal blocked"):
+            ws_mod._safe_path("..", "..", "etc", "passwd")
+
+
+class TestSanitizeFilename:
+    def test_safe_characters_preserved(self):
+        assert ws_mod._sanitize_filename("hello-world_v2.tar.gz") == (
+            "hello-world_v2.tar.gz"
+        )
+
+    def test_unsafe_characters_replaced(self):
+        assert ws_mod._sanitize_filename("a/b\\c..d\x00e") == "a_b_c..d_e"
+
+    def test_email_sanitized(self):
+        assert ws_mod._sanitize_filename("user@example.com") == (
+            "user@example.com"
+        )
+
+
+class TestRmtree:
+    def test_removes_directory(self, temp_data_dir):
+        d = temp_data_dir / "workspaces" / "toremove"
+        d.mkdir(parents=True)
+        (d / "file.txt").write_text("data")
+        ws_mod._rmtree(d, "test")
+        assert not d.exists()
+
+    def test_logs_errors(self, temp_data_dir, caplog):
+        """Logs warnings on individual file removal failures."""
+        d = temp_data_dir / "workspaces" / "failremove"
+        d.mkdir(parents=True)
+
+        def bad_rmtree(path, onexc=None):
+            onexc(os.unlink, str(d / "bad"), PermissionError("denied"))
+
+        with patch.object(shutil, "rmtree", bad_rmtree):
+            import logging
+
+            with caplog.at_level(logging.WARNING):
+                ws_mod._rmtree(d, "test-label")
+        assert "denied" in caplog.text
+        assert "test-label" in caplog.text
+
+
+class TestFindExternalSymlinks:
+    async def test_ignores_unrelated_paths_in_output(self, temp_data_dir):
+        """Paths that can't be made relative to home_dir's parent are skipped."""
+        ws_root = ws_mod.WORKSPACES_ROOT
+        ws_root.mkdir(parents=True, exist_ok=True)
+        home_dir = ws_root / "user1" / "home" / "ws1"
+        home_dir.mkdir(parents=True)
+
+        mock_proc = AsyncMock()
+        # Return a path that isn't under home_dir's parent
+        mock_proc.communicate = AsyncMock(
+            return_value=(b"/completely/unrelated/path\n", b"")
+        )
+        mock_proc.returncode = 0
+
+        with patch("asyncio.create_subprocess_shell", return_value=mock_proc):
+            result = await ws_mod._find_external_symlinks(home_dir)
+        assert result == []
+
+
 class TestBuildWorkspaceArchive:
     async def test_builds_importable_archive(self, temp_data_dir):
         """Archive contains workspace.json and home/ directory."""
         import json
         import subprocess
 
-        home_dir = temp_data_dir / "home" / "ws1"
+        ws_root = ws_mod.WORKSPACES_ROOT
+        ws_root.mkdir(parents=True, exist_ok=True)
+        home_dir = ws_root / "user1" / "home" / "ws1"
         home_dir.mkdir(parents=True)
         (home_dir / "hello.txt").write_text("test content")
 
         metadata = {"name": "myws", "image": None, "num_ports": 5}
-        archive_path = temp_data_dir / "test.tar.gz"
+        archive_path = ws_root / "test.tar.gz"
 
         result = await ws_mod.build_workspace_archive(
             metadata, home_dir, archive_path
@@ -2047,9 +2120,11 @@ class TestBuildWorkspaceArchive:
 
     async def test_builds_archive_without_home(self, temp_data_dir):
         """Archive works when home directory doesn't exist."""
-        home_dir = temp_data_dir / "nonexistent"
+        ws_root = ws_mod.WORKSPACES_ROOT
+        ws_root.mkdir(parents=True, exist_ok=True)
+        home_dir = ws_root / "nonexistent"
         metadata = {"name": "empty"}
-        archive_path = temp_data_dir / "empty.tar.gz"
+        archive_path = ws_root / "empty.tar.gz"
 
         result = await ws_mod.build_workspace_archive(
             metadata, home_dir, archive_path
@@ -2057,12 +2132,44 @@ class TestBuildWorkspaceArchive:
         assert result is True
         assert archive_path.exists()
 
+    async def test_excludes_external_symlinks(self, temp_data_dir):
+        """Symlinks pointing outside home_dir are excluded."""
+        import subprocess
+
+        ws_root = ws_mod.WORKSPACES_ROOT
+        ws_root.mkdir(parents=True, exist_ok=True)
+        home_dir = ws_root / "user1" / "home" / "ws1"
+        home_dir.mkdir(parents=True)
+        (home_dir / "good.txt").write_text("keep")
+        (home_dir / "bad_link").symlink_to("/etc/passwd")
+        (home_dir / "good_link").symlink_to("good.txt")
+
+        metadata = {"name": "test"}
+        archive_path = ws_root / "symtest.tar.gz"
+
+        result = await ws_mod.build_workspace_archive(
+            metadata, home_dir, archive_path
+        )
+        assert result is True
+
+        listing = subprocess.run(
+            ["tar", "tzf", str(archive_path)],
+            capture_output=True,
+            text=True,
+        )
+        members = listing.stdout.strip().split("\n")
+        assert any("good.txt" in m for m in members)
+        assert not any("bad_link" in m for m in members)
+        assert any("good_link" in m for m in members)
+
     async def test_tar_failure_returns_false(self, temp_data_dir):
         """Returns False when tar exits non-zero."""
-        home_dir = temp_data_dir / "home"
+        ws_root = ws_mod.WORKSPACES_ROOT
+        ws_root.mkdir(parents=True, exist_ok=True)
+        home_dir = ws_root / "home"
         home_dir.mkdir()
         metadata = {"name": "fail"}
-        archive_path = temp_data_dir / "fail.tar.gz"
+        archive_path = ws_root / "fail.tar.gz"
 
         mock_proc = AsyncMock()
         mock_proc.communicate = AsyncMock(return_value=(b"", b"tar: error"))
@@ -2076,9 +2183,11 @@ class TestBuildWorkspaceArchive:
 
     async def test_oserror_returns_false(self, temp_data_dir):
         """Returns False when tar cannot be started."""
-        home_dir = temp_data_dir / "home"
+        ws_root = ws_mod.WORKSPACES_ROOT
+        ws_root.mkdir(parents=True, exist_ok=True)
+        home_dir = ws_root / "home"
         metadata = {"name": "fail"}
-        archive_path = temp_data_dir / "fail.tar.gz"
+        archive_path = ws_root / "fail.tar.gz"
 
         with patch(
             "asyncio.create_subprocess_exec", side_effect=OSError("no tar")
@@ -2086,6 +2195,18 @@ class TestBuildWorkspaceArchive:
             result = await ws_mod.build_workspace_archive(
                 metadata, home_dir, archive_path
             )
+        assert result is False
+
+    async def test_path_outside_workspaces_root_rejected(self, temp_data_dir):
+        """Returns False if paths are outside WORKSPACES_ROOT."""
+        home_dir = temp_data_dir / "outside"
+        home_dir.mkdir(parents=True)
+        metadata = {"name": "bad"}
+        archive_path = temp_data_dir / "bad.tar.gz"
+
+        result = await ws_mod.build_workspace_archive(
+            metadata, home_dir, archive_path
+        )
         assert result is False
 
 
@@ -2208,7 +2329,9 @@ class TestArchiveUserData:
         assert archive.resolve().is_relative_to(
             ws_mod.WORKSPACES_ROOT.resolve()
         )
-        assert ".." not in archive.name
+        # Slashes are replaced with underscores
+        assert "/" not in archive.name
+        assert "\\" not in archive.name
 
     async def test_archive_path_traversal_blocked(self, user, workspace):
         """Skips workspace if archive path would escape WORKSPACES_ROOT."""

--- a/src/backend/tests/test_terminal.py
+++ b/src/backend/tests/test_terminal.py
@@ -572,7 +572,16 @@ class TestIsAlive:
 
         first_msg = MagicMock()
         first_msg.data = b"prompt"
-        stream.read_out = AsyncMock(side_effect=[first_msg, slow_read()])
+        call_count = 0
+
+        async def _read_side_effect():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return first_msg
+            return await slow_read()
+
+        stream.read_out = _read_side_effect
         exec_obj = _mock_exec(stream)
         container = _mock_container(exec_obj)
         docker = _mock_docker(container)


### PR DESCRIPTION
## Summary
- Escape regex metacharacters in `--transform` sed expression (#63)
- Add `_safe_path()` to validate path helpers against traversal (#64)
- Filter external symlinks via `find`/`realpath` + tar `--exclude` (#65)
- Validate `home_dir`/`archive_path` in `build_workspace_archive` (#66)
- Use `_sanitize_filename()` allowlist for archive filenames (#67)
- Replace silent `shutil.rmtree` with `_rmtree` logging via `onexc` (#68)
- Fix unawaited coroutine warning in TestIsAlive (#71)
- Add bash to devenv.nix for portable shell scripts
- Add E2E test verifying internal symlinks kept, external stripped

Closes #63, #64, #65, #66, #67, #68, #71

## Test plan
- [x] 828 backend unit tests, 100% coverage
- [x] 32 CLI E2E tests passing (including new symlink export test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)