### PR TITLE
perf(ws): skip HTTP pre-check on non-Firefox browsers (saves ~250ms)

### DIFF
--- a/src/frontend/lib/utils/web_helpers_stub.dart
+++ b/src/frontend/lib/utils/web_helpers_stub.dart
@@ -22,6 +22,9 @@ String getLocationHash() => '';
 /// Stub — return empty query string in VM tests.
 String getLocationSearch() => '';
 
+/// Stub — no User-Agent outside the browser.
+String getUserAgent() => '';
+
 /// Query params captured at startup (empty in VM tests).
 Map<String, String> capturedPageQuery = {};
 

--- a/src/frontend/lib/utils/web_helpers_web.dart
+++ b/src/frontend/lib/utils/web_helpers_web.dart
@@ -48,6 +48,11 @@ String getLocationHash() => web.window.location.hash;
 /// Get the browser's location query string (e.g. '?token=xxx').
 String getLocationSearch() => web.window.location.search;
 
+/// The browser's User-Agent string. Used to detect Firefox (whose
+/// FailDelayManager can throttle WebSocket reconnects) so the HTTP pre-check
+/// in [WsClient._waitForServer] only runs there.
+String getUserAgent() => web.window.navigator.userAgent;
+
 /// Query params captured from the page URL at startup, before GoRouter
 /// navigation clears them. Plugin callback routes read from this.
 Map<String, String> capturedPageQuery = {};

--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -71,6 +71,17 @@ class WsClient extends ChangeNotifier {
   @visibleForTesting
   static Duration Function(int attempt)? testBackoffOverride;
 
+  /// Whether [userAgent] identifies Firefox. Pure (no DOM) so it is
+  /// unit-tested directly; the live browser UA is read via [getUserAgent]
+  /// (see [_waitForServer]).
+  ///
+  /// Firefox's UA contains "Firefox"; Chrome, Edge and Safari do not
+  /// (Safari carries "Safari" but not "Firefox", Chrome carries
+  /// "Chrome" but not "Firefox").
+  @visibleForTesting
+  static bool isFirefoxUserAgent(String userAgent) =>
+      userAgent.contains('Firefox');
+
   /// Inject a pre-connected channel for testing.
   @visibleForTesting
   void connectForTest(WebSocketChannel channel) {
@@ -163,6 +174,11 @@ class WsClient extends ChangeNotifier {
     if (testHttpPreCheck != null) return testHttpPreCheck!();
     if (testChannelFactory != null) return true; // coverage:ignore-line
     // coverage:ignore-start
+    // The HTTP pre-check exists only to drain Firefox's FailDelayManager
+    // throttle (which can delay a WebSocket reconnect by 30-60s after an
+    // unclean close). Other browsers connect immediately, so skip the
+    // extra round-trip (~250ms) and open the WebSocket straight away.
+    if (!isFirefoxUserAgent(getUserAgent())) return true;
     try {
       final resp = await http.get(Uri.parse('$_httpBaseUrl/api/v1/config'));
       return resp.statusCode == 200;

--- a/src/frontend/test/ws_client_test.dart
+++ b/src/frontend/test/ws_client_test.dart
@@ -313,6 +313,60 @@ void main() {
     });
   });
 
+  group('WsClient.isFirefoxUserAgent', () {
+    // Real User-Agent strings sampled from each browser engine.
+    test('detects Firefox', () {
+      expect(
+        WsClient.isFirefoxUserAgent(
+          'Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 '
+          'Firefox/128.0',
+        ),
+        isTrue,
+      );
+      expect(
+        WsClient.isFirefoxUserAgent(
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 14.5; rv:126.0) '
+          'Gecko/20100101 Firefox/126.0',
+        ),
+        isTrue,
+      );
+    });
+
+    test('rejects Chrome', () {
+      expect(
+        WsClient.isFirefoxUserAgent(
+          'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, '
+          'like Gecko) Chrome/124.0.0.0 Safari/537.36',
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects Safari (carries "Safari" but not "Firefox")', () {
+      expect(
+        WsClient.isFirefoxUserAgent(
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/'
+          '605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15',
+        ),
+        isFalse,
+      );
+    });
+
+    test('rejects Edge', () {
+      expect(
+        WsClient.isFirefoxUserAgent(
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
+          '(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36 Edg/124.0.0.0',
+        ),
+        isFalse,
+      );
+    });
+
+    test('empty UA is not Firefox', () {
+      expect(WsClient.isFirefoxUserAgent(''), isFalse);
+    });
+  });
+
   group('WsClient.dispose', () {
     test('dispose cleans up streams', () {
       final client = WsClient();


### PR DESCRIPTION
Closes #916.

## Summary

From the #914 responsiveness audit: \`WsClient._waitForServer()\` runs a full HTTP GET to \`/api/v1/config\` and gates the WebSocket open on it — on **every** connect and reconnect, on **all** browsers. That's ~250ms of added latency before the WS even starts opening, on the critical path of opening a workspace.

The pre-check exists only to drain **Firefox's** \`FailDelayManager\` throttle (30–60s after an unclean WS close), which does not affect Chromium/WebKit. So on non-Firefox browsers, skip the extra round-trip and open the WebSocket directly; keep the pre-check for Firefox exactly as before.

## Changes
- \`web_helpers\`: add \`getUserAgent()\` (stub \`''\` / web \`navigator.userAgent\`), matching the existing DOM-access conditional-import pattern.
- \`ws_client\`: add a pure, unit-tested \`isFirefoxUserAgent()\` and guard the HTTP GET behind it — placed inside the **existing** \`coverage:ignore\` browser block, so the Firefox path and its reconnect-server-up detection are unchanged.

## Behavior preservation
- Firefox: the pre-check still runs (FailDelayManager drain + reconnect server-up detection intact).
- Chromium/WebKit: WS opens immediately, ~250ms faster.
- The two existing pre-check tests (\`testHttpPreCheck\` override) still pass unchanged; \`testChannelFactory\` still short-circuits before the guard.

## Test plan
- [x] New \`isFirefoxUserAgent\` tests against real UA strings for Firefox (Linux/macOS), Chrome, Safari, Edge, and empty.
- [x] Full frontend suite: **582 passed**, **100% coverage** (\`ws_client.dart\` 301/301, TOTAL 2708/2708).
- [x] Pre-commit hooks pass (dart format, prettier, trufflehog).