### PR TITLE
fix(chat): seed agent user into DB so handle displays

### DIFF
--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -137,6 +137,46 @@ async def seed_default_user() -> None:
         await model.add_user_to_group(existing["id"], admin_group_id)
 
 
+async def seed_agent_user() -> None:
+    """Ensure the chat agent has a row in the users table.
+
+    The agent user cannot log in (password_hash is NULL).  If the row
+    already exists we update email/handle so env-var changes take effect.
+    """
+    db = await model.get_db()
+    try:
+        cursor = await db.execute(
+            "SELECT id FROM users WHERE id = ?", (model.AGENT_USER_ID,)
+        )
+        row = await cursor.fetchone()
+        if row is None:
+            await db.execute(
+                """INSERT INTO users (id, email, password_hash, verified,
+                   provider, handle)
+                   VALUES (?, ?, NULL, 1, 'system', ?)""",
+                (model.AGENT_USER_ID, model.AGENT_EMAIL, model.AGENT_HANDLE),
+            )
+            await db.commit()
+            logger.info(
+                "Created agent user '%s' (%s)",
+                model.AGENT_HANDLE,
+                model.AGENT_USER_ID,
+            )
+        else:
+            await db.execute(
+                "UPDATE users SET email = ?, handle = ? WHERE id = ?",
+                (model.AGENT_EMAIL, model.AGENT_HANDLE, model.AGENT_USER_ID),
+            )
+            await db.commit()
+            logger.info(
+                "Updated agent user '%s' (%s)",
+                model.AGENT_HANDLE,
+                model.AGENT_USER_ID,
+            )
+    finally:
+        await db.close()
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     from . import auth
@@ -147,6 +187,7 @@ async def lifespan(app: FastAPI):
     oidc.init_providers()
     oidc.load_login_hook()
     await seed_default_user()
+    await seed_agent_user()
     from . import wshandler
 
     container.registry.set_on_workspace_killed(wshandler.reset_workspace_state)

--- a/src/backend/tests/test_main.py
+++ b/src/backend/tests/test_main.py
@@ -51,6 +51,52 @@ class TestSeedDefaultUser:
         assert "log-test" in caplog.text
 
 
+# --- Seed agent user ---
+
+
+class TestSeedAgentUser:
+    async def test_creates_agent_user_when_missing(self, db):
+        await main.seed_agent_user()
+        user = await model.get_user_by_email(model.AGENT_EMAIL)
+        assert user is not None
+        assert user["id"] == model.AGENT_USER_ID
+        assert user["handle"] == model.AGENT_HANDLE
+        assert user["provider"] == "system"
+        assert user["verified"] == 1
+
+    async def test_agent_user_has_no_password(self, db):
+        await main.seed_agent_user()
+        user = await model.get_user_by_email(model.AGENT_EMAIL)
+        assert user is not None
+        assert user["password_hash"] is None
+
+    async def test_updates_existing_agent_user(self, db, monkeypatch):
+        await main.seed_agent_user()
+        # Change env vars and re-seed
+        monkeypatch.setattr(model, "AGENT_EMAIL", "new-agent@example.com")
+        monkeypatch.setattr(model, "AGENT_HANDLE", "NewBoops")
+        await main.seed_agent_user()
+        user_db = await model.get_db()
+        try:
+            cursor = await user_db.execute(
+                "SELECT email, handle FROM users WHERE id = ?",
+                (model.AGENT_USER_ID,),
+            )
+            row = await cursor.fetchone()
+        finally:
+            await user_db.close()
+        assert row is not None
+        assert row["email"] == "new-agent@example.com"
+        assert row["handle"] == "NewBoops"
+
+    async def test_idempotent(self, db):
+        await main.seed_agent_user()
+        await main.seed_agent_user()
+        user = await model.get_user_by_email(model.AGENT_EMAIL)
+        assert user is not None
+        assert user["id"] == model.AGENT_USER_ID
+
+
 # --- Lifespan ---
 
 


### PR DESCRIPTION
## Summary
- The MrBoops chat agent had no row in the `users` table, so `add_chat_message` couldn't look up its handle and the frontend fell back to showing the email address
- Added `seed_agent_user()` in `main.py` that inserts (or updates) the agent user with `provider='system'` and no password hash, called during lifespan startup after `seed_default_user()`
- Added 4 backend tests covering creation, no-password, update-on-env-change, and idempotency

## Test plan
- [x] All 1514 backend tests pass with 100% coverage
- [ ] Verify MrBoops displays as "MrBoops" (not email) in chat UI