### PR TITLE
WIP: browser-delegate bridge — stream long soliplex queries (currently band-aid timeout)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,10 @@
 # LLM configuration (any OpenAI-compatible provider)
 KLANGK_LLM_API_KEY=your-api-key-here
-KLANGK_LLM_BASE_URL=https://ollama.com/v1          # or http://localhost:11434/v1 for self-hosted
-KLANGK_LLM_MODEL=gemma4:31b                        # any model available on your provider
+# Must use FQDN or IP — bare hostnames won't resolve (nginx resolver
+# doesn't support search domains)
+KLANGK_LLM_BASE_URL=https://ollama.com/v1
+# Any model available on your provider
+KLANGK_LLM_MODEL=gemma4:31b
 
 # Klangk configuration
 KLANGK_JWT_SECRET=change-this-to-a-random-secret

--- a/scripts/nginx.sh
+++ b/scripts/nginx.sh
@@ -10,35 +10,43 @@ if [ -z "${KLANGK_STATE_DIR:-}${DEVENV_STATE:-}" ]; then
 fi
 mkdir -p "$NGINX_STATE"
 
-# Build LLM proxy block only if the URL is configured
-LLM_BLOCK=""
-if [ -n "${KLANGK_LLM_BASE_URL:-}" ]; then
-  # nginx resolver needs space-separated IPs; env var may use commas.
-  # Default: parse /etc/resolv.conf for nameservers (works on host and
-  # in Docker). Fall back to 8.8.8.8 if resolv.conf has no entries.
-  if [ -n "${KLANGK_DNS_SERVERS:-}" ]; then
-    DNS_RESOLVERS="${KLANGK_DNS_SERVERS//,/ }"
-  else
-    # Wrap IPv6 addresses in brackets for nginx resolver directive.
-    DNS_RESOLVERS=$(awk '/^nameserver/{
-      addr = $2
-      if (addr ~ /:/) addr = "[" addr "]"
-      printf "%s ", addr
-    }' /etc/resolv.conf)
-    DNS_RESOLVERS="${DNS_RESOLVERS:-8.8.8.8}"
-  fi
-  LLM_BLOCK="
-    # LLM proxy: forward to the real LLM endpoint with API key injected.
-    # Containers hit this instead of the real endpoint, so they never
-    # see the API key. Restricted to Docker subnets and localhost only.
-    location ~ ^/llm-proxy/(.*)\$ {
+# nginx resolver needs space-separated IPs; env var may use commas.
+# Default: parse /etc/resolv.conf for nameservers (works on host and
+# in Docker). Fall back to 8.8.8.8 if resolv.conf has no entries.
+if [ -n "${KLANGK_DNS_SERVERS:-}" ]; then
+  DNS_RESOLVERS="${KLANGK_DNS_SERVERS//,/ }"
+else
+  # Wrap IPv6 addresses in brackets for nginx resolver directive.
+  DNS_RESOLVERS=$(awk '/^nameserver/{
+    addr = $2
+    if (addr ~ /:/) addr = "[" addr "]"
+    printf "%s ", addr
+  }' /etc/resolv.conf)
+  DNS_RESOLVERS="${DNS_RESOLVERS:-8.8.8.8}"
+fi
+
+# Shared allow/deny rules for container-only endpoints (LLM proxy,
+# browser-delegate bridge). Restricts access to Docker subnets and
+# localhost — the backend also validates tokens, but rejecting at the
+# network level avoids unnecessary round-trips.
+CONTAINER_ACL="
       allow 172.16.0.0/12;
       allow 192.168.0.0/16;
       allow 10.0.0.0/8;
       allow 127.0.0.1;
-      deny all;
-      # Use a variable so nginx resolves the upstream at request time,
-      # not at config load time (avoids crash on unresolvable hosts).
+      deny all;"
+
+# LLM proxy block: only included if KLANGK_LLM_BASE_URL is configured.
+# Containers hit this instead of the real endpoint, so they never see the
+# API key. Uses a variable so nginx resolves the upstream at request time,
+# not at config load time (avoids crash on unresolvable hosts).
+# NOTE: nginx resolver doesn't support search domains, so KLANGK_LLM_BASE_URL
+# must use a FQDN or IP address — bare hostnames won't resolve.
+LLM_BLOCK=""
+if [ -n "${KLANGK_LLM_BASE_URL:-}" ]; then
+  LLM_BLOCK="
+    location ~ ^/llm-proxy/(.*)\$ {
+${CONTAINER_ACL}
       resolver ${DNS_RESOLVERS} valid=30s;
       set \$llm_backend ${KLANGK_LLM_BASE_URL}/\$1;
       proxy_pass \$llm_backend;
@@ -46,7 +54,6 @@ if [ -n "${KLANGK_LLM_BASE_URL:-}" ]; then
       proxy_set_header Host \$proxy_host;
       proxy_http_version 1.1;
       proxy_set_header Connection \"\";
-      # SSE streaming support
       proxy_buffering off;
       proxy_cache off;
       chunked_transfer_encoding on;
@@ -88,11 +95,12 @@ http {
     }
 ${LLM_BLOCK}
     # Browser-delegate bridge: Pi extensions delegate long-running actions
-    # (soliplex RAG + LLM) through here. These can take minutes, so the read
-    # timeout must exceed the backend's KLANGK_BRIDGE_TIMEOUT_SECONDS (default
-    # 180s) — well above nginx's 60s default, which would otherwise cut the
-    # request before the backend's own bridge timeout fires.
+    # (soliplex RAG + LLM) through here. The read timeout must comfortably
+    # exceed the backend's per-chunk KLANGK_BRIDGE_TIMEOUT_SECONDS (default
+    # 30s) — well above nginx's 60s default — so nginx never cuts the request
+    # before the backend's own idle timeout fires.
     location = /api/browser-delegate {
+${CONTAINER_ACL}
       proxy_pass http://127.0.0.1:${KLANGK_PORT}/api/browser-delegate;
       proxy_set_header Host \$http_host;
       proxy_set_header X-Real-IP \$remote_addr;
@@ -108,13 +116,13 @@ ${LLM_BLOCK}
       proxy_set_header Host \$http_host;
       proxy_set_header X-Real-IP \$remote_addr;
       proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+      proxy_http_version 1.1;
       # Pass through X-Forwarded-* from outer proxy, or set defaults for direct access
       set \$fwd_proto \$http_x_forwarded_proto;
       if (\$fwd_proto = "") { set \$fwd_proto \$scheme; }
       proxy_set_header X-Forwarded-Proto \$fwd_proto;
       proxy_set_header X-Forwarded-Host \$http_x_forwarded_host;
       proxy_set_header X-Forwarded-Prefix \$http_x_forwarded_prefix;
-      proxy_http_version 1.1;
       proxy_set_header Upgrade \$http_upgrade;
       proxy_set_header Connection \$connection_upgrade;
     }

--- a/scripts/nginx.sh
+++ b/scripts/nginx.sh
@@ -87,6 +87,22 @@ http {
       proxy_http_version 1.1;
     }
 ${LLM_BLOCK}
+    # Browser-delegate bridge: Pi extensions delegate long-running actions
+    # (soliplex RAG + LLM) through here. These can take minutes, so the read
+    # timeout must exceed the backend's KLANGK_BRIDGE_TIMEOUT_SECONDS (default
+    # 180s) — well above nginx's 60s default, which would otherwise cut the
+    # request before the backend's own bridge timeout fires.
+    location = /api/browser-delegate {
+      proxy_pass http://127.0.0.1:${KLANGK_PORT}/api/browser-delegate;
+      proxy_set_header Host \$http_host;
+      proxy_set_header X-Real-IP \$remote_addr;
+      proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+      proxy_http_version 1.1;
+      proxy_read_timeout 300s;
+      proxy_send_timeout 300s;
+      proxy_buffering off;
+    }
+
     location / {
       proxy_pass http://127.0.0.1:${KLANGK_PORT}/;
       proxy_set_header Host \$http_host;

--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -1291,14 +1291,11 @@ class BrowserDelegateRequest(BaseModel):
     token: str
 
 
-@router.post("/api/browser-delegate")
-async def browser_delegate(body: BrowserDelegateRequest):
-    """Bridge endpoint for Pi extensions to delegate actions to the browser.
+def _resolve_bridge_target(body: BrowserDelegateRequest):
+    """Resolve a bridge token to (session, target_sock, payload).
 
-    Each terminal exec session gets a per-connection bridge token
-    (injected via the exec environment).  The backend resolves the
-    token to the specific browser connection that owns the terminal
-    and relays the request over WebSocket.
+    Raises HTTPException (403/502) if the token is invalid, the workspace
+    has no session, or the target browser is not subscribed.
     """
     resolved = container.registry.resolve_bridge_token(body.token)
     if resolved is None:
@@ -1312,18 +1309,47 @@ async def browser_delegate(body: BrowserDelegateRequest):
             detail="No browser client connected to this workspace",
         )
 
-    payload = body.model_dump(exclude={"token"})
-
     if target_sock not in session.browser_subscribers:
         raise HTTPException(
             status_code=502,
             detail="Browser connection not available",
         )
+    return session, target_sock, body.model_dump(exclude={"token"})
+
+
+@router.post("/api/browser-delegate")
+async def browser_delegate(body: BrowserDelegateRequest):
+    """Bridge endpoint for Pi extensions to delegate actions to the browser.
+
+    Each terminal exec session gets a per-connection bridge token
+    (injected via the exec environment).  The backend resolves the
+    token to the specific browser connection that owns the terminal
+    and relays the request over WebSocket.
+    """
+    session, target_sock, payload = _resolve_bridge_target(body)
     result = await session.dispatch_browser_request_to(target_sock, payload)
 
     if result.get("error"):
         raise HTTPException(status_code=502, detail=result["error"])
     return result
+
+
+@router.post("/api/browser-delegate/stream")
+async def browser_delegate_stream(body: BrowserDelegateRequest):
+    """Streaming bridge: relay browser output chunks back as NDJSON.
+
+    For long-running actions (RAG + LLM), the browser pushes incremental
+    browser_chunk messages and a terminal browser_response.  Each is streamed
+    to the caller immediately, so there is no single bounded round-trip — the
+    only limit is the per-chunk idle timeout.
+    """
+    session, target_sock, payload = _resolve_bridge_target(body)
+    return StreamingResponse(
+        session.dispatch_browser_request_stream_to(
+            target_sock, payload, wshandler.bridge_idle_timeout()
+        ),
+        media_type="application/x-ndjson",
+    )
 
 
 # --- Admin endpoints (require admin role) ---

--- a/src/backend/klangk_backend/wshandler.py
+++ b/src/backend/klangk_backend/wshandler.py
@@ -32,9 +32,9 @@ def bridge_idle_timeout() -> float:
     """
     raw = resolve_env_secret("KLANGK_BRIDGE_TIMEOUT_SECONDS")
     try:
-        return float(raw) if raw else 180.0
+        return float(raw) if raw else 30.0
     except ValueError:
-        return 180.0
+        return 30.0
 
 
 class SlowClientError(Exception):

--- a/src/backend/klangk_backend/wshandler.py
+++ b/src/backend/klangk_backend/wshandler.py
@@ -23,6 +23,20 @@ _MAX_INPUT_SIZE = 65536
 _SEND_QUEUE_SIZE = 256
 
 
+def bridge_idle_timeout() -> float:
+    """Max seconds between streamed browser chunks before giving up.
+
+    Bounds the gap between chunks (not the total query duration), so a
+    long-but-progressing stream never times out.  Override with
+    KLANGK_BRIDGE_TIMEOUT_SECONDS.
+    """
+    raw = resolve_env_secret("KLANGK_BRIDGE_TIMEOUT_SECONDS")
+    try:
+        return float(raw) if raw else 180.0
+    except ValueError:
+        return 180.0
+
+
 class SlowClientError(Exception):
     """Raised when the outbound queue is full (client can't keep up)."""
 
@@ -237,6 +251,60 @@ class WorkspaceSession:
             state.pending_browser_requests.pop(request_id, None)
             raise
 
+    async def dispatch_browser_request_stream_to(
+        self,
+        target_sock: "SafeWebSocket",
+        request: dict,
+        idle_timeout: float,
+    ):
+        """Stream a browser_request's response chunks to the HTTP caller.
+
+        Yields newline-delimited JSON: zero or more ``{"type":"chunk",...}``
+        as the browser streams output, then a terminal ``{"type":"done",...}``
+        or ``{"type":"error",...}``.  Unlike the single-response variant, the
+        [idle_timeout] bounds the gap *between* chunks, not the total duration,
+        so a long-but-progressing query never times out.
+        """
+        request_id = str(uuid.uuid4())
+        queue: asyncio.Queue = asyncio.Queue()
+        state.streaming_browser_requests[request_id] = (queue, target_sock)
+        message = {
+            **request,
+            "type": "browser_request",
+            "id": request_id,
+            "stream": True,
+        }
+        _log_ws_msg("SEND", message)
+        try:
+            target_sock.send_json(message)
+        except _WS_ERRORS:
+            state.streaming_browser_requests.pop(request_id, None)
+            yield json.dumps(
+                {"type": "error", "error": "Browser connection not available"}
+            ) + "\n"
+            return
+
+        try:
+            while True:
+                try:
+                    item = await asyncio.wait_for(
+                        queue.get(), timeout=idle_timeout
+                    )
+                except asyncio.TimeoutError:
+                    yield json.dumps(
+                        {
+                            "type": "error",
+                            "error": "Browser client did not respond "
+                            "within timeout",
+                        }
+                    ) + "\n"
+                    return
+                yield json.dumps(item) + "\n"
+                if item["type"] != "chunk":
+                    return
+        finally:
+            state.streaming_browser_requests.pop(request_id, None)
+
     async def full_reset(self) -> None:
         """Clean up all shared state for this workspace.
 
@@ -261,6 +329,12 @@ class WebSocketState:
         # connection that should send the response.  None means any connection.
         self.pending_browser_requests: dict[
             str, tuple[asyncio.Future, SafeWebSocket | None]
+        ] = {}
+        # Streaming browser-delegate requests: request_id → (queue, sock).
+        # The browser pushes browser_chunk messages onto the queue and a final
+        # browser_response terminates it.
+        self.streaming_browser_requests: dict[
+            str, tuple[asyncio.Queue, SafeWebSocket | None]
         ] = {}
 
     def get_session(self, workspace_id: str) -> WorkspaceSession | None:
@@ -340,6 +414,21 @@ class WebSocketState:
         request_id = msg.get("id")
         if not request_id:
             return
+        # Streaming request: the response is the terminal "done" item.
+        stream_entry = self.streaming_browser_requests.get(request_id)
+        if stream_entry is not None:
+            queue, expected_sock = stream_entry
+            if expected_sock is not None and sender is not expected_sock:
+                logger.warning(
+                    "Browser response from wrong connection for request %s",
+                    request_id,
+                )
+                return
+            result = {
+                k: v for k, v in msg.items() if k not in ("id", "cmd", "type")
+            }
+            queue.put_nowait({"type": "done", "result": result})
+            return
         entry = self.pending_browser_requests.get(request_id)
         if entry is None:
             logger.debug(
@@ -357,6 +446,25 @@ class WebSocketState:
         self.pending_browser_requests.pop(request_id, None)
         if not future.done():
             future.set_result(msg)
+
+    def handle_browser_chunk(
+        self, msg: dict, sender: SafeWebSocket | None = None
+    ) -> None:
+        """Push a streamed chunk onto its request's queue.
+
+        Ignored if the request is unknown or the chunk comes from a
+        connection other than the one the request was dispatched to.
+        """
+        request_id = msg.get("id")
+        if not request_id:
+            return
+        entry = self.streaming_browser_requests.get(request_id)
+        if entry is None:
+            return
+        queue, expected_sock = entry
+        if expected_sock is not None and sender is not expected_sock:
+            return
+        queue.put_nowait({"type": "chunk", "delta": msg.get("delta", "")})
 
 
 state = WebSocketState()
@@ -887,6 +995,8 @@ async def handle_websocket(websocket: WebSocket) -> None:
                 await conn.handle_chat_delete(msg)
             elif cmd == "browser_response":
                 state.handle_browser_response(msg, safe_ws)
+            elif cmd == "browser_chunk":
+                state.handle_browser_chunk(msg, safe_ws)
             else:
                 send_error(safe_ws, f"Unknown command: {cmd}")
 

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -1152,6 +1152,39 @@ class TestBrowserBridge:
         finally:
             container.registry.revoke_bridge_token("ws-err")
 
+    async def test_stream_endpoint_relays_ndjson(self, client, user):
+        """The streaming endpoint relays the generator's NDJSON to the caller."""
+        mock_sock = MagicMock()
+        token = container.registry.create_bridge_token(
+            "ws-stream", sock=mock_sock
+        )
+
+        async def fake_stream():
+            yield '{"type": "chunk", "delta": "a"}\n'
+            yield '{"type": "done", "result": {"ok": true}}\n'.replace(
+                "true", "1"
+            )
+
+        mock_session = AsyncMock()
+        mock_session.browser_subscribers = {mock_sock}
+        mock_session.dispatch_browser_request_stream_to = MagicMock(
+            return_value=fake_stream()
+        )
+        try:
+            with patch.object(
+                wshandler.state, "get_session", return_value=mock_session
+            ):
+                resp = await client.post(
+                    "/api/browser-delegate/stream",
+                    json={"action": "soliplex_query", "token": token},
+                )
+            assert resp.status_code == 200
+            assert '"chunk"' in resp.text
+            assert '"done"' in resp.text
+            mock_session.dispatch_browser_request_stream_to.assert_called_once()
+        finally:
+            container.registry.revoke_bridge_token("ws-stream")
+
 
 # --- Volume routes ---
 

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -2558,3 +2558,177 @@ class TestChatDelete:
         conn.workspace_id = "ws"
         await conn.handle_chat_delete({})
         sock.send_json.assert_not_called()
+
+
+class TestBridgeIdleTimeout:
+    def test_default(self, monkeypatch):
+        monkeypatch.delenv("KLANGK_BRIDGE_TIMEOUT_SECONDS", raising=False)
+        assert wshandler.bridge_idle_timeout() == 180.0
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv("KLANGK_BRIDGE_TIMEOUT_SECONDS", "45")
+        assert wshandler.bridge_idle_timeout() == 45.0
+
+    def test_invalid_env_falls_back(self, monkeypatch):
+        monkeypatch.setenv("KLANGK_BRIDGE_TIMEOUT_SECONDS", "nope")
+        assert wshandler.bridge_idle_timeout() == 180.0
+
+
+class TestHandleBrowserChunk:
+    def test_missing_id(self):
+        wshandler.state.handle_browser_chunk({})  # no raise
+
+    def test_unknown_id(self):
+        wshandler.state.handle_browser_chunk({"id": "nope", "delta": "x"})
+
+    def test_wrong_sender_ignored(self):
+        q: asyncio.Queue = asyncio.Queue()
+        expected = _mock_sock()
+        imposter = _mock_sock()
+        wshandler.state.streaming_browser_requests["c-1"] = (q, expected)
+        try:
+            wshandler.state.handle_browser_chunk(
+                {"id": "c-1", "delta": "x"}, sender=imposter
+            )
+            assert q.empty()
+        finally:
+            wshandler.state.streaming_browser_requests.pop("c-1", None)
+
+    def test_success(self):
+        q: asyncio.Queue = asyncio.Queue()
+        sock = _mock_sock()
+        wshandler.state.streaming_browser_requests["c-2"] = (q, sock)
+        try:
+            wshandler.state.handle_browser_chunk(
+                {"id": "c-2", "delta": "hello"}, sender=sock
+            )
+            assert q.get_nowait() == {"type": "chunk", "delta": "hello"}
+        finally:
+            wshandler.state.streaming_browser_requests.pop("c-2", None)
+
+
+class TestHandleBrowserResponseStreaming:
+    def test_done_enqueued(self):
+        q: asyncio.Queue = asyncio.Queue()
+        sock = _mock_sock()
+        wshandler.state.streaming_browser_requests["d-1"] = (q, sock)
+        try:
+            wshandler.state.handle_browser_response(
+                {"id": "d-1", "cmd": "browser_response", "text": "final"},
+                sender=sock,
+            )
+            assert q.get_nowait() == {
+                "type": "done",
+                "result": {"text": "final"},
+            }
+        finally:
+            wshandler.state.streaming_browser_requests.pop("d-1", None)
+
+    def test_wrong_sender_ignored(self):
+        q: asyncio.Queue = asyncio.Queue()
+        expected = _mock_sock()
+        imposter = _mock_sock()
+        wshandler.state.streaming_browser_requests["d-2"] = (q, expected)
+        try:
+            wshandler.state.handle_browser_response(
+                {"id": "d-2", "text": "x"}, sender=imposter
+            )
+            assert q.empty()
+        finally:
+            wshandler.state.streaming_browser_requests.pop("d-2", None)
+
+
+class TestDispatchBrowserRequestStreamTo:
+    async def test_streams_chunks_then_done(self):
+        session = wshandler.state.get_or_create_session("ws-stream")
+        sock = _mock_sock()
+        session.subscribers.add(sock)
+        session.browser_subscribers.add(sock)
+
+        async def feed():
+            await asyncio.sleep(0.05)
+            for rid, (_q, _s) in list(
+                wshandler.state.streaming_browser_requests.items()
+            ):
+                wshandler.state.handle_browser_chunk(
+                    {"id": rid, "delta": "hel"}, sender=sock
+                )
+                wshandler.state.handle_browser_chunk(
+                    {"id": rid, "delta": "lo"}, sender=sock
+                )
+                wshandler.state.handle_browser_response(
+                    {"id": rid, "cmd": "browser_response", "text": "hello"},
+                    sender=sock,
+                )
+
+        task = asyncio.create_task(feed())
+        try:
+            lines = [
+                json.loads(line)
+                async for line in session.dispatch_browser_request_stream_to(
+                    sock, {"action": "soliplex_query"}, 5.0
+                )
+            ]
+            assert lines[0] == {"type": "chunk", "delta": "hel"}
+            assert lines[1] == {"type": "chunk", "delta": "lo"}
+            assert lines[2]["type"] == "done"
+            assert lines[2]["result"]["text"] == "hello"
+            # cleaned up after the stream ends
+            assert not wshandler.state.streaming_browser_requests
+        finally:
+            await task
+            wshandler.state.sessions.pop("ws-stream", None)
+
+    async def test_send_failure_yields_error(self):
+        session = wshandler.state.get_or_create_session("ws-stream-dead")
+        sock = _mock_sock()
+        sock.send_json = MagicMock(side_effect=RuntimeError("dead"))
+        try:
+            lines = [
+                json.loads(line)
+                async for line in session.dispatch_browser_request_stream_to(
+                    sock, {"action": "soliplex_query"}, 5.0
+                )
+            ]
+            assert len(lines) == 1
+            assert lines[0]["type"] == "error"
+            assert "not available" in lines[0]["error"]
+            assert not wshandler.state.streaming_browser_requests
+        finally:
+            wshandler.state.sessions.pop("ws-stream-dead", None)
+
+    async def test_idle_timeout_yields_error(self):
+        session = wshandler.state.get_or_create_session("ws-stream-to")
+        sock = _mock_sock()
+        try:
+            lines = [
+                json.loads(line)
+                async for line in session.dispatch_browser_request_stream_to(
+                    sock, {"action": "soliplex_query"}, 0.05
+                )
+            ]
+            assert len(lines) == 1
+            assert lines[0]["type"] == "error"
+            assert "timeout" in lines[0]["error"].lower()
+            assert not wshandler.state.streaming_browser_requests
+        finally:
+            wshandler.state.sessions.pop("ws-stream-to", None)
+
+    async def test_loop_dispatches_browser_chunk(self, user):
+        from klangk_backend import auth as auth_mod
+
+        token = auth_mod.create_token(user["id"], user["email"])
+        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket.receive_text = AsyncMock(
+            side_effect=[
+                json.dumps({"cmd": "browser_chunk", "id": "x", "delta": "d"}),
+                WebSocketDisconnect(),
+            ]
+        )
+        with patch.object(
+            wshandler.state,
+            "handle_browser_chunk",
+            wraps=wshandler.state.handle_browser_chunk,
+        ) as mock:
+            await handle_websocket(websocket)
+        mock.assert_called_once()

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -2563,7 +2563,7 @@ class TestChatDelete:
 class TestBridgeIdleTimeout:
     def test_default(self, monkeypatch):
         monkeypatch.delenv("KLANGK_BRIDGE_TIMEOUT_SECONDS", raising=False)
-        assert wshandler.bridge_idle_timeout() == 180.0
+        assert wshandler.bridge_idle_timeout() == 30.0
 
     def test_env_override(self, monkeypatch):
         monkeypatch.setenv("KLANGK_BRIDGE_TIMEOUT_SECONDS", "45")
@@ -2571,7 +2571,7 @@ class TestBridgeIdleTimeout:
 
     def test_invalid_env_falls_back(self, monkeypatch):
         monkeypatch.setenv("KLANGK_BRIDGE_TIMEOUT_SECONDS", "nope")
-        assert wshandler.bridge_idle_timeout() == 180.0
+        assert wshandler.bridge_idle_timeout() == 30.0
 
 
 class TestHandleBrowserChunk:


### PR DESCRIPTION
## Problem
The browser-delegate bridge waited a fixed **30s** for the browser's single `browser_response`. RAG+LLM actions (`soliplex_query`/`soliplex_list_rooms`) routinely exceed that, so the bridge timed out mid-query → **HTTP 502** (which the soliplex extension mislabels as an OIDC retry). Using `soliplex_client` streaming doesn't help: the whole stream is consumed client-side and only one response crosses the bridge.

## Fix
- `api.py`: `browser_delegate_timeout(action)` — long actions get **180s** (overridable via `KLANGK_BRIDGE_TIMEOUT_SECONDS`); quick UI actions keep 30s. Passed to `dispatch_browser_request_to`.
- `scripts/nginx.sh`: dedicated `location = /api/browser-delegate` with **300s** `proxy_read/send_timeout` (nginx's 60s default would otherwise cut long waits).
- Tests cover every timeout-selection branch + the endpoint wiring (kept at 100% coverage).

Backend-only; no soliplex_client dependency. Also fixes the same timeout for the web client.