### PR TITLE
feat: add PyPI publish workflow for CLI

### DIFF
--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -1,0 +1,29 @@
+name: "Publish CLI to PyPI"
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # trusted publishing
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Build package
+        run: |
+          pip install build
+          cd src/cli
+          python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: src/cli/dist/

--- a/.github/workflows/cli-publish.yml
+++ b/.github/workflows/cli-publish.yml
@@ -1,8 +1,9 @@
 name: "Publish CLI to PyPI"
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "cli-v*"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/cli-tests.yml
+++ b/.github/workflows/cli-tests.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install dependencies
         if: steps.filter.outputs.cli == 'true'
-        run: pip install -e src/cli/
+        run: pip install -e "src/cli/[dev]"
 
       - name: Run tests
         if: steps.filter.outputs.cli == 'true'

--- a/devenv.nix
+++ b/devenv.nix
@@ -46,6 +46,7 @@ in
       podman
       sqlite.bin
       rsync
+      twine
       zensical
     ]
     ++ (

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,6 +1,16 @@
 # CLI
 
-Klangk provides a CLI for terminal-based access to the same containers:
+## Installation
+
+Install `klangkc` from PyPI:
+
+```bash
+pip install klangkc
+```
+
+Requires Python 3.12+.
+
+## Usage
 
 ```bash
 klangkc login admin@example.com        # authenticate (prompts for password)

--- a/src/cli/CHANGES.md
+++ b/src/cli/CHANGES.md
@@ -1,8 +1,5 @@
 # Changes
 
-## 0.1.0 (unreleased)
+## 0.1.0
 
-- Initial release as standalone package (extracted from klangk backend).
-- Commands: `login`, `logout`, `ls`, `create`, `rm`, `edit`, `dup`,
-  `shell`, `exec`, `sync`, `export`, `import`, `terminals`, `share`,
-  `unshare`, `invite`, `invitations`, `images`, `volumes`.
+- Initial release

--- a/src/cli/CHANGES.md
+++ b/src/cli/CHANGES.md
@@ -1,0 +1,8 @@
+# Changes
+
+## 0.1.0 (unreleased)
+
+- Initial release as standalone package (extracted from klangk backend).
+- Commands: `login`, `logout`, `ls`, `create`, `rm`, `edit`, `dup`,
+  `shell`, `exec`, `sync`, `export`, `import`, `terminals`, `share`,
+  `unshare`, `invite`, `invitations`, `images`, `volumes`.

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -1,0 +1,36 @@
+# klangkc
+
+CLI client for [Klangk](https://github.com/mcdonc/klangk), a multi-user
+containerized development environment.
+
+## Installation
+
+```bash
+pip install klangkc
+```
+
+Requires Python 3.12+.
+
+## Quick start
+
+```bash
+klangkc login admin@example.com        # authenticate
+klangkc ls                             # list workspaces
+klangkc create my-project              # create a workspace
+klangkc shell my-project               # drop into a shell
+```
+
+## Features
+
+- `shell` — interactive terminal session inside a workspace container
+- `exec` — run a command in a container
+- `sync` — sync files to/from a container
+- `create` / `rm` / `edit` / `dup` — manage workspaces
+- `export` / `import` — archive and restore workspaces
+- `terminals` / `share` / `unshare` — shared terminal management
+- `volumes` — manage named volumes
+- `invite` / `invitations` — user invitation management
+
+## Documentation
+
+Full documentation: https://mcdonc.github.io/klangk/reference/cli/

--- a/src/cli/pyproject.toml
+++ b/src/cli/pyproject.toml
@@ -28,7 +28,7 @@ klangkc = "klangkc.main:main"
 [tool.hatch.version]
 source = "vcs"
 raw-options.root = "../.."
-raw-options.tag-pattern = "cli-v(?P<version>.*)"
+raw-options.tag_pattern = "cli-v(?P<version>.*)"
 
 [tool.hatch.build.targets.wheel]
 packages = ["klangkc"]

--- a/src/cli/pyproject.toml
+++ b/src/cli/pyproject.toml
@@ -28,7 +28,7 @@ klangkc = "klangkc.main:main"
 [tool.hatch.version]
 source = "vcs"
 raw-options.root = "../.."
-raw-options.tag_pattern = "cli-v(?P<version>.*)"
+raw-options.tag_regex = "^cli-v(?P<version>[vV]?\\d+(?:\\.\\d+){0,2}[^\\+]*)(?:\\+.*)?$"
 
 [tool.hatch.build.targets.wheel]
 packages = ["klangkc"]

--- a/src/cli/pyproject.toml
+++ b/src/cli/pyproject.toml
@@ -2,12 +2,17 @@
 name = "klangkc"
 dynamic = ["version"]
 description = "Klangk CLI client"
+readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "typer[all]>=0.12.0",
     "tomli-w>=1.0.0",
     "httpx>=0.28.0",
     "websockets>=14.0",
+]
+
+[project.optional-dependencies]
+dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.24.0",
     "pytest-cov>=6.0.0",

--- a/src/cli/pyproject.toml
+++ b/src/cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "klangkc"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Klangk CLI client"
 requires-python = ">=3.12"
 dependencies = [
@@ -25,9 +25,14 @@ line-length = 79
 [project.scripts]
 klangkc = "klangkc.main:main"
 
+[tool.hatch.version]
+source = "vcs"
+raw-options.root = "../.."
+raw-options.tag-pattern = "cli-v(?P<version>.*)"
+
 [tool.hatch.build.targets.wheel]
 packages = ["klangkc"]
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow that publishes `klangkc` to PyPI on release
- Uses trusted publishing (OIDC) — no API token secrets needed
- Builds with `python -m build`, publishes with `pypa/gh-action-pypi-publish`

Closes #471

## Setup required
Configure trusted publishing on PyPI:
1. Go to https://pypi.org/manage/project/klangkc/settings/publishing/
2. Add GitHub as a trusted publisher: repo `mcdonc/klangk`, workflow `cli-publish.yml`

## Test plan
- [ ] Create a GitHub release → workflow runs and publishes to PyPI