### PR TITLE
fix: handle registration race for duplicate email

### DIFF
--- a/src/backend/klangk_backend/auth.py
+++ b/src/backend/klangk_backend/auth.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta, timezone
 
 import bcrypt
 from fastapi import Depends, HTTPException
+from sqlalchemy.exc import IntegrityError as SAIntegrityError
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jose import ExpiredSignatureError, JWTError, jwt
 from pydantic import BaseModel
@@ -211,7 +212,17 @@ async def register(
     validate_password_length(req.password)
 
     password_hash = hash_password(req.password)
-    user = await model.create_user(req.email, password_hash, verified=verified)
+    # The duplicate-email pre-check above is not atomic with the
+    # INSERT, so two concurrent registrations can both pass it and
+    # one hits the UNIQUE constraint. Catch that and return the same
+    # opaque error as the pre-check (avoids user enumeration and an
+    # unhandled HTTP 500).
+    try:
+        user = await model.create_user(
+            req.email, password_hash, verified=verified
+        )
+    except SAIntegrityError:
+        raise HTTPException(status_code=400, detail="Registration failed")
     token = None
     if verified:
         token = create_token(user["id"], user["email"])

--- a/src/backend/tests/test_auth.py
+++ b/src/backend/tests/test_auth.py
@@ -3,12 +3,14 @@
 import os
 import pytest
 from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
 from fastapi import HTTPException
 from fastapi.security import HTTPAuthorizationCredentials
 from jose import jwt
 
 from klangk_backend import auth, model
 from klangk_backend.exceptions import ConfigurationError
+from sqlalchemy.exc import IntegrityError as SAIntegrityError
 
 
 class TestPasswordHashing:
@@ -119,6 +121,25 @@ class TestRegister:
                 )
             )
         assert exc_info.value.status_code == 400
+
+    async def test_register_race_integrity_error(self, db):
+        """If a concurrent registration wins the UNIQUE constraint,
+        the loser must get a clean 400 rather than an unhandled 500
+        (regression for #877)."""
+        with patch(
+            "klangk_backend.model.create_user",
+            side_effect=SAIntegrityError(
+                "statement", {}, Exception("UNIQUE constraint failed")
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await auth.register(
+                    auth.RegisterRequest(
+                        email="race@example.com", password="pass1234"
+                    )
+                )
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail == "Registration failed"
 
     async def test_register_invalid_email(self, db):
         with pytest.raises(HTTPException) as exc_info:


### PR DESCRIPTION
## Summary

Fixes #877.

`register()` in `auth.py` performed a duplicate-email pre-check (`get_user_by_email`) and then inserted the user in a **separate** transaction. Two concurrent registrations with the same email could both pass the check; the loser then hit the UNIQUE constraint and raised an unhandled `IntegrityError`, producing an HTTP 500 instead of a clean error.

## Fix

Catch `SAIntegrityError` from `create_user` and return a clean error, following the codebase's existing convention (`api.py` already imports and catches `sqlalchemy.exc.IntegrityError as SAIntegrityError`):

```python
try:
    user = await model.create_user(
        req.email, password_hash, verified=verified
    )
except SAIntegrityError:
    raise HTTPException(status_code=400, detail="Registration failed")
```

### Why a 400 "Registration failed" instead of 409 "Email already registered"

The issue suggested either catching the error or a 409. I chose to return the **same opaque `400 "Registration failed"`** the existing pre-check already uses, rather than a distinct 409. This keeps the race path consistent with the normal duplicate path and avoids leaking which emails are registered (user enumeration). Happy to switch to 409 if you'd prefer the explicit conflict semantics.

## Tests

- Added `test_register_race_integrity_error` — mocks `create_user` to raise `SAIntegrityError` (simulating the lost race) and asserts a clean `400 "Registration failed"` rather than an unhandled 500.

`test_auth.py`: 89 passed; `auth.py` at 99% coverage (the 2 uncovered lines are pre-existing JWT-validation branches unrelated to `register`).