### PR TITLE
fix(e2e): write cli.yaml not cli.toml in token expiry test

### DIFF
--- a/src/frontend/e2e-tests/e2e/token-expiry.spec.ts
+++ b/src/frontend/e2e-tests/e2e/token-expiry.spec.ts
@@ -71,8 +71,8 @@ test.describe("Token expiry", () => {
     const configDir = join(tmpHome, ".config", "klangk");
     mkdirSync(configDir, { recursive: true });
     writeFileSync(
-      join(configDir, "cli.toml"),
-      `[server]\nurl = "${API_BASE}"\n\n[auth]\ntoken = "${expiredToken}"\nemail = "${email}"\n`,
+      join(configDir, "cli.yaml"),
+      `server:\n  url: ${API_BASE}\nauth:\n  token: ${expiredToken}\n  email: ${email}\n`,
     );
 
     // Run klangkc shell — it should fail with a clear error


### PR DESCRIPTION
The CLI config switched from TOML to YAML in #576 but this test
still wrote cli.toml. The CLI couldn't find the config, saw token
as None, and printed "Not logged in" instead of "Session expired".

Closes #596

## Test plan
- [ ] 3 successive passing frontend E2E runs