### PR TITLE
fix: add fallback_version for hatch-vcs

### DIFF
--- a/src/cli/pyproject.toml
+++ b/src/cli/pyproject.toml
@@ -34,6 +34,7 @@ klangkc = "klangkc.main:main"
 source = "vcs"
 raw-options.root = "../.."
 raw-options.tag_regex = "^cli-v(?P<version>[vV]?\\d+(?:\\.\\d+){0,2}[^\\+]*)(?:\\+.*)?$"
+raw-options.fallback_version = "0.0.0.dev0"
 
 [tool.hatch.build.targets.wheel]
 packages = ["klangkc"]


### PR DESCRIPTION
Without a `cli-v*` tag in the repo, hatch-vcs fails to determine a version and `uv sync` breaks. Add `fallback_version = "0.0.0.dev0"` so dev builds work before the first release tag.