### PR TITLE
feat: add password visibility toggle to all password fields

### DIFF
--- a/src/frontend/lib/admin/admin_users_page.dart
+++ b/src/frontend/lib/admin/admin_users_page.dart
@@ -37,14 +37,11 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
 
   void _resolvePermissions() {
     final auth = context.read<AuthService>();
-    _canUsers =
-        auth.hasPermission('/admin', '*') ||
+    _canUsers = auth.hasPermission('/admin', '*') ||
         auth.hasPermission('/admin/users', 'view');
-    _canGroups =
-        auth.hasPermission('/admin', '*') ||
+    _canGroups = auth.hasPermission('/admin', '*') ||
         auth.hasPermission('/admin/groups', 'view');
-    _canInvitations =
-        auth.hasPermission('/admin', '*') ||
+    _canInvitations = auth.hasPermission('/admin', '*') ||
         auth.hasPermission('/admin/invitations', 'view');
   }
 
@@ -223,9 +220,8 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
       builder: (ctx) => StatefulBuilder(
         builder: (ctx, setDialogState) {
           final memberIds = members.map((m) => m['id']).toSet();
-          final nonMembers = allUsers
-              .where((u) => !memberIds.contains(u['id']))
-              .toList();
+          final nonMembers =
+              allUsers.where((u) => !memberIds.contains(u['id'])).toList();
 
           return AlertDialog(
             title: Text('Members of "$groupName"'),
@@ -675,8 +671,8 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
               backgroundColor: isPending
                   ? KColors.accentAmber
                   : status == 'accepted'
-                  ? KColors.accentGreen
-                  : KColors.textMuted,
+                      ? KColors.accentGreen
+                      : KColors.textMuted,
               child: Text(
                 initial,
                 style: const TextStyle(
@@ -728,9 +724,8 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
 
   @override
   Widget build(BuildContext context) {
-    final pendingCount = _invitations
-        .where((i) => i['status'] == 'pending')
-        .length;
+    final pendingCount =
+        _invitations.where((i) => i['status'] == 'pending').length;
     final tabs = <SkeuoTab>[];
     final views = <Widget>[];
     final tabTypes = _tabTypes;
@@ -856,6 +851,7 @@ class _AddUserDialogState extends State<_AddUserDialog> {
   final _emailController = TextEditingController();
   final _passwordController = TextEditingController();
   bool _sendVerificationEmail = false;
+  bool _obscurePassword = true;
 
   @override
   void dispose() {
@@ -910,8 +906,15 @@ class _AddUserDialogState extends State<_AddUserDialog> {
                   floatingLabelStyle: labelStyle,
                   floatingLabelBehavior: FloatingLabelBehavior.always,
                   border: const OutlineInputBorder(),
+                  suffixIcon: IconButton(
+                    icon: Icon(_obscurePassword
+                        ? Icons.visibility_off
+                        : Icons.visibility),
+                    onPressed: () =>
+                        setState(() => _obscurePassword = !_obscurePassword),
+                  ),
                 ),
-                obscureText: true,
+                obscureText: _obscurePassword,
               ),
             ],
           ],
@@ -965,6 +968,7 @@ class _EditUserDialogState extends State<_EditUserDialog> {
   late final TextEditingController _emailController;
   late final TextEditingController _handleController;
   final _passwordController = TextEditingController();
+  bool _obscurePassword = true;
 
   @override
   void initState() {
@@ -1026,8 +1030,15 @@ class _EditUserDialogState extends State<_EditUserDialog> {
                 floatingLabelBehavior: FloatingLabelBehavior.always,
                 hintText: 'Leave blank to keep current',
                 border: const OutlineInputBorder(),
+                suffixIcon: IconButton(
+                  icon: Icon(_obscurePassword
+                      ? Icons.visibility_off
+                      : Icons.visibility),
+                  onPressed: () =>
+                      setState(() => _obscurePassword = !_obscurePassword),
+                ),
               ),
-              obscureText: true,
+              obscureText: _obscurePassword,
             ),
           ],
         ),

--- a/src/frontend/lib/auth/accept_invite_page.dart
+++ b/src/frontend/lib/auth/accept_invite_page.dart
@@ -21,6 +21,7 @@ class _AcceptInvitePageState extends State<AcceptInvitePage> {
   final _formKey = GlobalKey<FormState>();
   bool _submitting = false;
   String? _error;
+  bool _obscurePassword = true;
 
   @override
   void initState() {
@@ -131,11 +132,18 @@ class _AcceptInvitePageState extends State<AcceptInvitePage> {
                   const SizedBox(height: 24),
                   TextFormField(
                     controller: _passwordController,
-                    decoration: const InputDecoration(
+                    decoration: InputDecoration(
                       labelText: 'Password',
-                      border: OutlineInputBorder(),
+                      border: const OutlineInputBorder(),
+                      suffixIcon: IconButton(
+                        icon: Icon(_obscurePassword
+                            ? Icons.visibility_off
+                            : Icons.visibility),
+                        onPressed: () => setState(
+                            () => _obscurePassword = !_obscurePassword),
+                      ),
                     ),
-                    obscureText: true,
+                    obscureText: _obscurePassword,
                     validator: (v) {
                       if (v == null || v.isEmpty) return 'Required';
                       if (v.length < 4) return 'Min 4 characters';
@@ -145,11 +153,18 @@ class _AcceptInvitePageState extends State<AcceptInvitePage> {
                   const SizedBox(height: 16),
                   TextFormField(
                     controller: _confirmController,
-                    decoration: const InputDecoration(
+                    decoration: InputDecoration(
                       labelText: 'Confirm Password',
-                      border: OutlineInputBorder(),
+                      border: const OutlineInputBorder(),
+                      suffixIcon: IconButton(
+                        icon: Icon(_obscurePassword
+                            ? Icons.visibility_off
+                            : Icons.visibility),
+                        onPressed: () => setState(
+                            () => _obscurePassword = !_obscurePassword),
+                      ),
                     ),
-                    obscureText: true,
+                    obscureText: _obscurePassword,
                     validator: (v) {
                       if (v != _passwordController.text) {
                         return 'Passwords do not match';

--- a/src/frontend/lib/auth/login_page.dart
+++ b/src/frontend/lib/auth/login_page.dart
@@ -31,6 +31,7 @@ class _LoginPageState extends State<LoginPage> {
   bool _needsVerification = false;
   bool _resending = false;
   bool _registrationEnabled = true;
+  bool _obscurePassword = true;
   List<Map<String, dynamic>> _oidcProviders = [];
   String _authModes = 'password';
 
@@ -194,11 +195,21 @@ class _LoginPageState extends State<LoginPage> {
                       const SizedBox(height: 16),
                       TextFormField(
                         controller: _passwordController,
-                        decoration: const InputDecoration(
+                        decoration: InputDecoration(
                           labelText: 'Password',
-                          border: OutlineInputBorder(),
+                          border: const OutlineInputBorder(),
+                          suffixIcon: IconButton(
+                            icon: Icon(_obscurePassword
+                                ? Icons.visibility_off
+                                : Icons.visibility),
+                            onPressed: () {
+                              setState(() {
+                                _obscurePassword = !_obscurePassword;
+                              });
+                            },
+                          ),
                         ),
-                        obscureText: true,
+                        obscureText: _obscurePassword,
                         validator: (v) {
                           if (v == null || v.isEmpty) return 'Required';
                           if (_isRegister && v.length < 4)

--- a/src/frontend/lib/auth/reset_password_page.dart
+++ b/src/frontend/lib/auth/reset_password_page.dart
@@ -21,6 +21,7 @@ class _ResetPasswordPageState extends State<ResetPasswordPage> {
   final _formKey = GlobalKey<FormState>();
   bool _submitting = false;
   String? _error;
+  bool _obscurePassword = true;
 
   @override
   void initState() {
@@ -126,11 +127,18 @@ class _ResetPasswordPageState extends State<ResetPasswordPage> {
                   const SizedBox(height: 24),
                   TextFormField(
                     controller: _passwordController,
-                    decoration: const InputDecoration(
+                    decoration: InputDecoration(
                       labelText: 'New Password',
-                      border: OutlineInputBorder(),
+                      border: const OutlineInputBorder(),
+                      suffixIcon: IconButton(
+                        icon: Icon(_obscurePassword
+                            ? Icons.visibility_off
+                            : Icons.visibility),
+                        onPressed: () => setState(
+                            () => _obscurePassword = !_obscurePassword),
+                      ),
                     ),
-                    obscureText: true,
+                    obscureText: _obscurePassword,
                     validator: (v) {
                       if (v == null || v.isEmpty) return 'Required';
                       if (v.length < 4) return 'Min 4 characters';
@@ -140,11 +148,18 @@ class _ResetPasswordPageState extends State<ResetPasswordPage> {
                   const SizedBox(height: 16),
                   TextFormField(
                     controller: _confirmController,
-                    decoration: const InputDecoration(
+                    decoration: InputDecoration(
                       labelText: 'Confirm Password',
-                      border: OutlineInputBorder(),
+                      border: const OutlineInputBorder(),
+                      suffixIcon: IconButton(
+                        icon: Icon(_obscurePassword
+                            ? Icons.visibility_off
+                            : Icons.visibility),
+                        onPressed: () => setState(
+                            () => _obscurePassword = !_obscurePassword),
+                      ),
                     ),
-                    obscureText: true,
+                    obscureText: _obscurePassword,
                     validator: (v) {
                       if (v != _passwordController.text) {
                         return 'Passwords do not match';

--- a/src/frontend/lib/auth/settings_page.dart
+++ b/src/frontend/lib/auth/settings_page.dart
@@ -25,6 +25,8 @@ class _SettingsPageState extends State<SettingsPage> {
   bool _changingPassword = false;
   String? _passwordMessage;
   bool _passwordSuccess = false;
+  bool _obscureCurrentPassword = true;
+  bool _obscureNewPassword = true;
 
   // Email change
   final _newEmailController = TextEditingController();
@@ -33,6 +35,7 @@ class _SettingsPageState extends State<SettingsPage> {
   bool _changingEmail = false;
   String? _emailMessage;
   bool _emailSuccess = false;
+  bool _obscureEmailPassword = true;
 
   // Handle change
   final _newHandleController = TextEditingController();
@@ -41,6 +44,7 @@ class _SettingsPageState extends State<SettingsPage> {
   bool _changingHandle = false;
   String? _handleMessage;
   bool _handleSuccess = false;
+  bool _obscureHandlePassword = true;
 
   String? _currentHandle;
 
@@ -331,8 +335,15 @@ class _SettingsPageState extends State<SettingsPage> {
               floatingLabelStyle: TextStyle(color: KColors.textSecondary),
               floatingLabelBehavior: FloatingLabelBehavior.always,
               border: const OutlineInputBorder(),
+              suffixIcon: IconButton(
+                icon: Icon(_obscureCurrentPassword
+                    ? Icons.visibility_off
+                    : Icons.visibility),
+                onPressed: () => setState(
+                    () => _obscureCurrentPassword = !_obscureCurrentPassword),
+              ),
             ),
-            obscureText: true,
+            obscureText: _obscureCurrentPassword,
             validator: (v) => v == null || v.isEmpty ? 'Required' : null,
           ),
           const SizedBox(height: 12),
@@ -344,8 +355,15 @@ class _SettingsPageState extends State<SettingsPage> {
               floatingLabelStyle: TextStyle(color: KColors.textSecondary),
               floatingLabelBehavior: FloatingLabelBehavior.always,
               border: const OutlineInputBorder(),
+              suffixIcon: IconButton(
+                icon: Icon(_obscureNewPassword
+                    ? Icons.visibility_off
+                    : Icons.visibility),
+                onPressed: () =>
+                    setState(() => _obscureNewPassword = !_obscureNewPassword),
+              ),
             ),
-            obscureText: true,
+            obscureText: _obscureNewPassword,
             validator: (v) {
               if (v == null || v.isEmpty) return 'Required';
               if (v.length < 4) return 'Min 4 characters';
@@ -361,8 +379,15 @@ class _SettingsPageState extends State<SettingsPage> {
               floatingLabelStyle: TextStyle(color: KColors.textSecondary),
               floatingLabelBehavior: FloatingLabelBehavior.always,
               border: const OutlineInputBorder(),
+              suffixIcon: IconButton(
+                icon: Icon(_obscureNewPassword
+                    ? Icons.visibility_off
+                    : Icons.visibility),
+                onPressed: () =>
+                    setState(() => _obscureNewPassword = !_obscureNewPassword),
+              ),
             ),
-            obscureText: true,
+            obscureText: _obscureNewPassword,
             validator: (v) {
               if (v != _newPasswordController.text) {
                 return 'Passwords do not match';
@@ -453,8 +478,15 @@ class _SettingsPageState extends State<SettingsPage> {
               floatingLabelStyle: TextStyle(color: KColors.textSecondary),
               floatingLabelBehavior: FloatingLabelBehavior.always,
               border: const OutlineInputBorder(),
+              suffixIcon: IconButton(
+                icon: Icon(_obscureHandlePassword
+                    ? Icons.visibility_off
+                    : Icons.visibility),
+                onPressed: () => setState(
+                    () => _obscureHandlePassword = !_obscureHandlePassword),
+              ),
             ),
-            obscureText: true,
+            obscureText: _obscureHandlePassword,
             validator: (v) => v == null || v.isEmpty ? 'Required' : null,
             onFieldSubmitted: (_) => _changeHandle(),
           ),
@@ -531,8 +563,15 @@ class _SettingsPageState extends State<SettingsPage> {
               floatingLabelStyle: TextStyle(color: KColors.textSecondary),
               floatingLabelBehavior: FloatingLabelBehavior.always,
               border: const OutlineInputBorder(),
+              suffixIcon: IconButton(
+                icon: Icon(_obscureEmailPassword
+                    ? Icons.visibility_off
+                    : Icons.visibility),
+                onPressed: () => setState(
+                    () => _obscureEmailPassword = !_obscureEmailPassword),
+              ),
             ),
-            obscureText: true,
+            obscureText: _obscureEmailPassword,
             validator: (v) => v == null || v.isEmpty ? 'Required' : null,
             onFieldSubmitted: (_) => _changeEmail(),
           ),

--- a/src/frontend/test/login_page_test.dart
+++ b/src/frontend/test/login_page_test.dart
@@ -518,6 +518,50 @@ void main() {
       expect(find.text('Invalid credentials'), findsOneWidget);
     });
 
+    testWidgets('password field is obscured by default', (tester) async {
+      await tester.pumpWidget(buildLoginPage());
+      await tester.pumpAndSettle();
+
+      final passwordField = tester.widget<EditableText>(
+        find.descendant(
+          of: find.byType(TextField).last,
+          matching: find.byType(EditableText),
+        ),
+      );
+      expect(passwordField.obscureText, isTrue);
+    });
+
+    testWidgets('eye button toggles password visibility', (tester) async {
+      await tester.pumpWidget(buildLoginPage());
+      await tester.pumpAndSettle();
+
+      // Initially obscured
+      expect(find.byIcon(Icons.visibility_off), findsOneWidget);
+      expect(find.byIcon(Icons.visibility), findsNothing);
+
+      // Tap the eye button
+      await tester.tap(find.byIcon(Icons.visibility_off));
+      await tester.pumpAndSettle();
+
+      // Now visible
+      expect(find.byIcon(Icons.visibility), findsOneWidget);
+      expect(find.byIcon(Icons.visibility_off), findsNothing);
+
+      final passwordField = tester.widget<EditableText>(
+        find.descendant(
+          of: find.byType(TextField).last,
+          matching: find.byType(EditableText),
+        ),
+      );
+      expect(passwordField.obscureText, isFalse);
+
+      // Tap again to re-obscure
+      await tester.tap(find.byIcon(Icons.visibility));
+      await tester.pumpAndSettle();
+
+      expect(find.byIcon(Icons.visibility_off), findsOneWidget);
+    });
+
     testWidgets('hides register toggle when registration disabled',
         (tester) async {
       testConfigHttpClientOverride = _configClient(registrationEnabled: false);


### PR DESCRIPTION
## Summary
- Added eye icon button (visibility toggle) to every password field across the app: login, settings (change password/handle/email), admin add/edit user dialogs, reset password, and accept invitation pages
- Password + confirm pairs share a single toggle; the settings change-password section uses a separate toggle for current vs new+confirm

## Test plan
- [x] Frontend tests pass with 100% coverage
- [ ] Verify eye icon toggles password visibility on login page
- [ ] Verify toggles work on settings page (change password, handle, email sections)
- [ ] Verify toggles work on admin add/edit user dialogs

Closes #836