### PR TITLE
fix: stop agent RPC subprocess on workspace teardown

### DIFF
--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -27,7 +27,6 @@ from pydantic import BaseModel
 
 from . import (
     acl,
-    agent,
     auth,
     container,
     emailsvc,
@@ -1173,7 +1172,9 @@ async def delete_workspace(
         if live_state
         else workspace.get("container_id")
     )
-    await agent.stop_session(workspace_id)
+    # reset_workspace_state (below) stops the agent session and clears
+    # shared state; the agent subprocess runs inside the container, so
+    # stopping the container kills it either way.
     if cid:
         await container.registry.stop_and_remove_container(cid)
     await wshandler.reset_workspace_state(workspace_id)
@@ -1207,7 +1208,6 @@ async def restart_workspace(
         if live_state
         else workspace.get("container_id")
     )
-    await agent.stop_session(workspace_id)
     if cid:
         await container.registry.stop_and_remove_container(cid)
     await wshandler.reset_workspace_state(workspace_id)

--- a/src/backend/klangk_backend/wshandler.py
+++ b/src/backend/klangk_backend/wshandler.py
@@ -545,6 +545,8 @@ class WebSocketState:
         task = _agent_tasks.pop(workspace_id, None)
         if task and not task.done():
             task.cancel()
+        # Stop the Pi RPC subprocess so it doesn't outlive the container.
+        await agent.stop_session(workspace_id)
 
     async def logout_user(self, user_id: str) -> None:
         """Stop containers for a logging-out user, skipping any that
@@ -1064,6 +1066,9 @@ class Connection:
             logger.warning("Error stopping container: %s", e)
 
         await container.registry._notify_workspace_killed(workspace_id)
+
+        # Stop the Pi RPC subprocess now that its container is gone.
+        await agent.stop_session(workspace_id)
 
         # Notify subscribers AFTER the container is fully stopped, so
         # reconnecting clients don't find a half-dead container.

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -911,7 +911,7 @@ class TestWorkspaceRoutes:
                 new_callable=AsyncMock,
             ) as mock_rm,
             patch.object(
-                api.agent,
+                wshandler.agent,
                 "stop_session",
                 new_callable=AsyncMock,
             ) as mock_stop_agent,

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -2978,6 +2978,15 @@ class TestResetWorkspaceState:
             if not task.done():
                 task.cancel()
 
+    async def test_reset_stops_agent_session(self):
+        """reset_workspace stops the Pi RPC subprocess via agent.stop_session."""
+        ws_id = "ws-agent-stop"
+        with patch(
+            "klangk_backend.agent.stop_session", new_callable=AsyncMock
+        ) as mock_stop:
+            await reset_workspace_state(ws_id)
+            mock_stop.assert_awaited_once_with(ws_id)
+
 
 class TestRemoveSessionLocked:
     async def test_removes_session(self):
@@ -3460,6 +3469,39 @@ class TestHandleShutdownContainer:
             ), "container_stopped not sent to subscriber"
 
         wshandler.state.sessions.pop(ws["id"], None)
+
+    async def test_shutdown_stops_agent_session(self, user):
+        """handle_shutdown_container stops the agent RPC subprocess."""
+        sock = _mock_sock()
+        conn = _base_conn(user=user, ws=sock)
+        ws = await _create_workspace_with_acl(user["id"], "shutdown-agent")
+        conn.workspace_id = ws["id"]
+        conn.container_id = "cid"
+
+        session = wshandler.state.get_or_create_session(ws["id"])
+        await session.add_subscriber(sock, "cid")
+
+        # The on_workspace_killed callback also routes to reset_workspace,
+        # so disable it here to measure only the explicit teardown call.
+        old_cb = container.registry.on_workspace_killed
+        container.registry.on_workspace_killed = None
+        try:
+            with (
+                patch.object(
+                    container.registry,
+                    "stop_and_remove_container",
+                    new_callable=AsyncMock,
+                ),
+                patch(
+                    "klangk_backend.agent.stop_session",
+                    new_callable=AsyncMock,
+                ) as mock_stop,
+            ):
+                await conn.handle_shutdown_container()
+            mock_stop.assert_awaited_once_with(ws["id"])
+        finally:
+            container.registry.on_workspace_killed = old_cb
+            wshandler.state.sessions.pop(ws["id"], None)
 
     async def test_shutdown_clears_other_connections_container_id(self, user):
         sock1 = _mock_sock()


### PR DESCRIPTION
## Summary

Fixes #872.

The Pi RPC subprocess (`podman exec ... pi --mode rpc`) leaked after its container was killed (idle timeout, user shutdown). `reset_workspace` cancelled the agent asyncio task but never called `agent.stop_session`, and `handle_shutdown_container` likewise never stopped the agent session. `agent.stop_session` was only invoked on explicit delete/recreate via `api.py`.

## Changes

- **`wshandler.py` — `reset_workspace`**: now calls `agent.stop_session(workspace_id)`. This is the single funnel for *all* teardown paths (idle timeout via the `on_workspace_killed` callback wired in `main.py`, `logout_user`, and api.py delete/restart), so this one change covers idle timeout, logout, delete, and restart.
- **`wshandler.py` — `handle_shutdown_container`**: defensive explicit `agent.stop_session` call, matching the issue and robust if the kill callback is ever absent.
- **`api.py`**: removed the now-redundant `agent.stop_session` calls (and the unused `agent` import) from `delete_workspace`/`restart_workspace` — they existed only as a band-aid because `reset_workspace` didn't stop the agent.

`agent.stop_session` is idempotent (`_agents.pop(...)` + only stops if a session exists), so double-calls when the `on_workspace_killed` callback also routes to `reset_workspace` are harmless.

## Tests

- `test_wshandler.py`: added `test_reset_stops_agent_session` and `test_shutdown_stops_agent_session`.
- `test_api.py`: updated the `stop_session` patch target to `wshandler.agent` (where the call now originates).

All backend unit tests pass; `wshandler.py` remains at 100% coverage.