### PR TITLE
fix: clean up _workspace_locks in stop_and_remove_container

### DIFF
--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -702,6 +702,7 @@ class ContainerRegistry:
         if ws_id:
             self.revoke_workspace_browsers(ws_id)
             self.states.pop(ws_id, None)
+            self._workspace_locks.pop(ws_id, None)
 
     async def _notify_workspace_killed(self, workspace_id: str) -> None:
         """Call the on_workspace_killed callback, logging any errors."""

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -1295,14 +1295,17 @@ class TestStopContainer:
 
     async def test_stop_running(self):
         container.registry.track_activity("cid", "ws")
+        container.registry._workspace_locks["ws"] = asyncio.Lock()
 
         with patch_podman() as p:
             await container.registry.stop_and_remove_container("cid")
         p.remove_container.assert_awaited_once_with("cid")
         assert "ws" not in container.registry.states
+        assert "ws" not in container.registry._workspace_locks
 
     async def test_stop_podman_error(self):
         container.registry.track_activity("cid", "ws")
+        container.registry._workspace_locks["ws"] = asyncio.Lock()
 
         with patch_podman(
             remove_container=AsyncMock(
@@ -1312,6 +1315,7 @@ class TestStopContainer:
             await container.registry.stop_and_remove_container("cid")
         # Should still remove from tracking
         assert "ws" not in container.registry.states
+        assert "ws" not in container.registry._workspace_locks
 
 
 class TestRemoveContainer:
@@ -1323,14 +1327,17 @@ class TestRemoveContainer:
 
     async def test_remove(self):
         container.registry.track_activity("cid", "ws")
+        container.registry._workspace_locks["ws"] = asyncio.Lock()
 
         with patch_podman() as p:
             await container.registry.stop_and_remove_container("cid")
         p.remove_container.assert_awaited_once_with("cid")
         assert "ws" not in container.registry.states
+        assert "ws" not in container.registry._workspace_locks
 
     async def test_remove_podman_error(self):
         container.registry.track_activity("cid", "ws")
+        container.registry._workspace_locks["ws"] = asyncio.Lock()
 
         with patch_podman(
             remove_container=AsyncMock(
@@ -1339,6 +1346,7 @@ class TestRemoveContainer:
         ):
             await container.registry.stop_and_remove_container("cid")
         assert "ws" not in container.registry.states
+        assert "ws" not in container.registry._workspace_locks
 
 
 class TestStopUserContainers:


### PR DESCRIPTION
## Summary
- Add missing `self._workspace_locks.pop(ws_id, None)` to `stop_and_remove_container`, matching `remove_state`
- Prevents minor memory leak of `asyncio.Lock` objects for workspaces that have had containers started and stopped

## Test plan
- [x] Added assertions to existing stop/remove tests verifying lock cleanup
- [x] All backend tests pass

Closes #850