### PR TITLE
Block protected host paths and foreign volumes from workspace mounts

### DIFF
--- a/.github/workflows/backend-e2e-tests.yml
+++ b/.github/workflows/backend-e2e-tests.yml
@@ -19,6 +19,7 @@ jobs:
       KLANGK_LLM_MODEL: gemma4:31b
       # Use system podman on Ubuntu runners (nix podman lacks SUID newuidmap)
       KLANGK_PODMAN_BIN: /usr/bin/podman
+      KLANGK_PODMAN_STORAGE: /home/runner/.local/share/containers/storage
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -32,6 +32,7 @@ jobs:
       KLANGK_TEST_MODE: "1"
       # Use system podman on Ubuntu runners (nix podman lacks SUID newuidmap)
       KLANGK_PODMAN_BIN: /usr/bin/podman
+      KLANGK_PODMAN_STORAGE: /home/runner/.local/share/containers/storage
     steps:
       - uses: actions/checkout@v6
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -99,7 +99,7 @@ All settings can be overridden in `.env`. Defaults (where appropriate) are provi
 | `KLANGK_IMAGE_NAME`             | `klangk`                             | Podman image name for workspace containers                                                                                                                                                 |
 | `KLANGK_IMAGE_PULL_POLICY`      | `never`                              | Podman `--pull` policy for workspace containers (`never`, `missing`, `always`, `newer`). Default `never` requires the image to exist locally; `missing` pulls from a registry if not found |
 | `KLANGK_PODMAN_STORAGE`         |                                      | Custom path for podman image storage (graphroot). Set to a path on ext4 (not ZFS) for `--userns=keep-id` support. ZFS lacks idmapped mounts, causing slow container startup.               |
-| `KLANGK_ALLOWED_MOUNT_ROOTS`    |                                      | Comma-separated list of allowed host path prefixes for bind mounts (e.g., `/home,/data`). If unset, all bind mount paths are allowed.                                                      |
+| `KLANGK_ALLOWED_MOUNT_ROOTS`    |                                      | Comma-separated list of allowed host path prefixes for bind mounts (e.g., `/home,/data`). If unset, all bind mount paths are allowed. Protected paths are always blocked (see below).      |
 | `KLANGK_INSTANCE_ID`            | `default`                            | Instance identifier for multi-instance deployments on the same host — isolates containers, names, and cleanup                                                                              |
 | `KLANGK_DNS_SERVERS`            |                                      | Comma-separated DNS server IPs for containers (e.g., `100.100.100.100,8.8.8.8` for Tailscale MagicDNS). If unset, containers use podman's default DNS.                                     |
 | `KLANGK_HOSTING_HOSTNAME`       | (auto-derived)                       | Hostname for hosted app URLs. Behind a reverse proxy: uses `X-Forwarded-Host` as-is. Direct access: uses `Host` header with `KLANGK_NGINX_PORT` substituted                                |
@@ -155,6 +155,17 @@ KLANGK_DNS_SERVERS=100.100.100.100,8.8.8.8            # for containers (works fi
 ```
 
 Tailscale IPs are stable and don't change, so using the IP directly is safe.
+
+### Mount Security
+
+Workspace bind mounts are validated at create and edit time. Two protections apply regardless of `KLANGK_ALLOWED_MOUNT_ROOTS`:
+
+**Protected paths** — the following host paths are always blocked, even if they fall under an allowed root:
+
+- `/var/run/docker.sock`, `/run/docker.sock`, `/run/podman/podman.sock` — mounting a container engine socket grants full host control
+- `KLANGK_DATA_DIR` (and anything beneath it) — contains every user's workspace home and the database
+
+**Volume instance isolation** — named volumes (e.g., `nix-store:/nix`) are labelled with `klangk.instance` at creation time. A workspace cannot mount a volume created by a different `KLANGK_INSTANCE_ID`. This prevents cross-tenant data access on shared hosts.
 
 ## Branch Protection
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -165,7 +165,7 @@ Workspace bind mounts are validated at create and edit time. Two protections app
 - `/var/run/docker.sock`, `/run/docker.sock`, `/run/podman/podman.sock` — mounting a container engine socket grants full host control
 - `KLANGK_DATA_DIR` (and anything beneath it) — contains every user's workspace home and the database
 
-**Volume instance isolation** — named volumes (e.g., `nix-store:/nix`) are labelled with `klangk.instance` at creation time. A workspace cannot mount a volume created by a different `KLANGK_INSTANCE_ID`. This prevents cross-tenant data access on shared hosts.
+**Volume isolation** — named volumes (e.g., `nix-store:/nix`) are labelled with `klangk.instance` and `klangk.user-id` at creation time. A workspace cannot mount a volume created by a different `KLANGK_INSTANCE_ID` or a different user. This prevents both cross-tenant and cross-user data access on shared hosts.
 
 ## Branch Protection
 

--- a/src/backend/e2e-tests/test_cli_e2e.py
+++ b/src/backend/e2e-tests/test_cli_e2e.py
@@ -1315,6 +1315,109 @@ class TestAllowedMountRoots:
         )
 
 
+class TestVolumeUserIsolation:
+    """Verify that a user cannot mount another user's volume."""
+
+    @pytest.fixture(autouse=True, scope="class")
+    def two_user_server(self, tmp_path_factory):
+        import httpx
+
+        data_dir = tempfile.mkdtemp(prefix="klangk-vol-iso-")
+        proc, base_url = _start_server(
+            data_dir,
+            "18999",
+            "vol-iso-e2e",
+        )
+
+        # Register a second user via the API
+        httpx.post(
+            f"{base_url}/auth/register",
+            json={
+                "email": "user2@example.com",
+                "password": "testpass2",
+            },
+        )
+
+        # Set up CLI configs for both users
+        for attr, email, password in [
+            ("_env_a", "test@example.com", "testpass"),
+            ("_env_b", "user2@example.com", "testpass2"),
+        ]:
+            config_dir = tmp_path_factory.mktemp(f"klangk-vol-iso-{attr}")
+            env = {**os.environ, "HOME": str(config_dir)}
+            (config_dir / ".config" / "klangk").mkdir(parents=True)
+            _run(
+                [
+                    "klangk",
+                    "login",
+                    email,
+                    "--server",
+                    base_url,
+                    "--password-file",
+                    "-",
+                ],
+                input=f"{password}\n",
+                env=env,
+            )
+            setattr(self.__class__, attr, env)
+
+        self.__class__._base_url = base_url
+        yield
+        _stop_server(proc, data_dir, "vol-iso-e2e")
+
+    def test_cross_user_volume_rejected(self):
+        env_a = self._env_a
+        env_b = self._env_b
+
+        # User A creates workspace with a named volume
+        _run(
+            [
+                "klangk",
+                "create",
+                "ws-a",
+                "--mount",
+                "shared-vol:/data",
+            ],
+            env=env_a,
+        )
+        try:
+            # User A execs to trigger container start (creates the volume)
+            result = _run(
+                ["klangk", "exec", "ws-a", "echo", "ok"],
+                env=env_a,
+                timeout=60,
+            )
+            assert result.returncode == 0
+
+            # User B creates workspace with the same volume
+            _run(
+                [
+                    "klangk",
+                    "create",
+                    "ws-b",
+                    "--mount",
+                    "shared-vol:/data",
+                ],
+                env=env_b,
+            )
+            try:
+                # User B execs — should fail because the volume belongs to A
+                result = _run(
+                    ["klangk", "exec", "ws-b", "echo", "stolen"],
+                    env=env_b,
+                    timeout=60,
+                )
+                assert result.returncode != 0
+            finally:
+                _run(["klangk", "rm", "ws-b"], env=env_b)
+        finally:
+            _run(["klangk", "rm", "ws-a"], env=env_a)
+            subprocess.run(
+                ["podman", "volume", "rm", "shared-vol"],
+                capture_output=True,
+            )
+
+
 class TestContainerReplace:
     """Verify podman --replace handles stale/crashed containers."""
 

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -74,6 +74,33 @@ ALLOWED_MOUNT_ROOTS: list[str] = [
     if p.strip()
 ]
 
+_PROTECTED_PATHS = [
+    "/var/run/docker.sock",
+    "/run/docker.sock",
+    "/run/podman/podman.sock",
+]
+
+
+def _is_named_volume(source: str) -> bool:
+    """A mount source with no '/' that doesn't start with '.' is a volume."""
+    return "/" not in source and not source.startswith(".")
+
+
+def _is_protected(source: str) -> bool:
+    """True if source is a protected host path that must never be mounted."""
+    norm = os.path.normpath(source)
+    data_dir = os.path.normpath(
+        util.resolve_env_secret(
+            "KLANGK_DATA_DIR", os.path.expanduser("~/.klangk/data")
+        )
+        or os.path.expanduser("~/.klangk/data")
+    )
+    for blocked in [*_PROTECTED_PATHS, data_dir]:
+        blocked = os.path.normpath(blocked)
+        if norm == blocked or norm.startswith(blocked + "/"):
+            return True
+    return False
+
 
 def validate_mount_spec(spec: str) -> str | None:
     """Validate a container mount spec string.
@@ -95,17 +122,20 @@ def validate_mount_spec(spec: str) -> str | None:
         for opt in options.split(","):
             if opt and opt not in _VALID_MOUNT_OPTIONS:
                 return f"Invalid mount {spec!r}: unknown option {opt!r}"
-    if ALLOWED_MOUNT_ROOTS and source.startswith("/"):
-        norm = os.path.normpath(source)
-        if not any(
-            norm == root or norm.startswith(root + "/")
-            for root in ALLOWED_MOUNT_ROOTS
-        ):
-            allowed = ", ".join(ALLOWED_MOUNT_ROOTS)
-            return (
-                f"Invalid mount {spec!r}: bind mount source must be "
-                f"under an allowed root ({allowed})"
-            )
+    if not _is_named_volume(source):
+        if _is_protected(source):
+            return f"Invalid mount {spec!r}: source is a protected host path"
+        if ALLOWED_MOUNT_ROOTS:
+            norm = os.path.normpath(source)
+            if not any(
+                norm == root or norm.startswith(root + "/")
+                for root in ALLOWED_MOUNT_ROOTS
+            ):
+                allowed = ", ".join(ALLOWED_MOUNT_ROOTS)
+                return (
+                    f"Invalid mount {spec!r}: bind mount source must be "
+                    f"under an allowed root ({allowed})"
+                )
     return None
 
 
@@ -398,11 +428,13 @@ class ContainerRegistry:
                 env_vars.append(f"{k}={v}")
 
         # Ensure named volumes in extra_mounts exist with klangk labels.
+        # Refuse to mount a volume owned by another instance.
         if extra_mounts:
             for mount_spec in extra_mounts:
                 source = mount_spec.split(":")[0]
-                if "/" not in source and not source.startswith("."):
-                    if await podman.inspect_volume(source) is None:
+                if _is_named_volume(source):
+                    info = await podman.inspect_volume(source)
+                    if info is None:
                         await podman.create_volume(
                             source,
                             {
@@ -410,6 +442,13 @@ class ContainerRegistry:
                                 "klangk.instance": INSTANCE_ID,
                             },
                         )
+                    else:
+                        labels = info.get("Labels") or {}
+                        if labels.get("klangk.instance") != INSTANCE_ID:
+                            raise ValueError(
+                                f"Volume {source!r} is not managed by this "
+                                "klangk instance"
+                            )
 
         binds = [
             f"{home_path}:/home/klangk",

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -337,6 +337,7 @@ class ContainerRegistry:
         config_path: str | None = None,
         extra_mounts: list[str] | None = None,
         extra_env: dict[str, str] | None = None,
+        user_id: str | None = None,
     ) -> tuple[str, str]:
         """Start (or restart) a Pi container for a workspace.
 
@@ -428,26 +429,31 @@ class ContainerRegistry:
                 env_vars.append(f"{k}={v}")
 
         # Ensure named volumes in extra_mounts exist with klangk labels.
-        # Refuse to mount a volume owned by another instance.
+        # Refuse to mount a volume owned by another instance or user.
         if extra_mounts:
             for mount_spec in extra_mounts:
                 source = mount_spec.split(":")[0]
                 if _is_named_volume(source):
                     info = await podman.inspect_volume(source)
                     if info is None:
-                        await podman.create_volume(
-                            source,
-                            {
-                                "klangk.managed": "true",
-                                "klangk.instance": INSTANCE_ID,
-                            },
-                        )
+                        labels = {
+                            "klangk.managed": "true",
+                            "klangk.instance": INSTANCE_ID,
+                        }
+                        if user_id:
+                            labels["klangk.user-id"] = user_id
+                        await podman.create_volume(source, labels)
                     else:
-                        labels = info.get("Labels") or {}
-                        if labels.get("klangk.instance") != INSTANCE_ID:
+                        vol_labels = info.get("Labels") or {}
+                        if vol_labels.get("klangk.instance") != INSTANCE_ID:
                             raise ValueError(
                                 f"Volume {source!r} is not managed by this "
                                 "klangk instance"
+                            )
+                        vol_owner = vol_labels.get("klangk.user-id")
+                        if vol_owner and user_id and vol_owner != user_id:
+                            raise ValueError(
+                                f"Volume {source!r} belongs to another user"
                             )
 
         binds = [

--- a/src/backend/klangk_backend/wshandler.py
+++ b/src/backend/klangk_backend/wshandler.py
@@ -531,6 +531,7 @@ class Connection:
             config_path=cfg_path,
             extra_mounts=workspace.get("mounts"),
             extra_env=workspace.get("env"),
+            user_id=self.user["id"],
         )
         self.container_status = container_status
         self.workspace_id = workspace_id

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -861,6 +861,40 @@ class TestAllowedMountRoots:
         assert err is not None
 
 
+class TestProtectedPaths:
+    def test_docker_socket_blocked(self, monkeypatch):
+        monkeypatch.setattr(container, "ALLOWED_MOUNT_ROOTS", ["/"])
+        err = container.validate_mount_spec(
+            "/var/run/docker.sock:/var/run/docker.sock"
+        )
+        assert err is not None
+        assert "protected" in err.lower()
+
+    def test_podman_socket_blocked(self, monkeypatch):
+        monkeypatch.setattr(container, "ALLOWED_MOUNT_ROOTS", ["/"])
+        err = container.validate_mount_spec(
+            "/run/podman/podman.sock:/run/podman/podman.sock"
+        )
+        assert err is not None
+        assert "protected" in err.lower()
+
+    def test_data_dir_blocked(self, monkeypatch):
+        monkeypatch.setattr(container, "ALLOWED_MOUNT_ROOTS", ["/"])
+        monkeypatch.setenv("KLANGK_DATA_DIR", "/srv/klangk/data")
+        err = container.validate_mount_spec(
+            "/srv/klangk/data/workspaces:/loot"
+        )
+        assert err is not None
+        assert "protected" in err.lower()
+
+    def test_protected_blocked_even_without_allowlist(self):
+        err = container.validate_mount_spec(
+            "/var/run/docker.sock:/var/run/docker.sock"
+        )
+        assert err is not None
+        assert "protected" in err.lower()
+
+
 class TestExtraMountsVolumeCreation:
     async def test_auto_creates_named_volume(self, workspace):
         """Named volumes (no leading /) are auto-created with klangk labels."""
@@ -879,9 +913,14 @@ class TestExtraMountsVolumeCreation:
         assert labels["klangk.instance"] == container.INSTANCE_ID
 
     async def test_existing_volume_not_recreated(self, workspace):
-        """Existing volumes are used as-is, not recreated."""
+        """Existing volumes owned by this instance are used as-is."""
         with patch_podman(
-            inspect_volume=AsyncMock(return_value={"Name": "existing"})
+            inspect_volume=AsyncMock(
+                return_value={
+                    "Name": "existing",
+                    "Labels": {"klangk.instance": container.INSTANCE_ID},
+                }
+            )
         ) as p:
             await container.registry.start_container(
                 workspace["id"],
@@ -890,6 +929,37 @@ class TestExtraMountsVolumeCreation:
                 extra_mounts=["existing:/data"],
             )
         p.create_volume.assert_not_awaited()
+
+    async def test_foreign_volume_rejected(self, workspace):
+        """A named volume owned by another instance is refused."""
+        with patch_podman(
+            inspect_volume=AsyncMock(
+                return_value={
+                    "Name": "stolen",
+                    "Labels": {"klangk.instance": "someone-else"},
+                }
+            )
+        ):
+            with pytest.raises(ValueError, match="not managed by this"):
+                await container.registry.start_container(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    extra_mounts=["stolen:/data"],
+                )
+
+    async def test_unlabelled_volume_rejected(self, workspace):
+        """A named volume with no klangk labels is refused."""
+        with patch_podman(
+            inspect_volume=AsyncMock(return_value={"Name": "bare"})
+        ):
+            with pytest.raises(ValueError, match="not managed by this"):
+                await container.registry.start_container(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    extra_mounts=["bare:/data"],
+                )
 
     async def test_bind_mount_not_treated_as_volume(self, workspace):
         """Bind mounts (starting with /) are not treated as volumes."""

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -905,20 +905,25 @@ class TestExtraMountsVolumeCreation:
                 "/tmp/ws",
                 "/tmp/home",
                 extra_mounts=["nix-store:/nix"],
+                user_id="user-123",
             )
         p.create_volume.assert_awaited_once()
         name, labels = p.create_volume.call_args.args
         assert name == "nix-store"
         assert labels["klangk.managed"] == "true"
         assert labels["klangk.instance"] == container.INSTANCE_ID
+        assert labels["klangk.user-id"] == "user-123"
 
     async def test_existing_volume_not_recreated(self, workspace):
-        """Existing volumes owned by this instance are used as-is."""
+        """Existing volumes owned by this instance and user are used as-is."""
         with patch_podman(
             inspect_volume=AsyncMock(
                 return_value={
                     "Name": "existing",
-                    "Labels": {"klangk.instance": container.INSTANCE_ID},
+                    "Labels": {
+                        "klangk.instance": container.INSTANCE_ID,
+                        "klangk.user-id": "user-123",
+                    },
                 }
             )
         ) as p:
@@ -927,6 +932,7 @@ class TestExtraMountsVolumeCreation:
                 "/tmp/ws",
                 "/tmp/home",
                 extra_mounts=["existing:/data"],
+                user_id="user-123",
             )
         p.create_volume.assert_not_awaited()
 
@@ -960,6 +966,49 @@ class TestExtraMountsVolumeCreation:
                     "/tmp/home",
                     extra_mounts=["bare:/data"],
                 )
+
+    async def test_cross_user_volume_rejected(self, workspace):
+        """A volume owned by another user is refused."""
+        with patch_podman(
+            inspect_volume=AsyncMock(
+                return_value={
+                    "Name": "private",
+                    "Labels": {
+                        "klangk.instance": container.INSTANCE_ID,
+                        "klangk.user-id": "user-other",
+                    },
+                }
+            )
+        ):
+            with pytest.raises(ValueError, match="belongs to another user"):
+                await container.registry.start_container(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    extra_mounts=["private:/data"],
+                    user_id="user-me",
+                )
+
+    async def test_volume_without_user_label_allowed(self, workspace):
+        """A volume with no user-id label (pre-existing) is allowed."""
+        with patch_podman(
+            inspect_volume=AsyncMock(
+                return_value={
+                    "Name": "legacy",
+                    "Labels": {
+                        "klangk.instance": container.INSTANCE_ID,
+                    },
+                }
+            )
+        ) as p:
+            await container.registry.start_container(
+                workspace["id"],
+                "/tmp/ws",
+                "/tmp/home",
+                extra_mounts=["legacy:/data"],
+                user_id="user-123",
+            )
+        p.create_volume.assert_not_awaited()
 
     async def test_bind_mount_not_treated_as_volume(self, workspace):
         """Bind mounts (starting with /) are not treated as volumes."""


### PR DESCRIPTION
## Summary
- Always block mounting docker/podman sockets and `KLANGK_DATA_DIR`, even if they fall under an allowed mount root
- Reject named volumes not owned by the current `KLANGK_INSTANCE_ID` to prevent cross-tenant data access
- Document mount security in HACKING.md

## Test plan
- [ ] Unit tests: protected path tests (docker socket, podman socket, data dir), foreign volume rejection, unlabelled volume rejection
- [ ] Verify existing mount restriction tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)