### PR TITLE
fix(ws): stop auto-reconnect after 5 minutes

### DIFF
--- a/src/frontend/lib/workspace/workspace_page.dart
+++ b/src/frontend/lib/workspace/workspace_page.dart
@@ -703,7 +703,7 @@ class _WorkspacePageState extends State<WorkspacePage> {
                         mainAxisSize: MainAxisSize.min,
                         children: [
                           const Text(
-                            'Disconnected from server',
+                            'Connection lost',
                             style: TextStyle(color: Colors.white, fontSize: 16),
                           ),
                           const SizedBox(height: 16),

--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -55,6 +55,12 @@ class WsClient extends ChangeNotifier {
   /// Max backoff duration in seconds.
   static const int _maxBackoffSeconds = 30;
 
+  /// Give up auto-reconnecting after this duration.
+  static const Duration _reconnectTimeout = Duration(minutes: 5);
+
+  /// When the current reconnect cycle started.
+  DateTime? _reconnectStartedAt;
+
   /// Workspace ID to rejoin after reconnecting.
   String? _pendingWorkspaceId;
 
@@ -65,6 +71,10 @@ class WsClient extends ChangeNotifier {
   /// Override for testing to control reconnect backoff delay.
   @visibleForTesting
   static Duration Function(int attempt)? testBackoffOverride;
+
+  /// Override for testing to shorten the reconnect timeout.
+  @visibleForTesting
+  static Duration? testReconnectTimeout;
 
   /// Inject a pre-connected channel for testing.
   @visibleForTesting
@@ -186,6 +196,7 @@ class WsClient extends ChangeNotifier {
             _defaultCommand = json['defaultCommand'] as String?;
             _reconnecting = false;
             _reconnectAttempt = 0;
+            _reconnectStartedAt = null;
             _pendingWorkspaceId = null;
             _startHeartbeat();
             notifyListeners();
@@ -448,6 +459,21 @@ class WsClient extends ChangeNotifier {
 
   void _scheduleReconnect() {
     if (!_autoReconnect || _reconnecting) return;
+
+    // Record when the reconnect cycle started.
+    _reconnectStartedAt ??= DateTime.now();
+
+    // Give up after the timeout — stop auto-reconnect and let the UI
+    // show "Disconnected" with a manual reconnect button.
+    final timeout = testReconnectTimeout ?? _reconnectTimeout;
+    if (DateTime.now().difference(_reconnectStartedAt!) >= timeout) {
+      _autoReconnect = false;
+      _reconnecting = false;
+      _reconnectStartedAt = null;
+      notifyListeners();
+      return;
+    }
+
     _reconnecting = true;
     _reconnectAttempt++;
     notifyListeners();
@@ -483,6 +509,7 @@ class WsClient extends ChangeNotifier {
     _autoReconnect = false;
     _reconnecting = false;
     _reconnectAttempt = 0;
+    _reconnectStartedAt = null;
     _pendingWorkspaceId = null;
     _reconnectTimer?.cancel();
     _reconnectTimer = null;

--- a/src/frontend/test/ws_client_test.dart
+++ b/src/frontend/test/ws_client_test.dart
@@ -544,6 +544,48 @@ void main() {
       expect(channels.length, 1); // no reconnect attempt was made
     });
 
+    test('gives up reconnecting after timeout', () async {
+      final auth = AuthService();
+      await Future.delayed(Duration.zero);
+
+      // Zero backoff so reconnects fire immediately; zero timeout so
+      // the second attempt exceeds the deadline.
+      WsClient.testBackoffOverride = (_) => Duration.zero;
+      WsClient.testReconnectTimeout = Duration.zero;
+
+      final client = WsClient();
+      client.updateAuth(auth);
+      await client.connect();
+      client.connectWorkspace('ws-1');
+      channels[0]
+          .serverSend({'type': 'workspace_ready', 'workspaceId': 'ws-1'});
+      await Future.delayed(Duration.zero);
+
+      // Make all future channels fail.
+      WsClient.testChannelFactory = (_) {
+        final ch = _FakeWebSocketChannel()..failReady = true;
+        channels.add(ch);
+        return ch;
+      };
+
+      // Disconnect → first reconnect attempt fires.
+      channels[0].serverClose();
+      await Future.delayed(Duration.zero);
+
+      // Let the first attempt fire and fail, then the second schedule
+      // check triggers the timeout.
+      await Future.delayed(Duration.zero);
+      await Future.delayed(Duration.zero);
+      await Future.delayed(Duration.zero);
+
+      // Auto-reconnect should have given up.
+      expect(client.reconnecting, isFalse);
+
+      WsClient.testReconnectTimeout = null;
+      client.disconnect();
+      client.dispose();
+    });
+
     test('backoff delay override is called with correct attempt', () async {
       final attempts = <int>[];
       WsClient.testBackoffOverride = (attempt) {


### PR DESCRIPTION
## Summary
- Auto-reconnect now gives up after 5 minutes and shows "Connection lost" with a manual Reconnect button
- The manual Reconnect button works at any time (before or after timeout)
- Reconnect timer resets on successful connection

Closes #419

## Test plan
- [x] Frontend tests pass (100% coverage)
- [x] New test: `gives up reconnecting after timeout`
- [ ] Kill server, verify reconnecting overlay appears, verify it stops after 5 min
- [ ] Click Reconnect button after timeout, verify it works