### PR TITLE
Add pagination, sorting, and filtering on the /admin/users invitations page

### DIFF
--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -695,10 +695,23 @@ async def send_invitation(
 
 @router.get("/admin/invitations")
 async def list_invitations(
+    page: int = 1,
+    page_size: int = 10,
+    sort: str = "created",
+    order: str = "desc",
+    q: str | None = None,
     admin: dict = Depends(acl.has_permission("admin")),
 ):
-    """List all invitations (admin only)."""
-    return await model.list_invitations()
+    """List invitations (admin only), server-side paginated/sorted/filtered.
+
+    Returns a paged envelope ``{invitations, page, page_size, total,
+    pending_count}`` supporting forwards/backwards paging. ``sort`` is one
+    of ``email`` | ``invited_by`` | ``created``, ``order`` is ``asc`` |
+    ``desc``, and ``q`` is a substring filter on the invitee email.
+    """
+    return await model.list_invitations(
+        page=page, page_size=page_size, sort=sort, order=order, q=q
+    )
 
 
 @router.delete("/admin/invitations/{invitation_id}")

--- a/src/backend/klangk_backend/model.py
+++ b/src/backend/klangk_backend/model.py
@@ -2018,17 +2018,75 @@ async def get_pending_invitation_by_email(email: str) -> dict | None:
     }
 
 
-async def list_invitations() -> list[dict]:
-    """List all invitations, most recent first."""
+# Whitelisted sort columns for the admin invitations list. Values are the
+# SQL expressions to ORDER BY; the ``invited_by`` key sorts by the inviter's
+# email (the joined ``users.email``), which is the value the UI displays.
+_ADMIN_INVITATION_SORT_COLUMNS = {
+    "email": "i.email",
+    "invited_by": "u.email",
+    "created": "i.created_at",
+}
+
+
+async def list_invitations(
+    page: int = 1,
+    page_size: int = 10,
+    sort: str = "created",
+    order: str = "desc",
+    q: str | None = None,
+) -> dict:
+    """List invitations with server-side pagination, sorting, and filtering.
+
+    Returns a paged envelope ``{"invitations", "page", "page_size",
+    "total", "pending_count"}`` suitable for forwards/backwards paging.
+    ``pending_count`` is the total number of pending invitations across the
+    whole table (ignoring the ``q`` filter and pagination) so the admin UI
+    can keep its "pending invitations" badge accurate on every page.
+
+    Sort keys: ``email`` (invitee email), ``invited_by`` (inviter's email),
+    ``created`` (creation time). An unknown ``sort`` is whitelisted against
+    a static map and falls back to ``i.created_at`` (no string
+    interpolation of user input). The ``q`` filter is a substring match on
+    the invitee email. A trailing ``i.id`` tiebreaker keeps offset
+    pagination deterministic when rows share the sort key.
+    """
+    sort_col = _ADMIN_INVITATION_SORT_COLUMNS.get(sort, "i.created_at")
+    direction = "DESC" if order.lower() == "desc" else "ASC"
+    page = max(1, page)
+    page_size = max(1, min(page_size, 200))
+    offset = (page - 1) * page_size
+
     async with transaction() as db:
+        where_clause = ""
+        params: list = []
+        if q:
+            where_clause = " WHERE i.email LIKE ?"
+            params.append(f"%{q}%")
+
+        count_cursor = await db.execute(
+            f"SELECT COUNT(*) AS c FROM invitations i{where_clause}",
+            params,
+        )
+        total = (await count_cursor.fetchone())["c"]
+
+        # Global pending count for the UI badge — independent of the q
+        # filter and the current page.
+        pending_cursor = await db.execute(
+            "SELECT COUNT(*) AS c FROM invitations WHERE status = 'pending'"
+        )
+        pending_count = (await pending_cursor.fetchone())["c"]
+
         cursor = await db.execute(
             "SELECT i.id, i.email, i.invited_by, i.status,"
             " i.created_at, i.accepted_at, u.email AS invited_by_email"
             " FROM invitations i"
             " JOIN users u ON i.invited_by = u.id"
-            " ORDER BY i.created_at DESC"
+            f"{where_clause}"
+            f" ORDER BY {sort_col} {direction}, i.id"
+            " LIMIT ? OFFSET ?",
+            (*params, page_size, offset),
         )
-        return [
+        invitations = [
             {
                 "id": row["id"],
                 "email": row["email"],
@@ -2040,6 +2098,13 @@ async def list_invitations() -> list[dict]:
             }
             for row in await cursor.fetchall()
         ]
+        return {
+            "invitations": invitations,
+            "page": page,
+            "page_size": page_size,
+            "total": total,
+            "pending_count": pending_count,
+        }
 
 
 async def mark_invitation_accepted(invitation_id: str) -> bool:

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -5938,11 +5938,206 @@ class TestInvitations:
             )
         resp = await client.get("/api/v1/admin/invitations", headers=headers)
         assert resp.status_code == 200
-        data = resp.json()
-        emails = [inv["email"] for inv in data]
+        body = resp.json()
+        invitations = body["invitations"]
+        emails = [inv["email"] for inv in invitations]
         assert "list1@example.com" in emails
         assert "list2@example.com" in emails
-        assert data[0]["invited_by_email"] == "testadmin@example.com"
+        assert invitations[0]["invited_by_email"] == "testadmin@example.com"
+        # Paged envelope metadata.
+        assert body["page"] == 1
+        assert body["page_size"] == 10
+        assert body["total"] >= 2
+        # Two freshly-created pending invitations are reflected in the
+        # global pending count (used by the UI badge).
+        assert body["pending_count"] >= 2
+
+    async def test_list_invitations_default_page_size_is_10(
+        self, client, admin_user
+    ):
+        headers = await self._admin_headers(client)
+        with patch.object(
+            api.emailsvc,
+            "send_invitation_email",
+            new_callable=AsyncMock,
+        ):
+            for i in range(12):
+                await client.post(
+                    "/api/v1/admin/invitations",
+                    headers=headers,
+                    json={"email": f"page{i}@example.com"},
+                )
+        resp = await client.get("/api/v1/admin/invitations", headers=headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["page"] == 1
+        assert body["page_size"] == 10
+        assert body["total"] >= 12
+        assert len(body["invitations"]) == 10
+
+    async def test_list_invitations_pagination_across_pages(
+        self, client, admin_user
+    ):
+        headers = await self._admin_headers(client)
+        with patch.object(
+            api.emailsvc,
+            "send_invitation_email",
+            new_callable=AsyncMock,
+        ):
+            for i in range(6):
+                await client.post(
+                    "/api/v1/admin/invitations",
+                    headers=headers,
+                    json={"email": f"pg{i}@example.com"},
+                )
+        page1 = await client.get(
+            "/api/v1/admin/invitations?page=1&page_size=3", headers=headers
+        )
+        page2 = await client.get(
+            "/api/v1/admin/invitations?page=2&page_size=3", headers=headers
+        )
+        assert page1.status_code == 200
+        assert page2.status_code == 200
+        b1 = page1.json()
+        b2 = page2.json()
+        assert b1["page"] == 1
+        assert b2["page"] == 2
+        assert b1["page_size"] == 3
+        assert b1["total"] == b2["total"]
+        # Pages don't overlap.
+        ids1 = {inv["id"] for inv in b1["invitations"]}
+        ids2 = {inv["id"] for inv in b2["invitations"]}
+        assert ids1.isdisjoint(ids2)
+        assert len(b1["invitations"]) == 3
+        assert len(b2["invitations"]) == 3
+
+    async def test_list_invitations_sort_by_email(self, client, admin_user):
+        headers = await self._admin_headers(client)
+        with patch.object(
+            api.emailsvc,
+            "send_invitation_email",
+            new_callable=AsyncMock,
+        ):
+            for e in [
+                "charlie@example.com",
+                "alpha@example.com",
+                "bravo@example.com",
+            ]:
+                await client.post(
+                    "/api/v1/admin/invitations",
+                    headers=headers,
+                    json={"email": e},
+                )
+        resp = await client.get(
+            "/api/v1/admin/invitations?sort=email&order=asc&page_size=50",
+            headers=headers,
+        )
+        emails = [inv["email"] for inv in resp.json()["invitations"]]
+        assert emails == sorted(emails, key=str.lower)
+        assert emails[0] == "alpha@example.com"
+
+    async def test_list_invitations_sort_by_invited_by(
+        self, client, admin_user
+    ):
+        # Two invitations from two different inviters. Sorting by
+        # ``invited_by`` must track the inviter's email (the value the UI
+        # displays), not the invitee's email.
+        inviter_a = await model.create_user(
+            "aaa-admin@example.com", None, verified=True
+        )
+        inviter_z = await model.create_user(
+            "zzz-admin@example.com", None, verified=True
+        )
+        await model.create_invitation("zeta@example.com", inviter_z["id"])
+        await model.create_invitation("alpha@example.com", inviter_a["id"])
+        headers = await self._admin_headers(client)
+        resp = await client.get(
+            "/api/v1/admin/invitations?sort=invited_by&order=asc&page_size=50",
+            headers=headers,
+        )
+        rows = resp.json()["invitations"]
+        # Only the two we just created are relevant; confirm the inviter
+        # ordering among them and that it tracks invited_by_email.
+        ours = [
+            r
+            for r in rows
+            if r["email"] in {"zeta@example.com", "alpha@example.com"}
+        ]
+        inviters = [r["invited_by_email"] for r in ours]
+        assert inviters == sorted(inviters, key=str.lower)
+        assert ours[0]["invited_by_email"] == "aaa-admin@example.com"
+        assert ours[0]["email"] == "alpha@example.com"
+
+    async def test_list_invitations_sort_desc_reverses(
+        self, client, admin_user
+    ):
+        headers = await self._admin_headers(client)
+        with patch.object(
+            api.emailsvc,
+            "send_invitation_email",
+            new_callable=AsyncMock,
+        ):
+            for e in [
+                "charlie@example.com",
+                "alpha@example.com",
+                "bravo@example.com",
+            ]:
+                await client.post(
+                    "/api/v1/admin/invitations",
+                    headers=headers,
+                    json={"email": e},
+                )
+        asc = await client.get(
+            "/api/v1/admin/invitations?sort=email&order=asc&page_size=50",
+            headers=headers,
+        )
+        desc = await client.get(
+            "/api/v1/admin/invitations?sort=email&order=desc&page_size=50",
+            headers=headers,
+        )
+        asc_emails = [inv["email"] for inv in asc.json()["invitations"]]
+        desc_emails = [inv["email"] for inv in desc.json()["invitations"]]
+        assert asc_emails == list(reversed(desc_emails))
+
+    async def test_list_invitations_filter_by_email(self, client, admin_user):
+        headers = await self._admin_headers(client)
+        with patch.object(
+            api.emailsvc,
+            "send_invitation_email",
+            new_callable=AsyncMock,
+        ):
+            await client.post(
+                "/api/v1/admin/invitations",
+                headers=headers,
+                json={"email": "needle@example.com"},
+            )
+            await client.post(
+                "/api/v1/admin/invitations",
+                headers=headers,
+                json={"email": "haystack@example.com"},
+            )
+        resp = await client.get(
+            "/api/v1/admin/invitations?q=needle&page_size=50",
+            headers=headers,
+        )
+        body = resp.json()
+        emails = [inv["email"] for inv in body["invitations"]]
+        assert emails == ["needle@example.com"]
+        assert body["total"] == 1
+        # The filter narrows the page but not the global pending count.
+        assert body["pending_count"] >= 2
+
+    async def test_list_invitations_invalid_sort_falls_back_to_created(
+        self, client, admin_user
+    ):
+        headers = await self._admin_headers(client)
+        # An unknown sort column must not 500 (falls back to created_at).
+        resp = await client.get(
+            "/api/v1/admin/invitations?sort=evil%3B%20DROP%20TABLE&order=asc",
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["invitations"] is not None
 
     async def test_revoke_invitation(self, client, admin_user):
         headers = await self._admin_headers(client)

--- a/src/backend/tests/test_model.py
+++ b/src/backend/tests/test_model.py
@@ -1080,12 +1080,18 @@ class TestInvitations:
     async def test_list(self, db, admin_user):
         await model.create_invitation("x@b.com", admin_user["id"])
         await model.create_invitation("y@b.com", admin_user["id"])
-        invs = await model.list_invitations()
+        result = await model.list_invitations()
+        invs = result["invitations"]
         assert len(invs) >= 2
         emails = [i["email"] for i in invs]
         assert "x@b.com" in emails
         assert "y@b.com" in emails
         assert invs[0]["invited_by_email"] == "testadmin@example.com"
+        # Paged envelope metadata + global pending count.
+        assert result["page"] == 1
+        assert result["page_size"] == 10
+        assert result["total"] >= 2
+        assert result["pending_count"] >= 2
 
     async def test_mark_accepted(self, db, admin_user):
         inv = await model.create_invitation("acc@b.com", admin_user["id"])

--- a/src/cli/klangkc/main.py
+++ b/src/cli/klangkc/main.py
@@ -1586,10 +1586,10 @@ def list_invitations() -> None:
     """List all invitations (admin only)."""
     _require_auth()
     client = _client()
-    resp = client.get("/api/v1/admin/invitations")
+    resp = client.get("/api/v1/admin/invitations?page_size=200")
     client._check_auth(resp)
     resp.raise_for_status()
-    data = resp.json()
+    data = resp.json().get("invitations", [])
     if not data:
         typer.echo("No invitations.")
         return

--- a/src/cli/tests/test_cli_main.py
+++ b/src/cli/tests/test_cli_main.py
@@ -2545,14 +2545,20 @@ class TestInviteCLI:
         client = MagicMock()
         client.get.return_value = MagicMock(
             status_code=200,
-            json=lambda: [
-                {
-                    "email": "a@b.com",
-                    "status": "pending",
-                    "invited_by_email": "admin@x.com",
-                    "created_at": "2026-01-01 00:00:00",
-                }
-            ],
+            json=lambda: {
+                "invitations": [
+                    {
+                        "email": "a@b.com",
+                        "status": "pending",
+                        "invited_by_email": "admin@x.com",
+                        "created_at": "2026-01-01 00:00:00",
+                    }
+                ],
+                "page": 1,
+                "page_size": 200,
+                "total": 1,
+                "pending_count": 1,
+            },
         )
         monkeypatch.setattr(main, "_client", lambda: client)
 
@@ -2569,7 +2575,13 @@ class TestInviteCLI:
         client = MagicMock()
         client.get.return_value = MagicMock(
             status_code=200,
-            json=lambda: [],
+            json=lambda: {
+                "invitations": [],
+                "page": 1,
+                "page_size": 200,
+                "total": 0,
+                "pending_count": 0,
+            },
         )
         monkeypatch.setattr(main, "_client", lambda: client)
 

--- a/src/frontend/lib/admin/admin_users_page.dart
+++ b/src/frontend/lib/admin/admin_users_page.dart
@@ -34,6 +34,19 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
   String _usersOrder = 'desc'; // asc | desc
   String _usersQuery = '';
   final TextEditingController _searchController = TextEditingController();
+  Timer? _usersQueryDebounce;
+
+  // Admin invitations list: server-side pagination / sort / filter state.
+  int _invitationsPage = 1;
+  final int _invitationsPageSize = 10;
+  int _invitationsTotal = 0;
+  int _invitationsPending = 0; // global pending count (drives the tab badge)
+  String _invitationsSort = 'created'; // email | invited_by | created
+  String _invitationsOrder = 'desc'; // asc | desc
+  String _invitationsQuery = '';
+  final TextEditingController _invitationsSearchController =
+      TextEditingController();
+  Timer? _invitationsQueryDebounce;
 
   bool _canUsers = false;
   bool _canGroups = false;
@@ -54,12 +67,35 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
   @override
   void initState() {
     super.initState();
+    // Live filter: re-query the backend as the user types, debounced so
+    // we don't fire a request per keystroke. Restarts the debounce timer
+    // on every change and resets to page 1 (a narrower result set may
+    // collapse the previous page range).
+    _searchController.addListener(() {
+      final value = _searchController.text;
+      if (value == _usersQuery) return;
+      _usersQuery = value;
+      _usersQueryDebounce?.cancel();
+      _usersQueryDebounce =
+          Timer(const Duration(milliseconds: 300), () => _loadUsers(page: 1));
+    });
+    _invitationsSearchController.addListener(() {
+      final value = _invitationsSearchController.text;
+      if (value == _invitationsQuery) return;
+      _invitationsQuery = value;
+      _invitationsQueryDebounce?.cancel();
+      _invitationsQueryDebounce = Timer(
+          const Duration(milliseconds: 300), () => _loadInvitations(page: 1));
+    });
     _loadData();
   }
 
   @override
   void dispose() {
+    _usersQueryDebounce?.cancel();
+    _invitationsQueryDebounce?.cancel();
     _searchController.dispose();
+    _invitationsSearchController.dispose();
     super.dispose();
   }
 
@@ -117,15 +153,29 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
     }
   }
 
-  Future<void> _loadInvitations() async {
+  Future<void> _loadInvitations({int page = 1}) async {
+    setState(() {
+      _invitationsPage = page;
+    });
     try {
       final auth = context.read<AuthService>();
-      final resp = await auth.authGet('/api/v1/admin/invitations');
+      final q = _invitationsQuery.trim();
+      final query = 'page=$_invitationsPage'
+          '&page_size=$_invitationsPageSize'
+          '&sort=${Uri.encodeQueryComponent(_invitationsSort)}'
+          '&order=${Uri.encodeQueryComponent(_invitationsOrder)}'
+          '${q.isNotEmpty ? '&q=${Uri.encodeQueryComponent(q)}' : ''}';
+      final resp = await auth.authGet(
+        '/api/v1/admin/invitations?$query',
+      );
       if (resp.statusCode == 200) {
-        final data = jsonDecode(resp.body) as List;
+        final data = jsonDecode(resp.body) as Map<String, dynamic>;
         if (mounted) {
           setState(() {
-            _invitations = data.cast<Map<String, dynamic>>();
+            _invitations =
+                (data['invitations'] as List).cast<Map<String, dynamic>>();
+            _invitationsTotal = (data['total'] as num).toInt();
+            _invitationsPending = (data['pending_count'] as num).toInt();
           });
         }
       }
@@ -435,7 +485,9 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
       body: jsonEncode({'email': email}),
     );
     if (resp.statusCode == 200) {
-      _loadInvitations();
+      // New invitation sorts to the top (created desc) — jump to page 1
+      // so the admin sees it immediately.
+      _loadInvitations(page: 1);
       if (mounted) {
         ScaffoldMessenger.of(
           context,
@@ -483,7 +535,9 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
       '/api/v1/admin/invitations/$invitationId',
     );
     if (resp.statusCode == 200) {
-      _loadInvitations();
+      // Revoked invitations stay in the list (status filter is out of
+      // scope), so just refresh the current page to show the new status.
+      _loadInvitations(page: _invitationsPage);
     } else {
       if (mounted) {
         final error = jsonDecode(resp.body);
@@ -623,7 +677,22 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
   Widget _buildUsersTab() {
     return Column(
       children: [
-        _buildUsersToolbar(),
+        _AdminListToolbar(
+          key: const ValueKey('admin-users-toolbar'),
+          columns: const [
+            ('Email', 'email'),
+            ('Handle', 'handle'),
+            ('Created', 'created'),
+          ],
+          sort: _usersSort,
+          order: _usersOrder,
+          onChangeSort: _changeSort,
+          searchController: _searchController,
+          page: _usersPage,
+          pageSize: _usersPageSize,
+          total: _usersTotal,
+          onPage: (p) => _loadUsers(page: p),
+        ),
         Expanded(child: _buildUsersList()),
       ],
     );
@@ -643,77 +712,6 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
       });
     }
     await _loadUsers(page: 1);
-  }
-
-  Widget _sortChip(String label, String sortKey) {
-    final active = _usersSort == sortKey;
-    final arrow = _usersOrder == 'asc' ? '▲' : '▼';
-    return ActionChip(
-      label: Text(active ? '$label $arrow' : label),
-      onPressed: () => _changeSort(sortKey),
-      backgroundColor:
-          active ? KColors.accentBlue.withValues(alpha: 0.2) : null,
-    );
-  }
-
-  Widget _buildUsersToolbar() {
-    final totalPages = _usersTotal == 0
-        ? 1
-        : (_usersTotal + _usersPageSize - 1) ~/ _usersPageSize;
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
-      child: Wrap(
-        spacing: 8,
-        runSpacing: 8,
-        crossAxisAlignment: WrapCrossAlignment.center,
-        children: [
-          _sortChip('Email', 'email'),
-          _sortChip('Handle', 'handle'),
-          _sortChip('Created', 'created'),
-          const SizedBox(width: 12),
-          SizedBox(
-            width: 220,
-            child: TextField(
-              controller: _searchController,
-              decoration: const InputDecoration(
-                isDense: true,
-                hintText: 'Filter by email…',
-                prefixIcon: Icon(Icons.search, size: 18),
-                border: OutlineInputBorder(),
-                contentPadding: EdgeInsets.symmetric(
-                  horizontal: 8,
-                  vertical: 0,
-                ),
-              ),
-              onSubmitted: (value) {
-                _usersQuery = value;
-                _loadUsers(page: 1);
-              },
-            ),
-          ),
-          Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              IconButton(
-                tooltip: 'Previous page',
-                icon: const Icon(Icons.chevron_left),
-                onPressed: _usersPage > 1
-                    ? () => _loadUsers(page: _usersPage - 1)
-                    : null,
-              ),
-              Text('$_usersPage / $totalPages'),
-              IconButton(
-                tooltip: 'Next page',
-                icon: const Icon(Icons.chevron_right),
-                onPressed: _usersPage < totalPages
-                    ? () => _loadUsers(page: _usersPage + 1)
-                    : null,
-              ),
-            ],
-          ),
-        ],
-      ),
-    );
   }
 
   Widget _buildUsersList() {
@@ -771,6 +769,47 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
   }
 
   Widget _buildInvitationsTab() {
+    return Column(
+      children: [
+        _AdminListToolbar(
+          key: const ValueKey('admin-invitations-toolbar'),
+          columns: const [
+            ('Email', 'email'),
+            ('Invited by', 'invited_by'),
+            ('Created', 'created'),
+          ],
+          sort: _invitationsSort,
+          order: _invitationsOrder,
+          onChangeSort: _changeInvitationsSort,
+          searchController: _invitationsSearchController,
+          page: _invitationsPage,
+          pageSize: _invitationsPageSize,
+          total: _invitationsTotal,
+          onPage: (p) => _loadInvitations(page: p),
+        ),
+        Expanded(child: _buildInvitationsList()),
+      ],
+    );
+  }
+
+  /// Select a sort column, or toggle direction if already selected —
+  /// resets to page 1 because a different sort reorders every row.
+  Future<void> _changeInvitationsSort(String sortKey) async {
+    if (_invitationsSort == sortKey) {
+      setState(() {
+        _invitationsOrder = _invitationsOrder == 'asc' ? 'desc' : 'asc';
+      });
+    } else {
+      setState(() {
+        _invitationsSort = sortKey;
+        // Email/invited_by read naturally ascending; created descending.
+        _invitationsOrder = sortKey == 'created' ? 'desc' : 'asc';
+      });
+    }
+    await _loadInvitations(page: 1);
+  }
+
+  Widget _buildInvitationsList() {
     if (_invitations.isEmpty) {
       return const Center(child: Text('No invitations'));
     }
@@ -850,8 +889,7 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
     // Re-resolve on each build: AuthService loads permissions asynchronously,
     // so the first build (before they arrive) would otherwise show no tabs.
     _resolvePermissions();
-    final pendingCount =
-        _invitations.where((i) => i['status'] == 'pending').length;
+    final pendingCount = _invitationsPending;
     final tabs = <SkeuoTab>[];
     final views = <Widget>[];
     final tabTypes = _tabTypes;
@@ -1440,6 +1478,99 @@ class _AclBrowserTabState extends State<_AclBrowserTab> {
           ),
         ),
       ],
+    );
+  }
+}
+
+/// Shared toolbar for the admin list tabs (Users, Invitations): sort chips,
+/// a debounced email filter, and prev/next paging. The owning State holds
+/// the sort/order/page/total fields and the search controller (whose
+/// listener debounces a backend re-query); this widget just renders the
+/// controls and reports interactions back via callbacks.
+class _AdminListToolbar extends StatelessWidget {
+  final List<(String, String)> columns; // (label, sortKey)
+  final String sort;
+  final String order; // 'asc' | 'desc'
+  final ValueChanged<String> onChangeSort;
+  final TextEditingController searchController;
+  final int page;
+  final int pageSize;
+  final int total;
+  final ValueChanged<int> onPage; // requested page number
+
+  const _AdminListToolbar({
+    super.key,
+    required this.columns,
+    required this.sort,
+    required this.order,
+    required this.onChangeSort,
+    required this.searchController,
+    required this.page,
+    required this.pageSize,
+    required this.total,
+    required this.onPage,
+  });
+
+  Widget _sortChip(String label, String sortKey) {
+    final active = sort == sortKey;
+    final arrow = order == 'asc' ? '▲' : '▼';
+    return ActionChip(
+      label: Text(active ? '$label $arrow' : label),
+      onPressed: () => onChangeSort(sortKey),
+      backgroundColor:
+          active ? KColors.accentBlue.withValues(alpha: 0.2) : null,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final totalPages = total == 0 ? 1 : (total + pageSize - 1) ~/ pageSize;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 12, 16, 4),
+      child: Wrap(
+        spacing: 8,
+        runSpacing: 8,
+        crossAxisAlignment: WrapCrossAlignment.center,
+        children: [
+          for (final (label, key) in columns) _sortChip(label, key),
+          const SizedBox(width: 12),
+          SizedBox(
+            width: 220,
+            child: TextField(
+              controller: searchController,
+              decoration: const InputDecoration(
+                isDense: true,
+                hintText: 'Filter by email…',
+                prefixIcon: Icon(Icons.search, size: 18),
+                border: OutlineInputBorder(),
+                contentPadding: EdgeInsets.symmetric(
+                  horizontal: 8,
+                  vertical: 0,
+                ),
+              ),
+              // Enter submits immediately; the live debounce runs via the
+              // controller listener in the owning State.
+              onSubmitted: (_) => onPage(1),
+            ),
+          ),
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              IconButton(
+                tooltip: 'Previous page',
+                icon: const Icon(Icons.chevron_left),
+                onPressed: page > 1 ? () => onPage(page - 1) : null,
+              ),
+              Text('$page / $totalPages'),
+              IconButton(
+                tooltip: 'Next page',
+                icon: const Icon(Icons.chevron_right),
+                onPressed: page < totalPages ? () => onPage(page + 1) : null,
+              ),
+            ],
+          ),
+        ],
+      ),
     );
   }
 }

--- a/src/frontend/test/admin_invitations_page_test.dart
+++ b/src/frontend/test/admin_invitations_page_test.dart
@@ -9,27 +9,38 @@ import 'package:klangk_frontend/admin/admin_users_page.dart';
 import 'package:klangk_frontend/auth/auth_service.dart';
 import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 
-/// A paged envelope, matching the backend `GET /admin/users` response.
-String _usersEnvelope(
-  List<Map<String, dynamic>> users, {
+/// A paged invitations envelope, matching the backend
+/// `GET /admin/invitations` response.
+String _invitationsEnvelope(
+  List<Map<String, dynamic>> invitations, {
   int page = 1,
   int pageSize = 10,
   int total = 0,
+  int pendingCount = 0,
 }) =>
     jsonEncode({
-      'users': users,
+      'invitations': invitations,
       'page': page,
       'page_size': pageSize,
       'total': total,
+      'pending_count': pendingCount,
     });
 
-Map<String, dynamic> _user(String email, {String id = ''}) => {
+Map<String, dynamic> _invitation(
+  String email, {
+  String id = '',
+  String status = 'pending',
+  String invitedBy = 'admin@example.com',
+  String createdAt = '2026-01-01 00:00:00',
+}) =>
+    {
       'id': id.isEmpty ? email : id,
       'email': email,
-      'handle': '',
-      'verified': true,
-      'provider': 'local',
-      'created_at': '2026-01-01T00:00:00',
+      'invited_by': 'admin-user',
+      'invited_by_email': invitedBy,
+      'status': status,
+      'created_at': createdAt,
+      'accepted_at': null,
     };
 
 /// Default JWT for a logged-in admin user.
@@ -101,11 +112,19 @@ void main() {
   }
 
   /// Pump the page on a wide surface (the admin tab row overflows on the
-  /// default 800px test surface) and settle.
-  Future<void> pumpPage(WidgetTester tester) async {
+  /// default 800px test surface) and settle. Optionally navigates to the
+  /// Invitations tab before settling.
+  Future<void> pumpPage(WidgetTester tester,
+      {bool toInvitations = true}) async {
     await tester.binding.setSurfaceSize(const Size(1280, 900));
     await tester.pumpWidget(buildPage());
     await tester.pumpAndSettle();
+    if (toInvitations) {
+      // The Invitations tab is the 3rd visible tab (Users, Groups,
+      // Invitations). Tap its label to switch.
+      await tester.tap(find.text('Invitations'));
+      await tester.pumpAndSettle();
+    }
   }
 
   /// The IconButton whose tooltip matches [tooltip]. The tooltip is a
@@ -115,34 +134,28 @@ void main() {
         matching: find.byType(IconButton),
       );
 
-  /// Empty paged invitations envelope, matching the backend
-  /// `GET /admin/invitations` response shape.
-  String emptyInvitationsEnvelope() => jsonEncode({
-        'invitations': <Map<String, dynamic>>[],
-        'page': 1,
-        'page_size': 10,
-        'total': 0,
-        'pending_count': 0,
-      });
-
-  /// The Users toolbar is rendered alongside the (offstage) Invitations
-  /// toolbar inside the IndexedStack, so a bare `find.text(...)` can match
-  /// chips in both. Scope widgets to the users toolbar via its key.
-  Finder inUsersToolbar(Finder inner) => find.descendant(
-        of: find.byKey(const ValueKey('admin-users-toolbar')),
+  /// The Invitations toolbar is rendered alongside the (offstage) Users
+  /// toolbar inside the IndexedStack, so a plain `find.text(...)` can match
+  /// chips in both. Scope widgets to the invitations toolbar via its key.
+  Finder inInvitationsToolbar(Finder inner) => find.descendant(
+        of: find.byKey(const ValueKey('admin-invitations-toolbar')),
         matching: inner,
       );
 
-  /// Serves the admin/users endpoint via [usersFor] plus empty
-  /// invitations/groups so the page loads.
-  void serveUsers(
+  /// Serves the admin/invitations endpoint via [invitationsFor] plus empty
+  /// users/groups so the page loads. The prev/next pagination IconButtons
+  /// are distinguished from the per-card Resend/Revoke IconButtons by their
+  /// tooltips, so serveInvitations and the default pending total must keep
+  /// the page count > 1 for those controls to be present.
+  void serveInvitations(
     List<Map<String, dynamic>> Function(
             int page, int pageSize, String sort, String order, String? q)
-        usersFor, {
+        invitationsFor, {
     int total = 25,
+    int pendingCount = 0,
   }) {
     testAuthHttpClientOverride = _mockClient((request) async {
-      if (request.url.path == '/api/v1/admin/users') {
+      if (request.url.path == '/api/v1/admin/invitations') {
         final page = int.parse(request.url.queryParameters['page'] ?? '1');
         final pageSize =
             int.parse(request.url.queryParameters['page_size'] ?? '10');
@@ -150,13 +163,27 @@ void main() {
         final order = request.url.queryParameters['order'] ?? 'desc';
         final q = request.url.queryParameters['q'];
         return http.Response(
-          _usersEnvelope(usersFor(page, pageSize, sort, order, q),
-              page: page, pageSize: pageSize, total: total),
+          _invitationsEnvelope(
+            invitationsFor(page, pageSize, sort, order, q),
+            page: page,
+            pageSize: pageSize,
+            total: total,
+            pendingCount: pendingCount,
+          ),
           200,
         );
       }
-      if (request.url.path == '/api/v1/admin/invitations') {
-        return http.Response(emptyInvitationsEnvelope(), 200);
+      if (request.url.path == '/api/v1/admin/users') {
+        // Paged users envelope expected by the page.
+        return http.Response(
+          jsonEncode({
+            'users': <Map<String, dynamic>>[],
+            'page': 1,
+            'page_size': 10,
+            'total': 0,
+          }),
+          200,
+        );
       }
       if (request.url.path == '/api/v1/admin/groups') {
         return http.Response(jsonEncode([]), 200);
@@ -165,14 +192,15 @@ void main() {
     });
   }
 
-  group('AdminUsersPage', () {
-    testWidgets('renders users from the paged envelope', (tester) async {
-      serveUsers(
+  group('AdminUsersPage invitations', () {
+    testWidgets('renders invitations from the paged envelope', (tester) async {
+      serveInvitations(
         (page, pageSize, sort, order, q) => [
-          _user('alice@example.com'),
-          _user('bob@example.com'),
+          _invitation('alice@example.com'),
+          _invitation('bob@example.com'),
         ],
         total: 2,
+        pendingCount: 2,
       );
 
       await pumpPage(tester);
@@ -180,18 +208,16 @@ void main() {
       expect(
           find.text('alice@example.com', skipOffstage: false), findsOneWidget);
       expect(find.text('bob@example.com', skipOffstage: false), findsOneWidget);
-      // No per-card groups subtitle anymore.
-      expect(find.textContaining('Groups:'), findsNothing);
     });
 
     testWidgets('shows pagination controls when more than one page',
         (tester) async {
-      // 25 users with page_size 10 => 3 pages.
-      serveUsers((page, pageSize, sort, order, q) {
+      // 25 invitations with page_size 10 => 3 pages.
+      serveInvitations((page, pageSize, sort, order, q) {
         final start = (page - 1) * pageSize;
         return [
           for (int i = start; i < start + pageSize && i < 25; i++)
-            _user('user$i@example.com'),
+            _invitation('inv$i@example.com'),
         ];
       });
 
@@ -208,18 +234,18 @@ void main() {
 
     testWidgets('navigates to next and previous pages', (tester) async {
       var lastPageRequested = 1;
-      serveUsers((page, pageSize, sort, order, q) {
+      serveInvitations((page, pageSize, sort, order, q) {
         lastPageRequested = page;
         final start = (page - 1) * pageSize;
         return [
           for (int i = start; i < start + pageSize && i < 15; i++)
-            _user('user$i@example.com'),
+            _invitation('inv$i@example.com'),
         ];
       }, total: 15);
 
       await pumpPage(tester);
 
-      // 15 users / 10 => 2 pages.
+      // 15 invitations / 10 => 2 pages.
       expect(find.text('1 / 2', skipOffstage: false), findsOneWidget);
 
       await tester.tap(iconButton('Next page'));
@@ -241,16 +267,29 @@ void main() {
       String? capturedSort;
       String? capturedOrder;
       testAuthHttpClientOverride = _mockClient((request) async {
-        if (request.url.path == '/api/v1/admin/users') {
+        if (request.url.path == '/api/v1/admin/invitations') {
           capturedSort = request.url.queryParameters['sort'];
           capturedOrder = request.url.queryParameters['order'];
+          final page = int.parse(request.url.queryParameters['page'] ?? '1');
           return http.Response(
-            _usersEnvelope([_user('a@example.com')], total: 1),
+            _invitationsEnvelope(
+              [_invitation('a@example.com')],
+              page: page,
+              total: 1,
+            ),
             200,
           );
         }
-        if (request.url.path == '/api/v1/admin/invitations') {
-          return http.Response(emptyInvitationsEnvelope(), 200);
+        if (request.url.path == '/api/v1/admin/users') {
+          return http.Response(
+            jsonEncode({
+              'users': <Map<String, dynamic>>[],
+              'page': 1,
+              'page_size': 10,
+              'total': 0,
+            }),
+            200,
+          );
         }
         if (request.url.path == '/api/v1/admin/groups') {
           return http.Response(jsonEncode([]), 200);
@@ -261,41 +300,54 @@ void main() {
       await pumpPage(tester);
 
       // Defaults: created, descending. The active Created chip shows ▼.
-      // Scope to the users toolbar: the Invitations toolbar is also built
+      // Scope to the invitations toolbar: the Users toolbar is also built
       // (offstage) inside the IndexedStack, so a bare find.text would match
       // chips in both.
       expect(capturedSort, 'created');
       expect(capturedOrder, 'desc');
-      expect(inUsersToolbar(find.text('Created ▼')), findsOneWidget);
+      expect(inInvitationsToolbar(find.text('Created ▼')), findsOneWidget);
 
       // Tap the Email chip to switch sort (defaults to asc).
-      await tester.tap(inUsersToolbar(find.text('Email')));
+      await tester.tap(inInvitationsToolbar(find.text('Email')));
       await tester.pumpAndSettle();
 
       expect(capturedSort, 'email');
       expect(capturedOrder, 'asc');
-      expect(inUsersToolbar(find.text('Email ▲')), findsOneWidget);
+      expect(inInvitationsToolbar(find.text('Email ▲')), findsOneWidget);
 
       // Tap Email again to flip direction to desc.
-      await tester.tap(inUsersToolbar(find.text('Email ▲')));
+      await tester.tap(inInvitationsToolbar(find.text('Email ▲')));
       await tester.pumpAndSettle();
 
       expect(capturedOrder, 'desc');
-      expect(inUsersToolbar(find.text('Email ▼')), findsOneWidget);
+      expect(inInvitationsToolbar(find.text('Email ▼')), findsOneWidget);
     });
 
     testWidgets('sends email filter query live (debounced)', (tester) async {
       String? capturedQ;
       testAuthHttpClientOverride = _mockClient((request) async {
-        if (request.url.path == '/api/v1/admin/users') {
+        if (request.url.path == '/api/v1/admin/invitations') {
           capturedQ = request.url.queryParameters['q'];
+          final page = int.parse(request.url.queryParameters['page'] ?? '1');
           return http.Response(
-            _usersEnvelope([_user('needle@example.com')], total: 1),
+            _invitationsEnvelope(
+              [_invitation('needle@example.com')],
+              page: page,
+              total: 1,
+            ),
             200,
           );
         }
-        if (request.url.path == '/api/v1/admin/invitations') {
-          return http.Response(emptyInvitationsEnvelope(), 200);
+        if (request.url.path == '/api/v1/admin/users') {
+          return http.Response(
+            jsonEncode({
+              'users': <Map<String, dynamic>>[],
+              'page': 1,
+              'page_size': 10,
+              'total': 0,
+            }),
+            200,
+          );
         }
         if (request.url.path == '/api/v1/admin/groups') {
           return http.Response(jsonEncode([]), 200);
@@ -308,26 +360,14 @@ void main() {
       expect(capturedQ, isNull);
 
       // The filter re-queries as the user types, debounced — settle past
-      // the debounce timer. Scope to the users toolbar so we type into the
-      // users filter, not the offstage invitations one.
+      // the debounce timer.
       await tester.enterText(
-        inUsersToolbar(find.byType(TextField)),
+        inInvitationsToolbar(find.byType(TextField)),
         'needle',
       );
       await tester.pumpAndSettle();
 
       expect(capturedQ, 'needle');
-    });
-
-    testWidgets('omits groups from user cards', (tester) async {
-      serveUsers(
-        (page, pageSize, sort, order, q) => [_user('alice@example.com')],
-        total: 1,
-      );
-
-      await pumpPage(tester);
-
-      expect(find.textContaining('Groups:'), findsNothing);
     });
   });
 }


### PR DESCRIPTION
Implements #948 — brings the invitations tab on `/admin/users` to parity with the users tab (#983 / #947): server-side pagination (10 per page, forwards/backwards), sorting (`email` / `invited_by` / `created`, asc+desc), and server-side email substring filtering.

## Backend
- `list_invitations()` now accepts `page` / `page_size` / `sort` / `order` / `q` and returns the envelope `{invitations, page, page_size, total, pending_count}`.
  - `pending_count` is a **global** count (ignoring the `q` filter) so the invitations tab badge stays accurate across pages and while filtering.
  - Sort keys are whitelisted via `_ADMIN_INVITATION_SORT_COLUMNS`: `email`, `invited_by` (joins the inviter's email), `created`. Unknown keys fall back to `created`.
  - `q` does a case-insensitive substring match on the invitee email.
- `GET /api/v1/admin/invitations` wires up the new query params.

## CLI
- `klangkc`'s `list_invitations` unwraps the new envelope (fetches `?page_size=200` to preserve previous "all" behavior).

## Frontend
- Extracted a shared **`_AdminListToolbar`** widget (sort chips with asc/desc arrows, debounced search field, prev/next pager) used by **both** the users and invitations tabs, removing the duplicated toolbar/sort-chip/pager code.
- **Live debounced (300 ms) filtering** is now on **both** tabs — #983 shipped the users filter as submit-only, so this PR fixes that too. Typing re-queries as you type; no need to press Enter.
- The invitations tab badge is driven by `pending_count`.

## Tests
- Backend: full suite green at **100% coverage** (new tests for pagination, each sort key + invalid-sort fallback, and the `q` filter).
- Frontend: new `admin_invitations_page_test.dart` covers paging, sort, and live debounced filtering. The sibling `admin_users_page_test.dart` is updated to scope its sort/filter assertions to the users toolbar (both toolbars render inside the page's `IndexedStack`) and to verify live filtering.

Closes #948.