### PR TITLE
perf(api): batch ACL reads in /my-permissions (878ms → ~floor)

### DIFF
--- a/src/backend/klangk_backend/acl.py
+++ b/src/backend/klangk_backend/acl.py
@@ -42,6 +42,23 @@ def _ace_matches_principals(ace: dict, principals: dict) -> bool:
     return False
 
 
+def _resource_ancestors(resource_path: str) -> list[str]:
+    """Return [resource_path, ..., '/'] — the paths ``check_permission`` walks.
+
+    Mirrors the loop in [check_permission] so a caller can preload ACL
+    entries for exactly these paths and evaluate permissions in memory.
+    """
+    paths: list[str] = []
+    path = resource_path
+    while True:
+        paths.append(path)
+        if path == "/":
+            break
+        parent = path.rsplit("/", 1)[0]
+        path = parent if parent else "/"
+    return paths
+
+
 async def check_permission(
     resource_path: str,
     principals: dict,
@@ -52,18 +69,67 @@ async def check_permission(
     Returns True if an Allow ACE matches, False if a Deny ACE matches
     or no match is found (default deny).
     """
-    path = resource_path
-    while True:
+    for path in _resource_ancestors(resource_path):
         aces = await model.get_acl_entries(path)
         for ace in aces:
             if _ace_matches_principals(ace, principals):
                 if ace["permission"] == "*" or ace["permission"] == permission:
                     return ace["action"] == ACTION_ALLOW
-        if path == "/":
-            break
-        parent = path.rsplit("/", 1)[0]
-        path = parent if parent else "/"
     return False
+
+
+def check_permission_cached(
+    resource_path: str,
+    principals: dict,
+    permission: str,
+    entries_by_resource: dict[str, list[dict]],
+) -> bool:
+    """In-memory equivalent of [check_permission] over a preloaded ACE map.
+
+    ``entries_by_resource`` must contain every ancestor of
+    ``resource_path`` (see [_resource_ancestors]); missing paths are treated
+    as having no entries, matching the async version's behavior.
+    """
+    for path in _resource_ancestors(resource_path):
+        for ace in entries_by_resource.get(path, ()):
+            if _ace_matches_principals(ace, principals):
+                if ace["permission"] == "*" or ace["permission"] == permission:
+                    return ace["action"] == ACTION_ALLOW
+    return False
+
+
+async def permissions_for_resources(
+    resources: list[str],
+    principals: dict,
+    permissions: list[str],
+) -> dict[str, list[str]]:
+    """Effective permissions for each resource, preload-then-evaluate.
+
+    Fetches ACL entries for the union of every resource's ancestor paths
+    in a single query ([model.get_acl_entries_map]), then checks each
+    (resource, permission) pair in memory via [check_permission_cached].
+    This is equivalent to awaiting [check_permission] once per pair, but
+    avoids opening a fresh database connection per pair — the static
+    resource set previously triggered ~300 sequential connection-per-query
+    reads on every ``/my-permissions`` call.
+
+    Only resources with at least one granted permission appear in the
+    result, matching the historical response shape.
+    """
+    ancestor_paths: list[str] = []
+    for res in resources:
+        ancestor_paths.extend(_resource_ancestors(res))
+    entries = await model.get_acl_entries_map(ancestor_paths)
+    result: dict[str, list[str]] = {}
+    for res in resources:
+        perms = [
+            p
+            for p in permissions
+            if check_permission_cached(res, principals, p, entries)
+        ]
+        if perms:
+            result[res] = perms
+    return result
 
 
 def _request_to_resource(request: Request) -> str:

--- a/src/backend/klangk_backend/acl.py
+++ b/src/backend/klangk_backend/acl.py
@@ -78,7 +78,7 @@ async def check_permission(
     return False
 
 
-def check_permission_cached(
+def check_permission_inmemory(
     resource_path: str,
     principals: dict,
     permission: str,
@@ -89,6 +89,11 @@ def check_permission_cached(
     ``entries_by_resource`` must contain every ancestor of
     ``resource_path`` (see [_resource_ancestors]); missing paths are treated
     as having no entries, matching the async version's behavior.
+
+    This does no I/O and stores nothing: ``entries_by_resource`` is a local
+    built fresh on each call by [permissions_for_resources], so every
+    request re-reads the live ``acl_entries`` table. There is no
+    cross-request cache and therefore no invalidation surface.
     """
     for path in _resource_ancestors(resource_path):
         for ace in entries_by_resource.get(path, ()):
@@ -107,11 +112,15 @@ async def permissions_for_resources(
 
     Fetches ACL entries for the union of every resource's ancestor paths
     in a single query ([model.get_acl_entries_map]), then checks each
-    (resource, permission) pair in memory via [check_permission_cached].
+    (resource, permission) pair in memory via [check_permission_inmemory].
     This is equivalent to awaiting [check_permission] once per pair, but
     avoids opening a fresh database connection per pair — the static
     resource set previously triggered ~300 sequential connection-per-query
     reads on every ``/my-permissions`` call.
+
+    No results are retained between requests: ``entries`` is a local that
+    is reloaded from the live ``acl_entries`` table on every call, so a
+    permission change is reflected on the next request immediately.
 
     Only resources with at least one granted permission appear in the
     result, matching the historical response shape.
@@ -125,7 +134,7 @@ async def permissions_for_resources(
         perms = [
             p
             for p in permissions
-            if check_permission_cached(res, principals, p, entries)
+            if check_permission_inmemory(res, principals, p, entries)
         ]
         if perms:
             result[res] = perms

--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -2668,26 +2668,21 @@ async def my_permissions(
     principals = await acl.get_principals(user["id"])
     groups = await model.get_user_groups(user["id"])
     if resource is not None:
-        perms = [
-            p
-            for p in ALL_PERMISSIONS
-            if await acl.check_permission(resource, principals, p)
-        ]
+        permissions = await acl.permissions_for_resources(
+            [resource], principals, ALL_PERMISSIONS
+        )
+        perms = permissions.get(resource, [])
         return {
             "user_id": user["id"],
             "email": user["email"],
             "groups": groups,
             "permissions": {resource: perms} if perms else {},
         }
-    permissions = {}
-    for res in STATIC_RESOURCES:
-        perms = [
-            p
-            for p in ALL_PERMISSIONS
-            if await acl.check_permission(res, principals, p)
-        ]
-        if perms:
-            permissions[res] = perms
+    # Batch all static resources into a single ACL query instead of
+    # awaiting check_permission() per resource/permission pair.
+    permissions = await acl.permissions_for_resources(
+        STATIC_RESOURCES, principals, ALL_PERMISSIONS
+    )
     return {
         "user_id": user["id"],
         "email": user["email"],

--- a/src/backend/klangk_backend/model.py
+++ b/src/backend/klangk_backend/model.py
@@ -825,6 +825,21 @@ async def add_acl_entry(
         return cursor.lastrowid
 
 
+def _row_to_acl_entry(row) -> dict:
+    """Map an acl_entries row to the dict shape callers expect."""
+    return {
+        "id": row["id"],
+        "resource": row["resource"],
+        "position": row["position"],
+        "action": row["action"],
+        "principal_type": row["principal_type"],
+        "user_id": row["user_id"],
+        "group_id": row["group_id"],
+        "system_principal": row["system_principal"],
+        "permission": row["permission"],
+    }
+
+
 async def get_acl_entries(resource: str) -> list[dict]:
     """Get ACL entries for a resource, ordered by position."""
     async with transaction() as db:
@@ -835,20 +850,38 @@ async def get_acl_entries(resource: str) -> list[dict]:
             " ORDER BY position",
             (resource,),
         )
-        return [
-            {
-                "id": row["id"],
-                "resource": row["resource"],
-                "position": row["position"],
-                "action": row["action"],
-                "principal_type": row["principal_type"],
-                "user_id": row["user_id"],
-                "group_id": row["group_id"],
-                "system_principal": row["system_principal"],
-                "permission": row["permission"],
-            }
-            for row in await cursor.fetchall()
-        ]
+        return [_row_to_acl_entry(row) for row in await cursor.fetchall()]
+
+
+async def get_acl_entries_map(
+    resources: list[str],
+) -> dict[str, list[dict]]:
+    """Fetch ACL entries for many resources in a single query.
+
+    Returns a ``{resource: [entries]}`` map (entries ordered by position).
+    Resources with no entries are present as empty lists. This exists so
+    callers that check many resources/permissions (e.g. ``my_permissions``)
+    don't open one DB connection per resource — see ``acl.check_permission``
+    which previously caused ~300 sequential connection-per-query reads.
+    """
+    resources = list(dict.fromkeys(resources))  # de-dup, keep order
+    result: dict[str, list[dict]] = {r: [] for r in resources}
+    if not resources:
+        return result
+    placeholders = ",".join("?" for _ in resources)
+    async with transaction() as db:
+        cursor = await db.execute(
+            "SELECT id, resource, position, action, principal_type,"
+            " user_id, group_id, system_principal, permission"
+            " FROM acl_entries WHERE resource IN"
+            f" ({placeholders}) ORDER BY position",
+            tuple(resources),
+        )
+        for row in await cursor.fetchall():
+            result.setdefault(row["resource"], []).append(
+                _row_to_acl_entry(row)
+            )
+    return result
 
 
 async def get_acl_entries_resolved(resource: str) -> list[dict]:

--- a/src/backend/tests/test_acl.py
+++ b/src/backend/tests/test_acl.py
@@ -159,6 +159,147 @@ class TestCheckPermission:
         assert await acl.check_permission("/test", principals, "edit") is False
 
 
+class TestCheckPermissionCached:
+    """The batched in-memory path must match the per-call async path."""
+
+    _RESOURCES = ["/", "/workspaces", "/admin/users"]
+    _PERMISSIONS = ["view", "edit", "create", "terminal", "*"]
+
+    async def test_cached_matches_async_across_resources(self, user):
+        # Seed a mix: allow on root (everyone), allow on /admin (user),
+        # deny on /admin/users (authenticated) to exercise parent walk +
+        # first-match-wins + wildcard in both code paths.
+        await model.add_acl_entry(
+            "/",
+            0,
+            ACTION_ALLOW,
+            "view",
+            PRINCIPAL_SYSTEM,
+            system_principal=SYSTEM_EVERYONE,
+        )
+        await model.add_acl_entry(
+            "/admin",
+            0,
+            ACTION_ALLOW,
+            "*",
+            PRINCIPAL_USER,
+            user_id=user["id"],
+        )
+        await model.add_acl_entry(
+            "/admin/users",
+            0,
+            ACTION_DENY,
+            "view",
+            PRINCIPAL_SYSTEM,
+            system_principal=SYSTEM_AUTHENTICATED,
+        )
+        principals = await acl.get_principals(user["id"])
+
+        ancestor_paths: list[str] = []
+        for res in self._RESOURCES:
+            ancestor_paths.extend(acl._resource_ancestors(res))
+        entries = await model.get_acl_entries_map(ancestor_paths)
+
+        for res in self._RESOURCES:
+            for perm in self._PERMISSIONS:
+                async_result = await acl.check_permission(
+                    res, principals, perm
+                )
+                cached_result = acl.check_permission_cached(
+                    res, principals, perm, entries
+                )
+                assert async_result == cached_result, (
+                    f"mismatch for {res}/{perm}: "
+                    f"async={async_result} cached={cached_result}"
+                )
+
+    async def test_permissions_for_resources_matches_pairwise(self, user):
+        await model.add_acl_entry(
+            "/workspaces",
+            0,
+            ACTION_ALLOW,
+            "view",
+            PRINCIPAL_SYSTEM,
+            system_principal=SYSTEM_AUTHENTICATED,
+        )
+        await model.add_acl_entry(
+            "/admin",
+            0,
+            ACTION_ALLOW,
+            "terminal",
+            PRINCIPAL_USER,
+            user_id=user["id"],
+        )
+        principals = await acl.get_principals(user["id"])
+
+        batched = await acl.permissions_for_resources(
+            self._RESOURCES, principals, self._PERMISSIONS
+        )
+
+        # Reconstruct the same map the old pairwise loop produced.
+        pairwise: dict[str, list[str]] = {}
+        for res in self._RESOURCES:
+            perms = [
+                p
+                for p in self._PERMISSIONS
+                if await acl.check_permission(res, principals, p)
+            ]
+            if perms:
+                pairwise[res] = perms
+        assert batched == pairwise
+
+
+class TestGetAclEntriesMap:
+    async def test_single_query_for_many_resources(self, user):
+        await model.add_acl_entry(
+            "/workspaces",
+            0,
+            ACTION_ALLOW,
+            "view",
+            PRINCIPAL_SYSTEM,
+            system_principal=SYSTEM_AUTHENTICATED,
+        )
+        await model.add_acl_entry(
+            "/admin",
+            0,
+            ACTION_ALLOW,
+            "edit",
+            PRINCIPAL_USER,
+            user_id=user["id"],
+        )
+        result = await model.get_acl_entries_map(
+            ["/workspaces", "/admin", "/nonexistent"]
+        )
+        # Every requested resource is a key; missing ones are empty lists.
+        assert set(result.keys()) == {
+            "/workspaces",
+            "/admin",
+            "/nonexistent",
+        }
+        assert len(result["/workspaces"]) == 1
+        assert result["/workspaces"][0]["permission"] == "view"
+        assert len(result["/admin"]) == 1
+        assert result["/nonexistent"] == []
+
+    async def test_empty_resource_list(self):
+        assert await model.get_acl_entries_map([]) == {}
+
+    async def test_de_duplicates_resources(self, user):
+        await model.add_acl_entry(
+            "/workspaces",
+            0,
+            ACTION_ALLOW,
+            "view",
+            PRINCIPAL_SYSTEM,
+            system_principal=SYSTEM_AUTHENTICATED,
+        )
+        result = await model.get_acl_entries_map(
+            ["/workspaces", "/workspaces"]
+        )
+        assert list(result.keys()) == ["/workspaces"]
+        assert len(result["/workspaces"]) == 1
+
+
 class TestRequestToResource:
     def _make_request(self, path):
         request = MagicMock()

--- a/src/backend/tests/test_acl.py
+++ b/src/backend/tests/test_acl.py
@@ -159,13 +159,13 @@ class TestCheckPermission:
         assert await acl.check_permission("/test", principals, "edit") is False
 
 
-class TestCheckPermissionCached:
+class TestCheckPermissionInMemory:
     """The batched in-memory path must match the per-call async path."""
 
     _RESOURCES = ["/", "/workspaces", "/admin/users"]
     _PERMISSIONS = ["view", "edit", "create", "terminal", "*"]
 
-    async def test_cached_matches_async_across_resources(self, user):
+    async def test_inmemory_matches_async_across_resources(self, user):
         # Seed a mix: allow on root (everyone), allow on /admin (user),
         # deny on /admin/users (authenticated) to exercise parent walk +
         # first-match-wins + wildcard in both code paths.
@@ -205,12 +205,12 @@ class TestCheckPermissionCached:
                 async_result = await acl.check_permission(
                     res, principals, perm
                 )
-                cached_result = acl.check_permission_cached(
+                inmemory_result = acl.check_permission_inmemory(
                     res, principals, perm, entries
                 )
-                assert async_result == cached_result, (
+                assert async_result == inmemory_result, (
                     f"mismatch for {res}/{perm}: "
-                    f"async={async_result} cached={cached_result}"
+                    f"async={async_result} inmemory={inmemory_result}"
                 )
 
     async def test_permissions_for_resources_matches_pairwise(self, user):


### PR DESCRIPTION
## Summary

`GET /api/v1/my-permissions` sits on the critical login / app-start path (called by `AuthService` after every login and on startup). This is **opportunity #1** from a responsiveness audit measured against \`demo.toughserv.com/klangk\`.

### Measured problem
Against the demo, `/api/v1/my-permissions` consistently took **~878ms** — about **620ms of pure server work** above the ~250ms network floor (verified via repeated sampling; every other endpoint sits right at the floor).

### Root cause
`my_permissions()` awaited `acl.check_permission()` once per `(resource, permission)` pair: **7 static resources × 17 permissions = 119 calls**. Each `check_permission` walks every ancestor path, calling `model.get_acl_entries()` per segment. Because the engine uses `NullPool` (every `transaction()` is a fresh SQLite connection: connect + 3 PRAGMAs + query + close), a single call issued **~300 sequential connection-per-query reads**.

### Fix
Preload all relevant ACL entries in **one query** (`model.get_acl_entries_map`, `WHERE resource IN (...)`), then evaluate every pair in memory (`acl.check_permission_cached`). `acl.permissions_for_resources` wraps the preload + evaluate flow.

Micro-benchmark over the static resource set (local, NullPool + SQLite):

| path | ms/call |
|---|---|
| pairwise `check_permission` (old) | **1172** |
| batched `permissions_for_resources` (new) | **7** |

→ **~174× faster**, saving ~1165ms/call. On the demo this should drop `/my-permissions` from ~878ms to the ~260ms network floor.

`check_permission` is refactored to share an `_resource_ancestors` helper (behavior identical; covered by existing tests). The public response shape of `/my-permissions` is unchanged.

## Test plan
- [x] New tests assert `check_permission_cached` / `permissions_for_resources` match the async pairwise path across resources (incl. parent-walk, first-match-wins, wildcard), plus `get_acl_entries_map` coverage (multi-resource, empty list, de-dup).
- [x] Full backend suite: **1595 passed**.
- [x] Pre-commit hooks pass (ruff format/check, prettier, trufflehog).
- [ ] CI backend-tests (100% coverage gate).

## Other responsiveness opportunities found (not in this PR)
For follow-ups, the audit also identified:
- **WS connect pre-check** adds ~250ms before every connect/reconnect on all browsers (`_waitForServer()`; only Firefox needs it).
- **Per-request ACL `Depends(has_permission)`** opens 2–3 fresh `NullPool` conns per authed request (50 endpoints) — could share the batched preload within a request.
- **File-viewer dir navigation** (250–440ms/click) has no client cache; revisiting a seen dir re-fetches.