### PR TITLE
docs: document container policy.json requirement

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,6 +51,12 @@ To run project commands like `test-backend` or `build-workspace-image`
 in a separate terminal, use `devenv shell` to enter the same
 environment.
 
+!!! note "Podman policy errors"
+If you see errors about missing container signatures or policies,
+you may need to create a policy file. See
+[Container Policy](reference/podman.md#container-policy) for
+instructions.
+
 ## Logging In
 
 Log in with `admin@example.com` (or whatever you set

--- a/docs/reference/podman.md
+++ b/docs/reference/podman.md
@@ -36,6 +36,29 @@ achieve `Supports shifting: true`.
 This means `storage-chown-by-maps` is the normal and expected path
 for rootless podman.
 
+## Container Policy
+
+Podman requires a container signature policy file to pull and manage
+images. The devenv shell creates one automatically, but outside of
+devenv (e.g., production deployments) you need to create it yourself:
+
+```bash
+mkdir -p ~/.config/containers
+cat > ~/.config/containers/policy.json <<'EOF'
+{
+    "default": [
+        {
+            "type": "insecureAcceptAnything"
+        }
+    ]
+}
+EOF
+```
+
+Alternatively, create it system-wide at `/etc/containers/policy.json`.
+Without this file, podman operations fail with confusing errors about
+missing signatures or policies.
+
 ## Configuring Storage
 
 By default, podman stores images and runtime state under


### PR DESCRIPTION
Add container policy section to podman docs. Devenv handles this
automatically, but production deployments need manual setup.

Closes #617