### PR TITLE
fix: event-driven Firefox WebSocket throttle avoidance

### DIFF
--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:math';
 import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
 import 'package:web_socket_channel/web_socket_channel.dart';
 import '../auth/auth_service.dart';
 import '../utils/web_helpers_stub.dart'
@@ -52,6 +53,11 @@ class WsClient extends ChangeNotifier {
   /// Whether auto-reconnect should be attempted on disconnect.
   /// Set to false during intentional disconnects.
   bool _autoReconnect = false;
+
+  /// Whether the last WebSocket close was unclean (not code 1000).
+  /// Firefox's FailDelayManager throttles reconnections after unclean
+  /// closes, so we pre-check via HTTP before reconnecting.
+  bool _lastCloseUnclean = false;
 
   /// Max backoff duration in seconds.
   static const int _maxBackoffSeconds = 30;
@@ -148,10 +154,52 @@ class WsClient extends ChangeNotifier {
     }
   }
 
+  /// HTTP base URL for pre-connect checks, derived from the page location.
+  // coverage:ignore-start
+  static String get _httpBaseUrl {
+    final loc = Uri.base;
+    return '${loc.scheme}://${loc.host}:${loc.port}$baseUrl';
+  }
+  // coverage:ignore-end
+
+  /// Override for testing to inject a custom HTTP pre-check function.
+  @visibleForTesting
+  static Future<bool> Function()? testHttpPreCheck;
+
+  /// Wait for the server to respond via HTTP before opening a WebSocket.
+  /// This drains Firefox's FailDelayManager throttle (which only affects
+  /// WebSocket connections, not HTTP) so the subsequent WS connect succeeds
+  /// without a 30-60s delay.
+  Future<bool> _waitForServer() async {
+    if (testHttpPreCheck != null) return testHttpPreCheck!();
+    if (testChannelFactory != null) return true; // coverage:ignore-line
+    // coverage:ignore-start
+    try {
+      final resp = await http.get(Uri.parse('$_httpBaseUrl/api/config'));
+      return resp.statusCode == 200;
+    } catch (_) {
+      return false;
+    }
+    // coverage:ignore-end
+  }
+
   Future<void> connect() async {
     _reconnectTimer?.cancel();
     _reconnectTimer = null;
     if (_connected || _auth?.token == null) return;
+
+    // After an unclean WebSocket close, Firefox's FailDelayManager throttles
+    // new WebSocket connections by up to 60s. HTTP requests are not affected,
+    // so we pre-check via HTTP to confirm the server is reachable before
+    // opening a new WebSocket. This avoids hanging on `channel.ready`.
+    if (_lastCloseUnclean) {
+      final serverUp = await _waitForServer();
+      if (!serverUp) {
+        _scheduleReconnect();
+        return;
+      }
+      _lastCloseUnclean = false;
+    }
 
     if (testChannelFactory != null) {
       _channel = testChannelFactory!(Uri());
@@ -290,8 +338,9 @@ class WsClient extends ChangeNotifier {
         _pendingWorkspaceId ??= _currentWorkspaceId;
         _currentWorkspaceId = null;
         _defaultCommand = null;
-        notifyListeners();
         final code = _channel?.closeCode;
+        _lastCloseUnclean = code != 1000;
+        notifyListeners();
         if (code == 4001 || code == 4002) {
           _errorController.add('Session expired, please log in again');
           _auth?.logout();

--- a/src/frontend/test/ws_client_test.dart
+++ b/src/frontend/test/ws_client_test.dart
@@ -255,6 +255,122 @@ void main() {
       expect(errors[0], 'Session expired, please log in again');
       client.dispose();
     });
+
+    test('unclean close sets flag and pre-checks HTTP on reconnect', () async {
+      SharedPreferences.setMockInitialValues({'klangk_jwt': 'test-token'});
+      final channel = _FakeWebSocketChannel();
+      WsClient.testChannelFactory = (_) => channel;
+      WsClient.testBackoffOverride = (_) => Duration.zero;
+      var httpCheckCalled = false;
+      WsClient.testHttpPreCheck = () async {
+        httpCheckCalled = true;
+        return true;
+      };
+
+      final auth = AuthService();
+      await Future.delayed(Duration.zero);
+
+      final client = WsClient();
+      client.updateAuth(auth);
+
+      await client.connect();
+      expect(client.connected, isTrue);
+
+      // Connect to workspace so auto-reconnect is armed
+      client.connectWorkspace('ws1');
+      channel.serverSend({'type': 'workspace_ready', 'workspaceId': 'ws1'});
+      await Future.delayed(Duration.zero);
+
+      // Simulate unclean server close (no code 1000)
+      channel.serverClose(1006);
+      await Future.delayed(Duration.zero);
+      expect(client.connected, isFalse);
+
+      // Wait for reconnect attempt
+      await Future.delayed(const Duration(milliseconds: 50));
+      expect(httpCheckCalled, isTrue);
+
+      WsClient.testBackoffOverride = null;
+      WsClient.testHttpPreCheck = null;
+      client.dispose();
+    });
+
+    test('clean close does not trigger HTTP pre-check', () async {
+      SharedPreferences.setMockInitialValues({'klangk_jwt': 'test-token'});
+      final channel = _FakeWebSocketChannel();
+      WsClient.testChannelFactory = (_) => channel;
+      WsClient.testBackoffOverride = (_) => Duration.zero;
+      var httpCheckCalled = false;
+      WsClient.testHttpPreCheck = () async {
+        httpCheckCalled = true;
+        return true;
+      };
+
+      final auth = AuthService();
+      await Future.delayed(Duration.zero);
+
+      final client = WsClient();
+      client.updateAuth(auth);
+
+      await client.connect();
+      expect(client.connected, isTrue);
+
+      // Connect to workspace so auto-reconnect is armed
+      client.connectWorkspace('ws1');
+      channel.serverSend({'type': 'workspace_ready', 'workspaceId': 'ws1'});
+      await Future.delayed(Duration.zero);
+
+      // Simulate clean server close (code 1000)
+      channel.serverClose(1000);
+      await Future.delayed(Duration.zero);
+
+      // Wait for reconnect attempt
+      await Future.delayed(const Duration(milliseconds: 50));
+      expect(httpCheckCalled, isFalse);
+
+      WsClient.testBackoffOverride = null;
+      WsClient.testHttpPreCheck = null;
+      client.dispose();
+    });
+
+    test('HTTP pre-check failure schedules another reconnect', () async {
+      SharedPreferences.setMockInitialValues({'klangk_jwt': 'test-token'});
+      final channel = _FakeWebSocketChannel();
+      WsClient.testChannelFactory = (_) => channel;
+      WsClient.testBackoffOverride = (_) => Duration.zero;
+      var httpCheckCount = 0;
+      WsClient.testHttpPreCheck = () async {
+        httpCheckCount++;
+        return false; // server not reachable
+      };
+
+      final auth = AuthService();
+      await Future.delayed(Duration.zero);
+
+      final client = WsClient();
+      client.updateAuth(auth);
+
+      await client.connect();
+      expect(client.connected, isTrue);
+
+      // Connect to workspace so auto-reconnect is armed
+      client.connectWorkspace('ws1');
+      channel.serverSend({'type': 'workspace_ready', 'workspaceId': 'ws1'});
+      await Future.delayed(Duration.zero);
+
+      // Simulate unclean close
+      channel.serverClose(1006);
+      await Future.delayed(Duration.zero);
+
+      // First reconnect attempt: HTTP check fails, schedules another
+      await Future.delayed(const Duration(milliseconds: 50));
+      expect(httpCheckCount, greaterThanOrEqualTo(1));
+      expect(client.reconnecting, isTrue);
+
+      WsClient.testBackoffOverride = null;
+      WsClient.testHttpPreCheck = null;
+      client.dispose();
+    });
   });
 
   group('WsClient.dispose', () {


### PR DESCRIPTION
## Summary
- Track whether the last WebSocket close was unclean (code != 1000)
- On reconnect after an unclean close, pre-check server via HTTP (`GET /api/config`) before opening a new WebSocket — HTTP is not affected by Firefox's FailDelayManager
- If HTTP check fails, schedule another reconnect; if it succeeds, proceed with WebSocket connection
- Replaces the reverted timeout-on-ready approach from #604 which broke container startup

## Test plan
- [x] 68 ws_client tests pass (3 new tests for unclean/clean close and HTTP pre-check failure)
- [x] All 563 frontend tests pass

Fixes #603