### PR TITLE
fix: add 5s timeout on WebSocket ready to avoid Firefox throttle

### DIFF
--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -73,6 +73,10 @@ class WsClient extends ChangeNotifier {
   @visibleForTesting
   static Duration Function(int attempt)? testBackoffOverride;
 
+  /// Override for testing to shorten the connection ready timeout.
+  @visibleForTesting
+  static Duration? testReadyTimeout;
+
   /// Override for testing to shorten the reconnect timeout.
   @visibleForTesting
   static Duration? testReconnectTimeout;
@@ -163,7 +167,16 @@ class WsClient extends ChangeNotifier {
     }
 
     try {
-      await _channel!.ready;
+      // Timeout after 5s to avoid Firefox's FailDelayManager throttle
+      // (up to 60s) after an unclean server-side disconnect.
+      final readyTimeout = testReadyTimeout ??
+          const Duration(seconds: 5); // coverage:ignore-line
+      await _channel!.ready.timeout(readyTimeout);
+    } on TimeoutException {
+      _channel?.sink.close(1000, 'connection timeout');
+      _channel = null;
+      _errorController.add('Connection timed out');
+      return;
     } catch (e) {
       final code = _channel?.closeCode;
       if (code == 4001 || code == 4002) {

--- a/src/frontend/test/ws_client_test.dart
+++ b/src/frontend/test/ws_client_test.dart
@@ -12,6 +12,7 @@ class _FakeWebSocketChannel extends Fake implements WebSocketChannel {
   final _incoming = StreamController<dynamic>.broadcast();
   final _sink = _FakeSink();
   bool failReady = false;
+  bool hangReady = false;
   int? _closeCode;
 
   @override
@@ -24,8 +25,11 @@ class _FakeWebSocketChannel extends Fake implements WebSocketChannel {
   int? get closeCode => _closeCode;
 
   @override
-  Future<void> get ready =>
-      failReady ? Future.error('Connection refused') : Future.value();
+  Future<void> get ready {
+    if (failReady) return Future.error('Connection refused');
+    if (hangReady) return Completer<void>().future; // never completes
+    return Future.value();
+  }
 
   void serverSend(Map<String, dynamic> msg) => _incoming.add(jsonEncode(msg));
 
@@ -253,6 +257,31 @@ void main() {
       expect(client.connected, isFalse);
       expect(errors.length, 1);
       expect(errors[0], 'Session expired, please log in again');
+      client.dispose();
+    });
+
+    test('connect timeout emits error and does not hang', () async {
+      SharedPreferences.setMockInitialValues({'klangk_jwt': 'test-token'});
+      final hangChannel = _FakeWebSocketChannel();
+      hangChannel.hangReady = true;
+      WsClient.testChannelFactory = (_) => hangChannel;
+      WsClient.testReadyTimeout = const Duration(milliseconds: 50);
+
+      final auth = AuthService();
+      await Future.delayed(Duration.zero);
+
+      final client = WsClient();
+      client.updateAuth(auth);
+
+      final errors = <String>[];
+      client.errors.listen(errors.add);
+
+      await client.connect();
+      await Future.delayed(Duration.zero);
+      expect(client.connected, isFalse);
+      expect(errors.length, 1);
+      expect(errors[0], 'Connection timed out');
+      WsClient.testReadyTimeout = null;
       client.dispose();
     });
   });


### PR DESCRIPTION
## Summary
Firefox's FailDelayManager delays WebSocket connections by up to 60s after an unclean server-side disconnect (e.g., uvicorn restart). The `await _channel!.ready` call would hang for that entire duration.

This adds a 5-second timeout on `ready`. If it expires, the channel is closed and the reconnect logic retries immediately instead of waiting up to 60s.

Closes #603

## Test plan
- [x] Frontend tests pass (100% coverage)
- [x] New test verifies timeout emits error and doesn't hang