### PR TITLE
feat: default EDITOR to nano in workspace containers

### DIFF
--- a/src/containers/workspace/bash.bashrc
+++ b/src/containers/workspace/bash.bashrc
@@ -10,6 +10,9 @@ export PATH="/opt/klangk/bin:$PATH"
 _herdr_dir=$(mktemp -d "/tmp/herdr-${KLANGK_USER_ID:-default}-XXXXXXXX")
 export HERDR_SOCKET_PATH="$_herdr_dir/herdr.sock"
 
+# Default editor for git commit, crontab -e, etc.
+export EDITOR=nano
+
 # Ignore Ctrl+C until setup is complete and any default command has started.
 trap '' INT
 


### PR DESCRIPTION
## Summary
- Sets `EDITOR=nano` in `bash.bashrc` so tools like `git commit` and `crontab -e` use nano by default

Fixes #477

## Test plan
- [ ] Open a workspace terminal and run `echo $EDITOR` — should print `nano`
- [ ] Run `git commit` with no staged changes to verify nano opens