### PR TITLE
fix: don't swallow on-image-build plugin output

### DIFF
--- a/src/containers/workspace/Dockerfile
+++ b/src/containers/workspace/Dockerfile
@@ -66,7 +66,7 @@ COPY tmux.conf /etc/tmux.conf
 # These run as root at image build time for system-level config.
 RUN for f in /opt/klangk/hooks/*/on-image-build.sh; do \
       [ -x "$f" ] && "$f"; \
-    done 2>/dev/null; true
+    done; true
 
 # Fix non-root group ownership that causes crun fchownat errors with
 # --userns=keep-id. crun cannot remap groups like utmp, shadow, adm, ssh


### PR DESCRIPTION
## Summary

- Remove `2>/dev/null` from the Dockerfile `on-image-build.sh` hook runner so plugin stderr is visible during image builds

Closes #797

## Test plan

- [ ] Rebuild workspace image with a plugin that has `on-image-build.sh` and verify output is visible in the build log