### PR TITLE
fix: sanitize Content-Disposition filenames

### DIFF
--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -46,7 +46,12 @@ from .model import (
     PRINCIPAL_USER,
     SYSTEM_AUTHENTICATED,
 )
-from .util import API_PREFIX, derive_hosting_info, resolve_env_secret
+from .util import (
+    API_PREFIX,
+    derive_hosting_info,
+    resolve_env_secret,
+    sanitize_disposition_name,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1278,7 +1283,7 @@ async def export_workspace(
         finally:
             shutil.rmtree(tmpdir, ignore_errors=True)
 
-    safe_name = ws_name.replace("/", "_").replace("\\", "_")
+    safe_name = sanitize_disposition_name(ws_name)
     # Rough estimate: gzip typically compresses to ~20% of original
     # for text-heavy home dirs (source code, dotfiles, configs).
     estimated_compressed = max(int(estimated_size * 0.2), 1)
@@ -1903,7 +1908,7 @@ async def download_file(
         raise HTTPException(status_code=400, detail=str(e))
     if info is None:
         raise HTTPException(status_code=404, detail="Path not found")
-    name = posixpath.basename(path) or "download"
+    name = sanitize_disposition_name(posixpath.basename(path) or "download")
     if not info["is_dir"]:
         return StreamingResponse(
             files.stream_file(cid, path),

--- a/src/backend/klangk_backend/util.py
+++ b/src/backend/klangk_backend/util.py
@@ -62,6 +62,15 @@ def resolve_file_secret(value: str) -> str:
     return value
 
 
+def sanitize_disposition_name(name: str) -> str:
+    """Sanitize a filename for use in a Content-Disposition header.
+
+    Strips characters that would break or inject into the header value
+    (double quotes, backslashes, path separators).
+    """
+    return name.replace("/", "_").replace("\\", "_").replace('"', "")
+
+
 _REJECT_PROXY = resolve_env_bool("KLANGK_REJECT_PROXY_HEADERS")
 
 

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -2984,6 +2984,39 @@ class TestFileRoutes:
         finally:
             self._cleanup(ws_id)
 
+    async def test_download_file_strips_quotes_from_filename(
+        self, client, user
+    ):
+        headers = await _auth_headers(client)
+        ws_id = await self._create_workspace(client, headers)
+        try:
+
+            async def fake_stream(*a, **kw):
+                yield b"data"
+
+            with (
+                patch(
+                    "klangk_backend.files.podman.exec_container",
+                    new_callable=AsyncMock,
+                    return_value=(0, "regular file\t4", ""),
+                ),
+                patch(
+                    "klangk_backend.files.podman.exec_container_stream",
+                    side_effect=fake_stream,
+                ),
+            ):
+                resp = await client.get(
+                    f"/api/v1/workspaces/{ws_id}/files/download?path=/home/work/f%22name.txt",
+                    headers=headers,
+                )
+            assert resp.status_code == 200
+            assert (
+                resp.headers["content-disposition"]
+                == 'attachment; filename="fname.txt"'
+            )
+        finally:
+            self._cleanup(ws_id)
+
     async def test_download_directory_as_tar(self, client, user):
         headers = await _auth_headers(client)
         ws_id = await self._create_workspace(client, headers)

--- a/src/backend/tests/test_util.py
+++ b/src/backend/tests/test_util.py
@@ -4,6 +4,7 @@ from klangk_backend.util import (
     resolve_env_bool,
     resolve_env_secret,
     resolve_file_secret,
+    sanitize_disposition_name,
 )
 
 
@@ -71,3 +72,17 @@ class TestResolveFileSecret:
 
     def test_file_missing_returns_empty(self):
         assert resolve_file_secret("file:/no/such/file") == ""
+
+
+class TestSanitizeDispositionName:
+    def test_plain_name(self):
+        assert sanitize_disposition_name("file.txt") == "file.txt"
+
+    def test_strips_double_quotes(self):
+        assert sanitize_disposition_name('f"name.txt') == "fname.txt"
+
+    def test_replaces_slashes_with_underscore(self):
+        assert sanitize_disposition_name("a/b\\c") == "a_b_c"
+
+    def test_combined(self):
+        assert sanitize_disposition_name('my/"file".txt') == "my_file.txt"


### PR DESCRIPTION
## Summary
- Add `sanitize_disposition_name()` helper in `util.py` to strip `"`, `/`, `\` from filenames
- Use it at all three Content-Disposition header sites in `api.py`
- Prevents malformed HTTP responses or header injection from filenames containing double quotes

## Test plan
- [x] Unit tests for `sanitize_disposition_name()` in `test_util.py`
- [x] Integration test for download with quoted filename in `test_api.py`

Closes #848