### PR TITLE
fix: re-validate OIDC cli_redirect at callback time (token disclosure)

### DIFF
--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -726,6 +726,19 @@ async def resend_invitation(
     return {"status": "resent"}
 
 
+def _valid_cli_redirect(url: str | None) -> bool:
+    """True if *url* is a permitted CLI redirect target (localhost only).
+
+    The OIDC state cookie is unsigned and client-controlled, so the
+    cli_redirect stored there must be re-validated at callback time —
+    otherwise a tampered cookie could redirect the freshly-minted
+    access token to an attacker-controlled host (#936).
+    """
+    return bool(url) and url.startswith(
+        ("http://localhost:", "http://127.0.0.1:")
+    )
+
+
 # --- OIDC endpoints ---
 
 
@@ -743,10 +756,9 @@ async def oidc_login(
     if provider is None:
         raise HTTPException(status_code=404, detail="Unknown OIDC provider")
 
-    # Validate cli_redirect is localhost only
-    if cli_redirect and not cli_redirect.startswith(
-        ("http://localhost:", "http://127.0.0.1:")
-    ):
+    # Validate cli_redirect is localhost only (re-checked at callback,
+    # since the state cookie storing it is unsigned — see #936).
+    if cli_redirect and not _valid_cli_redirect(cli_redirect):
         raise HTTPException(
             status_code=400, detail="cli_redirect must be localhost"
         )
@@ -901,11 +913,15 @@ async def oidc_callback(
     # Clear the state cookie
     cli_redirect = cookie_data.get("cli_redirect")
 
-    if cli_redirect:
-        # CLI flow: redirect to the CLI's localhost server with the token
+    if _valid_cli_redirect(cli_redirect):
+        # CLI flow: redirect to the CLI's localhost server with the token.
+        # Re-validate here because the state cookie is unsigned and
+        # client-controlled — a tampered cli_redirect must not leak the
+        # access token to an arbitrary host (#936).
         redirect_url = f"{cli_redirect}?token={access_token}"
     else:
-        # Web flow: redirect to the frontend with token in the hash
+        # Web flow (also the safe fallback when the cookie's
+        # cli_redirect was missing or tampered to a non-localhost host).
         hostname, proto, base_path = derive_hosting_info(request.headers)
         redirect_url = (
             f"{proto}://{hostname}{base_path}"

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -6232,6 +6232,64 @@ class TestOIDCCallback:
             "http://localhost:12345/callback?token="
         )
 
+    async def test_callback_tampered_cli_redirect_falls_back(
+        self, client, monkeypatch, db
+    ):
+        """A tampered (non-localhost) cli_redirect in the unsigned state
+        cookie must NOT receive the token — fall back to the web flow.
+
+        Regression test for #936: the state cookie is client-controlled,
+        so cli_redirect is re-validated at callback time.
+        """
+        import json as json_mod
+
+        provider = api.oidc.OIDCProvider(
+            id="test",
+            display_name="Test",
+            issuer="https://idp.example.com",
+            client_id="klangk",
+            client_secret="s",
+        )
+        monkeypatch.setattr(api.oidc, "get_provider", lambda _: provider)
+        monkeypatch.setattr(
+            api.oidc,
+            "exchange_code",
+            AsyncMock(return_value={"id_token": "idt", "access_token": "at"}),
+        )
+        monkeypatch.setattr(
+            api.oidc,
+            "validate_id_token",
+            AsyncMock(
+                return_value={
+                    "sub": "evil-sub",
+                    "email": "evil@example.com",
+                    "email_verified": True,
+                }
+            ),
+        )
+        cookie_data = json_mod.dumps(
+            {
+                "state": "s",
+                "verifier": "v",
+                "redirect_uri": "https://klangk.example.com/cb",
+                "cli_redirect": "https://evil.com/steal",
+            }
+        )
+        resp = await client.get(
+            "/api/v1/auth/oidc/test/callback",
+            params={"code": "code", "state": "s"},
+            cookies={"oidc_test": cookie_data},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        location = resp.headers["location"]
+        # Must NOT redirect to the attacker host with the token.
+        assert not location.startswith("https://evil.com")
+        assert "evil.com" not in location
+        # Falls back to the web flow, still carrying the token in-house.
+        assert "oidc-complete" in location
+        assert "token=" in location
+
     async def test_callback_token_exchange_failure(
         self, client, monkeypatch, db
     ):


### PR DESCRIPTION
## Summary
- Fixes #936 — the CLI-login redirect target (`cli_redirect`) was validated at login time but stored in an **unsigned, client-controlled** state cookie and trusted as-is at callback time
- An attacker could complete a legitimate OIDC login, then overwrite their own `oidc_{provider}` cookie with a non-localhost `cli_redirect` (keeping the original `state`/`verifier`) and receive a `302` to `https://evil.com?token=<valid session JWT>` — an open redirect leaking the access token to an attacker-controlled host
- Extract `_valid_cli_redirect` (localhost-only) and apply it in **both** `oidc_login` and `oidc_callback`; at callback a missing or tampered `cli_redirect` now falls back to the web flow instead of appending the token to an untrusted URL
- Adds `TestOIDCCallback.test_callback_tampered_cli_redirect_falls_back`, verified to fail against the unpatched code (which redirected to `https://evil.com/steal?token=...`)

Closes #936