### PR TITLE
refactor(workspaces): route populate_home_skel through exec_container

### DIFF
--- a/src/backend/klangk_backend/workspaces.py
+++ b/src/backend/klangk_backend/workspaces.py
@@ -372,23 +372,13 @@ async def populate_home_skel(
     container runs Ubuntu, which always has it.
     """
     home = f"/home/.users/{user_id}"
-    argv = [
-        "exec",
-        "-u",
-        "klangk",
-        container_id,
-        "/opt/klangk/bin/klangk-setup-home",
-        home,
-    ]
     try:
-        proc = await asyncio.create_subprocess_exec(
-            podman.PODMAN_BIN,
-            *argv,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            env=podman.subprocess_env(),
+        await podman.exec_container(
+            container_id,
+            ["/opt/klangk/bin/klangk-setup-home", home],
+            user="klangk",
+            timeout=10,
         )
-        await asyncio.wait_for(proc.communicate(), timeout=10)
     except Exception:
         logger.warning(
             "Failed to populate skel for user %s in %s",

--- a/src/backend/tests/test_workspaces.py
+++ b/src/backend/tests/test_workspaces.py
@@ -211,23 +211,24 @@ class TestEnsureHomeSymlink:
 class TestPopulateHomeSkel:
     async def test_execs_setup_home(self):
         """populate_home_skel runs podman exec with klangk-setup-home script."""
-        mock_proc = AsyncMock()
-        mock_proc.communicate = AsyncMock(return_value=(b"", b""))
         with patch(
-            "asyncio.create_subprocess_exec",
-            return_value=mock_proc,
+            "klangk_backend.workspaces.podman.exec_container",
+            new_callable=AsyncMock,
+            return_value=(0, "", ""),
         ) as mock_exec:
             await ws_mod.populate_home_skel("cid-123", "uid-456")
-        args = mock_exec.call_args[0]
-        assert "exec" in args
-        assert "cid-123" in args
-        assert any("klangk-setup-home" in str(a) for a in args)
-        assert any("uid-456" in str(a) for a in args)
+        mock_exec.assert_awaited_once_with(
+            "cid-123",
+            ["/opt/klangk/bin/klangk-setup-home", "/home/.users/uid-456"],
+            user="klangk",
+            timeout=10,
+        )
 
     async def test_logs_warning_on_failure(self):
         """populate_home_skel logs but does not raise on failure."""
         with patch(
-            "asyncio.create_subprocess_exec",
+            "klangk_backend.workspaces.podman.exec_container",
+            new_callable=AsyncMock,
             side_effect=OSError("podman not found"),
         ):
             # Should not raise


### PR DESCRIPTION
Follow-up to #897 (PR #908). Applies the same `podman exec` → `podman.exec_container` consolidation to the one remaining one-shot podman exec site that is a clean fit.

## Summary

`workspaces.populate_home_skel` hand-built its `podman exec` invocation (argv list + `create_subprocess_exec` + `wait_for(communicate())`) — the same pattern consolidated across `terminal.py` in #897. Route it through `podman.exec_container`, which encapsulates the same spawn/timeout/returncode scaffolding and captures output to temp files via `_run` (avoiding the pipe-fd deadlocks that motivated that helper).

## Why this site and not others

Of the remaining hand-built `podman exec` sites outside `podman.py`/`terminal.py`, only `populate_home_skel` is a clean swap. It is a clean fit on **both** axes discussed during #897:

- **Failure semantics:** the caller **swallows** errors (logs a warning, continues). `exec_container(..., check=False)` returns `rc` rather than raising, and this caller ignores `rc` anyway — behavior preserved exactly.
- **stdin:** the prior code did **not** pass `stdin=DEVNULL`, i.e. stdin was inherited. `exec_container(stdin_data=None)` also inherits — behavior preserved exactly.

The sibling `agent.py` `setup-clankers` site was **deliberately not migrated**: it passes `stdin=DEVNULL` (would regress to inherited stdin) and is fail-loud on timeout (would regress to a silent `rc=-1`). Migrating it would require extending `exec_container`'s API for a single caller — net negative.

The long-lived/streaming sites (`pi --mode rpc`, `socat` SSH-agent relay, the PTY shell path) are correctly out of scope — they need a TTY / bidirectional streaming that `exec_container*` can't model.

## Test changes
- Mocks move from `asyncio.create_subprocess_exec` → `podman.exec_container`, now asserting the exact call (user, command, container, timeout) rather than substring-matching across the argv array.

## Verification
- `test_workspaces.py` + `test_agent.py` + `test_wshandler.py`: **408 passed** (these cover all callers of `populate_home_skel`).

## Checklist
- [x] Existing behavior preserved (timeout, swallow-and-warn, inherited stdin)
- [x] Tests updated for the new mock seam
- [x] Pre-commit hooks pass (ruff, trufflehog)