### PR TITLE
PR6: feat(deploy) podman-in-docker daemon stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Temp
 tmp/
+.env
+data
 
 # devenv
 .devenv/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,133 @@
+# klangk daemon stack — DOCKER.md §7.
+#
+#   cp .env.example .env   # fill in KLANGK_LLM_*, KLANGK_JWT_SECRET, admin creds
+#   docker compose up --build
+#   # then log in at  http://localhost:${KLANGK_NGINX_PORT:-8995}
+#
+# Two services on two networks: only `nginx` is published to the host; the
+# `backend` (uvicorn + rootless Podman) is reachable only via the `internal`
+# network.  The backend runs rootless Podman-in-Docker — see src/daemon/* and
+# /home/bryan/src/podman_test for the recipe each flag comes from.
+#
+# HOST PREREQUISITES for the rootless-nesting backend (same as podman_test):
+#   - the tun module:  sudo modprobe tun
+#   - unprivileged user namespaces.  Modern Debian/Ubuntu harden these off; the
+#     backend grabs `cap_add: SYS_ADMIN` below to cover that without host edits.
+#     To drop that cap instead, relax the host and persist via sysctl.d:
+#       Ubuntu 24.04+:  sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+#       Debian/older:   sudo sysctl -w kernel.unprivileged_userns_clone=1
+#       Always:         sudo sysctl -w user.max_user_namespaces=15000
+
+services:
+  nginx:
+    image: nginx:alpine
+    restart: unless-stopped
+    depends_on:
+      - backend
+    networks:
+      - edge
+      - internal
+    # The only host-published port in the stack.
+    ports:
+      - "${KLANGK_NGINX_PORT:-8995}:${KLANGK_NGINX_PORT:-8995}"
+    volumes:
+      - ./src/daemon/nginx.conf.template:/etc/nginx/templates/nginx.conf.template:ro
+    # nginx is the ONLY place KLANGK_LLM_API_KEY / KLANGK_LLM_BASE_URL live —
+    # the llm-proxy injects the key so workspace containers never see it (§10).
+    # NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx renders the full nginx.conf template
+    # to /etc/nginx/nginx.conf (not conf.d/).
+    environment:
+      NGINX_ENVSUBST_OUTPUT_DIR: /etc/nginx
+      KLANGK_NGINX_PORT: "${KLANGK_NGINX_PORT:-8995}"
+      KLANGK_PORT: "${KLANGK_PORT:-8997}"
+      KLANGK_LLM_BASE_URL: "${KLANGK_LLM_BASE_URL}"
+      KLANGK_LLM_API_KEY: "${KLANGK_LLM_API_KEY}"
+
+  backend:
+    build:
+      context: .
+      dockerfile: src/daemon/Dockerfile
+    image: klangk-daemon
+    restart: unless-stopped
+    # NOT on `edge`: unreachable from the host, only nginx can reach it.
+    networks:
+      - internal
+
+    # --- rootless Podman-in-Docker profile (mirrors podman_test) ---
+    # Devices passed through explicitly (NOT --privileged):
+    devices:
+      - /dev/fuse        # fuse-overlayfs storage driver
+      - /dev/net/tun     # passt/slirp4netns container networking
+    # All far weaker than `privileged: true`:
+    security_opt:
+      - seccomp=unconfined
+      - apparmor=unconfined
+      - label=disable
+      # Clear Docker's read-only/masked /proc paths so the inner podman can set
+      # its default container sysctls (podman's unmask=ALL equivalent).  Lighter
+      # alternative: set `default_sysctls = []` in src/daemon/containers.conf and
+      # drop this line.
+      - systempaths=unconfined
+    # The one capability the rootless userns setup needs when the host kernel
+    # forbids unprivileged user namespaces (the dependable lever; see header).
+    cap_add:
+      - SYS_ADMIN
+
+    volumes:
+      # App state: SQLite DB + workspace homes (§4).
+      - ./data/klangk-data:/var/lib/klangk/data
+      # Rootless podman's image/container layers — persisted so they aren't
+      # re-fused every restart.
+      - ./data/klangk-podman-storage:/home/klangk/.local/share/containers
+      # §9/B — prebuilt workspace-image store, read-only.  Uncomment together
+      # with `additionalimagestores` in src/daemon/storage.conf once the store
+      # volume is seeded offline.
+      # - klangk-images:/var/lib/klangk-images:ro
+
+    # Healthcheck per §7: confirm the in-process engine initialises.
+    healthcheck:
+      test: ["CMD", "podman", "info"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+    # Backend env.  KLANGK_LLM_API_KEY / _BASE_URL are deliberately ABSENT —
+    # they belong to nginx only (§10; the backend never needs the key).  Values
+    # interpolate from the root `.env`.  Add any other KLANGK_* your deployment
+    # uses (KLANGK_DNS_SERVERS, KLANGK_ALLOWED_IMAGES, KLANGK_LOGIN_*,
+    # KLANGK_DISABLE_REGISTRATION, KLANGK_IMPORT_MAX_SIZE, ...).
+    environment:
+      KLANGK_PORT: "${KLANGK_PORT:-8997}"
+      KLANGK_NGINX_PORT: "${KLANGK_NGINX_PORT:-8995}"
+      KLANGK_DATA_DIR: /var/lib/klangk/data
+      # §8 knob: how a pi container reaches the nginx front. The backend
+      # resolves this name to an IP and passes it via --add-host so passt
+      # can route workspace traffic through the backend's network namespace.
+      KLANGK_HOST_GATEWAY: "${KLANGK_HOST_GATEWAY:-nginx}"
+      KLANGK_INSTANCE_ID: "${KLANGK_INSTANCE_ID:-default}"
+      KLANGK_IMAGE_NAME: "${KLANGK_IMAGE_NAME:-klangk}"
+      # Where workspace images come from: `never` (default) = offline only
+      # (local + the §9/B additional store); `missing` = pull from a registry
+      # if absent locally; also `always`/`newer`.
+      KLANGK_IMAGE_PULL_POLICY: "${KLANGK_IMAGE_PULL_POLICY:-never}"
+      KLANGK_LLM_MODEL: "${KLANGK_LLM_MODEL:-}"
+      KLANGK_JWT_SECRET: "${KLANGK_JWT_SECRET}"
+      KLANGK_DEFAULT_USER: "${KLANGK_DEFAULT_USER:-}"
+      KLANGK_DEFAULT_PASSWORD: "${KLANGK_DEFAULT_PASSWORD:-}"
+      KLANGK_IDLE_TIMEOUT_SECONDS: "${KLANGK_IDLE_TIMEOUT_SECONDS:-1800}"
+      # SMTP (optional — for email verification / password reset).
+      KLANGK_SMTP_HOST: "${KLANGK_SMTP_HOST:-}"
+      KLANGK_SMTP_PORT: "${KLANGK_SMTP_PORT:-}"
+      KLANGK_SMTP_USER: "${KLANGK_SMTP_USER:-}"
+      KLANGK_SMTP_PASSWORD: "${KLANGK_SMTP_PASSWORD:-}"
+      KLANGK_SMTP_FROM: "${KLANGK_SMTP_FROM:-}"
+      KLANGK_SMTP_USE_TLS: "${KLANGK_SMTP_USE_TLS:-}"
+
+networks:
+  edge:
+    # Host-facing; only nginx attaches here.
+  internal:
+    # nginx <-> backend only; not reachable from the host.
+    internal: true
+

--- a/scripts/dockerbuild.sh
+++ b/scripts/dockerbuild.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-cd "${DEVENV_ROOT:-$SCRIPT_DIR/..}"
+REPO_ROOT="${DEVENV_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+cd "$REPO_ROOT"
+
+KLANGK_PLUGINS_DIR="${KLANGK_PLUGINS_DIR:-$REPO_ROOT/.devenv/state/klangk/plugins}"
+KLANGK_IMAGE_NAME="${KLANGK_IMAGE_NAME:-klangk}"
+KLANGK_INSTANCE_ID="${KLANGK_INSTANCE_ID:-default}"
 
 # Auto-fetch plugins on first run
 if [ -f "$KLANGK_PLUGINS_DIR/plugins.yaml" ] && [ ! -f "$KLANGK_PLUGINS_DIR/plugins.lock" ]; then
@@ -9,7 +14,7 @@ if [ -f "$KLANGK_PLUGINS_DIR/plugins.yaml" ] && [ ! -f "$KLANGK_PLUGINS_DIR/plug
   python3 scripts/update_plugins.py
 fi
 
-# Stage plugin files outside the source tree
+# Stage plugin files outside the source tree (empty staging is fine — no plugins)
 STAGING="$KLANGK_PLUGINS_DIR/.docker"
 rm -rf "$STAGING"
 mkdir -p "$STAGING/extensions" "$STAGING/tools"

--- a/scripts/run-pi-container.sh
+++ b/scripts/run-pi-container.sh
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
-# This script simulates the Docker run command used by container_manager.py
+# This script simulates the podman run command used by container.py
 
 # Using defaults based on the code for demonstration; replace with real paths if needed.
 HOST_PATH="/tmp/klangk-work-test"
 HOME_PATH="/tmp/klangk-home-test"
 WORKSPACE_ID="test-workspace-123"
-IMAGE_NAME="klangk-pi:latest"
+IMAGE_NAME="klangk:latest"
 
 # Ensure bind mount directories exist
 mkdir -p "$HOST_PATH"
 mkdir -p "$HOME_PATH"
 
-docker run -it --rm \
+podman run -it --rm \
   --name "klangk-test-container" \
   --label "klangk.managed=true" \
   --label "klangk.instance=default" \
@@ -21,9 +21,9 @@ docker run -it --rm \
   --tmpfs /run:rw,noexec,nosuid,size=16m \
   --tmpfs /var/log:rw,noexec,nosuid,size=16m \
   --mount type=bind,source="$HOME_PATH",target=/home/klangk \
-  --add-host=host.docker.internal:host-gateway \
+  --add-host=host.containers.internal:host-gateway \
   -p 9000:8000 -p 9001:8001 -p 9002:8002 -p 9003:8003 -p 9004:8004 \
-  -e KLANGK_LLM_PROXY_URL=http://host.docker.internal:8995/llm-proxy \
+  -e KLANGK_LLM_PROXY_URL=http://host.containers.internal:8995/llm-proxy \
   -e KLANGK_LLM_MODEL=gemma4:31b \
   -e PI_SKIP_VERSION_CHECK=1 \
   -e KLANGK_PORT_MAPPINGS=8000:9000,8001:9001,8002:9002,8003:9003,8004:9004 \

--- a/scripts/seed-workspace-image.sh
+++ b/scripts/seed-workspace-image.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# Seed the locally-built workspace image into the daemon stack's rootless
+# podman store (DOCKER.md §9). Fully local — NOTHING is pushed to any registry.
+#
+# The daemon's in-container podman runs with `--pull=never` by default, so the
+# `klangk` image must already be in its store. This transfers the image you
+# built with scripts/dockerbuild.sh into the running backend container's
+# rootless store, where it persists in the `klangk-podman-storage` volume.
+#
+# Prereqs:
+#   - the image is built locally:  scripts/dockerbuild.sh   (pulls public
+#     klangk-base; no credentials, no push)
+#   - the stack is running:        docker compose up -d
+#
+# Usage:
+#   scripts/seed-workspace-image.sh [IMAGE]      # IMAGE defaults to $KLANGK_IMAGE_NAME or "klangk"
+#
+# Env overrides:
+#   KLANGK_IMAGE_NAME   image tag to seed (default "klangk")
+#   COMPOSE_FILE        compose file (default docker-compose.yml at repo root)
+#   BACKEND_SERVICE     compose service name (default "backend")
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="${DEVENV_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+cd "$REPO_ROOT"
+
+IMAGE="${1:-${KLANGK_IMAGE_NAME:-klangk}}"
+BACKEND_SERVICE="${BACKEND_SERVICE:-backend}"
+TAG="$IMAGE:latest"
+TAR="/tmp/klangk-seed-$$.tar"
+REMOTE_TAR="/tmp/klangk-seed-$$.tar"
+
+cleanup() {
+  rm -f "$TAR" 2>/dev/null || true
+  docker compose exec -T --user root "$BACKEND_SERVICE" rm -f "$REMOTE_TAR" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# 1. The image must exist in the host docker engine (build it first).
+if ! docker image inspect "$TAG" >/dev/null 2>&1; then
+  echo "error: image '$TAG' not found in docker. Build it first:" >&2
+  echo "         scripts/dockerbuild.sh" >&2
+  exit 1
+fi
+
+# 2. The backend service must be running (we load into its live rootless store).
+if ! docker compose exec -T "$BACKEND_SERVICE" true >/dev/null 2>&1; then
+  echo "error: backend service '$BACKEND_SERVICE' is not running. Start it:" >&2
+  echo "         docker compose up -d" >&2
+  exit 1
+fi
+
+echo "==> Saving $TAG"
+docker save "$TAG" -o "$TAR"
+
+echo "==> Copying into the backend container"
+docker compose cp "$TAR" "$BACKEND_SERVICE:$REMOTE_TAR"
+# docker cp lands the file root-owned; the rootless user must be able to read it.
+docker compose exec -T --user root "$BACKEND_SERVICE" chmod 644 "$REMOTE_TAR"
+
+echo "==> Loading into the rootless podman store"
+docker compose exec -T "$BACKEND_SERVICE" podman load -i "$REMOTE_TAR"
+
+echo "==> Verifying 'podman create --pull=never $IMAGE' resolves"
+if docker compose exec -T "$BACKEND_SERVICE" podman image exists "$IMAGE"; then
+  echo "==> Done. '$IMAGE' is in the rootless store and persists in the"
+  echo "    klangk-podman-storage volume."
+else
+  echo "error: image not found in the store after load" >&2
+  exit 1
+fi

--- a/src/daemon/Dockerfile
+++ b/src/daemon/Dockerfile
@@ -1,0 +1,160 @@
+# syntax=docker/dockerfile:1
+#
+# Multi-stage build for the **klangk daemon** (FastAPI backend + rootless
+# Podman engine).  This is an alternative to the devenv/nix flow for shipping;
+# devenv.nix stays the source of truth for local dev.  See DOCKER.md §6.
+#
+# Build from the repo ROOT so both src/frontend and src/backend are in context:
+#   docker build -f src/daemon/Dockerfile -t klangk-daemon .
+#
+# The nginx front is a separate off-the-shelf service (see docker-compose.yml +
+# src/daemon/nginx.conf.template); this image is backend + engine only.
+
+# ---------------------------------------------------------------------------
+# Stage `web` — build the Flutter web assets (production flags only).
+# ---------------------------------------------------------------------------
+# NOTE: pinned to match devenv's nix toolchain (Flutter 3.41 / Dart 3.11 — see
+# the flterm comment in scripts/flutterbuildweb.sh).  The frontend pubspec floor
+# is only `flutter: ^3.27.0` / Dart `^3.6.0`, which 3.41 satisfies.  **This tag
+# is the one knob to confirm against your dev toolchain** — a mismatch here is
+# the most likely build break.
+FROM ghcr.io/cirruslabs/flutter:3.41.9 AS web
+
+# Replicate the repo layout (scripts/ and src/ as siblings under /repo) because
+# stub_dart_plugins.sh resolves the frontend as `$(dirname $0)/../src/frontend`.
+WORKDIR /repo
+# Scripts first (cache-friendly: rarely change relative to app code).
+COPY scripts/ /repo/scripts/
+COPY src/frontend/ /repo/src/frontend/
+
+# Stub the klangk_plugins package so `flutter pub get` resolves without the
+# full import_dart_plugins.py codegen (no plugins baked into the daemon image).
+RUN bash scripts/stub_dart_plugins.sh
+
+WORKDIR /repo/src/frontend
+# Production build: drop the dev-only flags (--source-maps, --no-minify-*,
+# --no-strip-wasm) and the inline_sources_in_map.py step that flutterbuildweb.sh
+# uses — those exist for devtools source resolution and bloat the assets.
+RUN flutter --disable-analytics \
+    && flutter pub get \
+    && flutter build web --wasm --release --base-href=/ --no-web-resources-cdn \
+    && rm -f build/web/flutter_service_worker.js
+
+# Cache-bust flutter_bootstrap.js by content hash (index.html is served
+# no-cache, so the ?v= query busts cached bootstrap/main.dart.* — mirrors
+# the tail of scripts/flutterbuildweb.sh).
+RUN set -eu; \
+    for f in main.dart.wasm main.dart.js; do \
+      if [ -f "build/web/$f" ]; then \
+        HASH=$(sha256sum "build/web/$f" | cut -c1-12); break; \
+      fi; \
+    done; \
+    sed -i "s|flutter_bootstrap.js|flutter_bootstrap.js?v=${HASH}|" build/web/index.html
+
+# ---------------------------------------------------------------------------
+# Stage `runtime` — backend (uvicorn) + rootless Podman-in-Docker.
+# ---------------------------------------------------------------------------
+# Based on debian:trixie-slim to match the proven rootless-podman recipe in
+# /home/bryan/src/podman_test (podman 5.x + passt).  trixie's python3 is 3.13,
+# which satisfies the backend's `requires-python >=3.12` and matches the dev
+# venv.  The rootless plumbing below (non-root user + subuid/subgid + setuid
+# newuidmap + fuse.conf) is the in-image half of DOCKER.md §7; the matching
+# host-side flags (devices, security_opt, cap_add) live in docker-compose.yml.
+FROM debian:trixie-slim AS runtime
+
+ARG USER=klangk
+ARG UID=1000
+ARG GID=1000
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Engine + rootless plumbing + backend runtime deps:
+#  - podman/crun/fuse-overlayfs: the in-process engine; nested rootless needs
+#    fuse-overlayfs (overlay2/vfs don't work cleanly nested, needs /dev/fuse).
+#  - uidmap: newuidmap/newgidmap setuid helpers for the rootless userns.
+#  - passt/slirp4netns: userspace networking for rootless containers (/dev/net/tun).
+#  - catatonit: tiny init for `podman run --init` (the pi containers use Init=True)
+#    and as this container's PID 1 reaper.
+#  - git/rsync: CLI shell-outs + workspace export/import.
+#  - python3: runs the backend (uv builds a venv against it).
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        catatonit \
+        curl \
+        crun \
+        fuse-overlayfs \
+        git \
+        passt \
+        podman \
+        python3 \
+        rsync \
+        slirp4netns \
+        uidmap \
+    && rm -rf /var/lib/apt/lists/*
+
+# Unprivileged user that runs uvicorn *and* rootless podman, with subuid/subgid
+# ranges so podman can map a range of IDs inside its user namespace.
+RUN groupadd -g ${GID} ${USER} \
+    && useradd -u ${UID} -g ${GID} -m -s /bin/bash ${USER} \
+    && printf '%s:100000:65536\n' "${USER}" > /etc/subuid \
+    && printf '%s:100000:65536\n' "${USER}" > /etc/subgid
+
+# Debian ships newuidmap/newgidmap with *file capabilities* (xattrs) that often
+# don't survive onto the overlay mount inside a container, dropping
+# CAP_SETUID/SETGID -> "newuidmap: write to uid_map failed: Operation not
+# permitted".  The plain setuid bit (inode mode) is always preserved; this is
+# what quay.io/podman/stable does for the same reason.
+RUN chmod 4755 /usr/bin/newuidmap /usr/bin/newgidmap
+
+# fuse-overlayfs uses /dev/fuse; allow non-root mounts.
+RUN echo 'user_allow_other' >> /etc/fuse.conf
+
+# Engine/storage/registry config tuned for rootless-in-a-container (see files).
+COPY src/daemon/containers.conf /etc/containers/containers.conf
+COPY src/daemon/storage.conf /etc/containers/storage.conf
+COPY src/daemon/registries.conf /etc/containers/registries.conf
+
+# Pinned uv, used to build a venv and install the backend.
+COPY --from=ghcr.io/astral-sh/uv:0.5.11 /uv /usr/local/bin/uv
+
+# Lay the source out so main.py's web-assets lookup resolves unchanged:
+# main.py does Path(__file__).parent.parent.parent / "frontend/build/web",
+# i.e. <src>/frontend/build/web.  Keep src/backend + src/frontend under /app/src
+# and install the backend EDITABLE so __file__ stays in the source tree.
+WORKDIR /app
+COPY src/backend/ /app/src/backend/
+ENV VIRTUAL_ENV=/opt/venv \
+    PATH=/opt/venv/bin:/usr/local/bin:/usr/bin:/bin
+RUN uv venv --python /usr/bin/python3 "$VIRTUAL_ENV" \
+    && uv pip install --no-cache -e /app/src/backend
+
+# Web assets from the build stage, at the path main.py expects.
+COPY --from=web /repo/src/frontend/build/web /app/src/frontend/build/web
+
+# Pre-create state dirs owned by the unprivileged user *before* the volumes
+# mount over them: a named volume whose path is absent (or root-owned) in the
+# image gets created root-owned, and rootless podman / the backend then can't
+# write inside it.  Covers both the app data dir and podman's rootless store.
+RUN mkdir -p /var/lib/klangk/data \
+             /home/${USER}/.local/share/containers \
+    && chown -R ${UID}:${GID} /var/lib/klangk /home/${USER}/.local
+
+# Backend defaults (overridable via compose environment).
+#  - KLANGK_HOST_GATEWAY: how a pi container reaches the nginx front. Default
+#    host.containers.internal is podman's native alias; this is the §8 knob to
+#    confirm during the smoke test (the backend also `--add-host`s it).
+ENV KLANGK_DATA_DIR=/var/lib/klangk/data \
+    KLANGK_PORT=8997 \
+    KLANGK_HOST_GATEWAY=host.containers.internal \
+    KLANGK_PODMAN_BIN=podman \
+    HOME=/home/${USER}
+
+USER ${USER}
+
+# Sanity-check at build time that the engine binary initialises.
+RUN podman --version
+
+EXPOSE 8997
+ENTRYPOINT ["/usr/bin/catatonit", "--"]
+# Shell form for ${KLANGK_PORT} expansion; flags mirror devenv.nix:89.
+CMD ["sh", "-c", "exec uvicorn klangk_backend.main:app --host 0.0.0.0 --port ${KLANGK_PORT} --ws-max-size 65536 --ws-ping-interval 20 --ws-ping-timeout 20"]

--- a/src/daemon/containers.conf
+++ b/src/daemon/containers.conf
@@ -1,0 +1,22 @@
+# Podman engine config for the rootless-in-Docker backend (DOCKER.md §7).
+# Mirrors the proven recipe in /home/bryan/src/podman_test.
+
+[containers]
+# slirp4netns/pasta is the only networking available rootless-in-a-container.
+netns = "private"
+# Podman sets net.ipv4.ping_group_range on every container by default; Docker
+# mounts /proc/sys read-only, so that write fails ("Read-only file system").
+# The compose backend service runs with `--security-opt systempaths=unconfined`
+# (podman's unmask=ALL equivalent) so this works.  Lighter alternative if you'd
+# rather keep /proc masked: uncomment the next line so podman never writes it
+# (trade-off: inner containers won't have ping_group_range set).
+# default_sysctls = []
+
+[engine]
+# No systemd/journald inside the container -> manage cgroups directly, log
+# events to a file, and run crun (low-footprint, cgroup-v2 friendly).
+cgroup_manager = "cgroupfs"
+events_logger = "file"
+runtime = "crun"
+# Init binary for `podman run --init` (the pi/workspace containers set Init=True).
+init_path = "/usr/bin/catatonit"

--- a/src/daemon/nginx.conf.template
+++ b/src/daemon/nginx.conf.template
@@ -1,0 +1,106 @@
+# Production nginx config for the klangk daemon stack (DOCKER.md §6).
+#
+# Rendered at container start by the official nginx:alpine image's
+# `20-envsubst-on-templates.sh`.  This is a FULL nginx.conf (not a conf.d
+# server block), so the compose `nginx` service must:
+#   - mount this file at /etc/nginx/templates/nginx.conf.template
+#   - set NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx   (so it renders to
+#     /etc/nginx/nginx.conf, replacing the stock config, instead of conf.d/)
+# envsubst only replaces variables that are actually exported, so nginx's own
+# runtime vars ($http_upgrade, $scheme, regex captures $1/$2, ...) pass through
+# untouched.  Required env: KLANGK_NGINX_PORT, KLANGK_PORT, KLANGK_LLM_BASE_URL,
+# KLANGK_LLM_API_KEY.
+#
+# Lifted from scripts/nginx.sh with two changes for the compose stack:
+#   - upstreams point at the `backend` service instead of 127.0.0.1
+#     (nginx and backend are separate containers on the `internal` network)
+#   - /hosted/ proxies to backend:<port>, since the workspace-container ports
+#     are published into the backend container's network namespace by Podman.
+
+# NB: no `daemon off;` here — the official nginx image already passes
+# `-g 'daemon off;'`, and a duplicate directive is a fatal config error.
+pid /tmp/nginx.pid;
+error_log stderr;
+events { worker_connections 64; }
+http {
+  access_log /dev/stdout;
+  client_body_temp_path /tmp/nginx_client_body;
+  proxy_temp_path /tmp/nginx_proxy;
+  fastcgi_temp_path /tmp/nginx_fastcgi;
+  uwsgi_temp_path /tmp/nginx_uwsgi;
+  scgi_temp_path /tmp/nginx_scgi;
+
+  map $http_upgrade $connection_upgrade {
+    default upgrade;
+    "" close;
+  }
+
+  client_max_body_size 500m;
+
+  # Resolve upstreams at request time, not config-load. 127.0.0.11 is Docker's
+  # embedded DNS (always present under compose).  Without this, a `proxy_pass`
+  # to a hostname behind a variable (the LLM endpoint and the hosted-app
+  # `backend:$port` below) is resolved at startup, so an unresolvable/down LLM
+  # host would crash the whole front — login + UI included.  With it, those
+  # upstreams fail at request time (502) and the rest of the daemon stays up.
+  resolver 127.0.0.11 valid=10s ipv6=off;
+
+  server {
+    listen ${KLANGK_NGINX_PORT};
+
+    # Hosted app proxy: extract port from URL and proxy to the backend
+    # container (where Podman published the workspace ports).  `backend` is in
+    # a variable-bearing proxy_pass, so it resolves via the resolver above.
+    location ~ ^/hosted/[^/]+/(\d+)/(.*)$ {
+      proxy_pass http://backend:$1/$2$is_args$args;
+      proxy_set_header Host $http_host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_http_version 1.1;
+    }
+
+    # LLM proxy: forward to the real LLM endpoint with API key injected.
+    # Workspace containers hit this instead of the real endpoint, so they
+    # never see the API key. Restricted to private subnets and localhost.
+    # Variable proxy_pass (+ resolver) so a down LLM endpoint doesn't block
+    # nginx startup; the regex capture replaces the old prefix-strip behavior.
+    location ~ ^/llm-proxy/(.*)$ {
+      allow 172.16.0.0/12;
+      allow 192.168.0.0/16;
+      allow 10.0.0.0/8;
+      allow 127.0.0.1;
+      deny all;
+      # Base URL in a variable so proxy_pass defers DNS to the resolver above.
+      set $llm_base "${KLANGK_LLM_BASE_URL}";
+      proxy_pass $llm_base/$1$is_args$args;
+      proxy_set_header Authorization "Bearer ${KLANGK_LLM_API_KEY}";
+      proxy_set_header Host $proxy_host;
+      proxy_http_version 1.1;
+      proxy_set_header Connection "";
+      # SSE streaming support
+      proxy_buffering off;
+      proxy_cache off;
+      chunked_transfer_encoding on;
+    }
+
+    location / {
+      proxy_pass http://backend:${KLANGK_PORT}/;
+      proxy_set_header Host $http_host;
+      proxy_set_header X-Real-IP $remote_addr;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+      # Pass through X-Forwarded-* from an outer proxy, or default for direct access
+      set $fwd_proto $http_x_forwarded_proto;
+      if ($fwd_proto = "") { set $fwd_proto $scheme; }
+      proxy_set_header X-Forwarded-Proto $fwd_proto;
+      proxy_set_header X-Forwarded-Host $http_x_forwarded_host;
+      proxy_set_header X-Forwarded-Prefix $http_x_forwarded_prefix;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection $connection_upgrade;
+      # Keep WebSocket connections alive — default 60 s would drop idle terminals.
+      proxy_read_timeout 3600s;
+      proxy_send_timeout 3600s;
+    }
+  }
+}

--- a/src/daemon/registries.conf
+++ b/src/daemon/registries.conf
@@ -1,0 +1,5 @@
+# Default registry search list (Debian's podman ships this unset).
+# Used only when seeding the workspace-image store offline; at runtime the
+# backend creates workspace containers with `--pull=never`, so no registry is
+# ever contacted for the airgapped deployment (DOCKER.md §9/B).
+unqualified-search-registries = ["docker.io"]

--- a/src/daemon/storage.conf
+++ b/src/daemon/storage.conf
@@ -1,0 +1,25 @@
+# Podman storage config for the rootless-in-Docker backend (DOCKER.md §7, §9/B).
+#
+# Nested rootless Podman cannot use overlay2/vfs cleanly, so the storage driver
+# is overlay via fuse-overlayfs (the `fuse-overlayfs` binary + /dev/fuse must be
+# present — both supplied by the image and the compose device passthrough).
+# graphroot/runroot are intentionally omitted: rootless podman manages them
+# under $HOME/.local/share/containers, which is persisted by a named volume.
+
+[storage]
+driver = "overlay"
+
+[storage.options]
+mount_program = "/usr/bin/fuse-overlayfs"
+
+[storage.options.overlay]
+mountopt = "nodev,fsync=0"
+
+# §9/B — read-only additional image store(s).  The prebuilt `klangk` workspace
+# image is seeded offline (CI `podman build`/`pull` + export) and mounted here
+# read-only; writable container layers still go to the rootless store above.
+# Enable by mounting the store at this path (compose volume) and uncommenting:
+#
+# additionalimagestores = [
+#   "/var/lib/klangk-images",
+# ]

--- a/src/docker/workspace/bash.bashrc
+++ b/src/docker/workspace/bash.bashrc
@@ -30,7 +30,7 @@ alias ls='ls --color=auto'
 alias grep='grep --color=auto'
 
 # Determine which command to exec into (if any).
-# KLANGK_CMD_OVERRIDE (set per-session via docker exec -e) takes priority.
+# KLANGK_CMD_OVERRIDE (set per-session via podman exec -e) takes priority.
 # Otherwise fall back to the workspace default from the config mount.
 # KLANGK_CMD_STARTED guard prevents infinite recursion if the command is bash.
 if [ -z "$KLANGK_CMD_STARTED" ]; then

--- a/src/docker/workspace/entrypoint.sh
+++ b/src/docker/workspace/entrypoint.sh
@@ -25,10 +25,10 @@ chown klangk:klangk /home/klangk /home/klangk/work
 # terminal sessions find everything in place.
 su -c "python3 /usr/local/bin/setup_clankers" klangk
 
-# Signal that setup is complete. Terminal sessions (docker exec) source
+# Signal that setup is complete. Terminal sessions (podman exec) source
 # /etc/bash.bashrc which waits for this file before showing a prompt.
 # /tmp is a tmpfs, so .klangk-ready is cleared on every container start.
 touch /tmp/.klangk-ready
 
-# Keep the container alive. Terminal sessions are started via docker exec.
+# Keep the container alive. Terminal sessions are started via podman exec.
 exec sleep infinity


### PR DESCRIPTION
Stack 6/9 (base: `drop-aiodocker`).

Two-service compose stack (nginx + backend-with-rootless-podman): daemon Dockerfile, `containers.conf`/`registries.conf`/`storage.conf` (read-only additional image store, `--pull=never` airgap), `nginx.conf.template`, workspace-image seeding script, and workspace entrypoint tweaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)