### PR TITLE
docs: explain handle/HOME relationship and single-UNIX-user design

### DIFF
--- a/docs/features/handles.md
+++ b/docs/features/handles.md
@@ -6,6 +6,8 @@ used throughout the platform:
 - **Chat** — @mention other users in workspace chat messages
 - **Terminal** — your `$HOME` directory is `/home/<handle>/`
 - **Presence** — avatar tooltips show your handle in the workspace
+- **Shared terminals** — shared tabs are prefixed with the owner's
+  handle (e.g., `alice:build`)
 
 ## How handles are assigned
 
@@ -17,10 +19,22 @@ If that handle is already taken, a numeric suffix is appended
 Handles must be lowercase and may contain letters, digits, dots,
 dashes, and underscores.
 
+## Handle and HOME directory
+
+Your handle determines your home directory path inside workspace
+containers. When you open a terminal, `$HOME` is set to
+`/home/<handle>/`, which is a symlink to `.users/<user-id>/` on the
+host filesystem.
+
+If you change your handle, your `$HOME` path changes on your next
+terminal session — but the underlying directory (keyed by user ID)
+stays the same. Your files, dotfiles, and history are preserved.
+
 ## Changing your handle
 
-You can change your handle from the user menu in the top-right corner
-of the UI. The new handle must be unique and follow the naming rules
-above.
+You can change your handle from the Settings page. The new handle
+must be unique and follow the naming rules above. A password
+confirmation is required.
 
-Admins can also change any user's handle from the admin panel.
+Admins can change any user's handle from the Admin panel without
+needing the user's password.

--- a/docs/features/the-shell.md
+++ b/docs/features/the-shell.md
@@ -8,25 +8,60 @@ personal `~/.bashrc`.
 Your `~/.bashrc` persists across container restarts (it lives on the
 bind-mounted home directory), so any customizations you make are permanent.
 
-## User environment
+## Users and the single-UNIX-user design
 
-Each workspace container runs as a single UNIX user (`klangk`), but
-Klangk supports multiple workspace members by giving each person their
-own `$HOME` directory. When you open a terminal, `$HOME` is set to your
-personal directory (e.g., `/home/<handle>/`), so
-dotfiles like `.bashrc`, `.gitconfig`, `.vimrc`, and `.zshrc` are
-per-user and persist across sessions.
+Workspace containers run as a single UNIX user called `klangk`. There
+are no separate UNIX accounts for each workspace member — everyone
+runs as the same uid.
 
-You can customize your environment the same way you would on any UNIX
-system — edit dotfiles in `$HOME`, add scripts to `~/bin`, configure
-your shell prompt, set up aliases, etc.
+This is intentional. Collaboration between actual UNIX users is
+invariably painful: file ownership mismatches, group permission
+headaches, umask defaults that lock teammates out, setgid directory
+hacks that half-work. Every project that tries to make multi-user
+file sharing work on UNIX ends up with a pile of permission workarounds.
+
+By running everything as a single UNIX user, Klangk sidesteps all of
+this. Every workspace member can read and write every file without
+fighting permissions. Collaboration just works.
+
+### Per-user home directories
+
+Even though everyone shares the same UNIX user, each workspace member
+gets their own `$HOME` directory. When you open a terminal, `$HOME` is
+set to `/home/<handle>/` — a symlink that points to
+`.users/<user-id>/` on the bind-mounted home volume.
+
+This means:
+
+- Your dotfiles (`.bashrc`, `.gitconfig`, `.vimrc`) are yours alone
+- Your bash history is separate from other members'
+- Your AI agent config (`.pi/agent/`, `.claude/`) is per-user
+- The shared project directory at `/home/work/` is accessible to everyone
+
+See [Handles](handles.md) for how handles are assigned and how they
+relate to your home directory path.
+
+### The tradeoff
+
+Because all workspace members share the same UNIX user, every member
+can read and modify every file under `/home` — including other members'
+home directories and dotfiles. This is the cost of frictionless
+collaboration.
 
 !!! warning
-Because all workspace members share the same UNIX user, every
-member can read and modify every file under `/home` — including
-other members' home directories. Do not store secrets or sensitive
-data in your home directory if you share the workspace with
-untrusted users.
+Do not store secrets or sensitive data in your home directory if
+you share the workspace with untrusted users.
+
+## Customizing your environment
+
+You can customize your shell the same way you would on any UNIX
+system:
+
+- Edit `~/.bashrc` for aliases, prompt customization, PATH changes
+- Add scripts to `~/bin`
+- Configure `~/.gitconfig`, `~/.vimrc`, etc.
+
+All changes persist across container restarts.
 
 ## Using zsh instead
 

--- a/docs/features/the-shell.md
+++ b/docs/features/the-shell.md
@@ -46,7 +46,9 @@ relate to your home directory path.
 Because all workspace members share the same UNIX user, every member
 can read and modify every file under `/home` — including other members'
 home directories and dotfiles. This is the cost of frictionless
-collaboration.
+collaboration. Use separate workspaces for collaboration with different
+groups of differently trusted users, or for solo work where you need
+full privacy.
 
 !!! warning
 Do not store secrets or sensitive data in your home directory if


### PR DESCRIPTION
## Summary
- Explain why Klangk uses a single UNIX user per container (collaboration between UNIX users is painful — permissions, umask, ownership)
- Document per-user HOME directories and the handle → symlink → user-id mapping
- Document the tradeoff (shared uid = shared file access, don't store secrets)
- Update Handles chapter with HOME path behavior on handle change

Closes #585

## Test plan
- [ ] Docs build and render correctly