### PR TITLE
fix: only abort stream on non-zero exit when no data was produced

### DIFF
--- a/src/backend/klangk_backend/podman.py
+++ b/src/backend/klangk_backend/podman.py
@@ -338,11 +338,13 @@ async def exec_container_stream(
         stderr=asyncio.subprocess.DEVNULL,
         env=subprocess_env(),
     )
+    yielded = False
     try:
         while True:
             chunk = await proc.stdout.read(chunk_size)
             if not chunk:
                 break
+            yielded = True
             yield chunk
     finally:
         if proc.returncode is None:
@@ -355,10 +357,14 @@ async def exec_container_stream(
             container_id,
             cmd,
         )
-        raise PodmanError(
-            proc.returncode,
-            f"stream command exited with code {proc.returncode}",
-        )
+        # Only abort the stream if no data was produced; if data was
+        # yielded the response is already in-flight and may be valid
+        # (e.g. tar exits 1 when files change during archiving).
+        if not yielded:
+            raise PodmanError(
+                proc.returncode,
+                f"stream command exited with code {proc.returncode}",
+            )
 
 
 async def remove_container(container_id: str, *, force: bool = True) -> None:

--- a/src/backend/tests/test_podman.py
+++ b/src/backend/tests/test_podman.py
@@ -419,7 +419,19 @@ class TestExecContainerStream:
             await gen.aclose()
         mock_proc.kill.assert_called_once()
 
-    async def test_raises_on_nonzero_exit(self):
+    async def test_raises_on_nonzero_exit_no_output(self):
+        mock_proc = MagicMock()
+        mock_proc.returncode = 1
+        mock_proc.stdout = AsyncMock()
+        mock_proc.stdout.read = AsyncMock(return_value=b"")
+        mock_proc.wait = AsyncMock(return_value=1)
+
+        with patch(EXEC, AsyncMock(return_value=mock_proc)):
+            with pytest.raises(podman.PodmanError):
+                async for _ in podman.exec_container_stream("cid", ["cat"]):
+                    pass
+
+    async def test_nonzero_exit_with_output_does_not_raise(self):
         mock_proc = MagicMock()
         mock_proc.returncode = 1
         mock_proc.stdout = AsyncMock()
@@ -427,9 +439,10 @@ class TestExecContainerStream:
         mock_proc.wait = AsyncMock(return_value=1)
 
         with patch(EXEC, AsyncMock(return_value=mock_proc)):
-            with pytest.raises(podman.PodmanError):
-                async for _ in podman.exec_container_stream("cid", ["cat"]):
-                    pass
+            chunks = []
+            async for chunk in podman.exec_container_stream("cid", ["tar"]):
+                chunks.append(chunk)
+        assert chunks == [b"partial"]
 
 
 class TestRemoveContainer:


### PR DESCRIPTION
## Summary
- `exec_container_stream` now only raises `PodmanError` on non-zero exit when no data was yielded
- Commands like `tar` can exit 1 (files changed during archiving) while still producing valid output — these should not abort the download
- Still logs a warning for all non-zero exits for diagnostics

## Test plan
- [x] Test: non-zero exit with no output raises PodmanError
- [x] Test: non-zero exit with output does not raise
- [x] All existing stream tests pass

Fixes E2E failure in `test_download_homedir_symlink_as_tar` from PR #858.