### PR TITLE
fix: debounce presence join/leave broadcasts during reconnection

### DIFF
--- a/src/backend/klangk_backend/wshandler.py
+++ b/src/backend/klangk_backend/wshandler.py
@@ -404,6 +404,12 @@ class WorkspaceSession:
 class WebSocketState:
     """Module-level singleton holding mutable WebSocket handler state."""
 
+    # Delay before broadcasting presence_leave after a user disconnects.
+    # If the same user reconnects within this window the leave (and the
+    # subsequent re-join) are suppressed, avoiding flicker during
+    # WebSocket reconnection with backoff.
+    PRESENCE_LEAVE_DELAY = 10.0  # seconds
+
     def __init__(self) -> None:
         # Active connections: SafeWebSocket -> Connection
         self.connections: dict[SafeWebSocket, "Connection"] = {}
@@ -421,6 +427,10 @@ class WebSocketState:
         self.streaming_browser_requests: dict[
             str, tuple[asyncio.Queue, SafeWebSocket | None]
         ] = {}
+        # Pending presence leave tasks: (workspace_id, user_id) → Task.
+        # When a user's last connection drops we schedule a delayed
+        # broadcast; if they reconnect before it fires we cancel it.
+        self._pending_leaves: dict[tuple[str, str], asyncio.Task] = {}
 
     def get_session(self, workspace_id: str) -> WorkspaceSession | None:
         return self.sessions.get(workspace_id)
@@ -450,6 +460,79 @@ class WebSocketState:
         """Remove session when caller already holds ``session.lock``."""
         self.sessions.pop(session.workspace_id, None)
         await session.reset()
+
+    def cancel_pending_leave(self, workspace_id: str, user_id: str) -> bool:
+        """Cancel a pending presence_leave for *user_id* in *workspace_id*.
+
+        Returns True if a pending leave was cancelled (meaning the
+        subsequent join broadcast should also be suppressed).
+        """
+        key = (workspace_id, user_id)
+        task = self._pending_leaves.pop(key, None)
+        if task and not task.done():
+            task.cancel()
+            logger.info(
+                "Cancelled pending presence_leave for user %s in %s",
+                user_id,
+                workspace_id,
+            )
+            return True
+        return False
+
+    def schedule_pending_leave(
+        self,
+        workspace_id: str,
+        user: dict,
+        session: "WorkspaceSession",
+    ) -> None:
+        """Schedule a delayed presence_leave broadcast.
+
+        If the user reconnects before the delay expires the task is
+        cancelled via ``cancel_pending_leave``.
+        """
+        user_id = user["id"]
+        key = (workspace_id, user_id)
+        # Cancel any already-pending leave (shouldn't happen, but be safe).
+        old = self._pending_leaves.pop(key, None)
+        if old and not old.done():  # pragma: no cover
+            old.cancel()
+
+        async def _fire() -> None:
+            try:
+                await asyncio.sleep(self.PRESENCE_LEAVE_DELAY)
+            except asyncio.CancelledError:
+                return
+            finally:
+                self._pending_leaves.pop(key, None)
+
+            # Still no connection for this user in the workspace?
+            cur_session = self.get_session(workspace_id)
+            if cur_session:
+                still_connected = any(
+                    self.connections.get(s) is not None
+                    and self.connections[s].user["id"] == user_id
+                    for s in cur_session.subscribers
+                )
+                if still_connected:  # pragma: no cover
+                    return
+
+                sys_msg = await model.add_chat_message(
+                    workspace_id,
+                    user_id,
+                    user["email"],
+                    f"{user.get('handle') or user['email']} left",
+                    message_type=model.MSG_SYSTEM,
+                )
+                cur_session.broadcast({"type": "chat_message", **sys_msg})
+                cur_session.broadcast(
+                    {
+                        "type": "presence_leave",
+                        "user_id": user_id,
+                        "user_email": user["email"],
+                    }
+                )
+
+        self._pending_leaves[key] = asyncio.create_task(_fire())
 
     async def reset_workspace(self, workspace_id: str) -> None:
         """Clean up shared state for a workspace.
@@ -841,11 +924,16 @@ class Connection:
         if self.container_id:
             asyncio.create_task(self._start_agent_if_needed(self.container_id))
 
+        # If this user had a pending leave (reconnecting after a brief
+        # disconnect), cancel it and suppress the join broadcast — other
+        # users never saw them leave so there's nothing to announce.
+        rejoining = state.cancel_pending_leave(workspace_id, self.user["id"])
+
         # Send presence list to joining user and broadcast join to others
         presence = await _get_presence_list(workspace_id)
         self.sock.send_json({"type": "presence_list", "users": presence})
         session = state.get_session(workspace_id)
-        if session:
+        if session and not rejoining:
             join_msg = {
                 "type": "presence_join",
                 "user_id": self.user["id"],
@@ -2205,28 +2293,17 @@ class Connection:
         if session:
             empty = await session.remove_subscriber(self.sock)
             if not empty:
-                # Broadcast presence_leave if user has no other connections
+                # Schedule a debounced presence_leave if user has no
+                # other connections.  If they reconnect within the delay
+                # window the leave (and re-join) are suppressed.
                 still_connected = any(
                     state.connections.get(s) is not None
                     and state.connections[s].user["id"] == self.user["id"]
                     for s in session.subscribers
                 )
                 if not still_connected:
-                    # Broadcast a system chat message for the leave
-                    sys_msg = await model.add_chat_message(
-                        workspace_id,
-                        self.user["id"],
-                        self.user["email"],
-                        f"{self.user.get('handle') or self.user['email']} left",
-                        message_type=model.MSG_SYSTEM,
-                    )
-                    session.broadcast({"type": "chat_message", **sys_msg})
-                    session.broadcast(
-                        {
-                            "type": "presence_leave",
-                            "user_id": self.user["id"],
-                            "user_email": self.user["email"],
-                        }
+                    state.schedule_pending_leave(
+                        workspace_id, self.user, session
                     )
             else:
                 # Lock is released by remove_subscriber, so use the

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -5421,7 +5421,7 @@ class TestPresence:
             wshandler.state.connections.pop(sock2, None)
 
     async def test_presence_leave_broadcast(self, user):
-        """Remaining subscribers receive presence_leave on disconnect."""
+        """Remaining subscribers receive presence_leave after debounce."""
         from klangk_backend import model
 
         workspace = await _create_workspace_with_acl(user["id"], "pres-lv-ws")
@@ -5443,18 +5443,128 @@ class TestPresence:
         wshandler.state.connections[sock1] = conn1
         wshandler.state.connections[sock2] = conn2
 
+        saved_delay = wshandler.state.PRESENCE_LEAVE_DELAY
         try:
-            # conn2 disconnects
+            # Use a tiny delay so the test completes quickly
+            wshandler.state.PRESENCE_LEAVE_DELAY = 0.05
+
+            # conn2 disconnects — leave is debounced, not immediate
             await conn2.cleanup()
+            calls1 = [c[0][0] for c in sock1.send_json.call_args_list]
+            leaves = [c for c in calls1 if c.get("type") == "presence_leave"]
+            assert len(leaves) == 0  # not yet
+
+            # Wait for the debounce to fire
+            await asyncio.sleep(0.1)
 
             calls1 = [c[0][0] for c in sock1.send_json.call_args_list]
             leaves = [c for c in calls1 if c.get("type") == "presence_leave"]
             assert len(leaves) == 1
             assert leaves[0]["user_id"] == other["id"]
         finally:
+            wshandler.state.PRESENCE_LEAVE_DELAY = saved_delay
+            wshandler.state._pending_leaves.clear()
             wshandler.state.sessions.pop(workspace["id"], None)
             wshandler.state.connections.pop(sock1, None)
             wshandler.state.connections.pop(sock2, None)
+
+    async def test_presence_leave_suppressed_on_reconnect(self, user):
+        """Reconnecting within debounce window suppresses leave and join."""
+        from klangk_backend import model
+
+        workspace = await _create_workspace_with_acl(
+            user["id"], "pres-debounce-ws"
+        )
+
+        sock1 = _mock_sock()  # observer
+        other = await model.create_user("flap@test.com", "hash", verified=True)
+        await model.add_acl_entry(
+            f"/workspaces/{workspace['id']}",
+            1,
+            model.ACTION_ALLOW,
+            "*",
+            model.PRINCIPAL_USER,
+            user_id=other["id"],
+        )
+        other_user = {
+            "id": other["id"],
+            "email": "flap@test.com",
+            "handle": other.get("handle", ""),
+        }
+        sock2 = _mock_sock()  # flapping user
+        conn1 = _base_conn(user=user, ws=sock1)
+        conn2 = _base_conn(user=other_user, ws=sock2)
+        conn1.workspace_id = workspace["id"]
+        conn2.workspace_id = workspace["id"]
+
+        session = WorkspaceSession(workspace["id"])
+        session.subscribers.add(sock1)
+        session.subscribers.add(sock2)
+        wshandler.state.sessions[workspace["id"]] = session
+        wshandler.state.connections[sock1] = conn1
+        wshandler.state.connections[sock2] = conn2
+
+        saved_delay = wshandler.state.PRESENCE_LEAVE_DELAY
+        try:
+            wshandler.state.PRESENCE_LEAVE_DELAY = 5.0  # long enough to cancel
+
+            # conn2 disconnects — pending leave scheduled
+            await conn2.cleanup()
+            key = (workspace["id"], other["id"])
+            assert key in wshandler.state._pending_leaves
+
+            # conn2 reconnects — cancel pending leave
+            sock3 = _mock_sock()
+            conn3 = _base_conn(user=other_user, ws=sock3)
+            wshandler.state.connections[sock3] = conn3
+
+            async def fake_start(wid, ws_obj):
+                conn3.container_id = "cid"
+                s = wshandler.state.get_or_create_session(wid)
+                await s.add_subscriber(sock3, "cid")
+
+            with (
+                patch.object(
+                    Connection,
+                    "start_workspace_container",
+                    side_effect=fake_start,
+                ),
+                patch.object(
+                    container.registry,
+                    "get_workspace_ports",
+                    return_value=[],
+                ),
+            ):
+                await conn3.handle_workspace_connect(
+                    {"workspaceId": workspace["id"]}
+                )
+
+            # Pending leave should be cancelled
+            assert key not in wshandler.state._pending_leaves
+
+            # Observer should NOT have received presence_leave or
+            # presence_join (the user never visibly left)
+            calls1 = [c[0][0] for c in sock1.send_json.call_args_list]
+            leaves = [c for c in calls1 if c.get("type") == "presence_leave"]
+            joins = [c for c in calls1 if c.get("type") == "presence_join"]
+            assert len(leaves) == 0
+            assert len(joins) == 0
+
+            # No system chat messages about join/leave
+            chats = [
+                c
+                for c in calls1
+                if c.get("type") == "chat_message"
+                and c.get("message_type") == model.MSG_SYSTEM
+            ]
+            assert len(chats) == 0
+        finally:
+            wshandler.state.PRESENCE_LEAVE_DELAY = saved_delay
+            wshandler.state._pending_leaves.clear()
+            wshandler.state.sessions.pop(workspace["id"], None)
+            wshandler.state.connections.pop(sock1, None)
+            wshandler.state.connections.pop(sock2, None)
+            wshandler.state.connections.pop(sock3, None)
 
     async def test_presence_leave_multi_tab(self, user):
         """No presence_leave if user has another connection in workspace."""

--- a/src/frontend/e2e-tests/e2e/klangk.spec.ts
+++ b/src/frontend/e2e-tests/e2e/klangk.spec.ts
@@ -1471,10 +1471,11 @@ test.describe("Klangk E2E", () => {
     expect(joinMsgs.length).toBeGreaterThan(0);
     expect(joinMsgs[0].message).toBe(`${memberHandle} joined`);
 
-    // Member leaves — owner should see a "left" system message
+    // Member leaves — owner should see a "left" system message after the
+    // backend's 10-second presence debounce window expires.
     const beforeLeave = systemMessages.length;
     await ctx2.close();
-    await page1.waitForTimeout(2000);
+    await page1.waitForTimeout(12000);
 
     const leaveMsgs = systemMessages.filter(
       (m) => m.message.includes("left") && m.message.includes(memberHandle),


### PR DESCRIPTION
## Summary
- Delay `presence_leave` broadcast by 10 seconds after a user's last WebSocket disconnects
- If the same user reconnects within that window, cancel the pending leave and suppress the re-join broadcast and system chat messages
- Other users no longer see repeated join/leave flicker or a stream of "{user} joined" / "{user} left" messages during WebSocket reconnection with backoff

## Implementation
- Added `_pending_leaves` dict on `WebSocketState` tracking `(workspace_id, user_id) → asyncio.Task`
- `schedule_pending_leave()` creates a delayed task that re-checks connection state before broadcasting
- `cancel_pending_leave()` cancels the task and returns `True` so the join handler knows to suppress its broadcast
- Multi-tab behavior unchanged: if a user has other connections in the workspace, no leave is scheduled at all

## Test plan
- [x] `test_presence_leave_broadcast` — leave fires after debounce delay
- [x] `test_presence_leave_suppressed_on_reconnect` — reconnect within window suppresses both leave and join
- [x] `test_presence_leave_multi_tab` — multi-tab still works (no leave when other tabs remain)
- [x] Full backend suite: 1398 passed, 100% coverage

Closes #246