### PR TITLE
fix: replace Unicode box-drawing chars with ASCII dashes in plugin banners

### DIFF
--- a/src/containers/workspace/Dockerfile
+++ b/src/containers/workspace/Dockerfile
@@ -84,9 +84,10 @@ RUN touch /tmp/.klangk-image-build \
       plugin=$(basename "$(dirname "$f")"); \
       label=" $plugin (on-image-build) "; \
       pad=$(( (60 - ${#label}) / 2 )); \
-      line=$(printf '%*s' "$pad" '' | tr ' ' '━'); \
+      line=$(printf '%*s' "$pad" '' | tr ' ' '-'); \
       printf '\033[33m%s%s%s\033[0m\n' "$line" "$label" "$line"; \
       "$f"; \
+      printf '\033[33m%s\033[0m\n' "$(printf '%*s' 60 '' | tr ' ' '-')"; \
     done; rm -f /tmp/.klangk-image-build; true
 
 # Fix non-root group ownership that causes crun fchownat errors with

--- a/src/containers/workspace/bash.bashrc
+++ b/src/containers/workspace/bash.bashrc
@@ -40,9 +40,10 @@ for f in /opt/klangk/plugins/*/on-shell-init.sh; do
   plugin=$(basename "$(dirname "$f")")
   label=" $plugin (on-shell-init) "
   pad=$(( (60 - ${#label}) / 2 ))
-  line=$(printf '%*s' "$pad" '' | tr ' ' '━')
+  line=$(printf '%*s' "$pad" '' | tr ' ' '-')
   printf '\033[33m%s%s%s\033[0m\n' "$line" "$label" "$line"
   "$f" || true
+  printf '\033[33m%s\033[0m\n' "$(printf '%*s' 60 '' | tr ' ' '-')"
 done
 
 # Determine which command to exec into (if any).

--- a/src/containers/workspace/entrypoint.sh
+++ b/src/containers/workspace/entrypoint.sh
@@ -13,9 +13,10 @@ for f in /opt/klangk/plugins/*/on-entrypoint.sh; do
   plugin=$(basename "$(dirname "$f")")
   label=" $plugin (on-entrypoint) "
   pad=$(((60 - ${#label}) / 2))
-  line=$(printf '%*s' "$pad" '' | tr ' ' '━')
+  line=$(printf '%*s' "$pad" '' | tr ' ' '-')
   printf '\033[33m%s%s%s\033[0m\n' "$line" "$label" "$line"
   "$f" || true
+  printf '\033[33m%s\033[0m\n' "$(printf '%*s' 60 '' | tr ' ' '-')"
 done
 
 # Create the workspace token directory.


### PR DESCRIPTION
## Summary
- Replace `━` (U+2501) with `-` in all three plugin hook banner sites (Dockerfile, entrypoint.sh, bash.bashrc)
- Add an ending separator line after each plugin hook's output

## Test plan
- [x] Visual inspection — banners render correctly on ASCII-only terminals

Closes #861