### PR TITLE
fix: bypass Firefox WebSocket throttle with channel.ready timeout

### DIFF
--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -38,6 +38,7 @@ class WsClient extends ChangeNotifier {
   String? _currentUserId;
   String? _defaultCommand;
   bool _connected = false;
+  bool _connecting = false;
   Timer? _heartbeatTimer;
 
   /// Whether an automatic reconnection is in progress.
@@ -191,22 +192,27 @@ class WsClient extends ChangeNotifier {
     debugPrint('[WsClient] connect() enter: ${DateTime.now()}');
     _reconnectTimer?.cancel();
     _reconnectTimer = null;
-    if (_connected || _auth?.token == null) {
+    if (_connected || _connecting || _auth?.token == null) {
+      debugPrint('[WsClient] connect() early return: connected=$_connected '
+          'connecting=$_connecting token=${_auth?.token != null}');
+      return;
+    }
+
+    _connecting = true;
+    try {
+      debugPrint('[WsClient] _waitForServer() start: ${DateTime.now()}');
+      final serverUp = await _waitForServer();
       debugPrint(
-          '[WsClient] connect() early return: connected=$_connected token=${_auth?.token != null}');
-      return;
-    }
+          '[WsClient] _waitForServer() done: serverUp=$serverUp ${DateTime.now()}');
+      if (!serverUp) {
+        _scheduleReconnect();
+        return;
+      }
 
-    debugPrint('[WsClient] _waitForServer() start: ${DateTime.now()}');
-    final serverUp = await _waitForServer();
-    debugPrint(
-        '[WsClient] _waitForServer() done: serverUp=$serverUp ${DateTime.now()}');
-    if (!serverUp) {
-      _scheduleReconnect();
-      return;
+      return await _connectWs();
+    } finally {
+      _connecting = false;
     }
-
-    return _connectWs();
   }
 
   /// Open a WebSocket and wait for it to be ready.  If `channel.ready` times
@@ -404,6 +410,7 @@ class WsClient extends ChangeNotifier {
     _channel?.sink.close(1000, 'client disconnect');
     _channel = null;
     _connected = false;
+    _connecting = false;
     _currentWorkspaceId = null;
     notifyListeners();
   }

--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -78,6 +78,14 @@ class WsClient extends ChangeNotifier {
   @visibleForTesting
   static Duration? testReconnectTimeout;
 
+  /// Timeout for `channel.ready` — if the server is confirmed up via HTTP but
+  /// `ready` hangs (Firefox FailDelayManager throttle), close and retry.
+  static const Duration _readyTimeout = Duration(seconds: 5);
+
+  /// Override for testing to control the ready timeout.
+  @visibleForTesting
+  static Duration? testReadyTimeout;
+
   /// Inject a pre-connected channel for testing.
   @visibleForTesting
   void connectForTest(WebSocketChannel channel) {
@@ -213,8 +221,20 @@ class WsClient extends ChangeNotifier {
 
     try {
       debugPrint('[WsClient] await channel.ready start: ${DateTime.now()}');
-      await _channel!.ready;
+      final timeout = testReadyTimeout ?? _readyTimeout;
+      await _channel!.ready.timeout(timeout);
       debugPrint('[WsClient] await channel.ready done: ${DateTime.now()}');
+    } on TimeoutException {
+      // Firefox's FailDelayManager is throttling the WebSocket connection.
+      // The server is confirmed up (HTTP pre-check passed), so close this
+      // throttled connection and retry — each attempt consumes part of the
+      // throttle window.  Don't call _scheduleReconnect() here; the caller
+      // (_attemptReconnect) handles rescheduling when _connected is false.
+      debugPrint('[WsClient] channel.ready timed out (Firefox throttle), '
+          'closing and retrying: ${DateTime.now()}');
+      _channel?.sink.close(1000, 'ready timeout');
+      _channel = null;
+      return;
     } catch (e) {
       debugPrint('[WsClient] channel.ready failed: $e ${DateTime.now()}');
       final code = _channel?.closeCode;

--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -240,7 +240,10 @@ class WsClient extends ChangeNotifier {
     } on TimeoutException {
       debugPrint('[WsClient] channel.ready timed out (Firefox throttle), '
           'retrying (attempt ${attempt + 1}): ${DateTime.now()}');
-      _channel?.sink.close(1000, 'ready timeout');
+      // Close and wait for it to complete before opening a new channel,
+      // otherwise Firefox queues multiple connections behind the
+      // FailDelayManager and they all arrive at once.
+      await _channel?.sink.close(1000, 'ready timeout');
       _channel = null;
       return _connectWs(attempt + 1);
     } catch (e) {

--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -221,15 +221,22 @@ class WsClient extends ChangeNotifier {
 
     try {
       debugPrint('[WsClient] await channel.ready start: ${DateTime.now()}');
-      final timeout = testReadyTimeout ?? _readyTimeout;
-      await _channel!.ready.timeout(timeout);
+      if (_reconnecting) {
+        // During reconnect, apply a timeout so Firefox's FailDelayManager
+        // throttle doesn't block us for up to 60s.  The HTTP pre-check already
+        // confirmed the server is up, so normal establishment takes <1s.
+        final timeout = testReadyTimeout ?? _readyTimeout;
+        await _channel!.ready.timeout(timeout);
+      } else {
+        // First connection — let it take as long as it needs.
+        await _channel!.ready;
+      }
       debugPrint('[WsClient] await channel.ready done: ${DateTime.now()}');
     } on TimeoutException {
       // Firefox's FailDelayManager is throttling the WebSocket connection.
-      // The server is confirmed up (HTTP pre-check passed), so close this
-      // throttled connection and retry — each attempt consumes part of the
-      // throttle window.  Don't call _scheduleReconnect() here; the caller
-      // (_attemptReconnect) handles rescheduling when _connected is false.
+      // Close this throttled connection and retry — each attempt consumes
+      // part of the throttle window.  Don't call _scheduleReconnect() here;
+      // the caller (_attemptReconnect) handles rescheduling.
       debugPrint('[WsClient] channel.ready timed out (Firefox throttle), '
           'closing and retrying: ${DateTime.now()}');
       _channel?.sink.close(1000, 'ready timeout');

--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -81,7 +81,9 @@ class WsClient extends ChangeNotifier {
 
   /// Timeout for `channel.ready` — if the server is confirmed up via HTTP but
   /// `ready` hangs (Firefox FailDelayManager throttle), close and retry.
-  static const Duration _readyTimeout = Duration(seconds: 5);
+  /// Normal WebSocket handshake takes <100ms; this just needs to be long
+  /// enough to avoid false positives on slow networks.
+  static const Duration _readyTimeout = Duration(seconds: 2);
 
   /// Override for testing to control the ready timeout.
   @visibleForTesting
@@ -189,7 +191,7 @@ class WsClient extends ChangeNotifier {
   }
 
   Future<void> connect() async {
-    debugPrint('[WsClient v2] connect() enter: ${DateTime.now()}');
+    debugPrint('[WsClient v3] connect() enter: ${DateTime.now()}');
     _reconnectTimer?.cancel();
     _reconnectTimer = null;
     if (_connected || _connecting || _auth?.token == null) {
@@ -238,7 +240,7 @@ class WsClient extends ChangeNotifier {
       await _channel!.ready.timeout(timeout);
       debugPrint('[WsClient] await channel.ready done: ${DateTime.now()}');
     } on TimeoutException {
-      debugPrint('[WsClient v2] channel.ready timed out (Firefox throttle), '
+      debugPrint('[WsClient v3] channel.ready timed out (Firefox throttle), '
           'retrying (attempt ${attempt + 1}): ${DateTime.now()}');
       // Fire-and-forget the close — don't await it because Firefox's
       // FailDelayManager blocks the close handshake too.  The channel is

--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -189,7 +189,7 @@ class WsClient extends ChangeNotifier {
   }
 
   Future<void> connect() async {
-    debugPrint('[WsClient] connect() enter: ${DateTime.now()}');
+    debugPrint('[WsClient v1] connect() enter: ${DateTime.now()}');
     _reconnectTimer?.cancel();
     _reconnectTimer = null;
     if (_connected || _connecting || _auth?.token == null) {

--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -206,6 +206,13 @@ class WsClient extends ChangeNotifier {
       return;
     }
 
+    return _connectWs();
+  }
+
+  /// Open a WebSocket and wait for it to be ready.  If `channel.ready` times
+  /// out (Firefox FailDelayManager throttle), close and retry — each attempt
+  /// consumes part of the throttle window until the delay expires.
+  Future<void> _connectWs([int attempt = 0]) async {
     if (testChannelFactory != null) {
       _channel = testChannelFactory!(Uri());
     } else {
@@ -221,27 +228,15 @@ class WsClient extends ChangeNotifier {
 
     try {
       debugPrint('[WsClient] await channel.ready start: ${DateTime.now()}');
-      if (_reconnecting) {
-        // During reconnect, apply a timeout so Firefox's FailDelayManager
-        // throttle doesn't block us for up to 60s.  The HTTP pre-check already
-        // confirmed the server is up, so normal establishment takes <1s.
-        final timeout = testReadyTimeout ?? _readyTimeout;
-        await _channel!.ready.timeout(timeout);
-      } else {
-        // First connection — let it take as long as it needs.
-        await _channel!.ready;
-      }
+      final timeout = testReadyTimeout ?? _readyTimeout;
+      await _channel!.ready.timeout(timeout);
       debugPrint('[WsClient] await channel.ready done: ${DateTime.now()}');
     } on TimeoutException {
-      // Firefox's FailDelayManager is throttling the WebSocket connection.
-      // Close this throttled connection and retry — each attempt consumes
-      // part of the throttle window.  Don't call _scheduleReconnect() here;
-      // the caller (_attemptReconnect) handles rescheduling.
       debugPrint('[WsClient] channel.ready timed out (Firefox throttle), '
-          'closing and retrying: ${DateTime.now()}');
+          'retrying (attempt ${attempt + 1}): ${DateTime.now()}');
       _channel?.sink.close(1000, 'ready timeout');
       _channel = null;
-      return;
+      return _connectWs(attempt + 1);
     } catch (e) {
       debugPrint('[WsClient] channel.ready failed: $e ${DateTime.now()}');
       final code = _channel?.closeCode;
@@ -255,6 +250,10 @@ class WsClient extends ChangeNotifier {
     }
 
     _connected = true;
+    if (attempt > 0) {
+      debugPrint(
+          '[WsClient] connected after $attempt throttle retry(ies): ${DateTime.now()}');
+    }
     // Close cleanly on page unload so Firefox's FailDelayManager doesn't
     // treat it as a failure and throttle the next connection by up to 60s.
     _removeBeforeUnload?.call();

--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -189,7 +189,7 @@ class WsClient extends ChangeNotifier {
   }
 
   Future<void> connect() async {
-    debugPrint('[WsClient v1] connect() enter: ${DateTime.now()}');
+    debugPrint('[WsClient v2] connect() enter: ${DateTime.now()}');
     _reconnectTimer?.cancel();
     _reconnectTimer = null;
     if (_connected || _connecting || _auth?.token == null) {
@@ -238,13 +238,15 @@ class WsClient extends ChangeNotifier {
       await _channel!.ready.timeout(timeout);
       debugPrint('[WsClient] await channel.ready done: ${DateTime.now()}');
     } on TimeoutException {
-      debugPrint('[WsClient] channel.ready timed out (Firefox throttle), '
+      debugPrint('[WsClient v2] channel.ready timed out (Firefox throttle), '
           'retrying (attempt ${attempt + 1}): ${DateTime.now()}');
-      // Close and wait for it to complete before opening a new channel,
-      // otherwise Firefox queues multiple connections behind the
-      // FailDelayManager and they all arrive at once.
-      await _channel?.sink.close(1000, 'ready timeout');
+      // Fire-and-forget the close — don't await it because Firefox's
+      // FailDelayManager blocks the close handshake too.  The channel is
+      // abandoned; set _channel to null before closing so nothing else
+      // references it.
+      final old = _channel;
       _channel = null;
+      old?.sink.close(1000, 'ready timeout');
       return _connectWs(attempt + 1);
     } catch (e) {
       debugPrint('[WsClient] channel.ready failed: $e ${DateTime.now()}');

--- a/src/frontend/test/ws_client_test.dart
+++ b/src/frontend/test/ws_client_test.dart
@@ -783,118 +783,72 @@ void main() {
       client.dispose();
     });
 
-    test('ready timeout only applies during reconnect, not initial connect',
-        () async {
-      // A channel whose ready never completes on its own.
-      final slowChannel = _FakeWebSocketChannel()
-        ..readyCompleter = Completer<void>();
+    test('channel.ready timeout retries and eventually connects', () async {
+      // First two channels hang (simulating Firefox throttle), third succeeds.
+      var channelIndex = 0;
       WsClient.testChannelFactory = (_) {
-        channels.add(slowChannel);
-        return slowChannel;
-      };
-      WsClient.testReadyTimeout = Duration.zero;
-
-      final auth = AuthService();
-      await Future.delayed(Duration.zero);
-
-      final client = WsClient();
-      client.updateAuth(auth);
-
-      // Initial connect — timeout should NOT apply, so connect() will hang
-      // on channel.ready.  Complete it manually to prove it waited.
-      final connectFuture = client.connect();
-      await Future.delayed(Duration.zero);
-
-      // Still not connected (ready hasn't completed) but also not timed out.
-      expect(client.connected, isFalse);
-      final sink = slowChannel.sink as _FakeSink;
-      expect(sink.closeCalled, isFalse); // not closed by timeout
-
-      // Now complete ready — connect should finish.
-      slowChannel.readyCompleter!.complete();
-      await connectFuture;
-      expect(client.connected, isTrue);
-
-      client.disconnect();
-      client.dispose();
-    });
-
-    test('channel.ready timeout closes channel during reconnect', () async {
-      final auth = AuthService();
-      await Future.delayed(Duration.zero);
-
-      // First channel connects normally.
-      final client = WsClient();
-      client.updateAuth(auth);
-      await client.connect();
-      client.connectWorkspace('ws-1');
-      channels[0]
-          .serverSend({'type': 'workspace_ready', 'workspaceId': 'ws-1'});
-      await Future.delayed(Duration.zero);
-
-      // Make the next channel's ready hang.
-      final throttledChannel = _FakeWebSocketChannel()
-        ..readyCompleter = Completer<void>();
-      WsClient.testChannelFactory = (_) {
-        channels.add(throttledChannel);
-        return throttledChannel;
-      };
-      WsClient.testReadyTimeout = Duration.zero;
-
-      // Server crashes — triggers auto-reconnect.
-      channels[0].serverClose();
-      await Future.delayed(Duration.zero);
-      expect(client.reconnecting, isTrue);
-
-      // Let the reconnect timer fire — ready times out.
-      await Future.delayed(Duration.zero);
-      await Future.delayed(Duration.zero);
-
-      // The throttled channel should have been closed with code 1000.
-      final sink = throttledChannel.sink as _FakeSink;
-      expect(sink.closeCalled, isTrue);
-      expect(sink.lastCloseCode, 1000);
-
-      client.disconnect();
-      client.dispose();
-    });
-
-    test('ready timeout during auto-reconnect schedules next attempt',
-        () async {
-      final auth = AuthService();
-      await Future.delayed(Duration.zero);
-
-      // First channel connects normally.
-      final client = WsClient();
-      client.updateAuth(auth);
-      await client.connect();
-      client.connectWorkspace('ws-1');
-      channels[0]
-          .serverSend({'type': 'workspace_ready', 'workspaceId': 'ws-1'});
-      await Future.delayed(Duration.zero);
-
-      // Now make subsequent channels' ready hang (simulating Firefox throttle).
-      WsClient.testChannelFactory = (_) {
-        final ch = _FakeWebSocketChannel()..readyCompleter = Completer<void>();
+        channelIndex++;
+        final ch = channelIndex <= 2
+            ? (_FakeWebSocketChannel()..readyCompleter = Completer<void>())
+            : _FakeWebSocketChannel();
         channels.add(ch);
         return ch;
       };
       WsClient.testReadyTimeout = Duration.zero;
 
-      // Server crashes — triggers auto-reconnect.
-      channels[0].serverClose();
-      await Future.delayed(Duration.zero);
-      expect(client.reconnecting, isTrue);
-      expect(client.reconnectAttempt, 1);
-
-      // Let the reconnect timer fire — the ready timeout should cause a retry.
-      await Future.delayed(Duration.zero);
-      await Future.delayed(Duration.zero);
+      final auth = AuthService();
       await Future.delayed(Duration.zero);
 
-      // Should have attempted more than one reconnect.
-      expect(client.reconnectAttempt, greaterThan(1));
+      final client = WsClient();
+      client.updateAuth(auth);
 
+      await client.connect();
+      // Should have retried through the two hanging channels and connected
+      // on the third.
+      expect(client.connected, isTrue);
+      expect(channels.length, 3);
+
+      // First two channels should have been closed with code 1000.
+      for (var i = 0; i < 2; i++) {
+        final sink = channels[i].sink as _FakeSink;
+        expect(sink.closeCalled, isTrue);
+        expect(sink.lastCloseCode, 1000);
+      }
+
+      client.disconnect();
+      client.dispose();
+    });
+
+    test('channel.ready timeout skips HTTP pre-check on retries', () async {
+      var httpCheckCount = 0;
+      WsClient.testHttpPreCheck = () async {
+        httpCheckCount++;
+        return true;
+      };
+      // First two channels hang, third succeeds.
+      var channelIndex = 0;
+      WsClient.testChannelFactory = (_) {
+        channelIndex++;
+        final ch = channelIndex <= 2
+            ? (_FakeWebSocketChannel()..readyCompleter = Completer<void>())
+            : _FakeWebSocketChannel();
+        channels.add(ch);
+        return ch;
+      };
+      WsClient.testReadyTimeout = Duration.zero;
+
+      final auth = AuthService();
+      await Future.delayed(Duration.zero);
+
+      final client = WsClient();
+      client.updateAuth(auth);
+
+      await client.connect();
+      expect(client.connected, isTrue);
+      // HTTP pre-check should only be called once (on the first attempt).
+      expect(httpCheckCount, 1);
+
+      WsClient.testHttpPreCheck = null;
       client.disconnect();
       client.dispose();
     });

--- a/src/frontend/test/ws_client_test.dart
+++ b/src/frontend/test/ws_client_test.dart
@@ -783,20 +783,14 @@ void main() {
       client.dispose();
     });
 
-    test('channel.ready timeout closes channel and retries', () async {
-      // Use a channel whose ready never completes to simulate Firefox throttle.
-      final throttledChannel = _FakeWebSocketChannel()
+    test('ready timeout only applies during reconnect, not initial connect',
+        () async {
+      // A channel whose ready never completes on its own.
+      final slowChannel = _FakeWebSocketChannel()
         ..readyCompleter = Completer<void>();
-      var channelIndex = 0;
       WsClient.testChannelFactory = (_) {
-        channelIndex++;
-        if (channelIndex == 1) {
-          channels.add(throttledChannel);
-          return throttledChannel;
-        }
-        final ch = _FakeWebSocketChannel();
-        channels.add(ch);
-        return ch;
+        channels.add(slowChannel);
+        return slowChannel;
       };
       WsClient.testReadyTimeout = Duration.zero;
 
@@ -806,16 +800,62 @@ void main() {
       final client = WsClient();
       client.updateAuth(auth);
 
-      // First connect: channel.ready times out, connect() returns without
-      // setting _connected.
-      await client.connect();
+      // Initial connect — timeout should NOT apply, so connect() will hang
+      // on channel.ready.  Complete it manually to prove it waited.
+      final connectFuture = client.connect();
+      await Future.delayed(Duration.zero);
+
+      // Still not connected (ready hasn't completed) but also not timed out.
       expect(client.connected, isFalse);
+      final sink = slowChannel.sink as _FakeSink;
+      expect(sink.closeCalled, isFalse); // not closed by timeout
+
+      // Now complete ready — connect should finish.
+      slowChannel.readyCompleter!.complete();
+      await connectFuture;
+      expect(client.connected, isTrue);
+
+      client.disconnect();
+      client.dispose();
+    });
+
+    test('channel.ready timeout closes channel during reconnect', () async {
+      final auth = AuthService();
+      await Future.delayed(Duration.zero);
+
+      // First channel connects normally.
+      final client = WsClient();
+      client.updateAuth(auth);
+      await client.connect();
+      client.connectWorkspace('ws-1');
+      channels[0]
+          .serverSend({'type': 'workspace_ready', 'workspaceId': 'ws-1'});
+      await Future.delayed(Duration.zero);
+
+      // Make the next channel's ready hang.
+      final throttledChannel = _FakeWebSocketChannel()
+        ..readyCompleter = Completer<void>();
+      WsClient.testChannelFactory = (_) {
+        channels.add(throttledChannel);
+        return throttledChannel;
+      };
+      WsClient.testReadyTimeout = Duration.zero;
+
+      // Server crashes — triggers auto-reconnect.
+      channels[0].serverClose();
+      await Future.delayed(Duration.zero);
+      expect(client.reconnecting, isTrue);
+
+      // Let the reconnect timer fire — ready times out.
+      await Future.delayed(Duration.zero);
+      await Future.delayed(Duration.zero);
 
       // The throttled channel should have been closed with code 1000.
       final sink = throttledChannel.sink as _FakeSink;
       expect(sink.closeCalled, isTrue);
       expect(sink.lastCloseCode, 1000);
 
+      client.disconnect();
       client.dispose();
     });
 

--- a/src/frontend/test/ws_client_test.dart
+++ b/src/frontend/test/ws_client_test.dart
@@ -12,6 +12,11 @@ class _FakeWebSocketChannel extends Fake implements WebSocketChannel {
   final _incoming = StreamController<dynamic>.broadcast();
   final _sink = _FakeSink();
   bool failReady = false;
+
+  /// If set, `ready` waits on this completer instead of resolving immediately.
+  /// Used to simulate Firefox FailDelayManager throttling.
+  Completer<void>? readyCompleter;
+
   int? _closeCode;
 
   @override
@@ -24,8 +29,11 @@ class _FakeWebSocketChannel extends Fake implements WebSocketChannel {
   int? get closeCode => _closeCode;
 
   @override
-  Future<void> get ready =>
-      failReady ? Future.error('Connection refused') : Future.value();
+  Future<void> get ready {
+    if (failReady) return Future.error('Connection refused');
+    if (readyCompleter != null) return readyCompleter!.future;
+    return Future.value();
+  }
 
   void serverSend(Map<String, dynamic> msg) => _incoming.add(jsonEncode(msg));
 
@@ -43,12 +51,17 @@ class _FakeWebSocketChannel extends Fake implements WebSocketChannel {
 
 class _FakeSink extends Fake implements WebSocketSink {
   final List<dynamic> sent = [];
+  bool closeCalled = false;
+  int? lastCloseCode;
 
   @override
   void add(dynamic data) => sent.add(data);
 
   @override
-  Future close([int? closeCode, String? closeReason]) async {}
+  Future close([int? closeCode, String? closeReason]) async {
+    closeCalled = true;
+    lastCloseCode = closeCode;
+  }
 }
 
 void main() {
@@ -358,6 +371,8 @@ void main() {
     tearDown(() {
       WsClient.testChannelFactory = null;
       WsClient.testBackoffOverride = null;
+      WsClient.testReadyTimeout = null;
+      WsClient.testReconnectTimeout = null;
     });
 
     test('server close triggers auto-reconnect when workspace was connected',
@@ -763,6 +778,82 @@ void main() {
       expect(client.reconnecting, isFalse);
       expect(client.reconnectAttempt, 0);
       expect(errors, contains('Session expired, please log in again'));
+
+      client.disconnect();
+      client.dispose();
+    });
+
+    test('channel.ready timeout closes channel and retries', () async {
+      // Use a channel whose ready never completes to simulate Firefox throttle.
+      final throttledChannel = _FakeWebSocketChannel()
+        ..readyCompleter = Completer<void>();
+      var channelIndex = 0;
+      WsClient.testChannelFactory = (_) {
+        channelIndex++;
+        if (channelIndex == 1) {
+          channels.add(throttledChannel);
+          return throttledChannel;
+        }
+        final ch = _FakeWebSocketChannel();
+        channels.add(ch);
+        return ch;
+      };
+      WsClient.testReadyTimeout = Duration.zero;
+
+      final auth = AuthService();
+      await Future.delayed(Duration.zero);
+
+      final client = WsClient();
+      client.updateAuth(auth);
+
+      // First connect: channel.ready times out, connect() returns without
+      // setting _connected.
+      await client.connect();
+      expect(client.connected, isFalse);
+
+      // The throttled channel should have been closed with code 1000.
+      final sink = throttledChannel.sink as _FakeSink;
+      expect(sink.closeCalled, isTrue);
+      expect(sink.lastCloseCode, 1000);
+
+      client.dispose();
+    });
+
+    test('ready timeout during auto-reconnect schedules next attempt',
+        () async {
+      final auth = AuthService();
+      await Future.delayed(Duration.zero);
+
+      // First channel connects normally.
+      final client = WsClient();
+      client.updateAuth(auth);
+      await client.connect();
+      client.connectWorkspace('ws-1');
+      channels[0]
+          .serverSend({'type': 'workspace_ready', 'workspaceId': 'ws-1'});
+      await Future.delayed(Duration.zero);
+
+      // Now make subsequent channels' ready hang (simulating Firefox throttle).
+      WsClient.testChannelFactory = (_) {
+        final ch = _FakeWebSocketChannel()..readyCompleter = Completer<void>();
+        channels.add(ch);
+        return ch;
+      };
+      WsClient.testReadyTimeout = Duration.zero;
+
+      // Server crashes — triggers auto-reconnect.
+      channels[0].serverClose();
+      await Future.delayed(Duration.zero);
+      expect(client.reconnecting, isTrue);
+      expect(client.reconnectAttempt, 1);
+
+      // Let the reconnect timer fire — the ready timeout should cause a retry.
+      await Future.delayed(Duration.zero);
+      await Future.delayed(Duration.zero);
+      await Future.delayed(Duration.zero);
+
+      // Should have attempted more than one reconnect.
+      expect(client.reconnectAttempt, greaterThan(1));
 
       client.disconnect();
       client.dispose();


### PR DESCRIPTION
## Summary

Fixes #606.

After an unclean WebSocket close (server crash/restart), Firefox's FailDelayManager throttles subsequent WebSocket connections for up to 60s. The existing HTTP pre-check (`GET /api/v1/config`) confirms the server is up, but Firefox throttles WebSocket connections independently — `channel.ready` was observed hanging for 21-54 seconds.

**Root cause**: Firefox's FailDelayManager uses truncated exponential backoff (1.5x multiplier, starting at 200-400ms, capped at 60s) on WebSocket connections after any unclean close. Each failed reconnect attempt while the server is still starting ratchets the delay higher. This is WebSocket-only — HTTP is not affected.

**Fix**: Add a 2-second timeout on `await channel.ready`. When it fires, abandon the throttled channel and immediately open a new one. Each retry consumes part of the FailDelayManager's throttle window, so the connection succeeds once the delay expires. Key details:

- Split `connect()` into public `connect()` (HTTP pre-check, once) and private `_connectWs()` (WebSocket open + retry loop)
- Fire-and-forget `sink.close()` on timeout — awaiting it blocks for the full throttle duration since FailDelayManager also delays the close handshake
- Added `_connecting` guard to prevent concurrent `connect()` calls from racing (workspace_page, auto-reconnect timer, and manual Reconnect button could all call `connect()` simultaneously)
- Reduced observed delay from 21-54s down to ~9s

## Test plan

- [x] `channel.ready` timeout retries and eventually connects (2 hanging channels, 3rd succeeds)
- [x] Timeout retry skips HTTP pre-check on subsequent attempts
- [x] All 69 existing `ws_client_test.dart` tests pass
- [x] Manual test on Firefox: server restart → workspace loads in ~9s instead of 21-54s