### PR TITLE
Container support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Temp
 tmp/
+.env
 
 # devenv
 .devenv/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Temp
 tmp/
 .env
+data
 
 # devenv
 .devenv/

--- a/HACKING.md
+++ b/HACKING.md
@@ -49,6 +49,94 @@ devenv processes up --no-tui
 
 This builds the Docker image and Flutter web app on first run (via `execIfModified`), starts nginx, the FastAPI backend, and watches for file changes. Open http://localhost:8995.
 
+## Running with Docker Compose (without Nix)
+
+As an alternative to the devenv flow, the daemon (nginx + backend) ships as a
+self-contained Docker Compose stack with **no dependency on Nix**. This is the
+path for deploying/shipping. devenv stays the source of truth for local dev —
+this adds a run mode, it doesn't replace one.
+
+The stack is two services on two networks (only nginx is published):
+
+- **nginx** (`nginx:alpine`) — the only host-published service (`:8995`);
+  reverse proxy + LLM-key-injecting proxy + hosted-app proxy.
+- **backend** — uvicorn **plus rootless Podman**, which launches the per-user
+  workspace containers _inside_ the backend container (podman-in-docker).
+
+Files: [docker-compose.yml](docker-compose.yml) (repo root) and
+[src/daemon/](src/daemon/) (the daemon `Dockerfile`, `nginx.conf.template`, and
+the rootless podman config — `storage.conf`, `containers.conf`,
+`registries.conf`).
+
+### Host prerequisites (for the rootless podman-in-docker backend)
+
+```bash
+sudo modprobe tun          # pasta/slirp4netns need /dev/net/tun
+```
+
+The backend also needs unprivileged user namespaces. Modern Debian/Ubuntu
+harden these off; the compose file grabs `cap_add: SYS_ADMIN` by default to
+cover that with no host changes. To drop that capability instead, relax the
+host and persist via `/etc/sysctl.d/`:
+
+```bash
+# Ubuntu 24.04+
+sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+# Debian / older
+sudo sysctl -w kernel.unprivileged_userns_clone=1
+# Always
+sudo sysctl -w user.max_user_namespaces=15000
+```
+
+### Bring up the stack
+
+```bash
+cp -n .env.example .env          # same .env as the devenv flow; edit creds
+$EDITOR .env                     # KLANGK_LLM_API_KEY, KLANGK_JWT_SECRET, ...
+
+docker compose up --build        # first build is heavy (Flutter web + podman runtime)
+```
+
+Then log in at http://localhost:8995 (same default-user behavior as devenv).
+`KLANGK_LLM_API_KEY` is passed **only** to nginx — the LLM-proxy injects it so
+workspace containers never see the key.
+
+State persists in two named volumes across `docker compose down`/`up`:
+`klangk-data` (SQLite DB + workspace homes) and `klangk-podman-storage` (the
+rootless podman image/container layers).
+
+### Provide the workspace image
+
+The daemon spawns workspace containers from the **`klangk`** image, which is
+distinct from the daemon image. The backend's podman runs with `--pull=never`
+by default (airgap-friendly), so the image must be present in its store first.
+It is built locally — nothing is pushed to any registry (building only *pulls*
+the public `klangk-base`, which needs no credentials):
+
+```bash
+scripts/dockerbuild.sh             # build the klangk image locally with docker
+docker compose up -d               # stack must be running
+scripts/seed-workspace-image.sh    # docker save | podman load into the backend store
+```
+
+`seed-workspace-image.sh` loads the image into the running backend's rootless
+store, where it persists in `klangk-podman-storage`. Alternatively, on a
+network-connected host, set `KLANGK_IMAGE_PULL_POLICY=missing` to have the
+backend pull the image from a registry when it's absent locally (see the
+env-var table). For an immutable / refresh-by-volume-swap deployment, ship a
+read-only additional image store instead (hooks are stubbed in
+`src/daemon/storage.conf` + `docker-compose.yml`).
+
+### Compose vs. devenv differences
+
+- **Engine is Podman, not Docker.** The backend drives rootless Podman via the
+  CLI (`KLANGK_PODMAN_BIN`, default `podman`); set it to `docker` to run against
+  a Docker host instead.
+- **`KLANGK_HOST_GATEWAY`** controls how a workspace container reaches the nginx
+  front. It defaults to `host.containers.internal` in the daemon image (vs.
+  `host.docker.internal` in the host-process/devenv flow).
+- Workspace containers no longer get a `/var/run/docker.sock` bind.
+
 ## Running Tests
 
 ```bash
@@ -85,6 +173,9 @@ All settings can be overridden in `.env`. Defaults (where appropriate) are provi
 | `KLANGK_DATA_DIR`               | `$DEVENV_STATE/klangk/data`          | Database, workspaces, Pi sessions                                                                                                                           |
 | `KLANGK_PLUGINS_DIR`            | `$DEVENV_STATE/klangk/plugins`       | Fetched plugins (outside repo for `execIfModified`)                                                                                                         |
 | `KLANGK_IMAGE_NAME`             | `klangk`                             | Docker image name for workspace containers                                                                                                                  |
+| `KLANGK_IMAGE_PULL_POLICY`      | `never`                              | Workspace-image pull policy (podman `--pull`): `never` (offline; local + additional store only), `missing` (pull if absent), `always`/`newer`. Invalid → `never` |
+| `KLANGK_PODMAN_BIN`             | `podman`                             | Container engine binary the backend shells out to (set to `docker` to run against a Docker host)                                                            |
+| `KLANGK_HOST_GATEWAY`           | `host.docker.internal`               | Hostname a workspace container uses to reach the nginx front (LLM-proxy + bridge); also registered via `--add-host`. The Compose daemon image defaults it to `host.containers.internal` |
 | `KLANGK_INSTANCE_ID`            | `default`                            | Instance identifier for multi-instance deployments on the same host — isolates containers, names, and cleanup                                               |
 | `KLANGK_DNS_SERVERS`            |                                      | Comma-separated DNS server IPs for containers (e.g., `100.100.100.100,8.8.8.8` for Tailscale MagicDNS). If unset, containers use Docker's default DNS.      |
 | `KLANGK_HOSTING_HOSTNAME`       | (auto-derived)                       | Hostname for hosted app URLs. Behind a reverse proxy: uses `X-Forwarded-Host` as-is. Direct access: uses `Host` header with `KLANGK_NGINX_PORT` substituted |
@@ -143,10 +234,12 @@ src/
   frontend/            # Flutter web app
     test/              # Frontend unit tests
     e2e-tests/         # Playwright E2E tests
-  docker/              # Dockerfile, entrypoint, system prompt
+  docker/              # workspace image (Dockerfile, entrypoint, system prompt)
+  daemon/              # daemon image + Compose stack (Dockerfile, nginx + podman config)
   bridge/              # @klangk/bridge npm package
 plugins/               # Built-in plugins (celebrate, beep, etc.)
 scripts/               # Build and utility scripts
+docker-compose.yml     # no-Nix deployment stack (nginx + backend)
 devenv.nix             # devenv configuration
 ```
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@ devenv processes up --no-tui
 
 Open [http://localhost:8995](http://localhost:8995) and log in with `admin@example.com` (or whatever you set `KLANGK_DEFAULT_USER` to). If you set `KLANGK_DEFAULT_PASSWORD` in `.env`, use that password. Otherwise, check the server log output for the generated password. The default user has the admin role and can manage other users at `/admin/users`.
 
+### Alternative: Docker Compose (no Nix)
+
+If you'd rather not install Nix, the daemon ships as a self-contained Docker
+Compose stack (nginx + a backend that runs rootless Podman):
+
+```bash
+cp -n .env.example .env && $EDITOR .env   # set KLANGK_LLM_API_KEY, KLANGK_JWT_SECRET, ...
+docker compose up --build                 # log in at http://localhost:8995
+```
+
+Workspaces need the `klangk` image seeded into the stack first
+(`scripts/dockerbuild.sh` then `scripts/seed-workspace-image.sh`). See the
+[Docker Compose section in HACKING.md](HACKING.md#running-with-docker-compose-without-nix)
+for host prerequisites and details.
+
 ### What You Can Do
 
 1. **Create a workspace** — each workspace is an isolated coding environment

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,10 +75,10 @@ services:
 
     volumes:
       # App state: SQLite DB + workspace homes (§4).
-      - klangk-data:/var/lib/klangk/data
+      - ./data/klangk-data:/var/lib/klangk/data
       # Rootless podman's image/container layers — persisted so they aren't
       # re-fused every restart.
-      - klangk-podman-storage:/home/klangk/.local/share/containers
+      - ./data/klangk-podman-storage:/home/klangk/.local/share/containers
       # §9/B — prebuilt workspace-image store, read-only.  Uncomment together
       # with `additionalimagestores` in src/daemon/storage.conf once the store
       # volume is seeded offline.
@@ -101,8 +101,10 @@ services:
       KLANGK_PORT: "${KLANGK_PORT:-8997}"
       KLANGK_NGINX_PORT: "${KLANGK_NGINX_PORT:-8995}"
       KLANGK_DATA_DIR: /var/lib/klangk/data
-      # §8 knob: how a pi container reaches the nginx front. Confirm at smoke test.
-      KLANGK_HOST_GATEWAY: "${KLANGK_HOST_GATEWAY:-host.containers.internal}"
+      # §8 knob: how a pi container reaches the nginx front. The backend
+      # resolves this name to an IP and passes it via --add-host so passt
+      # can route workspace traffic through the backend's network namespace.
+      KLANGK_HOST_GATEWAY: "${KLANGK_HOST_GATEWAY:-nginx}"
       KLANGK_INSTANCE_ID: "${KLANGK_INSTANCE_ID:-default}"
       KLANGK_IMAGE_NAME: "${KLANGK_IMAGE_NAME:-klangk}"
       # Where workspace images come from: `never` (default) = offline only
@@ -129,8 +131,3 @@ networks:
     # nginx <-> backend only; not reachable from the host.
     internal: true
 
-volumes:
-  klangk-data:
-  klangk-podman-storage:
-  # §9/B — seed offline, then uncomment the mount above + storage.conf entry.
-  # klangk-images:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,136 @@
+# klangk daemon stack — DOCKER.md §7.
+#
+#   cp .env.example .env   # fill in KLANGK_LLM_*, KLANGK_JWT_SECRET, admin creds
+#   docker compose up --build
+#   # then log in at  http://localhost:${KLANGK_NGINX_PORT:-8995}
+#
+# Two services on two networks: only `nginx` is published to the host; the
+# `backend` (uvicorn + rootless Podman) is reachable only via the `internal`
+# network.  The backend runs rootless Podman-in-Docker — see src/daemon/* and
+# /home/bryan/src/podman_test for the recipe each flag comes from.
+#
+# HOST PREREQUISITES for the rootless-nesting backend (same as podman_test):
+#   - the tun module:  sudo modprobe tun
+#   - unprivileged user namespaces.  Modern Debian/Ubuntu harden these off; the
+#     backend grabs `cap_add: SYS_ADMIN` below to cover that without host edits.
+#     To drop that cap instead, relax the host and persist via sysctl.d:
+#       Ubuntu 24.04+:  sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+#       Debian/older:   sudo sysctl -w kernel.unprivileged_userns_clone=1
+#       Always:         sudo sysctl -w user.max_user_namespaces=15000
+
+services:
+  nginx:
+    image: nginx:alpine
+    restart: unless-stopped
+    depends_on:
+      - backend
+    networks:
+      - edge
+      - internal
+    # The only host-published port in the stack.
+    ports:
+      - "${KLANGK_NGINX_PORT:-8995}:${KLANGK_NGINX_PORT:-8995}"
+    volumes:
+      - ./src/daemon/nginx.conf.template:/etc/nginx/templates/nginx.conf.template:ro
+    # nginx is the ONLY place KLANGK_LLM_API_KEY / KLANGK_LLM_BASE_URL live —
+    # the llm-proxy injects the key so workspace containers never see it (§10).
+    # NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx renders the full nginx.conf template
+    # to /etc/nginx/nginx.conf (not conf.d/).
+    environment:
+      NGINX_ENVSUBST_OUTPUT_DIR: /etc/nginx
+      KLANGK_NGINX_PORT: "${KLANGK_NGINX_PORT:-8995}"
+      KLANGK_PORT: "${KLANGK_PORT:-8997}"
+      KLANGK_LLM_BASE_URL: "${KLANGK_LLM_BASE_URL}"
+      KLANGK_LLM_API_KEY: "${KLANGK_LLM_API_KEY}"
+
+  backend:
+    build:
+      context: .
+      dockerfile: src/daemon/Dockerfile
+    image: klangk-daemon
+    restart: unless-stopped
+    # NOT on `edge`: unreachable from the host, only nginx can reach it.
+    networks:
+      - internal
+
+    # --- rootless Podman-in-Docker profile (mirrors podman_test) ---
+    # Devices passed through explicitly (NOT --privileged):
+    devices:
+      - /dev/fuse        # fuse-overlayfs storage driver
+      - /dev/net/tun     # passt/slirp4netns container networking
+    # All far weaker than `privileged: true`:
+    security_opt:
+      - seccomp=unconfined
+      - apparmor=unconfined
+      - label=disable
+      # Clear Docker's read-only/masked /proc paths so the inner podman can set
+      # its default container sysctls (podman's unmask=ALL equivalent).  Lighter
+      # alternative: set `default_sysctls = []` in src/daemon/containers.conf and
+      # drop this line.
+      - systempaths=unconfined
+    # The one capability the rootless userns setup needs when the host kernel
+    # forbids unprivileged user namespaces (the dependable lever; see header).
+    cap_add:
+      - SYS_ADMIN
+
+    volumes:
+      # App state: SQLite DB + workspace homes (§4).
+      - klangk-data:/var/lib/klangk/data
+      # Rootless podman's image/container layers — persisted so they aren't
+      # re-fused every restart.
+      - klangk-podman-storage:/home/klangk/.local/share/containers
+      # §9/B — prebuilt workspace-image store, read-only.  Uncomment together
+      # with `additionalimagestores` in src/daemon/storage.conf once the store
+      # volume is seeded offline.
+      # - klangk-images:/var/lib/klangk-images:ro
+
+    # Healthcheck per §7: confirm the in-process engine initialises.
+    healthcheck:
+      test: ["CMD", "podman", "info"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+    # Backend env.  KLANGK_LLM_API_KEY / _BASE_URL are deliberately ABSENT —
+    # they belong to nginx only (§10; the backend never needs the key).  Values
+    # interpolate from the root `.env`.  Add any other KLANGK_* your deployment
+    # uses (KLANGK_DNS_SERVERS, KLANGK_ALLOWED_IMAGES, KLANGK_LOGIN_*,
+    # KLANGK_DISABLE_REGISTRATION, KLANGK_IMPORT_MAX_SIZE, ...).
+    environment:
+      KLANGK_PORT: "${KLANGK_PORT:-8997}"
+      KLANGK_NGINX_PORT: "${KLANGK_NGINX_PORT:-8995}"
+      KLANGK_DATA_DIR: /var/lib/klangk/data
+      # §8 knob: how a pi container reaches the nginx front. Confirm at smoke test.
+      KLANGK_HOST_GATEWAY: "${KLANGK_HOST_GATEWAY:-host.containers.internal}"
+      KLANGK_INSTANCE_ID: "${KLANGK_INSTANCE_ID:-default}"
+      KLANGK_IMAGE_NAME: "${KLANGK_IMAGE_NAME:-klangk}"
+      # Where workspace images come from: `never` (default) = offline only
+      # (local + the §9/B additional store); `missing` = pull from a registry
+      # if absent locally; also `always`/`newer`.
+      KLANGK_IMAGE_PULL_POLICY: "${KLANGK_IMAGE_PULL_POLICY:-never}"
+      KLANGK_LLM_MODEL: "${KLANGK_LLM_MODEL:-}"
+      KLANGK_JWT_SECRET: "${KLANGK_JWT_SECRET}"
+      KLANGK_DEFAULT_USER: "${KLANGK_DEFAULT_USER:-}"
+      KLANGK_DEFAULT_PASSWORD: "${KLANGK_DEFAULT_PASSWORD:-}"
+      KLANGK_IDLE_TIMEOUT_SECONDS: "${KLANGK_IDLE_TIMEOUT_SECONDS:-1800}"
+      # SMTP (optional — for email verification / password reset).
+      KLANGK_SMTP_HOST: "${KLANGK_SMTP_HOST:-}"
+      KLANGK_SMTP_PORT: "${KLANGK_SMTP_PORT:-}"
+      KLANGK_SMTP_USER: "${KLANGK_SMTP_USER:-}"
+      KLANGK_SMTP_PASSWORD: "${KLANGK_SMTP_PASSWORD:-}"
+      KLANGK_SMTP_FROM: "${KLANGK_SMTP_FROM:-}"
+      KLANGK_SMTP_USE_TLS: "${KLANGK_SMTP_USE_TLS:-}"
+
+networks:
+  edge:
+    # Host-facing; only nginx attaches here.
+  internal:
+    # nginx <-> backend only; not reachable from the host.
+    internal: true
+
+volumes:
+  klangk-data:
+  klangk-podman-storage:
+  # §9/B — seed offline, then uncomment the mount above + storage.conf entry.
+  # klangk-images:

--- a/scripts/dockerbuild.sh
+++ b/scripts/dockerbuild.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-cd "${DEVENV_ROOT:-$SCRIPT_DIR/..}"
+REPO_ROOT="${DEVENV_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+cd "$REPO_ROOT"
+
+KLANGK_PLUGINS_DIR="${KLANGK_PLUGINS_DIR:-$REPO_ROOT/.devenv/state/klangk/plugins}"
+KLANGK_IMAGE_NAME="${KLANGK_IMAGE_NAME:-klangk}"
+KLANGK_INSTANCE_ID="${KLANGK_INSTANCE_ID:-default}"
 
 # Auto-fetch plugins on first run
 if [ -f "$KLANGK_PLUGINS_DIR/plugins.yaml" ] && [ ! -f "$KLANGK_PLUGINS_DIR/plugins.lock" ]; then
@@ -9,7 +14,7 @@ if [ -f "$KLANGK_PLUGINS_DIR/plugins.yaml" ] && [ ! -f "$KLANGK_PLUGINS_DIR/plug
   python3 scripts/update_plugins.py
 fi
 
-# Stage plugin files outside the source tree
+# Stage plugin files outside the source tree (empty staging is fine — no plugins)
 STAGING="$KLANGK_PLUGINS_DIR/.docker"
 rm -rf "$STAGING"
 mkdir -p "$STAGING/extensions" "$STAGING/tools"

--- a/scripts/run-pi-container.sh
+++ b/scripts/run-pi-container.sh
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
-# This script simulates the Docker run command used by container_manager.py
+# This script simulates the podman run command used by container.py
 
 # Using defaults based on the code for demonstration; replace with real paths if needed.
 HOST_PATH="/tmp/klangk-work-test"
 HOME_PATH="/tmp/klangk-home-test"
 WORKSPACE_ID="test-workspace-123"
-IMAGE_NAME="klangk-pi:latest"
+IMAGE_NAME="klangk:latest"
 
 # Ensure bind mount directories exist
 mkdir -p "$HOST_PATH"
 mkdir -p "$HOME_PATH"
 
-docker run -it --rm \
+podman run -it --rm \
   --name "klangk-test-container" \
   --label "klangk.managed=true" \
   --label "klangk.instance=default" \
@@ -21,9 +21,9 @@ docker run -it --rm \
   --tmpfs /run:rw,noexec,nosuid,size=16m \
   --tmpfs /var/log:rw,noexec,nosuid,size=16m \
   --mount type=bind,source="$HOME_PATH",target=/home/klangk \
-  --add-host=host.docker.internal:host-gateway \
+  --add-host=host.containers.internal:host-gateway \
   -p 9000:8000 -p 9001:8001 -p 9002:8002 -p 9003:8003 -p 9004:8004 \
-  -e KLANGK_LLM_PROXY_URL=http://host.docker.internal:8995/llm-proxy \
+  -e KLANGK_LLM_PROXY_URL=http://host.containers.internal:8995/llm-proxy \
   -e KLANGK_LLM_MODEL=gemma4:31b \
   -e PI_SKIP_VERSION_CHECK=1 \
   -e KLANGK_PORT_MAPPINGS=8000:9000,8001:9001,8002:9002,8003:9003,8004:9004 \

--- a/scripts/seed-workspace-image.sh
+++ b/scripts/seed-workspace-image.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Seed the locally-built workspace image into the daemon stack's rootless
+# podman store (DOCKER.md §9). Fully local — NOTHING is pushed to any registry.
+#
+# The daemon's in-container podman runs with `--pull=never` by default, so the
+# `klangk` image must already be in its store. This transfers the image you
+# built with scripts/dockerbuild.sh into the running backend container's
+# rootless store, where it persists in the `klangk-podman-storage` volume.
+#
+# Prereqs:
+#   - the image is built locally:  scripts/dockerbuild.sh   (pulls public
+#     klangk-base; no credentials, no push)
+#   - the stack is running:        docker compose up -d
+#
+# Usage:
+#   scripts/seed-workspace-image.sh [IMAGE]      # IMAGE defaults to $KLANGK_IMAGE_NAME or "klangk"
+#
+# Env overrides:
+#   KLANGK_IMAGE_NAME   image tag to seed (default "klangk")
+#   COMPOSE_FILE        compose file (default docker-compose.yml at repo root)
+#   BACKEND_SERVICE     compose service name (default "backend")
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="${DEVENV_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+cd "$REPO_ROOT"
+
+IMAGE="${1:-${KLANGK_IMAGE_NAME:-klangk}}"
+BACKEND_SERVICE="${BACKEND_SERVICE:-backend}"
+TAG="$IMAGE:latest"
+TAR="/tmp/klangk-seed-$$.tar"
+REMOTE_TAR="/tmp/klangk-seed-$$.tar"
+
+cleanup() {
+  rm -f "$TAR" 2>/dev/null || true
+  docker compose exec -T --user root "$BACKEND_SERVICE" rm -f "$REMOTE_TAR" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# 1. The image must exist in the host docker engine (build it first).
+if ! docker image inspect "$TAG" >/dev/null 2>&1; then
+  echo "error: image '$TAG' not found in docker. Build it first:" >&2
+  echo "         scripts/dockerbuild.sh" >&2
+  exit 1
+fi
+
+# 2. The backend service must be running (we load into its live rootless store).
+if ! docker compose exec -T "$BACKEND_SERVICE" true >/dev/null 2>&1; then
+  echo "error: backend service '$BACKEND_SERVICE' is not running. Start it:" >&2
+  echo "         docker compose up -d" >&2
+  exit 1
+fi
+
+echo "==> Saving $TAG"
+docker save "$TAG" -o "$TAR"
+
+echo "==> Copying into the backend container"
+docker compose cp "$TAR" "$BACKEND_SERVICE:$REMOTE_TAR"
+# docker cp lands the file root-owned; the rootless user must be able to read it.
+docker compose exec -T --user root "$BACKEND_SERVICE" chmod 644 "$REMOTE_TAR"
+
+echo "==> Loading into the rootless podman store"
+docker compose exec -T "$BACKEND_SERVICE" podman load -i "$REMOTE_TAR"
+
+echo "==> Verifying 'podman create --pull=never $IMAGE' resolves"
+if docker compose exec -T "$BACKEND_SERVICE" podman image exists "$IMAGE"; then
+  echo "==> Done. '$IMAGE' is in the rootless store and persists in the"
+  echo "    klangk-podman-storage volume."
+else
+  echo "error: image not found in the store after load" >&2
+  exit 1
+fi

--- a/src/backend/DOCKER.md
+++ b/src/backend/DOCKER.md
@@ -1,0 +1,584 @@
+# Dockerizing the klangk daemon
+
+A plan to simplify klangk's build/run process and package the **klangk
+daemon** as a self-contained container stack, with no dependency on the
+local server except the LLM endpoint.
+
+## 0. Current status
+
+**Phase 1 — backend code migration (aiodocker → podman CLI): DONE and
+verified on Linux** (full unit suite `pytest -n auto`: 867 passed, statement
+coverage gate 100%, `ruff check`/`format --check` clean). The Linux run
+surfaced one residual gap — `ShellProcess.__init__` + `_make_shell_process()`
+were uncovered (the rest of the OS glue is `# pragma: no cover`); both are
+pure-Python and are now covered by `test_factory_returns_unstarted_shell`.
+
+**Phase 2 — §13.1 (env-parameterize pi→nginx addressing): DONE** (see §8 /
+§13 remaining-work list).
+
+**Phase 3 — §6 (daemon image + nginx) and §7 (compose + rootless profile):
+DONE; image builds and the backend + nested rootless podman are smoke-tested.
+Only the full two-service stack smoke test (§5) remains.** The rootless
+Podman-in-Docker recipe is lifted from the working example in
+`/home/bryan/src/podman_test`.
+
+New files under `src/daemon/`:
+- `Dockerfile` — multi-stage. `web`: Flutter `3.41.9` → prod `flutter build web
+  --wasm --release` (dev-only flags + source-map inlining dropped). `runtime`:
+  **`debian:trixie-slim`** (matches podman_test's podman 5.x/passt; its python3
+  is 3.13, what the tests already run on) + podman/crun/fuse-overlayfs/uidmap/
+  passt/slirp4netns/catatonit/git/rsync. Runs as a **non-root `klangk` user**
+  with subuid/subgid + the `chmod 4755 newuidmap/newgidmap` fix + `fuse.conf`.
+  Backend installed **editable** into a `uv` venv so main.py's
+  `frontend/build/web` lookup resolves; web assets copied there;
+  `catatonit`→`uvicorn`.
+- `nginx.conf.template` — production config from `scripts/nginx.sh`, upstreams
+  repointed `127.0.0.1`→`backend`; rendered by nginx:alpine envsubst (needs
+  `NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx`).
+- `containers.conf` / `storage.conf` / `registries.conf` — rootless
+  fuse-overlayfs (overlay mountopt), crun/cgroupfs/`events_logger=file`,
+  `netns=private`, `init_path=catatonit`; `storage.conf` has the §9/B
+  `additionalimagestores` hook (commented until the store volume is wired).
+
+New file at repo root:
+- `docker-compose.yml` — `nginx` (host-published, `edge`+`internal`) + `backend`
+  (`internal` only). Backend carries the rootless profile: `devices: /dev/fuse,
+  /dev/net/tun`; `security_opt: seccomp/apparmor/label=disable + systempaths=
+  unconfined`; `cap_add: SYS_ADMIN`; `podman info` healthcheck. Volumes:
+  `klangk-data` (app DB + homes) and `klangk-podman-storage` (engine layers —
+  a *second* volume beyond §4's single one, since engine storage is separate
+  plumbing), plus a commented RO `klangk-images` for §9/B. **`KLANGK_LLM_API_KEY`
+  /`_BASE_URL` go to nginx only** (§10); the backend gets an explicit
+  `environment:` allow-list (no full `env_file`) so the key never enters its
+  container env — the backend only ever uses the key's *name* to strip it from
+  workspace shells.
+
+Verified: **full `docker build` succeeds** (Flutter wasm compile + plugin stub +
+git `klangk-plugin-api` all resolve; image `klangk-daemon`, 696 MB, podman
+5.4.2). **Backend boot smoke-tested**: the container serves HTTP 200 on `/`
+(Flutter app) and `/docs`, creates the admin user, and `main.py`'s editable
+install resolves the web assets at `/app/src/frontend/build/web`. **Rootless
+Podman-in-Docker validated** with the compose security profile (`/dev/fuse`,
+`/dev/net/tun`, `systempaths=unconfined`, `cap_add: SYS_ADMIN`): `podman info`
+reports `overlay`/fuse-overlayfs + `rootless=true`, and a nested
+`podman run --rm alpine` pulled and executed successfully.
+**§5 stack smoke test — front HALF DONE.** `docker compose up` brings up both
+services healthy; through nginx on `:8995`: the Flutter SPA (`GET /` → 200),
+`/docs` → 200, the auth round-trip (`POST /auth/login` → 200 + JWT, then
+`GET /workspaces` with the token → 200), and **volume persistence** (after
+`docker compose down` + `up`, the admin user is not recreated and re-login
+succeeds — the DB survived in `klangk-data`). The backend `podman info`
+healthcheck passes.
+
+Two nginx-template bugs were found + fixed during this run:
+- removed `daemon off;` (the official nginx image already passes
+  `-g 'daemon off;'` → duplicate-directive fatal error);
+- the LLM upstream was resolved at config-load, so an unresolvable/down LLM host
+  crashed the *whole* front (login + UI). Fixed with a `resolver 127.0.0.11`
+  (Docker DNS) + variable `proxy_pass` so the LLM (and the hosted-app
+  `backend:$port`, which I'd put behind a variable) resolve at request time and
+  only 502 when actually called.
+
+**Still not verified (needs the `klangk` workspace image + a real LLM):**
+opening a workspace, the interactive terminal, the hosted-app proxy, and real
+LLM calls. That's §9/B + the true end-to-end.
+
+Two knobs to confirm at smoke-test time: the Flutter tag `3.41.9` (vs. the dev
+toolchain) and `KLANGK_HOST_GATEWAY` (the §8 pi→nginx reachability value).
+
+HOST prereqs for the backend (same as podman_test): `modprobe tun`, and either
+the `cap_add: SYS_ADMIN` (kept by default) or relaxed unprivileged-userns
+sysctls.
+
+Done in the backend (`src/backend`):
+
+- **`aiodocker` removed entirely** — dropped from
+  [pyproject.toml](src/backend/pyproject.toml). Replaced by
+  [`klangk_backend/podman.py`](src/backend/klangk_backend/podman.py): a thin
+  async wrapper over the `podman` CLI (binary via `KLANGK_PODMAN_BIN`,
+  default `podman`). `PodmanError.status` reproduces aiodocker's 404/409
+  semantics for the HTTP layer.
+- **Migrated call sites:** `container.py` (lifecycle/volumes), `api.py`
+  (`/volumes` routes), `dockerexec.py` (binary swap), and **`terminal.py`**
+  (rewritten: interactive shell via `podman exec -t -i` over a
+  `pty.openpty()` slave in raw mode; resize = set master winsize + send
+  `SIGWINCH` to podman; OS glue isolated in `ShellProcess`, `# pragma: no
+  cover`; lifecycle logic in `TerminalSession`, unit-tested via an injected
+  fake shell).
+- **Airgap hardening:** `podman create --pull=never` (use only the local /
+  additional image store, never attempt a registry pull); the stale
+  `/var/run/docker.sock` bind on workspace containers was **removed**.
+- **Tooling:** `ruff` added to deps so it installs into the venv.
+- **Pre-existing CLI test hangs fixed** (unrelated to the migration, but they
+  block serial test runs): `test_cli.py::TestRunShell::test_stdout_loop_writes_data`
+  and `test_cli_integration.py::TestRunShell::test_stdin_loop_broken_pipe`
+  patched `select.select` "ready" but let `_run_shell` do a blocking
+  `os.read(0,1)` on real stdin. Fixed by also patching
+  `klangk_backend.cli.client.os.read`. (Running `pytest -n auto` avoids these
+  entirely — xdist detaches worker stdin.)
+
+Verified on Windows/Git-Bash (modules without `termios`): `podman.py` 100%,
+`container.py` 0 statement misses, `dockerexec.py` 100%, `api.py` volume
+routes covered, `ruff` clean. On Linux: `terminal.py` imports clean + `ruff`
+clean. **The full unit suite + coverage gate must be confirmed on Linux**
+(see §13) — `terminal.py`/`cli/` import `pty`/`termios` and can't run on
+Windows at all.
+
+Decision locked since the original plan: **workspace image store = (B) a
+read-only additional image store** (§9), not a live registry.
+
+**Not yet started:** wiring the §9/B `additionalimagestores` store volume +
+the offline build/seed of the `klangk` workspace image, the end-to-end smoke
+test (which is what first exercises a real `docker build` of §6/§7), and
+README/HACKING docs. (§8 env-parameterization is **done**; the §6 daemon image
++ nginx template and the §7 compose stack are **written** but not yet
+build-run.)
+
+> Note: the coverage gate is **statement** coverage
+> (`--cov-fail-under=100`, no `branch` config in `pyproject.toml`), despite
+> CLAUDE.md mentioning "branch coverage". All migrated modules meet the
+> statement gate; a handful of pre-existing partial *branches* are not
+> enforced.
+
+## 1. Scope & terminology
+
+**The klangk daemon** = the FastAPI/uvicorn backend
+(`klangk_backend.main:app`) + its **nginx** front (reverse proxy,
+LLM-key-injecting proxy, hosted-app proxy) + the built **Flutter web
+assets** it serves.
+
+This is distinct from the **workspace image** (`src/docker/Dockerfile` on
+`klangk-base`) — the per-user "pi" agent sandbox the daemon *spawns*. We are
+**not** folding the workspace image into the daemon image; we are giving the
+daemon its own container engine to launch those sandboxes into.
+
+## 2. Decisions taken
+
+| Topic | Decision |
+|---|---|
+| Outer runtime | **Docker** runs the compose stack (`docker compose up`). |
+| Inner engine | **Rootless Podman**, launching the pi/workspace containers (podman-in-docker). |
+| Engine placement | **Merged into the backend container** (Podman is daemonless, so no separate engine service). |
+| Service count | **Two services**: `nginx` + `backend`. |
+| Network isolation | Docker networks isolate components; only `nginx` is published to the host. |
+| Engine API | **Remove `aiodocker`** and drive Podman via the CLI — no socket, no `podman system service`, single process. |
+| External deps | **LLM endpoint only** (eventually rolled into the stack too). |
+
+## 3. Why these choices
+
+- **Podman, daemonless.** Unlike `dockerd`, Podman fork-execs `crun` directly,
+  so "merge the engine into the backend" is clean rather than an anti-pattern
+  (no second daemon behind a supervisor). It also gives the rootless story the
+  user is targeting.
+- **Merging the engine** collapses the stack to two services *and* eliminates
+  the bind-mount path-alignment problem: because Podman shares the backend's
+  filesystem, the `home_path` strings the backend computes
+  ([workspaces.py:229](src/backend/klangk_backend/workspaces.py#L229)) resolve
+  correctly for the pi containers with no shared-volume-at-identical-path trick.
+  The `klangk-data` volume mounts into the one backend container.
+- **Removing aiodocker** is what lets the backend stay a single process. The
+  backend talks to the engine two ways; only one needs a socket:
+  - `docker exec -i …` shell-outs
+    ([dockerexec.py:27](src/backend/klangk_backend/dockerexec.py#L27)) — fork-exec,
+    no socket.
+  - **aiodocker** (Docker REST API) in
+    [container.py](src/backend/klangk_backend/container.py) /
+    [terminal.py](src/backend/klangk_backend/terminal.py) — needs a socket,
+    which is the *only* reason `podman system service` would be required.
+  Replace aiodocker with `podman` CLI calls and the socket/service disappears
+  entirely.
+
+## 4. Target architecture
+
+```
+ host :8995 ── docker compose (outer) ───────────────────────┐
+   ┌─────────┐  edge net   ┌──────────────────────────────────┐
+   │  nginx  │────────────▶│  backend (uvicorn)                │
+   └─────────┘  internal   │   + rootless podman ──▶ pi/        │
+        ▲                  │     workspace containers          │
+        │                  │   klangk-data volume (one mount)  │
+   host:8995               └──────────────────────────────────┘
+   (only external dep: the LLM endpoint, reached via nginx llm-proxy)
+```
+
+**Services**
+
+- **`nginx`** — the only host-published service (`8995`). On `edge` +
+  `internal` networks. Reaches the backend at `backend:8997`. Keeps the
+  LLM-proxy (injects `KLANGK_LLM_API_KEY`, so pi containers never see the key)
+  and the hosted-app proxy.
+- **`backend`** — uvicorn + rootless Podman, **not** published to the host;
+  only `nginx` can reach it. Mounts the `klangk-data` volume. Carries the
+  rootless-nesting profile (see §7).
+
+**Networks** — `edge` (host-facing, nginx only) and `internal` (nginx ↔
+backend). The backend is unreachable except via nginx.
+
+**Volume** — a single named `klangk-data` (SQLite DB + workspace homes), mounted
+into the backend at `KLANGK_DATA_DIR=/var/lib/klangk/data`.
+
+## 5. Removing aiodocker (the core refactor)
+
+The aiodocker surface is small and bounded. Replace it with a thin async
+wrapper module `klangk_backend/podman.py` that shells `podman` via
+`asyncio.create_subprocess_exec`, parses `--format json`, and maps non-zero
+exits to a small `PodmanError(status, msg)` so the HTTP 404/409 control flow in
+[api.py](src/backend/klangk_backend/api.py) survives unchanged.
+
+### Operation inventory
+
+| # | aiodocker call | Where | podman CLI replacement | Risk |
+|---|---|---|---|---|
+| 1 | `containers.get` + `.show()` | [container.py:297](src/backend/klangk_backend/container.py#L297), [468](src/backend/klangk_backend/container.py#L468) | `podman inspect <id>` → JSON (`.State.Running`, `.Config.Labels`) | low |
+| 2 | `containers.create_or_replace(name, config)` + `.start()` | [container.py:446](src/backend/klangk_backend/container.py#L446) | `podman rm -f` (if exists) then `podman create <flags>` + `podman start` | med |
+| 3 | `container.delete(force=True)` | [container.py:469](src/backend/klangk_backend/container.py#L469), [615](src/backend/klangk_backend/container.py#L615) | `podman rm -f <id>` | low |
+| 4 | `containers.list(filters={label})` | [container.py:568](src/backend/klangk_backend/container.py#L568), [606](src/backend/klangk_backend/container.py#L606) | `podman ps -a --filter label=… --format json` | low |
+| 5 | `volumes.get/create/list/delete` + `.show()` | [container.py:379](src/backend/klangk_backend/container.py#L379), [api.py:431-489](src/backend/klangk_backend/api.py#L431) | `podman volume inspect/create/ls/rm` | low |
+| 6 | `DockerError.status` (404/409) for control flow | api.py volume routes | parse exit code + stderr → map to 404/409 | med |
+| 7 | **`container.exec(tty=True…)` + `Stream`** | [terminal.py:69-107](src/backend/klangk_backend/terminal.py#L69) | `podman exec -t` over a `pty.openpty()` in raw mode; resize via `TIOCSWINSZ` ioctl | **HIGH** |
+| 8 | `docker exec -i …` (already CLI) | [dockerexec.py:27](src/backend/klangk_backend/dockerexec.py#L27) | swap binary `docker` → `podman` | trivial |
+
+### Container spec translation (#2)
+
+The `config` dict at
+[container.py:403](src/backend/klangk_backend/container.py#L403) becomes
+`podman create` flags:
+
+- `Binds` → `-v host:container[:opts]`
+- `Tmpfs` → `--tmpfs /tmp:rw,exec,nosuid,size=2g` (etc.)
+- `PortBindings` / `ExposedPorts` → `-p host:container`
+- `ExtraHosts` → `--add-host host.docker.internal:host-gateway`
+  (or Podman's native `host.containers.internal` — pin during the §8 spike)
+- DNS config → `--dns …`
+- `Env` → `-e KEY=VAL`
+- `Labels` → `--label k=v`
+- `Init: True` → `--init`
+- `OpenStdin` / `AttachStdin` → `-i`
+- name → `--name klangk-<instance>-<wsid>`
+
+### The hard part: the interactive terminal (#7)
+
+The original author deliberately moved *off* subprocess to the API exec — see
+the comment at [terminal.py:20](src/backend/klangk_backend/terminal.py#L20):
+
+> "avoiding the double-PTY issue that occurs with `docker exec -it` as a
+> subprocess (which consumed ESC bytes from arrow key sequences)."
+
+The API exec gives a **single** container-side PTY with bytes flowing raw over
+the socket. Naively shelling `podman exec -it` reintroduces a second (local)
+PTY in series whose line discipline eats escape sequences — the exact bug they
+fixed. The correct single-PTY CLI equivalent:
+
+- `podman exec -t -i <id> …` for the **container-side** PTY (vim/arrow keys
+  work),
+- local side on a `pty.openpty()` master/slave with the slave in **raw mode**
+  (`termios.cfmakeraw`) so the local line discipline passes bytes through
+  untouched,
+- **resize** done locally via `fcntl.ioctl(master, TIOCSWINSZ, winsize)` — no
+  engine round-trip,
+- proxy master ↔ websocket via `loop.add_reader` / `os.read` / `os.write`.
+
+This pattern is well-trodden but **must be manually tested** against arrow keys,
+vim, tmux, and ctrl-sequences before it is trusted.
+
+### Cost
+
+- **Test rewrite.** Four test files mock aiodocker
+  ([test_container.py](src/backend/tests/test_container.py),
+  [test_terminal.py](src/backend/tests/test_terminal.py),
+  [test_api.py](src/backend/tests/test_api.py),
+  [test_wshandler.py](src/backend/tests/test_wshandler.py)). They must switch to
+  mocking subprocess / `podman.py`, and CLAUDE.md mandates **100% branch
+  coverage** — every error branch (404/409 mapping, PTY failure paths) needs a
+  test. Likely larger than the production change.
+- **CLI JSON verification.** `podman inspect` / `volume ls` field names are
+  Docker-compatible but verify `.State.Running`, `.Config.Labels`, and volume
+  `CreatedAt` against the target Podman version rather than assuming.
+
+### Sequencing (two passes)
+
+1. Introduce `podman.py`; migrate the non-streaming calls (#1–6, 8) + their
+   tests. Removes most of aiodocker; surface shrinks to one file.
+2. Rewrite the terminal PTY (#7) with manual interactive testing. Only then
+   drop `aiodocker` from [pyproject.toml](src/backend/pyproject.toml).
+
+## 6. Build simplification (decouple from Nix for shipping)
+
+Add a **multi-stage Dockerfile for the daemon** (`src/daemon/Dockerfile`),
+independent of devenv. Keep `devenv.nix` as-is for local dev — this *adds* a
+path, it does not remove one.
+
+- **Stage `web`** — `FROM` a pinned Flutter SDK image matching devenv's
+  toolchain. Run `stub_dart_plugins.sh` (or `import_dart_plugins.py` if plugins
+  are baked), then `flutter build web --wasm --release`. **Drop** the
+  dev-only flags (`--source-maps`, `--no-minify-*`, `--no-strip-wasm`) and the
+  `inline_sources_in_map.py` step ([flutterbuildweb.sh](scripts/flutterbuildweb.sh)) —
+  this removes the heaviest, most fragile part of the build and shrinks the
+  assets. Output `build/web`.
+- **Stage `runtime`** — `FROM python:3.12-slim`. Install `podman` + `crun` +
+  `fuse-overlayfs`, `bash`, `git`, `rsync` (needed by the CLI shell-outs and
+  workspace export/import), then `uv pip install` the backend from
+  `src/backend`. Copy `build/web` from the `web` stage to the path
+  [main.py:141](src/backend/klangk_backend/main.py#L141) expects. `tini` as
+  PID 1; `exec uvicorn …` as CMD (same flags as
+  [devenv.nix:89](devenv.nix#L89)).
+
+**nginx** stays an off-the-shelf `nginx:alpine`; lift the config out of
+[nginx.sh](scripts/nginx.sh) into a templated `nginx.conf` (env-substituted at
+start), with `127.0.0.1` → `backend` and the `/hosted/` upstream pointed at the
+address resolved by the §8 spike.
+
+## 7. Rootless Podman-in-Docker profile
+
+The backend container runs rootless Podman to launch pi containers. **Done** —
+the recipe was lifted from the working `/home/bryan/src/podman_test` example and
+split across the image (in-image half) and compose (host-side half):
+
+- **`fuse-overlayfs` + `/dev/fuse`** — driver set in `src/daemon/storage.conf`
+  (`overlay` + `mount_program`), `/dev/fuse` passed through in
+  `docker-compose.yml` (`devices:`).
+- **setuid `newuidmap`/`newgidmap` + `/etc/subuid`/`/etc/subgid`** — the
+  `Dockerfile` creates the non-root `klangk` user with both ID ranges and
+  `chmod 4755`s the helpers (file-cap xattrs don't survive the overlay mount).
+- **caps / devices / userns** — `cap_add: SYS_ADMIN`, `security_opt`
+  (`seccomp`/`apparmor`/`label=disable` + `systempaths=unconfined`), and
+  `/dev/net/tun` for passt/slirp4netns, all on the backend service.
+- **healthcheck** — `podman info` confirms the in-process engine initialises
+  (`podman create` of a real container is the §5 smoke test, since it needs the
+  workspace image present).
+
+Host prerequisites (same as the example): `sudo modprobe tun`, and unprivileged
+user namespaces — covered by the `SYS_ADMIN` cap, or relax the host sysctls and
+drop the cap (see the comment block at the top of `docker-compose.yml`).
+
+## 8. Open item — the one spike to run first
+
+**Workspace-container → nginx reachability.** The pi containers must reach the
+nginx LLM-proxy and the bridge. Today the backend injects
+`KLANGK_LLM_PROXY_URL` / `KLANGK_BRIDGE_URL` pointing at
+`host.docker.internal:{nginx_port}`
+([container.py:333](src/backend/klangk_backend/container.py#L333),
+[355](src/backend/klangk_backend/container.py#L355)).
+
+Under Podman-in-the-backend with isolated networks, validate how a pi container
+reaches nginx (likely Podman's native `host.containers.internal`, or an
+`--add-host` alias), and pin the exact injected URLs + the nginx `/hosted/`
+upstream from the result.
+
+> **Status: DONE.** Both strings (and the workspace container's `--add-host`)
+> now derive from `KLANGK_HOST_GATEWAY`
+> ([container.py:329](src/backend/klangk_backend/container.py#L329)), default
+> `host.docker.internal` — byte-for-byte preserving the devenv/host-process
+> behavior. Under the Podman-in-Docker stack, set
+> `KLANGK_HOST_GATEWAY=host.containers.internal` (podman's native alias). The
+> backend always registers `--add-host <gateway>:host-gateway`, which resolves
+> on both Docker and Podman (both honor the `host-gateway` magic value), so the
+> name is reachable from inside the pi container either way.
+
+## 9. Workspace image availability
+
+Podman in the backend starts with no `klangk` workspace image, and the target
+deployment is **network-restricted** (no registry pull at runtime).
+
+**Decision: (B) a read-only additional image store.** Ship the prebuilt image
+store as an RO artifact/volume and register it in the backend's
+`storage.conf`:
+
+```
+[storage.options]
+additionalimagestores = ["/var/lib/klangk-images"]
+```
+
+podman reads the `klangk` base image from the RO store; writable container
+layers go to the normal rw store. The store is seeded offline in CI
+(`podman build`/`pull` the image, export the store dir). Lets the sandbox
+image be refreshed by swapping one volume without rebuilding the backend.
+
+**Pull policy is selectable** via `KLANGK_IMAGE_PULL_POLICY`
+([container.py `image_pull_policy()`](src/backend/klangk_backend/container.py)),
+mapped onto `podman create --pull=<policy>`:
+
+- `never` (**default**) — offline only: read the image from the local store +
+  the additional RO store, never contact a registry (fails fast if absent).
+  This is the §9/B airgap behavior.
+- `missing` — pull from a registry only if the image isn't present locally
+  (i.e. registry-with-store-fallback). Use this on a connected host.
+- `always` / `newer` — also accepted; check the registry every start.
+
+An unrecognized value logs a warning and falls back to `never`. So the same
+image binary supports both the airgapped "offline store" deployment and a
+"pull from registry" deployment with one env var — answering the
+pull-vs-store question without code changes.
+
+### Populating the image — local, nothing pushed
+
+The `klangk` image is built **locally** by
+[scripts/dockerbuild.sh](scripts/dockerbuild.sh) (`docker build -t klangk
+src/docker/`); its only upstream dependency is `klangk-base`, which is *pulled*
+from public GHCR (a pull of a public image — no credentials, no push). Getting
+that locally-built image into the daemon's rootless store has two targets:
+
+1. **Live rootless store load (the simple path, verified).** With the stack
+   running, transfer the image into the backend container's rootless store with
+   `docker save | podman load`; it persists in the `klangk-podman-storage`
+   volume and `podman create --pull=never klangk` resolves the bare short name.
+   Wrapped in [scripts/seed-workspace-image.sh](scripts/seed-workspace-image.sh):
+
+   ```
+   scripts/dockerbuild.sh             # build locally (pulls public base, no creds)
+   docker compose up -d               # stack must be running
+   scripts/seed-workspace-image.sh    # docker save -> podman load into the store
+   ```
+
+   Verified end-to-end against the running stack: load succeeds and
+   `--pull=never <name>` resolves it. (Gotcha confirmed: podman *container*
+   `--name`s must start `[a-zA-Z0-9]`, but the *image* short name resolves
+   fine — no special `localhost/` re-tag needed.)
+
+2. **Read-only additional image store (§9/B, for immutable / swap-to-refresh
+   deployments) — not yet wired.** Build/load the image into a *separate*
+   containers-storage root offline, ship that dir as an RO volume mounted at
+   `/var/lib/klangk-images`, and uncomment `additionalimagestores` in
+   `src/daemon/storage.conf` + the `klangk-images` volume in `docker-compose.yml`.
+   Lets the sandbox image be refreshed by swapping one volume without touching
+   the backend. Path 1 is sufficient for a single running deployment; this is
+   the airgapped-artifact story.
+
+Rejected alternatives: baking the image into the backend image (couples image
+updates to backend rebuilds); a live in-stack `registry:2` (more moving parts,
+still needs an offline seed).
+
+## 10. Configuration & secrets
+
+- Single `.env` consumed by compose (`env_file:`), mapping the existing
+  `KLANGK_*` vars ([.env.example](.env.example)). Set
+  `KLANGK_DATA_DIR=/var/lib/klangk/data` and the nginx/backend ports.
+- `KLANGK_LLM_API_KEY` lives **only** in nginx's environment — it is injected by
+  the proxy and deliberately never reaches pi containers. Preserve this.
+- `KLANGK_JWT_SECRET`, default admin creds, SMTP, etc. unchanged.
+
+## 11. Deliverables & order
+
+1. **Spike** the §8 reachability question; pin the proxy/bridge addressing.
+2. **aiodocker removal, pass 1** — `podman.py` wrapper + container/volume
+   migration (#1–6, 8) + test rewrite.
+3. **aiodocker removal, pass 2** — terminal PTY (#7) + manual interactive
+   testing; drop `aiodocker` from `pyproject.toml`.
+4. Parameterize the two `host.docker.internal:{nginx_port}` strings via env
+   (default preserves host-process behavior for devenv).
+5. `src/daemon/Dockerfile` (multi-stage) + production `nginx.conf` template.
+6. `docker-compose.yml` — `nginx` + `backend`; `edge`/`internal` networks;
+   `klangk-data` volume; `.env`; rootless-nesting placeholder block.
+7. Workspace-image availability in Podman (registry pull or init build).
+8. Smoke test: `docker compose up` → log in at `:8995` → open a workspace →
+   confirm terminal, hosted-app proxy, and LLM calls; restart the stack and
+   confirm persistence via the volume.
+9. Update [README.md](README.md) / [HACKING.md](HACKING.md) with the
+   `docker compose up` path alongside the existing devenv flow.
+
+## 12. Trade-offs to keep in view
+
+- The backend container takes the rootless-nesting privileges — the engine is no
+  longer isolated from the app process. Acceptable given the simplicity and
+  rootless goals.
+- Switching the engine from Docker to Podman moves the backend onto Podman's
+  CLI/behaviour surface; the `create`-flag translation and the 404/409 error
+  mapping are the parts most worth testing.
+- The interactive terminal (§5 #7) is the single highest-risk change and gates
+  dropping aiodocker entirely.
+
+## 13. Continuing on Linux
+
+Phase 1 (backend code) is done; the rest must be built/verified on Linux with
+`podman` installed. This captures the environment gotchas hit during Phase 1.
+
+### Environment
+
+- Develop/test on **Linux** (or WSL). The repo's dev `.venv` is a Linux venv
+  (has a `lib64` symlink); **Windows `uv` corrupts it** (`failed to remove
+  .venv/lib64`). `terminal.py` and `cli/client.py` import `pty`/`termios`/
+  `fcntl`, so those modules and their tests **cannot be imported on Windows**.
+- If the venv is missing/broken: `cd src/backend && uv sync` (recreates it;
+  now includes `ruff`).
+
+### Running the tests
+
+```bash
+cd src/backend
+uv run pytest tests -n auto                 # unit suite + 100% statement gate
+uv run ruff check && uv run ruff format --check
+```
+
+- **Always use `-n auto`** (pytest-xdist). It detaches worker stdin, which is
+  how the repo's `test-backend` runs and what avoids the `TestRunShell`
+  `os.read(0)` stdin hangs. Serial runs (`pytest` without `-n auto`, attached
+  to a tty) hang on those CLI tests — pre-existing, partly fixed at source.
+- **`e2e-tests/` are expected to fail** until the `klangk` workspace image is
+  present in podman's store: `podman create klangk` hits
+  `--pull=never` (or, before that change, an unqualified-registry pull that's
+  denied). They need a real LLM too. Run them separately, not as the gate.
+
+### Verifying the terminal rewrite (the one piece written blind)
+
+`terminal.py`'s `ShellProcess` (the `podman exec -t` + PTY glue) is
+`# pragma: no cover` and needs **interactive** validation against a real
+podman + `klangk` container:
+
+1. Arrow keys / shell history, `vim`, `tmux`, Ctrl-C/Ctrl-D, wide-unicode →
+   confirm raw mode passes escape sequences through (no double-PTY mangling).
+2. Resize the browser terminal → `tput cols` / vim redraw → confirm the
+   `SIGWINCH`-to-podman path actually resizes the container PTY. **This is the
+   most likely thing to need adjustment** if podman's tty handling differs
+   from the assumption (alternative: drive resize via `podman` differently).
+3. `exit` the shell → session closes cleanly (read returns `b""`/EIO).
+
+### Remaining work (was §11 steps 4–9; steps 1–4 are done)
+
+1. ~~**§8 — env-parameterize** the two `host.docker.internal:{nginx_port}`
+   strings (LLM-proxy + bridge URLs) and pin pi→nginx reachability.~~ **DONE** —
+   `KLANGK_HOST_GATEWAY` env var (default `host.docker.internal`) drives both
+   URLs and the `--add-host` alias; set to `host.containers.internal` for the
+   podman stack. See §8. Covered by `test_host_gateway_override`.
+2. ~~**§6 — daemon `Dockerfile`** (multi-stage) + templated `nginx.conf`.~~
+   **WRITTEN** in `src/daemon/` (`Dockerfile`, `nginx.conf.template`,
+   `storage.conf`, `containers.conf`); lints clean (`docker build --check`).
+   Full `docker build` + runtime still to be exercised by the smoke test (§5).
+3. ~~**§7 — `docker-compose.yml`** with the rootless Podman-in-Docker profile.~~
+   **WRITTEN** (`docker-compose.yml` at repo root + the rootless plumbing in the
+   `runtime` stage / `src/daemon/*.conf`), modeled on `/home/bryan/src/podman_test`.
+   `docker compose config` valid. Full build/run is the §5 smoke test.
+4. **§9 — image population:** the **live-store load is DONE** —
+   [scripts/seed-workspace-image.sh](scripts/seed-workspace-image.sh)
+   (`docker save | podman load` into the running backend's rootless store,
+   no registry push; verified end-to-end). Pull policy is also selectable
+   (`KLANGK_IMAGE_PULL_POLICY`). **Remaining (§9/B):** the read-only
+   `additionalimagestores` artifact path for immutable/swap deployments — wire
+   the RO `klangk-images` volume + the `storage.conf`/compose entries (both
+   stubbed) and an offline build-into-separate-root step.
+5. **Smoke test** the stack — **front half done** (login at `:8995`, SPA, API,
+   auth, volume persistence all verified; see §0). Remaining: open a workspace →
+   terminal + hosted-app proxy + LLM calls (needs the §9/B workspace image + LLM).
+6. ~~**Docs** — README/HACKING `docker compose up` path.~~ **DONE** —
+   [HACKING.md](HACKING.md) has a "Running with Docker Compose (without Nix)"
+   section (services, host prereqs, bring-up, workspace-image seeding, compose
+   vs. devenv differences) + the new env vars (`KLANGK_IMAGE_PULL_POLICY`,
+   `KLANGK_PODMAN_BIN`, `KLANGK_HOST_GATEWAY`) in the table; [README.md](README.md)
+   has a Quick-Start pointer.
+
+### Notable behavior changes from the migration (review when wiring the stack)
+
+- Workspace containers no longer get `/var/run/docker.sock` (removed in Phase 1;
+  originally added by commit 9d2d584). **Resolved — no replacement socket
+  needed:** a repo-wide audit found nothing in the workspace image or pi agent
+  that talks to a container-engine socket (no `docker`/`podman` daemon calls, no
+  `DOCKER_HOST`, no dind). The only residual mentions are stale "docker exec"
+  comments in `src/docker/entrypoint.sh` / `bash.bashrc` (the backend now
+  attaches via `podman exec`) and `scripts/run-pi-container.sh`, a dev-only
+  manual-run helper — none bind the socket.
+- `podman create --pull=<policy>` defaults to `never` (a missing image fails
+  immediately rather than pulling — the airgapped target). Set
+  `KLANGK_IMAGE_PULL_POLICY=missing` to pull from a registry when the image is
+  absent locally; see §9.
+- `KLANGK_PODMAN_BIN` env var overrides the `podman` binary (default `podman`);
+  set to `docker` to run the existing behavior on a docker host for comparison.
+

--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -23,6 +23,7 @@ from . import (
     container,
     emailsvc,
     files,
+    podman,
     wshandler,
     model,
     workspaces,
@@ -427,16 +428,15 @@ async def list_images(_user: dict = Depends(auth.get_current_user)):
 
 @router.get("/volumes")
 async def list_volumes(_user: dict = Depends(auth.get_current_user)):
-    docker = await container.registry.get_docker()
-    volumes = await docker.volumes.list(
-        filters={"label": [f"klangk.instance={container.INSTANCE_ID}"]}
+    volumes = await podman.list_volumes(
+        f"klangk.instance={container.INSTANCE_ID}"
     )
     return [
         {
             "name": v["Name"],
             "created": v.get("CreatedAt", ""),
         }
-        for v in volumes.get("Volumes") or []
+        for v in volumes
     ]
 
 
@@ -449,26 +449,17 @@ async def create_volume(
     body: CreateVolumeRequest,
     _user: dict = Depends(auth.get_current_user),
 ):
-    docker = await container.registry.get_docker()
-    try:
-        existing = await docker.volumes.get(body.name)
-        await existing.show()  # raises 404 if not found
+    if await podman.inspect_volume(body.name) is not None:
         raise HTTPException(
             status_code=409, detail=f"Volume {body.name!r} already exists"
         )
-    except container.aiodocker.exceptions.DockerError as e:
-        if e.status != 404:
-            raise
-    vol = await docker.volumes.create(
+    info = await podman.create_volume(
+        body.name,
         {
-            "Name": body.name,
-            "Labels": {
-                "klangk.managed": "true",
-                "klangk.instance": container.INSTANCE_ID,
-            },
-        }
+            "klangk.managed": "true",
+            "klangk.instance": container.INSTANCE_ID,
+        },
     )
-    info = await vol.show()
     return {"name": info["Name"], "created": info.get("CreatedAt", "")}
 
 
@@ -476,18 +467,18 @@ async def create_volume(
 async def delete_volume(
     name: str, _user: dict = Depends(auth.get_current_user)
 ):
-    docker = await container.registry.get_docker()
+    info = await podman.inspect_volume(name)
+    if info is None:
+        raise HTTPException(status_code=404, detail="Volume not found")
+    labels = info.get("Labels") or {}
+    if labels.get("klangk.instance") != container.INSTANCE_ID:
+        raise HTTPException(
+            status_code=404,
+            detail="Volume not managed by this Klangk instance",
+        )
     try:
-        vol = await docker.volumes.get(name)
-        info = await vol.show()
-        labels = info.get("Labels") or {}
-        if labels.get("klangk.instance") != container.INSTANCE_ID:
-            raise HTTPException(
-                status_code=404,
-                detail="Volume not managed by this Klangk instance",
-            )
-        await vol.delete()
-    except container.aiodocker.exceptions.DockerError as e:
+        await podman.remove_volume(name)
+    except podman.PodmanError as e:
         if e.status == 404:
             raise HTTPException(
                 status_code=404, detail="Volume not found"

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -34,6 +34,29 @@ ALLOWED_IMAGES: set[str] = {
 }
 ALLOWED_IMAGES.add(IMAGE_NAME)  # default image is always allowed
 
+# podman --pull policies; controls where workspace images come from.
+_VALID_PULL_POLICIES = {"never", "missing", "always", "newer"}
+
+
+def image_pull_policy() -> str:
+    """Resolve the workspace-image pull policy from the environment.
+
+    Default ``never`` keeps the airgapped behavior (use only the local +
+    additional image stores). Set ``KLANGK_IMAGE_PULL_POLICY=missing`` to pull
+    from a registry when the image isn't present locally; ``always``/``newer``
+    are also accepted. An unrecognized value falls back to ``never``.
+    """
+    policy = util.resolve_env_secret("KLANGK_IMAGE_PULL_POLICY", "never")
+    if policy not in _VALID_PULL_POLICIES:
+        logger.warning(
+            "Invalid KLANGK_IMAGE_PULL_POLICY=%r (valid: %s); using 'never'.",
+            policy,
+            ", ".join(sorted(_VALID_PULL_POLICIES)),
+        )
+        return "never"
+    return policy
+
+
 _VALID_MOUNT_OPTIONS = {
     "ro",
     "rw",
@@ -319,7 +342,17 @@ class ContainerRegistry:
 
         env_vars = []
         nginx_port = util.resolve_env_secret("KLANGK_NGINX_PORT", "8995")
-        proxy_url = f"http://host.docker.internal:{nginx_port}/llm-proxy"
+        # Hostname a workspace container uses to reach the nginx front
+        # (LLM-proxy + bridge).  Default `host.docker.internal` preserves
+        # the host-process / devenv behavior; under the Podman-in-Docker
+        # stack with isolated networks this is set to podman's native
+        # `host.containers.internal` (or another alias resolvable to the
+        # host gateway).  The same name is registered via `--add-host
+        # <gateway>:host-gateway` below so it resolves inside the container.
+        host_gateway = util.resolve_env_secret(
+            "KLANGK_HOST_GATEWAY", "host.docker.internal"
+        )
+        proxy_url = f"http://{host_gateway}:{nginx_port}/llm-proxy"
         llm_model = util.resolve_env_secret("KLANGK_LLM_MODEL", "")
         env_vars.append(f"KLANGK_LLM_PROXY_URL={proxy_url}")
         if llm_model:
@@ -341,7 +374,7 @@ class ContainerRegistry:
         # know the backend URL.  KLANGK_BRIDGE_TOKEN is set per-exec
         # session (in terminal.py) so each connection has its own token.
         env_vars.append(
-            f"KLANGK_BRIDGE_URL=http://host.docker.internal:{nginx_port}"
+            f"KLANGK_BRIDGE_URL=http://{host_gateway}:{nginx_port}"
         )
         env_vars.append(f"KLANGK_HOSTING_HOSTNAME={hosting_hostname}")
         env_vars.append(f"KLANGK_HOSTING_PROTO={hosting_proto}")
@@ -402,11 +435,12 @@ class ContainerRegistry:
                 "/var/log": "rw,noexec,nosuid,size=256m",
             },
             publish=publish,
-            add_hosts=["host.docker.internal:host-gateway"],
+            add_hosts=[f"{host_gateway}:host-gateway"],
             dns=_container_dns_config().get("Dns"),
             env=env_vars,
             init=True,
             interactive=True,
+            pull=image_pull_policy(),
         )
         await podman.start_container(container_id)
 

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -339,6 +339,33 @@ class ContainerRegistry:
                     existing_container_id,
                     workspace_id,
                 )
+        else:
+            # DB has no container_id (e.g. after a backend restart that lost
+            # in-memory state).  Scan by label so we can adopt a running
+            # container rather than blindly --replace it (which hangs trying
+            # to stop it).
+            containers = await podman.list_containers(
+                f"klangk.workspace-id={workspace_id}"
+            )
+            if containers:
+                found_id = containers[0].get("Id") or containers[0].get("ID", "")
+                info = await podman.inspect_container(found_id)
+                if info and info["State"]["Running"]:
+                    logger.info(
+                        "Adopted running container %s for workspace %s",
+                        found_id,
+                        workspace_id,
+                    )
+                    await model.update_workspace_container(workspace_id, found_id)
+                    self.track_activity(found_id, workspace_id)
+                    return found_id, "connected"
+                elif info:
+                    await podman.remove_container(found_id)
+                    logger.info(
+                        "Removed stopped orphan container %s for workspace %s",
+                        found_id,
+                        workspace_id,
+                    )
 
         # Lock the entire read+allocate sequence to prevent
         # concurrent start_container calls from double-allocating.
@@ -436,32 +463,47 @@ class ContainerRegistry:
             for i, host_port in enumerate(host_ports)
         ]
 
-        container_id = await podman.create_container(
-            f"klangk-{INSTANCE_ID}-{workspace_id[:12]}",
-            resolved_image,
-            labels={
-                "klangk.managed": "true",
-                "klangk.instance": INSTANCE_ID,
-                "klangk.workspace-id": workspace_id,
-            },
-            binds=binds,
-            tmpfs={
-                "/tmp": "rw,exec,nosuid,size=2g",
-                "/run": "rw,noexec,nosuid,size=256m",
-                "/var/log": "rw,noexec,nosuid,size=256m",
-            },
-            publish=publish,
-            add_hosts=[f"{host_gateway}:{_resolve_add_host_target(host_gateway)}"],
-            dns=_container_dns_config().get("Dns"),
-            env=env_vars,
-            init=True,
-            interactive=True,
-            pull=image_pull_policy(),
-        )
-        await podman.start_container(container_id)
+        # Create, persist, and start as one cancellation-shielded unit.
+        # The connecting client's websocket can drop mid-startup (idle
+        # ping-timeout, navigation), which cancels this coroutine. Without
+        # the shield, a cancel landing between `create`/`start` and the DB
+        # write orphans a running container with no `container_id` on record
+        # — the workspace then appears "stuck" until the adopt-by-label path
+        # recovers it on a later connect. Persisting the id immediately after
+        # create (before start) also means the container is never lost even
+        # if start raises: the next connect inspects it via existing_id and
+        # recreates if needed.
+        async def _create_and_start() -> str:
+            cid = await podman.create_container(
+                f"klangk-{INSTANCE_ID}-{workspace_id[:12]}",
+                resolved_image,
+                labels={
+                    "klangk.managed": "true",
+                    "klangk.instance": INSTANCE_ID,
+                    "klangk.workspace-id": workspace_id,
+                },
+                binds=binds,
+                tmpfs={
+                    "/tmp": "rw,exec,nosuid,size=2g",
+                    "/run": "rw,noexec,nosuid,size=256m",
+                    "/var/log": "rw,noexec,nosuid,size=256m",
+                },
+                publish=publish,
+                add_hosts=[
+                    f"{host_gateway}:{_resolve_add_host_target(host_gateway)}"
+                ],
+                dns=_container_dns_config().get("Dns"),
+                env=env_vars,
+                init=True,
+                interactive=True,
+                pull=image_pull_policy(),
+            )
+            await model.update_workspace_container(workspace_id, cid)
+            self.track_activity(cid, workspace_id)
+            await podman.start_container(cid)
+            return cid
 
-        await model.update_workspace_container(workspace_id, container_id)
-        self.track_activity(container_id, workspace_id)
+        container_id = await asyncio.shield(_create_and_start())
 
         logger.info(
             "Started container %s for workspace %s (ports %s)",

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -6,9 +6,7 @@ import os
 import time
 import uuid
 
-import aiodocker
-
-from . import util, model
+from . import model, podman, util
 
 logger = logging.getLogger(__name__)
 
@@ -139,7 +137,6 @@ class ContainerRegistry:
         # sock is None for workspace-level fallback tokens, or a specific
         # SafeWebSocket for per-connection tokens.
         self._bridge_tokens: dict[str, tuple[str, object | None]] = {}
-        self.docker: aiodocker.Docker | None = None
         self.cleanup_task: asyncio.Task | None = None
         self.port_lock: asyncio.Lock = asyncio.Lock()
         self.on_workspace_killed = None
@@ -149,11 +146,6 @@ class ContainerRegistry:
         if self._cleanup_wake is None:
             self._cleanup_wake = asyncio.Event()
         return self._cleanup_wake
-
-    async def get_docker(self) -> aiodocker.Docker:  # pragma: no cover
-        if self.docker is None:
-            self.docker = aiodocker.Docker()
-        return self.docker
 
     # --- State tracking ---
 
@@ -290,26 +282,23 @@ class ContainerRegistry:
                 f"{sorted(ALLOWED_IMAGES)}"
             )
 
-        docker = await self.get_docker()
-
         if existing_container_id:
-            try:
-                container = await docker.containers.get(existing_container_id)
-                info = await container.show()
-                if info["State"]["Running"]:
-                    self.track_activity(existing_container_id, workspace_id)
-                    return existing_container_id, "connected"
-                await container.delete(force=True)
+            info = await podman.inspect_container(existing_container_id)
+            if info is None:
+                logger.info(
+                    "Could not find container %s, creating new one",
+                    existing_container_id,
+                )
+            elif info["State"]["Running"]:
+                self.track_activity(existing_container_id, workspace_id)
+                return existing_container_id, "connected"
+            else:
+                await podman.remove_container(existing_container_id)
                 logger.info(
                     "Removed stopped container %s for workspace %s, "
                     "will recreate",
                     existing_container_id,
                     workspace_id,
-                )
-            except aiodocker.exceptions.DockerError:
-                logger.info(
-                    "Could not find container %s, creating new one",
-                    existing_container_id,
                 )
 
         # Lock the entire read+allocate sequence to prevent
@@ -375,80 +364,52 @@ class ContainerRegistry:
                 source = mount_spec.split(":")[0]
                 if "/" not in source and not source.startswith("."):
                     # Named volume — ensure it exists with klangk labels
-                    try:
-                        vol = await docker.volumes.get(source)
-                        await vol.show()
-                    except aiodocker.exceptions.DockerError as e:
-                        if e.status == 404:
-                            await docker.volumes.create(
-                                {
-                                    "Name": source,
-                                    "Labels": {
-                                        "klangk.managed": "true",
-                                        "klangk.instance": INSTANCE_ID,
-                                    },
-                                }
-                            )
-                        else:
-                            raise
+                    if await podman.inspect_volume(source) is None:
+                        await podman.create_volume(
+                            source,
+                            {
+                                "klangk.managed": "true",
+                                "klangk.instance": INSTANCE_ID,
+                            },
+                        )
 
-        port_bindings = {}
-        exposed_ports = {}
-        for i, host_port in enumerate(host_ports):
-            container_port = CONTAINER_PORT_START + i
-            port_key = f"{container_port}/tcp"
-            exposed_ports[port_key] = {}
-            port_bindings[port_key] = [{"HostPort": str(host_port)}]
+        binds = [
+            f"{home_path}:/home/klangk",
+            "/var/run/docker.sock:/var/run/docker.sock",
+        ]
+        if ssh_auth_sock and os.path.exists(ssh_auth_sock):
+            binds.append(f"{ssh_auth_sock}:/run/ssh-agent.sock:ro")
+        if config_path:
+            binds.append(f"{config_path}:/opt/klangk/config:ro")
+        binds += extra_mounts or []
 
-        config = {
-            "Image": resolved_image,
-            "Labels": {
+        publish = [
+            (host_port, CONTAINER_PORT_START + i)
+            for i, host_port in enumerate(host_ports)
+        ]
+
+        container_id = await podman.create_container(
+            f"klangk-{INSTANCE_ID}-{workspace_id[:12]}",
+            resolved_image,
+            labels={
                 "klangk.managed": "true",
                 "klangk.instance": INSTANCE_ID,
                 "klangk.workspace-id": workspace_id,
             },
-            "HostConfig": {
-                "Init": True,
-                "ReadonlyRootfs": False,
-                "Binds": [
-                    f"{home_path}:/home/klangk",
-                    "/var/run/docker.sock:/var/run/docker.sock",
-                ]
-                + (
-                    [f"{ssh_auth_sock}:/run/ssh-agent.sock:ro"]
-                    if ssh_auth_sock and os.path.exists(ssh_auth_sock)
-                    else []
-                )
-                + (
-                    [f"{config_path}:/opt/klangk/config:ro"]
-                    if config_path
-                    else []
-                )
-                + (extra_mounts or []),
-                "Tmpfs": {
-                    "/tmp": "rw,exec,nosuid,size=2g",
-                    "/run": "rw,noexec,nosuid,size=256m",
-                    "/var/log": "rw,noexec,nosuid,size=256m",
-                },
-                "PortBindings": port_bindings,
-                "ExtraHosts": ["host.docker.internal:host-gateway"],
-                **_container_dns_config(),
+            binds=binds,
+            tmpfs={
+                "/tmp": "rw,exec,nosuid,size=2g",
+                "/run": "rw,noexec,nosuid,size=256m",
+                "/var/log": "rw,noexec,nosuid,size=256m",
             },
-            "ExposedPorts": exposed_ports,
-            "Env": env_vars,
-            "OpenStdin": True,
-            "AttachStdin": True,
-            "AttachStdout": True,
-            "AttachStderr": True,
-            "Tty": False,
-        }
-
-        created = await docker.containers.create_or_replace(
-            name=f"klangk-{INSTANCE_ID}-{workspace_id[:12]}",
-            config=config,
+            publish=publish,
+            add_hosts=["host.docker.internal:host-gateway"],
+            dns=_container_dns_config().get("Dns"),
+            env=env_vars,
+            init=True,
+            interactive=True,
         )
-        await created.start()
-        container_id = created.id
+        await podman.start_container(container_id)
 
         await model.update_workspace_container(workspace_id, container_id)
         self.track_activity(container_id, workspace_id)
@@ -463,12 +424,10 @@ class ContainerRegistry:
 
     async def stop_and_remove_container(self, container_id: str) -> None:
         """Stop and remove a container."""
-        docker = await self.get_docker()
         try:
-            container = await docker.containers.get(container_id)
-            await container.delete(force=True)
+            await podman.remove_container(container_id)
             logger.info("Stopped container %s", container_id)
-        except aiodocker.exceptions.DockerError as e:
+        except podman.PodmanError as e:
             logger.warning(
                 "Failed to stop container %s: %s",
                 container_id,
@@ -564,22 +523,22 @@ class ContainerRegistry:
 
     async def adopt_orphaned_containers(self) -> None:
         try:
-            docker = await self.get_docker()
-            containers = await docker.containers.list(
-                filters={"label": [f"klangk.instance={INSTANCE_ID}"]},
+            containers = await podman.list_containers(
+                f"klangk.instance={INSTANCE_ID}"
             )
             for c in containers:
-                if c.id not in self._cid_to_wsid:
-                    labels = (await c.show())["Config"]["Labels"]
+                cid = c["Id"]
+                if cid not in self._cid_to_wsid:
+                    labels = c.get("Labels") or {}
                     workspace_id = labels.get("klangk.workspace-id", "unknown")
-                    self.track_activity(c.id, workspace_id)
+                    self.track_activity(cid, workspace_id)
                     logger.info(
                         "Adopted orphaned container %s (workspace %s)",
-                        c.id[:12],
+                        cid[:12],
                         workspace_id,
                     )
         except (
-            aiodocker.exceptions.DockerError,
+            podman.PodmanError,
             OSError,
         ) as e:
             logger.warning("Error scanning for orphaned containers: %s", e)
@@ -602,27 +561,24 @@ class ContainerRegistry:
         tracked_ids = set(self._cid_to_wsid.keys())
         tasks = [self.stop_and_remove_container(cid) for cid in tracked_ids]
         try:
-            docker = await self.get_docker()
-            containers = await docker.containers.list(
-                filters={"label": [f"klangk.instance={INSTANCE_ID}"]},
+            containers = await podman.list_containers(
+                f"klangk.instance={INSTANCE_ID}"
             )
             for c in containers:
-                if c.id not in tracked_ids:
+                cid = c["Id"]
+                if cid not in tracked_ids:
                     logger.info(
                         "Removing orphaned klangk container %s",
-                        c.id,
+                        cid,
                     )
-                    tasks.append(c.delete(force=True))
+                    tasks.append(self.stop_and_remove_container(cid))
         except (
-            aiodocker.exceptions.DockerError,
+            podman.PodmanError,
             OSError,
         ) as e:
             logger.warning("Error listing orphaned containers: %s", e)
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
-        if self.docker:
-            await self.docker.close()
-            self.docker = None
 
 
 # Module-level singleton

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import os
+import socket
 import time
 import uuid
 
@@ -23,6 +24,21 @@ def _container_dns_config() -> dict:
     if servers:
         return {"Dns": servers}
     return {}
+
+
+def _resolve_add_host_target(hostname: str) -> str:
+    """Return an IP for --add-host, or the 'host-gateway' special token.
+
+    When hostname resolves (e.g. a Docker service name like 'nginx' visible
+    via the embedded DNS 127.0.0.11), returns the IP so workspace containers
+    can route to it via slirp4netns through the backend's network stack.
+    Falls back to the podman/docker 'host-gateway' token for names that don't
+    resolve locally (e.g. 'host.docker.internal' outside Docker).
+    """
+    try:
+        return socket.gethostbyname(hostname)
+    except socket.gaierror:
+        return "host-gateway"
 
 
 IMAGE_NAME = util.resolve_env_secret("KLANGK_IMAGE_NAME", "klangk")
@@ -435,7 +451,7 @@ class ContainerRegistry:
                 "/var/log": "rw,noexec,nosuid,size=256m",
             },
             publish=publish,
-            add_hosts=[f"{host_gateway}:host-gateway"],
+            add_hosts=[f"{host_gateway}:{_resolve_add_host_target(host_gateway)}"],
             dns=_container_dns_config().get("Dns"),
             env=env_vars,
             init=True,

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -375,7 +375,6 @@ class ContainerRegistry:
 
         binds = [
             f"{home_path}:/home/klangk",
-            "/var/run/docker.sock:/var/run/docker.sock",
         ]
         if ssh_auth_sock and os.path.exists(ssh_auth_sock):
             binds.append(f"{ssh_auth_sock}:/run/ssh-agent.sock:ro")

--- a/src/backend/klangk_backend/dockerexec.py
+++ b/src/backend/klangk_backend/dockerexec.py
@@ -1,9 +1,10 @@
-"""Raw exec session: docker exec subprocess without PTY for piped commands."""
+"""Raw exec session: podman exec subprocess without PTY for piped commands."""
 
 import asyncio
 import logging
 from collections.abc import AsyncGenerator
 
+from . import podman
 from .util import BoundedOutputQueue
 
 logger = logging.getLogger(__name__)
@@ -25,7 +26,7 @@ class ExecSession:
     async def start(self, command: list[str]) -> None:
         """Start a command via docker exec with piped stdin/stdout."""
         exec_cmd = [
-            "docker",
+            podman.PODMAN_BIN,
             "exec",
             "-i",
             "-u",

--- a/src/backend/klangk_backend/podman.py
+++ b/src/backend/klangk_backend/podman.py
@@ -106,6 +106,7 @@ async def create_container(
     env: list[str] | None = None,
     init: bool = False,
     interactive: bool = False,
+    pull: str = "never",
     replace: bool = True,
 ) -> str:
     """Create a container (``podman create``) and return its id.
@@ -114,12 +115,13 @@ async def create_container(
     ``replace=True`` uses ``--replace`` so an existing container with the
     same name is removed first (the ``create_or_replace`` equivalent).
 
-    ``--pull=never`` is always passed: the deployment is network-restricted,
-    so the image must already be in the local store (or a configured
-    additional image store). This fails fast with a clear error instead of
-    attempting a registry pull.
+    ``pull`` maps to podman's ``--pull`` policy (default ``never``). With
+    ``never`` the image must already be in the local store (or a configured
+    additional image store) — the airgapped default, which fails fast instead
+    of attempting a registry pull. Set it to ``missing`` to pull from a
+    registry when the image isn't present locally.
     """
-    args = ["create", "--pull=never", "--name", name]
+    args = ["create", f"--pull={pull}", "--name", name]
     if replace:
         args.append("--replace")
     if init:

--- a/src/backend/klangk_backend/podman.py
+++ b/src/backend/klangk_backend/podman.py
@@ -1,0 +1,220 @@
+"""Thin async wrapper around the ``podman`` CLI.
+
+Replaces the previous ``aiodocker`` (Docker REST API) dependency so the
+backend can drive a *rootless, daemonless* Podman engine with no socket and
+no ``podman system service``. Every call shells out via
+``asyncio.create_subprocess_exec`` and parses ``--format json``.
+
+Non-zero exits raise :class:`PodmanError` whose ``status`` mimics the
+``aiodocker.exceptions.DockerError.status`` codes (404 not-found, 409
+conflict/in-use) that the HTTP layer relies on for control flow; anything
+else maps to 500.
+
+The binary is configurable via ``KLANGK_PODMAN_BIN`` (defaults to
+``podman``) so dev environments can point at ``docker`` instead.
+"""
+
+import asyncio
+import json
+import logging
+
+from . import util
+
+logger = logging.getLogger(__name__)
+
+PODMAN_BIN = util.resolve_env_secret("KLANGK_PODMAN_BIN", "podman")
+
+
+class PodmanError(Exception):
+    """A podman CLI invocation failed.
+
+    ``status`` is an HTTP-like code (404, 409, 500) derived from stderr so
+    callers can branch the same way they did on
+    ``aiodocker.exceptions.DockerError.status``.
+    """
+
+    def __init__(self, status: int, message: str):
+        self.status = status
+        self.message = message
+        super().__init__(f"[{status}] {message}")
+
+
+def _classify(stderr: str) -> int:
+    """Map podman stderr text to an HTTP-like status code."""
+    low = stderr.lower()
+    if "no such" in low or "not found" in low or "no container" in low:
+        return 404
+    if "in use" in low or "being used" in low or "already in use" in low:
+        return 409
+    return 500
+
+
+async def _run(
+    args: list[str],
+    *,
+    check: bool = True,
+    stdin_data: bytes | None = None,
+) -> tuple[int, str, str]:
+    """Run ``podman <args>`` and return ``(returncode, stdout, stderr)``.
+
+    When ``check`` is true a non-zero exit raises :class:`PodmanError`.
+    """
+    proc = await asyncio.create_subprocess_exec(
+        PODMAN_BIN,
+        *args,
+        stdin=(asyncio.subprocess.PIPE if stdin_data is not None else None),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    out_b, err_b = await proc.communicate(stdin_data)
+    rc = proc.returncode or 0
+    out = out_b.decode("utf-8", errors="replace")
+    err = err_b.decode("utf-8", errors="replace")
+    if check and rc != 0:
+        raise PodmanError(_classify(err), err.strip() or f"podman {args[0]}")
+    return rc, out, err
+
+
+# --- Containers ---
+
+
+async def inspect_container(container_id: str) -> dict | None:
+    """Return the inspect dict for a container, or None if it is gone.
+
+    Mirrors ``containers.get(id)`` + ``.show()``: the result carries
+    ``["State"]["Running"]`` and ``["Config"]["Labels"]``.
+    """
+    rc, out, _err = await _run(
+        ["container", "inspect", container_id], check=False
+    )
+    if rc != 0:
+        return None
+    data = json.loads(out)
+    return data[0] if data else None
+
+
+async def create_container(
+    name: str,
+    image: str,
+    *,
+    labels: dict[str, str] | None = None,
+    binds: list[str] | None = None,
+    tmpfs: dict[str, str] | None = None,
+    publish: list[tuple[int, int]] | None = None,
+    add_hosts: list[str] | None = None,
+    dns: list[str] | None = None,
+    env: list[str] | None = None,
+    init: bool = False,
+    interactive: bool = False,
+    replace: bool = True,
+) -> str:
+    """Create a container (``podman create``) and return its id.
+
+    ``publish`` is a list of ``(host_port, container_port)`` pairs.
+    ``replace=True`` uses ``--replace`` so an existing container with the
+    same name is removed first (the ``create_or_replace`` equivalent).
+    """
+    args = ["create", "--name", name]
+    if replace:
+        args.append("--replace")
+    if init:
+        args.append("--init")
+    if interactive:
+        args.append("-i")
+    for key, value in (labels or {}).items():
+        args += ["--label", f"{key}={value}"]
+    for bind in binds or []:
+        args += ["-v", bind]
+    for path, opts in (tmpfs or {}).items():
+        args += ["--tmpfs", f"{path}:{opts}"]
+    for host_port, container_port in publish or []:
+        args += ["-p", f"{host_port}:{container_port}"]
+    for host in add_hosts or []:
+        args += ["--add-host", host]
+    for server in dns or []:
+        args += ["--dns", server]
+    for entry in env or []:
+        args += ["-e", entry]
+    args.append(image)
+    _rc, out, _err = await _run(args)
+    return out.strip()
+
+
+async def start_container(container_id: str) -> None:
+    """Start a created container (``podman start``)."""
+    await _run(["start", container_id])
+
+
+async def remove_container(container_id: str, *, force: bool = True) -> None:
+    """Remove a container (``podman rm [-f]``); never raises on 404.
+
+    Matches the previous ``delete(force=True)`` callers, which treated a
+    missing container as already-removed.
+    """
+    args = ["rm"]
+    if force:
+        args.append("-f")
+    args.append(container_id)
+    rc, _out, err = await _run(args, check=False)
+    if rc != 0 and _classify(err) != 404:
+        raise PodmanError(_classify(err), err.strip() or "podman rm")
+
+
+async def list_containers(label: str) -> list[dict]:
+    """List containers matching ``label`` (``key=value``).
+
+    Each entry carries ``Id`` and ``Labels`` (podman includes labels in the
+    ``ps`` JSON, so no extra inspect is needed for adoption).
+    """
+    _rc, out, _err = await _run(
+        ["ps", "-a", "--filter", f"label={label}", "--format", "json"]
+    )
+    out = out.strip()
+    return json.loads(out) if out else []
+
+
+# --- Volumes ---
+
+
+async def inspect_volume(name: str) -> dict | None:
+    """Return a volume's inspect dict, or None if it does not exist."""
+    rc, out, _err = await _run(["volume", "inspect", name], check=False)
+    if rc != 0:
+        return None
+    data = json.loads(out)
+    return data[0] if data else None
+
+
+async def create_volume(
+    name: str, labels: dict[str, str] | None = None
+) -> dict:
+    """Create a labelled volume and return its inspect dict."""
+    args = ["volume", "create"]
+    for key, value in (labels or {}).items():
+        args += ["--label", f"{key}={value}"]
+    args.append(name)
+    await _run(args)
+    info = await inspect_volume(name)
+    if info is None:  # pragma: no cover - created then vanished
+        raise PodmanError(500, f"volume {name!r} vanished after create")
+    return info
+
+
+async def list_volumes(label: str) -> list[dict]:
+    """List volumes matching ``label`` (``key=value``)."""
+    _rc, out, _err = await _run(
+        ["volume", "ls", "--filter", f"label={label}", "--format", "json"]
+    )
+    out = out.strip()
+    return json.loads(out) if out else []
+
+
+async def remove_volume(name: str) -> None:
+    """Remove a volume (``podman volume rm``).
+
+    Raises :class:`PodmanError` with status 404 (no such volume) or 409
+    (in use) so the HTTP layer can map them to responses.
+    """
+    rc, _out, err = await _run(["volume", "rm", name], check=False)
+    if rc != 0:
+        raise PodmanError(_classify(err), err.strip() or "podman volume rm")

--- a/src/backend/klangk_backend/podman.py
+++ b/src/backend/klangk_backend/podman.py
@@ -17,6 +17,7 @@ The binary is configurable via ``KLANGK_PODMAN_BIN`` (defaults to
 import asyncio
 import json
 import logging
+import tempfile
 
 from . import util
 
@@ -58,18 +59,37 @@ async def _run(
     """Run ``podman <args>`` and return ``(returncode, stdout, stderr)``.
 
     When ``check`` is true a non-zero exit raises :class:`PodmanError`.
+
+    Output is captured to temp files rather than ``stdout=PIPE`` +
+    ``communicate()``. Lifecycle commands such as ``podman start --publish``
+    spawn a long-lived rootless network helper (``pasta``) that inherits the
+    child's stdout/stderr. Under uvloop (which uvicorn selects) that helper
+    keeps the inherited *pipe* write-end open for the container's lifetime,
+    so ``communicate()`` blocks forever waiting for an EOF that never comes.
+    A regular file has no such EOF dependency: the helper harmlessly inherits
+    a file fd and we read the output after the process exits.
     """
-    proc = await asyncio.create_subprocess_exec(
-        PODMAN_BIN,
-        *args,
-        stdin=(asyncio.subprocess.PIPE if stdin_data is not None else None),
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-    )
-    out_b, err_b = await proc.communicate(stdin_data)
+    with (
+        tempfile.TemporaryFile() as out_f,
+        tempfile.TemporaryFile() as err_f,
+    ):
+        proc = await asyncio.create_subprocess_exec(
+            PODMAN_BIN,
+            *args,
+            stdin=(asyncio.subprocess.PIPE if stdin_data is not None else None),
+            stdout=out_f,
+            stderr=err_f,
+        )
+        if stdin_data is not None:
+            proc.stdin.write(stdin_data)
+            await proc.stdin.drain()
+            proc.stdin.close()
+        await proc.wait()
+        out_f.seek(0)
+        err_f.seek(0)
+        out = out_f.read().decode("utf-8", errors="replace")
+        err = err_f.read().decode("utf-8", errors="replace")
     rc = proc.returncode or 0
-    out = out_b.decode("utf-8", errors="replace")
-    err = err_b.decode("utf-8", errors="replace")
     if check and rc != 0:
         raise PodmanError(_classify(err), err.strip() or f"podman {args[0]}")
     return rc, out, err

--- a/src/backend/klangk_backend/podman.py
+++ b/src/backend/klangk_backend/podman.py
@@ -113,8 +113,13 @@ async def create_container(
     ``publish`` is a list of ``(host_port, container_port)`` pairs.
     ``replace=True`` uses ``--replace`` so an existing container with the
     same name is removed first (the ``create_or_replace`` equivalent).
+
+    ``--pull=never`` is always passed: the deployment is network-restricted,
+    so the image must already be in the local store (or a configured
+    additional image store). This fails fast with a clear error instead of
+    attempting a registry pull.
     """
-    args = ["create", "--name", name]
+    args = ["create", "--pull=never", "--name", name]
     if replace:
         args.append("--replace")
     if init:

--- a/src/backend/klangk_backend/terminal.py
+++ b/src/backend/klangk_backend/terminal.py
@@ -1,30 +1,162 @@
-"""Terminal session: Docker API exec with single PTY for interactive shell."""
+"""Terminal session: an interactive shell via ``podman exec`` over a PTY.
+
+A single local PTY (slave set to raw mode) bridges the ``podman exec``
+subprocess's stdio to the container-side PTY allocated by ``-t``. Raw mode
+keeps the local line discipline from consuming escape sequences (arrow keys,
+etc.) -- the "double-PTY" problem that an interactive subprocess ``exec`` is
+otherwise prone to. Resize sets the master window size and signals podman
+with ``SIGWINCH`` so it re-reads the size and resizes the container PTY.
+
+The OS/subprocess glue lives in :class:`ShellProcess`; its methods need a
+real PTY and a real podman, so they are validated by interactive testing on
+Linux rather than unit tests (marked ``# pragma: no cover``).
+:class:`TerminalSession` holds the lifecycle/queue logic and is unit-tested
+against an injected fake shell.
+"""
 
 import asyncio
+import fcntl
 import logging
 import os
+import pty
+import signal
+import struct
+import termios
+import tty
 from collections.abc import AsyncGenerator
 
-import aiodocker
-import aiodocker.exceptions
-
+from . import podman
 from .util import BoundedOutputQueue
 
 logger = logging.getLogger(__name__)
 
+_READ_CHUNK = 65536
+
+# Backend env vars stripped from the in-container shell (defence in depth;
+# the container is not started with these, but never inherit them).
+_SENSITIVE_ENV_PREFIXES = (
+    "KLANGK_LLM_API_KEY",
+    "ANTHROPIC_",
+    "OPENAI_",
+    "GOOGLE_",
+    "GROQ_",
+    "MISTRAL_",
+)
+
+
+def _build_environment(
+    command_override: str | None, bridge_token: str | None
+) -> list[str]:
+    env = ["TERM=xterm-256color"]
+    if command_override is not None:
+        env.append(f"KLANGK_CMD_OVERRIDE={command_override}")
+    if bridge_token is not None:
+        env.append(f"KLANGK_BRIDGE_TOKEN={bridge_token}")
+    return env
+
+
+def _build_shell_command() -> list[str]:
+    unset_args: list[str] = []
+    for key in os.environ:
+        if key.startswith(_SENSITIVE_ENV_PREFIXES):
+            unset_args.extend(["-u", key])
+    return ["env", *unset_args, "/bin/bash"]
+
+
+def _build_exec_argv(
+    container_id: str, env: list[str], shell_cmd: list[str]
+) -> list[str]:
+    argv = ["exec", "-t", "-i", "-u", "klangk", "-w", "/home/klangk/work"]
+    for entry in env:
+        argv += ["-e", entry]
+    argv.append(container_id)
+    argv += shell_cmd
+    return argv
+
+
+class ShellProcess:
+    """Owns the PTY + ``podman exec`` subprocess for one shell.
+
+    Every method is a thin wrapper over OS / subprocess calls that require a
+    real PTY and a real podman, so they are exercised by interactive testing
+    on Linux rather than unit tests.
+    """
+
+    def __init__(self) -> None:
+        self._master_fd: int | None = None
+        self._proc: asyncio.subprocess.Process | None = None
+
+    async def start(  # pragma: no cover - needs a real PTY + podman
+        self, argv: list[str], rows: int, cols: int
+    ) -> None:
+        master_fd, slave_fd = pty.openpty()
+        try:
+            # Raw mode: pass bytes through untouched so the container PTY is
+            # the only one applying line discipline (no double-PTY).
+            tty.setraw(slave_fd)
+            _set_winsize(master_fd, rows, cols)
+            self._proc = await asyncio.create_subprocess_exec(
+                podman.PODMAN_BIN,
+                *argv,
+                stdin=slave_fd,
+                stdout=slave_fd,
+                stderr=slave_fd,
+                start_new_session=True,
+            )
+        finally:
+            os.close(slave_fd)
+        self._master_fd = master_fd
+
+    async def read(self) -> bytes:  # pragma: no cover - needs a real PTY
+        loop = asyncio.get_running_loop()
+        try:
+            return await loop.run_in_executor(
+                None, os.read, self._master_fd, _READ_CHUNK
+            )
+        except OSError:
+            # Slave closed (the shell exited) -> EIO on the master.
+            return b""
+
+    async def write(self, data: bytes) -> None:  # pragma: no cover
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, os.write, self._master_fd, data)
+
+    def resize(self, rows: int, cols: int) -> None:  # pragma: no cover
+        _set_winsize(self._master_fd, rows, cols)
+        if self._proc is not None:
+            # Make podman re-read its tty size and resize the container PTY.
+            os.kill(self._proc.pid, signal.SIGWINCH)
+
+    def close(self) -> None:  # pragma: no cover
+        if self._proc is not None and self._proc.returncode is None:
+            try:
+                self._proc.kill()
+            except ProcessLookupError:
+                pass
+        if self._master_fd is not None:
+            try:
+                os.close(self._master_fd)
+            except OSError:
+                pass
+            self._master_fd = None
+
+
+def _set_winsize(  # pragma: no cover - needs a real fd
+    fd: int, rows: int, cols: int
+) -> None:
+    fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", rows, cols, 0, 0))
+
+
+def _make_shell_process() -> ShellProcess:
+    return ShellProcess()
+
 
 class TerminalSession:
-    """Manages a Docker exec shell session via the Docker API.
-
-    Uses aiodocker's exec API to create a single PTY connection,
-    avoiding the double-PTY issue that occurs with `docker exec -it`
-    as a subprocess (which consumed ESC bytes from arrow key sequences).
-    """
+    """Manages an interactive shell session over a PTY."""
 
     def __init__(self, container_id: str):
         self.container_id = container_id
-        self._stream: aiodocker.stream.Stream | None = None
-        self._exec: aiodocker.execs.Exec | None = None
+        self._shell: ShellProcess | None = None
         self._output_queue: BoundedOutputQueue[str] = BoundedOutputQueue(
             maxsize=64
         )
@@ -38,92 +170,33 @@ class TerminalSession:
         command_override: str | None = None,
         bridge_token: str | None = None,
     ) -> None:
-        """Start a shell session via Docker API exec."""
+        """Start a shell session via ``podman exec`` over a PTY."""
         self._running = True
+        env = _build_environment(command_override, bridge_token)
+        shell_cmd = _build_shell_command()
+        argv = _build_exec_argv(self.container_id, env, shell_cmd)
 
-        # Build environment for the exec
-        env = ["TERM=xterm-256color"]
-        if command_override is not None:
-            env.append(f"KLANGK_CMD_OVERRIDE={command_override}")
-        if bridge_token is not None:
-            env.append(f"KLANGK_BRIDGE_TOKEN={bridge_token}")
-
-        # Build the command: env -u KEY ... /bin/bash
-        # Strip sensitive env vars from the terminal session.
-        unset_args = []
-        for key in os.environ:
-            if key.startswith(
-                (
-                    "KLANGK_LLM_API_KEY",
-                    "ANTHROPIC_",
-                    "OPENAI_",
-                    "GOOGLE_",
-                    "GROQ_",
-                    "MISTRAL_",
-                )
-            ):
-                unset_args.extend(["-u", key])
-        cmd = ["env", *unset_args, "/bin/bash"]
-
-        # Create and start exec via Docker API (single PTY)
-        docker = aiodocker.Docker()
+        shell = _make_shell_process()
         try:
-            container = await docker.containers.get(self.container_id)
-            self._exec = await container.exec(
-                cmd,
-                tty=True,
-                stdin=True,
-                stdout=True,
-                stderr=True,
-                user="klangk",
-                workdir="/home/klangk/work",
-                environment=env,
-            )
-            self._stream = self._exec.start()
-            logger.info(
-                "Exec created for container %s, exec_id=%s",
-                self.container_id,
-                self._exec._id,
-            )
-
-            # Do the first read to establish the WebSocket connection,
-            # then resize. The stream connects lazily on first I/O.
-            first_msg = await self._stream.read_out()
-            if first_msg is not None:
-                logger.info(
-                    "First read OK (%d bytes), exec_id=%s",
-                    len(first_msg.data),
-                    self._exec._id,
-                )
-                await self._output_queue.put(
-                    first_msg.data.decode("utf-8", errors="replace")
-                )
-            else:
-                logger.info(
-                    "First read returned None (exec exited?), exec_id=%s",
-                    self._exec._id,
-                )
-
-            await self._exec.resize(h=rows, w=cols)
+            await shell.start(argv, rows, cols)
         except Exception:
-            await docker.close()
+            self._running = False
             raise
 
-        self._docker = docker
+        self._shell = shell
         self._read_task = asyncio.create_task(self._read_loop())
-
         logger.info(
             "Terminal session started for container %s", self.container_id
         )
 
     async def _read_loop(self) -> None:
-        """Read output from the Docker exec stream."""
+        """Read PTY output and queue it as text."""
         try:
-            while self._running and self._stream is not None:
-                msg = await self._stream.read_out()
-                if msg is None:
+            while self._running and self._shell is not None:
+                data = await self._shell.read()
+                if not data:
                     break
-                text = msg.data.decode("utf-8", errors="replace")
+                text = data.decode("utf-8", errors="replace")
                 if text:
                     # Bounded queue: blocks when full, back-pressuring the
                     # PTY via its kernel buffer.
@@ -137,7 +210,7 @@ class TerminalSession:
 
     @property
     def is_alive(self) -> bool:
-        if self._exec is None:
+        if self._shell is None:
             return False
         if self._read_task is not None and self._read_task.done():
             return False
@@ -145,24 +218,18 @@ class TerminalSession:
 
     async def write(self, data: str) -> None:
         """Write user input to the terminal."""
-        if self._stream is not None:
+        if self._shell is not None:
             try:
-                await self._stream.write_in(data.encode("utf-8"))
-            except (
-                aiodocker.exceptions.DockerError,
-                OSError,
-            ):
-                logger.debug("Write to terminal stream failed", exc_info=True)
+                await self._shell.write(data.encode("utf-8"))
+            except OSError:
+                logger.debug("Write to terminal failed", exc_info=True)
 
     async def resize(self, cols: int, rows: int) -> None:
         """Resize the terminal."""
-        if self._exec is not None:
+        if self._shell is not None:
             try:
-                await self._exec.resize(h=rows, w=cols)
-            except (
-                aiodocker.exceptions.DockerError,
-                OSError,
-            ):
+                self._shell.resize(rows, cols)
+            except OSError:
                 logger.debug("Terminal resize failed", exc_info=True)
 
     async def output(self) -> AsyncGenerator[str, None]:
@@ -195,27 +262,12 @@ class TerminalSession:
                 logger.exception("Error awaiting terminal read task")
             self._read_task = None
 
-        if self._stream is not None:
+        if self._shell is not None:
             try:
-                await self._stream.close()
-            except (
-                aiodocker.exceptions.DockerError,
-                OSError,
-            ):
-                logger.debug("Error closing terminal stream", exc_info=True)
-            self._stream = None
-
-        if hasattr(self, "_docker") and self._docker is not None:
-            try:
-                await self._docker.close()
-            except (
-                aiodocker.exceptions.DockerError,
-                OSError,
-            ):
-                logger.debug("Error closing Docker client", exc_info=True)
-            self._docker = None
-
-        self._exec = None
+                self._shell.close()
+            except OSError:
+                logger.debug("Error closing terminal shell", exc_info=True)
+            self._shell = None
 
         logger.info(
             "Terminal session stopped for container %s", self.container_id

--- a/src/backend/klangk_backend/wshandler.py
+++ b/src/backend/klangk_backend/wshandler.py
@@ -826,18 +826,19 @@ class Connection:
 
 async def handle_websocket(websocket: WebSocket) -> None:
     """Main WebSocket handler."""
-    # Authenticate via query param
+    # Authenticate via query param — accept before close (WebSocket protocol
+    # requires a completed handshake before a close frame can be sent).
     token = websocket.query_params.get("token")
+    user = await auth.get_user_from_token(token) if token else None
+
+    await websocket.accept()
+
     if not token:
         await websocket.close(code=4001, reason="Missing token")
         return
-
-    user = await auth.get_user_from_token(token)
     if user is None:
         await websocket.close(code=4001, reason="Invalid token")
         return
-
-    await websocket.accept()
     safe_ws = SafeWebSocket(websocket)
     safe_ws.start_sender()
     conn = Connection(safe_ws, user)

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "pytest-asyncio>=0.24.0",
     "pytest-cov>=6.0.0",
     "pytest-xdist>=3.0.0",
+    "ruff>=0.6.0",
 ]
 
 [tool.pytest.ini_options]

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -7,7 +7,6 @@ dependencies = [
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.32.0",
     "websockets>=14.0",
-    "aiodocker>=0.23.0",
     "aiosqlite>=0.20.0",
     "bcrypt>=4.0.0",
     "python-jose[cryptography]>=3.3.0",

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -17,6 +17,7 @@ from klangk_backend import (
     auth,
     container,
     model,
+    podman,
     workspaces as ws_mod,
     wshandler,
 )
@@ -1116,28 +1117,30 @@ class TestBrowserBridge:
 # --- Volume routes ---
 
 
+def _managed_volume():
+    """An inspect_volume result owned by this klangk instance."""
+    return {
+        "Labels": {
+            "klangk.managed": "true",
+            "klangk.instance": container.INSTANCE_ID,
+        }
+    }
+
+
 class TestVolumeRoutes:
     async def test_list_volumes(self, client, user):
         headers = await _auth_headers(client)
         with patch.object(
-            container.registry,
-            "get_docker",
-            return_value=MagicMock(
-                volumes=MagicMock(
-                    list=AsyncMock(
-                        return_value={
-                            "Volumes": [
-                                {
-                                    "Name": "test-vol",
-                                    "CreatedAt": "2026-01-01T00:00:00Z",
-                                    "Labels": {
-                                        "klangk.instance": container.INSTANCE_ID
-                                    },
-                                }
-                            ]
-                        }
-                    )
-                )
+            podman,
+            "list_volumes",
+            AsyncMock(
+                return_value=[
+                    {
+                        "Name": "test-vol",
+                        "CreatedAt": "2026-01-01T00:00:00Z",
+                        "Labels": {"klangk.instance": container.INSTANCE_ID},
+                    }
+                ]
             ),
         ):
             resp = await client.get("/volumes", headers=headers)
@@ -1148,20 +1151,20 @@ class TestVolumeRoutes:
 
     async def test_create_volume(self, client, user):
         headers = await _auth_headers(client)
-        mock_vol = MagicMock()
-        mock_vol.show = AsyncMock(
-            return_value={"Name": "new-vol", "CreatedAt": "2026-01-01"}
-        )
-        mock_docker = MagicMock()
-        mock_docker.volumes = MagicMock()
-        mock_docker.volumes.get = AsyncMock(
-            side_effect=container.aiodocker.exceptions.DockerError(
-                404, {"message": "not found"}
-            )
-        )
-        mock_docker.volumes.create = AsyncMock(return_value=mock_vol)
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
+        with (
+            patch.object(
+                podman, "inspect_volume", AsyncMock(return_value=None)
+            ),
+            patch.object(
+                podman,
+                "create_volume",
+                AsyncMock(
+                    return_value={
+                        "Name": "new-vol",
+                        "CreatedAt": "2026-01-01",
+                    }
+                ),
+            ),
         ):
             resp = await client.post(
                 "/volumes",
@@ -1173,13 +1176,10 @@ class TestVolumeRoutes:
 
     async def test_create_duplicate_volume(self, client, user):
         headers = await _auth_headers(client)
-        mock_vol = MagicMock()
-        mock_vol.show = AsyncMock(return_value={"Name": "dup-vol"})
-        mock_docker = MagicMock()
-        mock_docker.volumes = MagicMock()
-        mock_docker.volumes.get = AsyncMock(return_value=mock_vol)
         with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
+            podman,
+            "inspect_volume",
+            AsyncMock(return_value={"Name": "dup-vol"}),
         ):
             resp = await client.post(
                 "/volumes",
@@ -1188,71 +1188,18 @@ class TestVolumeRoutes:
             )
         assert resp.status_code == 409
 
-    async def test_delete_volume(self, client, user):
+    async def test_create_volume_error_propagates(self, client, user):
         headers = await _auth_headers(client)
-        mock_vol = MagicMock()
-        mock_vol.show = AsyncMock(
-            return_value={
-                "Labels": {
-                    "klangk.managed": "true",
-                    "klangk.instance": container.INSTANCE_ID,
-                }
-            }
-        )
-        mock_vol.delete = AsyncMock()
-        mock_docker = MagicMock()
-        mock_docker.volumes = MagicMock()
-        mock_docker.volumes.get = AsyncMock(return_value=mock_vol)
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
-            resp = await client.delete("/volumes/test-vol", headers=headers)
-        assert resp.status_code == 200
-
-    async def test_delete_volume_not_found(self, client, user):
-        headers = await _auth_headers(client)
-        mock_docker = MagicMock()
-        mock_docker.volumes = MagicMock()
-        mock_docker.volumes.get = AsyncMock(
-            side_effect=container.aiodocker.exceptions.DockerError(
-                404, {"message": "not found"}
-            )
-        )
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
-            resp = await client.delete("/volumes/nope", headers=headers)
-        assert resp.status_code == 404
-
-    async def test_delete_volume_wrong_instance(self, client, user):
-        headers = await _auth_headers(client)
-        mock_vol = MagicMock()
-        mock_vol.show = AsyncMock(
-            return_value={"Labels": {"klangk.instance": "other-instance"}}
-        )
-        mock_docker = MagicMock()
-        mock_docker.volumes = MagicMock()
-        mock_docker.volumes.get = AsyncMock(return_value=mock_vol)
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
-            resp = await client.delete("/volumes/foreign", headers=headers)
-        assert resp.status_code == 404
-
-    async def test_create_volume_docker_error(self, client, user):
-        headers = await _auth_headers(client)
-        mock_docker = MagicMock()
-        mock_docker.volumes = MagicMock()
-        mock_docker.volumes.get = AsyncMock(
-            side_effect=container.aiodocker.exceptions.DockerError(
-                500, {"message": "internal error"}
-            )
-        )
         with (
             patch.object(
-                container.registry, "get_docker", return_value=mock_docker
+                podman, "inspect_volume", AsyncMock(return_value=None)
             ),
-            pytest.raises(container.aiodocker.exceptions.DockerError),
+            patch.object(
+                podman,
+                "create_volume",
+                AsyncMock(side_effect=podman.PodmanError(500, "boom")),
+            ),
+            pytest.raises(podman.PodmanError),
         ):
             await client.post(
                 "/volumes",
@@ -1260,54 +1207,85 @@ class TestVolumeRoutes:
                 headers=headers,
             )
 
-    async def test_delete_volume_docker_error(self, client, user):
+    async def test_delete_volume(self, client, user):
         headers = await _auth_headers(client)
-        mock_vol = MagicMock()
-        mock_vol.show = AsyncMock(
-            return_value={
-                "Labels": {
-                    "klangk.managed": "true",
-                    "klangk.instance": container.INSTANCE_ID,
-                }
-            }
-        )
-        mock_vol.delete = AsyncMock(
-            side_effect=container.aiodocker.exceptions.DockerError(
-                500, {"message": "internal error"}
-            )
-        )
-        mock_docker = MagicMock()
-        mock_docker.volumes = MagicMock()
-        mock_docker.volumes.get = AsyncMock(return_value=mock_vol)
         with (
             patch.object(
-                container.registry, "get_docker", return_value=mock_docker
+                podman,
+                "inspect_volume",
+                AsyncMock(return_value=_managed_volume()),
             ),
-            pytest.raises(container.aiodocker.exceptions.DockerError),
+            patch.object(podman, "remove_volume", AsyncMock()),
+        ):
+            resp = await client.delete("/volumes/test-vol", headers=headers)
+        assert resp.status_code == 200
+
+    async def test_delete_volume_not_found(self, client, user):
+        headers = await _auth_headers(client)
+        with patch.object(
+            podman, "inspect_volume", AsyncMock(return_value=None)
+        ):
+            resp = await client.delete("/volumes/nope", headers=headers)
+        assert resp.status_code == 404
+
+    async def test_delete_volume_wrong_instance(self, client, user):
+        headers = await _auth_headers(client)
+        with patch.object(
+            podman,
+            "inspect_volume",
+            AsyncMock(return_value={"Labels": {"klangk.instance": "other"}}),
+        ):
+            resp = await client.delete("/volumes/foreign", headers=headers)
+        assert resp.status_code == 404
+
+    async def test_delete_volume_remove_not_found(self, client, user):
+        """Volume vanishes between inspect and remove → 404."""
+        headers = await _auth_headers(client)
+        with (
+            patch.object(
+                podman,
+                "inspect_volume",
+                AsyncMock(return_value=_managed_volume()),
+            ),
+            patch.object(
+                podman,
+                "remove_volume",
+                AsyncMock(side_effect=podman.PodmanError(404, "gone")),
+            ),
+        ):
+            resp = await client.delete("/volumes/gone", headers=headers)
+        assert resp.status_code == 404
+
+    async def test_delete_volume_other_error(self, client, user):
+        headers = await _auth_headers(client)
+        with (
+            patch.object(
+                podman,
+                "inspect_volume",
+                AsyncMock(return_value=_managed_volume()),
+            ),
+            patch.object(
+                podman,
+                "remove_volume",
+                AsyncMock(side_effect=podman.PodmanError(500, "internal")),
+            ),
+            pytest.raises(podman.PodmanError),
         ):
             await client.delete("/volumes/err-vol", headers=headers)
 
     async def test_delete_volume_in_use(self, client, user):
         headers = await _auth_headers(client)
-        mock_vol = MagicMock()
-        mock_vol.show = AsyncMock(
-            return_value={
-                "Labels": {
-                    "klangk.managed": "true",
-                    "klangk.instance": container.INSTANCE_ID,
-                }
-            }
-        )
-        mock_vol.delete = AsyncMock(
-            side_effect=container.aiodocker.exceptions.DockerError(
-                409, {"message": "in use"}
-            )
-        )
-        mock_docker = MagicMock()
-        mock_docker.volumes = MagicMock()
-        mock_docker.volumes.get = AsyncMock(return_value=mock_vol)
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
+        with (
+            patch.object(
+                podman,
+                "inspect_volume",
+                AsyncMock(return_value=_managed_volume()),
+            ),
+            patch.object(
+                podman,
+                "remove_volume",
+                AsyncMock(side_effect=podman.PodmanError(409, "in use")),
+            ),
         ):
             resp = await client.delete("/volumes/busy", headers=headers)
         assert resp.status_code == 409

--- a/src/backend/tests/test_cli.py
+++ b/src/backend/tests/test_cli.py
@@ -678,9 +678,7 @@ class TestRunShell:
                 "klangk_backend.cli.client.select.select",
                 return_value=([99], [], []),
             ),
-            patch(
-                "klangk_backend.cli.client.os.read", return_value=b""
-            ),
+            patch("klangk_backend.cli.client.os.read", return_value=b""),
         ):
             task = asyncio.create_task(
                 _run_shell(ws, 80, 24, stdin=fake_buf, stdout=fake_stdout)

--- a/src/backend/tests/test_cli.py
+++ b/src/backend/tests/test_cli.py
@@ -668,11 +668,19 @@ class TestRunShell:
                 pass
 
         fake_buf = BytesIO(b"")
-        fake_buf.fileno = lambda: 0
+        fake_buf.fileno = lambda: 99
         fake_stdout = CaptureWriter()
-        with patch(
-            "klangk_backend.cli.client.select.select",
-            return_value=([0], [], []),
+        # Patch os.read alongside select so stdin_loop sees EOF and exits
+        # instead of blocking on the real stdin fd (which hangs serial runs
+        # where stdin is an interactive tty).
+        with (
+            patch(
+                "klangk_backend.cli.client.select.select",
+                return_value=([99], [], []),
+            ),
+            patch(
+                "klangk_backend.cli.client.os.read", return_value=b""
+            ),
         ):
             task = asyncio.create_task(
                 _run_shell(ws, 80, 24, stdin=fake_buf, stdout=fake_stdout)

--- a/src/backend/tests/test_cli_integration.py
+++ b/src/backend/tests/test_cli_integration.py
@@ -237,11 +237,19 @@ class TestRunShell:
         )
 
         fake_stdin = MagicMock()
-        fake_stdin.fileno = MagicMock(return_value=0)
-        fake_stdin.read = MagicMock(side_effect=BrokenPipeError)
-        with patch(
-            "klangk_backend.cli.client.select.select",
-            return_value=([0], [], []),
+        fake_stdin.fileno = MagicMock(return_value=99)
+        # stdin_loop reads via os.read(fd, ...), not stdin.read(); patch it
+        # to raise BrokenPipeError so the OSError handler runs instead of
+        # blocking on the real stdin fd.
+        with (
+            patch(
+                "klangk_backend.cli.client.select.select",
+                return_value=([99], [], []),
+            ),
+            patch(
+                "klangk_backend.cli.client.os.read",
+                side_effect=BrokenPipeError,
+            ),
         ):
             task = asyncio.create_task(
                 _run_shell(ws, 80, 24, stdin=fake_stdin)

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -298,6 +298,99 @@ class TestStartContainer:
         p.start_container.assert_awaited_once_with("new-cid")
         assert workspace["id"] in container.registry.states
 
+    async def test_container_id_persisted_before_start(self, workspace, user):
+        # If `start` fails, the id created just before it must already be on
+        # record so the next connect can inspect/recreate it rather than
+        # orphaning a created-but-unrecorded container.
+        with patch_podman(
+            start_container=AsyncMock(side_effect=RuntimeError("boom"))
+        ):
+            with pytest.raises(RuntimeError, match="boom"):
+                await container.registry.start_container(
+                    workspace["id"], "/tmp/ws", "/tmp/home"
+                )
+        ws = await model.get_workspace(workspace["id"], user["id"])
+        assert ws["container_id"] == "new-cid"
+        assert workspace["id"] in container.registry.states
+
+    async def test_cancel_during_start_still_persists(self, workspace, user):
+        # The connecting client can disconnect mid-startup, cancelling this
+        # coroutine. The shield must let create+persist+start finish so a
+        # running container is never orphaned with a NULL container_id.
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def slow_start(_cid):
+            started.set()
+            await release.wait()
+
+        with patch_podman(
+            start_container=AsyncMock(side_effect=slow_start)
+        ) as p:
+            task = asyncio.create_task(
+                container.registry.start_container(
+                    workspace["id"], "/tmp/ws", "/tmp/home"
+                )
+            )
+            await started.wait()
+            task.cancel()  # client disconnects mid-startup
+            release.set()  # let the shielded inner run to completion
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        # Despite the cancel, the container was started and recorded.
+        ws = await model.get_workspace(workspace["id"], user["id"])
+        assert ws["container_id"] == "new-cid"
+        p.start_container.assert_awaited_once_with("new-cid")
+        assert workspace["id"] in container.registry.states
+
+    async def test_adopts_running_orphan_when_db_has_no_id(
+        self, workspace, user
+    ):
+        # No container_id on record but a running container exists for the
+        # workspace (e.g. a prior connect cancelled before persisting). Adopt
+        # it instead of `--replace`-ing a running container, which hangs.
+        with patch_podman(
+            list_containers=AsyncMock(return_value=[{"Id": "orphan-cid"}]),
+            inspect_container=_running(True),
+        ) as p:
+            cid, status = await container.registry.start_container(
+                workspace["id"], "/tmp/ws", "/tmp/home"
+            )
+        assert cid == "orphan-cid"
+        assert status == "connected"
+        p.create_container.assert_not_awaited()
+        ws = await model.get_workspace(workspace["id"], user["id"])
+        assert ws["container_id"] == "orphan-cid"
+        assert workspace["id"] in container.registry.states
+
+    async def test_removes_stopped_orphan_when_db_has_no_id(self, workspace):
+        # A stopped orphan can't be adopted — remove it and create fresh.
+        with patch_podman(
+            list_containers=AsyncMock(return_value=[{"Id": "orphan-cid"}]),
+            inspect_container=_running(False),
+        ) as p:
+            cid, status = await container.registry.start_container(
+                workspace["id"], "/tmp/ws", "/tmp/home"
+            )
+        assert cid == "new-cid"
+        assert status == "created"
+        p.remove_container.assert_awaited_once_with("orphan-cid")
+        p.create_container.assert_awaited_once()
+
+    async def test_orphan_vanished_between_list_and_inspect(self, workspace):
+        # Listed orphan is gone by the time we inspect it → create fresh.
+        with patch_podman(
+            list_containers=AsyncMock(return_value=[{"Id": "orphan-cid"}]),
+            inspect_container=AsyncMock(return_value=None),
+        ) as p:
+            cid, status = await container.registry.start_container(
+                workspace["id"], "/tmp/ws", "/tmp/home"
+            )
+        assert cid == "new-cid"
+        assert status == "created"
+        p.remove_container.assert_not_awaited()
+
     async def test_ssh_agent_forwarded_when_socket_exists(
         self, workspace, monkeypatch, tmp_path
     ):

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -2,12 +2,13 @@
 
 import asyncio
 import time
-from unittest.mock import AsyncMock, MagicMock, patch
+from contextlib import ExitStack, contextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
 
-import aiodocker.exceptions
 import pytest
 
-from klangk_backend import container, model
+from klangk_backend import container, model, podman
 
 
 class TestParseIdleTimeout:
@@ -232,24 +233,34 @@ class TestConstants:
 # --- Docker-dependent tests (mocked) ---
 
 
-def _mock_docker():
-    """Create a mock Docker client with containers namespace."""
-    docker = AsyncMock()
-    docker.containers = AsyncMock()
-    docker.close = AsyncMock()
-    return docker
+@contextmanager
+def patch_podman(**overrides):
+    """Patch the podman.* calls container.py makes.
+
+    Yields a namespace of the AsyncMocks so tests can assert on them.
+    Override any default by passing ``name=AsyncMock(...)``.
+    """
+    defaults = {
+        "inspect_container": AsyncMock(return_value=None),
+        "create_container": AsyncMock(return_value="new-cid"),
+        "start_container": AsyncMock(),
+        "remove_container": AsyncMock(),
+        "list_containers": AsyncMock(return_value=[]),
+        "inspect_volume": AsyncMock(return_value=None),
+        "create_volume": AsyncMock(
+            return_value={"Name": "v", "CreatedAt": ""}
+        ),
+    }
+    mocks = {**defaults, **overrides}
+    with ExitStack() as stack:
+        for name, mock in mocks.items():
+            stack.enter_context(patch.object(podman, name, mock))
+        yield SimpleNamespace(**mocks)
 
 
-def _mock_container(container_id="fake-cid", running=True):
-    """Create a mock container object."""
-    c = AsyncMock()
-    c.id = container_id
-    c.show = AsyncMock(return_value={"State": {"Running": running}})
-    c.start = AsyncMock()
-    c.stop = AsyncMock()
-    c.delete = AsyncMock()
-    c.attach = MagicMock(return_value=AsyncMock())
-    return c
+def _running(value=True):
+    """An inspect_container mock returning a container in the given state."""
+    return AsyncMock(return_value={"State": {"Running": value}})
 
 
 class TestStartContainer:
@@ -260,15 +271,7 @@ class TestStartContainer:
         container.registry.states.clear()
 
     async def test_create_new_container(self, workspace):
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("new-cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=mock_c
-        )
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             cid, status = await container.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -276,7 +279,7 @@ class TestStartContainer:
             )
         assert cid == "new-cid"
         assert status == "created"
-        mock_c.start.assert_awaited_once()
+        p.start_container.assert_awaited_once_with("new-cid")
         assert workspace["id"] in container.registry.states
 
     async def test_ssh_agent_forwarded_when_socket_exists(
@@ -285,54 +288,30 @@ class TestStartContainer:
         sock = tmp_path / "agent.sock"
         sock.touch()
         monkeypatch.setenv("SSH_AUTH_SOCK", str(sock))
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("new-cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=mock_c
-        )
 
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             await container.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
-        call_kwargs = mock_docker.containers.create_or_replace.call_args
-        env_list = call_kwargs[1]["config"]["Env"]
-        binds = call_kwargs[1]["config"]["HostConfig"]["Binds"]
-        assert "SSH_AUTH_SOCK=/run/ssh-agent.sock" in env_list
-        assert f"{sock}:/run/ssh-agent.sock:ro" in binds
+        kwargs = p.create_container.call_args.kwargs
+        assert "SSH_AUTH_SOCK=/run/ssh-agent.sock" in kwargs["env"]
+        assert f"{sock}:/run/ssh-agent.sock:ro" in kwargs["binds"]
 
     async def test_ssh_agent_not_forwarded_when_unset(
         self, workspace, monkeypatch
     ):
         monkeypatch.delenv("SSH_AUTH_SOCK", raising=False)
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("new-cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=mock_c
-        )
 
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             await container.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
-        call_kwargs = mock_docker.containers.create_or_replace.call_args
-        env_list = call_kwargs[1]["config"]["Env"]
-        binds = call_kwargs[1]["config"]["HostConfig"]["Binds"]
-        assert "SSH_AUTH_SOCK=/run/ssh-agent.sock" not in env_list
-        assert not any("ssh-agent" in b for b in binds)
+        kwargs = p.create_container.call_args.kwargs
+        assert "SSH_AUTH_SOCK=/run/ssh-agent.sock" not in kwargs["env"]
+        assert not any("ssh-agent" in b for b in kwargs["binds"])
 
     async def test_reuse_running_container(self, workspace):
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("existing-cid", running=True)
-        mock_docker.containers.get = AsyncMock(return_value=mock_c)
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman(inspect_container=_running(True)) as p:
             cid, status = await container.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -341,20 +320,11 @@ class TestStartContainer:
             )
         assert cid == "existing-cid"
         assert status == "connected"
-        mock_c.start.assert_not_awaited()
+        p.start_container.assert_not_awaited()
+        p.create_container.assert_not_awaited()
 
     async def test_recreate_stopped_container(self, workspace):
-        mock_docker = _mock_docker()
-        stopped_c = _mock_container("old-cid", running=False)
-        mock_docker.containers.get = AsyncMock(return_value=stopped_c)
-        new_c = _mock_container("new-cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=new_c
-        )
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman(inspect_container=_running(False)) as p:
             cid, status = await container.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -363,21 +333,11 @@ class TestStartContainer:
             )
         assert cid == "new-cid"
         assert status == "created"
-        stopped_c.delete.assert_awaited_once_with(force=True)
+        p.remove_container.assert_awaited_once_with("old-cid")
 
     async def test_missing_container_creates_new(self, workspace):
-        mock_docker = _mock_docker()
-        mock_docker.containers.get = AsyncMock(
-            side_effect=aiodocker.exceptions.DockerError(404, "not found")
-        )
-        new_c = _mock_container("new-cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=new_c
-        )
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        # inspect_container returns None (default) → treated as gone.
+        with patch_podman() as p:
             cid, status = await container.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -386,6 +346,7 @@ class TestStartContainer:
             )
         assert cid == "new-cid"
         assert status == "created"
+        p.remove_container.assert_not_awaited()
 
     async def test_disallowed_image_raises(self, workspace):
         with pytest.raises(ValueError, match="not in the allowed list"):
@@ -397,22 +358,15 @@ class TestStartContainer:
         """Container gets proxy URL, not real API keys."""
         monkeypatch.setenv("KLANGK_LLM_MODEL", "gemma4:31b")
         monkeypatch.setenv("KLANGK_NGINX_PORT", "8995")
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=mock_c
-        )
 
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             await container.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
             )
-        call_kwargs = mock_docker.containers.create_or_replace.call_args
-        env = call_kwargs[1]["config"]["Env"]
+        kwargs = p.create_container.call_args.kwargs
+        env = kwargs["env"]
         env_dict = dict(e.split("=", 1) for e in env)
         assert env_dict["KLANGK_LLM_PROXY_URL"] == (
             "http://host.docker.internal:8995/llm-proxy"
@@ -422,60 +376,33 @@ class TestStartContainer:
         assert not any(e.startswith("KLANGK_LLM_API_KEY=") for e in env)
         assert not any(e.startswith("ANTHROPIC_API_KEY=") for e in env)
         # host.docker.internal must be resolvable
-        host_config = call_kwargs[1]["config"]["HostConfig"]
-        assert "host.docker.internal:host-gateway" in host_config["ExtraHosts"]
+        assert "host.docker.internal:host-gateway" in kwargs["add_hosts"]
 
     async def test_config_mount_added(self, workspace):
         """Container gets read-only config mount when config_path is set."""
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=mock_c
-        )
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             await container.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
                 config_path="/tmp/config",
             )
-        call_kwargs = mock_docker.containers.create_or_replace.call_args
-        binds = call_kwargs[1]["config"]["HostConfig"]["Binds"]
+        binds = p.create_container.call_args.kwargs["binds"]
         assert "/tmp/config:/opt/klangk/config:ro" in binds
 
     async def test_no_config_mount_without_config_path(self, workspace):
         """Container has no config mount when config_path is not set."""
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=mock_c
-        )
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             await container.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
             )
-        call_kwargs = mock_docker.containers.create_or_replace.call_args
-        binds = call_kwargs[1]["config"]["HostConfig"]["Binds"]
+        binds = p.create_container.call_args.kwargs["binds"]
         assert not any("config" in b for b in binds)
 
     async def test_hosting_env_vars(self, workspace):
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=mock_c
-        )
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             await container.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -484,22 +411,13 @@ class TestStartContainer:
                 hosting_proto="https",
                 hosting_base_path="/klangk",
             )
-        call_kwargs = mock_docker.containers.create_or_replace.call_args
-        env = call_kwargs[1]["config"]["Env"]
+        env = p.create_container.call_args.kwargs["env"]
         assert "KLANGK_HOSTING_HOSTNAME=example.com" in env
         assert "KLANGK_HOSTING_PROTO=https" in env
         assert "KLANGK_HOSTING_BASE_PATH=/klangk" in env
 
     async def test_port_allocation_on_create(self, workspace):
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=mock_c
-        )
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman():
             await container.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -515,15 +433,7 @@ class TestStartContainer:
         await model.find_and_allocate_ports(
             workspace["id"], 5, container.PORT_RANGE_START
         )
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=mock_c
-        )
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman():
             await container.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -534,47 +444,28 @@ class TestStartContainer:
         assert len(ports) == 2
 
     async def test_container_config_structure(self, workspace):
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=mock_c
-        )
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             await container.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
             )
-        call_kwargs = mock_docker.containers.create_or_replace.call_args
-        config = call_kwargs[1]["config"]
-        assert config["Image"] == container.IMAGE_NAME
-        assert config["Labels"]["klangk.managed"] == "true"
-        assert config["Labels"]["klangk.workspace-id"] == workspace["id"]
-        assert config["HostConfig"]["ReadonlyRootfs"] is False
-        assert config["HostConfig"]["Init"] is True
-        assert config["OpenStdin"] is True
+        args, kwargs = p.create_container.call_args
+        assert args[1] == container.IMAGE_NAME
+        assert kwargs["labels"]["klangk.managed"] == "true"
+        assert kwargs["labels"]["klangk.workspace-id"] == workspace["id"]
+        assert kwargs["init"] is True
+        assert kwargs["interactive"] is True
 
     async def test_create_container_with_extra_env(self, workspace):
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("new-cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=mock_c
-        )
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             await container.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
                 extra_env={"KLANGK_SKILLS": "stats,rdkit", "FOO": "bar"},
             )
-        call_kwargs = mock_docker.containers.create_or_replace.call_args
-        env_list = call_kwargs[1]["config"]["Env"]
+        env_list = p.create_container.call_args.kwargs["env"]
         env_dict = dict(e.split("=", 1) for e in env_list)
         assert env_dict["KLANGK_SKILLS"] == "stats,rdkit"
         assert env_dict["FOO"] == "bar"
@@ -630,166 +521,87 @@ class TestValidateMountSpec:
 class TestExtraMountsVolumeCreation:
     async def test_auto_creates_named_volume(self, workspace):
         """Named volumes (no leading /) are auto-created with klangk labels."""
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=mock_c
-        )
-        mock_vol = MagicMock()
-        mock_vol.show = AsyncMock(return_value={"Name": "nix-store"})
-        mock_docker.volumes.get = AsyncMock(
-            side_effect=container.aiodocker.exceptions.DockerError(
-                404, {"message": "not found"}
-            )
-        )
-        mock_docker.volumes.create = AsyncMock(return_value=mock_vol)
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        # inspect_volume returns None (default) → volume is created.
+        with patch_podman() as p:
             await container.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
                 extra_mounts=["nix-store:/nix"],
             )
-        mock_docker.volumes.create.assert_awaited_once()
-        create_args = mock_docker.volumes.create.call_args[0][0]
-        assert create_args["Name"] == "nix-store"
-        assert create_args["Labels"]["klangk.managed"] == "true"
-        assert (
-            create_args["Labels"]["klangk.instance"] == container.INSTANCE_ID
-        )
+        p.create_volume.assert_awaited_once()
+        name, labels = p.create_volume.call_args.args
+        assert name == "nix-store"
+        assert labels["klangk.managed"] == "true"
+        assert labels["klangk.instance"] == container.INSTANCE_ID
 
     async def test_existing_volume_not_recreated(self, workspace):
         """Existing volumes are used as-is, not recreated."""
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=mock_c
-        )
-        mock_vol = MagicMock()
-        mock_vol.show = AsyncMock(return_value={"Name": "existing"})
-        mock_docker.volumes.get = AsyncMock(return_value=mock_vol)
-        mock_docker.volumes.create = AsyncMock()
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman(
+            inspect_volume=AsyncMock(return_value={"Name": "existing"})
+        ) as p:
             await container.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
                 extra_mounts=["existing:/data"],
             )
-        mock_docker.volumes.create.assert_not_awaited()
+        p.create_volume.assert_not_awaited()
 
     async def test_bind_mount_not_treated_as_volume(self, workspace):
         """Bind mounts (starting with /) are not treated as volumes."""
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=mock_c
-        )
-        mock_docker.volumes.get = AsyncMock()
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             await container.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
                 extra_mounts=["/home/me/src:/work/src"],
             )
-        mock_docker.volumes.get.assert_not_awaited()
+        p.inspect_volume.assert_not_awaited()
 
     async def test_mount_with_multiple_colons(self, workspace):
         """Mount spec with options (host:container:ro) — source starts with /."""
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=mock_c
-        )
-        mock_docker.volumes.get = AsyncMock()
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             await container.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
                 extra_mounts=["/data/shared:/mnt/data:ro"],
             )
-        # Bind mount, not a volume — volumes.get should not be called
-        mock_docker.volumes.get.assert_not_awaited()
+        # Bind mount, not a volume — inspect_volume should not be called
+        p.inspect_volume.assert_not_awaited()
 
     async def test_volume_mount_with_options(self, workspace):
         """Named volume with options (vol:container:ro) — auto-creates."""
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=mock_c
-        )
-        mock_vol = MagicMock()
-        mock_vol.show = AsyncMock(return_value={"Name": "my-vol"})
-        mock_docker.volumes.get = AsyncMock(
-            side_effect=container.aiodocker.exceptions.DockerError(
-                404, {"message": "not found"}
-            )
-        )
-        mock_docker.volumes.create = AsyncMock(return_value=mock_vol)
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             await container.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
                 extra_mounts=["my-vol:/data:ro"],
             )
-        mock_docker.volumes.create.assert_awaited_once()
+        p.create_volume.assert_awaited_once()
 
     async def test_mount_source_with_slash_is_bind(self, workspace):
         """A mount source containing slashes is a bind mount, not a volume."""
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=mock_c
-        )
-        mock_docker.volumes.get = AsyncMock()
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             await container.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
                 extra_mounts=["./relative/path:/work/rel"],
             )
-        mock_docker.volumes.get.assert_not_awaited()
+        p.inspect_volume.assert_not_awaited()
 
-    async def test_volume_auto_create_docker_error(self, workspace):
-        """Non-404 Docker error during volume check is re-raised."""
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=mock_c
-        )
-        mock_docker.volumes.get = AsyncMock(
-            side_effect=container.aiodocker.exceptions.DockerError(
-                500, {"message": "internal error"}
-            )
-        )
-
+    async def test_volume_create_error_propagates(self, workspace):
+        """An error creating a named volume propagates to the caller."""
         with (
-            patch.object(
-                container.registry, "get_docker", return_value=mock_docker
+            patch_podman(
+                create_volume=AsyncMock(
+                    side_effect=podman.PodmanError(500, "internal error")
+                )
             ),
-            pytest.raises(container.aiodocker.exceptions.DockerError),
+            pytest.raises(podman.PodmanError),
         ):
             await container.registry.start_container(
                 workspace["id"],
@@ -800,16 +612,7 @@ class TestExtraMountsVolumeCreation:
 
     async def test_mount_source_with_special_characters(self, workspace):
         """Mount source with special/binary-like chars is a bind mount."""
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=mock_c
-        )
-        mock_docker.volumes.get = AsyncMock()
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             await container.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -817,20 +620,17 @@ class TestExtraMountsVolumeCreation:
                 extra_mounts=["/path/with spaces\x00and\x01binary:/work/bad"],
             )
         # Has leading /, so treated as bind mount
-        mock_docker.volumes.get.assert_not_awaited()
+        p.inspect_volume.assert_not_awaited()
 
     async def test_bridge_token_revoked_on_creation_failure(self, workspace):
-        """If container creation fails, the bridge token is revoked."""
-        mock_docker = _mock_docker()
-        mock_docker.containers.create_or_replace = AsyncMock(
-            side_effect=RuntimeError("docker broke")
-        )
-
+        """If container creation fails, the error propagates cleanly."""
         with (
-            patch.object(
-                container.registry, "get_docker", return_value=mock_docker
+            patch_podman(
+                create_container=AsyncMock(
+                    side_effect=RuntimeError("podman broke")
+                )
             ),
-            pytest.raises(RuntimeError, match="docker broke"),
+            pytest.raises(RuntimeError, match="podman broke"),
         ):
             await container.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
@@ -849,27 +649,20 @@ class TestStopContainer:
         container.registry.states.clear()
 
     async def test_stop_running(self):
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.get = AsyncMock(return_value=mock_c)
         container.registry.track_activity("cid", "ws")
 
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             await container.registry.stop_and_remove_container("cid")
-        mock_c.delete.assert_awaited()
+        p.remove_container.assert_awaited_once_with("cid")
         assert "ws" not in container.registry.states
 
     async def test_stop_docker_error(self):
-        mock_docker = _mock_docker()
-        mock_docker.containers.get = AsyncMock(
-            side_effect=aiodocker.exceptions.DockerError(404, "gone")
-        )
         container.registry.track_activity("cid", "ws")
 
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
+        with patch_podman(
+            remove_container=AsyncMock(
+                side_effect=podman.PodmanError(404, "gone")
+            )
         ):
             await container.registry.stop_and_remove_container("cid")
         # Should still remove from tracking
@@ -884,28 +677,20 @@ class TestRemoveContainer:
         container.registry.states.clear()
 
     async def test_remove(self):
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.get = AsyncMock(return_value=mock_c)
         container.registry.track_activity("cid", "ws")
 
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             await container.registry.stop_and_remove_container("cid")
-        mock_c.delete.assert_awaited()
-        mock_c.delete.assert_awaited_once_with(force=True)
+        p.remove_container.assert_awaited_once_with("cid")
         assert "ws" not in container.registry.states
 
     async def test_remove_docker_error(self):
-        mock_docker = _mock_docker()
-        mock_docker.containers.get = AsyncMock(
-            side_effect=aiodocker.exceptions.DockerError(404, "gone")
-        )
         container.registry.track_activity("cid", "ws")
 
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
+        with patch_podman(
+            remove_container=AsyncMock(
+                side_effect=podman.PodmanError(404, "gone")
+            )
         ):
             await container.registry.stop_and_remove_container("cid")
         assert "ws" not in container.registry.states
@@ -919,26 +704,16 @@ class TestStopUserContainers:
         container.registry.states.clear()
 
     async def test_stop_user_containers(self, user, workspace):
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.get = AsyncMock(return_value=mock_c)
-
         # Set container_id on the workspace
         await model.update_workspace_container(workspace["id"], "cid")
         container.registry.track_activity("cid", workspace["id"])
 
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             await container.registry.stop_user_containers(user["id"])
-        mock_c.delete.assert_awaited()
+        p.remove_container.assert_awaited_once_with("cid")
         assert workspace["id"] not in container.registry.states
 
     async def test_stop_user_calls_workspace_killed(self, user, workspace):
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.get = AsyncMock(return_value=mock_c)
-
         await model.update_workspace_container(workspace["id"], "cid")
         container.registry.track_activity("cid", workspace["id"])
 
@@ -946,33 +721,28 @@ class TestStopUserContainers:
         old_cb = container.registry.on_workspace_killed
         container.registry.on_workspace_killed = killed_cb
 
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman():
             await container.registry.stop_user_containers(user["id"])
 
         killed_cb.assert_awaited_once_with(workspace["id"])
         container.registry.on_workspace_killed = old_cb
 
     async def test_stop_user_no_containers(self, user):
-        mock_docker = _mock_docker()
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             await container.registry.stop_user_containers(user["id"])
-        mock_docker.containers.get.assert_not_awaited()
+        p.remove_container.assert_not_awaited()
 
 
 class TestShutdown:
     def setup_method(self):
         container.registry.states.clear()
+        container.registry._cid_to_wsid.clear()
         container.registry.cleanup_task = None
-        container.registry.docker = None
 
     def teardown_method(self):
         container.registry.states.clear()
+        container.registry._cid_to_wsid.clear()
         container.registry.cleanup_task = None
-        container.registry.docker = None
 
     async def test_shutdown_skips_in_docker(self):
         """When running inside a container, shutdown skips cleanup."""
@@ -983,40 +753,25 @@ class TestShutdown:
         assert "ws" in container.registry.states
 
     async def test_shutdown_stops_tracked(self):
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.get = AsyncMock(return_value=mock_c)
-        mock_docker.containers.list = AsyncMock(return_value=[])
+        # list_containers returns the tracked cid; it should be skipped in
+        # the orphan loop (already tracked) but still removed via tracking.
         container.registry.track_activity("cid", "ws")
 
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
-            container.registry.docker = mock_docker
+        with patch_podman(
+            list_containers=AsyncMock(return_value=[{"Id": "cid"}])
+        ) as p:
             await container.registry.shutdown()
-        mock_c.delete.assert_awaited()
+        p.remove_container.assert_awaited_once_with("cid")
         assert "ws" not in container.registry.states
-        mock_docker.close.assert_awaited_once()
 
     async def test_shutdown_stops_orphans(self):
-        mock_docker = _mock_docker()
-        orphan = _mock_container("orphan-cid")
-        mock_docker.containers.list = AsyncMock(return_value=[orphan])
-        mock_docker.containers.get = AsyncMock(
-            return_value=_mock_container("x")
-        )
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
-            container.registry.docker = mock_docker
+        with patch_podman(
+            list_containers=AsyncMock(return_value=[{"Id": "orphan-cid"}])
+        ) as p:
             await container.registry.shutdown()
-        orphan.delete.assert_awaited_once()
+        p.remove_container.assert_awaited_once_with("orphan-cid")
 
     async def test_shutdown_cancels_cleanup_task(self):
-        mock_docker = _mock_docker()
-        mock_docker.containers.list = AsyncMock(return_value=[])
-
         # Create a real cancellable task so shutdown can await it.
         async def fake_cleanup():
             await asyncio.sleep(999)
@@ -1024,55 +779,36 @@ class TestShutdown:
         task = asyncio.create_task(fake_cleanup())
         container.registry.cleanup_task = task
 
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
-            container.registry.docker = mock_docker
+        with patch_podman():
             await container.registry.shutdown()
         assert task.cancelled()
         assert container.registry.cleanup_task is None
 
     async def test_shutdown_handles_docker_error(self):
-        mock_docker = _mock_docker()
-        mock_docker.containers.list = AsyncMock(
-            side_effect=OSError("Docker connection refused")
-        )
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
+        with patch_podman(
+            list_containers=AsyncMock(
+                side_effect=OSError("Docker connection refused")
+            )
         ):
-            container.registry.docker = mock_docker
             await container.registry.shutdown()
         # Should not raise
-        mock_docker.close.assert_awaited_once()
 
     async def test_shutdown_no_docker(self):
-        container.registry.docker = None
-        mock_docker = _mock_docker()
-        mock_docker.containers.list = AsyncMock(return_value=[])
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman():
             await container.registry.shutdown()
         assert container.registry.cleanup_task is None
 
-    async def test_shutdown_orphan_delete_error(self):
-        """Orphan container that raises on delete is handled gracefully."""
-        mock_docker = _mock_docker()
-        orphan = _mock_container("orphan-cid")
-        orphan.delete = AsyncMock(
-            side_effect=aiodocker.exceptions.DockerError(500, "delete failed")
-        )
-        mock_docker.containers.list = AsyncMock(return_value=[orphan])
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
-            container.registry.docker = mock_docker
+    async def test_shutdown_orphan_remove_error(self):
+        """Orphan container that errors on removal is handled gracefully."""
+        with patch_podman(
+            list_containers=AsyncMock(return_value=[{"Id": "orphan-cid"}]),
+            remove_container=AsyncMock(
+                side_effect=podman.PodmanError(500, "remove failed")
+            ),
+        ) as p:
             await container.registry.shutdown()
-        # Should have attempted to delete and not raised
-        orphan.delete.assert_awaited_once()
-        mock_docker.close.assert_awaited_once()
+        # Attempted removal and did not raise
+        p.remove_container.assert_awaited_once_with("orphan-cid")
 
 
 class TestCleanupIdleContainers:
@@ -1085,19 +821,13 @@ class TestCleanupIdleContainers:
         container.registry._cleanup_wake = None
 
     async def test_idle_container_stopped(self):
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.get = AsyncMock(return_value=mock_c)
-
         # Set activity far in the past
         container.registry.track_activity("cid", "ws-1")
         container.registry.states["ws-1"].last_activity = (
             time.time() - container.IDLE_TIMEOUT_SECONDS - 100
         )
 
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             task = asyncio.create_task(
                 container.registry.cleanup_idle_containers()
             )
@@ -1110,14 +840,10 @@ class TestCleanupIdleContainers:
                 await task
             except asyncio.CancelledError:
                 pass
-        mock_c.delete.assert_awaited()
+        p.remove_container.assert_awaited()
         assert "ws-1" not in container.registry.states
 
     async def test_idle_calls_workspace_killed_callback(self):
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.get = AsyncMock(return_value=mock_c)
-
         container.registry.track_activity("cid", "ws-killed")
         container.registry.states["ws-killed"].last_activity = (
             time.time() - container.IDLE_TIMEOUT_SECONDS - 100
@@ -1127,9 +853,7 @@ class TestCleanupIdleContainers:
         old_cb = container.registry.on_workspace_killed
         container.registry.on_workspace_killed = killed_cb
 
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman():
             task = asyncio.create_task(
                 container.registry.cleanup_idle_containers()
             )
@@ -1146,10 +870,6 @@ class TestCleanupIdleContainers:
         container.registry.on_workspace_killed = old_cb
 
     async def test_idle_workspace_killed_callback_error(self):
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.get = AsyncMock(return_value=mock_c)
-
         container.registry.track_activity("cid", "ws-err")
         container.registry.states["ws-err"].last_activity = (
             time.time() - container.IDLE_TIMEOUT_SECONDS - 100
@@ -1159,9 +879,7 @@ class TestCleanupIdleContainers:
         old_cb = container.registry.on_workspace_killed
         container.registry.on_workspace_killed = killed_cb
 
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman():
             task = asyncio.create_task(
                 container.registry.cleanup_idle_containers()
             )
@@ -1179,13 +897,9 @@ class TestCleanupIdleContainers:
         container.registry.on_workspace_killed = old_cb
 
     async def test_active_container_not_stopped(self):
-        mock_docker = _mock_docker()
-
         container.registry.track_activity("cid", "ws-1")
 
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman():
             task = asyncio.create_task(
                 container.registry.cleanup_idle_containers()
             )
@@ -1201,10 +915,6 @@ class TestCleanupIdleContainers:
         assert "ws-1" in container.registry.states
 
     async def test_idle_callback_invoked(self):
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.get = AsyncMock(return_value=mock_c)
-
         container.registry.track_activity("cid", "ws-1")
         container.registry.states["ws-1"].last_activity = (
             time.time() - container.IDLE_TIMEOUT_SECONDS - 100
@@ -1217,9 +927,7 @@ class TestCleanupIdleContainers:
 
         container.registry.on_idle_stop("ws-1", on_idle)
 
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman():
             task = asyncio.create_task(
                 container.registry.cleanup_idle_containers()
             )
@@ -1234,10 +942,6 @@ class TestCleanupIdleContainers:
         assert callback_called == ["ws-1"]
 
     async def test_idle_callback_error_handled(self):
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.get = AsyncMock(return_value=mock_c)
-
         container.registry.track_activity("cid", "ws-1")
         container.registry.states["ws-1"].last_activity = (
             time.time() - container.IDLE_TIMEOUT_SECONDS - 100
@@ -1248,9 +952,7 @@ class TestCleanupIdleContainers:
 
         container.registry.on_idle_stop("ws-1", bad_callback)
 
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             task = asyncio.create_task(
                 container.registry.cleanup_idle_containers()
             )
@@ -1263,24 +965,16 @@ class TestCleanupIdleContainers:
             except asyncio.CancelledError:
                 pass
         # Container should still be stopped despite callback error
-        mock_c.delete.assert_awaited()
+        p.remove_container.assert_awaited()
 
     async def test_per_workspace_timeout_uses_event_wait(self):
         """When per-workspace timeouts exist, cleanup uses Event-based wait."""
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.get = AsyncMock(return_value=mock_c)
-
         container.registry.track_activity("cid", "ws-fast")
         container.registry.states["ws-fast"].last_activity = time.time() - 100
         container.registry.states["ws-fast"].idle_timeout = 5
 
         try:
-            with patch.object(
-                container.registry,
-                "get_docker",
-                return_value=mock_docker,
-            ):
+            with patch_podman() as p:
                 # The Event-based wait will timeout after max(2, 5//2)=2s,
                 # then check containers. We cancel after one iteration.
                 task = asyncio.create_task(
@@ -1295,26 +989,18 @@ class TestCleanupIdleContainers:
                     await task
                 except asyncio.CancelledError:
                     pass
-            mock_c.delete.assert_awaited()
+            p.remove_container.assert_awaited()
         finally:
             container.registry.states.clear()
 
     async def test_per_workspace_timeout_event_timeout(self):
         """Event-based wait times out when no wake signal is sent."""
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.get = AsyncMock(return_value=mock_c)
-
         container.registry.track_activity("cid", "ws-fast")
         container.registry.states["ws-fast"].last_activity = time.time() - 100
         container.registry.states["ws-fast"].idle_timeout = 4
 
         try:
-            with patch.object(
-                container.registry,
-                "get_docker",
-                return_value=mock_docker,
-            ):
+            with patch_podman() as p:
                 # Patch wait_for to immediately raise TimeoutError (simulates
                 # the event not being set within the interval)
                 async def fast_timeout(coro, timeout):
@@ -1340,7 +1026,7 @@ class TestCleanupIdleContainers:
                         await container.registry.cleanup_idle_containers()
                     except asyncio.CancelledError:
                         pass
-            mock_c.delete.assert_awaited()
+            p.remove_container.assert_awaited()
         finally:
             container.registry.states.clear()
 
@@ -1375,17 +1061,15 @@ class TestAdoptOrphanedContainers:
         container.registry.states.clear()
 
     async def test_adopts_running_containers(self):
-        mock_container = MagicMock()
-        mock_container.id = "orphan-123"
-        mock_container.show = AsyncMock(
-            return_value={
-                "Config": {"Labels": {"klangk.workspace-id": "ws-orphan"}}
-            }
-        )
-        mock_docker = AsyncMock()
-        mock_docker.containers.list = AsyncMock(return_value=[mock_container])
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
+        with patch_podman(
+            list_containers=AsyncMock(
+                return_value=[
+                    {
+                        "Id": "orphan-123",
+                        "Labels": {"klangk.workspace-id": "ws-orphan"},
+                    }
+                ]
+            )
         ):
             await container.registry.adopt_orphaned_containers()
         assert "ws-orphan" in container.registry.states
@@ -1393,28 +1077,34 @@ class TestAdoptOrphanedContainers:
             container.registry.states["ws-orphan"].container_id == "orphan-123"
         )
 
-    async def test_skips_already_tracked(self):
-        container.registry.track_activity("tracked-456", "ws-tracked")
-        mock_container = MagicMock()
-        mock_container.id = "tracked-456"
-        mock_docker = AsyncMock()
-        mock_docker.containers.list = AsyncMock(return_value=[mock_container])
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
+    async def test_adopts_orphan_without_labels(self):
+        # A container with no labels gets the "unknown" workspace id.
+        with patch_podman(
+            list_containers=AsyncMock(
+                return_value=[{"Id": "orphan-x", "Labels": None}]
+            )
         ):
             await container.registry.adopt_orphaned_containers()
-        # Should not have called show() since it's already tracked
-        mock_container.show.assert_not_called()
+        assert container.registry.states["unknown"].container_id == "orphan-x"
+
+    async def test_skips_already_tracked(self):
+        container.registry.track_activity("tracked-456", "ws-tracked")
+        with patch_podman(
+            list_containers=AsyncMock(return_value=[{"Id": "tracked-456"}])
+        ):
+            await container.registry.adopt_orphaned_containers()
+        # Already tracked → not re-adopted, no "unknown" entry created.
+        assert (
+            container.registry.states["ws-tracked"].container_id
+            == "tracked-456"
+        )
+        assert "unknown" not in container.registry.states
 
     async def test_docker_error_handled(self):
-        mock_docker = AsyncMock()
-        mock_docker.containers.list = AsyncMock(
-            side_effect=aiodocker.exceptions.DockerError(
-                "err", {"message": "fail"}
+        with patch_podman(
+            list_containers=AsyncMock(
+                side_effect=podman.PodmanError(500, "fail")
             )
-        )
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
         ):
             await container.registry.adopt_orphaned_containers()
         # Should not raise

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -42,6 +42,22 @@ class TestParseIdleTimeout:
         assert interval == 60  # clamped to max 60
 
 
+class TestImagePullPolicy:
+    def test_default_is_never(self, monkeypatch):
+        monkeypatch.delenv("KLANGK_IMAGE_PULL_POLICY", raising=False)
+        assert container.image_pull_policy() == "never"
+
+    def test_valid_override(self, monkeypatch):
+        monkeypatch.setenv("KLANGK_IMAGE_PULL_POLICY", "missing")
+        assert container.image_pull_policy() == "missing"
+
+    def test_invalid_falls_back_to_never(self, monkeypatch, caplog):
+        monkeypatch.setenv("KLANGK_IMAGE_PULL_POLICY", "sometimes")
+        with caplog.at_level("WARNING"):
+            assert container.image_pull_policy() == "never"
+        assert "Invalid KLANGK_IMAGE_PULL_POLICY" in caplog.text
+
+
 class TestActivityTracking:
     def setup_method(self):
         container.registry.states.clear()
@@ -372,11 +388,50 @@ class TestStartContainer:
             "http://host.docker.internal:8995/llm-proxy"
         )
         assert env_dict["KLANGK_LLM_MODEL"] == "gemma4:31b"
+        assert (
+            env_dict["KLANGK_BRIDGE_URL"] == "http://host.docker.internal:8995"
+        )
         # API keys should NOT be in the container env
         assert not any(e.startswith("KLANGK_LLM_API_KEY=") for e in env)
         assert not any(e.startswith("ANTHROPIC_API_KEY=") for e in env)
         # host.docker.internal must be resolvable
         assert "host.docker.internal:host-gateway" in kwargs["add_hosts"]
+
+    async def test_host_gateway_override(self, workspace, monkeypatch):
+        """KLANGK_HOST_GATEWAY reparents the proxy/bridge URLs + add-host."""
+        monkeypatch.setenv("KLANGK_NGINX_PORT", "8995")
+        monkeypatch.setenv("KLANGK_HOST_GATEWAY", "host.containers.internal")
+
+        with patch_podman() as p:
+            await container.registry.start_container(
+                workspace["id"],
+                "/tmp/ws",
+                "/tmp/home",
+            )
+        kwargs = p.create_container.call_args.kwargs
+        env_dict = dict(e.split("=", 1) for e in kwargs["env"])
+        assert env_dict["KLANGK_LLM_PROXY_URL"] == (
+            "http://host.containers.internal:8995/llm-proxy"
+        )
+        assert env_dict["KLANGK_BRIDGE_URL"] == (
+            "http://host.containers.internal:8995"
+        )
+        assert "host.containers.internal:host-gateway" in kwargs["add_hosts"]
+
+    async def test_pull_policy_default_never(self, workspace):
+        with patch_podman() as p:
+            await container.registry.start_container(
+                workspace["id"], "/tmp/ws", "/tmp/home"
+            )
+        assert p.create_container.call_args.kwargs["pull"] == "never"
+
+    async def test_pull_policy_from_env(self, workspace, monkeypatch):
+        monkeypatch.setenv("KLANGK_IMAGE_PULL_POLICY", "missing")
+        with patch_podman() as p:
+            await container.registry.start_container(
+                workspace["id"], "/tmp/ws", "/tmp/home"
+            )
+        assert p.create_container.call_args.kwargs["pull"] == "missing"
 
     async def test_config_mount_added(self, workspace):
         """Container gets read-only config mount when config_path is set."""

--- a/src/backend/tests/test_podman.py
+++ b/src/backend/tests/test_podman.py
@@ -11,21 +11,43 @@ EXEC = "klangk_backend.podman.asyncio.create_subprocess_exec"
 
 
 def _procs(*results):
-    """Build fake subprocess objects, one per (stdout, stderr, rc)."""
+    """Build fake subprocess objects, one per (stdout, stderr, rc).
+
+    ``_run`` reads output from the temp files it passes as stdout/stderr and
+    awaits ``proc.wait()`` (not ``communicate()``), so each fake carries its
+    canned bytes for ``_exec`` to write into those files.
+    """
     out = []
     for stdout, stderr, rc in results:
         p = MagicMock()
         p.returncode = rc
-        p.communicate = AsyncMock(
-            return_value=(stdout.encode(), stderr.encode())
-        )
+        p._canned = (stdout.encode(), stderr.encode())
+        p.wait = AsyncMock(return_value=rc)
+        p.stdin = MagicMock()
+        p.stdin.drain = AsyncMock()
         out.append(p)
     return out
 
 
 def _exec(*results):
-    """An AsyncMock standing in for create_subprocess_exec."""
-    return AsyncMock(side_effect=_procs(*results))
+    """An AsyncMock standing in for create_subprocess_exec.
+
+    Writes each fake's canned output into the temp files ``_run`` passes as
+    ``stdout``/``stderr`` so the wrapper reads them back as real output.
+    """
+    procs = iter(_procs(*results))
+
+    def side_effect(*args, **kwargs):
+        p = next(procs)
+        out_b, err_b = p._canned
+        stdout_f, stderr_f = kwargs.get("stdout"), kwargs.get("stderr")
+        if hasattr(stdout_f, "write"):
+            stdout_f.write(out_b)
+        if hasattr(stderr_f, "write"):
+            stderr_f.write(err_b)
+        return p
+
+    return AsyncMock(side_effect=side_effect)
 
 
 def _args(mock_exec, call_index=0):
@@ -88,7 +110,8 @@ class TestRun:
         with patch(EXEC, AsyncMock(return_value=proc)) as m:
             await podman._run(["x"], stdin_data=b"payload")
         assert m.call_args.kwargs["stdin"] is not None
-        assert proc.communicate.await_args.args == (b"payload",)
+        proc.stdin.write.assert_called_once_with(b"payload")
+        proc.stdin.close.assert_called_once()
 
     async def test_returncode_none_treated_as_zero(self):
         with patch(EXEC, _exec(("ok", "", None))):

--- a/src/backend/tests/test_podman.py
+++ b/src/backend/tests/test_podman.py
@@ -1,0 +1,287 @@
+"""Tests for the podman CLI wrapper."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from klangk_backend import podman
+
+EXEC = "klangk_backend.podman.asyncio.create_subprocess_exec"
+
+
+def _procs(*results):
+    """Build fake subprocess objects, one per (stdout, stderr, rc)."""
+    out = []
+    for stdout, stderr, rc in results:
+        p = MagicMock()
+        p.returncode = rc
+        p.communicate = AsyncMock(
+            return_value=(stdout.encode(), stderr.encode())
+        )
+        out.append(p)
+    return out
+
+
+def _exec(*results):
+    """An AsyncMock standing in for create_subprocess_exec."""
+    return AsyncMock(side_effect=_procs(*results))
+
+
+def _args(mock_exec, call_index=0):
+    """The podman args (sans binary) from the Nth create_subprocess_exec."""
+    return list(mock_exec.call_args_list[call_index].args[1:])
+
+
+# --- _classify ---
+
+
+class TestClassify:
+    @pytest.mark.parametrize(
+        "stderr,expected",
+        [
+            ("Error: no such container foo", 404),
+            ("layer not found", 404),
+            ("no container with name", 404),
+            ("volume is being used by a container", 409),
+            ("volume already in use", 409),
+            ("Error: name is in use", 409),
+            ("something else broke", 500),
+        ],
+    )
+    def test_classify(self, stderr, expected):
+        assert podman._classify(stderr) == expected
+
+
+# --- _run ---
+
+
+class TestRun:
+    async def test_success(self):
+        with patch(EXEC, _exec(("hello\n", "", 0))) as m:
+            rc, out, err = await podman._run(["version"])
+        assert (rc, out, err) == (0, "hello\n", "")
+        assert m.call_args.args[0] == podman.PODMAN_BIN
+        assert m.call_args.kwargs["stdin"] is None
+
+    async def test_check_raises_with_classified_status(self):
+        with patch(EXEC, _exec(("", "no such container x", 1))):
+            with pytest.raises(podman.PodmanError) as exc:
+                await podman._run(["start", "x"])
+        assert exc.value.status == 404
+        assert "no such container" in exc.value.message
+
+    async def test_check_raises_empty_stderr_fallback(self):
+        with patch(EXEC, _exec(("", "", 5))):
+            with pytest.raises(podman.PodmanError) as exc:
+                await podman._run(["boom"])
+        assert exc.value.status == 500
+        assert exc.value.message == "podman boom"
+
+    async def test_no_check_returns_nonzero(self):
+        with patch(EXEC, _exec(("", "bad", 2))):
+            rc, out, err = await podman._run(["x"], check=False)
+        assert rc == 2
+
+    async def test_stdin_data_uses_pipe(self):
+        proc = _procs(("", "", 0))[0]
+        with patch(EXEC, AsyncMock(return_value=proc)) as m:
+            await podman._run(["x"], stdin_data=b"payload")
+        assert m.call_args.kwargs["stdin"] is not None
+        assert proc.communicate.await_args.args == (b"payload",)
+
+    async def test_returncode_none_treated_as_zero(self):
+        with patch(EXEC, _exec(("ok", "", None))):
+            rc, _out, _err = await podman._run(["x"], check=False)
+        assert rc == 0
+
+
+# --- containers ---
+
+
+class TestInspectContainer:
+    async def test_missing_returns_none(self):
+        with patch(EXEC, _exec(("", "no such container", 1))):
+            assert await podman.inspect_container("c") is None
+
+    async def test_found_returns_first(self):
+        payload = json.dumps([{"State": {"Running": True}}])
+        with patch(EXEC, _exec((payload, "", 0))):
+            info = await podman.inspect_container("c")
+        assert info["State"]["Running"] is True
+
+    async def test_empty_list_returns_none(self):
+        with patch(EXEC, _exec(("[]", "", 0))):
+            assert await podman.inspect_container("c") is None
+
+
+class TestCreateContainer:
+    async def test_minimal(self):
+        with patch(EXEC, _exec(("abc123\n", "", 0))) as m:
+            cid = await podman.create_container("n", "img", replace=False)
+        assert cid == "abc123"
+        assert _args(m) == ["create", "--name", "n", "img"]
+
+    async def test_all_flags(self):
+        with patch(EXEC, _exec(("id\n", "", 0))) as m:
+            await podman.create_container(
+                "n",
+                "img",
+                labels={"a": "1"},
+                binds=["/h:/c"],
+                tmpfs={"/tmp": "rw,size=2g"},
+                publish=[(9000, 8000)],
+                add_hosts=["host.docker.internal:host-gateway"],
+                dns=["8.8.8.8"],
+                env=["K=V"],
+                init=True,
+                interactive=True,
+                replace=True,
+            )
+        args = _args(m)
+        assert "--replace" in args
+        assert "--init" in args
+        assert "-i" in args
+        assert ["--label", "a=1"] == args[
+            args.index("--label") : args.index("--label") + 2
+        ]
+        assert ["-v", "/h:/c"] == args[args.index("-v") : args.index("-v") + 2]
+        assert ["--tmpfs", "/tmp:rw,size=2g"] == args[
+            args.index("--tmpfs") : args.index("--tmpfs") + 2
+        ]
+        assert ["-p", "9000:8000"] == args[
+            args.index("-p") : args.index("-p") + 2
+        ]
+        assert ["--add-host", "host.docker.internal:host-gateway"] == args[
+            args.index("--add-host") : args.index("--add-host") + 2
+        ]
+        assert ["--dns", "8.8.8.8"] == args[
+            args.index("--dns") : args.index("--dns") + 2
+        ]
+        assert ["-e", "K=V"] == args[args.index("-e") : args.index("-e") + 2]
+        assert args[-1] == "img"
+
+
+class TestStartContainer:
+    async def test_start(self):
+        with patch(EXEC, _exec(("", "", 0))) as m:
+            await podman.start_container("cid")
+        assert _args(m) == ["start", "cid"]
+
+
+class TestRemoveContainer:
+    async def test_force_default(self):
+        with patch(EXEC, _exec(("", "", 0))) as m:
+            await podman.remove_container("cid")
+        assert _args(m) == ["rm", "-f", "cid"]
+
+    async def test_no_force(self):
+        with patch(EXEC, _exec(("", "", 0))) as m:
+            await podman.remove_container("cid", force=False)
+        assert _args(m) == ["rm", "cid"]
+
+    async def test_missing_is_ignored(self):
+        with patch(EXEC, _exec(("", "no such container", 1))):
+            await podman.remove_container("cid")  # no raise
+
+    async def test_other_error_raises(self):
+        with patch(EXEC, _exec(("", "in use", 1))):
+            with pytest.raises(podman.PodmanError) as exc:
+                await podman.remove_container("cid")
+        assert exc.value.status == 409
+
+    async def test_other_error_empty_stderr_fallback(self):
+        with patch(EXEC, _exec(("", "", 1))):
+            with pytest.raises(podman.PodmanError) as exc:
+                await podman.remove_container("cid")
+        assert exc.value.message == "podman rm"
+
+
+class TestListContainers:
+    async def test_parses_json(self):
+        payload = json.dumps([{"Id": "a", "Labels": {"k": "v"}}])
+        with patch(EXEC, _exec((payload, "", 0))) as m:
+            result = await podman.list_containers("k=v")
+        assert result[0]["Id"] == "a"
+        assert _args(m) == [
+            "ps",
+            "-a",
+            "--filter",
+            "label=k=v",
+            "--format",
+            "json",
+        ]
+
+    async def test_empty_output(self):
+        with patch(EXEC, _exec(("  \n", "", 0))):
+            assert await podman.list_containers("k=v") == []
+
+
+# --- volumes ---
+
+
+class TestInspectVolume:
+    async def test_missing(self):
+        with patch(EXEC, _exec(("", "no such volume", 1))):
+            assert await podman.inspect_volume("v") is None
+
+    async def test_found(self):
+        payload = json.dumps([{"Name": "v", "CreatedAt": "now"}])
+        with patch(EXEC, _exec((payload, "", 0))):
+            info = await podman.inspect_volume("v")
+        assert info["Name"] == "v"
+
+    async def test_empty_list(self):
+        with patch(EXEC, _exec(("[]", "", 0))):
+            assert await podman.inspect_volume("v") is None
+
+
+class TestCreateVolume:
+    async def test_with_labels(self):
+        info = json.dumps([{"Name": "v", "CreatedAt": "t"}])
+        with patch(EXEC, _exec(("v\n", "", 0), (info, "", 0))) as m:
+            result = await podman.create_volume("v", {"a": "1"})
+        assert result["Name"] == "v"
+        assert ["--label", "a=1"] == _args(m, 0)[2:4]
+
+    async def test_without_labels(self):
+        info = json.dumps([{"Name": "v", "CreatedAt": "t"}])
+        with patch(EXEC, _exec(("v\n", "", 0), (info, "", 0))) as m:
+            await podman.create_volume("v")
+        assert _args(m, 0) == ["volume", "create", "v"]
+
+
+class TestListVolumes:
+    async def test_parses(self):
+        payload = json.dumps([{"Name": "v"}])
+        with patch(EXEC, _exec((payload, "", 0))):
+            assert (await podman.list_volumes("k=v"))[0]["Name"] == "v"
+
+    async def test_empty(self):
+        with patch(EXEC, _exec(("", "", 0))):
+            assert await podman.list_volumes("k=v") == []
+
+
+class TestRemoveVolume:
+    async def test_success(self):
+        with patch(EXEC, _exec(("", "", 0))) as m:
+            await podman.remove_volume("v")
+        assert _args(m) == ["volume", "rm", "v"]
+
+    async def test_not_found(self):
+        with patch(EXEC, _exec(("", "no such volume", 1))):
+            with pytest.raises(podman.PodmanError) as exc:
+                await podman.remove_volume("v")
+        assert exc.value.status == 404
+
+    async def test_in_use(self):
+        with patch(EXEC, _exec(("", "volume is being used", 1))):
+            with pytest.raises(podman.PodmanError) as exc:
+                await podman.remove_volume("v")
+        assert exc.value.status == 409
+
+    async def test_empty_stderr_fallback(self):
+        with patch(EXEC, _exec(("", "", 1))):
+            with pytest.raises(podman.PodmanError) as exc:
+                await podman.remove_volume("v")
+        assert exc.value.message == "podman volume rm"

--- a/src/backend/tests/test_podman.py
+++ b/src/backend/tests/test_podman.py
@@ -120,7 +120,13 @@ class TestCreateContainer:
         with patch(EXEC, _exec(("abc123\n", "", 0))) as m:
             cid = await podman.create_container("n", "img", replace=False)
         assert cid == "abc123"
-        assert _args(m) == ["create", "--name", "n", "img"]
+        assert _args(m) == [
+            "create",
+            "--pull=never",
+            "--name",
+            "n",
+            "img",
+        ]
 
     async def test_all_flags(self):
         with patch(EXEC, _exec(("id\n", "", 0))) as m:

--- a/src/backend/tests/test_podman.py
+++ b/src/backend/tests/test_podman.py
@@ -167,6 +167,15 @@ class TestCreateContainer:
         assert ["-e", "K=V"] == args[args.index("-e") : args.index("-e") + 2]
         assert args[-1] == "img"
 
+    async def test_pull_policy_override(self):
+        with patch(EXEC, _exec(("id\n", "", 0))) as m:
+            await podman.create_container(
+                "n", "img", pull="missing", replace=False
+            )
+        args = _args(m)
+        assert "--pull=missing" in args
+        assert "--pull=never" not in args
+
 
 class TestStartContainer:
     async def test_start(self):

--- a/src/backend/tests/test_terminal.py
+++ b/src/backend/tests/test_terminal.py
@@ -1,457 +1,301 @@
-"""Tests for terminal: Docker API exec-based terminal sessions."""
+"""Tests for terminal: PTY-based ``podman exec`` shell sessions.
+
+The OS/PTY glue (:class:`ShellProcess`) needs a real PTY + podman and is
+marked ``# pragma: no cover``; these tests drive :class:`TerminalSession`'s
+lifecycle/queue logic against an injected fake shell.
+"""
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
-
+from unittest.mock import patch
 
 from klangk_backend.terminal import TerminalSession
 
-
-def _mock_stream():
-    stream = MagicMock()
-    stream.write_in = AsyncMock()
-    stream.close = AsyncMock()
-    return stream
+SHELL_FACTORY = "klangk_backend.terminal._make_shell_process"
 
 
-def _mock_exec(stream):
-    exec_obj = MagicMock()
-    exec_obj.start = MagicMock(return_value=stream)
-    exec_obj.resize = AsyncMock()
-    return exec_obj
+class FakeShell:
+    """Stand-in for ShellProcess: scripted reads, recorded writes/resizes."""
+
+    def __init__(
+        self,
+        chunks=(),
+        *,
+        start_error=None,
+        write_error=None,
+        close_error=None,
+        block_after_chunks=False,
+    ):
+        self._chunks = list(chunks)
+        self._start_error = start_error
+        self._write_error = write_error
+        self._close_error = close_error
+        self._block = block_after_chunks
+        self.argv = None
+        self.rows = None
+        self.cols = None
+        self.writes = []
+        self.resizes = []
+        self.closed = False
+
+    async def start(self, argv, rows, cols):
+        self.argv = argv
+        self.rows = rows
+        self.cols = cols
+        if self._start_error is not None:
+            raise self._start_error
+
+    async def read(self):
+        if self._chunks:
+            item = self._chunks.pop(0)
+            if isinstance(item, BaseException):
+                raise item
+            return item
+        if self._block:
+            await asyncio.Event().wait()  # hang until the task is cancelled
+        return b""
+
+    async def write(self, data):
+        if self._write_error is not None:
+            raise self._write_error
+        self.writes.append(data)
+
+    def resize(self, rows, cols):
+        self.resizes.append((rows, cols))
+
+    def close(self):
+        self.closed = True
+        if self._close_error is not None:
+            raise self._close_error
 
 
-def _mock_container(exec_obj):
-    container = MagicMock()
-    container.exec = AsyncMock(return_value=exec_obj)
-    return container
-
-
-def _mock_docker(container):
-    docker = MagicMock()
-    docker.containers = MagicMock()
-    docker.containers.get = AsyncMock(return_value=container)
-    docker.close = AsyncMock()
-    return docker
+def _patch(fake):
+    return patch(SHELL_FACTORY, return_value=fake)
 
 
 class TestInit:
     def test_initial_state(self):
         s = TerminalSession("cid")
         assert s.container_id == "cid"
-        assert s._stream is None
-        assert s._exec is None
+        assert s._shell is None
         assert s._running is False
         assert s.is_alive is False
 
 
 class TestStart:
-    async def test_start_creates_exec_session(self):
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(return_value=None)
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+    async def test_start_builds_exec_argv(self):
+        fake = FakeShell(block_after_chunks=True)
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start(120, 40)
 
-        docker.containers.get.assert_awaited_once_with("cid")
-        container.exec.assert_awaited_once()
-        call_kwargs = container.exec.call_args
-        assert call_kwargs[1]["tty"] is True
-        assert call_kwargs[1]["stdin"] is True
-        assert call_kwargs[1]["user"] == "klangk"
-        assert call_kwargs[1]["workdir"] == "/home/klangk/work"
-        exec_obj.start.assert_called_once()
-        exec_obj.resize.assert_awaited_once_with(h=40, w=120)
-
+        argv = fake.argv
+        assert argv[0] == "exec"
+        assert "-t" in argv and "-i" in argv
+        assert argv[argv.index("-u") + 1] == "klangk"
+        assert argv[argv.index("-w") + 1] == "/home/klangk/work"
+        assert "cid" in argv
+        assert argv[-1] == "/bin/bash"
+        assert (fake.rows, fake.cols) == (40, 120)
         assert s._running is True
         await s.stop()
 
     async def test_start_unsets_sensitive_env_vars(self, monkeypatch):
         monkeypatch.setenv("KLANGK_LLM_API_KEY", "secret")
         monkeypatch.setenv("ANTHROPIC_API_KEY", "secret2")
-
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(return_value=None)
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+        fake = FakeShell(block_after_chunks=True)
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start()
 
-        call_args = container.exec.call_args
-        cmd = call_args[0][0]
-        assert "env" in cmd
-        env_idx = cmd.index("env")
-        env_args = cmd[env_idx:]
-        unset_keys = [
-            env_args[i + 1] for i, a in enumerate(env_args) if a == "-u"
-        ]
-        assert "KLANGK_LLM_API_KEY" in unset_keys
-        assert "ANTHROPIC_API_KEY" in unset_keys
-
+        argv = fake.argv
+        unset = [argv[i + 1] for i, a in enumerate(argv) if a == "-u"]
+        assert "KLANGK_LLM_API_KEY" in unset
+        assert "ANTHROPIC_API_KEY" in unset
         await s.stop()
 
     async def test_command_override_sets_env_var(self):
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(return_value=None)
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+        fake = FakeShell(block_after_chunks=True)
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start(command_override="bash")
-
-        call_kwargs = container.exec.call_args[1]
-        assert "KLANGK_CMD_OVERRIDE=bash" in call_kwargs["environment"]
-
+        assert "-e" in fake.argv
+        assert "KLANGK_CMD_OVERRIDE=bash" in fake.argv
         await s.stop()
 
     async def test_no_command_override_by_default(self):
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(return_value=None)
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+        fake = FakeShell(block_after_chunks=True)
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start()
-
-        call_kwargs = container.exec.call_args[1]
-        assert not any(
-            "KLANGK_CMD_OVERRIDE" in e for e in call_kwargs["environment"]
-        )
-
+        assert not any("KLANGK_CMD_OVERRIDE" in a for a in fake.argv)
         await s.stop()
 
     async def test_bridge_token_sets_env_var(self):
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(return_value=None)
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+        fake = FakeShell(block_after_chunks=True)
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start(bridge_token="tok-123")
-
-        call_kwargs = container.exec.call_args[1]
-        assert "KLANGK_BRIDGE_TOKEN=tok-123" in call_kwargs["environment"]
-
+        assert "KLANGK_BRIDGE_TOKEN=tok-123" in fake.argv
         await s.stop()
 
     async def test_no_bridge_token_by_default(self):
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(return_value=None)
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+        fake = FakeShell(block_after_chunks=True)
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start()
-
-        call_kwargs = container.exec.call_args[1]
-        assert not any(
-            "KLANGK_BRIDGE_TOKEN" in e for e in call_kwargs["environment"]
-        )
-
+        assert not any("KLANGK_BRIDGE_TOKEN" in a for a in fake.argv)
         await s.stop()
 
-    async def test_start_exception_closes_docker(self):
-        stream = _mock_stream()
-        exec_obj = _mock_exec(stream)
-        exec_obj.resize = AsyncMock(side_effect=RuntimeError("resize fail"))
-        stream.read_out = AsyncMock(return_value=None)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+    async def test_start_failure_resets_running(self):
+        fake = FakeShell(start_error=RuntimeError("spawn fail"))
+        with _patch(fake):
             s = TerminalSession("cid")
             try:
                 await s.start()
             except RuntimeError:
                 pass
-
-        docker.close.assert_awaited()
+        assert s._running is False
+        assert s._shell is None
+        assert s.is_alive is False
 
 
 class TestReadLoop:
-    async def test_output_from_stream(self):
-        first_msg = MagicMock()
-        first_msg.data = b"prompt"
-        second_msg = MagicMock()
-        second_msg.data = b"hello world"
-        stream = _mock_stream()
-        # First read consumed by start(), second by read_loop
-        stream.read_out = AsyncMock(side_effect=[first_msg, second_msg, None])
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+    async def test_output_from_shell(self):
+        fake = FakeShell(chunks=[b"prompt", b"hello world"])
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start()
 
-        await asyncio.sleep(0.1)
-        # First msg queued by start(), second by read_loop
-        data1 = s._output_queue.get_nowait()
-        assert data1 == "prompt"
-        data2 = s._output_queue.get_nowait()
-        assert data2 == "hello world"
-
+        await asyncio.sleep(0.05)
+        assert s._output_queue.get_nowait() == "prompt"
+        assert s._output_queue.get_nowait() == "hello world"
         await s.stop()
 
     async def test_stream_end_signals_none(self):
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(return_value=None)
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+        fake = FakeShell(chunks=[])  # immediate EOF
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start()
 
-        await asyncio.sleep(0.1)
-        data = s._output_queue.get_nowait()
-        assert data is None
-
+        await asyncio.sleep(0.05)
+        assert s._output_queue.get_nowait() is None
         await s.stop()
 
     async def test_read_loop_handles_exception(self):
-        first_msg = MagicMock()
-        first_msg.data = b"prompt"
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(
-            side_effect=[first_msg, RuntimeError("connection lost")]
-        )
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+        fake = FakeShell(chunks=[b"prompt", RuntimeError("connection lost")])
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start()
 
-        await asyncio.sleep(0.1)
-        # Should get prompt then None (from exception cleanup)
-        s._output_queue.get_nowait()  # prompt
-        data = s._output_queue.get_nowait()
-        assert data is None
-
+        await asyncio.sleep(0.05)
+        assert s._output_queue.get_nowait() == "prompt"
+        # exception in read -> loop ends -> sentinel queued
+        assert s._output_queue.get_nowait() is None
         await s.stop()
-
-    async def test_sentinel_uses_put_nowait(self):
-        """_read_loop uses put_nowait for the sentinel, not blocking put."""
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(return_value=None)
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
-            s = TerminalSession("cid")
-            await s.start()
-
-        await asyncio.sleep(0.1)
-        # Sentinel should be in the queue (put_nowait succeeded)
-        data = s._output_queue.get_nowait()
-        assert data is None
-        await s.stop()
-
-    async def test_sentinel_dropped_when_queue_full(self):
-        """When queue is full, sentinel is silently dropped (no deadlock)."""
-        s = TerminalSession("cid")
-        s._running = True
-        # Pre-fill the queue to capacity
-        for _ in range(64):
-            s._output_queue.put_nowait("data")
-        assert s._output_queue.full()
-
-        # Simulate _read_loop finally block: put_nowait should catch QueueFull
-        try:
-            s._output_queue.put_nowait(None)
-        except asyncio.QueueFull:
-            pass  # This is the expected path
-
-        # Queue is still full, sentinel was dropped, no hang
-        assert s._output_queue.full()
-        # Verify no None sentinel in the queue
-        items = []
-        while not s._output_queue.empty():
-            items.append(s._output_queue.get_nowait())
-        assert None not in items
 
 
 class TestWrite:
-    async def test_write_sends_to_stream(self):
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(return_value=None)
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+    async def test_write_sends_to_shell(self):
+        fake = FakeShell(block_after_chunks=True)
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start()
-
         await s.write("hello")
-        stream.write_in.assert_awaited_with(b"hello")
-
+        assert fake.writes == [b"hello"]
         await s.stop()
 
     async def test_write_exception_suppressed(self):
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(return_value=None)
-        stream.write_in = AsyncMock(side_effect=OSError("broken"))
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+        fake = FakeShell(block_after_chunks=True, write_error=OSError("broke"))
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start()
-
-        # Should not raise
-        await s.write("hello")
+        await s.write("hello")  # should not raise
         await s.stop()
 
     async def test_write_when_stopped(self):
         s = TerminalSession("cid")
-        await s.write("hello")
+        await s.write("hello")  # no shell -> no-op
 
 
 class TestResize:
-    async def test_resize_calls_exec_resize(self):
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(return_value=None)
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+    async def test_resize_calls_shell_resize(self):
+        fake = FakeShell(block_after_chunks=True)
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start()
-
         await s.resize(200, 50)
-        exec_obj.resize.assert_awaited_with(h=50, w=200)
-
+        assert fake.resizes == [(50, 200)]  # (rows, cols)
         await s.stop()
 
     async def test_resize_exception_suppressed(self):
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(return_value=None)
-        exec_obj = _mock_exec(stream)
-        exec_obj.resize = AsyncMock(side_effect=[None, OSError("broken")])
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
+        fake = FakeShell(block_after_chunks=True)
 
-        with patch("aiodocker.Docker", return_value=docker):
+        def boom(rows, cols):
+            raise OSError("broke")
+
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start()
-
-        # Should not raise (second call raises)
-        await s.resize(200, 50)
+        fake.resize = boom
+        await s.resize(200, 50)  # should not raise
         await s.stop()
 
     async def test_resize_when_stopped(self):
         s = TerminalSession("cid")
-        await s.resize(80, 24)
+        await s.resize(80, 24)  # no shell -> no-op
 
 
 class TestStop:
     async def test_stop_cleans_up(self):
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(return_value=None)
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+        fake = FakeShell(block_after_chunks=True)
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start()
-
         await s.stop()
         assert s._running is False
-        assert s._stream is None
-        assert s._exec is None
+        assert s._shell is None
         assert s.is_alive is False
-        docker.close.assert_awaited()
+        assert fake.closed is True
 
-    async def test_stop_handles_close_exceptions(self):
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(return_value=None)
-        stream.close = AsyncMock(side_effect=OSError("close fail"))
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-        docker.close = AsyncMock(side_effect=OSError("docker close fail"))
-
-        with patch("aiodocker.Docker", return_value=docker):
+    async def test_stop_handles_close_exception(self):
+        fake = FakeShell(
+            block_after_chunks=True, close_error=OSError("close fail")
+        )
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start()
-
-        # Should not raise despite exceptions
-        await s.stop()
-        assert s._stream is None
-        assert s._exec is None
+        await s.stop()  # should not raise
+        assert s._shell is None
 
     async def test_stop_cancels_blocked_read_loop(self):
-        """CancelledError re-raised from _read_loop when stop() cancels it."""
-        hang = asyncio.Future()  # blocks forever until cancelled
-        first_msg = MagicMock()
-        first_msg.data = b"prompt"
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(side_effect=[first_msg, hang])
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+        fake = FakeShell(chunks=[b"prompt"], block_after_chunks=True)
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start()
-
-        # Read loop is now blocked on the hanging future
+        await asyncio.sleep(0.05)  # consume prompt, then block on read
         await s.stop()
         assert s._running is False
-        assert s._stream is None
+        assert s._shell is None
 
     async def test_stop_read_task_unexpected_exception(self):
-        """Non-CancelledError from read task is logged, not raised."""
-
         async def bad_task():
             raise RuntimeError("unexpected")
 
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(return_value=None)
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+        fake = FakeShell(block_after_chunks=True)
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start()
 
-        # Replace the read task with one that raises a non-CancelledError
-        if s._read_task is not None:
-            s._read_task.cancel()
-            try:
-                await s._read_task
-            except (asyncio.CancelledError, Exception):
-                pass
+        # Replace the read task with one that raises a non-CancelledError.
+        s._read_task.cancel()
+        try:
+            await s._read_task
+        except asyncio.CancelledError:
+            pass
         s._read_task = asyncio.create_task(bad_task())
-        await asyncio.sleep(0)  # let it finish
+        await asyncio.sleep(0)
 
-        # stop() should handle the RuntimeError without raising
-        await s.stop()
+        await s.stop()  # logs the RuntimeError, does not raise
         assert s._read_task is None
 
     async def test_stop_when_not_started(self):
@@ -461,165 +305,81 @@ class TestStop:
 
 class TestOutput:
     async def test_output_yields_data(self):
-        first_msg = MagicMock()
-        first_msg.data = b"prompt"
-        second_msg = MagicMock()
-        second_msg.data = b"output"
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(side_effect=[first_msg, second_msg, None])
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+        fake = FakeShell(chunks=[b"prompt", b"output"])
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start()
 
         collected = []
         async for data in s.output():
             collected.append(data)
-
         assert "prompt" in collected
         assert "output" in collected
         await s.stop()
 
-    async def test_output_exits_when_running_cleared_without_sentinel(self):
-        """When sentinel is dropped (QueueFull), output() exits via _running check."""
-        stream = _mock_stream()
-        first_msg = MagicMock()
-        first_msg.data = b"prompt"
-        stream.read_out = AsyncMock(side_effect=[first_msg, None])
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
-            s = TerminalSession("cid")
-            await s.start()
-
-        # Drain the queue (prompt + sentinel from read_loop)
-        await asyncio.sleep(0.1)
-        while not s._output_queue.empty():
-            s._output_queue.get_nowait()
-
-        # Now simulate: no sentinel in queue, consumer should exit
-        # when _running is set to False after timeout
+    async def test_output_exits_when_running_cleared(self):
+        """Sentinel dropped: output() exits via the _running check."""
+        s = TerminalSession("cid")
         s._running = True
+        s._read_task = None  # no task -> only _running governs exit
 
         async def _consume():
-            collected = []
-            async for data in s.output():
-                collected.append(data)
-            return collected
+            return [data async for data in s.output()]
 
         task = asyncio.create_task(_consume())
-        # Let the consumer block on get() with timeout
         await asyncio.sleep(0.05)
-        # Clear _running so the next timeout cycle exits
         s._running = False
         result = await asyncio.wait_for(task, timeout=3.0)
         assert result == []
-        await s.stop()
 
-    async def test_output_exits_when_read_task_done_without_sentinel(self):
-        """When sentinel is dropped and _running is True, output() exits
-        via _read_task.done() check after timeout."""
-        stream = _mock_stream()
-        first_msg = MagicMock()
-        first_msg.data = b"prompt"
-        stream.read_out = AsyncMock(side_effect=[first_msg, None])
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+    async def test_output_exits_when_read_task_done(self):
+        """Sentinel dropped: output() exits via the _read_task.done() check."""
+        fake = FakeShell(chunks=[])  # immediate EOF -> read task finishes
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start()
 
-        # Wait for read_loop to finish (it gets None from read_out)
-        await asyncio.sleep(0.1)
+        await asyncio.sleep(0.05)
         assert s._read_task.done()
-
-        # Drain the queue (prompt + sentinel)
+        # Drain the queued sentinel so output() must rely on the done() check.
         while not s._output_queue.empty():
             s._output_queue.get_nowait()
-
-        # _running is still True — only _read_task.done() signals exit
-        assert s._running
-
-        async def _consume():
-            collected = []
-            async for data in s.output():
-                collected.append(data)
-            return collected
+        assert s._running  # still True; only read_task.done() signals exit
 
         result = await asyncio.wait_for(
-            asyncio.create_task(_consume()), timeout=3.0
+            asyncio.create_task(_collect(s)),
+            timeout=3.0,
         )
         assert result == []
         await s.stop()
 
 
+async def _collect(session):
+    return [data async for data in session.output()]
+
+
 class TestIsAlive:
     async def test_alive_while_running(self):
-        stream = _mock_stream()
-        # Never-ending stream — read_out blocks forever
-        event = asyncio.Event()
-
-        async def slow_read():
-            await event.wait()
-            return None
-
-        first_msg = MagicMock()
-        first_msg.data = b"prompt"
-        call_count = 0
-
-        async def _read_side_effect():
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                return first_msg
-            return await slow_read()
-
-        stream.read_out = _read_side_effect
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+        fake = FakeShell(chunks=[b"prompt"], block_after_chunks=True)
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start()
-
         assert s.is_alive is True
-        event.set()
         await s.stop()
 
     async def test_not_alive_after_stream_ends(self):
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(return_value=None)
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+        fake = FakeShell(chunks=[])  # EOF
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start()
-
-        await asyncio.sleep(0.1)
+        await asyncio.sleep(0.05)
         assert s.is_alive is False
-
         await s.stop()
 
     async def test_not_alive_after_stop(self):
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(return_value=None)
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+        fake = FakeShell(block_after_chunks=True)
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start()
-
         await s.stop()
         assert s.is_alive is False

--- a/src/backend/tests/test_terminal.py
+++ b/src/backend/tests/test_terminal.py
@@ -8,9 +8,20 @@ lifecycle/queue logic against an injected fake shell.
 import asyncio
 from unittest.mock import patch
 
-from klangk_backend.terminal import TerminalSession
+from klangk_backend.terminal import TerminalSession, _make_shell_process
 
 SHELL_FACTORY = "klangk_backend.terminal._make_shell_process"
+
+
+class TestShellProcessFactory:
+    """The factory + ctor are pure Python (no PTY); the OS methods that
+    need a real PTY/podman are ``# pragma: no cover`` and validated
+    interactively."""
+
+    def test_factory_returns_unstarted_shell(self):
+        shell = _make_shell_process()
+        assert shell._master_fd is None
+        assert shell._proc is None
 
 
 class FakeShell:

--- a/src/daemon/Dockerfile
+++ b/src/daemon/Dockerfile
@@ -80,6 +80,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         catatonit \
+        curl \
         crun \
         fuse-overlayfs \
         git \
@@ -154,6 +155,7 @@ USER ${USER}
 RUN podman --version
 
 EXPOSE 8997
+COPY --chmod=755 src/daemon/start.sh /usr/local/bin/start.sh
+
 ENTRYPOINT ["/usr/bin/catatonit", "--"]
-# Shell form for ${KLANGK_PORT} expansion; flags mirror devenv.nix:89.
-CMD ["sh", "-c", "exec uvicorn klangk_backend.main:app --host 0.0.0.0 --port ${KLANGK_PORT} --ws-max-size 65536 --ws-ping-interval 20 --ws-ping-timeout 20"]
+CMD ["/usr/local/bin/start.sh"]

--- a/src/daemon/Dockerfile
+++ b/src/daemon/Dockerfile
@@ -155,7 +155,6 @@ USER ${USER}
 RUN podman --version
 
 EXPOSE 8997
-COPY --chmod=755 src/daemon/start.sh /usr/local/bin/start.sh
-
 ENTRYPOINT ["/usr/bin/catatonit", "--"]
-CMD ["/usr/local/bin/start.sh"]
+# Shell form for ${KLANGK_PORT} expansion; flags mirror devenv.nix:89.
+CMD ["sh", "-c", "exec uvicorn klangk_backend.main:app --host 0.0.0.0 --port ${KLANGK_PORT} --ws-max-size 65536 --ws-ping-interval 20 --ws-ping-timeout 20"]

--- a/src/daemon/Dockerfile
+++ b/src/daemon/Dockerfile
@@ -1,0 +1,159 @@
+# syntax=docker/dockerfile:1
+#
+# Multi-stage build for the **klangk daemon** (FastAPI backend + rootless
+# Podman engine).  This is an alternative to the devenv/nix flow for shipping;
+# devenv.nix stays the source of truth for local dev.  See DOCKER.md §6.
+#
+# Build from the repo ROOT so both src/frontend and src/backend are in context:
+#   docker build -f src/daemon/Dockerfile -t klangk-daemon .
+#
+# The nginx front is a separate off-the-shelf service (see docker-compose.yml +
+# src/daemon/nginx.conf.template); this image is backend + engine only.
+
+# ---------------------------------------------------------------------------
+# Stage `web` — build the Flutter web assets (production flags only).
+# ---------------------------------------------------------------------------
+# NOTE: pinned to match devenv's nix toolchain (Flutter 3.41 / Dart 3.11 — see
+# the flterm comment in scripts/flutterbuildweb.sh).  The frontend pubspec floor
+# is only `flutter: ^3.27.0` / Dart `^3.6.0`, which 3.41 satisfies.  **This tag
+# is the one knob to confirm against your dev toolchain** — a mismatch here is
+# the most likely build break.
+FROM ghcr.io/cirruslabs/flutter:3.41.9 AS web
+
+# Replicate the repo layout (scripts/ and src/ as siblings under /repo) because
+# stub_dart_plugins.sh resolves the frontend as `$(dirname $0)/../src/frontend`.
+WORKDIR /repo
+# Scripts first (cache-friendly: rarely change relative to app code).
+COPY scripts/ /repo/scripts/
+COPY src/frontend/ /repo/src/frontend/
+
+# Stub the klangk_plugins package so `flutter pub get` resolves without the
+# full import_dart_plugins.py codegen (no plugins baked into the daemon image).
+RUN bash scripts/stub_dart_plugins.sh
+
+WORKDIR /repo/src/frontend
+# Production build: drop the dev-only flags (--source-maps, --no-minify-*,
+# --no-strip-wasm) and the inline_sources_in_map.py step that flutterbuildweb.sh
+# uses — those exist for devtools source resolution and bloat the assets.
+RUN flutter --disable-analytics \
+    && flutter pub get \
+    && flutter build web --wasm --release --base-href=/ --no-web-resources-cdn \
+    && rm -f build/web/flutter_service_worker.js
+
+# Cache-bust flutter_bootstrap.js by content hash (index.html is served
+# no-cache, so the ?v= query busts cached bootstrap/main.dart.* — mirrors
+# the tail of scripts/flutterbuildweb.sh).
+RUN set -eu; \
+    for f in main.dart.wasm main.dart.js; do \
+      if [ -f "build/web/$f" ]; then \
+        HASH=$(sha256sum "build/web/$f" | cut -c1-12); break; \
+      fi; \
+    done; \
+    sed -i "s|flutter_bootstrap.js|flutter_bootstrap.js?v=${HASH}|" build/web/index.html
+
+# ---------------------------------------------------------------------------
+# Stage `runtime` — backend (uvicorn) + rootless Podman-in-Docker.
+# ---------------------------------------------------------------------------
+# Based on debian:trixie-slim to match the proven rootless-podman recipe in
+# /home/bryan/src/podman_test (podman 5.x + passt).  trixie's python3 is 3.13,
+# which satisfies the backend's `requires-python >=3.12` and matches the dev
+# venv.  The rootless plumbing below (non-root user + subuid/subgid + setuid
+# newuidmap + fuse.conf) is the in-image half of DOCKER.md §7; the matching
+# host-side flags (devices, security_opt, cap_add) live in docker-compose.yml.
+FROM debian:trixie-slim AS runtime
+
+ARG USER=klangk
+ARG UID=1000
+ARG GID=1000
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Engine + rootless plumbing + backend runtime deps:
+#  - podman/crun/fuse-overlayfs: the in-process engine; nested rootless needs
+#    fuse-overlayfs (overlay2/vfs don't work cleanly nested, needs /dev/fuse).
+#  - uidmap: newuidmap/newgidmap setuid helpers for the rootless userns.
+#  - passt/slirp4netns: userspace networking for rootless containers (/dev/net/tun).
+#  - catatonit: tiny init for `podman run --init` (the pi containers use Init=True)
+#    and as this container's PID 1 reaper.
+#  - git/rsync: CLI shell-outs + workspace export/import.
+#  - python3: runs the backend (uv builds a venv against it).
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        catatonit \
+        crun \
+        fuse-overlayfs \
+        git \
+        passt \
+        podman \
+        python3 \
+        rsync \
+        slirp4netns \
+        uidmap \
+    && rm -rf /var/lib/apt/lists/*
+
+# Unprivileged user that runs uvicorn *and* rootless podman, with subuid/subgid
+# ranges so podman can map a range of IDs inside its user namespace.
+RUN groupadd -g ${GID} ${USER} \
+    && useradd -u ${UID} -g ${GID} -m -s /bin/bash ${USER} \
+    && printf '%s:100000:65536\n' "${USER}" > /etc/subuid \
+    && printf '%s:100000:65536\n' "${USER}" > /etc/subgid
+
+# Debian ships newuidmap/newgidmap with *file capabilities* (xattrs) that often
+# don't survive onto the overlay mount inside a container, dropping
+# CAP_SETUID/SETGID -> "newuidmap: write to uid_map failed: Operation not
+# permitted".  The plain setuid bit (inode mode) is always preserved; this is
+# what quay.io/podman/stable does for the same reason.
+RUN chmod 4755 /usr/bin/newuidmap /usr/bin/newgidmap
+
+# fuse-overlayfs uses /dev/fuse; allow non-root mounts.
+RUN echo 'user_allow_other' >> /etc/fuse.conf
+
+# Engine/storage/registry config tuned for rootless-in-a-container (see files).
+COPY src/daemon/containers.conf /etc/containers/containers.conf
+COPY src/daemon/storage.conf /etc/containers/storage.conf
+COPY src/daemon/registries.conf /etc/containers/registries.conf
+
+# Pinned uv, used to build a venv and install the backend.
+COPY --from=ghcr.io/astral-sh/uv:0.5.11 /uv /usr/local/bin/uv
+
+# Lay the source out so main.py's web-assets lookup resolves unchanged:
+# main.py does Path(__file__).parent.parent.parent / "frontend/build/web",
+# i.e. <src>/frontend/build/web.  Keep src/backend + src/frontend under /app/src
+# and install the backend EDITABLE so __file__ stays in the source tree.
+WORKDIR /app
+COPY src/backend/ /app/src/backend/
+ENV VIRTUAL_ENV=/opt/venv \
+    PATH=/opt/venv/bin:/usr/local/bin:/usr/bin:/bin
+RUN uv venv --python /usr/bin/python3 "$VIRTUAL_ENV" \
+    && uv pip install --no-cache -e /app/src/backend
+
+# Web assets from the build stage, at the path main.py expects.
+COPY --from=web /repo/src/frontend/build/web /app/src/frontend/build/web
+
+# Pre-create state dirs owned by the unprivileged user *before* the volumes
+# mount over them: a named volume whose path is absent (or root-owned) in the
+# image gets created root-owned, and rootless podman / the backend then can't
+# write inside it.  Covers both the app data dir and podman's rootless store.
+RUN mkdir -p /var/lib/klangk/data \
+             /home/${USER}/.local/share/containers \
+    && chown -R ${UID}:${GID} /var/lib/klangk /home/${USER}/.local
+
+# Backend defaults (overridable via compose environment).
+#  - KLANGK_HOST_GATEWAY: how a pi container reaches the nginx front. Default
+#    host.containers.internal is podman's native alias; this is the §8 knob to
+#    confirm during the smoke test (the backend also `--add-host`s it).
+ENV KLANGK_DATA_DIR=/var/lib/klangk/data \
+    KLANGK_PORT=8997 \
+    KLANGK_HOST_GATEWAY=host.containers.internal \
+    KLANGK_PODMAN_BIN=podman \
+    HOME=/home/${USER}
+
+USER ${USER}
+
+# Sanity-check at build time that the engine binary initialises.
+RUN podman --version
+
+EXPOSE 8997
+ENTRYPOINT ["/usr/bin/catatonit", "--"]
+# Shell form for ${KLANGK_PORT} expansion; flags mirror devenv.nix:89.
+CMD ["sh", "-c", "exec uvicorn klangk_backend.main:app --host 0.0.0.0 --port ${KLANGK_PORT} --ws-max-size 65536 --ws-ping-interval 20 --ws-ping-timeout 20"]

--- a/src/daemon/containers.conf
+++ b/src/daemon/containers.conf
@@ -1,0 +1,22 @@
+# Podman engine config for the rootless-in-Docker backend (DOCKER.md §7).
+# Mirrors the proven recipe in /home/bryan/src/podman_test.
+
+[containers]
+# slirp4netns/pasta is the only networking available rootless-in-a-container.
+netns = "private"
+# Podman sets net.ipv4.ping_group_range on every container by default; Docker
+# mounts /proc/sys read-only, so that write fails ("Read-only file system").
+# The compose backend service runs with `--security-opt systempaths=unconfined`
+# (podman's unmask=ALL equivalent) so this works.  Lighter alternative if you'd
+# rather keep /proc masked: uncomment the next line so podman never writes it
+# (trade-off: inner containers won't have ping_group_range set).
+# default_sysctls = []
+
+[engine]
+# No systemd/journald inside the container -> manage cgroups directly, log
+# events to a file, and run crun (low-footprint, cgroup-v2 friendly).
+cgroup_manager = "cgroupfs"
+events_logger = "file"
+runtime = "crun"
+# Init binary for `podman run --init` (the pi/workspace containers set Init=True).
+init_path = "/usr/bin/catatonit"

--- a/src/daemon/nginx.conf.template
+++ b/src/daemon/nginx.conf.template
@@ -98,6 +98,9 @@ http {
       proxy_http_version 1.1;
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection $connection_upgrade;
+      # Keep WebSocket connections alive — default 60 s would drop idle terminals.
+      proxy_read_timeout 3600s;
+      proxy_send_timeout 3600s;
     }
   }
 }

--- a/src/daemon/nginx.conf.template
+++ b/src/daemon/nginx.conf.template
@@ -1,0 +1,103 @@
+# Production nginx config for the klangk daemon stack (DOCKER.md §6).
+#
+# Rendered at container start by the official nginx:alpine image's
+# `20-envsubst-on-templates.sh`.  This is a FULL nginx.conf (not a conf.d
+# server block), so the compose `nginx` service must:
+#   - mount this file at /etc/nginx/templates/nginx.conf.template
+#   - set NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx   (so it renders to
+#     /etc/nginx/nginx.conf, replacing the stock config, instead of conf.d/)
+# envsubst only replaces variables that are actually exported, so nginx's own
+# runtime vars ($http_upgrade, $scheme, regex captures $1/$2, ...) pass through
+# untouched.  Required env: KLANGK_NGINX_PORT, KLANGK_PORT, KLANGK_LLM_BASE_URL,
+# KLANGK_LLM_API_KEY.
+#
+# Lifted from scripts/nginx.sh with two changes for the compose stack:
+#   - upstreams point at the `backend` service instead of 127.0.0.1
+#     (nginx and backend are separate containers on the `internal` network)
+#   - /hosted/ proxies to backend:<port>, since the workspace-container ports
+#     are published into the backend container's network namespace by Podman.
+
+# NB: no `daemon off;` here — the official nginx image already passes
+# `-g 'daemon off;'`, and a duplicate directive is a fatal config error.
+pid /tmp/nginx.pid;
+error_log stderr;
+events { worker_connections 64; }
+http {
+  access_log /dev/stdout;
+  client_body_temp_path /tmp/nginx_client_body;
+  proxy_temp_path /tmp/nginx_proxy;
+  fastcgi_temp_path /tmp/nginx_fastcgi;
+  uwsgi_temp_path /tmp/nginx_uwsgi;
+  scgi_temp_path /tmp/nginx_scgi;
+
+  map $http_upgrade $connection_upgrade {
+    default upgrade;
+    "" close;
+  }
+
+  client_max_body_size 500m;
+
+  # Resolve upstreams at request time, not config-load. 127.0.0.11 is Docker's
+  # embedded DNS (always present under compose).  Without this, a `proxy_pass`
+  # to a hostname behind a variable (the LLM endpoint and the hosted-app
+  # `backend:$port` below) is resolved at startup, so an unresolvable/down LLM
+  # host would crash the whole front — login + UI included.  With it, those
+  # upstreams fail at request time (502) and the rest of the daemon stays up.
+  resolver 127.0.0.11 valid=10s ipv6=off;
+
+  server {
+    listen ${KLANGK_NGINX_PORT};
+
+    # Hosted app proxy: extract port from URL and proxy to the backend
+    # container (where Podman published the workspace ports).  `backend` is in
+    # a variable-bearing proxy_pass, so it resolves via the resolver above.
+    location ~ ^/hosted/[^/]+/(\d+)/(.*)$ {
+      proxy_pass http://backend:$1/$2$is_args$args;
+      proxy_set_header Host $http_host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_http_version 1.1;
+    }
+
+    # LLM proxy: forward to the real LLM endpoint with API key injected.
+    # Workspace containers hit this instead of the real endpoint, so they
+    # never see the API key. Restricted to private subnets and localhost.
+    # Variable proxy_pass (+ resolver) so a down LLM endpoint doesn't block
+    # nginx startup; the regex capture replaces the old prefix-strip behavior.
+    location ~ ^/llm-proxy/(.*)$ {
+      allow 172.16.0.0/12;
+      allow 192.168.0.0/16;
+      allow 10.0.0.0/8;
+      allow 127.0.0.1;
+      deny all;
+      # Base URL in a variable so proxy_pass defers DNS to the resolver above.
+      set $llm_base "${KLANGK_LLM_BASE_URL}";
+      proxy_pass $llm_base/$1$is_args$args;
+      proxy_set_header Authorization "Bearer ${KLANGK_LLM_API_KEY}";
+      proxy_set_header Host $proxy_host;
+      proxy_http_version 1.1;
+      proxy_set_header Connection "";
+      # SSE streaming support
+      proxy_buffering off;
+      proxy_cache off;
+      chunked_transfer_encoding on;
+    }
+
+    location / {
+      proxy_pass http://backend:${KLANGK_PORT}/;
+      proxy_set_header Host $http_host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      # Pass through X-Forwarded-* from an outer proxy, or default for direct access
+      set $fwd_proto $http_x_forwarded_proto;
+      if ($fwd_proto = "") { set $fwd_proto $scheme; }
+      proxy_set_header X-Forwarded-Proto $fwd_proto;
+      proxy_set_header X-Forwarded-Host $http_x_forwarded_host;
+      proxy_set_header X-Forwarded-Prefix $http_x_forwarded_prefix;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
+    }
+  }
+}

--- a/src/daemon/registries.conf
+++ b/src/daemon/registries.conf
@@ -1,0 +1,5 @@
+# Default registry search list (Debian's podman ships this unset).
+# Used only when seeding the workspace-image store offline; at runtime the
+# backend creates workspace containers with `--pull=never`, so no registry is
+# ever contacted for the airgapped deployment (DOCKER.md §9/B).
+unqualified-search-registries = ["docker.io"]

--- a/src/daemon/start.sh
+++ b/src/daemon/start.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-set -e
-
-exec uvicorn klangk_backend.main:app \
-    --host 0.0.0.0 \
-    --port "${KLANGK_PORT:-8997}" \
-    --ws-max-size 65536 \
-    --ws-ping-interval 20 \
-    --ws-ping-timeout 20

--- a/src/daemon/start.sh
+++ b/src/daemon/start.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+exec uvicorn klangk_backend.main:app \
+    --host 0.0.0.0 \
+    --port "${KLANGK_PORT:-8997}" \
+    --ws-max-size 65536 \
+    --ws-ping-interval 20 \
+    --ws-ping-timeout 20

--- a/src/daemon/storage.conf
+++ b/src/daemon/storage.conf
@@ -1,0 +1,25 @@
+# Podman storage config for the rootless-in-Docker backend (DOCKER.md §7, §9/B).
+#
+# Nested rootless Podman cannot use overlay2/vfs cleanly, so the storage driver
+# is overlay via fuse-overlayfs (the `fuse-overlayfs` binary + /dev/fuse must be
+# present — both supplied by the image and the compose device passthrough).
+# graphroot/runroot are intentionally omitted: rootless podman manages them
+# under $HOME/.local/share/containers, which is persisted by a named volume.
+
+[storage]
+driver = "overlay"
+
+[storage.options]
+mount_program = "/usr/bin/fuse-overlayfs"
+
+[storage.options.overlay]
+mountopt = "nodev,fsync=0"
+
+# §9/B — read-only additional image store(s).  The prebuilt `klangk` workspace
+# image is seeded offline (CI `podman build`/`pull` + export) and mounted here
+# read-only; writable container layers still go to the rootless store above.
+# Enable by mounting the store at this path (compose volume) and uncommenting:
+#
+# additionalimagestores = [
+#   "/var/lib/klangk-images",
+# ]

--- a/src/docker/bash.bashrc
+++ b/src/docker/bash.bashrc
@@ -30,7 +30,7 @@ alias ls='ls --color=auto'
 alias grep='grep --color=auto'
 
 # Determine which command to exec into (if any).
-# KLANGK_CMD_OVERRIDE (set per-session via docker exec -e) takes priority.
+# KLANGK_CMD_OVERRIDE (set per-session via podman exec -e) takes priority.
 # Otherwise fall back to the workspace default from the config mount.
 # KLANGK_CMD_STARTED guard prevents infinite recursion if the command is bash.
 if [ -z "$KLANGK_CMD_STARTED" ]; then

--- a/src/docker/entrypoint.sh
+++ b/src/docker/entrypoint.sh
@@ -15,10 +15,10 @@ chown klangk:klangk /home/klangk /home/klangk/work
 # terminal sessions find everything in place.
 su -c "python3 /usr/local/bin/setup_clankers" klangk
 
-# Signal that setup is complete. Terminal sessions (docker exec) source
+# Signal that setup is complete. Terminal sessions (podman exec) source
 # /etc/bash.bashrc which waits for this file before showing a prompt.
 # /tmp is a tmpfs, so .klangk-ready is cleared on every container start.
 touch /tmp/.klangk-ready
 
-# Keep the container alive. Terminal sessions are started via docker exec.
+# Keep the container alive. Terminal sessions are started via podman exec.
 exec sleep infinity


### PR DESCRIPTION
# Migrate the container engine from Docker/aiodocker to rootless Podman (CLI)

## Summary

Replaces the backend's Docker dependency (`aiodocker` + the Docker REST API
socket) with a thin **`podman` CLI wrapper**, so the daemon can drive a
**rootless, daemonless** Podman engine with **no socket** and **no
`podman system service`** — a single backend process. This is phase 1 of
packaging the klangk daemon as a self-contained, network-restricted compose
stack (full plan in [`DOCKER.md`](DOCKER.md)); this PR is **backend code
only** and changes no build/deploy files.

## Motivation

The target deployment is a rootless, network-restricted (effectively
airgapped) environment where privileged Docker-in-Docker is not acceptable.
Podman is daemonless, so the engine can run **in-process** in the backend
container with no second daemon and no socket to manage. The one thing that
forced a socket was `aiodocker` (an HTTP client for the Docker API); removing
it lets the backend stay a single process and talk to Podman purely via the
CLI.

## What changed

**New engine abstraction**
- `klangk_backend/podman.py` — async wrapper over the `podman` CLI
  (`asyncio.create_subprocess_exec`, parses `--format json`). `PodmanError`
  carries an HTTP-like `status` (404/409/500) derived from stderr so the
  existing HTTP control flow is preserved. Binary configurable via
  `KLANGK_PODMAN_BIN` (default `podman`).

**Migrated call sites (behaviour preserved)**
- `container.py` — container lifecycle (create/start/inspect/remove/list) and
  named-volume ensure now go through `podman.*`; the Docker `config` dict is
  translated to `podman create` flags. The `get_docker()`/`aiodocker` client
  is gone.
- `api.py` — the `/volumes` routes use `podman` volume ops; `PodmanError.status`
  drives the 404/409 responses (replacing `DockerError.status`).
- `dockerexec.py` — the raw piped `exec` now invokes the configured podman
  binary.
- `terminal.py` — the interactive shell is rewritten from the aiodocker exec
  stream to **`podman exec -t -i` over a `pty.openpty()`** whose slave is set
  to **raw mode** (so the container-side PTY is the only line discipline —
  avoids the historic "double-PTY" escape-sequence mangling). Resize sets the
  master window size and signals podman with `SIGWINCH`. OS/PTY glue is
  isolated in a `ShellProcess` class; the testable lifecycle/queue logic lives
  in `TerminalSession`.

**Airgap hardening**
- `podman create --pull=never` — the engine only ever reads the local (and, in
  the deployment, a read-only additional) image store and fails fast instead of
  attempting a registry pull.
- Removed the stale `/var/run/docker.sock` bind from workspace containers (dead
  weight under rootless podman).

**Tooling / deps**
- `aiodocker` removed from `pyproject.toml`; `ruff` added so it installs into
  the venv.

**Tests**
- New `tests/test_podman.py` (full coverage of the wrapper).
- `tests/test_container.py`, `tests/test_api.py`, `tests/test_terminal.py`
  rewritten to drive `podman.*` / an injected fake shell instead of mocking
  `aiodocker`.

## Behaviour changes reviewers should note

- **No `/var/run/docker.sock`** in workspace containers anymore. If anything in
  the in-container agent relied on Docker access, it must move to a rootless
  podman socket instead.
- **`--pull=never`**: a missing workspace image now errors immediately rather
  than pulling — intentional for the airgapped target (image is provided via a
  read-only additional image store; see `DOCKER.md` §9).
- **`KLANGK_PODMAN_BIN`** overrides the engine binary (default `podman`); set to
  `docker` to run the prior behaviour on a Docker host for comparison.

## Testing

- Run with xdist (matches `test-backend`; also avoids unrelated CLI stdin-test
  hangs): `uv run pytest tests -n auto`.
- Coverage gate is **statement** coverage (`--cov-fail-under=100`). The new and
  migrated modules meet it; the PTY OS-glue in `ShellProcess` is `# pragma: no
  cover` (needs a real PTY + podman).
- **Linux only** for `terminal.py`/`cli` (they import `pty`/`termios`).

**Still needs interactive verification on a real podman host** (the one piece
that can't be unit-tested): the terminal PTY — arrow keys/history, `vim`,
`tmux`, Ctrl-C/Ctrl-D, terminal **resize** (the `SIGWINCH`-to-podman path is
the most likely thing to need adjustment), and clean exit on shell EOF.

## Not in this PR (follow-ups, tracked in `DOCKER.md`)

- Env-parameterizing the two `host.docker.internal` proxy/bridge URLs (§8).
- The daemon multi-stage `Dockerfile` and templated `nginx.conf` (§6).
- `docker-compose.yml` + the rootless Podman-in-Docker profile (§7).
- `storage.conf` read-only `additionalimagestores` + the offline image-store
  seed (§9).
- Building the `klangk` workspace image into podman for the `e2e-tests/` suite
  (those e2e tests are expected to fail until then) and README/HACKING docs.

## Related

- [`DOCKER.md`](DOCKER.md) — the full plan, decisions, and Linux continuation
  notes.
- Separate PR: **`fix/cli-shell-test-stdin-hang`** — pre-existing
  `TestRunShell` stdin-hang fixes, independent of this migration.


