### PR TITLE
PR9: harden(auth) reject default JWT secret; require verified OIDC email

### DIFF
--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -726,6 +726,19 @@ async def oidc_callback(
         )
     auth.validate_email(email)
 
+    # Require a verified email before trusting it to link/provision an
+    # account — otherwise an IdP user who can assert an arbitrary email could
+    # take over an existing local account (e.g. the seeded admin). Providers
+    # known to verify email out of band can opt out via trust_unverified_email.
+    if (
+        claims.get("email_verified") is not True
+        and not provider.trust_unverified_email
+    ):
+        raise HTTPException(
+            status_code=403,
+            detail="Email not verified by identity provider",
+        )
+
     # Find or create user
     user = await model.get_user_by_external_id(provider_id, sub)
     if user is None:

--- a/src/backend/klangk_backend/auth.py
+++ b/src/backend/klangk_backend/auth.py
@@ -1,3 +1,4 @@
+import logging
 import re
 import uuid
 from datetime import datetime, timedelta, timezone
@@ -10,6 +11,8 @@ from pydantic import BaseModel
 
 from . import model
 from .util import resolve_env_secret
+
+logger = logging.getLogger(__name__)
 
 # --- Rate limiting constants ---
 LOGIN_LOCKOUT_WINDOW = int(
@@ -53,11 +56,40 @@ def _should_lockout(attempt_info: dict | None) -> bool:
     )  # pragma: no cover
 
 
-SECRET_KEY = resolve_env_secret(
-    "KLANGK_JWT_SECRET", "klangk-dev-secret-change-in-production"
-)
+_INSECURE_DEFAULT_SECRET = "klangk-dev-secret-change-in-production"
+SECRET_KEY = resolve_env_secret("KLANGK_JWT_SECRET", _INSECURE_DEFAULT_SECRET)
 ALGORITHM = "HS256"
 TOKEN_EXPIRE_HOURS = 24
+
+
+def jwt_secret_is_secure() -> bool:
+    """True if a non-empty, non-default JWT signing secret is configured."""
+    return bool(SECRET_KEY) and SECRET_KEY != _INSECURE_DEFAULT_SECRET
+
+
+def require_secure_jwt_secret() -> None:
+    """Fail closed at startup unless a strong JWT secret is configured.
+
+    With the unset/default secret, anyone can forge tokens for any user or
+    role. The insecure default is permitted only when
+    KLANGK_ALLOW_INSECURE_JWT_SECRET is truthy (local dev / tests).
+    """
+    if jwt_secret_is_secure():
+        return
+    allow = (
+        resolve_env_secret("KLANGK_ALLOW_INSECURE_JWT_SECRET", "") or ""
+    ).lower()
+    if allow in ("1", "true", "yes"):
+        logger.warning(
+            "KLANGK_JWT_SECRET is unset or the insecure default; allowed "
+            "only because KLANGK_ALLOW_INSECURE_JWT_SECRET is set. Do NOT "
+            "use this in production."
+        )
+        return
+    raise RuntimeError(
+        "KLANGK_JWT_SECRET is unset or the insecure default. Set a strong "
+        "secret (or KLANGK_ALLOW_INSECURE_JWT_SECRET=1 for local dev)."
+    )
 
 MIN_PASSWORD_LENGTH = int(
     resolve_env_secret("KLANGK_MIN_PASSWORD_LENGTH", "4")

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -135,6 +135,9 @@ async def seed_default_user() -> None:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    from . import auth
+
+    auth.require_secure_jwt_secret()
     await model.init_db()
     oidc.init_providers()
     oidc.load_group_hook()

--- a/src/backend/klangk_backend/oidc.py
+++ b/src/backend/klangk_backend/oidc.py
@@ -37,6 +37,10 @@ class OIDCProvider:
     ca_cert: str | None = None  # path to CA cert PEM for custom trust
     token_validation_pem: str | None = None  # static RSA/EC public key PEM
     logout_redirect: bool = False  # redirect to IdP logout on user logout
+    # Trust the email claim even when the IdP omits/!email_verified. Only
+    # enable for providers that are known to verify email out of band; an
+    # unverified email is otherwise an account-takeover vector.
+    trust_unverified_email: bool = False
 
 
 @dataclass
@@ -93,6 +97,9 @@ def load_config() -> list[OIDCProvider]:
                 ca_cert=ca_cert,
                 token_validation_pem=entry.get("token_validation_pem"),
                 logout_redirect=entry.get("logout_redirect", False),
+                trust_unverified_email=entry.get(
+                    "trust_unverified_email", False
+                ),
             )
         )
     return providers

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -4546,6 +4546,7 @@ class TestOIDCCallback:
         default_claims = {
             "sub": "oidc-sub-123",
             "email": "oidcuser@example.com",
+            "email_verified": True,
         }
         if claims:
             default_claims.update(claims)
@@ -4874,6 +4875,47 @@ class TestOIDCCallback:
         )
         assert resp.status_code == 502
         assert "missing" in resp.json()["detail"].lower()
+
+    async def test_callback_unverified_email_rejected(
+        self, client, monkeypatch, db
+    ):
+        """An unverified email claim is refused (account-takeover guard)."""
+        _, cookie_data = await self._setup_callback(
+            client,
+            monkeypatch,
+            db,
+            claims={"email_verified": False},
+        )
+        resp = await client.get(
+            "/auth/oidc/test/callback",
+            params={"code": "auth-code", "state": "test-state"},
+            cookies={"oidc_test": cookie_data},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 403
+        assert "not verified" in resp.json()["detail"].lower()
+        # No account was provisioned from the unverified claim.
+        assert await model.get_user_by_email("oidcuser@example.com") is None
+
+    async def test_callback_unverified_email_trusted_provider(
+        self, client, monkeypatch, db
+    ):
+        """trust_unverified_email lets a trusted IdP skip the check."""
+        provider, cookie_data = await self._setup_callback(
+            client,
+            monkeypatch,
+            db,
+            claims={"email_verified": False},
+        )
+        provider.trust_unverified_email = True
+        resp = await client.get(
+            "/auth/oidc/test/callback",
+            params={"code": "auth-code", "state": "test-state"},
+            cookies={"oidc_test": cookie_data},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        assert await model.get_user_by_email("oidcuser@example.com") is not None
 
     async def test_callback_unknown_provider(self, client, monkeypatch, db):
         monkeypatch.setattr(api.oidc, "get_provider", lambda _: None)

--- a/src/backend/tests/test_auth.py
+++ b/src/backend/tests/test_auth.py
@@ -589,3 +589,38 @@ class TestInvitationsEnabled:
     def test_disabled(self, monkeypatch):
         monkeypatch.setenv("KLANGK_DISABLE_INVITES", "true")
         assert auth.invitations_enabled() is False
+
+
+class TestRequireSecureJwtSecret:
+    def test_secure_secret_passes(self, monkeypatch):
+        monkeypatch.setattr(auth, "SECRET_KEY", "a-real-strong-secret")
+        assert auth.jwt_secret_is_secure() is True
+        auth.require_secure_jwt_secret()  # no raise
+
+    def test_default_secret_is_insecure(self, monkeypatch):
+        monkeypatch.setattr(
+            auth, "SECRET_KEY", auth._INSECURE_DEFAULT_SECRET
+        )
+        assert auth.jwt_secret_is_secure() is False
+
+    def test_default_secret_blocks_startup(self, monkeypatch):
+        monkeypatch.setattr(
+            auth, "SECRET_KEY", auth._INSECURE_DEFAULT_SECRET
+        )
+        monkeypatch.delenv("KLANGK_ALLOW_INSECURE_JWT_SECRET", raising=False)
+        with pytest.raises(RuntimeError, match="KLANGK_JWT_SECRET"):
+            auth.require_secure_jwt_secret()
+
+    def test_empty_secret_blocks_startup(self, monkeypatch):
+        monkeypatch.setattr(auth, "SECRET_KEY", "")
+        monkeypatch.delenv("KLANGK_ALLOW_INSECURE_JWT_SECRET", raising=False)
+        assert auth.jwt_secret_is_secure() is False
+        with pytest.raises(RuntimeError):
+            auth.require_secure_jwt_secret()
+
+    def test_insecure_allowed_with_optin(self, monkeypatch):
+        monkeypatch.setattr(
+            auth, "SECRET_KEY", auth._INSECURE_DEFAULT_SECRET
+        )
+        monkeypatch.setenv("KLANGK_ALLOW_INSECURE_JWT_SECRET", "1")
+        auth.require_secure_jwt_secret()  # no raise

--- a/src/backend/tests/test_main.py
+++ b/src/backend/tests/test_main.py
@@ -58,6 +58,9 @@ class TestLifespan:
     async def test_lifespan_starts_and_stops(self, db, monkeypatch):
         monkeypatch.delenv("KLANGK_OIDC_CONFIG", raising=False)
         monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
+        # Tests run with the insecure default JWT secret; allow it explicitly
+        # so the startup guard doesn't abort lifespan.
+        monkeypatch.setenv("KLANGK_ALLOW_INSECURE_JWT_SECRET", "1")
         app = FastAPI()
         with (
             patch.object(


### PR DESCRIPTION
Stack 9/9 (base: `harden-workspace-isolation`).

**M1:** fail closed at startup (`auth.require_secure_jwt_secret`, called from lifespan) when `KLANGK_JWT_SECRET` is unset or the insecure dev default — otherwise anyone can forge admin tokens. Dev/tests opt in via `KLANGK_ALLOW_INSECURE_JWT_SECRET=1`.

**H4:** the OIDC callback now requires `claims["email_verified"] is True` before linking/provisioning a local account, closing an account-takeover path (an IdP user asserting a victim's unverified email — e.g. the seeded admin). Providers that verify email out of band opt out per-provider via `trust_unverified_email`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)