### PR TITLE
fix(tests): stop TestRunShell stdin tests hanging on serial runs

### DIFF
--- a/src/backend/tests/test_cli.py
+++ b/src/backend/tests/test_cli.py
@@ -668,11 +668,17 @@ class TestRunShell:
                 pass
 
         fake_buf = BytesIO(b"")
-        fake_buf.fileno = lambda: 0
+        fake_buf.fileno = lambda: 99
         fake_stdout = CaptureWriter()
-        with patch(
-            "klangk_backend.cli.client.select.select",
-            return_value=([0], [], []),
+        # Patch os.read alongside select so stdin_loop sees EOF and exits
+        # instead of blocking on the real stdin fd (which hangs serial runs
+        # where stdin is an interactive tty).
+        with (
+            patch(
+                "klangk_backend.cli.client.select.select",
+                return_value=([99], [], []),
+            ),
+            patch("klangk_backend.cli.client.os.read", return_value=b""),
         ):
             task = asyncio.create_task(
                 _run_shell(ws, 80, 24, stdin=fake_buf, stdout=fake_stdout)

--- a/src/backend/tests/test_cli_integration.py
+++ b/src/backend/tests/test_cli_integration.py
@@ -237,11 +237,19 @@ class TestRunShell:
         )
 
         fake_stdin = MagicMock()
-        fake_stdin.fileno = MagicMock(return_value=0)
-        fake_stdin.read = MagicMock(side_effect=BrokenPipeError)
-        with patch(
-            "klangk_backend.cli.client.select.select",
-            return_value=([0], [], []),
+        fake_stdin.fileno = MagicMock(return_value=99)
+        # stdin_loop reads via os.read(fd, ...), not stdin.read(); patch it
+        # to raise BrokenPipeError so the OSError handler runs instead of
+        # blocking on the real stdin fd.
+        with (
+            patch(
+                "klangk_backend.cli.client.select.select",
+                return_value=([99], [], []),
+            ),
+            patch(
+                "klangk_backend.cli.client.os.read",
+                side_effect=BrokenPipeError,
+            ),
         ):
             task = asyncio.create_task(
                 _run_shell(ws, 80, 24, stdin=fake_stdin)


### PR DESCRIPTION
test_cli.py::TestRunShell::test_stdout_loop_writes_data and test_cli_integration.py::TestRunShell::test_stdin_loop_broken_pipe patched select.select to report stdin "ready" but let _run_shell call a blocking os.read(0, 1) on the real stdin fd. With an interactive tty attached (serial pytest), that blocks the event loop and even task.cancel() cannot interrupt the syscall, hanging the suite. Running `pytest -n auto` masks it because xdist detaches worker stdin.

Patch klangk_backend.cli.client.os.read alongside select.select so stdin_loop sees EOF / BrokenPipeError and exits cleanly. Pre-existing issue, independent of other work.