### PR TITLE
refactor(util): extract shared file-read helper from secret resolvers

### DIFF
--- a/src/backend/klangk_backend/util.py
+++ b/src/backend/klangk_backend/util.py
@@ -14,6 +14,24 @@ API_PREFIX = "/api/v1"
 logger = logging.getLogger(__name__)
 
 
+def _read_file_value(value: str) -> tuple[str | None, OSError | None]:
+    """Strip a 'file:' prefix and read the referenced file.
+
+    Returns (contents, None) on success, where contents is the
+    file's text stripped of surrounding whitespace, or (None, error)
+    on failure, where error is the OSError raised while reading.
+
+    Shared by resolve_env_secret and resolve_file_secret, which differ
+    only in their default value and log message on failure.
+    """
+    path = value[5:]
+    try:
+        return open(path).read().strip(), None
+    except OSError as e:
+        e.filename = e.filename or path
+        return None, e
+
+
 def resolve_env_secret(key: str, default: str | None = None) -> str | None:
     """Read an env var, dereferencing 'path:' prefixed values.
 
@@ -25,12 +43,11 @@ def resolve_env_secret(key: str, default: str | None = None) -> str | None:
     if val is None:
         return default
     if val.startswith("file:"):
-        path = val[5:]
-        try:
-            return open(path).read().strip()
-        except OSError as e:
-            logger.error("Cannot read %s from %s: %s", key, path, e)
+        contents, err = _read_file_value(val)
+        if err is not None:
+            logger.error("Cannot read %s from %s: %s", key, err.filename, err)
             return None
+        return contents
     return val
 
 
@@ -53,12 +70,12 @@ def resolve_file_secret(value: str) -> str:
     its stripped contents. Otherwise returns the value as-is.
     """
     if value.startswith("file:"):
-        path = value[5:]
-        try:
-            return open(path).read().strip()
-        except OSError as e:
-            logger.error("Cannot read secret file: %s", e)
+        contents, err = _read_file_value(value)
+        if err is not None:
+            logger.error("Cannot read secret file: %s", err)
             return ""
+        assert contents is not None
+        return contents
     return value
 
 

--- a/src/backend/tests/test_util.py
+++ b/src/backend/tests/test_util.py
@@ -1,11 +1,30 @@
 """Tests for util: file-backed secret resolution."""
 
 from klangk_backend.util import (
+    _read_file_value,
     resolve_env_bool,
     resolve_env_secret,
     resolve_file_secret,
     sanitize_disposition_name,
 )
+
+
+class TestReadFileValue:
+    """_read_file_value is the shared helper behind resolve_env_secret
+    and resolve_file_secret."""
+
+    def test_reads_and_strips_contents(self, tmp_path):
+        f = tmp_path / "secret"
+        f.write_text("from-file\n")
+        contents, err = _read_file_value(f"file:{f}")
+        assert contents == "from-file"
+        assert err is None
+
+    def test_missing_file_returns_error(self):
+        contents, err = _read_file_value("file:/no/such/file")
+        assert contents is None
+        assert isinstance(err, OSError)
+        assert err.filename == "/no/such/file"
 
 
 class TestResolveEnvSecret:


### PR DESCRIPTION
`resolve_env_secret` and `resolve_file_secret` both implement the same 'file:'-prefix-strip-and-read logic independently - they differ only in their failure return value (None vs "") and log message.
This extracts the shared file-read into _read_file_value, which returns (contents, error). Each public function keeps its own error handling and messaging, so behavior is unchanged in every case: plain value, file: prefix success, file: prefix failure (missing/unreadable file), and unset env var.
No callers change - both functions keep their existing signatures.
Added TestReadFileValue covering the new helper directly; existing tests for both public functions pass unmodified.