### PR TITLE
Stream zip downloads via temp file instead of memory

### DIFF
--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -1,7 +1,6 @@
 """API route handlers for Klangk backend."""
 
 import asyncio
-import io
 import json
 import logging
 import os
@@ -18,6 +17,7 @@ import zipfile
 import httpx
 
 from fastapi import APIRouter, Depends, HTTPException, Request, UploadFile
+from starlette.background import BackgroundTask
 from fastapi.responses import (
     FileResponse,
     JSONResponse,
@@ -1900,19 +1900,23 @@ async def download_file(
         raise HTTPException(status_code=404, detail="Path not found")
     if resolved.is_file():
         return FileResponse(resolved, filename=resolved.name)
-    buf = io.BytesIO()
-    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
-        for file_path in resolved.rglob("*"):
-            if file_path.is_file():
-                zf.write(file_path, file_path.relative_to(resolved))
-    buf.seek(0)
-    return StreamingResponse(
-        buf,
-        media_type="application/zip",
-        headers={
-            "Content-Disposition": f'attachment; filename="{resolved.name}.zip"'
-        },
-    )
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".zip")
+    try:
+        with zipfile.ZipFile(tmp, "w", zipfile.ZIP_DEFLATED) as zf:
+            for file_path in resolved.rglob("*"):
+                if file_path.is_file():
+                    zf.write(file_path, file_path.relative_to(resolved))
+        tmp.close()
+        return FileResponse(
+            tmp.name,
+            media_type="application/zip",
+            filename=f"{resolved.name}.zip",
+            background=BackgroundTask(os.unlink, tmp.name),
+        )
+    except BaseException:
+        tmp.close()
+        os.unlink(tmp.name)
+        raise
 
 
 @router.post("/workspaces/{workspace_id}/files/upload")

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -2734,6 +2734,23 @@ class TestFileRoutes:
         assert "b.txt" in names
         assert zf.read("a.txt") == b"aaa"
 
+    async def test_download_directory_zip_error_cleans_up(self, client, user):
+        headers = await _auth_headers(client)
+        ws_id = await self._create_workspace(client, headers)
+
+        await client.post(
+            f"/workspaces/{ws_id}/files/upload?path=mydir/a.txt",
+            headers=headers,
+            files={"file": ("a.txt", b"aaa", "text/plain")},
+        )
+        with patch("klangk_backend.api.zipfile.ZipFile") as mock_zf:
+            mock_zf.side_effect = OSError("disk full")
+            with pytest.raises(OSError, match="disk full"):
+                await client.get(
+                    f"/workspaces/{ws_id}/files/download?path=mydir",
+                    headers=headers,
+                )
+
     async def test_download_nonexistent(self, client, user):
         headers = await _auth_headers(client)
         ws_id = await self._create_workspace(client, headers)


### PR DESCRIPTION
## Summary
- Replace `io.BytesIO()` buffering with `tempfile.NamedTemporaryFile` + `FileResponse` for directory zip downloads
- Temp file is cleaned up via `BackgroundTask` after response, or immediately on error
- Add test for zip creation error cleanup path

Closes #626

## Test plan
- [x] All 1399 backend tests pass with 100% coverage