### PR TITLE
refactor(ws): remove unreachable time-based reconnect give-up

### DIFF
--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -60,12 +60,6 @@ class WsClient extends ChangeNotifier {
   /// is cheap and fast — we just need to detect when the server is back.
   static const int _maxBackoffSeconds = 5;
 
-  /// Give up auto-reconnecting after this duration.
-  static const Duration _reconnectTimeout = Duration(minutes: 5);
-
-  /// When the current reconnect cycle started.
-  DateTime? _reconnectStartedAt;
-
   /// Workspace ID to rejoin after reconnecting.
   String? _pendingWorkspaceId;
 
@@ -76,10 +70,6 @@ class WsClient extends ChangeNotifier {
   /// Override for testing to control reconnect backoff delay.
   @visibleForTesting
   static Duration Function(int attempt)? testBackoffOverride;
-
-  /// Override for testing to shorten the reconnect timeout.
-  @visibleForTesting
-  static Duration? testReconnectTimeout;
 
   /// Inject a pre-connected channel for testing.
   @visibleForTesting
@@ -277,7 +267,6 @@ class WsClient extends ChangeNotifier {
             _userHome = json['userHome'] as String?;
             _reconnecting = false;
             _reconnectAttempt = 0;
-            _reconnectStartedAt = null;
             _pendingWorkspaceId = null;
             _startHeartbeat();
             notifyListeners();
@@ -562,20 +551,6 @@ class WsClient extends ChangeNotifier {
   void _scheduleReconnect() {
     if (!_autoReconnect || _reconnecting || _reconnectTimer != null) return;
 
-    // Record when the reconnect cycle started.
-    _reconnectStartedAt ??= DateTime.now();
-
-    // Give up after the timeout — stop auto-reconnect and let the UI
-    // show "Disconnected" with a manual reconnect button.
-    final timeout = testReconnectTimeout ?? _reconnectTimeout;
-    if (DateTime.now().difference(_reconnectStartedAt!) >= timeout) {
-      _autoReconnect = false;
-      _reconnecting = false;
-      _reconnectStartedAt = null;
-      notifyListeners();
-      return;
-    }
-
     _reconnectAttempt++;
     if (_reconnectAttempt > 25) {
       _autoReconnect = false;
@@ -618,7 +593,6 @@ class WsClient extends ChangeNotifier {
     _autoReconnect = false;
     _reconnecting = false;
     _reconnectAttempt = 0;
-    _reconnectStartedAt = null;
     _pendingWorkspaceId = null;
     _reconnectTimer?.cancel();
     _reconnectTimer = null;

--- a/src/frontend/test/ws_client_test.dart
+++ b/src/frontend/test/ws_client_test.dart
@@ -371,7 +371,6 @@ void main() {
     tearDown(() {
       WsClient.testChannelFactory = null;
       WsClient.testBackoffOverride = null;
-      WsClient.testReconnectTimeout = null;
     });
 
     test('server close triggers auto-reconnect when workspace was connected',
@@ -717,48 +716,6 @@ void main() {
       client.dispose();
       expect(client.reconnecting, isFalse);
       expect(channels.length, 1); // no reconnect attempt was made
-    });
-
-    test('gives up reconnecting after timeout', () async {
-      final auth = AuthService();
-      await Future.delayed(Duration.zero);
-
-      // Zero backoff so reconnects fire immediately; zero timeout so
-      // the second attempt exceeds the deadline.
-      WsClient.testBackoffOverride = (_) => Duration.zero;
-      WsClient.testReconnectTimeout = Duration.zero;
-
-      final client = WsClient();
-      client.updateAuth(auth);
-      await client.connect();
-      client.connectWorkspace('ws-1');
-      channels[0]
-          .serverSend({'type': 'workspace_ready', 'workspaceId': 'ws-1'});
-      await Future.delayed(Duration.zero);
-
-      // Make all future channels fail.
-      WsClient.testChannelFactory = (_) {
-        final ch = _FakeWebSocketChannel()..failReady = true;
-        channels.add(ch);
-        return ch;
-      };
-
-      // Disconnect → first reconnect attempt fires.
-      channels[0].serverClose();
-      await Future.delayed(Duration.zero);
-
-      // Let the first attempt fire and fail, then the second schedule
-      // check triggers the timeout.
-      await Future.delayed(Duration.zero);
-      await Future.delayed(Duration.zero);
-      await Future.delayed(Duration.zero);
-
-      // Auto-reconnect should have given up.
-      expect(client.reconnecting, isFalse);
-
-      WsClient.testReconnectTimeout = null;
-      client.disconnect();
-      client.dispose();
     });
 
     test('backoff delay override is called with correct attempt', () async {


### PR DESCRIPTION
## Summary

The WebSocket reconnect loop had **two independent give-up mechanisms**, and one is provably unreachable dead code. This PR removes it.

### History (why both exist)

1. **#419 / #425** added a **5-minute time-based cap** when backoff was capped at **30s** — so 5 minutes was a meaningful bound.
2. **#813** added a **count-based cap** (25 attempts), which the UI surfaces via `"Reconnecting (attempt N)..."`.
3. **#709** later cut the backoff cap **30s → 5s** "for faster recovery."

### Why the time cap is now unreachable

With backoff capped at 5s, the count cap (25 attempts) **always fires first**. Even with worst-case jitter on every single attempt, 25 attempts complete in **≤121s (~2 min)** — well under the 300s deadline:

| attempt | base | cumulative |
|---|---|---|
| 1 | 2s | 2s |
| 2 | 4s | 6s |
| 3–25 | 5s each | 121s total |

So the time-based cap and all its supporting code never execute.

## What's removed (69 lines)

- `_reconnectTimeout` (5-min constant)
- `_reconnectStartedAt` (cycle-start field)
- `testReconnectTimeout` (test override)
- The unreachable `if (... >= timeout)` branch in `_scheduleReconnect`
- Its housekeeping resets in `workspace_ready` and `_cancelReconnect`
- The `'gives up reconnecting after timeout'` test (only passed by forcing `testReconnectTimeout = Duration.zero`)

The **count-based cap (`> 25` attempts) is unchanged** and remains the live give-up path.

## Verification

- `flutter test test/ws_client_test.dart` → 68/68 pass
- `flutter analyze` → no issues
- `dart format` → no changes