### PR TITLE
fix(security): add workspace token auth to browser-delegate endpoints

### DIFF
--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -145,6 +145,11 @@ if resolve_env_secret("KLANGK_TEST_MODE"):  # pragma: no cover
             container.CHECK_INTERVAL_SECONDS = max(10, min(60, seconds // 3))
         return {"idle_timeout_seconds": seconds}
 
+    @router.get("/api/test/workspace-token/{workspace_id}")
+    async def get_workspace_token(workspace_id: str):
+        """Return a workspace JWT for testing (test only)."""
+        return {"token": auth.create_workspace_token(workspace_id)}
+
     @router.get("/api/test/browsers/{workspace_id}")
     async def get_browsers(workspace_id: str):
         """Return all active browser registrations for a workspace (test only)."""

--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -1919,6 +1919,24 @@ async def upload_file(
 # --- Browser bridge endpoint ---
 
 
+async def _require_workspace_token(request: Request) -> str:
+    """FastAPI dependency: validate workspace JWT from Authorization header.
+
+    Returns the workspace_id. Raises 401 if missing, expired, or invalid.
+    This duplicates the nginx auth_request check as defense-in-depth.
+    """
+    authorization = request.headers.get("authorization", "")
+    if not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Missing workspace token")
+    token = authorization[7:]
+    result = auth.decode_workspace_token(token)
+    if result is auth.WORKSPACE_TOKEN_EXPIRED:
+        raise HTTPException(status_code=401, detail="Workspace token expired")
+    if result is None:
+        raise HTTPException(status_code=401, detail="Invalid workspace token")
+    return result
+
+
 class BrowserDelegateRequest(BaseModel):
     model_config = {"extra": "allow"}
     action: str
@@ -1952,7 +1970,10 @@ def _resolve_bridge_target(body: BrowserDelegateRequest):
 
 
 @router.post("/api/browser-delegate")
-async def browser_delegate(body: BrowserDelegateRequest):
+async def browser_delegate(
+    body: BrowserDelegateRequest,
+    workspace_id: str = Depends(_require_workspace_token),
+):
     """Bridge endpoint for container processes to delegate actions to the browser.
 
     The container reads the current browser ID via ``klangk-browser-id``
@@ -1978,7 +1999,10 @@ async def browser_delegate(body: BrowserDelegateRequest):
 
 
 @router.post("/api/browser-delegate/stream")
-async def browser_delegate_stream(body: BrowserDelegateRequest):
+async def browser_delegate_stream(
+    body: BrowserDelegateRequest,
+    workspace_id: str = Depends(_require_workspace_token),
+):
     """Streaming bridge: relay browser output chunks back as NDJSON.
 
     For long-running actions (RAG + LLM), the browser pushes incremental
@@ -2003,20 +2027,15 @@ class WorkspaceChatRequest(BaseModel):
 
 
 @router.post("/api/workspace/post-chat-message")
-async def workspace_chat(body: WorkspaceChatRequest, request: Request):
+async def workspace_chat(
+    body: WorkspaceChatRequest,
+    workspace_id: str = Depends(_require_workspace_token),
+):
     """Post a chat message from a container using a workspace JWT.
 
     The message is stored as MSG_AGENT and broadcast to all connected
     WebSocket subscribers in the workspace.
     """
-    authorization = request.headers.get("authorization", "")
-    if not authorization.startswith("Bearer "):
-        raise HTTPException(status_code=401, detail="Not authenticated")
-    token = authorization[7:]
-    workspace_id = auth.decode_workspace_token(token)
-    if workspace_id is None:
-        raise HTTPException(status_code=401, detail="Invalid workspace token")
-
     workspace = await model.get_workspace_by_id(workspace_id)
     if workspace is None:
         raise HTTPException(status_code=404, detail="Workspace not found")

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -2021,13 +2021,39 @@ class TestUserSearch:
 
 
 class TestBrowserBridge:
-    async def test_unknown_browser_id_returns_403(self, client, user):
+    def _ws_token_headers(self, workspace_id="ws-test"):
+        token = auth.create_workspace_token(workspace_id)
+        return {"Authorization": f"Bearer {token}"}
+
+    async def test_missing_token_returns_401(self, client, user):
         resp = await client.post(
             "/api/browser-delegate",
             json={"action": "fetch", "browser_id": "bad-id"},
         )
+        assert resp.status_code == 401
+
+    async def test_unknown_browser_id_returns_403(self, client, user):
+        resp = await client.post(
+            "/api/browser-delegate",
+            json={"action": "fetch", "browser_id": "bad-id"},
+            headers=self._ws_token_headers(),
+        )
         assert resp.status_code == 403
         assert "Unknown browser ID" in resp.json()["detail"]
+
+    async def test_expired_token_returns_401(self, client, user):
+        with patch.object(
+            auth,
+            "decode_workspace_token",
+            return_value=auth.WORKSPACE_TOKEN_EXPIRED,
+        ):
+            resp = await client.post(
+                "/api/browser-delegate",
+                json={"action": "fetch", "browser_id": "x"},
+                headers={"Authorization": "Bearer some-expired-token"},
+            )
+        assert resp.status_code == 401
+        assert "expired" in resp.json()["detail"].lower()
 
     async def test_browser_id_routes_to_correct_tab(self, client, user):
         """Browser ID routes to the specific browser tab."""
@@ -2047,6 +2073,7 @@ class TestBrowserBridge:
                 resp = await client.post(
                     "/api/browser-delegate",
                     json={"action": "fetch", "browser_id": "bid-conn"},
+                    headers=self._ws_token_headers("ws-conn"),
                 )
             assert resp.status_code == 200
             assert resp.json()["body"] == "targeted"
@@ -2071,6 +2098,7 @@ class TestBrowserBridge:
                 resp = await client.post(
                     "/api/browser-delegate",
                     json={"action": "fetch", "browser_id": "bid-nosub"},
+                    headers=self._ws_token_headers("ws-nosub"),
                 )
             assert resp.status_code == 502
             assert "Browser connection not available" in resp.json()["detail"]
@@ -2086,6 +2114,7 @@ class TestBrowserBridge:
             resp = await client.post(
                 "/api/browser-delegate",
                 json={"action": "fetch", "browser_id": "bid-nosess"},
+                headers=self._ws_token_headers("ws-nosess"),
             )
             assert resp.status_code == 502
             assert "No browser client" in resp.json()["detail"]
@@ -2109,6 +2138,7 @@ class TestBrowserBridge:
                 resp = await client.post(
                     "/api/browser-delegate",
                     json={"action": "fetch", "browser_id": "bid-err"},
+                    headers=self._ws_token_headers("ws-err"),
                 )
             assert resp.status_code == 502
             assert "timeout" in resp.json()["detail"].lower()
@@ -2143,6 +2173,7 @@ class TestBrowserBridge:
                         "action": "soliplex_query",
                         "browser_id": "bid-stream",
                     },
+                    headers=self._ws_token_headers("ws-stream"),
                 )
             assert resp.status_code == 200
             assert '"chunk"' in resp.text

--- a/src/frontend/e2e-tests/e2e/klangk.spec.ts
+++ b/src/frontend/e2e-tests/e2e/klangk.spec.ts
@@ -1185,9 +1185,18 @@ test.describe("Klangk E2E", () => {
     expect(ownerBrowser).toBeTruthy();
     expect(memberBrowser).toBeTruthy();
 
+    // Get a workspace token for the bridge requests
+    const tokenResp = await request.get(
+      `${API_BASE}/api/test/workspace-token/${workspaceId}`,
+    );
+    expect(tokenResp.ok()).toBeTruthy();
+    const wsToken = (await tokenResp.json()).token;
+    const bridgeHeaders = { Authorization: `Bearer ${wsToken}` };
+
     // Send bridge request targeting the OWNER — the auto-responder
     // in page1 will reply with {pong: "ping owner"}.
     const resp1 = await request.post(`${API_BASE}/api/browser-delegate`, {
+      headers: bridgeHeaders,
       data: {
         action: "test_ping",
         message: "ping owner",
@@ -1200,6 +1209,7 @@ test.describe("Klangk E2E", () => {
     // Send bridge request targeting the MEMBER — the auto-responder
     // in page2 will reply with {pong: "ping member"}.
     const resp2 = await request.post(`${API_BASE}/api/browser-delegate`, {
+      headers: bridgeHeaders,
       data: {
         action: "test_ping",
         message: "ping member",


### PR DESCRIPTION
## Summary
- Add `_require_workspace_token` FastAPI dependency that validates workspace JWTs
- Apply to `/api/browser-delegate`, `/api/browser-delegate/stream`, and `/api/workspace/post-chat-message`
- Refactors `post-chat-message` from inline token validation to shared dependency
- Handles missing, expired, and invalid tokens with appropriate 401 responses

Defense-in-depth: these endpoints were previously only protected by nginx `auth_request`. Now they're also validated at the FastAPI level.

Closes #510

## Test plan
- [x] Backend tests pass (1390 passed, 100% coverage)
- [ ] E2E tests pass on CI