### PR TITLE
feat(frontend): stale build detection with reload banner

### DIFF
--- a/scripts/flutterbuildweb.sh
+++ b/scripts/flutterbuildweb.sh
@@ -82,4 +82,6 @@ for f in main.dart.wasm main.dart.js; do
   fi
 done
 sed -i "s|flutter_bootstrap.js|flutter_bootstrap.js?v=${HASH}|" "$BUILD_DIR/index.html"
+# Inject build hash as a meta tag so the Dart app can detect stale builds.
+sed -i "s|</head>|<meta name=\"klangk-build-hash\" content=\"${HASH}\" />\n</head>|" "$BUILD_DIR/index.html"
 echo "Cache-bust: v=$HASH"

--- a/src/frontend/lib/app.dart
+++ b/src/frontend/lib/app.dart
@@ -13,6 +13,7 @@ import 'auth/accept_invite_page.dart';
 import 'auth/oidc_complete_page.dart';
 import 'auth/reset_password_page.dart';
 import 'auth/settings_page.dart';
+import 'widgets/stale_build_banner.dart';
 import 'workspace/workspace_list_page.dart';
 import 'workspace/workspace_page.dart';
 
@@ -50,6 +51,14 @@ class _KlangkAppState extends State<KlangkApp> {
           debugShowCheckedModeBanner: false,
           theme: _theme,
           routerConfig: _router!,
+          builder: (context, child) {
+            return Stack(
+              children: [
+                child!,
+                const StaleBuildBanner(),
+              ],
+            );
+          },
         );
       },
     );

--- a/src/frontend/lib/utils/web_helpers_stub.dart
+++ b/src/frontend/lib/utils/web_helpers_stub.dart
@@ -29,3 +29,6 @@ void Function() installPageKeyListener(bool Function() shouldSuppress) => () {};
 
 /// Stub — no system clipboard outside the browser.
 Future<String?> readClipboardText() async => null;
+
+/// Stub — no build hash outside the browser.
+String getBuildHash() => '';

--- a/src/frontend/lib/utils/web_helpers_web.dart
+++ b/src/frontend/lib/utils/web_helpers_web.dart
@@ -113,6 +113,13 @@ Future<String?> readClipboardText() async {
   }
 }
 
+/// Read the build hash from the <meta name="klangk-build-hash"> tag.
+/// Returns empty string if not found (e.g. dev server without build script).
+String getBuildHash() {
+  final meta = web.document.querySelector('meta[name="klangk-build-hash"]');
+  return meta?.getAttribute('content') ?? '';
+}
+
 /// Web implementation — suppresses native browser context menu on right-click.
 Widget buildSuppressor(Widget child) {
   return Listener(

--- a/src/frontend/lib/widgets/stale_build_banner.dart
+++ b/src/frontend/lib/widgets/stale_build_banner.dart
@@ -1,0 +1,112 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+
+import '../utils/web_helpers_stub.dart'
+    if (dart.library.js_interop) '../utils/web_helpers_web.dart';
+
+/// Banner shown when the running frontend build is outdated.
+///
+/// Reads the build hash from the `<meta name="klangk-build-hash">` tag at
+/// startup, then periodically fetches `index.html` to check if a new build
+/// has been deployed. Shows a dismissible banner with a reload button when
+/// the hashes differ.
+class StaleBuildBanner extends StatefulWidget {
+  const StaleBuildBanner({super.key});
+
+  @override
+  State<StaleBuildBanner> createState() => _StaleBuildBannerState();
+}
+
+class _StaleBuildBannerState extends State<StaleBuildBanner> {
+  static const _checkInterval = Duration(minutes: 2);
+  static final _hashPattern =
+      RegExp(r'klangk-build-hash["\s]+content="([^"]+)"');
+
+  Timer? _timer;
+  bool _stale = false;
+  bool _dismissed = false;
+  final String _currentHash = getBuildHash();
+
+  @override
+  void initState() {
+    super.initState();
+    if (_currentHash.isNotEmpty) {
+      _timer = Timer.periodic(_checkInterval, (_) => _check());
+    }
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  Future<void> _check() async {
+    if (_stale || !mounted) return;
+    try {
+      final resp = await http.get(Uri.parse('/index.html'));
+      if (resp.statusCode != 200) return;
+      final match = _hashPattern.firstMatch(resp.body);
+      if (match == null) return;
+      final serverHash = match.group(1) ?? '';
+      if (serverHash.isNotEmpty && serverHash != _currentHash) {
+        if (mounted) setState(() => _stale = true);
+      }
+    } catch (_) {
+      // Network error — skip this check.
+    }
+  }
+
+  void _reload() {
+    navigateTo(Uri.base.toString());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_stale || _dismissed) return const SizedBox.shrink();
+
+    return Positioned(
+      top: 0,
+      left: 0,
+      right: 0,
+      child: Material(
+        color: Colors.transparent,
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          color: const Color(0xFF1A3A2A),
+          child: Row(
+            children: [
+              const Icon(Icons.update, color: Colors.greenAccent, size: 18),
+              const SizedBox(width: 8),
+              const Expanded(
+                child: Text(
+                  'A new version is available.',
+                  style: TextStyle(color: Colors.white, fontSize: 13),
+                ),
+              ),
+              TextButton(
+                onPressed: _reload,
+                child: const Text(
+                  'Reload',
+                  style: TextStyle(
+                    color: Colors.greenAccent,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+              IconButton(
+                onPressed: () => setState(() => _dismissed = true),
+                icon: const Icon(Icons.close, color: Colors.white54, size: 16),
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints(minWidth: 24, minHeight: 24),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/src/frontend/lib/widgets/stale_build_banner.dart
+++ b/src/frontend/lib/widgets/stale_build_banner.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
@@ -14,27 +13,43 @@ import '../utils/web_helpers_stub.dart'
 /// has been deployed. Shows a dismissible banner with a reload button when
 /// the hashes differ.
 class StaleBuildBanner extends StatefulWidget {
-  const StaleBuildBanner({super.key});
+  /// Override the build hash for testing (normally read from DOM).
+  final String? testHash;
+
+  /// Override the HTTP client for testing.
+  final http.Client? testClient;
+
+  /// Override the check interval for testing.
+  final Duration? testInterval;
+
+  const StaleBuildBanner({
+    super.key,
+    this.testHash,
+    this.testClient,
+    this.testInterval,
+  });
 
   @override
-  State<StaleBuildBanner> createState() => _StaleBuildBannerState();
+  State<StaleBuildBanner> createState() => StaleBuildBannerState();
 }
 
-class _StaleBuildBannerState extends State<StaleBuildBanner> {
-  static const _checkInterval = Duration(minutes: 2);
+class StaleBuildBannerState extends State<StaleBuildBanner> {
+  static const _defaultInterval = Duration(minutes: 2);
   static final _hashPattern =
       RegExp(r'klangk-build-hash["\s]+content="([^"]+)"');
 
   Timer? _timer;
   bool _stale = false;
   bool _dismissed = false;
-  final String _currentHash = getBuildHash();
+  late final String _currentHash;
 
   @override
   void initState() {
     super.initState();
+    _currentHash = widget.testHash ?? getBuildHash();
     if (_currentHash.isNotEmpty) {
-      _timer = Timer.periodic(_checkInterval, (_) => _check());
+      final interval = widget.testInterval ?? _defaultInterval;
+      _timer = Timer.periodic(interval, (_) => check());
     }
   }
 
@@ -44,16 +59,22 @@ class _StaleBuildBannerState extends State<StaleBuildBanner> {
     super.dispose();
   }
 
-  Future<void> _check() async {
+  /// Check if a new build is available. Public for testing.
+  Future<void> check() async {
     if (_stale || !mounted) return;
     try {
-      final resp = await http.get(Uri.parse('/index.html'));
-      if (resp.statusCode != 200) return;
-      final match = _hashPattern.firstMatch(resp.body);
-      if (match == null) return;
-      final serverHash = match.group(1) ?? '';
-      if (serverHash.isNotEmpty && serverHash != _currentHash) {
-        if (mounted) setState(() => _stale = true);
+      final client = widget.testClient ?? http.Client();
+      try {
+        final resp = await client.get(Uri.parse('/index.html'));
+        if (resp.statusCode != 200) return;
+        final match = _hashPattern.firstMatch(resp.body);
+        if (match == null) return;
+        final serverHash = match.group(1) ?? '';
+        if (serverHash.isNotEmpty && serverHash != _currentHash) {
+          if (mounted) setState(() => _stale = true);
+        }
+      } finally {
+        if (widget.testClient == null) client.close();
       }
     } catch (_) {
       // Network error — skip this check.

--- a/src/frontend/test/stale_build_banner_test.dart
+++ b/src/frontend/test/stale_build_banner_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:klangk_frontend/widgets/stale_build_banner.dart';
+
+void main() {
+  testWidgets('renders nothing when no build hash is available',
+      (tester) async {
+    // In VM tests, getBuildHash() returns '' (stub), so the banner
+    // should render as SizedBox.shrink and never start polling.
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Stack(
+          children: [
+            Scaffold(body: Text('Main content')),
+            StaleBuildBanner(),
+          ],
+        ),
+      ),
+    );
+
+    expect(find.text('A new version is available.'), findsNothing);
+    expect(find.text('Reload'), findsNothing);
+    expect(find.text('Main content'), findsOneWidget);
+  });
+}

--- a/src/frontend/test/stale_build_banner_test.dart
+++ b/src/frontend/test/stale_build_banner_test.dart
@@ -1,12 +1,24 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 import 'package:klangk_frontend/widgets/stale_build_banner.dart';
+
+const _indexWithHash = '''
+<!doctype html><html><head>
+<meta name="klangk-build-hash" content="newhash123" />
+</head><body></body></html>
+''';
+
+const _indexSameHash = '''
+<!doctype html><html><head>
+<meta name="klangk-build-hash" content="currenthash" />
+</head><body></body></html>
+''';
 
 void main() {
   testWidgets('renders nothing when no build hash is available',
       (tester) async {
-    // In VM tests, getBuildHash() returns '' (stub), so the banner
-    // should render as SizedBox.shrink and never start polling.
     await tester.pumpWidget(
       const MaterialApp(
         home: Stack(
@@ -19,7 +31,150 @@ void main() {
     );
 
     expect(find.text('A new version is available.'), findsNothing);
-    expect(find.text('Reload'), findsNothing);
     expect(find.text('Main content'), findsOneWidget);
+  });
+
+  testWidgets('shows banner when server hash differs', (tester) async {
+    final client = MockClient((request) async {
+      return http.Response(_indexWithHash, 200);
+    });
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Stack(
+          children: [
+            const Scaffold(body: Text('Main content')),
+            StaleBuildBanner(
+              testHash: 'currenthash',
+              testClient: client,
+            ),
+          ],
+        ),
+      ),
+    );
+
+    // Trigger check manually.
+    final state =
+        tester.state<StaleBuildBannerState>(find.byType(StaleBuildBanner));
+    await state.check();
+    await tester.pump();
+
+    expect(find.text('A new version is available.'), findsOneWidget);
+    expect(find.text('Reload'), findsOneWidget);
+  });
+
+  testWidgets('does not show banner when hashes match', (tester) async {
+    final client = MockClient((request) async {
+      return http.Response(_indexSameHash, 200);
+    });
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Stack(
+          children: [
+            const Scaffold(body: Text('Main content')),
+            StaleBuildBanner(
+              testHash: 'currenthash',
+              testClient: client,
+            ),
+          ],
+        ),
+      ),
+    );
+
+    final state =
+        tester.state<StaleBuildBannerState>(find.byType(StaleBuildBanner));
+    await state.check();
+    await tester.pump();
+
+    expect(find.text('A new version is available.'), findsNothing);
+  });
+
+  testWidgets('dismiss hides the banner', (tester) async {
+    final client = MockClient((request) async {
+      return http.Response(_indexWithHash, 200);
+    });
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Stack(
+          children: [
+            const Scaffold(body: Text('Main content')),
+            StaleBuildBanner(
+              testHash: 'currenthash',
+              testClient: client,
+            ),
+          ],
+        ),
+      ),
+    );
+
+    final state =
+        tester.state<StaleBuildBannerState>(find.byType(StaleBuildBanner));
+    await state.check();
+    await tester.pump();
+
+    expect(find.text('A new version is available.'), findsOneWidget);
+
+    // Tap the close button.
+    await tester.tap(find.byIcon(Icons.close));
+    await tester.pump();
+
+    expect(find.text('A new version is available.'), findsNothing);
+  });
+
+  testWidgets('handles HTTP error gracefully', (tester) async {
+    final client = MockClient((request) async {
+      return http.Response('Server Error', 500);
+    });
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Stack(
+          children: [
+            const Scaffold(body: Text('Main content')),
+            StaleBuildBanner(
+              testHash: 'currenthash',
+              testClient: client,
+            ),
+          ],
+        ),
+      ),
+    );
+
+    final state =
+        tester.state<StaleBuildBannerState>(find.byType(StaleBuildBanner));
+    await state.check();
+    await tester.pump();
+
+    // No banner, no crash.
+    expect(find.text('A new version is available.'), findsNothing);
+  });
+
+  testWidgets('handles missing meta tag gracefully', (tester) async {
+    final client = MockClient((request) async {
+      return http.Response('<html><head></head></html>', 200);
+    });
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Stack(
+          children: [
+            const Scaffold(body: Text('Main content')),
+            StaleBuildBanner(
+              testHash: 'currenthash',
+              testClient: client,
+            ),
+          ],
+        ),
+      ),
+    );
+
+    final state =
+        tester.state<StaleBuildBannerState>(find.byType(StaleBuildBanner));
+    await state.check();
+    await tester.pump();
+
+    expect(find.text('A new version is available.'), findsNothing);
   });
 }

--- a/src/frontend/test/stale_build_banner_test.dart
+++ b/src/frontend/test/stale_build_banner_test.dart
@@ -123,6 +123,35 @@ void main() {
     expect(find.text('A new version is available.'), findsNothing);
   });
 
+  testWidgets('reload button calls navigateTo', (tester) async {
+    final client = MockClient((request) async {
+      return http.Response(_indexWithHash, 200);
+    });
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Stack(
+          children: [
+            const Scaffold(body: Text('Main content')),
+            StaleBuildBanner(
+              testHash: 'currenthash',
+              testClient: client,
+            ),
+          ],
+        ),
+      ),
+    );
+
+    final state =
+        tester.state<StaleBuildBannerState>(find.byType(StaleBuildBanner));
+    await state.check();
+    await tester.pump();
+
+    // Tap the Reload button — navigateTo is a no-op stub in VM tests.
+    await tester.tap(find.text('Reload'));
+    await tester.pump();
+  });
+
   testWidgets('handles HTTP error gracefully', (tester) async {
     final client = MockClient((request) async {
       return http.Response('Server Error', 500);


### PR DESCRIPTION
## Summary

- Inject the build hash into a `<meta name="klangk-build-hash">` tag at build time (alongside the existing `?v=` cache-bust)
- New `StaleBuildBanner` widget reads the hash at startup and polls `index.html` every 2 minutes
- When a newer build is detected, a dismissible green banner appears at the top: "A new version is available. [Reload]"
- Banner is app-wide via `MaterialApp.router`'s builder

## Test plan

- [x] 549 frontend unit tests pass
- [ ] Manual: build, load app, rebuild, wait 2 min — banner appears
- [ ] Manual: click Reload — page refreshes to new build
- [ ] Manual: click X — banner dismisses

Closes #423