### PR TITLE
feat(terminal): cross-viewport text selection via tmux mouse mode

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -32,3 +32,31 @@ klangk volumes rm nix-store         # delete a volume (must be yours)
 ```
 
 The CLI connects to the running Klangk backend over HTTP + WebSocket — it works locally and against remote servers.
+
+## Terminal behavior differences
+
+`klangk shell` provides the same tmux-based terminal as the web frontend, but clipboard behavior differs:
+
+- **Web frontend**: Text selections auto-copy to the system clipboard via the browser bridge. Mouse wheel scrolls through scrollback. No extra setup needed.
+- **CLI (`klangk shell`)**: Text selections auto-copy to the system clipboard via [OSC 52](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-Operating-System-Commands), which requires your terminal emulator to support it. Mouse wheel scrollback works. Native text selection (viewport-only) is available via **Shift+drag**.
+
+### OSC 52 terminal support
+
+The following terminal emulators support OSC 52 clipboard integration (auto-copy from tmux selections will work):
+
+| Terminal         | OSC 52 support |
+| ---------------- | -------------- |
+| iTerm2           | Yes            |
+| kitty            | Yes            |
+| alacritty        | Yes            |
+| WezTerm          | Yes            |
+| foot             | Yes            |
+| Windows Terminal | Yes            |
+| Konsole          | Yes (22.04+)   |
+| xterm            | Yes            |
+| GNOME Terminal   | No             |
+| Tilix            | No             |
+| MATE Terminal    | No             |
+| Terminator       | No             |
+
+If your terminal does not support OSC 52, tmux selections will still be captured in the tmux paste buffer (accessible via tmux commands) but will not automatically appear on your system clipboard. You can work around this by installing `xclip`, `xsel`, or `wl-copy` on your local machine and configuring tmux's `copy-command` in your local tmux config.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -59,4 +59,4 @@ The following terminal emulators support OSC 52 clipboard integration (auto-copy
 | MATE Terminal    | No             |
 | Terminator       | No             |
 
-If your terminal does not support OSC 52, tmux selections will still be captured in the tmux paste buffer (accessible via tmux commands) but will not automatically appear on your system clipboard. You can work around this by installing `xclip`, `xsel`, or `wl-copy` on your local machine and configuring tmux's `copy-command` in your local tmux config.
+If your terminal does not support OSC 52, tmux selections will still be captured in the tmux paste buffer but will not automatically appear on your system clipboard. Consider switching to a terminal emulator that supports OSC 52 for the best `klangk shell` experience.

--- a/src/backend/klangk_backend/cli/client.py
+++ b/src/backend/klangk_backend/cli/client.py
@@ -499,7 +499,12 @@ async def _ws_shell(
 
         # 2. Start terminal
         cols, rows = _get_terminal_size()
-        start_msg: dict = {"cmd": "terminal_start", "cols": cols, "rows": rows}
+        start_msg: dict = {
+            "cmd": "terminal_start",
+            "cols": cols,
+            "rows": rows,
+            "browser_id": "klangkshell",
+        }
         if command_override is not None:
             start_msg["commandOverride"] = command_override
         await ws.send(json.dumps(start_msg))

--- a/src/backend/klangk_backend/wshandler.py
+++ b/src/backend/klangk_backend/wshandler.py
@@ -943,9 +943,12 @@ class Connection:
 
         # Register browser ID for bridge routing.  The browser sends
         # its sessionStorage UUID with terminal_start; on refresh the
-        # same ID re-registers with the new WebSocket.
+        # same ID re-registers with the new WebSocket.  The CLI sends
+        # "klangkshell" as a sentinel — store it in tmux env (so
+        # klangk-copy-to-clipboard can skip the bridge) but don't
+        # register it for bridge routing.
         browser_id = msg.get("browser_id")
-        if browser_id:
+        if browser_id and browser_id != "klangkshell":
             container.registry.revoke_browser(self.sock)
             container.registry.register_browser(
                 browser_id, self.workspace_id, self.sock

--- a/src/containers/workspace/Dockerfile
+++ b/src/containers/workspace/Dockerfile
@@ -37,11 +37,13 @@ COPY setup_clankers.py /opt/klangk/bin/setup-clankers
 COPY setup-home.sh /opt/klangk/bin/setup-home
 COPY klangk-attach-browser /opt/klangk/bin/klangk-attach-browser
 COPY klangk-browser-id /opt/klangk/bin/klangk-browser-id
+COPY klangk-copy-to-clipboard /opt/klangk/bin/klangk-copy-to-clipboard
 RUN chmod +x /opt/klangk/entrypoint.sh \
       /opt/klangk/bin/setup-clankers \
       /opt/klangk/bin/setup-home \
       /opt/klangk/bin/klangk-attach-browser \
-      /opt/klangk/bin/klangk-browser-id
+      /opt/klangk/bin/klangk-browser-id \
+      /opt/klangk/bin/klangk-copy-to-clipboard
 COPY bash.bashrc /etc/bash.bashrc
 COPY tmux.conf /etc/tmux.conf
 

--- a/src/containers/workspace/klangk-copy-to-clipboard
+++ b/src/containers/workspace/klangk-copy-to-clipboard
@@ -1,17 +1,25 @@
 #!/usr/bin/env python3
-"""Copy text from stdin to the browser's system clipboard via the bridge.
+"""Copy text from stdin to the system clipboard.
 
 Used by tmux's copy-pipe to make selections auto-copy to the user's
-clipboard.  Reads the selected text from stdin, resolves the current
-browser ID, and POSTs a clipboard_write action to the bridge endpoint.
+clipboard.
+
+Two strategies, tried in order:
+
+1. **Bridge** (web frontend): POST clipboard_write to the browser-delegate
+   bridge endpoint, which tells the Flutter app to call Clipboard.setData.
+2. **OSC 52** (klangk shell / any terminal): emit the OSC 52 escape
+   sequence so the outer terminal emulator copies to the system clipboard.
+   Supported by iTerm2, Windows Terminal, kitty, alacritty, foot, etc.
 """
 
+import base64
 import json
 import os
 import subprocess
 import sys
-import urllib.request
 import urllib.error
+import urllib.request
 
 BRIDGE_URL = os.environ.get("KLANGK_BRIDGE_URL", "")
 WORKSPACE_TOKEN = os.environ.get("KLANGK_WORKSPACE_TOKEN", "")
@@ -32,17 +40,10 @@ def _get_browser_id():
     return ""
 
 
-def main():
-    if not BRIDGE_URL:
-        sys.exit(1)
-
-    browser_id = _get_browser_id()
-    if not browser_id:
-        sys.exit(1)
-
-    text = sys.stdin.read()
-    if not text:
-        sys.exit(0)
+def _try_bridge(text, browser_id):
+    """Try to copy via the bridge. Returns True on success."""
+    if not BRIDGE_URL or not browser_id:
+        return False
 
     payload = json.dumps({
         "action": "clipboard_write",
@@ -61,10 +62,43 @@ def main():
         method="POST",
     )
     try:
-        with urllib.request.urlopen(req, timeout=5):
-            pass
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return 200 <= resp.status < 300
     except (urllib.error.URLError, OSError):
+        return False
+
+
+def _osc52(text):
+    """Emit OSC 52 escape sequence to set the system clipboard.
+
+    Works in most modern terminal emulators.  Writes to the tmux
+    parent terminal via the passthrough escape (DCS tmux; ... ST).
+    """
+    encoded = base64.b64encode(text.encode()).decode()
+    # tmux requires DCS passthrough to forward OSC 52 to the outer terminal.
+    if os.environ.get("TMUX"):
+        seq = f"\033Ptmux;\033\033]52;c;{encoded}\033\033\\\033\\"
+    else:
+        seq = f"\033]52;c;{encoded}\033\\"
+    # Write to the terminal, not stdout (which tmux has piped).
+    try:
+        with open("/dev/tty", "w") as tty:
+            tty.write(seq)
+            tty.flush()
+    except OSError:
         pass
+
+
+def main():
+    text = sys.stdin.read()
+    if not text:
+        sys.exit(0)
+
+    browser_id = _get_browser_id()
+
+    # Try bridge first (web frontend); fall back to OSC 52 (CLI terminal).
+    if not _try_bridge(text, browser_id):
+        _osc52(text)
 
 
 if __name__ == "__main__":

--- a/src/containers/workspace/klangk-copy-to-clipboard
+++ b/src/containers/workspace/klangk-copy-to-clipboard
@@ -96,6 +96,12 @@ def main():
 
     browser_id = _get_browser_id()
 
+    # "klangkshell" sentinel means we're in klangk shell (CLI), not a
+    # browser — skip the bridge and go straight to OSC 52.
+    if browser_id == "klangkshell":
+        _osc52(text)
+        return
+
     # Try bridge first (web frontend); fall back to OSC 52 (CLI terminal).
     if not _try_bridge(text, browser_id):
         _osc52(text)

--- a/src/containers/workspace/klangk-copy-to-clipboard
+++ b/src/containers/workspace/klangk-copy-to-clipboard
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Copy text from stdin to the browser's system clipboard via the bridge.
+
+Used by tmux's copy-pipe to make selections auto-copy to the user's
+clipboard.  Reads the selected text from stdin, resolves the current
+browser ID, and POSTs a clipboard_write action to the bridge endpoint.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import urllib.request
+import urllib.error
+
+BRIDGE_URL = os.environ.get("KLANGK_BRIDGE_URL", "")
+WORKSPACE_TOKEN = os.environ.get("KLANGK_WORKSPACE_TOKEN", "")
+
+
+def _get_browser_id():
+    try:
+        result = subprocess.run(
+            ["klangk-browser-id"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+    return ""
+
+
+def main():
+    if not BRIDGE_URL:
+        sys.exit(1)
+
+    browser_id = _get_browser_id()
+    if not browser_id:
+        sys.exit(1)
+
+    text = sys.stdin.read()
+    if not text:
+        sys.exit(0)
+
+    payload = json.dumps({
+        "action": "clipboard_write",
+        "browser_id": browser_id,
+        "text": text,
+    }).encode()
+
+    headers = {"Content-Type": "application/json"}
+    if WORKSPACE_TOKEN:
+        headers["Authorization"] = f"Bearer {WORKSPACE_TOKEN}"
+
+    req = urllib.request.Request(
+        f"{BRIDGE_URL}/api/browser-delegate",
+        data=payload,
+        headers=headers,
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5):
+            pass
+    except (urllib.error.URLError, OSError):
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/src/containers/workspace/tmux.conf
+++ b/src/containers/workspace/tmux.conf
@@ -16,15 +16,32 @@ set -g extended-keys on
 set -g extended-keys-format csi-u
 set -gs terminal-features 'xterm*:extkeys'
 
-# Mouse off — the outer terminal handles text selection natively.
-# Mouse wheel scrollback is not available in klangk shell (CLI) due to
-# xterm mouse protocol limitations (see #383). Use Shift+PgUp/PgDn for
-# scrollback instead. The web frontend handles wheel scrollback
-# independently by converting wheel events to Shift+PgUp/PgDn sequences.
+# Mouse on — enables wheel scrollback and cross-viewport text selection.
+# Tradeoff: native terminal selection requires Shift+drag (standard tmux
+# convention). See #384 for full research on why this is unavoidable.
+#
+# Selections auto-copy to the browser's system clipboard via the bridge
+# (klangk-copy-to-clipboard). In klangk shell (CLI), Shift+drag gives
+# native terminal selection (viewport-only); plain drag uses tmux
+# selection (cross-viewport, routed to clipboard via bridge).
+set -g mouse on
 
-# Only Shift+PgUp/PgDn enter copy mode for scrollback.
-# Plain PgUp/PgDn pass through to the application (e.g. less, vim).
-# -e = auto-exit copy mode when scrolling back to the bottom.
+# Mouse wheel enters copy mode for scrollback.
+bind -n WheelUpPane copy-mode -eu
+
+# Copy selection to system clipboard via bridge. copy-pipe sends the
+# selected text to stdin of the script and also copies to tmux's paste
+# buffer. -and-cancel exits copy mode after copying.
+set -g copy-command "klangk-copy-to-clipboard"
+bind -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel
+bind -T copy-mode MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel
+
+# Keyboard-driven copy in copy mode (Enter or y).
+bind -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel
+bind -T copy-mode-vi y send-keys -X copy-pipe-and-cancel
+bind -T copy-mode Enter send-keys -X copy-pipe-and-cancel
+
+# Shift+PgUp/PgDn also enter/navigate copy mode.
 bind -n S-PgUp copy-mode -eu
 bind -n S-PgDn send-keys PgDn
 
@@ -35,9 +52,10 @@ bind -T copy-mode S-PgUp send-keys -X halfpage-up
 bind -T copy-mode S-PgDn send-keys -X halfpage-down
 
 # Exit copy mode
+bind -T copy-mode-vi Escape send-keys -X cancel
+bind -T copy-mode-vi q send-keys -X cancel
 bind -T copy-mode Escape send-keys -X cancel
 bind -T copy-mode q send-keys -X cancel
-bind -T copy-mode Enter send-keys -X cancel
 set -g mode-keys vi
 
 # Prevent tmux from auto-renaming windows based on the running process.

--- a/src/containers/workspace/tmux.conf
+++ b/src/containers/workspace/tmux.conf
@@ -10,6 +10,7 @@ set -g default-terminal "xterm-256color"
 set -ga terminal-overrides ",xterm-256color:Tc"
 set -g escape-time 0
 set -g history-limit 50000
+set -g allow-passthrough on
 
 # Pass through extended keys to applications (csi-u format for Pi compatibility)
 set -g extended-keys on

--- a/src/frontend/e2e-tests/e2e/terminal-copy.spec.ts
+++ b/src/frontend/e2e-tests/e2e/terminal-copy.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect, Page } from "@playwright/test";
+import { createAndOpenWorkspace, fv, terminalType, vp } from "./helpers";
+
+/**
+ * Capture all WebSocket frames received from the server.
+ * Returns the array — it grows as frames arrive.
+ */
+function captureReceivedFrames(page: Page): string[] {
+  const frames: string[] = [];
+  page.on("websocket", (ws: { on: Function }) => {
+    ws.on("framereceived", (frame: { payload: string | Buffer }) => {
+      frames.push(frame.payload.toString());
+    });
+  });
+  return frames;
+}
+
+test.describe("terminal copy via bridge", () => {
+  test("mouse drag selection copies to system clipboard via bridge", async ({
+    page,
+    context,
+    request,
+  }) => {
+    // Grant clipboard permissions so Clipboard.setData works without
+    // user activation (the bridge round-trip may exceed the activation
+    // window).
+    await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+
+    const received = captureReceivedFrames(page);
+    const { cleanup } = await createAndOpenWorkspace(page, request, "copy", {
+      waitForTerminal: true,
+    });
+
+    try {
+      const { width, height } = vp(page);
+
+      // Focus the terminal and generate visible output.
+      await fv(page).click({
+        position: { x: width / 2, y: height / 2 },
+        force: true,
+      });
+      await page.waitForTimeout(500);
+
+      await terminalType(
+        page,
+        "echo COPYTEST-START; seq 1 10; echo COPYTEST-END",
+      );
+      await page.waitForTimeout(2000);
+
+      // Mouse drag across several lines in the terminal area.
+      // With mouse-on, tmux enters copy mode on drag and selects text.
+      // On mouse-up, copy-pipe sends the selection to klangk-copy-to-clipboard
+      // which POSTs clipboard_write to the bridge → server relays to browser
+      // → Flutter writes to system clipboard.
+      const startX = 50;
+      const startY = height / 2 - 40;
+      const endX = width - 50;
+      const endY = height / 2 + 40;
+
+      await page.mouse.move(startX, startY);
+      await page.waitForTimeout(100);
+      await page.mouse.down();
+      await page.waitForTimeout(100);
+
+      // Drag slowly so tmux registers the selection
+      const steps = 10;
+      for (let i = 1; i <= steps; i++) {
+        const x = startX + ((endX - startX) * i) / steps;
+        const y = startY + ((endY - startY) * i) / steps;
+        await page.mouse.move(x, y);
+        await page.waitForTimeout(50);
+      }
+      await page.mouse.up();
+
+      // Wait for the clipboard_write browser_request to arrive via WebSocket.
+      const deadline = Date.now() + 15_000;
+      let clipboardFrame: string | undefined;
+      while (Date.now() < deadline) {
+        clipboardFrame = received.find(
+          (f) => f.includes("clipboard_write") && f.includes("browser_request"),
+        );
+        if (clipboardFrame) break;
+        await page.waitForTimeout(200);
+      }
+
+      expect(clipboardFrame).toBeDefined();
+      const msg = JSON.parse(clipboardFrame!);
+      expect(msg.action).toBe("clipboard_write");
+      expect(msg.text.length).toBeGreaterThan(0);
+
+      // After the bridge round-trip, the system clipboard should have
+      // the selected text.
+      await page.waitForTimeout(500);
+      const clipboard = await page.evaluate(() =>
+        navigator.clipboard.readText(),
+      );
+      expect(clipboard.length).toBeGreaterThan(0);
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/frontend/lib/browser/browser_delegate.dart
+++ b/src/frontend/lib/browser/browser_delegate.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
 import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 import '../ws/ws_client.dart';
@@ -40,6 +41,8 @@ class BrowserDelegate {
     try {
       if (action == 'fetch') {
         result = await _handleFetch(request);
+      } else if (action == 'clipboard_write') {
+        result = await _handleClipboardWrite(request);
       } else if (action != null) {
         // Streaming bridge: when the backend marks the request as a stream,
         // relay incremental deltas as browser_chunk messages; the final
@@ -62,6 +65,20 @@ class BrowserDelegate {
     }
 
     _client.sendBrowserResponse(id, result);
+  }
+
+  Future<Map<String, dynamic>> _handleClipboardWrite(
+      Map<String, dynamic> request) async {
+    final text = request['text'] as String?;
+    if (text == null || text.isEmpty) {
+      return {'error': 'missing text'};
+    }
+    try {
+      await Clipboard.setData(ClipboardData(text: text));
+      return {'status': 'ok'};
+    } catch (e) {
+      return {'error': 'clipboard write failed: $e'};
+    }
   }
 
   Future<Map<String, dynamic>> _handleFetch(

--- a/src/frontend/lib/terminal/container_terminal.dart
+++ b/src/frontend/lib/terminal/container_terminal.dart
@@ -173,7 +173,8 @@ class ContainerTerminalState extends State<ContainerTerminal> {
             // Check if right-click is on a URL
             final tappedUrl = _getUrlAtOffset(offset); // coverage:ignore-line
             // Build menu items based on whether text is selected
-            final hasSelection = _controller.selection != null;
+            // Copy is handled by tmux (mouse-on + copy-pipe routes
+            // selections to the system clipboard via the bridge).
             final items = <PopupMenuEntry<String>>[
               // coverage:ignore-start
               if (tappedUrl != null) ...[
@@ -190,13 +191,6 @@ class ContainerTerminalState extends State<ContainerTerminal> {
                         leading: Icon(Icons.link, size: 18),
                         title: Text('Copy Link'))),
               ],
-              if (hasSelection)
-                const PopupMenuItem(
-                    value: 'copy',
-                    child: ListTile(
-                        dense: true,
-                        leading: Icon(Icons.copy, size: 18),
-                        title: Text('Copy'))),
               // coverage:ignore-end
               const PopupMenuItem(
                   value: 'paste',
@@ -216,12 +210,6 @@ class ContainerTerminalState extends State<ContainerTerminal> {
                 openUrl(tappedUrl);
               } else if (action == 'copy_link' && tappedUrl != null) {
                 Clipboard.setData(ClipboardData(text: tappedUrl));
-              } else if (action == 'copy') {
-                final selection = _controller.selection;
-                if (selection != null) {
-                  final text = _terminal.buffer.getText(selection);
-                  Clipboard.setData(ClipboardData(text: text));
-                }
               } else // coverage:ignore-end
               if (action == 'paste') {
                 Clipboard.getData(Clipboard.kTextPlain).then((data) {

--- a/src/frontend/lib/terminal/ghostty_terminal.dart
+++ b/src/frontend/lib/terminal/ghostty_terminal.dart
@@ -2,14 +2,12 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:flterm/flterm.dart';
-import 'package:flutter/gestures.dart'
-    show PointerScrollEvent, kSecondaryMouseButton;
+import 'package:flutter/gestures.dart' show PointerScrollEvent;
 import 'package:flutter/foundation.dart'
     show TargetPlatform, defaultTargetPlatform, kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
-import '../utils/suppress_browser_menu.dart';
 import '../ws/ws_client.dart';
 import '../utils/web_helpers_stub.dart'
     if (dart.library.js_interop) '../utils/web_helpers_web.dart';
@@ -238,35 +236,6 @@ class GhosttyTerminalState extends State<GhosttyTerminal> {
         k == LogicalKeyboardKey.numpad0;
   }
 
-  // Right-click context menu for the terminal. Copy is handled by tmux
-  // (mouse-on + copy-pipe routes selections to the system clipboard via
-  // the bridge), so we only offer Paste here.
-  void _showTerminalContextMenu(BuildContext ctx, Offset position) {
-    // coverage:ignore-start
-    final overlay = Overlay.of(ctx).context.findRenderObject() as RenderBox;
-    showMenu<String>(
-      context: ctx,
-      position: RelativeRect.fromLTRB(
-        position.dx,
-        position.dy,
-        overlay.size.width - position.dx,
-        overlay.size.height - position.dy,
-      ),
-      items: const [
-        PopupMenuItem(value: 'paste', child: Text('Paste')),
-      ],
-    ).then((value) {
-      if (value == 'paste') {
-        Clipboard.getData(Clipboard.kTextPlain).then((data) {
-          if (data?.text != null && data!.text!.isNotEmpty) {
-            _terminal.paste(data.text!);
-          }
-        });
-      }
-    });
-    // coverage:ignore-end
-  }
-
   // Native-only font zoom (Ctrl +/-/0). On web these shortcuts are not bound,
   // so the browser's own zoom handles them.
   void _zoomBy(double delta) {
@@ -394,77 +363,59 @@ class GhosttyTerminalState extends State<GhosttyTerminal> {
           onInvoke: (_) => _zoomReset(),
         ),
       },
-      child: SuppressBrowserContextMenu(
-        child: Listener(
-          // Right-click context menu for Copy/Paste. Use Listener (not
-          // GestureDetector) to avoid gesture arena conflicts that block
-          // mouse wheel scrollback in flterm's Scrollable.
-          onPointerSignal: (event) {
-            // On the alternate screen (tmux), convert wheel events to
-            // PgUp/PgDn key sequences so tmux can handle scrollback via
-            // copy-mode. flterm has no local scrollback on the alt screen.
-            if (event is PointerScrollEvent &&
-                _scrollController.hasClients &&
-                _scrollController.activeScreen == TerminalScreen.alternate) {
-              if (event.scrollDelta.dy < 0) {
-                // Wheel up → Shift+PgUp (ESC [5;2~)
-                widget.wsClient.sendTerminalInput('\x1b[5;2~');
-              } else if (event.scrollDelta.dy > 0) {
-                // Wheel down → Shift+PgDn (ESC [6;2~)
-                widget.wsClient.sendTerminalInput('\x1b[6;2~');
-              }
+      child: Listener(
+        // On the alternate screen (tmux), convert wheel events to
+        // PgUp/PgDn key sequences so tmux can handle scrollback via
+        // copy-mode. flterm has no local scrollback on the alt screen.
+        onPointerSignal: (event) {
+          if (event is PointerScrollEvent &&
+              _scrollController.hasClients &&
+              _scrollController.activeScreen == TerminalScreen.alternate) {
+            if (event.scrollDelta.dy < 0) {
+              // Wheel up → Shift+PgUp (ESC [5;2~)
+              widget.wsClient.sendTerminalInput('\x1b[5;2~');
+            } else if (event.scrollDelta.dy > 0) {
+              // Wheel down → Shift+PgDn (ESC [6;2~)
+              widget.wsClient.sendTerminalInput('\x1b[6;2~');
             }
+          }
+        },
+        child: TerminalView(
+          controller: _terminal,
+          theme: _theme,
+          fontData: _fontData,
+          focusNode: _focusNode,
+          scrollController: _scrollController,
+          autofocus: false,
+          padding: EdgeInsets.zero,
+          // On web, let plain PgUp/PgDn on the primary screen and the browser
+          // zoom combos (Cmd/Ctrl +/-/0) reach the browser (see [_bypassKey]);
+          // on the alt screen and on native they go to the PTY as usual.
+          bypassKey: _bypassKey,
+          // Disable flterm's built-in Ctrl/Cmd+V paste (it reads via
+          // Clipboard.getData, which fails on Firefox). These override flterm's
+          // platform defaults, so paste flows solely through the native
+          // `paste` event in [installPasteListener] — one path, no double-paste.
+          //
+          // Native-only font zoom is added via [zoomShortcutsFor]; on web
+          // the browser zooms. Page-scroll keys go to the PTY where tmux
+          // handles scrollback; alt-screen scroll is handled in [_bypassKey].
+          shortcuts: {
+            ..._disableFltermPaste,
+            if (!isWebOverride) ...zoomShortcutsFor(defaultTargetPlatform),
           },
-          onPointerDown: (event) {
-            // coverage:ignore-start
-            if (event.buttons == kSecondaryMouseButton) {
-              // Show context menu on right-click release. Schedule after
-              // the pointer down so the menu appears at the click location.
-              Future.delayed(const Duration(milliseconds: 50), () {
-                if (mounted) {
-                  _showTerminalContextMenu(context, event.position);
-                }
-              });
-            }
-            // coverage:ignore-end
-          },
-          child: TerminalView(
-            controller: _terminal,
-            theme: _theme,
-            fontData: _fontData,
-            focusNode: _focusNode,
-            scrollController: _scrollController,
-            autofocus: false,
-            padding: EdgeInsets.zero,
-            // On web, let plain PgUp/PgDn on the primary screen and the browser
-            // zoom combos (Cmd/Ctrl +/-/0) reach the browser (see [_bypassKey]);
-            // on the alt screen and on native they go to the PTY as usual.
-            bypassKey: _bypassKey,
-            // Disable flterm's built-in Ctrl/Cmd+V paste (it reads via
-            // Clipboard.getData, which fails on Firefox). These override flterm's
-            // platform defaults, so paste flows solely through the native
-            // `paste` event in [installPasteListener] — one path, no double-paste.
-            //
-            // Native-only font zoom is added via [zoomShortcutsFor]; on web
-            // the browser zooms. Page-scroll keys go to the PTY where tmux
-            // handles scrollback; alt-screen scroll is handled in [_bypassKey].
-            shortcuts: {
-              ..._disableFltermPaste,
-              if (!isWebOverride) ...zoomShortcutsFor(defaultTargetPlatform),
+          // Keep mouse selection (drag/word/line/long-press) but drop the
+          // keyboard select-all gesture, so Ctrl+A falls through to the shell
+          // (readline beginning-of-line / tmux prefix) instead of selecting the
+          // buffer. Ctrl+C already passes through (flterm's copy is selection-
+          // conditional); copy stays on Ctrl+Shift+C and the right-click menu.
+          gestureSettings: const TerminalGestureSettings(
+            enabledSelections: {
+              SelectionGesture.drag,
+              SelectionGesture.word,
+              SelectionGesture.line,
+              SelectionGesture.longPress,
             },
-            // Keep mouse selection (drag/word/line/long-press) but drop the
-            // keyboard select-all gesture, so Ctrl+A falls through to the shell
-            // (readline beginning-of-line / tmux prefix) instead of selecting the
-            // buffer. Ctrl+C already passes through (flterm's copy is selection-
-            // conditional); copy stays on Ctrl+Shift+C and the right-click menu.
-            gestureSettings: const TerminalGestureSettings(
-              enabledSelections: {
-                SelectionGesture.drag,
-                SelectionGesture.word,
-                SelectionGesture.line,
-                SelectionGesture.longPress,
-              },
-            ),
           ),
         ),
       ),

--- a/src/frontend/lib/terminal/ghostty_terminal.dart
+++ b/src/frontend/lib/terminal/ghostty_terminal.dart
@@ -238,11 +238,11 @@ class GhosttyTerminalState extends State<GhosttyTerminal> {
         k == LogicalKeyboardKey.numpad0;
   }
 
-  // Right-click context menu for the terminal. The browser's native Copy
-  // doesn't work with flterm's canvas selection, so we provide our own.
+  // Right-click context menu for the terminal. Copy is handled by tmux
+  // (mouse-on + copy-pipe routes selections to the system clipboard via
+  // the bridge), so we only offer Paste here.
   void _showTerminalContextMenu(BuildContext ctx, Offset position) {
     // coverage:ignore-start
-    final hasSelection = _terminal.selectedText().isNotEmpty;
     final overlay = Overlay.of(ctx).context.findRenderObject() as RenderBox;
     showMenu<String>(
       context: ctx,
@@ -252,18 +252,11 @@ class GhosttyTerminalState extends State<GhosttyTerminal> {
         overlay.size.width - position.dx,
         overlay.size.height - position.dy,
       ),
-      items: [
-        if (hasSelection)
-          const PopupMenuItem(value: 'copy', child: Text('Copy')),
-        const PopupMenuItem(value: 'paste', child: Text('Paste')),
+      items: const [
+        PopupMenuItem(value: 'paste', child: Text('Paste')),
       ],
     ).then((value) {
-      if (value == 'copy') {
-        final text = _terminal.selectedText();
-        if (text.isNotEmpty) {
-          Clipboard.setData(ClipboardData(text: text));
-        }
-      } else if (value == 'paste') {
+      if (value == 'paste') {
         Clipboard.getData(Clipboard.kTextPlain).then((data) {
           if (data?.text != null && data!.text!.isNotEmpty) {
             _terminal.paste(data.text!);

--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -340,8 +340,11 @@ class WsClient extends ChangeNotifier {
   void sendBrowserReattach() {
     final bid = getBrowserId();
     if (bid.isNotEmpty) {
-      debugPrint('[WsClient] browser_reattach: $bid');
-      _send({'cmd': 'browser_reattach', 'browser_id': bid});
+      debugPrint('[WsClient] browser_reattach: $bid'); // coverage:ignore-start
+      _send({
+        'cmd': 'browser_reattach',
+        'browser_id': bid
+      }); // coverage:ignore-end
     }
   }
 

--- a/src/frontend/test/browser_delegate_test.dart
+++ b/src/frontend/test/browser_delegate_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
@@ -93,6 +94,8 @@ List<Map<String, dynamic>> _browserChunks(_FakeWebSocketChannel channel) {
 }
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
   setUp(() {
     testBaseUrlOverride = 'http://localhost:8997';
     SharedPreferences.setMockInitialValues({});
@@ -249,6 +252,88 @@ void main() {
       await Future.delayed(const Duration(milliseconds: 50));
 
       expect(_browserResponses(channel), isEmpty);
+    });
+
+    test('clipboard_write copies text to clipboard', () async {
+      // Mock the platform clipboard channel so Clipboard.setData works.
+      String? clipboardText;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+        if (call.method == 'Clipboard.setData') {
+          clipboardText = (call.arguments as Map)['text'] as String?;
+        }
+        return null;
+      });
+
+      channel.serverSend({
+        'type': 'browser_request',
+        'id': 'req-clip-1',
+        'action': 'clipboard_write',
+        'text': 'hello clipboard',
+      });
+      await Future.delayed(const Duration(milliseconds: 50));
+
+      final responses = _browserResponses(channel);
+      expect(responses.length, 1);
+      expect(responses[0]['id'], 'req-clip-1');
+      expect(responses[0]['status'], 'ok');
+      expect(clipboardText, 'hello clipboard');
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, null);
+    });
+
+    test('clipboard_write with missing text returns error', () async {
+      channel.serverSend({
+        'type': 'browser_request',
+        'id': 'req-clip-empty',
+        'action': 'clipboard_write',
+      });
+      await Future.delayed(const Duration(milliseconds: 50));
+
+      final responses = _browserResponses(channel);
+      expect(responses.length, 1);
+      expect(responses[0]['error'], contains('missing text'));
+    });
+
+    test('clipboard_write failure returns error', () async {
+      // Make Clipboard.setData throw.
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+        if (call.method == 'Clipboard.setData') {
+          throw PlatformException(code: 'FAIL', message: 'clipboard denied');
+        }
+        return null;
+      });
+
+      channel.serverSend({
+        'type': 'browser_request',
+        'id': 'req-clip-fail',
+        'action': 'clipboard_write',
+        'text': 'denied text',
+      });
+      await Future.delayed(const Duration(milliseconds: 50));
+
+      final responses = _browserResponses(channel);
+      expect(responses.length, 1);
+      expect(responses[0]['error'], contains('clipboard write failed'));
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, null);
+    });
+
+    test('clipboard_write with empty text returns error', () async {
+      channel.serverSend({
+        'type': 'browser_request',
+        'id': 'req-clip-blank',
+        'action': 'clipboard_write',
+        'text': '',
+      });
+      await Future.delayed(const Duration(milliseconds: 50));
+
+      final responses = _browserResponses(channel);
+      expect(responses.length, 1);
+      expect(responses[0]['error'], contains('missing text'));
     });
 
     test('fetch returns response from HTTP client', () async {

--- a/src/frontend/test/container_terminal_test.dart
+++ b/src/frontend/test/container_terminal_test.dart
@@ -217,25 +217,24 @@ void main() {
       client.close();
     });
 
-    testWidgets('right-click with selection shows copy option', (tester) async {
+    testWidgets('right-click menu has Paste but not Copy', (tester) async {
       final client = _MockWsClient();
       await tester.pumpWidget(_buildTerminal(client));
       await tester.pumpAndSettle();
 
-      // Write some text to the terminal so there's content to select
+      // Write some text to the terminal so there's content
       client.emitTerminal('hello world\r\n');
       await tester.pump();
 
       final terminalView = find.byType(ContainerTerminal);
       final center = tester.getCenter(terminalView);
 
-      // Right-click to open menu — Copy only shows when there's a selection
-      // but we can't easily create a selection in tests, so just verify
-      // the menu opens and Paste is available
+      // Copy is handled by tmux copy-pipe, not the context menu.
       await tester.tapAt(center, buttons: kSecondaryMouseButton);
       await tester.pumpAndSettle();
 
       expect(find.text('Paste'), findsOneWidget);
+      expect(find.text('Copy'), findsNothing);
 
       // Dismiss by tapping away
       await tester.tapAt(Offset.zero);

--- a/src/frontend/test/ghostty_terminal_test.dart
+++ b/src/frontend/test/ghostty_terminal_test.dart
@@ -249,21 +249,6 @@ void main() {
       client.close();
     });
 
-    testWidgets('right-click shows context menu with Paste', (tester) async {
-      final client = _MockWsClient();
-      await tester.pumpWidget(_build(client));
-      await tester.pumpAndSettle();
-
-      final center = tester.getCenter(find.byType(TerminalView));
-      await tester.tapAt(center, buttons: kSecondaryMouseButton);
-      await tester.pumpAndSettle();
-
-      // Context menu only shows Paste; Copy is handled by tmux copy-pipe.
-      expect(find.text('Paste'), findsOneWidget);
-      expect(find.text('Copy'), findsNothing);
-      client.close();
-    });
-
     testWidgets('routeNativePaste drops the payload when not focused',
         (tester) async {
       final client = _MockWsClient();

--- a/src/frontend/test/ghostty_terminal_test.dart
+++ b/src/frontend/test/ghostty_terminal_test.dart
@@ -258,7 +258,7 @@ void main() {
       await tester.tapAt(center, buttons: kSecondaryMouseButton);
       await tester.pumpAndSettle();
 
-      // Custom context menu shows Paste (Copy only appears with selection)
+      // Context menu only shows Paste; Copy is handled by tmux copy-pipe.
       expect(find.text('Paste'), findsOneWidget);
       expect(find.text('Copy'), findsNothing);
       client.close();


### PR DESCRIPTION
## Summary
- Switch tmux to `mouse on` so text selections can span the scrollback buffer (not just the visible viewport)
- Tmux `copy-pipe` routes selected text through `klangk-copy-to-clipboard`, which sends it to the browser's system clipboard via the bridge (`clipboard_write` action)
- Mouse wheel scrollback now works in both the web frontend and `klangk shell`
- Remove "Copy" from terminal right-click context menus — selecting text IS copying (auto-sent to clipboard)
- Shift+drag still does native flterm selection (viewport-only)
- CLI sends `browser_id="klangkshell"` sentinel so `klangk-copy-to-clipboard` skips the bridge and uses OSC 52 directly
- OSC 52 fallback for terminal emulators that support it (iTerm2, kitty, alacritty, WezTerm, etc.)

Closes #409
Closes #420

## Why switch from Option A to Option B (#384)

Issue #384 chose Option A (`mouse off`) because Option B's tradeoff — requiring Shift+drag for native selection — seemed worse than losing wheel scrollback. But #409 revealed that Option A also prevents cross-viewport text selection entirely, which is a more fundamental limitation.

The bridge clipboard pipe (`copy-pipe` → `klangk-copy-to-clipboard` → `clipboard_write` action) tips the balance: tmux selections now auto-copy to the system clipboard, so the user doesn't need to learn tmux copy-mode commands. The UX is: drag to select (even across scrollback pages), release, text is on your clipboard. This makes Option B strictly better than it was when #384 was written.

## Tradeoffs
- **Gained**: cross-viewport selection, mouse wheel scrollback, auto-copy to clipboard
- **Lost**: native click-drag in `klangk shell` now requires Shift+drag (standard tmux convention)

## Test plan
- [x] Frontend tests pass (100% coverage)
- [x] Backend tests pass (100% coverage)
- [x] Manual: mouse drag selects text, auto-copies to clipboard via bridge
- [x] Manual: klangk shell does not hit browser-delegate API (klangkshell sentinel)
- [ ] Rebuild image, verify mouse wheel enters tmux copy mode
- [ ] Shift+drag still works for quick viewport selection
- [ ] Right-click menu shows only Paste (no Copy)
- [ ] `klangk shell`: mouse wheel scrollback works, Shift+drag for native selection