### PR TITLE
fix(auth): return 401 for OIDC-only users on password login

### DIFF
--- a/src/backend/klangk_backend/auth.py
+++ b/src/backend/klangk_backend/auth.py
@@ -229,8 +229,12 @@ async def login(req: LoginRequest) -> TokenResponse:
             raise HTTPException(status_code=429, detail=msg)
 
     user = await model.get_user_by_email(req.email)
-    if user is None or not verify_password(
-        req.password, user["password_hash"]
+    # OIDC-only users have no password hash; treat that as invalid
+    # credentials rather than letting verify_password crash on None.
+    if (
+        user is None
+        or not user.get("password_hash")
+        or not verify_password(req.password, user["password_hash"])
     ):
         if LOGIN_LOCKOUT_FAILURES > 0:
             await model.record_failed_login(req.email)

--- a/src/backend/tests/test_auth.py
+++ b/src/backend/tests/test_auth.py
@@ -178,6 +178,21 @@ class TestLogin:
             )
         assert exc_info.value.status_code == 401
 
+    async def test_login_oidc_only_user_no_password_hash(self, db):
+        """OIDC-only users have no password hash; login must return 401
+        (Invalid credentials) rather than crashing with a 500."""
+        await model.create_user(
+            "oidc@example.com", None, verified=True, provider="oidc"
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await auth.login(
+                auth.LoginRequest(
+                    email="oidc@example.com", password="anything"
+                )
+            )
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.detail == "Invalid credentials"
+
     async def test_login_unverified(self, db):
         import bcrypt
 


### PR DESCRIPTION
Fixes #869.

## Summary

OIDC-only users have a `NULL` `password_hash`. `login()` passed it straight to `verify_password()`, which called `None.encode()` and raised `AttributeError`, producing a **500** instead of a clean `401 Invalid credentials`.

## Fix

Guard the `verify_password()` call: treat a missing password hash the same as a wrong password, so the user gets a proper `401` and the normal brute-force lockout accounting applies.

```python
if (
    user is None
    or not user.get("password_hash")        # new guard
    or not verify_password(req.password, user["password_hash"])
):
```

## Test

Adds regression test `test_login_oidc_only_user_no_password_hash` — creates an OIDC user with `password_hash=None` and asserts login returns `401` with detail `Invalid credentials`. All 88 tests in `test_auth.py` pass.