### PR TITLE
PR4: refactor(backend) migrate terminal to podman exec + pty

### DIFF
--- a/src/backend/klangk_backend/terminal.py
+++ b/src/backend/klangk_backend/terminal.py
@@ -1,30 +1,162 @@
-"""Terminal session: Docker API exec with single PTY for interactive shell."""
+"""Terminal session: an interactive shell via ``podman exec`` over a PTY.
+
+A single local PTY (slave set to raw mode) bridges the ``podman exec``
+subprocess's stdio to the container-side PTY allocated by ``-t``. Raw mode
+keeps the local line discipline from consuming escape sequences (arrow keys,
+etc.) -- the "double-PTY" problem that an interactive subprocess ``exec`` is
+otherwise prone to. Resize sets the master window size and signals podman
+with ``SIGWINCH`` so it re-reads the size and resizes the container PTY.
+
+The OS/subprocess glue lives in :class:`ShellProcess`; its methods need a
+real PTY and a real podman, so they are validated by interactive testing on
+Linux rather than unit tests (marked ``# pragma: no cover``).
+:class:`TerminalSession` holds the lifecycle/queue logic and is unit-tested
+against an injected fake shell.
+"""
 
 import asyncio
+import fcntl
 import logging
 import os
+import pty
+import signal
+import struct
+import termios
+import tty
 from collections.abc import AsyncGenerator
 
-import aiodocker
-import aiodocker.exceptions
-
+from . import podman
 from .util import BoundedOutputQueue
 
 logger = logging.getLogger(__name__)
 
+_READ_CHUNK = 65536
+
+# Backend env vars stripped from the in-container shell (defence in depth;
+# the container is not started with these, but never inherit them).
+_SENSITIVE_ENV_PREFIXES = (
+    "KLANGK_LLM_API_KEY",
+    "ANTHROPIC_",
+    "OPENAI_",
+    "GOOGLE_",
+    "GROQ_",
+    "MISTRAL_",
+)
+
+
+def _build_environment(
+    command_override: str | None, bridge_token: str | None
+) -> list[str]:
+    env = ["TERM=xterm-256color"]
+    if command_override is not None:
+        env.append(f"KLANGK_CMD_OVERRIDE={command_override}")
+    if bridge_token is not None:
+        env.append(f"KLANGK_BRIDGE_TOKEN={bridge_token}")
+    return env
+
+
+def _build_shell_command() -> list[str]:
+    unset_args: list[str] = []
+    for key in os.environ:
+        if key.startswith(_SENSITIVE_ENV_PREFIXES):
+            unset_args.extend(["-u", key])
+    return ["env", *unset_args, "/bin/bash"]
+
+
+def _build_exec_argv(
+    container_id: str, env: list[str], shell_cmd: list[str]
+) -> list[str]:
+    argv = ["exec", "-t", "-i", "-u", "klangk", "-w", "/home/klangk/work"]
+    for entry in env:
+        argv += ["-e", entry]
+    argv.append(container_id)
+    argv += shell_cmd
+    return argv
+
+
+class ShellProcess:
+    """Owns the PTY + ``podman exec`` subprocess for one shell.
+
+    Every method is a thin wrapper over OS / subprocess calls that require a
+    real PTY and a real podman, so they are exercised by interactive testing
+    on Linux rather than unit tests.
+    """
+
+    def __init__(self) -> None:
+        self._master_fd: int | None = None
+        self._proc: asyncio.subprocess.Process | None = None
+
+    async def start(  # pragma: no cover - needs a real PTY + podman
+        self, argv: list[str], rows: int, cols: int
+    ) -> None:
+        master_fd, slave_fd = pty.openpty()
+        try:
+            # Raw mode: pass bytes through untouched so the container PTY is
+            # the only one applying line discipline (no double-PTY).
+            tty.setraw(slave_fd)
+            _set_winsize(master_fd, rows, cols)
+            self._proc = await asyncio.create_subprocess_exec(
+                podman.PODMAN_BIN,
+                *argv,
+                stdin=slave_fd,
+                stdout=slave_fd,
+                stderr=slave_fd,
+                start_new_session=True,
+            )
+        finally:
+            os.close(slave_fd)
+        self._master_fd = master_fd
+
+    async def read(self) -> bytes:  # pragma: no cover - needs a real PTY
+        loop = asyncio.get_running_loop()
+        try:
+            return await loop.run_in_executor(
+                None, os.read, self._master_fd, _READ_CHUNK
+            )
+        except OSError:
+            # Slave closed (the shell exited) -> EIO on the master.
+            return b""
+
+    async def write(self, data: bytes) -> None:  # pragma: no cover
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, os.write, self._master_fd, data)
+
+    def resize(self, rows: int, cols: int) -> None:  # pragma: no cover
+        _set_winsize(self._master_fd, rows, cols)
+        if self._proc is not None:
+            # Make podman re-read its tty size and resize the container PTY.
+            os.kill(self._proc.pid, signal.SIGWINCH)
+
+    def close(self) -> None:  # pragma: no cover
+        if self._proc is not None and self._proc.returncode is None:
+            try:
+                self._proc.kill()
+            except ProcessLookupError:
+                pass
+        if self._master_fd is not None:
+            try:
+                os.close(self._master_fd)
+            except OSError:
+                pass
+            self._master_fd = None
+
+
+def _set_winsize(  # pragma: no cover - needs a real fd
+    fd: int, rows: int, cols: int
+) -> None:
+    fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", rows, cols, 0, 0))
+
+
+def _make_shell_process() -> ShellProcess:
+    return ShellProcess()
+
 
 class TerminalSession:
-    """Manages a Docker exec shell session via the Docker API.
-
-    Uses aiodocker's exec API to create a single PTY connection,
-    avoiding the double-PTY issue that occurs with `docker exec -it`
-    as a subprocess (which consumed ESC bytes from arrow key sequences).
-    """
+    """Manages an interactive shell session over a PTY."""
 
     def __init__(self, container_id: str):
         self.container_id = container_id
-        self._stream: aiodocker.stream.Stream | None = None
-        self._exec: aiodocker.execs.Exec | None = None
+        self._shell: ShellProcess | None = None
         self._output_queue: BoundedOutputQueue[str] = BoundedOutputQueue(
             maxsize=64
         )
@@ -38,92 +170,33 @@ class TerminalSession:
         command_override: str | None = None,
         bridge_token: str | None = None,
     ) -> None:
-        """Start a shell session via Docker API exec."""
+        """Start a shell session via ``podman exec`` over a PTY."""
         self._running = True
+        env = _build_environment(command_override, bridge_token)
+        shell_cmd = _build_shell_command()
+        argv = _build_exec_argv(self.container_id, env, shell_cmd)
 
-        # Build environment for the exec
-        env = ["TERM=xterm-256color"]
-        if command_override is not None:
-            env.append(f"KLANGK_CMD_OVERRIDE={command_override}")
-        if bridge_token is not None:
-            env.append(f"KLANGK_BRIDGE_TOKEN={bridge_token}")
-
-        # Build the command: env -u KEY ... /bin/bash
-        # Strip sensitive env vars from the terminal session.
-        unset_args = []
-        for key in os.environ:
-            if key.startswith(
-                (
-                    "KLANGK_LLM_API_KEY",
-                    "ANTHROPIC_",
-                    "OPENAI_",
-                    "GOOGLE_",
-                    "GROQ_",
-                    "MISTRAL_",
-                )
-            ):
-                unset_args.extend(["-u", key])
-        cmd = ["env", *unset_args, "/bin/bash"]
-
-        # Create and start exec via Docker API (single PTY)
-        docker = aiodocker.Docker()
+        shell = _make_shell_process()
         try:
-            container = await docker.containers.get(self.container_id)
-            self._exec = await container.exec(
-                cmd,
-                tty=True,
-                stdin=True,
-                stdout=True,
-                stderr=True,
-                user="klangk",
-                workdir="/home/klangk/work",
-                environment=env,
-            )
-            self._stream = self._exec.start()
-            logger.info(
-                "Exec created for container %s, exec_id=%s",
-                self.container_id,
-                self._exec._id,
-            )
-
-            # Do the first read to establish the WebSocket connection,
-            # then resize. The stream connects lazily on first I/O.
-            first_msg = await self._stream.read_out()
-            if first_msg is not None:
-                logger.info(
-                    "First read OK (%d bytes), exec_id=%s",
-                    len(first_msg.data),
-                    self._exec._id,
-                )
-                await self._output_queue.put(
-                    first_msg.data.decode("utf-8", errors="replace")
-                )
-            else:
-                logger.info(
-                    "First read returned None (exec exited?), exec_id=%s",
-                    self._exec._id,
-                )
-
-            await self._exec.resize(h=rows, w=cols)
+            await shell.start(argv, rows, cols)
         except Exception:
-            await docker.close()
+            self._running = False
             raise
 
-        self._docker = docker
+        self._shell = shell
         self._read_task = asyncio.create_task(self._read_loop())
-
         logger.info(
             "Terminal session started for container %s", self.container_id
         )
 
     async def _read_loop(self) -> None:
-        """Read output from the Docker exec stream."""
+        """Read PTY output and queue it as text."""
         try:
-            while self._running and self._stream is not None:
-                msg = await self._stream.read_out()
-                if msg is None:
+            while self._running and self._shell is not None:
+                data = await self._shell.read()
+                if not data:
                     break
-                text = msg.data.decode("utf-8", errors="replace")
+                text = data.decode("utf-8", errors="replace")
                 if text:
                     # Bounded queue: blocks when full, back-pressuring the
                     # PTY via its kernel buffer.
@@ -137,7 +210,7 @@ class TerminalSession:
 
     @property
     def is_alive(self) -> bool:
-        if self._exec is None:
+        if self._shell is None:
             return False
         if self._read_task is not None and self._read_task.done():
             return False
@@ -145,24 +218,18 @@ class TerminalSession:
 
     async def write(self, data: str) -> None:
         """Write user input to the terminal."""
-        if self._stream is not None:
+        if self._shell is not None:
             try:
-                await self._stream.write_in(data.encode("utf-8"))
-            except (
-                aiodocker.exceptions.DockerError,
-                OSError,
-            ):
-                logger.debug("Write to terminal stream failed", exc_info=True)
+                await self._shell.write(data.encode("utf-8"))
+            except OSError:
+                logger.debug("Write to terminal failed", exc_info=True)
 
     async def resize(self, cols: int, rows: int) -> None:
         """Resize the terminal."""
-        if self._exec is not None:
+        if self._shell is not None:
             try:
-                await self._exec.resize(h=rows, w=cols)
-            except (
-                aiodocker.exceptions.DockerError,
-                OSError,
-            ):
+                self._shell.resize(rows, cols)
+            except OSError:
                 logger.debug("Terminal resize failed", exc_info=True)
 
     async def output(self) -> AsyncGenerator[str, None]:
@@ -195,27 +262,12 @@ class TerminalSession:
                 logger.exception("Error awaiting terminal read task")
             self._read_task = None
 
-        if self._stream is not None:
+        if self._shell is not None:
             try:
-                await self._stream.close()
-            except (
-                aiodocker.exceptions.DockerError,
-                OSError,
-            ):
-                logger.debug("Error closing terminal stream", exc_info=True)
-            self._stream = None
-
-        if hasattr(self, "_docker") and self._docker is not None:
-            try:
-                await self._docker.close()
-            except (
-                aiodocker.exceptions.DockerError,
-                OSError,
-            ):
-                logger.debug("Error closing Docker client", exc_info=True)
-            self._docker = None
-
-        self._exec = None
+                self._shell.close()
+            except OSError:
+                logger.debug("Error closing terminal shell", exc_info=True)
+            self._shell = None
 
         logger.info(
             "Terminal session stopped for container %s", self.container_id

--- a/src/backend/tests/test_terminal.py
+++ b/src/backend/tests/test_terminal.py
@@ -1,457 +1,312 @@
-"""Tests for terminal: Docker API exec-based terminal sessions."""
+"""Tests for terminal: PTY-based ``podman exec`` shell sessions.
+
+The OS/PTY glue (:class:`ShellProcess`) needs a real PTY + podman and is
+marked ``# pragma: no cover``; these tests drive :class:`TerminalSession`'s
+lifecycle/queue logic against an injected fake shell.
+"""
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import patch
+
+from klangk_backend.terminal import TerminalSession, _make_shell_process
+
+SHELL_FACTORY = "klangk_backend.terminal._make_shell_process"
 
 
-from klangk_backend.terminal import TerminalSession
+class TestShellProcessFactory:
+    """The factory + ctor are pure Python (no PTY); the OS methods that
+    need a real PTY/podman are ``# pragma: no cover`` and validated
+    interactively."""
+
+    def test_factory_returns_unstarted_shell(self):
+        shell = _make_shell_process()
+        assert shell._master_fd is None
+        assert shell._proc is None
 
 
-def _mock_stream():
-    stream = MagicMock()
-    stream.write_in = AsyncMock()
-    stream.close = AsyncMock()
-    return stream
+class FakeShell:
+    """Stand-in for ShellProcess: scripted reads, recorded writes/resizes."""
+
+    def __init__(
+        self,
+        chunks=(),
+        *,
+        start_error=None,
+        write_error=None,
+        close_error=None,
+        block_after_chunks=False,
+    ):
+        self._chunks = list(chunks)
+        self._start_error = start_error
+        self._write_error = write_error
+        self._close_error = close_error
+        self._block = block_after_chunks
+        self.argv = None
+        self.rows = None
+        self.cols = None
+        self.writes = []
+        self.resizes = []
+        self.closed = False
+
+    async def start(self, argv, rows, cols):
+        self.argv = argv
+        self.rows = rows
+        self.cols = cols
+        if self._start_error is not None:
+            raise self._start_error
+
+    async def read(self):
+        if self._chunks:
+            item = self._chunks.pop(0)
+            if isinstance(item, BaseException):
+                raise item
+            return item
+        if self._block:
+            await asyncio.Event().wait()  # hang until the task is cancelled
+        return b""
+
+    async def write(self, data):
+        if self._write_error is not None:
+            raise self._write_error
+        self.writes.append(data)
+
+    def resize(self, rows, cols):
+        self.resizes.append((rows, cols))
+
+    def close(self):
+        self.closed = True
+        if self._close_error is not None:
+            raise self._close_error
 
 
-def _mock_exec(stream):
-    exec_obj = MagicMock()
-    exec_obj.start = MagicMock(return_value=stream)
-    exec_obj.resize = AsyncMock()
-    return exec_obj
-
-
-def _mock_container(exec_obj):
-    container = MagicMock()
-    container.exec = AsyncMock(return_value=exec_obj)
-    return container
-
-
-def _mock_docker(container):
-    docker = MagicMock()
-    docker.containers = MagicMock()
-    docker.containers.get = AsyncMock(return_value=container)
-    docker.close = AsyncMock()
-    return docker
+def _patch(fake):
+    return patch(SHELL_FACTORY, return_value=fake)
 
 
 class TestInit:
     def test_initial_state(self):
         s = TerminalSession("cid")
         assert s.container_id == "cid"
-        assert s._stream is None
-        assert s._exec is None
+        assert s._shell is None
         assert s._running is False
         assert s.is_alive is False
 
 
 class TestStart:
-    async def test_start_creates_exec_session(self):
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(return_value=None)
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+    async def test_start_builds_exec_argv(self):
+        fake = FakeShell(block_after_chunks=True)
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start(120, 40)
 
-        docker.containers.get.assert_awaited_once_with("cid")
-        container.exec.assert_awaited_once()
-        call_kwargs = container.exec.call_args
-        assert call_kwargs[1]["tty"] is True
-        assert call_kwargs[1]["stdin"] is True
-        assert call_kwargs[1]["user"] == "klangk"
-        assert call_kwargs[1]["workdir"] == "/home/klangk/work"
-        exec_obj.start.assert_called_once()
-        exec_obj.resize.assert_awaited_once_with(h=40, w=120)
-
+        argv = fake.argv
+        assert argv[0] == "exec"
+        assert "-t" in argv and "-i" in argv
+        assert argv[argv.index("-u") + 1] == "klangk"
+        assert argv[argv.index("-w") + 1] == "/home/klangk/work"
+        assert "cid" in argv
+        assert argv[-1] == "/bin/bash"
+        assert (fake.rows, fake.cols) == (40, 120)
         assert s._running is True
         await s.stop()
 
     async def test_start_unsets_sensitive_env_vars(self, monkeypatch):
         monkeypatch.setenv("KLANGK_LLM_API_KEY", "secret")
         monkeypatch.setenv("ANTHROPIC_API_KEY", "secret2")
-
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(return_value=None)
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+        fake = FakeShell(block_after_chunks=True)
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start()
 
-        call_args = container.exec.call_args
-        cmd = call_args[0][0]
-        assert "env" in cmd
-        env_idx = cmd.index("env")
-        env_args = cmd[env_idx:]
-        unset_keys = [
-            env_args[i + 1] for i, a in enumerate(env_args) if a == "-u"
-        ]
-        assert "KLANGK_LLM_API_KEY" in unset_keys
-        assert "ANTHROPIC_API_KEY" in unset_keys
-
+        argv = fake.argv
+        unset = [argv[i + 1] for i, a in enumerate(argv) if a == "-u"]
+        assert "KLANGK_LLM_API_KEY" in unset
+        assert "ANTHROPIC_API_KEY" in unset
         await s.stop()
 
     async def test_command_override_sets_env_var(self):
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(return_value=None)
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+        fake = FakeShell(block_after_chunks=True)
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start(command_override="bash")
-
-        call_kwargs = container.exec.call_args[1]
-        assert "KLANGK_CMD_OVERRIDE=bash" in call_kwargs["environment"]
-
+        assert "-e" in fake.argv
+        assert "KLANGK_CMD_OVERRIDE=bash" in fake.argv
         await s.stop()
 
     async def test_no_command_override_by_default(self):
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(return_value=None)
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+        fake = FakeShell(block_after_chunks=True)
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start()
-
-        call_kwargs = container.exec.call_args[1]
-        assert not any(
-            "KLANGK_CMD_OVERRIDE" in e for e in call_kwargs["environment"]
-        )
-
+        assert not any("KLANGK_CMD_OVERRIDE" in a for a in fake.argv)
         await s.stop()
 
     async def test_bridge_token_sets_env_var(self):
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(return_value=None)
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+        fake = FakeShell(block_after_chunks=True)
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start(bridge_token="tok-123")
-
-        call_kwargs = container.exec.call_args[1]
-        assert "KLANGK_BRIDGE_TOKEN=tok-123" in call_kwargs["environment"]
-
+        assert "KLANGK_BRIDGE_TOKEN=tok-123" in fake.argv
         await s.stop()
 
     async def test_no_bridge_token_by_default(self):
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(return_value=None)
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+        fake = FakeShell(block_after_chunks=True)
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start()
-
-        call_kwargs = container.exec.call_args[1]
-        assert not any(
-            "KLANGK_BRIDGE_TOKEN" in e for e in call_kwargs["environment"]
-        )
-
+        assert not any("KLANGK_BRIDGE_TOKEN" in a for a in fake.argv)
         await s.stop()
 
-    async def test_start_exception_closes_docker(self):
-        stream = _mock_stream()
-        exec_obj = _mock_exec(stream)
-        exec_obj.resize = AsyncMock(side_effect=RuntimeError("resize fail"))
-        stream.read_out = AsyncMock(return_value=None)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+    async def test_start_failure_resets_running(self):
+        fake = FakeShell(start_error=RuntimeError("spawn fail"))
+        with _patch(fake):
             s = TerminalSession("cid")
             try:
                 await s.start()
             except RuntimeError:
                 pass
-
-        docker.close.assert_awaited()
+        assert s._running is False
+        assert s._shell is None
+        assert s.is_alive is False
 
 
 class TestReadLoop:
-    async def test_output_from_stream(self):
-        first_msg = MagicMock()
-        first_msg.data = b"prompt"
-        second_msg = MagicMock()
-        second_msg.data = b"hello world"
-        stream = _mock_stream()
-        # First read consumed by start(), second by read_loop
-        stream.read_out = AsyncMock(side_effect=[first_msg, second_msg, None])
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+    async def test_output_from_shell(self):
+        fake = FakeShell(chunks=[b"prompt", b"hello world"])
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start()
 
-        await asyncio.sleep(0.1)
-        # First msg queued by start(), second by read_loop
-        data1 = s._output_queue.get_nowait()
-        assert data1 == "prompt"
-        data2 = s._output_queue.get_nowait()
-        assert data2 == "hello world"
-
+        await asyncio.sleep(0.05)
+        assert s._output_queue.get_nowait() == "prompt"
+        assert s._output_queue.get_nowait() == "hello world"
         await s.stop()
 
     async def test_stream_end_signals_none(self):
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(return_value=None)
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+        fake = FakeShell(chunks=[])  # immediate EOF
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start()
 
-        await asyncio.sleep(0.1)
-        data = s._output_queue.get_nowait()
-        assert data is None
-
+        await asyncio.sleep(0.05)
+        assert s._output_queue.get_nowait() is None
         await s.stop()
 
     async def test_read_loop_handles_exception(self):
-        first_msg = MagicMock()
-        first_msg.data = b"prompt"
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(
-            side_effect=[first_msg, RuntimeError("connection lost")]
-        )
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+        fake = FakeShell(chunks=[b"prompt", RuntimeError("connection lost")])
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start()
 
-        await asyncio.sleep(0.1)
-        # Should get prompt then None (from exception cleanup)
-        s._output_queue.get_nowait()  # prompt
-        data = s._output_queue.get_nowait()
-        assert data is None
-
+        await asyncio.sleep(0.05)
+        assert s._output_queue.get_nowait() == "prompt"
+        # exception in read -> loop ends -> sentinel queued
+        assert s._output_queue.get_nowait() is None
         await s.stop()
-
-    async def test_sentinel_uses_put_nowait(self):
-        """_read_loop uses put_nowait for the sentinel, not blocking put."""
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(return_value=None)
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
-            s = TerminalSession("cid")
-            await s.start()
-
-        await asyncio.sleep(0.1)
-        # Sentinel should be in the queue (put_nowait succeeded)
-        data = s._output_queue.get_nowait()
-        assert data is None
-        await s.stop()
-
-    async def test_sentinel_dropped_when_queue_full(self):
-        """When queue is full, sentinel is silently dropped (no deadlock)."""
-        s = TerminalSession("cid")
-        s._running = True
-        # Pre-fill the queue to capacity
-        for _ in range(64):
-            s._output_queue.put_nowait("data")
-        assert s._output_queue.full()
-
-        # Simulate _read_loop finally block: put_nowait should catch QueueFull
-        try:
-            s._output_queue.put_nowait(None)
-        except asyncio.QueueFull:
-            pass  # This is the expected path
-
-        # Queue is still full, sentinel was dropped, no hang
-        assert s._output_queue.full()
-        # Verify no None sentinel in the queue
-        items = []
-        while not s._output_queue.empty():
-            items.append(s._output_queue.get_nowait())
-        assert None not in items
 
 
 class TestWrite:
-    async def test_write_sends_to_stream(self):
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(return_value=None)
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+    async def test_write_sends_to_shell(self):
+        fake = FakeShell(block_after_chunks=True)
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start()
-
         await s.write("hello")
-        stream.write_in.assert_awaited_with(b"hello")
-
+        assert fake.writes == [b"hello"]
         await s.stop()
 
     async def test_write_exception_suppressed(self):
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(return_value=None)
-        stream.write_in = AsyncMock(side_effect=OSError("broken"))
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+        fake = FakeShell(block_after_chunks=True, write_error=OSError("broke"))
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start()
-
-        # Should not raise
-        await s.write("hello")
+        await s.write("hello")  # should not raise
         await s.stop()
 
     async def test_write_when_stopped(self):
         s = TerminalSession("cid")
-        await s.write("hello")
+        await s.write("hello")  # no shell -> no-op
 
 
 class TestResize:
-    async def test_resize_calls_exec_resize(self):
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(return_value=None)
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+    async def test_resize_calls_shell_resize(self):
+        fake = FakeShell(block_after_chunks=True)
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start()
-
         await s.resize(200, 50)
-        exec_obj.resize.assert_awaited_with(h=50, w=200)
-
+        assert fake.resizes == [(50, 200)]  # (rows, cols)
         await s.stop()
 
     async def test_resize_exception_suppressed(self):
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(return_value=None)
-        exec_obj = _mock_exec(stream)
-        exec_obj.resize = AsyncMock(side_effect=[None, OSError("broken")])
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
+        fake = FakeShell(block_after_chunks=True)
 
-        with patch("aiodocker.Docker", return_value=docker):
+        def boom(rows, cols):
+            raise OSError("broke")
+
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start()
-
-        # Should not raise (second call raises)
-        await s.resize(200, 50)
+        fake.resize = boom
+        await s.resize(200, 50)  # should not raise
         await s.stop()
 
     async def test_resize_when_stopped(self):
         s = TerminalSession("cid")
-        await s.resize(80, 24)
+        await s.resize(80, 24)  # no shell -> no-op
 
 
 class TestStop:
     async def test_stop_cleans_up(self):
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(return_value=None)
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+        fake = FakeShell(block_after_chunks=True)
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start()
-
         await s.stop()
         assert s._running is False
-        assert s._stream is None
-        assert s._exec is None
+        assert s._shell is None
         assert s.is_alive is False
-        docker.close.assert_awaited()
+        assert fake.closed is True
 
-    async def test_stop_handles_close_exceptions(self):
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(return_value=None)
-        stream.close = AsyncMock(side_effect=OSError("close fail"))
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-        docker.close = AsyncMock(side_effect=OSError("docker close fail"))
-
-        with patch("aiodocker.Docker", return_value=docker):
+    async def test_stop_handles_close_exception(self):
+        fake = FakeShell(
+            block_after_chunks=True, close_error=OSError("close fail")
+        )
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start()
-
-        # Should not raise despite exceptions
-        await s.stop()
-        assert s._stream is None
-        assert s._exec is None
+        await s.stop()  # should not raise
+        assert s._shell is None
 
     async def test_stop_cancels_blocked_read_loop(self):
-        """CancelledError re-raised from _read_loop when stop() cancels it."""
-        hang = asyncio.Future()  # blocks forever until cancelled
-        first_msg = MagicMock()
-        first_msg.data = b"prompt"
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(side_effect=[first_msg, hang])
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+        fake = FakeShell(chunks=[b"prompt"], block_after_chunks=True)
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start()
-
-        # Read loop is now blocked on the hanging future
+        await asyncio.sleep(0.05)  # consume prompt, then block on read
         await s.stop()
         assert s._running is False
-        assert s._stream is None
+        assert s._shell is None
 
     async def test_stop_read_task_unexpected_exception(self):
-        """Non-CancelledError from read task is logged, not raised."""
-
         async def bad_task():
             raise RuntimeError("unexpected")
 
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(return_value=None)
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+        fake = FakeShell(block_after_chunks=True)
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start()
 
-        # Replace the read task with one that raises a non-CancelledError
-        if s._read_task is not None:
-            s._read_task.cancel()
-            try:
-                await s._read_task
-            except (asyncio.CancelledError, Exception):
-                pass
+        # Replace the read task with one that raises a non-CancelledError.
+        s._read_task.cancel()
+        try:
+            await s._read_task
+        except asyncio.CancelledError:
+            pass
         s._read_task = asyncio.create_task(bad_task())
-        await asyncio.sleep(0)  # let it finish
+        await asyncio.sleep(0)
 
-        # stop() should handle the RuntimeError without raising
-        await s.stop()
+        await s.stop()  # logs the RuntimeError, does not raise
         assert s._read_task is None
 
     async def test_stop_when_not_started(self):
@@ -461,165 +316,81 @@ class TestStop:
 
 class TestOutput:
     async def test_output_yields_data(self):
-        first_msg = MagicMock()
-        first_msg.data = b"prompt"
-        second_msg = MagicMock()
-        second_msg.data = b"output"
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(side_effect=[first_msg, second_msg, None])
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+        fake = FakeShell(chunks=[b"prompt", b"output"])
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start()
 
         collected = []
         async for data in s.output():
             collected.append(data)
-
         assert "prompt" in collected
         assert "output" in collected
         await s.stop()
 
-    async def test_output_exits_when_running_cleared_without_sentinel(self):
-        """When sentinel is dropped (QueueFull), output() exits via _running check."""
-        stream = _mock_stream()
-        first_msg = MagicMock()
-        first_msg.data = b"prompt"
-        stream.read_out = AsyncMock(side_effect=[first_msg, None])
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
-            s = TerminalSession("cid")
-            await s.start()
-
-        # Drain the queue (prompt + sentinel from read_loop)
-        await asyncio.sleep(0.1)
-        while not s._output_queue.empty():
-            s._output_queue.get_nowait()
-
-        # Now simulate: no sentinel in queue, consumer should exit
-        # when _running is set to False after timeout
+    async def test_output_exits_when_running_cleared(self):
+        """Sentinel dropped: output() exits via the _running check."""
+        s = TerminalSession("cid")
         s._running = True
+        s._read_task = None  # no task -> only _running governs exit
 
         async def _consume():
-            collected = []
-            async for data in s.output():
-                collected.append(data)
-            return collected
+            return [data async for data in s.output()]
 
         task = asyncio.create_task(_consume())
-        # Let the consumer block on get() with timeout
         await asyncio.sleep(0.05)
-        # Clear _running so the next timeout cycle exits
         s._running = False
         result = await asyncio.wait_for(task, timeout=3.0)
         assert result == []
-        await s.stop()
 
-    async def test_output_exits_when_read_task_done_without_sentinel(self):
-        """When sentinel is dropped and _running is True, output() exits
-        via _read_task.done() check after timeout."""
-        stream = _mock_stream()
-        first_msg = MagicMock()
-        first_msg.data = b"prompt"
-        stream.read_out = AsyncMock(side_effect=[first_msg, None])
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+    async def test_output_exits_when_read_task_done(self):
+        """Sentinel dropped: output() exits via the _read_task.done() check."""
+        fake = FakeShell(chunks=[])  # immediate EOF -> read task finishes
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start()
 
-        # Wait for read_loop to finish (it gets None from read_out)
-        await asyncio.sleep(0.1)
+        await asyncio.sleep(0.05)
         assert s._read_task.done()
-
-        # Drain the queue (prompt + sentinel)
+        # Drain the queued sentinel so output() must rely on the done() check.
         while not s._output_queue.empty():
             s._output_queue.get_nowait()
-
-        # _running is still True — only _read_task.done() signals exit
-        assert s._running
-
-        async def _consume():
-            collected = []
-            async for data in s.output():
-                collected.append(data)
-            return collected
+        assert s._running  # still True; only read_task.done() signals exit
 
         result = await asyncio.wait_for(
-            asyncio.create_task(_consume()), timeout=3.0
+            asyncio.create_task(_collect(s)),
+            timeout=3.0,
         )
         assert result == []
         await s.stop()
 
 
+async def _collect(session):
+    return [data async for data in session.output()]
+
+
 class TestIsAlive:
     async def test_alive_while_running(self):
-        stream = _mock_stream()
-        # Never-ending stream — read_out blocks forever
-        event = asyncio.Event()
-
-        async def slow_read():
-            await event.wait()
-            return None
-
-        first_msg = MagicMock()
-        first_msg.data = b"prompt"
-        call_count = 0
-
-        async def _read_side_effect():
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                return first_msg
-            return await slow_read()
-
-        stream.read_out = _read_side_effect
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+        fake = FakeShell(chunks=[b"prompt"], block_after_chunks=True)
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start()
-
         assert s.is_alive is True
-        event.set()
         await s.stop()
 
     async def test_not_alive_after_stream_ends(self):
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(return_value=None)
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+        fake = FakeShell(chunks=[])  # EOF
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start()
-
-        await asyncio.sleep(0.1)
+        await asyncio.sleep(0.05)
         assert s.is_alive is False
-
         await s.stop()
 
     async def test_not_alive_after_stop(self):
-        stream = _mock_stream()
-        stream.read_out = AsyncMock(return_value=None)
-        exec_obj = _mock_exec(stream)
-        container = _mock_container(exec_obj)
-        docker = _mock_docker(container)
-
-        with patch("aiodocker.Docker", return_value=docker):
+        fake = FakeShell(block_after_chunks=True)
+        with _patch(fake):
             s = TerminalSession("cid")
             await s.start()
-
         await s.stop()
         assert s.is_alive is False


### PR DESCRIPTION
Stack 4/9 (base: `migrate-container-engine`).

Rewrite the interactive shell from aiodocker's exec stream to `podman exec -t -i` over a `pty.openpty()` slave in raw mode; resize sets the master winsize and sends SIGWINCH. OS glue isolated in `ShellProcess`; lifecycle unit-tested via an injected fake shell. Removes the last aiodocker call site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)