### PR TITLE
fix(security): prevent shell injection via tmux window name

### DIFF
--- a/src/backend/klangk_backend/terminal.py
+++ b/src/backend/klangk_backend/terminal.py
@@ -10,6 +10,7 @@ podman with ``SIGWINCH`` so it resizes the container PTY.
 import asyncio
 import codecs
 import fcntl
+import re
 import json
 import logging
 import os
@@ -28,6 +29,22 @@ logger = logging.getLogger(__name__)
 
 _READ_CHUNK = 65536
 CONTAINER_USER = "klangk"
+
+_SAFE_WINDOW_NAME = re.compile(r"^[A-Za-z0-9 _.\-]+$")
+_MAX_WINDOW_NAME_LEN = 64
+
+
+def _validate_window_name(name: str) -> None:
+    """Raise ``ValueError`` if *name* contains shell-unsafe characters."""
+    if not name or len(name) > _MAX_WINDOW_NAME_LEN:
+        raise ValueError(
+            f"Window name must be 1-{_MAX_WINDOW_NAME_LEN} characters"
+        )
+    if not _SAFE_WINDOW_NAME.match(name):
+        raise ValueError(
+            "Window name may only contain letters, digits,"
+            " spaces, hyphens, underscores, and dots"
+        )
 
 
 def terminal_tmux_enabled() -> bool:
@@ -271,6 +288,7 @@ async def new_window(
     round-trips (list + create + list in one call).
     """
     if name is not None:
+        _validate_window_name(name)
         # Explicit name — check + create + list in one exec.
         script = (
             f"existing=$(tmux list-windows -t {session_name}"
@@ -334,8 +352,10 @@ async def rename_window(
 ) -> None:
     """Rename a tmux window.
 
-    Raises ``ValueError`` if *name* duplicates another window's name.
+    Raises ``ValueError`` if *name* contains unsafe characters or
+    duplicates another window's name.
     """
+    _validate_window_name(name)
     existing = await list_windows(container_id, session_name)
     if any(w["name"] == name and w["index"] != index for w in existing):
         raise ValueError(f"Window name '{name}' already exists")

--- a/src/backend/tests/test_terminal.py
+++ b/src/backend/tests/test_terminal.py
@@ -15,6 +15,7 @@ from klangk_backend.terminal import (
     _build_environment,
     _build_shell_command,
     _make_shell_process,
+    _validate_window_name,
     attach_browser,
     close_window,
     kill_joiner_sessions,
@@ -632,6 +633,25 @@ class TestListWindows:
         assert result == []
 
 
+class TestValidateWindowName:
+    def test_accepts_safe_names(self):
+        for name in ["bash", "build-1", "my_window", "test.log", "A B C"]:
+            _validate_window_name(name)
+
+    def test_rejects_empty(self):
+        with pytest.raises(ValueError, match="1-64 characters"):
+            _validate_window_name("")
+
+    def test_rejects_too_long(self):
+        with pytest.raises(ValueError, match="1-64 characters"):
+            _validate_window_name("a" * 65)
+
+    def test_rejects_shell_metacharacters(self):
+        for name in ["a'b", 'a"b', "a;b", "a|b", "a`b", "a$(cmd)", "a&b"]:
+            with pytest.raises(ValueError, match="only contain"):
+                _validate_window_name(name)
+
+
 class TestNewWindow:
     async def test_creates_window_auto_name(self):
         proc = AsyncMock()
@@ -662,6 +682,10 @@ class TestNewWindow:
             result = await new_window("cid", "sess", name="build")
         assert len(result) == 2
         assert result[1]["name"] == "build"
+
+    async def test_rejects_shell_injection(self):
+        with pytest.raises(ValueError, match="only contain"):
+            await new_window("cid", "sess", name="';rm -rf /;'")
 
     async def test_rejects_duplicate_name(self):
         proc = AsyncMock()
@@ -754,6 +778,10 @@ class TestRenameWindow:
         mock_cmd.assert_called_once_with(
             "cid", "sess", ["rename-window", "-t", "sess:0", "build"]
         )
+
+    async def test_rejects_shell_injection(self):
+        with pytest.raises(ValueError, match="only contain"):
+            await rename_window("cid", "sess", 0, "';rm -rf /;'")
 
     async def test_rejects_duplicate_name(self):
         with patch(


### PR DESCRIPTION
## Summary

- Validate tmux window names to reject shell metacharacters (quotes, semicolons, backticks, pipes, etc.)
- Names must be 1-64 chars, alphanumeric/spaces/hyphens/underscores/dots only
- Applied to both `new_window` and `rename_window`
- Previously, a WebSocket client could send `terminal_new_window` with a name like `'; rm -rf / ;'` to execute arbitrary commands inside the container

Closes #506

## Test plan

- [x] `TestValidateWindowName` — safe names accepted, metacharacters rejected
- [x] `test_rejects_shell_injection` on both `new_window` and `rename_window`
- [x] Full backend suite passes (1381 tests, 100% coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)