### PR TITLE
fix: cancel token renewal task on workspace session reset

### DIFF
--- a/src/backend/klangk_backend/wshandler.py
+++ b/src/backend/klangk_backend/wshandler.py
@@ -175,6 +175,17 @@ class WorkspaceSession:
         self.subscribers.clear()
         self.browser_subscribers.clear()
         self.terminal_windows.clear()
+        # Cancel the token renewal loop so it doesn't keep renewing
+        # tokens for a container that has been killed or reset.
+        task = self._token_renewal_task
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        self._token_renewal_task = None
+        self.workspace_token_expiry = None
 
     async def add_subscriber(
         self, sock: SafeWebSocket, container_id: str

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -6116,6 +6116,47 @@ class TestTokenRenewal:
         finally:
             wshandler.state.sessions.pop(workspace["id"], None)
 
+    async def test_reset_cancels_token_renewal_task(self, user):
+        """reset() cancels the token renewal task (issue #871).
+
+        Without cancellation the renewal loop keeps running after a
+        container is killed and the session is reset, leaking a task
+        that renews tokens for a dead container forever.
+        """
+        workspace = await _create_workspace_with_acl(user["id"], "leak-ws")
+        session = wshandler.state.get_or_create_session(workspace["id"])
+        session.container_id = "test-cid"
+
+        try:
+            with (
+                patch.object(
+                    wshandler.auth,
+                    "WORKSPACE_TOKEN_EXPIRE_HOURS",
+                    0.0001,
+                ),
+                patch(
+                    "klangk_backend.terminal.set_workspace_token",
+                    new_callable=AsyncMock,
+                ) as mock_set,
+            ):
+                expiry = datetime.now(timezone.utc) + timedelta(seconds=0.1)
+                session.start_token_renewal(expiry)
+                task = session._token_renewal_task
+                assert task is not None and not task.done()
+
+                await session.reset()
+
+                assert task.done()
+                assert session._token_renewal_task is None
+                assert session.workspace_token_expiry is None
+
+            # Renewal must never fire again after reset, even if we wait.
+            calls_before = mock_set.call_count
+            await asyncio.sleep(0.3)
+            assert mock_set.call_count == calls_before
+        finally:
+            wshandler.state.sessions.pop(workspace["id"], None)
+
 
 class TestSSHAgentDispatch:
     async def test_dispatch_ssh_agent_start(self, user):


### PR DESCRIPTION
## Summary
- `WorkspaceSession.reset()` cleared subscribers, browser subscribers, and terminal windows but never cancelled `_token_renewal_task`
- When a container was killed by the idle timeout and the session reset, the renewal loop kept running indefinitely, renewing tokens for a dead container
- `reset()` now cancels and awaits the task, and clears `workspace_token_expiry`, returning the session to its initial state (mirrors the cancellation pattern in `_stop_ssh_agent`)
- Adds `TestTokenRenewal.test_reset_cancels_token_renewal_task`

Closes #871