### PR TITLE
Build klangk images for host architecture (native arm64)

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -215,6 +215,22 @@ The `docker-host.yml` workflow builds and pushes the host image to GHCR on push 
 - Nginx starts automatically alongside uvicorn. If `KLANGK_LLM_BASE_URL` is not set, the LLM proxy block is omitted and nginx still serves the UI and API.
 - The workspace Docker image (`klangk`) must be available in the host's Docker daemon — the host container does not build it.
 
+## Build Architecture (amd64 / arm64)
+
+All `docker build` calls (`dockerbuild`, `dockerbuild-base`, `dockerbuild-host`) build for `$KLANGK_PLATFORM`, which `devenv.nix` defaults to the host architecture (`linux/arm64` on Apple Silicon, `linux/amd64` elsewhere). This means images build and run natively instead of under QEMU emulation. Override per-shell via `.env`:
+
+```bash
+KLANGK_PLATFORM=linux/amd64   # force amd64 even on an arm64 host
+```
+
+Building the **workspace** image natively requires a **base** image with a matching variant. The base (`ghcr.io/mcdonc/klangk/klangk-base`) is published as a multi-arch manifest (amd64 + arm64) by `push-base-image`, so `pull-base-image` automatically gets the right variant for the host. If the published base lacks your arch, build it locally first:
+
+```bash
+dockerbuild-base            # local single-arch build for $KLANGK_PLATFORM
+```
+
+`push-base-image` builds and pushes both arches in one step via `docker buildx` (a multi-arch manifest cannot be loaded into the local daemon). Override the published set with `KLANGK_BASE_PLATFORMS` (default `linux/amd64,linux/arm64`).
+
 ## Project Layout
 
 ```text

--- a/devenv.nix
+++ b/devenv.nix
@@ -128,6 +128,14 @@ in
   );
   env.KLANGK_IMAGE_NAME = lib.mkOverride 1500 "klangk";
   env.KLANGK_INSTANCE_ID = lib.mkOverride 1500 "default";
+  # Docker build platform for klangk images. Defaults to the host
+  # architecture so arm64 machines build/run natively instead of under
+  # amd64 emulation. Override in .env (e.g. KLANGK_PLATFORM=linux/amd64)
+  # to force a specific arch. Building the workspace natively on arm64
+  # requires a base image that has an arm64 variant (see push-base-image).
+  env.KLANGK_PLATFORM = lib.mkOverride 1500 (
+    if pkgs.stdenv.hostPlatform.isAarch64 then "linux/arm64" else "linux/amd64"
+  );
   dotenv.enable = true;
 
   scripts.flutterbuildweb.exec = ''

--- a/scripts/dockerbuild-base.sh
+++ b/scripts/dockerbuild-base.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
-# Build base Docker image.
+# Build base Docker image locally (single arch, loaded into Docker).
 # Run when Dockerfile.base, apt packages, or Pi agent version changes.
+# Builds for KLANGK_PLATFORM (the host arch by default) so the image
+# can be loaded and run locally. To publish a multi-arch base to GHCR,
+# use push-base-image.sh instead.
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "${DEVENV_ROOT:-$SCRIPT_DIR/..}"
@@ -10,8 +13,8 @@ CALVER="$(date -u +%Y.%m.%d)"
 VERSION="${CALVER}-${COMMIT}"
 IMAGE="ghcr.io/mcdonc/klangk/klangk-base"
 
-echo "==> Building base image $VERSION"
-docker build --platform linux/amd64 \
+echo "==> Building base image $VERSION (${KLANGK_PLATFORM:-linux/amd64})"
+docker build --platform "${KLANGK_PLATFORM:-linux/amd64}" \
   --build-arg KLANGK_UID="$(id -u)" \
   --build-arg KLANGK_GID="$(id -g)" \
   -f src/docker/workspace/Dockerfile.base \

--- a/scripts/dockerbuild-host.sh
+++ b/scripts/dockerbuild-host.sh
@@ -20,7 +20,7 @@ IMAGE="${KLANGK_HOST_IMAGE:-klangk-host}"
 echo "Building $IMAGE $VERSION ..."
 
 docker build \
-  --platform linux/amd64 \
+  --platform "${KLANGK_PLATFORM:-linux/amd64}" \
   -f src/docker/host/Dockerfile \
   --build-arg "KLANGK_BUILD_VERSION=$VERSION" \
   --build-arg "KLANGK_BUILD_COMMIT=$COMMIT" \

--- a/scripts/dockerbuild.sh
+++ b/scripts/dockerbuild.sh
@@ -30,7 +30,7 @@ if [ ! -f /.dockerenv ]; then
 fi
 
 # Build workspace image on top of the base
-docker build --platform linux/amd64 \
+docker build --platform "${KLANGK_PLATFORM:-linux/amd64}" \
   --build-context plugin-extensions="$STAGING/extensions" \
   --build-context plugin-tools="$STAGING/tools" \
   -t "${KLANGK_IMAGE_NAME}" "$@" src/docker/workspace/

--- a/scripts/push-base-image.sh
+++ b/scripts/push-base-image.sh
@@ -1,16 +1,48 @@
 #!/usr/bin/env bash
-# Push the base Docker image to GHCR.
-# Logs in if not already authenticated.
+# Build and push a MULTI-ARCH base Docker image to GHCR.
+#
+# Publishes both linux/amd64 and linux/arm64 variants under a single
+# manifest list so that amd64 (CI) and arm64 (Apple Silicon) machines
+# each pull a native base image. A multi-arch build cannot be loaded
+# into the local Docker engine, so it is built and pushed in one step
+# via buildx; use dockerbuild-base.sh for a local single-arch build.
+#
+# Override the published architectures with KLANGK_BASE_PLATFORMS,
+# e.g. KLANGK_BASE_PLATFORMS=linux/amd64 to publish amd64 only.
 set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "${DEVENV_ROOT:-$SCRIPT_DIR/..}"
 
-IMAGE="ghcr.io/mcdonc/klangk/klangk-base:latest"
+IMAGE="ghcr.io/mcdonc/klangk/klangk-base"
+COMMIT="$(git rev-parse --short HEAD)"
+CALVER="$(date -u +%Y.%m.%d)"
+VERSION="${CALVER}-${COMMIT}"
+PLATFORMS="${KLANGK_BASE_PLATFORMS:-linux/amd64,linux/arm64}"
+BUILDER="klangk-multiarch"
 
 # Check if already logged in to ghcr.io
-if ! docker manifest inspect "$IMAGE" >/dev/null 2>&1; then
+if ! docker manifest inspect "$IMAGE:latest" >/dev/null 2>&1; then
   echo "==> Logging in to ghcr.io"
   docker login ghcr.io
 fi
 
-echo "==> Pushing $IMAGE"
-docker push "$IMAGE"
-echo "==> Done"
+# A multi-platform build needs a buildx builder backed by the
+# docker-container driver (the default "docker" driver is single-arch).
+if ! docker buildx inspect "$BUILDER" >/dev/null 2>&1; then
+  echo "==> Creating buildx builder $BUILDER"
+  docker buildx create --name "$BUILDER" --driver docker-container >/dev/null
+fi
+
+echo "==> Building and pushing $IMAGE ($PLATFORMS) version $VERSION"
+docker buildx build \
+  --builder "$BUILDER" \
+  --platform "$PLATFORMS" \
+  --build-arg KLANGK_UID="$(id -u)" \
+  --build-arg KLANGK_GID="$(id -g)" \
+  -f src/docker/workspace/Dockerfile.base \
+  -t "$IMAGE:latest" \
+  -t "$IMAGE:$VERSION" \
+  --push \
+  "$@" src/docker/workspace/
+
+echo "==> Done: $IMAGE:$VERSION ($PLATFORMS)"


### PR DESCRIPTION
## Problem

All `docker build` calls hardcoded `--platform linux/amd64`, so on arm64 hosts (Apple Silicon) the base, workspace, and host images were built — and spun up — under amd64 QEMU emulation, which is slow. The runtime launcher (`container.py`) does not pin a platform, so it inherits the image's arch; fixing the build is sufficient.

## Changes

- **`devenv.nix`**: new `KLANGK_PLATFORM` env defaulting to the host arch (`linux/arm64` on aarch64, `linux/amd64` otherwise). Override in `.env`.
- **`dockerbuild.sh` / `dockerbuild-base.sh` / `dockerbuild-host.sh`**: build for `"${KLANGK_PLATFORM:-linux/amd64}"`. The amd64 fallback preserves current behavior when run outside devenv.
- **`push-base-image.sh`**: rewritten to build+push a **multi-arch** (`linux/amd64,linux/arm64`) base manifest via `docker buildx`, so `pull-base-image` fetches the native variant per host. Set via `KLANGK_BASE_PLATFORMS`.
- **`HACKING.md`**: new "Build Architecture" section.

## Rollout note

The published base is currently amd64-only. After merge, a maintainer must run `push-base-image` once to publish the multi-arch manifest. Until then, arm64 devs run `dockerbuild-base` locally or set `KLANGK_PLATFORM=linux/amd64`. Documented in HACKING.md.

## Testing

- `shellcheck` + `shfmt` clean on all four scripts.
- `nixfmt -c devenv.nix` clean; expression evaluates to `linux/arm64` on an arm64 host.