### PR TITLE
refactor(ws): extract _find_window terminal-window lookup helper

### DIFF
--- a/src/backend/klangk_backend/wshandler.py
+++ b/src/backend/klangk_backend/wshandler.py
@@ -1502,6 +1502,36 @@ class Connection:
             f"/workspaces/{self.workspace_id}", principals, perm
         )
 
+    def _find_window(
+        self,
+        ws_session: WorkspaceSession,
+        user_id: str,
+        window_id: str,
+        *,
+        shared: bool = False,
+        error_msg: str = "Window not found",
+    ) -> dict | None:
+        """Look up a terminal window by id, sending an error if absent.
+
+        Returns the matching window dict, or None after sending
+        *error_msg* to the socket.  When *shared* is True, only
+        windows already marked shared are considered (used when
+        joining another user's terminal).
+        """
+        windows = ws_session.terminal_windows.get(user_id, [])
+        match = next(
+            (
+                w
+                for w in windows
+                if w.get("id") == window_id and (not shared or w.get("shared"))
+            ),
+            None,
+        )
+        if match is None:
+            send_error(self.sock, error_msg)
+            return None
+        return match
+
     async def handle_share_window(self, msg: dict) -> None:
         """Mark one of the user's own windows as shared."""
         if not self.container_id or not self._user_home:
@@ -1517,10 +1547,8 @@ class Connection:
         ws_session = state.get_session(self.workspace_id)
         if not ws_session:
             return
-        windows = ws_session.terminal_windows.get(user_id, [])
-        match = next((w for w in windows if w.get("id") == window_id), None)
+        match = self._find_window(ws_session, user_id, window_id)
         if match is None:
-            send_error(self.sock, "Window not found")
             return
         match["shared"] = True
         self._broadcast_shared_terminals(ws_session)
@@ -1543,10 +1571,8 @@ class Connection:
         ws_session = state.get_session(self.workspace_id)
         if not ws_session:
             return
-        windows = ws_session.terminal_windows.get(user_id, [])
-        match = next((w for w in windows if w.get("id") == window_id), None)
+        match = self._find_window(ws_session, user_id, window_id)
         if match is None:
-            send_error(self.sock, "Window not found")
             return
         match["shared"] = False
         # Kick spectators/collaborators
@@ -1590,17 +1616,14 @@ class Connection:
         ws_session = state.get_session(self.workspace_id)
         if not ws_session:
             return
-        owner_windows = ws_session.terminal_windows.get(owner_user_id, [])
-        match = next(
-            (
-                w
-                for w in owner_windows
-                if w.get("id") == window_id and w.get("shared")
-            ),
-            None,
+        match = self._find_window(
+            ws_session,
+            owner_user_id,
+            window_id,
+            shared=True,
+            error_msg="Shared terminal not found",
         )
         if match is None:
-            send_error(self.sock, "Shared terminal not found")
             return
         window_name = match["name"]
 
@@ -1790,13 +1813,13 @@ class Connection:
         ws_session = state.get_session(self.workspace_id)
         if not ws_session:
             return
-        owner_windows = ws_session.terminal_windows.get(owner_user_id, [])
-        match = next(
-            (w for w in owner_windows if w.get("id") == window_id),
-            None,
+        match = self._find_window(
+            ws_session,
+            owner_user_id,
+            window_id,
+            error_msg="Terminal not found",
         )
         if match is None:
-            send_error(self.sock, "Terminal not found")
             return
         window_name = match["name"]
         try:
@@ -1809,6 +1832,7 @@ class Connection:
         except Exception as e:
             send_error(self.sock, f"Failed to delete shared terminal: {e}")
             return
+        owner_windows = ws_session.terminal_windows.get(owner_user_id, [])
         owner_windows[:] = [
             w for w in owner_windows if w.get("id") != window_id
         ]

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -4913,6 +4913,95 @@ class TestShareWindowHandlers:
         assert not await conn._has_perm("view")
 
 
+class TestFindWindow:
+    """Direct tests for the extracted _find_window helper (#899).
+
+    Locks its contract independently of the handlers that call it.
+    In particular the shared=True branch, where a window that exists
+    but is not shared must be rejected — previously covered, if at
+    all, only incidentally through the join handlers.
+    """
+
+    def _setup(self, user, windows):
+        sock = _mock_sock()
+        conn = _base_conn(user=user, ws=sock)
+        session = wshandler.state.get_or_create_session("ws-find")
+        if windows is not None:
+            session.terminal_windows[user["id"]] = windows
+        return sock, conn, session
+
+    def _messages(self, sock):
+        return [c[0][0] for c in sock.send_json.call_args_list]
+
+    async def test_found_returns_window(self, user):
+        sock, conn, session = self._setup(
+            user, [{"id": "@0", "name": "a", "shared": False}]
+        )
+        try:
+            assert (
+                conn._find_window(session, user["id"], "@0")
+                == (session.terminal_windows[user["id"]][0])
+            )
+            assert self._messages(sock) == []
+        finally:
+            wshandler.state.sessions.pop("ws-find", None)
+
+    async def test_not_found_sends_error_and_returns_none(self, user):
+        sock, conn, session = self._setup(user, [])
+        try:
+            assert conn._find_window(session, user["id"], "@99") is None
+            assert self._messages(sock) == [
+                {"type": "error", "message": "Window not found"}
+            ]
+        finally:
+            wshandler.state.sessions.pop("ws-find", None)
+
+    async def test_shared_true_finds_shared_window(self, user):
+        sock, conn, session = self._setup(
+            user, [{"id": "@0", "name": "a", "shared": True}]
+        )
+        try:
+            found = conn._find_window(session, user["id"], "@0", shared=True)
+            assert found is not None
+            assert found["name"] == "a"
+        finally:
+            wshandler.state.sessions.pop("ws-find", None)
+
+    async def test_shared_true_rejects_unshared_window(self, user):
+        """A present-but-unshared window is treated as not found."""
+        sock, conn, session = self._setup(
+            user, [{"id": "@0", "name": "a", "shared": False}]
+        )
+        try:
+            assert (
+                conn._find_window(session, user["id"], "@0", shared=True)
+                is None
+            )
+            assert self._messages(sock) == [
+                {"type": "error", "message": "Window not found"}
+            ]
+        finally:
+            wshandler.state.sessions.pop("ws-find", None)
+
+    async def test_custom_error_message(self, user):
+        sock, conn, session = self._setup(user, [])
+        try:
+            assert (
+                conn._find_window(
+                    session,
+                    user["id"],
+                    "@99",
+                    error_msg="Shared terminal not found",
+                )
+                is None
+            )
+            assert self._messages(sock) == [
+                {"type": "error", "message": "Shared terminal not found"}
+            ]
+        finally:
+            wshandler.state.sessions.pop("ws-find", None)
+
+
 class TestFractionalTimeout:
     async def test_fractional_timeout_display(
         self, user, monkeypatch, agent_user


### PR DESCRIPTION
## Summary
- Five terminal-window handlers duplicated the same lookup + not-found-error block (scan `ws_session.terminal_windows` by id, `send_error`, `return`)
- Extract `Connection._find_window(ws_session, user_id, window_id, *, shared=False, error_msg=...) -> dict | None` that does the lookup and emits the error; each handler now reduces to a `match/return` guard
- `handle_share_window` / `handle_unshare_window`: default lookup; `handle_join_shared_terminal`: `shared=True` + its own message; `handle_delete_shared_terminal`: its own message and rebinds `owner_windows` before the in-place list rebuild
- `handle_create_shared_terminal` left untouched — it looks up by **name**, not id, and has no not-found error path (doesn't fit the helper)
- Adds `TestFindWindow` pinning the helper's contract directly. The `shared=True` branch (a window that **exists but is not shared** must be rejected) was previously covered, if at all, only incidentally via the join handlers — added an explicit test, verified to fail if the `shared` filter is disabled
- `wshandler.py` remains at 100% coverage; all 338 handler tests pass

Closes #899