### PR TITLE
fix: prevent orphaned agent runs on concurrent @mentions

### DIFF
--- a/src/backend/klangk_backend/wshandler.py
+++ b/src/backend/klangk_backend/wshandler.py
@@ -553,9 +553,7 @@ class WebSocketState:
 
         # Clean up module-level agent state for this workspace.
         _agent_conversations.pop(workspace_id, None)
-        task = _agent_tasks.pop(workspace_id, None)
-        if task and not task.done():
-            task.cancel()
+        _cancel_agent_task(workspace_id)
         # Stop the Pi RPC subprocess so it doesn't outlive the container.
         await agent.stop_session(workspace_id)
 
@@ -2086,6 +2084,9 @@ class Connection:
             del _agent_conversations[workspace_id]
 
         if should_route and self.container_id:
+            # One agent-run slot per workspace: cancel any in-flight run
+            # so concurrent @mentions don't orphan the earlier task.
+            _cancel_agent_task(workspace_id)
             _agent_tasks[workspace_id] = asyncio.create_task(
                 _handle_agent_mention(workspace_id, self.container_id, text)
             )
@@ -2148,9 +2149,7 @@ class Connection:
         workspace_id = self.workspace_id
         if not workspace_id:
             return
-        task = _agent_tasks.pop(workspace_id, None)
-        if task and not task.done():
-            task.cancel()
+        _cancel_agent_task(workspace_id)
 
     async def handle_ui_ready(self) -> None:
         if self.workspace_id:
@@ -2419,6 +2418,29 @@ async def _addresses_other_user(text: str) -> bool:
 _agent_tasks: dict[str, asyncio.Task] = {}
 
 
+def _cancel_agent_task(workspace_id: str) -> None:
+    """Cancel and drop any in-flight agent run for a workspace.
+
+    There is a single agent-run slot per workspace, so a new run must
+    supersede (cancel) any still-running one — otherwise the earlier
+    task is orphaned and can no longer be reached by an abort.
+    """
+    task = _agent_tasks.pop(workspace_id, None)
+    if task is not None and not task.done():
+        task.cancel()
+
+
+def _drop_agent_task_if_current(workspace_id: str) -> None:
+    """Remove the workspace's agent-task entry only if it is *this* run.
+
+    A superseding mention cancels the prior run and installs a newer
+    task, so a finishing (or cancelled) run must not pop an entry that
+    now belongs to its replacement.
+    """
+    if _agent_tasks.get(workspace_id) is asyncio.current_task():
+        _agent_tasks.pop(workspace_id, None)
+
+
 async def _handle_agent_mention(
     workspace_id: str, container_id: str, user_text: str
 ) -> None:
@@ -2488,7 +2510,7 @@ async def _handle_agent_mention(
         if session:
             session.broadcast({"type": "agent_thinking", "thinking": False})
             session.broadcast({"type": "chat_message", **sys_msg})
-        _agent_tasks.pop(workspace_id, None)
+        _drop_agent_task_if_current(workspace_id)
         return
     except Exception:
         logger.exception("Agent error for workspace %s", workspace_id)
@@ -2507,7 +2529,7 @@ async def _handle_agent_mention(
     if session:
         session.broadcast({"type": "agent_thinking", "thinking": False})
         session.broadcast({"type": "chat_message", **agent_msg})
-    _agent_tasks.pop(workspace_id, None)
+    _drop_agent_task_if_current(workspace_id)
 
 
 async def handle_websocket(websocket: WebSocket) -> None:

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -5572,6 +5572,62 @@ class TestChatSend:
         finally:
             await session.remove_subscriber(sock)
 
+    async def test_chat_send_mention_supersedes_prior_run(
+        self, workspace, user, agent_user
+    ):
+        """A second rapid @mention cancels the prior in-flight run, and abort
+        then reaches the latest run instead of an orphaned task."""
+        from klangk_backend.wshandler import state
+
+        sock1 = _mock_sock()
+        sock2 = _mock_sock()
+        conn1 = _base_conn(user=user, ws=sock1)
+        conn1.workspace_id = workspace["id"]
+        conn1.container_id = "cid"
+        user2 = {
+            "id": "uid-second",
+            "email": "second@test.com",
+            "handle": "second",
+        }
+        conn2 = _base_conn(user=user2, ws=sock2)
+        conn2.workspace_id = workspace["id"]
+        conn2.container_id = "cid"
+
+        session = state.get_or_create_session(workspace["id"])
+        await session.add_subscriber(sock1, "cid")
+        await session.add_subscriber(sock2, "cid")
+
+        async def slow_mention(workspace_id, container_id, text):
+            await asyncio.sleep(999)
+
+        try:
+            with patch(
+                "klangk_backend.wshandler._handle_agent_mention",
+                new=slow_mention,
+            ):
+                await conn1.handle_chat_send({"message": "@MrBoops first"})
+                task1 = wshandler._agent_tasks[workspace["id"]]
+                # A second mention from a different user must supersede
+                # task1 rather than orphaning it.
+                await conn2.handle_chat_send({"message": "@MrBoops second"})
+                task2 = wshandler._agent_tasks[workspace["id"]]
+                assert task2 is not task1
+                await asyncio.sleep(0)
+                assert task1.cancelled()
+                # abort reaches the now-current run.
+                await conn2.handle_chat_agent_abort()
+                assert workspace["id"] not in wshandler._agent_tasks
+                await asyncio.sleep(0)
+                assert task2.cancelled()
+        finally:
+            await session.remove_subscriber(sock1)
+            await session.remove_subscriber(sock2)
+            for t in list(wshandler._agent_tasks.values()):
+                if not t.done():
+                    t.cancel()
+            wshandler._agent_tasks.clear()
+            wshandler._agent_conversations.pop(workspace["id"], None)
+
     async def test_chat_history_on_connect(self, user, agent_user):
         from klangk_backend import model
 
@@ -6691,6 +6747,37 @@ class TestHandleChatAgentAbort:
         conn.workspace_id = workspace["id"]
         wshandler._agent_tasks.pop(workspace["id"], None)
         await conn.handle_chat_agent_abort()
+
+    async def test_drop_if_current_removes_own_entry(self):
+        """A finishing run drops the entry only when it is the current task."""
+        ws_id = "ws-drop-self"
+        wshandler._agent_tasks[ws_id] = asyncio.current_task()
+        try:
+            wshandler._drop_agent_task_if_current(ws_id)
+            assert ws_id not in wshandler._agent_tasks
+        finally:
+            wshandler._agent_tasks.pop(ws_id, None)
+
+    async def test_drop_if_current_keeps_other_entry(self):
+        """A superseded (older) run must not pop a newer task's entry."""
+        ws_id = "ws-drop-other"
+
+        async def other():
+            await asyncio.sleep(999)
+
+        other_task = asyncio.create_task(other())
+        wshandler._agent_tasks[ws_id] = other_task
+        try:
+            wshandler._drop_agent_task_if_current(ws_id)
+            # Entry belongs to a different task; left intact.
+            assert wshandler._agent_tasks[ws_id] is other_task
+        finally:
+            other_task.cancel()
+            try:
+                await other_task
+            except asyncio.CancelledError:
+                pass
+            wshandler._agent_tasks.pop(ws_id, None)
 
 
 class TestPresenceIncludesAgent:


### PR DESCRIPTION
## Summary

Fixes #889.

`_agent_tasks` is keyed by `workspace_id` — one slot per workspace, shared across all users. In a shared workspace, two near-simultaneous `@agent` mentions from different users raced: the second assignment overwrote the first task's dict entry, **orphaning** the earlier in-flight run. Consequences:

- `handle_chat_agent_abort` does `_agent_tasks.pop(workspace_id, …)` and could only ever see/cancel the **latest** task. The orphaned earlier run ran to completion, continuing to stream output after the user expected it to stop.

## Changes (`wshandler.py`)

I went with the issue's "at most one in-flight run" option (consistent with `_agent_conversations`, which already resets on a new `@mention`, and with the single Pi RPC session per workspace whose `send_prompt` serializes on a lock):

- **`handle_chat_send`**: cancel any existing in-flight task for the workspace before starting a new one — concurrent mentions now supersede instead of orphan.
- **`_handle_agent_mention`**: drop its `_agent_tasks` entry only if it is still the current task, so a superseded (cancelled) run finishing later does **not** pop the newer task's entry. (Both finish sites use the guard: normal completion and the `AgentProcessDied` branch.)
- Both behaviors share two small module-level helpers: `_cancel_agent_task` (pop + cancel, now also used by `reset_workspace` and `handle_chat_agent_abort` to dedupe the existing pattern) and `_drop_agent_task_if_current`.

`stop_session`/`agent.stop_session` interaction is unchanged.

## Tests (`test_wshandler.py`)

- `test_chat_send_mention_supersedes_prior_run` — regression from the issue: two users `@mention` in quick succession; the earlier task is cancelled (not orphaned) and `abort` then reaches the latest running task.
- `test_drop_if_current_removes_own_entry` / `test_drop_if_current_keeps_other_entry` — cover the guard's two branches (a finishing run drops its own entry but leaves a newer task's entry intact).

All 1576 backend unit tests pass; `wshandler.py` remains at 100% coverage.