### PR TITLE
soliplex (native): emit query deltas as browser_chunk

### DIFF
--- a/native-plugins/soliplex/lib/plugin.dart
+++ b/native-plugins/soliplex/lib/plugin.dart
@@ -39,6 +39,11 @@ class SoliplexPlugin extends ToolPlugin with ChangeNotifier {
         'soliplex_query': _query,
       };
 
+  @override
+  Map<String, StreamingToolHandler> get streamingHandlers => {
+        'soliplex_query': _queryStream,
+      };
+
   late final _overlay = _SoliplexAuthOverlay(
     key: const ValueKey('soliplex_auth_overlay'),
     plugin: this,
@@ -87,12 +92,21 @@ class SoliplexPlugin extends ToolPlugin with ChangeNotifier {
     }
   }
 
-  Future<String> _query(Map<String, dynamic> request) async {
+  Future<String> _query(Map<String, dynamic> request) =>
+      _runQuery(request, null);
+
+  Future<String> _queryStream(
+          Map<String, dynamic> request, ToolChunkSink emit) =>
+      _runQuery(request, emit);
+
+  Future<String> _runQuery(
+      Map<String, dynamic> request, ToolChunkSink? onChunk) async {
     final roomId = request['room_id'] as String? ?? 'search';
     final question = request['question'] as String? ?? '';
     if (question.isEmpty) return 'Error: question is required';
     try {
-      final result = await SoliplexClient().queryRoom(roomId, question);
+      final result = await SoliplexClient()
+          .queryRoom(roomId, question, onChunk: onChunk);
       await _refreshAuthState();
       return result;
     } catch (e) {

--- a/native-plugins/soliplex/lib/soliplex_tools.dart
+++ b/native-plugins/soliplex/lib/soliplex_tools.dart
@@ -191,7 +191,11 @@ class SoliplexClient {
 
   /// Query a room by creating a thread, posting a question, and
   /// collecting the streamed response.
-  Future<String> queryRoom(String roomId, String question) async {
+  Future<String> queryRoom(
+    String roomId,
+    String question, {
+    void Function(String delta)? onChunk,
+  }) async {
     final soliplexUrl = await _getSoliplexUrl();
     final headers = await _getHeaders();
 
@@ -248,6 +252,7 @@ class SoliplexClient {
           final event = outcome.event;
           if (event is sox.TextMessageContentEvent) {
             buffer.write(event.delta);
+            onChunk?.call(event.delta);
           }
         }
       }

--- a/src/frontend/pubspec_overrides.yaml
+++ b/src/frontend/pubspec_overrides.yaml
@@ -7,3 +7,9 @@
 dependency_overrides:
   klangk_plugins:
     path: ../../native-plugins/aggregator
+  # Use the streaming-tool-handler API (adds StreamingToolHandler + onChunk)
+  # until mcdonc/klangk-plugin-api#1 merges; then drop this override.
+  klangk_plugin_api:
+    git:
+      url: https://github.com/runyaga/klangk-plugin-api.git
+      ref: streaming-tool-handler


### PR DESCRIPTION
Re-scoped: now **only** the soliplex-native delta emission. The generic, plugin-agnostic bridge plumbing moved to **#91** (→ `main`).

## What
- `queryRoom` takes an optional `onChunk`, fed from `AgUiStreamClient` text deltas.
- plugin exposes `streamingHandlers['soliplex_query']`.
- `pubspec_overrides`: `klangk_plugin_api` → fork until **mcdonc/klangk-plugin-api#1** lands.

## Stack
1. **mcdonc/klangk#79** — backend `/stream`
2. **mcdonc/klangk-plugin-api#1** — `StreamingToolHandler`/`onChunk` API
3. **mcdonc/klangk#91** — generic `BrowserDelegate`/`ws_client` chunk plumbing (→ `main`)
4. **this PR (#80)** — soliplex-native emission (→ `macos-native`)

Dormant until `macos-native` picks up #91's plumbing (via `main`).