### PR TITLE
chore: fix module name in test_cli docstring

### DIFF
--- a/src/cli/tests/test_cli.py
+++ b/src/cli/tests/test_cli.py
@@ -1,4 +1,4 @@
-"""Tests for the klangk CLI."""
+"""Tests for the klangkc CLI."""
 
 import asyncio
 import json


### PR DESCRIPTION
## Summary
- Fix docstring: "klangk CLI" → "klangkc CLI" to match actual module name