### PR TITLE
cli: rename 'klangk list' to 'klangk ls'

### DIFF
--- a/docs/reference/acl.md
+++ b/docs/reference/acl.md
@@ -76,7 +76,7 @@ When a workspace is created, the owner gets a `(Allow, user:{id}, *)` ACE on `/w
 
 **API**: `GET /api/my-permissions` returns your effective permissions on all static resources. Add `?resource=/workspaces/{id}` to check a specific resource.
 
-**CLI**: `klangk list --shared` shows workspaces shared with you.
+**CLI**: `klangk ls --shared` shows workspaces shared with you.
 
 ## Troubleshooting: "Why can't I access this workspace?"
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -4,7 +4,7 @@ Klangk provides a CLI for terminal-based access to the same containers:
 
 ```bash
 klangk login admin@example.com        # authenticate (prompts for password)
-klangk list                             # list workspaces
+klangk ls                               # list workspaces
 klangk create my-project                # create a workspace
 klangk create my-project --mount ~/src:/home/klangk/work/src          # with bind mount
 klangk create my-project --mount nix-store:/nix           # with named volume

--- a/src/backend/e2e-tests/test_cli_e2e.py
+++ b/src/backend/e2e-tests/test_cli_e2e.py
@@ -239,7 +239,7 @@ class TestWorkspaceCRUD:
 
     def test_list_workspaces(self, cli_config):
         result = _run(
-            ["klangk", "list", "--plain"],
+            ["klangk", "ls", "--plain"],
             env=cli_config["env"],
         )
         assert result.returncode == 0
@@ -269,7 +269,7 @@ class TestWorkspaceCRUD:
 
     def test_list_after_delete(self, cli_config):
         result = _run(
-            ["klangk", "list", "--plain"],
+            ["klangk", "ls", "--plain"],
             env=cli_config["env"],
         )
         assert "e2e-crud" not in result.stdout
@@ -309,7 +309,7 @@ class TestDuplicate:
 
             # Verify copy appears in list
             result = _run(
-                ["klangk", "list", "--plain"],
+                ["klangk", "ls", "--plain"],
                 env=env,
             )
             assert "e2e-dup-src" in result.stdout
@@ -940,7 +940,7 @@ class TestAuthError:
         klangk_config.mkdir(parents=True)
         env = {**os.environ, "HOME": str(config_dir)}
         result = _run(
-            ["klangk", "list"],
+            ["klangk", "ls"],
             env=env,
         )
         assert result.returncode != 0
@@ -1138,7 +1138,7 @@ class TestExportImport:
         assert result.returncode == 0, result.stderr or result.stdout
 
         # Verify the imported workspace exists
-        result = _run(["klangk", "list", "--plain"], env=env)
+        result = _run(["klangk", "ls", "--plain"], env=env)
         assert "export-restored" in result.stdout
 
     def test_export_import_round_trip_with_symlinks(

--- a/src/backend/klangk_backend/cli/main.py
+++ b/src/backend/klangk_backend/cli/main.py
@@ -122,7 +122,7 @@ def status(
     console.print(table)
 
 
-@app.command("list")
+@app.command("ls")
 def list_workspaces(
     plain: bool = typer.Option(False, "--plain", help="Plain text output"),
     shared: bool = typer.Option(


### PR DESCRIPTION
## Summary
- Rename `klangk list` command to `klangk ls` for consistency with `klangk volumes ls` and more natural usage
- Update E2E tests and docs to match

Closes #368

## Test plan
- [x] Backend unit tests pass (1510 passed, 100% coverage)
- [ ] E2E tests pass on CI