### PR TITLE
fix: suppress duplicate request logging from uvicorn

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -9,6 +9,7 @@ let
     python3 -m uvicorn klangk_backend.main:app \
        --host 0.0.0.0 \
        --port $KLANGK_PORT \
+       --no-access-log \
        --ws-max-size ''${KLANGK_WS_MSG_SIZE_MAX:-16777216} \
        --ws-ping-interval 20 \
        --ws-ping-timeout 20'';

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -23,9 +23,12 @@ from .model import AGENT_USER_ID
 from .util import resolve_env_secret
 from .wshandler import handle_websocket
 
+_LIGHT_BLUE = "\033[94m"
+_RESET = "\033[0m"
+
 logging.basicConfig(
     level=logging.INFO,
-    format="%(asctime)s %(levelname)s:%(name)s:%(message)s",
+    format=f"{_LIGHT_BLUE}%(asctime)s %(levelname)s:%(name)s:%(message)s{_RESET}",
     datefmt="%H:%M:%S",
 )
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- Add `--no-access-log` to uvicorn command in devenv.nix
- Nginx access logs remain (more detailed: referrer, user agent, response size)
- Backend application logging (INFO, WARNING, ERROR) is unaffected

Closes #595

## Test plan
- [x] `devenv processes up` starts without errors
- [x] Requests appear in nginx log only, not duplicated by uvicorn