### PR TITLE
fix: remove BASH_ENV from workspace Dockerfile

### DIFF
--- a/src/containers/workspace/Dockerfile
+++ b/src/containers/workspace/Dockerfile
@@ -10,9 +10,6 @@ RUN npm install -g @earendil-works/pi-coding-agent@0.79.9 \
 
 # Plugin tools: flat directory, all on PATH via /opt/klangk/bin/
 ENV PATH="/opt/klangk/bin:${PATH}"
-# Let non-interactive bash shells (sandbox setup scripts, `bash -c`) source
-# the same environment as interactive shells — PATH, Pi agent config, etc.
-ENV BASH_ENV="/etc/bash.bashrc"
 COPY --from=plugin-tools / /opt/klangk/bin/
 RUN echo 'PATH="/opt/klangk/bin:${PATH}"' >> /etc/environment
 


### PR DESCRIPTION
## Summary

- Remove `ENV BASH_ENV="/etc/bash.bashrc"` from the workspace Dockerfile
- This was causing every non-interactive bash subprocess to source the full bashrc (which runs `klangk-setup-clankers` and all `on-shell-init` plugin hooks), creating fork bombs when `on-image-build` hooks spawn bash subprocesses during image build

## Test plan

- [ ] Rebuild workspace image — verify no fork bomb / hanging during `on-image-build` hooks
- [ ] Open a workspace shell — verify interactive shells still get full bashrc setup
- [ ] Run `klangkc sandbox` setup scripts — verify they still get PATH