### PR TITLE
nginx: fix hosted-app proxy for slashless URLs and websockets

### DIFF
--- a/scripts/nginx.sh
+++ b/scripts/nginx.sh
@@ -84,6 +84,15 @@ http {
   server {
     listen ${KLANGK_NGINX_PORT};
 
+    # A hosted URL without a trailing slash (e.g. .../9001) can't match the
+    # proxy location below. Proxying it to the app root wouldn't help either:
+    # hosted apps emit relative asset paths (./assets/...) that resolve against
+    # the browser's base URL, so without the slash every asset 404s. Redirect to
+    # the canonical trailing-slash form so the base URL is correct.
+    location ~ ^/hosted/[^/]+/\d+\$ {
+      return 308 \$uri/\$is_args\$args;
+    }
+
     # Hosted app proxy: extract port from URL and proxy directly to container
     location ~ ^/hosted/[^/]+/(\d+)/(.*)\$ {
       proxy_pass http://127.0.0.1:\$1/\$2\$is_args\$args;
@@ -92,6 +101,11 @@ http {
       proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto \$scheme;
       proxy_http_version 1.1;
+      # Hosted apps (marimo, jupyter, vite, ...) talk to their backends over
+      # websockets. Without these the WS handshake never upgrades and the app
+      # reports things like "kernel not found".
+      proxy_set_header Upgrade \$http_upgrade;
+      proxy_set_header Connection \$connection_upgrade;
     }
 ${LLM_BLOCK}
     # Browser-delegate bridge: Pi extensions delegate long-running actions


### PR DESCRIPTION
## Problem

Hosted apps reached through the `/hosted/<workspace-id>/<port>/` proxy (e.g. a marimo notebook) failed in two ways:

1. **Slashless URL → 404.** Visiting `…/hosted/<id>/9001` (no trailing slash) returned 404. The proxy `location` regex `^/hosted/[^/]+/(\d+)/(.*)$` requires a slash after the port, so the request fell through to the klangk app, which has no such route.
2. **"kernel not found" / broken app.** Even with the trailing slash, the page loaded but the app couldn't reach its backend. marimo (and jupyter, vite HMR, etc.) talk to their backend over a websocket, and the hosted proxy block set `proxy_http_version 1.1` but never forwarded the `Upgrade`/`Connection` headers, so the WS handshake never upgraded.

## Fix (`scripts/nginx.sh`)

1. **308 redirect** from the slashless form to the canonical trailing-slash form. A redirect (not just widening the regex) is required because hosted apps emit *relative* asset paths (`./assets/...`) that resolve against the browser's base URL — so the address bar must end in `/<port>/` for assets to resolve.
2. **Forward websocket headers** in the proxy block, reusing the `$connection_upgrade` map already defined for the main `location /` block.

## Verification

Confirmed live after a full `devenv processes up` restart (config regenerated from this script):

```
no trailing slash   →  308  →  Location: …/9001/
  (followed)        →  200   (marimo loads)
with trailing slash →  200
/ws?session_id=…    →  101 Switching Protocols   (kernel websocket upgrades)
```

Before the fix: slashless → 404, and the kernel websocket could not upgrade ("kernel not found").