### PR TITLE
fix: plug memory leaks in long-running server processes

### DIFF
--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -316,6 +316,7 @@ class ContainerRegistry:
         state = self.states.pop(workspace_id, None)
         if state:
             self._cid_to_wsid.pop(state.container_id, None)
+        self._workspace_locks.pop(workspace_id, None)
 
     # --- Port allocation ---
 

--- a/src/backend/klangk_backend/wshandler.py
+++ b/src/backend/klangk_backend/wshandler.py
@@ -166,6 +166,7 @@ class WorkspaceSession:
     async def reset(self) -> None:
         self.subscribers.clear()
         self.browser_subscribers.clear()
+        self.terminal_windows.clear()
 
     async def add_subscriber(
         self, sock: SafeWebSocket, container_id: str
@@ -396,6 +397,12 @@ class WebSocketState:
         else:
             container.registry.remove_state(workspace_id)
             logger.info("Reset workspace state for %s", workspace_id)
+
+        # Clean up module-level agent state for this workspace.
+        _agent_conversations.pop(workspace_id, None)
+        task = _agent_tasks.pop(workspace_id, None)
+        if task and not task.done():
+            task.cancel()
 
     async def logout_user(self, user_id: str) -> None:
         """Stop containers for a logging-out user, skipping any that

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -102,6 +102,12 @@ class TestActivityTracking:
         assert "ws-rm" not in container.registry.states
         assert "cid-rm" not in container.registry._cid_to_wsid
 
+    def test_remove_state_cleans_up_workspace_lock(self):
+        container.registry._get_workspace_lock("ws-lock-rm")
+        assert "ws-lock-rm" in container.registry._workspace_locks
+        container.registry.remove_state("ws-lock-rm")
+        assert "ws-lock-rm" not in container.registry._workspace_locks
+
     def test_get_state_returns_state(self):
         container.registry.track_activity("cid-1", "ws-1")
         state = container.registry.get_state("ws-1")

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -2627,6 +2627,32 @@ class TestResetWorkspaceState:
         finally:
             wshandler.state.sessions.pop("ws-reappear", None)
 
+    async def test_reset_cleans_agent_state(self):
+        """reset_workspace removes agent conversations and cancels agent tasks."""
+        ws_id = "ws-agent-cleanup"
+        wshandler._agent_conversations[ws_id] = {"user_id": "u1"}
+
+        async def noop():
+            await asyncio.sleep(999)
+
+        task = asyncio.create_task(noop())
+        wshandler._agent_tasks[ws_id] = task
+        try:
+            await reset_workspace_state(ws_id)
+            assert ws_id not in wshandler._agent_conversations
+            assert ws_id not in wshandler._agent_tasks
+            # Let cancellation propagate
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            assert task.cancelled()
+        finally:
+            wshandler._agent_conversations.pop(ws_id, None)
+            wshandler._agent_tasks.pop(ws_id, None)
+            if not task.done():
+                task.cancel()
+
 
 class TestRemoveSessionLocked:
     async def test_removes_session(self):


### PR DESCRIPTION
## Summary
- Clear `terminal_windows` in `WorkspaceSession.reset()` — previously accumulated per-user window state across resets
- Remove workspace locks from `ContainerRegistry` on state removal — previously grew monotonically with workspace churn
- Clean up `_agent_conversations` and `_agent_tasks` on workspace reset — previously leaked entries for workspaces with agent interactions

## Test plan
- [x] Backend tests: 1510 passed, 100% coverage
- New tests for workspace lock cleanup and agent state cleanup

Closes #437