### PR TITLE
fix: remove stale version tags from workspace image builds

### DIFF
--- a/docs/deployment/index.md
+++ b/docs/deployment/index.md
@@ -57,7 +57,7 @@ trivy-host --severity CRITICAL    # critical only
 
 **No `:latest` tags are pushed to the registry.** Every image (host, workspace, workspace base) is pushed only with an explicit version tag. This prevents confusion when stable branches would otherwise overwrite `:latest` with an older version. Consumers always reference a specific version via `KLANGK_REF` or build locally.
 
-Locally, `build-workspace-image` still tags `klangk-workspace:latest` in the local podman store — this is the tag the backend uses at runtime (with pull policy `never`). The local `:latest` tag is never pushed to GHCR.
+Locally, `build-workspace-image` tags `klangk-workspace:latest` (used by the backend at runtime with pull policy `never`) and a deterministic version tag (`YYYY.MM.DD-<commit>`). Stale version tags from previous builds are automatically removed so they don't accumulate. The local `:latest` tag is never pushed to GHCR.
 
 ## Workspace Base Image Pin
 

--- a/scripts/build-workspace-image.sh
+++ b/scripts/build-workspace-image.sh
@@ -67,10 +67,20 @@ if [ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ]; then
   "$PODMAN" ps -a --filter "label=klangk.instance=${KLANGK_INSTANCE_ID}" -q | xargs -r "$PODMAN" rm -f
 fi
 
-# Build workspace image on top of the base
+# Build workspace image on top of the base.
+# Tag with both :latest (used by the backend at runtime) and a
+# deterministic version tag (date + commit hash).  Remove stale
+# version tags from previous builds so they don't accumulate.
 COMMIT="$(git rev-parse --short HEAD)"
 CALVER="$(date -u +%Y.%m.%d)"
 VERSION="${CALVER}-${COMMIT}"
+# Remove old version tags (but not :latest — podman build will update it).
+for old_tag in $("$PODMAN" images --format '{{.Tag}}' --filter "reference=${KLANGK_IMAGE_NAME}" 2>/dev/null || true); do
+  case "$old_tag" in
+  latest | "$VERSION" | "<none>") ;;
+  *) "$PODMAN" untag "${KLANGK_IMAGE_NAME}:${old_tag}" 2>/dev/null || true ;;
+  esac
+done
 "$PODMAN" build \
   --pull=newer \
   --platform "${KLANGK_PLATFORM:-linux/amd64}" \


### PR DESCRIPTION
Closes #482

## Summary
- Remove stale version tags (date+commit) from previous builds before building the new image
- Keep `:latest` tag since the backend references images without an explicit tag
- After a build, only two tags exist: `:latest` and `:<date>-<commit>`

## Test plan
- [ ] Run `devenv up` and verify `podman images klangk-workspace` shows only `:latest` and the current version tag
- [ ] Rebuild and verify old version tags are gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)