### PR TITLE
Fix nginx ACL host IP detection on macOS

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -32,19 +32,22 @@ in
     directory = "./src/backend";
   };
 
-  packages = with pkgs; [
-    bash # explicit bash for shell scripts (CI /bin/sh may be dash)
-    coreutils # GNU du (macOS BSD du lacks -b)
-    docker-client
-    flutter
-    git # "error: Failed to find git" during devenv:git-hooks:install
-    gzip
-    gnutar
-    nginx
-    podman
-    sqlite.bin
-    rsync
-  ];
+  packages =
+    with pkgs;
+    [
+      bash # explicit bash for shell scripts (CI /bin/sh may be dash)
+      coreutils # GNU du (macOS BSD du lacks -b)
+      docker-client
+      flutter
+      git # "error: Failed to find git" during devenv:git-hooks:install
+      gzip
+      gnutar
+      nginx
+      podman
+      sqlite.bin
+      rsync
+    ]
+    ++ (if pkgs.stdenv.isDarwin then [ iproute2mac ] else [ iproute2 ]);
 
   env.PLAYWRIGHT_BROWSERS_PATH = pkgs.playwright-driver.browsers;
   env.PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS = "true";


### PR DESCRIPTION
## Summary
- Add `iproute2mac` (Darwin) / `iproute2` (Linux) to devenv packages so the `ip` command is available on both platforms.
- `nginx.sh` uses `ip -4 addr show` to auto-detect host IPs for the container ACL. This was failing on macOS because `ip` doesn't exist there, causing fallback to broad RFC1918 ranges.

## Test plan
- [x] `devenv shell -- ip -4 addr show` works on Linux
- [ ] `devenv shell -- ip -4 addr show` works on macOS after `devenv up`
- [ ] nginx container ACL shows detected host IPs instead of fallback ranges

🤖 Generated with [Claude Code](https://claude.com/claude-code)