### PR TITLE
fix(agent): don't persist agent disconnect/reconnect to chat history

### DIFF
--- a/src/backend/klangk_backend/agent.py
+++ b/src/backend/klangk_backend/agent.py
@@ -9,6 +9,7 @@ import asyncio
 import json
 import logging
 import re
+import time
 
 from . import container, model, podman, workspaces
 
@@ -508,8 +509,45 @@ async def stop_session(workspace_id: str) -> None:
         await session.stop()
 
 
+def _ephemeral_system_message(
+    workspace_id: str,
+    agent_email: str,
+    agent_handle: str,
+    text: str,
+) -> dict:
+    """Build a transient agent presence system message for live broadcast.
+
+    Mirrors the shape returned by [model.add_chat_message] so the frontend
+    renders it the same as a persisted system message, but is never written
+    to chat history — agent presence transitions (disconnect/reconnect) are
+    driven by container lifecycle (idle-stop, restart, crash) and would
+    otherwise pollute history with stale, unbalanced "has disconnected"
+    entries.  ``id`` is a synthetic prefix so the frontend can dedupe;
+    ``created_at`` is empty (the frontend tolerates that).
+    """
+    return {
+        "id": f"ephemeral-agent-{workspace_id}-{int(time.monotonic() * 1000)}",
+        "workspace_id": workspace_id,
+        "user_id": model.AGENT_USER_ID,
+        "user_email": agent_email,
+        "user_handle": agent_handle,
+        "message": text,
+        "message_type": model.MSG_SYSTEM,
+        "created_at": "",
+        "mentions": [],
+    }
+
+
 async def _broadcast_agent_disconnect(workspace_id: str) -> None:
-    """Broadcast a disconnect system message when the agent process dies."""
+    """Broadcast a disconnect system message when the agent process dies.
+
+    Ephemeral only — sent to currently-connected subscribers, never written
+    to chat history.  The agent subprocess lives inside the workspace
+    container, so it dies on every container idle-stop / restart; persisting
+    "has disconnected" made those lifecycle events linger in chat history
+    and surface as a stale leading message on the next visit, with no
+    symmetric persisted "has connected" to balance them.
+    """
     if not workspace_id:
         return
     # Workspace may have been deleted — skip if gone.
@@ -517,12 +555,11 @@ async def _broadcast_agent_disconnect(workspace_id: str) -> None:
         return
     agent_handle = await model.agent_handle()
     agent_email = await model.agent_email()
-    sys_msg = await model.add_chat_message(
+    sys_msg = _ephemeral_system_message(
         workspace_id,
-        model.AGENT_USER_ID,
         agent_email,
+        agent_handle,
         f"{agent_handle} has disconnected",
-        message_type=model.MSG_SYSTEM,
     )
     session = (
         _get_workspace_session(workspace_id)
@@ -543,7 +580,10 @@ async def _broadcast_agent_disconnect(workspace_id: str) -> None:
 
 
 async def _broadcast_agent_reconnect(workspace_id: str) -> None:
-    """Broadcast a reconnect system message after auto-restart."""
+    """Broadcast a reconnect system message after auto-restart.
+
+    Ephemeral only — see [_broadcast_agent_disconnect].
+    """
     if not workspace_id:
         return
     # Workspace may have been deleted — skip if gone.
@@ -551,12 +591,11 @@ async def _broadcast_agent_reconnect(workspace_id: str) -> None:
         return
     agent_handle = await model.agent_handle()
     agent_email = await model.agent_email()
-    sys_msg = await model.add_chat_message(
+    sys_msg = _ephemeral_system_message(
         workspace_id,
-        model.AGENT_USER_ID,
         agent_email,
+        agent_handle,
         f"{agent_handle} has reconnected",
-        message_type=model.MSG_SYSTEM,
     )
     session = (
         _get_workspace_session(workspace_id)

--- a/src/backend/klangk_backend/wshandler.py
+++ b/src/backend/klangk_backend/wshandler.py
@@ -2542,13 +2542,14 @@ async def _handle_agent_mention(
         response_text = "Stopped."
     except agent.AgentProcessDied:
         logger.warning("Agent process died for workspace %s", workspace_id)
-        # Post system message about the crash
-        sys_msg = await model.add_chat_message(
+        # Broadcast an ephemeral (non-persisted) system message — agent
+        # presence transitions are container-lifecycle events and must
+        # not linger in chat history (no symmetric persisted "connected").
+        sys_msg = agent._ephemeral_system_message(
             workspace_id,
-            model.AGENT_USER_ID,
             agent_email,
+            agent_handle,
             f"{agent_handle} has disconnected",
-            message_type=model.MSG_SYSTEM,
         )
         session = state.get_session(workspace_id)
         if session:

--- a/src/backend/tests/test_agent.py
+++ b/src/backend/tests/test_agent.py
@@ -842,10 +842,6 @@ class TestMonitorProcess:
                 model,
                 "add_chat_message",
                 new_callable=AsyncMock,
-                return_value={
-                    "id": "msg-1",
-                    "message": "MrBoops has disconnected",
-                },
             ) as mock_chat,
             patch(
                 "klangk_backend.agent._get_workspace_session"
@@ -856,9 +852,16 @@ class TestMonitorProcess:
 
             await _broadcast_agent_disconnect("ws-mon")
 
-            mock_chat.assert_awaited_once()
-            assert "disconnected" in mock_chat.call_args[0][3]
+            # Presence transitions must NOT be persisted to chat history
+            # (they'd linger as stale "has disconnected" on the next visit).
+            mock_chat.assert_not_awaited()
+            # Still broadcast live to connected subscribers: agent_thinking,
+            # the ephemeral chat_message, and presence_leave.
             assert mock_session.broadcast.call_count == 3
+            chat_broadcast = mock_session.broadcast.call_args_list[1][0][0]
+            assert chat_broadcast["type"] == "chat_message"
+            assert "disconnected" in chat_broadcast["message"]
+            assert chat_broadcast["message_type"] == model.MSG_SYSTEM
 
     async def test_broadcast_no_workspace(self):
         from klangk_backend.agent import _broadcast_agent_disconnect
@@ -1100,7 +1103,6 @@ class TestMonitorProcess:
                 model,
                 "add_chat_message",
                 new_callable=AsyncMock,
-                return_value={"id": "m1", "message": "reconnected"},
             ) as mock_chat,
             patch(
                 "klangk_backend.agent._get_workspace_session"
@@ -1111,9 +1113,13 @@ class TestMonitorProcess:
 
             await _broadcast_agent_reconnect("ws-rc")
 
-            mock_chat.assert_awaited_once()
-            assert "reconnected" in mock_chat.call_args[0][3]
+            # Reconnect is ephemeral too — never persisted.
+            mock_chat.assert_not_awaited()
             assert mock_session.broadcast.call_count == 2
+            chat_broadcast = mock_session.broadcast.call_args_list[0][0][0]
+            assert chat_broadcast["type"] == "chat_message"
+            assert "reconnected" in chat_broadcast["message"]
+            assert chat_broadcast["message_type"] == model.MSG_SYSTEM
 
     async def test_broadcast_reconnect_no_workspace(self):
         from klangk_backend.agent import _broadcast_agent_reconnect


### PR DESCRIPTION
## Problem

Stale "mrboops has disconnected" system messages appear as leading chat history when opening a workspace — even before anyone has actively used it this session.

## Root cause

The agent (`pi`) subprocess lives inside the workspace container, so it dies on **every** container idle-stop / restart / crash. On each death, `_broadcast_agent_disconnect` (and the `AgentProcessDied` handler in `_handle_agent_mention`, plus `_broadcast_agent_reconnect` on auto-restart) wrote a `MSG_SYSTEM` "has disconnected" / "has reconnected" row to `chat_messages` via `model.add_chat_message`.

But there is **no symmetric persisted "has connected"** — initial agent start only broadcasts an *ephemeral* `presence_list`. So every idle-stop left a dangling "has disconnected" in chat history that surfaced as a stale leading message on the next visit.

These are container-lifecycle / live-presence events, not conversation history.

## Fix

Make agent presence transitions **ephemeral**: broadcast them live to currently-connected subscribers (so users watching still see the agent flap), but don't write them to chat history.

- New `_ephemeral_system_message(...)` helper in `agent.py` builds a `chat_message`-shaped dict (synthetic `id`, empty `created_at` — the frontend tolerates both) for the live broadcast only.
- `_broadcast_agent_disconnect` and `_broadcast_agent_reconnect` use it instead of `model.add_chat_message`.
- The `AgentProcessDied` handler in `wshandler.py` likewise broadcasts ephemeral instead of persisting.

User join/leave system messages are unchanged — those remain persisted, as intended (they have symmetric join/leave and are genuine conversation context).

## Tests
- `test_agent.py`: the disconnect/reconnect broadcast tests now assert `add_chat_message` is **not** awaited (no persistence) and that the ephemeral `chat_message` is still broadcast with the right text/type.
- The `wshandler.py` `AgentProcessDied` test already asserted the live `chat_message` broadcast shape (not persistence), so it passes unchanged.

## Verification
- `agent.py` and `wshandler.py` at **100%** coverage.
- Full backend suite: **1618 passed**.
- Pre-commit hooks pass (ruff, deferred-imports, trufflehog).

## Manual repro (before fix)
1. Open a workspace, chat with the agent.
2. Let the container idle-stop (or restart it) — agent dies, "mrboops has disconnected" is written to `chat_messages`.
3. Reopen the workspace → the disconnect is the leading chat message, with no prior "has connected".

After fix: step 3 shows no stale disconnect; live viewers in step 2 still see the ephemeral "has disconnected" broadcast.