### PR TITLE
fix(devenv): guard su/util-linux to Linux-only

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -46,11 +46,18 @@ in
       podman
       sqlite.bin
       rsync
-      su
-      util-linux
       zensical
     ]
-    ++ (if pkgs.stdenv.isDarwin then [ iproute2mac ] else [ iproute2 ]);
+    ++ (
+      if pkgs.stdenv.isDarwin then
+        [ iproute2mac ]
+      else
+        [
+          iproute2
+          su
+          util-linux
+        ]
+    );
 
   env.PLAYWRIGHT_BROWSERS_PATH = pkgs.playwright-driver.browsers;
   env.PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS = "true";


### PR DESCRIPTION
## Problem

Commit bb2c846 ("chore: add util-linux package to devenv") added `su` and `util-linux` to the unconditional `packages` list in `devenv.nix`. Both are Linux-only packages, so on darwin (macOS) Nix evaluation fails with an `unsupported system` error — `devenv up` / `devenv shell` is broken for every macOS developer who pulls `main`.

## Fix

Move `su` and `util-linux` into the existing `pkgs.stdenv.isLinux` branch alongside `iproute2`, so they're only pulled in where they actually build and are needed (the Linux workspace tooling).

## Verification

- Before: `devenv up` on darwin fails during shell evaluation (`Failed to get drvPath from shell derivation` → unsupported system).
- After: `devenv up -d` evaluates cleanly; `backend` and `nginx` both come up ready and nginx serves 200 on :8995.