### PR TITLE
PR3: refactor(backend) migrate container engine aiodocker→podman

### DIFF
--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -28,6 +28,7 @@ from . import (
     emailsvc,
     files,
     oidc,
+    podman,
     wshandler,
     model,
     workspaces,
@@ -803,16 +804,15 @@ async def list_images(_user: dict = Depends(auth.get_current_user)):
 
 @router.get("/volumes")
 async def list_volumes(_user: dict = Depends(auth.get_current_user)):
-    docker = await container.registry.get_docker()
-    volumes = await docker.volumes.list(
-        filters={"label": [f"klangk.instance={container.INSTANCE_ID}"]}
+    volumes = await podman.list_volumes(
+        f"klangk.instance={container.INSTANCE_ID}"
     )
     return [
         {
             "name": v["Name"],
             "created": v.get("CreatedAt", ""),
         }
-        for v in volumes.get("Volumes") or []
+        for v in volumes
     ]
 
 
@@ -825,26 +825,17 @@ async def create_volume(
     body: CreateVolumeRequest,
     _user: dict = Depends(auth.get_current_user),
 ):
-    docker = await container.registry.get_docker()
-    try:
-        existing = await docker.volumes.get(body.name)
-        await existing.show()  # raises 404 if not found
+    if await podman.inspect_volume(body.name) is not None:
         raise HTTPException(
             status_code=409, detail=f"Volume {body.name!r} already exists"
         )
-    except container.aiodocker.exceptions.DockerError as e:
-        if e.status != 404:
-            raise
-    vol = await docker.volumes.create(
+    info = await podman.create_volume(
+        body.name,
         {
-            "Name": body.name,
-            "Labels": {
-                "klangk.managed": "true",
-                "klangk.instance": container.INSTANCE_ID,
-            },
-        }
+            "klangk.managed": "true",
+            "klangk.instance": container.INSTANCE_ID,
+        },
     )
-    info = await vol.show()
     return {"name": info["Name"], "created": info.get("CreatedAt", "")}
 
 
@@ -852,18 +843,18 @@ async def create_volume(
 async def delete_volume(
     name: str, _user: dict = Depends(auth.get_current_user)
 ):
-    docker = await container.registry.get_docker()
+    info = await podman.inspect_volume(name)
+    if info is None:
+        raise HTTPException(status_code=404, detail="Volume not found")
+    labels = info.get("Labels") or {}
+    if labels.get("klangk.instance") != container.INSTANCE_ID:
+        raise HTTPException(
+            status_code=404,
+            detail="Volume not managed by this Klangk instance",
+        )
     try:
-        vol = await docker.volumes.get(name)
-        info = await vol.show()
-        labels = info.get("Labels") or {}
-        if labels.get("klangk.instance") != container.INSTANCE_ID:
-            raise HTTPException(
-                status_code=404,
-                detail="Volume not managed by this Klangk instance",
-            )
-        await vol.delete()
-    except container.aiodocker.exceptions.DockerError as e:
+        await podman.remove_volume(name)
+    except podman.PodmanError as e:
         if e.status == 404:
             raise HTTPException(
                 status_code=404, detail="Volume not found"

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -3,12 +3,11 @@
 import asyncio
 import logging
 import os
+import socket
 import time
 import uuid
 
-import aiodocker
-
-from . import util, model
+from . import model, podman, util
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +26,21 @@ def _container_dns_config() -> dict:
     return {}
 
 
+def _resolve_add_host_target(hostname: str) -> str:
+    """Return an IP for --add-host, or the 'host-gateway' special token.
+
+    When hostname resolves (e.g. a Docker service name like 'nginx' visible
+    via the embedded DNS 127.0.0.11), returns the IP so workspace containers
+    can route to it via slirp4netns through the backend's network stack.
+    Falls back to the podman/docker 'host-gateway' token for names that don't
+    resolve locally (e.g. 'host.docker.internal' outside Docker).
+    """
+    try:
+        return socket.gethostbyname(hostname)
+    except socket.gaierror:
+        return "host-gateway"
+
+
 IMAGE_NAME = util.resolve_env_secret("KLANGK_IMAGE_NAME", "klangk")
 INSTANCE_ID = util.resolve_env_secret("KLANGK_INSTANCE_ID", "default")
 
@@ -35,6 +49,29 @@ ALLOWED_IMAGES: set[str] = {
     img.strip() for img in _allowed_images_env.split(",") if img.strip()
 }
 ALLOWED_IMAGES.add(IMAGE_NAME)  # default image is always allowed
+
+# podman --pull policies; controls where workspace images come from.
+_VALID_PULL_POLICIES = {"never", "missing", "always", "newer"}
+
+
+def image_pull_policy() -> str:
+    """Resolve the workspace-image pull policy from the environment.
+
+    Default ``never`` keeps the airgapped behavior (use only the local +
+    additional image stores). Set ``KLANGK_IMAGE_PULL_POLICY=missing`` to pull
+    from a registry when the image isn't present locally; ``always``/``newer``
+    are also accepted. An unrecognized value falls back to ``never``.
+    """
+    policy = util.resolve_env_secret("KLANGK_IMAGE_PULL_POLICY", "never")
+    if policy not in _VALID_PULL_POLICIES:
+        logger.warning(
+            "Invalid KLANGK_IMAGE_PULL_POLICY=%r (valid: %s); using 'never'.",
+            policy,
+            ", ".join(sorted(_VALID_PULL_POLICIES)),
+        )
+        return "never"
+    return policy
+
 
 _VALID_MOUNT_OPTIONS = {
     "ro",
@@ -139,7 +176,6 @@ class ContainerRegistry:
         # sock is None for workspace-level fallback tokens, or a specific
         # SafeWebSocket for per-connection tokens.
         self._bridge_tokens: dict[str, tuple[str, object | None]] = {}
-        self.docker: aiodocker.Docker | None = None
         self.cleanup_task: asyncio.Task | None = None
         self.port_lock: asyncio.Lock = asyncio.Lock()
         self.on_workspace_killed = None
@@ -149,11 +185,6 @@ class ContainerRegistry:
         if self._cleanup_wake is None:
             self._cleanup_wake = asyncio.Event()
         return self._cleanup_wake
-
-    async def get_docker(self) -> aiodocker.Docker:  # pragma: no cover
-        if self.docker is None:
-            self.docker = aiodocker.Docker()
-        return self.docker
 
     # --- State tracking ---
 
@@ -290,27 +321,51 @@ class ContainerRegistry:
                 f"{sorted(ALLOWED_IMAGES)}"
             )
 
-        docker = await self.get_docker()
-
         if existing_container_id:
-            try:
-                container = await docker.containers.get(existing_container_id)
-                info = await container.show()
-                if info["State"]["Running"]:
-                    self.track_activity(existing_container_id, workspace_id)
-                    return existing_container_id, "connected"
-                await container.delete(force=True)
+            info = await podman.inspect_container(existing_container_id)
+            if info is None:
+                logger.info(
+                    "Could not find container %s, creating new one",
+                    existing_container_id,
+                )
+            elif info["State"]["Running"]:
+                self.track_activity(existing_container_id, workspace_id)
+                return existing_container_id, "connected"
+            else:
+                await podman.remove_container(existing_container_id)
                 logger.info(
                     "Removed stopped container %s for workspace %s, "
                     "will recreate",
                     existing_container_id,
                     workspace_id,
                 )
-            except aiodocker.exceptions.DockerError:
-                logger.info(
-                    "Could not find container %s, creating new one",
-                    existing_container_id,
-                )
+        else:
+            # DB has no container_id (e.g. after a backend restart that lost
+            # in-memory state).  Scan by label so we can adopt a running
+            # container rather than blindly --replace it (which hangs trying
+            # to stop it).
+            containers = await podman.list_containers(
+                f"klangk.workspace-id={workspace_id}"
+            )
+            if containers:
+                found_id = containers[0].get("Id") or containers[0].get("ID", "")
+                info = await podman.inspect_container(found_id)
+                if info and info["State"]["Running"]:
+                    logger.info(
+                        "Adopted running container %s for workspace %s",
+                        found_id,
+                        workspace_id,
+                    )
+                    await model.update_workspace_container(workspace_id, found_id)
+                    self.track_activity(found_id, workspace_id)
+                    return found_id, "connected"
+                elif info:
+                    await podman.remove_container(found_id)
+                    logger.info(
+                        "Removed stopped orphan container %s for workspace %s",
+                        found_id,
+                        workspace_id,
+                    )
 
         # Lock the entire read+allocate sequence to prevent
         # concurrent start_container calls from double-allocating.
@@ -330,7 +385,17 @@ class ContainerRegistry:
 
         env_vars = []
         nginx_port = util.resolve_env_secret("KLANGK_NGINX_PORT", "8995")
-        proxy_url = f"http://host.docker.internal:{nginx_port}/llm-proxy"
+        # Hostname a workspace container uses to reach the nginx front
+        # (LLM-proxy + bridge).  Default `host.docker.internal` preserves
+        # the host-process / devenv behavior; under the Podman-in-Docker
+        # stack with isolated networks this is set to podman's native
+        # `host.containers.internal` (or another alias resolvable to the
+        # host gateway).  The same name is registered via `--add-host
+        # <gateway>:host-gateway` below so it resolves inside the container.
+        host_gateway = util.resolve_env_secret(
+            "KLANGK_HOST_GATEWAY", "host.docker.internal"
+        )
+        proxy_url = f"http://{host_gateway}:{nginx_port}/llm-proxy"
         llm_model = util.resolve_env_secret("KLANGK_LLM_MODEL", "")
         env_vars.append(f"KLANGK_LLM_PROXY_URL={proxy_url}")
         if llm_model:
@@ -354,7 +419,7 @@ class ContainerRegistry:
         # know the backend URL.  KLANGK_BRIDGE_TOKEN is set per-exec
         # session (in terminal.py) so each connection has its own token.
         env_vars.append(
-            f"KLANGK_BRIDGE_URL=http://host.docker.internal:{nginx_port}"
+            f"KLANGK_BRIDGE_URL=http://{host_gateway}:{nginx_port}"
         )
         env_vars.append(f"KLANGK_HOSTING_HOSTNAME={hosting_hostname}")
         env_vars.append(f"KLANGK_HOSTING_PROTO={hosting_proto}")
@@ -377,132 +442,75 @@ class ContainerRegistry:
                 source = mount_spec.split(":")[0]
                 if "/" not in source and not source.startswith("."):
                     # Named volume — ensure it exists with klangk labels
-                    try:
-                        vol = await docker.volumes.get(source)
-                        await vol.show()
-                    except aiodocker.exceptions.DockerError as e:
-                        if e.status == 404:
-                            await docker.volumes.create(
-                                {
-                                    "Name": source,
-                                    "Labels": {
-                                        "klangk.managed": "true",
-                                        "klangk.instance": INSTANCE_ID,
-                                    },
-                                }
-                            )
-                        else:
-                            raise
+                    if await podman.inspect_volume(source) is None:
+                        await podman.create_volume(
+                            source,
+                            {
+                                "klangk.managed": "true",
+                                "klangk.instance": INSTANCE_ID,
+                            },
+                        )
 
-        port_bindings = {}
-        exposed_ports = {}
-        for i, host_port in enumerate(host_ports):
-            container_port = CONTAINER_PORT_START + i
-            port_key = f"{container_port}/tcp"
-            exposed_ports[port_key] = {}
-            port_bindings[port_key] = [{"HostPort": str(host_port)}]
+        binds = [
+            f"{home_path}:/home/klangk",
+        ]
+        if ssh_auth_sock and os.path.exists(ssh_auth_sock):
+            binds.append(f"{ssh_auth_sock}:/run/ssh-agent.sock:ro")
+        if config_path:
+            binds.append(f"{config_path}:/opt/klangk/config:ro")
+        binds += extra_mounts or []
 
-        config = {
-            "Image": resolved_image,
-            "Labels": {
-                "klangk.managed": "true",
-                "klangk.instance": INSTANCE_ID,
-                "klangk.workspace-id": workspace_id,
-            },
-            "HostConfig": {
-                "Init": True,
-                "ReadonlyRootfs": False,
-                "Binds": [
-                    f"{home_path}:/home/klangk",
-                    "/var/run/docker.sock:/var/run/docker.sock",
-                ]
-                + (
-                    [f"{ssh_auth_sock}:/run/ssh-agent.sock:ro"]
-                    if ssh_auth_sock and os.path.exists(ssh_auth_sock)
-                    else []
-                )
-                + (
-                    [f"{config_path}:/opt/klangk/config:ro"]
-                    if config_path
-                    else []
-                )
-                + (extra_mounts or []),
-                "Tmpfs": {
+        publish = [
+            (host_port, CONTAINER_PORT_START + i)
+            for i, host_port in enumerate(host_ports)
+        ]
+
+        # Create, persist, and start as one cancellation-shielded unit.
+        # The connecting client's websocket can drop mid-startup (idle
+        # ping-timeout, navigation), which cancels this coroutine. Without
+        # the shield, a cancel landing between `create`/`start` and the DB
+        # write orphans a running container with no `container_id` on record
+        # — the workspace then appears "stuck" until the adopt-by-label path
+        # recovers it on a later connect. Persisting the id immediately after
+        # create (before start) also means the container is never lost even
+        # if start raises: the next connect inspects it via existing_id and
+        # recreates if needed.
+        async def _create_and_start() -> str:
+            cid = await podman.create_container(
+                f"klangk-{INSTANCE_ID}-{workspace_id[:12]}",
+                resolved_image,
+                labels={
+                    "klangk.managed": "true",
+                    "klangk.instance": INSTANCE_ID,
+                    "klangk.workspace-id": workspace_id,
+                },
+                binds=binds,
+                tmpfs={
                     "/tmp": "rw,exec,nosuid,size=2g",
                     "/run": "rw,noexec,nosuid,size=256m",
                     "/var/log": "rw,noexec,nosuid,size=256m",
                 },
-                "PortBindings": port_bindings,
-                "ExtraHosts": ["host.docker.internal:host-gateway"],
-                **_container_dns_config(),
-            },
-            "ExposedPorts": exposed_ports,
-            "Env": env_vars,
-            "OpenStdin": True,
-            "AttachStdin": True,
-            "AttachStdout": True,
-            "AttachStderr": True,
-            "Tty": False,
-        }
-
-        container_name = f"klangk-{INSTANCE_ID}-{workspace_id[:12]}"
-        created = await docker.containers.create_or_replace(
-            name=container_name,
-            config=config,
-        )
-        try:
-            await created.start()
-        except aiodocker.exceptions.DockerError as exc:
-            if "port is already allocated" not in str(exc):
-                raise
-            # A stale container is holding one of our ports.
-            # Find which managed containers bind the conflicting ports
-            # and remove only those, not all containers.
-            logger.warning(
-                "Port conflict starting %s, cleaning stale containers",
-                container_name,
+                publish=publish,
+                add_hosts=[
+                    f"{host_gateway}:{_resolve_add_host_target(host_gateway)}"
+                ],
+                dns=_container_dns_config().get("Dns"),
+                env=env_vars,
+                init=True,
+                interactive=True,
+                pull=image_pull_policy(),
             )
-            wanted_ports = set(host_ports)
-            stale = await docker.containers.list(
-                all=True,
-                filters={
-                    "label": [
-                        "klangk.managed=true",
-                        f"klangk.instance={INSTANCE_ID}",
-                    ],
-                },
-            )
-            for c in stale:
-                if c.id == created.id:
-                    continue
-                info = await c.show()
-                bindings = info.get("HostConfig", {}).get("PortBindings") or {}
-                bound_ports = set()
-                for ports_list in bindings.values():
-                    for entry in ports_list or []:
-                        try:
-                            bound_ports.add(int(entry["HostPort"]))
-                        except (KeyError, ValueError, TypeError):
-                            pass
-                if bound_ports & wanted_ports:
-                    try:
-                        await c.delete(force=True)
-                        logger.info(
-                            "Removed stale container %s (ports %s)",
-                            c.id,
-                            bound_ports & wanted_ports,
-                        )
-                    except aiodocker.exceptions.DockerError as del_exc:
-                        logger.info(
-                            "Could not remove stale container %s: %s",
-                            c.id,
-                            del_exc,
-                        )
-            await created.start()
-        container_id = created.id
+            await model.update_workspace_container(workspace_id, cid)
+            self.track_activity(cid, workspace_id)
+            await podman.start_container(cid)
+            return cid
 
-        await model.update_workspace_container(workspace_id, container_id)
-        self.track_activity(container_id, workspace_id)
+        # NOTE: main added an aiodocker-based port-conflict retry here that
+        # cleaned up stale containers holding our ports. That enhancement was
+        # dropped in this merge because it was written against aiodocker, which
+        # the podman migration removed. Re-port to podman if the conflict
+        # recovery is needed.
+        container_id = await asyncio.shield(_create_and_start())
 
         logger.info(
             "Started container %s for workspace %s (ports %s)",
@@ -514,12 +522,10 @@ class ContainerRegistry:
 
     async def stop_and_remove_container(self, container_id: str) -> None:
         """Stop and remove a container."""
-        docker = await self.get_docker()
         try:
-            container = await docker.containers.get(container_id)
-            await container.delete(force=True)
+            await podman.remove_container(container_id)
             logger.info("Stopped container %s", container_id)
-        except aiodocker.exceptions.DockerError as e:
+        except podman.PodmanError as e:
             logger.warning(
                 "Failed to stop container %s: %s",
                 container_id,
@@ -615,22 +621,22 @@ class ContainerRegistry:
 
     async def adopt_orphaned_containers(self) -> None:
         try:
-            docker = await self.get_docker()
-            containers = await docker.containers.list(
-                filters={"label": [f"klangk.instance={INSTANCE_ID}"]},
+            containers = await podman.list_containers(
+                f"klangk.instance={INSTANCE_ID}"
             )
             for c in containers:
-                if c.id not in self._cid_to_wsid:
-                    labels = (await c.show())["Config"]["Labels"]
+                cid = c["Id"]
+                if cid not in self._cid_to_wsid:
+                    labels = c.get("Labels") or {}
                     workspace_id = labels.get("klangk.workspace-id", "unknown")
-                    self.track_activity(c.id, workspace_id)
+                    self.track_activity(cid, workspace_id)
                     logger.info(
                         "Adopted orphaned container %s (workspace %s)",
-                        c.id[:12],
+                        cid[:12],
                         workspace_id,
                     )
         except (
-            aiodocker.exceptions.DockerError,
+            podman.PodmanError,
             OSError,
         ) as e:
             logger.warning("Error scanning for orphaned containers: %s", e)
@@ -653,27 +659,24 @@ class ContainerRegistry:
         tracked_ids = set(self._cid_to_wsid.keys())
         tasks = [self.stop_and_remove_container(cid) for cid in tracked_ids]
         try:
-            docker = await self.get_docker()
-            containers = await docker.containers.list(
-                filters={"label": [f"klangk.instance={INSTANCE_ID}"]},
+            containers = await podman.list_containers(
+                f"klangk.instance={INSTANCE_ID}"
             )
             for c in containers:
-                if c.id not in tracked_ids:
+                cid = c["Id"]
+                if cid not in tracked_ids:
                     logger.info(
                         "Removing orphaned klangk container %s",
-                        c.id,
+                        cid,
                     )
-                    tasks.append(c.delete(force=True))
+                    tasks.append(self.stop_and_remove_container(cid))
         except (
-            aiodocker.exceptions.DockerError,
+            podman.PodmanError,
             OSError,
         ) as e:
             logger.warning("Error listing orphaned containers: %s", e)
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
-        if self.docker:
-            await self.docker.close()
-            self.docker = None
 
 
 # Module-level singleton

--- a/src/backend/klangk_backend/dockerexec.py
+++ b/src/backend/klangk_backend/dockerexec.py
@@ -1,9 +1,10 @@
-"""Raw exec session: docker exec subprocess without PTY for piped commands."""
+"""Raw exec session: podman exec subprocess without PTY for piped commands."""
 
 import asyncio
 import logging
 from collections.abc import AsyncGenerator
 
+from . import podman
 from .util import BoundedOutputQueue
 
 logger = logging.getLogger(__name__)
@@ -25,7 +26,7 @@ class ExecSession:
     async def start(self, command: list[str]) -> None:
         """Start a command via docker exec with piped stdin/stdout."""
         exec_cmd = [
-            "docker",
+            podman.PODMAN_BIN,
             "exec",
             "-i",
             "-u",

--- a/src/backend/klangk_backend/wshandler.py
+++ b/src/backend/klangk_backend/wshandler.py
@@ -949,18 +949,19 @@ class Connection:
 
 async def handle_websocket(websocket: WebSocket) -> None:
     """Main WebSocket handler."""
-    # Authenticate via query param
+    # Authenticate via query param — accept before close (WebSocket protocol
+    # requires a completed handshake before a close frame can be sent).
     token = websocket.query_params.get("token")
+    user = await auth.get_user_from_token(token) if token else None
+
+    await websocket.accept()
+
     if not token:
         await websocket.close(code=4001, reason="Missing token")
         return
-
-    user = await auth.get_user_from_token(token)
     if user is None:
         await websocket.close(code=4001, reason="Invalid token")
         return
-
-    await websocket.accept()
     safe_ws = SafeWebSocket(websocket)
     safe_ws.start_sender()
     conn = Connection(safe_ws, user)

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -18,6 +18,7 @@ from klangk_backend import (
     auth,
     container,
     model,
+    podman,
     workspaces as ws_mod,
     wshandler,
 )
@@ -1714,28 +1715,30 @@ class TestBrowserBridge:
 # --- Volume routes ---
 
 
+def _managed_volume():
+    """An inspect_volume result owned by this klangk instance."""
+    return {
+        "Labels": {
+            "klangk.managed": "true",
+            "klangk.instance": container.INSTANCE_ID,
+        }
+    }
+
+
 class TestVolumeRoutes:
     async def test_list_volumes(self, client, user):
         headers = await _auth_headers(client)
         with patch.object(
-            container.registry,
-            "get_docker",
-            return_value=MagicMock(
-                volumes=MagicMock(
-                    list=AsyncMock(
-                        return_value={
-                            "Volumes": [
-                                {
-                                    "Name": "test-vol",
-                                    "CreatedAt": "2026-01-01T00:00:00Z",
-                                    "Labels": {
-                                        "klangk.instance": container.INSTANCE_ID
-                                    },
-                                }
-                            ]
-                        }
-                    )
-                )
+            podman,
+            "list_volumes",
+            AsyncMock(
+                return_value=[
+                    {
+                        "Name": "test-vol",
+                        "CreatedAt": "2026-01-01T00:00:00Z",
+                        "Labels": {"klangk.instance": container.INSTANCE_ID},
+                    }
+                ]
             ),
         ):
             resp = await client.get("/volumes", headers=headers)
@@ -1746,20 +1749,20 @@ class TestVolumeRoutes:
 
     async def test_create_volume(self, client, user):
         headers = await _auth_headers(client)
-        mock_vol = MagicMock()
-        mock_vol.show = AsyncMock(
-            return_value={"Name": "new-vol", "CreatedAt": "2026-01-01"}
-        )
-        mock_docker = MagicMock()
-        mock_docker.volumes = MagicMock()
-        mock_docker.volumes.get = AsyncMock(
-            side_effect=container.aiodocker.exceptions.DockerError(
-                404, {"message": "not found"}
-            )
-        )
-        mock_docker.volumes.create = AsyncMock(return_value=mock_vol)
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
+        with (
+            patch.object(
+                podman, "inspect_volume", AsyncMock(return_value=None)
+            ),
+            patch.object(
+                podman,
+                "create_volume",
+                AsyncMock(
+                    return_value={
+                        "Name": "new-vol",
+                        "CreatedAt": "2026-01-01",
+                    }
+                ),
+            ),
         ):
             resp = await client.post(
                 "/volumes",
@@ -1771,13 +1774,10 @@ class TestVolumeRoutes:
 
     async def test_create_duplicate_volume(self, client, user):
         headers = await _auth_headers(client)
-        mock_vol = MagicMock()
-        mock_vol.show = AsyncMock(return_value={"Name": "dup-vol"})
-        mock_docker = MagicMock()
-        mock_docker.volumes = MagicMock()
-        mock_docker.volumes.get = AsyncMock(return_value=mock_vol)
         with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
+            podman,
+            "inspect_volume",
+            AsyncMock(return_value={"Name": "dup-vol"}),
         ):
             resp = await client.post(
                 "/volumes",
@@ -1786,71 +1786,18 @@ class TestVolumeRoutes:
             )
         assert resp.status_code == 409
 
-    async def test_delete_volume(self, client, user):
+    async def test_create_volume_error_propagates(self, client, user):
         headers = await _auth_headers(client)
-        mock_vol = MagicMock()
-        mock_vol.show = AsyncMock(
-            return_value={
-                "Labels": {
-                    "klangk.managed": "true",
-                    "klangk.instance": container.INSTANCE_ID,
-                }
-            }
-        )
-        mock_vol.delete = AsyncMock()
-        mock_docker = MagicMock()
-        mock_docker.volumes = MagicMock()
-        mock_docker.volumes.get = AsyncMock(return_value=mock_vol)
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
-            resp = await client.delete("/volumes/test-vol", headers=headers)
-        assert resp.status_code == 200
-
-    async def test_delete_volume_not_found(self, client, user):
-        headers = await _auth_headers(client)
-        mock_docker = MagicMock()
-        mock_docker.volumes = MagicMock()
-        mock_docker.volumes.get = AsyncMock(
-            side_effect=container.aiodocker.exceptions.DockerError(
-                404, {"message": "not found"}
-            )
-        )
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
-            resp = await client.delete("/volumes/nope", headers=headers)
-        assert resp.status_code == 404
-
-    async def test_delete_volume_wrong_instance(self, client, user):
-        headers = await _auth_headers(client)
-        mock_vol = MagicMock()
-        mock_vol.show = AsyncMock(
-            return_value={"Labels": {"klangk.instance": "other-instance"}}
-        )
-        mock_docker = MagicMock()
-        mock_docker.volumes = MagicMock()
-        mock_docker.volumes.get = AsyncMock(return_value=mock_vol)
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
-            resp = await client.delete("/volumes/foreign", headers=headers)
-        assert resp.status_code == 404
-
-    async def test_create_volume_docker_error(self, client, user):
-        headers = await _auth_headers(client)
-        mock_docker = MagicMock()
-        mock_docker.volumes = MagicMock()
-        mock_docker.volumes.get = AsyncMock(
-            side_effect=container.aiodocker.exceptions.DockerError(
-                500, {"message": "internal error"}
-            )
-        )
         with (
             patch.object(
-                container.registry, "get_docker", return_value=mock_docker
+                podman, "inspect_volume", AsyncMock(return_value=None)
             ),
-            pytest.raises(container.aiodocker.exceptions.DockerError),
+            patch.object(
+                podman,
+                "create_volume",
+                AsyncMock(side_effect=podman.PodmanError(500, "boom")),
+            ),
+            pytest.raises(podman.PodmanError),
         ):
             await client.post(
                 "/volumes",
@@ -1858,54 +1805,85 @@ class TestVolumeRoutes:
                 headers=headers,
             )
 
-    async def test_delete_volume_docker_error(self, client, user):
+    async def test_delete_volume(self, client, user):
         headers = await _auth_headers(client)
-        mock_vol = MagicMock()
-        mock_vol.show = AsyncMock(
-            return_value={
-                "Labels": {
-                    "klangk.managed": "true",
-                    "klangk.instance": container.INSTANCE_ID,
-                }
-            }
-        )
-        mock_vol.delete = AsyncMock(
-            side_effect=container.aiodocker.exceptions.DockerError(
-                500, {"message": "internal error"}
-            )
-        )
-        mock_docker = MagicMock()
-        mock_docker.volumes = MagicMock()
-        mock_docker.volumes.get = AsyncMock(return_value=mock_vol)
         with (
             patch.object(
-                container.registry, "get_docker", return_value=mock_docker
+                podman,
+                "inspect_volume",
+                AsyncMock(return_value=_managed_volume()),
             ),
-            pytest.raises(container.aiodocker.exceptions.DockerError),
+            patch.object(podman, "remove_volume", AsyncMock()),
+        ):
+            resp = await client.delete("/volumes/test-vol", headers=headers)
+        assert resp.status_code == 200
+
+    async def test_delete_volume_not_found(self, client, user):
+        headers = await _auth_headers(client)
+        with patch.object(
+            podman, "inspect_volume", AsyncMock(return_value=None)
+        ):
+            resp = await client.delete("/volumes/nope", headers=headers)
+        assert resp.status_code == 404
+
+    async def test_delete_volume_wrong_instance(self, client, user):
+        headers = await _auth_headers(client)
+        with patch.object(
+            podman,
+            "inspect_volume",
+            AsyncMock(return_value={"Labels": {"klangk.instance": "other"}}),
+        ):
+            resp = await client.delete("/volumes/foreign", headers=headers)
+        assert resp.status_code == 404
+
+    async def test_delete_volume_remove_not_found(self, client, user):
+        """Volume vanishes between inspect and remove → 404."""
+        headers = await _auth_headers(client)
+        with (
+            patch.object(
+                podman,
+                "inspect_volume",
+                AsyncMock(return_value=_managed_volume()),
+            ),
+            patch.object(
+                podman,
+                "remove_volume",
+                AsyncMock(side_effect=podman.PodmanError(404, "gone")),
+            ),
+        ):
+            resp = await client.delete("/volumes/gone", headers=headers)
+        assert resp.status_code == 404
+
+    async def test_delete_volume_other_error(self, client, user):
+        headers = await _auth_headers(client)
+        with (
+            patch.object(
+                podman,
+                "inspect_volume",
+                AsyncMock(return_value=_managed_volume()),
+            ),
+            patch.object(
+                podman,
+                "remove_volume",
+                AsyncMock(side_effect=podman.PodmanError(500, "internal")),
+            ),
+            pytest.raises(podman.PodmanError),
         ):
             await client.delete("/volumes/err-vol", headers=headers)
 
     async def test_delete_volume_in_use(self, client, user):
         headers = await _auth_headers(client)
-        mock_vol = MagicMock()
-        mock_vol.show = AsyncMock(
-            return_value={
-                "Labels": {
-                    "klangk.managed": "true",
-                    "klangk.instance": container.INSTANCE_ID,
-                }
-            }
-        )
-        mock_vol.delete = AsyncMock(
-            side_effect=container.aiodocker.exceptions.DockerError(
-                409, {"message": "in use"}
-            )
-        )
-        mock_docker = MagicMock()
-        mock_docker.volumes = MagicMock()
-        mock_docker.volumes.get = AsyncMock(return_value=mock_vol)
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
+        with (
+            patch.object(
+                podman,
+                "inspect_volume",
+                AsyncMock(return_value=_managed_volume()),
+            ),
+            patch.object(
+                podman,
+                "remove_volume",
+                AsyncMock(side_effect=podman.PodmanError(409, "in use")),
+            ),
         ):
             resp = await client.delete("/volumes/busy", headers=headers)
         assert resp.status_code == 409

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -2,12 +2,13 @@
 
 import asyncio
 import time
-from unittest.mock import AsyncMock, MagicMock, patch
+from contextlib import ExitStack, contextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
 
-import aiodocker.exceptions
 import pytest
 
-from klangk_backend import container, model
+from klangk_backend import container, model, podman
 
 
 class TestParseIdleTimeout:
@@ -39,6 +40,22 @@ class TestParseIdleTimeout:
         timeout, interval = container.parse_idle_timeout()
         assert timeout == 3600
         assert interval == 60  # clamped to max 60
+
+
+class TestImagePullPolicy:
+    def test_default_is_never(self, monkeypatch):
+        monkeypatch.delenv("KLANGK_IMAGE_PULL_POLICY", raising=False)
+        assert container.image_pull_policy() == "never"
+
+    def test_valid_override(self, monkeypatch):
+        monkeypatch.setenv("KLANGK_IMAGE_PULL_POLICY", "missing")
+        assert container.image_pull_policy() == "missing"
+
+    def test_invalid_falls_back_to_never(self, monkeypatch, caplog):
+        monkeypatch.setenv("KLANGK_IMAGE_PULL_POLICY", "sometimes")
+        with caplog.at_level("WARNING"):
+            assert container.image_pull_policy() == "never"
+        assert "Invalid KLANGK_IMAGE_PULL_POLICY" in caplog.text
 
 
 class TestActivityTracking:
@@ -232,24 +249,34 @@ class TestConstants:
 # --- Docker-dependent tests (mocked) ---
 
 
-def _mock_docker():
-    """Create a mock Docker client with containers namespace."""
-    docker = AsyncMock()
-    docker.containers = AsyncMock()
-    docker.close = AsyncMock()
-    return docker
+@contextmanager
+def patch_podman(**overrides):
+    """Patch the podman.* calls container.py makes.
+
+    Yields a namespace of the AsyncMocks so tests can assert on them.
+    Override any default by passing ``name=AsyncMock(...)``.
+    """
+    defaults = {
+        "inspect_container": AsyncMock(return_value=None),
+        "create_container": AsyncMock(return_value="new-cid"),
+        "start_container": AsyncMock(),
+        "remove_container": AsyncMock(),
+        "list_containers": AsyncMock(return_value=[]),
+        "inspect_volume": AsyncMock(return_value=None),
+        "create_volume": AsyncMock(
+            return_value={"Name": "v", "CreatedAt": ""}
+        ),
+    }
+    mocks = {**defaults, **overrides}
+    with ExitStack() as stack:
+        for name, mock in mocks.items():
+            stack.enter_context(patch.object(podman, name, mock))
+        yield SimpleNamespace(**mocks)
 
 
-def _mock_container(container_id="fake-cid", running=True):
-    """Create a mock container object."""
-    c = AsyncMock()
-    c.id = container_id
-    c.show = AsyncMock(return_value={"State": {"Running": running}})
-    c.start = AsyncMock()
-    c.stop = AsyncMock()
-    c.delete = AsyncMock()
-    c.attach = MagicMock(return_value=AsyncMock())
-    return c
+def _running(value=True):
+    """An inspect_container mock returning a container in the given state."""
+    return AsyncMock(return_value={"State": {"Running": value}})
 
 
 class TestStartContainer:
@@ -260,15 +287,7 @@ class TestStartContainer:
         container.registry.states.clear()
 
     async def test_create_new_container(self, workspace):
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("new-cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=mock_c
-        )
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             cid, status = await container.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -276,8 +295,101 @@ class TestStartContainer:
             )
         assert cid == "new-cid"
         assert status == "created"
-        mock_c.start.assert_awaited_once()
+        p.start_container.assert_awaited_once_with("new-cid")
         assert workspace["id"] in container.registry.states
+
+    async def test_container_id_persisted_before_start(self, workspace, user):
+        # If `start` fails, the id created just before it must already be on
+        # record so the next connect can inspect/recreate it rather than
+        # orphaning a created-but-unrecorded container.
+        with patch_podman(
+            start_container=AsyncMock(side_effect=RuntimeError("boom"))
+        ):
+            with pytest.raises(RuntimeError, match="boom"):
+                await container.registry.start_container(
+                    workspace["id"], "/tmp/ws", "/tmp/home"
+                )
+        ws = await model.get_workspace(workspace["id"], user["id"])
+        assert ws["container_id"] == "new-cid"
+        assert workspace["id"] in container.registry.states
+
+    async def test_cancel_during_start_still_persists(self, workspace, user):
+        # The connecting client can disconnect mid-startup, cancelling this
+        # coroutine. The shield must let create+persist+start finish so a
+        # running container is never orphaned with a NULL container_id.
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def slow_start(_cid):
+            started.set()
+            await release.wait()
+
+        with patch_podman(
+            start_container=AsyncMock(side_effect=slow_start)
+        ) as p:
+            task = asyncio.create_task(
+                container.registry.start_container(
+                    workspace["id"], "/tmp/ws", "/tmp/home"
+                )
+            )
+            await started.wait()
+            task.cancel()  # client disconnects mid-startup
+            release.set()  # let the shielded inner run to completion
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        # Despite the cancel, the container was started and recorded.
+        ws = await model.get_workspace(workspace["id"], user["id"])
+        assert ws["container_id"] == "new-cid"
+        p.start_container.assert_awaited_once_with("new-cid")
+        assert workspace["id"] in container.registry.states
+
+    async def test_adopts_running_orphan_when_db_has_no_id(
+        self, workspace, user
+    ):
+        # No container_id on record but a running container exists for the
+        # workspace (e.g. a prior connect cancelled before persisting). Adopt
+        # it instead of `--replace`-ing a running container, which hangs.
+        with patch_podman(
+            list_containers=AsyncMock(return_value=[{"Id": "orphan-cid"}]),
+            inspect_container=_running(True),
+        ) as p:
+            cid, status = await container.registry.start_container(
+                workspace["id"], "/tmp/ws", "/tmp/home"
+            )
+        assert cid == "orphan-cid"
+        assert status == "connected"
+        p.create_container.assert_not_awaited()
+        ws = await model.get_workspace(workspace["id"], user["id"])
+        assert ws["container_id"] == "orphan-cid"
+        assert workspace["id"] in container.registry.states
+
+    async def test_removes_stopped_orphan_when_db_has_no_id(self, workspace):
+        # A stopped orphan can't be adopted — remove it and create fresh.
+        with patch_podman(
+            list_containers=AsyncMock(return_value=[{"Id": "orphan-cid"}]),
+            inspect_container=_running(False),
+        ) as p:
+            cid, status = await container.registry.start_container(
+                workspace["id"], "/tmp/ws", "/tmp/home"
+            )
+        assert cid == "new-cid"
+        assert status == "created"
+        p.remove_container.assert_awaited_once_with("orphan-cid")
+        p.create_container.assert_awaited_once()
+
+    async def test_orphan_vanished_between_list_and_inspect(self, workspace):
+        # Listed orphan is gone by the time we inspect it → create fresh.
+        with patch_podman(
+            list_containers=AsyncMock(return_value=[{"Id": "orphan-cid"}]),
+            inspect_container=AsyncMock(return_value=None),
+        ) as p:
+            cid, status = await container.registry.start_container(
+                workspace["id"], "/tmp/ws", "/tmp/home"
+            )
+        assert cid == "new-cid"
+        assert status == "created"
+        p.remove_container.assert_not_awaited()
 
     async def test_ssh_agent_forwarded_when_socket_exists(
         self, workspace, monkeypatch, tmp_path
@@ -285,54 +397,30 @@ class TestStartContainer:
         sock = tmp_path / "agent.sock"
         sock.touch()
         monkeypatch.setenv("SSH_AUTH_SOCK", str(sock))
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("new-cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=mock_c
-        )
 
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             await container.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
-        call_kwargs = mock_docker.containers.create_or_replace.call_args
-        env_list = call_kwargs[1]["config"]["Env"]
-        binds = call_kwargs[1]["config"]["HostConfig"]["Binds"]
-        assert "SSH_AUTH_SOCK=/run/ssh-agent.sock" in env_list
-        assert f"{sock}:/run/ssh-agent.sock:ro" in binds
+        kwargs = p.create_container.call_args.kwargs
+        assert "SSH_AUTH_SOCK=/run/ssh-agent.sock" in kwargs["env"]
+        assert f"{sock}:/run/ssh-agent.sock:ro" in kwargs["binds"]
 
     async def test_ssh_agent_not_forwarded_when_unset(
         self, workspace, monkeypatch
     ):
         monkeypatch.delenv("SSH_AUTH_SOCK", raising=False)
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("new-cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=mock_c
-        )
 
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             await container.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
-        call_kwargs = mock_docker.containers.create_or_replace.call_args
-        env_list = call_kwargs[1]["config"]["Env"]
-        binds = call_kwargs[1]["config"]["HostConfig"]["Binds"]
-        assert "SSH_AUTH_SOCK=/run/ssh-agent.sock" not in env_list
-        assert not any("ssh-agent" in b for b in binds)
+        kwargs = p.create_container.call_args.kwargs
+        assert "SSH_AUTH_SOCK=/run/ssh-agent.sock" not in kwargs["env"]
+        assert not any("ssh-agent" in b for b in kwargs["binds"])
 
     async def test_reuse_running_container(self, workspace):
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("existing-cid", running=True)
-        mock_docker.containers.get = AsyncMock(return_value=mock_c)
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman(inspect_container=_running(True)) as p:
             cid, status = await container.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -341,20 +429,11 @@ class TestStartContainer:
             )
         assert cid == "existing-cid"
         assert status == "connected"
-        mock_c.start.assert_not_awaited()
+        p.start_container.assert_not_awaited()
+        p.create_container.assert_not_awaited()
 
     async def test_recreate_stopped_container(self, workspace):
-        mock_docker = _mock_docker()
-        stopped_c = _mock_container("old-cid", running=False)
-        mock_docker.containers.get = AsyncMock(return_value=stopped_c)
-        new_c = _mock_container("new-cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=new_c
-        )
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman(inspect_container=_running(False)) as p:
             cid, status = await container.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -363,21 +442,11 @@ class TestStartContainer:
             )
         assert cid == "new-cid"
         assert status == "created"
-        stopped_c.delete.assert_awaited_once_with(force=True)
+        p.remove_container.assert_awaited_once_with("old-cid")
 
     async def test_missing_container_creates_new(self, workspace):
-        mock_docker = _mock_docker()
-        mock_docker.containers.get = AsyncMock(
-            side_effect=aiodocker.exceptions.DockerError(404, "not found")
-        )
-        new_c = _mock_container("new-cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=new_c
-        )
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        # inspect_container returns None (default) → treated as gone.
+        with patch_podman() as p:
             cid, status = await container.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -386,6 +455,7 @@ class TestStartContainer:
             )
         assert cid == "new-cid"
         assert status == "created"
+        p.remove_container.assert_not_awaited()
 
     async def test_disallowed_image_raises(self, workspace):
         with pytest.raises(ValueError, match="not in the allowed list"):
@@ -397,85 +467,90 @@ class TestStartContainer:
         """Container gets proxy URL, not real API keys."""
         monkeypatch.setenv("KLANGK_LLM_MODEL", "gemma4:31b")
         monkeypatch.setenv("KLANGK_NGINX_PORT", "8995")
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=mock_c
-        )
 
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             await container.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
             )
-        call_kwargs = mock_docker.containers.create_or_replace.call_args
-        env = call_kwargs[1]["config"]["Env"]
+        kwargs = p.create_container.call_args.kwargs
+        env = kwargs["env"]
         env_dict = dict(e.split("=", 1) for e in env)
         assert env_dict["KLANGK_LLM_PROXY_URL"] == (
             "http://host.docker.internal:8995/llm-proxy"
         )
         assert env_dict["KLANGK_LLM_MODEL"] == "gemma4:31b"
+        assert (
+            env_dict["KLANGK_BRIDGE_URL"] == "http://host.docker.internal:8995"
+        )
         # API keys should NOT be in the container env
         assert not any(e.startswith("KLANGK_LLM_API_KEY=") for e in env)
         assert not any(e.startswith("ANTHROPIC_API_KEY=") for e in env)
         # host.docker.internal must be resolvable
-        host_config = call_kwargs[1]["config"]["HostConfig"]
-        assert "host.docker.internal:host-gateway" in host_config["ExtraHosts"]
+        assert "host.docker.internal:host-gateway" in kwargs["add_hosts"]
+
+    async def test_host_gateway_override(self, workspace, monkeypatch):
+        """KLANGK_HOST_GATEWAY reparents the proxy/bridge URLs + add-host."""
+        monkeypatch.setenv("KLANGK_NGINX_PORT", "8995")
+        monkeypatch.setenv("KLANGK_HOST_GATEWAY", "host.containers.internal")
+
+        with patch_podman() as p:
+            await container.registry.start_container(
+                workspace["id"],
+                "/tmp/ws",
+                "/tmp/home",
+            )
+        kwargs = p.create_container.call_args.kwargs
+        env_dict = dict(e.split("=", 1) for e in kwargs["env"])
+        assert env_dict["KLANGK_LLM_PROXY_URL"] == (
+            "http://host.containers.internal:8995/llm-proxy"
+        )
+        assert env_dict["KLANGK_BRIDGE_URL"] == (
+            "http://host.containers.internal:8995"
+        )
+        assert "host.containers.internal:host-gateway" in kwargs["add_hosts"]
+
+    async def test_pull_policy_default_never(self, workspace):
+        with patch_podman() as p:
+            await container.registry.start_container(
+                workspace["id"], "/tmp/ws", "/tmp/home"
+            )
+        assert p.create_container.call_args.kwargs["pull"] == "never"
+
+    async def test_pull_policy_from_env(self, workspace, monkeypatch):
+        monkeypatch.setenv("KLANGK_IMAGE_PULL_POLICY", "missing")
+        with patch_podman() as p:
+            await container.registry.start_container(
+                workspace["id"], "/tmp/ws", "/tmp/home"
+            )
+        assert p.create_container.call_args.kwargs["pull"] == "missing"
 
     async def test_config_mount_added(self, workspace):
         """Container gets read-only config mount when config_path is set."""
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=mock_c
-        )
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             await container.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
                 config_path="/tmp/config",
             )
-        call_kwargs = mock_docker.containers.create_or_replace.call_args
-        binds = call_kwargs[1]["config"]["HostConfig"]["Binds"]
+        binds = p.create_container.call_args.kwargs["binds"]
         assert "/tmp/config:/opt/klangk/config:ro" in binds
 
     async def test_no_config_mount_without_config_path(self, workspace):
         """Container has no config mount when config_path is not set."""
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=mock_c
-        )
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             await container.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
             )
-        call_kwargs = mock_docker.containers.create_or_replace.call_args
-        binds = call_kwargs[1]["config"]["HostConfig"]["Binds"]
+        binds = p.create_container.call_args.kwargs["binds"]
         assert not any("config" in b for b in binds)
 
     async def test_hosting_env_vars(self, workspace):
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=mock_c
-        )
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             await container.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -484,22 +559,13 @@ class TestStartContainer:
                 hosting_proto="https",
                 hosting_base_path="/klangk",
             )
-        call_kwargs = mock_docker.containers.create_or_replace.call_args
-        env = call_kwargs[1]["config"]["Env"]
+        env = p.create_container.call_args.kwargs["env"]
         assert "KLANGK_HOSTING_HOSTNAME=example.com" in env
         assert "KLANGK_HOSTING_PROTO=https" in env
         assert "KLANGK_HOSTING_BASE_PATH=/klangk" in env
 
     async def test_port_allocation_on_create(self, workspace):
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=mock_c
-        )
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman():
             await container.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -515,15 +581,7 @@ class TestStartContainer:
         await model.find_and_allocate_ports(
             workspace["id"], 5, container.PORT_RANGE_START
         )
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=mock_c
-        )
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman():
             await container.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -534,47 +592,28 @@ class TestStartContainer:
         assert len(ports) == 2
 
     async def test_container_config_structure(self, workspace):
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=mock_c
-        )
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             await container.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
             )
-        call_kwargs = mock_docker.containers.create_or_replace.call_args
-        config = call_kwargs[1]["config"]
-        assert config["Image"] == container.IMAGE_NAME
-        assert config["Labels"]["klangk.managed"] == "true"
-        assert config["Labels"]["klangk.workspace-id"] == workspace["id"]
-        assert config["HostConfig"]["ReadonlyRootfs"] is False
-        assert config["HostConfig"]["Init"] is True
-        assert config["OpenStdin"] is True
+        args, kwargs = p.create_container.call_args
+        assert args[1] == container.IMAGE_NAME
+        assert kwargs["labels"]["klangk.managed"] == "true"
+        assert kwargs["labels"]["klangk.workspace-id"] == workspace["id"]
+        assert kwargs["init"] is True
+        assert kwargs["interactive"] is True
 
     async def test_create_container_with_extra_env(self, workspace):
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("new-cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=mock_c
-        )
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             await container.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
                 extra_env={"KLANGK_SKILLS": "stats,rdkit", "FOO": "bar"},
             )
-        call_kwargs = mock_docker.containers.create_or_replace.call_args
-        env_list = call_kwargs[1]["config"]["Env"]
+        env_list = p.create_container.call_args.kwargs["env"]
         env_dict = dict(e.split("=", 1) for e in env_list)
         assert env_dict["KLANGK_SKILLS"] == "stats,rdkit"
         assert env_dict["FOO"] == "bar"
@@ -846,166 +885,87 @@ class TestValidateMountSpec:
 class TestExtraMountsVolumeCreation:
     async def test_auto_creates_named_volume(self, workspace):
         """Named volumes (no leading /) are auto-created with klangk labels."""
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=mock_c
-        )
-        mock_vol = MagicMock()
-        mock_vol.show = AsyncMock(return_value={"Name": "nix-store"})
-        mock_docker.volumes.get = AsyncMock(
-            side_effect=container.aiodocker.exceptions.DockerError(
-                404, {"message": "not found"}
-            )
-        )
-        mock_docker.volumes.create = AsyncMock(return_value=mock_vol)
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        # inspect_volume returns None (default) → volume is created.
+        with patch_podman() as p:
             await container.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
                 extra_mounts=["nix-store:/nix"],
             )
-        mock_docker.volumes.create.assert_awaited_once()
-        create_args = mock_docker.volumes.create.call_args[0][0]
-        assert create_args["Name"] == "nix-store"
-        assert create_args["Labels"]["klangk.managed"] == "true"
-        assert (
-            create_args["Labels"]["klangk.instance"] == container.INSTANCE_ID
-        )
+        p.create_volume.assert_awaited_once()
+        name, labels = p.create_volume.call_args.args
+        assert name == "nix-store"
+        assert labels["klangk.managed"] == "true"
+        assert labels["klangk.instance"] == container.INSTANCE_ID
 
     async def test_existing_volume_not_recreated(self, workspace):
         """Existing volumes are used as-is, not recreated."""
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=mock_c
-        )
-        mock_vol = MagicMock()
-        mock_vol.show = AsyncMock(return_value={"Name": "existing"})
-        mock_docker.volumes.get = AsyncMock(return_value=mock_vol)
-        mock_docker.volumes.create = AsyncMock()
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman(
+            inspect_volume=AsyncMock(return_value={"Name": "existing"})
+        ) as p:
             await container.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
                 extra_mounts=["existing:/data"],
             )
-        mock_docker.volumes.create.assert_not_awaited()
+        p.create_volume.assert_not_awaited()
 
     async def test_bind_mount_not_treated_as_volume(self, workspace):
         """Bind mounts (starting with /) are not treated as volumes."""
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=mock_c
-        )
-        mock_docker.volumes.get = AsyncMock()
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             await container.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
                 extra_mounts=["/home/me/src:/work/src"],
             )
-        mock_docker.volumes.get.assert_not_awaited()
+        p.inspect_volume.assert_not_awaited()
 
     async def test_mount_with_multiple_colons(self, workspace):
         """Mount spec with options (host:container:ro) — source starts with /."""
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=mock_c
-        )
-        mock_docker.volumes.get = AsyncMock()
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             await container.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
                 extra_mounts=["/data/shared:/mnt/data:ro"],
             )
-        # Bind mount, not a volume — volumes.get should not be called
-        mock_docker.volumes.get.assert_not_awaited()
+        # Bind mount, not a volume — inspect_volume should not be called
+        p.inspect_volume.assert_not_awaited()
 
     async def test_volume_mount_with_options(self, workspace):
         """Named volume with options (vol:container:ro) — auto-creates."""
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=mock_c
-        )
-        mock_vol = MagicMock()
-        mock_vol.show = AsyncMock(return_value={"Name": "my-vol"})
-        mock_docker.volumes.get = AsyncMock(
-            side_effect=container.aiodocker.exceptions.DockerError(
-                404, {"message": "not found"}
-            )
-        )
-        mock_docker.volumes.create = AsyncMock(return_value=mock_vol)
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             await container.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
                 extra_mounts=["my-vol:/data:ro"],
             )
-        mock_docker.volumes.create.assert_awaited_once()
+        p.create_volume.assert_awaited_once()
 
     async def test_mount_source_with_slash_is_bind(self, workspace):
         """A mount source containing slashes is a bind mount, not a volume."""
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=mock_c
-        )
-        mock_docker.volumes.get = AsyncMock()
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             await container.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
                 extra_mounts=["./relative/path:/work/rel"],
             )
-        mock_docker.volumes.get.assert_not_awaited()
+        p.inspect_volume.assert_not_awaited()
 
-    async def test_volume_auto_create_docker_error(self, workspace):
-        """Non-404 Docker error during volume check is re-raised."""
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=mock_c
-        )
-        mock_docker.volumes.get = AsyncMock(
-            side_effect=container.aiodocker.exceptions.DockerError(
-                500, {"message": "internal error"}
-            )
-        )
-
+    async def test_volume_create_error_propagates(self, workspace):
+        """An error creating a named volume propagates to the caller."""
         with (
-            patch.object(
-                container.registry, "get_docker", return_value=mock_docker
+            patch_podman(
+                create_volume=AsyncMock(
+                    side_effect=podman.PodmanError(500, "internal error")
+                )
             ),
-            pytest.raises(container.aiodocker.exceptions.DockerError),
+            pytest.raises(podman.PodmanError),
         ):
             await container.registry.start_container(
                 workspace["id"],
@@ -1016,16 +976,7 @@ class TestExtraMountsVolumeCreation:
 
     async def test_mount_source_with_special_characters(self, workspace):
         """Mount source with special/binary-like chars is a bind mount."""
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.create_or_replace = AsyncMock(
-            return_value=mock_c
-        )
-        mock_docker.volumes.get = AsyncMock()
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             await container.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -1033,20 +984,17 @@ class TestExtraMountsVolumeCreation:
                 extra_mounts=["/path/with spaces\x00and\x01binary:/work/bad"],
             )
         # Has leading /, so treated as bind mount
-        mock_docker.volumes.get.assert_not_awaited()
+        p.inspect_volume.assert_not_awaited()
 
     async def test_bridge_token_revoked_on_creation_failure(self, workspace):
-        """If container creation fails, the bridge token is revoked."""
-        mock_docker = _mock_docker()
-        mock_docker.containers.create_or_replace = AsyncMock(
-            side_effect=RuntimeError("docker broke")
-        )
-
+        """If container creation fails, the error propagates cleanly."""
         with (
-            patch.object(
-                container.registry, "get_docker", return_value=mock_docker
+            patch_podman(
+                create_container=AsyncMock(
+                    side_effect=RuntimeError("podman broke")
+                )
             ),
-            pytest.raises(RuntimeError, match="docker broke"),
+            pytest.raises(RuntimeError, match="podman broke"),
         ):
             await container.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
@@ -1065,27 +1013,20 @@ class TestStopContainer:
         container.registry.states.clear()
 
     async def test_stop_running(self):
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.get = AsyncMock(return_value=mock_c)
         container.registry.track_activity("cid", "ws")
 
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             await container.registry.stop_and_remove_container("cid")
-        mock_c.delete.assert_awaited()
+        p.remove_container.assert_awaited_once_with("cid")
         assert "ws" not in container.registry.states
 
     async def test_stop_docker_error(self):
-        mock_docker = _mock_docker()
-        mock_docker.containers.get = AsyncMock(
-            side_effect=aiodocker.exceptions.DockerError(404, "gone")
-        )
         container.registry.track_activity("cid", "ws")
 
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
+        with patch_podman(
+            remove_container=AsyncMock(
+                side_effect=podman.PodmanError(404, "gone")
+            )
         ):
             await container.registry.stop_and_remove_container("cid")
         # Should still remove from tracking
@@ -1100,28 +1041,20 @@ class TestRemoveContainer:
         container.registry.states.clear()
 
     async def test_remove(self):
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.get = AsyncMock(return_value=mock_c)
         container.registry.track_activity("cid", "ws")
 
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             await container.registry.stop_and_remove_container("cid")
-        mock_c.delete.assert_awaited()
-        mock_c.delete.assert_awaited_once_with(force=True)
+        p.remove_container.assert_awaited_once_with("cid")
         assert "ws" not in container.registry.states
 
     async def test_remove_docker_error(self):
-        mock_docker = _mock_docker()
-        mock_docker.containers.get = AsyncMock(
-            side_effect=aiodocker.exceptions.DockerError(404, "gone")
-        )
         container.registry.track_activity("cid", "ws")
 
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
+        with patch_podman(
+            remove_container=AsyncMock(
+                side_effect=podman.PodmanError(404, "gone")
+            )
         ):
             await container.registry.stop_and_remove_container("cid")
         assert "ws" not in container.registry.states
@@ -1135,26 +1068,16 @@ class TestStopUserContainers:
         container.registry.states.clear()
 
     async def test_stop_user_containers(self, user, workspace):
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.get = AsyncMock(return_value=mock_c)
-
         # Set container_id on the workspace
         await model.update_workspace_container(workspace["id"], "cid")
         container.registry.track_activity("cid", workspace["id"])
 
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             await container.registry.stop_user_containers(user["id"])
-        mock_c.delete.assert_awaited()
+        p.remove_container.assert_awaited_once_with("cid")
         assert workspace["id"] not in container.registry.states
 
     async def test_stop_user_calls_workspace_killed(self, user, workspace):
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.get = AsyncMock(return_value=mock_c)
-
         await model.update_workspace_container(workspace["id"], "cid")
         container.registry.track_activity("cid", workspace["id"])
 
@@ -1162,33 +1085,28 @@ class TestStopUserContainers:
         old_cb = container.registry.on_workspace_killed
         container.registry.on_workspace_killed = killed_cb
 
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman():
             await container.registry.stop_user_containers(user["id"])
 
         killed_cb.assert_awaited_once_with(workspace["id"])
         container.registry.on_workspace_killed = old_cb
 
     async def test_stop_user_no_containers(self, user):
-        mock_docker = _mock_docker()
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             await container.registry.stop_user_containers(user["id"])
-        mock_docker.containers.get.assert_not_awaited()
+        p.remove_container.assert_not_awaited()
 
 
 class TestShutdown:
     def setup_method(self):
         container.registry.states.clear()
+        container.registry._cid_to_wsid.clear()
         container.registry.cleanup_task = None
-        container.registry.docker = None
 
     def teardown_method(self):
         container.registry.states.clear()
+        container.registry._cid_to_wsid.clear()
         container.registry.cleanup_task = None
-        container.registry.docker = None
 
     async def test_shutdown_skips_in_docker(self):
         """When running inside a container, shutdown skips cleanup."""
@@ -1199,40 +1117,25 @@ class TestShutdown:
         assert "ws" in container.registry.states
 
     async def test_shutdown_stops_tracked(self):
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.get = AsyncMock(return_value=mock_c)
-        mock_docker.containers.list = AsyncMock(return_value=[])
+        # list_containers returns the tracked cid; it should be skipped in
+        # the orphan loop (already tracked) but still removed via tracking.
         container.registry.track_activity("cid", "ws")
 
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
-            container.registry.docker = mock_docker
+        with patch_podman(
+            list_containers=AsyncMock(return_value=[{"Id": "cid"}])
+        ) as p:
             await container.registry.shutdown()
-        mock_c.delete.assert_awaited()
+        p.remove_container.assert_awaited_once_with("cid")
         assert "ws" not in container.registry.states
-        mock_docker.close.assert_awaited_once()
 
     async def test_shutdown_stops_orphans(self):
-        mock_docker = _mock_docker()
-        orphan = _mock_container("orphan-cid")
-        mock_docker.containers.list = AsyncMock(return_value=[orphan])
-        mock_docker.containers.get = AsyncMock(
-            return_value=_mock_container("x")
-        )
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
-            container.registry.docker = mock_docker
+        with patch_podman(
+            list_containers=AsyncMock(return_value=[{"Id": "orphan-cid"}])
+        ) as p:
             await container.registry.shutdown()
-        orphan.delete.assert_awaited_once()
+        p.remove_container.assert_awaited_once_with("orphan-cid")
 
     async def test_shutdown_cancels_cleanup_task(self):
-        mock_docker = _mock_docker()
-        mock_docker.containers.list = AsyncMock(return_value=[])
-
         # Create a real cancellable task so shutdown can await it.
         async def fake_cleanup():
             await asyncio.sleep(999)
@@ -1240,55 +1143,36 @@ class TestShutdown:
         task = asyncio.create_task(fake_cleanup())
         container.registry.cleanup_task = task
 
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
-            container.registry.docker = mock_docker
+        with patch_podman():
             await container.registry.shutdown()
         assert task.cancelled()
         assert container.registry.cleanup_task is None
 
     async def test_shutdown_handles_docker_error(self):
-        mock_docker = _mock_docker()
-        mock_docker.containers.list = AsyncMock(
-            side_effect=OSError("Docker connection refused")
-        )
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
+        with patch_podman(
+            list_containers=AsyncMock(
+                side_effect=OSError("Docker connection refused")
+            )
         ):
-            container.registry.docker = mock_docker
             await container.registry.shutdown()
         # Should not raise
-        mock_docker.close.assert_awaited_once()
 
     async def test_shutdown_no_docker(self):
-        container.registry.docker = None
-        mock_docker = _mock_docker()
-        mock_docker.containers.list = AsyncMock(return_value=[])
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman():
             await container.registry.shutdown()
         assert container.registry.cleanup_task is None
 
-    async def test_shutdown_orphan_delete_error(self):
-        """Orphan container that raises on delete is handled gracefully."""
-        mock_docker = _mock_docker()
-        orphan = _mock_container("orphan-cid")
-        orphan.delete = AsyncMock(
-            side_effect=aiodocker.exceptions.DockerError(500, "delete failed")
-        )
-        mock_docker.containers.list = AsyncMock(return_value=[orphan])
-
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
-            container.registry.docker = mock_docker
+    async def test_shutdown_orphan_remove_error(self):
+        """Orphan container that errors on removal is handled gracefully."""
+        with patch_podman(
+            list_containers=AsyncMock(return_value=[{"Id": "orphan-cid"}]),
+            remove_container=AsyncMock(
+                side_effect=podman.PodmanError(500, "remove failed")
+            ),
+        ) as p:
             await container.registry.shutdown()
-        # Should have attempted to delete and not raised
-        orphan.delete.assert_awaited_once()
-        mock_docker.close.assert_awaited_once()
+        # Attempted removal and did not raise
+        p.remove_container.assert_awaited_once_with("orphan-cid")
 
 
 class TestCleanupIdleContainers:
@@ -1301,19 +1185,13 @@ class TestCleanupIdleContainers:
         container.registry._cleanup_wake = None
 
     async def test_idle_container_stopped(self):
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.get = AsyncMock(return_value=mock_c)
-
         # Set activity far in the past
         container.registry.track_activity("cid", "ws-1")
         container.registry.states["ws-1"].last_activity = (
             time.time() - container.IDLE_TIMEOUT_SECONDS - 100
         )
 
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             task = asyncio.create_task(
                 container.registry.cleanup_idle_containers()
             )
@@ -1326,14 +1204,10 @@ class TestCleanupIdleContainers:
                 await task
             except asyncio.CancelledError:
                 pass
-        mock_c.delete.assert_awaited()
+        p.remove_container.assert_awaited()
         assert "ws-1" not in container.registry.states
 
     async def test_idle_calls_workspace_killed_callback(self):
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.get = AsyncMock(return_value=mock_c)
-
         container.registry.track_activity("cid", "ws-killed")
         container.registry.states["ws-killed"].last_activity = (
             time.time() - container.IDLE_TIMEOUT_SECONDS - 100
@@ -1343,9 +1217,7 @@ class TestCleanupIdleContainers:
         old_cb = container.registry.on_workspace_killed
         container.registry.on_workspace_killed = killed_cb
 
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman():
             task = asyncio.create_task(
                 container.registry.cleanup_idle_containers()
             )
@@ -1362,10 +1234,6 @@ class TestCleanupIdleContainers:
         container.registry.on_workspace_killed = old_cb
 
     async def test_idle_workspace_killed_callback_error(self):
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.get = AsyncMock(return_value=mock_c)
-
         container.registry.track_activity("cid", "ws-err")
         container.registry.states["ws-err"].last_activity = (
             time.time() - container.IDLE_TIMEOUT_SECONDS - 100
@@ -1375,9 +1243,7 @@ class TestCleanupIdleContainers:
         old_cb = container.registry.on_workspace_killed
         container.registry.on_workspace_killed = killed_cb
 
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman():
             task = asyncio.create_task(
                 container.registry.cleanup_idle_containers()
             )
@@ -1395,13 +1261,9 @@ class TestCleanupIdleContainers:
         container.registry.on_workspace_killed = old_cb
 
     async def test_active_container_not_stopped(self):
-        mock_docker = _mock_docker()
-
         container.registry.track_activity("cid", "ws-1")
 
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman():
             task = asyncio.create_task(
                 container.registry.cleanup_idle_containers()
             )
@@ -1417,10 +1279,6 @@ class TestCleanupIdleContainers:
         assert "ws-1" in container.registry.states
 
     async def test_idle_callback_invoked(self):
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.get = AsyncMock(return_value=mock_c)
-
         container.registry.track_activity("cid", "ws-1")
         container.registry.states["ws-1"].last_activity = (
             time.time() - container.IDLE_TIMEOUT_SECONDS - 100
@@ -1433,9 +1291,7 @@ class TestCleanupIdleContainers:
 
         container.registry.on_idle_stop("ws-1", on_idle)
 
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman():
             task = asyncio.create_task(
                 container.registry.cleanup_idle_containers()
             )
@@ -1450,10 +1306,6 @@ class TestCleanupIdleContainers:
         assert callback_called == ["ws-1"]
 
     async def test_idle_callback_error_handled(self):
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.get = AsyncMock(return_value=mock_c)
-
         container.registry.track_activity("cid", "ws-1")
         container.registry.states["ws-1"].last_activity = (
             time.time() - container.IDLE_TIMEOUT_SECONDS - 100
@@ -1464,9 +1316,7 @@ class TestCleanupIdleContainers:
 
         container.registry.on_idle_stop("ws-1", bad_callback)
 
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
-        ):
+        with patch_podman() as p:
             task = asyncio.create_task(
                 container.registry.cleanup_idle_containers()
             )
@@ -1479,24 +1329,16 @@ class TestCleanupIdleContainers:
             except asyncio.CancelledError:
                 pass
         # Container should still be stopped despite callback error
-        mock_c.delete.assert_awaited()
+        p.remove_container.assert_awaited()
 
     async def test_per_workspace_timeout_uses_event_wait(self):
         """When per-workspace timeouts exist, cleanup uses Event-based wait."""
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.get = AsyncMock(return_value=mock_c)
-
         container.registry.track_activity("cid", "ws-fast")
         container.registry.states["ws-fast"].last_activity = time.time() - 100
         container.registry.states["ws-fast"].idle_timeout = 5
 
         try:
-            with patch.object(
-                container.registry,
-                "get_docker",
-                return_value=mock_docker,
-            ):
+            with patch_podman() as p:
                 # The Event-based wait will timeout after max(2, 5//2)=2s,
                 # then check containers. We cancel after one iteration.
                 task = asyncio.create_task(
@@ -1511,26 +1353,18 @@ class TestCleanupIdleContainers:
                     await task
                 except asyncio.CancelledError:
                     pass
-            mock_c.delete.assert_awaited()
+            p.remove_container.assert_awaited()
         finally:
             container.registry.states.clear()
 
     async def test_per_workspace_timeout_event_timeout(self):
         """Event-based wait times out when no wake signal is sent."""
-        mock_docker = _mock_docker()
-        mock_c = _mock_container("cid")
-        mock_docker.containers.get = AsyncMock(return_value=mock_c)
-
         container.registry.track_activity("cid", "ws-fast")
         container.registry.states["ws-fast"].last_activity = time.time() - 100
         container.registry.states["ws-fast"].idle_timeout = 4
 
         try:
-            with patch.object(
-                container.registry,
-                "get_docker",
-                return_value=mock_docker,
-            ):
+            with patch_podman() as p:
                 # Patch wait_for to immediately raise TimeoutError (simulates
                 # the event not being set within the interval)
                 async def fast_timeout(coro, timeout):
@@ -1556,7 +1390,7 @@ class TestCleanupIdleContainers:
                         await container.registry.cleanup_idle_containers()
                     except asyncio.CancelledError:
                         pass
-            mock_c.delete.assert_awaited()
+            p.remove_container.assert_awaited()
         finally:
             container.registry.states.clear()
 
@@ -1591,17 +1425,15 @@ class TestAdoptOrphanedContainers:
         container.registry.states.clear()
 
     async def test_adopts_running_containers(self):
-        mock_container = MagicMock()
-        mock_container.id = "orphan-123"
-        mock_container.show = AsyncMock(
-            return_value={
-                "Config": {"Labels": {"klangk.workspace-id": "ws-orphan"}}
-            }
-        )
-        mock_docker = AsyncMock()
-        mock_docker.containers.list = AsyncMock(return_value=[mock_container])
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
+        with patch_podman(
+            list_containers=AsyncMock(
+                return_value=[
+                    {
+                        "Id": "orphan-123",
+                        "Labels": {"klangk.workspace-id": "ws-orphan"},
+                    }
+                ]
+            )
         ):
             await container.registry.adopt_orphaned_containers()
         assert "ws-orphan" in container.registry.states
@@ -1609,28 +1441,34 @@ class TestAdoptOrphanedContainers:
             container.registry.states["ws-orphan"].container_id == "orphan-123"
         )
 
-    async def test_skips_already_tracked(self):
-        container.registry.track_activity("tracked-456", "ws-tracked")
-        mock_container = MagicMock()
-        mock_container.id = "tracked-456"
-        mock_docker = AsyncMock()
-        mock_docker.containers.list = AsyncMock(return_value=[mock_container])
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
+    async def test_adopts_orphan_without_labels(self):
+        # A container with no labels gets the "unknown" workspace id.
+        with patch_podman(
+            list_containers=AsyncMock(
+                return_value=[{"Id": "orphan-x", "Labels": None}]
+            )
         ):
             await container.registry.adopt_orphaned_containers()
-        # Should not have called show() since it's already tracked
-        mock_container.show.assert_not_called()
+        assert container.registry.states["unknown"].container_id == "orphan-x"
+
+    async def test_skips_already_tracked(self):
+        container.registry.track_activity("tracked-456", "ws-tracked")
+        with patch_podman(
+            list_containers=AsyncMock(return_value=[{"Id": "tracked-456"}])
+        ):
+            await container.registry.adopt_orphaned_containers()
+        # Already tracked → not re-adopted, no "unknown" entry created.
+        assert (
+            container.registry.states["ws-tracked"].container_id
+            == "tracked-456"
+        )
+        assert "unknown" not in container.registry.states
 
     async def test_docker_error_handled(self):
-        mock_docker = AsyncMock()
-        mock_docker.containers.list = AsyncMock(
-            side_effect=aiodocker.exceptions.DockerError(
-                "err", {"message": "fail"}
+        with patch_podman(
+            list_containers=AsyncMock(
+                side_effect=podman.PodmanError(500, "fail")
             )
-        )
-        with patch.object(
-            container.registry, "get_docker", return_value=mock_docker
         ):
             await container.registry.adopt_orphaned_containers()
         # Should not raise


### PR DESCRIPTION
Stack 3/9 (base: `podman-wrapper`).

Swap container lifecycle, `/volumes` routes, and the raw exec session to the podman wrapper. **Drops the `/var/run/docker.sock` bind on workspace containers — removes the host-daemon-control breakout.** Adds `--pull` policy (`KLANGK_IMAGE_PULL_POLICY`, default `never`), `--replace`, `KLANGK_HOST_GATEWAY`, `asyncio.shield` around create+start, and adopt-by-label recovery. aiodocker remains installed (terminal.py not yet migrated) but unused here.

Note: main's aiodocker-based port-conflict retry was dropped (written against the removed API); see the `NOTE` in `container.start_container`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)