### PR TITLE
feat(file-viewer): Code renderer, syntax-highlighted (M5)

### DIFF
--- a/src/frontend/e2e-tests/e2e/file-viewers/code-view.spec.ts
+++ b/src/frontend/e2e-tests/e2e/file-viewers/code-view.spec.ts
@@ -1,0 +1,116 @@
+import { test, expect } from "@playwright/test";
+import {
+  API_BASE,
+  createAndOpenWorkspace,
+  seedFile,
+  openFilesTab,
+  clickFileRow,
+  flutterClick,
+  vp,
+} from "../helpers";
+
+// M5 — Code viewer (View, syntax-highlighted) with Raw also available.
+//
+// Verify via files-API + title + download round-trip + screenshot artifacts.
+// A code file has TWO renderers (Code View + Raw) → mode chips appear.
+// NOTE: chrome-row chip/button coordinates are calibrated on the live stack.
+
+const DART = `void main() {
+  final greeting = 'hello, klangk';
+  print(greeting);
+}
+`;
+
+test.describe("file-viewers/code-view", () => {
+  test("highlights code by default and toggles to Raw", async ({
+    page,
+    request,
+  }) => {
+    const { workspaceId, headers, cleanup } = await createAndOpenWorkspace(
+      page,
+      request,
+      "fv-code-view",
+    );
+    try {
+      await seedFile(request, workspaceId, "work/main.dart", DART, headers);
+      const api = await request.get(
+        `${API_BASE}/workspaces/${workspaceId}/files/content?path=work/main.dart`,
+        { headers },
+      );
+      expect((await api.json()).content).toContain("void main()");
+
+      await openFilesTab(page);
+      await clickFileRow(page, 0);
+      await page.screenshot({ path: "test-results/fv-code-highlighted.png" });
+
+      // Toggle to Raw via the mode chip.
+      const { width } = vp(page);
+      await flutterClick(page, width - 70, 105); // "Raw" chip — calibrate
+      await page.waitForTimeout(400);
+      await page.screenshot({ path: "test-results/fv-code-raw.png" });
+
+      await expect(page).toHaveTitle(/^Klangk - /);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("download round-trips the source", async ({ page, request }) => {
+    const { workspaceId, headers, cleanup } = await createAndOpenWorkspace(
+      page,
+      request,
+      "fv-code-download",
+    );
+    try {
+      await seedFile(request, workspaceId, "work/dl.dart", DART, headers);
+      await openFilesTab(page);
+      await clickFileRow(page, 0);
+
+      // Download-raw verified via the files API round-trip (the download icon
+      // routes here; Flutter web's blob download doesn't surface a Playwright
+      // "download" event in CI).
+      const dl = await request.get(
+        `${API_BASE}/workspaces/${workspaceId}/files/download?path=${encodeURIComponent(
+          "work/dl.dart",
+        )}`,
+        { headers },
+      );
+      expect(dl.ok()).toBeTruthy();
+      expect(Buffer.from(await dl.body()).toString()).toContain("void main()");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("close and navigate-away keep clean state", async ({
+    page,
+    request,
+  }) => {
+    const { workspaceId, headers, cleanup } = await createAndOpenWorkspace(
+      page,
+      request,
+      "fv-code-nav",
+    );
+    try {
+      await seedFile(
+        request,
+        workspaceId,
+        "work/nav.py",
+        "print('x')\n",
+        headers,
+      );
+      await openFilesTab(page);
+      await clickFileRow(page, 0);
+
+      await flutterClick(page, 12, 105); // back/close
+      await page.waitForTimeout(400);
+
+      await page.goto("/");
+      await expect(page).toHaveTitle(/Workspaces/i, { timeout: 10_000 });
+      await page.goto(`/#/workspace/${workspaceId}`, { waitUntil: "load" });
+      await expect(page).toHaveTitle(/^Klangk - /, { timeout: 30_000 });
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/frontend/lib/file_viewer/renderers/builtin_file_renderers.dart
+++ b/src/frontend/lib/file_viewer/renderers/builtin_file_renderers.dart
@@ -1,5 +1,6 @@
 import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 
+import 'code_renderer.dart';
 import 'image_renderer.dart';
 import 'markdown_renderer.dart';
 import 'raw_text_renderer.dart';
@@ -10,5 +11,6 @@ import 'raw_text_renderer.dart';
 List<FileRenderer> builtinFileRenderers() => [
       MarkdownRenderer(),
       ImageRenderer(),
+      CodeRenderer(),
       RawTextRenderer(),
     ];

--- a/src/frontend/lib/file_viewer/renderers/code_renderer.dart
+++ b/src/frontend/lib/file_viewer/renderers/code_renderer.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_highlight/flutter_highlight.dart';
+import 'package:flutter_highlight/themes/atom-one-dark.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:klangk_plugin_api/klangk_plugin_api.dart';
+
+/// Maps a (lowercased, no-dot) file extension to a `highlight` language id.
+/// Extensions not present here are not handled by [CodeRenderer.canRender];
+/// [languageForExtension] still defends with a `plaintext` fallback.
+const _languageByExtension = {
+  'dart': 'dart',
+  'py': 'python',
+  'ts': 'typescript',
+  'tsx': 'typescript',
+  'js': 'javascript',
+  'jsx': 'javascript',
+  'mjs': 'javascript',
+  'json': 'json',
+  'yaml': 'yaml',
+  'yml': 'yaml',
+  'sh': 'bash',
+  'bash': 'bash',
+  'zsh': 'bash',
+  'go': 'go',
+  'rs': 'rust',
+  'c': 'cpp',
+  'h': 'cpp',
+  'cpp': 'cpp',
+  'cc': 'cpp',
+  'cxx': 'cpp',
+  'hpp': 'cpp',
+  'css': 'css',
+  'scss': 'scss',
+  'html': 'xml',
+  'htm': 'xml',
+  'xml': 'xml',
+};
+
+/// The `highlight` language id for [extension], or `plaintext` when unknown.
+String languageForExtension(String extension) =>
+    _languageByExtension[extension] ?? 'plaintext';
+
+/// Read-only, syntax-highlighted view for code files via `flutter_highlight`.
+class CodeRenderer extends FileRenderer {
+  @override
+  String get id => 'code';
+
+  @override
+  String get modeLabel => 'View';
+
+  @override
+  IconData get icon => Icons.code;
+
+  @override
+  int get priority => 10;
+
+  @override
+  bool canRender(RenderableFile file) =>
+      _languageByExtension.containsKey(file.extension);
+
+  @override
+  Widget build(BuildContext context, RenderableFile file) =>
+      _CodeView(file: file);
+}
+
+class _CodeView extends StatefulWidget {
+  const _CodeView({required this.file});
+
+  final RenderableFile file;
+
+  @override
+  State<_CodeView> createState() => _CodeViewState();
+}
+
+class _CodeViewState extends State<_CodeView> {
+  late final Future<String> _content = widget.file.readText();
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<String>(
+      future: _content,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        if (snapshot.hasError) {
+          return Padding(
+            padding: const EdgeInsets.all(8),
+            child: SelectableText('Failed to load file: ${snapshot.error}'),
+          );
+        }
+        return SingleChildScrollView(
+          scrollDirection: Axis.vertical,
+          child: SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: HighlightView(
+              snapshot.data ?? '',
+              language: languageForExtension(widget.file.extension),
+              theme: atomOneDarkTheme,
+              padding: const EdgeInsets.all(12),
+              textStyle: TextStyle(
+                fontFamily: GoogleFonts.robotoMono().fontFamily,
+                fontSize: 13,
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/src/frontend/test/code_renderer_test.dart
+++ b/src/frontend/test/code_renderer_test.dart
@@ -1,0 +1,137 @@
+import 'dart:typed_data';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_highlight/flutter_highlight.dart';
+import 'package:klangk_frontend/file_viewer/renderers/code_renderer.dart';
+import 'package:klangk_frontend/file_viewer/renderers/builtin_file_renderers.dart';
+import 'package:klangk_plugin_api/klangk_plugin_api.dart';
+
+RenderableFile codeFile({
+  String name = 'main.dart',
+  String extension = 'dart',
+  String text = 'void main() => print("hi");',
+  bool fail = false,
+}) {
+  return RenderableFile(
+    path: 'work/$name',
+    name: name,
+    extension: extension,
+    readText: () async {
+      if (fail) throw Exception('boom');
+      return text;
+    },
+    readBytes: () async => Uint8List(0),
+    downloadUrl: 'http://x/$name',
+  );
+}
+
+Future<void> pumpRenderer(WidgetTester tester, Widget child) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(body: SizedBox(width: 800, height: 600, child: child)),
+    ),
+  );
+}
+
+void main() {
+  group('languageForExtension', () {
+    test('maps known code extensions', () {
+      expect(languageForExtension('dart'), 'dart');
+      expect(languageForExtension('py'), 'python');
+      expect(languageForExtension('ts'), 'typescript');
+      expect(languageForExtension('yml'), 'yaml');
+      expect(languageForExtension('sh'), 'bash');
+      expect(languageForExtension('c'), 'cpp');
+      expect(languageForExtension('html'), 'xml');
+    });
+
+    test('falls back to plaintext for unknown extensions', () {
+      expect(languageForExtension('zzz'), 'plaintext');
+      expect(languageForExtension(''), 'plaintext');
+    });
+  });
+
+  group('CodeRenderer metadata', () {
+    test('id/label/icon/priority', () {
+      final r = CodeRenderer();
+      expect(r.id, 'code');
+      expect(r.modeLabel, 'View');
+      expect(r.icon, Icons.code);
+      expect(r.priority, 10);
+    });
+
+    test('canRender matches code extensions only', () {
+      final r = CodeRenderer();
+      for (final ext in [
+        'dart',
+        'py',
+        'ts',
+        'js',
+        'json',
+        'yaml',
+        'sh',
+        'go'
+      ]) {
+        expect(r.canRender(codeFile(extension: ext)), isTrue, reason: ext);
+      }
+      expect(r.canRender(codeFile(extension: 'md')), isFalse);
+      expect(r.canRender(codeFile(extension: 'png')), isFalse);
+      expect(r.canRender(codeFile(extension: '')), isFalse);
+    });
+  });
+
+  group('CodeRenderer build', () {
+    testWidgets('shows a spinner before content resolves', (tester) async {
+      await pumpRenderer(
+        tester,
+        Builder(builder: (c) => CodeRenderer().build(c, codeFile())),
+      );
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('renders a highlighted code view', (tester) async {
+      await pumpRenderer(
+        tester,
+        Builder(builder: (c) => CodeRenderer().build(c, codeFile())),
+      );
+      await tester.pumpAndSettle();
+      expect(find.byType(HighlightView), findsOneWidget);
+    });
+
+    testWidgets('handles an unknown-but-registered code extension',
+        (tester) async {
+      // .go is in the code set; ensures the language path runs for it.
+      await pumpRenderer(
+        tester,
+        Builder(
+          builder: (c) => CodeRenderer().build(
+            c,
+            codeFile(name: 'main.go', extension: 'go', text: 'package main'),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.byType(HighlightView), findsOneWidget);
+    });
+
+    testWidgets('shows an error message when the read fails', (tester) async {
+      await pumpRenderer(
+        tester,
+        Builder(builder: (c) => CodeRenderer().build(c, codeFile(fail: true))),
+      );
+      await tester.pumpAndSettle();
+      expect(find.textContaining('Failed to load file'), findsOneWidget);
+    });
+  });
+
+  group('registry integration', () {
+    test('code is the default for code exts, raw still offered', () {
+      final registry = FileRendererRegistry()
+        ..registerAll(builtinFileRenderers());
+      final renderers = registry.renderersFor(codeFile());
+      expect(renderers.first, isA<CodeRenderer>());
+      expect(renderers.last.id, 'raw');
+    });
+  });
+}


### PR DESCRIPTION
## M5 — Code viewer (View, syntax-highlighted)

Stacks on #152 (M4). Read-only, highlighted view for code files.

- **CodeRenderer** (priority 10, default for the code-extension set) via
  `flutter_highlight` + `atom-one-dark` theme; language inferred by
  `languageForExtension` (plaintext fallback). Scrollable both axes.
- `builtinFileRenderers()` → `[Markdown, Image, Code, Raw]`; Raw offered as a
  second mode.

### Gate
- `flutter analyze` clean; `dart format` clean.
- `devenv shell test-frontend`: **100% coverage** (TOTAL 1633/1633).
- E2E: `file-viewers/code-view.spec.ts` (highlight, →Raw, download round-trip,
  close, leave/return). CI-gated.