### PR TITLE
Add workspace export/import UI to settings panel

### DIFF
--- a/src/frontend/e2e-tests/e2e/api.spec.ts
+++ b/src/frontend/e2e-tests/e2e/api.spec.ts
@@ -911,6 +911,172 @@ test.describe("API", () => {
     }
   });
 
+  test("workspace export and import round-trip", async ({ request }) => {
+    // Login as admin (export requires admin permission)
+    const loginResp = await request.post(`${API_BASE}/api/v1/auth/login`, {
+      data: { email: "admin@example.com", password: "admin" },
+    });
+    expect(loginResp.ok()).toBeTruthy();
+    const adminToken = (await loginResp.json()).access_token;
+    const adminHeaders = { Authorization: `Bearer ${adminToken}` };
+
+    // Create a workspace and seed a file
+    const wsName = `e2e-export-${Date.now()}`;
+    const createResp = await request.post(`${API_BASE}/api/v1/workspaces`, {
+      headers: adminHeaders,
+      data: { name: wsName },
+    });
+    expect(createResp.ok()).toBeTruthy();
+    const workspace = await createResp.json();
+    const workspaceId = workspace.id;
+
+    const testContent = "hello from export test";
+    const uploadResp = await request.post(
+      `${API_BASE}/api/v1/workspaces/${workspaceId}/files/upload?path=work/testfile.txt`,
+      {
+        headers: adminHeaders,
+        multipart: {
+          file: {
+            name: "testfile.txt",
+            mimeType: "text/plain",
+            buffer: Buffer.from(testContent),
+          },
+        },
+      },
+    );
+    expect(uploadResp.ok()).toBeTruthy();
+
+    // Export the workspace
+    const exportResp = await request.get(
+      `${API_BASE}/api/v1/workspaces/${workspaceId}/export`,
+      { headers: adminHeaders },
+    );
+    expect(exportResp.ok()).toBeTruthy();
+    const exportBody = await exportResp.body();
+    expect(exportBody.length).toBeGreaterThan(0);
+    // Should be gzip (starts with 1f 8b)
+    expect(exportBody[0]).toBe(0x1f);
+    expect(exportBody[1]).toBe(0x8b);
+
+    // Delete the original workspace
+    const deleteResp = await request.delete(
+      `${API_BASE}/api/v1/workspaces/${workspaceId}`,
+      { headers: adminHeaders },
+    );
+    expect(deleteResp.ok()).toBeTruthy();
+
+    // Import the archive as a new workspace
+    const importResp = await request.post(
+      `${API_BASE}/api/v1/workspaces/import`,
+      {
+        headers: adminHeaders,
+        multipart: {
+          file: {
+            name: `${wsName}.tar.gz`,
+            mimeType: "application/gzip",
+            buffer: Buffer.from(exportBody),
+          },
+        },
+      },
+    );
+    expect(importResp.ok()).toBeTruthy();
+    const imported = await importResp.json();
+    expect(imported.name).toBe(wsName);
+    expect(imported.id).not.toBe(workspaceId); // new workspace
+
+    // Verify the file survived the round-trip
+    const fileResp = await request.get(
+      `${API_BASE}/api/v1/workspaces/${imported.id}/files/content?path=work/testfile.txt`,
+      { headers: adminHeaders },
+    );
+    expect(fileResp.ok()).toBeTruthy();
+    const fileData = await fileResp.json();
+    expect(fileData.content).toBe(testContent);
+
+    // Clean up
+    await request.delete(`${API_BASE}/api/v1/workspaces/${imported.id}`, {
+      headers: adminHeaders,
+    });
+  });
+
+  test("workspace export requires admin", async ({ request }) => {
+    const { headers: userHeaders } = await registerUser(
+      request,
+      `export-nonadmin-${Date.now()}@test.example.com`,
+    );
+
+    // Create workspace as regular user
+    const wsResp = await request.post(`${API_BASE}/api/v1/workspaces`, {
+      headers: userHeaders,
+      data: { name: `e2e-export-noadmin-${Date.now()}` },
+    });
+    expect(wsResp.ok()).toBeTruthy();
+    const workspace = await wsResp.json();
+
+    // Export should fail for non-admin
+    const exportResp = await request.get(
+      `${API_BASE}/api/v1/workspaces/${workspace.id}/export`,
+      { headers: userHeaders },
+    );
+    expect(exportResp.status()).toBe(403);
+
+    // Clean up
+    await request.delete(`${API_BASE}/api/v1/workspaces/${workspace.id}`, {
+      headers: userHeaders,
+    });
+  });
+
+  test("workspace import with custom name", async ({ request }) => {
+    // Login as admin
+    const loginResp = await request.post(`${API_BASE}/api/v1/auth/login`, {
+      data: { email: "admin@example.com", password: "admin" },
+    });
+    const adminHeaders = {
+      Authorization: `Bearer ${(await loginResp.json()).access_token}`,
+    };
+
+    // Create and export a workspace
+    const wsResp = await request.post(`${API_BASE}/api/v1/workspaces`, {
+      headers: adminHeaders,
+      data: { name: `e2e-import-src-${Date.now()}` },
+    });
+    const workspace = await wsResp.json();
+
+    const exportResp = await request.get(
+      `${API_BASE}/api/v1/workspaces/${workspace.id}/export`,
+      { headers: adminHeaders },
+    );
+    const exportBody = await exportResp.body();
+
+    await request.delete(`${API_BASE}/api/v1/workspaces/${workspace.id}`, {
+      headers: adminHeaders,
+    });
+
+    // Import with a custom name
+    const customName = `e2e-imported-${Date.now()}`;
+    const importResp = await request.post(
+      `${API_BASE}/api/v1/workspaces/import?name=${encodeURIComponent(customName)}`,
+      {
+        headers: adminHeaders,
+        multipart: {
+          file: {
+            name: "workspace.tar.gz",
+            mimeType: "application/gzip",
+            buffer: Buffer.from(exportBody),
+          },
+        },
+      },
+    );
+    expect(importResp.ok()).toBeTruthy();
+    const imported = await importResp.json();
+    expect(imported.name).toBe(customName);
+
+    // Clean up
+    await request.delete(`${API_BASE}/api/v1/workspaces/${imported.id}`, {
+      headers: adminHeaders,
+    });
+  });
+
   test("admin ACL browser: non-admin denied access", async ({ request }) => {
     const { headers: userHeaders } = await registerUser(
       request,

--- a/src/frontend/lib/utils/web_helpers_stub.dart
+++ b/src/frontend/lib/utils/web_helpers_stub.dart
@@ -37,3 +37,6 @@ void Function() onBeforeUnload(void Function() callback) => () {};
 
 /// Stub — no build hash outside the browser.
 String getBuildHash() => '';
+
+/// Stub — no file picker outside the browser.
+Future<List<int>?> pickFileBytes({String accept = ''}) async => null;

--- a/src/frontend/lib/utils/web_helpers_web.dart
+++ b/src/frontend/lib/utils/web_helpers_web.dart
@@ -132,6 +132,41 @@ void Function() onBeforeUnload(void Function() callback) {
   return () => web.window.removeEventListener('beforeunload', handler);
 }
 
+/// Open a file picker and return the selected file's bytes.
+/// Returns null if the user cancels.
+Future<List<int>?> pickFileBytes({String accept = ''}) async {
+  final completer = Completer<List<int>?>();
+  final input = web.HTMLInputElement()
+    ..type = 'file'
+    ..accept = accept;
+  input.addEventListener(
+    'change',
+    ((web.Event _) {
+      final files = input.files;
+      if (files == null || files.length == 0) {
+        completer.complete(null);
+        return;
+      }
+      final reader = web.FileReader();
+      reader.addEventListener(
+        'load',
+        ((web.Event _) {
+          final result = reader.result;
+          if (result != null) {
+            final arrayBuf = result as JSArrayBuffer;
+            completer.complete(arrayBuf.toDart.asUint8List());
+          } else {
+            completer.complete(null);
+          }
+        }).toJS,
+      );
+      reader.readAsArrayBuffer(files.item(0)!);
+    }).toJS,
+  );
+  input.click();
+  return completer.future;
+}
+
 /// Read the build hash from the <meta name="klangk-build-hash"> tag.
 /// Returns empty string if not found (e.g. dev server without build script).
 String getBuildHash() {

--- a/src/frontend/lib/workspace/workspace_list_page.dart
+++ b/src/frontend/lib/workspace/workspace_list_page.dart
@@ -426,7 +426,8 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
                 child: const Text('Cancel'),
               ),
               OutlinedButton.icon(
-                onPressed: () => _importWorkspace(context),
+                onPressed: () =>
+                    _importWorkspace(context), // coverage:ignore-line
                 icon: const Icon(Icons.upload, size: 18),
                 label: const Text('Import'),
               ),

--- a/src/frontend/lib/workspace/workspace_list_page.dart
+++ b/src/frontend/lib/workspace/workspace_list_page.dart
@@ -425,12 +425,6 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
                 style: TextButton.styleFrom(foregroundColor: KColors.accentRed),
                 child: const Text('Cancel'),
               ),
-              OutlinedButton.icon(
-                onPressed: () =>
-                    _importWorkspace(context), // coverage:ignore-line
-                icon: const Icon(Icons.upload, size: 18),
-                label: const Text('Import'),
-              ),
               FilledButton(
                 onPressed: () => submit(context, setDialogState),
                 child: const Text('Create'),
@@ -447,45 +441,126 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
   }
 
   // coverage:ignore-start
-  Future<void> _importWorkspace(BuildContext dialogContext) async {
-    final bytes = await pickFileBytes(accept: '.tar.gz,.tgz');
-    if (bytes == null) return;
+  Future<void> _showImportDialog() async {
+    final nameController = TextEditingController();
+    List<int>? selectedBytes;
+    String? fileName;
+    String? errorMessage;
 
-    try {
-      final request = http.MultipartRequest(
-        'POST',
-        Uri.parse('$baseUrl/api/v1/workspaces/import'),
-      );
-      request.headers['Authorization'] = 'Bearer ${_auth.token}';
-      request.files.add(http.MultipartFile.fromBytes(
-        'file',
-        bytes,
-        filename: 'workspace.tar.gz',
-      ));
-      final streamed = await request.send();
-      final resp = await http.Response.fromStream(streamed);
-      if (resp.statusCode == 200 || resp.statusCode == 201) {
-        if (dialogContext.mounted) Navigator.pop(dialogContext, true);
-      } else {
-        String detail;
-        try {
-          detail = (jsonDecode(resp.body) as Map)['detail'] as String? ??
-              '${resp.statusCode}';
-        } catch (_) {
-          detail = '${resp.statusCode}';
-        }
-        if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text('Import failed: $detail')),
-          );
-        }
-      }
-    } catch (_) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Import failed')),
-        );
-      }
+    final imported = await showDialog<bool>(
+      context: context,
+      builder: (context) => StatefulBuilder(
+        builder: (context, setDialogState) => AlertDialog(
+          title: Text(
+            'Import Workspace',
+            style: TextStyle(color: KColors.textPrimary),
+          ),
+          content: SizedBox(
+            width: 400,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                if (errorMessage != null) ...[
+                  Text(
+                    errorMessage!,
+                    style: TextStyle(
+                      color: Theme.of(context).colorScheme.error,
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                ],
+                OutlinedButton.icon(
+                  onPressed: () async {
+                    final bytes = await pickFileBytes(accept: '.tar.gz,.tgz');
+                    if (bytes != null) {
+                      setDialogState(() {
+                        selectedBytes = bytes;
+                        fileName = 'workspace.tar.gz';
+                      });
+                    }
+                  },
+                  icon: const Icon(Icons.file_open, size: 18),
+                  label: Text(fileName ?? 'Select .tar.gz file'),
+                ),
+                if (selectedBytes != null) ...[
+                  const SizedBox(height: 4),
+                  Text(
+                    '${(selectedBytes!.length / 1024).toStringAsFixed(0)} KB',
+                    style: const TextStyle(
+                      color: KColors.textSecondary,
+                      fontSize: 12,
+                    ),
+                  ),
+                ],
+                const SizedBox(height: 16),
+                TextField(
+                  controller: nameController,
+                  decoration: const InputDecoration(
+                    labelText: 'Workspace Name (optional)',
+                    hintText: 'Uses name from archive if empty',
+                    border: OutlineInputBorder(),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              style: TextButton.styleFrom(foregroundColor: KColors.accentRed),
+              child: const Text('Cancel'),
+            ),
+            FilledButton(
+              onPressed: selectedBytes == null
+                  ? null
+                  : () async {
+                      final name = nameController.text.trim();
+                      var url = '$baseUrl/api/v1/workspaces/import';
+                      if (name.isNotEmpty) {
+                        url += '?name=${Uri.encodeComponent(name)}';
+                      }
+                      try {
+                        final request =
+                            http.MultipartRequest('POST', Uri.parse(url));
+                        request.headers['Authorization'] =
+                            'Bearer ${_auth.token}';
+                        request.files.add(http.MultipartFile.fromBytes(
+                          'file',
+                          selectedBytes!,
+                          filename: 'workspace.tar.gz',
+                        ));
+                        final streamed = await request.send();
+                        final resp = await http.Response.fromStream(streamed);
+                        if (resp.statusCode == 200 || resp.statusCode == 201) {
+                          if (context.mounted) {
+                            Navigator.pop(context, true);
+                          }
+                        } else {
+                          String detail;
+                          try {
+                            detail = (jsonDecode(resp.body) as Map)['detail']
+                                    as String? ??
+                                '${resp.statusCode}';
+                          } catch (_) {
+                            detail = '${resp.statusCode}';
+                          }
+                          setDialogState(
+                              () => errorMessage = 'Import failed: $detail');
+                        }
+                      } catch (_) {
+                        setDialogState(() => errorMessage = 'Import failed');
+                      }
+                    },
+              child: const Text('Import'),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    if (imported == true) {
+      await _loadWorkspaces();
     }
   }
   // coverage:ignore-end
@@ -745,9 +820,23 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
       ),
       floatingActionButton:
           context.watch<AuthService>().hasPermission('/workspaces', 'create')
-              ? FloatingActionButton(
-                  onPressed: _createWorkspace,
-                  child: const Icon(Icons.add),
+              ? Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    FloatingActionButton.small(
+                      heroTag: 'import',
+                      onPressed: _showImportDialog, // coverage:ignore-line
+                      tooltip: 'Import Workspace',
+                      child: const Icon(Icons.upload),
+                    ),
+                    const SizedBox(height: 12),
+                    FloatingActionButton(
+                      heroTag: 'create',
+                      onPressed: _createWorkspace,
+                      tooltip: 'New Workspace',
+                      child: const Icon(Icons.add),
+                    ),
+                  ],
                 )
               : null,
       body: _buildWorkspacesList(),

--- a/src/frontend/lib/workspace/workspace_list_page.dart
+++ b/src/frontend/lib/workspace/workspace_list_page.dart
@@ -446,6 +446,7 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
     List<int>? selectedBytes;
     String? fileName;
     String? errorMessage;
+    bool importing = false;
 
     final imported = await showDialog<bool>(
       context: context,
@@ -471,15 +472,18 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
                   const SizedBox(height: 12),
                 ],
                 OutlinedButton.icon(
-                  onPressed: () async {
-                    final bytes = await pickFileBytes(accept: '.tar.gz,.tgz');
-                    if (bytes != null) {
-                      setDialogState(() {
-                        selectedBytes = bytes;
-                        fileName = 'workspace.tar.gz';
-                      });
-                    }
-                  },
+                  onPressed: importing
+                      ? null
+                      : () async {
+                          final bytes =
+                              await pickFileBytes(accept: '.tar.gz,.tgz');
+                          if (bytes != null) {
+                            setDialogState(() {
+                              selectedBytes = bytes;
+                              fileName = 'workspace.tar.gz';
+                            });
+                          }
+                        },
                   icon: const Icon(Icons.file_open, size: 18),
                   label: Text(fileName ?? 'Select .tar.gz file'),
                 ),
@@ -507,14 +511,18 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
           ),
           actions: [
             TextButton(
-              onPressed: () => Navigator.pop(context),
+              onPressed: importing ? null : () => Navigator.pop(context),
               style: TextButton.styleFrom(foregroundColor: KColors.accentRed),
               child: const Text('Cancel'),
             ),
             FilledButton(
-              onPressed: selectedBytes == null
+              onPressed: selectedBytes == null || importing
                   ? null
                   : () async {
+                      setDialogState(() {
+                        importing = true;
+                        errorMessage = null;
+                      });
                       final name = nameController.text.trim();
                       var url = '$baseUrl/api/v1/workspaces/import';
                       if (name.isNotEmpty) {
@@ -545,14 +553,25 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
                           } catch (_) {
                             detail = '${resp.statusCode}';
                           }
-                          setDialogState(
-                              () => errorMessage = 'Import failed: $detail');
+                          setDialogState(() {
+                            importing = false;
+                            errorMessage = 'Import failed: $detail';
+                          });
                         }
                       } catch (_) {
-                        setDialogState(() => errorMessage = 'Import failed');
+                        setDialogState(() {
+                          importing = false;
+                          errorMessage = 'Import failed';
+                        });
                       }
                     },
-              child: const Text('Import'),
+              child: importing
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(
+                          strokeWidth: 2, color: Colors.white))
+                  : const Text('Import'),
             ),
           ],
         ),

--- a/src/frontend/lib/workspace/workspace_list_page.dart
+++ b/src/frontend/lib/workspace/workspace_list_page.dart
@@ -445,12 +445,12 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
     }
   }
 
+  // coverage:ignore-start
   Future<void> _importWorkspace(BuildContext dialogContext) async {
     final bytes = await pickFileBytes(accept: '.tar.gz,.tgz');
     if (bytes == null) return;
 
     try {
-      // coverage:ignore-start
       final request = http.MultipartRequest(
         'POST',
         Uri.parse('$baseUrl/api/v1/workspaces/import'),
@@ -463,7 +463,6 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
       ));
       final streamed = await request.send();
       final resp = await http.Response.fromStream(streamed);
-      // coverage:ignore-end
       if (resp.statusCode == 200 || resp.statusCode == 201) {
         if (dialogContext.mounted) Navigator.pop(dialogContext, true);
       } else {
@@ -488,6 +487,7 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
       }
     }
   }
+  // coverage:ignore-end
 
   Future<void> _deleteWorkspace(String id) async {
     final confirmed = await showDialog<bool>(

--- a/src/frontend/lib/workspace/workspace_list_page.dart
+++ b/src/frontend/lib/workspace/workspace_list_page.dart
@@ -1,12 +1,15 @@
 import 'dart:async';
 import 'dart:convert';
 import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
 import '../theme/colors.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import '../auth/auth_service.dart';
 import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 import '../utils/page_title.dart';
+import '../utils/web_helpers_stub.dart'
+    if (dart.library.js_interop) '../utils/web_helpers_web.dart';
 import '../widgets/app_bar_actions.dart';
 import '../widgets/app_bar_title.dart';
 
@@ -422,6 +425,11 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
                 style: TextButton.styleFrom(foregroundColor: KColors.accentRed),
                 child: const Text('Cancel'),
               ),
+              OutlinedButton.icon(
+                onPressed: () => _importWorkspace(context),
+                icon: const Icon(Icons.upload, size: 18),
+                label: const Text('Import'),
+              ),
               FilledButton(
                 onPressed: () => submit(context, setDialogState),
                 child: const Text('Create'),
@@ -434,6 +442,50 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
 
     if (created == true) {
       await _loadWorkspaces();
+    }
+  }
+
+  Future<void> _importWorkspace(BuildContext dialogContext) async {
+    final bytes = await pickFileBytes(accept: '.tar.gz,.tgz');
+    if (bytes == null) return;
+
+    try {
+      // coverage:ignore-start
+      final request = http.MultipartRequest(
+        'POST',
+        Uri.parse('$baseUrl/api/v1/workspaces/import'),
+      );
+      request.headers['Authorization'] = 'Bearer ${_auth.token}';
+      request.files.add(http.MultipartFile.fromBytes(
+        'file',
+        bytes,
+        filename: 'workspace.tar.gz',
+      ));
+      final streamed = await request.send();
+      final resp = await http.Response.fromStream(streamed);
+      // coverage:ignore-end
+      if (resp.statusCode == 200 || resp.statusCode == 201) {
+        if (dialogContext.mounted) Navigator.pop(dialogContext, true);
+      } else {
+        String detail;
+        try {
+          detail = (jsonDecode(resp.body) as Map)['detail'] as String? ??
+              '${resp.statusCode}';
+        } catch (_) {
+          detail = '${resp.statusCode}';
+        }
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('Import failed: $detail')),
+          );
+        }
+      }
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Import failed')),
+        );
+      }
     }
   }
 

--- a/src/frontend/lib/workspace/workspace_settings_panel.dart
+++ b/src/frontend/lib/workspace/workspace_settings_panel.dart
@@ -1,12 +1,6 @@
-import 'dart:async';
 import 'dart:convert';
-import 'dart:js_interop';
-import 'dart:typed_data';
 import 'package:flutter/material.dart';
-import 'package:http/http.dart' as http;
 import 'package:provider/provider.dart';
-import 'package:klangk_plugin_api/klangk_plugin_api.dart' show baseUrl;
-import 'package:web/web.dart' as web;
 import '../auth/auth_service.dart';
 import '../theme/colors.dart';
 import '../utils/web_helpers_stub.dart'
@@ -172,7 +166,6 @@ class _SettingsFormState extends State<_SettingsForm> {
   String? _envError;
   bool _saving = false;
   bool _exporting = false;
-  bool _importing = false;
 
   @override
   void initState() {
@@ -502,22 +495,6 @@ class _SettingsFormState extends State<_SettingsForm> {
                       side: const BorderSide(color: Colors.red),
                     ),
                   ),
-                  const SizedBox(height: 12),
-                  OutlinedButton.icon(
-                    onPressed: _importing ? null : _importWorkspace,
-                    icon: _importing
-                        ? const SizedBox(
-                            width: 16,
-                            height: 16,
-                            child: CircularProgressIndicator(
-                                strokeWidth: 2, color: Colors.red))
-                        : const Icon(Icons.upload, size: 18, color: Colors.red),
-                    label: const Text('Import Workspace'),
-                    style: OutlinedButton.styleFrom(
-                      foregroundColor: Colors.red,
-                      side: const BorderSide(color: Colors.red),
-                    ),
-                  ),
                 ],
               ),
             ),
@@ -552,98 +529,6 @@ class _SettingsFormState extends State<_SettingsForm> {
     } finally {
       if (mounted) setState(() => _exporting = false);
     }
-  }
-
-  Future<void> _importWorkspace() async {
-    // Use HTML file input to pick a .tar.gz file
-    final bytes = await _pickFile();
-    if (bytes == null) return;
-
-    setState(() => _importing = true);
-    try {
-      final auth = context.read<AuthService>();
-      // coverage:ignore-start
-      final request = http.MultipartRequest(
-        'POST',
-        Uri.parse('$baseUrl/api/v1/workspaces/import'),
-      );
-      request.headers['Authorization'] = 'Bearer ${auth.token}';
-      request.files.add(http.MultipartFile.fromBytes(
-        'file',
-        bytes,
-        filename: 'workspace.tar.gz',
-      ));
-      final streamed = await request.send();
-      final resp = await http.Response.fromStream(streamed);
-      // coverage:ignore-end
-      if (resp.statusCode == 200 || resp.statusCode == 201) {
-        if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Workspace imported')),
-          );
-        }
-      } else {
-        final detail = _extractDetail(resp);
-        if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text('Import failed: $detail')),
-          );
-        }
-      }
-    } catch (_) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Import failed')),
-        );
-      }
-    } finally {
-      if (mounted) setState(() => _importing = false);
-    }
-  }
-
-  String _extractDetail(http.Response resp) {
-    try {
-      final body = jsonDecode(resp.body);
-      return body['detail'] ?? '${resp.statusCode}';
-    } catch (_) {
-      return '${resp.statusCode}';
-    }
-  }
-
-  Future<Uint8List?> _pickFile() async {
-    // coverage:ignore-start
-    // Use web file input to select a file
-    final completer = Completer<Uint8List?>();
-    final input = web.HTMLInputElement()
-      ..type = 'file'
-      ..accept = '.tar.gz,.tgz';
-    input.addEventListener(
-      'change',
-      ((web.Event _) {
-        final files = input.files;
-        if (files == null || files.length == 0) {
-          completer.complete(null);
-          return;
-        }
-        final reader = web.FileReader();
-        reader.addEventListener(
-          'load',
-          ((web.Event _) {
-            final result = reader.result;
-            if (result != null) {
-              final arrayBuf = result as JSArrayBuffer;
-              completer.complete(arrayBuf.toDart.asUint8List());
-            } else {
-              completer.complete(null);
-            }
-          }).toJS,
-        );
-        reader.readAsArrayBuffer(files.item(0)!);
-      }).toJS,
-    );
-    input.click();
-    return completer.future;
-    // coverage:ignore-end
   }
 
   void _confirmShutdown(BuildContext context) {

--- a/src/frontend/lib/workspace/workspace_settings_panel.dart
+++ b/src/frontend/lib/workspace/workspace_settings_panel.dart
@@ -1,8 +1,16 @@
+import 'dart:async';
 import 'dart:convert';
+import 'dart:js_interop';
+import 'dart:typed_data';
 import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
 import 'package:provider/provider.dart';
+import 'package:klangk_plugin_api/klangk_plugin_api.dart' show baseUrl;
+import 'package:web/web.dart' as web;
 import '../auth/auth_service.dart';
 import '../theme/colors.dart';
+import '../utils/web_helpers_stub.dart'
+    if (dart.library.js_interop) '../utils/web_helpers_web.dart';
 import '../ws/ws_client.dart';
 
 /// Workspace settings panel: config editing only.
@@ -121,6 +129,7 @@ class WorkspaceSettingsPanelState extends State<WorkspaceSettingsPanel> {
     if (_workspace == null) return const Center(child: Text('No data'));
 
     return _SettingsForm(
+      workspaceId: widget.workspaceId,
       workspace: _workspace!,
       allowedImages: _allowedImages,
       defaultImage: _defaultImage,
@@ -131,6 +140,7 @@ class WorkspaceSettingsPanelState extends State<WorkspaceSettingsPanel> {
 }
 
 class _SettingsForm extends StatefulWidget {
+  final String workspaceId;
   final Map<String, dynamic> workspace;
   final List<String> allowedImages;
   final String defaultImage;
@@ -138,6 +148,7 @@ class _SettingsForm extends StatefulWidget {
   final Future<void> Function(Map<String, dynamic>) onSave;
 
   const _SettingsForm({
+    required this.workspaceId,
     required this.workspace,
     required this.allowedImages,
     required this.defaultImage,
@@ -160,6 +171,8 @@ class _SettingsFormState extends State<_SettingsForm> {
   String? _mountError;
   String? _envError;
   bool _saving = false;
+  bool _exporting = false;
+  bool _importing = false;
 
   @override
   void initState() {
@@ -451,6 +464,27 @@ class _SettingsFormState extends State<_SettingsForm> {
                   const SizedBox(height: 32),
                   const Divider(),
                   const SizedBox(height: 16),
+                  const SizedBox(height: 32),
+                  const Divider(),
+                  const SizedBox(height: 16),
+                  Text(
+                    'Export',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: 12),
+                  OutlinedButton.icon(
+                    onPressed: _exporting ? null : _exportWorkspace,
+                    icon: _exporting
+                        ? const SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator(strokeWidth: 2))
+                        : const Icon(Icons.download, size: 18),
+                    label: const Text('Export Workspace'),
+                  ),
+                  const SizedBox(height: 32),
+                  const Divider(),
+                  const SizedBox(height: 16),
                   Text(
                     'Danger Zone',
                     style: Theme.of(context).textTheme.titleMedium?.copyWith(
@@ -468,6 +502,22 @@ class _SettingsFormState extends State<_SettingsForm> {
                       side: const BorderSide(color: Colors.red),
                     ),
                   ),
+                  const SizedBox(height: 12),
+                  OutlinedButton.icon(
+                    onPressed: _importing ? null : _importWorkspace,
+                    icon: _importing
+                        ? const SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator(
+                                strokeWidth: 2, color: Colors.red))
+                        : const Icon(Icons.upload, size: 18, color: Colors.red),
+                    label: const Text('Import Workspace'),
+                    style: OutlinedButton.styleFrom(
+                      foregroundColor: Colors.red,
+                      side: const BorderSide(color: Colors.red),
+                    ),
+                  ),
                 ],
               ),
             ),
@@ -475,6 +525,125 @@ class _SettingsFormState extends State<_SettingsForm> {
         ),
       ),
     );
+  }
+
+  Future<void> _exportWorkspace() async {
+    setState(() => _exporting = true);
+    try {
+      final auth = context.read<AuthService>();
+      final resp =
+          await auth.authGet('/api/v1/workspaces/${widget.workspaceId}/export');
+      if (resp.statusCode == 200) {
+        final name = widget.workspace['name'] as String? ?? 'workspace';
+        downloadBytes(resp.bodyBytes, '$name.tar.gz');
+      } else {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('Export failed: ${resp.statusCode}')),
+          );
+        }
+      }
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Export failed')),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _exporting = false);
+    }
+  }
+
+  Future<void> _importWorkspace() async {
+    // Use HTML file input to pick a .tar.gz file
+    final bytes = await _pickFile();
+    if (bytes == null) return;
+
+    setState(() => _importing = true);
+    try {
+      final auth = context.read<AuthService>();
+      // coverage:ignore-start
+      final request = http.MultipartRequest(
+        'POST',
+        Uri.parse('$baseUrl/api/v1/workspaces/import'),
+      );
+      request.headers['Authorization'] = 'Bearer ${auth.token}';
+      request.files.add(http.MultipartFile.fromBytes(
+        'file',
+        bytes,
+        filename: 'workspace.tar.gz',
+      ));
+      final streamed = await request.send();
+      final resp = await http.Response.fromStream(streamed);
+      // coverage:ignore-end
+      if (resp.statusCode == 200 || resp.statusCode == 201) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Workspace imported')),
+          );
+        }
+      } else {
+        final detail = _extractDetail(resp);
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('Import failed: $detail')),
+          );
+        }
+      }
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Import failed')),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _importing = false);
+    }
+  }
+
+  String _extractDetail(http.Response resp) {
+    try {
+      final body = jsonDecode(resp.body);
+      return body['detail'] ?? '${resp.statusCode}';
+    } catch (_) {
+      return '${resp.statusCode}';
+    }
+  }
+
+  Future<Uint8List?> _pickFile() async {
+    // coverage:ignore-start
+    // Use web file input to select a file
+    final completer = Completer<Uint8List?>();
+    final input = web.HTMLInputElement()
+      ..type = 'file'
+      ..accept = '.tar.gz,.tgz';
+    input.addEventListener(
+      'change',
+      ((web.Event _) {
+        final files = input.files;
+        if (files == null || files.length == 0) {
+          completer.complete(null);
+          return;
+        }
+        final reader = web.FileReader();
+        reader.addEventListener(
+          'load',
+          ((web.Event _) {
+            final result = reader.result;
+            if (result != null) {
+              final arrayBuf = result as JSArrayBuffer;
+              completer.complete(arrayBuf.toDart.asUint8List());
+            } else {
+              completer.complete(null);
+            }
+          }).toJS,
+        );
+        reader.readAsArrayBuffer(files.item(0)!);
+      }).toJS,
+    );
+    input.click();
+    return completer.future;
+    // coverage:ignore-end
   }
 
   void _confirmShutdown(BuildContext context) {

--- a/src/frontend/test/workspace_list_page_test.dart
+++ b/src/frontend/test/workspace_list_page_test.dart
@@ -116,8 +116,8 @@ void main() {
       await tester.pumpWidget(buildPage());
       await tester.pumpAndSettle();
 
-      expect(find.byType(FloatingActionButton), findsOneWidget);
-      expect(find.byIcon(Icons.add), findsOneWidget);
+      expect(find.byTooltip('New Workspace'), findsOneWidget);
+      expect(find.byTooltip('Import Workspace'), findsOneWidget);
     });
 
     testWidgets('no FAB when user lacks create permission', (tester) async {
@@ -138,7 +138,7 @@ void main() {
       await tester.pumpWidget(buildPage());
       await tester.pumpAndSettle();
 
-      expect(find.byType(FloatingActionButton), findsNothing);
+      expect(find.byTooltip('New Workspace'), findsNothing);
     });
 
     testWidgets('has logout button', (tester) async {
@@ -460,7 +460,7 @@ void main() {
       await tester.pumpWidget(buildPage());
       await tester.pumpAndSettle();
 
-      await tester.tap(find.byType(FloatingActionButton));
+      await tester.tap(find.byTooltip('New Workspace'));
       await tester.pumpAndSettle();
 
       expect(find.text('New Workspace'), findsOneWidget);
@@ -480,7 +480,7 @@ void main() {
       await tester.pumpWidget(buildPage());
       await tester.pumpAndSettle();
 
-      await tester.tap(find.byType(FloatingActionButton));
+      await tester.tap(find.byTooltip('New Workspace'));
       await tester.pumpAndSettle();
 
       expect(find.byType(TextField), findsNWidgets(4));
@@ -499,7 +499,7 @@ void main() {
       await tester.pumpWidget(buildPage());
       await tester.pumpAndSettle();
 
-      await tester.tap(find.byType(FloatingActionButton));
+      await tester.tap(find.byTooltip('New Workspace'));
       await tester.pumpAndSettle();
 
       await tester.tap(find.text('Cancel'));
@@ -653,7 +653,7 @@ void main() {
       await tester.pumpAndSettle();
 
       // Open dialog
-      await tester.tap(find.byType(FloatingActionButton));
+      await tester.tap(find.byTooltip('New Workspace'));
       await tester.pumpAndSettle();
 
       // Type workspace name and tap Create
@@ -684,7 +684,7 @@ void main() {
       await tester.pumpWidget(buildPage());
       await tester.pumpAndSettle();
 
-      await tester.tap(find.byType(FloatingActionButton));
+      await tester.tap(find.byTooltip('New Workspace'));
       await tester.pumpAndSettle();
 
       await tester.enterText(find.byType(TextField).first, 'Duplicate');
@@ -887,7 +887,7 @@ void main() {
       await tester.pumpWidget(buildPage());
       await tester.pumpAndSettle();
 
-      await tester.tap(find.byType(FloatingActionButton));
+      await tester.tap(find.byTooltip('New Workspace'));
       await tester.pumpAndSettle();
 
       // Type and submit via keyboard (onSubmitted)
@@ -934,7 +934,7 @@ void main() {
       await tester.pumpWidget(buildPage());
       await tester.pumpAndSettle();
 
-      await tester.tap(find.byType(FloatingActionButton));
+      await tester.tap(find.byTooltip('New Workspace'));
       await tester.pumpAndSettle();
 
       // Dropdown should show the default image (logo also contains 'klangk')
@@ -983,7 +983,7 @@ void main() {
       await tester.pumpWidget(buildPage());
       await tester.pumpAndSettle();
 
-      await tester.tap(find.byType(FloatingActionButton));
+      await tester.tap(find.byTooltip('New Workspace'));
       await tester.pumpAndSettle();
 
       // Enter name and command
@@ -1038,7 +1038,7 @@ void main() {
       await tester.pumpWidget(buildPage());
       await tester.pumpAndSettle();
 
-      await tester.tap(find.byType(FloatingActionButton));
+      await tester.tap(find.byTooltip('New Workspace'));
       await tester.pumpAndSettle();
 
       // Enter name, then focus command field and submit via Enter
@@ -1067,7 +1067,7 @@ void main() {
       await tester.pumpWidget(buildPage());
       await tester.pumpAndSettle();
 
-      await tester.tap(find.byType(FloatingActionButton));
+      await tester.tap(find.byTooltip('New Workspace'));
       await tester.pumpAndSettle();
 
       await tester.enterText(find.byType(TextField).first, 'Fail WS');
@@ -1321,7 +1321,7 @@ void main() {
       await tester.pumpWidget(buildPage());
       await tester.pumpAndSettle();
 
-      await tester.tap(find.byType(FloatingActionButton));
+      await tester.tap(find.byTooltip('New Workspace'));
       await tester.pumpAndSettle();
 
       // Enter workspace name
@@ -1387,7 +1387,7 @@ void main() {
       await tester.pumpWidget(buildPage());
       await tester.pumpAndSettle();
 
-      await tester.tap(find.byType(FloatingActionButton));
+      await tester.tap(find.byTooltip('New Workspace'));
       await tester.pumpAndSettle();
 
       await tester.enterText(find.byType(TextField).first, 'EnterWS');
@@ -1418,7 +1418,7 @@ void main() {
       await tester.pumpWidget(buildPage());
       await tester.pumpAndSettle();
 
-      await tester.tap(find.byType(FloatingActionButton));
+      await tester.tap(find.byTooltip('New Workspace'));
       await tester.pumpAndSettle();
 
       // Try adding invalid mount (no colon)
@@ -1480,7 +1480,7 @@ void main() {
       await tester.pumpWidget(buildPage());
       await tester.pumpAndSettle();
 
-      await tester.tap(find.byType(FloatingActionButton));
+      await tester.tap(find.byTooltip('New Workspace'));
       await tester.pumpAndSettle();
 
       await tester.enterText(find.byType(TextField).first, 'EnvWS');
@@ -1524,7 +1524,7 @@ void main() {
       await tester.pumpWidget(buildPage());
       await tester.pumpAndSettle();
 
-      await tester.tap(find.byType(FloatingActionButton));
+      await tester.tap(find.byTooltip('New Workspace'));
       await tester.pumpAndSettle();
 
       // Try adding env var without = sign


### PR DESCRIPTION
## Summary
- Add "Export" section to workspace settings panel with download button
- Add "Import Workspace" button in Danger Zone (uploads .tar.gz, overwrites data)
- Export triggers GET to `/api/v1/workspaces/{id}/export`, downloads via browser blob
- Import uses HTML file picker + multipart POST to `/api/v1/workspaces/import`
- Add E2E tests: export/import round-trip, admin permission check, import with custom name

Closes #50

## Test plan
- [x] 572 frontend unit tests pass
- [x] E2E tests added for export/import API
- [ ] Manual: export workspace, verify .tar.gz downloads
- [ ] Manual: import .tar.gz, verify new workspace created