### PR TITLE
feat: extension-free auto-reload watcher for web dev (Firefox-friendly)

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -165,6 +165,9 @@ in
   # Port the opt-in `flutter run` dev server listens on (nginx proxies the app
   # root here when KLANGK_WEB_DEV=1). Between nginx (8995) and backend (8997).
   env.KLANGK_WEB_DEV_PORT = lib.mkOverride 1500 "8996";
+  # Port for the opt-in extension-free livereload SSE server
+  # (scripts/flutter_reload_server.py), used when KLANGK_WEB_DEV_RELOAD=1.
+  env.KLANGK_WEB_DEV_RELOAD_PORT = lib.mkOverride 1500 "8994";
   env.KLANGK_DATA_DIR = lib.mkOverride 1500 (
     config.devenv.root + "/.devenv/state/klangk/data"
   );

--- a/docs/dev/web-autoreload.md
+++ b/docs/dev/web-autoreload.md
@@ -1,0 +1,74 @@
+# Extension-free auto-reload (Firefox-friendly)
+
+Opt-in, off by default. Builds on the hot-reload dev mode
+(`docs/dev/web-fast-iteration.md`). Gives a **hands-free** edit→see-it loop in
+**any browser** (Firefox, Safari, Chrome) with **no Dart Debug Extension**.
+
+## Why this exists (the important caveat)
+
+`flutter run -d web-server` compiles the app at **startup** and on `r`/`R` hot
+reload/restart. Hot reload/restart require a _debug-connected_ browser — i.e. the
+**Chrome-only Dart Debug Extension** (without it, `R` times out:
+`Hot restart … received 0/1 responses`). A plain **browser reload does NOT
+trigger recompilation** — verified empirically: editing a widget and refreshing
+the tab (even a hard refresh) shows the _old_ code; only after restarting the dev
+server does the change appear.
+
+So the only way to pick up a source edit **without the extension** is to **restart
+the dev server**. This watcher automates that.
+
+## What it does
+
+With `KLANGK_WEB_DEV_RELOAD=1`, `scripts/flutterdevweb.sh` launches
+`scripts/flutter_reload_server.py` (a supervisor) instead of `flutter` directly.
+The supervisor:
+
+1. owns the `flutter run -d web-server` process,
+2. watches `src/frontend/lib/**` and `web/**`,
+3. on a save (debounced), **restarts** the dev server — the warm `.dart_tool`
+   cache makes this an incremental recompile, not a cold build,
+4. once it's serving again, pushes a Server-Sent Events `reload` to browsers,
+5. an `EventSource` client — injected into the served HTML by nginx's dev profile
+   via `sub_filter` — calls `location.reload()`.
+
+Same-origin throughout (served via nginx `:8995`), so API/WS/bridge keep working.
+
+## Usage
+
+```bash
+# terminal 1 — backend + nginx (dev routing + livereload injection), release build skipped
+KLANGK_WEB_DEV=1 KLANGK_WEB_DEV_RELOAD=1 devenv processes up --no-tui
+# terminal 2 — supervisor (owns flutter + the livereload SSE server)
+KLANGK_WEB_DEV=1 KLANGK_WEB_DEV_RELOAD=1 devenv shell -- flutterdevweb
+```
+
+Open the app at `http://localhost:8995/` in **any** browser, edit a `.dart` file,
+save — the tab reloads itself a few seconds later showing the change. No keypress,
+no extension.
+
+## Measured cost (macOS arm64, Flutter 3.41.6)
+
+|                                                            | time                                   |
+| ---------------------------------------------------------- | -------------------------------------- |
+| dev-server **warm restart** (per save, this watcher)       | **~12 s** (measured 11.8 s)            |
+| dev-server cold first start                                | ~12–15 s                               |
+| `flutter build web --release` (the old per-change cost)    | ~21 s (minutes on a plugin-set change) |
+| hot reload `r` / restart `R` **with** Dart Debug Extension | ~0.1–0.3 s, stateful (Chrome only)     |
+
+So this is faster than the release build and fully hands-free, but it's a full
+restart (app state resets) — slower than extension hot reload. Pick this for
+Firefox / no-extension; pick the Dart Debug Extension for the fastest loop in
+Chrome.
+
+## Knobs
+
+- `KLANGK_WEB_DEV_RELOAD=1` — enable (requires `KLANGK_WEB_DEV=1`).
+- `KLANGK_WEB_DEV_RELOAD_PORT` — SSE server port (default 8994).
+- Default / production: untouched — none of this runs unless the flag is set.
+
+## How the pieces fit
+
+- `scripts/flutter_reload_server.py` — the supervisor + SSE server (stdlib only).
+- `scripts/nginx.sh` — when `KLANGK_WEB_DEV_RELOAD=1`: a `/__livereload` proxy to
+  the SSE server + `sub_filter` injection of the `EventSource` client.
+- `scripts/flutterdevweb.sh` — execs the supervisor when the flag is set.

--- a/docs/dev/web-fast-iteration.md
+++ b/docs/dev/web-fast-iteration.md
@@ -99,20 +99,20 @@ experiments to layer on.
 - Trigger reload: press `r`/`R` in the `flutter run` console (Strategy B removes
   the keypress).
 
-### B — Auto-reload watcher (revised after measurement)
+### B — Auto-reload watcher ✅ built + validated (extension-free, Firefox-friendly)
 
-Goal: no manual keypress / manual refresh. Two variants:
+**Implemented** (see `docs/dev/web-autoreload.md`, `KLANGK_WEB_DEV_RELOAD=1`).
+Crucial correction from measurement: a plain **browser reload does NOT
+recompile** — `flutter run -d web-server` only compiles at startup and on `r`/`R`
+(which need the extension). So the working extension-free watcher
+(`scripts/flutter_reload_server.py`) **restarts the dev server** on save (warm
+`.dart_tool` → incremental, ~12 s) and then pushes an SSE `reload` to an injected
+`EventSource` client. Hands-free, any browser, same-origin, no extension. State
+resets and it's ~12 s (vs ~0.1 s extension hot reload), but it needs no Chrome
+extension.
 
-- **Browser-reload watcher (extension-free, preferred):** watch
-  `src/frontend/lib/**`; on save, tell the open tab at :8995 to reload (e.g. a
-  tiny injected websocket livereload client, or driving Chrome via the DevTools
-  Protocol). Reload triggers the incremental DDC recompile — the ~9 s path that
-  needs no extension.
-- **`flutter run --machine` + `app.restart`:** true hot restart with no keypress,
-  but on the web-server device it still needs the Dart Debug Extension connected
-  (same limitation as pressing `R`). Adopt once the extension is standard in the
-  dev setup.
-  Build only after A is proven (it is).
+(The `flutter run --machine` + `app.restart` route gives true hot restart with no
+keypress but still needs the Dart Debug Extension on web-server — not pursued.)
 
 ### C — Faster release build (for those who keep the build-then-serve model)
 
@@ -152,13 +152,13 @@ this. Investigated in the loop; findings + blockers tracked in `PROGRESS.md`.
 Validated against a live stack (backend :8997 + nginx-dev :8995 + `flutter run
 -d web-server` :8996), driving real Chrome through nginx :8995.
 
-| Path                                                         | Time                     | Notes                                                                                                           |
-| ------------------------------------------------------------ | ------------------------ | --------------------------------------------------------------------------------------------------------------- |
-| `flutter build web --release` (warm cache, no plugin change) | **21.3 s**               | compile only; the `flutterbuildweb.sh` task adds plugin import + ~25 MB source-map inlining + cache-bust on top |
-| same, after a **plugin-set change**                          | minutes                  | `flutterbuildweb.sh` does `rm -rf .dart_tool/flutter_build` → full cold dart2js compile                         |
-| dev server: edit Dart + **browser refresh**                  | **~8.8 s**               | incremental DDC recompile + app boot; **no release build runs**; needs no extension                             |
-| dev server: **hot reload** (`r`), debug-connected browser    | **122–135 ms**, stateful | measured via `-d chrome`; same-origin needs the Dart Debug Extension (see finding)                              |
-| dev server: **hot restart** (`R`), debug-connected browser   | **249 ms**               | measured via `-d chrome`; same-origin needs the Dart Debug Extension (see finding)                              |
+| Path                                                                  | Time                     | Notes                                                                                                                                                                                             |
+| --------------------------------------------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `flutter build web --release` (warm cache, no plugin change)          | **21.3 s**               | compile only; the `flutterbuildweb.sh` task adds plugin import + ~25 MB source-map inlining + cache-bust on top                                                                                   |
+| same, after a **plugin-set change**                                   | minutes                  | `flutterbuildweb.sh` does `rm -rf .dart_tool/flutter_build` → full cold dart2js compile                                                                                                           |
+| dev server: edit Dart + **dev-server restart** (auto via the watcher) | **~12 s**                | warm `.dart_tool` incremental recompile; **no release build runs**; no extension. NOTE: a plain browser _refresh_ does NOT recompile — only startup/restart or `r`/`R` do (see web-autoreload.md) |
+| dev server: **hot reload** (`r`), debug-connected browser             | **122–135 ms**, stateful | measured via `-d chrome`; same-origin needs the Dart Debug Extension (see finding)                                                                                                                |
+| dev server: **hot restart** (`R`), debug-connected browser            | **249 ms**               | measured via `-d chrome`; same-origin needs the Dart Debug Extension (see finding)                                                                                                                |
 
 Verified the layered routing is correct: the app loaded from the dev server
 through nginx :8995, auto-logged-in (admin2@example.com), rendered the Workspaces
@@ -187,11 +187,11 @@ Tested empirically (real Chrome, driven via the devtools MCP):
 
 **Conclusion — pick two of three (extension-free / same-origin / sub-second):**
 
-| Goal                                       | How                                                     | Cost                                     |
-| ------------------------------------------ | ------------------------------------------------------- | ---------------------------------------- |
-| same-origin **+** extension-free           | `-d web-server` behind nginx, **edit + refresh**        | ~9 s, loses state                        |
-| same-origin **+** sub-second hot reload    | `-d web-server` behind nginx **+ Dart Debug Extension** | one-time extension install               |
-| extension-free **+** sub-second hot reload | `-d chrome`                                             | **not** same-origin → app's API/WS break |
+| Goal                                       | How                                                                     | Cost                                     |
+| ------------------------------------------ | ----------------------------------------------------------------------- | ---------------------------------------- |
+| same-origin **+** extension-free           | `-d web-server` behind nginx, **auto-reload watcher** (restart on save) | ~12 s, loses state (Firefox ✓)           |
+| same-origin **+** sub-second hot reload    | `-d web-server` behind nginx **+ Dart Debug Extension**                 | one-time extension install               |
+| extension-free **+** sub-second hot reload | `-d chrome`                                                             | **not** same-origin → app's API/WS break |
 
 For klangk's app (which needs API/WS), the realistic choices are the first two.
 The shipped Strategy A is the first row. The Dart Debug Extension upgrades it to

--- a/scripts/flutter_reload_server.py
+++ b/scripts/flutter_reload_server.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Extension-free auto-reload supervisor for the Flutter web dev server.
+
+`flutter run -d web-server` compiles at **startup** (and on `r`/`R` hot
+reload/restart, which require a debug-connected browser — i.e. the Chrome-only
+Dart Debug Extension). A plain browser reload does **not** recompile. So to pick
+up a source edit **without** the extension (e.g. in Firefox), this supervisor:
+
+1. starts and owns the `flutter run -d web-server` process,
+2. watches the frontend source,
+3. on a save, **restarts** the dev server (warm `.dart_tool` cache → incremental
+   recompile), and once it is serving again,
+4. pushes a Server-Sent Events ``reload`` to connected browsers, which reload the
+   tab via an injected ``EventSource`` client (works in Firefox/Safari/Chrome).
+
+Trade-off vs the Dart Debug Extension: a dev-server restart (seconds) per save and
+app state resets — but no extension and any browser. Dev-only; paired with
+``KLANGK_WEB_DEV_RELOAD=1`` in ``scripts/nginx.sh`` (proxies ``/__livereload`` and
+injects the client) and launched by ``scripts/flutterdevweb.sh``.
+
+Env: KLANGK_WEB_DEV_RELOAD_PORT (SSE port, default 8994), KLANGK_WEB_DEV_PORT
+(dev-server port, default 8996), KLANGK_WEB_FLUTTER (flutter binary), DEVENV_ROOT.
+"""
+
+from __future__ import annotations
+
+import http.server
+import os
+import signal
+import socketserver
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+ROOT = Path(os.environ.get("DEVENV_ROOT") or ".").resolve() / "src" / "frontend"
+WATCH_DIRS = [ROOT / "lib", ROOT / "web"]
+SSE_PORT = int(os.environ.get("KLANGK_WEB_DEV_RELOAD_PORT", "8994"))
+DEV_PORT = os.environ.get("KLANGK_WEB_DEV_PORT", "8996")
+FLUTTER = os.environ.get("KLANGK_WEB_FLUTTER", "flutter")
+POLL_SECONDS = 0.25
+DEBOUNCE_SECONDS = 0.5
+PING_SECONDS = 15.0
+SERVE_MARKER = "is being served"
+
+_generation = 0
+_lock = threading.Lock()
+_ready = threading.Event()
+_proc: subprocess.Popen | None = None
+_proc_lock = threading.Lock()
+
+
+def _flutter_cmd() -> list[str]:
+    return [
+        FLUTTER,
+        "run",
+        "-d",
+        "web-server",
+        "--web-hostname=127.0.0.1",
+        f"--web-port={DEV_PORT}",
+        "--no-web-resources-cdn",
+    ]
+
+
+def _start_flutter() -> None:
+    global _proc
+    _ready.clear()
+    with _proc_lock:
+        _proc = subprocess.Popen(
+            _flutter_cmd(),
+            cwd=str(ROOT),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+        proc = _proc
+
+    def _pump() -> None:
+        assert proc.stdout is not None
+        for line in proc.stdout:
+            sys.stdout.write("[flutter] " + line)
+            sys.stdout.flush()
+            if SERVE_MARKER in line:
+                _ready.set()
+
+    threading.Thread(target=_pump, daemon=True).start()
+
+
+def _restart_flutter() -> None:
+    with _proc_lock:
+        proc = _proc
+    if proc and proc.poll() is None:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+    _start_flutter()
+
+
+def _snapshot() -> tuple[int, float]:
+    count = 0
+    latest = 0.0
+    for d in WATCH_DIRS:
+        if not d.is_dir():
+            continue
+        for p in d.rglob("*"):
+            if p.is_file():
+                try:
+                    latest = max(latest, p.stat().st_mtime)
+                    count += 1
+                except OSError:
+                    pass
+    return count, latest
+
+
+def _watch() -> None:
+    global _generation
+    last = _snapshot()
+    pending_since: float | None = None
+    while True:
+        time.sleep(POLL_SECONDS)
+        cur = _snapshot()
+        if cur != last:
+            last = cur
+            pending_since = time.monotonic()
+        elif pending_since is not None and (
+            time.monotonic() - pending_since >= DEBOUNCE_SECONDS
+        ):
+            pending_since = None
+            t0 = time.monotonic()
+            print("livereload: change -> restarting dev server", flush=True)
+            _restart_flutter()
+            if _ready.wait(timeout=120):
+                with _lock:
+                    _generation += 1
+                    gen = _generation
+                dt = time.monotonic() - t0
+                print(
+                    f"livereload: dev server back in {dt:.1f}s -> reload (gen={gen})",
+                    flush=True,
+                )
+            else:
+                print("livereload: dev server did not come back in time", flush=True)
+
+
+class _Handler(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def log_message(self, *args) -> None:
+        pass
+
+    def handle_one_request(self) -> None:
+        try:
+            super().handle_one_request()
+        except (ConnectionResetError, BrokenPipeError, TimeoutError):
+            self.close_connection = True
+
+    def do_GET(self) -> None:
+        if self.path.split("?", 1)[0] != "/__livereload":
+            self.send_response(404)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+            return
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Connection", "keep-alive")
+        self.end_headers()
+        with _lock:
+            seen = _generation
+        last_ping = time.monotonic()
+        try:
+            self.wfile.write(b": connected\n\n")
+            self.wfile.flush()
+            while True:
+                time.sleep(0.5)
+                with _lock:
+                    cur = _generation
+                if cur != seen:
+                    seen = cur
+                    self.wfile.write(b"data: reload\n\n")
+                    self.wfile.flush()
+                elif time.monotonic() - last_ping >= PING_SECONDS:
+                    last_ping = time.monotonic()
+                    self.wfile.write(b": ping\n\n")
+                    self.wfile.flush()
+        except (BrokenPipeError, ConnectionResetError, OSError):
+            return
+
+
+class _Server(socketserver.ThreadingMixIn, http.server.HTTPServer):
+    daemon_threads = True
+    allow_reuse_address = True
+
+
+def _shutdown(*_args) -> None:
+    with _proc_lock:
+        proc = _proc
+    if proc and proc.poll() is None:
+        proc.terminate()
+    sys.exit(0)
+
+
+def main() -> None:
+    signal.signal(signal.SIGINT, _shutdown)
+    signal.signal(signal.SIGTERM, _shutdown)
+    dirs = ", ".join(str(d) for d in WATCH_DIRS)
+    print(
+        f"livereload: supervising flutter dev server on :{DEV_PORT}, "
+        f"SSE on 127.0.0.1:{SSE_PORT}/__livereload — watching {dirs}",
+        flush=True,
+    )
+    _start_flutter()
+    _ready.wait(timeout=120)
+    threading.Thread(target=_watch, daemon=True).start()
+    _Server(("127.0.0.1", SSE_PORT), _Handler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/flutterdevweb.sh
+++ b/scripts/flutterdevweb.sh
@@ -52,6 +52,18 @@ if [ "${KLANGK_WEB_HOT_RELOAD:-0}" = "1" ]; then
   fi
 fi
 
+# Extension-free auto-reload (KLANGK_WEB_DEV_RELOAD=1): hand the dev server to
+# the supervisor (scripts/flutter_reload_server.py), which owns the `flutter run`
+# process, restarts it on save (a plain browser reload does NOT recompile), and
+# pushes an SSE reload once it's serving again. nginx injects the EventSource
+# client. Works in any browser, no Dart Debug Extension.
+if [ "${KLANGK_WEB_DEV_RELOAD:-0}" = "1" ]; then
+  export KLANGK_WEB_FLUTTER="$FLUTTER" KLANGK_WEB_DEV_PORT="$DEV_PORT"
+  echo "Auto-reload supervisor: edit + save -> dev-server restart -> tab reloads"
+  echo "  -> browse the app at nginx :${KLANGK_NGINX_PORT:-8995} (any browser)"
+  exec python3 "$SCRIPT_DIR/flutter_reload_server.py"
+fi
+
 echo "Starting Flutter dev server on 127.0.0.1:${DEV_PORT}"
 echo "  -> with KLANGK_WEB_DEV=1, browse the app at nginx :${KLANGK_NGINX_PORT:-8995}"
 echo "  -> press R for hot restart, r for hot reload, q to quit"

--- a/scripts/nginx.sh
+++ b/scripts/nginx.sh
@@ -145,9 +145,40 @@ if [ "${KLANGK_WEB_DEV:-0}" = "1" ]; then
       proxy_http_version 1.1;
     }
 "
+  # Extension-free auto-reload (KLANGK_WEB_DEV_RELOAD=1): proxy the livereload
+  # SSE stream (scripts/flutter_reload_server.py) and inject a tiny EventSource
+  # client into the served HTML via sub_filter. Browser-agnostic (Firefox /
+  # Safari / Chrome), no Dart Debug Extension. On a lib/** change the client
+  # reloads the tab, which makes the dev server recompile incrementally.
+  RELOAD_LOCATION=""
+  RELOAD_INJECT=""
+  if [ "${KLANGK_WEB_DEV_RELOAD:-0}" = "1" ]; then
+    _reload_port="${KLANGK_WEB_DEV_RELOAD_PORT:-8994}"
+    echo "nginx WEB DEV auto-reload: /__livereload -> :${_reload_port}, injecting EventSource client" >&2
+    RELOAD_LOCATION="
+    location = /__livereload {
+      proxy_pass http://127.0.0.1:${_reload_port};
+      proxy_http_version 1.1;
+      proxy_set_header Connection \"\";
+      proxy_buffering off;
+      proxy_cache off;
+      proxy_read_timeout 3600s;
+      chunked_transfer_encoding off;
+    }
+"
+    RELOAD_INJECT="
+      # Inject the livereload client and disable upstream compression so
+      # sub_filter can rewrite the HTML body.
+      proxy_set_header Accept-Encoding \"\";
+      sub_filter '</body>' '<script>(function(){try{var s=new EventSource(\"/__livereload\");s.onmessage=function(e){if(e.data===\"reload\")location.reload();};}catch(_){}})();</script></body>';
+      sub_filter_once on;
+"
+  fi
 else
   ROOT_UPSTREAM="http://127.0.0.1:${KLANGK_PORT}"
   DEV_API_WS_BLOCK=""
+  RELOAD_LOCATION=""
+  RELOAD_INJECT=""
 fi
 
 cat >"$NGINX_STATE/nginx.conf" <<NGINX
@@ -248,10 +279,10 @@ ${CONTAINER_ACL}
       return 401 '{\"error\":\"\$auth_token_error\",\"detail\":\"Workspace token \$auth_token_error\"}';
     }
 
-${DEV_API_WS_BLOCK}
+${DEV_API_WS_BLOCK}${RELOAD_LOCATION}
     location / {
       proxy_pass ${ROOT_UPSTREAM}/;
-      proxy_set_header Host \$http_host;
+${RELOAD_INJECT}      proxy_set_header Host \$http_host;
       proxy_set_header X-Real-IP \$remote_addr;
       proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
       proxy_http_version 1.1;


### PR DESCRIPTION
**Stacked on #785** (base = `feat/flutter-web-dev-mode`). Builds the extension-free auto-reload watcher you asked for — hands-free edit→see-it in **any browser** (Firefox/Safari/Chrome), **no Dart Debug Extension**.

## Important finding (corrects #785's doc)
While validating, I found a plain **browser reload does NOT recompile**: `flutter run -d web-server` compiles only at **startup** and on `r`/`R` (which need the Chrome-only Dart Debug Extension). Editing + refreshing — even a hard refresh — shows the *old* code; only a dev-server **restart** picks up the change. So #785's "edit + refresh ≈ 9 s" line was wrong (that was a restarted server); this PR corrects it.

## What it does (`KLANGK_WEB_DEV_RELOAD=1`)
`scripts/flutter_reload_server.py` supervises `flutter run`: watches `lib/**` + `web/**`, **restarts the dev server on save** (warm `.dart_tool` → incremental), then pushes an SSE `reload`. nginx injects an `EventSource` client into the HTML via `sub_filter`; the client reloads the tab. Same-origin throughout (served via nginx `:8995`), so API/WS/bridge keep working.

```bash
KLANGK_WEB_DEV=1 KLANGK_WEB_DEV_RELOAD=1 devenv processes up --no-tui   # term 1
KLANGK_WEB_DEV=1 KLANGK_WEB_DEV_RELOAD=1 devenv shell -- flutterdevweb  # term 2
# open :8995 in Firefox/any browser, edit a .dart file, save → tab auto-reloads
```

## Validated live (Chrome via devtools MCP, through nginx :8995)
Edited a widget title and **saw the tab auto-reload to the new code with no manual action** — still logged in, API/WS intact, no extension. Supervisor logged: `change -> restarting dev server` → `dev server back in 11.8s -> reload`.

| | time |
|---|---|
| auto-reload (warm dev-server restart, per save) | **~12 s** |
| `flutter build web --release` (old per-change cost) | ~21 s |
| `r`/`R` with Dart Debug Extension (Chrome only) | ~0.1–0.3 s, stateful |

So: ~12 s and state resets, but hands-free and works in Firefox. For the fastest loop in Chrome, the Dart Debug Extension still wins.

## Scope
`scripts/flutter_reload_server.py` (new, stdlib-only dev tool), `scripts/nginx.sh`, `scripts/flutterdevweb.sh`, `devenv.nix`, docs. Default/prod unchanged. Merge after #785.