### PR TITLE
fix: detect and signal streaming download failures

### DIFF
--- a/src/backend/klangk_backend/podman.py
+++ b/src/backend/klangk_backend/podman.py
@@ -348,6 +348,17 @@ async def exec_container_stream(
         if proc.returncode is None:
             proc.kill()
         await proc.wait()
+    if proc.returncode != 0:
+        logger.warning(
+            "exec_container_stream command failed (rc=%d): %s %s",
+            proc.returncode,
+            container_id,
+            cmd,
+        )
+        raise PodmanError(
+            proc.returncode,
+            f"stream command exited with code {proc.returncode}",
+        )
 
 
 async def remove_container(container_id: str, *, force: bool = True) -> None:

--- a/src/backend/tests/test_podman.py
+++ b/src/backend/tests/test_podman.py
@@ -419,6 +419,18 @@ class TestExecContainerStream:
             await gen.aclose()
         mock_proc.kill.assert_called_once()
 
+    async def test_raises_on_nonzero_exit(self):
+        mock_proc = MagicMock()
+        mock_proc.returncode = 1
+        mock_proc.stdout = AsyncMock()
+        mock_proc.stdout.read = AsyncMock(side_effect=[b"partial", b""])
+        mock_proc.wait = AsyncMock(return_value=1)
+
+        with patch(EXEC, AsyncMock(return_value=mock_proc)):
+            with pytest.raises(podman.PodmanError):
+                async for _ in podman.exec_container_stream("cid", ["cat"]):
+                    pass
+
 
 class TestRemoveContainer:
     async def test_force_default(self):


### PR DESCRIPTION
## Summary
- `exec_container_stream` now checks process exit code after streaming completes
- Logs a warning and raises `PodmanError` on non-zero exit, aborting the chunked transfer
- Clients see a failed download instead of silently receiving truncated/empty content with HTTP 200

## Test plan
- [x] Added test for non-zero exit code raising PodmanError
- [x] All existing stream and download tests pass

Closes #846