### PR TITLE
fix: relay SSH agent during sandbox setup exec sessions

### DIFF
--- a/docs/features/sandbox.md
+++ b/docs/features/sandbox.md
@@ -66,12 +66,14 @@ specified as a positional argument on the command line.
 sandbox:
   mount-at: ~/klangk
   setup: setup.sh
+  setup-timeout: 300
 ```
 
-| Field      | Required | Default  | Description                                                                                                |
-| ---------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------- |
-| `mount-at` | no       | `~/work` | Where the sandbox root is mounted inside the container. `~` expands to `/home/{handle}`.                   |
-| `setup`    | no       | (none)   | Script to run inside the container after creation. Relative to `mount-at`, or absolute if starts with `/`. |
+| Field           | Required | Default  | Description                                                                                                |
+| --------------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------- |
+| `mount-at`      | no       | `~/work` | Where the sandbox root is mounted inside the container. `~` expands to `/home/{handle}`.                   |
+| `setup`         | no       | (none)   | Script to run inside the container after creation. Relative to `mount-at`, or absolute if starts with `/`. |
+| `setup-timeout` | no       | `300`    | Maximum seconds the setup script may run before being killed. Set to `0` to disable.                       |
 
 The setup script runs once — on workspace creation, not on reconnect.
 It runs as the `klangk` user inside the container. If
@@ -210,6 +212,12 @@ or re-run the setup script. This means:
 The setup script runs inside the container as the `klangk` user. It
 has access to everything that's been mounted and copied. The working
 directory is the sandbox root (the `mount-at` path).
+
+**SSH agent forwarding** is active during setup when `-A` /
+`--forward-agent` is used. This means `git clone git@github.com:...`
+and other SSH operations work in your setup script without any extra
+configuration. SSH host key checking is set to `accept-new` during
+setup (new hosts are automatically trusted on first connect).
 
 **Important:** The `klangk` user does not have sudo access by
 default. Without it, setup scripts are limited to user-space

--- a/examples/haiku-rag/.klangk-sandbox.yaml
+++ b/examples/haiku-rag/.klangk-sandbox.yaml
@@ -1,3 +1,3 @@
 sandbox:
-  mount_at: ~/haiku-rag
+  mount-at: ~/haiku-rag
   setup: setup.sh

--- a/src/cli/klangkc/client.py
+++ b/src/cli/klangkc/client.py
@@ -1047,6 +1047,7 @@ async def _exec_on_ws(
     command: list[str],
     stdin: io.RawIOBase | None = None,
     stdout: io.RawIOBase | None = None,
+    timeout: int | None = None,
 ) -> int:
     """Run a command on an already-connected WebSocket.
 
@@ -1060,6 +1061,10 @@ async def _exec_on_ws(
     *stdout*: file-like to write output to.  ``None`` discards output.
     For a real terminal pass ``sys.stdout.buffer``; for capture pass
     an ``io.BytesIO()``.
+
+    *timeout*: optional seconds; if the command doesn't finish in
+    time, it is stopped and exit code 124 is returned (matching
+    coreutils ``timeout(1)``).
 
     Returns the remote process exit code.
     """
@@ -1112,6 +1117,8 @@ async def _exec_on_ws(
                 )
         await ws.send(json.dumps({"cmd": "exec_close_stdin"}))
 
+    agent_queue: asyncio.Queue[bytes] = asyncio.Queue()
+
     async def stdout_forward() -> None:
         nonlocal exit_code
         while True:
@@ -1130,6 +1137,10 @@ async def _exec_on_ws(
                         )
                     else:
                         stdout.write(raw)
+            elif data.get("type") == "ssh_agent_response":
+                raw = base64.b64decode(data.get("data", ""))
+                if raw:
+                    await agent_queue.put(raw)
             elif data.get("type") == "exec_exit":
                 exit_code = data.get("code", 0)
                 break
@@ -1151,6 +1162,60 @@ async def _exec_on_ws(
             if not stop.is_set():
                 await ws.send(json.dumps({"cmd": "heartbeat"}))
 
+    async def ssh_agent_relay() -> None:
+        """Relay SSH agent protocol between container and local agent.
+
+        Without this, git-over-SSH during exec sessions hangs because
+        the container's SSH process talks to the forwarded agent socket
+        (socat) which relays through the backend to us, but nobody
+        reads the response and forwards it to the real local agent.
+        """
+        local_sock = os.environ.get("SSH_AUTH_SOCK")
+        if not local_sock or not os.path.exists(local_sock):
+            return
+        while not stop.is_set():
+            try:
+                data = await asyncio.wait_for(agent_queue.get(), timeout=1.0)
+            except asyncio.TimeoutError:
+                continue
+            try:
+                agent = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                try:
+                    agent.connect(local_sock)
+                    agent.sendall(data)
+                    header = b""
+                    while len(header) < 4:
+                        chunk = agent.recv(4 - len(header))
+                        if not chunk:  # pragma: no cover
+                            break
+                        header += chunk
+                    if len(header) == 4:
+                        msg_len = struct.unpack(">I", header)[0]
+                        body = b""
+                        while len(body) < msg_len:
+                            chunk = agent.recv(msg_len - len(body))
+                            if not chunk:  # pragma: no cover
+                                break
+                            body += chunk
+                        response = header + body
+                        await ws.send(
+                            json.dumps(
+                                {
+                                    "cmd": "ssh_agent_data",
+                                    "data": base64.b64encode(response).decode(
+                                        "ascii"
+                                    ),
+                                }
+                            )
+                        )
+                finally:
+                    agent.close()
+            except OSError:
+                logger.debug(
+                    "SSH agent relay: failed to contact local agent",
+                    exc_info=True,
+                )
+
     stdout_fd = -1
     try:
         if stdout is not None:
@@ -1162,7 +1227,19 @@ async def _exec_on_ws(
     stdout_task = asyncio.create_task(stdout_forward())
     stdin_task = asyncio.create_task(stdin_forward())
     heartbeat_task = asyncio.create_task(heartbeat_loop())
-    await stdout_task
+    agent_task = asyncio.create_task(ssh_agent_relay())
+    try:
+        if timeout is not None:
+            await asyncio.wait_for(stdout_task, timeout=timeout)
+        else:
+            await stdout_task
+    except asyncio.TimeoutError:
+        exit_code = 124  # same as coreutils timeout(1)
+        stdout_task.cancel()
+        try:
+            await stdout_task
+        except asyncio.CancelledError:
+            pass
     stop.set()
     try:
         await asyncio.wait_for(stdin_task, timeout=2)
@@ -1176,6 +1253,11 @@ async def _exec_on_ws(
     try:
         await heartbeat_task
     except asyncio.CancelledError:  # pragma: no cover
+        pass
+    agent_task.cancel()
+    try:
+        await agent_task
+    except asyncio.CancelledError:
         pass
 
     await ws.send(json.dumps({"cmd": "exec_stop"}))

--- a/src/cli/klangkc/client.py
+++ b/src/cli/klangkc/client.py
@@ -35,6 +35,38 @@ _RETRY_BACKOFF = 2.0  # seconds, doubled each retry
 _WS_CONNECT_TIMEOUT = 60  # seconds to wait for workspace_ready
 
 
+def _query_local_ssh_agent(sock_path: str, data: bytes) -> bytes | None:
+    """Send *data* to the local SSH agent and return its response.
+
+    Connects to the Unix socket at *sock_path*, writes *data*, then
+    reads one SSH agent protocol message (4-byte big-endian length
+    prefix followed by the message body).  Returns the full response
+    (header + body) or ``None`` on failure.
+    """
+    agent = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        agent.connect(sock_path)
+        agent.sendall(data)
+        header = b""
+        while len(header) < 4:
+            chunk = agent.recv(4 - len(header))
+            if not chunk:  # pragma: no cover
+                break
+            header += chunk
+        if len(header) < 4:  # pragma: no cover
+            return None
+        msg_len = struct.unpack(">I", header)[0]
+        body = b""
+        while len(body) < msg_len:
+            chunk = agent.recv(msg_len - len(body))
+            if not chunk:  # pragma: no cover
+                break
+            body += chunk
+        return header + body
+    finally:
+        agent.close()
+
+
 async def _wait_workspace_ready(
     ws: websockets.ClientConnection,
     workspace_id: str,
@@ -973,66 +1005,26 @@ async def _run_shell(
                     "[ssh-agent] relay: got %d bytes from queue", len(data)
                 )
             try:
-                # Connect to local agent, forward data, read response.
-                agent = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-                try:
-                    agent.connect(ssh_agent_sock)
+                response = _query_local_ssh_agent(ssh_agent_sock, data)
+                if response is not None:
                     if _debug_agent:  # pragma: no cover
                         logger.info(
-                            "[ssh-agent] relay: connected to local agent"
+                            "[ssh-agent] relay: sending %d bytes back "
+                            "to backend",
+                            len(response),
                         )
-                    agent.sendall(data)
-                    if _debug_agent:  # pragma: no cover
-                        logger.info(
-                            "[ssh-agent] relay: sent %d bytes to local agent",
-                            len(data),
+                    await ws.send(
+                        json.dumps(
+                            {
+                                "cmd": "ssh_agent_data",
+                                "data": base64.b64encode(response).decode(
+                                    "ascii"
+                                ),
+                            }
                         )
-                    # SSH agent protocol: 4-byte big-endian length prefix
-                    # followed by the message body.
-                    header = b""
-                    while len(header) < 4:
-                        chunk = agent.recv(4 - len(header))
-                        if not chunk:  # pragma: no cover
-                            break
-                        header += chunk
-                    if len(header) == 4:
-                        msg_len = struct.unpack(">I", header)[0]
-                        if _debug_agent:  # pragma: no cover
-                            logger.info(
-                                "[ssh-agent] relay: agent response header, "
-                                "body_len=%d",
-                                msg_len,
-                            )
-                        body = b""
-                        while len(body) < msg_len:
-                            chunk = agent.recv(msg_len - len(body))
-                            if not chunk:  # pragma: no cover
-                                break
-                            body += chunk
-                        response = header + body
-                        if _debug_agent:  # pragma: no cover
-                            logger.info(
-                                "[ssh-agent] relay: sending %d bytes back "
-                                "to backend",
-                                len(response),
-                            )
-                        await ws.send(
-                            json.dumps(
-                                {
-                                    "cmd": "ssh_agent_data",
-                                    "data": base64.b64encode(response).decode(
-                                        "ascii"
-                                    ),
-                                }
-                            )
-                        )
-                    elif _debug_agent:  # pragma: no cover
-                        logger.info(
-                            "[ssh-agent] relay: incomplete header (%d bytes)",
-                            len(header),
-                        )
-                finally:
-                    agent.close()
+                    )
+                elif _debug_agent:  # pragma: no cover
+                    logger.info("[ssh-agent] relay: no response from agent")
             except (OSError, ConnectionError) as e:
                 logger.warning("SSH agent relay: %s", e)
 
@@ -1179,37 +1171,18 @@ async def _exec_on_ws(
             except asyncio.TimeoutError:
                 continue
             try:
-                agent = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-                try:
-                    agent.connect(local_sock)
-                    agent.sendall(data)
-                    header = b""
-                    while len(header) < 4:
-                        chunk = agent.recv(4 - len(header))
-                        if not chunk:  # pragma: no cover
-                            break
-                        header += chunk
-                    if len(header) == 4:
-                        msg_len = struct.unpack(">I", header)[0]
-                        body = b""
-                        while len(body) < msg_len:
-                            chunk = agent.recv(msg_len - len(body))
-                            if not chunk:  # pragma: no cover
-                                break
-                            body += chunk
-                        response = header + body
-                        await ws.send(
-                            json.dumps(
-                                {
-                                    "cmd": "ssh_agent_data",
-                                    "data": base64.b64encode(response).decode(
-                                        "ascii"
-                                    ),
-                                }
-                            )
+                response = _query_local_ssh_agent(local_sock, data)
+                if response is not None:
+                    await ws.send(
+                        json.dumps(
+                            {
+                                "cmd": "ssh_agent_data",
+                                "data": base64.b64encode(response).decode(
+                                    "ascii"
+                                ),
+                            }
                         )
-                finally:
-                    agent.close()
+                    )
             except OSError:
                 logger.debug(
                     "SSH agent relay: failed to contact local agent",

--- a/src/cli/klangkc/main.py
+++ b/src/cli/klangkc/main.py
@@ -871,12 +871,25 @@ async def _sandbox_setup(ws, config, sandbox_root, handle):
     if setup_cmd:
         mount_at = expand_container_path(config.mount_at, handle)
         _err.print(f"[dim]setup:[/dim] {setup_cmd}")
+        # Set GIT_SSH_COMMAND so SSH accepts new host keys automatically.
+        # Setup runs non-interactively (no TTY), so SSH cannot prompt the
+        # user for host-key confirmation; without this, git-over-SSH hangs
+        # indefinitely waiting for input that will never arrive.
+        shell_cmd = (
+            "export GIT_SSH_COMMAND="
+            "'ssh -o StrictHostKeyChecking=accept-new'"
+            f" && cd {mount_at} && bash {setup_cmd}"
+        )
+        timeout = config.setup_timeout or None
         exit_code = await _exec_on_ws(
             ws,
-            ["sh", "-c", f"cd {mount_at} && bash {setup_cmd}"],
+            ["sh", "-c", shell_cmd],
             stdout=sys.stderr.buffer,
+            timeout=timeout,
         )
-        if exit_code != 0:
+        if exit_code == 124:
+            _err.print(f"[yellow]Setup timed out after {timeout}s[/yellow]")
+        elif exit_code != 0:
             _err.print(f"[yellow]Setup exited with code {exit_code}[/yellow]")
 
 

--- a/src/cli/klangkc/main.py
+++ b/src/cli/klangkc/main.py
@@ -878,7 +878,7 @@ async def _sandbox_setup(ws, config, sandbox_root, handle):
         shell_cmd = (
             "export GIT_SSH_COMMAND="
             "'ssh -o StrictHostKeyChecking=accept-new'"
-            f" && cd {mount_at} && {setup_cmd}"
+            f" && cd {mount_at} && sh {setup_cmd}"
         )
         timeout = config.setup_timeout or None
         exit_code = await _exec_on_ws(

--- a/src/cli/klangkc/main.py
+++ b/src/cli/klangkc/main.py
@@ -878,7 +878,7 @@ async def _sandbox_setup(ws, config, sandbox_root, handle):
         shell_cmd = (
             "export GIT_SSH_COMMAND="
             "'ssh -o StrictHostKeyChecking=accept-new'"
-            f" && cd {mount_at} && sh {setup_cmd}"
+            f" && cd {mount_at} && bash -c '{setup_cmd}'"
         )
         timeout = config.setup_timeout or None
         exit_code = await _exec_on_ws(

--- a/src/cli/klangkc/main.py
+++ b/src/cli/klangkc/main.py
@@ -878,7 +878,7 @@ async def _sandbox_setup(ws, config, sandbox_root, handle):
         shell_cmd = (
             "export GIT_SSH_COMMAND="
             "'ssh -o StrictHostKeyChecking=accept-new'"
-            f" && cd {mount_at} && bash {setup_cmd}"
+            f" && cd {mount_at} && {setup_cmd}"
         )
         timeout = config.setup_timeout or None
         exit_code = await _exec_on_ws(

--- a/src/cli/klangkc/sandbox.py
+++ b/src/cli/klangkc/sandbox.py
@@ -18,6 +18,7 @@ class SandboxConfig:
     # sandbox
     mount_at: str = "~/work"
     setup: str | None = None
+    setup_timeout: int = 300
     # lists
     copy: list[str] = field(default_factory=list)
     mounts: list[str] = field(default_factory=list)
@@ -41,10 +42,21 @@ def load_sandbox_config(sandbox_root: Path) -> SandboxConfig:
     workspace = raw.get("workspace") or {}
     sandbox = raw.get("sandbox") or {}
 
+    setup_timeout = sandbox.get(
+        "setup-timeout", sandbox.get("setup_timeout", 300)
+    )
+    try:
+        setup_timeout = int(setup_timeout)
+    except (TypeError, ValueError):
+        raise ValueError(
+            f"setup-timeout must be an integer, got {setup_timeout!r}"
+        )
+
     return SandboxConfig(
         image=workspace.get("image"),
         mount_at=sandbox.get("mount-at", sandbox.get("mount_at", "~/work")),
         setup=sandbox.get("setup"),
+        setup_timeout=setup_timeout,
         copy=raw.get("copy") or [],
         mounts=raw.get("mounts") or [],
         volumes=raw.get("volumes") or [],

--- a/src/cli/tests/test_cli_integration.py
+++ b/src/cli/tests/test_cli_integration.py
@@ -2097,6 +2097,40 @@ class TestExecOnWsRealFd:
 
         assert code == 0
 
+    async def test_ssh_agent_relay_idle_loop(self):
+        """Relay loops with no data then exits when stop is set."""
+        import tempfile
+
+        from klangkc.client import _exec_on_ws
+
+        # Create a real socket file so the relay enters the while loop,
+        # but never send ssh_agent_response — it should hit the
+        # TimeoutError/continue branch, then exit when exec finishes.
+        with tempfile.TemporaryDirectory() as tmpdir:
+            sock_path = os.path.join(tmpdir, "agent.sock")
+            srv = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            srv.bind(sock_path)
+            srv.listen(1)
+
+            ws = AsyncMock()
+            ws.send = AsyncMock()
+
+            async def delayed_exit():
+                # Give the relay time to hit at least one timeout cycle.
+                await asyncio.sleep(1.5)
+                return json.dumps({"type": "exec_exit", "code": 0})
+
+            ws.recv = delayed_exit
+
+            with patch.dict(
+                os.environ, {"SSH_AUTH_SOCK": sock_path}, clear=False
+            ):
+                code = await _exec_on_ws(ws, ["true"])
+
+            srv.close()
+
+        assert code == 0
+
     async def test_ssh_agent_relay_bad_socket(self):
         """Relay handles OSError when local agent socket is a regular file."""
         import base64

--- a/src/cli/tests/test_cli_integration.py
+++ b/src/cli/tests/test_cli_integration.py
@@ -1977,6 +1977,190 @@ class TestExecOnWsRealFd:
         os.close(read_fd)
         assert result == b"hello output"
 
+    async def test_ssh_agent_response_queued(self):
+        """ssh_agent_response messages are queued for the relay."""
+        import base64
+
+        from klangkc.client import _exec_on_ws
+
+        ws = AsyncMock()
+        sent = []
+        ws.send = AsyncMock(side_effect=lambda m: sent.append(m))
+
+        agent_data = base64.b64encode(b"\x00\x00\x00\x01\x0b").decode()
+        ws.recv = AsyncMock(
+            side_effect=[
+                json.dumps({"type": "ssh_agent_response", "data": agent_data}),
+                json.dumps({"type": "exec_exit", "code": 0}),
+            ]
+        )
+
+        # No real SSH_AUTH_SOCK — the relay will exit early, but the
+        # stdout_forward path still exercises the queuing branch.
+        with patch.dict(os.environ, {"SSH_AUTH_SOCK": ""}, clear=False):
+            code = await _exec_on_ws(ws, ["true"])
+
+        assert code == 0
+
+    async def test_ssh_agent_relay_forwards_to_local_agent(self):
+        """ssh_agent_relay reads from queue and talks to local agent."""
+        import base64
+        import struct
+        import tempfile
+        import threading
+
+        from klangkc.client import _exec_on_ws
+
+        # Create a fake agent socket that echoes a fixed response.
+        agent_response = struct.pack(">I", 1) + b"\x0b"  # 1-byte body
+        agent_request = b"\x00\x00\x00\x01\x01"  # request-identities
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            sock_path = os.path.join(tmpdir, "agent.sock")
+            server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            server.bind(sock_path)
+            server.listen(1)
+            server.settimeout(5)
+
+            # Run the fake agent in a thread so blocking socket calls
+            # in the relay don't deadlock the event loop.
+            def serve_agent():
+                conn, _ = server.accept()
+                try:
+                    conn.recv(4096)
+                    conn.sendall(agent_response)
+                finally:
+                    conn.close()
+
+            agent_thread = threading.Thread(target=serve_agent, daemon=True)
+            agent_thread.start()
+
+            ws = AsyncMock()
+            sent = []
+
+            # Track when agent relay has sent its response.
+            relay_done = threading.Event()
+
+            async def track_send(m):
+                sent.append(m)
+                if "ssh_agent_data" in str(m):
+                    relay_done.set()
+
+            ws.send = track_send
+
+            recv_idx = 0
+
+            async def fake_recv():
+                nonlocal recv_idx
+                recv_idx += 1
+                if recv_idx == 1:
+                    return json.dumps(
+                        {
+                            "type": "ssh_agent_response",
+                            "data": base64.b64encode(agent_request).decode(),
+                        }
+                    )
+                # Wait until the relay has processed before ending.
+                loop = asyncio.get_event_loop()
+                await loop.run_in_executor(None, relay_done.wait, 5)
+                return json.dumps({"type": "exec_exit", "code": 0})
+
+            ws.recv = fake_recv
+
+            with patch.dict(
+                os.environ, {"SSH_AUTH_SOCK": sock_path}, clear=False
+            ):
+                code = await _exec_on_ws(ws, ["true"])
+
+            agent_thread.join(timeout=2)
+            server.close()
+
+        assert code == 0
+        # The relay should have sent ssh_agent_data back.
+        agent_msgs = [
+            json.loads(s) for s in sent if "ssh_agent_data" in str(s)
+        ]
+        assert len(agent_msgs) >= 1
+
+    async def test_ssh_agent_relay_no_socket(self):
+        """Relay exits early when SSH_AUTH_SOCK is unset."""
+        from klangkc.client import _exec_on_ws
+
+        ws = AsyncMock()
+        ws.send = AsyncMock()
+        ws.recv = AsyncMock(
+            return_value=json.dumps({"type": "exec_exit", "code": 0})
+        )
+
+        with patch.dict(os.environ, {"SSH_AUTH_SOCK": ""}, clear=False):
+            code = await _exec_on_ws(ws, ["true"])
+
+        assert code == 0
+
+    async def test_ssh_agent_relay_bad_socket(self):
+        """Relay handles OSError when local agent socket is a regular file."""
+        import base64
+        import tempfile
+
+        from klangkc.client import _exec_on_ws
+
+        # Create a regular file (not a socket) so os.path.exists()
+        # passes but socket.connect() raises OSError.
+        with tempfile.NamedTemporaryFile() as f:
+            bad_path = f.name
+
+            ws = AsyncMock()
+            sent = []
+
+            async def track_send(m):
+                sent.append(m)
+
+            ws.send = track_send
+
+            recv_idx = 0
+
+            async def fake_recv():
+                nonlocal recv_idx
+                recv_idx += 1
+                if recv_idx == 1:
+                    return json.dumps(
+                        {
+                            "type": "ssh_agent_response",
+                            "data": base64.b64encode(
+                                b"\x00\x00\x00\x01\x01"
+                            ).decode(),
+                        }
+                    )
+                # Give the relay time to hit the error path.
+                await asyncio.sleep(0.3)
+                return json.dumps({"type": "exec_exit", "code": 0})
+
+            ws.recv = fake_recv
+
+            with patch.dict(
+                os.environ,
+                {"SSH_AUTH_SOCK": bad_path},
+                clear=False,
+            ):
+                code = await _exec_on_ws(ws, ["true"])
+
+        assert code == 0
+
+    async def test_timeout_returns_124(self):
+        """When timeout expires, exit code 124 is returned."""
+        from klangkc.client import _exec_on_ws
+
+        ws = AsyncMock()
+        ws.send = AsyncMock()
+
+        async def hang_forever():
+            await asyncio.sleep(3600)
+
+        ws.recv = hang_forever
+
+        code = await _exec_on_ws(ws, ["sleep", "999"], timeout=1)
+        assert code == 124
+
 
 class TestWsExecWrapper:
     """Test _ws_exec wrapper connects and delegates to _exec_on_ws."""

--- a/src/cli/tests/test_cli_main.py
+++ b/src/cli/tests/test_cli_main.py
@@ -2742,7 +2742,7 @@ class TestSandboxSetup:
         ws = AsyncMock()
         exec_calls = []
 
-        async def fake_exec(ws, cmd, stdin=None, stdout=None):
+        async def fake_exec(ws, cmd, stdin=None, stdout=None, timeout=None):
             exec_calls.append(
                 {"cmd": cmd, "stdin": stdin.read() if stdin else None}
             )
@@ -2767,7 +2767,7 @@ class TestSandboxSetup:
 
         ws = AsyncMock()
 
-        async def fake_exec(ws, cmd, stdin=None, stdout=None):
+        async def fake_exec(ws, cmd, stdin=None, stdout=None, timeout=None):
             return 1  # failure
 
         with patch("klangkc.main._exec_on_ws", fake_exec):
@@ -2800,7 +2800,7 @@ class TestSandboxSetup:
         ws = AsyncMock()
         exec_calls = []
 
-        async def fake_exec(ws, cmd, stdin=None, stdout=None):
+        async def fake_exec(ws, cmd, stdin=None, stdout=None, timeout=None):
             exec_calls.append(cmd)
             return 0
 
@@ -2809,6 +2809,72 @@ class TestSandboxSetup:
 
         assert len(exec_calls) == 1
         assert "/home/admin/project/setup.sh" in exec_calls[0][2]
+
+    async def test_setup_sets_git_ssh_command(self, tmp_path):
+        from klangkc.main import _sandbox_setup
+        from klangkc.sandbox import SandboxConfig
+
+        config = SandboxConfig(
+            mount_at="~/project",
+            setup="setup.sh",
+        )
+
+        ws = AsyncMock()
+        exec_calls = []
+
+        async def fake_exec(ws, cmd, stdin=None, stdout=None, timeout=None):
+            exec_calls.append(cmd)
+            return 0
+
+        with patch("klangkc.main._exec_on_ws", fake_exec):
+            await _sandbox_setup(ws, config, tmp_path, "admin")
+
+        shell_cmd = exec_calls[0][2]
+        assert "GIT_SSH_COMMAND=" in shell_cmd
+        assert "StrictHostKeyChecking=accept-new" in shell_cmd
+
+    async def test_setup_passes_timeout(self, tmp_path):
+        from klangkc.main import _sandbox_setup
+        from klangkc.sandbox import SandboxConfig
+
+        config = SandboxConfig(
+            mount_at="~/project",
+            setup="setup.sh",
+            setup_timeout=60,
+        )
+
+        ws = AsyncMock()
+        captured_timeout = []
+
+        async def fake_exec(ws, cmd, stdin=None, stdout=None, timeout=None):
+            captured_timeout.append(timeout)
+            return 0
+
+        with patch("klangkc.main._exec_on_ws", fake_exec):
+            await _sandbox_setup(ws, config, tmp_path, "admin")
+
+        assert captured_timeout == [60]
+
+    async def test_setup_timeout_warns(self, tmp_path, capsys):
+        from klangkc.main import _sandbox_setup
+        from klangkc.sandbox import SandboxConfig
+
+        config = SandboxConfig(
+            mount_at="~/project",
+            setup="setup.sh",
+            setup_timeout=10,
+        )
+
+        ws = AsyncMock()
+
+        async def fake_exec(ws, cmd, stdin=None, stdout=None, timeout=None):
+            return 124
+
+        with patch("klangkc.main._exec_on_ws", fake_exec):
+            await _sandbox_setup(ws, config, tmp_path, "admin")
+
+        err = capsys.readouterr().err
+        assert "timed out after 10s" in err
 
     async def test_setup_failure_warns(self, tmp_path):
         from klangkc.main import _sandbox_setup
@@ -2821,7 +2887,7 @@ class TestSandboxSetup:
 
         ws = AsyncMock()
 
-        async def fake_exec(ws, cmd, stdin=None, stdout=None):
+        async def fake_exec(ws, cmd, stdin=None, stdout=None, timeout=None):
             return 1
 
         with patch("klangkc.main._exec_on_ws", fake_exec):

--- a/src/cli/tests/test_sandbox.py
+++ b/src/cli/tests/test_sandbox.py
@@ -58,6 +58,37 @@ class TestLoadSandboxConfig:
         assert config.mounts == ["/data:~/data:ro"]
         assert config.volumes == ["cache:/cache"]
 
+    def test_setup_timeout_default(self, sandbox_root):
+        _write_config(sandbox_root, {})
+        config = load_sandbox_config(sandbox_root)
+        assert config.setup_timeout == 300
+
+    def test_setup_timeout_custom(self, sandbox_root):
+        _write_config(
+            sandbox_root,
+            {"sandbox": {"setup-timeout": 60}},
+        )
+        config = load_sandbox_config(sandbox_root)
+        assert config.setup_timeout == 60
+
+    def test_setup_timeout_snake_case_fallback(self, sandbox_root):
+        _write_config(
+            sandbox_root,
+            {"sandbox": {"setup_timeout": 120}},
+        )
+        config = load_sandbox_config(sandbox_root)
+        assert config.setup_timeout == 120
+
+    def test_setup_timeout_invalid_raises(self, sandbox_root):
+        _write_config(
+            sandbox_root,
+            {"sandbox": {"setup-timeout": "not-a-number"}},
+        )
+        with pytest.raises(
+            ValueError, match="setup-timeout must be an integer"
+        ):
+            load_sandbox_config(sandbox_root)
+
     def test_snake_case_mount_at_fallback(self, sandbox_root):
         """Legacy mount_at key still works for backwards compat."""
         _write_config(


### PR DESCRIPTION
## Summary

- **Root cause**: `_exec_on_ws` (used for sandbox setup) silently dropped `ssh_agent_response` WebSocket messages, so SSH authentication via the forwarded agent hung indefinitely during setup scripts that use git-over-SSH
- Add SSH agent relay task to `_exec_on_ws` that forwards agent protocol between container and local agent, matching the terminal session behavior
- Set `GIT_SSH_COMMAND='ssh -o StrictHostKeyChecking=accept-new'` during setup so new host keys are accepted non-interactively
- Add configurable `setup-timeout` (default 300s) to `.klangk-sandbox.yaml` as a safety net against hung setups

## Test plan

- [x] Backend tests pass (1482 passed, 100% coverage)
- [x] CLI tests pass (354 passed, 100% coverage)
- [x] Manual test: `klangkc sandbox hr -A` from `examples/haiku-rag` completes git clone + uv install successfully
- [x] Verified setup timeout returns exit code 124 with descriptive message

Closes #772