### PR TITLE
Style workspace list with bordered section cards

### DIFF
--- a/src/frontend/lib/workspace/workspace_list_page.dart
+++ b/src/frontend/lib/workspace/workspace_list_page.dart
@@ -490,94 +490,123 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
       padding: const EdgeInsets.all(16),
       children: [
         if (_workspaces.isNotEmpty)
-          Padding(
-            padding: const EdgeInsets.only(bottom: 8),
-            child: Text(
-              'Owned by Me',
-              style: TextStyle(
-                fontSize: 16,
-                fontWeight: FontWeight.w600,
-                color: KColors.textPrimary,
-                letterSpacing: 0.5,
-              ),
+          Container(
+            margin: const EdgeInsets.only(bottom: 16),
+            decoration: BoxDecoration(
+              border: Border.all(color: KColors.borderDefault),
+              borderRadius: BorderRadius.circular(8),
+              color: KColors.bgSurface,
             ),
-          ),
-        ..._workspaces.map((ws) {
-          final wsMembers = _workspaceMembers[ws['id'] as String] ?? [];
-          return Card(
-            child: ListTile(
-              leading: const Icon(Icons.folder, color: KColors.accentGreen),
-              title: Text(ws['name'] as String),
-              subtitle: Row(
-                children: [
-                  Text(_formatCreatedAt(ws['created_at'] as String?)),
-                  if (wsMembers.isNotEmpty) ...[
-                    const SizedBox(width: 8),
-                    ...wsMembers.map((m) {
-                      final email = m['email'] as String;
-                      final letter =
-                          email.isNotEmpty ? email[0].toUpperCase() : '?';
-                      return Padding(
-                        padding: const EdgeInsets.only(right: 2),
-                        child: Tooltip(
-                          message: email,
-                          child: CircleAvatar(
-                            radius: 10,
-                            backgroundColor: KColors.accentGreen,
-                            child: Text(
-                              letter,
-                              style: const TextStyle(
-                                fontSize: 10,
-                                color: Colors.white,
-                                fontWeight: FontWeight.bold,
-                              ),
-                            ),
-                          ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+                  child: Row(
+                    children: [
+                      const Icon(Icons.folder,
+                          size: 18, color: KColors.textSecondary),
+                      const SizedBox(width: 8),
+                      Text(
+                        'Owned by Me',
+                        style: TextStyle(
+                          fontSize: 14,
+                          fontWeight: FontWeight.bold,
+                          color: KColors.textPrimary,
                         ),
-                      );
-                    }),
-                  ],
-                ],
-              ),
-              trailing: IconButton(
-                icon: const Icon(Icons.delete_outline),
-                tooltip: 'Delete workspace',
-                onPressed: () => _deleteWorkspace(ws['id'] as String),
-              ),
-              onTap: () => context.go('/workspace/${ws['id']}'),
-            ),
-          );
-        }),
-        if (_sharedWorkspaces.isNotEmpty) ...[
-          const Padding(
-            padding: EdgeInsets.symmetric(vertical: 12),
-            child: Divider(),
-          ),
-          Padding(
-            padding: const EdgeInsets.only(bottom: 8),
-            child: Text(
-              'Shared with Me',
-              style: TextStyle(
-                fontSize: 16,
-                fontWeight: FontWeight.w600,
-                color: KColors.textPrimary,
-                letterSpacing: 0.5,
-              ),
-            ),
-          ),
-          ..._sharedWorkspaces.map((ws) => Card(
-                child: ListTile(
-                  leading: const Icon(Icons.folder_shared,
-                      color: KColors.accentGreen),
-                  title: Text(ws['name'] as String),
-                  subtitle: Text(
-                      '${ws['owner_email']} · ${_formatCreatedAt(ws['created_at'] as String?)}'),
-                  // coverage:ignore-start
-                  onTap: () => context.go('/workspace/${ws['id']}'),
-                  // coverage:ignore-end
+                      ),
+                    ],
+                  ),
                 ),
-              )),
-        ],
+                ..._workspaces.map((ws) {
+                  final wsMembers = _workspaceMembers[ws['id'] as String] ?? [];
+                  return ListTile(
+                    leading: const Icon(Icons.terminal,
+                        size: 20, color: KColors.accentGreen),
+                    title: Text(ws['name'] as String),
+                    subtitle: Row(
+                      children: [
+                        Text(_formatCreatedAt(ws['created_at'] as String?)),
+                        if (wsMembers.isNotEmpty) ...[
+                          const SizedBox(width: 8),
+                          ...wsMembers.map((m) {
+                            final email = m['email'] as String;
+                            final letter =
+                                email.isNotEmpty ? email[0].toUpperCase() : '?';
+                            return Padding(
+                              padding: const EdgeInsets.only(right: 2),
+                              child: Tooltip(
+                                message: email,
+                                child: CircleAvatar(
+                                  radius: 10,
+                                  backgroundColor: KColors.accentGreen,
+                                  child: Text(
+                                    letter,
+                                    style: const TextStyle(
+                                      fontSize: 10,
+                                      color: Colors.white,
+                                      fontWeight: FontWeight.bold,
+                                    ),
+                                  ),
+                                ),
+                              ),
+                            );
+                          }),
+                        ],
+                      ],
+                    ),
+                    trailing: IconButton(
+                      icon: const Icon(Icons.delete_outline),
+                      tooltip: 'Delete workspace',
+                      onPressed: () => _deleteWorkspace(ws['id'] as String),
+                    ),
+                    onTap: () => context.go('/workspace/${ws['id']}'),
+                  );
+                }),
+              ],
+            ),
+          ),
+        if (_sharedWorkspaces.isNotEmpty)
+          Container(
+            decoration: BoxDecoration(
+              border: Border.all(color: KColors.borderDefault),
+              borderRadius: BorderRadius.circular(8),
+              color: KColors.bgSurface,
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+                  child: Row(
+                    children: [
+                      const Icon(Icons.folder_shared,
+                          size: 18, color: KColors.textSecondary),
+                      const SizedBox(width: 8),
+                      Text(
+                        'Shared with Me',
+                        style: TextStyle(
+                          fontSize: 14,
+                          fontWeight: FontWeight.bold,
+                          color: KColors.textPrimary,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                ..._sharedWorkspaces.map((ws) => ListTile(
+                      leading: const Icon(Icons.terminal,
+                          size: 20, color: KColors.accentBlue),
+                      title: Text(ws['name'] as String),
+                      subtitle: Text(
+                          '${ws['owner_email']} · ${_formatCreatedAt(ws['created_at'] as String?)}'),
+                      // coverage:ignore-start
+                      onTap: () => context.go('/workspace/${ws['id']}'),
+                      // coverage:ignore-end
+                    )),
+              ],
+            ),
+          ),
       ],
     );
   }

--- a/src/frontend/test/workspace_list_page_test.dart
+++ b/src/frontend/test/workspace_list_page_test.dart
@@ -186,7 +186,7 @@ void main() {
 
       expect(find.text('Project A'), findsOneWidget);
       expect(find.text('Project B'), findsOneWidget);
-      expect(find.byIcon(Icons.folder), findsNWidgets(2));
+      expect(find.byIcon(Icons.terminal), findsNWidgets(2));
       // Dates formatted as local time (VM tests run in UTC)
       expect(find.textContaining('Jan 15, 2026'), findsOneWidget);
       expect(find.textContaining('Jun 2, 2026'), findsOneWidget);
@@ -270,7 +270,8 @@ void main() {
       expect(find.text('Shared with Me'), findsOneWidget);
       expect(find.text('Team Project'), findsOneWidget);
       expect(find.textContaining('alice@example.com'), findsOneWidget);
-      expect(find.byIcon(Icons.folder_shared), findsOneWidget);
+      // Shared workspaces use terminal icon with blue color
+      expect(find.byIcon(Icons.terminal), findsNWidgets(2));
     });
 
     testWidgets('shows only shared section when no owned workspaces',
@@ -578,7 +579,6 @@ void main() {
       await tester.pumpWidget(buildPage());
       await tester.pumpAndSettle();
 
-      expect(find.byType(Card), findsOneWidget);
       expect(find.byType(ListTile), findsOneWidget);
     });
 


### PR DESCRIPTION
## Summary

- Replace horizontal divider between Owned/Shared workspace sections with bordered container cards
- Each section has an icon header row (folder/folder_shared icons)
- Workspace list items use terminal icon instead of folder icon
- Shared workspaces use blue terminal icon to distinguish from green owned ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)