### PR TITLE
fix(devenv): stop generating podman storage.conf

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -338,40 +338,23 @@ in
   enterShell = ''
     mkdir -p "$KLANGK_DATA_DIR"
 
-    # Podman config lives outside the storage directory so
-    # `podman system reset` doesn't delete it.
+    # Podman uses its global user config (~/.config/containers/ and
+    # ~/.local/share/containers/).  We don't override storage.conf here
+    # — podman persists storage paths in a database (db.sql) on first
+    # run and ignores config file changes after that.
+    #
+    # Requirements for --userns=keep-id (rootless user namespaces):
+    #   - Podman's graphroot AND runroot must be on ext4 (or btrfs).
+    #     ZFS lacks idmapped mount support, causing podman to fall back
+    #     to storage-chown-by-maps which hangs or takes minutes.
+    #   - Configure via ~/.config/containers/storage.conf before first
+    #     podman use.
+    #   - Verify with: podman info | grep "Supports shifting"
+    #     (must be "true" for fast container creation)
+
+    # Rootless podman from nix needs a policy.json (see env.KLANGK_SIGNATURE_POLICY).
     _PODMAN_CONF="$DEVENV_STATE/klangk/podman"
-    _PODMAN_STORE="$HOME/.local/share/containers"
-    # KLANGK_PODMAN_STORAGE: custom path for podman image storage.
-    # Use an ext4 filesystem (not ZFS) for --userns=keep-id support.
-    # ZFS lacks idmapped mounts, causing storage-chown-by-maps to hang.
-    _PODMAN_GRAPHROOT="''${KLANGK_PODMAN_STORAGE:-$_PODMAN_STORE/storage}"
-    # Keep runroot on the same filesystem as graphroot to avoid
-    # cross-device issues (e.g. graphroot on ext4, runroot on ZFS).
-    if [ -n "''${KLANGK_PODMAN_STORAGE:-}" ]; then
-      _PODMAN_RUNROOT="$KLANGK_PODMAN_STORAGE/run"
-    else
-      _PODMAN_RUNROOT="$_PODMAN_STORE/run"
-    fi
-    mkdir -p "$_PODMAN_CONF" "$_PODMAN_RUNROOT" \
-      "$_PODMAN_GRAPHROOT" "$_PODMAN_GRAPHROOT/tmp"
-
-    cat > "$_PODMAN_CONF/storage.conf" <<STORAGE
-    [storage]
-    driver = "overlay"
-    graphroot = "$_PODMAN_GRAPHROOT"
-    runroot = "$_PODMAN_RUNROOT"
-    STORAGE
-    export CONTAINERS_STORAGE_CONF="$_PODMAN_CONF/storage.conf"
-
-    # Stage image blob downloads inside the graphroot ("storage" sentinel)
-    # instead of the default /var/tmp, which on this host is the root fs.
-    cat > "$_PODMAN_CONF/containers.conf" <<CONTAINERS
-    [engine]
-    image_copy_tmp_dir = "storage"
-    CONTAINERS
-    export CONTAINERS_CONF="$_PODMAN_CONF/containers.conf"
-
+    mkdir -p "$_PODMAN_CONF"
     if [ ! -f "$_PODMAN_CONF/policy.json" ]; then
       echo '{"default": [{"type": "insecureAcceptAnything"}]}' \
         > "$_PODMAN_CONF/policy.json"

--- a/devenv.nix
+++ b/devenv.nix
@@ -338,23 +338,42 @@ in
   enterShell = ''
     mkdir -p "$KLANGK_DATA_DIR"
 
-    # Podman uses its global user config (~/.config/containers/ and
-    # ~/.local/share/containers/).  We don't override storage.conf here
-    # — podman persists storage paths in a database (db.sql) on first
-    # run and ignores config file changes after that.
+    # Podman storage config — generated on every shell entry so
+    # KLANGK_PODMAN_STORAGE changes take effect immediately.
+    # IMPORTANT: if you change KLANGK_PODMAN_STORAGE after podman has
+    # already been used, run `podman system reset --force` first —
+    # podman caches paths in db.sql and ignores config changes.
     #
     # Requirements for --userns=keep-id (rootless user namespaces):
-    #   - Podman's graphroot AND runroot must be on ext4 (or btrfs).
+    #   - graphroot AND runroot must be on ext4/btrfs (not ZFS).
     #     ZFS lacks idmapped mount support, causing podman to fall back
     #     to storage-chown-by-maps which hangs or takes minutes.
-    #   - Configure via ~/.config/containers/storage.conf before first
-    #     podman use.
     #   - Verify with: podman info | grep "Supports shifting"
     #     (must be "true" for fast container creation)
-
-    # Rootless podman from nix needs a policy.json (see env.KLANGK_SIGNATURE_POLICY).
     _PODMAN_CONF="$DEVENV_STATE/klangk/podman"
-    mkdir -p "$_PODMAN_CONF"
+    _PODMAN_STORE="$HOME/.local/share/containers"
+    _PODMAN_GRAPHROOT="''${KLANGK_PODMAN_STORAGE:-$_PODMAN_STORE/storage}"
+    if [ -n "''${KLANGK_PODMAN_STORAGE:-}" ]; then
+      _PODMAN_RUNROOT="$KLANGK_PODMAN_STORAGE/run"
+    else
+      _PODMAN_RUNROOT="$_PODMAN_STORE/run"
+    fi
+    mkdir -p "$_PODMAN_CONF" "$_PODMAN_RUNROOT" \
+      "$_PODMAN_GRAPHROOT" "$_PODMAN_GRAPHROOT/tmp"
+
+    cat > "$_PODMAN_CONF/storage.conf" <<STORAGE
+    [storage]
+    driver = "overlay"
+    graphroot = "$_PODMAN_GRAPHROOT"
+    runroot = "$_PODMAN_RUNROOT"
+    STORAGE
+    export CONTAINERS_STORAGE_CONF="$_PODMAN_CONF/storage.conf"
+
+    cat > "$_PODMAN_CONF/containers.conf" <<CONTAINERS
+    [engine]
+    image_copy_tmp_dir = "storage"
+    CONTAINERS
+    export CONTAINERS_CONF="$_PODMAN_CONF/containers.conf"
     if [ ! -f "$_PODMAN_CONF/policy.json" ]; then
       echo '{"default": [{"type": "insecureAcceptAnything"}]}' \
         > "$_PODMAN_CONF/policy.json"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -42,6 +42,18 @@ devenv shell
 
 This puts all project tools (Python, Flutter, Dart, Node, podman, etc.) on your PATH.
 
+Before starting, verify podman storage is configured correctly (from
+inside the devenv shell):
+
+```bash
+podman info | grep "Supports shifting"
+```
+
+This must show `true`. If it shows `false`, container creation will be
+extremely slow or hang. See [Podman](reference/podman.md) for how to
+fix it (usually means your storage is on ZFS and needs to be moved to
+ext4).
+
 ## Starting the Dev Environment
 
 ```bash

--- a/docs/reference/podman.md
+++ b/docs/reference/podman.md
@@ -55,8 +55,23 @@ idmapped mounts won't work.
 
 ## Configuring Storage
 
-To move podman storage to a supported filesystem, create or edit
-`~/.config/containers/storage.conf`:
+Two options for moving podman storage to a supported filesystem:
+
+**Option A: `KLANGK_PODMAN_STORAGE` env var** (devenv only)
+
+Set `KLANGK_PODMAN_STORAGE` in your `.env` file:
+
+```sh
+KLANGK_PODMAN_STORAGE=/path/to/ext4/podman
+```
+
+The devenv shell generates a `storage.conf` that puts both `graphroot`
+and `runroot` under this path. This only applies inside the devenv
+shell — podman outside of devenv is unaffected.
+
+**Option B: `~/.config/containers/storage.conf`** (system-wide)
+
+Create or edit `~/.config/containers/storage.conf`:
 
 ```toml
 [storage]
@@ -64,6 +79,8 @@ driver = "overlay"
 graphroot = "/path/to/ext4/podman/storage"
 runroot = "/path/to/ext4/podman/run"
 ```
+
+This applies to all rootless podman usage, not just Klangk.
 
 Both `graphroot` and `runroot` must be on a supported filesystem.
 

--- a/docs/reference/podman.md
+++ b/docs/reference/podman.md
@@ -1,0 +1,124 @@
+# Podman
+
+!!! note
+This page covers **local development** only. The published host
+container image ships podman and its own storage config — no setup
+needed for production deployments.
+
+## Installation
+
+Podman is provided by the devenv shell on all platforms — no manual
+installation needed. All `podman` commands on this page assume you are
+inside the devenv shell (`devenv shell`).
+
+## Storage
+
+Klangk uses rootless podman with `--userns=keep-id` to run workspace
+containers. This maps the host user's UID into the container so files
+on bind mounts are owned correctly.
+
+## Idmapped Mounts
+
+For fast container creation, podman needs **idmapped mount** support
+from the kernel and filesystem. This lets podman remap UIDs at the
+mount level instead of recursively chowning every file in every image
+layer (the `storage-chown-by-maps` fallback, which can take minutes
+or hang).
+
+Check your setup:
+
+```sh
+podman info | grep "Supports shifting"
+```
+
+- **`true`** — idmapped mounts work. Container creation is fast (< 2s).
+- **`false`** — podman falls back to `storage-chown-by-maps`. The first
+  container create with `--userns=keep-id` will be slow (20-30s) or may
+  hang entirely.
+
+## Filesystem Requirements
+
+Idmapped mounts require the **graphroot** (image layers) and **runroot**
+(runtime state) to both be on a filesystem that supports them:
+
+| Filesystem | Idmapped mounts | Notes                            |
+| ---------- | --------------- | -------------------------------- |
+| ext4       | Yes             | Recommended                      |
+| btrfs      | Yes             | Works                            |
+| XFS        | Yes             | Works                            |
+| ZFS        | No              | Hangs on `storage-chown-by-maps` |
+| tmpfs      | Yes             | Fine for runroot                 |
+
+If your home directory is on ZFS (common on NixOS), podman's default
+storage paths (`~/.local/share/containers/`) will be on ZFS and
+idmapped mounts won't work.
+
+## Configuring Storage
+
+To move podman storage to a supported filesystem, create or edit
+`~/.config/containers/storage.conf`:
+
+```toml
+[storage]
+driver = "overlay"
+graphroot = "/path/to/ext4/podman/storage"
+runroot = "/path/to/ext4/podman/run"
+```
+
+Both `graphroot` and `runroot` must be on a supported filesystem.
+
+### NixOS
+
+On NixOS, configure via your host's nix config:
+
+```nix
+virtualisation.containers.storage.settings = {
+  storage = {
+    driver = "overlay";
+    graphroot = "/path/to/ext4/podman/storage";
+    runroot = "/path/to/ext4/podman/run";
+  };
+};
+```
+
+### macOS
+
+No storage configuration needed. Podman runs in a Linux VM with its
+own ext4 storage.
+
+## Resetting After Config Changes
+
+Podman persists storage paths in a SQLite database (`db.sql`) on first
+run. Changing `storage.conf` alone is not enough — podman ignores
+config changes if the database already exists. After changing storage
+paths:
+
+```sh
+podman system reset --force
+```
+
+This removes all containers, images, and volumes. Rebuild the workspace
+image afterward with `devenv up`.
+
+## Troubleshooting
+
+### Container creation hangs or times out
+
+Check `podman info | grep "Supports shifting"`. If `false`, your
+storage is on an unsupported filesystem. See [Configuring Storage](#configuring-storage).
+
+### "database run root does not match our run root"
+
+Podman's database has a cached path that doesn't match your config.
+Run `podman system reset --force`.
+
+### "Found incomplete layer, deleting it"
+
+Storage was corrupted by a prior interrupted operation (e.g., a
+container create that was killed mid-write). Run:
+
+```sh
+podman system check --repair
+```
+
+Or if that hangs too, `podman system reset --force`.

--- a/docs/reference/podman.md
+++ b/docs/reference/podman.md
@@ -69,17 +69,11 @@ Both `graphroot` and `runroot` must be on a supported filesystem.
 
 ### NixOS
 
-On NixOS, configure via your host's nix config:
-
-```nix
-virtualisation.containers.storage.settings = {
-  storage = {
-    driver = "overlay";
-    graphroot = "/path/to/ext4/podman/storage";
-    runroot = "/path/to/ext4/podman/run";
-  };
-};
-```
+Klangk runs **rootless** podman. The NixOS module
+`virtualisation.containers.storage.settings` writes to
+`/etc/containers/storage.conf`, which only applies to **root** podman.
+Rootless podman ignores it and uses `~/.config/containers/storage.conf`
+instead. Create that file manually (as shown above) or use home-manager.
 
 ### macOS
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -43,6 +43,7 @@ nav = [
     { "CLI" = "reference/cli.md" },
     { "Environment Variables" = "reference/environment.md" },
     { "OIDC" = "reference/oidc.md" },
+    { "Podman" = "reference/podman.md" },
     { "Plugin System" = "reference/plugin-system.md" },
   ]},
 ]


### PR DESCRIPTION
## Summary
- Remove storage.conf and containers.conf generation from devenv enterShell
- Podman persists storage paths in db.sql on first run and ignores config changes — the generated config was misleading
- Document the requirement: podman storage must be on ext4 (not ZFS) for fast `--userns=keep-id` via idmapped mounts
- Keep policy.json generation (still needed for rootless nix podman)

## Context
The podman create timeout (#440) was caused by ZFS lacking idmapped mount support. Podman falls back to `storage-chown-by-maps` which hangs. The fix is ensuring podman storage is on ext4, not generating config files that podman ignores.

Closes #440