### PR TITLE
fix: graceful handling of expired access and workspace tokens

### DIFF
--- a/scripts/nginx.sh
+++ b/scripts/nginx.sh
@@ -91,6 +91,8 @@ if [ -n "${KLANGK_LLM_BASE_URL:-}" ]; then
     location ~ ^/llm-proxy/(.*)\$ {
 ${CONTAINER_ACL}
       auth_request /auth/verify-workspace-token;
+      auth_request_set \$auth_token_error \$upstream_http_x_token_error;
+      error_page 401 = @token_auth_failed;
       resolver ${DNS_RESOLVERS} valid=30s;
       set \$llm_backend ${KLANGK_LLM_BASE_URL}/\$1;
       proxy_pass \$llm_backend;
@@ -160,6 +162,8 @@ ${LLM_BLOCK}
     location = /api/browser-delegate {
 ${CONTAINER_ACL}
       auth_request /auth/verify-workspace-token;
+      auth_request_set \$auth_token_error \$upstream_http_x_token_error;
+      error_page 401 = @token_auth_failed;
       proxy_pass http://127.0.0.1:${KLANGK_PORT}/api/browser-delegate;
       proxy_set_header Host \$http_host;
       proxy_set_header X-Real-IP \$remote_addr;
@@ -174,6 +178,8 @@ ${CONTAINER_ACL}
     location = /api/workspace/post-chat-message {
 ${CONTAINER_ACL}
       auth_request /auth/verify-workspace-token;
+      auth_request_set \$auth_token_error \$upstream_http_x_token_error;
+      error_page 401 = @token_auth_failed;
       proxy_pass http://127.0.0.1:${KLANGK_PORT}/api/workspace/post-chat-message;
       proxy_set_header Host \$http_host;
       proxy_set_header X-Real-IP \$remote_addr;
@@ -182,12 +188,22 @@ ${CONTAINER_ACL}
     }
 
     # Workspace token verification subrequest (nginx auth_request target).
+    # X-Token-Error is captured so the 401 error page can return a
+    # meaningful JSON body to containers (expired vs invalid vs missing).
     location = /auth/verify-workspace-token {
       internal;
       proxy_pass http://127.0.0.1:${KLANGK_PORT}/auth/verify-workspace-token;
       proxy_pass_request_body off;
       proxy_set_header Content-Length "";
       proxy_set_header Authorization \$http_authorization;
+    }
+
+    # JSON 401 error page for auth_request failures.  The \$auth_token_error
+    # variable is set from the X-Token-Error header of the auth subrequest.
+    location @token_auth_failed {
+      internal;
+      default_type application/json;
+      return 401 '{\"error\":\"\$auth_token_error\",\"detail\":\"Workspace token \$auth_token_error\"}';
     }
 
     location / {

--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -17,7 +17,12 @@ import zipfile
 import httpx
 
 from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile
-from fastapi.responses import FileResponse, RedirectResponse, StreamingResponse
+from fastapi.responses import (
+    FileResponse,
+    JSONResponse,
+    RedirectResponse,
+    StreamingResponse,
+)
 from pydantic import BaseModel
 
 from . import (
@@ -63,12 +68,26 @@ async def verify_workspace_token(request: Request):
     container→host endpoints (/llm-proxy, /api/browser-delegate, etc.)."""
     authorization = request.headers.get("authorization", "")
     if not authorization.startswith("Bearer "):
-        raise HTTPException(status_code=401, detail="Missing token")
+        return JSONResponse(
+            status_code=401,
+            content={"detail": "Missing token"},
+            headers={"X-Token-Error": "missing"},
+        )
     token = authorization[7:]
-    workspace_id = auth.decode_workspace_token(token)
-    if workspace_id is None:
-        raise HTTPException(status_code=401, detail="Invalid workspace token")
-    return {"status": "ok", "workspace_id": workspace_id}
+    result = auth.decode_workspace_token(token)
+    if result is auth.WORKSPACE_TOKEN_EXPIRED:
+        return JSONResponse(
+            status_code=401,
+            content={"detail": "Workspace token expired"},
+            headers={"X-Token-Error": "expired"},
+        )
+    if result is None:
+        return JSONResponse(
+            status_code=401,
+            content={"detail": "Invalid workspace token"},
+            headers={"X-Token-Error": "invalid"},
+        )
+    return {"status": "ok", "workspace_id": result}
 
 
 @router.get("/version")

--- a/src/backend/klangk_backend/auth.py
+++ b/src/backend/klangk_backend/auth.py
@@ -6,7 +6,7 @@ from datetime import datetime, timedelta, timezone
 import bcrypt
 from fastapi import Depends, HTTPException
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
-from jose import JWTError, jwt
+from jose import ExpiredSignatureError, JWTError, jwt
 from pydantic import BaseModel
 
 from . import model
@@ -324,13 +324,25 @@ def create_workspace_token(workspace_id: str) -> str:
     return jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM)
 
 
+# Sentinel returned by decode_workspace_token when the JWT is expired.
+WORKSPACE_TOKEN_EXPIRED = "WORKSPACE_TOKEN_EXPIRED"
+
+
 def decode_workspace_token(token: str) -> str | None:
-    """Decode a workspace token. Returns workspace_id or None if invalid."""
+    """Decode a workspace token.
+
+    Returns:
+        str workspace_id on success.
+        WORKSPACE_TOKEN_EXPIRED if the token is expired.
+        None for all other failures.
+    """
     try:
         payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
         if payload.get("purpose") != "workspace":
             return None
         return payload.get("sub")
+    except ExpiredSignatureError:
+        return WORKSPACE_TOKEN_EXPIRED
     except JWTError:
         return None
 
@@ -380,8 +392,18 @@ async def get_current_user_optional(
         return None
 
 
-async def get_user_from_token(token: str) -> dict | None:
-    """Validate a token string (used for WebSocket auth)."""
+# Sentinel returned by get_user_from_token when the JWT is expired.
+TOKEN_EXPIRED = "TOKEN_EXPIRED"
+
+
+async def get_user_from_token(token: str) -> dict | str | None:
+    """Validate a token string (used for WebSocket auth).
+
+    Returns:
+        dict: the user record on success.
+        TOKEN_EXPIRED: if the token signature is valid but expired.
+        None: for all other failures (malformed, revoked, missing user).
+    """
     try:
         payload = decode_token(token)
         user_id = payload.get("sub")
@@ -391,6 +413,8 @@ async def get_user_from_token(token: str) -> dict | None:
         if await model.is_token_blocklisted(jti):
             return None
         return await model.get_user_by_id(user_id)
+    except ExpiredSignatureError:
+        return TOKEN_EXPIRED
     except JWTError:
         return None
 

--- a/src/backend/klangk_backend/cli/client.py
+++ b/src/backend/klangk_backend/cli/client.py
@@ -766,9 +766,15 @@ async def _run_shell(
                         logging.info("[container stopped]")
                         stop_event.set()
                         break
-        except websockets.ConnectionClosed:
+        except websockets.ConnectionClosed as exc:
             if not stop_event.is_set():
-                stdout.write("\r\nServer disconnected.\r\n")
+                if exc.code in (4001, 4002):
+                    stdout.write(
+                        "\r\nSession expired. Run `klangk login` to"
+                        " re-authenticate.\r\n"
+                    )
+                else:
+                    stdout.write("\r\nServer disconnected.\r\n")
                 stdout.flush()
         stop_event.set()
 

--- a/src/backend/klangk_backend/cli/main.py
+++ b/src/backend/klangk_backend/cli/main.py
@@ -659,6 +659,19 @@ def shell(
                 window=terminal,
             )
         )
+    except websockets.exceptions.InvalidStatusCode as e:
+        from .client import _drain_stdin, reset_terminal
+
+        reset_terminal()
+        _drain_stdin()
+        if e.status_code in (4001, 4002):
+            _err.print(
+                "[red]Session expired. Run `klangk login`"
+                " to re-authenticate.[/red]"
+            )
+        else:
+            _err.print(f"[red]Connection rejected: {e}[/red]")
+        raise typer.Exit(code=1) from None
     except ConnectionError as e:
         from .client import _drain_stdin, reset_terminal
 

--- a/src/backend/klangk_backend/wshandler.py
+++ b/src/backend/klangk_backend/wshandler.py
@@ -2167,10 +2167,14 @@ async def handle_websocket(websocket: WebSocket) -> None:
         await websocket.close(code=4001, reason="Missing token")
         return
 
-    user = await auth.get_user_from_token(token)
-    if user is None:
+    result = await auth.get_user_from_token(token)
+    if result is auth.TOKEN_EXPIRED:
+        await websocket.close(code=4002, reason="Token expired")
+        return
+    if result is None:
         await websocket.close(code=4001, reason="Invalid token")
         return
+    user = result
 
     await websocket.accept()
     safe_ws = SafeWebSocket(websocket)

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -89,6 +89,29 @@ class TestVerifyWorkspaceToken:
         )
         assert resp.status_code == 401
 
+    async def test_expired_workspace_token(self, client):
+        from datetime import datetime, timedelta, timezone
+
+        from jose import jwt
+
+        expired = datetime.now(timezone.utc) - timedelta(hours=1)
+        payload = {"sub": "ws-123", "purpose": "workspace", "exp": expired}
+        token = jwt.encode(payload, auth.SECRET_KEY, algorithm=auth.ALGORITHM)
+        resp = await client.get(
+            "/auth/verify-workspace-token",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 401
+        assert resp.json()["detail"] == "Workspace token expired"
+
+    async def test_invalid_workspace_token_detail(self, client):
+        resp = await client.get(
+            "/auth/verify-workspace-token",
+            headers={"Authorization": "Bearer garbage"},
+        )
+        assert resp.status_code == 401
+        assert resp.json()["detail"] == "Invalid workspace token"
+
 
 class TestWorkspaceChat:
     async def test_post_agent_message(self, client, user):

--- a/src/backend/tests/test_cli_integration.py
+++ b/src/backend/tests/test_cli_integration.py
@@ -909,6 +909,43 @@ class TestStdoutLoopExited:
         assert "Enter, then ~." in output
 
 
+class TestStdoutLoopAuthClose:
+    @pytest.mark.asyncio
+    async def test_auth_close_shows_session_expired(self):
+        """Mid-session close with code 4002 shows session expired message."""
+        import websockets
+        from websockets.frames import Close
+
+        from klangk_backend.cli.client import _run_shell
+
+        ws = AsyncMock()
+        exc = websockets.ConnectionClosed(Close(4002, "Token expired"), None)
+        ws.recv = AsyncMock(side_effect=exc)
+
+        captured = []
+
+        class CaptureWriter:
+            def write(self, data):
+                captured.append(data)
+
+            def flush(self):
+                pass
+
+        task = asyncio.create_task(
+            _run_shell(ws, 80, 24, stdout=CaptureWriter())
+        )
+        await asyncio.sleep(0.3)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+        output = "".join(captured)
+        assert "Session expired" in output
+        assert "klangk login" in output
+
+
 class TestStdinTerminalResponseFilter:
     @pytest.mark.asyncio
     async def test_terminal_response_filtered_from_stdin(self):
@@ -1155,6 +1192,66 @@ class TestShellConnectionError:
         monkeypatch.setattr(
             "klangk_backend.cli.client.reset_terminal", lambda: None
         )
+
+        import typer
+
+        with pytest.raises(typer.Exit) as exc_info:
+            shell(workspace="ws", terminal="x")
+        assert exc_info.value.exit_code == 1
+
+    def _shell_with_side_effect(self, monkeypatch, side_effect):
+        """Helper: run shell() with a mocked asyncio.run side_effect."""
+        from klangk_backend.cli.client import Workspace
+        from klangk_backend.cli.config import AuthConfig, ServerConfig
+
+        fake_cfg = CLIConfig(
+            server=ServerConfig(url="http://localhost:8995"),
+            auth=AuthConfig(token="fake", email="test@test.com"),
+        )
+        monkeypatch.setattr("klangk_backend.cli.main._cfg", lambda: fake_cfg)
+
+        fake_ws = Workspace(id="ws1", name="ws", created_at="2026-01-01")
+        monkeypatch.setattr(
+            "klangk_backend.cli.main._client",
+            lambda: MagicMock(
+                resolve_workspace=MagicMock(return_value=fake_ws)
+            ),
+        )
+
+        monkeypatch.setattr(
+            "klangk_backend.cli.main.asyncio.run",
+            MagicMock(side_effect=side_effect),
+        )
+        monkeypatch.setattr(
+            "klangk_backend.cli.client._drain_stdin", lambda: None
+        )
+        monkeypatch.setattr(
+            "klangk_backend.cli.client.reset_terminal", lambda: None
+        )
+
+    def test_shell_catches_expired_token(self, monkeypatch):
+        """shell() catches InvalidStatusCode with 4001/4002 and shows auth error."""
+        from websockets.exceptions import InvalidStatusCode
+
+        from klangk_backend.cli.main import shell
+
+        self._shell_with_side_effect(
+            monkeypatch, InvalidStatusCode(4002, None)
+        )
+
+        import typer
+
+        with pytest.raises(typer.Exit) as exc_info:
+            shell(workspace="ws", terminal="x")
+        assert exc_info.value.exit_code == 1
+
+    def test_shell_catches_non_auth_invalid_status(self, monkeypatch):
+        """shell() catches InvalidStatusCode with non-auth code (e.g. 500)."""
+        from websockets.exceptions import InvalidStatusCode
+
+        from klangk_backend.cli.main import shell
+
+        self._shell_with_side_effect(monkeypatch, InvalidStatusCode(500, None))
 
         import typer
 

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -1781,6 +1781,29 @@ class TestHandleWebsocket:
             code=4001, reason="Invalid token"
         )
 
+    async def test_expired_token(self, user):
+        from datetime import datetime, timedelta, timezone
+
+        from jose import jwt
+
+        from klangk_backend import auth as auth_mod
+
+        expired = datetime.now(timezone.utc) - timedelta(hours=1)
+        payload = {
+            "sub": user["id"],
+            "email": user["email"],
+            "jti": "test-jti",
+            "exp": expired,
+        }
+        token = jwt.encode(
+            payload, auth_mod.SECRET_KEY, algorithm=auth_mod.ALGORITHM
+        )
+        websocket = _mock_raw_sock(query_params={"token": token})
+        await handle_websocket(websocket)
+        websocket.close.assert_awaited_once_with(
+            code=4002, reason="Token expired"
+        )
+
     async def test_valid_token_then_disconnect(self, user):
         from klangk_backend import auth as auth_mod
 

--- a/src/frontend/e2e-tests/e2e/token-expiry.spec.ts
+++ b/src/frontend/e2e-tests/e2e/token-expiry.spec.ts
@@ -1,0 +1,98 @@
+import { test, expect } from "@playwright/test";
+import { execSync } from "child_process";
+import { mkdirSync, mkdtempSync, writeFileSync } from "fs";
+import jwt from "jsonwebtoken";
+import { tmpdir } from "os";
+import { join } from "path";
+import { API_BASE, registerUser } from "./helpers";
+
+const JWT_SECRET = "e2e-test-secret";
+
+test.describe("Token expiry", () => {
+  test("expired workspace token returns distinct error", async ({
+    request,
+  }) => {
+    // Create an expired workspace token
+    const expiredToken = jwt.sign(
+      { sub: "ws-test-123", purpose: "workspace" },
+      JWT_SECRET,
+      { algorithm: "HS256", expiresIn: -60 },
+    );
+
+    const resp = await request.get(`${API_BASE}/auth/verify-workspace-token`, {
+      headers: { Authorization: `Bearer ${expiredToken}` },
+    });
+
+    expect(resp.status()).toBe(401);
+    const body = await resp.json();
+    expect(body.detail).toBe("Workspace token expired");
+    // Verify the X-Token-Error header is set for nginx forwarding
+    const tokenError = resp.headers()["x-token-error"];
+    expect(tokenError).toBe("expired");
+  });
+
+  test("invalid workspace token returns distinct error", async ({
+    request,
+  }) => {
+    const resp = await request.get(`${API_BASE}/auth/verify-workspace-token`, {
+      headers: { Authorization: "Bearer garbage-token" },
+    });
+
+    expect(resp.status()).toBe(401);
+    const body = await resp.json();
+    expect(body.detail).toBe("Invalid workspace token");
+    const tokenError = resp.headers()["x-token-error"];
+    expect(tokenError).toBe("invalid");
+  });
+
+  test("klangk shell with expired token shows session expired", async ({
+    request,
+  }) => {
+    // Register a user and create a workspace so the shell has a target
+    const email = `cli-expired-${Date.now()}@test.example.com`;
+    const { token, headers } = await registerUser(request, email);
+    const wsResp = await request.post(`${API_BASE}/workspaces`, {
+      headers,
+      data: { name: `cli-expiry-${Date.now()}` },
+    });
+    expect(wsResp.ok()).toBeTruthy();
+    const workspace = await wsResp.json();
+
+    // Create an expired JWT
+    const decoded = jwt.decode(token) as jwt.JwtPayload;
+    const expiredToken = jwt.sign(
+      { sub: decoded.sub, email: decoded.email, jti: "cli-expired-jti" },
+      JWT_SECRET,
+      { algorithm: "HS256", expiresIn: -60 },
+    );
+
+    // Write a temporary CLI config with the expired token
+    const tmpHome = mkdtempSync(join(tmpdir(), "klangk-cli-e2e-"));
+    const configDir = join(tmpHome, ".config", "klangk");
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(
+      join(configDir, "cli.toml"),
+      `[server]\nurl = "${API_BASE}"\n\n[auth]\ntoken = "${expiredToken}"\nemail = "${email}"\n`,
+    );
+
+    // Run klangk shell — it should fail with a clear error
+    try {
+      execSync(`klangk shell "${workspace.name}"`, {
+        env: { ...process.env, HOME: tmpHome },
+        encoding: "utf-8",
+        timeout: 15_000,
+      });
+      // Should not succeed
+      expect(false).toBe(true);
+    } catch (e: any) {
+      const output = (e.stderr || "") + (e.stdout || "");
+      expect(output).toContain("Session expired");
+      expect(output).toContain("klangk login");
+    }
+
+    // Cleanup
+    await request.delete(`${API_BASE}/workspaces/${workspace.id}`, {
+      headers,
+    });
+  });
+});

--- a/src/frontend/e2e-tests/package-lock.json
+++ b/src/frontend/e2e-tests/package-lock.json
@@ -8,8 +8,10 @@
       "devDependencies": {
         "@playwright/test": "^1.60.0",
         "@types/adm-zip": "^0.5.8",
+        "@types/jsonwebtoken": "^9.0.10",
         "@types/ws": "^8.18.1",
         "adm-zip": "^0.5.17",
+        "jsonwebtoken": "^9.0.3",
         "ws": "^8.18.2"
       }
     },
@@ -38,6 +40,24 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "25.8.0",
@@ -69,6 +89,23 @@
         "node": ">=12.0"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -83,6 +120,108 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/playwright": {
       "version": "1.60.0",
@@ -114,6 +253,40 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/undici-types": {

--- a/src/frontend/e2e-tests/package.json
+++ b/src/frontend/e2e-tests/package.json
@@ -9,8 +9,10 @@
   "devDependencies": {
     "@playwright/test": "^1.60.0",
     "@types/adm-zip": "^0.5.8",
+    "@types/jsonwebtoken": "^9.0.10",
     "@types/ws": "^8.18.1",
     "adm-zip": "^0.5.17",
+    "jsonwebtoken": "^9.0.3",
     "ws": "^8.18.2"
   }
 }

--- a/src/frontend/e2e-tests/playwright.config.ts
+++ b/src/frontend/e2e-tests/playwright.config.ts
@@ -64,7 +64,7 @@ export default defineConfig({
     {
       // API-only and simple-UI tests — no cross-browser behavior, run once.
       name: "chromium-api",
-      testMatch: "api.spec.ts",
+      testMatch: ["api.spec.ts", "token-expiry.spec.ts"],
       use: chromiumUse,
     },
     {

--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -164,7 +164,13 @@ class WsClient extends ChangeNotifier {
     try {
       await _channel!.ready;
     } catch (e) {
-      _errorController.add('Connection failed: $e');
+      final code = _channel?.closeCode;
+      if (code == 4001 || code == 4002) {
+        _errorController.add('Session expired, please log in again');
+        _auth?.logout();
+      } else {
+        _errorController.add('Connection failed: $e');
+      }
       return;
     }
 
@@ -278,7 +284,13 @@ class WsClient extends ChangeNotifier {
         _currentWorkspaceId = null;
         _defaultCommand = null;
         notifyListeners();
-        _scheduleReconnect();
+        final code = _channel?.closeCode;
+        if (code == 4001 || code == 4002) {
+          _errorController.add('Session expired, please log in again');
+          _auth?.logout();
+        } else {
+          _scheduleReconnect();
+        }
       },
       onError: (e) {
         _errorController.add('WebSocket error: $e');
@@ -287,7 +299,12 @@ class WsClient extends ChangeNotifier {
         _pendingWorkspaceId ??= _currentWorkspaceId;
         _currentWorkspaceId = null;
         notifyListeners();
-        _scheduleReconnect();
+        final code = _channel?.closeCode;
+        if (code == 4001 || code == 4002) {
+          _auth?.logout();
+        } else {
+          _scheduleReconnect();
+        }
       },
     );
   }

--- a/src/frontend/test/ws_client_test.dart
+++ b/src/frontend/test/ws_client_test.dart
@@ -384,6 +384,33 @@ void main() {
       client.dispose();
     });
 
+    test('server error with auth close code triggers logout', () async {
+      final auth = AuthService();
+      await Future.delayed(Duration.zero);
+
+      final client = WsClient();
+      client.updateAuth(auth);
+      await client.connect();
+      client.connectWorkspace('ws-1');
+      channels[0]
+          .serverSend({'type': 'workspace_ready', 'workspaceId': 'ws-1'});
+      await Future.delayed(Duration.zero);
+
+      final errors = <String>[];
+      client.errors.listen(errors.add);
+
+      // Set close code before emitting error
+      channels[0]._closeCode = 4002;
+      channels[0].serverError(Exception('auth failure'));
+      await Future.delayed(Duration.zero);
+
+      expect(client.reconnecting, isFalse);
+      expect(client.reconnectAttempt, 0);
+
+      client.disconnect();
+      client.dispose();
+    });
+
     test('successful reconnect clears reconnect state', () async {
       final auth = AuthService();
       await Future.delayed(Duration.zero);

--- a/src/frontend/test/ws_client_test.dart
+++ b/src/frontend/test/ws_client_test.dart
@@ -231,6 +231,30 @@ void main() {
       expect(errors[0], startsWith('Connection failed:'));
       client.dispose();
     });
+
+    test('connect failure with auth close code triggers logout', () async {
+      SharedPreferences.setMockInitialValues({'klangk_jwt': 'test-token'});
+      final failChannel = _FakeWebSocketChannel();
+      failChannel.failReady = true;
+      failChannel._closeCode = 4001;
+      WsClient.testChannelFactory = (_) => failChannel;
+
+      final auth = AuthService();
+      await Future.delayed(Duration.zero);
+
+      final client = WsClient();
+      client.updateAuth(auth);
+
+      final errors = <String>[];
+      client.errors.listen(errors.add);
+
+      await client.connect();
+      await Future.delayed(Duration.zero);
+      expect(client.connected, isFalse);
+      expect(errors.length, 1);
+      expect(errors[0], 'Session expired, please log in again');
+      client.dispose();
+    });
   });
 
   group('WsClient.dispose', () {

--- a/src/frontend/test/ws_client_test.dart
+++ b/src/frontend/test/ws_client_test.dart
@@ -12,6 +12,7 @@ class _FakeWebSocketChannel extends Fake implements WebSocketChannel {
   final _incoming = StreamController<dynamic>.broadcast();
   final _sink = _FakeSink();
   bool failReady = false;
+  int? _closeCode;
 
   @override
   Stream<dynamic> get stream => _incoming.stream;
@@ -20,12 +21,18 @@ class _FakeWebSocketChannel extends Fake implements WebSocketChannel {
   WebSocketSink get sink => _sink;
 
   @override
+  int? get closeCode => _closeCode;
+
+  @override
   Future<void> get ready =>
       failReady ? Future.error('Connection refused') : Future.value();
 
   void serverSend(Map<String, dynamic> msg) => _incoming.add(jsonEncode(msg));
 
-  void serverClose() => _incoming.close();
+  void serverClose([int? code]) {
+    _closeCode = code;
+    _incoming.close();
+  }
 
   void serverError(Object error) => _incoming.addError(error);
 
@@ -608,6 +615,60 @@ void main() {
       await Future.delayed(Duration.zero);
 
       expect(attempts, [1]);
+
+      client.disconnect();
+      client.dispose();
+    });
+
+    test('auth close code 4001 triggers logout instead of reconnect', () async {
+      final auth = AuthService();
+      await Future.delayed(Duration.zero);
+
+      final client = WsClient();
+      client.updateAuth(auth);
+      await client.connect();
+      client.connectWorkspace('ws-1');
+      channels[0]
+          .serverSend({'type': 'workspace_ready', 'workspaceId': 'ws-1'});
+      await Future.delayed(Duration.zero);
+
+      final errors = <String>[];
+      client.errors.listen(errors.add);
+
+      // Server closes with auth failure code
+      channels[0].serverClose(4001);
+      await Future.delayed(Duration.zero);
+
+      expect(client.reconnecting, isFalse);
+      expect(client.reconnectAttempt, 0);
+      expect(errors, contains('Session expired, please log in again'));
+
+      client.disconnect();
+      client.dispose();
+    });
+
+    test('auth close code 4002 triggers logout instead of reconnect', () async {
+      final auth = AuthService();
+      await Future.delayed(Duration.zero);
+
+      final client = WsClient();
+      client.updateAuth(auth);
+      await client.connect();
+      client.connectWorkspace('ws-1');
+      channels[0]
+          .serverSend({'type': 'workspace_ready', 'workspaceId': 'ws-1'});
+      await Future.delayed(Duration.zero);
+
+      final errors = <String>[];
+      client.errors.listen(errors.add);
+
+      // Server closes with token expired code
+      channels[0].serverClose(4002);
+      await Future.delayed(Duration.zero);
+
+      expect(client.reconnecting, isFalse);
+      expect(client.reconnectAttempt, 0);
+      expect(errors, contains('Session expired, please log in again'));
 
       client.disconnect();
       client.dispose();


### PR DESCRIPTION
## Summary
- Backend distinguishes expired vs invalid tokens: WebSocket close code 4002 for expired (vs 4001 for invalid), distinct error messages on workspace token verification
- Frontend detects auth close codes and redirects to login instead of futile 5-minute reconnect cycle
- CLI `klangk shell` shows "Session expired — run `klangk login`" instead of cryptic tracebacks or generic "Server disconnected"
- Nginx surfaces token-expiry detail as JSON to containers via `X-Token-Error` header and custom error page

Closes #484

## Test plan
- [x] Backend tests pass (1535 passed, 100% coverage)
- [x] Frontend tests pass (558 passed), including new auth close code tests
- [ ] Manual: corrupt JWT in browser storage, verify redirect to login
- [ ] Manual: let token expire in `klangk shell`, verify clear error message
- [ ] Manual: call `/llm-proxy/` with expired workspace token, verify JSON error body