### PR TITLE
feat: add admin endpoint to reset user login lockout

### DIFF
--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -70,6 +70,21 @@ No request body.
 
 ---
 
+### POST `/api/v1/admin/users/{id}/unlockout`
+
+Reset a user's login lockout, allowing them to log in immediately after
+being locked out due to too many failed attempts.
+
+**Auth:** JWT required. User must have `admin` permission on `/`.
+
+No request body.
+
+```json
+{ "status": "unlocked" }
+```
+
+---
+
 ### GET `/api/v1/admin/acl/by-principal/group/{id}`
 
 List all ACL entries granted to a specific group across all resources.

--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -2243,6 +2243,18 @@ async def update_user(
     return {"status": "updated"}
 
 
+@router.post("/admin/users/{user_id}/unlockout")
+async def unlock_user(
+    user_id: str, admin: dict = Depends(acl.has_permission("admin"))
+):
+    """Reset a user's login lockout so they can log in immediately."""
+    user = await model.get_user_by_id(user_id)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    await model.clear_login_attempts(user["email"])
+    return {"status": "unlocked"}
+
+
 # --- Group management endpoints ---
 
 

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -3629,6 +3629,44 @@ class TestAdminEndpoints:
         assert resp.status_code == 400
         assert "system agent" in resp.json()["detail"]
 
+    async def test_unlock_user(self, client, admin_user, user):
+        headers = await self._admin_headers(client)
+        # Lock out the user
+        await model.record_failed_login(user["email"])
+        await model.set_login_lockout(
+            user["email"], "2099-01-01T00:00:00+00:00"
+        )
+        # Verify locked
+        info = await model.get_login_attempt_info(user["email"])
+        assert info["locked_until"] is not None
+        # Unlock via admin endpoint
+        resp = await client.post(
+            f"/api/v1/admin/users/{user['id']}/unlockout", headers=headers
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "unlocked"
+        # Verify lockout cleared
+        info = await model.get_login_attempt_info(user["email"])
+        assert info is None
+
+    async def test_unlock_nonexistent_user(self, client, admin_user):
+        headers = await self._admin_headers(client)
+        resp = await client.post(
+            "/api/v1/admin/users/nonexistent-id/unlockout", headers=headers
+        )
+        assert resp.status_code == 404
+
+    async def test_unlock_requires_admin(self, client, user):
+        resp = await client.post(
+            "/api/v1/auth/login",
+            json={"email": "testuser@example.com", "password": "testpass"},
+        )
+        headers = {"Authorization": f"Bearer {resp.json()['access_token']}"}
+        resp = await client.post(
+            f"/api/v1/admin/users/{user['id']}/unlockout", headers=headers
+        )
+        assert resp.status_code == 403
+
 
 class TestGroupEndpoints:
     async def _admin_headers(self, client):


### PR DESCRIPTION
## Summary
- Add `POST /api/v1/admin/users/{id}/unlockout` endpoint
- Clears a user's login lockout state so they can log in immediately
- Requires admin permission, returns 404 for unknown users
- Documented in `docs/reference/api-endpoints.md`

## Test plan
- [x] Test unlock clears lockout and allows login
- [x] Test 404 for nonexistent user
- [x] Test 403 for non-admin

Closes #835