### PR TITLE
fix(container): set HERDR_SOCKET_PATH to tmpfs for macOS virtiofs compat

### DIFF
--- a/src/containers/workspace/bash.bashrc
+++ b/src/containers/workspace/bash.bashrc
@@ -5,6 +5,10 @@
 # Plugin tools on PATH (ENV in Dockerfile is overridden by login shells).
 export PATH="/opt/klangk/bin:$PATH"
 
+# Keep herdr's API socket on tmpfs — virtiofs (macOS) rejects chmod on sockets.
+# Per-user socket since multiple users share the same container.
+export HERDR_SOCKET_PATH="/tmp/herdr-${KLANGK_USER_ID:-default}.sock"
+
 # Ignore Ctrl+C until setup is complete and any default command has started.
 trap '' INT
 

--- a/src/containers/workspace/bash.bashrc
+++ b/src/containers/workspace/bash.bashrc
@@ -6,8 +6,9 @@
 export PATH="/opt/klangk/bin:$PATH"
 
 # Keep herdr's API socket on tmpfs — virtiofs (macOS) rejects chmod on sockets.
-# Per-user socket since multiple users share the same container.
-export HERDR_SOCKET_PATH="/tmp/herdr-${KLANGK_USER_ID:-default}.sock"
+# Per-user with random suffix to prevent predictable-path attacks in /tmp.
+_herdr_dir=$(mktemp -d "/tmp/herdr-${KLANGK_USER_ID:-default}-XXXXXXXX")
+export HERDR_SOCKET_PATH="$_herdr_dir/herdr.sock"
 
 # Ignore Ctrl+C until setup is complete and any default command has started.
 trap '' INT


### PR DESCRIPTION
## Summary
- Set `HERDR_SOCKET_PATH=/tmp/herdr-${KLANGK_USER_ID}.sock` in bash.bashrc
- Apple's virtiofs rejects `chmod()` on unix sockets with EINVAL, causing herdr to hang on startup when `~/.config/herdr` is on a virtiofs mount
- `/tmp` is always tmpfs inside containers, so `chmod` works fine
- Per-user socket path since multiple users share containers

Closes #269

## Test plan
- [ ] Verify herdr starts without hanging on macOS host with Podman