### PR TITLE
fix: stop caching agent mention regex

### DIFF
--- a/src/backend/klangk_backend/wshandler.py
+++ b/src/backend/klangk_backend/wshandler.py
@@ -2354,21 +2354,22 @@ class Connection:
 # interjected: True after a different human spoke
 _agent_conversations: dict[str, dict] = {}
 
-# Lazily compiled after agent user is seeded.
-_agent_mention_re: re.Pattern | None = None
-
+# _ANY_MENTION_RE matches any @mention; the agent-specific regex is
+# compiled fresh per call (see _get_agent_mention_re).
 _ANY_MENTION_RE = re.compile(r"(?:^|(?<=\s))@\S+")
 
 
 def _get_agent_mention_re(handle: str) -> re.Pattern:
-    """Return the compiled agent mention regex, caching it."""
-    global _agent_mention_re
-    if _agent_mention_re is None:
-        _agent_mention_re = re.compile(
-            r"(?:^|(?<=\s))@" + re.escape(handle) + r"(?:\s|$)",
-            re.IGNORECASE,
-        )
-    return _agent_mention_re
+    """Return the compiled agent mention regex for *handle*.
+
+    The agent's handle can change at runtime (DB update), so this is
+    compiled fresh on every call rather than cached. Regex compilation
+    is cheap, and caching would return a stale pattern after a rename.
+    """
+    return re.compile(
+        r"(?:^|(?<=\s))@" + re.escape(handle) + r"(?:\s|$)",
+        re.IGNORECASE,
+    )
 
 
 async def _mentions_agent(text: str) -> bool:

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -43,9 +43,6 @@ def temp_data_dir(tmp_path, monkeypatch):
     wm.WORKSPACES_ROOT = tmp_path / "workspaces"
     # Clear agent caches so each test starts fresh.
     us.clear_agent_cache()
-    import klangk_backend.wshandler as wsh
-
-    wsh._agent_mention_re = None
     return tmp_path
 
 

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -4868,6 +4868,32 @@ class TestMentionsAgent:
         assert not await _mentions_agent("MrBoops without at sign")
         assert not await _mentions_agent("@MrBoopsy partial match")
 
+    async def test_follows_agent_handle_rename(self, agent_user):
+        """Detection must track a renamed agent handle, not a stale cache.
+
+        Regression test for #875: the compiled mention regex was cached
+        permanently and ignored handle changes, so @mentions kept using
+        the old handle forever.
+        """
+        import klangk_backend.model as us
+        from klangk_backend.wshandler import _mentions_agent
+
+        # Sanity: original handle is detected before the rename.
+        assert await _mentions_agent("@MrBoops hello")
+
+        # Rename the agent handle in the DB and drop the cached user.
+        async with us.transaction() as db:
+            await db.execute(
+                "UPDATE users SET handle = ? WHERE id = ?",
+                ("RenamedBot", us.AGENT_USER_ID),
+            )
+        us.clear_agent_cache()
+
+        # New handle is now detected ...
+        assert await _mentions_agent("@RenamedBot hello")
+        # ... and the stale old handle no longer matches.
+        assert not await _mentions_agent("@MrBoops hello")
+
 
 class TestAddressesOtherUser:
     async def test_starts_with_other_mention(self, agent_user):


### PR DESCRIPTION
## Summary
- `_get_agent_mention_re` compiled a regex from the agent handle and cached it in a module-level global, ignoring its `handle` argument after the first call
- When the agent's handle was renamed in the DB, the stale regex kept matching the old handle, so @mentions broke silently
- Drop the cache and compile fresh on each call; `agent_handle()` already reads the DB per call and regex compilation is cheap, so the cache added nothing but the staleness bug
- Remove the now-dead reset of the global in the test fixture
- Adds `test_follows_agent_handle_rename` proving detection tracks a renamed handle

Closes #875