### PR TITLE
Document OIDC group mapping hook security responsibility

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -490,6 +490,8 @@ Async hooks are also supported (`async def`).
 - If the hook raises an exception, it's logged and group sync is skipped (user still logs in)
 - If `KLANGK_GROUP_MAPPING_HOOK` is not set, no group sync occurs
 
+**Security note:** The hook is entirely responsible for auditing, logging, and hardening of group sync operations. There is no default hook and no default mappings — the hook is written by the deploying organization (or their consultants), and it is their responsibility to give IdP claims as much or as little trust as appropriate. There is no declarative aspect to its operation; the hook is arbitrary Python code with full control over which groups are returned.
+
 **Built-in example hook:**
 
 An example hook is included at `klangk_backend.oidc.example_admin_hook` that maps the `realm_access.roles` claim containing `klangk-admin` to the `admin` group. Use it as a starting point:


### PR DESCRIPTION
## Summary
- Add security note to HACKING.md clarifying that the OIDC group mapping hook is responsible for its own auditing, logging, and hardening. There is no default hook, no default mappings, and no declarative guardrails — the deploying organization writes the hook and controls how much trust to give IdP claims.

Closes #169.

## Test plan
- [x] Documentation-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)