### PR TITLE
fix(e2e): reduce flakiness in idle-timeout test

### DIFF
--- a/src/frontend/e2e-tests/e2e/helpers.ts
+++ b/src/frontend/e2e-tests/e2e/helpers.ts
@@ -300,7 +300,10 @@ export async function openWorkspace(
   page: Page,
   email: string,
   workspaceId: string,
-  { waitForTerminal = false }: { waitForTerminal?: boolean } = {},
+  {
+    waitForTerminal = false,
+    containerTimeout = 120_000,
+  }: { waitForTerminal?: boolean; containerTimeout?: number } = {},
 ) {
   // Set up WebSocket listener before login so we catch all WebSocket
   // connections.  A single framereceived handler watches for both
@@ -308,19 +311,21 @@ export async function openWorkspace(
   // race where a separate waitForTerminalReady listener misses the frame.
   let resolveContainer: () => void;
   let resolveTerminal: (() => void) | null = null;
+  const secs = Math.round(containerTimeout / 1000);
   const containerPromise = new Promise<void>((resolve, reject) => {
     resolveContainer = resolve;
     setTimeout(
-      () => reject(new Error("Container did not become ready within 120s")),
-      120_000,
+      () => reject(new Error(`Container did not become ready within ${secs}s`)),
+      containerTimeout,
     );
   });
   const terminalPromise = waitForTerminal
     ? new Promise<void>((resolve, reject) => {
         resolveTerminal = resolve;
         setTimeout(
-          () => reject(new Error("Terminal did not become ready within 120s")),
-          120_000,
+          () =>
+            reject(new Error(`Terminal did not become ready within ${secs}s`)),
+          containerTimeout,
         );
       })
     : Promise.resolve();
@@ -351,7 +356,10 @@ export async function createAndOpenWorkspace(
   page: Page,
   request: APIRequestContext,
   namePrefix: string,
-  { waitForTerminal = false }: { waitForTerminal?: boolean } = {},
+  {
+    waitForTerminal = false,
+    containerTimeout,
+  }: { waitForTerminal?: boolean; containerTimeout?: number } = {},
 ): Promise<{
   workspaceId: string;
   email: string;
@@ -366,7 +374,10 @@ export async function createAndOpenWorkspace(
     headers,
     namePrefix,
   );
-  await openWorkspace(page, email, workspaceId, { waitForTerminal });
+  await openWorkspace(page, email, workspaceId, {
+    waitForTerminal,
+    containerTimeout,
+  });
   return { workspaceId, email, token, headers, cleanup };
 }
 

--- a/src/frontend/e2e-tests/e2e/klangk.spec.ts
+++ b/src/frontend/e2e-tests/e2e/klangk.spec.ts
@@ -1106,56 +1106,64 @@ test.describe("Klangk E2E", () => {
     }
   });
 
-  test("container stops after idle timeout", async ({ page, request }) => {
-    test.skip(
-      !!process.env.KLANGK_CONTAINER_TEST_MODE,
-      "requires local podman access",
-    );
-    // Check if test mode is enabled
-    const getResp = await request.get(`${API_BASE}/api/test/idle-timeout`);
-    if (!getResp.ok()) {
-      test.skip(true, "KLANGK_TEST_MODE not enabled");
-      return;
-    }
+  test.describe("idle timeout", () => {
+    test.describe.configure({ retries: 1 });
 
-    const { workspaceId, email, headers, cleanup } =
-      await createAndOpenWorkspace(page, request, "e2e-idle-test");
-
-    // Set a short idle timeout for this workspace only
-    await request.post(`${API_BASE}/api/test/set-idle-timeout`, {
-      headers,
-      data: { seconds: 5, workspace_id: workspaceId },
-    });
-
-    try {
-      // Wait for the container to actually stop
-      let stopped = false;
-      for (let i = 0; i < 30; i++) {
-        if (dockerContainersForWorkspace(workspaceId).length === 0) {
-          stopped = true;
-          break;
-        }
-        await page.waitForTimeout(1000);
+    test("container stops after idle timeout", async ({ page, request }) => {
+      test.skip(
+        !!process.env.KLANGK_CONTAINER_TEST_MODE,
+        "requires local podman access",
+      );
+      // Check if test mode is enabled
+      const getResp = await request.get(`${API_BASE}/api/test/idle-timeout`);
+      if (!getResp.ok()) {
+        test.skip(true, "KLANGK_TEST_MODE not enabled");
+        return;
       }
-      expect(stopped).toBeTruthy();
 
-      // Reset per-workspace timeout so the restarted container isn't
-      // immediately killed again.
+      const { workspaceId, email, headers, cleanup } =
+        await createAndOpenWorkspace(page, request, "e2e-idle-test", {
+          containerTimeout: 180_000,
+        });
+
+      // Set a short idle timeout for this workspace only
       await request.post(`${API_BASE}/api/test/set-idle-timeout`, {
         headers,
-        data: { seconds: 300, workspace_id: workspaceId },
+        data: { seconds: 5, workspace_id: workspaceId },
       });
 
-      // Re-open the workspace using openWorkspace which handles login,
-      // navigation, WebSocket lifecycle, and container_ready properly.
-      await openWorkspace(page, email, workspaceId);
+      try {
+        // Wait for the container to actually stop
+        let stopped = false;
+        for (let i = 0; i < 30; i++) {
+          if (dockerContainersForWorkspace(workspaceId).length === 0) {
+            stopped = true;
+            break;
+          }
+          await page.waitForTimeout(1000);
+        }
+        expect(stopped).toBeTruthy();
 
-      expect(dockerContainersForWorkspace(workspaceId).length).toBeGreaterThan(
-        0,
-      );
-    } finally {
-      await cleanup();
-    }
+        // Reset per-workspace timeout so the restarted container isn't
+        // immediately killed again.
+        await request.post(`${API_BASE}/api/test/set-idle-timeout`, {
+          headers,
+          data: { seconds: 300, workspace_id: workspaceId },
+        });
+
+        // Re-open the workspace using openWorkspace which handles login,
+        // navigation, WebSocket lifecycle, and container_ready properly.
+        await openWorkspace(page, email, workspaceId, {
+          containerTimeout: 180_000,
+        });
+
+        expect(
+          dockerContainersForWorkspace(workspaceId).length,
+        ).toBeGreaterThan(0);
+      } finally {
+        await cleanup();
+      }
+    });
   });
 
   test("admin can list users, add/remove groups, and delete users", async ({


### PR DESCRIPTION
## Summary
- Add optional `containerTimeout` param to `openWorkspace` / `createAndOpenWorkspace` helpers (default 120s, backward compatible)
- Increase container ready timeout to 180s for the idle-timeout test, which starts containers twice and runs late in the suite when CI is under load
- Wrap in `test.describe` with `retries: 1` so a single timeout doesn't fail the run

## Test plan
- [ ] CI E2E passes (especially webkit, where this test was failing)
- [ ] Existing tests unaffected (helper signature is backward compatible)

Fixes #222