### PR TITLE
fix(cli): skip broadcast messages while waiting for workspace_ready

### DIFF
--- a/src/backend/klangk_backend/cli/client.py
+++ b/src/backend/klangk_backend/cli/client.py
@@ -30,6 +30,37 @@ logger = logging.getLogger(__name__)
 _RETRY_ATTEMPTS = 3
 _RETRY_BACKOFF = 2.0  # seconds, doubled each retry
 
+_WS_CONNECT_TIMEOUT = 60  # seconds to wait for workspace_ready
+
+
+async def _wait_workspace_ready(
+    ws: websockets.ClientConnection,
+    workspace_id: str,
+    timeout: float = _WS_CONNECT_TIMEOUT,
+) -> dict:
+    """Send workspace_connect and wait for workspace_ready, skipping broadcasts.
+
+    The server may send broadcast messages (e.g. presence_list from eager
+    agent startup) before workspace_ready.  This drains them rather than
+    treating the first non-ready message as an error.
+
+    Returns the workspace_ready payload.
+    """
+    await ws.send(
+        json.dumps({"cmd": "workspace_connect", "workspaceId": workspace_id})
+    )
+    deadline = asyncio.get_event_loop().time() + timeout
+    while True:
+        remaining = deadline - asyncio.get_event_loop().time()
+        if remaining <= 0:
+            raise asyncio.TimeoutError("Timed out waiting for workspace_ready")
+        raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
+        resp = json.loads(raw)
+        if resp.get("type") == "workspace_ready":
+            return resp
+        if resp.get("type") == "error":
+            raise ConnectionError(f"Connection failed: {resp}")
+
 
 def _request_with_retry(
     method: str,
@@ -464,14 +495,7 @@ async def _ws_shell(
         f"{ws_url}?token={token}", max_size=_WS_MAX_SIZE
     ) as ws:
         # 1. Connect to workspace
-        await ws.send(
-            json.dumps(
-                {"cmd": "workspace_connect", "workspaceId": workspace_id}
-            )
-        )
-        resp = json.loads(await ws.recv())
-        if resp.get("type") != "workspace_ready":
-            raise ConnectionError(f"Connection failed: {resp}")
+        await _wait_workspace_ready(ws, workspace_id)
 
         # 2. Start terminal
         cols, rows = _get_terminal_size()
@@ -790,14 +814,7 @@ async def _ws_exec(
         f"{ws_url}?token={token}", max_size=_WS_MAX_SIZE
     ) as ws:
         # 1. Connect to workspace
-        await ws.send(
-            json.dumps(
-                {"cmd": "workspace_connect", "workspaceId": workspace_id}
-            )
-        )
-        resp = json.loads(await ws.recv())
-        if resp.get("type") != "workspace_ready":
-            raise ConnectionError(f"Connection failed: {resp}")
+        await _wait_workspace_ready(ws, workspace_id)
 
         # 2. Start exec session
         await ws.send(json.dumps({"cmd": "exec_start", "command": command}))

--- a/src/backend/klangk_backend/cli/main.py
+++ b/src/backend/klangk_backend/cli/main.py
@@ -22,6 +22,7 @@ from .client import (
     _WS_MAX_SIZE,
     _get_terminal_size,
     _send_ignore_closed,
+    _wait_workspace_ready,
     _ws_exec,
     _ws_shell,
 )
@@ -702,12 +703,7 @@ def terminals(
         async with websockets.connect(
             f"{ws_url}?token={token}", max_size=_WS_MAX_SIZE
         ) as conn:
-            await conn.send(
-                json.dumps({"cmd": "workspace_connect", "workspaceId": ws.id})
-            )
-            resp = json.loads(await conn.recv())
-            if resp.get("type") != "workspace_ready":
-                raise ConnectionError(f"Connection failed: {resp}")
+            await _wait_workspace_ready(conn, ws.id)
 
             await conn.send(json.dumps({"cmd": "ui_ready"}))
 
@@ -785,12 +781,7 @@ def share(
         async with websockets.connect(
             f"{ws_url}?token={token}", max_size=_WS_MAX_SIZE
         ) as conn:
-            await conn.send(
-                json.dumps({"cmd": "workspace_connect", "workspaceId": ws.id})
-            )
-            resp = json.loads(await conn.recv())
-            if resp.get("type") != "workspace_ready":
-                raise ConnectionError(f"Connection failed: {resp}")
+            await _wait_workspace_ready(conn, ws.id)
 
             await conn.send(json.dumps({"cmd": "ui_ready"}))
 
@@ -870,12 +861,7 @@ def unshare(
         async with websockets.connect(
             f"{ws_url}?token={token}", max_size=_WS_MAX_SIZE
         ) as conn:
-            await conn.send(
-                json.dumps({"cmd": "workspace_connect", "workspaceId": ws.id})
-            )
-            resp = json.loads(await conn.recv())
-            if resp.get("type") != "workspace_ready":
-                raise ConnectionError(f"Connection failed: {resp}")
+            await _wait_workspace_ready(conn, ws.id)
 
             await conn.send(json.dumps({"cmd": "ui_ready"}))
 

--- a/src/backend/tests/test_cli_integration.py
+++ b/src/backend/tests/test_cli_integration.py
@@ -27,7 +27,7 @@ class TestWsShell:
         ws_mock.__aexit__ = fake_exit
         ws_mock.recv = AsyncMock(
             return_value=json.dumps(
-                {"type": "not_workspace_ready", "data": "oops"}
+                {"type": "error", "message": "bad workspace"}
             )
         )
         ws_mock.send = AsyncMock()
@@ -35,6 +35,40 @@ class TestWsShell:
         with patch("websockets.connect", return_value=ws_mock):
             with pytest.raises(ConnectionError):
                 await _ws_shell("ws://localhost/ws", "token", "ws1")
+
+    @pytest.mark.asyncio
+    async def test_wait_workspace_ready_timeout(self):
+        """Times out if workspace_ready never arrives."""
+        from klangk_backend.cli.client import _wait_workspace_ready
+
+        ws_mock = AsyncMock()
+        # Always return a non-ready message
+        ws_mock.recv = AsyncMock(
+            return_value=json.dumps({"type": "presence_list", "users": []})
+        )
+        ws_mock.send = AsyncMock()
+
+        with pytest.raises(asyncio.TimeoutError):
+            await _wait_workspace_ready(ws_mock, "ws1", timeout=0.01)
+
+    @pytest.mark.asyncio
+    async def test_wait_workspace_ready_skips_broadcasts(self):
+        """Broadcast messages before workspace_ready are skipped."""
+        from klangk_backend.cli.client import _wait_workspace_ready
+
+        ws_mock = AsyncMock()
+        ws_mock.recv = AsyncMock(
+            side_effect=[
+                json.dumps({"type": "presence_list", "users": [{"id": "u1"}]}),
+                json.dumps({"type": "chat_history", "messages": []}),
+                json.dumps({"type": "workspace_ready", "workspaceId": "ws1"}),
+            ]
+        )
+        ws_mock.send = AsyncMock()
+
+        resp = await _wait_workspace_ready(ws_mock, "ws1")
+        assert resp["type"] == "workspace_ready"
+        assert resp["workspaceId"] == "ws1"
 
     @pytest.mark.asyncio
     async def test_ws_shell_success_sends_connect_and_start(self):


### PR DESCRIPTION
## Summary
- The `klangk exec` (and other CLI commands) failed intermittently because the server may send broadcast messages (e.g. `presence_list` from eager agent startup) before `workspace_ready` arrives on the WebSocket
- Changed all `workspace_ready` wait points to loop and skip non-`workspace_ready` messages instead of failing on the first unexpected message

Fixes #414

## Test plan
- [x] Backend unit tests pass locally
- [ ] CI E2E tests pass (3 successive runs)