### PR TITLE
Match container klangk user UID/GID to host at runtime

### DIFF
--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -348,6 +348,8 @@ class ContainerRegistry:
         ]
         env_vars.append(f"KLANGK_PORT_MAPPINGS={','.join(mappings)}")
         env_vars.append(f"KLANGK_WORKSPACE_ID={workspace_id}")
+        env_vars.append(f"KLANGK_HOST_UID={os.getuid()}")
+        env_vars.append(f"KLANGK_HOST_GID={os.getgid()}")
         # KLANGK_BRIDGE_URL is set at container level so all exec sessions
         # know the backend URL.  KLANGK_BRIDGE_TOKEN is set per-exec
         # session (in terminal.py) so each connection has its own token.

--- a/src/docker/workspace/Dockerfile.base
+++ b/src/docker/workspace/Dockerfile.base
@@ -66,7 +66,10 @@ RUN ln -sf /usr/bin/fdfind /usr/bin/fd
 # Install @earendil-works last so its `pi` binary wins.
 RUN npm install -g @mariozechner/pi-coding-agent @earendil-works/pi-coding-agent @anthropic-ai/claude-code
 
-# Create klangk user with host UID/GID (passed as build args)
+# Create klangk user with a default UID/GID. The entrypoint adjusts
+# this at runtime via usermod/groupmod to match the host UID/GID
+# (passed as KLANGK_HOST_UID/KLANGK_HOST_GID env vars) so that files
+# on the bind-mounted home directory are owned by the backend's user.
 ARG KLANGK_UID=1000
 ARG KLANGK_GID=1000
 RUN EXISTING_USER=$(getent passwd $KLANGK_UID | cut -d: -f1) \

--- a/src/docker/workspace/entrypoint.sh
+++ b/src/docker/workspace/entrypoint.sh
@@ -2,12 +2,22 @@
 # Minimal container entrypoint.
 set -e
 
-# The host bind-mounts $home_path as /home/klangk and pre-creates the
-# work/ subdirectory before the container starts.  Both end up owned by
-# the host UID.  chown is not recursive, so we must fix ownership on
-# the mount-point AND the work dir individually — otherwise the
-# container's klangk user cannot write to /home/klangk/work (breaks
-# rsync, file creation, etc.).
+# Match the container's klangk user to the host UID/GID so files
+# created inside the container are owned by the same user that runs
+# the backend.  This avoids permission mismatches on the bind-mounted
+# home directory (the backend needs to delete workspace files on cleanup).
+HOST_UID="${KLANGK_HOST_UID:-}"
+HOST_GID="${KLANGK_HOST_GID:-}"
+CURRENT_UID=$(id -u klangk)
+CURRENT_GID=$(id -g klangk)
+
+if [ -n "$HOST_GID" ] && [ "$HOST_GID" != "$CURRENT_GID" ]; then
+  groupmod -g "$HOST_GID" klangk 2>/dev/null || true
+fi
+if [ -n "$HOST_UID" ] && [ "$HOST_UID" != "$CURRENT_UID" ]; then
+  usermod -u "$HOST_UID" klangk 2>/dev/null || true
+fi
+
 chown klangk:klangk /home/klangk /home/klangk/work
 
 # Set up Pi agent config as the klangk user (extensions, settings, models,


### PR DESCRIPTION
## Summary

- Backend passes `KLANGK_HOST_UID`/`KLANGK_HOST_GID` env vars to each workspace container
- Entrypoint adjusts the klangk user's UID/GID via `usermod`/`groupmod` before running setup
- Files on the bind-mounted home directory are now owned by the same user that runs the backend
- Fixes CI E2E failures where `rmtree` couldn't delete UID 1000 files as UID 1001 (GitHub Actions runner), flooding the event loop with permission errors and causing WebSocket timeouts

## Test plan
- [x] `devenv shell -- test-backend` — 879 passed, 100% coverage
- [x] browser-delegate E2E test passes locally
- [x] chat message broadcast E2E test passes locally
- [ ] CI E2E tests pass (validates UID mismatch is resolved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)