### PR TITLE
Update release docs to reference semver

### DIFF
--- a/docs/development/building-images.md
+++ b/docs/development/building-images.md
@@ -8,10 +8,10 @@ build-host-image
 
 This builds everything from source: Flutter web, workspace image
 (podman), then the host image (Docker). Tagged locally with `latest`
-and a CalVer version (e.g., `2026.06.09-abc1234`). Only the CalVer
-version tag is pushed to GHCR — `:latest` is never pushed to the
-registry. The version is baked into `/home/klangk/version.json` and
-served at `GET /version`.
+and a version tag derived from git state (release tag, branch name,
+or commit). Only the version tag is pushed to GHCR — `:latest` is
+never pushed to the registry. The version is baked into
+`/home/klangk/version.json` and served at `GET /version`.
 
 ## Custom Image with Plugins
 

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -1,14 +1,14 @@
 # Releasing
 
-Push a CalVer tag to trigger the `release.yml` workflow:
+Push a semver tag to trigger the `release.yml` workflow:
 
 ```bash
-git tag v2026.06.10
-git push origin v2026.06.10
+git tag v0.1.0
+git push origin v0.1.0
 ```
 
-This builds the host image (including workspace and Flutter web), pushes both `klangk-host` and `klangk-workspace` to GHCR tagged with the version (e.g. `v2026.06.10`), and creates a GitHub Release with auto-generated notes. No `:latest` tag is pushed — all images are referenced by explicit version. If you need a second release on the same day, append a suffix: `v2026.06.10.1`.
+This builds the host image (including workspace and Flutter web), pushes both `klangk-host` and `klangk-workspace` to GHCR tagged with the version (e.g. `v0.1.0`), and creates a GitHub Release with auto-generated notes. No `:latest` tag is pushed — all images are referenced by explicit version. For patch releases, increment the patch version: `v0.1.1`.
 
 ## CI
 
-The `release.yml` workflow builds and pushes the host image to GHCR, triggered by pushing a CalVer tag. The `image-workspace.yml` workflow builds and pushes the workspace image independently on push to `main` (when workspace container files change).
+The `release.yml` workflow builds and pushes the host image to GHCR, triggered by pushing a version tag matching `v[0-9]*`. The `image-workspace.yml` workflow builds and pushes the workspace image independently on push to `main` (when workspace container files change).

--- a/docs/development/stable-branches.md
+++ b/docs/development/stable-branches.md
@@ -3,18 +3,18 @@
 For deployments that need a fixed release with cherry-picked hotfixes (rather than upgrading to the latest), create a stable branch:
 
 ```bash
-git checkout -b stable/2026.06.10 v2026.06.10
+git checkout -b stable/0.1 v0.1.0
 git cherry-pick <hotfix-commit>
 ```
 
-Tag backport releases with a `-N` suffix to distinguish them from same-day mainline releases:
+Tag patch releases on the stable branch:
 
 ```bash
-git tag v2026.06.10-1
-git push origin v2026.06.10-1
+git tag v0.1.1
+git push origin v0.1.1
 ```
 
-This triggers the release workflow, which builds and pushes versioned images. The deployment repo (e.g. `klangk-host-with-plugins`) references the tag via `KLANGK_REF=v2026.06.10-1`.
+This triggers the release workflow, which builds and pushes versioned images. The deployment repo (e.g. `klangk-host-with-plugins`) references the tag via `KLANGK_REF=v0.1.1`.
 
 Note: do not use `+` in tags — Docker image tags don't allow the `+` character.
 


### PR DESCRIPTION
## Summary

- Update `releasing.md` to show semver tags (`v0.1.0`) instead of calver (`v2026.06.10`)
- Update `stable-branches.md` examples to use semver branches and patch versions
- Update `building-images.md` to remove calver-specific language

Closes #579