### PR TITLE
deps: pin klangk_plugin_api to v0.1.0

### DIFF
--- a/src/frontend/pubspec.yaml
+++ b/src/frontend/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
+      ref: v0.1.0
   # Path set by import_plugins.py — do not edit this line
   klangk_plugins:
     path: PLACEHOLDER


### PR DESCRIPTION
Pin the klangk_plugin_api git dependency to the v0.1.0 tag instead of floating on main.