### PR TITLE
refactor(ws): replace message if/else chain with dispatch table

### DIFF
--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -291,6 +291,37 @@ class WsClient extends ChangeNotifier {
     _listenToChannel();
   }
 
+  /// Dispatch table for incoming WebSocket message types.
+  ///
+  /// Simple pass-throughs are one-line lambdas/tear-offs; stateful
+  /// branches live in named `_on…` methods so the `notifyListeners()`
+  /// calls and mutations stay auditable. See #952.
+  late final Map<String, void Function(Map<String, dynamic>)> _handlers = {
+    'workspace_ready': _onWorkspaceReady,
+    'terminal_output': (json) =>
+        _terminalOutputController.add(json['data'] as String? ?? ''),
+    'error': (json) =>
+        _errorController.add(json['message'] as String? ?? 'Unknown error'),
+    'browser_request': _browserRequestController.add,
+    'chat_message': (json) {
+      chatHistory.add(json);
+      _chatController.add(json);
+    },
+    'chat_history': _onChatHistory,
+    'chat_history_page': _chatHistoryPageController.add,
+    'chat_updated': _chatController.add,
+    'agent_thinking': _chatController.add,
+    'workspace_members': _onWorkspaceMembers,
+    'presence_list': _onPresenceList,
+    'presence_join': _onPresenceJoin,
+    'presence_leave': _onPresenceLeave,
+    'terminal_windows': _onTerminalWindows,
+    'shared_terminals': _onSharedTerminals,
+    'shared_terminal_deleted': _onSharedTerminalDeleted,
+    'workspaces_changed': (json) => _workspacesChangedController.add(null),
+    'event': _customEventController.add,
+  };
+
   void _listenToChannel() {
     _channel!.stream.listen(
       (data) {
@@ -308,85 +339,7 @@ class WsClient extends ChangeNotifier {
             );
           }
 
-          if (type == 'workspace_ready') {
-            _currentWorkspaceId = json['workspaceId'] as String?;
-            _currentUserId = json['userId'] as String?;
-            _defaultCommand = json['defaultCommand'] as String?;
-            _userHome = json['userHome'] as String?;
-            _reconnecting = false;
-            _reconnectAttempt = 0;
-            _pendingWorkspaceId = null;
-            _startHeartbeat();
-            notifyListeners();
-          } else if (type == 'terminal_output') {
-            _terminalOutputController.add(json['data'] as String? ?? '');
-          } else if (type == 'error') {
-            _errorController.add(json['message'] as String? ?? 'Unknown error');
-          } else if (type == 'browser_request') {
-            _browserRequestController.add(json);
-          } else if (type == 'chat_message') {
-            chatHistory.add(json);
-            _chatController.add(json);
-          } else if (type == 'chat_history') {
-            final messages = json['messages'] as List? ?? [];
-            for (final m in messages) {
-              final msg = m as Map<String, dynamic>;
-              chatHistory.add(msg);
-              _chatController.add(msg);
-            }
-          } else if (type == 'chat_history_page') {
-            _chatHistoryPageController.add(json);
-          } else if (type == 'chat_updated') {
-            _chatController.add(json);
-          } else if (type == 'agent_thinking') {
-            _chatController.add(json);
-          } else if (type == 'workspace_members') {
-            final members = json['members'] as List? ?? [];
-            workspaceMembers = members.cast<Map<String, dynamic>>();
-            notifyListeners();
-          } else if (type == 'presence_list') {
-            final users = json['users'] as List? ?? [];
-            presenceUsers = users.cast<Map<String, dynamic>>();
-            notifyListeners();
-          } else if (type == 'presence_join') {
-            final uid = json['user_id'] as String?;
-            if (uid != null && !presenceUsers.any((u) => u['user_id'] == uid)) {
-              presenceUsers = [
-                ...presenceUsers,
-                {
-                  'user_id': uid,
-                  'user_email': json['user_email'],
-                  'user_handle': json['user_handle'] ?? '',
-                },
-              ];
-              notifyListeners();
-            }
-          } else if (type == 'presence_leave') {
-            final uid = json['user_id'] as String?;
-            if (uid != null) {
-              presenceUsers =
-                  presenceUsers.where((u) => u['user_id'] != uid).toList();
-              notifyListeners();
-            }
-          } else if (type == 'terminal_windows') {
-            debugPrint(
-              '[WsClient] terminal_windows received: ${DateTime.now()}',
-            );
-            final windows = json['windows'] as List? ?? [];
-            terminalWindows = windows.cast<Map<String, dynamic>>();
-            notifyListeners();
-          } else if (type == 'shared_terminals') {
-            final terminals = json['terminals'] as List? ?? [];
-            sharedTerminals = terminals.cast<Map<String, dynamic>>();
-            notifyListeners();
-          } else if (type == 'shared_terminal_deleted') {
-            _sharedTerminalDeletedController.add(json);
-            notifyListeners();
-          } else if (type == 'workspaces_changed') {
-            _workspacesChangedController.add(null);
-          } else if (type == 'event') {
-            _customEventController.add(json);
-          }
+          _handlers[type]?.call(json);
         } catch (e) {
           _errorController.add('Parse error: $e');
         }
@@ -422,6 +375,82 @@ class WsClient extends ChangeNotifier {
         }
       },
     );
+  }
+
+  void _onWorkspaceReady(Map<String, dynamic> json) {
+    _currentWorkspaceId = json['workspaceId'] as String?;
+    _currentUserId = json['userId'] as String?;
+    _defaultCommand = json['defaultCommand'] as String?;
+    _userHome = json['userHome'] as String?;
+    _reconnecting = false;
+    _reconnectAttempt = 0;
+    _pendingWorkspaceId = null;
+    _startHeartbeat();
+    notifyListeners();
+  }
+
+  void _onChatHistory(Map<String, dynamic> json) {
+    final messages = json['messages'] as List? ?? [];
+    for (final m in messages) {
+      final msg = m as Map<String, dynamic>;
+      chatHistory.add(msg);
+      _chatController.add(msg);
+    }
+  }
+
+  void _onWorkspaceMembers(Map<String, dynamic> json) {
+    final members = json['members'] as List? ?? [];
+    workspaceMembers = members.cast<Map<String, dynamic>>();
+    notifyListeners();
+  }
+
+  void _onPresenceList(Map<String, dynamic> json) {
+    final users = json['users'] as List? ?? [];
+    presenceUsers = users.cast<Map<String, dynamic>>();
+    notifyListeners();
+  }
+
+  void _onPresenceJoin(Map<String, dynamic> json) {
+    final uid = json['user_id'] as String?;
+    if (uid != null && !presenceUsers.any((u) => u['user_id'] == uid)) {
+      presenceUsers = [
+        ...presenceUsers,
+        {
+          'user_id': uid,
+          'user_email': json['user_email'],
+          'user_handle': json['user_handle'] ?? '',
+        },
+      ];
+      notifyListeners();
+    }
+  }
+
+  void _onPresenceLeave(Map<String, dynamic> json) {
+    final uid = json['user_id'] as String?;
+    if (uid != null) {
+      presenceUsers = presenceUsers.where((u) => u['user_id'] != uid).toList();
+      notifyListeners();
+    }
+  }
+
+  void _onTerminalWindows(Map<String, dynamic> json) {
+    debugPrint(
+      '[WsClient] terminal_windows received: ${DateTime.now()}',
+    );
+    final windows = json['windows'] as List? ?? [];
+    terminalWindows = windows.cast<Map<String, dynamic>>();
+    notifyListeners();
+  }
+
+  void _onSharedTerminals(Map<String, dynamic> json) {
+    final terminals = json['terminals'] as List? ?? [];
+    sharedTerminals = terminals.cast<Map<String, dynamic>>();
+    notifyListeners();
+  }
+
+  void _onSharedTerminalDeleted(Map<String, dynamic> json) {
+    _sharedTerminalDeletedController.add(json);
+    notifyListeners();
   }
 
   void disconnect() {


### PR DESCRIPTION
## Summary
- `_listenToChannel` in `ws_client.dart` was a ~133-line method built on a ~20-branch `if/else-if` chain mapping each incoming WebSocket message `type` to a controller `.add(...)` and/or a state mutation + `notifyListeners()`
- Adding a type meant editing the chain; branch order and `notifyListeners()` calls were easy to get wrong, and trivial pass-throughs were mixed with stateful mutations
- Replaced the chain with a `late final _handlers` dispatch table (`Map<String, void Function(Map<String,dynamic>)>`): simple pass-throughs are one-line lambdas/tear-offs; the stateful branches extract to named `_on…` methods (`_onWorkspaceReady`, `_onChatHistory`, `_onWorkspaceMembers`, `_onPresenceList`, `_onPresenceJoin`, `_onPresenceLeave`, `_onTerminalWindows`, `_onSharedTerminals`, `_onSharedTerminalDeleted`)
- `_listenToChannel` now just parses JSON, emits the debug-log entry, and calls `_handlers[type]?.call(json)` (unknown types are a no-op, same as the old fall-through)

## Behavior preservation
- Preserved exactly which branches call `notifyListeners()`, the `chat_history` buffering into `chatHistory`, the `terminal_output` skip from the debug log, and the `event` summary special-casing
- `dart analyze` is clean
- All **78 tests** in `ws_client_test.dart` pass (workspace_ready, terminal_output, error, chat_message, chat_history, chat_updated, presence_list/join/leave, workspace_members, terminal_windows, workspaces_changed, parse errors, reconnect, etc.)

Closes #952