### PR TITLE
Fix port conflict when stale workspace containers hold ports

### DIFF
--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -443,11 +443,44 @@ class ContainerRegistry:
             "Tty": False,
         }
 
+        container_name = f"klangk-{INSTANCE_ID}-{workspace_id[:12]}"
         created = await docker.containers.create_or_replace(
-            name=f"klangk-{INSTANCE_ID}-{workspace_id[:12]}",
+            name=container_name,
             config=config,
         )
-        await created.start()
+        try:
+            await created.start()
+        except aiodocker.exceptions.DockerError as exc:
+            if "port is already allocated" not in str(exc):
+                raise
+            # A stale container is holding one of our ports.
+            # Kill all managed containers for this instance that
+            # aren't the one we just created, then retry.
+            logger.warning(
+                "Port conflict starting %s, cleaning stale containers",
+                container_name,
+            )
+            stale = await docker.containers.list(
+                all=True,
+                filters={
+                    "label": [
+                        "klangk.managed=true",
+                        f"klangk.instance={INSTANCE_ID}",
+                    ],
+                },
+            )
+            for c in stale:
+                if c.id != created.id:
+                    try:
+                        await c.delete(force=True)
+                        logger.info("Removed stale container %s", c.id)
+                    except aiodocker.exceptions.DockerError as del_exc:
+                        logger.info(
+                            "Could not remove stale container %s: %s",
+                            c.id,
+                            del_exc,
+                        )
+            await created.start()
         container_id = created.id
 
         await model.update_workspace_container(workspace_id, container_id)

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -580,6 +580,139 @@ class TestStartContainer:
         assert env_dict["FOO"] == "bar"
 
 
+class TestStartContainerPortConflict:
+    """Test retry logic when a stale container holds a port."""
+
+    def setup_method(self):
+        container.registry.states.clear()
+
+    def teardown_method(self):
+        container.registry.states.clear()
+
+    async def test_port_conflict_kills_stale_and_retries(self, workspace):
+        mock_docker = _mock_docker()
+        mock_c = _mock_container("new-cid")
+        # First start() raises port conflict, second succeeds
+        mock_c.start = AsyncMock(
+            side_effect=[
+                aiodocker.exceptions.DockerError(
+                    500,
+                    {
+                        "message": "Bind for 0.0.0.0:9000 failed: "
+                        "port is already allocated"
+                    },
+                ),
+                None,
+            ]
+        )
+        mock_docker.containers.create_or_replace = AsyncMock(
+            return_value=mock_c
+        )
+        # Stale container to be cleaned up
+        stale = MagicMock()
+        stale.id = "stale-cid"
+        stale.delete = AsyncMock()
+        mock_docker.containers.list = AsyncMock(return_value=[stale])
+
+        with patch.object(
+            container.registry, "get_docker", return_value=mock_docker
+        ):
+            cid, status = await container.registry.start_container(
+                workspace["id"], "/tmp/ws", "/tmp/home"
+            )
+        assert cid == "new-cid"
+        assert status == "created"
+        assert mock_c.start.await_count == 2
+        stale.delete.assert_awaited_once_with(force=True)
+
+    async def test_port_conflict_skips_own_container(self, workspace):
+        mock_docker = _mock_docker()
+        mock_c = _mock_container("new-cid")
+        mock_c.start = AsyncMock(
+            side_effect=[
+                aiodocker.exceptions.DockerError(
+                    500,
+                    {"message": "port is already allocated"},
+                ),
+                None,
+            ]
+        )
+        mock_docker.containers.create_or_replace = AsyncMock(
+            return_value=mock_c
+        )
+        # Only "stale" container is our own — should not be deleted
+        own = MagicMock()
+        own.id = "new-cid"
+        own.delete = AsyncMock()
+        mock_docker.containers.list = AsyncMock(return_value=[own])
+
+        with patch.object(
+            container.registry, "get_docker", return_value=mock_docker
+        ):
+            cid, _ = await container.registry.start_container(
+                workspace["id"], "/tmp/ws", "/tmp/home"
+            )
+        assert cid == "new-cid"
+        own.delete.assert_not_awaited()
+
+    async def test_port_conflict_stale_delete_error_logged(self, workspace):
+        mock_docker = _mock_docker()
+        mock_c = _mock_container("new-cid")
+        mock_c.start = AsyncMock(
+            side_effect=[
+                aiodocker.exceptions.DockerError(
+                    500,
+                    {"message": "port is already allocated"},
+                ),
+                None,
+            ]
+        )
+        mock_docker.containers.create_or_replace = AsyncMock(
+            return_value=mock_c
+        )
+        stale = MagicMock()
+        stale.id = "stale-cid"
+        stale.delete = AsyncMock(
+            side_effect=aiodocker.exceptions.DockerError(
+                500, {"message": "removal in progress"}
+            )
+        )
+        mock_docker.containers.list = AsyncMock(return_value=[stale])
+
+        with patch.object(
+            container.registry, "get_docker", return_value=mock_docker
+        ):
+            cid, _ = await container.registry.start_container(
+                workspace["id"], "/tmp/ws", "/tmp/home"
+            )
+        assert cid == "new-cid"
+        stale.delete.assert_awaited_once()
+
+    async def test_non_port_conflict_error_raised(self, workspace):
+        mock_docker = _mock_docker()
+        mock_c = _mock_container("new-cid")
+        mock_c.start = AsyncMock(
+            side_effect=aiodocker.exceptions.DockerError(
+                500, {"message": "some other error"}
+            )
+        )
+        mock_docker.containers.create_or_replace = AsyncMock(
+            return_value=mock_c
+        )
+
+        with (
+            patch.object(
+                container.registry,
+                "get_docker",
+                return_value=mock_docker,
+            ),
+            pytest.raises(aiodocker.exceptions.DockerError),
+        ):
+            await container.registry.start_container(
+                workspace["id"], "/tmp/ws", "/tmp/home"
+            )
+
+
 class TestValidateMountSpec:
     def test_valid_bind_mount(self):
         assert container.validate_mount_spec("/host:/container") is None


### PR DESCRIPTION
## Summary

- When `start_container` fails with "port is already allocated", kill all managed containers for this instance (except the one being started) and retry
- Handles the case where the DB is ephemeral (e.g. tmpdir in host container) but old workspace containers are still running in Docker
- Logs stale container cleanup at warning/info level

## Test plan

- [x] 4 new tests covering port conflict retry, skip-own-container, delete error logging, and non-port-conflict passthrough
- [x] 835 tests pass, 100% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)