### PR TITLE
Add haiku-rag example sandbox and uv to workspace image

### DIFF
--- a/examples/haiku-rag/.klangk-sandbox.yaml
+++ b/examples/haiku-rag/.klangk-sandbox.yaml
@@ -1,0 +1,3 @@
+sandbox:
+  mount_at: ~/haiku-rag
+  setup: setup.sh

--- a/examples/haiku-rag/setup.sh
+++ b/examples/haiku-rag/setup.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -euo pipefail
+
+REPO_DIR="$HOME/haiku-rag/repo"
+
+# Clone the repo via SSH if not already present.
+if [ ! -d "$REPO_DIR" ]; then
+  echo "Cloning ggozad/haiku.rag..."
+  git clone git@github.com:ggozad/haiku.rag.git "$REPO_DIR"
+else
+  echo "Repo already cloned, pulling latest..."
+  git -C "$REPO_DIR" pull
+fi
+
+# Create virtualenv and install the package.
+if [ ! -d "$REPO_DIR/.venv" ]; then
+  echo "Creating virtualenv..."
+  uv venv "$REPO_DIR/.venv"
+fi
+
+echo "Installing haiku.rag..."
+uv pip install --python "$REPO_DIR/.venv/bin/python" -e "$REPO_DIR"
+
+echo "Setup complete."

--- a/examples/haiku-rag/setup.sh
+++ b/examples/haiku-rag/setup.sh
@@ -8,8 +8,7 @@ if [ ! -d "$REPO_DIR" ]; then
   echo "Cloning ggozad/haiku.rag..."
   git clone git@github.com:ggozad/haiku.rag.git "$REPO_DIR"
 else
-  echo "Repo already cloned, pulling latest..."
-  git -C "$REPO_DIR" pull
+  echo "Repo already cloned, skipping."
 fi
 
 # Create virtualenv and install the package.

--- a/src/containers/workspace/Dockerfile
+++ b/src/containers/workspace/Dockerfile
@@ -20,6 +20,11 @@ COPY --from=plugin-hooks / /opt/klangk/hooks/
 COPY --from=plugin-extensions / /opt/klangk/pi-agent/extensions/
 COPY builtin-extensions/ /opt/klangk/pi-agent/extensions/
 
+# Install uv (fast Python package manager)
+RUN curl -LsSf https://astral.sh/uv/0.11.23/install.sh | sh \
+    && mv /root/.local/bin/uv /usr/local/bin/uv \
+    && mv /root/.local/bin/uvx /usr/local/bin/uvx
+
 # Herdr: terminal-based agent runtime (persistent sessions, pane API)
 ARG HERDR_VERSION=0.6.6
 ARG TARGETARCH

--- a/src/containers/workspace/Dockerfile.base
+++ b/src/containers/workspace/Dockerfile.base
@@ -68,11 +68,6 @@ RUN ssh-keyscan -t ed25519,ecdsa,rsa github.com >> /etc/ssh/ssh_known_hosts 2>/d
 # fd-find installs as fdfind on Debian — symlink to fd
 RUN ln -sf /usr/bin/fdfind /usr/bin/fd
 
-# Install uv (fast Python package manager)
-RUN curl -LsSf https://astral.sh/uv/0.11.23/install.sh | sh \
-    && mv /root/.local/bin/uv /usr/local/bin/uv \
-    && mv /root/.local/bin/uvx /usr/local/bin/uvx
-
 # Create klangk user with fixed UID/GID 1000. The container runs with
 # --userns=keep-id:uid=1000,gid=1000 which maps the host user to
 # this UID, so files on bind mounts are owned by the host user.

--- a/src/containers/workspace/Dockerfile.base
+++ b/src/containers/workspace/Dockerfile.base
@@ -68,6 +68,11 @@ RUN ssh-keyscan -t ed25519,ecdsa,rsa github.com >> /etc/ssh/ssh_known_hosts 2>/d
 # fd-find installs as fdfind on Debian — symlink to fd
 RUN ln -sf /usr/bin/fdfind /usr/bin/fd
 
+# Install uv (fast Python package manager)
+RUN curl -LsSf https://astral.sh/uv/0.11.23/install.sh | sh \
+    && mv /root/.local/bin/uv /usr/local/bin/uv \
+    && mv /root/.local/bin/uvx /usr/local/bin/uvx
+
 # Create klangk user with fixed UID/GID 1000. The container runs with
 # --userns=keep-id:uid=1000,gid=1000 which maps the host user to
 # this UID, so files on bind mounts are owned by the host user.


### PR DESCRIPTION
## Summary
- Add `examples/haiku-rag` sandbox that clones `ggozad/haiku.rag` via SSH and installs it in a virtualenv using `uv`
- Install `uv` 0.11.23 in the workspace Docker image (not the base image)

## Test plan
- [ ] Build workspace image and verify `uv` is available
- [ ] Run `klangkc sandbox haikurag` and verify clone + install succeeds

Closes #760