### PR TITLE
rename test-cli-e2e to test-backend-e2e

### DIFF
--- a/.github/workflows/backend-e2e-tests.yml
+++ b/.github/workflows/backend-e2e-tests.yml
@@ -44,7 +44,7 @@ jobs:
         if: steps.filter.outputs.e2e == 'true'
         run: |
           . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-          devenv shell -- test-cli-e2e
+          devenv shell -- test-backend-e2e
 
       - name: Skip notice
         if: steps.filter.outputs.e2e != 'true'

--- a/devenv.nix
+++ b/devenv.nix
@@ -199,8 +199,8 @@ in
     exec python -m pytest src/backend/tests -v -n auto "$@"
   '';
 
-  # CLI E2E tests: start real server, run klangk commands
-  scripts.test-cli-e2e.exec = ''
+  # Backend E2E tests: start real server, run klangk commands
+  scripts.test-backend-e2e.exec = ''
     cd $DEVENV_ROOT
     exec python -m pytest src/backend/e2e-tests \
       -v -p no:xdist --no-cov "$@"

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -40,7 +40,7 @@ $KLANGK_DATA_DIR/workspaces/<user-id>/home/<workspace-id>/
 src/
   backend/             # FastAPI app
     tests/             # Backend unit tests
-    e2e-tests/         # CLI E2E tests
+    e2e-tests/         # Backend E2E tests
   frontend/            # Flutter web app
     test/              # Frontend unit tests
     e2e-tests/         # Playwright E2E tests

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -9,8 +9,8 @@ test-backend
 # Frontend unit tests (Dart, flutter test, 100% coverage required)
 test-frontend
 
-# CLI E2E tests (starts real server + podman containers)
-test-cli-e2e
+# Backend E2E tests (starts real server + podman containers)
+test-backend-e2e
 
 # Flutter E2E tests (Playwright, needs flutter build + podman build)
 test-frontend-e2e
@@ -27,7 +27,7 @@ Backend tests for Python changes, frontend tests for Dart changes. Run E2E tests
 src/
   backend/             # FastAPI app
     tests/             # Backend unit tests
-    e2e-tests/         # CLI E2E tests
+    e2e-tests/         # Backend E2E tests
   frontend/            # Flutter web app
     test/              # Frontend unit tests
     e2e-tests/         # Playwright E2E tests
@@ -48,7 +48,7 @@ Inside `devenv shell`, these commands are available:
 | ----------------------- | ------------------------------------- |
 | `test-backend`          | Run backend unit tests                |
 | `test-frontend`         | Run frontend unit tests with coverage |
-| `test-cli-e2e`          | Run CLI E2E tests                     |
+| `test-backend-e2e`      | Run backend E2E tests                 |
 | `test-frontend-e2e`     | Run Flutter E2E tests (all browsers)  |
 | `flutterbuildweb`       | Rebuild Flutter web only              |
 | `build-workspace-image` | Rebuild workspace image (podman)      |

--- a/src/backend/e2e-tests/test_api_e2e.py
+++ b/src/backend/e2e-tests/test_api_e2e.py
@@ -3,7 +3,7 @@
 Exercises group management, ACL permissions, workspace sharing via ACL,
 and permission denials.
 
-Run with: devenv shell -- test-cli-e2e test_api_e2e.py
+Run with: devenv shell -- test-backend-e2e test_api_e2e.py
 """
 
 import os

--- a/src/backend/e2e-tests/test_cli_e2e.py
+++ b/src/backend/e2e-tests/test_cli_e2e.py
@@ -1,11 +1,11 @@
-"""CLI end-to-end tests against a real Klangk server.
+"""Backend end-to-end tests against a real Klangk server.
 
 These tests start a real uvicorn server, run klangk CLI commands as
 subprocesses, and verify behavior against real podman containers.
 
 Requires: podman available, klangk image built.
 
-Run with: devenv shell -- test-cli-e2e
+Run with: devenv shell -- test-backend-e2e
 """
 
 import logging

--- a/src/backend/e2e-tests/test_event_fanout.py
+++ b/src/backend/e2e-tests/test_event_fanout.py
@@ -9,7 +9,7 @@ state between tests.
 
 Requires: podman available, klangk image built.
 
-Run with: devenv shell -- test-cli-e2e
+Run with: devenv shell -- test-backend-e2e
 """
 
 import asyncio


### PR DESCRIPTION
## Summary
- Rename `test-cli-e2e` devenv script to `test-backend-e2e` for consistency with `test-backend` and `test-frontend-e2e`
- Update all references in CI workflow, docs, and test file docstrings
- Also rename "CLI E2E" descriptions to "Backend E2E" throughout

Closes #454