### PR TITLE
fix: prevent agent process death on terminal PTY EOF

### DIFF
--- a/src/backend/klangk_backend/agent.py
+++ b/src/backend/klangk_backend/agent.py
@@ -176,12 +176,12 @@ class AgentSession:
             return
         self._proc = None
 
-        # Drain stderr for diagnostics (limit to 1 KiB to avoid memory issues).
+        # Drain stderr for diagnostics.
         stderr_text = ""
         if proc.stderr is not None:
             try:
                 stderr_bytes = await asyncio.wait_for(
-                    proc.stderr.read(1024), timeout=2
+                    proc.stderr.read(8192), timeout=2
                 )
                 stderr_text = stderr_bytes.decode(errors="replace").strip()
             except (asyncio.TimeoutError, OSError):

--- a/src/backend/klangk_backend/agent.py
+++ b/src/backend/klangk_backend/agent.py
@@ -65,6 +65,7 @@ class AgentSession:
         self._home_ready = False
         self._monitor_task: asyncio.Task | None = None
         self._restart_attempts = 0
+        self._gave_up = False
 
     async def _ensure_home(self) -> str:
         """Ensure the agent has a home directory with Pi config.
@@ -128,6 +129,10 @@ class AgentSession:
     async def _ensure_started(self) -> asyncio.subprocess.Process:
         if self._proc is not None and self._proc.returncode is None:
             return self._proc
+        if self._gave_up:
+            raise AgentError(
+                "Agent gave up restarting for workspace %s" % self.workspace_id
+            )
 
         container_home = await self._ensure_home()
         agent_handle = await model.agent_handle()
@@ -155,6 +160,7 @@ class AgentSession:
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            start_new_session=True,
             env=podman.subprocess_env(),
         )
         self._monitor_task = asyncio.create_task(
@@ -169,15 +175,29 @@ class AgentSession:
         if self._proc is not proc:
             return
         self._proc = None
+
+        # Drain stderr for diagnostics (limit to 1 KiB to avoid memory issues).
+        stderr_text = ""
+        if proc.stderr is not None:
+            try:
+                stderr_bytes = await asyncio.wait_for(
+                    proc.stderr.read(1024), timeout=2
+                )
+                stderr_text = stderr_bytes.decode(errors="replace").strip()
+            except (asyncio.TimeoutError, OSError):
+                pass
         logger.warning(
-            "Agent process died (rc=%s) for container %s",
+            "Agent process died (rc=%s) for container %s%s",
             proc.returncode,
             self.container_id,
+            f": {stderr_text}" if stderr_text else "",
         )
+
         await _broadcast_agent_disconnect(self.workspace_id)
         # Auto-restart after a brief delay to avoid tight loops
         self._restart_attempts += 1
         if self._restart_attempts > 2:
+            self._gave_up = True
             logger.error(
                 "Agent exceeded 3 restart attempts for workspace %s, giving up",
                 self.workspace_id,
@@ -405,6 +425,7 @@ async def get_session(workspace_id: str, container_id: str) -> AgentSession:
         session.container_id = container_id
         session._home_ready = False
         session._restart_attempts = 0
+        session._gave_up = False
     return session
 
 

--- a/src/backend/tests/test_agent.py
+++ b/src/backend/tests/test_agent.py
@@ -7,6 +7,7 @@ import pytest
 from unittest.mock import AsyncMock, patch, MagicMock
 
 from klangk_backend.agent import (
+    AgentError,
     AgentProcessDied,
     AgentSession,
     any_running,
@@ -734,6 +735,8 @@ class TestMonitorProcess:
         mock_proc = AsyncMock()
         mock_proc.returncode = 1
         mock_proc.wait = AsyncMock()
+        mock_proc.stderr = asyncio.StreamReader()
+        mock_proc.stderr.feed_eof()
         session._proc = mock_proc
 
         with (
@@ -771,6 +774,8 @@ class TestMonitorProcess:
         mock_proc = AsyncMock()
         mock_proc.returncode = 1
         mock_proc.wait = AsyncMock()
+        mock_proc.stderr = asyncio.StreamReader()
+        mock_proc.stderr.feed_eof()
         session._proc = mock_proc
 
         with (
@@ -794,6 +799,85 @@ class TestMonitorProcess:
 
             mock_start.assert_not_awaited()
             assert session._restart_attempts == 3
+            assert session._gave_up is True
+
+    async def test_gave_up_blocks_ensure_started(self):
+        session = _make_session("cid-gaveup", "ws-gaveup")
+        session._gave_up = True
+
+        with pytest.raises(AgentError, match="gave up"):
+            await session._ensure_started()
+
+    async def test_gave_up_reset_on_container_change(self):
+        s = await get_session("ws-gaveup2", "old-cid")
+        s._gave_up = True
+        s2 = await get_session("ws-gaveup2", "new-cid")
+        assert s2._gave_up is False
+
+    async def test_monitor_logs_stderr(self, caplog):
+        from klangk_backend import model
+        import logging
+
+        session = _make_session("cid-stderr", "ws-stderr")
+        _agents["ws-stderr"] = session
+        session._restart_attempts = 2  # will give up
+
+        mock_proc = AsyncMock()
+        mock_proc.returncode = 255
+        mock_proc.wait = AsyncMock()
+        mock_proc.stderr = asyncio.StreamReader()
+        mock_proc.stderr.feed_data(b"Error: container not running\n")
+        mock_proc.stderr.feed_eof()
+        session._proc = mock_proc
+
+        with (
+            patch.object(
+                model,
+                "add_chat_message",
+                new_callable=AsyncMock,
+                return_value={"id": "m1", "message": "msg"},
+            ),
+            patch(
+                "klangk_backend.agent._get_workspace_session",
+                return_value=MagicMock(),
+            ),
+            caplog.at_level(logging.WARNING, logger="klangk_backend.agent"),
+        ):
+            await session._monitor_process(mock_proc)
+
+        assert any(
+            "container not running" in r.message for r in caplog.records
+        )
+
+    async def test_monitor_stderr_read_error(self):
+        """Monitor handles stderr read errors gracefully."""
+        from klangk_backend import model
+
+        session = _make_session("cid-stderr-err", "ws-stderr-err")
+        _agents["ws-stderr-err"] = session
+        session._restart_attempts = 2
+
+        mock_proc = AsyncMock()
+        mock_proc.returncode = 1
+        mock_proc.wait = AsyncMock()
+        mock_proc.stderr = AsyncMock()
+        mock_proc.stderr.read = AsyncMock(side_effect=OSError("broken pipe"))
+        session._proc = mock_proc
+
+        with (
+            patch.object(
+                model,
+                "add_chat_message",
+                new_callable=AsyncMock,
+                return_value={"id": "m1", "message": "msg"},
+            ),
+            patch(
+                "klangk_backend.agent._get_workspace_session",
+                return_value=MagicMock(),
+            ),
+        ):
+            await session._monitor_process(mock_proc)
+            assert session._gave_up is True
 
     async def test_monitor_restart_failure_logged(self):
         from klangk_backend import model
@@ -804,6 +888,8 @@ class TestMonitorProcess:
         mock_proc = AsyncMock()
         mock_proc.returncode = 1
         mock_proc.wait = AsyncMock()
+        mock_proc.stderr = asyncio.StreamReader()
+        mock_proc.stderr.feed_eof()
         session._proc = mock_proc
 
         with (
@@ -880,6 +966,8 @@ class TestMonitorProcess:
         dead_proc = AsyncMock()
         dead_proc.returncode = 1
         dead_proc.wait = AsyncMock()
+        dead_proc.stderr = asyncio.StreamReader()
+        dead_proc.stderr.feed_eof()
         session._proc = dead_proc
 
         async def fake_sleep(_):


### PR DESCRIPTION
Closes #608

## Summary
- Add `start_new_session=True` to agent's `podman exec` subprocess so it runs in its own process group, isolating it from signals that may propagate when the terminal PTY hits EOF
- Drain stderr (up to 1 KiB) when the agent process dies and include it in the warning log for diagnostics
- Add `_gave_up` flag to prevent infinite restart cycling — once the monitor exhausts 3 restart attempts, `_ensure_started` raises `AgentError` instead of silently starting a new doomed process. The flag resets when the container ID changes (container restart)

## Test plan
- [x] All 53 agent tests pass
- [x] agent.py at 100% coverage
- [x] New tests: `test_gave_up_blocks_ensure_started`, `test_gave_up_reset_on_container_change`, `test_monitor_logs_stderr`, `test_monitor_stderr_read_error`