### PR TITLE
fix: prevent Firefox WebSocket reconnect throttling

### DIFF
--- a/src/frontend/lib/utils/web_helpers_stub.dart
+++ b/src/frontend/lib/utils/web_helpers_stub.dart
@@ -32,5 +32,8 @@ void Function() installPageKeyListener(bool Function() shouldSuppress) => () {};
 /// Stub — no system clipboard outside the browser.
 Future<String?> readClipboardText() async => null;
 
+/// Stub — no beforeunload outside the browser.
+void Function() onBeforeUnload(void Function() callback) => () {};
+
 /// Stub — no build hash outside the browser.
 String getBuildHash() => '';

--- a/src/frontend/lib/utils/web_helpers_web.dart
+++ b/src/frontend/lib/utils/web_helpers_web.dart
@@ -118,6 +118,17 @@ Future<String?> readClipboardText() async {
   }
 }
 
+/// Register a callback to run when the page is about to unload (reload,
+/// close tab, navigate away). Used to send a clean WebSocket close frame
+/// so Firefox's FailDelayManager doesn't throttle the next connection.
+void Function() onBeforeUnload(void Function() callback) {
+  final handler = ((web.Event _) {
+    callback();
+  }).toJS;
+  web.window.addEventListener('beforeunload', handler);
+  return () => web.window.removeEventListener('beforeunload', handler);
+}
+
 /// Read the build hash from the <meta name="klangk-build-hash"> tag.
 /// Returns empty string if not found (e.g. dev server without build script).
 String getBuildHash() {

--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -31,6 +31,7 @@ class WsClient extends ChangeNotifier {
   // coverage:ignore-end
 
   WebSocketChannel? _channel;
+  void Function()? _removeBeforeUnload;
   AuthService? _auth;
   String? _currentWorkspaceId;
   String? _currentUserId;
@@ -169,6 +170,12 @@ class WsClient extends ChangeNotifier {
     }
 
     _connected = true;
+    // Close cleanly on page unload so Firefox's FailDelayManager doesn't
+    // treat it as a failure and throttle the next connection by up to 60s.
+    _removeBeforeUnload?.call();
+    _removeBeforeUnload = onBeforeUnload(() {
+      _channel?.sink.close(1000, 'page unload');
+    });
     notifyListeners();
     _listenToChannel();
   }
@@ -295,7 +302,11 @@ class WsClient extends ChangeNotifier {
   void disconnect() {
     _cancelReconnect();
     _stopHeartbeat();
-    _channel?.sink.close();
+    _removeBeforeUnload?.call();
+    _removeBeforeUnload = null;
+    // Close with 1000 (normal closure) so Firefox's FailDelayManager
+    // doesn't treat it as a failure and throttle the next connection.
+    _channel?.sink.close(1000, 'client disconnect');
     _channel = null;
     _connected = false;
     _currentWorkspaceId = null;

--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -174,7 +174,7 @@ class WsClient extends ChangeNotifier {
     // treat it as a failure and throttle the next connection by up to 60s.
     _removeBeforeUnload?.call();
     _removeBeforeUnload = onBeforeUnload(() {
-      _channel?.sink.close(1000, 'page unload');
+      _channel?.sink.close(1000, 'page unload'); // coverage:ignore-line
     });
     notifyListeners();
     _listenToChannel();


### PR DESCRIPTION
## Summary

Firefox's `FailDelayManager` throttles WebSocket reconnections after abnormal closes (no status code), adding cumulative delays up to 60 seconds. During development, page reloads and navigation caused abnormal closes, which made workspace connections take 20-45 seconds on Firefox. Chrome was unaffected.

**Root cause**: `_channel?.sink.close()` was called without a close code, which Firefox treats as an abnormal termination. Each such close increases the delay for the next connection to the same endpoint (starting at 200-400ms, multiplying by 1.5x, capped at 60s).

**Fix**:
- Close WebSocket with code 1000 (normal closure) in `disconnect()`
- Add a `beforeunload` event handler that sends a clean close frame on page reload/navigation/tab close
- Add `onBeforeUnload` helper to web_helpers (with VM stub)

Fixes #481

## Test plan
- [x] All 556 frontend unit tests pass
- [x] Firefox: workspace connects in <3s after page reload (was 20-45s)
- [x] Chrome: no regression, workspace connects in <3s
- [x] Page reload in Firefox doesn't accumulate delay on subsequent connections