### PR TITLE
ci: add CodeQL security scanning workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,25 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: python
+
+      - uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## Summary

- Add CodeQL GitHub Action to run security analysis on Python code
- Triggers on PRs to main and pushes to main
- Results appear in the repo's Security tab

Closes #549

## Test plan

- [ ] PR triggers the CodeQL workflow
- [ ] Results visible in Security > Code scanning alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)