### PR TITLE
build(web): switch web renderer to dart2js (CanvasKit) — mitigates skwasm WASM-heap crash

### DIFF
--- a/scripts/flutterbuildweb.sh
+++ b/scripts/flutterbuildweb.sh
@@ -17,7 +17,12 @@ python3 scripts/import_dart_plugins.py
 # can still override the binary; defaults to `flutter` on PATH (nix toolchain).
 FLUTTER="${KLANGK_WEB_FLUTTER:-flutter}"
 
-cd src/frontend && "$FLUTTER" --disable-analytics && "$FLUTTER" pub get && "$FLUTTER" build web --wasm --release --base-href=/ --no-web-resources-cdn --source-maps --no-strip-wasm --no-minify-wasm --no-minify-js
+# TEMPORARY: wasm builds are disabled to debug a production-only issue on
+# rag.enfoldsystems.net that is not reproducible locally. This builds the
+# dart2js (JS) renderer instead of WasmGC. To revert, restore the wasm flags:
+#   --wasm --no-strip-wasm --no-minify-wasm
+# (a benign "Wasm dry run succeeded" warning is expected in JS-only mode.)
+cd src/frontend && "$FLUTTER" --disable-analytics && "$FLUTTER" pub get && "$FLUTTER" build web --release --base-href=/ --no-web-resources-cdn --source-maps --no-minify-js
 rm -f build/web/flutter_service_worker.js
 
 # Inline `sourcesContent` into the source maps so devtools (especially
@@ -27,8 +32,15 @@ rm -f build/web/flutter_service_worker.js
 # app tree; the .map files grow (~25MB each) but the .wasm/.js artifacts are
 # unaffected.
 FLUTTER_SDK_DIR="$(cd "$(dirname "$(readlink -f "$(command -v "$FLUTTER")")")/.." && pwd)"
-python3 "$SCRIPT_DIR/inline_sources_in_map.py" "$FLUTTER_SDK_DIR" \
-  build/web/main.dart.wasm.map build/web/main.dart.js.map
+# Inline whichever maps exist: wasm builds emit main.dart.wasm.map, JS-only
+# builds emit only main.dart.js.map.
+MAPS=()
+for m in build/web/main.dart.wasm.map build/web/main.dart.js.map; do
+  [ -f "$m" ] && MAPS+=("$m")
+done
+if [ ${#MAPS[@]} -gt 0 ]; then
+  python3 "$SCRIPT_DIR/inline_sources_in_map.py" "$FLUTTER_SDK_DIR" "${MAPS[@]}"
+fi
 
 # Cache-busting: append a content hash to flutter_bootstrap.js reference
 # in index.html. Since index.html is served with no-cache headers, browsers


### PR DESCRIPTION
## Why

The `--wasm` (skwasm) web build crashes the renderer with `Uncaught RuntimeError: memory access out of bounds` from `skwasm.wasm` when the terminal renders heavy output — the canvas freezes ("seizes up") while JS keeps running. This is the fault seen on `rag.enfoldsystems.net`.

**Now reproduced locally and root-caused (2026-06-08):**

- **Repro (DPR 2 / retina):** stream ~100k *wide* lines (`yes "<long line>" | head -100000`), then a handful of `Shift+PageUp` scroll-repaints + a type-to-snap-to-bottom jump → skwasm faults. Wide-glyph content at DPR 2 is the accelerant (large per-row text atlas); it trips after only ~4 scrolls. A headless DPR-1 run never reproduced it (¼ the per-frame surface bytes), which is why it looked "not reproducible locally."
- **A/B confirms it is renderer-specific:** the identical recipe — pushed to **160k lines + ~24 scroll events + multiple snaps**, well past skwasm's failure point — runs **clean under dart2js/CanvasKit**: no `memory access out of bounds`, no skwasm fault, the canvas stays live and keeps rendering. Same widget tree, same flterm paint calls; only skwasm's WASM linear heap exhausts/corrupts.

**Localization:** this is an **engine-level Flutter bug in the skwasm renderer** — *not* klangk, flterm, or libghostty. App paint is viewport-bounded (~67 KiB regardless of scrollback); the app isn't leaking, skwasm's backing heap is.

A repeatable Playwright form of the repro lives at `src/frontend/e2e-tests/e2e/terminal-scroll-churn.spec.ts`.

## What

`scripts/flutterbuildweb.sh`:
- Drop `--wasm` and the wasm-only flags (`--no-strip-wasm`, `--no-minify-wasm`) from `flutter build web`. Keep `--release --base-href=/ --no-web-resources-cdn --source-maps --no-minify-js`.
- Make the source-map inliner skip maps that don't exist (JS builds emit only `main.dart.js.map`, not `main.dart.wasm.map`). The cache-bust loop already handled either entrypoint, so it's untouched.

A benign `Wasm dry run succeeded` warning is expected in JS-only mode (harmless; can be silenced later with `--no-wasm-dry-run` if desired).

## Validation

Built on the actual deploy toolchain — **devenv Flutter 3.41.6** (the same nix Flutter `docker-host.yml` uses via `klangk:flutter-build`):
- emits `main.dart.js` + `main.dart.js.map`, **no `.wasm`**
- source-map inliner resolves **1043/1043** sources
- cache-bust hashes `main.dart.js`
- `shfmt -s -i 2` clean, `shellcheck` clean

**Live A/B (Chrome MCP, DPR 2):** the dart2js/CanvasKit build survives the exact recipe that reliably (and repeatedly, on reload) crashes the skwasm build.

## Revert

This is the **mitigation until the upstream skwasm heap bug is fixed**. To revert once that lands: restore `--wasm --no-strip-wasm --no-minify-wasm` on the build line. The repro spec guards against silently regressing back into the crash.
