### PR TITLE
Fix token-expiry E2E test for new config/state split

### DIFF
--- a/src/frontend/e2e-tests/e2e/token-expiry.spec.ts
+++ b/src/frontend/e2e-tests/e2e/token-expiry.spec.ts
@@ -72,13 +72,17 @@ test.describe("Token expiry", () => {
       { algorithm: "HS256", expiresIn: -60 },
     );
 
-    // Write a temporary CLI config with the expired token
+    // Write temporary CLI config and state with the expired token
     const tmpHome = mkdtempSync(join(tmpdir(), "klangk-cli-e2e-"));
     const configDir = join(tmpHome, ".config", "klangk");
     mkdirSync(configDir, { recursive: true });
     writeFileSync(
       join(configDir, "cli.yaml"),
-      `server:\n  url: ${API_BASE}\nauth:\n  token: ${expiredToken}\n  email: ${email}\n`,
+      `servers:\n  test:\n    url: ${API_BASE}\n`,
+    );
+    writeFileSync(
+      join(configDir, "state.yaml"),
+      `active-server: "${API_BASE}"\n"${API_BASE}":\n  active-user: "${email}"\n  users:\n    "${email}":\n      token: ${expiredToken}\n`,
     );
 
     // Run klangkc shell — it should fail with a clear error


### PR DESCRIPTION
## Summary

- Update token-expiry E2E test to write both `cli.yaml` and `state.yaml` in the new format instead of the old single-file config
- The test was writing the old `server.url` / `auth.token` format which no longer works after #752

## Test plan

- [ ] E2E test `token-expiry.spec.ts:54` passes in CI

Fixes #767