### PR TITLE
fix(files): bump directory-listing cache TTL to 20s

### DIFF
--- a/src/frontend/lib/file_viewer/file_list_cache.dart
+++ b/src/frontend/lib/file_viewer/file_list_cache.dart
@@ -8,6 +8,11 @@ class FileListCacheEntry {
   FileListCacheEntry(this.entries, this.expiresAt);
 }
 
+/// Default time-to-live for cached listings. Window within which a
+/// revisit returns instantly without re-listing the directory. Tuned so
+/// normal folder-browsing cadence stays within cache; see #979.
+const Duration _defaultTtl = Duration(seconds: 20);
+
 /// A small bounded LRU cache of directory listings, keyed by
 /// `(workspaceId, path)`.
 ///
@@ -35,7 +40,7 @@ class FileListCache {
 
   FileListCache({
     this.capacity = 32,
-    this.ttl = const Duration(seconds: 5),
+    this.ttl = _defaultTtl,
     DateTime Function()? now,
   }) : _now = now ?? DateTime.now;
 

--- a/src/frontend/test/file_list_cache_test.dart
+++ b/src/frontend/test/file_list_cache_test.dart
@@ -8,6 +8,11 @@ void main() {
       expect(cache.get('ws-1', '/home/x'), isNull);
     });
 
+    test('default TTL is 20 seconds (#979)', () {
+      final cache = FileListCache();
+      expect(cache.ttl, const Duration(seconds: 20));
+    });
+
     test('put then get returns the entries', () {
       final cache = FileListCache();
       final entries = [


### PR DESCRIPTION
## Summary

Closes #979 (the TTL portion). The client-side directory-listing cache's 5s TTL expired between typical folder clicks, so nearly every navigation re-fetched and re-`podman exec`'d. Bump the default TTL to **20 seconds** via a named `_defaultTtl` constant.

Local mutations (upload/delete/rename) still call `invalidate` before refetching, so staleness only affects revisits within the 20s window — it won't show a directory the user just changed.

## Change

- `src/frontend/lib/file_viewer/file_list_cache.dart`: default `ttl` 5s → 20s, via `const Duration _defaultTtl = Duration(seconds: 20)`.
- Test asserts the default TTL is 20s (regression guard).

## Verification

- `flutter test`: **639 passed**; analyzer clean.

## Scope note

This addresses the "TTL too short" root cause from #979. The other root cause flagged there — **no server-side cache**, so first-visits to any folder always exec — is **not** fixed by this PR and remains open in #979 for a follow-up (server-side memoization of `list_files` with mutation invalidation).
