### PR TITLE
Refactor: extract SshAgentForwarder collaborator from Connection (#961)

### DIFF
--- a/src/backend/klangk_backend/wshandler.py
+++ b/src/backend/klangk_backend/wshandler.py
@@ -756,6 +756,176 @@ def _get_shared_terminals(ws_session) -> list[dict]:
     return terminals
 
 
+class SshAgentForwarder:
+    """SSH agent forwarding relay via socat inside the container.
+
+    Owns the socat subprocess, its stdout-relay task, and the socket
+    path.  ``Connection`` delegates the ``ssh_agent_*`` WebSocket
+    commands here, and reads :attr:`socket` (the in-container
+    ``SSH_AUTH_SOCK`` path) when starting terminals/exec sessions.
+
+    Extracted from ``Connection`` (issue #961) so the relay can be
+    unit-tested in isolation without standing up a full connection.
+    """
+
+    def __init__(self, conn: "Connection") -> None:
+        self._conn = conn
+        self.proc: asyncio.subprocess.Process | None = None
+        self.task: asyncio.Task | None = None
+        self.socket: str | None = None
+
+    async def start(self) -> None:
+        """Start SSH agent forwarding via socat inside the container."""
+        _debug_agent = os.environ.get("KLANGKC_DEBUG_SSH_AGENT", "")
+        container_id = self._conn.container_id
+        if not container_id:
+            send_error(
+                self._conn.sock, "No container for SSH agent forwarding"
+            )
+            return
+        # Clean up any existing agent relay.
+        await self.stop()
+        user_id = self._conn.user["id"]
+        sock_path = f"/tmp/klangk-ssh-agent-{user_id}.sock"
+        # Remove stale socket if it exists from a previous session.
+        await podman.exec_container(container_id, ["rm", "-f", sock_path])
+        if _debug_agent:
+            logger.info("[ssh-agent] starting socat at %s", sock_path)
+        # Start socat: listen on the Unix socket, relay to stdin/stdout.
+        proc = await asyncio.create_subprocess_exec(
+            podman.PODMAN_BIN,
+            "exec",
+            "-i",
+            container_id,
+            "socat",
+            f"UNIX-LISTEN:{sock_path},mode=600,unlink-early,fork",
+            "STDIO",
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE
+            if _debug_agent
+            else asyncio.subprocess.DEVNULL,
+        )
+        self.proc = proc
+        self.socket = sock_path
+        self.task = asyncio.create_task(self.forward_output())
+        if _debug_agent and proc.stderr is not None:
+            asyncio.create_task(self.log_stderr())
+        self._conn.sock.send_json(
+            {
+                "type": "ssh_agent_started",
+                "socket": sock_path,
+            }
+        )
+        logger.info(
+            "SSH agent forwarding started for user %s at %s",
+            user_id,
+            sock_path,
+        )
+
+    async def log_stderr(self) -> None:
+        """Log socat stderr when KLANGKC_DEBUG_SSH_AGENT is set."""
+        proc = self.proc
+        if proc is None or proc.stderr is None:
+            return
+        try:
+            while True:
+                line = await proc.stderr.readline()
+                if not line:
+                    break
+                logger.info(
+                    "[ssh-agent] socat stderr: %s", line.decode().rstrip()
+                )
+        except (asyncio.CancelledError, OSError):
+            pass
+
+    async def forward_output(self) -> None:
+        """Read from socat stdout and send to the CLI as ssh_agent_response."""
+        _debug_agent = os.environ.get("KLANGKC_DEBUG_SSH_AGENT", "")
+        proc = self.proc
+        if proc is None or proc.stdout is None:
+            return
+        try:
+            while True:
+                data = await proc.stdout.read(65536)
+                if not data:
+                    if _debug_agent:
+                        logger.info("[ssh-agent] socat stdout EOF")
+                    break
+                if _debug_agent:
+                    logger.info(
+                        "[ssh-agent] socat stdout: %d bytes", len(data)
+                    )
+                self._conn.sock.send_json(
+                    {
+                        "type": "ssh_agent_response",
+                        "data": base64.b64encode(data).decode("ascii"),
+                    }
+                )
+        except asyncio.CancelledError:
+            logger.debug("SSH agent output relay cancelled")
+        except OSError as e:
+            logger.warning("SSH agent output relay error: %s", e)
+
+    async def data(self, msg: dict) -> None:
+        """Write data from the CLI's local agent into socat stdin."""
+        _debug_agent = os.environ.get("KLANGKC_DEBUG_SSH_AGENT", "")
+        proc = self.proc
+        if proc is None or proc.stdin is None:
+            if _debug_agent:
+                logger.info(
+                    "[ssh-agent] data received but no proc (proc=%s)",
+                    proc,
+                )
+            return
+        raw = msg.get("data", "")
+        if raw:
+            decoded = base64.b64decode(raw)
+            if _debug_agent:
+                logger.info(
+                    "[ssh-agent] writing %d bytes to socat stdin",
+                    len(decoded),
+                )
+            proc.stdin.write(decoded)
+            await proc.stdin.drain()
+
+    async def stop_command(self) -> None:
+        """Stop SSH agent forwarding and notify the client."""
+        await self.stop()
+        self._conn.sock.send_json({"type": "ssh_agent_stopped"})
+
+    async def stop(self) -> None:
+        """Clean up the SSH agent relay process."""
+        if self.task is not None:
+            self.task.cancel()
+            try:
+                await self.task
+            except asyncio.CancelledError:
+                pass
+            self.task = None
+        if self.proc is not None:
+            try:
+                self.proc.kill()
+                await self.proc.wait()
+            except ProcessLookupError:
+                logger.debug("SSH agent process already exited")
+            self.proc = None
+        container_id = self._conn.container_id
+        if self.socket and container_id:
+            try:
+                await podman.exec_container(
+                    container_id,
+                    ["rm", "-f", self.socket],
+                )
+            except OSError as e:
+                logger.warning(
+                    "Failed to remove SSH agent socket %s: %s",
+                    self.socket,
+                    e,
+                )
+        self.socket = None
+
+
 class Connection:
     """Per-WebSocket connection state and command handlers."""
 
@@ -779,10 +949,60 @@ class Connection:
         # Tracks which shared terminal this connection is viewing.
         # Set on join_shared_terminal, cleared on stop_terminal/terminal_start.
         self._viewing_shared: dict | None = None  # {user_id, window_id}
-        # SSH agent forwarding state.
-        self._ssh_agent_proc: asyncio.subprocess.Process | None = None
-        self._ssh_agent_task: asyncio.Task | None = None
-        self._ssh_agent_socket: str | None = None
+        # SSH agent forwarding is owned by the SshAgentForwarder
+        # collaborator; Connection delegates the ssh_agent_* commands to
+        # it.  The ``_ssh_agent_*`` properties below proxy to the
+        # forwarder for backwards compatibility with code (and tests)
+        # that read/write those fields directly.
+        self.ssh_agent = SshAgentForwarder(self)
+
+    # --- SSH agent forwarding (delegates to SshAgentForwarder) ---
+
+    # Backwards-compatible proxies for the state formerly held on
+    # Connection itself.  Reads and writes are forwarded to the
+    # collaborator so existing callers (and the terminal/exec code
+    # that consumes ``_ssh_agent_socket``) keep working unchanged.
+    @property
+    def _ssh_agent_proc(self):
+        return self.ssh_agent.proc
+
+    @_ssh_agent_proc.setter
+    def _ssh_agent_proc(self, value):
+        self.ssh_agent.proc = value
+
+    @property
+    def _ssh_agent_task(self):
+        return self.ssh_agent.task
+
+    @_ssh_agent_task.setter
+    def _ssh_agent_task(self, value):
+        self.ssh_agent.task = value
+
+    @property
+    def _ssh_agent_socket(self):
+        return self.ssh_agent.socket
+
+    @_ssh_agent_socket.setter
+    def _ssh_agent_socket(self, value):
+        self.ssh_agent.socket = value
+
+    async def handle_ssh_agent_start(self) -> None:
+        await self.ssh_agent.start()
+
+    async def handle_ssh_agent_data(self, msg: dict) -> None:
+        await self.ssh_agent.data(msg)
+
+    async def handle_ssh_agent_stop(self) -> None:
+        await self.ssh_agent.stop_command()
+
+    async def _stop_ssh_agent(self) -> None:
+        await self.ssh_agent.stop()
+
+    async def _forward_ssh_agent_output(self) -> None:
+        await self.ssh_agent.forward_output()
+
+    async def _log_ssh_agent_stderr(self) -> None:
+        await self.ssh_agent.log_stderr()
 
     async def start_workspace_container(
         self, workspace_id: str, workspace: dict
@@ -1932,155 +2152,6 @@ class Connection:
         await self.stop_exec()
 
     # --- SSH agent forwarding ---
-
-    async def handle_ssh_agent_start(self) -> None:
-        """Start SSH agent forwarding via socat inside the container."""
-        _debug_agent = os.environ.get("KLANGKC_DEBUG_SSH_AGENT", "")
-        if not self.container_id:
-            send_error(self.sock, "No container for SSH agent forwarding")
-            return
-        # Clean up any existing agent relay.
-        await self._stop_ssh_agent()
-        user_id = self.user["id"]
-        sock_path = f"/tmp/klangk-ssh-agent-{user_id}.sock"
-        # Remove stale socket if it exists from a previous session.
-        await podman.exec_container(self.container_id, ["rm", "-f", sock_path])
-        if _debug_agent:  # pragma: no cover
-            logger.info("[ssh-agent] starting socat at %s", sock_path)
-        # Start socat: listen on the Unix socket, relay to stdin/stdout.
-        proc = await asyncio.create_subprocess_exec(
-            podman.PODMAN_BIN,
-            "exec",
-            "-i",
-            self.container_id,
-            "socat",
-            f"UNIX-LISTEN:{sock_path},mode=600,unlink-early,fork",
-            "STDIO",
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE
-            if _debug_agent
-            else asyncio.subprocess.DEVNULL,
-        )
-        self._ssh_agent_proc = proc
-        self._ssh_agent_socket = sock_path
-        self._ssh_agent_task = asyncio.create_task(
-            self._forward_ssh_agent_output()
-        )
-        if _debug_agent and proc.stderr is not None:  # pragma: no cover
-            asyncio.create_task(self._log_ssh_agent_stderr())
-        self.sock.send_json(
-            {
-                "type": "ssh_agent_started",
-                "socket": sock_path,
-            }
-        )
-        logger.info(
-            "SSH agent forwarding started for user %s at %s",
-            user_id,
-            sock_path,
-        )
-
-    async def _log_ssh_agent_stderr(self) -> None:  # pragma: no cover
-        """Log socat stderr when KLANGKC_DEBUG_SSH_AGENT is set."""
-        proc = self._ssh_agent_proc
-        if proc is None or proc.stderr is None:
-            return
-        try:
-            while True:
-                line = await proc.stderr.readline()
-                if not line:
-                    break
-                logger.info(
-                    "[ssh-agent] socat stderr: %s", line.decode().rstrip()
-                )
-        except (asyncio.CancelledError, OSError):
-            pass
-
-    async def _forward_ssh_agent_output(self) -> None:
-        """Read from socat stdout and send to the CLI as ssh_agent_response."""
-        _debug_agent = os.environ.get("KLANGKC_DEBUG_SSH_AGENT", "")
-        proc = self._ssh_agent_proc
-        if proc is None or proc.stdout is None:  # pragma: no cover
-            return
-        try:
-            while True:
-                data = await proc.stdout.read(65536)
-                if not data:
-                    if _debug_agent:  # pragma: no cover
-                        logger.info("[ssh-agent] socat stdout EOF")
-                    break
-                if _debug_agent:  # pragma: no cover
-                    logger.info(
-                        "[ssh-agent] socat stdout: %d bytes", len(data)
-                    )
-                self.sock.send_json(
-                    {
-                        "type": "ssh_agent_response",
-                        "data": base64.b64encode(data).decode("ascii"),
-                    }
-                )
-        except asyncio.CancelledError:  # pragma: no cover
-            logger.debug("SSH agent output relay cancelled")
-        except OSError as e:  # pragma: no cover
-            logger.warning("SSH agent output relay error: %s", e)
-
-    async def handle_ssh_agent_data(self, msg: dict) -> None:
-        """Write data from the CLI's local agent into socat stdin."""
-        _debug_agent = os.environ.get("KLANGKC_DEBUG_SSH_AGENT", "")
-        proc = self._ssh_agent_proc
-        if proc is None or proc.stdin is None:
-            if _debug_agent:  # pragma: no cover
-                logger.info(
-                    "[ssh-agent] data received but no proc (proc=%s)",
-                    proc,
-                )
-            return
-        raw = msg.get("data", "")
-        if raw:
-            decoded = base64.b64decode(raw)
-            if _debug_agent:  # pragma: no cover
-                logger.info(
-                    "[ssh-agent] writing %d bytes to socat stdin",
-                    len(decoded),
-                )
-            proc.stdin.write(decoded)
-            await proc.stdin.drain()
-
-    async def handle_ssh_agent_stop(self) -> None:
-        """Stop SSH agent forwarding."""
-        await self._stop_ssh_agent()
-        self.sock.send_json({"type": "ssh_agent_stopped"})
-
-    async def _stop_ssh_agent(self) -> None:
-        """Clean up the SSH agent relay process."""
-        if self._ssh_agent_task is not None:
-            self._ssh_agent_task.cancel()
-            try:
-                await self._ssh_agent_task
-            except asyncio.CancelledError:
-                pass
-            self._ssh_agent_task = None
-        if self._ssh_agent_proc is not None:
-            try:
-                self._ssh_agent_proc.kill()
-                await self._ssh_agent_proc.wait()
-            except ProcessLookupError:  # pragma: no cover
-                logger.debug("SSH agent process already exited")
-            self._ssh_agent_proc = None
-        if self._ssh_agent_socket and self.container_id:
-            try:
-                await podman.exec_container(
-                    self.container_id,
-                    ["rm", "-f", self._ssh_agent_socket],
-                )
-            except OSError as e:  # pragma: no cover
-                logger.warning(
-                    "Failed to remove SSH agent socket %s: %s",
-                    self._ssh_agent_socket,
-                    e,
-                )
-        self._ssh_agent_socket = None
 
     async def handle_heartbeat(self) -> None:
         if self.container_id is not None:

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -1,10 +1,13 @@
 """Tests for wshandler: WebSocket command dispatch, event forwarding, terminal, cleanup."""
 
 import asyncio
+import base64
 import json
+import os
 import time
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
@@ -25,6 +28,7 @@ from klangk_backend.wshandler import (
     Connection,
     SafeWebSocket,
     SlowClientError,
+    SshAgentForwarder,
     WorkspaceSession,
     state,
     send_error,
@@ -2597,6 +2601,354 @@ class TestSSHAgentHandlers:
             user_handle="testuser",
             ssh_agent_socket="/tmp/klangk-ssh-agent-uid.sock",
         )
+
+
+class TestSshAgentForwarder:
+    """Unit tests for the SshAgentForwarder collaborator in isolation.
+
+    These exercise the forwarder directly against a lightweight fake
+    connection (a SimpleNamespace), proving the collaborator is
+    decoupled from Connection (issue #961) and covering the debug /
+    error branches that were previously excluded with
+    ``# pragma: no cover``.
+    """
+
+    def _forwarder(self, *, container_id="cid", user=None, sock=None):
+        if sock is None:
+            sock = _mock_sock()
+        if user is None:
+            user = {
+                "id": "uid",
+                "email": "testuser@example.com",
+                "handle": "testuser",
+            }
+        conn = SimpleNamespace(sock=sock, user=user, container_id=container_id)
+        return SshAgentForwarder(conn), sock
+
+    @asynccontextmanager
+    async def _track_tasks(self):
+        """Capture asyncio.create_task() calls for cleanup."""
+        created = []
+        orig = asyncio.create_task
+
+        def _wrap(coro, **kw):
+            t = orig(coro, **kw)
+            created.append(t)
+            return t
+
+        with patch("klangk_backend.wshandler.asyncio.create_task", _wrap):
+            yield created
+        for t in created:
+            if not t.done():
+                t.cancel()
+                try:
+                    await t
+                except (asyncio.CancelledError, Exception):
+                    pass
+
+    async def test_start_logs_and_spawns_stderr_relay_when_debug(self):
+        """KLANGKC_DEBUG_SSH_AGENT logs start + spawns the stderr relay."""
+        fwd, sock = self._forwarder()
+        mock_proc = AsyncMock()
+        mock_proc.stdout = AsyncMock()
+        mock_proc.stdout.read = AsyncMock(return_value=b"")
+        # stderr.readline returns EOF immediately so the relay exits.
+        mock_proc.stderr = AsyncMock()
+        mock_proc.stderr.readline = AsyncMock(return_value=b"")
+        mock_proc.stdin = AsyncMock()
+        with (
+            patch.dict(os.environ, {"KLANGKC_DEBUG_SSH_AGENT": "1"}),
+            patch(
+                "klangk_backend.wshandler.podman.exec_container",
+                new=AsyncMock(),
+            ),
+            patch(
+                "asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=mock_proc),
+            ),
+        ):
+            async with self._track_tasks() as tasks:
+                await fwd.start()
+                # Let the relay tasks run to completion.
+                for _ in range(5):
+                    await asyncio.sleep(0)
+        assert fwd.proc is mock_proc
+        assert fwd.socket == "/tmp/klangk-ssh-agent-uid.sock"
+        # stderr relay task was created (debug + proc.stderr is not None).
+        assert any(
+            t.get_coro().__qualname__.startswith(
+                "SshAgentForwarder.log_stderr"
+            )
+            for t in tasks
+        )
+        msg = sock.send_json.call_args[0][0]
+        assert msg["type"] == "ssh_agent_started"
+        assert msg["socket"] == "/tmp/klangk-ssh-agent-uid.sock"
+
+    async def test_start_skips_stderr_relay_when_proc_has_no_stderr(self):
+        """Debug set but proc.stderr is None -> no stderr relay task."""
+        fwd, sock = self._forwarder()
+        mock_proc = AsyncMock()
+        mock_proc.stdout = AsyncMock()
+        mock_proc.stdout.read = AsyncMock(return_value=b"")
+        mock_proc.stderr = None
+        mock_proc.stdin = AsyncMock()
+        with (
+            patch.dict(os.environ, {"KLANGKC_DEBUG_SSH_AGENT": "1"}),
+            patch(
+                "klangk_backend.wshandler.podman.exec_container",
+                new=AsyncMock(),
+            ),
+            patch(
+                "asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=mock_proc),
+            ),
+        ):
+            async with self._track_tasks() as tasks:
+                await fwd.start()
+                for _ in range(3):
+                    await asyncio.sleep(0)
+        assert not any(
+            t.get_coro().__qualname__.startswith(
+                "SshAgentForwarder.log_stderr"
+            )
+            for t in tasks
+        )
+
+    async def test_start_no_container_sends_error(self):
+        fwd, sock = self._forwarder(container_id=None)
+        await fwd.start()
+        msg = sock.send_json.call_args[0][0]
+        assert msg.get("type") == "error"
+        assert fwd.proc is None
+
+    async def test_log_stderr_no_proc(self):
+        fwd, _ = self._forwarder()
+        fwd.proc = None
+        # No-op, must not raise.
+        await fwd.log_stderr()
+
+    async def test_log_stderr_no_stderr_stream(self):
+        fwd, _ = self._forwarder()
+        fwd.proc = MagicMock(stderr=None)
+        await fwd.log_stderr()
+
+    async def test_log_stderr_reads_lines_until_eof(self):
+        fwd, _ = self._forwarder()
+        mock_proc = MagicMock()
+        mock_proc.stderr = AsyncMock()
+        mock_proc.stderr.readline = AsyncMock(
+            side_effect=[b"line one\n", b"line two\n", b""]
+        )
+        fwd.proc = mock_proc
+        with patch("klangk_backend.wshandler.logger") as lg:
+            await fwd.log_stderr()
+        info_msgs = [c.args for c in lg.info.call_args_list]
+        assert (
+            any(
+                "line one" in a[0] % () if False else "line one" in str(a)
+                for a in info_msgs
+            )
+            or info_msgs
+        )
+        # Decoded lines were logged.
+        assert any("line one" in str(a) for a in info_msgs)
+        assert any("line two" in str(a) for a in info_msgs)
+
+    async def test_log_stderr_swallows_oserror(self):
+        fwd, _ = self._forwarder()
+        mock_proc = MagicMock()
+        mock_proc.stderr = AsyncMock()
+        mock_proc.stderr.readline = AsyncMock(side_effect=OSError("boom"))
+        fwd.proc = mock_proc
+        # Must not raise.
+        await fwd.log_stderr()
+
+    async def test_log_stderr_swallows_cancelled(self):
+        fwd, _ = self._forwarder()
+        mock_proc = MagicMock()
+        mock_proc.stderr = AsyncMock()
+        # Block on readline so we can cancel the running task.
+        never = asyncio.Event()
+
+        async def _block(*a, **k):
+            await never.wait()
+
+        mock_proc.stderr.readline = _block
+        fwd.proc = mock_proc
+        task = asyncio.create_task(fwd.log_stderr())
+        for _ in range(3):
+            await asyncio.sleep(0)
+        task.cancel()
+        # Should suppress the CancelledError and complete normally.
+        await task
+
+    async def test_forward_output_no_proc(self):
+        fwd, _ = self._forwarder()
+        fwd.proc = None
+        await fwd.forward_output()
+
+    async def test_forward_output_no_stdout(self):
+        fwd, _ = self._forwarder()
+        fwd.proc = MagicMock(stdout=None)
+        await fwd.forward_output()
+
+    async def test_forward_output_relays_data(self):
+        import base64
+
+        fwd, sock = self._forwarder()
+        mock_proc = AsyncMock()
+        mock_proc.stdout = AsyncMock()
+        mock_proc.stdout.read = AsyncMock(side_effect=[b"resp", b""])
+        fwd.proc = mock_proc
+        await fwd.forward_output()
+        calls = [
+            c[0][0]
+            for c in sock.send_json.call_args_list
+            if c[0][0].get("type") == "ssh_agent_response"
+        ]
+        assert len(calls) == 1
+        assert base64.b64decode(calls[0]["data"]) == b"resp"
+
+    async def test_forward_output_debug_logs_eof_and_data(self):
+        fwd, _ = self._forwarder()
+        mock_proc = AsyncMock()
+        mock_proc.stdout = AsyncMock()
+        mock_proc.stdout.read = AsyncMock(side_effect=[b"x", b""])
+        fwd.proc = mock_proc
+        with (
+            patch.dict(os.environ, {"KLANGKC_DEBUG_SSH_AGENT": "1"}),
+            patch("klangk_backend.wshandler.logger") as lg,
+        ):
+            await fwd.forward_output()
+        info_args = [str(c) for c in lg.info.call_args_list]
+        assert any("socat stdout" in a and "bytes" in a for a in info_args)
+        assert any("socat stdout EOF" in a for a in info_args)
+
+    async def test_forward_output_swallows_oserror(self):
+        fwd, _ = self._forwarder()
+        mock_proc = AsyncMock()
+        mock_proc.stdout = AsyncMock()
+        mock_proc.stdout.read = AsyncMock(side_effect=OSError("boom"))
+        fwd.proc = mock_proc
+        with patch("klangk_backend.wshandler.logger") as lg:
+            await fwd.forward_output()
+        lg.warning.assert_called_once()
+        assert "SSH agent output relay error" in str(lg.warning.call_args)
+
+    async def test_forward_output_swallows_cancelled(self):
+        fwd, _ = self._forwarder()
+        mock_proc = AsyncMock()
+        mock_proc.stdout = AsyncMock()
+        never = asyncio.Event()
+
+        async def _block(*a, **k):
+            await never.wait()
+
+        mock_proc.stdout.read = _block
+        fwd.proc = mock_proc
+        task = asyncio.create_task(fwd.forward_output())
+        for _ in range(3):
+            await asyncio.sleep(0)
+        task.cancel()
+        # Suppresses CancelledError and completes normally.
+        await task
+
+    async def test_data_no_proc_debug_logs(self):
+        fwd, _ = self._forwarder()
+        fwd.proc = None
+        with (
+            patch.dict(os.environ, {"KLANGKC_DEBUG_SSH_AGENT": "1"}),
+            patch("klangk_backend.wshandler.logger") as lg,
+        ):
+            await fwd.data({"data": base64.b64encode(b"x").decode()})
+        assert any(
+            "data received but no proc" in str(c)
+            for c in lg.info.call_args_list
+        )
+
+    async def test_data_debug_logs_write(self):
+        data = base64.b64encode(b"agent-request").decode()
+        fwd, _ = self._forwarder()
+        mock_proc = AsyncMock()
+        mock_proc.stdin = AsyncMock()
+        mock_proc.stdin.write = MagicMock()
+        mock_proc.stdin.drain = AsyncMock()
+        fwd.proc = mock_proc
+        with (
+            patch.dict(os.environ, {"KLANGKC_DEBUG_SSH_AGENT": "1"}),
+            patch("klangk_backend.wshandler.logger") as lg,
+        ):
+            await fwd.data({"data": data})
+        mock_proc.stdin.write.assert_called_once_with(b"agent-request")
+        assert any(
+            "writing" in str(c) and "bytes" in str(c)
+            for c in lg.info.call_args_list
+        )
+
+    async def test_data_empty_payload_noop(self):
+        fwd, _ = self._forwarder()
+        mock_proc = AsyncMock()
+        mock_proc.stdin = AsyncMock()
+        mock_proc.stdin.write = MagicMock()
+        fwd.proc = mock_proc
+        await fwd.data({"data": ""})
+        mock_proc.stdin.write.assert_not_called()
+
+    async def test_stop_command_notifies_client(self):
+        fwd, sock = self._forwarder()
+        with patch.object(fwd, "stop", new=AsyncMock()) as stop:
+            await fwd.stop_command()
+        stop.assert_awaited_once()
+        msg = sock.send_json.call_args[0][0]
+        assert msg["type"] == "ssh_agent_stopped"
+
+    async def test_stop_handles_process_lookup_error(self):
+        fwd, _ = self._forwarder()
+        mock_proc = MagicMock()
+        mock_proc.kill = MagicMock(side_effect=ProcessLookupError())
+        mock_proc.wait = AsyncMock()
+        fwd.proc = mock_proc
+        # No task, no socket: only the proc branch runs.
+        await fwd.stop()
+        assert fwd.proc is None
+
+    async def test_stop_handles_socket_remove_oserror(self):
+        fwd, _ = self._forwarder()
+        fwd.socket = "/tmp/agent.sock"
+        with patch(
+            "klangk_backend.wshandler.podman.exec_container",
+            new=AsyncMock(side_effect=OSError("boom")),
+        ) as exec_mock:
+            with patch("klangk_backend.wshandler.logger") as lg:
+                await fwd.stop()
+        exec_mock.assert_awaited_once()
+        lg.warning.assert_called_once()
+        assert "Failed to remove SSH agent socket" in str(lg.warning.call_args)
+        assert fwd.socket is None
+
+    async def test_stop_cancels_task_and_kills_proc(self):
+        fwd, _ = self._forwarder()
+        mock_proc = MagicMock()
+        mock_proc.kill = MagicMock()
+        mock_proc.wait = AsyncMock()
+        fwd.proc = mock_proc
+        fwd.socket = None  # skip socket-removal branch
+        fwd.task = asyncio.create_task(asyncio.sleep(999))
+        with patch(
+            "klangk_backend.wshandler.podman.exec_container", new=AsyncMock()
+        ):
+            await fwd.stop()
+        assert fwd.task is None
+        assert fwd.proc is None
+        mock_proc.kill.assert_called_once()
+
+    async def test_connection_log_stderr_delegate(self):
+        """Connection._log_ssh_agent_stderr forwards to the collaborator."""
+        conn = _base_conn()
+        with patch.object(conn.ssh_agent, "log_stderr", new=AsyncMock()) as m:
+            await conn._log_ssh_agent_stderr()
+        m.assert_awaited_once()
 
 
 class TestExecDispatch:


### PR DESCRIPTION
Stage 1 of the Connection god-class split proposed in #961: extract the SSH-agent forwarding concern into a dedicated `SshAgentForwarder` collaborator.

## What changed

`src/backend/klangk_backend/wshandler.py`

- New `SshAgentForwarder` class owns the socat subprocess, its stdout-relay task, and the in-container socket path (`proc`, `task`, `socket`).
- `Connection` now owns `self.ssh_agent = SshAgentForwarder(self)` and delegates `handle_ssh_agent_start/data/stop`, `_stop_ssh_agent`, `_forward_ssh_agent_output`, and `_log_ssh_agent_stderr` to it.
- Backwards-compatible `_ssh_agent_proc` / `_ssh_agent_task` / `_ssh_agent_socket` property shims on `Connection` proxy reads and writes to the forwarder, so existing callers (`handle_terminal_start`, `handle_exec_start`) and the existing tests that set those fields directly keep working unchanged. `cleanup` still calls `self._stop_ssh_agent()`.
- Removed every `# pragma: no cover` from the ssh-agent debug/error branches now that they are directly unit-testable.

`src/backend/tests/test_wshandler.py`

- New `TestSshAgentForwarder` exercises the collaborator **in isolation** against a lightweight fake connection (`types.SimpleNamespace`), proving the collaborator is decoupled from `Connection` — the core benefit called out in the issue ("Unblocks unit testing of each subsystem in isolation"). Covers the previously-excluded branches:
  - `start`: debug logging + stderr-relay spawn; debug set but `proc.stderr is None`; no-container error.
  - `log_stderr`: no proc / no stderr / read-until-EOF / swallowed `OSError` / swallowed `CancelledError`.
  - `forward_output`: no proc / no stdout / data relay / debug EOF + data logging / swallowed `OSError` / swallowed `CancelledError`.
  - `data`: debug no-proc log / debug write log / empty-payload no-op.
  - `stop_command`: notifies client.
  - `stop`: `ProcessLookupError` handling / socket-remove `OSError` / task cancel + proc kill.
  - `Connection._log_ssh_agent_stderr` delegate.

## Why this scope

The issue recommends doing the split "in stages (one collaborator at a time) behind the existing tests." SSH-agent forwarding is the most self-contained of the four proposed collaborators (its only cross-dependencies are `container_id`, `user["id"]`, `sock`, and the `socket` value consumed by terminal/exec start), making it the lowest-risk first extraction and establishing the collaborator pattern the remaining three (TerminalController, ExecController, SharedTerminalController) can follow.

## Verification

- No behavior change: pure move + delegation.
- `pytest src/backend/tests` (full backend suite with the project's `--cov-fail-under=100` gate): **1669 passed, 100.00% coverage**.
- `wshandler.py` remains at 100% coverage with the `pragma: no cover` exclusions removed and those lines now genuinely covered by direct unit tests.
- `ruff check` + `ruff format` clean; pre-commit hooks pass.

Closes #961 (stage 1). The remaining collaborators are left for follow-up PRs to keep each stage reviewable.