### PR TITLE
Fix token refresh idempotency for expired tokens

### DIFF
--- a/src/backend/klangk_backend/model.py
+++ b/src/backend/klangk_backend/model.py
@@ -1484,20 +1484,19 @@ async def is_token_blocklisted(jti: str) -> bool:
 
 
 async def get_refreshed_token(jti: str) -> str | None:
-    """Return the replacement token for a refreshed JTI, if still valid."""
+    """Return the replacement token for a refreshed JTI.
+
+    The returned token is a full JWT whose own ``exp`` claim governs
+    its validity — no additional expiry check is needed here.
+    """
     async with transaction() as db:
         cursor = await db.execute(
-            "SELECT new_token, expires_at FROM token_blocklist"
+            "SELECT new_token FROM token_blocklist"
             " WHERE jti = ? AND new_token IS NOT NULL",
             (jti,),
         )
         row = await cursor.fetchone()
-        if row is None:
-            return None
-        expires_at = datetime.fromisoformat(row[1])
-        if expires_at < datetime.now(timezone.utc):
-            return None
-        return row[0]
+        return row[0] if row else None
 
 
 # Message history

--- a/src/backend/tests/test_auth.py
+++ b/src/backend/tests/test_auth.py
@@ -646,18 +646,21 @@ class TestRefreshToken:
         result = await auth.refresh_token(expired)
         assert result.access_token == "cached-new-token"
 
-    async def test_refresh_expired_cached_token_returns_401(self, db):
-        """Expired token with expired blocklist entry returns 401."""
+    async def test_refresh_expired_returns_cached_regardless_of_blocklist_expiry(
+        self, db
+    ):
+        """Cached replacement is returned even when the old token's
+        blocklist expires_at has passed — the new token's own exp
+        governs its validity."""
         await model.create_user(
             "a@b.com", auth.hash_password("pw"), verified=True
         )
         user = await model.get_user_by_email("a@b.com")
-        # Blocklist entry also expired
         expires_at = (
             datetime.now(timezone.utc) - timedelta(hours=1)
         ).isoformat()
         await model.blocklist_token(
-            "old-jti", expires_at, new_token="stale-token"
+            "old-jti", expires_at, new_token="cached-replacement"
         )
         expired = jwt.encode(
             {
@@ -669,9 +672,8 @@ class TestRefreshToken:
             auth.SECRET_KEY,
             algorithm=auth.ALGORITHM,
         )
-        with pytest.raises(HTTPException) as exc_info:
-            await auth.refresh_token(expired)
-        assert exc_info.value.status_code == 401
+        result = await auth.refresh_token(expired)
+        assert result.access_token == "cached-replacement"
 
     async def test_refresh_deleted_user_returns_401(self, db):
         """Refreshing a token for a deleted user returns 401."""


### PR DESCRIPTION
## Summary

- Remove the `expires_at` check from `get_refreshed_token()` in `model.py`
- The check compared against the old token's expiry, which had always passed when the `ExpiredSignatureError` handler runs — making the cached-token lookup dead code
- The cached replacement token's own `exp` claim governs its validity

Closes #668

## Test plan

- [x] Backend tests pass (1435 passed)
- [x] Updated test to verify cached replacement is returned regardless of old token's blocklist expiry