### PR TITLE
fix(e2e): harden flaky frontend e2e tests against backend load

### DIFF
--- a/src/frontend/e2e-tests/e2e/helpers.ts
+++ b/src/frontend/e2e-tests/e2e/helpers.ts
@@ -10,20 +10,60 @@ export const API_BASE =
   process.env.KLANGK_TEST_URL || `http://localhost:${BACKEND_PORT}`;
 export const TEST_PASSWORD = "testpass";
 
+/** Sleep with exponential backoff + jitter before retrying a request. */
+function sleepBackoff(attempt: number): Promise<void> {
+  const ms = 250 * 2 ** (attempt - 1) + Math.random() * 200;
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/** POST JSON to the E2E backend, retrying transient failures.
+ *
+ * The suite runs several workers against a single backend, and SQLite can
+ * briefly return a "database is locked" 5xx under concurrent writes; slow
+ * responses can also surface as thrown network errors. Those are retried with
+ * exponential backoff. Non-transient 4xx responses are surfaced immediately
+ * since retrying them (e.g. a real duplicate-email 400) cannot succeed. */
+async function postJsonWithRetry(
+  request: APIRequestContext,
+  url: string,
+  data: Record<string, unknown>,
+  label: string,
+  { headers }: { headers?: Record<string, string> } = {},
+) {
+  const maxAttempts = 4;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    let resp;
+    try {
+      resp = await request.post(url, { data, headers, timeout: 30_000 });
+    } catch (err) {
+      // Network/timeout error — retry unless this was the last attempt.
+      if (attempt === maxAttempts) throw err;
+      await sleepBackoff(attempt);
+      continue;
+    }
+    if (resp.ok()) return resp.json();
+    const body = await resp.text().catch(() => "");
+    const transient = resp.status() >= 500 || resp.status() === 429;
+    if (!transient || attempt === maxAttempts) {
+      throw new Error(`${label} failed: ${resp.status()} ${body}`);
+    }
+    await sleepBackoff(attempt);
+  }
+  throw new Error(`${label} failed: retries exhausted`);
+}
+
 /** Register a new user via API (test mode allows unauthenticated registration).
  *  Returns { token, headers }. */
 export async function registerUser(
   request: APIRequestContext,
   email: string,
 ): Promise<{ token: string; headers: Record<string, string> }> {
-  const resp = await request.post(`${API_BASE}/api/v1/auth/register`, {
-    data: { email, password: TEST_PASSWORD },
-  });
-  if (!resp.ok()) {
-    const body = await resp.text();
-    throw new Error(`Register failed: ${resp.status()} ${body}`);
-  }
-  const data = await resp.json();
+  const data = await postJsonWithRetry(
+    request,
+    `${API_BASE}/api/v1/auth/register`,
+    { email, password: TEST_PASSWORD },
+    "Register",
+  );
   const token = data.access_token;
   return { token, headers: { Authorization: `Bearer ${token}` } };
 }
@@ -268,17 +308,13 @@ export async function createWorkspace(
   cleanup: () => Promise<void>;
 }> {
   const name = `${namePrefix}-${Date.now()}@test.example.com`;
-  const createResp = await request.post(`${API_BASE}/api/v1/workspaces`, {
-    headers,
-    data: { name },
-  });
-  if (!createResp.ok()) {
-    const body = await createResp.text();
-    throw new Error(
-      `Workspace creation failed: ${createResp.status()} ${body}`,
-    );
-  }
-  const workspace = await createResp.json();
+  const workspace = await postJsonWithRetry(
+    request,
+    `${API_BASE}/api/v1/workspaces`,
+    { name },
+    "Workspace creation",
+    { headers },
+  );
   const workspaceId = workspace.id;
 
   return {

--- a/src/frontend/e2e-tests/e2e/terminal-tabs.spec.ts
+++ b/src/frontend/e2e-tests/e2e/terminal-tabs.spec.ts
@@ -34,7 +34,7 @@ class TerminalWsClient {
     this.ws.send(JSON.stringify(msg));
   }
 
-  async recv(timeout = 10_000): Promise<Record<string, unknown>> {
+  async recv(timeout = 30_000): Promise<Record<string, unknown>> {
     if (this.messageQueue.length > 0) {
       return this.messageQueue.shift()!;
     }
@@ -49,15 +49,22 @@ class TerminalWsClient {
     });
   }
 
-  /** Receive messages until one matches the predicate. */
+  /** Receive messages until one matches the predicate. A transient inner recv
+   *  timeout (e.g. a slow terminal backend under load) is tolerated as long as
+   *  the overall deadline has not elapsed; only then does this reject. */
   async recvUntil(
     predicate: (msg: Record<string, unknown>) => boolean,
-    timeout = 30_000,
+    timeout = 60_000,
   ): Promise<Record<string, unknown>> {
     const deadline = Date.now() + timeout;
     while (Date.now() < deadline) {
-      const msg = await this.recv(deadline - Date.now());
-      if (predicate(msg)) return msg;
+      try {
+        const msg = await this.recv(deadline - Date.now());
+        if (predicate(msg)) return msg;
+      } catch (err) {
+        // Inner recv timed out — only fail if the overall deadline passed.
+        if (Date.now() >= deadline) throw err;
+      }
     }
     throw new Error("recvUntil timed out");
   }


### PR DESCRIPTION
## Summary

Addresses flakiness/failures seen in the `test-frontend-e2e` (chromium) job — e.g. [run 28273527687 on PR #893](https://github.com/mcdonc/klangk/actions/runs/28273527687). The chromium job runs 4 parallel workers against a single backend; under that load two tests became unreliable:

- **`ws-connect-speed` › "workspace reopens within 10s after navigating away and back"** — failed (even on retry) at `registerUser`. The SQLite-backed register endpoint can briefly return a \`database is locked\` **5xx** under concurrent writes, but \`registerUser\` did a single POST with no retry.
- **`terminal-tabs` › "list-windows returns all windows"** — flaky \`recv timed out\`. The \`TerminalWsClient\` \`recv\`/\`recvUntil\` timeouts (10s/30s) were too tight under load, and \`recvUntil\` propagated an inner \`recv\` timeout instead of tolerating it while the overall deadline remained.

## Changes

- **`helpers.ts`**: add \`postJsonWithRetry\` — retries 5xx / 429 / thrown network errors with exponential backoff + jitter; surfaces non-transient 4xx (e.g. a real duplicate-email 400) immediately since retrying cannot help. Applied to \`registerUser\` and \`createWorkspace\`.
- **`terminal-tabs.spec.ts`**: bump \`recv\` default timeout 10s → 30s and \`recvUntil\` 30s → 60s, and make \`recvUntil\` tolerate a transient inner \`recv\` timeout unless the overall deadline has elapsed.

## Test plan

Iterating on CI: targeting 3 successive green `test-frontend-e2e` (chromium) runs.