### PR TITLE
Stop git-credential plugin from using KLANGK_BRIDGE_TIMEOUT_SECONDS

### DIFF
--- a/plugins/git-credential/tools/git-credential-klangk
+++ b/plugins/git-credential/tools/git-credential-klangk
@@ -25,7 +25,7 @@ import urllib.request
 
 BRIDGE_URL = os.environ.get("KLANGK_BRIDGE_URL", "")
 WORKSPACE_TOKEN = os.environ.get("KLANGK_WORKSPACE_TOKEN", "")
-TIMEOUT = int(os.environ.get("KLANGK_BRIDGE_TIMEOUT_SECONDS", "30"))
+TIMEOUT = 30
 # Device flow codes expire after 15 minutes; the credential get operation
 # may block on user interaction (PAT dialog or device flow), so use a much
 # longer timeout than the default bridge timeout.

--- a/src/backend/tests/test_git_credential.py
+++ b/src/backend/tests/test_git_credential.py
@@ -35,7 +35,6 @@ def run_helper(operation, stdin_text="", env_override=None, extra_path=None):
         **os.environ,
         "KLANGK_BRIDGE_URL": "",
         "KLANGK_WORKSPACE_TOKEN": "",
-        "KLANGK_BRIDGE_TIMEOUT_SECONDS": "5",
     }
     # Remove stale env vars from the old bridge-token era
     env.pop("KLANGK_BRIDGE_TOKEN", None)
@@ -222,7 +221,6 @@ class TestGetOperation:
             "protocol=https\nhost=github.com\n\n",
             env_override={
                 "KLANGK_BRIDGE_URL": "http://127.0.0.1:1",
-                "KLANGK_BRIDGE_TIMEOUT_SECONDS": "1",
             },
             extra_path=str(fake_browser_id),
         )


### PR DESCRIPTION
## Summary
- Remove `KLANGK_BRIDGE_TIMEOUT_SECONDS` from git-credential plugin — it's the bridge idle timeout for streamed chunks, not a general HTTP timeout
- Use hardcoded 30s default for short bridge requests (store, erase, device flow signals)
- The long-running credential get already has its own `KLANGK_CREDENTIAL_GET_TIMEOUT` (900s)

Closes #671

## Test plan
- [x] All 15 git-credential tests pass