### PR TITLE
PR8: harden(isolation) restrict workspace bind mounts & foreign volumes

### DIFF
--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -85,12 +85,76 @@ _VALID_MOUNT_OPTIONS = {
 }
 
 
+def _is_named_volume(source: str) -> bool:
+    """A mount source with no '/' that doesn't start with '.' is a volume."""
+    return "/" not in source and not source.startswith(".")
+
+
+def _allowed_mount_roots() -> list[str]:
+    """Host directory prefixes that may be bind-mounted into workspaces.
+
+    Read from KLANGK_ALLOWED_MOUNT_SOURCES (comma-separated). Empty (the
+    default) means host bind mounts are disabled entirely — only named
+    volumes are permitted.
+    """
+    raw = util.resolve_env_secret("KLANGK_ALLOWED_MOUNT_SOURCES", "") or ""
+    return [p.strip() for p in raw.split(",") if p.strip()]
+
+
+def _protected_mount_roots() -> list[str]:
+    """Host paths that must never be bind-mounted, regardless of allowlist.
+
+    Covers the container-engine sockets (mounting one is a full host-control
+    breakout) and the klangk data directory (mounting it exposes every other
+    user's workspace home and the database — a cross-workspace break).
+    """
+    data_dir = (
+        util.resolve_env_secret(
+            "KLANGK_DATA_DIR", os.path.expanduser("~/.klangk/data")
+        )
+        or os.path.expanduser("~/.klangk/data")
+    )
+    return [
+        "/var/run/docker.sock",
+        "/run/docker.sock",
+        "/run/podman/podman.sock",
+        os.path.realpath(data_dir),
+    ]
+
+
+def _under(path: str, root: str) -> bool:
+    """True if *path* equals *root* or is nested beneath it."""
+    root = root.rstrip("/")
+    return path == root or path.startswith(root + "/")
+
+
+def _validate_bind_source(source: str) -> str | None:
+    """Validate a host bind-mount source against the block/allow lists."""
+    resolved = os.path.realpath(source)
+    for blocked in _protected_mount_roots():
+        if _under(resolved, blocked):
+            return (
+                f"Invalid mount {source!r}: source is a protected host path"
+            )
+    roots = _allowed_mount_roots()
+    if not roots:
+        return (
+            f"Invalid mount {source!r}: host bind mounts are disabled "
+            "(set KLANGK_ALLOWED_MOUNT_SOURCES to permit specific roots)"
+        )
+    if any(_under(resolved, os.path.realpath(r)) for r in roots):
+        return None
+    return f"Invalid mount {source!r}: source is outside the allowed roots"
+
+
 def validate_mount_spec(spec: str) -> str | None:
     """Validate a Docker mount spec string.
 
     Returns None if valid, or an error message string if invalid.
     Valid forms: source:dest or source:dest:options
-    The container path (dest) must be absolute.
+    The container path (dest) must be absolute. Host bind-mount sources are
+    restricted to KLANGK_ALLOWED_MOUNT_SOURCES (default: none) and may never
+    target a protected path (engine sockets, the klangk data dir).
     """
     parts = spec.split(":")
     if len(parts) < 2 or len(parts) > 3:
@@ -105,6 +169,10 @@ def validate_mount_spec(spec: str) -> str | None:
         for opt in options.split(","):
             if opt and opt not in _VALID_MOUNT_OPTIONS:
                 return f"Invalid mount {spec!r}: unknown option {opt!r}"
+    if not _is_named_volume(source):
+        bind_err = _validate_bind_source(source)
+        if bind_err:
+            return bind_err
     return None
 
 
@@ -440,9 +508,12 @@ class ContainerRegistry:
         if extra_mounts:
             for mount_spec in extra_mounts:
                 source = mount_spec.split(":")[0]
-                if "/" not in source and not source.startswith("."):
-                    # Named volume — ensure it exists with klangk labels
-                    if await podman.inspect_volume(source) is None:
+                if _is_named_volume(source):
+                    # Named volume — create it (labelled) if absent, else
+                    # refuse to mount a volume owned by another instance so a
+                    # workspace can't attach a foreign/other-tenant volume.
+                    info = await podman.inspect_volume(source)
+                    if info is None:
                         await podman.create_volume(
                             source,
                             {
@@ -450,6 +521,13 @@ class ContainerRegistry:
                                 "klangk.instance": INSTANCE_ID,
                             },
                         )
+                    else:
+                        labels = info.get("Labels") or {}
+                        if labels.get("klangk.instance") != INSTANCE_ID:
+                            raise ValueError(
+                                f"Volume {source!r} is not managed by this "
+                                "klangk instance"
+                            )
 
         binds = [
             f"{home_path}:/home/klangk",

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -638,7 +638,8 @@ class TestWorkspaceRoutes:
         assert resp.status_code == 400
         assert "Invalid mount" in resp.json()["detail"]
 
-    async def test_create_with_valid_mount(self, client, user):
+    async def test_create_with_valid_mount(self, client, user, monkeypatch):
+        monkeypatch.setenv("KLANGK_ALLOWED_MOUNT_SOURCES", "/tmp")
         headers = await _auth_headers(client)
         resp = await client.post(
             "/workspaces",
@@ -646,6 +647,20 @@ class TestWorkspaceRoutes:
             json={"name": "good-mount", "mounts": ["/tmp:/mnt/tmp"]},
         )
         assert resp.status_code == 200
+
+    async def test_create_with_disallowed_bind_mount(
+        self, client, user, monkeypatch
+    ):
+        # No allowlist configured → host bind mounts are rejected.
+        monkeypatch.delenv("KLANGK_ALLOWED_MOUNT_SOURCES", raising=False)
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/workspaces",
+            headers=headers,
+            json={"name": "denied-mount", "mounts": ["/tmp:/mnt/tmp"]},
+        )
+        assert resp.status_code == 400
+        assert "Invalid mount" in resp.json()["detail"]
 
     async def test_list_images(self, client, user):
         headers = await _auth_headers(client)
@@ -844,7 +859,8 @@ class TestWorkspaceRoutes:
         assert resp.status_code == 400
         assert "Invalid mount" in resp.json()["detail"]
 
-    async def test_duplicate_workspace(self, client, user):
+    async def test_duplicate_workspace(self, client, user, monkeypatch):
+        monkeypatch.setenv("KLANGK_ALLOWED_MOUNT_SOURCES", "/tmp")
         headers = await _auth_headers(client)
         resp = await client.post(
             "/workspaces",

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -836,16 +836,61 @@ class TestStartContainerPortConflict:
 
 
 class TestValidateMountSpec:
-    def test_valid_bind_mount(self):
+    @pytest.fixture(autouse=True)
+    def _isolate_mount_env(self, monkeypatch):
+        # Default: no allowlist (host bind mounts disabled) and a stable
+        # data dir so the protected-path check is deterministic.
+        monkeypatch.delenv("KLANGK_ALLOWED_MOUNT_SOURCES", raising=False)
+        monkeypatch.setenv("KLANGK_DATA_DIR", "/srv/klangk/data")
+
+    def _allow(self, monkeypatch, *roots):
+        monkeypatch.setenv("KLANGK_ALLOWED_MOUNT_SOURCES", ",".join(roots))
+
+    def test_bind_mount_disabled_by_default(self):
+        err = container.validate_mount_spec("/host:/container")
+        assert err is not None
+        assert "disabled" in err.lower()
+
+    def test_bind_mount_allowed_when_listed(self, monkeypatch):
+        self._allow(monkeypatch, "/host")
         assert container.validate_mount_spec("/host:/container") is None
 
+    def test_bind_mount_subdir_of_allowed_root(self, monkeypatch):
+        self._allow(monkeypatch, "/host")
+        assert container.validate_mount_spec("/host/sub:/container") is None
+
+    def test_bind_mount_outside_allowed_roots(self, monkeypatch):
+        self._allow(monkeypatch, "/host")
+        err = container.validate_mount_spec("/elsewhere:/container")
+        assert err is not None
+        assert "outside the allowed roots" in err.lower()
+
+    def test_protected_socket_always_blocked(self, monkeypatch):
+        self._allow(monkeypatch, "/")  # even an all-permitting allowlist
+        err = container.validate_mount_spec(
+            "/var/run/docker.sock:/var/run/docker.sock"
+        )
+        assert err is not None
+        assert "protected" in err.lower()
+
+    def test_protected_data_dir_always_blocked(self, monkeypatch):
+        self._allow(monkeypatch, "/")
+        err = container.validate_mount_spec(
+            "/srv/klangk/data/workspaces/other:/loot"
+        )
+        assert err is not None
+        assert "protected" in err.lower()
+
     def test_valid_volume_mount(self):
+        # Named volumes are unaffected by the bind-source allowlist.
         assert container.validate_mount_spec("vol-name:/data") is None
 
-    def test_valid_with_options(self):
+    def test_valid_with_options(self, monkeypatch):
+        self._allow(monkeypatch, "/host")
         assert container.validate_mount_spec("/host:/container:ro") is None
 
-    def test_valid_with_multiple_options(self):
+    def test_valid_with_multiple_options(self, monkeypatch):
+        self._allow(monkeypatch, "/host")
         assert (
             container.validate_mount_spec("/host:/container:ro,nocopy") is None
         )
@@ -874,10 +919,12 @@ class TestValidateMountSpec:
         assert err is not None
         assert "unknown option" in err.lower()
 
-    def test_validate_mounts_list(self):
+    def test_validate_mounts_list(self, monkeypatch):
+        self._allow(monkeypatch, "/a")
         assert container.validate_mounts(["/a:/b", "vol:/c"]) is None
 
-    def test_validate_mounts_list_with_error(self):
+    def test_validate_mounts_list_with_error(self, monkeypatch):
+        self._allow(monkeypatch, "/a")
         err = container.validate_mounts(["/a:/b", "bad"])
         assert err is not None
 
@@ -900,9 +947,14 @@ class TestExtraMountsVolumeCreation:
         assert labels["klangk.instance"] == container.INSTANCE_ID
 
     async def test_existing_volume_not_recreated(self, workspace):
-        """Existing volumes are used as-is, not recreated."""
+        """Existing volumes owned by this instance are used as-is."""
         with patch_podman(
-            inspect_volume=AsyncMock(return_value={"Name": "existing"})
+            inspect_volume=AsyncMock(
+                return_value={
+                    "Name": "existing",
+                    "Labels": {"klangk.instance": container.INSTANCE_ID},
+                }
+            )
         ) as p:
             await container.registry.start_container(
                 workspace["id"],
@@ -911,6 +963,37 @@ class TestExtraMountsVolumeCreation:
                 extra_mounts=["existing:/data"],
             )
         p.create_volume.assert_not_awaited()
+
+    async def test_foreign_volume_rejected(self, workspace):
+        """A named volume owned by another instance is refused."""
+        with patch_podman(
+            inspect_volume=AsyncMock(
+                return_value={
+                    "Name": "stolen",
+                    "Labels": {"klangk.instance": "someone-else"},
+                }
+            )
+        ):
+            with pytest.raises(ValueError, match="not managed by this"):
+                await container.registry.start_container(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    extra_mounts=["stolen:/data"],
+                )
+
+    async def test_unlabelled_volume_rejected(self, workspace):
+        """A named volume with no klangk labels is refused."""
+        with patch_podman(
+            inspect_volume=AsyncMock(return_value={"Name": "bare"})
+        ):
+            with pytest.raises(ValueError, match="not managed by this"):
+                await container.registry.start_container(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    extra_mounts=["bare:/data"],
+                )
 
     async def test_bind_mount_not_treated_as_volume(self, workspace):
         """Bind mounts (starting with /) are not treated as volumes."""


### PR DESCRIPTION
Stack 8/9 (base: `migration-docs`).

**C2:** host bind-mount sources denied by default; operators opt in specific roots via `KLANGK_ALLOWED_MOUNT_SOURCES`. Engine sockets and the klangk data dir are always blocked (the latter prevented a workspace mounting another user's home or the DB). Enforced in `validate_mount_spec` at create/update/import.

**C3:** an `extra_mount` naming an *existing* volume is refused unless its `klangk.instance` label matches — stops attaching a foreign/other-tenant volume by name.

Tests updated for the default-deny posture; added blocked-socket/data-dir, allowlist, and foreign/unlabelled-volume cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)