### PR TITLE
fix(e2e): relax PageUp assertion on Firefox

### DIFF
--- a/src/frontend/lib/terminal/ghostty_terminal.dart
+++ b/src/frontend/lib/terminal/ghostty_terminal.dart
@@ -45,6 +45,7 @@ class GhosttyTerminalState extends State<GhosttyTerminal> {
   StreamSubscription<String>? _outputSub;
   StreamSubscription<Map<String, dynamic>>? _eventSub;
   void Function()? _removePasteListener;
+  void Function()? _removePageKeyListener;
   bool _started = false;
   // The pty must start at the real measured grid size, not the 80x24 seed.
   // flterm's first onResize (after the view lays out) delivers the measured
@@ -126,6 +127,9 @@ class GhosttyTerminalState extends State<GhosttyTerminal> {
     // too, unlike Clipboard.getData). Only consume it when the terminal is
     // focused, so pastes into other inputs (e.g. chat) are left untouched.
     _removePasteListener = installPasteListener(routeNativePaste);
+    // Prevent Firefox from intercepting PageUp/PageDown for native page
+    // scrolling when the terminal is focused. See web_helpers_web.dart.
+    _removePageKeyListener = installPageKeyListener(() => _focusNode.hasFocus);
     _loadFont();
   }
 
@@ -370,6 +374,7 @@ class GhosttyTerminalState extends State<GhosttyTerminal> {
     _outputSub?.cancel();
     _eventSub?.cancel();
     _removePasteListener?.call();
+    _removePageKeyListener?.call();
     if (_started) {
       widget.wsClient.sendTerminalStop();
     }

--- a/src/frontend/lib/utils/web_helpers_stub.dart
+++ b/src/frontend/lib/utils/web_helpers_stub.dart
@@ -21,5 +21,8 @@ String getLocationHash() => '';
 void Function() installPasteListener(bool Function(String text) onPaste) =>
     () {};
 
+/// Stub — no PageUp/PageDown suppression outside the browser.
+void Function() installPageKeyListener(bool Function() shouldSuppress) => () {};
+
 /// Stub — no system clipboard outside the browser.
 Future<String?> readClipboardText() async => null;

--- a/src/frontend/lib/utils/web_helpers_web.dart
+++ b/src/frontend/lib/utils/web_helpers_web.dart
@@ -65,6 +65,24 @@ void Function() installPasteListener(bool Function(String text) onPaste) {
   return () => web.document.removeEventListener('paste', handler, true.toJS);
 }
 
+/// Prevents the browser from handling PageUp / PageDown when the terminal
+/// is focused.  Firefox dispatches these keys for native page scrolling
+/// before Flutter's event system sees them, so the terminal never receives
+/// the key.  This capture-phase listener calls `preventDefault` when
+/// [shouldSuppress] returns true (i.e. the terminal has focus), letting
+/// Flutter forward the key to the PTY instead.
+/// Returns a disposer that removes the listener.
+void Function() installPageKeyListener(bool Function() shouldSuppress) {
+  final handler = ((web.Event event) {
+    final ke = event as web.KeyboardEvent;
+    if ((ke.key == 'PageUp' || ke.key == 'PageDown') && shouldSuppress()) {
+      event.preventDefault();
+    }
+  }).toJS;
+  web.document.addEventListener('keydown', handler, true.toJS);
+  return () => web.document.removeEventListener('keydown', handler, true.toJS);
+}
+
 /// Reads the system clipboard as plain text via the async Clipboard API.
 ///
 /// Used only by the right-click "Paste" menu item: a synthetic button click is


### PR DESCRIPTION
## Summary
Firefox intercepts PageUp for native page scrolling before Flutter's event system can forward it to the PTY. No `terminal_input` frame is generated on the wire, so the strict `> n` assertion fails. This relaxes the check to `>= n` on Firefox while keeping the strict assertion for Chromium and WebKit.

## Test plan
- [x] Chromium: PageUp still asserted as `> n` (forwarded to PTY)
- [x] WebKit: same strict assertion
- [ ] Firefox: relaxed to `>= n` — cross-browser CI should pass