### PR TITLE
Replace trust_unverified_email + group hook with single OIDC login hook (#196)

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -389,26 +389,24 @@ KLANGK_OIDC_CONFIG=/path/to/oidc.yaml
 
 ### Provider Config Fields
 
-| Field                    | Required | Description                                                                                                                             |
-| ------------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `id`                     | Yes      | URL-safe slug, used in endpoint paths (`/auth/oidc/{id}/login`) and stored as `provider` on users                                       |
-| `display_name`           | Yes      | Button label on the login page (e.g., "CAC Login", "Google")                                                                            |
-| `issuer`                 | Yes      | OIDC issuer URL. Discovery via `{issuer}/.well-known/openid-configuration`                                                              |
-| `client_id`              | Yes      | OIDC client ID registered with the IdP                                                                                                  |
-| `client_secret`          | Yes      | OIDC client secret. Supports `file:` prefix for secret management                                                                       |
-| `scopes`                 | No       | Space-separated scopes (default: `openid email profile`)                                                                                |
-| `ca_cert`                | No       | Path to a CA certificate PEM file for IdPs with custom/private CAs                                                                      |
-| `token_validation_pem`   | No       | Inline RSA/EC public key PEM for static token validation (skips JWKS discovery)                                                         |
-| `logout_redirect`        | No       | If `true`, logout redirects to the IdP's `end_session_endpoint` (RP-Initiated Logout). Default: `false` (local-only logout)             |
-| `trust_unverified_email` | No       | If `true`, skip the `email_verified` check in ID token claims. Only enable for IdPs known to verify email out of band. Default: `false` |
+| Field                  | Required | Description                                                                                                                 |
+| ---------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `id`                   | Yes      | URL-safe slug, used in endpoint paths (`/auth/oidc/{id}/login`) and stored as `provider` on users                           |
+| `display_name`         | Yes      | Button label on the login page (e.g., "CAC Login", "Google")                                                                |
+| `issuer`               | Yes      | OIDC issuer URL. Discovery via `{issuer}/.well-known/openid-configuration`                                                  |
+| `client_id`            | Yes      | OIDC client ID registered with the IdP                                                                                      |
+| `client_secret`        | Yes      | OIDC client secret. Supports `file:` prefix for secret management                                                           |
+| `scopes`               | No       | Space-separated scopes (default: `openid email profile`)                                                                    |
+| `ca_cert`              | No       | Path to a CA certificate PEM file for IdPs with custom/private CAs                                                          |
+| `token_validation_pem` | No       | Inline RSA/EC public key PEM for static token validation (skips JWKS discovery)                                             |
+| `logout_redirect`      | No       | If `true`, logout redirects to the IdP's `end_session_endpoint` (RP-Initiated Logout). Default: `false` (local-only logout) |
 
 ### How It Works
 
 - **Web**: Login page shows one button per provider. Clicking redirects to the IdP via Authorization Code flow with PKCE. After authentication, the IdP redirects back to Klangk which exchanges the code for tokens, validates the ID token, and issues a Klangk JWT.
 - **CLI**: `klangk login` detects OIDC from the server config, opens a browser for authentication, and receives the token via a temporary localhost callback server.
-- **Email verification**: The OIDC callback requires `email_verified: true` in the ID token claims before linking or provisioning accounts. This prevents account takeover via unverified email assertion. IdPs that verify email out of band can opt out per-provider with `trust_unverified_email: true`.
+- **Login hook**: A single Python hook (`KLANGK_OIDC_LOGIN_HOOK`) handles both login validation and group mapping. See [OIDC Login Hook](#oidc-login-hook) below.
 - **User provisioning**: On first OIDC login, a user is created automatically (verified, no password). If a local user with the same email already exists, the OIDC identity is linked to it.
-- **Group mapping**: configurable via a Python hook. See [OIDC Group Mapping](#oidc-group-mapping) below.
 - **OIDC users** cannot use forgot-password, change-password, or change-email.
 - **Logout**: By default, logout only kills the Klangk session. With `logout_redirect: true`, the user is also redirected to the IdP's logout endpoint to end the SSO session (requires full re-authentication on next login).
 
@@ -422,23 +420,23 @@ KLANGK_OIDC_CONFIG=/path/to/oidc.yaml
 2. Copy the client secret to a file or set it directly in the OIDC config
 3. For CAC: configure the X.509 client certificate authenticator in the Keycloak authentication flow
 
-### OIDC Group Mapping
+### OIDC Login Hook
 
-Klangk can sync group memberships from OIDC claims on every login using a Python hook function.
+A single Python hook handles both login validation and group mapping on every OIDC login.
 
 **Configuration:**
 
 ```bash
-KLANGK_GROUP_MAPPING_HOOK=my_module.map_groups
+KLANGK_OIDC_LOGIN_HOOK=my_module.on_login
 ```
 
-The value is a dotted Python path where the last component is the function name. If not set, no group sync is performed.
+The value is a dotted Python path where the last component is the function name. If not set, all OIDC logins are accepted with no group sync.
 
 **Hook signature:**
 
 ```python
-def map_groups(provider, claims, email, tokens):
-    """Return group names this user should belong to via OIDC sync.
+def on_login(provider, claims, email, tokens):
+    """Validate the login and optionally return group names.
 
     Args:
         provider: OIDCProvider object (id, issuer, client_id, etc.)
@@ -447,36 +445,46 @@ def map_groups(provider, claims, email, tokens):
         tokens: raw token response (id_token, access_token, etc.)
 
     Returns:
-        set of group name strings
+        None — login allowed, no group sync
+        set[str] — login allowed, sync memberships to these groups
+
+    Raises:
+        Any exception — login rejected (message shown to user)
     """
+    # Example: reject unverified emails
+    if claims.get("email_verified") is not True:
+        raise ValueError("Email not verified by identity provider")
+
+    # Example: map IdP roles to groups
     groups = set()
     roles = claims.get("realm_access", {}).get("roles", [])
     if "klangk-admin" in roles:
         groups.add("admin")
-    if "developers" in roles:
-        groups.add("devs")
-    return groups
+    return groups or None
 ```
 
 Async hooks are also supported (`async def`).
 
 **Behavior:**
 
-- On every OIDC login, the hook is called with the IdP's claims
+- Called after ID token validation, before user provisioning
+- **Raise** an exception → login rejected (HTTP 403, exception message shown)
+- **Return** `None` → login allowed, no group sync
+- **Return** a `set[str]` → login allowed, memberships synced to those groups
 - Groups returned by the hook are auto-created if they don't exist
-- Memberships are tracked with `source='oidc_sync'` — only these are added/removed by the sync
+- Memberships are tracked with `source='oidc_sync'` — only these are added/removed
 - Manual group memberships (`source='manual'`) are never touched
-- If the hook raises an exception, it's logged and group sync is skipped (user still logs in)
-- If `KLANGK_GROUP_MAPPING_HOOK` is not set, no group sync occurs
 
-**Security note:** The hook is entirely responsible for auditing, logging, and hardening of group sync operations. There is no default hook and no default mappings — the hook is written by the deploying organization (or their consultants), and it is their responsibility to give IdP claims as much or as little trust as appropriate. There is no declarative aspect to its operation; the hook is arbitrary Python code with full control over which groups are returned.
+**Security note:** The hook is entirely responsible for login validation and group mapping. There is no default hook — the hook is written by the deploying organization, and it is their responsibility to validate IdP claims as appropriate. Without a hook, all OIDC logins are accepted (including those with unverified emails).
 
-**Built-in example hook:**
-
-An example hook is included at `klangk_backend.oidc.example_admin_hook` that maps the `realm_access.roles` claim containing `klangk-admin` to the `admin` group. Use it as a starting point:
+**Built-in example hooks:**
 
 ```bash
-KLANGK_GROUP_MAPPING_HOOK=klangk_backend.oidc.example_admin_hook
+# Reject logins with unverified emails
+KLANGK_OIDC_LOGIN_HOOK=klangk_backend.oidc.example_require_verified_email
+
+# Map Keycloak klangk-admin role to the admin group
+KLANGK_OIDC_LOGIN_HOOK=klangk_backend.oidc.example_admin_hook
 ```
 
 ## Authorization (ACL System)

--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -724,18 +724,19 @@ async def oidc_callback(
         )
     auth.validate_email(email)
 
-    # Require a verified email before trusting it to link/provision an
-    # account — otherwise an IdP user who can assert an arbitrary email could
-    # take over an existing local account (e.g. the seeded admin). Providers
-    # known to verify email out of band can opt out via trust_unverified_email.
-    if (
-        claims.get("email_verified") is not True
-        and not provider.trust_unverified_email
-    ):
+    # Call the OIDC login hook (if configured). The hook can:
+    # - raise an exception to reject the login (HTTP 403)
+    # - return None to allow the login without group sync
+    # - return a set of group names to allow login and sync groups
+    try:
+        hook_groups = await oidc.call_login_hook(
+            provider, claims, email, tokens
+        )
+    except Exception as exc:
         raise HTTPException(
             status_code=403,
-            detail="Email not verified by identity provider",
-        )
+            detail=str(exc),
+        ) from None
 
     # Find or create user
     user = await model.get_user_by_external_id(provider_id, sub)
@@ -756,8 +757,9 @@ async def oidc_callback(
                 external_id=sub,
             )
 
-    # Sync group memberships from OIDC hook
-    await oidc.sync_oidc_groups(user["id"], provider, claims, email, tokens)
+    # Sync group memberships if the hook returned group names
+    if hook_groups is not None:
+        await oidc.sync_oidc_groups(user["id"], hook_groups)
 
     # Issue Klangk JWT
     access_token = auth.create_token(user["id"], email)

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -140,7 +140,7 @@ async def lifespan(app: FastAPI):
     auth.require_secure_jwt_secret()
     await model.init_db()
     oidc.init_providers()
-    oidc.load_group_hook()
+    oidc.load_login_hook()
     await seed_default_user()
     from . import wshandler
 

--- a/src/backend/klangk_backend/oidc.py
+++ b/src/backend/klangk_backend/oidc.py
@@ -37,10 +37,6 @@ class OIDCProvider:
     ca_cert: str | None = None  # path to CA cert PEM for custom trust
     token_validation_pem: str | None = None  # static RSA/EC public key PEM
     logout_redirect: bool = False  # redirect to IdP logout on user logout
-    # Trust the email claim even when the IdP omits/!email_verified. Only
-    # enable for providers that are known to verify email out of band; an
-    # unverified email is otherwise an account-takeover vector.
-    trust_unverified_email: bool = False
 
 
 @dataclass
@@ -97,9 +93,6 @@ def load_config() -> list[OIDCProvider]:
                 ca_cert=ca_cert,
                 token_validation_pem=entry.get("token_validation_pem"),
                 logout_redirect=entry.get("logout_redirect", False),
-                trust_unverified_email=entry.get(
-                    "trust_unverified_email", False
-                ),
             )
         )
     return providers
@@ -317,10 +310,10 @@ async def build_logout_url(
     return f"{endpoint}?{urlencode(params)}"
 
 
-# --- Group mapping hook ---
+# --- OIDC login hook ---
 
-_group_hook: Callable | None = None
-_group_hook_is_async: bool = False
+_login_hook: Callable | None = None
+_login_hook_is_async: bool = False
 
 
 def example_admin_hook(
@@ -331,7 +324,7 @@ def example_admin_hook(
 ) -> set[str]:
     """Example hook: map a Keycloak realm role to the admin group.
 
-    To use: KLANGK_GROUP_MAPPING_HOOK=klangk_backend.oidc.example_admin_hook
+    To use: KLANGK_OIDC_LOGIN_HOOK=klangk_backend.oidc.example_admin_hook
 
     Customize the claim_path and claim_value for your IdP.
     """
@@ -351,22 +344,50 @@ def example_admin_hook(
     return set()
 
 
-def load_group_hook() -> None:
-    """Load the group mapping hook from KLANGK_GROUP_MAPPING_HOOK env var.
+def example_require_verified_email(
+    provider: OIDCProvider,  # noqa: ARG001
+    claims: dict,
+    email: str,  # noqa: ARG001
+    tokens: dict,  # noqa: ARG001
+) -> None:
+    """Example hook: reject logins where email_verified is not true.
+
+    To use: KLANGK_OIDC_LOGIN_HOOK=klangk_backend.oidc.example_require_verified_email
+
+    Raise an exception to reject the login. The exception message is
+    returned as the HTTP 403 detail.  Return None to allow the login
+    without group sync, or return a set of group names to sync.
+    """
+    if claims.get("email_verified") is not True:
+        raise ValueError("Email not verified by identity provider")
+
+
+def load_login_hook() -> None:
+    """Load the OIDC login hook from KLANGK_OIDC_LOGIN_HOOK.
 
     Format: ``module.path.func_name`` (last dot separates function).
-    If not set, no group sync is performed on OIDC login.
+
+    The hook is called after ID token validation and before user
+    provisioning.  It combines login validation and group mapping:
+
+    - **Raise** any exception → login rejected (HTTP 403, message
+      from the exception).
+    - **Return** ``None`` → login allowed, no group sync.
+    - **Return** a ``set[str]`` of group names → login allowed,
+      memberships synced to those groups.
+
+    If not set, all OIDC logins are accepted with no group sync.
     """
-    global _group_hook, _group_hook_is_async
-    raw = os.environ.get("KLANGK_GROUP_MAPPING_HOOK")
+    global _login_hook, _login_hook_is_async
+    raw = os.environ.get("KLANGK_OIDC_LOGIN_HOOK")
     if not raw:
-        _group_hook = None
-        _group_hook_is_async = False
+        _login_hook = None
+        _login_hook_is_async = False
         return
     dot = raw.rfind(".")
     if dot <= 0:
         raise RuntimeError(
-            f"KLANGK_GROUP_MAPPING_HOOK must be module.path.func_name, "
+            f"KLANGK_OIDC_LOGIN_HOOK must be module.path.func_name, "
             f"got: {raw!r}"
         )
     module_path = raw[:dot]
@@ -374,51 +395,45 @@ def load_group_hook() -> None:
     mod = importlib.import_module(module_path)
     hook = getattr(mod, func_name)
     if not callable(hook):
-        raise RuntimeError(
-            f"KLANGK_GROUP_MAPPING_HOOK: {raw!r} is not callable"
-        )
-    _group_hook = hook
-    _group_hook_is_async = asyncio.iscoroutinefunction(hook)
-    logger.info("OIDC group mapping hook loaded: %s", raw)
+        raise RuntimeError(f"KLANGK_OIDC_LOGIN_HOOK: {raw!r} is not callable")
+    _login_hook = hook
+    _login_hook_is_async = asyncio.iscoroutinefunction(hook)
+    logger.info("OIDC login hook loaded: %s", raw)
 
 
-async def call_group_hook(
+async def call_login_hook(
     provider: OIDCProvider,
     claims: dict,
     email: str,
     tokens: dict,
 ) -> set[str] | None:
-    """Call the group mapping hook. Returns None on error."""
-    if _group_hook is None:
+    """Call the OIDC login hook.
+
+    Returns group names to sync, or None if no groups.
+    Raises the hook's exception if login is rejected.
+    If no hook is configured, returns None (login allowed, no sync).
+    """
+    if _login_hook is None:
         return None
-    try:
-        if _group_hook_is_async:
-            result = await _group_hook(provider, claims, email, tokens)
-        else:
-            result = _group_hook(provider, claims, email, tokens)
-        return set(result)
-    except Exception:
-        logger.exception("Group mapping hook failed")
+    if _login_hook_is_async:
+        result = await _login_hook(provider, claims, email, tokens)
+    else:
+        result = _login_hook(provider, claims, email, tokens)
+    if result is None:
         return None
+    return set(result)
 
 
 async def sync_oidc_groups(
     user_id: str,
-    provider: OIDCProvider,
-    claims: dict,
-    email: str,
-    tokens: dict,
+    groups: set[str],
 ) -> None:
-    """Sync group memberships based on the group mapping hook."""
+    """Sync group memberships from the login hook result."""
     from . import model
-
-    desired_names = await call_group_hook(provider, claims, email, tokens)
-    if desired_names is None:
-        return
 
     # Resolve group names to IDs, auto-creating missing groups
     desired_ids: set[str] = set()
-    for name in desired_names:
+    for name in groups:
         group = await model.get_group_by_name(name)
         if group is None:
             group = await model.create_group(name)
@@ -435,8 +450,8 @@ async def sync_oidc_groups(
 
 def clear_caches() -> None:
     """Clear all caches (for testing)."""
-    global _group_hook, _group_hook_is_async
+    global _login_hook, _login_hook_is_async
     _discovery_cache.clear()
     _jwks_cache.clear()
-    _group_hook = None
-    _group_hook_is_async = False
+    _login_hook = None
+    _login_hook_is_async = False

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -851,7 +851,7 @@ class TestWorkspaceRoutes:
             "/workspaces",
             json={
                 "name": "src-ws",
-                "image": "klangk",
+                "image": "klangk-workspace",
                 "default_command": "pi",
                 "mounts": ["/tmp:/mnt/tmp"],
                 "env": {"FOO": "bar"},
@@ -867,7 +867,7 @@ class TestWorkspaceRoutes:
         assert resp.status_code == 200
         data = resp.json()
         assert data["name"] == "dup-ws"
-        assert data["image"] == "klangk"
+        assert data["image"] == "klangk-workspace"
         assert data["default_command"] == "pi"
         assert data["mounts"] == ["/tmp:/mnt/tmp"]
         assert data["env"] == {"FOO": "bar"}
@@ -4720,8 +4720,8 @@ class TestOIDCCallback:
                 return {"admin", "power-users"}
             return {"users"}
 
-        monkeypatch.setattr(api.oidc, "_group_hook", test_hook)
-        monkeypatch.setattr(api.oidc, "_group_hook_is_async", False)
+        monkeypatch.setattr(api.oidc, "_login_hook", test_hook)
+        monkeypatch.setattr(api.oidc, "_login_hook_is_async", False)
 
         _, cookie_data = await self._setup_callback(
             client,

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -18,6 +18,7 @@ from klangk_backend import (
     auth,
     container,
     model,
+    oidc,
     podman,
     workspaces as ws_mod,
     wshandler,
@@ -5000,16 +5001,20 @@ class TestOIDCCallback:
         assert resp.status_code == 502
         assert "missing" in resp.json()["detail"].lower()
 
-    async def test_callback_unverified_email_rejected(
-        self, client, monkeypatch, db
-    ):
-        """An unverified email claim is refused (account-takeover guard)."""
+    async def test_callback_login_hook_rejects(self, client, monkeypatch, db):
+        """A login validation hook can reject an OIDC login."""
         _, cookie_data = await self._setup_callback(
             client,
             monkeypatch,
             db,
             claims={"email_verified": False},
         )
+        monkeypatch.setattr(
+            oidc,
+            "_login_hook",
+            oidc.example_require_verified_email,
+        )
+        monkeypatch.setattr(oidc, "_login_hook_is_async", False)
         resp = await client.get(
             "/auth/oidc/test/callback",
             params={"code": "auth-code", "state": "test-state"},
@@ -5018,20 +5023,19 @@ class TestOIDCCallback:
         )
         assert resp.status_code == 403
         assert "not verified" in resp.json()["detail"].lower()
-        # No account was provisioned from the unverified claim.
         assert await model.get_user_by_email("oidcuser@example.com") is None
 
-    async def test_callback_unverified_email_trusted_provider(
+    async def test_callback_no_login_hook_allows_unverified(
         self, client, monkeypatch, db
     ):
-        """trust_unverified_email lets a trusted IdP skip the check."""
-        provider, cookie_data = await self._setup_callback(
+        """Without a login hook, unverified emails are accepted."""
+        _, cookie_data = await self._setup_callback(
             client,
             monkeypatch,
             db,
             claims={"email_verified": False},
         )
-        provider.trust_unverified_email = True
+        monkeypatch.setattr(oidc, "_login_hook", None)
         resp = await client.get(
             "/auth/oidc/test/callback",
             params={"code": "auth-code", "state": "test-state"},

--- a/src/backend/tests/test_oidc.py
+++ b/src/backend/tests/test_oidc.py
@@ -567,113 +567,124 @@ class TestExampleAdminHook:
         assert result == {"admin"}
 
 
-class TestLoadGroupHook:
+class TestLoadLoginHook:
     def test_no_hook_when_not_set(self, monkeypatch):
-        monkeypatch.delenv("KLANGK_GROUP_MAPPING_HOOK", raising=False)
-        oidc.load_group_hook()
-        assert oidc._group_hook is None
+        monkeypatch.delenv("KLANGK_OIDC_LOGIN_HOOK", raising=False)
+        oidc.load_login_hook()
+        assert oidc._login_hook is None
 
     def test_custom_hook_loaded(self, monkeypatch):
-        # Use a known stdlib function as the hook
-        monkeypatch.setenv("KLANGK_GROUP_MAPPING_HOOK", "os.path.exists")
-        oidc.load_group_hook()
-        assert oidc._group_hook is os.path.exists
+        monkeypatch.setenv("KLANGK_OIDC_LOGIN_HOOK", "os.path.exists")
+        oidc.load_login_hook()
+        assert oidc._login_hook is os.path.exists
 
     def test_bad_format_no_dot(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_GROUP_MAPPING_HOOK", "nofunc")
+        monkeypatch.setenv("KLANGK_OIDC_LOGIN_HOOK", "nofunc")
         with pytest.raises(RuntimeError, match="module.path.func_name"):
-            oidc.load_group_hook()
+            oidc.load_login_hook()
 
     def test_bad_module(self, monkeypatch):
-        monkeypatch.setenv(
-            "KLANGK_GROUP_MAPPING_HOOK", "nonexistent_module.func"
-        )
+        monkeypatch.setenv("KLANGK_OIDC_LOGIN_HOOK", "nonexistent_module.func")
         with pytest.raises(ModuleNotFoundError):
-            oidc.load_group_hook()
+            oidc.load_login_hook()
 
     def test_bad_function(self, monkeypatch):
-        monkeypatch.setenv(
-            "KLANGK_GROUP_MAPPING_HOOK", "os.nonexistent_func_xyz"
-        )
+        monkeypatch.setenv("KLANGK_OIDC_LOGIN_HOOK", "os.nonexistent_func_xyz")
         with pytest.raises(AttributeError):
-            oidc.load_group_hook()
+            oidc.load_login_hook()
 
     def test_not_callable(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_GROUP_MAPPING_HOOK", "os.sep")
+        monkeypatch.setenv("KLANGK_OIDC_LOGIN_HOOK", "os.sep")
         with pytest.raises(RuntimeError, match="not callable"):
-            oidc.load_group_hook()
+            oidc.load_login_hook()
 
 
-class TestCallGroupHook:
+class TestCallLoginHook:
     async def test_no_hook_returns_none(self):
-        oidc._group_hook = None
-        result = await oidc.call_group_hook(
+        oidc._login_hook = None
+        result = await oidc.call_login_hook(
             _provider(), {}, "x@example.com", {}
         )
         assert result is None
 
-    async def test_sync_hook(self):
+    async def test_hook_returns_groups(self):
         def hook(provider, claims, email, tokens):
             return {"admin", "devs"}
 
-        oidc._group_hook = hook
-        oidc._group_hook_is_async = False
-        result = await oidc.call_group_hook(
+        oidc._login_hook = hook
+        oidc._login_hook_is_async = False
+        result = await oidc.call_login_hook(
             _provider(), {}, "x@example.com", {}
         )
         assert result == {"admin", "devs"}
 
-    async def test_async_hook(self):
+    async def test_hook_returns_none(self):
+        def hook(provider, claims, email, tokens):
+            return None
+
+        oidc._login_hook = hook
+        oidc._login_hook_is_async = False
+        result = await oidc.call_login_hook(
+            _provider(), {}, "x@example.com", {}
+        )
+        assert result is None
+
+    async def test_async_hook_returns_groups(self):
         async def hook(provider, claims, email, tokens):
             return {"editors"}
 
-        oidc._group_hook = hook
-        oidc._group_hook_is_async = True
-        result = await oidc.call_group_hook(
+        oidc._login_hook = hook
+        oidc._login_hook_is_async = True
+        result = await oidc.call_login_hook(
             _provider(), {}, "x@example.com", {}
         )
         assert result == {"editors"}
 
-    async def test_hook_exception_returns_none(self):
+    async def test_hook_raises_rejects_login(self):
         def hook(provider, claims, email, tokens):
-            raise ValueError("broken")
+            raise ValueError("denied")
 
-        oidc._group_hook = hook
-        oidc._group_hook_is_async = False
-        result = await oidc.call_group_hook(
-            _provider(), {}, "x@example.com", {}
+        oidc._login_hook = hook
+        oidc._login_hook_is_async = False
+        with pytest.raises(ValueError, match="denied"):
+            await oidc.call_login_hook(_provider(), {}, "x@example.com", {})
+
+    async def test_async_hook_raises_rejects_login(self):
+        async def hook(provider, claims, email, tokens):
+            raise ValueError("async denied")
+
+        oidc._login_hook = hook
+        oidc._login_hook_is_async = True
+        with pytest.raises(ValueError, match="async denied"):
+            await oidc.call_login_hook(_provider(), {}, "x@example.com", {})
+
+    async def test_example_require_verified_email_rejects(self):
+        oidc._login_hook = oidc.example_require_verified_email
+        oidc._login_hook_is_async = False
+        with pytest.raises(ValueError, match="not verified"):
+            await oidc.call_login_hook(
+                _provider(), {"email_verified": False}, "a@b.com", {}
+            )
+
+    async def test_example_require_verified_email_allows(self):
+        oidc._login_hook = oidc.example_require_verified_email
+        oidc._login_hook_is_async = False
+        result = await oidc.call_login_hook(
+            _provider(), {"email_verified": True}, "a@b.com", {}
         )
         assert result is None
 
 
 class TestSyncOidcGroups:
-    async def test_no_hook_does_nothing(self, db):
-        oidc._group_hook = None
-        from klangk_backend import model
-
-        user = await model.create_user("sync@example.com", "hash")
-        await oidc.sync_oidc_groups(
-            user["id"], _provider(), {}, "sync@example.com", {}
-        )
-        assert await model.get_user_group_ids(user["id"]) == []
-
     async def test_creates_groups_and_adds_memberships(self, db):
-        def hook(provider, claims, email, tokens):
-            return {"new-group-a", "new-group-b"}
-
-        oidc._group_hook = hook
-        oidc._group_hook_is_async = False
         from klangk_backend import model
 
         user = await model.create_user("sync2@example.com", "hash")
-        await oidc.sync_oidc_groups(
-            user["id"], _provider(), {}, "sync2@example.com", {}
-        )
+        await oidc.sync_oidc_groups(user["id"], {"new-group-a", "new-group-b"})
         groups = await model.get_user_groups(user["id"])
         names = {g["name"] for g in groups}
         assert "new-group-a" in names
         assert "new-group-b" in names
-        # Verify source is oidc_sync
         sync_ids = await model.get_user_oidc_sync_group_ids(user["id"])
         assert len(sync_ids) == 2
 
@@ -681,18 +692,10 @@ class TestSyncOidcGroups:
         from klangk_backend import model
 
         user = await model.create_user("sync3@example.com", "hash")
-        # Pre-create group and add oidc_sync membership
         group = await model.create_group("old-group")
         await model.add_user_to_group(user["id"], group["id"], "oidc_sync")
 
-        def hook(provider, claims, email, tokens):
-            return set()  # no groups
-
-        oidc._group_hook = hook
-        oidc._group_hook_is_async = False
-        await oidc.sync_oidc_groups(
-            user["id"], _provider(), {}, "sync3@example.com", {}
-        )
+        await oidc.sync_oidc_groups(user["id"], set())
         assert await model.get_user_oidc_sync_group_ids(user["id"]) == []
 
     async def test_preserves_manual_memberships(self, db):
@@ -702,33 +705,6 @@ class TestSyncOidcGroups:
         group = await model.create_group("manual-group")
         await model.add_user_to_group(user["id"], group["id"], "manual")
 
-        def hook(provider, claims, email, tokens):
-            return set()  # hook returns nothing
-
-        oidc._group_hook = hook
-        oidc._group_hook_is_async = False
-        await oidc.sync_oidc_groups(
-            user["id"], _provider(), {}, "sync4@example.com", {}
-        )
-        # Manual membership untouched
+        await oidc.sync_oidc_groups(user["id"], set())
         all_ids = await model.get_user_group_ids(user["id"])
         assert group["id"] in all_ids
-
-    async def test_hook_error_preserves_existing(self, db):
-        from klangk_backend import model
-
-        user = await model.create_user("sync5@example.com", "hash")
-        group = await model.create_group("keep-group")
-        await model.add_user_to_group(user["id"], group["id"], "oidc_sync")
-
-        def hook(provider, claims, email, tokens):
-            raise RuntimeError("broken")
-
-        oidc._group_hook = hook
-        oidc._group_hook_is_async = False
-        await oidc.sync_oidc_groups(
-            user["id"], _provider(), {}, "sync5@example.com", {}
-        )
-        # Membership unchanged because hook errored
-        sync_ids = await model.get_user_oidc_sync_group_ids(user["id"])
-        assert group["id"] in sync_ids

--- a/src/frontend/e2e-tests/global-setup.ts
+++ b/src/frontend/e2e-tests/global-setup.ts
@@ -135,7 +135,7 @@ async function globalSetup() {
         KLANGK_LOGIN_BANNER: "",
         KLANGK_OIDC_CONFIG: "", // Disable OIDC providers in E2E tests
         KLANGK_AUTH_MODES: "", // Use default (password) auth mode
-        KLANGK_GROUP_MAPPING_HOOK: "", // No group mapping hook in E2E tests
+        KLANGK_OIDC_LOGIN_HOOK: "", // No OIDC login hook in E2E tests
         KLANGK_DISABLE_REGISTRATION: "", // Allow registration in E2E tests
         KLANGK_DISABLE_INVITES: "", // Allow invitations in E2E tests
       },


### PR DESCRIPTION
## Summary
Replace `trust_unverified_email` per-provider config and `KLANGK_GROUP_MAPPING_HOOK` with a single `KLANGK_OIDC_LOGIN_HOOK` that handles both login validation and group mapping:

- **Raise** an exception → login rejected (HTTP 403, message shown to user)
- **Return** `None` → login allowed, no group sync
- **Return** `set[str]` → login allowed, sync memberships to those groups

Built-in example hooks:
- `klangk_backend.oidc.example_require_verified_email` — reject unverified emails
- `klangk_backend.oidc.example_admin_hook` — map Keycloak roles to admin group

## Test plan
- [x] 23 backend tests pass (hook loading, call semantics, group sync, API callback)
- [ ] Backend unit test suite passes

Closes #196