### PR TITLE
Add OIDC authentication with multi-provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,14 @@ KLANGK_LLM_MODEL=gemma4:31b
 KLANGK_JWT_SECRET=change-this-to-a-random-secret
 KLANGK_DEFAULT_USER=admin@example.com
 # KLANGK_DEFAULT_PASSWORD=admin  # omit to generate a random password on first run
+
+# SMTP (optional — enables email delivery for verification, invitations, password reset)
+# KLANGK_SMTP_HOST=smtp.gmail.com
+# KLANGK_SMTP_PORT=587
+# KLANGK_SMTP_USER=you@gmail.com
+# KLANGK_SMTP_PASSWORD=your-app-password
+# KLANGK_SMTP_FROM=you@gmail.com
+
+# OIDC authentication (optional — see HACKING.md for details)
+# KLANGK_OIDC_CONFIG=/path/to/oidc.json   # path to provider config JSON
+# KLANGK_AUTH_MODES=both                   # password | oidc | both

--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,8 @@ KLANGK_LLM_MODEL=gemma4:31b
 # Klangk configuration
 KLANGK_JWT_SECRET=change-this-to-a-random-secret
 KLANGK_DEFAULT_USER=admin@example.com
-# KLANGK_DEFAULT_PASSWORD=admin  # omit to generate a random password on first run
+# Omit to generate a random password on first run
+# KLANGK_DEFAULT_PASSWORD=admin
 
 # SMTP (optional — enables email delivery for verification, invitations, password reset)
 # KLANGK_SMTP_HOST=smtp.gmail.com
@@ -19,5 +20,6 @@ KLANGK_DEFAULT_USER=admin@example.com
 # KLANGK_SMTP_FROM=you@gmail.com
 
 # OIDC authentication (optional — see HACKING.md for details)
-# KLANGK_OIDC_CONFIG=/path/to/oidc.json   # path to provider config JSON
-# KLANGK_AUTH_MODES=both                   # password | oidc | both
+# KLANGK_OIDC_CONFIG=/path/to/oidc.yaml
+# password | oidc | both
+# KLANGK_AUTH_MODES=both

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ src/frontend/coverage/
 # Environment / secrets
 .env
 *.env.local
+oidc.json
 
 # IDE
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ src/frontend/coverage/
 # Environment / secrets
 .env
 *.env.local
-oidc.json
+.oidc/
 
 # IDE
 .idea/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -64,7 +64,9 @@ In CI, `devenv processes up -d` starts nginx before E2E tests run.
 
 ### Authentication
 
-- Email/password with bcrypt hashing, email validated at registration
+- **Two auth methods**: email/password (local) and OIDC (external Identity Providers). Configurable via `KLANGK_AUTH_MODES`: `password`, `oidc`, or `both` (default: `both` if OIDC configured, `password` otherwise).
+- **OIDC authentication**: Supports multiple OIDC providers (e.g., two Keycloak realms for CAC + internal SSO). Configured via a JSON file (`KLANGK_OIDC_CONFIG`). Each provider has its own login/callback endpoints (`GET /auth/oidc/{provider_id}/login`, `GET /auth/oidc/{provider_id}/callback`). Uses Authorization Code flow with PKCE. ID token signature validated against the IdP's JWKS. Login page shows one button per configured provider. JIT user provisioning on first OIDC login — users are created as verified with no password. Existing email/password users are linked to their OIDC identity on first SSO login. Per-provider role mapping syncs IdP group claims to Klangk roles on every login. CLI login (`klangk login`) opens a browser for the OIDC flow and receives the token via a temporary localhost callback server.
+- **Email/password authentication**: bcrypt hashing, email validated at registration
 - Email verification: registration sends a verification email with a signed token link; user must click to activate account and is auto-logged-in on verification. Resend via "Resend verification email" link on login page (shown on 403 "not verified" error, rate-limited to 1/min per email)
 - Email sent via SMTP (`KLANGK_SMTP_HOST/PORT/USER/PASSWORD/FROM`) or local sendmail (default, configurable via `KLANGK_SENDMAIL_PATH`)
 - JWT tokens (24hr expiry, secret configurable via KLANGK_JWT_SECRET) with token blocklist for logout, roles claim in JWT payload

--- a/HACKING.md
+++ b/HACKING.md
@@ -103,7 +103,7 @@ All settings can be overridden in `.env`. Defaults (where appropriate) are provi
 | `KLANGK_MIN_PASSWORD_LENGTH`    | `4`                                  | Minimum password length                                                                                                                                     |
 | `KLANGK_IMPORT_MAX_SIZE`        | `524288000`                          | Maximum upload size in bytes for workspace import (default 500 MB)                                                                                          |
 | `KLANGK_DISABLE_REGISTRATION`   |                                      | Set to any non-empty value to block new user signups and hide the registration link in the UI                                                               |
-| `KLANGK_OIDC_CONFIG`            |                                      | Path to OIDC provider config JSON file. Enables OIDC authentication when set. See [OIDC Configuration](#oidc-configuration).                                |
+| `KLANGK_OIDC_CONFIG`            |                                      | Path to OIDC provider config file (YAML or JSON). Enables OIDC authentication when set. See [OIDC Configuration](#oidc-configuration).                      |
 | `KLANGK_AUTH_MODES`             | `both` (if OIDC configured)          | Auth modes: `password`, `oidc`, or `both`. Defaults to `password` when no OIDC config.                                                                      |
 | `KLANGK_SMTP_HOST`              |                                      | SMTP server hostname (if set, uses SMTP; otherwise uses sendmail)                                                                                           |
 | `KLANGK_SMTP_PORT`              | `587`                                | SMTP server port                                                                                                                                            |
@@ -334,35 +334,31 @@ Klangk supports OIDC authentication via one or more external Identity Providers 
 
 ### Setup
 
-1. Create a JSON config file with your OIDC providers:
+1. Create a YAML config file with your OIDC providers:
 
-```json
-[
-  {
-    "id": "cac",
-    "display_name": "CAC Login",
-    "issuer": "https://keycloak.example.com/realms/dod",
-    "client_id": "klangk",
-    "client_secret": "file:/run/secrets/cac-secret",
-    "scopes": "openid email profile",
-    "admin_claim": "realm_access.roles",
-    "admin_group": "klangk-admin",
-    "ca_cert": "/etc/pki/tls/certs/dod-ca-bundle.pem"
-  },
-  {
-    "id": "internal",
-    "display_name": "Internal SSO",
-    "issuer": "https://keycloak.example.com/realms/corp",
-    "client_id": "klangk",
-    "client_secret": "file:/run/secrets/corp-secret"
-  }
-]
+```yaml
+- id: cac
+  display_name: CAC Login
+  issuer: https://keycloak.example.com/realms/dod
+  client_id: klangk
+  client_secret: "file:/run/secrets/cac-secret"
+  scopes: openid email profile
+  admin_claim: realm_access.roles
+  admin_group: klangk-admin
+  ca_cert: /etc/pki/tls/certs/dod-ca-bundle.pem
+  logout_redirect: true
+
+- id: internal
+  display_name: Internal SSO
+  issuer: https://keycloak.example.com/realms/corp
+  client_id: klangk
+  client_secret: "file:/run/secrets/corp-secret"
 ```
 
 1. Set `KLANGK_OIDC_CONFIG` in `.env`:
 
 ```bash
-KLANGK_OIDC_CONFIG=/path/to/oidc.json
+KLANGK_OIDC_CONFIG=/path/to/oidc.yaml
 ```
 
 1. Optionally set `KLANGK_AUTH_MODES` to control which login methods are available:
@@ -372,18 +368,19 @@ KLANGK_OIDC_CONFIG=/path/to/oidc.json
 
 ### Provider Config Fields
 
-| Field                  | Required | Description                                                                                       |
-| ---------------------- | -------- | ------------------------------------------------------------------------------------------------- |
-| `id`                   | Yes      | URL-safe slug, used in endpoint paths (`/auth/oidc/{id}/login`) and stored as `provider` on users |
-| `display_name`         | Yes      | Button label on the login page (e.g., "CAC Login", "Google")                                      |
-| `issuer`               | Yes      | OIDC issuer URL. Discovery via `{issuer}/.well-known/openid-configuration`                        |
-| `client_id`            | Yes      | OIDC client ID registered with the IdP                                                            |
-| `client_secret`        | Yes      | OIDC client secret. Supports `file:` prefix for secret management                                 |
-| `scopes`               | No       | Space-separated scopes (default: `openid email profile`)                                          |
-| `admin_claim`          | No       | Dot-path to the claim containing roles/groups (e.g., `realm_access.roles`)                        |
-| `admin_group`          | No       | Value in that claim that maps to the Klangk admin role                                            |
-| `ca_cert`              | No       | Path to a CA certificate PEM file for IdPs with custom/private CAs (e.g., DoD PKI)                |
-| `token_validation_pem` | No       | Inline RSA/EC public key PEM for static token validation (skips JWKS discovery)                   |
+| Field                  | Required | Description                                                                                                                 |
+| ---------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `id`                   | Yes      | URL-safe slug, used in endpoint paths (`/auth/oidc/{id}/login`) and stored as `provider` on users                           |
+| `display_name`         | Yes      | Button label on the login page (e.g., "CAC Login", "Google")                                                                |
+| `issuer`               | Yes      | OIDC issuer URL. Discovery via `{issuer}/.well-known/openid-configuration`                                                  |
+| `client_id`            | Yes      | OIDC client ID registered with the IdP                                                                                      |
+| `client_secret`        | Yes      | OIDC client secret. Supports `file:` prefix for secret management                                                           |
+| `scopes`               | No       | Space-separated scopes (default: `openid email profile`)                                                                    |
+| `admin_claim`          | No       | Dot-path to the claim containing roles/groups (e.g., `realm_access.roles`)                                                  |
+| `admin_group`          | No       | Value in that claim that maps to the Klangk admin role                                                                      |
+| `ca_cert`              | No       | Path to a CA certificate PEM file for IdPs with custom/private CAs (e.g., DoD PKI)                                          |
+| `token_validation_pem` | No       | Inline RSA/EC public key PEM for static token validation (skips JWKS discovery)                                             |
+| `logout_redirect`      | No       | If `true`, logout redirects to the IdP's `end_session_endpoint` (RP-Initiated Logout). Default: `false` (local-only logout) |
 
 ### How It Works
 
@@ -392,6 +389,7 @@ KLANGK_OIDC_CONFIG=/path/to/oidc.json
 - **User provisioning**: On first OIDC login, a user is created automatically (verified, no password). If a local user with the same email already exists, the OIDC identity is linked to it.
 - **Role mapping**: If `admin_claim` and `admin_group` are configured, the admin role is synced from the IdP claim on every login.
 - **OIDC users** cannot use forgot-password, change-password, or change-email.
+- **Logout**: By default, logout only kills the Klangk session. With `logout_redirect: true`, the user is also redirected to the IdP's logout endpoint to end the SSO session (requires full re-authentication on next login).
 
 ### IdP Setup (Keycloak Example)
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -346,7 +346,8 @@ Klangk supports OIDC authentication via one or more external Identity Providers 
     "client_secret": "file:/run/secrets/cac-secret",
     "scopes": "openid email profile",
     "admin_claim": "realm_access.roles",
-    "admin_group": "klangk-admin"
+    "admin_group": "klangk-admin",
+    "ca_cert": "/etc/pki/tls/certs/dod-ca-bundle.pem"
   },
   {
     "id": "internal",
@@ -381,6 +382,7 @@ KLANGK_OIDC_CONFIG=/path/to/oidc.json
 | `scopes`        | No       | Space-separated scopes (default: `openid email profile`)                                          |
 | `admin_claim`   | No       | Dot-path to the claim containing roles/groups (e.g., `realm_access.roles`)                        |
 | `admin_group`   | No       | Value in that claim that maps to the Klangk admin role                                            |
+| `ca_cert`       | No       | Path to a CA certificate PEM file for IdPs with custom/private CAs (e.g., DoD PKI)                |
 
 ### How It Works
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -103,6 +103,8 @@ All settings can be overridden in `.env`. Defaults (where appropriate) are provi
 | `KLANGK_MIN_PASSWORD_LENGTH`    | `4`                                  | Minimum password length                                                                                                                                     |
 | `KLANGK_IMPORT_MAX_SIZE`        | `524288000`                          | Maximum upload size in bytes for workspace import (default 500 MB)                                                                                          |
 | `KLANGK_DISABLE_REGISTRATION`   |                                      | Set to any non-empty value to block new user signups and hide the registration link in the UI                                                               |
+| `KLANGK_OIDC_CONFIG`            |                                      | Path to OIDC provider config JSON file. Enables OIDC authentication when set. See [OIDC Configuration](#oidc-configuration).                                |
+| `KLANGK_AUTH_MODES`             | `both` (if OIDC configured)          | Auth modes: `password`, `oidc`, or `both`. Defaults to `password` when no OIDC config.                                                                      |
 | `KLANGK_SMTP_HOST`              |                                      | SMTP server hostname (if set, uses SMTP; otherwise uses sendmail)                                                                                           |
 | `KLANGK_SMTP_PORT`              | `587`                                | SMTP server port                                                                                                                                            |
 | `KLANGK_SMTP_USER`              |                                      | SMTP auth username                                                                                                                                          |
@@ -325,6 +327,78 @@ git clone git@github.com:yourorg/private-repo.git
 ```
 
 For extra security, use `ssh-add -c` to require confirmation on the host for each SSH operation, preventing malicious code from silently using your key.
+
+## OIDC Configuration
+
+Klangk supports OIDC authentication via one or more external Identity Providers (e.g., Keycloak). This is used for CAC card login and other SSO scenarios. Klangk is a standard OIDC relying party — the IdP handles all certificate/credential complexity.
+
+### Setup
+
+1. Create a JSON config file with your OIDC providers:
+
+```json
+[
+  {
+    "id": "cac",
+    "display_name": "CAC Login",
+    "issuer": "https://keycloak.example.com/realms/dod",
+    "client_id": "klangk",
+    "client_secret": "file:/run/secrets/cac-secret",
+    "scopes": "openid email profile",
+    "admin_claim": "realm_access.roles",
+    "admin_group": "klangk-admin"
+  },
+  {
+    "id": "internal",
+    "display_name": "Internal SSO",
+    "issuer": "https://keycloak.example.com/realms/corp",
+    "client_id": "klangk",
+    "client_secret": "file:/run/secrets/corp-secret"
+  }
+]
+```
+
+1. Set `KLANGK_OIDC_CONFIG` in `.env`:
+
+```bash
+KLANGK_OIDC_CONFIG=/path/to/oidc.json
+```
+
+1. Optionally set `KLANGK_AUTH_MODES` to control which login methods are available:
+   - `both` (default when OIDC configured) — SSO buttons + email/password form
+   - `oidc` — SSO buttons only, email/password disabled
+   - `password` — email/password only (same as no OIDC config)
+
+### Provider Config Fields
+
+| Field           | Required | Description                                                                                       |
+| --------------- | -------- | ------------------------------------------------------------------------------------------------- |
+| `id`            | Yes      | URL-safe slug, used in endpoint paths (`/auth/oidc/{id}/login`) and stored as `provider` on users |
+| `display_name`  | Yes      | Button label on the login page (e.g., "CAC Login", "Google")                                      |
+| `issuer`        | Yes      | OIDC issuer URL. Discovery via `{issuer}/.well-known/openid-configuration`                        |
+| `client_id`     | Yes      | OIDC client ID registered with the IdP                                                            |
+| `client_secret` | Yes      | OIDC client secret. Supports `file:` prefix for secret management                                 |
+| `scopes`        | No       | Space-separated scopes (default: `openid email profile`)                                          |
+| `admin_claim`   | No       | Dot-path to the claim containing roles/groups (e.g., `realm_access.roles`)                        |
+| `admin_group`   | No       | Value in that claim that maps to the Klangk admin role                                            |
+
+### How It Works
+
+- **Web**: Login page shows one button per provider. Clicking redirects to the IdP via Authorization Code flow with PKCE. After authentication, the IdP redirects back to Klangk which exchanges the code for tokens, validates the ID token, and issues a Klangk JWT.
+- **CLI**: `klangk login` detects OIDC from the server config, opens a browser for authentication, and receives the token via a temporary localhost callback server.
+- **User provisioning**: On first OIDC login, a user is created automatically (verified, no password). If a local user with the same email already exists, the OIDC identity is linked to it.
+- **Role mapping**: If `admin_claim` and `admin_group` are configured, the admin role is synced from the IdP claim on every login.
+- **OIDC users** cannot use forgot-password, change-password, or change-email.
+
+### IdP Setup (Keycloak Example)
+
+1. Create a client in your Keycloak realm:
+   - Client ID: `klangk`
+   - Client authentication: On (confidential)
+   - Valid redirect URIs: `https://your-klangk-host/auth/oidc/cac/callback` (one per provider ID)
+   - Web origins: `https://your-klangk-host`
+2. Copy the client secret to a file or set it directly in the OIDC config
+3. For CAC: configure the X.509 client certificate authenticator in the Keycloak authentication flow
 
 ## CLI Access
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -372,17 +372,18 @@ KLANGK_OIDC_CONFIG=/path/to/oidc.json
 
 ### Provider Config Fields
 
-| Field           | Required | Description                                                                                       |
-| --------------- | -------- | ------------------------------------------------------------------------------------------------- |
-| `id`            | Yes      | URL-safe slug, used in endpoint paths (`/auth/oidc/{id}/login`) and stored as `provider` on users |
-| `display_name`  | Yes      | Button label on the login page (e.g., "CAC Login", "Google")                                      |
-| `issuer`        | Yes      | OIDC issuer URL. Discovery via `{issuer}/.well-known/openid-configuration`                        |
-| `client_id`     | Yes      | OIDC client ID registered with the IdP                                                            |
-| `client_secret` | Yes      | OIDC client secret. Supports `file:` prefix for secret management                                 |
-| `scopes`        | No       | Space-separated scopes (default: `openid email profile`)                                          |
-| `admin_claim`   | No       | Dot-path to the claim containing roles/groups (e.g., `realm_access.roles`)                        |
-| `admin_group`   | No       | Value in that claim that maps to the Klangk admin role                                            |
-| `ca_cert`       | No       | Path to a CA certificate PEM file for IdPs with custom/private CAs (e.g., DoD PKI)                |
+| Field                  | Required | Description                                                                                       |
+| ---------------------- | -------- | ------------------------------------------------------------------------------------------------- |
+| `id`                   | Yes      | URL-safe slug, used in endpoint paths (`/auth/oidc/{id}/login`) and stored as `provider` on users |
+| `display_name`         | Yes      | Button label on the login page (e.g., "CAC Login", "Google")                                      |
+| `issuer`               | Yes      | OIDC issuer URL. Discovery via `{issuer}/.well-known/openid-configuration`                        |
+| `client_id`            | Yes      | OIDC client ID registered with the IdP                                                            |
+| `client_secret`        | Yes      | OIDC client secret. Supports `file:` prefix for secret management                                 |
+| `scopes`               | No       | Space-separated scopes (default: `openid email profile`)                                          |
+| `admin_claim`          | No       | Dot-path to the claim containing roles/groups (e.g., `realm_access.roles`)                        |
+| `admin_group`          | No       | Value in that claim that maps to the Klangk admin role                                            |
+| `ca_cert`              | No       | Path to a CA certificate PEM file for IdPs with custom/private CAs (e.g., DoD PKI)                |
+| `token_validation_pem` | No       | Inline RSA/EC public key PEM for static token validation (skips JWKS discovery)                   |
 
 ### How It Works
 

--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -718,6 +718,7 @@ async def oidc_callback(
             status_code=502,
             detail="ID token missing sub or email claim",
         )
+    auth.validate_email(email)
 
     # Find or create user
     user = await model.get_user_by_external_id(provider_id, sub)

--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -425,7 +425,20 @@ async def logout(
     authorization = request.headers.get("authorization", "")
     if authorization.startswith("Bearer "):
         await auth.logout(authorization[7:])
-    return {"status": "ok"}
+
+    # If the user logged in via OIDC and the provider has logout_redirect
+    # enabled, return the IdP logout URL so the frontend can redirect.
+    result: dict = {"status": "ok"}
+    db_user = await model.get_user_by_email(user["email"])
+    if db_user and db_user.get("provider", "local") != "local":
+        provider = oidc.get_provider(db_user["provider"])
+        if provider:
+            hostname, proto, base_path = derive_hosting_info(request.headers)
+            post_logout_uri = f"{proto}://{hostname}{base_path}/#/login"
+            logout_url = await oidc.build_logout_url(provider, post_logout_uri)
+            if logout_url:
+                result["oidc_logout_url"] = logout_url
+    return result
 
 
 # --- Invitation endpoints ---
@@ -689,7 +702,9 @@ async def oidc_callback(
         raise HTTPException(status_code=502, detail="No ID token in response")
 
     try:
-        claims = await oidc.validate_id_token(provider, id_token)
+        claims = await oidc.validate_id_token(
+            provider, id_token, access_token=tokens.get("access_token")
+        )
     except Exception as exc:
         logger.error("OIDC ID token validation failed: %s", exc)
         raise HTTPException(

--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import posixpath
+import secrets
 import sqlite3
 import subprocess
 import tarfile
@@ -14,8 +15,10 @@ import time
 import uuid
 import zipfile
 
+import httpx
+
 from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile
-from fastapi.responses import FileResponse, StreamingResponse
+from fastapi.responses import FileResponse, RedirectResponse, StreamingResponse
 from pydantic import BaseModel
 
 from . import (
@@ -23,6 +26,7 @@ from . import (
     container,
     emailsvc,
     files,
+    oidc,
     wshandler,
     model,
     workspaces,
@@ -140,6 +144,8 @@ async def get_config():
         "invitations_enabled": auth.invitations_enabled(),
         "login_banner_title": LOGIN_BANNER_TITLE,
         "login_banner": LOGIN_BANNER,
+        "oidc_providers": oidc.list_providers(),
+        "auth_modes": oidc.auth_modes(),
     }
 
 
@@ -151,6 +157,11 @@ async def register(
     req: auth.RegisterRequest,
     request: Request,
 ):
+    if not oidc.password_login_allowed():
+        raise HTTPException(
+            status_code=403,
+            detail="Password registration is disabled",
+        )
     if resolve_env_secret("KLANGK_TEST_MODE"):
         # Test mode: auto-verify so E2E tests get immediate access
         result = await auth.register(req, verified=True)
@@ -329,6 +340,10 @@ async def reset_password(req: ResetPasswordRequest):
 
 @router.post("/auth/login", response_model=auth.TokenResponse)
 async def login(req: auth.LoginRequest):
+    if not oidc.password_login_allowed():
+        raise HTTPException(
+            status_code=403, detail="Password login is disabled"
+        )
     return await auth.login(req)
 
 
@@ -560,6 +575,185 @@ async def resend_invitation(
     )
 
     return {"status": "resent"}
+
+
+# --- OIDC endpoints ---
+
+
+@router.get("/auth/oidc/{provider_id}/login")
+async def oidc_login(
+    provider_id: str,
+    request: Request,
+    cli_redirect: str | None = None,
+):
+    """Redirect to the OIDC IdP for authentication."""
+    if not oidc.oidc_login_allowed():
+        raise HTTPException(status_code=404, detail="OIDC not enabled")
+
+    provider = oidc.get_provider(provider_id)
+    if provider is None:
+        raise HTTPException(status_code=404, detail="Unknown OIDC provider")
+
+    # Validate cli_redirect is localhost only
+    if cli_redirect and not cli_redirect.startswith(
+        ("http://localhost:", "http://127.0.0.1:")
+    ):
+        raise HTTPException(
+            status_code=400, detail="cli_redirect must be localhost"
+        )
+
+    verifier, challenge = oidc.generate_pkce()
+    state = secrets.token_urlsafe(32)
+
+    hostname, proto, base_path = derive_hosting_info(request.headers)
+    redirect_uri = (
+        f"{proto}://{hostname}{base_path}/auth/oidc/{provider_id}/callback"
+    )
+
+    auth_url = await oidc.build_auth_url(
+        provider, redirect_uri, state, challenge
+    )
+
+    response = RedirectResponse(url=auth_url, status_code=302)
+    # Store state + verifier + cli_redirect in a cookie
+    cookie_value = json.dumps(
+        {
+            "state": state,
+            "verifier": verifier,
+            "redirect_uri": redirect_uri,
+            "cli_redirect": cli_redirect,
+        }
+    )
+    response.set_cookie(
+        key=f"oidc_{provider_id}",
+        value=cookie_value,
+        httponly=True,
+        max_age=600,
+        samesite="lax",
+        path="/",
+    )
+    return response
+
+
+@router.get("/auth/oidc/{provider_id}/callback")
+async def oidc_callback(
+    provider_id: str,
+    request: Request,
+    code: str = "",
+    state: str = "",
+    error: str | None = None,
+):
+    """Handle the OIDC callback from the IdP."""
+    if error:
+        raise HTTPException(status_code=400, detail=f"IdP error: {error}")
+
+    provider = oidc.get_provider(provider_id)
+    if provider is None:
+        raise HTTPException(status_code=404, detail="Unknown OIDC provider")
+
+    # Retrieve and validate state from cookie
+    cookie_name = f"oidc_{provider_id}"
+    cookie_raw = request.cookies.get(cookie_name)
+    if not cookie_raw:
+        raise HTTPException(
+            status_code=400, detail="Missing OIDC state cookie"
+        )
+
+    try:
+        cookie_data = json.loads(cookie_raw)
+    except json.JSONDecodeError:
+        raise HTTPException(
+            status_code=400, detail="Invalid OIDC state cookie"
+        )
+
+    if cookie_data.get("state") != state:
+        raise HTTPException(status_code=400, detail="State mismatch")
+
+    # Exchange code for tokens
+    try:
+        tokens = await oidc.exchange_code(
+            provider,
+            code,
+            cookie_data["redirect_uri"],
+            cookie_data["verifier"],
+        )
+    except httpx.HTTPStatusError as exc:
+        logger.error("OIDC token exchange failed: %s", exc.response.text)
+        raise HTTPException(
+            status_code=502, detail="Token exchange failed"
+        ) from None
+
+    # Validate ID token
+    id_token = tokens.get("id_token")
+    if not id_token:
+        raise HTTPException(status_code=502, detail="No ID token in response")
+
+    try:
+        claims = await oidc.validate_id_token(provider, id_token)
+    except Exception as exc:
+        logger.error("OIDC ID token validation failed: %s", exc)
+        raise HTTPException(
+            status_code=502, detail="ID token validation failed"
+        ) from None
+
+    sub = claims.get("sub")
+    email = claims.get("email")
+    if not sub or not email:
+        raise HTTPException(
+            status_code=502,
+            detail="ID token missing sub or email claim",
+        )
+
+    # Find or create user
+    user = await model.get_user_by_external_id(provider_id, sub)
+    if user is None:
+        # Check for existing local user with same email
+        existing = await model.get_user_by_email(email)
+        if existing is not None:
+            # Link OIDC identity to existing user
+            await model.link_oidc_identity(existing["id"], provider_id, sub)
+            user = existing
+        else:
+            # JIT provisioning
+            user = await model.create_user(
+                email=email,
+                password_hash=None,
+                verified=True,
+                provider=provider_id,
+                external_id=sub,
+            )
+
+    # Sync admin role from IdP claims
+    should_be_admin = oidc.extract_admin_role(provider, claims)
+    if should_be_admin is not None:
+        roles = await model.get_user_roles(user["id"])
+        if should_be_admin and "admin" not in roles:
+            await model.ensure_role("admin")
+            await model.assign_role(user["id"], "admin")
+        elif not should_be_admin and "admin" in roles:
+            await model.remove_role(user["id"], "admin")
+
+    # Issue Klangk JWT
+    roles = await model.get_user_roles(user["id"])
+    access_token = auth.create_token(user["id"], email, roles)
+
+    # Clear the state cookie
+    cli_redirect = cookie_data.get("cli_redirect")
+
+    if cli_redirect:
+        # CLI flow: redirect to the CLI's localhost server with the token
+        redirect_url = f"{cli_redirect}?token={access_token}"
+    else:
+        # Web flow: redirect to the frontend with token in the hash
+        hostname, proto, base_path = derive_hosting_info(request.headers)
+        redirect_url = (
+            f"{proto}://{hostname}{base_path}"
+            f"/#/oidc-complete?token={access_token}"
+        )
+
+    response = RedirectResponse(url=redirect_url, status_code=302)
+    response.delete_cookie(cookie_name, path="/")
+    return response
 
 
 # --- Workspace endpoints ---

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -9,7 +9,7 @@ from fastapi import FastAPI, WebSocket
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
-from . import container, model
+from . import container, model, oidc
 from .api import router
 from .util import resolve_env_secret
 from .wshandler import handle_websocket
@@ -58,6 +58,7 @@ async def seed_default_user() -> None:
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     await model.init_db()
+    oidc.init_providers()
     await seed_default_user()
     from . import wshandler
 

--- a/src/backend/klangk_backend/model.py
+++ b/src/backend/klangk_backend/model.py
@@ -34,8 +34,10 @@ async def init_db() -> None:
             CREATE TABLE IF NOT EXISTS users (
                 id TEXT PRIMARY KEY,
                 email TEXT UNIQUE NOT NULL,
-                password_hash TEXT NOT NULL,
+                password_hash TEXT,
                 verified INTEGER NOT NULL DEFAULT 0,
+                provider TEXT NOT NULL DEFAULT 'local',
+                external_id TEXT,
                 created_at TEXT NOT NULL DEFAULT (datetime('now'))
             )
         """)
@@ -46,6 +48,17 @@ async def init_db() -> None:
             )
         except Exception:
             pass  # Column already exists
+        # Migration: add OIDC columns if missing
+        for col, defn in [
+            ("provider", "TEXT NOT NULL DEFAULT 'local'"),
+            ("external_id", "TEXT"),
+        ]:
+            try:
+                await db.execute(
+                    f"ALTER TABLE users ADD COLUMN {col} {defn}"  # noqa: S608
+                )
+            except Exception:
+                pass  # Column already exists
         await db.execute("""
             CREATE TABLE IF NOT EXISTS workspaces (
                 id TEXT PRIMARY KEY,
@@ -144,18 +157,69 @@ async def transaction():
 
 async def create_user(
     email: str,
-    password_hash: str,
+    password_hash: str | None,
     verified: bool = False,
+    provider: str = "local",
+    external_id: str | None = None,
 ) -> dict:
     db = await get_db()
     try:
         user_id = str(uuid.uuid4())
         await db.execute(
-            "INSERT INTO users (id, email, password_hash, verified) VALUES (?, ?, ?, ?)",
-            (user_id, email, password_hash, int(verified)),
+            "INSERT INTO users (id, email, password_hash, verified,"
+            " provider, external_id) VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                user_id,
+                email,
+                password_hash,
+                int(verified),
+                provider,
+                external_id,
+            ),
         )
         await db.commit()
         return {"id": user_id, "email": email, "verified": verified}
+    finally:
+        await db.close()
+
+
+async def get_user_by_external_id(
+    provider: str, external_id: str
+) -> dict | None:
+    """Find a user by OIDC provider + external ID."""
+    db = await get_db()
+    try:
+        cursor = await db.execute(
+            "SELECT id, email, password_hash, verified, provider, external_id"
+            " FROM users WHERE provider = ? AND external_id = ?",
+            (provider, external_id),
+        )
+        row = await cursor.fetchone()
+        if row is None:
+            return None
+        return {
+            "id": row["id"],
+            "email": row["email"],
+            "password_hash": row["password_hash"],
+            "verified": bool(row["verified"]),
+            "provider": row["provider"],
+            "external_id": row["external_id"],
+        }
+    finally:
+        await db.close()
+
+
+async def link_oidc_identity(
+    user_id: str, provider: str, external_id: str
+) -> None:
+    """Link an OIDC identity to an existing user."""
+    db = await get_db()
+    try:
+        await db.execute(
+            "UPDATE users SET provider = ?, external_id = ? WHERE id = ?",
+            (provider, external_id, user_id),
+        )
+        await db.commit()
     finally:
         await db.close()
 
@@ -215,7 +279,8 @@ async def get_user_by_email(email: str) -> dict | None:
     db = await get_db()
     try:
         cursor = await db.execute(
-            "SELECT id, email, password_hash, verified FROM users WHERE email = ?",
+            "SELECT id, email, password_hash, verified, provider, external_id"
+            " FROM users WHERE email = ?",
             (email,),
         )
         row = await cursor.fetchone()
@@ -226,6 +291,8 @@ async def get_user_by_email(email: str) -> dict | None:
             "email": row["email"],
             "password_hash": row["password_hash"],
             "verified": bool(row["verified"]),
+            "provider": row["provider"],
+            "external_id": row["external_id"],
         }
     finally:
         await db.close()

--- a/src/backend/klangk_backend/model.py
+++ b/src/backend/klangk_backend/model.py
@@ -41,24 +41,43 @@ async def init_db() -> None:
                 created_at TEXT NOT NULL DEFAULT (datetime('now'))
             )
         """)
-        # Migration: add verified column if missing
-        try:
-            await db.execute(
-                "ALTER TABLE users ADD COLUMN verified INTEGER NOT NULL DEFAULT 0"
-            )
-        except Exception:
-            pass  # Column already exists
-        # Migration: add OIDC columns if missing
-        for col, defn in [
-            ("provider", "TEXT NOT NULL DEFAULT 'local'"),
-            ("external_id", "TEXT"),
-        ]:
-            try:
-                await db.execute(
-                    f"ALTER TABLE users ADD COLUMN {col} {defn}"  # noqa: S608
+        # Migration: make password_hash nullable and add OIDC columns.
+        # SQLite can't ALTER COLUMN, so we recreate the table if needed.
+        cursor = await db.execute("PRAGMA table_info(users)")
+        columns = {row[1]: row for row in await cursor.fetchall()}
+        needs_recreate = False
+        if "password_hash" in columns and columns["password_hash"][3]:
+            # password_hash has NOT NULL — need to drop it for OIDC users
+            needs_recreate = True
+        if "provider" not in columns:
+            needs_recreate = True
+        if needs_recreate:
+            await db.execute("""
+                CREATE TABLE users_new (
+                    id TEXT PRIMARY KEY,
+                    email TEXT UNIQUE NOT NULL,
+                    password_hash TEXT,
+                    verified INTEGER NOT NULL DEFAULT 0,
+                    provider TEXT NOT NULL DEFAULT 'local',
+                    external_id TEXT,
+                    created_at TEXT NOT NULL DEFAULT (datetime('now'))
                 )
-            except Exception:
-                pass  # Column already exists
+            """)
+            # Copy existing data — old tables may lack some columns
+            old_cols = list(columns.keys())
+            shared = [
+                c
+                for c in old_cols
+                if c
+                in ("id", "email", "password_hash", "verified", "created_at")
+            ]
+            cols_str = ", ".join(shared)
+            await db.execute(
+                f"INSERT INTO users_new ({cols_str})"  # noqa: S608
+                f" SELECT {cols_str} FROM users"
+            )
+            await db.execute("DROP TABLE users")
+            await db.execute("ALTER TABLE users_new RENAME TO users")
         await db.execute("""
             CREATE TABLE IF NOT EXISTS workspaces (
                 id TEXT PRIMARY KEY,

--- a/src/backend/klangk_backend/oidc.py
+++ b/src/backend/klangk_backend/oidc.py
@@ -33,6 +33,7 @@ class OIDCProvider:
     admin_claim: str | None = None
     admin_group: str | None = None
     ca_cert: str | None = None  # path to CA cert PEM for custom trust
+    token_validation_pem: str | None = None  # static RSA/EC public key PEM
 
 
 @dataclass
@@ -78,6 +79,7 @@ def load_config() -> list[OIDCProvider]:
                 admin_claim=entry.get("admin_claim"),
                 admin_group=entry.get("admin_group"),
                 ca_cert=entry.get("ca_cert"),
+                token_validation_pem=entry.get("token_validation_pem"),
             )
         )
     return providers
@@ -239,12 +241,18 @@ async def exchange_code(
 
 
 async def validate_id_token(provider: OIDCProvider, id_token: str) -> dict:
-    """Validate and decode an ID token. Returns the claims dict."""
-    jwks = await get_jwks(provider)
-    # python-jose needs the keys in JWKS format
+    """Validate and decode an ID token. Returns the claims dict.
+
+    Uses the static token_validation_pem if configured, otherwise
+    fetches JWKS from the IdP's discovery endpoint.
+    """
+    if provider.token_validation_pem:
+        key = provider.token_validation_pem
+    else:
+        key = await get_jwks(provider)
     claims = jose_jwt.decode(
         id_token,
-        jwks,
+        key,
         algorithms=["RS256", "ES256"],
         audience=provider.client_id,
         issuer=provider.issuer,

--- a/src/backend/klangk_backend/oidc.py
+++ b/src/backend/klangk_backend/oidc.py
@@ -32,6 +32,7 @@ class OIDCProvider:
     scopes: str = "openid email profile"
     admin_claim: str | None = None
     admin_group: str | None = None
+    ca_cert: str | None = None  # path to CA cert PEM for custom trust
 
 
 @dataclass
@@ -76,6 +77,7 @@ def load_config() -> list[OIDCProvider]:
                 scopes=entry.get("scopes", "openid email profile"),
                 admin_claim=entry.get("admin_claim"),
                 admin_group=entry.get("admin_group"),
+                ca_cert=entry.get("ca_cert"),
             )
         )
     return providers
@@ -131,6 +133,18 @@ def generate_pkce() -> tuple[str, str]:
     return verifier, challenge
 
 
+# --- HTTP client ---
+
+
+def _client_kwargs(provider: OIDCProvider) -> dict:
+    """Return httpx.AsyncClient kwargs for a provider, including
+    custom CA cert if configured."""
+    kwargs: dict = {}
+    if provider.ca_cert:
+        kwargs["verify"] = provider.ca_cert
+    return kwargs
+
+
 # --- Discovery ---
 
 
@@ -142,7 +156,7 @@ async def discover(provider: OIDCProvider) -> dict:
         return cached.data
 
     url = f"{provider.issuer}/.well-known/openid-configuration"
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(**_client_kwargs(provider)) as client:
         resp = await client.get(url, timeout=10)
         resp.raise_for_status()
         data = resp.json()
@@ -160,7 +174,7 @@ async def get_jwks(provider: OIDCProvider) -> dict:
 
     disc = await discover(provider)
     jwks_uri = disc["jwks_uri"]
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(**_client_kwargs(provider)) as client:
         resp = await client.get(jwks_uri, timeout=10)
         resp.raise_for_status()
         keys = resp.json()
@@ -211,7 +225,7 @@ async def exchange_code(
         "client_secret": provider.client_secret,
         "code_verifier": code_verifier,
     }
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(**_client_kwargs(provider)) as client:
         resp = await client.post(
             disc["token_endpoint"],
             data=data,

--- a/src/backend/klangk_backend/oidc.py
+++ b/src/backend/klangk_backend/oidc.py
@@ -1,0 +1,268 @@
+"""OIDC client for external Identity Provider authentication."""
+
+import base64
+import hashlib
+import json
+import logging
+import os
+import secrets
+import time
+from dataclasses import dataclass
+from urllib.parse import urlencode
+
+import httpx
+from jose import jwt as jose_jwt
+
+from .util import resolve_env_secret, resolve_file_secret
+
+logger = logging.getLogger(__name__)
+
+# Cache TTL for OIDC discovery and JWKS (seconds)
+_DISCOVERY_TTL = 300
+_JWKS_TTL = 3600
+
+
+@dataclass
+class OIDCProvider:
+    id: str
+    display_name: str
+    issuer: str
+    client_id: str
+    client_secret: str
+    scopes: str = "openid email profile"
+    admin_claim: str | None = None
+    admin_group: str | None = None
+
+
+@dataclass
+class _CachedDiscovery:
+    data: dict
+    fetched_at: float
+
+
+@dataclass
+class _CachedJWKS:
+    keys: dict
+    fetched_at: float
+
+
+_discovery_cache: dict[str, _CachedDiscovery] = {}
+_jwks_cache: dict[str, _CachedJWKS] = {}
+
+# Provider registry — loaded once at startup
+_providers: list[OIDCProvider] = []
+
+
+def load_config() -> list[OIDCProvider]:
+    """Load OIDC provider config from the JSON file specified by
+    KLANGK_OIDC_CONFIG. Returns empty list if not configured."""
+    config_path = resolve_env_secret("KLANGK_OIDC_CONFIG", "")
+    if not config_path or not os.path.isfile(config_path):
+        return []
+
+    with open(config_path) as f:
+        raw = json.load(f)
+
+    providers = []
+    for entry in raw:
+        secret = resolve_file_secret(entry.get("client_secret", ""))
+        providers.append(
+            OIDCProvider(
+                id=entry["id"],
+                display_name=entry["display_name"],
+                issuer=entry["issuer"].rstrip("/"),
+                client_id=entry["client_id"],
+                client_secret=secret or "",
+                scopes=entry.get("scopes", "openid email profile"),
+                admin_claim=entry.get("admin_claim"),
+                admin_group=entry.get("admin_group"),
+            )
+        )
+    return providers
+
+
+def init_providers() -> None:
+    """Load providers into the module-level registry."""
+    global _providers
+    _providers = load_config()
+    if _providers:
+        names = ", ".join(p.id for p in _providers)
+        logger.info("OIDC providers loaded: %s", names)
+
+
+def get_provider(provider_id: str) -> OIDCProvider | None:
+    """Look up a provider by ID."""
+    return next((p for p in _providers if p.id == provider_id), None)
+
+
+def list_providers() -> list[dict]:
+    """Return public info for all configured providers."""
+    return [{"id": p.id, "display_name": p.display_name} for p in _providers]
+
+
+def is_enabled() -> bool:
+    return len(_providers) > 0
+
+
+def auth_modes() -> str:
+    """Return the configured auth mode."""
+    val = resolve_env_secret("KLANGK_AUTH_MODES", "")
+    if val in ("oidc", "password", "both"):
+        return val
+    return "both" if is_enabled() else "password"
+
+
+def password_login_allowed() -> bool:
+    return auth_modes() in ("password", "both")
+
+
+def oidc_login_allowed() -> bool:
+    return auth_modes() in ("oidc", "both") and is_enabled()
+
+
+# --- PKCE ---
+
+
+def generate_pkce() -> tuple[str, str]:
+    """Generate PKCE verifier and challenge (S256)."""
+    verifier = secrets.token_urlsafe(64)
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return verifier, challenge
+
+
+# --- Discovery ---
+
+
+async def discover(provider: OIDCProvider) -> dict:
+    """Fetch OIDC discovery document, cached."""
+    now = time.time()
+    cached = _discovery_cache.get(provider.id)
+    if cached and now - cached.fetched_at < _DISCOVERY_TTL:
+        return cached.data
+
+    url = f"{provider.issuer}/.well-known/openid-configuration"
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(url, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+
+    _discovery_cache[provider.id] = _CachedDiscovery(data=data, fetched_at=now)
+    return data
+
+
+async def get_jwks(provider: OIDCProvider) -> dict:
+    """Fetch JWKS keys for token validation, cached."""
+    now = time.time()
+    cached = _jwks_cache.get(provider.id)
+    if cached and now - cached.fetched_at < _JWKS_TTL:
+        return cached.keys
+
+    disc = await discover(provider)
+    jwks_uri = disc["jwks_uri"]
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(jwks_uri, timeout=10)
+        resp.raise_for_status()
+        keys = resp.json()
+
+    _jwks_cache[provider.id] = _CachedJWKS(keys=keys, fetched_at=now)
+    return keys
+
+
+# --- Authorization URL ---
+
+
+async def build_auth_url(
+    provider: OIDCProvider,
+    redirect_uri: str,
+    state: str,
+    code_challenge: str,
+) -> str:
+    """Build the authorization URL to redirect the user to the IdP."""
+    disc = await discover(provider)
+    params = {
+        "response_type": "code",
+        "client_id": provider.client_id,
+        "redirect_uri": redirect_uri,
+        "scope": provider.scopes,
+        "state": state,
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+    }
+    return f"{disc['authorization_endpoint']}?{urlencode(params)}"
+
+
+# --- Token Exchange ---
+
+
+async def exchange_code(
+    provider: OIDCProvider,
+    code: str,
+    redirect_uri: str,
+    code_verifier: str,
+) -> dict:
+    """Exchange an authorization code for tokens."""
+    disc = await discover(provider)
+    data = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": redirect_uri,
+        "client_id": provider.client_id,
+        "client_secret": provider.client_secret,
+        "code_verifier": code_verifier,
+    }
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(
+            disc["token_endpoint"],
+            data=data,
+            timeout=15,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+
+# --- ID Token Validation ---
+
+
+async def validate_id_token(provider: OIDCProvider, id_token: str) -> dict:
+    """Validate and decode an ID token. Returns the claims dict."""
+    jwks = await get_jwks(provider)
+    # python-jose needs the keys in JWKS format
+    claims = jose_jwt.decode(
+        id_token,
+        jwks,
+        algorithms=["RS256", "ES256"],
+        audience=provider.client_id,
+        issuer=provider.issuer,
+    )
+    return claims
+
+
+def extract_admin_role(provider: OIDCProvider, claims: dict) -> bool | None:
+    """Check if the user should have the admin role based on IdP claims.
+
+    Returns True (grant), False (revoke), or None (no mapping configured).
+    """
+    if not provider.admin_claim or not provider.admin_group:
+        return None
+
+    # Support dot-path claims like "realm_access.roles"
+    value = claims
+    for key in provider.admin_claim.split("."):
+        if isinstance(value, dict):
+            value = value.get(key)
+        else:
+            value = None
+            break
+
+    if isinstance(value, list):
+        return provider.admin_group in value
+    if isinstance(value, str):
+        return value == provider.admin_group
+    return False
+
+
+def clear_caches() -> None:
+    """Clear all caches (for testing)."""
+    _discovery_cache.clear()
+    _jwks_cache.clear()

--- a/src/backend/klangk_backend/oidc.py
+++ b/src/backend/klangk_backend/oidc.py
@@ -2,11 +2,12 @@
 
 import base64
 import hashlib
-import json
 import logging
 import os
 import secrets
 import time
+
+import yaml
 from dataclasses import dataclass
 from urllib.parse import urlencode
 
@@ -34,6 +35,7 @@ class OIDCProvider:
     admin_group: str | None = None
     ca_cert: str | None = None  # path to CA cert PEM for custom trust
     token_validation_pem: str | None = None  # static RSA/EC public key PEM
+    logout_redirect: bool = False  # redirect to IdP logout on user logout
 
 
 @dataclass
@@ -57,17 +59,28 @@ _providers: list[OIDCProvider] = []
 
 def load_config() -> list[OIDCProvider]:
     """Load OIDC provider config from the JSON file specified by
-    KLANGK_OIDC_CONFIG. Returns empty list if not configured."""
+    KLANGK_OIDC_CONFIG. Returns empty list if not configured.
+    Raises if the path is set but the file doesn't exist."""
     config_path = resolve_env_secret("KLANGK_OIDC_CONFIG", "")
-    if not config_path or not os.path.isfile(config_path):
+    if not config_path:
         return []
+    if not os.path.isfile(config_path):
+        raise RuntimeError(
+            f"KLANGK_OIDC_CONFIG={config_path!r} not found"
+            " (use an absolute path)"
+        )
 
+    config_dir = os.path.dirname(os.path.abspath(config_path))
     with open(config_path) as f:
-        raw = json.load(f)
+        raw = yaml.safe_load(f)
 
     providers = []
     for entry in raw:
         secret = resolve_file_secret(entry.get("client_secret", ""))
+        # Resolve ca_cert relative to the config file's directory
+        ca_cert = entry.get("ca_cert")
+        if ca_cert and not os.path.isabs(ca_cert):
+            ca_cert = os.path.join(config_dir, ca_cert)
         providers.append(
             OIDCProvider(
                 id=entry["id"],
@@ -78,17 +91,27 @@ def load_config() -> list[OIDCProvider]:
                 scopes=entry.get("scopes", "openid email profile"),
                 admin_claim=entry.get("admin_claim"),
                 admin_group=entry.get("admin_group"),
-                ca_cert=entry.get("ca_cert"),
+                ca_cert=ca_cert,
                 token_validation_pem=entry.get("token_validation_pem"),
+                logout_redirect=entry.get("logout_redirect", False),
             )
         )
     return providers
 
 
 def init_providers() -> None:
-    """Load providers into the module-level registry."""
+    """Load providers into the module-level registry.
+
+    Raises RuntimeError if KLANGK_AUTH_MODES requires OIDC but no
+    providers are configured or the config file is missing.
+    """
     global _providers
     _providers = load_config()
+    mode = auth_modes()
+    if mode in ("oidc", "both") and not _providers:
+        raise RuntimeError(
+            f"KLANGK_AUTH_MODES={mode!r} but no OIDC providers configured"
+        )
     if _providers:
         names = ", ".join(p.id for p in _providers)
         logger.info("OIDC providers loaded: %s", names)
@@ -240,11 +263,16 @@ async def exchange_code(
 # --- ID Token Validation ---
 
 
-async def validate_id_token(provider: OIDCProvider, id_token: str) -> dict:
+async def validate_id_token(
+    provider: OIDCProvider,
+    id_token: str,
+    access_token: str | None = None,
+) -> dict:
     """Validate and decode an ID token. Returns the claims dict.
 
     Uses the static token_validation_pem if configured, otherwise
-    fetches JWKS from the IdP's discovery endpoint.
+    fetches JWKS from the IdP's discovery endpoint. Pass access_token
+    so jose can verify the at_hash claim if present.
     """
     if provider.token_validation_pem:
         key = provider.token_validation_pem
@@ -256,6 +284,7 @@ async def validate_id_token(provider: OIDCProvider, id_token: str) -> dict:
         algorithms=["RS256", "ES256"],
         audience=provider.client_id,
         issuer=provider.issuer,
+        access_token=access_token,
     )
     return claims
 
@@ -282,6 +311,28 @@ def extract_admin_role(provider: OIDCProvider, claims: dict) -> bool | None:
     if isinstance(value, str):
         return value == provider.admin_group
     return False
+
+
+async def build_logout_url(
+    provider: OIDCProvider,
+    post_logout_redirect_uri: str,
+) -> str | None:
+    """Build the IdP logout URL for RP-Initiated Logout.
+
+    Returns None if logout_redirect is disabled or the IdP doesn't
+    advertise an end_session_endpoint.
+    """
+    if not provider.logout_redirect:
+        return None
+    disc = await discover(provider)
+    endpoint = disc.get("end_session_endpoint")
+    if not endpoint:
+        return None
+    params = {
+        "client_id": provider.client_id,
+        "post_logout_redirect_uri": post_logout_redirect_uri,
+    }
+    return f"{endpoint}?{urlencode(params)}"
 
 
 def clear_caches() -> None:

--- a/src/backend/klangk_backend/util.py
+++ b/src/backend/klangk_backend/util.py
@@ -30,6 +30,22 @@ def resolve_env_secret(key: str, default: str | None = None) -> str | None:
     return val
 
 
+def resolve_file_secret(value: str) -> str:
+    """Resolve a value that may have a 'file:' prefix.
+
+    If the value starts with 'file:', reads the file and returns
+    its stripped contents. Otherwise returns the value as-is.
+    """
+    if value.startswith("file:"):
+        path = value[5:]
+        try:
+            return open(path).read().strip()
+        except OSError as e:
+            logger.error("Cannot read secret from %s: %s", path, e)
+            return ""
+    return value
+
+
 def derive_hosting_info(headers) -> tuple[str, str, str]:
     """Derive hosting hostname, proto, and base path from env vars or request headers.
 

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -3542,7 +3542,8 @@ class TestInvitations:
 
 
 class TestOIDCConfig:
-    async def test_config_includes_oidc_fields(self, client):
+    async def test_config_includes_oidc_fields(self, client, monkeypatch):
+        monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
         resp = await client.get("/api/config")
         assert resp.status_code == 200
         data = resp.json()
@@ -4072,3 +4073,80 @@ class TestOIDCCallback:
             cookies={"oidc_test": "not-json"},
         )
         assert resp.status_code == 400
+
+
+class TestOIDCLogout:
+    async def test_logout_returns_oidc_logout_url(self, client, db):
+        """OIDC user with logout_redirect gets IdP logout URL in response."""
+        # Create OIDC user
+        user = await model.create_user(
+            "oidc-logout@example.com",
+            password_hash=None,
+            verified=True,
+            provider="test",
+            external_id="logout-sub",
+        )
+        roles = await model.get_user_roles(user["id"])
+        token = auth.create_token(user["id"], user["email"], roles)
+        headers = {"Authorization": f"Bearer {token}"}
+
+        provider = api.oidc.OIDCProvider(
+            id="test",
+            display_name="Test",
+            issuer="https://idp.example.com",
+            client_id="klangk",
+            client_secret="s",
+            logout_redirect=True,
+        )
+        with (
+            patch.object(api.oidc, "get_provider", return_value=provider),
+            patch.object(
+                api.oidc,
+                "build_logout_url",
+                AsyncMock(return_value="https://idp.example.com/logout?x=1"),
+            ),
+        ):
+            resp = await client.post("/auth/logout", headers=headers)
+        assert resp.status_code == 200
+        assert (
+            resp.json()["oidc_logout_url"]
+            == "https://idp.example.com/logout?x=1"
+        )
+
+    async def test_logout_no_redirect_for_local_user(self, client, user):
+        """Local user gets no oidc_logout_url."""
+        login_resp = await client.post(
+            "/auth/login",
+            json={"email": "testuser@example.com", "password": "testpass"},
+        )
+        headers = {
+            "Authorization": f"Bearer {login_resp.json()['access_token']}"
+        }
+        resp = await client.post("/auth/logout", headers=headers)
+        assert resp.status_code == 200
+        assert "oidc_logout_url" not in resp.json()
+
+    async def test_logout_no_redirect_when_disabled(self, client, db):
+        """OIDC user with logout_redirect=false gets no URL."""
+        user = await model.create_user(
+            "oidc-nologout@example.com",
+            password_hash=None,
+            verified=True,
+            provider="test",
+            external_id="nologout-sub",
+        )
+        token = auth.create_token(user["id"], user["email"])
+        headers = {"Authorization": f"Bearer {token}"}
+
+        provider = api.oidc.OIDCProvider(
+            id="test",
+            display_name="Test",
+            issuer="https://idp.example.com",
+            client_id="klangk",
+            client_secret="s",
+            logout_redirect=False,
+        )
+        with patch.object(api.oidc, "get_provider", return_value=provider):
+            resp = await client.post("/auth/logout", headers=headers)
+        assert resp.status_code == 200
+        assert "oidc_logout_url" not in resp.json()

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -10,6 +10,7 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from fastapi import FastAPI, HTTPException
+import httpx
 from httpx import AsyncClient, ASGITransport
 
 from klangk_backend import (
@@ -3535,3 +3536,539 @@ class TestInvitations:
         resp = await client.get("/api/config")
         assert resp.status_code == 200
         assert "invitations_enabled" in resp.json()
+
+
+# --- OIDC endpoints ---
+
+
+class TestOIDCConfig:
+    async def test_config_includes_oidc_fields(self, client):
+        resp = await client.get("/api/config")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "oidc_providers" in data
+        assert "auth_modes" in data
+        assert data["oidc_providers"] == []
+        assert data["auth_modes"] == "password"
+
+    async def test_config_with_providers(self, client, monkeypatch):
+        monkeypatch.setattr(
+            api.oidc,
+            "list_providers",
+            lambda: [{"id": "test", "display_name": "Test"}],
+        )
+        monkeypatch.setattr(api.oidc, "auth_modes", lambda: "both")
+        resp = await client.get("/api/config")
+        data = resp.json()
+        assert len(data["oidc_providers"]) == 1
+        assert data["auth_modes"] == "both"
+
+
+class TestOIDCAuthModeGuards:
+    async def test_login_blocked_when_oidc_only(
+        self, client, monkeypatch, user
+    ):
+        monkeypatch.setattr(api.oidc, "password_login_allowed", lambda: False)
+        resp = await client.post(
+            "/auth/login",
+            json={"email": "testuser@example.com", "password": "testpass"},
+        )
+        assert resp.status_code == 403
+        assert "disabled" in resp.json()["detail"]
+
+    async def test_register_blocked_when_oidc_only(
+        self, client, monkeypatch, db
+    ):
+        monkeypatch.setattr(api.oidc, "password_login_allowed", lambda: False)
+        resp = await client.post(
+            "/auth/register",
+            json={"email": "new@example.com", "password": "testpass"},
+        )
+        assert resp.status_code == 403
+
+    async def test_login_allowed_when_both(self, client, monkeypatch, user):
+        monkeypatch.setattr(api.oidc, "password_login_allowed", lambda: True)
+        resp = await client.post(
+            "/auth/login",
+            json={"email": "testuser@example.com", "password": "testpass"},
+        )
+        assert resp.status_code == 200
+
+
+class TestOIDCLogin:
+    async def test_oidc_login_not_enabled(self, client, monkeypatch):
+        monkeypatch.setattr(api.oidc, "oidc_login_allowed", lambda: False)
+        resp = await client.get("/auth/oidc/test/login")
+        assert resp.status_code == 404
+
+    async def test_unknown_provider(self, client, monkeypatch):
+        monkeypatch.setattr(api.oidc, "oidc_login_allowed", lambda: True)
+        monkeypatch.setattr(api.oidc, "get_provider", lambda _: None)
+        resp = await client.get("/auth/oidc/nope/login")
+        assert resp.status_code == 404
+
+    async def test_invalid_cli_redirect(self, client, monkeypatch):
+        provider = api.oidc.OIDCProvider(
+            id="test",
+            display_name="Test",
+            issuer="https://idp.example.com",
+            client_id="klangk",
+            client_secret="s",
+        )
+        monkeypatch.setattr(api.oidc, "oidc_login_allowed", lambda: True)
+        monkeypatch.setattr(api.oidc, "get_provider", lambda _: provider)
+        resp = await client.get(
+            "/auth/oidc/test/login",
+            params={"cli_redirect": "https://evil.com/steal"},
+        )
+        assert resp.status_code == 400
+        assert "localhost" in resp.json()["detail"]
+
+    async def test_oidc_login_redirects(self, client, monkeypatch):
+        provider = api.oidc.OIDCProvider(
+            id="test",
+            display_name="Test",
+            issuer="https://idp.example.com",
+            client_id="klangk",
+            client_secret="s",
+        )
+        monkeypatch.setattr(api.oidc, "oidc_login_allowed", lambda: True)
+        monkeypatch.setattr(api.oidc, "get_provider", lambda _: provider)
+        monkeypatch.setattr(
+            api.oidc,
+            "build_auth_url",
+            AsyncMock(return_value="https://idp.example.com/auth?foo=bar"),
+        )
+        resp = await client.get(
+            "/auth/oidc/test/login", follow_redirects=False
+        )
+        assert resp.status_code == 302
+        assert (
+            resp.headers["location"] == "https://idp.example.com/auth?foo=bar"
+        )
+        assert "oidc_test" in resp.headers.get("set-cookie", "")
+
+
+class TestOIDCCallback:
+    async def _setup_callback(self, client, monkeypatch, db, claims=None):
+        """Set up mocks for a successful OIDC callback test."""
+        import json as json_mod
+
+        provider = api.oidc.OIDCProvider(
+            id="test",
+            display_name="Test",
+            issuer="https://idp.example.com",
+            client_id="klangk",
+            client_secret="s",
+        )
+        monkeypatch.setattr(api.oidc, "get_provider", lambda _: provider)
+        monkeypatch.setattr(
+            api.oidc,
+            "exchange_code",
+            AsyncMock(
+                return_value={
+                    "id_token": "fake-id-token",
+                    "access_token": "at",
+                }
+            ),
+        )
+        default_claims = {
+            "sub": "oidc-sub-123",
+            "email": "oidcuser@example.com",
+        }
+        if claims:
+            default_claims.update(claims)
+        monkeypatch.setattr(
+            api.oidc,
+            "validate_id_token",
+            AsyncMock(return_value=default_claims),
+        )
+        # Set the state cookie
+        cookie_data = json_mod.dumps(
+            {
+                "state": "test-state",
+                "verifier": "test-verifier",
+                "redirect_uri": "https://klangk.example.com/auth/oidc/test/callback",
+                "cli_redirect": None,
+            }
+        )
+        return provider, cookie_data
+
+    async def test_callback_creates_user(self, client, monkeypatch, db):
+        _, cookie_data = await self._setup_callback(client, monkeypatch, db)
+        resp = await client.get(
+            "/auth/oidc/test/callback",
+            params={"code": "auth-code", "state": "test-state"},
+            cookies={"oidc_test": cookie_data},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        location = resp.headers["location"]
+        assert "oidc-complete" in location
+        assert "token=" in location
+
+        # User was created
+        user = await model.get_user_by_email("oidcuser@example.com")
+        assert user is not None
+        assert user["provider"] == "test"
+        assert user["external_id"] == "oidc-sub-123"
+        assert user["password_hash"] is None
+
+    async def test_callback_links_existing_user(
+        self, client, monkeypatch, db, user
+    ):
+        _, cookie_data = await self._setup_callback(
+            client,
+            monkeypatch,
+            db,
+            claims={"sub": "new-sub", "email": "testuser@example.com"},
+        )
+        resp = await client.get(
+            "/auth/oidc/test/callback",
+            params={"code": "code", "state": "test-state"},
+            cookies={"oidc_test": cookie_data},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+
+        # Existing user was linked
+        linked = await model.get_user_by_external_id("test", "new-sub")
+        assert linked is not None
+        assert linked["id"] == user["id"]
+
+    async def test_callback_maps_admin_role(self, client, monkeypatch, db):
+        provider, cookie_data = await self._setup_callback(
+            client,
+            monkeypatch,
+            db,
+            claims={
+                "sub": "admin-sub",
+                "email": "oidcadmin@example.com",
+                "roles": ["klangk-admin"],
+            },
+        )
+        # Enable role mapping on the provider
+        provider.admin_claim = "roles"
+        provider.admin_group = "klangk-admin"
+        monkeypatch.setattr(api.oidc, "get_provider", lambda _: provider)
+
+        resp = await client.get(
+            "/auth/oidc/test/callback",
+            params={"code": "code", "state": "test-state"},
+            cookies={"oidc_test": cookie_data},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+
+        user = await model.get_user_by_email("oidcadmin@example.com")
+        roles = await model.get_user_roles(user["id"])
+        assert "admin" in roles
+
+    async def test_callback_state_mismatch(self, client, monkeypatch, db):
+        _, cookie_data = await self._setup_callback(client, monkeypatch, db)
+        resp = await client.get(
+            "/auth/oidc/test/callback",
+            params={"code": "code", "state": "wrong-state"},
+            cookies={"oidc_test": cookie_data},
+        )
+        assert resp.status_code == 400
+        assert "State mismatch" in resp.json()["detail"]
+
+    async def test_callback_missing_cookie(self, client, monkeypatch, db):
+        await self._setup_callback(client, monkeypatch, db)
+        resp = await client.get(
+            "/auth/oidc/test/callback",
+            params={"code": "code", "state": "test-state"},
+        )
+        assert resp.status_code == 400
+        assert "cookie" in resp.json()["detail"].lower()
+
+    async def test_callback_idp_error(self, client, monkeypatch, db):
+        provider = api.oidc.OIDCProvider(
+            id="test",
+            display_name="Test",
+            issuer="https://idp.example.com",
+            client_id="klangk",
+            client_secret="s",
+        )
+        monkeypatch.setattr(api.oidc, "get_provider", lambda _: provider)
+        resp = await client.get(
+            "/auth/oidc/test/callback",
+            params={"error": "access_denied"},
+        )
+        assert resp.status_code == 400
+        assert "access_denied" in resp.json()["detail"]
+
+    async def test_callback_cli_redirect(self, client, monkeypatch, db):
+        import json as json_mod
+
+        provider = api.oidc.OIDCProvider(
+            id="test",
+            display_name="Test",
+            issuer="https://idp.example.com",
+            client_id="klangk",
+            client_secret="s",
+        )
+        monkeypatch.setattr(api.oidc, "get_provider", lambda _: provider)
+        monkeypatch.setattr(
+            api.oidc,
+            "exchange_code",
+            AsyncMock(return_value={"id_token": "idt", "access_token": "at"}),
+        )
+        monkeypatch.setattr(
+            api.oidc,
+            "validate_id_token",
+            AsyncMock(
+                return_value={
+                    "sub": "cli-sub",
+                    "email": "cli@example.com",
+                }
+            ),
+        )
+        cookie_data = json_mod.dumps(
+            {
+                "state": "s",
+                "verifier": "v",
+                "redirect_uri": "https://klangk.example.com/cb",
+                "cli_redirect": "http://localhost:12345/callback",
+            }
+        )
+        resp = await client.get(
+            "/auth/oidc/test/callback",
+            params={"code": "code", "state": "s"},
+            cookies={"oidc_test": cookie_data},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        assert resp.headers["location"].startswith(
+            "http://localhost:12345/callback?token="
+        )
+
+    async def test_callback_token_exchange_failure(
+        self, client, monkeypatch, db
+    ):
+        import json as json_mod
+
+        provider = api.oidc.OIDCProvider(
+            id="test",
+            display_name="Test",
+            issuer="https://idp.example.com",
+            client_id="klangk",
+            client_secret="s",
+        )
+        monkeypatch.setattr(api.oidc, "get_provider", lambda _: provider)
+        mock_request = httpx.Request("POST", "https://idp/token")
+        mock_response = httpx.Response(
+            400, text="bad request", request=mock_request
+        )
+        monkeypatch.setattr(
+            api.oidc,
+            "exchange_code",
+            AsyncMock(
+                side_effect=httpx.HTTPStatusError(
+                    "err", request=mock_request, response=mock_response
+                )
+            ),
+        )
+        cookie_data = json_mod.dumps(
+            {
+                "state": "s",
+                "verifier": "v",
+                "redirect_uri": "https://cb",
+                "cli_redirect": None,
+            }
+        )
+        resp = await client.get(
+            "/auth/oidc/test/callback",
+            params={"code": "code", "state": "s"},
+            cookies={"oidc_test": cookie_data},
+        )
+        assert resp.status_code == 502
+
+    async def test_callback_no_id_token(self, client, monkeypatch, db):
+        import json as json_mod
+
+        provider = api.oidc.OIDCProvider(
+            id="test",
+            display_name="Test",
+            issuer="https://idp.example.com",
+            client_id="klangk",
+            client_secret="s",
+        )
+        monkeypatch.setattr(api.oidc, "get_provider", lambda _: provider)
+        monkeypatch.setattr(
+            api.oidc,
+            "exchange_code",
+            AsyncMock(return_value={"access_token": "at"}),
+        )
+        cookie_data = json_mod.dumps(
+            {
+                "state": "s",
+                "verifier": "v",
+                "redirect_uri": "https://cb",
+                "cli_redirect": None,
+            }
+        )
+        resp = await client.get(
+            "/auth/oidc/test/callback",
+            params={"code": "code", "state": "s"},
+            cookies={"oidc_test": cookie_data},
+        )
+        assert resp.status_code == 502
+        assert "No ID token" in resp.json()["detail"]
+
+    async def test_callback_invalid_id_token(self, client, monkeypatch, db):
+        import json as json_mod
+
+        provider = api.oidc.OIDCProvider(
+            id="test",
+            display_name="Test",
+            issuer="https://idp.example.com",
+            client_id="klangk",
+            client_secret="s",
+        )
+        monkeypatch.setattr(api.oidc, "get_provider", lambda _: provider)
+        monkeypatch.setattr(
+            api.oidc,
+            "exchange_code",
+            AsyncMock(return_value={"id_token": "bad", "access_token": "at"}),
+        )
+        monkeypatch.setattr(
+            api.oidc,
+            "validate_id_token",
+            AsyncMock(side_effect=Exception("bad token")),
+        )
+        cookie_data = json_mod.dumps(
+            {
+                "state": "s",
+                "verifier": "v",
+                "redirect_uri": "https://cb",
+                "cli_redirect": None,
+            }
+        )
+        resp = await client.get(
+            "/auth/oidc/test/callback",
+            params={"code": "code", "state": "s"},
+            cookies={"oidc_test": cookie_data},
+        )
+        assert resp.status_code == 502
+        assert "validation failed" in resp.json()["detail"]
+
+    async def test_callback_missing_claims(self, client, monkeypatch, db):
+        import json as json_mod
+
+        provider = api.oidc.OIDCProvider(
+            id="test",
+            display_name="Test",
+            issuer="https://idp.example.com",
+            client_id="klangk",
+            client_secret="s",
+        )
+        monkeypatch.setattr(api.oidc, "get_provider", lambda _: provider)
+        monkeypatch.setattr(
+            api.oidc,
+            "exchange_code",
+            AsyncMock(return_value={"id_token": "t", "access_token": "at"}),
+        )
+        monkeypatch.setattr(
+            api.oidc,
+            "validate_id_token",
+            AsyncMock(return_value={"sub": "s"}),  # no email
+        )
+        cookie_data = json_mod.dumps(
+            {
+                "state": "s",
+                "verifier": "v",
+                "redirect_uri": "https://cb",
+                "cli_redirect": None,
+            }
+        )
+        resp = await client.get(
+            "/auth/oidc/test/callback",
+            params={"code": "code", "state": "s"},
+            cookies={"oidc_test": cookie_data},
+        )
+        assert resp.status_code == 502
+        assert "missing" in resp.json()["detail"].lower()
+
+    async def test_callback_unknown_provider(self, client, monkeypatch, db):
+        monkeypatch.setattr(api.oidc, "get_provider", lambda _: None)
+        resp = await client.get(
+            "/auth/oidc/nope/callback",
+            params={"code": "code", "state": "s"},
+        )
+        assert resp.status_code == 404
+
+    async def test_callback_revokes_admin_role(self, client, monkeypatch, db):
+        # Create user with admin role
+        user = await model.create_user(
+            "revoke-admin@example.com",
+            password_hash=None,
+            verified=True,
+            provider="test",
+            external_id="revoke-sub",
+        )
+        await model.ensure_role("admin")
+        await model.assign_role(user["id"], "admin")
+
+        import json as json_mod
+
+        provider = api.oidc.OIDCProvider(
+            id="test",
+            display_name="Test",
+            issuer="https://idp.example.com",
+            client_id="klangk",
+            client_secret="s",
+            admin_claim="roles",
+            admin_group="klangk-admin",
+        )
+        monkeypatch.setattr(api.oidc, "get_provider", lambda _: provider)
+        monkeypatch.setattr(
+            api.oidc,
+            "exchange_code",
+            AsyncMock(return_value={"id_token": "t", "access_token": "at"}),
+        )
+        monkeypatch.setattr(
+            api.oidc,
+            "validate_id_token",
+            AsyncMock(
+                return_value={
+                    "sub": "revoke-sub",
+                    "email": "revoke-admin@example.com",
+                    "roles": ["user"],  # no admin group
+                }
+            ),
+        )
+        cookie_data = json_mod.dumps(
+            {
+                "state": "s",
+                "verifier": "v",
+                "redirect_uri": "https://cb",
+                "cli_redirect": None,
+            }
+        )
+        resp = await client.get(
+            "/auth/oidc/test/callback",
+            params={"code": "code", "state": "s"},
+            cookies={"oidc_test": cookie_data},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        roles = await model.get_user_roles(user["id"])
+        assert "admin" not in roles
+
+    async def test_callback_invalid_cookie_json(self, client, monkeypatch, db):
+        provider = api.oidc.OIDCProvider(
+            id="test",
+            display_name="Test",
+            issuer="https://idp.example.com",
+            client_id="klangk",
+            client_secret="s",
+        )
+        monkeypatch.setattr(api.oidc, "get_provider", lambda _: provider)
+        resp = await client.get(
+            "/auth/oidc/test/callback",
+            params={"code": "code", "state": "s"},
+            cookies={"oidc_test": "not-json"},
+        )
+        assert resp.status_code == 400

--- a/src/backend/tests/test_main.py
+++ b/src/backend/tests/test_main.py
@@ -54,7 +54,9 @@ class TestSeedDefaultUser:
 
 
 class TestLifespan:
-    async def test_lifespan_starts_and_stops(self, db):
+    async def test_lifespan_starts_and_stops(self, db, monkeypatch):
+        monkeypatch.delenv("KLANGK_OIDC_CONFIG", raising=False)
+        monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
         app = FastAPI()
         with (
             patch.object(

--- a/src/backend/tests/test_model.py
+++ b/src/backend/tests/test_model.py
@@ -557,3 +557,55 @@ class TestInvitations:
 
     async def test_revoke_nonexistent(self, db):
         assert not await model.revoke_invitation("nonexistent")
+
+
+class TestOIDCUsers:
+    async def test_create_oidc_user(self, db):
+        user = await model.create_user(
+            "oidc@example.com",
+            password_hash=None,
+            verified=True,
+            provider="keycloak",
+            external_id="sub-123",
+        )
+        assert user["id"]
+        assert user["email"] == "oidc@example.com"
+
+    async def test_get_by_external_id(self, db):
+        await model.create_user(
+            "ext@example.com",
+            password_hash=None,
+            verified=True,
+            provider="kc",
+            external_id="ext-456",
+        )
+        found = await model.get_user_by_external_id("kc", "ext-456")
+        assert found is not None
+        assert found["email"] == "ext@example.com"
+        assert found["provider"] == "kc"
+        assert found["external_id"] == "ext-456"
+
+    async def test_get_by_external_id_not_found(self, db):
+        assert await model.get_user_by_external_id("kc", "nope") is None
+
+    async def test_link_oidc_identity(self, db):
+        user = await model.create_user(
+            "link@example.com", "hash", verified=True
+        )
+        await model.link_oidc_identity(user["id"], "kc", "linked-sub")
+        found = await model.get_user_by_external_id("kc", "linked-sub")
+        assert found is not None
+        assert found["id"] == user["id"]
+
+    async def test_get_user_by_email_includes_oidc_fields(self, db):
+        await model.create_user(
+            "fields@example.com",
+            password_hash=None,
+            verified=True,
+            provider="google",
+            external_id="g-789",
+        )
+        user = await model.get_user_by_email("fields@example.com")
+        assert user["provider"] == "google"
+        assert user["external_id"] == "g-789"
+        assert user["password_hash"] is None

--- a/src/backend/tests/test_model.py
+++ b/src/backend/tests/test_model.py
@@ -1,8 +1,53 @@
 """Tests for model: users, workspaces, messages, port allocations."""
 
+import aiosqlite
 import pytest
 
 from klangk_backend import model
+
+
+class TestMigration:
+    async def test_migrate_old_schema(self, temp_data_dir):
+        """Migrates a pre-OIDC database: password_hash NOT NULL, no
+        provider/external_id columns."""
+        db = await aiosqlite.connect(str(model.DB_PATH))
+        model.DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            await db.execute("""
+                CREATE TABLE users (
+                    id TEXT PRIMARY KEY,
+                    email TEXT UNIQUE NOT NULL,
+                    password_hash TEXT NOT NULL,
+                    verified INTEGER NOT NULL DEFAULT 0,
+                    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+                )
+            """)
+            await db.execute(
+                "INSERT INTO users (id, email, password_hash, verified)"
+                " VALUES ('u1', 'old@example.com', 'hash', 1)"
+            )
+            await db.commit()
+        finally:
+            await db.close()
+
+        await model.init_db()
+
+        # Old user survived migration
+        user = await model.get_user_by_email("old@example.com")
+        assert user is not None
+        assert user["password_hash"] == "hash"
+        assert user["provider"] == "local"
+        assert user["external_id"] is None
+
+        # Can create OIDC user (NULL password_hash)
+        oidc_user = await model.create_user(
+            "new@example.com",
+            password_hash=None,
+            verified=True,
+            provider="kc",
+            external_id="sub-1",
+        )
+        assert oidc_user["id"]
 
 
 class TestUsers:

--- a/src/backend/tests/test_oidc.py
+++ b/src/backend/tests/test_oidc.py
@@ -89,6 +89,45 @@ class TestLoadConfig:
         providers = oidc.load_config()
         assert providers[0].client_secret == "file-secret"
 
+    def test_ca_cert(self, monkeypatch, tmp_path):
+        cfg = tmp_path / "oidc.json"
+        cfg.write_text(
+            json.dumps(
+                [
+                    {
+                        "id": "dod",
+                        "display_name": "DoD",
+                        "issuer": "https://sso.mil/realms/dod",
+                        "client_id": "klangk",
+                        "client_secret": "s",
+                        "ca_cert": "/etc/pki/dod-ca.pem",
+                    }
+                ]
+            )
+        )
+        monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(cfg))
+        providers = oidc.load_config()
+        assert providers[0].ca_cert == "/etc/pki/dod-ca.pem"
+
+    def test_ca_cert_default_none(self, monkeypatch, tmp_path):
+        cfg = tmp_path / "oidc.json"
+        cfg.write_text(
+            json.dumps(
+                [
+                    {
+                        "id": "test",
+                        "display_name": "Test",
+                        "issuer": "https://idp.example.com",
+                        "client_id": "klangk",
+                        "client_secret": "s",
+                    }
+                ]
+            )
+        )
+        monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(cfg))
+        providers = oidc.load_config()
+        assert providers[0].ca_cert is None
+
     def test_multiple_providers(self, monkeypatch, tmp_path):
         cfg = tmp_path / "oidc.json"
         cfg.write_text(
@@ -174,6 +213,16 @@ class TestAuthModes:
         assert oidc.auth_modes() == "password"
         assert oidc.password_login_allowed()
         assert not oidc.oidc_login_allowed()
+
+
+class TestClientKwargs:
+    def test_no_ca_cert(self):
+        provider = _provider()
+        assert oidc._client_kwargs(provider) == {}
+
+    def test_with_ca_cert(self):
+        provider = _provider(ca_cert="/etc/pki/ca.pem")
+        assert oidc._client_kwargs(provider) == {"verify": "/etc/pki/ca.pem"}
 
 
 class TestPKCE:

--- a/src/backend/tests/test_oidc.py
+++ b/src/backend/tests/test_oidc.py
@@ -1,8 +1,9 @@
 """Tests for OIDC client module."""
 
-import json
 import time
 from unittest.mock import AsyncMock, patch
+
+import yaml
 
 import pytest
 
@@ -10,8 +11,10 @@ from klangk_backend import oidc
 
 
 @pytest.fixture(autouse=True)
-def clean_oidc_state():
+def clean_oidc_state(monkeypatch):
     """Reset OIDC module state between tests."""
+    monkeypatch.delenv("KLANGK_OIDC_CONFIG", raising=False)
+    monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
     oidc._providers.clear()
     oidc.clear_caches()
     yield
@@ -41,12 +44,13 @@ class TestLoadConfig:
 
     def test_missing_file(self, monkeypatch, tmp_path):
         monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(tmp_path / "nope.json"))
-        assert oidc.load_config() == []
+        with pytest.raises(RuntimeError, match="absolute path"):
+            oidc.load_config()
 
     def test_valid_config(self, monkeypatch, tmp_path):
-        cfg = tmp_path / "oidc.json"
+        cfg = tmp_path / "oidc.yaml"
         cfg.write_text(
-            json.dumps(
+            yaml.dump(
                 [
                     {
                         "id": "test",
@@ -71,9 +75,9 @@ class TestLoadConfig:
     def test_file_secret(self, monkeypatch, tmp_path):
         secret_file = tmp_path / "secret"
         secret_file.write_text("file-secret\n")
-        cfg = tmp_path / "oidc.json"
+        cfg = tmp_path / "oidc.yaml"
         cfg.write_text(
-            json.dumps(
+            yaml.dump(
                 [
                     {
                         "id": "fs",
@@ -90,9 +94,9 @@ class TestLoadConfig:
         assert providers[0].client_secret == "file-secret"
 
     def test_ca_cert(self, monkeypatch, tmp_path):
-        cfg = tmp_path / "oidc.json"
+        cfg = tmp_path / "oidc.yaml"
         cfg.write_text(
-            json.dumps(
+            yaml.dump(
                 [
                     {
                         "id": "dod",
@@ -111,9 +115,9 @@ class TestLoadConfig:
 
     def test_token_validation_pem(self, monkeypatch, tmp_path):
         pem = "-----BEGIN PUBLIC KEY-----\nMIIBI...\n-----END PUBLIC KEY-----"
-        cfg = tmp_path / "oidc.json"
+        cfg = tmp_path / "oidc.yaml"
         cfg.write_text(
-            json.dumps(
+            yaml.dump(
                 [
                     {
                         "id": "dod",
@@ -130,10 +134,31 @@ class TestLoadConfig:
         providers = oidc.load_config()
         assert providers[0].token_validation_pem == pem
 
-    def test_ca_cert_default_none(self, monkeypatch, tmp_path):
-        cfg = tmp_path / "oidc.json"
+    def test_ca_cert_relative_resolved(self, monkeypatch, tmp_path):
+        cfg = tmp_path / "oidc.yaml"
         cfg.write_text(
-            json.dumps(
+            yaml.dump(
+                [
+                    {
+                        "id": "rel",
+                        "display_name": "Rel",
+                        "issuer": "https://idp.example.com",
+                        "client_id": "klangk",
+                        "client_secret": "s",
+                        "ca_cert": "certs/ca.pem",
+                    }
+                ]
+            )
+        )
+        monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(cfg))
+        providers = oidc.load_config()
+        expected = str(tmp_path / "certs" / "ca.pem")
+        assert providers[0].ca_cert == expected
+
+    def test_ca_cert_default_none(self, monkeypatch, tmp_path):
+        cfg = tmp_path / "oidc.yaml"
+        cfg.write_text(
+            yaml.dump(
                 [
                     {
                         "id": "test",
@@ -150,9 +175,9 @@ class TestLoadConfig:
         assert providers[0].ca_cert is None
 
     def test_multiple_providers(self, monkeypatch, tmp_path):
-        cfg = tmp_path / "oidc.json"
+        cfg = tmp_path / "oidc.yaml"
         cfg.write_text(
-            json.dumps(
+            yaml.dump(
                 [
                     {
                         "id": "a",
@@ -180,9 +205,9 @@ class TestLoadConfig:
 
 class TestProviderRegistry:
     def test_init_and_lookup(self, monkeypatch, tmp_path):
-        cfg = tmp_path / "oidc.json"
+        cfg = tmp_path / "oidc.yaml"
         cfg.write_text(
-            json.dumps(
+            yaml.dump(
                 [
                     {
                         "id": "test",
@@ -205,6 +230,28 @@ class TestProviderRegistry:
     def test_not_enabled_when_empty(self):
         assert not oidc.is_enabled()
         assert oidc.list_providers() == []
+
+    def test_init_raises_when_oidc_required_but_no_providers(
+        self, monkeypatch
+    ):
+        monkeypatch.delenv("KLANGK_OIDC_CONFIG", raising=False)
+        monkeypatch.setenv("KLANGK_AUTH_MODES", "oidc")
+        with pytest.raises(RuntimeError, match="no OIDC providers"):
+            oidc.init_providers()
+
+    def test_init_raises_when_both_required_but_no_providers(
+        self, monkeypatch
+    ):
+        monkeypatch.delenv("KLANGK_OIDC_CONFIG", raising=False)
+        monkeypatch.setenv("KLANGK_AUTH_MODES", "both")
+        with pytest.raises(RuntimeError, match="no OIDC providers"):
+            oidc.init_providers()
+
+    def test_init_ok_when_password_only(self, monkeypatch):
+        monkeypatch.delenv("KLANGK_OIDC_CONFIG", raising=False)
+        monkeypatch.setenv("KLANGK_AUTH_MODES", "password")
+        oidc.init_providers()
+        assert not oidc.is_enabled()
 
 
 class TestAuthModes:
@@ -426,7 +473,9 @@ class TestValidateIdToken:
                 MagicMock(return_value=claims),
             ) as mock_decode,
         ):
-            result = await oidc.validate_id_token(provider, "fake-token")
+            result = await oidc.validate_id_token(
+                provider, "fake-token", access_token="fake-at"
+            )
             assert result == claims
             mock_jwks.assert_awaited_once()
             mock_decode.assert_called_once_with(
@@ -435,6 +484,7 @@ class TestValidateIdToken:
                 algorithms=["RS256", "ES256"],
                 audience="klangk",
                 issuer="https://idp.example.com",
+                access_token="fake-at",
             )
 
     async def test_validate_id_token_with_static_pem(self):
@@ -460,7 +510,40 @@ class TestValidateIdToken:
                 algorithms=["RS256", "ES256"],
                 audience="klangk",
                 issuer="https://idp.example.com",
+                access_token=None,
             )
+
+
+class TestBuildLogoutUrl:
+    async def test_disabled(self):
+        provider = _provider(logout_redirect=False)
+        result = await oidc.build_logout_url(provider, "https://klangk/login")
+        assert result is None
+
+    async def test_no_end_session_endpoint(self):
+        provider = _provider(logout_redirect=True)
+        oidc._discovery_cache[provider.id] = oidc._CachedDiscovery(
+            data={"authorization_endpoint": "https://idp/auth"},
+            fetched_at=time.time(),
+        )
+        result = await oidc.build_logout_url(provider, "https://klangk/login")
+        assert result is None
+
+    async def test_builds_url(self):
+        provider = _provider(logout_redirect=True)
+        oidc._discovery_cache[provider.id] = oidc._CachedDiscovery(
+            data={
+                "end_session_endpoint": "https://idp.example.com/logout",
+            },
+            fetched_at=time.time(),
+        )
+        result = await oidc.build_logout_url(
+            provider, "https://klangk.example.com/#/login"
+        )
+        assert result is not None
+        assert result.startswith("https://idp.example.com/logout?")
+        assert "client_id=klangk" in result
+        assert "post_logout_redirect_uri=" in result
 
 
 class TestExtractAdminRole:

--- a/src/backend/tests/test_oidc.py
+++ b/src/backend/tests/test_oidc.py
@@ -109,6 +109,27 @@ class TestLoadConfig:
         providers = oidc.load_config()
         assert providers[0].ca_cert == "/etc/pki/dod-ca.pem"
 
+    def test_token_validation_pem(self, monkeypatch, tmp_path):
+        pem = "-----BEGIN PUBLIC KEY-----\nMIIBI...\n-----END PUBLIC KEY-----"
+        cfg = tmp_path / "oidc.json"
+        cfg.write_text(
+            json.dumps(
+                [
+                    {
+                        "id": "dod",
+                        "display_name": "DoD",
+                        "issuer": "https://sso.mil/realms/dod",
+                        "client_id": "klangk",
+                        "client_secret": "s",
+                        "token_validation_pem": pem,
+                    }
+                ]
+            )
+        )
+        monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(cfg))
+        providers = oidc.load_config()
+        assert providers[0].token_validation_pem == pem
+
     def test_ca_cert_default_none(self, monkeypatch, tmp_path):
         cfg = tmp_path / "oidc.json"
         cfg.write_text(
@@ -390,7 +411,7 @@ class TestGetJWKS:
 
 
 class TestValidateIdToken:
-    async def test_validate_id_token(self):
+    async def test_validate_id_token_with_jwks(self):
         from unittest.mock import MagicMock
 
         provider = _provider()
@@ -398,15 +419,48 @@ class TestValidateIdToken:
         with (
             patch.object(
                 oidc, "get_jwks", AsyncMock(return_value={"keys": []})
-            ),
+            ) as mock_jwks,
             patch.object(
                 oidc.jose_jwt,
                 "decode",
                 MagicMock(return_value=claims),
-            ),
+            ) as mock_decode,
         ):
             result = await oidc.validate_id_token(provider, "fake-token")
             assert result == claims
+            mock_jwks.assert_awaited_once()
+            mock_decode.assert_called_once_with(
+                "fake-token",
+                {"keys": []},
+                algorithms=["RS256", "ES256"],
+                audience="klangk",
+                issuer="https://idp.example.com",
+            )
+
+    async def test_validate_id_token_with_static_pem(self):
+        from unittest.mock import MagicMock
+
+        pem = "-----BEGIN PUBLIC KEY-----\nMIIBI...\n-----END PUBLIC KEY-----"
+        provider = _provider(token_validation_pem=pem)
+        claims = {"sub": "user1", "email": "user@example.com"}
+        with (
+            patch.object(oidc, "get_jwks", AsyncMock()) as mock_jwks,
+            patch.object(
+                oidc.jose_jwt,
+                "decode",
+                MagicMock(return_value=claims),
+            ) as mock_decode,
+        ):
+            result = await oidc.validate_id_token(provider, "fake-token")
+            assert result == claims
+            mock_jwks.assert_not_awaited()
+            mock_decode.assert_called_once_with(
+                "fake-token",
+                pem,
+                algorithms=["RS256", "ES256"],
+                audience="klangk",
+                issuer="https://idp.example.com",
+            )
 
 
 class TestExtractAdminRole:

--- a/src/backend/tests/test_oidc.py
+++ b/src/backend/tests/test_oidc.py
@@ -1,0 +1,402 @@
+"""Tests for OIDC client module."""
+
+import json
+import time
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from klangk_backend import oidc
+
+
+@pytest.fixture(autouse=True)
+def clean_oidc_state():
+    """Reset OIDC module state between tests."""
+    oidc._providers.clear()
+    oidc.clear_caches()
+    yield
+    oidc._providers.clear()
+    oidc.clear_caches()
+
+
+def _provider(**overrides):
+    defaults = {
+        "id": "test",
+        "display_name": "Test IdP",
+        "issuer": "https://idp.example.com",
+        "client_id": "klangk",
+        "client_secret": "secret",
+        "scopes": "openid email profile",
+        "admin_claim": None,
+        "admin_group": None,
+    }
+    defaults.update(overrides)
+    return oidc.OIDCProvider(**defaults)
+
+
+class TestLoadConfig:
+    def test_no_config(self, monkeypatch):
+        monkeypatch.delenv("KLANGK_OIDC_CONFIG", raising=False)
+        assert oidc.load_config() == []
+
+    def test_missing_file(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(tmp_path / "nope.json"))
+        assert oidc.load_config() == []
+
+    def test_valid_config(self, monkeypatch, tmp_path):
+        cfg = tmp_path / "oidc.json"
+        cfg.write_text(
+            json.dumps(
+                [
+                    {
+                        "id": "test",
+                        "display_name": "Test",
+                        "issuer": "https://idp.example.com/",
+                        "client_id": "klangk",
+                        "client_secret": "s3cret",
+                        "admin_claim": "roles",
+                        "admin_group": "admin",
+                    }
+                ]
+            )
+        )
+        monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(cfg))
+        providers = oidc.load_config()
+        assert len(providers) == 1
+        assert providers[0].id == "test"
+        assert providers[0].issuer == "https://idp.example.com"
+        assert providers[0].client_secret == "s3cret"
+        assert providers[0].admin_claim == "roles"
+
+    def test_file_secret(self, monkeypatch, tmp_path):
+        secret_file = tmp_path / "secret"
+        secret_file.write_text("file-secret\n")
+        cfg = tmp_path / "oidc.json"
+        cfg.write_text(
+            json.dumps(
+                [
+                    {
+                        "id": "fs",
+                        "display_name": "File Secret",
+                        "issuer": "https://idp.example.com",
+                        "client_id": "klangk",
+                        "client_secret": f"file:{secret_file}",
+                    }
+                ]
+            )
+        )
+        monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(cfg))
+        providers = oidc.load_config()
+        assert providers[0].client_secret == "file-secret"
+
+    def test_multiple_providers(self, monkeypatch, tmp_path):
+        cfg = tmp_path / "oidc.json"
+        cfg.write_text(
+            json.dumps(
+                [
+                    {
+                        "id": "a",
+                        "display_name": "A",
+                        "issuer": "https://a.example.com",
+                        "client_id": "klangk",
+                        "client_secret": "sa",
+                    },
+                    {
+                        "id": "b",
+                        "display_name": "B",
+                        "issuer": "https://b.example.com",
+                        "client_id": "klangk",
+                        "client_secret": "sb",
+                    },
+                ]
+            )
+        )
+        monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(cfg))
+        providers = oidc.load_config()
+        assert len(providers) == 2
+        assert providers[0].id == "a"
+        assert providers[1].id == "b"
+
+
+class TestProviderRegistry:
+    def test_init_and_lookup(self, monkeypatch, tmp_path):
+        cfg = tmp_path / "oidc.json"
+        cfg.write_text(
+            json.dumps(
+                [
+                    {
+                        "id": "test",
+                        "display_name": "Test",
+                        "issuer": "https://idp.example.com",
+                        "client_id": "klangk",
+                        "client_secret": "s",
+                    }
+                ]
+            )
+        )
+        monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(cfg))
+        oidc.init_providers()
+        assert oidc.is_enabled()
+        assert oidc.get_provider("test") is not None
+        assert oidc.get_provider("nope") is None
+        providers = oidc.list_providers()
+        assert providers == [{"id": "test", "display_name": "Test"}]
+
+    def test_not_enabled_when_empty(self):
+        assert not oidc.is_enabled()
+        assert oidc.list_providers() == []
+
+
+class TestAuthModes:
+    def test_default_password_when_no_oidc(self, monkeypatch):
+        monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
+        assert oidc.auth_modes() == "password"
+        assert oidc.password_login_allowed()
+        assert not oidc.oidc_login_allowed()
+
+    def test_default_both_when_oidc_enabled(self, monkeypatch):
+        monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
+        oidc._providers.append(_provider())
+        assert oidc.auth_modes() == "both"
+        assert oidc.password_login_allowed()
+        assert oidc.oidc_login_allowed()
+
+    def test_oidc_only(self, monkeypatch):
+        monkeypatch.setenv("KLANGK_AUTH_MODES", "oidc")
+        oidc._providers.append(_provider())
+        assert oidc.auth_modes() == "oidc"
+        assert not oidc.password_login_allowed()
+        assert oidc.oidc_login_allowed()
+
+    def test_password_only(self, monkeypatch):
+        monkeypatch.setenv("KLANGK_AUTH_MODES", "password")
+        oidc._providers.append(_provider())
+        assert oidc.auth_modes() == "password"
+        assert oidc.password_login_allowed()
+        assert not oidc.oidc_login_allowed()
+
+
+class TestPKCE:
+    def test_generate_pkce(self):
+        verifier, challenge = oidc.generate_pkce()
+        assert len(verifier) > 32
+        assert len(challenge) > 32
+        assert verifier != challenge
+
+    def test_pkce_challenge_is_s256(self):
+        import base64
+        import hashlib
+
+        verifier, challenge = oidc.generate_pkce()
+        expected = (
+            base64.urlsafe_b64encode(
+                hashlib.sha256(verifier.encode("ascii")).digest()
+            )
+            .rstrip(b"=")
+            .decode("ascii")
+        )
+        assert challenge == expected
+
+
+def _mock_httpx_client(get_response=None, post_response=None):
+    """Create a mock httpx.AsyncClient that works as an async context manager."""
+    client = AsyncMock()
+    if get_response:
+        client.get.return_value = get_response
+    if post_response:
+        client.post.return_value = post_response
+    # httpx.AsyncClient.__aenter__ returns self
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    return client
+
+
+def _mock_response(data):
+    """Create a mock httpx response with sync .json() and .raise_for_status()."""
+    from unittest.mock import MagicMock
+
+    resp = MagicMock()
+    resp.json.return_value = data
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+class TestDiscovery:
+    async def test_discover_caches(self):
+        provider = _provider()
+        disc_data = {
+            "authorization_endpoint": "https://idp.example.com/auth",
+            "token_endpoint": "https://idp.example.com/token",
+            "jwks_uri": "https://idp.example.com/jwks",
+        }
+        mock_resp = _mock_response(disc_data)
+        client_instance = _mock_httpx_client(get_response=mock_resp)
+
+        with patch("httpx.AsyncClient", return_value=client_instance):
+            result1 = await oidc.discover(provider)
+            assert result1 == disc_data
+
+            # Second call should use cache
+            result2 = await oidc.discover(provider)
+            assert result2 == disc_data
+            # Only one HTTP call
+            assert client_instance.get.call_count == 1
+
+    async def test_discover_cache_expires(self):
+        provider = _provider()
+        disc_data = {"authorization_endpoint": "https://idp.example.com/auth"}
+        mock_resp = _mock_response(disc_data)
+        client_instance = _mock_httpx_client(get_response=mock_resp)
+
+        with patch("httpx.AsyncClient", return_value=client_instance):
+            await oidc.discover(provider)
+            # Expire the cache
+            oidc._discovery_cache[provider.id].fetched_at = (
+                time.time() - oidc._DISCOVERY_TTL - 1
+            )
+            await oidc.discover(provider)
+            assert client_instance.get.call_count == 2
+
+
+class TestBuildAuthUrl:
+    async def test_build_auth_url(self):
+        provider = _provider()
+        oidc._discovery_cache[provider.id] = oidc._CachedDiscovery(
+            data={
+                "authorization_endpoint": "https://idp.example.com/auth",
+            },
+            fetched_at=time.time(),
+        )
+        url = await oidc.build_auth_url(
+            provider,
+            "https://klangk.example.com/callback",
+            "state123",
+            "challenge456",
+        )
+        assert url.startswith("https://idp.example.com/auth?")
+        assert "client_id=klangk" in url
+        assert "state=state123" in url
+        assert "code_challenge=challenge456" in url
+        assert "code_challenge_method=S256" in url
+
+
+class TestExchangeCode:
+    async def test_exchange_code(self):
+        provider = _provider()
+        oidc._discovery_cache[provider.id] = oidc._CachedDiscovery(
+            data={"token_endpoint": "https://idp.example.com/token"},
+            fetched_at=time.time(),
+        )
+        token_resp = {"access_token": "at", "id_token": "idt"}
+        mock_resp = _mock_response(token_resp)
+        client_instance = _mock_httpx_client(post_response=mock_resp)
+
+        with patch("httpx.AsyncClient", return_value=client_instance):
+            result = await oidc.exchange_code(
+                provider, "code123", "https://cb", "verifier"
+            )
+            assert result == token_resp
+            call_data = client_instance.post.call_args[1]["data"]
+            assert call_data["code"] == "code123"
+            assert call_data["code_verifier"] == "verifier"
+            assert call_data["client_secret"] == "secret"
+
+
+class TestGetJWKS:
+    async def test_get_jwks_caches(self):
+        provider = _provider()
+        # Pre-populate discovery cache
+        oidc._discovery_cache[provider.id] = oidc._CachedDiscovery(
+            data={"jwks_uri": "https://idp.example.com/jwks"},
+            fetched_at=time.time(),
+        )
+        jwks_data = {"keys": [{"kty": "RSA", "kid": "key1"}]}
+        mock_resp = _mock_response(jwks_data)
+        client_instance = _mock_httpx_client(get_response=mock_resp)
+
+        with patch("httpx.AsyncClient", return_value=client_instance):
+            result1 = await oidc.get_jwks(provider)
+            assert result1 == jwks_data
+            result2 = await oidc.get_jwks(provider)
+            assert result2 == jwks_data
+            assert client_instance.get.call_count == 1
+
+    async def test_get_jwks_cache_expires(self):
+        provider = _provider()
+        oidc._discovery_cache[provider.id] = oidc._CachedDiscovery(
+            data={"jwks_uri": "https://idp.example.com/jwks"},
+            fetched_at=time.time(),
+        )
+        jwks_data = {"keys": []}
+        mock_resp = _mock_response(jwks_data)
+        client_instance = _mock_httpx_client(get_response=mock_resp)
+
+        with patch("httpx.AsyncClient", return_value=client_instance):
+            await oidc.get_jwks(provider)
+            oidc._jwks_cache[provider.id].fetched_at = (
+                time.time() - oidc._JWKS_TTL - 1
+            )
+            await oidc.get_jwks(provider)
+            assert client_instance.get.call_count == 2
+
+
+class TestValidateIdToken:
+    async def test_validate_id_token(self):
+        from unittest.mock import MagicMock
+
+        provider = _provider()
+        claims = {"sub": "user1", "email": "user@example.com"}
+        with (
+            patch.object(
+                oidc, "get_jwks", AsyncMock(return_value={"keys": []})
+            ),
+            patch.object(
+                oidc.jose_jwt,
+                "decode",
+                MagicMock(return_value=claims),
+            ),
+        ):
+            result = await oidc.validate_id_token(provider, "fake-token")
+            assert result == claims
+
+
+class TestExtractAdminRole:
+    def test_no_mapping_configured(self):
+        provider = _provider()
+        assert oidc.extract_admin_role(provider, {}) is None
+
+    def test_admin_in_flat_list(self):
+        provider = _provider(admin_claim="roles", admin_group="klangk-admin")
+        claims = {"roles": ["user", "klangk-admin"]}
+        assert oidc.extract_admin_role(provider, claims) is True
+
+    def test_admin_not_in_list(self):
+        provider = _provider(admin_claim="roles", admin_group="klangk-admin")
+        claims = {"roles": ["user"]}
+        assert oidc.extract_admin_role(provider, claims) is False
+
+    def test_nested_claim_path(self):
+        provider = _provider(
+            admin_claim="realm_access.roles",
+            admin_group="admin",
+        )
+        claims = {"realm_access": {"roles": ["admin", "user"]}}
+        assert oidc.extract_admin_role(provider, claims) is True
+
+    def test_nested_claim_missing(self):
+        provider = _provider(
+            admin_claim="realm_access.roles",
+            admin_group="admin",
+        )
+        claims = {"other": "stuff"}
+        assert oidc.extract_admin_role(provider, claims) is False
+
+    def test_string_claim(self):
+        provider = _provider(admin_claim="role", admin_group="admin")
+        claims = {"role": "admin"}
+        assert oidc.extract_admin_role(provider, claims) is True
+
+    def test_string_claim_no_match(self):
+        provider = _provider(admin_claim="role", admin_group="admin")
+        claims = {"role": "user"}
+        assert oidc.extract_admin_role(provider, claims) is False

--- a/src/backend/tests/test_util.py
+++ b/src/backend/tests/test_util.py
@@ -1,6 +1,6 @@
 """Tests for util: file-backed secret resolution."""
 
-from klangk_backend.util import resolve_env_secret
+from klangk_backend.util import resolve_env_secret, resolve_file_secret
 
 
 class TestResolveEnvSecret:
@@ -29,3 +29,16 @@ class TestResolveEnvSecret:
     def test_empty_string_returned_as_is(self, monkeypatch):
         monkeypatch.setenv("TEST_SECRET", "")
         assert resolve_env_secret("TEST_SECRET") == ""
+
+
+class TestResolveFileSecret:
+    def test_plain_value(self):
+        assert resolve_file_secret("plain") == "plain"
+
+    def test_file_prefix(self, tmp_path):
+        f = tmp_path / "secret"
+        f.write_text("from-file\n")
+        assert resolve_file_secret(f"file:{f}") == "from-file"
+
+    def test_file_missing_returns_empty(self):
+        assert resolve_file_secret("file:/no/such/file") == ""

--- a/src/frontend/lib/app.dart
+++ b/src/frontend/lib/app.dart
@@ -10,6 +10,7 @@ import 'auth/login_page.dart';
 import 'auth/verify_page.dart';
 import 'auth/forgot_password_page.dart';
 import 'auth/accept_invite_page.dart';
+import 'auth/oidc_complete_page.dart';
 import 'auth/reset_password_page.dart';
 import 'auth/settings_page.dart';
 import 'workspace/workspace_list_page.dart';
@@ -76,6 +77,7 @@ class _KlangkAppState extends State<KlangkApp> {
           '/forgot-password',
           '/reset-password',
           '/accept-invite',
+          '/oidc-complete',
           '/consent',
         };
         if (!isLoggedIn && !publicRoutes.contains(loc)) {
@@ -140,6 +142,13 @@ class _KlangkAppState extends State<KlangkApp> {
           builder: (context, state) {
             final token = state.uri.queryParameters['token'] ?? '';
             return AcceptInvitePage(token: token);
+          },
+        ),
+        GoRoute(
+          path: '/oidc-complete',
+          builder: (context, state) {
+            final token = state.uri.queryParameters['token'] ?? '';
+            return OidcCompletePage(token: token);
           },
         ),
         GoRoute(

--- a/src/frontend/lib/auth/auth_service.dart
+++ b/src/frontend/lib/auth/auth_service.dart
@@ -236,15 +236,23 @@ class AuthService extends ChangeNotifier {
     return response;
   }
 
-  Future<void> logout() async {
+  /// Log out. Returns the IdP logout URL if the provider requires
+  /// a redirect, or null for local-only logout.
+  Future<String?> logout() async {
+    String? oidcLogoutUrl;
     try {
-      await _client.post(
+      final resp = await _client.post(
         Uri.parse('$_baseUrl/auth/logout'),
         headers: _authHeaders,
       );
+      if (resp.statusCode == 200) {
+        final data = jsonDecode(resp.body);
+        oidcLogoutUrl = data['oidc_logout_url'] as String?;
+      }
     } catch (_) {
       // Best effort — clear token regardless
     }
     await _clearToken();
+    return oidcLogoutUrl;
   }
 }

--- a/src/frontend/lib/auth/login_page.dart
+++ b/src/frontend/lib/auth/login_page.dart
@@ -8,6 +8,8 @@ import 'package:provider/provider.dart';
 import 'auth_service.dart';
 import 'pending_redirect.dart';
 import '../utils/page_title.dart';
+import '../utils/web_helpers_stub.dart'
+    if (dart.library.js_interop) '../utils/web_helpers_web.dart';
 import '../widgets/klangk_logo.dart';
 
 /// Override for testing — set to intercept HTTP calls in _loadConfig.
@@ -29,6 +31,10 @@ class _LoginPageState extends State<LoginPage> {
   bool _needsVerification = false;
   bool _resending = false;
   bool _registrationEnabled = true;
+  List<Map<String, dynamic>> _oidcProviders = [];
+  String _authModes = 'password';
+
+  bool get _showPasswordForm => _authModes != 'oidc';
 
   @override
   void initState() {
@@ -46,6 +52,9 @@ class _LoginPageState extends State<LoginPage> {
         if (mounted) {
           setState(() {
             _registrationEnabled = data['registration_enabled'] ?? true;
+            _oidcProviders =
+                List<Map<String, dynamic>>.from(data['oidc_providers'] ?? []);
+            _authModes = data['auth_modes'] ?? 'password';
           });
         }
       }
@@ -125,112 +134,149 @@ class _LoginPageState extends State<LoginPage> {
                       _isRegister ? 'Create Account' : 'Log In',
                       style: Theme.of(context).textTheme.titleLarge,
                     ),
-                    const SizedBox(height: 24),
-                    TextFormField(
-                      controller: _emailController,
-                      decoration: InputDecoration(
-                        labelText: 'Email',
-                        border: const OutlineInputBorder(),
-                      ),
-                      validator: (v) {
-                        if (v == null || v.trim().isEmpty) return 'Required';
-                        if (!RegExp(r'^[^@\s]+@[^@\s]+\.[^@\s]+$')
-                            .hasMatch(v.trim())) {
-                          return 'Enter a valid email address';
-                        }
-                        return null;
-                      },
-                      onFieldSubmitted: (_) => _submit(),
-                    ),
-                    const SizedBox(height: 16),
-                    TextFormField(
-                      controller: _passwordController,
-                      decoration: const InputDecoration(
-                        labelText: 'Password',
-                        border: OutlineInputBorder(),
-                      ),
-                      obscureText: true,
-                      validator: (v) {
-                        if (v == null || v.isEmpty) return 'Required';
-                        if (_isRegister && v.length < 4)
-                          return 'Min 4 characters';
-                        return null;
-                      },
-                      onFieldSubmitted: (_) => _submit(),
-                    ),
-                    if (_error != null) ...[
-                      const SizedBox(height: 16),
-                      Text(_error!,
-                          style: TextStyle(
-                              color: Theme.of(context).colorScheme.error)),
-                      if (_needsVerification) ...[
+                    if (_oidcProviders.isNotEmpty) ...[
+                      const SizedBox(height: 24),
+                      for (final provider in _oidcProviders)
+                        Padding(
+                          padding: const EdgeInsets.only(bottom: 8),
+                          child: SizedBox(
+                            width: double.infinity,
+                            child: OutlinedButton.icon(
+                              icon: const Icon(Icons.login),
+                              label: Text(
+                                  'Log in with ${provider['display_name']}'),
+                              onPressed: () {
+                                final id = provider['id'];
+                                final url = '${baseUrl}/auth/oidc/$id/login';
+                                navigateTo(url);
+                              },
+                            ),
+                          ),
+                        ),
+                      if (_showPasswordForm) ...[
                         const SizedBox(height: 8),
-                        TextButton(
-                          onPressed: _resending ? null : _resendVerification,
-                          child: _resending
-                              ? const SizedBox(
-                                  height: 16,
-                                  width: 16,
-                                  child:
-                                      CircularProgressIndicator(strokeWidth: 2),
-                                )
-                              : const Text('Resend verification email'),
+                        Row(
+                          children: [
+                            const Expanded(child: Divider()),
+                            Padding(
+                              padding:
+                                  const EdgeInsets.symmetric(horizontal: 16),
+                              child: Text('or',
+                                  style: TextStyle(color: KColors.textMuted)),
+                            ),
+                            const Expanded(child: Divider()),
+                          ],
                         ),
                       ],
                     ],
-                    const SizedBox(height: 24),
-                    SizedBox(
-                      width: double.infinity,
-                      child: FilledButton(
-                        onPressed: auth.loading ? null : _submit,
-                        style: _isRegister
-                            ? FilledButton.styleFrom(
-                                backgroundColor: KColors.accentGreen,
-                                foregroundColor: Colors.white,
-                              )
-                            : null,
-                        child: auth.loading
-                            ? const SizedBox(
-                                height: 20,
-                                width: 20,
-                                child:
-                                    CircularProgressIndicator(strokeWidth: 2),
-                              )
-                            : Text(_isRegister ? 'Create Account' : 'Log In'),
-                      ),
-                    ),
-                    if (pendingRedirect != null) ...[
-                      const SizedBox(height: 12),
-                      Text(
-                        'Please log in to continue.',
-                        style: TextStyle(
-                          color: Theme.of(context).colorScheme.error,
+                    if (_showPasswordForm) ...[
+                      const SizedBox(height: 24),
+                      TextFormField(
+                        controller: _emailController,
+                        decoration: InputDecoration(
+                          labelText: 'Email',
+                          border: const OutlineInputBorder(),
                         ),
-                      ),
-                    ],
-                    if (_registrationEnabled) ...[
-                      const SizedBox(height: 8),
-                      TextButton(
-                        onPressed: () {
-                          setState(() {
-                            _isRegister = !_isRegister;
-                            _error = null;
-                          });
+                        validator: (v) {
+                          if (v == null || v.trim().isEmpty) return 'Required';
+                          if (!RegExp(r'^[^@\s]+@[^@\s]+\.[^@\s]+$')
+                              .hasMatch(v.trim())) {
+                            return 'Enter a valid email address';
+                          }
+                          return null;
                         },
-                        child: Text(
-                          _isRegister
-                              ? 'Already have an account? Log in'
-                              : 'Need an account? Create one',
+                        onFieldSubmitted: (_) => _submit(),
+                      ),
+                      const SizedBox(height: 16),
+                      TextFormField(
+                        controller: _passwordController,
+                        decoration: const InputDecoration(
+                          labelText: 'Password',
+                          border: OutlineInputBorder(),
+                        ),
+                        obscureText: true,
+                        validator: (v) {
+                          if (v == null || v.isEmpty) return 'Required';
+                          if (_isRegister && v.length < 4)
+                            return 'Min 4 characters';
+                          return null;
+                        },
+                        onFieldSubmitted: (_) => _submit(),
+                      ),
+                      if (_error != null) ...[
+                        const SizedBox(height: 16),
+                        Text(_error!,
+                            style: TextStyle(
+                                color: Theme.of(context).colorScheme.error)),
+                        if (_needsVerification) ...[
+                          const SizedBox(height: 8),
+                          TextButton(
+                            onPressed: _resending ? null : _resendVerification,
+                            child: _resending
+                                ? const SizedBox(
+                                    height: 16,
+                                    width: 16,
+                                    child: CircularProgressIndicator(
+                                        strokeWidth: 2),
+                                  )
+                                : const Text('Resend verification email'),
+                          ),
+                        ],
+                      ],
+                      const SizedBox(height: 24),
+                      SizedBox(
+                        width: double.infinity,
+                        child: FilledButton(
+                          onPressed: auth.loading ? null : _submit,
+                          style: _isRegister
+                              ? FilledButton.styleFrom(
+                                  backgroundColor: KColors.accentGreen,
+                                  foregroundColor: Colors.white,
+                                )
+                              : null,
+                          child: auth.loading
+                              ? const SizedBox(
+                                  height: 20,
+                                  width: 20,
+                                  child:
+                                      CircularProgressIndicator(strokeWidth: 2),
+                                )
+                              : Text(_isRegister ? 'Create Account' : 'Log In'),
                         ),
                       ),
-                    ],
-                    // coverage:ignore-start
-                    if (!_isRegister)
-                      TextButton(
-                        onPressed: () => context.go('/forgot-password'),
-                        child: const Text('Forgot password?'),
-                      ),
-                    // coverage:ignore-end
+                      if (pendingRedirect != null) ...[
+                        const SizedBox(height: 12),
+                        Text(
+                          'Please log in to continue.',
+                          style: TextStyle(
+                            color: Theme.of(context).colorScheme.error,
+                          ),
+                        ),
+                      ],
+                      if (_registrationEnabled) ...[
+                        const SizedBox(height: 8),
+                        TextButton(
+                          onPressed: () {
+                            setState(() {
+                              _isRegister = !_isRegister;
+                              _error = null;
+                            });
+                          },
+                          child: Text(
+                            _isRegister
+                                ? 'Already have an account? Log in'
+                                : 'Need an account? Create one',
+                          ),
+                        ),
+                      ],
+                      // coverage:ignore-start
+                      if (!_isRegister)
+                        TextButton(
+                          onPressed: () => context.go('/forgot-password'),
+                          child: const Text('Forgot password?'),
+                        ),
+                      // coverage:ignore-end
+                    ], // end _showPasswordForm
                   ],
                 ),
               ),

--- a/src/frontend/lib/auth/oidc_complete_page.dart
+++ b/src/frontend/lib/auth/oidc_complete_page.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'auth_service.dart';
+import '../utils/page_title.dart';
+import '../widgets/klangk_logo.dart';
+
+/// Landing page after OIDC callback. Extracts the token from the URL
+/// query parameters, saves it, and redirects to /workspaces.
+class OidcCompletePage extends StatefulWidget {
+  final String token;
+
+  const OidcCompletePage({super.key, required this.token});
+
+  @override
+  State<OidcCompletePage> createState() => _OidcCompletePageState();
+}
+
+class _OidcCompletePageState extends State<OidcCompletePage> {
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    setPageTitle('Signing in...');
+    _completeLogin();
+  }
+
+  Future<void> _completeLogin() async {
+    if (widget.token.isEmpty) {
+      setState(() => _error = 'Missing authentication token.');
+      return;
+    }
+    final auth = context.read<AuthService>();
+    await auth.saveTokenFromVerification(widget.token);
+    // GoRouter redirect handles navigation to /workspaces
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_error != null) {
+      return Scaffold(
+        body: Center(
+          child: Card(
+            child: Container(
+              constraints: const BoxConstraints(maxWidth: 400),
+              padding: const EdgeInsets.all(32),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const KlangkLogo(height: 80),
+                  const SizedBox(height: 24),
+                  Text(_error!,
+                      style: TextStyle(
+                          color: Theme.of(context).colorScheme.error)),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+    return const Scaffold(
+      body: Center(child: CircularProgressIndicator()),
+    );
+  }
+}

--- a/src/frontend/lib/utils/web_helpers_stub.dart
+++ b/src/frontend/lib/utils/web_helpers_stub.dart
@@ -5,6 +5,8 @@ import 'package:flutter/widgets.dart';
 
 void openUrl(String url) {}
 
+void navigateTo(String url) {}
+
 void downloadBytes(List<int> bytes, String filename) {}
 
 void suppressContextMenuBriefly() {}

--- a/src/frontend/lib/utils/web_helpers_web.dart
+++ b/src/frontend/lib/utils/web_helpers_web.dart
@@ -9,6 +9,11 @@ void openUrl(String url) {
   web.window.open(url, '_blank');
 }
 
+/// Navigate the current page to a URL (full page redirect).
+void navigateTo(String url) {
+  web.window.location.href = url;
+}
+
 /// Download bytes as a file via a temporary blob URL.
 void downloadBytes(List<int> bytes, String filename) {
   final parts = [Uint8List.fromList(bytes).toJS].toJS;

--- a/src/frontend/lib/widgets/app_bar_actions.dart
+++ b/src/frontend/lib/widgets/app_bar_actions.dart
@@ -4,6 +4,8 @@ import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 import '../auth/auth_service.dart';
+import '../utils/web_helpers_stub.dart'
+    if (dart.library.js_interop) '../utils/web_helpers_web.dart';
 
 /// Shared widget for the email chip, admin, and logout icons in the app bar.
 /// The email chip navigates to Settings when tapped.
@@ -65,8 +67,13 @@ class AppBarActions extends StatelessWidget {
           tooltip: 'Logout',
           onPressed: onLogoutPressed ??
               () async {
-                await context.read<AuthService>().logout();
-                if (context.mounted) context.go('/login');
+                final logoutUrl = await context.read<AuthService>().logout();
+                if (!context.mounted) return;
+                if (logoutUrl != null) {
+                  navigateTo(logoutUrl);
+                } else {
+                  context.go('/login');
+                }
               },
         ),
       ],

--- a/src/frontend/pubspec.lock
+++ b/src/frontend/pubspec.lock
@@ -274,34 +274,6 @@ packages:
       url: "https://github.com/mcdonc/klangk-plugin-api.git"
     source: git
     version: "0.1.0"
-  klangk_plugin_beep:
-    dependency: transitive
-    description:
-      path: "/home/chrism/projects/klangk/.devenv/state/klangk/plugins/beep/klangk"
-      relative: false
-    source: path
-    version: "0.1.0"
-  klangk_plugin_bobdobbs:
-    dependency: transitive
-    description:
-      path: "/home/chrism/projects/klangk/.devenv/state/klangk/plugins/bobdobbs/klangk"
-      relative: false
-    source: path
-    version: "0.1.0"
-  klangk_plugin_celebrate:
-    dependency: transitive
-    description:
-      path: "/home/chrism/projects/klangk/.devenv/state/klangk/plugins/celebrate/klangk"
-      relative: false
-    source: path
-    version: "0.1.0"
-  klangk_plugin_itstime:
-    dependency: transitive
-    description:
-      path: "/home/chrism/projects/klangk/.devenv/state/klangk/plugins/itstime/klangk"
-      relative: false
-    source: path
-    version: "0.1.0"
   klangk_plugins:
     dependency: "direct main"
     description:

--- a/src/frontend/test/auth_service_test.dart
+++ b/src/frontend/test/auth_service_test.dart
@@ -334,6 +334,23 @@ void main() {
       expect(service.token, isNull);
     });
 
+    test('returns oidc logout url when present', () async {
+      testAuthHttpClientOverride = MockClient((request) async {
+        return http.Response(
+          '{"status":"ok","oidc_logout_url":"https://idp/logout"}',
+          200,
+        );
+      });
+
+      SharedPreferences.setMockInitialValues({'klangk_jwt': 'my-token'});
+      final service = AuthService();
+      await Future.delayed(Duration.zero);
+
+      final url = await service.logout();
+      expect(url, 'https://idp/logout');
+      expect(service.isLoggedIn, isFalse);
+    });
+
     test('clears token even if server call fails', () async {
       testAuthHttpClientOverride = MockClient((request) async {
         throw Exception('Server down');

--- a/src/frontend/test/login_page_test.dart
+++ b/src/frontend/test/login_page_test.dart
@@ -28,7 +28,11 @@ void main() {
 
   // Provide a mock config client that returns no banner by default,
   // so login page tests don't need to worry about the AuthService config fetch.
-  http.Client _configClient({bool registrationEnabled = true}) {
+  http.Client _configClient({
+    bool registrationEnabled = true,
+    List<Map<String, dynamic>>? oidcProviders,
+    String authModes = 'password',
+  }) {
     return MockClient((request) async {
       if (request.url.path.contains('/api/config')) {
         return http.Response(
@@ -37,6 +41,8 @@ void main() {
             'registration_enabled': registrationEnabled,
             'login_banner_title': '',
             'login_banner': '',
+            'oidc_providers': oidcProviders ?? [],
+            'auth_modes': authModes,
           }),
           200,
         );
@@ -522,6 +528,70 @@ void main() {
 
       expect(find.textContaining('Create one'), findsNothing);
       expect(find.text('Log In'), findsWidgets);
+    });
+
+    testWidgets('shows OIDC buttons when providers configured', (tester) async {
+      testConfigHttpClientOverride = _configClient(
+        oidcProviders: [
+          {'id': 'cac', 'display_name': 'CAC Login'},
+          {'id': 'sso', 'display_name': 'Internal SSO'},
+        ],
+        authModes: 'both',
+      );
+      await tester.pumpWidget(buildLoginPage());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Log in with CAC Login'), findsOneWidget);
+      expect(find.text('Log in with Internal SSO'), findsOneWidget);
+      // Password form still visible in "both" mode
+      expect(find.text('Email'), findsOneWidget);
+      expect(find.text('or'), findsOneWidget);
+    });
+
+    testWidgets('hides password form in oidc-only mode', (tester) async {
+      testConfigHttpClientOverride = _configClient(
+        oidcProviders: [
+          {'id': 'cac', 'display_name': 'CAC Login'},
+        ],
+        authModes: 'oidc',
+      );
+      await tester.pumpWidget(buildLoginPage());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Log in with CAC Login'), findsOneWidget);
+      // Password form hidden
+      expect(find.text('Email'), findsNothing);
+      expect(find.text('Password'), findsNothing);
+    });
+
+    testWidgets('no OIDC buttons when no providers', (tester) async {
+      testConfigHttpClientOverride = _configClient(
+        oidcProviders: [],
+        authModes: 'password',
+      );
+      await tester.pumpWidget(buildLoginPage());
+      await tester.pumpAndSettle();
+
+      // No SSO buttons
+      expect(find.textContaining('Log in with'), findsNothing);
+      // Password form visible
+      expect(find.text('Email'), findsOneWidget);
+    });
+
+    testWidgets('OIDC button triggers navigateTo', (tester) async {
+      testConfigHttpClientOverride = _configClient(
+        oidcProviders: [
+          {'id': 'test', 'display_name': 'Test IdP'},
+        ],
+        authModes: 'both',
+      );
+      await tester.pumpWidget(buildLoginPage());
+      await tester.pumpAndSettle();
+
+      // Tapping the button calls navigateTo (which is a stub in tests)
+      await tester.tap(find.text('Log in with Test IdP'));
+      await tester.pumpAndSettle();
+      // No crash — navigateTo stub is a no-op
     });
   });
 }

--- a/src/frontend/test/workspace_list_page_test.dart
+++ b/src/frontend/test/workspace_list_page_test.dart
@@ -1028,6 +1028,50 @@ void main() {
       expect(logoutCalled, isTrue);
     });
 
+    testWidgets('logout with oidc redirect calls navigateTo', (tester) async {
+      testAuthHttpClientOverride = MockClient((request) async {
+        if (request.url.path == '/workspaces') {
+          return http.Response(jsonEncode([]), 200);
+        }
+        if (request.url.path == '/auth/logout') {
+          return http.Response(
+            jsonEncode({
+              'status': 'ok',
+              'oidc_logout_url': 'https://idp.example.com/logout',
+            }),
+            200,
+          );
+        }
+        return http.Response('Not found', 404);
+      });
+
+      final router = GoRouter(
+        initialLocation: '/',
+        routes: [
+          GoRoute(
+            path: '/',
+            builder: (_, __) => const WorkspaceListPage(),
+          ),
+          GoRoute(
+            path: '/login',
+            builder: (_, __) => const Scaffold(body: Text('Login')),
+          ),
+        ],
+      );
+
+      await tester.pumpWidget(
+        ChangeNotifierProvider(
+          create: (_) => AuthService(),
+          child: MaterialApp.router(routerConfig: router),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.logout));
+      await tester.pumpAndSettle();
+      // navigateTo is a stub (no-op) in VM tests — just verifying no crash
+    });
+
     testWidgets('title tap navigates to home', (tester) async {
       testAuthHttpClientOverride = MockClient((request) async {
         if (request.url.path == '/workspaces') {


### PR DESCRIPTION
## Summary

- Multi-provider OIDC authentication (e.g., two Keycloak realms for CAC + internal SSO)
- Configured via YAML file (`KLANGK_OIDC_CONFIG`), auth modes: `password`, `oidc`, or `both`
- Authorization Code flow with PKCE, ID token validation via JWKS or static PEM
- JIT user provisioning on first login, email-match linking for existing users
- Per-provider admin role mapping from IdP claims
- Per-provider RP-Initiated Logout (`logout_redirect` flag)
- Custom CA cert support for IdPs with private CAs (e.g., DoD PKI)
- Schema migration: password_hash nullable, provider/external_id columns
- Frontend: SSO buttons on login page, OIDC complete page, logout redirect
- CLI: browser-based OIDC login flow (planned, endpoints ready)
- 968 backend tests, 100% coverage; frontend 100% coverage

## Test plan
- [x] Backend unit tests (OIDC client, config loading, endpoints, migration, logout)
- [x] Frontend unit tests (login page SSO buttons, auth service logout URL, app bar redirect)
- [ ] Manual: configure Keycloak, login via SSO, verify user created with correct roles
- [ ] Manual: logout with `logout_redirect: true`, verify IdP session killed
- [ ] CI passes

Closes #87 partially (OIDC portion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)