### PR TITLE
fix(workspace-list): wrap workspace ListTiles in Material (Flutter 3.44)

### DIFF
--- a/src/frontend/lib/workspace/workspace_list_page.dart
+++ b/src/frontend/lib/workspace/workspace_list_page.dart
@@ -519,9 +519,14 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
                   final i = e.key;
                   final ws = e.value;
                   final wsMembers = _workspaceMembers[ws['id'] as String] ?? [];
-                  return Container(
-                    color:
-                        i.isEven ? Colors.white.withValues(alpha: 0.03) : null,
+                  // Material (not a plain ColoredBox/Container color) so the
+                  // ListTile paints its background and ink splashes on this
+                  // surface; Flutter 3.44+ asserts when a ListTile's nearest
+                  // ancestor with a background is a ColoredBox.
+                  return Material(
+                    color: i.isEven
+                        ? Colors.white.withValues(alpha: 0.03)
+                        : Colors.transparent,
                     child: ListTile(
                       leading: const Icon(Icons.terminal,
                           size: 20, color: KColors.accentGreen),
@@ -599,10 +604,10 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
                     ],
                   ),
                 ),
-                ..._sharedWorkspaces.asMap().entries.map((e) => Container(
+                ..._sharedWorkspaces.asMap().entries.map((e) => Material(
                       color: e.key.isEven
                           ? Colors.white.withValues(alpha: 0.03)
-                          : null,
+                          : Colors.transparent,
                       child: ListTile(
                         leading: const Icon(Icons.terminal,
                             size: 20, color: KColors.accentBlue),


### PR DESCRIPTION
## Problem
`test-frontend` fails on CI (Flutter **3.44.1**) with many `workspace_list_page_test` failures, while passing locally on the nix toolchain (Flutter **3.41.6**). The assertion:

> ListTile background color or ink splashes may be invisible. The ListTile is wrapped in a ColoredBox that has a background color... To fix this, wrap the ListTile in its own Material widget, or remove the background color from the intermediate ColoredBox.

This check was added in Flutter 3.42+, so only CI (3.44.1) trips it.

## Cause
Both the "Owned by Me" and "Shared" workspace lists wrap each `ListTile` in a `Container(color: …isEven ? faintWhite : null)` for zebra striping. A `Container(color:)` is a `ColoredBox`, which is exactly what the assertion forbids as a ListTile's nearest background ancestor.

## Fix
Use `Material(color: …isEven ? faintWhite : Colors.transparent)` instead. `Material` becomes the surface the `ListTile` paints its background and ink splashes on — clearing the assertion (and actually making ink splashes visible, which the `ColoredBox` was hiding). Existing `workspace_list_page_test` cases cover the rendering.

Surfaced while validating the local↔CI Flutter version skew.