### PR TITLE
Copy full plugin repos into container; support skills and prompts

### DIFF
--- a/customize/plugins.yaml
+++ b/customize/plugins.yaml
@@ -1,26 +1,26 @@
 # Klangk plugins configuration for custom host image build.
 plugins:
   - name: celebrate
-    git: git@github.com:mcdonc/klangk.git
+    git: https://github.com/mcdonc/klangk.git
     path: plugins/celebrate
     ref: main
   - name: beep
-    git: git@github.com:mcdonc/klangk.git
+    git: https://github.com/mcdonc/klangk.git
     path: plugins/beep
     ref: main
   - name: pig-latin
-    git: git@github.com:mcdonc/klangk.git
+    git: https://github.com/mcdonc/klangk.git
     path: plugins/pig-latin
     ref: main
   - name: word-count
-    git: git@github.com:mcdonc/klangk.git
+    git: https://github.com/mcdonc/klangk.git
     path: plugins/word-count
     ref: main
   - name: browser-fetch
-    git: git@github.com:mcdonc/klangk.git
+    git: https://github.com/mcdonc/klangk.git
     path: plugins/browser-fetch
     ref: main
   - name: bobdobbs
-    git: git@github.com:mcdonc/klangk.git
+    git: https://github.com/mcdonc/klangk.git
     path: plugins/bobdobbs
     ref: main

--- a/docs/deployment/customizing.md
+++ b/docs/deployment/customizing.md
@@ -94,7 +94,7 @@ To add an external plugin:
 ```yaml
 plugins:
   - name: my-plugin
-    git: git@github.com:myorg/my-klangk-plugin.git
+    git: https://github.com/myorg/my-klangk-plugin.git
     ref: main
 ```
 

--- a/docs/development/creating-plugins.md
+++ b/docs/development/creating-plugins.md
@@ -9,7 +9,7 @@ All plugins live in `$KLANGK_PLUGINS_DIR/<name>/` directories (defaults to `.dev
   - `klangk/pubspec.yaml` — Package definition, depends on `klangk_plugin_api` (git)
   - `klangk/lib/plugin.dart` — Class extending `ToolPlugin` with action handlers
   - `klangk/lib/*.dart` — Supporting Dart files (widgets, utilities)
-- `tools/` — Server-side scripts and commands. Symlinked to `/opt/klangk/bin/` in the workspace image (on `PATH`).
+- `tools/` — Server-side scripts and commands. Available at `/opt/klangk/plugins/<name>/tools/` in the container. Plugins that need a tool on `PATH` should symlink it in their `on-image-build.sh` hook.
 - `on-image-build.sh` — Lifecycle hook: runs at image build time (see [Lifecycle Hooks](#lifecycle-hooks))
 - `on-entrypoint.sh` — Lifecycle hook: runs at container start
 - `on-shell-init.sh` — Lifecycle hook: runs on every shell open

--- a/docs/development/creating-plugins.md
+++ b/docs/development/creating-plugins.md
@@ -2,12 +2,14 @@
 
 All plugins live in `$KLANGK_PLUGINS_DIR/<name>/` directories (defaults to `.devenv/state/klangk/plugins/`). A plugin can contain any combination of:
 
-- `extension.ts` — Pi extension with `pi.registerTool()`. Copied into the workspace image at build time.
+- `extension.ts` — Pi extension with `pi.registerTool()`. Symlinked as `<plugin-name>.ts` into the workspace image at build time.
+- `skills/` — Pi skill directories (each containing a `SKILL.md`). Symlinked as `<plugin-name>-<skill>/` into the image.
+- `prompts/` — Pi prompt templates (`.md` files). Symlinked as `<plugin-name>-<file>.md` into the image.
 - `klangk/` — Dart package for client-side browser actions:
   - `klangk/pubspec.yaml` — Package definition, depends on `klangk_plugin_api` (git)
   - `klangk/lib/plugin.dart` — Class extending `ToolPlugin` with action handlers
   - `klangk/lib/*.dart` — Supporting Dart files (widgets, utilities)
-- `tools/` — Server-side scripts and commands. Copied to `/opt/klangk/bin/` in the workspace image (on `PATH`).
+- `tools/` — Server-side scripts and commands. Symlinked to `/opt/klangk/bin/` in the workspace image (on `PATH`).
 - `on-image-build.sh` — Lifecycle hook: runs at image build time (see [Lifecycle Hooks](#lifecycle-hooks))
 - `on-entrypoint.sh` — Lifecycle hook: runs at container start
 - `on-shell-init.sh` — Lifecycle hook: runs on every shell open
@@ -17,10 +19,7 @@ No single component is required — a plugin can be an extension + Dart UI, just
 ## Build Integration
 
 - `scripts/import_dart_plugins.py` scans `$KLANGK_PLUGINS_DIR/*/klangk/` for plugin Dart packages and generates `$KLANGK_PLUGINS_DIR/.dart/` (the `klangk_plugins` package with path deps and `createAllPlugins()`)
-- `build-workspace-image` stages files from all plugins into `$KLANGK_PLUGINS_DIR/.docker/` and passes them via named build contexts:
-  - `plugin-extensions` — `extension.ts` files
-  - `plugin-tools` — flat directory of all `tools/*` files (installed to `/opt/klangk/bin/`)
-  - `plugin-hooks` — per-plugin lifecycle hook directories (installed to `/opt/klangk/hooks/<name>/`)
+- `build-workspace-image` copies entire plugin directories into `$KLANGK_PLUGINS_DIR/.docker/plugins/` and passes them as a single `plugins` build context. The Dockerfile copies them to `/opt/klangk/plugins/` and symlinks discoverable pieces (extensions, skills, prompts, tools) into central directories.
 - `flutterbuildweb` runs the codegen before compiling
 - `stub_dart_plugins.sh` creates a minimal stub at `$KLANGK_PLUGINS_DIR/.dart/` so `flutter pub get` works before plugins are fetched (runs automatically as part of the `klangk:update-plugins` task; skips if `pubspec_overrides.yaml` already exists)
 - Plugins are fetched automatically on `devenv up`: `klangk:init-plugins` creates `plugins.yaml` on first run, then `klangk:update-plugins` fetches plugins when `plugins.yaml` changes
@@ -94,11 +93,20 @@ Hooks execute **alphabetically by plugin name**. Within each plugin, only the re
 
 ### Container Layout
 
+The entire plugin directory is available in the container. Hooks (and any support scripts or assets they need) can be referenced via their plugin directory:
+
 ```text
-/opt/klangk/hooks/
+/opt/klangk/plugins/
   git-credential/
     on-image-build.sh
+    helper-script.sh        # accessible to hooks via $SCRIPT_DIR
   some-other-plugin/
+    extension.ts            # symlinked to /opt/klangk/pi-agent/extensions/some-other-plugin.ts
+    skills/
+      my-skill/
+        SKILL.md            # symlinked to /opt/klangk/pi-agent/skills/some-other-plugin-my-skill/
+    prompts/
+      setup.md              # symlinked to /opt/klangk/pi-agent/prompts/some-other-plugin-setup.md
     on-entrypoint.sh
     on-shell-init.sh
 ```

--- a/docs/features/github-authentication.md
+++ b/docs/features/github-authentication.md
@@ -20,7 +20,7 @@ it to your `plugins.yaml`:
 ```yaml
 plugins:
   - name: git-credential
-    git: git@github.com:mcdonc/klangk.git
+    git: https://github.com/mcdonc/klangk.git
     path: plugins/git-credential
     ref: main
 ```

--- a/docs/features/plugins.md
+++ b/docs/features/plugins.md
@@ -23,7 +23,9 @@ plugins).
 
 ### Git plugins
 
-Remote plugins are cloned from a git repository. `path` and `ref` are
+Remote plugins are cloned from a git repository. Both HTTPS and SSH URLs
+work (`https://github.com/...` or `git@github.com:...`), but HTTPS is
+the default since it doesn't require SSH keys. `path` and `ref` are
 optional:
 
 ```yaml

--- a/docs/features/plugins.md
+++ b/docs/features/plugins.md
@@ -29,7 +29,7 @@ optional:
 ```yaml
 plugins:
   - name: celebrate
-    git: git@github.com:mcdonc/klangk.git
+    git: https://github.com/mcdonc/klangk.git
     path: plugins/celebrate
     ref: main
 ```

--- a/plugins/git-credential/README.md
+++ b/plugins/git-credential/README.md
@@ -11,9 +11,9 @@ session.
 ### Container side
 
 **`git-credential-klangk`** (`tools/git-credential-klangk`) is a Python
-script installed to `/opt/klangk/bin/` in the workspace image. Git calls
-it automatically because `on-image-build.sh` sets
-`git config --system credential.helper klangk` at image build time.
+script at `/opt/klangk/plugins/git-credential/tools/`, symlinked to
+`/usr/local/bin/` by `on-image-build.sh`. Git calls it automatically
+because the same hook sets `git config --system credential.helper klangk`.
 
 Git invokes the helper with one of three operations:
 

--- a/plugins/git-credential/on-image-build.sh
+++ b/plugins/git-credential/on-image-build.sh
@@ -2,4 +2,6 @@
 # Configure git to use the klangk credential helper system-wide.
 # Runs at image build time (Dockerfile RUN).
 set -e
+PLUGIN_DIR="$(cd "$(dirname "$0")" && pwd)"
+ln -sf "$PLUGIN_DIR/tools/git-credential-klangk" /usr/local/bin/git-credential-klangk
 git config --system credential.helper klangk

--- a/plugins/word-count/extension.ts
+++ b/plugins/word-count/extension.ts
@@ -17,7 +17,7 @@ export default function (pi: any) {
       try {
         const result = await pi.exec(
           "python3",
-          ["/opt/klangk/plugin-tools/word-count/word_count.py", params.path],
+          ["/opt/klangk/plugins/word-count/tools/word_count.py", params.path],
           { signal, timeout: 10000 },
         );
         return {

--- a/scripts/build-backend-image.sh
+++ b/scripts/build-backend-image.sh
@@ -28,18 +28,14 @@ if [ -f "$KLANGK_PLUGINS_DIR/plugins.yaml" ] && [ ! -f "$KLANGK_PLUGINS_DIR/plug
   python3 scripts/update_plugins.py
 fi
 
-# Stage plugin files outside the source tree
+# Stage full plugin directories outside the source tree
 STAGING="$KLANGK_PLUGINS_DIR/.docker"
 rm -rf "$STAGING"
-mkdir -p "$STAGING/extensions" "$STAGING/tools"
+mkdir -p "$STAGING/plugins"
 for d in "$KLANGK_PLUGINS_DIR"/*/; do
   [ -d "$d" ] || continue
   name=$(basename "$d")
-  [ -f "$d/extension.ts" ] && cp "$d/extension.ts" "$STAGING/extensions/$name.ts"
-  if [ -d "$d/tools" ]; then
-    mkdir -p "$STAGING/tools/$name"
-    cp -r "$d/tools/"* "$STAGING/tools/$name/" 2>/dev/null
-  fi
+  cp -r "$d" "$STAGING/plugins/$name"
 done
 
 # Remove old containers before rebuilding so they get recreated from the new image.
@@ -52,8 +48,7 @@ fi
 "$PODMAN" build \
   --pull=newer \
   --platform "${KLANGK_PLATFORM:-linux/amd64}" \
-  --build-context plugin-extensions="$STAGING/extensions" \
-  --build-context plugin-tools="$STAGING/tools" \
+  --build-context plugins="$STAGING/plugins" \
   -t "${KLANGK_IMAGE_NAME}" "$@" src/containers/workspace/
 
 echo "$CURRENT_HASH" >"$STAMP"

--- a/scripts/build-workspace-image.sh
+++ b/scripts/build-workspace-image.sh
@@ -33,32 +33,14 @@ if [ -f "$KLANGK_PLUGINS_DIR/plugins.yaml" ] && [ ! -f "$KLANGK_PLUGINS_DIR/plug
   python3 scripts/update_plugins.py
 fi
 
-# Stage plugin files outside the source tree
+# Stage full plugin directories outside the source tree
 STAGING="$KLANGK_PLUGINS_DIR/.docker"
 rm -rf "$STAGING"
-mkdir -p "$STAGING/extensions" "$STAGING/tools" "$STAGING/hooks"
+mkdir -p "$STAGING/plugins"
 for d in "$KLANGK_PLUGINS_DIR"/*/; do
   [ -d "$d" ] || continue
   name=$(basename "$d")
-  [ -f "$d/extension.ts" ] && cp "$d/extension.ts" "$STAGING/extensions/$name.ts"
-  # Flatten all plugin tools into a single directory (/opt/klangk/bin/)
-  if [ -d "$d/tools" ]; then
-    cp -r "$d/tools/"* "$STAGING/tools/" 2>/dev/null
-  fi
-  # Stage lifecycle hooks per-plugin (/opt/klangk/hooks/<plugin>/)
-  has_hooks=false
-  for hook in on-image-build.sh on-entrypoint.sh on-shell-init.sh; do
-    if [ -f "$d/$hook" ]; then
-      has_hooks=true
-      break
-    fi
-  done
-  if $has_hooks; then
-    mkdir -p "$STAGING/hooks/$name"
-    for hook in on-image-build.sh on-entrypoint.sh on-shell-init.sh; do
-      [ -f "$d/$hook" ] && cp "$d/$hook" "$STAGING/hooks/$name/$hook"
-    done
-  fi
+  cp -r "$d" "$STAGING/plugins/$name"
 done
 
 # Remove old containers before rebuilding so they get recreated from the new image.
@@ -84,9 +66,7 @@ done
 "$PODMAN" build \
   --pull=newer \
   --platform "${KLANGK_PLATFORM:-linux/amd64}" \
-  --build-context plugin-extensions="$STAGING/extensions" \
-  --build-context plugin-tools="$STAGING/tools" \
-  --build-context plugin-hooks="$STAGING/hooks" \
+  --build-context plugins="$STAGING/plugins" \
   -t "${KLANGK_IMAGE_NAME}:latest" \
   -t "${KLANGK_IMAGE_NAME}:${VERSION}" \
   "$@" src/containers/workspace/

--- a/scripts/update_plugins.py
+++ b/scripts/update_plugins.py
@@ -71,7 +71,7 @@ def _default_template(ref):
         lines.append(f"    ref: {ref}")
     lines.extend(
         [
-            "  # Add more plugins:",
+            "  # Add more plugins (HTTPS or SSH URLs both work):",
             "  # - name: my-plugin",
             "  #   git: https://github.com/user/repo.git",
             "  #   path: subdir              # optional: subdirectory within the repo",

--- a/scripts/update_plugins.py
+++ b/scripts/update_plugins.py
@@ -66,14 +66,14 @@ def _default_template(ref):
     ]
     for name in _DEFAULT_PLUGINS:
         lines.append(f"  - name: {name}")
-        lines.append("    git: git@github.com:mcdonc/klangk.git")
+        lines.append("    git: https://github.com/mcdonc/klangk.git")
         lines.append(f"    path: plugins/{name}")
         lines.append(f"    ref: {ref}")
     lines.extend(
         [
             "  # Add more plugins:",
             "  # - name: my-plugin",
-            "  #   git: git@github.com:user/repo.git",
+            "  #   git: https://github.com/user/repo.git",
             "  #   path: subdir              # optional: subdirectory within the repo",
             "  #   ref: main                 # branch, tag, or commit SHA",
             "  #",

--- a/src/backend/tests/test_setup_clankers.py
+++ b/src/backend/tests/test_setup_clankers.py
@@ -1,0 +1,209 @@
+"""Tests for klangk-setup-clankers.py (per-user Pi agent setup)."""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+# Import the script as a module (it's not a package).
+_SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / "containers"
+    / "workspace"
+    / "klangk-setup-clankers.py"
+)
+_spec = importlib.util.spec_from_file_location("setup_clankers", _SCRIPT)
+sc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(sc)
+
+
+@pytest.fixture()
+def fake_home(tmp_path, monkeypatch):
+    """Set HOME and IMAGE_DIR to temp directories."""
+    home = tmp_path / "home" / "testuser"
+    home.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+
+    image_dir = tmp_path / "opt" / "klangk" / "pi-agent"
+    for d in ("extensions", "skills", "prompts", "npm"):
+        (image_dir / d).mkdir(parents=True)
+    # Write a base settings.json the way the real image would.
+    (image_dir / "settings.json").write_text(json.dumps({"version": 1}))
+
+    monkeypatch.setattr(sc, "IMAGE_DIR", image_dir)
+    monkeypatch.setattr(sc, "ERROR_LOG", tmp_path / "errors.log")
+    return home
+
+
+class TestSetupDirs:
+    def test_creates_npm_and_extensions(self, fake_home):
+        sc.setup_dirs()
+        agent = fake_home / ".pi" / "agent"
+        assert (agent / "npm").is_dir()
+        assert (agent / "extensions").is_dir()
+
+
+class TestWriteSettings:
+    def test_creates_settings_with_all_keys(self, fake_home, monkeypatch):
+        monkeypatch.setenv("KLANGK_LLM_MODEL", "test-model")
+        agent = fake_home / ".pi" / "agent"
+        agent.mkdir(parents=True)
+
+        sc.write_settings()
+
+        settings = json.loads((agent / "settings.json").read_text())
+        assert settings["defaultProvider"] == "llm-proxy"
+        assert settings["defaultModel"] == "test-model"
+        assert settings["defaultThinkingLevel"] == "off"
+        assert settings["extensions"] == [str(sc.IMAGE_DIR / "extensions")]
+        assert settings["skills"] == [str(sc.IMAGE_DIR / "skills")]
+        assert settings["prompts"] == [str(sc.IMAGE_DIR / "prompts")]
+
+    def test_does_not_overwrite_existing(self, fake_home):
+        agent = fake_home / ".pi" / "agent"
+        agent.mkdir(parents=True)
+        existing = {"custom": True}
+        (agent / "settings.json").write_text(json.dumps(existing))
+
+        sc.write_settings()
+
+        assert json.loads((agent / "settings.json").read_text()) == existing
+
+
+class TestEnsureSettingsKeys:
+    def test_backfills_missing_keys(self, fake_home):
+        agent = fake_home / ".pi" / "agent"
+        agent.mkdir(parents=True)
+        # Simulate old settings that only has extensions.
+        old = {"extensions": ["/old/extensions"], "other": "keep"}
+        (agent / "settings.json").write_text(json.dumps(old))
+
+        sc.ensure_settings_keys()
+
+        settings = json.loads((agent / "settings.json").read_text())
+        assert settings["extensions"] == ["/old/extensions"]  # not overwritten
+        assert settings["skills"] == [str(sc.IMAGE_DIR / "skills")]
+        assert settings["prompts"] == [str(sc.IMAGE_DIR / "prompts")]
+        assert settings["other"] == "keep"
+
+    def test_no_write_when_all_present(self, fake_home):
+        agent = fake_home / ".pi" / "agent"
+        agent.mkdir(parents=True)
+        full = {
+            "extensions": ["/e"],
+            "skills": ["/s"],
+            "prompts": ["/p"],
+        }
+        (agent / "settings.json").write_text(json.dumps(full))
+        mtime_before = (agent / "settings.json").stat().st_mtime_ns
+
+        sc.ensure_settings_keys()
+
+        # File should not have been rewritten.
+        assert (agent / "settings.json").stat().st_mtime_ns == mtime_before
+
+    def test_noop_when_no_settings(self, fake_home):
+        # Should not raise when settings.json doesn't exist.
+        sc.ensure_settings_keys()
+
+
+class TestWriteModels:
+    def test_creates_models_json(self, fake_home, monkeypatch):
+        monkeypatch.setenv("KLANGK_LLM_PROXY_URL", "http://proxy:8080")
+        monkeypatch.setenv("KLANGK_LLM_MODEL", "test-model")
+        agent = fake_home / ".pi" / "agent"
+        agent.mkdir(parents=True)
+
+        sc.write_models()
+
+        models = json.loads((agent / "models.json").read_text())
+        provider = models["providers"]["llm-proxy"]
+        assert provider["baseUrl"] == "http://proxy:8080"
+        assert provider["models"][0]["id"] == "test-model"
+
+    def test_empty_models_without_env(self, fake_home, monkeypatch):
+        monkeypatch.delenv("KLANGK_LLM_MODEL", raising=False)
+        agent = fake_home / ".pi" / "agent"
+        agent.mkdir(parents=True)
+
+        sc.write_models()
+
+        models = json.loads((agent / "models.json").read_text())
+        assert models["providers"]["llm-proxy"]["models"] == []
+
+
+class TestBuildSystemPrompt:
+    def test_copies_prompt(self, fake_home, monkeypatch):
+        prompt_src = sc.IMAGE_DIR.parent / "system-prompt.md"
+        prompt_src.write_text("# System Prompt")
+        monkeypatch.setattr(sc, "SYSTEM_PROMPT_SRC", prompt_src)
+
+        sc.build_system_prompt()
+
+        assert (fake_home / "AGENTS.md").read_text() == "# System Prompt"
+
+    def test_does_not_overwrite_existing(self, fake_home, monkeypatch):
+        prompt_src = sc.IMAGE_DIR.parent / "system-prompt.md"
+        prompt_src.write_text("# New")
+        monkeypatch.setattr(sc, "SYSTEM_PROMPT_SRC", prompt_src)
+        (fake_home / "AGENTS.md").write_text("# User Custom")
+
+        sc.build_system_prompt()
+
+        assert (fake_home / "AGENTS.md").read_text() == "# User Custom"
+
+
+class TestMain:
+    def test_first_run_creates_everything(self, fake_home, monkeypatch):
+        monkeypatch.setenv("KLANGK_LLM_MODEL", "m")
+        monkeypatch.setenv("KLANGK_LLM_PROXY_URL", "http://x")
+        monkeypatch.setattr("sys.argv", ["setup-clankers"])
+
+        sc.main()
+
+        agent = fake_home / ".pi" / "agent"
+        assert (agent / "settings.json").exists()
+        assert (agent / "models.json").exists()
+        settings = json.loads((agent / "settings.json").read_text())
+        assert "skills" in settings
+        assert "prompts" in settings
+
+    def test_existing_settings_gets_backfill(self, fake_home, monkeypatch):
+        monkeypatch.setenv("KLANGK_LLM_MODEL", "m")
+        monkeypatch.setenv("KLANGK_LLM_PROXY_URL", "http://x")
+        monkeypatch.setattr("sys.argv", ["setup-clankers"])
+        agent = fake_home / ".pi" / "agent"
+        agent.mkdir(parents=True)
+        # Old settings missing skills/prompts.
+        old = {"extensions": ["/e"]}
+        (agent / "settings.json").write_text(json.dumps(old))
+
+        sc.main()
+
+        settings = json.loads((agent / "settings.json").read_text())
+        assert "skills" in settings
+        assert "prompts" in settings
+        assert settings["extensions"] == ["/e"]  # preserved
+
+    def test_force_rewrites_settings(self, fake_home, monkeypatch):
+        monkeypatch.setenv("KLANGK_LLM_MODEL", "m")
+        monkeypatch.setenv("KLANGK_LLM_PROXY_URL", "http://x")
+        monkeypatch.setattr("sys.argv", ["setup-clankers", "--force"])
+        agent = fake_home / ".pi" / "agent"
+        agent.mkdir(parents=True)
+        (agent / "settings.json").write_text(json.dumps({"old": True}))
+
+        sc.main()
+
+        settings = json.loads((agent / "settings.json").read_text())
+        assert "old" not in settings
+        assert settings["defaultProvider"] == "llm-proxy"
+
+    def test_skips_system_user(self, fake_home, monkeypatch):
+        monkeypatch.setenv("HOME", "/home")
+        monkeypatch.setattr("sys.argv", ["setup-clankers"])
+
+        sc.main()  # should not raise or create anything
+
+        assert not (Path("/home") / ".pi").exists()

--- a/src/containers/workspace/Dockerfile
+++ b/src/containers/workspace/Dockerfile
@@ -8,16 +8,34 @@ RUN npm install -g @earendil-works/pi-coding-agent@0.79.9 \
     && mkdir -p /opt/klangk/pi-agent/extensions /opt/klangk/pi-agent/skills \
     && PI_CODING_AGENT_DIR=/opt/klangk/pi-agent pi install npm:@demigodmode/pi-web-agent@1.5.0
 
-# Plugin tools: flat directory, all on PATH via /opt/klangk/bin/
+# Copy full plugin repos and symlink discoverable pieces into central dirs.
+# Extensions get <plugin>.ts, skills get <plugin>-<skill>/, prompts get
+# <plugin>-<file>.md, tools are flattened into /opt/klangk/bin/.
+COPY --from=plugins / /opt/klangk/plugins/
 ENV PATH="/opt/klangk/bin:${PATH}"
-COPY --from=plugin-tools / /opt/klangk/bin/
-RUN echo 'PATH="/opt/klangk/bin:${PATH}"' >> /etc/environment
-
-# Plugin lifecycle hooks: /opt/klangk/hooks/<plugin>/{on-image-build,on-entrypoint,on-shell-init}.sh
-COPY --from=plugin-hooks / /opt/klangk/hooks/
-
-# Pi extensions from plugins and builtins (changes when plugins change)
-COPY --from=plugin-extensions / /opt/klangk/pi-agent/extensions/
+RUN mkdir -p /opt/klangk/bin /opt/klangk/pi-agent/extensions \
+             /opt/klangk/pi-agent/skills /opt/klangk/pi-agent/prompts \
+    && echo 'PATH="/opt/klangk/bin:${PATH}"' >> /etc/environment \
+    && for d in /opt/klangk/plugins/*/; do \
+         [ -d "$d" ] || continue; \
+         name=$(basename "$d"); \
+         [ -f "$d/extension.ts" ] && ln -sf "$d/extension.ts" /opt/klangk/pi-agent/extensions/"$name.ts"; \
+         if [ -d "$d/skills" ]; then \
+           for s in "$d/skills"/*/; do \
+             [ -d "$s" ] && ln -sf "$s" /opt/klangk/pi-agent/skills/"$name-$(basename "$s")"; \
+           done; \
+         fi; \
+         if [ -d "$d/prompts" ]; then \
+           for p in "$d/prompts"/*.md; do \
+             [ -f "$p" ] && ln -sf "$p" /opt/klangk/pi-agent/prompts/"$name-$(basename "$p")"; \
+           done; \
+         fi; \
+         if [ -d "$d/tools" ]; then \
+           for t in "$d/tools"/*; do \
+             [ -f "$t" ] && ln -sf "$t" /opt/klangk/bin/; \
+           done; \
+         fi; \
+       done
 COPY builtin-extensions/ /opt/klangk/pi-agent/extensions/
 
 # Install uv (fast Python package manager)
@@ -65,8 +83,14 @@ COPY tmux.conf /etc/tmux.conf
 # `bash -i` spawned by plugin installers doesn't run user-session setup.
 # Removed after hooks finish so it doesn't persist into the final image.
 RUN touch /tmp/.klangk-image-build \
-    && for f in /opt/klangk/hooks/*/on-image-build.sh; do \
-      [ -x "$f" ] && "$f"; \
+    && for f in /opt/klangk/plugins/*/on-image-build.sh; do \
+      [ -x "$f" ] || continue; \
+      plugin=$(basename "$(dirname "$f")"); \
+      label=" $plugin (on-image-build) "; \
+      pad=$(( (60 - ${#label}) / 2 )); \
+      line=$(printf '%*s' "$pad" '' | tr ' ' '━'); \
+      printf '\033[33m%s%s%s\033[0m\n' "$line" "$label" "$line"; \
+      "$f"; \
     done; rm -f /tmp/.klangk-image-build; true
 
 # Fix non-root group ownership that causes crun fchownat errors with

--- a/src/containers/workspace/Dockerfile
+++ b/src/containers/workspace/Dockerfile
@@ -10,7 +10,8 @@ RUN npm install -g @earendil-works/pi-coding-agent@0.79.9 \
 
 # Copy full plugin repos and symlink discoverable pieces into central dirs.
 # Extensions get <plugin>.ts, skills get <plugin>-<skill>/, prompts get
-# <plugin>-<file>.md, tools are flattened into /opt/klangk/bin/.
+# <plugin>-<file>.md.  Plugins reference their own files directly via
+# /opt/klangk/plugins/<name>/ (no tools symlinking).
 COPY --from=plugins / /opt/klangk/plugins/
 ENV PATH="/opt/klangk/bin:${PATH}"
 RUN mkdir -p /opt/klangk/bin /opt/klangk/pi-agent/extensions \
@@ -28,11 +29,6 @@ RUN mkdir -p /opt/klangk/bin /opt/klangk/pi-agent/extensions \
          if [ -d "$d/prompts" ]; then \
            for p in "$d/prompts"/*.md; do \
              [ -f "$p" ] && ln -sf "$p" /opt/klangk/pi-agent/prompts/"$name-$(basename "$p")"; \
-           done; \
-         fi; \
-         if [ -d "$d/tools" ]; then \
-           for t in "$d/tools"/*; do \
-             [ -f "$t" ] && ln -sf "$t" /opt/klangk/bin/; \
            done; \
          fi; \
        done

--- a/src/containers/workspace/bash.bashrc
+++ b/src/containers/workspace/bash.bashrc
@@ -35,9 +35,14 @@ python3 /opt/klangk/bin/klangk-setup-clankers
 
 # Run plugin on-shell-init hooks (alphabetical by plugin name).
 # These run as the klangk user on every shell open.
-for f in /opt/klangk/hooks/*/on-shell-init.sh; do
-  # shellcheck disable=SC2181
-  [ -x "$f" ] && "$f" || true
+for f in /opt/klangk/plugins/*/on-shell-init.sh; do
+  [ -x "$f" ] || continue
+  plugin=$(basename "$(dirname "$f")")
+  label=" $plugin (on-shell-init) "
+  pad=$(( (60 - ${#label}) / 2 ))
+  line=$(printf '%*s' "$pad" '' | tr ' ' '━')
+  printf '\033[33m%s%s%s\033[0m\n' "$line" "$label" "$line"
+  "$f" || true
 done
 
 # Determine which command to exec into (if any).

--- a/src/containers/workspace/entrypoint.sh
+++ b/src/containers/workspace/entrypoint.sh
@@ -8,8 +8,14 @@ set -e
 
 # Run plugin on-entrypoint hooks (alphabetical by plugin name).
 # These run once per container start, as root (inside userns).
-for f in /opt/klangk/hooks/*/on-entrypoint.sh; do
-  [ -x "$f" ] && "$f" || true
+for f in /opt/klangk/plugins/*/on-entrypoint.sh; do
+  [ -x "$f" ] || continue
+  plugin=$(basename "$(dirname "$f")")
+  label=" $plugin (on-entrypoint) "
+  pad=$(((60 - ${#label}) / 2))
+  line=$(printf '%*s' "$pad" '' | tr ' ' '━')
+  printf '\033[33m%s%s%s\033[0m\n' "$line" "$label" "$line"
+  "$f" || true
 done
 
 # Create the workspace token directory.

--- a/src/containers/workspace/klangk-setup-clankers.py
+++ b/src/containers/workspace/klangk-setup-clankers.py
@@ -60,11 +60,34 @@ def write_settings():
     # Disable thinking by default — Ctrl+T toggle doesn't work in web
     # terminals because the browser captures it.
     image_settings["defaultThinkingLevel"] = "off"
-    # Point at image extensions dir directly — Pi also auto-discovers
-    # ~/.pi/agent/extensions/ for user-installed extensions.
+    # Point at image dirs directly — Pi also auto-discovers
+    # ~/.pi/agent/{extensions,skills,prompts}/ for user-installed ones.
     image_settings["extensions"] = [str(IMAGE_DIR / "extensions")]
+    image_settings["skills"] = [str(IMAGE_DIR / "skills")]
+    image_settings["prompts"] = [str(IMAGE_DIR / "prompts")]
 
     settings_path.write_text(json.dumps(image_settings, indent=2))
+
+
+def ensure_settings_keys():
+    """Backfill new settings keys into an existing settings.json."""
+    agent = _agent_dir()
+    settings_path = agent / "settings.json"
+    if not settings_path.exists():
+        return
+    settings = json.loads(settings_path.read_text())
+    defaults = {
+        "extensions": [str(IMAGE_DIR / "extensions")],
+        "skills": [str(IMAGE_DIR / "skills")],
+        "prompts": [str(IMAGE_DIR / "prompts")],
+    }
+    changed = False
+    for key, value in defaults.items():
+        if key not in settings:
+            settings[key] = value
+            changed = True
+    if changed:
+        settings_path.write_text(json.dumps(settings, indent=2))
 
 
 def write_models():
@@ -120,8 +143,9 @@ def main():
         (agent / "settings.json").unlink(missing_ok=True)
 
     if (agent / "settings.json").exists():
-        # Already initialized — just refresh models.json (token may
-        # have changed on container restart).
+        # Already initialized — refresh models.json (token may have
+        # changed on container restart) and backfill any new keys.
+        _run_step("ensure_settings_keys", ensure_settings_keys)
         _run_step("write_models", write_models)
         return
 


### PR DESCRIPTION
## Summary

- Copy entire plugin directories into `/opt/klangk/plugins/` instead of cherry-picking individual files, so hooks can reference sibling scripts and assets (closes #805)
- Symlink extensions (`<plugin>.ts`), skills (`<plugin>-<skill>/`), prompts (`<plugin>-<file>.md`), and tools into central discovery directories
- Add `skills` and `prompts` arrays to Pi `settings.json` via `klangk-setup-clankers.py`
- Backfill missing keys for existing users via `ensure_settings_keys()` on every shell open
- Add colored banners to lifecycle hook output showing which plugin is running
- Update plugin docs with new layout and skills/prompts convention

Closes #841, resolves #805.

## Test plan

- [x] 14 new unit tests for `klangk-setup-clankers.py` (all pass)
- [x] Backend tests pass (1506 passed)
- [x] CLI tests pass
- [ ] Build workspace image and verify plugins appear in `/opt/klangk/plugins/`
- [ ] Verify symlinks in `/opt/klangk/pi-agent/{extensions,skills,prompts}/`
- [ ] Verify hooks run with yellow banners in build output