### PR TITLE
refactor(app): extract GoRouter redirect guards from _createRouter

### DIFF
--- a/src/frontend/lib/app.dart
+++ b/src/frontend/lib/app.dart
@@ -3,7 +3,6 @@ import 'package:go_router/go_router.dart';
 import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 import 'package:provider/provider.dart';
 import 'auth/auth_service.dart';
-import 'auth/pending_redirect.dart';
 import 'utils/web_helpers_stub.dart'
     if (dart.library.js_interop) 'utils/web_helpers_web.dart';
 import 'theme/colors.dart';
@@ -19,6 +18,7 @@ import 'auth/settings_page.dart';
 import 'widgets/stale_build_banner.dart';
 import 'workspace/workspace_list_page.dart';
 import 'workspace/workspace_page.dart';
+import 'app_guards.dart';
 
 class KlangkApp extends StatefulWidget {
   final String initialLocation;
@@ -76,39 +76,16 @@ class _KlangkAppState extends State<KlangkApp> {
       initialLocation: initialLocation,
       refreshListenable: auth,
       redirect: (context, state) {
-        final isLoggedIn = auth.isLoggedIn;
         final loc = state.matchedLocation;
-
-        // Banner gate — blocks everything until accepted
-        if (auth.bannerRequired) {
-          return loc == '/consent' ? null : '/consent';
-        }
-        if (!auth.bannerRequired && loc == '/consent') {
-          return '/login';
-        }
-
-        final publicRoutes = {
-          '/login',
-          '/verify',
-          '/forgot-password',
-          '/reset-password',
-          '/accept-invite',
-          '/oidc-complete',
-          '/consent',
-          ...pluginPaths,
-        };
-        if (!isLoggedIn && !publicRoutes.contains(loc)) {
-          if (loc != '/' && loc != '/workspaces') {
-            pendingRedirect = state.uri.toString();
-          }
-          return '/login';
-        }
-        if (isLoggedIn && publicRoutes.contains(loc) &&
-            !pluginPaths.contains(loc)) {
-          return pendingRedirect ?? '/workspaces';
-        }
-        if (isLoggedIn && loc == '/') return '/workspaces';
-        return null;
+        final routes = {...publicRoutes, ...pluginPaths};
+        return evaluateGuards(
+          isLoggedIn: auth.isLoggedIn,
+          bannerRequired: auth.bannerRequired,
+          loc: loc,
+          currentUri: state.uri.toString(),
+          publicRoutes: routes,
+          pluginPaths: pluginPaths,
+        );
       },
       routes: [
         GoRoute(

--- a/src/frontend/lib/app_guards.dart
+++ b/src/frontend/lib/app_guards.dart
@@ -1,0 +1,125 @@
+// Redirect guards extracted from KlangkApp's GoRouter. See #955.
+//
+// Each guard takes the inputs it needs and returns the redirect target
+// (a path) or null to allow the navigation. They are top-level functions
+// (not closures inside _createRouter) so they can be unit-tested in
+// isolation; _createRouter just wires them up in precedence order.
+//
+// The order matters: the first guard to return non-null wins. The
+// precedence matches the original inline redirect callback:
+//   banner -> auth -> logged-in-on-public -> root.
+
+import 'auth/pending_redirect.dart';
+
+/// Set of routes reachable without being logged in.
+///
+/// Plugin paths are appended by the caller, since they depend on the
+/// installed plugins and are not known at compile time.
+const Set<String> publicRoutes = {
+  '/login',
+  '/verify',
+  '/forgot-password',
+  '/reset-password',
+  '/accept-invite',
+  '/oidc-complete',
+  '/consent',
+};
+
+/// Banner gate.
+///
+/// When a banner must be accepted, force every route to `/consent`
+/// (allowing `/consent` itself). When no banner is pending, a visit to
+/// `/consent` bounces to `/login` — the consent page is only meaningful
+/// while a banner is required.
+///
+/// Returns the redirect target, or null to allow.
+String? guardBanner({required bool bannerRequired, required String loc}) {
+  if (bannerRequired) {
+    return loc == '/consent' ? null : '/consent';
+  }
+  if (loc == '/consent') {
+    return '/login';
+  }
+  return null;
+}
+
+/// Auth gate.
+///
+/// Logged-out users hitting a non-public route are sent to `/login`.
+/// Their intended destination is stashed in [pendingRedirect] (unless
+/// it was `/` or `/workspaces`, which have no value as a return target)
+/// so login can send them back. This guard has a side effect on the
+/// [pendingRedirect] global, matching the legacy inline behavior.
+///
+/// Returns the redirect target, or null to allow.
+String? guardAuth({
+  required bool isLoggedIn,
+  required String loc,
+  required Set<String> publicRoutes,
+  required String currentUri,
+}) {
+  if (!isLoggedIn && !publicRoutes.contains(loc)) {
+    if (loc != '/' && loc != '/workspaces') {
+      pendingRedirect = currentUri;
+    }
+    return '/login';
+  }
+  return null;
+}
+
+/// Logged-in-on-public gate.
+///
+/// A logged-in user landing on a public route (e.g. `/login` after a
+/// refresh) is bounced to their pending redirect, or `/workspaces`.
+/// Plugin routes are excluded: they are public but a logged-in user may
+/// legitimately navigate to them.
+///
+/// Returns the redirect target, or null to allow.
+String? guardLoggedInPublicRoute({
+  required bool isLoggedIn,
+  required String loc,
+  required Set<String> publicRoutes,
+  required Set<String> pluginPaths,
+}) {
+  if (isLoggedIn && publicRoutes.contains(loc) && !pluginPaths.contains(loc)) {
+    return pendingRedirect ?? '/workspaces';
+  }
+  return null;
+}
+
+/// Root shortcut: a logged-in user at `/` goes to `/workspaces`.
+///
+/// Returns the redirect target, or null to allow.
+String? guardRoot({required bool isLoggedIn, required String loc}) {
+  if (isLoggedIn && loc == '/') return '/workspaces';
+  return null;
+}
+
+/// Run the redirect guards in precedence order and return the first
+/// non-null redirect target, or null if all guards allow.
+///
+/// [publicRoutes] should already include the plugin paths; [pluginPaths]
+/// is passed separately so [guardLoggedInPublicRoute] can exclude them.
+String? evaluateGuards({
+  required bool isLoggedIn,
+  required bool bannerRequired,
+  required String loc,
+  required String currentUri,
+  required Set<String> publicRoutes,
+  required Set<String> pluginPaths,
+}) {
+  return guardBanner(bannerRequired: bannerRequired, loc: loc) ??
+      guardAuth(
+        isLoggedIn: isLoggedIn,
+        loc: loc,
+        publicRoutes: publicRoutes,
+        currentUri: currentUri,
+      ) ??
+      guardLoggedInPublicRoute(
+        isLoggedIn: isLoggedIn,
+        loc: loc,
+        publicRoutes: publicRoutes,
+        pluginPaths: pluginPaths,
+      ) ??
+      guardRoot(isLoggedIn: isLoggedIn, loc: loc);
+}

--- a/src/frontend/test/app_guards_test.dart
+++ b/src/frontend/test/app_guards_test.dart
@@ -1,0 +1,303 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:klangk_frontend/app_guards.dart';
+import 'package:klangk_frontend/auth/pending_redirect.dart';
+
+/// The full public-route set as the router builds it (publicRoutes
+/// constant plus a couple of plugin paths used in the tests below).
+Set<String> _routesWithPlugins(Set<String> pluginPaths) =>
+    {...publicRoutes, ...pluginPaths};
+
+void main() {
+  // guardAuth mutates the top-level pendingRedirect global; reset it
+  // between tests so order doesn't matter.
+  setUp(() => pendingRedirect = null);
+  tearDown(() => pendingRedirect = null);
+
+  group('guardBanner', () {
+    test('forces /consent when a banner is required', () {
+      expect(
+        guardBanner(bannerRequired: true, loc: '/workspaces'),
+        '/consent',
+      );
+      expect(
+        guardBanner(bannerRequired: true, loc: '/workspace/x'),
+        '/consent',
+      );
+    });
+
+    test('allows /consent itself when a banner is required', () {
+      expect(guardBanner(bannerRequired: true, loc: '/consent'), isNull);
+    });
+
+    test('bounces /consent to /login when no banner is pending', () {
+      expect(guardBanner(bannerRequired: false, loc: '/consent'), '/login');
+    });
+
+    test('allows other routes when no banner is pending', () {
+      expect(
+        guardBanner(bannerRequired: false, loc: '/workspaces'),
+        isNull,
+      );
+      expect(guardBanner(bannerRequired: false, loc: '/login'), isNull);
+    });
+  });
+
+  group('guardAuth', () {
+    test('sends logged-out users on non-public routes to /login', () {
+      expect(
+        guardAuth(
+          isLoggedIn: false,
+          loc: '/workspaces',
+          publicRoutes: publicRoutes,
+          currentUri: '/workspaces',
+        ),
+        '/login',
+      );
+    });
+
+    test('remembers the intended destination in pendingRedirect', () {
+      expect(
+        guardAuth(
+          isLoggedIn: false,
+          loc: '/workspace/abc',
+          publicRoutes: publicRoutes,
+          currentUri: '/workspace/abc?file=main.dart',
+        ),
+        '/login',
+      );
+      expect(pendingRedirect, '/workspace/abc?file=main.dart');
+    });
+
+    test('does not remember / or /workspaces as a return target', () {
+      guardAuth(
+        isLoggedIn: false,
+        loc: '/',
+        publicRoutes: publicRoutes,
+        currentUri: '/',
+      );
+      expect(pendingRedirect, isNull);
+      guardAuth(
+        isLoggedIn: false,
+        loc: '/workspaces',
+        publicRoutes: publicRoutes,
+        currentUri: '/workspaces',
+      );
+      expect(pendingRedirect, isNull);
+    });
+
+    test('allows logged-out users on public routes', () {
+      expect(
+        guardAuth(
+          isLoggedIn: false,
+          loc: '/login',
+          publicRoutes: publicRoutes,
+          currentUri: '/login',
+        ),
+        isNull,
+      );
+      expect(pendingRedirect, isNull);
+    });
+
+    test('allows logged-in users (no opinion)', () {
+      expect(
+        guardAuth(
+          isLoggedIn: true,
+          loc: '/workspaces',
+          publicRoutes: publicRoutes,
+          currentUri: '/workspaces',
+        ),
+        isNull,
+      );
+    });
+  });
+
+  group('guardLoggedInPublicRoute', () {
+    final pluginPaths = {'/celebrate'};
+    final routes = _routesWithPlugins(pluginPaths);
+
+    test('bounces logged-in users on public routes to pendingRedirect', () {
+      pendingRedirect = '/workspace/abc';
+      expect(
+        guardLoggedInPublicRoute(
+          isLoggedIn: true,
+          loc: '/login',
+          publicRoutes: routes,
+          pluginPaths: pluginPaths,
+        ),
+        '/workspace/abc',
+      );
+    });
+
+    test('falls back to /workspaces with no pending redirect', () {
+      expect(
+        guardLoggedInPublicRoute(
+          isLoggedIn: true,
+          loc: '/login',
+          publicRoutes: routes,
+          pluginPaths: pluginPaths,
+        ),
+        '/workspaces',
+      );
+    });
+
+    test('does not bounce for plugin routes (public but legitimate)', () {
+      expect(
+        guardLoggedInPublicRoute(
+          isLoggedIn: true,
+          loc: '/celebrate',
+          publicRoutes: routes,
+          pluginPaths: pluginPaths,
+        ),
+        isNull,
+      );
+    });
+
+    test('does not bounce for non-public routes', () {
+      expect(
+        guardLoggedInPublicRoute(
+          isLoggedIn: true,
+          loc: '/workspaces',
+          publicRoutes: routes,
+          pluginPaths: pluginPaths,
+        ),
+        isNull,
+      );
+    });
+
+    test('does not bounce for logged-out users', () {
+      expect(
+        guardLoggedInPublicRoute(
+          isLoggedIn: false,
+          loc: '/login',
+          publicRoutes: routes,
+          pluginPaths: pluginPaths,
+        ),
+        isNull,
+      );
+    });
+  });
+
+  group('guardRoot', () {
+    test('sends logged-in users at / to /workspaces', () {
+      expect(guardRoot(isLoggedIn: true, loc: '/'), '/workspaces');
+    });
+
+    test('allows logged-out users at /', () {
+      expect(guardRoot(isLoggedIn: false, loc: '/'), isNull);
+    });
+
+    test('allows non-root locations', () {
+      expect(guardRoot(isLoggedIn: true, loc: '/workspaces'), isNull);
+    });
+  });
+
+  group('evaluateGuards precedence', () {
+    final pluginPaths = {'/celebrate'};
+    final routes = _routesWithPlugins(pluginPaths);
+
+    test('banner takes precedence over everything', () {
+      // Logged-out user on a protected route, but banner required ->
+      // sent to /consent, not /login, and pendingRedirect untouched.
+      expect(
+        evaluateGuards(
+          isLoggedIn: false,
+          bannerRequired: true,
+          loc: '/workspaces',
+          currentUri: '/workspaces',
+          publicRoutes: routes,
+          pluginPaths: pluginPaths,
+        ),
+        '/consent',
+      );
+      expect(pendingRedirect, isNull);
+    });
+
+    test('logged-out protected route -> /login with pendingRedirect', () {
+      expect(
+        evaluateGuards(
+          isLoggedIn: false,
+          bannerRequired: false,
+          loc: '/workspace/abc',
+          currentUri: '/workspace/abc?x=1',
+          publicRoutes: routes,
+          pluginPaths: pluginPaths,
+        ),
+        '/login',
+      );
+      expect(pendingRedirect, '/workspace/abc?x=1');
+    });
+
+    test('logged-in on /login -> pendingRedirect', () {
+      pendingRedirect = '/workspace/zzz';
+      expect(
+        evaluateGuards(
+          isLoggedIn: true,
+          bannerRequired: false,
+          loc: '/login',
+          currentUri: '/login',
+          publicRoutes: routes,
+          pluginPaths: pluginPaths,
+        ),
+        '/workspace/zzz',
+      );
+    });
+
+    test('logged-in on / -> /workspaces (root, not public-route guard)', () {
+      // '/' is not in publicRoutes, so the public-route guard skips;
+      // the root guard then redirects.
+      expect(
+        evaluateGuards(
+          isLoggedIn: true,
+          bannerRequired: false,
+          loc: '/',
+          currentUri: '/',
+          publicRoutes: routes,
+          pluginPaths: pluginPaths,
+        ),
+        '/workspaces',
+      );
+    });
+
+    test('logged-in on /workspaces -> allowed (null)', () {
+      expect(
+        evaluateGuards(
+          isLoggedIn: true,
+          bannerRequired: false,
+          loc: '/workspaces',
+          currentUri: '/workspaces',
+          publicRoutes: routes,
+          pluginPaths: pluginPaths,
+        ),
+        isNull,
+      );
+    });
+
+    test('logged-in on plugin route -> allowed (null)', () {
+      expect(
+        evaluateGuards(
+          isLoggedIn: true,
+          bannerRequired: false,
+          loc: '/celebrate',
+          currentUri: '/celebrate',
+          publicRoutes: routes,
+          pluginPaths: pluginPaths,
+        ),
+        isNull,
+      );
+    });
+
+    test('logged-out on /consent with no banner -> /login', () {
+      expect(
+        evaluateGuards(
+          isLoggedIn: false,
+          bannerRequired: false,
+          loc: '/consent',
+          currentUri: '/consent',
+          publicRoutes: routes,
+          pluginPaths: pluginPaths,
+        ),
+        '/login',
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- `_createRouter` in `app.dart` built the `GoRouter` with all redirect/guard logic inlined as multi-line `if` blocks inside the `redirect:` callback (banner gate, auth gate, logged-in-on-public, root) — hard to read and impossible to unit-test as closures embedded in router construction
- Extracted each guard into a named top-level function in a new `app_guards.dart` module: `guardBanner`, `guardAuth`, `guardLoggedInPublicRoute`, `guardRoot`, plus `evaluateGuards` running them in precedence order (first non-null wins)
- Each guard takes primitive inputs (bools, strings, sets) and returns the redirect target or `null`; `publicRoutes` is exported as a constant set. The route table stays in `_createRouter`, which now just wires the guards — the `redirect:` callback shrank from ~37 lines to ~10

## Behavior preservation
- Precedence preserved exactly: banner → auth → logged-in-on-public → root
- The `pendingRedirect` side effect (in `guardAuth`) and the plugin-route exclusion (in `guardLoggedInPublicRoute`) are unchanged; the now-unused `pending_redirect` import was dropped from `app.dart` (it lives in `app_guards.dart`)
- `dart analyze` clean; full frontend suite (**633 tests**) passes

## Tests
- Adds `app_guards_test.dart` with **24 tests** covering each guard's branches and the `evaluateGuards` precedence (banner beats auth, logged-out protected → `/login` with `pendingRedirect`, logged-in on `/login` → pending redirect, `/` → `/workspaces` via root guard, plugin routes allowed, `/consent`-without-banner → `/login`)

Closes #955