### PR TITLE
Use kebab-case for YAML config keys

### DIFF
--- a/docs/features/sandbox.md
+++ b/docs/features/sandbox.md
@@ -25,7 +25,7 @@ Create a `.klangk-sandbox.yaml` in your project root:
 
 ```yaml
 sandbox:
-  mount_at: ~/myproj
+  mount-at: ~/myproj
 ```
 
 Then run:
@@ -42,8 +42,8 @@ Run the same command again to reconnect to the existing workspace.
 
 The config file lives at `.klangk-sandbox.yaml` inside your project.
 The directory containing `.klangk-sandbox.yaml` is called the **sandbox root** —
-it's automatically mounted into the container at the `mount_at`
-location. If you do not specify a `mount_at` location, it will be
+it's automatically mounted into the container at the `mount-at`
+location. If you do not specify a `mount-at` location, it will be
 placed in `~/work`.
 
 ### `workspace`
@@ -64,14 +64,14 @@ specified as a positional argument on the command line.
 
 ```yaml
 sandbox:
-  mount_at: ~/klangk
+  mount-at: ~/klangk
   setup: setup.sh
 ```
 
 | Field      | Required | Default  | Description                                                                                                |
 | ---------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------- |
-| `mount_at` | no       | `~/work` | Where the sandbox root is mounted inside the container. `~` expands to `/home/{handle}`.                   |
-| `setup`    | no       | (none)   | Script to run inside the container after creation. Relative to `mount_at`, or absolute if starts with `/`. |
+| `mount-at` | no       | `~/work` | Where the sandbox root is mounted inside the container. `~` expands to `/home/{handle}`.                   |
+| `setup`    | no       | (none)   | Script to run inside the container after creation. Relative to `mount-at`, or absolute if starts with `/`. |
 
 The setup script runs once — on workspace creation, not on reconnect.
 It runs as the `klangk` user inside the container. If
@@ -113,7 +113,7 @@ Bind mounts from the host into the container. Format:
   Tilde expands to the host user's home.
 - **Destination**: container path. Tilde expands to
   `/home/{handle}`. Relative paths (no `~` or `/` prefix) are
-  resolved relative to `mount_at`.
+  resolved relative to `mount-at`.
 - **Options**: optional, comma-separated. Common options: `ro`
   (read-only), `rw` (read-write, default).
 
@@ -121,7 +121,7 @@ Relative source paths are resolved to absolute paths before being
 sent to the server. The server validates all mount sources against
 `KLANGK_ALLOWED_MOUNT_ROOTS` if that setting is configured.
 
-The sandbox root mount (at `mount_at`) is implicit — you don't need
+The sandbox root mount (at `mount-at`) is implicit — you don't need
 to list it here.
 
 Use mounts for files that should stay in sync between host and
@@ -181,7 +181,7 @@ klangkc sandbox WORKSPACE [PATH] [--forward-agent/-A] [--force-setup]
 1. Read `.klangk-sandbox.yaml` from the sandbox root
 2. Create the workspace with the configured image, mounts, and
    volumes
-3. Mount the sandbox root at `mount_at`
+3. Mount the sandbox root at `mount-at`
 4. Copy files listed in `copy` into the container home
 5. Run the `setup` script inside the container (if configured)
 6. Connect to the workspace shell
@@ -209,7 +209,7 @@ or re-run the setup script. This means:
 
 The setup script runs inside the container as the `klangk` user. It
 has access to everything that's been mounted and copied. The working
-directory is the sandbox root (the `mount_at` path).
+directory is the sandbox root (the `mount-at` path).
 
 **Important:** The `klangk` user does not have sudo access by
 default. Without it, setup scripts are limited to user-space
@@ -274,7 +274,7 @@ and SSH access to GitHub:
 ```yaml
 # .klangk-sandbox.yaml
 sandbox:
-  mount_at: ~/klangk
+  mount-at: ~/klangk
   setup: setup.sh
 
 copy:

--- a/docs/reference/oidc.md
+++ b/docs/reference/oidc.md
@@ -8,19 +8,19 @@ Klangk supports OIDC authentication via one or more external Identity Providers 
 
 ```yaml
 - id: cac
-  display_name: CAC Login
+  display-name: CAC Login
   issuer: https://keycloak.example.com/realms/company
-  client_id: klangk
-  client_secret: "file:/run/secrets/cac-secret"
+  client-id: klangk
+  client-secret: "file:/run/secrets/cac-secret"
   scopes: openid email profile
-  ca_cert: /etc/pki/tls/certs/company-ca-bundle.pem
-  logout_redirect: true
+  ca-cert: /etc/pki/tls/certs/company-ca-bundle.pem
+  logout-redirect: true
 
 - id: internal
-  display_name: Internal SSO
+  display-name: Internal SSO
   issuer: https://keycloak.example.com/realms/corp
-  client_id: klangk
-  client_secret: "file:/run/secrets/corp-secret"
+  client-id: klangk
+  client-secret: "file:/run/secrets/corp-secret"
 ```
 
 1. Set `KLANGK_OIDC_CONFIG` in `.env`:
@@ -39,14 +39,14 @@ KLANGK_OIDC_CONFIG=/path/to/oidc.yaml
 | Field                  | Required | Description                                                                                                                 |
 | ---------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------- |
 | `id`                   | Yes      | URL-safe slug, used in endpoint paths (`/api/v1/auth/oidc/{id}/login`) and stored as `provider` on users                    |
-| `display_name`         | Yes      | Button label on the login page (e.g., "CAC Login", "Google")                                                                |
+| `display-name`         | Yes      | Button label on the login page (e.g., "CAC Login", "Google")                                                                |
 | `issuer`               | Yes      | OIDC issuer URL. Discovery via `{issuer}/.well-known/openid-configuration`                                                  |
-| `client_id`            | Yes      | OIDC client ID registered with the IdP                                                                                      |
-| `client_secret`        | Yes      | OIDC client secret. Supports `file:` prefix for secret management                                                           |
+| `client-id`            | Yes      | OIDC client ID registered with the IdP                                                                                      |
+| `client-secret`        | Yes      | OIDC client secret. Supports `file:` prefix for secret management                                                           |
 | `scopes`               | No       | Space-separated scopes (default: `openid email profile`)                                                                    |
-| `ca_cert`              | No       | Path to a CA certificate PEM file for IdPs with custom/private CAs                                                          |
-| `token_validation_pem` | No       | Inline RSA/EC public key PEM for static token validation (skips JWKS discovery)                                             |
-| `logout_redirect`      | No       | If `true`, logout redirects to the IdP's `end_session_endpoint` (RP-Initiated Logout). Default: `false` (local-only logout) |
+| `ca-cert`              | No       | Path to a CA certificate PEM file for IdPs with custom/private CAs                                                          |
+| `token-validation-pem` | No       | Inline RSA/EC public key PEM for static token validation (skips JWKS discovery)                                             |
+| `logout-redirect`      | No       | If `true`, logout redirects to the IdP's `end_session_endpoint` (RP-Initiated Logout). Default: `false` (local-only logout) |
 
 ## How It Works
 
@@ -55,7 +55,7 @@ KLANGK_OIDC_CONFIG=/path/to/oidc.yaml
 - **Login hook**: A single Python hook (`KLANGK_OIDC_LOGIN_HOOK`) handles both login validation and group mapping. See [OIDC Login Hook](#oidc-login-hook) below.
 - **User provisioning**: On first OIDC login, a user is created automatically (verified, no password). If a local user with the same email already exists, the OIDC identity is linked to it.
 - **OIDC users** cannot use forgot-password, change-password, or change-email.
-- **Logout**: By default, logout only kills the Klangk session. With `logout_redirect: true`, the user is also redirected to the IdP's logout endpoint to end the SSO session (requires full re-authentication on next login).
+- **Logout**: By default, logout only kills the Klangk session. With `logout-redirect: true`, the user is also redirected to the IdP's logout endpoint to end the SSO session (requires full re-authentication on next login).
 
 ## IdP Setup (Keycloak Example)
 

--- a/examples/devenv-sandbox/.klangk-sandbox.yaml
+++ b/examples/devenv-sandbox/.klangk-sandbox.yaml
@@ -1,5 +1,5 @@
 sandbox:
-  mount_at: ~/devenv-sandbox
+  mount-at: ~/devenv-sandbox
   setup: setup.sh
 
 mounts:

--- a/examples/todo-sandbox/.klangk-sandbox.yaml
+++ b/examples/todo-sandbox/.klangk-sandbox.yaml
@@ -1,5 +1,5 @@
 sandbox:
-  mount_at: ~/sandbox-test
+  mount-at: ~/sandbox-test
   setup: setup.sh
 
 copy:

--- a/src/backend/klangk_backend/oidc.py
+++ b/src/backend/klangk_backend/oidc.py
@@ -60,6 +60,24 @@ _jwks_cache: dict[str, _CachedJWKS] = {}
 _providers: list[OIDCProvider] = []
 
 
+_SENTINEL = object()
+
+
+def _get(entry: dict, key: str, default: object = _SENTINEL) -> object:
+    """Look up *key* (kebab-case) with snake_case fallback for backwards compat."""
+    value = entry.get(key, _SENTINEL)
+    if value is not _SENTINEL:
+        return value
+    snake = key.replace("-", "_")
+    if snake != key:
+        value = entry.get(snake, _SENTINEL)
+        if value is not _SENTINEL:
+            return value
+    if default is not _SENTINEL:
+        return default
+    raise KeyError(key)
+
+
 def load_config() -> list[OIDCProvider]:
     """Load OIDC provider config from the JSON file specified by
     KLANGK_OIDC_CONFIG. Returns empty list if not configured.
@@ -79,22 +97,22 @@ def load_config() -> list[OIDCProvider]:
 
     providers = []
     for entry in raw:
-        secret = resolve_file_secret(entry.get("client_secret", ""))
-        # Resolve ca_cert relative to the config file's directory
-        ca_cert = entry.get("ca_cert")
+        secret = resolve_file_secret(_get(entry, "client-secret", ""))
+        # Resolve ca-cert relative to the config file's directory
+        ca_cert = _get(entry, "ca-cert", None)
         if ca_cert and not os.path.isabs(ca_cert):
             ca_cert = os.path.join(config_dir, ca_cert)
         providers.append(
             OIDCProvider(
                 id=entry["id"],
-                display_name=entry["display_name"],
+                display_name=_get(entry, "display-name"),
                 issuer=entry["issuer"].rstrip("/"),
-                client_id=entry["client_id"],
+                client_id=_get(entry, "client-id"),
                 client_secret=secret or "",
                 scopes=entry.get("scopes", "openid email profile"),
                 ca_cert=ca_cert,
-                token_validation_pem=entry.get("token_validation_pem"),
-                logout_redirect=entry.get("logout_redirect", False),
+                token_validation_pem=_get(entry, "token-validation-pem", None),
+                logout_redirect=_get(entry, "logout-redirect", False),
             )
         )
     return providers

--- a/src/backend/tests/test_oidc.py
+++ b/src/backend/tests/test_oidc.py
@@ -37,6 +37,12 @@ def _provider(**overrides):
     return oidc.OIDCProvider(**defaults)
 
 
+class TestGet:
+    def test_missing_key_raises(self):
+        with pytest.raises(KeyError, match="missing-key"):
+            oidc._get({}, "missing-key")
+
+
 class TestLoadConfig:
     def test_no_config(self, monkeypatch):
         monkeypatch.delenv("KLANGK_OIDC_CONFIG", raising=False)

--- a/src/backend/tests/test_oidc.py
+++ b/src/backend/tests/test_oidc.py
@@ -54,10 +54,10 @@ class TestLoadConfig:
                 [
                     {
                         "id": "test",
-                        "display_name": "Test",
+                        "display-name": "Test",
                         "issuer": "https://idp.example.com/",
-                        "client_id": "klangk",
-                        "client_secret": "s3cret",
+                        "client-id": "klangk",
+                        "client-secret": "s3cret",
                     }
                 ]
             )
@@ -78,10 +78,10 @@ class TestLoadConfig:
                 [
                     {
                         "id": "fs",
-                        "display_name": "File Secret",
+                        "display-name": "File Secret",
                         "issuer": "https://idp.example.com",
-                        "client_id": "klangk",
-                        "client_secret": f"file:{secret_file}",
+                        "client-id": "klangk",
+                        "client-secret": f"file:{secret_file}",
                     }
                 ]
             )
@@ -97,11 +97,11 @@ class TestLoadConfig:
                 [
                     {
                         "id": "dod",
-                        "display_name": "DoD",
+                        "display-name": "DoD",
                         "issuer": "https://sso.mil/realms/dod",
-                        "client_id": "klangk",
-                        "client_secret": "s",
-                        "ca_cert": "/etc/pki/dod-ca.pem",
+                        "client-id": "klangk",
+                        "client-secret": "s",
+                        "ca-cert": "/etc/pki/dod-ca.pem",
                     }
                 ]
             )
@@ -118,11 +118,11 @@ class TestLoadConfig:
                 [
                     {
                         "id": "dod",
-                        "display_name": "DoD",
+                        "display-name": "DoD",
                         "issuer": "https://sso.mil/realms/dod",
-                        "client_id": "klangk",
-                        "client_secret": "s",
-                        "token_validation_pem": pem,
+                        "client-id": "klangk",
+                        "client-secret": "s",
+                        "token-validation-pem": pem,
                     }
                 ]
             )
@@ -138,11 +138,11 @@ class TestLoadConfig:
                 [
                     {
                         "id": "rel",
-                        "display_name": "Rel",
+                        "display-name": "Rel",
                         "issuer": "https://idp.example.com",
-                        "client_id": "klangk",
-                        "client_secret": "s",
-                        "ca_cert": "certs/ca.pem",
+                        "client-id": "klangk",
+                        "client-secret": "s",
+                        "ca-cert": "certs/ca.pem",
                     }
                 ]
             )
@@ -159,10 +159,10 @@ class TestLoadConfig:
                 [
                     {
                         "id": "test",
-                        "display_name": "Test",
+                        "display-name": "Test",
                         "issuer": "https://idp.example.com",
-                        "client_id": "klangk",
-                        "client_secret": "s",
+                        "client-id": "klangk",
+                        "client-secret": "s",
                     }
                 ]
             )
@@ -178,17 +178,17 @@ class TestLoadConfig:
                 [
                     {
                         "id": "a",
-                        "display_name": "A",
+                        "display-name": "A",
                         "issuer": "https://a.example.com",
-                        "client_id": "klangk",
-                        "client_secret": "sa",
+                        "client-id": "klangk",
+                        "client-secret": "sa",
                     },
                     {
                         "id": "b",
-                        "display_name": "B",
+                        "display-name": "B",
                         "issuer": "https://b.example.com",
-                        "client_id": "klangk",
-                        "client_secret": "sb",
+                        "client-id": "klangk",
+                        "client-secret": "sb",
                     },
                 ]
             )
@@ -199,6 +199,35 @@ class TestLoadConfig:
         assert providers[0].id == "a"
         assert providers[1].id == "b"
 
+    def test_snake_case_fallback(self, monkeypatch, tmp_path):
+        """Legacy snake_case keys still work for backwards compat."""
+        cfg = tmp_path / "oidc.yaml"
+        cfg.write_text(
+            yaml.dump(
+                [
+                    {
+                        "id": "legacy",
+                        "display_name": "Legacy",
+                        "issuer": "https://idp.example.com/",
+                        "client_id": "klangk",
+                        "client_secret": "s3cret",
+                        "ca_cert": "/etc/ca.pem",
+                        "token_validation_pem": "pem-data",
+                        "logout_redirect": True,
+                    }
+                ]
+            )
+        )
+        monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(cfg))
+        providers = oidc.load_config()
+        assert len(providers) == 1
+        assert providers[0].display_name == "Legacy"
+        assert providers[0].client_id == "klangk"
+        assert providers[0].client_secret == "s3cret"
+        assert providers[0].ca_cert == "/etc/ca.pem"
+        assert providers[0].token_validation_pem == "pem-data"
+        assert providers[0].logout_redirect is True
+
 
 class TestProviderRegistry:
     def test_init_and_lookup(self, monkeypatch, tmp_path):
@@ -208,10 +237,10 @@ class TestProviderRegistry:
                 [
                     {
                         "id": "test",
-                        "display_name": "Test",
+                        "display-name": "Test",
                         "issuer": "https://idp.example.com",
-                        "client_id": "klangk",
-                        "client_secret": "s",
+                        "client-id": "klangk",
+                        "client-secret": "s",
                     }
                 ]
             )

--- a/src/cli/klangkc/sandbox.py
+++ b/src/cli/klangkc/sandbox.py
@@ -43,7 +43,7 @@ def load_sandbox_config(sandbox_root: Path) -> SandboxConfig:
 
     return SandboxConfig(
         image=workspace.get("image"),
-        mount_at=sandbox.get("mount_at", "~/work"),
+        mount_at=sandbox.get("mount-at", sandbox.get("mount_at", "~/work")),
         setup=sandbox.get("setup"),
         copy=raw.get("copy") or [],
         mounts=raw.get("mounts") or [],

--- a/src/cli/tests/test_cli_main.py
+++ b/src/cli/tests/test_cli_main.py
@@ -2591,7 +2591,7 @@ class TestSandboxCommand:
         from klangkc import main
 
         (tmp_path / ".klangk-sandbox.yaml").write_text(
-            "sandbox:\n  mount_at: ~/test\n"
+            "sandbox:\n  mount-at: ~/test\n"
         )
 
         ws = Workspace(
@@ -2627,7 +2627,7 @@ class TestSandboxCommand:
         from klangkc import main
 
         (tmp_path / ".klangk-sandbox.yaml").write_text(
-            "sandbox:\n  mount_at: ~/test\n"
+            "sandbox:\n  mount-at: ~/test\n"
         )
 
         ws = Workspace(
@@ -2661,7 +2661,7 @@ class TestSandboxCommand:
         from klangkc import main
 
         (tmp_path / ".klangk-sandbox.yaml").write_text(
-            "sandbox:\n  mount_at: ~/test\nmounts:\n  - /extra:/extra\n"
+            "sandbox:\n  mount-at: ~/test\nmounts:\n  - /extra:/extra\n"
         )
 
         ws = Workspace(
@@ -2694,7 +2694,7 @@ class TestSandboxCommand:
         from klangkc import main
 
         (tmp_path / ".klangk-sandbox.yaml").write_text(
-            "sandbox:\n  mount_at: ~/test\n"
+            "sandbox:\n  mount-at: ~/test\n"
         )
 
         ws = Workspace(
@@ -2831,7 +2831,7 @@ class TestSandboxSetup:
         from klangkc import main
 
         (tmp_path / ".klangk-sandbox.yaml").write_text(
-            "sandbox:\n  mount_at: ~/test\n"
+            "sandbox:\n  mount-at: ~/test\n"
         )
 
         ws = Workspace(

--- a/src/cli/tests/test_sandbox.py
+++ b/src/cli/tests/test_sandbox.py
@@ -42,7 +42,7 @@ class TestLoadSandboxConfig:
             {
                 "workspace": {"image": "my-image"},
                 "sandbox": {
-                    "mount_at": "~/project",
+                    "mount-at": "~/project",
                     "setup": "setup.sh",
                 },
                 "copy": ["~/.gitconfig:~/.gitconfig"],
@@ -57,6 +57,15 @@ class TestLoadSandboxConfig:
         assert config.copy == ["~/.gitconfig:~/.gitconfig"]
         assert config.mounts == ["/data:~/data:ro"]
         assert config.volumes == ["cache:/cache"]
+
+    def test_snake_case_mount_at_fallback(self, sandbox_root):
+        """Legacy mount_at key still works for backwards compat."""
+        _write_config(
+            sandbox_root,
+            {"sandbox": {"mount_at": "~/legacy"}},
+        )
+        config = load_sandbox_config(sandbox_root)
+        assert config.mount_at == "~/legacy"
 
     def test_missing_config_raises(self, tmp_path):
         with pytest.raises(FileNotFoundError, match="No sandbox config"):


### PR DESCRIPTION
## Summary

- Switch `.klangk-sandbox.yaml` and OIDC config YAML keys from snake_case to kebab-case (`mount_at` → `mount-at`, `display_name` → `display-name`, etc.)
- Snake_case keys are still accepted for backwards compatibility
- Updated examples, docs, and tests

Closes #751