### PR TITLE
Remove Access Control tab from workspaces page

### DIFF
--- a/src/frontend/e2e-tests/e2e/klangk.spec.ts
+++ b/src/frontend/e2e-tests/e2e/klangk.spec.ts
@@ -1731,6 +1731,47 @@ test.describe("Klangk E2E", () => {
     expect(resp.ok()).toBeTruthy();
   });
 
+  test("admin ACL browser: all static resources readable", async ({
+    request,
+  }) => {
+    const loginResp = await request.post(`${API_BASE}/auth/login`, {
+      data: { email: "admin@example.com", password: "admin" },
+    });
+    const adminHeaders = {
+      Authorization: `Bearer ${(await loginResp.json()).access_token}`,
+    };
+
+    const resources = [
+      "/",
+      "/workspaces",
+      "/admin",
+      "/admin/users",
+      "/admin/invitations",
+      "/admin/groups",
+    ];
+
+    for (const resource of resources) {
+      const resp = await request.get(
+        `${API_BASE}/admin/acl/resource?resource=${encodeURIComponent(resource)}`,
+        { headers: adminHeaders },
+      );
+      expect(resp.ok()).toBeTruthy();
+    }
+  });
+
+  test("admin ACL browser: non-admin denied access", async ({ request }) => {
+    const { headers: userHeaders } = await registerUser(
+      request,
+      `acl-denied-${Date.now()}@test.example.com`,
+    );
+
+    const resp = await request.get(
+      `${API_BASE}/admin/acl/resource?resource=/`,
+      { headers: userHeaders },
+    );
+    expect(resp.status()).toBe(403);
+  });
+
   test("browser-delegate routes to the correct connection", async ({
     browser,
     request,

--- a/src/frontend/lib/admin/admin_users_page.dart
+++ b/src/frontend/lib/admin/admin_users_page.dart
@@ -707,7 +707,7 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
     if (tabTypes.isNotEmpty) {
       final idx = tabs.length;
       tabs.add(SkeuoTab(
-        label: 'ACL',
+        label: 'Access Control',
         icon: Icons.security,
         isSelected: _selectedIndex == idx,
         onTap: () => setState(() => _selectedIndex = idx),
@@ -1085,9 +1085,9 @@ class _AclBrowserTabState extends State<_AclBrowserTab> {
     ('/', 'Root', Icons.home),
     ('/workspaces', 'Workspaces', Icons.folder),
     ('/admin', 'Admin', Icons.admin_panel_settings),
-    ('/admin/users', 'Admin / Users', Icons.people),
-    ('/admin/invitations', 'Admin / Invitations', Icons.mail_outline),
-    ('/admin/groups', 'Admin / Groups', Icons.group),
+    ('/admin/users', 'Users', Icons.people),
+    ('/admin/invitations', 'Invitations', Icons.mail_outline),
+    ('/admin/groups', 'Groups', Icons.group),
   ];
 
   String _selectedResource = '/';

--- a/src/frontend/lib/workspace/workspace_list_page.dart
+++ b/src/frontend/lib/workspace/workspace_list_page.dart
@@ -7,10 +7,8 @@ import 'package:provider/provider.dart';
 import '../auth/auth_service.dart';
 import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 import '../utils/page_title.dart';
-import '../widgets/acl_editor.dart';
 import '../widgets/app_bar_actions.dart';
 import '../widgets/app_bar_title.dart';
-import '../widgets/skeuo_tab.dart';
 
 const _validMountOptions = {
   'ro',
@@ -56,7 +54,6 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
   List<Map<String, dynamic>> _sharedWorkspaces = [];
   Map<String, List<Map<String, dynamic>>> _workspaceMembers = {};
   bool _loading = true;
-  int _selectedTab = 0;
 
   @override
   void initState() {
@@ -625,38 +622,6 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
 
   @override
   Widget build(BuildContext context) {
-    final auth = context.watch<AuthService>();
-    final canAdmin = auth.hasPermission('/workspaces', '*') ||
-        auth.hasPermission('/admin', '*');
-
-    final tabs = <SkeuoTab>[
-      SkeuoTab(
-        label: 'Workspaces',
-        icon: Icons.folder,
-        isSelected: _selectedTab == 0,
-        onTap: () => setState(() => _selectedTab = 0),
-      ),
-    ];
-    final views = <Widget>[_buildWorkspacesList()];
-
-    if (canAdmin) {
-      tabs.add(SkeuoTab(
-        label: 'Access Control',
-        icon: Icons.security,
-        isSelected: _selectedTab == 1,
-        onTap: () => setState(() => _selectedTab = 1),
-      ));
-      views.add(
-        Padding(
-          padding: const EdgeInsets.all(16),
-          child: ConstrainedBox(
-            constraints: const BoxConstraints(maxWidth: 500),
-            child: const AclEditor(resource: '/workspaces'),
-          ),
-        ),
-      );
-    }
-
     return Scaffold(
       appBar: AppBar(
         title: const AppBarTitle(title: 'Workspaces'),
@@ -665,31 +630,13 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
         ],
       ),
       floatingActionButton:
-          _selectedTab == 0 && auth.hasPermission('/workspaces', 'create')
+          context.watch<AuthService>().hasPermission('/workspaces', 'create')
               ? FloatingActionButton(
                   onPressed: _createWorkspace,
                   child: const Icon(Icons.add),
                 )
               : null,
-      body: Column(
-        children: [
-          if (tabs.length > 1)
-            Container(
-              height: 40,
-              color: KColors.bgCanvas,
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: tabs.map((t) => Expanded(child: t)).toList(),
-              ),
-            ),
-          Expanded(
-            child: IndexedStack(
-              index: _selectedTab < views.length ? _selectedTab : 0,
-              children: views,
-            ),
-          ),
-        ],
-      ),
+      body: _buildWorkspacesList(),
     );
   }
 }

--- a/src/frontend/test/workspace_list_page_test.dart
+++ b/src/frontend/test/workspace_list_page_test.dart
@@ -10,7 +10,6 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:klangk_frontend/auth/auth_service.dart';
 import 'package:klangk_frontend/workspace/workspace_list_page.dart';
 import 'package:klangk_frontend/widgets/klangk_logo.dart';
-import 'package:klangk_frontend/widgets/skeuo_tab.dart';
 import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 
 void main() {
@@ -1519,48 +1518,6 @@ void main() {
       await tester.pumpAndSettle();
       expect(find.textContaining('Key cannot'), findsNothing);
       expect(find.text('A=1'), findsOneWidget);
-    });
-
-    testWidgets('Access Control tab shown for admin', (tester) async {
-      final token = makeJwt({'sub': 'admin-1', 'email': 'admin@example.com'});
-      SharedPreferences.setMockInitialValues({'klangk_jwt': token});
-      testAuthHttpClientOverride = withPermissions(
-        (request) async {
-          if (request.url.path == '/workspaces') {
-            return http.Response(jsonEncode([]), 200);
-          }
-          if (request.url.path == '/workspaces/shared') {
-            return http.Response(jsonEncode([]), 200);
-          }
-          return http.Response('Not found', 404);
-        },
-        permissions: {
-          '/admin': ['*'],
-          '/workspaces': ['create'],
-        },
-      );
-      await tester.pumpWidget(buildPage());
-      await tester.pumpAndSettle();
-
-      expect(find.text('Access Control'), findsOneWidget);
-
-      // Switch to Access Control tab
-      await tester.tap(find.text('Access Control'));
-      await tester.pumpAndSettle();
-
-      // Switch back to Workspaces tab — use the SkeuoTab, not the AppBar title
-      await tester.tap(find.descendant(
-        of: find.byType(SkeuoTab),
-        matching: find.text('Workspaces'),
-      ));
-      await tester.pumpAndSettle();
-    });
-
-    testWidgets('Access Control tab hidden for non-admin', (tester) async {
-      await tester.pumpWidget(buildPage());
-      await tester.pumpAndSettle();
-
-      expect(find.text('Access Control'), findsNothing);
     });
   });
 }


### PR DESCRIPTION
## Summary

- Remove Access Control tab from workspaces page (now available in admin page)
- Rename admin ACL tab from "ACL" to "Access Control"
- Shorten resource labels (remove "Admin / " prefix)
- Add E2E tests: all static resources readable, non-admin denied

🤖 Generated with [Claude Code](https://claude.com/claude-code)