### PR TITLE
docs: add GitHub repo link to site header

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -3,6 +3,8 @@ site_name = "Klangk"
 site_description = "Multi-User AI Sandboxing, Collaboration and Coding Platform"
 site_author = "Chris McDonough"
 site_url = "https://mcdonc.github.io/klangk/"
+repo_url = "https://github.com/mcdonc/klangk"
+repo_name = "mcdonc/klangk"
 copyright = "Copyright &copy; 2026 Chris McDonough"
 extra_css = ["stylesheets/extra.css"]
 


### PR DESCRIPTION
## Summary
- Add `repo_url` and `repo_name` to `zensical.toml` so the docs site header includes a GitHub icon linking to the repository

Fixes #580