### PR TITLE
fix: scope agent presence to its running workspace

### DIFF
--- a/src/backend/klangk_backend/wshandler.py
+++ b/src/backend/klangk_backend/wshandler.py
@@ -659,9 +659,9 @@ async def _get_presence_list(workspace_id: str) -> list[dict]:
                     "user_handle": conn.user.get("handle", ""),
                 }
             )
-    # Include agent only if its RPC process is alive.
+    # Include agent only if its RPC process is alive in this workspace.
 
-    if agent.any_running():
+    if agent.is_running(workspace_id):
         agent_user = await model.get_agent_user()
         users.append(
             {

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -6388,10 +6388,38 @@ class TestPresenceIncludesAgent:
         state.connections[sock] = conn
 
         try:
-            with patch("klangk_backend.agent.any_running", return_value=True):
+            with patch(
+                "klangk_backend.agent.is_running",
+                side_effect=lambda ws_id: ws_id == workspace["id"],
+            ):
                 users = await _get_presence_list(workspace["id"])
             ids = [u["user_id"] for u in users]
             assert model.AGENT_USER_ID in ids
+        finally:
+            await session.remove_subscriber(sock)
+            state.connections.pop(sock, None)
+            state.sessions.pop(workspace["id"], None)
+
+    async def test_agent_not_in_presence_when_running_in_other_workspace(
+        self, user, agent_user
+    ):
+        """Agent running in a different workspace must not appear in this
+        workspace's presence list (regression for #870)."""
+        sock = _mock_sock()
+        conn = _base_conn(user=user, ws=sock)
+        workspace = await ws_mod.create_workspace(user["id"], "pres-ws")
+        session = state.get_or_create_session(workspace["id"])
+        await session.add_subscriber(sock, "cid")
+        state.connections[sock] = conn
+
+        try:
+            with patch(
+                "klangk_backend.agent.is_running",
+                side_effect=lambda ws_id: ws_id == "other-workspace",
+            ):
+                users = await _get_presence_list(workspace["id"])
+            ids = [u["user_id"] for u in users]
+            assert model.AGENT_USER_ID not in ids
         finally:
             await session.remove_subscriber(sock)
             state.connections.pop(sock, None)


### PR DESCRIPTION
## Summary

Fixes #870.

`_get_presence_list` in `wshandler.py` used `agent.any_running()`, which returns `True` if **any** workspace has a running agent. This caused the agent to appear in the presence list of workspaces where it was **not** running.

## Fix

Use `agent.is_running(workspace_id)` to check only the target workspace (the `workspace_id` was already in scope). This function already existed in `agent.py`.

```diff
-    if agent.any_running():
+    if agent.is_running(workspace_id):
```

## Tests

- Updated `test_agent_in_presence_when_running` to mock `is_running`.
- Added `test_agent_not_in_presence_when_running_in_other_workspace` — regression test confirming the agent does not appear in a workspace where it isn't running.

Full `test_wshandler.py` + `test_agent.py` suites pass (372 passed); touched modules remain at 100% coverage.