### PR TITLE
fix(terminal): auto-exit tmux copy mode on scroll to bottom

### DIFF
--- a/src/containers/workspace/tmux.conf
+++ b/src/containers/workspace/tmux.conf
@@ -19,10 +19,11 @@ set -gs terminal-features 'xterm*:extkeys'
 # Mouse off — the terminal emulator handles text selection and mouse wheel
 # scrollback locally. Scrollback is also available via PgUp (tmux copy-mode).
 
-# PgUp/PgDn and Shift+PgUp/PgDn enter copy mode and scroll
-bind -n PgUp copy-mode -u
+# PgUp/PgDn and Shift+PgUp/PgDn enter copy mode and scroll.
+# -e = auto-exit copy mode when scrolling back to the bottom.
+bind -n PgUp copy-mode -eu
 bind -n PgDn send-keys PgDn
-bind -n S-PgUp copy-mode -u
+bind -n S-PgUp copy-mode -eu
 bind -n S-PgDn send-keys PgDn
 
 # Scroll within copy mode


### PR DESCRIPTION
## Summary
- Add `-e` flag to PgUp `copy-mode` bindings in tmux.conf
- Copy mode now automatically exits when the user scrolls back down to the live terminal output
- Reduces friction for users who PgUp to review output history

## Test plan
- [ ] PgUp into scrollback history → scroll down to bottom → copy mode exits automatically
- [ ] Shift+PgUp behaves the same way

Refs #380