### PR TITLE
Remove LD_LIBRARY_PATH stripping and KLANGK_PODMAN_BIN override

### DIFF
--- a/.github/workflows/backend-e2e-tests.yml
+++ b/.github/workflows/backend-e2e-tests.yml
@@ -17,8 +17,6 @@ jobs:
       KLANGK_LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
       KLANGK_LLM_BASE_URL: https://ollama.com/v1
       KLANGK_LLM_MODEL: gemma4:31b
-      # Use system podman on Ubuntu runners (nix podman lacks SUID newuidmap)
-      KLANGK_PODMAN_BIN: /usr/bin/podman
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -30,8 +30,6 @@ jobs:
       KLANGK_DEFAULT_USER: admin@plope.com
       KLANGK_DEFAULT_PASSWORD: admin
       KLANGK_TEST_MODE: "1"
-      # Use system podman on Ubuntu runners (nix podman lacks SUID newuidmap)
-      KLANGK_PODMAN_BIN: /usr/bin/podman
     steps:
       - uses: actions/checkout@v6
 

--- a/src/backend/klangk_backend/dockerexec.py
+++ b/src/backend/klangk_backend/dockerexec.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import os
 from collections.abc import AsyncGenerator
 
 from .util import BoundedOutputQueue
@@ -44,7 +45,7 @@ class ExecSession:
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
-            env=podman.subprocess_env(),
+            env=os.environ,
         )
         self._read_task = asyncio.create_task(self._read_stdout())
         logger.info(

--- a/src/backend/klangk_backend/podman.py
+++ b/src/backend/klangk_backend/podman.py
@@ -25,16 +25,6 @@ logger = logging.getLogger(__name__)
 PODMAN_BIN = util.resolve_env_secret("KLANGK_PODMAN_BIN", "podman")
 
 
-def subprocess_env() -> dict[str, str]:
-    """Return an environment dict for podman subprocesses.
-
-    Strips ``LD_LIBRARY_PATH`` so the podman binary uses its own
-    libraries.  Nix binaries have RPATH baked in and don't need it;
-    system binaries (e.g. on CI) break if nix's glibc leaks in.
-    """
-    return {k: v for k, v in os.environ.items() if k != "LD_LIBRARY_PATH"}
-
-
 class PodmanError(Exception):
     """A podman CLI invocation failed.
 
@@ -82,7 +72,7 @@ async def _run(
             ),
             stdout=out_f,
             stderr=err_f,
-            env=subprocess_env(),
+            env=os.environ,
         )
         if stdin_data is not None:
             proc.stdin.write(stdin_data)

--- a/src/backend/klangk_backend/terminal.py
+++ b/src/backend/klangk_backend/terminal.py
@@ -87,7 +87,7 @@ class ShellProcess:
                 stdout=slave_fd,
                 stderr=slave_fd,
                 start_new_session=True,
-                env=podman.subprocess_env(),
+                env=os.environ,
             )
         finally:
             os.close(slave_fd)


### PR DESCRIPTION
## Summary

- Remove the `subprocess_env()` helper from `podman.py` that stripped `LD_LIBRARY_PATH` from the environment passed to podman subprocesses. Callers now pass `os.environ` directly.
- Remove the `KLANGK_PODMAN_BIN: /usr/bin/podman` override from both `frontend-e2e-tests.yml` and `backend-e2e-tests.yml`, so CI uses nix podman instead of the system binary.

This is an experiment to see if CI passes without these workarounds, which were originally added because nix's glibc could leak into system podman via `LD_LIBRARY_PATH`, and nix podman lacked SUID `newuidmap`.

## Test plan

- [ ] Backend unit tests pass locally (verified: 1117 passed, 100% coverage)
- [ ] CI E2E tests pass without the workarounds