### PR TITLE
feat: opt-in hot-reload web dev mode (KLANGK_WEB_DEV)

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -66,7 +66,16 @@ in
 
   tasks = {
     "klangk:flutter-build" = {
-      exec = ''exec bash "$DEVENV_ROOT/scripts/flutterbuildweb.sh"'';
+      # In opt-in dev mode the live `flutter run` dev server
+      # (scripts/flutterdevweb.sh) owns compilation, so skip the slow release
+      # build. Default behaviour is unchanged.
+      exec = ''
+        if [ "''${KLANGK_WEB_DEV:-0}" = "1" ]; then
+          echo "KLANGK_WEB_DEV=1: skipping release build (run flutterdevweb for hot reload)."
+          exit 0
+        fi
+        exec bash "$DEVENV_ROOT/scripts/flutterbuildweb.sh"
+      '';
       showOutput = true;
       execIfModified = [
         "scripts/flutterbuildweb.sh"
@@ -153,6 +162,9 @@ in
   # devenv.local.nix (mkForce/50) > .env (1000) > these (1500)
   env.KLANGK_PORT = lib.mkOverride 1500 "8997";
   env.KLANGK_NGINX_PORT = lib.mkOverride 1500 "8995";
+  # Port the opt-in `flutter run` dev server listens on (nginx proxies the app
+  # root here when KLANGK_WEB_DEV=1). Between nginx (8995) and backend (8997).
+  env.KLANGK_WEB_DEV_PORT = lib.mkOverride 1500 "8996";
   env.KLANGK_DATA_DIR = lib.mkOverride 1500 (
     config.devenv.root + "/.devenv/state/klangk/data"
   );
@@ -183,6 +195,9 @@ in
   dotenv.enable = true;
 
   scripts.flutterbuildweb.exec = ''exec bash "$DEVENV_ROOT/scripts/flutterbuildweb.sh" "$@"'';
+  # Opt-in hot-reload dev server. Pair with `KLANGK_WEB_DEV=1 devenv processes
+  # up` so nginx routes the app root here while /api + /ws stay on the backend.
+  scripts.flutterdevweb.exec = ''exec bash "$DEVENV_ROOT/scripts/flutterdevweb.sh" "$@"'';
   scripts.build-workspace-image.exec = ''exec bash "$DEVENV_ROOT/scripts/build-workspace-image.sh" "$@"'';
   scripts.pull-base-image.exec = ''exec bash "$DEVENV_ROOT/scripts/pull-base-image.sh" "$@"'';
   scripts.push-base-image.exec = ''exec bash "$DEVENV_ROOT/scripts/push-base-image.sh" "$@"'';

--- a/docs/dev/web-fast-iteration-PROGRESS.md
+++ b/docs/dev/web-fast-iteration-PROGRESS.md
@@ -1,0 +1,54 @@
+# PROGRESS — web fast-iteration (autonomous run, 2026-06-23)
+
+Running log so you can see direction + decisions while away. Newest at top.
+
+## Decisions locked (from your answers)
+
+- Scope: **layered** — hot reload for UI; release path stays the pi/bridge validation path.
+- Integration: **opt-in** (`KLANGK_WEB_DEV=1`), default `devenv up` unchanged.
+- Autonomy: implement on branch `feat/flutter-web-dev-mode`, push, open **draft PR**.
+- Validation: **full local** (podman VM, image build, real Chrome via devtools MCP). No macOS playwright e2e.
+- Stretch: hermes agent build in klangkc mode; minimax key is in `.env`.
+
+## Key technical anchor
+
+`ws_client.dart` derives WS + HTTP base from `Uri.base`. Keep browser on nginx :8995 →
+all API/WS/bridge unchanged; nginx only forks by path in dev mode.
+
+## Log
+
+- [setup] Branched `feat/flutter-web-dev-mode` off main@1783784. Pre-existing WIP
+  (main.py, flutterbuildweb.sh, test_oidc.py) left uncommitted — will NOT enter my PR.
+- [doc] Wrote docs/dev/web-fast-iteration.md (scenarios + strategy menu).
+- [impl] Strategy A done: scripts/flutterdevweb.sh (new), scripts/nginx.sh dev
+  profile, devenv.nix (flutterdevweb script + KLANGK_WEB_DEV_PORT=8996 + skip
+  flutter-build in dev). bash -n + nix parse clean.
+- [validate] nginx dev config generates + passes `nginx -t`. Routing confirmed:
+  `location = /ws` -> backend; `location /api/` -> backend; `location /` -> dev
+  server :8996; bridge locations unchanged -> backend. Podman VM started.
+- [validate] Surgical stack up (backend :8997 + nginx-dev :8995 + flutterdevweb
+  :8996). Confirmed: nginx :8995/ serves the LIVE dev-server bundle
+  (`<title>Klangk</title>`, flutter_bootstrap), :8995/api/v1/config -> backend 200.
+  Flutter 3.41.6 web-server EXPOSES `r` Hot reload + `R` Hot restart. First DDC
+  serve ~15s.
+- [VALIDATED ✅] End-to-end in real Chrome via nginx :8995:
+  - App loads from the live dev server, auto-logged-in as admin2@example.com,
+    Workspaces list renders, API + WS work (it reached #/workspaces). So the
+    layered routing (/ -> dev server, /api+/ws -> backend) is correct and the
+    pi/bridge path is untouched.
+  - Edited `workspace_list_page.dart` app-bar title -> 'Workspaces HOTRELOAD-OK',
+    did a plain **browser refresh**: the change appeared in ~8.8s via incremental
+    DDC recompile. NO `flutter build web --release` ran. (Edit since reverted.)
+    Screenshots: scratch/devmode-before.png, scratch/devmode-after.png.
+- [FINDING ⚠️] `flutter run -d web-server` hot restart (`R`) / hot reload (`r`)
+  needs a debug-connected browser — i.e. the **Dart Debug Extension** — or it
+  times out ("received 0/1 responses"). My headless MCP Chrome has no extension,
+  so true hot reload couldn't be auto-triggered. BUT the extension-free path
+  (edit + refresh = incremental recompile, ~9s) is the real daily win and needs
+  no extension. Implication for Strategy B: for web-server, an auto-**browser-
+  reload** watcher (livereload-style) beats trying to script `R`, unless we adopt
+  `-d chrome` (flutter-controlled Chrome has the debug client, but loads from
+  :8996 directly -> breaks same-origin API/WS). Documenting both.
+- [next] Capture baseline `flutter build web --release` time -> compute speedup;
+  fold findings into the doc; commit my files; push; draft PR. Then loop on
+  Strategy B (reload watcher), D/F (bind-mount extensions), and hermes/klangkc.

--- a/docs/dev/web-fast-iteration-PROGRESS.md
+++ b/docs/dev/web-fast-iteration-PROGRESS.md
@@ -71,5 +71,14 @@ Now working the container side (D/F + hermes) where your interest is.
 - [G hermes ⛔ BLOCKED] "hermes" is nowhere in repo/git. Can't build it without a
   definition. Documented the 4 possibilities + the concrete klangkc-sandbox path
   once identified. Needs your answer (see doc "Stretch (G)").
-- [next] Commit docs to branch + refresh PR. Strategy B (reload watcher) remains
-  optional. Awaiting hermes definition.
+- [DONE] Docs committed (181d40d) + pushed; PR #785 updated with a comment.
+- [handoff] Tore down my surgical validation stack (8995/8996/8997 freed) so your
+  next `devenv processes up` is clean. PoC artifacts in scratch/ (untracked):
+  devmode-before.png, devmode-after.png, fdev-extensions/.
+- [STOPPED HERE — needs your input] Remaining work is either blocked on you or an
+  architectural call:
+  - hermes (G): blocked on what hermes IS.
+  - F full impl (task #8): needs your steer on mounting approach + go-ahead.
+  - B (reload watcher): optional polish.
+    I stopped rather than push a nuanced backend change in a direction you might
+    not want. Ready to implement F the moment you confirm scope.

--- a/docs/dev/web-fast-iteration-PROGRESS.md
+++ b/docs/dev/web-fast-iteration-PROGRESS.md
@@ -15,6 +15,13 @@ Running log so you can see direction + decisions while away. Newest at top.
 `ws_client.dart` derives WS + HTTP base from `Uri.base`. Keep browser on nginx :8995 →
 all API/WS/bridge unchanged; nginx only forks by path in dev mode.
 
+## Status
+
+Foundation (Strategy A) DONE + validated + pushed. Draft PR:
+https://github.com/mcdonc/klangk/pull/785 (commit 6c7ae4b). Live stack still up:
+backend :8997 + nginx-dev :8995 (dev server :8996 stopped after baseline build).
+Now working the container side (D/F + hermes) where your interest is.
+
 ## Log
 
 - [setup] Branched `feat/flutter-web-dev-mode` off main@1783784. Pre-existing WIP
@@ -49,6 +56,20 @@ all API/WS/bridge unchanged; nginx only forks by path in dev mode.
   reload** watcher (livereload-style) beats trying to script `R`, unless we adopt
   `-d chrome` (flutter-controlled Chrome has the debug client, but loads from
   :8996 directly -> breaks same-origin API/WS). Documenting both.
-- [next] Capture baseline `flutter build web --release` time -> compute speedup;
-  fold findings into the doc; commit my files; push; draft PR. Then loop on
-  Strategy B (reload watcher), D/F (bind-mount extensions), and hermes/klangkc.
+- [DONE] Baseline 21.3s warm; folded into doc; committed (6c7ae4b); pushed; draft
+  PR #785 opened.
+- [container side] Mapped it: long-lived container (`sleep infinity`), sessions via
+  `podman exec`; agents = Pi + Herdr baked; LLM via `llm-proxy`; MiniMax is a
+  provider; klangkc `sandbox` runs a setup/default command in a workspace.
+- [D] build-workspace-image is already hash-gated and skips when unchanged
+  (confirmed live: "up to date, skipping build"). Dev mode also skips
+  flutter-build. Documented; no change needed.
+- [F ✅ validated] Bind-mount mechanic proven on the real klangk-arm64 image:
+  host edit -> live in running container, NO rebuild/restart, using the additive
+  `~/.pi/agent/extensions/` path (doesn't hide baked extensions). Wrote the exact
+  opt-in container.py design. Full impl = a separate tested PR (100% cov bar).
+- [G hermes ⛔ BLOCKED] "hermes" is nowhere in repo/git. Can't build it without a
+  definition. Documented the 4 possibilities + the concrete klangkc-sandbox path
+  once identified. Needs your answer (see doc "Stretch (G)").
+- [next] Commit docs to branch + refresh PR. Strategy B (reload watcher) remains
+  optional. Awaiting hermes definition.

--- a/docs/dev/web-fast-iteration.md
+++ b/docs/dev/web-fast-iteration.md
@@ -152,12 +152,13 @@ this. Investigated in the loop; findings + blockers tracked in `PROGRESS.md`.
 Validated against a live stack (backend :8997 + nginx-dev :8995 + `flutter run
 -d web-server` :8996), driving real Chrome through nginx :8995.
 
-| Path                                                         | Time                         | Notes                                                                                                           |
-| ------------------------------------------------------------ | ---------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| `flutter build web --release` (warm cache, no plugin change) | **21.3 s**                   | compile only; the `flutterbuildweb.sh` task adds plugin import + ~25 MB source-map inlining + cache-bust on top |
-| same, after a **plugin-set change**                          | minutes                      | `flutterbuildweb.sh` does `rm -rf .dart_tool/flutter_build` → full cold dart2js compile                         |
-| dev server: edit Dart + **browser refresh**                  | **~8.8 s**                   | incremental DDC recompile + app boot; **no release build runs**; needs no extension                             |
-| dev server: **hot reload/restart** (`r`/`R`)                 | sub-second–seconds, stateful | requires the **Dart Debug Extension** on the web-server device (see finding below)                              |
+| Path                                                         | Time                     | Notes                                                                                                           |
+| ------------------------------------------------------------ | ------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| `flutter build web --release` (warm cache, no plugin change) | **21.3 s**               | compile only; the `flutterbuildweb.sh` task adds plugin import + ~25 MB source-map inlining + cache-bust on top |
+| same, after a **plugin-set change**                          | minutes                  | `flutterbuildweb.sh` does `rm -rf .dart_tool/flutter_build` → full cold dart2js compile                         |
+| dev server: edit Dart + **browser refresh**                  | **~8.8 s**               | incremental DDC recompile + app boot; **no release build runs**; needs no extension                             |
+| dev server: **hot reload** (`r`), debug-connected browser    | **122–135 ms**, stateful | measured via `-d chrome`; same-origin needs the Dart Debug Extension (see finding)                              |
+| dev server: **hot restart** (`R`), debug-connected browser   | **249 ms**               | measured via `-d chrome`; same-origin needs the Dart Debug Extension (see finding)                              |
 
 Verified the layered routing is correct: the app loaded from the dev server
 through nginx :8995, auto-logged-in (admin2@example.com), rendered the Workspaces
@@ -165,27 +166,42 @@ list, and reached `#/workspaces` — i.e. `/api/v1/*` and `/ws` still hit the
 backend. A title edit in `workspace_list_page.dart` appeared after a plain
 refresh with no `flutter build` invocation. Screenshots in `scratch/`.
 
-### Finding: hot reload needs a debug-connected browser
+### Finding: hot reload needs the browser to be the _debug-connected_ one
 
-`flutter run -d web-server` cannot _push_ a hot restart/reload into a browser it
-doesn't control — it relies on the **Dart Debug Extension** to relay the debug
-connection. Without it, `R` times out (`Hot restart ... received 0/1 responses`).
-Two usable modes:
+Tested empirically (real Chrome, driven via the devtools MCP):
 
-- **Extension-free (default, recommended to start):** edit + refresh the tab at
-  nginx :8995. DDC recompiles incrementally (~9 s here) and the app reboots.
-  Same-origin, so API/WS/bridge all work.
-- **With the Dart Debug Extension:** install it in Chrome, open :8995, and `r`/`R`
-  give true stateful hot reload (sub-second). Still same-origin via nginx.
-- **`-d chrome` is NOT used** here: it launches a Chrome it controls (so hot
-  reload works out of the box) but pointed at :8996 directly, which makes
-  `Uri.base` = :8996 and breaks the app's API/WS calls. Same-origin via nginx is
-  worth more than out-of-the-box hot reload.
+- `flutter run -d web-server` cannot _push_ a hot restart/reload into a browser it
+  doesn't control — without the **Dart Debug Extension**, `R` times out
+  (`Hot restart ... received 0/1 responses`).
+- `flutter run -d chrome` _does_ control its browser, so hot reload/restart land
+  with **no extension**: measured **`r` = 122–135 ms** (stateful), **`R` = 249 ms**.
+  But that Chrome loads from `:8996` directly, so `Uri.base = :8996` and the app's
+  `/api/v1/config` + `/ws` hit the dev server, not the backend (observed:
+  `AuthService load config failed: ... <!doctype ...`). **Same-origin breaks.**
+- Crucially: with `-d chrome` running, a **separate** same-origin tab opened at
+  nginx `:8995` (where the app _does_ work — logged in, workspaces rendered) did
+  **not** receive the 122 ms hot reload — DDC reload only patches the
+  debug-connected browser, not an independently-loaded tab (verified by
+  screenshot). So you cannot "share" one `-d chrome` debug session with a
+  same-origin tab.
 
-This reframes **Strategy B**: for the web-server device, the no-keypress win is an
-auto-**browser-reload** watcher (watch `lib/**` → tell the tab to reload →
-incremental recompile), which works _without_ the extension. Scripting `R` only
-helps once the extension is installed.
+**Conclusion — pick two of three (extension-free / same-origin / sub-second):**
+
+| Goal                                       | How                                                     | Cost                                     |
+| ------------------------------------------ | ------------------------------------------------------- | ---------------------------------------- |
+| same-origin **+** extension-free           | `-d web-server` behind nginx, **edit + refresh**        | ~9 s, loses state                        |
+| same-origin **+** sub-second hot reload    | `-d web-server` behind nginx **+ Dart Debug Extension** | one-time extension install               |
+| extension-free **+** sub-second hot reload | `-d chrome`                                             | **not** same-origin → app's API/WS break |
+
+For klangk's app (which needs API/WS), the realistic choices are the first two.
+The shipped Strategy A is the first row. The Dart Debug Extension upgrades it to
+the second (sub-second) with no code change.
+
+This pins down **Strategy B**: scripting `R` (via `--machine` or a FIFO) only
+helps once the **Dart Debug Extension** is installed (then it's same-origin +
+sub-second). The only _extension-free_ no-keypress win is an auto-**browser-
+reload** watcher (watch `lib/**` → reload the `:8995` tab → ~9 s incremental
+recompile).
 
 ## Validation plan (full local)
 

--- a/docs/dev/web-fast-iteration.md
+++ b/docs/dev/web-fast-iteration.md
@@ -196,3 +196,86 @@ helps once the extension is installed.
 4. Edit a widget; confirm `R` reflects in the browser in seconds with **no** full
    rebuild; confirm login, `/api/v1/config`, and the WS still work.
 5. Record real timings back into this doc. (macOS playwright e2e stays excluded.)
+
+## Container-side iteration (D + F) — validated
+
+The other half of `devenv up` is `klangk:build-workspace-image` (the image where
+`pi` / `claude code` / `hermes` run). Two findings:
+
+### D — the image build is already hash-gated (decoupled)
+
+`build-workspace-image.sh` hashes `scripts/build-workspace-image.sh` +
+`src/containers/workspace/` + the plugins dir against
+`$DEVENV_STATE/klangk/.backend-image-hash` and **skips** when unchanged
+(confirmed live: "Image klangk-arm64 is up to date, skipping build."). So
+frontend-only work doesn't rebuild the image. Dev mode (Strategy A) additionally
+skips `klangk:flutter-build`, so a `KLANGK_WEB_DEV=1` start does neither heavy
+build when nothing relevant changed. No change needed here beyond documenting it.
+
+### F — bind-mount extensions to skip the image rebuild ✅ mechanic validated
+
+Today the Dockerfile `COPY`s plugin/builtin **extensions**, **tools**, **hooks**,
+and the frequently-edited `klangk-*` scripts / `system-prompt.md` /
+`entrypoint.sh` into the image (`src/containers/workspace/Dockerfile:13-60`). Any
+edit to those changes the hash → full `podman build`. Pi runs as a long-lived
+container (`entrypoint.sh` = `sleep infinity`; sessions via `podman exec`), so the
+container doesn't even need rebuilding — just the files refreshed.
+
+**Key insight** (`klangk-setup-clankers.py:64`): Pi auto-discovers
+`~/.pi/agent/extensions/` _in addition_ to the baked image dir. So dev extensions
+can be bind-mounted **additively** into the user dir — no need to mount over
+`/opt/klangk/pi-agent/extensions` (which would _hide_ the baked builtin/plugin
+extensions).
+
+Validated against the real `klangk-arm64` image (no rebuild):
+
+```text
+podman run -d --userns=keep-id:uid=1000,gid=1000 \
+  -v $PWD/scratch/fdev-extensions:/home/klangk/.pi/agent/extensions:ro klangk-arm64
+# file visible inside, owned by klangk; host edit -> reflected live in the
+# running container with NO rebuild and NO restart.
+```
+
+**Proposed implementation (opt-in, separate tested PR):** in `container.py` where
+`binds` is assembled (~line 538), when a dev flag is set (e.g.
+`KLANGK_WORKSPACE_DEV=1`), append additive read-only mounts:
+
+- host plugin/builtin extensions dir → `/home/klangk/.pi/agent/extensions/` (or a
+  second dir added to Pi's `extensions` array in `settings.json`)
+- staged tools dir → an extra `PATH` dir (avoid hiding `/opt/klangk/bin`)
+- `src/containers/workspace/*.sh` dev copies → `/opt/klangk/bin/*` individually
+
+Then editing an extension/tool/script + reopening the workspace (or re-exec'ing
+the agent) picks up changes with **no image rebuild**. Gate it so prod/default is
+untouched, mirroring Strategy A. Needs unit tests (container `binds` assembly is
+covered) to hold the 100% coverage bar — hence a separate PR, not bundled here.
+
+## Stretch (G) — hermes agent in klangkc mode: investigation + blocker
+
+What I confirmed:
+
+- The workspace image bakes in only **Pi** (`@earendil-works/pi-coding-agent`)
+  and **Herdr** (`herdr` 0.6.6, a terminal-based agent runtime). `claude code`
+  and `hermes` are not baked — they'd be installed/run _inside_ a workspace.
+- Agents talk to the LLM via the **`llm-proxy`** provider (nginx →
+  `KLANGK_LLM_BASE_URL` with the server-side key); `klangk-setup-clankers.py`
+  wires Pi's `~/.pi/agent/{settings,models}.json` to it using `KLANGK_LLM_MODEL`.
+- **MiniMax** is a supported LLM (builtin `minimax-thinking-tags.ts` repairs
+  `<think>` tags from MiniMax models). `MINIMAX_API_KEY` is in `.env`.
+- **`klangkc sandbox`** reads a `.klangk/` config (`image`, `setup-command`,
+  mounts, `forward-agent`) and runs a default command in a workspace container —
+  this is the "klangkc mode" surface where an agent build would be driven.
+- **"hermes" appears nowhere** in the repo or git history/branches.
+
+**Blocker (needs your input):** I can't "get the hermes agent build running"
+without knowing what `hermes` _is_. Which of these?
+
+1. An external agent CLI/binary (give the repo URL / install command), or
+2. An npm package (like Pi) to add to the image / a sandbox `setup-command`, or
+3. A Pi/Herdr configuration preset, or
+4. A MiniMax **model id** named "Hermes" to set as `KLANGK_LLM_MODEL`.
+
+Once identified, the concrete path is: add a `.klangk/` sandbox config (or image
+layer) that installs hermes and sets the MiniMax-backed model via the llm-proxy,
+then `klangkc sandbox` / `klangkc shell` to run it. I've left this unblocked-but-
+unstarted rather than guess.

--- a/docs/dev/web-fast-iteration.md
+++ b/docs/dev/web-fast-iteration.md
@@ -1,0 +1,198 @@
+# Faster web-frontend iteration in klangk
+
+Status: WIP on branch `feat/flutter-web-dev-mode`. Author: autonomous session, 2026-06-23.
+
+## The problem
+
+Day-to-day we start the stack with:
+
+```bash
+devenv processes up --no-tui     # daemon, reachable at http://localhost:8995/
+```
+
+On every start, two heavy build steps run before the `backend`/`nginx` processes
+come up (devenv.nix `tasks`):
+
+1. **`klangk:flutter-build`** → `scripts/flutterbuildweb.sh` → a full
+   `flutter build web --release` (dart2js AOT compile, `--no-minify-js`,
+   `--source-maps` + a ~25 MB source-map inlining pass). It re-runs whenever any
+   of these change (`execIfModified`):
+   - `scripts/flutterbuildweb.sh`
+   - `src/frontend/lib/**`
+   - `src/frontend/web/**`
+   - `src/frontend/pubspec.yaml` / `pubspec.lock`
+   - `$KLANGK_PLUGINS_DIR/**/*.dart`, `plugins.lock`
+2. **`klangk:build-workspace-image`** → `scripts/build-workspace-image.sh` → a
+   `podman build` of the workspace image where `pi`, `claude code`, and the
+   `hermes` agent run. Hash-gated over `src/containers/workspace/` + the plugins
+   dir, so it _skips_ when nothing changed — but the first build, and any
+   extension/tool/hook edit, pays the full image build.
+
+The pain: a one-line Dart UI edit (`lib/**`) invalidates step 1 and forces a
+**full release recompile** before you can see the change. Flutter supports hot
+reload / hot restart, but **only through `flutter run`** (the DDC dev compiler) —
+the `flutter build web --release` path has no incremental/dev server, so we never
+get it.
+
+## Why hot reload isn't "just turn it on"
+
+`pi` (and `claude code` / `hermes`) run _inside_ the workspace container and their
+extensions call back **through the Flutter app** via the
+`/api/v1/browser-delegate` bridge (nginx `:8995` → backend `:8997` → the frontend
+served at the nginx origin). So the dev server can't live on some random origin —
+it has to stay **same-origin** with the bridge or the container→frontend path
+breaks.
+
+Key enabling fact (`src/frontend/lib/ws/ws_client.dart:28,157`): the frontend
+derives **both** its WebSocket URL (`{scheme}://{host}:{port}{base}/ws`) and its
+HTTP API base from `Uri.base` — i.e. _whatever origin the browser loaded from_.
+The backend mounts the built assets as a `StaticFiles` catch-all at `/` and the
+API under `/api/v1` (`main.py:326,359`), WS at `/ws` (`main.py:332`).
+
+**Consequence:** if the browser keeps loading from nginx `:8995`, every API/WS/
+bridge call still targets `:8995`. We only need nginx to fork **by path** in dev
+mode:
+
+```text
+/api/   + /ws   ->  backend   127.0.0.1:8997   (unchanged behaviour)
+/  + assets + DWDS ->  flutter run dev server   127.0.0.1:$KLANGK_WEB_DEV_PORT
+```
+
+That keeps the pi/bridge flow byte-for-byte identical to today (it never touches
+the dev server), which is exactly the "layered" scope we chose: hot reload for
+everyday UI work, release build still the path used to validate the
+pi/extension/bridge flow.
+
+## Six representative change scenarios
+
+| #          | Change                                              | Today (`devenv up` release path)                                                            | With Strategy A (dev server)                                                               |
+| ---------- | --------------------------------------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| 1          | Tweak a widget (color/padding) in `lib/**`          | Full `flutter build web --release` + map inline, then reload                                | `r`/`R` → DDC incremental recompile of changed module (seconds); hot reload may keep state |
+| 2          | Change provider/state logic in `lib/**`             | Full release rebuild + state lost                                                           | Hot restart (`R`) recompiles incrementally; state reset only                               |
+| 3          | Add a new Dart file / `go_router` route             | Full release rebuild                                                                        | Hot restart picks it up; new top-level classes need restart not reload                     |
+| 4          | `pubspec.yaml` dependency add/bump                  | `flutter pub get` + full rebuild                                                            | Must stop/restart `flutter run` (pub get + cold start) — no hot path either way            |
+| 5          | Plugin set change (`plugins.yaml` / plugin `.dart`) | update-plugins + import + **cache wipe** (`rm -rf .dart_tool/flutter_build`) + full rebuild | Restart `flutter run` + re-import; cache wipe defeats incrementality regardless            |
+| 6          | `web/` asset / `index.html` / manifest              | Full release rebuild + cache-bust `sed`                                                     | Static assets served live; `index.html` template change needs restart                      |
+| (baseline) | Backend-only Python change                          | Not in `execIfModified` → no flutter rebuild; uvicorn reload                                | identical                                                                                  |
+
+Takeaway: scenarios **1–3** (the overwhelming majority of frontend work) go from
+a full release compile to a seconds-long incremental recompile. **4–6** are
+inherently cold-ish in both modes, so the dev server's value there is smaller —
+honesty matters: we are not claiming hot reload for dependency or plugin-set
+changes.
+
+## Strategy menu (big picture)
+
+Ordered roughly by value-to-effort. **A is the concrete foundation**; the rest are
+experiments to layer on.
+
+### A — Layered, opt-in hot-reload dev server ★ foundation
+
+- New `scripts/flutterdevweb.sh`: `flutter run -d web-server
+--web-port=$KLANGK_WEB_DEV_PORT --web-hostname=127.0.0.1` (DDC, incremental).
+- `scripts/nginx.sh` grows a **dev profile** under `KLANGK_WEB_DEV=1` that routes
+  `/api/` + `/ws` → backend and everything else → the dev server.
+- `devenv.nix`: in dev mode, **skip** `klangk:flutter-build` (the dev server owns
+  compilation) and expose a `flutterdevweb` script (+ optionally a `frontend-dev`
+  process).
+- Default `devenv processes up --no-tui` is **unchanged** (release build).
+- Trigger reload: press `r`/`R` in the `flutter run` console (Strategy B removes
+  the keypress).
+
+### B — Auto-reload watcher (revised after measurement)
+
+Goal: no manual keypress / manual refresh. Two variants:
+
+- **Browser-reload watcher (extension-free, preferred):** watch
+  `src/frontend/lib/**`; on save, tell the open tab at :8995 to reload (e.g. a
+  tiny injected websocket livereload client, or driving Chrome via the DevTools
+  Protocol). Reload triggers the incremental DDC recompile — the ~9 s path that
+  needs no extension.
+- **`flutter run --machine` + `app.restart`:** true hot restart with no keypress,
+  but on the web-server device it still needs the Dart Debug Extension connected
+  (same limitation as pressing `R`). Adopt once the extension is standard in the
+  dev setup.
+  Build only after A is proven (it is).
+
+### C — Faster release build (for those who keep the build-then-serve model)
+
+`flutter build web` is always dart2js (no DDC), so it can't be incremental, but we
+can offer a "fast build" variant: drop `--source-maps` (skips the 25 MB
+map-inlining pass) and tune `--minify`. Minor win vs A; useful for CI smoke /
+quick prod-like checks.
+
+### D — Decouple the two `devenv up` build steps
+
+Frontend iteration shouldn't trigger a workspace image rebuild and vice-versa.
+Make dev mode short-circuit `klangk:flutter-build`, and document the existing
+hash-gates so people understand when `build-workspace-image` actually re-runs.
+
+### F — Bind-mount extensions instead of COPY-at-build (pi / claude-code / hermes speed)
+
+`build-workspace-image.sh` stages plugin `extension.ts` / `tools` / `hooks` into
+build-contexts and `COPY`s them into the image — so editing an extension forces a
+full image rebuild. If we instead **bind-mount** the staged plugin dir into the
+running container, extension/tool/hook edits take effect on container restart with
+**no image rebuild**. This is the container-side analogue of hot reload and the
+main lever for fast `pi`/`hermes` iteration.
+
+### E — (declined) Replace the default with hot reload
+
+Recorded for completeness; we chose opt-in to keep the release path as the
+default and as the pi/bridge validation path.
+
+### G — Stretch: hermes agent build in `klangkc` mode
+
+Containers run `pi`, `claude code`, and the `hermes` agent. Goal: get the hermes
+agent **build** running under `klangkc`. A minimax API key was added to `.env` for
+this. Investigated in the loop; findings + blockers tracked in `PROGRESS.md`.
+
+## Measured results (2026-06-23, macOS arm64, Flutter 3.41.6)
+
+Validated against a live stack (backend :8997 + nginx-dev :8995 + `flutter run
+-d web-server` :8996), driving real Chrome through nginx :8995.
+
+| Path                                                         | Time                         | Notes                                                                                                           |
+| ------------------------------------------------------------ | ---------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `flutter build web --release` (warm cache, no plugin change) | **21.3 s**                   | compile only; the `flutterbuildweb.sh` task adds plugin import + ~25 MB source-map inlining + cache-bust on top |
+| same, after a **plugin-set change**                          | minutes                      | `flutterbuildweb.sh` does `rm -rf .dart_tool/flutter_build` → full cold dart2js compile                         |
+| dev server: edit Dart + **browser refresh**                  | **~8.8 s**                   | incremental DDC recompile + app boot; **no release build runs**; needs no extension                             |
+| dev server: **hot reload/restart** (`r`/`R`)                 | sub-second–seconds, stateful | requires the **Dart Debug Extension** on the web-server device (see finding below)                              |
+
+Verified the layered routing is correct: the app loaded from the dev server
+through nginx :8995, auto-logged-in (admin2@example.com), rendered the Workspaces
+list, and reached `#/workspaces` — i.e. `/api/v1/*` and `/ws` still hit the
+backend. A title edit in `workspace_list_page.dart` appeared after a plain
+refresh with no `flutter build` invocation. Screenshots in `scratch/`.
+
+### Finding: hot reload needs a debug-connected browser
+
+`flutter run -d web-server` cannot _push_ a hot restart/reload into a browser it
+doesn't control — it relies on the **Dart Debug Extension** to relay the debug
+connection. Without it, `R` times out (`Hot restart ... received 0/1 responses`).
+Two usable modes:
+
+- **Extension-free (default, recommended to start):** edit + refresh the tab at
+  nginx :8995. DDC recompiles incrementally (~9 s here) and the app reboots.
+  Same-origin, so API/WS/bridge all work.
+- **With the Dart Debug Extension:** install it in Chrome, open :8995, and `r`/`R`
+  give true stateful hot reload (sub-second). Still same-origin via nginx.
+- **`-d chrome` is NOT used** here: it launches a Chrome it controls (so hot
+  reload works out of the box) but pointed at :8996 directly, which makes
+  `Uri.base` = :8996 and breaks the app's API/WS calls. Same-origin via nginx is
+  worth more than out-of-the-box hot reload.
+
+This reframes **Strategy B**: for the web-server device, the no-keypress win is an
+auto-**browser-reload** watcher (watch `lib/**` → tell the tab to reload →
+incremental recompile), which works _without_ the extension. Scripting `R` only
+helps once the extension is installed.
+
+## Validation plan (full local)
+
+1. Start podman VM if needed; `devenv processes up --no-tui`; confirm `:8995`.
+2. Measure baseline: time a `flutter build web --release`.
+3. Start `flutterdevweb`; load `:8995` in Chrome via the devtools MCP
+   (admin2@example.com / password).
+4. Edit a widget; confirm `R` reflects in the browser in seconds with **no** full
+   rebuild; confirm login, `/api/v1/config`, and the WS still work.
+5. Record real timings back into this doc. (macOS playwright e2e stays excluded.)

--- a/scripts/flutterdevweb.sh
+++ b/scripts/flutterdevweb.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Fast frontend iteration: run the Flutter web app through the DDC dev compiler
+# (`flutter run -d web-server`) instead of the full `flutter build web --release`
+# path (see scripts/flutterbuildweb.sh). DDC compiles incrementally, so a Dart
+# edit recompiles in seconds via hot restart (R) / hot reload (r) rather than a
+# full AOT release rebuild.
+#
+# This is the OPT-IN dev path. It does NOT replace flutterbuildweb.sh:
+#   - Default `devenv processes up` still does the release build.
+#   - `KLANGK_WEB_DEV=1 devenv processes up` makes nginx route `/` (+ assets +
+#     DWDS) to THIS dev server, while `/api/` and `/ws` still go to the backend.
+#     Because the frontend derives every API/WS URL from `Uri.base` (the nginx
+#     origin, :8995), the pi / browser-delegate bridge is unaffected.
+#
+# Usage (typical two-terminal flow):
+#   term1$  KLANGK_WEB_DEV=1 devenv processes up --no-tui     # backend + nginx(dev)
+#   term2$  devenv shell -- flutterdevweb                     # this script; press R to reload
+#
+# Env:
+#   KLANGK_WEB_DEV_PORT   dev-server port nginx proxies to (default 8996)
+#   KLANGK_WEB_FLUTTER    flutter binary (default: `flutter` on PATH / nix)
+#   KLANGK_WEB_HOT_RELOAD if "1", enable experimental web hot reload (stateful);
+#                         otherwise rely on hot restart (R), which is reliable.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "${DEVENV_ROOT:-$SCRIPT_DIR/..}"
+
+# Same plugin bootstrap as the release build: fetch plugins on first run and
+# rewrite the pubspec plugin path so the app compiles against the current set.
+if [ -f "${KLANGK_PLUGINS_DIR:-}/plugins.yaml" ] && [ ! -f "${KLANGK_PLUGINS_DIR:-}/plugins.lock" ]; then
+  echo "No plugins.lock found, running update-plugins..."
+  python3 scripts/update_plugins.py
+fi
+python3 scripts/import_dart_plugins.py
+
+FLUTTER="${KLANGK_WEB_FLUTTER:-flutter}"
+DEV_PORT="${KLANGK_WEB_DEV_PORT:-8996}"
+
+cd src/frontend
+"$FLUTTER" --disable-analytics >/dev/null 2>&1 || true
+"$FLUTTER" pub get
+
+HOT_RELOAD_FLAG=()
+if [ "${KLANGK_WEB_HOT_RELOAD:-0}" = "1" ]; then
+  # Stateful web hot reload is experimental; falls back gracefully if the
+  # installed Flutter doesn't accept the flag.
+  if "$FLUTTER" run --help 2>/dev/null | grep -q -- '--web-experimental-hot-reload'; then
+    HOT_RELOAD_FLAG=(--web-experimental-hot-reload)
+    echo "Web hot reload (experimental) enabled."
+  else
+    echo "This Flutter has no --web-experimental-hot-reload; using hot restart (R)." >&2
+  fi
+fi
+
+echo "Starting Flutter dev server on 127.0.0.1:${DEV_PORT}"
+echo "  -> with KLANGK_WEB_DEV=1, browse the app at nginx :${KLANGK_NGINX_PORT:-8995}"
+echo "  -> press R for hot restart, r for hot reload, q to quit"
+exec "$FLUTTER" run -d web-server \
+  --web-hostname=127.0.0.1 \
+  --web-port="${DEV_PORT}" \
+  --no-web-resources-cdn \
+  "${HOT_RELOAD_FLAG[@]}"

--- a/scripts/nginx.sh
+++ b/scripts/nginx.sh
@@ -115,6 +115,41 @@ ${CONTAINER_ACL}
 "
 fi
 
+# Dev mode (KLANGK_WEB_DEV=1): serve the app root from a live `flutter run`
+# dev server (scripts/flutterdevweb.sh) for hot reload, while keeping /api and
+# /ws on the backend. The frontend derives every API/WS URL from Uri.base (the
+# nginx origin), so the pi/browser-delegate bridge is unaffected — it still hits
+# the backend through its own location blocks below.
+if [ "${KLANGK_WEB_DEV:-0}" = "1" ]; then
+  _dev_port="${KLANGK_WEB_DEV_PORT:-8996}"
+  ROOT_UPSTREAM="http://127.0.0.1:${_dev_port}"
+  echo "nginx WEB DEV mode: / -> flutter dev server :${_dev_port}, /api+/ws -> backend :${KLANGK_PORT}" >&2
+  DEV_API_WS_BLOCK="
+    # Dev mode: app API + websocket must still reach the backend (the catch-all
+    # location / points at the flutter dev server in this mode).
+    location = /ws {
+      proxy_pass http://127.0.0.1:${KLANGK_PORT}/ws;
+      proxy_set_header Host \$http_host;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade \$http_upgrade;
+      proxy_set_header Connection \$connection_upgrade;
+      proxy_read_timeout 920s;
+      proxy_send_timeout 920s;
+    }
+    location /api/ {
+      proxy_pass http://127.0.0.1:${KLANGK_PORT}/api/;
+      proxy_set_header Host \$http_host;
+      proxy_set_header X-Real-IP \$remote_addr;
+      proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto \$scheme;
+      proxy_http_version 1.1;
+    }
+"
+else
+  ROOT_UPSTREAM="http://127.0.0.1:${KLANGK_PORT}"
+  DEV_API_WS_BLOCK=""
+fi
+
 cat >"$NGINX_STATE/nginx.conf" <<NGINX
 daemon off;
 pid /tmp/nginx.pid;
@@ -213,8 +248,9 @@ ${CONTAINER_ACL}
       return 401 '{\"error\":\"\$auth_token_error\",\"detail\":\"Workspace token \$auth_token_error\"}';
     }
 
+${DEV_API_WS_BLOCK}
     location / {
-      proxy_pass http://127.0.0.1:${KLANGK_PORT}/;
+      proxy_pass ${ROOT_UPSTREAM}/;
       proxy_set_header Host \$http_host;
       proxy_set_header X-Real-IP \$remote_addr;
       proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Summary

Adds a **layered, opt-in** fast-iteration path for the Flutter web frontend. Today every `devenv processes up` reruns a full `flutter build web --release` whenever `lib/**` changes; this lets you iterate via the DDC dev server (`flutter run -d web-server`) instead — incremental recompiles in seconds — **without changing the default flow**.

Autonomous session work; see `docs/dev/web-fast-iteration.md` (scenarios + strategy menu + measured results) and `docs/dev/web-fast-iteration-PROGRESS.md` (running log).

## How it works

The frontend derives every API/WS URL from `Uri.base` (`ws_client.dart:28,157`). So as long as the browser stays on nginx `:8995`, the **pi / browser-delegate bridge and all API/WS are byte-for-byte unaffected** — nginx just forks by path in dev mode:

- `/api/` + `/ws` → backend `:8997` (unchanged)
- `/` + assets + DWDS → `flutter run` dev server `:8996`

## Usage (opt-in)

```bash
# terminal 1 — backend + nginx(dev routing); release build is skipped
KLANGK_WEB_DEV=1 devenv processes up --no-tui
# terminal 2 — the dev server
devenv shell -- flutterdevweb
```
Then edit `lib/**` and **refresh the tab at :8995** (incremental DDC recompile, ~9s, no extension). Install the **Dart Debug Extension** for true sub-second `r`/`R` hot reload.

## Validated (macOS arm64, Flutter 3.41.6)

- App loads from the dev server through nginx :8995, auto-logged-in, Workspaces list renders, API + WS work → layered routing correct, pi/bridge untouched.
- Edited an app-bar title → plain browser refresh reflected it in **~8.8s** with **no `flutter build web --release`**.
- Baseline warm `flutter build web --release` = **21.3s** (cold/plugin-set change = minutes; the cache is wiped).

| Path | Time |
|------|------|
| `flutter build web --release` (warm) | 21.3s |
| dev server: edit + browser refresh | ~8.8s |
| dev server: `r`/`R` hot reload (needs Dart Debug Extension) | sub-second, stateful |

## Finding / follow-ups (not in this PR)

- `-d web-server` hot restart **needs a debug-connected browser** (Dart Debug Extension); otherwise `R` times out. Extension-free edit+refresh is the default win. `-d chrome` would give hot reload out of the box but loads from :8996 → breaks same-origin → not used.
- Next (tracked in the doc): **B** auto-reload watcher, **D/F** decouple build steps + bind-mount workspace extensions so `pi`/`claude code`/`hermes` edits skip the image rebuild, **G** hermes-in-klangkc stretch.

## Scope

Default `devenv processes up` is unchanged. Touches only `scripts/flutterdevweb.sh` (new), `scripts/nginx.sh`, `devenv.nix`, and docs.