### PR TITLE
Fix duplicate reconnect timers causing rapid counter advance

### DIFF
--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -198,7 +198,6 @@ class WsClient extends ChangeNotifier {
       debugPrint(
           '[WsClient] _waitForServer() done: serverUp=$serverUp ${DateTime.now()}');
       if (!serverUp) {
-        _scheduleReconnect();
         return;
       }
 


### PR DESCRIPTION
## Summary

Remove `_scheduleReconnect()` from `connect()` when the server is unreachable. Both `connect()` and `_attemptReconnect()` were scheduling reconnect timers, creating duplicate timers that caused the counter to advance rapidly.

Now only `_attemptReconnect()` (for failed reconnects) and `onDone`/`onError` (for initial disconnects) schedule reconnects.

Closes #711

## Test plan

- [x] Frontend tests pass (100% coverage)