### PR TITLE
fix: show Connection Lost after reconnect attempts exhausted

### DIFF
--- a/src/frontend/lib/workspace/workspace_page.dart
+++ b/src/frontend/lib/workspace/workspace_page.dart
@@ -351,8 +351,8 @@ class _WorkspacePageState extends State<WorkspacePage> {
     if (!wsClient.connected && !_connecting && !_disconnected) {
       setState(() => _disconnected = true);
     }
-    // Rebuild when reconnecting state changes
-    if (wsClient.reconnecting) {
+    // Rebuild when reconnecting state changes (including when it stops)
+    if (_disconnected) {
       setState(() {});
     }
   }


### PR DESCRIPTION
## Summary
- The UI only called `setState` when `wsClient.reconnecting` was `true`, so when the reconnect loop stopped after 25 attempts, the overlay stayed stuck showing "Reconnecting (attempt 25)..."
- Changed to rebuild whenever `_disconnected` is true, so the "Connection lost" state with manual Reconnect button is shown after attempts are exhausted
- Fixes #833

## Test plan
- [x] Unit tests pass (workspace_page_test.dart, ws_client_test.dart)