### PR TITLE
fix: prevent stderr deadlock and subprocess leak in export streaming

### DIFF
--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -1267,14 +1267,19 @@ async def export_workspace(
             proc = await asyncio.create_subprocess_exec(
                 *tar_args,
                 stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.DEVNULL,
             )
-            while True:
-                chunk = await proc.stdout.read(_CHUNK_SIZE)
-                if not chunk:
-                    break
-                yield chunk
-            await proc.wait()
+            try:
+                while True:
+                    chunk = await proc.stdout.read(_CHUNK_SIZE)
+                    if not chunk:
+                        break
+                    yield chunk
+                await proc.wait()
+            finally:
+                if proc.returncode is None:
+                    proc.kill()
+                    await proc.wait()
         finally:
             shutil.rmtree(tmpdir, ignore_errors=True)
 


### PR DESCRIPTION
## Summary
- Change `stderr=PIPE` to `stderr=DEVNULL` in the export tar subprocess to prevent deadlock when tar produces >64KB of warnings
- Add `proc.kill()`/`proc.wait()` in finally block to clean up the subprocess on client disconnect

## Test plan
- [x] All 9 existing export tests pass

Closes #844