### PR TITLE
refactor(podman): extract _exec_args helper, add extra_env (#900)

### DIFF
--- a/src/backend/klangk_backend/podman.py
+++ b/src/backend/klangk_backend/podman.py
@@ -273,25 +273,54 @@ async def start_container(container_id: str) -> None:
     await _run(["start", container_id], timeout=120.0)
 
 
+def _exec_args(
+    container_id: str,
+    cmd: list[str],
+    *,
+    user: str | None = None,
+    interactive: bool = False,
+    extra_env: dict[str, str] | None = None,
+) -> list[str]:
+    """Build the ``podman exec`` argument list (without the leading binary).
+
+    All options (``-i`` / ``-u`` / ``-e``) precede the container id and
+    command, matching ``podman exec [OPTIONS] CONTAINER [COMMAND...]``.
+    Centralized so the three ``exec_container*`` callers stay in sync and
+    there is a single place to add flags (e.g. ``extra_env``).
+    """
+    args = ["exec"]
+    if interactive:
+        args.append("-i")
+    if user:
+        args += ["-u", user]
+    if extra_env:
+        for key, value in extra_env.items():
+            args += ["-e", f"{key}={value}"]
+    args.append(container_id)
+    args.extend(cmd)
+    return args
+
+
 async def exec_container(
     container_id: str,
     cmd: list[str],
     *,
     user: str | None = None,
     stdin_data: bytes | None = None,
+    extra_env: dict[str, str] | None = None,
     timeout: float | None = 30.0,
 ) -> tuple[int, str, str]:
     """Run a command inside a running container.
 
     Returns ``(returncode, stdout, stderr)``.
     """
-    args = ["exec"]
-    if stdin_data is not None:
-        args.append("-i")
-    if user:
-        args += ["-u", user]
-    args.append(container_id)
-    args.extend(cmd)
+    args = _exec_args(
+        container_id,
+        cmd,
+        user=user,
+        interactive=stdin_data is not None,
+        extra_env=extra_env,
+    )
     return await _run(
         args, check=False, stdin_data=stdin_data, timeout=timeout
     )
@@ -302,14 +331,11 @@ async def exec_container_bytes(
     cmd: list[str],
     *,
     user: str | None = None,
+    extra_env: dict[str, str] | None = None,
     timeout: float | None = 30.0,
 ) -> tuple[int, bytes, str]:
     """Like ``exec_container`` but returns raw stdout bytes (for binary data)."""
-    args = ["exec"]
-    if user:
-        args += ["-u", user]
-    args.append(container_id)
-    args.extend(cmd)
+    args = _exec_args(container_id, cmd, user=user, extra_env=extra_env)
     return await _run_raw(args, check=False, timeout=timeout)
 
 
@@ -318,6 +344,7 @@ async def exec_container_stream(
     cmd: list[str],
     *,
     user: str | None = None,
+    extra_env: dict[str, str] | None = None,
     chunk_size: int = 64 * 1024,
 ) -> AsyncGenerator[bytes, None]:
     """Stream stdout from a command inside a container.
@@ -326,11 +353,7 @@ async def exec_container_stream(
     to disk.  stderr is discarded to avoid pipe-buffer deadlocks (the
     process would block if stderr fills while we only drain stdout).
     """
-    args = ["exec"]
-    if user:
-        args += ["-u", user]
-    args.append(container_id)
-    args.extend(cmd)
+    args = _exec_args(container_id, cmd, user=user, extra_env=extra_env)
     proc = await asyncio.create_subprocess_exec(
         PODMAN_BIN,
         *args,

--- a/src/backend/tests/test_podman.py
+++ b/src/backend/tests/test_podman.py
@@ -290,6 +290,44 @@ class TestExecContainerWithStdin:
         with patch(EXEC, _exec(("", "", 0))):
             await podman.exec_container("cid", ["ls"], timeout=60.0)
 
+    async def test_extra_env_adds_flags_before_container(self):
+        with patch(EXEC, _exec(("", "", 0))) as m:
+            await podman.exec_container(
+                "cid",
+                ["env"],
+                extra_env={"HOME": "/home/x", "FOO": "bar"},
+            )
+        # -e flags precede the container id and command.
+        assert _args(m) == [
+            "exec",
+            "-e",
+            "HOME=/home/x",
+            "-e",
+            "FOO=bar",
+            "cid",
+            "env",
+        ]
+
+    async def test_extra_env_with_user_and_stdin(self):
+        with patch(EXEC, _exec(("", "", 0))) as m:
+            await podman.exec_container(
+                "cid",
+                ["sh"],
+                user="root",
+                stdin_data=b"x",
+                extra_env={"A": "1"},
+            )
+        assert _args(m) == [
+            "exec",
+            "-i",
+            "-u",
+            "root",
+            "-e",
+            "A=1",
+            "cid",
+            "sh",
+        ]
+
 
 class TestExecContainerBytes:
     async def test_returns_raw_bytes(self):
@@ -308,6 +346,19 @@ class TestExecContainerBytes:
                 "cid", ["cat", "/f"], user="klangk"
             )
         assert _args(m) == ["exec", "-u", "klangk", "cid", "cat", "/f"]
+
+    async def test_extra_env_adds_flags_before_container(self):
+        with patch(EXEC, _exec(("", "", 0))) as m:
+            await podman.exec_container_bytes(
+                "cid", ["env"], extra_env={"HOME": "/home/x"}
+            )
+        assert _args(m) == [
+            "exec",
+            "-e",
+            "HOME=/home/x",
+            "cid",
+            "env",
+        ]
 
     async def test_nonzero_returned(self):
         with patch(EXEC, _exec(("", "err", 1))):
@@ -401,6 +452,26 @@ class TestExecContainerStream:
             "cid",
             "cat",
             "/f",
+        ]
+
+    async def test_extra_env_adds_flags_before_container(self):
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.stdout = AsyncMock()
+        mock_proc.stdout.read = AsyncMock(return_value=b"")
+        mock_proc.wait = AsyncMock(return_value=0)
+
+        with patch(EXEC, AsyncMock(return_value=mock_proc)) as m:
+            async for _ in podman.exec_container_stream(
+                "cid", ["env"], extra_env={"HOME": "/home/x"}
+            ):
+                pass
+        assert list(m.call_args.args[1:]) == [
+            "exec",
+            "-e",
+            "HOME=/home/x",
+            "cid",
+            "env",
         ]
 
     async def test_kills_process_on_early_exit(self):


### PR DESCRIPTION
Closes #900.

## Summary

Extracts a single private `_exec_args` helper that owns the `podman exec [OPTIONS] CONTAINER [COMMAND...]` argument layout (`-i` / `-u` / `-e` before the container id), and routes all three of `exec_container`, `exec_container_bytes`, `exec_container_stream` through it — removing the per-function argument-building that was duplicated across them.

Also adds an `extra_env: dict[str, str]` parameter to all three (emitted as `-e K=V` flags before the container id). This is the support `terminal.py` needs to adopt these helpers for its sites that set `HOME` / `SSH_AUTH_SOCK` — a prerequisite for #897.

## Behavior-preserving

Existing pinned arg-list tests in `test_podman.py` (`TestExecContainer`, `TestExecContainerBytes`, `TestExecContainerStream`) are unchanged and still pass — the produced argument lists match the prior per-function construction exactly.

## Tests

- Added 4 tests covering the new `extra_env` path on all three functions (including combined `user + stdin + extra_env`).
- `test_podman.py` + `test_podman_exec.py`: 86 passed
- `test_container.py` + `test_api.py` + `test_files.py`: 572 passed

## Checklist
- [x] Existing behavior preserved
- [x] Tests added for new functionality
- [x] Pre-commit hooks pass