### PR TITLE
fix: remove .klangk-image-build marker after hooks run

### DIFF
--- a/src/containers/workspace/Dockerfile
+++ b/src/containers/workspace/Dockerfile
@@ -63,11 +63,11 @@ COPY tmux.conf /etc/tmux.conf
 # These run as root at image build time for system-level config.
 # /tmp/.klangk-image-build tells bash.bashrc to bail out early so that any
 # `bash -i` spawned by plugin installers doesn't run user-session setup.
-# At runtime /tmp is a tmpfs so the marker is always absent.
+# Removed after hooks finish so it doesn't persist into the final image.
 RUN touch /tmp/.klangk-image-build \
     && for f in /opt/klangk/hooks/*/on-image-build.sh; do \
       [ -x "$f" ] && "$f"; \
-    done; true
+    done; rm -f /tmp/.klangk-image-build; true
 
 # Fix non-root group ownership that causes crun fchownat errors with
 # --userns=keep-id. crun cannot remap groups like utmp, shadow, adm, ssh

--- a/src/containers/workspace/bash.bashrc
+++ b/src/containers/workspace/bash.bashrc
@@ -6,9 +6,9 @@
 export PATH="/opt/klangk/bin:$PATH"
 
 # Nothing below here is meaningful during image build. The Dockerfile touches
-# /tmp/.klangk-image-build before running plugin hooks; any `bash -i` spawned
-# by those hooks (e.g. hermes installer probing PATH) exits early here.
-# At runtime /tmp is a tmpfs so this file is always absent.
+# /tmp/.klangk-image-build before running plugin hooks and removes it after;
+# any `bash -i` spawned by those hooks (e.g. hermes installer probing PATH)
+# exits early here.
 [ -f /tmp/.klangk-image-build ] && return 0
 
 # Keep herdr's API socket on tmpfs — virtiofs (macOS) rejects chmod on sockets.


### PR DESCRIPTION
## Summary
- The `/tmp/.klangk-image-build` marker from #807 persisted into the final image because `/tmp` is not a tmpfs during build
- This caused `bash.bashrc` to bail out early at runtime, skipping all `on-shell-init` hooks
- Add `rm -f /tmp/.klangk-image-build` after hooks finish so it doesn't leak into the final image

See #810 for mounting `/tmp` as a tmpfs long-term.

## Test plan
- [ ] `build-workspace-image --no-cache` completes
- [ ] `/tmp/.klangk-image-build` does not exist in running container
- [ ] `on-shell-init` hooks run on shell open