### PR TITLE
feat(acl): grant collaborators share-terminals permission

### DIFF
--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -970,6 +970,7 @@ async def create_workspace(
             "code-in-isolation",
             "code-in-shared-terminals",
             "spectate-on-shared-terminals",
+            "share-terminals",
             "files",
             "chat",
         ],

--- a/src/frontend/lib/workspace/workspace_sharing_panel.dart
+++ b/src/frontend/lib/workspace/workspace_sharing_panel.dart
@@ -28,7 +28,8 @@ class WorkspaceSharingPanelState extends State<WorkspaceSharingPanel> {
     'owners': 'Full admin access',
     'coders':
         'Use isolated terminals, spectate on shared terminals, files, chat',
-    'collaborators': 'Use isolated and shared terminals, files, chat',
+    'collaborators':
+        'Use isolated and shared terminals, share terminals, files, chat',
     'spectators': 'Watch shared terminals, chat',
   };
 


### PR DESCRIPTION
## Summary

- Add `share-terminals` to the collaborators role group permissions
- Collaborators can now share their own terminals, not just join/spectate
- Update sharing page description to reflect the new capability

## Test plan

- [x] Backend tests pass with 100% coverage
- [ ] Create new workspace, add user as collaborator, verify they can share a terminal

Closes #344 