### PR TITLE
docs: clean up features index, getting started, and CLI reference

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -7,6 +7,7 @@ Klangk provides a rich set of features for multi-user AI collaboration:
 - [**Terminal**](terminal.md) — Full terminal emulator with Pi agent integration, idle timeout, session persistence
 - [**Chat**](chat.md) — Real-time workspace chat with markdown, @mentions, message types, container-to-chat API
 - [**File Viewer**](file-viewer.md) — Directory tree, drag-and-drop upload, preview, download
+- [**Invitations**](invitations.md) — Admin invitation workflow for onboarding new users
 - [**Plugins & Extensions**](plugins.md) — Server-side and client-side extensions via TypeScript and Dart
 
 ## UI/Theme
@@ -18,7 +19,7 @@ Klangk provides a rich set of features for multi-user AI collaboration:
 - Slidable Debug panel on bottom (collapsed by default)
 - Browser tab title updates per page ("Klangk - Login", "Klangk - Workspaces", "Klangk - workspace-name")
 
-## Right Panel Layout
+## Panel Layout
 
 - Two-part split: tabbed panel on top (Terminal, Files tabs) and slidable Debug panel on bottom
 - Debug panel collapsed by default, expandable via draggable horizontal divider
@@ -35,9 +36,3 @@ Klangk provides a rich set of features for multi-user AI collaboration:
 - Timestamps and color-coded entries
 - Selectable text for titles and content
 - Clear button
-
-## Workspace Presence
-
-- Real-time display of connected users per workspace
-- `presence_list` sent to joining user, `presence_join`/`presence_leave` broadcast to others
-- Tracks per-connection state; leave only broadcast when user's last connection closes

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -3,7 +3,6 @@
 ## Prerequisites
 
 - macOS or Linux
-- Podman (rootless) available
 - [Nix](https://nixos.org/download/) with [devenv](https://devenv.sh/) installed (or run `./bootstrap`)
 - An OpenAI-compatible LLM provider (e.g., [Ollama Cloud](https://ollama.com) or self-hosted Ollama or LiteLLM instance)
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -20,6 +20,12 @@ klangk export my-project            # export workspace to my-project.tar.gz (adm
 klangk export my-project -o bak.tar.gz  # export to specific file
 klangk import bak.tar.gz            # import workspace from archive
 klangk import bak.tar.gz --name new-name  # import with a different name
+klangk terminals my-project         # list all terminals (own + shared)
+klangk share my-project bash        # share a terminal with workspace members
+klangk unshare my-project bash      # stop sharing a terminal
+klangk invite user@example.com      # send an invitation email (admin only)
+klangk invitations                  # list all invitations (admin only)
+klangk images                       # list available container images
 klangk volumes ls                   # list your podman volumes
 klangk volumes create nix-store     # create a named volume (owned by you)
 klangk volumes rm nix-store         # delete a volume (must be yours)


### PR DESCRIPTION
- Remove non-existent Workspace Presence section from features index
- Add Invitations to features list
- Rename Right Panel Layout to Panel Layout
- Remove Podman prerequisite from getting started (provided by devenv)
- Add terminals, share/unshare, invite, images commands to CLI reference