### PR TITLE
fix(devenv): share podman image storage across checkouts

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -332,7 +332,7 @@ in
     # Podman config lives outside the storage directory so
     # `podman system reset` doesn't delete it.
     _PODMAN_CONF="$DEVENV_STATE/klangk/podman"
-    _PODMAN_STORE="$DEVENV_STATE/klangk/containers"
+    _PODMAN_STORE="$HOME/.local/share/containers"
     # KLANGK_PODMAN_STORAGE: custom path for podman image storage.
     # Use an ext4 filesystem (not ZFS) for --userns=keep-id support.
     # ZFS lacks idmapped mounts, causing storage-chown-by-maps to hang.


### PR DESCRIPTION
## Summary
- Move podman graphroot from per-checkout `.devenv/state/klangk/containers/storage` to `~/.local/share/containers/storage` (the standard podman default)
- Images built in one checkout are now available in all checkouts without re-downloading

## Test plan
- [x] Backend tests pass
- [ ] Switch worktrees, verify `podman images` shows the same images

Closes #310

🤖 Generated with [Claude Code](https://claude.com/claude-code)