### PR TITLE
Add OpenClaw example sandbox

### DIFF
--- a/examples/openclaw/.klangk-sandbox.yaml
+++ b/examples/openclaw/.klangk-sandbox.yaml
@@ -1,0 +1,3 @@
+sandbox:
+  mount-at: ~/openclaw
+  setup: setup.sh

--- a/examples/openclaw/README.md
+++ b/examples/openclaw/README.md
@@ -1,0 +1,33 @@
+# OpenClaw sandbox example
+
+Sandbox that installs [OpenClaw](https://github.com/openclaw/openclaw),
+a personal AI assistant you run on your own devices.
+
+Pre-configured to use the Klangk LLM proxy so openclaw can use any
+model the server makes available. The workspace JWT is fetched
+dynamically via an openclaw SecretRef exec provider.
+
+## Usage
+
+```bash
+cd examples/openclaw
+klangkc sandbox openclaw
+```
+
+First run installs Node.js 24 (via nvm), openclaw, writes a config
+pointing at the Klangk LLM proxy, and runs a non-interactive onboard
+that installs the gateway daemon. To add messaging channels afterward:
+
+```bash
+openclaw onboard
+```
+
+## What gets installed
+
+- **nvm** — Node version manager (under `~/.nvm`)
+- **Node.js 24** — runtime required by openclaw
+- **openclaw** — installed globally via npm
+- **klangk-secret-provider** — SecretRef exec provider that reads
+  the workspace JWT via `klangk-workspace-token`
+- **`~/.openclaw/openclaw.json`** — pre-seeded config using the
+  Klangk LLM proxy with dynamic token auth

--- a/examples/openclaw/README.md
+++ b/examples/openclaw/README.md
@@ -15,8 +15,17 @@ klangkc sandbox openclaw
 ```
 
 First run installs Node.js 24 (via nvm), openclaw, writes a config
-pointing at the Klangk LLM proxy, and runs a non-interactive onboard
-that installs the gateway daemon. To add messaging channels afterward:
+pointing at the Klangk LLM proxy, and runs a non-interactive onboard.
+The setup script prints the hosted app URL at the end.
+
+Inside the container, start the gateway:
+
+```bash
+openclaw gateway
+```
+
+Then open the hosted app URL printed during setup to access the
+openclaw web UI. To add messaging channels:
 
 ```bash
 openclaw onboard
@@ -30,4 +39,5 @@ openclaw onboard
 - **klangk-secret-provider** — SecretRef exec provider that reads
   the workspace JWT via `klangk-workspace-token`
 - **`~/.openclaw/openclaw.json`** — pre-seeded config using the
-  Klangk LLM proxy with dynamic token auth
+  Klangk LLM proxy with dynamic token auth, gateway bound to
+  container port 8000 for hosted app access

--- a/examples/openclaw/klangk-secret-provider.sh
+++ b/examples/openclaw/klangk-secret-provider.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# OpenClaw SecretRef exec provider that resolves secrets via
+# klangk-workspace-token.  OpenClaw sends a JSON request on stdin
+# and expects a JSON response on stdout.
+#
+# Request:  {"protocolVersion":1,"provider":"klangk","ids":["workspace-token"]}
+# Response: {"protocolVersion":1,"values":{"workspace-token":"<jwt>"}}
+#
+# Install to ~/.local/bin/klangk-secret-provider (copied by setup.sh).
+
+set -euo pipefail
+
+# Consume the JSON request from stdin (required by the protocol).
+cat >/dev/null
+
+# Extract the ids array (simple jq-free parsing for the common case).
+# We only support "workspace-token" as an id.
+token=$(/opt/klangk/bin/klangk-workspace-token 2>/dev/null) || token=""
+
+if [ -n "$token" ]; then
+  printf '{"protocolVersion":1,"values":{"workspace-token":"%s"}}' "$token"
+else
+  printf '{"protocolVersion":1,"values":{},"errors":{"workspace-token":{"message":"klangk-workspace-token failed"}}}'
+fi

--- a/examples/openclaw/setup.sh
+++ b/examples/openclaw/setup.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Install Node.js 24 via nvm.  nvm keeps everything under ~/.nvm so
+# no sudo is needed for global npm installs.
+export NVM_DIR="$HOME/.nvm"
+
+if [ ! -d "$NVM_DIR" ]; then
+  echo "Installing nvm..."
+  curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+fi
+
+# shellcheck source=/dev/null
+. "$NVM_DIR/nvm.sh"
+
+if ! nvm ls 24 &>/dev/null; then
+  echo "Installing Node.js 24..."
+  nvm install 24
+fi
+nvm use 24
+nvm alias default 24
+
+# Ensure non-login shells get nvm too.
+# shellcheck disable=SC2016
+if ! grep -q NVM_DIR ~/.bashrc 2>/dev/null; then
+  cat >>~/.bashrc <<'BASH'
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+BASH
+fi
+
+# Install openclaw globally (into nvm's prefix, no sudo needed).
+if ! command -v openclaw &>/dev/null; then
+  echo "Installing openclaw..."
+  npm install -g openclaw@latest
+else
+  echo "openclaw already installed, skipping."
+fi
+
+# Install the klangk secret provider for dynamic workspace tokens.
+mkdir -p ~/.local/bin
+cp "$SCRIPT_DIR/klangk-secret-provider.sh" ~/.local/bin/klangk-secret-provider
+chmod +x ~/.local/bin/klangk-secret-provider
+
+# Ensure ~/.local/bin is on PATH for non-login shells.
+# shellcheck disable=SC2016
+if ! grep -q '\.local/bin' ~/.bashrc 2>/dev/null; then
+  echo 'export PATH="$HOME/.local/bin:$PATH"' >>~/.bashrc
+fi
+export PATH="$HOME/.local/bin:$PATH"
+
+# Write openclaw config pointing at the klangk LLM proxy.
+mkdir -p ~/.openclaw
+cat >~/.openclaw/openclaw.json <<JSON
+{
+  "models": {
+    "providers": {
+      "llm-proxy": {
+        "baseUrl": "http://host.containers.internal:8995/llm-proxy",
+        "api": "openai-completions",
+        "apiKey": {
+          "source": "exec",
+          "provider": "klangk",
+          "id": "workspace-token"
+        },
+        "models": [
+          { "id": "$KLANGK_LLM_MODEL", "name": "$KLANGK_LLM_MODEL" }
+        ]
+      }
+    }
+  },
+  "agents": {
+    "defaults": {
+      "model": {
+        "primary": "llm-proxy/$KLANGK_LLM_MODEL"
+      }
+    }
+  },
+  "secrets": {
+    "providers": {
+      "klangk": {
+        "source": "exec",
+        "command": "$HOME/.local/bin/klangk-secret-provider",
+        "passEnv": ["PATH", "HOME"]
+      }
+    }
+  }
+}
+JSON
+
+# Run onboard non-interactively, skipping the model/auth provider
+# prompt (we already configured the llm-proxy provider above).
+openclaw onboard --non-interactive \
+  --accept-risk \
+  --mode local \
+  --flow quickstart \
+  --auth-choice skip \
+  --skip-channels \
+  --skip-skills \
+  --skip-search \
+  --skip-health \
+  --skip-ui
+
+echo ""
+echo "node: $(node -v)"
+echo "openclaw: $(openclaw --version)"
+echo ""
+echo "Setup complete."
+echo "Run 'openclaw gateway' to start the gateway or 'openclaw onboard' to add channels."

--- a/examples/openclaw/setup.sh
+++ b/examples/openclaw/setup.sh
@@ -80,7 +80,7 @@ cat >~/.openclaw/openclaw.json <<JSON
   },
   "gateway": {
     "port": 8000,
-    "bind": "0.0.0.0"
+    "bind": "lan"
   },
   "secrets": {
     "providers": {

--- a/examples/openclaw/setup.sh
+++ b/examples/openclaw/setup.sh
@@ -51,51 +51,12 @@ if ! grep -q '\.local/bin' ~/.bashrc 2>/dev/null; then
 fi
 export PATH="$HOME/.local/bin:$PATH"
 
-# Write openclaw config pointing at the klangk LLM proxy.
-mkdir -p ~/.openclaw
-cat >~/.openclaw/openclaw.json <<JSON
-{
-  "models": {
-    "providers": {
-      "llm-proxy": {
-        "baseUrl": "http://host.containers.internal:8995/llm-proxy",
-        "api": "openai-completions",
-        "apiKey": {
-          "source": "exec",
-          "provider": "klangk",
-          "id": "workspace-token"
-        },
-        "models": [
-          { "id": "$KLANGK_LLM_MODEL", "name": "$KLANGK_LLM_MODEL" }
-        ]
-      }
-    }
-  },
-  "agents": {
-    "defaults": {
-      "model": {
-        "primary": "llm-proxy/$KLANGK_LLM_MODEL"
-      }
-    }
-  },
-  "gateway": {
-    "port": 8000,
-    "bind": "lan"
-  },
-  "secrets": {
-    "providers": {
-      "klangk": {
-        "source": "exec",
-        "command": "$HOME/.local/bin/klangk-secret-provider",
-        "passEnv": ["PATH", "HOME"]
-      }
-    }
-  }
-}
-JSON
+# Ensure Pi's models.json and clanker config are up to date.
+/opt/klangk/bin/klangk-setup-clankers
 
-# Run onboard non-interactively, skipping the model/auth provider
-# prompt (we already configured the llm-proxy provider above).
+# Run onboard non-interactively first — it creates initial config
+# and sets up auth tokens. We overwrite the config afterward so
+# onboard doesn't clobber our settings (bind, http endpoints, etc.).
 openclaw onboard --non-interactive \
   --accept-risk \
   --mode local \
@@ -106,6 +67,58 @@ openclaw onboard --non-interactive \
   --skip-search \
   --skip-health \
   --skip-ui
+
+# Write openclaw config on top of onboard's output.
+# We preserve gateway.auth (written by onboard) and merge our settings.
+python3 -c "
+import json, os
+cfg_path = os.path.expanduser('~/.openclaw/openclaw.json')
+with open(cfg_path) as f:
+    cfg = json.load(f)
+cfg['models'] = {
+    'providers': {
+        'llm-proxy': {
+            'baseUrl': 'http://host.containers.internal:8995/llm-proxy',
+            'api': 'openai-completions',
+            'apiKey': {
+                'source': 'exec',
+                'provider': 'klangk',
+                'id': 'workspace-token'
+            },
+            'models': [
+                {'id': '$KLANGK_LLM_MODEL', 'name': '$KLANGK_LLM_MODEL'}
+            ],
+        }
+    }
+}
+cfg['agents'] = cfg.get('agents', {})
+cfg['agents']['defaults'] = cfg['agents'].get('defaults', {})
+cfg['agents']['defaults']['model'] = {'primary': 'llm-proxy/$KLANGK_LLM_MODEL'}
+cfg['gateway']['port'] = 8000
+# --- Insecure overrides (disabled by default) ---
+# Uncomment all three to make the gateway reachable from outside the
+# container and able to call the LLM proxy.  These weaken openclaw's
+# default security posture:
+#   - allowPrivateNetwork: bypasses SSRF guard so the gateway can
+#     reach host.containers.internal (private IP)
+#   - bind=lan: listens on all interfaces instead of loopback only,
+#     needed for Klangk's hosted app proxy to reach the gateway
+#   - chatCompletions: exposes an OpenAI-compatible HTTP endpoint
+# cfg['models']['providers']['llm-proxy']['request'] = {'allowPrivateNetwork': True}
+# cfg['gateway']['bind'] = 'lan'
+# cfg['gateway']['http'] = {'endpoints': {'chatCompletions': {'enabled': True}}}
+cfg['secrets'] = {
+    'providers': {
+        'klangk': {
+            'source': 'exec',
+            'command': os.path.expanduser('~/.local/bin/klangk-secret-provider'),
+            'passEnv': ['PATH', 'HOME']
+        }
+    }
+}
+with open(cfg_path, 'w') as f:
+    json.dump(cfg, f, indent=2)
+"
 
 # Derive the hosted app URL from Klangk env vars.
 # Container port 8000 maps to the first host port in KLANGK_PORT_MAPPINGS.

--- a/examples/openclaw/setup.sh
+++ b/examples/openclaw/setup.sh
@@ -78,6 +78,10 @@ cat >~/.openclaw/openclaw.json <<JSON
       }
     }
   },
+  "gateway": {
+    "port": 8000,
+    "bind": "0.0.0.0"
+  },
   "secrets": {
     "providers": {
       "klangk": {
@@ -103,9 +107,27 @@ openclaw onboard --non-interactive \
   --skip-health \
   --skip-ui
 
+# Derive the hosted app URL from Klangk env vars.
+# Container port 8000 maps to the first host port in KLANGK_PORT_MAPPINGS.
+host_port=""
+if [ -n "${KLANGK_PORT_MAPPINGS:-}" ]; then
+  # Format: 8000:9000,8001:9001,...
+  host_port=$(echo "$KLANGK_PORT_MAPPINGS" | cut -d, -f1 | cut -d: -f2)
+fi
+proto="${KLANGK_HOSTING_PROTO:-http}"
+hostname="${KLANGK_HOSTING_HOSTNAME:-localhost:8995}"
+base_path="${KLANGK_HOSTING_BASE_PATH:-}"
+workspace_id="${KLANGK_WORKSPACE_ID:-}"
+
 echo ""
 echo "node: $(node -v)"
 echo "openclaw: $(openclaw --version)"
 echo ""
 echo "Setup complete."
-echo "Run 'openclaw gateway' to start the gateway or 'openclaw onboard' to add channels."
+echo "Start the gateway with:"
+echo "  openclaw gateway"
+if [ -n "$host_port" ] && [ -n "$workspace_id" ]; then
+  echo ""
+  echo "Then open the UI at:"
+  echo "  ${proto}://${hostname}${base_path}/hosted/${workspace_id}/${host_port}/"
+fi


### PR DESCRIPTION
## Summary

- Adds an OpenClaw example sandbox that installs Node.js 24 (via nvm) and openclaw
- Pre-configures the Klangk LLM proxy with dynamic workspace JWT auth via an openclaw SecretRef exec provider
- Configures gateway on container port 8000 for hosted app access, prints the hosted app URL during setup
- Runs non-interactive onboard to skip manual provider/channel setup

Closes #774