### PR TITLE
PR2: feat(backend) add podman CLI wrapper

### DIFF
--- a/src/backend/klangk_backend/cli/client.py
+++ b/src/backend/klangk_backend/cli/client.py
@@ -423,7 +423,11 @@ async def _run_shell(
             if not ready:
                 continue
             try:
-                data = os.read(fd, 1)
+                # os.read runs in the executor, never on the event loop:
+                # a false-positive select (e.g. a racing reader, or a test
+                # that stubs select) must not be able to block stdout/resize/
+                # heartbeat while this read waits for a byte.
+                data = await loop.run_in_executor(None, os.read, fd, 1)
                 if not data:  # EOF on stdin
                     return
                 # If the first byte is ESC, read the rest of the escape
@@ -433,7 +437,9 @@ async def _run_shell(
                 if data == b"\x1b":
                     # Brief wait for the rest of the sequence
                     if select.select([fd], [], [], 0.05)[0]:
-                        more = os.read(fd, 32)
+                        more = await loop.run_in_executor(
+                            None, os.read, fd, 32
+                        )
                         if more:
                             data += more
             except (OSError, io.UnsupportedOperation):  # pragma: no cover
@@ -540,7 +546,10 @@ async def _ws_exec(
                 )
                 if not ready:  # pragma: no cover
                     continue
-                data = os.read(0, 65536)
+                # Offload the read so a false-positive select cannot wedge
+                # the event loop (and with it stdout_forward) on a blocking
+                # os.read. See stdin_loop in _run_shell for the same pattern.
+                data = await loop.run_in_executor(None, os.read, 0, 65536)
                 if not data:
                     await ws.send(json.dumps({"cmd": "exec_close_stdin"}))
                     break
@@ -562,7 +571,11 @@ async def _ws_exec(
                 data = json.loads(msg)
                 if data.get("type") == "exec_output":
                     raw = base64.b64decode(data["data"])
-                    os.write(1, raw)
+                    # Offload: when the downstream consumer (e.g. rsync over
+                    # `klangk exec`) is slow, the stdout pipe fills and this
+                    # write blocks. On the event loop that would also stall
+                    # stdin_forward and the heartbeat — a sync deadlock.
+                    await loop.run_in_executor(None, os.write, 1, raw)
                 elif data.get("type") == "exec_exit":
                     exit_code = data.get("code", 0)
                     break

--- a/src/backend/klangk_backend/podman.py
+++ b/src/backend/klangk_backend/podman.py
@@ -1,0 +1,247 @@
+"""Thin async wrapper around the ``podman`` CLI.
+
+Replaces the previous ``aiodocker`` (Docker REST API) dependency so the
+backend can drive a *rootless, daemonless* Podman engine with no socket and
+no ``podman system service``. Every call shells out via
+``asyncio.create_subprocess_exec`` and parses ``--format json``.
+
+Non-zero exits raise :class:`PodmanError` whose ``status`` mimics the
+``aiodocker.exceptions.DockerError.status`` codes (404 not-found, 409
+conflict/in-use) that the HTTP layer relies on for control flow; anything
+else maps to 500.
+
+The binary is configurable via ``KLANGK_PODMAN_BIN`` (defaults to
+``podman``) so dev environments can point at ``docker`` instead.
+"""
+
+import asyncio
+import json
+import logging
+import tempfile
+
+from . import util
+
+logger = logging.getLogger(__name__)
+
+PODMAN_BIN = util.resolve_env_secret("KLANGK_PODMAN_BIN", "podman")
+
+
+class PodmanError(Exception):
+    """A podman CLI invocation failed.
+
+    ``status`` is an HTTP-like code (404, 409, 500) derived from stderr so
+    callers can branch the same way they did on
+    ``aiodocker.exceptions.DockerError.status``.
+    """
+
+    def __init__(self, status: int, message: str):
+        self.status = status
+        self.message = message
+        super().__init__(f"[{status}] {message}")
+
+
+def _classify(stderr: str) -> int:
+    """Map podman stderr text to an HTTP-like status code."""
+    low = stderr.lower()
+    if "no such" in low or "not found" in low or "no container" in low:
+        return 404
+    if "in use" in low or "being used" in low or "already in use" in low:
+        return 409
+    return 500
+
+
+async def _run(
+    args: list[str],
+    *,
+    check: bool = True,
+    stdin_data: bytes | None = None,
+) -> tuple[int, str, str]:
+    """Run ``podman <args>`` and return ``(returncode, stdout, stderr)``.
+
+    When ``check`` is true a non-zero exit raises :class:`PodmanError`.
+
+    Output is captured to temp files rather than ``stdout=PIPE`` +
+    ``communicate()``. Lifecycle commands such as ``podman start --publish``
+    spawn a long-lived rootless network helper (``pasta``) that inherits the
+    child's stdout/stderr. Under uvloop (which uvicorn selects) that helper
+    keeps the inherited *pipe* write-end open for the container's lifetime,
+    so ``communicate()`` blocks forever waiting for an EOF that never comes.
+    A regular file has no such EOF dependency: the helper harmlessly inherits
+    a file fd and we read the output after the process exits.
+    """
+    with (
+        tempfile.TemporaryFile() as out_f,
+        tempfile.TemporaryFile() as err_f,
+    ):
+        proc = await asyncio.create_subprocess_exec(
+            PODMAN_BIN,
+            *args,
+            stdin=(asyncio.subprocess.PIPE if stdin_data is not None else None),
+            stdout=out_f,
+            stderr=err_f,
+        )
+        if stdin_data is not None:
+            proc.stdin.write(stdin_data)
+            await proc.stdin.drain()
+            proc.stdin.close()
+        await proc.wait()
+        out_f.seek(0)
+        err_f.seek(0)
+        out = out_f.read().decode("utf-8", errors="replace")
+        err = err_f.read().decode("utf-8", errors="replace")
+    rc = proc.returncode or 0
+    if check and rc != 0:
+        raise PodmanError(_classify(err), err.strip() or f"podman {args[0]}")
+    return rc, out, err
+
+
+# --- Containers ---
+
+
+async def inspect_container(container_id: str) -> dict | None:
+    """Return the inspect dict for a container, or None if it is gone.
+
+    Mirrors ``containers.get(id)`` + ``.show()``: the result carries
+    ``["State"]["Running"]`` and ``["Config"]["Labels"]``.
+    """
+    rc, out, _err = await _run(
+        ["container", "inspect", container_id], check=False
+    )
+    if rc != 0:
+        return None
+    data = json.loads(out)
+    return data[0] if data else None
+
+
+async def create_container(
+    name: str,
+    image: str,
+    *,
+    labels: dict[str, str] | None = None,
+    binds: list[str] | None = None,
+    tmpfs: dict[str, str] | None = None,
+    publish: list[tuple[int, int]] | None = None,
+    add_hosts: list[str] | None = None,
+    dns: list[str] | None = None,
+    env: list[str] | None = None,
+    init: bool = False,
+    interactive: bool = False,
+    pull: str = "never",
+    replace: bool = True,
+) -> str:
+    """Create a container (``podman create``) and return its id.
+
+    ``publish`` is a list of ``(host_port, container_port)`` pairs.
+    ``replace=True`` uses ``--replace`` so an existing container with the
+    same name is removed first (the ``create_or_replace`` equivalent).
+
+    ``pull`` maps to podman's ``--pull`` policy (default ``never``). With
+    ``never`` the image must already be in the local store (or a configured
+    additional image store) — the airgapped default, which fails fast instead
+    of attempting a registry pull. Set it to ``missing`` to pull from a
+    registry when the image isn't present locally.
+    """
+    args = ["create", f"--pull={pull}", "--name", name]
+    if replace:
+        args.append("--replace")
+    if init:
+        args.append("--init")
+    if interactive:
+        args.append("-i")
+    for key, value in (labels or {}).items():
+        args += ["--label", f"{key}={value}"]
+    for bind in binds or []:
+        args += ["-v", bind]
+    for path, opts in (tmpfs or {}).items():
+        args += ["--tmpfs", f"{path}:{opts}"]
+    for host_port, container_port in publish or []:
+        args += ["-p", f"{host_port}:{container_port}"]
+    for host in add_hosts or []:
+        args += ["--add-host", host]
+    for server in dns or []:
+        args += ["--dns", server]
+    for entry in env or []:
+        args += ["-e", entry]
+    args.append(image)
+    _rc, out, _err = await _run(args)
+    return out.strip()
+
+
+async def start_container(container_id: str) -> None:
+    """Start a created container (``podman start``)."""
+    await _run(["start", container_id])
+
+
+async def remove_container(container_id: str, *, force: bool = True) -> None:
+    """Remove a container (``podman rm [-f]``); never raises on 404.
+
+    Matches the previous ``delete(force=True)`` callers, which treated a
+    missing container as already-removed.
+    """
+    args = ["rm"]
+    if force:
+        args.append("-f")
+    args.append(container_id)
+    rc, _out, err = await _run(args, check=False)
+    if rc != 0 and _classify(err) != 404:
+        raise PodmanError(_classify(err), err.strip() or "podman rm")
+
+
+async def list_containers(label: str) -> list[dict]:
+    """List containers matching ``label`` (``key=value``).
+
+    Each entry carries ``Id`` and ``Labels`` (podman includes labels in the
+    ``ps`` JSON, so no extra inspect is needed for adoption).
+    """
+    _rc, out, _err = await _run(
+        ["ps", "-a", "--filter", f"label={label}", "--format", "json"]
+    )
+    out = out.strip()
+    return json.loads(out) if out else []
+
+
+# --- Volumes ---
+
+
+async def inspect_volume(name: str) -> dict | None:
+    """Return a volume's inspect dict, or None if it does not exist."""
+    rc, out, _err = await _run(["volume", "inspect", name], check=False)
+    if rc != 0:
+        return None
+    data = json.loads(out)
+    return data[0] if data else None
+
+
+async def create_volume(
+    name: str, labels: dict[str, str] | None = None
+) -> dict:
+    """Create a labelled volume and return its inspect dict."""
+    args = ["volume", "create"]
+    for key, value in (labels or {}).items():
+        args += ["--label", f"{key}={value}"]
+    args.append(name)
+    await _run(args)
+    info = await inspect_volume(name)
+    if info is None:  # pragma: no cover - created then vanished
+        raise PodmanError(500, f"volume {name!r} vanished after create")
+    return info
+
+
+async def list_volumes(label: str) -> list[dict]:
+    """List volumes matching ``label`` (``key=value``)."""
+    _rc, out, _err = await _run(
+        ["volume", "ls", "--filter", f"label={label}", "--format", "json"]
+    )
+    out = out.strip()
+    return json.loads(out) if out else []
+
+
+async def remove_volume(name: str) -> None:
+    """Remove a volume (``podman volume rm``).
+
+    Raises :class:`PodmanError` with status 404 (no such volume) or 409
+    (in use) so the HTTP layer can map them to responses.
+    """
+    rc, _out, err = await _run(["volume", "rm", name], check=False)
+    if rc != 0:
+        raise PodmanError(_classify(err), err.strip() or "podman volume rm")

--- a/src/backend/tests/test_cli.py
+++ b/src/backend/tests/test_cli.py
@@ -868,11 +868,22 @@ class TestRunShell:
                 pass
 
         fake_buf = BytesIO(b"")
-        fake_buf.fileno = lambda: 0
+        fake_buf.fileno = lambda: 99
         fake_stdout = CaptureWriter()
-        with patch(
-            "klangk_backend.cli.client.select.select",
-            return_value=([0], [], []),
+        # Stub os.read too: select is forced to report fd 0 ready, so without
+        # a stubbed read stdin_loop would issue a real, blocking os.read(0, 1)
+        # on the process's stdin. Under `pytest -n auto` that fd is detached
+        # (immediate EOF) and the test passes; run serially against a live tty
+        # it blocks forever. Returning b"" makes the read an explicit EOF.
+        with (
+            patch(
+                "klangk_backend.cli.client.select.select",
+                return_value=([0], [], []),
+            ),
+            patch(
+                "klangk_backend.cli.client.os.read",
+                return_value=b"",
+            ),
         ):
             task = asyncio.create_task(
                 _run_shell(ws, 80, 24, stdin=fake_buf, stdout=fake_stdout)

--- a/src/backend/tests/test_cli_integration.py
+++ b/src/backend/tests/test_cli_integration.py
@@ -237,11 +237,19 @@ class TestRunShell:
         )
 
         fake_stdin = MagicMock()
-        fake_stdin.fileno = MagicMock(return_value=0)
-        fake_stdin.read = MagicMock(side_effect=BrokenPipeError)
-        with patch(
-            "klangk_backend.cli.client.select.select",
-            return_value=([0], [], []),
+        fake_stdin.fileno = MagicMock(return_value=99)
+        # stdin_loop reads via os.read(fd, ...), not stdin.read(); patch it
+        # to raise BrokenPipeError so the OSError handler runs instead of
+        # blocking on the real stdin fd.
+        with (
+            patch(
+                "klangk_backend.cli.client.select.select",
+                return_value=([99], [], []),
+            ),
+            patch(
+                "klangk_backend.cli.client.os.read",
+                side_effect=BrokenPipeError,
+            ),
         ):
             task = asyncio.create_task(
                 _run_shell(ws, 80, 24, stdin=fake_stdin)

--- a/src/backend/tests/test_podman.py
+++ b/src/backend/tests/test_podman.py
@@ -1,0 +1,325 @@
+"""Tests for the podman CLI wrapper."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from klangk_backend import podman
+
+EXEC = "klangk_backend.podman.asyncio.create_subprocess_exec"
+
+
+def _procs(*results):
+    """Build fake subprocess objects, one per (stdout, stderr, rc).
+
+    ``_run`` reads output from the temp files it passes as stdout/stderr and
+    awaits ``proc.wait()`` (not ``communicate()``), so each fake carries its
+    canned bytes for ``_exec`` to write into those files.
+    """
+    out = []
+    for stdout, stderr, rc in results:
+        p = MagicMock()
+        p.returncode = rc
+        p._canned = (stdout.encode(), stderr.encode())
+        p.wait = AsyncMock(return_value=rc)
+        p.stdin = MagicMock()
+        p.stdin.drain = AsyncMock()
+        out.append(p)
+    return out
+
+
+def _exec(*results):
+    """An AsyncMock standing in for create_subprocess_exec.
+
+    Writes each fake's canned output into the temp files ``_run`` passes as
+    ``stdout``/``stderr`` so the wrapper reads them back as real output.
+    """
+    procs = iter(_procs(*results))
+
+    def side_effect(*args, **kwargs):
+        p = next(procs)
+        out_b, err_b = p._canned
+        stdout_f, stderr_f = kwargs.get("stdout"), kwargs.get("stderr")
+        if hasattr(stdout_f, "write"):
+            stdout_f.write(out_b)
+        if hasattr(stderr_f, "write"):
+            stderr_f.write(err_b)
+        return p
+
+    return AsyncMock(side_effect=side_effect)
+
+
+def _args(mock_exec, call_index=0):
+    """The podman args (sans binary) from the Nth create_subprocess_exec."""
+    return list(mock_exec.call_args_list[call_index].args[1:])
+
+
+# --- _classify ---
+
+
+class TestClassify:
+    @pytest.mark.parametrize(
+        "stderr,expected",
+        [
+            ("Error: no such container foo", 404),
+            ("layer not found", 404),
+            ("no container with name", 404),
+            ("volume is being used by a container", 409),
+            ("volume already in use", 409),
+            ("Error: name is in use", 409),
+            ("something else broke", 500),
+        ],
+    )
+    def test_classify(self, stderr, expected):
+        assert podman._classify(stderr) == expected
+
+
+# --- _run ---
+
+
+class TestRun:
+    async def test_success(self):
+        with patch(EXEC, _exec(("hello\n", "", 0))) as m:
+            rc, out, err = await podman._run(["version"])
+        assert (rc, out, err) == (0, "hello\n", "")
+        assert m.call_args.args[0] == podman.PODMAN_BIN
+        assert m.call_args.kwargs["stdin"] is None
+
+    async def test_check_raises_with_classified_status(self):
+        with patch(EXEC, _exec(("", "no such container x", 1))):
+            with pytest.raises(podman.PodmanError) as exc:
+                await podman._run(["start", "x"])
+        assert exc.value.status == 404
+        assert "no such container" in exc.value.message
+
+    async def test_check_raises_empty_stderr_fallback(self):
+        with patch(EXEC, _exec(("", "", 5))):
+            with pytest.raises(podman.PodmanError) as exc:
+                await podman._run(["boom"])
+        assert exc.value.status == 500
+        assert exc.value.message == "podman boom"
+
+    async def test_no_check_returns_nonzero(self):
+        with patch(EXEC, _exec(("", "bad", 2))):
+            rc, out, err = await podman._run(["x"], check=False)
+        assert rc == 2
+
+    async def test_stdin_data_uses_pipe(self):
+        proc = _procs(("", "", 0))[0]
+        with patch(EXEC, AsyncMock(return_value=proc)) as m:
+            await podman._run(["x"], stdin_data=b"payload")
+        assert m.call_args.kwargs["stdin"] is not None
+        proc.stdin.write.assert_called_once_with(b"payload")
+        proc.stdin.close.assert_called_once()
+
+    async def test_returncode_none_treated_as_zero(self):
+        with patch(EXEC, _exec(("ok", "", None))):
+            rc, _out, _err = await podman._run(["x"], check=False)
+        assert rc == 0
+
+
+# --- containers ---
+
+
+class TestInspectContainer:
+    async def test_missing_returns_none(self):
+        with patch(EXEC, _exec(("", "no such container", 1))):
+            assert await podman.inspect_container("c") is None
+
+    async def test_found_returns_first(self):
+        payload = json.dumps([{"State": {"Running": True}}])
+        with patch(EXEC, _exec((payload, "", 0))):
+            info = await podman.inspect_container("c")
+        assert info["State"]["Running"] is True
+
+    async def test_empty_list_returns_none(self):
+        with patch(EXEC, _exec(("[]", "", 0))):
+            assert await podman.inspect_container("c") is None
+
+
+class TestCreateContainer:
+    async def test_minimal(self):
+        with patch(EXEC, _exec(("abc123\n", "", 0))) as m:
+            cid = await podman.create_container("n", "img", replace=False)
+        assert cid == "abc123"
+        assert _args(m) == [
+            "create",
+            "--pull=never",
+            "--name",
+            "n",
+            "img",
+        ]
+
+    async def test_all_flags(self):
+        with patch(EXEC, _exec(("id\n", "", 0))) as m:
+            await podman.create_container(
+                "n",
+                "img",
+                labels={"a": "1"},
+                binds=["/h:/c"],
+                tmpfs={"/tmp": "rw,size=2g"},
+                publish=[(9000, 8000)],
+                add_hosts=["host.docker.internal:host-gateway"],
+                dns=["8.8.8.8"],
+                env=["K=V"],
+                init=True,
+                interactive=True,
+                replace=True,
+            )
+        args = _args(m)
+        assert "--replace" in args
+        assert "--init" in args
+        assert "-i" in args
+        assert ["--label", "a=1"] == args[
+            args.index("--label") : args.index("--label") + 2
+        ]
+        assert ["-v", "/h:/c"] == args[args.index("-v") : args.index("-v") + 2]
+        assert ["--tmpfs", "/tmp:rw,size=2g"] == args[
+            args.index("--tmpfs") : args.index("--tmpfs") + 2
+        ]
+        assert ["-p", "9000:8000"] == args[
+            args.index("-p") : args.index("-p") + 2
+        ]
+        assert ["--add-host", "host.docker.internal:host-gateway"] == args[
+            args.index("--add-host") : args.index("--add-host") + 2
+        ]
+        assert ["--dns", "8.8.8.8"] == args[
+            args.index("--dns") : args.index("--dns") + 2
+        ]
+        assert ["-e", "K=V"] == args[args.index("-e") : args.index("-e") + 2]
+        assert args[-1] == "img"
+
+    async def test_pull_policy_override(self):
+        with patch(EXEC, _exec(("id\n", "", 0))) as m:
+            await podman.create_container(
+                "n", "img", pull="missing", replace=False
+            )
+        args = _args(m)
+        assert "--pull=missing" in args
+        assert "--pull=never" not in args
+
+
+class TestStartContainer:
+    async def test_start(self):
+        with patch(EXEC, _exec(("", "", 0))) as m:
+            await podman.start_container("cid")
+        assert _args(m) == ["start", "cid"]
+
+
+class TestRemoveContainer:
+    async def test_force_default(self):
+        with patch(EXEC, _exec(("", "", 0))) as m:
+            await podman.remove_container("cid")
+        assert _args(m) == ["rm", "-f", "cid"]
+
+    async def test_no_force(self):
+        with patch(EXEC, _exec(("", "", 0))) as m:
+            await podman.remove_container("cid", force=False)
+        assert _args(m) == ["rm", "cid"]
+
+    async def test_missing_is_ignored(self):
+        with patch(EXEC, _exec(("", "no such container", 1))):
+            await podman.remove_container("cid")  # no raise
+
+    async def test_other_error_raises(self):
+        with patch(EXEC, _exec(("", "in use", 1))):
+            with pytest.raises(podman.PodmanError) as exc:
+                await podman.remove_container("cid")
+        assert exc.value.status == 409
+
+    async def test_other_error_empty_stderr_fallback(self):
+        with patch(EXEC, _exec(("", "", 1))):
+            with pytest.raises(podman.PodmanError) as exc:
+                await podman.remove_container("cid")
+        assert exc.value.message == "podman rm"
+
+
+class TestListContainers:
+    async def test_parses_json(self):
+        payload = json.dumps([{"Id": "a", "Labels": {"k": "v"}}])
+        with patch(EXEC, _exec((payload, "", 0))) as m:
+            result = await podman.list_containers("k=v")
+        assert result[0]["Id"] == "a"
+        assert _args(m) == [
+            "ps",
+            "-a",
+            "--filter",
+            "label=k=v",
+            "--format",
+            "json",
+        ]
+
+    async def test_empty_output(self):
+        with patch(EXEC, _exec(("  \n", "", 0))):
+            assert await podman.list_containers("k=v") == []
+
+
+# --- volumes ---
+
+
+class TestInspectVolume:
+    async def test_missing(self):
+        with patch(EXEC, _exec(("", "no such volume", 1))):
+            assert await podman.inspect_volume("v") is None
+
+    async def test_found(self):
+        payload = json.dumps([{"Name": "v", "CreatedAt": "now"}])
+        with patch(EXEC, _exec((payload, "", 0))):
+            info = await podman.inspect_volume("v")
+        assert info["Name"] == "v"
+
+    async def test_empty_list(self):
+        with patch(EXEC, _exec(("[]", "", 0))):
+            assert await podman.inspect_volume("v") is None
+
+
+class TestCreateVolume:
+    async def test_with_labels(self):
+        info = json.dumps([{"Name": "v", "CreatedAt": "t"}])
+        with patch(EXEC, _exec(("v\n", "", 0), (info, "", 0))) as m:
+            result = await podman.create_volume("v", {"a": "1"})
+        assert result["Name"] == "v"
+        assert ["--label", "a=1"] == _args(m, 0)[2:4]
+
+    async def test_without_labels(self):
+        info = json.dumps([{"Name": "v", "CreatedAt": "t"}])
+        with patch(EXEC, _exec(("v\n", "", 0), (info, "", 0))) as m:
+            await podman.create_volume("v")
+        assert _args(m, 0) == ["volume", "create", "v"]
+
+
+class TestListVolumes:
+    async def test_parses(self):
+        payload = json.dumps([{"Name": "v"}])
+        with patch(EXEC, _exec((payload, "", 0))):
+            assert (await podman.list_volumes("k=v"))[0]["Name"] == "v"
+
+    async def test_empty(self):
+        with patch(EXEC, _exec(("", "", 0))):
+            assert await podman.list_volumes("k=v") == []
+
+
+class TestRemoveVolume:
+    async def test_success(self):
+        with patch(EXEC, _exec(("", "", 0))) as m:
+            await podman.remove_volume("v")
+        assert _args(m) == ["volume", "rm", "v"]
+
+    async def test_not_found(self):
+        with patch(EXEC, _exec(("", "no such volume", 1))):
+            with pytest.raises(podman.PodmanError) as exc:
+                await podman.remove_volume("v")
+        assert exc.value.status == 404
+
+    async def test_in_use(self):
+        with patch(EXEC, _exec(("", "volume is being used", 1))):
+            with pytest.raises(podman.PodmanError) as exc:
+                await podman.remove_volume("v")
+        assert exc.value.status == 409
+
+    async def test_empty_stderr_fallback(self):
+        with patch(EXEC, _exec(("", "", 1))):
+            with pytest.raises(podman.PodmanError) as exc:
+                await podman.remove_volume("v")
+        assert exc.value.message == "podman volume rm"


### PR DESCRIPTION
Stack 2/9 (base: `cli-stdin-blocking-read`).

Thin async wrapper over the `podman` CLI (binary via `KLANGK_PODMAN_BIN`). `PodmanError.status` reproduces aiodocker's 404/409 semantics for the HTTP layer. Pure addition — no call sites yet, aiodocker still present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)