### PR TITLE
Update workspace base image: bash shell, remove sudo

### DIFF
--- a/src/containers/workspace/Dockerfile
+++ b/src/containers/workspace/Dockerfile
@@ -1,4 +1,4 @@
-ARG WORKSPACE_BASE_IMAGE=ghcr.io/mcdonc/klangk/klangk-workspace-base:2026.06.11-2603487
+ARG WORKSPACE_BASE_IMAGE=ghcr.io/mcdonc/klangk/klangk-workspace-base:2026.06.12-a1181e0
 FROM $WORKSPACE_BASE_IMAGE
 
 # Install npm-based Pi extensions globally via pi install.

--- a/src/containers/workspace/Dockerfile.base
+++ b/src/containers/workspace/Dockerfile.base
@@ -71,6 +71,3 @@ RUN ln -sf /bin/bash /bin/sh
 
 RUN mkdir -p /home/klangk/work && chown -R klangk:klangk /home/klangk
 WORKDIR /home/klangk/work
-
-# Allow klangk user to sudo without a password (for installing packages, etc.)
-RUN echo "klangk ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/klangk

--- a/src/containers/workspace/Dockerfile.base
+++ b/src/containers/workspace/Dockerfile.base
@@ -64,7 +64,7 @@ RUN npm install -g @mariozechner/pi-coding-agent @earendil-works/pi-coding-agent
 RUN EXISTING_USER=$(getent passwd 1000 | cut -d: -f1) \
     && [ -n "$EXISTING_USER" ] && userdel "$EXISTING_USER" || true \
     && groupadd -g 1000 klangk \
-    && useradd -u 1000 -g 1000 -m -d /home/klangk -s /bin/sh klangk
+    && useradd -u 1000 -g 1000 -m -d /home/klangk -s /bin/bash klangk
 
 # Make /bin/sh point to bash so Pi's bash tool supports bashisms (source, etc.)
 RUN ln -sf /bin/bash /bin/sh


### PR DESCRIPTION
## Summary

- Set klangk user login shell to `/bin/bash` (was `/bin/sh`) so tmux uses bash by default without needing `default-command` in tmux.conf
- Remove passwordless sudo for klangk user — unnecessary privilege escalation

Requires base image rebuild and tag update in `src/containers/workspace/Dockerfile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)