### PR TITLE
feat: admin add-user dialog offers send verification email option

### DIFF
--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -770,10 +770,14 @@ No request body.
 
 ### POST `/api/v1/admin/users`
 
-Create a new user account with email already verified (no verification
-email sent).
+Create a new user account. By default the user is created verified with
+the given password. Set `send_verification_email` to `true` to create
+the user unverified and send a verification email so they can set their
+own password (the `password` field is ignored in this case).
 
 **Auth:** JWT required. User must have `admin` permission on `/`.
+
+With password (default):
 
 ```json
 { "email": "user@example.com", "password": "secretpass" }
@@ -781,6 +785,20 @@ email sent).
 
 ```json
 { "id": "uuid", "email": "user@example.com", "status": "created" }
+```
+
+With verification email:
+
+```json
+{ "email": "user@example.com", "send_verification_email": true }
+```
+
+```json
+{
+  "id": "uuid",
+  "email": "user@example.com",
+  "status": "pending_verification"
+}
 ```
 
 ---

--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -2123,18 +2123,64 @@ async def list_users(admin: dict = Depends(acl.has_permission("admin"))):
 
 class AdminCreateUserRequest(BaseModel):
     email: str
-    password: str
+    password: str | None = None
+    send_verification_email: bool = False
 
 
 @router.post("/admin/users")
 async def admin_create_user(
     req: AdminCreateUserRequest,
+    request: Request,
     admin: dict = Depends(acl.has_permission("admin")),
 ):
-    """Create a verified user directly (admin only, no email verification)."""
+    """Create a user (admin only).
+
+    By default creates a verified user with the given password.  When
+    ``send_verification_email`` is true, the password field is ignored
+    and a verification email is sent so the user can set their own
+    password.
+    """
+    auth.validate_email(req.email)
     existing = await model.get_user_by_email(req.email)
     if existing is not None:
         raise HTTPException(status_code=400, detail="Email already registered")
+
+    if req.send_verification_email:
+        user_id = str(uuid.uuid4())
+        # Use a random password hash — the user will set their own
+        # password via the verification link.
+        password_hash = auth.hash_password(uuid.uuid4().hex[:24])
+
+        hostname, proto, base_path = derive_hosting_info(request.headers)
+        verification_token = auth.create_verification_token(user_id)
+        verification_url = (
+            f"{proto}://{hostname}{base_path}"
+            f"/#/verify?token={verification_token}"
+        )
+
+        async with model.transaction() as db:
+            await db.execute(
+                "INSERT INTO users (id, email, password_hash, verified)"
+                " VALUES (?, ?, ?, 0)",
+                (user_id, req.email, password_hash),
+            )
+            await _send_email(
+                emailsvc.send_verification_email(req.email, verification_url),
+                req.email,
+                "verification email",
+            )
+
+        return {
+            "id": user_id,
+            "email": req.email,
+            "status": "pending_verification",
+        }
+
+    if not req.password:
+        raise HTTPException(
+            status_code=400,
+            detail="Password is required when not sending verification email",
+        )
     auth.validate_password_length(req.password)
     password_hash = auth.hash_password(req.password)
     user = await model.create_user(req.email, password_hash, verified=True)

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -3216,6 +3216,42 @@ class TestAdminEndpoints:
         assert resp.status_code == 400
         assert "Password" in resp.json()["detail"]
 
+    async def test_admin_create_user_send_verification_email(
+        self, client, admin_user
+    ):
+        headers = await self._admin_headers(client)
+        with patch("klangk_backend.api.emailsvc") as mock_email:
+            mock_email.send_verification_email = AsyncMock()
+            resp = await client.post(
+                "/api/v1/admin/users",
+                headers=headers,
+                json={
+                    "email": "verify@example.com",
+                    "send_verification_email": True,
+                },
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["email"] == "verify@example.com"
+        assert data["status"] == "pending_verification"
+        mock_email.send_verification_email.assert_called_once()
+        # User should exist but not be verified
+        user = await model.get_user_by_email("verify@example.com")
+        assert user is not None
+        assert user["verified"] == 0
+
+    async def test_admin_create_user_no_password_no_verify(
+        self, client, admin_user
+    ):
+        headers = await self._admin_headers(client)
+        resp = await client.post(
+            "/api/v1/admin/users",
+            headers=headers,
+            json={"email": "nopw@example.com"},
+        )
+        assert resp.status_code == 400
+        assert "Password is required" in resp.json()["detail"]
+
     async def test_admin_create_user_requires_admin(self, client, user):
         login_resp = await client.post(
             "/api/v1/auth/login",

--- a/src/frontend/lib/admin/admin_users_page.dart
+++ b/src/frontend/lib/admin/admin_users_page.dart
@@ -37,11 +37,14 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
 
   void _resolvePermissions() {
     final auth = context.read<AuthService>();
-    _canUsers = auth.hasPermission('/admin', '*') ||
+    _canUsers =
+        auth.hasPermission('/admin', '*') ||
         auth.hasPermission('/admin/users', 'view');
-    _canGroups = auth.hasPermission('/admin', '*') ||
+    _canGroups =
+        auth.hasPermission('/admin', '*') ||
         auth.hasPermission('/admin/groups', 'view');
-    _canInvitations = auth.hasPermission('/admin', '*') ||
+    _canInvitations =
+        auth.hasPermission('/admin', '*') ||
         auth.hasPermission('/admin/invitations', 'view');
   }
 
@@ -203,8 +206,9 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
     final groupId = group['id'] as String;
     final groupName = group['name'] as String;
 
-    final membersResp =
-        await auth.authGet('/api/v1/admin/groups/$groupId/members');
+    final membersResp = await auth.authGet(
+      '/api/v1/admin/groups/$groupId/members',
+    );
     final usersResp = await auth.authGet('/api/v1/admin/users');
     if (!mounted) return;
     if (membersResp.statusCode != 200 || usersResp.statusCode != 200) return;
@@ -219,8 +223,9 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
       builder: (ctx) => StatefulBuilder(
         builder: (ctx, setDialogState) {
           final memberIds = members.map((m) => m['id']).toSet();
-          final nonMembers =
-              allUsers.where((u) => !memberIds.contains(u['id'])).toList();
+          final nonMembers = allUsers
+              .where((u) => !memberIds.contains(u['id']))
+              .toList();
 
           return AlertDialog(
             title: Text('Members of "$groupName"'),
@@ -436,8 +441,9 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
     if (confirm != true) return;
 
     final auth = context.read<AuthService>();
-    final resp =
-        await auth.authDelete('/api/v1/admin/invitations/$invitationId');
+    final resp = await auth.authDelete(
+      '/api/v1/admin/invitations/$invitationId',
+    );
     if (resp.statusCode == 200) {
       _loadInvitations();
     } else {
@@ -454,8 +460,9 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
 
   Future<void> _resendInvitation(String invitationId, String email) async {
     final auth = context.read<AuthService>();
-    final resp =
-        await auth.authPost('/api/v1/admin/invitations/$invitationId/resend');
+    final resp = await auth.authPost(
+      '/api/v1/admin/invitations/$invitationId/resend',
+    );
     if (mounted) {
       if (resp.statusCode == 200) {
         ScaffoldMessenger.of(
@@ -473,17 +480,30 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
   }
 
   Future<void> _addUser() async {
-    final result = await showDialog<Map<String, String>>(
+    final result = await showDialog<Map<String, dynamic>>(
       context: context,
       builder: (ctx) => _AddUserDialog(),
     );
     if (result == null) return;
 
     final auth = context.read<AuthService>();
-    final resp =
-        await auth.authPost('/api/v1/admin/users', body: jsonEncode(result));
+    final resp = await auth.authPost(
+      '/api/v1/admin/users',
+      body: jsonEncode(result),
+    );
     if (resp.statusCode == 200) {
       _loadUsers();
+      if (mounted) {
+        final body = jsonDecode(resp.body);
+        final status = body['status'] as String? ?? '';
+        if (status == 'pending_verification') {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('Verification email sent to ${result['email']}'),
+            ),
+          );
+        }
+      }
     } else {
       if (mounted) {
         final error = jsonDecode(resp.body);
@@ -655,8 +675,8 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
               backgroundColor: isPending
                   ? KColors.accentAmber
                   : status == 'accepted'
-                      ? KColors.accentGreen
-                      : KColors.textMuted,
+                  ? KColors.accentGreen
+                  : KColors.textMuted,
               child: Text(
                 initial,
                 style: const TextStyle(
@@ -708,8 +728,9 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
 
   @override
   Widget build(BuildContext context) {
-    final pendingCount =
-        _invitations.where((i) => i['status'] == 'pending').length;
+    final pendingCount = _invitations
+        .where((i) => i['status'] == 'pending')
+        .length;
     final tabs = <SkeuoTab>[];
     final views = <Widget>[];
     final tabTypes = _tabTypes;
@@ -834,6 +855,7 @@ class _AddUserDialog extends StatefulWidget {
 class _AddUserDialogState extends State<_AddUserDialog> {
   final _emailController = TextEditingController();
   final _passwordController = TextEditingController();
+  bool _sendVerificationEmail = false;
 
   @override
   void dispose() {
@@ -867,17 +889,31 @@ class _AddUserDialogState extends State<_AddUserDialog> {
               autofocus: true,
             ),
             const SizedBox(height: 16),
-            TextField(
-              controller: _passwordController,
-              decoration: InputDecoration(
-                labelText: 'Password',
-                labelStyle: labelStyle,
-                floatingLabelStyle: labelStyle,
-                floatingLabelBehavior: FloatingLabelBehavior.always,
-                border: const OutlineInputBorder(),
+            CheckboxListTile(
+              value: _sendVerificationEmail,
+              onChanged: (v) =>
+                  setState(() => _sendVerificationEmail = v ?? false),
+              title: const Text('Send verification email'),
+              subtitle: const Text(
+                'User sets their own password via email link',
               ),
-              obscureText: true,
+              controlAffinity: ListTileControlAffinity.leading,
+              contentPadding: EdgeInsets.zero,
             ),
+            if (!_sendVerificationEmail) ...[
+              const SizedBox(height: 16),
+              TextField(
+                controller: _passwordController,
+                decoration: InputDecoration(
+                  labelText: 'Password',
+                  labelStyle: labelStyle,
+                  floatingLabelStyle: labelStyle,
+                  floatingLabelBehavior: FloatingLabelBehavior.always,
+                  border: const OutlineInputBorder(),
+                ),
+                obscureText: true,
+              ),
+            ],
           ],
         ),
       ),
@@ -890,9 +926,20 @@ class _AddUserDialogState extends State<_AddUserDialog> {
         FilledButton(
           onPressed: () {
             final email = _emailController.text.trim();
-            final password = _passwordController.text;
-            if (email.isEmpty || password.isEmpty) return;
-            Navigator.pop(context, {'email': email, 'password': password});
+            if (email.isEmpty) return;
+            if (_sendVerificationEmail) {
+              Navigator.pop(context, <String, dynamic>{
+                'email': email,
+                'send_verification_email': true,
+              });
+            } else {
+              final password = _passwordController.text;
+              if (password.isEmpty) return;
+              Navigator.pop(context, <String, dynamic>{
+                'email': email,
+                'password': password,
+              });
+            }
           },
           child: const Text('Add'),
         ),


### PR DESCRIPTION
## Summary
- Add `send_verification_email` flag to `POST /admin/users` endpoint
- When true, user is created unverified with a random password hash, and a verification email is sent so the user sets their own password
- When false (default), existing behavior: password is required, user is created verified
- Frontend `_AddUserDialog` gets a checkbox; password field is hidden when checked
- Snackbar confirms when verification email is sent

Closes #17

## Test plan
- [x] Backend test: create user with `send_verification_email: true` sends email, user is unverified
- [x] Backend test: create user without password and without verify flag returns 400
- [x] Existing admin create-user tests still pass
- [x] Full backend suite passes (1461 tests, 100% coverage)