### PR TITLE
feat(container): restore passwordless sudo for klangk user

### DIFF
--- a/src/containers/workspace/Dockerfile
+++ b/src/containers/workspace/Dockerfile
@@ -49,4 +49,8 @@ RUN chgrp root \
       /usr/sbin/unix_chkpwd /var/mail \
     2>/dev/null; true
 
+# Allow klangk user to sudo without a password (for installing packages, etc.)
+RUN echo "klangk ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/klangk \
+    && chmod 0440 /etc/sudoers.d/klangk
+
 ENTRYPOINT ["/opt/klangk/entrypoint.sh"]


### PR DESCRIPTION
Re-adds the sudoers rule removed in a1181e0. Placed in Dockerfile
(not Dockerfile.base) so it's part of the workspace layer.