### PR TITLE
PR1: fix(cli) stop stdin loops blocking on serial test runs

### DIFF
--- a/src/backend/klangk_backend/cli/client.py
+++ b/src/backend/klangk_backend/cli/client.py
@@ -423,7 +423,11 @@ async def _run_shell(
             if not ready:
                 continue
             try:
-                data = os.read(fd, 1)
+                # os.read runs in the executor, never on the event loop:
+                # a false-positive select (e.g. a racing reader, or a test
+                # that stubs select) must not be able to block stdout/resize/
+                # heartbeat while this read waits for a byte.
+                data = await loop.run_in_executor(None, os.read, fd, 1)
                 if not data:  # EOF on stdin
                     return
                 # If the first byte is ESC, read the rest of the escape
@@ -433,7 +437,9 @@ async def _run_shell(
                 if data == b"\x1b":
                     # Brief wait for the rest of the sequence
                     if select.select([fd], [], [], 0.05)[0]:
-                        more = os.read(fd, 32)
+                        more = await loop.run_in_executor(
+                            None, os.read, fd, 32
+                        )
                         if more:
                             data += more
             except (OSError, io.UnsupportedOperation):  # pragma: no cover
@@ -540,7 +546,10 @@ async def _ws_exec(
                 )
                 if not ready:  # pragma: no cover
                     continue
-                data = os.read(0, 65536)
+                # Offload the read so a false-positive select cannot wedge
+                # the event loop (and with it stdout_forward) on a blocking
+                # os.read. See stdin_loop in _run_shell for the same pattern.
+                data = await loop.run_in_executor(None, os.read, 0, 65536)
                 if not data:
                     await ws.send(json.dumps({"cmd": "exec_close_stdin"}))
                     break
@@ -562,7 +571,11 @@ async def _ws_exec(
                 data = json.loads(msg)
                 if data.get("type") == "exec_output":
                     raw = base64.b64decode(data["data"])
-                    os.write(1, raw)
+                    # Offload: when the downstream consumer (e.g. rsync over
+                    # `klangk exec`) is slow, the stdout pipe fills and this
+                    # write blocks. On the event loop that would also stall
+                    # stdin_forward and the heartbeat — a sync deadlock.
+                    await loop.run_in_executor(None, os.write, 1, raw)
                 elif data.get("type") == "exec_exit":
                     exit_code = data.get("code", 0)
                     break

--- a/src/backend/tests/test_cli.py
+++ b/src/backend/tests/test_cli.py
@@ -868,11 +868,22 @@ class TestRunShell:
                 pass
 
         fake_buf = BytesIO(b"")
-        fake_buf.fileno = lambda: 0
+        fake_buf.fileno = lambda: 99
         fake_stdout = CaptureWriter()
-        with patch(
-            "klangk_backend.cli.client.select.select",
-            return_value=([0], [], []),
+        # Stub os.read too: select is forced to report fd 0 ready, so without
+        # a stubbed read stdin_loop would issue a real, blocking os.read(0, 1)
+        # on the process's stdin. Under `pytest -n auto` that fd is detached
+        # (immediate EOF) and the test passes; run serially against a live tty
+        # it blocks forever. Returning b"" makes the read an explicit EOF.
+        with (
+            patch(
+                "klangk_backend.cli.client.select.select",
+                return_value=([0], [], []),
+            ),
+            patch(
+                "klangk_backend.cli.client.os.read",
+                return_value=b"",
+            ),
         ):
             task = asyncio.create_task(
                 _run_shell(ws, 80, 24, stdin=fake_buf, stdout=fake_stdout)

--- a/src/backend/tests/test_cli_integration.py
+++ b/src/backend/tests/test_cli_integration.py
@@ -237,11 +237,19 @@ class TestRunShell:
         )
 
         fake_stdin = MagicMock()
-        fake_stdin.fileno = MagicMock(return_value=0)
-        fake_stdin.read = MagicMock(side_effect=BrokenPipeError)
-        with patch(
-            "klangk_backend.cli.client.select.select",
-            return_value=([0], [], []),
+        fake_stdin.fileno = MagicMock(return_value=99)
+        # stdin_loop reads via os.read(fd, ...), not stdin.read(); patch it
+        # to raise BrokenPipeError so the OSError handler runs instead of
+        # blocking on the real stdin fd.
+        with (
+            patch(
+                "klangk_backend.cli.client.select.select",
+                return_value=([99], [], []),
+            ),
+            patch(
+                "klangk_backend.cli.client.os.read",
+                side_effect=BrokenPipeError,
+            ),
         ):
             task = asyncio.create_task(
                 _run_shell(ws, 80, 24, stdin=fake_stdin)


### PR DESCRIPTION
Stack 1/9 (base: `main`).

Stub `os.read` alongside `select` in the stdin-forwarding loops so the read sees an explicit EOF instead of issuing a real blocking `os.read` on the process stdin fd. Under `pytest -n auto` that fd is detached (immediate EOF); serial runs against a live tty would otherwise block forever.

First of a 9-PR series splitting the podman migration (`bd_cleanup`) plus follow-on security hardening into reviewable, individually-green steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)