### PR TITLE
feat(cli): switch config from TOML to YAML

### DIFF
--- a/src/cli/e2e-tests/test_cli_e2e.py
+++ b/src/cli/e2e-tests/test_cli_e2e.py
@@ -145,13 +145,13 @@ def cli_config(server, tmp_path_factory):
     """Create a CLI config pointing at the test server."""
     config_dir = tmp_path_factory.mktemp("klangk-cli-config")
     env = {**os.environ, "HOME": str(config_dir)}
-    # The CLI reads from ~/.config/klangk/cli.toml
+    # The CLI reads from ~/.config/klangk/cli.yaml
     klangk_config_dir = config_dir / ".config" / "klangk"
     klangk_config_dir.mkdir(parents=True)
     return {
         "env": env,
         "config_dir": klangk_config_dir,
-        "config_file": klangk_config_dir / "cli.toml",
+        "config_file": klangk_config_dir / "cli.yaml",
         "server_url": server["url"],
     }
 

--- a/src/cli/klangkc/config.py
+++ b/src/cli/klangkc/config.py
@@ -1,15 +1,14 @@
-"""CLI configuration storage (~/.config/klangk/cli.toml)."""
+"""CLI configuration storage (~/.config/klangk/cli.yaml)."""
 
 from __future__ import annotations
 
 
 import os
-import tomllib
-import tomli_w
+import yaml
 from dataclasses import dataclass, field
 from pathlib import Path
 
-_CONFIG_PATH = Path.home() / ".config" / "klangk" / "cli.toml"
+_CONFIG_PATH = Path.home() / ".config" / "klangk" / "cli.yaml"
 
 
 @dataclass
@@ -33,7 +32,7 @@ class CLIConfig:
         if not _CONFIG_PATH.exists():
             return cls()
         text = _CONFIG_PATH.read_text()
-        data = tomllib.loads(text)
+        data = yaml.safe_load(text) or {}
         return cls(
             server=ServerConfig(
                 url=data.get("server", {}).get("url", "http://localhost:8995")
@@ -57,6 +56,6 @@ class CLIConfig:
                 if v is not None
             },
         }
-        content = tomli_w.dumps(data)
+        content = yaml.dump(data, default_flow_style=False)
         _CONFIG_PATH.write_text(content)
         os.chmod(_CONFIG_PATH, 0o600)

--- a/src/cli/pyproject.toml
+++ b/src/cli/pyproject.toml
@@ -6,7 +6,6 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "typer[all]>=0.12.0",
-    "tomli-w>=1.0.0",
     "httpx>=0.28.0",
     "websockets>=14.0",
     "PyYAML>=6.0",

--- a/src/cli/tests/test_cli.py
+++ b/src/cli/tests/test_cli.py
@@ -37,10 +37,10 @@ class TestCLIConfig:
         assert cfg.auth.email is None
 
     def test_load_existing(self, tmp_path, monkeypatch):
-        config_path = tmp_path / "cli.toml"
+        config_path = tmp_path / "cli.yaml"
         config_path.write_text(
-            '[server]\nurl = "http://custom:9999"\n\n'
-            '[auth]\ntoken = "abc123"\nemail = "test@example.com"\n'
+            "server:\n  url: http://custom:9999\n"
+            "auth:\n  token: abc123\n  email: test@example.com\n"
         )
         monkeypatch.setattr("klangkc.config._CONFIG_PATH", config_path)
         cfg = CLIConfig.load()
@@ -49,7 +49,7 @@ class TestCLIConfig:
         assert cfg.auth.email == "test@example.com"
 
     def test_save_roundtrip(self, tmp_path, monkeypatch):
-        config_path = tmp_path / "cli.toml"
+        config_path = tmp_path / "cli.yaml"
         monkeypatch.setattr("klangkc.config._CONFIG_PATH", config_path)
         cfg = CLIConfig()
         cfg.server.url = "http://saved:5678"
@@ -62,14 +62,14 @@ class TestCLIConfig:
         assert loaded.auth.email == "save@test.com"
 
     def test_save_creates_parent_dirs(self, tmp_path, monkeypatch):
-        config_path = tmp_path / "sub" / "dir" / "cli.toml"
+        config_path = tmp_path / "sub" / "dir" / "cli.yaml"
         monkeypatch.setattr("klangkc.config._CONFIG_PATH", config_path)
         cfg = CLIConfig()
         cfg.save()
         assert config_path.exists()
 
     def test_save_sets_restrictive_permissions(self, tmp_path, monkeypatch):
-        config_path = tmp_path / "klangk" / "cli.toml"
+        config_path = tmp_path / "klangk" / "cli.yaml"
         monkeypatch.setattr("klangkc.config._CONFIG_PATH", config_path)
         cfg = CLIConfig()
         cfg.auth.token = "secret"
@@ -78,8 +78,8 @@ class TestCLIConfig:
         assert oct(config_path.parent.stat().st_mode & 0o777) == oct(0o700)
 
     def test_load_token_only(self, tmp_path, monkeypatch):
-        config_path = tmp_path / "cli.toml"
-        config_path.write_text('[auth]\ntoken = "tok"\n')
+        config_path = tmp_path / "cli.yaml"
+        config_path.write_text("auth:\n  token: tok\n")
         monkeypatch.setattr("klangkc.config._CONFIG_PATH", config_path)
         cfg = CLIConfig.load()
         assert cfg.auth.token == "tok"
@@ -95,7 +95,7 @@ class TestAuth:
         monkeypatch.setattr("klangkc.auth._fetch_config", lambda _: None)
 
     def test_login_success(self, tmp_path, monkeypatch):
-        config_path = tmp_path / "cli.toml"
+        config_path = tmp_path / "cli.yaml"
         monkeypatch.setattr("klangkc.config._CONFIG_PATH", config_path)
         mock_resp = MagicMock()
         mock_resp.status_code = 200
@@ -113,7 +113,7 @@ class TestAuth:
         assert cfg.auth.email == "u@test.com"
 
     def test_login_with_user_flag(self, tmp_path, monkeypatch):
-        config_path = tmp_path / "cli.toml"
+        config_path = tmp_path / "cli.yaml"
         monkeypatch.setattr("klangkc.config._CONFIG_PATH", config_path)
         mock_resp = MagicMock()
         mock_resp.status_code = 200
@@ -132,7 +132,7 @@ class TestAuth:
         assert cfg.auth.email == "cli@test.com"
 
     def test_login_with_password_file(self, tmp_path, monkeypatch):
-        config_path = tmp_path / "cli.toml"
+        config_path = tmp_path / "cli.yaml"
         monkeypatch.setattr("klangkc.config._CONFIG_PATH", config_path)
         pw_file = tmp_path / "pw.txt"
         pw_file.write_text("file-secret\n")
@@ -152,7 +152,7 @@ class TestAuth:
         assert cfg.auth.email == "pw@test.com"
 
     def test_login_reuses_valid_token(self, tmp_path, monkeypatch):
-        config_path = tmp_path / "cli.toml"
+        config_path = tmp_path / "cli.yaml"
         monkeypatch.setattr("klangkc.config._CONFIG_PATH", config_path)
         # Save a config with an existing token
         cfg = CLIConfig()
@@ -174,7 +174,7 @@ class TestAuth:
         assert loaded.auth.email == "saved@test.com"
 
     def test_login_network_error_falls_through(self, tmp_path, monkeypatch):
-        config_path = tmp_path / "cli.toml"
+        config_path = tmp_path / "cli.yaml"
         monkeypatch.setattr("klangkc.config._CONFIG_PATH", config_path)
         cfg = CLIConfig()
         cfg.server.url = "http://localhost:8995"
@@ -200,7 +200,7 @@ class TestAuth:
         assert loaded.auth.token == "fresh"
 
     def test_login_expired_token_prompts(self, tmp_path, monkeypatch):
-        config_path = tmp_path / "cli.toml"
+        config_path = tmp_path / "cli.yaml"
         monkeypatch.setattr("klangkc.config._CONFIG_PATH", config_path)
         cfg = CLIConfig()
         cfg.server.url = "http://localhost:8995"
@@ -229,7 +229,7 @@ class TestAuth:
         assert loaded.auth.email == "new@test.com"
 
     def test_login_failure(self, tmp_path, monkeypatch):
-        config_path = tmp_path / "cli.toml"
+        config_path = tmp_path / "cli.yaml"
         monkeypatch.setattr("klangkc.config._CONFIG_PATH", config_path)
         mock_resp = MagicMock()
         mock_resp.status_code = 401
@@ -245,8 +245,8 @@ class TestAuth:
                     auth.login("http://localhost:8995")
 
     def test_logout_clears_token(self, tmp_path, monkeypatch):
-        config_path = tmp_path / "cli.toml"
-        config_path.write_text('[auth]\ntoken = "tok"\nemail = "x@y.com"\n')
+        config_path = tmp_path / "cli.yaml"
+        config_path.write_text("auth:\n  token: tok\n  email: x@y.com\n")
         monkeypatch.setattr("klangkc.config._CONFIG_PATH", config_path)
         mock_resp = MagicMock()
         mock_resp.status_code = 200
@@ -259,7 +259,7 @@ class TestAuth:
         assert cfg.auth.email is None
 
     def test_logout_swallows_server_error(self, tmp_path, monkeypatch):
-        config_path = tmp_path / "cli.toml"
+        config_path = tmp_path / "cli.yaml"
         monkeypatch.setattr("klangkc.config._CONFIG_PATH", config_path)
         cfg = CLIConfig()
         cfg.save()
@@ -291,7 +291,7 @@ class TestOIDCCLILogin:
         """OIDC login with single provider goes straight to browser."""
         from klangkc import auth
 
-        config_path = tmp_path / "cli.toml"
+        config_path = tmp_path / "cli.yaml"
         monkeypatch.setattr("klangkc.config._CONFIG_PATH", config_path)
         monkeypatch.setattr(
             "klangkc.auth._fetch_config",
@@ -309,7 +309,7 @@ class TestOIDCCLILogin:
         """OIDC login with multiple providers prompts for selection."""
         from klangkc import auth
 
-        config_path = tmp_path / "cli.toml"
+        config_path = tmp_path / "cli.yaml"
         monkeypatch.setattr("klangkc.config._CONFIG_PATH", config_path)
         monkeypatch.setattr(
             "klangkc.auth._fetch_config",
@@ -338,7 +338,7 @@ class TestOIDCCLILogin:
         """Explicit email+password skips OIDC even in both mode."""
         from klangkc import auth
 
-        config_path = tmp_path / "cli.toml"
+        config_path = tmp_path / "cli.yaml"
         monkeypatch.setattr("klangkc.config._CONFIG_PATH", config_path)
         monkeypatch.setattr(
             "klangkc.auth._fetch_config",
@@ -362,7 +362,7 @@ class TestOIDCCLILogin:
     def test_oidc_invalid_provider_choice(self, tmp_path, monkeypatch):
         from klangkc import auth
 
-        config_path = tmp_path / "cli.toml"
+        config_path = tmp_path / "cli.yaml"
         monkeypatch.setattr("klangkc.config._CONFIG_PATH", config_path)
         monkeypatch.setattr(
             "klangkc.auth._fetch_config",
@@ -387,7 +387,7 @@ class TestOIDCCLILogin:
         """301 redirect shows a helpful hint about HTTPS."""
         from klangkc import auth
 
-        config_path = tmp_path / "cli.toml"
+        config_path = tmp_path / "cli.yaml"
         monkeypatch.setattr("klangkc.config._CONFIG_PATH", config_path)
         monkeypatch.setattr(
             "klangkc.auth._fetch_config",
@@ -410,7 +410,7 @@ class TestOIDCCLILogin:
         """Login with empty error response doesn't crash."""
         from klangkc import auth
 
-        config_path = tmp_path / "cli.toml"
+        config_path = tmp_path / "cli.yaml"
         monkeypatch.setattr("klangkc.config._CONFIG_PATH", config_path)
         monkeypatch.setattr(
             "klangkc.auth._fetch_config",
@@ -1174,7 +1174,7 @@ class TestMisc:
         assert ws.created_at == "z"
 
     def test_login_success_stores_email(self, tmp_path, monkeypatch):
-        config_path = tmp_path / "cli.toml"
+        config_path = tmp_path / "cli.yaml"
         monkeypatch.setattr("klangkc.config._CONFIG_PATH", config_path)
         mock_resp = MagicMock()
         mock_resp.status_code = 200

--- a/src/cli/tests/test_cli_integration.py
+++ b/src/cli/tests/test_cli_integration.py
@@ -1015,7 +1015,7 @@ class TestAuthLines:
     def test_logout_network_error_propagates(self, tmp_path, monkeypatch):
         from klangkc import auth
 
-        config_path = tmp_path / "cli.toml"
+        config_path = tmp_path / "cli.yaml"
         monkeypatch.setattr("klangkc.config._CONFIG_PATH", config_path)
         cfg = CLIConfig()
         cfg.server.url = "http://localhost:8995"

--- a/src/cli/tests/test_cli_main.py
+++ b/src/cli/tests/test_cli_main.py
@@ -16,7 +16,7 @@ from klangkc.client import Workspace
 @pytest.fixture
 def logged_in_cfg(tmp_path, monkeypatch):
     """Config with a valid token and email pre-loaded."""
-    config_path = tmp_path / "cli.toml"
+    config_path = tmp_path / "cli.yaml"
     monkeypatch.setattr("klangkc.config._CONFIG_PATH", config_path)
     cfg = CLIConfig()
     cfg.server.url = "http://localhost:8995"
@@ -55,7 +55,7 @@ class TestMainCLI:
     def test_login_cmd_stores_token(self, tmp_path, monkeypatch):
         from klangkc.main import login_cmd
 
-        config_path = tmp_path / "cli.toml"
+        config_path = tmp_path / "cli.yaml"
         monkeypatch.setattr("klangkc.config._CONFIG_PATH", config_path)
         mock_resp = MagicMock()
         mock_resp.status_code = 200
@@ -77,7 +77,7 @@ class TestMainCLI:
     def test_login_cmd_with_password_file(self, tmp_path, monkeypatch):
         from klangkc.main import login_cmd
 
-        config_path = tmp_path / "cli.toml"
+        config_path = tmp_path / "cli.yaml"
         monkeypatch.setattr("klangkc.config._CONFIG_PATH", config_path)
         pw_file = tmp_path / "pw.txt"
         pw_file.write_text("file-pw\n")
@@ -96,7 +96,7 @@ class TestMainCLI:
     def test_login_cmd_with_password_stdin(self, tmp_path, monkeypatch):
         from klangkc.main import login_cmd
 
-        config_path = tmp_path / "cli.toml"
+        config_path = tmp_path / "cli.yaml"
         monkeypatch.setattr("klangkc.config._CONFIG_PATH", config_path)
         mock_resp = MagicMock()
         mock_resp.status_code = 200
@@ -118,7 +118,7 @@ class TestMainCLI:
         import typer
         from klangkc import main
 
-        config_path = tmp_path / "cli.toml"
+        config_path = tmp_path / "cli.yaml"
         monkeypatch.setattr("klangkc.config._CONFIG_PATH", config_path)
         cfg = CLIConfig()
         cfg.auth.token = None
@@ -328,7 +328,7 @@ class TestMainCLI:
         import typer
         from klangkc import main
 
-        config_path = tmp_path / "cli.toml"
+        config_path = tmp_path / "cli.yaml"
         monkeypatch.setattr("klangkc.config._CONFIG_PATH", config_path)
         cfg = CLIConfig()
         cfg.auth.token = None
@@ -340,7 +340,7 @@ class TestMainCLI:
     def test_status_not_logged_in(self, tmp_path, monkeypatch, capsys):
         from klangkc import main
 
-        config_path = tmp_path / "cli.toml"
+        config_path = tmp_path / "cli.yaml"
         monkeypatch.setattr("klangkc.config._CONFIG_PATH", config_path)
         cfg = CLIConfig()
         cfg.server.url = "http://custom:1234"
@@ -385,7 +385,7 @@ class TestMainCLI:
 
         from klangkc import main
 
-        config_path = tmp_path / "cli.toml"
+        config_path = tmp_path / "cli.yaml"
         monkeypatch.setattr("klangkc.config._CONFIG_PATH", config_path)
         cfg = CLIConfig()
         cfg.auth.token = None
@@ -413,7 +413,7 @@ class TestMainCLI:
     def test_status_plain_not_logged_in(self, tmp_path, monkeypatch, capsys):
         from klangkc import main
 
-        config_path = tmp_path / "cli.toml"
+        config_path = tmp_path / "cli.yaml"
         monkeypatch.setattr("klangkc.config._CONFIG_PATH", config_path)
         cfg = CLIConfig()
         cfg.server.url = "http://custom:1234"

--- a/uv.lock
+++ b/uv.lock
@@ -650,6 +650,7 @@ dependencies = [
     { name = "aiosmtplib" },
     { name = "aiosqlite" },
     { name = "bcrypt" },
+    { name = "cryptography" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "logfire", extra = ["fastapi"] },
@@ -661,6 +662,7 @@ dependencies = [
     { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "starlette" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "websockets" },
 ]
@@ -670,6 +672,7 @@ requires-dist = [
     { name = "aiosmtplib", specifier = ">=3.0.0" },
     { name = "aiosqlite", specifier = ">=0.20.0" },
     { name = "bcrypt", specifier = ">=4.0.0" },
+    { name = "cryptography", specifier = ">=48.0.1" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "logfire", extras = ["fastapi"], specifier = ">=3.0.0" },
@@ -678,9 +681,10 @@ requires-dist = [
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "pytest-xdist", specifier = ">=3.0.0" },
     { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3.0" },
-    { name = "python-multipart", specifier = ">=0.0.12" },
+    { name = "python-multipart", specifier = ">=0.0.30" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0" },
+    { name = "starlette", specifier = ">=1.3.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
     { name = "websockets", specifier = ">=14.0" },
 ]
@@ -691,7 +695,6 @@ source = { editable = "src/cli" }
 dependencies = [
     { name = "httpx" },
     { name = "pyyaml" },
-    { name = "tomli-w" },
     { name = "typer" },
     { name = "websockets" },
 ]
@@ -712,7 +715,6 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.0.0" },
     { name = "pyyaml", specifier = ">=6.0" },
-    { name = "tomli-w", specifier = ">=1.0.0" },
     { name = "typer", extras = ["all"], specifier = ">=0.12.0" },
     { name = "websockets", specifier = ">=14.0" },
 ]
@@ -1303,15 +1305,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
-]
-
-[[package]]
-name = "tomli-w"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Replace `~/.config/klangk/cli.toml` with `cli.yaml`
- Drop `tomli-w` dependency (PyYAML already required)
- Update all tests to use YAML format

Closes #564

## Test plan
- [x] CLI tests pass (266/267 — 1 pre-existing websockets deprecation failure on main)