### PR TITLE
Fix port conflict cleanup to scope by port, not all containers

### DIFF
--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -454,12 +454,13 @@ class ContainerRegistry:
             if "port is already allocated" not in str(exc):
                 raise
             # A stale container is holding one of our ports.
-            # Kill all managed containers for this instance that
-            # aren't the one we just created, then retry.
+            # Find which managed containers bind the conflicting ports
+            # and remove only those, not all containers.
             logger.warning(
                 "Port conflict starting %s, cleaning stale containers",
                 container_name,
             )
+            wanted_ports = set(host_ports)
             stale = await docker.containers.list(
                 all=True,
                 filters={
@@ -470,10 +471,25 @@ class ContainerRegistry:
                 },
             )
             for c in stale:
-                if c.id != created.id:
+                if c.id == created.id:
+                    continue
+                info = await c.show()
+                bindings = info.get("HostConfig", {}).get("PortBindings") or {}
+                bound_ports = set()
+                for ports_list in bindings.values():
+                    for entry in ports_list or []:
+                        try:
+                            bound_ports.add(int(entry["HostPort"]))
+                        except (KeyError, ValueError, TypeError):
+                            pass
+                if bound_ports & wanted_ports:
                     try:
                         await c.delete(force=True)
-                        logger.info("Removed stale container %s", c.id)
+                        logger.info(
+                            "Removed stale container %s (ports %s)",
+                            c.id,
+                            bound_ports & wanted_ports,
+                        )
                     except aiodocker.exceptions.DockerError as del_exc:
                         logger.info(
                             "Could not remove stale container %s: %s",

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -589,6 +589,19 @@ class TestStartContainerPortConflict:
     def teardown_method(self):
         container.registry.states.clear()
 
+    def _stale_with_ports(self, cid, ports):
+        """Create a mock stale container that binds the given host ports."""
+        stale = MagicMock()
+        stale.id = cid
+        stale.delete = AsyncMock()
+        bindings = {}
+        for p in ports:
+            bindings[f"{p}/tcp"] = [{"HostPort": str(p)}]
+        stale.show = AsyncMock(
+            return_value={"HostConfig": {"PortBindings": bindings}}
+        )
+        return stale
+
     async def test_port_conflict_kills_stale_and_retries(self, workspace):
         mock_docker = _mock_docker()
         mock_c = _mock_container("new-cid")
@@ -608,10 +621,10 @@ class TestStartContainerPortConflict:
         mock_docker.containers.create_or_replace = AsyncMock(
             return_value=mock_c
         )
-        # Stale container to be cleaned up
-        stale = MagicMock()
-        stale.id = "stale-cid"
-        stale.delete = AsyncMock()
+        # Stale container that holds a port in the range we'll allocate
+        stale = self._stale_with_ports(
+            "stale-cid", [container.PORT_RANGE_START]
+        )
         mock_docker.containers.list = AsyncMock(return_value=[stale])
 
         with patch.object(
@@ -624,6 +637,36 @@ class TestStartContainerPortConflict:
         assert status == "created"
         assert mock_c.start.await_count == 2
         stale.delete.assert_awaited_once_with(force=True)
+
+    async def test_port_conflict_skips_non_overlapping_container(
+        self, workspace
+    ):
+        mock_docker = _mock_docker()
+        mock_c = _mock_container("new-cid")
+        mock_c.start = AsyncMock(
+            side_effect=[
+                aiodocker.exceptions.DockerError(
+                    500,
+                    {"message": "port is already allocated"},
+                ),
+                None,
+            ]
+        )
+        mock_docker.containers.create_or_replace = AsyncMock(
+            return_value=mock_c
+        )
+        # Container that does NOT hold any of our ports — should not be deleted
+        other = self._stale_with_ports("other-cid", [59999])
+        mock_docker.containers.list = AsyncMock(return_value=[other])
+
+        with patch.object(
+            container.registry, "get_docker", return_value=mock_docker
+        ):
+            cid, _ = await container.registry.start_container(
+                workspace["id"], "/tmp/ws", "/tmp/home"
+            )
+        assert cid == "new-cid"
+        other.delete.assert_not_awaited()
 
     async def test_port_conflict_skips_own_container(self, workspace):
         mock_docker = _mock_docker()
@@ -641,9 +684,7 @@ class TestStartContainerPortConflict:
             return_value=mock_c
         )
         # Only "stale" container is our own — should not be deleted
-        own = MagicMock()
-        own.id = "new-cid"
-        own.delete = AsyncMock()
+        own = self._stale_with_ports("new-cid", [container.PORT_RANGE_START])
         mock_docker.containers.list = AsyncMock(return_value=[own])
 
         with patch.object(
@@ -670,8 +711,9 @@ class TestStartContainerPortConflict:
         mock_docker.containers.create_or_replace = AsyncMock(
             return_value=mock_c
         )
-        stale = MagicMock()
-        stale.id = "stale-cid"
+        stale = self._stale_with_ports(
+            "stale-cid", [container.PORT_RANGE_START]
+        )
         stale.delete = AsyncMock(
             side_effect=aiodocker.exceptions.DockerError(
                 500, {"message": "removal in progress"}
@@ -687,6 +729,47 @@ class TestStartContainerPortConflict:
             )
         assert cid == "new-cid"
         stale.delete.assert_awaited_once()
+
+    async def test_port_conflict_skips_bad_port_bindings(self, workspace):
+        mock_docker = _mock_docker()
+        mock_c = _mock_container("new-cid")
+        mock_c.start = AsyncMock(
+            side_effect=[
+                aiodocker.exceptions.DockerError(
+                    500,
+                    {"message": "port is already allocated"},
+                ),
+                None,
+            ]
+        )
+        mock_docker.containers.create_or_replace = AsyncMock(
+            return_value=mock_c
+        )
+        # Container with malformed port bindings — should not crash
+        stale = MagicMock()
+        stale.id = "bad-cid"
+        stale.delete = AsyncMock()
+        stale.show = AsyncMock(
+            return_value={
+                "HostConfig": {
+                    "PortBindings": {
+                        "80/tcp": [{"HostPort": "not-a-number"}],
+                        "81/tcp": [{}],
+                        "82/tcp": None,
+                    }
+                }
+            }
+        )
+        mock_docker.containers.list = AsyncMock(return_value=[stale])
+
+        with patch.object(
+            container.registry, "get_docker", return_value=mock_docker
+        ):
+            cid, _ = await container.registry.start_container(
+                workspace["id"], "/tmp/ws", "/tmp/home"
+            )
+        assert cid == "new-cid"
+        stale.delete.assert_not_awaited()
 
     async def test_non_port_conflict_error_raised(self, workspace):
         mock_docker = _mock_docker()


### PR DESCRIPTION
## Summary

- Port conflict retry was force-deleting **all** managed containers, not just the one holding the conflicting port
- This killed unrelated workspaces' containers during concurrent operations (root cause of browser-delegate E2E test flake)
- Now inspects each container's `HostConfig.PortBindings` and only removes those binding a port we need

## Test plan
- [x] `devenv shell -- test-backend` — 879 passed, 100% coverage
- [ ] Run frontend E2E tests to verify browser-delegate test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)