### PR TITLE
Add deferred-imports pre-commit hook

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -347,6 +347,15 @@ in
     };
     # YAML lint
     yamllint.enable = true;
+    # Deferred imports
+    deferred-imports = {
+      enable = true;
+      name = "deferred-imports";
+      entry = "python3 scripts/check_deferred_imports.py";
+      files = "\\.py$";
+      language = "system";
+      pass_filenames = true;
+    };
   };
 
   enterShell = ''

--- a/docs/development/pre-commit.md
+++ b/docs/development/pre-commit.md
@@ -4,6 +4,7 @@ Pre-commit hooks run automatically on `git commit` via [git-hooks.nix](https://g
 
 - **actionlint** — GitHub Actions workflow linting
 - **check-executables-have-shebangs** — ensures executable scripts have a shebang line
+- **deferred-imports** — flags non-module-scope imports
 - **check-toml** — TOML syntax validation
 - **dart format** — Dart formatting
 - **markdownlint** — Markdown linting

--- a/scripts/check_deferred_imports.py
+++ b/scripts/check_deferred_imports.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Detect non-module-scope (deferred) imports in Python packages.
+
+Imports inside functions, methods, or branches are flagged. Add
+``# noqa: allow-deferred-import`` on the import line to suppress.
+
+Usage:
+    check_imports.py src/backend/klangk_backend src/cli/klangkc
+    check_imports.py src/backend/klangk_backend/main.py  # discovers package
+    check_imports.py                                      # discovers from cwd
+"""
+
+import ast
+import sys
+from pathlib import Path
+
+
+def _is_top_level(node: ast.AST) -> bool:
+    """Check if a node is at module scope (parent is ast.Module)."""
+    return isinstance(getattr(node, "_parent", None), ast.Module)
+
+
+def _parse_file(filepath: Path):
+    """Parse a file and annotate parent nodes. Returns (tree, lines) or None."""
+    try:
+        source_text = filepath.read_text()
+        tree = ast.parse(source_text)
+    except SyntaxError:
+        return None
+    for node in ast.walk(tree):
+        for child in ast.iter_child_nodes(node):
+            child._parent = node  # noqa: SLF001
+    return tree, source_text.splitlines()
+
+
+def _line_has_comment(lines: list[str], lineno: int, comment: str) -> bool:
+    return comment in lines[lineno - 1] if lineno <= len(lines) else False
+
+
+def check_deferred_imports(package_dir: str) -> list[str]:
+    """Flag imports that are not at module scope.
+
+    Lines with ``# noqa: allow-deferred-import`` are exempted.
+    Returns error lines.
+    """
+    root = Path(package_dir).resolve()
+    if not root.is_dir():
+        return [f"ERROR: {package_dir} is not a directory"]
+
+    errors: list[str] = []
+    for pyfile in sorted(root.rglob("*.py")):
+        parsed = _parse_file(pyfile)
+        if parsed is None:
+            continue
+        tree, source_lines = parsed
+
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.Import, ast.ImportFrom)):
+                continue
+            if _is_top_level(node):
+                continue
+            if _line_has_comment(
+                source_lines, node.lineno, "noqa: allow-deferred-import"
+            ):
+                continue
+
+            rel = pyfile.relative_to(root.parent)
+            if isinstance(node, ast.Import):
+                names = ", ".join(a.name for a in node.names)
+                errors.append(f"{rel}:{node.lineno}: deferred import: import {names}")
+            else:
+                module = node.module or ""
+                prefix = "." * node.level + module
+                names = ", ".join(a.name for a in node.names)
+                errors.append(
+                    f"{rel}:{node.lineno}: deferred import:"
+                    f" from {prefix} import {names}"
+                )
+    return errors
+
+
+def _find_package_root(filepath: Path) -> Path | None:
+    """Walk up from a .py file to find the top-level package directory.
+
+    Returns the deepest directory that still has an ``__init__.py`` in
+    every ancestor up to the package root, or None if the file isn't
+    inside a package.
+    """
+    parent = filepath.parent
+    root = None
+    while (parent / "__init__.py").exists():
+        root = parent
+        parent = parent.parent
+    return root
+
+
+def _packages_from_files(files: list[str]) -> list[str]:
+    """Derive unique package directories from a list of .py file paths."""
+    roots: set[str] = set()
+    for f in files:
+        p = Path(f).resolve()
+        if p.suffix != ".py":
+            continue
+        pkg = _find_package_root(p)
+        if pkg is not None:
+            roots.add(str(pkg))
+    return sorted(roots)
+
+
+def _find_packages_in_dir(directory: Path) -> list[str]:
+    """Find all Python packages (dirs with __init__.py) under *directory*."""
+    roots: set[Path] = set()
+    for init in sorted(directory.rglob("__init__.py")):
+        pkg = _find_package_root(init)
+        if pkg is not None:
+            roots.add(pkg)
+    return sorted(str(r) for r in roots)
+
+
+def main() -> int:
+    args = sys.argv[1:]
+
+    if not args:
+        # No arguments: discover packages under cwd
+        package_dirs = _find_packages_in_dir(Path.cwd())
+    elif any(a.endswith(".py") for a in args):
+        # File paths: discover packages from them
+        package_dirs = _packages_from_files(args)
+    else:
+        # Package directories
+        package_dirs = args
+
+    if not package_dirs:
+        return 0
+
+    all_errors: list[str] = []
+    for pkg_dir in package_dirs:
+        all_errors.extend(check_deferred_imports(pkg_dir))
+
+    if all_errors:
+        for line in all_errors:
+            print(line, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -1,15 +1,18 @@
 """Klangk backend: FastAPI app with HTTP + WebSocket endpoints."""
 
 import logging
+import secrets
+import sys
 from contextlib import asynccontextmanager
 
 from pathlib import Path
 
+import bcrypt
 from fastapi import FastAPI, WebSocket
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
-from . import container, model, oidc, plugins
+from . import auth, container, model, oidc, plugins, wshandler
 from .api import router
 from .model import (
     ACTION_ALLOW,
@@ -110,10 +113,6 @@ async def seed_default_user() -> None:
     If KLANGK_DEFAULT_PASSWORD is set, use it. Otherwise generate a random
     password and print it to the console (only on first creation).
     """
-    import secrets
-
-    import bcrypt
-
     admin_group_id = await ensure_admin_group()
     await seed_default_acls(admin_group_id)
 
@@ -136,8 +135,6 @@ async def seed_default_user() -> None:
             )
             # Print password to stderr only — keep it out of structured
             # logs where it could be shipped to a log aggregator.
-            import sys
-
             print(
                 f"{_GREEN}Default admin password for"
                 f" '{email}': {password}{_RESET}",
@@ -174,8 +171,6 @@ async def seed_agent_user() -> None:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    from . import auth
-
     auth.require_secure_jwt_secret()
     plugins.load()
     await model.init_db()
@@ -183,8 +178,6 @@ async def lifespan(app: FastAPI):
     oidc.load_login_hook()
     await seed_default_user()
     await seed_agent_user()
-    from . import wshandler
-
     container.registry.set_on_workspace_killed(wshandler.reset_workspace_state)
     await container.registry.prewarm_podman()
     await container.registry.adopt_orphaned_containers()
@@ -203,7 +196,7 @@ def setup_logfire(app: FastAPI) -> bool:
     """Enable Logfire instrumentation if LOGFIRE_TOKEN is set."""
     if not resolve_env_secret("LOGFIRE_TOKEN"):
         return False
-    import logfire
+    import logfire  # noqa: allow-deferred-import
 
     base_url = resolve_env_secret("LOGFIRE_BASE_URL")
     environment = resolve_env_secret("LOGFIRE_ENVIRONMENT")

--- a/src/backend/klangk_backend/model.py
+++ b/src/backend/klangk_backend/model.py
@@ -1485,8 +1485,6 @@ async def is_token_blocklisted(jti: str) -> bool:
 
 async def get_refreshed_token(jti: str) -> str | None:
     """Return the replacement token for a refreshed JTI, if still valid."""
-    from datetime import datetime, timezone
-
     async with transaction() as db:
         cursor = await db.execute(
             "SELECT new_token, expires_at FROM token_blocklist"

--- a/src/cli/klangkc/auth.py
+++ b/src/cli/klangkc/auth.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import base64
 import html
 import http.server
+import json
+import socket
 import threading
 import webbrowser
 from urllib.parse import parse_qs, urlparse
@@ -36,8 +39,6 @@ def _oidc_browser_login(  # pragma: no cover
 ) -> None:
     """Launch browser for OIDC login, receive token via localhost callback."""
     # Find a free port
-    import socket
-
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     sock.bind(("127.0.0.1", 0))
     port = sock.getsockname()[1]
@@ -117,9 +118,6 @@ margin:0;background:#1a1a2e;color:#e0e0e0">
         token = token_holder[0]
         # Decode the JWT to get the email
         try:
-            import base64
-            import json
-
             payload = token.split(".")[1]
             # Add padding
             payload += "=" * (4 - len(payload) % 4)

--- a/src/cli/klangkc/main.py
+++ b/src/cli/klangkc/main.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 
 import asyncio
 import io
+import json
 import os
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 
@@ -13,25 +16,41 @@ import httpx
 import typer
 import websockets
 from rich.console import Console
+from rich.live import Live
+from rich.progress import (
+    BarColumn,
+    DownloadColumn,
+    Progress,
+    TransferSpeedColumn,
+)
+from rich.spinner import Spinner
 from rich.table import Table
+from rich.text import Text
 
 from .auth import login, logout as do_logout
-import json
-
 from .client import (
     AuthError,
     KlangkClient,
     WorkspaceNotFoundError,
     _WS_MAX_SIZE,
+    _drain_stdin,
     _get_terminal_size,
     _send_ignore_closed,
     _exec_on_ws,
     _wait_workspace_ready,
     _ws_exec,
     _ws_shell,
+    reset_terminal,
 )
 from .config import CLIConfig
 from .mount import validate_mount_spec
+from .sandbox import (
+    build_all_mounts,
+    build_copy_pairs,
+    expand_container_path,
+    load_sandbox_config,
+    resolve_setup_command,
+)
 
 app = typer.Typer(
     name="klangkc",
@@ -85,8 +104,6 @@ def login_cmd(
     password = None
     if password_file is not None:
         if password_file == "-":
-            import sys
-
             password = sys.stdin.readline().rstrip("\n")
         else:
             password = Path(password_file).read_text().strip()
@@ -322,16 +339,6 @@ def export_workspace(
             out_path = Path(f"{stem}-{n}.tar.gz")
             n += 1
     try:
-        from rich.live import Live
-        from rich.spinner import Spinner
-        from rich.progress import (
-            Progress,
-            BarColumn,
-            DownloadColumn,
-            TransferSpeedColumn,
-        )
-
-        from rich.text import Text
 
         class _EstDownloadColumn(DownloadColumn):
             def render(self, task):
@@ -394,13 +401,6 @@ def import_workspace(
         raise typer.Exit(code=1)
     client = _client()
     try:
-        from rich.progress import (
-            Progress,
-            BarColumn,
-            DownloadColumn,
-            TransferSpeedColumn,
-        )
-
         progress = Progress(
             "[progress.description]{task.description}",
             BarColumn(),
@@ -753,8 +753,6 @@ def shell(
             )
         )
     except websockets.InvalidStatus as e:
-        from .client import _drain_stdin, reset_terminal
-
         reset_terminal()
         _drain_stdin()
         if e.response.status_code in (4001, 4002):
@@ -766,8 +764,6 @@ def shell(
             _err.print(f"[red]Connection rejected: {e}[/red]")
         raise typer.Exit(code=1) from None
     except ConnectionError as e:
-        from .client import _drain_stdin, reset_terminal
-
         reset_terminal()
         _drain_stdin()
         _err.print(f"[red]{e}[/red]")
@@ -802,14 +798,6 @@ async def _sandbox_setup(ws, config, sandbox_root, handle):
     Called once after workspace creation, before the shell starts.
     The caller has already connected and called _wait_workspace_ready.
     """
-    from pathlib import Path
-
-    from .sandbox import (
-        build_copy_pairs,
-        expand_container_path,
-        resolve_setup_command,
-    )
-
     # Copy files into container home.
     for host_path, container_dest in build_copy_pairs(
         config, sandbox_root, handle
@@ -870,11 +858,6 @@ def sandbox(
     ),
 ) -> None:
     """Create or reconnect to a sandbox workspace."""
-    from pathlib import Path
-
-    from .client import WorkspaceNotFoundError
-    from .sandbox import build_all_mounts, load_sandbox_config
-
     cfg = _cfg()
     if not cfg.auth.token:  # pragma: no cover
         _err.print(
@@ -939,8 +922,6 @@ def sandbox(
             )
         )
     except websockets.InvalidStatus as e:  # pragma: no cover
-        from .client import _drain_stdin, reset_terminal
-
         reset_terminal()
         _drain_stdin()
         if e.response.status_code in (4001, 4002):
@@ -1351,9 +1332,6 @@ def sync(
 
         klangkc sync ~/src ws:/work/src --delete --exclude .git
     """
-    import shutil
-    import subprocess
-
     _require_auth()
 
     klangkc_bin = shutil.which("klangkc")


### PR DESCRIPTION
## Summary
- Add `scripts/check_deferred_imports.py`: AST-based checker that flags imports inside functions/methods/branches. Suppress individual cases with `# noqa: allow-deferred-import`
- Wire up as `deferred-imports` git hook in devenv.nix (runs on staged `.py` files, discovers package roots automatically)
- Move all existing deferred imports to module scope in backend (`main.py`, `model.py`) and CLI (`auth.py`, `main.py`)
- One exemption: `import logfire` in `main.py` stays deferred (conditional on env var)

## Test plan
- [x] `check_deferred_imports.py` passes on both packages
- [x] Backend tests pass (1433 passed, 100% coverage)
- [x] CLI tests pass (290 passed, 100% coverage)
- [x] Pre-commit hook runs and passes

Closes #670