### PR TITLE
feat: opt-in workspace dev mounts (edit Pi extensions without an image rebuild)

### DIFF
--- a/docs/dev/workspace-dev-mounts.md
+++ b/docs/dev/workspace-dev-mounts.md
@@ -1,0 +1,49 @@
+# Workspace dev mounts (edit Pi extensions without an image rebuild)
+
+Opt-in, off by default. Lets you iterate on Pi extensions inside a running
+workspace container without the `klangk:build-workspace-image` (`podman build`)
+round-trip.
+
+## Why
+
+The workspace image `COPY`s plugin/builtin Pi extensions at build time
+(`src/containers/workspace/Dockerfile`). Editing one normally changes the image
+hash and forces a full rebuild. But the container is long-lived (`sleep
+infinity`; sessions via `podman exec`) and Pi **auto-discovers
+`~/.pi/agent/extensions/`** in addition to the baked image dir
+(`klangk-setup-clankers.py`). So a host directory mounted there is **additive** —
+it doesn't hide the baked builtin/plugin extensions — and host edits show up on
+the next workspace open with no rebuild.
+
+## Usage
+
+```bash
+export KLANGK_WORKSPACE_DEV=1
+# A host dir of Pi extensions (.ts files) to overlay into the workspace:
+export KLANGK_WORKSPACE_DEV_EXTENSIONS_DIR=$PWD/src/containers/workspace/builtin-extensions
+# then start the stack as usual (devenv processes up / your normal flow)
+```
+
+Open a workspace, edit a `.ts` file in that host dir, reopen the workspace (or
+restart the agent) — the change is live, no `podman build`.
+
+- Flag accepts `1`, `true`, `yes` (case-insensitive). Anything else = off.
+- The mount is **read-only** and mounted at `/home/klangk/.pi/agent/extensions`.
+- If the flag is off, the dir is unset, or the dir doesn't exist, behaviour is
+  exactly as today (a missing-dir case logs a warning and is skipped).
+- Default / production: **unchanged** — `workspace_dev_mounts()` returns `[]`.
+
+## Implementation
+
+`container.py::workspace_dev_mounts()` returns the extra bind specs, appended to
+the container `binds`. Validated on the real `klangk-arm64` image: a host edit to
+a bind-mounted extension is reflected live in the running container with no
+rebuild and no restart, including the nested case under the `/home` mount.
+
+## Scope / follow-ups
+
+This PR covers **extensions** (the common iteration case). Tools
+(`/opt/klangk/bin`) and the frequently-edited `klangk-*` scripts could get the
+same treatment, but those live outside `/home` and would need either individual
+file mounts or a merged dir — left as a follow-up to keep this change small and
+additive.

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -84,6 +84,39 @@ def _is_named_volume(source: str) -> bool:
     return "/" not in source and not source.startswith(".")
 
 
+def workspace_dev_mounts() -> list[str]:
+    """Opt-in dev bind mounts for fast workspace iteration.
+
+    Enabled with ``KLANGK_WORKSPACE_DEV=1``. Mounts a host directory of Pi
+    extensions read-only into ``~/.pi/agent/extensions`` — which Pi
+    auto-discovers in addition to the image's baked extensions
+    (see ``klangk-setup-clankers.py``), so editing an extension on the host
+    takes effect on the next workspace open with **no image rebuild**, and the
+    baked builtin/plugin extensions are not hidden (additive mount).
+
+    The host source is ``KLANGK_WORKSPACE_DEV_EXTENSIONS_DIR``. Returns an empty
+    list (default/prod behaviour) when the flag is off, the dir is unset, or the
+    dir does not exist.
+    """
+    flag = util.resolve_env_secret("KLANGK_WORKSPACE_DEV", "")
+    if flag.lower() not in ("1", "true", "yes"):
+        return []
+    ext_dir = util.resolve_env_secret(
+        "KLANGK_WORKSPACE_DEV_EXTENSIONS_DIR", ""
+    )
+    if not ext_dir:
+        return []
+    ext_dir = os.path.realpath(ext_dir)
+    if not os.path.isdir(ext_dir):
+        logger.warning(
+            "KLANGK_WORKSPACE_DEV=1 but KLANGK_WORKSPACE_DEV_EXTENSIONS_DIR=%r "
+            "is not a directory; skipping dev extension mount.",
+            ext_dir,
+        )
+        return []
+    return [f"{ext_dir}:/home/klangk/.pi/agent/extensions:ro"]
+
+
 def _is_protected(source: str) -> bool:
     """True if source is a protected host path that must never be mounted.
 
@@ -541,6 +574,9 @@ class ContainerRegistry:
         if config_path:
             binds.append(f"{config_path}:/opt/klangk/config:ro")
         binds += extra_mounts or []
+        # Opt-in dev mounts (KLANGK_WORKSPACE_DEV=1): overlay host-side Pi
+        # extensions so they can be edited without rebuilding the image.
+        binds += workspace_dev_mounts()
 
         publish = [
             (host_port, CONTAINER_PORT_START + i)

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -1,6 +1,7 @@
 """Tests for container: idle timeout parsing, activity tracking, callbacks, port allocation."""
 
 import asyncio
+import os
 import time
 from contextlib import ExitStack, contextmanager
 from pathlib import Path
@@ -57,6 +58,53 @@ class TestImagePullPolicy:
         with caplog.at_level("WARNING"):
             assert container.image_pull_policy() == "never"
         assert "Invalid KLANGK_IMAGE_PULL_POLICY" in caplog.text
+
+
+class TestWorkspaceDevMounts:
+    def test_flag_off_returns_empty(self, monkeypatch):
+        monkeypatch.delenv("KLANGK_WORKSPACE_DEV", raising=False)
+        assert container.workspace_dev_mounts() == []
+
+    def test_flag_off_ignores_dir(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("KLANGK_WORKSPACE_DEV", raising=False)
+        monkeypatch.setenv(
+            "KLANGK_WORKSPACE_DEV_EXTENSIONS_DIR", str(tmp_path)
+        )
+        assert container.workspace_dev_mounts() == []
+
+    def test_flag_on_dir_unset_returns_empty(self, monkeypatch):
+        monkeypatch.setenv("KLANGK_WORKSPACE_DEV", "1")
+        monkeypatch.delenv(
+            "KLANGK_WORKSPACE_DEV_EXTENSIONS_DIR", raising=False
+        )
+        assert container.workspace_dev_mounts() == []
+
+    def test_flag_on_missing_dir_warns_and_empty(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        monkeypatch.setenv("KLANGK_WORKSPACE_DEV", "true")
+        missing = tmp_path / "nope"
+        monkeypatch.setenv("KLANGK_WORKSPACE_DEV_EXTENSIONS_DIR", str(missing))
+        with caplog.at_level("WARNING"):
+            assert container.workspace_dev_mounts() == []
+        assert "is not a directory" in caplog.text
+
+    def test_flag_on_valid_dir_returns_mount(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("KLANGK_WORKSPACE_DEV", "yes")
+        ext = tmp_path / "ext"
+        ext.mkdir()
+        monkeypatch.setenv("KLANGK_WORKSPACE_DEV_EXTENSIONS_DIR", str(ext))
+        mounts = container.workspace_dev_mounts()
+        assert mounts == [
+            f"{os.path.realpath(ext)}:/home/klangk/.pi/agent/extensions:ro"
+        ]
+
+    def test_disabled_value_returns_empty(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("KLANGK_WORKSPACE_DEV", "0")
+        ext = tmp_path / "ext"
+        ext.mkdir()
+        monkeypatch.setenv("KLANGK_WORKSPACE_DEV_EXTENSIONS_DIR", str(ext))
+        assert container.workspace_dev_mounts() == []
 
 
 class TestActivityTracking:


### PR DESCRIPTION
## Summary

Opt-in (off by default) fast-iteration path for the **container side**: edit Pi extensions in a running workspace without the `klangk:build-workspace-image` (`podman build`) round-trip. Companion to the web-frontend dev mode in #785 — same "layered, opt-in, default-unchanged" philosophy.

## How

The workspace container is long-lived (`sleep infinity`; sessions via `podman exec`) and Pi **auto-discovers `~/.pi/agent/extensions/`** in addition to the baked image dir (`klangk-setup-clankers.py:64`). So a host dir mounted there is **additive** — it doesn't hide the baked builtin/plugin extensions — and host edits show up on the next workspace open with no rebuild.

```bash
export KLANGK_WORKSPACE_DEV=1
export KLANGK_WORKSPACE_DEV_EXTENSIONS_DIR=$PWD/src/containers/workspace/builtin-extensions
# start the stack normally; edit a .ts file; reopen the workspace -> live, no podman build
```

`container.py::workspace_dev_mounts()` returns the extra read-only bind specs appended to the container `binds`; returns `[]` (default/prod unchanged) when the flag is off, the dir is unset, or the dir is missing (missing logs a warning).

## Validation

- **Live on the real `klangk-arm64` image:** mounted a host dir of extensions into a running workspace container; a host edit reflected live with **no rebuild and no restart**, including the nested case under the `/home` mount.
- **Unit tests:** full branch coverage of `workspace_dev_mounts()` (flag off / off-with-dir / on-no-dir / on-missing-dir-warns / on-valid-dir / disabled-value). 6 tests, all green.
- Note: 3 unrelated `TestAllowedMountRoots`/`TestProtectedPaths` tests fail **locally on macOS only** (`/tmp`→`/private/tmp` realpath); they fail identically on `main` and pass on Linux CI.

## Scope / follow-ups

Covers **extensions** (the common case). Tools (`/opt/klangk/bin`) and the frequently-edited `klangk-*` scripts live outside `/home` and would need per-file mounts or a merged dir — left as a follow-up to keep this additive and small.

See `docs/dev/workspace-dev-mounts.md`. Strategy rationale in #785's `docs/dev/web-fast-iteration.md`.