### PR TITLE
Gate volume endpoints by user ownership

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -608,9 +608,9 @@ klangk export my-project            # export workspace to my-project.tar.gz (adm
 klangk export my-project -o bak.tar.gz  # export to specific file
 klangk import bak.tar.gz            # import workspace from archive
 klangk import bak.tar.gz --name new-name  # import with a different name
-klangk volumes ls                   # list podman volumes
-klangk volumes create nix-store     # create a named volume
-klangk volumes rm nix-store         # delete a volume
+klangk volumes ls                   # list your podman volumes
+klangk volumes create nix-store     # create a named volume (owned by you)
+klangk volumes rm nix-store         # delete a volume (must be yours)
 ```
 
 The CLI connects to the running Klangk backend over HTTP + WebSocket — it works locally and against remote servers.

--- a/src/backend/e2e-tests/test_cli_e2e.py
+++ b/src/backend/e2e-tests/test_cli_e2e.py
@@ -1418,6 +1418,56 @@ class TestVolumeUserIsolation:
                 capture_output=True,
             )
 
+    def test_volumes_ls_only_own(self):
+        """Each user only sees their own volumes via 'volumes ls'."""
+        env_a = self._env_a
+        env_b = self._env_b
+
+        # User A creates a volume
+        result = _run(["klangk", "volumes", "create", "vol-a"], env=env_a)
+        assert result.returncode == 0
+        try:
+            # User B creates a volume
+            result = _run(["klangk", "volumes", "create", "vol-b"], env=env_b)
+            assert result.returncode == 0
+            try:
+                # User A should see vol-a but not vol-b
+                result = _run(
+                    ["klangk", "volumes", "ls", "--plain"], env=env_a
+                )
+                assert "vol-a" in result.stdout
+                assert "vol-b" not in result.stdout
+
+                # User B should see vol-b but not vol-a
+                result = _run(
+                    ["klangk", "volumes", "ls", "--plain"], env=env_b
+                )
+                assert "vol-b" in result.stdout
+                assert "vol-a" not in result.stdout
+            finally:
+                _run(["klangk", "volumes", "rm", "vol-b"], env=env_b)
+        finally:
+            _run(["klangk", "volumes", "rm", "vol-a"], env=env_a)
+
+    def test_volumes_rm_other_user_rejected(self):
+        """A user cannot delete another user's volume."""
+        env_a = self._env_a
+        env_b = self._env_b
+
+        # User A creates a volume
+        result = _run(
+            ["klangk", "volumes", "create", "vol-private"], env=env_a
+        )
+        assert result.returncode == 0
+        try:
+            # User B tries to delete it — should fail
+            result = _run(
+                ["klangk", "volumes", "rm", "vol-private"], env=env_b
+            )
+            assert result.returncode != 0
+        finally:
+            _run(["klangk", "volumes", "rm", "vol-private"], env=env_a)
+
 
 class TestContainerReplace:
     """Verify podman --replace handles stale/crashed containers."""

--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -814,18 +814,20 @@ async def list_images(_user: dict = Depends(auth.get_current_user)):
 
 
 @router.get("/volumes")
-async def list_volumes(_user: dict = Depends(auth.get_current_user)):
+async def list_volumes(user: dict = Depends(auth.get_current_user)):
     from . import podman
 
     volumes = await podman.list_volumes(
         f"klangk.instance={container.INSTANCE_ID}"
     )
+    uid = user["id"]
     return [
         {
             "name": v["Name"],
             "created": v.get("CreatedAt", ""),
         }
         for v in volumes
+        if (v.get("Labels") or {}).get("klangk.user-id") == uid
     ]
 
 
@@ -836,7 +838,7 @@ class CreateVolumeRequest(BaseModel):
 @router.post("/volumes")
 async def create_volume(
     body: CreateVolumeRequest,
-    _user: dict = Depends(auth.get_current_user),
+    user: dict = Depends(auth.get_current_user),
 ):
     from . import podman
 
@@ -849,6 +851,7 @@ async def create_volume(
         {
             "klangk.managed": "true",
             "klangk.instance": container.INSTANCE_ID,
+            "klangk.user-id": user["id"],
         },
     )
     return {"name": info["Name"], "created": info.get("CreatedAt", "")}
@@ -856,7 +859,7 @@ async def create_volume(
 
 @router.delete("/volumes/{name}")
 async def delete_volume(
-    name: str, _user: dict = Depends(auth.get_current_user)
+    name: str, user: dict = Depends(auth.get_current_user)
 ):
     from . import podman
 
@@ -868,6 +871,11 @@ async def delete_volume(
         raise HTTPException(
             status_code=404,
             detail="Volume not managed by this Klangk instance",
+        )
+    if labels.get("klangk.user-id") != user["id"]:
+        raise HTTPException(
+            status_code=403,
+            detail="Volume belongs to another user",
         )
     try:
         await podman.remove_volume(name)

--- a/src/backend/klangk_backend/cli/main.py
+++ b/src/backend/klangk_backend/cli/main.py
@@ -862,6 +862,9 @@ def volumes_rm(
     client = _client()
     resp = client.delete(f"/volumes/{name}")
     client._check_auth(resp)
+    if resp.status_code == 403:
+        _err.print(f"[red]Permission denied:[/red] {name}")
+        raise typer.Exit(code=1)
     if resp.status_code == 404:
         _err.print(f"[red]Volume not found:[/red] {name}")
         raise typer.Exit(code=1)

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -1715,12 +1715,13 @@ class TestBrowserBridge:
 # --- Volume routes ---
 
 
-def _managed_volume():
+def _managed_volume(user_id="test-user"):
     """An inspect_volume result owned by this klangk instance."""
     return {
         "Labels": {
             "klangk.managed": "true",
             "klangk.instance": container.INSTANCE_ID,
+            "klangk.user-id": user_id,
         }
     }
 
@@ -1734,10 +1735,21 @@ class TestVolumeRoutes:
             AsyncMock(
                 return_value=[
                     {
-                        "Name": "test-vol",
+                        "Name": "my-vol",
                         "CreatedAt": "2026-01-01T00:00:00Z",
-                        "Labels": {"klangk.instance": container.INSTANCE_ID},
-                    }
+                        "Labels": {
+                            "klangk.instance": container.INSTANCE_ID,
+                            "klangk.user-id": user["id"],
+                        },
+                    },
+                    {
+                        "Name": "other-vol",
+                        "CreatedAt": "2026-01-01T00:00:00Z",
+                        "Labels": {
+                            "klangk.instance": container.INSTANCE_ID,
+                            "klangk.user-id": "someone-else",
+                        },
+                    },
                 ]
             ),
         ):
@@ -1745,24 +1757,18 @@ class TestVolumeRoutes:
         assert resp.status_code == 200
         data = resp.json()
         assert len(data) == 1
-        assert data[0]["name"] == "test-vol"
+        assert data[0]["name"] == "my-vol"
 
     async def test_create_volume(self, client, user):
         headers = await _auth_headers(client)
+        mock_create = AsyncMock(
+            return_value={"Name": "new-vol", "CreatedAt": "2026-01-01"}
+        )
         with (
             patch.object(
                 podman, "inspect_volume", AsyncMock(return_value=None)
             ),
-            patch.object(
-                podman,
-                "create_volume",
-                AsyncMock(
-                    return_value={
-                        "Name": "new-vol",
-                        "CreatedAt": "2026-01-01",
-                    }
-                ),
-            ),
+            patch.object(podman, "create_volume", mock_create),
         ):
             resp = await client.post(
                 "/volumes",
@@ -1771,6 +1777,8 @@ class TestVolumeRoutes:
             )
         assert resp.status_code == 200
         assert resp.json()["name"] == "new-vol"
+        _, labels = mock_create.call_args.args
+        assert labels["klangk.user-id"] == user["id"]
 
     async def test_create_duplicate_volume(self, client, user):
         headers = await _auth_headers(client)
@@ -1811,7 +1819,7 @@ class TestVolumeRoutes:
             patch.object(
                 podman,
                 "inspect_volume",
-                AsyncMock(return_value=_managed_volume()),
+                AsyncMock(return_value=_managed_volume(user["id"])),
             ),
             patch.object(podman, "remove_volume", AsyncMock()),
         ):
@@ -1836,6 +1844,16 @@ class TestVolumeRoutes:
             resp = await client.delete("/volumes/foreign", headers=headers)
         assert resp.status_code == 404
 
+    async def test_delete_volume_wrong_user(self, client, user):
+        headers = await _auth_headers(client)
+        with patch.object(
+            podman,
+            "inspect_volume",
+            AsyncMock(return_value=_managed_volume("someone-else")),
+        ):
+            resp = await client.delete("/volumes/other", headers=headers)
+        assert resp.status_code == 403
+
     async def test_delete_volume_remove_not_found(self, client, user):
         """Volume vanishes between inspect and remove -> 404."""
         headers = await _auth_headers(client)
@@ -1843,7 +1861,7 @@ class TestVolumeRoutes:
             patch.object(
                 podman,
                 "inspect_volume",
-                AsyncMock(return_value=_managed_volume()),
+                AsyncMock(return_value=_managed_volume(user["id"])),
             ),
             patch.object(
                 podman,
@@ -1860,7 +1878,7 @@ class TestVolumeRoutes:
             patch.object(
                 podman,
                 "inspect_volume",
-                AsyncMock(return_value=_managed_volume()),
+                AsyncMock(return_value=_managed_volume(user["id"])),
             ),
             patch.object(
                 podman,
@@ -1877,7 +1895,7 @@ class TestVolumeRoutes:
             patch.object(
                 podman,
                 "inspect_volume",
-                AsyncMock(return_value=_managed_volume()),
+                AsyncMock(return_value=_managed_volume(user["id"])),
             ),
             patch.object(
                 podman,

--- a/src/backend/tests/test_cli_main.py
+++ b/src/backend/tests/test_cli_main.py
@@ -1434,6 +1434,19 @@ class TestVolumes:
         result = runner.invoke(main.app, ["volumes", "rm", "busy"])
         assert result.exit_code == 1
 
+    def test_volumes_rm_permission_denied(self, logged_in_cfg, monkeypatch):
+        from klangk_backend.cli import main
+
+        client = MagicMock()
+        client.delete.return_value = MagicMock(status_code=403)
+        monkeypatch.setattr(main, "_client", lambda: client)
+
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+        result = runner.invoke(main.app, ["volumes", "rm", "not-mine"])
+        assert result.exit_code == 1
+
 
 class TestExportImportCLI:
     def test_export_success(self, logged_in_cfg, monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- Volume `GET /volumes` now only returns volumes owned by the calling user (filtered by `klangk.user-id` label)
- Volume `POST /volumes` now stamps `klangk.user-id` on created volumes
- Volume `DELETE /volumes/{name}` returns 403 if the volume belongs to another user
- CLI `volumes rm` handles 403 with a "Permission denied" message
- E2E tests verify cross-user list filtering and delete rejection

Closes #171

## Test plan
- [x] Unit tests pass (1134 passed, 100% coverage)
- [x] CLI unit test for 403 on `volumes rm`
- [x] E2E: `test_volumes_ls_only_own` — each user only sees their own volumes
- [x] E2E: `test_volumes_rm_other_user_rejected` — cannot delete another user's volume
- [ ] CI passes

Closes #171