### PR TITLE
chore: add socat to workspace base image

### DIFF
--- a/src/containers/workspace/Dockerfile.base
+++ b/src/containers/workspace/Dockerfile.base
@@ -39,6 +39,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     iproute2 \
     bsdextrautils \
     tmux \
+    socat \
     locales \
     && rm -rf /var/lib/apt/lists/* \
     && chown -R root:root /var/log/apt


### PR DESCRIPTION
## Summary
- Add `socat` to the apt-get install list in `Dockerfile.base`
- Prerequisite for SSH agent forwarding (#399) — socat will bridge the container-side Unix socket to stdin/stdout for the WebSocket relay

## Test plan
- [ ] Base image builds successfully with socat included