### PR TITLE
fix(security): set restrictive permissions on CLI config file

### DIFF
--- a/src/cli/klangkc/config.py
+++ b/src/cli/klangkc/config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 
+import os
 import tomllib
 import tomli_w
 from dataclasses import dataclass, field
@@ -44,7 +45,7 @@ class CLIConfig:
         )
 
     def save(self) -> None:
-        _CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
         data = {
             "server": {"url": self.server.url},
             "auth": {
@@ -58,3 +59,4 @@ class CLIConfig:
         }
         content = tomli_w.dumps(data)
         _CONFIG_PATH.write_text(content)
+        os.chmod(_CONFIG_PATH, 0o600)

--- a/src/cli/tests/test_cli.py
+++ b/src/cli/tests/test_cli.py
@@ -68,6 +68,15 @@ class TestCLIConfig:
         cfg.save()
         assert config_path.exists()
 
+    def test_save_sets_restrictive_permissions(self, tmp_path, monkeypatch):
+        config_path = tmp_path / "klangk" / "cli.toml"
+        monkeypatch.setattr("klangkc.config._CONFIG_PATH", config_path)
+        cfg = CLIConfig()
+        cfg.auth.token = "secret"
+        cfg.save()
+        assert oct(config_path.stat().st_mode & 0o777) == oct(0o600)
+        assert oct(config_path.parent.stat().st_mode & 0o777) == oct(0o700)
+
     def test_load_token_only(self, tmp_path, monkeypatch):
         config_path = tmp_path / "cli.toml"
         config_path.write_text('[auth]\ntoken = "tok"\n')


### PR DESCRIPTION
## Summary
- Config file gets `0o600` permissions (owner read/write only)
- Config directory gets `0o700` permissions
- Prevents other system users from reading the JWT token

Closes #507

## Test plan
- [x] CLI tests pass (266 passed, 100% coverage)
- [x] New test verifies file and directory permissions