### PR TITLE
refactor: remove function-scope imports

### DIFF
--- a/src/backend/klangk_backend/acl.py
+++ b/src/backend/klangk_backend/acl.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from fastapi import Depends, HTTPException, Request
 
-from . import model
+from . import auth, model
 from .model import (
     ACTION_ALLOW,
     PRINCIPAL_GROUP,
@@ -98,7 +98,6 @@ def has_permission(permission: str, resource_fn=None):
     resource_fn: optional async callable(request, user) -> resource_path.
     If not provided, the resource is derived from the request URL path.
     """
-    from . import auth
 
     async def check(
         request: Request, user: dict = Depends(auth.get_current_user)

--- a/src/backend/klangk_backend/agent.py
+++ b/src/backend/klangk_backend/agent.py
@@ -10,7 +10,7 @@ import json
 import logging
 import re
 
-from . import podman
+from . import model, podman, workspaces
 
 _THINK_RE = re.compile(r"<think>.*?</think>\s*", re.DOTALL)
 
@@ -49,6 +49,10 @@ class AgentSetupError(AgentError):
 # Registry of active agent sessions keyed by workspace ID.
 _agents: dict[str, "AgentSession"] = {}
 
+# Callback to get a workspace session for broadcasting.
+# Set by wshandler at import time to break the circular dependency.
+_get_workspace_session = None
+
 
 class AgentSession:
     """Wraps a ``pi --mode rpc`` subprocess inside a container."""
@@ -71,13 +75,8 @@ class AgentSession:
         path, e.g. ``/home/MrBoops``.
         """
         if self._home_ready:
-            from . import model
-
             handle = await model.agent_handle()
             return f"/home/{handle}"
-
-        from . import model
-        from . import workspaces
 
         ws = await model.get_workspace_by_id(self.workspace_id)
         if not ws:
@@ -129,7 +128,6 @@ class AgentSession:
     async def _ensure_started(self) -> asyncio.subprocess.Process:
         if self._proc is not None and self._proc.returncode is None:
             return self._proc
-        from . import model
 
         container_home = await self._ensure_home()
         agent_handle = await model.agent_handle()
@@ -437,9 +435,6 @@ async def stop_session(workspace_id: str) -> None:
 
 async def _broadcast_agent_disconnect(workspace_id: str) -> None:
     """Broadcast a disconnect system message when the agent process dies."""
-    from . import model
-    from . import wshandler
-
     if not workspace_id:
         return
     # Workspace may have been deleted — skip if gone.
@@ -454,7 +449,11 @@ async def _broadcast_agent_disconnect(workspace_id: str) -> None:
         f"{agent_handle} has disconnected",
         message_type=model.MSG_SYSTEM,
     )
-    session = wshandler.state.get_session(workspace_id)
+    session = (
+        _get_workspace_session(workspace_id)
+        if _get_workspace_session
+        else None
+    )
     if session:
         session.broadcast({"type": "agent_thinking", "thinking": False})
         session.broadcast({"type": "chat_message", **sys_msg})
@@ -470,9 +469,6 @@ async def _broadcast_agent_disconnect(workspace_id: str) -> None:
 
 async def _broadcast_agent_reconnect(workspace_id: str) -> None:
     """Broadcast a reconnect system message after auto-restart."""
-    from . import model
-    from . import wshandler
-
     if not workspace_id:
         return
     # Workspace may have been deleted — skip if gone.
@@ -487,7 +483,11 @@ async def _broadcast_agent_reconnect(workspace_id: str) -> None:
         f"{agent_handle} has reconnected",
         message_type=model.MSG_SYSTEM,
     )
-    session = wshandler.state.get_session(workspace_id)
+    session = (
+        _get_workspace_session(workspace_id)
+        if _get_workspace_session
+        else None
+    )
     if session:
         session.broadcast({"type": "chat_message", **sys_msg})
         session.broadcast(

--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -7,6 +7,7 @@ import logging
 import os
 import posixpath
 import secrets
+import shutil
 from sqlalchemy.exc import IntegrityError as SAIntegrityError
 import subprocess
 import tempfile
@@ -34,6 +35,7 @@ from . import (
     files,
     oidc,
     plugins,
+    podman,
     wshandler,
     model,
     workspaces,
@@ -888,8 +890,6 @@ async def list_images(_user: dict = Depends(auth.get_current_user)):
 
 @router.get("/volumes")
 async def list_volumes(user: dict = Depends(auth.get_current_user)):
-    from . import podman
-
     volumes = await podman.list_volumes(
         f"klangk.instance={container.INSTANCE_ID}"
     )
@@ -913,8 +913,6 @@ async def create_volume(
     body: CreateVolumeRequest,
     user: dict = Depends(auth.get_current_user),
 ):
-    from . import podman
-
     if await podman.inspect_volume(body.name) is not None:
         raise HTTPException(
             status_code=409, detail=f"Volume {body.name!r} already exists"
@@ -934,8 +932,6 @@ async def create_volume(
 async def delete_volume(
     name: str, user: dict = Depends(auth.get_current_user)
 ):
-    from . import podman
-
     info = await podman.inspect_volume(name)
     if info is None:
         raise HTTPException(status_code=404, detail="Volume not found")
@@ -1266,8 +1262,6 @@ async def export_workspace(
                 yield chunk
             await proc.wait()
         finally:
-            import shutil
-
             shutil.rmtree(tmpdir, ignore_errors=True)
 
     safe_name = ws_name.replace("/", "_").replace("\\", "_")

--- a/src/backend/klangk_backend/dockerexec.py
+++ b/src/backend/klangk_backend/dockerexec.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 from collections.abc import AsyncGenerator
 
+from . import podman
 from .util import BoundedOutputQueue
 
 logger = logging.getLogger(__name__)
@@ -25,8 +26,6 @@ class ExecSession:
 
     async def start(self, command: list[str]) -> None:
         """Start a command via podman exec with piped stdin/stdout."""
-        from . import podman
-
         env_flags: list[str] = []
         work_dir = "/home/work"
         if self.user_home is not None:

--- a/src/backend/klangk_backend/emailsvc.py
+++ b/src/backend/klangk_backend/emailsvc.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import shutil
 from email.message import EmailMessage
 
 import aiosmtplib
@@ -69,8 +70,6 @@ async def send_via_smtp(msg: EmailMessage) -> None:
 async def send_via_sendmail(msg: EmailMessage) -> None:
     sendmail = resolve_env_secret("KLANGK_SENDMAIL_PATH", "sendmail")
     logger.info("Using sendmail at: %s", sendmail)
-    import shutil
-
     resolved = shutil.which(sendmail)
     logger.info("Resolved sendmail path: %s", resolved)
     proc = await asyncio.create_subprocess_exec(

--- a/src/backend/klangk_backend/files.py
+++ b/src/backend/klangk_backend/files.py
@@ -1,5 +1,6 @@
 """File operations on workspace home directories (host-side mount)."""
 
+import shutil
 from pathlib import Path
 
 from . import workspaces
@@ -63,8 +64,6 @@ def delete_path(user_id: str, workspace_id: str, relative_path: str) -> str:
     if not path.exists():
         raise FileNotFoundError("Path not found")
     if path.is_dir():
-        import shutil
-
         shutil.rmtree(path)
     else:
         path.unlink()

--- a/src/backend/klangk_backend/model.py
+++ b/src/backend/klangk_backend/model.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import logging
 import re
@@ -169,6 +170,9 @@ MSG_SYSTEM = 2
 # Agent identity
 AGENT_USER_ID = "00000000-0000-0000-0000-000000000001"
 
+# Must match the DB default and container.DEFAULT_PORTS_PER_WORKSPACE.
+_DEFAULT_PORTS_PER_WORKSPACE = 5
+
 # Cached agent user dict (populated after seeding).
 _agent_user_cache: dict | None = None
 
@@ -276,7 +280,7 @@ async def init_db() -> None:
                 user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
                 name TEXT NOT NULL,
                 container_id TEXT,
-                num_ports INTEGER NOT NULL DEFAULT 5,  -- see container.DEFAULT_PORTS_PER_WORKSPACE
+                num_ports INTEGER NOT NULL DEFAULT 5,
                 image TEXT,  -- custom container image; NULL means use default
                 default_command TEXT,  -- auto-run in terminal on connect
                 mounts TEXT,  -- JSON array of host:container mount specs
@@ -436,8 +440,6 @@ async def _unique_handle(db, base: str) -> str:
 
 
 def _hash_fallback_handle(base: str) -> str:  # pragma: no cover
-    import hashlib
-
     suffix = hashlib.sha256(base.encode()).hexdigest()[:8]
     return f"{base[: _MAX_HANDLE_LEN - 9]}-{suffix}"
 
@@ -1103,8 +1105,6 @@ async def create_workspace(
                 created_at,
             ),
         )
-        from . import container
-
         return {
             "id": workspace_id,
             "user_id": user_id,
@@ -1113,7 +1113,7 @@ async def create_workspace(
             "default_command": default_command,
             "mounts": mounts,
             "env": env,
-            "num_ports": container.DEFAULT_PORTS_PER_WORKSPACE,
+            "num_ports": _DEFAULT_PORTS_PER_WORKSPACE,
             "created_at": created_at,
         }
 

--- a/src/backend/klangk_backend/oidc.py
+++ b/src/backend/klangk_backend/oidc.py
@@ -17,6 +17,7 @@ from urllib.parse import urlencode
 import httpx
 from jose import jwt as jose_jwt
 
+from . import model
 from .util import resolve_env_secret, resolve_file_secret
 
 logger = logging.getLogger(__name__)
@@ -429,8 +430,6 @@ async def sync_oidc_groups(
     groups: set[str],
 ) -> None:
     """Sync group memberships from the login hook result."""
-    from . import model
-
     # Resolve group names to IDs, auto-creating missing groups
     desired_ids: set[str] = set()
     for name in groups:

--- a/src/backend/klangk_backend/terminal.py
+++ b/src/backend/klangk_backend/terminal.py
@@ -10,6 +10,7 @@ podman with ``SIGWINCH`` so it resizes the container PTY.
 import asyncio
 import codecs
 import fcntl
+import json
 import logging
 import os
 import pty
@@ -409,8 +410,6 @@ async def load_workspace_state(container_id: str) -> dict:
     if proc.returncode != 0:
         return {}
     try:
-        import json
-
         return json.loads(stdout.decode("utf-8", errors="replace"))
     except (json.JSONDecodeError, ValueError):
         return {}
@@ -425,8 +424,6 @@ async def save_workspace_state(container_id: str, state: dict) -> None:
     Uses ``mktemp`` inside the container so the temp file is created with
     ``O_EXCL``, preventing symlink-following attacks.
     """
-    import json
-
     data = json.dumps(state, indent=2)
     # mktemp creates a file safely (O_EXCL); cat writes into it; mv renames
     # atomically; trap ensures cleanup on any failure.

--- a/src/backend/klangk_backend/workspaces.py
+++ b/src/backend/klangk_backend/workspaces.py
@@ -7,7 +7,7 @@ import shutil
 import tempfile
 from pathlib import Path
 
-from . import container, model
+from . import container, model, podman
 from .util import resolve_env_secret
 
 logger = logging.getLogger(__name__)
@@ -357,8 +357,6 @@ async def populate_home_skel(
     Linux distributions (notable exception: NixOS).  The workspace
     container runs Ubuntu, which always has it.
     """
-    from . import podman
-
     home = f"/home/.users/{user_id}"
     argv = [
         "exec",

--- a/src/backend/klangk_backend/wshandler.py
+++ b/src/backend/klangk_backend/wshandler.py
@@ -12,7 +12,8 @@ from datetime import datetime, timedelta, timezone
 
 from fastapi import WebSocket, WebSocketDisconnect
 
-from . import auth, container, model, podman, workspaces
+from . import acl as _acl
+from . import agent, auth, container, model, podman, terminal, workspaces
 from .util import derive_hosting_info, resolve_env_secret
 from .dockerexec import ExecSession
 from .terminal import TerminalSession, attach_browser
@@ -559,6 +560,11 @@ class WebSocketState:
 
 state = WebSocketState()
 
+# Wire up the agent broadcast callback so agent.py can broadcast
+# to WebSocket sessions without importing wshandler (breaking the
+# agent ↔ wshandler circular dependency).
+agent._get_workspace_session = state.get_session
+
 
 async def _get_presence_list(workspace_id: str) -> list[dict]:
     """Return deduplicated list of users connected to a workspace."""
@@ -579,7 +585,6 @@ async def _get_presence_list(workspace_id: str) -> list[dict]:
                 }
             )
     # Include agent only if its RPC process is alive.
-    from . import agent  # pragma: no cover
 
     if agent.any_running():  # pragma: no cover
         agent_user = await model.get_agent_user()
@@ -755,8 +760,6 @@ class Connection:
         if not workspace_id:
             send_error(self.sock, "Missing workspaceId")
             return
-
-        from . import acl as _acl
 
         principals = await _acl.get_principals(self.user["id"])
         if not await _acl.check_permission(
@@ -955,15 +958,13 @@ class Connection:
         # when the container restarts.
         session = state.get_session(workspace_id)
         if session:
-            from .terminal import save_workspace_state
-
             snapshot = {
                 uid: [dict(w) for w in wins]
                 for uid, wins in session.terminal_windows.items()
             }
             if snapshot:
                 try:
-                    await save_workspace_state(container_id, snapshot)
+                    await terminal.save_workspace_state(container_id, snapshot)
                 except Exception as e:
                     logger.warning("State save before shutdown failed: %s", e)
 
@@ -1010,9 +1011,7 @@ class Connection:
             return
         # Debounce: if the last terminal start was very recent, skip.
         # This prevents rapid retry loops when the PTY exits immediately.
-        import time as _time
-
-        now = _time.monotonic()
+        now = time.monotonic()
         if hasattr(self, "_last_terminal_start"):
             if now - self._last_terminal_start < 2.0:
                 logger.warning(
@@ -1092,12 +1091,6 @@ class Connection:
                     return
                 conn.sock.send_json({"type": "terminal_started"})
                 try:
-                    from .terminal import (
-                        list_windows,
-                        load_workspace_state,
-                        restore_windows,
-                    )
-
                     sname = conn._tmux_session_name()
                     user_id = conn.user["id"]
                     ws_session = state.get_session(conn.workspace_id)
@@ -1108,10 +1101,12 @@ class Connection:
                         ws_session
                         and user_id not in ws_session.terminal_windows
                     ):
-                        saved = await load_workspace_state(conn.container_id)
+                        saved = await terminal.load_workspace_state(
+                            conn.container_id
+                        )
                         if user_id in saved:
                             saved_windows = saved[user_id]
-                            await restore_windows(
+                            await terminal.restore_windows(
                                 conn.container_id, sname, saved_windows
                             )
                             ws_session.terminal_windows[user_id] = (
@@ -1124,7 +1119,9 @@ class Connection:
                                         uid, wins
                                     )
 
-                    windows = await list_windows(conn.container_id, sname)
+                    windows = await terminal.list_windows(
+                        conn.container_id, sname
+                    )
                     conn._sync_terminal_windows(windows)
                     conn.sock.send_json(
                         {
@@ -1186,9 +1183,7 @@ class Connection:
         await attach_browser(self.container_id, browser_id)
 
     async def handle_terminal_input(self, msg: dict) -> None:
-        import time as _time
-
-        t0 = _time.monotonic()
+        t0 = time.monotonic()
         session = self.terminal_session
         if session is None or not session.is_alive:
             logger.warning("terminal_input: no session or not alive")
@@ -1207,7 +1202,7 @@ class Connection:
             return
         container.registry.record_activity(self.container_id)
         await session.write(data)
-        elapsed = _time.monotonic() - t0
+        elapsed = time.monotonic() - t0
         if elapsed > 0.1:  # pragma: no cover
             logger.warning("terminal_input SLOW: %.3fs", elapsed)
 
@@ -1271,22 +1266,19 @@ class Connection:
         self._save_state_snapshot(ws_session)
 
     async def handle_terminal_new_window(self, msg: dict) -> None:
-        import time as _time
-
-        t0 = _time.monotonic()
+        t0 = time.monotonic()
         if not self.container_id or not self._user_home:
             return
-        from .terminal import new_window
 
         session_name = self._tmux_session_name()
         name = msg.get("name")
         try:
-            windows = await new_window(
+            windows = await terminal.new_window(
                 self.container_id, session_name, name=name
             )
             logger.info(
                 "handle_terminal_new_window: %.3fs",
-                _time.monotonic() - t0,
+                time.monotonic() - t0,
             )
             self._sync_terminal_windows(windows)
             self.sock.send_json(
@@ -1296,21 +1288,20 @@ class Connection:
             send_error(self.sock, f"Failed to create window: {e}")
 
     async def handle_terminal_select_window(self, msg: dict) -> None:
-        import time as _time
-
-        t0 = _time.monotonic()
+        t0 = time.monotonic()
         if not self.container_id or not self._user_home:
             return
-        from .terminal import select_window
 
         session_name = self._tmux_session_name()
         index = msg.get("index", 0)
         try:
-            await select_window(self.container_id, session_name, index)
+            await terminal.select_window(
+                self.container_id, session_name, index
+            )
             logger.info(
                 "handle_terminal_select_window: index=%s %.3fs",
                 index,
-                _time.monotonic() - t0,
+                time.monotonic() - t0,
             )
         except Exception as e:
             send_error(self.sock, f"Failed to select window: {e}")
@@ -1318,12 +1309,11 @@ class Connection:
     async def handle_terminal_close_window(self, msg: dict) -> None:
         if not self.container_id or not self._user_home:
             return
-        from .terminal import close_window
 
         session_name = self._tmux_session_name()
         index = msg.get("index", 0)
         try:
-            windows = await close_window(
+            windows = await terminal.close_window(
                 self.container_id, session_name, index
             )
             self._sync_terminal_windows(windows)
@@ -1336,7 +1326,6 @@ class Connection:
     async def handle_terminal_rename_window(self, msg: dict) -> None:
         if not self.container_id or not self._user_home:
             return
-        from .terminal import list_windows, rename_window
 
         session_name = self._tmux_session_name()
         index = msg.get("index", 0)
@@ -1345,8 +1334,12 @@ class Connection:
             send_error(self.sock, "Name required")
             return
         try:
-            await rename_window(self.container_id, session_name, index, name)
-            windows = await list_windows(self.container_id, session_name)
+            await terminal.rename_window(
+                self.container_id, session_name, index, name
+            )
+            windows = await terminal.list_windows(
+                self.container_id, session_name
+            )
             self._sync_terminal_windows(windows)
             self.sock.send_json(
                 {"type": "terminal_windows", "windows": windows}
@@ -1357,11 +1350,12 @@ class Connection:
     async def handle_terminal_list_windows(self) -> None:
         if not self.container_id or not self._user_home:
             return
-        from .terminal import list_windows
 
         session_name = self._tmux_session_name()
         try:
-            windows = await list_windows(self.container_id, session_name)
+            windows = await terminal.list_windows(
+                self.container_id, session_name
+            )
             self.sock.send_json(
                 {"type": "terminal_windows", "windows": windows}
             )
@@ -1370,8 +1364,6 @@ class Connection:
 
     async def _has_perm(self, perm: str) -> bool:
         """Check if the connected user has a workspace permission."""
-        from . import acl as _acl
-
         if not self.workspace_id:
             return False
         principals = await _acl.get_principals(self.user["id"])
@@ -1410,7 +1402,6 @@ class Connection:
         if not await self._has_perm("share-terminals"):
             send_error(self.sock, "Permission denied")
             return
-        from .terminal import kill_joiner_sessions
 
         window_id = msg.get("window_id", "")
         if not window_id:
@@ -1429,7 +1420,9 @@ class Connection:
         match["shared"] = False
         # Kick spectators/collaborators
         try:
-            await kill_joiner_sessions(self.container_id, session_name)
+            await terminal.kill_joiner_sessions(
+                self.container_id, session_name
+            )
         except Exception:
             logger.debug("Failed to kill joiner sessions", exc_info=True)
         ws_session.broadcast(
@@ -1517,12 +1510,10 @@ class Connection:
                 # specifically so the active window changes for the
                 # joiner, not the group owner.  Fall back to bare @N
                 # if the session isn't ready yet (race on rapid joins).
-                from .terminal import tmux_command
-
                 joiner_session = session._tmux_session_name
                 if joiner_session:
                     try:
-                        await tmux_command(
+                        await terminal.tmux_command(
                             conn.container_id,
                             joiner_session,
                             [
@@ -1533,15 +1524,11 @@ class Connection:
                         )
                     except RuntimeError:
                         # Joiner session not ready — fall back to bare @N
-                        from .terminal import select_window
-
-                        await select_window(
+                        await terminal.select_window(
                             conn.container_id, owner_user_id, window_id
                         )
                 else:
-                    from .terminal import select_window
-
-                    await select_window(
+                    await terminal.select_window(
                         conn.container_id, owner_user_id, window_id
                     )
                 if not await conn._activate_session(session, cols, rows):
@@ -1597,7 +1584,6 @@ class Connection:
         Uses the session's _save_lock so concurrent saves don't overlap.
         """
         return  # temporarily disabled for debugging
-        from .terminal import save_workspace_state
 
         container_id = self.container_id
         # Snapshot the state now — the dict may mutate before the task runs.
@@ -1608,7 +1594,7 @@ class Connection:
 
         async def _do_save() -> None:
             async with ws_session._save_lock:
-                await save_workspace_state(container_id, snapshot)
+                await terminal.save_workspace_state(container_id, snapshot)
 
         asyncio.create_task(_do_save())
 
@@ -1626,10 +1612,8 @@ class Connection:
             send_error(self.sock, "Name required")
             return
         session_name = self._tmux_session_name()
-        from .terminal import new_window
-
         try:
-            windows = await new_window(
+            windows = await terminal.new_window(
                 self.container_id, session_name, name=name
             )
         except Exception as e:
@@ -1657,7 +1641,6 @@ class Connection:
         if not await self._has_perm("share-terminals"):
             send_error(self.sock, "Permission denied")
             return
-        from .terminal import close_window, kill_joiner_sessions
 
         owner_user_id = msg.get("user_id", "").strip()
         window_id = msg.get("window_id", "").strip()
@@ -1677,8 +1660,12 @@ class Connection:
             return
         window_name = match["name"]
         try:
-            await kill_joiner_sessions(self.container_id, owner_user_id)
-            await close_window(self.container_id, owner_user_id, window_id)
+            await terminal.kill_joiner_sessions(
+                self.container_id, owner_user_id
+            )
+            await terminal.close_window(
+                self.container_id, owner_user_id, window_id
+            )
         except Exception as e:
             send_error(self.sock, f"Failed to delete shared terminal: {e}")
             return
@@ -1996,8 +1983,6 @@ class Connection:
         self, container_id: str
     ) -> None:
         """Start the Pi RPC agent so it shows in presence."""
-        from . import agent
-
         try:
             session = await agent.get_session(self.workspace_id, container_id)
             await session._ensure_started()
@@ -2099,8 +2084,6 @@ class Connection:
 
     async def forward_exec_output(self, session: ExecSession) -> None:
         """Forward exec stdout to the client via WebSocket as base64."""
-        import base64
-
         try:
             async for data in session.output():
                 self.sock.send_json(
@@ -2303,7 +2286,6 @@ async def _handle_agent_mention(
     workspace_id: str, container_id: str, user_text: str
 ) -> None:
     """Handle an @agent mention by sending the prompt to Pi RPC."""
-    from . import agent
 
     agent_handle = await model.agent_handle()
     agent_re = _get_agent_mention_re(agent_handle)

--- a/src/backend/tests/test_agent.py
+++ b/src/backend/tests/test_agent.py
@@ -686,7 +686,7 @@ class TestMonitorProcess:
                 },
             ) as mock_chat,
             patch(
-                "klangk_backend.wshandler.state.get_session"
+                "klangk_backend.agent._get_workspace_session"
             ) as mock_get_session,
         ):
             mock_session = MagicMock()
@@ -744,7 +744,7 @@ class TestMonitorProcess:
                 return_value={"id": "m1", "message": "msg"},
             ),
             patch(
-                "klangk_backend.wshandler.state.get_session",
+                "klangk_backend.agent._get_workspace_session",
                 return_value=MagicMock(),
             ),
             patch.object(
@@ -781,7 +781,7 @@ class TestMonitorProcess:
                 return_value={"id": "m1", "message": "msg"},
             ),
             patch(
-                "klangk_backend.wshandler.state.get_session",
+                "klangk_backend.agent._get_workspace_session",
                 return_value=MagicMock(),
             ),
             patch.object(
@@ -814,7 +814,7 @@ class TestMonitorProcess:
                 return_value={"id": "m1", "message": "msg"},
             ),
             patch(
-                "klangk_backend.wshandler.state.get_session",
+                "klangk_backend.agent._get_workspace_session",
                 return_value=MagicMock(),
             ),
             patch.object(
@@ -848,7 +848,7 @@ class TestMonitorProcess:
                 return_value={"id": "m1", "message": "reconnected"},
             ) as mock_chat,
             patch(
-                "klangk_backend.wshandler.state.get_session"
+                "klangk_backend.agent._get_workspace_session"
             ) as mock_get_session,
         ):
             mock_session = MagicMock()
@@ -894,7 +894,7 @@ class TestMonitorProcess:
                 return_value={"id": "m1", "message": "msg"},
             ),
             patch(
-                "klangk_backend.wshandler.state.get_session",
+                "klangk_backend.agent._get_workspace_session",
                 return_value=MagicMock(),
             ),
             patch(


### PR DESCRIPTION
Closes #547

## Summary
- Move all function-scope imports to module scope across 11 backend files
- Break agent ↔ wshandler circular dependency with a `_get_workspace_session` callback set at module init time
- Break model → container circular dependency by inlining `DEFAULT_PORTS_PER_WORKSPACE`
- Only `main.py` lifespan imports remain (intentional — avoid importing heavy modules at startup)

## Test plan
- [ ] All backend tests pass
- [ ] No circular import errors on startup
- [ ] Agent broadcast still works (disconnect/reconnect messages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)