### PR TITLE
fix: return 400 for passwords exceeding bcrypt 72-byte limit

### DIFF
--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -220,11 +220,7 @@ async def register(
     existing = await model.get_user_by_email(req.email)
     if existing is not None:
         raise HTTPException(status_code=400, detail="Registration failed")
-    if len(req.password) < auth.MIN_PASSWORD_LENGTH:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Password must be at least {auth.MIN_PASSWORD_LENGTH} characters",
-        )
+    auth.validate_password_length(req.password)
 
     password_hash = auth.hash_password(req.password)
     user_id = str(uuid.uuid4())
@@ -374,11 +370,7 @@ async def reset_password(req: ResetPasswordRequest):
         raise HTTPException(
             status_code=400, detail="Invalid or expired reset token"
         )
-    if len(req.password) < auth.MIN_PASSWORD_LENGTH:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Password must be at least {auth.MIN_PASSWORD_LENGTH} characters",
-        )
+    auth.validate_password_length(req.password)
     if user_id == model.AGENT_USER_ID:
         raise HTTPException(
             status_code=400,
@@ -431,11 +423,7 @@ async def change_password(
         raise HTTPException(
             status_code=401, detail="Current password is incorrect"
         )
-    if len(req.new_password) < auth.MIN_PASSWORD_LENGTH:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Password must be at least {auth.MIN_PASSWORD_LENGTH} characters",
-        )
+    auth.validate_password_length(req.new_password)
     password_hash = auth.hash_password(req.new_password)
     await model.update_password(user["id"], password_hash)
     return {"status": "updated"}
@@ -564,11 +552,7 @@ async def accept_invite(req: AcceptInviteRequest):
             status_code=400, detail="Invitation is no longer valid"
         )
 
-    if len(req.password) < auth.MIN_PASSWORD_LENGTH:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Password must be at least {auth.MIN_PASSWORD_LENGTH} characters",
-        )
+    auth.validate_password_length(req.password)
 
     existing = await model.get_user_by_email(email)
     if existing is not None:
@@ -2151,11 +2135,7 @@ async def admin_create_user(
     existing = await model.get_user_by_email(req.email)
     if existing is not None:
         raise HTTPException(status_code=400, detail="Email already registered")
-    if len(req.password) < auth.MIN_PASSWORD_LENGTH:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Password must be at least {auth.MIN_PASSWORD_LENGTH} characters",
-        )
+    auth.validate_password_length(req.password)
     password_hash = auth.hash_password(req.password)
     user = await model.create_user(req.email, password_hash, verified=True)
     return {"id": user["id"], "email": user["email"], "status": "created"}
@@ -2208,6 +2188,7 @@ async def update_user(
                 status_code=400,
                 detail="Cannot set a password on the system agent user",
             )
+        auth.validate_password_length(req.password)
         password_hash = auth.hash_password(req.password)
         await model.update_password(user_id, password_hash)
     if req.handle is not None:

--- a/src/backend/klangk_backend/auth.py
+++ b/src/backend/klangk_backend/auth.py
@@ -96,6 +96,7 @@ def require_secure_jwt_secret() -> None:
 MIN_PASSWORD_LENGTH = int(
     resolve_env_secret("KLANGK_MIN_PASSWORD_LENGTH", "4")
 )
+MAX_PASSWORD_BYTES = 72  # bcrypt limit
 
 # Set KLANGK_LOGIN_LOCKOUT_FAILURES=0 to disable login lockout.
 LOGIN_LOCKOUT_FAILURES = int(
@@ -105,8 +106,27 @@ LOGIN_LOCKOUT_FAILURES = int(
 security = HTTPBearer(auto_error=False)
 
 
+def validate_password_length(password: str) -> None:
+    if len(password) < MIN_PASSWORD_LENGTH:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Password must be at least {MIN_PASSWORD_LENGTH} characters",
+        )
+    if len(password.encode()) > MAX_PASSWORD_BYTES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Password must not exceed {MAX_PASSWORD_BYTES} bytes",
+        )
+
+
 def hash_password(password: str) -> str:
-    return bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
+    encoded = password.encode()
+    if len(encoded) > MAX_PASSWORD_BYTES:
+        raise ValueError(
+            f"Password exceeds {MAX_PASSWORD_BYTES} bytes; "
+            "call validate_password_length first"
+        )
+    return bcrypt.hashpw(encoded, bcrypt.gensalt()).decode()
 
 
 def verify_password(password: str, hashed: str) -> bool:
@@ -185,11 +205,7 @@ async def register(
     if existing is not None:
         raise HTTPException(status_code=400, detail="Registration failed")
     validate_email(req.email)
-    if len(req.password) < MIN_PASSWORD_LENGTH:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Password must be at least {MIN_PASSWORD_LENGTH} characters",
-        )
+    validate_password_length(req.password)
 
     password_hash = hash_password(req.password)
     user = await model.create_user(req.email, password_hash, verified=verified)

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -350,6 +350,14 @@ class TestAuthRoutes:
         )
         assert resp.status_code == 400
 
+    async def test_register_password_exceeds_72_bytes(self, client, db):
+        resp = await client.post(
+            "/api/v1/auth/register",
+            json={"email": "long@example.com", "password": "a" * 73},
+        )
+        assert resp.status_code == 400
+        assert "72 bytes" in resp.json()["detail"]
+
     async def test_register_duplicate(self, client, admin_user):
         login_resp = await client.post(
             "/api/v1/auth/login",

--- a/src/backend/tests/test_auth.py
+++ b/src/backend/tests/test_auth.py
@@ -25,6 +25,39 @@ class TestPasswordHashing:
         h2 = auth.hash_password("same")
         assert h1 != h2  # bcrypt uses random salt
 
+    def test_hash_password_rejects_over_72_bytes(self):
+        long_pw = "a" * 73
+        with pytest.raises(ValueError, match="exceeds 72 bytes"):
+            auth.hash_password(long_pw)
+
+    def test_hash_password_accepts_exactly_72_bytes(self):
+        pw = "a" * 72
+        hashed = auth.hash_password(pw)
+        assert auth.verify_password(pw, hashed)
+
+
+class TestValidatePasswordLength:
+    def test_rejects_short_password(self):
+        with pytest.raises(HTTPException) as exc_info:
+            auth.validate_password_length("")
+        assert exc_info.value.status_code == 400
+        assert "at least" in exc_info.value.detail
+
+    def test_rejects_over_72_bytes(self):
+        with pytest.raises(HTTPException) as exc_info:
+            auth.validate_password_length("a" * 73)
+        assert exc_info.value.status_code == 400
+        assert "72 bytes" in exc_info.value.detail
+
+    def test_rejects_multibyte_over_72_bytes(self):
+        pw = "\u00e9" * 37  # 2 bytes each = 74 bytes
+        with pytest.raises(HTTPException) as exc_info:
+            auth.validate_password_length(pw)
+        assert exc_info.value.status_code == 400
+
+    def test_accepts_valid_password(self):
+        auth.validate_password_length("goodpass")
+
 
 class TestJWT:
     def test_create_and_decode_token(self):


### PR DESCRIPTION
## Summary
- Add `validate_password_length()` in `auth.py` that checks both min length and max 72-byte bcrypt limit, returning 400 with a clear message
- Replace all 6 inline min-length checks across `api.py` and `auth.py` with the unified validator
- Add safety-net `ValueError` in `hash_password()` itself

Closes #717

## Test plan
- [x] Unit tests for `validate_password_length` (short, over 72 bytes, multibyte, valid)
- [x] Unit tests for `hash_password` rejecting >72 bytes and accepting exactly 72
- [x] Integration test for register endpoint with 73-byte password
- [x] Full backend suite passes (1454 tests, 100% coverage)