### PR TITLE
fix(plugins): send workspace JWT to browser-delegate bridge calls

### DIFF
--- a/plugins/beep/extension.ts
+++ b/plugins/beep/extension.ts
@@ -1,5 +1,6 @@
 const BRIDGE_URL = process.env.KLANGK_BRIDGE_URL;
 const BRIDGE_TOKEN = process.env.KLANGK_BRIDGE_TOKEN;
+const WORKSPACE_TOKEN = process.env.KLANGK_WORKSPACE_TOKEN;
 
 export default function (pi: any) {
   if (!BRIDGE_URL || !BRIDGE_TOKEN) return;
@@ -19,7 +20,12 @@ export default function (pi: any) {
       try {
         const resp = await fetch(`${BRIDGE_URL}/api/browser-delegate`, {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            ...(WORKSPACE_TOKEN
+              ? { Authorization: `Bearer ${WORKSPACE_TOKEN}` }
+              : {}),
+          },
           body: JSON.stringify({
             action: "beep",
             token: BRIDGE_TOKEN,

--- a/plugins/bobdobbs/extension.ts
+++ b/plugins/bobdobbs/extension.ts
@@ -1,5 +1,6 @@
 const BRIDGE_URL = process.env.KLANGK_BRIDGE_URL;
 const BRIDGE_TOKEN = process.env.KLANGK_BRIDGE_TOKEN;
+const WORKSPACE_TOKEN = process.env.KLANGK_WORKSPACE_TOKEN;
 
 export default function (pi: any) {
   if (!BRIDGE_URL || !BRIDGE_TOKEN) return;
@@ -21,7 +22,12 @@ export default function (pi: any) {
       try {
         const resp = await fetch(`${BRIDGE_URL}/api/browser-delegate`, {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            ...(WORKSPACE_TOKEN
+              ? { Authorization: `Bearer ${WORKSPACE_TOKEN}` }
+              : {}),
+          },
           body: JSON.stringify({
             action: "bobdobbs",
             token: BRIDGE_TOKEN,

--- a/plugins/browser-fetch/extension.ts
+++ b/plugins/browser-fetch/extension.ts
@@ -2,6 +2,7 @@ import { Type } from "@sinclair/typebox";
 
 const BRIDGE_URL = process.env.KLANGK_BRIDGE_URL;
 const BRIDGE_TOKEN = process.env.KLANGK_BRIDGE_TOKEN;
+const WORKSPACE_TOKEN = process.env.KLANGK_WORKSPACE_TOKEN;
 
 export default function (pi: any) {
   if (!BRIDGE_URL || !BRIDGE_TOKEN) return;
@@ -44,7 +45,12 @@ export default function (pi: any) {
       try {
         const resp = await fetch(`${BRIDGE_URL}/api/browser-delegate`, {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            ...(WORKSPACE_TOKEN
+              ? { Authorization: `Bearer ${WORKSPACE_TOKEN}` }
+              : {}),
+          },
           body: JSON.stringify({
             action: "fetch",
             token: BRIDGE_TOKEN,

--- a/plugins/celebrate/extension.ts
+++ b/plugins/celebrate/extension.ts
@@ -1,5 +1,6 @@
 const BRIDGE_URL = process.env.KLANGK_BRIDGE_URL;
 const BRIDGE_TOKEN = process.env.KLANGK_BRIDGE_TOKEN;
+const WORKSPACE_TOKEN = process.env.KLANGK_WORKSPACE_TOKEN;
 
 const CONFETTI_CHARS = [
   "\x1b[91m*\x1b[0m",
@@ -89,7 +90,12 @@ export default function (pi: any) {
       try {
         const resp = await fetch(`${BRIDGE_URL}/api/browser-delegate`, {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            ...(WORKSPACE_TOKEN
+              ? { Authorization: `Bearer ${WORKSPACE_TOKEN}` }
+              : {}),
+          },
           body: JSON.stringify({
             action: "celebrate",
             token: BRIDGE_TOKEN,

--- a/plugins/itstime/extension.ts
+++ b/plugins/itstime/extension.ts
@@ -1,5 +1,6 @@
 const BRIDGE_URL = process.env.KLANGK_BRIDGE_URL;
 const BRIDGE_TOKEN = process.env.KLANGK_BRIDGE_TOKEN;
+const WORKSPACE_TOKEN = process.env.KLANGK_WORKSPACE_TOKEN;
 
 export default function (pi: any) {
   if (!BRIDGE_URL || !BRIDGE_TOKEN) return;
@@ -20,7 +21,12 @@ export default function (pi: any) {
       try {
         const resp = await fetch(`${BRIDGE_URL}/api/browser-delegate`, {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: {
+            "Content-Type": "application/json",
+            ...(WORKSPACE_TOKEN
+              ? { Authorization: `Bearer ${WORKSPACE_TOKEN}` }
+              : {}),
+          },
           body: JSON.stringify({
             action: "itstime",
             token: BRIDGE_TOKEN,


### PR DESCRIPTION
## Problem

#232 gated the container→host bridge endpoint `/api/browser-delegate` behind nginx `auth_request /auth/verify-workspace-token`, which requires `Authorization: Bearer $KLANGK_WORKSPACE_TOKEN`.

The shared client (`src/bridge/index.js`) was updated, but the five plugins that call the bridge with a raw `fetch` were not. nginx now answers their POSTs with 401 before the backend ever sees them, and each extension silently degrades:

- **celebrate** falls back to the ANSI alt-screen confetti instead of triggering the Flutter `ConfettiOverlay`
- **beep**, **bobdobbs**, **itstime**, **browser-fetch** fail their primary path outright

## Fix

Send the workspace JWT (`KLANGK_WORKSPACE_TOKEN`, injected into the container env at start) as a Bearer header on the bridge POST in all five `extension.ts` files — the same thing `@klangk/bridge` already does. The header is added conditionally so the extensions still work against older backends without the auth gate.

## Verification

Verified live against a running stack (macOS host, podman):

- with a valid per-session bridge token but **no** Authorization header, nginx returns 401 (reproducing the silent ANSI fallback)
- with the header, `POST /api/browser-delegate` returns 200 with `{"status":"ok","result":"Celebration triggered! "}` — that string is produced by `CelebratePlugin._handle` in the browser, i.e. the Flutter confetti fired
- a fresh pi session in the workspace registers `celebrate.ts` and the `celebrate` tool round-trips through the bridge

Note: backend pytest suite passes locally apart from `TestWorkspaceRoutes::test_duplicate_workspace`, which also fails on unmodified main on macOS (mount validation vs the `/tmp` symlink) and is unrelated to this change; backend CI on main is green.

## Follow-up (not in this PR)

Longer-term it would be better to install `@klangk/bridge` into the workspace image so extensions import it instead of hand-rolling `fetch` — auth contract changes would then land in one place. The bridge auth requirement is also currently undocumented in `docs/reference/plugin-system.md`.