### PR TITLE
fix(agent): skip broadcast on deleted workspace to avoid FK constraint

### DIFF
--- a/src/backend/klangk_backend/agent.py
+++ b/src/backend/klangk_backend/agent.py
@@ -442,6 +442,9 @@ async def _broadcast_agent_disconnect(workspace_id: str) -> None:
 
     if not workspace_id:
         return
+    # Workspace may have been deleted — skip if gone.
+    if await model.get_workspace_by_id(workspace_id) is None:
+        return
     agent_handle = await model.agent_handle()
     agent_email = await model.agent_email()
     sys_msg = await model.add_chat_message(
@@ -471,6 +474,9 @@ async def _broadcast_agent_reconnect(workspace_id: str) -> None:
     from . import wshandler
 
     if not workspace_id:
+        return
+    # Workspace may have been deleted — skip if gone.
+    if await model.get_workspace_by_id(workspace_id) is None:
         return
     agent_handle = await model.agent_handle()
     agent_email = await model.agent_email()

--- a/src/backend/tests/test_agent.py
+++ b/src/backend/tests/test_agent.py
@@ -672,6 +672,12 @@ class TestMonitorProcess:
         with (
             patch.object(
                 model,
+                "get_workspace_by_id",
+                new_callable=AsyncMock,
+                return_value={"id": "ws-mon"},
+            ),
+            patch.object(
+                model,
                 "add_chat_message",
                 new_callable=AsyncMock,
                 return_value={
@@ -697,6 +703,12 @@ class TestMonitorProcess:
 
         # Should not raise when workspace_id is empty
         await _broadcast_agent_disconnect("")
+
+    async def test_broadcast_disconnect_deleted_workspace(self):
+        from klangk_backend.agent import _broadcast_agent_disconnect
+
+        # Should not raise when workspace has been deleted
+        await _broadcast_agent_disconnect("deleted-ws-id")
 
     async def test_stop_cancels_monitor(self):
         session = _make_session()
@@ -825,6 +837,12 @@ class TestMonitorProcess:
         with (
             patch.object(
                 model,
+                "get_workspace_by_id",
+                new_callable=AsyncMock,
+                return_value={"id": "ws-rc"},
+            ),
+            patch.object(
+                model,
                 "add_chat_message",
                 new_callable=AsyncMock,
                 return_value={"id": "m1", "message": "reconnected"},
@@ -846,6 +864,12 @@ class TestMonitorProcess:
         from klangk_backend.agent import _broadcast_agent_reconnect
 
         await _broadcast_agent_reconnect("")
+
+    async def test_broadcast_reconnect_deleted_workspace(self):
+        from klangk_backend.agent import _broadcast_agent_reconnect
+
+        # Should not raise when workspace has been deleted
+        await _broadcast_agent_reconnect("deleted-ws-id")
 
     async def test_monitor_skips_restart_if_already_restarted(self):
         from klangk_backend import model


### PR DESCRIPTION
## Summary
- Check workspace exists before posting agent disconnect/reconnect chat messages
- Prevents `IntegrityError: FOREIGN KEY constraint failed` when workspace is deleted while agent is running

Closes #542

## Test plan
- [x] Backend tests pass (1370 passed, 100% coverage)
- [ ] E2E tests pass on CI