### PR TITLE
Fix nginx resolver crash on IPv6 nameservers

### DIFF
--- a/scripts/nginx.sh
+++ b/scripts/nginx.sh
@@ -19,7 +19,12 @@ if [ -n "${KLANGK_LLM_BASE_URL:-}" ]; then
   if [ -n "${KLANGK_DNS_SERVERS:-}" ]; then
     DNS_RESOLVERS="${KLANGK_DNS_SERVERS//,/ }"
   else
-    DNS_RESOLVERS=$(awk '/^nameserver/{printf "%s ", $2}' /etc/resolv.conf)
+    # Wrap IPv6 addresses in brackets for nginx resolver directive.
+    DNS_RESOLVERS=$(awk '/^nameserver/{
+      addr = $2
+      if (addr ~ /:/) addr = "[" addr "]"
+      printf "%s ", addr
+    }' /etc/resolv.conf)
     DNS_RESOLVERS="${DNS_RESOLVERS:-8.8.8.8}"
   fi
   LLM_BLOCK="


### PR DESCRIPTION
## Summary

- Nginx fails to start when `/etc/resolv.conf` contains IPv6 nameservers (e.g., Tailscale `fd7a:115c:a1e0::53`)
- Nginx requires IPv6 addresses wrapped in brackets in the `resolver` directive
- The awk parser now detects colons in addresses and adds brackets automatically
- This was the root cause of the browser bridge being unreachable on biggysmalls/rag — nginx wasn't running, so containers couldn't reach `host.docker.internal:8995`

## Test plan
- [x] Verified nginx starts on a system with IPv6 nameservers in resolv.conf

🤖 Generated with [Claude Code](https://claude.com/claude-code)