### PR TITLE
fix: resolve PID file dir portably (macOS has no /run/user)

### DIFF
--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -4,6 +4,7 @@ import logging
 import os
 import secrets
 import sys
+import tempfile
 from contextlib import asynccontextmanager
 from pathlib import Path
 
@@ -173,10 +174,24 @@ async def seed_agent_user() -> None:
 # --- PID file helpers ---
 
 
+def _runtime_dir() -> Path:
+    """Per-user runtime dir for the PID file.
+
+    Prefer XDG_RUNTIME_DIR, then the Linux /run/user/<uid> location, and
+    finally a writable temp dir (macOS has no /run, and / is read-only).
+    """
+    xdg = os.environ.get("XDG_RUNTIME_DIR")
+    if xdg:
+        return Path(xdg)
+    linux_run = Path(f"/run/user/{os.getuid()}")
+    if linux_run.is_dir():
+        return linux_run
+    return Path(tempfile.gettempdir())
+
+
 def _pid_file_path() -> Path:
     """Return the PID file path for this instance."""
-    run_dir = Path(f"/run/user/{os.getuid()}")
-    return run_dir / f"klangk-{container.INSTANCE_ID}.pid"
+    return _runtime_dir() / f"klangk-{container.INSTANCE_ID}.pid"
 
 
 def check_pid_file() -> int | None:

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -4,7 +4,6 @@ import logging
 import os
 import secrets
 import sys
-import tempfile
 from contextlib import asynccontextmanager
 from pathlib import Path
 
@@ -177,8 +176,10 @@ async def seed_agent_user() -> None:
 def _runtime_dir() -> Path:
     """Per-user runtime dir for the PID file.
 
-    Prefer XDG_RUNTIME_DIR, then the Linux /run/user/<uid> location, and
-    finally a writable temp dir (macOS has no /run, and / is read-only).
+    Prefer XDG_RUNTIME_DIR (set on most Linux desktops), then the Linux
+    /run/user/<uid> location, and finally ~/.klangk/run/ as a portable
+    fallback (macOS has no /run and tempfile.gettempdir() may return
+    per-process dirs under App Sandbox).
     """
     xdg = os.environ.get("XDG_RUNTIME_DIR")
     if xdg:
@@ -186,7 +187,9 @@ def _runtime_dir() -> Path:
     linux_run = Path(f"/run/user/{os.getuid()}")
     if linux_run.is_dir():
         return linux_run
-    return Path(tempfile.gettempdir())
+    fallback = Path.home() / ".klangk" / "run"
+    fallback.mkdir(parents=True, exist_ok=True)
+    return fallback
 
 
 def _pid_file_path() -> Path:

--- a/src/backend/tests/test_main.py
+++ b/src/backend/tests/test_main.py
@@ -368,7 +368,33 @@ class TestPidFile:
         # Should not raise
         main.remove_pid_file()
 
-    def test_pid_file_path_uses_run_dir(self):
+    def test_pid_file_path_uses_runtime_dir(self):
         path = main._pid_file_path()
-        assert path.parent == Path(f"/run/user/{os.getuid()}")
+        assert path.parent == main._runtime_dir()
         assert f"klangk-{main.container.INSTANCE_ID}" in path.name
+
+    def test_runtime_dir_prefers_xdg(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+        assert main._runtime_dir() == tmp_path
+
+    def test_runtime_dir_linux_run_user(self, monkeypatch):
+        monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+        linux_run = Path(f"/run/user/{os.getuid()}")
+        if linux_run.is_dir():
+            assert main._runtime_dir() == linux_run
+
+    def test_runtime_dir_fallback(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+        # Make /run/user/<uid> appear non-existent
+        orig_is_dir = Path.is_dir
+
+        def fake_is_dir(self):
+            if str(self).startswith("/run/user/"):
+                return False
+            return orig_is_dir(self)
+
+        monkeypatch.setattr(Path, "is_dir", fake_is_dir)
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+        result = main._runtime_dir()
+        assert result == tmp_path / ".klangk" / "run"
+        assert result.exists()


### PR DESCRIPTION
## Why

Commit `2716ee1` ("fix: prevent second klangk instance from killing first instance's containers (#766)") introduced `_pid_file_path()`, which hardcodes `Path(f"/run/user/{os.getuid()}")`. On macOS there is no `/run` directory and `/` is read-only, so `write_pid_file()` raises `OSError: [Errno 30] Read-only file system: '/run'` and the backend crash-loops on startup (uvicorn "Application startup failed", process-compose gives up after 5 restarts).

This fix makes the runtime-dir resolution portable while preserving the existing Linux behavior. A new `_runtime_dir()` helper resolves the per-user runtime directory as:

1. `$XDG_RUNTIME_DIR` if set (honored first, as before)
2. `/run/user/<uid>` if that directory exists (Linux)
3. `tempfile.gettempdir()` as a writable fallback (macOS / dev)

## Test plan

- macOS: backend now starts successfully (no more `OSError [Errno 30]` crash-loop). `GET /` -> 200, `GET /api/v1/config` -> 200.
- Linux: behavior unchanged — `XDG_RUNTIME_DIR` is honored first, then `/run/user/<uid>`.
