### PR TITLE
docs: rewrite terminal chapter — explain tmux first

### DIFF
--- a/docs/features/terminal.md
+++ b/docs/features/terminal.md
@@ -1,22 +1,53 @@
 # Terminal
 
-- Direct shell access to the workspace container via the Terminal tab in the right panel
-- Uses flterm (Flutter terminal emulator backed by libghostty) with xterm.dart as a fallback, dark theme (Tomorrow Night palette)
-- Backend spawns `podman exec` subprocess with PTY (`os.openpty`) piped over the existing WebSocket
-- Runs as `klangk` user in `/home/klangk/work` with bash, tab completion, readline, colored prompt/ls, and persistent history (defaults from `/etc/bash.bashrc` in the image, overridable via `~/.bashrc` on the persistent home mount). History is flushed to `~/.bash_history` after each command via `PROMPT_COMMAND` so it survives terminal kills. See [The Shell](the-shell.md) for alternative shell options.
-- Terminal interaction bumps the container idle timeout via `record_activity()`
-- On-demand: subprocess starts when user clicks the Terminal tab
-- State preserved across tab switches (IndexedStack keeps all panels alive)
+Every workspace terminal runs inside [tmux](https://github.com/tmux/tmux),
+a terminal multiplexer. You never interact with tmux directly — Klangk's
+web UI and CLI manage everything for you — but understanding the basics
+helps explain how terminal features work.
+
+## Why tmux?
+
+Klangk uses tmux for three reasons:
+
+1. **Session persistence** — your terminal survives disconnects, page
+   refreshes, and even container restarts. When you reconnect, you pick
+   up exactly where you left off.
+2. **Window management** — each terminal tab is a tmux window. Switching
+   tabs is instant because all windows share the same tmux session.
+3. **Shared terminals** — tmux session groups let multiple users see
+   the same terminal in real time. One user's session group can have
+   spectators or collaborators attached.
+
+Tmux runs with no status bar, no prefix key, and no keybindings beyond
+scrollback — it looks and feels like a plain terminal.
+
+## How it maps to what you see
+
+| Klangk concept            | tmux concept                                           |
+| ------------------------- | ------------------------------------------------------ |
+| Terminal tab              | tmux window                                            |
+| Your set of tabs          | tmux session (named by your user ID)                   |
+| Joining a shared terminal | New tmux session in the owner's session group          |
+| Tab name                  | tmux window name (persists, visible to other users)    |
+| Shell exit + respawn      | `remain-on-exit` + `pane-died` hook respawns the shell |
+
+## Using the terminal
+
+The terminal panel gives you direct shell access to the workspace
+container. It starts on demand when you click the Terminal tab.
+
+- Runs as the `klangk` user with bash (see [The Shell](the-shell.md)
+  for zsh and customization)
 - Right-click context menu with Copy (when text selected) and Paste
-- Scrollbar for terminal history
-- Overlay with restart button when container stops (idle timeout or unexpected), auto-reconnects terminal session after restart
-- Cleaned up on workspace disconnect or WebSocket close
+- Mouse wheel scrollback via tmux copy mode
+- If the container stops (idle timeout or crash), an overlay appears
+  with a restart button. The terminal auto-reconnects after restart.
 
-## Terminal Tabs
+## Terminal tabs
 
-Each user has their own set of terminal tabs. Tabs map 1:1 to tmux windows
-inside the container. All tabs share a single tmux session named by the
-user's ID, so switching tabs is instant — no new process is started.
+Each user has their own set of terminal tabs. Tabs map 1:1 to tmux
+windows inside the container. All tabs share a single tmux session
+named by your user ID, so switching tabs is instant.
 
 ![Initial terminal with a single tab](../assets/terminal-sharing/01-initial-terminal.png)
 
@@ -25,7 +56,7 @@ user's ID, so switching tabs is instant — no new process is started.
 - Click **✕** on a tab to close it (only shown when more than one tab exists)
 - Right-click a tab to open a context menu with **Rename** and **Share/Unshare**
 
-### Renaming Tabs
+### Renaming tabs
 
 Right-click any tab and select **Rename** to change its display name. The
 name is stored as the tmux window name, so it persists across reconnections
@@ -33,16 +64,23 @@ and is visible to other users if the tab is shared.
 
 ![Two terminal tabs — one shared, one isolated](../assets/terminal-sharing/06-two-tabs.png)
 
-## Shared Terminals
+## Shared terminals
 
 Any terminal tab can be promoted to a shared terminal, making it visible
 and joinable by other workspace members. Sharing is per-tab — you can share
 one tab while keeping others private.
 
-### Sharing a Tab
+Under the hood, when a user joins a shared terminal, Klangk creates a
+new tmux session in the same **session group** as the owner's session.
+Session groups share the same set of windows, so all participants see the
+same content in real time. Each joiner gets an independent tmux session
+(separate scroll position, active window selection) but shares the
+underlying window panes.
+
+### Sharing a tab
 
 Right-click a tab and select **Share**. The tab gains a broadcast icon
-(📡) indicating it is now shared. Other workspace members see the shared
+indicating it is now shared. Other workspace members see the shared
 tab appear in their tab bar.
 
 ![Tab with broadcast icon indicating it is shared](../assets/terminal-sharing/04-shared-tab-with-icon.png)
@@ -52,50 +90,38 @@ To unshare, either:
 - Right-click the tab and select **Unshare**, or
 - Click the broadcast icon directly
 
-### Joining a Shared Terminal
+### Joining a shared terminal
 
 Shared terminals from other users appear in your tab bar with a prefix
-showing the owner's handle (e.g. `alice:build`). Click the tab to join —
+showing the owner's handle (e.g., `alice:build`). Click the tab to join —
 you are now seeing the same terminal session as the owner.
 
 ![Collaborator's view showing a shared terminal from another user](../assets/terminal-sharing/08-collaborator-view.png)
 
 Depending on your role, you may be able to type (read-write) or only
-watch (read-only). A 🔒 icon indicates read-only access.
+watch (read-only). A lock icon indicates read-only access.
 
-### Viewer Tracking
+### Viewer tracking
 
-When someone joins your shared terminal, a 👁 icon with a count appears
+When someone joins your shared terminal, an eye icon with a count appears
 on the tab showing how many users are currently viewing.
 
 ![Shared tab showing one viewer](../assets/terminal-sharing/07-viewer-count.png)
 
 Hover over the tab to see a tooltip listing the full tab name and the
-email handles of all current viewers.
+handles of all current viewers.
 
-### How It Works
-
-Under the hood, each user's terminals run in a single tmux session inside
-the workspace container. When a user joins a shared terminal, they create
-a new tmux session in the same **session group** as the owner's session.
-Session groups share the same set of windows, so all participants see the
-same content in real time.
-
-Each joiner gets an independent tmux session (separate scroll position,
-active window) but shares the underlying window panes. When a joiner
-disconnects, their session is cleaned up automatically.
-
-### Role Permissions
+## Role permissions
 
 | Permission                     | Owners | Coders | Collaborators | Spectators |
 | ------------------------------ | ------ | ------ | ------------- | ---------- |
-| `terminal`                     | ✓\*    | ✓      | ✓             | ✓          |
-| `code-in-isolation`            | ✓\*    | ✓      | ✓             |            |
-| `share-terminals`              | ✓\*    |        |               |            |
-| `code-in-shared-terminals`     | ✓\*    |        | ✓             |            |
-| `spectate-on-shared-terminals` | ✓\*    | ✓      | ✓             | ✓          |
-| `files`                        | ✓\*    | ✓      | ✓             |            |
-| `chat`                         | ✓\*    | ✓      | ✓             | ✓          |
+| `terminal`                     | \*     | yes    | yes           | yes        |
+| `code-in-isolation`            | \*     | yes    | yes           |            |
+| `share-terminals`              | \*     |        |               |            |
+| `code-in-shared-terminals`     | \*     |        | yes           |            |
+| `spectate-on-shared-terminals` | \*     | yes    | yes           | yes        |
+| `files`                        | \*     | yes    | yes           |            |
+| `chat`                         | \*     | yes    | yes           | yes        |
 
 \* Owners have the wildcard (`*`) permission which implies all permissions.
 


### PR DESCRIPTION
## Summary
- Lead with what tmux is and why Klangk uses it (persistence, window management, sharing)
- Add concept mapping table (tab = window, session = per-user, session group = shared)
- Restructure from implementation-first to user-first
- Remove internal details (PTY, IndexedStack, flterm) that don't help users

Closes #565

## Test plan
- [ ] Docs build and render correctly