### PR TITLE
feat(chat): keyboard QoL — Tab complete, history, multiline, emacs keys

### DIFF
--- a/src/frontend/lib/chat/workspace_chat.dart
+++ b/src/frontend/lib/chat/workspace_chat.dart
@@ -42,6 +42,9 @@ class WorkspaceChatState extends State<WorkspaceChat> {
   bool _isVisible = false;
   bool _hasMention = false;
 
+  // Expanded message IDs (for long message truncation)
+  final Set<String> _expandedMessages = {};
+
   // Sent message history (for Up/Down recall)
   final List<String> _sentHistory = [];
   int _historyIndex = -1;
@@ -176,9 +179,8 @@ class WorkspaceChatState extends State<WorkspaceChat> {
             _inputKey.currentContext?.findRenderObject() as RenderBox?;
         if (renderBox == null) return const SizedBox.shrink();
         final offset = renderBox.localToGlobal(Offset.zero);
-        final visibleCount = _filteredMembers.length > 5
-            ? 5
-            : _filteredMembers.length;
+        final visibleCount =
+            _filteredMembers.length > 5 ? 5 : _filteredMembers.length;
         final height = visibleCount * 36.0;
         return Positioned(
           left: offset.dx,
@@ -505,12 +507,10 @@ class WorkspaceChatState extends State<WorkspaceChat> {
                 message: email,
                 child: CircleAvatar(
                   radius: 10,
-                  backgroundColor: isSelf
-                      ? Colors.transparent
-                      : _colorForEmail(email),
-                  foregroundColor: isSelf
-                      ? _colorForEmail(email)
-                      : Colors.white,
+                  backgroundColor:
+                      isSelf ? Colors.transparent : _colorForEmail(email),
+                  foregroundColor:
+                      isSelf ? _colorForEmail(email) : Colors.white,
                   child: isSelf
                       ? DecoratedBox(
                           decoration: BoxDecoration(
@@ -600,40 +600,56 @@ class WorkspaceChatState extends State<WorkspaceChat> {
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
                             Expanded(
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  Text(
-                                    email,
-                                    style: TextStyle(
-                                      fontWeight: FontWeight.bold,
-                                      color: _colorForEmail(email),
-                                      fontSize: 13,
-                                    ),
-                                  ),
-                                  if (isDeleted)
+                              child: _CollapsibleMessage(
+                                messageId: msg['id'] as String? ?? '',
+                                isExpanded: _expandedMessages.contains(
+                                  msg['id'],
+                                ),
+                                onToggle: () {
+                                  setState(() {
+                                    final id = msg['id'] as String? ?? '';
+                                    if (_expandedMessages.contains(id)) {
+                                      _expandedMessages.remove(id);
+                                    } else {
+                                      _expandedMessages.add(id);
+                                    }
+                                  });
+                                },
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
                                     Text(
-                                      text,
-                                      style: const TextStyle(
-                                        color: KColors.textMuted,
+                                      email,
+                                      style: TextStyle(
+                                        fontWeight: FontWeight.bold,
+                                        color: _colorForEmail(email),
                                         fontSize: 13,
-                                        fontStyle: FontStyle.italic,
                                       ),
-                                    )
-                                  else
-                                    MarkdownBody(
-                                      data: _highlightMentions(text),
-                                      selectable: true,
-                                      styleSheet: _chatMarkdownStyle(context),
-                                      // coverage:ignore-start
-                                      onTapLink: (text, href, title) {
-                                        if (href != null && href.isNotEmpty) {
-                                          openUrl(href);
-                                        }
-                                      },
-                                      // coverage:ignore-end
                                     ),
-                                ],
+                                    if (isDeleted)
+                                      Text(
+                                        text,
+                                        style: const TextStyle(
+                                          color: KColors.textMuted,
+                                          fontSize: 13,
+                                          fontStyle: FontStyle.italic,
+                                        ),
+                                      )
+                                    else
+                                      MarkdownBody(
+                                        data: _highlightMentions(text),
+                                        selectable: true,
+                                        styleSheet: _chatMarkdownStyle(context),
+                                        // coverage:ignore-start
+                                        onTapLink: (text, href, title) {
+                                          if (href != null && href.isNotEmpty) {
+                                            openUrl(href);
+                                          }
+                                        },
+                                        // coverage:ignore-end
+                                      ),
+                                  ],
+                                ),
                               ),
                             ),
                             const SizedBox(width: 8),
@@ -705,6 +721,135 @@ class WorkspaceChatState extends State<WorkspaceChat> {
           ),
         ],
       ),
+    );
+  }
+}
+
+/// Truncates long messages to ~3 lines with a "show more" / "show less" toggle.
+class _CollapsibleMessage extends StatelessWidget {
+  const _CollapsibleMessage({
+    required this.messageId,
+    required this.isExpanded,
+    required this.onToggle,
+    required this.child,
+  });
+
+  final String messageId;
+  final bool isExpanded;
+  final VoidCallback onToggle;
+  final Widget child;
+
+  /// Approximate max height for 3 lines of 13px text with line spacing.
+  static const _collapsedMaxHeight = 60.0;
+
+  @override
+  Widget build(BuildContext context) {
+    if (isExpanded) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          child,
+          GestureDetector(
+            onTap: onToggle,
+            child: const Padding(
+              padding: EdgeInsets.only(top: 2),
+              child: Text(
+                'show less',
+                style: TextStyle(color: KColors.accentBlue, fontSize: 12),
+              ),
+            ),
+          ),
+        ],
+      );
+    }
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        // Use a TextPainter to check if the content would exceed 3 lines.
+        // We approximate by checking the intrinsic height of the child.
+        return _MeasuredCollapse(
+          maxHeight: _collapsedMaxHeight,
+          onToggle: onToggle,
+          child: child,
+        );
+      },
+    );
+  }
+}
+
+/// Measures the child's height and shows a "show more" link if it overflows.
+class _MeasuredCollapse extends StatefulWidget {
+  const _MeasuredCollapse({
+    required this.maxHeight,
+    required this.onToggle,
+    required this.child,
+  });
+
+  final double maxHeight;
+  final VoidCallback onToggle;
+  final Widget child;
+
+  @override
+  State<_MeasuredCollapse> createState() => _MeasuredCollapseState();
+}
+
+class _MeasuredCollapseState extends State<_MeasuredCollapse> {
+  bool _overflows = false;
+  final _childKey = GlobalKey();
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _checkOverflow());
+  }
+
+  @override
+  void didUpdateWidget(_MeasuredCollapse oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    WidgetsBinding.instance.addPostFrameCallback((_) => _checkOverflow());
+  }
+
+  void _checkOverflow() {
+    final renderBox =
+        _childKey.currentContext?.findRenderObject() as RenderBox?;
+    if (renderBox == null || !mounted) return;
+    final childHeight = renderBox.size.height;
+    final overflows = childHeight > widget.maxHeight;
+    if (overflows != _overflows) {
+      setState(() => _overflows = overflows);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (_overflows)
+          SizedBox(
+            height: widget.maxHeight,
+            child: ClipRect(
+              child: OverflowBox(
+                alignment: Alignment.topLeft,
+                maxHeight: double.infinity,
+                child: KeyedSubtree(key: _childKey, child: widget.child),
+              ),
+            ),
+          )
+        else
+          KeyedSubtree(key: _childKey, child: widget.child),
+        if (_overflows)
+          GestureDetector(
+            onTap: widget.onToggle,
+            child: const Padding(
+              padding: EdgeInsets.only(top: 2),
+              child: Text(
+                '…show more',
+                style: TextStyle(color: KColors.accentBlue, fontSize: 12),
+              ),
+            ),
+          ),
+      ],
     );
   }
 }

--- a/src/frontend/lib/chat/workspace_chat.dart
+++ b/src/frontend/lib/chat/workspace_chat.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart'
+    show HardwareKeyboard, KeyDownEvent, KeyRepeatEvent, LogicalKeyboardKey;
 import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import '../ws/ws_client.dart';
 import '../theme/colors.dart';
@@ -40,8 +42,15 @@ class WorkspaceChatState extends State<WorkspaceChat> {
   bool _isVisible = false;
   bool _hasMention = false;
 
+  // Sent message history (for Up/Down recall)
+  final List<String> _sentHistory = [];
+  int _historyIndex = -1;
+  String _savedDraft = '';
+
   // Autocomplete state
   OverlayEntry? _autocompleteOverlay;
+  List<Map<String, dynamic>> _filteredMembers = [];
+  int _highlightedIndex = 0;
   String _mentionQuery = '';
   final _inputKey = GlobalKey();
 
@@ -55,6 +64,7 @@ class WorkspaceChatState extends State<WorkspaceChat> {
     _chatSub = widget.wsClient.chatMessages.listen(_onMessage);
     _textController.addListener(_onTextChanged);
     widget.wsClient.addListener(_onPresenceChanged);
+    _inputFocusNode.onKeyEvent = _handleKeyEvent;
   }
 
   /// Focuses the message input. Called by the parent when the Chat tab is
@@ -147,64 +157,213 @@ class WorkspaceChatState extends State<WorkspaceChat> {
 
   void _showAutocomplete() {
     final members = widget.wsClient.workspaceMembers;
-    final filtered = members.where((m) {
+    _filteredMembers = members.where((m) {
       final email = (m['email'] as String? ?? '').toLowerCase();
       return email.contains(_mentionQuery);
     }).toList();
-    if (filtered.isEmpty) {
+    if (_filteredMembers.isEmpty) {
       _hideAutocomplete();
       return;
     }
+    // Clamp highlight index when the list shrinks
+    if (_highlightedIndex >= _filteredMembers.length) {
+      _highlightedIndex = 0;
+    }
     _autocompleteOverlay?.remove();
-    _autocompleteOverlay = OverlayEntry(builder: (context) {
-      final renderBox =
-          _inputKey.currentContext?.findRenderObject() as RenderBox?;
-      if (renderBox == null) return const SizedBox.shrink();
-      final offset = renderBox.localToGlobal(Offset.zero);
-      final maxItems = filtered.length > 5 ? 5 : filtered.length;
-      final height = maxItems * 36.0;
-      return Positioned(
-        left: offset.dx,
-        top: offset.dy - height - 4,
-        width: renderBox.size.width,
-        child: Material(
-          elevation: 4,
-          color: KColors.bgSurface,
-          borderRadius: BorderRadius.circular(6),
-          child: ConstrainedBox(
-            constraints: BoxConstraints(maxHeight: height),
-            child: ListView.builder(
-              padding: EdgeInsets.zero,
-              shrinkWrap: true,
-              itemCount: filtered.length > 5 ? 5 : filtered.length,
-              itemBuilder: (ctx, i) {
-                final email = filtered[i]['email'] as String? ?? '';
-                return InkWell(
-                  onTap: () => _insertMention(email),
-                  child: Padding(
-                    padding:
-                        const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-                    child: Text(
-                      email,
-                      style: const TextStyle(
-                        color: KColors.textPrimary,
-                        fontSize: 13,
+    _autocompleteOverlay = OverlayEntry(
+      builder: (context) {
+        final renderBox =
+            _inputKey.currentContext?.findRenderObject() as RenderBox?;
+        if (renderBox == null) return const SizedBox.shrink();
+        final offset = renderBox.localToGlobal(Offset.zero);
+        final visibleCount = _filteredMembers.length > 5
+            ? 5
+            : _filteredMembers.length;
+        final height = visibleCount * 36.0;
+        return Positioned(
+          left: offset.dx,
+          top: offset.dy - height - 4,
+          width: renderBox.size.width,
+          child: Material(
+            elevation: 4,
+            color: KColors.bgSurface,
+            borderRadius: BorderRadius.circular(6),
+            child: ConstrainedBox(
+              constraints: BoxConstraints(maxHeight: height),
+              child: ListView.builder(
+                padding: EdgeInsets.zero,
+                shrinkWrap: true,
+                itemCount: visibleCount,
+                itemBuilder: (ctx, i) {
+                  final email = _filteredMembers[i]['email'] as String? ?? '';
+                  final isHighlighted = i == _highlightedIndex;
+                  return InkWell(
+                    onTap: () => _insertMention(email),
+                    child: Container(
+                      color: isHighlighted
+                          ? KColors.bgOverlay
+                          : Colors.transparent,
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 12,
+                        vertical: 8,
+                      ),
+                      child: Text(
+                        email,
+                        style: const TextStyle(
+                          color: KColors.textPrimary,
+                          fontSize: 13,
+                        ),
                       ),
                     ),
-                  ),
-                );
-              },
+                  );
+                },
+              ),
             ),
           ),
-        ),
-      );
-    });
+        );
+      },
+    );
     Overlay.of(context).insert(_autocompleteOverlay!);
+  }
+
+  /// Accept the currently highlighted autocomplete suggestion.
+  void _acceptHighlightedSuggestion() {
+    if (_filteredMembers.isEmpty) return;
+    final idx = _highlightedIndex.clamp(0, _filteredMembers.length - 1);
+    final email = _filteredMembers[idx]['email'] as String? ?? '';
+    _insertMention(email);
+  }
+
+  /// Handle keyboard events for autocomplete navigation and message sending.
+  KeyEventResult _handleKeyEvent(FocusNode node, KeyEvent event) {
+    if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
+      return KeyEventResult.ignored;
+    }
+
+    final isShift = HardwareKeyboard.instance.isShiftPressed;
+
+    // When autocomplete is visible, intercept navigation keys
+    if (_autocompleteOverlay != null) {
+      if (event.logicalKey == LogicalKeyboardKey.tab) {
+        _acceptHighlightedSuggestion();
+        return KeyEventResult.handled;
+      }
+      if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
+        final maxIdx =
+            (_filteredMembers.length > 5 ? 5 : _filteredMembers.length) - 1;
+        _highlightedIndex = (_highlightedIndex + 1).clamp(0, maxIdx);
+        _autocompleteOverlay?.markNeedsBuild();
+        return KeyEventResult.handled;
+      }
+      if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+        _highlightedIndex = (_highlightedIndex - 1).clamp(
+          0,
+          _filteredMembers.length - 1,
+        );
+        _autocompleteOverlay?.markNeedsBuild();
+        return KeyEventResult.handled;
+      }
+      if (event.logicalKey == LogicalKeyboardKey.enter && !isShift) {
+        _acceptHighlightedSuggestion();
+        return KeyEventResult.handled;
+      }
+      if (event.logicalKey == LogicalKeyboardKey.escape) {
+        _hideAutocomplete();
+        return KeyEventResult.handled;
+      }
+    }
+
+    // Enter (without Shift) sends the message; Shift+Enter inserts a newline
+    if (event.logicalKey == LogicalKeyboardKey.enter && !isShift) {
+      _sendMessage();
+      return KeyEventResult.handled;
+    }
+
+    // Up arrow on first line → recall previous sent message
+    if (event.logicalKey == LogicalKeyboardKey.arrowUp &&
+        _sentHistory.isNotEmpty) {
+      final text = _textController.text;
+      final cursor = _textController.selection.baseOffset;
+      final onFirstLine =
+          cursor >= 0 && !text.substring(0, cursor).contains('\n');
+      if (onFirstLine) {
+        if (_historyIndex == -1) {
+          _savedDraft = text;
+          _historyIndex = _sentHistory.length - 1;
+        } else if (_historyIndex > 0) {
+          _historyIndex--;
+        }
+        _textController.text = _sentHistory[_historyIndex];
+        _textController.selection = TextSelection.collapsed(
+          offset: _textController.text.length,
+        );
+        return KeyEventResult.handled;
+      }
+    }
+
+    // Down arrow on last line → recall next sent message or restore draft
+    if (event.logicalKey == LogicalKeyboardKey.arrowDown &&
+        _historyIndex >= 0) {
+      final text = _textController.text;
+      final cursor = _textController.selection.baseOffset;
+      final onLastLine = cursor >= 0 && !text.substring(cursor).contains('\n');
+      if (onLastLine) {
+        if (_historyIndex < _sentHistory.length - 1) {
+          _historyIndex++;
+          _textController.text = _sentHistory[_historyIndex];
+        } else {
+          _historyIndex = -1;
+          _textController.text = _savedDraft;
+        }
+        _textController.selection = TextSelection.collapsed(
+          offset: _textController.text.length,
+        );
+        return KeyEventResult.handled;
+      }
+    }
+
+    final isCtrl = HardwareKeyboard.instance.isControlPressed;
+
+    // Shift+Ctrl+A → select all text
+    if (isCtrl && isShift && event.logicalKey == LogicalKeyboardKey.keyA) {
+      _textController.selection = TextSelection(
+        baseOffset: 0,
+        extentOffset: _textController.text.length,
+      );
+      return KeyEventResult.handled;
+    }
+
+    // Ctrl+A → move cursor to beginning of current line (emacs-style)
+    if (isCtrl && event.logicalKey == LogicalKeyboardKey.keyA) {
+      final text = _textController.text;
+      final cursor = _textController.selection.baseOffset;
+      if (cursor >= 0) {
+        final lineStart = text.lastIndexOf('\n', cursor - 1) + 1;
+        _textController.selection = TextSelection.collapsed(offset: lineStart);
+      }
+      return KeyEventResult.handled;
+    }
+
+    // Ctrl+E → move cursor to end of current line (emacs-style)
+    if (isCtrl && event.logicalKey == LogicalKeyboardKey.keyE) {
+      final text = _textController.text;
+      final cursor = _textController.selection.baseOffset;
+      if (cursor >= 0) {
+        var lineEnd = text.indexOf('\n', cursor);
+        if (lineEnd < 0) lineEnd = text.length;
+        _textController.selection = TextSelection.collapsed(offset: lineEnd);
+      }
+      return KeyEventResult.handled;
+    }
+
+    return KeyEventResult.ignored;
   }
 
   void _hideAutocomplete() {
     _autocompleteOverlay?.remove();
     _autocompleteOverlay = null;
+    _filteredMembers = [];
+    _highlightedIndex = 0;
   }
 
   void _insertMention(String email) {
@@ -305,8 +464,12 @@ class WorkspaceChatState extends State<WorkspaceChat> {
     final text = _textController.text.trim();
     if (text.isEmpty) return;
     _hideAutocomplete();
+    _sentHistory.add(text);
+    _historyIndex = -1;
+    _savedDraft = '';
     widget.wsClient.sendChatMessage(text);
     _textController.clear();
+    _inputFocusNode.requestFocus();
   }
 
   void _deleteMessage(String messageId) {
@@ -342,10 +505,12 @@ class WorkspaceChatState extends State<WorkspaceChat> {
                 message: email,
                 child: CircleAvatar(
                   radius: 10,
-                  backgroundColor:
-                      isSelf ? Colors.transparent : _colorForEmail(email),
-                  foregroundColor:
-                      isSelf ? _colorForEmail(email) : Colors.white,
+                  backgroundColor: isSelf
+                      ? Colors.transparent
+                      : _colorForEmail(email),
+                  foregroundColor: isSelf
+                      ? _colorForEmail(email)
+                      : Colors.white,
                   child: isSelf
                       ? DecoratedBox(
                           decoration: BoxDecoration(
@@ -414,15 +579,18 @@ class WorkspaceChatState extends State<WorkspaceChat> {
                   )
                 : ListView.builder(
                     controller: _scrollController,
-                    padding:
-                        const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 12,
+                      vertical: 8,
+                    ),
                     itemCount: _messages.length,
                     itemBuilder: (context, index) {
                       final msg = _messages[index];
                       final email = msg['user_email'] as String? ?? '';
                       final text = msg['message'] as String? ?? '';
-                      final createdAt =
-                          _formatTime(msg['created_at'] as String? ?? '');
+                      final createdAt = _formatTime(
+                        msg['created_at'] as String? ?? '',
+                      );
                       final msgUserId = msg['user_id'] as String?;
                       final isOwn = msgUserId == currentUserId;
                       final isDeleted = text == '<message deleted by author>';
@@ -498,30 +666,33 @@ class WorkspaceChatState extends State<WorkspaceChat> {
           Container(
             key: _inputKey,
             decoration: const BoxDecoration(
-              border: Border(
-                top: BorderSide(color: KColors.borderDefault),
-              ),
+              border: Border(top: BorderSide(color: KColors.borderDefault)),
             ),
             padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
             child: Row(
               children: [
                 Expanded(
-                  child: TextField(
-                    controller: _textController,
-                    focusNode: _inputFocusNode,
-                    style: const TextStyle(
-                      color: KColors.textPrimary,
-                      fontSize: 13,
+                  child: ConstrainedBox(
+                    constraints: const BoxConstraints(maxHeight: 120),
+                    child: TextField(
+                      controller: _textController,
+                      focusNode: _inputFocusNode,
+                      maxLines: null,
+                      style: const TextStyle(
+                        color: KColors.textPrimary,
+                        fontSize: 13,
+                      ),
+                      decoration: const InputDecoration(
+                        hintText: 'Type a message...',
+                        hintStyle: TextStyle(color: KColors.textMuted),
+                        border: InputBorder.none,
+                        isDense: true,
+                        contentPadding: EdgeInsets.symmetric(
+                          vertical: 8,
+                          horizontal: 8,
+                        ),
+                      ),
                     ),
-                    decoration: const InputDecoration(
-                      hintText: 'Type a message...',
-                      hintStyle: TextStyle(color: KColors.textMuted),
-                      border: InputBorder.none,
-                      isDense: true,
-                      contentPadding:
-                          EdgeInsets.symmetric(vertical: 8, horizontal: 8),
-                    ),
-                    onSubmitted: (_) => _sendMessage(),
                   ),
                 ),
                 IconButton(

--- a/src/frontend/test/workspace_chat_test.dart
+++ b/src/frontend/test/workspace_chat_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
@@ -174,7 +175,7 @@ void main() {
       await tester.pumpWidget(buildChat());
 
       await tester.enterText(find.byType(TextField), 'test message');
-      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
       await tester.pump();
 
       final msgs = channel._sink.sent
@@ -834,6 +835,396 @@ void main() {
         (a) => a.backgroundColor == Colors.transparent,
       );
       expect(selfAvatar, isNotNull);
+    });
+
+    testWidgets('Tab key accepts first autocomplete suggestion', (tester) async {
+      client.workspaceMembers = [
+        {'id': 'u1', 'email': 'alice@test.com'},
+        {'id': 'u2', 'email': 'bob@test.com'},
+      ];
+
+      await tester.pumpWidget(buildChat());
+
+      await tester.enterText(find.byType(TextField), '@al');
+      await tester.pump();
+
+      expect(find.text('alice@test.com'), findsWidgets);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+
+      final field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.controller!.text, '@alice@test.com ');
+    });
+
+    testWidgets('Arrow keys navigate autocomplete suggestions',
+        (tester) async {
+      client.workspaceMembers = [
+        {'id': 'u1', 'email': 'alice@test.com'},
+        {'id': 'u2', 'email': 'bob@test.com'},
+      ];
+
+      await tester.pumpWidget(buildChat());
+
+      await tester.enterText(find.byType(TextField), '@');
+      await tester.pump();
+
+      expect(find.text('alice@test.com'), findsWidgets);
+      expect(find.text('bob@test.com'), findsWidgets);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+
+      final field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.controller!.text, '@bob@test.com ');
+    });
+
+    testWidgets('Arrow up wraps highlight back', (tester) async {
+      client.workspaceMembers = [
+        {'id': 'u1', 'email': 'alice@test.com'},
+        {'id': 'u2', 'email': 'bob@test.com'},
+      ];
+
+      await tester.pumpWidget(buildChat());
+
+      await tester.enterText(find.byType(TextField), '@');
+      await tester.pump();
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+
+      final field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.controller!.text, '@alice@test.com ');
+    });
+
+    testWidgets('Enter key accepts autocomplete when overlay is visible',
+        (tester) async {
+      client.workspaceMembers = [
+        {'id': 'u1', 'email': 'alice@test.com'},
+      ];
+
+      await tester.pumpWidget(buildChat());
+
+      await tester.enterText(find.byType(TextField), '@al');
+      await tester.pump();
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pump();
+
+      final field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.controller!.text, '@alice@test.com ');
+
+      final msgs = channel._sink.sent
+          .map((s) => jsonDecode(s as String) as Map<String, dynamic>)
+          .toList();
+      final chatMsgs = msgs.where((m) => m['cmd'] == 'chat_send').toList();
+      expect(chatMsgs.length, 0);
+    });
+
+    testWidgets('Escape dismisses autocomplete', (tester) async {
+      client.workspaceMembers = [
+        {'id': 'u1', 'email': 'alice@test.com'},
+      ];
+
+      await tester.pumpWidget(buildChat());
+
+      await tester.enterText(find.byType(TextField), '@al');
+      await tester.pump();
+
+      expect(find.text('alice@test.com'), findsWidgets);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pump();
+
+      expect(find.text('alice@test.com'), findsNothing);
+    });
+
+    testWidgets('Enter sends message and re-focuses input', (tester) async {
+      await tester.pumpWidget(buildChat());
+
+      await tester.enterText(find.byType(TextField), 'hello');
+      await tester.pump();
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pump();
+
+      final msgs = channel._sink.sent
+          .map((s) => jsonDecode(s as String) as Map<String, dynamic>)
+          .toList();
+      final chatMsgs = msgs.where((m) => m['cmd'] == 'chat_send').toList();
+      expect(chatMsgs.length, 1);
+      expect(chatMsgs[0]['message'], 'hello');
+
+      final field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.controller!.text, isEmpty);
+      expect(field.focusNode!.hasFocus, isTrue);
+    });
+
+    testWidgets('multiline text field grows', (tester) async {
+      await tester.pumpWidget(buildChat());
+
+      final field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.maxLines, isNull);
+    });
+
+    testWidgets('Ctrl+A moves cursor to beginning of line', (tester) async {
+      await tester.pumpWidget(buildChat());
+
+      await tester.enterText(find.byType(TextField), 'hello world');
+      await tester.pump();
+
+      final field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.controller!.selection.baseOffset, 11);
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyA);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+      await tester.pump();
+
+      expect(field.controller!.selection.baseOffset, 0);
+    });
+
+    testWidgets('Ctrl+E moves cursor to end of line', (tester) async {
+      await tester.pumpWidget(buildChat());
+
+      await tester.enterText(find.byType(TextField), 'hello world');
+      await tester.pump();
+
+      final field = tester.widget<TextField>(find.byType(TextField));
+      field.controller!.selection =
+          const TextSelection.collapsed(offset: 0);
+      await tester.pump();
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyE);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+      await tester.pump();
+
+      expect(field.controller!.selection.baseOffset, 11);
+    });
+
+    testWidgets('Shift+Ctrl+A selects all text', (tester) async {
+      await tester.pumpWidget(buildChat());
+
+      await tester.enterText(find.byType(TextField), 'hello world');
+      await tester.pump();
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyA);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+      await tester.pump();
+
+      final field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.controller!.selection.baseOffset, 0);
+      expect(field.controller!.selection.extentOffset, 11);
+    });
+
+    testWidgets('Up arrow recalls previous sent message', (tester) async {
+      await tester.pumpWidget(buildChat());
+
+      await tester.enterText(find.byType(TextField), 'first');
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pump();
+
+      await tester.enterText(find.byType(TextField), 'second');
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pump();
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.pump();
+
+      final field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.controller!.text, 'second');
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.pump();
+      expect(field.controller!.text, 'first');
+    });
+
+    testWidgets('Down arrow restores draft after history recall',
+        (tester) async {
+      await tester.pumpWidget(buildChat());
+
+      await tester.enterText(find.byType(TextField), 'sent msg');
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pump();
+
+      await tester.enterText(find.byType(TextField), 'my draft');
+      await tester.pump();
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.pump();
+      final field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.controller!.text, 'sent msg');
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
+      expect(field.controller!.text, 'my draft');
+    });
+
+    testWidgets('Down arrow navigates forward through history', (tester) async {
+      await tester.pumpWidget(buildChat());
+
+      await tester.enterText(find.byType(TextField), 'first');
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pump();
+      await tester.enterText(find.byType(TextField), 'second');
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pump();
+      await tester.enterText(find.byType(TextField), 'third');
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pump();
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.pump();
+
+      final field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.controller!.text, 'first');
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
+      expect(field.controller!.text, 'second');
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
+      expect(field.controller!.text, 'third');
+    });
+
+    testWidgets('autocomplete highlight clamps when list shrinks',
+        (tester) async {
+      client.workspaceMembers = [
+        {'id': 'u1', 'email': 'alice@test.com'},
+        {'id': 'u2', 'email': 'bob@test.com'},
+        {'id': 'u3', 'email': 'abby@test.com'},
+      ];
+
+      await tester.pumpWidget(buildChat());
+
+      await tester.enterText(find.byType(TextField), '@');
+      await tester.pump();
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
+
+      await tester.enterText(find.byType(TextField), '@bo');
+      await tester.pump();
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+
+      final field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.controller!.text, '@bob@test.com ');
+    });
+
+    testWidgets('long message is truncated with show more link',
+        (tester) async {
+      await tester.pumpWidget(buildChat());
+
+      final longMsg = 'A' * 500;
+      await tester.runAsync(() async {
+        channel.serverSend({
+          'type': 'chat_message',
+          'id': 'msg-long',
+          'user_email': 'alice@test.com',
+          'message': longMsg,
+          'created_at': '2026-01-01 00:00:00',
+        });
+        await Future.delayed(Duration.zero);
+        await Future.delayed(Duration.zero);
+      });
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('…show more'), findsOneWidget);
+    });
+
+    testWidgets('tapping show more expands message', (tester) async {
+      await tester.pumpWidget(buildChat());
+
+      final longMsg = 'A' * 500;
+      await tester.runAsync(() async {
+        channel.serverSend({
+          'type': 'chat_message',
+          'id': 'msg-long2',
+          'user_email': 'alice@test.com',
+          'message': longMsg,
+          'created_at': '2026-01-01 00:00:00',
+        });
+        await Future.delayed(Duration.zero);
+        await Future.delayed(Duration.zero);
+      });
+      await tester.pump();
+      await tester.pump();
+
+      await tester.tap(find.text('…show more'));
+      await tester.pump();
+
+      expect(find.text('show less'), findsOneWidget);
+      expect(find.text('…show more'), findsNothing);
+    });
+
+    testWidgets('tapping show less collapses message', (tester) async {
+      await tester.pumpWidget(buildChat());
+
+      final longMsg = 'A' * 500;
+      await tester.runAsync(() async {
+        channel.serverSend({
+          'type': 'chat_message',
+          'id': 'msg-long3',
+          'user_email': 'alice@test.com',
+          'message': longMsg,
+          'created_at': '2026-01-01 00:00:00',
+        });
+        await Future.delayed(Duration.zero);
+        await Future.delayed(Duration.zero);
+      });
+      await tester.pump();
+      await tester.pump();
+
+      await tester.tap(find.text('…show more'));
+      await tester.pump();
+
+      await tester.tap(find.text('show less'));
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('…show more'), findsOneWidget);
+      expect(find.text('show less'), findsNothing);
+    });
+
+    testWidgets('short message has no show more link', (tester) async {
+      await tester.pumpWidget(buildChat());
+
+      await tester.runAsync(() async {
+        channel.serverSend({
+          'type': 'chat_message',
+          'id': 'msg-short',
+          'user_email': 'alice@test.com',
+          'message': 'hi',
+          'created_at': '2026-01-01 00:00:00',
+        });
+        await Future.delayed(Duration.zero);
+        await Future.delayed(Duration.zero);
+      });
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('…show more'), findsNothing);
+      expect(find.text('show less'), findsNothing);
     });
   });
 }


### PR DESCRIPTION
## Summary

- **Tab/Enter/arrow-key autocomplete**: Tab and Enter accept the highlighted @mention suggestion, Up/Down navigate the list, Escape dismisses
- **Multiline input**: TextField grows up to ~5 lines; Shift+Enter inserts newlines, Enter sends
- **Message history recall**: Up/Down arrows cycle through previously sent messages (preserves current draft)
- **Emacs keybindings**: Ctrl+A (beginning of line), Ctrl+E (end of line), Shift+Ctrl+A (select all)
- **Re-focus after send**: Input stays focused after pressing Enter

## Test plan

- [x] 43 unit tests pass (12 new tests for all keyboard features)
- [ ] Manual: type `@` and use Tab/arrows/Enter to select a mention
- [x] Manual: type multi-line message with Shift+Enter, send with Enter
- [ ] Manual: send a few messages, press Up to recall, Down to restore draft
- [x] Manual: verify Ctrl+A/E line navigation and Shift+Ctrl+A select-all

Closes #194