### PR TITLE
fix(security): address CodeQL path injection and logging findings

### DIFF
--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -1853,11 +1853,13 @@ async def download_file(
         raise HTTPException(status_code=400, detail=str(e))
     if not resolved.exists():
         raise HTTPException(status_code=404, detail="Path not found")
-    if resolved.is_file():
-        return FileResponse(resolved, filename=resolved.name)
+    if resolved.is_file():  # lgtm[py/path-injection]
+        return FileResponse(  # lgtm[py/path-injection]
+            resolved, filename=resolved.name
+        )
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
-        for file_path in resolved.rglob("*"):
+        for file_path in resolved.rglob("*"):  # lgtm[py/path-injection]
             if file_path.is_file():
                 zf.write(file_path, file_path.relative_to(resolved))
     buf.seek(0)
@@ -1898,12 +1900,12 @@ async def upload_file(
     max_upload = FILE_UPLOAD_SIZE_MAX
     total = 0
     try:
-        with open(dest, "wb") as fp:
+        with open(dest, "wb") as fp:  # lgtm[py/path-injection]
             while chunk := await file.read(1024 * 1024):
                 total += len(chunk)
                 if total > max_upload:
                     fp.close()
-                    dest.unlink(missing_ok=True)
+                    dest.unlink(missing_ok=True)  # lgtm[py/path-injection]
                     raise HTTPException(
                         status_code=413,
                         detail=f"File exceeds {max_upload // (1024 * 1024)} MB limit",
@@ -1912,7 +1914,7 @@ async def upload_file(
     except HTTPException:
         raise
     except Exception as e:  # pragma: no cover
-        dest.unlink(missing_ok=True)
+        dest.unlink(missing_ok=True)  # lgtm[py/path-injection]
         raise HTTPException(
             status_code=500, detail=f"Upload failed: {e}"
         ) from e

--- a/src/backend/klangk_backend/emailsvc.py
+++ b/src/backend/klangk_backend/emailsvc.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import os
 import shutil
 from email.message import EmailMessage
 
@@ -68,7 +69,7 @@ async def send_via_smtp(msg: EmailMessage) -> None:
 
 
 async def send_via_sendmail(msg: EmailMessage) -> None:
-    sendmail = resolve_env_secret("KLANGK_SENDMAIL_PATH", "sendmail")
+    sendmail = os.environ.get("KLANGK_SENDMAIL_PATH", "sendmail")
     logger.info("Using sendmail at: %s", sendmail)
     resolved = shutil.which(sendmail)
     logger.info("Resolved sendmail path: %s", resolved)

--- a/src/backend/klangk_backend/files.py
+++ b/src/backend/klangk_backend/files.py
@@ -1,4 +1,11 @@
-"""File operations on workspace home directories (host-side mount)."""
+"""File operations on workspace home directories (host-side mount).
+
+All path-accepting functions in this module delegate to ``resolve_path``
+which validates that the resolved path stays within the workspace root
+via ``Path.is_relative_to``.  CodeQL cannot trace this inter-procedural
+validation, so downstream filesystem operations are annotated with
+``lgtm[py/path-injection]`` suppressions.
+"""
 
 import shutil
 from pathlib import Path
@@ -7,10 +14,10 @@ from . import workspaces
 
 
 def resolve_path(user_id: str, workspace_id: str, relative_path: str) -> Path:
-    """Resolve a relative path within a workspace, preventing directory traversal."""
-    root = workspaces.get_home_host_path(user_id, workspace_id)
-    resolved = (root / relative_path).resolve()
-    if not str(resolved).startswith(str(root.resolve())):
+    """Resolve a relative path within a workspace, preventing traversal."""
+    root = workspaces.get_home_host_path(user_id, workspace_id).resolve()
+    resolved = (root / relative_path).resolve()  # lgtm[py/path-injection]
+    if not resolved.is_relative_to(root):
         raise ValueError("Path traversal not allowed")
     return resolved
 
@@ -20,7 +27,7 @@ def list_files(
 ) -> list[dict]:
     """List files and directories at the given path."""
     path = resolve_path(user_id, workspace_id, relative_path)
-    if not path.exists() or not path.is_dir():
+    if not path.exists() or not path.is_dir():  # lgtm[py/path-injection]
         return []
 
     entries = []
@@ -45,15 +52,17 @@ def read_file(
 ) -> str | None:
     """Read file contents. Returns None if file doesn't exist or is too large."""
     path = resolve_path(user_id, workspace_id, relative_path)
-    if not path.exists() or not path.is_file():
+    if not path.exists() or not path.is_file():  # lgtm[py/path-injection]
         return None
 
     # Limit to 1MB
-    if path.stat().st_size > 1_000_000:
+    if path.stat().st_size > 1_000_000:  # lgtm[py/path-injection]
         return None
 
     try:
-        return path.read_text(encoding="utf-8", errors="replace")
+        return path.read_text(  # lgtm[py/path-injection]
+            encoding="utf-8", errors="replace"
+        )
     except OSError:
         return None
 
@@ -61,12 +70,12 @@ def read_file(
 def delete_path(user_id: str, workspace_id: str, relative_path: str) -> str:
     """Delete a file or directory. Returns the relative path deleted."""
     path = resolve_path(user_id, workspace_id, relative_path)
-    if not path.exists():
+    if not path.exists():  # lgtm[py/path-injection]
         raise FileNotFoundError("Path not found")
-    if path.is_dir():
-        shutil.rmtree(path)
+    if path.is_dir():  # lgtm[py/path-injection]
+        shutil.rmtree(path)  # lgtm[py/path-injection]
     else:
-        path.unlink()
+        path.unlink()  # lgtm[py/path-injection]
     return str(
         path.relative_to(workspaces.get_home_host_path(user_id, workspace_id))
     )
@@ -78,12 +87,12 @@ def rename_path(
     """Rename/move a file or directory. Returns the new relative path."""
     src = resolve_path(user_id, workspace_id, old_path)
     dst = resolve_path(user_id, workspace_id, new_path)
-    if not src.exists():
+    if not src.exists():  # lgtm[py/path-injection]
         raise FileNotFoundError("Source path not found")
-    if dst.exists():
+    if dst.exists():  # lgtm[py/path-injection]
         raise FileExistsError("Destination already exists")
-    dst.parent.mkdir(parents=True, exist_ok=True)
-    src.rename(dst)
+    dst.parent.mkdir(parents=True, exist_ok=True)  # lgtm[py/path-injection]
+    src.rename(dst)  # lgtm[py/path-injection]
     return str(
         dst.relative_to(workspaces.get_home_host_path(user_id, workspace_id))
     )
@@ -94,8 +103,8 @@ def write_file(
 ) -> str:
     """Write file contents. Returns the resolved relative path."""
     path = resolve_path(user_id, workspace_id, relative_path)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_bytes(content)
+    path.parent.mkdir(parents=True, exist_ok=True)  # lgtm[py/path-injection]
+    path.write_bytes(content)  # lgtm[py/path-injection]
     return str(
         path.relative_to(workspaces.get_home_host_path(user_id, workspace_id))
     )
@@ -110,5 +119,5 @@ def write_file_path(
     Callers are responsible for writing data to the returned path.
     """
     path = resolve_path(user_id, workspace_id, relative_path)
-    path.parent.mkdir(parents=True, exist_ok=True)
+    path.parent.mkdir(parents=True, exist_ok=True)  # lgtm[py/path-injection]
     return path

--- a/src/backend/klangk_backend/util.py
+++ b/src/backend/klangk_backend/util.py
@@ -53,7 +53,7 @@ def resolve_file_secret(value: str) -> str:
         try:
             return open(path).read().strip()
         except OSError as e:
-            logger.error("Cannot read secret from %s: %s", path, e)
+            logger.error("Cannot read secret file: %s", e)
             return ""
     return value
 

--- a/src/backend/klangk_backend/workspaces.py
+++ b/src/backend/klangk_backend/workspaces.py
@@ -165,7 +165,7 @@ async def archive_user_data(user_id: str, email: str) -> list[Path]:
     After successful archival the user's data directory is removed.
     """
     user_workspaces = await model.list_workspaces(user_id)
-    user_dir = WORKSPACES_ROOT / user_id
+    user_dir = _safe_path(user_id)  # lgtm[py/path-injection]
     if not user_dir.exists():
         return []
 
@@ -175,10 +175,9 @@ async def archive_user_data(user_id: str, email: str) -> list[Path]:
     for ws in user_workspaces:
         ws_name = _sanitize_filename(ws["name"])
         archive_name = f"{user_id}-{safe_email}-{ws_name}.tar.gz"
-        archive_path = WORKSPACES_ROOT / archive_name
-        if not archive_path.resolve().is_relative_to(
-            WORKSPACES_ROOT.resolve()
-        ):
+        try:
+            archive_path = _safe_path(archive_name)  # lgtm[py/path-injection]
+        except ValueError:
             logger.error(
                 "Archive path traversal blocked for workspace %s", ws["name"]
             )


### PR DESCRIPTION
## Summary
- Use `is_relative_to()` instead of string comparison for path traversal validation in `files.resolve_path()`
- Use `_safe_path()` consistently in `workspaces.archive_user_data()` instead of raw path concatenation
- Stop logging secret file paths in `util.resolve_file_secret()` error messages
- Use `os.environ.get` for sendmail binary path (not a secret, shouldn't use `resolve_env_secret`)
- Add `lgtm[py/path-injection]` inline suppressions on validated path operations that CodeQL cannot trace through inter-procedural validation

## Test plan
- [x] All 1391 backend tests pass with 100% coverage

Fixes #583