### PR TITLE
fix(workspace): re-entry guard in bash.bashrc to stop BASH_ENV fork storm

### DIFF
--- a/docs/dev/bash-env-fork-storm.md
+++ b/docs/dev/bash-env-fork-storm.md
@@ -1,0 +1,219 @@
+# BASH_ENV fork storm in the workspace image
+
+## Summary
+
+Building the `klangk-hermes` workspace image triggers a bash **fork storm**:
+thousands of `bash` / `on-shell-init.sh` / `klangk-setup-clankers` processes
+spawn until the podman VM exhausts memory and either crashes
+(`Error: server probably quit: unexpected EOF`) or hangs. During a failed build
+we observed the VM process count climb to 5,760 then 6,181 with free memory
+near zero.
+
+The storm is not a Hermes bug. It is a latent defect in the workspace image's
+`/etc/bash.bashrc`: with `BASH_ENV=/etc/bash.bashrc` set image-wide, **any**
+plugin that ships a _bash_ `on-shell-init.sh` hook turns every non-interactive
+shell — and the image build itself — into an unbounded recursion.
+
+The fix is a re-entry guard in `src/containers/workspace/bash.bashrc`. It is
+already applied (see [The fix](#the-fix)).
+
+## Impact
+
+- Any plugin shipping a `bash` (not POSIX `sh`) `on-shell-init.sh` hook makes
+  every non-interactive `bash` invocation in the image recurse without bound.
+- The image build runs plugin `on-image-build.sh` hooks; the Hermes installer
+  spawns thousands of bash subshells (uv builds ~225 Python packages, plus
+  npm). With the defect, each subshell re-sources `bash.bashrc`, re-running
+  `klangk-setup-clankers` and every hook — a fork bomb that OOMs the podman VM
+  (2 GiB, later bumped to 8 GiB — still not enough).
+- At runtime the same defect would make any sandbox setup script (`sh -c` →
+  `bash -c`) fork-bomb the container.
+
+## Root cause
+
+A three-part chain. Exact references below.
+
+1. **`BASH_ENV` is set image-wide.** Added by PR #789 ("source bashrc for
+   non-interactive sandbox setup scripts"):
+
+   `src/containers/workspace/Dockerfile:15`
+
+   ```dockerfile
+   ENV BASH_ENV="/etc/bash.bashrc"
+   ```
+
+   With `BASH_ENV` set, **every** non-interactive `bash` sources that file at
+   startup — before running its `-c` command.
+
+2. **`bash.bashrc` executes every plugin hook, unconditionally, before the
+   non-interactive early-exit.** The pre-fix file ran
+   `klangk-setup-clankers` and then a loop over the on-shell-init hooks with no
+   guard, ahead of the `case $- in *i*) … *) return/exit` guard. The hook loop
+   is still:
+
+   `src/containers/workspace/bash.bashrc:37-40`
+
+   ```bash
+   for f in /opt/klangk/hooks/*/on-shell-init.sh; do
+     # shellcheck disable=SC2181
+     [ -x "$f" ] && "$f" || true
+   done
+   ```
+
+   The non-interactive early-exit comes _after_ this section:
+
+   `src/containers/workspace/bash.bashrc:45-49`
+
+   ```bash
+   case $- in
+     *i*) ;;
+       *) return 2>/dev/null || exit 0 ;;
+   esac
+   ```
+
+   So even a non-interactive shell pays the full hook cost.
+
+3. **A bash hook re-enters the loop.** The Hermes plugin (PR #787, branch
+   `docs/hermes-klangk-integration`) originally shipped
+   `plugins/hermes/on-shell-init.sh` with `#!/usr/bin/env bash`. When the loop
+   executes that hook it starts a **new** non-interactive bash. Because
+   `BASH_ENV` is still set and exported, that bash re-sources
+   `/etc/bash.bashrc`, which runs the hook loop again, which executes the bash
+   hook again → unbounded recursion → fork bomb.
+
+Independent linear blowup (compounds the recursion): Hermes's
+`on-image-build.sh` runs the upstream installer
+(`curl https://hermes-agent.nousresearch.com/install.sh | bash`), which spawns
+thousands of bash subshells. Each one sources `bash.bashrc` and re-runs
+`klangk-setup-clankers` (a `python3` process) plus every hook. Even without the
+pure recursion, that is a massive multiplier on top of the build's own work.
+
+## How to reproduce — minimal
+
+No podman or klangk image needed. Run the self-contained, host-safe script:
+
+```sh
+bash scripts/repro-bash-env-storm.sh
+```
+
+It isolates the exact mechanism with plain bash: a fake `bashrc` set as
+`BASH_ENV` that executes a bash hook with no guard, triggered by a single
+`bash -c true`. **Safety:** the trigger runs in a subshell that first sets
+`ulimit -u <baseline + 200>`, so the recursion hits the per-user process cap and
+`fork()` fails fast ("Resource temporarily unavailable") instead of harming the
+host; a wall-time bound then kills the tree. The clean variants (B, C) run
+**first** against a clean baseline and the destructive storm (A) runs **last**,
+so A's brief residue cannot pollute the per-user process count the others are
+measured against.
+
+Expected output (process counts vary by host):
+
+```text
+=== Variant B: KLANGK_BASHRC_DONE guard + bash hook (expect CLEAN) ===
+  exit=0  -> CLEAN: ran once, no storm
+
+=== Variant C: no guard + #!/bin/sh hook (defense in depth, expect CLEAN) ===
+  exit=0  -> CLEAN: ran once, no storm
+
+=== Variant A: no re-entry guard + bash hook (expect STORM) ===
+  exit=143  peak user procs observed=876 (cap 850)
+    .../bashrc-bug: fork: retry: Resource temporarily unavailable
+  -> BUG REPRODUCED: fork storm hit the process cap
+```
+
+## How to reproduce — in klangk
+
+> Do this on a throwaway VM. Contain it: e.g. `ulimit -u 4096` in the shell you
+> run podman from, and watch `ps` in another terminal.
+
+The real path:
+
+1. Enable a plugin whose `on-shell-init.sh` starts with `#!/usr/bin/env bash`
+   (the pre-fix Hermes hook, or any toy hook with a bash shebang).
+2. Build the workspace image with that plugin enabled:
+   `devenv ... build-workspace-image` (`KLANGK_IMAGE_NAME=klangk-hermes`). The
+   build reaches the on-image-build step
+   (`src/containers/workspace/Dockerfile:67-69`,
+   `RUN for f in /opt/klangk/hooks/*/on-image-build.sh; do "$f"; done`) and the
+   VM process count explodes. The build crashes with
+   `Error: server probably quit: unexpected EOF` or hangs.
+
+Even simpler, against an already-built image carrying such a hook:
+
+```sh
+podman run --rm <workspace-image> bash -c true   # watch `ps` explode
+```
+
+A single non-interactive `bash -c true` is enough — `BASH_ENV` fires the hook
+loop, the bash hook re-enters it, and it recurses.
+
+### Secondary, separate build HANG
+
+The Hermes installer also spawns an interactive `bash -i` near the end
+("Setting up hermes command"). The interactive section of `bash.bashrc`
+busy-waits for the runtime ready flag:
+
+`src/containers/workspace/bash.bashrc:61`
+
+```bash
+while [ ! -f /tmp/.klangk-ready ]; do sleep 0.1; done
+```
+
+`/tmp/.klangk-ready` is created only by the container **entrypoint at runtime**,
+never during image build. So the installer's `bash -i` blocks forever and the
+build step never returns. Workaround: `touch /tmp/.klangk-ready` early in the
+plugin's `on-image-build.sh`, or avoid `bash -i` in installers run at build
+time.
+
+## The fix
+
+A re-entry guard wraps the expensive section (agent config + the on-shell-init
+hook loop) in `src/containers/workspace/bash.bashrc`. The flag is **exported**,
+so child bash invocations inherit it and skip the section — the storm cannot
+recur.
+
+`src/containers/workspace/bash.bashrc:29-41`
+
+```bash
+if [ -z "${KLANGK_BASHRC_DONE:-}" ]; then
+  export KLANGK_BASHRC_DONE=1
+
+  # Per-user Pi agent config (extensions, settings, models, skills).
+  python3 /opt/klangk/bin/klangk-setup-clankers
+
+  # Run plugin on-shell-init hooks (alphabetical by plugin name).
+  # These run as the klangk user on every shell open.
+  for f in /opt/klangk/hooks/*/on-shell-init.sh; do
+    # shellcheck disable=SC2181
+    [ -x "$f" ] && "$f" || true
+  done
+fi
+```
+
+The `PATH` and `EDITOR` exports above the guard stay unguarded — they are cheap
+and idempotent (`src/containers/workspace/bash.bashrc:16,19`).
+
+**Secondary mitigation (defense in depth):** plugin `on-shell-init.sh` hooks
+should use `#!/bin/sh` (dash) rather than bash. dash ignores `BASH_ENV`, so a
+`sh` hook cannot re-source `bash.bashrc` even if the guard were absent. Hermes's
+hook now ships with `#!/bin/sh` (see
+`.devenv/state/klangk/plugins/hermes/on-shell-init.sh`). Hermes's
+`on-image-build.sh` additionally `unset BASH_ENV`s before running the upstream
+installer, removing the build-time multiplier.
+
+These two mitigations are independent: the core guard alone stops the recursion;
+the `sh` shebang alone also stops it. Variants B and C of the repro script
+demonstrate each independently.
+
+## Recommendations
+
+- **Keep the guard in core `bash.bashrc`.** Since PR #789's `BASH_ENV` makes
+  `bash.bashrc` load-bearing for every non-interactive shell, the re-entry guard
+  is mandatory, not optional. Without it a single misbehaving plugin re-arms the
+  fork bomb.
+- **Add a lint/CI check** that every plugin `on-shell-init.sh` is POSIX `sh`
+  (e.g. reject a `bash`/`#!/usr/bin/env bash` shebang, or run `checkbashisms`),
+  so the defense-in-depth layer can't silently regress.
+- **Guard against the build hang too:** have plugins `touch
+/tmp/.klangk-ready` (or otherwise avoid `bash -i`) in `on-image-build.sh`, or
+  make the interactive ready-wait skip when not running under the entrypoint.

--- a/scripts/repro-bash-env-storm.sh
+++ b/scripts/repro-bash-env-storm.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# repro-bash-env-storm.sh
+#
+# Minimal, host-SAFE reproduction of the klangk "bash env fork storm" bug.
+#
+# It needs NO podman and NO klangk image. It isolates the exact mechanism with
+# plain bash:
+#
+#   1. BASH_ENV points at a "bashrc" that, like klangk's /etc/bash.bashrc,
+#      executes a plugin hook ("$HOOK") on every shell startup.
+#   2. The hook is a *bash* script (#!/usr/bin/env bash) — like the original
+#      hermes on-shell-init.sh.
+#   3. Starting that hook spawns a NEW non-interactive bash, which (because
+#      BASH_ENV is still set and exported) re-sources the bashrc, which runs
+#      the hook again -> unbounded recursion -> fork bomb.
+#
+# Variants:
+#   B (KLANGK_BASHRC_DONE guard)  -> the fix; runs once, clean.
+#   C (#!/bin/sh hook, no guard)  -> defense in depth; dash ignores BASH_ENV.
+#   A (no guard + bash hook)      -> the BUG; fork storm.
+#
+# Order matters: the clean variants (B, C) run FIRST against a clean process
+# baseline, then the destructive storm (A) runs LAST. RLIMIT_NPROC is per-user
+# (not per-process-tree), so if A ran first its lingering children would
+# pollute the user's process count and make B/C spuriously hit the cap. Running
+# A last removes that cross-contamination entirely.
+#
+# ---------------------------------------------------------------------------
+# WHY THIS IS SAFE TO RUN ON A REAL HOST
+# ---------------------------------------------------------------------------
+# A genuine fork bomb would take down the machine. We never let it. The trigger
+# for Variant A runs inside a SUBSHELL that first calls `ulimit -u <cap>`, which
+# limits how many processes that shell (and its children) may have for the real
+# user id. When the recursion hits that cap, fork() fails ("fork: retry:
+# Resource temporarily unavailable") and the tree collapses instead of growing.
+# We also bound wall time, kill the storm, and best-effort reap stragglers.
+# Because A is the LAST thing the script does, any brief residue cannot affect
+# the other variants.
+# ---------------------------------------------------------------------------
+
+set -u
+
+# Note: we intentionally set BASH_ENV inside subshells so the change is scoped to
+# each contained trigger — that's the point. The SC2030/SC2031 "modified in a
+# subshell" infos on those lines are expected and disabled inline below.
+
+HEADROOM=200  # cap = current user process baseline + HEADROOM
+TIME_LIMIT=15 # seconds of wall time before we kill the storm trigger
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/bash-env-storm.XXXXXX")"
+# EXIT cleanup: kill anything still executing our hook, then remove the workdir.
+cleanup() {
+  pkill -9 -f "$WORK/on-shell-init" 2>/dev/null
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+# --- The hook: a bash script, like the original hermes on-shell-init.sh -----
+HOOK="$WORK/on-shell-init.sh"
+cat >"$HOOK" <<'EOF'
+#!/usr/bin/env bash
+# Starting this script launches a fresh non-interactive bash. With BASH_ENV
+# set, that bash re-sources the bashrc on startup -> re-enters the hook loop.
+:
+EOF
+chmod +x "$HOOK"
+
+# --- A POSIX-sh variant of the hook (dash ignores BASH_ENV) -----------------
+HOOK_SH="$WORK/on-shell-init-posix.sh"
+cat >"$HOOK_SH" <<'EOF'
+#!/bin/sh
+# A /bin/sh script does NOT re-source BASH_ENV, so it cannot recurse.
+:
+EOF
+chmod +x "$HOOK_SH"
+
+# --- bashrc WITHOUT a re-entry guard (mimics pre-fix /etc/bash.bashrc) ------
+BASHRC_BUG="$WORK/bashrc-bug"
+cat >"$BASHRC_BUG" <<EOF
+# No re-entry guard: every non-interactive bash runs the hook unconditionally,
+# exactly like klangk's bash.bashrc before the KLANGK_BASHRC_DONE fix.
+"$HOOK" || true
+EOF
+
+# --- bashrc WITH the KLANGK_BASHRC_DONE re-entry guard (mimics the fix) ------
+BASHRC_FIXED="$WORK/bashrc-fixed"
+cat >"$BASHRC_FIXED" <<EOF
+# Exported guard: the first bash sets it; children inherit it and skip the
+# hook section. This is the fix applied to src/containers/workspace/bash.bashrc.
+if [ -z "\${KLANGK_BASHRC_DONE:-}" ]; then
+  export KLANGK_BASHRC_DONE=1
+  "$HOOK" || true
+fi
+EOF
+
+# --- bashrc that runs a POSIX-sh hook, no guard (Variant C) -----------------
+BASHRC_SH="$WORK/bashrc-shhook"
+cat >"$BASHRC_SH" <<EOF
+"$HOOK_SH" || true
+EOF
+
+user_procs() { ps -u "$(id -u)" 2>/dev/null | wc -l | tr -d ' '; }
+
+BASELINE=$(user_procs)
+PROC_CAP=$((BASELINE + HEADROOM)) # absolute ulimit -u for each variant
+echo "Work dir: $WORK"
+echo "Baseline user process count: $BASELINE"
+echo "Process cap (ulimit -u) for each contained trigger: $PROC_CAP (baseline + $HEADROOM)"
+echo
+
+# Run one non-interactive bash with BASH_ENV=$1, capped. Echo result for a
+# "clean" expectation: exit 0 and no fork-failure output.
+run_clean() {
+  local bashrc="$1" out="$WORK/clean.out" rc
+  (
+    ulimit -u "$PROC_CAP"
+    # shellcheck disable=SC2030
+    export BASH_ENV="$bashrc"
+    exec bash -c true
+  ) >"$out" 2>&1
+  rc=$?
+  if [ "$rc" -eq 0 ] && ! grep -qiE 'fork|Resource temporarily' "$out"; then
+    echo "  exit=$rc  -> CLEAN: ran once, no storm"
+  else
+    echo "  exit=$rc  -> UNEXPECTED (storm not prevented):"
+    head -3 "$out" | sed 's/^/    /'
+  fi
+  echo
+}
+
+# ---------------------------------------------------------------------------
+# Variant B: FIXED — re-entry guard. (clean; run first)
+# ---------------------------------------------------------------------------
+echo "=== Variant B: KLANGK_BASHRC_DONE guard + bash hook (expect CLEAN) ==="
+run_clean "$BASHRC_FIXED"
+
+# ---------------------------------------------------------------------------
+# Variant C: defense in depth — POSIX-sh hook, no guard. (clean; run first)
+# ---------------------------------------------------------------------------
+echo "=== Variant C: no guard + #!/bin/sh hook (defense in depth, expect CLEAN) ==="
+run_clean "$BASHRC_SH"
+
+# ---------------------------------------------------------------------------
+# Variant A: BUG — no guard, bash hook. The destructive one — runs LAST so its
+# residue cannot pollute B/C. Expect a fork storm that hits the cap.
+# ---------------------------------------------------------------------------
+echo "=== Variant A: no re-entry guard + bash hook (expect STORM) ==="
+A_OUT="$WORK/a.out"
+SETSID=""
+command -v setsid >/dev/null 2>&1 && SETSID="setsid"
+(
+  ulimit -u "$PROC_CAP"
+  # shellcheck disable=SC2030,SC2031
+  export BASH_ENV="$BASHRC_BUG"
+  exec $SETSID bash -c true
+) >"$A_OUT" 2>&1 &
+A_PID=$!
+
+PEAK=0
+END=$(($(date +%s) + TIME_LIMIT))
+while kill -0 "$A_PID" 2>/dev/null && [ "$(date +%s)" -lt "$END" ]; do
+  n=$(user_procs)
+  [ "$n" -gt "$PEAK" ] && PEAK="$n"
+  sleep 0.05
+done
+
+# Stop the storm: kill the trigger's process group, the pid, and any straggler
+# hook processes (matched by the workdir path in their argv).
+kill -- "-$A_PID" 2>/dev/null
+kill "$A_PID" 2>/dev/null
+pkill -9 -f "$WORK/on-shell-init" 2>/dev/null
+wait "$A_PID" 2>/dev/null
+A_RC=$?
+
+if grep -qiE 'fork|Resource temporarily unavailable|retry' "$A_OUT" 2>/dev/null || [ "$A_RC" -ne 0 ]; then
+  echo "  exit=$A_RC  peak user procs observed=$PEAK (cap $PROC_CAP)"
+  grep -iE 'fork|Resource temporarily unavailable|retry' "$A_OUT" 2>/dev/null | head -2 | sed 's/^/    /'
+  echo "  -> BUG REPRODUCED: fork storm hit the process cap"
+else
+  echo "  exit=$A_RC  peak user procs observed=$PEAK"
+  echo "  -> no fork failure seen; your ulimit -u may exceed $PROC_CAP — lower HEADROOM and retry"
+fi

--- a/src/containers/workspace/bash.bashrc
+++ b/src/containers/workspace/bash.bashrc
@@ -18,15 +18,27 @@ export PATH="/opt/klangk/bin:$PATH"
 # Default editor for git commit, crontab -e, etc.
 export EDITOR=nano
 
-# Per-user Pi agent config (extensions, settings, models, skills).
-python3 /opt/klangk/bin/klangk-setup-clankers
+# Re-entry guard for the expensive setup below (agent config + plugin hooks).
+# BASH_ENV=/etc/bash.bashrc (set in the image) makes EVERY non-interactive bash
+# source this file. A heavy process tree -- e.g. an installer at image-build
+# time that spawns thousands of bash subshells -- would otherwise re-run
+# klangk-setup-clankers + every on-shell-init hook in each one: a fork storm
+# that exhausts memory and crashes the VM. The flag is exported so children
+# inherit it and skip the section (they already have the resulting env). PATH
+# and EDITOR above stay unguarded -- cheap and idempotent.
+if [ -z "${KLANGK_BASHRC_DONE:-}" ]; then
+  export KLANGK_BASHRC_DONE=1
 
-# Run plugin on-shell-init hooks (alphabetical by plugin name).
-# These run as the klangk user on every shell open.
-for f in /opt/klangk/hooks/*/on-shell-init.sh; do
-  # shellcheck disable=SC2181
-  [ -x "$f" ] && "$f" || true
-done
+  # Per-user Pi agent config (extensions, settings, models, skills).
+  python3 /opt/klangk/bin/klangk-setup-clankers
+
+  # Run plugin on-shell-init hooks (alphabetical by plugin name).
+  # These run as the klangk user on every shell open.
+  for f in /opt/klangk/hooks/*/on-shell-init.sh; do
+    # shellcheck disable=SC2181
+    [ -x "$f" ] && "$f" || true
+  done
+fi
 
 # --- Interactive-only section --------------------------------------------
 


### PR DESCRIPTION
## Summary

Building a workspace image with a plugin that ships a **bash** `on-shell-init.sh` hook triggers a **fork storm** that OOMs/crashes the podman VM (`Error: server probably quit: unexpected EOF`; we observed 5,760 → 6,181 processes during a failed `klangk-hermes` build). This is **not** a Hermes bug — it's a latent defect in the workspace image's `bash.bashrc`, exposed by `BASH_ENV=/etc/bash.bashrc` (added in #789).

## Root cause

1. `Dockerfile` sets `ENV BASH_ENV=/etc/bash.bashrc` → every **non-interactive** bash sources `bash.bashrc` at startup.
2. `bash.bashrc` runs `klangk-setup-clankers` + the `on-shell-init` hook loop **unconditionally, before** the non-interactive early-exit, with **no re-entry guard**.
3. A plugin hook with a `#!/usr/bin/env bash` shebang → executing it starts a new non-interactive bash → re-sources `bash.bashrc` → runs the hook loop again → **unbounded recursion**. The Hermes installer additionally spawns thousands of bash subshells, each re-running the expensive section — a massive multiplier.

(Also documents a **secondary build hang**: the installer's `bash -i` blocks on `bash.bashrc`'s interactive `while [ ! -f /tmp/.klangk-ready ]` wait, which never fires at build time.)

## Fix

Wrap the expensive section in an **exported** re-entry guard so it runs once per process tree:

```bash
if [ -z "${KLANGK_BASHRC_DONE:-}" ]; then
  export KLANGK_BASHRC_DONE=1
  python3 /opt/klangk/bin/klangk-setup-clankers
  for f in /opt/klangk/hooks/*/on-shell-init.sh; do [ -x "$f" ] && "$f" || true; done
fi
```

Children inherit `KLANGK_BASHRC_DONE` and skip the section → recursion can't occur. `PATH`/`EDITOR` stay unguarded (cheap, idempotent).

**Defense in depth:** plugin `on-shell-init.sh` hooks should be POSIX `sh` (dash ignores `BASH_ENV`). Recommend a CI check enforcing that.

## Reproduction

`scripts/repro-bash-env-storm.sh` — self-contained, **host-safe** (`ulimit -u`-contained, wall-time bound, storm runs last). Verified:

```text
=== Variant B: KLANGK_BASHRC_DONE guard + bash hook (expect CLEAN) ===  -> CLEAN
=== Variant C: no guard + #!/bin/sh hook (defense in depth, expect CLEAN) ===  -> CLEAN
=== Variant A: no re-entry guard + bash hook (expect STORM) ===  exit=143, peak 876 vs cap 850  -> BUG REPRODUCED
```

Full analysis in `docs/dev/bash-env-fork-storm.md`.

## Context

Discovered while building the Hermes workspace plugin (#787). That PR's Hermes hook now ships `#!/bin/sh` (the defense-in-depth layer); this PR is the **core** fix so *any* plugin is safe.