### PR TITLE
feat: add klangkc restart command

### DIFF
--- a/docs/features/sandbox.md
+++ b/docs/features/sandbox.md
@@ -200,9 +200,10 @@ or re-run the setup script. This means:
 - **Setup script changes** are not re-applied automatically. Use
   `--force-setup` to re-run the copy and setup steps on an existing
   workspace.
-- **Config changes** (new mounts, different image) require deleting
-  and recreating the workspace. A warning is shown if the config
-  has changed since creation.
+- **Config changes** (new mounts, different image) require
+  restarting (`klangkc restart myws`) or deleting and recreating
+  the workspace. A warning is shown if the config has changed
+  since creation.
 
 ## Setup scripts
 
@@ -245,9 +246,10 @@ the workspace is left in an inconsistent state. To recover:
 
 - **If your script is idempotent:** re-run with `--force-setup`:
   `klangkc sandbox myws --force-setup`
-- **If not:** delete the workspace and start over
-  (`klangkc rm myws && klangkc sandbox myws`), or create a fresh
-  workspace with a different name (`klangkc sandbox myws-2`).
+- **If not:** restart the container and try again:
+  `klangkc restart myws && klangkc sandbox myws --force-setup`.
+  Or delete the workspace entirely and start over:
+  `klangkc rm myws && klangkc sandbox myws`.
 
 ### Tips
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -38,7 +38,7 @@ klangkc sandbox myws --force-setup       # re-run copy and setup on existing wor
 klangkc exec my-project ls /home/klangk/work         # run a command in the container
 klangkc sync ~/src my-project:/home/klangk/work      # sync files to/from the container
 klangkc rm my-project                # delete a workspace
-klangkc restart my-project           # restart the container (owner only)
+klangkc restart my-project           # restart the container for a workspace (owner only)
 klangkc export my-project            # export workspace to my-project.tar.gz (admin only)
 klangkc export my-project -o bak.tar.gz  # export to specific file
 klangkc import bak.tar.gz            # import workspace from archive

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -38,6 +38,7 @@ klangkc sandbox myws --force-setup       # re-run copy and setup on existing wor
 klangkc exec my-project ls /home/klangk/work         # run a command in the container
 klangkc sync ~/src my-project:/home/klangk/work      # sync files to/from the container
 klangkc rm my-project                # delete a workspace
+klangkc restart my-project           # restart the container (owner only)
 klangkc export my-project            # export workspace to my-project.tar.gz (admin only)
 klangkc export my-project -o bak.tar.gz  # export to specific file
 klangkc import bak.tar.gz            # import workspace from archive

--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -27,6 +27,7 @@ from pydantic import BaseModel
 
 from . import (
     acl,
+    agent,
     auth,
     container,
     emailsvc,
@@ -1191,8 +1192,6 @@ async def restart_workspace(
         if live_state
         else workspace.get("container_id")
     )
-    from . import agent
-
     await agent.stop_session(workspace_id)
     if cid:
         await container.registry.stop_and_remove_container(cid)

--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -1172,6 +1172,31 @@ async def delete_workspace(
     return {"status": "deleted"}
 
 
+@router.post("/workspaces/{workspace_id}/restart")
+async def restart_workspace(
+    workspace_id: str,
+    user: dict = Depends(acl.has_permission("terminal", _workspace_resource)),
+):
+    """Restart a workspace container.
+
+    Stops and removes the running container.  The next WebSocket
+    connect will start a fresh one with the same workspace config.
+    """
+    workspace = await model.get_workspace(workspace_id)
+    if workspace is None:
+        raise HTTPException(status_code=404, detail="Workspace not found")
+    live_state = container.registry.get_state(workspace_id)
+    cid = (
+        live_state.container_id
+        if live_state
+        else workspace.get("container_id")
+    )
+    if cid:
+        await container.registry.stop_and_remove_container(cid)
+    await wshandler.reset_workspace_state(workspace_id)
+    return {"status": "restarted"}
+
+
 # --- Workspace export/import endpoints ---
 
 

--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -1191,6 +1191,9 @@ async def restart_workspace(
         if live_state
         else workspace.get("container_id")
     )
+    from . import agent
+
+    await agent.stop_session(workspace_id)
     if cid:
         await container.registry.stop_and_remove_container(cid)
     await wshandler.reset_workspace_state(workspace_id)

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -903,16 +903,23 @@ class TestWorkspaceRoutes:
         )
         ws_id = create_resp.json()["id"]
 
+        # Simulate a running container so the stop path is exercised.
+        api.container.registry.track_activity("cid-restart", ws_id)
+
         with patch.object(
             api.container.registry,
             "stop_and_remove_container",
             new_callable=AsyncMock,
-        ):
+        ) as mock_stop:
             resp = await client.post(
                 f"/workspaces/{ws_id}/restart", headers=headers
             )
         assert resp.status_code == 200
         assert resp.json()["status"] == "restarted"
+        mock_stop.assert_awaited_once_with("cid-restart")
+
+        # Clean up registry state.
+        api.container.registry.states.pop(ws_id, None)
 
     async def test_restart_not_found(self, client, user):
         headers = await _auth_headers(client)

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -896,6 +896,40 @@ class TestWorkspaceRoutes:
         acl = await model.get_acl_entries(f"/workspaces/{ws_id}")
         assert len(acl) == 0
 
+    async def test_restart_workspace(self, client, user):
+        headers = await _auth_headers(client)
+        create_resp = await client.post(
+            "/workspaces", headers=headers, json={"name": "restart-me"}
+        )
+        ws_id = create_resp.json()["id"]
+
+        with patch.object(
+            api.container.registry,
+            "stop_and_remove_container",
+            new_callable=AsyncMock,
+        ):
+            resp = await client.post(
+                f"/workspaces/{ws_id}/restart", headers=headers
+            )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "restarted"
+
+    async def test_restart_not_found(self, client, user):
+        headers = await _auth_headers(client)
+        fake_id = "fake-restart-id"
+        await model.add_acl_entry(
+            f"/workspaces/{fake_id}",
+            0,
+            model.ACTION_ALLOW,
+            "terminal",
+            model.PRINCIPAL_USER,
+            user_id=user["id"],
+        )
+        resp = await client.post(
+            f"/workspaces/{fake_id}/restart", headers=headers
+        )
+        assert resp.status_code == 404
+
     async def test_list_no_auth(self, client):
         resp = await client.get("/workspaces")
         assert resp.status_code == 401

--- a/src/cli/klangkc/client.py
+++ b/src/cli/klangkc/client.py
@@ -269,9 +269,13 @@ class KlangkClient:
         ws = self.resolve_workspace(name)
         resp = self.delete(f"/workspaces/{ws.id}")
         self._check_auth(resp)
-        if not resp.is_success:
-            logging.error("Failed to delete workspace: %s", resp.text)
-            sys.exit(1)
+        resp.raise_for_status()
+
+    def restart_workspace(self, name: str) -> None:
+        ws = self.resolve_workspace(name)
+        resp = self.post(f"/workspaces/{ws.id}/restart")
+        self._check_auth(resp)
+        resp.raise_for_status()
 
     def export_workspace(
         self,

--- a/src/cli/klangkc/main.py
+++ b/src/cli/klangkc/main.py
@@ -255,6 +255,20 @@ def rm(
     typer.echo(f"Deleted workspace {name}")
 
 
+@app.command("restart")
+def restart(
+    name: str = typer.Argument(..., help="Workspace name"),
+) -> None:
+    """Restart a workspace container."""
+    _require_auth()
+    try:
+        _client().restart_workspace(name)
+    except WorkspaceNotFoundError:
+        _err.print(f"[red]No workspace named[/red] '{name}'")
+        raise typer.Exit(code=1) from None
+    typer.echo(f"Restarted workspace {name}")
+
+
 @app.command("export")
 def export_workspace(
     name: str = typer.Argument(..., help="Workspace name"),

--- a/src/cli/klangkc/main.py
+++ b/src/cli/klangkc/main.py
@@ -259,7 +259,7 @@ def rm(
 def restart(
     name: str = typer.Argument(..., help="Workspace name"),
 ) -> None:
-    """Restart a workspace container."""
+    """Restart the container for a workspace."""
     _require_auth()
     try:
         _client().restart_workspace(name)

--- a/src/cli/tests/test_cli.py
+++ b/src/cli/tests/test_cli.py
@@ -671,7 +671,7 @@ class TestKlangkClient:
                 with pytest.raises(AuthError):
                     client.delete_workspace("ws1")
 
-    def test_delete_workspace_non_200_exits(self):
+    def test_delete_workspace_non_200_raises(self):
         cfg = CLIConfig()
         cfg.auth.token = "token"
         client = KlangkClient(cfg)
@@ -682,11 +682,12 @@ class TestKlangkClient:
         ]
         del_resp = MagicMock()
         del_resp.status_code = 500
-        del_resp.text = "Server error"
-        del_resp.is_success = False
+        del_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "500", request=MagicMock(), response=MagicMock()
+        )
         with patch.object(client, "get", return_value=list_resp):
             with patch.object(client, "delete", return_value=del_resp):
-                with pytest.raises(SystemExit):
+                with pytest.raises(httpx.HTTPStatusError):
                     client.delete_workspace("ws1")
 
     def test_no_token_uses_empty_string(self):

--- a/src/cli/tests/test_cli_integration.py
+++ b/src/cli/tests/test_cli_integration.py
@@ -1058,6 +1058,34 @@ class TestClientLines:
                 with pytest.raises(httpx.HTTPStatusError):
                     client.delete_workspace("ws1")
 
+    def test_restart_workspace_calls_post(self):
+
+        from klangkc.client import KlangkClient
+
+        cfg = CLIConfig()
+        cfg.auth.token = "tok"
+        client = KlangkClient(cfg)
+
+        list_resp = MagicMock()
+        list_resp.status_code = 200
+        list_resp.json.return_value = [
+            {
+                "id": "ws1",
+                "name": "ws1",
+                "created_at": "2025-01-01T00:00:00Z",
+            }
+        ]
+        restart_resp = MagicMock()
+        restart_resp.status_code = 200
+
+        with patch.object(client, "get", return_value=list_resp):
+            with patch.object(
+                client, "post", return_value=restart_resp
+            ) as mock_post:
+                client.restart_workspace("ws1")
+
+        mock_post.assert_called_once_with("/workspaces/ws1/restart")
+
 
 class TestImagesCommand:
     def test_images_lists_allowed(self, monkeypatch):

--- a/src/cli/tests/test_cli_integration.py
+++ b/src/cli/tests/test_cli_integration.py
@@ -1033,7 +1033,9 @@ class TestAuthLines:
 
 
 class TestClientLines:
-    def test_delete_workspace_500_exit(self):
+    def test_delete_workspace_500_raises(self):
+        import httpx
+
         from klangkc.client import KlangkClient
 
         cfg = CLIConfig()
@@ -1047,12 +1049,13 @@ class TestClientLines:
         ]
         del_resp = MagicMock()
         del_resp.status_code = 500
-        del_resp.text = "server error"
-        del_resp.is_success = False
+        del_resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "500", request=MagicMock(), response=MagicMock()
+        )
 
         with patch.object(client, "get", return_value=list_resp):
             with patch.object(client, "delete", return_value=del_resp):
-                with pytest.raises(SystemExit):
+                with pytest.raises(httpx.HTTPStatusError):
                     client.delete_workspace("ws1")
 
 

--- a/src/cli/tests/test_cli_main.py
+++ b/src/cli/tests/test_cli_main.py
@@ -301,6 +301,29 @@ class TestMainCLI:
         with pytest.raises(typer.Exit):
             main.rm("nope")
 
+    def test_restart_workspace(self, logged_in_cfg, monkeypatch):
+        from klangkc import main
+
+        client = MagicMock()
+        monkeypatch.setattr(main, "_client", lambda: client)
+
+        with patch("typer.echo"):
+            main.restart("my-ws")
+        client.restart_workspace.assert_called_once_with("my-ws")
+
+    def test_restart_workspace_not_found(self, logged_in_cfg, monkeypatch):
+        import typer
+
+        from klangkc.client import WorkspaceNotFoundError
+        from klangkc import main
+
+        client = MagicMock()
+        client.restart_workspace.side_effect = WorkspaceNotFoundError("nope")
+        monkeypatch.setattr(main, "_client", lambda: client)
+
+        with pytest.raises(typer.Exit):
+            main.restart("nope")
+
     def test_shell_requires_auth(self, tmp_path, monkeypatch):
         import typer
         from klangkc import main

--- a/uv.lock
+++ b/uv.lock
@@ -690,6 +690,7 @@ name = "klangkc"
 source = { editable = "src/cli" }
 dependencies = [
     { name = "httpx" },
+    { name = "pyyaml" },
     { name = "tomli-w" },
     { name = "typer" },
     { name = "websockets" },
@@ -710,6 +711,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.0.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "tomli-w", specifier = ">=1.0.0" },
     { name = "typer", extras = ["all"], specifier = ">=0.12.0" },
     { name = "websockets", specifier = ">=14.0" },


### PR DESCRIPTION
Closes #538

## Summary
- Add `POST /workspaces/{workspace_id}/restart` REST endpoint — stops and removes the container so the next connect starts fresh
- Add `klangkc restart <workspace>` CLI command
- Replace `sys.exit(1)` with `raise_for_status()` in client delete/restart methods

## Test plan
- [ ] `klangkc restart my-workspace` stops the container
- [ ] Next `klangkc shell` or `klangkc sandbox` starts a fresh container
- [ ] `klangkc restart nonexistent` shows error

🤖 Generated with [Claude Code](https://claude.com/claude-code)