### PR TITLE
fix(terminal): reassemble PTY UTF-8 across read chunks (terminal ghosting)

### DIFF
--- a/src/backend/klangk_backend/terminal.py
+++ b/src/backend/klangk_backend/terminal.py
@@ -8,6 +8,7 @@ podman with ``SIGWINCH`` so it resizes the container PTY.
 """
 
 import asyncio
+import codecs
 import fcntl
 import logging
 import os
@@ -172,15 +173,29 @@ class TerminalSession:
         )
 
     async def _read_loop(self) -> None:
-        """Read PTY output and queue it as text."""
+        """Read PTY output and queue it as text.
+
+        Uses an *incremental* UTF-8 decoder so a multi-byte glyph (e.g. the
+        box-drawing ``─`` = ``e2 94 80``) split across two ``os.read`` chunks is
+        buffered and reassembled instead of being mangled into ``U+FFFD``
+        replacement chars. Per-chunk ``bytes.decode`` corrupted such glyphs,
+        shifting columns and desyncing the terminal cell model (ghosting).
+        """
+        decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
         try:
             while self._running and self._shell is not None:
                 data = await self._shell.read()
                 if not data:
                     break
-                text = data.decode("utf-8", errors="replace")
+                text = decoder.decode(data)
                 if text:
                     await self._output_queue.put(text)
+            # Flush any trailing partial sequence (a stream that ends
+            # mid-character yields a single replacement char rather than
+            # dropping bytes).
+            tail = decoder.decode(b"", final=True)
+            if tail:
+                await self._output_queue.put(tail)
         except asyncio.CancelledError:  # pragma: no cover
             raise
         except Exception:

--- a/src/backend/tests/test_terminal.py
+++ b/src/backend/tests/test_terminal.py
@@ -83,6 +83,17 @@ def _patch(fake):
     return patch(SHELL_FACTORY, return_value=fake)
 
 
+def _drain_text(session):
+    """Concatenate queued text output up to the end-of-stream sentinel."""
+    out = ""
+    while not session._output_queue.empty():
+        item = session._output_queue.get_nowait()
+        if item is None:
+            break
+        out += item
+    return out
+
+
 class TestInit:
     def test_initial_state(self):
         s = TerminalSession("cid")
@@ -202,6 +213,33 @@ class TestReadLoop:
         assert s._output_queue.get_nowait() == "prompt"
         # exception in read -> loop ends -> sentinel queued
         assert s._output_queue.get_nowait() is None
+        await s.stop()
+
+    async def test_read_loop_reassembles_split_utf8(self):
+        # '─' (U+2500) is e2 94 80; split across two reads. A per-chunk
+        # decode would mangle it into replacement chars; the incremental
+        # decoder must buffer the partial sequence and emit the intact glyph.
+        fake = FakeShell(chunks=[b"\xe2\x94", b"\x80 done"])
+        with _patch(fake):
+            s = TerminalSession("cid")
+            await s.start()
+
+        await asyncio.sleep(0.05)
+        out = _drain_text(s)
+        assert out == "─ done"
+        assert "�" not in out
+        await s.stop()
+
+    async def test_read_loop_flushes_incomplete_trailing_bytes(self):
+        # Stream ends mid-character: the buffered partial sequence is flushed
+        # as a single replacement char rather than silently dropped.
+        fake = FakeShell(chunks=[b"ok\xe2\x94"])  # ends mid '─'
+        with _patch(fake):
+            s = TerminalSession("cid")
+            await s.start()
+
+        await asyncio.sleep(0.05)
+        assert _drain_text(s) == "ok�"
         await s.stop()
 
 


### PR DESCRIPTION
Closes #251

## Problem

Full-screen TUIs in the workspace terminal (claude, pi) produced **stale-glyph "ghosting"**: duplicate rows and character-level interleaving — e.g. `Wantrme to point you…`, `Successfully─loaded─skill`, `─` bleeding through word gaps. Resizing the window always cleared it; plain shell output never triggered it.

## Root cause — klangk backend, not flterm/libghostty/the agent

`klangk_backend/terminal.py` read the PTY with `os.read(fd, 65536)` and decoded **each chunk independently**:

```python
text = data.decode("utf-8", errors="replace")
```

A multi-byte glyph split across a read boundary was mangled into `U+FFFD`. A box-drawing `─` (`e2 94 80`) split as `[e2 94][80]` became **two** replacement cells, changing the cell count → shifting every following column → desyncing the agent's screen model from the rendered grid. The agent's next cursor-positioned (`\e[NG`) redraw then wrote into the wrong cells and skipped gaps that still held stale glyphs. A resize forced a full redraw, which is why it "fixed" it. Plain ASCII output has nothing to split, which is why only TUIs tripped it.

## Evidence

- claude's raw output: **0** `U+FFFD` in iTerm and in a native flterm terminal (direct PTY, no klangk stack).
- klangk's received stream (same workflow): **26** `U+FFFD`, all inside runs of `─`.
- The captured stream replays identically corrupt in pyte, native libghostty, and tmux — i.e. flterm renders the already-corrupted bytes faithfully; it is conformant.
- Offline sweep over real claude bytes: old per-chunk decode injects U+FFFD at every realistic `os.read` size (256→16384: 159/90/40/14/3); the fix yields **0** and a **byte-identical** copy of claude's output at every size.

## Fix

Use a persistent `codecs.getincrementaldecoder("utf-8")` in the read loop that buffers an incomplete trailing sequence across reads, plus a final flush at stream end.

## Validation

- `test_read_loop_reassembles_split_utf8` is a regression guard — it **fails on the old per-chunk decode** (`'�� done'` vs `'─ done'`) and passes on the fix. `test_read_loop_flushes_incomplete_trailing_bytes` covers the flush branch. `terminal.py` stays at **100%** coverage.
- **Live:** the same workflow that produced 26 `U+FFFD` now produces **0**, with no visual ghosting.