### PR TITLE
feat(workspace): focus the active pane's input on tab select

### DIFF
--- a/src/frontend/lib/chat/workspace_chat.dart
+++ b/src/frontend/lib/chat/workspace_chat.dart
@@ -30,6 +30,7 @@ class WorkspaceChatState extends State<WorkspaceChat> {
   final List<Map<String, dynamic>> _messages = [];
   final _scrollController = ScrollController();
   final _textController = TextEditingController();
+  final _inputFocusNode = FocusNode(debugLabel: 'workspace-chat-input');
   StreamSubscription<Map<String, dynamic>>? _chatSub;
   int _unreadCount = 0;
   bool _isVisible = false;
@@ -43,6 +44,10 @@ class WorkspaceChatState extends State<WorkspaceChat> {
     }
     _chatSub = widget.wsClient.chatMessages.listen(_onMessage);
   }
+
+  /// Focuses the message input. Called by the parent when the Chat tab is
+  /// selected so the user can type immediately without an extra click.
+  void requestFocus() => _inputFocusNode.requestFocus();
 
   /// Called by the parent when this tab becomes visible/hidden.
   void setVisible(bool visible) {
@@ -184,6 +189,7 @@ class WorkspaceChatState extends State<WorkspaceChat> {
     _chatSub?.cancel();
     _scrollController.dispose();
     _textController.dispose();
+    _inputFocusNode.dispose();
     super.dispose();
   }
 
@@ -278,6 +284,7 @@ class WorkspaceChatState extends State<WorkspaceChat> {
                 Expanded(
                   child: TextField(
                     controller: _textController,
+                    focusNode: _inputFocusNode,
                     style: const TextStyle(
                       color: KColors.textPrimary,
                       fontSize: 13,

--- a/src/frontend/lib/layout/ide_layout.dart
+++ b/src/frontend/lib/layout/ide_layout.dart
@@ -45,17 +45,43 @@ class _IdeLayoutState extends State<IdeLayout> {
   static const _minDebugHeight = 0.0;
   static const _maxDebugHeight = 500.0;
 
+  @override
+  void initState() {
+    super.initState();
+    // Focus the pane shown first (Terminal by default) so the user can type
+    // immediately on workspace open, without an extra click into it.
+    _focusPane(_selectedIndex);
+  }
+
   void _selectTab(int index) {
-    if (index == _selectedIndex) return;
-    setState(() => _selectedIndex = index);
-    if (index == 0) {
-      widget.terminalKey?.currentState?.requestFocus();
-    } else if (index == 1) {
-      widget.fileViewerKey?.currentState?.refresh();
+    final changed = index != _selectedIndex;
+    if (changed) {
+      setState(() => _selectedIndex = index);
+      if (index == 1) {
+        widget.fileViewerKey?.currentState?.refresh();
+      }
+      // Notify chat widget of visibility change.
+      final chatIdx = widget.chat != null ? 2 : -1;
+      widget.chatKey?.currentState?.setVisible(index == chatIdx);
     }
-    // Notify chat widget of visibility change
+    // Always (re)focus the tab's input — even when re-clicking the already
+    // active tab — so clicking Terminal/Chat returns focus to its input.
+    _focusPane(index);
+  }
+
+  /// Focuses the input of the pane at [index] (Terminal or Chat). Deferred to
+  /// after the frame so the target's FocusNode is attached and the pane is
+  /// visible in the IndexedStack before we request focus.
+  void _focusPane(int index) {
     final chatIdx = widget.chat != null ? 2 : -1;
-    widget.chatKey?.currentState?.setVisible(index == chatIdx);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      if (index == 0) {
+        widget.terminalKey?.currentState?.requestFocus();
+      } else if (index == chatIdx) {
+        widget.chatKey?.currentState?.requestFocus();
+      }
+    });
   }
 
   @override

--- a/src/frontend/test/workspace_chat_test.dart
+++ b/src/frontend/test/workspace_chat_test.dart
@@ -471,6 +471,20 @@ void main() {
       expect(unreadCounts, [1, 0]);
     });
 
+    testWidgets('requestFocus focuses the message input', (tester) async {
+      final chatKey = GlobalKey<WorkspaceChatState>();
+      await tester.pumpWidget(buildChat(chatKey: chatKey));
+
+      final field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.focusNode, isNotNull);
+      expect(field.focusNode!.hasFocus, isFalse);
+
+      chatKey.currentState!.requestFocus();
+      await tester.pump();
+
+      expect(field.focusNode!.hasFocus, isTrue);
+    });
+
     testWidgets('loads buffered chat history on init', (tester) async {
       // Pre-populate the buffer before building the widget
       client.chatHistory.addAll([


### PR DESCRIPTION
## What

Clicking the **Terminal** or **Chat** tab now focuses that pane's input, so you can type immediately without an extra click. The default pane (Terminal) is also focused on workspace open, and re-clicking the already-active tab re-focuses it.

## Why

Previously `_selectTab` only requested terminal focus when *switching* to it, and bailed early when the tab was already selected — so the initial display and re-clicks left focus unset, and Chat had no focus hook at all.

## Changes

- **`ide_layout.dart`**
  - Focus the Terminal/Chat input in `_selectTab`, deferred to a post-frame callback so the `IndexedStack` child is visible and its `FocusNode` is attached before requesting focus.
  - Focus the initial pane in `initState` (Terminal by default).
  - Re-focus on re-click of the active tab (the early `return` previously skipped it).
- **`workspace_chat.dart`**
  - Add a message-input `FocusNode` + `requestFocus()`, wired to the `TextField` (mirrors `GhosttyTerminalState.requestFocus()`), disposed on teardown.

## Testing

Verified live: on workspace open the terminal's editable is focused (DOM `activeElement` is the flterm textarea). Chat focus uses the identical mechanism.

Note: independent of the CanvasKit-renderer fix (separate branch/PR); touches only these two widgets.