### PR TITLE
Make mounts and env vars selectable/copyable in workspace settings

### DIFF
--- a/src/frontend/lib/workspace/workspace_list_page.dart
+++ b/src/frontend/lib/workspace/workspace_list_page.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:http/http.dart' as http;
 import '../theme/colors.dart';
 import 'package:go_router/go_router.dart';
@@ -80,8 +81,9 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
           workspaces.map((ws) async {
             final id = ws['id'] as String;
             try {
-              final resp =
-                  await _auth.authGet('/api/v1/workspaces/$id/members');
+              final resp = await _auth.authGet(
+                '/api/v1/workspaces/$id/members',
+              );
               if (resp.statusCode == 200) {
                 members[id] = List<Map<String, dynamic>>.from(
                   jsonDecode(resp.body) as List,
@@ -306,27 +308,37 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
                     Text('Mounts', style: labelStyle),
                     const SizedBox(height: 8),
                     ...mounts.asMap().entries.map(
-                          (e) => Padding(
-                            padding: const EdgeInsets.only(bottom: 4),
-                            child: Row(
-                              children: [
-                                Expanded(
-                                  child: Text(
-                                    e.value,
-                                    style: const TextStyle(fontSize: 13),
-                                  ),
-                                ),
-                                IconButton(
-                                  icon: const Icon(Icons.close, size: 18),
-                                  onPressed: () => setDialogState(
-                                      () => mounts.removeAt(e.key)),
-                                  padding: EdgeInsets.zero,
-                                  constraints: const BoxConstraints(),
-                                ),
-                              ],
+                      (e) => Padding(
+                        padding: const EdgeInsets.only(bottom: 4),
+                        child: Row(
+                          children: [
+                            Expanded(
+                              child: SelectableText(
+                                e.value,
+                                style: const TextStyle(fontSize: 13),
+                              ),
                             ),
-                          ),
+                            IconButton(
+                              icon: const Icon(Icons.copy, size: 16),
+                              tooltip: 'Copy',
+                              onPressed: () => Clipboard.setData(
+                                ClipboardData(text: e.value),
+                              ),
+                              padding: EdgeInsets.zero,
+                              constraints: const BoxConstraints(),
+                            ),
+                            const SizedBox(width: 4),
+                            IconButton(
+                              icon: const Icon(Icons.close, size: 18),
+                              onPressed: () =>
+                                  setDialogState(() => mounts.removeAt(e.key)),
+                              padding: EdgeInsets.zero,
+                              constraints: const BoxConstraints(),
+                            ),
+                          ],
                         ),
+                      ),
+                    ),
                     if (mountError != null) ...[
                       Text(
                         mountError!,
@@ -362,28 +374,40 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
                     Text('Environment Variables', style: labelStyle),
                     const SizedBox(height: 8),
                     ...envVars.entries.toList().asMap().entries.map(
-                          (e) => Padding(
-                            padding: const EdgeInsets.only(bottom: 4),
-                            child: Row(
-                              children: [
-                                Expanded(
-                                  child: Text(
-                                    '${e.value.key}=${e.value.value}',
-                                    style: const TextStyle(fontSize: 13),
-                                  ),
-                                ),
-                                IconButton(
-                                  icon: const Icon(Icons.close, size: 18),
-                                  onPressed: () => setDialogState(
-                                    () => envVars.remove(e.value.key),
-                                  ),
-                                  padding: EdgeInsets.zero,
-                                  constraints: const BoxConstraints(),
-                                ),
-                              ],
+                      (e) => Padding(
+                        padding: const EdgeInsets.only(bottom: 4),
+                        child: Row(
+                          children: [
+                            Expanded(
+                              child: SelectableText(
+                                '${e.value.key}=${e.value.value}',
+                                style: const TextStyle(fontSize: 13),
+                              ),
                             ),
-                          ),
+                            IconButton(
+                              icon: const Icon(Icons.copy, size: 16),
+                              tooltip: 'Copy',
+                              onPressed: () => Clipboard.setData(
+                                ClipboardData(
+                                  text: '${e.value.key}=${e.value.value}',
+                                ),
+                              ),
+                              padding: EdgeInsets.zero,
+                              constraints: const BoxConstraints(),
+                            ),
+                            const SizedBox(width: 4),
+                            IconButton(
+                              icon: const Icon(Icons.close, size: 18),
+                              onPressed: () => setDialogState(
+                                () => envVars.remove(e.value.key),
+                              ),
+                              padding: EdgeInsets.zero,
+                              constraints: const BoxConstraints(),
+                            ),
+                          ],
                         ),
+                      ),
+                    ),
                     if (envError != null) ...[
                       Text(
                         envError!,
@@ -475,8 +499,9 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
                   onPressed: importing
                       ? null
                       : () async {
-                          final bytes =
-                              await pickFileBytes(accept: '.tar.gz,.tgz');
+                          final bytes = await pickFileBytes(
+                            accept: '.tar.gz,.tgz',
+                          );
                           if (bytes != null) {
                             setDialogState(() {
                               selectedBytes = bytes;
@@ -529,15 +554,19 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
                         url += '?name=${Uri.encodeComponent(name)}';
                       }
                       try {
-                        final request =
-                            http.MultipartRequest('POST', Uri.parse(url));
+                        final request = http.MultipartRequest(
+                          'POST',
+                          Uri.parse(url),
+                        );
                         request.headers['Authorization'] =
                             'Bearer ${_auth.token}';
-                        request.files.add(http.MultipartFile.fromBytes(
-                          'file',
-                          selectedBytes!,
-                          filename: 'workspace.tar.gz',
-                        ));
+                        request.files.add(
+                          http.MultipartFile.fromBytes(
+                            'file',
+                            selectedBytes!,
+                            filename: 'workspace.tar.gz',
+                          ),
+                        );
                         final streamed = await request.send();
                         final resp = await http.Response.fromStream(streamed);
                         if (resp.statusCode == 200 || resp.statusCode == 201) {
@@ -547,7 +576,8 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
                         } else {
                           String detail;
                           try {
-                            detail = (jsonDecode(resp.body) as Map)['detail']
+                            detail =
+                                (jsonDecode(resp.body) as Map)['detail']
                                     as String? ??
                                 '${resp.statusCode}';
                           } catch (_) {
@@ -570,7 +600,10 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
                       width: 16,
                       height: 16,
                       child: CircularProgressIndicator(
-                          strokeWidth: 2, color: Colors.white))
+                        strokeWidth: 2,
+                        color: Colors.white,
+                      ),
+                    )
                   : const Text('Import'),
             ),
           ],
@@ -802,27 +835,26 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
                   ),
                 ),
                 ..._sharedWorkspaces.asMap().entries.map(
-                      (e) => Material(
-                        color: e.key.isEven
-                            ? Colors.white.withValues(alpha: 0.03)
-                            : Colors.transparent,
-                        child: ListTile(
-                          leading: const Icon(
-                            Icons.terminal,
-                            size: 20,
-                            color: KColors.accentBlue,
-                          ),
-                          title: Text(e.value['name'] as String),
-                          subtitle: Text(
-                            '${e.value['owner_email']} · ${_formatCreatedAt(e.value['created_at'] as String?)}',
-                          ),
-                          // coverage:ignore-start
-                          onTap: () =>
-                              context.go('/workspace/${e.value['id']}'),
-                          // coverage:ignore-end
-                        ),
+                  (e) => Material(
+                    color: e.key.isEven
+                        ? Colors.white.withValues(alpha: 0.03)
+                        : Colors.transparent,
+                    child: ListTile(
+                      leading: const Icon(
+                        Icons.terminal,
+                        size: 20,
+                        color: KColors.accentBlue,
                       ),
+                      title: Text(e.value['name'] as String),
+                      subtitle: Text(
+                        '${e.value['owner_email']} · ${_formatCreatedAt(e.value['created_at'] as String?)}',
+                      ),
+                      // coverage:ignore-start
+                      onTap: () => context.go('/workspace/${e.value['id']}'),
+                      // coverage:ignore-end
                     ),
+                  ),
+                ),
               ],
             ),
           ),
@@ -839,25 +871,25 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
       ),
       floatingActionButton:
           context.watch<AuthService>().hasPermission('/workspaces', 'create')
-              ? Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    FloatingActionButton.small(
-                      heroTag: 'import',
-                      onPressed: _showImportDialog, // coverage:ignore-line
-                      tooltip: 'Import Workspace',
-                      child: const Icon(Icons.upload),
-                    ),
-                    const SizedBox(height: 12),
-                    FloatingActionButton(
-                      heroTag: 'create',
-                      onPressed: _createWorkspace,
-                      tooltip: 'New Workspace',
-                      child: const Icon(Icons.add),
-                    ),
-                  ],
-                )
-              : null,
+          ? Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                FloatingActionButton.small(
+                  heroTag: 'import',
+                  onPressed: _showImportDialog, // coverage:ignore-line
+                  tooltip: 'Import Workspace',
+                  child: const Icon(Icons.upload),
+                ),
+                const SizedBox(height: 12),
+                FloatingActionButton(
+                  heroTag: 'create',
+                  onPressed: _createWorkspace,
+                  tooltip: 'New Workspace',
+                  child: const Icon(Icons.add),
+                ),
+              ],
+            )
+          : null,
       body: _buildWorkspacesList(),
     );
   }

--- a/src/frontend/lib/workspace/workspace_settings_panel.dart
+++ b/src/frontend/lib/workspace/workspace_settings_panel.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import '../auth/auth_service.dart';
 import '../theme/colors.dart';
@@ -372,11 +373,21 @@ class _SettingsFormState extends State<_SettingsForm> {
                         child: Row(
                           children: [
                             Expanded(
-                              child: Text(
+                              child: SelectableText(
                                 e.value,
                                 style: const TextStyle(fontSize: 13),
                               ),
                             ),
+                            IconButton(
+                              icon: const Icon(Icons.copy, size: 16),
+                              tooltip: 'Copy',
+                              onPressed: () => Clipboard.setData(
+                                ClipboardData(text: e.value),
+                              ),
+                              padding: EdgeInsets.zero,
+                              constraints: const BoxConstraints(),
+                            ),
+                            const SizedBox(width: 4),
                             IconButton(
                               icon: const Icon(Icons.close, size: 18),
                               onPressed: () =>
@@ -428,11 +439,23 @@ class _SettingsFormState extends State<_SettingsForm> {
                         child: Row(
                           children: [
                             Expanded(
-                              child: Text(
+                              child: SelectableText(
                                 '${e.value.key}=${e.value.value}',
                                 style: const TextStyle(fontSize: 13),
                               ),
                             ),
+                            IconButton(
+                              icon: const Icon(Icons.copy, size: 16),
+                              tooltip: 'Copy',
+                              onPressed: () => Clipboard.setData(
+                                ClipboardData(
+                                  text: '${e.value.key}=${e.value.value}',
+                                ),
+                              ),
+                              padding: EdgeInsets.zero,
+                              constraints: const BoxConstraints(),
+                            ),
+                            const SizedBox(width: 4),
                             IconButton(
                               icon: const Icon(Icons.close, size: 18),
                               onPressed: () =>

--- a/src/frontend/test/workspace_list_page_test.dart
+++ b/src/frontend/test/workspace_list_page_test.dart
@@ -1546,5 +1546,64 @@ void main() {
       expect(find.textContaining('Key cannot'), findsNothing);
       expect(find.text('A=1'), findsOneWidget);
     });
+
+    testWidgets('copy button appears and works for mount', (tester) async {
+      testAuthHttpClientOverride = withPermissions((request) async {
+        if (request.url.path == '/api/v1/workspaces' &&
+            request.method == 'GET') {
+          return http.Response(jsonEncode([]), 200);
+        }
+        return http.Response('Not found', 404);
+      });
+
+      await tester.pumpWidget(buildPage());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byTooltip('New Workspace'));
+      await tester.pumpAndSettle();
+
+      // No copy buttons initially
+      expect(find.byTooltip('Copy'), findsNothing);
+
+      // Add a mount
+      await tester.enterText(find.byType(TextField).at(2), '/src:/work');
+      await tester.tap(find.byIcon(Icons.add).at(1));
+      await tester.pumpAndSettle();
+
+      // Copy button appears for the mount
+      expect(find.byTooltip('Copy'), findsOneWidget);
+
+      // Tap copy button — exercises the Clipboard.setData call
+      await tester.tap(find.byTooltip('Copy').first);
+      await tester.pump();
+    });
+
+    testWidgets('copy button appears and works for env var', (tester) async {
+      testAuthHttpClientOverride = withPermissions((request) async {
+        if (request.url.path == '/api/v1/workspaces' &&
+            request.method == 'GET') {
+          return http.Response(jsonEncode([]), 200);
+        }
+        return http.Response('Not found', 404);
+      });
+
+      await tester.pumpWidget(buildPage());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byTooltip('New Workspace'));
+      await tester.pumpAndSettle();
+
+      // Add an env var
+      await tester.enterText(find.byType(TextField).at(3), 'FOO=bar');
+      await tester.tap(find.byIcon(Icons.add).at(2));
+      await tester.pumpAndSettle();
+
+      // Copy button appears for the env var
+      expect(find.byTooltip('Copy'), findsOneWidget);
+
+      // Tap copy button — exercises the Clipboard.setData call
+      await tester.tap(find.byTooltip('Copy').first);
+      await tester.pump();
+    });
   });
 }


### PR DESCRIPTION
## Summary
- Replace `Text` with `SelectableText` for mount paths and environment variables in workspace settings dialogs
- Add copy-to-clipboard buttons next to each mount and env var entry
- Applied to both the workspace settings panel and the new workspace creation dialog

Fixes #851

## Test plan
- [ ] Open workspace settings dialog, verify mount text is selectable
- [ ] Open workspace settings dialog, verify env var text is selectable
- [ ] Click copy button on a mount, verify it copies to clipboard
- [ ] Click copy button on an env var, verify it copies to clipboard
- [ ] Repeat above in the new workspace creation dialog