### PR TITLE
Simplify host build, rename images, update docs

### DIFF
--- a/.github/actions/devenv-setup/action.yml
+++ b/.github/actions/devenv-setup/action.yml
@@ -3,8 +3,9 @@ description: Bootstrap nix/devenv, build Docker image, and start services
 
 inputs:
   build-tasks:
-    description: "Space-separated devenv tasks to run (e.g. 'klangk:build-backend-image klangk:flutter-build')"
-    required: true
+    description: "Space-separated devenv tasks to run (e.g. 'klangk:build-backend-image klangk:flutter-build'). Empty to skip."
+    required: false
+    default: ""
   cache-nix:
     description: "Enable nix store caching (default true)"
     required: false
@@ -48,6 +49,7 @@ runs:
         devenv shell -- true
 
     - name: Build
+      if: inputs.build-tasks != ''
       shell: bash
       run: |
         . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh

--- a/.github/actions/devenv-setup/action.yml
+++ b/.github/actions/devenv-setup/action.yml
@@ -3,7 +3,7 @@ description: Bootstrap nix/devenv, build Docker image, and start services
 
 inputs:
   build-tasks:
-    description: "Space-separated devenv tasks to run (e.g. 'klangk:build-backend-image klangk:flutter-build'). Empty to skip."
+    description: "Space-separated devenv tasks to run (e.g. 'klangk:build-workspace-image klangk:flutter-build'). Empty to skip."
     required: false
     default: ""
   cache-nix:

--- a/.github/workflows/backend-e2e-tests.yml
+++ b/.github/workflows/backend-e2e-tests.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: ./.github/actions/devenv-setup
         if: steps.filter.outputs.e2e == 'true'
         with:
-          build-tasks: klangk:build-backend-image
+          build-tasks: klangk:build-workspace-image
           cache-nix: "false"
 
       - name: Run backend E2E tests

--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -52,7 +52,7 @@ jobs:
       - uses: ./.github/actions/devenv-setup
         if: steps.filter.outputs.e2e == 'true'
         with:
-          build-tasks: klangk:build-backend-image klangk:flutter-build
+          build-tasks: klangk:build-workspace-image klangk:flutter-build
           cache-nix: "false"
 
       - name: Run E2E tests

--- a/.github/workflows/image-host.yml
+++ b/.github/workflows/image-host.yml
@@ -11,6 +11,7 @@ on:
       - "src/frontend/lib/**"
       - "scripts/build-host-image.sh"
       - "scripts/build-backend-image.sh"
+      - "scripts/flutterbuildweb.sh"
       - "scripts/nginx.sh"
       - ".github/workflows/image-host.yml"
 
@@ -19,14 +20,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  workspace:
-    uses: ./.github/workflows/image-workspace.yml
-    permissions:
-      packages: write
-      contents: read
-
   build:
-    needs: workspace
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
@@ -37,17 +31,16 @@ jobs:
 
       - uses: ./.github/actions/devenv-setup
         with:
-          build-tasks: klangk:flutter-build
+          build-tasks: ""
 
-      - name: Build host image (pulls workspace image from GHCR)
+      - name: Build host image (builds everything from source)
         run: |
           . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-          KLANGK_WORKSPACE_REGISTRY="ghcr.io/${{ github.repository }}/klangk-workspace:latest" \
-            devenv shell -- build-host-image
+          devenv shell -- build-host-image
 
       - name: Push host image to GHCR
         run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
           COMMIT=$(git rev-parse --short HEAD)
           CALVER="$(date -u +%Y.%m.%d)"
           VERSION="${CALVER}-${COMMIT}"

--- a/.github/workflows/image-host.yml
+++ b/.github/workflows/image-host.yml
@@ -2,18 +2,6 @@ name: Build Host Image
 
 on:
   workflow_dispatch:
-  push:
-    branches: [main]
-    paths:
-      - "src/containers/host/**"
-      - "src/containers/workspace/**"
-      - "src/backend/klangk_backend/**"
-      - "src/frontend/lib/**"
-      - "scripts/build-host-image.sh"
-      - "scripts/build-backend-image.sh"
-      - "scripts/flutterbuildweb.sh"
-      - "scripts/nginx.sh"
-      - ".github/workflows/image-host.yml"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/image-workspace-base.yml
+++ b/.github/workflows/image-workspace-base.yml
@@ -31,8 +31,6 @@ jobs:
           VERSION="${CALVER}-${COMMIT}"
           REPO="ghcr.io/${{ github.repository }}/klangk-workspace-base"
           docker build --platform linux/amd64 \
-            --build-arg KLANGK_UID=1000 \
-            --build-arg KLANGK_GID=1000 \
             -f src/containers/workspace/Dockerfile.base \
             -t "$REPO:latest" \
             -t "$REPO:$VERSION" \

--- a/.github/workflows/image-workspace.yml
+++ b/.github/workflows/image-workspace.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
     paths:
       - "src/containers/workspace/**"
-      - "scripts/build-backend-image.sh"
+      - "scripts/build-workspace-image.sh"
       - ".github/workflows/image-workspace.yml"
 
 concurrency:
@@ -26,7 +26,7 @@ jobs:
 
       - uses: ./.github/actions/devenv-setup
         with:
-          build-tasks: klangk:build-backend-image
+          build-tasks: klangk:build-workspace-image
 
       - name: Push workspace image to GHCR
         run: |

--- a/HACKING.md
+++ b/HACKING.md
@@ -84,7 +84,7 @@ All settings can be overridden in `.env`. Defaults (where appropriate) are provi
 | `KLANGK_PORT`                        | `8997`                               | Backend (FastAPI/uvicorn) port — proxied through nginx, not accessed directly                                                                                                              |
 | `KLANGK_DATA_DIR`                    | `$DEVENV_STATE/klangk/data`          | Database, workspaces, Pi sessions                                                                                                                                                          |
 | `KLANGK_PLUGINS_DIR`                 | `$DEVENV_STATE/klangk/plugins`       | Fetched plugins (outside repo for `execIfModified`)                                                                                                                                        |
-| `KLANGK_IMAGE_NAME`                  | `klangk`                             | Podman image name for workspace containers                                                                                                                                                 |
+| `KLANGK_IMAGE_NAME`                  | `klangk-workspace`                   | Podman image name for workspace containers                                                                                                                                                 |
 | `KLANGK_IMAGE_PULL_POLICY`           | `never`                              | Podman `--pull` policy for workspace containers (`never`, `missing`, `always`, `newer`). Default `never` requires the image to exist locally; `missing` pulls from a registry if not found |
 | `KLANGK_PODMAN_STORAGE`              |                                      | Custom path for podman image storage (graphroot). Set to a path on ext4 (not ZFS) for `--userns=keep-id` support. ZFS lacks idmapped mounts, causing slow container startup.               |
 | `KLANGK_ALLOWED_MOUNT_ROOTS`         |                                      | Comma-separated list of allowed host path prefixes for bind mounts (e.g., `/home,/data`). If unset, all bind mount paths are allowed. Protected paths are always blocked (see below).      |
@@ -255,7 +255,7 @@ src/
   frontend/            # Flutter web app
     test/              # Frontend unit tests
     e2e-tests/         # Playwright E2E tests
-  docker/
+  containers/
     host/              # Host container (Dockerfile, entrypoint)
     workspace/         # Workspace container (Dockerfile, base, entrypoint)
   bridge/              # @klangk/bridge npm package

--- a/HACKING.md
+++ b/HACKING.md
@@ -169,50 +169,54 @@ All 4 run automatically on PRs. You can bypass as repo admin.
 
 ## Host Container
 
-The host container packages the backend, nginx proxy, and Flutter web UI into a single Docker image based on `python:3.13-slim`. It does **not** include workspace containers — those are managed separately via podman.
+The host container is a self-contained deployment image. It packages the backend, nginx proxy, Flutter web UI, and the workspace image into a single Docker image based on `python:3.13-slim`. Workspace containers are launched inside the host container via rootless podman (pasta networking).
 
-### Building
+The published image is available from GHCR:
 
 ```bash
-build-host-image
+docker pull ghcr.io/mcdonc/klangk/klangk-host:latest
 ```
 
-This builds the `klangk-host` image using the pre-built venv from devenv and the Flutter web output. The image is tagged with both `latest` and a CalVer version (e.g., `2026.06.05-abc1234`).
-
-The version is baked into `/home/klangk/version.json` inside the image and served at the `GET /version` endpoint.
-
 ### Running
+
+```bash
+docker run -d \
+  -p 8995:8995 -p 8997:8997 \
+  --cap-add SYS_ADMIN \
+  --device /dev/fuse \
+  --device /dev/net/tun \
+  --security-opt seccomp=unconfined \
+  --security-opt systempaths=unconfined \
+  -e KLANGK_DEFAULT_USER=admin@example.com \
+  -e KLANGK_DEFAULT_PASSWORD=admin \
+  -e KLANGK_JWT_SECRET=change-me \
+  klangk-host
+```
+
+Open http://localhost:8995. On first startup the embedded workspace image is automatically loaded into podman.
+
+The five Docker flags are required for rootless podman to create workspace containers inside the host container. They grant mount capabilities (`SYS_ADMIN`), FUSE filesystem access (`/dev/fuse`), pasta networking (`/dev/net/tun`), and remove default restrictions on syscalls and `/proc` that block nested container creation.
+
+Data is stored in `/home/klangk/data` inside the container. To persist across restarts, mount a volume:
+
+```bash
+docker run -d -v klangk-data:/home/klangk/data ...
+```
+
+Inside devenv, `run-host-container` handles the flags and passes through `KLANGK_*` env vars automatically:
 
 ```bash
 run-host-container        # foreground (Ctrl-C to stop)
 run-host-container -d     # detached
 ```
 
-Open http://localhost:8995 (nginx) or http://localhost:8997 (uvicorn direct).
-
-`run-host-container` collects all `KLANGK_*` environment variables from the current devenv shell (including values loaded from `.env` via `dotenv.enable`) and passes them into the container via `--env-file`. Host-local paths like `KLANGK_DATA_DIR` and `KLANGK_PLUGINS_DIR` are excluded so the container's own defaults apply. It also maps the Docker socket and exposes the configured ports.
-
-To run manually without devenv:
+### Building locally
 
 ```bash
-docker run -d \
-  -p 8997:8997 -p 8995:8995 \
-  -v /var/run/docker.sock:/var/run/docker.sock \
-  --group-add $(stat -c '%g' /var/run/docker.sock) \
-  -e KLANGK_DEFAULT_USER=admin@example.com \
-  -e KLANGK_DEFAULT_PASSWORD=admin \
-  -e KLANGK_JWT_SECRET=change-me \
-  -e KLANGK_LLM_API_KEY=your-key \
-  -e KLANGK_LLM_BASE_URL=https://ollama.com/v1 \
-  -e KLANGK_LLM_MODEL=gemma4:31b \
-  klangk-host
+build-host-image
 ```
 
-Data is stored in `/home/klangk/data` inside the container. To persist it across restarts, mount a volume:
-
-```bash
-docker run -d -v klangk-data:/home/klangk/data ...
-```
+This builds everything from source: Flutter web, workspace image (podman), then the host image (Docker). Tagged with `latest` and a CalVer version (e.g., `2026.06.09-abc1234`). The version is baked into `/home/klangk/version.json` and served at `GET /version`.
 
 ### Scanning
 
@@ -223,13 +227,7 @@ trivy-host --severity CRITICAL    # critical only
 
 ### CI
 
-The `docker-host.yml` workflow builds and pushes the host image to GHCR on push to `main` when relevant files change (host Dockerfile, backend source, frontend source, build scripts). It tags the image with both `:latest` and the CalVer version (e.g., `:2026.06.05-abc1234`). It can also be triggered manually via `workflow_dispatch`.
-
-### Notes
-
-- The `--group-add` flag grants the container user access to the Docker socket. The GID must match the host's docker socket group.
-- Nginx starts automatically alongside uvicorn. If `KLANGK_LLM_BASE_URL` is not set, the LLM proxy block is omitted and nginx still serves the UI and API.
-- The workspace image (`klangk`) must be available in the podman image store — the host container does not build it.
+The `image-host.yml` workflow builds and pushes the host image to GHCR. It is triggered manually via `workflow_dispatch` (building is too expensive for automatic push triggers). The `image-workspace.yml` workflow builds and pushes the workspace image independently on push to `main`.
 
 ## Build Architecture (amd64 / arm64)
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -233,7 +233,7 @@ The `docker-host.yml` workflow builds and pushes the host image to GHCR on push 
 
 ## Build Architecture (amd64 / arm64)
 
-All workspace image builds (`build-backend-image`, `build-base-image`) use podman and build for `$KLANGK_PLATFORM`, which `devenv.nix` defaults to the host architecture (`linux/arm64` on Apple Silicon, `linux/amd64` elsewhere). This means images build and run natively instead of under QEMU emulation. The host container (`build-host-image`) still uses Docker. Override per-shell via `.env`:
+All workspace image builds (`build-workspace-image`, `build-base-image`) use podman and build for `$KLANGK_PLATFORM`, which `devenv.nix` defaults to the host architecture (`linux/arm64` on Apple Silicon, `linux/amd64` elsewhere). This means images build and run natively instead of under QEMU emulation. The host container (`build-host-image`) still uses Docker. Override per-shell via `.env`:
 
 ```bash
 KLANGK_PLATFORM=linux/amd64   # force amd64 even on an arm64 host
@@ -270,19 +270,19 @@ devenv.nix             # devenv configuration
 
 Inside `devenv shell`, these commands are available:
 
-| Command               | Description                           |
-| --------------------- | ------------------------------------- |
-| `test-backend`        | Run backend unit tests                |
-| `test-frontend`       | Run frontend unit tests with coverage |
-| `test-cli-e2e`        | Run CLI E2E tests                     |
-| `test-frontend-e2e`   | Run Flutter E2E tests (all browsers)  |
-| `flutterbuildweb`     | Rebuild Flutter web only              |
-| `build-backend-image` | Rebuild workspace image (podman)      |
-| `build-base-image`    | Rebuild workspace base image          |
-| `build-host-image`    | Build host container image            |
-| `run-host-container`  | Run host container locally            |
-| `trivy-host`          | Scan host image for vulnerabilities   |
-| `update-plugins`      | Fetch plugins from plugins.yaml       |
+| Command                 | Description                           |
+| ----------------------- | ------------------------------------- |
+| `test-backend`          | Run backend unit tests                |
+| `test-frontend`         | Run frontend unit tests with coverage |
+| `test-cli-e2e`          | Run CLI E2E tests                     |
+| `test-frontend-e2e`     | Run Flutter E2E tests (all browsers)  |
+| `flutterbuildweb`       | Rebuild Flutter web only              |
+| `build-workspace-image` | Rebuild workspace image (podman)      |
+| `build-base-image`      | Rebuild workspace base image          |
+| `build-host-image`      | Build host container image            |
+| `run-host-container`    | Run host container locally            |
+| `trivy-host`            | Scan host image for vulnerabilities   |
+| `update-plugins`        | Fetch plugins from plugins.yaml       |
 
 ## Plugin System
 
@@ -300,7 +300,7 @@ A plugin needs at minimum an `extension.ts`. The `klangk/` subdirectory is only 
 ### Build integration
 
 - `scripts/import_dart_plugins.py` scans `$KLANGK_PLUGINS_DIR/*/klangk/` for plugin Dart packages and generates `$KLANGK_PLUGINS_DIR/.dart/` (the `klangk_plugins` package with path deps and `createAllPlugins()`)
-- `build-backend-image` stages `extension.ts` and `tools/` files from all plugins into `$KLANGK_PLUGINS_DIR/.docker/` and passes them via named build contexts (`plugin-extensions`, `plugin-tools`)
+- `build-workspace-image` stages `extension.ts` and `tools/` files from all plugins into `$KLANGK_PLUGINS_DIR/.docker/` and passes them via named build contexts (`plugin-extensions`, `plugin-tools`)
 - `flutterbuildweb` runs the codegen before compiling
 - `stub_dart_plugins.sh` creates a minimal stub at `$KLANGK_PLUGINS_DIR/.dart/` so `flutter pub get` works before plugins are fetched (runs automatically at devenv shell startup via `enterShell`; skips if `pubspec_overrides.yaml` already exists)
 - Both build tasks are triggered automatically by `devenv up` via `execIfModified`

--- a/devenv.nix
+++ b/devenv.nix
@@ -66,8 +66,8 @@ in
         "${config.env.KLANGK_PLUGINS_DIR}/plugins.lock"
       ];
     };
-    "klangk:build-backend-image" = {
-      exec = ''exec bash "$DEVENV_ROOT/scripts/build-backend-image.sh"'';
+    "klangk:build-workspace-image" = {
+      exec = ''exec bash "$DEVENV_ROOT/scripts/build-workspace-image.sh"'';
       showOutput = true;
     };
     "klangk:kill-containers" = {
@@ -96,7 +96,7 @@ in
       '';
       after = [
         "klangk:flutter-build"
-        "klangk:build-backend-image"
+        "klangk:build-workspace-image"
         "klangk:kill-containers"
         "klangk:kill-port-holders"
       ];
@@ -105,7 +105,7 @@ in
       exec = ''exec bash "$DEVENV_ROOT/scripts/nginx.sh"'';
       after = [
         "klangk:flutter-build"
-        "klangk:build-backend-image"
+        "klangk:build-workspace-image"
         "klangk:kill-port-holders"
       ];
     };
@@ -164,7 +164,7 @@ in
   dotenv.enable = true;
 
   scripts.flutterbuildweb.exec = ''exec bash "$DEVENV_ROOT/scripts/flutterbuildweb.sh" "$@"'';
-  scripts.build-backend-image.exec = ''exec bash "$DEVENV_ROOT/scripts/build-backend-image.sh" "$@"'';
+  scripts.build-workspace-image.exec = ''exec bash "$DEVENV_ROOT/scripts/build-workspace-image.sh" "$@"'';
   scripts.pull-base-image.exec = ''exec bash "$DEVENV_ROOT/scripts/pull-base-image.sh" "$@"'';
   scripts.push-base-image.exec = ''exec bash "$DEVENV_ROOT/scripts/push-base-image.sh" "$@"'';
   scripts.build-base-image.exec = ''exec bash "$DEVENV_ROOT/scripts/build-base-image.sh" "$@"'';
@@ -189,7 +189,7 @@ in
 
   scripts.rebuild.exec = ''
     echo "Rebuilding backend image..."
-    build-backend-image
+    build-workspace-image
     echo "Rebuilding Flutter..."
     flutterbuildweb
     echo "==> Done"
@@ -215,7 +215,7 @@ in
 
   scripts.test-frontend-e2e.exec = ''
     cd $DEVENV_ROOT
-    devenv tasks run klangk:flutter-build klangk:build-backend-image
+    devenv tasks run klangk:flutter-build klangk:build-workspace-image
     cd src/frontend/e2e-tests
     npm install --silent
     exec npx playwright test --reporter=list "$@"

--- a/scripts/build-backend-image.sh
+++ b/scripts/build-backend-image.sh
@@ -54,6 +54,7 @@ if [ -n "${KLANGK_SIGNATURE_POLICY:-}" ]; then
   POLICY_ARGS+=(--signature-policy "${KLANGK_SIGNATURE_POLICY}")
 fi
 "$PODMAN" build "${POLICY_ARGS[@]}" \
+  --pull=newer \
   --platform "${KLANGK_PLATFORM:-linux/amd64}" \
   --build-context plugin-extensions="$STAGING/extensions" \
   --build-context plugin-tools="$STAGING/tools" \

--- a/scripts/build-base-image.sh
+++ b/scripts/build-base-image.sh
@@ -21,8 +21,6 @@ if [ -n "${KLANGK_SIGNATURE_POLICY:-}" ]; then
 fi
 "$PODMAN" build "${POLICY_ARGS[@]}" \
   --platform "${KLANGK_PLATFORM:-linux/amd64}" \
-  --build-arg KLANGK_UID="$(id -u)" \
-  --build-arg KLANGK_GID="$(id -g)" \
   -f src/containers/workspace/Dockerfile.base \
   -t "$IMAGE:latest" \
   -t "$IMAGE:$VERSION" \

--- a/scripts/build-host-image.sh
+++ b/scripts/build-host-image.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Build the klangk-host container image via Dockerfile.
 #
-# Builds all prerequisites (flutter web, workspace image) unless pulling
-# the workspace image from a registry via KLANGK_WORKSPACE_REGISTRY.
+# Builds all prerequisites (flutter web, workspace image) then embeds
+# the workspace image tarball in the host image.
 #
 # Usage:
 #   bash scripts/build-host-image.sh
@@ -11,11 +11,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "${DEVENV_ROOT:-$SCRIPT_DIR/..}"
 
-# Build prerequisites unless using a registry workspace image.
-if [ -z "${KLANGK_WORKSPACE_REGISTRY:-}" ]; then
-  bash "$SCRIPT_DIR/flutterbuildweb.sh"
-  bash "$SCRIPT_DIR/build-backend-image.sh"
-fi
+bash "$SCRIPT_DIR/flutterbuildweb.sh"
+bash "$SCRIPT_DIR/build-backend-image.sh"
 
 COMMIT="$(git rev-parse --short HEAD)"
 CALVER="$(date -u +%Y.%m.%d)"
@@ -23,7 +20,7 @@ VERSION="${CALVER}-${COMMIT}"
 TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 IMAGE="${KLANGK_HOST_IMAGE:-klangk-host}"
 
-WORKSPACE_IMAGE="${KLANGK_IMAGE_NAME:-klangk}"
+WORKSPACE_IMAGE="${KLANGK_IMAGE_NAME:-klangk-workspace}"
 PODMAN="${KLANGK_PODMAN_BIN:-podman}"
 POLICY_ARGS=()
 if [ -n "${KLANGK_SIGNATURE_POLICY:-}" ]; then
@@ -31,25 +28,10 @@ if [ -n "${KLANGK_SIGNATURE_POLICY:-}" ]; then
 fi
 
 # Export workspace image so it can be embedded in the host image.
-# Use local podman image if available, otherwise pull from GHCR via docker.
 WORKSPACE_DIR=$(mktemp -d "${TMPDIR:-/tmp}/klangk-workspace-XXXXXX")
 trap 'rm -rf "$WORKSPACE_DIR"' EXIT
-if "$PODMAN" image exists "$WORKSPACE_IMAGE" 2>/dev/null; then
-  echo "Exporting workspace image $WORKSPACE_IMAGE from podman ..."
-  "$PODMAN" save "${POLICY_ARGS[@]}" -o "$WORKSPACE_DIR/workspace.tar" "$WORKSPACE_IMAGE"
-elif [ -n "${KLANGK_WORKSPACE_REGISTRY:-}" ]; then
-  echo "Pulling workspace image from $KLANGK_WORKSPACE_REGISTRY ..."
-  docker pull "$KLANGK_WORKSPACE_REGISTRY"
-  # Retag so the embedded tarball uses the local image name, matching
-  # KLANGK_IMAGE_NAME inside the host container.
-  docker tag "$KLANGK_WORKSPACE_REGISTRY" "$WORKSPACE_IMAGE"
-  docker save -o "$WORKSPACE_DIR/workspace.tar" "$WORKSPACE_IMAGE"
-else
-  echo "ERROR: workspace image '$WORKSPACE_IMAGE' not found in podman"
-  echo "  Build it first: devenv shell -- build-backend-image"
-  echo "  Or set KLANGK_WORKSPACE_REGISTRY to pull from a registry"
-  exit 1
-fi
+echo "Exporting workspace image $WORKSPACE_IMAGE from podman ..."
+"$PODMAN" save "${POLICY_ARGS[@]}" -o "$WORKSPACE_DIR/workspace.tar" "$WORKSPACE_IMAGE"
 
 echo "Building $IMAGE $VERSION ..."
 

--- a/scripts/build-host-image.sh
+++ b/scripts/build-host-image.sh
@@ -12,7 +12,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "${DEVENV_ROOT:-$SCRIPT_DIR/..}"
 
 bash "$SCRIPT_DIR/flutterbuildweb.sh"
-bash "$SCRIPT_DIR/build-backend-image.sh"
+bash "$SCRIPT_DIR/build-workspace-image.sh"
 
 COMMIT="$(git rev-parse --short HEAD)"
 CALVER="$(date -u +%Y.%m.%d)"

--- a/scripts/build-host-image.sh
+++ b/scripts/build-host-image.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Build the klangk-host container image via Dockerfile.
 #
-# Embeds version info (CalVer + commit) into the image.
-# Requires: devenv shell (for venv), flutter build web (for frontend).
+# Builds all prerequisites (flutter web, workspace image) unless pulling
+# the workspace image from a registry via KLANGK_WORKSPACE_REGISTRY.
 #
 # Usage:
 #   bash scripts/build-host-image.sh
@@ -10,6 +10,12 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "${DEVENV_ROOT:-$SCRIPT_DIR/..}"
+
+# Build prerequisites unless using a registry workspace image.
+if [ -z "${KLANGK_WORKSPACE_REGISTRY:-}" ]; then
+  bash "$SCRIPT_DIR/flutterbuildweb.sh"
+  bash "$SCRIPT_DIR/build-backend-image.sh"
+fi
 
 COMMIT="$(git rev-parse --short HEAD)"
 CALVER="$(date -u +%Y.%m.%d)"

--- a/scripts/build-workspace-image.sh
+++ b/scripts/build-workspace-image.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "${DEVENV_ROOT:-$SCRIPT_DIR/..}"
+PODMAN="${KLANGK_PODMAN_BIN:-podman}"
+
+STAMP="$DEVENV_STATE/klangk/.backend-image-hash"
+
+# Compute a hash of all files that affect the workspace image.
+CURRENT_HASH=$(find \
+  scripts/build-workspace-image.sh \
+  src/containers/workspace/ \
+  "$KLANGK_PLUGINS_DIR" \
+  -type f 2>/dev/null | sort | xargs sha256sum 2>/dev/null | sha256sum | cut -d' ' -f1)
+
+# Skip rebuild if the image exists and the hash hasn't changed.
+if "$PODMAN" image exists "${KLANGK_IMAGE_NAME}" 2>/dev/null && [ -f "$STAMP" ]; then
+  OLD_HASH=$(cat "$STAMP" 2>/dev/null || true)
+  if [ "$CURRENT_HASH" = "$OLD_HASH" ]; then
+    echo "Image ${KLANGK_IMAGE_NAME} is up to date, skipping build."
+    exit 0
+  fi
+fi
+
+# Auto-fetch plugins on first run
+if [ -f "$KLANGK_PLUGINS_DIR/plugins.yaml" ] && [ ! -f "$KLANGK_PLUGINS_DIR/plugins.lock" ]; then
+  echo "No plugins.lock found, running update-plugins..."
+  python3 scripts/update_plugins.py
+fi
+
+# Stage plugin files outside the source tree
+STAGING="$KLANGK_PLUGINS_DIR/.docker"
+rm -rf "$STAGING"
+mkdir -p "$STAGING/extensions" "$STAGING/tools"
+for d in "$KLANGK_PLUGINS_DIR"/*/; do
+  [ -d "$d" ] || continue
+  name=$(basename "$d")
+  [ -f "$d/extension.ts" ] && cp "$d/extension.ts" "$STAGING/extensions/$name.ts"
+  if [ -d "$d/tools" ]; then
+    mkdir -p "$STAGING/tools/$name"
+    cp -r "$d/tools/"* "$STAGING/tools/$name/" 2>/dev/null
+  fi
+done
+
+# Remove old containers before rebuilding so they get recreated from the new image.
+# Skip when running inside a container (developing klangk in klangk).
+if [ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ]; then
+  "$PODMAN" ps -a --filter "label=klangk.instance=${KLANGK_INSTANCE_ID}" -q | xargs -r "$PODMAN" rm -f
+fi
+
+# Build workspace image on top of the base
+POLICY_ARGS=()
+if [ -n "${KLANGK_SIGNATURE_POLICY:-}" ]; then
+  POLICY_ARGS+=(--signature-policy "${KLANGK_SIGNATURE_POLICY}")
+fi
+"$PODMAN" build "${POLICY_ARGS[@]}" \
+  --pull=newer \
+  --platform "${KLANGK_PLATFORM:-linux/amd64}" \
+  --build-context plugin-extensions="$STAGING/extensions" \
+  --build-context plugin-tools="$STAGING/tools" \
+  -t "${KLANGK_IMAGE_NAME}" "$@" src/containers/workspace/
+
+echo "$CURRENT_HASH" >"$STAMP"

--- a/scripts/push-base-image.sh
+++ b/scripts/push-base-image.sh
@@ -37,8 +37,6 @@ echo "==> Building and pushing $IMAGE ($PLATFORMS) version $VERSION"
 docker buildx build \
   --builder "$BUILDER" \
   --platform "$PLATFORMS" \
-  --build-arg KLANGK_UID="$(id -u)" \
-  --build-arg KLANGK_GID="$(id -g)" \
   -f src/containers/workspace/Dockerfile.base \
   -t "$IMAGE:latest" \
   -t "$IMAGE:$VERSION" \

--- a/src/containers/workspace/Dockerfile.base
+++ b/src/containers/workspace/Dockerfile.base
@@ -58,17 +58,13 @@ RUN ln -sf /usr/bin/fdfind /usr/bin/fd
 # Install @earendil-works last so its `pi` binary wins.
 RUN npm install -g @mariozechner/pi-coding-agent @earendil-works/pi-coding-agent @anthropic-ai/claude-code
 
-# Create klangk user with a fixed UID/GID. The container runs with
+# Create klangk user with fixed UID/GID 1000. The container runs with
 # --userns=keep-id:uid=1000,gid=1000 which maps the host user to
 # this UID, so files on bind mounts are owned by the host user.
-ARG KLANGK_UID=1000
-ARG KLANGK_GID=1000
-RUN EXISTING_USER=$(getent passwd $KLANGK_UID | cut -d: -f1) \
+RUN EXISTING_USER=$(getent passwd 1000 | cut -d: -f1) \
     && [ -n "$EXISTING_USER" ] && userdel "$EXISTING_USER" || true \
-    && EXISTING_GROUP=$(getent group $KLANGK_GID | cut -d: -f1) \
-    && [ -n "$EXISTING_GROUP" ] && groupdel "$EXISTING_GROUP" 2>/dev/null || true \
-    && groupadd -g $KLANGK_GID klangk 2>/dev/null || true \
-    && useradd -u $KLANGK_UID -g $KLANGK_GID -m -d /home/klangk -s /bin/sh klangk
+    && groupadd -g 1000 klangk \
+    && useradd -u 1000 -g 1000 -m -d /home/klangk -s /bin/sh klangk
 
 # Make /bin/sh point to bash so Pi's bash tool supports bashisms (source, etc.)
 RUN ln -sf /bin/bash /bin/sh


### PR DESCRIPTION
## Summary
- `build-host-image` now builds everything from source (flutter web + workspace image + host image) in one command
- Rename `build-backend-image` → `build-workspace-image` everywhere (scripts, devenv tasks, CI workflows, docs)
- Rename images: `klangk-base` → `klangk-workspace-base`, `klangk` → `klangk-workspace`
- `image-host.yml` is workflow_dispatch only (too expensive for push triggers)
- `build-workspace-image` uses `--pull=newer` to avoid stale base images
- Remove `KLANGK_UID`/`KLANGK_GID` build args — hardcode UID/GID 1000
- Rewrite HACKING.md Host Container section for production deployment
- `devenv-setup` action `build-tasks` is now optional

## Test plan
- [x] `build-host-image` builds everything from source end-to-end
- [x] All pre-commit hooks pass