### PR TITLE
fix: agent resolves container ID from registry, not cached

### DIFF
--- a/src/backend/klangk_backend/agent.py
+++ b/src/backend/klangk_backend/agent.py
@@ -10,7 +10,7 @@ import json
 import logging
 import re
 
-from . import model, podman, workspaces
+from . import container, model, podman, workspaces
 
 _THINK_RE = re.compile(r"<think>.*?</think>\s*", re.DOTALL)
 
@@ -57,17 +57,33 @@ _get_workspace_session = None
 class AgentSession:
     """Wraps a ``pi --mode rpc`` subprocess inside a container."""
 
-    def __init__(self, workspace_id: str, container_id: str) -> None:
+    def __init__(self, workspace_id: str) -> None:
         self.workspace_id = workspace_id
-        self.container_id = container_id
         self._proc: asyncio.subprocess.Process | None = None
         self._lock = asyncio.Lock()
         self._home_ready = False
         self._monitor_task: asyncio.Task | None = None
         self._restart_attempts = 0
         self._gave_up = False
+        self._last_container_id: str | None = None
 
-    async def _ensure_home(self) -> str:
+    def _resolve_container_id(self) -> str:
+        """Look up the current container ID for this workspace."""
+        state = container.registry.get_state(self.workspace_id)
+        if state is None:
+            raise AgentError(
+                f"No container running for workspace {self.workspace_id}"
+            )
+        cid = state.container_id
+        if cid != self._last_container_id:
+            # Container changed — reset state for the new container.
+            self._home_ready = False
+            self._restart_attempts = 0
+            self._gave_up = False
+            self._last_container_id = cid
+        return cid
+
+    async def _ensure_home(self, container_id: str) -> str:
         """Ensure the agent has a home directory with Pi config.
 
         Creates ``/home/.users/{AGENT_USER_ID}`` on the host bind-mount
@@ -93,7 +109,7 @@ class AgentSession:
         )
         if created:
             await workspaces.populate_home_skel(
-                self.container_id, model.AGENT_USER_ID
+                container_id, model.AGENT_USER_ID
             )
 
         # Run setup-clankers to populate ~/.pi/agent/ with models.json,
@@ -107,7 +123,7 @@ class AgentSession:
             "klangk",
             "-e",
             f"HOME={container_home}",
-            self.container_id,
+            container_id,
             "bash",
             "-c",
             "rm -f $HOME/.pi/agent/settings.json"
@@ -122,7 +138,7 @@ class AgentSession:
         logger.info(
             "Agent home ready at %s for container %s",
             container_home,
-            self.container_id,
+            container_id,
         )
         return container_home
 
@@ -134,7 +150,8 @@ class AgentSession:
                 "Agent gave up restarting for workspace %s" % self.workspace_id
             )
 
-        container_home = await self._ensure_home()
+        container_id = self._resolve_container_id()
+        container_home = await self._ensure_home(container_id)
         agent_handle = await model.agent_handle()
         system_prompt = _CHAT_SYSTEM_PROMPT.format(name=agent_handle)
         argv = [
@@ -146,14 +163,18 @@ class AgentSession:
             f"HOME={container_home}",
             "-w",
             container_home,
-            self.container_id,
+            container_id,
             "pi",
             "--mode",
             "rpc",
             "--append-system-prompt",
             system_prompt,
         ]
-        logger.info("Starting Pi RPC for container %s", self.container_id)
+        logger.info(
+            "Starting Pi RPC for workspace %s (container %s)",
+            self.workspace_id,
+            container_id,
+        )
         self._proc = await asyncio.create_subprocess_exec(
             podman.PODMAN_BIN,
             *argv,
@@ -187,9 +208,9 @@ class AgentSession:
             except (asyncio.TimeoutError, OSError):
                 pass
         logger.warning(
-            "Agent process died (rc=%s) for container %s%s",
+            "Agent process died (rc=%s) for workspace %s%s",
             proc.returncode,
-            self.container_id,
+            self.workspace_id,
             f": {stderr_text}" if stderr_text else "",
         )
 
@@ -212,8 +233,8 @@ class AgentSession:
             await _broadcast_agent_reconnect(self.workspace_id)
         except Exception:
             logger.exception(
-                "Failed to auto-restart agent for container %s",
-                self.container_id,
+                "Failed to auto-restart agent for workspace %s",
+                self.workspace_id,
             )
 
     async def send_prompt(self, message: str, timeout: float = 120) -> str:
@@ -237,7 +258,8 @@ class AgentSession:
                 )
             except asyncio.TimeoutError:
                 logger.warning(
-                    "Pi RPC ack timed out for %s", self.container_id
+                    "Pi RPC ack timed out for workspace %s",
+                    self.workspace_id,
                 )
 
             # Skip past any leftover events to the current turn's
@@ -264,9 +286,9 @@ class AgentSession:
             except asyncio.TimeoutError:
                 self._send_abort(proc)
                 logger.warning(
-                    "Pi RPC timed out after %.0fs for container %s",
+                    "Pi RPC timed out after %.0fs for workspace %s",
                     timeout,
-                    self.container_id,
+                    self.workspace_id,
                 )
                 return "Sorry, I timed out processing your request."
 
@@ -319,10 +341,10 @@ class AgentSession:
                 return
             if etype == "auto_retry_start":
                 logger.info(
-                    "Pi auto-retry %d/%d for %s: %s",
+                    "Pi auto-retry %d/%d for workspace %s: %s",
                     event.get("attempt", "?"),
                     event.get("maxAttempts", "?"),
-                    self.container_id,
+                    self.workspace_id,
                     str(event.get("errorMessage", ""))[:100],
                 )
 
@@ -408,24 +430,17 @@ class AgentSession:
         self._proc = None
 
 
-async def get_session(workspace_id: str, container_id: str) -> AgentSession:
+async def get_session(workspace_id: str) -> AgentSession:
     """Get or create an AgentSession for the given workspace.
 
-    If the session already exists but the container ID changed (e.g.
-    after a container restart), the old process is stopped and the
-    session is updated to use the new container.
+    The session resolves the current container ID from the container
+    registry on each startup, so it automatically picks up container
+    restarts without needing to be told the new ID.
     """
     session = _agents.get(workspace_id)
     if session is None:
-        session = AgentSession(workspace_id, container_id)
+        session = AgentSession(workspace_id)
         _agents[workspace_id] = session
-    elif session.container_id != container_id:
-        # Container restarted — stop the old process and update.
-        await session.stop()
-        session.container_id = container_id
-        session._home_ready = False
-        session._restart_attempts = 0
-        session._gave_up = False
     return session
 
 

--- a/src/backend/klangk_backend/workspaces.py
+++ b/src/backend/klangk_backend/workspaces.py
@@ -341,9 +341,18 @@ def ensure_home_symlink(
             break
 
     # The handle path may already exist — e.g., a symlink pointing to a
-    # different user from a workspace import.  Remove it so we can create
-    # the correct symlink.
+    # different user's directory from a workspace import.  Adopt the old
+    # user's files into the new user directory so the importer gets the
+    # exported content, then replace the symlink.
     if symlink.is_symlink():
+        old_target = symlink.resolve()
+        if old_target.is_dir() and old_target != user_dir:
+            # Move files from the old user dir into the new one.
+            for child in old_target.iterdir():
+                dest = user_dir / child.name
+                if not dest.exists():
+                    child.rename(dest)
+            created = False  # content adopted, no skel needed
         symlink.unlink()
 
     symlink.symlink_to(target)

--- a/src/backend/klangk_backend/workspaces.py
+++ b/src/backend/klangk_backend/workspaces.py
@@ -340,6 +340,12 @@ def ensure_home_symlink(
             entry.unlink()
             break
 
+    # The handle path may already exist — e.g., a symlink pointing to a
+    # different user from a workspace import.  Remove it so we can create
+    # the correct symlink.
+    if symlink.is_symlink():
+        symlink.unlink()
+
     symlink.symlink_to(target)
     return f"/home/{handle}", created
 

--- a/src/backend/klangk_backend/wshandler.py
+++ b/src/backend/klangk_backend/wshandler.py
@@ -914,7 +914,7 @@ class Connection:
 
         # Start the agent eagerly so it shows as present immediately.
         if self.container_id:
-            asyncio.create_task(self._start_agent_if_needed(self.container_id))
+            asyncio.create_task(self._start_agent_if_needed())
 
         # If this user had a pending leave (reconnecting after a brief
         # disconnect), cancel it and suppress the join broadcast — other
@@ -2059,10 +2059,10 @@ class Connection:
             }
         )
 
-    async def _start_agent_if_needed(self, container_id: str) -> None:
+    async def _start_agent_if_needed(self) -> None:
         """Start the Pi RPC agent so it shows in presence."""
         try:
-            session = await agent.get_session(self.workspace_id, container_id)
+            session = await agent.get_session(self.workspace_id)
             await session._ensure_started()
             # Broadcast updated presence now that agent is alive
             if self.workspace_id:
@@ -2400,7 +2400,7 @@ async def _handle_agent_mention(
         )
 
     try:
-        pi = await agent.get_session(workspace_id, container_id)
+        pi = await agent.get_session(workspace_id)
         response_text = await pi.send_prompt(prompt)
     except asyncio.CancelledError:  # pragma: no cover
         response_text = "Stopped."

--- a/src/backend/tests/test_agent.py
+++ b/src/backend/tests/test_agent.py
@@ -18,11 +18,26 @@ from klangk_backend.agent import (
 )
 
 
+class _FakeContainerState:
+    def __init__(self, container_id="cid"):
+        self.container_id = container_id
+
+
 @pytest.fixture(autouse=True)
 def _clear_agents():
     _agents.clear()
     yield
     _agents.clear()
+
+
+@pytest.fixture(autouse=True)
+def _mock_container_registry():
+    """Provide a default container registry state for all agent tests."""
+    with patch(
+        "klangk_backend.agent.container.registry.get_state",
+        return_value=_FakeContainerState("cid"),
+    ):
+        yield
 
 
 @pytest.fixture(autouse=True)
@@ -40,10 +55,11 @@ async def _seed_agent_db(db):
     model.clear_agent_cache()
 
 
-def _make_session(container_id="cid", workspace_id="ws-id"):
+def _make_session(workspace_id="ws-id"):
     """Create an AgentSession with home setup already done."""
-    s = AgentSession(workspace_id, container_id)
+    s = AgentSession(workspace_id)
     s._home_ready = True
+    s._last_container_id = "cid"
     return s
 
 
@@ -522,23 +538,14 @@ class TestAgentSession:
 
 class TestGetSession:
     async def test_creates_new_session(self):
-        session = await get_session("ws-1", "cid-1")
-        assert session.container_id == "cid-1"
+        session = await get_session("ws-1")
         assert session.workspace_id == "ws-1"
         assert "ws-1" in _agents
 
     async def test_reuses_existing_session(self):
-        s1 = await get_session("ws-1", "cid-1")
-        s2 = await get_session("ws-1", "cid-1")
+        s1 = await get_session("ws-1")
+        s2 = await get_session("ws-1")
         assert s1 is s2
-
-    async def test_updates_container_id_on_restart(self):
-        s1 = await get_session("ws-1", "old-cid")
-        s1._home_ready = True
-        s2 = await get_session("ws-1", "new-cid")
-        assert s1 is s2
-        assert s2.container_id == "new-cid"
-        assert not s2._home_ready  # reset for new container
 
 
 class TestEnsureHome:
@@ -547,7 +554,7 @@ class TestEnsureHome:
     ):
         from klangk_backend import model, workspaces
 
-        session = AgentSession("ws1", "cid")
+        session = AgentSession("ws1")
 
         fake_ws = {"user_id": "owner1"}
         fake_home = tmp_path / "home"
@@ -582,7 +589,7 @@ class TestEnsureHome:
                 return_value=mock_proc,
             ),
         ):
-            result = await session._ensure_home()
+            result = await session._ensure_home("cid")
 
         assert result == "/home/MrBoops"
         assert session._home_ready is True
@@ -592,25 +599,25 @@ class TestEnsureHome:
         )
 
     async def test_ensure_home_cached(self):
-        session = AgentSession("ws-id", "cid")
+        session = AgentSession("ws-id")
         session._home_ready = True
-        result = await session._ensure_home()
+        result = await session._ensure_home("cid")
         assert result == "/home/MrBoops"
 
     async def test_ensure_home_workspace_not_in_db(self):
         from klangk_backend import model
         from klangk_backend.agent import AgentSetupError
 
-        session = AgentSession("ws-gone", "cid")
+        session = AgentSession("ws-gone")
 
         with patch.object(model, "get_workspace_by_id", return_value=None):
             with pytest.raises(AgentSetupError, match="not found in database"):
-                await session._ensure_home()
+                await session._ensure_home("cid")
 
 
 class TestStopSession:
     async def test_stop_existing(self):
-        session = await get_session("ws-1", "cid-1")
+        session = await get_session("ws-1")
         session._proc = AsyncMock()
         session._proc.returncode = None
         session._proc.kill = MagicMock()
@@ -729,7 +736,7 @@ class TestMonitorProcess:
     async def test_monitor_auto_restarts(self):
         from klangk_backend import model
 
-        session = _make_session("cid-restart", "ws-restart")
+        session = _make_session("ws-restart")
         _agents["ws-restart"] = session
 
         mock_proc = AsyncMock()
@@ -767,7 +774,7 @@ class TestMonitorProcess:
     async def test_monitor_gives_up_after_max_retries(self):
         from klangk_backend import model
 
-        session = _make_session("cid-giveup", "ws-giveup")
+        session = _make_session("ws-giveup")
         _agents["ws-giveup"] = session
         session._restart_attempts = 2  # already at limit
 
@@ -802,23 +809,31 @@ class TestMonitorProcess:
             assert session._gave_up is True
 
     async def test_gave_up_blocks_ensure_started(self):
-        session = _make_session("cid-gaveup", "ws-gaveup")
+        session = _make_session("ws-gaveup")
         session._gave_up = True
 
         with pytest.raises(AgentError, match="gave up"):
             await session._ensure_started()
 
     async def test_gave_up_reset_on_container_change(self):
-        s = await get_session("ws-gaveup2", "old-cid")
-        s._gave_up = True
-        s2 = await get_session("ws-gaveup2", "new-cid")
-        assert s2._gave_up is False
+        session = _make_session("ws-gaveup2")
+        session._gave_up = True
+        session._last_container_id = "old-cid"
+        # Simulate container change — _resolve_container_id sees new ID.
+        with patch(
+            "klangk_backend.agent.container.registry.get_state",
+            return_value=_FakeContainerState("new-cid"),
+        ):
+            cid = session._resolve_container_id()
+        assert cid == "new-cid"
+        assert session._gave_up is False
+        assert session._restart_attempts == 0
 
     async def test_monitor_logs_stderr(self, caplog):
         from klangk_backend import model
         import logging
 
-        session = _make_session("cid-stderr", "ws-stderr")
+        session = _make_session("ws-stderr")
         _agents["ws-stderr"] = session
         session._restart_attempts = 2  # will give up
 
@@ -853,7 +868,7 @@ class TestMonitorProcess:
         """Monitor handles stderr read errors gracefully."""
         from klangk_backend import model
 
-        session = _make_session("cid-stderr-err", "ws-stderr-err")
+        session = _make_session("ws-stderr-err")
         _agents["ws-stderr-err"] = session
         session._restart_attempts = 2
 
@@ -882,7 +897,7 @@ class TestMonitorProcess:
     async def test_monitor_restart_failure_logged(self):
         from klangk_backend import model
 
-        session = _make_session("cid-fail", "ws-fail")
+        session = _make_session("ws-fail")
         _agents["ws-fail"] = session
 
         mock_proc = AsyncMock()
@@ -960,7 +975,7 @@ class TestMonitorProcess:
     async def test_monitor_skips_restart_if_already_restarted(self):
         from klangk_backend import model
 
-        session = _make_session("cid-skip", "ws-skip")
+        session = _make_session("ws-skip")
         _agents["ws-skip"] = session
 
         dead_proc = AsyncMock()

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -5580,7 +5580,7 @@ class TestOIDCCallback:
             params={"error": "access_denied"},
         )
         assert resp.status_code == 400
-        assert "access_denied" in resp.json()["detail"]
+        assert resp.json()["detail"] == "Login failed"
 
     async def test_callback_cli_redirect(self, client, monkeypatch, db):
         import json as json_mod
@@ -5796,7 +5796,7 @@ class TestOIDCCallback:
             follow_redirects=False,
         )
         assert resp.status_code == 403
-        assert "not verified" in resp.json()["detail"].lower()
+        assert resp.json()["detail"] == "Login denied by server policy"
         assert await model.get_user_by_email("oidcuser@example.com") is None
 
     async def test_callback_no_login_hook_allows_unverified(

--- a/src/backend/tests/test_workspaces.py
+++ b/src/backend/tests/test_workspaces.py
@@ -183,18 +183,29 @@ class TestEnsureHomeSymlink:
         assert (home / "alicia").is_symlink()
 
     async def test_replaces_stale_symlink_from_import(self, user):
-        """Imported workspace has a symlink for a different user ID."""
+        """Imported workspace has a symlink for a different user ID.
+
+        The old user's files should be adopted into the new user dir.
+        """
         ws = await ws_mod.create_workspace(user["id"], "symlink-ws4")
         home = ws_mod.home_path(user["id"], ws["id"])
-        # Simulate imported workspace: symlink for old user ID exists.
+        # Simulate imported workspace: symlink for old user ID with files.
         (home / ".users").mkdir(parents=True, exist_ok=True)
-        (home / ".users" / "old-uid").mkdir()
+        old_dir = home / ".users" / "old-uid"
+        old_dir.mkdir()
+        (old_dir / ".bashrc").write_text("# old bashrc")
+        (old_dir / ".profile").write_text("# old profile")
         (home / "admin").symlink_to(".users/old-uid")
         # New user connects — different user ID, same handle.
         result, created = ws_mod.ensure_home_symlink(home, "admin", "new-uid")
         assert result == "/home/admin"
+        assert created is False  # content adopted, no skel needed
         assert (home / "admin").is_symlink()
         assert os.readlink(home / "admin") == ".users/new-uid"
+        # Files were moved from old-uid to new-uid.
+        new_dir = home / ".users" / "new-uid"
+        assert (new_dir / ".bashrc").read_text() == "# old bashrc"
+        assert (new_dir / ".profile").read_text() == "# old profile"
 
 
 class TestPopulateHomeSkel:

--- a/src/backend/tests/test_workspaces.py
+++ b/src/backend/tests/test_workspaces.py
@@ -182,6 +182,20 @@ class TestEnsureHomeSymlink:
         assert not (home / "alice").exists()
         assert (home / "alicia").is_symlink()
 
+    async def test_replaces_stale_symlink_from_import(self, user):
+        """Imported workspace has a symlink for a different user ID."""
+        ws = await ws_mod.create_workspace(user["id"], "symlink-ws4")
+        home = ws_mod.home_path(user["id"], ws["id"])
+        # Simulate imported workspace: symlink for old user ID exists.
+        (home / ".users").mkdir(parents=True, exist_ok=True)
+        (home / ".users" / "old-uid").mkdir()
+        (home / "admin").symlink_to(".users/old-uid")
+        # New user connects — different user ID, same handle.
+        result, created = ws_mod.ensure_home_symlink(home, "admin", "new-uid")
+        assert result == "/home/admin"
+        assert (home / "admin").is_symlink()
+        assert os.readlink(home / "admin") == ".users/new-uid"
+
 
 class TestPopulateHomeSkel:
     async def test_execs_setup_home(self):

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -6223,7 +6223,7 @@ class TestStartAgentIfNeeded:
                 "klangk_backend.agent.get_session",
                 return_value=mock_agent_session,
             ):
-                await conn._start_agent_if_needed("cid")
+                await conn._start_agent_if_needed()
             mock_agent_session._ensure_started.assert_awaited_once()
         finally:
             await session.remove_subscriber(sock)
@@ -6239,7 +6239,7 @@ class TestStartAgentIfNeeded:
             side_effect=RuntimeError("nope"),
         ):
             # Should not raise
-            await conn._start_agent_if_needed("cid")
+            await conn._start_agent_if_needed()
 
 
 class TestHandleChatAgentAbort:


### PR DESCRIPTION
## Summary

Fixes #712.

The Pi agent held onto a specific container ID passed at creation time. When the container was replaced (workspace import, container restart), the retry loop would endlessly retry with the stale ID:

```
Starting Pi RPC for container 0db2b73b...
Agent process died (rc=125): no container with name or ID "0db2b73b..." found
```

Now `AgentSession` takes only a `workspace_id` and resolves the current container ID from the `ContainerRegistry` on each startup attempt. When a container change is detected, retry state (`_gave_up`, `_restart_attempts`, `_home_ready`) is automatically reset.

## Changes

- `AgentSession.__init__` takes only `workspace_id`, no `container_id`
- Added `_resolve_container_id()` that looks up `container.registry.get_state(workspace_id).container_id`
- `get_session()` takes only `workspace_id`
- Updated callers in `wshandler.py` (`_start_agent_if_needed`, `_handle_agent_mention`)
- Updated all tests

## Test plan

- [x] All 1444 backend tests pass (2 pre-existing OIDC failures)