### PR TITLE
feat: allow users and admins to change handles

### DIFF
--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -460,6 +460,7 @@ async def change_email(
 
 class ChangeHandleRequest(auth.BaseModel):
     handle: str
+    password: str
 
 
 @router.post("/auth/change-handle")
@@ -467,7 +468,12 @@ async def change_handle(
     req: ChangeHandleRequest,
     user: dict = Depends(auth.get_current_user),
 ):
-    """Change the current user's handle."""
+    """Change the current user's handle. Requires password confirmation."""
+    stored = await model.get_user_by_email(user["email"])
+    if stored is None or not auth.verify_password(
+        req.password, stored["password_hash"]
+    ):
+        raise HTTPException(status_code=401, detail="Password is incorrect")
     try:
         await model.set_user_handle(user["id"], req.handle)
     except ValueError as e:

--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -458,6 +458,32 @@ async def change_email(
     return {"status": "updated", "needs_verification": True}
 
 
+class ChangeHandleRequest(auth.BaseModel):
+    handle: str
+
+
+@router.post("/auth/change-handle")
+async def change_handle(
+    req: ChangeHandleRequest,
+    user: dict = Depends(auth.get_current_user),
+):
+    """Change the current user's handle."""
+    try:
+        await model.set_user_handle(user["id"], req.handle)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return {"status": "updated", "handle": req.handle}
+
+
+@router.get("/auth/me")
+async def get_me(user: dict = Depends(auth.get_current_user)):
+    """Return the current user's profile."""
+    full = await model.get_user_by_id(user["id"])
+    if full is None:  # pragma: no cover — race between auth and lookup
+        raise HTTPException(status_code=404, detail="User not found")
+    return {"id": full["id"], "email": full["email"], "handle": full["handle"]}
+
+
 @router.post("/auth/logout")
 async def logout(
     request: Request,
@@ -2021,6 +2047,7 @@ async def delete_user(
 class UpdateUserRequest(auth.BaseModel):
     email: str | None = None
     password: str | None = None
+    handle: str | None = None
 
 
 @router.patch("/admin/users/{user_id}")
@@ -2042,6 +2069,11 @@ async def update_user(
             )
         password_hash = auth.hash_password(req.password)
         await model.update_password(user_id, password_hash)
+    if req.handle is not None:
+        try:
+            await model.set_user_handle(user_id, req.handle)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
     return {"status": "updated"}
 
 

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -5535,3 +5535,104 @@ class TestOIDCLogout:
             resp = await client.post("/auth/logout", headers=headers)
         assert resp.status_code == 200
         assert "oidc_logout_url" not in resp.json()
+
+
+class TestHandleEndpoints:
+    async def test_change_own_handle(self, client, user):
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/auth/change-handle",
+            json={"handle": "newhandle"},
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "updated"
+        assert data["handle"] == "newhandle"
+        # Verify it actually changed in the DB
+        updated = await model.get_user_by_id(user["id"])
+        assert updated["handle"] == "newhandle"
+
+    async def test_change_handle_invalid_empty(self, client, user):
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/auth/change-handle",
+            json={"handle": ""},
+            headers=headers,
+        )
+        assert resp.status_code == 400
+
+    async def test_change_handle_invalid_chars(self, client, user):
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/auth/change-handle",
+            json={"handle": "BAD HANDLE!"},
+            headers=headers,
+        )
+        assert resp.status_code == 400
+
+    async def test_change_handle_reserved(self, client, user):
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/auth/change-handle",
+            json={"handle": "work"},
+            headers=headers,
+        )
+        assert resp.status_code == 400
+        assert "reserved" in resp.json()["detail"]
+
+    async def test_change_handle_conflict(self, client, admin_user, user):
+        # Set admin_user's handle to something known
+        await model.set_user_handle(admin_user["id"], "taken-handle")
+        # Try to set user's handle to the same
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/auth/change-handle",
+            json={"handle": "taken-handle"},
+            headers=headers,
+        )
+        assert resp.status_code == 400
+        assert "already taken" in resp.json()["detail"]
+
+    async def test_admin_change_user_handle(self, client, admin_user, user):
+        admin_resp = await client.post(
+            "/auth/login",
+            json={"email": "testadmin@example.com", "password": "testpass"},
+        )
+        admin_headers = {
+            "Authorization": f"Bearer {admin_resp.json()['access_token']}"
+        }
+        resp = await client.patch(
+            f"/admin/users/{user['id']}",
+            json={"handle": "admin-set-handle"},
+            headers=admin_headers,
+        )
+        assert resp.status_code == 200
+        updated = await model.get_user_by_id(user["id"])
+        assert updated["handle"] == "admin-set-handle"
+
+    async def test_admin_change_user_handle_invalid(
+        self, client, admin_user, user
+    ):
+        admin_resp = await client.post(
+            "/auth/login",
+            json={"email": "testadmin@example.com", "password": "testpass"},
+        )
+        admin_headers = {
+            "Authorization": f"Bearer {admin_resp.json()['access_token']}"
+        }
+        resp = await client.patch(
+            f"/admin/users/{user['id']}",
+            json={"handle": ""},
+            headers=admin_headers,
+        )
+        assert resp.status_code == 400
+
+    async def test_get_me(self, client, user):
+        headers = await _auth_headers(client)
+        resp = await client.get("/auth/me", headers=headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["id"] == user["id"]
+        assert data["email"] == "testuser@example.com"
+        assert "handle" in data

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -5542,7 +5542,7 @@ class TestHandleEndpoints:
         headers = await _auth_headers(client)
         resp = await client.post(
             "/auth/change-handle",
-            json={"handle": "newhandle"},
+            json={"handle": "newhandle", "password": "testpass"},
             headers=headers,
         )
         assert resp.status_code == 200
@@ -5557,7 +5557,7 @@ class TestHandleEndpoints:
         headers = await _auth_headers(client)
         resp = await client.post(
             "/auth/change-handle",
-            json={"handle": ""},
+            json={"handle": "", "password": "testpass"},
             headers=headers,
         )
         assert resp.status_code == 400
@@ -5566,7 +5566,7 @@ class TestHandleEndpoints:
         headers = await _auth_headers(client)
         resp = await client.post(
             "/auth/change-handle",
-            json={"handle": "BAD HANDLE!"},
+            json={"handle": "BAD HANDLE!", "password": "testpass"},
             headers=headers,
         )
         assert resp.status_code == 400
@@ -5575,7 +5575,7 @@ class TestHandleEndpoints:
         headers = await _auth_headers(client)
         resp = await client.post(
             "/auth/change-handle",
-            json={"handle": "work"},
+            json={"handle": "work", "password": "testpass"},
             headers=headers,
         )
         assert resp.status_code == 400
@@ -5588,11 +5588,20 @@ class TestHandleEndpoints:
         headers = await _auth_headers(client)
         resp = await client.post(
             "/auth/change-handle",
-            json={"handle": "taken-handle"},
+            json={"handle": "taken-handle", "password": "testpass"},
             headers=headers,
         )
         assert resp.status_code == 400
         assert "already taken" in resp.json()["detail"]
+
+    async def test_change_handle_wrong_password(self, client, user):
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/auth/change-handle",
+            json={"handle": "good-handle", "password": "wrongpass"},
+            headers=headers,
+        )
+        assert resp.status_code == 401
 
     async def test_admin_change_user_handle(self, client, admin_user, user):
         admin_resp = await client.post(
@@ -5623,7 +5632,7 @@ class TestHandleEndpoints:
         }
         resp = await client.patch(
             f"/admin/users/{user['id']}",
-            json={"handle": ""},
+            json={"handle": "", "password": "testpass"},
             headers=admin_headers,
         )
         assert resp.status_code == 400

--- a/src/frontend/lib/admin/admin_users_page.dart
+++ b/src/frontend/lib/admin/admin_users_page.dart
@@ -37,14 +37,11 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
 
   void _resolvePermissions() {
     final auth = context.read<AuthService>();
-    _canUsers =
-        auth.hasPermission('/admin', '*') ||
+    _canUsers = auth.hasPermission('/admin', '*') ||
         auth.hasPermission('/admin/users', 'view');
-    _canGroups =
-        auth.hasPermission('/admin', '*') ||
+    _canGroups = auth.hasPermission('/admin', '*') ||
         auth.hasPermission('/admin/groups', 'view');
-    _canInvitations =
-        auth.hasPermission('/admin', '*') ||
+    _canInvitations = auth.hasPermission('/admin', '*') ||
         auth.hasPermission('/admin/invitations', 'view');
   }
 
@@ -221,9 +218,8 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
       builder: (ctx) => StatefulBuilder(
         builder: (ctx, setDialogState) {
           final memberIds = members.map((m) => m['id']).toSet();
-          final nonMembers = allUsers
-              .where((u) => !memberIds.contains(u['id']))
-              .toList();
+          final nonMembers =
+              allUsers.where((u) => !memberIds.contains(u['id'])).toList();
 
           return AlertDialog(
             title: Text('Members of "$groupName"'),
@@ -537,7 +533,10 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
   Future<void> _editUser(Map<String, dynamic> user) async {
     final result = await showDialog<Map<String, String>>(
       context: context,
-      builder: (ctx) => _EditUserDialog(currentEmail: user['email'] as String),
+      builder: (ctx) => _EditUserDialog(
+        currentEmail: user['email'] as String,
+        currentHandle: user['handle'] as String? ?? '',
+      ),
     );
     if (result == null) return;
 
@@ -637,8 +636,8 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
               backgroundColor: isPending
                   ? KColors.accentAmber
                   : status == 'accepted'
-                  ? KColors.accentGreen
-                  : KColors.textMuted,
+                      ? KColors.accentGreen
+                      : KColors.textMuted,
               child: Text(
                 initial,
                 style: const TextStyle(
@@ -690,9 +689,8 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
 
   @override
   Widget build(BuildContext context) {
-    final pendingCount = _invitations
-        .where((i) => i['status'] == 'pending')
-        .length;
+    final pendingCount =
+        _invitations.where((i) => i['status'] == 'pending').length;
     final tabs = <SkeuoTab>[];
     final views = <Widget>[];
     final tabTypes = _tabTypes;
@@ -886,8 +884,12 @@ class _AddUserDialogState extends State<_AddUserDialog> {
 
 class _EditUserDialog extends StatefulWidget {
   final String currentEmail;
+  final String currentHandle;
 
-  const _EditUserDialog({required this.currentEmail});
+  const _EditUserDialog({
+    required this.currentEmail,
+    required this.currentHandle,
+  });
 
   @override
   State<_EditUserDialog> createState() => _EditUserDialogState();
@@ -895,17 +897,20 @@ class _EditUserDialog extends StatefulWidget {
 
 class _EditUserDialogState extends State<_EditUserDialog> {
   late final TextEditingController _emailController;
+  late final TextEditingController _handleController;
   final _passwordController = TextEditingController();
 
   @override
   void initState() {
     super.initState();
     _emailController = TextEditingController(text: widget.currentEmail);
+    _handleController = TextEditingController(text: widget.currentHandle);
   }
 
   @override
   void dispose() {
     _emailController.dispose();
+    _handleController.dispose();
     _passwordController.dispose();
     super.dispose();
   }
@@ -936,6 +941,17 @@ class _EditUserDialogState extends State<_EditUserDialog> {
             ),
             const SizedBox(height: 16),
             TextField(
+              controller: _handleController,
+              decoration: InputDecoration(
+                labelText: 'Handle',
+                labelStyle: labelStyle,
+                floatingLabelStyle: labelStyle,
+                floatingLabelBehavior: FloatingLabelBehavior.always,
+                border: const OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 16),
+            TextField(
               controller: _passwordController,
               decoration: InputDecoration(
                 labelText: 'New Password',
@@ -959,9 +975,11 @@ class _EditUserDialogState extends State<_EditUserDialog> {
         FilledButton(
           onPressed: () {
             final email = _emailController.text.trim();
+            final handle = _handleController.text.trim();
             final password = _passwordController.text;
             if (email.isEmpty) return;
             final result = <String, String>{'email': email};
+            if (handle != widget.currentHandle) result['handle'] = handle;
             if (password.isNotEmpty) result['password'] = password;
             Navigator.pop(context, result);
           },

--- a/src/frontend/lib/admin/admin_users_page.dart
+++ b/src/frontend/lib/admin/admin_users_page.dart
@@ -583,7 +583,21 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
               email: email,
               isAdmin: isAdmin,
             ),
-            title: Text(email),
+            title: Row(
+              children: [
+                Text(email),
+                if ((user['handle'] as String?)?.isNotEmpty == true) ...[
+                  const SizedBox(width: 8),
+                  Text(
+                    '@${user['handle']}',
+                    style: const TextStyle(
+                      color: KColors.textSecondary,
+                      fontSize: 13,
+                    ),
+                  ),
+                ],
+              ],
+            ),
             subtitle: Text(
               groupNames.isEmpty
                   ? 'No groups'

--- a/src/frontend/lib/auth/settings_page.dart
+++ b/src/frontend/lib/auth/settings_page.dart
@@ -36,6 +36,7 @@ class _SettingsPageState extends State<SettingsPage> {
 
   // Handle change
   final _newHandleController = TextEditingController();
+  final _handlePasswordController = TextEditingController();
   final _handleFormKey = GlobalKey<FormState>();
   bool _changingHandle = false;
   String? _handleMessage;
@@ -74,6 +75,7 @@ class _SettingsPageState extends State<SettingsPage> {
     _newEmailController.dispose();
     _emailPasswordController.dispose();
     _newHandleController.dispose();
+    _handlePasswordController.dispose();
     super.dispose();
   }
 
@@ -123,6 +125,28 @@ class _SettingsPageState extends State<SettingsPage> {
 
   Future<void> _changeHandle() async {
     if (!_handleFormKey.currentState!.validate()) return;
+    final newHandle = _newHandleController.text.trim();
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Change Handle?'),
+        content: Text(
+          'Change your handle from @${_currentHandle ?? ''} to @$newHandle?\n\n'
+          'This will affect your terminal home directory and how others see you in chat.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Change'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
     setState(() {
       _changingHandle = true;
       _handleMessage = null;
@@ -134,6 +158,7 @@ class _SettingsPageState extends State<SettingsPage> {
         '/auth/change-handle',
         body: jsonEncode({
           'handle': _newHandleController.text.trim(),
+          'password': _handlePasswordController.text,
         }),
       );
       if (!mounted) return;
@@ -146,6 +171,7 @@ class _SettingsPageState extends State<SettingsPage> {
           _currentHandle = data['handle'] as String?;
         });
         _newHandleController.clear();
+        _handlePasswordController.clear();
       } else {
         final data = jsonDecode(resp.body);
         setState(() {
@@ -391,6 +417,13 @@ class _SettingsPageState extends State<SettingsPage> {
                       letterSpacing: 0.3)),
             ],
           ),
+          if (_currentHandle != null) ...[
+            const SizedBox(height: 12),
+            Text(
+              'Current handle: @$_currentHandle',
+              style: const TextStyle(color: KColors.textSecondary),
+            ),
+          ],
           const SizedBox(height: 16),
           TextFormField(
             controller: _newHandleController,
@@ -409,6 +442,20 @@ class _SettingsPageState extends State<SettingsPage> {
               }
               return null;
             },
+            onFieldSubmitted: (_) => FocusScope.of(context).nextFocus(),
+          ),
+          const SizedBox(height: 12),
+          TextFormField(
+            controller: _handlePasswordController,
+            decoration: InputDecoration(
+              labelText: 'Password (to confirm)',
+              labelStyle: TextStyle(color: KColors.textSecondary),
+              floatingLabelStyle: TextStyle(color: KColors.textSecondary),
+              floatingLabelBehavior: FloatingLabelBehavior.always,
+              border: const OutlineInputBorder(),
+            ),
+            obscureText: true,
+            validator: (v) => v == null || v.isEmpty ? 'Required' : null,
             onFieldSubmitted: (_) => _changeHandle(),
           ),
           if (_handleMessage != null) ...[

--- a/src/frontend/lib/auth/settings_page.dart
+++ b/src/frontend/lib/auth/settings_page.dart
@@ -34,10 +34,36 @@ class _SettingsPageState extends State<SettingsPage> {
   String? _emailMessage;
   bool _emailSuccess = false;
 
+  // Handle change
+  final _newHandleController = TextEditingController();
+  final _handleFormKey = GlobalKey<FormState>();
+  bool _changingHandle = false;
+  String? _handleMessage;
+  bool _handleSuccess = false;
+
+  String? _currentHandle;
+
   @override
   void initState() {
     super.initState();
     setPageTitle('Settings');
+    _fetchCurrentHandle();
+  }
+
+  Future<void> _fetchCurrentHandle() async {
+    final auth = context.read<AuthService>();
+    try {
+      final resp = await auth.authGet('/auth/me');
+      if (!mounted) return;
+      if (resp.statusCode == 200) {
+        final data = jsonDecode(resp.body);
+        setState(() {
+          _currentHandle = data['handle'] as String?;
+        });
+      }
+    } catch (_) {
+      // best-effort
+    }
   }
 
   @override
@@ -47,6 +73,7 @@ class _SettingsPageState extends State<SettingsPage> {
     _confirmPasswordController.dispose();
     _newEmailController.dispose();
     _emailPasswordController.dispose();
+    _newHandleController.dispose();
     super.dispose();
   }
 
@@ -90,6 +117,49 @@ class _SettingsPageState extends State<SettingsPage> {
         _passwordSuccess = false;
         _passwordMessage = 'Network error.';
         _changingPassword = false;
+      });
+    }
+  }
+
+  Future<void> _changeHandle() async {
+    if (!_handleFormKey.currentState!.validate()) return;
+    setState(() {
+      _changingHandle = true;
+      _handleMessage = null;
+    });
+
+    final auth = context.read<AuthService>();
+    try {
+      final resp = await auth.authPost(
+        '/auth/change-handle',
+        body: jsonEncode({
+          'handle': _newHandleController.text.trim(),
+        }),
+      );
+      if (!mounted) return;
+      if (resp.statusCode == 200) {
+        final data = jsonDecode(resp.body);
+        setState(() {
+          _handleSuccess = true;
+          _handleMessage = 'Handle updated.';
+          _changingHandle = false;
+          _currentHandle = data['handle'] as String?;
+        });
+        _newHandleController.clear();
+      } else {
+        final data = jsonDecode(resp.body);
+        setState(() {
+          _handleSuccess = false;
+          _handleMessage = data['detail'] ?? 'Failed to change handle.';
+          _changingHandle = false;
+        });
+      }
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _handleSuccess = false;
+        _handleMessage = 'Network error.';
+        _changingHandle = false;
       });
     }
   }
@@ -167,6 +237,15 @@ class _SettingsPageState extends State<SettingsPage> {
                             fontSize: 20,
                             fontWeight: FontWeight.w700,
                             color: KColors.textSecondary)),
+                    if (_currentHandle != null &&
+                        _currentHandle!.isNotEmpty) ...[
+                      const SizedBox(width: 12),
+                      Text('@$_currentHandle',
+                          style: const TextStyle(
+                              fontSize: 16,
+                              fontWeight: FontWeight.w500,
+                              color: KColors.textSecondary)),
+                    ],
                   ],
                 ),
                 const SizedBox(height: 32),
@@ -174,6 +253,13 @@ class _SettingsPageState extends State<SettingsPage> {
                   child: Padding(
                     padding: const EdgeInsets.all(24),
                     child: _buildPasswordSection(),
+                  ),
+                ),
+                const SizedBox(height: 24),
+                Card(
+                  child: Padding(
+                    padding: const EdgeInsets.all(24),
+                    child: _buildHandleSection(),
                   ),
                 ),
                 const SizedBox(height: 24),
@@ -280,6 +366,72 @@ class _SettingsPageState extends State<SettingsPage> {
                     child: CircularProgressIndicator(strokeWidth: 2),
                   )
                 : const Text('Update Password'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildHandleSection() {
+    return Form(
+      key: _handleFormKey,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Icon(Icons.alternate_email,
+                  size: 18, color: KColors.textSecondary),
+              const SizedBox(width: 8),
+              Text('Change Handle',
+                  style: const TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w700,
+                      color: KColors.textSecondary,
+                      letterSpacing: 0.3)),
+            ],
+          ),
+          const SizedBox(height: 16),
+          TextFormField(
+            controller: _newHandleController,
+            decoration: InputDecoration(
+              labelText: 'New Handle',
+              labelStyle: TextStyle(color: KColors.textSecondary),
+              floatingLabelStyle: TextStyle(color: KColors.textSecondary),
+              floatingLabelBehavior: FloatingLabelBehavior.always,
+              border: const OutlineInputBorder(),
+            ),
+            validator: (v) {
+              if (v == null || v.trim().isEmpty) return 'Required';
+              if (v != v.toLowerCase()) return 'Must be lowercase';
+              if (!RegExp(r'^[a-z0-9._-]+$').hasMatch(v)) {
+                return 'Only lowercase letters, numbers, dots, hyphens, underscores';
+              }
+              return null;
+            },
+            onFieldSubmitted: (_) => _changeHandle(),
+          ),
+          if (_handleMessage != null) ...[
+            const SizedBox(height: 12),
+            Text(
+              _handleMessage!,
+              style: TextStyle(
+                color: _handleSuccess
+                    ? Colors.green
+                    : Theme.of(context).colorScheme.error,
+              ),
+            ),
+          ],
+          const SizedBox(height: 16),
+          FilledButton(
+            onPressed: _changingHandle ? null : _changeHandle,
+            child: _changingHandle
+                ? const SizedBox(
+                    height: 20,
+                    width: 20,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Text('Update Handle'),
           ),
         ],
       ),


### PR DESCRIPTION
## Summary
- `POST /auth/change-handle` endpoint for users to change their own handle
- `GET /auth/me` endpoint returning user profile with handle
- `PATCH /admin/users/{id}` now accepts optional `handle` field
- Settings page shows current handle and allows changing it
- Admin Edit User dialog includes handle field

Closes #526

## Test plan
- [x] Backend tests pass (1367 passed, 100% coverage)
- [x] Frontend tests pass (100% coverage)
- [ ] E2E tests pass on CI