### PR TITLE
feat: sort + name filter on workspace list (backend + CLI + frontend)

### DIFF
--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -475,15 +475,23 @@ No request body.
 
 **Query params (optional, pagination):**
 
-| Param    | Type | Default | Constraints |
-| -------- | ---- | ------- | ----------- |
-| `limit`  | int  | (none)  | `1`–`100`   |
-| `offset` | int  | (none)  | `>= 0`      |
+| Param    | Type   | Default   | Constraints           |
+| -------- | ------ | --------- | --------------------- |
+| `limit`  | int    | (none)    | `1`–`100`             |
+| `offset` | int    | (none)    | `>= 0`                |
+| `sort`   | string | `created` | `name` \| `created`   |
+| `order`  | string | `desc`    | `asc` \| `desc`       |
+| `q`      | string | (none)    | name substring filter |
 
 Without pagination params the endpoint returns a **bare list** (backward
 compatible). With `?limit=` and/or `?offset=` it returns a **pagination
-envelope** `{ items, has_more, next_offset }`, ordered by `created_at, id`
-so offset pagination is deterministic.
+envelope** `{ items, has_more, next_offset }`. `sort`/`order`/`q` apply in
+both shapes.
+
+Sorting is whitelisted (`created`→`created_at`, `name`→`name`) with an `id`
+tiebreaker so offset pagination is deterministic. `q` matches anywhere in
+the name (`LIKE '%q%'`), not just a prefix, and is applied before pagination
+so `has_more`/`next_offset` reflect the filtered set.
 
 ```json
 [
@@ -526,8 +534,9 @@ List workspaces that other users have shared with the current user.
 No request body.
 
 **Query params (optional, pagination):** same `?limit=` / `?offset=` as
-`GET /api/v1/workspaces` — without params returns a bare list, with params
-returns the `{ items, has_more, next_offset }` envelope.
+`GET /api/v1/workspaces`, plus `?sort=name|created`, `?order=asc|desc`, and
+`?q=<substring>` (name substring). Without params returns a bare list, with
+params returns the `{ items, has_more, next_offset }` envelope.
 
 ```json
 [

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -143,6 +143,8 @@ klangkc ls                               # list workspaces (first page)
 klangkc ls --shared                      # include workspaces shared with you
 klangkc ls --limit 50                    # list up to 50 per section
 klangkc ls --all                         # page through every workspace
+klangkc ls --sort name --order asc       # sort by name, ascending
+klangkc ls --filter gamma                # substring filter on name
 klangkc create my-project                # create a workspace
 klangkc create my-project --mount ~/src:/home/klangk/work/src          # with bind mount
 klangkc create my-project --mount nix-store:/nix           # with named volume

--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -7,6 +7,7 @@ import os
 import posixpath
 import secrets
 import shutil
+from typing import Literal
 from sqlalchemy.exc import IntegrityError as SAIntegrityError
 import subprocess
 import tempfile
@@ -948,18 +949,28 @@ async def list_workspaces(
     user: dict = Depends(auth.get_current_user),
     limit: int | None = Query(None, ge=1, le=100),
     offset: int | None = Query(None, ge=0),
+    sort: Literal["name", "created"] = Query("created"),
+    order: Literal["asc", "desc"] = Query("desc"),
+    q: str | None = Query(None),
 ):
     """List workspaces owned by the user.
 
     Without ``limit``/``offset`` (backward-compatible) returns a bare list.
     With pagination params returns an envelope
     ``{"items": [...], "has_more": bool, "next_offset": int | None}``.
+    ``sort`` (``name``/``created``), ``order`` (``asc``/``desc``) and ``q``
+    (name substring) apply in both shapes.
     """
-    if limit is None and offset is None:
-        return (await workspaces.list_workspaces(user["id"]))["items"]
     result = await workspaces.list_workspaces(
-        user["id"], limit=limit or 10, offset=offset or 0
+        user["id"],
+        limit=limit or 10,
+        offset=offset or 0,
+        sort=sort,
+        order=order,
+        q=q,
     )
+    if limit is None and offset is None:
+        return result["items"]
     return result
 
 
@@ -968,17 +979,26 @@ async def list_shared_workspaces(
     user: dict = Depends(auth.get_current_user),
     limit: int | None = Query(None, ge=1, le=100),
     offset: int | None = Query(None, ge=0),
+    sort: Literal["name", "created"] = Query("created"),
+    order: Literal["asc", "desc"] = Query("desc"),
+    q: str | None = Query(None),
 ):
     """List workspaces shared with the user.
 
     Without ``limit``/``offset`` (backward-compatible) returns a bare list.
     With pagination params returns an envelope (see ``list_workspaces``).
     """
-    if limit is None and offset is None:
-        return (await model.list_shared_workspaces(user["id"]))["items"]
-    return await model.list_shared_workspaces(
-        user["id"], limit=limit or 10, offset=offset or 0
+    result = await model.list_shared_workspaces(
+        user["id"],
+        limit=limit or 10,
+        offset=offset or 0,
+        sort=sort,
+        order=order,
+        q=q,
     )
+    if limit is None and offset is None:
+        return result["items"]
+    return result
 
 
 class CreateWorkspaceRequest(BaseModel):

--- a/src/backend/klangk_backend/model.py
+++ b/src/backend/klangk_backend/model.py
@@ -1160,23 +1160,53 @@ async def create_workspace(
         }
 
 
+# Whitelisted sort columns for workspace list queries. Values are the
+# real column names; the prefix (e.g. "w.") is applied by the caller.
+_SORT_COLUMNS = {"created": "created_at", "name": "name"}
+
+
+def _sort_order_clause(sort: str, order: str, prefix: str = "") -> str:
+    """Build a deterministic ORDER BY clause for paginated workspace lists.
+
+    ``sort`` is whitelisted against ``_SORT_COLUMNS``; ``order`` is
+    coerced to ASC/DESC. The ``id`` tiebreaker uses the same direction so
+    offset pagination stays stable when rows share the sort key.
+    """
+    col = _SORT_COLUMNS.get(sort, "created_at")
+    p = f"{prefix}." if prefix else ""
+    direction = "DESC" if order.lower() == "desc" else "ASC"
+    return f"ORDER BY {p}{col} {direction}, {p}id {direction}"
+
+
 async def list_workspaces(
-    user_id: str, limit: int = 10, offset: int = 0
+    user_id: str,
+    limit: int = 10,
+    offset: int = 0,
+    sort: str = "created",
+    order: str = "desc",
+    q: str | None = None,
 ) -> dict:
-    """List a page of workspaces owned by ``user_id``, newest first.
+    """List a page of workspaces owned by ``user_id``.
 
     Returns a pagination envelope:
     ``{"items": [...], "has_more": bool, "next_offset": int | None}``.
-    Ordering is ``created_at, id`` so offset pagination is deterministic
-    even when rows share a timestamp.
+    ``sort`` (``created``/``name``) and ``order`` (``asc``/``desc``) are
+    whitelisted; ``q`` filters by name substring. The ``id`` tiebreaker
+    keeps offset pagination deterministic.
     """
+    order_by = _sort_order_clause(sort, order)
+    where = "WHERE user_id = ?"
+    params: list = [user_id]
+    if q:
+        where += " AND name LIKE '%' || ? || '%'"
+        params.append(q)
+    params.extend([limit, offset])
     async with transaction() as db:
         cursor = await db.execute(
             "SELECT id, name, container_id, image, default_command,"
             " mounts, env, created_at FROM workspaces"
-            " WHERE user_id = ? ORDER BY created_at, id"
-            " LIMIT ? OFFSET ?",
-            (user_id, limit, offset),
+            f" {where} {order_by} LIMIT ? OFFSET ?",
+            tuple(params),
         )
         rows = await cursor.fetchall()
         items = [
@@ -1201,15 +1231,22 @@ async def list_workspaces(
 
 
 async def list_shared_workspaces(
-    user_id: str, limit: int = 10, offset: int = 0
+    user_id: str,
+    limit: int = 10,
+    offset: int = 0,
+    sort: str = "created",
+    order: str = "desc",
+    q: str | None = None,
 ) -> dict:
     """List a page of workspaces shared with (not owned by) this user.
 
     Access is granted through either a direct user-level ACE or a
     group-level ACE on ``/workspaces/{id}``. Returns a pagination
     envelope: ``{"items": [...], "has_more": bool, "next_offset": int | None}``.
-    Ordering is ``created_at, id`` so offset pagination is deterministic.
+    ``sort``/``order``/``q`` as in :func:`list_workspaces`.
     """
+    order_by = _sort_order_clause(sort, order, prefix="w")
+    name_filter = " AND w.name LIKE '%' || ? || '%'" if q else ""
     async with transaction() as db:
         group_ids = await get_user_group_ids(user_id)
         group_placeholders = ",".join("?" for _ in group_ids)
@@ -1231,9 +1268,17 @@ async def list_shared_workspaces(
             f"    (ae.principal_type = {PRINCIPAL_USER} AND ae.user_id = ?)"
             f"    {group_clause}"
             "   )"
-            " ORDER BY w.created_at, w.id"
-            " LIMIT ? OFFSET ?",
-            (ACTION_ALLOW, user_id, user_id, *group_ids, limit, offset),
+            f"{name_filter}"
+            f" {order_by} LIMIT ? OFFSET ?",
+            (
+                ACTION_ALLOW,
+                user_id,
+                user_id,
+                *group_ids,
+                *([q] if q else []),
+                limit,
+                offset,
+            ),
         )
         rows = await cursor.fetchall()
         items = [

--- a/src/backend/klangk_backend/workspaces.py
+++ b/src/backend/klangk_backend/workspaces.py
@@ -279,9 +279,14 @@ async def create_workspace(
 
 
 async def list_workspaces(
-    user_id: str, limit: int = 10, offset: int = 0
+    user_id: str,
+    limit: int = 10,
+    offset: int = 0,
+    sort: str = "created",
+    order: str = "desc",
+    q: str | None = None,
 ) -> dict:
-    return await model.list_workspaces(user_id, limit, offset)
+    return await model.list_workspaces(user_id, limit, offset, sort, order, q)
 
 
 async def get_workspace(

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -980,6 +980,67 @@ class TestWorkspaceRoutes:
         )
         assert resp.status_code == 422
 
+    async def test_list_sort_by_name(self, client, user):
+        headers = await _auth_headers(client)
+        for name in ["charlie", "alpha", "bravo"]:
+            await client.post(
+                "/api/v1/workspaces",
+                headers=headers,
+                json={"name": name},
+            )
+        resp = await client.get(
+            "/api/v1/workspaces?limit=10&sort=name&order=asc",
+            headers=headers,
+        )
+        names = [w["name"] for w in resp.json()["items"]]
+        assert names == sorted(names)
+        assert names[0] == "alpha"
+
+    async def test_list_sort_desc(self, client, user):
+        headers = await _auth_headers(client)
+        for name in ["alpha", "bravo", "charlie"]:
+            await client.post(
+                "/api/v1/workspaces",
+                headers=headers,
+                json={"name": name},
+            )
+        resp = await client.get(
+            "/api/v1/workspaces?limit=10&sort=name&order=desc",
+            headers=headers,
+        )
+        names = [w["name"] for w in resp.json()["items"]]
+        assert names == sorted(names, reverse=True)
+        assert names[0] == "charlie"
+
+    async def test_list_filter_substring(self, client, user):
+        headers = await _auth_headers(client)
+        for name in ["alpha", "beta-gamma", "delta"]:
+            await client.post(
+                "/api/v1/workspaces",
+                headers=headers,
+                json={"name": name},
+            )
+        # Matches anywhere (substring), not just prefix.
+        resp = await client.get(
+            "/api/v1/workspaces?limit=10&q=gamma", headers=headers
+        )
+        names = [w["name"] for w in resp.json()["items"]]
+        assert names == ["beta-gamma"]
+
+    async def test_list_rejects_invalid_sort(self, client, user):
+        headers = await _auth_headers(client)
+        resp = await client.get(
+            "/api/v1/workspaces?sort=bogus", headers=headers
+        )
+        assert resp.status_code == 422
+
+    async def test_list_rejects_invalid_order(self, client, user):
+        headers = await _auth_headers(client)
+        resp = await client.get(
+            "/api/v1/workspaces?order=sideways", headers=headers
+        )
+        assert resp.status_code == 422
+
     async def test_create_workspace(self, client, user):
         headers = await _auth_headers(client)
         resp = await client.post(
@@ -1515,6 +1576,37 @@ class TestWorkspaceSharingRoutes:
         assert isinstance(body, dict)
         assert "items" in body and "has_more" in body
         assert any(w["id"] == ws_id for w in body["items"])
+
+    async def test_list_shared_filter_and_sort(self, client, user):
+        headers = await _auth_headers(client)
+        await self._create_other_user()
+        other_headers = await self._other_headers(client)
+        for name in ["alpha", "beta-shared", "gamma"]:
+            resp = await client.post(
+                "/api/v1/workspaces",
+                headers=headers,
+                json={"name": name},
+            )
+            await client.post(
+                f"/api/v1/workspaces/{resp.json()['id']}/members",
+                headers=headers,
+                json={"email": "other@example.com"},
+            )
+        # Substring filter on name.
+        resp = await client.get(
+            "/api/v1/workspaces/shared?limit=10&q=shared",
+            headers=other_headers,
+        )
+        names = [w["name"] for w in resp.json()["items"]]
+        assert names == ["beta-shared"]
+        # Sort by name ascending across all shared.
+        resp = await client.get(
+            "/api/v1/workspaces/shared?limit=10&sort=name&order=asc",
+            headers=other_headers,
+        )
+        names = [w["name"] for w in resp.json()["items"]]
+        assert names == sorted(names)
+        assert names[0] == "alpha"
 
     async def test_get_members_empty(self, client, user):
         headers = await _auth_headers(client)

--- a/src/cli/klangkc/client.py
+++ b/src/cli/klangkc/client.py
@@ -232,11 +232,16 @@ class KlangkClient:
         limit: int = 10,
         offset: int = 0,
         all_pages: bool = False,
+        sort: str = "created",
+        order: str = "desc",
+        q: str | None = None,
     ) -> list[Workspace]:
         """List workspaces owned by the current user.
 
         By default returns a single page (10 items). Pass ``all_pages=True``
-        to page through every workspace.
+        to page through every workspace. ``sort`` (``created``/``name``),
+        ``order`` (``asc``/``desc``) and ``q`` (name substring) mirror the
+        API query params.
         """
         return self._list_paginated(
             "/api/v1/workspaces",
@@ -244,6 +249,9 @@ class KlangkClient:
             offset=offset,
             all_pages=all_pages,
             shared=False,
+            sort=sort,
+            order=order,
+            q=q,
         )
 
     def list_shared_workspaces(
@@ -251,6 +259,9 @@ class KlangkClient:
         limit: int = 10,
         offset: int = 0,
         all_pages: bool = False,
+        sort: str = "created",
+        order: str = "desc",
+        q: str | None = None,
     ) -> list[Workspace]:
         """List workspaces shared with the current user."""
         return self._list_paginated(
@@ -259,6 +270,9 @@ class KlangkClient:
             offset=offset,
             all_pages=all_pages,
             shared=True,
+            sort=sort,
+            order=order,
+            q=q,
         )
 
     def _list_paginated(
@@ -269,10 +283,21 @@ class KlangkClient:
         offset: int,
         all_pages: bool,
         shared: bool,
+        sort: str = "created",
+        order: str = "desc",
+        q: str | None = None,
     ) -> list[Workspace]:
         workspaces: list[Workspace] = []
+        params: dict = {
+            "limit": limit,
+            "offset": offset,
+            "sort": sort,
+            "order": order,
+        }
+        if q:
+            params["q"] = q
         while True:
-            resp = self.get(path, params={"limit": limit, "offset": offset})
+            resp = self.get(path, params=params)
             self._check_auth(resp)
             resp.raise_for_status()
             body = resp.json()
@@ -280,7 +305,7 @@ class KlangkClient:
                 workspaces.append(self._workspace_from_json(w, shared=shared))
             if not all_pages or not body.get("has_more"):
                 break
-            offset = body["next_offset"]
+            params["offset"] = body["next_offset"]
         return workspaces
 
     @staticmethod

--- a/src/cli/klangkc/main.py
+++ b/src/cli/klangkc/main.py
@@ -209,17 +209,45 @@ def list_workspaces(
     all_workspaces: bool = typer.Option(
         False, "--all", help="List every workspace (follow pagination)"
     ),
+    sort: str = typer.Option(
+        "created",
+        "--sort",
+        help="Sort by 'created' or 'name'",
+    ),
+    order: str = typer.Option(
+        "desc",
+        "--order",
+        help="Sort direction: 'asc' or 'desc'",
+    ),
+    filter: str = typer.Option(
+        None,
+        "--filter",
+        help="Substring filter on workspace name",
+    ),
 ) -> None:
     """List workspaces.
 
     Lists one page at a time (default 10). Pass --all to page through
-    every workspace.
+    every workspace. Sort with --sort/--order and filter by name substring
+    with --filter.
     """
     _require_auth()
     client = _client()
-    workspaces = client.list_workspaces(limit=limit, all_pages=all_workspaces)
+    workspaces = client.list_workspaces(
+        limit=limit,
+        all_pages=all_workspaces,
+        sort=sort,
+        order=order,
+        q=filter,
+    )
     shared_workspaces = (
-        client.list_shared_workspaces(limit=limit, all_pages=all_workspaces)
+        client.list_shared_workspaces(
+            limit=limit,
+            all_pages=all_workspaces,
+            sort=sort,
+            order=order,
+            q=filter,
+        )
         if shared
         else []
     )

--- a/src/cli/tests/test_cli_integration.py
+++ b/src/cli/tests/test_cli_integration.py
@@ -1171,6 +1171,24 @@ class TestClientLines:
         assert mock_get.call_count == 2
         assert mock_get.call_args_list[1].kwargs["params"]["offset"] == 10
 
+    def test_list_workspaces_sort_order_q_forwarded(self):
+        from klangkc.client import KlangkClient
+
+        client = KlangkClient("http://test:8995", "tok")
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "items": [],
+            "has_more": False,
+            "next_offset": None,
+        }
+        with patch.object(client, "get", return_value=resp) as mock_get:
+            client.list_workspaces(sort="name", order="asc", q="gamma")
+        params = mock_get.call_args.kwargs["params"]
+        assert params["sort"] == "name"
+        assert params["order"] == "asc"
+        assert params["q"] == "gamma"
+
 
 class TestImagesCommand:
     def test_images_lists_allowed(self, monkeypatch):

--- a/src/cli/tests/test_cli_main.py
+++ b/src/cli/tests/test_cli_main.py
@@ -369,13 +369,20 @@ class TestMainCLI:
         client.list_shared_workspaces.return_value = []
         monkeypatch.setattr(main, "_client", lambda: client)
 
-        main.list_workspaces(limit=10, all_workspaces=True, shared=True)
+        main.list_workspaces(
+            limit=10,
+            all_workspaces=True,
+            shared=True,
+            sort="created",
+            order="desc",
+            filter=None,
+        )
 
         client.list_workspaces.assert_called_once_with(
-            limit=10, all_pages=True
+            limit=10, all_pages=True, sort="created", order="desc", q=None
         )
         client.list_shared_workspaces.assert_called_once_with(
-            limit=10, all_pages=True
+            limit=10, all_pages=True, sort="created", order="desc", q=None
         )
 
     def test_list_workspaces_limit_forwarded(self, logged_in_cfg, monkeypatch):
@@ -386,13 +393,54 @@ class TestMainCLI:
         client.list_shared_workspaces.return_value = []
         monkeypatch.setattr(main, "_client", lambda: client)
 
-        main.list_workspaces(limit=50, all_workspaces=False, shared=True)
+        main.list_workspaces(
+            limit=50,
+            all_workspaces=False,
+            shared=True,
+            sort="created",
+            order="desc",
+            filter=None,
+        )
 
         client.list_workspaces.assert_called_once_with(
-            limit=50, all_pages=False
+            limit=50, all_pages=False, sort="created", order="desc", q=None
         )
         client.list_shared_workspaces.assert_called_once_with(
-            limit=50, all_pages=False
+            limit=50, all_pages=False, sort="created", order="desc", q=None
+        )
+
+    def test_list_workspaces_sort_filter_forwarded(
+        self, logged_in_cfg, monkeypatch
+    ):
+        from klangkc import main
+
+        client = MagicMock()
+        client.list_workspaces.return_value = []
+        client.list_shared_workspaces.return_value = []
+        monkeypatch.setattr(main, "_client", lambda: client)
+
+        main.list_workspaces(
+            limit=10,
+            all_workspaces=False,
+            sort="name",
+            order="asc",
+            filter="gamma",
+            shared=True,
+        )
+
+        client.list_workspaces.assert_called_once_with(
+            limit=10,
+            all_pages=False,
+            sort="name",
+            order="asc",
+            q="gamma",
+        )
+        client.list_shared_workspaces.assert_called_once_with(
+            limit=10,
+            all_pages=False,
+            sort="name",
+            order="asc",
+            q="gamma",
         )
 
     def test_create_workspace(self, logged_in_cfg, monkeypatch):

--- a/src/frontend/lib/workspace/workspace_list_page.dart
+++ b/src/frontend/lib/workspace/workspace_list_page.dart
@@ -913,11 +913,104 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
     );
   }
 
-  Widget _buildWorkspacesList() {
-    if (_loading) {
-      return const Center(child: CircularProgressIndicator());
-    }
-    final empty = _owned.workspaces.isEmpty && _shared.workspaces.isEmpty;
+  Widget _buildSection(_Section section) {
+    return Container(
+      decoration: BoxDecoration(
+        border: Border.all(color: KColors.borderDefault),
+        borderRadius: BorderRadius.circular(8),
+        color: KColors.bgSurface,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          ...section.workspaces.asMap().entries.map(
+                (e) => Material(
+                  color: e.key.isEven
+                      ? Colors.white.withValues(alpha: 0.03)
+                      : Colors.transparent,
+                  child: ListTile(
+                    leading: Icon(
+                      Icons.terminal,
+                      size: 20,
+                      color: section.isShared
+                          ? KColors.accentBlue
+                          : KColors.accentGreen,
+                    ),
+                    title: Text(e.value['name'] as String),
+                    subtitle: section.isShared
+                        ? Text(
+                            '${e.value['owner_email']} · ${_formatCreatedAt(e.value['created_at'] as String?)}',
+                          )
+                        : Builder(builder: (context) {
+                            final wsMembers =
+                                _workspaceMembers[e.value['id'] as String] ??
+                                    [];
+                            return Row(
+                              children: [
+                                Text(_formatCreatedAt(
+                                  e.value['created_at'] as String?,
+                                )),
+                                if (wsMembers.isNotEmpty) ...[
+                                  const SizedBox(width: 8),
+                                  ...wsMembers.map((m) {
+                                    final email = m['email'] as String;
+                                    final letter = email.isNotEmpty
+                                        ? email[0].toUpperCase()
+                                        : '?';
+                                    return Padding(
+                                      padding: const EdgeInsets.only(right: 2),
+                                      child: Tooltip(
+                                        message: email,
+                                        child: CircleAvatar(
+                                          radius: 10,
+                                          backgroundColor:
+                                              KColors.colorForString(email),
+                                          child: Text(
+                                            letter,
+                                            style: const TextStyle(
+                                              fontSize: 10,
+                                              color: Colors.white,
+                                              fontWeight: FontWeight.bold,
+                                            ),
+                                          ),
+                                        ),
+                                      ),
+                                    );
+                                  }),
+                                ],
+                              ],
+                            );
+                          }),
+                    trailing: section.isShared
+                        ? null
+                        : IconButton(
+                            icon: const Icon(Icons.delete_outline),
+                            tooltip: 'Delete workspace',
+                            onPressed: () =>
+                                _deleteWorkspace(e.value['id'] as String),
+                          ),
+                    onTap: () =>
+                        // coverage:ignore-start
+                        context.go('/workspace/${e.value['id']}'),
+                    // coverage:ignore-end
+                  ),
+                ),
+              ),
+          _loadMoreButton(
+            section.isShared
+                ? 'Load more shared workspaces'
+                : 'Load more workspaces',
+            enabled: section.hasMore,
+            loading: section.loadingMore,
+            onPressed: () => _loadMore(section),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTabBody(_Section section) {
+    final empty = section.workspaces.isEmpty;
     return ListView(
       padding: const EdgeInsets.all(16),
       children: [
@@ -928,181 +1021,46 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
               padding: const EdgeInsets.only(top: 32),
               child: Text(
                 _query.isEmpty
-                    ? 'No workspaces yet. Create one to get started.'
+                    ? (section.isShared
+                        ? 'No workspaces shared with you.'
+                        : 'No workspaces yet. Create one to get started.')
                     : 'No workspaces match.',
               ),
             ),
           )
-        else ...[
-          if (_shared.workspaces.isNotEmpty)
-            Container(
-              margin: const EdgeInsets.only(bottom: 16),
-              decoration: BoxDecoration(
-                border: Border.all(color: KColors.borderDefault),
-                borderRadius: BorderRadius.circular(8),
-                color: KColors.bgSurface,
-              ),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Padding(
-                    padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
-                    child: Row(
-                      children: [
-                        const Icon(
-                          Icons.folder_shared,
-                          size: 18,
-                          color: KColors.textSecondary,
-                        ),
-                        const SizedBox(width: 8),
-                        Text(
-                          'Shared with Me',
-                          style: TextStyle(
-                            fontSize: 14,
-                            fontWeight: FontWeight.bold,
-                            color: KColors.textPrimary,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                  ..._shared.workspaces.asMap().entries.map(
-                        (e) => Material(
-                          color: e.key.isEven
-                              ? Colors.white.withValues(alpha: 0.03)
-                              : Colors.transparent,
-                          child: ListTile(
-                            leading: const Icon(
-                              Icons.terminal,
-                              size: 20,
-                              color: KColors.accentBlue,
-                            ),
-                            title: Text(e.value['name'] as String),
-                            subtitle: Text(
-                              '${e.value['owner_email']} · ${_formatCreatedAt(e.value['created_at'] as String?)}',
-                            ),
-                            // coverage:ignore-start
-                            onTap: () =>
-                                context.go('/workspace/${e.value['id']}'),
-                            // coverage:ignore-end
-                          ),
-                        ),
-                      ),
-                  _loadMoreButton(
-                    'Load more shared workspaces',
-                    enabled: _shared.hasMore,
-                    loading: _shared.loadingMore,
-                    onPressed: () => _loadMore(_shared),
-                  ),
-                ],
-              ),
-            ),
-          if (_owned.workspaces.isNotEmpty)
-            Container(
-              margin: const EdgeInsets.only(bottom: 16),
-              decoration: BoxDecoration(
-                border: Border.all(color: KColors.borderDefault),
-                borderRadius: BorderRadius.circular(8),
-                color: KColors.bgSurface,
-              ),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Padding(
-                    padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
-                    child: Row(
-                      children: [
-                        const Icon(
-                          Icons.folder,
-                          size: 18,
-                          color: KColors.textSecondary,
-                        ),
-                        const SizedBox(width: 8),
-                        Text(
-                          'Owned by Me',
-                          style: TextStyle(
-                            fontSize: 14,
-                            fontWeight: FontWeight.bold,
-                            color: KColors.textPrimary,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                  ..._owned.workspaces.asMap().entries.map((e) {
-                    final i = e.key;
-                    final ws = e.value;
-                    final wsMembers =
-                        _workspaceMembers[ws['id'] as String] ?? [];
-                    // Material (not a plain ColoredBox/Container color) so the
-                    // ListTile paints its background and ink splashes on this
-                    // surface; Flutter 3.44+ asserts when a ListTile's nearest
-                    // ancestor with a background is a ColoredBox.
-                    return Material(
-                      color: i.isEven
-                          ? Colors.white.withValues(alpha: 0.03)
-                          : Colors.transparent,
-                      child: ListTile(
-                        leading: const Icon(
-                          Icons.terminal,
-                          size: 20,
-                          color: KColors.accentGreen,
-                        ),
-                        title: Text(ws['name'] as String),
-                        subtitle: Row(
-                          children: [
-                            Text(_formatCreatedAt(ws['created_at'] as String?)),
-                            if (wsMembers.isNotEmpty) ...[
-                              const SizedBox(width: 8),
-                              ...wsMembers.map((m) {
-                                final email = m['email'] as String;
-                                final letter = email.isNotEmpty
-                                    ? email[0].toUpperCase()
-                                    : '?';
-                                return Padding(
-                                  padding: const EdgeInsets.only(right: 2),
-                                  child: Tooltip(
-                                    message: email,
-                                    child: CircleAvatar(
-                                      radius: 10,
-                                      backgroundColor: KColors.colorForString(
-                                        email,
-                                      ),
-                                      child: Text(
-                                        letter,
-                                        style: const TextStyle(
-                                          fontSize: 10,
-                                          color: Colors.white,
-                                          fontWeight: FontWeight.bold,
-                                        ),
-                                      ),
-                                    ),
-                                  ),
-                                );
-                              }),
-                            ],
-                          ],
-                        ),
-                        trailing: IconButton(
-                          icon: const Icon(Icons.delete_outline),
-                          tooltip: 'Delete workspace',
-                          onPressed: () => _deleteWorkspace(ws['id'] as String),
-                        ),
-                        onTap: () => context.go('/workspace/${ws['id']}'),
-                      ),
-                    );
-                  }),
-                  _loadMoreButton(
-                    'Load more workspaces',
-                    enabled: _owned.hasMore,
-                    loading: _owned.loadingMore,
-                    onPressed: () => _loadMore(_owned),
-                  ),
-                ],
-              ),
-            ),
-        ],
+        else
+          _buildSection(section),
       ],
+    );
+  }
+
+  Widget _buildWorkspacesList() {
+    if (_loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    return DefaultTabController(
+      length: 2,
+      child: Column(
+        children: [
+          Material(
+            color: KColors.bgSurface,
+            child: const TabBar(
+              tabs: [
+                Tab(text: 'Owned by Me'),
+                Tab(text: 'Shared with Me'),
+              ],
+            ),
+          ),
+          Expanded(
+            child: TabBarView(
+              children: [
+                _buildTabBody(_owned),
+                _buildTabBody(_shared),
+              ],
+            ),
+          ),
+        ],
+      ),
     );
   }
 

--- a/src/frontend/lib/workspace/workspace_list_page.dart
+++ b/src/frontend/lib/workspace/workspace_list_page.dart
@@ -66,10 +66,15 @@ class _Section {
   int? nextOffset;
   bool loadingMore = false;
 
-  /// API path for this section, paginated at [offset].
-  String path(int offset) {
+  /// API path for this section, paginated at [offset] with the shared
+  /// sort/order/filter query params.
+  String path(int offset,
+      {String sort = 'created', String order = 'desc', String? q}) {
     final base = isShared ? '/api/v1/workspaces/shared' : '/api/v1/workspaces';
-    return '$base?limit=${_WorkspaceListPageState._pageSize}&offset=$offset';
+    var p = '$base?limit=${_WorkspaceListPageState._pageSize}&offset=$offset'
+        '&sort=$sort&order=$order';
+    if (q != null && q.isNotEmpty) p += '&q=${Uri.encodeQueryComponent(q)}';
+    return p;
   }
 }
 
@@ -84,6 +89,15 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
   Map<String, List<Map<String, dynamic>>> _workspaceMembers = {};
   bool _loading = true;
   StreamSubscription<void>? _workspacesChangedSub;
+
+  // Shared sort/filter (applied to both sections). Changing any of these
+  // resets each section to its first page, since a different sort/filter
+  // reorders every row.
+  String _sort = 'created';
+  String _order = 'desc';
+  String _query = '';
+  Timer? _queryDebounce;
+  final TextEditingController _searchController = TextEditingController();
 
   @override
   void initState() {
@@ -102,6 +116,8 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
   @override
   void dispose() {
     _workspacesChangedSub?.cancel();
+    _queryDebounce?.cancel();
+    _searchController.dispose();
     super.dispose();
   }
 
@@ -125,7 +141,9 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
   Future<({List<Map<String, dynamic>> items, bool hasMore, int? nextOffset})?>
       _fetchPage(_Section section, int offset) async {
     try {
-      final resp = await _auth.authGet(section.path(offset));
+      final resp = await _auth.authGet(
+        section.path(offset, sort: _sort, order: _order, q: _query),
+      );
       if (resp.statusCode != 200) return null;
       return _parseEnvelope(resp.body);
     } catch (_) {
@@ -235,6 +253,36 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
     finally {
       if (mounted) setState(() => section.loadingMore = false);
     }
+  }
+
+  /// Change sort column/direction. Resets both sections to page 1 because
+  /// a different sort reorders every row.
+  Future<void> _changeSort(String sort) async {
+    if (_sort == sort) {
+      // Same column -> toggle direction.
+      setState(() => _order = _order == 'asc' ? 'desc' : 'asc');
+    } else {
+      setState(() {
+        _sort = sort;
+        _order = sort == 'name' ? 'asc' : 'desc';
+      });
+    }
+    await _reloadFromFirstPage();
+  }
+
+  /// Debounced name-filter handler. Resets to page 1 on change.
+  void _onQueryChanged(String value) {
+    setState(() => _query = value);
+    _queryDebounce?.cancel();
+    _queryDebounce = Timer(const Duration(milliseconds: 300), () {
+      _reloadFromFirstPage();
+    });
+  }
+
+  Future<void> _reloadFromFirstPage() async {
+    await _loadFirstPage(_owned);
+    if (!mounted) return;
+    await _loadFirstPage(_shared);
   }
 
   Future<Map<String, dynamic>?> _fetchImages() async {
@@ -825,184 +873,236 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
     );
   }
 
+  Widget _sortChip(String label, String sortKey) {
+    final active = _sort == sortKey;
+    final arrow = _order == 'asc' ? '▲' : '▼';
+    return ActionChip(
+      label: Text(active ? '$label $arrow' : label),
+      onPressed: () => _changeSort(sortKey),
+      backgroundColor:
+          active ? KColors.accentBlue.withValues(alpha: 0.2) : null,
+    );
+  }
+
+  Widget _buildControls() {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 12),
+      child: Row(
+        children: [
+          _sortChip('Name', 'name'),
+          const SizedBox(width: 8),
+          _sortChip('Created', 'created'),
+          const SizedBox(width: 12),
+          Expanded(
+            child: TextField(
+              controller: _searchController,
+              decoration: const InputDecoration(
+                isDense: true,
+                hintText: 'Filter by name...',
+                prefixIcon: Icon(Icons.search, size: 18),
+                border: OutlineInputBorder(),
+                contentPadding: EdgeInsets.symmetric(
+                  horizontal: 8,
+                  vertical: 0,
+                ),
+              ),
+              onChanged: _onQueryChanged,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
   Widget _buildWorkspacesList() {
     if (_loading) {
       return const Center(child: CircularProgressIndicator());
     }
-    if (_owned.workspaces.isEmpty && _shared.workspaces.isEmpty) {
-      return const Center(
-        child: Text('No workspaces yet. Create one to get started.'),
-      );
-    }
+    final empty = _owned.workspaces.isEmpty && _shared.workspaces.isEmpty;
     return ListView(
       padding: const EdgeInsets.all(16),
       children: [
-        if (_shared.workspaces.isNotEmpty)
-          Container(
-            margin: const EdgeInsets.only(bottom: 16),
-            decoration: BoxDecoration(
-              border: Border.all(color: KColors.borderDefault),
-              borderRadius: BorderRadius.circular(8),
-              color: KColors.bgSurface,
+        _buildControls(),
+        if (empty)
+          Center(
+            child: Padding(
+              padding: const EdgeInsets.only(top: 32),
+              child: Text(
+                _query.isEmpty
+                    ? 'No workspaces yet. Create one to get started.'
+                    : 'No workspaces match.',
+              ),
             ),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Padding(
-                  padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
-                  child: Row(
-                    children: [
-                      const Icon(
-                        Icons.folder_shared,
-                        size: 18,
-                        color: KColors.textSecondary,
-                      ),
-                      const SizedBox(width: 8),
-                      Text(
-                        'Shared with Me',
-                        style: TextStyle(
-                          fontSize: 14,
-                          fontWeight: FontWeight.bold,
-                          color: KColors.textPrimary,
+          )
+        else ...[
+          if (_shared.workspaces.isNotEmpty)
+            Container(
+              margin: const EdgeInsets.only(bottom: 16),
+              decoration: BoxDecoration(
+                border: Border.all(color: KColors.borderDefault),
+                borderRadius: BorderRadius.circular(8),
+                color: KColors.bgSurface,
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+                    child: Row(
+                      children: [
+                        const Icon(
+                          Icons.folder_shared,
+                          size: 18,
+                          color: KColors.textSecondary,
                         ),
-                      ),
-                    ],
-                  ),
-                ),
-                ..._shared.workspaces.asMap().entries.map(
-                      (e) => Material(
-                        color: e.key.isEven
-                            ? Colors.white.withValues(alpha: 0.03)
-                            : Colors.transparent,
-                        child: ListTile(
-                          leading: const Icon(
-                            Icons.terminal,
-                            size: 20,
-                            color: KColors.accentBlue,
+                        const SizedBox(width: 8),
+                        Text(
+                          'Shared with Me',
+                          style: TextStyle(
+                            fontSize: 14,
+                            fontWeight: FontWeight.bold,
+                            color: KColors.textPrimary,
                           ),
-                          title: Text(e.value['name'] as String),
-                          subtitle: Text(
-                            '${e.value['owner_email']} · ${_formatCreatedAt(e.value['created_at'] as String?)}',
-                          ),
-                          // coverage:ignore-start
-                          onTap: () =>
-                              context.go('/workspace/${e.value['id']}'),
-                          // coverage:ignore-end
                         ),
-                      ),
+                      ],
                     ),
-                _loadMoreButton(
-                  'Load more shared workspaces',
-                  enabled: _shared.hasMore,
-                  loading: _shared.loadingMore,
-                  onPressed: () => _loadMore(_shared),
-                ),
-              ],
-            ),
-          ),
-        if (_owned.workspaces.isNotEmpty)
-          Container(
-            margin: const EdgeInsets.only(bottom: 16),
-            decoration: BoxDecoration(
-              border: Border.all(color: KColors.borderDefault),
-              borderRadius: BorderRadius.circular(8),
-              color: KColors.bgSurface,
-            ),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Padding(
-                  padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
-                  child: Row(
-                    children: [
-                      const Icon(
-                        Icons.folder,
-                        size: 18,
-                        color: KColors.textSecondary,
-                      ),
-                      const SizedBox(width: 8),
-                      Text(
-                        'Owned by Me',
-                        style: TextStyle(
-                          fontSize: 14,
-                          fontWeight: FontWeight.bold,
-                          color: KColors.textPrimary,
+                  ),
+                  ..._shared.workspaces.asMap().entries.map(
+                        (e) => Material(
+                          color: e.key.isEven
+                              ? Colors.white.withValues(alpha: 0.03)
+                              : Colors.transparent,
+                          child: ListTile(
+                            leading: const Icon(
+                              Icons.terminal,
+                              size: 20,
+                              color: KColors.accentBlue,
+                            ),
+                            title: Text(e.value['name'] as String),
+                            subtitle: Text(
+                              '${e.value['owner_email']} · ${_formatCreatedAt(e.value['created_at'] as String?)}',
+                            ),
+                            // coverage:ignore-start
+                            onTap: () =>
+                                context.go('/workspace/${e.value['id']}'),
+                            // coverage:ignore-end
+                          ),
                         ),
                       ),
-                    ],
+                  _loadMoreButton(
+                    'Load more shared workspaces',
+                    enabled: _shared.hasMore,
+                    loading: _shared.loadingMore,
+                    onPressed: () => _loadMore(_shared),
                   ),
-                ),
-                ..._owned.workspaces.asMap().entries.map((e) {
-                  final i = e.key;
-                  final ws = e.value;
-                  final wsMembers = _workspaceMembers[ws['id'] as String] ?? [];
-                  // Material (not a plain ColoredBox/Container color) so the
-                  // ListTile paints its background and ink splashes on this
-                  // surface; Flutter 3.44+ asserts when a ListTile's nearest
-                  // ancestor with a background is a ColoredBox.
-                  return Material(
-                    color: i.isEven
-                        ? Colors.white.withValues(alpha: 0.03)
-                        : Colors.transparent,
-                    child: ListTile(
-                      leading: const Icon(
-                        Icons.terminal,
-                        size: 20,
-                        color: KColors.accentGreen,
-                      ),
-                      title: Text(ws['name'] as String),
-                      subtitle: Row(
-                        children: [
-                          Text(_formatCreatedAt(ws['created_at'] as String?)),
-                          if (wsMembers.isNotEmpty) ...[
-                            const SizedBox(width: 8),
-                            ...wsMembers.map((m) {
-                              final email = m['email'] as String;
-                              final letter = email.isNotEmpty
-                                  ? email[0].toUpperCase()
-                                  : '?';
-                              return Padding(
-                                padding: const EdgeInsets.only(right: 2),
-                                child: Tooltip(
-                                  message: email,
-                                  child: CircleAvatar(
-                                    radius: 10,
-                                    backgroundColor: KColors.colorForString(
-                                      email,
-                                    ),
-                                    child: Text(
-                                      letter,
-                                      style: const TextStyle(
-                                        fontSize: 10,
-                                        color: Colors.white,
-                                        fontWeight: FontWeight.bold,
+                ],
+              ),
+            ),
+          if (_owned.workspaces.isNotEmpty)
+            Container(
+              margin: const EdgeInsets.only(bottom: 16),
+              decoration: BoxDecoration(
+                border: Border.all(color: KColors.borderDefault),
+                borderRadius: BorderRadius.circular(8),
+                color: KColors.bgSurface,
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+                    child: Row(
+                      children: [
+                        const Icon(
+                          Icons.folder,
+                          size: 18,
+                          color: KColors.textSecondary,
+                        ),
+                        const SizedBox(width: 8),
+                        Text(
+                          'Owned by Me',
+                          style: TextStyle(
+                            fontSize: 14,
+                            fontWeight: FontWeight.bold,
+                            color: KColors.textPrimary,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  ..._owned.workspaces.asMap().entries.map((e) {
+                    final i = e.key;
+                    final ws = e.value;
+                    final wsMembers =
+                        _workspaceMembers[ws['id'] as String] ?? [];
+                    // Material (not a plain ColoredBox/Container color) so the
+                    // ListTile paints its background and ink splashes on this
+                    // surface; Flutter 3.44+ asserts when a ListTile's nearest
+                    // ancestor with a background is a ColoredBox.
+                    return Material(
+                      color: i.isEven
+                          ? Colors.white.withValues(alpha: 0.03)
+                          : Colors.transparent,
+                      child: ListTile(
+                        leading: const Icon(
+                          Icons.terminal,
+                          size: 20,
+                          color: KColors.accentGreen,
+                        ),
+                        title: Text(ws['name'] as String),
+                        subtitle: Row(
+                          children: [
+                            Text(_formatCreatedAt(ws['created_at'] as String?)),
+                            if (wsMembers.isNotEmpty) ...[
+                              const SizedBox(width: 8),
+                              ...wsMembers.map((m) {
+                                final email = m['email'] as String;
+                                final letter = email.isNotEmpty
+                                    ? email[0].toUpperCase()
+                                    : '?';
+                                return Padding(
+                                  padding: const EdgeInsets.only(right: 2),
+                                  child: Tooltip(
+                                    message: email,
+                                    child: CircleAvatar(
+                                      radius: 10,
+                                      backgroundColor: KColors.colorForString(
+                                        email,
+                                      ),
+                                      child: Text(
+                                        letter,
+                                        style: const TextStyle(
+                                          fontSize: 10,
+                                          color: Colors.white,
+                                          fontWeight: FontWeight.bold,
+                                        ),
                                       ),
                                     ),
                                   ),
-                                ),
-                              );
-                            }),
+                                );
+                              }),
+                            ],
                           ],
-                        ],
+                        ),
+                        trailing: IconButton(
+                          icon: const Icon(Icons.delete_outline),
+                          tooltip: 'Delete workspace',
+                          onPressed: () => _deleteWorkspace(ws['id'] as String),
+                        ),
+                        onTap: () => context.go('/workspace/${ws['id']}'),
                       ),
-                      trailing: IconButton(
-                        icon: const Icon(Icons.delete_outline),
-                        tooltip: 'Delete workspace',
-                        onPressed: () => _deleteWorkspace(ws['id'] as String),
-                      ),
-                      onTap: () => context.go('/workspace/${ws['id']}'),
-                    ),
-                  );
-                }),
-                _loadMoreButton(
-                  'Load more workspaces',
-                  enabled: _owned.hasMore,
-                  loading: _owned.loadingMore,
-                  onPressed: () => _loadMore(_owned),
-                ),
-              ],
+                    );
+                  }),
+                  _loadMoreButton(
+                    'Load more workspaces',
+                    enabled: _owned.hasMore,
+                    loading: _owned.loadingMore,
+                    onPressed: () => _loadMore(_owned),
+                  ),
+                ],
+              ),
             ),
-          ),
+        ],
       ],
     );
   }

--- a/src/frontend/lib/workspace/workspace_list_page.dart
+++ b/src/frontend/lib/workspace/workspace_list_page.dart
@@ -66,15 +66,27 @@ class _Section {
   int? nextOffset;
   bool loadingMore = false;
 
-  /// API path for this section, paginated at [offset] with the shared
+  // Independent sort/filter per section. Defaults: created, descending,
+  // no filter.
+  String sort = 'created';
+  String order = 'desc';
+  String query = '';
+  Timer? queryDebounce;
+  final TextEditingController searchController = TextEditingController();
+
+  /// API path for this section, paginated at [offset] with this section's
   /// sort/order/filter query params.
-  String path(int offset,
-      {String sort = 'created', String order = 'desc', String? q}) {
+  String path(int offset) {
     final base = isShared ? '/api/v1/workspaces/shared' : '/api/v1/workspaces';
     var p = '$base?limit=${_WorkspaceListPageState._pageSize}&offset=$offset'
         '&sort=$sort&order=$order';
-    if (q != null && q.isNotEmpty) p += '&q=${Uri.encodeQueryComponent(q)}';
+    if (query.isNotEmpty) p += '&q=${Uri.encodeQueryComponent(query)}';
     return p;
+  }
+
+  void dispose() {
+    queryDebounce?.cancel();
+    searchController.dispose();
   }
 }
 
@@ -89,15 +101,6 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
   Map<String, List<Map<String, dynamic>>> _workspaceMembers = {};
   bool _loading = true;
   StreamSubscription<void>? _workspacesChangedSub;
-
-  // Shared sort/filter (applied to both sections). Changing any of these
-  // resets each section to its first page, since a different sort/filter
-  // reorders every row.
-  String _sort = 'created';
-  String _order = 'desc';
-  String _query = '';
-  Timer? _queryDebounce;
-  final TextEditingController _searchController = TextEditingController();
 
   @override
   void initState() {
@@ -116,8 +119,8 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
   @override
   void dispose() {
     _workspacesChangedSub?.cancel();
-    _queryDebounce?.cancel();
-    _searchController.dispose();
+    _owned.dispose();
+    _shared.dispose();
     super.dispose();
   }
 
@@ -141,9 +144,7 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
   Future<({List<Map<String, dynamic>> items, bool hasMore, int? nextOffset})?>
       _fetchPage(_Section section, int offset) async {
     try {
-      final resp = await _auth.authGet(
-        section.path(offset, sort: _sort, order: _order, q: _query),
-      );
+      final resp = await _auth.authGet(section.path(offset));
       if (resp.statusCode != 200) return null;
       return _parseEnvelope(resp.body);
     } catch (_) {
@@ -255,34 +256,28 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
     }
   }
 
-  /// Change sort column/direction. Resets both sections to page 1 because
-  /// a different sort reorders every row.
-  Future<void> _changeSort(String sort) async {
-    if (_sort == sort) {
+  /// Change sort column/direction for [section]. Resets that section to
+  /// page 1 because a different sort reorders every row.
+  Future<void> _changeSort(_Section section, String sort) async {
+    if (section.sort == sort) {
       // Same column -> toggle direction.
-      setState(() => _order = _order == 'asc' ? 'desc' : 'asc');
+      setState(() => section.order = section.order == 'asc' ? 'desc' : 'asc');
     } else {
       setState(() {
-        _sort = sort;
-        _order = sort == 'name' ? 'asc' : 'desc';
+        section.sort = sort;
+        section.order = sort == 'name' ? 'asc' : 'desc';
       });
     }
-    await _reloadFromFirstPage();
+    await _loadFirstPage(section);
   }
 
-  /// Debounced name-filter handler. Resets to page 1 on change.
-  void _onQueryChanged(String value) {
-    setState(() => _query = value);
-    _queryDebounce?.cancel();
-    _queryDebounce = Timer(const Duration(milliseconds: 300), () {
-      _reloadFromFirstPage();
+  /// Debounced name-filter handler for [section]. Resets to page 1 on change.
+  void _onQueryChanged(_Section section, String value) {
+    setState(() => section.query = value);
+    section.queryDebounce?.cancel();
+    section.queryDebounce = Timer(const Duration(milliseconds: 300), () {
+      _loadFirstPage(section);
     });
-  }
-
-  Future<void> _reloadFromFirstPage() async {
-    await _loadFirstPage(_owned);
-    if (!mounted) return;
-    await _loadFirstPage(_shared);
   }
 
   Future<Map<String, dynamic>?> _fetchImages() async {
@@ -872,29 +867,29 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
     );
   }
 
-  Widget _sortChip(String label, String sortKey) {
-    final active = _sort == sortKey;
-    final arrow = _order == 'asc' ? '▲' : '▼';
+  Widget _sortChip(_Section section, String label, String sortKey) {
+    final active = section.sort == sortKey;
+    final arrow = section.order == 'asc' ? '▲' : '▼';
     return ActionChip(
       label: Text(active ? '$label $arrow' : label),
-      onPressed: () => _changeSort(sortKey),
+      onPressed: () => _changeSort(section, sortKey),
       backgroundColor:
           active ? KColors.accentBlue.withValues(alpha: 0.2) : null,
     );
   }
 
-  Widget _buildControls() {
+  Widget _buildControls(_Section section) {
     return Padding(
       padding: const EdgeInsets.only(bottom: 12),
       child: Row(
         children: [
-          _sortChip('Name', 'name'),
+          _sortChip(section, 'Name', 'name'),
           const SizedBox(width: 8),
-          _sortChip('Created', 'created'),
+          _sortChip(section, 'Created', 'created'),
           const SizedBox(width: 12),
           Expanded(
             child: TextField(
-              controller: _searchController,
+              controller: section.searchController,
               decoration: const InputDecoration(
                 isDense: true,
                 hintText: 'Filter by name...',
@@ -905,7 +900,7 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
                   vertical: 0,
                 ),
               ),
-              onChanged: _onQueryChanged,
+              onChanged: (v) => _onQueryChanged(section, v),
             ),
           ),
         ],
@@ -1014,13 +1009,13 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
     return ListView(
       padding: const EdgeInsets.all(16),
       children: [
-        _buildControls(),
+        _buildControls(section),
         if (empty)
           Center(
             child: Padding(
               padding: const EdgeInsets.only(top: 32),
               child: Text(
-                _query.isEmpty
+                section.query.isEmpty
                     ? (section.isShared
                         ? 'No workspaces shared with you.'
                         : 'No workspaces yet. Create one to get started.')

--- a/src/frontend/lib/workspace/workspace_list_page.dart
+++ b/src/frontend/lib/workspace/workspace_list_page.dart
@@ -319,7 +319,6 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
         String? errorMessage;
         String? mountError;
         String? envError;
-        final primary = Theme.of(context).colorScheme.primary;
         final labelStyle = TextStyle(
           color: KColors.textPrimary,
           fontWeight: FontWeight.bold,

--- a/src/frontend/test/workspace_list_page_test.dart
+++ b/src/frontend/test/workspace_list_page_test.dart
@@ -338,15 +338,21 @@ void main() {
       await tester.pumpWidget(buildPage());
       await tester.pumpAndSettle();
 
+      // Both tab labels render; the Owned tab is active by default.
       expect(find.text('Owned by Me'), findsOneWidget);
-      expect(find.text('My Project'), findsOneWidget);
       expect(find.text('Shared with Me'), findsOneWidget);
+      expect(find.text('My Project'), findsOneWidget);
+
+      // Switch to the Shared tab to see shared workspaces.
+      await tester.tap(find.text('Shared with Me'));
+      await tester.pumpAndSettle();
+
       expect(find.text('Team Project'), findsOneWidget);
       expect(find.text('Other Project'), findsOneWidget);
       expect(find.textContaining('alice@example.com'), findsOneWidget);
       expect(find.textContaining('bob@example.com'), findsOneWidget);
-      // 1 owned + 2 shared = 3 terminal icons
-      expect(find.byIcon(Icons.terminal), findsNWidgets(3));
+      // 2 shared terminals visible on this tab.
+      expect(find.byIcon(Icons.terminal), findsNWidgets(2));
     });
 
     testWidgets('load more appends next page and hides when done',
@@ -470,6 +476,10 @@ void main() {
       });
 
       await tester.pumpWidget(buildPage());
+      await tester.pumpAndSettle();
+
+      // Switch to the Shared tab (owned is empty/active by default).
+      await tester.tap(find.text('Shared with Me'));
       await tester.pumpAndSettle();
 
       expect(find.text('Shared First'), findsOneWidget);
@@ -614,8 +624,13 @@ void main() {
       await tester.pumpWidget(buildPage());
       await tester.pumpAndSettle();
 
-      expect(find.text('Owned by Me'), findsNothing);
+      // Both tab labels always render; the Owned tab is empty.
+      expect(find.text('Owned by Me'), findsOneWidget);
       expect(find.text('Shared with Me'), findsOneWidget);
+
+      // Switch to the Shared tab to see the shared workspace.
+      await tester.tap(find.text('Shared with Me'));
+      await tester.pumpAndSettle();
       expect(find.text('Guest Project'), findsOneWidget);
     });
 

--- a/src/frontend/test/workspace_list_page_test.dart
+++ b/src/frontend/test/workspace_list_page_test.dart
@@ -483,6 +483,106 @@ void main() {
       expect(find.text('Load more shared workspaces'), findsNothing);
     });
 
+    testWidgets('sorting by name requests sort=name and resets to page 1',
+        (tester) async {
+      var lastSort = '';
+      testAuthHttpClientOverride = withPermissions((request) async {
+        if (request.url.path == '/api/v1/workspaces') {
+          lastSort = request.url.queryParameters['sort'] ?? '';
+          return http.Response(
+            jsonEncode({
+              'items': [
+                {
+                  'id': 'ws-1',
+                  'name': 'Alpha',
+                  'container_id': null,
+                  'created_at': ''
+                },
+              ],
+              'has_more': false,
+              'next_offset': null,
+            }),
+            200,
+          );
+        }
+        if (request.url.path == '/api/v1/workspaces/shared') {
+          return http.Response(jsonEncode(_envelope([])), 200);
+        }
+        if (request.url.path == '/api/v1/workspaces/ws-1/members') {
+          return http.Response(jsonEncode([]), 200);
+        }
+        return http.Response('Not found', 404);
+      });
+
+      await tester.pumpWidget(buildPage());
+      await tester.pumpAndSettle();
+      expect(lastSort, 'created');
+
+      // Tap the Name sort chip -> request uses sort=name.
+      await tester.tap(find.textContaining('Name'));
+      await tester.pumpAndSettle();
+      expect(lastSort, 'name');
+    });
+
+    testWidgets('filter box sends q= and filters results', (tester) async {
+      var lastQ = '';
+      testAuthHttpClientOverride = withPermissions((request) async {
+        if (request.url.path == '/api/v1/workspaces') {
+          lastQ = request.url.queryParameters['q'] ?? '';
+          final items = (lastQ.isEmpty)
+              ? [
+                  {
+                    'id': 'ws-1',
+                    'name': 'Alpha',
+                    'container_id': null,
+                    'created_at': ''
+                  },
+                  {
+                    'id': 'ws-2',
+                    'name': 'Beta',
+                    'container_id': null,
+                    'created_at': ''
+                  },
+                ]
+              : [
+                  {
+                    'id': 'ws-1',
+                    'name': 'Alpha',
+                    'container_id': null,
+                    'created_at': ''
+                  },
+                ];
+          return http.Response(
+            jsonEncode(
+                {'items': items, 'has_more': false, 'next_offset': null}),
+            200,
+          );
+        }
+        if (request.url.path == '/api/v1/workspaces/shared') {
+          return http.Response(jsonEncode(_envelope([])), 200);
+        }
+        if (request.url.path == '/api/v1/workspaces/ws-1/members' ||
+            request.url.path == '/api/v1/workspaces/ws-2/members') {
+          return http.Response(jsonEncode([]), 200);
+        }
+        return http.Response('Not found', 404);
+      });
+
+      await tester.pumpWidget(buildPage());
+      await tester.pumpAndSettle();
+      expect(find.text('Alpha'), findsOneWidget);
+      expect(find.text('Beta'), findsOneWidget);
+
+      // Type into the filter box (debounced 300ms).
+      await tester.enterText(find.byType(TextField).first, 'alp');
+      await tester.pump(const Duration(milliseconds: 400));
+      await tester.pumpAndSettle();
+
+      expect(lastQ, 'alp');
+      expect(find.text('Alpha'), findsOneWidget);
+      expect(find.text('Beta'), findsNothing);
+    });
+
     testWidgets('shows only shared section when no owned workspaces',
         (tester) async {
       testAuthHttpClientOverride = withPermissions((request) async {
@@ -684,7 +784,10 @@ void main() {
       await tester.tap(find.byTooltip('New Workspace'));
       await tester.pumpAndSettle();
 
-      expect(find.byType(TextField), findsNWidgets(4));
+      expect(
+          find.descendant(
+              of: find.byType(AlertDialog), matching: find.byType(TextField)),
+          findsNWidgets(4));
       expect(find.byType(DropdownButtonFormField<String>), findsOneWidget);
     });
 
@@ -858,7 +961,13 @@ void main() {
       await tester.pumpAndSettle();
 
       // Type workspace name and tap Create
-      await tester.enterText(find.byType(TextField).first, 'New WS');
+      await tester.enterText(
+          find
+              .descendant(
+                  of: find.byType(AlertDialog),
+                  matching: find.byType(TextField))
+              .first,
+          'New WS');
       await tester.tap(find.text('Create'));
       await tester.pumpAndSettle();
 
@@ -888,7 +997,13 @@ void main() {
       await tester.tap(find.byTooltip('New Workspace'));
       await tester.pumpAndSettle();
 
-      await tester.enterText(find.byType(TextField).first, 'Duplicate');
+      await tester.enterText(
+          find
+              .descendant(
+                  of: find.byType(AlertDialog),
+                  matching: find.byType(TextField))
+              .first,
+          'Duplicate');
       await tester.tap(find.text('Create'));
       await tester.pumpAndSettle();
 
@@ -1095,7 +1210,13 @@ void main() {
       await tester.pumpAndSettle();
 
       // Type and submit via keyboard (onSubmitted)
-      await tester.enterText(find.byType(TextField).first, 'Submitted');
+      await tester.enterText(
+          find
+              .descendant(
+                  of: find.byType(AlertDialog),
+                  matching: find.byType(TextField))
+              .first,
+          'Submitted');
       await tester.testTextInput.receiveAction(TextInputAction.done);
       await tester.pumpAndSettle();
 
@@ -1150,7 +1271,13 @@ void main() {
       await tester.tap(find.text('klangk-custom').last);
       await tester.pumpAndSettle();
 
-      await tester.enterText(find.byType(TextField).first, 'ImgWS');
+      await tester.enterText(
+          find
+              .descendant(
+                  of: find.byType(AlertDialog),
+                  matching: find.byType(TextField))
+              .first,
+          'ImgWS');
       await tester.tap(find.text('Create'));
       await tester.pumpAndSettle();
 
@@ -1191,8 +1318,20 @@ void main() {
       await tester.pumpAndSettle();
 
       // Enter name and command
-      await tester.enterText(find.byType(TextField).first, 'CmdWS');
-      await tester.enterText(find.byType(TextField).at(1), 'klangk-pi');
+      await tester.enterText(
+          find
+              .descendant(
+                  of: find.byType(AlertDialog),
+                  matching: find.byType(TextField))
+              .first,
+          'CmdWS');
+      await tester.enterText(
+          find
+              .descendant(
+                  of: find.byType(AlertDialog),
+                  matching: find.byType(TextField))
+              .at(1),
+          'klangk-pi');
       await tester.tap(find.text('Create'));
       await tester.pumpAndSettle();
 
@@ -1246,8 +1385,20 @@ void main() {
       await tester.pumpAndSettle();
 
       // Enter name, then focus command field and submit via Enter
-      await tester.enterText(find.byType(TextField).first, 'CmdSubmit');
-      await tester.enterText(find.byType(TextField).at(1), 'pi');
+      await tester.enterText(
+          find
+              .descendant(
+                  of: find.byType(AlertDialog),
+                  matching: find.byType(TextField))
+              .first,
+          'CmdSubmit');
+      await tester.enterText(
+          find
+              .descendant(
+                  of: find.byType(AlertDialog),
+                  matching: find.byType(TextField))
+              .at(1),
+          'pi');
       await tester.testTextInput.receiveAction(TextInputAction.done);
       await tester.pumpAndSettle();
 
@@ -1274,7 +1425,13 @@ void main() {
       await tester.tap(find.byTooltip('New Workspace'));
       await tester.pumpAndSettle();
 
-      await tester.enterText(find.byType(TextField).first, 'Fail WS');
+      await tester.enterText(
+          find
+              .descendant(
+                  of: find.byType(AlertDialog),
+                  matching: find.byType(TextField))
+              .first,
+          'Fail WS');
       await tester.tap(find.text('Create'));
       await tester.pumpAndSettle();
 
@@ -1541,11 +1698,22 @@ void main() {
       await tester.pumpAndSettle();
 
       // Enter workspace name
-      await tester.enterText(find.byType(TextField).first, 'MountWS');
+      await tester.enterText(
+          find
+              .descendant(
+                  of: find.byType(AlertDialog),
+                  matching: find.byType(TextField))
+              .first,
+          'MountWS');
 
       // Add a mount via the mount text field (last TextField) + add button
       await tester.enterText(
-          find.byType(TextField).at(2), '/host/src:/work/src');
+          find
+              .descendant(
+                  of: find.byType(AlertDialog),
+                  matching: find.byType(TextField))
+              .at(2),
+          '/host/src:/work/src');
       // Tap the add (+) button next to the mount input
       // The FAB also has an add icon, so find the one inside the dialog
       final addIcons = find.byIcon(Icons.add);
@@ -1557,7 +1725,13 @@ void main() {
       expect(find.text('/host/src:/work/src'), findsOneWidget);
 
       // Add a second mount
-      await tester.enterText(find.byType(TextField).at(2), 'nix-vol:/nix');
+      await tester.enterText(
+          find
+              .descendant(
+                  of: find.byType(AlertDialog),
+                  matching: find.byType(TextField))
+              .at(2),
+          'nix-vol:/nix');
       await tester.tap(find.byIcon(Icons.add).at(1));
       await tester.pumpAndSettle();
       expect(find.text('nix-vol:/nix'), findsOneWidget);
@@ -1606,10 +1780,22 @@ void main() {
       await tester.tap(find.byTooltip('New Workspace'));
       await tester.pumpAndSettle();
 
-      await tester.enterText(find.byType(TextField).first, 'EnterWS');
+      await tester.enterText(
+          find
+              .descendant(
+                  of: find.byType(AlertDialog),
+                  matching: find.byType(TextField))
+              .first,
+          'EnterWS');
 
       // Add mount via Enter key on the mount text field
-      await tester.enterText(find.byType(TextField).at(2), '/a:/b');
+      await tester.enterText(
+          find
+              .descendant(
+                  of: find.byType(AlertDialog),
+                  matching: find.byType(TextField))
+              .at(2),
+          '/a:/b');
       await tester.testTextInput.receiveAction(TextInputAction.done);
       await tester.pumpAndSettle();
       expect(find.text('/a:/b'), findsOneWidget);
@@ -1638,7 +1824,13 @@ void main() {
       await tester.pumpAndSettle();
 
       // Try adding invalid mount (no colon)
-      await tester.enterText(find.byType(TextField).at(2), 'bad-mount');
+      await tester.enterText(
+          find
+              .descendant(
+                  of: find.byType(AlertDialog),
+                  matching: find.byType(TextField))
+              .at(2),
+          'bad-mount');
       await tester.tap(find.byIcon(Icons.add).at(1));
       await tester.pumpAndSettle();
 
@@ -1647,7 +1839,13 @@ void main() {
       expect(find.text('bad-mount'), findsOneWidget); // still in text field
 
       // Try adding mount with relative container path
-      await tester.enterText(find.byType(TextField).at(2), '/host:relative');
+      await tester.enterText(
+          find
+              .descendant(
+                  of: find.byType(AlertDialog),
+                  matching: find.byType(TextField))
+              .at(2),
+          '/host:relative');
       await tester.tap(find.byIcon(Icons.add).at(1));
       await tester.pumpAndSettle();
 
@@ -1655,14 +1853,25 @@ void main() {
 
       // Try adding mount with unknown option
       await tester.enterText(
-          find.byType(TextField).at(2), '/host:/container:bogus');
+          find
+              .descendant(
+                  of: find.byType(AlertDialog),
+                  matching: find.byType(TextField))
+              .at(2),
+          '/host:/container:bogus');
       await tester.tap(find.byIcon(Icons.add).at(1));
       await tester.pumpAndSettle();
 
       expect(find.textContaining('Unknown option'), findsOneWidget);
 
       // Valid mount clears the error
-      await tester.enterText(find.byType(TextField).at(2), '/a:/b');
+      await tester.enterText(
+          find
+              .descendant(
+                  of: find.byType(AlertDialog),
+                  matching: find.byType(TextField))
+              .at(2),
+          '/a:/b');
       await tester.tap(find.byIcon(Icons.add).at(1));
       await tester.pumpAndSettle();
 
@@ -1699,16 +1908,34 @@ void main() {
       await tester.tap(find.byTooltip('New Workspace'));
       await tester.pumpAndSettle();
 
-      await tester.enterText(find.byType(TextField).first, 'EnvWS');
+      await tester.enterText(
+          find
+              .descendant(
+                  of: find.byType(AlertDialog),
+                  matching: find.byType(TextField))
+              .first,
+          'EnvWS');
 
       // Add env var via the + button (env add is at index 2: FAB=0, mount=1, env=2)
-      await tester.enterText(find.byType(TextField).at(3), 'FOO=bar');
+      await tester.enterText(
+          find
+              .descendant(
+                  of: find.byType(AlertDialog),
+                  matching: find.byType(TextField))
+              .at(3),
+          'FOO=bar');
       await tester.tap(find.byIcon(Icons.add).at(2));
       await tester.pumpAndSettle();
       expect(find.text('FOO=bar'), findsOneWidget);
 
       // Add a second env var via Enter key
-      await tester.enterText(find.byType(TextField).at(3), 'X=1');
+      await tester.enterText(
+          find
+              .descendant(
+                  of: find.byType(AlertDialog),
+                  matching: find.byType(TextField))
+              .at(3),
+          'X=1');
       await tester.testTextInput.receiveAction(TextInputAction.done);
       await tester.pumpAndSettle();
       expect(find.text('X=1'), findsOneWidget);
@@ -1744,19 +1971,37 @@ void main() {
       await tester.pumpAndSettle();
 
       // Try adding env var without = sign
-      await tester.enterText(find.byType(TextField).at(3), 'NOEQ');
+      await tester.enterText(
+          find
+              .descendant(
+                  of: find.byType(AlertDialog),
+                  matching: find.byType(TextField))
+              .at(3),
+          'NOEQ');
       await tester.tap(find.byIcon(Icons.add).at(2));
       await tester.pumpAndSettle();
       expect(find.textContaining('Expected KEY=VALUE'), findsOneWidget);
 
       // Try adding env var with empty key
-      await tester.enterText(find.byType(TextField).at(3), '=value');
+      await tester.enterText(
+          find
+              .descendant(
+                  of: find.byType(AlertDialog),
+                  matching: find.byType(TextField))
+              .at(3),
+          '=value');
       await tester.tap(find.byIcon(Icons.add).at(2));
       await tester.pumpAndSettle();
       expect(find.textContaining('Key cannot be empty'), findsOneWidget);
 
       // Valid env var clears error
-      await tester.enterText(find.byType(TextField).at(3), 'A=1');
+      await tester.enterText(
+          find
+              .descendant(
+                  of: find.byType(AlertDialog),
+                  matching: find.byType(TextField))
+              .at(3),
+          'A=1');
       await tester.tap(find.byIcon(Icons.add).at(2));
       await tester.pumpAndSettle();
       expect(find.textContaining('Key cannot'), findsNothing);
@@ -1782,7 +2027,13 @@ void main() {
       expect(find.byTooltip('Copy'), findsNothing);
 
       // Add a mount
-      await tester.enterText(find.byType(TextField).at(2), '/src:/work');
+      await tester.enterText(
+          find
+              .descendant(
+                  of: find.byType(AlertDialog),
+                  matching: find.byType(TextField))
+              .at(2),
+          '/src:/work');
       await tester.tap(find.byIcon(Icons.add).at(1));
       await tester.pumpAndSettle();
 
@@ -1810,7 +2061,13 @@ void main() {
       await tester.pumpAndSettle();
 
       // Add an env var
-      await tester.enterText(find.byType(TextField).at(3), 'FOO=bar');
+      await tester.enterText(
+          find
+              .descendant(
+                  of: find.byType(AlertDialog),
+                  matching: find.byType(TextField))
+              .at(3),
+          'FOO=bar');
       await tester.tap(find.byIcon(Icons.add).at(2));
       await tester.pumpAndSettle();
 

--- a/src/frontend/test/workspace_list_page_test.dart
+++ b/src/frontend/test/workspace_list_page_test.dart
@@ -1573,7 +1573,6 @@ void main() {
         return http.Response('Not found', 404);
       });
 
-      String? navigatedTo;
       final router = GoRouter(
         initialLocation: '/',
         routes: [
@@ -1583,10 +1582,7 @@ void main() {
           ),
           GoRoute(
             path: '/workspace/:id',
-            builder: (_, state) {
-              navigatedTo = state.uri.toString();
-              return const Scaffold();
-            },
+            builder: (_, __) => const Scaffold(),
           ),
         ],
       );

--- a/src/frontend/test/workspace_list_page_test.dart
+++ b/src/frontend/test/workspace_list_page_test.dart
@@ -518,7 +518,12 @@ void main() {
       await tester.pumpAndSettle();
       expect(lastSort, 'created');
 
-      // Tap the Name sort chip -> request uses sort=name.
+      // Tap the Name sort chip -> request uses sort=name (asc by default).
+      await tester.tap(find.text('Name'));
+      await tester.pumpAndSettle();
+      expect(lastSort, 'name');
+
+      // Tap the now-active Name chip again -> toggles direction to desc.
       await tester.tap(find.textContaining('Name'));
       await tester.pumpAndSettle();
       expect(lastSort, 'name');

--- a/src/frontend/test/workspace_list_page_test.dart
+++ b/src/frontend/test/workspace_list_page_test.dart
@@ -539,6 +539,69 @@ void main() {
       expect(lastSort, 'name');
     });
 
+    testWidgets('sort state is independent per tab', (tester) async {
+      String? ownedSort;
+      String? sharedSort;
+      testAuthHttpClientOverride = withPermissions((request) async {
+        if (request.url.path == '/api/v1/workspaces') {
+          ownedSort = request.url.queryParameters['sort'];
+          return http.Response(
+            jsonEncode({
+              'items': [
+                {
+                  'id': 'ws-1',
+                  'name': 'Alpha',
+                  'container_id': null,
+                  'created_at': ''
+                },
+              ],
+              'has_more': false,
+              'next_offset': null,
+            }),
+            200,
+          );
+        }
+        if (request.url.path == '/api/v1/workspaces/shared') {
+          sharedSort = request.url.queryParameters['sort'];
+          return http.Response(
+            jsonEncode({
+              'items': [
+                {
+                  'id': 'sh-1',
+                  'name': 'Shared',
+                  'container_id': null,
+                  'created_at': '',
+                  'owner_email': 'o@e.com'
+                },
+              ],
+              'has_more': false,
+              'next_offset': null,
+            }),
+            200,
+          );
+        }
+        if (request.url.path == '/api/v1/workspaces/ws-1/members' ||
+            request.url.path == '/api/v1/workspaces/sh-1/members') {
+          return http.Response(jsonEncode([]), 200);
+        }
+        return http.Response('Not found', 404);
+      });
+
+      await tester.pumpWidget(buildPage());
+      await tester.pumpAndSettle();
+
+      // Owned tab is active: sort by name there.
+      await tester.tap(find.text('Name'));
+      await tester.pumpAndSettle();
+      expect(ownedSort, 'name');
+
+      // Switch to the Shared tab: its request should still use the
+      // default 'created' sort, unaffected by the Owned tab's sort.
+      await tester.tap(find.text('Shared with Me'));
+      await tester.pumpAndSettle();
+      expect(sharedSort, 'created');
+    });
+
     testWidgets('filter box sends q= and filters results', (tester) async {
       var lastQ = '';
       testAuthHttpClientOverride = withPermissions((request) async {


### PR DESCRIPTION
## Summary

Closes #945. Adds sort-by-name/created and a name substring filter to the paginated workspace list, across backend + CLI + frontend.

## Backend

`GET /api/v1/workspaces` and `/workspaces/shared` accept three new optional query params (apply in both the bare-list and envelope shapes):

| Param   | Values             | Default   |
| ------- | ------------------ | --------- |
| `sort`  | `name` \| `created`| `created` |
| `order` | `asc` \| `desc`    | `desc`    |
| `q`     | substring          | (none)    |

- `sort`/`order` are `Literal`-validated → **422** on invalid values.
- Sort columns are **whitelisted** (`created`→`created_at`, `name`→`name`) — never interpolated from user input. The `id` tiebreaker uses the same direction so offset pagination stays deterministic.
- `q` matches **anywhere** in the name (`LIKE '%q%'`, not a prefix), applied before `LIMIT`/`OFFSET` so `has_more`/`next_offset` reflect the filtered set. The shared endpoint filters on workspace name.

## CLI

`klangkc ls` gains `--sort name|created`, `--order asc|desc`, and `--filter <substring>`; forwarded as query params through the paginated client.

## Frontend

Above the sections: **sort chips** (Name / Created — click toggles asc/desc, active chip shows ▲/▼) and a **name search box**. Changing sort **or** filter reloads both sections from **page 1** (a different sort/filter reorders every row). The filter input is **debounced 300ms**. Sort/order/q are threaded through `_Section.path` and `_fetchPage`.

## Verification

- Backend: **1634 passed**, **100% coverage**; ruff clean. New tests: sort asc/desc, substring filter, invalid sort/order → 422, shared-endpoint sort+filter.
- CLI: **369 passed** (5 pre-existing stdin-`fileno()` failures deselected — they fail identically on clean main); ruff clean. New tests: sort/order/q forwarded as params; `--sort`/`--order`/`--filter` forwarded from the command.
- Frontend: **613 passed**; analyzer clean (only 2 pre-existing unused-var warnings). New tests: sort chip requests `sort=name` and resets to page 1; filter box sends `q=` and filters results. Dialog `TextField` finds scoped to the `AlertDialog` so the new search box doesn't interfere.

## Docs

`api-endpoints.md` (sort/order/q params + substring semantics) and `cli.md` (`--sort`/`--order`/`--filter` examples) updated.
