### PR TITLE
Replace RuntimeError with domain-specific exceptions

### DIFF
--- a/src/backend/klangk_backend/auth.py
+++ b/src/backend/klangk_backend/auth.py
@@ -10,6 +10,7 @@ from jose import ExpiredSignatureError, JWTError, jwt
 from pydantic import BaseModel
 
 from . import model
+from .exceptions import ConfigurationError
 from .util import resolve_env_secret
 
 logger = logging.getLogger(__name__)
@@ -80,7 +81,7 @@ def require_secure_jwt_secret() -> None:
         resolve_env_secret("KLANGK_PREVENT_INSECURE_JWT_SECRET", "") or ""
     ).lower()
     if prevent in ("1", "true", "yes"):
-        raise RuntimeError(
+        raise ConfigurationError(
             "KLANGK_JWT_SECRET is unset or the insecure default. Set a "
             "strong secret or remove KLANGK_PREVENT_INSECURE_JWT_SECRET."
         )

--- a/src/backend/klangk_backend/emailsvc.py
+++ b/src/backend/klangk_backend/emailsvc.py
@@ -8,6 +8,7 @@ from email.message import EmailMessage
 
 import aiosmtplib
 
+from .exceptions import SendmailError
 from .util import resolve_env_secret
 
 logger = logging.getLogger(__name__)
@@ -82,7 +83,7 @@ async def send_via_sendmail(msg: EmailMessage) -> None:
     )
     stdout, stderr = await proc.communicate(msg.as_bytes())
     if proc.returncode != 0:
-        raise RuntimeError(
+        raise SendmailError(
             f"sendmail ({sendmail}) exited with code {proc.returncode}: {stderr.decode()}"
         )
     logger.info("Email sent via sendmail to %s", msg["To"])

--- a/src/backend/klangk_backend/exceptions.py
+++ b/src/backend/klangk_backend/exceptions.py
@@ -1,0 +1,13 @@
+"""Domain-specific exceptions for the klangk backend."""
+
+
+class ConfigurationError(RuntimeError):
+    """A required configuration value is missing, invalid, or insecure."""
+
+
+class TerminalError(RuntimeError):
+    """A tmux or terminal operation failed."""
+
+
+class SendmailError(RuntimeError):
+    """The sendmail subprocess exited with a non-zero status."""

--- a/src/backend/klangk_backend/oidc.py
+++ b/src/backend/klangk_backend/oidc.py
@@ -18,6 +18,7 @@ import httpx
 from jose import jwt as jose_jwt
 
 from . import model
+from .exceptions import ConfigurationError
 from .util import resolve_env_secret, resolve_file_secret
 
 logger = logging.getLogger(__name__)
@@ -67,7 +68,7 @@ def load_config() -> list[OIDCProvider]:
     if not config_path:
         return []
     if not os.path.isfile(config_path):
-        raise RuntimeError(
+        raise ConfigurationError(
             f"KLANGK_OIDC_CONFIG={config_path!r} not found"
             " (use an absolute path)"
         )
@@ -102,14 +103,14 @@ def load_config() -> list[OIDCProvider]:
 def init_providers() -> None:
     """Load providers into the module-level registry.
 
-    Raises RuntimeError if KLANGK_AUTH_MODES requires OIDC but no
+    Raises ConfigurationError if KLANGK_AUTH_MODES requires OIDC but no
     providers are configured or the config file is missing.
     """
     global _providers
     _providers = load_config()
     mode = auth_modes()
     if mode in ("oidc", "both") and not _providers:
-        raise RuntimeError(
+        raise ConfigurationError(
             f"KLANGK_AUTH_MODES={mode!r} but no OIDC providers configured"
         )
     if _providers:
@@ -387,7 +388,7 @@ def load_login_hook() -> None:
         return
     dot = raw.rfind(".")
     if dot <= 0:
-        raise RuntimeError(
+        raise ConfigurationError(
             f"KLANGK_OIDC_LOGIN_HOOK must be module.path.func_name, "
             f"got: {raw!r}"
         )
@@ -396,7 +397,9 @@ def load_login_hook() -> None:
     mod = importlib.import_module(module_path)
     hook = getattr(mod, func_name)
     if not callable(hook):
-        raise RuntimeError(f"KLANGK_OIDC_LOGIN_HOOK: {raw!r} is not callable")
+        raise ConfigurationError(
+            f"KLANGK_OIDC_LOGIN_HOOK: {raw!r} is not callable"
+        )
     _login_hook = hook
     _login_hook_is_async = asyncio.iscoroutinefunction(hook)
     logger.info("OIDC login hook loaded: %s", raw)

--- a/src/backend/klangk_backend/terminal.py
+++ b/src/backend/klangk_backend/terminal.py
@@ -23,6 +23,7 @@ import tty
 from collections.abc import AsyncGenerator
 
 from . import podman
+from .exceptions import TerminalError
 from .util import BoundedOutputQueue, resolve_env_secret
 
 logger = logging.getLogger(__name__)
@@ -244,7 +245,7 @@ async def tmux_command(
         if "No such file or directory" in err and attempt < 2:
             await asyncio.sleep(0.5)
             continue
-        raise RuntimeError(f"tmux command failed: {err}")
+        raise TerminalError(f"tmux command failed: {err}")
     return ""  # pragma: no cover
 
 
@@ -331,7 +332,7 @@ async def new_window(
         if "DUPLICATE" in output:
             raise ValueError(f"Window name '{name}' already exists")
         err = stderr.decode("utf-8", errors="replace").strip()
-        raise RuntimeError(f"new_window failed: {err}")
+        raise TerminalError(f"new_window failed: {err}")
     windows = []
     for line in output.strip().splitlines():
         parts = line.split("|||")
@@ -513,9 +514,9 @@ async def kill_joiner_sessions(container_id: str, owner_handle: str) -> None:
                         owner_handle,
                         ["kill-session", "-t", session_name],
                     )
-                except RuntimeError:
+                except TerminalError:
                     pass  # Session may have already exited
-    except RuntimeError:
+    except TerminalError:
         pass  # No sessions
 
 

--- a/src/backend/klangk_backend/wshandler.py
+++ b/src/backend/klangk_backend/wshandler.py
@@ -14,6 +14,7 @@ from fastapi import WebSocket, WebSocketDisconnect
 
 from . import acl as _acl
 from . import agent, auth, container, model, podman, terminal, workspaces
+from .exceptions import TerminalError
 from .util import derive_hosting_info, resolve_env_secret
 from .dockerexec import ExecSession
 from .terminal import TerminalSession, attach_browser
@@ -1217,7 +1218,7 @@ class Connection:
                             "windows": windows,
                         }
                     )
-                except (RuntimeError, OSError):
+                except (TerminalError, OSError):
                     logger.exception("_start_terminal: window list failed")
                 # Also send the shared terminal list from in-memory state.
                 ws_session = state.get_session(conn.workspace_id)
@@ -1610,7 +1611,7 @@ class Connection:
                                 f"{joiner_session}:{window_id}",
                             ],
                         )
-                    except RuntimeError:
+                    except TerminalError:
                         # Joiner session not ready — fall back to bare @N
                         await terminal.select_window(
                             conn.container_id, owner_user_id, window_id

--- a/src/backend/tests/test_auth.py
+++ b/src/backend/tests/test_auth.py
@@ -8,6 +8,7 @@ from fastapi.security import HTTPAuthorizationCredentials
 from jose import jwt
 
 from klangk_backend import auth, model
+from klangk_backend.exceptions import ConfigurationError
 
 
 class TestPasswordHashing:
@@ -631,12 +632,12 @@ class TestRequireSecureJwtSecret:
     def test_default_secret_blocks_with_prevent(self, monkeypatch):
         monkeypatch.setattr(auth, "SECRET_KEY", auth._INSECURE_DEFAULT_SECRET)
         monkeypatch.setenv("KLANGK_PREVENT_INSECURE_JWT_SECRET", "1")
-        with pytest.raises(RuntimeError, match="KLANGK_JWT_SECRET"):
+        with pytest.raises(ConfigurationError, match="KLANGK_JWT_SECRET"):
             auth.require_secure_jwt_secret()
 
     def test_empty_secret_blocks_with_prevent(self, monkeypatch):
         monkeypatch.setattr(auth, "SECRET_KEY", "")
         monkeypatch.setenv("KLANGK_PREVENT_INSECURE_JWT_SECRET", "1")
         assert auth.jwt_secret_is_secure() is False
-        with pytest.raises(RuntimeError):
+        with pytest.raises(ConfigurationError):
             auth.require_secure_jwt_secret()

--- a/src/backend/tests/test_emailsvc.py
+++ b/src/backend/tests/test_emailsvc.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from klangk_backend import emailsvc
+from klangk_backend.exceptions import SendmailError
 
 
 class TestBuildMessage:
@@ -143,7 +144,7 @@ class TestSendViaSendmail:
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
             msg = emailsvc.build_message("to@example.com", "Hi", "Body")
-            with pytest.raises(RuntimeError, match="exited with code 1"):
+            with pytest.raises(SendmailError, match="exited with code 1"):
                 await emailsvc.send_via_sendmail(msg)
 
 

--- a/src/backend/tests/test_oidc.py
+++ b/src/backend/tests/test_oidc.py
@@ -9,6 +9,7 @@ import yaml
 import pytest
 
 from klangk_backend import oidc
+from klangk_backend.exceptions import ConfigurationError
 
 
 @pytest.fixture(autouse=True)
@@ -43,7 +44,7 @@ class TestLoadConfig:
 
     def test_missing_file(self, monkeypatch, tmp_path):
         monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(tmp_path / "nope.json"))
-        with pytest.raises(RuntimeError, match="absolute path"):
+        with pytest.raises(ConfigurationError, match="absolute path"):
             oidc.load_config()
 
     def test_valid_config(self, monkeypatch, tmp_path):
@@ -232,7 +233,7 @@ class TestProviderRegistry:
     ):
         monkeypatch.delenv("KLANGK_OIDC_CONFIG", raising=False)
         monkeypatch.setenv("KLANGK_AUTH_MODES", "oidc")
-        with pytest.raises(RuntimeError, match="no OIDC providers"):
+        with pytest.raises(ConfigurationError, match="no OIDC providers"):
             oidc.init_providers()
 
     def test_init_raises_when_both_required_but_no_providers(
@@ -240,7 +241,7 @@ class TestProviderRegistry:
     ):
         monkeypatch.delenv("KLANGK_OIDC_CONFIG", raising=False)
         monkeypatch.setenv("KLANGK_AUTH_MODES", "both")
-        with pytest.raises(RuntimeError, match="no OIDC providers"):
+        with pytest.raises(ConfigurationError, match="no OIDC providers"):
             oidc.init_providers()
 
     def test_init_ok_when_password_only(self, monkeypatch):
@@ -580,7 +581,7 @@ class TestLoadLoginHook:
 
     def test_bad_format_no_dot(self, monkeypatch):
         monkeypatch.setenv("KLANGK_OIDC_LOGIN_HOOK", "nofunc")
-        with pytest.raises(RuntimeError, match="module.path.func_name"):
+        with pytest.raises(ConfigurationError, match="module.path.func_name"):
             oidc.load_login_hook()
 
     def test_bad_module(self, monkeypatch):
@@ -595,7 +596,7 @@ class TestLoadLoginHook:
 
     def test_not_callable(self, monkeypatch):
         monkeypatch.setenv("KLANGK_OIDC_LOGIN_HOOK", "os.sep")
-        with pytest.raises(RuntimeError, match="not callable"):
+        with pytest.raises(ConfigurationError, match="not callable"):
             oidc.load_login_hook()
 
 

--- a/src/backend/tests/test_terminal.py
+++ b/src/backend/tests/test_terminal.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from klangk_backend.exceptions import TerminalError
 from klangk_backend.terminal import (
     TerminalSession,
     _build_environment,
@@ -591,7 +592,7 @@ class TestTmuxCommand:
         proc.communicate = AsyncMock(return_value=(b"", b"error msg"))
         proc.returncode = 1
         with patch("asyncio.create_subprocess_exec", return_value=proc):
-            with pytest.raises(RuntimeError, match="error msg"):
+            with pytest.raises(TerminalError, match="error msg"):
                 await tmux_command("cid", "sess", ["bad-cmd"])
 
     async def test_retries_on_socket_not_found(self):
@@ -700,7 +701,7 @@ class TestNewWindow:
         proc.communicate = AsyncMock(return_value=(b"", b"session not found"))
         proc.returncode = 1
         with patch("asyncio.create_subprocess_exec", return_value=proc):
-            with pytest.raises(RuntimeError, match="session not found"):
+            with pytest.raises(TerminalError, match="session not found"):
                 await new_window("cid", "sess")
 
 
@@ -1023,7 +1024,7 @@ class TestKillJoinerSessions:
             "klangk_backend.terminal.tmux_command",
             side_effect=[
                 "admin\nbob-abc\ncarol-def\n",  # list-sessions
-                RuntimeError("already exited"),  # kill bob fails
+                TerminalError("already exited"),  # kill bob fails
                 "",  # kill carol succeeds
             ],
         ) as mock_cmd:
@@ -1033,7 +1034,7 @@ class TestKillJoinerSessions:
     async def test_no_sessions(self):
         with patch(
             "klangk_backend.terminal.tmux_command",
-            side_effect=RuntimeError("no sessions"),
+            side_effect=TerminalError("no sessions"),
         ):
             # Should not raise
             await kill_joiner_sessions("cid", "admin")

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -15,6 +15,7 @@ from klangk_backend import (
     container,
     workspaces as ws_mod,
 )
+from klangk_backend.exceptions import TerminalError
 from klangk_backend.util import (
     derive_hosting_info,
 )
@@ -773,7 +774,7 @@ class TestHandleTerminalStart:
             patch.object(wshandler, "TerminalSession") as MockTS,
             patch(
                 "klangk_backend.terminal.list_windows",
-                side_effect=RuntimeError("tmux not ready"),
+                side_effect=TerminalError("tmux not ready"),
             ),
         ):
             mock_session = _mock_terminal()
@@ -3588,7 +3589,7 @@ class TestTerminalWindowHandlers:
         conn._user_home = "/home/alice"
         with patch(
             "klangk_backend.terminal.select_window",
-            side_effect=RuntimeError("no such window"),
+            side_effect=TerminalError("no such window"),
         ):
             await conn.handle_terminal_select_window({"index": 99})
         sent = sock.send_json.call_args[0][0]
@@ -3650,7 +3651,7 @@ class TestTerminalWindowHandlers:
         conn._user_home = "/home/alice"
         with patch(
             "klangk_backend.terminal.close_window",
-            side_effect=RuntimeError("no such window"),
+            side_effect=TerminalError("no such window"),
         ):
             await conn.handle_terminal_close_window({"index": 99})
         sent = sock.send_json.call_args[0][0]
@@ -3726,7 +3727,7 @@ class TestTerminalWindowHandlers:
         conn._user_home = "/home/alice"
         with patch(
             "klangk_backend.terminal.list_windows",
-            side_effect=RuntimeError("tmux not running"),
+            side_effect=TerminalError("tmux not running"),
         ):
             await conn.handle_terminal_list_windows()
         sent = sock.send_json.call_args[0][0]
@@ -4067,7 +4068,7 @@ class TestShareWindowHandlers:
                 ),
                 patch(
                     "klangk_backend.terminal.kill_joiner_sessions",
-                    side_effect=RuntimeError("no sessions"),
+                    side_effect=TerminalError("no sessions"),
                 ),
             ):
                 await conn.handle_unshare_window({"window_id": "@0"})
@@ -4229,7 +4230,7 @@ class TestShareWindowHandlers:
                 patch(
                     "klangk_backend.terminal.tmux_command",
                     new_callable=AsyncMock,
-                    side_effect=RuntimeError("can't find session"),
+                    side_effect=TerminalError("can't find session"),
                 ),
                 patch(
                     "klangk_backend.terminal.select_window",
@@ -4334,7 +4335,7 @@ class TestShareWindowHandlers:
             ):
                 mock_sess = _mock_terminal()
                 mock_sess.start = AsyncMock(
-                    side_effect=RuntimeError("start failed")
+                    side_effect=TerminalError("start failed")
                 )
                 MockTS.return_value = mock_sess
 


### PR DESCRIPTION
## Summary
- Add `exceptions.py` with `ConfigurationError`, `TerminalError`, and `SendmailError` (all subclass `RuntimeError` for backward compat)
- Replace 8 `raise RuntimeError` sites: auth (1), oidc (4), emailsvc (1), terminal (2)
- Update 4 `except RuntimeError` catch sites in terminal and wshandler to use specific types
- Update test assertions and mock side-effects to match

## Test plan
- [x] Backend tests pass (1398 passed, 100% coverage)
- [x] CLI tests pass (280 passed, 100% coverage)

Closes #622