### PR TITLE
feat: chat history pagination — load older messages on scroll

### DIFF
--- a/src/backend/klangk_backend/model.py
+++ b/src/backend/klangk_backend/model.py
@@ -1452,6 +1452,69 @@ async def delete_chat_message(message_id: str, user_id: str) -> bool:
         await db.close()
 
 
+async def get_chat_messages_before(
+    workspace_id: str, before_id: str, limit: int = 50
+) -> list[dict]:
+    """Get older chat messages before a given message ID."""
+    db = await get_db()
+    try:
+        # Get the created_at and rowid of the anchor message
+        cursor = await db.execute(
+            "SELECT created_at, rowid FROM chat_messages WHERE id = ?",
+            (before_id,),
+        )
+        anchor = await cursor.fetchone()
+        if anchor is None:
+            return []
+        anchor_ts = anchor["created_at"]
+        anchor_rowid = anchor["rowid"]
+
+        cursor = await db.execute(
+            "SELECT id, workspace_id, user_id, user_email, message,"
+            " message_type, created_at"
+            " FROM chat_messages WHERE workspace_id = ?"
+            " AND (created_at < ? OR (created_at = ? AND rowid < ?))"
+            " ORDER BY created_at DESC, rowid DESC LIMIT ?",
+            (workspace_id, anchor_ts, anchor_ts, anchor_rowid, limit),
+        )
+        rows = await cursor.fetchall()
+        messages = list(
+            reversed(
+                [
+                    {
+                        "id": row["id"],
+                        "workspace_id": row["workspace_id"],
+                        "user_id": row["user_id"],
+                        "user_email": row["user_email"],
+                        "message": row["message"],
+                        "message_type": row["message_type"],
+                        "created_at": row["created_at"],
+                    }
+                    for row in rows
+                ]
+            )
+        )
+        if messages:
+            msg_ids = [m["id"] for m in messages]
+            placeholders = ",".join("?" for _ in msg_ids)
+            cursor = await db.execute(
+                "SELECT message_id, user_id FROM chat_mentions"
+                " WHERE message_id IN (" + placeholders + ")",
+                msg_ids,
+            )
+            mention_rows = await cursor.fetchall()
+            mentions_by_msg: dict[str, list[str]] = {}
+            for mr in mention_rows:
+                mentions_by_msg.setdefault(mr["message_id"], []).append(
+                    mr["user_id"]
+                )
+            for m in messages:
+                m["mentions"] = mentions_by_msg.get(m["id"], [])
+        return messages
+    finally:
+        await db.close()
+
+
 async def get_chat_messages(workspace_id: str, limit: int = 50) -> list[dict]:
     """Get the most recent chat messages for a workspace."""
     db = await get_db()

--- a/src/backend/klangk_backend/wshandler.py
+++ b/src/backend/klangk_backend/wshandler.py
@@ -875,6 +875,25 @@ class Connection:
                     }
                 )
 
+    async def handle_chat_load_more(self, msg: dict) -> None:
+        workspace_id = self.workspace_id
+        if not workspace_id:
+            return
+        before_id = msg.get("before_id", "")
+        if not before_id:
+            return
+        limit = min(msg.get("limit", 50), 100)
+        messages = await model.get_chat_messages_before(
+            workspace_id, before_id, limit
+        )
+        self.sock.send_json(
+            {
+                "type": "chat_history_page",
+                "messages": messages,
+                "has_more": len(messages) == limit,
+            }
+        )
+
     async def handle_ui_ready(self) -> None:
         if self.workspace_id:
             sess = state.get_session(self.workspace_id)
@@ -1081,6 +1100,8 @@ async def handle_websocket(websocket: WebSocket) -> None:
                 await conn.handle_chat_send(msg)
             elif cmd == "chat_delete":
                 await conn.handle_chat_delete(msg)
+            elif cmd == "chat_load_more":
+                await conn.handle_chat_load_more(msg)
             elif cmd == "browser_response":
                 state.handle_browser_response(msg, safe_ws)
             elif cmd == "browser_chunk":

--- a/src/backend/tests/test_model.py
+++ b/src/backend/tests/test_model.py
@@ -649,6 +649,72 @@ class TestChatMessages:
         assert msgs[0]["message"] == "mine"
 
 
+class TestChatMessagesPagination:
+    async def test_get_messages_before(self, workspace, user):
+        msgs = []
+        for i in range(5):
+            msgs.append(
+                await model.add_chat_message(
+                    workspace["id"], "uid", "u@test.com", f"msg{i}"
+                )
+            )
+        # Load messages before the last one
+        older = await model.get_chat_messages_before(
+            workspace["id"], msgs[4]["id"], limit=50
+        )
+        assert len(older) == 4
+        assert older[0]["message"] == "msg0"
+        assert older[3]["message"] == "msg3"
+
+    async def test_get_messages_before_with_limit(self, workspace, user):
+        msgs = []
+        for i in range(5):
+            msgs.append(
+                await model.add_chat_message(
+                    workspace["id"], "uid", "u@test.com", f"msg{i}"
+                )
+            )
+        older = await model.get_chat_messages_before(
+            workspace["id"], msgs[4]["id"], limit=2
+        )
+        assert len(older) == 2
+        assert older[0]["message"] == "msg2"
+        assert older[1]["message"] == "msg3"
+
+    async def test_get_messages_before_invalid_id(self, workspace, user):
+        older = await model.get_chat_messages_before(
+            workspace["id"], "nonexistent", limit=50
+        )
+        assert older == []
+
+    async def test_get_messages_before_includes_mentions(
+        self, workspace, user
+    ):
+        # Create a user and add ACL so mention resolution finds them
+        target = await model.create_user(
+            "mention-pag@test.com", "pass", verified=True
+        )
+        await model.add_acl_entry(
+            f"/workspaces/{workspace['id']}",
+            0,
+            model.ACTION_ALLOW,
+            "*",
+            model.PRINCIPAL_USER,
+            user_id=target["id"],
+        )
+        await model.add_chat_message(
+            workspace["id"], "uid", "u@test.com", f"hey @{target['email']}"
+        )
+        anchor = await model.add_chat_message(
+            workspace["id"], "uid", "u@test.com", "anchor"
+        )
+        older = await model.get_chat_messages_before(
+            workspace["id"], anchor["id"]
+        )
+        assert len(older) == 1
+        assert len(older[0]["mentions"]) > 0
+
+
 class TestChatMentions:
     async def test_mention_workspace_owner(self, workspace, user):
         """@mentioning the workspace owner resolves to their user ID."""

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -1522,6 +1522,27 @@ class TestExecDispatch:
         mock.assert_awaited_once()
 
 
+class TestChatLoadMoreDispatch:
+    async def test_dispatch_chat_load_more(self, user):
+        from klangk_backend import auth as auth_mod
+
+        token = auth_mod.create_token(user["id"], user["email"])
+        websocket = _mock_raw_sock(query_params={"token": token})
+        websocket.receive_text = AsyncMock(
+            side_effect=[
+                json.dumps(
+                    {"cmd": "chat_load_more", "before_id": "x", "limit": 10}
+                ),
+                WebSocketDisconnect(),
+            ]
+        )
+        with patch.object(
+            Connection, "handle_chat_load_more", new_callable=AsyncMock
+        ) as mock:
+            await handle_websocket(websocket)
+        mock.assert_awaited_once()
+
+
 class TestHandleHeartbeat:
     async def test_records_activity(self):
         conn = _base_conn()
@@ -2575,6 +2596,41 @@ class TestChatSend:
         assert len(history) == 1
         assert len(history[0]["messages"]) == 1
         assert history[0]["messages"][0]["message"] == "old message"
+
+    async def test_chat_load_more(self, workspace, user):
+        from klangk_backend import model
+
+        msgs = []
+        for i in range(5):
+            msgs.append(
+                await model.add_chat_message(
+                    workspace["id"], "uid", "u@test.com", f"msg{i}"
+                )
+            )
+        sock = _mock_sock()
+        conn = _base_conn(user=user, ws=sock)
+        conn.workspace_id = workspace["id"]
+        await conn.handle_chat_load_more(
+            {"before_id": msgs[4]["id"], "limit": 2}
+        )
+        sent = sock.send_json.call_args[0][0]
+        assert sent["type"] == "chat_history_page"
+        assert len(sent["messages"]) == 2
+        assert sent["messages"][0]["message"] == "msg2"
+        assert sent["has_more"] is True
+
+    async def test_chat_load_more_no_workspace(self):
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock)
+        await conn.handle_chat_load_more({"before_id": "x"})
+        sock.send_json.assert_not_called()
+
+    async def test_chat_load_more_no_before_id(self, workspace, user):
+        sock = _mock_sock()
+        conn = _base_conn(user=user, ws=sock)
+        conn.workspace_id = workspace["id"]
+        await conn.handle_chat_load_more({})
+        sock.send_json.assert_not_called()
 
     async def test_workspace_members_on_connect(self, user):
         """Workspace members list is sent on connect."""

--- a/src/frontend/lib/chat/workspace_chat.dart
+++ b/src/frontend/lib/chat/workspace_chat.dart
@@ -38,9 +38,12 @@ class WorkspaceChatState extends State<WorkspaceChat> {
   final _textController = TextEditingController();
   final _inputFocusNode = FocusNode(debugLabel: 'workspace-chat-input');
   StreamSubscription<Map<String, dynamic>>? _chatSub;
+  StreamSubscription<Map<String, dynamic>>? _historyPageSub;
   int _unreadCount = 0;
   bool _isVisible = false;
   bool _hasMention = false;
+  bool _loadingOlder = false;
+  bool _hasMore = true;
 
   // Expanded message IDs (for long message truncation)
   final Set<String> _expandedMessages = {};
@@ -65,6 +68,8 @@ class WorkspaceChatState extends State<WorkspaceChat> {
       _messages.addAll(widget.wsClient.chatHistory);
     }
     _chatSub = widget.wsClient.chatMessages.listen(_onMessage);
+    _historyPageSub = widget.wsClient.chatHistoryPages.listen(_onHistoryPage);
+    _scrollController.addListener(_onScroll);
     _textController.addListener(_onTextChanged);
     widget.wsClient.addListener(_onPresenceChanged);
     _inputFocusNode.onKeyEvent = _handleKeyEvent;
@@ -128,6 +133,59 @@ class WorkspaceChatState extends State<WorkspaceChat> {
           duration: const Duration(milliseconds: 150),
           curve: Curves.easeOut,
         );
+      }
+    });
+  }
+
+  void _onScroll() {
+    if (!_hasMore || _loadingOlder) return;
+    if (!_scrollController.hasClients) return;
+    if (_scrollController.position.pixels <= 0 && _messages.isNotEmpty) {
+      _loadOlderMessages();
+    }
+  }
+
+  void _loadOlderMessages() {
+    final oldestId = _messages.first['id'] as String?;
+    if (oldestId == null) return;
+    setState(() => _loadingOlder = true);
+    widget.wsClient.sendChatLoadMore(oldestId);
+  }
+
+  void _onHistoryPage(Map<String, dynamic> page) {
+    if (!mounted) return;
+    final messages = page['messages'] as List? ?? [];
+    final hasMore = page['has_more'] as bool? ?? false;
+
+    if (messages.isEmpty) {
+      setState(() {
+        _loadingOlder = false;
+        _hasMore = false;
+      });
+      return;
+    }
+
+    // Preserve scroll position: measure before prepending, restore after.
+    final scrollBefore = _scrollController.hasClients
+        ? _scrollController.position.pixels
+        : 0.0;
+    final maxBefore = _scrollController.hasClients
+        ? _scrollController.position.maxScrollExtent
+        : 0.0;
+
+    setState(() {
+      final older = messages.cast<Map<String, dynamic>>();
+      _messages.insertAll(0, older);
+      _loadingOlder = false;
+      _hasMore = hasMore;
+    });
+
+    // After rebuild, restore scroll so the view doesn't jump.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_scrollController.hasClients) {
+        final maxAfter = _scrollController.position.maxScrollExtent;
+        final delta = maxAfter - maxBefore;
+        _scrollController.jumpTo(scrollBefore + delta);
       }
     });
   }
@@ -574,6 +632,8 @@ class WorkspaceChatState extends State<WorkspaceChat> {
     widget.wsClient.removeListener(_onPresenceChanged);
     _hideAutocomplete();
     _chatSub?.cancel();
+    _historyPageSub?.cancel();
+    _scrollController.removeListener(_onScroll);
     _scrollController.dispose();
     _textController.removeListener(_onTextChanged);
     _textController.dispose();
@@ -605,9 +665,22 @@ class WorkspaceChatState extends State<WorkspaceChat> {
                       horizontal: 12,
                       vertical: 8,
                     ),
-                    itemCount: _messages.length,
+                    itemCount: _messages.length + (_loadingOlder ? 1 : 0),
                     itemBuilder: (context, index) {
-                      final msg = _messages[index];
+                      if (_loadingOlder && index == 0) {
+                        return const Padding(
+                          padding: EdgeInsets.symmetric(vertical: 8),
+                          child: Center(
+                            child: SizedBox(
+                              width: 16,
+                              height: 16,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            ),
+                          ),
+                        );
+                      }
+                      final msgIndex = _loadingOlder ? index - 1 : index;
+                      final msg = _messages[msgIndex];
                       final email = msg['user_email'] as String? ?? '';
                       final text = msg['message'] as String? ?? '';
                       final createdAt = _formatTime(

--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -12,11 +12,8 @@ class WsDebugEntry {
   final String summary;
   final Map<String, dynamic>? data;
 
-  WsDebugEntry({
-    required this.direction,
-    required this.summary,
-    this.data,
-  }) : timestamp = DateTime.now();
+  WsDebugEntry({required this.direction, required this.summary, this.data})
+    : timestamp = DateTime.now();
 }
 
 /// Manages WebSocket connection to the Klangk backend, sending commands
@@ -76,6 +73,12 @@ class WsClient extends ChangeNotifier {
   /// Chat messages (individual and history) from the backend.
   Stream<Map<String, dynamic>> get chatMessages => _chatController.stream;
 
+  /// Older chat history pages loaded on demand.
+  final _chatHistoryPageController =
+      StreamController<Map<String, dynamic>>.broadcast();
+  Stream<Map<String, dynamic>> get chatHistoryPages =>
+      _chatHistoryPageController.stream;
+
   /// Custom events from the backend (container_ready, container_stopped, etc.)
   Stream<Map<String, dynamic>> get customEvents =>
       _customEventController.stream;
@@ -129,11 +132,9 @@ class WsClient extends ChangeNotifier {
             final summary = type == 'event'
                 ? 'event:${(json['event'] as Map?)?['name'] ?? '?'}'
                 : type ?? '?';
-            _debugLogController.add(WsDebugEntry(
-              direction: 'RECV',
-              summary: summary,
-              data: json,
-            ));
+            _debugLogController.add(
+              WsDebugEntry(direction: 'RECV', summary: summary, data: json),
+            );
           }
 
           if (type == 'workspace_ready') {
@@ -157,6 +158,8 @@ class WsClient extends ChangeNotifier {
               chatHistory.add(msg);
               _chatController.add(msg);
             }
+          } else if (type == 'chat_history_page') {
+            _chatHistoryPageController.add(json);
           } else if (type == 'chat_updated') {
             _chatController.add(json);
           } else if (type == 'workspace_members') {
@@ -179,8 +182,9 @@ class WsClient extends ChangeNotifier {
           } else if (type == 'presence_leave') {
             final uid = json['user_id'] as String?;
             if (uid != null) {
-              presenceUsers =
-                  presenceUsers.where((u) => u['user_id'] != uid).toList();
+              presenceUsers = presenceUsers
+                  .where((u) => u['user_id'] != uid)
+                  .toList();
               notifyListeners();
             }
           } else if (type == 'event') {
@@ -218,11 +222,9 @@ class WsClient extends ChangeNotifier {
     final cmd = msg['cmd'] as String? ?? '?';
     // Skip noisy terminal_input from debug log
     if (cmd != 'terminal_input') {
-      _debugLogController.add(WsDebugEntry(
-        direction: 'SEND',
-        summary: cmd,
-        data: msg,
-      ));
+      _debugLogController.add(
+        WsDebugEntry(direction: 'SEND', summary: cmd, data: msg),
+      );
     }
     _channel!.sink.add(jsonEncode(msg));
   }
@@ -273,6 +275,10 @@ class WsClient extends ChangeNotifier {
     _send({'cmd': 'chat_send', 'message': text});
   }
 
+  void sendChatLoadMore(String beforeId, {int limit = 50}) {
+    _send({'cmd': 'chat_load_more', 'before_id': beforeId, 'limit': limit});
+  }
+
   void sendChatDelete(String messageId) {
     _send({'cmd': 'chat_delete', 'message_id': messageId});
   }
@@ -307,6 +313,7 @@ class WsClient extends ChangeNotifier {
     _terminalOutputController.close();
     _browserRequestController.close();
     _chatController.close();
+    _chatHistoryPageController.close();
     _customEventController.close();
     _debugLogController.close();
     super.dispose();

--- a/src/frontend/test/workspace_chat_test.dart
+++ b/src/frontend/test/workspace_chat_test.dart
@@ -836,8 +836,9 @@ void main() {
       expect(find.byType(SelectableText), findsOneWidget);
     });
 
-    testWidgets('user message renders without robot icon (default type)',
-        (tester) async {
+    testWidgets('user message renders without robot icon (default type)', (
+      tester,
+    ) async {
       await tester.pumpWidget(buildChat());
 
       await tester.runAsync(() async {
@@ -1362,6 +1363,148 @@ void main() {
 
       expect(find.text('…show more'), findsNothing);
       expect(find.text('show less'), findsNothing);
+    });
+
+    testWidgets('scroll to top triggers load more', (tester) async {
+      await tester.pumpWidget(buildChat());
+
+      // Add enough messages to require scrolling
+      await tester.runAsync(() async {
+        for (int i = 0; i < 30; i++) {
+          channel.serverSend({
+            'type': 'chat_message',
+            'id': 'msg-$i',
+            'user_email': 'user@test.com',
+            'message': 'Message $i',
+            'created_at': '2026-01-01 00:${i.toString().padLeft(2, '0')}:00',
+          });
+        }
+        await Future.delayed(Duration.zero);
+        await Future.delayed(Duration.zero);
+      });
+      await tester.pumpAndSettle();
+
+      // Scroll to top
+      await tester.drag(find.byType(ListView).last, const Offset(0, 5000));
+      await tester.pump();
+
+      // Should have sent chat_load_more
+      final msgs = channel._sink.sent
+          .map((s) => jsonDecode(s as String) as Map<String, dynamic>)
+          .toList();
+      final loadMore = msgs.where((m) => m['cmd'] == 'chat_load_more').toList();
+      expect(loadMore.length, 1);
+      expect(loadMore[0]['before_id'], 'msg-0');
+    });
+
+    testWidgets('history page prepends messages', (tester) async {
+      await tester.pumpWidget(buildChat());
+
+      // Add initial messages
+      await tester.runAsync(() async {
+        channel.serverSend({
+          'type': 'chat_message',
+          'id': 'msg-new',
+          'user_email': 'user@test.com',
+          'message': 'newest',
+          'created_at': '2026-01-01 00:01:00',
+        });
+        await Future.delayed(Duration.zero);
+        await Future.delayed(Duration.zero);
+      });
+      await tester.pump();
+
+      // Simulate receiving a history page
+      await tester.runAsync(() async {
+        channel.serverSend({
+          'type': 'chat_history_page',
+          'messages': [
+            {
+              'id': 'msg-old',
+              'user_email': 'user@test.com',
+              'message': 'oldest',
+              'created_at': '2026-01-01 00:00:00',
+            },
+          ],
+          'has_more': false,
+        });
+        await Future.delayed(Duration.zero);
+        await Future.delayed(Duration.zero);
+      });
+      await tester.pump();
+
+      // Both messages should be present
+      expect(find.byType(MarkdownBody), findsNWidgets(2));
+    });
+
+    testWidgets('empty history page sets hasMore to false', (tester) async {
+      final chatKey = GlobalKey<WorkspaceChatState>();
+      await tester.pumpWidget(buildChat(chatKey: chatKey));
+
+      // Add a message
+      await tester.runAsync(() async {
+        channel.serverSend({
+          'type': 'chat_message',
+          'id': 'msg-1',
+          'user_email': 'user@test.com',
+          'message': 'hello',
+          'created_at': '2026-01-01 00:00:00',
+        });
+        await Future.delayed(Duration.zero);
+        await Future.delayed(Duration.zero);
+      });
+      await tester.pump();
+
+      // Simulate empty history page
+      await tester.runAsync(() async {
+        channel.serverSend({
+          'type': 'chat_history_page',
+          'messages': [],
+          'has_more': false,
+        });
+        await Future.delayed(Duration.zero);
+        await Future.delayed(Duration.zero);
+      });
+      await tester.pump();
+
+      // Scrolling to top should NOT trigger another load
+      channel._sink.sent.clear();
+      await tester.drag(find.byType(ListView).last, const Offset(0, 5000));
+      await tester.pump();
+
+      final msgs = channel._sink.sent
+          .map((s) => jsonDecode(s as String) as Map<String, dynamic>)
+          .toList();
+      final loadMore = msgs.where((m) => m['cmd'] == 'chat_load_more').toList();
+      expect(loadMore.length, 0);
+    });
+
+    testWidgets('loading spinner shown during load more', (tester) async {
+      final chatKey = GlobalKey<WorkspaceChatState>();
+      await tester.pumpWidget(buildChat(chatKey: chatKey));
+
+      // Add enough messages to scroll
+      await tester.runAsync(() async {
+        for (int i = 0; i < 30; i++) {
+          channel.serverSend({
+            'type': 'chat_message',
+            'id': 'load-$i',
+            'user_email': 'user@test.com',
+            'message': 'Message $i',
+            'created_at': '2026-01-01 00:${i.toString().padLeft(2, '0')}:00',
+          });
+        }
+        await Future.delayed(Duration.zero);
+        await Future.delayed(Duration.zero);
+      });
+      await tester.pumpAndSettle();
+
+      // Scroll to top to trigger loading
+      await tester.drag(find.byType(ListView).last, const Offset(0, 5000));
+      await tester.pump();
+
+      // Loading spinner should be visible
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
## Summary

- **Backend**: `get_chat_messages_before()` for cursor-based pagination using `(created_at, rowid)` ordering. New `chat_load_more` WebSocket command returns `chat_history_page` with `has_more` flag. Limit capped at 100.
- **Frontend**: Scroll-to-top triggers `chat_load_more`, prepends older messages with scroll position preservation, shows loading spinner, stops when `has_more` is false.
- **WsClient**: New `sendChatLoadMore()` method and `chatHistoryPages` stream.

## Test plan

- [x] 1160 backend tests pass, 100% coverage
- [x] Model tests: pagination, limit, invalid ID, mentions preserved
- [x] WsHandler tests: load_more handler, dispatch routing, edge cases
- [ ] Manual: send 60+ messages, scroll to top, verify older messages load

Closes #189