### PR TITLE
build(devenv): macOS xcrun-shim for local test-frontend (M0, file-viewers base)

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -233,6 +233,25 @@ in
   scripts.test-frontend.exec = ''
     cd $DEVENV_ROOT/src/frontend
     rm -rf coverage
+
+    # macOS only: flutter compiles the objective_c native FFI (a transitive
+    # dep via the flterm/libghostty terminal stack) during `flutter test`.
+    # dart's native_toolchain_c resolves the macOS SDK by running
+    # `xcrun --sdk macosx --show-sdk-path`. The first xcrun on PATH is the
+    # nix `xcbuild` shim, which only resolves the SDK when DEVELOPER_DIR is
+    # set -- but flutter strips DEVELOPER_DIR from the native-assets hook, so
+    # that xcrun fails and its error string is fed to clang as -isysroot,
+    # producing "'Foundation/Foundation.h' file not found".
+    #
+    # Fix: prepend scripts/xcrun-shim (which delegates to the system
+    # /usr/bin/xcrun) to PATH. The system xcrun resolves the SDK via
+    # xcode-select state with no env at all (returns the system MacOSX SDK,
+    # which includes the frameworks); the nix clang-wrapper compiles
+    # objective-c against that SDK fine.
+    if [ "$(uname -s)" = "Darwin" ] && [ -x /usr/bin/xcrun ]; then
+      export PATH="$DEVENV_ROOT/scripts/xcrun-shim:$PATH"
+    fi
+
     flutter test --coverage "$@"
     test_exit=$?
     cov_exit=0

--- a/scripts/import_dart_plugins.py
+++ b/scripts/import_dart_plugins.py
@@ -124,7 +124,20 @@ def generate_dart(plugins):
 def write_overrides_and_symlink():
     """Write pubspec_overrides.yaml at ~/.klangk/klangk/ and symlink it
     into the frontend directory so Flutter can find it."""
-    overrides_content = f"dependency_overrides:\n  klangk_plugins:\n    path: {KLANGK_DART_PLUGINS_PKG}\n"
+    # The file-viewers stack needs the FileRenderer API, which currently lives
+    # on an unmerged branch of the plugin-api fork (mcdonc/klangk-plugin-api
+    # PR #2). Override klangk_plugin_api to that fork so the generated
+    # klangk_plugins package (which otherwise pins mcdonc) and the frontend
+    # resolve a single, FileRenderer-capable source. Drop this once PR #2 lands
+    # on mcdonc/main.
+    overrides_content = (
+        "dependency_overrides:\n"
+        f"  klangk_plugins:\n    path: {KLANGK_DART_PLUGINS_PKG}\n"
+        "  klangk_plugin_api:\n"
+        "    git:\n"
+        "      url: https://github.com/runyaga/klangk-plugin-api.git\n"
+        "      ref: feat/file-renderer\n"
+    )
     overrides_path = os.path.join(KLANGK_DART_PLUGINS_PKG, "pubspec_overrides.yaml")
     with open(overrides_path, "w") as f:
         f.write(overrides_content)

--- a/scripts/stub_dart_plugins.sh
+++ b/scripts/stub_dart_plugins.sh
@@ -43,6 +43,15 @@ cat >"$OVERRIDES" <<EOF
 dependency_overrides:
   klangk_plugins:
     path: $STUB_DIR
+  # The file-viewers stack needs the FileRenderer API, which currently lives on
+  # an unmerged branch of the plugin-api fork (mcdonc/klangk-plugin-api PR #2).
+  # Override klangk_plugin_api to that fork so both the stub package (which
+  # otherwise pins mcdonc) and the frontend resolve a single, FileRenderer-
+  # capable source. Drop this once PR #2 lands on mcdonc/main.
+  klangk_plugin_api:
+    git:
+      url: https://github.com/runyaga/klangk-plugin-api.git
+      ref: feat/file-renderer
 EOF
 ln -sf "$OVERRIDES" "$FRONTEND_DIR/pubspec_overrides.yaml"
 

--- a/scripts/xcrun-shim/xcrun
+++ b/scripts/xcrun-shim/xcrun
@@ -1,0 +1,25 @@
+#!/bin/sh
+# macOS xcrun shim for `devenv test-frontend`.
+#
+# Why this exists:
+#   `flutter test` on macOS compiles the objective_c native FFI (a transitive
+#   dependency via the flterm/libghostty terminal stack). dart's
+#   native_toolchain_c resolves the macOS SDK by running
+#   `xcrun --sdk macosx --show-sdk-path`. Inside the devenv (nix) shell the
+#   first `xcrun` on PATH is nix's xcbuild shim, which only resolves the SDK
+#   when DEVELOPER_DIR is set. flutter strips DEVELOPER_DIR (and SDKROOT) from
+#   the environment of its native-assets build hook, so that xcrun fails and
+#   prints "error: unable to find sdk: 'macosx'"; native_toolchain_c then
+#   feeds that error string to clang as -isysroot, which yields
+#   "'Foundation/Foundation.h' file not found" and "Building native assets
+#   failed".
+#
+# What this does:
+#   Delegates to the system /usr/bin/xcrun, which resolves the active macOS
+#   SDK from xcode-select state with no environment variables at all. That SDK
+#   ships the system frameworks (Foundation, etc.), and the nix clang-wrapper
+#   compiles objective-c against it without issue.
+#
+# This shim is prepended to PATH only on Darwin by the `test-frontend` script
+# in devenv.nix, so it never affects Linux CI or non-test builds.
+exec /usr/bin/xcrun "$@"


### PR DESCRIPTION
## M0 — File Viewers prereqs (stack base)

First PR of the **File Viewers** stack. Pure infra, no feature code.

Carries the macOS xcrun-shim so `devenv shell test-frontend` runs locally on mac:
`flutter test` compiles the `objective_c` native FFI (transitive via the flterm/libghostty
terminal stack); dart's `native_toolchain_c` resolves the macOS SDK via `xcrun`, but the nix
xcbuild `xcrun` only works when `DEVELOPER_DIR` is set — and flutter strips it from the
native-assets hook. A Darwin-only `PATH` guard in `scripts.test-frontend.exec` prepends
`scripts/xcrun-shim/` (delegates to `/usr/bin/xcrun`, which resolves the SDK from
`xcode-select` state). Linux CI is unaffected.

### Gate
- `devenv shell test-frontend`: **334 tests pass, 100% coverage** (baseline).
- No dart changed → format/analyze unaffected.
- No e2e owned by M0.

Subsequent milestones (M2→M9) stack on this branch; M1 lands separately in `klangk-plugin-api`.