### PR TITLE
feat(chat): display user handle instead of email

### DIFF
--- a/src/backend/klangk_backend/model.py
+++ b/src/backend/klangk_backend/model.py
@@ -1597,11 +1597,17 @@ async def add_chat_message(
             "SELECT created_at FROM chat_messages WHERE id = ?", (msg_id,)
         )
         row = await cursor.fetchone()
+        # Fetch the current handle for the sender.
+        handle_cursor = await db.execute(
+            "SELECT handle FROM users WHERE id = ?", (user_id,)
+        )
+        handle_row = await handle_cursor.fetchone()
         return {
             "id": msg_id,
             "workspace_id": workspace_id,
             "user_id": user_id,
             "user_email": user_email,
+            "user_handle": handle_row["handle"] if handle_row else None,
             "message": message,
             "message_type": message_type,
             "created_at": row["created_at"],
@@ -1648,11 +1654,13 @@ async def get_chat_messages_before(
         anchor_rowid = anchor["rowid"]
 
         cursor = await db.execute(
-            "SELECT id, workspace_id, user_id, user_email, message,"
-            " message_type, created_at"
-            " FROM chat_messages WHERE workspace_id = ?"
-            " AND (created_at < ? OR (created_at = ? AND rowid < ?))"
-            " ORDER BY created_at DESC, rowid DESC LIMIT ?",
+            "SELECT c.id, c.workspace_id, c.user_id, c.user_email,"
+            " c.message, c.message_type, c.created_at,"
+            " u.handle AS user_handle"
+            " FROM chat_messages c LEFT JOIN users u ON c.user_id = u.id"
+            " WHERE c.workspace_id = ?"
+            " AND (c.created_at < ? OR (c.created_at = ? AND c.rowid < ?))"
+            " ORDER BY c.created_at DESC, c.rowid DESC LIMIT ?",
             (workspace_id, anchor_ts, anchor_ts, anchor_rowid, limit),
         )
         rows = await cursor.fetchall()
@@ -1664,6 +1672,7 @@ async def get_chat_messages_before(
                         "workspace_id": row["workspace_id"],
                         "user_id": row["user_id"],
                         "user_email": row["user_email"],
+                        "user_handle": row["user_handle"],
                         "message": row["message"],
                         "message_type": row["message_type"],
                         "created_at": row["created_at"],
@@ -1698,10 +1707,11 @@ async def get_chat_messages(workspace_id: str, limit: int = 50) -> list[dict]:
     db = await get_db()
     try:
         cursor = await db.execute(
-            "SELECT id, workspace_id, user_id, user_email, message,"
-            " message_type, created_at"
-            " FROM chat_messages WHERE workspace_id = ?"
-            " ORDER BY created_at DESC, rowid DESC LIMIT ?",
+            "SELECT c.id, c.workspace_id, c.user_id, c.user_email,"
+            " c.message, c.message_type, c.created_at, u.handle AS user_handle"
+            " FROM chat_messages c LEFT JOIN users u ON c.user_id = u.id"
+            " WHERE c.workspace_id = ?"
+            " ORDER BY c.created_at DESC, c.rowid DESC LIMIT ?",
             (workspace_id, limit),
         )
         rows = await cursor.fetchall()
@@ -1713,6 +1723,7 @@ async def get_chat_messages(workspace_id: str, limit: int = 50) -> list[dict]:
                         "workspace_id": row["workspace_id"],
                         "user_id": row["user_id"],
                         "user_email": row["user_email"],
+                        "user_handle": row["user_handle"],
                         "message": row["message"],
                         "message_type": row["message_type"],
                         "created_at": row["created_at"],

--- a/src/backend/tests/test_model.py
+++ b/src/backend/tests/test_model.py
@@ -671,6 +671,7 @@ class TestChatMessages:
         assert msg["workspace_id"] == workspace["id"]
         assert msg["user_id"] == user["id"]
         assert msg["user_email"] == "testuser@example.com"
+        assert msg["user_handle"] == "testuser"
         assert msg["message"] == "hello"
         assert msg["message_type"] == model.MSG_USER
         assert "id" in msg
@@ -698,15 +699,17 @@ class TestChatMessages:
 
     async def test_get_chat_messages(self, workspace, user):
         await model.add_chat_message(
-            workspace["id"], "uid-a", "a@test.com", "first"
+            workspace["id"], user["id"], "testuser@example.com", "first"
         )
         await model.add_chat_message(
-            workspace["id"], "uid-b", "b@test.com", "second"
+            workspace["id"], user["id"], "testuser@example.com", "second"
         )
         msgs = await model.get_chat_messages(workspace["id"])
         assert len(msgs) == 2
         assert msgs[0]["message"] == "first"
         assert msgs[1]["message"] == "second"
+        assert msgs[0]["user_handle"] == "testuser"
+        assert msgs[1]["user_handle"] == "testuser"
         assert msgs[0]["message_type"] == model.MSG_USER
         assert msgs[1]["message_type"] == model.MSG_USER
         assert msgs[0]["mentions"] == []

--- a/src/frontend/lib/chat/workspace_chat.dart
+++ b/src/frontend/lib/chat/workspace_chat.dart
@@ -491,18 +491,18 @@ class WorkspaceChatState extends State<WorkspaceChat> {
 
   Widget _buildMessageContent(
     BuildContext context, {
-    required String email,
+    required String senderName,
     required String text,
     required bool isAgent,
     required bool isDeleted,
   }) {
-    final nameColor = isAgent ? KColors.accentCyan : _colorForEmail(email);
+    final nameColor = isAgent ? KColors.accentCyan : _colorForEmail(senderName);
 
     if (isDeleted) {
       return Text.rich(
         TextSpan(children: [
           TextSpan(
-            text: '$email  ',
+            text: '$senderName  ',
             style: TextStyle(
               fontWeight: FontWeight.bold,
               color: nameColor,
@@ -525,7 +525,7 @@ class WorkspaceChatState extends State<WorkspaceChat> {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
-          email,
+          senderName,
           style: TextStyle(
             fontWeight: FontWeight.bold,
             color: nameColor,
@@ -773,7 +773,11 @@ class WorkspaceChatState extends State<WorkspaceChat> {
                       }
                       final msgIndex = _loadingOlder ? index - 1 : index;
                       final msg = _messages[msgIndex];
+                      final handle = msg['user_handle'] as String?;
                       final email = msg['user_email'] as String? ?? '';
+                      final senderName = (handle != null && handle.isNotEmpty)
+                          ? handle
+                          : email;
                       final text = msg['message'] as String? ?? '';
                       final createdAt = _formatTime(
                         msg['created_at'] as String? ?? '',
@@ -866,7 +870,7 @@ class WorkspaceChatState extends State<WorkspaceChat> {
                                 },
                                 child: _buildMessageContent(
                                   context,
-                                  email: email,
+                                  senderName: senderName,
                                   text: text,
                                   isAgent: isAgent,
                                   isDeleted: isDeleted,

--- a/src/frontend/test/workspace_chat_test.dart
+++ b/src/frontend/test/workspace_chat_test.dart
@@ -111,6 +111,7 @@ void main() {
           'type': 'chat_message',
           'id': 'msg-1',
           'user_email': 'alice@test.com',
+          'user_handle': 'alice',
           'message': 'hello world',
           'created_at': '2026-01-01 00:00:00',
         });
@@ -121,8 +122,9 @@ void main() {
       await tester.pump(const Duration(milliseconds: 200));
 
       expect(find.text('No messages yet'), findsNothing);
-      // Sender email rendered as Text widget
-      expect(find.text('alice@test.com'), findsOneWidget);
+      // Sender handle rendered (not email) when handle is present
+      expect(find.text('alice'), findsOneWidget);
+      expect(find.text('alice@test.com'), findsNothing);
       // Message rendered via MarkdownBody
       expect(find.byType(MarkdownBody), findsOneWidget);
       expect(_findMarkdownData(tester), 'hello world');


### PR DESCRIPTION
## Summary
- Chat messages now show the user's handle (e.g. "alice") instead of their full email address
- Falls back to email when no handle is set (backward compatible)
- Backend JOINs chat_messages with users table to include `user_handle` in all chat queries

Closes #334

## Test plan
- [x] Backend tests pass (100% coverage)
- [x] Frontend tests pass (100% coverage)
- [ ] Send a chat message, verify handle is displayed instead of email
- [ ] User without a handle shows email as fallback