### PR TITLE
refactor(test): adopt _conn_in_workspace in test_ui_ready

### DIFF
--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -6286,23 +6286,17 @@ class TestUiReadySharedTerminals:
         from klangk_backend import workspaces
 
         ws = await workspaces.create_workspace(user["id"], "ui-shared")
-        sock = _mock_sock()
-        conn = _base_conn(
-            user={"id": user["id"], "email": user["email"]}, ws=sock
-        )
-        conn.workspace_id = ws["id"]
-        conn.container_id = "cid"
-        conn._user_home = "/home/testuser"
-        conn.pending_status_msg = "ready"
+        async with _conn_in_workspace(
+            {"id": user["id"], "email": user["email"]},
+            ws["id"],
+            user_home="/home/testuser",
+        ) as (sock, conn, session):
+            conn.pending_status_msg = "ready"
 
-        # Set up in-memory shared state
-        session = wshandler.state.get_or_create_session(ws["id"])
-        session.terminal_windows[user["id"]] = [
-            {"name": "dev", "index": 0, "id": "@0", "shared": True},
-        ]
-        await session.add_subscriber(sock, "cid")
-        wshandler.state.connections[sock] = conn
-        try:
+            # Set up in-memory shared state
+            session.terminal_windows[user["id"]] = [
+                {"name": "dev", "index": 0, "id": "@0", "shared": True},
+            ]
             await conn.handle_ui_ready()
 
             sent = [c[0][0] for c in sock.send_json.call_args_list]
@@ -6310,9 +6304,6 @@ class TestUiReadySharedTerminals:
                 isinstance(m, dict) and m.get("type") == "shared_terminals"
                 for m in sent
             )
-        finally:
-            wshandler.state.sessions.pop(ws["id"], None)
-            wshandler.state.connections.pop(sock, None)
 
     async def test_ui_ready_sends_container_ready(self, user, temp_data_dir):
         from klangk_backend import workspaces


### PR DESCRIPTION
## Summary

Closes #905.

#903 shipped the `_conn_in_workspace` helper and converted the 8 cleanest single-connection sites. #905 tracked adopting it across the remaining sites. After an empirical scan of every registration site in `test_wshandler.py`, **only one additional site cleanly matches the helper's contract**; the rest use distinct patterns that don't fit without behavior changes.

## Change

Converted `test_ui_ready_sends_shared_terminals` — the one remaining single-connection site that does full `add_subscriber` registration + simple teardown (no registry/terminal-task/debounce complications).

## Why not more (the honest finding)

A strict scan for top-level `add_subscriber(sock)` + `state.connections[sock] = conn` + simple `sessions.pop`/`connections.pop` teardown (no `container.registry`, `terminal_task`, `_pending_leaves`, or mock-injected registration) yielded exactly this one site. The remaining ~30 fall into patterns where forcing the helper would either change behavior or add complexity:

| Pattern | Sites | Why it doesn't fit |
|---|---|---|
| Bare conn + `container.registry`, **no session/subscriber** (terminal-input/forward tests) | ~14 | Wrong abstraction — no `WorkspaceSession` or subscriber; would need a separate helper saving ~3 lines each |
| `terminal_start` cluster | 2 | Complex teardown: `terminal_task.cancel()` + `revoke_workspace_browsers` |
| `join_shared_terminal` cluster | ~4 | `track_activity` + complex teardown |
| Presence-leave tests | 3 | Raw `subscribers.add` + direct `WorkspaceSession()` + `PRESENCE_LEAVE_DELAY`/`_pending_leaves` state; async user creation interleaved with socket setup |
| Restart/shutdown tests | ~4 | Connection-map only, **no session** |
| Agent-chat tests | ~6 | `add_subscriber` without `connections[sock]` registration + `_agent_conversations` teardown |
| Presence-connect tests | 2 | Registration happens **inside a mocked `start_workspace_container`** (`fake_start`), not at top level |

Forcing any of these would change test semantics (e.g. adding `connections[sock]` that isn't there, setting `session.container_id` via `add_subscriber` where raw `subscribers.add` is used intentionally, or swallowing complex teardown). The helper's value was the **uniform** sites, which #903 already captured.

## Verification

- `test_wshandler.py`: **333 passed**, `wshandler.py` at **100% coverage**, ruff clean.

## Recommendation

Close #905 — the helper is complete and has captured every site it cleanly fits. Future opportunistic conversions can reference this analysis if a test is rewritten to match the helper's contract.
