### PR TITLE
feat(cli): add workspace share/unshare/members commands

### DIFF
--- a/docs/features/workspaces.md
+++ b/docs/features/workspaces.md
@@ -44,9 +44,10 @@ Workspace owners can share access with other users or groups from the
 **Sharing** tab, or from the CLI:
 
 ```bash
-klangkc share my-project user@example.com    # share with a user
-klangkc unshare my-project user@example.com  # remove access
-klangkc members my-project                   # list members
+klangkc share my-project user@example.com                # share (coder role)
+klangkc share my-project user@example.com --role=owner   # share with role
+klangkc unshare my-project user@example.com              # remove access
+klangkc members my-project                               # list members
 ```
 
 Shared users connect to the same container and see the workspace in

--- a/docs/features/workspaces.md
+++ b/docs/features/workspaces.md
@@ -41,8 +41,16 @@ sessions all persist across container restarts.
 ## Sharing workspaces
 
 Workspace owners can share access with other users or groups from the
-**Sharing** tab. Shared users connect to the same container and see
-the workspace in a "Shared with Me" section on their workspace list.
+**Sharing** tab, or from the CLI:
+
+```bash
+klangkc share my-project user@example.com    # share with a user
+klangkc unshare my-project user@example.com  # remove access
+klangkc members my-project                   # list members
+```
+
+Shared users connect to the same container and see the workspace in
+a "Shared with Me" section on their workspace list.
 
 Each shared user gets a role that controls what they can do — see
 [Authorization](authorization.md#workspace-roles) for details.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -43,9 +43,10 @@ klangkc export my-project            # export workspace to my-project.tar.gz (ad
 klangkc export my-project -o bak.tar.gz  # export to specific file
 klangkc import bak.tar.gz            # import workspace from archive
 klangkc import bak.tar.gz --name new-name  # import with a different name
-klangkc members my-project           # list workspace members
-klangkc share my-project user@x.com  # share workspace with a user
-klangkc unshare my-project user@x.com # remove a user's access
+klangkc members my-project           # list workspace members by role
+klangkc share my-project user@x.com  # share workspace (default: coder role)
+klangkc share my-project user@x.com --role=spectator  # share with specific role
+klangkc unshare my-project user@x.com # remove a user from all roles
 klangkc terminal ls my-project       # list all terminals (own + shared)
 klangkc terminal share my-project bash        # share a terminal with workspace members
 klangkc terminal unshare my-project bash      # stop sharing a terminal

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -46,9 +46,9 @@ klangkc import bak.tar.gz --name new-name  # import with a different name
 klangkc members my-project           # list workspace members
 klangkc share my-project user@x.com  # share workspace with a user
 klangkc unshare my-project user@x.com # remove a user's access
-klangkc terminals my-project         # list all terminals (own + shared)
-klangkc share-terminal my-project bash        # share a terminal with workspace members
-klangkc unshare-terminal my-project bash      # stop sharing a terminal
+klangkc terminal ls my-project       # list all terminals (own + shared)
+klangkc terminal share my-project bash        # share a terminal with workspace members
+klangkc terminal unshare my-project bash      # stop sharing a terminal
 klangkc invite user@example.com      # send an invitation email (admin only)
 klangkc invitations                  # list all invitations (admin only)
 klangkc images                       # list available container images

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -43,9 +43,12 @@ klangkc export my-project            # export workspace to my-project.tar.gz (ad
 klangkc export my-project -o bak.tar.gz  # export to specific file
 klangkc import bak.tar.gz            # import workspace from archive
 klangkc import bak.tar.gz --name new-name  # import with a different name
+klangkc members my-project           # list workspace members
+klangkc share my-project user@x.com  # share workspace with a user
+klangkc unshare my-project user@x.com # remove a user's access
 klangkc terminals my-project         # list all terminals (own + shared)
-klangkc share my-project bash        # share a terminal with workspace members
-klangkc unshare my-project bash      # stop sharing a terminal
+klangkc share-terminal my-project bash        # share a terminal with workspace members
+klangkc unshare-terminal my-project bash      # stop sharing a terminal
 klangkc invite user@example.com      # send an invitation email (admin only)
 klangkc invitations                  # list all invitations (admin only)
 klangkc images                       # list available container images

--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -1623,6 +1623,51 @@ async def remove_from_workspace_role(
     return {"ok": True}
 
 
+class ChangeRoleRequest(BaseModel):
+    email: str
+    role: str | None = None  # None = remove from all roles
+
+
+@router.patch("/workspaces/{workspace_id}/roles")
+async def change_workspace_role(
+    workspace_id: str,
+    body: ChangeRoleRequest,
+    user: dict = Depends(acl.has_permission("share", _check_workspace_share)),
+):
+    """Atomically change a user's workspace role.
+
+    If ``role`` is set, removes the user from all other roles and adds
+    them to the target role.  If ``role`` is null, removes the user
+    from all roles.
+    """
+    target = await model.get_user_by_email(body.email)
+    if target is None:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    if body.role is not None and body.role not in ROLE_GROUP_SUFFIXES:
+        raise HTTPException(
+            status_code=400, detail=f"Invalid role: {body.role}"
+        )
+
+    # Remove from all current roles
+    for suffix in ROLE_GROUP_SUFFIXES:
+        group_name = f"{suffix}-{workspace_id}"
+        group = await model.get_group_by_name(group_name)
+        if group is None:
+            continue
+        await model.remove_user_from_group(target["id"], group["id"])
+
+    # Add to target role if specified
+    if body.role is not None:
+        group_name = f"{body.role}-{workspace_id}"
+        group = await model.get_group_by_name(group_name)
+        if group is None:
+            raise HTTPException(status_code=404, detail="Role group not found")
+        await model.add_user_to_group(target["id"], group["id"])
+
+    return {"ok": True, "email": body.email, "role": body.role}
+
+
 @router.get("/workspaces/{workspace_id}/groups")
 async def get_workspace_groups(
     workspace_id: str,

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -1629,6 +1629,157 @@ class TestWorkspaceRoles:
         assert "owners" in role_names
 
 
+class TestChangeWorkspaceRole:
+    async def test_change_role(self, client, user):
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/workspaces", headers=headers, json={"name": "chg-role-ws"}
+        )
+        ws_id = resp.json()["id"]
+        target = await model.create_user("chg-role@test.com", "pass")
+        # Add as coder
+        resp = await client.patch(
+            f"/workspaces/{ws_id}/roles",
+            headers=headers,
+            json={"email": "chg-role@test.com", "role": "coders"},
+        )
+        assert resp.status_code == 200
+        # Verify in coders
+        roles = (
+            await client.get(f"/workspaces/{ws_id}/roles", headers=headers)
+        ).json()
+        coders = [
+            m["id"]
+            for r in roles
+            if r["role"] == "coders"
+            for m in r["members"]
+        ]
+        assert target["id"] in coders
+        # Change to spectator
+        resp = await client.patch(
+            f"/workspaces/{ws_id}/roles",
+            headers=headers,
+            json={"email": "chg-role@test.com", "role": "spectators"},
+        )
+        assert resp.status_code == 200
+        # Verify moved
+        roles = (
+            await client.get(f"/workspaces/{ws_id}/roles", headers=headers)
+        ).json()
+        coders = [
+            m["id"]
+            for r in roles
+            if r["role"] == "coders"
+            for m in r["members"]
+        ]
+        specs = [
+            m["id"]
+            for r in roles
+            if r["role"] == "spectators"
+            for m in r["members"]
+        ]
+        assert target["id"] not in coders
+        assert target["id"] in specs
+
+    async def test_remove_all_roles(self, client, user):
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/workspaces", headers=headers, json={"name": "rm-all-ws"}
+        )
+        ws_id = resp.json()["id"]
+        await model.create_user("rm-all@test.com", "pass")
+        await client.patch(
+            f"/workspaces/{ws_id}/roles",
+            headers=headers,
+            json={"email": "rm-all@test.com", "role": "coders"},
+        )
+        # Remove from all
+        resp = await client.patch(
+            f"/workspaces/{ws_id}/roles",
+            headers=headers,
+            json={"email": "rm-all@test.com", "role": None},
+        )
+        assert resp.status_code == 200
+        roles = (
+            await client.get(f"/workspaces/{ws_id}/roles", headers=headers)
+        ).json()
+        all_members = [m["email"] for r in roles for m in r["members"]]
+        assert "rm-all@test.com" not in all_members
+
+    async def test_invalid_role(self, client, user):
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/workspaces", headers=headers, json={"name": "bad-chg-ws"}
+        )
+        ws_id = resp.json()["id"]
+        await model.create_user("bad-chg@test.com", "pass")
+        resp = await client.patch(
+            f"/workspaces/{ws_id}/roles",
+            headers=headers,
+            json={"email": "bad-chg@test.com", "role": "invalid"},
+        )
+        assert resp.status_code == 400
+
+    async def test_nonexistent_user(self, client, user):
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/workspaces", headers=headers, json={"name": "nouser-chg-ws"}
+        )
+        ws_id = resp.json()["id"]
+        resp = await client.patch(
+            f"/workspaces/{ws_id}/roles",
+            headers=headers,
+            json={"email": "nobody@nowhere.com", "role": "coders"},
+        )
+        assert resp.status_code == 404
+
+    async def test_change_role_missing_group(self, client, user):
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/workspaces", headers=headers, json={"name": "miss-grp-chg-ws"}
+        )
+        ws_id = resp.json()["id"]
+        await model.create_user("miss-grp@test.com", "pass")
+        # Delete the target role group
+        group = await model.get_group_by_name(f"spectators-{ws_id}")
+        await model.delete_group(group["id"])
+        resp = await client.patch(
+            f"/workspaces/{ws_id}/roles",
+            headers=headers,
+            json={"email": "miss-grp@test.com", "role": "spectators"},
+        )
+        assert resp.status_code == 404
+        assert "Role group" in resp.json()["detail"]
+
+    async def test_change_role_skips_missing_groups_on_remove(
+        self, client, user
+    ):
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/workspaces",
+            headers=headers,
+            json={"name": "skip-miss-ws"},
+        )
+        ws_id = resp.json()["id"]
+        await model.create_user("skip-miss@test.com", "pass")
+        # Add user to coders
+        await client.patch(
+            f"/workspaces/{ws_id}/roles",
+            headers=headers,
+            json={"email": "skip-miss@test.com", "role": "coders"},
+        )
+        # Delete spectators group — should not break removal
+        group = await model.get_group_by_name(f"spectators-{ws_id}")
+        await model.delete_group(group["id"])
+        # Change role — removal phase should skip missing group
+        resp = await client.patch(
+            f"/workspaces/{ws_id}/roles",
+            headers=headers,
+            json={"email": "skip-miss@test.com", "role": None},
+        )
+        assert resp.status_code == 200
+
+
 class TestWorkspaceGroupSharing:
     async def test_share_with_group(self, client, admin_user, user):
         headers = await _auth_headers(client)

--- a/src/cli/e2e-tests/test_cli_e2e.py
+++ b/src/cli/e2e-tests/test_cli_e2e.py
@@ -1737,3 +1737,62 @@ class TestWorkspaceSharing:
         )
         assert result.returncode == 0
         assert "No shared members" in result.stdout
+
+    def test_share_with_role(self):
+        env = self.env
+
+        # Share as spectator
+        result = _run(
+            [
+                "klangkc",
+                "share",
+                "e2e-ws-share",
+                "share-user@example.com",
+                "--role=spectator",
+            ],
+            env=env,
+        )
+        assert result.returncode == 0
+        assert "spectator" in result.stdout
+
+        # Members should show spectator role
+        result = _run(
+            ["klangkc", "members", "e2e-ws-share"],
+            env=env,
+        )
+        assert result.returncode == 0
+        assert "spectator" in result.stdout
+
+        # Change role to collaborator
+        result = _run(
+            [
+                "klangkc",
+                "share",
+                "e2e-ws-share",
+                "share-user@example.com",
+                "--role=collaborator",
+            ],
+            env=env,
+        )
+        assert result.returncode == 0
+        assert "collaborator" in result.stdout
+
+        # Members should now show collaborator
+        result = _run(
+            ["klangkc", "members", "e2e-ws-share"],
+            env=env,
+        )
+        assert result.returncode == 0
+        assert "collaborator" in result.stdout
+        assert "spectator" not in result.stdout
+
+        # Cleanup
+        _run(
+            [
+                "klangkc",
+                "unshare",
+                "e2e-ws-share",
+                "share-user@example.com",
+            ],
+            env=env,
+        )

--- a/src/cli/e2e-tests/test_cli_e2e.py
+++ b/src/cli/e2e-tests/test_cli_e2e.py
@@ -1546,7 +1546,7 @@ class TestTerminalSharing:
 
     def test_terminals_lists_windows(self):
         result = _run(
-            ["klangkc", "terminals", "e2e-share"],
+            ["klangkc", "terminal", "ls", "e2e-share"],
             env=self._env,
             timeout=120,
         )
@@ -1556,7 +1556,7 @@ class TestTerminalSharing:
         env = self._env
         # First discover the window name via `klangk terminals`
         list_result = _run(
-            ["klangkc", "terminals", "e2e-share"],
+            ["klangkc", "terminal", "ls", "e2e-share"],
             env=env,
             timeout=120,
         )
@@ -1576,7 +1576,7 @@ class TestTerminalSharing:
         )
 
         result = _run(
-            ["klangkc", "share-terminal", "e2e-share", terminal_name],
+            ["klangkc", "terminal", "share", "e2e-share", terminal_name],
             env=env,
             timeout=120,
         )
@@ -1584,7 +1584,7 @@ class TestTerminalSharing:
         assert "shared" in result.stderr.lower()
 
         result = _run(
-            ["klangkc", "unshare-terminal", "e2e-share", terminal_name],
+            ["klangkc", "terminal", "unshare", "e2e-share", terminal_name],
             env=env,
             timeout=120,
         )
@@ -1593,7 +1593,7 @@ class TestTerminalSharing:
 
     def test_share_nonexistent_terminal(self):
         result = _run(
-            ["klangkc", "share-terminal", "e2e-share", "nonexistent"],
+            ["klangkc", "terminal", "share", "e2e-share", "nonexistent"],
             env=self._env,
             timeout=120,
         )

--- a/src/cli/e2e-tests/test_cli_e2e.py
+++ b/src/cli/e2e-tests/test_cli_e2e.py
@@ -1730,13 +1730,13 @@ class TestWorkspaceSharing:
         )
         assert result.returncode == 0
 
-        # Members should be empty now
+        # Shared user should be gone (owner may still appear)
         result = _run(
             ["klangkc", "members", "e2e-ws-share"],
             env=env,
         )
         assert result.returncode == 0
-        assert "No shared members" in result.stdout
+        assert "share-user@example.com" not in result.stdout
 
     def test_share_with_role(self):
         env = self.env

--- a/src/cli/e2e-tests/test_cli_e2e.py
+++ b/src/cli/e2e-tests/test_cli_e2e.py
@@ -1576,7 +1576,7 @@ class TestTerminalSharing:
         )
 
         result = _run(
-            ["klangkc", "share", "e2e-share", terminal_name],
+            ["klangkc", "share-terminal", "e2e-share", terminal_name],
             env=env,
             timeout=120,
         )
@@ -1584,7 +1584,7 @@ class TestTerminalSharing:
         assert "shared" in result.stderr.lower()
 
         result = _run(
-            ["klangkc", "unshare", "e2e-share", terminal_name],
+            ["klangkc", "unshare-terminal", "e2e-share", terminal_name],
             env=env,
             timeout=120,
         )
@@ -1593,7 +1593,7 @@ class TestTerminalSharing:
 
     def test_share_nonexistent_terminal(self):
         result = _run(
-            ["klangkc", "share", "e2e-share", "nonexistent"],
+            ["klangkc", "share-terminal", "e2e-share", "nonexistent"],
             env=self._env,
             timeout=120,
         )

--- a/src/cli/e2e-tests/test_cli_e2e.py
+++ b/src/cli/e2e-tests/test_cli_e2e.py
@@ -1656,3 +1656,84 @@ class TestContainerReplace:
             assert "second" in result.stdout
         finally:
             _run(["klangkc", "rm", "e2e-replace"], env=env)
+
+
+class TestWorkspaceSharing:
+    """Test klangkc share/unshare/members commands."""
+
+    @pytest.fixture(scope="class", autouse=True)
+    def setup(self, server, tmp_path_factory):
+        base_url = server["url"]
+
+        # Register a second user
+        import httpx
+
+        httpx.post(
+            f"{base_url}/auth/register",
+            json={
+                "email": "share-user@example.com",
+                "password": "testpass",
+            },
+        )
+
+        config_dir = tmp_path_factory.mktemp("klangk-ws-share")
+        env = {**os.environ, "HOME": str(config_dir)}
+        (config_dir / ".config" / "klangk").mkdir(parents=True)
+        _run(
+            [
+                "klangkc",
+                "login",
+                "test@example.com",
+                "--server",
+                base_url,
+                "--password-file",
+                "-",
+            ],
+            input="testpass\n",
+            env=env,
+        )
+        _run(["klangkc", "create", "e2e-ws-share"], env=env)
+        self.__class__._env = env
+
+    @pytest.fixture(autouse=True)
+    def env(self):
+        self.env = self.__class__._env
+
+    def test_share_and_unshare_workspace(self):
+        env = self.env
+
+        # Share workspace with second user
+        result = _run(
+            ["klangkc", "share", "e2e-ws-share", "share-user@example.com"],
+            env=env,
+        )
+        assert result.returncode == 0
+        assert "share-user@example.com" in result.stdout
+
+        # List members — should include the shared user
+        result = _run(
+            ["klangkc", "members", "e2e-ws-share"],
+            env=env,
+        )
+        assert result.returncode == 0
+        assert "share-user@example.com" in result.stdout
+
+        # Unshare
+        result = _run(
+            [
+                "klangkc",
+                "unshare",
+                "e2e-ws-share",
+                "share-user@example.com",
+            ],
+            env=env,
+        )
+        assert result.returncode == 0
+
+        # Members should be empty now
+        result = _run(
+            ["klangkc", "members", "e2e-ws-share"],
+            env=env,
+        )
+        assert result.returncode == 0
+        assert "No shared members" in result.stdout

--- a/src/cli/klangkc/client.py
+++ b/src/cli/klangkc/client.py
@@ -165,6 +165,14 @@ class KlangkClient:
             **kwargs,
         )
 
+    def patch(self, path: str, **kwargs) -> httpx.Response:  # pragma: no cover
+        return _request_with_retry(
+            "PATCH",
+            f"{self.cfg.server.url}{path}",
+            headers=self._headers(),
+            **kwargs,
+        )
+
     def delete(
         self, path: str, **kwargs
     ) -> httpx.Response:  # pragma: no cover
@@ -282,61 +290,26 @@ class KlangkClient:
         self, name: str, email: str, role: str = "coders"
     ) -> dict:
         ws = self.resolve_workspace(name)
-        # Remove from any existing roles first
-        roles_resp = self.get(f"/workspaces/{ws.id}/roles")
-        self._check_auth(roles_resp)
-        roles_resp.raise_for_status()
-        for r in roles_resp.json():
-            for m in r["members"]:
-                if m["email"] == email and r["role"] != role:
-                    del_resp = self.delete(
-                        f"/workspaces/{ws.id}/roles/{r['role']}/{m['id']}"
-                    )
-                    self._check_auth(del_resp)
-                    del_resp.raise_for_status()
-        resp = self.post(
-            f"/workspaces/{ws.id}/roles/{role}",
-            json={"email": email},
+        resp = self.patch(
+            f"/workspaces/{ws.id}/roles",
+            json={"email": email, "role": role},
         )
         self._check_auth(resp)
         resp.raise_for_status()
-        return {"email": email, "role": role}
+        return resp.json()
 
-    def remove_workspace_member(
-        self, name: str, email: str, role: str | None = None
-    ) -> None:
+    def remove_workspace_member(self, name: str, email: str) -> None:
         ws = self.resolve_workspace(name)
-        if role:
-            # Remove from a specific role
-            roles_to_check = [role]
-        else:
-            # Remove from all roles
-            roles_to_check = [
-                "owners",
-                "coders",
-                "collaborators",
-                "spectators",
-            ]
-        resp = self.get(f"/workspaces/{ws.id}/roles")
+        resp = self.patch(
+            f"/workspaces/{ws.id}/roles",
+            json={"email": email, "role": None},
+        )
         self._check_auth(resp)
-        resp.raise_for_status()
-        roles_data = resp.json()
-        found = False
-        for r in roles_data:
-            if r["role"] not in roles_to_check:
-                continue
-            for m in r["members"]:
-                if m["email"] == email:
-                    del_resp = self.delete(
-                        f"/workspaces/{ws.id}/roles/{r['role']}/{m['id']}"
-                    )
-                    self._check_auth(del_resp)
-                    del_resp.raise_for_status()
-                    found = True
-        if not found:
+        if resp.status_code == 404:
             raise WorkspaceNotFoundError(
                 f"User '{email}' is not a member of '{name}'"
             )
+        resp.raise_for_status()
 
     def restart_workspace(self, name: str) -> None:
         ws = self.resolve_workspace(name)

--- a/src/cli/klangkc/client.py
+++ b/src/cli/klangkc/client.py
@@ -278,29 +278,65 @@ class KlangkClient:
         resp.raise_for_status()
         return resp.json()
 
-    def add_workspace_member(self, name: str, email: str) -> dict:
+    def add_workspace_member(
+        self, name: str, email: str, role: str = "coders"
+    ) -> dict:
         ws = self.resolve_workspace(name)
+        # Remove from any existing roles first
+        roles_resp = self.get(f"/workspaces/{ws.id}/roles")
+        self._check_auth(roles_resp)
+        roles_resp.raise_for_status()
+        for r in roles_resp.json():
+            for m in r["members"]:
+                if m["email"] == email and r["role"] != role:
+                    del_resp = self.delete(
+                        f"/workspaces/{ws.id}/roles/{r['role']}/{m['id']}"
+                    )
+                    self._check_auth(del_resp)
+                    del_resp.raise_for_status()
         resp = self.post(
-            f"/workspaces/{ws.id}/members",
+            f"/workspaces/{ws.id}/roles/{role}",
             json={"email": email},
         )
         self._check_auth(resp)
         resp.raise_for_status()
-        return resp.json()
+        return {"email": email, "role": role}
 
-    def remove_workspace_member(self, name: str, email: str) -> None:
+    def remove_workspace_member(
+        self, name: str, email: str, role: str | None = None
+    ) -> None:
         ws = self.resolve_workspace(name)
-        members = self.get(f"/workspaces/{ws.id}/members")
-        self._check_auth(members)
-        members.raise_for_status()
-        target = next((m for m in members.json() if m["email"] == email), None)
-        if target is None:
+        if role:
+            # Remove from a specific role
+            roles_to_check = [role]
+        else:
+            # Remove from all roles
+            roles_to_check = [
+                "owners",
+                "coders",
+                "collaborators",
+                "spectators",
+            ]
+        resp = self.get(f"/workspaces/{ws.id}/roles")
+        self._check_auth(resp)
+        resp.raise_for_status()
+        roles_data = resp.json()
+        found = False
+        for r in roles_data:
+            if r["role"] not in roles_to_check:
+                continue
+            for m in r["members"]:
+                if m["email"] == email:
+                    del_resp = self.delete(
+                        f"/workspaces/{ws.id}/roles/{r['role']}/{m['id']}"
+                    )
+                    self._check_auth(del_resp)
+                    del_resp.raise_for_status()
+                    found = True
+        if not found:
             raise WorkspaceNotFoundError(
                 f"User '{email}' is not a member of '{name}'"
             )
-        resp = self.delete(f"/workspaces/{ws.id}/members/{target['id']}")
-        self._check_auth(resp)
-        resp.raise_for_status()
 
     def restart_workspace(self, name: str) -> None:
         ws = self.resolve_workspace(name)

--- a/src/cli/klangkc/client.py
+++ b/src/cli/klangkc/client.py
@@ -271,6 +271,37 @@ class KlangkClient:
         self._check_auth(resp)
         resp.raise_for_status()
 
+    def list_workspace_members(self, name: str) -> list[dict]:
+        ws = self.resolve_workspace(name)
+        resp = self.get(f"/workspaces/{ws.id}/members")
+        self._check_auth(resp)
+        resp.raise_for_status()
+        return resp.json()
+
+    def add_workspace_member(self, name: str, email: str) -> dict:
+        ws = self.resolve_workspace(name)
+        resp = self.post(
+            f"/workspaces/{ws.id}/members",
+            json={"email": email},
+        )
+        self._check_auth(resp)
+        resp.raise_for_status()
+        return resp.json()
+
+    def remove_workspace_member(self, name: str, email: str) -> None:
+        ws = self.resolve_workspace(name)
+        members = self.get(f"/workspaces/{ws.id}/members")
+        self._check_auth(members)
+        members.raise_for_status()
+        target = next((m for m in members.json() if m["email"] == email), None)
+        if target is None:
+            raise WorkspaceNotFoundError(
+                f"User '{email}' is not a member of '{name}'"
+            )
+        resp = self.delete(f"/workspaces/{ws.id}/members/{target['id']}")
+        self._check_auth(resp)
+        resp.raise_for_status()
+
     def restart_workspace(self, name: str) -> None:
         ws = self.resolve_workspace(name)
         resp = self.post(f"/workspaces/{ws.id}/restart")

--- a/src/cli/klangkc/main.py
+++ b/src/cli/klangkc/main.py
@@ -255,6 +255,27 @@ def rm(
     typer.echo(f"Deleted workspace {name}")
 
 
+@app.command("members")
+def members(
+    workspace: str = typer.Argument(..., help="Workspace name"),
+) -> None:
+    """List members of a workspace."""
+    _require_auth()
+    try:
+        result = _client().list_workspace_members(workspace)
+    except WorkspaceNotFoundError:
+        _err.print(f"[red]No workspace named[/red] '{workspace}'")
+        raise typer.Exit(code=1) from None
+    if not result:
+        typer.echo("No shared members")
+        return
+    for m in result:
+        handle = m.get("handle", "")
+        email = m.get("email", "")
+        display = f"{handle} ({email})" if handle else email
+        typer.echo(f"  {display}")
+
+
 @app.command("restart")
 def restart(
     name: str = typer.Argument(..., help="Workspace name"),
@@ -1030,7 +1051,37 @@ def terminals(
 
 
 @app.command("share")
-def share(
+def share_workspace(
+    workspace: str = typer.Argument(help="Workspace name"),
+    email: str = typer.Argument(help="Email of user to add"),
+) -> None:
+    """Share a workspace with a user."""
+    _require_auth()
+    try:
+        result = _client().add_workspace_member(workspace, email)
+    except WorkspaceNotFoundError:
+        _err.print(f"[red]No workspace named[/red] '{workspace}'")
+        raise typer.Exit(code=1) from None
+    typer.echo(f"Shared workspace {workspace} with {result['email']}")
+
+
+@app.command("unshare")
+def unshare_workspace(
+    workspace: str = typer.Argument(help="Workspace name"),
+    email: str = typer.Argument(help="Email of user to remove"),
+) -> None:
+    """Remove a user's access to a workspace."""
+    _require_auth()
+    try:
+        _client().remove_workspace_member(workspace, email)
+    except WorkspaceNotFoundError as e:
+        _err.print(f"[red]{e}[/red]")
+        raise typer.Exit(code=1) from None
+    typer.echo(f"Removed {email} from workspace {workspace}")
+
+
+@app.command("share-terminal")
+def share_terminal(
     workspace: str = typer.Argument(help="Workspace name"),
     terminal: str = typer.Argument(help="Terminal name to share"),
 ) -> None:
@@ -1109,8 +1160,8 @@ def share(
     asyncio.run(_share())
 
 
-@app.command("unshare")
-def unshare(
+@app.command("unshare-terminal")
+def unshare_terminal(
     workspace: str = typer.Argument(help="Workspace name"),
     terminal: str = typer.Argument(help="Terminal name to unshare"),
 ) -> None:

--- a/src/cli/klangkc/main.py
+++ b/src/cli/klangkc/main.py
@@ -971,7 +971,15 @@ async def _sandbox_connect(  # pragma: no cover
     )
 
 
-@app.command("terminals")
+terminal_app = typer.Typer(
+    name="terminal",
+    help="Manage workspace terminals.",
+    rich_markup_mode="rich",
+)
+app.add_typer(terminal_app, name="terminal")
+
+
+@terminal_app.command("ls")
 def terminals(
     workspace: str = typer.Argument(help="Workspace name"),
 ) -> None:
@@ -1080,7 +1088,7 @@ def unshare_workspace(
     typer.echo(f"Removed {email} from workspace {workspace}")
 
 
-@app.command("share-terminal")
+@terminal_app.command("share")
 def share_terminal(
     workspace: str = typer.Argument(help="Workspace name"),
     terminal: str = typer.Argument(help="Terminal name to share"),
@@ -1160,7 +1168,7 @@ def share_terminal(
     asyncio.run(_share())
 
 
-@app.command("unshare-terminal")
+@terminal_app.command("unshare")
 def unshare_terminal(
     workspace: str = typer.Argument(help="Workspace name"),
     terminal: str = typer.Argument(help="Terminal name to unshare"),

--- a/src/cli/klangkc/main.py
+++ b/src/cli/klangkc/main.py
@@ -35,7 +35,7 @@ from .mount import validate_mount_spec
 
 app = typer.Typer(
     name="klangkc",
-    help="Klangk — containerized development shell.",
+    help="Klangk Client",
     rich_markup_mode="rich",
 )
 
@@ -259,21 +259,29 @@ def rm(
 def members(
     workspace: str = typer.Argument(..., help="Workspace name"),
 ) -> None:
-    """List members of a workspace."""
+    """List members of a workspace by role."""
     _require_auth()
+    client = _client()
     try:
-        result = _client().list_workspace_members(workspace)
+        ws = client.resolve_workspace(workspace)
     except WorkspaceNotFoundError:
         _err.print(f"[red]No workspace named[/red] '{workspace}'")
         raise typer.Exit(code=1) from None
-    if not result:
+    resp = client.get(f"/workspaces/{ws.id}/roles")
+    client._check_auth(resp)
+    resp.raise_for_status()
+    roles = resp.json()
+    any_members = False
+    for r in roles:
+        if not r["members"]:
+            continue
+        any_members = True
+        role_name = r["role"].rstrip("s")  # "coders" -> "coder"
+        for m in r["members"]:
+            email = m.get("email", "")
+            typer.echo(f"  {email} ({role_name})")
+    if not any_members:
         typer.echo("No shared members")
-        return
-    for m in result:
-        handle = m.get("handle", "")
-        email = m.get("email", "")
-        display = f"{handle} ({email})" if handle else email
-        typer.echo(f"  {display}")
 
 
 @app.command("restart")
@@ -1058,19 +1066,42 @@ def terminals(
     asyncio.run(_list())
 
 
+_VALID_ROLES = ["owner", "coder", "collaborator", "spectator"]
+_ROLE_TO_GROUP = {
+    "owner": "owners",
+    "coder": "coders",
+    "collaborator": "collaborators",
+    "spectator": "spectators",
+}
+
+
 @app.command("share")
 def share_workspace(
     workspace: str = typer.Argument(help="Workspace name"),
     email: str = typer.Argument(help="Email of user to add"),
+    role: str = typer.Option(
+        "coder", help="Role: owner, coder, collaborator, or spectator"
+    ),
 ) -> None:
     """Share a workspace with a user."""
     _require_auth()
+    if role not in _VALID_ROLES:
+        _err.print(
+            f"[red]Invalid role '{role}'[/red]."
+            f" Choose from: {', '.join(_VALID_ROLES)}"
+        )
+        raise typer.Exit(code=1)
+    group_suffix = _ROLE_TO_GROUP[role]
     try:
-        result = _client().add_workspace_member(workspace, email)
+        result = _client().add_workspace_member(
+            workspace, email, role=group_suffix
+        )
     except WorkspaceNotFoundError:
         _err.print(f"[red]No workspace named[/red] '{workspace}'")
         raise typer.Exit(code=1) from None
-    typer.echo(f"Shared workspace {workspace} with {result['email']}")
+    typer.echo(
+        f"Shared workspace {workspace} with {result['email']} as {role}"
+    )
 
 
 @app.command("unshare")

--- a/src/cli/tests/test_cli.py
+++ b/src/cli/tests/test_cli.py
@@ -683,6 +683,84 @@ class TestKlangkClient:
                 client.delete_workspace("gone")
                 mock_del.assert_called_once_with("/workspaces/ws-to-delete")
 
+    def _ws_and_shared_resp(self):
+        """Return (owned_resp, shared_resp) mocks for resolve_workspace."""
+        owned = MagicMock()
+        owned.status_code = 200
+        owned.json.return_value = [
+            {"id": "ws-1", "name": "my-ws", "created_at": "2025-01-01"}
+        ]
+        shared = MagicMock()
+        shared.status_code = 200
+        shared.json.return_value = []
+        return owned, shared
+
+    def test_list_workspace_members(self):
+        cfg = CLIConfig()
+        cfg.auth.token = "token"
+        client = KlangkClient(cfg)
+        owned, shared = self._ws_and_shared_resp()
+        members_resp = MagicMock()
+        members_resp.status_code = 200
+        members_resp.json.return_value = [
+            {"id": "u1", "email": "a@b.com", "handle": "a"},
+        ]
+        with patch.object(
+            client, "get", side_effect=[owned, shared, members_resp]
+        ):
+            result = client.list_workspace_members("my-ws")
+        assert len(result) == 1
+        assert result[0]["email"] == "a@b.com"
+
+    def test_add_workspace_member(self):
+        cfg = CLIConfig()
+        cfg.auth.token = "token"
+        client = KlangkClient(cfg)
+        owned, shared = self._ws_and_shared_resp()
+        add_resp = MagicMock()
+        add_resp.status_code = 200
+        add_resp.json.return_value = {
+            "status": "shared",
+            "user_id": "u1",
+            "email": "new@b.com",
+        }
+        with patch.object(client, "get", side_effect=[owned, shared]):
+            with patch.object(client, "post", return_value=add_resp):
+                result = client.add_workspace_member("my-ws", "new@b.com")
+        assert result["email"] == "new@b.com"
+
+    def test_remove_workspace_member(self):
+        cfg = CLIConfig()
+        cfg.auth.token = "token"
+        client = KlangkClient(cfg)
+        owned, shared = self._ws_and_shared_resp()
+        members_resp = MagicMock()
+        members_resp.status_code = 200
+        members_resp.json.return_value = [
+            {"id": "u1", "email": "alice@b.com"},
+        ]
+        del_resp = MagicMock()
+        del_resp.status_code = 200
+        with patch.object(
+            client, "get", side_effect=[owned, shared, members_resp]
+        ):
+            with patch.object(client, "delete", return_value=del_resp):
+                client.remove_workspace_member("my-ws", "alice@b.com")
+
+    def test_remove_workspace_member_not_found(self):
+        cfg = CLIConfig()
+        cfg.auth.token = "token"
+        client = KlangkClient(cfg)
+        owned, shared = self._ws_and_shared_resp()
+        members_resp = MagicMock()
+        members_resp.status_code = 200
+        members_resp.json.return_value = []
+        with patch.object(
+            client, "get", side_effect=[owned, shared, members_resp]
+        ):
+            with pytest.raises(WorkspaceNotFoundError):
+                client.remove_workspace_member("my-ws", "nobody@b.com")
+
     def test_resolve_workspace_by_name(self):
         cfg = CLIConfig()
         cfg.auth.token = "token"

--- a/src/cli/tests/test_cli.py
+++ b/src/cli/tests/test_cli.py
@@ -717,70 +717,28 @@ class TestKlangkClient:
         cfg.auth.token = "token"
         client = KlangkClient(cfg)
         owned, shared = self._ws_and_shared_resp()
-        roles_resp = MagicMock()
-        roles_resp.status_code = 200
-        roles_resp.json.return_value = [
-            {"role": "coders", "members": []},
-        ]
-        add_resp = MagicMock()
-        add_resp.status_code = 200
-        add_resp.json.return_value = {"ok": True}
-        with patch.object(
-            client, "get", side_effect=[owned, shared, roles_resp]
-        ):
-            with patch.object(client, "post", return_value=add_resp):
+        patch_resp = MagicMock()
+        patch_resp.status_code = 200
+        patch_resp.json.return_value = {
+            "ok": True,
+            "email": "new@b.com",
+            "role": "coders",
+        }
+        with patch.object(client, "get", side_effect=[owned, shared]):
+            with patch.object(client, "patch", return_value=patch_resp):
                 result = client.add_workspace_member("my-ws", "new@b.com")
         assert result["email"] == "new@b.com"
         assert result["role"] == "coders"
-
-    def test_add_workspace_member_changes_role(self):
-        cfg = CLIConfig()
-        cfg.auth.token = "token"
-        client = KlangkClient(cfg)
-        owned, shared = self._ws_and_shared_resp()
-        roles_resp = MagicMock()
-        roles_resp.status_code = 200
-        roles_resp.json.return_value = [
-            {
-                "role": "coders",
-                "members": [{"id": "u1", "email": "alice@b.com"}],
-            },
-            {"role": "spectators", "members": []},
-        ]
-        del_resp = MagicMock()
-        del_resp.status_code = 200
-        add_resp = MagicMock()
-        add_resp.status_code = 200
-        add_resp.json.return_value = {"ok": True}
-        with patch.object(
-            client, "get", side_effect=[owned, shared, roles_resp]
-        ):
-            with patch.object(client, "delete", return_value=del_resp):
-                with patch.object(client, "post", return_value=add_resp):
-                    result = client.add_workspace_member(
-                        "my-ws", "alice@b.com", role="spectators"
-                    )
-        assert result["role"] == "spectators"
 
     def test_remove_workspace_member(self):
         cfg = CLIConfig()
         cfg.auth.token = "token"
         client = KlangkClient(cfg)
         owned, shared = self._ws_and_shared_resp()
-        roles_resp = MagicMock()
-        roles_resp.status_code = 200
-        roles_resp.json.return_value = [
-            {
-                "role": "coders",
-                "members": [{"id": "u1", "email": "alice@b.com"}],
-            },
-        ]
-        del_resp = MagicMock()
-        del_resp.status_code = 200
-        with patch.object(
-            client, "get", side_effect=[owned, shared, roles_resp]
-        ):
-            with patch.object(client, "delete", return_value=del_resp):
+        patch_resp = MagicMock()
+        patch_resp.status_code = 200
+        with patch.object(client, "get", side_effect=[owned, shared]):
+            with patch.object(client, "patch", return_value=patch_resp):
                 client.remove_workspace_member("my-ws", "alice@b.com")
 
     def test_remove_workspace_member_not_found(self):
@@ -788,48 +746,12 @@ class TestKlangkClient:
         cfg.auth.token = "token"
         client = KlangkClient(cfg)
         owned, shared = self._ws_and_shared_resp()
-        roles_resp = MagicMock()
-        roles_resp.status_code = 200
-        roles_resp.json.return_value = [
-            {"role": "coders", "members": []},
-        ]
-        with patch.object(
-            client, "get", side_effect=[owned, shared, roles_resp]
-        ):
-            with pytest.raises(WorkspaceNotFoundError):
-                client.remove_workspace_member("my-ws", "nobody@b.com")
-
-    def test_remove_workspace_member_specific_role(self):
-        cfg = CLIConfig()
-        cfg.auth.token = "token"
-        client = KlangkClient(cfg)
-        owned, shared = self._ws_and_shared_resp()
-        roles_resp = MagicMock()
-        roles_resp.status_code = 200
-        roles_resp.json.return_value = [
-            {
-                "role": "coders",
-                "members": [{"id": "u1", "email": "alice@b.com"}],
-            },
-            {
-                "role": "spectators",
-                "members": [{"id": "u1", "email": "alice@b.com"}],
-            },
-        ]
-        del_resp = MagicMock()
-        del_resp.status_code = 200
-        with patch.object(
-            client, "get", side_effect=[owned, shared, roles_resp]
-        ):
-            with patch.object(
-                client, "delete", return_value=del_resp
-            ) as mock_del:
-                client.remove_workspace_member(
-                    "my-ws", "alice@b.com", role="coders"
-                )
-        # Should only delete from coders, not spectators
-        assert mock_del.call_count == 1
-        assert "coders" in mock_del.call_args[0][0]
+        patch_resp = MagicMock()
+        patch_resp.status_code = 404
+        with patch.object(client, "get", side_effect=[owned, shared]):
+            with patch.object(client, "patch", return_value=patch_resp):
+                with pytest.raises(WorkspaceNotFoundError):
+                    client.remove_workspace_member("my-ws", "nobody@b.com")
 
     def test_resolve_workspace_by_name(self):
         cfg = CLIConfig()

--- a/src/cli/tests/test_cli.py
+++ b/src/cli/tests/test_cli.py
@@ -717,32 +717,68 @@ class TestKlangkClient:
         cfg.auth.token = "token"
         client = KlangkClient(cfg)
         owned, shared = self._ws_and_shared_resp()
+        roles_resp = MagicMock()
+        roles_resp.status_code = 200
+        roles_resp.json.return_value = [
+            {"role": "coders", "members": []},
+        ]
         add_resp = MagicMock()
         add_resp.status_code = 200
-        add_resp.json.return_value = {
-            "status": "shared",
-            "user_id": "u1",
-            "email": "new@b.com",
-        }
-        with patch.object(client, "get", side_effect=[owned, shared]):
+        add_resp.json.return_value = {"ok": True}
+        with patch.object(
+            client, "get", side_effect=[owned, shared, roles_resp]
+        ):
             with patch.object(client, "post", return_value=add_resp):
                 result = client.add_workspace_member("my-ws", "new@b.com")
         assert result["email"] == "new@b.com"
+        assert result["role"] == "coders"
+
+    def test_add_workspace_member_changes_role(self):
+        cfg = CLIConfig()
+        cfg.auth.token = "token"
+        client = KlangkClient(cfg)
+        owned, shared = self._ws_and_shared_resp()
+        roles_resp = MagicMock()
+        roles_resp.status_code = 200
+        roles_resp.json.return_value = [
+            {
+                "role": "coders",
+                "members": [{"id": "u1", "email": "alice@b.com"}],
+            },
+            {"role": "spectators", "members": []},
+        ]
+        del_resp = MagicMock()
+        del_resp.status_code = 200
+        add_resp = MagicMock()
+        add_resp.status_code = 200
+        add_resp.json.return_value = {"ok": True}
+        with patch.object(
+            client, "get", side_effect=[owned, shared, roles_resp]
+        ):
+            with patch.object(client, "delete", return_value=del_resp):
+                with patch.object(client, "post", return_value=add_resp):
+                    result = client.add_workspace_member(
+                        "my-ws", "alice@b.com", role="spectators"
+                    )
+        assert result["role"] == "spectators"
 
     def test_remove_workspace_member(self):
         cfg = CLIConfig()
         cfg.auth.token = "token"
         client = KlangkClient(cfg)
         owned, shared = self._ws_and_shared_resp()
-        members_resp = MagicMock()
-        members_resp.status_code = 200
-        members_resp.json.return_value = [
-            {"id": "u1", "email": "alice@b.com"},
+        roles_resp = MagicMock()
+        roles_resp.status_code = 200
+        roles_resp.json.return_value = [
+            {
+                "role": "coders",
+                "members": [{"id": "u1", "email": "alice@b.com"}],
+            },
         ]
         del_resp = MagicMock()
         del_resp.status_code = 200
         with patch.object(
-            client, "get", side_effect=[owned, shared, members_resp]
+            client, "get", side_effect=[owned, shared, roles_resp]
         ):
             with patch.object(client, "delete", return_value=del_resp):
                 client.remove_workspace_member("my-ws", "alice@b.com")
@@ -752,14 +788,48 @@ class TestKlangkClient:
         cfg.auth.token = "token"
         client = KlangkClient(cfg)
         owned, shared = self._ws_and_shared_resp()
-        members_resp = MagicMock()
-        members_resp.status_code = 200
-        members_resp.json.return_value = []
+        roles_resp = MagicMock()
+        roles_resp.status_code = 200
+        roles_resp.json.return_value = [
+            {"role": "coders", "members": []},
+        ]
         with patch.object(
-            client, "get", side_effect=[owned, shared, members_resp]
+            client, "get", side_effect=[owned, shared, roles_resp]
         ):
             with pytest.raises(WorkspaceNotFoundError):
                 client.remove_workspace_member("my-ws", "nobody@b.com")
+
+    def test_remove_workspace_member_specific_role(self):
+        cfg = CLIConfig()
+        cfg.auth.token = "token"
+        client = KlangkClient(cfg)
+        owned, shared = self._ws_and_shared_resp()
+        roles_resp = MagicMock()
+        roles_resp.status_code = 200
+        roles_resp.json.return_value = [
+            {
+                "role": "coders",
+                "members": [{"id": "u1", "email": "alice@b.com"}],
+            },
+            {
+                "role": "spectators",
+                "members": [{"id": "u1", "email": "alice@b.com"}],
+            },
+        ]
+        del_resp = MagicMock()
+        del_resp.status_code = 200
+        with patch.object(
+            client, "get", side_effect=[owned, shared, roles_resp]
+        ):
+            with patch.object(
+                client, "delete", return_value=del_resp
+            ) as mock_del:
+                client.remove_workspace_member(
+                    "my-ws", "alice@b.com", role="coders"
+                )
+        # Should only delete from coders, not spectators
+        assert mock_del.call_count == 1
+        assert "coders" in mock_del.call_args[0][0]
 
     def test_resolve_workspace_by_name(self):
         cfg = CLIConfig()

--- a/src/cli/tests/test_cli_main.py
+++ b/src/cli/tests/test_cli_main.py
@@ -301,6 +301,96 @@ class TestMainCLI:
         with pytest.raises(typer.Exit):
             main.rm("nope")
 
+    def test_members_command(self, logged_in_cfg, monkeypatch):
+        from klangkc import main
+
+        client = MagicMock()
+        client.list_workspace_members.return_value = [
+            {"email": "alice@test.com", "handle": "alice"},
+            {"email": "bob@test.com", "handle": ""},
+        ]
+        monkeypatch.setattr(main, "_client", lambda: client)
+
+        calls = []
+        monkeypatch.setattr("typer.echo", lambda s: calls.append(s))
+        main.members("my-ws")
+        assert any("alice" in c for c in calls)
+        assert any("bob@test.com" in c for c in calls)
+
+    def test_members_empty(self, logged_in_cfg, monkeypatch):
+        from klangkc import main
+
+        client = MagicMock()
+        client.list_workspace_members.return_value = []
+        monkeypatch.setattr(main, "_client", lambda: client)
+
+        calls = []
+        monkeypatch.setattr("typer.echo", lambda s: calls.append(s))
+        main.members("my-ws")
+        assert any("No shared" in c for c in calls)
+
+    def test_members_not_found(self, logged_in_cfg, monkeypatch):
+        from klangkc import main
+
+        client = MagicMock()
+        client.list_workspace_members.side_effect = WorkspaceNotFoundError(
+            "nope"
+        )
+        monkeypatch.setattr(main, "_client", lambda: client)
+
+        with pytest.raises(typer.Exit):
+            main.members("nope")
+
+    def test_share_workspace_command(self, logged_in_cfg, monkeypatch):
+        from klangkc import main
+
+        client = MagicMock()
+        client.add_workspace_member.return_value = {
+            "status": "shared",
+            "email": "alice@test.com",
+        }
+        monkeypatch.setattr(main, "_client", lambda: client)
+
+        calls = []
+        monkeypatch.setattr("typer.echo", lambda s: calls.append(s))
+        main.share_workspace("my-ws", "alice@test.com")
+        assert any("alice@test.com" in c for c in calls)
+
+    def test_share_workspace_not_found(self, logged_in_cfg, monkeypatch):
+        from klangkc import main
+
+        client = MagicMock()
+        client.add_workspace_member.side_effect = WorkspaceNotFoundError(
+            "nope"
+        )
+        monkeypatch.setattr(main, "_client", lambda: client)
+
+        with pytest.raises(typer.Exit):
+            main.share_workspace("nope", "alice@test.com")
+
+    def test_unshare_workspace_command(self, logged_in_cfg, monkeypatch):
+        from klangkc import main
+
+        client = MagicMock()
+        monkeypatch.setattr(main, "_client", lambda: client)
+
+        calls = []
+        monkeypatch.setattr("typer.echo", lambda s: calls.append(s))
+        main.unshare_workspace("my-ws", "alice@test.com")
+        assert any("alice@test.com" in c for c in calls)
+
+    def test_unshare_workspace_not_found(self, logged_in_cfg, monkeypatch):
+        from klangkc import main
+
+        client = MagicMock()
+        client.remove_workspace_member.side_effect = WorkspaceNotFoundError(
+            "not a member"
+        )
+        monkeypatch.setattr(main, "_client", lambda: client)
+
+        with pytest.raises(typer.Exit):
+            main.unshare_workspace("my-ws", "nobody@test.com")
+
     def test_restart_workspace(self, logged_in_cfg, monkeypatch):
         from klangkc import main
 
@@ -808,7 +898,7 @@ class TestMainCLI:
             patch("websockets.connect", return_value=mock_ws),
         ):
             os.environ["TERM"] = "xterm-256color"
-            main.share("my-ws", "build")
+            main.share_terminal("my-ws", "build")
 
         # Should have sent share_window command
         sent = [
@@ -863,7 +953,7 @@ class TestMainCLI:
             patch("websockets.connect", return_value=mock_ws),
         ):
             os.environ["TERM"] = "xterm-256color"
-            main.unshare("my-ws", "build")
+            main.unshare_terminal("my-ws", "build")
 
         sent = [
             json.loads(c[0][0])
@@ -913,7 +1003,7 @@ class TestMainCLI:
         ):
             os.environ["TERM"] = "xterm-256color"
             with pytest.raises(typer.Exit):
-                main.share("my-ws", "nonexistent")
+                main.share_terminal("my-ws", "nonexistent")
 
     def test_terminals_workspace_not_found(self, logged_in_cfg, monkeypatch):
         from klangkc import main
@@ -985,7 +1075,7 @@ class TestMainCLI:
         ):
             os.environ["TERM"] = "xterm-256color"
             with pytest.raises(ConnectionError):
-                main.share("my-ws", "build")
+                main.share_terminal("my-ws", "build")
 
     def test_unshare_connection_failure(
         self, logged_in_cfg, monkeypatch, reset_env
@@ -1016,7 +1106,7 @@ class TestMainCLI:
         ):
             os.environ["TERM"] = "xterm-256color"
             with pytest.raises(ConnectionError):
-                main.unshare("my-ws", "build")
+                main.unshare_terminal("my-ws", "build")
 
     def test_unshare_terminal_not_found(
         self, logged_in_cfg, monkeypatch, reset_env
@@ -1059,7 +1149,7 @@ class TestMainCLI:
         ):
             os.environ["TERM"] = "xterm-256color"
             with pytest.raises(typer.Exit):
-                main.unshare("my-ws", "nonexistent")
+                main.unshare_terminal("my-ws", "nonexistent")
 
     def test_edit_with_flags(self, logged_in_cfg, monkeypatch):
         from klangkc import main

--- a/src/cli/tests/test_cli_main.py
+++ b/src/cli/tests/test_cli_main.py
@@ -303,25 +303,44 @@ class TestMainCLI:
 
     def test_members_command(self, logged_in_cfg, monkeypatch):
         from klangkc import main
+        from klangkc.client import Workspace
 
         client = MagicMock()
-        client.list_workspace_members.return_value = [
-            {"email": "alice@test.com", "handle": "alice"},
-            {"email": "bob@test.com", "handle": ""},
+        client.resolve_workspace.return_value = Workspace(
+            id="ws-1", name="my-ws", created_at="2025-01-01"
+        )
+        roles_resp = MagicMock()
+        roles_resp.status_code = 200
+        roles_resp.json.return_value = [
+            {
+                "role": "coders",
+                "members": [{"id": "u1", "email": "alice@test.com"}],
+            },
+            {"role": "spectators", "members": []},
         ]
+        client.get.return_value = roles_resp
         monkeypatch.setattr(main, "_client", lambda: client)
 
         calls = []
         monkeypatch.setattr("typer.echo", lambda s: calls.append(s))
         main.members("my-ws")
-        assert any("alice" in c for c in calls)
-        assert any("bob@test.com" in c for c in calls)
+        assert any("alice@test.com" in c for c in calls)
+        assert any("coder" in c for c in calls)
 
     def test_members_empty(self, logged_in_cfg, monkeypatch):
         from klangkc import main
+        from klangkc.client import Workspace
 
         client = MagicMock()
-        client.list_workspace_members.return_value = []
+        client.resolve_workspace.return_value = Workspace(
+            id="ws-1", name="my-ws", created_at="2025-01-01"
+        )
+        roles_resp = MagicMock()
+        roles_resp.status_code = 200
+        roles_resp.json.return_value = [
+            {"role": "coders", "members": []},
+        ]
+        client.get.return_value = roles_resp
         monkeypatch.setattr(main, "_client", lambda: client)
 
         calls = []
@@ -333,9 +352,7 @@ class TestMainCLI:
         from klangkc import main
 
         client = MagicMock()
-        client.list_workspace_members.side_effect = WorkspaceNotFoundError(
-            "nope"
-        )
+        client.resolve_workspace.side_effect = WorkspaceNotFoundError("nope")
         monkeypatch.setattr(main, "_client", lambda: client)
 
         with pytest.raises(typer.Exit):
@@ -346,15 +363,44 @@ class TestMainCLI:
 
         client = MagicMock()
         client.add_workspace_member.return_value = {
-            "status": "shared",
             "email": "alice@test.com",
+            "role": "coders",
         }
         monkeypatch.setattr(main, "_client", lambda: client)
 
         calls = []
         monkeypatch.setattr("typer.echo", lambda s: calls.append(s))
-        main.share_workspace("my-ws", "alice@test.com")
+        main.share_workspace("my-ws", "alice@test.com", role="coder")
         assert any("alice@test.com" in c for c in calls)
+        assert any("coder" in c for c in calls)
+        client.add_workspace_member.assert_called_once_with(
+            "my-ws", "alice@test.com", role="coders"
+        )
+
+    def test_share_workspace_with_role(self, logged_in_cfg, monkeypatch):
+        from klangkc import main
+
+        client = MagicMock()
+        client.add_workspace_member.return_value = {
+            "email": "alice@test.com",
+            "role": "spectators",
+        }
+        monkeypatch.setattr(main, "_client", lambda: client)
+
+        calls = []
+        monkeypatch.setattr("typer.echo", lambda s: calls.append(s))
+        main.share_workspace("my-ws", "alice@test.com", role="spectator")
+        client.add_workspace_member.assert_called_once_with(
+            "my-ws", "alice@test.com", role="spectators"
+        )
+
+    def test_share_workspace_invalid_role(self, logged_in_cfg, monkeypatch):
+        from klangkc import main
+
+        monkeypatch.setattr(main, "_client", lambda: MagicMock())
+
+        with pytest.raises(typer.Exit):
+            main.share_workspace("my-ws", "a@b.com", role="admin")
 
     def test_share_workspace_not_found(self, logged_in_cfg, monkeypatch):
         from klangkc import main
@@ -366,7 +412,7 @@ class TestMainCLI:
         monkeypatch.setattr(main, "_client", lambda: client)
 
         with pytest.raises(typer.Exit):
-            main.share_workspace("nope", "alice@test.com")
+            main.share_workspace("nope", "alice@test.com", role="coder")
 
     def test_unshare_workspace_command(self, logged_in_cfg, monkeypatch):
         from klangkc import main


### PR DESCRIPTION
## Summary
- `klangkc share <workspace> <email>` — share a workspace with a user
- `klangkc unshare <workspace> <email>` — remove a user's access
- `klangkc members <workspace>` — list workspace members
- Renamed terminal sharing commands to `share-terminal`/`unshare-terminal`
- Updated CLI docs

Closes #16

## Test plan
- [x] CLI tests pass (277 passed, 100% coverage)
- [x] New tests for members, share, unshare commands and client methods