### PR TITLE
Refactor: extract ExecController collaborator from Connection (#961)

### DIFF
--- a/src/backend/klangk_backend/wshandler.py
+++ b/src/backend/klangk_backend/wshandler.py
@@ -926,6 +926,124 @@ class SshAgentForwarder:
         self.socket = None
 
 
+class ExecController:
+    """Exec session lifecycle: start, input, output forwarding, stop.
+
+    Owns the current ``ExecSession`` and its output-forwarding task.
+    ``Connection`` delegates the ``exec_*`` WebSocket commands here,
+    and reads :attr:`session` when wiring up new exec runs.
+
+    Extracted from ``Connection`` (issue #961) so the exec subsystem
+    can be unit-tested in isolation without standing up a full
+    connection.  Follows the same collaborator pattern as
+    :class:`SshAgentForwarder`.
+    """
+
+    def __init__(self, conn: "Connection") -> None:
+        self._conn = conn
+        self.session: ExecSession | None = None
+        self.task: asyncio.Task | None = None
+
+    async def start(self, msg: dict) -> None:
+        container_id = self._conn.container_id
+        if not container_id:
+            return
+        if not await self._conn._has_perm("code-in-isolation"):
+            send_error(
+                self._conn.sock,
+                "exec requires code-in-isolation permission",
+            )
+            return
+        await self.stop()
+        command = msg.get("command", [])
+        if not command:
+            send_error(self._conn.sock, "exec_start requires a command list")
+            return
+        env: list[str] = []
+        work_dir = "/home/work"
+        user_home = self._conn._user_home
+        if user_home is not None:
+            env.append(f"HOME={user_home}")
+            work_dir = user_home
+        ssh_agent_socket = self._conn._ssh_agent_socket
+        if ssh_agent_socket is not None:
+            env.append(f"SSH_AUTH_SOCK={ssh_agent_socket}")
+        session = ExecSession(container_id, env=env, work_dir=work_dir)
+        await session.start(command)
+        self.session = session
+        self.task = asyncio.create_task(self.forward_output(session))
+        container.registry.record_activity(container_id)
+
+    async def input(self, msg: dict) -> None:
+        session = self.session
+        if session is None or not session.is_alive:
+            return
+        raw = base64.b64decode(msg.get("data", ""))
+        if len(raw) > _MAX_INPUT_SIZE:
+            logger.warning(
+                "exec_input too large (%d bytes), dropping", len(raw)
+            )
+            return
+        container.registry.record_activity(self._conn.container_id)
+        await session.write(raw)
+
+    async def close_stdin(self) -> None:
+        session = self.session
+        if session is None:
+            return
+        await session.close_stdin()
+
+    async def stop_command(self) -> None:
+        await self.stop()
+
+    async def claim_and_stop(self) -> None:
+        """Drop and stop the current session (idempotent)."""
+        session = self.session
+        self.session = None
+        if session is not None:
+            await session.stop()
+
+    async def stop(self) -> None:
+        """Cancel the output-forwarding task and stop the session."""
+        task = self.task
+        if task:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            self.task = None
+        await self.claim_and_stop()
+
+    async def forward_output(self, session: ExecSession) -> None:
+        """Forward exec stdout to the client via WebSocket as base64."""
+        try:
+            async for data in session.output():
+                self._conn.sock.send_json(
+                    {
+                        "type": "exec_output",
+                        "data": base64.b64encode(data).decode("ascii"),
+                    }
+                )
+                if self._conn.container_id:
+                    container.registry.record_activity(self._conn.container_id)
+            # Process exited — send exit code
+            self._conn.sock.send_json(
+                {
+                    "type": "exec_exit",
+                    "code": session.returncode
+                    if session.returncode is not None
+                    else 1,
+                }
+            )
+        except asyncio.CancelledError:
+            raise
+        except _WS_ERRORS as e:
+            logger.error("Exec output forwarding error: %s", e)
+        finally:
+            await self.claim_and_stop()
+
+
 class Connection:
     """Per-WebSocket connection state and command handlers."""
 
@@ -936,8 +1054,12 @@ class Connection:
         self.container_id: str | None = None
         self.terminal_session: TerminalSession | None = None
         self.terminal_task: asyncio.Task | None = None
-        self.exec_session: ExecSession | None = None
-        self.exec_task: asyncio.Task | None = None
+        # Exec sessions are owned by the ExecController collaborator;
+        # Connection delegates the exec_* commands to it.  The
+        # ``exec_session``/``exec_task`` properties below proxy to the
+        # controller for backwards compatibility with code (and tests)
+        # that read/write those fields directly.
+        self.exec = ExecController(self)
         self.workspace: dict | None = None
         self._idle_cb = None
         self.pending_status_msg: str | None = None
@@ -1003,6 +1125,49 @@ class Connection:
 
     async def _log_ssh_agent_stderr(self) -> None:
         await self.ssh_agent.log_stderr()
+
+    # --- Exec sessions (delegates to ExecController) ---
+
+    # Backwards-compatible proxies for the state formerly held on
+    # Connection itself.  Reads and writes are forwarded to the
+    # controller so existing callers (and tests) that read/write
+    # ``exec_session``/``exec_task`` directly keep working unchanged.
+    @property
+    def exec_session(self):
+        return self.exec.session
+
+    @exec_session.setter
+    def exec_session(self, value):
+        self.exec.session = value
+
+    @property
+    def exec_task(self):
+        return self.exec.task
+
+    @exec_task.setter
+    def exec_task(self, value):
+        self.exec.task = value
+
+    async def handle_exec_start(self, msg: dict) -> None:
+        await self.exec.start(msg)
+
+    async def handle_exec_input(self, msg: dict) -> None:
+        await self.exec.input(msg)
+
+    async def handle_exec_close_stdin(self) -> None:
+        await self.exec.close_stdin()
+
+    async def handle_exec_stop(self) -> None:
+        await self.exec.stop_command()
+
+    async def stop_exec(self) -> None:
+        await self.exec.stop()
+
+    async def forward_exec_output(self, session: ExecSession) -> None:
+        await self.exec.forward_output(session)
+
+    async def _claim_and_stop_exec(self) -> None:
+        await self.exec.claim_and_stop()
 
     async def start_workspace_container(
         self, workspace_id: str, workspace: dict
@@ -2105,52 +2270,6 @@ class Connection:
     ) -> None:  # pragma: no cover
         send_error(self.sock, f"Failed to list shared terminals: {e}")
 
-    async def handle_exec_start(self, msg: dict) -> None:
-        if not self.container_id:
-            return
-        if not await self._has_perm("code-in-isolation"):
-            send_error(self.sock, "exec requires code-in-isolation permission")
-            return
-        await self.stop_exec()
-        command = msg.get("command", [])
-        if not command:
-            send_error(self.sock, "exec_start requires a command list")
-            return
-        env: list[str] = []
-        work_dir = "/home/work"
-        if self._user_home is not None:
-            env.append(f"HOME={self._user_home}")
-            work_dir = self._user_home
-        if self._ssh_agent_socket is not None:
-            env.append(f"SSH_AUTH_SOCK={self._ssh_agent_socket}")
-        session = ExecSession(self.container_id, env=env, work_dir=work_dir)
-        await session.start(command)
-        self.exec_session = session
-        self.exec_task = asyncio.create_task(self.forward_exec_output(session))
-        container.registry.record_activity(self.container_id)
-
-    async def handle_exec_input(self, msg: dict) -> None:
-        session = self.exec_session
-        if session is None or not session.is_alive:
-            return
-        raw = base64.b64decode(msg.get("data", ""))
-        if len(raw) > _MAX_INPUT_SIZE:
-            logger.warning(
-                "exec_input too large (%d bytes), dropping", len(raw)
-            )
-            return
-        container.registry.record_activity(self.container_id)
-        await session.write(raw)
-
-    async def handle_exec_close_stdin(self) -> None:
-        session = self.exec_session
-        if session is None:
-            return
-        await session.close_stdin()
-
-    async def handle_exec_stop(self) -> None:
-        await self.stop_exec()
-
     # --- SSH agent forwarding ---
 
     async def handle_heartbeat(self) -> None:
@@ -2337,51 +2456,6 @@ class Connection:
         self.terminal_session = None
         if session is not None:
             await session.stop()
-
-    async def _claim_and_stop_exec(self) -> None:
-        session = self.exec_session
-        self.exec_session = None
-        if session is not None:
-            await session.stop()
-
-    async def stop_exec(self) -> None:
-        task = self.exec_task
-        if task:
-            task.cancel()
-            try:
-                await task
-            except asyncio.CancelledError:
-                pass
-            self.exec_task = None
-        await self._claim_and_stop_exec()
-
-    async def forward_exec_output(self, session: ExecSession) -> None:
-        """Forward exec stdout to the client via WebSocket as base64."""
-        try:
-            async for data in session.output():
-                self.sock.send_json(
-                    {
-                        "type": "exec_output",
-                        "data": base64.b64encode(data).decode("ascii"),
-                    }
-                )
-                if self.container_id:
-                    container.registry.record_activity(self.container_id)
-            # Process exited — send exit code
-            self.sock.send_json(
-                {
-                    "type": "exec_exit",
-                    "code": session.returncode
-                    if session.returncode is not None
-                    else 1,
-                }
-            )
-        except asyncio.CancelledError:  # pragma: no cover
-            raise
-        except _WS_ERRORS as e:
-            logger.error("Exec output forwarding error: %s", e)
-        finally:
-            await self._claim_and_stop_exec()
 
     async def _activate_session(
         self, session: TerminalSession, cols: int, rows: int

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -26,6 +26,7 @@ from klangk_backend.util import (
 )
 from klangk_backend.wshandler import (
     Connection,
+    ExecController,
     SafeWebSocket,
     SlowClientError,
     SshAgentForwarder,
@@ -2425,6 +2426,339 @@ class TestExecHandlers:
         await conn.cleanup()
         session.stop.assert_awaited_once()
         assert conn.exec_session is None
+
+
+class TestExecController:
+    """Unit tests for the ExecController collaborator in isolation.
+
+    These exercise the controller directly against a lightweight fake
+    connection (a SimpleNamespace), proving it is decoupled from
+    Connection (issue #961) and covering the branches that the
+    existing Connection-level tests don't reach directly — notably the
+    ``asyncio.CancelledError`` re-raise in ``forward_output`` and the
+    ``Connection._claim_and_stop_exec`` backward-compat delegate.
+    """
+
+    def _controller(
+        self,
+        *,
+        container_id="cid",
+        user_home=None,
+        ssh_agent_socket=None,
+        sock=None,
+        has_perm=True,
+    ):
+        if sock is None:
+            sock = _mock_sock()
+        conn = SimpleNamespace(
+            sock=sock,
+            container_id=container_id,
+            _user_home=user_home,
+            _ssh_agent_socket=ssh_agent_socket,
+            _has_perm=AsyncMock(return_value=has_perm),
+        )
+        return ExecController(conn), sock, conn
+
+    async def test_start_no_container_noop(self):
+        ctrl, sock, _ = self._controller(container_id=None)
+        await ctrl.start({"command": ["ls"]})
+        assert ctrl.session is None
+        assert ctrl.task is None
+        sock.send_json.assert_not_called()
+
+    async def test_start_no_perm_sends_error(self):
+        ctrl, sock, _ = self._controller(has_perm=False)
+        await ctrl.start({"command": ["ls"]})
+        msg = sock.send_json.call_args[0][0]
+        assert msg["type"] == "error"
+        assert "code-in-isolation" in msg["message"]
+        assert ctrl.session is None
+
+    async def test_start_no_command_sends_error(self):
+        ctrl, sock, _ = self._controller()
+        await ctrl.start({"command": []})
+        msg = sock.send_json.call_args[0][0]
+        assert "command" in msg["message"]
+        assert ctrl.session is None
+
+    async def test_start_stops_existing_session_first(self):
+        """start() tears down any in-flight exec before starting a new one."""
+        ctrl, _, _ = self._controller()
+        old = AsyncMock()
+        ctrl.session = old
+        with (
+            patch("klangk_backend.wshandler.ExecSession") as MockExec,
+            patch.object(container.registry, "record_activity"),
+        ):
+            mock_session = MockExec.return_value
+            mock_session.start = AsyncMock()
+            await ctrl.start({"command": ["ls"]})
+            # Drain the spawned output-forwarding task.
+            assert ctrl.task is not None
+            ctrl.task.cancel()
+            try:
+                await ctrl.task
+            except asyncio.CancelledError:
+                pass
+        old.stop.assert_awaited_once()
+        assert ctrl.session is mock_session
+
+    async def test_start_passes_user_home_and_ssh_agent_socket(self):
+        ctrl, _, _ = self._controller(
+            user_home="/home/admin",
+            ssh_agent_socket="/tmp/agent.sock",
+        )
+        with (
+            patch("klangk_backend.wshandler.ExecSession") as MockExec,
+            patch.object(container.registry, "record_activity"),
+        ):
+            mock_session = MockExec.return_value
+            mock_session.start = AsyncMock()
+            await ctrl.start({"command": ["ls"]})
+            ctrl.task.cancel()
+            try:
+                await ctrl.task
+            except asyncio.CancelledError:
+                pass
+        kwargs = MockExec.call_args.kwargs
+        assert "HOME=/home/admin" in kwargs["env"]
+        assert "SSH_AUTH_SOCK=/tmp/agent.sock" in kwargs["env"]
+        assert kwargs["work_dir"] == "/home/admin"
+
+    async def test_start_defaults_work_dir_when_no_user_home(self):
+        ctrl, _, _ = self._controller(user_home=None)
+        with (
+            patch("klangk_backend.wshandler.ExecSession") as MockExec,
+            patch.object(container.registry, "record_activity"),
+        ):
+            mock_session = MockExec.return_value
+            mock_session.start = AsyncMock()
+            await ctrl.start({"command": ["ls"]})
+            ctrl.task.cancel()
+            try:
+                await ctrl.task
+            except asyncio.CancelledError:
+                pass
+        kwargs = MockExec.call_args.kwargs
+        assert kwargs["env"] == []
+        assert kwargs["work_dir"] == "/home/work"
+
+    async def test_input_no_session(self):
+        ctrl, _, _ = self._controller()
+        await ctrl.input({"data": base64.b64encode(b"x").decode()})
+
+    async def test_input_dead_session_dropped(self):
+        ctrl, _, _ = self._controller()
+        session = AsyncMock()
+        session.is_alive = False
+        ctrl.session = session
+        await ctrl.input({"data": base64.b64encode(b"x").decode()})
+        session.write.assert_not_awaited()
+
+    async def test_input_oversized_dropped(self):
+        ctrl, _, _ = self._controller()
+        session = AsyncMock()
+        session.is_alive = True
+        ctrl.session = session
+        big = base64.b64encode(b"x" * 70000).decode()
+        with patch.object(container.registry, "record_activity"):
+            await ctrl.input({"data": big})
+        session.write.assert_not_awaited()
+
+    async def test_input_writes_and_records_activity(self):
+        ctrl, _, _ = self._controller()
+        session = AsyncMock()
+        session.is_alive = True
+        ctrl.session = session
+        data = base64.b64encode(b"hello").decode()
+        with patch.object(container.registry, "record_activity") as rec:
+            await ctrl.input({"data": data})
+        session.write.assert_awaited_once_with(b"hello")
+        rec.assert_called_once_with("cid")
+
+    async def test_close_stdin_no_session(self):
+        ctrl, _, _ = self._controller()
+        await ctrl.close_stdin()
+
+    async def test_close_stdin_delegates(self):
+        ctrl, _, _ = self._controller()
+        session = AsyncMock()
+        ctrl.session = session
+        await ctrl.close_stdin()
+        session.close_stdin.assert_awaited_once()
+
+    async def test_stop_command_calls_stop(self):
+        ctrl, _, _ = self._controller()
+        with patch.object(ctrl, "stop", new=AsyncMock()) as stop:
+            await ctrl.stop_command()
+        stop.assert_awaited_once()
+
+    async def test_stop_no_session(self):
+        ctrl, _, _ = self._controller()
+        await ctrl.stop()
+        assert ctrl.session is None
+        assert ctrl.task is None
+
+    async def test_stop_cancels_task_and_stops_session(self):
+        ctrl, _, _ = self._controller()
+        session = AsyncMock()
+        ctrl.session = session
+        ctrl.task = asyncio.create_task(asyncio.sleep(999))
+        await ctrl.stop()
+        assert ctrl.task is None
+        assert ctrl.session is None
+        session.stop.assert_awaited_once()
+
+    async def test_claim_and_stop_no_session(self):
+        ctrl, _, _ = self._controller()
+        await ctrl.claim_and_stop()
+        assert ctrl.session is None
+
+    async def test_claim_and_stop_drops_and_stops(self):
+        ctrl, _, _ = self._controller()
+        session = AsyncMock()
+        ctrl.session = session
+        await ctrl.claim_and_stop()
+        assert ctrl.session is None
+        session.stop.assert_awaited_once()
+
+    async def test_forward_output_relays_chunks_and_exit_code(self):
+        ctrl, sock, _ = self._controller()
+        session = AsyncMock()
+        session.returncode = 7
+        ctrl.session = session
+
+        async def fake_output():
+            yield b"chunk1"
+            yield b"chunk2"
+
+        session.output = fake_output
+        with patch.object(container.registry, "record_activity"):
+            await ctrl.forward_output(session)
+        calls = [c[0][0] for c in sock.send_json.call_args_list]
+        outputs = [c for c in calls if c["type"] == "exec_output"]
+        exits = [c for c in calls if c["type"] == "exec_exit"]
+        assert len(outputs) == 2
+        assert base64.b64decode(outputs[0]["data"]) == b"chunk1"
+        assert base64.b64decode(outputs[1]["data"]) == b"chunk2"
+        assert exits[0]["code"] == 7
+        # Session claimed and stopped by the finally block.
+        session.stop.assert_awaited_once()
+
+    async def test_forward_output_exit_code_defaults_to_1(self):
+        ctrl, sock, _ = self._controller()
+        session = AsyncMock()
+        session.returncode = None
+        ctrl.session = session
+
+        async def fake_output():
+            return
+            yield  # pragma: no cover
+
+        session.output = fake_output
+        with patch.object(container.registry, "record_activity"):
+            await ctrl.forward_output(session)
+        exits = [
+            c[0][0]
+            for c in sock.send_json.call_args_list
+            if c[0][0]["type"] == "exec_exit"
+        ]
+        assert exits[0]["code"] == 1
+
+    async def test_forward_output_records_activity_when_container_set(self):
+        ctrl, _, _ = self._controller(container_id="cid")
+        session = AsyncMock()
+        session.returncode = 0
+        ctrl.session = session
+
+        async def fake_output():
+            yield b"data"
+
+        session.output = fake_output
+        with patch.object(container.registry, "record_activity") as rec:
+            await ctrl.forward_output(session)
+        rec.assert_called_once_with("cid")
+
+    async def test_forward_output_swallows_ws_error(self):
+        ctrl, sock, _ = self._controller()
+        session = AsyncMock()
+        ctrl.session = session
+
+        async def fake_output():
+            yield b"data"
+
+        session.output = fake_output
+        sock.send_json = MagicMock(side_effect=RuntimeError("ws dead"))
+        with patch.object(container.registry, "record_activity"):
+            # Must not raise; error is logged.
+            await ctrl.forward_output(session)
+        session.stop.assert_awaited_once()
+
+    async def test_forward_output_reraises_cancelled(self):
+        """Cancellation mid-stream re-raises and still cleans up the session."""
+        ctrl, _, _ = self._controller()
+        session = AsyncMock()
+        session.returncode = 0
+        ctrl.session = session
+        never = asyncio.Event()
+
+        async def blocking_output():
+            yield b"first"
+            await never.wait()  # blocks until cancelled
+
+        session.output = blocking_output
+        task = asyncio.create_task(ctrl.forward_output(session))
+        for _ in range(3):
+            await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        # finally block ran claim_and_stop -> session stopped.
+        session.stop.assert_awaited_once()
+        assert ctrl.session is None
+
+    async def test_connection_claim_and_stop_exec_delegate(self):
+        """Connection._claim_and_stop_exec forwards to the controller."""
+        conn = _base_conn()
+        with patch.object(conn.exec, "claim_and_stop", new=AsyncMock()) as m:
+            await conn._claim_and_stop_exec()
+        m.assert_awaited_once()
+
+    async def test_connection_forward_exec_output_delegate(self):
+        """Connection.forward_exec_output forwards to the controller."""
+        conn = _base_conn()
+        session = AsyncMock()
+        with patch.object(conn.exec, "forward_output", new=AsyncMock()) as m:
+            await conn.forward_exec_output(session)
+        m.assert_awaited_once_with(session)
+
+    async def test_connection_stop_exec_delegate(self):
+        """Connection.stop_exec forwards to the controller."""
+        conn = _base_conn()
+        with patch.object(conn.exec, "stop", new=AsyncMock()) as m:
+            await conn.stop_exec()
+        m.assert_awaited_once()
+
+    async def test_exec_session_property_round_trips_to_controller(self):
+        conn = _base_conn()
+        sentinel = object()
+        conn.exec_session = sentinel
+        assert conn.exec_session is sentinel
+        assert conn.exec.session is sentinel
+
+    async def test_exec_task_property_round_trips_to_controller(self):
+        conn = _base_conn()
+        task = asyncio.create_task(asyncio.sleep(999))
+        try:
+            conn.exec_task = task
+            assert conn.exec_task is task
+            assert conn.exec.task is task
+        finally:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
 
 
 class TestSSHAgentHandlers:


### PR DESCRIPTION
Stage 2 of the Connection god-class split proposed in #961: extract the exec-session concern into a dedicated `ExecController` collaborator.

## What changed

`src/backend/klangk_backend/wshandler.py`

- New `ExecController` class owns the current `ExecSession` (`session`) and its output-forwarding task (`task`), and implements `start`, `input`, `close_stdin`, `stop_command`, `stop`, `claim_and_stop`, and `forward_output` — moved verbatim from `Connection`.
- `Connection` now owns `self.exec = ExecController(self)` and delegates `handle_exec_start/input/close_stdin/stop`, `stop_exec`, `forward_exec_output`, and `_claim_and_stop_exec` to it.
- Backwards-compatible `exec_session` / `exec_task` **property shims** on `Connection` proxy reads and writes to the controller, so existing callers and tests that read/write those fields directly keep working unchanged. `cleanup` still calls `self.stop_exec()`.
- Removed the single `# pragma: no cover` from the `except asyncio.CancelledError: raise` branch in `forward_output` now that it is directly unit-testable.

`src/backend/tests/test_wshandler.py`

- New `TestExecController` (27 tests) exercises the collaborator **in isolation** against a lightweight fake connection (`types.SimpleNamespace`), proving it is decoupled from `Connection`. Covers:
  - `start`: no-container / no-perm / no-command / stops-existing-session / `user_home`+`ssh_agent_socket` env wiring / default `work_dir` when no `user_home`.
  - `input`: no-session / dead-session / oversized / writes-and-records-activity.
  - `close_stdin`: no-session / delegates.
  - `stop` / `stop_command` / `claim_and_stop`: no-session / cancels-task-and-stops / drops-and-stops.
  - `forward_output`: relays chunks + exit code / exit-code default 1 / records activity / swallows `_WS_ERRORS` / **reraises `CancelledError`** (the previously-excluded branch) and still cleans up the session.
  - `Connection._claim_and_stop_exec` / `forward_exec_output` / `stop_exec` delegate wiring, and `exec_session`/`exec_task` property round-trips to the controller.

## Why this scope

Continues the staged collaborator extraction from #961 ("one collaborator at a time behind the existing tests"). Exec is the next most self-contained concern after SSH-agent forwarding — its only cross-dependencies are `container_id`, `_user_home`, `_ssh_agent_socket`, `sock`, and `_has_perm`. This PR mirrors the `SshAgentForwarder` pattern (PR #984) and establishes it further for the remaining `TerminalController` and `SharedTerminalController` follow-ups.

## Verification

- No behavior change: pure move + delegation.
- `pytest src/backend/tests` (full backend suite with the project's `--cov-fail-under=100` gate): **1696 passed, 100.00% coverage**.
- `wshandler.py` remains at 100% coverage with the `pragma: no cover` exclusion removed and that line now genuinely covered by a direct unit test.
- `ruff check` + `ruff format` clean; pre-commit hooks pass.

Refs #961 (stage 2). `TerminalController` and `SharedTerminalController` are left for follow-up PRs to keep each stage reviewable.