### PR TITLE
chore(devenv): add ruff to packages

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -46,6 +46,7 @@ in
       gnutar
       nginx
       podman
+      ruff
       sqlite.bin
       rsync
       twine


### PR DESCRIPTION
Add the `ruff` binary directly to the shell `packages` list so it is on PATH, alongside the existing pre-commit hook usage of `pkgs.ruff`.