### PR TITLE
Add workspace presence: show who's connected

### DIFF
--- a/src/backend/klangk_backend/wshandler.py
+++ b/src/backend/klangk_backend/wshandler.py
@@ -479,6 +479,23 @@ class WebSocketState:
 state = WebSocketState()
 
 
+def _get_presence_list(workspace_id: str) -> list[dict]:
+    """Return deduplicated list of users connected to a workspace."""
+    session = state.get_session(workspace_id)
+    if not session:
+        return []
+    seen: set[str] = set()
+    users: list[dict] = []
+    for sock in session.subscribers:
+        conn = state.connections.get(sock)
+        if conn and conn.user["id"] not in seen:
+            seen.add(conn.user["id"])
+            users.append(
+                {"user_id": conn.user["id"], "user_email": conn.user["email"]}
+            )
+    return users
+
+
 class Connection:
     """Per-WebSocket connection state and command handlers."""
 
@@ -619,6 +636,20 @@ class Connection:
         if owner and not any(m["id"] == owner["id"] for m in members):
             members.append({"id": owner["id"], "email": owner["email"]})
         self.sock.send_json({"type": "workspace_members", "members": members})
+
+        # Send presence list to joining user and broadcast join to others
+        presence = _get_presence_list(workspace_id)
+        self.sock.send_json({"type": "presence_list", "users": presence})
+        session = state.get_session(workspace_id)
+        if session:
+            join_msg = {
+                "type": "presence_join",
+                "user_id": self.user["id"],
+                "user_email": self.user["email"],
+            }
+            for sock in list(session.subscribers):
+                if sock is not self.sock:
+                    sock.send_json(join_msg)
 
         # Store status for when frontend sends ui_ready
         self.pending_status_msg = status_msg
@@ -949,7 +980,22 @@ class Connection:
         session = state.get_session(workspace_id) if workspace_id else None
         if session:
             empty = await session.remove_subscriber(self.sock)
-            if empty:
+            if not empty:
+                # Broadcast presence_leave if user has no other connections
+                still_connected = any(
+                    state.connections.get(s) is not None
+                    and state.connections[s].user["id"] == self.user["id"]
+                    for s in session.subscribers
+                )
+                if not still_connected:
+                    session.broadcast(
+                        {
+                            "type": "presence_leave",
+                            "user_id": self.user["id"],
+                            "user_email": self.user["email"],
+                        }
+                    )
+            else:
                 # Lock is released by remove_subscriber, so use the
                 # lock-acquiring version.
                 await state.remove_session(workspace_id)

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -2598,6 +2598,192 @@ class TestChatSend:
         assert user["id"] in member_ids
 
 
+class TestPresence:
+    async def test_presence_list_on_connect(self, user):
+        """Joining user receives presence_list with current users."""
+        workspace = await _create_workspace_with_acl(user["id"], "pres-ws")
+
+        sock = _mock_sock()
+        conn = _base_conn(user=user, ws=sock)
+        wshandler.state.connections[sock] = conn
+
+        async def fake_start(wid, ws_obj):
+            conn.container_id = "cid"
+            session = wshandler.state.get_or_create_session(wid)
+            await session.add_subscriber(sock, "cid")
+
+        try:
+            with (
+                patch.object(
+                    Connection,
+                    "start_workspace_container",
+                    side_effect=fake_start,
+                ),
+                patch.object(
+                    container.registry,
+                    "get_workspace_ports",
+                    return_value=[],
+                ),
+            ):
+                await conn.handle_workspace_connect(
+                    {"workspaceId": workspace["id"]}
+                )
+
+            calls = [c[0][0] for c in sock.send_json.call_args_list]
+            plist = [c for c in calls if c.get("type") == "presence_list"]
+            assert len(plist) == 1
+            assert any(u["user_id"] == user["id"] for u in plist[0]["users"])
+        finally:
+            wshandler.state.sessions.pop(workspace["id"], None)
+            wshandler.state.connections.pop(sock, None)
+
+    async def test_presence_join_broadcast(self, user):
+        """Existing subscribers receive presence_join when someone connects."""
+        from klangk_backend import model
+
+        workspace = await _create_workspace_with_acl(
+            user["id"], "pres-join-ws"
+        )
+
+        # First user connects
+        sock1 = _mock_sock()
+        conn1 = _base_conn(user=user, ws=sock1)
+
+        session = wshandler.state.get_or_create_session(workspace["id"])
+        session.subscribers.add(sock1)
+        wshandler.state.connections[sock1] = conn1
+        conn1.workspace_id = workspace["id"]
+
+        # Second user connects
+        other = await model.create_user(
+            "other@test.com", "hash", verified=True
+        )
+        await model.add_acl_entry(
+            f"/workspaces/{workspace['id']}",
+            1,
+            model.ACTION_ALLOW,
+            "*",
+            model.PRINCIPAL_USER,
+            user_id=other["id"],
+        )
+        sock2 = _mock_sock()
+        conn2 = _base_conn(
+            user={"id": other["id"], "email": "other@test.com"}, ws=sock2
+        )
+        wshandler.state.connections[sock2] = conn2
+
+        async def fake_start(wid, ws_obj):
+            conn2.container_id = "cid"
+            session = wshandler.state.get_or_create_session(wid)
+            await session.add_subscriber(sock2, "cid")
+
+        try:
+            with (
+                patch.object(
+                    Connection,
+                    "start_workspace_container",
+                    side_effect=fake_start,
+                ),
+                patch.object(
+                    container.registry,
+                    "get_workspace_ports",
+                    return_value=[],
+                ),
+            ):
+                await conn2.handle_workspace_connect(
+                    {"workspaceId": workspace["id"]}
+                )
+
+            # sock1 should have received presence_join for other user
+            calls1 = [c[0][0] for c in sock1.send_json.call_args_list]
+            joins = [c for c in calls1 if c.get("type") == "presence_join"]
+            assert len(joins) == 1
+            assert joins[0]["user_id"] == other["id"]
+            assert joins[0]["user_email"] == "other@test.com"
+        finally:
+            wshandler.state.sessions.pop(workspace["id"], None)
+            wshandler.state.connections.pop(sock1, None)
+            wshandler.state.connections.pop(sock2, None)
+
+    async def test_presence_leave_broadcast(self, user):
+        """Remaining subscribers receive presence_leave on disconnect."""
+        from klangk_backend import model
+
+        workspace = await _create_workspace_with_acl(user["id"], "pres-lv-ws")
+
+        sock1 = _mock_sock()
+        sock2 = _mock_sock()
+        conn1 = _base_conn(user=user, ws=sock1)
+        other = await model.create_user("lv@test.com", "hash", verified=True)
+        conn2 = _base_conn(
+            user={"id": other["id"], "email": "lv@test.com"}, ws=sock2
+        )
+        conn1.workspace_id = workspace["id"]
+        conn2.workspace_id = workspace["id"]
+
+        session = WorkspaceSession(workspace["id"])
+        session.subscribers.add(sock1)
+        session.subscribers.add(sock2)
+        wshandler.state.sessions[workspace["id"]] = session
+        wshandler.state.connections[sock1] = conn1
+        wshandler.state.connections[sock2] = conn2
+
+        try:
+            # conn2 disconnects
+            await conn2.cleanup()
+
+            calls1 = [c[0][0] for c in sock1.send_json.call_args_list]
+            leaves = [c for c in calls1 if c.get("type") == "presence_leave"]
+            assert len(leaves) == 1
+            assert leaves[0]["user_id"] == other["id"]
+        finally:
+            wshandler.state.sessions.pop(workspace["id"], None)
+            wshandler.state.connections.pop(sock1, None)
+            wshandler.state.connections.pop(sock2, None)
+
+    async def test_presence_leave_multi_tab(self, user):
+        """No presence_leave if user has another connection in workspace."""
+        from klangk_backend import model
+
+        workspace = await _create_workspace_with_acl(user["id"], "pres-mt-ws")
+
+        sock1 = _mock_sock()
+        sock2 = _mock_sock()
+        sock3 = _mock_sock()
+        # sock1 and sock2 are same user, sock3 is another user
+        conn1 = _base_conn(user=user, ws=sock1)
+        conn2 = _base_conn(user=user, ws=sock2)
+        other = await model.create_user("mt@test.com", "hash", verified=True)
+        conn3 = _base_conn(
+            user={"id": other["id"], "email": "mt@test.com"}, ws=sock3
+        )
+        conn1.workspace_id = workspace["id"]
+        conn2.workspace_id = workspace["id"]
+        conn3.workspace_id = workspace["id"]
+
+        session = WorkspaceSession(workspace["id"])
+        session.subscribers.add(sock1)
+        session.subscribers.add(sock2)
+        session.subscribers.add(sock3)
+        wshandler.state.sessions[workspace["id"]] = session
+        wshandler.state.connections[sock1] = conn1
+        wshandler.state.connections[sock2] = conn2
+        wshandler.state.connections[sock3] = conn3
+
+        try:
+            # sock1 disconnects, but sock2 (same user) remains
+            await conn1.cleanup()
+
+            calls3 = [c[0][0] for c in sock3.send_json.call_args_list]
+            leaves = [c for c in calls3 if c.get("type") == "presence_leave"]
+            assert len(leaves) == 0
+        finally:
+            wshandler.state.sessions.pop(workspace["id"], None)
+            wshandler.state.connections.pop(sock1, None)
+            wshandler.state.connections.pop(sock2, None)
+            wshandler.state.connections.pop(sock3, None)
+
+
 class TestChatDelete:
     async def test_chat_delete_broadcasts_update(self, user):
         from klangk_backend import model

--- a/src/frontend/e2e-tests/e2e/klangk.spec.ts
+++ b/src/frontend/e2e-tests/e2e/klangk.spec.ts
@@ -2190,6 +2190,57 @@ test.describe("Klangk E2E", () => {
     });
   });
 
+  test("presence_list includes logged-in user on connect", async ({
+    browser,
+    request,
+  }) => {
+    const email = `presence-${Date.now()}@test.example.com`;
+    const { headers } = await registerUser(request, email);
+
+    const wsResp = await request.post(`${API_BASE}/workspaces`, {
+      headers,
+      data: { name: `e2e-presence-${Date.now()}` },
+    });
+    expect(wsResp.ok()).toBeTruthy();
+    const workspaceId = (await wsResp.json()).id;
+
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+
+    const presenceMessages: string[] = [];
+    page.on("websocket", (ws) => {
+      ws.on("framereceived", (frame: { payload: string | Buffer }) => {
+        const text = frame.payload.toString();
+        if (text.includes("presence_list")) {
+          presenceMessages.push(text);
+        }
+      });
+    });
+
+    await openWorkspace(page, email, workspaceId, {
+      waitForTerminal: true,
+    });
+
+    // Wait for presence_list to arrive
+    await page.waitForTimeout(2000);
+
+    expect(presenceMessages.length).toBeGreaterThan(0);
+    const presenceList = JSON.parse(
+      presenceMessages[presenceMessages.length - 1],
+    );
+    expect(presenceList.type).toBe("presence_list");
+    expect(presenceList.users.length).toBeGreaterThan(0);
+    const emails = presenceList.users.map(
+      (u: { user_email: string }) => u.user_email,
+    );
+    expect(emails).toContain(email);
+
+    await ctx.close();
+    await request.delete(`${API_BASE}/workspaces/${workspaceId}`, {
+      headers,
+    });
+  });
+
   test("container recreated on page refresh", async ({ page, request }) => {
     const { workspaceId, headers, cleanup } = await createAndOpenWorkspace(
       page,

--- a/src/frontend/lib/chat/workspace_chat.dart
+++ b/src/frontend/lib/chat/workspace_chat.dart
@@ -54,6 +54,7 @@ class WorkspaceChatState extends State<WorkspaceChat> {
     }
     _chatSub = widget.wsClient.chatMessages.listen(_onMessage);
     _textController.addListener(_onTextChanged);
+    widget.wsClient.addListener(_onPresenceChanged);
   }
 
   /// Focuses the message input. Called by the parent when the Chat tab is
@@ -349,8 +350,78 @@ class WorkspaceChatState extends State<WorkspaceChat> {
     widget.wsClient.sendChatDelete(messageId);
   }
 
+  void _onPresenceChanged() {
+    if (mounted) setState(() {});
+  }
+
+  Widget _buildPresenceBar(String? currentUserId) {
+    final users = widget.wsClient.presenceUsers;
+    if (users.isEmpty) return const SizedBox.shrink();
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      decoration: const BoxDecoration(
+        border: Border(bottom: BorderSide(color: KColors.borderDefault)),
+      ),
+      child: Row(
+        children: [
+          const Text(
+            'Online ',
+            style: TextStyle(color: KColors.textMuted, fontSize: 11),
+          ),
+          ...users.map((u) {
+            final email = u['user_email'] as String? ?? '';
+            final uid = u['user_id'] as String?;
+            final isSelf = uid == currentUserId;
+            final initial = email.isNotEmpty ? email[0].toUpperCase() : '?';
+            return Padding(
+              padding: const EdgeInsets.only(right: 4),
+              child: Tooltip(
+                message: email,
+                child: CircleAvatar(
+                  radius: 10,
+                  backgroundColor:
+                      isSelf ? Colors.transparent : _colorForEmail(email),
+                  foregroundColor:
+                      isSelf ? _colorForEmail(email) : Colors.white,
+                  child: isSelf
+                      ? DecoratedBox(
+                          decoration: BoxDecoration(
+                            shape: BoxShape.circle,
+                            border: Border.all(
+                              color: _colorForEmail(email),
+                              width: 1.5,
+                            ),
+                          ),
+                          child: Center(
+                            child: Text(
+                              initial,
+                              style: TextStyle(
+                                fontSize: 10,
+                                fontWeight: FontWeight.bold,
+                                color: _colorForEmail(email),
+                              ),
+                            ),
+                          ),
+                        )
+                      : Text(
+                          initial,
+                          style: const TextStyle(
+                            fontSize: 10,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                ),
+              ),
+            );
+          }),
+        ],
+      ),
+    );
+  }
+
   @override
   void dispose() {
+    widget.wsClient.removeListener(_onPresenceChanged);
     _hideAutocomplete();
     _chatSub?.cancel();
     _scrollController.dispose();
@@ -370,6 +441,7 @@ class WorkspaceChatState extends State<WorkspaceChat> {
       color: KColors.bgCanvas,
       child: Column(
         children: [
+          _buildPresenceBar(currentUserId),
           Expanded(
             child: _messages.isEmpty
                 ? const Center(

--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -70,6 +70,9 @@ class WsClient extends ChangeNotifier {
   /// Workspace members for @mention autocomplete.
   List<Map<String, dynamic>> workspaceMembers = [];
 
+  /// Users currently connected to the workspace.
+  List<Map<String, dynamic>> presenceUsers = [];
+
   /// Chat messages (individual and history) from the backend.
   Stream<Map<String, dynamic>> get chatMessages => _chatController.stream;
 
@@ -160,6 +163,26 @@ class WsClient extends ChangeNotifier {
             final members = json['members'] as List? ?? [];
             workspaceMembers = members.cast<Map<String, dynamic>>();
             notifyListeners();
+          } else if (type == 'presence_list') {
+            final users = json['users'] as List? ?? [];
+            presenceUsers = users.cast<Map<String, dynamic>>();
+            notifyListeners();
+          } else if (type == 'presence_join') {
+            final uid = json['user_id'] as String?;
+            if (uid != null && !presenceUsers.any((u) => u['user_id'] == uid)) {
+              presenceUsers = [
+                ...presenceUsers,
+                {'user_id': uid, 'user_email': json['user_email']},
+              ];
+              notifyListeners();
+            }
+          } else if (type == 'presence_leave') {
+            final uid = json['user_id'] as String?;
+            if (uid != null) {
+              presenceUsers =
+                  presenceUsers.where((u) => u['user_id'] != uid).toList();
+              notifyListeners();
+            }
           } else if (type == 'event') {
             _customEventController.add(json);
           }
@@ -214,6 +237,7 @@ class WsClient extends ChangeNotifier {
     _currentWorkspaceId = null;
     chatHistory.clear();
     workspaceMembers = [];
+    presenceUsers = [];
     notifyListeners();
   }
 

--- a/src/frontend/test/workspace_chat_test.dart
+++ b/src/frontend/test/workspace_chat_test.dart
@@ -821,5 +821,76 @@ void main() {
       expect(foundUrl, isTrue);
       expect(foundMention, isTrue);
     });
+
+    testWidgets('presence bar shows connected users', (tester) async {
+      client.presenceUsers = [
+        {'user_id': 'u1', 'user_email': 'alice@test.com'},
+        {'user_id': 'u2', 'user_email': 'bob@test.com'},
+      ];
+
+      await tester.pumpWidget(buildChat());
+
+      expect(find.text('Online '), findsOneWidget);
+      // Initials rendered in CircleAvatars
+      expect(find.text('A'), findsOneWidget);
+      expect(find.text('B'), findsOneWidget);
+    });
+
+    testWidgets('presence bar hidden when no users', (tester) async {
+      client.presenceUsers = [];
+
+      await tester.pumpWidget(buildChat());
+
+      expect(find.text('Online '), findsNothing);
+    });
+
+    testWidgets('presence bar updates on join', (tester) async {
+      client.presenceUsers = [
+        {'user_id': 'u1', 'user_email': 'alice@test.com'},
+      ];
+
+      await tester.pumpWidget(buildChat());
+      expect(find.text('A'), findsOneWidget);
+
+      // Simulate a presence_join via WsClient
+      client.presenceUsers = [
+        {'user_id': 'u1', 'user_email': 'alice@test.com'},
+        {'user_id': 'u2', 'user_email': 'bob@test.com'},
+      ];
+      client.notifyListeners();
+      await tester.pump();
+
+      expect(find.text('B'), findsOneWidget);
+    });
+
+    testWidgets('self user shown with outline style', (tester) async {
+      final fakeJwt = base64Url.encode(utf8.encode('{"alg":"HS256"}')) +
+          '.' +
+          base64Url
+              .encode(utf8.encode('{"sub":"my-uid","email":"me@test.com"}')) +
+          '.sig';
+      SharedPreferences.setMockInitialValues({'klangk_jwt': fakeJwt});
+      final auth = AuthService();
+      await tester.runAsync(() => Future.delayed(Duration.zero));
+
+      client.presenceUsers = [
+        {'user_id': 'my-uid', 'user_email': 'me@test.com'},
+        {'user_id': 'other', 'user_email': 'other@test.com'},
+      ];
+
+      await tester.pumpWidget(buildChat(authService: auth));
+
+      // Both users should be rendered
+      expect(find.text('M'), findsOneWidget);
+      expect(find.text('O'), findsOneWidget);
+
+      // Self avatar should have transparent background (outline style)
+      final avatars =
+          tester.widgetList<CircleAvatar>(find.byType(CircleAvatar));
+      final selfAvatar = avatars.firstWhere(
+        (a) => a.backgroundColor == Colors.transparent,
+      );
+      expect(selfAvatar, isNotNull);
+    });
   });
 }

--- a/src/frontend/test/ws_client_test.dart
+++ b/src/frontend/test/ws_client_test.dart
@@ -558,5 +558,92 @@ void main() {
       client.disconnectWorkspace();
       expect(client.workspaceMembers, isEmpty);
     });
+
+    test('presence_list populates presenceUsers', () async {
+      channel.serverSend({
+        'type': 'presence_list',
+        'users': [
+          {'user_id': 'u1', 'user_email': 'alice@test.com'},
+          {'user_id': 'u2', 'user_email': 'bob@test.com'},
+        ],
+      });
+      await Future.delayed(Duration.zero);
+
+      expect(client.presenceUsers.length, 2);
+      expect(client.presenceUsers[0]['user_email'], 'alice@test.com');
+    });
+
+    test('presence_join adds user', () async {
+      channel.serverSend({
+        'type': 'presence_list',
+        'users': [
+          {'user_id': 'u1', 'user_email': 'alice@test.com'},
+        ],
+      });
+      await Future.delayed(Duration.zero);
+
+      channel.serverSend({
+        'type': 'presence_join',
+        'user_id': 'u2',
+        'user_email': 'bob@test.com',
+      });
+      await Future.delayed(Duration.zero);
+
+      expect(client.presenceUsers.length, 2);
+      expect(client.presenceUsers.any((u) => u['user_id'] == 'u2'), isTrue);
+    });
+
+    test('presence_join ignores duplicate', () async {
+      channel.serverSend({
+        'type': 'presence_list',
+        'users': [
+          {'user_id': 'u1', 'user_email': 'alice@test.com'},
+        ],
+      });
+      await Future.delayed(Duration.zero);
+
+      channel.serverSend({
+        'type': 'presence_join',
+        'user_id': 'u1',
+        'user_email': 'alice@test.com',
+      });
+      await Future.delayed(Duration.zero);
+
+      expect(client.presenceUsers.length, 1);
+    });
+
+    test('presence_leave removes user', () async {
+      channel.serverSend({
+        'type': 'presence_list',
+        'users': [
+          {'user_id': 'u1', 'user_email': 'alice@test.com'},
+          {'user_id': 'u2', 'user_email': 'bob@test.com'},
+        ],
+      });
+      await Future.delayed(Duration.zero);
+
+      channel.serverSend({
+        'type': 'presence_leave',
+        'user_id': 'u1',
+      });
+      await Future.delayed(Duration.zero);
+
+      expect(client.presenceUsers.length, 1);
+      expect(client.presenceUsers[0]['user_id'], 'u2');
+    });
+
+    test('disconnectWorkspace clears presenceUsers', () async {
+      channel.serverSend({
+        'type': 'presence_list',
+        'users': [
+          {'user_id': 'u1', 'user_email': 'alice@test.com'},
+        ],
+      });
+      await Future.delayed(Duration.zero);
+      expect(client.presenceUsers.length, 1);
+
+      client.disconnectWorkspace();
+      expect(client.presenceUsers, isEmpty);
+    });
   });
 }


### PR DESCRIPTION
## Summary

- Broadcast `presence_join`/`presence_leave` events on workspace connect/disconnect
- Send full `presence_list` to each joining user
- Multi-tab aware: `presence_leave` only fires when a user's last connection drops
- Frontend presence bar at top of chat panel with colored avatar circles and email tooltips
- Self user shown with outline style, others filled

Closes #181

## Test plan

- [x] Backend: 1147 passed, 100% coverage (4 new presence tests)
- [x] Frontend: 362 passed, 100% coverage (7 ws_client + 4 chat widget presence tests)
- [x] E2E: `presence_list` includes logged-in user on connect
- [x] Manual: open workspace in 2 browser tabs with different users, verify avatars appear/disappear in real time