### PR TITLE
fix: clean up sharing data on workspace delete

### DIFF
--- a/src/backend/klangk_backend/model.py
+++ b/src/backend/klangk_backend/model.py
@@ -1390,8 +1390,47 @@ async def delete_workspace(workspace_id: str, user_id: str) -> bool:
             "DELETE FROM workspaces WHERE id = ? AND user_id = ?",
             (workspace_id, user_id),
         )
+        if cursor.rowcount == 0:
+            await db.commit()
+            return False
+        # Clean up ACL entries for this workspace
+        resource = f"/workspaces/{workspace_id}"
+        await db.execute(
+            "DELETE FROM acl_entries WHERE resource = ?", (resource,)
+        )
+        # Clean up per-workspace role groups and their memberships
+        role_suffixes = ["owners", "coders", "collaborators", "spectators"]
+        for suffix in role_suffixes:
+            group_name = f"{suffix}-{workspace_id}"
+            cursor_g = await db.execute(
+                "SELECT id FROM groups WHERE name = ?", (group_name,)
+            )
+            row = await cursor_g.fetchone()
+            if row:
+                group_id = row["id"]
+                await db.execute(
+                    "DELETE FROM user_groups WHERE group_id = ?",
+                    (group_id,),
+                )
+                await db.execute(
+                    "DELETE FROM acl_entries WHERE group_id = ?",
+                    (group_id,),
+                )
+                await db.execute(
+                    "DELETE FROM groups WHERE id = ?", (group_id,)
+                )
+        # Clean up port allocations
+        await db.execute(
+            "DELETE FROM port_allocations WHERE workspace_id = ?",
+            (workspace_id,),
+        )
+        # Clean up chat messages
+        await db.execute(
+            "DELETE FROM chat_messages WHERE workspace_id = ?",
+            (workspace_id,),
+        )
         await db.commit()
-        return cursor.rowcount > 0
+        return True
     finally:
         await db.close()
 

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -840,6 +840,39 @@ class TestWorkspaceRoutes:
         assert resp.status_code == 200
         mock_rm.assert_awaited_once_with("fake-container-id")
 
+    async def test_delete_workspace_cleans_up_groups(self, client, user):
+        headers = await _auth_headers(client)
+        create_resp = await client.post(
+            "/workspaces", headers=headers, json={"name": "cleanup-test"}
+        )
+        ws_id = create_resp.json()["id"]
+
+        # Verify role groups were created
+        for suffix in ["owners", "coders", "collaborators", "spectators"]:
+            group = await model.get_group_by_name(f"{suffix}-{ws_id}")
+            assert group is not None, f"expected {suffix} group to exist"
+
+        # Verify ACL entries exist for the workspace
+        acl = await model.get_acl_entries(f"/workspaces/{ws_id}")
+        assert len(acl) > 0
+
+        with patch.object(
+            api.container.registry,
+            "stop_and_remove_container",
+            new_callable=AsyncMock,
+        ):
+            resp = await client.delete(f"/workspaces/{ws_id}", headers=headers)
+        assert resp.status_code == 200
+
+        # Role groups should be gone
+        for suffix in ["owners", "coders", "collaborators", "spectators"]:
+            group = await model.get_group_by_name(f"{suffix}-{ws_id}")
+            assert group is None, f"expected {suffix} group to be deleted"
+
+        # ACL entries should be gone
+        acl = await model.get_acl_entries(f"/workspaces/{ws_id}")
+        assert len(acl) == 0
+
     async def test_list_no_auth(self, client):
         resp = await client.get("/workspaces")
         assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- Workspace deletion now cascades to clean up:
  - ACL entries referencing `/workspaces/{id}`
  - Per-workspace role groups (owners, coders, collaborators, spectators) and their memberships
  - ACL entries referencing those role groups
  - Port allocations
  - Chat messages

Closes #453

## Test plan
- [x] Backend tests pass (100% coverage)