### PR TITLE
Run tests automatically on pushes to release branches

### DIFF
--- a/.github/workflows/backend-e2e-tests.yml
+++ b/.github/workflows/backend-e2e-tests.yml
@@ -2,6 +2,8 @@ name: "E2E: Backend Tests"
 
 on:
   workflow_dispatch:
+  push:
+    branches: [release/**]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -2,6 +2,8 @@ name: Backend Tests
 
 on:
   workflow_dispatch:
+  push:
+    branches: [release/**]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/frontend-e2e-cross-browser.yml
+++ b/.github/workflows/frontend-e2e-cross-browser.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     # Every 6 hours
     - cron: "0 */6 * * *"
+  push:
+    branches: [release/**]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/frontend-e2e-tests.yml
+++ b/.github/workflows/frontend-e2e-tests.yml
@@ -11,6 +11,8 @@ on:
         description: "-g pattern to filter tests; blank = all"
         required: false
         default: ""
+  push:
+    branches: [release/**]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -2,6 +2,8 @@ name: Frontend Tests
 
 on:
   workflow_dispatch:
+  push:
+    branches: [release/**]
   pull_request:
     branches: [main]
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -272,14 +272,16 @@ git checkout -b stable/2026.06.10 v2026.06.10
 git cherry-pick <hotfix-commit>
 ```
 
-Tag backport releases with a `+N` suffix to distinguish them from same-day mainline releases:
+Tag backport releases with a `-N` suffix to distinguish them from same-day mainline releases:
 
 ```bash
-git tag v2026.06.10+1
-git push origin v2026.06.10+1
+git tag v2026.06.10-1
+git push origin v2026.06.10-1
 ```
 
-This triggers the release workflow, which builds and pushes versioned images. The customer's deployment repo (e.g. `klangk-host-with-plugins`) references the tag via `KLANGK_REF=v2026.06.10+1`.
+This triggers the release workflow, which builds and pushes versioned images. The customer's deployment repo (e.g. `klangk-host-with-plugins`) references the tag via `KLANGK_REF=v2026.06.10-1`.
+
+Note: do not use `+` in tags — Docker image tags don't allow the `+` character.
 
 Because the workspace base image is pinned in the Dockerfile, stable branches are isolated from base image changes on main. The branch only gets changes that are explicitly cherry-picked onto it.
 


### PR DESCRIPTION
## Summary

- Add `push` trigger for `release/**` branches to all four test workflows (backend, frontend, backend e2e, frontend e2e).
- Cherry-picks pushed directly to release branches now get tested automatically.
- PRs can still be used for larger backports if desired.

## Test plan

- [ ] Push a commit to `release/2026.06.10` after merging and verify all four test workflows trigger