### PR TITLE
fix: mask token in verification URL log message

### DIFF
--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -239,7 +239,12 @@ async def register(
     verification_url = (
         f"{proto}://{hostname}{base_path}/#/verify?token={verification_token}"
     )
-    logger.info("Verification URL: %s", verification_url)
+    logger.info(
+        "Verification URL: %s/#/verify?token=%s...%s",
+        f"{proto}://{hostname}{base_path}",
+        verification_token[:8],
+        verification_token[-4:],
+    )
 
     # Insert user and send email in a transaction — if the email fails,
     # the user insert is rolled back so they can try again.


### PR DESCRIPTION
Closes #694

## Summary
- Truncate the JWT token in the verification URL INFO log to `first8...last4` instead of logging the full token
- The old "Sending verification/reset/invitation email with URL" logs that also leaked tokens were already removed in #695

## Test plan
- [x] 40 related tests pass (registration, verification, email)