### PR TITLE
feat: broadcast workspace token expiry warnings

### DIFF
--- a/src/backend/klangk_backend/wshandler.py
+++ b/src/backend/klangk_backend/wshandler.py
@@ -6,6 +6,7 @@ import logging
 import re
 import time
 import uuid
+from datetime import datetime, timedelta, timezone
 
 from fastapi import WebSocket, WebSocketDisconnect
 
@@ -162,6 +163,9 @@ class WorkspaceSession:
         # to /home/.workspace-state.json for crash recovery.
         self.terminal_windows: dict[str, list[dict]] = {}
         self._save_lock = asyncio.Lock()
+        # Workspace token expiry tracking for warning broadcasts.
+        self.workspace_token_expiry: datetime | None = None
+        self._token_warning_task: asyncio.Task | None = None
 
     async def reset(self) -> None:
         self.subscribers.clear()
@@ -189,6 +193,66 @@ class WorkspaceSession:
     def broadcast(self, message: dict) -> int:
         """Send message to all subscribers, removing dead ones."""
         return _broadcast_to_set(self.subscribers, message)
+
+    def start_token_expiry_warnings(self, expiry: datetime) -> None:
+        """Schedule background warnings before the workspace token expires.
+
+        Warnings are fire-and-forget — only a container restart (which
+        creates a fresh token) resets the expiry clock.
+        """
+        self.workspace_token_expiry = expiry
+        self._token_warning_task = asyncio.create_task(
+            self._token_warning_loop()
+        )
+
+    async def _token_warning_loop(self) -> None:
+        """Broadcast system chat warnings before workspace token expires."""
+        expiry = self.workspace_token_expiry
+        if expiry is None:
+            return  # pragma: no cover
+
+        # Warning thresholds: (time_before_expiry, message)
+        warnings = [
+            (
+                timedelta(hours=1),
+                "Workspace token expires in 1 hour. An admin can"
+                " restart the container to refresh it. When the token"
+                " expires, LLM and chat API access from within the"
+                " container will stop working until the container is"
+                " restarted.",
+            ),
+            (
+                timedelta(minutes=15),
+                "Workspace token expires in 15 minutes. LLM and chat"
+                " API access from within the container will stop"
+                " working when the token expires. Restart the container"
+                " to refresh it.",
+            ),
+        ]
+        for threshold, message in warnings:
+            fire_at = expiry - threshold
+            delay = (fire_at - datetime.now(timezone.utc)).total_seconds()
+            if delay <= 0:
+                continue
+            try:
+                await asyncio.sleep(delay)
+            except asyncio.CancelledError:
+                return  # pragma: no cover
+            try:
+                agent_user = await model.get_agent_user()
+                sys_msg = await model.add_chat_message(
+                    self.workspace_id,
+                    agent_user["id"],
+                    agent_user["email"],
+                    message,
+                    message_type=model.MSG_SYSTEM,
+                )
+                self.broadcast({"type": "chat_message", **sys_msg})
+            except Exception:  # pragma: no cover
+                logger.warning(
+                    "Failed to broadcast token expiry warning",
+                    exc_info=True,
+                )
 
     def broadcast_to_browsers(self, message: dict) -> int:
         """Send message to browser subscribers only, removing dead ones."""
@@ -633,6 +697,13 @@ class Connection:
 
         session = state.get_or_create_session(workspace_id)
         await session.add_subscriber(self.sock, container_id)
+
+        # Start token expiry warnings if not already running for this session.
+        if session.workspace_token_expiry is None:
+            token_expiry = datetime.now(timezone.utc) + timedelta(
+                hours=auth.WORKSPACE_TOKEN_EXPIRE_HOURS
+            )
+            session.start_token_expiry_warnings(token_expiry)
 
         # Register idle timeout notification (per-connection)
         sock = self.sock

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -5612,3 +5612,72 @@ class TestUiReadySharedTerminals:
             )
         finally:
             wshandler.state.sessions.pop(ws["id"], None)
+
+
+class TestTokenExpiryWarnings:
+    async def test_warning_fires_when_threshold_reached(
+        self, user, agent_user
+    ):
+        """Token expiry warning is broadcast when the threshold is reached."""
+        from datetime import datetime, timedelta, timezone
+
+        workspace = await _create_workspace_with_acl(user["id"], "expiry-ws")
+        session = wshandler.state.get_or_create_session(workspace["id"])
+        sock = _mock_sock()
+        conn = _base_conn(user=user, ws=sock)
+        wshandler.state.connections[sock] = conn
+        session.subscribers.add(sock)
+
+        try:
+            # Set expiry 0.3s from now — only the 15-min warning threshold
+            # will have delay <= 0 (skipped), so we need expiry close enough
+            # that the 1-hour threshold is also skipped, but a custom short
+            # threshold fires.  Instead, set expiry in the past + 0.3s so
+            # both thresholds are skipped except a very short sleep.
+            #
+            # Simpler: set expiry to 15min + 0.2s from now, so the 1-hour
+            # warning is skipped (delay < 0) and the 15-min warning fires
+            # after 0.2s.
+            expiry = datetime.now(timezone.utc) + timedelta(
+                minutes=15, milliseconds=200
+            )
+            session.start_token_expiry_warnings(expiry)
+
+            await asyncio.sleep(0.5)
+
+            calls = [c[0][0] for c in sock.send_json.call_args_list]
+            chat_msgs = [c for c in calls if c.get("type") == "chat_message"]
+            assert len(chat_msgs) == 1
+            assert "15 minutes" in chat_msgs[0]["message"]
+            assert chat_msgs[0]["message_type"] == 2  # MSG_SYSTEM
+        finally:
+            wshandler.state.sessions.pop(workspace["id"], None)
+            wshandler.state.connections.pop(sock, None)
+
+    async def test_skips_past_thresholds(self, user, agent_user):
+        """Thresholds that are already past are skipped."""
+        from datetime import datetime, timedelta, timezone
+
+        workspace = await _create_workspace_with_acl(
+            user["id"], "past-expiry-ws"
+        )
+        session = wshandler.state.get_or_create_session(workspace["id"])
+        sock = _mock_sock()
+        conn = _base_conn(user=user, ws=sock)
+        wshandler.state.connections[sock] = conn
+        session.subscribers.add(sock)
+
+        try:
+            # Expiry in 5 minutes — both 1-hour and 15-min thresholds
+            # are in the past, so no warnings should fire.
+            expiry = datetime.now(timezone.utc) + timedelta(minutes=5)
+            session.start_token_expiry_warnings(expiry)
+
+            await asyncio.sleep(0.3)
+
+            calls = [c[0][0] for c in sock.send_json.call_args_list]
+            chat_msgs = [c for c in calls if c.get("type") == "chat_message"]
+            assert len(chat_msgs) == 0
+        finally:
+            wshandler.state.sessions.pop(workspace["id"], None)
+            wshandler.state.connections.pop(sock, None)


### PR DESCRIPTION
## Summary
- Broadcast system chat messages at 1 hour and 15 minutes before workspace token expiry
- Warnings tell users that LLM and chat API access will stop working and that an admin can restart the container to refresh the token
- Warnings are fire-and-forget — only a container restart resets the expiry clock

Closes #230

## Test plan
- [x] Backend tests pass (1537 passed, 100% coverage)
- [ ] Manual: set `KLANGK_WORKSPACE_TOKEN_HOURS=0.02` (~1 min), open workspace, verify warning appears in chat