### PR TITLE
fix(ws): clear _reconnecting on no-workspace reconnect

### DIFF
--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -640,10 +640,13 @@ class WsClient extends ChangeNotifier {
     await connect();
     if (_connected && _pendingWorkspaceId != null) {
       connectWorkspace(_pendingWorkspaceId!);
-    } else if (!_connected) {
-      // connect() failed — schedule next attempt
+    } else {
+      // Clear _reconnecting here: when connected with no pending
+      // workspace the server sends no workspace_ready frame (which
+      // otherwise clears it), so _scheduleReconnect would otherwise
+      // short-circuit on the next drop.
       _reconnecting = false;
-      _scheduleReconnect();
+      if (!_connected) _scheduleReconnect();
     }
   }
 

--- a/src/frontend/test/ws_client_test.dart
+++ b/src/frontend/test/ws_client_test.dart
@@ -801,6 +801,49 @@ void main() {
       client.dispose();
     });
 
+    test('reconnect after no-workspace success keeps reconnecting on next drop',
+        () async {
+      // Regression: a successful reconnect with no pending workspace used
+      // to leave _reconnecting = true, so the *next* drop never reconnected.
+      final auth = AuthService();
+      await Future.delayed(Duration.zero);
+
+      final client = WsClient();
+      client.updateAuth(auth);
+      await client.connect();
+      // No workspace joined — _pendingWorkspaceId stays null.
+
+      // First drop + successful reconnect.
+      channels[0].serverClose();
+      for (var i = 0; i < 10 && channels.length < 2; i++) {
+        await Future.delayed(Duration.zero);
+      }
+      expect(channels.length, 2);
+      expect(client.connected, isTrue);
+      // The bug: _reconnecting was left true here.
+      expect(client.reconnecting, isFalse,
+          reason: 'successful reconnect with no workspace must clear '
+              '_reconnecting');
+
+      // Second drop must schedule a fresh reconnect.
+      channels[1].serverClose();
+      await Future.delayed(Duration.zero);
+      expect(client.reconnecting, isTrue,
+          reason: 'client must reconnect again after a second drop');
+      expect(client.reconnectAttempt, greaterThanOrEqualTo(1));
+
+      // ...and it actually reconnects.
+      for (var i = 0; i < 10 && channels.length < 3; i++) {
+        await Future.delayed(Duration.zero);
+      }
+      expect(channels.length, 3);
+      expect(client.connected, isTrue);
+      expect(client.reconnecting, isFalse);
+
+      client.disconnect();
+      client.dispose();
+    });
+
     test('manual connect cancels pending reconnect timer', () async {
       final auth = AuthService();
       await Future.delayed(Duration.zero);


### PR DESCRIPTION
## Summary

Closes #929.

`_attemptReconnect` left `_reconnecting = true` when `connect()` succeeded but `_pendingWorkspaceId` was null. The success-with-workspace path relies on the server's `workspace_ready` frame to clear `_reconnecting`, but that frame never arrives when there is no workspace — so `_scheduleReconnect` short-circuited on every subsequent drop and the client **never reconnected again**. This silently broke `workspaces_changed` delivery for users sitting on the workspace list page, and is reachable precisely because PR #925 hoists the WS connect to login (with no pending workspace).

## Fix

Clear `_reconnecting` in the `else` branch regardless of `_pendingWorkspaceId`, mirroring the reset `workspace_ready` performs:

```dart
if (_connected && _pendingWorkspaceId != null) {
  connectWorkspace(_pendingWorkspaceId!);
} else {
  _reconnecting = false;
  if (!_connected) _scheduleReconnect();
}
```

All three paths are preserved:
- **Success with pending workspace** → `connectWorkspace()`; server `workspace_ready` clears `_reconnecting` (unchanged).
- **Success without pending workspace** → clear `_reconnecting`, no reconnect scheduled (the fix).
- **Connect failed** → clear `_reconnecting`, schedule next attempt (unchanged).

## Test

Added `reconnect after no-workspace success keeps reconnecting on next drop`, which covers exactly the repro from the issue: connect-on-login with no pending workspace → drop → `_attemptReconnect` succeeds with `_pendingWorkspaceId == null` → assert `reconnecting == false` → drop again → assert a new reconnect is scheduled and completes. Verified the test **fails on the unpatched code** (`Expected: false, Actual: <true>`) and passes with the fix.

## Verification

- `flutter test test/ws_client_test.dart`: **78 passed**.
- `flutter analyze lib/ws/ws_client.dart test/ws_client_test.dart`: no issues.

## Out of scope

The reconnect *attempt counter* (`_reconnectAttempt`) is reset only by `workspace_ready`/`disconnectWorkspace`/`_cancelReconnect`, not by a no-workspace successful reconnect — so it accumulates across reconnects while sitting on the list page. This is a separate concern from #929 (which is about `_reconnecting` blocking *all* reconnects) and not touched here; the regression test uses `greaterThanOrEqualTo(1)` rather than coupling to the exact counter value.
