### PR TITLE
fix: stop infinite agent restart loop when container is missing

### DIFF
--- a/src/backend/klangk_backend/agent.py
+++ b/src/backend/klangk_backend/agent.py
@@ -229,7 +229,6 @@ class AgentSession:
             return  # something else already restarted it
         try:
             await self._ensure_started()
-            self._restart_attempts = 0
             await _broadcast_agent_reconnect(self.workspace_id)
         except Exception:
             logger.exception(

--- a/src/backend/tests/test_agent.py
+++ b/src/backend/tests/test_agent.py
@@ -769,7 +769,7 @@ class TestMonitorProcess:
             await session._monitor_process(mock_proc)
 
             mock_start.assert_awaited_once()
-            assert session._restart_attempts == 0
+            assert session._restart_attempts == 1
 
     async def test_monitor_gives_up_after_max_retries(self):
         from klangk_backend import model


### PR DESCRIPTION
## Summary
- Removed `_restart_attempts = 0` reset after successful process spawn in `_monitor_process`
- Previously, each "successful" restart (process spawned but immediately dying) reset the counter, allowing infinite retries when the container didn't exist
- Now the attempt counter only resets when the container ID actually changes (in `_resolve_container_id`), so after 3 consecutive failures the agent gives up

## Test plan
- [x] Backend tests pass (1464 passed, 100% coverage)
- [ ] Verify agent stops retrying after 3 failures with a missing container