### PR TITLE
fix: return 400 for filenames exceeding OS NAME_MAX limit

### DIFF
--- a/src/backend/klangk_backend/files.py
+++ b/src/backend/klangk_backend/files.py
@@ -6,14 +6,20 @@ via ``Path.is_relative_to``.  CodeQL cannot trace this inter-procedural
 validation; the corresponding alerts are dismissed as false positives.
 """
 
+import os
 import shutil
 from pathlib import Path
 
 from . import workspaces
 
+NAME_MAX = os.pathconf("/", "PC_NAME_MAX") if hasattr(os, "pathconf") else 255
+
 
 def resolve_path(user_id: str, workspace_id: str, relative_path: str) -> Path:
     """Resolve a relative path within a workspace, preventing traversal."""
+    for part in Path(relative_path).parts:
+        if len(part.encode()) > NAME_MAX:
+            raise ValueError(f"Filename exceeds {NAME_MAX}-byte limit")
     root = workspaces.get_home_host_path(user_id, workspace_id).resolve()
     resolved = (root / relative_path).resolve()
     if not resolved.is_relative_to(root):

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -2745,6 +2745,28 @@ class TestFileRoutes:
         )
         assert resp.status_code in (400, 422)
 
+    async def test_upload_filename_too_long(self, client, user):
+        headers = await _auth_headers(client)
+        ws_id = await self._create_workspace(client, headers)
+        long_name = "a" * 256 + ".txt"
+        resp = await client.post(
+            f"/api/v1/workspaces/{ws_id}/files/upload",
+            headers=headers,
+            files={"file": (long_name, b"data", "application/octet-stream")},
+        )
+        assert resp.status_code == 400
+        assert "limit" in resp.json()["detail"]
+
+    async def test_list_files_path_too_long(self, client, user):
+        headers = await _auth_headers(client)
+        ws_id = await self._create_workspace(client, headers)
+        long_path = "a" * 256
+        resp = await client.get(
+            f"/api/v1/workspaces/{ws_id}/files?path={long_path}",
+            headers=headers,
+        )
+        assert resp.status_code == 400
+
     async def test_delete_file(self, client, user):
         headers = await _auth_headers(client)
         ws_id = await self._create_workspace(client, headers)

--- a/src/backend/tests/test_files.py
+++ b/src/backend/tests/test_files.py
@@ -29,6 +29,24 @@ class TestResolvePathTraversal:
         resolved = files.resolve_path(uid, wid, ".")
         assert resolved == path
 
+    async def test_filename_too_long_rejected(self, workspace_dir):
+        uid, wid, _ = workspace_dir
+        long_name = "a" * 256
+        with pytest.raises(ValueError, match="limit"):
+            files.resolve_path(uid, wid, long_name)
+
+    async def test_nested_component_too_long_rejected(self, workspace_dir):
+        uid, wid, _ = workspace_dir
+        long_name = "a" * 256
+        with pytest.raises(ValueError, match="limit"):
+            files.resolve_path(uid, wid, f"subdir/{long_name}")
+
+    async def test_255_byte_filename_accepted(self, workspace_dir):
+        uid, wid, path = workspace_dir
+        name = "a" * 255
+        resolved = files.resolve_path(uid, wid, name)
+        assert str(resolved).endswith(name)
+
 
 class TestWriteAndRead:
     async def test_write_and_read_file(self, workspace_dir):


### PR DESCRIPTION
## Summary
- Validate path component lengths in `files.resolve_path()` against OS `NAME_MAX` (255 bytes)
- All file endpoints already catch `ValueError`, so the new check returns 400 automatically
- Prevents `OSError: [Errno 36] File name too long` from surfacing as a 500

Closes #721

## Test plan
- [x] Unit tests for `resolve_path` rejecting 256-byte names, nested long names, and accepting 255-byte names
- [x] API tests for upload and list-files with too-long filenames
- [x] Full backend suite passes (1459 tests, 100% coverage)