### PR TITLE
feat: resolve @mentions by handle instead of email

### DIFF
--- a/docs/features/chat.md
+++ b/docs/features/chat.md
@@ -3,6 +3,10 @@
 Per-workspace chat panel with real-time messaging. All workspace members
 see messages instantly via WebSocket. Click the **Chat** tab to open.
 
+!!! note
+Chat is per-workspace only — there are no direct messages (DMs)
+between users. Use separate workspaces for private conversations.
+
 [![Empty chat panel](../assets/chat/01-chat-panel.png)](../assets/chat/01-chat-panel.png)
 
 [![Chat with agent response](../assets/chat/03-agent-response.png)](../assets/chat/03-agent-response.png)

--- a/src/backend/klangk_backend/model.py
+++ b/src/backend/klangk_backend/model.py
@@ -1530,15 +1530,15 @@ async def clear_login_attempts(email: str) -> None:
 
 # Chat messages
 
-_MENTION_RE = re.compile(r"@(\S+)")
+_MENTION_RE = re.compile(r"@([a-zA-Z0-9._-]+)")
 
 
 async def parse_mentions(
     db: _Connection, message: str, workspace_id: str
 ) -> list[str]:
-    """Extract @email mentions from message text and resolve to user IDs.
+    """Extract @handle mentions from message text and resolve to user IDs.
 
-    Returns a deduplicated list of user IDs for emails that belong to
+    Returns a deduplicated list of user IDs for handles that belong to
     workspace members (including the owner).
     """
     candidates = _MENTION_RE.findall(message)
@@ -1555,15 +1555,15 @@ async def parse_mentions(
 
     placeholders = ",".join("?" for _ in unique)
     cursor = await db.execute(
-        "SELECT DISTINCT u.id, LOWER(u.email) AS email FROM users u"
+        "SELECT DISTINCT u.id FROM users u"
         " JOIN acl_entries ae ON ae.user_id = u.id"
-        " WHERE LOWER(u.email) IN (" + placeholders + ")"
+        " WHERE LOWER(u.handle) IN (" + placeholders + ")"
         "   AND ae.resource = ?"
         "   AND ae.principal_type = ? AND ae.action = ?"
         " UNION"
-        " SELECT w.user_id AS id, LOWER(u2.email) AS email"
+        " SELECT w.user_id AS id"
         " FROM workspaces w JOIN users u2 ON u2.id = w.user_id"
-        " WHERE w.id = ? AND LOWER(u2.email) IN (" + placeholders + ")",
+        " WHERE w.id = ? AND LOWER(u2.handle) IN (" + placeholders + ")",
         (
             *unique,
             f"/workspaces/{workspace_id}",

--- a/src/backend/klangk_backend/wshandler.py
+++ b/src/backend/klangk_backend/wshandler.py
@@ -2251,7 +2251,7 @@ def _get_agent_mention_re(handle: str) -> re.Pattern:
     global _agent_mention_re
     if _agent_mention_re is None:
         _agent_mention_re = re.compile(
-            r"(?:^|(?<=\s))@" + re.escape(handle) + r"(?:@\S+)?(?:\s|$)",
+            r"(?:^|(?<=\s))@" + re.escape(handle) + r"(?:\s|$)",
             re.IGNORECASE,
         )
     return _agent_mention_re
@@ -2273,7 +2273,7 @@ async def _addresses_other_user(text: str) -> bool:
     m = _ANY_MENTION_RE.match(text.lstrip())
     if not m:
         return False
-    mention = m.group().lstrip("@").split("@")[0].lower()
+    mention = m.group().lstrip("@").lower()
     handle = await model.agent_handle()
     return mention != handle.lower()
 

--- a/src/backend/tests/test_model.py
+++ b/src/backend/tests/test_model.py
@@ -819,7 +819,7 @@ class TestChatMessagesPagination:
             user_id=target["id"],
         )
         await model.add_chat_message(
-            workspace["id"], "uid", "u@test.com", f"hey @{target['email']}"
+            workspace["id"], "uid", "u@test.com", f"hey @{target['handle']}"
         )
         anchor = await model.add_chat_message(
             workspace["id"], "uid", "u@test.com", "anchor"
@@ -838,7 +838,7 @@ class TestChatMentions:
             workspace["id"],
             user["id"],
             user["email"],
-            f"hello @{user['email']}",
+            f"hello @{user['handle']}",
         )
         assert msg["mentions"] == [user["id"]]
 
@@ -859,7 +859,7 @@ class TestChatMentions:
             workspace["id"],
             user["id"],
             user["email"],
-            "hey @member@test.com check this",
+            f"hey @{member['handle']} check this",
         )
         assert msg["mentions"] == [member["id"]]
 
@@ -870,7 +870,7 @@ class TestChatMentions:
             workspace["id"],
             user["id"],
             user["email"],
-            "hey @outsider@test.com",
+            "hey @outsider",
         )
         assert msg["mentions"] == []
 
@@ -889,7 +889,7 @@ class TestChatMentions:
             workspace["id"],
             user["id"],
             user["email"],
-            f"@{user['email']} and @m@test.com",
+            f"@{user['handle']} and @{member['handle']}",
         )
         assert set(msg["mentions"]) == {user["id"], member["id"]}
 
@@ -899,7 +899,7 @@ class TestChatMentions:
             workspace["id"],
             user["id"],
             user["email"],
-            f"@{user['email']} @{user['email']}",
+            f"@{user['handle']} @{user['handle']}",
         )
         assert msg["mentions"] == [user["id"]]
 
@@ -909,7 +909,7 @@ class TestChatMentions:
             workspace["id"],
             user["id"],
             user["email"],
-            f"hello @{user['email']}",
+            f"hello @{user['handle']}",
         )
         msgs = await model.get_chat_messages(workspace["id"])
         assert len(msgs) == 1

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -4762,8 +4762,6 @@ class TestMentionsAgent:
         assert await _mentions_agent("@MrBoops hello")
         assert await _mentions_agent("hey @MrBoops what's up")
         assert await _mentions_agent("@MRBOOPS help")
-        assert await _mentions_agent("@MrBoops@klangk.local hello")
-        assert await _mentions_agent("hey @MrBoops@klangk.local")
 
     async def test_no_false_positives(self, agent_user):
         from klangk_backend.wshandler import _mentions_agent


### PR DESCRIPTION
## Summary
- `parse_mentions()` now matches `@handle` against `users.handle` instead of `users.email`
- Mention regex changed from `@(\S+)` to `@([a-zA-Z0-9._-]+)` to match handle characters only
- Agent mention regex simplified — no longer matches `@MrBoops@email.com` format
- Added note to chat docs that DMs are not supported

Closes #587

## Test plan
- [x] Backend tests pass (1391 passed, 100% coverage)
- [x] Frontend autocomplete already inserts handles (no changes needed)
- [ ] E2E tests pass on CI