### PR TITLE
fix(devenv): make the macOS podman path work

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -129,18 +129,32 @@ in
     config.devenv.root + "/.devenv/state/klangk/plugins"
   );
   env.KLANGK_IMAGE_NAME = lib.mkOverride 1500 "klangk";
-  # Rootless podman from nix has no default policy.json; generated in
-  # enterShell, scripts reference it via this env var + --signature-policy.
-  env.KLANGK_SIGNATURE_POLICY =
-    config.devenv.state + "/klangk/podman/policy.json";
+  # Rootless podman from nix (Linux) has no default policy.json; it is
+  # generated in enterShell and scripts pass it via --signature-policy.
+  # On macOS podman runs in *remote* mode against the VM, which has its own
+  # policy and rejects the local-storage --signature-policy flag, so leave
+  # this empty there (scripts skip the flag when the var is unset).
+  env.KLANGK_SIGNATURE_POLICY = lib.mkOverride 1500 (
+    if pkgs.stdenv.hostPlatform.isDarwin then
+      ""
+    else
+      config.devenv.state + "/klangk/podman/policy.json"
+  );
   env.KLANGK_INSTANCE_ID = lib.mkOverride 1500 "default";
-  # Docker build platform for klangk images. Defaults to the host
-  # architecture so arm64 machines build/run natively instead of under
-  # amd64 emulation. Override in .env (e.g. KLANGK_PLATFORM=linux/amd64)
-  # to force a specific arch. Building the workspace natively on arm64
-  # requires a base image that has an arm64 variant (see push-base-image).
+  # Docker build platform for klangk images. On Linux, default to the host
+  # architecture so arm64 machines build/run natively instead of under amd64
+  # emulation. On macOS, pin to linux/amd64: the published GHCR base
+  # (klangk-base:latest) is amd64-only, so an arm64 default would mismatch
+  # (containers run in the podman VM, emulated when needed). Override in .env
+  # to force a specific arch; native arm64 needs an arm64 base variant (see
+  # push-base-image).
   env.KLANGK_PLATFORM = lib.mkOverride 1500 (
-    if pkgs.stdenv.hostPlatform.isAarch64 then "linux/arm64" else "linux/amd64"
+    if pkgs.stdenv.hostPlatform.isDarwin then
+      "linux/amd64"
+    else if pkgs.stdenv.hostPlatform.isAarch64 then
+      "linux/arm64"
+    else
+      "linux/amd64"
   );
   dotenv.enable = true;
 


### PR DESCRIPTION
## What

Bringing the stack up on Apple Silicon via the nix devenv against the `podman machine` VM hit two macOS-only gaps. This makes `devenv up` work on macOS with **no manual overrides**.

- **`KLANGK_SIGNATURE_POLICY`** — on macOS podman runs in *remote* mode against the VM, which **rejects** the local-storage `--signature-policy` flag (`Error: unknown flag: --signature-policy`) and doesn't need it (the VM has its own policy). `pull-base-image.sh` and `build-backend-image.sh` pass it whenever the var is set, so they failed. Now empty on Darwin (scripts skip the flag); the generated `policy.json` path is kept on Linux. Moved to `mkOverride 1500` so `.env` can still override.
- **`KLANGK_PLATFORM`** — the published GHCR base (`klangk-base:latest`) is **amd64-only**, so the arm64 default mismatched on Apple Silicon (`WARNING: image platform (linux/amd64) does not match the expected platform (linux/arm64)`). Pin Darwin to `linux/amd64` (workspace containers run emulated in the VM). Linux unchanged; native arm64 still needs an arm64 base variant.

Both gated to `pkgs.stdenv.hostPlatform.isDarwin`, so Linux CI is unaffected.

## Verification (macOS, Apple Silicon)

- `podman` runtime healthy; base pulls from GHCR (public, 1.72 GB).
- `build-backend-image.sh` builds `localhost/klangk` with **no inline overrides**.
- `devenv up` → backend `:8997` (`/health` 200) and nginx `:8995` (`/` 200), `Application startup complete`.

## Note

The macOS `flutter test` xcrun-shim is handled separately in **#149** (the file-viewers M0 base), so it's intentionally **not** included here to avoid duplication/conflict.