### PR TITLE
refactor(terminal): route podman exec through exec_container helpers (#897)

### DIFF
--- a/src/backend/klangk_backend/terminal.py
+++ b/src/backend/klangk_backend/terminal.py
@@ -109,50 +109,31 @@ async def _ensure_base_session(
     """
     # Check if the session already exists.
     try:
-        proc = await asyncio.create_subprocess_exec(
-            podman.PODMAN_BIN,
-            "exec",
-            "-u",
-            CONTAINER_USER,
+        rc, _, _ = await podman.exec_container(
             container_id,
-            "tmux",
-            "has-session",
-            "-t",
-            session_name,
-            stdout=asyncio.subprocess.DEVNULL,
-            stderr=asyncio.subprocess.DEVNULL,
-            env=podman.subprocess_env(),
+            ["tmux", "has-session", "-t", session_name],
+            user=CONTAINER_USER,
+            timeout=5,
         )
-        rc = await asyncio.wait_for(proc.wait(), timeout=5)
         if rc == 0:
             return  # already exists
     except Exception:
         pass  # assume it doesn't exist
 
-    # Create detached base session.
+    # Create detached base session.  HOME / SSH_AUTH_SOCK are passed as
+    # tmux's own ``-e`` flags (part of the command), not podman's.
     env_args: list[str] = []
     if user_home is not None:
         env_args += ["-e", f"HOME={user_home}"]
     if ssh_agent_socket is not None:
         env_args += ["-e", f"SSH_AUTH_SOCK={ssh_agent_socket}"]
     try:
-        proc = await asyncio.create_subprocess_exec(
-            podman.PODMAN_BIN,
-            "exec",
-            "-u",
-            CONTAINER_USER,
+        await podman.exec_container(
             container_id,
-            "tmux",
-            "new-session",
-            "-d",
-            "-s",
-            session_name,
-            *env_args,
-            stdout=asyncio.subprocess.DEVNULL,
-            stderr=asyncio.subprocess.DEVNULL,
-            env=podman.subprocess_env(),
+            ["tmux", "new-session", "-d", "-s", session_name, *env_args],
+            user=CONTAINER_USER,
+            timeout=10,
         )
-        await asyncio.wait_for(proc.wait(), timeout=10)
     except Exception:
         logger.warning("Failed to create base tmux session %s", session_name)
 
@@ -256,27 +237,17 @@ async def attach_browser(container_id: str, browser_id: str) -> None:
     ``klangk-browser-id`` can read it dynamically.  Called after each
     ``terminal_start`` (including re-attach after browser refresh).
     """
-    argv = [
-        "exec",
-        "-u",
-        CONTAINER_USER,
+    rc, _stdout, stderr = await podman.exec_container(
         container_id,
-        "klangk-attach-browser",
-        browser_id,
-    ]
-    proc = await asyncio.create_subprocess_exec(
-        podman.PODMAN_BIN,
-        *argv,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        env=podman.subprocess_env(),
+        ["klangk-attach-browser", browser_id],
+        user=CONTAINER_USER,
+        timeout=10,
     )
-    _stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=10)
-    if proc.returncode != 0:
+    if rc != 0:
         logger.warning(
             "klangk-attach-browser failed (rc=%d): %s",
-            proc.returncode,
-            stderr.decode(errors="replace").strip(),
+            rc,
+            stderr.strip(),
         )
 
 
@@ -284,27 +255,17 @@ async def set_workspace_token(container_id: str, token: str) -> None:
     """Write a workspace token to ``/run/klangk/workspace-token`` inside
     the container via ``klangk-set-workspace-token``.
     """
-    argv = [
-        "exec",
-        "-u",
-        CONTAINER_USER,
+    rc, _stdout, stderr = await podman.exec_container(
         container_id,
-        "klangk-set-workspace-token",
-        token,
-    ]
-    proc = await asyncio.create_subprocess_exec(
-        podman.PODMAN_BIN,
-        *argv,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        env=podman.subprocess_env(),
+        ["klangk-set-workspace-token", token],
+        user=CONTAINER_USER,
+        timeout=10,
     )
-    _stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=10)
-    if proc.returncode != 0:
+    if rc != 0:
         logger.warning(
             "klangk-set-workspace-token failed (rc=%d): %s",
-            proc.returncode,
-            stderr.decode(errors="replace").strip(),
+            rc,
+            stderr.strip(),
         )
 
 
@@ -317,29 +278,18 @@ async def tmux_command(
     when the tmux server is still starting in a fresh container.
     """
     for attempt in range(3):
-        argv = [
-            "exec",
-            "-u",
-            CONTAINER_USER,
+        rc, stdout, stderr = await podman.exec_container(
             container_id,
-            "tmux",
-            *args,
-        ]
-        proc = await asyncio.create_subprocess_exec(
-            podman.PODMAN_BIN,
-            *argv,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            env=podman.subprocess_env(),
+            ["tmux", *args],
+            user=CONTAINER_USER,
+            timeout=10,
         )
-        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=10)
-        if proc.returncode == 0:
-            return stdout.decode("utf-8", errors="replace")
-        err = stderr.decode("utf-8", errors="replace").strip()
-        if "No such file or directory" in err and attempt < 2:
+        if rc == 0:
+            return stdout
+        if "No such file or directory" in stderr and attempt < 2:
             await asyncio.sleep(0.5)
             continue
-        raise TerminalError(f"tmux command failed: {err}")
+        raise TerminalError(f"tmux command failed: {stderr.strip()}")
     return ""  # pragma: no cover
 
 
@@ -404,29 +354,16 @@ async def new_window(
             f" tmux list-windows -t {session_name}"
             f" -F '#{{window_id}}|||#{{window_index}}|||#{{window_name}}|||#{{window_active}}'"
         )
-    argv = [
-        "exec",
-        "-u",
-        CONTAINER_USER,
+    rc, output, stderr = await podman.exec_container(
         container_id,
-        "bash",
-        "-c",
-        script,
-    ]
-    proc = await asyncio.create_subprocess_exec(
-        podman.PODMAN_BIN,
-        *argv,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        env=podman.subprocess_env(),
+        ["bash", "-c", script],
+        user=CONTAINER_USER,
+        timeout=10,
     )
-    stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=10)
-    output = stdout.decode("utf-8", errors="replace")
-    if proc.returncode != 0:
+    if rc != 0:
         if "DUPLICATE" in output:
             raise ValueError(f"Window name '{name}' already exists")
-        err = stderr.decode("utf-8", errors="replace").strip()
-        raise TerminalError(f"new_window failed: {err}")
+        raise TerminalError(f"new_window failed: {stderr.strip()}")
     windows = []
     for line in output.strip().splitlines():
         parts = line.split("|||")
@@ -513,19 +450,16 @@ async def load_workspace_state(container_id: str) -> dict:
     Returns empty dict if the file doesn't exist or is corrupt.
     Used for restoring state after container restart.
     """
-    argv = ["exec", "-u", CONTAINER_USER, container_id, "cat", _STATE_PATH]
-    proc = await asyncio.create_subprocess_exec(
-        podman.PODMAN_BIN,
-        *argv,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        env=podman.subprocess_env(),
+    rc, stdout, _ = await podman.exec_container(
+        container_id,
+        ["cat", _STATE_PATH],
+        user=CONTAINER_USER,
+        timeout=10,
     )
-    stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=10)
-    if proc.returncode != 0:
+    if rc != 0:
         return {}
     try:
-        return json.loads(stdout.decode("utf-8", errors="replace"))
+        return json.loads(stdout)
     except (json.JSONDecodeError, ValueError):
         return {}
 
@@ -538,24 +472,13 @@ async def save_workspace_state(container_id: str, state: dict) -> None:
     Callers should serialize access via WorkspaceSession._save_lock.
     """
     data = json.dumps(state, indent=2)
-    argv = [
-        "exec",
-        "-i",
-        "-u",
-        CONTAINER_USER,
+    await podman.exec_container(
         container_id,
-        "klangk-save-workspace-state",
-        _STATE_PATH,
-    ]
-    proc = await asyncio.create_subprocess_exec(
-        podman.PODMAN_BIN,
-        *argv,
-        stdin=asyncio.subprocess.PIPE,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        env=podman.subprocess_env(),
+        ["klangk-save-workspace-state", _STATE_PATH],
+        user=CONTAINER_USER,
+        stdin_data=data.encode(),
+        timeout=10,
     )
-    await asyncio.wait_for(proc.communicate(input=data.encode()), timeout=10)
 
 
 async def restore_windows(
@@ -917,26 +840,19 @@ class TerminalSession:
                 socket_args = (
                     ["-S", self.socket_path] if self.socket_path else []
                 )
-                argv = [
-                    "exec",
-                    "-u",
-                    CONTAINER_USER,
+                await podman.exec_container(
                     self.container_id,
-                    "tmux",
-                    *socket_args,
-                    "kill-session",
-                    "-t",
-                    self._tmux_session_name,
-                ]
-                proc = await asyncio.create_subprocess_exec(
-                    podman.PODMAN_BIN,
-                    *argv,
-                    stdout=asyncio.subprocess.DEVNULL,
-                    stderr=asyncio.subprocess.DEVNULL,
-                    env=podman.subprocess_env(),
+                    [
+                        "tmux",
+                        *socket_args,
+                        "kill-session",
+                        "-t",
+                        self._tmux_session_name,
+                    ],
+                    user=CONTAINER_USER,
+                    timeout=5,
                 )
-                await asyncio.wait_for(proc.wait(), timeout=5)
-            except Exception:  # pragma: no cover
+            except Exception:
                 logger.debug(
                     "Failed to kill tmux session %s",
                     self._tmux_session_name,

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -286,6 +286,24 @@ def _running(value=True):
     return AsyncMock(return_value={"State": {"Running": value}})
 
 
+def _sudo_call(p):
+    """Return the ``exec_container`` call that configures sudo.
+
+    ``start_container`` also invokes ``terminal.set_workspace_token`` which,
+    since terminal.py adopted ``podman.exec_container``, shows up as an
+    additional ``exec_container`` call.  Identify the sudoers call by its
+    command rather than assuming it is the only (or last) call.
+    """
+    for call in p.exec_container.call_args_list:
+        cmd = call.args[1] if len(call.args) > 1 else []
+        if "klangk-configure-sudo" in cmd:
+            return call
+    raise AssertionError(
+        "no klangk-configure-sudo exec_container call in "
+        f"{p.exec_container.call_args_list}"
+    )
+
+
 class TestStartContainer:
     def setup_method(self):
         container.registry.states.clear()
@@ -311,10 +329,9 @@ class TestStartContainer:
             await container.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
-        p.exec_container.assert_awaited_once()
-        call_args = p.exec_container.call_args
-        assert call_args.kwargs.get("user") == "root"
-        assert "!ALL" in str(call_args.args[1])
+        call = _sudo_call(p)
+        assert call.kwargs.get("user") == "root"
+        assert "!ALL" in str(call.args[1])
 
     async def test_sudo_enabled(self, workspace, monkeypatch):
         monkeypatch.setenv("KLANGK_ALLOW_SUDO", "true")
@@ -322,10 +339,9 @@ class TestStartContainer:
             await container.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
-        p.exec_container.assert_awaited_once()
-        call_args = p.exec_container.call_args
-        assert call_args.kwargs.get("user") == "root"
-        assert "NOPASSWD:ALL" in str(call_args.args[1])
+        call = _sudo_call(p)
+        assert call.kwargs.get("user") == "root"
+        assert "NOPASSWD:ALL" in str(call.args[1])
 
     async def test_sudo_disabled(self, workspace, monkeypatch):
         monkeypatch.setenv("KLANGK_ALLOW_SUDO", "0")
@@ -333,8 +349,7 @@ class TestStartContainer:
             await container.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
-        p.exec_container.assert_awaited_once()
-        assert "!ALL" in str(p.exec_container.call_args.args[1])
+        assert "!ALL" in str(_sudo_call(p).args[1])
 
     async def test_sudo_disabled_false(self, workspace, monkeypatch):
         monkeypatch.setenv("KLANGK_ALLOW_SUDO", "false")
@@ -342,8 +357,7 @@ class TestStartContainer:
             await container.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
-        p.exec_container.assert_awaited_once()
-        assert "!ALL" in str(p.exec_container.call_args.args[1])
+        assert "!ALL" in str(_sudo_call(p).args[1])
 
     async def test_sudo_toggled_off_to_on(self, workspace, monkeypatch):
         """Start with sudo disabled, restart with sudo enabled."""
@@ -352,7 +366,7 @@ class TestStartContainer:
             await container.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
-        assert "!ALL" in str(p.exec_container.call_args.args[1])
+        assert "!ALL" in str(_sudo_call(p).args[1])
 
         # "Restart" — remove container state so start_container creates a new one
         container.registry.states.clear()
@@ -362,7 +376,7 @@ class TestStartContainer:
             await container.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
-        assert "NOPASSWD:ALL" in str(p.exec_container.call_args.args[1])
+        assert "NOPASSWD:ALL" in str(_sudo_call(p).args[1])
 
     async def test_sudo_toggled_on_to_off(self, workspace, monkeypatch):
         """Start with sudo enabled, restart with sudo disabled."""
@@ -371,7 +385,7 @@ class TestStartContainer:
             await container.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
-        assert "NOPASSWD:ALL" in str(p.exec_container.call_args.args[1])
+        assert "NOPASSWD:ALL" in str(_sudo_call(p).args[1])
 
         container.registry.states.clear()
         await model.update_workspace_container(workspace["id"], None)
@@ -380,7 +394,7 @@ class TestStartContainer:
             await container.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
-        assert "!ALL" in str(p.exec_container.call_args.args[1])
+        assert "!ALL" in str(_sudo_call(p).args[1])
 
     async def test_container_id_persisted_before_start(self, workspace, user):
         # If `start` fails, the id created just before it must already be on

--- a/src/backend/tests/test_terminal.py
+++ b/src/backend/tests/test_terminal.py
@@ -7,12 +7,14 @@ lifecycle/queue logic against an injected fake shell.
 
 import asyncio
 import contextlib
+import json
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from klangk_backend.exceptions import TerminalError
 from klangk_backend.terminal import (
+    CONTAINER_USER,
     TerminalSession,
     set_workspace_token,
     _build_environment,
@@ -289,25 +291,24 @@ class TestStart:
 
 class TestAttachBrowser:
     async def test_runs_klangk_attach_browser(self):
-        mock_proc = AsyncMock()
-        mock_proc.communicate.return_value = (b"", b"")
-        mock_proc.returncode = 0
         with patch(
-            "klangk_backend.terminal.asyncio.create_subprocess_exec",
-            return_value=mock_proc,
+            "klangk_backend.terminal.podman.exec_container",
+            new_callable=AsyncMock,
+            return_value=(0, "", ""),
         ) as mock_exec:
             await attach_browser("cid-123", "bid-abc")
-        args = mock_exec.call_args[0]
-        assert "klangk-attach-browser" in args
-        assert "bid-abc" in args
+        mock_exec.assert_awaited_once_with(
+            "cid-123",
+            ["klangk-attach-browser", "bid-abc"],
+            user=CONTAINER_USER,
+            timeout=10,
+        )
 
     async def test_logs_warning_on_failure(self):
-        mock_proc = AsyncMock()
-        mock_proc.communicate.return_value = (b"", b"attach failed")
-        mock_proc.returncode = 1
         with patch(
-            "klangk_backend.terminal.asyncio.create_subprocess_exec",
-            return_value=mock_proc,
+            "klangk_backend.terminal.podman.exec_container",
+            new_callable=AsyncMock,
+            return_value=(1, "", "attach failed"),
         ):
             # Should not raise
             await attach_browser("cid-123", "bid-abc")
@@ -315,25 +316,24 @@ class TestAttachBrowser:
 
 class TestSetWorkspaceToken:
     async def test_runs_klangk_set_workspace_token(self):
-        mock_proc = AsyncMock()
-        mock_proc.communicate.return_value = (b"", b"")
-        mock_proc.returncode = 0
         with patch(
-            "klangk_backend.terminal.asyncio.create_subprocess_exec",
-            return_value=mock_proc,
+            "klangk_backend.terminal.podman.exec_container",
+            new_callable=AsyncMock,
+            return_value=(0, "", ""),
         ) as mock_exec:
             await set_workspace_token("cid-123", "jwt-token-xyz")
-        args = mock_exec.call_args[0]
-        assert "klangk-set-workspace-token" in args
-        assert "jwt-token-xyz" in args
+        mock_exec.assert_awaited_once_with(
+            "cid-123",
+            ["klangk-set-workspace-token", "jwt-token-xyz"],
+            user=CONTAINER_USER,
+            timeout=10,
+        )
 
     async def test_logs_warning_on_failure(self):
-        mock_proc = AsyncMock()
-        mock_proc.communicate.return_value = (b"", b"set failed")
-        mock_proc.returncode = 1
         with patch(
-            "klangk_backend.terminal.asyncio.create_subprocess_exec",
-            return_value=mock_proc,
+            "klangk_backend.terminal.podman.exec_container",
+            new_callable=AsyncMock,
+            return_value=(1, "", "set failed"),
         ):
             await set_workspace_token("cid-123", "jwt-token-xyz")
 
@@ -519,18 +519,34 @@ class TestStop:
         # Manually set tmux session name (normally set by _build_shell_command
         # when join_session is used with a socket path)
         s._tmux_session_name = "uid-abc123"
-        proc_mock = AsyncMock()
-        proc_mock.wait = AsyncMock(return_value=0)
         with patch(
-            "asyncio.create_subprocess_exec",
-            return_value=proc_mock,
+            "klangk_backend.terminal.podman.exec_container",
+            new_callable=AsyncMock,
+            return_value=(0, "", ""),
         ) as mock_exec:
             await s.stop()
-        mock_exec.assert_called_once()
-        argv = mock_exec.call_args[0]
-        assert "kill-session" in argv
-        assert "-t" in argv
-        assert "uid-abc123" in argv
+        mock_exec.assert_awaited_once()
+        cmd = mock_exec.call_args.args[1]
+        assert "kill-session" in cmd
+        assert "-t" in cmd
+        assert "uid-abc123" in cmd
+
+    async def test_stop_kill_session_failure_is_swallowed(self):
+        """A failing kill-session exec must not propagate from stop()."""
+        fake = FakeShell(block_after_chunks=True)
+        with _patch(fake):
+            s = TerminalSession(
+                "cid", session_name="uid", socket_path="/tmp/s.sock"
+            )
+            await s.start()
+        s._tmux_session_name = "uid-abc123"
+        with patch(
+            "klangk_backend.terminal.podman.exec_container",
+            new_callable=AsyncMock,
+            side_effect=OSError("boom"),
+        ):
+            # Should not raise — failure is logged at debug level.
+            await s.stop()
 
 
 class TestOutput:
@@ -617,39 +633,46 @@ class TestIsAlive:
 
 class TestTmuxCommand:
     async def test_returns_stdout(self):
-        proc = AsyncMock()
-        proc.communicate = AsyncMock(return_value=(b"output\n", b""))
-        proc.returncode = 0
-        with patch("asyncio.create_subprocess_exec", return_value=proc):
+        with patch(
+            "klangk_backend.terminal.podman.exec_container",
+            new_callable=AsyncMock,
+            return_value=(0, "output\n", ""),
+        ) as mock_exec:
             result = await tmux_command("cid", "sess", ["list-windows"])
         assert result == "output\n"
+        mock_exec.assert_awaited_once_with(
+            "cid",
+            ["tmux", "list-windows"],
+            user=CONTAINER_USER,
+            timeout=10,
+        )
 
     async def test_raises_on_failure(self):
-        proc = AsyncMock()
-        proc.communicate = AsyncMock(return_value=(b"", b"error msg"))
-        proc.returncode = 1
-        with patch("asyncio.create_subprocess_exec", return_value=proc):
+        with patch(
+            "klangk_backend.terminal.podman.exec_container",
+            new_callable=AsyncMock,
+            return_value=(1, "", "error msg"),
+        ) as mock_exec:
             with pytest.raises(TerminalError, match="error msg"):
                 await tmux_command("cid", "sess", ["bad-cmd"])
+        assert mock_exec.await_count == 1  # no retry on non-socket errors
 
     async def test_retries_on_socket_not_found(self):
-        fail_proc = AsyncMock()
-        fail_proc.communicate = AsyncMock(
-            return_value=(b"", b"No such file or directory")
-        )
-        fail_proc.returncode = 1
-        ok_proc = AsyncMock()
-        ok_proc.communicate = AsyncMock(return_value=(b"ok\n", b""))
-        ok_proc.returncode = 0
         with (
             patch(
-                "asyncio.create_subprocess_exec",
-                side_effect=[fail_proc, ok_proc],
-            ),
+                "klangk_backend.terminal.podman.exec_container",
+                new_callable=AsyncMock,
+                side_effect=[
+                    (1, "", "No such file or directory"),
+                    (0, "ok\n", ""),
+                ],
+            ) as mock_exec,
             patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
         ):
             result = await tmux_command("cid", "sess", ["list-windows"])
         assert result == "ok\n"
+        assert mock_exec.await_count == 2
+        mock_sleep.assert_awaited_once_with(0.5)
         mock_sleep.assert_awaited_once_with(0.5)
 
 
@@ -692,52 +715,60 @@ class TestValidateWindowName:
 
 class TestNewWindow:
     async def test_creates_window_auto_name(self):
-        proc = AsyncMock()
-        proc.communicate = AsyncMock(return_value=(b"@0|||0|||1|||1\n", b""))
-        proc.returncode = 0
-        with patch("asyncio.create_subprocess_exec", return_value=proc):
+        with patch(
+            "klangk_backend.terminal.podman.exec_container",
+            new_callable=AsyncMock,
+            return_value=(0, "@0|||0|||1|||1\n", ""),
+        ) as mock_exec:
             result = await new_window("cid", "sess")
         assert len(result) == 1
         assert result[0]["name"] == "1"
+        assert mock_exec.call_args.args[1][:2] == ["bash", "-c"]
 
     async def test_auto_name_skips_existing(self):
-        proc = AsyncMock()
-        proc.communicate = AsyncMock(
-            return_value=(b"@0|||0|||1|||0\n@1|||1|||2|||1\n", b"")
-        )
-        proc.returncode = 0
-        with patch("asyncio.create_subprocess_exec", return_value=proc):
+        with patch(
+            "klangk_backend.terminal.podman.exec_container",
+            new_callable=AsyncMock,
+            return_value=(0, "@0|||0|||1|||0\n@1|||1|||2|||1\n", ""),
+        ):
             result = await new_window("cid", "sess")
         assert len(result) == 2
 
     async def test_creates_named_window(self):
-        proc = AsyncMock()
-        proc.communicate = AsyncMock(
-            return_value=(b"@0|||0|||bash|||0\n@1|||1|||build|||1\n", b"")
-        )
-        proc.returncode = 0
-        with patch("asyncio.create_subprocess_exec", return_value=proc):
+        with patch(
+            "klangk_backend.terminal.podman.exec_container",
+            new_callable=AsyncMock,
+            return_value=(
+                0,
+                "@0|||0|||bash|||0\n@1|||1|||build|||1\n",
+                "",
+            ),
+        ) as mock_exec:
             result = await new_window("cid", "sess", name="build")
         assert len(result) == 2
         assert result[1]["name"] == "build"
+        # the chosen name is interpolated into the bash script
+        assert "'build'" in mock_exec.call_args.args[1][2]
 
     async def test_rejects_shell_injection(self):
         with pytest.raises(ValueError, match="only contain"):
             await new_window("cid", "sess", name="';rm -rf /;'")
 
     async def test_rejects_duplicate_name(self):
-        proc = AsyncMock()
-        proc.communicate = AsyncMock(return_value=(b"DUPLICATE\n", b""))
-        proc.returncode = 1
-        with patch("asyncio.create_subprocess_exec", return_value=proc):
+        with patch(
+            "klangk_backend.terminal.podman.exec_container",
+            new_callable=AsyncMock,
+            return_value=(1, "DUPLICATE\n", ""),
+        ):
             with pytest.raises(ValueError, match="already exists"):
                 await new_window("cid", "sess", name="build")
 
     async def test_raises_on_tmux_error(self):
-        proc = AsyncMock()
-        proc.communicate = AsyncMock(return_value=(b"", b"session not found"))
-        proc.returncode = 1
-        with patch("asyncio.create_subprocess_exec", return_value=proc):
+        with patch(
+            "klangk_backend.terminal.podman.exec_container",
+            new_callable=AsyncMock,
+            return_value=(1, "", "session not found"),
+        ):
             with pytest.raises(TerminalError, match="session not found"):
                 await new_window("cid", "sess")
 
@@ -949,44 +980,58 @@ class TestBuildShellCommandTmuxDisabled:
 
 class TestLoadWorkspaceState:
     async def test_loads_state(self):
-        import json
-
         state = {"admin": [{"name": "1", "shared": False}]}
-        proc = AsyncMock()
-        proc.communicate = AsyncMock(
-            return_value=(json.dumps(state).encode(), b"")
-        )
-        proc.returncode = 0
-        with patch("asyncio.create_subprocess_exec", return_value=proc):
+        with patch(
+            "klangk_backend.terminal.podman.exec_container",
+            new_callable=AsyncMock,
+            return_value=(0, json.dumps(state), ""),
+        ) as mock_exec:
             result = await load_workspace_state("cid")
         assert result == state
+        mock_exec.assert_awaited_once_with(
+            "cid",
+            ["cat", "/home/.workspace-state.json"],
+            user=CONTAINER_USER,
+            timeout=10,
+        )
 
     async def test_missing_file(self):
-        proc = AsyncMock()
-        proc.communicate = AsyncMock(return_value=(b"", b"No such file"))
-        proc.returncode = 1
-        with patch("asyncio.create_subprocess_exec", return_value=proc):
+        with patch(
+            "klangk_backend.terminal.podman.exec_container",
+            new_callable=AsyncMock,
+            return_value=(1, "", "No such file"),
+        ):
             result = await load_workspace_state("cid")
         assert result == {}
 
     async def test_corrupt_json(self):
-        proc = AsyncMock()
-        proc.communicate = AsyncMock(return_value=(b"not json{", b""))
-        proc.returncode = 0
-        with patch("asyncio.create_subprocess_exec", return_value=proc):
+        with patch(
+            "klangk_backend.terminal.podman.exec_container",
+            new_callable=AsyncMock,
+            return_value=(0, "not json{", ""),
+        ):
             result = await load_workspace_state("cid")
         assert result == {}
 
 
 class TestSaveWorkspaceState:
     async def test_saves_state(self):
-        proc = AsyncMock()
-        proc.communicate = AsyncMock(return_value=(b"", b""))
-        with patch("asyncio.create_subprocess_exec", return_value=proc):
+        with patch(
+            "klangk_backend.terminal.podman.exec_container",
+            new_callable=AsyncMock,
+            return_value=(0, "", ""),
+        ) as mock_exec:
             await save_workspace_state(
                 "cid", {"admin": [{"name": "1", "shared": False}]}
             )
-        proc.communicate.assert_awaited_once()
+        mock_exec.assert_awaited_once()
+        cmd = mock_exec.call_args.args[1]
+        assert cmd == [
+            "klangk-save-workspace-state",
+            "/home/.workspace-state.json",
+        ]
+        assert mock_exec.call_args.kwargs["user"] == CONTAINER_USER
+        assert b'"admin"' in mock_exec.call_args.kwargs["stdin_data"]
 
 
 class TestRestoreWindows:
@@ -1115,76 +1160,66 @@ class TestEnsureBaseSession:
         """Skip creation if tmux has-session succeeds."""
         from klangk_backend.terminal import _ensure_base_session
 
-        proc_mock = AsyncMock()
-        proc_mock.wait = AsyncMock(return_value=0)
         with patch(
-            "asyncio.create_subprocess_exec",
-            return_value=proc_mock,
+            "klangk_backend.terminal.podman.exec_container",
+            new_callable=AsyncMock,
+            return_value=(0, "", ""),  # has-session succeeds
         ) as mock_exec:
             await _ensure_base_session("cid", "my-session")
         # has-session called, but new-session not called
-        assert mock_exec.call_count == 1
-        call_args = mock_exec.call_args[0]
-        assert "has-session" in call_args
+        mock_exec.assert_awaited_once()
+        assert "has-session" in mock_exec.call_args.args[1]
 
     async def test_session_does_not_exist(self):
         """Create detached session when has-session fails."""
         from klangk_backend.terminal import _ensure_base_session
 
-        has_proc = AsyncMock()
-        has_proc.wait = AsyncMock(return_value=1)
-        new_proc = AsyncMock()
-        new_proc.wait = AsyncMock(return_value=0)
         with patch(
-            "asyncio.create_subprocess_exec",
-            side_effect=[has_proc, new_proc],
+            "klangk_backend.terminal.podman.exec_container",
+            new_callable=AsyncMock,
+            side_effect=[(1, "", ""), (0, "", "")],  # has fail, new ok
         ) as mock_exec:
             await _ensure_base_session(
                 "cid", "my-session", user_home="/home/u"
             )
-        assert mock_exec.call_count == 2
-        new_args = mock_exec.call_args_list[1][0]
-        assert "new-session" in new_args
-        assert "-d" in new_args
-        assert "-s" in new_args
+        assert mock_exec.await_count == 2
+        new_cmd = mock_exec.call_args_list[1].args[1]
+        assert "new-session" in new_cmd
+        assert "-d" in new_cmd
+        assert "-s" in new_cmd
 
     async def test_has_session_exception(self):
         """Falls through to create if has-session raises."""
         from klangk_backend.terminal import _ensure_base_session
 
-        new_proc = AsyncMock()
-        new_proc.wait = AsyncMock(return_value=0)
         with patch(
-            "asyncio.create_subprocess_exec",
-            side_effect=[OSError("boom"), new_proc],
+            "klangk_backend.terminal.podman.exec_container",
+            new_callable=AsyncMock,
+            side_effect=[OSError("boom"), (0, "", "")],
         ) as mock_exec:
             await _ensure_base_session("cid", "my-session")
-        assert mock_exec.call_count == 2
+        assert mock_exec.await_count == 2
 
     async def test_create_failure_logs_warning(self):
         """Warning logged when new-session fails."""
         from klangk_backend.terminal import _ensure_base_session
 
-        has_proc = AsyncMock()
-        has_proc.wait = AsyncMock(return_value=1)
         with patch(
-            "asyncio.create_subprocess_exec",
-            side_effect=[has_proc, OSError("create failed")],
+            "klangk_backend.terminal.podman.exec_container",
+            new_callable=AsyncMock,
+            side_effect=[(1, "", ""), OSError("create failed")],
         ):
             # Should not raise
             await _ensure_base_session("cid", "my-session")
 
     async def test_env_args_passed(self):
-        """HOME and SSH_AUTH_SOCK are passed as -e flags."""
+        """HOME and SSH_AUTH_SOCK are passed as tmux -e flags."""
         from klangk_backend.terminal import _ensure_base_session
 
-        has_proc = AsyncMock()
-        has_proc.wait = AsyncMock(return_value=1)
-        new_proc = AsyncMock()
-        new_proc.wait = AsyncMock(return_value=0)
         with patch(
-            "asyncio.create_subprocess_exec",
-            side_effect=[has_proc, new_proc],
+            "klangk_backend.terminal.podman.exec_container",
+            new_callable=AsyncMock,
+            side_effect=[(1, "", ""), (0, "", "")],
         ) as mock_exec:
             await _ensure_base_session(
                 "cid",
@@ -1192,6 +1227,6 @@ class TestEnsureBaseSession:
                 user_home="/home/u",
                 ssh_agent_socket="/tmp/agent.sock",
             )
-        new_args = mock_exec.call_args_list[1][0]
-        assert "HOME=/home/u" in new_args
-        assert "SSH_AUTH_SOCK=/tmp/agent.sock" in new_args
+        new_cmd = mock_exec.call_args_list[1].args[1]
+        assert "HOME=/home/u" in new_cmd
+        assert "SSH_AUTH_SOCK=/tmp/agent.sock" in new_cmd


### PR DESCRIPTION
Closes #897.

> **Depends on #906 (#900).** This branch includes #900's `_exec_args` / `extra_env` changes as its first commit so it is independently testable. Once #906 merges, rebasing this PR will auto-drop that commit (identical patch), leaving only the `terminal.py` migration.

## Summary

`terminal.py` hand-built ~9 `podman exec` invocations, re-implementing the same spawn / communicate / timeout / returncode scaffolding each time. This routes them through the existing `podman.exec_container` / `exec_container_bytes` helpers, which capture output to temp files via `_run` — avoiding the pipe-fd deadlocks that motivated that helper.

### Migrated sites
- `_ensure_base_session`: `has-session` probe + `new-session` create
- `attach_browser`, `set_workspace_token`
- `tmux_command` (3-attempt retry logic preserved)
- `new_window` (`DUPLICATE` detection + window-list parse preserved)
- `load_workspace_state`, `save_workspace_state` (stdin via `stdin_data`)
- `TerminalSession.stop`: `tmux kill-session` cleanup

### Deliberately not migrated
- The **interactive PTY shell path** (`ShellProcess.start` / `_build_exec_argv`) needs a TTY (`-t`) and streams via a PTY master fd — `exec_container*` can't provide that, so it stays a raw subprocess.
- `close_window` and `kill_joiner_sessions` already delegate to `tmux_command` (transitively migrated).

### A wrinkle worth noting
The `HOME` / `SSH_AUTH_SOCK` flags in `_ensure_base_session` are **tmux's own `-e` flags** (passed to `tmux new-session`), not podman exec flags — so they correctly stay in the command list rather than using the new `extra_env` param.

## Behavior preserved
Decoding (`utf-8`/`replace`), timeouts, error messages, and retry / swallow semantics are all unchanged. Output capture moves from `PIPE`+`communicate()` to the temp-file path used across the rest of `podman.py`.

## Test changes
- `test_terminal.py`: mocks move from `asyncio.create_subprocess_exec` → `podman.exec_container` (returning `(rc, stdout, stderr)` tuples). Added a test for the `stop()` kill-session failure path (replaces a `# pragma: no cover`).
- `test_container.py`: the sudo tests now locate the sudoers `exec_container` call by command. `start_container` also calls `terminal.set_workspace_token`, which since this change routes through `exec_container` too — so `exec_container` is no longer called exactly once, and the old `assert_awaited_once()` / last-call assertions no longer held. A `_sudo_call(p)` helper finds the `klangk-configure-sudo` call robustly.

## Verification
- `terminal.py` and `podman.py` both at **100%** coverage.
- Full backend suite: **1586 passed** (5 more than current `main`, which is at 1581).

## Note on the coverage gate
The repo's `--cov-fail-under=100` gate currently fails on `main` itself (≈91.99%, pre-existing — `api.py`/`model.py`/etc. have uncovered lines unrelated to this PR). This PR does not add any new uncovered lines.

## Checklist
- [x] Existing behavior preserved
- [x] No new uncovered lines (`terminal.py` / `podman.py` at 100%)
- [x] Tests updated for the new mock seam + extra `exec_container` caller
- [x] Pre-commit hooks pass (ruff, trufflehog, prettier)