### PR TITLE
refactor: replace inline shell commands with container-side scripts

### DIFF
--- a/src/backend/klangk_backend/agent.py
+++ b/src/backend/klangk_backend/agent.py
@@ -114,7 +114,7 @@ class AgentSession:
 
         # Run setup-clankers to populate ~/.pi/agent/ with models.json,
         # settings.json, etc.  Unlike real users, the agent has no
-        # personal preferences — always delete settings.json first so
+        # personal preferences — --force deletes settings.json first so
         # it picks up the current KLANGK_LLM_MODEL env var.
         proc = await asyncio.create_subprocess_exec(
             podman.PODMAN_BIN,
@@ -124,10 +124,8 @@ class AgentSession:
             "-e",
             f"HOME={container_home}",
             container_id,
-            "bash",
-            "-c",
-            "rm -f $HOME/.pi/agent/settings.json"
-            " && python3 /opt/klangk/bin/setup-clankers",
+            "setup-clankers",
+            "--force",
             stdin=asyncio.subprocess.DEVNULL,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -650,13 +650,7 @@ class ContainerRegistry:
                 sudoers_rule = "klangk ALL=(ALL) !ALL"
             await podman.exec_container(
                 cid,
-                [
-                    "sh",
-                    "-c",
-                    f'echo "{sudoers_rule}"'
-                    " > /etc/sudoers.d/klangk"
-                    " && chmod 0440 /etc/sudoers.d/klangk",
-                ],
+                ["klangk-configure-sudo", sudoers_rule],
                 user="root",
             )
 

--- a/src/backend/klangk_backend/terminal.py
+++ b/src/backend/klangk_backend/terminal.py
@@ -467,30 +467,19 @@ async def load_workspace_state(container_id: str) -> dict:
 async def save_workspace_state(container_id: str, state: dict) -> None:
     """Snapshot per-user workspace state.
 
-    Writes atomically to /home/.workspace-state.json via temp + rename.
+    Delegates to ``klangk-save-workspace-state`` inside the container,
+    which atomically writes stdin to the target path via mktemp + rename.
     Callers should serialize access via WorkspaceSession._save_lock.
-
-    Uses ``mktemp`` inside the container so the temp file is created with
-    ``O_EXCL``, preventing symlink-following attacks.
     """
     data = json.dumps(state, indent=2)
-    # mktemp creates a file safely (O_EXCL); cat writes into it; mv renames
-    # atomically; trap ensures cleanup on any failure.
-    script = (
-        "set -e; t=$(mktemp /home/.workspace-state.XXXXXX);"
-        " trap 'rm -f \"$t\"' EXIT;"
-        f' cat > "$t" && mv "$t" {_STATE_PATH};'
-        " trap - EXIT"
-    )
     argv = [
         "exec",
         "-i",
         "-u",
         CONTAINER_USER,
         container_id,
-        "bash",
-        "-c",
-        script,
+        "klangk-save-workspace-state",
+        _STATE_PATH,
     ]
     proc = await asyncio.create_subprocess_exec(
         podman.PODMAN_BIN,

--- a/src/containers/workspace/Dockerfile
+++ b/src/containers/workspace/Dockerfile
@@ -37,6 +37,8 @@ COPY setup-home.sh /opt/klangk/bin/setup-home
 COPY klangk-attach-browser /opt/klangk/bin/klangk-attach-browser
 COPY klangk-browser-id /opt/klangk/bin/klangk-browser-id
 COPY klangk-copy-to-clipboard /opt/klangk/bin/klangk-copy-to-clipboard
+COPY klangk-configure-sudo /opt/klangk/bin/klangk-configure-sudo
+COPY klangk-save-workspace-state /opt/klangk/bin/klangk-save-workspace-state
 COPY klangk-set-workspace-token /opt/klangk/bin/klangk-set-workspace-token
 COPY klangk-workspace-token /opt/klangk/bin/klangk-workspace-token
 RUN chmod +x /opt/klangk/entrypoint.sh \
@@ -44,7 +46,9 @@ RUN chmod +x /opt/klangk/entrypoint.sh \
       /opt/klangk/bin/setup-home \
       /opt/klangk/bin/klangk-attach-browser \
       /opt/klangk/bin/klangk-browser-id \
+      /opt/klangk/bin/klangk-configure-sudo \
       /opt/klangk/bin/klangk-copy-to-clipboard \
+      /opt/klangk/bin/klangk-save-workspace-state \
       /opt/klangk/bin/klangk-set-workspace-token \
       /opt/klangk/bin/klangk-workspace-token
 COPY bash.bashrc /etc/bash.bashrc

--- a/src/containers/workspace/klangk-configure-sudo
+++ b/src/containers/workspace/klangk-configure-sudo
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Write a sudoers rule for the klangk user.
+# Usage: klangk-configure-sudo <rule>
+# Example: klangk-configure-sudo "klangk ALL=(ALL) NOPASSWD:ALL"
+printf '%s\n' "$1" > /etc/sudoers.d/klangk
+chmod 0440 /etc/sudoers.d/klangk

--- a/src/containers/workspace/klangk-save-workspace-state
+++ b/src/containers/workspace/klangk-save-workspace-state
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Atomically write stdin to a target file via mktemp + rename.
+# Usage: klangk-save-workspace-state <path>
+set -e
+target="${1:-/home/.workspace-state.json}"
+t=$(mktemp "${target}.XXXXXX")
+trap 'rm -f "$t"' EXIT
+cat > "$t" && mv "$t" "$target"
+trap - EXIT

--- a/src/containers/workspace/setup_clankers.py
+++ b/src/containers/workspace/setup_clankers.py
@@ -11,6 +11,7 @@ Skips setup if $HOME/.pi/agent/settings.json already exists.
 import json
 import os
 import subprocess
+import sys
 import traceback
 from pathlib import Path
 
@@ -112,7 +113,12 @@ def main():
     if not home or home == Path("/home"):
         return  # don't init for the system user
 
+    force = "--force" in sys.argv
+
     agent = _agent_dir()
+    if force:
+        (agent / "settings.json").unlink(missing_ok=True)
+
     if (agent / "settings.json").exists():
         # Already initialized — just refresh models.json (token may
         # have changed on container restart).


### PR DESCRIPTION
## Summary

- Extract three inline shell commands from Python backend into named scripts in `/opt/klangk/bin/`, making them overridable by custom container images
- **`klangk-configure-sudo`**: writes sudoers rule + chmod (was `sh -c 'echo ... > /etc/sudoers.d/klangk && chmod ...'`)
- **`klangk-save-workspace-state`**: atomic stdin-to-file via mktemp+rename (was inline bash script)
- **`setup-clankers --force`**: new flag deletes `settings.json` before init (was `bash -c 'rm -f ... && python3 ...'`)

Closes #725

## Test plan

- [x] Backend unit tests: 1464 passed, 100% coverage
- [x] E2E tests: 43 passed, 1 pre-existing flaky failure (unrelated WebSocket fanout timing test)
- [ ] Manual: rebuild image + restart, verify sudo works, agent starts, workspace state persists