### PR TITLE
Don't alias /bin/sh to /bin/bash

### DIFF
--- a/src/containers/workspace/Dockerfile.base
+++ b/src/containers/workspace/Dockerfile.base
@@ -76,8 +76,5 @@ RUN EXISTING_USER=$(getent passwd 1000 | cut -d: -f1) \
     && groupadd -g 1000 klangk \
     && useradd -u 1000 -g 1000 -m -d /home -s /bin/bash klangk
 
-# Make /bin/sh point to bash so Pi's bash tool supports bashisms (source, etc.)
-RUN ln -sf /bin/bash /bin/sh
-
 RUN mkdir -p /home/work && chown -R klangk:klangk /home
 WORKDIR /home/work


### PR DESCRIPTION
## Summary
- Remove the `ln -sf /bin/bash /bin/sh` symlink from `Dockerfile.base`
- Scripts using `#!/bin/sh` will now run with the default shell instead of bash

Fixes #802