### PR TITLE
fix: run sandbox setup after SSH agent forwarding

### DIFF
--- a/src/cli/klangkc/client.py
+++ b/src/cli/klangkc/client.py
@@ -535,7 +535,7 @@ async def _ws_shell(
     command_override: str | None = None,
     window: str | None = None,
     forward_agent: bool = False,
-    pre_shell=None,
+    sandbox_setup=None,
     max_size: int = _WS_MAX_SIZE,
 ) -> None:
     """Run the interactive PTY shell over WebSocket.
@@ -545,7 +545,7 @@ async def _ws_shell(
     command_override, if set, overrides the workspace default command.
     window, if set, selects a specific window by name. Use
     ``handle:window_name`` to join another user's shared window.
-    pre_shell, if set, is an async callable(ws) invoked after the
+    sandbox_setup, if set, is an async callable(ws) invoked after the
     workspace is ready but before the terminal starts.  Used by
     ``sandbox`` to run copy/setup on the same connection.
     """
@@ -554,10 +554,6 @@ async def _ws_shell(
     ) as ws:
         # 1. Connect to workspace
         await _wait_workspace_ready(ws, workspace_id)
-
-        # 1a. Run pre-shell hook (sandbox setup) if provided.
-        if pre_shell is not None:
-            await pre_shell(ws)
 
         # 2a. Start SSH agent forwarding if requested and available.
         ssh_agent_active = False
@@ -615,7 +611,12 @@ async def _ws_shell(
                     logger.info("[ssh-agent] timed out waiting for start")
                 pass  # proceed without agent forwarding
 
-        # 2b. Start terminal
+        # 2b. Run pre-shell hook (sandbox setup) after agent forwarding
+        # is active so that setup scripts can use SSH (e.g. git clone).
+        if sandbox_setup is not None:
+            await sandbox_setup(ws)
+
+        # 2c. Start terminal
         cols, rows = _get_terminal_size()
         start_msg: dict = {
             "cmd": "terminal_start",

--- a/src/cli/klangkc/main.py
+++ b/src/cli/klangkc/main.py
@@ -1009,7 +1009,7 @@ async def _sandbox_connect(  # pragma: no cover
         token,
         workspace_id,
         forward_agent=forward_agent,
-        pre_shell=(
+        sandbox_setup=(
             (lambda ws: _sandbox_setup(ws, config, sandbox_root, handle))
             if config
             else None

--- a/src/cli/tests/test_cli_integration.py
+++ b/src/cli/tests/test_cli_integration.py
@@ -2027,10 +2027,10 @@ class TestWsExecWrapper:
         assert code == 42
 
 
-class TestPreShellHook:
-    """Test that _ws_shell calls pre_shell before terminal_start."""
+class TestSandboxSetupHook:
+    """Test that _ws_shell calls sandbox_setup before terminal_start."""
 
-    async def test_pre_shell_called(self, tmp_path):
+    async def test_sandbox_setup_called(self, tmp_path):
         from klangkc.client import _ws_shell
 
         ws_mock = MagicMock()
@@ -2045,10 +2045,10 @@ class TestPreShellHook:
         ws_mock.__aexit__ = fake_exit
         ws_mock.send = AsyncMock()
 
-        pre_shell_called = []
+        sandbox_setup_called = []
 
-        async def fake_pre_shell(ws):
-            pre_shell_called.append(True)
+        async def fake_sandbox_setup(ws):
+            sandbox_setup_called.append(True)
 
         ws_mock.recv = AsyncMock(
             side_effect=[
@@ -2081,13 +2081,13 @@ class TestPreShellHook:
                     "ws://localhost/ws",
                     "token",
                     "ws1",
-                    pre_shell=fake_pre_shell,
+                    sandbox_setup=fake_sandbox_setup,
                 )
             except Exception:
                 pass
 
-        assert pre_shell_called == [True]
-        # Verify pre_shell ran before terminal_start
+        assert sandbox_setup_called == [True]
+        # Verify sandbox_setup ran before terminal_start
         sent = [c[0][0] for c in ws_mock.send.call_args_list]
         parsed = [json.loads(s) for s in sent]
         cmds = [m.get("cmd") for m in parsed]


### PR DESCRIPTION
## Summary
- Move sandbox setup to run after SSH agent forwarding is established, so setup scripts can use SSH (e.g. `git clone git@github.com:...`)
- Rename `pre_shell` parameter to `sandbox_setup` for clarity

## Test plan
- [x] Backend tests pass (1 pre-existing unrelated failure in `test_sudo_disabled_by_default`)
- [ ] Run `klangkc sandbox` with a config that clones via SSH and verify it works

Closes #764