### PR TITLE
fix(terminal): start the pty at the measured grid, not the 80x24 seed

### DIFF
--- a/src/frontend/lib/terminal/ghostty_terminal.dart
+++ b/src/frontend/lib/terminal/ghostty_terminal.dart
@@ -34,6 +34,13 @@ class GhosttyTerminalState extends State<GhosttyTerminal> {
   StreamSubscription<Map<String, dynamic>>? _eventSub;
   void Function()? _removePasteListener;
   bool _started = false;
+  // The pty must start at the real measured grid size, not the 80x24 seed.
+  // flterm's first onResize (after the view lays out) delivers the measured
+  // size, but the backend `container_ready` event can arrive before that. Track
+  // whether we've measured so start is deferred until the true cols/rows are
+  // known; otherwise the pty is created at 80 cols until the window is resized.
+  bool _measured = false;
+  bool _startPending = false;
 
   // Raw bytes of the bundled monospace font. flterm measures cell width from
   // this font's 'M' advance; without it, FontDataResolver's asset-path guessing
@@ -66,7 +73,15 @@ class GhosttyTerminalState extends State<GhosttyTerminal> {
       ..onResize = (cols, rows) {
         _cols = cols;
         _rows = rows;
+        _measured = true;
+        // Report the measured grid so the backend always tracks the real size,
+        // whether or not the pty has started yet.
         widget.wsClient.sendTerminalResize(cols, rows);
+        if (_startPending) {
+          // container_ready arrived before the first measurement; create the
+          // pty now at the real grid size instead of the 80x24 seed.
+          _startTerminal();
+        }
       };
     _outputSub = widget.wsClient.terminalOutput.listen((data) {
       _terminal.write(utf8.encode(data));
@@ -94,12 +109,21 @@ class GhosttyTerminalState extends State<GhosttyTerminal> {
     return true;
   }
 
+  // Loads the bundled font's raw bytes. Overridable in tests so the
+  // "container_ready before the first measurement" path can be driven
+  // deterministically: a test holds this future pending while it emits the
+  // event, then completes it to trigger layout. Mirrors the
+  // [testBaseUrlOverride] seam used elsewhere in the frontend.
+  @visibleForTesting
+  static Future<ByteData> Function(String asset) loadFontAsset =
+      rootBundle.load;
+
   // flterm measures cell width by laying out 'M' in [_fontFamily]; if the font
   // isn't loaded yet it measures a wider fallback advance and never re-measures,
   // leaving space around every glyph. Register the family with the engine and
   // await it before the view builds, so the one measurement uses the real font.
   Future<void> _loadFont() async {
-    final data = await rootBundle.load(_fontAsset);
+    final data = await loadFontAsset(_fontAsset);
     await (FontLoader(_fontFamily)..addFont(Future.value(data))).load();
     if (mounted) setState(() => _fontData = data.buffer.asUint8List());
   }
@@ -109,13 +133,20 @@ class GhosttyTerminalState extends State<GhosttyTerminal> {
     if (event == null) return;
     if (event['type'] == 'CUSTOM' && event['name'] == 'container_ready') {
       _started = false;
-      _startTerminal();
+      if (_measured) {
+        _startTerminal();
+      } else {
+        // Defer start until the first onResize delivers the measured grid
+        // size, so the pty isn't created at the 80x24 seed.
+        _startPending = true;
+      }
     }
   }
 
   void _startTerminal() {
     if (_started) return;
     _started = true;
+    _startPending = false;
     widget.wsClient.sendTerminalStart(cols: _cols, rows: _rows);
   }
 

--- a/src/frontend/test/ghostty_terminal_test.dart
+++ b/src/frontend/test/ghostty_terminal_test.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flterm/flterm.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:klangk_frontend/terminal/ghostty_terminal.dart';
 import 'package:klangk_frontend/ws/ws_client.dart';
@@ -165,6 +166,50 @@ void main() {
         client.sentCommands.where((c) => c.startsWith('terminal_resize')),
         isNotEmpty,
       );
+      client.close();
+    });
+
+    testWidgets(
+        'defers terminal_start until measured when container_ready arrives '
+        'before the first layout (starts at the real grid, not the 80x24 seed)',
+        (tester) async {
+      // Hold the font load pending so the view stays a placeholder and flterm
+      // never measures the grid until we choose. Without this, the async asset
+      // load can resolve during the first pump and measure the grid before
+      // container_ready is delivered, so the deferral path would never run.
+      final fontGate = Completer<ByteData>();
+      final realFont =
+          await rootBundle.load('assets/fonts/JetBrainsMono-Regular.ttf');
+      GhosttyTerminalState.loadFontAsset = (_) => fontGate.future;
+      addTearDown(() => GhosttyTerminalState.loadFontAsset = rootBundle.load);
+
+      final client = _MockWsClient();
+      await tester.pumpWidget(_build(client));
+      // The font has not loaded yet, so the view is a placeholder and flterm
+      // has not measured the grid. container_ready arrives first.
+      expect(find.byType(TerminalView), findsNothing);
+      client.emit(_containerReady());
+      await tester.pump();
+      // Start is deferred — we must not create the pty at the 80x24 seed.
+      expect(client.sentCommands.where((c) => c.startsWith('terminal_start')),
+          isEmpty);
+
+      // Font loads, the view lays out, flterm measures and fires onResize,
+      // which triggers the deferred start at the measured size.
+      fontGate.complete(realFont);
+      await tester.pumpAndSettle();
+
+      final starts = client.sentCommands
+          .where((c) => c.startsWith('terminal_start:'))
+          .toList();
+      final resizes = client.sentCommands
+          .where((c) => c.startsWith('terminal_resize:'))
+          .toList();
+      expect(starts.length, 1);
+      expect(resizes, isNotEmpty);
+      // The start carries the measured grid (same WxH as the resize), not the
+      // hardcoded 80x24 seed.
+      expect(starts.single.split(':')[1], resizes.last.split(':')[1]);
       client.close();
     });
 


### PR DESCRIPTION
## Problem
On workspace open the terminal is **80 columns wide regardless of the window** — it only sizes correctly after you resize the window.

## Cause
`GhosttyTerminal` seeds `cols/rows` to `80x24` and updates them from flterm's `onResize`, which fires after the `TerminalView` lays out. But the backend `container_ready` event can arrive **before** that first measurement, so `_startTerminal()` sent `terminal_start` at the `80x24` seed. The pty is created 80 cols wide and stays there until a window resize triggers another `onResize`.

## Fix
Defer the start until a real measurement exists:
- Track `_measured` (first `onResize` landed) and `_startPending` (`container_ready` arrived early).
- On `container_ready`: start immediately if already measured, else mark `_startPending`.
- On the first `onResize`: if a start is pending, start now — at the measured grid.

## Test
Adds a test for the `container_ready`-before-layout ordering: asserts no `terminal_start` is sent before measurement, and that the eventual start carries the measured grid (same WxH as the resize), not the seed. Existing tests (which `pumpAndSettle` before `container_ready`) are unaffected.