### PR TITLE
feat(terminal): add tmux window management for terminal tabs

### DIFF
--- a/src/backend/klangk_backend/terminal.py
+++ b/src/backend/klangk_backend/terminal.py
@@ -154,15 +154,25 @@ async def new_window(
 ) -> list[dict]:
     """Create a new tmux window and return the updated window list.
 
+    If *name* is not provided, auto-generates a unique name like
+    ``shell``, ``shell-2``, ``shell-3``, etc.
+
     Raises ``ValueError`` if *name* duplicates an existing window name.
     """
-    if name:
-        existing = await list_windows(container_id, session_name)
-        if any(w["name"] == name for w in existing):
-            raise ValueError(f"Window name '{name}' already exists")
-    args = ["new-window", "-t", session_name]
-    if name:
-        args += ["-n", name]
+    existing = await list_windows(container_id, session_name)
+    existing_names = {w["name"] for w in existing}
+
+    if name is None:
+        # Auto-generate a unique name.
+        name = "shell"
+        counter = 2
+        while name in existing_names:
+            name = f"shell-{counter}"
+            counter += 1
+    elif name in existing_names:
+        raise ValueError(f"Window name '{name}' already exists")
+
+    args = ["new-window", "-t", session_name, "-n", name]
     await tmux_command(container_id, session_name, args)
     return await list_windows(container_id, session_name)
 

--- a/src/backend/klangk_backend/terminal.py
+++ b/src/backend/klangk_backend/terminal.py
@@ -132,12 +132,12 @@ async def list_windows(container_id: str, session_name: str) -> list[dict]:
             "-t",
             session_name,
             "-F",
-            "#{window_index}\t#{window_name}\t#{window_active}",
+            "#{window_index}|||#{window_name}|||#{window_active}",
         ],
     )
     windows = []
     for line in output.strip().splitlines():
-        parts = line.split("\t")
+        parts = line.split("|||")
         if len(parts) >= 3:
             windows.append(
                 {

--- a/src/backend/klangk_backend/terminal.py
+++ b/src/backend/klangk_backend/terminal.py
@@ -163,12 +163,11 @@ async def new_window(
     existing_names = {w["name"] for w in existing}
 
     if name is None:
-        # Auto-generate a unique name.
-        name = "shell"
-        counter = 2
-        while name in existing_names:
-            name = f"shell-{counter}"
+        # Auto-generate a unique numeric name.
+        counter = 1
+        while str(counter) in existing_names:
             counter += 1
+        name = str(counter)
     elif name in existing_names:
         raise ValueError(f"Window name '{name}' already exists")
 

--- a/src/backend/klangk_backend/terminal.py
+++ b/src/backend/klangk_backend/terminal.py
@@ -89,6 +89,124 @@ def _build_exec_argv(
     return argv
 
 
+def _session_name(user_home: str | None) -> str | None:
+    """Extract the tmux session name from a user_home path."""
+    if user_home is None:
+        return None
+    return user_home.rsplit("/", 1)[-1]
+
+
+async def tmux_command(
+    container_id: str, session_name: str, args: list[str]
+) -> str:
+    """Run a tmux command in the container and return stdout."""
+    argv = [
+        "exec",
+        "-u",
+        "klangk",
+        container_id,
+        "tmux",
+        *args,
+    ]
+    proc = await asyncio.create_subprocess_exec(
+        podman.PODMAN_BIN,
+        *argv,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=podman.subprocess_env(),
+    )
+    stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=10)
+    if proc.returncode != 0:
+        err = stderr.decode("utf-8", errors="replace").strip()
+        raise RuntimeError(f"tmux command failed: {err}")
+    return stdout.decode("utf-8", errors="replace")
+
+
+async def list_windows(container_id: str, session_name: str) -> list[dict]:
+    """List tmux windows for a session. Returns [{index, name}, ...]."""
+    output = await tmux_command(
+        container_id,
+        session_name,
+        [
+            "list-windows",
+            "-t",
+            session_name,
+            "-F",
+            "#{window_index}\t#{window_name}\t#{window_active}",
+        ],
+    )
+    windows = []
+    for line in output.strip().splitlines():
+        parts = line.split("\t")
+        if len(parts) >= 3:
+            windows.append(
+                {
+                    "index": int(parts[0]),
+                    "name": parts[1],
+                    "active": parts[2] == "1",
+                }
+            )
+    return windows
+
+
+async def new_window(
+    container_id: str, session_name: str, name: str | None = None
+) -> list[dict]:
+    """Create a new tmux window and return the updated window list.
+
+    Raises ``ValueError`` if *name* duplicates an existing window name.
+    """
+    if name:
+        existing = await list_windows(container_id, session_name)
+        if any(w["name"] == name for w in existing):
+            raise ValueError(f"Window name '{name}' already exists")
+    args = ["new-window", "-t", session_name]
+    if name:
+        args += ["-n", name]
+    await tmux_command(container_id, session_name, args)
+    return await list_windows(container_id, session_name)
+
+
+async def rename_window(
+    container_id: str, session_name: str, index: int, name: str
+) -> None:
+    """Rename a tmux window.
+
+    Raises ``ValueError`` if *name* duplicates another window's name.
+    """
+    existing = await list_windows(container_id, session_name)
+    if any(w["name"] == name and w["index"] != index for w in existing):
+        raise ValueError(f"Window name '{name}' already exists")
+    await tmux_command(
+        container_id,
+        session_name,
+        ["rename-window", "-t", f"{session_name}:{index}", name],
+    )
+
+
+async def select_window(
+    container_id: str, session_name: str, index: int
+) -> None:
+    """Switch the active tmux window."""
+    await tmux_command(
+        container_id,
+        session_name,
+        ["select-window", "-t", f"{session_name}:{index}"],
+    )
+
+
+async def close_window(
+    container_id: str, session_name: str, index: int
+) -> list[dict]:
+    """Close a tmux window and return the updated window list."""
+    await tmux_command(
+        container_id,
+        session_name,
+        ["kill-window", "-t", f"{session_name}:{index}"],
+    )
+    return await list_windows(container_id, session_name)
+
+
 class ShellProcess:
     """Owns the PTY + ``podman exec`` subprocess for one shell."""
 

--- a/src/backend/klangk_backend/wshandler.py
+++ b/src/backend/klangk_backend/wshandler.py
@@ -860,15 +860,40 @@ class Connection:
                 )
                 container.registry.record_activity(conn.container_id)
                 conn.sock.send_json({"type": "terminal_started"})
-                # Send initial window list so the frontend can render tabs.
+                # Rename the initial window to "1" and send the list.
                 try:
-                    from .terminal import _session_name, list_windows
+                    from .terminal import (
+                        _session_name,
+                        list_windows,
+                        rename_window,
+                    )
 
                     sname = _session_name(conn._user_home)
                     if sname:
                         windows = await list_windows(conn.container_id, sname)
+                        # Rename any window still called "bash" to
+                        # the next available number.
+                        for w in windows:
+                            if w["name"] == "bash":
+                                num = 1
+                                used = {x["name"] for x in windows}
+                                while str(num) in used:
+                                    num += 1
+                                try:
+                                    await rename_window(
+                                        conn.container_id,
+                                        sname,
+                                        w["index"],
+                                        str(num),
+                                    )
+                                except Exception:
+                                    pass
+                        windows = await list_windows(conn.container_id, sname)
                         conn.sock.send_json(
-                            {"type": "terminal_windows", "windows": windows}
+                            {
+                                "type": "terminal_windows",
+                                "windows": windows,
+                            }
                         )
                 except Exception:
                     pass  # Non-critical; tabs update on next window op

--- a/src/backend/klangk_backend/wshandler.py
+++ b/src/backend/klangk_backend/wshandler.py
@@ -860,6 +860,18 @@ class Connection:
                 )
                 container.registry.record_activity(conn.container_id)
                 conn.sock.send_json({"type": "terminal_started"})
+                # Send initial window list so the frontend can render tabs.
+                try:
+                    from .terminal import _session_name, list_windows
+
+                    sname = _session_name(conn._user_home)
+                    if sname:
+                        windows = await list_windows(conn.container_id, sname)
+                        conn.sock.send_json(
+                            {"type": "terminal_windows", "windows": windows}
+                        )
+                except Exception:
+                    pass  # Non-critical; tabs update on next window op
             except asyncio.CancelledError:
                 await session.stop()
                 container.registry.revoke_connection_token(conn.sock)
@@ -895,6 +907,92 @@ class Connection:
 
     async def handle_terminal_stop(self) -> None:
         await self.stop_terminal()
+
+    def _tmux_session_name(self) -> str | None:
+        """Get the tmux session name from user_home."""
+        from .terminal import _session_name
+
+        return _session_name(self._user_home)
+
+    async def handle_terminal_new_window(self, msg: dict) -> None:
+        if not self.container_id or not self._user_home:
+            return
+        from .terminal import new_window
+
+        session_name = self._tmux_session_name()
+        name = msg.get("name")
+        try:
+            windows = await new_window(
+                self.container_id, session_name, name=name
+            )
+            self.sock.send_json(
+                {"type": "terminal_windows", "windows": windows}
+            )
+        except Exception as e:
+            send_error(self.sock, f"Failed to create window: {e}")
+
+    async def handle_terminal_select_window(self, msg: dict) -> None:
+        if not self.container_id or not self._user_home:
+            return
+        from .terminal import select_window
+
+        session_name = self._tmux_session_name()
+        index = msg.get("index", 0)
+        try:
+            await select_window(self.container_id, session_name, index)
+        except Exception as e:
+            send_error(self.sock, f"Failed to select window: {e}")
+
+    async def handle_terminal_close_window(self, msg: dict) -> None:
+        if not self.container_id or not self._user_home:
+            return
+        from .terminal import close_window
+
+        session_name = self._tmux_session_name()
+        index = msg.get("index", 0)
+        try:
+            windows = await close_window(
+                self.container_id, session_name, index
+            )
+            self.sock.send_json(
+                {"type": "terminal_windows", "windows": windows}
+            )
+        except Exception as e:
+            send_error(self.sock, f"Failed to close window: {e}")
+
+    async def handle_terminal_rename_window(self, msg: dict) -> None:
+        if not self.container_id or not self._user_home:
+            return
+        from .terminal import list_windows, rename_window
+
+        session_name = self._tmux_session_name()
+        index = msg.get("index", 0)
+        name = msg.get("name", "")
+        if not name:
+            send_error(self.sock, "Name required")
+            return
+        try:
+            await rename_window(self.container_id, session_name, index, name)
+            windows = await list_windows(self.container_id, session_name)
+            self.sock.send_json(
+                {"type": "terminal_windows", "windows": windows}
+            )
+        except Exception as e:
+            send_error(self.sock, f"Failed to rename window: {e}")
+
+    async def handle_terminal_list_windows(self) -> None:
+        if not self.container_id or not self._user_home:
+            return
+        from .terminal import list_windows
+
+        session_name = self._tmux_session_name()
+        try:
+            windows = await list_windows(self.container_id, session_name)
+            self.sock.send_json(
+                {"type": "terminal_windows", "windows": windows}
+            )
+        except Exception as e:
+            send_error(self.sock, f"Failed to list windows: {e}")
 
     async def handle_exec_start(self, msg: dict) -> None:
         if not self.container_id:
@@ -1215,6 +1313,16 @@ async def handle_websocket(websocket: WebSocket) -> None:
                 await conn.handle_terminal_resize(msg)
             elif cmd == "terminal_stop":
                 await conn.handle_terminal_stop()
+            elif cmd == "terminal_new_window":
+                await conn.handle_terminal_new_window(msg)
+            elif cmd == "terminal_select_window":
+                await conn.handle_terminal_select_window(msg)
+            elif cmd == "terminal_close_window":
+                await conn.handle_terminal_close_window(msg)
+            elif cmd == "terminal_rename_window":
+                await conn.handle_terminal_rename_window(msg)
+            elif cmd == "terminal_list_windows":
+                await conn.handle_terminal_list_windows()
             elif cmd == "restart_container":
                 await conn.handle_restart_container()
             elif cmd == "shutdown_container":

--- a/src/backend/tests/test_terminal.py
+++ b/src/backend/tests/test_terminal.py
@@ -502,7 +502,7 @@ class TestListWindows:
     async def test_parses_output(self):
         with patch(
             "klangk_backend.terminal.tmux_command",
-            return_value="0\tbash\t1\n1\tbuild\t0\n",
+            return_value="0|||bash|||1\n1|||build|||0\n",
         ):
             result = await list_windows("cid", "sess")
         assert result == [

--- a/src/backend/tests/test_terminal.py
+++ b/src/backend/tests/test_terminal.py
@@ -517,7 +517,18 @@ class TestListWindows:
 
 
 class TestNewWindow:
-    async def test_creates_window(self):
+    async def test_creates_window_auto_name(self):
+        call_count = [0]
+
+        async def fake_list(*a, **kw):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return [{"index": 0, "name": "bash", "active": True}]
+            return [
+                {"index": 0, "name": "bash", "active": False},
+                {"index": 1, "name": "shell", "active": True},
+            ]
+
         with (
             patch(
                 "klangk_backend.terminal.tmux_command",
@@ -525,17 +536,46 @@ class TestNewWindow:
             ) as mock_cmd,
             patch(
                 "klangk_backend.terminal.list_windows",
-                return_value=[
-                    {"index": 0, "name": "bash", "active": False},
-                    {"index": 1, "name": "bash", "active": True},
-                ],
+                side_effect=fake_list,
             ),
         ):
             result = await new_window("cid", "sess")
         mock_cmd.assert_called_once_with(
-            "cid", "sess", ["new-window", "-t", "sess"]
+            "cid", "sess", ["new-window", "-t", "sess", "-n", "shell"]
         )
         assert len(result) == 2
+
+    async def test_auto_name_skips_existing(self):
+        call_count = [0]
+
+        async def fake_list(*a, **kw):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return [
+                    {"index": 0, "name": "bash", "active": True},
+                    {"index": 1, "name": "shell", "active": False},
+                ]
+            return [
+                {"index": 0, "name": "bash", "active": False},
+                {"index": 1, "name": "shell", "active": False},
+                {"index": 2, "name": "shell-2", "active": True},
+            ]
+
+        with (
+            patch(
+                "klangk_backend.terminal.tmux_command",
+                return_value="",
+            ) as mock_cmd,
+            patch(
+                "klangk_backend.terminal.list_windows",
+                side_effect=fake_list,
+            ),
+        ):
+            result = await new_window("cid", "sess")
+        mock_cmd.assert_called_once_with(
+            "cid", "sess", ["new-window", "-t", "sess", "-n", "shell-2"]
+        )
+        assert len(result) == 3
 
     async def test_creates_named_window(self):
         call_count = [0]

--- a/src/backend/tests/test_terminal.py
+++ b/src/backend/tests/test_terminal.py
@@ -526,7 +526,7 @@ class TestNewWindow:
                 return [{"index": 0, "name": "bash", "active": True}]
             return [
                 {"index": 0, "name": "bash", "active": False},
-                {"index": 1, "name": "shell", "active": True},
+                {"index": 1, "name": "1", "active": True},
             ]
 
         with (
@@ -541,7 +541,7 @@ class TestNewWindow:
         ):
             result = await new_window("cid", "sess")
         mock_cmd.assert_called_once_with(
-            "cid", "sess", ["new-window", "-t", "sess", "-n", "shell"]
+            "cid", "sess", ["new-window", "-t", "sess", "-n", "1"]
         )
         assert len(result) == 2
 
@@ -553,12 +553,12 @@ class TestNewWindow:
             if call_count[0] == 1:
                 return [
                     {"index": 0, "name": "bash", "active": True},
-                    {"index": 1, "name": "shell", "active": False},
+                    {"index": 1, "name": "1", "active": False},
                 ]
             return [
                 {"index": 0, "name": "bash", "active": False},
-                {"index": 1, "name": "shell", "active": False},
-                {"index": 2, "name": "shell-2", "active": True},
+                {"index": 1, "name": "1", "active": False},
+                {"index": 2, "name": "2", "active": True},
             ]
 
         with (
@@ -573,7 +573,7 @@ class TestNewWindow:
         ):
             result = await new_window("cid", "sess")
         mock_cmd.assert_called_once_with(
-            "cid", "sess", ["new-window", "-t", "sess", "-n", "shell-2"]
+            "cid", "sess", ["new-window", "-t", "sess", "-n", "2"]
         )
         assert len(result) == 3
 

--- a/src/backend/tests/test_terminal.py
+++ b/src/backend/tests/test_terminal.py
@@ -6,9 +6,21 @@ lifecycle/queue logic against an injected fake shell.
 """
 
 import asyncio
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
-from klangk_backend.terminal import TerminalSession, _make_shell_process
+import pytest
+
+from klangk_backend.terminal import (
+    TerminalSession,
+    _make_shell_process,
+    _session_name,
+    close_window,
+    list_windows,
+    new_window,
+    rename_window,
+    select_window,
+    tmux_command,
+)
 
 SHELL_FACTORY = "klangk_backend.terminal._make_shell_process"
 
@@ -458,3 +470,169 @@ class TestIsAlive:
             await s.start()
         await s.stop()
         assert s.is_alive is False
+
+
+class TestSessionName:
+    def test_extracts_handle(self):
+        assert _session_name("/home/alice") == "alice"
+
+    def test_none(self):
+        assert _session_name(None) is None
+
+
+class TestTmuxCommand:
+    async def test_returns_stdout(self):
+        proc = AsyncMock()
+        proc.communicate = AsyncMock(return_value=(b"output\n", b""))
+        proc.returncode = 0
+        with patch("asyncio.create_subprocess_exec", return_value=proc):
+            result = await tmux_command("cid", "sess", ["list-windows"])
+        assert result == "output\n"
+
+    async def test_raises_on_failure(self):
+        proc = AsyncMock()
+        proc.communicate = AsyncMock(return_value=(b"", b"error msg"))
+        proc.returncode = 1
+        with patch("asyncio.create_subprocess_exec", return_value=proc):
+            with pytest.raises(RuntimeError, match="error msg"):
+                await tmux_command("cid", "sess", ["bad-cmd"])
+
+
+class TestListWindows:
+    async def test_parses_output(self):
+        with patch(
+            "klangk_backend.terminal.tmux_command",
+            return_value="0\tbash\t1\n1\tbuild\t0\n",
+        ):
+            result = await list_windows("cid", "sess")
+        assert result == [
+            {"index": 0, "name": "bash", "active": True},
+            {"index": 1, "name": "build", "active": False},
+        ]
+
+    async def test_empty_session(self):
+        with patch("klangk_backend.terminal.tmux_command", return_value=""):
+            result = await list_windows("cid", "sess")
+        assert result == []
+
+
+class TestNewWindow:
+    async def test_creates_window(self):
+        with (
+            patch(
+                "klangk_backend.terminal.tmux_command",
+                return_value="",
+            ) as mock_cmd,
+            patch(
+                "klangk_backend.terminal.list_windows",
+                return_value=[
+                    {"index": 0, "name": "bash", "active": False},
+                    {"index": 1, "name": "bash", "active": True},
+                ],
+            ),
+        ):
+            result = await new_window("cid", "sess")
+        mock_cmd.assert_called_once_with(
+            "cid", "sess", ["new-window", "-t", "sess"]
+        )
+        assert len(result) == 2
+
+    async def test_creates_named_window(self):
+        call_count = [0]
+
+        async def fake_list(*a, **kw):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                # First call: duplicate check — no existing "build"
+                return [{"index": 0, "name": "bash", "active": True}]
+            # Second call: after creation
+            return [
+                {"index": 0, "name": "bash", "active": False},
+                {"index": 1, "name": "build", "active": True},
+            ]
+
+        with (
+            patch(
+                "klangk_backend.terminal.tmux_command",
+                return_value="",
+            ) as mock_cmd,
+            patch(
+                "klangk_backend.terminal.list_windows",
+                side_effect=fake_list,
+            ),
+        ):
+            result = await new_window("cid", "sess", name="build")
+        mock_cmd.assert_called_once_with(
+            "cid", "sess", ["new-window", "-t", "sess", "-n", "build"]
+        )
+        assert len(result) == 2
+
+    async def test_rejects_duplicate_name(self):
+        with patch(
+            "klangk_backend.terminal.list_windows",
+            return_value=[{"index": 0, "name": "build", "active": True}],
+        ):
+            with pytest.raises(ValueError, match="already exists"):
+                await new_window("cid", "sess", name="build")
+
+
+class TestSelectWindow:
+    async def test_selects_window(self):
+        with patch(
+            "klangk_backend.terminal.tmux_command",
+            return_value="",
+        ) as mock_cmd:
+            await select_window("cid", "sess", 2)
+        mock_cmd.assert_called_once_with(
+            "cid", "sess", ["select-window", "-t", "sess:2"]
+        )
+
+
+class TestCloseWindow:
+    async def test_closes_window(self):
+        with (
+            patch(
+                "klangk_backend.terminal.tmux_command",
+                return_value="",
+            ) as mock_cmd,
+            patch(
+                "klangk_backend.terminal.list_windows",
+                return_value=[{"index": 0, "name": "bash", "active": True}],
+            ),
+        ):
+            result = await close_window("cid", "sess", 1)
+        mock_cmd.assert_called_once_with(
+            "cid", "sess", ["kill-window", "-t", "sess:1"]
+        )
+        assert len(result) == 1
+
+
+class TestRenameWindow:
+    async def test_renames_window(self):
+        with (
+            patch(
+                "klangk_backend.terminal.list_windows",
+                return_value=[
+                    {"index": 0, "name": "bash", "active": True},
+                ],
+            ),
+            patch(
+                "klangk_backend.terminal.tmux_command",
+                return_value="",
+            ) as mock_cmd,
+        ):
+            await rename_window("cid", "sess", 0, "build")
+        mock_cmd.assert_called_once_with(
+            "cid", "sess", ["rename-window", "-t", "sess:0", "build"]
+        )
+
+    async def test_rejects_duplicate_name(self):
+        with patch(
+            "klangk_backend.terminal.list_windows",
+            return_value=[
+                {"index": 0, "name": "bash", "active": True},
+                {"index": 1, "name": "build", "active": False},
+            ],
+        ):
+            with pytest.raises(ValueError, match="already exists"):
+                await rename_window("cid", "sess", 0, "build")

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -407,7 +407,13 @@ class TestHandleTerminalStart:
         conn._user_home = "/home/testuser"
         container.registry.track_activity("cid", "ws")
 
-        with patch.object(wshandler, "TerminalSession") as MockTS:
+        with (
+            patch.object(wshandler, "TerminalSession") as MockTS,
+            patch(
+                "klangk_backend.terminal.list_windows",
+                return_value=[{"index": 0, "name": "bash", "active": True}],
+            ),
+        ):
             mock_session = _mock_terminal()
             MockTS.return_value = mock_session
 
@@ -422,6 +428,12 @@ class TestHandleTerminalStart:
             await asyncio.sleep(0)
 
         MockTS.assert_called_once_with("cid", user_home="/home/testuser")
+        # Should have sent terminal_windows after terminal_started
+        sent = [c[0][0] for c in sock.send_json.call_args_list]
+        assert any(
+            isinstance(m, dict) and m.get("type") == "terminal_windows"
+            for m in sent
+        )
         # bridge_token should be passed (a UUID string)
         start_kwargs = mock_session.start.call_args
         assert start_kwargs[1]["command_override"] is None
@@ -429,8 +441,11 @@ class TestHandleTerminalStart:
         assert conn._bridge_token == start_kwargs[1]["bridge_token"]
         assert conn.terminal_session is mock_session
         assert conn.terminal_task is not None
-        # Should have sent terminal_started ack
-        sock.send_json.assert_called_with({"type": "terminal_started"})
+        # Should have sent terminal_started ack (followed by terminal_windows)
+        assert any(
+            isinstance(m, dict) and m.get("type") == "terminal_started"
+            for m in sent
+        )
 
         # Clean up
         conn.terminal_task.cancel()
@@ -455,6 +470,47 @@ class TestHandleTerminalStart:
             and "Handle" in call.args[0].get("message", "")
             for call in sent
         )
+
+    async def test_start_window_list_failure_non_fatal(self):
+        """If list_windows fails after terminal start, terminal still works."""
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock)
+        conn.container_id = "cid"
+        conn.workspace_id = "ws"
+        conn._user_home = "/home/testuser"
+        container.registry.track_activity("cid", "ws")
+
+        with (
+            patch.object(wshandler, "TerminalSession") as MockTS,
+            patch(
+                "klangk_backend.terminal.list_windows",
+                side_effect=RuntimeError("tmux not ready"),
+            ),
+        ):
+            mock_session = _mock_terminal()
+            MockTS.return_value = mock_session
+
+            async def fake_output():
+                return
+                yield
+
+            mock_session.output = fake_output
+            await conn.handle_terminal_start({"cols": 80, "rows": 24})
+            await asyncio.sleep(0)
+
+        # terminal_started still sent despite list_windows failure
+        sent = [c[0][0] for c in sock.send_json.call_args_list]
+        assert any(
+            isinstance(m, dict) and m.get("type") == "terminal_started"
+            for m in sent
+        )
+        conn.terminal_task.cancel()
+        try:
+            await conn.terminal_task
+        except asyncio.CancelledError:
+            pass
+        container.registry.revoke_bridge_token("ws")
+        container.registry.states.pop("ws", None)
 
     async def test_restart_revokes_old_bridge_token(self):
         """Starting a second terminal revokes the previous bridge token."""
@@ -1239,6 +1295,17 @@ class TestHandleWebsocketDispatch:
     async def test_dispatch_terminal_stop(self, user):
         websocket = await self._run_commands(user, [{"cmd": "terminal_stop"}])
         websocket.accept.assert_awaited_once()
+
+    async def test_dispatch_terminal_window_commands(self, user):
+        for cmd in (
+            "terminal_new_window",
+            "terminal_select_window",
+            "terminal_close_window",
+            "terminal_rename_window",
+            "terminal_list_windows",
+        ):
+            websocket = await self._run_commands(user, [{"cmd": cmd}])
+            websocket.accept.assert_awaited_once()
 
     async def test_dispatch_restart_container(self, user):
         websocket = await self._run_commands(
@@ -2663,6 +2730,182 @@ class TestHandleShutdownContainer:
         assert any(
             isinstance(m, dict) and "Not connected" in str(m) for m in sent
         )
+
+
+class TestTerminalWindowHandlers:
+    async def test_new_window_no_container(self):
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock)
+        conn.container_id = None
+        await conn.handle_terminal_new_window({})
+        assert sock.send_json.call_count == 0
+
+    async def test_new_window_success(self):
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock)
+        conn.container_id = "cid"
+        conn._user_home = "/home/alice"
+        with patch(
+            "klangk_backend.terminal.new_window",
+            return_value=[
+                {"index": 0, "name": "bash", "active": False},
+                {"index": 1, "name": "bash", "active": True},
+            ],
+        ):
+            await conn.handle_terminal_new_window({})
+        sent = sock.send_json.call_args[0][0]
+        assert sent["type"] == "terminal_windows"
+        assert len(sent["windows"]) == 2
+
+    async def test_new_window_with_name(self):
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock)
+        conn.container_id = "cid"
+        conn._user_home = "/home/alice"
+        with patch(
+            "klangk_backend.terminal.new_window",
+            return_value=[
+                {"index": 0, "name": "bash", "active": False},
+                {"index": 1, "name": "build", "active": True},
+            ],
+        ) as mock_new:
+            await conn.handle_terminal_new_window({"name": "build"})
+        mock_new.assert_called_once_with("cid", "alice", name="build")
+
+    async def test_new_window_error(self):
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock)
+        conn.container_id = "cid"
+        conn._user_home = "/home/alice"
+        with patch(
+            "klangk_backend.terminal.new_window",
+            side_effect=ValueError("already exists"),
+        ):
+            await conn.handle_terminal_new_window({"name": "dup"})
+        sent = sock.send_json.call_args[0][0]
+        assert sent["type"] == "error"
+
+    async def test_select_window(self):
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock)
+        conn.container_id = "cid"
+        conn._user_home = "/home/alice"
+        with patch(
+            "klangk_backend.terminal.select_window",
+        ) as mock_sel:
+            await conn.handle_terminal_select_window({"index": 2})
+        mock_sel.assert_called_once_with("cid", "alice", 2)
+
+    async def test_select_window_error(self):
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock)
+        conn.container_id = "cid"
+        conn._user_home = "/home/alice"
+        with patch(
+            "klangk_backend.terminal.select_window",
+            side_effect=RuntimeError("no such window"),
+        ):
+            await conn.handle_terminal_select_window({"index": 99})
+        sent = sock.send_json.call_args[0][0]
+        assert sent["type"] == "error"
+
+    async def test_close_window(self):
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock)
+        conn.container_id = "cid"
+        conn._user_home = "/home/alice"
+        with patch(
+            "klangk_backend.terminal.close_window",
+            return_value=[{"index": 0, "name": "bash", "active": True}],
+        ):
+            await conn.handle_terminal_close_window({"index": 1})
+        sent = sock.send_json.call_args[0][0]
+        assert sent["type"] == "terminal_windows"
+
+    async def test_close_window_error(self):
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock)
+        conn.container_id = "cid"
+        conn._user_home = "/home/alice"
+        with patch(
+            "klangk_backend.terminal.close_window",
+            side_effect=RuntimeError("no such window"),
+        ):
+            await conn.handle_terminal_close_window({"index": 99})
+        sent = sock.send_json.call_args[0][0]
+        assert sent["type"] == "error"
+
+    async def test_rename_window(self):
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock)
+        conn.container_id = "cid"
+        conn._user_home = "/home/alice"
+        with (
+            patch(
+                "klangk_backend.terminal.rename_window",
+            ),
+            patch(
+                "klangk_backend.terminal.list_windows",
+                return_value=[{"index": 0, "name": "build", "active": True}],
+            ),
+        ):
+            await conn.handle_terminal_rename_window(
+                {"index": 0, "name": "build"}
+            )
+        sent = sock.send_json.call_args[0][0]
+        assert sent["type"] == "terminal_windows"
+
+    async def test_rename_window_no_name(self):
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock)
+        conn.container_id = "cid"
+        conn._user_home = "/home/alice"
+        await conn.handle_terminal_rename_window({"index": 0})
+        sent = sock.send_json.call_args[0][0]
+        assert sent["type"] == "error"
+        assert "Name" in sent["message"]
+
+    async def test_rename_window_error(self):
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock)
+        conn.container_id = "cid"
+        conn._user_home = "/home/alice"
+        with patch(
+            "klangk_backend.terminal.rename_window",
+            side_effect=ValueError("already exists"),
+        ):
+            await conn.handle_terminal_rename_window(
+                {"index": 0, "name": "dup"}
+            )
+        sent = sock.send_json.call_args[0][0]
+        assert sent["type"] == "error"
+
+    async def test_list_windows(self):
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock)
+        conn.container_id = "cid"
+        conn._user_home = "/home/alice"
+        with patch(
+            "klangk_backend.terminal.list_windows",
+            return_value=[{"index": 0, "name": "bash", "active": True}],
+        ):
+            await conn.handle_terminal_list_windows()
+        sent = sock.send_json.call_args[0][0]
+        assert sent["type"] == "terminal_windows"
+        assert len(sent["windows"]) == 1
+
+    async def test_list_windows_error(self):
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock)
+        conn.container_id = "cid"
+        conn._user_home = "/home/alice"
+        with patch(
+            "klangk_backend.terminal.list_windows",
+            side_effect=RuntimeError("tmux not running"),
+        ):
+            await conn.handle_terminal_list_windows()
+        sent = sock.send_json.call_args[0][0]
+        assert sent["type"] == "error"
 
 
 class TestFractionalTimeout:

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -407,12 +407,21 @@ class TestHandleTerminalStart:
         conn._user_home = "/home/testuser"
         container.registry.track_activity("cid", "ws")
 
+        list_call = [0]
+
+        async def fake_list(*a, **kw):
+            list_call[0] += 1
+            if list_call[0] <= 1:
+                return [{"index": 0, "name": "bash", "active": True}]
+            return [{"index": 0, "name": "1", "active": True}]
+
         with (
             patch.object(wshandler, "TerminalSession") as MockTS,
             patch(
                 "klangk_backend.terminal.list_windows",
-                return_value=[{"index": 0, "name": "bash", "active": True}],
+                side_effect=fake_list,
             ),
+            patch("klangk_backend.terminal.rename_window"),
         ):
             mock_session = _mock_terminal()
             MockTS.return_value = mock_session
@@ -470,6 +479,107 @@ class TestHandleTerminalStart:
             and "Handle" in call.args[0].get("message", "")
             for call in sent
         )
+
+    async def test_start_renames_bash_skips_taken_numbers(self):
+        """If window '1' exists, bash gets renamed to '2'."""
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock)
+        conn.container_id = "cid"
+        conn.workspace_id = "ws"
+        conn._user_home = "/home/testuser"
+        container.registry.track_activity("cid", "ws")
+
+        list_call = [0]
+
+        async def fake_list(*a, **kw):
+            list_call[0] += 1
+            if list_call[0] <= 1:
+                return [
+                    {"index": 0, "name": "bash", "active": True},
+                    {"index": 1, "name": "1", "active": False},
+                ]
+            return [
+                {"index": 0, "name": "2", "active": True},
+                {"index": 1, "name": "1", "active": False},
+            ]
+
+        with (
+            patch.object(wshandler, "TerminalSession") as MockTS,
+            patch(
+                "klangk_backend.terminal.list_windows",
+                side_effect=fake_list,
+            ),
+            patch("klangk_backend.terminal.rename_window") as mock_rename,
+        ):
+            mock_session = _mock_terminal()
+            MockTS.return_value = mock_session
+
+            async def fake_output():
+                return
+                yield
+
+            mock_session.output = fake_output
+            await conn.handle_terminal_start({"cols": 80, "rows": 24})
+            await asyncio.sleep(0)
+
+        # Should have renamed bash to "2" (skipping "1")
+        mock_rename.assert_called_once_with("cid", "testuser", 0, "2")
+        conn.terminal_task.cancel()
+        try:
+            await conn.terminal_task
+        except asyncio.CancelledError:
+            pass
+        container.registry.revoke_bridge_token("ws")
+        container.registry.states.pop("ws", None)
+
+    async def test_start_rename_failure_non_fatal(self):
+        """If renaming the initial bash window fails, tabs still work."""
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock)
+        conn.container_id = "cid"
+        conn.workspace_id = "ws"
+        conn._user_home = "/home/testuser"
+        container.registry.track_activity("cid", "ws")
+
+        with (
+            patch.object(wshandler, "TerminalSession") as MockTS,
+            patch(
+                "klangk_backend.terminal.list_windows",
+                return_value=[{"index": 0, "name": "bash", "active": True}],
+            ),
+            patch(
+                "klangk_backend.terminal.rename_window",
+                side_effect=RuntimeError("rename failed"),
+            ),
+        ):
+            mock_session = _mock_terminal()
+            MockTS.return_value = mock_session
+
+            async def fake_output():
+                return
+                yield
+
+            mock_session.output = fake_output
+            await conn.handle_terminal_start({"cols": 80, "rows": 24})
+            await asyncio.sleep(0)
+
+        sent = [c[0][0] for c in sock.send_json.call_args_list]
+        assert any(
+            isinstance(m, dict) and m.get("type") == "terminal_started"
+            for m in sent
+        )
+        # terminal_windows still sent even though rename failed
+        assert any(
+            isinstance(m, dict) and m.get("type") == "terminal_windows"
+            for m in sent
+        )
+        conn.terminal_task.cancel()
+        try:
+            await conn.terminal_task
+        except asyncio.CancelledError:
+            pass
+        container.registry.revoke_bridge_token("ws")
+        container.registry.states.pop("ws", None)
 
     async def test_start_window_list_failure_non_fatal(self):
         """If list_windows fails after terminal start, terminal still works."""

--- a/src/frontend/e2e-tests/e2e/terminal-tabs.spec.ts
+++ b/src/frontend/e2e-tests/e2e/terminal-tabs.spec.ts
@@ -1,0 +1,409 @@
+import { test, expect } from "@playwright/test";
+import WebSocket from "ws";
+import { createAndOpenWorkspace, API_BASE } from "./helpers";
+
+// Helper: open a parallel WebSocket, connect to the workspace, wait for
+// container_ready, then expose send/receive for window management commands.
+
+interface WindowInfo {
+  index: number;
+  name: string;
+  active: boolean;
+}
+
+class TerminalWsClient {
+  private ws: WebSocket;
+  private messageQueue: Array<Record<string, unknown>> = [];
+  private waiters: Array<(msg: Record<string, unknown>) => void> = [];
+  private closed = false;
+
+  constructor(ws: WebSocket) {
+    this.ws = ws;
+    ws.on("message", (raw: Buffer | string) => {
+      const msg = JSON.parse(raw.toString());
+      if (this.waiters.length > 0) {
+        this.waiters.shift()!(msg);
+      } else {
+        this.messageQueue.push(msg);
+      }
+    });
+  }
+
+  send(msg: Record<string, unknown>) {
+    this.ws.send(JSON.stringify(msg));
+  }
+
+  async recv(timeout = 10_000): Promise<Record<string, unknown>> {
+    if (this.messageQueue.length > 0) {
+      return this.messageQueue.shift()!;
+    }
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        reject(new Error("recv timed out"));
+      }, timeout);
+      this.waiters.push((msg) => {
+        clearTimeout(timer);
+        resolve(msg);
+      });
+    });
+  }
+
+  /** Receive messages until one matches the predicate. */
+  async recvUntil(
+    predicate: (msg: Record<string, unknown>) => boolean,
+    timeout = 30_000,
+  ): Promise<Record<string, unknown>> {
+    const deadline = Date.now() + timeout;
+    while (Date.now() < deadline) {
+      const msg = await this.recv(deadline - Date.now());
+      if (predicate(msg)) return msg;
+    }
+    throw new Error("recvUntil timed out");
+  }
+
+  close() {
+    if (!this.closed) {
+      this.closed = true;
+      this.ws.close();
+    }
+  }
+}
+
+/** Connect to a workspace via WebSocket, wait for container_ready.
+ *  Returns a client that can send window management commands. */
+async function connectToWorkspace(
+  token: string,
+  workspaceId: string,
+): Promise<TerminalWsClient> {
+  const wsUrl = API_BASE.replace("http://", "ws://");
+
+  return new Promise<TerminalWsClient>((resolve, reject) => {
+    const ws = new WebSocket(`${wsUrl}/ws?token=${token}`);
+    const timeout = setTimeout(() => {
+      ws.close();
+      reject(new Error("connect timed out"));
+    }, 60_000);
+
+    const client = new TerminalWsClient(ws);
+
+    ws.on("open", () => {
+      client.send({ cmd: "workspace_connect", workspaceId });
+    });
+
+    ws.on("error", (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+
+    // Drive through the connection flow
+    (async () => {
+      // Wait for workspace_ready
+      await client.recvUntil((m) => m.type === "workspace_ready");
+      // Send ui_ready
+      client.send({ cmd: "ui_ready" });
+      // Wait for container_ready
+      await client.recvUntil(
+        (m) =>
+          m.type === "event" &&
+          (m.event as Record<string, unknown>)?.name === "container_ready",
+      );
+      clearTimeout(timeout);
+      resolve(client);
+    })().catch((err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+}
+
+/** Send a terminal_start and wait for terminal_windows response. */
+async function startTerminalAndGetWindows(
+  client: TerminalWsClient,
+): Promise<WindowInfo[]> {
+  client.send({ cmd: "terminal_start", cols: 80, rows: 24 });
+  const msg = await client.recvUntil((m) => m.type === "terminal_windows");
+  return msg.windows as WindowInfo[];
+}
+
+test.describe("terminal tabs", () => {
+  test("terminal starts with one window", async ({ page, request }) => {
+    const { workspaceId, token, cleanup } = await createAndOpenWorkspace(
+      page,
+      request,
+      "tabs-init",
+      { waitForTerminal: true },
+    );
+    try {
+      const client = await connectToWorkspace(token, workspaceId);
+      try {
+        const windows = await startTerminalAndGetWindows(client);
+        expect(windows.length).toBe(1);
+        expect(windows[0].active).toBe(true);
+        expect(windows[0].index).toBe(0);
+      } finally {
+        client.close();
+      }
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("create a new terminal window", async ({ page, request }) => {
+    const { workspaceId, token, cleanup } = await createAndOpenWorkspace(
+      page,
+      request,
+      "tabs-create",
+      { waitForTerminal: true },
+    );
+    try {
+      const client = await connectToWorkspace(token, workspaceId);
+      try {
+        await startTerminalAndGetWindows(client);
+
+        // Create a new window
+        client.send({ cmd: "terminal_new_window", name: "build" });
+        const msg = await client.recvUntil(
+          (m) => m.type === "terminal_windows",
+        );
+        const windows = msg.windows as WindowInfo[];
+        expect(windows.length).toBe(2);
+        expect(windows.some((w) => w.name === "build")).toBe(true);
+      } finally {
+        client.close();
+      }
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("create named window rejects duplicate names", async ({
+    page,
+    request,
+  }) => {
+    const { workspaceId, token, cleanup } = await createAndOpenWorkspace(
+      page,
+      request,
+      "tabs-dup",
+      { waitForTerminal: true },
+    );
+    try {
+      const client = await connectToWorkspace(token, workspaceId);
+      try {
+        await startTerminalAndGetWindows(client);
+
+        // Create first window named "test"
+        client.send({ cmd: "terminal_new_window", name: "test" });
+        await client.recvUntil((m) => m.type === "terminal_windows");
+
+        // Try to create another with the same name
+        client.send({ cmd: "terminal_new_window", name: "test" });
+        const msg = await client.recvUntil((m) => m.type === "error");
+        expect((msg.message as string).toLowerCase()).toContain(
+          "already exists",
+        );
+      } finally {
+        client.close();
+      }
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("close a terminal window", async ({ page, request }) => {
+    const { workspaceId, token, cleanup } = await createAndOpenWorkspace(
+      page,
+      request,
+      "tabs-close",
+      { waitForTerminal: true },
+    );
+    try {
+      const client = await connectToWorkspace(token, workspaceId);
+      try {
+        await startTerminalAndGetWindows(client);
+
+        // Create a second window
+        client.send({ cmd: "terminal_new_window", name: "temp" });
+        const created = await client.recvUntil(
+          (m) => m.type === "terminal_windows",
+        );
+        const tempWindow = (created.windows as WindowInfo[]).find(
+          (w) => w.name === "temp",
+        )!;
+        expect(tempWindow).toBeDefined();
+
+        // Close it
+        client.send({
+          cmd: "terminal_close_window",
+          index: tempWindow.index,
+        });
+        const afterClose = await client.recvUntil(
+          (m) => m.type === "terminal_windows",
+        );
+        const remaining = afterClose.windows as WindowInfo[];
+        expect(remaining.length).toBe(1);
+        expect(remaining.some((w) => w.name === "temp")).toBe(false);
+      } finally {
+        client.close();
+      }
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("rename a terminal window", async ({ page, request }) => {
+    const { workspaceId, token, cleanup } = await createAndOpenWorkspace(
+      page,
+      request,
+      "tabs-rename",
+      { waitForTerminal: true },
+    );
+    try {
+      const client = await connectToWorkspace(token, workspaceId);
+      try {
+        const windows = await startTerminalAndGetWindows(client);
+        const firstIndex = windows[0].index;
+
+        // Rename window 0
+        client.send({
+          cmd: "terminal_rename_window",
+          index: firstIndex,
+          name: "main-shell",
+        });
+        const msg = await client.recvUntil(
+          (m) => m.type === "terminal_windows",
+        );
+        const renamed = msg.windows as WindowInfo[];
+        expect(renamed[0].name).toBe("main-shell");
+      } finally {
+        client.close();
+      }
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("rename rejects duplicate names", async ({ page, request }) => {
+    const { workspaceId, token, cleanup } = await createAndOpenWorkspace(
+      page,
+      request,
+      "tabs-rename-dup",
+      { waitForTerminal: true },
+    );
+    try {
+      const client = await connectToWorkspace(token, workspaceId);
+      try {
+        await startTerminalAndGetWindows(client);
+
+        // Create a second window named "build"
+        client.send({ cmd: "terminal_new_window", name: "build" });
+        await client.recvUntil((m) => m.type === "terminal_windows");
+
+        // Try to rename window 0 to "build"
+        client.send({
+          cmd: "terminal_rename_window",
+          index: 0,
+          name: "build",
+        });
+        const msg = await client.recvUntil((m) => m.type === "error");
+        expect((msg.message as string).toLowerCase()).toContain(
+          "already exists",
+        );
+      } finally {
+        client.close();
+      }
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("select-window switches the active window", async ({
+    page,
+    request,
+  }) => {
+    const { workspaceId, token, cleanup } = await createAndOpenWorkspace(
+      page,
+      request,
+      "tabs-select",
+      { waitForTerminal: true },
+    );
+    try {
+      const client = await connectToWorkspace(token, workspaceId);
+      try {
+        await startTerminalAndGetWindows(client);
+
+        // Create second window
+        client.send({ cmd: "terminal_new_window", name: "second" });
+        const created = await client.recvUntil(
+          (m) => m.type === "terminal_windows",
+        );
+        const secondIdx = (created.windows as WindowInfo[]).find(
+          (w) => w.name === "second",
+        )!.index;
+
+        // Switch back to window 0
+        client.send({ cmd: "terminal_select_window", index: 0 });
+
+        // Verify by listing windows — window 0 should be active
+        client.send({ cmd: "terminal_list_windows" });
+        const listed = await client.recvUntil(
+          (m) => m.type === "terminal_windows",
+        );
+        const windows = listed.windows as WindowInfo[];
+        const active = windows.find((w) => w.active);
+        expect(active).toBeDefined();
+        expect(active!.index).toBe(0);
+
+        // Switch to second window
+        client.send({ cmd: "terminal_select_window", index: secondIdx });
+        client.send({ cmd: "terminal_list_windows" });
+        const listed2 = await client.recvUntil(
+          (m) => m.type === "terminal_windows",
+        );
+        const windows2 = listed2.windows as WindowInfo[];
+        const active2 = windows2.find((w) => w.active);
+        expect(active2).toBeDefined();
+        expect(active2!.index).toBe(secondIdx);
+      } finally {
+        client.close();
+      }
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("list-windows returns all windows", async ({ page, request }) => {
+    const { workspaceId, token, cleanup } = await createAndOpenWorkspace(
+      page,
+      request,
+      "tabs-list",
+      { waitForTerminal: true },
+    );
+    try {
+      const client = await connectToWorkspace(token, workspaceId);
+      try {
+        await startTerminalAndGetWindows(client);
+
+        // Create two more windows
+        client.send({ cmd: "terminal_new_window", name: "build" });
+        await client.recvUntil((m) => m.type === "terminal_windows");
+        client.send({ cmd: "terminal_new_window", name: "logs" });
+        await client.recvUntil((m) => m.type === "terminal_windows");
+
+        // List all
+        client.send({ cmd: "terminal_list_windows" });
+        const msg = await client.recvUntil(
+          (m) => m.type === "terminal_windows",
+        );
+        const windows = msg.windows as WindowInfo[];
+        expect(windows.length).toBe(3);
+        const names = windows.map((w) => w.name);
+        expect(names).toContain("build");
+        expect(names).toContain("logs");
+      } finally {
+        client.close();
+      }
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/frontend/lib/workspace/workspace_page.dart
+++ b/src/frontend/lib/workspace/workspace_page.dart
@@ -531,7 +531,7 @@ class _TerminalTab extends StatelessWidget {
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
         decoration: BoxDecoration(
-          color: active ? KColors.panelBg : Colors.transparent,
+          color: active ? KColors.bgSurface : Colors.transparent,
           border: Border(
             bottom: BorderSide(
               color: active ? KColors.accentGreen : Colors.transparent,

--- a/src/frontend/lib/workspace/workspace_page.dart
+++ b/src/frontend/lib/workspace/workspace_page.dart
@@ -248,6 +248,58 @@ class _WorkspacePageState extends State<WorkspacePage> {
     wsClient.sendRestartContainer();
   }
 
+  Widget _buildTerminalWithTabs(WsClient wsClient) {
+    final windows = wsClient.terminalWindows;
+    return Column(
+      children: [
+        if (windows.length > 1 || windows.isNotEmpty)
+          SizedBox(
+            height: 28,
+            child: Row(
+              children: [
+                Expanded(
+                  child: ListView(
+                    scrollDirection: Axis.horizontal,
+                    children: [
+                      for (final w in windows)
+                        _TerminalTab(
+                          name: w['name'] as String? ?? '?',
+                          active: w['active'] as bool? ?? false,
+                          onTap: () => wsClient.sendTerminalSelectWindow(
+                            w['index'] as int,
+                          ),
+                          onClose: windows.length > 1
+                              ? () => wsClient.sendTerminalCloseWindow(
+                                    w['index'] as int,
+                                  )
+                              : null,
+                        ),
+                    ],
+                  ),
+                ),
+                IconButton(
+                  onPressed: () => wsClient.sendTerminalNewWindow(),
+                  icon: const Icon(Icons.add, size: 16),
+                  iconSize: 16,
+                  padding: EdgeInsets.zero,
+                  constraints:
+                      const BoxConstraints(minWidth: 28, minHeight: 28),
+                  tooltip: 'New terminal',
+                ),
+              ],
+            ),
+          ),
+        Expanded(
+          child: GhosttyTerminal(
+            key: _terminalKey,
+            wsClient: wsClient,
+            onPathTap: _handleTerminalPathTap,
+          ),
+        ),
+      ],
+    );
+  }
+
   Future<void> _reconnect() async {
     setState(() => _connecting = true);
     final wsClient = context.read<WsClient>();
@@ -338,11 +390,7 @@ class _WorkspacePageState extends State<WorkspacePage> {
               authToken: authToken,
               registry: _fileRenderers,
             ),
-            terminal: GhosttyTerminal(
-              key: _terminalKey,
-              wsClient: wsClient,
-              onPathTap: _handleTerminalPathTap,
-            ),
+            terminal: _buildTerminalWithTabs(wsClient),
             chat: _hasPerm('chat')
                 ? WorkspaceChat(
                     key: _chatKey,
@@ -458,6 +506,62 @@ class _WorkspacePageState extends State<WorkspacePage> {
               ),
             ),
         ],
+      ),
+    );
+  }
+}
+
+class _TerminalTab extends StatelessWidget {
+  final String name;
+  final bool active;
+  final VoidCallback onTap;
+  final VoidCallback? onClose;
+
+  const _TerminalTab({
+    required this.name,
+    required this.active,
+    required this.onTap,
+    this.onClose,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+        decoration: BoxDecoration(
+          color: active ? KColors.panelBg : Colors.transparent,
+          border: Border(
+            bottom: BorderSide(
+              color: active ? KColors.accentGreen : Colors.transparent,
+              width: 2,
+            ),
+          ),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              name,
+              style: TextStyle(
+                fontSize: 12,
+                color: active ? Colors.white : Colors.white60,
+              ),
+            ),
+            if (onClose != null) ...[
+              const SizedBox(width: 4),
+              GestureDetector(
+                onTap: onClose,
+                child: Icon(
+                  Icons.close,
+                  size: 12,
+                  color: active ? Colors.white54 : Colors.white30,
+                ),
+              ),
+            ],
+          ],
+        ),
       ),
     );
   }

--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -95,6 +95,9 @@ class WsClient extends ChangeNotifier {
   /// Users currently connected to the workspace.
   List<Map<String, dynamic>> presenceUsers = [];
 
+  /// Terminal windows in the current tmux session.
+  List<Map<String, dynamic>> terminalWindows = [];
+
   /// Chat messages (individual and history) from the backend.
   Stream<Map<String, dynamic>> get chatMessages => _chatController.stream;
 
@@ -216,6 +219,10 @@ class WsClient extends ChangeNotifier {
                   presenceUsers.where((u) => u['user_id'] != uid).toList();
               notifyListeners();
             }
+          } else if (type == 'terminal_windows') {
+            final windows = json['windows'] as List? ?? [];
+            terminalWindows = windows.cast<Map<String, dynamic>>();
+            notifyListeners();
           } else if (type == 'event') {
             _customEventController.add(json);
           }
@@ -305,6 +312,28 @@ class WsClient extends ChangeNotifier {
 
   void sendTerminalResize(int cols, int rows) {
     _send({'cmd': 'terminal_resize', 'cols': cols, 'rows': rows});
+  }
+
+  void sendTerminalNewWindow({String? name}) {
+    final msg = <String, dynamic>{'cmd': 'terminal_new_window'};
+    if (name != null) msg['name'] = name;
+    _send(msg);
+  }
+
+  void sendTerminalSelectWindow(int index) {
+    _send({'cmd': 'terminal_select_window', 'index': index});
+  }
+
+  void sendTerminalCloseWindow(int index) {
+    _send({'cmd': 'terminal_close_window', 'index': index});
+  }
+
+  void sendTerminalRenameWindow(int index, String name) {
+    _send({'cmd': 'terminal_rename_window', 'index': index, 'name': name});
+  }
+
+  void sendTerminalListWindows() {
+    _send({'cmd': 'terminal_list_windows'});
   }
 
   void sendTerminalStop() {

--- a/src/frontend/test/ws_client_test.dart
+++ b/src/frontend/test/ws_client_test.dart
@@ -121,6 +121,12 @@ void main() {
       client.sendTerminalStart();
       client.sendTerminalInput('ls\n');
       client.sendTerminalResize(120, 40);
+      client.sendTerminalNewWindow();
+      client.sendTerminalNewWindow(name: 'build');
+      client.sendTerminalSelectWindow(1);
+      client.sendTerminalCloseWindow(1);
+      client.sendTerminalRenameWindow(0, 'test');
+      client.sendTerminalListWindows();
       client.sendTerminalStop();
       client.sendHeartbeat();
       client.sendBrowserResponse('req-1', {'status': 'ok'});
@@ -587,6 +593,11 @@ void main() {
       client.sendTerminalStart(cols: 100, rows: 30);
       client.sendTerminalInput('ls\n');
       client.sendTerminalResize(120, 40);
+      client.sendTerminalNewWindow(name: 'build');
+      client.sendTerminalSelectWindow(2);
+      client.sendTerminalCloseWindow(1);
+      client.sendTerminalRenameWindow(0, 'main');
+      client.sendTerminalListWindows();
       client.sendTerminalStop();
       client.sendUiReady();
       client.connectWorkspace('ws-1');
@@ -600,10 +611,37 @@ void main() {
       expect(msgs[2], {'cmd': 'terminal_start', 'cols': 100, 'rows': 30});
       expect(msgs[3], {'cmd': 'terminal_input', 'data': 'ls\n'});
       expect(msgs[4], {'cmd': 'terminal_resize', 'cols': 120, 'rows': 40});
-      expect(msgs[5], {'cmd': 'terminal_stop'});
-      expect(msgs[6], {'cmd': 'ui_ready'});
-      expect(msgs[7], {'cmd': 'workspace_connect', 'workspaceId': 'ws-1'});
-      expect(msgs[8], {'cmd': 'workspace_disconnect'});
+      expect(msgs[5], {'cmd': 'terminal_new_window', 'name': 'build'});
+      expect(msgs[6], {'cmd': 'terminal_select_window', 'index': 2});
+      expect(msgs[7], {'cmd': 'terminal_close_window', 'index': 1});
+      expect(msgs[8],
+          {'cmd': 'terminal_rename_window', 'index': 0, 'name': 'main'});
+      expect(msgs[9], {'cmd': 'terminal_list_windows'});
+      expect(msgs[10], {'cmd': 'terminal_stop'});
+      expect(msgs[11], {'cmd': 'ui_ready'});
+      expect(msgs[12], {'cmd': 'workspace_connect', 'workspaceId': 'ws-1'});
+      expect(msgs[13], {'cmd': 'workspace_disconnect'});
+    });
+
+    test('sendTerminalNewWindow without name omits name field', () {
+      client.sendTerminalNewWindow();
+      final msg = jsonDecode(channel.sentMessages.last as String);
+      expect(msg['cmd'], 'terminal_new_window');
+      expect(msg.containsKey('name'), isFalse);
+    });
+
+    test('terminal_windows message updates terminalWindows', () async {
+      channel.serverSend({
+        'type': 'terminal_windows',
+        'windows': [
+          {'index': 0, 'name': 'bash', 'active': true},
+          {'index': 1, 'name': 'build', 'active': false},
+        ],
+      });
+      await Future.delayed(Duration.zero);
+      expect(client.terminalWindows.length, 2);
+      expect(client.terminalWindows[0]['name'], 'bash');
+      expect(client.terminalWindows[1]['name'], 'build');
     });
 
     test('sendTerminalStart uses default cols/rows', () {


### PR DESCRIPTION
## Summary
- Add WebSocket commands: `terminal_new_window`, `terminal_select_window`, `terminal_close_window`, `terminal_rename_window`, `terminal_list_windows`
- Window names must be unique within the session
- Backend sends `terminal_windows` list after `terminal_started` and after each mutation
- Frontend tab bar with "+" button, close buttons, active tab highlighting
- 8 frontend E2E tests exercising create, close, rename, duplicate rejection, select, and list

## Architecture
Single PTY approach — one `podman exec` → tmux session. Window switching via `tmux select-window`. Background windows keep running and buffering output. No multiple PTYs or output demuxing needed.

## Test plan
- [x] Backend: 1252 tests, 100% coverage
- [x] Frontend: 539 tests passed
- [ ] Frontend E2E: 8 terminal-tabs tests (run on CI)
- [ ] Manual: open workspace, click "+", see new tab, switch tabs, close tab, rename

Closes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)