### PR TITLE
perf(files): cache directory listings client-side + graceful 404s

### DIFF
--- a/src/frontend/lib/file_viewer/file_list_cache.dart
+++ b/src/frontend/lib/file_viewer/file_list_cache.dart
@@ -1,0 +1,82 @@
+import 'dart:collection';
+
+/// A cached file-viewer directory listing with an expiry.
+class FileListCacheEntry {
+  final List<Map<String, dynamic>> entries;
+  final DateTime expiresAt;
+
+  FileListCacheEntry(this.entries, this.expiresAt);
+}
+
+/// A small bounded LRU cache of directory listings, keyed by
+/// `(workspaceId, path)`.
+///
+/// Purpose: revisiting a recently-viewed directory renders instantly from
+/// cache instead of re-paying the ~250-440ms listing round-trip every click.
+///
+/// Staleness strategy:
+/// - A short [ttl] bounds how stale a cached entry can be. Within the TTL a
+///   cache hit returns immediately (no network); beyond it the entry is
+///   dropped and the caller refetches.
+/// - Local mutations (upload/delete/rename in this panel) call [invalidate]
+///   for the affected directory before forcing a refetch, so the panel never
+///   shows stale data for a change it just made.
+/// - File content readers (`/files/content`, `/files/download`) are not cached
+///   here — only the (small) directory listing.
+///
+/// No cross-workspace leakage: the workspaceId is part of the key.
+class FileListCache {
+  final int capacity;
+  final Duration ttl;
+  final DateTime Function() _now;
+
+  /// Insertion-ordered map (LinkedHashMap) so the LRU victim is `keys.first`.
+  final LinkedHashMap<String, FileListCacheEntry> _map = LinkedHashMap();
+
+  FileListCache({
+    this.capacity = 32,
+    this.ttl = const Duration(seconds: 5),
+    DateTime Function()? now,
+  }) : _now = now ?? DateTime.now;
+
+  String _key(String workspaceId, String path) => '$workspaceId|$path';
+
+  /// Returns the cached listing for `(workspaceId, path)` if present and
+  /// not expired, marking it most-recently-used; otherwise null.
+  FileListCacheEntry? get(String workspaceId, String path) {
+    final key = _key(workspaceId, path);
+    final entry = _map.remove(key);
+    if (entry == null) return null;
+    if (_now().isAfter(entry.expiresAt)) {
+      // Expired — drop it so the caller refetches.
+      return null;
+    }
+    // Re-insert at the MRU end.
+    _map[key] = entry;
+    return entry;
+  }
+
+  /// Stores [entries] for `(workspaceId, path)`, evicting the LRU victim
+  /// when over capacity.
+  void put(
+    String workspaceId,
+    String path,
+    List<Map<String, dynamic>> entries,
+  ) {
+    final key = _key(workspaceId, path);
+    _map.remove(key);
+    _map[key] = FileListCacheEntry(entries, _now().add(ttl));
+    while (_map.length > capacity) {
+      _map.remove(_map.keys.first);
+    }
+  }
+
+  /// Drops the cached listing for `(workspaceId, path)`, if any. Call after a
+  /// local mutation (delete/rename/upload) so the next read refetches.
+  void invalidate(String workspaceId, String path) {
+    _map.remove(_key(workspaceId, path));
+  }
+
+  /// Clears all cached listings. Used by tests for isolation.
+  void clear() => _map.clear();
+}

--- a/src/frontend/lib/file_viewer/file_viewer_panel.dart
+++ b/src/frontend/lib/file_viewer/file_viewer_panel.dart
@@ -8,11 +8,21 @@ import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 import '../utils/web_helpers_stub.dart'
     if (dart.library.js_interop) '../utils/web_helpers_web.dart';
 import 'file_upload.dart';
+import 'file_list_cache.dart';
 import 'renderers/builtin_file_renderers.dart';
 import '../utils/suppress_browser_menu.dart';
 
 /// Override for testing — set to intercept all HTTP calls in file viewer.
 http.Client? testHttpClientOverride;
+
+/// Shared directory-listing cache, so revisiting a recently-viewed directory
+/// (even across panel rebuilds) renders instantly instead of re-fetching.
+/// Bounded LRU + short TTL; see [FileListCache].
+final FileListCache _fileListCache = FileListCache();
+
+/// Clears the shared file-list cache. Used by tests for isolation.
+@visibleForTesting
+void clearFileListCacheForTest() => _fileListCache.clear();
 
 /// Format a Unix timestamp (seconds since epoch) as a relative time string.
 String formatMtime(dynamic mtime) {
@@ -67,8 +77,41 @@ class FileViewerPanelState extends State<FileViewerPanel> {
   bool _loading = false;
   late final FileRendererRegistry _registry;
 
-  /// Refresh the file list for the current directory.
-  void refresh() => _loadFiles();
+  /// Refresh the file list for the current directory, bypassing the cache
+  /// (manual refresh, or after a mutation that changed this directory).
+  void refresh() => _loadFiles(force: true);
+
+  /// The directory currently displayed. Exposed for tests so navigation
+  /// assertions don't depend on whether a listing fetch happened (the cache
+  /// may serve a revisit without a round-trip).
+  @visibleForTesting
+  String get currentPathForTest => _currentPath;
+
+  /// Test hook for the [FileDropZone.onUploadComplete] path (driving a real
+  /// desktop drop through the widget tree in a unit test is impractical).
+  /// Invalidates the current listing and forces a refetch.
+  @visibleForTesting
+  void triggerUploadCompleteForTest() => _onUploadComplete();
+
+  @visibleForTesting
+  Future<String> readFileTextForTest(String path) => _readFileText(path);
+
+  @visibleForTesting
+  Future<Uint8List> readFileBytesForTest(String path) => _readFileBytes(path);
+
+  /// Drop the cached listing for the current directory and force a refetch.
+  /// Called after local mutations (delete/rename/upload) so the panel never
+  /// shows stale data for a change it just made.
+  void _invalidateCurrent() {
+    _fileListCache.invalidate(widget.workspaceId, _currentPath);
+  }
+
+  /// Called by [FileDropZone] after uploads land. The current directory's
+  /// listing has changed, so invalidate the cached entry and force a refetch.
+  void _onUploadComplete() {
+    _invalidateCurrent();
+    _loadFiles(force: true);
+  }
 
   /// Opens [path] (absolute container path) directly in the viewer: positions
   /// the browser at the file's directory — so the path bar's up/breadcrumbs
@@ -107,8 +150,22 @@ class FileViewerPanelState extends State<FileViewerPanel> {
           'Authorization': 'Bearer ${widget.authToken}',
       };
 
-  Future<void> _loadFiles() async {
+  Future<void> _loadFiles({bool force = false}) async {
     if (!mounted) return;
+    // Read-through cache: a fresh-enough hit renders instantly and skips
+    // the listing round-trip (~250-440ms), so navigating back to a recently
+    // viewed directory feels instantaneous. `force` (manual refresh, or a
+    // mutation that changed this directory) bypasses the cache.
+    if (!force) {
+      final cached = _fileListCache.get(widget.workspaceId, _currentPath);
+      if (cached != null) {
+        setState(() {
+          _entries = cached.entries;
+          _loading = false;
+        });
+        return;
+      }
+    }
     setState(() => _loading = true);
     try {
       final response = await _client.get(
@@ -119,8 +176,9 @@ class FileViewerPanelState extends State<FileViewerPanel> {
       );
       if (response.statusCode == 200) {
         final data = jsonDecode(response.body) as List;
-        if (mounted)
-          setState(() => _entries = data.cast<Map<String, dynamic>>());
+        final entries = data.cast<Map<String, dynamic>>();
+        _fileListCache.put(widget.workspaceId, _currentPath, entries);
+        if (mounted) setState(() => _entries = entries);
       } else {
         debugPrint('File listing failed: ${response.statusCode}');
       }
@@ -140,6 +198,16 @@ class FileViewerPanelState extends State<FileViewerPanel> {
       ),
       headers: _headers,
     );
+    if (response.statusCode == 404) {
+      // The file no longer exists (e.g. deleted in the terminal since the
+      // listing was cached). Invalidate the cached listing so the next
+      // navigation/refresh refetches, and surface a clear message to the
+      // renderer. (Don't trigger a listing refresh here — this read runs
+      // lazily during the renderer's build, and a setState from build would
+      // loop on a persistently-missing file.)
+      _invalidateCurrent();
+      throw Exception('$path no longer exists');
+    }
     if (response.statusCode != 200) {
       throw Exception('Failed to read $path: ${response.statusCode}');
     }
@@ -147,7 +215,6 @@ class FileViewerPanelState extends State<FileViewerPanel> {
     return data['content'] as String? ?? '';
   }
 
-  /// Reads a file's raw bytes via the `/files/download` endpoint. Injected into
   /// [RenderableFile.readBytes] for binary renderers (image/pdf/video).
   Future<Uint8List> _readFileBytes(String path) async {
     final response = await _client.get(
@@ -156,13 +223,19 @@ class FileViewerPanelState extends State<FileViewerPanel> {
       ),
       headers: _headers,
     );
+    if (response.statusCode == 404) {
+      // The file no longer exists since the listing was cached; invalidate
+      // the listing so the next navigation/refresh refetches and surface a
+      // clear message. (No listing refresh here — see _readFileText.)
+      _invalidateCurrent();
+      throw Exception('$path no longer exists');
+    }
     if (response.statusCode != 200) {
       throw Exception('Failed to download $path: ${response.statusCode}');
     }
     return response.bodyBytes;
   }
 
-  /// Persists [content] to [path] via the `/files/upload` endpoint (which
   /// overwrites). Injected into [RenderableFile.saveText] so editor renderers
   /// can save edits.
   Future<void> _saveFileText(String path, String content) async {
@@ -240,8 +313,17 @@ class FileViewerPanelState extends State<FileViewerPanel> {
         ),
         headers: _headers,
       );
-      if (response.statusCode == 200) {
-        _loadFiles();
+      if (response.statusCode == 200 || response.statusCode == 404) {
+        // 404 means it was already gone (e.g. deleted in the terminal
+        // since the listing was cached) — the user's goal is satisfied, so
+        // drop the stale entry and reload rather than alarming them.
+        _invalidateCurrent();
+        _loadFiles(force: true);
+        if (response.statusCode == 404 && mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('"$name" was already deleted')),
+          );
+        }
       } else {
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
@@ -299,7 +381,16 @@ class FileViewerPanelState extends State<FileViewerPanel> {
         body: jsonEncode({'old_path': path, 'new_path': newPath}),
       );
       if (response.statusCode == 200) {
-        _loadFiles();
+        _invalidateCurrent();
+        _loadFiles(force: true);
+      } else if (response.statusCode == 404 && mounted) {
+        // Source no longer exists (e.g. deleted in the terminal since the
+        // listing was cached). Drop the stale entry and inform the user.
+        _invalidateCurrent();
+        _loadFiles(force: true);
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('"$name" no longer exists')),
+        );
       } else {
         if (mounted) {
           final body = jsonDecode(response.body);
@@ -326,6 +417,18 @@ class FileViewerPanelState extends State<FileViewerPanel> {
         '$_baseUrl/api/v1/workspaces/${widget.workspaceId}/files/download?path=${Uri.encodeComponent(path)}';
     try {
       final response = await _client.get(Uri.parse(url), headers: _headers);
+      if (response.statusCode == 404) {
+        // The file no longer exists since the listing was cached; drop the
+        // stale entry and inform the user instead of showing a bare 404.
+        _invalidateCurrent();
+        _loadFiles(force: true);
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('"$name" no longer exists')),
+          );
+        }
+        return;
+      }
       if (response.statusCode != 200) {
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
@@ -473,7 +576,7 @@ class FileViewerPanelState extends State<FileViewerPanel> {
         authToken: widget.authToken,
         currentPath: _currentPath,
         currentEntries: _entries,
-        onUploadComplete: _loadFiles,
+        onUploadComplete: _onUploadComplete,
         child: Column(
           children: [
             // Path bar
@@ -503,7 +606,7 @@ class FileViewerPanelState extends State<FileViewerPanel> {
                     ),
                   IconButton(
                     icon: const Icon(Icons.refresh, size: 28),
-                    onPressed: _loadFiles,
+                    onPressed: () => _loadFiles(force: true),
                     iconSize: 28,
                   ),
                 ],

--- a/src/frontend/test/file_list_cache_test.dart
+++ b/src/frontend/test/file_list_cache_test.dart
@@ -1,0 +1,125 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:klangk_frontend/file_viewer/file_list_cache.dart';
+
+void main() {
+  group('FileListCache', () {
+    test('get returns null for a miss', () {
+      final cache = FileListCache();
+      expect(cache.get('ws-1', '/home/x'), isNull);
+    });
+
+    test('put then get returns the entries', () {
+      final cache = FileListCache();
+      final entries = [
+        {'name': 'a.txt', 'is_dir': false},
+      ];
+      cache.put('ws-1', '/home', entries);
+      final got = cache.get('ws-1', '/home');
+      expect(got, isNotNull);
+      expect(got!.entries, entries);
+    });
+
+    test('entries are isolated by workspaceId', () {
+      final cache = FileListCache();
+      cache.put('ws-1', '/home', [
+        {'name': 'one'}
+      ]);
+      cache.put('ws-2', '/home', [
+        {'name': 'two'}
+      ]);
+      expect(cache.get('ws-1', '/home')!.entries.first['name'], 'one');
+      expect(cache.get('ws-2', '/home')!.entries.first['name'], 'two');
+    });
+
+    test('get drops an expired entry and returns null', () {
+      var now = DateTime(2026, 1, 1, 12, 0, 0);
+      final cache = FileListCache(
+        ttl: const Duration(seconds: 5),
+        now: () => now,
+      );
+      cache.put('ws-1', '/home', [
+        {'name': 'a'}
+      ]);
+      // Within TTL: hit.
+      expect(cache.get('ws-1', '/home'), isNotNull);
+      // Advance past TTL: miss, and the entry is evicted.
+      now = now.add(const Duration(seconds: 6));
+      expect(cache.get('ws-1', '/home'), isNull);
+    });
+
+    test('get promotes an entry to most-recently-used', () {
+      final cache = FileListCache(capacity: 2);
+      cache.put('ws-1', '/a', [
+        {'name': 'a'}
+      ]);
+      cache.put('ws-1', '/b', [
+        {'name': 'b'}
+      ]);
+      // Touch /a so /b becomes the LRU victim.
+      expect(cache.get('ws-1', '/a'), isNotNull);
+      cache.put('ws-1', '/c', [
+        {'name': 'c'}
+      ]); // evicts LRU = /b
+      expect(cache.get('ws-1', '/a'), isNotNull);
+      expect(cache.get('ws-1', '/b'), isNull);
+      expect(cache.get('ws-1', '/c'), isNotNull);
+    });
+
+    test('put evicts the LRU victim when over capacity', () {
+      final cache = FileListCache(capacity: 2);
+      cache.put('ws-1', '/a', [
+        {'name': 'a'}
+      ]);
+      cache.put('ws-1', '/b', [
+        {'name': 'b'}
+      ]);
+      cache.put('ws-1', '/c', [
+        {'name': 'c'}
+      ]); // evicts /a
+      expect(cache.get('ws-1', '/a'), isNull);
+      expect(cache.get('ws-1', '/b'), isNotNull);
+      expect(cache.get('ws-1', '/c'), isNotNull);
+    });
+
+    test('put over an existing key updates it without growing size', () {
+      final cache = FileListCache(capacity: 2);
+      cache.put('ws-1', '/a', [
+        {'name': 'a'}
+      ]);
+      cache.put('ws-1', '/b', [
+        {'name': 'b'}
+      ]);
+      cache.put('ws-1', '/a', [
+        {'name': 'a2'}
+      ]); // replace, no evict
+      expect(cache.get('ws-1', '/a')!.entries.first['name'], 'a2');
+      expect(cache.get('ws-1', '/b'), isNotNull);
+    });
+
+    test('invalidate drops a single entry', () {
+      final cache = FileListCache();
+      cache.put('ws-1', '/a', [
+        {'name': 'a'}
+      ]);
+      cache.put('ws-1', '/b', [
+        {'name': 'b'}
+      ]);
+      cache.invalidate('ws-1', '/a');
+      expect(cache.get('ws-1', '/a'), isNull);
+      expect(cache.get('ws-1', '/b'), isNotNull);
+    });
+
+    test('clear drops all entries', () {
+      final cache = FileListCache();
+      cache.put('ws-1', '/a', [
+        {'name': 'a'}
+      ]);
+      cache.put('ws-1', '/b', [
+        {'name': 'b'}
+      ]);
+      cache.clear();
+      expect(cache.get('ws-1', '/a'), isNull);
+      expect(cache.get('ws-1', '/b'), isNull);
+    });
+  });
+}

--- a/src/frontend/test/file_viewer_m2_test.dart
+++ b/src/frontend/test/file_viewer_m2_test.dart
@@ -121,6 +121,7 @@ Future<_MockWsClient> _pumpPanel(
 }) async {
   testBaseUrlOverride = 'http://localhost:8997';
   testHttpClientOverride = client;
+  clearFileListCacheForTest();
   final ws = _MockWsClient();
   await tester.pumpWidget(
     MaterialApp(
@@ -183,6 +184,7 @@ void main() {
   tearDown(() {
     testBaseUrlOverride = null;
     testHttpClientOverride = null;
+    clearFileListCacheForTest();
   });
 
   group('RawTextRenderer', () {

--- a/src/frontend/test/file_viewer_panel_test.dart
+++ b/src/frontend/test/file_viewer_panel_test.dart
@@ -49,11 +49,13 @@ void main() {
       }
       return http.Response('Not found', 404);
     });
+    clearFileListCacheForTest();
   });
 
   tearDown(() {
     testBaseUrlOverride = null;
     testHttpClientOverride = null;
+    clearFileListCacheForTest();
   });
 
   group('FileViewerPanel', () {
@@ -1147,12 +1149,13 @@ void main() {
         return http.Response('Not found', 404);
       });
       final client = _MockWsClient();
+      final key = GlobalKey<FileViewerPanelState>();
       await tester.pumpWidget(MaterialApp(
           home: Scaffold(
               body: SizedBox(
                   width: 800,
                   height: 600,
-                  child: buildPanel(wsClient: client)))));
+                  child: buildPanel(wsClient: client, key: key)))));
       await tester.pumpAndSettle();
 
       // Navigate deep: . -> a -> a/b
@@ -1161,11 +1164,13 @@ void main() {
       await tester.tap(find.text('b'));
       await tester.pumpAndSettle();
 
-      // Tap the up/parent button
+      // Tap the up/parent button. Revisiting /home/tester/a is a cache
+      // hit (no round-trip), so assert on the panel's current path rather
+      // than on the last-fetched URL.
       await tester.tap(find.byIcon(Icons.arrow_upward));
       await tester.pumpAndSettle();
 
-      expect(lastPath, '/home/tester/a');
+      expect(key.currentState!.currentPathForTest, '/home/tester/a');
       client.close();
     });
 
@@ -1215,12 +1220,13 @@ void main() {
         return http.Response('Not found', 404);
       });
       final client = _MockWsClient();
+      final key = GlobalKey<FileViewerPanelState>();
       await tester.pumpWidget(MaterialApp(
           home: Scaffold(
               body: SizedBox(
                   width: 800,
                   height: 600,
-                  child: buildPanel(wsClient: client)))));
+                  child: buildPanel(wsClient: client, key: key)))));
       await tester.pumpAndSettle();
 
       // Navigate deep
@@ -1229,11 +1235,13 @@ void main() {
       await tester.tap(find.text('deep'));
       await tester.pumpAndSettle();
 
-      // Tap the "sub" breadcrumb segment to go back
+      // Tap the "sub" breadcrumb segment to go back. Revisiting
+      // /home/tester/sub is a cache hit (no round-trip), so assert on the
+      // panel's current path rather than the last-fetched URL.
       await tester.tap(find.text('sub'));
       await tester.pumpAndSettle();
 
-      expect(lastPath, '/home/tester/sub');
+      expect(key.currentState!.currentPathForTest, '/home/tester/sub');
       client.close();
     });
 
@@ -1421,6 +1429,253 @@ void main() {
       const oldTimestamp = 1736899200.0;
       final result = formatMtime(oldTimestamp);
       expect(result, matches(RegExp(r'^\d{4}-\d{2}-\d{2}$')));
+    });
+  });
+
+  group('FileViewerPanel listing cache', () {
+    /// Mock that returns [entries] for every listing request and records how
+    /// many listing fetches happened.
+    (MockClient, int Function()) _countingListing(
+      List<Map<String, dynamic>> entries,
+    ) {
+      var fetches = 0;
+      final client = MockClient((request) async {
+        if (request.method == 'GET' &&
+            request.url.path.contains('/files') &&
+            !request.url.path.contains('/content') &&
+            !request.url.path.contains('/download')) {
+          fetches++;
+          return http.Response(jsonEncode(entries), 200);
+        }
+        return http.Response('Not found', 404);
+      });
+      return (client, () => fetches);
+    }
+
+    Future<GlobalKey<FileViewerPanelState>> _pump(
+      WidgetTester tester,
+      MockClient client,
+    ) async {
+      testBaseUrlOverride = 'http://localhost:8997';
+      testHttpClientOverride = client;
+      clearFileListCacheForTest();
+      final key = GlobalKey<FileViewerPanelState>();
+      await tester.pumpWidget(MaterialApp(
+          home: Scaffold(
+              body: SizedBox(
+                  width: 800,
+                  height: 600,
+                  child: buildPanel(wsClient: _MockWsClient(), key: key)))));
+      await tester.pumpAndSettle();
+      return key;
+    }
+
+    testWidgets('revisiting a directory is served from cache (no refetch)',
+        (tester) async {
+      final (client, fetchCount) = _countingListing([
+        {'name': 'a', 'path': '/home/tester/a', 'is_dir': true, 'size': null},
+      ]);
+      final key = await _pump(tester, client);
+      final firstCount = fetchCount();
+
+      // Navigate into /home/tester/a (cache miss -> fetch), then back up
+      // (cache hit for /home/tester -> no fetch).
+      key.currentState!.openDir('/home/tester/a');
+      await tester.pumpAndSettle();
+      expect(fetchCount(), firstCount + 1);
+      key.currentState!.openDir('/home/tester');
+      await tester.pumpAndSettle();
+      expect(fetchCount(), firstCount + 1); // revisit: served from cache
+    });
+
+    testWidgets('refresh() forces a refetch even on a cache hit',
+        (tester) async {
+      final (client, fetchCount) = _countingListing([]);
+      final key = await _pump(tester, client);
+      final initial = fetchCount();
+
+      key.currentState!.refresh();
+      await tester.pumpAndSettle();
+      expect(fetchCount(), initial + 1);
+    });
+
+    testWidgets('the refresh button forces a refetch', (tester) async {
+      final (client, fetchCount) = _countingListing([]);
+      await _pump(tester, client);
+      final initial = fetchCount();
+
+      await tester.tap(find.byIcon(Icons.refresh));
+      await tester.pumpAndSettle();
+      expect(fetchCount(), initial + 1);
+    });
+
+    testWidgets('upload complete invalidates and forces a refetch',
+        (tester) async {
+      final (client, fetchCount) = _countingListing([]);
+      final key = await _pump(tester, client);
+      final initial = fetchCount();
+
+      key.currentState!.triggerUploadCompleteForTest();
+      await tester.pumpAndSettle();
+      expect(fetchCount(), initial + 1);
+    });
+  });
+
+  group('FileViewerPanel staleness (404 on a cached entry)', () {
+    /// A mock that lists one file [name] and returns [deleteStatus] for a
+    /// DELETE, [renameStatus] for rename, [downloadStatus] for download.
+    MockClient _mock({
+      String name = 'file.txt',
+      int deleteStatus = 404,
+      int renameStatus = 404,
+      int downloadStatus = 404,
+      int contentStatus = 404,
+    }) {
+      final listing = [
+        {
+          'name': name,
+          'path': '/home/tester/$name',
+          'is_dir': false,
+          'size': 5
+        },
+      ];
+      return MockClient((request) async {
+        final p = request.url.path;
+        if (request.method == 'DELETE') {
+          return http.Response('', deleteStatus);
+        }
+        if (p.contains('/files/rename')) {
+          return http.Response(
+              jsonEncode({'detail': 'Source not found'}), renameStatus);
+        }
+        if (p.contains('/files/download')) {
+          return http.Response('x', downloadStatus);
+        }
+        if (p.contains('/files/content')) {
+          return http.Response(jsonEncode({'content': 'x'}), contentStatus);
+        }
+        if (p.contains('/files')) {
+          return http.Response(jsonEncode(listing), 200);
+        }
+        return http.Response('Not found', 404);
+      });
+    }
+
+    Future<GlobalKey<FileViewerPanelState>> _pump(
+      WidgetTester tester,
+      MockClient client,
+    ) async {
+      testBaseUrlOverride = 'http://localhost:8997';
+      testHttpClientOverride = client;
+      clearFileListCacheForTest();
+      final key = GlobalKey<FileViewerPanelState>();
+      await tester.pumpWidget(MaterialApp(
+          home: Scaffold(
+              body: SizedBox(
+                  width: 800,
+                  height: 600,
+                  child: buildPanel(wsClient: _MockWsClient(), key: key)))));
+      await tester.pumpAndSettle();
+      return key;
+    }
+
+    testWidgets('delete of an already-gone file says "already deleted"',
+        (tester) async {
+      await _pump(tester, _mock());
+
+      final center = tester.getCenter(find.text('file.txt'));
+      await tester.tapAt(center, buttons: kSecondaryMouseButton);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Delete'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.widgetWithText(FilledButton, 'Delete'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('already deleted'), findsOneWidget);
+    });
+
+    testWidgets('rename of a gone source says "no longer exists"',
+        (tester) async {
+      await _pump(tester, _mock(name: 'old.txt'));
+
+      final center = tester.getCenter(find.text('old.txt'));
+      await tester.tapAt(center, buttons: kSecondaryMouseButton);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Rename'));
+      await tester.pumpAndSettle();
+      await tester.enterText(find.byType(TextField), 'new.txt');
+      await tester.tap(find.text('Rename'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('no longer exists'), findsOneWidget);
+    });
+
+    testWidgets('download of a gone file says "no longer exists"',
+        (tester) async {
+      await _pump(tester, _mock());
+
+      final center = tester.getCenter(find.text('file.txt'));
+      await tester.tapAt(center, buttons: kSecondaryMouseButton);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Download'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('no longer exists'), findsOneWidget);
+    });
+
+    testWidgets('download non-404 failure shows the bare failure',
+        (tester) async {
+      await _pump(tester, _mock(downloadStatus: 500));
+
+      final center = tester.getCenter(find.text('file.txt'));
+      await tester.tapAt(center, buttons: kSecondaryMouseButton);
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Download'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Download failed'), findsOneWidget);
+    });
+
+    testWidgets('reading a gone file\'s text throws "no longer exists"',
+        (tester) async {
+      final key = await _pump(tester, _mock(name: 'gone.txt'));
+      Object? err;
+      await tester.runAsync(() async {
+        try {
+          await key.currentState!.readFileTextForTest('/home/tester/gone.txt');
+        } catch (e) {
+          err = e;
+        }
+      });
+      expect(err.toString(), contains('no longer exists'));
+    });
+
+    testWidgets('reading a gone file\'s bytes throws "no longer exists"',
+        (tester) async {
+      final key = await _pump(tester, _mock(name: 'gone.txt'));
+      Object? err;
+      await tester.runAsync(() async {
+        try {
+          await key.currentState!.readFileBytesForTest('/home/tester/gone.txt');
+        } catch (e) {
+          err = e;
+        }
+      });
+      expect(err.toString(), contains('no longer exists'));
+    });
+
+    testWidgets('reading bytes with a non-404 error throws the bare failure',
+        (tester) async {
+      final key = await _pump(tester, _mock(downloadStatus: 500));
+      Object? err;
+      await tester.runAsync(() async {
+        try {
+          await key.currentState!.readFileBytesForTest('/home/tester/file.txt');
+        } catch (e) {
+          err = e;
+        }
+      });
+      expect(err.toString(), contains('Failed to download'));
     });
   });
 }

--- a/src/frontend/test/ide_layout_initial_file_test.dart
+++ b/src/frontend/test/ide_layout_initial_file_test.dart
@@ -63,9 +63,11 @@ Widget _ide(GlobalKey<FileViewerPanelState> fvKey, WsClient ws, String? file,
     );
 
 void main() {
+  setUp(clearFileListCacheForTest);
   tearDown(() {
     testBaseUrlOverride = null;
     testHttpClientOverride = null;
+    clearFileListCacheForTest();
   });
 
   testWidgets('initialFile opens the file in the Files tab on load',


### PR DESCRIPTION
Closes #918.

## Summary

From the #914 responsiveness audit (measured against \`demo.toughserv.com/klangk\`): \`FileViewerPanel\` re-fetched the directory listing on **every** navigation (~250–440ms each). Navigating back to a recently-viewed directory re-paid the full round-trip every time, making folder browsing feel sluggish.

## Changes

**Cache:** add a small bounded LRU \`FileListCache\` (keyed by \`workspaceId|path\`, short TTL) with **read-through on navigation** — a fresh-enough hit renders instantly and skips the round-trip. It survives panel rebuilds and is scoped per-workspace (no leakage); nothing is retained beyond the TTL.
- \`refresh()\` and local mutations bypass/invalidate the cache (upload/delete/rename invalidate the affected directory).
- File content readers (\`/files/content\`, \`/files/download\`) are intentionally **not** cached long-term.

**Stale-entry handling (raised during review):** the cache can show an entry that was since deleted in the terminal. Acting on a ghost entry now degrades gracefully instead of a bare failure:
- **delete** 404 → \"was already deleted\" + listing refresh
- **rename** 404 (source gone) → \"no longer exists\" + refresh
- **download** 404 → \"no longer exists\" + refresh
- **content read** 404 → throw \"no longer exists\" + invalidate (deliberately **no** listing refresh from inside the lazy read — it runs during the renderer's build, and a \`setState\` from build would loop on a persistently-missing file)

## Test plan
- [x] New \`file_list_cache_test.dart\` (9 unit tests: get/put, TTL expiry, LRU eviction + recency, invalidate, clear, cross-workspace isolation).
- [x] New panel tests: cache hit skips refetch; \`refresh()\` + refresh button force-refetch; upload-complete invalidates; delete/rename/download/read-404 staleness paths; download non-404 failure.
- [x] Tests that asserted on HTTP-request-path now assert on \`currentPathForTest\` (cache makes revisits not re-fetch).
- [x] \`clearFileListCacheForTest()\` in setUp/tearDown of affected suites for isolation.
- [x] Full frontend suite: **602 passed**, **100% coverage** (\`file_list_cache.dart\` 17/17, \`file_viewer_panel.dart\` 357/357, TOTAL 2768/2768).
- [x] Pre-commit hooks pass (dart format, prettier, trufflehog).