### PR TITLE
fix(chat): show handles instead of emails in presence avatar tooltips

### DIFF
--- a/src/backend/klangk_backend/wshandler.py
+++ b/src/backend/klangk_backend/wshandler.py
@@ -769,6 +769,7 @@ class Connection:
                 "type": "presence_join",
                 "user_id": self.user["id"],
                 "user_email": self.user["email"],
+                "user_handle": self.user["handle"],
             }
             for sock in list(session.subscribers):
                 if sock is not self.sock:

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -5140,7 +5140,12 @@ class TestPresence:
         )
         sock2 = _mock_sock()
         conn2 = _base_conn(
-            user={"id": other["id"], "email": "other@test.com"}, ws=sock2
+            user={
+                "id": other["id"],
+                "email": "other@test.com",
+                "handle": other.get("handle", ""),
+            },
+            ws=sock2,
         )
         wshandler.state.connections[sock2] = conn2
 
@@ -5172,6 +5177,7 @@ class TestPresence:
             assert len(joins) == 1
             assert joins[0]["user_id"] == other["id"]
             assert joins[0]["user_email"] == "other@test.com"
+            assert "user_handle" in joins[0]
         finally:
             wshandler.state.sessions.pop(workspace["id"], None)
             wshandler.state.connections.pop(sock1, None)

--- a/src/frontend/lib/chat/workspace_chat.dart
+++ b/src/frontend/lib/chat/workspace_chat.dart
@@ -674,13 +674,16 @@ class WorkspaceChatState extends State<WorkspaceChat> {
           ),
           ...users.map((u) {
             final email = u['user_email'] as String? ?? '';
+            final handle = u['user_handle'] as String? ?? '';
             final uid = u['user_id'] as String?;
             final isSelf = uid == currentUserId;
-            final initial = email.isNotEmpty ? email[0].toUpperCase() : '?';
+            final displayName = handle.isNotEmpty ? handle : email;
+            final initial =
+                displayName.isNotEmpty ? displayName[0].toUpperCase() : '?';
             return Padding(
               padding: const EdgeInsets.only(right: 4),
               child: Tooltip(
-                message: email,
+                message: displayName,
                 child: CircleAvatar(
                   radius: 10,
                   backgroundColor:

--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -235,7 +235,11 @@ class WsClient extends ChangeNotifier {
             if (uid != null && !presenceUsers.any((u) => u['user_id'] == uid)) {
               presenceUsers = [
                 ...presenceUsers,
-                {'user_id': uid, 'user_email': json['user_email']},
+                {
+                  'user_id': uid,
+                  'user_email': json['user_email'],
+                  'user_handle': json['user_handle'] ?? '',
+                },
               ];
               notifyListeners();
             }

--- a/src/frontend/test/workspace_chat_test.dart
+++ b/src/frontend/test/workspace_chat_test.dart
@@ -912,15 +912,46 @@ void main() {
 
     testWidgets('presence bar shows connected users', (tester) async {
       client.presenceUsers = [
-        {'user_id': 'u1', 'user_email': 'alice@test.com'},
-        {'user_id': 'u2', 'user_email': 'bob@test.com'},
+        {
+          'user_id': 'u1',
+          'user_email': 'alice@test.com',
+          'user_handle': 'alice',
+        },
+        {
+          'user_id': 'u2',
+          'user_email': 'bob@test.com',
+          'user_handle': 'bob',
+        },
       ];
 
       await tester.pumpWidget(buildChat());
 
-      // Green dot + avatar initials
+      // Green dot + avatar initials (from handle)
       expect(find.text('A'), findsOneWidget);
       expect(find.text('B'), findsOneWidget);
+    });
+
+    testWidgets('presence tooltip shows handle instead of email',
+        (tester) async {
+      client.presenceUsers = [
+        {
+          'user_id': 'u1',
+          'user_email': 'alice@test.com',
+          'user_handle': 'alice',
+        },
+        {
+          'user_id': 'u2',
+          'user_email': 'bob@test.com',
+          'user_handle': '',
+        },
+      ];
+
+      await tester.pumpWidget(buildChat());
+
+      // Tooltip for user with handle shows handle
+      expect(find.byTooltip('alice'), findsOneWidget);
+      // Tooltip for user without handle falls back to email
+      expect(find.byTooltip('bob@test.com'), findsOneWidget);
     });
 
     testWidgets('presence bar hidden when no users', (tester) async {


### PR DESCRIPTION
## Summary
- Presence bar avatar tooltips now show the user's handle instead of email, falling back to email only when no handle is set
- Avatar initials also derive from the handle when available
- Backend `presence_join` message now includes `user_handle`

Closes #460

## Test plan
- [x] Backend tests pass (1520 passed)
- [x] Frontend tests pass (63 passed), including new `presence tooltip shows handle instead of email` test
- [ ] Manual: hover presence avatars, verify handle shown for users with handles and email for those without