### PR TITLE
Fix CI E2E: kill leftover nginx/backend after devenv processes down

### DIFF
--- a/.github/workflows/cli-e2e-tests.yml
+++ b/.github/workflows/cli-e2e-tests.yml
@@ -41,6 +41,10 @@ jobs:
         run: |
           . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
           devenv processes down --no-tui 2>/dev/null || true
+          # Ensure no leftover processes hold ports
+          for port in 8995 8997; do
+            fuser -k "$port/tcp" 2>/dev/null || true
+          done
 
       - name: Run CLI E2E tests
         if: steps.filter.outputs.e2e == 'true'


### PR DESCRIPTION
## Summary

Kill leftover processes on ports 8995/8997 after `devenv processes down` in the CLI E2E workflow. The new nginx.sh no longer crashes on unresolvable LLM hostnames, so nginx stays alive after `devenv processes up -d`. If `devenv processes down` doesn't kill it cleanly, the leftover process competes for Docker socket resources with the E2E test server, causing timeouts starting at TestSync.

## Test plan

- [ ] CI CLI E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)