### PR TITLE
fix: check bind mount sources exist before creating container

### DIFF
--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -525,6 +525,16 @@ class ContainerRegistry:
                                 f"Volume {source!r} belongs to another user"
                             )
 
+        # Check that bind-mount sources exist before calling podman.
+        # Missing sources cause a cryptic podman 404 (statfs) error.
+        if extra_mounts:
+            for mount_spec in extra_mounts:
+                source = mount_spec.split(":")[0]
+                if not _is_named_volume(source) and not os.path.exists(source):
+                    raise ValueError(
+                        f"Bind mount source does not exist: {source}"
+                    )
+
         binds = [
             f"{home_path}:/home",
         ]

--- a/src/backend/klangk_backend/wshandler.py
+++ b/src/backend/klangk_backend/wshandler.py
@@ -856,7 +856,11 @@ class Connection:
         await self.handle_workspace_disconnect()
 
         t_container = time.monotonic()
-        await self.start_workspace_container(workspace_id, workspace)
+        try:
+            await self.start_workspace_container(workspace_id, workspace)
+        except ValueError as exc:
+            send_error(self.sock, str(exc))
+            return
         logger.info(
             "workspace-open: start or reuse container (see breakdown above): %.3fs",
             time.monotonic() - t_container,

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -1171,8 +1171,11 @@ class TestExtraMountsVolumeCreation:
             )
         p.create_volume.assert_not_awaited()
 
-    async def test_bind_mount_not_treated_as_volume(self, workspace):
+    async def test_bind_mount_not_treated_as_volume(
+        self, workspace, monkeypatch
+    ):
         """Bind mounts (starting with /) are not treated as volumes."""
+        monkeypatch.setattr("os.path.exists", lambda p: True)
         with patch_podman() as p:
             await container.registry.start_container(
                 workspace["id"],
@@ -1182,8 +1185,9 @@ class TestExtraMountsVolumeCreation:
             )
         p.inspect_volume.assert_not_awaited()
 
-    async def test_mount_with_multiple_colons(self, workspace):
+    async def test_mount_with_multiple_colons(self, workspace, monkeypatch):
         """Mount spec with options (host:container:ro) — source starts with /."""
+        monkeypatch.setattr("os.path.exists", lambda p: True)
         with patch_podman() as p:
             await container.registry.start_container(
                 workspace["id"],
@@ -1205,8 +1209,11 @@ class TestExtraMountsVolumeCreation:
             )
         p.create_volume.assert_awaited_once()
 
-    async def test_mount_source_with_slash_is_bind(self, workspace):
+    async def test_mount_source_with_slash_is_bind(
+        self, workspace, monkeypatch
+    ):
         """A mount source containing slashes is a bind mount, not a volume."""
+        monkeypatch.setattr("os.path.exists", lambda p: True)
         with patch_podman() as p:
             await container.registry.start_container(
                 workspace["id"],
@@ -1233,8 +1240,11 @@ class TestExtraMountsVolumeCreation:
                 extra_mounts=["bad-vol:/data"],
             )
 
-    async def test_mount_source_with_special_characters(self, workspace):
+    async def test_mount_source_with_special_characters(
+        self, workspace, monkeypatch
+    ):
         """Mount source with special/binary-like chars is a bind mount."""
+        monkeypatch.setattr("os.path.exists", lambda p: True)
         with patch_podman() as p:
             await container.registry.start_container(
                 workspace["id"],
@@ -1244,6 +1254,17 @@ class TestExtraMountsVolumeCreation:
             )
         # Has leading /, so treated as bind mount
         p.inspect_volume.assert_not_awaited()
+
+    async def test_missing_bind_mount_source_rejected(self, workspace):
+        """A bind mount with a non-existent source path is refused."""
+        with patch_podman():
+            with pytest.raises(ValueError, match="does not exist"):
+                await container.registry.start_container(
+                    workspace["id"],
+                    "/tmp/ws",
+                    "/tmp/home",
+                    extra_mounts=["/nonexistent/path:/work/src"],
+                )
 
     async def test_browsers_revoked_on_creation_failure(self, workspace):
         """If container creation fails, the error propagates cleanly."""

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -1528,6 +1528,26 @@ class TestHandleWorkspaceConnect:
         calls = [c[0][0] for c in sock.send_json.call_args_list]
         assert any("Workspace not found" in str(c) for c in calls)
 
+    async def test_connect_container_start_valueerror(self, user, agent_user):
+        """ValueError from start_container is sent as an error, not a crash."""
+        sock = _mock_sock()
+        workspace = await _create_workspace_with_acl(user["id"], "bad-mount")
+        conn = _base_conn(user=user, ws=sock)
+
+        with patch.object(
+            Connection,
+            "start_workspace_container",
+            side_effect=ValueError("Bind mount source does not exist: /nope"),
+        ):
+            await conn.handle_workspace_connect(
+                {"workspaceId": workspace["id"]}
+            )
+
+        calls = [c[0][0] for c in sock.send_json.call_args_list]
+        errors = [c for c in calls if c.get("type") == "error"]
+        assert len(errors) == 1
+        assert "does not exist" in errors[0]["message"]
+
 
 class TestHandleWorkspaceDisconnect:
     async def test_disconnect(self):


### PR DESCRIPTION
## Summary

- Pre-check that bind mount source paths exist before calling `podman create`
- Raises a clear `ValueError` naming the missing path instead of a cryptic podman 404 statfs error
- WebSocket handler catches the `ValueError` and sends it to the client as an error message

Closes #740

## Test plan

- [x] Backend unit tests: 1466 passed, 100% coverage
- [x] New test: missing bind mount source is rejected with clear error
- [x] New test: ValueError from container start is sent to client, not a crash