### PR TITLE
Add [skip ci] to automated base image bump commits

### DIFF
--- a/.github/workflows/image-workspace-base.yml
+++ b/.github/workflows/image-workspace-base.yml
@@ -61,7 +61,7 @@ jobs:
           git add src/containers/workspace/Dockerfile
           git -c user.name="github-actions[bot]" \
               -c user.email="github-actions[bot]@users.noreply.github.com" \
-              commit -m "build: bump workspace base image to ${VERSION}"
+              commit -m "build: bump workspace base image to ${VERSION} [skip ci]"
           git push origin "$BRANCH"
           gh pr create \
             --title "Bump workspace base image to ${VERSION}" \


### PR DESCRIPTION
## Summary

- Adds `[skip ci]` to the commit message generated by the workspace base image workflow when it bumps the pin in `src/containers/workspace/Dockerfile`.
- Prevents redundant test runs on the auto-generated PR, since the `Dockerfile.base` change that triggered the build already ran tests.

## Test plan

- [ ] Next time `Dockerfile.base` changes, verify the auto-generated bump PR commit has `[skip ci]` and doesn't trigger test workflows