### PR TITLE
chore(deps): resolve klangk_plugin_api from mcdonc/main

### DIFF
--- a/scripts/import_dart_plugins.py
+++ b/scripts/import_dart_plugins.py
@@ -124,19 +124,13 @@ def generate_dart(plugins):
 def write_overrides_and_symlink():
     """Write pubspec_overrides.yaml at ~/.klangk/klangk/ and symlink it
     into the frontend directory so Flutter can find it."""
-    # The file-viewers stack needs the FileRenderer API, which currently lives
-    # on an unmerged branch of the plugin-api fork (mcdonc/klangk-plugin-api
-    # PR #2). Override klangk_plugin_api to that fork so the generated
-    # klangk_plugins package (which otherwise pins mcdonc) and the frontend
-    # resolve a single, FileRenderer-capable source. Drop this once PR #2 lands
-    # on mcdonc/main.
+    # Both the generated klangk_plugins package and the frontend depend on
+    # klangk_plugin_api from mcdonc/main (which carries the FileRenderer API as
+    # of PR #2), so no klangk_plugin_api override is needed — they resolve a
+    # single source on their own.
     overrides_content = (
         "dependency_overrides:\n"
         f"  klangk_plugins:\n    path: {KLANGK_DART_PLUGINS_PKG}\n"
-        "  klangk_plugin_api:\n"
-        "    git:\n"
-        "      url: https://github.com/runyaga/klangk-plugin-api.git\n"
-        "      ref: feat/file-renderer\n"
     )
     overrides_path = os.path.join(KLANGK_DART_PLUGINS_PKG, "pubspec_overrides.yaml")
     with open(overrides_path, "w") as f:

--- a/scripts/stub_dart_plugins.sh
+++ b/scripts/stub_dart_plugins.sh
@@ -43,15 +43,6 @@ cat >"$OVERRIDES" <<EOF
 dependency_overrides:
   klangk_plugins:
     path: $STUB_DIR
-  # The file-viewers stack needs the FileRenderer API, which currently lives on
-  # an unmerged branch of the plugin-api fork (mcdonc/klangk-plugin-api PR #2).
-  # Override klangk_plugin_api to that fork so both the stub package (which
-  # otherwise pins mcdonc) and the frontend resolve a single, FileRenderer-
-  # capable source. Drop this once PR #2 lands on mcdonc/main.
-  klangk_plugin_api:
-    git:
-      url: https://github.com/runyaga/klangk-plugin-api.git
-      ref: feat/file-renderer
 EOF
 ln -sf "$OVERRIDES" "$FRONTEND_DIR/pubspec_overrides.yaml"
 

--- a/src/frontend/pubspec.lock
+++ b/src/frontend/pubspec.lock
@@ -333,9 +333,9 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "feat/file-renderer"
-      resolved-ref: "8c87c8790037c85c3744500de629b85c4c5aa299"
-      url: "https://github.com/runyaga/klangk-plugin-api.git"
+      ref: HEAD
+      resolved-ref: a2887d6cfc9508ff6fe0b4806d5bb08b69153058
+      url: "https://github.com/mcdonc/klangk-plugin-api.git"
     source: git
     version: "0.1.0"
   klangk_plugins:

--- a/src/frontend/pubspec.yaml
+++ b/src/frontend/pubspec.yaml
@@ -35,8 +35,7 @@ dependencies:
   highlight: ^0.7.0
   klangk_plugin_api:
     git:
-      url: https://github.com/runyaga/klangk-plugin-api.git
-      ref: feat/file-renderer
+      url: https://github.com/mcdonc/klangk-plugin-api.git
   # Path set by import_plugins.py — do not edit this line
   klangk_plugins:
     path: PLACEHOLDER


### PR DESCRIPTION
## What

The FileRenderer API — `FileRenderer` / `FileRendererRegistry` / `FileRendererPlugin` — landed on `mcdonc/klangk-plugin-api` main via PR #2 (commit `a2887d6`). The frontend was temporarily pinned to the `runyaga/klangk-plugin-api` fork branch `feat/file-renderer` while that was unmerged; this drops the fork pin and resolves from upstream mcdonc.

## Changes

- **pubspec.yaml** — `klangk_plugin_api` now points at `mcdonc/klangk-plugin-api` (default branch) instead of `runyaga` `feat/file-renderer`.
- **import_dart_plugins.py / stub_dart_plugins.sh** — drop the `klangk_plugin_api` `dependency_override`. The generated `klangk_plugins` package and the frontend both depend on mcdonc now, so they resolve a single source without an override.
- **pubspec.lock** — re-resolved to mcdonc main (`a2887d6`).

## Verification

`flutter pub get` resolves `klangk_plugin_api` from `mcdonc/klangk-plugin-api.git` at `resolved-ref a2887d6` (the FileRenderer commit), and a full `flutter build web` compiles end-to-end (mcdonc main is byte-identical API to the merged fork branch).