### PR TITLE
PR5: chore(backend) drop aiodocker dependency

### DIFF
--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -7,7 +7,6 @@ dependencies = [
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.32.0",
     "websockets>=14.0",
-    "aiodocker>=0.23.0",
     "aiosqlite>=0.20.0",
     "bcrypt>=4.0.0",
     "python-jose[cryptography]>=3.3.0",
@@ -22,6 +21,7 @@ dependencies = [
     "pytest-asyncio>=0.24.0",
     "pytest-cov>=6.0.0",
     "pytest-xdist>=3.0.0",
+    "ruff>=0.6.0",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Stack 5/9 (base: `migrate-terminal`).

All call sites now use the podman wrapper, so remove aiodocker from the dependency list; add `ruff` as a dev dep. The (gitignored) `uv.lock` is regenerated by CI / `uv sync`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)