### PR TITLE
build(flterm): pin to libghostty tag 0.0.3.1 (reproducible dep)

### DIFF
--- a/src/frontend/pubspec.yaml
+++ b/src/frontend/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   flterm:
     git:
       url: https://github.com/runyaga/libghostty.git
-      ref: main
+      ref: "0.0.3.1"
       path: packages/flterm
   libghostty: ^0.0.9
   google_fonts: ^8.1.0


### PR DESCRIPTION
Pins the flterm git dependency from the moving `ref: main` to the immutable tag `0.0.3.1` (`runyaga/libghostty` @ `c943f0d`, which adds the `bypassKey` predicate and public `TerminalController.handleScroll`) so the build is reproducible and the dependency can't drift.