### PR TITLE
feat: chat message types — user, agent, system

### DIFF
--- a/src/backend/e2e-tests/test_event_fanout.py
+++ b/src/backend/e2e-tests/test_event_fanout.py
@@ -202,6 +202,20 @@ async def recv_until(ws, predicate, timeout=30):
     return messages
 
 
+def register_user(server, email, password):
+    """Register a new user (requires KLANGK_TEST_MODE=1), return auth dict."""
+    url = server["url"]
+    resp = httpx.post(
+        f"{url}/auth/register",
+        json={"email": email, "password": password},
+        timeout=10,
+    )
+    assert resp.status_code == 200
+    token = resp.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+    return {"token": token, "headers": headers}
+
+
 class TestEventFanout:
     @pytest.mark.asyncio
     async def test_both_connections_receive_container_ready(
@@ -279,6 +293,111 @@ class TestEventFanout:
             finally:
                 await ws1.close()
                 await ws2.close()
+        finally:
+            cleanup()
+
+    @pytest.mark.asyncio
+    async def test_join_broadcasts_system_chat_message(self, server, auth):
+        """Connecting to a workspace broadcasts a system chat message."""
+        workspace_id, cleanup = create_workspace(server, auth)
+        try:
+            ws1 = await ws_connect(server, auth, workspace_id)
+            try:
+                # Drain ws1 until we see the "joined" system chat message
+                def is_join_chat(msg):
+                    return (
+                        msg.get("type") == "chat_message"
+                        and msg.get("message_type") == 2
+                        and "joined" in msg.get("message", "")
+                    )
+
+                msgs = await recv_until(ws1, is_join_chat, timeout=15)
+                join_msgs = [m for m in msgs if is_join_chat(m)]
+                assert len(join_msgs) >= 1
+                assert join_msgs[0]["message"] == "test@example.com joined"
+                assert join_msgs[0]["message_type"] == 2
+            finally:
+                await ws1.close()
+        finally:
+            cleanup()
+
+    @pytest.mark.asyncio
+    async def test_leave_broadcasts_system_chat_message(self, server, auth):
+        """Disconnecting broadcasts a 'left' system chat message to others."""
+        workspace_id, cleanup = create_workspace(server, auth)
+        try:
+            # Register a second user and share the workspace
+            auth2 = register_user(server, "user2@example.com", "testpass2")
+            resp = httpx.post(
+                f"{server['url']}/workspaces/{workspace_id}/members",
+                headers=auth["headers"],
+                json={"email": "user2@example.com"},
+                timeout=10,
+            )
+            assert resp.status_code == 200
+
+            ws1 = await ws_connect(server, auth, workspace_id)
+            ws2 = await ws_connect(server, auth2, workspace_id)
+
+            try:
+                # Drain any pending messages on ws1
+                await recv_until(
+                    ws1,
+                    lambda m: False,
+                    timeout=3,
+                )
+
+                # Close ws2 — should trigger "left" system message
+                await ws2.close()
+
+                # ws1 should receive the leave system chat message
+                def is_leave_chat(msg):
+                    return (
+                        msg.get("type") == "chat_message"
+                        and msg.get("message_type") == 2
+                        and "left" in msg.get("message", "")
+                    )
+
+                msgs = await recv_until(ws1, is_leave_chat, timeout=10)
+                leave_msgs = [m for m in msgs if is_leave_chat(m)]
+                assert len(leave_msgs) >= 1
+                assert leave_msgs[0]["message"] == "user2@example.com left"
+                assert leave_msgs[0]["message_type"] == 2
+            finally:
+                await ws1.close()
+        finally:
+            cleanup()
+
+    @pytest.mark.asyncio
+    async def test_same_user_multi_connect_no_duplicate_leave(
+        self, server, auth
+    ):
+        """Same user with two connections — closing one does not emit 'left'."""
+        workspace_id, cleanup = create_workspace(server, auth)
+        try:
+            ws1 = await ws_connect(server, auth, workspace_id)
+            ws2 = await ws_connect(server, auth, workspace_id)
+
+            try:
+                # Drain pending messages on ws1
+                await recv_until(ws1, lambda m: False, timeout=3)
+
+                # Close ws2 — same user still has ws1
+                await ws2.close()
+                await asyncio.sleep(1)
+
+                # Drain ws1 — should NOT have a "left" message
+                remaining = await recv_until(ws1, lambda m: False, timeout=3)
+                leave_msgs = [
+                    m
+                    for m in remaining
+                    if m.get("type") == "chat_message"
+                    and m.get("message_type") == 2
+                    and "left" in m.get("message", "")
+                ]
+                assert len(leave_msgs) == 0
+            finally:
+                await ws1.close()
         finally:
             cleanup()
 

--- a/src/backend/klangk_backend/model.py
+++ b/src/backend/klangk_backend/model.py
@@ -17,6 +17,11 @@ _data_dir = Path(
 )
 DB_PATH = _data_dir / "klangk.db"
 
+# Chat message types
+MSG_USER = 0
+MSG_AGENT = 1
+MSG_SYSTEM = 2
+
 
 async def get_db() -> aiosqlite.Connection:
     DB_PATH.parent.mkdir(parents=True, exist_ok=True)
@@ -143,9 +148,18 @@ async def init_db() -> None:
                 user_id TEXT NOT NULL,
                 user_email TEXT NOT NULL,
                 message TEXT NOT NULL,
+                message_type INTEGER NOT NULL DEFAULT 0,
                 created_at TEXT NOT NULL DEFAULT (datetime('now'))
             )
         """)
+        # Migration: add message_type column to existing chat_messages tables
+        cursor = await db.execute("PRAGMA table_info(chat_messages)")
+        chat_cols = {row[1] for row in await cursor.fetchall()}
+        if "message_type" not in chat_cols:
+            await db.execute(
+                "ALTER TABLE chat_messages"
+                " ADD COLUMN message_type INTEGER NOT NULL DEFAULT 0"
+            )
         await db.execute("""
             CREATE TABLE IF NOT EXISTS chat_mentions (
                 id TEXT PRIMARY KEY,
@@ -1377,16 +1391,21 @@ async def parse_mentions(
 
 
 async def add_chat_message(
-    workspace_id: str, user_id: str, user_email: str, message: str
+    workspace_id: str,
+    user_id: str,
+    user_email: str,
+    message: str,
+    message_type: int = MSG_USER,
 ) -> dict:
     """Store a chat message and return it."""
     db = await get_db()
     try:
         msg_id = str(uuid.uuid4())
         await db.execute(
-            "INSERT INTO chat_messages (id, workspace_id, user_id, user_email, message)"
-            " VALUES (?, ?, ?, ?, ?)",
-            (msg_id, workspace_id, user_id, user_email, message),
+            "INSERT INTO chat_messages"
+            " (id, workspace_id, user_id, user_email, message, message_type)"
+            " VALUES (?, ?, ?, ?, ?, ?)",
+            (msg_id, workspace_id, user_id, user_email, message, message_type),
         )
         mentioned_user_ids = await parse_mentions(db, message, workspace_id)
         for uid in mentioned_user_ids:
@@ -1406,6 +1425,7 @@ async def add_chat_message(
             "user_id": user_id,
             "user_email": user_email,
             "message": message,
+            "message_type": message_type,
             "created_at": row["created_at"],
             "mentions": mentioned_user_ids,
         }
@@ -1437,7 +1457,8 @@ async def get_chat_messages(workspace_id: str, limit: int = 50) -> list[dict]:
     db = await get_db()
     try:
         cursor = await db.execute(
-            "SELECT id, workspace_id, user_id, user_email, message, created_at"
+            "SELECT id, workspace_id, user_id, user_email, message,"
+            " message_type, created_at"
             " FROM chat_messages WHERE workspace_id = ?"
             " ORDER BY created_at DESC, rowid DESC LIMIT ?",
             (workspace_id, limit),
@@ -1452,6 +1473,7 @@ async def get_chat_messages(workspace_id: str, limit: int = 50) -> list[dict]:
                         "user_id": row["user_id"],
                         "user_email": row["user_email"],
                         "message": row["message"],
+                        "message_type": row["message_type"],
                         "created_at": row["created_at"],
                     }
                     for row in rows

--- a/src/backend/klangk_backend/wshandler.py
+++ b/src/backend/klangk_backend/wshandler.py
@@ -651,6 +651,16 @@ class Connection:
                 if sock is not self.sock:
                     sock.send_json(join_msg)
 
+            # Broadcast a system chat message for the join
+            sys_msg = await model.add_chat_message(
+                workspace_id,
+                self.user["id"],
+                self.user["email"],
+                f"{self.user['email']} joined",
+                message_type=model.MSG_SYSTEM,
+            )
+            session.broadcast({"type": "chat_message", **sys_msg})
+
         # Store status for when frontend sends ui_ready
         self.pending_status_msg = status_msg
         logger.info(
@@ -988,6 +998,15 @@ class Connection:
                     for s in session.subscribers
                 )
                 if not still_connected:
+                    # Broadcast a system chat message for the leave
+                    sys_msg = await model.add_chat_message(
+                        workspace_id,
+                        self.user["id"],
+                        self.user["email"],
+                        f"{self.user['email']} left",
+                        message_type=model.MSG_SYSTEM,
+                    )
+                    session.broadcast({"type": "chat_message", **sys_msg})
                     session.broadcast(
                         {
                             "type": "presence_leave",

--- a/src/backend/tests/test_model.py
+++ b/src/backend/tests/test_model.py
@@ -507,6 +507,42 @@ class TestLoginAttempts:
         await model.clear_login_attempts("nobody@example.com")
 
 
+class TestChatMessagesMigration:
+    async def test_migrate_adds_message_type_column(self, db):
+        """init_db adds message_type column to existing tables that lack it."""
+        raw_db = await model.get_db()
+        try:
+            # Drop and recreate without message_type to simulate old schema
+            await raw_db.execute("DROP TABLE IF EXISTS chat_mentions")
+            await raw_db.execute("DROP TABLE IF EXISTS chat_messages")
+            await raw_db.execute("""
+                CREATE TABLE chat_messages (
+                    id TEXT PRIMARY KEY,
+                    workspace_id TEXT NOT NULL,
+                    user_id TEXT NOT NULL,
+                    user_email TEXT NOT NULL,
+                    message TEXT NOT NULL,
+                    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+                )
+            """)
+            await raw_db.commit()
+        finally:
+            await raw_db.close()
+
+        # Re-run init_db — should add message_type via ALTER TABLE
+        await model.init_db()
+
+        migrated_db = await model.get_db()
+        try:
+            cursor = await migrated_db.execute(
+                "PRAGMA table_info(chat_messages)"
+            )
+            cols = {row[1] for row in await cursor.fetchall()}
+            assert "message_type" in cols
+        finally:
+            await migrated_db.close()
+
+
 class TestChatMessages:
     async def test_add_chat_message(self, workspace, user):
         msg = await model.add_chat_message(

--- a/src/backend/tests/test_model.py
+++ b/src/backend/tests/test_model.py
@@ -516,9 +516,29 @@ class TestChatMessages:
         assert msg["user_id"] == user["id"]
         assert msg["user_email"] == "testuser@example.com"
         assert msg["message"] == "hello"
+        assert msg["message_type"] == model.MSG_USER
         assert "id" in msg
         assert "created_at" in msg
         assert msg["mentions"] == []
+
+    async def test_add_chat_message_with_type(self, workspace, user):
+        msg = await model.add_chat_message(
+            workspace["id"],
+            user["id"],
+            "testuser@example.com",
+            "system event",
+            message_type=model.MSG_SYSTEM,
+        )
+        assert msg["message_type"] == model.MSG_SYSTEM
+
+        agent_msg = await model.add_chat_message(
+            workspace["id"],
+            user["id"],
+            "agent@bot",
+            "agent reply",
+            message_type=model.MSG_AGENT,
+        )
+        assert agent_msg["message_type"] == model.MSG_AGENT
 
     async def test_get_chat_messages(self, workspace, user):
         await model.add_chat_message(
@@ -531,8 +551,29 @@ class TestChatMessages:
         assert len(msgs) == 2
         assert msgs[0]["message"] == "first"
         assert msgs[1]["message"] == "second"
+        assert msgs[0]["message_type"] == model.MSG_USER
+        assert msgs[1]["message_type"] == model.MSG_USER
         assert msgs[0]["mentions"] == []
         assert msgs[1]["mentions"] == []
+
+    async def test_get_chat_messages_preserves_type(self, workspace, user):
+        await model.add_chat_message(
+            workspace["id"],
+            "uid",
+            "u@test.com",
+            "joined",
+            message_type=model.MSG_SYSTEM,
+        )
+        await model.add_chat_message(
+            workspace["id"],
+            "uid",
+            "u@test.com",
+            "hello",
+        )
+        msgs = await model.get_chat_messages(workspace["id"])
+        assert len(msgs) == 2
+        assert msgs[0]["message_type"] == model.MSG_SYSTEM
+        assert msgs[1]["message_type"] == model.MSG_USER
 
     async def test_get_chat_messages_limit(self, workspace, user):
         for i in range(5):

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
 from fastapi import WebSocketDisconnect
 
 from klangk_backend import (
+    model,
     wshandler,
     container,
     workspaces as ws_mod,
@@ -753,7 +754,13 @@ class TestCleanupConnection:
             conn._idle_cb
         )
 
-        await conn.cleanup()
+        with patch.object(
+            model,
+            "add_chat_message",
+            new_callable=AsyncMock,
+            return_value={"id": "fake", "message": "left", "message_type": 2},
+        ):
+            await conn.cleanup()
 
         # Terminal for THIS connection should be stopped
         t.stop.assert_awaited_once()
@@ -1988,7 +1995,13 @@ class TestCleanupSubscriberRace:
         conn1.container_id = "cid-conc"
 
         # sock1 disconnects, sock2 remains
-        await conn1.cleanup()
+        with patch.object(
+            model,
+            "add_chat_message",
+            new_callable=AsyncMock,
+            return_value={"id": "fake", "message": "left", "message_type": 2},
+        ):
+            await conn1.cleanup()
 
         # Session should still exist because sock2 is still subscribed
         assert "ws-conc" in wshandler.state.sessions

--- a/src/frontend/e2e-tests/e2e/klangk.spec.ts
+++ b/src/frontend/e2e-tests/e2e/klangk.spec.ts
@@ -2085,8 +2085,12 @@ test.describe("Klangk E2E", () => {
 
     await page2.waitForTimeout(2000);
 
-    expect(memberChatMessages.length).toBeGreaterThan(0);
-    const received = JSON.parse(memberChatMessages[0]);
+    // Filter out system messages (message_type 2 = join/leave)
+    const userMessages = memberChatMessages
+      .map((s) => JSON.parse(s))
+      .filter((m: any) => m.type === "chat_message" && m.message_type !== 2);
+    expect(userMessages.length).toBeGreaterThan(0);
+    const received = userMessages[0];
     expect(received.type).toBe("chat_message");
     expect(received.message).toBe("hello from e2e");
     expect(received.user_email).toBe(ownerEmail);
@@ -2277,8 +2281,12 @@ test.describe("Klangk E2E", () => {
 
     await page1.waitForTimeout(2000);
 
-    expect(ownerChatMessages.length).toBeGreaterThan(0);
-    const chatMsg = JSON.parse(ownerChatMessages[0]);
+    // Filter out system messages (message_type 2 = join/leave)
+    const userChatMsgs = ownerChatMessages
+      .map((s) => JSON.parse(s))
+      .filter((m: any) => m.type === "chat_message" && m.message_type !== 2);
+    expect(userChatMsgs.length).toBeGreaterThan(0);
+    const chatMsg = userChatMsgs[0];
     expect(chatMsg.type).toBe("chat_message");
     expect(chatMsg.message).toContain(`@${memberEmail}`);
     expect(chatMsg.mentions).toBeDefined();

--- a/src/frontend/e2e-tests/e2e/klangk.spec.ts
+++ b/src/frontend/e2e-tests/e2e/klangk.spec.ts
@@ -2098,6 +2098,82 @@ test.describe("Klangk E2E", () => {
     });
   });
 
+  test("system chat messages on user join and leave", async ({
+    browser,
+    request,
+  }) => {
+    const ownerEmail = `join-owner-${Date.now()}@test.example.com`;
+    const memberEmail = `join-member-${Date.now()}@test.example.com`;
+    const { headers: ownerHeaders } = await registerUser(request, ownerEmail);
+    await registerUser(request, memberEmail);
+
+    const wsResp = await request.post(`${API_BASE}/workspaces`, {
+      headers: ownerHeaders,
+      data: { name: `e2e-joinleave-${Date.now()}` },
+    });
+    expect(wsResp.ok()).toBeTruthy();
+    const workspaceId = (await wsResp.json()).id;
+
+    await request.post(`${API_BASE}/workspaces/${workspaceId}/members`, {
+      headers: ownerHeaders,
+      data: { email: memberEmail },
+    });
+
+    const ctx1 = await browser.newContext();
+    const page1 = await ctx1.newPage();
+
+    // Collect system chat messages (message_type == 2) on the owner's page
+    const systemMessages: any[] = [];
+    page1.on("websocket", (ws) => {
+      ws.on("framereceived", (frame: { payload: string | Buffer }) => {
+        const text = frame.payload.toString();
+        if (text.includes("chat_message")) {
+          try {
+            const msg = JSON.parse(text);
+            if (msg.type === "chat_message" && msg.message_type === 2) {
+              systemMessages.push(msg);
+            }
+          } catch {}
+        }
+      });
+    });
+
+    await openWorkspace(page1, ownerEmail, workspaceId, {
+      waitForTerminal: true,
+    });
+
+    // Member joins — owner should see a "joined" system message
+    const ctx2 = await browser.newContext();
+    const page2 = await ctx2.newPage();
+    await openWorkspace(page2, memberEmail, workspaceId, {
+      waitForTerminal: true,
+    });
+
+    // Wait for join message to arrive
+    await page1.waitForTimeout(2000);
+    const joinMsgs = systemMessages.filter(
+      (m) => m.message.includes("joined") && m.message.includes(memberEmail),
+    );
+    expect(joinMsgs.length).toBeGreaterThan(0);
+    expect(joinMsgs[0].message).toBe(`${memberEmail} joined`);
+
+    // Member leaves — owner should see a "left" system message
+    const beforeLeave = systemMessages.length;
+    await ctx2.close();
+    await page1.waitForTimeout(2000);
+
+    const leaveMsgs = systemMessages.filter(
+      (m) => m.message.includes("left") && m.message.includes(memberEmail),
+    );
+    expect(leaveMsgs.length).toBeGreaterThan(0);
+    expect(leaveMsgs[0].message).toBe(`${memberEmail} left`);
+
+    await ctx1.close();
+    await request.delete(`${API_BASE}/workspaces/${workspaceId}`, {
+      headers: ownerHeaders,
+    });
+  });
+
   test("workspace_members broadcast on member add and chat @mention", async ({
     browser,
     request,

--- a/src/frontend/lib/chat/workspace_chat.dart
+++ b/src/frontend/lib/chat/workspace_chat.dart
@@ -594,11 +594,42 @@ class WorkspaceChatState extends State<WorkspaceChat> {
                       final msgUserId = msg['user_id'] as String?;
                       final isOwn = msgUserId == currentUserId;
                       final isDeleted = text == '<message deleted by author>';
+                      final messageType = msg['message_type'] as int? ?? 0;
+
+                      // System messages: centered, muted, no sender
+                      if (messageType == 2) {
+                        return Padding(
+                          padding: const EdgeInsets.only(bottom: 4),
+                          child: Center(
+                            child: Text(
+                              text,
+                              style: const TextStyle(
+                                color: KColors.textMuted,
+                                fontSize: 11,
+                                fontStyle: FontStyle.italic,
+                              ),
+                            ),
+                          ),
+                        );
+                      }
+
+                      // Agent messages: robot icon prefix, subtle tint
+                      final isAgent = messageType == 1;
+
                       return Padding(
                         padding: const EdgeInsets.only(bottom: 8),
                         child: Row(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
+                            if (isAgent)
+                              const Padding(
+                                padding: EdgeInsets.only(right: 6, top: 1),
+                                child: Icon(
+                                  Icons.smart_toy,
+                                  size: 14,
+                                  color: KColors.accentCyan,
+                                ),
+                              ),
                             Expanded(
                               child: _CollapsibleMessage(
                                 messageId: msg['id'] as String? ?? '',
@@ -622,7 +653,9 @@ class WorkspaceChatState extends State<WorkspaceChat> {
                                       email,
                                       style: TextStyle(
                                         fontWeight: FontWeight.bold,
-                                        color: _colorForEmail(email),
+                                        color: isAgent
+                                            ? KColors.accentCyan
+                                            : _colorForEmail(email),
                                         fontSize: 13,
                                       ),
                                     ),

--- a/src/frontend/test/workspace_chat_test.dart
+++ b/src/frontend/test/workspace_chat_test.dart
@@ -766,6 +766,75 @@ void main() {
       expect(data, contains('**@bob@test.com**'));
     });
 
+    testWidgets('system message renders centered and muted', (tester) async {
+      await tester.pumpWidget(buildChat());
+
+      await tester.runAsync(() async {
+        channel.serverSend({
+          'type': 'chat_message',
+          'id': 'msg-sys',
+          'user_email': 'alice@test.com',
+          'message': 'alice@test.com joined',
+          'message_type': 2,
+          'created_at': '2026-01-01 00:00:00',
+        });
+        await Future.delayed(Duration.zero);
+        await Future.delayed(Duration.zero);
+      });
+      await tester.pump();
+
+      // System message text is rendered
+      expect(find.text('alice@test.com joined'), findsOneWidget);
+      // Should be centered — wrapped in a Center widget
+      expect(find.byType(Center), findsWidgets);
+      // No delete button for system messages
+      expect(find.byIcon(Icons.close), findsNothing);
+    });
+
+    testWidgets('agent message renders with robot icon', (tester) async {
+      await tester.pumpWidget(buildChat());
+
+      await tester.runAsync(() async {
+        channel.serverSend({
+          'type': 'chat_message',
+          'id': 'msg-agent',
+          'user_email': 'agent@bot',
+          'message': 'I can help with that',
+          'message_type': 1,
+          'created_at': '2026-01-01 00:00:00',
+        });
+        await Future.delayed(Duration.zero);
+        await Future.delayed(Duration.zero);
+      });
+      await tester.pump();
+
+      // Agent message should have a smart_toy icon
+      expect(find.byIcon(Icons.smart_toy), findsOneWidget);
+      // Message text should be present
+      expect(find.byType(SelectableText), findsOneWidget);
+    });
+
+    testWidgets('user message renders without robot icon (default type)',
+        (tester) async {
+      await tester.pumpWidget(buildChat());
+
+      await tester.runAsync(() async {
+        channel.serverSend({
+          'type': 'chat_message',
+          'id': 'msg-user',
+          'user_email': 'alice@test.com',
+          'message': 'normal message',
+          'created_at': '2026-01-01 00:00:00',
+        });
+        await Future.delayed(Duration.zero);
+        await Future.delayed(Duration.zero);
+      });
+      await tester.pump();
+
+      // No robot icon for user messages
+      expect(find.byIcon(Icons.smart_toy), findsNothing);
+    });
+
     testWidgets('presence bar shows connected users', (tester) async {
       client.presenceUsers = [
         {'user_id': 'u1', 'user_email': 'alice@test.com'},


### PR DESCRIPTION
## Summary

- Add `message_type` integer column to `chat_messages` table (0=user, 1=agent, 2=system) with migration for existing DBs
- Backend emits system messages on user join (`"alice@test.com joined"`) and leave (`"alice@test.com left"`)
- Frontend renders each type distinctly:
  - **User** (0): unchanged (colored by sender)
  - **Agent** (1): robot icon, cyan accent color
  - **System** (2): centered, muted, italic, no sender attribution

## Test plan

- [x] Backend unit tests: message_type persisted and returned in add/get
- [x] Frontend unit tests: system, agent, and user message rendering
- [x] Playwright E2E: user A sees user B join and leave system messages
- [x] Backend E2E: join/leave broadcasts, no duplicate leave on multi-connect
- [x] Manual: verify join/leave messages appear in chat panel

Closes #183