### PR TITLE
fix: always pre-check HTTP before WebSocket connect

### DIFF
--- a/src/frontend/e2e-tests/e2e/ws-connect-speed.spec.ts
+++ b/src/frontend/e2e-tests/e2e/ws-connect-speed.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect } from "@playwright/test";
+import {
+  registerUser,
+  createWorkspace,
+  openWorkspace,
+  waitForFlutter,
+  loginViaUI,
+  TEST_PASSWORD,
+} from "./helpers";
+
+// These tests verify that WebSocket connections complete quickly,
+// guarding against Firefox's FailDelayManager throttling connections
+// by up to 60s after an unclean close.
+
+test.describe("WebSocket connect speed", () => {
+  test("workspace opens within 10s of WebSocket connect", async ({
+    page,
+    request,
+  }) => {
+    const email = `ws-speed-${Date.now()}@test.example.com`;
+    const { headers } = await registerUser(request, email);
+    const { workspaceId, cleanup } = await createWorkspace(
+      request,
+      headers,
+      "ws-speed",
+    );
+
+    try {
+      await loginViaUI(page, email, TEST_PASSWORD);
+
+      let containerReady = false;
+      page.on("websocket", (ws: { on: Function }) => {
+        ws.on("framereceived", (frame: { payload: string | Buffer }) => {
+          const text = frame.payload.toString();
+          if (text.includes("container_ready")) containerReady = true;
+        });
+      });
+
+      const start = Date.now();
+      await page.goto(`/#/workspace/${workspaceId}`, { waitUntil: "load" });
+      await waitForFlutter(page);
+
+      await expect
+        .poll(() => containerReady, {
+          timeout: 10_000,
+          message: "container_ready not received within 10s of navigation",
+        })
+        .toBeTruthy();
+
+      const elapsed = Date.now() - start;
+      expect(elapsed).toBeLessThan(10_000);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test("workspace reopens within 10s after navigating away and back", async ({
+    page,
+    request,
+  }) => {
+    const email = `ws-reopen-${Date.now()}@test.example.com`;
+    const { headers } = await registerUser(request, email);
+    const { workspaceId, cleanup } = await createWorkspace(
+      request,
+      headers,
+      "ws-reopen",
+    );
+
+    try {
+      // First visit: register a global WS frame listener that persists
+      // across SPA navigations. Track container_ready count.
+      let containerReadyCount = 0;
+      page.on("websocket", (ws: { on: Function }) => {
+        ws.on("framereceived", (frame: { payload: string | Buffer }) => {
+          const text = frame.payload.toString();
+          if (text.includes("container_ready")) containerReadyCount++;
+        });
+      });
+
+      await openWorkspace(page, email, workspaceId, {
+        containerTimeout: 30_000,
+      });
+      // First container_ready received
+      expect(containerReadyCount).toBeGreaterThanOrEqual(1);
+      const countAfterFirst = containerReadyCount;
+
+      // Navigate away via hash (SPA, no full reload — WS stays open)
+      await page.evaluate(() => {
+        window.location.hash = "#/workspaces";
+      });
+      await page.waitForTimeout(2000);
+
+      // Second visit: navigate back to workspace
+      const reopenStart = Date.now();
+      await page.evaluate((id: string) => {
+        window.location.hash = `#/workspace/${id}`;
+      }, workspaceId);
+
+      await expect
+        .poll(() => containerReadyCount > countAfterFirst, {
+          timeout: 10_000,
+          message: "container_ready not received within 10s on reopen",
+        })
+        .toBeTruthy();
+
+      const reopenTime = Date.now() - reopenStart;
+      expect(reopenTime).toBeLessThan(10_000);
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/frontend/e2e-tests/playwright.config.ts
+++ b/src/frontend/e2e-tests/playwright.config.ts
@@ -77,12 +77,17 @@ export default defineConfig({
         "shared-terminals.spec.ts",
         "tab-speed.spec.ts",
         "sudo.spec.ts",
+        "ws-connect-speed.spec.ts",
       ],
       use: chromiumUse,
     },
     {
       name: "firefox",
-      testMatch: ["klangk.spec.ts", "terminal-keymap.spec.ts"],
+      testMatch: [
+        "klangk.spec.ts",
+        "terminal-keymap.spec.ts",
+        "ws-connect-speed.spec.ts",
+      ],
       use: firefoxUse,
     },
     {

--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -54,11 +54,6 @@ class WsClient extends ChangeNotifier {
   /// Set to false during intentional disconnects.
   bool _autoReconnect = false;
 
-  /// Whether the last WebSocket close was unclean (not code 1000).
-  /// Firefox's FailDelayManager throttles reconnections after unclean
-  /// closes, so we pre-check via HTTP before reconnecting.
-  bool _lastCloseUnclean = false;
-
   /// Max backoff duration in seconds.
   static const int _maxBackoffSeconds = 30;
 
@@ -188,17 +183,14 @@ class WsClient extends ChangeNotifier {
     _reconnectTimer = null;
     if (_connected || _auth?.token == null) return;
 
-    // After an unclean WebSocket close, Firefox's FailDelayManager throttles
-    // new WebSocket connections by up to 60s. HTTP requests are not affected,
-    // so we pre-check via HTTP to confirm the server is reachable before
-    // opening a new WebSocket. This avoids hanging on `channel.ready`.
-    if (_lastCloseUnclean) {
-      final serverUp = await _waitForServer();
-      if (!serverUp) {
-        _scheduleReconnect();
-        return;
-      }
-      _lastCloseUnclean = false;
+    // Firefox's FailDelayManager throttles WebSocket connections by up to
+    // 60s after an unclean close, and persists this across page reloads.
+    // HTTP is not affected, so we always pre-check server reachability
+    // before opening a WebSocket to avoid hanging on `channel.ready`.
+    final serverUp = await _waitForServer();
+    if (!serverUp) {
+      _scheduleReconnect();
+      return;
     }
 
     if (testChannelFactory != null) {
@@ -339,7 +331,6 @@ class WsClient extends ChangeNotifier {
         _currentWorkspaceId = null;
         _defaultCommand = null;
         final code = _channel?.closeCode;
-        _lastCloseUnclean = code != 1000;
         notifyListeners();
         if (code == 4001 || code == 4002) {
           _errorController.add('Session expired, please log in again');

--- a/src/frontend/test/ws_client_test.dart
+++ b/src/frontend/test/ws_client_test.dart
@@ -256,11 +256,10 @@ void main() {
       client.dispose();
     });
 
-    test('unclean close sets flag and pre-checks HTTP on reconnect', () async {
+    test('connect always pre-checks HTTP before opening WebSocket', () async {
       SharedPreferences.setMockInitialValues({'klangk_jwt': 'test-token'});
       final channel = _FakeWebSocketChannel();
       WsClient.testChannelFactory = (_) => channel;
-      WsClient.testBackoffOverride = (_) => Duration.zero;
       var httpCheckCalled = false;
       WsClient.testHttpPreCheck = () async {
         httpCheckCalled = true;
@@ -274,100 +273,28 @@ void main() {
       client.updateAuth(auth);
 
       await client.connect();
+      expect(httpCheckCalled, isTrue);
       expect(client.connected, isTrue);
 
-      // Connect to workspace so auto-reconnect is armed
-      client.connectWorkspace('ws1');
-      channel.serverSend({'type': 'workspace_ready', 'workspaceId': 'ws1'});
+      WsClient.testHttpPreCheck = null;
+      client.dispose();
+    });
+
+    test('connect aborts when HTTP pre-check fails', () async {
+      SharedPreferences.setMockInitialValues({'klangk_jwt': 'test-token'});
+      final channel = _FakeWebSocketChannel();
+      WsClient.testChannelFactory = (_) => channel;
+      WsClient.testHttpPreCheck = () async => false;
+
+      final auth = AuthService();
       await Future.delayed(Duration.zero);
 
-      // Simulate unclean server close (no code 1000)
-      channel.serverClose(1006);
-      await Future.delayed(Duration.zero);
+      final client = WsClient();
+      client.updateAuth(auth);
+
+      await client.connect();
       expect(client.connected, isFalse);
 
-      // Wait for reconnect attempt
-      await Future.delayed(const Duration(milliseconds: 50));
-      expect(httpCheckCalled, isTrue);
-
-      WsClient.testBackoffOverride = null;
-      WsClient.testHttpPreCheck = null;
-      client.dispose();
-    });
-
-    test('clean close does not trigger HTTP pre-check', () async {
-      SharedPreferences.setMockInitialValues({'klangk_jwt': 'test-token'});
-      final channel = _FakeWebSocketChannel();
-      WsClient.testChannelFactory = (_) => channel;
-      WsClient.testBackoffOverride = (_) => Duration.zero;
-      var httpCheckCalled = false;
-      WsClient.testHttpPreCheck = () async {
-        httpCheckCalled = true;
-        return true;
-      };
-
-      final auth = AuthService();
-      await Future.delayed(Duration.zero);
-
-      final client = WsClient();
-      client.updateAuth(auth);
-
-      await client.connect();
-      expect(client.connected, isTrue);
-
-      // Connect to workspace so auto-reconnect is armed
-      client.connectWorkspace('ws1');
-      channel.serverSend({'type': 'workspace_ready', 'workspaceId': 'ws1'});
-      await Future.delayed(Duration.zero);
-
-      // Simulate clean server close (code 1000)
-      channel.serverClose(1000);
-      await Future.delayed(Duration.zero);
-
-      // Wait for reconnect attempt
-      await Future.delayed(const Duration(milliseconds: 50));
-      expect(httpCheckCalled, isFalse);
-
-      WsClient.testBackoffOverride = null;
-      WsClient.testHttpPreCheck = null;
-      client.dispose();
-    });
-
-    test('HTTP pre-check failure schedules another reconnect', () async {
-      SharedPreferences.setMockInitialValues({'klangk_jwt': 'test-token'});
-      final channel = _FakeWebSocketChannel();
-      WsClient.testChannelFactory = (_) => channel;
-      WsClient.testBackoffOverride = (_) => Duration.zero;
-      var httpCheckCount = 0;
-      WsClient.testHttpPreCheck = () async {
-        httpCheckCount++;
-        return false; // server not reachable
-      };
-
-      final auth = AuthService();
-      await Future.delayed(Duration.zero);
-
-      final client = WsClient();
-      client.updateAuth(auth);
-
-      await client.connect();
-      expect(client.connected, isTrue);
-
-      // Connect to workspace so auto-reconnect is armed
-      client.connectWorkspace('ws1');
-      channel.serverSend({'type': 'workspace_ready', 'workspaceId': 'ws1'});
-      await Future.delayed(Duration.zero);
-
-      // Simulate unclean close
-      channel.serverClose(1006);
-      await Future.delayed(Duration.zero);
-
-      // First reconnect attempt: HTTP check fails, schedules another
-      await Future.delayed(const Duration(milliseconds: 50));
-      expect(httpCheckCount, greaterThanOrEqualTo(1));
-      expect(client.reconnecting, isTrue);
-
-      WsClient.testBackoffOverride = null;
       WsClient.testHttpPreCheck = null;
       client.dispose();
     });


### PR DESCRIPTION
## Summary
- Always pre-check server reachability via HTTP before opening a WebSocket connection, not just after in-session unclean closes
- Firefox's FailDelayManager persists throttle state across page reloads, so the previous conditional check missed cross-session throttling
- Removed `_lastCloseUnclean` tracking (no longer needed)
- Added E2E tests on both Firefox and Chromium asserting workspace connect completes within 10s

## Test plan
- [x] 67 ws_client unit tests pass
- [x] 562 frontend unit tests pass
- [x] E2E `ws-connect-speed.spec.ts` passes on Firefox (2 tests, 25s)
- [x] E2E `ws-connect-speed.spec.ts` passes on Chromium (2 tests, 21s)

Fixes #603