### PR TITLE
fix: require ownership to delete shared terminal

### DIFF
--- a/src/backend/klangk_backend/wshandler.py
+++ b/src/backend/klangk_backend/wshandler.py
@@ -1767,6 +1767,15 @@ class Connection:
         if not owner_user_id or not window_id:
             send_error(self.sock, "user_id and window_id required")
             return
+        # Only the terminal's owner — or the workspace owner — may
+        # delete it. The owner_user_id comes from the client and must
+        # not be trusted blindly, otherwise any collaborator with the
+        # share-terminals permission could close other users' windows.
+        if owner_user_id != self.user["id"]:
+            workspace = await model.get_workspace_by_id(self.workspace_id)
+            if workspace is None or workspace["user_id"] != self.user["id"]:
+                send_error(self.sock, "Permission denied")
+                return
         ws_session = state.get_session(self.workspace_id)
         if not ws_session:
             return

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -4548,7 +4548,7 @@ class TestShareWindowHandlers:
                 "klangk_backend.acl.check_permission", return_value=True
             ):
                 await conn.handle_delete_shared_terminal(
-                    {"user_id": "nobody", "window_id": "@99"}
+                    {"user_id": user["id"], "window_id": "@99"}
                 )
             calls = [c[0][0] for c in sock.send_json.call_args_list]
             assert any(
@@ -4556,6 +4556,77 @@ class TestShareWindowHandlers:
             )
         finally:
             wshandler.state.sessions.pop("ws-1", None)
+
+    async def test_delete_shared_terminal_other_user_denied(
+        self, user, temp_data_dir
+    ):
+        """A collaborator may not delete another user's terminal
+        (regression for #874)."""
+        other = await model.create_user(
+            "other@example.com", "x", verified=True
+        )
+        # Workspace owned by `other`; caller is neither the terminal
+        # owner nor the workspace owner.
+        workspace = await model.create_workspace(other["id"], "ws-other")
+        sock = _mock_sock()
+        conn = _base_conn(user=user, ws=sock)
+        conn.container_id = "cid"
+        conn.workspace_id = workspace["id"]
+        session = wshandler.state.get_or_create_session(workspace["id"])
+        session.terminal_windows[other["id"]] = [
+            {"name": "build", "index": 0, "id": "@0", "shared": True},
+        ]
+        try:
+            with patch(
+                "klangk_backend.acl.check_permission", return_value=True
+            ):
+                await conn.handle_delete_shared_terminal(
+                    {"user_id": other["id"], "window_id": "@0"}
+                )
+            calls = [c[0][0] for c in sock.send_json.call_args_list]
+            assert any(
+                "permission" in c.get("message", "").lower() for c in calls
+            )
+            # Window is untouched.
+            assert len(session.terminal_windows[other["id"]]) == 1
+        finally:
+            wshandler.state.sessions.pop(workspace["id"], None)
+            wshandler.state.connections.pop(sock, None)
+
+    async def test_delete_shared_terminal_workspace_owner_can_delete_others(
+        self, user, temp_data_dir
+    ):
+        """The workspace owner may delete another member's terminal."""
+        other = await model.create_user(
+            "other@example.com", "x", verified=True
+        )
+        # Workspace owned by the caller (`user`).
+        workspace = await model.create_workspace(user["id"], "ws-mine")
+        sock = _mock_sock()
+        conn = _base_conn(user=user, ws=sock)
+        conn.container_id = "cid"
+        conn.workspace_id = workspace["id"]
+        session = wshandler.state.get_or_create_session(workspace["id"])
+        session.terminal_windows[other["id"]] = [
+            {"name": "build", "index": 0, "id": "@0", "shared": True},
+        ]
+        await session.add_subscriber(sock, "cid")
+        wshandler.state.connections[sock] = conn
+        try:
+            with (
+                patch(
+                    "klangk_backend.acl.check_permission", return_value=True
+                ),
+                patch("klangk_backend.terminal.kill_joiner_sessions"),
+                patch("klangk_backend.terminal.close_window", return_value=[]),
+            ):
+                await conn.handle_delete_shared_terminal(
+                    {"user_id": other["id"], "window_id": "@0"}
+                )
+            assert session.terminal_windows[other["id"]] == []
+        finally:
+            wshandler.state.sessions.pop(workspace["id"], None)
+            wshandler.state.connections.pop(sock, None)
 
     async def test_delete_shared_terminal_error(self, user):
         sock = _mock_sock()
@@ -4604,7 +4675,7 @@ class TestShareWindowHandlers:
         conn.workspace_id = "no-session"
         with patch("klangk_backend.acl.check_permission", return_value=True):
             await conn.handle_delete_shared_terminal(
-                {"user_id": "x", "window_id": "@99"}
+                {"user_id": user["id"], "window_id": "@99"}
             )
         # Early return — no crash
 


### PR DESCRIPTION
## Summary

Fixes #874.

`handle_delete_shared_terminal` checked the `share-terminals` permission but trusted the client-supplied `user_id` (`owner_user_id = msg.get("user_id")`). Any collaborator with `share-terminals` could therefore close **other users'** tmux windows by sending an arbitrary `user_id`. The sibling handlers (`handle_share_window`, `handle_unshare_window`) already use `self.user["id"]` instead of trusting the client.

## Fix

After the existing permission check, verify the caller is authorized to delete this terminal — they must either **own the terminal** or be the **workspace owner**:

```python
if owner_user_id != self.user["id"]:
    workspace = await model.get_workspace_by_id(self.workspace_id)
    if workspace is None or workspace["user_id"] != self.user["id"]:
        send_error(self.sock, "Permission denied")
        return
```

This matches the fix suggested in the issue: verify the requesting user's ID matches the owner, or allow the workspace owner to delete other members' windows.

## Tests

- Updated `test_delete_shared_terminal_not_found` and `test_delete_shared_terminal_no_session` to use the caller's own `user_id` (they previously passed foreign IDs that now correctly hit the ownership check).
- Added `test_delete_shared_terminal_other_user_denied` — regression test: a non-owner collaborator is denied and the target window is left untouched.
- Added `test_delete_shared_terminal_workspace_owner_can_delete_others` — covers the workspace-owner branch.

Full `test_wshandler.py` + `test_agent.py` suites pass (375 passed); `wshandler.py` remains at 100% coverage.