### PR TITLE
Fix crun fchownat errors with rootless userns

### DIFF
--- a/src/containers/workspace/Dockerfile
+++ b/src/containers/workspace/Dockerfile
@@ -34,4 +34,16 @@ RUN chmod +x /opt/klangk/entrypoint.sh /usr/local/bin/setup_clankers
 COPY bash.bashrc /etc/bash.bashrc
 COPY tmux.conf /etc/tmux.conf
 
+# Fix non-root group ownership that causes crun fchownat errors with
+# --userns=keep-id. crun cannot remap groups like utmp, shadow, adm, ssh
+# in rootless user namespaces. The find handles most files; explicit
+# chgrp catches files that xargs may skip due to batch error handling.
+RUN chgrp root \
+      /var/log/btmp /var/log/wtmp /var/log/lastlog \
+      /var/log/apt/term.log \
+      /etc/shadow /etc/shadow- /etc/gshadow /etc/gshadow- \
+      /usr/bin/chage /usr/bin/expiry /usr/bin/ssh-agent \
+      /usr/sbin/unix_chkpwd /var/mail \
+    2>/dev/null; true
+
 ENTRYPOINT ["/opt/klangk/entrypoint.sh"]

--- a/src/containers/workspace/Dockerfile.base
+++ b/src/containers/workspace/Dockerfile.base
@@ -39,7 +39,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     iproute2 \
     bsdextrautils \
     tmux \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && chown -R root:root /var/log/apt
 
 # GitHub CLI (not in default Debian repos)
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
@@ -47,7 +48,8 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
     > /etc/apt/sources.list.d/github-cli.list \
     && apt-get update && apt-get install -y --no-install-recommends gh \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && chown -R root:root /var/log/apt
 
 # fd-find installs as fdfind on Debian — symlink to fd
 RUN ln -sf /usr/bin/fdfind /usr/bin/fd


### PR DESCRIPTION
## Summary

- Fix container startup failure: `crun: fchownat 'apt/term.log': Invalid argument`
- crun cannot remap non-root groups (utmp, shadow, adm, ssh) when using `--userns=keep-id` in rootless mode
- chgrp known problem files to root in both Dockerfile.base (apt/term.log) and Dockerfile (btmp, wtmp, lastlog, shadow, ssh-agent, etc.)

## Test plan

- [x] Container starts successfully with `--userns=keep-id:uid=1000,gid=1000`
- [ ] CI E2E tests pass (container startup works)

Requires base image rebuild for the Dockerfile.base changes to take effect.