### PR TITLE
Add ACL browser tab to admin page

### DIFF
--- a/src/frontend/e2e-tests/e2e/klangk.spec.ts
+++ b/src/frontend/e2e-tests/e2e/klangk.spec.ts
@@ -1644,6 +1644,93 @@ test.describe("Klangk E2E", () => {
     });
   });
 
+  test("admin ACL browser: read and modify static resource ACL", async ({
+    request,
+  }) => {
+    // Login as admin
+    const loginResp = await request.post(`${API_BASE}/auth/login`, {
+      data: { email: "admin@example.com", password: "admin" },
+    });
+    expect(loginResp.ok()).toBeTruthy();
+    const adminHeaders = {
+      Authorization: `Bearer ${(await loginResp.json()).access_token}`,
+    };
+
+    // Read the root resource ACL
+    let resp = await request.get(`${API_BASE}/admin/acl/resource?resource=/`, {
+      headers: adminHeaders,
+    });
+    expect(resp.ok()).toBeTruthy();
+    const rootAces = await resp.json();
+    expect(rootAces.length).toBeGreaterThan(0);
+    // Root has Authenticated view and Everyone deny
+    expect(
+      rootAces.some(
+        (a: any) => a.principal === "Authenticated" && a.permission === "view",
+      ),
+    ).toBeTruthy();
+
+    // Read /admin resource ACL
+    resp = await request.get(`${API_BASE}/admin/acl/resource?resource=/admin`, {
+      headers: adminHeaders,
+    });
+    expect(resp.ok()).toBeTruthy();
+    const adminAces = await resp.json();
+    expect(
+      adminAces.some(
+        (a: any) => a.principal === "admin" && a.permission === "*",
+      ),
+    ).toBeTruthy();
+
+    // Modify /admin/groups ACL: add a view entry, then restore
+    resp = await request.get(
+      `${API_BASE}/admin/acl/resource?resource=/admin/groups`,
+      { headers: adminHeaders },
+    );
+    const originalGroupsAces = await resp.json();
+
+    const newEntries = [
+      ...originalGroupsAces.map((a: any) => ({
+        action: a.action,
+        principal_type: a.principal_type,
+        permission: a.permission,
+        user_id: a.user_id || null,
+        group_id: a.group_id || null,
+        system_principal: a.system_principal ?? null,
+      })),
+      {
+        action: 1,
+        principal_type: 0,
+        permission: "view",
+        user_id: null,
+        group_id: null,
+        system_principal: 1,
+      },
+    ];
+
+    resp = await request.put(
+      `${API_BASE}/admin/acl/resource?resource=/admin/groups`,
+      { headers: adminHeaders, data: newEntries },
+    );
+    expect(resp.ok()).toBeTruthy();
+    expect((await resp.json()).length).toBe(originalGroupsAces.length + 1);
+
+    // Restore original
+    const restore = originalGroupsAces.map((a: any) => ({
+      action: a.action,
+      principal_type: a.principal_type,
+      permission: a.permission,
+      user_id: a.user_id || null,
+      group_id: a.group_id || null,
+      system_principal: a.system_principal ?? null,
+    }));
+    resp = await request.put(
+      `${API_BASE}/admin/acl/resource?resource=/admin/groups`,
+      { headers: adminHeaders, data: restore },
+    );
+    expect(resp.ok()).toBeTruthy();
+  });
+
   test("browser-delegate routes to the correct connection", async ({
     browser,
     request,

--- a/src/frontend/lib/admin/admin_users_page.dart
+++ b/src/frontend/lib/admin/admin_users_page.dart
@@ -4,6 +4,7 @@ import '../theme/colors.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../auth/auth_service.dart';
+import '../widgets/acl_editor.dart';
 import '../widgets/app_bar_actions.dart';
 import '../widgets/app_bar_title.dart';
 import '../widgets/skeuo_tab.dart';
@@ -658,6 +659,7 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
     if (_canUsers) types.add('users');
     if (_canGroups) types.add('groups');
     if (_canInvitations) types.add('invitations');
+    if (types.isNotEmpty) types.add('acl');
     return types;
   }
 
@@ -699,6 +701,18 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
         onTap: () => setState(() => _selectedIndex = idx),
       ));
       views.add(_buildInvitationsTab());
+    }
+
+    // ACL tab — always visible for admins
+    if (tabTypes.isNotEmpty) {
+      final idx = tabs.length;
+      tabs.add(SkeuoTab(
+        label: 'ACL',
+        icon: Icons.security,
+        isSelected: _selectedIndex == idx,
+        onTap: () => setState(() => _selectedIndex = idx),
+      ));
+      views.add(const _AclBrowserTab());
     }
 
     if (tabs.isEmpty) {
@@ -1054,6 +1068,120 @@ class _UserAvatar extends StatelessWidget {
             ),
         ],
       ),
+    );
+  }
+}
+
+/// ACL browser tab: shows the static resource tree and lets you edit ACLs.
+class _AclBrowserTab extends StatefulWidget {
+  const _AclBrowserTab();
+
+  @override
+  State<_AclBrowserTab> createState() => _AclBrowserTabState();
+}
+
+class _AclBrowserTabState extends State<_AclBrowserTab> {
+  static const _resources = [
+    ('/', 'Root', Icons.home),
+    ('/workspaces', 'Workspaces', Icons.folder),
+    ('/admin', 'Admin', Icons.admin_panel_settings),
+    ('/admin/users', 'Admin / Users', Icons.people),
+    ('/admin/invitations', 'Admin / Invitations', Icons.mail_outline),
+    ('/admin/groups', 'Admin / Groups', Icons.group),
+  ];
+
+  String _selectedResource = '/';
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Resource tree sidebar
+        SizedBox(
+          width: 220,
+          child: Container(
+            decoration: const BoxDecoration(
+              border: Border(
+                right: BorderSide(color: KColors.borderDefault),
+              ),
+            ),
+            child: ListView(
+              padding: const EdgeInsets.symmetric(vertical: 8),
+              children: _resources.map((r) {
+                final (path, label, icon) = r;
+                final isSelected = path == _selectedResource;
+                final depth = path == '/' ? 0 : path.split('/').length - 1;
+                return InkWell(
+                  onTap: () => setState(() => _selectedResource = path),
+                  child: Container(
+                    color: isSelected
+                        ? KColors.accentGreen.withValues(alpha: 0.15)
+                        : null,
+                    padding: EdgeInsets.only(
+                      left: 12.0 + depth * 16.0,
+                      right: 12,
+                      top: 10,
+                      bottom: 10,
+                    ),
+                    child: Row(
+                      children: [
+                        Icon(icon,
+                            size: 16,
+                            color: isSelected
+                                ? KColors.accentGreen
+                                : KColors.textSecondary),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(
+                            label,
+                            style: TextStyle(
+                              fontSize: 13,
+                              fontWeight: isSelected
+                                  ? FontWeight.bold
+                                  : FontWeight.normal,
+                              color: isSelected
+                                  ? KColors.textPrimary
+                                  : KColors.textSecondary,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                );
+              }).toList(),
+            ),
+          ),
+        ),
+        // ACL editor for selected resource
+        Expanded(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'ACL for $_selectedResource',
+                  style: const TextStyle(
+                    fontWeight: FontWeight.bold,
+                    fontSize: 14,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Expanded(
+                  child: SingleChildScrollView(
+                    child: AclEditor(
+                      key: ValueKey(_selectedResource),
+                      resource: _selectedResource,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
Closes #109

## Summary

- New ACL tab on the admin page with a resource tree sidebar
- Shows all static resources: /, /workspaces, /admin, /admin/users, /admin/invitations, /admin/groups
- Click any resource to view/edit its ACEs using the AclEditor widget
- Indented tree layout with icons per resource type
- E2E test: read and modify static resource ACLs via admin API

🤖 Generated with [Claude Code](https://claude.com/claude-code)