### PR TITLE
fix(security): add ACL check to exec_start WebSocket command

### DIFF
--- a/src/backend/klangk_backend/wshandler.py
+++ b/src/backend/klangk_backend/wshandler.py
@@ -1705,6 +1705,9 @@ class Connection:
     async def handle_exec_start(self, msg: dict) -> None:
         if not self.container_id:
             return
+        if not await self._has_perm("code-in-isolation"):
+            send_error(self.sock, "exec requires code-in-isolation permission")
+            return
         await self.stop_exec()
         command = msg.get("command", [])
         if not command:

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -1949,11 +1949,26 @@ class TestExecHandlers:
         await conn.handle_exec_start({"command": ["ls"]})
         assert conn.exec_session is None
 
+    async def test_exec_start_no_perm(self):
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock)
+        conn.container_id = "cid"
+        with patch.object(
+            conn, "_has_perm", new=AsyncMock(return_value=False)
+        ):
+            await conn.handle_exec_start({"command": ["ls"]})
+        sock.send_json.assert_called()
+        assert "code-in-isolation" in sock.send_json.call_args[0][0].get(
+            "message", ""
+        )
+        assert conn.exec_session is None
+
     async def test_exec_start_no_command(self):
         sock = _mock_sock()
         conn = _base_conn(ws=sock)
         conn.container_id = "cid"
-        await conn.handle_exec_start({"command": []})
+        with patch.object(conn, "_has_perm", new=AsyncMock(return_value=True)):
+            await conn.handle_exec_start({"command": []})
         sock.send_json.assert_called()
         assert "command" in sock.send_json.call_args[0][0].get("message", "")
 
@@ -1975,7 +1990,10 @@ class TestExecHandlers:
             return_value=mock_session,
         ):
             with patch.object(container.registry, "record_activity"):
-                await conn.handle_exec_start({"command": ["ls"]})
+                with patch.object(
+                    conn, "_has_perm", new=AsyncMock(return_value=True)
+                ):
+                    await conn.handle_exec_start({"command": ["ls"]})
         assert conn.exec_session is mock_session
         assert conn.exec_task is not None
         conn.exec_task.cancel()


### PR DESCRIPTION
## Summary

- Add `code-in-isolation` ACL check to `exec_start` WebSocket command, matching the existing check in `terminal_start`
- Without this, any authenticated user (including spectators) could execute arbitrary commands in a workspace container via `exec_start`

Closes #509

## Test plan

- [x] New test `test_exec_start_no_perm` verifies denied users get an error
- [x] Existing exec tests updated to mock the permission check
- [x] Full backend test suite passes (1370 tests, 100% coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)