### PR TITLE
fix: stop agent session before removing container on workspace delete

### DIFF
--- a/src/backend/klangk_backend/agent.py
+++ b/src/backend/klangk_backend/agent.py
@@ -225,6 +225,13 @@ class AgentSession:
         await asyncio.sleep(2)
         if self._proc is not None:
             return  # something else already restarted it
+        # If the container is gone (workspace deleted), don't restart.
+        if container.registry.get_state(self.workspace_id) is None:
+            logger.info(
+                "Container gone for workspace %s, not restarting agent",
+                self.workspace_id,
+            )
+            return
         try:
             await self._ensure_started()
             await _broadcast_agent_reconnect(self.workspace_id)

--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -1164,6 +1164,7 @@ async def delete_workspace(
         if live_state
         else workspace.get("container_id")
     )
+    await agent.stop_session(workspace_id)
     if cid:
         await container.registry.stop_and_remove_container(cid)
     await wshandler.reset_workspace_state(workspace_id)

--- a/src/backend/tests/test_agent.py
+++ b/src/backend/tests/test_agent.py
@@ -972,6 +972,51 @@ class TestMonitorProcess:
         # Should not raise when workspace has been deleted
         await _broadcast_agent_reconnect("deleted-ws-id")
 
+    async def test_monitor_skips_restart_if_container_gone(self, caplog):
+        """Monitor does not restart when the container has been removed."""
+        from klangk_backend import model
+        import logging
+
+        session = _make_session("ws-gone")
+        _agents["ws-gone"] = session
+
+        mock_proc = AsyncMock()
+        mock_proc.returncode = 1
+        mock_proc.wait = AsyncMock()
+        mock_proc.stderr = asyncio.StreamReader()
+        mock_proc.stderr.feed_eof()
+        session._proc = mock_proc
+
+        with (
+            patch.object(
+                model,
+                "add_chat_message",
+                new_callable=AsyncMock,
+                return_value={"id": "m1", "message": "msg"},
+            ),
+            patch(
+                "klangk_backend.agent._get_workspace_session",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "klangk_backend.agent.container.registry.get_state",
+                return_value=None,
+            ),
+            patch(
+                "klangk_backend.agent.asyncio.sleep", new_callable=AsyncMock
+            ),
+            patch.object(
+                session,
+                "_ensure_started",
+                new_callable=AsyncMock,
+            ) as mock_start,
+            caplog.at_level(logging.INFO, logger="klangk_backend.agent"),
+        ):
+            await session._monitor_process(mock_proc)
+            mock_start.assert_not_awaited()
+
+        assert any("Container gone" in r.message for r in caplog.records)
+
     async def test_monitor_skips_restart_if_already_restarted(self):
         from klangk_backend import model
 

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -898,15 +898,23 @@ class TestWorkspaceRoutes:
         # Simulate a running container
         await model.update_workspace_container(ws_id, "fake-container-id")
 
-        with patch.object(
-            api.container.registry,
-            "stop_and_remove_container",
-            new_callable=AsyncMock,
-        ) as mock_rm:
+        with (
+            patch.object(
+                api.container.registry,
+                "stop_and_remove_container",
+                new_callable=AsyncMock,
+            ) as mock_rm,
+            patch.object(
+                api.agent,
+                "stop_session",
+                new_callable=AsyncMock,
+            ) as mock_stop_agent,
+        ):
             resp = await client.delete(
                 f"/api/v1/workspaces/{ws_id}", headers=headers
             )
         assert resp.status_code == 200
+        mock_stop_agent.assert_awaited_once_with(ws_id)
         mock_rm.assert_awaited_once_with("fake-container-id")
 
     async def test_delete_workspace_cleans_up_groups(self, client, user):


### PR DESCRIPTION
## Summary

- Stop the agent session in `delete_workspace` before removing the container, preventing the monitor task from racing and attempting to auto-restart against a missing container
- Add a defensive check in `_monitor_process` to bail out if the container registry returns `None` (workspace already deleted)

Closes #739

## Test plan

- [x] New test: `test_monitor_skips_restart_if_container_gone` verifies monitor does not restart when container is gone
- [x] Updated test: `test_delete_workspace_with_container` asserts `agent.stop_session` is called during deletion
- [x] Full backend test suite passes (1467 tests)