### PR TITLE
fix: skip bashrc user-session setup during image build

### DIFF
--- a/src/containers/workspace/Dockerfile
+++ b/src/containers/workspace/Dockerfile
@@ -61,7 +61,11 @@ COPY tmux.conf /etc/tmux.conf
 
 # Run plugin on-image-build hooks (alphabetical by plugin name).
 # These run as root at image build time for system-level config.
-RUN for f in /opt/klangk/hooks/*/on-image-build.sh; do \
+# /tmp/.klangk-image-build tells bash.bashrc to bail out early so that any
+# `bash -i` spawned by plugin installers doesn't run user-session setup.
+# At runtime /tmp is a tmpfs so the marker is always absent.
+RUN touch /tmp/.klangk-image-build \
+    && for f in /opt/klangk/hooks/*/on-image-build.sh; do \
       [ -x "$f" ] && "$f"; \
     done; true
 

--- a/src/containers/workspace/bash.bashrc
+++ b/src/containers/workspace/bash.bashrc
@@ -5,6 +5,12 @@
 # Plugin tools on PATH (ENV in Dockerfile is overridden by login shells).
 export PATH="/opt/klangk/bin:$PATH"
 
+# Nothing below here is meaningful during image build. The Dockerfile touches
+# /tmp/.klangk-image-build before running plugin hooks; any `bash -i` spawned
+# by those hooks (e.g. hermes installer probing PATH) exits early here.
+# At runtime /tmp is a tmpfs so this file is always absent.
+[ -f /tmp/.klangk-image-build ] && return 0
+
 # Keep herdr's API socket on tmpfs — virtiofs (macOS) rejects chmod on sockets.
 # Per-user with random suffix to prevent predictable-path attacks in /tmp.
 _herdr_dir=$(mktemp -d "/tmp/herdr-${KLANGK_USER_ID:-default}-XXXXXXXX")
@@ -13,14 +19,11 @@ export HERDR_SOCKET_PATH="$_herdr_dir/herdr.sock"
 # Default editor for git commit, crontab -e, etc.
 export EDITOR=nano
 
-# Ignore Ctrl+C until setup is complete and any default command has started.
+# Block interactive shells until the entrypoint signals that setup is done.
+# /tmp is a tmpfs, so .klangk-ready starts absent on every container boot
+# and is created by the entrypoint when setup finishes.
 trap '' INT
-
-# Wait for the entrypoint to finish setup before showing a prompt.
-# /tmp is a tmpfs, so .klangk-ready is cleared on every container start.
 while [ ! -f /tmp/.klangk-ready ]; do sleep 0.1; done
-
-# Restore Ctrl+C for interactive shell.
 trap - INT
 
 # Change to the user's home directory (podman exec -w can't use symlinks


### PR DESCRIPTION
## Summary
- Plugin installers (e.g. hermes) may spawn `bash -i` during `on-image-build.sh` hooks to probe PATH, which sources `bash.bashrc` and blocks forever waiting for the entrypoint readiness file
- Touch `/tmp/.klangk-image-build` in the Dockerfile before running hooks; `bash.bashrc` bails out early when that marker exists
- At runtime `/tmp` is a tmpfs so the marker is always absent — no behavior change for running containers

Closes #806

## Test plan
- [ ] `build-workspace-image --no-cache` completes without hanging
- [ ] Workspace shells still wait for entrypoint readiness before showing a prompt