### PR TITLE
fix: resolve symlinks in mount path validation

### DIFF
--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -67,7 +67,7 @@ _allowed_mount_roots_env = util.resolve_env_secret(
     "KLANGK_ALLOWED_MOUNT_ROOTS", ""
 )
 ALLOWED_MOUNT_ROOTS: list[str] = [
-    os.path.normpath(p)
+    os.path.realpath(p.strip())
     for p in _allowed_mount_roots_env.split(",")
     if p.strip()
 ]
@@ -85,17 +85,21 @@ def _is_named_volume(source: str) -> bool:
 
 
 def _is_protected(source: str) -> bool:
-    """True if source is a protected host path that must never be mounted."""
-    norm = os.path.normpath(source)
-    data_dir = os.path.normpath(
+    """True if source is a protected host path that must never be mounted.
+
+    Uses ``os.path.realpath`` to resolve symlinks — a symlink pointing
+    to a protected path (e.g. Docker socket) is still blocked.
+    """
+    resolved = os.path.realpath(source)
+    data_dir = os.path.realpath(
         util.resolve_env_secret(
             "KLANGK_DATA_DIR", os.path.expanduser("~/.klangk/data")
         )
         or os.path.expanduser("~/.klangk/data")
     )
     for blocked in [*_PROTECTED_PATHS, data_dir]:
-        blocked = os.path.normpath(blocked)
-        if norm == blocked or norm.startswith(blocked + "/"):
+        blocked = os.path.realpath(blocked)
+        if resolved == blocked or resolved.startswith(blocked + "/"):
             return True
     return False
 
@@ -124,9 +128,9 @@ def validate_mount_spec(spec: str) -> str | None:
         if _is_protected(source):
             return f"Invalid mount {spec!r}: source is a protected host path"
         if ALLOWED_MOUNT_ROOTS:
-            norm = os.path.normpath(source)
+            resolved = os.path.realpath(source)
             if not any(
-                norm == root or norm.startswith(root + "/")
+                resolved == root or resolved.startswith(root + "/")
                 for root in ALLOWED_MOUNT_ROOTS
             ):
                 allowed = ", ".join(ALLOWED_MOUNT_ROOTS)

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -3,6 +3,7 @@
 import asyncio
 import time
 from contextlib import ExitStack, contextmanager
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
@@ -997,6 +998,59 @@ class TestProtectedPaths:
         )
         assert err is not None
         assert "protected" in err.lower()
+
+    def test_symlink_to_protected_path_blocked(self, tmp_path):
+        """Symlinks to protected paths are resolved and blocked."""
+        link = tmp_path / "sneaky-sock"
+        link.symlink_to("/var/run/docker.sock")
+        err = container.validate_mount_spec(f"{link}:/mnt/sock")
+        assert err is not None
+        assert "protected" in err.lower()
+
+    def test_symlink_to_allowed_root_passes(self, monkeypatch):
+        """Symlinks resolved to an allowed root pass validation."""
+        import tempfile
+
+        # Use a separate temp dir so it doesn't overlap with the
+        # KLANGK_DATA_DIR that conftest sets to tmp_path.
+        with tempfile.TemporaryDirectory(prefix="mount-test-") as d:
+            d = Path(d)
+            allowed = d / "allowed"
+            allowed.mkdir()
+            target = allowed / "data"
+            target.mkdir()
+            link = d / "link-to-data"
+            link.symlink_to(str(target))
+
+            monkeypatch.setattr(
+                container,
+                "ALLOWED_MOUNT_ROOTS",
+                [str(allowed)],
+            )
+            err = container.validate_mount_spec(f"{link}:/mnt/data")
+            assert err is None
+
+    def test_symlink_outside_allowed_root_blocked(self, monkeypatch):
+        """Symlinks resolving outside allowed roots are blocked."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory(prefix="mount-test-") as d:
+            d = Path(d)
+            allowed = d / "allowed"
+            allowed.mkdir()
+            outside = d / "outside"
+            outside.mkdir()
+            link = d / "link-to-outside"
+            link.symlink_to(str(outside))
+
+            monkeypatch.setattr(
+                container,
+                "ALLOWED_MOUNT_ROOTS",
+                [str(allowed)],
+            )
+            err = container.validate_mount_spec(f"{link}:/mnt/data")
+            assert err is not None
+            assert "allowed root" in err.lower()
 
 
 class TestExtraMountsVolumeCreation:


### PR DESCRIPTION
Closes #508

## Summary
- Replace `os.path.normpath` with `os.path.realpath` in `_is_protected()` and `ALLOWED_MOUNT_ROOTS` validation
- A symlink pointing to a protected path (e.g. Docker socket) is now blocked
- A symlink resolving outside an allowed mount root is now blocked
- `ALLOWED_MOUNT_ROOTS` values are also resolved with `realpath` at init time

## Test plan
- [ ] Symlink to `/var/run/docker.sock` is blocked
- [ ] Symlink resolving to an allowed root passes
- [ ] Symlink resolving outside allowed roots is blocked
- [ ] All existing mount validation tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)