### PR TITLE
feat(frontend): paginate workspace list with per-section load more

### DIFF
--- a/src/frontend/lib/workspace/workspace_list_page.dart
+++ b/src/frontend/lib/workspace/workspace_list_page.dart
@@ -54,9 +54,33 @@ class WorkspaceListPage extends StatefulWidget {
   State<WorkspaceListPage> createState() => _WorkspaceListPageState();
 }
 
+/// Mutable pagination state for one list section (owned or shared).
+/// Held as a field so owned/shared advance independently — each has its
+/// own cursor and its own "load more" control.
+class _Section {
+  _Section({this.isShared = false});
+
+  final bool isShared;
+  List<Map<String, dynamic>> workspaces = [];
+  bool hasMore = false;
+  int? nextOffset;
+  bool loadingMore = false;
+
+  /// API path for this section, paginated at [offset].
+  String path(int offset) {
+    final base = isShared ? '/api/v1/workspaces/shared' : '/api/v1/workspaces';
+    return '$base?limit=${_WorkspaceListPageState._pageSize}&offset=$offset';
+  }
+}
+
 class _WorkspaceListPageState extends State<WorkspaceListPage> {
-  List<Map<String, dynamic>> _workspaces = [];
-  List<Map<String, dynamic>> _sharedWorkspaces = [];
+  static const int _pageSize = 10;
+
+  /// Per-section pagination state. Owned and shared lists come from
+  /// different queries with independent cursors, so each section tracks
+  /// its own list + has_more + next_offset + loading-more flag.
+  final _Section _owned = _Section();
+  final _Section _shared = _Section(isShared: true);
   Map<String, List<Map<String, dynamic>>> _workspaceMembers = {};
   bool _loading = true;
   StreamSubscription<void>? _workspacesChangedSub;
@@ -83,93 +107,94 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
 
   AuthService get _auth => context.read<AuthService>();
 
-  /// Silent refresh: re-fetches workspaces without showing the loading
-  /// spinner or error snackbars.  Driven by `workspaces_changed` WS events.
-  Future<void> _refreshWorkspaces() async {
+  /// Parse a paginated envelope response into its items + cursors.
+  static ({List<Map<String, dynamic>> items, bool hasMore, int? nextOffset})
+      _parseEnvelope(String body) {
+    final json = jsonDecode(body) as Map<String, dynamic>;
+    final items = (json['items'] as List).cast<Map<String, dynamic>>();
+    return (
+      items: items,
+      hasMore: json['has_more'] == true,
+      nextOffset:
+          json['next_offset'] is int ? json['next_offset'] as int : null,
+    );
+  }
+
+  /// Fetch one page for [section] at [offset]. Returns the parsed page or
+  /// null on failure. Caller handles members + state.
+  Future<({List<Map<String, dynamic>> items, bool hasMore, int? nextOffset})?>
+      _fetchPage(_Section section, int offset) async {
     try {
-      final response = await _auth.authGet('/api/v1/workspaces');
-      if (response.statusCode != 200 || !mounted) return;
-      final data = jsonDecode(response.body) as List;
-      final workspaces = data.cast<Map<String, dynamic>>();
-      final members = <String, List<Map<String, dynamic>>>{};
-      await Future.wait(
-        workspaces.map((ws) async {
-          final id = ws['id'] as String;
-          try {
-            final resp = await _auth.authGet('/api/v1/workspaces/$id/members');
-            if (resp.statusCode == 200) {
-              members[id] = List<Map<String, dynamic>>.from(
-                jsonDecode(resp.body) as List,
-              );
-            }
-          } catch (_) {} // coverage:ignore-line
-        }),
-      );
-      List<Map<String, dynamic>> shared = [];
-      try {
-        final sharedResp = await _auth.authGet('/api/v1/workspaces/shared');
-        if (sharedResp.statusCode == 200) {
-          shared = List<Map<String, dynamic>>.from(
-            jsonDecode(sharedResp.body) as List,
-          );
-        }
-      } catch (_) {} // coverage:ignore-line
-      if (mounted) {
-        setState(() {
-          _workspaces = workspaces;
-          _sharedWorkspaces = shared;
-          _workspaceMembers = members;
-        });
-      }
-    } catch (_) {} // coverage:ignore-line
+      final resp = await _auth.authGet(section.path(offset));
+      if (resp.statusCode != 200) return null;
+      return _parseEnvelope(resp.body);
+    } catch (_) {
+      return null;
+    } // coverage:ignore-line
+  }
+
+  /// Fetch members for the given workspaces only (bounded to a page so
+  /// we never fan out N+1 across the whole list). Merges into the cache.
+  Future<void> _fetchMembers(List<Map<String, dynamic>> workspaces) async {
+    final members = <String, List<Map<String, dynamic>>>{};
+    await Future.wait(
+      workspaces.map((ws) async {
+        final id = ws['id'] as String;
+        try {
+          final resp = await _auth.authGet('/api/v1/workspaces/$id/members');
+          if (resp.statusCode == 200) {
+            members[id] = List<Map<String, dynamic>>.from(
+              jsonDecode(resp.body) as List,
+            );
+          }
+        } catch (_) {} // coverage:ignore-line
+      }),
+    );
+    if (mounted) {
+      setState(() {
+        _workspaceMembers = {..._workspaceMembers, ...members};
+      });
+    }
+  }
+
+  /// Replace a section with its first page. Returns true on success.
+  Future<bool> _loadFirstPage(_Section section) async {
+    final page = await _fetchPage(section, 0);
+    if (page == null) return false;
+    await _fetchMembers(page.items);
+    if (!mounted) return false;
+    setState(() {
+      section.workspaces = page.items;
+      section.hasMore = page.hasMore;
+      section.nextOffset = page.nextOffset;
+    });
+    return true;
+  }
+
+  /// Silent refresh: re-fetch the first page of each section without
+  /// showing the loading spinner or error snackbars. Driven by
+  /// `workspaces_changed` WS events — the set changed, so reset each
+  /// section to its first page rather than refetching every loaded page.
+  Future<void> _refreshWorkspaces() async {
+    await _loadFirstPage(_owned);
+    if (!mounted) return;
+    await _loadFirstPage(_shared);
   }
 
   Future<void> _loadWorkspaces() async {
     setState(() => _loading = true);
     try {
-      final response = await _auth.authGet('/api/v1/workspaces');
-      if (response.statusCode == 200) {
-        final data = jsonDecode(response.body) as List;
-        final workspaces = data.cast<Map<String, dynamic>>();
-        // Fetch members for each workspace in parallel
-        final members = <String, List<Map<String, dynamic>>>{};
-        await Future.wait(
-          workspaces.map((ws) async {
-            final id = ws['id'] as String;
-            try {
-              final resp = await _auth.authGet(
-                '/api/v1/workspaces/$id/members',
-              );
-              if (resp.statusCode == 200) {
-                members[id] = List<Map<String, dynamic>>.from(
-                  jsonDecode(resp.body) as List,
-                );
-              }
-            } catch (e) {
-              // coverage:ignore-start
-              debugPrint('[WorkspaceListPage] fetch members failed: $e');
-            } // coverage:ignore-end
-          }),
-        );
-        // Fetch shared workspaces
-        List<Map<String, dynamic>> shared = [];
-        try {
-          final sharedResp = await _auth.authGet('/api/v1/workspaces/shared');
-          if (sharedResp.statusCode == 200) {
-            shared = List<Map<String, dynamic>>.from(
-              jsonDecode(sharedResp.body) as List,
-            );
-          }
-        } catch (e) {
-          // coverage:ignore-start
-          debugPrint('[WorkspaceListPage] fetch shared workspaces failed: $e');
-        } // coverage:ignore-end
-        setState(() {
-          _workspaces = workspaces;
-          _sharedWorkspaces = shared;
-          _workspaceMembers = members;
-        });
+      final ownedOk = await _loadFirstPage(_owned);
+      if (!ownedOk) {
+        throw Exception('owned workspaces load failed');
       }
+      if (!mounted) return;
+      try {
+        await _loadFirstPage(_shared);
+      } catch (e) {
+        // coverage:ignore-start
+        debugPrint('[WorkspaceListPage] fetch shared workspaces failed: $e');
+      } // coverage:ignore-end
     } catch (e) {
       debugPrint('Failed to load workspaces: $e');
       if (mounted) {
@@ -183,6 +208,32 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
       }
     } finally {
       if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  /// Append the next page of [section] (owned or shared). No-op when
+  /// already loading, when there's no next page, or on fetch failure.
+  Future<void> _loadMore(_Section section) async {
+    if (section.loadingMore || !section.hasMore || section.nextOffset == null) {
+      return;
+    }
+    setState(() => section.loadingMore = true);
+    try {
+      final page = await _fetchPage(section, section.nextOffset!);
+      if (page != null) {
+        await _fetchMembers(page.items);
+        if (mounted) {
+          setState(() {
+            section.workspaces = [...section.workspaces, ...page.items];
+            section.hasMore = page.hasMore;
+            section.nextOffset = page.nextOffset;
+          });
+        }
+      }
+    } catch (_) {
+    } // coverage:ignore-line
+    finally {
+      if (mounted) setState(() => section.loadingMore = false);
     }
   }
 
@@ -749,11 +800,36 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
     }
   }
 
+  Widget _loadMoreButton(
+    String label, {
+    required bool enabled,
+    required bool loading,
+    required VoidCallback onPressed,
+  }) {
+    if (!enabled) return const SizedBox.shrink();
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Center(
+        child: loading
+            ? const SizedBox(
+                width: 20,
+                height: 20,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              )
+            : TextButton.icon(
+                onPressed: onPressed,
+                icon: const Icon(Icons.expand_more, size: 18),
+                label: Text(label),
+              ),
+      ),
+    );
+  }
+
   Widget _buildWorkspacesList() {
     if (_loading) {
       return const Center(child: CircularProgressIndicator());
     }
-    if (_workspaces.isEmpty && _sharedWorkspaces.isEmpty) {
+    if (_owned.workspaces.isEmpty && _shared.workspaces.isEmpty) {
       return const Center(
         child: Text('No workspaces yet. Create one to get started.'),
       );
@@ -761,7 +837,7 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
     return ListView(
       padding: const EdgeInsets.all(16),
       children: [
-        if (_workspaces.isNotEmpty)
+        if (_owned.workspaces.isNotEmpty)
           Container(
             margin: const EdgeInsets.only(bottom: 16),
             decoration: BoxDecoration(
@@ -793,7 +869,7 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
                     ],
                   ),
                 ),
-                ..._workspaces.asMap().entries.map((e) {
+                ..._owned.workspaces.asMap().entries.map((e) {
                   final i = e.key;
                   final ws = e.value;
                   final wsMembers = _workspaceMembers[ws['id'] as String] ?? [];
@@ -855,10 +931,16 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
                     ),
                   );
                 }),
+                _loadMoreButton(
+                  'Load more workspaces',
+                  enabled: _owned.hasMore,
+                  loading: _owned.loadingMore,
+                  onPressed: () => _loadMore(_owned),
+                ),
               ],
             ),
           ),
-        if (_sharedWorkspaces.isNotEmpty)
+        if (_shared.workspaces.isNotEmpty)
           Container(
             decoration: BoxDecoration(
               border: Border.all(color: KColors.borderDefault),
@@ -889,7 +971,7 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
                     ],
                   ),
                 ),
-                ..._sharedWorkspaces.asMap().entries.map(
+                ..._shared.workspaces.asMap().entries.map(
                       (e) => Material(
                         color: e.key.isEven
                             ? Colors.white.withValues(alpha: 0.03)
@@ -911,6 +993,12 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
                         ),
                       ),
                     ),
+                _loadMoreButton(
+                  'Load more shared workspaces',
+                  enabled: _shared.hasMore,
+                  loading: _shared.loadingMore,
+                  onPressed: () => _loadMore(_shared),
+                ),
               ],
             ),
           ),

--- a/src/frontend/lib/workspace/workspace_list_page.dart
+++ b/src/frontend/lib/workspace/workspace_list_page.dart
@@ -74,7 +74,7 @@ class _Section {
 }
 
 class _WorkspaceListPageState extends State<WorkspaceListPage> {
-  static const int _pageSize = 10;
+  static const int _pageSize = 5;
 
   /// Per-section pagination state. Owned and shared lists come from
   /// different queries with independent cursors, so each section tracks
@@ -837,6 +837,69 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
     return ListView(
       padding: const EdgeInsets.all(16),
       children: [
+        if (_shared.workspaces.isNotEmpty)
+          Container(
+            margin: const EdgeInsets.only(bottom: 16),
+            decoration: BoxDecoration(
+              border: Border.all(color: KColors.borderDefault),
+              borderRadius: BorderRadius.circular(8),
+              color: KColors.bgSurface,
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+                  child: Row(
+                    children: [
+                      const Icon(
+                        Icons.folder_shared,
+                        size: 18,
+                        color: KColors.textSecondary,
+                      ),
+                      const SizedBox(width: 8),
+                      Text(
+                        'Shared with Me',
+                        style: TextStyle(
+                          fontSize: 14,
+                          fontWeight: FontWeight.bold,
+                          color: KColors.textPrimary,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                ..._shared.workspaces.asMap().entries.map(
+                      (e) => Material(
+                        color: e.key.isEven
+                            ? Colors.white.withValues(alpha: 0.03)
+                            : Colors.transparent,
+                        child: ListTile(
+                          leading: const Icon(
+                            Icons.terminal,
+                            size: 20,
+                            color: KColors.accentBlue,
+                          ),
+                          title: Text(e.value['name'] as String),
+                          subtitle: Text(
+                            '${e.value['owner_email']} · ${_formatCreatedAt(e.value['created_at'] as String?)}',
+                          ),
+                          // coverage:ignore-start
+                          onTap: () =>
+                              context.go('/workspace/${e.value['id']}'),
+                          // coverage:ignore-end
+                        ),
+                      ),
+                    ),
+                _loadMoreButton(
+                  'Load more shared workspaces',
+                  enabled: _shared.hasMore,
+                  loading: _shared.loadingMore,
+                  onPressed: () => _loadMore(_shared),
+                ),
+              ],
+            ),
+          ),
         if (_owned.workspaces.isNotEmpty)
           Container(
             margin: const EdgeInsets.only(bottom: 16),
@@ -936,68 +999,6 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
                   enabled: _owned.hasMore,
                   loading: _owned.loadingMore,
                   onPressed: () => _loadMore(_owned),
-                ),
-              ],
-            ),
-          ),
-        if (_shared.workspaces.isNotEmpty)
-          Container(
-            decoration: BoxDecoration(
-              border: Border.all(color: KColors.borderDefault),
-              borderRadius: BorderRadius.circular(8),
-              color: KColors.bgSurface,
-            ),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Padding(
-                  padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
-                  child: Row(
-                    children: [
-                      const Icon(
-                        Icons.folder_shared,
-                        size: 18,
-                        color: KColors.textSecondary,
-                      ),
-                      const SizedBox(width: 8),
-                      Text(
-                        'Shared with Me',
-                        style: TextStyle(
-                          fontSize: 14,
-                          fontWeight: FontWeight.bold,
-                          color: KColors.textPrimary,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-                ..._shared.workspaces.asMap().entries.map(
-                      (e) => Material(
-                        color: e.key.isEven
-                            ? Colors.white.withValues(alpha: 0.03)
-                            : Colors.transparent,
-                        child: ListTile(
-                          leading: const Icon(
-                            Icons.terminal,
-                            size: 20,
-                            color: KColors.accentBlue,
-                          ),
-                          title: Text(e.value['name'] as String),
-                          subtitle: Text(
-                            '${e.value['owner_email']} · ${_formatCreatedAt(e.value['created_at'] as String?)}',
-                          ),
-                          // coverage:ignore-start
-                          onTap: () =>
-                              context.go('/workspace/${e.value['id']}'),
-                          // coverage:ignore-end
-                        ),
-                      ),
-                    ),
-                _loadMoreButton(
-                  'Load more shared workspaces',
-                  enabled: _shared.hasMore,
-                  loading: _shared.loadingMore,
-                  onPressed: () => _loadMore(_shared),
                 ),
               ],
             ),

--- a/src/frontend/test/workspace_list_page_test.dart
+++ b/src/frontend/test/workspace_list_page_test.dart
@@ -13,6 +13,13 @@ import 'package:klangk_frontend/ws/ws_client.dart';
 import 'package:klangk_frontend/widgets/klangk_logo.dart';
 import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 
+/// Wrap a workspace list in the pagination envelope returned by the API.
+dynamic _envelope(dynamic items) => {
+      'items': items,
+      'has_more': false,
+      'next_offset': null,
+    };
+
 /// A WsClient whose workspacesChanged stream can be driven from tests.
 class _MockWsClient extends WsClient {
   final StreamController<void> _workspacesChanged =
@@ -67,10 +74,10 @@ void main() {
   http.Client defaultMockClient() {
     return withPermissions((request) async {
       if (request.url.path == '/api/v1/workspaces') {
-        return http.Response(jsonEncode([]), 200);
+        return http.Response(jsonEncode(_envelope([])), 200);
       }
       if (request.url.path == '/api/v1/workspaces/shared') {
-        return http.Response(jsonEncode([]), 200);
+        return http.Response(jsonEncode(_envelope([])), 200);
       }
       return http.Response('Not found', 404);
     });
@@ -143,13 +150,13 @@ void main() {
                   {'id': 'ws-1', 'name': 'appeared', 'created_at': ''}
                 ]
               : [];
-          return http.Response(jsonEncode(list), 200);
+          return http.Response(jsonEncode(_envelope(list)), 200);
         }
         if (request.url.path == '/api/v1/workspaces/ws-1/members') {
           return http.Response(jsonEncode([]), 200);
         }
         if (request.url.path == '/api/v1/workspaces/shared') {
-          return http.Response(jsonEncode([]), 200);
+          return http.Response(jsonEncode(_envelope([])), 200);
         }
         return http.Response('Not found', 404);
       });
@@ -184,10 +191,10 @@ void main() {
       testAuthHttpClientOverride = withPermissions(
         (request) async {
           if (request.url.path == '/api/v1/workspaces') {
-            return http.Response(jsonEncode([]), 200);
+            return http.Response(jsonEncode(_envelope([])), 200);
           }
           if (request.url.path == '/api/v1/workspaces/shared') {
-            return http.Response(jsonEncode([]), 200);
+            return http.Response(jsonEncode(_envelope([])), 200);
           }
           return http.Response('Not found', 404);
         },
@@ -220,7 +227,7 @@ void main() {
       testAuthHttpClientOverride = withPermissions((request) async {
         if (request.url.path == '/api/v1/workspaces') {
           return http.Response(
-            jsonEncode([
+            jsonEncode(_envelope([
               {
                 'id': 'ws-1',
                 'name': 'Project A',
@@ -233,7 +240,7 @@ void main() {
                 'container_id': null,
                 'created_at': '2026-06-02 09:00:00'
               },
-            ]),
+            ])),
             200,
           );
         }
@@ -255,14 +262,14 @@ void main() {
       testAuthHttpClientOverride = withPermissions((request) async {
         if (request.url.path == '/api/v1/workspaces') {
           return http.Response(
-            jsonEncode([
+            jsonEncode(_envelope([
               {
                 'id': 'ws-1',
                 'name': 'Shared Project',
                 'container_id': null,
                 'created_at': '2026-01-15 14:30:00',
               },
-            ]),
+            ])),
             200,
           );
         }
@@ -293,20 +300,20 @@ void main() {
       testAuthHttpClientOverride = withPermissions((request) async {
         if (request.url.path == '/api/v1/workspaces') {
           return http.Response(
-            jsonEncode([
+            jsonEncode(_envelope([
               {
                 'id': 'ws-1',
                 'name': 'My Project',
                 'container_id': null,
                 'created_at': '2026-01-15 14:30:00',
               },
-            ]),
+            ])),
             200,
           );
         }
         if (request.url.path == '/api/v1/workspaces/shared') {
           return http.Response(
-            jsonEncode([
+            jsonEncode(_envelope([
               {
                 'id': 'ws-shared-1',
                 'name': 'Team Project',
@@ -321,7 +328,7 @@ void main() {
                 'created_at': '2026-03-01 10:00:00',
                 'owner_email': 'bob@example.com',
               },
-            ]),
+            ])),
             200,
           );
         }
@@ -342,15 +349,149 @@ void main() {
       expect(find.byIcon(Icons.terminal), findsNWidgets(3));
     });
 
+    testWidgets('load more appends next page and hides when done',
+        (tester) async {
+      // Page 1: 1 workspace, signals more. Page 2 (offset=10): 1 more,
+      // no more. The mock branches on the offset query param.
+      testAuthHttpClientOverride = withPermissions((request) async {
+        if (request.url.path == '/api/v1/workspaces') {
+          final offset = int.parse(
+            request.url.queryParameters['offset'] ?? '0',
+          );
+          if (offset == 0) {
+            return http.Response(
+              jsonEncode({
+                'items': [
+                  {
+                    'id': 'ws-1',
+                    'name': 'First',
+                    'container_id': null,
+                    'created_at': '2026-01-01',
+                  },
+                ],
+                'has_more': true,
+                'next_offset': 10,
+              }),
+              200,
+            );
+          }
+          return http.Response(
+            jsonEncode({
+              'items': [
+                {
+                  'id': 'ws-2',
+                  'name': 'Second',
+                  'container_id': null,
+                  'created_at': '2026-02-01',
+                },
+              ],
+              'has_more': false,
+              'next_offset': null,
+            }),
+            200,
+          );
+        }
+        if (request.url.path == '/api/v1/workspaces/shared') {
+          return http.Response(jsonEncode(_envelope([])), 200);
+        }
+        if (request.url.path == '/api/v1/workspaces/ws-1/members' ||
+            request.url.path == '/api/v1/workspaces/ws-2/members') {
+          return http.Response(jsonEncode([]), 200);
+        }
+        return http.Response('Not found', 404);
+      });
+
+      await tester.pumpWidget(buildPage());
+      await tester.pumpAndSettle();
+
+      // First page rendered, "Load more" shown.
+      expect(find.text('First'), findsOneWidget);
+      expect(find.text('Second'), findsNothing);
+      expect(find.text('Load more workspaces'), findsOneWidget);
+
+      // Tap load more → second page appended, control disappears.
+      await tester.tap(find.text('Load more workspaces'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('First'), findsOneWidget);
+      expect(find.text('Second'), findsOneWidget);
+      expect(find.text('Load more workspaces'), findsNothing);
+    });
+
+    testWidgets('load more works for the shared section', (tester) async {
+      testAuthHttpClientOverride = withPermissions((request) async {
+        if (request.url.path == '/api/v1/workspaces') {
+          return http.Response(jsonEncode(_envelope([])), 200);
+        }
+        if (request.url.path == '/api/v1/workspaces/shared') {
+          final offset = int.parse(
+            request.url.queryParameters['offset'] ?? '0',
+          );
+          if (offset == 0) {
+            return http.Response(
+              jsonEncode({
+                'items': [
+                  {
+                    'id': 'sh-1',
+                    'name': 'Shared First',
+                    'container_id': null,
+                    'created_at': '2026-01-01',
+                    'owner_email': 'a@example.com',
+                  },
+                ],
+                'has_more': true,
+                'next_offset': 10,
+              }),
+              200,
+            );
+          }
+          return http.Response(
+            jsonEncode({
+              'items': [
+                {
+                  'id': 'sh-2',
+                  'name': 'Shared Second',
+                  'container_id': null,
+                  'created_at': '2026-02-01',
+                  'owner_email': 'b@example.com',
+                },
+              ],
+              'has_more': false,
+              'next_offset': null,
+            }),
+            200,
+          );
+        }
+        if (request.url.path == '/api/v1/workspaces/sh-1/members' ||
+            request.url.path == '/api/v1/workspaces/sh-2/members') {
+          return http.Response(jsonEncode([]), 200);
+        }
+        return http.Response('Not found', 404);
+      });
+
+      await tester.pumpWidget(buildPage());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Shared First'), findsOneWidget);
+      expect(find.text('Load more shared workspaces'), findsOneWidget);
+
+      await tester.tap(find.text('Load more shared workspaces'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Shared First'), findsOneWidget);
+      expect(find.text('Shared Second'), findsOneWidget);
+      expect(find.text('Load more shared workspaces'), findsNothing);
+    });
+
     testWidgets('shows only shared section when no owned workspaces',
         (tester) async {
       testAuthHttpClientOverride = withPermissions((request) async {
         if (request.url.path == '/api/v1/workspaces') {
-          return http.Response(jsonEncode([]), 200);
+          return http.Response(jsonEncode(_envelope([])), 200);
         }
         if (request.url.path == '/api/v1/workspaces/shared') {
           return http.Response(
-            jsonEncode([
+            jsonEncode(_envelope([
               {
                 'id': 'ws-s1',
                 'name': 'Guest Project',
@@ -358,7 +499,7 @@ void main() {
                 'created_at': '2026-03-01 08:00:00',
                 'owner_email': 'owner@example.com',
               },
-            ]),
+            ])),
             200,
           );
         }
@@ -378,7 +519,7 @@ void main() {
       testAuthHttpClientOverride = withPermissions((request) async {
         if (request.url.path == '/api/v1/workspaces') {
           return http.Response(
-            jsonEncode([
+            jsonEncode(_envelope([
               {
                 'id': 'ws-1',
                 'name': 'No Date',
@@ -403,7 +544,7 @@ void main() {
                 'container_id': null,
                 'created_at': '2026-03-01 00:15:00'
               },
-            ]),
+            ])),
             200,
           );
         }
@@ -422,7 +563,7 @@ void main() {
     testWidgets('shows empty state when no workspaces', (tester) async {
       testAuthHttpClientOverride = withPermissions((request) async {
         if (request.url.path == '/api/v1/workspaces') {
-          return http.Response(jsonEncode([]), 200);
+          return http.Response(jsonEncode(_envelope([])), 200);
         }
         return http.Response('Not found', 404);
       });
@@ -437,14 +578,14 @@ void main() {
       testAuthHttpClientOverride = withPermissions((request) async {
         if (request.url.path == '/api/v1/workspaces') {
           return http.Response(
-            jsonEncode([
+            jsonEncode(_envelope([
               {
                 'id': 'ws-1',
                 'name': 'Test WS',
                 'container_id': null,
                 'created_at': '2026-01-01'
               },
-            ]),
+            ])),
             200,
           );
         }
@@ -469,7 +610,7 @@ void main() {
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
 
       // Complete the request so the test can clean up
-      completer.complete(http.Response(jsonEncode([]), 200));
+      completer.complete(http.Response(jsonEncode(_envelope([])), 200));
       await tester.pumpAndSettle();
     });
 
@@ -488,14 +629,14 @@ void main() {
       testAuthHttpClientOverride = withPermissions((request) async {
         if (request.url.path == '/api/v1/workspaces') {
           return http.Response(
-            jsonEncode([
+            jsonEncode(_envelope([
               {
                 'id': 'ws-1',
                 'name': 'My Project',
                 'container_id': null,
                 'created_at': '2026-03-15'
               },
-            ]),
+            ])),
             200,
           );
         }
@@ -512,7 +653,7 @@ void main() {
       testAuthHttpClientOverride = withPermissions((request) async {
         if (request.url.path == '/api/v1/workspaces' &&
             request.method == 'GET') {
-          return http.Response(jsonEncode([]), 200);
+          return http.Response(jsonEncode(_envelope([])), 200);
         }
         return http.Response('Not found', 404);
       });
@@ -532,7 +673,7 @@ void main() {
       testAuthHttpClientOverride = withPermissions((request) async {
         if (request.url.path == '/api/v1/workspaces' &&
             request.method == 'GET') {
-          return http.Response(jsonEncode([]), 200);
+          return http.Response(jsonEncode(_envelope([])), 200);
         }
         return http.Response('Not found', 404);
       });
@@ -551,7 +692,7 @@ void main() {
       testAuthHttpClientOverride = withPermissions((request) async {
         if (request.url.path == '/api/v1/workspaces' &&
             request.method == 'GET') {
-          return http.Response(jsonEncode([]), 200);
+          return http.Response(jsonEncode(_envelope([])), 200);
         }
         return http.Response('Not found', 404);
       });
@@ -572,14 +713,14 @@ void main() {
       testAuthHttpClientOverride = withPermissions((request) async {
         if (request.url.path == '/api/v1/workspaces') {
           return http.Response(
-            jsonEncode([
+            jsonEncode(_envelope([
               {
                 'id': 'ws-1',
                 'name': 'To Delete',
                 'container_id': null,
                 'created_at': '2026-01-01'
               },
-            ]),
+            ])),
             200,
           );
         }
@@ -602,14 +743,14 @@ void main() {
       testAuthHttpClientOverride = withPermissions((request) async {
         if (request.url.path == '/api/v1/workspaces') {
           return http.Response(
-            jsonEncode([
+            jsonEncode(_envelope([
               {
                 'id': 'ws-1',
                 'name': 'Keep Me',
                 'container_id': null,
                 'created_at': '2026-01-01'
               },
-            ]),
+            ])),
             200,
           );
         }
@@ -633,14 +774,14 @@ void main() {
       testAuthHttpClientOverride = withPermissions((request) async {
         if (request.url.path == '/api/v1/workspaces') {
           return http.Response(
-            jsonEncode([
+            jsonEncode(_envelope([
               {
                 'id': 'ws-1',
                 'name': 'WS 1',
                 'container_id': null,
                 'created_at': '2026-01-01'
               },
-            ]),
+            ])),
             200,
           );
         }
@@ -662,7 +803,7 @@ void main() {
       SharedPreferences.setMockInitialValues({'klangk_jwt': token});
       testAuthHttpClientOverride = withPermissions((request) async {
         if (request.url.path == '/api/v1/workspaces') {
-          return http.Response(jsonEncode([]), 200);
+          return http.Response(jsonEncode(_envelope([])), 200);
         }
         return http.Response('Not found', 404);
       });
@@ -680,18 +821,18 @@ void main() {
             request.method == 'GET') {
           if (postCalled) {
             return http.Response(
-              jsonEncode([
+              jsonEncode(_envelope([
                 {
                   'id': 'ws-new',
                   'name': 'New WS',
                   'container_id': null,
                   'created_at': '2026-05-21',
                 },
-              ]),
+              ])),
               200,
             );
           }
-          return http.Response(jsonEncode([]), 200);
+          return http.Response(jsonEncode(_envelope([])), 200);
         }
         if (request.url.path == '/api/v1/workspaces' &&
             request.method == 'POST') {
@@ -729,7 +870,7 @@ void main() {
       testAuthHttpClientOverride = withPermissions((request) async {
         if (request.url.path == '/api/v1/workspaces' &&
             request.method == 'GET') {
-          return http.Response(jsonEncode([]), 200);
+          return http.Response(jsonEncode(_envelope([])), 200);
         }
         if (request.url.path == '/api/v1/workspaces' &&
             request.method == 'POST') {
@@ -760,17 +901,17 @@ void main() {
         if (request.url.path == '/api/v1/workspaces' &&
             request.method == 'GET') {
           if (deleteCalled) {
-            return http.Response(jsonEncode([]), 200);
+            return http.Response(jsonEncode(_envelope([])), 200);
           }
           return http.Response(
-            jsonEncode([
+            jsonEncode(_envelope([
               {
                 'id': 'ws-1',
                 'name': 'Doomed',
                 'container_id': null,
                 'created_at': '2026-01-01',
               },
-            ]),
+            ])),
             200,
           );
         }
@@ -805,14 +946,14 @@ void main() {
       testAuthHttpClientOverride = withPermissions((request) async {
         if (request.url.path == '/api/v1/workspaces') {
           return http.Response(
-            jsonEncode([
+            jsonEncode(_envelope([
               {
                 'id': 'ws-42',
                 'name': 'Nav Test',
                 'container_id': null,
                 'created_at': '2026-01-01',
               },
-            ]),
+            ])),
             200,
           );
         }
@@ -866,7 +1007,7 @@ void main() {
       testAuthHttpClientOverride = withPermissions(
         (request) async {
           if (request.url.path == '/api/v1/workspaces') {
-            return http.Response(jsonEncode([]), 200);
+            return http.Response(jsonEncode(_envelope([])), 200);
           }
           return http.Response('Not found', 404);
         },
@@ -895,7 +1036,7 @@ void main() {
       testAuthHttpClientOverride = withPermissions(
         (request) async {
           if (request.url.path == '/api/v1/workspaces') {
-            return http.Response(jsonEncode([]), 200);
+            return http.Response(jsonEncode(_envelope([])), 200);
           }
           return http.Response('Not found', 404);
         },
@@ -918,18 +1059,18 @@ void main() {
             request.method == 'GET') {
           if (postCalled) {
             return http.Response(
-              jsonEncode([
+              jsonEncode(_envelope([
                 {
                   'id': 'ws-sub',
                   'name': 'Submitted',
                   'container_id': null,
                   'created_at': '2026-05-21',
                 },
-              ]),
+              ])),
               200,
             );
           }
-          return http.Response(jsonEncode([]), 200);
+          return http.Response(jsonEncode(_envelope([])), 200);
         }
         if (request.url.path == '/api/v1/workspaces' &&
             request.method == 'POST') {
@@ -967,7 +1108,7 @@ void main() {
       testAuthHttpClientOverride = withPermissions((request) async {
         if (request.url.path == '/api/v1/workspaces' &&
             request.method == 'GET') {
-          return http.Response(jsonEncode([]), 200);
+          return http.Response(jsonEncode(_envelope([])), 200);
         }
         if (request.url.path == '/api/v1/images' && request.method == 'GET') {
           return http.Response(
@@ -1025,7 +1166,7 @@ void main() {
       testAuthHttpClientOverride = withPermissions((request) async {
         if (request.url.path == '/api/v1/workspaces' &&
             request.method == 'GET') {
-          return http.Response(jsonEncode([]), 200);
+          return http.Response(jsonEncode(_envelope([])), 200);
         }
         if (request.url.path == '/api/v1/workspaces' &&
             request.method == 'POST') {
@@ -1069,18 +1210,18 @@ void main() {
             request.method == 'GET') {
           if (postCalled) {
             return http.Response(
-              jsonEncode([
+              jsonEncode(_envelope([
                 {
                   'id': 'ws-cmd2',
                   'name': 'CmdSubmit',
                   'container_id': null,
                   'created_at': '2026-05-28',
                 },
-              ]),
+              ])),
               200,
             );
           }
-          return http.Response(jsonEncode([]), 200);
+          return http.Response(jsonEncode(_envelope([])), 200);
         }
         if (request.url.path == '/api/v1/workspaces' &&
             request.method == 'POST') {
@@ -1118,7 +1259,7 @@ void main() {
       testAuthHttpClientOverride = withPermissions((request) async {
         if (request.url.path == '/api/v1/workspaces' &&
             request.method == 'GET') {
-          return http.Response(jsonEncode([]), 200);
+          return http.Response(jsonEncode(_envelope([])), 200);
         }
         if (request.url.path == '/api/v1/workspaces' &&
             request.method == 'POST') {
@@ -1146,14 +1287,14 @@ void main() {
         if (request.url.path == '/api/v1/workspaces' &&
             request.method == 'GET') {
           return http.Response(
-            jsonEncode([
+            jsonEncode(_envelope([
               {
                 'id': 'ws-1',
                 'name': 'Doomed',
                 'container_id': null,
                 'created_at': '2026-01-01',
               },
-            ]),
+            ])),
             200,
           );
         }
@@ -1180,7 +1321,7 @@ void main() {
       var logoutCalled = false;
       testAuthHttpClientOverride = withPermissions((request) async {
         if (request.url.path == '/api/v1/workspaces') {
-          return http.Response(jsonEncode([]), 200);
+          return http.Response(jsonEncode(_envelope([])), 200);
         }
         if (request.url.path == '/api/v1/auth/logout') {
           logoutCalled = true;
@@ -1223,7 +1364,7 @@ void main() {
     testWidgets('logout with oidc redirect calls navigateTo', (tester) async {
       testAuthHttpClientOverride = withPermissions((request) async {
         if (request.url.path == '/api/v1/workspaces') {
-          return http.Response(jsonEncode([]), 200);
+          return http.Response(jsonEncode(_envelope([])), 200);
         }
         if (request.url.path == '/api/v1/auth/logout') {
           return http.Response(
@@ -1270,7 +1411,7 @@ void main() {
     testWidgets('title tap navigates to home', (tester) async {
       testAuthHttpClientOverride = withPermissions((request) async {
         if (request.url.path == '/api/v1/workspaces') {
-          return http.Response(jsonEncode([]), 200);
+          return http.Response(jsonEncode(_envelope([])), 200);
         }
         return http.Response('Not found', 404);
       });
@@ -1322,7 +1463,7 @@ void main() {
       testAuthHttpClientOverride = withPermissions(
         (request) async {
           if (request.url.path == '/api/v1/workspaces') {
-            return http.Response(jsonEncode([]), 200);
+            return http.Response(jsonEncode(_envelope([])), 200);
           }
           return http.Response('Not found', 404);
         },
@@ -1375,7 +1516,7 @@ void main() {
       testAuthHttpClientOverride = withPermissions((request) async {
         if (request.url.path == '/api/v1/workspaces' &&
             request.method == 'GET') {
-          return http.Response(jsonEncode([]), 200);
+          return http.Response(jsonEncode(_envelope([])), 200);
         }
         if (request.url.path == '/api/v1/workspaces' &&
             request.method == 'POST') {
@@ -1441,7 +1582,7 @@ void main() {
       testAuthHttpClientOverride = withPermissions((request) async {
         if (request.url.path == '/api/v1/workspaces' &&
             request.method == 'GET') {
-          return http.Response(jsonEncode([]), 200);
+          return http.Response(jsonEncode(_envelope([])), 200);
         }
         if (request.url.path == '/api/v1/workspaces' &&
             request.method == 'POST') {
@@ -1485,7 +1626,7 @@ void main() {
       testAuthHttpClientOverride = withPermissions((request) async {
         if (request.url.path == '/api/v1/workspaces' &&
             request.method == 'GET') {
-          return http.Response(jsonEncode([]), 200);
+          return http.Response(jsonEncode(_envelope([])), 200);
         }
         return http.Response('Not found', 404);
       });
@@ -1534,7 +1675,7 @@ void main() {
       testAuthHttpClientOverride = withPermissions((request) async {
         if (request.url.path == '/api/v1/workspaces' &&
             request.method == 'GET') {
-          return http.Response(jsonEncode([]), 200);
+          return http.Response(jsonEncode(_envelope([])), 200);
         }
         if (request.url.path == '/api/v1/workspaces' &&
             request.method == 'POST') {
@@ -1591,7 +1732,7 @@ void main() {
       testAuthHttpClientOverride = withPermissions((request) async {
         if (request.url.path == '/api/v1/workspaces' &&
             request.method == 'GET') {
-          return http.Response(jsonEncode([]), 200);
+          return http.Response(jsonEncode(_envelope([])), 200);
         }
         return http.Response('Not found', 404);
       });
@@ -1626,7 +1767,7 @@ void main() {
       testAuthHttpClientOverride = withPermissions((request) async {
         if (request.url.path == '/api/v1/workspaces' &&
             request.method == 'GET') {
-          return http.Response(jsonEncode([]), 200);
+          return http.Response(jsonEncode(_envelope([])), 200);
         }
         return http.Response('Not found', 404);
       });
@@ -1657,7 +1798,7 @@ void main() {
       testAuthHttpClientOverride = withPermissions((request) async {
         if (request.url.path == '/api/v1/workspaces' &&
             request.method == 'GET') {
-          return http.Response(jsonEncode([]), 200);
+          return http.Response(jsonEncode(_envelope([])), 200);
         }
         return http.Response('Not found', 404);
       });


### PR DESCRIPTION
## Summary

Closes #943. Frontend half of workspace-list pagination (the backend + CLI landed in #919 / PR #942).

The workspace list page now consumes the paginated envelope and adds per-section "Load more".

## Changes (`src/frontend/lib/workspace/workspace_list_page.dart`)

- **Consume the envelope.** `_loadWorkspaces` / `_refreshWorkspaces` now call `/api/v1/workspaces?limit=10&offset=0` (and `/shared`) and read `items` / `has_more` / `next_offset` instead of parsing a bare list.
- **Per-section pagination.** Each section ("Owned by Me" / "Shared with Me") has its own cursor and its own "Load more" control, shown only when `has_more`. Loading more **appends** to the section's existing list (incremental), never replaces. The two sections advance independently — no tabs, both stay in the single scroll view.
- **N+1 members fetch gated to a page.** `_fetchMembers` runs only for the workspaces on the page just fetched, so per-page cost is bounded (was: fan out across the whole loaded list).
- **`workspaces_changed` refresh** resets each section to its first page (the set changed).

## Code consolidation

To avoid duplicating the fetch/append logic for owned vs shared, extracted:
- `_Section` — holds one section's list + `hasMore` + `nextOffset` + `loadingMore`.
- `_fetchPage(section, offset)` — one GET + envelope parse.
- `_loadFirstPage(section)` — replace a section with page 1.
- `_loadMore(section)` — append the next page (shared by both sections).
- `_fetchMembers(workspaces)` — bounded to a page.

## Tests (`src/frontend/test/workspace_list_page_test.dart`)

- Updated the mock handlers (which returned bare lists) to return the envelope via an `_envelope(items)` helper.
- Added `load more appends next page and hides when done` (owned section) and `load more works for the shared section` — both verify page 1 renders + control shows, tapping appends page 2, and the control disappears when `has_more` is false.

## Verification

- `flutter test`: **611 passed** (full frontend suite).
- `flutter analyze`: no new warnings (the two `unused_local_variable` warnings are pre-existing on `main`).

## Out of scope

Sort (`?sort=`) and name text filter (`?q=`) are tracked in **#945**.
