### PR TITLE
Remove host SSH agent socket forwarding from containers

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -117,7 +117,6 @@ In CI, `devenv processes up -d` starts nginx before E2E tests run.
 - Root escalation prevented: root password locked, suid removed from `su`/`chsh`/`chfn`/`newgrp`
 - Containers labeled with `klangk.managed=true`, `klangk.instance=<KLANGK_INSTANCE_ID>`, and `klangk.workspace-id=<id>` for identification, cleanup, and orphan detection (not reliant on image name). Multiple Klangk instances on the same host use different `KLANGK_INSTANCE_ID` values to isolate their containers.
 - `--init` runs an init process as PID 1 to reap zombie processes from terminal sessions and tool executions
-- **SSH agent forwarding**: If the host has an SSH agent running (`SSH_AUTH_SOCK` set and socket exists), it is automatically bind-mounted into the container at `/run/ssh-agent.sock`. Private keys never enter the container — the agent socket forwards signing requests back to the host. Use `ssh-add -c` on the host to require per-operation confirmation.
 
 ### Container Terminal
 

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -3,7 +3,6 @@
 import asyncio
 import logging
 import os
-import sys
 import time
 import uuid
 
@@ -413,17 +412,6 @@ class ContainerRegistry:
         env_vars.append(f"KLANGK_HOSTING_PROTO={hosting_proto}")
         env_vars.append(f"KLANGK_HOSTING_BASE_PATH={hosting_base_path}")
 
-        # Forward host SSH agent if available.
-        # On macOS, Podman runs containers in a Linux VM so host Unix
-        # sockets cannot be bind-mounted; skip SSH forwarding there.
-        ssh_auth_sock = os.environ.get("SSH_AUTH_SOCK", "")
-        if (
-            ssh_auth_sock
-            and os.path.exists(ssh_auth_sock)
-            and sys.platform != "darwin"
-        ):
-            env_vars.append("SSH_AUTH_SOCK=/run/ssh-agent.sock")
-
         if extra_env:
             for k, v in extra_env.items():
                 env_vars.append(f"{k}={v}")
@@ -459,12 +447,6 @@ class ContainerRegistry:
         binds = [
             f"{home_path}:/home/klangk",
         ]
-        if (
-            ssh_auth_sock
-            and os.path.exists(ssh_auth_sock)
-            and sys.platform != "darwin"
-        ):
-            binds.append(f"{ssh_auth_sock}:/run/ssh-agent.sock:ro")
         if config_path:
             binds.append(f"{config_path}:/opt/klangk/config:ro")
         binds += extra_mounts or []

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -343,34 +343,6 @@ class TestStartContainer:
         p.start_container.assert_awaited_once_with("new-cid")
         assert workspace["id"] in container.registry.states
 
-    async def test_ssh_agent_forwarded_when_socket_exists(
-        self, workspace, monkeypatch, tmp_path
-    ):
-        sock = tmp_path / "agent.sock"
-        sock.touch()
-        monkeypatch.setenv("SSH_AUTH_SOCK", str(sock))
-
-        with patch_podman() as p:
-            await container.registry.start_container(
-                workspace["id"], "/tmp/ws", "/tmp/home"
-            )
-        kwargs = p.create_container.call_args.kwargs
-        assert "SSH_AUTH_SOCK=/run/ssh-agent.sock" in kwargs["env"]
-        assert f"{sock}:/run/ssh-agent.sock:ro" in kwargs["binds"]
-
-    async def test_ssh_agent_not_forwarded_when_unset(
-        self, workspace, monkeypatch
-    ):
-        monkeypatch.delenv("SSH_AUTH_SOCK", raising=False)
-
-        with patch_podman() as p:
-            await container.registry.start_container(
-                workspace["id"], "/tmp/ws", "/tmp/home"
-            )
-        kwargs = p.create_container.call_args.kwargs
-        assert "SSH_AUTH_SOCK=/run/ssh-agent.sock" not in kwargs["env"]
-        assert not any("ssh-agent" in b for b in kwargs["binds"])
-
     async def test_reuse_running_container(self, workspace):
         with patch_podman(inspect_container=_running(True)) as p:
             cid, status = await container.registry.start_container(


### PR DESCRIPTION
## Summary
- Remove automatic bind-mount of `SSH_AUTH_SOCK` into workspace containers. Any code in the container could use the forwarded agent to sign SSH requests with the host user's private keys — a risk in multi-user/shared workspace scenarios.
- Remove related tests and ARCHITECTURE.md documentation.

Closes #170.

## Test plan
- [x] 1130 backend unit tests pass, 100% coverage
- [x] SSH agent env var and bind mount no longer appear in container create args

🤖 Generated with [Claude Code](https://claude.com/claude-code)