### PR TITLE
Fix flaky E2E container_ready timeout (#73)

### DIFF
--- a/src/frontend/e2e-tests/e2e/helpers.ts
+++ b/src/frontend/e2e-tests/e2e/helpers.ts
@@ -291,10 +291,16 @@ export async function openWorkspace(
   });
 
   await loginViaUI(page, email, TEST_PASSWORD);
-  // Use full URL (not just #fragment) so the page reloads and creates a new
-  // WebSocket — a hash-only change is handled internally by Flutter's router
-  // without opening a new WebSocket, so our listener would never fire.
-  await page.goto(`/#/workspace/${workspaceId}`);
+  // Navigate to the workspace URL and force a full page reload.
+  // A hash-only change from the workspaces list is handled by Flutter's
+  // router internally without opening a new WebSocket, so our listener
+  // would never fire.  Setting the hash then reloading ensures a fresh
+  // page load that creates a new WebSocket connection.
+  await page.evaluate((id) => {
+    window.location.hash = `/workspace/${id}`;
+  }, workspaceId);
+  await page.reload({ waitUntil: "load" });
+  await waitForFlutter(page);
   await containerPromise;
   await terminalPromise;
 }


### PR DESCRIPTION
## Summary
- Fix race condition in `openWorkspace` where `page.goto("/#/workspace/...")` was a hash-only navigation handled by Flutter's router without creating a new WebSocket
- The `page.on("websocket")` listener never fired, so `container_ready` was never detected, causing a 120s timeout
- Fix: set the hash via `page.evaluate`, then `page.reload()` to force a full page load that creates a new WebSocket connection
- Auth survives the reload because the JWT is stored in localStorage via SharedPreferences

Closes #73

## Test plan
- [x] All 37 chromium E2E tests pass locally
- [ ] CI should no longer flake on the shared workspace test

🤖 Generated with [Claude Code](https://claude.com/claude-code)