### PR TITLE
fix(emailsvc): HTML-escape invited_by_email in invitation emails

### DIFF
--- a/src/backend/klangk_backend/emailsvc.py
+++ b/src/backend/klangk_backend/emailsvc.py
@@ -1,6 +1,7 @@
 """Email sending via SMTP or local sendmail."""
 
 import asyncio
+import html
 import logging
 import os
 import shutil
@@ -196,6 +197,11 @@ async def send_invitation_email(
     to: str, invite_url: str, invited_by_email: str
 ) -> None:
     """Send an invitation email with the given registration URL."""
+    # Escape the inviter's email for safe interpolation into the HTML
+    # body. The email validator permits characters such as '<', '>', and
+    # '"' in the local part, so an unescaped value could be used to inject
+    # markup/script into invitation emails sent to other users.
+    invited_by_html = html.escape(invited_by_email)
     text_body = (
         f"{invited_by_email} has invited you to join Klangk.\n\n"
         "Click the link below to set your password and activate "
@@ -212,7 +218,7 @@ async def send_invitation_email(
         'line-height:48px;font-size:24px">&#128062;</span>'
         '<h2 style="margin:8px 0 0">Klangk</h2>'
         "</div>"
-        f"<p><strong>{invited_by_email}</strong> has invited you to "
+        f"<p><strong>{invited_by_html}</strong> has invited you to "
         "join Klangk.</p>"
         "<p>Click the link below to set your password and activate "
         "your account:</p>"

--- a/src/backend/tests/test_emailsvc.py
+++ b/src/backend/tests/test_emailsvc.py
@@ -276,3 +276,27 @@ class TestSendInvitationEmail:
                 "admin@example.com",
             )
         mock_smtp.assert_awaited_once()
+
+    async def test_invited_by_email_html_escaped(self, monkeypatch):
+        # A crafted inviter email with HTML/marker characters must be
+        # escaped in the HTML body so it cannot inject markup or script.
+        # See https://github.com/mcdonc/klangk/issues/878
+        monkeypatch.delenv("KLANGK_SMTP_HOST", raising=False)
+        mock_sendmail = AsyncMock()
+        crafted = 'admin"><img/src=x onerror=alert(1)>@example.com'
+        with patch.object(emailsvc, "send_via_sendmail", mock_sendmail):
+            await emailsvc.send_invitation_email(
+                "invited@example.com",
+                "https://klangk.example.com/#/accept-invite?token=abc",
+                crafted,
+            )
+        msg = mock_sendmail.call_args[0][0]
+        parts = list(msg.iter_parts())
+        html_part = parts[1].get_content()
+        # The crafted payload must not form a live HTML element; angle
+        # brackets and quotes must be escaped so the email renders as
+        # inert text rather than injecting markup/script.
+        assert "<img" not in html_part
+        assert "&lt;img" in html_part
+        assert 'admin"&gt;' not in html_part
+        assert "admin&quot;&gt;" in html_part


### PR DESCRIPTION
## Summary

Fixes #878.

`send_invitation_email` in `emailsvc.py` interpolated `invited_by_email` directly into the HTML body (`<strong>{invited_by_email}</strong>`). The email validator permits characters like `<`, `>`, and `"` in the local part, so an admin with a crafted email address could inject HTML/JS into invitation emails sent to other users.

## Changes

- Escape the inviter's email with `html.escape()` before interpolating it into the HTML body.
- The plain-text body is left as-is since it is not HTML.
- Add `test_invited_by_email_html_escaped`, which feeds a crafted payload (`admin"><img/src=x onerror=alert(1)>@example.com`) and asserts the result is escaped (`&lt;img`, `admin&quot;&gt;`) rather than forming a live element.

## Test plan

- [x] `python -m pytest tests/test_emailsvc.py` — all 24 tests pass; `emailsvc.py` at 100% coverage.
- [x] Full backend suite: 1571 passed, 0 failures.
- [x] Pre-commit hooks pass (ruff format/check, prettier, trufflehog).