### PR TITLE
fix(agent): detect process death and broadcast disconnect immediately

### DIFF
--- a/src/backend/klangk_backend/agent.py
+++ b/src/backend/klangk_backend/agent.py
@@ -58,6 +58,7 @@ class AgentSession:
         self._proc: asyncio.subprocess.Process | None = None
         self._lock = asyncio.Lock()
         self._home_ready = False
+        self._monitor_task: asyncio.Task | None = None
 
     async def _ensure_home(self) -> str:
         """Ensure the agent has a home directory with Pi config.
@@ -163,7 +164,24 @@ class AgentSession:
             stderr=asyncio.subprocess.PIPE,
             env=podman.subprocess_env(),
         )
+        self._monitor_task = asyncio.create_task(
+            self._monitor_process(self._proc)
+        )
         return self._proc
+
+    async def _monitor_process(self, proc: asyncio.subprocess.Process) -> None:
+        """Wait for the agent subprocess to exit and broadcast disconnect."""
+        await proc.wait()
+        # Only act if this is still our current process (not replaced)
+        if self._proc is not proc:
+            return
+        self._proc = None
+        logger.warning(
+            "Agent process died (rc=%s) for container %s",
+            proc.returncode,
+            self.container_id,
+        )
+        await _broadcast_agent_disconnect(self.container_id)
 
     async def send_prompt(self, message: str, timeout: float = 120) -> str:
         """Send a prompt to Pi and return the accumulated text response."""
@@ -347,6 +365,9 @@ class AgentSession:
 
     async def stop(self) -> None:
         """Kill the Pi subprocess."""
+        if self._monitor_task is not None:
+            self._monitor_task.cancel()
+            self._monitor_task = None
         if self._proc is not None and self._proc.returncode is None:
             try:
                 self._proc.kill()
@@ -384,3 +405,35 @@ async def stop_session(container_id: str) -> None:
     session = _agents.pop(container_id, None)
     if session:
         await session.stop()
+
+
+async def _broadcast_agent_disconnect(container_id: str) -> None:
+    """Broadcast a disconnect system message when the agent process dies."""
+    from . import container as container_mod
+    from . import model
+    from . import wshandler
+
+    workspace_id = container_mod.registry.workspace_id_for(container_id)
+    if not workspace_id:
+        return
+    agent_handle = await model.agent_handle()
+    agent_email = await model.agent_email()
+    sys_msg = await model.add_chat_message(
+        workspace_id,
+        model.AGENT_USER_ID,
+        agent_email,
+        f"{agent_handle} has disconnected",
+        message_type=model.MSG_SYSTEM,
+    )
+    session = wshandler.state.get_session(workspace_id)
+    if session:
+        session.broadcast({"type": "agent_thinking", "thinking": False})
+        session.broadcast({"type": "chat_message", **sys_msg})
+        session.broadcast(
+            {
+                "type": "presence_leave",
+                "user_id": model.AGENT_USER_ID,
+                "user_email": agent_email,
+                "user_handle": agent_handle,
+            }
+        )

--- a/src/backend/klangk_backend/agent.py
+++ b/src/backend/klangk_backend/agent.py
@@ -59,6 +59,7 @@ class AgentSession:
         self._lock = asyncio.Lock()
         self._home_ready = False
         self._monitor_task: asyncio.Task | None = None
+        self._restart_attempts = 0
 
     async def _ensure_home(self) -> str:
         """Ensure the agent has a home directory with Pi config.
@@ -170,7 +171,7 @@ class AgentSession:
         return self._proc
 
     async def _monitor_process(self, proc: asyncio.subprocess.Process) -> None:
-        """Wait for the agent subprocess to exit and broadcast disconnect."""
+        """Wait for the agent subprocess to exit, broadcast disconnect, and restart."""
         await proc.wait()
         # Only act if this is still our current process (not replaced)
         if self._proc is not proc:
@@ -182,6 +183,26 @@ class AgentSession:
             self.container_id,
         )
         await _broadcast_agent_disconnect(self.container_id)
+        # Auto-restart after a brief delay to avoid tight loops
+        self._restart_attempts += 1
+        if self._restart_attempts > 2:
+            logger.error(
+                "Agent exceeded 3 restart attempts for container %s, giving up",
+                self.container_id,
+            )
+            return
+        await asyncio.sleep(2)
+        if self._proc is not None:
+            return  # something else already restarted it
+        try:
+            await self._ensure_started()
+            self._restart_attempts = 0
+            await _broadcast_agent_reconnect(self.container_id)
+        except Exception:
+            logger.exception(
+                "Failed to auto-restart agent for container %s",
+                self.container_id,
+            )
 
     async def send_prompt(self, message: str, timeout: float = 120) -> str:
         """Send a prompt to Pi and return the accumulated text response."""
@@ -432,6 +453,37 @@ async def _broadcast_agent_disconnect(container_id: str) -> None:
         session.broadcast(
             {
                 "type": "presence_leave",
+                "user_id": model.AGENT_USER_ID,
+                "user_email": agent_email,
+                "user_handle": agent_handle,
+            }
+        )
+
+
+async def _broadcast_agent_reconnect(container_id: str) -> None:
+    """Broadcast a reconnect system message after auto-restart."""
+    from . import container as container_mod
+    from . import model
+    from . import wshandler
+
+    workspace_id = container_mod.registry.workspace_id_for(container_id)
+    if not workspace_id:
+        return
+    agent_handle = await model.agent_handle()
+    agent_email = await model.agent_email()
+    sys_msg = await model.add_chat_message(
+        workspace_id,
+        model.AGENT_USER_ID,
+        agent_email,
+        f"{agent_handle} has reconnected",
+        message_type=model.MSG_SYSTEM,
+    )
+    session = wshandler.state.get_session(workspace_id)
+    if session:
+        session.broadcast({"type": "chat_message", **sys_msg})
+        session.broadcast(
+            {
+                "type": "presence_join",
                 "user_id": model.AGENT_USER_ID,
                 "user_email": agent_email,
                 "user_handle": agent_handle,

--- a/src/backend/tests/test_agent.py
+++ b/src/backend/tests/test_agent.py
@@ -670,3 +670,57 @@ class TestAnyRunning:
         s._proc.returncode = 0
         _agents["cid"] = s
         assert not any_running()
+
+
+class TestMonitorProcess:
+    async def test_monitor_broadcasts_on_death(self):
+        from klangk_backend import container, model
+        from klangk_backend.agent import _broadcast_agent_disconnect
+
+        container.registry.track_activity("cid-mon", "ws-mon")
+
+        with (
+            patch.object(
+                model,
+                "add_chat_message",
+                new_callable=AsyncMock,
+                return_value={
+                    "id": "msg-1",
+                    "message": "MrBoops has disconnected",
+                },
+            ) as mock_chat,
+            patch(
+                "klangk_backend.wshandler.state.get_session"
+            ) as mock_get_session,
+        ):
+            mock_session = MagicMock()
+            mock_get_session.return_value = mock_session
+
+            await _broadcast_agent_disconnect("cid-mon")
+
+            mock_chat.assert_awaited_once()
+            assert "disconnected" in mock_chat.call_args[0][3]
+            assert mock_session.broadcast.call_count == 3
+
+        container.registry.states.pop("ws-mon", None)
+
+    async def test_monitor_no_workspace(self):
+        from klangk_backend.agent import _broadcast_agent_disconnect
+
+        # Should not raise when container has no workspace
+        await _broadcast_agent_disconnect("no-such-container")
+
+    async def test_stop_cancels_monitor(self):
+        session = _make_session()
+        mock_task = MagicMock()
+        session._monitor_task = mock_task
+        session._proc = AsyncMock()
+        session._proc.returncode = None
+        session._proc.kill = MagicMock()
+        session._proc.wait = AsyncMock()
+
+        await session.stop()
+
+        mock_task.cancel.assert_called_once()
+        assert session._monitor_task is None
+        assert session._proc is None

--- a/src/backend/tests/test_agent.py
+++ b/src/backend/tests/test_agent.py
@@ -724,3 +724,196 @@ class TestMonitorProcess:
         mock_task.cancel.assert_called_once()
         assert session._monitor_task is None
         assert session._proc is None
+
+    async def test_monitor_auto_restarts(self):
+        from klangk_backend import container, model
+
+        container.registry.track_activity("cid-restart", "ws-restart")
+
+        session = _make_session("cid-restart")
+        _agents["cid-restart"] = session
+
+        mock_proc = AsyncMock()
+        mock_proc.returncode = 1
+        mock_proc.wait = AsyncMock()
+        session._proc = mock_proc
+
+        with (
+            patch.object(
+                model,
+                "add_chat_message",
+                new_callable=AsyncMock,
+                return_value={"id": "m1", "message": "msg"},
+            ),
+            patch(
+                "klangk_backend.wshandler.state.get_session",
+                return_value=MagicMock(),
+            ),
+            patch.object(
+                session,
+                "_ensure_started",
+                new_callable=AsyncMock,
+            ) as mock_start,
+            patch(
+                "klangk_backend.agent.asyncio.sleep", new_callable=AsyncMock
+            ),
+        ):
+            await session._monitor_process(mock_proc)
+
+            mock_start.assert_awaited_once()
+            assert session._restart_attempts == 0
+
+        container.registry.states.pop("ws-restart", None)
+
+    async def test_monitor_gives_up_after_max_retries(self):
+        from klangk_backend import container, model
+
+        container.registry.track_activity("cid-giveup", "ws-giveup")
+
+        session = _make_session("cid-giveup")
+        _agents["cid-giveup"] = session
+        session._restart_attempts = 2  # already at limit
+
+        mock_proc = AsyncMock()
+        mock_proc.returncode = 1
+        mock_proc.wait = AsyncMock()
+        session._proc = mock_proc
+
+        with (
+            patch.object(
+                model,
+                "add_chat_message",
+                new_callable=AsyncMock,
+                return_value={"id": "m1", "message": "msg"},
+            ),
+            patch(
+                "klangk_backend.wshandler.state.get_session",
+                return_value=MagicMock(),
+            ),
+            patch.object(
+                session,
+                "_ensure_started",
+                new_callable=AsyncMock,
+            ) as mock_start,
+        ):
+            await session._monitor_process(mock_proc)
+
+            mock_start.assert_not_awaited()
+            assert session._restart_attempts == 3
+
+        container.registry.states.pop("ws-giveup", None)
+
+    async def test_monitor_restart_failure_logged(self):
+        from klangk_backend import container, model
+
+        container.registry.track_activity("cid-fail", "ws-fail")
+
+        session = _make_session("cid-fail")
+        _agents["cid-fail"] = session
+
+        mock_proc = AsyncMock()
+        mock_proc.returncode = 1
+        mock_proc.wait = AsyncMock()
+        session._proc = mock_proc
+
+        with (
+            patch.object(
+                model,
+                "add_chat_message",
+                new_callable=AsyncMock,
+                return_value={"id": "m1", "message": "msg"},
+            ),
+            patch(
+                "klangk_backend.wshandler.state.get_session",
+                return_value=MagicMock(),
+            ),
+            patch.object(
+                session,
+                "_ensure_started",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("startup failed"),
+            ),
+            patch(
+                "klangk_backend.agent.asyncio.sleep", new_callable=AsyncMock
+            ),
+        ):
+            await session._monitor_process(mock_proc)
+            # Should not raise, just log
+
+        container.registry.states.pop("ws-fail", None)
+
+    async def test_broadcast_reconnect(self):
+        from klangk_backend import container, model
+        from klangk_backend.agent import _broadcast_agent_reconnect
+
+        container.registry.track_activity("cid-rc", "ws-rc")
+
+        with (
+            patch.object(
+                model,
+                "add_chat_message",
+                new_callable=AsyncMock,
+                return_value={"id": "m1", "message": "reconnected"},
+            ) as mock_chat,
+            patch(
+                "klangk_backend.wshandler.state.get_session"
+            ) as mock_get_session,
+        ):
+            mock_session = MagicMock()
+            mock_get_session.return_value = mock_session
+
+            await _broadcast_agent_reconnect("cid-rc")
+
+            mock_chat.assert_awaited_once()
+            assert "reconnected" in mock_chat.call_args[0][3]
+            assert mock_session.broadcast.call_count == 2
+
+        container.registry.states.pop("ws-rc", None)
+
+    async def test_broadcast_reconnect_no_workspace(self):
+        from klangk_backend.agent import _broadcast_agent_reconnect
+
+        await _broadcast_agent_reconnect("no-such-container")
+
+    async def test_monitor_skips_restart_if_already_restarted(self):
+        from klangk_backend import container, model
+
+        container.registry.track_activity("cid-skip", "ws-skip")
+
+        session = _make_session("cid-skip")
+        _agents["cid-skip"] = session
+
+        dead_proc = AsyncMock()
+        dead_proc.returncode = 1
+        dead_proc.wait = AsyncMock()
+        session._proc = dead_proc
+
+        async def fake_sleep(_):
+            # Simulate something else restarting the proc during sleep
+            session._proc = AsyncMock()
+
+        with (
+            patch.object(
+                model,
+                "add_chat_message",
+                new_callable=AsyncMock,
+                return_value={"id": "m1", "message": "msg"},
+            ),
+            patch(
+                "klangk_backend.wshandler.state.get_session",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "klangk_backend.agent.asyncio.sleep",
+                side_effect=fake_sleep,
+            ),
+            patch.object(
+                session,
+                "_ensure_started",
+                new_callable=AsyncMock,
+            ) as mock_start,
+        ):
+            await session._monitor_process(dead_proc)
+            mock_start.assert_not_awaited()
+
+        container.registry.states.pop("ws-skip", None)


### PR DESCRIPTION
## Summary
- Spawns a background `asyncio.Task` that awaits the Pi RPC subprocess exit
- When the process dies unexpectedly, immediately broadcasts:
  - "MrBoops has disconnected" system chat message
  - `agent_thinking: false` to clear any spinner
  - `presence_leave` to update the presence list
- `stop()` cancels the monitor task to avoid false disconnect on intentional shutdown

Closes #451

## Test plan
- [x] Backend tests pass (1523 passed, 100% coverage)
- [ ] Kill the Pi process externally — disconnect message should appear in chat