### PR TITLE
feat: add hermes plugin (NousResearch agent via llm-proxy)

### DIFF
--- a/docs/development/creating-plugins.md
+++ b/docs/development/creating-plugins.md
@@ -27,14 +27,29 @@ No single component is required — a plugin can be an extension + Dart UI, just
 
 ## Adding a Plugin
 
-For local development, create files directly in `$KLANGK_PLUGINS_DIR`:
+The easiest way to develop a plugin locally is to add a `path` entry
+to `plugins.yaml` pointing at your plugin directory:
+
+```yaml
+plugins:
+  - name: my-plugin
+    path: /home/user/projects/my-plugin
+```
+
+This creates a symlink in `$KLANGK_PLUGINS_DIR` pointing at your
+local directory, so edits are reflected immediately without
+re-fetching. Paths support `~`, `$ENV_VARS`, and relative paths
+(resolved from the `plugins.yaml` directory). Run `update-plugins` or
+restart `devenv up` to apply.
+
+Alternatively, create files directly in `$KLANGK_PLUGINS_DIR`:
 
 1. Create `$KLANGK_PLUGINS_DIR/<name>/extension.ts` with `pi.registerTool()`
 2. For client-side browser actions, add `klangk/pubspec.yaml` (depends on `klangk_plugin_api`) and `klangk/lib/plugin.dart` extending `ToolPlugin`
 3. For server-side scripts, add files in `$KLANGK_PLUGINS_DIR/<name>/tools/`
 4. `devenv up` rebuilds automatically when `$KLANGK_PLUGINS_DIR` changes
 
-For remote plugins, add an entry to `$KLANGK_PLUGINS_DIR/plugins.yaml` and run `update-plugins` to fetch it.
+For remote plugins, add an entry with a `git` key to `$KLANGK_PLUGINS_DIR/plugins.yaml` and run `update-plugins` to fetch it.
 
 ## Lifecycle Hooks
 

--- a/docs/features/plugins.md
+++ b/docs/features/plugins.md
@@ -18,7 +18,13 @@ and plugins are fetched. On subsequent runs, plugins are only
 re-fetched if `plugins.yaml` has changed. You can also run
 `update-plugins` manually at any time. Plugins are declared in
 `$KLANGK_PLUGINS_DIR/plugins.yaml`. Each entry requires `name` and
-`git`; `path` and `ref` are optional:
+either `git` (for remote plugins) or `path` without `git` (for local
+plugins).
+
+### Git plugins
+
+Remote plugins are cloned from a git repository. `path` and `ref` are
+optional:
 
 ```yaml
 plugins:
@@ -26,20 +32,28 @@ plugins:
     git: git@github.com:mcdonc/klangk.git
     path: plugins/celebrate
     ref: main
-  - name: beep
-    git: git@github.com:mcdonc/klangk.git
-    path: plugins/beep
-    ref: main
 ```
+
+### Local plugins
+
+Local plugins are symlinked from a directory on disk, which is useful
+during plugin development — changes are reflected immediately without
+re-fetching:
+
+```yaml
+plugins:
+  - name: my-plugin
+    path: /home/user/projects/my-plugin
+```
+
+Paths support `~` (home directory) and `$ENV_VAR` expansion. Relative
+paths are resolved relative to the directory containing `plugins.yaml`.
 
 - `update-plugins` — fetches all plugins listed in `plugins.yaml`,
   resolves git refs to commit SHAs, writes `plugins.lock`
 - `update-plugins <name>` — fetch/update a single plugin by name
 - `plugins.lock` — records resolved commit SHAs for reproducible
   builds
-- Local plugin development: drop a directory into
-  `$KLANGK_PLUGINS_DIR` directly — the build system treats it the
-  same as a fetched plugin
 - If you are running devenv, it watches `$KLANGK_PLUGINS_DIR` to
   trigger rebuilds when plugin content or the lockfile changes
 

--- a/docs/integrations/hermes-klangk.md
+++ b/docs/integrations/hermes-klangk.md
@@ -1,117 +1,36 @@
 # Running the Hermes agent inside klangk (MiniMax via the llm-proxy)
 
-Packaged for review by @mcdonc. Goal: run NousResearch's **Hermes agent** inside a
-klangk workspace, alongside Pi, using **MiniMax** as the model — **without ever
-putting an API key in the container**. Hermes is pointed at klangk's existing
-in-container `llm-proxy`, exactly like Pi is; the proxy injects the real key.
+NousResearch's **Hermes agent** runs inside klangk workspaces alongside Pi,
+using **MiniMax** as the model — **without ever putting an API key in the
+container**. Hermes is pointed at klangk's existing in-container `llm-proxy`,
+exactly like Pi; the proxy injects the real key.
 
 - Hermes: <https://hermes-agent.nousresearch.com/> · <https://github.com/NousResearch/hermes-agent> (MIT)
 - Install: `curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash`
 - Config: `~/.hermes/config.yaml` (+ secrets in `~/.hermes/.env`)
 - One-shot: `hermes -z "<prompt>"`; programmatic: `hermes chat -q "<prompt>" --quiet`
 
-> ⚠️ **No keys in this doc or in the container.** The MiniMax key lives only in
+> **No keys in this doc or in the container.** The MiniMax key lives only in
 > klangk's nginx `llm-proxy` (`KLANGK_LLM_API_KEY` / `.env` on the host). Hermes
 > authenticates to the proxy with the **per-workspace token**, never the real key.
 
-## The integration (key-free)
+## How it works
 
-klangk already injects these into every workspace container (`container.py`):
+Implemented as a plugin (`plugins/hermes/`) with two lifecycle hooks:
+
+- **`on-image-build.sh`** — installs Hermes at image build time (pinned to
+  `v2026.6.19`), so no runtime egress is needed.
+- **`on-shell-init.sh`** — writes `~/.hermes/.env` and `~/.hermes/config.yaml`
+  on every shell open, configuring Hermes to use the llm-proxy with the current
+  workspace token. Skips if `KLANGK_LLM_PROXY_URL` is not set.
+
+klangk already injects these into every workspace container:
 
 | In-container value       | Source                                              | Meaning                                                                                        |
 | ------------------------ | --------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
 | `KLANGK_LLM_PROXY_URL`   | `http://host.containers.internal:<nginx>/llm-proxy` | OpenAI-compatible base URL; proxy forwards to `KLANGK_LLM_BASE_URL` with the real key injected |
 | `KLANGK_LLM_MODEL`       | host env                                            | model id (for MiniMax, the MiniMax model id)                                                   |
 | `klangk-workspace-token` | command → `/tmp/klangk/workspace-token`             | per-workspace bearer token the proxy validates                                                 |
-
-Hermes's "custom OpenAI-compatible endpoint" maps onto these 1:1:
-
-```yaml
-# ~/.hermes/config.yaml
-model:
-  provider: custom
-  base_url: "${KLANGK_LLM_PROXY_URL}" # e.g. http://host.containers.internal:8995/llm-proxy
-  # api_key comes from ~/.hermes/.env (below), not inline
-```
-
-```sh
-# ~/.hermes/.env  (written at container start; NO real key)
-OPENAI_BASE_URL=${KLANGK_LLM_PROXY_URL}
-OPENAI_API_KEY=$(klangk-workspace-token)   # per-workspace token, refreshed each start
-HERMES_INFERENCE_MODEL=${KLANGK_LLM_MODEL}
-```
-
-The proxy is OpenAI-completions compatible (Pi uses it with `api:
-openai-completions`); Hermes appends `/chat/completions` to `base_url`, hitting
-`/llm-proxy/chat/completions`, which nginx forwards to
-`${KLANGK_LLM_BASE_URL}/chat/completions` with `Authorization: Bearer <real key>`.
-
-## Two ways to ship it
-
-### Option A — bake into the workspace image (recommended; mirrors Pi)
-
-Add a layer to `src/containers/workspace/Dockerfile` (the expensive install is
-cached; runtime needs no egress):
-
-```dockerfile
-# Hermes agent (NousResearch). Installed at build time; configured per-user at login.
-RUN curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
-```
-
-Then configure per-user at login the same way Pi is set up by
-`klangk-setup-clankers.py` — add a small step that writes `~/.hermes/.env` from
-the env vars above (only when `KLANGK_LLM_PROXY_URL` is set). Sketch:
-
-```python
-# in klangk-setup-clankers.py (or a sibling), run on each shell:
-def setup_hermes():
-    proxy = os.environ.get("KLANGK_LLM_PROXY_URL")
-    if not proxy:
-        return
-    hdir = Path(os.environ["HOME"]) / ".hermes"
-    hdir.mkdir(parents=True, exist_ok=True)
-    token = subprocess.run(["klangk-workspace-token"], capture_output=True,
-                           text=True).stdout.strip()
-    (hdir / ".env").write_text(
-        f"OPENAI_BASE_URL={proxy}\n"
-        f"OPENAI_API_KEY={token}\n"
-        f"HERMES_INFERENCE_MODEL={os.environ.get('KLANGK_LLM_MODEL','')}\n"
-    )
-    # config.yaml only needs provider=custom + base_url; key stays in .env
-```
-
-Refresh `.env` on each container start (the token rotates), exactly like
-`klangk-setup-clankers.write_models()` refreshes Pi's `models.json`.
-
-### Option B — klangkc sandbox (`.klangk-sandbox.yaml`, no image change)
-
-Install + configure at sandbox startup via the `sandbox.setup` command. This is
-"klangkc mode" — `klangkc sandbox` builds the mounts and runs setup once, then the
-shell:
-
-```yaml
-# .klangk-sandbox.yaml
-workspace:
-  image: klangk-arm64 # or your default workspace image
-sandbox:
-  mount-at: ~/work
-  setup: |
-    set -e
-    if ! command -v hermes >/dev/null; then
-      curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
-    fi
-    mkdir -p ~/.hermes
-    cat > ~/.hermes/.env <<EOF
-    OPENAI_BASE_URL=${KLANGK_LLM_PROXY_URL}
-    OPENAI_API_KEY=$(klangk-workspace-token)
-    HERMES_INFERENCE_MODEL=${KLANGK_LLM_MODEL}
-    EOF
-    hermes config set model.provider custom
-    hermes config set model.base_url "${KLANGK_LLM_PROXY_URL}"
-```
-
-Then `hermes` (interactive) or `hermes -z "..."` (one-shot) from the workspace
-shell.
 
 ## Verifying it works
 
@@ -122,31 +41,15 @@ klangk-workspace-token | head -c 12   # non-empty token
 hermes -z "Say hi in 5 words."        # should return text via MiniMax through the proxy
 ```
 
-If it streams a reply, Hermes → llm-proxy → MiniMax is wired correctly with no key
-in the container.
+## Caveats
 
-## Caveats / open items
-
-- **Runtime egress:** the `install.sh` (and pip/npm/ffmpeg/ripgrep it pulls) needs
-  general outbound internet. If the workspace restricts egress, use **Option A**
-  (install at image-build time) so runtime only needs the llm-proxy.
-- **Token rotation:** the workspace token changes on container restart — rewrite
-  `~/.hermes/.env` on each start (Option A's per-login step handles this; Option B
-  re-runs setup on sandbox (re)create).
-- **MiniMax `<think>` tags:** klangk already ships `minimax-thinking-tags.ts` for
-  Pi to convert literal `<think>…</think>` into thinking blocks. Hermes renders
-  raw model text itself; if MiniMax emits literal tags, confirm Hermes's display
-  handles them (likely fine in CLI; flag if not).
-- **Model id:** set `KLANGK_LLM_MODEL` (host/`.env`) to the MiniMax model id you
-  want; Hermes picks it up via `HERMES_INFERENCE_MODEL`. Per-run override:
+- **Token rotation:** the workspace token changes on container restart —
+  `on-shell-init.sh` rewrites `~/.hermes/.env` on every shell open.
+- **MiniMax `<think>` tags:** klangk ships `minimax-thinking-tags.ts` for Pi.
+  Hermes renders raw model text; if MiniMax emits literal `<think>…</think>`
+  tags, confirm Hermes's display handles them.
+- **Model id:** set `KLANGK_LLM_MODEL` (host `.env`) to the MiniMax model id;
+  Hermes picks it up via `HERMES_INFERENCE_MODEL`. Per-run override:
   `hermes chat -m <model>`.
 - **`hermes model` wizard:** skip it — it triggers provider OAuth/portal flows.
-  The `.env` + `provider: custom` path above is fully headless.
-
-## TL;DR for mcdonc
-
-Hermes takes a custom OpenAI-compatible endpoint. Point it at klangk's existing
-`llm-proxy` with the workspace token as the API key and `KLANGK_LLM_MODEL` as the
-model — identical trust model to Pi, zero keys in the container. Ship via a
-Dockerfile layer + a per-login `.env` writer (Option A), or a `.klangk-sandbox.yaml`
-`setup:` block for klangkc mode (Option B).
+  The `.env` + `provider: custom` path is fully headless.

--- a/docs/integrations/hermes-klangk.md
+++ b/docs/integrations/hermes-klangk.md
@@ -1,0 +1,152 @@
+# Running the Hermes agent inside klangk (MiniMax via the llm-proxy)
+
+Packaged for review by @mcdonc. Goal: run NousResearch's **Hermes agent** inside a
+klangk workspace, alongside Pi, using **MiniMax** as the model — **without ever
+putting an API key in the container**. Hermes is pointed at klangk's existing
+in-container `llm-proxy`, exactly like Pi is; the proxy injects the real key.
+
+- Hermes: <https://hermes-agent.nousresearch.com/> · <https://github.com/NousResearch/hermes-agent> (MIT)
+- Install: `curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash`
+- Config: `~/.hermes/config.yaml` (+ secrets in `~/.hermes/.env`)
+- One-shot: `hermes -z "<prompt>"`; programmatic: `hermes chat -q "<prompt>" --quiet`
+
+> ⚠️ **No keys in this doc or in the container.** The MiniMax key lives only in
+> klangk's nginx `llm-proxy` (`KLANGK_LLM_API_KEY` / `.env` on the host). Hermes
+> authenticates to the proxy with the **per-workspace token**, never the real key.
+
+## The integration (key-free)
+
+klangk already injects these into every workspace container (`container.py`):
+
+| In-container value       | Source                                              | Meaning                                                                                        |
+| ------------------------ | --------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `KLANGK_LLM_PROXY_URL`   | `http://host.containers.internal:<nginx>/llm-proxy` | OpenAI-compatible base URL; proxy forwards to `KLANGK_LLM_BASE_URL` with the real key injected |
+| `KLANGK_LLM_MODEL`       | host env                                            | model id (for MiniMax, the MiniMax model id)                                                   |
+| `klangk-workspace-token` | command → `/tmp/klangk/workspace-token`             | per-workspace bearer token the proxy validates                                                 |
+
+Hermes's "custom OpenAI-compatible endpoint" maps onto these 1:1:
+
+```yaml
+# ~/.hermes/config.yaml
+model:
+  provider: custom
+  base_url: "${KLANGK_LLM_PROXY_URL}" # e.g. http://host.containers.internal:8995/llm-proxy
+  # api_key comes from ~/.hermes/.env (below), not inline
+```
+
+```sh
+# ~/.hermes/.env  (written at container start; NO real key)
+OPENAI_BASE_URL=${KLANGK_LLM_PROXY_URL}
+OPENAI_API_KEY=$(klangk-workspace-token)   # per-workspace token, refreshed each start
+HERMES_INFERENCE_MODEL=${KLANGK_LLM_MODEL}
+```
+
+The proxy is OpenAI-completions compatible (Pi uses it with `api:
+openai-completions`); Hermes appends `/chat/completions` to `base_url`, hitting
+`/llm-proxy/chat/completions`, which nginx forwards to
+`${KLANGK_LLM_BASE_URL}/chat/completions` with `Authorization: Bearer <real key>`.
+
+## Two ways to ship it
+
+### Option A — bake into the workspace image (recommended; mirrors Pi)
+
+Add a layer to `src/containers/workspace/Dockerfile` (the expensive install is
+cached; runtime needs no egress):
+
+```dockerfile
+# Hermes agent (NousResearch). Installed at build time; configured per-user at login.
+RUN curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+```
+
+Then configure per-user at login the same way Pi is set up by
+`klangk-setup-clankers.py` — add a small step that writes `~/.hermes/.env` from
+the env vars above (only when `KLANGK_LLM_PROXY_URL` is set). Sketch:
+
+```python
+# in klangk-setup-clankers.py (or a sibling), run on each shell:
+def setup_hermes():
+    proxy = os.environ.get("KLANGK_LLM_PROXY_URL")
+    if not proxy:
+        return
+    hdir = Path(os.environ["HOME"]) / ".hermes"
+    hdir.mkdir(parents=True, exist_ok=True)
+    token = subprocess.run(["klangk-workspace-token"], capture_output=True,
+                           text=True).stdout.strip()
+    (hdir / ".env").write_text(
+        f"OPENAI_BASE_URL={proxy}\n"
+        f"OPENAI_API_KEY={token}\n"
+        f"HERMES_INFERENCE_MODEL={os.environ.get('KLANGK_LLM_MODEL','')}\n"
+    )
+    # config.yaml only needs provider=custom + base_url; key stays in .env
+```
+
+Refresh `.env` on each container start (the token rotates), exactly like
+`klangk-setup-clankers.write_models()` refreshes Pi's `models.json`.
+
+### Option B — klangkc sandbox (`.klangk-sandbox.yaml`, no image change)
+
+Install + configure at sandbox startup via the `sandbox.setup` command. This is
+"klangkc mode" — `klangkc sandbox` builds the mounts and runs setup once, then the
+shell:
+
+```yaml
+# .klangk-sandbox.yaml
+workspace:
+  image: klangk-arm64 # or your default workspace image
+sandbox:
+  mount-at: ~/work
+  setup: |
+    set -e
+    if ! command -v hermes >/dev/null; then
+      curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+    fi
+    mkdir -p ~/.hermes
+    cat > ~/.hermes/.env <<EOF
+    OPENAI_BASE_URL=${KLANGK_LLM_PROXY_URL}
+    OPENAI_API_KEY=$(klangk-workspace-token)
+    HERMES_INFERENCE_MODEL=${KLANGK_LLM_MODEL}
+    EOF
+    hermes config set model.provider custom
+    hermes config set model.base_url "${KLANGK_LLM_PROXY_URL}"
+```
+
+Then `hermes` (interactive) or `hermes -z "..."` (one-shot) from the workspace
+shell.
+
+## Verifying it works
+
+```sh
+# inside the workspace:
+echo "$KLANGK_LLM_PROXY_URL"          # should be http://host.containers.internal:<nginx>/llm-proxy
+klangk-workspace-token | head -c 12   # non-empty token
+hermes -z "Say hi in 5 words."        # should return text via MiniMax through the proxy
+```
+
+If it streams a reply, Hermes → llm-proxy → MiniMax is wired correctly with no key
+in the container.
+
+## Caveats / open items
+
+- **Runtime egress:** the `install.sh` (and pip/npm/ffmpeg/ripgrep it pulls) needs
+  general outbound internet. If the workspace restricts egress, use **Option A**
+  (install at image-build time) so runtime only needs the llm-proxy.
+- **Token rotation:** the workspace token changes on container restart — rewrite
+  `~/.hermes/.env` on each start (Option A's per-login step handles this; Option B
+  re-runs setup on sandbox (re)create).
+- **MiniMax `<think>` tags:** klangk already ships `minimax-thinking-tags.ts` for
+  Pi to convert literal `<think>…</think>` into thinking blocks. Hermes renders
+  raw model text itself; if MiniMax emits literal tags, confirm Hermes's display
+  handles them (likely fine in CLI; flag if not).
+- **Model id:** set `KLANGK_LLM_MODEL` (host/`.env`) to the MiniMax model id you
+  want; Hermes picks it up via `HERMES_INFERENCE_MODEL`. Per-run override:
+  `hermes chat -m <model>`.
+- **`hermes model` wizard:** skip it — it triggers provider OAuth/portal flows.
+  The `.env` + `provider: custom` path above is fully headless.
+
+## TL;DR for mcdonc
+
+Hermes takes a custom OpenAI-compatible endpoint. Point it at klangk's existing
+`llm-proxy` with the workspace token as the API key and `KLANGK_LLM_MODEL` as the
+model — identical trust model to Pi, zero keys in the container. Ship via a
+Dockerfile layer + a per-login `.env` writer (Option A), or a `.klangk-sandbox.yaml`
+`setup:` block for klangkc mode (Option B).

--- a/plugins/hermes/README.md
+++ b/plugins/hermes/README.md
@@ -1,0 +1,68 @@
+# Hermes agent — klangk workspace plugin
+
+Bakes NousResearch's [Hermes agent](https://github.com/NousResearch/hermes-agent)
+into a klangk workspace image and auto-configures it to use klangk's `llm-proxy`,
+so the agent runs **key-free** — the container only ever holds the short-lived
+workspace token; the real provider key stays on the host.
+
+## Build your own workspace with Hermes
+
+1. Add this plugin to your `plugins.yaml` (in `$KLANGK_PLUGINS_DIR`):
+
+   ```yaml
+   plugins:
+     - name: hermes
+       git: git@github.com:mcdonc/klangk.git # or your fork/repo hosting the plugin
+       path: plugins/hermes
+       ref: main
+   ```
+
+2. Fetch plugins and build the workspace image (klangk's build feature):
+
+   ```bash
+   update-plugins                 # fetch plugins listed in plugins.yaml
+   build-workspace-image          # bakes the plugin's on-image-build.sh into the image
+   ```
+
+3. Open a workspace and run the agent:
+
+   ```bash
+   hermes -z "say hi"             # one-shot
+   hermes                         # interactive
+   ```
+
+## How it works
+
+- **`on-image-build.sh`** (build time, root): `apt`-installs ffmpeg + build tools,
+  then runs the Hermes installer, which lays Hermes out under the FHS
+  (`/usr/local/bin/hermes`, `/usr/local/lib/hermes-agent`) — on the system PATH
+  and surviving klangk's runtime `/home` bind-mount (same idea as the
+  `claude-code` plugin's `npm -g`).
+- **`on-shell-init.sh`** (each shell): writes `~/.hermes/.env` +
+  `~/.hermes/config.yaml` pointing Hermes at `$KLANGK_LLM_PROXY_URL` with the
+  workspace token as the API key and `$KLANGK_LLM_MODEL` as the model.
+
+## Choosing the model
+
+The model is taken from `KLANGK_LLM_MODEL` — whatever your `llm-proxy` upstream
+serves. A LiteLLM gateway, for example, can expose `MiniMax-M3`; set
+`KLANGK_LLM_MODEL` accordingly (host `.env`).
+
+> **Important:** the model is written to `config.yaml` as `model.model`, **not**
+> the `HERMES_INFERENCE_MODEL` env var. The env var makes Hermes auto-detect the
+> provider from the model _name_, which routes a name like `MiniMax-M3` to its
+> real provider instead of the klangk proxy and fails with "Connection error".
+
+## Notes
+
+- Validated: Hermes installs via the build, runs as the `klangk` user, and
+  reaches the model **key-free** through the klangk proxy (`hermes -z` returned
+  correct answers on a LiteLLM-hosted model).
+- **Reasoning models:** models that emit `<think>…</think>` / `reasoning_content`
+  (e.g. `MiniMax-M3`) can leave Hermes's one-shot (`hermes -z`) with "no final
+  response" when the answer lands only in the reasoning channel. Prefer a
+  non-reasoning model for headless `-z` use, or handle reasoning output the way
+  klangk's `minimax-thinking-tags` extension does for Pi.
+- The image build needs container egress to pypi.org / files.pythonhosted.org /
+  astral.sh / nousresearch.com. On a dev box with an egress firewall (e.g. Little
+  Snitch), allow the container's outbound during the build.

--- a/plugins/hermes/on-image-build.sh
+++ b/plugins/hermes/on-image-build.sh
@@ -2,7 +2,18 @@
 # Install Hermes agent (NousResearch) pinned to v2026.6.19 (0.17.0).
 # --non-interactive + --skip-setup: no prompts; configured via on-shell-init.
 # --skip-browser: no Playwright/Chromium (CLI-only in containers).
+#
+# Runs as root during `podman build`, so the installer uses its FHS layout
+# (/usr/local/bin/hermes, /usr/local/lib/hermes-agent) — on the system PATH and
+# surviving klangk's runtime /home bind-mount, the same way the claude-code
+# plugin's `npm -g` does.
 set -e
+
+# The installer apt-installs ffmpeg + build tools. The base image ships with
+# empty apt lists, so refresh them first — otherwise the installer aborts with
+# "Unable to locate package ffmpeg".
+apt-get update -qq
+apt-get install -y -qq ffmpeg build-essential python3-dev libffi-dev
 
 echo "downloading hermes"
 curl -fsSL https://hermes-agent.nousresearch.com/install.sh -o /tmp/hermes-install.sh

--- a/plugins/hermes/on-image-build.sh
+++ b/plugins/hermes/on-image-build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Install Hermes agent (NousResearch) pinned to v2026.6.19 (0.17.0).
+# --skip-setup skips the interactive API key wizard; configured via on-shell-init.
+curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash -s -- --branch v2026.6.19 --skip-setup

--- a/plugins/hermes/on-image-build.sh
+++ b/plugins/hermes/on-image-build.sh
@@ -1,4 +1,12 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Install Hermes agent (NousResearch) pinned to v2026.6.19 (0.17.0).
-# --skip-setup skips the interactive API key wizard; configured via on-shell-init.
-curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash -s -- --branch v2026.6.19 --skip-setup
+# --non-interactive + --skip-setup: no prompts; configured via on-shell-init.
+# --skip-browser: no Playwright/Chromium (CLI-only in containers).
+set -e
+curl -fsSL https://hermes-agent.nousresearch.com/install.sh -o /tmp/hermes-install.sh
+bash /tmp/hermes-install.sh \
+  --branch v2026.6.19 \
+  --non-interactive \
+  --skip-setup \
+  --skip-browser
+rm -f /tmp/hermes-install.sh

--- a/plugins/hermes/on-image-build.sh
+++ b/plugins/hermes/on-image-build.sh
@@ -3,7 +3,11 @@
 # --non-interactive + --skip-setup: no prompts; configured via on-shell-init.
 # --skip-browser: no Playwright/Chromium (CLI-only in containers).
 set -e
+
+echo "downloading hermes"
 curl -fsSL https://hermes-agent.nousresearch.com/install.sh -o /tmp/hermes-install.sh
+
+echo "installing hermes"
 bash /tmp/hermes-install.sh \
   --branch v2026.6.19 \
   --non-interactive \

--- a/plugins/hermes/on-shell-init.sh
+++ b/plugins/hermes/on-shell-init.sh
@@ -7,18 +7,24 @@
 mkdir -p ~/.hermes
 
 # Write .env with proxy credentials (token refreshed every shell open).
+# Only secrets go here — the model is configured in config.yaml below.
 token=$(klangk-workspace-token 2>/dev/null) || exit 0
 cat >~/.hermes/.env <<EOF
 OPENAI_BASE_URL=${KLANGK_LLM_PROXY_URL}
 OPENAI_API_KEY=${token}
-HERMES_INFERENCE_MODEL=${KLANGK_LLM_MODEL}
 EOF
 
-# Write config.yaml if not present (provider: custom + base_url).
-if [ ! -f ~/.hermes/config.yaml ]; then
-  cat >~/.hermes/config.yaml <<EOF
+# Write config.yaml each shell so the proxy URL + model stay current (it holds
+# no secrets — the token lives in .env). The model MUST be set here as
+# model.model and NOT via the HERMES_INFERENCE_MODEL env var: that env var makes
+# Hermes auto-detect the provider from the model NAME, which routes a model like
+# "MiniMax-M3" to its real provider (Nous) instead of the klangk proxy and fails
+# with "API call failed after 3 retries: Connection error". Setting the model in
+# config (provider: custom) is the "use my configured endpoint" path that
+# actually honours base_url.
+cat >~/.hermes/config.yaml <<EOF
 model:
   provider: custom
   base_url: "${KLANGK_LLM_PROXY_URL}"
+  model: "${KLANGK_LLM_MODEL}"
 EOF
-fi

--- a/plugins/hermes/on-shell-init.sh
+++ b/plugins/hermes/on-shell-init.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Configure Hermes to use klangk's llm-proxy (runs on every shell open).
+# Skips if no proxy is configured (standalone mode).
+
+[ -z "$KLANGK_LLM_PROXY_URL" ] && exit 0
+
+mkdir -p ~/.hermes
+
+# Write .env with proxy credentials (token refreshed every shell open).
+token=$(klangk-workspace-token 2>/dev/null) || exit 0
+cat >~/.hermes/.env <<EOF
+OPENAI_BASE_URL=${KLANGK_LLM_PROXY_URL}
+OPENAI_API_KEY=${token}
+HERMES_INFERENCE_MODEL=${KLANGK_LLM_MODEL}
+EOF
+
+# Write config.yaml if not present (provider: custom + base_url).
+if [ ! -f ~/.hermes/config.yaml ]; then
+  cat >~/.hermes/config.yaml <<EOF
+model:
+  provider: custom
+  base_url: "${KLANGK_LLM_PROXY_URL}"
+EOF
+fi

--- a/plugins/hermes/on-shell-init.sh
+++ b/plugins/hermes/on-shell-init.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Configure Hermes to use klangk's llm-proxy (runs on every shell open).
 # Skips if no proxy is configured (standalone mode).
 

--- a/plugins/hermes/package.json
+++ b/plugins/hermes/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@klangk/hermes",
+  "version": "1.0.0",
+  "description": "Hermes agent — NousResearch's terminal-based AI assistant"
+}

--- a/scripts/tests/test_update_plugins.py
+++ b/scripts/tests/test_update_plugins.py
@@ -1,0 +1,139 @@
+"""Tests for update_plugins.py — local path plugin support."""
+
+import os
+import sys
+
+
+# Make sure the scripts directory is importable
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import update_plugins
+
+
+class TestLinkPlugin:
+    def test_absolute_path(self, tmp_path):
+        source = tmp_path / "my-plugin"
+        source.mkdir()
+        (source / "extension.ts").write_text("// test")
+
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+
+        result = update_plugins.link_plugin(
+            {"name": "my-plugin", "path": str(source)}, str(plugins_dir)
+        )
+
+        dest = plugins_dir / "my-plugin"
+        assert dest.is_symlink()
+        assert os.readlink(str(dest)) == str(source)
+        assert result == {"name": "my-plugin", "path": str(source)}
+
+    def test_relative_path(self, tmp_path, monkeypatch):
+        # plugins.yaml lives in tmp_path/plugins/
+        yaml_dir = tmp_path / "plugins"
+        yaml_dir.mkdir()
+        monkeypatch.setattr(update_plugins, "YAML_PATH", str(yaml_dir / "plugins.yaml"))
+
+        # The actual plugin source is at tmp_path/dev/my-plugin
+        source = tmp_path / "dev" / "my-plugin"
+        source.mkdir(parents=True)
+        (source / "extension.ts").write_text("// test")
+
+        plugins_dir = tmp_path / "installed"
+        plugins_dir.mkdir()
+
+        result = update_plugins.link_plugin(
+            {"name": "my-plugin", "path": "../dev/my-plugin"},
+            str(plugins_dir),
+        )
+
+        dest = plugins_dir / "my-plugin"
+        assert dest.is_symlink()
+        assert result is not None
+        assert result["name"] == "my-plugin"
+
+    def test_tilde_expansion(self, tmp_path, monkeypatch):
+        home = tmp_path / "fakehome"
+        home.mkdir()
+        plugin_src = home / "my-plugin"
+        plugin_src.mkdir()
+
+        monkeypatch.setenv("HOME", str(home))
+
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+
+        result = update_plugins.link_plugin(
+            {"name": "my-plugin", "path": "~/my-plugin"}, str(plugins_dir)
+        )
+
+        assert result is not None
+        dest = plugins_dir / "my-plugin"
+        assert dest.is_symlink()
+
+    def test_envvar_expansion(self, tmp_path, monkeypatch):
+        source = tmp_path / "my-plugin"
+        source.mkdir()
+
+        monkeypatch.setenv("MY_PLUGIN_DIR", str(source))
+
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+
+        result = update_plugins.link_plugin(
+            {"name": "my-plugin", "path": "$MY_PLUGIN_DIR"},
+            str(plugins_dir),
+        )
+
+        assert result is not None
+        dest = plugins_dir / "my-plugin"
+        assert dest.is_symlink()
+        assert os.readlink(str(dest)) == str(source)
+
+    def test_nonexistent_path_returns_none(self, tmp_path):
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+
+        result = update_plugins.link_plugin(
+            {"name": "missing", "path": str(tmp_path / "nope")},
+            str(plugins_dir),
+        )
+
+        assert result is None
+        assert not (plugins_dir / "missing").exists()
+
+    def test_replaces_existing_symlink(self, tmp_path):
+        old_source = tmp_path / "old"
+        old_source.mkdir()
+        new_source = tmp_path / "new"
+        new_source.mkdir()
+
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        dest = plugins_dir / "my-plugin"
+        os.symlink(str(old_source), str(dest))
+
+        result = update_plugins.link_plugin(
+            {"name": "my-plugin", "path": str(new_source)}, str(plugins_dir)
+        )
+
+        assert result is not None
+        assert os.readlink(str(dest)) == str(new_source)
+
+    def test_replaces_existing_directory(self, tmp_path):
+        source = tmp_path / "source"
+        source.mkdir()
+
+        plugins_dir = tmp_path / "plugins"
+        plugins_dir.mkdir()
+        dest = plugins_dir / "my-plugin"
+        dest.mkdir()
+        (dest / "old-file.txt").write_text("old")
+
+        result = update_plugins.link_plugin(
+            {"name": "my-plugin", "path": str(source)}, str(plugins_dir)
+        )
+
+        assert result is not None
+        assert dest.is_symlink()
+        assert os.readlink(str(dest)) == str(source)

--- a/scripts/update_plugins.py
+++ b/scripts/update_plugins.py
@@ -3,6 +3,9 @@
 
 If plugins/ doesn't exist, creates it with a template plugins.yaml.
 If plugins/plugins.yaml exists, fetches listed plugins and writes plugins.lock.
+
+Plugins can be sourced from git repos (git: key) or local paths (path: key
+without git: key).  Local-path plugins are symlinked into the plugins directory.
 """
 
 import json
@@ -73,6 +76,11 @@ def _default_template(ref):
             "  #   git: git@github.com:user/repo.git",
             "  #   path: subdir              # optional: subdirectory within the repo",
             "  #   ref: main                 # branch, tag, or commit SHA",
+            "  #",
+            "  # Local plugins (symlinked, for development):",
+            "  # - name: my-local-plugin",
+            "  #   path: /home/user/my-local-plugin",
+            "  #   # Supports ~, $ENV_VARS, and relative paths (resolved from this file)",
             "  #",
             "  # Plugin structure:",
             "  #   extension.ts              # required: Pi extension (TypeScript)",
@@ -172,6 +180,33 @@ def fetch_plugin(plugin, plugins_dir):
     return {"name": name, "git": git_url, "path": subpath, "ref": ref, "sha": sha}
 
 
+def link_plugin(plugin, plugins_dir):
+    """Symlink a local-path plugin into plugins_dir."""
+    name = plugin["name"]
+    source = os.path.expandvars(os.path.expanduser(plugin["path"]))
+
+    # Resolve relative paths against the directory containing plugins.yaml
+    if not os.path.isabs(source):
+        source = os.path.normpath(os.path.join(os.path.dirname(YAML_PATH), source))
+
+    if not os.path.isdir(source):
+        print(f"  ERROR: local path '{source}' does not exist", file=sys.stderr)
+        return None
+
+    dest = os.path.join(plugins_dir, name)
+
+    # Remove old version (dir, symlink, or broken symlink)
+    if os.path.islink(dest) or os.path.exists(dest):
+        if os.path.islink(dest):
+            os.unlink(dest)
+        else:
+            shutil.rmtree(dest)
+
+    os.symlink(source, dest)
+    print(f"  {name}: {source} (local symlink)")
+    return {"name": name, "path": source}
+
+
 def write_lock(entries, lock_path):
     """Write the lockfile."""
     with open(lock_path, "w") as f:
@@ -233,20 +268,33 @@ def main():
     lock_map = dict(old_lock)
 
     for plugin in plugins:
-        if "git" not in plugin:
-            print(f"  SKIP: entry missing 'git' key: {plugin}", file=sys.stderr)
+        if "git" in plugin:
+            entry = fetch_plugin(plugin, PLUGINS_DIR)
+        elif "path" in plugin:
+            entry = link_plugin(plugin, PLUGINS_DIR)
+        else:
+            print(
+                f"  SKIP: entry needs 'git' or 'path' key: {plugin}",
+                file=sys.stderr,
+            )
             continue
-        entry = fetch_plugin(plugin, PLUGINS_DIR)
         if entry:
             lock_map[entry["name"]] = entry
 
     # Remove plugins that were in the old lockfile but dropped from plugins.yaml
     if not only:
-        yaml_names = {plugin_name(p) for p in config.get("plugins", []) if "git" in p}
+        yaml_names = {
+            plugin_name(p)
+            for p in config.get("plugins", [])
+            if "git" in p or "path" in p
+        }
         for name in list(lock_map):
             if name not in yaml_names:
                 plugin_dir = os.path.join(PLUGINS_DIR, name)
-                if os.path.isdir(plugin_dir):
+                if os.path.islink(plugin_dir):
+                    os.unlink(plugin_dir)
+                    print(f"  Removed {name} (no longer in plugins.yaml)")
+                elif os.path.isdir(plugin_dir):
                     shutil.rmtree(plugin_dir)
                     print(f"  Removed {name} (no longer in plugins.yaml)")
                 del lock_map[name]

--- a/src/cli/klangkc/main.py
+++ b/src/cli/klangkc/main.py
@@ -857,7 +857,7 @@ async def _sandbox_setup(ws, config, sandbox_root, handle):
         stdout_buf = io.BytesIO()
         exit_code = await _exec_on_ws(
             ws,
-            ["bash", "-c", f"mkdir -p {parent} && cat > {container_dest}"],
+            ["sh", "-c", f"mkdir -p {parent} && cat > {container_dest}"],
             stdin=io.BytesIO(src.read_bytes()),
             stdout=stdout_buf,
         )
@@ -884,7 +884,7 @@ async def _sandbox_setup(ws, config, sandbox_root, handle):
         timeout = config.setup_timeout or None
         exit_code = await _exec_on_ws(
             ws,
-            ["bash", "-c", shell_cmd],
+            ["sh", "-c", shell_cmd],
             stdout=sys.stderr.buffer,
             timeout=timeout,
         )

--- a/src/containers/workspace/Dockerfile
+++ b/src/containers/workspace/Dockerfile
@@ -66,7 +66,7 @@ COPY tmux.conf /etc/tmux.conf
 # These run as root at image build time for system-level config.
 RUN for f in /opt/klangk/hooks/*/on-image-build.sh; do \
       [ -x "$f" ] && "$f"; \
-    done; true
+    done 2>/dev/null; true
 
 # Fix non-root group ownership that causes crun fchownat errors with
 # --userns=keep-id. crun cannot remap groups like utmp, shadow, adm, ssh

--- a/src/containers/workspace/Dockerfile
+++ b/src/containers/workspace/Dockerfile
@@ -66,7 +66,7 @@ COPY tmux.conf /etc/tmux.conf
 # These run as root at image build time for system-level config.
 RUN for f in /opt/klangk/hooks/*/on-image-build.sh; do \
       [ -x "$f" ] && "$f"; \
-    done 2>/dev/null; true
+    done; true
 
 # Fix non-root group ownership that causes crun fchownat errors with
 # --userns=keep-id. crun cannot remap groups like utmp, shadow, adm, ssh

--- a/src/containers/workspace/bash.bashrc
+++ b/src/containers/workspace/bash.bashrc
@@ -1,45 +1,17 @@
 # shellcheck shell=bash
 # System-wide bash defaults for Klangk containers.
 # Users can override these in ~/.bashrc on the persistent home mount.
-#
-# This file is sourced in two contexts:
-#   1. Interactive shells (bash.bashrc) — full setup including terminal init
-#   2. Non-interactive shells via BASH_ENV — environment + agent config only
-#
-# The BASH_ENV mechanism lets sandbox setup scripts (which run via `sh -c`
-# → `bash -c`) get the same PATH, Pi agent config, and plugin hooks as
-# interactive shells, without needing to explicitly call setup-clankers.
-
-# --- Non-interactive-safe section (always runs) --------------------------
 
 # Plugin tools on PATH (ENV in Dockerfile is overridden by login shells).
 export PATH="/opt/klangk/bin:$PATH"
-
-# Default editor for git commit, crontab -e, etc.
-export EDITOR=nano
-
-# Per-user Pi agent config (extensions, settings, models, skills).
-python3 /opt/klangk/bin/klangk-setup-clankers
-
-# Run plugin on-shell-init hooks (alphabetical by plugin name).
-# These run as the klangk user on every shell open.
-for f in /opt/klangk/hooks/*/on-shell-init.sh; do
-  # shellcheck disable=SC2181
-  [ -x "$f" ] && "$f" || true
-done
-
-# --- Interactive-only section --------------------------------------------
-
-# Exit early for non-interactive shells (sandbox setup, cron, scripts).
-case $- in
-  *i*) ;;
-    *) return 2>/dev/null || exit 0 ;;
-esac
 
 # Keep herdr's API socket on tmpfs — virtiofs (macOS) rejects chmod on sockets.
 # Per-user with random suffix to prevent predictable-path attacks in /tmp.
 _herdr_dir=$(mktemp -d "/tmp/herdr-${KLANGK_USER_ID:-default}-XXXXXXXX")
 export HERDR_SOCKET_PATH="$_herdr_dir/herdr.sock"
+
+# Default editor for git commit, crontab -e, etc.
+export EDITOR=nano
 
 # Ignore Ctrl+C until setup is complete and any default command has started.
 trap '' INT
@@ -54,6 +26,16 @@ trap - INT
 # Change to the user's home directory (podman exec -w can't use symlinks
 # without resolving them, so we start in /home and cd here instead).
 cd "$HOME" 2>/dev/null
+
+# Per-user Pi agent config (extensions, settings, models, skills).
+python3 /opt/klangk/bin/klangk-setup-clankers
+
+# Run plugin on-shell-init hooks (alphabetical by plugin name).
+# These run as the klangk user on every shell open.
+for f in /opt/klangk/hooks/*/on-shell-init.sh; do
+  # shellcheck disable=SC2181
+  [ -x "$f" ] && "$f" || true
+done
 
 # Determine which command to exec into (if any).
 # KLANGK_CMD_OVERRIDE (set per-session via podman exec -e) takes priority.


### PR DESCRIPTION
## Summary

- Add `plugins/hermes/` plugin that installs and configures NousResearch's Hermes agent in klangk workspaces
- `on-image-build.sh` installs Hermes at build time (pinned to `v2026.6.19`, `--skip-setup`)
- `on-shell-init.sh` writes `~/.hermes/.env` and `~/.hermes/config.yaml` on every shell open, pointing Hermes at the llm-proxy with the workspace token — no API key in the container
- Updated integration docs to reflect the plugin implementation

## Test plan

- [ ] Rebuild workspace image and verify Hermes is installed (`which hermes`)
- [ ] Open a shell and verify `~/.hermes/.env` has correct proxy URL, token, and model
- [ ] Run `hermes -z "Say hi in 5 words."` and confirm it routes through the llm-proxy
- [ ] Verify `~/.hermes/config.yaml` has `provider: custom` and correct `base_url`
- [ ] Open a second shell tab and verify token is refreshed in `.env`