### PR TITLE
Remove hardcoded admin_claim/admin_group OIDC mapping

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -343,8 +343,6 @@ Klangk supports OIDC authentication via one or more external Identity Providers 
   client_id: klangk
   client_secret: "file:/run/secrets/cac-secret"
   scopes: openid email profile
-  admin_claim: realm_access.roles
-  admin_group: klangk-admin
   ca_cert: /etc/pki/tls/certs/dod-ca-bundle.pem
   logout_redirect: true
 
@@ -376,8 +374,6 @@ KLANGK_OIDC_CONFIG=/path/to/oidc.yaml
 | `client_id`            | Yes      | OIDC client ID registered with the IdP                                                                                      |
 | `client_secret`        | Yes      | OIDC client secret. Supports `file:` prefix for secret management                                                           |
 | `scopes`               | No       | Space-separated scopes (default: `openid email profile`)                                                                    |
-| `admin_claim`          | No       | Dot-path to the claim containing roles/groups (e.g., `realm_access.roles`)                                                  |
-| `admin_group`          | No       | Value in that claim that maps to membership in the Klangk `admin` group                                                     |
 | `ca_cert`              | No       | Path to a CA certificate PEM file for IdPs with custom/private CAs (e.g., DoD PKI)                                          |
 | `token_validation_pem` | No       | Inline RSA/EC public key PEM for static token validation (skips JWKS discovery)                                             |
 | `logout_redirect`      | No       | If `true`, logout redirects to the IdP's `end_session_endpoint` (RP-Initiated Logout). Default: `false` (local-only logout) |
@@ -387,7 +383,7 @@ KLANGK_OIDC_CONFIG=/path/to/oidc.yaml
 - **Web**: Login page shows one button per provider. Clicking redirects to the IdP via Authorization Code flow with PKCE. After authentication, the IdP redirects back to Klangk which exchanges the code for tokens, validates the ID token, and issues a Klangk JWT.
 - **CLI**: `klangk login` detects OIDC from the server config, opens a browser for authentication, and receives the token via a temporary localhost callback server.
 - **User provisioning**: On first OIDC login, a user is created automatically (verified, no password). If a local user with the same email already exists, the OIDC identity is linked to it.
-- **Group mapping**: If `admin_claim` and `admin_group` are configured, the user is added to or removed from the `admin` group based on the IdP claim on every login. See [Authorization](#authorization-acl-system).
+- **Group mapping**: OIDC-to-group mapping (syncing IdP claims to Klangk group membership) is planned but not yet implemented. See issue #113.
 - **OIDC users** cannot use forgot-password, change-password, or change-email.
 - **Logout**: By default, logout only kills the Klangk session. With `logout_redirect: true`, the user is also redirected to the IdP's logout endpoint to end the SSO session (requires full re-authentication on next login).
 

--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -742,19 +742,6 @@ async def oidc_callback(
                 external_id=sub,
             )
 
-    # Sync admin group membership from IdP claims
-    should_be_admin = oidc.extract_admin_role(provider, claims)
-    if should_be_admin is not None:
-        admin_group = await model.get_group_by_name("admin")
-        if admin_group:
-            current_groups = await model.get_user_group_ids(user["id"])
-            if should_be_admin and admin_group["id"] not in current_groups:
-                await model.add_user_to_group(user["id"], admin_group["id"])
-            elif not should_be_admin and admin_group["id"] in current_groups:
-                await model.remove_user_from_group(
-                    user["id"], admin_group["id"]
-                )
-
     # Issue Klangk JWT
     access_token = auth.create_token(user["id"], email)
 

--- a/src/backend/klangk_backend/oidc.py
+++ b/src/backend/klangk_backend/oidc.py
@@ -31,8 +31,6 @@ class OIDCProvider:
     client_id: str
     client_secret: str
     scopes: str = "openid email profile"
-    admin_claim: str | None = None
-    admin_group: str | None = None
     ca_cert: str | None = None  # path to CA cert PEM for custom trust
     token_validation_pem: str | None = None  # static RSA/EC public key PEM
     logout_redirect: bool = False  # redirect to IdP logout on user logout
@@ -89,8 +87,6 @@ def load_config() -> list[OIDCProvider]:
                 client_id=entry["client_id"],
                 client_secret=secret or "",
                 scopes=entry.get("scopes", "openid email profile"),
-                admin_claim=entry.get("admin_claim"),
-                admin_group=entry.get("admin_group"),
                 ca_cert=ca_cert,
                 token_validation_pem=entry.get("token_validation_pem"),
                 logout_redirect=entry.get("logout_redirect", False),
@@ -287,30 +283,6 @@ async def validate_id_token(
         access_token=access_token,
     )
     return claims
-
-
-def extract_admin_role(provider: OIDCProvider, claims: dict) -> bool | None:
-    """Check if the user should have the admin role based on IdP claims.
-
-    Returns True (grant), False (revoke), or None (no mapping configured).
-    """
-    if not provider.admin_claim or not provider.admin_group:
-        return None
-
-    # Support dot-path claims like "realm_access.roles"
-    value = claims
-    for key in provider.admin_claim.split("."):
-        if isinstance(value, dict):
-            value = value.get(key)
-        else:
-            value = None
-            break
-
-    if isinstance(value, list):
-        return provider.admin_group in value
-    if isinstance(value, str):
-        return value == provider.admin_group
-    return False
 
 
 async def build_logout_url(

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -4255,36 +4255,6 @@ class TestOIDCCallback:
         assert linked is not None
         assert linked["id"] == user["id"]
 
-    async def test_callback_maps_admin_role(
-        self, client, monkeypatch, admin_group
-    ):
-        provider, cookie_data = await self._setup_callback(
-            client,
-            monkeypatch,
-            admin_group,  # db fixture is implied via admin_group
-            claims={
-                "sub": "admin-sub",
-                "email": "oidcadmin@example.com",
-                "roles": ["klangk-admin"],
-            },
-        )
-        # Enable role mapping on the provider
-        provider.admin_claim = "roles"
-        provider.admin_group = "klangk-admin"
-        monkeypatch.setattr(api.oidc, "get_provider", lambda _: provider)
-
-        resp = await client.get(
-            "/auth/oidc/test/callback",
-            params={"code": "code", "state": "test-state"},
-            cookies={"oidc_test": cookie_data},
-            follow_redirects=False,
-        )
-        assert resp.status_code == 302
-
-        user = await model.get_user_by_email("oidcadmin@example.com")
-        group_ids = await model.get_user_group_ids(user["id"])
-        assert admin_group["id"] in group_ids
-
     async def test_callback_state_mismatch(self, client, monkeypatch, db):
         _, cookie_data = await self._setup_callback(client, monkeypatch, db)
         resp = await client.get(
@@ -4519,65 +4489,6 @@ class TestOIDCCallback:
             params={"code": "code", "state": "s"},
         )
         assert resp.status_code == 404
-
-    async def test_callback_revokes_admin_role(
-        self, client, monkeypatch, admin_group
-    ):
-        # Create user in admin group
-        user = await model.create_user(
-            "revoke-admin@example.com",
-            password_hash=None,
-            verified=True,
-            provider="test",
-            external_id="revoke-sub",
-        )
-        await model.add_user_to_group(user["id"], admin_group["id"])
-
-        import json as json_mod
-
-        provider = api.oidc.OIDCProvider(
-            id="test",
-            display_name="Test",
-            issuer="https://idp.example.com",
-            client_id="klangk",
-            client_secret="s",
-            admin_claim="roles",
-            admin_group="klangk-admin",
-        )
-        monkeypatch.setattr(api.oidc, "get_provider", lambda _: provider)
-        monkeypatch.setattr(
-            api.oidc,
-            "exchange_code",
-            AsyncMock(return_value={"id_token": "t", "access_token": "at"}),
-        )
-        monkeypatch.setattr(
-            api.oidc,
-            "validate_id_token",
-            AsyncMock(
-                return_value={
-                    "sub": "revoke-sub",
-                    "email": "revoke-admin@example.com",
-                    "roles": ["user"],  # no admin group
-                }
-            ),
-        )
-        cookie_data = json_mod.dumps(
-            {
-                "state": "s",
-                "verifier": "v",
-                "redirect_uri": "https://cb",
-                "cli_redirect": None,
-            }
-        )
-        resp = await client.get(
-            "/auth/oidc/test/callback",
-            params={"code": "code", "state": "s"},
-            cookies={"oidc_test": cookie_data},
-            follow_redirects=False,
-        )
-        assert resp.status_code == 302
-        group_ids = await model.get_user_group_ids(user["id"])
-        assert admin_group["id"] not in group_ids
 
     async def test_callback_invalid_cookie_json(self, client, monkeypatch, db):
         provider = api.oidc.OIDCProvider(

--- a/src/backend/tests/test_oidc.py
+++ b/src/backend/tests/test_oidc.py
@@ -30,8 +30,6 @@ def _provider(**overrides):
         "client_id": "klangk",
         "client_secret": "secret",
         "scopes": "openid email profile",
-        "admin_claim": None,
-        "admin_group": None,
     }
     defaults.update(overrides)
     return oidc.OIDCProvider(**defaults)
@@ -58,8 +56,6 @@ class TestLoadConfig:
                         "issuer": "https://idp.example.com/",
                         "client_id": "klangk",
                         "client_secret": "s3cret",
-                        "admin_claim": "roles",
-                        "admin_group": "admin",
                     }
                 ]
             )
@@ -70,7 +66,6 @@ class TestLoadConfig:
         assert providers[0].id == "test"
         assert providers[0].issuer == "https://idp.example.com"
         assert providers[0].client_secret == "s3cret"
-        assert providers[0].admin_claim == "roles"
 
     def test_file_secret(self, monkeypatch, tmp_path):
         secret_file = tmp_path / "secret"
@@ -544,45 +539,3 @@ class TestBuildLogoutUrl:
         assert result.startswith("https://idp.example.com/logout?")
         assert "client_id=klangk" in result
         assert "post_logout_redirect_uri=" in result
-
-
-class TestExtractAdminRole:
-    def test_no_mapping_configured(self):
-        provider = _provider()
-        assert oidc.extract_admin_role(provider, {}) is None
-
-    def test_admin_in_flat_list(self):
-        provider = _provider(admin_claim="roles", admin_group="klangk-admin")
-        claims = {"roles": ["user", "klangk-admin"]}
-        assert oidc.extract_admin_role(provider, claims) is True
-
-    def test_admin_not_in_list(self):
-        provider = _provider(admin_claim="roles", admin_group="klangk-admin")
-        claims = {"roles": ["user"]}
-        assert oidc.extract_admin_role(provider, claims) is False
-
-    def test_nested_claim_path(self):
-        provider = _provider(
-            admin_claim="realm_access.roles",
-            admin_group="admin",
-        )
-        claims = {"realm_access": {"roles": ["admin", "user"]}}
-        assert oidc.extract_admin_role(provider, claims) is True
-
-    def test_nested_claim_missing(self):
-        provider = _provider(
-            admin_claim="realm_access.roles",
-            admin_group="admin",
-        )
-        claims = {"other": "stuff"}
-        assert oidc.extract_admin_role(provider, claims) is False
-
-    def test_string_claim(self):
-        provider = _provider(admin_claim="role", admin_group="admin")
-        claims = {"role": "admin"}
-        assert oidc.extract_admin_role(provider, claims) is True
-
-    def test_string_claim_no_match(self):
-        provider = _provider(admin_claim="role", admin_group="admin")
-        claims = {"role": "user"}
-        assert oidc.extract_admin_role(provider, claims) is False


### PR DESCRIPTION
## Summary

- Remove `admin_claim` and `admin_group` fields from `OIDCProvider` dataclass
- Remove `extract_admin_role()` function from oidc.py
- Remove admin group sync from OIDC callback in api.py
- Remove all related tests
- Update HACKING.md: remove config fields, update docs to reference #113

The hardcoded admin-only mapping is replaced by nothing for now. General OIDC-to-group mapping rules are tracked in #113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)