### PR TITLE
fix(container): populate home with /etc/skel so .bashrc works

### DIFF
--- a/src/backend/e2e-tests/test_per_user_home.py
+++ b/src/backend/e2e-tests/test_per_user_home.py
@@ -335,6 +335,42 @@ class TestPerUserHome:
             cleanup()
 
 
+class TestBashrc:
+    @pytest.mark.asyncio
+    async def test_user_bashrc_sourced_in_login_shell(self, server, auth):
+        """~/.bashrc is sourced when a login shell starts (as tmux does).
+
+        tmux starts bash as a login shell for new windows.  Login bash
+        reads /etc/profile then ~/.profile — but per-user HOME dirs
+        don't get /etc/skel/.profile, so ~/.bashrc is never sourced
+        unless /etc/bash.bashrc or ~/.profile does it explicitly.
+        """
+        workspace_id, cleanup = create_workspace(server, auth)
+        try:
+            ws = await ws_connect(server, auth, workspace_id)
+            try:
+                # Write a .bashrc that sets a marker env var
+                await exec_command(
+                    ws,
+                    [
+                        "bash",
+                        "-c",
+                        'echo "export BASHRC_MARKER=hello_from_bashrc" '
+                        "> $HOME/.bashrc",
+                    ],
+                )
+                # Start a login shell (same as tmux new-window does)
+                output = await exec_command(
+                    ws,
+                    ["bash", "-lic", "echo $BASHRC_MARKER"],
+                )
+                assert "hello_from_bashrc" in output
+            finally:
+                await ws.close()
+        finally:
+            cleanup()
+
+
 class TestHandleChange:
     @pytest.mark.asyncio
     async def test_change_handle_via_set_handle(self, server, auth):

--- a/src/backend/klangk_backend/workspaces.py
+++ b/src/backend/klangk_backend/workspaces.py
@@ -310,7 +310,7 @@ def ensure_home_symlink(
     workspace_home: Path,
     handle: str,
     user_id: str,
-) -> str:
+) -> tuple[str, bool]:
     """Ensure the ``/home/{handle} -> .users/{user_id}`` symlink exists.
 
     Creates the ``.users/{user_id}`` directory and symlink if missing.
@@ -318,19 +318,22 @@ def ensure_home_symlink(
     If the handle changed (old symlink for this user_id exists), removes
     the old one and creates the new one.
 
-    Returns the container-side home path (e.g. ``/home/alice``).
+    Returns ``(container_home_path, created)`` where *created* is True
+    when a new user directory was created (caller should populate it
+    with skeleton files).
     """
     users_dir = workspace_home / ".users"
     users_dir.mkdir(parents=True, exist_ok=True)
 
     user_dir = users_dir / user_id
+    created = not user_dir.exists()
     user_dir.mkdir(exist_ok=True)
 
     symlink = workspace_home / handle
     target = f".users/{user_id}"
 
     if symlink.is_symlink() and os.readlink(symlink) == target:
-        return f"/home/{handle}"  # already correct
+        return f"/home/{handle}", created
 
     # Remove any existing symlink for this user (handle rename).
     for entry in workspace_home.iterdir():
@@ -339,4 +342,39 @@ def ensure_home_symlink(
             break
 
     symlink.symlink_to(target)
-    return f"/home/{handle}"
+    return f"/home/{handle}", created
+
+
+async def populate_home_skel(
+    container_id: str,
+    user_id: str,
+) -> None:
+    """Copy /etc/skel into a new user's home directory inside the container.
+
+    This gives the user the standard skeleton files (.profile, .bashrc,
+    etc.) so login shells source ~/.bashrc as users expect.  /etc/skel
+    is part of the shadow-utils/login package and is present on most
+    Linux distributions (notable exception: NixOS).  The workspace
+    container runs Ubuntu, which always has it.
+    """
+    from . import podman
+
+    home = f"/home/.users/{user_id}"
+    script = f"if [ -d /etc/skel ]; then cp -a /etc/skel/. {home}/; fi"
+    argv = ["exec", "-u", "klangk", container_id, "bash", "-c", script]
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            podman.PODMAN_BIN,
+            *argv,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=podman.subprocess_env(),
+        )
+        await asyncio.wait_for(proc.communicate(), timeout=10)
+    except Exception:
+        logger.warning(
+            "Failed to populate skel for user %s in %s",
+            user_id,
+            container_id,
+            exc_info=True,
+        )

--- a/src/backend/klangk_backend/wshandler.py
+++ b/src/backend/klangk_backend/wshandler.py
@@ -643,9 +643,13 @@ class Connection:
         handle = await model.get_user_handle(self.user["id"])
         if handle:
             workspace_home = workspaces.home_path(owner_id, workspace_id)
-            self._user_home = workspaces.ensure_home_symlink(
+            self._user_home, created = workspaces.ensure_home_symlink(
                 workspace_home, handle, self.user["id"]
             )
+            if created:
+                await workspaces.populate_home_skel(
+                    container_id, self.user["id"]
+                )
         else:
             self._user_home = None
 
@@ -1723,9 +1727,13 @@ class Connection:
                 workspace_home = workspaces.home_path(
                     owner_id, self.workspace_id
                 )
-                container_home = workspaces.ensure_home_symlink(
+                container_home, created = workspaces.ensure_home_symlink(
                     workspace_home, handle, self.user["id"]
                 )
+                if created and self.container_id:
+                    await workspaces.populate_home_skel(
+                        self.container_id, self.user["id"]
+                    )
                 self._user_home = container_home
             self.sock.send_json(
                 {

--- a/src/backend/tests/test_workspaces.py
+++ b/src/backend/tests/test_workspaces.py
@@ -156,8 +156,9 @@ class TestEnsureHomeSymlink:
     async def test_creates_symlink(self, user):
         ws = await ws_mod.create_workspace(user["id"], "symlink-ws")
         home = ws_mod.home_path(user["id"], ws["id"])
-        result = ws_mod.ensure_home_symlink(home, "alice", "uid-1")
+        result, created = ws_mod.ensure_home_symlink(home, "alice", "uid-1")
         assert result == "/home/alice"
+        assert created is True
         symlink = home / "alice"
         assert symlink.is_symlink()
         assert os.readlink(symlink) == ".users/uid-1"
@@ -167,14 +168,42 @@ class TestEnsureHomeSymlink:
         ws = await ws_mod.create_workspace(user["id"], "symlink-ws2")
         home = ws_mod.home_path(user["id"], ws["id"])
         ws_mod.ensure_home_symlink(home, "bob", "uid-1")
-        result = ws_mod.ensure_home_symlink(home, "bob", "uid-1")
+        result, created = ws_mod.ensure_home_symlink(home, "bob", "uid-1")
         assert result == "/home/bob"
+        assert created is False
 
     async def test_rename_removes_old_symlink(self, user):
         ws = await ws_mod.create_workspace(user["id"], "symlink-ws3")
         home = ws_mod.home_path(user["id"], ws["id"])
         ws_mod.ensure_home_symlink(home, "alice", "uid-1")
-        result = ws_mod.ensure_home_symlink(home, "alicia", "uid-1")
+        result, created = ws_mod.ensure_home_symlink(home, "alicia", "uid-1")
         assert result == "/home/alicia"
+        assert created is False
         assert not (home / "alice").exists()
         assert (home / "alicia").is_symlink()
+
+
+class TestPopulateHomeSkel:
+    async def test_execs_cp_skel(self):
+        """populate_home_skel runs podman exec to copy /etc/skel."""
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+        with patch(
+            "asyncio.create_subprocess_exec",
+            return_value=mock_proc,
+        ) as mock_exec:
+            await ws_mod.populate_home_skel("cid-123", "uid-456")
+        args = mock_exec.call_args[0]
+        assert "exec" in args
+        assert "cid-123" in args
+        assert any("/etc/skel" in str(a) for a in args)
+        assert any("uid-456" in str(a) for a in args)
+
+    async def test_logs_warning_on_failure(self):
+        """populate_home_skel logs but does not raise on failure."""
+        with patch(
+            "asyncio.create_subprocess_exec",
+            side_effect=OSError("podman not found"),
+        ):
+            # Should not raise
+            await ws_mod.populate_home_skel("cid-123", "uid-456")

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -1038,8 +1038,14 @@ class TestHandleSetHandle:
         )
         conn.workspace_id = ws["id"]
         conn.workspace = {"user_id": user["id"]}
+        conn.container_id = "cid"
 
-        await conn.handle_set_handle({"handle": "alice"})
+        with patch(
+            "klangk_backend.workspaces.populate_home_skel",
+            new_callable=AsyncMock,
+        ) as mock_skel:
+            await conn.handle_set_handle({"handle": "alice"})
+        mock_skel.assert_awaited_once_with("cid", user["id"])
         sent = sock.send_json.call_args_list
         assert any(
             call.args[0].get("type") == "handle_set"

--- a/src/containers/workspace/bash.bashrc
+++ b/src/containers/workspace/bash.bashrc
@@ -23,9 +23,8 @@ cd "$HOME" 2>/dev/null
 
 # Per-user Pi agent config.  Shared config lives at /home/.pi/agent/
 # (written by setup_clankers at container start).  Each user gets their
-# own PI_CODING_AGENT_DIR with symlinks to shared resources and copies
-# of files they may customize.
-export PI_CODING_AGENT_DIR="$HOME/.pi/agent"
+# own ~/.pi/agent with symlinks to shared resources and copies of files
+# they may customize.
 python3 /opt/klangk/bin/setup-user-pi
 
 PS1='\[\033[01;34m\]\w\[\033[00m\]\$ '


### PR DESCRIPTION
## Summary

- Per-user home directories were created as empty dirs, missing standard skeleton files (`.profile`, `.bashrc`, etc.)
- Since tmux starts bash as a login shell, `~/.bashrc` was never sourced because there was no `~/.profile` to chain to it
- Now `ensure_home_symlink` reports when a new dir is created, and the caller copies `/etc/skel` into it via `podman exec`
- Removed redundant `PI_CODING_AGENT_DIR` export from `bash.bashrc` (it's the pi default)

## Test plan

- [x] E2E test verifies `~/.bashrc` is sourced in login shell (`bash -lic`)
- [x] Unit tests for `ensure_home_symlink` return value (`created` flag)
- [x] Unit test for `populate_home_skel` exec and error handling
- [x] Full backend suite passes with 100% coverage

Closes #345