### PR TITLE
feat(terminal): respawn shell on exit via tmux

### DIFF
--- a/src/containers/workspace/tmux.conf
+++ b/src/containers/workspace/tmux.conf
@@ -72,3 +72,9 @@ set -g status off
 # (shared terminals) so spectator/collaborator sessions survive
 # disconnect.  Orphaned sessions are cleaned up explicitly.
 set -g destroy-unattached off
+
+# Respawn the shell if it exits (user types "exit", Ctrl-D, or gets
+# killed).  remain-on-exit keeps the pane in "dead" state instead of
+# destroying it; pane-died hook immediately respawns it.
+set -g remain-on-exit on
+set-hook -g pane-died 'respawn-pane'


### PR DESCRIPTION
## Summary
- Add `remain-on-exit on` and `pane-died` hook to tmux.conf
- When the shell exits (exit, Ctrl-D, killed), tmux respawns the pane immediately
- The tmux session stays alive so the backend's PTY connection is unaffected

## Test plan
- [x] Type `exit` in terminal — shell respawns with fresh prompt
- [x] Press Ctrl-D — shell respawns
- [x] `kill -9 $$` — shell respawns