### PR TITLE
fix(chat): show handles instead of emails in tab completion and presence

### DIFF
--- a/src/backend/e2e-tests/test_event_fanout.py
+++ b/src/backend/e2e-tests/test_event_fanout.py
@@ -314,7 +314,7 @@ class TestEventFanout:
                 msgs = await recv_until(ws1, is_join_chat, timeout=15)
                 join_msgs = [m for m in msgs if is_join_chat(m)]
                 assert len(join_msgs) >= 1
-                assert join_msgs[0]["message"] == "test@example.com joined"
+                assert join_msgs[0]["message"] == "test joined"
                 assert join_msgs[0]["message_type"] == 2
             finally:
                 await ws1.close()
@@ -361,7 +361,7 @@ class TestEventFanout:
                 msgs = await recv_until(ws1, is_leave_chat, timeout=10)
                 leave_msgs = [m for m in msgs if is_leave_chat(m)]
                 assert len(leave_msgs) >= 1
-                assert leave_msgs[0]["message"] == "user2@example.com left"
+                assert leave_msgs[0]["message"] == "user2 left"
                 assert leave_msgs[0]["message_type"] == 2
             finally:
                 await ws1.close()

--- a/src/backend/klangk_backend/wshandler.py
+++ b/src/backend/klangk_backend/wshandler.py
@@ -506,7 +506,11 @@ async def _get_presence_list(workspace_id: str) -> list[dict]:
         if conn and conn.user["id"] not in seen:
             seen.add(conn.user["id"])
             users.append(
-                {"user_id": conn.user["id"], "user_email": conn.user["email"]}
+                {
+                    "user_id": conn.user["id"],
+                    "user_email": conn.user["email"],
+                    "user_handle": conn.user.get("handle", ""),
+                }
             )
     # Include agent only if its RPC process is alive.
     from . import agent  # pragma: no cover
@@ -514,7 +518,11 @@ async def _get_presence_list(workspace_id: str) -> list[dict]:
     if agent.any_running():  # pragma: no cover
         agent_user = await model.get_agent_user()
         users.append(
-            {"user_id": model.AGENT_USER_ID, "user_email": agent_user["email"]}
+            {
+                "user_id": model.AGENT_USER_ID,
+                "user_email": agent_user["email"],
+                "user_handle": agent_user.get("handle", ""),
+            }
         )
     return users
 
@@ -730,11 +738,21 @@ class Connection:
         members = await model.get_workspace_members(workspace_id)
         owner = await model.get_user_by_id(workspace.get("user_id", ""))
         if owner and not any(m["id"] == owner["id"] for m in members):
-            members.append({"id": owner["id"], "email": owner["email"]})
+            members.append(
+                {
+                    "id": owner["id"],
+                    "email": owner["email"],
+                    "handle": owner.get("handle", ""),
+                }
+            )
         # Include the agent so it autocompletes
         agent_user = await model.get_agent_user()
         members.append(
-            {"id": model.AGENT_USER_ID, "email": agent_user["email"]}
+            {
+                "id": model.AGENT_USER_ID,
+                "email": agent_user["email"],
+                "handle": agent_user.get("handle", ""),
+            }
         )
         self.sock.send_json({"type": "workspace_members", "members": members})
 

--- a/src/backend/klangk_backend/wshandler.py
+++ b/src/backend/klangk_backend/wshandler.py
@@ -779,7 +779,7 @@ class Connection:
                 workspace_id,
                 self.user["id"],
                 self.user["email"],
-                f"{self.user['email']} joined",
+                f"{self.user.get('handle') or self.user['email']} joined",
                 message_type=model.MSG_SYSTEM,
             )
             session.broadcast({"type": "chat_message", **sys_msg})
@@ -2001,7 +2001,7 @@ class Connection:
                         workspace_id,
                         self.user["id"],
                         self.user["email"],
-                        f"{self.user['email']} left",
+                        f"{self.user.get('handle') or self.user['email']} left",
                         message_type=model.MSG_SYSTEM,
                     )
                     session.broadcast({"type": "chat_message", **sys_msg})

--- a/src/frontend/e2e-tests/e2e/klangk.spec.ts
+++ b/src/frontend/e2e-tests/e2e/klangk.spec.ts
@@ -1453,12 +1453,13 @@ test.describe("Klangk E2E", () => {
     });
 
     // Wait for join message to arrive
+    const memberHandle = memberEmail.split("@")[0];
     await page1.waitForTimeout(2000);
     const joinMsgs = systemMessages.filter(
-      (m) => m.message.includes("joined") && m.message.includes(memberEmail),
+      (m) => m.message.includes("joined") && m.message.includes(memberHandle),
     );
     expect(joinMsgs.length).toBeGreaterThan(0);
-    expect(joinMsgs[0].message).toBe(`${memberEmail} joined`);
+    expect(joinMsgs[0].message).toBe(`${memberHandle} joined`);
 
     // Member leaves — owner should see a "left" system message
     const beforeLeave = systemMessages.length;
@@ -1466,10 +1467,10 @@ test.describe("Klangk E2E", () => {
     await page1.waitForTimeout(2000);
 
     const leaveMsgs = systemMessages.filter(
-      (m) => m.message.includes("left") && m.message.includes(memberEmail),
+      (m) => m.message.includes("left") && m.message.includes(memberHandle),
     );
     expect(leaveMsgs.length).toBeGreaterThan(0);
-    expect(leaveMsgs[0].message).toBe(`${memberEmail} left`);
+    expect(leaveMsgs[0].message).toBe(`${memberHandle} left`);
 
     await ctx1.close();
     await request.delete(`${API_BASE}/workspaces/${workspaceId}`, {

--- a/src/frontend/lib/chat/workspace_chat.dart
+++ b/src/frontend/lib/chat/workspace_chat.dart
@@ -242,7 +242,8 @@ class WorkspaceChatState extends State<WorkspaceChat> {
     final members = widget.wsClient.workspaceMembers;
     _filteredMembers = members.where((m) {
       final email = (m['email'] as String? ?? '').toLowerCase();
-      return email.contains(_mentionQuery);
+      final handle = (m['handle'] as String? ?? '').toLowerCase();
+      return handle.contains(_mentionQuery) || email.contains(_mentionQuery);
     }).toList();
     if (_filteredMembers.isEmpty) {
       _hideAutocomplete();
@@ -277,10 +278,12 @@ class WorkspaceChatState extends State<WorkspaceChat> {
                 shrinkWrap: true,
                 itemCount: visibleCount,
                 itemBuilder: (ctx, i) {
+                  final handle = _filteredMembers[i]['handle'] as String? ?? '';
                   final email = _filteredMembers[i]['email'] as String? ?? '';
+                  final displayName = handle.isNotEmpty ? handle : email;
                   final isHighlighted = i == _highlightedIndex;
                   return InkWell(
-                    onTap: () => _insertMention(email),
+                    onTap: () => _insertMention(displayName),
                     child: Container(
                       color: isHighlighted
                           ? KColors.bgOverlay
@@ -290,7 +293,7 @@ class WorkspaceChatState extends State<WorkspaceChat> {
                         vertical: 8,
                       ),
                       child: Text(
-                        email,
+                        displayName,
                         style: const TextStyle(
                           color: KColors.textPrimary,
                           fontSize: 13,
@@ -312,8 +315,9 @@ class WorkspaceChatState extends State<WorkspaceChat> {
   void _acceptHighlightedSuggestion() {
     if (_filteredMembers.isEmpty) return;
     final idx = _highlightedIndex.clamp(0, _filteredMembers.length - 1);
+    final handle = _filteredMembers[idx]['handle'] as String? ?? '';
     final email = _filteredMembers[idx]['email'] as String? ?? '';
-    _insertMention(email);
+    _insertMention(handle.isNotEmpty ? handle : email);
   }
 
   /// Handle keyboard events for autocomplete navigation and message sending.


### PR DESCRIPTION
## Summary
- Chat @mention autocomplete now displays and inserts handles instead of emails
- Autocomplete filters match against both handle and email
- `workspace_members` message includes handle for owner and agent
- `presence_list` includes `user_handle` field

## Test plan
- [x] Backend tests pass (100% coverage)
- [x] Frontend tests pass (100% coverage)
- [ ] Type `@` in chat — autocomplete shows handles
- [ ] Select a suggestion — inserts handle, not email