### PR TITLE
fix: use tmux.conf wheel bindings for scroll speed

### DIFF
--- a/src/containers/workspace/tmux.conf
+++ b/src/containers/workspace/tmux.conf
@@ -30,6 +30,12 @@ set -g mouse on
 # Mouse wheel enters copy mode for scrollback.
 bind -n WheelUpPane copy-mode -eu
 
+# Scroll one line per wheel tick in copy mode (default is 5, too fast).
+bind -T copy-mode WheelUpPane select-pane \; send-keys -X -N 1 scroll-up
+bind -T copy-mode WheelDownPane select-pane \; send-keys -X -N 1 scroll-down
+bind -T copy-mode-vi WheelUpPane select-pane \; send-keys -X -N 1 scroll-up
+bind -T copy-mode-vi WheelDownPane select-pane \; send-keys -X -N 1 scroll-down
+
 # Copy selection to system clipboard via bridge. copy-pipe sends the
 # selected text to stdin of the script and also copies to tmux's paste
 # buffer. -and-cancel exits copy mode after copying.

--- a/src/frontend/e2e-tests/e2e/terminal-keymap.spec.ts
+++ b/src/frontend/e2e-tests/e2e/terminal-keymap.spec.ts
@@ -151,8 +151,8 @@ test.describe("terminal keymap (web)", () => {
     request,
   }) => {
     // Verify the terminal remains responsive after scrolling. Wheel events
-    // are converted to arrow-key sequences on the alternate screen (tmux),
-    // but the exact behavior depends on how the browser delivers PointerScrollEvent.
+    // are sent to tmux as SGR mouse events (flterm encodes them natively);
+    // tmux copy-mode wheel bindings in tmux.conf control scroll speed.
     const sent = captureTerminalInput(page);
     const { cleanup } = await createAndOpenWorkspace(
       page,

--- a/src/frontend/lib/terminal/ghostty_terminal.dart
+++ b/src/frontend/lib/terminal/ghostty_terminal.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:flterm/flterm.dart';
-import 'package:flutter/gestures.dart' show PointerScrollEvent;
 import 'package:flutter/foundation.dart'
     show TargetPlatform, defaultTargetPlatform, kIsWeb;
 import 'package:flutter/material.dart';
@@ -363,60 +362,42 @@ class GhosttyTerminalState extends State<GhosttyTerminal> {
           onInvoke: (_) => _zoomReset(),
         ),
       },
-      child: Listener(
-        // On the alternate screen (tmux), convert wheel events to arrow-key
-        // sequences so tmux scrolls line-by-line in copy-mode. flterm has
-        // no local scrollback on the alt screen.
-        onPointerSignal: (event) {
-          if (event is PointerScrollEvent &&
-              _scrollController.hasClients &&
-              _scrollController.activeScreen == TerminalScreen.alternate) {
-            if (event.scrollDelta.dy < 0) {
-              // Wheel up → 3× Up arrow (ESC [A) for ~3 lines per tick
-              widget.wsClient.sendTerminalInput('\x1b[A\x1b[A\x1b[A');
-            } else if (event.scrollDelta.dy > 0) {
-              // Wheel down → 3× Down arrow (ESC [B) for ~3 lines per tick
-              widget.wsClient.sendTerminalInput('\x1b[B\x1b[B\x1b[B');
-            }
-          }
+      child: TerminalView(
+        controller: _terminal,
+        theme: _theme,
+        fontData: _fontData,
+        focusNode: _focusNode,
+        scrollController: _scrollController,
+        autofocus: false,
+        padding: EdgeInsets.zero,
+        // On web, let plain PgUp/PgDn on the primary screen and the browser
+        // zoom combos (Cmd/Ctrl +/-/0) reach the browser (see [_bypassKey]);
+        // on the alt screen and on native they go to the PTY as usual.
+        bypassKey: _bypassKey,
+        // Disable flterm's built-in Ctrl/Cmd+V paste (it reads via
+        // Clipboard.getData, which fails on Firefox). These override flterm's
+        // platform defaults, so paste flows solely through the native
+        // `paste` event in [installPasteListener] — one path, no double-paste.
+        //
+        // Native-only font zoom is added via [zoomShortcutsFor]; on web
+        // the browser zooms. Page-scroll keys go to the PTY where tmux
+        // handles scrollback.
+        shortcuts: {
+          ..._disableFltermPaste,
+          if (!isWebOverride) ...zoomShortcutsFor(defaultTargetPlatform),
         },
-        child: TerminalView(
-          controller: _terminal,
-          theme: _theme,
-          fontData: _fontData,
-          focusNode: _focusNode,
-          scrollController: _scrollController,
-          autofocus: false,
-          padding: EdgeInsets.zero,
-          // On web, let plain PgUp/PgDn on the primary screen and the browser
-          // zoom combos (Cmd/Ctrl +/-/0) reach the browser (see [_bypassKey]);
-          // on the alt screen and on native they go to the PTY as usual.
-          bypassKey: _bypassKey,
-          // Disable flterm's built-in Ctrl/Cmd+V paste (it reads via
-          // Clipboard.getData, which fails on Firefox). These override flterm's
-          // platform defaults, so paste flows solely through the native
-          // `paste` event in [installPasteListener] — one path, no double-paste.
-          //
-          // Native-only font zoom is added via [zoomShortcutsFor]; on web
-          // the browser zooms. Page-scroll keys go to the PTY where tmux
-          // handles scrollback; alt-screen scroll is handled in [_bypassKey].
-          shortcuts: {
-            ..._disableFltermPaste,
-            if (!isWebOverride) ...zoomShortcutsFor(defaultTargetPlatform),
+        // Keep mouse selection (drag/word/line/long-press) but drop the
+        // keyboard select-all gesture, so Ctrl+A falls through to the shell
+        // (readline beginning-of-line / tmux prefix) instead of selecting the
+        // buffer. Ctrl+C already passes through (flterm's copy is selection-
+        // conditional); copy stays on Ctrl+Shift+C and the right-click menu.
+        gestureSettings: const TerminalGestureSettings(
+          enabledSelections: {
+            SelectionGesture.drag,
+            SelectionGesture.word,
+            SelectionGesture.line,
+            SelectionGesture.longPress,
           },
-          // Keep mouse selection (drag/word/line/long-press) but drop the
-          // keyboard select-all gesture, so Ctrl+A falls through to the shell
-          // (readline beginning-of-line / tmux prefix) instead of selecting the
-          // buffer. Ctrl+C already passes through (flterm's copy is selection-
-          // conditional); copy stays on Ctrl+Shift+C and the right-click menu.
-          gestureSettings: const TerminalGestureSettings(
-            enabledSelections: {
-              SelectionGesture.drag,
-              SelectionGesture.word,
-              SelectionGesture.line,
-              SelectionGesture.longPress,
-            },
-          ),
         ),
       ),
     );

--- a/src/frontend/test/ghostty_terminal_scroll_test.dart
+++ b/src/frontend/test/ghostty_terminal_scroll_test.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:flterm/flterm.dart';
-import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -146,66 +145,6 @@ void main() {
         before,
         reason:
             'scroll position must not change while the alt screen is active',
-      );
-      client.close();
-    });
-  });
-
-  group('mouse wheel on alternate screen', () {
-    testWidgets('wheel up sends 3 arrow-up keys to PTY on alt screen', (
-      tester,
-    ) async {
-      final client = _MockWsClient();
-      final key = GlobalKey<GhosttyTerminalState>();
-      await _pumpReady(tester, client, key);
-
-      // Switch to alt screen (tmux uses this)
-      client.emitTerminal('\x1b[?1049h');
-      await tester.pumpAndSettle();
-      expect(key.currentState!.scrollController.activeScreen,
-          TerminalScreen.alternate);
-      client.sentCommands.clear();
-
-      // Send wheel up event
-      final center = tester.getCenter(find.byType(TerminalView));
-      await tester.sendEventToBinding(
-        PointerScrollEvent(
-            position: center, scrollDelta: const Offset(0, -100)),
-      );
-      await tester.pumpAndSettle();
-
-      // Should have sent 3× Up arrow (ESC [A) to the PTY
-      expect(
-        client.sentCommands.any((c) => c.contains('\x1b[A\x1b[A\x1b[A')),
-        isTrue,
-        reason:
-            'wheel up on alt screen sends 3 arrow-up keys for line-by-line scroll',
-      );
-      client.close();
-    });
-
-    testWidgets('wheel down sends 3 arrow-down keys to PTY on alt screen', (
-      tester,
-    ) async {
-      final client = _MockWsClient();
-      final key = GlobalKey<GhosttyTerminalState>();
-      await _pumpReady(tester, client, key);
-
-      client.emitTerminal('\x1b[?1049h');
-      await tester.pumpAndSettle();
-      client.sentCommands.clear();
-
-      final center = tester.getCenter(find.byType(TerminalView));
-      await tester.sendEventToBinding(
-        PointerScrollEvent(position: center, scrollDelta: const Offset(0, 100)),
-      );
-      await tester.pumpAndSettle();
-
-      expect(
-        client.sentCommands.any((c) => c.contains('\x1b[B\x1b[B\x1b[B')),
-        isTrue,
-        reason:
-            'wheel down on alt screen sends 3 arrow-down keys for line-by-line scroll',
       );
       client.close();
     });


### PR DESCRIPTION
## Summary
- Remove the frontend `Listener` that intercepted wheel events and translated them to arrow-key sequences — flterm already sends SGR mouse events to tmux natively
- Add `-N 1` wheel bindings in tmux.conf copy-mode so tmux scrolls one line per wheel tick instead of the default 5
- Simpler approach to #829, replacing the frontend hack from #830

## Test plan
- [x] Frontend unit tests pass (3 scroll tests, wheel-translation tests removed)
- [ ] Manual: mouse wheel scrolls one line at a time in tmux copy-mode
- [ ] E2E: typing still works after mouse wheel scroll

Fixes #838