### PR TITLE
bridge: relay streamed browser_chunk deltas (plugin-agnostic)

### DIFF
--- a/src/frontend/lib/browser/browser_delegate.dart
+++ b/src/frontend/lib/browser/browser_delegate.dart
@@ -41,7 +41,14 @@ class BrowserDelegate {
       if (action == 'fetch') {
         result = await _handleFetch(request);
       } else if (action != null) {
-        final response = await _registry.dispatch(action, request);
+        // Streaming bridge: when the backend marks the request as a stream,
+        // relay incremental deltas as browser_chunk messages; the final
+        // browser_response (below) terminates the stream.
+        final onChunk = request['stream'] == true
+            ? (String delta) => _client.sendBrowserChunk(id, delta)
+            : null;
+        final response =
+            await _registry.dispatch(action, request, onChunk: onChunk);
         if (response.startsWith('Unknown action:')) {
           result = {'error': response};
         } else {

--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -242,6 +242,12 @@ class WsClient extends ChangeNotifier {
     _send({'cmd': 'browser_response', 'id': id, ...result});
   }
 
+  /// Send an incremental streamed chunk for a browser_request (streaming
+  /// bridge). Followed by a final [sendBrowserResponse].
+  void sendBrowserChunk(String id, String delta) {
+    _send({'cmd': 'browser_chunk', 'id': id, 'delta': delta});
+  }
+
   void _startHeartbeat() {
     _stopHeartbeat();
     _heartbeatTimer = Timer.periodic(

--- a/src/frontend/test/browser_delegate_test.dart
+++ b/src/frontend/test/browser_delegate_test.dart
@@ -56,6 +56,17 @@ class _TestPlugin extends ToolPlugin {
           return 'beeped!';
         },
       };
+
+  @override
+  Map<String, StreamingToolHandler> get streamingHandlers => {
+        'stream_action': (request, emit) async {
+          callCount++;
+          lastAction = 'stream_action';
+          emit('Hel');
+          emit('lo');
+          return 'Hello';
+        },
+      };
 }
 
 class _ThrowingPlugin extends ToolPlugin {
@@ -71,6 +82,13 @@ List<Map<String, dynamic>> _browserResponses(_FakeWebSocketChannel channel) {
   return channel.sentMessages
       .map((s) => jsonDecode(s as String) as Map<String, dynamic>)
       .where((m) => m['cmd'] == 'browser_response')
+      .toList();
+}
+
+List<Map<String, dynamic>> _browserChunks(_FakeWebSocketChannel channel) {
+  return channel.sentMessages
+      .map((s) => jsonDecode(s as String) as Map<String, dynamic>)
+      .where((m) => m['cmd'] == 'browser_chunk')
       .toList();
 }
 
@@ -128,6 +146,25 @@ void main() {
       expect(responses[0]['id'], 'req-1');
       expect(responses[0]['status'], 'ok');
       expect(responses[0]['result'], 'celebrated!');
+    });
+
+    test('streams chunks then final response for stream requests', () async {
+      channel.serverSend({
+        'type': 'browser_request',
+        'id': 'req-s',
+        'action': 'stream_action',
+        'stream': true,
+      });
+      await Future.delayed(const Duration(milliseconds: 50));
+
+      final chunks = _browserChunks(channel);
+      expect(chunks.map((c) => c['delta']).toList(), ['Hel', 'lo']);
+      expect(chunks.every((c) => c['id'] == 'req-s'), isTrue);
+
+      final responses = _browserResponses(channel);
+      expect(responses.length, 1);
+      expect(responses[0]['id'], 'req-s');
+      expect(responses[0]['result'], 'Hello');
     });
 
     test('dispatches beep to plugin', () async {

--- a/src/frontend/test/ws_client_test.dart
+++ b/src/frontend/test/ws_client_test.dart
@@ -123,6 +123,7 @@ void main() {
       client.sendTerminalStop();
       client.sendHeartbeat();
       client.sendBrowserResponse('req-1', {'status': 'ok'});
+      client.sendBrowserChunk('req-1', 'delta');
 
       expect(client.connected, isFalse);
       client.dispose();


### PR DESCRIPTION
Split out of #80 — the **generic** half that belongs on `main` (plugin-agnostic).

## What
- `ws_client.sendBrowserChunk(id, delta)`
- `BrowserDelegate`: when a `browser_request` has `stream: true`, dispatch with an `onChunk` sink that relays each delta as `browser_chunk`; the final `browser_response` ends the stream.
- Tests for both.

Any streaming plugin benefits — no soliplex/native specifics here.

## Stack / deps
- **Depends on mcdonc/klangk-plugin-api#1** (the `onChunk` dispatch + `StreamingToolHandler` API) — won't compile/CI-pass until that merges, hence **draft**.
- Pairs with backend **#79** (`/api/browser-delegate/stream`).
- The soliplex-native delta emission is the remaining half — **#80** (re-scoped, base `macos-native`).