### PR TITLE
fix: evict expired resend/password-reset rate-limit entries

### DIFF
--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -287,6 +287,23 @@ async def verify_email(token: str):
     return {"status": "verified", "access_token": access_token}
 
 
+def _prune_timestamps(
+    timestamps: dict[str, float], cooldown_seconds: float, now: float
+) -> None:
+    """Evict rate-limit entries older than their cooldown window.
+
+    The resend/reset rate-limit dicts are keyed by email and gain an
+    entry on every request. Without eviction they grow without bound
+    and retain raw email addresses (PII) for the process lifetime,
+    long past the short cooldown window they're needed for. Opportunistically
+    sweeping expired entries on each access bounds both size and retention.
+    """
+    cutoff = now - cooldown_seconds
+    expired = [email for email, ts in timestamps.items() if ts < cutoff]
+    for email in expired:
+        del timestamps[email]
+
+
 _resend_timestamps: dict[str, float] = {}
 RESEND_COOLDOWN_SECONDS = 60
 
@@ -307,6 +324,7 @@ async def resend_verification(
 
     # Rate limit: one resend per email per minute
     now = time.time()
+    _prune_timestamps(_resend_timestamps, RESEND_COOLDOWN_SECONDS, now)
     last = _resend_timestamps.get(req.email, 0)
     if now - last < RESEND_COOLDOWN_SECONDS:
         raise HTTPException(
@@ -346,6 +364,7 @@ async def forgot_password(req: ForgotPasswordRequest, request: Request):
 
     # Rate limit: one reset email per address per minute
     now = time.time()
+    _prune_timestamps(_reset_timestamps, RESET_COOLDOWN_SECONDS, now)
     last = _reset_timestamps.get(req.email, 0)
     if now - last < RESET_COOLDOWN_SECONDS:
         raise HTTPException(

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -463,6 +463,32 @@ class TestResendVerification:
             "unverified@example.com", password_hash, verified=False
         )
 
+    def test_prune_timestamps_evicts_expired_keeps_recent(self):
+        """_prune_timestamps drops entries older than the cooldown only."""
+        import time
+
+        now = time.time()
+        cooldown = 60
+        ts = {
+            "old@a.com": now - cooldown - 5,  # expired
+            "edge@a.com": now - cooldown - 1,  # expired
+            "fresh@a.com": now - 10,  # within window
+            "recent@a.com": now,  # within window
+        }
+        api._prune_timestamps(ts, cooldown, now)
+        assert "old@a.com" not in ts
+        assert "edge@a.com" not in ts
+        assert "fresh@a.com" in ts
+        assert "recent@a.com" in ts
+
+    def test_prune_timestamps_empty_dict(self):
+        """Pruning an empty dict is a no-op."""
+        import time
+
+        ts: dict[str, float] = {}
+        api._prune_timestamps(ts, 60, time.time())
+        assert ts == {}
+
     async def test_resend_success(self, client, db):
         await self._create_unverified_user()
         with patch.object(
@@ -540,6 +566,44 @@ class TestResendVerification:
         assert resp2.status_code == 429
         api._resend_timestamps.pop("unverified@example.com", None)
 
+    async def test_resend_prunes_expired_entries(self, client, db):
+        # Stale rate-limit state from parallel test workers
+        api._resend_timestamps.clear()
+        await self._create_unverified_user()
+        with patch.object(
+            api.emailsvc, "send_verification_email", new_callable=AsyncMock
+        ):
+            resp1 = await client.post(
+                "/api/v1/auth/resend-verification",
+                json={
+                    "email": "unverified@example.com",
+                    "password": "testpass",
+                },
+            )
+            assert resp1.status_code == 200
+            # Backdate the entry past the cooldown window.
+            import time
+
+            api._resend_timestamps["unverified@example.com"] = (
+                time.time() - api.RESEND_COOLDOWN_SECONDS - 1
+            )
+            # Also seed an unrelated expired address to confirm it is evicted.
+            api._resend_timestamps["stale@example.com"] = (
+                time.time() - api.RESEND_COOLDOWN_SECONDS - 1
+            )
+            resp2 = await client.post(
+                "/api/v1/auth/resend-verification",
+                json={
+                    "email": "unverified@example.com",
+                    "password": "testpass",
+                },
+            )
+        # Expired entry no longer rate-limits, and unrelated stale entry
+        # was swept on access.
+        assert resp2.status_code == 200
+        assert "stale@example.com" not in api._resend_timestamps
+        api._resend_timestamps.clear()
+
 
 class TestForgotPassword:
     async def _create_user(self):
@@ -589,6 +653,34 @@ class TestForgotPassword:
             )
         assert resp2.status_code == 429
         api._reset_timestamps.pop("forgot@example.com", None)
+
+    async def test_forgot_prunes_expired_entries(self, client, db):
+        api._reset_timestamps.clear()
+        await self._create_user()
+        with patch.object(
+            api.emailsvc, "send_password_reset_email", new_callable=AsyncMock
+        ):
+            resp1 = await client.post(
+                "/api/v1/auth/forgot-password",
+                json={"email": "forgot@example.com"},
+            )
+            assert resp1.status_code == 200
+            # Backdate the entry and seed an unrelated expired address.
+            import time
+
+            api._reset_timestamps["forgot@example.com"] = (
+                time.time() - api.RESET_COOLDOWN_SECONDS - 1
+            )
+            api._reset_timestamps["stale@example.com"] = (
+                time.time() - api.RESET_COOLDOWN_SECONDS - 1
+            )
+            resp2 = await client.post(
+                "/api/v1/auth/forgot-password",
+                json={"email": "forgot@example.com"},
+            )
+        assert resp2.status_code == 200
+        assert "stale@example.com" not in api._reset_timestamps
+        api._reset_timestamps.clear()
 
 
 class TestResetPassword:


### PR DESCRIPTION
## Summary

Fixes #888.

`_resend_timestamps` and `_reset_timestamps` (in-memory rate-limit dicts keyed by email) gained an entry on every request but **never evicted** them. Each distinct email that ever hit `POST /auth/resend-verification` or `POST /auth/forgot-password` accumulated a permanent in-memory entry for the process lifetime. Two problems called out in the issue:

1. **Slow unbounded growth** — proportional to the number of distinct emails seen, including attacker-supplied ones (`forgot-password` is public and doesn't reveal whether the account exists).
2. **Indefinite PII retention** — raw email addresses held in memory with no TTL, long past the 60s cooldown window they're actually needed for.

## Changes (`api.py`)

Implemented the issue's suggested minimum — **opportunistic purge of expired keys on access**:

- New `_prune_timestamps(timestamps, cooldown_seconds, now)` helper that drops any entry older than its cooldown window.
- Called from both `resend_verification` and `forgot_password`, **before** the rate-limit lookup, so the dicts stay bounded in size and PII retention.

The cooldown enforcement itself is unchanged (`now - last < COOLDOWN_SECONDS`). Pruning before the lookup is correct: an expired entry is removed → lookup returns `0` → no rate limit (cooldown has elapsed); an in-window entry is kept → rate limiting applies as before.

## Tests (`test_api.py`)

- `test_prune_timestamps_evicts_expired_keeps_recent` / `test_prune_timestamps_empty_dict` — direct unit tests of the helper (expired evicted, recent kept, empty dict no-op); these fully cover `_prune_timestamps` line-by-line.
- `test_resend_prunes_expired_entries` / `test_forgot_prunes_expired_entries` — integration: backdate the entry past the cooldown, resend/reset succeeds again (200, not 429), and an unrelated seeded stale address is swept on access.

All 1580 backend unit tests pass; no regressions.