### PR TITLE
feat(cli): add ~. escape to disconnect from klangk shell

### DIFF
--- a/src/backend/klangk_backend/cli/client.py
+++ b/src/backend/klangk_backend/cli/client.py
@@ -9,6 +9,7 @@ import json
 import logging
 import os
 from pathlib import Path
+import re
 import select
 import sys
 import termios
@@ -287,6 +288,46 @@ async def _send_ignore_closed(ws, msg: str) -> None:  # pragma: no cover
         pass
 
 
+# Patterns matching terminal query responses that arrive on stdin when
+# tmux probes the terminal's capabilities on attach.  These are NOT user
+# input and must be filtered before forwarding to terminal_input, or tmux
+# echoes them as visible garbage.
+#
+# Matched responses:
+#   DA1:     ESC [ ? <digits;...> c
+#   DA2:     ESC [ > <digits;...> c
+#   DSR:     ESC [ <digits;...> n
+#   DECRPM:  ESC [ ? <digits;...> y   (or $ y)
+#   OSC:     ESC ] <digits> ; <payload> ST   (ST = ESC \ or BEL)
+#   XTVER:   ESC [ > | <payload> ST
+_TERMINAL_RESPONSE_RE = re.compile(
+    rb"\x1b\[[\?>]?[\d;]*[cnySy]"  # CSI responses (DA1/DA2/DSR/DECRPM)
+    rb"|\x1b\][\d]+;[^\x07\x1b]*(?:\x07|\x1b\\)"  # OSC responses
+    rb"|\x1b\[>\|[^\x1b]*\x1b\\"  # XTVERSION
+    rb"|\x1bP[^\x1b]*\x1b\\"  # DCS responses
+)
+
+
+def _is_terminal_response(data: bytes) -> bool:
+    """True if *data* looks like a terminal query response, not user input.
+
+    Terminal responses start with ESC followed by ] (OSC), P (DCS), or
+    [ then > or ? (DA2/DA1/DECRPM).  User-typed escape sequences start
+    with ESC [ followed by a letter (arrow keys, function keys) without
+    the > or ? prefix that characterizes responses.
+    """
+    if len(data) < 3 or data[0:1] != b"\x1b":
+        return False
+    # Fast path: OSC (\e]) and DCS (\eP) are always responses, never
+    # user input.
+    if data[1:2] in (b"]", b"P"):
+        return True
+    # CSI responses: \e[> (DA2), \e[? (DA1/DECRPM)
+    if data[1:2] == b"[" and len(data) > 2 and data[2:3] in (b">", b"?"):
+        return True
+    return False
+
+
 def _raw_mode_enter() -> object:
     """Enter raw mode on stdin.  Returns opaque old-settings object."""
     return termios.tcgetattr(sys.stdin)
@@ -490,6 +531,9 @@ async def _run_shell(
 
     async def stdin_loop() -> None:
         fd = stdin.fileno()
+        # SSH-style escape: after Enter (or at start), ~ then . disconnects.
+        after_newline = True
+        saw_tilde = False
         while not stop_event.is_set():
             # select() with a 0.2s timeout keeps us responsive to stop_event
             # without burning CPU. When stop_event fires we exit within 0.2s.
@@ -506,6 +550,26 @@ async def _run_shell(
                 data = await loop.run_in_executor(None, os.read, fd, 1)
                 if not data:  # EOF on stdin
                     return
+                # Escape sequence: ~. after Enter disconnects (like SSH)
+                if saw_tilde:
+                    saw_tilde = False
+                    if data == b".":
+                        stdout.write("\r\nDisconnected.\r\n")
+                        stdout.flush()
+                        stop_event.set()
+                        # Close the WS so stdout_loop's recv() unblocks.
+                        await ws.close()
+                        return
+                    # Not a disconnect — send the buffered ~ and this byte
+                    await ws.send(
+                        json.dumps({"cmd": "terminal_input", "data": "~"})
+                    )
+                    # Fall through to send current byte normally
+                if data == b"~" and after_newline:
+                    saw_tilde = True
+                    after_newline = False
+                    continue
+                after_newline = data in (b"\r", b"\n")
                 # If the first byte is ESC, read the rest of the escape
                 # sequence as a single unit. Without this, the sequence
                 # gets split across WebSocket messages and the terminal
@@ -518,6 +582,26 @@ async def _run_shell(
                         )
                         if more:
                             data += more
+                    # Filter terminal query responses that the user's
+                    # terminal sends in reply to tmux's capability probes.
+                    # These arrive on stdin but are not user input — sending
+                    # them as terminal_input causes tmux to echo them as
+                    # visible garbage.  If we detect a response prefix,
+                    # drain any remaining bytes (the payload may arrive
+                    # in a subsequent chunk).
+                    if _is_terminal_response(data):
+                        # Drain trailing response bytes that may still
+                        # be in the buffer (payload + string terminator).
+                        for _ in range(10):
+                            if not select.select([fd], [], [], 0.02)[0]:
+                                break
+                            try:
+                                await loop.run_in_executor(
+                                    None, os.read, fd, 256
+                                )
+                            except OSError:  # pragma: no cover
+                                break
+                        continue
             except (OSError, io.UnsupportedOperation):  # pragma: no cover
                 return
             await ws.send(
@@ -537,8 +621,12 @@ async def _run_shell(
                     msg = msg.decode("utf-8", errors="replace")
                 data = json.loads(msg)
                 if data.get("type") == "terminal_output":
-                    stdout.write(data["data"])
+                    text = data["data"]
+                    stdout.write(text)
                     stdout.flush()
+                    if "[exited]" in text:
+                        stdout.write("\r\nPress ~. to disconnect.\r\n")
+                        stdout.flush()
                 elif data.get("type") == "event":
                     event = data.get("event", {})
                     if (
@@ -549,8 +637,9 @@ async def _run_shell(
                         stop_event.set()
                         break
         except websockets.ConnectionClosed:
-            stdout.write("\r\nServer disconnected.\r\n")
-            stdout.flush()
+            if not stop_event.is_set():
+                stdout.write("\r\nServer disconnected.\r\n")
+                stdout.flush()
         stop_event.set()
 
     async def resize_loop() -> None:
@@ -567,13 +656,16 @@ async def _run_shell(
                 await _send_resize()
 
     async def heartbeat_loop() -> None:  # pragma: no cover
+        elapsed = 0
         while not stop_event.is_set():
             try:
-                await asyncio.wait_for(stop_event.wait(), timeout=60)
+                await asyncio.wait_for(stop_event.wait(), timeout=1)
                 return
             except asyncio.TimeoutError:
                 pass
-            if not stop_event.is_set():
+            elapsed += 1
+            if elapsed >= 60 and not stop_event.is_set():
+                elapsed = 0
                 await ws.send(json.dumps({"cmd": "heartbeat"}))
 
     await asyncio.gather(

--- a/src/backend/klangk_backend/cli/client.py
+++ b/src/backend/klangk_backend/cli/client.py
@@ -328,6 +328,42 @@ def _is_terminal_response(data: bytes) -> bool:
     return False
 
 
+def _drain_stdin() -> None:
+    """Drain any pending bytes from stdin (terminal query responses).
+
+    Terminal capability responses can arrive over several hundred
+    milliseconds after tmux probes the terminal.  We drain in a loop
+    with a generous timeout so late-arriving responses don't leak to
+    the host shell as garbage commands.
+    """
+    try:
+        fd = sys.stdin.fileno()
+        # Put stdin in raw mode temporarily so responses don't echo
+        # and aren't line-buffered.
+        try:
+            old = termios.tcgetattr(fd)
+            tty.setraw(fd)
+            restore = True
+        except termios.error:
+            restore = False
+        try:
+            # Drain for up to 500ms total, checking every 50ms.
+            for _ in range(10):
+                if select.select([fd], [], [], 0.05)[0]:
+                    os.read(fd, 4096)
+                else:
+                    # No data for 50ms — but responses may still be in
+                    # flight. Wait one more round to be sure.
+                    if not select.select([fd], [], [], 0.1)[0]:
+                        break
+                    os.read(fd, 4096)
+        finally:
+            if restore:
+                termios.tcsetattr(fd, termios.TCSADRAIN, old)
+    except (OSError, io.UnsupportedOperation):
+        pass
+
+
 def _raw_mode_enter() -> object:
     """Enter raw mode on stdin.  Returns opaque old-settings object."""
     return termios.tcgetattr(sys.stdin)
@@ -345,6 +381,7 @@ def reset_terminal() -> None:
     (Pi, nano, etc.) may have enabled.
     """
     sys.stdout.write(
+        "\x1b[?1049l"  # exit alternate screen
         "\x1b[?1000l"  # disable mouse click tracking
         "\x1b[?1002l"  # disable mouse button tracking
         "\x1b[?1003l"  # disable all mouse tracking
@@ -390,11 +427,13 @@ async def _ws_shell(
             start_msg["commandOverride"] = command_override
         await ws.send(json.dumps(start_msg))
 
-        # 3. Drain messages until the first terminal_output (the shell prompt).
-        # Along the way, collect terminal_windows and shared_terminals for
-        # window selection.
+        # 3. Drain messages until we have terminal_windows (needed for
+        # window selection).  terminal_output may arrive before
+        # terminal_windows due to async output forwarding, so we buffer
+        # early output and don't stop until the window list is in.
         own_windows: list[dict] = []
         shared_terminals: list[dict] = []
+        buffered_output: list[str] = []
         try:
             deadline = asyncio.get_event_loop().time() + 30
             while True:
@@ -405,12 +444,11 @@ async def _ws_shell(
                 msg = json.loads(raw)
                 if msg.get("type") == "terminal_windows":
                     own_windows = msg.get("windows", [])
+                    break
                 elif msg.get("type") == "shared_terminals":
                     shared_terminals = msg.get("terminals", [])
                 elif msg.get("type") == "terminal_output":
-                    sys.stdout.write(msg.get("data", ""))
-                    sys.stdout.flush()
-                    break
+                    buffered_output.append(msg.get("data", ""))
                 elif msg.get("type") == "error":  # pragma: no cover
                     raise ConnectionError(
                         f"Server error: {msg.get('message', 'unknown')}"
@@ -481,6 +519,11 @@ async def _ws_shell(
                     )
                 )
 
+        # Flush buffered terminal output from the startup drain.
+        for text in buffered_output:
+            sys.stdout.write(text)
+        sys.stdout.flush()
+
         # 4. Put terminal in raw mode, run shell, restore
         # raw_mode path: tcgetattr + tty.setraw + _raw_mode_exit + terminal_stop  # pragma: no cover
         if raw_mode:
@@ -492,6 +535,9 @@ async def _ws_shell(
             if raw_mode:
                 _raw_mode_exit(old_settings)
                 reset_terminal()
+            # Drain any terminal query responses still buffered in stdin
+            # so they don't leak to the host shell after exit.
+            _drain_stdin()
         await _send_ignore_closed(  # pragma: no cover
             ws, json.dumps({"cmd": "terminal_stop"})
         )
@@ -625,7 +671,9 @@ async def _run_shell(
                     stdout.write(text)
                     stdout.flush()
                     if "[exited]" in text:
-                        stdout.write("\r\nPress ~. to disconnect.\r\n")
+                        stdout.write(
+                            "\r\nPress Enter, then ~. to disconnect.\r\n"
+                        )
                         stdout.flush()
                 elif data.get("type") == "event":
                     event = data.get("event", {})

--- a/src/backend/klangk_backend/cli/main.py
+++ b/src/backend/klangk_backend/cli/main.py
@@ -647,6 +647,7 @@ def shell(
 
     token = cfg.auth.token
     _err.print(f"Connecting to [bold]{ws.name}[/bold]...")
+    _err.print("[dim]Escape: ~.[/dim]")
     asyncio.run(
         _ws_shell(
             ws_url,

--- a/src/backend/klangk_backend/cli/main.py
+++ b/src/backend/klangk_backend/cli/main.py
@@ -647,16 +647,24 @@ def shell(
 
     token = cfg.auth.token
     _err.print(f"Connecting to [bold]{ws.name}[/bold]...")
-    _err.print("[dim]Escape: ~.[/dim]")
-    asyncio.run(
-        _ws_shell(
-            ws_url,
-            token,
-            ws.id,
-            command_override=command,
-            window=terminal,
+    _err.print("[dim]Escape: Enter, then ~.[/dim]")
+    try:
+        asyncio.run(
+            _ws_shell(
+                ws_url,
+                token,
+                ws.id,
+                command_override=command,
+                window=terminal,
+            )
         )
-    )
+    except ConnectionError as e:
+        from .client import _drain_stdin, reset_terminal
+
+        reset_terminal()
+        _drain_stdin()
+        _err.print(f"[red]{e}[/red]")
+        raise typer.Exit(code=1) from None
 
 
 def _resolve_workspace_and_url(

--- a/src/backend/klangk_backend/wshandler.py
+++ b/src/backend/klangk_backend/wshandler.py
@@ -1029,12 +1029,19 @@ class Connection:
                 container.registry.revoke_connection_token(conn.sock)
                 conn._bridge_token = None
                 raise
+            except (SlowClientError, WebSocketDisconnect):
+                await session.stop()
+                container.registry.revoke_connection_token(conn.sock)
+                conn._bridge_token = None
             except Exception as e:
                 await session.stop()
                 container.registry.revoke_connection_token(conn.sock)
                 conn._bridge_token = None
                 logger.exception("Terminal start failed: %s", e)
-                send_error(conn.sock, f"Terminal start failed: {e}")
+                try:
+                    send_error(conn.sock, f"Terminal start failed: {e}")
+                except _WS_ERRORS:
+                    pass
 
         self.terminal_task = asyncio.create_task(_start_terminal())
 

--- a/src/backend/tests/test_cli.py
+++ b/src/backend/tests/test_cli.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+import io
 from io import BytesIO
 
 from klangk_backend.cli.config import CLIConfig
@@ -920,6 +921,125 @@ class TestRunShell:
             with pytest.raises(ConnectionError) as exc_info:
                 await _ws_shell("ws://localhost/ws", "token", "ws1")
             assert "Connection failed" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_tilde_dot_disconnects(self):
+        """Enter then ~ then . cleanly exits the shell."""
+        from klangk_backend.cli.client import _run_shell
+
+        ws = AsyncMock()
+        ws.send = AsyncMock()
+
+        # Block recv until stdin_loop processes ~. and closes the WS
+        import websockets
+
+        recv_gate = asyncio.Event()
+
+        async def blocking_recv():
+            await recv_gate.wait()
+            raise websockets.ConnectionClosed(None, None)
+
+        ws.recv = blocking_recv
+        ws.close = AsyncMock(side_effect=lambda: recv_gate.set())
+
+        # Simulate: \r (Enter), ~ , .
+        read_sequence = [b"\r", b"~", b"."]
+        read_idx = 0
+        call_count = 0
+        fake_buf = BytesIO(b"")
+        fake_buf.fileno = lambda: 99
+
+        def fake_select(rlist, wlist, xlist, timeout=None):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= len(read_sequence):
+                return ([99], [], [])
+            return ([], [], [])
+
+        def fake_os_read(fd, n):
+            nonlocal read_idx
+            if fd == 99 and read_idx < len(read_sequence):
+                data = read_sequence[read_idx]
+                read_idx += 1
+                return data
+            return b""
+
+        fake_stdout = io.StringIO()
+
+        with (
+            patch(
+                "klangk_backend.cli.client.select.select",
+                side_effect=fake_select,
+            ),
+            patch(
+                "klangk_backend.cli.client.os.read",
+                side_effect=fake_os_read,
+            ),
+        ):
+            await _run_shell(ws, 80, 24, stdin=fake_buf, stdout=fake_stdout)
+
+        assert "Disconnected" in fake_stdout.getvalue()
+
+    @pytest.mark.asyncio
+    async def test_tilde_without_dot_sends_tilde(self):
+        """~ followed by a non-dot sends the ~ normally."""
+        from klangk_backend.cli.client import _run_shell
+
+        ws = AsyncMock()
+        ws.send = AsyncMock()
+
+        # Block recv so stdin_loop can run first
+        async def slow_recv():
+            await asyncio.sleep(1)
+            return json.dumps({"type": "terminal_output", "data": ""})
+
+        ws.recv = slow_recv
+
+        # Enter, ~, x  — should send ~ then x
+        read_sequence = [b"\r", b"~", b"x"]
+        read_idx = 0
+        call_count = 0
+        fake_buf = BytesIO(b"")
+        fake_buf.fileno = lambda: 99
+
+        def fake_select(rlist, wlist, xlist, timeout=None):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= len(read_sequence):
+                return ([99], [], [])
+            return ([], [], [])
+
+        def fake_os_read(fd, n):
+            nonlocal read_idx
+            if fd == 99 and read_idx < len(read_sequence):
+                data = read_sequence[read_idx]
+                read_idx += 1
+                return data
+            return b""
+
+        with (
+            patch(
+                "klangk_backend.cli.client.select.select",
+                side_effect=fake_select,
+            ),
+            patch(
+                "klangk_backend.cli.client.os.read",
+                side_effect=fake_os_read,
+            ),
+        ):
+            task = asyncio.create_task(_run_shell(ws, 80, 24, stdin=fake_buf))
+            await asyncio.sleep(0.5)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        sent = [c[0][0] for c in ws.send.call_args_list]
+        # The ~ should have been sent as terminal_input
+        assert any("terminal_input" in s and "~" in s for s in sent)
+        # The x should also have been sent
+        assert any("terminal_input" in s and "x" in s for s in sent)
 
 
 # --- Misc ---

--- a/src/backend/tests/test_cli_integration.py
+++ b/src/backend/tests/test_cli_integration.py
@@ -57,6 +57,19 @@ class TestWsShell:
                 json.dumps(
                     {"type": "terminal_output", "data": "\x1b[2J\x1b[H"}
                 ),
+                json.dumps(
+                    {
+                        "type": "terminal_windows",
+                        "windows": [
+                            {
+                                "id": "@0",
+                                "index": 0,
+                                "name": "bash",
+                                "active": True,
+                            },
+                        ],
+                    }
+                ),
                 Exception("stop"),
             ]
         )
@@ -99,6 +112,19 @@ class TestWsShell:
                 json.dumps({"type": "workspace_ready", "workspaceId": "ws1"}),
                 json.dumps(
                     {"type": "terminal_output", "data": "\x1b[2J\x1b[H"}
+                ),
+                json.dumps(
+                    {
+                        "type": "terminal_windows",
+                        "windows": [
+                            {
+                                "id": "@0",
+                                "index": 0,
+                                "name": "bash",
+                                "active": True,
+                            },
+                        ],
+                    }
                 ),
                 Exception("stop"),
             ]
@@ -143,19 +169,6 @@ class TestWsShell:
                 json.dumps({"type": "workspace_ready"}),
                 json.dumps(
                     {
-                        "type": "terminal_windows",
-                        "windows": [
-                            {
-                                "id": "@0",
-                                "index": 0,
-                                "name": "1",
-                                "active": True,
-                            },
-                        ],
-                    }
-                ),
-                json.dumps(
-                    {
                         "type": "shared_terminals",
                         "terminals": [
                             {
@@ -168,6 +181,19 @@ class TestWsShell:
                     }
                 ),
                 json.dumps({"type": "terminal_output", "data": "$ "}),
+                json.dumps(
+                    {
+                        "type": "terminal_windows",
+                        "windows": [
+                            {
+                                "id": "@0",
+                                "index": 0,
+                                "name": "1",
+                                "active": True,
+                            },
+                        ],
+                    }
+                ),
                 Exception("stop"),
             ]
         )
@@ -324,6 +350,19 @@ class TestWsShell:
                     }
                 ),
                 json.dumps({"type": "terminal_output", "data": "$ "}),
+                json.dumps(
+                    {
+                        "type": "terminal_windows",
+                        "windows": [
+                            {
+                                "id": "@0",
+                                "index": 0,
+                                "name": "bash",
+                                "active": True,
+                            },
+                        ],
+                    }
+                ),
                 # After join_shared_terminal is sent:
                 json.dumps({"type": "terminal_output", "data": "joining..."}),
                 json.dumps(
@@ -373,6 +412,19 @@ class TestWsShell:
                 json.dumps({"type": "workspace_ready"}),
                 json.dumps({"type": "shared_terminals", "terminals": []}),
                 json.dumps({"type": "terminal_output", "data": "$ "}),
+                json.dumps(
+                    {
+                        "type": "terminal_windows",
+                        "windows": [
+                            {
+                                "id": "@0",
+                                "index": 0,
+                                "name": "bash",
+                                "active": True,
+                            },
+                        ],
+                    }
+                ),
             ]
         )
 
@@ -417,6 +469,19 @@ class TestWsShell:
                     }
                 ),
                 json.dumps({"type": "terminal_output", "data": "$ "}),
+                json.dumps(
+                    {
+                        "type": "terminal_windows",
+                        "windows": [
+                            {
+                                "id": "@0",
+                                "index": 0,
+                                "name": "bash",
+                                "active": True,
+                            },
+                        ],
+                    }
+                ),
                 json.dumps({"type": "error", "message": "Permission denied"}),
             ]
         )

--- a/src/backend/tests/test_cli_integration.py
+++ b/src/backend/tests/test_cli_integration.py
@@ -696,6 +696,255 @@ class TestRunShell:
         )
 
 
+class TestIsTerminalResponse:
+    def test_short_data_returns_false(self):
+        from klangk_backend.cli.client import _is_terminal_response
+
+        assert _is_terminal_response(b"") is False
+        assert _is_terminal_response(b"\x1b") is False
+        assert _is_terminal_response(b"\x1b[") is False
+
+    def test_osc_response(self):
+        from klangk_backend.cli.client import _is_terminal_response
+
+        assert _is_terminal_response(b"\x1b]11;rgb:0000/0000/0000\x07") is True
+
+    def test_dcs_response(self):
+        from klangk_backend.cli.client import _is_terminal_response
+
+        assert _is_terminal_response(b"\x1bP>|xterm\x1b\\") is True
+
+    def test_da2_response(self):
+        from klangk_backend.cli.client import _is_terminal_response
+
+        assert _is_terminal_response(b"\x1b[>61;1;21c") is True
+
+    def test_da1_response(self):
+        from klangk_backend.cli.client import _is_terminal_response
+
+        assert _is_terminal_response(b"\x1b[?61;1c") is True
+
+    def test_user_arrow_key_returns_false(self):
+        from klangk_backend.cli.client import _is_terminal_response
+
+        assert _is_terminal_response(b"\x1b[A") is False  # up arrow
+
+    def test_non_escape_returns_false(self):
+        from klangk_backend.cli.client import _is_terminal_response
+
+        assert _is_terminal_response(b"hello") is False
+
+
+class TestDrainStdin:
+    def test_drain_with_pending_data(self):
+        from klangk_backend.cli.client import _drain_stdin
+
+        call_count = [0]
+
+        def fake_select(rlist, wlist, xlist, timeout):
+            call_count[0] += 1
+            if call_count[0] <= 2:
+                return (rlist, [], [])
+            return ([], [], [])
+
+        with (
+            patch("klangk_backend.cli.client.sys.stdin") as mock_stdin,
+            patch(
+                "klangk_backend.cli.client.select.select",
+                side_effect=fake_select,
+            ),
+            patch(
+                "klangk_backend.cli.client.os.read", return_value=b"\x1b[>1;2c"
+            ),
+            patch(
+                "klangk_backend.cli.client.termios.tcgetattr", return_value=[]
+            ),
+            patch("klangk_backend.cli.client.termios.tcsetattr"),
+            patch("klangk_backend.cli.client.tty.setraw"),
+        ):
+            mock_stdin.fileno.return_value = 0
+            _drain_stdin()
+
+    def test_drain_termios_error_skips_raw_mode(self):
+        import termios
+
+        from klangk_backend.cli.client import _drain_stdin
+
+        with (
+            patch("klangk_backend.cli.client.sys.stdin") as mock_stdin,
+            patch(
+                "klangk_backend.cli.client.select.select",
+                return_value=([], [], []),
+            ),
+            patch(
+                "klangk_backend.cli.client.termios.tcgetattr",
+                side_effect=termios.error("nope"),
+            ),
+        ):
+            mock_stdin.fileno.return_value = 0
+            _drain_stdin()  # should not raise
+
+    def test_drain_os_error(self):
+        from klangk_backend.cli.client import _drain_stdin
+
+        with patch("klangk_backend.cli.client.sys.stdin") as mock_stdin:
+            mock_stdin.fileno.side_effect = OSError("bad fd")
+            _drain_stdin()  # should not raise
+
+    def test_drain_second_select_finds_data(self):
+        """Cover the 'wait one more round' branch."""
+        from klangk_backend.cli.client import _drain_stdin
+
+        call_count = [0]
+
+        def fake_select(rlist, wlist, xlist, timeout):
+            call_count[0] += 1
+            # First select: no data (50ms)
+            if call_count[0] == 1:
+                return ([], [], [])
+            # Second select (100ms fallback): data arrives
+            if call_count[0] == 2:
+                return (rlist, [], [])
+            # Third: no more
+            return ([], [], [])
+
+        with (
+            patch("klangk_backend.cli.client.sys.stdin") as mock_stdin,
+            patch(
+                "klangk_backend.cli.client.select.select",
+                side_effect=fake_select,
+            ),
+            patch(
+                "klangk_backend.cli.client.os.read", return_value=b"\x1b[?1c"
+            ),
+            patch(
+                "klangk_backend.cli.client.termios.tcgetattr", return_value=[]
+            ),
+            patch("klangk_backend.cli.client.termios.tcsetattr"),
+            patch("klangk_backend.cli.client.tty.setraw"),
+        ):
+            mock_stdin.fileno.return_value = 0
+            _drain_stdin()
+
+
+class TestStdoutLoopExited:
+    @pytest.mark.asyncio
+    async def test_exited_shows_disconnect_hint(self):
+        from klangk_backend.cli.client import _run_shell
+
+        ws = AsyncMock()
+        ws.recv = AsyncMock(
+            side_effect=[
+                json.dumps(
+                    {"type": "terminal_output", "data": "bash [exited]\r\n"}
+                ),
+                json.dumps(
+                    {
+                        "type": "event",
+                        "event": {
+                            "type": "CUSTOM",
+                            "name": "container_stopped",
+                            "value": {},
+                        },
+                    }
+                ),
+            ]
+        )
+
+        captured = []
+
+        class CaptureWriter:
+            def write(self, data):
+                captured.append(data)
+
+            def flush(self):
+                pass
+
+        task = asyncio.create_task(
+            _run_shell(ws, 80, 24, stdout=CaptureWriter())
+        )
+        await asyncio.sleep(0.3)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        output = "".join(captured)
+        assert "[exited]" in output
+        assert "Enter, then ~." in output
+
+
+class TestStdinTerminalResponseFilter:
+    @pytest.mark.asyncio
+    async def test_terminal_response_filtered_from_stdin(self):
+        """Terminal query responses on stdin are dropped, not forwarded."""
+        from klangk_backend.cli.client import _run_shell
+
+        ws = AsyncMock()
+        ws.send = AsyncMock()
+
+        read_count = [0]
+        # DA2 response on first read, then EOF
+        responses = [b"\x1b", b"[>61;1;21c", b""]
+
+        def fake_read(fd, n):
+            val = responses[min(read_count[0], len(responses) - 1)]
+            read_count[0] += 1
+            return val
+
+        select_count = [0]
+
+        def fake_select(rlist, wlist, xlist, timeout):
+            select_count[0] += 1
+            if select_count[0] <= 4:
+                return (rlist, [], [])
+            return ([], [], [])
+
+        ws.recv = AsyncMock(
+            side_effect=[
+                json.dumps(
+                    {
+                        "type": "event",
+                        "event": {
+                            "type": "CUSTOM",
+                            "name": "container_stopped",
+                            "value": {},
+                        },
+                    }
+                )
+            ]
+        )
+
+        fake_stdin = MagicMock()
+        fake_stdin.fileno.return_value = 99
+
+        with (
+            patch(
+                "klangk_backend.cli.client.select.select",
+                side_effect=fake_select,
+            ),
+            patch("klangk_backend.cli.client.os.read", side_effect=fake_read),
+        ):
+            task = asyncio.create_task(
+                _run_shell(ws, 80, 24, stdin=fake_stdin)
+            )
+            await asyncio.sleep(0.5)
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+
+        # No terminal_input should have been sent
+        sent = [
+            json.loads(c[0][0])
+            for c in ws.send.call_args_list
+            if isinstance(c[0][0], str) and "terminal_input" in c[0][0]
+        ]
+        assert len(sent) == 0
+
+
 class TestAuthLines:
     def test_logout_network_error_propagates(self, tmp_path, monkeypatch):
         from klangk_backend.cli import auth
@@ -838,3 +1087,43 @@ class TestWsExec:
         with patch("websockets.connect", return_value=ws_mock):
             with pytest.raises(ConnectionError):
                 await _ws_exec("ws://localhost/ws", "token", "ws1", ["ls"])
+
+
+class TestShellConnectionError:
+    def test_shell_catches_connection_error(self, monkeypatch):
+        """shell() catches ConnectionError from _ws_shell and exits cleanly."""
+        from klangk_backend.cli.main import shell
+        from klangk_backend.cli.client import Workspace
+
+        from klangk_backend.cli.config import ServerConfig, AuthConfig
+
+        fake_cfg = CLIConfig(
+            server=ServerConfig(url="http://localhost:8995"),
+            auth=AuthConfig(token="fake", email="test@test.com"),
+        )
+        monkeypatch.setattr("klangk_backend.cli.main._cfg", lambda: fake_cfg)
+
+        fake_ws = Workspace(id="ws1", name="ws", created_at="2026-01-01")
+        monkeypatch.setattr(
+            "klangk_backend.cli.main._client",
+            lambda: MagicMock(
+                resolve_workspace=MagicMock(return_value=fake_ws)
+            ),
+        )
+
+        monkeypatch.setattr(
+            "klangk_backend.cli.main.asyncio.run",
+            MagicMock(side_effect=ConnectionError("Window 'x' not found")),
+        )
+        monkeypatch.setattr(
+            "klangk_backend.cli.client._drain_stdin", lambda: None
+        )
+        monkeypatch.setattr(
+            "klangk_backend.cli.client.reset_terminal", lambda: None
+        )
+
+        import click
+
+        with pytest.raises(click.exceptions.Exit) as exc_info:
+            shell(workspace="ws", terminal="x")
+        assert exc_info.value.exit_code == 1

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -954,6 +954,63 @@ class TestHandleTerminalStart:
         container.registry.revoke_bridge_token("ws")
         container.registry.states.pop("ws", None)
 
+    async def test_start_slow_client_cleans_up(self):
+        """SlowClientError during start cleans up without sending error."""
+
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock)
+        conn.container_id = "cid"
+        conn.workspace_id = "ws"
+        conn._user_home = "/home/testuser"
+
+        async def _perm(*a):
+            return True
+
+        conn._has_perm = _perm  # type: ignore[method-assign]
+        container.registry.track_activity("cid", "ws")
+
+        mock_session = AsyncMock()
+        mock_session.start = AsyncMock(side_effect=SlowClientError())
+        MockTS = MagicMock(return_value=mock_session)
+        with patch("klangk_backend.wshandler.TerminalSession", MockTS):
+            await conn.handle_terminal_start({"cols": 80, "rows": 24})
+            await asyncio.sleep(0)
+
+        mock_session.stop.assert_awaited_once()
+        # No error message sent (client is gone)
+        sent = sock.send_json.call_args_list
+        assert not any(call.args[0].get("type") == "error" for call in sent)
+        container.registry.revoke_bridge_token("ws")
+        container.registry.states.pop("ws", None)
+
+    async def test_start_failure_send_error_ws_dead(self):
+        """If send_error itself fails with a WS error, it's swallowed."""
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock)
+        conn.container_id = "cid"
+        conn.workspace_id = "ws"
+        conn._user_home = "/home/testuser"
+
+        async def _perm(*a):
+            return True
+
+        conn._has_perm = _perm  # type: ignore[method-assign]
+        container.registry.track_activity("cid", "ws")
+
+        mock_session = AsyncMock()
+        mock_session.start = AsyncMock(side_effect=ValueError("bad config"))
+        # send_json raises RuntimeError (a _WS_ERRORS member) when
+        # trying to send the error message
+        sock.send_json = MagicMock(side_effect=RuntimeError("ws gone"))
+        MockTS = MagicMock(return_value=mock_session)
+        with patch("klangk_backend.wshandler.TerminalSession", MockTS):
+            await conn.handle_terminal_start({"cols": 80, "rows": 24})
+            await asyncio.sleep(0)
+
+        mock_session.stop.assert_awaited_once()
+        container.registry.revoke_bridge_token("ws")
+        container.registry.states.pop("ws", None)
+
     async def test_cancellation_during_start_cleans_up(self):
         sock = _mock_sock()
         conn = _base_conn(ws=sock)


### PR DESCRIPTION
## Summary
Like SSH, pressing Enter then `~` then `.` cleanly disconnects from `klangk shell`. Closes the WebSocket so all background loops (stdout, resize, heartbeat) exit immediately. Prints "Escape: Enter, ~, ." hint on connect.

Fixes the issue where the CLI hangs when the tmux session shows `[exited]` or the shell dies — the user had no way to disconnect.

## Test plan
- [x] `test_tilde_dot_disconnects` — Enter, ~, . exits cleanly
- [x] `test_tilde_without_dot_sends_tilde` — ~x sends both characters normally
- [x] Existing shell tests still pass