### PR TITLE
fix: add /api/v1 prefix to OIDC callback redirect URI

### DIFF
--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -47,7 +47,7 @@ from .model import (
     PRINCIPAL_USER,
     SYSTEM_AUTHENTICATED,
 )
-from .util import derive_hosting_info, resolve_env_secret
+from .util import API_PREFIX, derive_hosting_info, resolve_env_secret
 
 logger = logging.getLogger(__name__)
 
@@ -701,9 +701,7 @@ async def oidc_login(
     state = secrets.token_urlsafe(32)
 
     hostname, proto, base_path = derive_hosting_info(request.headers)
-    redirect_uri = (
-        f"{proto}://{hostname}{base_path}/auth/oidc/{provider_id}/callback"
-    )
+    redirect_uri = f"{proto}://{hostname}{base_path}{API_PREFIX}/auth/oidc/{provider_id}/callback"
 
     auth_url = await oidc.build_auth_url(
         provider, redirect_uri, state, challenge


### PR DESCRIPTION
## Summary
- OIDC login endpoint built the redirect_uri without the `/api/v1` prefix, so the IdP redirected back to a non-existent route (`/auth/oidc/{id}/callback` instead of `/api/v1/auth/oidc/{id}/callback`)
- Use `API_PREFIX` constant to construct the correct callback URL

## Test plan
- [x] Backend tests pass (1478 passed, 100% coverage)
- [ ] Manually test OIDC login flow end-to-end

Ref #755