### PR TITLE
fix: narrow broad except clauses and fix error log levels

### DIFF
--- a/src/backend/klangk_backend/agent.py
+++ b/src/backend/klangk_backend/agent.py
@@ -258,8 +258,8 @@ class AgentSession:
             try:
                 cmd = json.dumps({"type": "abort"})
                 proc.stdin.write((cmd + "\n").encode())
-            except Exception:  # pragma: no cover
-                pass
+            except (OSError, RuntimeError):  # pragma: no cover
+                pass  # process stdin already closed
 
     async def _wait_for_ack(self, stdout: asyncio.StreamReader) -> None:
         """Read lines until the Pi RPC command acknowledgement.

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -632,7 +632,7 @@ class ContainerRegistry:
                                 bound & wanted_ports,
                             )
                         except podman.PodmanError as del_exc:
-                            logger.info(
+                            logger.warning(
                                 "Could not remove stale container %s: %s",
                                 stale_id[:12],
                                 del_exc,

--- a/src/backend/klangk_backend/terminal.py
+++ b/src/backend/klangk_backend/terminal.py
@@ -593,8 +593,8 @@ class ShellProcess:
         if self._master_fd is not None:
             try:
                 asyncio.get_running_loop().remove_reader(self._master_fd)
-            except Exception:
-                pass
+            except (ValueError, RuntimeError):
+                pass  # loop already closed or fd not registered
             if self._read_event is not None:
                 self._read_event.set()  # unblock any pending read
             try:


### PR DESCRIPTION
## Summary
- Narrow `except Exception: pass` in terminal.py to `(ValueError, RuntimeError)` for event loop `remove_reader` cleanup
- Narrow `except Exception: pass` in agent.py to `(OSError, RuntimeError)` for stdin abort writes
- Change stale container removal failure log level from INFO to WARNING in container.py

Closes #376

## Test plan
- [x] Backend tests pass (1397 passed, 100% coverage)