### PR TITLE
fix: source bashrc for non-interactive sandbox setup scripts

### DIFF
--- a/src/cli/klangkc/main.py
+++ b/src/cli/klangkc/main.py
@@ -856,7 +856,7 @@ async def _sandbox_setup(ws, config, sandbox_root, handle):
         stdout_buf = io.BytesIO()
         exit_code = await _exec_on_ws(
             ws,
-            ["sh", "-c", f"mkdir -p {parent} && cat > {container_dest}"],
+            ["bash", "-c", f"mkdir -p {parent} && cat > {container_dest}"],
             stdin=io.BytesIO(src.read_bytes()),
             stdout=stdout_buf,
         )
@@ -883,7 +883,7 @@ async def _sandbox_setup(ws, config, sandbox_root, handle):
         timeout = config.setup_timeout or None
         exit_code = await _exec_on_ws(
             ws,
-            ["sh", "-c", shell_cmd],
+            ["bash", "-c", shell_cmd],
             stdout=sys.stderr.buffer,
             timeout=timeout,
         )

--- a/src/containers/workspace/Dockerfile
+++ b/src/containers/workspace/Dockerfile
@@ -10,6 +10,9 @@ RUN npm install -g @earendil-works/pi-coding-agent@0.79.9 \
 
 # Plugin tools: flat directory, all on PATH via /opt/klangk/bin/
 ENV PATH="/opt/klangk/bin:${PATH}"
+# Let non-interactive bash shells (sandbox setup scripts, `bash -c`) source
+# the same environment as interactive shells — PATH, Pi agent config, etc.
+ENV BASH_ENV="/etc/bash.bashrc"
 COPY --from=plugin-tools / /opt/klangk/bin/
 RUN echo 'PATH="/opt/klangk/bin:${PATH}"' >> /etc/environment
 

--- a/src/containers/workspace/bash.bashrc
+++ b/src/containers/workspace/bash.bashrc
@@ -1,17 +1,45 @@
 # shellcheck shell=bash
 # System-wide bash defaults for Klangk containers.
 # Users can override these in ~/.bashrc on the persistent home mount.
+#
+# This file is sourced in two contexts:
+#   1. Interactive shells (bash.bashrc) — full setup including terminal init
+#   2. Non-interactive shells via BASH_ENV — environment + agent config only
+#
+# The BASH_ENV mechanism lets sandbox setup scripts (which run via `sh -c`
+# → `bash -c`) get the same PATH, Pi agent config, and plugin hooks as
+# interactive shells, without needing to explicitly call setup-clankers.
+
+# --- Non-interactive-safe section (always runs) --------------------------
 
 # Plugin tools on PATH (ENV in Dockerfile is overridden by login shells).
 export PATH="/opt/klangk/bin:$PATH"
+
+# Default editor for git commit, crontab -e, etc.
+export EDITOR=nano
+
+# Per-user Pi agent config (extensions, settings, models, skills).
+python3 /opt/klangk/bin/klangk-setup-clankers
+
+# Run plugin on-shell-init hooks (alphabetical by plugin name).
+# These run as the klangk user on every shell open.
+for f in /opt/klangk/hooks/*/on-shell-init.sh; do
+  # shellcheck disable=SC2181
+  [ -x "$f" ] && "$f" || true
+done
+
+# --- Interactive-only section --------------------------------------------
+
+# Exit early for non-interactive shells (sandbox setup, cron, scripts).
+case $- in
+  *i*) ;;
+    *) return 2>/dev/null || exit 0 ;;
+esac
 
 # Keep herdr's API socket on tmpfs — virtiofs (macOS) rejects chmod on sockets.
 # Per-user with random suffix to prevent predictable-path attacks in /tmp.
 _herdr_dir=$(mktemp -d "/tmp/herdr-${KLANGK_USER_ID:-default}-XXXXXXXX")
 export HERDR_SOCKET_PATH="$_herdr_dir/herdr.sock"
-
-# Default editor for git commit, crontab -e, etc.
-export EDITOR=nano
 
 # Ignore Ctrl+C until setup is complete and any default command has started.
 trap '' INT
@@ -26,16 +54,6 @@ trap - INT
 # Change to the user's home directory (podman exec -w can't use symlinks
 # without resolving them, so we start in /home and cd here instead).
 cd "$HOME" 2>/dev/null
-
-# Per-user Pi agent config (extensions, settings, models, skills).
-python3 /opt/klangk/bin/klangk-setup-clankers
-
-# Run plugin on-shell-init hooks (alphabetical by plugin name).
-# These run as the klangk user on every shell open.
-for f in /opt/klangk/hooks/*/on-shell-init.sh; do
-  # shellcheck disable=SC2181
-  [ -x "$f" ] && "$f" || true
-done
 
 # Determine which command to exec into (if any).
 # KLANGK_CMD_OVERRIDE (set per-session via podman exec -e) takes priority.


### PR DESCRIPTION
## Summary

- Sandbox setup scripts (`setup.sh`) run via `sh -c "... bash -c 'setup.sh'"` — non-interactive, so `bash.bashrc` never fires
- If setup does `pi install`, Pi creates a minimal `settings.json` (just `packages`) before `klangk-setup-clankers` has run
- `setup-clankers` later sees `settings.json` exists and skips, leaving Pi without `defaultProvider`, `defaultModel`, `extensions`
- **Fix**: Set `BASH_ENV=/etc/bash.bashrc` in the Dockerfile so non-interactive `bash -c` sources bashrc automatically. Guard interactive-only code (`trap`, wait-for-ready, `stty`, default command exec) behind `case $-`.

## Test plan

- [x] `klangkc sandbox` with a `setup.sh` containing `pi install <pkg>`
- [x] Verified `~/.pi/agent/settings.json` has full config (provider, model, extensions) plus the installed package
- [x] Verified `pi list` shows both image packages and the setup-installed package

Fixes #788