### PR TITLE
docs: document workspace JWT lifetime limitation and lack of renewal

### DIFF
--- a/docs/architecture/workspace-jwt.md
+++ b/docs/architecture/workspace-jwt.md
@@ -7,3 +7,8 @@ Each container receives a `KLANGK_WORKSPACE_TOKEN` environment variable at start
 - `/api/workspace/post-chat-message` — containers can post chat messages
 
 The token uses the same `KLANGK_JWT_SECRET` as user JWTs but is distinguished by a `purpose: "workspace"` claim. Token lifetime is controlled by `KLANGK_WORKSPACE_TOKEN_HOURS` (default 24h). IP-based ACLs (`CONTAINER_ACL`) remain as defense-in-depth alongside JWT validation.
+
+## Limitations
+
+- **No renewal**: Workspace tokens are injected once at container creation. There is no refresh mechanism — if a container runs longer than `KLANGK_WORKSPACE_TOKEN_HOURS`, the token expires and bridge API calls (LLM proxy, browser-delegate, chat posting) will fail with 401. Restarting the workspace issues a fresh token.
+- **Workaround**: Increase `KLANGK_WORKSPACE_TOKEN_HOURS` to cover expected container lifetimes (e.g., `168` for one week). See [#393](https://github.com/mcdonc/klangk/issues/393) for the renewal feature request.

--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -16,7 +16,8 @@ See [OIDC Configuration](../reference/oidc.md) for detailed setup instructions.
 
 ## JWT Sessions
 
-- JWT tokens (24hr expiry, secret configurable via `KLANGK_JWT_SECRET`) with token blocklist for logout
+- JWT tokens (24hr expiry, secret configurable via `KLANGK_JWT_SECRET`) with token blocklist for logout; no refresh/renewal mechanism — users must re-authenticate when tokens expire
+- Workspace containers receive a separate JWT (`KLANGK_WORKSPACE_TOKEN`) at startup for bridge API calls; lifetime controlled by `KLANGK_WORKSPACE_TOKEN_HOURS` (default 24h). No renewal — containers running longer than the token lifetime lose bridge access until restarted. See [Workspace JWT Auth](../architecture/workspace-jwt.md) for details.
 - Session persists across page reloads (async token loading before routing)
 - Deep link preservation: unauthenticated visits to protected URLs redirect to login, then return to the original URL after successful login
 


### PR DESCRIPTION
## Summary

- Document that workspace tokens have no renewal mechanism in `docs/architecture/workspace-jwt.md`
- Add workspace JWT details to the JWT Sessions section in `docs/features/authentication.md`
- Note the workaround (increase `KLANGK_WORKSPACE_TOKEN_HOURS`) and link to #393

Closes #389