### PR TITLE
fix(api): use explicit resource function for workspace role ACL checks

### DIFF
--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -1474,7 +1474,7 @@ ROLE_GROUP_SUFFIXES = ["owners", "coders", "collaborators", "spectators"]
 @router.get("/workspaces/{workspace_id}/roles")
 async def get_workspace_roles(
     workspace_id: str,
-    user: dict = Depends(acl.has_permission("share")),
+    user: dict = Depends(acl.has_permission("share", _check_workspace_share)),
 ):
     """Return the workspace's role groups with their members."""
     roles = []
@@ -1506,7 +1506,7 @@ async def add_to_workspace_role(
     workspace_id: str,
     role: str,
     body: AddToRoleRequest,
-    user: dict = Depends(acl.has_permission("share")),
+    user: dict = Depends(acl.has_permission("share", _check_workspace_share)),
 ):
     """Add a user to a workspace role group."""
     if role not in ROLE_GROUP_SUFFIXES:
@@ -1527,7 +1527,7 @@ async def remove_from_workspace_role(
     workspace_id: str,
     role: str,
     member_id: str,
-    user: dict = Depends(acl.has_permission("share")),
+    user: dict = Depends(acl.has_permission("share", _check_workspace_share)),
 ):
     """Remove a user from a workspace role group."""
     if role not in ROLE_GROUP_SUFFIXES:


### PR DESCRIPTION
## Summary
- Workspace role endpoints (`GET/POST/DELETE /workspaces/{id}/roles/...`) were relying on implicit URL-based resource derivation for ACL checks instead of the explicit `_check_workspace_share` resource function
- All other share-gated workspace endpoints already used the explicit resource function — this makes the three role endpoints consistent

## Test plan
- [x] Backend tests pass

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)