### PR TITLE
fix(terminal): pass window name/session as argv, not interpolated

### DIFF
--- a/src/backend/klangk_backend/terminal.py
+++ b/src/backend/klangk_backend/terminal.py
@@ -334,29 +334,36 @@ async def new_window(
     """
     if name is not None:
         _validate_window_name(name)
-        # Explicit name — check + create + list in one exec.
+        # Explicit name — check + create + list in one exec. The window
+        # name and session name are passed as positional argv ($1/$2),
+        # never interpolated into the script, so shell metacharacters in
+        # either are harmless (name is validated above regardless).
         script = (
-            f"existing=$(tmux list-windows -t {session_name}"
-            f" -F '#{{window_name}}' 2>/dev/null);"
-            f" echo \"$existing\" | grep -qx '{name}'"
-            f" && echo 'DUPLICATE' && exit 1;"
-            f" tmux new-window -t {session_name} -n '{name}';"
-            f" tmux list-windows -t {session_name}"
-            f" -F '#{{window_id}}|||#{{window_index}}|||#{{window_name}}|||#{{window_active}}'"
+            'name="$1"; sn="$2";'
+            ' existing=$(tmux list-windows -t "$sn"'
+            " -F '#{window_name}' 2>/dev/null);"
+            ' echo "$existing" | grep -qx "$name"'
+            " && echo 'DUPLICATE' && exit 1;"
+            ' tmux new-window -t "$sn" -n "$name";'
+            ' tmux list-windows -t "$sn"'
+            " -F '#{window_id}|||#{window_index}|||#{window_name}|||#{window_active}'"
         )
+        argv = ["bash", "-c", script, "bash", name, session_name]
     else:
-        # Auto-name — find next number, create, list.
+        # Auto-name — find next number, create, list. session_name is $1.
         script = (
-            f"names=$(tmux list-windows -t {session_name}"
-            f" -F '#{{window_name}}' 2>/dev/null);"
-            f' n=1; while echo "$names" | grep -qx "$n"; do n=$((n+1)); done;'
-            f' tmux new-window -t {session_name} -n "$n";'
-            f" tmux list-windows -t {session_name}"
-            f" -F '#{{window_id}}|||#{{window_index}}|||#{{window_name}}|||#{{window_active}}'"
+            'sn="$1";'
+            ' names=$(tmux list-windows -t "$sn"'
+            " -F '#{window_name}' 2>/dev/null);"
+            ' n=1; while echo "$names" | grep -qx "$n"; do n=$((n+1)); done;'
+            ' tmux new-window -t "$sn" -n "$n";'
+            ' tmux list-windows -t "$sn"'
+            " -F '#{window_id}|||#{window_index}|||#{window_name}|||#{window_active}'"
         )
+        argv = ["bash", "-c", script, "bash", session_name]
     rc, output, stderr = await podman.exec_container(
         container_id,
-        ["bash", "-c", script],
+        argv,
         user=CONTAINER_USER,
         timeout=10,
     )

--- a/src/backend/tests/test_terminal.py
+++ b/src/backend/tests/test_terminal.py
@@ -747,8 +747,13 @@ class TestNewWindow:
             result = await new_window("cid", "sess", name="build")
         assert len(result) == 2
         assert result[1]["name"] == "build"
-        # the chosen name is interpolated into the bash script
-        assert "'build'" in mock_exec.call_args.args[1][2]
+        # the name is passed as a positional argv ($1), never interpolated
+        # into the bash script string (defense-in-depth against injection)
+        argv = mock_exec.call_args.args[1]
+        assert argv[:2] == ["bash", "-c"]
+        assert "build" not in argv[2]  # not in the script
+        assert argv[3] == "bash"  # $0
+        assert argv[4] == "build"  # $1 = name
 
     async def test_rejects_shell_injection(self):
         with pytest.raises(ValueError, match="only contain"):


### PR DESCRIPTION
Closes #939.

## Summary

\`terminal.py\` \`new_window\` built its \`bash -c\` script by interpolating the window \`name\` (and \`session_name\`) into **single-quoted** shell strings. This is **not exploitable today** — \`_validate_window_name\` blocks quotes/shell-metacharacters (\`^[A-Za-z0-9 _.\-]+$\`) and \`session_name\` is a server-derived UUID — but the safety depended **entirely on the regex staying strict**. Loosening it (e.g. allowing apostrophes in window names) would immediately permit shell injection running as \`CONTAINER_USER\` inside the workspace container.

## Change

Pass \`name\` and \`session_name\` as **positional argv** (\`$1\`/\`$2\`) rather than interpolating them into the command string — the same pattern \`files.py\` already uses for \`write_file\`/\`stream_dir_tar\`:
\`\`\`python
argv = [\"bash\", \"-c\", script, \"bash\", name, session_name]
\`\`\`

A crafted name is now inert (\`name=\"x';rm -rf /;'\"\` is just a string) rather than breaking out of the single quotes. Verified concretely:

| pattern | \`name=\"x';rm -rf /;'\"\` |
|---|---|
| old (interpolated) | breaks out → runs \`rm -rf /\` (blocked only by the regex) |
| new (positional \`$1\`) | inert — name is a plain string |

Severity: low (defense-in-depth; not exploitable today).

## Test plan
- [x] Updated \`test_creates_named_window\` to assert the name is passed as positional argv (\`argv[4]\`) and **not** interpolated into the script.
- [x] Existing \`test_rejects_shell_injection\` / \`test_rejects_duplicate_name\` / \`test_raises_on_tmux_error\` pass unchanged.
- [x] \`tests/test_terminal.py\`: **100 passed**, \`terminal.py\` at **100% coverage**.
- [x] Real-bash round-trip with a fake \`tmux\` confirms the generated script parses/runs and the injection payload is inert.
- [x] Full backend suite: **1618 passed**.
- [x] Pre-commit hooks pass (ruff, prettier, trufflehog).