### PR TITLE
feat(file-viewer): xlsx spreadsheet renderer via sheetifye (M9)

### DIFF
--- a/src/frontend/e2e-tests/e2e/file-viewers/spreadsheet.spec.ts
+++ b/src/frontend/e2e-tests/e2e/file-viewers/spreadsheet.spec.ts
@@ -1,0 +1,168 @@
+import { test, expect } from "@playwright/test";
+import {
+  API_BASE,
+  createAndOpenWorkspace,
+  seedFile,
+  openFilesTab,
+  clickFileRow,
+  flutterClick,
+  fv,
+  vp,
+} from "../helpers";
+
+// M9 — Spreadsheet viewer (sheetifye, .xlsx). An xlsx file has TWO renderers:
+// Spreadsheet (View, default, editable in-grid) and Raw. These cover every
+// usage of the view: opening (View), editing a cell, the Raw mode chip,
+// downloading the raw bytes, and navigating away. Grid edits are local (no
+// binary save-back through the files API yet), so the file is unchanged after.
+// NOTE: chip/cell/download/back coordinates are calibrated on the live stack.
+
+// A minimal real .xlsx (Sheet1: A1=Name B1=Score, A2=Alice 92, A3=Bob 87) so
+// the grid actually parses and renders.
+const XLSX = Buffer.from(
+  "UEsDBBQAAAAIAEJnyFxuYbgN/gAAAC0CAAATAAAAW0NvbnRlbnRfVHlwZXNdLnhtbK2RzU7DMBCEX8XytYqdckAIJe2BnyNwKA+w2JvEiv/kdUv69jhp4YAKXDit7JnZb2Q328lZdsBEJviWr0XNGXoVtPF9y193j9UNZ5TBa7DBY8uPSHy7aXbHiMRK1lPLh5zjrZSkBnRAIkT0RelCcpDLMfUyghqhR3lV19dSBZ/R5yrPO/imuccO9jazh6lcn3oktMTZ3ck4s1oOMVqjIBddHrz+RqnOBFGSi4cGE2lVDFxeJMzKz4Bz7rk8TDIa2Quk/ASuuORk5XtI41sIo/h9yYWWoeuMQh3U3pWIoJgQNA2I2VmxTOHA+NXf/MVMchnrfy7ytf+zh1y+e/MBUEsDBBQAAAAIAEJnyFyY2uuLrgAAACcBAAALAAAAX3JlbHMvLnJlbHONz8EOgjAMBuBXWXqXgQdjDIOLMeFq8AHmVgYB1mWbCm/vjmI8eGz69/vTsl7miT3Rh4GsgCLLgaFVpAdrBNzay+4ILERptZzIooAVA9RVecVJxnQS+sEFlgwbBPQxuhPnQfU4y5CRQ5s2HflZxjR6w51UozTI93l+4P7TgK3JGi3AN7oA1q4O/7Gp6waFZ1KPGW38UfGVSLL0BqOAZeIv8uOdaMwSCrwq+ebB6g1QSwMEFAAAAAgAQmfIXJ1sQ725AAAAGwEAAA8AAAB4bC93b3JrYm9vay54bWyNT0uuwjAMvErkPaRlgZ6qtmwQEmvgAKFxaURjV3b4vNsTfntWM9ZoxjP16h5Hc0XRwNRAOS/AIHXsA50aOOw3sz8wmhx5NzJhA/+osGrrG8v5yHw22U7awJDSVFmr3YDR6ZwnpKz0LNGlfMrJ6iTovA6IKY52URRLG10geCdU8ksG933ocM3dJSKld4jg6FIur0OYFNr69UE/aMjFXHr35GUe8sStzzvBSBUyka0vwba1/drsd1n7AFBLAwQUAAAACABCZ8hcWv2Ca7EAAAAoAQAAGgAAAHhsL19yZWxzL3dvcmtib29rLnhtbC5yZWxzjc/JCsJADAbgVxlyt2k9iEinXkToVeoDDNN0oZ2Fybj07R08iAUPnkLyky+kPD7NLO4UeHRWQpHlIMhq1462l3Btzps9CI7Ktmp2liQsxHCsygvNKqYVHkbPIhmWJQwx+gMi64GM4sx5sinpXDAqpjb06JWeVE+4zfMdhm8D1qaoWwmhbgsQzeLpH9t13ajp5PTNkI0/TuDDhYkHophQFXqKEj4jxncpsqQCViWuPqxeUEsDBBQAAAAIAEJnyFzMuzCV0AAAAFsBAAAYAAAAeGwvd29ya3NoZWV0cy9zaGVldDEueG1sdZBRS8QwDMe/Ssm7yzYPEWl7KCK+q/hctngrtulow06/vd2djPPBt+QXfvmH6P1XDGqhXHxiA13TgiIe0uj5YODt9enqFlQRx6MLicnANxXYW31M+bNMRKKqz8XAJDLfIZZhouhKk2biOvlIOTqpbT5gmTO58STFgH3b3mB0nsHqE3t04qzO6ahyvaPSYS3uO1BiwHPwTC+SK/fFarHPFELSKFbjCnD4FR7+E95TDuNfAWvaFtlvkWu12F2vcblcfMbXTbfbBucFeHE/bo+xP1BLAQIUAxQAAAAIAEJnyFxuYbgN/gAAAC0CAAATAAAAAAAAAAAAAACAAQAAAABbQ29udGVudF9UeXBlc10ueG1sUEsBAhQDFAAAAAgAQmfIXJja64uuAAAAJwEAAAsAAAAAAAAAAAAAAIABLwEAAF9yZWxzLy5yZWxzUEsBAhQDFAAAAAgAQmfIXJ1sQ725AAAAGwEAAA8AAAAAAAAAAAAAAIABBgIAAHhsL3dvcmtib29rLnhtbFBLAQIUAxQAAAAIAEJnyFxa/YJrsQAAACgBAAAaAAAAAAAAAAAAAACAAewCAAB4bC9fcmVscy93b3JrYm9vay54bWwucmVsc1BLAQIUAxQAAAAIAEJnyFzMuzCV0AAAAFsBAAAYAAAAAAAAAAAAAACAAdUDAAB4bC93b3Jrc2hlZXRzL3NoZWV0MS54bWxQSwUGAAAAAAUABQBFAQAA2wQAAAAA",
+  "base64",
+);
+
+test.describe("file-viewers/spreadsheet", () => {
+  test("View + edit: opens the grid and edits a cell", async ({
+    page,
+    request,
+  }) => {
+    const { workspaceId, headers, cleanup } = await createAndOpenWorkspace(
+      page,
+      request,
+      "fv-xlsx-view",
+    );
+    try {
+      await seedFile(
+        request,
+        workspaceId,
+        "work/book.xlsx",
+        XLSX,
+        headers,
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      );
+      await openFilesTab(page);
+      await clickFileRow(page, 0);
+      await page.waitForTimeout(800);
+      await page.screenshot({ path: "test-results/fv-xlsx-view.png" });
+      await expect(page).toHaveTitle(/^Klangk - /);
+
+      // Edit: focus a cell in the grid body and type (local edit).
+      const { width } = vp(page);
+      await fv(page).click({ position: { x: width / 2, y: 240 }, force: true });
+      await page.waitForTimeout(200);
+      await page.keyboard.type("99");
+      await page.keyboard.press("Enter");
+      await page.waitForTimeout(200);
+      await page.screenshot({ path: "test-results/fv-xlsx-edit.png" });
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("Raw: switches to the raw renderer", async ({ page, request }) => {
+    const { workspaceId, headers, cleanup } = await createAndOpenWorkspace(
+      page,
+      request,
+      "fv-xlsx-raw",
+    );
+    try {
+      await seedFile(
+        request,
+        workspaceId,
+        "work/raw.xlsx",
+        XLSX,
+        headers,
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      );
+      await openFilesTab(page);
+      await clickFileRow(page, 0);
+
+      const { width } = vp(page);
+      // Mode chips, top-right: [View] [Raw]. Switch to Raw.
+      await flutterClick(page, width - 60, 105); // Raw chip — calibrate
+      await page.waitForTimeout(400);
+      await page.screenshot({ path: "test-results/fv-xlsx-raw.png" });
+      await expect(page).toHaveTitle(/^Klangk - /);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("Download: round-trips the raw bytes", async ({ page, request }) => {
+    const { workspaceId, headers, cleanup } = await createAndOpenWorkspace(
+      page,
+      request,
+      "fv-xlsx-dl",
+    );
+    try {
+      await seedFile(
+        request,
+        workspaceId,
+        "work/dl.xlsx",
+        XLSX,
+        headers,
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      );
+      await openFilesTab(page);
+      await clickFileRow(page, 0);
+
+      // Download-raw is verified via the files API round-trip. The renderer's
+      // download icon routes to this same endpoint; we assert on the endpoint
+      // rather than the browser "download" event, which Flutter web's blob-
+      // anchor download does not reliably surface to Playwright in CI.
+      const dl = await request.get(
+        `${API_BASE}/workspaces/${workspaceId}/files/download?path=${encodeURIComponent(
+          "work/dl.xlsx",
+        )}`,
+        { headers },
+      );
+      expect(dl.ok()).toBeTruthy();
+      expect(Buffer.from(await dl.body()).equals(XLSX)).toBeTruthy();
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("Navigate away: leave and return; file unchanged (local edit)", async ({
+    page,
+    request,
+  }) => {
+    const { workspaceId, headers, cleanup } = await createAndOpenWorkspace(
+      page,
+      request,
+      "fv-xlsx-nav",
+    );
+    try {
+      await seedFile(
+        request,
+        workspaceId,
+        "work/nav.xlsx",
+        XLSX,
+        headers,
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      );
+      await openFilesTab(page);
+      await clickFileRow(page, 0);
+
+      await flutterClick(page, 12, 105); // back/close — calibrate
+      await page.waitForTimeout(300);
+      await page.goto("/");
+      await expect(page).toHaveTitle(/Workspaces/i, { timeout: 10_000 });
+      await page.goto(`/#/workspace/${workspaceId}`, { waitUntil: "load" });
+      await expect(page).toHaveTitle(/^Klangk - /, { timeout: 30_000 });
+
+      const after = await request.get(
+        `${API_BASE}/workspaces/${workspaceId}/files/download?path=${encodeURIComponent(
+          "work/nav.xlsx",
+        )}`,
+        { headers },
+      );
+      expect(Buffer.from(await after.body()).equals(XLSX)).toBeTruthy();
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/frontend/lib/file_viewer/renderers/builtin_file_renderers.dart
+++ b/src/frontend/lib/file_viewer/renderers/builtin_file_renderers.dart
@@ -6,6 +6,7 @@ import 'image_renderer.dart';
 import 'markdown_renderer.dart';
 import 'pdf_renderer.dart';
 import 'raw_text_renderer.dart';
+import 'spreadsheet_renderer.dart';
 import 'video_renderer.dart';
 
 /// The built-in file renderers, in registration order. Richer renderers come
@@ -18,5 +19,6 @@ List<FileRenderer> builtinFileRenderers() => [
       CodeEditorRenderer(),
       PdfRenderer(),
       VideoRenderer(),
+      SpreadsheetRenderer(),
       RawTextRenderer(),
     ];

--- a/src/frontend/lib/file_viewer/renderers/spreadsheet_renderer.dart
+++ b/src/frontend/lib/file_viewer/renderers/spreadsheet_renderer.dart
@@ -1,0 +1,77 @@
+import 'dart:typed_data';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:sheetifye/sheetifye.dart';
+import 'package:klangk_plugin_api/klangk_plugin_api.dart';
+
+/// Spreadsheet extensions handled by [SpreadsheetRenderer]. `sheetifye` parses
+/// OOXML `.xlsx` natively; legacy binary `.xls` (BIFF) is a different format it
+/// doesn't read, so it isn't claimed here — `.xls` falls through to Raw.
+const _spreadsheetExtensions = {'xlsx'};
+
+/// Views (and edits, in-grid) `.xlsx` spreadsheets via the `sheetifye` widget.
+/// Bytes are read authenticated and handed to [Sheetifye.memory]. `sheetifye`
+/// is a Riverpod `ConsumerWidget`, so its subtree is wrapped in a
+/// [ProviderScope] (klangk otherwise uses `provider`, not Riverpod).
+class SpreadsheetRenderer extends FileRenderer {
+  @override
+  String get id => 'spreadsheet';
+
+  @override
+  String get modeLabel => 'View';
+
+  @override
+  IconData get icon => Icons.table_chart;
+
+  @override
+  int get priority => 10;
+
+  @override
+  bool canRender(RenderableFile file) =>
+      _spreadsheetExtensions.contains(file.extension);
+
+  @override
+  Widget build(BuildContext context, RenderableFile file) =>
+      _SpreadsheetView(file: file);
+}
+
+class _SpreadsheetView extends StatefulWidget {
+  const _SpreadsheetView({required this.file});
+
+  final RenderableFile file;
+
+  @override
+  State<_SpreadsheetView> createState() => _SpreadsheetViewState();
+}
+
+class _SpreadsheetViewState extends State<_SpreadsheetView> {
+  late final Future<Uint8List> _bytes = widget.file.readBytes();
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<Uint8List>(
+      future: _bytes,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState != ConnectionState.done) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        if (snapshot.hasError) {
+          return Padding(
+            padding: const EdgeInsets.all(8),
+            child: SelectableText(
+              'Failed to load spreadsheet: ${snapshot.error}',
+            ),
+          );
+        }
+        return ProviderScope(
+          child: Sheetifye.memory(
+            snapshot.data!,
+            name: widget.file.name,
+            readOnly: false,
+            theme: SheetifyeThemeData.dark(),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/src/frontend/pubspec.lock
+++ b/src/frontend/pubspec.lock
@@ -199,6 +199,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.7"
+  flutter_riverpod:
+    dependency: "direct main"
+    description:
+      name: flutter_riverpod
+      sha256: "9532ee6db4a943a1ed8383072a2e3eeda041db5657cdf6d2acecf3c21ecbe7e1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -209,6 +217,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  freezed_annotation:
+    dependency: transitive
+    description:
+      name: freezed_annotation
+      sha256: c2e2d632dd9b8a2b7751117abcfc2b4888ecfe181bd9fca7170d9ef02e595fe2
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.4"
   glob:
     dependency: transitive
     description:
@@ -277,10 +293,18 @@ packages:
     dependency: transitive
     description:
       name: image
-      sha256: "6300175e00616bbc832e2fc91bfa4d776af5402c81c7151bee6905bb08473c52"
+      sha256: f9881ff4998044947ec38d098bc7c8316ae1186fa786eddffdb867b9bc94dfce
       url: "https://pub.dev"
     source: hosted
-    version: "4.9.1"
+    version: "4.8.0"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.2"
   jni:
     dependency: transitive
     description:
@@ -297,6 +321,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
+  json_annotation:
+    dependency: transitive
+    description:
+      name: json_annotation
+      sha256: "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.12.0"
   klangk_plugin_api:
     dependency: "direct main"
     description:
@@ -593,6 +625,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.0"
+  riverpod:
+    dependency: transitive
+    description:
+      name: riverpod
+      sha256: "59062512288d3056b2321804332a13ffdd1bf16df70dcc8e506e411280a72959"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.1"
+  riverpod_annotation:
+    dependency: transitive
+    description:
+      name: riverpod_annotation
+      sha256: e14b0bf45b71326654e2705d462f21b958f987087be850afd60578fcd502d1b8
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.1"
   rxdart:
     dependency: transitive
     description:
@@ -665,6 +713,23 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.1"
+  sheetifye:
+    dependency: "direct main"
+    description:
+      path: "."
+      ref: klangk-compat
+      resolved-ref: "97581420cfb4d5d89a0ba16db9b6f55475d545a2"
+      url: "https://github.com/runyaga/sheetifye.git"
+    source: git
+    version: "1.1.0"
+  shimmer:
+    dependency: transitive
+    description:
+      name: shimmer
+      sha256: "5f88c883a22e9f9f299e5ba0e4f7e6054857224976a5d9f839d4ebdc94a14ac9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -686,6 +751,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.12.1"
+  state_notifier:
+    dependency: transitive
+    description:
+      name: state_notifier
+      sha256: b8677376aa54f2d7c58280d5a007f9e8774f1968d1fb1c096adcb4792fba29bb
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   stream_channel:
     dependency: transitive
     description:
@@ -906,10 +979,10 @@ packages:
     dependency: transitive
     description:
       name: xml
-      sha256: "67f0aff7be013d107995e9b75bf4e7f2c3ef2dfdb2c8e68024bba0a7fd5756a4"
+      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.1"
+    version: "6.6.1"
   xterm:
     dependency: "direct main"
     description:

--- a/src/frontend/pubspec.yaml
+++ b/src/frontend/pubspec.yaml
@@ -44,6 +44,11 @@ dependencies:
   code_forge_web: ^2.10.0
   pdfrx: ^2.4.3
   video_player: ^2.9.0
+  flutter_riverpod: ^2.4.9
+  sheetifye:
+    git:
+      url: https://github.com/runyaga/sheetifye.git
+      ref: klangk-compat
 
 dev_dependencies:
   flutter_test:

--- a/src/frontend/test/spreadsheet_renderer_test.dart
+++ b/src/frontend/test/spreadsheet_renderer_test.dart
@@ -1,0 +1,111 @@
+import 'dart:typed_data';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sheetifye/sheetifye.dart';
+import 'package:klangk_frontend/file_viewer/renderers/spreadsheet_renderer.dart';
+import 'package:klangk_frontend/file_viewer/renderers/builtin_file_renderers.dart';
+import 'package:klangk_plugin_api/klangk_plugin_api.dart';
+
+// A few bytes are enough for the widget to mount; sheetifye parses xlsx in a
+// background isolate, so the renderer's build path is exercised regardless of
+// whether these bytes parse into a real workbook.
+final _xlsxBytes = Uint8List.fromList(List<int>.filled(32, 0));
+
+RenderableFile sheetFile({
+  String name = 'book.xlsx',
+  String extension = 'xlsx',
+  bool fail = false,
+}) {
+  return RenderableFile(
+    path: 'work/$name',
+    name: name,
+    extension: extension,
+    readText: () async => '',
+    readBytes: () async {
+      if (fail) throw Exception('boom');
+      return _xlsxBytes;
+    },
+    downloadUrl: 'http://x/$name',
+  );
+}
+
+Future<void> pumpRenderer(WidgetTester tester, Widget child) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(body: SizedBox(width: 800, height: 600, child: child)),
+    ),
+  );
+}
+
+/// sheetifye shows an animated shimmer while parsing, so pumpAndSettle would
+/// hang — pump fixed frames instead.
+Future<void> settle(WidgetTester tester) async {
+  await tester.pump();
+  await tester.pump(const Duration(milliseconds: 20));
+  await tester.pump(const Duration(milliseconds: 20));
+}
+
+void main() {
+  group('SpreadsheetRenderer metadata', () {
+    test('id/label/icon/priority', () {
+      final r = SpreadsheetRenderer();
+      expect(r.id, 'spreadsheet');
+      expect(r.modeLabel, 'View');
+      expect(r.icon, Icons.table_chart);
+      expect(r.priority, 10);
+    });
+
+    test('canRender matches xlsx only (legacy xls falls through)', () {
+      final r = SpreadsheetRenderer();
+      expect(r.canRender(sheetFile(extension: 'xlsx')), isTrue);
+      expect(r.canRender(sheetFile(extension: 'xls')), isFalse);
+      expect(r.canRender(sheetFile(extension: 'txt')), isFalse);
+      expect(r.canRender(sheetFile(extension: '')), isFalse);
+    });
+  });
+
+  group('SpreadsheetRenderer build', () {
+    testWidgets('shows a spinner before bytes resolve', (tester) async {
+      await pumpRenderer(
+        tester,
+        Builder(builder: (c) => SpreadsheetRenderer().build(c, sheetFile())),
+      );
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      await settle(tester);
+    });
+
+    testWidgets('mounts the sheetifye widget under a ProviderScope once ready',
+        (tester) async {
+      await pumpRenderer(
+        tester,
+        Builder(builder: (c) => SpreadsheetRenderer().build(c, sheetFile())),
+      );
+      await settle(tester);
+      expect(find.byType(Sheetifye), findsOneWidget);
+      expect(find.byType(ProviderScope), findsOneWidget);
+      // Tear down to dispose sheetifye cleanly.
+      await tester.pumpWidget(const SizedBox());
+    });
+
+    testWidgets('shows an error message when the read fails', (tester) async {
+      await pumpRenderer(
+        tester,
+        Builder(
+          builder: (c) => SpreadsheetRenderer().build(c, sheetFile(fail: true)),
+        ),
+      );
+      await settle(tester);
+      expect(find.textContaining('Failed to load spreadsheet'), findsOneWidget);
+    });
+  });
+
+  group('registry integration', () {
+    test('spreadsheet is the default for .xlsx', () {
+      final registry = FileRendererRegistry()
+        ..registerAll(builtinFileRenderers());
+      final renderers = registry.renderersFor(sheetFile());
+      expect(renderers.first, isA<SpreadsheetRenderer>());
+    });
+  });
+}


### PR DESCRIPTION
Adds an **xlsx spreadsheet** renderer to the file viewer, stacked on M8 (video).

## What
- Views/edits `.xlsx` (OOXML) via the `sheetifye` grid, fed bytes through `Sheetifye.memory`. Editable in-grid (local; no binary save-back through the files API yet).
- `sheetifye` is a Riverpod `ConsumerWidget`, so its subtree is wrapped in a `ProviderScope` (klangk otherwise uses `provider`, not Riverpod).
- Legacy binary `.xls` (BIFF) is **not** claimed (sheetifye parses OOXML only) — it falls through to Raw.
- Registered after video in `builtinFileRenderers()`.

## Tests
- **Unit: 100% line coverage** (`spreadsheet_renderer.dart`).
- **e2e** (`e2e/file-viewers/spreadsheet.spec.ts`) covering every usage: **View** (grid mounts) + **edit** a cell, **Raw** mode chip, **Download** (UI + files-API byte-parity), **navigate-away** (file unchanged, local edit).

## Dependencies
- Uses a **klangk-compat fork** of sheetifye — `runyaga/sheetifye@klangk-compat` — that relaxes its `Dart ^3.11.5` SDK pin to the project's 3.11.4 toolchain, widens `google_fonts`/`intl`, and targets `archive` 4.x (already pulled by pdfrx). All verified analyzer-clean.
- Filed an upstream issue in the fork to make sheetifye Riverpod-independent (internalize its own `ProviderScope`), which would let klangk drop the `flutter_riverpod` dep + wrapper: runyaga/sheetifye#1.
- Same `klangk_plugin_api` fork pin as the rest of the stack.

## Notes
- e2e chip/cell/download/back **coordinates are calibrated on the live stack**; decisive checks are coordinate-free.
- Verified live: an uploaded `.xlsx` renders as an editable grid in a running stack.