### PR TITLE
fix(workspace): set tmux extended-keys-format to csi-u

### DIFF
--- a/src/containers/workspace/tmux.conf
+++ b/src/containers/workspace/tmux.conf
@@ -11,8 +11,9 @@ set -ga terminal-overrides ",xterm-256color:Tc"
 set -g escape-time 0
 set -g history-limit 50000
 
-# Pass through extended keys to applications
+# Pass through extended keys to applications (csi-u format for Pi compatibility)
 set -g extended-keys on
+set -g extended-keys-format csi-u
 set -gs terminal-features 'xterm*:extkeys'
 
 # Mouse off — the terminal emulator handles text selection and mouse wheel


### PR DESCRIPTION
## Summary
- Set `extended-keys-format csi-u` in tmux.conf so Pi no longer warns about xterm format on startup

## Test plan
- [ ] Rebuild workspace image and verify Pi starts without the extended-keys warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)