### PR TITLE
Run update-plugins automatically during devenv startup

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -80,6 +80,7 @@ in
     };
     "klangk:build-workspace-image" = {
       exec = ''exec bash "$DEVENV_ROOT/scripts/build-workspace-image.sh"'';
+      after = [ "klangk:update-plugins" ];
       showOutput = true;
     };
     "klangk:kill-containers" = {
@@ -98,6 +99,28 @@ in
           done
         fi
       '';
+    };
+    "klangk:init-plugins" = {
+      exec = ''
+        if [ ! -f "${config.env.KLANGK_PLUGINS_DIR}/plugins.yaml" ]; then
+          cd $DEVENV_ROOT
+          python3 scripts/update_plugins.py
+        fi
+      '';
+      before = [ "klangk:update-plugins" ];
+      showOutput = true;
+    };
+    "klangk:update-plugins" = {
+      exec = ''
+        cd $DEVENV_ROOT
+        bash scripts/stub_dart_plugins.sh
+        exec python3 scripts/update_plugins.py
+      '';
+      before = [ "klangk:flutter-build" ];
+      showOutput = true;
+      execIfModified = [
+        "${config.env.KLANGK_PLUGINS_DIR}/plugins.yaml"
+      ];
     };
   };
 
@@ -173,22 +196,6 @@ in
     ''${KLANGK_PODMAN_BIN:-podman} ps -a \
       --filter "label=klangk.instance=''${KLANGK_INSTANCE_ID}" \
       -q | xargs -r ''${KLANGK_PODMAN_BIN:-podman} rm -f
-  '';
-
-  scripts.restart.exec = ''
-    echo "Stopping devenv processes..."
-    devenv processes down --no-tui 2>/dev/null || true
-    sleep 1
-    echo "Starting..."
-    exec devenv up --no-tui "$@"
-  '';
-
-  scripts.rebuild.exec = ''
-    echo "Rebuilding backend image..."
-    build-workspace-image
-    echo "Rebuilding Flutter..."
-    flutterbuildweb
-    echo "==> Done"
   '';
 
   scripts.update-plugins.exec = ''
@@ -366,9 +373,6 @@ in
       fi
     fi
 
-    # Ensure klangk_plugins stub exists so flutter pub get works
-    # before plugins are fetched (first-time checkout / CI)
-    bash "$DEVENV_ROOT/scripts/stub_dart_plugins.sh"
 
     # Generate prettierignore (not committed)
     cat > "$DEVENV_ROOT/.prettierignore" <<'PRETTIER'

--- a/docs/development/creating-plugins.md
+++ b/docs/development/creating-plugins.md
@@ -22,8 +22,8 @@ No single component is required — a plugin can be an extension + Dart UI, just
   - `plugin-tools` — flat directory of all `tools/*` files (installed to `/opt/klangk/bin/`)
   - `plugin-hooks` — per-plugin lifecycle hook directories (installed to `/opt/klangk/hooks/<name>/`)
 - `flutterbuildweb` runs the codegen before compiling
-- `stub_dart_plugins.sh` creates a minimal stub at `$KLANGK_PLUGINS_DIR/.dart/` so `flutter pub get` works before plugins are fetched (runs automatically at devenv shell startup via `enterShell`; skips if `pubspec_overrides.yaml` already exists)
-- Both build tasks are triggered automatically by `devenv up` via `execIfModified`
+- `stub_dart_plugins.sh` creates a minimal stub at `$KLANGK_PLUGINS_DIR/.dart/` so `flutter pub get` works before plugins are fetched (runs automatically as part of the `klangk:update-plugins` task; skips if `pubspec_overrides.yaml` already exists)
+- Plugins are fetched automatically on `devenv up`: `klangk:init-plugins` creates `plugins.yaml` on first run, then `klangk:update-plugins` fetches plugins when `plugins.yaml` changes
 
 ## Adding a Plugin
 

--- a/docs/features/plugins.md
+++ b/docs/features/plugins.md
@@ -12,10 +12,13 @@ For details on creating plugins, see the
 
 [![Running update-plugins](../assets/update-plugins.png)](../assets/update-plugins.png)
 
-Run `update-plugins` to fetch plugins. On first run it creates a
-`plugins.yaml` template with the default plugins. Plugins are
-declared in `$KLANGK_PLUGINS_DIR/plugins.yaml`. Each entry requires
-`name` and `git`; `path` and `ref` are optional:
+Plugins are fetched automatically when you run `devenv up`. On first
+run, a `plugins.yaml` template with the default plugins is created
+and plugins are fetched. On subsequent runs, plugins are only
+re-fetched if `plugins.yaml` has changed. You can also run
+`update-plugins` manually at any time. Plugins are declared in
+`$KLANGK_PLUGINS_DIR/plugins.yaml`. Each entry requires `name` and
+`git`; `path` and `ref` are optional:
 
 ```yaml
 plugins:

--- a/scripts/stub_dart_plugins.sh
+++ b/scripts/stub_dart_plugins.sh
@@ -43,15 +43,6 @@ cat >"$OVERRIDES" <<EOF
 dependency_overrides:
   klangk_plugins:
     path: $STUB_DIR
-  # The file-viewers stack needs the FileRenderer API, which currently lives on
-  # an unmerged branch of the plugin-api fork (mcdonc/klangk-plugin-api PR #2).
-  # Override klangk_plugin_api to that fork so both the stub package (which
-  # otherwise pins mcdonc) and the frontend resolve a single, FileRenderer-
-  # capable source. Drop this once PR #2 lands on mcdonc/main.
-  klangk_plugin_api:
-    git:
-      url: https://github.com/runyaga/klangk-plugin-api.git
-      ref: feat/file-renderer
 EOF
 ln -sf "$OVERRIDES" "$FRONTEND_DIR/pubspec_overrides.yaml"
 


### PR DESCRIPTION
## Summary
- Add `klangk:init-plugins` task that creates `plugins.yaml` on first run
- Add `klangk:update-plugins` task that fetches plugins when `plugins.yaml` changes (via `execIfModified`), runs `stub_dart_plugins.sh` before fetching
- `build-workspace-image` now depends on `update-plugins` to ensure plugins exist before staging
- Move `stub_dart_plugins.sh` call from `enterShell` into the `update-plugins` task
- Update plugin docs to reflect automatic fetching

Closes #652