### PR TITLE
fix(container): add UTF-8 locale for tmux unicode support

### DIFF
--- a/src/containers/workspace/Dockerfile.base
+++ b/src/containers/workspace/Dockerfile.base
@@ -39,8 +39,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     iproute2 \
     bsdextrautils \
     tmux \
+    locales \
     && rm -rf /var/lib/apt/lists/* \
     && chown -R root:root /var/log/apt
+
+# Generate UTF-8 locale — required for tmux to handle unicode/wide
+# characters correctly (e.g. Claude Code's ASCII art).
+# Uncomment en_US.UTF-8 in locale.gen (Debian slim ships all locales commented out)
+RUN sed -i '/en_US.UTF-8/s/^# //' /etc/locale.gen && locale-gen
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
 
 # GitHub CLI (not in default Debian repos)
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \


### PR DESCRIPTION
## Summary
- Install `locales` package in workspace base image and generate `en_US.UTF-8`
- Set `LANG` and `LC_ALL` env vars so tmux correctly handles unicode/wide characters
- Fixes garbled ASCII art when running Claude Code under tmux in workspace terminals

## Test plan
- [ ] Rebuild base image and workspace image
- [ ] Open a workspace terminal (tmux enabled) and run `claude`
- [ ] Verify ASCII art renders correctly (pixel pig, not garbled dashes/asterisks)
- [ ] Verify plain bash mode (`KLANGK_DISABLE_TMUX=1`) still works

Closes #371