### PR TITLE
perf(acl): batch the per-request ACL read in check_permission

### DIFF
--- a/src/backend/klangk_backend/acl.py
+++ b/src/backend/klangk_backend/acl.py
@@ -68,14 +68,21 @@ async def check_permission(
 
     Returns True if an Allow ACE matches, False if a Deny ACE matches
     or no match is found (default deny).
+
+    Fetches the ACEs for every ancestor of [resource_path] in a single
+    query ([model.get_acl_entries_map]) and evaluates them in memory via
+    [check_permission_inmemory] — equivalent to one [model.get_acl_entries]
+    call per path segment, but without opening a fresh [NullPool] database
+    connection per segment (2-3 connections per call -> 1). Nothing is
+    retained across requests; the live ``acl_entries`` table is re-read on
+    every call, so a permission change is reflected immediately.
     """
-    for path in _resource_ancestors(resource_path):
-        aces = await model.get_acl_entries(path)
-        for ace in aces:
-            if _ace_matches_principals(ace, principals):
-                if ace["permission"] == "*" or ace["permission"] == permission:
-                    return ace["action"] == ACTION_ALLOW
-    return False
+    entries = await model.get_acl_entries_map(
+        _resource_ancestors(resource_path)
+    )
+    return check_permission_inmemory(
+        resource_path, principals, permission, entries
+    )
 
 
 def check_permission_inmemory(


### PR DESCRIPTION
Closes #917.

## Summary

From the #914 responsiveness audit (measured against \`demo.toughserv.com/klangk\`): \`check_permission()\` walked a resource's ancestor paths calling \`model.get_acl_entries()\` **per segment**. With \`NullPool\` every \`transaction()\` is a fresh SQLite connection (connect + 3 PRAGMAs + query + close), so each authenticated request opened **2–3 fresh DB connections** just for the ACL gate — across the 48 \`Depends(has_permission(...))\` endpoints plus the per-terminal-op \`_has_perm\` checks in \`wshandler.py\`. Per-call ~5–15ms but **pervasive** (every authed API call + every terminal op).

## Change

Reuse the #914 batching: fetch all of the resource's ancestor ACEs in **one query** (\`model.get_acl_entries_map\`) and evaluate in memory (\`check_permission_inmemory\`). This is a one-function-body change to \`check_permission\` itself.

Making \`check_permission\` itself the batched path means **every caller gets the win with no call-site changes** — \`Depends(has_permission)\`, \`wshandler\`, and the tests that \`patch("klangk_backend.acl.check_permission", ...)\` by name all keep working unchanged (the mock still intercepts).

Micro-benchmark (resource with 3 ancestor segments):

| | ms/call |
|---|---|
| old per-segment | 9.2 |
| new batched | 4.1 |

→ **2.2×, ~5ms/call saved**, on every authenticated request.

## Behavior preservation (no invalidation surface)
- Same paths queried, same ACE order (per-resource \`ORDER BY position\`), same first-match-wins / default-deny. Covered by the \`TestCheckPermissionCached\` equivalence test added in #914 (it asserts \`check_permission\` == \`check_permission_inmemory\` over a preloaded map of the same live data).
- **Nothing is retained across requests** — the live \`acl_entries\` table is re-read on every call, so a permission change is reflected immediately. No cross-request cache → no invalidation surface (the same guarantee discussed in #914).
- \`get_acl_entries()\` (the per-segment reader) still has 4 production callers (ACL-management endpoints) + direct tests; not orphaned.

## Test plan
- [x] \`tests/test_acl.py\` (real-DB behavior) — identical results.
- [x] \`tests/test_wshandler.py\` (patches \`acl.check_permission\` by name at 9 sites) — all still intercept correctly.
- [x] Full backend suite: **1605 passed**.
- [x] Pre-commit hooks pass (ruff format/check, prettier, trufflehog).
- [ ] CI backend-tests (100% coverage gate).