### PR TITLE
fix: pass SSH_AUTH_SOCK to exec sessions for sandbox setup

### DIFF
--- a/src/backend/klangk_backend/podman.py
+++ b/src/backend/klangk_backend/podman.py
@@ -297,9 +297,15 @@ async def remove_volume(name: str) -> None:
 class ExecSession:
     """Manages a podman exec session with raw stdin/stdout pipes (no PTY)."""
 
-    def __init__(self, container_id: str, user_home: str | None = None):
+    def __init__(
+        self,
+        container_id: str,
+        env: list[str] | None = None,
+        work_dir: str = "/home/work",
+    ):
         self.container_id = container_id
-        self.user_home = user_home
+        self.env = env or []
+        self.work_dir = work_dir
         self._proc: asyncio.subprocess.Process | None = None
         self._output_queue: BoundedOutputQueue[bytes] = BoundedOutputQueue(
             maxsize=64
@@ -311,10 +317,8 @@ class ExecSession:
     async def start(self, command: list[str]) -> None:
         """Start a command via podman exec with piped stdin/stdout."""
         env_flags: list[str] = []
-        work_dir = "/home/work"
-        if self.user_home is not None:
-            env_flags += ["-e", f"HOME={self.user_home}"]
-            work_dir = self.user_home
+        for entry in self.env:
+            env_flags += ["-e", entry]
         exec_cmd = [
             PODMAN_BIN,
             "exec",
@@ -323,7 +327,7 @@ class ExecSession:
             "-u",
             "klangk",
             "-w",
-            work_dir,
+            self.work_dir,
             self.container_id,
             *command,
         ]

--- a/src/backend/klangk_backend/wshandler.py
+++ b/src/backend/klangk_backend/wshandler.py
@@ -1784,7 +1784,14 @@ class Connection:
         if not command:
             send_error(self.sock, "exec_start requires a command list")
             return
-        session = ExecSession(self.container_id, user_home=self._user_home)
+        env: list[str] = []
+        work_dir = "/home/work"
+        if self._user_home is not None:
+            env.append(f"HOME={self._user_home}")
+            work_dir = self._user_home
+        if self._ssh_agent_socket is not None:
+            env.append(f"SSH_AUTH_SOCK={self._ssh_agent_socket}")
+        session = ExecSession(self.container_id, env=env, work_dir=work_dir)
         await session.start(command)
         self.exec_session = session
         self.exec_task = asyncio.create_task(self.forward_exec_output(session))

--- a/src/backend/tests/test_podman_exec.py
+++ b/src/backend/tests/test_podman_exec.py
@@ -329,7 +329,11 @@ class TestExecSession:
         assert cmd[w_idx + 1] == "/home/work"
 
     async def test_user_home_sets_env_and_work_dir(self):
-        session = ExecSession("cid", user_home="/home/alice")
+        session = ExecSession(
+            "cid",
+            env=["HOME=/home/alice"],
+            work_dir="/home/alice",
+        )
         proc = _mock_proc(b"")
         with patch(
             "asyncio.create_subprocess_exec",
@@ -351,3 +355,18 @@ class TestExecSession:
             await session.start(["echo"])
         cmd = mock_exec.call_args[0]
         assert not any(str(a).startswith("HOME=") for a in cmd)
+
+    async def test_ssh_agent_socket_in_env(self):
+        session = ExecSession(
+            "cid",
+            env=["HOME=/home/alice", "SSH_AUTH_SOCK=/tmp/agent.sock"],
+            work_dir="/home/alice",
+        )
+        proc = _mock_proc(b"")
+        with patch(
+            "asyncio.create_subprocess_exec",
+            return_value=proc,
+        ) as mock_exec:
+            await session.start(["echo"])
+        cmd = mock_exec.call_args[0]
+        assert "SSH_AUTH_SOCK=/tmp/agent.sock" in cmd

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -2074,6 +2074,40 @@ class TestExecHandlers:
         except asyncio.CancelledError:
             pass
 
+    async def test_exec_start_passes_ssh_agent_socket(self):
+        sock = _mock_sock()
+        conn = _base_conn(ws=sock)
+        conn.container_id = "cid"
+        conn._user_home = "/home/admin"
+        conn._ssh_agent_socket = "/tmp/agent.sock"
+        mock_session = AsyncMock()
+        mock_session.start = AsyncMock()
+
+        async def empty_output():
+            return
+            yield  # pragma: no cover
+
+        mock_session.output = empty_output
+        mock_session.returncode = 0
+        with patch(
+            "klangk_backend.wshandler.ExecSession",
+            return_value=mock_session,
+        ) as mock_cls:
+            with patch.object(container.registry, "record_activity"):
+                with patch.object(
+                    conn, "_has_perm", new=AsyncMock(return_value=True)
+                ):
+                    await conn.handle_exec_start({"command": ["ls"]})
+        call_kwargs = mock_cls.call_args[1]
+        assert "SSH_AUTH_SOCK=/tmp/agent.sock" in call_kwargs["env"]
+        assert "HOME=/home/admin" in call_kwargs["env"]
+        assert call_kwargs["work_dir"] == "/home/admin"
+        conn.exec_task.cancel()
+        try:
+            await conn.exec_task
+        except asyncio.CancelledError:
+            pass
+
     async def test_exec_input_sends_data(self):
         import base64
 


### PR DESCRIPTION
## Summary

- `ExecSession` (used by sandbox setup) did not pass `SSH_AUTH_SOCK` to `podman exec`, so setup scripts cloning via SSH failed even when agent forwarding was active
- Refactored `ExecSession` to accept a generic `env` list and `work_dir` instead of `user_home`/`ssh_agent_socket` fields — the caller (`handle_exec_start`) builds the env, same pattern as terminal sessions
- `handle_exec_start` now includes `SSH_AUTH_SOCK` when the connection has an active SSH agent

## Test plan

- [x] All 1480 backend tests pass with 100% coverage
- [x] Manual: `klangkc sandbox hr` with `forward-agent: true` in cli.yaml — git clone via SSH succeeds during setup

Closes #770