### PR TITLE
Eliminate all CDN dependencies — serve everything locally (#49)

### DIFF
--- a/src/frontend/lib/file_viewer/file_viewer_panel.dart
+++ b/src/frontend/lib/file_viewer/file_viewer_panel.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 import 'package:flutter/material.dart';
-import 'package:google_fonts/google_fonts.dart';
 import '../theme/colors.dart';
 import 'package:http/http.dart' as http;
 import '../ws/ws_client.dart';
@@ -481,9 +480,7 @@ class FileViewerPanelState extends State<FileViewerPanel> {
               width: double.infinity,
               child: SelectableText(
                 _fileContent ?? 'Loading...',
-                style: TextStyle(
-                    fontFamily: GoogleFonts.robotoMono().fontFamily,
-                    fontSize: 14),
+                style: TextStyle(fontFamily: 'JetBrains Mono', fontSize: 14),
                 textAlign: TextAlign.left,
               ),
             ),

--- a/src/frontend/lib/terminal/container_terminal.dart
+++ b/src/frontend/lib/terminal/container_terminal.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:google_fonts/google_fonts.dart';
 import 'package:xterm/xterm.dart';
 import '../ws/ws_client.dart';
 import '../utils/web_helpers_stub.dart'
@@ -148,7 +147,7 @@ class ContainerTerminalState extends State<ContainerTerminal> {
           theme: _theme,
           textStyle: TerminalStyle(
             fontSize: 16,
-            fontFamily: GoogleFonts.robotoMono().fontFamily!,
+            fontFamily: 'JetBrains Mono',
           ),
           focusNode: _focusNode,
           scrollController: _scrollController,

--- a/src/frontend/pubspec.yaml
+++ b/src/frontend/pubspec.yaml
@@ -24,7 +24,6 @@ dependencies:
       ref: "0.0.3.1"
       path: packages/flterm
   libghostty: ^0.0.9
-  google_fonts: ^8.1.0
   web_socket_channel: ^3.0.0
   http: ^1.2.0
   provider: ^6.1.0

--- a/src/frontend/web/index.html
+++ b/src/frontend/web/index.html
@@ -10,12 +10,6 @@
     <link rel="icon" type="image/svg+xml" href="favicon.svg" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
     <link rel="manifest" href="manifest.json" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&display=swap"
-      rel="stylesheet"
-    />
   </head>
   <body>
     <div


### PR DESCRIPTION
## Summary
- Remove Google Fonts preconnect and stylesheet links from `web/index.html`
- Replace `GoogleFonts.robotoMono()` with bundled `JetBrains Mono` in `container_terminal.dart` and `file_viewer_panel.dart`
- Remove `google_fonts` package from `pubspec.yaml`

The JetBrains Mono font was already bundled in `assets/fonts/` and declared in `pubspec.yaml`. CanvasKit was already served locally via `useLocalCanvasKit:true`. No external network requests remain at runtime.

## Test plan
- [x] Frontend unit tests pass
- [x] Terminal renders with correct monospace font
- [x] File viewer renders with correct monospace font
- [x] No network requests to googleapis.com or gstatic.com in browser devtools

Closes #49