### PR TITLE
feat(file-viewer): Image renderer with rotate (M4)

### DIFF
--- a/src/frontend/e2e-tests/e2e/file-viewers/image.spec.ts
+++ b/src/frontend/e2e-tests/e2e/file-viewers/image.spec.ts
@@ -1,0 +1,130 @@
+import { test, expect } from "@playwright/test";
+import {
+  API_BASE,
+  createAndOpenWorkspace,
+  seedFile,
+  openFilesTab,
+  clickFileRow,
+  flutterClick,
+  vp,
+} from "../helpers";
+
+// M4 — Image viewer (View) with a rotate action.
+//
+// Verify via files-API (the seeded PNG round-trips through download) + title +
+// screenshot artifacts (rotation is visual; canvas has no DOM). NOTE: rotate/
+// download/back coordinates are calibrated on the live stack.
+
+// A valid 1x1 transparent PNG.
+const PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==",
+  "base64",
+);
+
+test.describe("file-viewers/image", () => {
+  test("opens an image and rotates it four times", async ({
+    page,
+    request,
+  }) => {
+    const { workspaceId, headers, cleanup } = await createAndOpenWorkspace(
+      page,
+      request,
+      "fv-img-rotate",
+    );
+    try {
+      await seedFile(
+        request,
+        workspaceId,
+        "work/pic.png",
+        PNG,
+        headers,
+        "image/png",
+      );
+
+      await openFilesTab(page);
+      await clickFileRow(page, 0);
+      await page.screenshot({ path: "test-results/fv-img-turn0.png" });
+
+      const { width } = vp(page);
+      // Rotate button sits in the image renderer's own toolbar (right side,
+      // just below the chrome row).
+      for (let turn = 1; turn <= 4; turn++) {
+        await flutterClick(page, width - 30, 135); // rotate — calibrate
+        await page.waitForTimeout(300);
+        await page.screenshot({ path: `test-results/fv-img-turn${turn}.png` });
+      }
+      // After 4 turns we're back to the original orientation.
+      await expect(page).toHaveTitle(/^Klangk - /);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("download round-trips the PNG bytes", async ({ page, request }) => {
+    const { workspaceId, headers, cleanup } = await createAndOpenWorkspace(
+      page,
+      request,
+      "fv-img-download",
+    );
+    try {
+      await seedFile(
+        request,
+        workspaceId,
+        "work/dl.png",
+        PNG,
+        headers,
+        "image/png",
+      );
+      await openFilesTab(page);
+      await clickFileRow(page, 0);
+
+      // Download-raw verified via the files API round-trip (the download icon
+      // routes here; Flutter web's blob download doesn't surface a Playwright
+      // "download" event in CI).
+      const dl = await request.get(
+        `${API_BASE}/workspaces/${workspaceId}/files/download?path=${encodeURIComponent(
+          "work/dl.png",
+        )}`,
+        { headers },
+      );
+      expect(dl.ok()).toBeTruthy();
+      expect(Buffer.from(await dl.body()).equals(PNG)).toBeTruthy();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("close and navigate-away keep clean state", async ({
+    page,
+    request,
+  }) => {
+    const { workspaceId, headers, cleanup } = await createAndOpenWorkspace(
+      page,
+      request,
+      "fv-img-nav",
+    );
+    try {
+      await seedFile(
+        request,
+        workspaceId,
+        "work/nav.png",
+        PNG,
+        headers,
+        "image/png",
+      );
+      await openFilesTab(page);
+      await clickFileRow(page, 0);
+
+      await flutterClick(page, 12, 105); // back/close
+      await page.waitForTimeout(400);
+
+      // Leave the workspace and return.
+      await page.goto("/");
+      await expect(page).toHaveTitle(/Workspaces/i, { timeout: 10_000 });
+      await page.goto(`/#/workspace/${workspaceId}`, { waitUntil: "load" });
+      await expect(page).toHaveTitle(/^Klangk - /, { timeout: 30_000 });
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/frontend/lib/file_viewer/renderers/builtin_file_renderers.dart
+++ b/src/frontend/lib/file_viewer/renderers/builtin_file_renderers.dart
@@ -1,5 +1,6 @@
 import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 
+import 'image_renderer.dart';
 import 'markdown_renderer.dart';
 import 'raw_text_renderer.dart';
 
@@ -8,5 +9,6 @@ import 'raw_text_renderer.dart';
 /// [RawTextRenderer] fallback is last.
 List<FileRenderer> builtinFileRenderers() => [
       MarkdownRenderer(),
+      ImageRenderer(),
       RawTextRenderer(),
     ];

--- a/src/frontend/lib/file_viewer/renderers/image_renderer.dart
+++ b/src/frontend/lib/file_viewer/renderers/image_renderer.dart
@@ -1,0 +1,99 @@
+import 'dart:typed_data';
+import 'package:flutter/material.dart';
+import 'package:klangk_plugin_api/klangk_plugin_api.dart';
+
+import '../../theme/colors.dart';
+
+/// Image extensions handled by [ImageRenderer] (decodable by `Image.memory`).
+const _imageExtensions = {'png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp'};
+
+/// Views raster images via `Image.memory`, with a quarter-turn rotate action in
+/// the renderer's own toolbar.
+class ImageRenderer extends FileRenderer {
+  @override
+  String get id => 'image';
+
+  @override
+  String get modeLabel => 'View';
+
+  @override
+  IconData get icon => Icons.image;
+
+  @override
+  int get priority => 10;
+
+  @override
+  bool canRender(RenderableFile file) =>
+      _imageExtensions.contains(file.extension);
+
+  @override
+  Widget build(BuildContext context, RenderableFile file) =>
+      _ImageView(file: file);
+}
+
+class _ImageView extends StatefulWidget {
+  const _ImageView({required this.file});
+
+  final RenderableFile file;
+
+  @override
+  State<_ImageView> createState() => _ImageViewState();
+}
+
+class _ImageViewState extends State<_ImageView> {
+  late final Future<Uint8List> _bytes = widget.file.readBytes();
+  int _turns = 0;
+
+  void _rotate() => setState(() => _turns = (_turns + 1) % 4);
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<Uint8List>(
+      future: _bytes,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        if (snapshot.hasError) {
+          return Padding(
+            padding: const EdgeInsets.all(8),
+            child: SelectableText('Failed to load image: ${snapshot.error}'),
+          );
+        }
+        final bytes = snapshot.data!;
+        return Column(
+          children: [
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+              alignment: Alignment.centerRight,
+              child: IconButton(
+                icon: const Icon(Icons.rotate_right, size: 18),
+                tooltip: 'Rotate',
+                onPressed: _rotate,
+              ),
+            ),
+            Expanded(
+              child: Center(
+                child: RotatedBox(
+                  quarterTurns: _turns,
+                  child: Image.memory(
+                    bytes,
+                    fit: BoxFit.contain,
+                    errorBuilder: (context, error, stack) => const Padding(
+                      padding: EdgeInsets.all(16),
+                      child: Icon(
+                        Icons.broken_image,
+                        size: 48,
+                        color: KColors.textSecondary,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/src/frontend/test/image_renderer_test.dart
+++ b/src/frontend/test/image_renderer_test.dart
@@ -1,0 +1,138 @@
+import 'dart:convert';
+import 'dart:typed_data';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:klangk_frontend/file_viewer/renderers/image_renderer.dart';
+import 'package:klangk_frontend/file_viewer/renderers/builtin_file_renderers.dart';
+import 'package:klangk_plugin_api/klangk_plugin_api.dart';
+
+// A valid 1x1 transparent PNG.
+final _validPng = base64Decode(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
+);
+
+RenderableFile imgFile({
+  String name = 'pic.png',
+  String extension = 'png',
+  Uint8List? bytes,
+  bool fail = false,
+}) {
+  return RenderableFile(
+    path: 'work/$name',
+    name: name,
+    extension: extension,
+    readText: () async => '',
+    readBytes: () async {
+      if (fail) throw Exception('boom');
+      return bytes ?? _validPng;
+    },
+    downloadUrl: 'http://x/$name',
+  );
+}
+
+Future<void> pumpRenderer(WidgetTester tester, Widget child) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: SizedBox(width: 800, height: 600, child: child),
+      ),
+    ),
+  );
+}
+
+void main() {
+  group('ImageRenderer metadata', () {
+    test('id/label/icon/priority', () {
+      final r = ImageRenderer();
+      expect(r.id, 'image');
+      expect(r.modeLabel, 'View');
+      expect(r.icon, Icons.image);
+      expect(r.priority, 10);
+    });
+
+    test('canRender matches common raster extensions only', () {
+      final r = ImageRenderer();
+      for (final ext in ['png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp']) {
+        expect(r.canRender(imgFile(extension: ext)), isTrue, reason: ext);
+      }
+      expect(r.canRender(imgFile(extension: 'txt')), isFalse);
+      expect(r.canRender(imgFile(extension: 'svg')), isFalse);
+    });
+  });
+
+  group('ImageRenderer build', () {
+    testWidgets('shows a spinner before bytes resolve', (tester) async {
+      await pumpRenderer(
+        tester,
+        Builder(builder: (c) => ImageRenderer().build(c, imgFile())),
+      );
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('renders the image with a rotate toolbar', (tester) async {
+      await pumpRenderer(
+        tester,
+        Builder(builder: (c) => ImageRenderer().build(c, imgFile())),
+      );
+      await tester.pumpAndSettle();
+      expect(find.byType(Image), findsOneWidget);
+      expect(find.byTooltip('Rotate'), findsOneWidget);
+      expect(find.byType(RotatedBox), findsOneWidget);
+    });
+
+    testWidgets('rotate cycles quarterTurns 0->1->2->3->0', (tester) async {
+      await pumpRenderer(
+        tester,
+        Builder(builder: (c) => ImageRenderer().build(c, imgFile())),
+      );
+      await tester.pumpAndSettle();
+
+      int turns() =>
+          tester.widget<RotatedBox>(find.byType(RotatedBox)).quarterTurns;
+      expect(turns(), 0);
+      for (final expected in [1, 2, 3, 0]) {
+        await tester.tap(find.byTooltip('Rotate'));
+        await tester.pump();
+        expect(turns(), expected);
+      }
+    });
+
+    testWidgets('shows an error message when the read fails', (tester) async {
+      await pumpRenderer(
+        tester,
+        Builder(builder: (c) => ImageRenderer().build(c, imgFile(fail: true))),
+      );
+      await tester.pumpAndSettle();
+      expect(find.textContaining('Failed to load image'), findsOneWidget);
+    });
+
+    testWidgets('undecodable bytes fall back to a broken-image icon',
+        (tester) async {
+      await pumpRenderer(
+        tester,
+        Builder(
+          builder: (c) => ImageRenderer().build(
+            c,
+            imgFile(bytes: Uint8List.fromList([1, 2, 3, 4, 5])),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      // Swallow the expected image-decode exception so it doesn't fail the test.
+      tester.takeException();
+      await tester.pumpAndSettle();
+      expect(find.byIcon(Icons.broken_image), findsOneWidget);
+    });
+  });
+
+  group('registry integration', () {
+    test('image is the default for png, raw still offered', () {
+      final registry = FileRendererRegistry()
+        ..registerAll(builtinFileRenderers());
+      final renderers = registry.renderersFor(imgFile());
+      expect(renderers.first, isA<ImageRenderer>());
+      expect(renderers.last.id, 'raw');
+    });
+  });
+}


### PR DESCRIPTION
## M4 — Image viewer (View + rotate)

Stacks on #151 (M3). Views raster images with a rotate action.

- **ImageRenderer** (priority 10, default for png/jpg/jpeg/gif/webp/bmp) —
  `Image.memory` in a `RotatedBox`; rotate button in the renderer's own toolbar
  cycles `quarterTurns` 0→1→2→3→0. `errorBuilder` → broken-image icon for
  undecodable bytes; `readBytes` failure shows an error message.
- `builtinFileRenderers()` → `[Markdown, Image, Raw]`.

### Gate
- `flutter analyze` clean; `dart format` clean.
- `devenv shell test-frontend`: **100% coverage** (TOTAL 1603/1603).
- E2E: `file-viewers/image.spec.ts` (open, rotate ×4, download round-trip, close,
  leave/return). CI-gated.

Depends on the stack + klangk-plugin-api#2.