### PR TITLE
fix: guard verify_password against NULL hash in 4 auth endpoints

### DIFF
--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -315,8 +315,12 @@ async def resend_verification(
 ):
     """Resend verification email. Requires email+password to prevent abuse."""
     user = await model.get_user_by_email(req.email)
-    if user is None or not auth.verify_password(
-        req.password, user["password_hash"]
+    # OIDC-only users have no password hash; treat that as invalid
+    # credentials rather than letting verify_password crash on None.
+    if (
+        user is None
+        or not user.get("password_hash")
+        or not auth.verify_password(req.password, user["password_hash"])
     ):
         raise HTTPException(status_code=401, detail="Invalid credentials")
     if user.get("verified"):
@@ -446,6 +450,13 @@ async def change_password(
 ):
     """Change password. Requires current password."""
     stored = await model.get_user_by_email(user["email"])
+    # OIDC-only users have no password; their credentials are managed
+    # by their identity provider and must not crash on a NULL hash.
+    if stored is not None and not stored.get("password_hash"):
+        raise HTTPException(
+            status_code=403,
+            detail="Account is managed by your identity provider",
+        )
     if stored is None or not auth.verify_password(
         req.current_password, stored["password_hash"]
     ):
@@ -471,6 +482,13 @@ async def change_email(
 ):
     """Change email. Requires password. Marks account as unverified."""
     stored = await model.get_user_by_email(user["email"])
+    # OIDC-only users have no password; their credentials are managed
+    # by their identity provider and must not crash on a NULL hash.
+    if stored is not None and not stored.get("password_hash"):
+        raise HTTPException(
+            status_code=403,
+            detail="Account is managed by your identity provider",
+        )
     if stored is None or not auth.verify_password(
         req.password, stored["password_hash"]
     ):
@@ -510,6 +528,13 @@ async def change_handle(
 ):
     """Change the current user's handle. Requires password confirmation."""
     stored = await model.get_user_by_email(user["email"])
+    # OIDC-only users have no password; their credentials are managed
+    # by their identity provider and must not crash on a NULL hash.
+    if stored is not None and not stored.get("password_hash"):
+        raise HTTPException(
+            status_code=403,
+            detail="Account is managed by your identity provider",
+        )
     if stored is None or not auth.verify_password(
         req.password, stored["password_hash"]
     ):

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -52,6 +52,18 @@ async def _auth_headers(client):
     return {"Authorization": f"Bearer {token}"}
 
 
+async def _oidc_user_headers(email="oidc@example.com"):
+    """Auth headers for an OIDC-only user (password_hash is NULL).
+
+    OIDC users can't use /auth/login, so we mint a token directly,
+    mirroring what the OIDC callback does.  Used to exercise the
+    authenticated endpoints that must not 500 on a NULL hash (#890).
+    """
+    user = await model.create_user(email, None, verified=True, provider="oidc")
+    token = auth.create_token(user["id"], user["email"])
+    return {"Authorization": f"Bearer {token}"}
+
+
 # --- Health ---
 
 
@@ -528,6 +540,18 @@ class TestResendVerification:
         )
         assert resp.status_code == 401
 
+    async def test_resend_oidc_only_user_no_password(self, client, db):
+        """OIDC-only users have no password hash; must 401, not 500 (#890)."""
+        await model.create_user(
+            "oidc@example.com", None, verified=False, provider="oidc"
+        )
+        resp = await client.post(
+            "/api/v1/auth/resend-verification",
+            json={"email": "oidc@example.com", "password": "anything"},
+        )
+        assert resp.status_code == 401
+        assert resp.json()["detail"] == "Invalid credentials"
+
     async def test_resend_already_verified(self, client, admin_user):
         resp = await client.post(
             "/api/v1/auth/resend-verification",
@@ -795,6 +819,23 @@ class TestChangePassword:
         )
         assert resp.status_code == 401
 
+    async def test_change_password_oidc_only_user(self, client, db):
+        """OIDC-only users have no password; must 403, not 500 (#890)."""
+        headers = await _oidc_user_headers()
+        resp = await client.post(
+            "/api/v1/auth/change-password",
+            json={
+                "current_password": "anything",
+                "new_password": "newpass",
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 403
+        assert (
+            resp.json()["detail"]
+            == "Account is managed by your identity provider"
+        )
+
 
 class TestChangeEmail:
     async def test_change_email_success(self, client, user):
@@ -872,6 +913,23 @@ class TestChangeEmail:
             },
         )
         assert resp.status_code == 401
+
+    async def test_change_email_oidc_only_user(self, client, db):
+        """OIDC-only users have no password; must 403, not 500 (#890)."""
+        headers = await _oidc_user_headers()
+        resp = await client.post(
+            "/api/v1/auth/change-email",
+            json={
+                "email": "new@example.com",
+                "password": "anything",
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 403
+        assert (
+            resp.json()["detail"]
+            == "Account is managed by your identity provider"
+        )
 
 
 # --- Workspace routes ---
@@ -6432,6 +6490,20 @@ class TestHandleEndpoints:
             headers=headers,
         )
         assert resp.status_code == 401
+
+    async def test_change_handle_oidc_only_user(self, client, db):
+        """OIDC-only users have no password; must 403, not 500 (#890)."""
+        headers = await _oidc_user_headers()
+        resp = await client.post(
+            "/api/v1/auth/change-handle",
+            json={"handle": "good-handle", "password": "anything"},
+            headers=headers,
+        )
+        assert resp.status_code == 403
+        assert (
+            resp.json()["detail"]
+            == "Account is managed by your identity provider"
+        )
 
     async def test_admin_change_user_handle(self, client, admin_user, user):
         admin_resp = await client.post(


### PR DESCRIPTION
## Summary
- Same root cause as #869 (which only fixed `login()`): four more endpoints called `auth.verify_password(req.password, user["password_hash"])` without checking for a `None` hash
- OIDC-only users have `password_hash = NULL`, so `verify_password` did `hashed.encode()` → `AttributeError` → **HTTP 500** instead of a clean response
- `POST /auth/resend-verification`: short-circuit on missing hash, return **401** `Invalid credentials` (mirrors #869; doesn't reveal OIDC status)
- `POST /auth/change-password`, `change-email`, `change-handle`: return **403** `Account is managed by your identity provider` (these authenticated actions aren't available to OIDC-only users)
- Adds `_oidc_user_headers` test helper (mints a token like the OIDC callback, since OIDC users can't use `/auth/login`) and one regression test per endpoint, each verified to reproduce the original 500 against unpatched code

Closes #890