### PR TITLE
fix: prevent second instance from killing first instance's containers

### DIFF
--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -1,10 +1,10 @@
 """Klangk backend: FastAPI app with HTTP + WebSocket endpoints."""
 
 import logging
+import os
 import secrets
 import sys
 from contextlib import asynccontextmanager
-
 from pathlib import Path
 
 import bcrypt
@@ -170,8 +170,74 @@ async def seed_agent_user() -> None:
     logger.info("Seeded agent user '%s' (%s)", handle, email)
 
 
+# --- PID file helpers ---
+
+
+def _pid_file_path() -> Path:
+    """Return the PID file path for this instance."""
+    run_dir = Path(f"/run/user/{os.getuid()}")
+    return run_dir / f"klangk-{container.INSTANCE_ID}.pid"
+
+
+def check_pid_file() -> int | None:
+    """Check if another instance is running.
+
+    Returns the PID of the running process, or None if no live process
+    holds the PID file.  Removes stale PID files automatically.
+    """
+    path = _pid_file_path()
+    try:
+        pid = int(path.read_text().strip())
+    except (FileNotFoundError, ValueError):
+        return None
+    try:
+        os.kill(pid, 0)
+    except (ProcessLookupError, OverflowError):
+        # Process is dead or PID is invalid — stale PID file.
+        path.unlink(missing_ok=True)
+        return None
+    except PermissionError:
+        # Process exists but we can't signal it (different user).
+        return pid
+    # Don't treat our own PID as a conflict (e.g., after a crash that
+    # left the PID file behind and the OS recycled the PID).
+    if pid == os.getpid():
+        return None
+    return pid
+
+
+def write_pid_file() -> None:
+    """Write the current PID to the instance PID file."""
+    path = _pid_file_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(str(os.getpid()))
+
+
+def remove_pid_file() -> None:
+    """Remove the PID file (best-effort)."""
+    try:
+        path = _pid_file_path()
+        # Only remove if it contains our PID (another instance may
+        # have overwritten it after we were signalled to stop).
+        if path.read_text().strip() == str(os.getpid()):
+            path.unlink()
+    except (FileNotFoundError, ValueError, OSError):
+        pass
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    existing_pid = check_pid_file()
+    if existing_pid is not None:
+        logger.error(
+            "Another klangk instance (PID %d) is already running "
+            "for instance %s — refusing to start",
+            existing_pid,
+            container.INSTANCE_ID,
+        )
+        raise SystemExit(1)
+    write_pid_file()
+
     auth.require_secure_jwt_secret()
     plugins.load()
     await model.init_db()
@@ -186,6 +252,7 @@ async def lifespan(app: FastAPI):
     logger.info("Klangk backend started")
     yield
     await container.registry.shutdown()
+    remove_pid_file()
     await model.dispose_engine()
     logger.info("Klangk backend stopped")
 

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -305,7 +305,8 @@ class TestStartContainer:
         p.start_container.assert_awaited_once_with("new-cid")
         assert workspace["id"] in container.registry.states
 
-    async def test_sudo_disabled_by_default(self, workspace):
+    async def test_sudo_disabled_by_default(self, workspace, monkeypatch):
+        monkeypatch.delenv("KLANGK_ALLOW_SUDO", raising=False)
         with patch_podman() as p:
             await container.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"

--- a/src/backend/tests/test_main.py
+++ b/src/backend/tests/test_main.py
@@ -1,7 +1,10 @@
 """Tests for main.py: lifespan, seed user, static files, logfire."""
 
+import os
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from fastapi import FastAPI
 from httpx import AsyncClient, ASGITransport
 
@@ -118,11 +121,31 @@ class TestLifespan:
                 "shutdown",
                 new_callable=AsyncMock,
             ) as mock_shutdown,
+            patch(
+                "klangk_backend.main.check_pid_file", return_value=None
+            ) as mock_check,
+            patch("klangk_backend.main.write_pid_file") as mock_write,
+            patch("klangk_backend.main.remove_pid_file") as mock_remove,
         ):
             async with main.lifespan(app):
+                mock_check.assert_called_once()
+                mock_write.assert_called_once()
                 mock_adopt.assert_awaited_once()
                 mock_start.assert_called_once()
             mock_shutdown.assert_awaited_once()
+            mock_remove.assert_called_once()
+
+    async def test_lifespan_refuses_if_pid_alive(self, db, monkeypatch):
+        monkeypatch.delenv("KLANGK_OIDC_CONFIG", raising=False)
+        monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
+        monkeypatch.delenv("KLANGK_PREVENT_INSECURE_JWT_SECRET", raising=False)
+        app = FastAPI()
+        with (
+            patch("klangk_backend.main.check_pid_file", return_value=12345),
+            pytest.raises(SystemExit),
+        ):
+            async with main.lifespan(app):
+                pass  # pragma: no cover
 
 
 # --- Static files ---
@@ -270,3 +293,82 @@ class TestCorsOrigins:
             base_url="https://custom.logfire",
             environment="staging",
         )
+
+
+# --- PID file helpers ---
+
+
+class TestPidFile:
+    def test_check_pid_file_no_file(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            main, "_pid_file_path", lambda: tmp_path / "klangk-test.pid"
+        )
+        assert main.check_pid_file() is None
+
+    def test_check_pid_file_stale_pid(self, tmp_path, monkeypatch):
+        pid_file = tmp_path / "klangk-test.pid"
+        # Use a PID that (almost certainly) doesn't exist
+        pid_file.write_text("2000000")
+        monkeypatch.setattr(main, "_pid_file_path", lambda: pid_file)
+        assert main.check_pid_file() is None
+        assert not pid_file.exists()
+
+    def test_check_pid_file_own_pid(self, tmp_path, monkeypatch):
+        pid_file = tmp_path / "klangk-test.pid"
+        pid_file.write_text(str(os.getpid()))
+        monkeypatch.setattr(main, "_pid_file_path", lambda: pid_file)
+        assert main.check_pid_file() is None
+
+    def test_check_pid_file_live_pid_permission_error(
+        self, tmp_path, monkeypatch
+    ):
+        pid_file = tmp_path / "klangk-test.pid"
+        # PID 1 (init) is always alive
+        pid_file.write_text("1")
+        monkeypatch.setattr(main, "_pid_file_path", lambda: pid_file)
+        # os.kill(1, 0) raises PermissionError for non-root
+        result = main.check_pid_file()
+        assert result == 1
+
+    def test_check_pid_file_live_foreign_pid(self, tmp_path, monkeypatch):
+        """Live PID that os.kill(pid, 0) succeeds on (not our PID)."""
+        pid_file = tmp_path / "klangk-test.pid"
+        # Use a PID we know is alive and can signal (our parent process)
+        ppid = os.getppid()
+        pid_file.write_text(str(ppid))
+        monkeypatch.setattr(main, "_pid_file_path", lambda: pid_file)
+        result = main.check_pid_file()
+        assert result == ppid
+
+    def test_check_pid_file_invalid_content(self, tmp_path, monkeypatch):
+        pid_file = tmp_path / "klangk-test.pid"
+        pid_file.write_text("not-a-number")
+        monkeypatch.setattr(main, "_pid_file_path", lambda: pid_file)
+        assert main.check_pid_file() is None
+
+    def test_write_and_remove_pid_file(self, tmp_path, monkeypatch):
+        pid_file = tmp_path / "klangk-test.pid"
+        monkeypatch.setattr(main, "_pid_file_path", lambda: pid_file)
+        main.write_pid_file()
+        assert pid_file.read_text() == str(os.getpid())
+        main.remove_pid_file()
+        assert not pid_file.exists()
+
+    def test_remove_pid_file_only_own_pid(self, tmp_path, monkeypatch):
+        pid_file = tmp_path / "klangk-test.pid"
+        pid_file.write_text("99999")
+        monkeypatch.setattr(main, "_pid_file_path", lambda: pid_file)
+        main.remove_pid_file()
+        # File should still exist — not our PID
+        assert pid_file.exists()
+
+    def test_remove_pid_file_missing(self, tmp_path, monkeypatch):
+        pid_file = tmp_path / "klangk-test.pid"
+        monkeypatch.setattr(main, "_pid_file_path", lambda: pid_file)
+        # Should not raise
+        main.remove_pid_file()
+
+    def test_pid_file_path_uses_run_dir(self):
+        path = main._pid_file_path()
+        assert path.parent == Path(f"/run/user/{os.getuid()}")
+        assert f"klangk-{main.container.INSTANCE_ID}" in path.name


### PR DESCRIPTION
## Summary

- Adds a PID file guard (`/run/user/{uid}/klangk-{instance}.pid`) at the top of the backend lifespan
- If another process with the same instance ID is alive, the new process raises `SystemExit(1)` before reaching `adopt_orphaned_containers` or `podman create --replace`
- Stale PID files (from crashed processes) are automatically cleaned up
- Also fixes `test_sudo_disabled_by_default` which was broken by `KLANGK_ALLOW_SUDO` being set in devenv

## Test plan

- [x] All 1478 backend tests pass with 100% coverage
- [ ] Manual: start klangk, run `devenv processes up` in another terminal — second backend refuses to start with clear error
- [ ] Manual: kill klangk with SIGKILL, restart — stale PID file cleaned up, starts normally

Closes #761
Closes #763