### PR TITLE
fix: reduce mouse wheel scroll speed in tmux

### DIFF
--- a/src/frontend/e2e-tests/e2e/terminal-keymap.spec.ts
+++ b/src/frontend/e2e-tests/e2e/terminal-keymap.spec.ts
@@ -151,8 +151,8 @@ test.describe("terminal keymap (web)", () => {
     request,
   }) => {
     // Verify the terminal remains responsive after scrolling. Wheel events
-    // are converted to PgUp/PgDn on the alternate screen (tmux), but the
-    // exact behavior depends on how the browser delivers PointerScrollEvent.
+    // are converted to arrow-key sequences on the alternate screen (tmux),
+    // but the exact behavior depends on how the browser delivers PointerScrollEvent.
     const sent = captureTerminalInput(page);
     const { cleanup } = await createAndOpenWorkspace(
       page,

--- a/src/frontend/lib/terminal/ghostty_terminal.dart
+++ b/src/frontend/lib/terminal/ghostty_terminal.dart
@@ -364,9 +364,9 @@ class GhosttyTerminalState extends State<GhosttyTerminal> {
         ),
       },
       child: Listener(
-        // On the alternate screen (tmux), convert wheel events to
-        // arrow-key sequences so tmux scrolls line-by-line in copy-mode.
-        // flterm has no local scrollback on the alt screen.
+        // On the alternate screen (tmux), convert wheel events to arrow-key
+        // sequences so tmux scrolls line-by-line in copy-mode. flterm has
+        // no local scrollback on the alt screen.
         onPointerSignal: (event) {
           if (event is PointerScrollEvent &&
               _scrollController.hasClients &&

--- a/src/frontend/lib/terminal/ghostty_terminal.dart
+++ b/src/frontend/lib/terminal/ghostty_terminal.dart
@@ -365,18 +365,18 @@ class GhosttyTerminalState extends State<GhosttyTerminal> {
       },
       child: Listener(
         // On the alternate screen (tmux), convert wheel events to
-        // PgUp/PgDn key sequences so tmux can handle scrollback via
-        // copy-mode. flterm has no local scrollback on the alt screen.
+        // arrow-key sequences so tmux scrolls line-by-line in copy-mode.
+        // flterm has no local scrollback on the alt screen.
         onPointerSignal: (event) {
           if (event is PointerScrollEvent &&
               _scrollController.hasClients &&
               _scrollController.activeScreen == TerminalScreen.alternate) {
             if (event.scrollDelta.dy < 0) {
-              // Wheel up → Shift+PgUp (ESC [5;2~)
-              widget.wsClient.sendTerminalInput('\x1b[5;2~');
+              // Wheel up → 3× Up arrow (ESC [A) for ~3 lines per tick
+              widget.wsClient.sendTerminalInput('\x1b[A\x1b[A\x1b[A');
             } else if (event.scrollDelta.dy > 0) {
-              // Wheel down → Shift+PgDn (ESC [6;2~)
-              widget.wsClient.sendTerminalInput('\x1b[6;2~');
+              // Wheel down → 3× Down arrow (ESC [B) for ~3 lines per tick
+              widget.wsClient.sendTerminalInput('\x1b[B\x1b[B\x1b[B');
             }
           }
         },

--- a/src/frontend/test/ghostty_terminal_scroll_test.dart
+++ b/src/frontend/test/ghostty_terminal_scroll_test.dart
@@ -152,7 +152,7 @@ void main() {
   });
 
   group('mouse wheel on alternate screen', () {
-    testWidgets('wheel up sends Shift+PgUp to PTY on alt screen', (
+    testWidgets('wheel up sends 3 arrow-up keys to PTY on alt screen', (
       tester,
     ) async {
       final client = _MockWsClient();
@@ -174,17 +174,19 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      // Should have sent Shift+PgUp (ESC [5;2~) to the PTY
+      // Should have sent 3× Up arrow (ESC [A) to the PTY
       expect(
-        client.sentCommands.any((c) => c.contains('\x1b[5;2~')),
+        client.sentCommands.any((c) => c.contains('\x1b[A\x1b[A\x1b[A')),
         isTrue,
         reason:
-            'wheel up on alt screen sends Shift+PgUp to PTY for tmux scrollback',
+            'wheel up on alt screen sends 3 arrow-up keys for line-by-line scroll',
       );
       client.close();
     });
 
-    testWidgets('wheel down sends PgDn to PTY on alt screen', (tester) async {
+    testWidgets('wheel down sends 3 arrow-down keys to PTY on alt screen', (
+      tester,
+    ) async {
       final client = _MockWsClient();
       final key = GlobalKey<GhosttyTerminalState>();
       await _pumpReady(tester, client, key);
@@ -200,10 +202,10 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(
-        client.sentCommands.any((c) => c.contains('\x1b[6;2~')),
+        client.sentCommands.any((c) => c.contains('\x1b[B\x1b[B\x1b[B')),
         isTrue,
         reason:
-            'wheel down on alt screen sends Shift+PgDn to PTY for tmux scrollback',
+            'wheel down on alt screen sends 3 arrow-down keys for line-by-line scroll',
       );
       client.close();
     });


### PR DESCRIPTION
## Summary
- Wheel events were sending `Shift+PgUp/PgDn` to tmux, causing half-page jumps per tick — way too fast
- Changed to send 3 arrow-key sequences per tick for line-by-line scrolling
- Fixes #829

## Test plan
- [x] Unit tests updated and passing (ghostty_terminal_scroll_test.dart)
- [x] Full frontend test suite passes (575 tests)