### PR TITLE
fix(security): address CodeQL code scanning findings

### DIFF
--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -1898,13 +1898,11 @@ async def download_file(
         raise HTTPException(status_code=400, detail=str(e))
     if not resolved.exists():
         raise HTTPException(status_code=404, detail="Path not found")
-    if resolved.is_file():  # lgtm[py/path-injection]
-        return FileResponse(  # lgtm[py/path-injection]
-            resolved, filename=resolved.name
-        )
+    if resolved.is_file():
+        return FileResponse(resolved, filename=resolved.name)
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
-        for file_path in resolved.rglob("*"):  # lgtm[py/path-injection]
+        for file_path in resolved.rglob("*"):
             if file_path.is_file():
                 zf.write(file_path, file_path.relative_to(resolved))
     buf.seek(0)
@@ -1945,12 +1943,12 @@ async def upload_file(
     max_upload = FILE_UPLOAD_SIZE_MAX
     total = 0
     try:
-        with open(dest, "wb") as fp:  # lgtm[py/path-injection]
+        with open(dest, "wb") as fp:
             while chunk := await file.read(1024 * 1024):
                 total += len(chunk)
                 if total > max_upload:
                     fp.close()
-                    dest.unlink(missing_ok=True)  # lgtm[py/path-injection]
+                    dest.unlink(missing_ok=True)
                     raise HTTPException(
                         status_code=413,
                         detail=f"File exceeds {max_upload // (1024 * 1024)} MB limit",
@@ -1959,7 +1957,7 @@ async def upload_file(
     except HTTPException:
         raise
     except Exception as e:  # pragma: no cover
-        dest.unlink(missing_ok=True)  # lgtm[py/path-injection]
+        dest.unlink(missing_ok=True)
         raise HTTPException(
             status_code=500, detail=f"Upload failed: {e}"
         ) from e

--- a/src/backend/klangk_backend/files.py
+++ b/src/backend/klangk_backend/files.py
@@ -3,8 +3,7 @@
 All path-accepting functions in this module delegate to ``resolve_path``
 which validates that the resolved path stays within the workspace root
 via ``Path.is_relative_to``.  CodeQL cannot trace this inter-procedural
-validation, so downstream filesystem operations are annotated with
-``lgtm[py/path-injection]`` suppressions.
+validation; the corresponding alerts are dismissed as false positives.
 """
 
 import shutil
@@ -16,7 +15,7 @@ from . import workspaces
 def resolve_path(user_id: str, workspace_id: str, relative_path: str) -> Path:
     """Resolve a relative path within a workspace, preventing traversal."""
     root = workspaces.get_home_host_path(user_id, workspace_id).resolve()
-    resolved = (root / relative_path).resolve()  # lgtm[py/path-injection]
+    resolved = (root / relative_path).resolve()
     if not resolved.is_relative_to(root):
         raise ValueError("Path traversal not allowed")
     return resolved
@@ -27,7 +26,7 @@ def list_files(
 ) -> list[dict]:
     """List files and directories at the given path."""
     path = resolve_path(user_id, workspace_id, relative_path)
-    if not path.exists() or not path.is_dir():  # lgtm[py/path-injection]
+    if not path.exists() or not path.is_dir():
         return []
 
     entries = []
@@ -52,17 +51,15 @@ def read_file(
 ) -> str | None:
     """Read file contents. Returns None if file doesn't exist or is too large."""
     path = resolve_path(user_id, workspace_id, relative_path)
-    if not path.exists() or not path.is_file():  # lgtm[py/path-injection]
+    if not path.exists() or not path.is_file():
         return None
 
     # Limit to 1MB
-    if path.stat().st_size > 1_000_000:  # lgtm[py/path-injection]
+    if path.stat().st_size > 1_000_000:
         return None
 
     try:
-        return path.read_text(  # lgtm[py/path-injection]
-            encoding="utf-8", errors="replace"
-        )
+        return path.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return None
 
@@ -70,12 +67,12 @@ def read_file(
 def delete_path(user_id: str, workspace_id: str, relative_path: str) -> str:
     """Delete a file or directory. Returns the relative path deleted."""
     path = resolve_path(user_id, workspace_id, relative_path)
-    if not path.exists():  # lgtm[py/path-injection]
+    if not path.exists():
         raise FileNotFoundError("Path not found")
-    if path.is_dir():  # lgtm[py/path-injection]
-        shutil.rmtree(path)  # lgtm[py/path-injection]
+    if path.is_dir():
+        shutil.rmtree(path)
     else:
-        path.unlink()  # lgtm[py/path-injection]
+        path.unlink()
     return str(
         path.relative_to(workspaces.get_home_host_path(user_id, workspace_id))
     )
@@ -87,12 +84,12 @@ def rename_path(
     """Rename/move a file or directory. Returns the new relative path."""
     src = resolve_path(user_id, workspace_id, old_path)
     dst = resolve_path(user_id, workspace_id, new_path)
-    if not src.exists():  # lgtm[py/path-injection]
+    if not src.exists():
         raise FileNotFoundError("Source path not found")
-    if dst.exists():  # lgtm[py/path-injection]
+    if dst.exists():
         raise FileExistsError("Destination already exists")
-    dst.parent.mkdir(parents=True, exist_ok=True)  # lgtm[py/path-injection]
-    src.rename(dst)  # lgtm[py/path-injection]
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    src.rename(dst)
     return str(
         dst.relative_to(workspaces.get_home_host_path(user_id, workspace_id))
     )
@@ -103,8 +100,8 @@ def write_file(
 ) -> str:
     """Write file contents. Returns the resolved relative path."""
     path = resolve_path(user_id, workspace_id, relative_path)
-    path.parent.mkdir(parents=True, exist_ok=True)  # lgtm[py/path-injection]
-    path.write_bytes(content)  # lgtm[py/path-injection]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
     return str(
         path.relative_to(workspaces.get_home_host_path(user_id, workspace_id))
     )
@@ -119,5 +116,5 @@ def write_file_path(
     Callers are responsible for writing data to the returned path.
     """
     path = resolve_path(user_id, workspace_id, relative_path)
-    path.parent.mkdir(parents=True, exist_ok=True)  # lgtm[py/path-injection]
+    path.parent.mkdir(parents=True, exist_ok=True)
     return path

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -131,12 +131,17 @@ async def seed_default_user() -> None:
         await model.add_user_to_group(user["id"], admin_group_id)
         if generated:
             logger.info(
-                "%sCreated default admin user '%s' with generated"
-                " password: %s%s",
-                _GREEN,
+                "Created default admin user '%s' (password printed to stderr)",
                 email,
-                password,
-                _RESET,
+            )
+            # Print password to stderr only — keep it out of structured
+            # logs where it could be shipped to a log aggregator.
+            import sys
+
+            print(
+                f"{_GREEN}Default admin password for"
+                f" '{email}': {password}{_RESET}",
+                file=sys.stderr,
             )
         else:
             logger.info("Created default user '%s' in admin group", email)

--- a/src/backend/tests/test_main.py
+++ b/src/backend/tests/test_main.py
@@ -40,15 +40,21 @@ class TestSeedDefaultUser:
         group_ids = await model.get_user_group_ids(user["id"])
         assert admin_group["id"] in group_ids
 
-    async def test_generated_password_is_logged(self, db, monkeypatch, caplog):
+    async def test_generated_password_printed_to_stderr(
+        self, db, monkeypatch, caplog, capsys
+    ):
         monkeypatch.setenv("KLANGK_DEFAULT_USER", "log-test")
         monkeypatch.delenv("KLANGK_DEFAULT_PASSWORD", raising=False)
         import logging
 
         with caplog.at_level(logging.INFO):
             await main.seed_default_user()
-        assert "generated password:" in caplog.text
+        # Password must NOT appear in log output (security)
+        assert "password printed to stderr" in caplog.text
         assert "log-test" in caplog.text
+        # Password appears on stderr only
+        captured = capsys.readouterr()
+        assert "Default admin password for" in captured.err
 
 
 # --- Seed agent user ---


### PR DESCRIPTION
## Summary
- Move generated admin password from `logger.info()` to `print(..., file=sys.stderr)` to prevent credentials from being shipped to log aggregators
- Remove stale `lgtm[py/path-injection]` inline comments that CodeQL ignores
- Dismiss all 24 path-injection alerts as false positives via the GitHub API (all paths validated through `resolve_path()` which uses `Path.resolve()` + `is_relative_to()`)

## Test plan
- [x] Full backend suite: 1397 passed, 100% coverage
- [x] Verified all 24 CodeQL alerts dismissed on GitHub

Closes #624