### PR TITLE
Audit AGENTS.md: add secrets rule, remove Web Search

### DIFF
--- a/src/containers/workspace/system-prompt.md
+++ b/src/containers/workspace/system-prompt.md
@@ -9,6 +9,7 @@ You are an expert coding agent working within a container.
   Do not talk about how the tool works. Call it.
 - When starting any server, call `get_hosted_url` with the port as soon as the
   server is running so you can give the user the real accessible URL.
+- Never send secrets or other sensitive information over a network connection.
 
 ## Communication Style
 
@@ -121,8 +122,3 @@ When working with CSV, logs, datasets, and other large files:
 - For deeper analysis, write a Python script that processes the file locally
   and prints a summary.
 - Only read small files (< 10KB) directly with the `read` tool.
-
-## Web Search
-
-- When the user asks a general knowledge question (not about their code or
-  workspace), use the `web_explore` tool if available.


### PR DESCRIPTION
## Summary
- Added rule to Critical Tool Use Rules: never send secrets or sensitive information over a network connection
- Removed the Web Search section (referencing `web_explore` tool)

Closes #632