### PR TITLE
deps(frontend): consume flterm from libghostty, not the standalone fork

### DIFF
--- a/src/frontend/pubspec.yaml
+++ b/src/frontend/pubspec.yaml
@@ -12,13 +12,16 @@ dependencies:
     sdk: flutter
   cupertino_icons: ^1.0.0
   xterm: ^4.0.0
-  # flterm: forked to build on Flutter 3.41 / Dart 3.11 (upstream 0.0.3 needs
-  # Dart 3.12 for private-named parameters; the fork removes that usage), so no
-  # host Flutter is required -- builds with the nix toolchain.
+  # flterm: vendored in libghostty as packages/flterm, patched to build on
+  # Flutter 3.41 / Dart 3.11 (upstream 0.0.3 needs Dart 3.12 for private-named
+  # parameters; the patch removes that usage), so no host Flutter is required --
+  # builds with the nix toolchain. Consumed from libghostty (the standalone
+  # runyaga/flterm fork is archived).
   flterm:
     git:
-      url: https://github.com/runyaga/flterm.git
+      url: https://github.com/runyaga/libghostty.git
       ref: main
+      path: packages/flterm
   libghostty: ^0.0.9
   google_fonts: ^8.1.0
   web_socket_channel: ^3.0.0

--- a/src/frontend/pubspec.yaml
+++ b/src/frontend/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
     sdk: flutter
   cupertino_icons: ^1.0.0
   xterm: ^4.0.0
+  # XXX: This is because nix MacOS does not support Flutter 3.44 - yet.
   # flterm: vendored in libghostty as packages/flterm, patched to build on
   # Flutter 3.41 / Dart 3.11 (upstream 0.0.3 needs Dart 3.12 for private-named
   # parameters; the patch removes that usage), so no host Flutter is required --


### PR DESCRIPTION
## What

Repoints the `flterm` git dependency in `src/frontend/pubspec.yaml` from the standalone `runyaga/flterm` fork to `runyaga/libghostty`, where flterm now lives as `packages/flterm`:

```yaml
flterm:
  git:
    url: https://github.com/runyaga/libghostty.git
    ref: main
    path: packages/flterm
```

## Why

We're consolidating flterm into libghostty and **archiving the standalone `runyaga/flterm` repo**. The libghostty copy is a superset of the fork:

- same Flutter 3.41 / Dart 3.11 build patches (upstream 0.0.3 needs Dart 3.12 for private-named params),
- an **extra** web fix (don't re-send unchanged `TextInputConfiguration`, which threw a caught-but-noisy null-check on every focus gain on web),
- a corrected 3.41 test (`enableInlinePrediction` serializes as `null`, not `false`, since the source stopped setting it).

flterm was made standalone-consumable in libghostty (removed from its pub workspace), and its full suite (548 tests) is green under devenv Flutter 3.41.6.

Archiving doesn't break this even before merge — archived GitHub repos stay cloneable read-only — but pointing at libghostty is the intended source going forward.

## Note

`src/frontend/pubspec.lock` is **not** updated here (the git dep source/commit changed). Run `flutter pub get` to regenerate it.

## Scope

`main` only. Active feature branches inherit the repoint when they merge/rebase off `main`.