### PR TITLE
feat: add --open/-o flag to klangkc sandbox

### DIFF
--- a/docs/features/sandbox.md
+++ b/docs/features/sandbox.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD013 -->
+
 # Sandbox
 
 `klangkc sandbox` creates and connects to a workspace using a
@@ -166,7 +168,7 @@ next shell session without recreating the workspace.
 ## Command reference
 
 ```text
-klangkc sandbox WORKSPACE [PATH] [--forward-agent/-A] [--force-setup]
+klangkc sandbox WORKSPACE [PATH] [--forward-agent/-A] [--force-setup] [--open/-o MODE]
 ```
 
 | Argument/Flag        | Default | Description                                                             |
@@ -175,6 +177,7 @@ klangkc sandbox WORKSPACE [PATH] [--forward-agent/-A] [--force-setup]
 | `PATH`               | `.`     | Path to the sandbox root (directory containing `.klangk-sandbox.yaml`). |
 | `--forward-agent/-A` | `false` | Forward local SSH agent into the container.                             |
 | `--force-setup`      | `false` | Re-run copy and setup steps even if the workspace exists.               |
+| `--open/-o MODE`     | `shell` | What to open after setup: `shell` (default), `browser`, or `none`.      |
 
 ### Behavior
 
@@ -191,6 +194,27 @@ klangkc sandbox WORKSPACE [PATH] [--forward-agent/-A] [--force-setup]
 **Subsequent runs** (workspace already exists):
 
 1. Connect to the existing workspace shell
+
+### Open modes
+
+The `--open` / `-o` flag controls what happens after the workspace is
+ready:
+
+- **`shell`** (default): Open an interactive terminal shell inside the
+  container. This is the original behavior.
+- **`browser`**: Open the workspace in your default web browser
+  (Klangk's web UI). Setup still runs if needed, but no CLI shell is
+  started.
+- **`none`**: Create the workspace and run setup, then exit. Useful for
+  provisioning workspaces in scripts or CI without opening anything.
+
+Examples:
+
+```bash
+klangkc sandbox myws -o browser      # create + open in browser
+klangkc sandbox myws -o none         # create + setup only, no shell
+klangkc sandbox myws                 # create + open shell (default)
+```
 
 The copy and setup steps only run on first creation. On reconnect,
 the command skips straight to the shell — it does not re-copy files

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable MD013 -->
+
 # CLI
 
 `klangkc` is the command-line client for Klangk. It lets you manage
@@ -150,6 +152,8 @@ klangkc shell my-project debug           # attach to the "debug" terminal window
 klangkc sandbox myws                     # create/reconnect from .klangk-sandbox.yaml
 klangkc sandbox myws ~/projects/myapp    # specify sandbox root explicitly
 klangkc sandbox myws --force-setup       # re-run copy and setup on existing workspace
+klangkc sandbox myws -o browser          # create/reconnect and open in web browser
+klangkc sandbox myws -o none             # create and run setup only, no shell or browser
 klangkc exec my-project ls /home/klangk/work         # run a command in the container
 klangkc sync ~/src my-project:/home/klangk/work      # sync files to/from the container
 klangkc rm my-project                # delete a workspace

--- a/src/cli/klangkc/main.py
+++ b/src/cli/klangkc/main.py
@@ -10,6 +10,7 @@ import os
 import shutil
 import subprocess
 import sys
+import webbrowser
 from pathlib import Path
 
 import httpx
@@ -911,6 +912,12 @@ def sandbox(
         "--force-setup",
         help="Re-run copy and setup even if the workspace already exists",
     ),
+    open_mode: str = typer.Option(
+        "shell",
+        "--open",
+        "-o",
+        help="What to open after setup: shell (default), browser, or none",
+    ),
 ) -> None:
     """Create or reconnect to a sandbox workspace."""
     if not isinstance(forward_agent, bool):
@@ -962,6 +969,49 @@ def sandbox(
         _err.print(f"Workspace [bold]{workspace}[/bold] created.")
         created = True
 
+    need_setup = created or force_setup
+    open_mode = open_mode.lower()
+    if open_mode not in ("shell", "browser", "none"):
+        _err.print(
+            f"[red]Invalid --open mode:[/red] {open_mode!r}"
+            " (expected shell, browser, or none)"
+        )
+        raise typer.Exit(code=1)
+
+    if open_mode in ("browser", "none"):
+        # Run setup if needed, then open browser or just exit.
+        if need_setup:
+            _err.print(f"Connecting to [bold]{workspace}[/bold] for setup...")
+            try:
+                asyncio.run(
+                    _sandbox_setup_only(
+                        ws_url,
+                        token,
+                        ws.id,
+                        config,
+                        sandbox_root,
+                        handle,
+                        max_size=_ws_max_size(),
+                    )
+                )
+            except websockets.InvalidStatus as e:  # pragma: no cover
+                if e.response.status_code in (4001, 4002):
+                    _err.print(
+                        "[red]Session expired.[/red] Run"
+                        " [bold]klangkc login[/bold] to re-authenticate."
+                    )
+                    raise typer.Exit(code=1) from None
+                raise
+            except ConnectionError as e:
+                _err.print(f"[red]{e}[/red]")
+                raise typer.Exit(code=1) from None
+
+        if open_mode == "browser":
+            workspace_url = f"{server_url}/#/workspace/{ws.id}"
+            _err.print(f"Opening [bold]{workspace_url}[/bold]")
+            webbrowser.open(workspace_url)
+        return
+
     # Single WebSocket connection: setup (if new) then shell.
     forward_agent = _resolve_forward_agent(
         forward_agent,
@@ -975,7 +1025,7 @@ def sandbox(
                 ws_url,
                 token,
                 ws.id,
-                config=config if (created or force_setup) else None,
+                config=config if need_setup else None,
                 sandbox_root=sandbox_root,
                 handle=handle,
                 forward_agent=forward_agent,
@@ -997,6 +1047,24 @@ def sandbox(
         _drain_stdin()
         _err.print(f"[red]{e}[/red]")
         raise typer.Exit(code=1) from None
+
+
+async def _sandbox_setup_only(
+    ws_url,
+    token,
+    workspace_id,
+    config,
+    sandbox_root,
+    handle,
+    max_size=None,
+):
+    """Connect to workspace, run setup, then disconnect (no shell)."""
+    kwargs = {}
+    if max_size is not None:
+        kwargs["max_size"] = max_size
+    async with websockets.connect(f"{ws_url}?token={token}", **kwargs) as ws:
+        await _wait_workspace_ready(ws, workspace_id)
+        await _sandbox_setup(ws, config, sandbox_root, handle)
 
 
 async def _sandbox_connect(  # pragma: no cover

--- a/src/cli/tests/test_cli_main.py
+++ b/src/cli/tests/test_cli_main.py
@@ -2726,6 +2726,236 @@ class TestSandboxCommand:
         assert result.exit_code == 0
         assert captured_kwargs.get("config") is not None
 
+    def test_invalid_open_mode_exits(self, logged_in_cfg, tmp_path):
+        from klangkc import main
+
+        (tmp_path / ".klangk-sandbox.yaml").write_text(
+            "sandbox:\n  mount-at: ~/test\n"
+        )
+
+        ws = Workspace(
+            id="ws1" + "0" * 52,
+            name="myws",
+            created_at="2025-01-01T00:00:00Z",
+            mounts=[f"{tmp_path.resolve()}:/home/admin/test"],
+        )
+        client = MagicMock()
+        client.get_handle.return_value = "admin"
+        client.resolve_workspace.return_value = ws
+
+        with patch.object(main, "_client", return_value=client):
+            from typer.testing import CliRunner
+
+            runner = CliRunner()
+            result = runner.invoke(
+                main.app,
+                ["sandbox", "myws", str(tmp_path), "--open", "invalid"],
+            )
+        assert result.exit_code != 0
+
+    def test_open_browser_existing_workspace(self, logged_in_cfg, tmp_path):
+        from klangkc import main
+
+        (tmp_path / ".klangk-sandbox.yaml").write_text(
+            "sandbox:\n  mount-at: ~/test\n"
+        )
+
+        ws = Workspace(
+            id="ws1" + "0" * 52,
+            name="myws",
+            created_at="2025-01-01T00:00:00Z",
+            mounts=[f"{tmp_path.resolve()}:/home/admin/test"],
+        )
+        client = MagicMock()
+        client.get_handle.return_value = "admin"
+        client.resolve_workspace.return_value = ws
+
+        with (
+            patch.object(main, "_client", return_value=client),
+            patch("webbrowser.open") as mock_wb_open,
+        ):
+            from typer.testing import CliRunner
+
+            runner = CliRunner()
+            result = runner.invoke(
+                main.app,
+                ["sandbox", "myws", str(tmp_path), "--open", "browser"],
+            )
+        assert result.exit_code == 0
+        mock_wb_open.assert_called_once()
+        url = mock_wb_open.call_args[0][0]
+        assert "/#/workspace/" in url
+        assert ws.id in url
+
+    def test_open_browser_new_workspace_runs_setup(
+        self, logged_in_cfg, tmp_path
+    ):
+        from klangkc import main
+
+        (tmp_path / ".klangk-sandbox.yaml").write_text(
+            "sandbox:\n  mount-at: ~/test\n"
+        )
+
+        ws = Workspace(
+            id="ws1" + "0" * 52,
+            name="myws",
+            created_at="2025-01-01T00:00:00Z",
+        )
+        client = MagicMock()
+        client.get_handle.return_value = "admin"
+        client.resolve_workspace.side_effect = WorkspaceNotFoundError("myws")
+        client.create_workspace.return_value = ws
+
+        async def fake_setup_only(*args, **kwargs):
+            pass
+
+        with (
+            patch.object(main, "_client", return_value=client),
+            patch.object(main, "_sandbox_setup_only", fake_setup_only),
+            patch("webbrowser.open") as mock_wb_open,
+        ):
+            from typer.testing import CliRunner
+
+            runner = CliRunner()
+            result = runner.invoke(
+                main.app,
+                ["sandbox", "myws", str(tmp_path), "--open", "browser"],
+            )
+        assert result.exit_code == 0
+        mock_wb_open.assert_called_once()
+
+    def test_open_none_existing_workspace(self, logged_in_cfg, tmp_path):
+        from klangkc import main
+
+        (tmp_path / ".klangk-sandbox.yaml").write_text(
+            "sandbox:\n  mount-at: ~/test\n"
+        )
+
+        ws = Workspace(
+            id="ws1" + "0" * 52,
+            name="myws",
+            created_at="2025-01-01T00:00:00Z",
+            mounts=[f"{tmp_path.resolve()}:/home/admin/test"],
+        )
+        client = MagicMock()
+        client.get_handle.return_value = "admin"
+        client.resolve_workspace.return_value = ws
+
+        with patch.object(main, "_client", return_value=client):
+            from typer.testing import CliRunner
+
+            runner = CliRunner()
+            result = runner.invoke(
+                main.app,
+                ["sandbox", "myws", str(tmp_path), "--open", "none"],
+            )
+        assert result.exit_code == 0
+
+    def test_open_none_new_workspace_runs_setup(self, logged_in_cfg, tmp_path):
+        from klangkc import main
+
+        (tmp_path / ".klangk-sandbox.yaml").write_text(
+            "sandbox:\n  mount-at: ~/test\n"
+        )
+
+        ws = Workspace(
+            id="ws1" + "0" * 52,
+            name="myws",
+            created_at="2025-01-01T00:00:00Z",
+        )
+        client = MagicMock()
+        client.get_handle.return_value = "admin"
+        client.resolve_workspace.side_effect = WorkspaceNotFoundError("myws")
+        client.create_workspace.return_value = ws
+
+        async def fake_setup_only(*args, **kwargs):
+            pass
+
+        with (
+            patch.object(main, "_client", return_value=client),
+            patch.object(main, "_sandbox_setup_only", fake_setup_only),
+        ):
+            from typer.testing import CliRunner
+
+            runner = CliRunner()
+            result = runner.invoke(
+                main.app,
+                ["sandbox", "myws", str(tmp_path), "--open", "none"],
+            )
+        assert result.exit_code == 0
+
+    def test_open_browser_setup_connection_error(
+        self, logged_in_cfg, tmp_path
+    ):
+        from klangkc import main
+
+        (tmp_path / ".klangk-sandbox.yaml").write_text(
+            "sandbox:\n  mount-at: ~/test\n"
+        )
+
+        ws = Workspace(
+            id="ws1" + "0" * 52,
+            name="myws",
+            created_at="2025-01-01T00:00:00Z",
+        )
+        client = MagicMock()
+        client.get_handle.return_value = "admin"
+        client.resolve_workspace.side_effect = WorkspaceNotFoundError("myws")
+        client.create_workspace.return_value = ws
+
+        async def failing_setup(*args, **kwargs):
+            raise ConnectionError("connection refused")
+
+        with (
+            patch.object(main, "_client", return_value=client),
+            patch.object(main, "_sandbox_setup_only", failing_setup),
+        ):
+            from typer.testing import CliRunner
+
+            runner = CliRunner()
+            result = runner.invoke(
+                main.app,
+                ["sandbox", "myws", str(tmp_path), "--open", "browser"],
+            )
+        assert result.exit_code == 1
+        assert "connection refused" in result.output
+
+
+class TestSandboxSetupOnly:
+    async def test_connects_and_runs_setup(self):
+        from pathlib import Path
+
+        from klangkc.main import _sandbox_setup_only
+        from klangkc.sandbox import SandboxConfig
+
+        config = SandboxConfig(setup="setup.sh")
+
+        mock_ws = AsyncMock()
+        mock_ws.recv = AsyncMock(
+            return_value=json.dumps({"type": "workspace_ready"})
+        )
+
+        with (
+            patch("klangkc.main.websockets.connect") as mock_connect,
+            patch("klangkc.main._sandbox_setup") as mock_setup,
+        ):
+            mock_connect.return_value.__aenter__ = AsyncMock(
+                return_value=mock_ws
+            )
+            mock_connect.return_value.__aexit__ = AsyncMock(return_value=False)
+            await _sandbox_setup_only(
+                "ws://test",
+                "token",
+                "ws-id",
+                config,
+                Path("/tmp"),
+                "admin",
+                max_size=2**20,
+            )
+            mock_setup.assert_called_once_with(
+                mock_ws, config, Path("/tmp"), "admin"
+            )
+
 
 class TestSandboxSetup:
     async def test_copies_files(self, tmp_path):


### PR DESCRIPTION
## Summary

- Adds `--open/-o MODE` flag to `klangkc sandbox` with three modes:
  - `shell` (default) — existing behavior, open interactive terminal
  - `browser` — open the workspace in the web browser, then exit
  - `none` — create workspace and run setup only, then exit
- Adds `_sandbox_setup_only()` for running setup without starting a terminal
- Updated sandbox and CLI docs

## Test plan

- [x] `klangkc sandbox myws` — default behavior unchanged
- [x] `klangkc sandbox myws -o browser` — opens browser URL
- [x] `klangkc sandbox myws -o none` — exits after setup
- [x] 170 CLI tests pass

Fixes #790