### PR TITLE
fix(ui): poll stale-build check every 5 minutes instead of 2

### DIFF
--- a/src/frontend/lib/widgets/stale_build_banner.dart
+++ b/src/frontend/lib/widgets/stale_build_banner.dart
@@ -22,6 +22,9 @@ class StaleBuildBanner extends StatefulWidget {
   /// Override the check interval for testing.
   final Duration? testInterval;
 
+  /// Default interval between stale-build checks.
+  static const defaultInterval = Duration(minutes: 5);
+
   const StaleBuildBanner({
     super.key,
     this.testHash,
@@ -34,7 +37,6 @@ class StaleBuildBanner extends StatefulWidget {
 }
 
 class StaleBuildBannerState extends State<StaleBuildBanner> {
-  static const _defaultInterval = Duration(minutes: 2);
   static final _hashPattern =
       RegExp(r'klangk-build-hash["\s]+content="([^"]+)"');
 
@@ -48,7 +50,7 @@ class StaleBuildBannerState extends State<StaleBuildBanner> {
     super.initState();
     _currentHash = widget.testHash ?? getBuildHash();
     if (_currentHash.isNotEmpty) {
-      final interval = widget.testInterval ?? _defaultInterval;
+      final interval = widget.testInterval ?? StaleBuildBanner.defaultInterval;
       _timer = Timer.periodic(interval, (_) => check());
     }
   }

--- a/src/frontend/test/stale_build_banner_test.dart
+++ b/src/frontend/test/stale_build_banner_test.dart
@@ -17,6 +17,13 @@ const _indexSameHash = '''
 ''';
 
 void main() {
+  test('default poll interval is 5 minutes', () {
+    // Issue #930: the stale-build poll runs on every page (the banner is
+    // mounted at the app root), so a longer interval cuts access-log noise
+    // uniformly without coupling to page-specific behavior.
+    expect(StaleBuildBanner.defaultInterval, const Duration(minutes: 5));
+  });
+
   testWidgets('renders nothing when no build hash is available',
       (tester) async {
     await tester.pumpWidget(


### PR DESCRIPTION
## Summary

Closes #930. Supersedes #922.

`StaleBuildBanner` mounts at the app root (`app.dart`) and polls `/index.html` on **every** page, so the 2-minute interval produced uniform access-log noise across all routes. Bumps the default poll interval from **2 → 5 minutes** to halve the traffic.

## Why not visibility-gating

A `visibilitychange`/WebSocket-derived "user is active" gate was considered and rejected: it would couple the check to page-specific behavior (some pages don't hold a WebSocket), making the banner behave inconsistently across the app. Polling is page-agnostic and consistent everywhere, which is the priority. The tradeoff accepted is simply a longer interval.

## Change

- `_defaultInterval`: `Duration(minutes: 2)` → `Duration(minutes: 5)`.
- Promoted the constant to a public `StaleBuildBanner.defaultInterval` static (so it's testable without spinning up a `Timer.periodic`); the State now references it.

## Verification

- `flutter test test/stale_build_banner_test.dart`: **8 passed** (incl. a new `default poll interval is 5 minutes` test).
- `flutter analyze`: no issues.
