### PR TITLE
Add System Info tab to debug panel

### DIFF
--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -95,12 +95,19 @@ async def verify_workspace_token(request: Request):
 
 @router.get("/version")
 async def version():
-    """Return build version info (version, commit, build timestamp)."""
-    version_file = os.environ.get("KLANGK_VERSION_FILE", "")
-    if version_file and os.path.isfile(version_file):
-        with open(version_file) as f:
-            return json.load(f)
-    return {"version": "dev", "commit": "unknown", "built_at": None}
+    """Return build version info, plus loaded plugin metadata."""
+    if version_file := os.environ.get("KLANGK_VERSION_FILE", ""):
+        if os.path.isfile(version_file):
+            with open(version_file) as f:
+                info = json.load(f)
+            info["plugins"] = plugins.plugin_list()
+            return info
+    return {
+        "version": "dev",
+        "commit": "unknown",
+        "built_at": None,
+        "plugins": plugins.plugin_list(),
+    }
 
 
 # --- Test/debug endpoints (only when KLANGK_TEST_MODE is set) ---

--- a/src/backend/klangk_backend/plugins.py
+++ b/src/backend/klangk_backend/plugins.py
@@ -73,6 +73,30 @@ def load() -> None:
         )
 
 
+def plugin_list() -> list[dict[str, str]]:
+    """Return metadata for each loaded plugin (name, version, description)."""
+    if not os.path.isdir(_PLUGINS_DIR):
+        return []
+    plugins = []
+    for name in sorted(os.listdir(_PLUGINS_DIR)):
+        pkg_json = os.path.join(_PLUGINS_DIR, name, "package.json")
+        if not os.path.isfile(pkg_json):
+            continue
+        try:
+            with open(pkg_json) as f:
+                manifest = json.load(f)
+        except (json.JSONDecodeError, ValueError, OSError):
+            continue
+        plugins.append(
+            {
+                "name": name,
+                "version": manifest.get("version", ""),
+                "description": manifest.get("description", ""),
+            }
+        )
+    return plugins
+
+
 def container_env() -> dict[str, str]:
     """Return env vars to inject into workspace containers."""
     result = {}

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -197,16 +197,38 @@ class TestVersion:
         assert data["version"] == "2026.01.01+abc1234"
         assert data["commit"] == "abc1234"
         assert data["built_at"] == "2026-01-01T00:00:00Z"
+        assert "plugins" in data
 
     async def test_version_no_file(self, client, monkeypatch):
         monkeypatch.delenv("KLANGK_VERSION_FILE", raising=False)
         resp = await client.get("/version")
         assert resp.status_code == 200
-        assert resp.json() == {
-            "version": "dev",
-            "commit": "unknown",
-            "built_at": None,
-        }
+        data = resp.json()
+        assert data["version"] == "dev"
+        assert data["commit"] == "unknown"
+        assert data["built_at"] is None
+        assert "plugins" in data
+
+    async def test_version_includes_plugins(
+        self, client, tmp_path, monkeypatch
+    ):
+        monkeypatch.delenv("KLANGK_VERSION_FILE", raising=False)
+        plugin_dir = tmp_path / "plugins" / "myplugin"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "package.json").write_text(
+            '{"name": "myplugin", "version": "1.2.3",'
+            ' "description": "A test plugin"}'
+        )
+        monkeypatch.setattr(
+            "klangk_backend.plugins._PLUGINS_DIR", str(tmp_path / "plugins")
+        )
+        resp = await client.get("/version")
+        assert resp.status_code == 200
+        plugins = resp.json()["plugins"]
+        assert len(plugins) == 1
+        assert plugins[0]["name"] == "myplugin"
+        assert plugins[0]["version"] == "1.2.3"
+        assert plugins[0]["description"] == "A test plugin"
 
 
 # --- Config ---

--- a/src/backend/tests/test_plugins.py
+++ b/src/backend/tests/test_plugins.py
@@ -211,3 +211,69 @@ class TestPluginConfig:
         plugins.load()
         assert plugins.container_env() == {"X_KEY": "val"}
         assert plugins.frontend_config() == {}
+
+
+class TestPluginList:
+    def test_no_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            plugins, "_PLUGINS_DIR", str(tmp_path / "nonexistent")
+        )
+        assert plugins.plugin_list() == []
+
+    def test_empty_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(plugins, "_PLUGINS_DIR", str(tmp_path))
+        assert plugins.plugin_list() == []
+
+    def test_returns_metadata(self, tmp_path, monkeypatch):
+        plugin_dir = tmp_path / "my-plugin"
+        plugin_dir.mkdir()
+        (plugin_dir / "package.json").write_text(
+            json.dumps(
+                {
+                    "name": "my-plugin",
+                    "version": "1.0.0",
+                    "description": "A plugin",
+                }
+            )
+        )
+        monkeypatch.setattr(plugins, "_PLUGINS_DIR", str(tmp_path))
+        result = plugins.plugin_list()
+        assert len(result) == 1
+        assert result[0] == {
+            "name": "my-plugin",
+            "version": "1.0.0",
+            "description": "A plugin",
+        }
+
+    def test_skips_invalid_json(self, tmp_path, monkeypatch):
+        plugin_dir = tmp_path / "bad"
+        plugin_dir.mkdir()
+        (plugin_dir / "package.json").write_text("not json")
+        monkeypatch.setattr(plugins, "_PLUGINS_DIR", str(tmp_path))
+        assert plugins.plugin_list() == []
+
+    def test_missing_fields_default_empty(self, tmp_path, monkeypatch):
+        plugin_dir = tmp_path / "minimal"
+        plugin_dir.mkdir()
+        (plugin_dir / "package.json").write_text(json.dumps({"name": "m"}))
+        monkeypatch.setattr(plugins, "_PLUGINS_DIR", str(tmp_path))
+        result = plugins.plugin_list()
+        assert result[0] == {
+            "name": "minimal",
+            "version": "",
+            "description": "",
+        }
+
+    def test_skips_dir_without_package_json(self, tmp_path, monkeypatch):
+        (tmp_path / "no-manifest").mkdir()
+        monkeypatch.setattr(plugins, "_PLUGINS_DIR", str(tmp_path))
+        assert plugins.plugin_list() == []
+
+    def test_sorted_by_name(self, tmp_path, monkeypatch):
+        for name in ["zeta", "alpha", "mid"]:
+            d = tmp_path / name
+            d.mkdir()
+            (d / "package.json").write_text(json.dumps({"name": name}))
+        monkeypatch.setattr(plugins, "_PLUGINS_DIR", str(tmp_path))
+        names = [p["name"] for p in plugins.plugin_list()]
+        assert names == ["alpha", "mid", "zeta"]

--- a/src/frontend/lib/debug/debug_panel.dart
+++ b/src/frontend/lib/debug/debug_panel.dart
@@ -1,9 +1,12 @@
 import 'dart:async';
 import 'dart:convert';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../auth/auth_service.dart';
 import '../ws/ws_client.dart';
+import 'system_info_tab.dart';
 
-/// Debug panel showing live WebSocket messages.
+/// Debug panel with tabs: WebSocket message log and System Info.
 /// Rendered inside IdeLayout's debug pane with a draggable divider above.
 class DebugPanel extends StatefulWidget {
   final WsClient wsClient;
@@ -15,6 +18,7 @@ class DebugPanel extends StatefulWidget {
 }
 
 class _DebugPanelState extends State<DebugPanel> {
+  int _tabIndex = 0;
   final List<WsDebugEntry> _entries = [];
   final ScrollController _scrollController = ScrollController();
   StreamSubscription<WsDebugEntry>? _sub;
@@ -55,55 +59,78 @@ class _DebugPanelState extends State<DebugPanel> {
       color: const Color(0xFF1A1A1A),
       child: Column(
         children: [
-          // Toolbar
+          // Tab bar
           Container(
             height: 22,
             color: const Color(0xFF2D2D2D),
             padding: const EdgeInsets.symmetric(horizontal: 8),
             child: Row(
               children: [
-                Text(
-                  'WebSocket (${_entries.length})',
-                  style: const TextStyle(
-                    color: Color(0xFF888888),
-                    fontSize: 10,
-                  ),
-                ),
+                _tabButton('WebSocket', 0),
+                const SizedBox(width: 12),
+                _tabButton('System', 1),
                 const Spacer(),
-                GestureDetector(
-                  onTap: () => setState(() => _autoScroll = !_autoScroll),
-                  child: Icon(
-                    _autoScroll
-                        ? Icons.vertical_align_bottom
-                        : Icons.pause,
-                    color: _autoScroll
-                        ? const Color(0xFF5B8C5A)
-                        : const Color(0xFF888888),
-                    size: 12,
+                if (_tabIndex == 0) ...[
+                  GestureDetector(
+                    onTap: () => setState(() => _autoScroll = !_autoScroll),
+                    child: Icon(
+                      _autoScroll ? Icons.vertical_align_bottom : Icons.pause,
+                      color: _autoScroll
+                          ? const Color(0xFF5B8C5A)
+                          : const Color(0xFF888888),
+                      size: 12,
+                    ),
                   ),
-                ),
-                const SizedBox(width: 8),
-                GestureDetector(
-                  onTap: () => setState(() => _entries.clear()),
-                  child: const Icon(Icons.delete_outline,
-                      color: Color(0xFF888888), size: 12),
+                  const SizedBox(width: 8),
+                  GestureDetector(
+                    onTap: () => setState(() => _entries.clear()),
+                    child: const Icon(Icons.delete_outline,
+                        color: Color(0xFF888888), size: 12),
+                  ),
+                ],
+              ],
+            ),
+          ),
+          // Content
+          Expanded(
+            child: IndexedStack(
+              index: _tabIndex,
+              children: [
+                _buildWsTab(),
+                SystemInfoTab(
+                  auth: Provider.of<AuthService>(context, listen: false),
                 ),
               ],
             ),
           ),
-          // Message list
-          Expanded(
-            child: ListView.builder(
-              controller: _scrollController,
-              itemCount: _entries.length,
-              itemBuilder: (context, index) {
-                final entry = _entries[index];
-                return _DebugEntryRow(entry: entry);
-              },
-            ),
-          ),
         ],
       ),
+    );
+  }
+
+  Widget _tabButton(String label, int index) {
+    final selected = _tabIndex == index;
+    return GestureDetector(
+      onTap: () => setState(() => _tabIndex = index),
+      child: Text(
+        label,
+        style: TextStyle(
+          color: selected ? const Color(0xFFC5C8C6) : const Color(0xFF888888),
+          fontSize: 10,
+          fontWeight: selected ? FontWeight.bold : FontWeight.normal,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildWsTab() {
+    return ListView.builder(
+      controller: _scrollController,
+      itemCount: _entries.length,
+      itemBuilder: (context, index) {
+        final entry = _entries[index];
+        return _DebugEntryRow(entry: entry);
+      },
     );
   }
 }
@@ -124,8 +151,7 @@ class _DebugEntryRow extends StatelessWidget {
         detail.length > 200 ? '${detail.substring(0, 200)}...' : detail;
 
     return InkWell(
-      onTap:
-          entry.data != null ? () => _showFullMessage(context, entry) : null,
+      onTap: entry.data != null ? () => _showFullMessage(context, entry) : null,
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
         child: Row(

--- a/src/frontend/lib/debug/system_info_tab.dart
+++ b/src/frontend/lib/debug/system_info_tab.dart
@@ -1,0 +1,144 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import '../auth/auth_service.dart';
+
+/// Tab showing server version, commit, build timestamp, and loaded plugins.
+class SystemInfoTab extends StatefulWidget {
+  final AuthService auth;
+  const SystemInfoTab({super.key, required this.auth});
+
+  @override
+  State<SystemInfoTab> createState() => _SystemInfoTabState();
+}
+
+class _SystemInfoTabState extends State<SystemInfoTab> {
+  Map<String, dynamic>? _info;
+  bool _loading = true;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _fetch();
+  }
+
+  Future<void> _fetch() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final resp = await widget.auth.authGet('/version');
+      if (resp.statusCode == 200) {
+        setState(() {
+          _info = jsonDecode(resp.body) as Map<String, dynamic>;
+          _loading = false;
+        });
+      } else {
+        setState(() {
+          _error = 'HTTP ${resp.statusCode}';
+          _loading = false;
+        });
+      }
+    } catch (_) {
+      setState(() {
+        _error = 'Failed to connect';
+        _loading = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return const Center(
+        child: SizedBox(
+          width: 16,
+          height: 16,
+          child: CircularProgressIndicator(strokeWidth: 2),
+        ),
+      );
+    }
+    if (_error != null) {
+      return Center(
+        child: Text(
+          _error!,
+          style: const TextStyle(color: Color(0xFF888888), fontSize: 11),
+        ),
+      );
+    }
+    final info = _info!;
+    final plugins = (info['plugins'] as List<dynamic>?) ?? [];
+
+    return ListView(
+      padding: const EdgeInsets.all(12),
+      children: [
+        _row('Version', info['version'] ?? 'unknown'),
+        _row('Commit', info['commit'] ?? 'unknown'),
+        _row('Built', info['built_at'] ?? 'n/a'),
+        const SizedBox(height: 12),
+        const Text(
+          'Plugins',
+          style: TextStyle(
+            color: Color(0xFF888888),
+            fontSize: 10,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        const SizedBox(height: 4),
+        if (plugins.isEmpty)
+          const Text(
+            'No plugins loaded',
+            style: TextStyle(color: Color(0xFF666666), fontSize: 10),
+          )
+        else
+          for (final p in plugins)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 2),
+              child: Text(
+                '${p['name']}'
+                '${(p['version'] ?? '').toString().isNotEmpty ? ' v${p['version']}' : ''}'
+                '${(p['description'] ?? '').toString().isNotEmpty ? ' — ${p['description']}' : ''}',
+                style: const TextStyle(
+                  color: Color(0xFFC5C8C6),
+                  fontSize: 10,
+                  fontFamily: 'monospace',
+                ),
+              ),
+            ),
+      ],
+    );
+  }
+
+  Widget _row(String label, String value) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 4),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 60,
+            child: Text(
+              label,
+              style: const TextStyle(
+                color: Color(0xFF888888),
+                fontSize: 10,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+          Expanded(
+            child: SelectableText(
+              value,
+              style: const TextStyle(
+                color: Color(0xFFC5C8C6),
+                fontSize: 10,
+                fontFamily: 'monospace',
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/src/frontend/test/system_info_tab_test.dart
+++ b/src/frontend/test/system_info_tab_test.dart
@@ -99,4 +99,88 @@ void main() {
 
     expect(find.text('HTTP 500'), findsOneWidget);
   });
+
+  testWidgets('shows connection error on exception', (tester) async {
+    testAuthHttpClientOverride = MockClient((request) async {
+      if (request.url.path == '/version') {
+        throw Exception('connection refused');
+      }
+      if (request.url.path.contains('/api/config')) {
+        return http.Response(
+          jsonEncode({'login_banner_title': '', 'login_banner': ''}),
+          200,
+        );
+      }
+      if (request.url.path.contains('/api/my-permissions')) {
+        return http.Response(
+          jsonEncode({
+            'user_id': 'test',
+            'email': 'test@example.com',
+            'permissions': <String, dynamic>{},
+            'groups': <dynamic>[],
+          }),
+          200,
+        );
+      }
+      return http.Response('{}', 200);
+    });
+
+    SharedPreferences.setMockInitialValues({'klangk_jwt': 'test-token'});
+    final auth = AuthService();
+
+    await tester.pumpWidget(
+      MaterialApp(home: Scaffold(body: SystemInfoTab(auth: auth))),
+    );
+    await tester.pump();
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('Failed to connect'), findsOneWidget);
+  });
+
+  testWidgets('shows no plugins loaded when list is empty', (tester) async {
+    testAuthHttpClientOverride = MockClient((request) async {
+      if (request.url.path == '/version') {
+        return http.Response(
+          jsonEncode({
+            'version': 'dev',
+            'commit': 'unknown',
+            'built_at': null,
+            'plugins': <dynamic>[],
+          }),
+          200,
+        );
+      }
+      if (request.url.path.contains('/api/config')) {
+        return http.Response(
+          jsonEncode({'login_banner_title': '', 'login_banner': ''}),
+          200,
+        );
+      }
+      if (request.url.path.contains('/api/my-permissions')) {
+        return http.Response(
+          jsonEncode({
+            'user_id': 'test',
+            'email': 'test@example.com',
+            'permissions': <String, dynamic>{},
+            'groups': <dynamic>[],
+          }),
+          200,
+        );
+      }
+      return http.Response('{}', 200);
+    });
+
+    SharedPreferences.setMockInitialValues({'klangk_jwt': 'test-token'});
+    final auth = AuthService();
+
+    await tester.pumpWidget(
+      MaterialApp(home: Scaffold(body: SystemInfoTab(auth: auth))),
+    );
+    await tester.pump();
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('No plugins loaded'), findsOneWidget);
+  });
 }

--- a/src/frontend/test/system_info_tab_test.dart
+++ b/src/frontend/test/system_info_tab_test.dart
@@ -1,0 +1,102 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:klangk_frontend/auth/auth_service.dart';
+import 'package:klangk_frontend/debug/system_info_tab.dart';
+import 'package:klangk_plugin_api/klangk_plugin_api.dart';
+
+http.Client _mockClient({int versionStatus = 200}) {
+  return MockClient((request) async {
+    if (request.url.path == '/version') {
+      if (versionStatus != 200) {
+        return http.Response('', versionStatus);
+      }
+      return http.Response(
+        jsonEncode({
+          'version': '1.2.3',
+          'commit': 'abc1234',
+          'built_at': '2026-01-01T00:00:00Z',
+          'plugins': [
+            {
+              'name': 'celebrate',
+              'version': '0.1.0',
+              'description': 'Confetti',
+            },
+          ],
+        }),
+        200,
+      );
+    }
+    if (request.url.path.contains('/api/config')) {
+      return http.Response(
+        jsonEncode({
+          'login_banner_title': '',
+          'login_banner': '',
+        }),
+        200,
+      );
+    }
+    if (request.url.path.contains('/api/my-permissions')) {
+      return http.Response(
+        jsonEncode({
+          'user_id': 'test',
+          'email': 'test@example.com',
+          'permissions': <String, dynamic>{},
+          'groups': <dynamic>[],
+        }),
+        200,
+      );
+    }
+    return http.Response('{}', 200);
+  });
+}
+
+void main() {
+  setUp(() {
+    testBaseUrlOverride = 'http://localhost:8997';
+    testAuthHttpClientOverride = null;
+  });
+
+  tearDown(() {
+    testBaseUrlOverride = null;
+    testAuthHttpClientOverride = null;
+  });
+
+  testWidgets('shows version info and plugins', (tester) async {
+    testAuthHttpClientOverride = _mockClient();
+    SharedPreferences.setMockInitialValues({'klangk_jwt': 'test-token'});
+    final auth = AuthService();
+
+    await tester.pumpWidget(
+      MaterialApp(home: Scaffold(body: SystemInfoTab(auth: auth))),
+    );
+    // Pump a few frames to let async init + fetch complete.
+    await tester.pump();
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('1.2.3'), findsOneWidget);
+    expect(find.text('abc1234'), findsOneWidget);
+    expect(find.text('2026-01-01T00:00:00Z'), findsOneWidget);
+    expect(find.textContaining('celebrate'), findsOneWidget);
+    expect(find.textContaining('Confetti'), findsOneWidget);
+  });
+
+  testWidgets('shows error on failure', (tester) async {
+    testAuthHttpClientOverride = _mockClient(versionStatus: 500);
+    SharedPreferences.setMockInitialValues({'klangk_jwt': 'test-token'});
+    final auth = AuthService();
+
+    await tester.pumpWidget(
+      MaterialApp(home: Scaffold(body: SystemInfoTab(auth: auth))),
+    );
+    await tester.pump();
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('HTTP 500'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- Add "System" tab to the bottom debug panel showing server version, commit, build timestamp, and loaded plugins
- Backend: add `plugins.plugin_list()` and include plugin metadata in `/version` response
- Frontend: convert `DebugPanel` from single-view to tabbed (WebSocket + System)

Closes #271

## Test plan
- [x] 1441 backend tests pass, 100% coverage
- [x] 569 frontend tests pass
- [ ] Manual: open debug pane, click System tab, verify version + plugins shown