### PR TITLE
feat: per-workspace JWT auth for container→host endpoints

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -103,6 +103,7 @@ All settings can be overridden in `.env`. Defaults (where appropriate) are provi
 | `KLANGK_LLM_MODEL`                   |                                      | LLM model name                                                                                                                                                                             |
 | `KLANGK_JWT_SECRET`                  |                                      | JWT signing secret. A warning is logged at startup if unset or left as the insecure dev default.                                                                                           |
 | `KLANGK_PREVENT_INSECURE_JWT_SECRET` |                                      | Set to `1` to fail at startup if `KLANGK_JWT_SECRET` is unset or insecure. Recommended for production.                                                                                     |
+| `KLANGK_WORKSPACE_TOKEN_HOURS`       | `24`                                 | Lifetime in hours for per-workspace JWTs injected into containers. Containers use this token to authenticate to /llm-proxy and /api/workspace/post-chat-message.                           |
 | `KLANGK_DEFAULT_USER`                |                                      | Auto-seeded admin email on startup                                                                                                                                                         |
 | `KLANGK_DEFAULT_PASSWORD`            |                                      | Auto-seeded password on startup (omit to generate random; supports `file:` prefix)                                                                                                         |
 | `KLANGK_MIN_PASSWORD_LENGTH`         | `4`                                  | Minimum password length                                                                                                                                                                    |
@@ -477,6 +478,16 @@ KLANGK_OIDC_LOGIN_HOOK=klangk_backend.oidc.example_require_verified_email
 # Map Keycloak klangk-admin role to the admin group
 KLANGK_OIDC_LOGIN_HOOK=klangk_backend.oidc.example_admin_hook
 ```
+
+## Workspace JWT Auth
+
+Each container receives a `KLANGK_WORKSPACE_TOKEN` environment variable at startup — a signed JWT identifying the workspace. Containers include this token as `Authorization: Bearer <token>` in HTTP requests to the host. Nginx validates it via `auth_request` before allowing access to:
+
+- `/llm-proxy` — LLM API proxy (injects the real API key upstream)
+- `/api/browser-delegate` — browser-delegate bridge for Pi extensions
+- `/api/workspace/post-chat-message` — containers can post chat messages
+
+The token uses the same `KLANGK_JWT_SECRET` as user JWTs but is distinguished by a `purpose: "workspace"` claim. Token lifetime is controlled by `KLANGK_WORKSPACE_TOKEN_HOURS` (default 24h). IP-based ACLs (`CONTAINER_ACL`) remain as defense-in-depth alongside JWT validation.
 
 ## Authorization (ACL System)
 

--- a/scripts/nginx.sh
+++ b/scripts/nginx.sh
@@ -90,6 +90,7 @@ if [ -n "${KLANGK_LLM_BASE_URL:-}" ]; then
   LLM_BLOCK="
     location ~ ^/llm-proxy/(.*)\$ {
 ${CONTAINER_ACL}
+      auth_request /auth/verify-workspace-token;
       resolver ${DNS_RESOLVERS} valid=30s;
       set \$llm_backend ${KLANGK_LLM_BASE_URL}/\$1;
       proxy_pass \$llm_backend;
@@ -158,6 +159,7 @@ ${LLM_BLOCK}
     # before the backend's own idle timeout fires.
     location = /api/browser-delegate {
 ${CONTAINER_ACL}
+      auth_request /auth/verify-workspace-token;
       proxy_pass http://127.0.0.1:${KLANGK_PORT}/api/browser-delegate;
       proxy_set_header Host \$http_host;
       proxy_set_header X-Real-IP \$remote_addr;
@@ -166,6 +168,26 @@ ${CONTAINER_ACL}
       proxy_read_timeout 300s;
       proxy_send_timeout 300s;
       proxy_buffering off;
+    }
+
+    # Container-to-chat API: containers post chat messages via workspace JWT.
+    location = /api/workspace/post-chat-message {
+${CONTAINER_ACL}
+      auth_request /auth/verify-workspace-token;
+      proxy_pass http://127.0.0.1:${KLANGK_PORT}/api/workspace/post-chat-message;
+      proxy_set_header Host \$http_host;
+      proxy_set_header X-Real-IP \$remote_addr;
+      proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+      proxy_http_version 1.1;
+    }
+
+    # Workspace token verification subrequest (nginx auth_request target).
+    location = /auth/verify-workspace-token {
+      internal;
+      proxy_pass http://127.0.0.1:${KLANGK_PORT}/auth/verify-workspace-token;
+      proxy_pass_request_body off;
+      proxy_set_header Content-Length "";
+      proxy_set_header Authorization \$http_authorization;
     }
 
     location / {

--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -56,6 +56,20 @@ async def health():
     return {"status": "ok"}
 
 
+@router.get("/auth/verify-workspace-token")
+async def verify_workspace_token(request: Request):
+    """Validate a workspace JWT. Used by nginx auth_request to gate
+    container→host endpoints (/llm-proxy, /api/browser-delegate, etc.)."""
+    authorization = request.headers.get("authorization", "")
+    if not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Missing token")
+    token = authorization[7:]
+    workspace_id = auth.decode_workspace_token(token)
+    if workspace_id is None:
+        raise HTTPException(status_code=401, detail="Invalid workspace token")
+    return {"status": "ok", "workspace_id": workspace_id}
+
+
 @router.get("/version")
 async def version():
     """Return build version info (version, commit, build timestamp)."""
@@ -1757,6 +1771,49 @@ async def browser_delegate_stream(body: BrowserDelegateRequest):
         ),
         media_type="application/x-ndjson",
     )
+
+
+# --- Container-to-chat API (workspace JWT auth) ---
+
+
+class WorkspaceChatRequest(BaseModel):
+    message: str
+
+
+@router.post("/api/workspace/post-chat-message")
+async def workspace_chat(body: WorkspaceChatRequest, request: Request):
+    """Post a chat message from a container using a workspace JWT.
+
+    The message is stored as MSG_AGENT and broadcast to all connected
+    WebSocket subscribers in the workspace.
+    """
+    authorization = request.headers.get("authorization", "")
+    if not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    token = authorization[7:]
+    workspace_id = auth.decode_workspace_token(token)
+    if workspace_id is None:
+        raise HTTPException(status_code=401, detail="Invalid workspace token")
+
+    workspace = await model.get_workspace_by_id(workspace_id)
+    if workspace is None:
+        raise HTTPException(status_code=404, detail="Workspace not found")
+
+    text = body.message.strip()
+    if not text:
+        raise HTTPException(status_code=400, detail="Message cannot be empty")
+
+    chat_msg = await model.add_chat_message(
+        workspace_id,
+        "agent",
+        "agent",
+        text,
+        message_type=model.MSG_AGENT,
+    )
+    session = wshandler.state.get_session(workspace_id)
+    if session:
+        session.broadcast({"type": "chat_message", **chat_msg})
+    return chat_msg
 
 
 # --- Admin endpoints (require admin role) ---

--- a/src/backend/klangk_backend/auth.py
+++ b/src/backend/klangk_backend/auth.py
@@ -310,6 +310,31 @@ def decode_invitation_token(token: str) -> tuple[str, str] | None:
         return None
 
 
+WORKSPACE_TOKEN_EXPIRE_HOURS = int(
+    resolve_env_secret("KLANGK_WORKSPACE_TOKEN_HOURS", "24")
+)
+
+
+def create_workspace_token(workspace_id: str) -> str:
+    """Create a JWT token identifying a workspace for container→host auth."""
+    expire = datetime.now(timezone.utc) + timedelta(
+        hours=WORKSPACE_TOKEN_EXPIRE_HOURS
+    )
+    payload = {"sub": workspace_id, "purpose": "workspace", "exp": expire}
+    return jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM)
+
+
+def decode_workspace_token(token: str) -> str | None:
+    """Decode a workspace token. Returns workspace_id or None if invalid."""
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        if payload.get("purpose") != "workspace":
+            return None
+        return payload.get("sub")
+    except JWTError:
+        return None
+
+
 async def get_current_user(
     credentials: HTTPAuthorizationCredentials | None = Depends(security),
 ) -> dict:

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -6,7 +6,7 @@ import os
 import time
 import uuid
 
-from . import model, podman, util
+from . import auth, model, podman, util
 
 logger = logging.getLogger(__name__)
 
@@ -411,6 +411,8 @@ class ContainerRegistry:
         env_vars.append(f"KLANGK_HOSTING_HOSTNAME={hosting_hostname}")
         env_vars.append(f"KLANGK_HOSTING_PROTO={hosting_proto}")
         env_vars.append(f"KLANGK_HOSTING_BASE_PATH={hosting_base_path}")
+        workspace_token = auth.create_workspace_token(workspace_id)
+        env_vars.append(f"KLANGK_WORKSPACE_TOKEN={workspace_token}")
 
         if extra_env:
             for k, v in extra_env.items():

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -59,6 +59,105 @@ class TestHealth:
         assert resp.json() == {"status": "ok"}
 
 
+class TestVerifyWorkspaceToken:
+    async def test_valid_workspace_token(self, client):
+        token = auth.create_workspace_token("ws-123")
+        resp = await client.get(
+            "/auth/verify-workspace-token",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["workspace_id"] == "ws-123"
+
+    async def test_missing_auth_header(self, client):
+        resp = await client.get("/auth/verify-workspace-token")
+        assert resp.status_code == 401
+
+    async def test_invalid_token(self, client):
+        resp = await client.get(
+            "/auth/verify-workspace-token",
+            headers={"Authorization": "Bearer garbage"},
+        )
+        assert resp.status_code == 401
+
+    async def test_user_jwt_rejected(self, client):
+        user_token = auth.create_token("user-1", "u@test.com")
+        resp = await client.get(
+            "/auth/verify-workspace-token",
+            headers={"Authorization": f"Bearer {user_token}"},
+        )
+        assert resp.status_code == 401
+
+
+class TestWorkspaceChat:
+    async def test_post_agent_message(self, client, user):
+        workspace = await model.create_workspace(user["id"], "chat-ws")
+        token = auth.create_workspace_token(workspace["id"])
+        resp = await client.post(
+            "/api/workspace/post-chat-message",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"message": "hello from agent"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["message"] == "hello from agent"
+        assert data["message_type"] == model.MSG_AGENT
+        assert data["workspace_id"] == workspace["id"]
+
+    async def test_broadcasts_to_websocket(self, client, user):
+        workspace = await model.create_workspace(user["id"], "bcast-ws")
+        token = auth.create_workspace_token(workspace["id"])
+        session = wshandler.state.get_or_create_session(workspace["id"])
+        mock_sock = MagicMock()
+        session.subscribers.add(mock_sock)
+
+        await client.post(
+            "/api/workspace/post-chat-message",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"message": "broadcast test"},
+        )
+
+        mock_sock.send_json.assert_called_once()
+        sent = mock_sock.send_json.call_args[0][0]
+        assert sent["type"] == "chat_message"
+        assert sent["message"] == "broadcast test"
+
+        wshandler.state.sessions.pop(workspace["id"], None)
+
+    async def test_missing_auth(self, client):
+        resp = await client.post(
+            "/api/workspace/post-chat-message", json={"message": "hi"}
+        )
+        assert resp.status_code == 401
+
+    async def test_invalid_token(self, client):
+        resp = await client.post(
+            "/api/workspace/post-chat-message",
+            headers={"Authorization": "Bearer garbage"},
+            json={"message": "hi"},
+        )
+        assert resp.status_code == 401
+
+    async def test_workspace_not_found(self, client):
+        token = auth.create_workspace_token("nonexistent-ws")
+        resp = await client.post(
+            "/api/workspace/post-chat-message",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"message": "hi"},
+        )
+        assert resp.status_code == 404
+
+    async def test_empty_message_rejected(self, client, user):
+        workspace = await model.create_workspace(user["id"], "empty-ws")
+        token = auth.create_workspace_token(workspace["id"])
+        resp = await client.post(
+            "/api/workspace/post-chat-message",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"message": "   "},
+        )
+        assert resp.status_code == 400
+
+
 class TestVersion:
     async def test_version_from_file(self, client, tmp_path, monkeypatch):
         version_file = tmp_path / "version.json"

--- a/src/backend/tests/test_auth.py
+++ b/src/backend/tests/test_auth.py
@@ -387,6 +387,28 @@ class TestPasswordReset:
         assert auth.decode_password_reset_token(verify) is None
 
 
+class TestWorkspaceToken:
+    def test_create_and_decode_workspace_token(self):
+        token = auth.create_workspace_token("ws-123")
+        assert auth.decode_workspace_token(token) == "ws-123"
+
+    def test_decode_invalid_token(self):
+        assert auth.decode_workspace_token("garbage") is None
+
+    def test_user_token_rejected(self):
+        user_token = auth.create_token("user-1", "u@test.com")
+        assert auth.decode_workspace_token(user_token) is None
+
+    def test_verify_token_rejected(self):
+        verify_token = auth.create_verification_token("user-1")
+        assert auth.decode_workspace_token(verify_token) is None
+
+    def test_workspace_token_rejected_by_other_decoders(self):
+        ws_token = auth.create_workspace_token("ws-123")
+        assert auth.decode_verification_token(ws_token) is None
+        assert auth.decode_password_reset_token(ws_token) is None
+
+
 class TestTokenValidation:
     async def test_get_user_from_valid_token(self, user):
         token = auth.create_token(user["id"], user["email"])

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -415,6 +415,22 @@ class TestStartContainer:
         # host.containers.internal must be resolvable
         assert "host.containers.internal:host-gateway" in kwargs["add_hosts"]
 
+    async def test_workspace_token_injected(self, workspace):
+        """Container env includes a valid KLANGK_WORKSPACE_TOKEN JWT."""
+        from klangk_backend import auth
+
+        with patch_podman() as p:
+            await container.registry.start_container(
+                workspace["id"], "/tmp/ws", "/tmp/home"
+            )
+        kwargs = p.create_container.call_args.kwargs
+        env_dict = dict(e.split("=", 1) for e in kwargs["env"])
+        assert "KLANGK_WORKSPACE_TOKEN" in env_dict
+        decoded_ws = auth.decode_workspace_token(
+            env_dict["KLANGK_WORKSPACE_TOKEN"]
+        )
+        assert decoded_ws == workspace["id"]
+
     async def test_pull_policy_default_never(self, workspace):
         with patch_podman() as p:
             await container.registry.start_container(

--- a/src/bridge/index.js
+++ b/src/bridge/index.js
@@ -8,6 +8,7 @@
 function getConfig() {
   const bridgeUrl = process.env.KLANGK_BRIDGE_URL;
   const token = process.env.KLANGK_BRIDGE_TOKEN;
+  const workspaceToken = process.env.KLANGK_WORKSPACE_TOKEN;
   if (!bridgeUrl) {
     throw new Error(
       "@klangk/bridge: KLANGK_BRIDGE_URL is not set. " +
@@ -23,6 +24,7 @@ function getConfig() {
   return {
     bridgeUrl: `${bridgeUrl}/api/browser-delegate`,
     token,
+    workspaceToken: workspaceToken || null,
   };
 }
 
@@ -37,11 +39,16 @@ function getConfig() {
  * @returns {Promise<{status: number, headers: Record<string, string>, body: string}>}
  */
 async function browserFetch(url, options = {}) {
-  const { bridgeUrl, token } = getConfig();
+  const { bridgeUrl, token, workspaceToken } = getConfig();
+
+  const headers = { "Content-Type": "application/json" };
+  if (workspaceToken) {
+    headers["Authorization"] = `Bearer ${workspaceToken}`;
+  }
 
   const resp = await fetch(bridgeUrl, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers,
     body: JSON.stringify({
       action: "fetch",
       token,
@@ -75,14 +82,19 @@ async function browserFetch(url, options = {}) {
  * @returns {Promise<{status: string}>}
  */
 async function browserAction(action, payload = {}) {
-  const { bridgeUrl, token } = getConfig();
+  const { bridgeUrl, token, workspaceToken } = getConfig();
 
   // Prevent payload from overwriting action or token
   const { action: _a, token: _t, ...safePayload } = payload;
 
+  const headers = { "Content-Type": "application/json" };
+  if (workspaceToken) {
+    headers["Authorization"] = `Bearer ${workspaceToken}`;
+  }
+
   const resp = await fetch(bridgeUrl, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers,
     body: JSON.stringify({
       action,
       token,

--- a/src/containers/workspace/setup_clankers.py
+++ b/src/containers/workspace/setup_clankers.py
@@ -135,10 +135,11 @@ def merge_models_json():
         models = {}
 
     providers = models.setdefault("providers", {})
+    workspace_token = os.environ.get("KLANGK_WORKSPACE_TOKEN", "proxy")
     providers["llm-proxy"] = {
         "baseUrl": proxy_url,
         "api": "openai-completions",
-        "apiKey": "proxy",
+        "apiKey": workspace_token,
         # Only advertise a model when one is configured. Pi's schema rejects an
         # empty id ("must not have fewer than 1 characters"), so when
         # KLANGK_LLM_MODEL is unset we write an empty model list instead of an


### PR DESCRIPTION
## Summary

- Mint per-workspace JWT (`KLANGK_WORKSPACE_TOKEN`) at container start
- Gate `/llm-proxy`, `/api/browser-delegate`, and new `/api/workspace/post-chat-message` via nginx `auth_request` + IP ACL
- Containers can post chat messages (MSG_AGENT) via REST API
- Token expiry configurable via `KLANGK_WORKSPACE_TOKEN_HOURS` (default 24h)
- Container-side: Pi uses workspace token as apiKey, bridge sends it as Authorization header

## Files changed

| File | Changes |
|------|---------|
| `auth.py` | `create_workspace_token` / `decode_workspace_token` |
| `container.py` | Inject `KLANGK_WORKSPACE_TOKEN` env var |
| `api.py` | `GET /auth/verify-workspace-token`, `POST /api/workspace/post-chat-message` |
| `nginx.sh` | `auth_request` on container endpoints, internal verify location |
| `setup_clankers.py` | Use workspace token as Pi apiKey |
| `src/bridge/index.js` | Send workspace token as Authorization header |
| `HACKING.md` | Document workspace JWT auth section + env var |

## Test plan

- [x] 1168 backend tests pass, 100% coverage
- [x] Auth tests: roundtrip, cross-token rejection
- [x] API tests: verify endpoint, chat POST, error cases, WS broadcast
- [x] Container tests: token injected in env vars
- [ ] Manual: curl from container to `/api/workspace/post-chat-message`

Closes #229