### PR TITLE
fix(auth): slide login lockout window so old failures don't count (#928)

### DIFF
--- a/src/backend/klangk_backend/auth.py
+++ b/src/backend/klangk_backend/auth.py
@@ -58,6 +58,28 @@ def _should_lockout(attempt_info: dict | None) -> bool:
     )  # pragma: no cover
 
 
+def _window_elapsed(attempt_info: dict | None) -> bool:
+    """Return True if the first failure in *attempt_info* predates the
+    sliding lockout window.
+
+    Used to decide whether ``record_failed_login`` should reset the
+    count (old failures stop counting) rather than increment.  ``None``
+    info, a missing/unparseable ``first_attempt_at`` → not elapsed.
+    """
+    if attempt_info is None:
+        return False
+    first = attempt_info.get("first_attempt_at")
+    if not first:
+        return False
+    try:
+        first_dt = datetime.fromisoformat(first)
+    except (TypeError, ValueError):
+        return False
+    return (
+        datetime.now(timezone.utc) - first_dt
+    ).total_seconds() > LOGIN_LOCKOUT_WINDOW
+
+
 _INSECURE_DEFAULT_SECRET = "klangk-dev-secret-change-in-production"
 SECRET_KEY = resolve_env_secret("KLANGK_JWT_SECRET", _INSECURE_DEFAULT_SECRET)
 ALGORITHM = "HS256"
@@ -248,7 +270,12 @@ async def login(req: LoginRequest) -> TokenResponse:
         or not verify_password(req.password, user["password_hash"])
     ):
         if LOGIN_LOCKOUT_FAILURES > 0:
-            await model.record_failed_login(req.email)
+            # Reuse the attempt_info fetched up front for the lockout
+            # check to decide whether the sliding window has elapsed —
+            # if so, reset the count instead of incrementing, so old
+            # failures stop counting toward the threshold.
+            reset = _window_elapsed(attempt_info)
+            await model.record_failed_login(req.email, reset=reset)
             # Check if this attempt triggered a lockout
             updated_info = await model.get_login_attempt_info(req.email)
             if _should_lockout(updated_info):

--- a/src/backend/klangk_backend/model.py
+++ b/src/backend/klangk_backend/model.py
@@ -1561,17 +1561,38 @@ async def get_refreshed_token(jti: str) -> str | None:
 # Login attempt tracking (brute-force protection)
 
 
-async def record_failed_login(email: str) -> None:
-    """Record a failed login attempt for an email. Resets after the window."""
+async def record_failed_login(email: str, *, reset: bool = False) -> None:
+    """Record a failed login attempt for an email.
+
+    Storage only; the sliding-window *decision* lives in ``auth.py``.
+    With ``reset=False`` the existing attempt count is incremented (or a
+    new row is inserted with count 1).  With ``reset=True`` the count is
+    reset to 1, ``first_attempt_at`` moved to now, and any stale
+    ``locked_until`` cleared — used when the prior failure fell outside
+    ``LOGIN_LOCKOUT_WINDOW`` so old failures stop counting.
+    """
     async with transaction() as db:
-        now = datetime.now(timezone.utc).isoformat()
-        # Try to update existing row
-        await db.execute(
-            """INSERT INTO login_attempts (email, attempt_count, first_attempt_at)
-               VALUES (?, 1, ?) ON CONFLICT(email) DO UPDATE SET
-               attempt_count = attempt_count + 1""",
-            (email, now),
-        )
+        now_iso = datetime.now(timezone.utc).isoformat()
+        if reset:
+            # Upsert a fresh count, clearing any stale lockout.  INSERT ...
+            # ON CONFLICT DO UPDATE keeps this a single statement.
+            await db.execute(
+                """INSERT INTO login_attempts
+                   (email, attempt_count, first_attempt_at)
+                   VALUES (?, 1, ?)
+                   ON CONFLICT(email) DO UPDATE SET
+                   attempt_count = 1,
+                   first_attempt_at = excluded.first_attempt_at,
+                   locked_until = NULL""",
+                (email, now_iso),
+            )
+        else:
+            await db.execute(
+                """INSERT INTO login_attempts (email, attempt_count, first_attempt_at)
+                   VALUES (?, 1, ?) ON CONFLICT(email) DO UPDATE SET
+                   attempt_count = attempt_count + 1""",
+                (email, now_iso),
+            )
 
 
 async def get_login_attempt_info(

--- a/src/backend/tests/test_auth.py
+++ b/src/backend/tests/test_auth.py
@@ -302,6 +302,52 @@ class TestLoginRateLimit:
             )
         assert exc_info.value.status_code == 429
 
+    async def test_login_resets_count_after_window(self, user):
+        """Failures older than the window don't accumulate to a lockout.
+
+        Seed a near-threshold count with an old first_attempt_at; the
+        next failed login should reset (not lock), so a user can't be
+        permanently locked out by failures spread across days.
+        """
+        old = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        async with model.transaction() as raw_db:
+            await raw_db.execute(
+                "INSERT INTO login_attempts"
+                " (email, attempt_count, first_attempt_at)"
+                " VALUES (?, ?, ?)",
+                (
+                    "testuser@example.com",
+                    auth.LOGIN_LOCKOUT_FAILURES - 1,
+                    old,
+                ),
+            )
+        # A wrong password now: window elapsed -> reset, not lock.
+        with pytest.raises(HTTPException) as exc_info:
+            await auth.login(
+                auth.LoginRequest(
+                    email="testuser@example.com", password="wrong"
+                )
+            )
+        assert exc_info.value.status_code == 401  # not 429
+        info = await model.get_login_attempt_info("testuser@example.com")
+        assert info["attempt_count"] == 1
+
+    def test_window_elapsed_policy(self):
+        """_window_elapsed decides whether the sliding window has passed."""
+        assert auth._window_elapsed(None) is False
+        assert auth._window_elapsed({"first_attempt_at": None}) is False
+        # Unparseable timestamp is treated as not-elapsed (safe default).
+        assert (
+            auth._window_elapsed({"first_attempt_at": "not-a-date"}) is False
+        )
+        old = (
+            datetime.now(timezone.utc)
+            - timedelta(seconds=auth.LOGIN_LOCKOUT_WINDOW + 1)
+        ).isoformat()
+        assert auth._window_elapsed({"first_attempt_at": old}) is True
+        recent = datetime.now(timezone.utc).isoformat()
+        assert auth._window_elapsed({"first_attempt_at": recent}) is False
+
     async def test_login_lockout_message_shows_remaining_time(self, user):
         """Lockout message includes remaining minutes."""
         locked_until = datetime.now(timezone.utc) + timedelta(minutes=15)

--- a/src/backend/tests/test_model.py
+++ b/src/backend/tests/test_model.py
@@ -655,6 +655,44 @@ class TestLoginAttempts:
         # Should not raise
         await model.clear_login_attempts("nobody@example.com")
 
+    async def test_record_resets_count(self, db):
+        """reset=True starts a fresh count and clears stale lockout."""
+        from datetime import datetime, timedelta, timezone
+
+        old = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        stale_lock = (
+            datetime.now(timezone.utc) - timedelta(minutes=1)
+        ).isoformat()
+        async with model.transaction() as raw_db:
+            await raw_db.execute(
+                "INSERT INTO login_attempts"
+                " (email, attempt_count, first_attempt_at, locked_until)"
+                " VALUES (?, 5, ?, ?)",
+                ("alice@example.com", old, stale_lock),
+            )
+        await model.record_failed_login("alice@example.com", reset=True)
+        info = await model.get_login_attempt_info("alice@example.com")
+        assert info["attempt_count"] == 1
+        assert info["locked_until"] is None
+        # first_attempt_at moved forward to ~now.
+        first = datetime.fromisoformat(info["first_attempt_at"])
+        assert (datetime.now(timezone.utc) - first).total_seconds() < 5
+
+    async def test_record_reset_upserts_missing_row(self, db):
+        """reset=True on a row that doesn't exist inserts count=1."""
+        await model.record_failed_login("alice@example.com", reset=True)
+        info = await model.get_login_attempt_info("alice@example.com")
+        assert info is not None
+        assert info["attempt_count"] == 1
+        assert info["locked_until"] is None
+
+    async def test_record_increments_within_window(self, db):
+        """reset=False (default) increments the count."""
+        await model.record_failed_login("alice@example.com")
+        await model.record_failed_login("alice@example.com")
+        info = await model.get_login_attempt_info("alice@example.com")
+        assert info["attempt_count"] == 2
+
 
 class TestChatMessagesMigration:
     async def test_migrate_adds_message_type_column(self, db):


### PR DESCRIPTION
Closes #928.

## Problem

`LOGIN_LOCKOUT_WINDOW` (default 300s) was defined as the sliding window over which failed logins are counted, but **never consulted**. `record_failed_login` incremented `attempt_count` unconditionally and never reset it when `first_attempt_at` fell outside the window. A user who failed login `LOGIN_LOCKOUT_FAILURES` times — even spread across days or weeks — was **permanently locked out**, and once locked could never recover (the count was only cleared on a successful login, which is impossible while locked out).

## Fix

Moved the sliding-window **decision** into `auth.py` (next to `_should_lockout`, `_is_locked_out`, and `LOGIN_LOCKOUT_WINDOW` — where the rest of the lockout policy lives), and made `record_failed_login` **storage only**. This keeps the storage/policy split clean and avoids any `model → auth` import (the `deferred-imports` lint forbids in-function imports, and a top-level cycle isn't needed).

- **`auth._window_elapsed(attempt_info)`** — returns True if the first failure predates `LOGIN_LOCKOUT_WINDOW`. `None`/missing/unparseable `first_attempt_at` → False (safe default).
- **`auth.login()`** — reuses the `attempt_info` it already fetches up front (for the `_is_locked_out` check) to decide `reset = _window_elapsed(attempt_info)`, then calls `record_failed_login(email, reset=reset)`.
- **`model.record_failed_login(email, *, reset=False)`** — `reset=True` upserts `count=1`, moves `first_attempt_at` to now, and clears stale `locked_until` (single `INSERT ... ON CONFLICT` statement); `reset=False` increments as before.

So only failures within the last `LOGIN_LOCKOUT_WINDOW` seconds count toward the threshold — the window slides, and a user can't be bricked by failures spread across days.

## Tests
- `test_auth.py`: login resets the count (returns 401, not 429 — no lock) when prior failures predate the window; `_window_elapsed` policy for `None`/missing/unparseable/old/recent `first_attempt_at`.
- `test_model.py`: `reset=True` resets count + clears stale `locked_until` + moves `first_attempt_at`; `reset=True` upserts a missing row; `reset=False` increments.

## Verification
- Full backend suite: **1618 passed**.
- `auth.py` and `model.py` add **no new uncovered lines** (`_window_elapsed` and the new `record_failed_login` branches are all covered). The repo's 100% gate is pre-existing-failing on `main` (~92%); this PR doesn't add to the uncovered set.
- Pre-commit hooks pass, including `deferred-imports`.

## Checklist
- [x] Root cause addressed (window now consulted)
- [x] No new uncovered lines
- [x] Tests for the sliding-window reset + storage behavior
- [x] Pre-commit hooks pass (ruff, deferred-imports, trufflehog)