### PR TITLE
Apply nginx container ACL to browser-delegate/stream

### DIFF
--- a/scripts/nginx.sh
+++ b/scripts/nginx.sh
@@ -166,12 +166,12 @@ ${LLM_BLOCK}
     # (soliplex RAG + LLM) through here. The read timeout must accommodate
     # the git-credential device flow (up to 15 min) as well as streaming
     # RAG/LLM responses, so it exceeds the backend's max bridge timeout.
-    location = /api/browser-delegate {
+    location /api/browser-delegate {
 ${CONTAINER_ACL}
       auth_request /auth/verify-workspace-token;
       auth_request_set \$auth_token_error \$upstream_http_x_token_error;
       error_page 401 = @token_auth_failed;
-      proxy_pass http://127.0.0.1:${KLANGK_PORT}/api/browser-delegate;
+      proxy_pass http://127.0.0.1:${KLANGK_PORT};
       proxy_set_header Host \$http_host;
       proxy_set_header X-Real-IP \$remote_addr;
       proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;

--- a/src/backend/e2e-tests/test_nginx_acl_e2e.py
+++ b/src/backend/e2e-tests/test_nginx_acl_e2e.py
@@ -134,8 +134,10 @@ class TestNginxAclConfig:
             str(tmp_path),
         )
         # Find the browser-delegate location block and check it has the ACL.
+        # Prefix match (no "=") covers both /api/browser-delegate and
+        # /api/browser-delegate/stream.
         bd_match = re.search(
-            r"location = /api/browser-delegate \{(.*?)\}",
+            r"location /api/browser-delegate \{(.*?)\}",
             conf,
             re.DOTALL,
         )


### PR DESCRIPTION
## Summary
- Change nginx `location = /api/browser-delegate` (exact match) to `location /api/browser-delegate` (prefix match)
- This applies the container IP ACL and `auth_request` workspace token verification to both `/api/browser-delegate` and `/api/browser-delegate/stream`
- Previously the `/stream` endpoint fell through to the default `location /` with no ACL or auth_request, bypassing nginx-level security (backend `_require_workspace_token` still enforced auth, but the network-level container ACL was missing)
- Update E2E test regex to match prefix location

Closes #673

## Test plan
- [x] `test_browser_delegate_has_acl` passes with updated regex
- [ ] Manual: verify browser-delegate and browser-delegate/stream both work from container
- [ ] Manual: verify requests from outside container network are rejected