### PR TITLE
Fix workspace import: owner ACL + keep container-home symlinks on export

### DIFF
--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -1125,14 +1125,21 @@ async def export_workspace(
                 info.size = len(meta_bytes)
                 tar.addfile(info, io.BytesIO(meta_bytes))
 
-                # Add home directory. Symlinks that resolve outside the
-                # home dir are stripped to prevent leaking host files.
-                home_resolved = home_dir.resolve()
+                # Add home directory. Symlinks whose target is an absolute path
+                # outside the workspace are stripped to avoid dangling/host
+                # references. Two kinds are kept:
+                #   - relative targets (they stay within the tree), and
+                #   - container-absolute targets under "/home/klangk" (the
+                #     bind-mount path — see container.py); these resolve once
+                #     re-mounted in a container, e.g. uv writes
+                #     ".venv/bin/python -> /home/klangk/.local/.../python".
+                # Resolving against the host home_dir (as before) wrongly
+                # stripped the latter, breaking venvs on import.
+                container_home = "/home/klangk/"
 
                 def _safe_filter(ti):
-                    if ti.issym():
-                        target = (home_dir / ti.linkname).resolve()
-                        if not target.is_relative_to(home_resolved):
+                    if ti.issym() and os.path.isabs(ti.linkname):
+                        if not ti.linkname.startswith(container_home):
                             return None
                     return ti
 
@@ -1257,6 +1264,18 @@ async def import_workspace(
                 status_code=409,
                 detail=f"A workspace named {ws_name!r} already exists",
             )
+
+        # Grant owner full access via ACL (mirrors create_workspace). Without
+        # this an imported workspace has no ACL entries, so even its owner is
+        # denied terminal/exec/files access.
+        await model.add_acl_entry(
+            f"/workspaces/{ws['id']}",
+            0,
+            ACTION_ALLOW,
+            "*",
+            PRINCIPAL_USER,
+            user_id=user["id"],
+        )
 
         # Extract home directory using tar (much faster than Python tarfile
         # for archives with many members). --strip-components=1 removes

--- a/src/backend/klangk_backend/workspaces.py
+++ b/src/backend/klangk_backend/workspaces.py
@@ -74,16 +74,33 @@ async def _find_external_symlinks(home_dir: Path) -> list[str]:
     Returns relative paths (from home_dir's parent) suitable for
     tar --exclude arguments.
     """
-    home_resolved = home_dir.resolve()
-    # find -type l prints all symlinks; we filter in the shell using
-    # realpath to check whether each target is under home_dir.
-    # This avoids a Python walk over potentially huge directory trees.
+    # find -type l prints all symlinks; we filter in the shell by inspecting
+    # each link's *raw* target. This avoids a Python walk over potentially huge
+    # directory trees, and — crucially — avoids `realpath`, which dereferences
+    # the whole chain on the host and breaks on container-absolute targets.
+    #
+    # Symlinks inside a workspace commonly target the *container* home path
+    # ("/home/klangk", the bind-mount target — see container.py), e.g. uv writes
+    # ".venv/bin/python -> /home/klangk/.local/.../python". Those are internal,
+    # but the export runs on the host where "/home/klangk" doesn't exist, so
+    # resolving them would wrongly flag them external and strip them — breaking
+    # venvs on import. Relative symlinks (".../python3 -> python") chain through
+    # those, so they hit the same problem.
+    #
+    # A symlink is "external" (and excluded) only when its target is an absolute
+    # path NOT under the container home. Relative targets stay within the tree,
+    # and "/home/klangk/..." targets resolve correctly once re-mounted in a
+    # container, so both are kept.
+    container_home = "/home/klangk"
     script = (
         f'find "{home_dir}" -type l -print0 | '
         f'while IFS= read -r -d "" link; do '
-        f'target=$(realpath "$link" 2>/dev/null || echo "///broken"); '
-        f'case "$target" in "{home_resolved}/"*) ;; *) '
-        f'echo "$link" ;; esac; done'
+        f'raw=$(readlink "$link"); '
+        f'case "$raw" in '
+        f'"{container_home}/"*) ;; '  # internal container-absolute: keep
+        f'/*) echo "$link" ;; '  # other absolute (host path): exclude
+        f"*) ;; "  # relative: stays in tree, keep
+        f"esac; done"
     )
     proc = await asyncio.create_subprocess_exec(
         "bash",


### PR DESCRIPTION
Two bugs broke the export → import round-trip when handing someone a shareable workspace (found while building a marimo "starter" workspace with a self-contained uv venv).

## Bug 1 — imported workspaces have no owner ACL

`create_workspace` grants the owner a `*` ACL entry, but `import_workspace` never did. An imported workspace had **zero** `acl_entries`, so its owner — even an admin — got `Permission denied` on terminal/exec/files (the WS handler checks `terminal` permission on `/workspaces/<id>`).

**Fix:** grant the same owner `*` entry right after the workspace row is created in `import_workspace`.

## Bug 2 — export strips container-home symlinks, breaking venvs

The export's symlink filter dropped any symlink whose target didn't resolve under the **host-side** home dir. But workspace symlinks routinely use the **container** home path (`/home/klangk`, the bind-mount target). For example, a uv-managed venv has:

```
.venv/bin/python -> /home/klangk/.local/share/uv/python/cpython-3.13-.../bin/python3.13
```

Export runs on the host, where `/home/klangk` doesn't exist, so `realpath`/`resolve()` placed those "outside" home and they were stripped — leaving the imported venv with **no interpreter**. (The relative `python3 -> python` links survived, pointing at the now-missing `python`.)

**Fix:** keep symlinks whose target is relative or under `/home/klangk`; only strip other absolute targets (e.g. `/usr/bin/...`, `/nix/...`). These resolve correctly once the home dir is re-mounted at `/home/klangk` in a container.

Fixed in **both** archive code paths:
- `api.py` `_safe_filter` — the export endpoint's Python `tarfile` filter (the one that actually runs on export)
- `workspaces.py` `_find_external_symlinks` — the GNU-tar deletion archiver

These two paths duplicating the symlink logic is exactly why the first fix attempt missed export; they should be unified (see #69).

## Verification

End to end: exported a workspace containing a self-contained uv venv (managed Python under `~/.local`), imported it into a fresh workspace, and it ran with **no manual ACL fix and no `uv sync`** — exec worked immediately and the venv interpreter was intact. marimo launched and was reachable through the hosted proxy.