### PR TITLE
Bump workspace base image to 2026.06.11-2603487

### DIFF
--- a/src/containers/workspace/Dockerfile
+++ b/src/containers/workspace/Dockerfile
@@ -1,4 +1,4 @@
-ARG WORKSPACE_BASE_IMAGE=ghcr.io/mcdonc/klangk/klangk-workspace-base:2026.06.10-e973f3c
+ARG WORKSPACE_BASE_IMAGE=ghcr.io/mcdonc/klangk/klangk-workspace-base:2026.06.11-2603487
 FROM $WORKSPACE_BASE_IMAGE
 
 # Install npm-based Pi extensions globally via pi install.


### PR DESCRIPTION
Auto-generated by the workspace base image build workflow.

Updates the pinned base image in `src/containers/workspace/Dockerfile` to `ghcr.io/mcdonc/klangk/klangk-workspace-base:2026.06.11-2603487`.