### PR TITLE
fix(agent): improve conversation context and error handling

### DIFF
--- a/scripts/test-agent-chat.py
+++ b/scripts/test-agent-chat.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Test the MrBoops agent via the live server's WebSocket + REST API.
+
+Usage:
+    python scripts/test-agent-chat.py [--server URL] [--workspace NAME]
+
+Sends a sequence of chat messages including @MrBoops mentions and
+follow-ups, then prints the agent's responses. Useful for iterating
+on context assembly and prompt quality.
+"""
+
+import argparse
+import asyncio
+import json
+import sys
+import time
+
+import httpx
+import websockets
+
+
+async def main():
+    parser = argparse.ArgumentParser(description="Test agent chat")
+    parser.add_argument("--server", default="http://localhost:8995", help="Server URL")
+    parser.add_argument(
+        "--workspace", default=None, help="Workspace name (default: first)"
+    )
+    parser.add_argument("--email", default="admin@plope.com", help="Login email")
+    parser.add_argument("--password", default="admin", help="Login password")
+    parser.add_argument(
+        "--clear", action="store_true", help="Delete all chat messages first"
+    )
+    args = parser.parse_args()
+
+    base = args.server.rstrip("/")
+
+    # Login
+    resp = httpx.post(
+        f"{base}/auth/login",
+        json={"email": args.email, "password": args.password},
+    )
+    resp.raise_for_status()
+    token = resp.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+    print(f"✓ Logged in as {args.email}")
+
+    # Find workspace
+    resp = httpx.get(f"{base}/workspaces", headers=headers)
+    resp.raise_for_status()
+    workspaces = resp.json()
+    if not workspaces:
+        print("No workspaces found")
+        sys.exit(1)
+    if args.workspace:
+        ws = next((w for w in workspaces if w["name"] == args.workspace), None)
+        if not ws:
+            print(f"Workspace '{args.workspace}' not found")
+            sys.exit(1)
+    else:
+        ws = workspaces[0]
+    print(f"✓ Using workspace: {ws['name']} ({ws['id'][:12]})")
+
+    # Clear chat if requested (via sqlite directly — no REST endpoint)
+    if args.clear:
+        import sqlite3
+        import os
+
+        db_path = os.path.join(os.environ.get("KLANGK_DATA_DIR", ""), "klangk.db")
+        if os.path.exists(db_path):
+            db = sqlite3.connect(db_path)
+            n = db.execute("DELETE FROM chat_messages").rowcount
+            db.commit()
+            db.close()
+            print(f"✓ Cleared {n} messages")
+        else:
+            print(f"⚠ DB not found at {db_path}, skipping clear")
+
+    # Connect via WebSocket
+    ws_url = base.replace("http://", "ws://").replace("https://", "wss://")
+    ws_url += f"/ws?token={token}"
+
+    async with websockets.connect(ws_url, max_size=16 * 1024 * 1024) as conn:
+        # Connect to workspace
+        await conn.send(
+            json.dumps({"cmd": "workspace_connect", "workspaceId": ws["id"]})
+        )
+        resp = json.loads(await conn.recv())
+        assert resp.get("type") == "workspace_ready", f"Unexpected: {resp}"
+        print("✓ Connected to workspace")
+
+        # Signal UI ready so container starts
+        await conn.send(json.dumps({"cmd": "ui_ready"}))
+
+        # Wait for container_ready (may already be running)
+        deadline = time.monotonic() + 120
+        ready = False
+        while time.monotonic() < deadline:
+            try:
+                raw = await asyncio.wait_for(conn.recv(), timeout=5)
+            except asyncio.TimeoutError:
+                # No more messages — container is probably already running
+                print("✓ Container already running (no container_ready event)")
+                ready = True
+                break
+            msg = json.loads(raw)
+            if (
+                msg.get("type") == "event"
+                and isinstance(msg.get("event"), dict)
+                and msg["event"].get("name") == "container_ready"
+            ):
+                print("✓ Container ready")
+                ready = True
+                break
+        if not ready:
+            print("✗ Container did not become ready")
+            sys.exit(1)
+
+        # Helper to send a chat message and wait for agent response
+        async def chat(text: str, expect_agent: bool = True) -> str | None:
+            print(f"\n→ {text}")
+            await conn.send(json.dumps({"cmd": "chat_send", "message": text}))
+
+            if not expect_agent:
+                await asyncio.sleep(1)
+                return None
+
+            # Wait for agent response (chat_message with message_type=1)
+            deadline = time.monotonic() + 180
+            while time.monotonic() < deadline:
+                try:
+                    raw = await asyncio.wait_for(conn.recv(), timeout=60)
+                except asyncio.TimeoutError:
+                    continue
+                msg = json.loads(raw)
+                if msg.get("type") == "chat_message" and msg.get("message_type") == 1:
+                    response = msg.get("message", "")
+                    print(f"← {response[:500]}")
+                    return response
+            print("← [TIMEOUT — no agent response]")
+            return None
+
+        # --- Test conversation ---
+        print("\n" + "=" * 60)
+        print("CONVERSATION TEST")
+        print("=" * 60)
+
+        # 1. Direct question
+        r1 = await chat("@MrBoops what is 2 + 2?")
+
+        # 2. Follow-up (no @mention — tests conversation continuity)
+        r2 = await chat("and what is that times 10?")
+
+        # 3. Another follow-up
+        r3 = await chat("can you write a Python function that computes that?")
+
+        # 4. New topic with @mention
+        r4 = await chat("@MrBoops what files are in the home directory?")
+
+        # 5. Follow-up about files
+        r5 = await chat("create a file called test.txt with 'hello world'")
+
+        # 6. Verify
+        r6 = await chat("now read that file back to me")
+
+        print("\n" + "=" * 60)
+        print("RESULTS SUMMARY")
+        print("=" * 60)
+        responses = [
+            ("2+2", r1),
+            ("times 10", r2),
+            ("python function", r3),
+            ("list files", r4),
+            ("create file", r5),
+            ("read file", r6),
+        ]
+        for label, r in responses:
+            status = "✓" if r and r != "I had nothing to say." else "✗"
+            preview = (r or "None")[:80].replace("\n", " ")
+            print(f"  {status} {label}: {preview}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/backend/klangk_backend/agent.py
+++ b/src/backend/klangk_backend/agent.py
@@ -170,7 +170,24 @@ class AgentSession:
             proc.stdin.write((cmd + "\n").encode())
             await proc.stdin.drain()
 
-            # Collect text deltas until agent_end
+            # Wait for the command ack before reading events.  Pi
+            # sends {"type":"response","command":"prompt","success":true}
+            # first; any lines before it are leftover from a previous
+            # turn and must be discarded.
+            try:
+                await asyncio.wait_for(
+                    self._wait_for_ack(proc.stdout), timeout=30
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "Pi RPC ack timed out for %s", self.container_id
+                )
+
+            # Skip past any leftover events to the current turn's
+            # agent_start, then collect deltas until agent_end.
+            await asyncio.wait_for(
+                self._skip_to_agent_start(proc.stdout), timeout=30
+            )
             text_parts: list[str] = []
             try:
                 response = await asyncio.wait_for(
@@ -207,12 +224,51 @@ class AgentSession:
             except Exception:  # pragma: no cover
                 pass
 
+    async def _wait_for_ack(self, stdout: asyncio.StreamReader) -> None:
+        """Read lines until the Pi RPC command acknowledgement.
+
+        Discards any leftover events from a previous turn that may
+        still be in the pipe.
+        """
+        while True:
+            line = await stdout.readline()
+            if not line:
+                return
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if (
+                event.get("type") == "response"
+                and event.get("command") == "prompt"
+            ):
+                return
+
+    async def _skip_to_agent_start(self, stdout: asyncio.StreamReader) -> None:
+        """Skip events until agent_start for the current turn.
+
+        After the ack, Pi emits agent_start before sending any deltas.
+        If there are leftover events from a prior turn (e.g. after a
+        timeout), they appear before agent_start and must be discarded.
+        """
+        while True:
+            line = await stdout.readline()
+            if not line:
+                return
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if event.get("type") == "agent_start":
+                return
+
     async def _read_until_agent_end(
         self,
         stdout: asyncio.StreamReader,
         text_parts: list[str],
     ) -> str:
         """Read JSONL events from Pi until agent_end."""
+        thinking_parts: list[str] = []
         while True:
             line = await stdout.readline()
             if not line:
@@ -227,8 +283,13 @@ class AgentSession:
 
             if event_type == "message_update":
                 delta = event.get("assistantMessageEvent", {})
-                if delta.get("type") == "text_delta":
+                delta_type = delta.get("type", "")
+                if delta_type == "text_delta":
                     text_parts.append(delta.get("delta", ""))
+                elif delta_type == "thinking_delta":
+                    thinking_parts.append(delta.get("delta", ""))
+                elif delta_type not in ("thinking_start", "thinking_end"):
+                    logger.debug("Unhandled delta type: %s", delta_type)
 
             elif event_type == "agent_end":
                 break
@@ -236,6 +297,12 @@ class AgentSession:
         text = "".join(text_parts)
         # Strip <think>...</think> tags that some models emit
         text = _THINK_RE.sub("", text).strip()
+        if not text:
+            # Some models put their response in thinking only (no
+            # text_delta). Fall back to the thinking content, stripped
+            # of reasoning artifacts.
+            text = "".join(thinking_parts).strip()
+            text = _THINK_RE.sub("", text).strip()
         return text or "I had nothing to say."
 
     async def stop(self) -> None:

--- a/src/backend/klangk_backend/agent.py
+++ b/src/backend/klangk_backend/agent.py
@@ -145,7 +145,6 @@ class AgentSession:
             "pi",
             "--mode",
             "rpc",
-            "--no-session",
             "--append-system-prompt",
             system_prompt,
         ]

--- a/src/backend/klangk_backend/agent.py
+++ b/src/backend/klangk_backend/agent.py
@@ -259,16 +259,32 @@ class AgentSession:
                 event = json.loads(line)
             except json.JSONDecodeError:
                 continue
-            if event.get("type") == "agent_start":
+            etype = event.get("type")
+            if etype == "agent_start":
                 return
+            if etype == "auto_retry_start":
+                logger.info(
+                    "Pi auto-retry %d/%d for %s: %s",
+                    event.get("attempt", "?"),
+                    event.get("maxAttempts", "?"),
+                    self.container_id,
+                    str(event.get("errorMessage", ""))[:100],
+                )
 
     async def _read_until_agent_end(
         self,
         stdout: asyncio.StreamReader,
         text_parts: list[str],
     ) -> str:
-        """Read JSONL events from Pi until agent_end."""
+        """Read JSONL events from Pi until the final agent_end.
+
+        Pi may emit multiple agent_start/agent_end cycles when it
+        auto-retries on errors (e.g. 429 rate limits).  We keep
+        reading until an agent_end with ``willRetry: false`` (or no
+        ``willRetry`` key, which is the normal success case).
+        """
         thinking_parts: list[str] = []
+        last_error: str = ""
         while True:
             line = await stdout.readline()
             if not line:
@@ -291,8 +307,23 @@ class AgentSession:
                 elif delta_type not in ("thinking_start", "thinking_end"):
                     logger.debug("Unhandled delta type: %s", delta_type)
 
+            elif event_type in ("message_start", "message_end"):
+                # Capture error messages from the LLM provider.
+                msg = event.get("message", {})
+                if msg.get("stopReason") == "error":
+                    last_error = msg.get("errorMessage", "")
+
             elif event_type == "agent_end":
-                break
+                if not event.get("willRetry", False):
+                    break
+                # Pi is retrying — reset parts for the next attempt
+                # and wait for the next agent_start.
+                text_parts.clear()
+                thinking_parts.clear()
+                last_error = ""
+                await self._skip_to_agent_start(stdout)
+
+            # auto_retry_start is consumed by _skip_to_agent_start
 
         text = "".join(text_parts)
         # Strip <think>...</think> tags that some models emit
@@ -303,6 +334,9 @@ class AgentSession:
             # of reasoning artifacts.
             text = "".join(thinking_parts).strip()
             text = _THINK_RE.sub("", text).strip()
+        if not text and last_error:
+            # Surface the LLM error to the user.
+            text = f"Error from LLM: {last_error}"
         return text or "I had nothing to say."
 
     async def stop(self) -> None:

--- a/src/backend/klangk_backend/agent.py
+++ b/src/backend/klangk_backend/agent.py
@@ -99,8 +99,9 @@ class AgentSession:
             )
 
         # Run setup-clankers to populate ~/.pi/agent/ with models.json,
-        # settings.json, etc. — the same script that /etc/bash.bashrc
-        # runs for interactive user shells.
+        # settings.json, etc.  Unlike real users, the agent has no
+        # personal preferences — always delete settings.json first so
+        # it picks up the current KLANGK_LLM_MODEL env var.
         proc = await asyncio.create_subprocess_exec(
             podman.PODMAN_BIN,
             "exec",
@@ -109,8 +110,10 @@ class AgentSession:
             "-e",
             f"HOME={container_home}",
             self.container_id,
-            "python3",
-            "/opt/klangk/bin/setup-clankers",
+            "bash",
+            "-c",
+            "rm -f $HOME/.pi/agent/settings.json"
+            " && python3 /opt/klangk/bin/setup-clankers",
             stdin=asyncio.subprocess.DEVNULL,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,

--- a/src/backend/tests/test_agent.py
+++ b/src/backend/tests/test_agent.py
@@ -31,9 +31,13 @@ def _make_session(container_id="cid"):
     return s
 
 
+_ACK = {"type": "response", "command": "prompt", "success": True}
+
+
 class TestAgentSession:
     async def test_send_prompt_collects_text_deltas(self):
         events = [
+            _ACK,
             {"type": "agent_start"},
             {
                 "type": "message_update",
@@ -71,8 +75,15 @@ class TestAgentSession:
         proc = AsyncMock()
         proc.returncode = None
         proc.stdin = AsyncMock()
-        # stdout that never produces data
+        # Feed ack + agent_start so we get past the preamble, then
+        # nothing — simulating a model that never responds.
         proc.stdout = asyncio.StreamReader()
+        proc.stdout.feed_data(
+            json.dumps(_ACK).encode()
+            + b"\n"
+            + json.dumps({"type": "agent_start"}).encode()
+            + b"\n"
+        )
         proc.stderr = asyncio.StreamReader()
 
         with patch("asyncio.create_subprocess_exec", return_value=proc):
@@ -83,6 +94,7 @@ class TestAgentSession:
 
     async def test_send_prompt_empty_response(self):
         events = [
+            _ACK,
             {"type": "agent_start"},
             {"type": "agent_end"},
         ]
@@ -102,9 +114,87 @@ class TestAgentSession:
 
         assert result == "I had nothing to say."
 
+    async def test_thinking_fallback_when_no_text_delta(self):
+        """When model only emits thinking_delta, use thinking as response."""
+        events = [
+            _ACK,
+            {"type": "agent_start"},
+            {
+                "type": "message_update",
+                "assistantMessageEvent": {
+                    "type": "thinking_start",
+                },
+            },
+            {
+                "type": "message_update",
+                "assistantMessageEvent": {
+                    "type": "thinking_delta",
+                    "delta": "The answer is 42.",
+                },
+            },
+            {
+                "type": "message_update",
+                "assistantMessageEvent": {
+                    "type": "thinking_end",
+                },
+            },
+            {"type": "agent_end"},
+        ]
+        stdout_data = "\n".join(json.dumps(e) for e in events) + "\n"
+
+        proc = AsyncMock()
+        proc.returncode = None
+        proc.stdin = AsyncMock()
+        proc.stdout = asyncio.StreamReader()
+        proc.stdout.feed_data(stdout_data.encode())
+        proc.stdout.feed_eof()
+        proc.stderr = asyncio.StreamReader()
+
+        with patch("asyncio.create_subprocess_exec", return_value=proc):
+            session = _make_session()
+            result = await session.send_prompt("test")
+
+        assert result == "The answer is 42."
+
+    async def test_unhandled_delta_type_logged(self, caplog):
+        """Unknown delta types are logged at debug level."""
+        events = [
+            _ACK,
+            {"type": "agent_start"},
+            {
+                "type": "message_update",
+                "assistantMessageEvent": {
+                    "type": "mystery_delta",
+                    "delta": "?",
+                },
+            },
+            {"type": "agent_end"},
+        ]
+        stdout_data = "\n".join(json.dumps(e) for e in events) + "\n"
+
+        proc = AsyncMock()
+        proc.returncode = None
+        proc.stdin = AsyncMock()
+        proc.stdout = asyncio.StreamReader()
+        proc.stdout.feed_data(stdout_data.encode())
+        proc.stdout.feed_eof()
+        proc.stderr = asyncio.StreamReader()
+
+        import logging
+
+        with (
+            patch("asyncio.create_subprocess_exec", return_value=proc),
+            caplog.at_level(logging.DEBUG, logger="klangk_backend.agent"),
+        ):
+            session = _make_session()
+            await session.send_prompt("test")
+
+        assert any("mystery_delta" in r.message for r in caplog.records)
+
     async def test_process_dies_raises(self):
         """AgentProcessDied raised when process exits mid-prompt."""
         events = [
+            _ACK,
             {"type": "agent_start"},
             {
                 "type": "message_update",
@@ -147,6 +237,8 @@ class TestAgentSession:
     async def test_reuses_running_proc(self):
         """Second prompt reuses the existing subprocess."""
         events = [
+            _ACK,
+            {"type": "agent_start"},
             {
                 "type": "message_update",
                 "assistantMessageEvent": {
@@ -155,6 +247,8 @@ class TestAgentSession:
                 },
             },
             {"type": "agent_end"},
+            _ACK,
+            {"type": "agent_start"},
             {
                 "type": "message_update",
                 "assistantMessageEvent": {
@@ -193,7 +287,9 @@ class TestAgentSession:
         proc.stdin = AsyncMock()
         proc.stdout = asyncio.StreamReader()
         # Feed partial data then EOF
-        proc.stdout.feed_data(b'{"type":"agent_start"}\n')
+        proc.stdout.feed_data(
+            json.dumps(_ACK).encode() + b"\n" + b'{"type":"agent_start"}\n'
+        )
         proc.stdout.feed_eof()
         proc.stderr = asyncio.StreamReader()
 
@@ -206,6 +302,8 @@ class TestAgentSession:
     async def test_malformed_jsonl_skipped(self):
         """Non-JSON lines are silently skipped."""
         lines = [
+            json.dumps(_ACK),
+            json.dumps({"type": "agent_start"}),
             "not json at all",
             json.dumps(
                 {
@@ -233,6 +331,92 @@ class TestAgentSession:
             result = await session.send_prompt("test")
 
         assert result == "ok"
+
+    async def test_skip_to_agent_start_discards_stale(self):
+        """_skip_to_agent_start skips stale events."""
+        session = _make_session()
+        reader = asyncio.StreamReader()
+        # Stale events from a prior turn, then agent_start
+        reader.feed_data(
+            json.dumps({"type": "message_update"}).encode()
+            + b"\n"
+            + json.dumps({"type": "agent_end"}).encode()
+            + b"\n"
+            + json.dumps({"type": "agent_start"}).encode()
+            + b"\n"
+        )
+        reader.feed_eof()
+        await session._skip_to_agent_start(reader)
+
+    async def test_skip_to_agent_start_eof(self):
+        """_skip_to_agent_start returns on EOF."""
+        session = _make_session()
+        reader = asyncio.StreamReader()
+        reader.feed_eof()
+        await session._skip_to_agent_start(reader)
+
+    async def test_skip_to_agent_start_skips_non_json(self):
+        """_skip_to_agent_start skips malformed lines."""
+        session = _make_session()
+        reader = asyncio.StreamReader()
+        reader.feed_data(
+            b"garbage\n" + json.dumps({"type": "agent_start"}).encode() + b"\n"
+        )
+        reader.feed_eof()
+        await session._skip_to_agent_start(reader)
+
+    async def test_ack_timeout_still_proceeds(self):
+        """If ack times out, send_prompt still tries to read response."""
+        events = [
+            # No _ACK — simulates ack timeout
+            {"type": "agent_start"},
+            {
+                "type": "message_update",
+                "assistantMessageEvent": {
+                    "type": "text_delta",
+                    "delta": "late",
+                },
+            },
+            {"type": "agent_end"},
+        ]
+        stdout_data = "\n".join(json.dumps(e) for e in events) + "\n"
+
+        proc = AsyncMock()
+        proc.returncode = None
+        proc.stdin = AsyncMock()
+        proc.stdout = asyncio.StreamReader()
+        proc.stdout.feed_data(stdout_data.encode())
+        proc.stdout.feed_eof()
+        proc.stderr = asyncio.StreamReader()
+
+        with (
+            patch("asyncio.create_subprocess_exec", return_value=proc),
+            patch(
+                "klangk_backend.agent.AgentSession._wait_for_ack",
+                side_effect=asyncio.TimeoutError,
+            ),
+        ):
+            session = _make_session()
+            result = await session.send_prompt("test")
+
+        # Should still get a result (skip_to_agent_start finds it)
+        assert result == "late"
+
+    async def test_wait_for_ack_eof(self):
+        """_wait_for_ack returns on EOF without error."""
+        session = _make_session()
+        reader = asyncio.StreamReader()
+        reader.feed_eof()
+        await session._wait_for_ack(reader)  # should not raise
+
+    async def test_wait_for_ack_skips_non_json(self):
+        """_wait_for_ack skips malformed lines before ack."""
+        session = _make_session()
+        reader = asyncio.StreamReader()
+        reader.feed_data(b"garbage\n")
+        reader.feed_data(json.dumps(_ACK).encode() + b"\n")
+        reader.feed_eof()
+        await session._wait_for_ack(reader)  # should not raise
 
 
 class TestGetSession:

--- a/src/backend/tests/test_agent.py
+++ b/src/backend/tests/test_agent.py
@@ -92,6 +92,91 @@ class TestAgentSession:
 
         assert "timed out" in result
 
+    async def test_llm_error_surfaced(self):
+        """LLM errors (e.g. 429) are returned to the user."""
+        events = [
+            _ACK,
+            {"type": "agent_start"},
+            {
+                "type": "message_start",
+                "message": {
+                    "role": "assistant",
+                    "stopReason": "error",
+                    "errorMessage": "429 rate limited",
+                },
+            },
+            {
+                "type": "message_end",
+                "message": {
+                    "role": "assistant",
+                    "stopReason": "error",
+                    "errorMessage": "429 rate limited",
+                },
+            },
+            {"type": "agent_end"},
+        ]
+        stdout_data = "\n".join(json.dumps(e) for e in events) + "\n"
+
+        proc = AsyncMock()
+        proc.returncode = None
+        proc.stdin = AsyncMock()
+        proc.stdout = asyncio.StreamReader()
+        proc.stdout.feed_data(stdout_data.encode())
+        proc.stdout.feed_eof()
+        proc.stderr = asyncio.StreamReader()
+
+        with patch("asyncio.create_subprocess_exec", return_value=proc):
+            session = _make_session()
+            result = await session.send_prompt("test")
+
+        assert "429 rate limited" in result
+
+    async def test_auto_retry_resets_and_reads_final(self):
+        """Pi auto-retry cycles are handled; final response is used."""
+        events = [
+            _ACK,
+            {"type": "agent_start"},
+            {
+                "type": "message_end",
+                "message": {
+                    "role": "assistant",
+                    "stopReason": "error",
+                    "errorMessage": "429 limit",
+                },
+            },
+            {"type": "agent_end", "willRetry": True},
+            {
+                "type": "auto_retry_start",
+                "attempt": 1,
+                "maxAttempts": 3,
+                "errorMessage": "429 limit",
+            },
+            {"type": "agent_start"},
+            {
+                "type": "message_update",
+                "assistantMessageEvent": {
+                    "type": "text_delta",
+                    "delta": "success",
+                },
+            },
+            {"type": "agent_end"},
+        ]
+        stdout_data = "\n".join(json.dumps(e) for e in events) + "\n"
+
+        proc = AsyncMock()
+        proc.returncode = None
+        proc.stdin = AsyncMock()
+        proc.stdout = asyncio.StreamReader()
+        proc.stdout.feed_data(stdout_data.encode())
+        proc.stdout.feed_eof()
+        proc.stderr = asyncio.StreamReader()
+
+        with patch("asyncio.create_subprocess_exec", return_value=proc):
+            session = _make_session()
+            result = await session.send_prompt("test")
+
+        assert result == "success"
+
     async def test_send_prompt_empty_response(self):
         events = [
             _ACK,


### PR DESCRIPTION
## Summary
- Remove `--no-session` so Pi maintains multi-turn conversation history across prompts
- Wait for Pi RPC command ack before reading events, draining stale data from prior turns
- Skip to `agent_start` to discard leftover events between turns
- Handle Pi auto-retries (429 rate limits etc.) by following `willRetry` cycles
- Surface LLM error messages to the user instead of "I had nothing to say"
- Fall back to thinking_delta content when model emits no text_delta
- Always refresh agent's settings.json so model changes in env vars take effect
- Add `test-agent-chat.py` script for live conversation testing

Fixes #356

## Test plan
- [x] Backend tests pass (1424 passed, 100% coverage)
- [x] Live conversation test: math follow-ups, file creation/reading all work
- [x] Rate limit errors surfaced correctly
- [x] Stale response buffering fixed