### PR TITLE
Support native arm64 workspace builds on Apple Silicon

### DIFF
--- a/.github/workflows/image-workspace-base.yml
+++ b/.github/workflows/image-workspace-base.yml
@@ -21,26 +21,25 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GHCR
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
-      - name: Build base image
+      - name: Build and push base image
         run: |
           COMMIT=$(git rev-parse --short HEAD)
           CALVER="$(date -u +%Y.%m.%d)"
           VERSION="${CALVER}-${COMMIT}"
           REPO="ghcr.io/${{ github.repository }}/klangk-workspace-base"
-          docker build --platform linux/amd64 \
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
             -f src/containers/workspace/Dockerfile.base \
             -t "$REPO:latest" \
             -t "$REPO:$VERSION" \
+            --push \
             src/containers/workspace/
-
-      - name: Push base image
-        run: |
-          COMMIT=$(git rev-parse --short HEAD)
-          CALVER="$(date -u +%Y.%m.%d)"
-          VERSION="${CALVER}-${COMMIT}"
-          REPO="ghcr.io/${{ github.repository }}/klangk-workspace-base"
-          docker push "$REPO:latest"
-          docker push "$REPO:$VERSION"

--- a/devenv.nix
+++ b/devenv.nix
@@ -148,18 +148,11 @@ in
   env.KLANGK_INSTANCE_ID = lib.mkOverride 1500 "default";
   # Docker build platform for klangk images. On Linux, default to the host
   # architecture so arm64 machines build/run natively instead of under amd64
-  # emulation. On macOS, pin to linux/amd64: the published GHCR base
-  # (klangk-workspace-base:latest) is amd64-only, so an arm64 default would mismatch
-  # (containers run in the podman VM, emulated when needed). Override in .env
-  # to force a specific arch; native arm64 needs an arm64 base variant (see
-  # push-base-image).
+  # emulation. The published GHCR base (klangk-workspace-base:latest) is
+  # multi-arch (amd64 + arm64), so we default to the host's native
+  # architecture on all platforms. Override in .env to force a specific arch.
   env.KLANGK_PLATFORM = lib.mkOverride 1500 (
-    if pkgs.stdenv.hostPlatform.isDarwin then
-      "linux/amd64"
-    else if pkgs.stdenv.hostPlatform.isAarch64 then
-      "linux/arm64"
-    else
-      "linux/amd64"
+    if pkgs.stdenv.hostPlatform.isAarch64 then "linux/arm64" else "linux/amd64"
   );
   dotenv.enable = true;
 

--- a/src/containers/workspace/Dockerfile
+++ b/src/containers/workspace/Dockerfile
@@ -18,8 +18,10 @@ COPY builtin-extensions/ /opt/klangk/pi-agent/extensions/
 
 # Herdr: terminal-based agent runtime (persistent sessions, pane API)
 ARG HERDR_VERSION=0.6.6
-RUN curl -fsSL -o /usr/local/bin/herdr \
-    "https://github.com/ogulcancelik/herdr/releases/download/v${HERDR_VERSION}/herdr-linux-x86_64" \
+ARG TARGETARCH
+RUN HERDR_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "x86_64") \
+    && curl -fsSL -o /usr/local/bin/herdr \
+    "https://github.com/ogulcancelik/herdr/releases/download/v${HERDR_VERSION}/herdr-linux-${HERDR_ARCH}" \
     && chmod +x /usr/local/bin/herdr
 
 # Entrypoint, system prompt, bash defaults (change frequently during dev)


### PR DESCRIPTION
## Summary
- Default `KLANGK_PLATFORM` to host architecture on macOS instead of forcing `linux/amd64`, so Apple Silicon builds/runs natively
- Use `TARGETARCH` in workspace Dockerfile to download the correct herdr binary (`aarch64` vs `x86_64`)
- Update CI workflow to build and push multi-arch base images (amd64 + arm64) via buildx + QEMU

Closes #214

## Test plan
- [ ] Verify `KLANGK_PLATFORM` resolves to `linux/arm64` on Apple Silicon Mac
- [ ] Build workspace image on Apple Silicon and confirm `arch` reports `aarch64` inside the container
- [ ] Confirm herdr binary runs natively (not under emulation) in arm64 container
- [ ] Trigger CI workflow and verify both amd64 and arm64 base image variants are pushed to GHCR