### PR TITLE
fix: align playwright browser versions between nix and npm

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -62,7 +62,11 @@ in
         ]
     );
 
-  env.PLAYWRIGHT_BROWSERS_PATH = pkgs.playwright-driver.browsers;
+  # Nix playwright-driver.browsers has revision numbers that may not match
+  # the npm @playwright/test package (nix backports browser security patches).
+  # enterShell runs setup-playwright-browsers.sh to create a symlink farm
+  # that bridges the two.
+  env.NIX_PLAYWRIGHT_BROWSERS = pkgs.playwright-driver.browsers;
   env.PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS = "true";
 
   tasks = {
@@ -372,6 +376,9 @@ in
   };
 
   enterShell = ''
+    # Create playwright browser symlink farm (nix revisions → npm revisions)
+    source "$DEVENV_ROOT/scripts/setup-playwright-browsers.sh"
+
     mkdir -p "$KLANGK_DATA_DIR"
 
     # Generate version file (used by update_plugins.py and /version endpoint)

--- a/scripts/setup-playwright-browsers.sh
+++ b/scripts/setup-playwright-browsers.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Create a symlink farm that maps nix playwright browser directories to the
+# revision names the npm @playwright/test package expects.
+#
+# Nix backports browser security patches independently, so its revision
+# numbers (e.g. firefox-1522) may differ from upstream npm (firefox-1511)
+# even at the same playwright version.
+#
+# Sourced from enterShell — exports PLAYWRIGHT_BROWSERS_PATH.
+# Requires: NIX_PLAYWRIGHT_BROWSERS, DEVENV_STATE, DEVENV_ROOT
+
+_nix_pw="${NIX_PLAYWRIGHT_BROWSERS:-}"
+_npm_json="$DEVENV_ROOT/src/frontend/e2e-tests/node_modules/playwright-core/browsers.json"
+
+if [ -z "$_nix_pw" ] || [ ! -f "$_npm_json" ]; then
+  export PLAYWRIGHT_BROWSERS_PATH="${_nix_pw:-}"
+  # shellcheck disable=SC2317
+  return 0 2>/dev/null || exit 0
+fi
+
+_farm="$DEVENV_STATE/playwright-browsers"
+mkdir -p "$_farm"
+
+for _dir in "$_nix_pw"/*/; do
+  _nix_name=$(basename "$_dir")
+  _prefix=${_nix_name%-*}
+  # browsers.json uses dashes; nix dirs use underscores
+  _json_prefix=${_prefix//_/-}
+
+  _target=$(python3 -c "
+import json, sys
+with open(sys.argv[1]) as f:
+    for b in json.load(f).get('browsers', []):
+        if b['name'] == sys.argv[2]:
+            print(b['name'].replace('-', '_') + '-' + b['revision'])
+            break
+" "$_npm_json" "$_json_prefix" 2>/dev/null)
+
+  [ -n "$_target" ] && ln -sfn "$_dir" "$_farm/$_target"
+done
+
+export PLAYWRIGHT_BROWSERS_PATH="$_farm"

--- a/src/frontend/e2e-tests/package.json
+++ b/src/frontend/e2e-tests/package.json
@@ -7,7 +7,7 @@
     "install-browsers": "npx playwright install chromium"
   },
   "devDependencies": {
-    "@playwright/test": "^1.60.0",
+    "@playwright/test": "1.59.1",
     "@types/adm-zip": "^0.5.8",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/ws": "^8.18.1",


### PR DESCRIPTION
## Summary

- Pin `@playwright/test` to `1.59.1` to match nix `playwright-driver` version (prevents protocol mismatch errors like `isMobile` not recognized)
- Add `scripts/setup-playwright-browsers.sh` — creates a symlink farm in `enterShell` mapping nix browser revision names to npm-expected names (e.g. `firefox-1522` → `firefox-1511`)
- Wire it up in `devenv.nix` via `NIX_PLAYWRIGHT_BROWSERS` env var

Without this, `npx playwright test` fails with "Executable doesn't exist at firefox-1511" because nix provides `firefox-1522`, and even if paths are symlinked, protocol errors occur when playwright-core 1.60 talks to 1.59.1 browser binaries.

Related: #406

## Test plan

- [x] `devenv shell -- node -e "firefox.launch + newContext + goto"` succeeds
- [x] Symlink farm correctly maps all browser names
- [x] Falls back to nix browsers directly when npm not yet installed