### PR TITLE
feat: mount plugin-contributed routes in GoRouter

### DIFF
--- a/plugins/beep/klangk/pubspec.yaml
+++ b/plugins/beep/klangk/pubspec.yaml
@@ -13,3 +13,4 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
+      ref: v0.1.0

--- a/plugins/bobdobbs/klangk/pubspec.yaml
+++ b/plugins/bobdobbs/klangk/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
+      ref: v0.1.0
 
 flutter:
   assets:

--- a/plugins/boingball/klangk/pubspec.yaml
+++ b/plugins/boingball/klangk/pubspec.yaml
@@ -13,4 +13,5 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
+      ref: v0.1.0
   http: ^1.2.0

--- a/plugins/celebrate/klangk/pubspec.yaml
+++ b/plugins/celebrate/klangk/pubspec.yaml
@@ -13,3 +13,4 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
+      ref: v0.1.0

--- a/plugins/git-credential/klangk/pubspec.yaml
+++ b/plugins/git-credential/klangk/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
+      ref: v0.1.0
 
 dev_dependencies:
   flutter_test:

--- a/plugins/itstime/klangk/pubspec.yaml
+++ b/plugins/itstime/klangk/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
+      ref: v0.1.0
 
 flutter:
   assets:

--- a/scripts/import_dart_plugins.py
+++ b/scripts/import_dart_plugins.py
@@ -127,19 +127,9 @@ def generate_dart(plugins):
 def write_overrides_and_symlink():
     """Write pubspec_overrides.yaml at ~/.klangk/klangk/ and symlink it
     into the frontend directory so Flutter can find it."""
-    # The file-viewers stack needs the FileRenderer API, which currently lives
-    # on an unmerged branch of the plugin-api fork (mcdonc/klangk-plugin-api
-    # PR #2). Override klangk_plugin_api to that fork so the generated
-    # klangk_plugins package (which otherwise pins mcdonc) and the frontend
-    # resolve a single, FileRenderer-capable source. Drop this once PR #2 lands
-    # on mcdonc/main.
     overrides_content = (
         "dependency_overrides:\n"
         f"  klangk_plugins:\n    path: {KLANGK_DART_PLUGINS_PKG}\n"
-        "  klangk_plugin_api:\n"
-        "    git:\n"
-        "      url: https://github.com/runyaga/klangk-plugin-api.git\n"
-        "      ref: feat/file-renderer\n"
     )
     overrides_path = os.path.join(KLANGK_DART_PLUGINS_PKG, "pubspec_overrides.yaml")
     with open(overrides_path, "w") as f:

--- a/scripts/import_dart_plugins.py
+++ b/scripts/import_dart_plugins.py
@@ -29,7 +29,10 @@ OUTPUT = os.path.join(KLANGK_DART_PLUGINS_PKG, "lib", "klangk_plugins.dart")
 
 PLUGIN_API_DEP = {
     "klangk_plugin_api": {
-        "git": {"url": "https://github.com/mcdonc/klangk-plugin-api.git"}
+        "git": {
+            "url": "https://github.com/mcdonc/klangk-plugin-api.git",
+            "ref": "v0.1.0",
+        }
     }
 }
 

--- a/scripts/stub_dart_plugins.sh
+++ b/scripts/stub_dart_plugins.sh
@@ -29,6 +29,7 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
+      ref: v0.1.0
 EOF
 
 cat >"$STUB_DIR/lib/klangk_plugins.dart" <<'EOF'

--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -21,6 +21,7 @@ from starlette.background import BackgroundTask
 from fastapi.responses import (
     FileResponse,
     JSONResponse,
+    PlainTextResponse,
     RedirectResponse,
     StreamingResponse,
 )
@@ -64,6 +65,13 @@ router = APIRouter()
 @root_router.get("/health")
 async def health():
     return {"status": "ok"}
+
+
+@root_router.get("/empty")
+async def empty():
+    """Return an empty page. Used as a lightweight OAuth callback landing URL
+    so the popup doesn't need to boot the Flutter SPA."""
+    return PlainTextResponse("")
 
 
 @router.get("/auth/verify-workspace-token")

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -63,6 +63,13 @@ class TestHealth:
         assert resp.json() == {"status": "ok"}
 
 
+class TestEmpty:
+    async def test_empty(self, client):
+        resp = await client.get("/empty")
+        assert resp.status_code == 200
+        assert resp.text == ""
+
+
 class TestVerifyWorkspaceToken:
     async def test_valid_workspace_token(self, client):
         token = auth.create_workspace_token("ws-123")

--- a/src/frontend/lib/app.dart
+++ b/src/frontend/lib/app.dart
@@ -4,6 +4,8 @@ import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 import 'package:provider/provider.dart';
 import 'auth/auth_service.dart';
 import 'auth/pending_redirect.dart';
+import 'utils/web_helpers_stub.dart'
+    if (dart.library.js_interop) 'utils/web_helpers_web.dart';
 import 'theme/colors.dart';
 import 'admin/admin_users_page.dart';
 import 'auth/consent_page.dart';

--- a/src/frontend/lib/app.dart
+++ b/src/frontend/lib/app.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 import 'package:provider/provider.dart';
 import 'auth/auth_service.dart';
 import 'auth/pending_redirect.dart';
@@ -65,6 +66,10 @@ class _KlangkAppState extends State<KlangkApp> {
   }
 
   GoRouter _createRouter(AuthService auth, String initialLocation) {
+    // Collect routes contributed by plugins.
+    final pluginRoutes = ToolPluginRegistry().routes;
+    final pluginPaths = pluginRoutes.map((r) => r.path).toSet();
+
     return GoRouter(
       initialLocation: initialLocation,
       refreshListenable: auth,
@@ -88,6 +93,7 @@ class _KlangkAppState extends State<KlangkApp> {
           '/accept-invite',
           '/oidc-complete',
           '/consent',
+          ...pluginPaths,
         };
         if (!isLoggedIn && !publicRoutes.contains(loc)) {
           if (loc != '/' && loc != '/workspaces') {
@@ -95,7 +101,8 @@ class _KlangkAppState extends State<KlangkApp> {
           }
           return '/login';
         }
-        if (isLoggedIn && publicRoutes.contains(loc)) {
+        if (isLoggedIn && publicRoutes.contains(loc) &&
+            !pluginPaths.contains(loc)) {
           return pendingRedirect ?? '/workspaces';
         }
         if (isLoggedIn && loc == '/') return '/workspaces';
@@ -166,6 +173,15 @@ class _KlangkAppState extends State<KlangkApp> {
           path: '/admin/users',
           builder: (context, state) => const AdminUsersPage(),
         ),
+        for (final route in pluginRoutes)
+          GoRoute(
+            path: route.path,
+            builder: (context, state) => route.builder(
+              context,
+              state.pathParameters,
+              state.uri.queryParameters,
+            ),
+          ),
       ],
     );
   }

--- a/src/frontend/lib/app.dart
+++ b/src/frontend/lib/app.dart
@@ -179,7 +179,12 @@ class _KlangkAppState extends State<KlangkApp> {
             builder: (context, state) => route.builder(
               context,
               state.pathParameters,
-              state.uri.queryParameters,
+              // Merge page-level query params (captured before GoRouter
+              // navigation cleared them) with the hash query params.
+              // This is needed because the Soliplex OAuth callback lands
+              // as ?token=...#/callback — the token is in the page query,
+              // not the hash query.
+              {...capturedPageQuery, ...state.uri.queryParameters},
             ),
           ),
       ],

--- a/src/frontend/lib/main.dart
+++ b/src/frontend/lib/main.dart
@@ -28,8 +28,13 @@ Future<void> main() async {
       Uri.parse('assets/assets/libghostty-wasm32-freestanding.wasm'),
     );
   }
-  // Capture the hash before Flutter/GoRouter can consume it.
+  // Capture the hash and query string before Flutter/GoRouter can consume
+  // them. The Soliplex OAuth callback lands as ?token=...#/soliplex-auth-callback
+  // — GoRouter navigates on the hash, which clears the page-level query
+  // params from window.location.search. Capture them here and pass to the
+  // app so plugin callback routes can read them.
   final hash = getLocationHash();
+  capturePageQuery();
   final initialLocation = (hash.length > 1) ? hash.substring(1) : '/';
   runApp(
     MultiProvider(

--- a/src/frontend/lib/main.dart
+++ b/src/frontend/lib/main.dart
@@ -1,6 +1,8 @@
 import 'package:flterm/flterm.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
+import 'package:klangk_plugin_api/klangk_plugin_api.dart';
+import 'package:klangk_plugins/klangk_plugins.dart';
 import 'package:provider/provider.dart';
 import 'app.dart';
 import 'auth/auth_service.dart';
@@ -10,6 +12,14 @@ import 'utils/web_helpers_stub.dart'
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  // Register plugins early so their routes are available when GoRouter
+  // is created (before any workspace page is opened).
+  final registry = ToolPluginRegistry();
+  for (final plugin in createAllPlugins()) {
+    registry.register(plugin);
+  }
+
   if (kIsWeb) {
     // libghostty's VT runs as WebAssembly in the browser; load it once before
     // any terminal is built. The bundled binary must match the resolved

--- a/src/frontend/lib/utils/web_helpers_stub.dart
+++ b/src/frontend/lib/utils/web_helpers_stub.dart
@@ -19,6 +19,15 @@ Widget buildSuppressor(Widget child) => child;
 /// Stub — return empty hash in VM tests.
 String getLocationHash() => '';
 
+/// Stub — return empty query string in VM tests.
+String getLocationSearch() => '';
+
+/// Query params captured at startup (empty in VM tests).
+Map<String, String> capturedPageQuery = {};
+
+/// Stub — no-op in VM tests.
+void capturePageQuery() {}
+
 /// Stub — return empty browser ID in VM tests.
 String getBrowserId(String instanceId) => '';
 

--- a/src/frontend/lib/utils/web_helpers_web.dart
+++ b/src/frontend/lib/utils/web_helpers_web.dart
@@ -45,6 +45,21 @@ void suppressContextMenuBriefly() {
 /// Get the browser's location hash fragment.
 String getLocationHash() => web.window.location.hash;
 
+/// Get the browser's location query string (e.g. '?token=xxx').
+String getLocationSearch() => web.window.location.search;
+
+/// Query params captured from the page URL at startup, before GoRouter
+/// navigation clears them. Plugin callback routes read from this.
+Map<String, String> capturedPageQuery = {};
+
+/// Call once from main() to snapshot the page-level query params.
+void capturePageQuery() {
+  final search = web.window.location.search;
+  if (search.length > 1) {
+    capturedPageQuery = Uri.splitQueryString(search.substring(1));
+  }
+}
+
 /// Return a stable browser tab ID from sessionStorage.
 ///
 /// Survives page refresh (same tab) but is unique per tab.

--- a/src/frontend/lib/workspace/workspace_page.dart
+++ b/src/frontend/lib/workspace/workspace_page.dart
@@ -123,10 +123,8 @@ class _WorkspacePageState extends State<WorkspacePage> {
   void initState() {
     super.initState();
     _pluginRegistry = ToolPluginRegistry();
-    _plugins = createAllPlugins();
-    for (final plugin in _plugins) {
-      _pluginRegistry.register(plugin);
-    }
+    // Plugins are registered once in main() — reuse them here.
+    _plugins = _pluginRegistry.plugins.toList();
     _fileRenderers = buildFileRendererRegistry(_plugins);
     _fetchWorkspaceName();
     WidgetsBinding.instance.addPostFrameCallback((_) => _connectToWorkspace());

--- a/src/frontend/pubspec.yaml
+++ b/src/frontend/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
+      ref: v0.1.0
   # Path set by import_plugins.py — do not edit this line
   klangk_plugins:
     path: PLACEHOLDER

--- a/src/frontend/pubspec.yaml
+++ b/src/frontend/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
-      ref: feat/plugin-routes
+      ref: v0.1.0
   # Path set by import_plugins.py — do not edit this line
   klangk_plugins:
     path: PLACEHOLDER

--- a/src/frontend/pubspec.yaml
+++ b/src/frontend/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
+      ref: feat/plugin-routes
   # Path set by import_plugins.py — do not edit this line
   klangk_plugins:
     path: PLACEHOLDER


### PR DESCRIPTION
## Summary

- Import `ToolPluginRegistry` and collect `PluginRoute`s from all registered plugins
- Add plugin routes to the GoRouter's route table
- Mark plugin routes as public (bypass auth redirect) so they work as OAuth callback landing pages
- Don't redirect authenticated users away from plugin routes (unlike login/verify pages)

## Motivation

Plugins need to register callback routes (e.g. `/soliplex-auth-callback` for OAuth popup flow). Without this, GoRouter throws `GoException: no routes for location` and the redirect guard bounces to `/login`, losing the `?token=` query params.

## Dependencies

- mcdonc/klangk-plugin-api#3 (adds `PluginRoute` and `routes` getter to `ToolPlugin`)
- `pubspec.yaml` temporarily points at `feat/plugin-routes` branch — update to `main` after merging the API PR