### PR TITLE
Add @mention support to workspace chat

### DIFF
--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -1303,6 +1303,20 @@ async def _check_workspace_share(request: Request, user: dict) -> str:
     return f"/workspaces/{workspace_id}"
 
 
+async def _broadcast_workspace_members(workspace_id: str) -> None:
+    """Push updated workspace members to all connected subscribers."""
+    session = wshandler.state.get_session(workspace_id)
+    if not session:
+        return
+    members = await model.get_workspace_members(workspace_id)
+    workspace = await model.get_workspace(workspace_id)
+    if workspace:
+        owner = await model.get_user_by_id(workspace.get("user_id", ""))
+        if owner and not any(m["id"] == owner["id"] for m in members):
+            members.append({"id": owner["id"], "email": owner["email"]})
+    session.broadcast({"type": "workspace_members", "members": members})
+
+
 @router.get("/workspaces/{workspace_id}/members")
 async def get_workspace_members(
     workspace_id: str,
@@ -1365,6 +1379,7 @@ async def add_workspace_member(
         PRINCIPAL_USER,
         user_id=target["id"],
     )
+    await _broadcast_workspace_members(workspace_id)
     return {
         "status": "shared",
         "user_id": target["id"],
@@ -1392,6 +1407,7 @@ async def remove_workspace_member(
     for i, entry in enumerate(remaining):
         entry["position"] = i
     await model.replace_acl_entries(resource, remaining)
+    await _broadcast_workspace_members(workspace_id)
     return {"status": "removed"}
 
 

--- a/src/backend/klangk_backend/model.py
+++ b/src/backend/klangk_backend/model.py
@@ -1,4 +1,5 @@
 import json
+import re
 import socket
 from contextlib import asynccontextmanager
 
@@ -144,6 +145,18 @@ async def init_db() -> None:
                 message TEXT NOT NULL,
                 created_at TEXT NOT NULL DEFAULT (datetime('now'))
             )
+        """)
+        await db.execute("""
+            CREATE TABLE IF NOT EXISTS chat_mentions (
+                id TEXT PRIMARY KEY,
+                message_id TEXT NOT NULL REFERENCES chat_messages(id) ON DELETE CASCADE,
+                user_id TEXT NOT NULL,
+                workspace_id TEXT NOT NULL
+            )
+        """)
+        await db.execute("""
+            CREATE INDEX IF NOT EXISTS idx_chat_mentions_user
+            ON chat_mentions(user_id, workspace_id)
         """)
         await db.execute("""
             CREATE TABLE IF NOT EXISTS login_attempts (
@@ -1316,6 +1329,52 @@ async def clear_login_attempts(email: str) -> None:
 
 # Chat messages
 
+_MENTION_RE = re.compile(r"@(\S+)")
+
+
+async def parse_mentions(
+    db: aiosqlite.Connection, message: str, workspace_id: str
+) -> list[str]:
+    """Extract @email mentions from message text and resolve to user IDs.
+
+    Returns a deduplicated list of user IDs for emails that belong to
+    workspace members (including the owner).
+    """
+    candidates = _MENTION_RE.findall(message)
+    if not candidates:
+        return []
+    # Deduplicate while preserving order
+    seen: set[str] = set()
+    unique: list[str] = []
+    for c in candidates:
+        low = c.lower()
+        if low not in seen:
+            seen.add(low)
+            unique.append(low)
+
+    placeholders = ",".join("?" for _ in unique)
+    cursor = await db.execute(
+        "SELECT DISTINCT u.id, LOWER(u.email) AS email FROM users u"
+        " JOIN acl_entries ae ON ae.user_id = u.id"
+        " WHERE LOWER(u.email) IN (" + placeholders + ")"
+        "   AND ae.resource = ?"
+        "   AND ae.principal_type = ? AND ae.action = ?"
+        " UNION"
+        " SELECT w.user_id AS id, LOWER(u2.email) AS email"
+        " FROM workspaces w JOIN users u2 ON u2.id = w.user_id"
+        " WHERE w.id = ? AND LOWER(u2.email) IN (" + placeholders + ")",
+        (
+            *unique,
+            f"/workspaces/{workspace_id}",
+            PRINCIPAL_USER,
+            ACTION_ALLOW,
+            workspace_id,
+            *unique,
+        ),
+    )
+    rows = await cursor.fetchall()
+    return [row["id"] for row in rows]
+
 
 async def add_chat_message(
     workspace_id: str, user_id: str, user_email: str, message: str
@@ -1329,6 +1388,13 @@ async def add_chat_message(
             " VALUES (?, ?, ?, ?, ?)",
             (msg_id, workspace_id, user_id, user_email, message),
         )
+        mentioned_user_ids = await parse_mentions(db, message, workspace_id)
+        for uid in mentioned_user_ids:
+            await db.execute(
+                "INSERT INTO chat_mentions (id, message_id, user_id, workspace_id)"
+                " VALUES (?, ?, ?, ?)",
+                (str(uuid.uuid4()), msg_id, uid, workspace_id),
+            )
         await db.commit()
         cursor = await db.execute(
             "SELECT created_at FROM chat_messages WHERE id = ?", (msg_id,)
@@ -1341,6 +1407,7 @@ async def add_chat_message(
             "user_email": user_email,
             "message": message,
             "created_at": row["created_at"],
+            "mentions": mentioned_user_ids,
         }
     finally:
         await db.close()
@@ -1376,8 +1443,7 @@ async def get_chat_messages(workspace_id: str, limit: int = 50) -> list[dict]:
             (workspace_id, limit),
         )
         rows = await cursor.fetchall()
-        # Return in chronological order (oldest first)
-        return list(
+        messages = list(
             reversed(
                 [
                     {
@@ -1392,6 +1458,23 @@ async def get_chat_messages(workspace_id: str, limit: int = 50) -> list[dict]:
                 ]
             )
         )
+        if messages:
+            msg_ids = [m["id"] for m in messages]
+            placeholders = ",".join("?" for _ in msg_ids)
+            cursor = await db.execute(
+                "SELECT message_id, user_id FROM chat_mentions"
+                " WHERE message_id IN (" + placeholders + ")",
+                msg_ids,
+            )
+            mention_rows = await cursor.fetchall()
+            mentions_by_msg: dict[str, list[str]] = {}
+            for mr in mention_rows:
+                mentions_by_msg.setdefault(mr["message_id"], []).append(
+                    mr["user_id"]
+                )
+            for m in messages:
+                m["mentions"] = mentions_by_msg.get(m["id"], [])
+        return messages
     finally:
         await db.close()
 

--- a/src/backend/klangk_backend/wshandler.py
+++ b/src/backend/klangk_backend/wshandler.py
@@ -613,6 +613,13 @@ class Connection:
                 {"type": "chat_history", "messages": chat_history}
             )
 
+        # Send workspace members for @mention autocomplete
+        members = await model.get_workspace_members(workspace_id)
+        owner = await model.get_user_by_id(workspace.get("user_id", ""))
+        if owner and not any(m["id"] == owner["id"] for m in members):
+            members.append({"id": owner["id"], "email": owner["email"]})
+        self.sock.send_json({"type": "workspace_members", "members": members})
+
         # Store status for when frontend sends ui_ready
         self.pending_status_msg = status_msg
         logger.info(

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -1080,6 +1080,38 @@ class TestWorkspaceSharingRoutes:
         )
         assert resp.status_code == 403
 
+    async def test_add_member_broadcasts_workspace_members(self, client, user):
+        """Adding a member broadcasts updated workspace_members to WS."""
+        from klangk_backend.wshandler import WorkspaceSession
+
+        headers = await _auth_headers(client)
+        await self._create_other_user()
+        resp = await client.post(
+            "/workspaces", headers=headers, json={"name": "broadcast-ws"}
+        )
+        ws_id = resp.json()["id"]
+        mock_sock = MagicMock()
+        mock_sock.send_json = MagicMock()
+        session = WorkspaceSession(ws_id)
+        session.subscribers.add(mock_sock)
+        wshandler.state.sessions[ws_id] = session
+        try:
+            resp = await client.post(
+                f"/workspaces/{ws_id}/members",
+                headers=headers,
+                json={"email": "other@example.com"},
+            )
+            assert resp.status_code == 200
+            calls = [c[0][0] for c in mock_sock.send_json.call_args_list]
+            members_msgs = [
+                c for c in calls if c.get("type") == "workspace_members"
+            ]
+            assert len(members_msgs) == 1
+            emails = [m["email"] for m in members_msgs[0]["members"]]
+            assert "other@example.com" in emails
+        finally:
+            wshandler.state.sessions.pop(ws_id, None)
+
     async def test_members_no_permission(self, client, user):
         """User without share permission gets 403 on nonexistent workspace."""
         headers = await _auth_headers(client)

--- a/src/backend/tests/test_model.py
+++ b/src/backend/tests/test_model.py
@@ -518,6 +518,7 @@ class TestChatMessages:
         assert msg["message"] == "hello"
         assert "id" in msg
         assert "created_at" in msg
+        assert msg["mentions"] == []
 
     async def test_get_chat_messages(self, workspace, user):
         await model.add_chat_message(
@@ -530,6 +531,8 @@ class TestChatMessages:
         assert len(msgs) == 2
         assert msgs[0]["message"] == "first"
         assert msgs[1]["message"] == "second"
+        assert msgs[0]["mentions"] == []
+        assert msgs[1]["mentions"] == []
 
     async def test_get_chat_messages_limit(self, workspace, user):
         for i in range(5):
@@ -567,6 +570,110 @@ class TestChatMessages:
         assert not deleted
         msgs = await model.get_chat_messages(workspace["id"])
         assert msgs[0]["message"] == "mine"
+
+
+class TestChatMentions:
+    async def test_mention_workspace_owner(self, workspace, user):
+        """@mentioning the workspace owner resolves to their user ID."""
+        msg = await model.add_chat_message(
+            workspace["id"],
+            user["id"],
+            user["email"],
+            f"hello @{user['email']}",
+        )
+        assert msg["mentions"] == [user["id"]]
+
+    async def test_mention_workspace_member(self, workspace, user):
+        """@mentioning a workspace member (via ACL) resolves."""
+        member = await model.create_user(
+            "member@test.com", "hash", verified=True
+        )
+        await model.add_acl_entry(
+            f"/workspaces/{workspace['id']}",
+            0,
+            model.ACTION_ALLOW,
+            "*",
+            model.PRINCIPAL_USER,
+            user_id=member["id"],
+        )
+        msg = await model.add_chat_message(
+            workspace["id"],
+            user["id"],
+            user["email"],
+            "hey @member@test.com check this",
+        )
+        assert msg["mentions"] == [member["id"]]
+
+    async def test_mention_non_member_ignored(self, workspace, user):
+        """@mentioning someone not in the workspace produces no mentions."""
+        await model.create_user("outsider@test.com", "hash", verified=True)
+        msg = await model.add_chat_message(
+            workspace["id"],
+            user["id"],
+            user["email"],
+            "hey @outsider@test.com",
+        )
+        assert msg["mentions"] == []
+
+    async def test_mention_multiple_users(self, workspace, user):
+        """Multiple @mentions in one message resolve correctly."""
+        member = await model.create_user("m@test.com", "hash", verified=True)
+        await model.add_acl_entry(
+            f"/workspaces/{workspace['id']}",
+            0,
+            model.ACTION_ALLOW,
+            "*",
+            model.PRINCIPAL_USER,
+            user_id=member["id"],
+        )
+        msg = await model.add_chat_message(
+            workspace["id"],
+            user["id"],
+            user["email"],
+            f"@{user['email']} and @m@test.com",
+        )
+        assert set(msg["mentions"]) == {user["id"], member["id"]}
+
+    async def test_mention_deduplication(self, workspace, user):
+        """Duplicate @mentions produce only one entry."""
+        msg = await model.add_chat_message(
+            workspace["id"],
+            user["id"],
+            user["email"],
+            f"@{user['email']} @{user['email']}",
+        )
+        assert msg["mentions"] == [user["id"]]
+
+    async def test_mentions_in_history(self, workspace, user):
+        """get_chat_messages includes mentions from the DB."""
+        await model.add_chat_message(
+            workspace["id"],
+            user["id"],
+            user["email"],
+            f"hello @{user['email']}",
+        )
+        msgs = await model.get_chat_messages(workspace["id"])
+        assert len(msgs) == 1
+        assert msgs[0]["mentions"] == [user["id"]]
+
+    async def test_mentions_cascade_with_message(self, workspace, user):
+        """Deleting a workspace cascades to chat_mentions."""
+        await model.add_chat_message(
+            workspace["id"],
+            user["id"],
+            user["email"],
+            f"@{user['email']}",
+        )
+        await model.delete_workspace(workspace["id"], user["id"])
+        msgs = await model.get_chat_messages(workspace["id"])
+        assert msgs == []
+
+    async def test_no_mention_pattern(self, workspace, user):
+        """Messages without @ produce empty mentions."""
+        msg = await model.add_chat_message(
+            workspace["id"], user["id"], user["email"], "just plain text"
+        )
+        assert msg["mentions"] == []
 
 
 class TestInvitations:

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -2494,6 +2494,22 @@ class TestChatSend:
             assert sent["user_email"] == user["email"]
             assert "id" in sent
             assert "created_at" in sent
+            assert sent["mentions"] == []
+        finally:
+            wshandler.state.sessions.pop(workspace["id"], None)
+
+    async def test_chat_send_with_mention(self, workspace, user):
+        """Broadcast includes mention user IDs when @email is used."""
+        sock = _mock_sock()
+        conn = _base_conn(user=user, ws=sock)
+        conn.workspace_id = workspace["id"]
+
+        session = wshandler.state.get_or_create_session(workspace["id"])
+        session.subscribers.add(sock)
+        try:
+            await conn.handle_chat_send({"message": f"hey @{user['email']}"})
+            sent = sock.send_json.call_args[0][0]
+            assert sent["mentions"] == [user["id"]]
         finally:
             wshandler.state.sessions.pop(workspace["id"], None)
 
@@ -2546,6 +2562,40 @@ class TestChatSend:
         assert len(history) == 1
         assert len(history[0]["messages"]) == 1
         assert history[0]["messages"][0]["message"] == "old message"
+
+    async def test_workspace_members_on_connect(self, user):
+        """Workspace members list is sent on connect."""
+        workspace = await _create_workspace_with_acl(user["id"], "members-ws")
+
+        sock = _mock_sock()
+        conn = _base_conn(user=user, ws=sock)
+
+        async def fake_start(wid, ws_obj):
+            conn.container_id = "cid"
+
+        with (
+            patch.object(
+                Connection,
+                "start_workspace_container",
+                side_effect=fake_start,
+            ),
+            patch.object(
+                container.registry,
+                "get_workspace_ports",
+                return_value=[],
+            ),
+        ):
+            await conn.handle_workspace_connect(
+                {"workspaceId": workspace["id"]}
+            )
+
+        calls = [c[0][0] for c in sock.send_json.call_args_list]
+        members_msgs = [
+            c for c in calls if c.get("type") == "workspace_members"
+        ]
+        assert len(members_msgs) == 1
+        member_ids = [m["id"] for m in members_msgs[0]["members"]]
+        assert user["id"] in member_ids
 
 
 class TestChatDelete:

--- a/src/frontend/e2e-tests/e2e/klangk.spec.ts
+++ b/src/frontend/e2e-tests/e2e/klangk.spec.ts
@@ -2074,6 +2074,122 @@ test.describe("Klangk E2E", () => {
     });
   });
 
+  test("workspace_members broadcast on member add and chat @mention", async ({
+    browser,
+    request,
+  }) => {
+    const ownerEmail = `mention-owner-${Date.now()}@test.example.com`;
+    const memberEmail = `mention-member-${Date.now()}@test.example.com`;
+    const lateEmail = `mention-late-${Date.now()}@test.example.com`;
+    const { headers: ownerHeaders } = await registerUser(request, ownerEmail);
+    await registerUser(request, memberEmail);
+    await registerUser(request, lateEmail);
+
+    const wsResp = await request.post(`${API_BASE}/workspaces`, {
+      headers: ownerHeaders,
+      data: { name: `e2e-mention-${Date.now()}` },
+    });
+    expect(wsResp.ok()).toBeTruthy();
+    const workspaceId = (await wsResp.json()).id;
+
+    // Share with first member
+    await request.post(`${API_BASE}/workspaces/${workspaceId}/members`, {
+      headers: ownerHeaders,
+      data: { email: memberEmail },
+    });
+
+    // Capture WS on owner page to send commands
+    const wsCaptureScript = `(() => {
+      const Orig = window.WebSocket;
+      window.WebSocket = function(...args) {
+        const ws = new Orig(...args);
+        window.__klangkWs = ws;
+        return ws;
+      };
+      window.WebSocket.prototype = Orig.prototype;
+      window.WebSocket.CONNECTING = Orig.CONNECTING;
+      window.WebSocket.OPEN = Orig.OPEN;
+      window.WebSocket.CLOSING = Orig.CLOSING;
+      window.WebSocket.CLOSED = Orig.CLOSED;
+    })()`;
+
+    const ctx1 = await browser.newContext();
+    await ctx1.addInitScript(wsCaptureScript);
+    const page1 = await ctx1.newPage();
+
+    // Collect workspace_members and chat_message on owner page
+    const ownerWsMessages: string[] = [];
+    const ownerChatMessages: string[] = [];
+    page1.on("websocket", (ws) => {
+      ws.on("framereceived", (frame: { payload: string | Buffer }) => {
+        const text = frame.payload.toString();
+        if (text.includes("workspace_members")) {
+          ownerWsMessages.push(text);
+        }
+        if (text.includes("chat_message")) {
+          ownerChatMessages.push(text);
+        }
+      });
+    });
+
+    await openWorkspace(page1, ownerEmail, workspaceId, {
+      waitForTerminal: true,
+    });
+
+    // Initial workspace_members should have been received on connect
+    expect(ownerWsMessages.length).toBeGreaterThan(0);
+    const initial = JSON.parse(ownerWsMessages[ownerWsMessages.length - 1]);
+    expect(initial.type).toBe("workspace_members");
+    const initialEmails = initial.members.map(
+      (m: { email: string }) => m.email,
+    );
+    expect(initialEmails).toContain(memberEmail);
+    expect(initialEmails).toContain(ownerEmail);
+
+    // Now add a late member while owner is connected
+    const countBefore = ownerWsMessages.length;
+    await request.post(`${API_BASE}/workspaces/${workspaceId}/members`, {
+      headers: ownerHeaders,
+      data: { email: lateEmail },
+    });
+
+    // Wait for the broadcast
+    await page1.waitForTimeout(2000);
+    expect(ownerWsMessages.length).toBeGreaterThan(countBefore);
+    const updated = JSON.parse(ownerWsMessages[ownerWsMessages.length - 1]);
+    const updatedEmails = updated.members.map(
+      (m: { email: string }) => m.email,
+    );
+    expect(updatedEmails).toContain(lateEmail);
+
+    // Send a chat message with @mention and verify mentions field
+    await page1.evaluate((email: string) => {
+      const ws = (window as any).__klangkWs;
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        ws.send(
+          JSON.stringify({
+            cmd: "chat_send",
+            message: `hey @${email} check this`,
+          }),
+        );
+      }
+    }, memberEmail);
+
+    await page1.waitForTimeout(2000);
+
+    expect(ownerChatMessages.length).toBeGreaterThan(0);
+    const chatMsg = JSON.parse(ownerChatMessages[0]);
+    expect(chatMsg.type).toBe("chat_message");
+    expect(chatMsg.message).toContain(`@${memberEmail}`);
+    expect(chatMsg.mentions).toBeDefined();
+    expect(chatMsg.mentions.length).toBeGreaterThan(0);
+
+    await ctx1.close();
+    await request.delete(`${API_BASE}/workspaces/${workspaceId}`, {
+      headers: ownerHeaders,
+    });
+  });
+
   test("container recreated on page refresh", async ({ page, request }) => {
     const { workspaceId, headers, cleanup } = await createAndOpenWorkspace(
       page,

--- a/src/frontend/lib/chat/workspace_chat.dart
+++ b/src/frontend/lib/chat/workspace_chat.dart
@@ -15,10 +15,14 @@ class WorkspaceChat extends StatefulWidget {
   /// Called when the unread message count changes.
   final ValueChanged<int>? onUnreadChanged;
 
+  /// Called when mention-while-hidden state changes.
+  final ValueChanged<bool>? onMentionChanged;
+
   const WorkspaceChat({
     super.key,
     required this.wsClient,
     this.onUnreadChanged,
+    this.onMentionChanged,
   });
 
   @override
@@ -34,6 +38,12 @@ class WorkspaceChatState extends State<WorkspaceChat> {
   StreamSubscription<Map<String, dynamic>>? _chatSub;
   int _unreadCount = 0;
   bool _isVisible = false;
+  bool _hasMention = false;
+
+  // Autocomplete state
+  OverlayEntry? _autocompleteOverlay;
+  String _mentionQuery = '';
+  final _inputKey = GlobalKey();
 
   @override
   void initState() {
@@ -43,6 +53,7 @@ class WorkspaceChatState extends State<WorkspaceChat> {
       _messages.addAll(widget.wsClient.chatHistory);
     }
     _chatSub = widget.wsClient.chatMessages.listen(_onMessage);
+    _textController.addListener(_onTextChanged);
   }
 
   /// Focuses the message input. Called by the parent when the Chat tab is
@@ -54,7 +65,9 @@ class WorkspaceChatState extends State<WorkspaceChat> {
     _isVisible = visible;
     if (visible && _unreadCount > 0) {
       _unreadCount = 0;
+      _hasMention = false;
       widget.onUnreadChanged?.call(0);
+      widget.onMentionChanged?.call(false);
     }
   }
 
@@ -82,6 +95,15 @@ class WorkspaceChatState extends State<WorkspaceChat> {
     if (!_isVisible) {
       _unreadCount++;
       widget.onUnreadChanged?.call(_unreadCount);
+
+      final mentions = msg['mentions'] as List?;
+      if (mentions != null && !_hasMention) {
+        final currentUserId = context.read<AuthService>().userId;
+        if (mentions.contains(currentUserId)) {
+          _hasMention = true;
+          widget.onMentionChanged?.call(true);
+        }
+      }
     }
 
     // Auto-scroll to bottom after frame renders
@@ -95,6 +117,113 @@ class WorkspaceChatState extends State<WorkspaceChat> {
       }
     });
   }
+
+  // --- Autocomplete ---
+
+  void _onTextChanged() {
+    final text = _textController.text;
+    final cursor = _textController.selection.baseOffset;
+    if (cursor < 0 || cursor > text.length) {
+      _hideAutocomplete();
+      return;
+    }
+    // Find the @ that starts the current mention token
+    final before = text.substring(0, cursor);
+    final atIdx = before.lastIndexOf('@');
+    if (atIdx < 0 ||
+        (atIdx > 0 && before[atIdx - 1] != ' ' && before[atIdx - 1] != '\n')) {
+      _hideAutocomplete();
+      return;
+    }
+    final query = before.substring(atIdx + 1);
+    if (query.contains(' ') || query.contains('\n')) {
+      _hideAutocomplete();
+      return;
+    }
+    _mentionQuery = query.toLowerCase();
+    _showAutocomplete();
+  }
+
+  void _showAutocomplete() {
+    final members = widget.wsClient.workspaceMembers;
+    final filtered = members.where((m) {
+      final email = (m['email'] as String? ?? '').toLowerCase();
+      return email.contains(_mentionQuery);
+    }).toList();
+    if (filtered.isEmpty) {
+      _hideAutocomplete();
+      return;
+    }
+    _autocompleteOverlay?.remove();
+    _autocompleteOverlay = OverlayEntry(builder: (context) {
+      final renderBox =
+          _inputKey.currentContext?.findRenderObject() as RenderBox?;
+      if (renderBox == null) return const SizedBox.shrink();
+      final offset = renderBox.localToGlobal(Offset.zero);
+      final maxItems = filtered.length > 5 ? 5 : filtered.length;
+      final height = maxItems * 36.0;
+      return Positioned(
+        left: offset.dx,
+        top: offset.dy - height - 4,
+        width: renderBox.size.width,
+        child: Material(
+          elevation: 4,
+          color: KColors.bgSurface,
+          borderRadius: BorderRadius.circular(6),
+          child: ConstrainedBox(
+            constraints: BoxConstraints(maxHeight: height),
+            child: ListView.builder(
+              padding: EdgeInsets.zero,
+              shrinkWrap: true,
+              itemCount: filtered.length > 5 ? 5 : filtered.length,
+              itemBuilder: (ctx, i) {
+                final email = filtered[i]['email'] as String? ?? '';
+                return InkWell(
+                  onTap: () => _insertMention(email),
+                  child: Padding(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                    child: Text(
+                      email,
+                      style: const TextStyle(
+                        color: KColors.textPrimary,
+                        fontSize: 13,
+                      ),
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      );
+    });
+    Overlay.of(context).insert(_autocompleteOverlay!);
+  }
+
+  void _hideAutocomplete() {
+    _autocompleteOverlay?.remove();
+    _autocompleteOverlay = null;
+  }
+
+  void _insertMention(String email) {
+    final text = _textController.text;
+    final cursor = _textController.selection.baseOffset;
+    final before = text.substring(0, cursor);
+    final atIdx = before.lastIndexOf('@');
+    final after = text.substring(cursor);
+    final newText = '${text.substring(0, atIdx)}@$email $after';
+    _textController.value = TextEditingValue(
+      text: newText,
+      selection: TextSelection.collapsed(
+        offset: atIdx + email.length + 2, // @email + space
+      ),
+    );
+    _hideAutocomplete();
+    _inputFocusNode.requestFocus();
+  }
+
+  // --- Message rendering ---
 
   static String _formatTime(String raw) {
     if (raw.isEmpty) return '';
@@ -125,9 +254,15 @@ class WorkspaceChatState extends State<WorkspaceChat> {
   static Color _colorForEmail(String email) => KColors.colorForString(email);
 
   static final _urlRegex = RegExp(r'https?://[^\s<>"{}|\\^`\[\]]+');
+  static final _mentionRegex = RegExp(r'@(\S+)');
 
-  /// Build TextSpans for a message, turning URLs into clickable links.
-  List<TextSpan> _buildMessageSpans(String text, bool isDeleted) {
+  /// Build TextSpans for a message, turning URLs into clickable links
+  /// and @mentions into highlighted spans.
+  List<TextSpan> _buildMessageSpans(
+    String text,
+    bool isDeleted,
+    String? currentUserEmail,
+  ) {
     final style = TextStyle(
       color: isDeleted ? KColors.textMuted : KColors.textPrimary,
       fontSize: 13,
@@ -138,25 +273,54 @@ class WorkspaceChatState extends State<WorkspaceChat> {
       return [TextSpan(text: text, style: style)];
     }
 
+    // Collect all matches (URLs and mentions) sorted by position
+    final matches = <_SpanMatch>[];
+    for (final m in _urlRegex.allMatches(text)) {
+      matches.add(_SpanMatch(m.start, m.end, _SpanType.url, m.group(0)!));
+    }
+    for (final m in _mentionRegex.allMatches(text)) {
+      // Skip if overlapping with a URL
+      final overlaps = matches.any((u) => m.start < u.end && m.end > u.start);
+      if (!overlaps) {
+        matches.add(_SpanMatch(m.start, m.end, _SpanType.mention, m.group(0)!));
+      }
+    }
+    matches.sort((a, b) => a.start.compareTo(b.start));
+
     final spans = <TextSpan>[];
     int lastEnd = 0;
-    for (final match in _urlRegex.allMatches(text)) {
+    for (final match in matches) {
       if (match.start > lastEnd) {
         spans.add(TextSpan(
           text: text.substring(lastEnd, match.start),
           style: style,
         ));
       }
-      final url = match.group(0)!;
-      spans.add(TextSpan(
-        text: url,
-        style: style.copyWith(
-          color: KColors.accentBlue,
-          decoration: TextDecoration.underline,
-        ),
-        recognizer: TapGestureRecognizer()
-          ..onTap = () => openUrl(url), // coverage:ignore-line
-      ));
+      if (match.type == _SpanType.url) {
+        spans.add(TextSpan(
+          text: match.text,
+          style: style.copyWith(
+            color: KColors.accentBlue,
+            decoration: TextDecoration.underline,
+          ),
+          recognizer: TapGestureRecognizer()
+            ..onTap = () => openUrl(match.text), // coverage:ignore-line
+        ));
+      } else {
+        // Mention
+        final mentionEmail = match.text.substring(1); // strip @
+        final isSelf = currentUserEmail != null &&
+            mentionEmail.toLowerCase() == currentUserEmail.toLowerCase();
+        spans.add(TextSpan(
+          text: match.text,
+          style: style.copyWith(
+            color: KColors.accentBlue,
+            fontWeight: FontWeight.bold,
+            backgroundColor:
+                isSelf ? KColors.accentBlue.withValues(alpha: 0.15) : null,
+          ),
+        ));
+      }
       lastEnd = match.end;
     }
     if (lastEnd < text.length) {
@@ -176,6 +340,7 @@ class WorkspaceChatState extends State<WorkspaceChat> {
   void _sendMessage() {
     final text = _textController.text.trim();
     if (text.isEmpty) return;
+    _hideAutocomplete();
     widget.wsClient.sendChatMessage(text);
     _textController.clear();
   }
@@ -186,8 +351,10 @@ class WorkspaceChatState extends State<WorkspaceChat> {
 
   @override
   void dispose() {
+    _hideAutocomplete();
     _chatSub?.cancel();
     _scrollController.dispose();
+    _textController.removeListener(_onTextChanged);
     _textController.dispose();
     _inputFocusNode.dispose();
     super.dispose();
@@ -195,7 +362,9 @@ class WorkspaceChatState extends State<WorkspaceChat> {
 
   @override
   Widget build(BuildContext context) {
-    final currentUserId = context.read<AuthService>().userId;
+    final auth = context.read<AuthService>();
+    final currentUserId = auth.userId;
+    final currentUserEmail = auth.email;
 
     return Container(
       color: KColors.bgCanvas,
@@ -240,7 +409,11 @@ class WorkspaceChatState extends State<WorkspaceChat> {
                                         fontSize: 13,
                                       ),
                                     ),
-                                    ..._buildMessageSpans(text, isDeleted),
+                                    ..._buildMessageSpans(
+                                      text,
+                                      isDeleted,
+                                      currentUserEmail,
+                                    ),
                                   ],
                                 ),
                               ),
@@ -273,6 +446,7 @@ class WorkspaceChatState extends State<WorkspaceChat> {
                   ),
           ),
           Container(
+            key: _inputKey,
             decoration: const BoxDecoration(
               border: Border(
                 top: BorderSide(color: KColors.borderDefault),
@@ -312,4 +486,14 @@ class WorkspaceChatState extends State<WorkspaceChat> {
       ),
     );
   }
+}
+
+enum _SpanType { url, mention }
+
+class _SpanMatch {
+  final int start;
+  final int end;
+  final _SpanType type;
+  final String text;
+  _SpanMatch(this.start, this.end, this.type, this.text);
 }

--- a/src/frontend/lib/layout/ide_layout.dart
+++ b/src/frontend/lib/layout/ide_layout.dart
@@ -15,6 +15,7 @@ class IdeLayout extends StatefulWidget {
   final Widget? sharing;
   final Widget? debug;
   final int chatUnread;
+  final bool chatMentioned;
   final GlobalKey<GhosttyTerminalState>? terminalKey;
   final GlobalKey<FileViewerPanelState>? fileViewerKey;
   final GlobalKey<WorkspaceChatState>? chatKey;
@@ -28,6 +29,7 @@ class IdeLayout extends StatefulWidget {
     this.sharing,
     this.debug,
     this.chatUnread = 0,
+    this.chatMentioned = false,
     this.terminalKey,
     this.fileViewerKey,
     this.chatKey,
@@ -123,6 +125,7 @@ class _IdeLayoutState extends State<IdeLayout> {
         icon: Icons.chat_outlined,
         isSelected: _selectedIndex == chatIndex,
         badge: widget.chatUnread > 0 ? widget.chatUnread : null,
+        badgeHighlight: widget.chatMentioned,
         onTap: () => _selectTab(chatIndex),
       ));
       content.add(Container(

--- a/src/frontend/lib/widgets/skeuo_tab.dart
+++ b/src/frontend/lib/widgets/skeuo_tab.dart
@@ -7,6 +7,7 @@ class SkeuoTab extends StatelessWidget {
   final IconData icon;
   final bool isSelected;
   final int? badge;
+  final bool badgeHighlight;
   final VoidCallback onTap;
 
   const SkeuoTab({
@@ -15,6 +16,7 @@ class SkeuoTab extends StatelessWidget {
     required this.icon,
     required this.isSelected,
     this.badge,
+    this.badgeHighlight = false,
     required this.onTap,
   });
 
@@ -52,11 +54,15 @@ class SkeuoTab extends StatelessWidget {
                   padding:
                       const EdgeInsets.symmetric(horizontal: 5, vertical: 1),
                   decoration: BoxDecoration(
-                    color: KColors.accentRed,
+                    color: badgeHighlight
+                        ? KColors.accentAmber
+                        : KColors.accentRed,
                     borderRadius: BorderRadius.circular(8),
                   ),
                   child: Text(
-                    badge! > 99 ? '99+' : badge.toString(),
+                    badgeHighlight
+                        ? '@${badge! > 99 ? '99+' : badge.toString()}'
+                        : (badge! > 99 ? '99+' : badge.toString()),
                     style: const TextStyle(
                       color: Colors.white,
                       fontSize: 10,

--- a/src/frontend/lib/workspace/workspace_page.dart
+++ b/src/frontend/lib/workspace/workspace_page.dart
@@ -38,6 +38,7 @@ class _WorkspacePageState extends State<WorkspacePage> {
   String? _error;
   String _workspaceName = '';
   int _chatUnread = 0;
+  bool _chatMentioned = false;
   bool _containerStopped = false;
   bool _restarting = false;
   bool _disconnected = false;
@@ -275,9 +276,13 @@ class _WorkspacePageState extends State<WorkspacePage> {
                     onUnreadChanged: (count) {
                       if (mounted) setState(() => _chatUnread = count);
                     },
+                    onMentionChanged: (mentioned) {
+                      if (mounted) setState(() => _chatMentioned = mentioned);
+                    },
                   )
                 : null,
             chatUnread: _chatUnread,
+            chatMentioned: _chatMentioned,
             settings: _hasPerm('edit')
                 ? WorkspaceSettingsPanel(
                     workspaceId: widget.workspaceId,

--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -67,6 +67,9 @@ class WsClient extends ChangeNotifier {
   /// Buffered chat history — populated from chat_history and chat_message.
   final List<Map<String, dynamic>> chatHistory = [];
 
+  /// Workspace members for @mention autocomplete.
+  List<Map<String, dynamic>> workspaceMembers = [];
+
   /// Chat messages (individual and history) from the backend.
   Stream<Map<String, dynamic>> get chatMessages => _chatController.stream;
 
@@ -153,6 +156,10 @@ class WsClient extends ChangeNotifier {
             }
           } else if (type == 'chat_updated') {
             _chatController.add(json);
+          } else if (type == 'workspace_members') {
+            final members = json['members'] as List? ?? [];
+            workspaceMembers = members.cast<Map<String, dynamic>>();
+            notifyListeners();
           } else if (type == 'event') {
             _customEventController.add(json);
           }
@@ -206,6 +213,7 @@ class WsClient extends ChangeNotifier {
     _send({'cmd': 'workspace_disconnect'});
     _currentWorkspaceId = null;
     chatHistory.clear();
+    workspaceMembers = [];
     notifyListeners();
   }
 

--- a/src/frontend/test/ide_layout_test.dart
+++ b/src/frontend/test/ide_layout_test.dart
@@ -50,6 +50,38 @@ void main() {
       ));
       expect(find.text('Y'), findsOneWidget);
     });
+
+    testWidgets('badgeHighlight shows @ prefix', (tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: SkeuoTab(
+            label: 'Chat',
+            icon: Icons.chat,
+            isSelected: false,
+            badge: 3,
+            badgeHighlight: true,
+            onTap: () {},
+          ),
+        ),
+      ));
+      expect(find.text('@3'), findsOneWidget);
+    });
+
+    testWidgets('badgeHighlight with 99+ shows @99+', (tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: SkeuoTab(
+            label: 'Chat',
+            icon: Icons.chat,
+            isSelected: false,
+            badge: 150,
+            badgeHighlight: true,
+            onTap: () {},
+          ),
+        ),
+      ));
+      expect(find.text('@99+'), findsOneWidget);
+    });
   });
 
   Widget buildLayout({

--- a/src/frontend/test/workspace_chat_test.dart
+++ b/src/frontend/test/workspace_chat_test.dart
@@ -79,6 +79,7 @@ void main() {
     Widget buildChat({
       AuthService? authService,
       ValueChanged<int>? onUnreadChanged,
+      ValueChanged<bool>? onMentionChanged,
       GlobalKey<WorkspaceChatState>? chatKey,
     }) {
       return ChangeNotifierProvider(
@@ -92,6 +93,7 @@ void main() {
                 key: chatKey,
                 wsClient: client,
                 onUnreadChanged: onUnreadChanged,
+                onMentionChanged: onMentionChanged,
               ),
             ),
           ),
@@ -501,6 +503,323 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.textContaining('buffered message'), findsOneWidget);
+    });
+
+    testWidgets('@mention renders as bold blue span', (tester) async {
+      await tester.pumpWidget(buildChat());
+
+      await tester.runAsync(() async {
+        channel.serverSend({
+          'type': 'chat_message',
+          'id': 'msg-mention',
+          'user_email': 'alice@test.com',
+          'message': 'hey @bob@test.com check this',
+          'created_at': '2026-01-01 00:00:00',
+          'mentions': ['bob-uid'],
+        });
+        await Future.delayed(Duration.zero);
+        await Future.delayed(Duration.zero);
+      });
+      await tester.pump();
+
+      bool foundMention = false;
+      for (final st
+          in tester.widgetList<SelectableText>(find.byType(SelectableText))) {
+        final span = st.textSpan;
+        if (span != null &&
+            _findSpan(
+                span,
+                (s) =>
+                    s.text == '@bob@test.com' &&
+                    s.style?.fontWeight == FontWeight.bold)) {
+          foundMention = true;
+        }
+      }
+      expect(foundMention, isTrue);
+    });
+
+    testWidgets('self-mention renders with background highlight',
+        (tester) async {
+      final fakeJwt = base64Url.encode(utf8.encode('{"alg":"HS256"}')) +
+          '.' +
+          base64Url
+              .encode(utf8.encode('{"sub":"my-uid","email":"me@test.com"}')) +
+          '.sig';
+      SharedPreferences.setMockInitialValues({'klangk_jwt': fakeJwt});
+      final auth = AuthService();
+      await tester.runAsync(() => Future.delayed(Duration.zero));
+
+      await tester.pumpWidget(buildChat(authService: auth));
+
+      await tester.runAsync(() async {
+        channel.serverSend({
+          'type': 'chat_message',
+          'id': 'msg-self',
+          'user_email': 'alice@test.com',
+          'message': 'hey @me@test.com look',
+          'created_at': '2026-01-01 00:00:00',
+          'mentions': ['my-uid'],
+        });
+        await Future.delayed(Duration.zero);
+        await Future.delayed(Duration.zero);
+      });
+      await tester.pump();
+
+      bool foundSelfMention = false;
+      for (final st
+          in tester.widgetList<SelectableText>(find.byType(SelectableText))) {
+        final span = st.textSpan;
+        if (span != null &&
+            _findSpan(
+                span,
+                (s) =>
+                    s.text == '@me@test.com' &&
+                    s.style?.backgroundColor != null)) {
+          foundSelfMention = true;
+        }
+      }
+      expect(foundSelfMention, isTrue);
+    });
+
+    testWidgets('onMentionChanged fires when mentioned while hidden',
+        (tester) async {
+      final fakeJwt = base64Url.encode(utf8.encode('{"alg":"HS256"}')) +
+          '.' +
+          base64Url
+              .encode(utf8.encode('{"sub":"my-uid","email":"me@test.com"}')) +
+          '.sig';
+      SharedPreferences.setMockInitialValues({'klangk_jwt': fakeJwt});
+      final auth = AuthService();
+      await tester.runAsync(() => Future.delayed(Duration.zero));
+
+      final mentionStates = <bool>[];
+      final chatKey = GlobalKey<WorkspaceChatState>();
+
+      await tester.pumpWidget(buildChat(
+        authService: auth,
+        onMentionChanged: (m) => mentionStates.add(m),
+        chatKey: chatKey,
+      ));
+
+      // Chat is not visible by default
+      await tester.runAsync(() async {
+        channel.serverSend({
+          'type': 'chat_message',
+          'id': 'msg-m1',
+          'user_email': 'alice@test.com',
+          'message': 'hey @me@test.com',
+          'created_at': '2026-01-01 00:00:00',
+          'mentions': ['my-uid'],
+        });
+        await Future.delayed(Duration.zero);
+        await Future.delayed(Duration.zero);
+      });
+      await tester.pump();
+
+      expect(mentionStates, [true]);
+
+      // Setting visible clears mention
+      chatKey.currentState!.setVisible(true);
+      expect(mentionStates, [true, false]);
+    });
+
+    testWidgets('mention not fired for non-self mentions', (tester) async {
+      final fakeJwt = base64Url.encode(utf8.encode('{"alg":"HS256"}')) +
+          '.' +
+          base64Url
+              .encode(utf8.encode('{"sub":"my-uid","email":"me@test.com"}')) +
+          '.sig';
+      SharedPreferences.setMockInitialValues({'klangk_jwt': fakeJwt});
+      final auth = AuthService();
+      await tester.runAsync(() => Future.delayed(Duration.zero));
+
+      final mentionStates = <bool>[];
+
+      await tester.pumpWidget(buildChat(
+        authService: auth,
+        onMentionChanged: (m) => mentionStates.add(m),
+      ));
+
+      await tester.runAsync(() async {
+        channel.serverSend({
+          'type': 'chat_message',
+          'id': 'msg-other',
+          'user_email': 'alice@test.com',
+          'message': 'hey @bob@test.com',
+          'created_at': '2026-01-01 00:00:00',
+          'mentions': ['bob-uid'],
+        });
+        await Future.delayed(Duration.zero);
+        await Future.delayed(Duration.zero);
+      });
+      await tester.pump();
+
+      expect(mentionStates, isEmpty);
+    });
+
+    testWidgets('@autocomplete shows members on @ input', (tester) async {
+      client.workspaceMembers = [
+        {'id': 'u1', 'email': 'alice@test.com'},
+        {'id': 'u2', 'email': 'bob@test.com'},
+      ];
+
+      await tester.pumpWidget(buildChat());
+
+      await tester.enterText(find.byType(TextField), '@');
+      await tester.pump();
+
+      // Overlay should show member emails
+      expect(find.text('alice@test.com'), findsWidgets);
+      expect(find.text('bob@test.com'), findsWidgets);
+    });
+
+    testWidgets('@autocomplete filters by query', (tester) async {
+      client.workspaceMembers = [
+        {'id': 'u1', 'email': 'alice@test.com'},
+        {'id': 'u2', 'email': 'bob@test.com'},
+      ];
+
+      await tester.pumpWidget(buildChat());
+
+      await tester.enterText(find.byType(TextField), '@ali');
+      await tester.pump();
+
+      expect(find.text('alice@test.com'), findsWidgets);
+      // bob should not appear since "ali" doesn't match
+      final bobFinder = find.text('bob@test.com');
+      // Bob should only appear once (in the message area or not at all in overlay)
+      expect(bobFinder, findsNothing);
+    });
+
+    testWidgets('@autocomplete inserts mention on tap', (tester) async {
+      client.workspaceMembers = [
+        {'id': 'u1', 'email': 'alice@test.com'},
+      ];
+
+      await tester.pumpWidget(buildChat());
+
+      await tester.enterText(find.byType(TextField), '@al');
+      await tester.pump();
+
+      // Tap on the autocomplete entry
+      await tester.tap(find.text('alice@test.com').last);
+      await tester.pump();
+
+      final field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.controller!.text, '@alice@test.com ');
+    });
+
+    testWidgets('@autocomplete hides when no match', (tester) async {
+      client.workspaceMembers = [
+        {'id': 'u1', 'email': 'alice@test.com'},
+      ];
+
+      await tester.pumpWidget(buildChat());
+
+      await tester.enterText(find.byType(TextField), '@zzz');
+      await tester.pump();
+
+      // Only the input should have text, no overlay entries
+      expect(find.text('alice@test.com'), findsNothing);
+    });
+
+    testWidgets('@autocomplete hides on send', (tester) async {
+      client.workspaceMembers = [
+        {'id': 'u1', 'email': 'alice@test.com'},
+      ];
+
+      await tester.pumpWidget(buildChat());
+
+      await tester.enterText(find.byType(TextField), '@al');
+      await tester.pump();
+
+      // Autocomplete overlay should be visible
+      expect(find.text('alice@test.com'), findsWidgets);
+
+      // Now send and verify overlay is gone (text field cleared)
+      await tester.tap(find.byIcon(Icons.send));
+      await tester.pump();
+
+      // After send, text field is cleared so no autocomplete
+      final field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.controller!.text, isEmpty);
+    });
+
+    testWidgets('@autocomplete hides when @ followed by space', (tester) async {
+      client.workspaceMembers = [
+        {'id': 'u1', 'email': 'alice@test.com'},
+      ];
+
+      await tester.pumpWidget(buildChat());
+
+      await tester.enterText(find.byType(TextField), '@ ');
+      await tester.pump();
+
+      // No autocomplete since there's a space after @
+      expect(find.text('alice@test.com'), findsNothing);
+    });
+
+    testWidgets('@autocomplete handles invalid cursor position',
+        (tester) async {
+      client.workspaceMembers = [
+        {'id': 'u1', 'email': 'alice@test.com'},
+      ];
+
+      await tester.pumpWidget(buildChat());
+
+      // Set text with an invalid selection (cursor = -1)
+      final field = tester.widget<TextField>(find.byType(TextField));
+      field.controller!.value = const TextEditingValue(
+        text: '@al',
+        selection: TextSelection.collapsed(offset: -1),
+      );
+      await tester.pump();
+
+      // No autocomplete since cursor is invalid
+      expect(find.text('alice@test.com'), findsNothing);
+    });
+
+    testWidgets('mention not in URL is highlighted', (tester) async {
+      await tester.pumpWidget(buildChat());
+
+      await tester.runAsync(() async {
+        channel.serverSend({
+          'type': 'chat_message',
+          'id': 'msg-urlmention',
+          'user_email': 'alice@test.com',
+          'message': 'see https://example.com and @bob@test.com',
+          'created_at': '2026-01-01 00:00:00',
+          'mentions': ['bob-uid'],
+        });
+        await Future.delayed(Duration.zero);
+        await Future.delayed(Duration.zero);
+      });
+      await tester.pump();
+
+      bool foundUrl = false;
+      bool foundMention = false;
+      for (final st
+          in tester.widgetList<SelectableText>(find.byType(SelectableText))) {
+        final span = st.textSpan;
+        if (span != null) {
+          if (_findSpan(
+              span,
+              (s) =>
+                  s.text == 'https://example.com' &&
+                  s.style?.decoration == TextDecoration.underline)) {
+            foundUrl = true;
+          }
+          if (_findSpan(
+              span,
+              (s) =>
+                  s.text == '@bob@test.com' &&
+                  s.style?.fontWeight == FontWeight.bold)) {
+            foundMention = true;
+          }
+        }
+      }
+      expect(foundUrl, isTrue);
+      expect(foundMention, isTrue);
     });
   });
 }

--- a/src/frontend/test/ws_client_test.dart
+++ b/src/frontend/test/ws_client_test.dart
@@ -514,5 +514,49 @@ void main() {
     test('chatMessages stream is broadcast', () {
       expect(client.chatMessages.isBroadcast, isTrue);
     });
+
+    test('workspace_members populates workspaceMembers', () async {
+      channel.serverSend({
+        'type': 'workspace_members',
+        'members': [
+          {'id': 'u1', 'email': 'alice@test.com'},
+          {'id': 'u2', 'email': 'bob@test.com'},
+        ],
+      });
+      await Future.delayed(Duration.zero);
+
+      expect(client.workspaceMembers.length, 2);
+      expect(client.workspaceMembers[0]['email'], 'alice@test.com');
+      expect(client.workspaceMembers[1]['email'], 'bob@test.com');
+    });
+
+    test('workspace_members notifies listeners', () async {
+      bool notified = false;
+      client.addListener(() => notified = true);
+
+      channel.serverSend({
+        'type': 'workspace_members',
+        'members': [
+          {'id': 'u1', 'email': 'alice@test.com'},
+        ],
+      });
+      await Future.delayed(Duration.zero);
+
+      expect(notified, isTrue);
+    });
+
+    test('disconnectWorkspace clears workspaceMembers', () async {
+      channel.serverSend({
+        'type': 'workspace_members',
+        'members': [
+          {'id': 'u1', 'email': 'alice@test.com'},
+        ],
+      });
+      await Future.delayed(Duration.zero);
+      expect(client.workspaceMembers.length, 1);
+
+      client.disconnectWorkspace();
+      expect(client.workspaceMembers, isEmpty);
+    });
   });
 }


### PR DESCRIPTION
## Summary

- Parse `@email` patterns in chat messages on the backend, resolve to workspace member user IDs, store in new `chat_mentions` table
- Return mention metadata in `chat_message` and `chat_history` payloads
- Frontend `@`-autocomplete dropdown filtered against workspace members
- Mentions render as highlighted blue bold spans; self-mentions get a background highlight
- Amber `@N` badge on chat tab when current user is mentioned while tab is hidden
- Broadcast updated `workspace_members` list on connect and when membership changes via API (so autocomplete stays current)

Closes #180

## Test plan

- [x] Backend unit tests: 8 new mention model tests, 2 new wshandler tests, 1 new API broadcast test (1143 total, 100% coverage)
- [x] Frontend Dart tests: all 336 pass
- [x] New E2E test: `workspace_members` broadcast on member add + chat `@mention` data
- [x] Manual: open workspace with 2 users, type `@` in chat input, verify autocomplete appears and mention renders highlighted
- [x] Manual: verify amber badge appears when mentioned user is on a different tab