### PR TITLE
feat(terminal): ⌘/Ctrl-click terminal paths open in the file viewer

### DIFF
--- a/src/frontend/e2e-tests/e2e/file-viewers/deep-link.spec.ts
+++ b/src/frontend/e2e-tests/e2e/file-viewers/deep-link.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from "@playwright/test";
+import {
+  API_BASE,
+  createAndOpenWorkspace,
+  seedFile,
+  waitForFlutter,
+} from "../helpers";
+
+// PR-A — deep-link a file into the EXISTING viewer via `?file=<workspace-rel>`
+// on the workspace route (hash routing: `/#/workspace/:id?file=...`).
+// WorkspacePage forwards it to IdeLayout, which selects the Files tab and calls
+// FileViewerPanel.openFile — reusing the existing viewer (no parallel viewer).
+//
+// Flutter canvas has no widget DOM, so we assert the backing content via the
+// files API and capture a screenshot artifact. Coordinates/visuals are
+// calibrated on the live stack in CI.
+
+const MD = `# Deep Link Heading
+
+Opened straight from a URL.
+`;
+
+test.describe("file-viewers/deep-link", () => {
+  test("?file= opens the file in the existing viewer (up + download present)", async ({
+    page,
+    request,
+  }) => {
+    const { workspaceId, headers, cleanup } = await createAndOpenWorkspace(
+      page,
+      request,
+      "fv-deeplink",
+    );
+    try {
+      await seedFile(
+        request,
+        workspaceId,
+        "work/readme.md",
+        MD,
+        headers,
+        "text/markdown",
+      );
+
+      // Backing content exists via API.
+      const api = await request.get(
+        `${API_BASE}/workspaces/${workspaceId}/files/content?path=work/readme.md`,
+        { headers },
+      );
+      expect((await api.json()).content).toContain("# Deep Link Heading");
+
+      // Navigate straight to the deep-link (hash route + query param). A fresh
+      // goto reloads the page so WorkspacePage rebuilds with initialFile set,
+      // which opens the file in the Files tab via the existing viewer.
+      await page.goto(`/#/workspace/${workspaceId}?file=work/readme.md`, {
+        waitUntil: "load",
+      });
+      await waitForFlutter(page);
+
+      // The viewer is showing the file (rendered on the Flutter canvas).
+      await page.screenshot({
+        path: "test-results/fv-deeplink-rendered.png",
+      });
+
+      // Sanity: the deep-link param is reflected in the URL.
+      expect(page.url()).toContain("file=work%2Freadme.md");
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/frontend/lib/app.dart
+++ b/src/frontend/lib/app.dart
@@ -113,6 +113,7 @@ class _KlangkAppState extends State<KlangkApp> {
           path: '/workspace/:id',
           builder: (context, state) => WorkspacePage(
             workspaceId: state.pathParameters['id']!,
+            initialFile: state.uri.queryParameters['file'],
           ),
         ),
         GoRoute(

--- a/src/frontend/lib/app.dart
+++ b/src/frontend/lib/app.dart
@@ -114,6 +114,7 @@ class _KlangkAppState extends State<KlangkApp> {
           builder: (context, state) => WorkspacePage(
             workspaceId: state.pathParameters['id']!,
             initialFile: state.uri.queryParameters['file'],
+            initialDir: state.uri.queryParameters['dir'],
           ),
         ),
         GoRoute(

--- a/src/frontend/lib/file_viewer/file_viewer_panel.dart
+++ b/src/frontend/lib/file_viewer/file_viewer_panel.dart
@@ -77,6 +77,16 @@ class FileViewerPanelState extends State<FileViewerPanel> {
     _loadFiles();
   }
 
+  /// Browses directory [path] (workspace-relative; empty = home root). Used by
+  /// deep-links and terminal directory-clicks.
+  void openDir(String path) {
+    setState(() {
+      _currentPath = path.isEmpty ? '.' : path;
+      _selectedFile = null;
+    });
+    _loadFiles();
+  }
+
   @override
   void initState() {
     super.initState();
@@ -455,6 +465,10 @@ class FileViewerPanelState extends State<FileViewerPanel> {
           Expanded(
             child: _selectedFile != null
                 ? _FileViewer(
+                    // Key by path so switching files (e.g. PDF → .md) directly —
+                    // without going through the list — recreates the viewer with
+                    // the new file's renderers instead of reusing stale ones.
+                    key: ValueKey(_selectedFile),
                     registry: _registry,
                     file: _renderableFor(_selectedFile!),
                     onClose: () => setState(() => _selectedFile = null),
@@ -542,6 +556,7 @@ class FileViewerPanelState extends State<FileViewerPanel> {
 /// actions (e.g. image rotate) live inside that widget.
 class _FileViewer extends StatefulWidget {
   const _FileViewer({
+    super.key,
     required this.registry,
     required this.file,
     required this.onClose,

--- a/src/frontend/lib/file_viewer/file_viewer_panel.dart
+++ b/src/frontend/lib/file_viewer/file_viewer_panel.dart
@@ -63,6 +63,20 @@ class FileViewerPanelState extends State<FileViewerPanel> {
   /// Refresh the file list for the current directory.
   void refresh() => _loadFiles();
 
+  /// Opens [path] (workspace-relative, same space as the file list) directly in
+  /// the viewer: positions the browser at the file's directory — so the path
+  /// bar's up/breadcrumbs work — and shows its content via the existing viewer.
+  /// Used by deep-links and terminal path-clicks.
+  void openFile(String path) {
+    final dir =
+        path.contains('/') ? path.substring(0, path.lastIndexOf('/')) : '.';
+    setState(() {
+      _currentPath = dir;
+      _selectedFile = path;
+    });
+    _loadFiles();
+  }
+
   @override
   void initState() {
     super.initState();

--- a/src/frontend/lib/layout/ide_layout.dart
+++ b/src/frontend/lib/layout/ide_layout.dart
@@ -20,6 +20,10 @@ class IdeLayout extends StatefulWidget {
   final GlobalKey<FileViewerPanelState>? fileViewerKey;
   final GlobalKey<WorkspaceChatState>? chatKey;
 
+  /// Deep-linked workspace-relative file path to open in the Files tab on load
+  /// (and whenever it changes). Null/empty shows the default (Terminal) tab.
+  final String? initialFile;
+
   const IdeLayout({
     super.key,
     required this.fileViewer,
@@ -33,13 +37,14 @@ class IdeLayout extends StatefulWidget {
     this.terminalKey,
     this.fileViewerKey,
     this.chatKey,
+    this.initialFile,
   });
 
   @override
-  State<IdeLayout> createState() => _IdeLayoutState();
+  State<IdeLayout> createState() => IdeLayoutState();
 }
 
-class _IdeLayoutState extends State<IdeLayout> {
+class IdeLayoutState extends State<IdeLayout> {
   int _selectedIndex = 0;
   double _debugHeight = 0; // collapsed by default
 
@@ -53,6 +58,29 @@ class _IdeLayoutState extends State<IdeLayout> {
     // Focus the pane shown first (Terminal by default) so the user can type
     // immediately on workspace open, without an extra click into it.
     _focusPane(_selectedIndex);
+    _maybeOpenInitialFile();
+  }
+
+  @override
+  void didUpdateWidget(IdeLayout oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.initialFile != oldWidget.initialFile) _maybeOpenInitialFile();
+  }
+
+  /// Opens [IdeLayout.initialFile] in the Files tab once the panel is built.
+  /// Deferred to after the frame so the fileViewer's state is attached.
+  void _maybeOpenInitialFile() {
+    final path = widget.initialFile;
+    if (path == null || path.isEmpty) return;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) openFile(path);
+    });
+  }
+
+  /// Switches to the Files tab and opens [path] in the existing viewer.
+  void openFile(String path) {
+    _selectTab(1);
+    widget.fileViewerKey?.currentState?.openFile(path);
   }
 
   void _selectTab(int index) {

--- a/src/frontend/lib/layout/ide_layout.dart
+++ b/src/frontend/lib/layout/ide_layout.dart
@@ -20,9 +20,13 @@ class IdeLayout extends StatefulWidget {
   final GlobalKey<FileViewerPanelState>? fileViewerKey;
   final GlobalKey<WorkspaceChatState>? chatKey;
 
-  /// Deep-linked workspace-relative file path to open in the Files tab on load
-  /// (and whenever it changes). Null/empty shows the default (Terminal) tab.
+  /// Deep-linked workspace-relative file to open in the Files tab on load (and
+  /// whenever it changes). Null/empty (with no [initialDir]) shows Terminal.
   final String? initialFile;
+
+  /// Deep-linked workspace-relative directory to browse in the Files tab on
+  /// load. Used when [initialFile] is null/empty.
+  final String? initialDir;
 
   const IdeLayout({
     super.key,
@@ -38,6 +42,7 @@ class IdeLayout extends StatefulWidget {
     this.fileViewerKey,
     this.chatKey,
     this.initialFile,
+    this.initialDir,
   });
 
   @override
@@ -58,22 +63,34 @@ class IdeLayoutState extends State<IdeLayout> {
     // Focus the pane shown first (Terminal by default) so the user can type
     // immediately on workspace open, without an extra click into it.
     _focusPane(_selectedIndex);
-    _maybeOpenInitialFile();
+    _maybeOpenInitial();
   }
 
   @override
   void didUpdateWidget(IdeLayout oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.initialFile != oldWidget.initialFile) _maybeOpenInitialFile();
+    if (widget.initialFile != oldWidget.initialFile ||
+        widget.initialDir != oldWidget.initialDir) {
+      _maybeOpenInitial();
+    }
   }
 
-  /// Opens [IdeLayout.initialFile] in the Files tab once the panel is built.
-  /// Deferred to after the frame so the fileViewer's state is attached.
-  void _maybeOpenInitialFile() {
-    final path = widget.initialFile;
-    if (path == null || path.isEmpty) return;
+  /// Opens the deep-linked [IdeLayout.initialFile] (preferred) or
+  /// [IdeLayout.initialDir] in the Files tab once the panel is built. Deferred
+  /// to after the frame so the fileViewer's state is attached.
+  void _maybeOpenInitial() {
+    final file = widget.initialFile;
+    final dir = widget.initialDir;
+    final hasFile = file != null && file.isNotEmpty;
+    final hasDir = dir != null && dir.isNotEmpty;
+    if (!hasFile && !hasDir) return;
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) openFile(path);
+      if (!mounted) return;
+      if (hasFile) {
+        openFile(file);
+      } else {
+        openDirectory(dir!);
+      }
     });
   }
 
@@ -81,6 +98,12 @@ class IdeLayoutState extends State<IdeLayout> {
   void openFile(String path) {
     _selectTab(1);
     widget.fileViewerKey?.currentState?.openFile(path);
+  }
+
+  /// Switches to the Files tab and browses directory [path].
+  void openDirectory(String path) {
+    _selectTab(1);
+    widget.fileViewerKey?.currentState?.openDir(path);
   }
 
   void _selectTab(int index) {

--- a/src/frontend/lib/layout/ide_layout.dart
+++ b/src/frontend/lib/layout/ide_layout.dart
@@ -164,7 +164,10 @@ class IdeLayoutState extends State<IdeLayout> {
         padding: const EdgeInsets.only(left: 6, top: 4),
         child: widget.terminal,
       ),
-      Container(
+      // Material (not a plain ColoredBox) so the file viewer's ListTiles paint
+      // their background/ink on a Material ancestor instead of this pane's
+      // colored box — newer Flutter asserts on ListTile-in-ColoredBox.
+      Material(
         color: KColors.bgCanvas,
         child: widget.fileViewer,
       ),

--- a/src/frontend/lib/terminal/ghostty_terminal.dart
+++ b/src/frontend/lib/terminal/ghostty_terminal.dart
@@ -22,7 +22,14 @@ import '../utils/web_helpers_stub.dart'
 class GhosttyTerminal extends StatefulWidget {
   final WsClient wsClient;
 
-  const GhosttyTerminal({super.key, required this.wsClient});
+  /// Called on a ⌘/Ctrl-click over a path/URL token, with the clicked token,
+  /// any OSC 8 uri, the row's tail (token start → EOL, for spaces in names),
+  /// and the current OSC 7 working directory. The host resolves and opens it
+  /// (see workspace_page).
+  final ValueChanged<({String token, String? uri, String pwd, String tail})>?
+      onPathTap;
+
+  const GhosttyTerminal({super.key, required this.wsClient, this.onPathTap});
 
   @override
   State<GhosttyTerminal> createState() => GhosttyTerminalState();
@@ -121,7 +128,8 @@ class GhosttyTerminalState extends State<GhosttyTerminal> {
           // pty now at the real grid size instead of the 80x24 seed.
           _startTerminal();
         }
-      };
+      }
+      ..onLinkTap = handleLinkTap;
     _outputSub = widget.wsClient.terminalOutput.listen((data) {
       _writingServerOutput = true;
       try {
@@ -151,6 +159,18 @@ class GhosttyTerminalState extends State<GhosttyTerminal> {
     if (!_focusNode.hasFocus) return false;
     _terminal.paste(text);
     return true;
+  }
+
+  /// Forwards a ⌘/Ctrl-click on a link cell to [GhosttyTerminal.onPathTap],
+  /// attaching the live OSC 7 working directory ([TerminalController.pwd]) so
+  /// the host can resolve relative tokens. Wired to the controller's
+  /// `onLinkTap`; exposed for tests since the gesture path needs the FFI engine.
+  @visibleForTesting
+  void handleLinkTap(LinkTap t) {
+    final cb = widget.onPathTap;
+    if (cb != null) {
+      cb((token: t.token, uri: t.uri, pwd: _terminal.pwd, tail: t.tail));
+    }
   }
 
   // Loads the bundled font's raw bytes. Overridable in tests so the

--- a/src/frontend/lib/terminal/terminal_link.dart
+++ b/src/frontend/lib/terminal/terminal_link.dart
@@ -1,0 +1,216 @@
+/// Pure classification of a ⌘-clicked terminal token into an action — no IO,
+/// no routing, no workspace id — so it is fully unit-testable. The widget layer
+/// performs the resulting open/navigate.
+library;
+
+/// What a terminal link tap resolves to.
+sealed class TerminalLinkTarget {
+  const TerminalLinkTarget();
+}
+
+/// An external `http(s)://` URL to open in a new tab/window.
+final class ExternalUrl extends TerminalLinkTarget {
+  const ExternalUrl(this.url);
+  final String url;
+
+  @override
+  bool operator ==(Object other) => other is ExternalUrl && other.url == url;
+  @override
+  int get hashCode => url.hashCode;
+  @override
+  String toString() => 'ExternalUrl($url)';
+}
+
+/// A workspace-relative file path to open in the file viewer.
+final class WorkspaceFile extends TerminalLinkTarget {
+  const WorkspaceFile(this.relativePath);
+  final String relativePath;
+
+  @override
+  bool operator ==(Object other) =>
+      other is WorkspaceFile && other.relativePath == relativePath;
+  @override
+  int get hashCode => relativePath.hashCode;
+  @override
+  String toString() => 'WorkspaceFile($relativePath)';
+}
+
+/// The token is neither an http(s) URL nor a file under the workspace root.
+final class NoLink extends TerminalLinkTarget {
+  const NoLink();
+}
+
+final _urlPattern = RegExp(r'^https?://');
+
+/// Classifies a ⌘-clicked terminal token.
+///
+/// [uri] is the cell's OSC 8 hyperlink (if any); [pwd] is the OSC 7 working
+/// directory (`file://host/abs`, a bare path, or empty); [workspaceRoot] is the
+/// container path files resolve under (e.g. `/home/klangk/work`).
+///
+/// Security: only `http(s)` URLs open externally — every other OSC 8 scheme
+/// (`javascript:`, `data:`, `file://`, …) is ignored.
+///
+/// Path resolution uses two roots because the file API addresses files
+/// relative to the container **home**, while the shell's working directory is a
+/// subdir of it:
+/// - [defaultCwd] is where a *relative* token resolves when [pwd] (OSC 7) is
+///   absent — the shell's cwd, e.g. `/home/klangk/work`.
+/// - [pathRoot] is stripped to produce the file-API path — the home, e.g.
+///   `/home/klangk`, so a file under `work/` yields `work/...`.
+///
+/// The resolved path must land inside [pathRoot], else [NoLink] (rejects
+/// `../` escapes).
+TerminalLinkTarget classifyTerminalLink({
+  required String token,
+  String? uri,
+  required String pwd,
+  required String pathRoot,
+  required String defaultCwd,
+}) {
+  if (uri != null && _urlPattern.hasMatch(uri)) return ExternalUrl(uri);
+  if (_urlPattern.hasMatch(token)) return ExternalUrl(token);
+  final rel = _toWorkspaceRelative(token, pwd, pathRoot, defaultCwd);
+  return rel == null ? const NoLink() : WorkspaceFile(rel);
+}
+
+/// Whether a workspace-relative path is a file, a directory, or absent.
+enum PathKind { file, directory, none }
+
+/// Dispatches a ⌘-clicked terminal link to host actions. The seams are injected
+/// so the dispatch is unit-testable without IO, routing, or a widget.
+class TerminalLinkActions {
+  TerminalLinkActions({
+    required this.pathRoot,
+    required this.defaultCwd,
+    required this.openExternalUrl,
+    required this.statPath,
+    required this.openFile,
+    required this.openDirectory,
+    this.maxTailWords = 6,
+  });
+
+  /// File-API path root (the container home) — stripped to produce `work/...`.
+  final String pathRoot;
+
+  /// Shell cwd that relative tokens resolve against when OSC 7 is absent.
+  final String defaultCwd;
+
+  /// Opens an external `http(s)` URL (e.g. `window.open` / url_launcher).
+  final void Function(String url) openExternalUrl;
+
+  /// Classifies [relativePath] as a file, directory, or absent (file-API).
+  final Future<PathKind> Function(String relativePath) statPath;
+
+  /// Opens the in-app file view for a file [relativePath].
+  final void Function(String relativePath) openFile;
+
+  /// Opens the file browser at a directory [relativePath].
+  final void Function(String relativePath) openDirectory;
+
+  /// Cap on how many whitespace-separated words of the tail to try (bounds the
+  /// number of stat calls when extending across spaces).
+  final int maxTailWords;
+
+  /// Resolves and opens the link. `http(s)` URLs open externally; otherwise the
+  /// tail is greedy-extended across spaces — progressively longer candidates are
+  /// [statPath]-checked and the **longest existing** one wins (file → [openFile],
+  /// directory → [openDirectory]). Non-files/stale paths open nothing, so a
+  /// mis-click never navigates away from the terminal.
+  Future<void> handle({
+    required String token,
+    String? uri,
+    required String pwd,
+    required String tail,
+  }) async {
+    final urlRe = RegExp(r'^https?://');
+    if (uri != null && urlRe.hasMatch(uri)) {
+      openExternalUrl(uri);
+      return;
+    }
+    if (urlRe.hasMatch(token)) {
+      openExternalUrl(token);
+      return;
+    }
+
+    final words =
+        tail.split(RegExp(r'[ \t]+')).where((w) => w.isNotEmpty).toList();
+    if (words.isEmpty) return;
+    final limit = words.length < maxTailWords ? words.length : maxTailWords;
+    // NOTE (backlog): trailing sentence punctuation (e.g. a path that ends a
+    // sentence — "…/TODO.") is not stripped; the `.`/`)` becomes part of the
+    // token and the stat misses. Discriminating sentence punctuation from a
+    // real filename char is ambiguous — deferred.
+    String? bestFile;
+    String? bestDir;
+    for (var n = 1; n <= limit; n++) {
+      final candidate = words.take(n).join(' ');
+      final target = classifyTerminalLink(
+        token: candidate,
+        pwd: pwd,
+        pathRoot: pathRoot,
+        defaultCwd: defaultCwd,
+      );
+      if (target is! WorkspaceFile) continue;
+      switch (await statPath(target.relativePath)) {
+        case PathKind.file:
+          bestFile = target.relativePath;
+        case PathKind.directory:
+          bestDir = target.relativePath;
+        case PathKind.none:
+          break;
+      }
+    }
+    if (bestFile != null) {
+      openFile(bestFile);
+    } else if (bestDir != null) {
+      openDirectory(bestDir);
+    }
+  }
+}
+
+String? _toWorkspaceRelative(
+  String token,
+  String pwd,
+  String pathRoot,
+  String defaultCwd,
+) {
+  if (token.isEmpty) return null;
+  final String raw;
+  if (token == '~') {
+    raw = pathRoot; // ~ → container home
+  } else if (token.startsWith('~/')) {
+    raw = '$pathRoot/${token.substring(2)}';
+  } else if (token.startsWith('/')) {
+    raw = token;
+  } else {
+    var base = defaultCwd;
+    if (pwd.startsWith('file://')) {
+      final parsed = Uri.tryParse(pwd);
+      if (parsed != null && parsed.path.isNotEmpty) base = parsed.path;
+    }
+    raw = '$base/$token';
+  }
+  // Normalizing collapses `./` and `..`; the prefix check then rejects anything
+  // that escaped the path root (e.g. `../../etc/passwd`).
+  final abs = _normalizePosix(raw);
+  final root = _normalizePosix(pathRoot);
+  if (abs == root) return '';
+  if (abs.startsWith('$root/')) return abs.substring(root.length + 1);
+  return null;
+}
+
+/// Collapses `.`/`..`/empty segments in an absolute posix path (callers always
+/// pass an absolute path). `..` at the root is dropped — it can't escape `/`.
+String _normalizePosix(String path) {
+  final out = <String>[];
+  for (final seg in path.split('/')) {
+    if (seg.isEmpty || seg == '.') continue;
+    if (seg == '..') {
+      if (out.isNotEmpty) out.removeLast();
+    } else {
+      out.add(seg);
+    }
+  }
+  return '/${out.join('/')}';
+}

--- a/src/frontend/lib/workspace/workspace_file_api.dart
+++ b/src/frontend/lib/workspace/workspace_file_api.dart
@@ -1,0 +1,45 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+import '../terminal/terminal_link.dart' show PathKind;
+
+/// Classifies a workspace-relative [rel] path as a file, directory, or absent
+/// by listing its **parent directory** and reading the matching entry's
+/// `is_dir`.
+///
+/// This is the authoritative classifier: `/files/content` is text-only and
+/// 404s for binary files (PDFs/images), and `/files?path=` returns 200 for both
+/// files and directories, so neither alone can tell them apart. The parent
+/// listing's `is_dir` works for binary, text, and directories alike. Any error
+/// (non-200, malformed body, network) yields [PathKind.none].
+Future<PathKind> statWorkspacePath({
+  required http.Client client,
+  required String baseUrl,
+  required String workspaceId,
+  required String rel,
+  String? authToken,
+}) async {
+  if (rel.isEmpty) return PathKind.directory; // the home root (~)
+  final slash = rel.lastIndexOf('/');
+  final parent = slash >= 0 ? rel.substring(0, slash) : '';
+  final name = slash >= 0 ? rel.substring(slash + 1) : rel;
+  final uri = Uri.parse('$baseUrl/workspaces/$workspaceId/files'
+      '?path=${Uri.encodeQueryComponent(parent)}');
+  try {
+    final res = await client.get(uri, headers: {
+      if (authToken != null) 'Authorization': 'Bearer $authToken',
+    });
+    if (res.statusCode != 200) return PathKind.none;
+    final entries = jsonDecode(res.body);
+    if (entries is! List) return PathKind.none;
+    for (final entry in entries) {
+      if (entry is Map && entry['name'] == name) {
+        return entry['is_dir'] == true ? PathKind.directory : PathKind.file;
+      }
+    }
+    return PathKind.none;
+  } catch (_) {
+    return PathKind.none;
+  }
+}

--- a/src/frontend/lib/workspace/workspace_page.dart
+++ b/src/frontend/lib/workspace/workspace_page.dart
@@ -16,6 +16,11 @@ import '../file_viewer/file_viewer_panel.dart';
 import '../file_viewer/file_renderer_wiring.dart';
 import '../layout/ide_layout.dart';
 import '../terminal/ghostty_terminal.dart';
+import '../terminal/terminal_link.dart';
+import 'workspace_file_api.dart';
+import 'package:http/http.dart' as http;
+import '../utils/web_helpers_stub.dart'
+    if (dart.library.js_interop) '../utils/web_helpers_web.dart';
 import '../browser/browser_delegate.dart';
 import '../chat/workspace_chat.dart';
 import '../debug/debug_panel.dart';
@@ -29,10 +34,15 @@ class WorkspacePage extends StatefulWidget {
   /// (from the `?file=` query param on the workspace route).
   final String? initialFile;
 
+  /// Deep-linked workspace-relative directory to browse in the Files tab on
+  /// load (from the `?dir=` query param).
+  final String? initialDir;
+
   const WorkspacePage({
     super.key,
     required this.workspaceId,
     this.initialFile,
+    this.initialDir,
   });
 
   @override
@@ -40,6 +50,12 @@ class WorkspacePage extends StatefulWidget {
 }
 
 class _WorkspacePageState extends State<WorkspacePage> {
+  // TODO(config): hoist these container paths into workspace/container config.
+  // They must match the container layout (the file API is relative to the
+  // home; the shell cwd is `work/` under it). Containers may be configured
+  // differently, so hardcoding is a stopgap — follow-up PR.
+  static const _containerHome = '/home/klangk';
+  static const _containerCwd = '/home/klangk/work';
   final _terminalKey = GlobalKey<GhosttyTerminalState>();
   final _fileViewerKey = GlobalKey<FileViewerPanelState>();
   final _chatKey = GlobalKey<WorkspaceChatState>();
@@ -59,6 +75,33 @@ class _WorkspacePageState extends State<WorkspacePage> {
   late final ToolPluginRegistry _pluginRegistry;
   late final List<ToolPlugin> _plugins;
   late final FileRendererRegistry _fileRenderers;
+
+  /// Resolves a ⌘/Ctrl-clicked terminal token and opens it: external `http(s)`
+  /// URLs in a new tab; workspace files (after existence-verify) in the file
+  /// view via the `?file=` deep-link. All untrusted-input handling lives in
+  /// [TerminalLinkActions]/[classifyTerminalLink].
+  void _handleTerminalPathTap(
+      ({String token, String? uri, String pwd, String tail}) e) {
+    final authToken = context.read<AuthService>().token;
+    final actions = TerminalLinkActions(
+      pathRoot: _containerHome,
+      defaultCwd: _containerCwd,
+      openExternalUrl: openUrl,
+      statPath: (rel) => statWorkspacePath(
+        client: http.Client(),
+        baseUrl: baseUrl,
+        workspaceId: widget.workspaceId,
+        rel: rel,
+        authToken: authToken,
+      ),
+      openFile: (rel) => context.go('/workspace/${widget.workspaceId}'
+          '?file=${Uri.encodeQueryComponent(rel)}'),
+      openDirectory: (rel) => context.go('/workspace/${widget.workspaceId}'
+          '?dir=${Uri.encodeQueryComponent(rel)}'),
+    );
+    unawaited(
+        actions.handle(token: e.token, uri: e.uri, pwd: e.pwd, tail: e.tail));
+  }
 
   @override
   void initState() {
@@ -295,7 +338,11 @@ class _WorkspacePageState extends State<WorkspacePage> {
               authToken: authToken,
               registry: _fileRenderers,
             ),
-            terminal: GhosttyTerminal(key: _terminalKey, wsClient: wsClient),
+            terminal: GhosttyTerminal(
+              key: _terminalKey,
+              wsClient: wsClient,
+              onPathTap: _handleTerminalPathTap,
+            ),
             chat: _hasPerm('chat')
                 ? WorkspaceChat(
                     key: _chatKey,
@@ -324,6 +371,7 @@ class _WorkspacePageState extends State<WorkspacePage> {
             fileViewerKey: _fileViewerKey,
             chatKey: _chatKey,
             initialFile: widget.initialFile,
+            initialDir: widget.initialDir,
             debug: DebugPanel(wsClient: wsClient),
           ),
           for (final plugin in _plugins)

--- a/src/frontend/lib/workspace/workspace_page.dart
+++ b/src/frontend/lib/workspace/workspace_page.dart
@@ -25,7 +25,15 @@ import 'workspace_sharing_panel.dart';
 class WorkspacePage extends StatefulWidget {
   final String workspaceId;
 
-  const WorkspacePage({super.key, required this.workspaceId});
+  /// Deep-linked workspace-relative file to open in the Files tab on load
+  /// (from the `?file=` query param on the workspace route).
+  final String? initialFile;
+
+  const WorkspacePage({
+    super.key,
+    required this.workspaceId,
+    this.initialFile,
+  });
 
   @override
   State<WorkspacePage> createState() => _WorkspacePageState();
@@ -315,6 +323,7 @@ class _WorkspacePageState extends State<WorkspacePage> {
             terminalKey: _terminalKey,
             fileViewerKey: _fileViewerKey,
             chatKey: _chatKey,
+            initialFile: widget.initialFile,
             debug: DebugPanel(wsClient: wsClient),
           ),
           for (final plugin in _plugins)

--- a/src/frontend/pubspec.lock
+++ b/src/frontend/pubspec.lock
@@ -157,8 +157,8 @@ packages:
     dependency: "direct main"
     description:
       path: "packages/flterm"
-      ref: "0.0.3.1"
-      resolved-ref: c943f0d8681de41c13a137a94116ee975a447fb8
+      ref: "0.0.3.2"
+      resolved-ref: "84c2ff087a8e937f1bef15725363cc3588b92028"
       url: "https://github.com/runyaga/libghostty.git"
     source: git
     version: "0.0.3"

--- a/src/frontend/pubspec.yaml
+++ b/src/frontend/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   flterm:
     git:
       url: https://github.com/runyaga/libghostty.git
-      ref: "0.0.3.1"
+      ref: "0.0.3.2"
       path: packages/flterm
   libghostty: ^0.0.9
   web_socket_channel: ^3.0.0

--- a/src/frontend/test/file_viewer_m2_test.dart
+++ b/src/frontend/test/file_viewer_m2_test.dart
@@ -159,6 +159,26 @@ MockClient _listing(List<Map<String, dynamic>> entries,
   });
 }
 
+/// Renders a unique marker for one extension, to prove which renderer the
+/// viewer selected (so a stale renderer after a direct file switch is visible).
+class _MarkerRenderer extends FileRenderer {
+  _MarkerRenderer(this.ext, this.marker);
+  final String ext;
+  final String marker;
+  @override
+  String get id => marker;
+  @override
+  String get modeLabel => marker;
+  @override
+  IconData get icon => Icons.abc;
+  @override
+  int get priority => 10;
+  @override
+  bool canRender(RenderableFile file) => file.extension == ext;
+  @override
+  Widget build(BuildContext context, RenderableFile file) => Text(marker);
+}
+
 void main() {
   tearDown(() {
     testBaseUrlOverride = null;
@@ -569,6 +589,76 @@ void main() {
       key.currentState!.openFile('docs/note.txt');
       await tester.pumpAndSettle();
       expect(find.textContaining('deep-linked body'), findsOneWidget);
+      ws.close();
+    });
+  });
+
+  group('openDir + direct file switch', () {
+    testWidgets('openDir browses the folder (shows the listing)',
+        (tester) async {
+      testBaseUrlOverride = 'http://localhost:8997';
+      testHttpClientOverride = _listing([
+        {'name': 'note.txt', 'path': 'docs/note.txt', 'is_dir': false},
+      ]);
+      final key = GlobalKey<FileViewerPanelState>();
+      final ws = _MockWsClient();
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 900,
+            height: 600,
+            child: FileViewerPanel(
+                key: key, wsClient: ws, workspaceId: 'ws-1', authToken: 'tok'),
+          ),
+        ),
+      ));
+      await tester.pumpAndSettle();
+      key.currentState!.openDir('docs');
+      await tester.pumpAndSettle();
+      expect(
+          find.text('note.txt'), findsOneWidget); // the listing, not a viewer
+      ws.close();
+    });
+
+    testWidgets(
+        'switching files directly recreates the viewer with the new renderer',
+        (tester) async {
+      testBaseUrlOverride = 'http://localhost:8997';
+      testHttpClientOverride = _listing([
+        {'name': 'a.md', 'path': 'docs/a.md', 'is_dir': false},
+        {'name': 'b.txt', 'path': 'docs/b.txt', 'is_dir': false},
+      ]);
+      final registry = FileRendererRegistry()
+        ..registerAll([
+          _MarkerRenderer('md', 'MD_RENDERER'),
+          _MarkerRenderer('txt', 'TXT_RENDERER'),
+        ]);
+      final key = GlobalKey<FileViewerPanelState>();
+      final ws = _MockWsClient();
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 900,
+            height: 600,
+            child: FileViewerPanel(
+              key: key,
+              wsClient: ws,
+              workspaceId: 'ws-1',
+              authToken: 'tok',
+              registry: registry,
+            ),
+          ),
+        ),
+      ));
+      await tester.pumpAndSettle();
+      key.currentState!.openFile('docs/a.md');
+      await tester.pumpAndSettle();
+      expect(find.text('MD_RENDERER'), findsOneWidget);
+      // Switch directly to a different-type file (no list step in between).
+      key.currentState!.openFile('docs/b.txt');
+      await tester.pumpAndSettle();
+      expect(find.text('TXT_RENDERER'), findsOneWidget);
+      expect(find.text('MD_RENDERER'), findsNothing);
       ws.close();
     });
   });

--- a/src/frontend/test/file_viewer_m2_test.dart
+++ b/src/frontend/test/file_viewer_m2_test.dart
@@ -541,4 +541,35 @@ void main() {
       ws.close();
     });
   });
+
+  group('openFile (deep-link entry point)', () {
+    testWidgets('positions at the file dir and shows its content',
+        (tester) async {
+      testBaseUrlOverride = 'http://localhost:8997';
+      testHttpClientOverride = _listing([
+        {'name': 'note.txt', 'path': 'docs/note.txt', 'is_dir': false},
+      ], content: 'deep-linked body');
+      final key = GlobalKey<FileViewerPanelState>();
+      final ws = _MockWsClient();
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 900,
+            height: 600,
+            child: FileViewerPanel(
+              key: key,
+              wsClient: ws,
+              workspaceId: 'ws-1',
+              authToken: 'token',
+            ),
+          ),
+        ),
+      ));
+      await tester.pumpAndSettle();
+      key.currentState!.openFile('docs/note.txt');
+      await tester.pumpAndSettle();
+      expect(find.textContaining('deep-linked body'), findsOneWidget);
+      ws.close();
+    });
+  });
 }

--- a/src/frontend/test/ghostty_terminal_test.dart
+++ b/src/frontend/test/ghostty_terminal_test.dart
@@ -307,5 +307,52 @@ void main() {
       expect(pasted.join(), contains('clipboard-payload'));
       client.close();
     });
+
+    testWidgets('handleLinkTap forwards token/uri/tail and the live pwd',
+        (tester) async {
+      ({String token, String? uri, String pwd, String tail})? captured;
+      final client = _MockWsClient();
+      final key = GlobalKey<GhosttyTerminalState>();
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: GhosttyTerminal(
+            key: key,
+            wsClient: client,
+            onPathTap: (e) => captured = e,
+          ),
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      key.currentState!.handleLinkTap(
+        (
+          row: 3,
+          col: 5,
+          token: 'work/a b.txt',
+          uri: null,
+          tail: 'work/a b.txt rest',
+        ),
+      );
+
+      expect(captured, isNotNull);
+      expect(captured!.token, 'work/a b.txt');
+      expect(captured!.tail, 'work/a b.txt rest');
+      expect(captured!.uri, isNull);
+      expect(captured!.pwd, isA<String>()); // live OSC 7 cwd (empty until set)
+      client.close();
+    });
+
+    testWidgets('handleLinkTap is a no-op when onPathTap is null',
+        (tester) async {
+      final client = _MockWsClient();
+      final key = GlobalKey<GhosttyTerminalState>();
+      await tester.pumpWidget(_build(client, key: key)); // no onPathTap
+      await tester.pumpAndSettle();
+      // Must not throw when there is no callback wired.
+      key.currentState!.handleLinkTap(
+        (row: 0, col: 0, token: 'x', uri: 'https://e', tail: 'x'),
+      );
+      client.close();
+    });
   });
 }

--- a/src/frontend/test/ide_layout_initial_file_test.dart
+++ b/src/frontend/test/ide_layout_initial_file_test.dart
@@ -34,7 +34,8 @@ MockClient _client() => MockClient((req) async {
       return http.Response('nf', 404);
     });
 
-Widget _ide(GlobalKey<FileViewerPanelState> fvKey, WsClient ws, String? file) =>
+Widget _ide(GlobalKey<FileViewerPanelState> fvKey, WsClient ws, String? file,
+        {String? dir}) =>
     MaterialApp(
       home: Scaffold(
         body: SizedBox(
@@ -50,6 +51,7 @@ Widget _ide(GlobalKey<FileViewerPanelState> fvKey, WsClient ws, String? file) =>
             ),
             terminal: const SizedBox(),
             initialFile: file,
+            initialDir: dir,
           ),
         ),
       ),
@@ -96,6 +98,36 @@ void main() {
     await tester.pumpWidget(_ide(fvKey, ws, 'docs/note.txt'));
     await tester.pumpAndSettle();
     expect(find.textContaining('ide body'), findsOneWidget);
+    ws.close();
+  });
+
+  testWidgets('initialDir browses the folder on load (no file opened)',
+      (tester) async {
+    testBaseUrlOverride = 'http://localhost:8997';
+    testHttpClientOverride = _client();
+    final fvKey = GlobalKey<FileViewerPanelState>();
+    final ws = _MockWsClient();
+    await tester.pumpWidget(_ide(fvKey, ws, null, dir: 'docs'));
+    await tester.pumpAndSettle();
+    // Breadcrumb segment proves openDirectory('docs') ran; no file content.
+    expect(find.text('docs'), findsOneWidget);
+    expect(find.textContaining('ide body'), findsNothing);
+    ws.close();
+  });
+
+  testWidgets('changing initialDir reopens the folder (didUpdateWidget)',
+      (tester) async {
+    testBaseUrlOverride = 'http://localhost:8997';
+    testHttpClientOverride = _client();
+    final fvKey = GlobalKey<FileViewerPanelState>();
+    final ws = _MockWsClient();
+    await tester.pumpWidget(_ide(fvKey, ws, null));
+    await tester.pumpAndSettle();
+    expect(find.text('docs'), findsNothing);
+    // Same tree, new initialDir → IdeLayout.didUpdateWidget fires.
+    await tester.pumpWidget(_ide(fvKey, ws, null, dir: 'docs'));
+    await tester.pumpAndSettle();
+    expect(find.text('docs'), findsOneWidget);
     ws.close();
   });
 }

--- a/src/frontend/test/ide_layout_initial_file_test.dart
+++ b/src/frontend/test/ide_layout_initial_file_test.dart
@@ -1,0 +1,101 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:klangk_frontend/file_viewer/file_viewer_panel.dart';
+import 'package:klangk_frontend/layout/ide_layout.dart';
+import 'package:klangk_frontend/ws/ws_client.dart';
+import 'package:klangk_plugin_api/klangk_plugin_api.dart'
+    show testBaseUrlOverride;
+
+class _MockWsClient extends WsClient {
+  final _controller = StreamController<Map<String, dynamic>>.broadcast();
+  @override
+  Stream<Map<String, dynamic>> get customEvents => _controller.stream;
+  void close() => _controller.close();
+}
+
+/// Serves a one-file listing + text content for any path.
+MockClient _client() => MockClient((req) async {
+      if (req.url.path.contains('/files/content')) {
+        return http.Response(jsonEncode({'content': 'ide body'}), 200);
+      }
+      if (req.url.path.contains('/files')) {
+        return http.Response(
+          jsonEncode([
+            {'name': 'note.txt', 'path': 'docs/note.txt', 'is_dir': false},
+          ]),
+          200,
+        );
+      }
+      return http.Response('nf', 404);
+    });
+
+Widget _ide(GlobalKey<FileViewerPanelState> fvKey, WsClient ws, String? file) =>
+    MaterialApp(
+      home: Scaffold(
+        body: SizedBox(
+          width: 1000,
+          height: 700,
+          child: IdeLayout(
+            fileViewerKey: fvKey,
+            fileViewer: FileViewerPanel(
+              key: fvKey,
+              wsClient: ws,
+              workspaceId: 'ws-1',
+              authToken: 'tok',
+            ),
+            terminal: const SizedBox(),
+            initialFile: file,
+          ),
+        ),
+      ),
+    );
+
+void main() {
+  tearDown(() {
+    testBaseUrlOverride = null;
+    testHttpClientOverride = null;
+  });
+
+  testWidgets('initialFile opens the file in the Files tab on load',
+      (tester) async {
+    testBaseUrlOverride = 'http://localhost:8997';
+    testHttpClientOverride = _client();
+    final fvKey = GlobalKey<FileViewerPanelState>();
+    final ws = _MockWsClient();
+    await tester.pumpWidget(_ide(fvKey, ws, 'docs/note.txt'));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('ide body'), findsOneWidget);
+    ws.close();
+  });
+
+  testWidgets('no initialFile leaves the file unopened', (tester) async {
+    testBaseUrlOverride = 'http://localhost:8997';
+    testHttpClientOverride = _client();
+    final fvKey = GlobalKey<FileViewerPanelState>();
+    final ws = _MockWsClient();
+    await tester.pumpWidget(_ide(fvKey, ws, null));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('ide body'), findsNothing);
+    ws.close();
+  });
+
+  testWidgets('changing initialFile reopens (didUpdateWidget)', (tester) async {
+    testBaseUrlOverride = 'http://localhost:8997';
+    testHttpClientOverride = _client();
+    final fvKey = GlobalKey<FileViewerPanelState>();
+    final ws = _MockWsClient();
+    await tester.pumpWidget(_ide(fvKey, ws, null));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('ide body'), findsNothing);
+    // Same tree, new initialFile → IdeLayout.didUpdateWidget fires.
+    await tester.pumpWidget(_ide(fvKey, ws, 'docs/note.txt'));
+    await tester.pumpAndSettle();
+    expect(find.textContaining('ide body'), findsOneWidget);
+    ws.close();
+  });
+}

--- a/src/frontend/test/terminal_link_test.dart
+++ b/src/frontend/test/terminal_link_test.dart
@@ -1,0 +1,193 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:klangk_frontend/terminal/terminal_link.dart';
+
+void main() {
+  // The file API addresses files relative to the container home; the shell cwd
+  // is `work/` under it. So files under work carry a `work/` prefix, while a
+  // file at the home root is bare (`file.txt`).
+  const home = '/home/klangk';
+  const cwd = '/home/klangk/work';
+  TerminalLinkTarget classify(String token, {String? uri, String pwd = ''}) =>
+      classifyTerminalLink(
+        token: token,
+        uri: uri,
+        pwd: pwd,
+        pathRoot: home,
+        defaultCwd: cwd,
+      );
+
+  group('classifyTerminalLink', () {
+    test('external http(s) URL from the token', () {
+      expect(classify('https://x.io/y?q=1#z'),
+          const ExternalUrl('https://x.io/y?q=1#z'));
+      expect(classify('http://x.io'), const ExternalUrl('http://x.io'));
+    });
+
+    test('OSC 8 http(s) uri takes precedence over the token', () {
+      expect(classify('label', uri: 'https://e.test'),
+          const ExternalUrl('https://e.test'));
+    });
+
+    test('non-http OSC 8 schemes never open externally (token used as path)',
+        () {
+      expect(classify('label', uri: 'javascript:alert(1)'),
+          const WorkspaceFile('work/label'));
+      expect(classify('readme.md', uri: 'file:///etc/passwd'),
+          const WorkspaceFile('work/readme.md'));
+    });
+
+    test('relative path resolves under cwd → work/-prefixed', () {
+      expect(classify('./research/ch01.md'),
+          const WorkspaceFile('work/research/ch01.md'));
+      expect(classify('research/ch01.md'),
+          const WorkspaceFile('work/research/ch01.md'));
+    });
+
+    test('~ expansion: home, work dir, files under work and at home', () {
+      expect(classify('~'), const WorkspaceFile('')); // home root
+      expect(classify('~/work'), const WorkspaceFile('work'));
+      expect(classify('~/work/file.txt'), const WorkspaceFile('work/file.txt'));
+      expect(classify('~/file.txt'),
+          const WorkspaceFile('file.txt')); // home-root file, no work/
+    });
+
+    test('absolute path under the home root', () {
+      expect(classify('/home/klangk/work/a/b.md'),
+          const WorkspaceFile('work/a/b.md'));
+      expect(
+          classify('/home/klangk/file.txt'), const WorkspaceFile('file.txt'));
+    });
+
+    test('relative path resolves against the OSC 7 pwd', () {
+      expect(
+        classify('x.md', pwd: 'file://host/home/klangk/work/sub'),
+        const WorkspaceFile('work/sub/x.md'),
+      );
+    });
+
+    test('paths escaping the path root → NoLink', () {
+      expect(classify('../../etc/passwd'), const NoLink());
+      expect(classify('../../../../../../x'), const NoLink());
+      expect(classify('/etc/passwd'), const NoLink());
+    });
+
+    test('token resolving to the home root itself → empty relative path', () {
+      expect(classify('..'), const WorkspaceFile(''));
+    });
+
+    test('empty token → NoLink', () {
+      expect(classify(''), const NoLink());
+    });
+
+    test('value semantics for the target types', () {
+      expect(const ExternalUrl('u'), const ExternalUrl('u'));
+      expect(const ExternalUrl('u').hashCode, const ExternalUrl('u').hashCode);
+      expect(const ExternalUrl('u').toString(), 'ExternalUrl(u)');
+      expect(const WorkspaceFile('p'), const WorkspaceFile('p'));
+      expect(
+          const WorkspaceFile('p').hashCode, const WorkspaceFile('p').hashCode);
+      expect(const WorkspaceFile('p').toString(), 'WorkspaceFile(p)');
+    });
+  });
+
+  group('TerminalLinkActions', () {
+    late List<String> opened;
+    late List<String> files;
+    late List<String> dirs;
+    late Map<String, PathKind> stat;
+
+    setUp(() {
+      opened = [];
+      files = [];
+      dirs = [];
+      stat = {};
+    });
+
+    TerminalLinkActions build() => TerminalLinkActions(
+          pathRoot: home,
+          defaultCwd: cwd,
+          openExternalUrl: opened.add,
+          statPath: (rel) async => stat[rel] ?? PathKind.none,
+          openFile: files.add,
+          openDirectory: dirs.add,
+        );
+
+    test('external URL → openExternalUrl, nothing else', () async {
+      await build()
+          .handle(token: 'https://x.io', pwd: '', tail: 'https://x.io');
+      expect(opened, ['https://x.io']);
+      expect(files, isEmpty);
+      expect(dirs, isEmpty);
+    });
+
+    test('OSC 8 http uri → openExternalUrl (precedence)', () async {
+      await build().handle(
+          token: 'label', uri: 'https://e.test', pwd: '', tail: 'label');
+      expect(opened, ['https://e.test']);
+    });
+
+    test('existing file → openFile', () async {
+      stat['work/a.md'] = PathKind.file;
+      await build().handle(token: './a.md', pwd: '', tail: './a.md');
+      expect(files, ['work/a.md']);
+    });
+
+    test('filename with spaces → greedy-extend to the longest existing file',
+        () async {
+      stat['work/a (1).pdf'] = PathKind.file; // only the full name exists
+      await build().handle(token: './a', pwd: '', tail: './a (1).pdf');
+      expect(files, ['work/a (1).pdf']);
+    });
+
+    test('directory → openDirectory', () async {
+      stat['work'] = PathKind.directory;
+      await build().handle(token: '~/work', pwd: '', tail: '~/work');
+      expect(dirs, ['work']);
+      expect(files, isEmpty);
+    });
+
+    test('home (~) → browse the root', () async {
+      stat[''] = PathKind.directory;
+      await build().handle(token: '~', pwd: '', tail: '~');
+      expect(dirs, ['']);
+    });
+
+    test('prefers the longest existing file over a shorter directory',
+        () async {
+      stat['work/a'] = PathKind.directory;
+      stat['work/a b.md'] = PathKind.file;
+      await build().handle(token: './a', pwd: '', tail: './a b.md');
+      expect(files, ['work/a b.md']);
+      expect(dirs, isEmpty);
+    });
+
+    test('nothing exists → opens nothing', () async {
+      await build().handle(token: './nope', pwd: '', tail: './nope');
+      expect(opened, isEmpty);
+      expect(files, isEmpty);
+      expect(dirs, isEmpty);
+    });
+
+    test('empty tail → nothing', () async {
+      await build().handle(token: 'x', pwd: '', tail: '');
+      expect(files, isEmpty);
+      expect(dirs, isEmpty);
+    });
+
+    test('greedy is bounded by maxTailWords', () async {
+      // Only a 4-word path exists, but the cap is 2 → never found.
+      stat['work/a b c d'] = PathKind.file;
+      final actions = TerminalLinkActions(
+        pathRoot: home,
+        defaultCwd: cwd,
+        openExternalUrl: opened.add,
+        statPath: (rel) async => stat[rel] ?? PathKind.none,
+        openFile: files.add,
+        openDirectory: dirs.add,
+        maxTailWords: 2,
+      );
+      await actions.handle(token: './a', pwd: '', tail: './a b c d');
+      expect(files, isEmpty);
+    });
+  });
+}

--- a/src/frontend/test/workspace_file_api_test.dart
+++ b/src/frontend/test/workspace_file_api_test.dart
@@ -1,0 +1,131 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:klangk_frontend/terminal/terminal_link.dart' show PathKind;
+import 'package:klangk_frontend/workspace/workspace_file_api.dart';
+
+void main() {
+  Future<PathKind> stat(
+    String rel, {
+    required http.Client client,
+    String? authToken,
+  }) =>
+      statWorkspacePath(
+        client: client,
+        baseUrl: 'https://h',
+        workspaceId: 'ws1',
+        rel: rel,
+        authToken: authToken,
+      );
+
+  MockClient listing(
+    List<Map<String, Object?>> entries, {
+    int status = 200,
+    void Function(http.Request req)? onReq,
+  }) =>
+      MockClient((req) async {
+        onReq?.call(req);
+        return http.Response(jsonEncode(entries), status);
+      });
+
+  group('statWorkspacePath', () {
+    test('home root (empty rel) → directory, no request made', () async {
+      var called = false;
+      final c = MockClient((_) async {
+        called = true;
+        return http.Response('[]', 200);
+      });
+      expect(await stat('', client: c), PathKind.directory);
+      expect(called, isFalse);
+    });
+
+    test('file: parent listing entry is_dir=false (parent path + auth header)',
+        () async {
+      late Uri seen;
+      late Map<String, String> headers;
+      final c = listing([
+        {'name': 'a.pdf', 'is_dir': false},
+      ], onReq: (r) {
+        seen = r.url;
+        headers = r.headers;
+      });
+      expect(await stat('work/research/a.pdf', client: c, authToken: 'tok'),
+          PathKind.file);
+      expect(seen.path, '/workspaces/ws1/files');
+      expect(seen.queryParameters['path'], 'work/research'); // parent listed
+      expect(headers['Authorization'], 'Bearer tok');
+    });
+
+    test('directory: parent listing entry is_dir=true', () async {
+      final c = listing([
+        {'name': 'sub', 'is_dir': true},
+      ]);
+      expect(await stat('work/sub', client: c), PathKind.directory);
+    });
+
+    test('a .pdf that is actually a directory → directory (the live bug)',
+        () async {
+      final c = listing([
+        {'name': 't2_rag_benchmark.pdf', 'is_dir': true},
+      ]);
+      expect(await stat('work/research/t2_rag_benchmark.pdf', client: c),
+          PathKind.directory);
+    });
+
+    test('absent: name not in the parent listing → none', () async {
+      final c = listing([
+        {'name': 'other', 'is_dir': false},
+      ]);
+      expect(await stat('work/missing.txt', client: c), PathKind.none);
+    });
+
+    test('top-level name (no slash) lists the home root', () async {
+      late Uri seen;
+      final c = listing([
+        {'name': 'file.txt', 'is_dir': false},
+      ], onReq: (r) => seen = r.url);
+      expect(await stat('file.txt', client: c), PathKind.file);
+      expect(seen.queryParameters['path'], ''); // parent = home root
+    });
+
+    test('spaces in the name match the listing entry', () async {
+      final c = listing([
+        {'name': 'a (1).pdf', 'is_dir': false},
+      ]);
+      expect(await stat('work/a (1).pdf', client: c), PathKind.file);
+    });
+
+    test('special chars (%) in the name', () async {
+      final c = listing([
+        {'name': 'a%b.txt', 'is_dir': false},
+      ]);
+      expect(await stat('work/a%b.txt', client: c), PathKind.file);
+    });
+
+    test('non-200 → none', () async {
+      expect(await stat('work/x', client: listing([], status: 404)),
+          PathKind.none);
+    });
+
+    test('non-list body → none', () async {
+      final c = MockClient((_) async => http.Response('{"oops":1}', 200));
+      expect(await stat('work/x', client: c), PathKind.none);
+    });
+
+    test('network error → none', () async {
+      final c = MockClient((_) async => throw Exception('down'));
+      expect(await stat('work/x', client: c), PathKind.none);
+    });
+
+    test('omits auth header when no token', () async {
+      late Map<String, String> headers;
+      final c = listing([
+        {'name': 'a', 'is_dir': false},
+      ], onReq: (r) => headers = r.headers);
+      await stat('work/a', client: c);
+      expect(headers.containsKey('Authorization'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## What

⌘-click (macOS) / Ctrl-click (Linux/Windows) a file path or URL in the terminal to open it:

- **Files** open in the **existing** file viewer (no duplicate viewer) via a go_router deep-link (`?file=`).
- **Directories** browse the folder in the Files tab (`?dir=`).
- **`http(s)` URLs** open in a new tab.

Two commits:
1. `feat(file-viewer): deep-link a file into the existing viewer` — the `?file=`/`?dir=` deep-link plumbing + the file-viewer `openFile`/`openDir` API.
2. `feat(terminal): wire ⌘/Ctrl-click terminal paths into the file viewer` — classify the clicked token, stat-resolve it, and dispatch.

## How it resolves

- `terminal_link.dart` — pure classifier (`http(s)` → external; else a workspace-relative path under the container home, rejecting `../` escapes) + a `TerminalLinkActions` dispatcher that greedy-extends the row tail across spaces, stats each candidate, and opens the **longest existing** file/dir.
- `workspace_file_api.statWorkspacePath` — file-vs-directory via the parent listing's `is_dir` (binary-safe; `/files/content` is text-only and 404s on binaries like PDFs).
- `ghostty_terminal` — forwards the flterm controller's `onLinkTap` (token / OSC 8 uri / row tail / live OSC 7 pwd) to the host.
- `file_viewer_panel` — `ValueKey(_selectedFile)` recreates the viewer so a direct file→file switch (e.g. PDF→Markdown) picks up fresh renderers.

## Security

Only `http(s)` opens externally (every other OSC 8 scheme is ignored). Every path is confined to the workspace root and **stat-verified before navigating**, so a mis-click never leaves the terminal.

## Dependency

Relies on a new `flterm` `onLinkTap` API (libghostty fork). The local build already overrides flterm to that fork via `KLANGK_FLTERM_PATH`; the upstream contribution is tracked separately.

## Backlog (documented in code + plan)

- Trailing sentence punctuation on a clicked path (`…/TODO.`) — the `.` is a valid path char and also ends prose; discrimination deferred.
- Soft-wrapped paths across terminal rows.

## Tests

- Unit: `terminal_link_test`, `workspace_file_api_test`, `ide_layout_initial_file_test`, `ghostty_terminal_test`, `file_viewer_m2_test` (incl. fail-first regression for the stale-renderer switch).
- e2e: `file-viewers/deep-link.spec.ts`.
- Full frontend suite green, **100% coverage**.