### PR TITLE
fix: catch OSError in delete_file and rename_file endpoints

### DIFF
--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -1862,6 +1862,8 @@ async def delete_file(
         raise HTTPException(status_code=400, detail=str(e))
     except FileNotFoundError:
         raise HTTPException(status_code=404, detail="Path not found")
+    except OSError as e:
+        raise HTTPException(status_code=500, detail=str(e))
     return {"path": deleted, "status": "deleted"}
 
 
@@ -1887,6 +1889,8 @@ async def rename_file(
         raise HTTPException(
             status_code=409, detail="Destination already exists"
         )
+    except OSError as e:
+        raise HTTPException(status_code=500, detail=str(e))
     return {"path": renamed, "status": "renamed"}
 
 

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -2890,6 +2890,24 @@ class TestFileRoutes:
         finally:
             self._cleanup(ws_id)
 
+    async def test_delete_file_oserror(self, client, user):
+        headers = await _auth_headers(client)
+        ws_id = await self._create_workspace(client, headers)
+        try:
+            with patch(
+                "klangk_backend.files.delete_path",
+                new_callable=AsyncMock,
+                side_effect=OSError("Permission denied"),
+            ):
+                resp = await client.delete(
+                    f"/api/v1/workspaces/{ws_id}/files?path=/usr/bin/test",
+                    headers=headers,
+                )
+            assert resp.status_code == 500
+            assert "Permission denied" in resp.json()["detail"]
+        finally:
+            self._cleanup(ws_id)
+
     async def test_rename_file(self, client, user):
         headers = await _auth_headers(client)
         ws_id = await self._create_workspace(client, headers)
@@ -2953,6 +2971,28 @@ class TestFileRoutes:
                     json={"old_path": "/a.txt", "new_path": "/b.txt"},
                 )
             assert resp.status_code == 409
+        finally:
+            self._cleanup(ws_id)
+
+    async def test_rename_file_oserror(self, client, user):
+        headers = await _auth_headers(client)
+        ws_id = await self._create_workspace(client, headers)
+        try:
+            with patch(
+                "klangk_backend.files.rename_path",
+                new_callable=AsyncMock,
+                side_effect=OSError("Permission denied"),
+            ):
+                resp = await client.post(
+                    f"/api/v1/workspaces/{ws_id}/files/rename",
+                    headers=headers,
+                    json={
+                        "old_path": "/usr/bin/a",
+                        "new_path": "/usr/bin/b",
+                    },
+                )
+            assert resp.status_code == 500
+            assert "Permission denied" in resp.json()["detail"]
         finally:
             self._cleanup(ws_id)
 


### PR DESCRIPTION
## Summary
- Add `except OSError` handling to `delete_file` and `rename_file` API endpoints
- Permission errors and other OS-level failures now return a clean 500 instead of an unhandled stack trace

## Test plan
- [x] Added tests for OSError in both delete and rename endpoints
- [x] All tests pass

Closes #847