### PR TITLE
Groups as ACL-managed resources

### DIFF
--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -1829,16 +1829,151 @@ async def update_user(
 # --- Group management endpoints ---
 
 
+class CreateGroupRequest(BaseModel):
+    name: str
+    description: str | None = None
+
+
+class UpdateGroupRequest(BaseModel):
+    name: str | None = None
+    description: str | None = None
+
+
+class AddGroupMemberRequest(BaseModel):
+    user_id: str
+
+
+# --- User-accessible group endpoints (ACL-gated per group) ---
+
+
+async def _group_resource(request: Request, user: dict) -> str:  # noqa: ARG001
+    """Resource function for group-level permission checks."""
+    group_id = request.path_params.get("group_id")
+    if group_id:
+        return f"/groups/{group_id}"
+    return "/groups"
+
+
+@router.get("/groups")
+async def user_list_groups(
+    user: dict = Depends(auth.get_current_user),
+):
+    """List all groups (any authenticated user can see groups)."""
+    return await model.list_groups()
+
+
+@router.post("/groups")
+async def user_create_group(
+    req: CreateGroupRequest,
+    user: dict = Depends(acl.has_permission("create", _group_resource)),
+):
+    """Create a group. The creator gets full ACL access."""
+    existing = await model.get_group_by_name(req.name)
+    if existing is not None:
+        raise HTTPException(
+            status_code=409, detail="A group with this name already exists"
+        )
+    group = await model.create_group(req.name, req.description)
+    # Grant creator full access via ACL
+    await model.add_acl_entry(
+        f"/groups/{group['id']}",
+        0,
+        ACTION_ALLOW,
+        "*",
+        PRINCIPAL_USER,
+        user_id=user["id"],
+    )
+    return group
+
+
+@router.patch("/groups/{group_id}")
+async def user_update_group(
+    group_id: str,
+    req: UpdateGroupRequest,
+    user: dict = Depends(acl.has_permission("edit", _group_resource)),
+):
+    """Update a group (requires edit permission on the group)."""
+    group = await model.get_group_by_id(group_id)
+    if group is None:
+        raise HTTPException(status_code=404, detail="Group not found")
+    updated = await model.update_group(
+        group_id, name=req.name, description=req.description
+    )
+    if not updated:
+        raise HTTPException(status_code=400, detail="No fields to update")
+    return {"status": "updated"}
+
+
+@router.delete("/groups/{group_id}")
+async def user_delete_group(
+    group_id: str,
+    user: dict = Depends(acl.has_permission("delete", _group_resource)),
+):
+    """Delete a group (requires delete permission on the group)."""
+    group = await model.get_group_by_id(group_id)
+    if group is None:
+        raise HTTPException(status_code=404, detail="Group not found")
+    await model.delete_group(group_id)
+    await model.delete_acl_entries_for_resource(f"/groups/{group_id}")
+    return {"status": "deleted"}
+
+
+@router.get("/groups/{group_id}/members")
+async def user_list_group_members(
+    group_id: str,
+    user: dict = Depends(acl.has_permission("view", _group_resource)),
+):
+    """List group members (requires view permission on the group)."""
+    group = await model.get_group_by_id(group_id)
+    if group is None:
+        raise HTTPException(status_code=404, detail="Group not found")
+    return await model.get_group_members(group_id)
+
+
+@router.post("/groups/{group_id}/members")
+async def user_add_group_member(
+    group_id: str,
+    req: AddGroupMemberRequest,
+    user: dict = Depends(
+        acl.has_permission("manage_members", _group_resource)
+    ),
+):
+    """Add a member (requires manage_members permission on the group)."""
+    group = await model.get_group_by_id(group_id)
+    if group is None:
+        raise HTTPException(status_code=404, detail="Group not found")
+    target = await model.get_user_by_id(req.user_id)
+    if target is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    await model.add_user_to_group(req.user_id, group_id)
+    return {"status": "added"}
+
+
+@router.delete("/groups/{group_id}/members/{user_id}")
+async def user_remove_group_member(
+    group_id: str,
+    user_id: str,
+    user: dict = Depends(
+        acl.has_permission("manage_members", _group_resource)
+    ),
+):
+    """Remove a member (requires manage_members on the group)."""
+    removed = await model.remove_user_from_group(user_id, group_id)
+    if not removed:
+        raise HTTPException(
+            status_code=404, detail="User is not a member of this group"
+        )
+    return {"status": "removed"}
+
+
+# --- Admin group endpoints (admin-only, kept for backward compat) ---
+
+
 @router.get("/admin/groups")
 async def list_groups(
     admin: dict = Depends(acl.has_permission("admin")),
 ):
     return await model.list_groups()
-
-
-class CreateGroupRequest(BaseModel):
-    name: str
-    description: str | None = None
 
 
 @router.post("/admin/groups")
@@ -1853,11 +1988,6 @@ async def create_group(
         )
     group = await model.create_group(req.name, req.description)
     return group
-
-
-class UpdateGroupRequest(BaseModel):
-    name: str | None = None
-    description: str | None = None
 
 
 @router.patch("/admin/groups/{group_id}")
@@ -1898,10 +2028,6 @@ async def list_group_members(
     if group is None:
         raise HTTPException(status_code=404, detail="Group not found")
     return await model.get_group_members(group_id)
-
-
-class AddGroupMemberRequest(BaseModel):
-    user_id: str
 
 
 @router.post("/admin/groups/{group_id}/members")
@@ -2026,6 +2152,7 @@ async def replace_resource_acl(
 STATIC_RESOURCES = [
     "/",
     "/workspaces",
+    "/groups",
     "/admin",
     "/admin/users",
     "/admin/invitations",
@@ -2041,6 +2168,7 @@ ALL_PERMISSIONS = [
     "files",
     "chat",
     "share",
+    "manage_members",
     "admin",
     "manage_users",
     "manage_invitations",

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -57,6 +57,15 @@ async def seed_default_acls(admin_group_id: str) -> None:
         PRINCIPAL_SYSTEM,
         system_principal=SYSTEM_AUTHENTICATED,
     )
+    # /groups: Authenticated users can create groups
+    await model.add_acl_entry(
+        "/groups",
+        0,
+        ACTION_ALLOW,
+        "create",
+        PRINCIPAL_SYSTEM,
+        system_principal=SYSTEM_AUTHENTICATED,
+    )
     # /admin: admin group gets full access, deny everyone else
     await model.add_acl_entry(
         "/admin",

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -1254,6 +1254,299 @@ class TestWorkspaceGroupSharing:
         assert resp.status_code == 403
 
 
+class TestUserGroupEndpoints:
+    """Tests for /groups endpoints (user-accessible, ACL-gated)."""
+
+    async def test_list_groups(self, client, user):
+        headers = await _auth_headers(client)
+        resp = await client.get("/groups", headers=headers)
+        assert resp.status_code == 200
+
+    async def test_create_group(self, client, admin_user, user):
+        """Any authenticated user with create permission can create groups."""
+        headers = await _auth_headers(client)
+        # Need create permission on /groups — seed it
+        await model.add_acl_entry(
+            "/groups",
+            0,
+            model.ACTION_ALLOW,
+            "create",
+            model.PRINCIPAL_SYSTEM,
+            system_principal=model.SYSTEM_AUTHENTICATED,
+        )
+        resp = await client.post(
+            "/groups",
+            headers=headers,
+            json={"name": "user-group", "description": "My team"},
+        )
+        assert resp.status_code == 200
+        group = resp.json()
+        assert group["name"] == "user-group"
+
+        # Creator should have * ACE on /groups/{id}
+        entries = await model.get_acl_entries(f"/groups/{group['id']}")
+        assert len(entries) >= 1
+        assert any(
+            e["permission"] == "*" and e["user_id"] == user["id"]
+            for e in entries
+        )
+
+    async def test_create_group_duplicate(self, client, admin_user, user):
+        headers = await _auth_headers(client)
+        await model.add_acl_entry(
+            "/groups",
+            0,
+            model.ACTION_ALLOW,
+            "create",
+            model.PRINCIPAL_SYSTEM,
+            system_principal=model.SYSTEM_AUTHENTICATED,
+        )
+        await client.post(
+            "/groups",
+            headers=headers,
+            json={"name": "dup-user-group"},
+        )
+        resp = await client.post(
+            "/groups",
+            headers=headers,
+            json={"name": "dup-user-group"},
+        )
+        assert resp.status_code == 409
+
+    async def test_update_own_group(self, client, admin_user, user):
+        headers = await _auth_headers(client)
+        await model.add_acl_entry(
+            "/groups",
+            0,
+            model.ACTION_ALLOW,
+            "create",
+            model.PRINCIPAL_SYSTEM,
+            system_principal=model.SYSTEM_AUTHENTICATED,
+        )
+        resp = await client.post(
+            "/groups",
+            headers=headers,
+            json={"name": "edit-group"},
+        )
+        group_id = resp.json()["id"]
+        resp = await client.patch(
+            f"/groups/{group_id}",
+            headers=headers,
+            json={"description": "updated"},
+        )
+        assert resp.status_code == 200
+
+    async def test_delete_own_group(self, client, admin_user, user):
+        headers = await _auth_headers(client)
+        await model.add_acl_entry(
+            "/groups",
+            0,
+            model.ACTION_ALLOW,
+            "create",
+            model.PRINCIPAL_SYSTEM,
+            system_principal=model.SYSTEM_AUTHENTICATED,
+        )
+        resp = await client.post(
+            "/groups",
+            headers=headers,
+            json={"name": "del-group"},
+        )
+        group_id = resp.json()["id"]
+        resp = await client.delete(f"/groups/{group_id}", headers=headers)
+        assert resp.status_code == 200
+        # ACEs should be cleaned up
+        entries = await model.get_acl_entries(f"/groups/{group_id}")
+        assert entries == []
+
+    async def test_manage_members_own_group(self, client, admin_user, user):
+        headers = await _auth_headers(client)
+        await model.add_acl_entry(
+            "/groups",
+            0,
+            model.ACTION_ALLOW,
+            "create",
+            model.PRINCIPAL_SYSTEM,
+            system_principal=model.SYSTEM_AUTHENTICATED,
+        )
+        resp = await client.post(
+            "/groups",
+            headers=headers,
+            json={"name": "member-group"},
+        )
+        group_id = resp.json()["id"]
+
+        # Add admin_user as member
+        resp = await client.post(
+            f"/groups/{group_id}/members",
+            headers=headers,
+            json={"user_id": admin_user["id"]},
+        )
+        assert resp.status_code == 200
+
+        # List members
+        resp = await client.get(f"/groups/{group_id}/members", headers=headers)
+        assert resp.status_code == 200
+        assert len(resp.json()) == 1
+
+        # Remove member
+        resp = await client.delete(
+            f"/groups/{group_id}/members/{admin_user['id']}",
+            headers=headers,
+        )
+        assert resp.status_code == 200
+
+    async def test_update_nonexistent_group(self, client, user):
+        headers = await _auth_headers(client)
+        # Grant * on fake group so ACL passes
+        await model.add_acl_entry(
+            "/groups/fake-id",
+            0,
+            model.ACTION_ALLOW,
+            "*",
+            model.PRINCIPAL_USER,
+            user_id=user["id"],
+        )
+        resp = await client.patch(
+            "/groups/fake-id",
+            headers=headers,
+            json={"name": "x"},
+        )
+        assert resp.status_code == 404
+
+    async def test_update_group_no_fields(self, client, admin_user, user):
+        headers = await _auth_headers(client)
+        await model.add_acl_entry(
+            "/groups",
+            0,
+            model.ACTION_ALLOW,
+            "create",
+            model.PRINCIPAL_SYSTEM,
+            system_principal=model.SYSTEM_AUTHENTICATED,
+        )
+        resp = await client.post(
+            "/groups",
+            headers=headers,
+            json={"name": "noupdate-group"},
+        )
+        group_id = resp.json()["id"]
+        resp = await client.patch(
+            f"/groups/{group_id}",
+            headers=headers,
+            json={},
+        )
+        assert resp.status_code == 400
+
+    async def test_delete_nonexistent_group(self, client, user):
+        headers = await _auth_headers(client)
+        await model.add_acl_entry(
+            "/groups/fake-del",
+            0,
+            model.ACTION_ALLOW,
+            "*",
+            model.PRINCIPAL_USER,
+            user_id=user["id"],
+        )
+        resp = await client.delete("/groups/fake-del", headers=headers)
+        assert resp.status_code == 404
+
+    async def test_list_members_nonexistent_group(self, client, user):
+        headers = await _auth_headers(client)
+        await model.add_acl_entry(
+            "/groups/fake-mem",
+            0,
+            model.ACTION_ALLOW,
+            "*",
+            model.PRINCIPAL_USER,
+            user_id=user["id"],
+        )
+        resp = await client.get("/groups/fake-mem/members", headers=headers)
+        assert resp.status_code == 404
+
+    async def test_add_member_nonexistent_group(self, client, user):
+        headers = await _auth_headers(client)
+        await model.add_acl_entry(
+            "/groups/fake-add",
+            0,
+            model.ACTION_ALLOW,
+            "*",
+            model.PRINCIPAL_USER,
+            user_id=user["id"],
+        )
+        resp = await client.post(
+            "/groups/fake-add/members",
+            headers=headers,
+            json={"user_id": user["id"]},
+        )
+        assert resp.status_code == 404
+
+    async def test_add_member_nonexistent_user(self, client, admin_user, user):
+        headers = await _auth_headers(client)
+        await model.add_acl_entry(
+            "/groups",
+            0,
+            model.ACTION_ALLOW,
+            "create",
+            model.PRINCIPAL_SYSTEM,
+            system_principal=model.SYSTEM_AUTHENTICATED,
+        )
+        resp = await client.post(
+            "/groups",
+            headers=headers,
+            json={"name": "baduser-group"},
+        )
+        group_id = resp.json()["id"]
+        resp = await client.post(
+            f"/groups/{group_id}/members",
+            headers=headers,
+            json={"user_id": "nonexistent"},
+        )
+        assert resp.status_code == 404
+
+    async def test_remove_nonmember(self, client, admin_user, user):
+        headers = await _auth_headers(client)
+        await model.add_acl_entry(
+            "/groups",
+            0,
+            model.ACTION_ALLOW,
+            "create",
+            model.PRINCIPAL_SYSTEM,
+            system_principal=model.SYSTEM_AUTHENTICATED,
+        )
+        resp = await client.post(
+            "/groups",
+            headers=headers,
+            json={"name": "noremove-group"},
+        )
+        group_id = resp.json()["id"]
+        resp = await client.delete(
+            f"/groups/{group_id}/members/nonexistent",
+            headers=headers,
+        )
+        assert resp.status_code == 404
+
+    async def test_non_owner_cannot_manage(self, client, admin_user, user):
+        """User without permission on the group gets 403."""
+        # Admin creates a group (no ACE for regular user)
+        admin_headers = {
+            "Authorization": f"Bearer {(await client.post('/auth/login', json={'email': 'testadmin@example.com', 'password': 'testpass'})).json()['access_token']}"
+        }
+        resp = await client.post(
+            "/admin/groups",
+            headers=admin_headers,
+            json={"name": "admin-only-group"},
+        )
+        group_id = resp.json()["id"]
+
+        # Regular user tries to manage members
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            f"/groups/{group_id}/members",
+            headers=headers,
+            json={"user_id": user["id"]},
+        )
+        assert resp.status_code == 403
+
+
 class TestUserSearch:
     async def test_search_users(self, client, user):
         headers = await _auth_headers(client)

--- a/src/frontend/lib/admin/admin_users_page.dart
+++ b/src/frontend/lib/admin/admin_users_page.dart
@@ -1075,10 +1075,11 @@ class _AclBrowserTabState extends State<_AclBrowserTab> {
   static const _resources = [
     ('/', 'Root', Icons.home),
     ('/workspaces', 'Workspaces', Icons.folder),
+    ('/groups', 'Groups', Icons.group),
     ('/admin', 'Admin', Icons.manage_accounts),
     ('/admin/users', 'Users', Icons.people),
     ('/admin/invitations', 'Invitations', Icons.mail_outline),
-    ('/admin/groups', 'Groups', Icons.group),
+    ('/admin/groups', 'Admin Groups', Icons.group),
   ];
 
   String _selectedResource = '/';


### PR DESCRIPTION
Closes #120

## Summary

- New `/groups` endpoints accessible to any authenticated user (ACL-gated per group)
- Group creator gets `(Allow, user:{id}, *)` on `/groups/{id}` — same pattern as workspace ownership
- Default ACE: `(Allow, Authenticated, create)` on `/groups` — any user can create groups
- Group deletion cleans up ACEs for `/groups/{id}`
- Manage members requires `manage_members` permission on the group
- Admin `/admin/groups` endpoints kept for backward compatibility
- ACL browser sidebar includes `/groups` resource
- Also includes root/admin ACL validation and sharing order swap from earlier commits

## Test plan

- [x] 1063 backend tests pass, 100% coverage
- [x] 1468 frontend lines, 100% coverage
- [x] Tests: create/update/delete groups, manage members, permission denials, edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)