### PR TITLE
fix: don't expose internal error details to client

### DIFF
--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -1975,11 +1975,10 @@ async def upload_file(
                 fp.write(chunk)
     except HTTPException:
         raise
-    except Exception as e:  # pragma: no cover
+    except Exception:  # pragma: no cover
+        logger.exception("Upload failed for workspace %s", workspace_id)
         dest.unlink(missing_ok=True)
-        raise HTTPException(
-            status_code=500, detail=f"Upload failed: {e}"
-        ) from e
+        raise HTTPException(status_code=500, detail="Upload failed")
     home = workspaces.get_home_host_path(workspace["user_id"], workspace_id)
     saved_path = str(dest.relative_to(home))
     return {"path": saved_path, "status": "uploaded"}

--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -826,10 +826,11 @@ async def oidc_callback(
         hook_groups = await oidc.call_login_hook(
             provider, claims, email, tokens
         )
-    except Exception as exc:
+    except Exception:
+        logger.exception("OIDC login hook failed for provider %s", provider)
         raise HTTPException(
             status_code=403,
-            detail=str(exc),
+            detail="Login denied by server policy",
         ) from None
 
     # Find or create user

--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -756,7 +756,10 @@ async def oidc_callback(
 ):
     """Handle the OIDC callback from the IdP."""
     if error:
-        raise HTTPException(status_code=400, detail=f"IdP error: {error}")
+        logger.warning(
+            "OIDC IdP error for provider %s: %s", provider_id, error
+        )
+        raise HTTPException(status_code=400, detail="Login failed")
 
     provider = oidc.get_provider(provider_id)
     if provider is None:


### PR DESCRIPTION
Closes #662, closes #663, closes #664

## Summary
- **#664**: Upload endpoint — replace `detail=f"Upload failed: {e}"` with generic `"Upload failed"`, log exception server-side
- **#663**: OIDC login hook — replace `detail=str(exc)` with generic `"Login denied by server policy"`, log exception server-side
- **#662**: OIDC IdP callback — replace `detail=f"IdP error: {error}"` with generic `"Login failed"`, log error server-side

All three were leaking internal paths, config, or provider details to the client via HTTP error responses.

## Test plan
- [x] 72 OIDC/login tests pass
- [x] 47 upload/file tests pass