### PR TITLE
fix: improve klangkc login error when URL points to wrong path

### DIFF
--- a/src/cli/klangkc/auth.py
+++ b/src/cli/klangkc/auth.py
@@ -21,15 +21,24 @@ _err = Console(stderr=True)
 _out = Console()
 
 
-def _fetch_config(server_url: str) -> dict | None:
-    """Fetch /api/v1/config from the server. Returns None on failure."""
+_UNREACHABLE = "unreachable"
+
+
+def _fetch_config(server_url: str) -> dict | str | None:
+    """Fetch /api/v1/config from the server.
+
+    Returns:
+        dict — valid klangk config
+        _UNREACHABLE — server is down or unreachable
+        None — server responded but is not a klangk instance
+    """
     try:
         resp = httpx.get(f"{server_url}/api/v1/config", timeout=5.0)
         if resp.status_code == 200:
             return resp.json()
+        return None
     except httpx.HTTPError:
-        pass
-    return None
+        return _UNREACHABLE
 
 
 def _oidc_browser_login(  # pragma: no cover
@@ -165,8 +174,22 @@ def login(
             except httpx.HTTPError:
                 pass  # Token invalid or server unreachable — fall through
 
-    # Check server config for OIDC providers
+    # Probe the server to verify it's a klangk instance
     config = _fetch_config(server_url)
+    if config is None:
+        _err.print(
+            f"[red]Error:[/red] {server_url} does not appear to be a"
+            " klangk server."
+        )
+        _err.print(
+            "[yellow]Hint:[/yellow] did you forget the subpath?"
+            " (e.g. https://host/klangk)"
+        )
+        raise SystemExit(1)
+    if config == _UNREACHABLE:
+        _err.print(f"[red]Error:[/red] could not reach {server_url}")
+        raise SystemExit(1)
+
     if config:
         providers = config.get("oidc_providers", [])
         auth_modes = config.get("auth_modes", "password")

--- a/src/cli/tests/test_cli.py
+++ b/src/cli/tests/test_cli.py
@@ -443,7 +443,7 @@ class TestCLIState:
 class TestAuth:
     @pytest.fixture(autouse=True)
     def no_oidc(self, monkeypatch):
-        monkeypatch.setattr("klangkc.auth._fetch_config", lambda _: None)
+        monkeypatch.setattr("klangkc.auth._fetch_config", lambda _: {})
 
     def test_login_success(self, tmp_path, monkeypatch):
         state_path = tmp_path / "state.yaml"
@@ -664,10 +664,19 @@ class TestOIDCCLILogin:
             result = _fetch_config("http://localhost:8995")
         assert result == {"auth_modes": "both"}
 
-    def test_fetch_config_failure(self, monkeypatch):
-        from klangkc.auth import _fetch_config
+    def test_fetch_config_unreachable(self, monkeypatch):
+        from klangkc.auth import _UNREACHABLE, _fetch_config
 
         with patch("httpx.get", side_effect=httpx.ConnectError("fail")):
+            result = _fetch_config("http://localhost:8995")
+        assert result == _UNREACHABLE
+
+    def test_fetch_config_not_klangk(self, monkeypatch):
+        from klangkc.auth import _fetch_config
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 404
+        with patch("httpx.get", return_value=mock_resp):
             result = _fetch_config("http://localhost:8995")
         assert result is None
 
@@ -773,10 +782,7 @@ class TestOIDCCLILogin:
 
         state_path = tmp_path / "state.yaml"
         monkeypatch.setattr("klangkc.config._STATE_PATH", state_path)
-        monkeypatch.setattr(
-            "klangkc.auth._fetch_config",
-            lambda _: None,
-        )
+        monkeypatch.setattr("klangkc.auth._fetch_config", lambda _: {})
         mock_resp = MagicMock()
         mock_resp.status_code = 301
         mock_resp.headers = {"location": "https://example.com/auth/login"}
@@ -796,10 +802,7 @@ class TestOIDCCLILogin:
 
         state_path = tmp_path / "state.yaml"
         monkeypatch.setattr("klangkc.config._STATE_PATH", state_path)
-        monkeypatch.setattr(
-            "klangkc.auth._fetch_config",
-            lambda _: None,
-        )
+        monkeypatch.setattr("klangkc.auth._fetch_config", lambda _: {})
         mock_resp = MagicMock()
         mock_resp.status_code = 403
         mock_resp.json.side_effect = Exception("no body")
@@ -810,6 +813,36 @@ class TestOIDCCLILogin:
         ):
             auth.login(
                 "http://localhost:8995",
+                email="u@test.com",
+                password="pw",
+            )
+
+    def test_login_not_klangk_server(self, tmp_path, monkeypatch):
+        """Non-klangk server shows helpful error with subpath hint."""
+        from klangkc import auth
+
+        state_path = tmp_path / "state.yaml"
+        monkeypatch.setattr("klangkc.config._STATE_PATH", state_path)
+        monkeypatch.setattr("klangkc.auth._fetch_config", lambda _: None)
+        with pytest.raises(SystemExit):
+            auth.login(
+                "http://example.com",
+                email="u@test.com",
+                password="pw",
+            )
+
+    def test_login_server_unreachable(self, tmp_path, monkeypatch):
+        """Unreachable server shows connection error, not subpath hint."""
+        from klangkc import auth
+
+        state_path = tmp_path / "state.yaml"
+        monkeypatch.setattr("klangkc.config._STATE_PATH", state_path)
+        monkeypatch.setattr(
+            "klangkc.auth._fetch_config", lambda _: auth._UNREACHABLE
+        )
+        with pytest.raises(SystemExit):
+            auth.login(
+                "http://example.com",
                 email="u@test.com",
                 password="pw",
             )
@@ -1581,7 +1614,7 @@ class TestRunShell:
 class TestMisc:
     @pytest.fixture(autouse=True)
     def no_oidc(self, monkeypatch):
-        monkeypatch.setattr("klangkc.auth._fetch_config", lambda _: None)
+        monkeypatch.setattr("klangkc.auth._fetch_config", lambda _: {})
 
     def test_auth_error_message(self):
         err = AuthError("Session expired — run `klangkc login`")

--- a/src/cli/tests/test_cli_main.py
+++ b/src/cli/tests/test_cli_main.py
@@ -65,7 +65,7 @@ def reset_env():
 class TestMainCLI:
     @pytest.fixture(autouse=True)
     def no_oidc(self, monkeypatch):
-        monkeypatch.setattr("klangkc.auth._fetch_config", lambda _: None)
+        monkeypatch.setattr("klangkc.auth._fetch_config", lambda _: {})
 
     def test_login_cmd_stores_token(self, tmp_path, monkeypatch):
         from klangkc.main import login_cmd


### PR DESCRIPTION
## Summary
- Probe `/api/v1/config` before attempting login to verify the server is a klangk instance
- Wrong URL (not klangk) shows: "does not appear to be a klangk server" with subpath hint
- Unreachable server shows: "could not reach {url}" instead of the misleading subpath hint

Closes #824