### PR TITLE
fix: bound port allocation range and unblock event loop

### DIFF
--- a/src/backend/klangk_backend/model.py
+++ b/src/backend/klangk_backend/model.py
@@ -1,3 +1,4 @@
+import asyncio
 import hashlib
 import json
 import logging
@@ -1305,6 +1306,11 @@ async def add_port_allocations(workspace_id: str, ports: list[int]) -> None:
             )
 
 
+# Highest valid TCP port.  find_and_allocate_ports will not scan past
+# this, so an exhausted range fails fast instead of looping forever.
+MAX_PORT = 65535
+
+
 def _port_in_use(port: int) -> bool:
     """Check if a port is bound at the OS level."""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
@@ -1313,6 +1319,29 @@ def _port_in_use(port: int) -> bool:
             return False
         except OSError:
             return True
+
+
+def _scan_free_ports(start: int, count: int, used: set[int]) -> list[int]:
+    """Find ``count`` free ports at or after ``start``.
+
+    Skips ports already in ``used`` (DB-allocated) and ports reported as
+    bound by the OS.  This is synchronous because it performs blocking
+    ``socket.bind()`` checks; ``find_and_allocate_ports`` runs it in an
+    executor so the event loop is not stalled.  Raises ``ValueError`` if
+    fewer than ``count`` free ports are available before ``MAX_PORT``.
+    """
+    ports: list[int] = []
+    port = start
+    while len(ports) < count:
+        if port > MAX_PORT:
+            raise ValueError(
+                f"Could not allocate {count} free ports starting at "
+                f"{start}: exhausted at {MAX_PORT}"
+            )
+        if port not in used and not _port_in_use(port):
+            ports.append(port)
+        port += 1
+    return ports
 
 
 async def find_and_allocate_ports(
@@ -1324,12 +1353,12 @@ async def find_and_allocate_ports(
         rows = await cursor.fetchall()
         used = {row["port"] for row in rows}
 
-        ports = []
-        port = start
-        while len(ports) < count:
-            if port not in used and not _port_in_use(port):
-                ports.append(port)
-            port += 1
+        # The socket.bind() probe inside _scan_free_ports blocks, so run
+        # the scan in the default executor to avoid stalling the loop.
+        loop = asyncio.get_running_loop()
+        ports = await loop.run_in_executor(
+            None, _scan_free_ports, start, count, used
+        )
 
         for p in ports:
             await db.execute(

--- a/src/backend/tests/test_model.py
+++ b/src/backend/tests/test_model.py
@@ -415,6 +415,35 @@ class TestPortAllocations:
         ports = await model.find_and_allocate_ports(workspace["id"], 3, 9000)
         assert ports == [9000, 9002, 9004]
 
+    async def test_find_and_allocate_raises_when_exhausted(
+        self, workspace, monkeypatch
+    ):
+        """Exhausting the port range fails fast instead of looping forever."""
+        # Every port at/after start is treated as in-use; asking for any
+        # ports from a start of MAX_PORT guarantees immediate exhaustion.
+        monkeypatch.setattr(model, "_port_in_use", lambda p: True)
+        with pytest.raises(ValueError):
+            await model.find_and_allocate_ports(
+                workspace["id"], 1, model.MAX_PORT
+            )
+
+    async def test_find_and_allocate_respects_max_port(
+        self, workspace, user, monkeypatch
+    ):
+        """The scan never exceeds MAX_PORT and raises if it can't fulfil."""
+        # Only the last two ports are free; requesting two succeeds, three raises.
+        free = {model.MAX_PORT - 1, model.MAX_PORT}
+        monkeypatch.setattr(model, "_port_in_use", lambda p: p not in free)
+        ports = await model.find_and_allocate_ports(
+            workspace["id"], 2, model.MAX_PORT - 1
+        )
+        assert ports == [model.MAX_PORT - 1, model.MAX_PORT]
+        ws2 = await model.create_workspace(user["id"], "ws-max")
+        with pytest.raises(ValueError):
+            await model.find_and_allocate_ports(
+                ws2["id"], 3, model.MAX_PORT - 1
+            )
+
 
 class TestPortInUse:
     def test_free_port(self):


### PR DESCRIPTION
## Summary

Fixes #876.

`find_and_allocate_ports` in `model.py` had two problems:

1. **Infinite loop on exhaustion.** The `while len(ports) < count` loop incremented `port` with no upper limit. If every port from `start` through 65535 was DB-allocated or OS-bound, the loop spun forever.
2. **Blocking the event loop.** `_port_in_use()` calls synchronous `socket.bind()`, and it was invoked directly in the async path, stalling the loop once per candidate port.

## Changes

**`model.py`**
- Added a `MAX_PORT = 65535` ceiling.
- Extracted the scan into a synchronous `_scan_free_ports(start, count, used)` helper that raises `ValueError` when it can't fulfil `count` ports before `MAX_PORT` — so exhaustion fails fast.
- `find_and_allocate_ports` now runs the scan via `loop.run_in_executor(None, _scan_free_ports, ...)`, so the blocking `socket.bind()` probes run off the event loop. The scan still runs inside the DB transaction, preserving the atomic read-then-allocate guarantee.

The raised `ValueError` propagates up through `container.registry.allocate_ports` → `workspaces.create_workspace`, which already cleans up (deletes the DB record and directories) on any `Exception` from port allocation.

## Tests (`test_model.py`)
- `test_find_and_allocate_raises_when_exhausted` — all ports in-use from `MAX_PORT` ⇒ `ValueError`.
- `test_find_and_allocate_respects_max_port` — only the last two ports free: requesting 2 succeeds (`[65534, 65535]`), requesting 3 raises.

All 1569 backend unit tests pass; the new port code is fully covered.