### PR TITLE
Fix /version endpoint path missing /api/v1 prefix

### DIFF
--- a/src/frontend/lib/debug/system_info_tab.dart
+++ b/src/frontend/lib/debug/system_info_tab.dart
@@ -28,7 +28,7 @@ class _SystemInfoTabState extends State<SystemInfoTab> {
       _error = null;
     });
     try {
-      final resp = await widget.auth.authGet('/version');
+      final resp = await widget.auth.authGet('/api/v1/version');
       if (resp.statusCode == 200) {
         setState(() {
           _info = jsonDecode(resp.body) as Map<String, dynamic>;

--- a/src/frontend/test/system_info_tab_test.dart
+++ b/src/frontend/test/system_info_tab_test.dart
@@ -10,7 +10,7 @@ import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 
 http.Client _mockClient({int versionStatus = 200}) {
   return MockClient((request) async {
-    if (request.url.path == '/version') {
+    if (request.url.path == '/api/v1/version') {
       if (versionStatus != 200) {
         return http.Response('', versionStatus);
       }
@@ -32,10 +32,7 @@ http.Client _mockClient({int versionStatus = 200}) {
     }
     if (request.url.path.contains('/api/config')) {
       return http.Response(
-        jsonEncode({
-          'login_banner_title': '',
-          'login_banner': '',
-        }),
+        jsonEncode({'login_banner_title': '', 'login_banner': ''}),
         200,
       );
     }
@@ -71,7 +68,9 @@ void main() {
     final auth = AuthService();
 
     await tester.pumpWidget(
-      MaterialApp(home: Scaffold(body: SystemInfoTab(auth: auth))),
+      MaterialApp(
+        home: Scaffold(body: SystemInfoTab(auth: auth)),
+      ),
     );
     // Pump a few frames to let async init + fetch complete.
     await tester.pump();
@@ -91,7 +90,9 @@ void main() {
     final auth = AuthService();
 
     await tester.pumpWidget(
-      MaterialApp(home: Scaffold(body: SystemInfoTab(auth: auth))),
+      MaterialApp(
+        home: Scaffold(body: SystemInfoTab(auth: auth)),
+      ),
     );
     await tester.pump();
     await tester.pump();
@@ -102,7 +103,7 @@ void main() {
 
   testWidgets('shows connection error on exception', (tester) async {
     testAuthHttpClientOverride = MockClient((request) async {
-      if (request.url.path == '/version') {
+      if (request.url.path == '/api/v1/version') {
         throw Exception('connection refused');
       }
       if (request.url.path.contains('/api/config')) {
@@ -129,7 +130,9 @@ void main() {
     final auth = AuthService();
 
     await tester.pumpWidget(
-      MaterialApp(home: Scaffold(body: SystemInfoTab(auth: auth))),
+      MaterialApp(
+        home: Scaffold(body: SystemInfoTab(auth: auth)),
+      ),
     );
     await tester.pump();
     await tester.pump();
@@ -140,7 +143,7 @@ void main() {
 
   testWidgets('shows no plugins loaded when list is empty', (tester) async {
     testAuthHttpClientOverride = MockClient((request) async {
-      if (request.url.path == '/version') {
+      if (request.url.path == '/api/v1/version') {
         return http.Response(
           jsonEncode({
             'version': 'dev',
@@ -175,7 +178,9 @@ void main() {
     final auth = AuthService();
 
     await tester.pumpWidget(
-      MaterialApp(home: Scaffold(body: SystemInfoTab(auth: auth))),
+      MaterialApp(
+        home: Scaffold(body: SystemInfoTab(auth: auth)),
+      ),
     );
     await tester.pump();
     await tester.pump();


### PR DESCRIPTION
## Summary
- Frontend `SystemInfoTab` was calling `/version` instead of `/api/v1/version`, causing a 404 when the server mounts all API routes under `/api/v1`
- Updated the mock paths in frontend tests to match

## Test plan
- [x] Frontend unit tests pass (`flutter test test/system_info_tab_test.dart`)

Fixes #747