### PR TITLE
feat(admin): paginate, sort, filter /admin/users groups tab (#949)

### DIFF
--- a/src/backend/e2e-tests/test_api_e2e.py
+++ b/src/backend/e2e-tests/test_api_e2e.py
@@ -193,7 +193,7 @@ class TestGroupManagement:
     def test_list_groups(self, api, admin_headers):
         resp = api.get("/api/v1/admin/groups", headers=admin_headers)
         assert resp.status_code == 200
-        groups = resp.json()
+        groups = resp.json()["groups"]
         assert any(g["name"] == "admin" for g in groups)
 
     def test_create_group(self, api, admin_headers):
@@ -247,7 +247,7 @@ class TestGroupManagement:
         assert resp.status_code == 200
         # Verify gone
         resp = api.get("/api/v1/admin/groups", headers=admin_headers)
-        assert not any(g["id"] == group_id for g in resp.json())
+        assert not any(g["id"] == group_id for g in resp.json()["groups"])
 
     def test_add_and_list_members(self, api, admin_headers, user_a):
         # Create a group
@@ -406,7 +406,9 @@ class TestACLIntrospection:
     def test_acl_by_group(self, api, admin_headers):
         # Get admin group ID
         resp = api.get("/api/v1/admin/groups", headers=admin_headers)
-        admin_group = next(g for g in resp.json() if g["name"] == "admin")
+        admin_group = next(
+            g for g in resp.json()["groups"] if g["name"] == "admin"
+        )
 
         resp = api.get(
             f"/api/v1/admin/acl/by-principal/group/{admin_group['id']}",
@@ -700,7 +702,9 @@ class TestGrantAdminViaGroup:
 
         # Get admin group and user A's ID
         resp = api.get("/api/v1/admin/groups", headers=admin_headers)
-        admin_group = next(g for g in resp.json() if g["name"] == "admin")
+        admin_group = next(
+            g for g in resp.json()["groups"] if g["name"] == "admin"
+        )
 
         resp = api.get(
             "/api/v1/admin/users?page_size=200", headers=admin_headers
@@ -811,7 +815,7 @@ class TestACLCascades:
 
         # Group should be gone
         resp = api.get("/api/v1/admin/groups", headers=admin_headers)
-        assert not any(g["id"] == group_id for g in resp.json())
+        assert not any(g["id"] == group_id for g in resp.json()["groups"])
 
 
 class TestSharedWorkspaceAccess:

--- a/src/backend/klangk_backend/api.py
+++ b/src/backend/klangk_backend/api.py
@@ -2440,8 +2440,13 @@ async def _group_resource(request: Request, user: dict) -> str:  # noqa: ARG001
 async def user_list_groups(
     user: dict = Depends(auth.get_current_user),
 ):
-    """List all groups (any authenticated user can see groups)."""
-    return await model.list_groups()
+    """List all groups (any authenticated user can see groups).
+
+    Returns a bare list for backward compatibility; the admin endpoint
+    exposes the paged envelope.
+    """
+    result = await model.list_groups(page_size=200)
+    return result["groups"]
 
 
 @router.post("/groups")
@@ -2553,9 +2558,16 @@ async def user_remove_group_member(
 
 @router.get("/admin/groups")
 async def list_groups(
+    page: int = 1,
+    page_size: int = 10,
+    sort: str = "name",
+    order: str = "asc",
+    q: str | None = None,
     admin: dict = Depends(acl.has_permission("admin")),
 ):
-    return await model.list_groups()
+    return await model.list_groups(
+        page=page, page_size=page_size, sort=sort, order=order, q=q
+    )
 
 
 @router.post("/admin/groups")

--- a/src/backend/klangk_backend/model/users.py
+++ b/src/backend/klangk_backend/model/users.py
@@ -285,14 +285,53 @@ async def get_group_by_id(group_id: str) -> dict | None:
     }
 
 
-async def list_groups() -> list[dict]:
-    """List all groups."""
+_ADMIN_GROUP_SORT_COLUMNS = {
+    "name": "name",
+    "created": "created_at",
+}
+
+
+async def list_groups(
+    page: int = 1,
+    page_size: int = 10,
+    sort: str = "name",
+    order: str = "asc",
+    q: str | None = None,
+) -> dict:
+    """List groups with server-side pagination, sorting, and filtering.
+
+    Returns a paged envelope ``{"groups", "page", "page_size", "total"}``
+    suitable for forwards/backwards paging. Callers that still want a
+    bare list (e.g. the non-admin ``GET /groups`` endpoint) can read
+    ``result["groups"]``.
+    """
+    sort_col = _ADMIN_GROUP_SORT_COLUMNS.get(sort, "name")
+    direction = "DESC" if order.lower() == "desc" else "ASC"
+    page = max(1, page)
+    page_size = max(1, min(page_size, 200))
+    offset = (page - 1) * page_size
+
     async with transaction() as db:
+        where_clause = ""
+        params: list = []
+        if q:
+            where_clause = " WHERE name LIKE ?"
+            params.append(f"%{q}%")
+
+        count_cursor = await db.execute(
+            f"SELECT COUNT(*) AS c FROM groups{where_clause}",
+            params,
+        )
+        total = (await count_cursor.fetchone())["c"]
+
         cursor = await db.execute(
             "SELECT id, name, description, created_at"
-            " FROM groups ORDER BY name"
+            f" FROM groups{where_clause}"
+            f" ORDER BY {sort_col} {direction}, id"
+            " LIMIT ? OFFSET ?",
+            (*params, page_size, offset),
         )
-        return [
+        groups = [
             {
                 "id": row["id"],
                 "name": row["name"],
@@ -301,6 +340,12 @@ async def list_groups() -> list[dict]:
             }
             for row in await cursor.fetchall()
         ]
+        return {
+            "groups": groups,
+            "page": page,
+            "page_size": page_size,
+            "total": total,
+        }
 
 
 async def delete_group(group_id: str) -> bool:

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -4184,8 +4184,107 @@ class TestGroupEndpoints:
         headers = await self._admin_headers(client)
         resp = await client.get("/api/v1/admin/groups", headers=headers)
         assert resp.status_code == 200
-        groups = resp.json()
+        body = resp.json()
+        groups = body["groups"]
         assert any(g["name"] == "admin" for g in groups)
+        # Paged envelope metadata.
+        assert body["page"] == 1
+        assert body["page_size"] == 10
+        assert body["total"] >= 1
+
+    async def test_list_groups_default_page_size_is_10(
+        self, client, admin_user
+    ):
+        headers = await self._admin_headers(client)
+        for i in range(12):
+            await model.create_group(f"size-{i}")
+        resp = await client.get("/api/v1/admin/groups", headers=headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["page"] == 1
+        assert body["page_size"] == 10
+        assert body["total"] >= 13  # 12 created + admin fixture
+        assert len(body["groups"]) == 10
+
+    async def test_list_groups_pagination_across_pages(
+        self, client, admin_user
+    ):
+        headers = await self._admin_headers(client)
+        for i in range(5):
+            await model.create_group(f"pg-{i}")
+        page1 = await client.get(
+            "/api/v1/admin/groups?page=1&page_size=3", headers=headers
+        )
+        page2 = await client.get(
+            "/api/v1/admin/groups?page=2&page_size=3", headers=headers
+        )
+        assert page1.status_code == 200
+        assert page2.status_code == 200
+        b1 = page1.json()
+        b2 = page2.json()
+        assert b1["page"] == 1
+        assert b2["page"] == 2
+        assert b1["page_size"] == 3
+        assert b1["total"] == b2["total"]
+        # Pages don't overlap.
+        ids1 = {g["id"] for g in b1["groups"]}
+        ids2 = {g["id"] for g in b2["groups"]}
+        assert ids1.isdisjoint(ids2)
+        assert len(b1["groups"]) == 3
+        assert len(b2["groups"]) == 3
+
+    async def test_list_groups_sort_by_name(self, client, admin_user):
+        headers = await self._admin_headers(client)
+        for n in ["charlie", "alpha", "bravo"]:
+            await model.create_group(n)
+        resp = await client.get(
+            "/api/v1/admin/groups?sort=name&order=asc&page_size=200",
+            headers=headers,
+        )
+        names = [g["name"] for g in resp.json()["groups"]]
+        assert names == sorted(names, key=str.lower)
+        assert "alpha" in names
+
+    async def test_list_groups_sort_desc_reverses(self, client, admin_user):
+        headers = await self._admin_headers(client)
+        for n in ["charlie", "alpha", "bravo"]:
+            await model.create_group(n)
+        asc = await client.get(
+            "/api/v1/admin/groups?sort=name&order=asc&page_size=200",
+            headers=headers,
+        )
+        desc = await client.get(
+            "/api/v1/admin/groups?sort=name&order=desc&page_size=200",
+            headers=headers,
+        )
+        asc_names = [g["name"] for g in asc.json()["groups"]]
+        desc_names = [g["name"] for g in desc.json()["groups"]]
+        assert asc_names == list(reversed(desc_names))
+
+    async def test_list_groups_filter_by_name(self, client, admin_user):
+        headers = await self._admin_headers(client)
+        await model.create_group("needle-group")
+        await model.create_group("haystack-group")
+        resp = await client.get(
+            "/api/v1/admin/groups?q=needle&page_size=200",
+            headers=headers,
+        )
+        body = resp.json()
+        names = [g["name"] for g in body["groups"]]
+        assert names == ["needle-group"]
+        assert body["total"] == 1
+
+    async def test_list_groups_invalid_sort_falls_back_to_name(
+        self, client, admin_user
+    ):
+        headers = await self._admin_headers(client)
+        # An unknown sort column must not 500 (falls back to name).
+        resp = await client.get(
+            "/api/v1/admin/groups?sort=evil%3B%20DROP%20TABLE&order=asc",
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["groups"] is not None
 
     async def test_create_group(self, client, admin_user):
         headers = await self._admin_headers(client)
@@ -4384,7 +4483,7 @@ class TestACLEndpoints:
     async def test_get_acl_by_group(self, client, admin_user):
         headers = await self._admin_headers(client)
         # Get the admin group ID
-        groups = await model.list_groups()
+        groups = (await model.list_groups())["groups"]
         admin_group = next(g for g in groups if g["name"] == "admin")
         resp = await client.get(
             f"/api/v1/admin/acl/by-principal/group/{admin_group['id']}",

--- a/src/frontend/lib/admin/admin_users_page.dart
+++ b/src/frontend/lib/admin/admin_users_page.dart
@@ -48,6 +48,16 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
       TextEditingController();
   Timer? _invitationsQueryDebounce;
 
+  // Admin groups list: server-side pagination / sort / filter state.
+  int _groupsPage = 1;
+  final int _groupsPageSize = 10;
+  int _groupsTotal = 0;
+  String _groupsSort = 'name'; // name | created
+  String _groupsOrder = 'asc'; // asc | desc
+  String _groupsQuery = '';
+  final TextEditingController _groupSearchController = TextEditingController();
+  Timer? _groupsQueryDebounce;
+
   bool _canUsers = false;
   bool _canGroups = false;
   bool _canInvitations = false;
@@ -87,6 +97,14 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
       _invitationsQueryDebounce = Timer(
           const Duration(milliseconds: 300), () => _loadInvitations(page: 1));
     });
+    _groupSearchController.addListener(() {
+      final value = _groupSearchController.text;
+      if (value == _groupsQuery) return;
+      _groupsQuery = value;
+      _groupsQueryDebounce?.cancel();
+      _groupsQueryDebounce =
+          Timer(const Duration(milliseconds: 300), () => _loadGroups(page: 1));
+    });
     _loadData();
   }
 
@@ -94,8 +112,10 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
   void dispose() {
     _usersQueryDebounce?.cancel();
     _invitationsQueryDebounce?.cancel();
+    _groupsQueryDebounce?.cancel();
     _searchController.dispose();
     _invitationsSearchController.dispose();
+    _groupSearchController.dispose();
     super.dispose();
   }
 
@@ -184,15 +204,29 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
     }
   }
 
-  Future<void> _loadGroups() async {
+  Future<void> _loadGroups({int page = 1}) async {
+    setState(() {
+      _groupsPage = page;
+    });
     try {
       final auth = context.read<AuthService>();
-      final resp = await auth.authGet('/api/v1/admin/groups');
+      final query = <String, String>{
+        'page': '$_groupsPage',
+        'page_size': '$_groupsPageSize',
+        'sort': _groupsSort,
+        'order': _groupsOrder,
+      };
+      final q = _groupsQuery.trim();
+      if (q.isNotEmpty) query['q'] = q;
+      final resp = await auth.authGet(
+        '/api/v1/admin/groups?${_encodeQuery(query)}',
+      );
       if (resp.statusCode == 200) {
-        final data = jsonDecode(resp.body) as List;
+        final data = jsonDecode(resp.body) as Map<String, dynamic>;
         if (mounted) {
           setState(() {
-            _groups = data.cast<Map<String, dynamic>>();
+            _groups = (data['groups'] as List).cast<Map<String, dynamic>>();
+            _groupsTotal = (data['total'] as num).toInt();
           });
         }
       }
@@ -425,6 +459,46 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
   }
 
   Widget _buildGroupsTab() {
+    return Column(
+      children: [
+        _AdminListToolbar(
+          key: const ValueKey('admin-groups-toolbar'),
+          columns: const [
+            ('Name', 'name'),
+            ('Created', 'created'),
+          ],
+          sort: _groupsSort,
+          order: _groupsOrder,
+          onChangeSort: _changeGroupsSort,
+          searchController: _groupSearchController,
+          searchHint: 'Filter by name…',
+          page: _groupsPage,
+          pageSize: _groupsPageSize,
+          total: _groupsTotal,
+          onPage: (p) => _loadGroups(page: p),
+        ),
+        Expanded(child: _buildGroupsList()),
+      ],
+    );
+  }
+
+  /// Select a sort column, or toggle direction if already selected —
+  /// mirrors the users tab sort chips. Resets to page 1 because a
+  /// different sort reorders every row.
+  Future<void> _changeGroupsSort(String sortKey) async {
+    if (_groupsSort == sortKey) {
+      setState(() => _groupsOrder = _groupsOrder == 'asc' ? 'desc' : 'asc');
+    } else {
+      setState(() {
+        _groupsSort = sortKey;
+        // Name reads naturally ascending; created descending.
+        _groupsOrder = sortKey == 'created' ? 'desc' : 'asc';
+      });
+    }
+    await _loadGroups(page: 1);
+  }
+
+  Widget _buildGroupsList() {
     if (_loading) return const Center(child: CircularProgressIndicator());
     if (_groups.isEmpty) return const Center(child: Text('No groups'));
     return ListView.builder(
@@ -1493,6 +1567,7 @@ class _AdminListToolbar extends StatelessWidget {
   final String order; // 'asc' | 'desc'
   final ValueChanged<String> onChangeSort;
   final TextEditingController searchController;
+  final String searchHint;
   final int page;
   final int pageSize;
   final int total;
@@ -1505,6 +1580,7 @@ class _AdminListToolbar extends StatelessWidget {
     required this.order,
     required this.onChangeSort,
     required this.searchController,
+    this.searchHint = 'Filter by email…',
     required this.page,
     required this.pageSize,
     required this.total,
@@ -1538,9 +1614,9 @@ class _AdminListToolbar extends StatelessWidget {
             width: 220,
             child: TextField(
               controller: searchController,
-              decoration: const InputDecoration(
+              decoration: InputDecoration(
                 isDense: true,
-                hintText: 'Filter by email…',
+                hintText: searchHint,
                 prefixIcon: Icon(Icons.search, size: 18),
                 border: OutlineInputBorder(),
                 contentPadding: EdgeInsets.symmetric(

--- a/src/frontend/lib/widgets/acl_editor.dart
+++ b/src/frontend/lib/widgets/acl_editor.dart
@@ -104,17 +104,27 @@ class AclEditorState extends State<AclEditor> {
     List<Map<String, dynamic>> users = [];
     List<Map<String, dynamic>> groups = [];
     try {
-      final uResp = await auth.authGet('/api/v1/admin/users');
+      final uResp = await auth.authGet(
+        '/api/v1/admin/users?page_size=200',
+      );
       if (uResp.statusCode == 200) {
-        users = List<Map<String, dynamic>>.from(jsonDecode(uResp.body));
+        final body = jsonDecode(uResp.body) as Map<String, dynamic>;
+        users = (body['users'] as List)
+            .map((e) => Map<String, dynamic>.from(e as Map))
+            .toList();
       }
     } catch (e) {
       debugPrint('[AclEditor] fetch users failed: $e');
     }
     try {
-      final gResp = await auth.authGet('/api/v1/admin/groups');
+      final gResp = await auth.authGet(
+        '/api/v1/admin/groups?page_size=200',
+      );
       if (gResp.statusCode == 200) {
-        groups = List<Map<String, dynamic>>.from(jsonDecode(gResp.body));
+        final body = jsonDecode(gResp.body) as Map<String, dynamic>;
+        groups = (body['groups'] as List)
+            .map((e) => Map<String, dynamic>.from(e as Map))
+            .toList();
       }
     } catch (e) {
       debugPrint('[AclEditor] fetch groups failed: $e');

--- a/src/frontend/test/admin_users_page_test.dart
+++ b/src/frontend/test/admin_users_page_test.dart
@@ -23,12 +23,35 @@ String _usersEnvelope(
       'total': total,
     });
 
+/// A paged envelope, matching the backend `GET /admin/groups` response.
+String _groupsEnvelope(
+  List<Map<String, dynamic>> groups, {
+  int page = 1,
+  int pageSize = 10,
+  int total = 0,
+}) =>
+    jsonEncode({
+      'groups': groups,
+      'page': page,
+      'page_size': pageSize,
+      'total': total,
+    });
+
 Map<String, dynamic> _user(String email, {String id = ''}) => {
       'id': id.isEmpty ? email : id,
       'email': email,
       'handle': '',
       'verified': true,
       'provider': 'local',
+      'created_at': '2026-01-01T00:00:00',
+    };
+
+Map<String, dynamic> _group(String name,
+        {String id = '', String description = ''}) =>
+    {
+      'id': id.isEmpty ? name : id,
+      'name': name,
+      'description': description,
       'created_at': '2026-01-01T00:00:00',
     };
 
@@ -133,6 +156,13 @@ void main() {
         matching: inner,
       );
 
+  /// Likewise, scope widgets to the groups toolbar (the users/invitations
+  /// toolbars are also built inside the IndexedStack).
+  Finder inGroupsToolbar(Finder inner) => find.descendant(
+        of: find.byKey(const ValueKey('admin-groups-toolbar')),
+        matching: inner,
+      );
+
   /// Serves the admin/users endpoint via [usersFor] plus empty
   /// invitations/groups so the page loads.
   void serveUsers(
@@ -159,7 +189,39 @@ void main() {
         return http.Response(emptyInvitationsEnvelope(), 200);
       }
       if (request.url.path == '/api/v1/admin/groups') {
-        return http.Response(jsonEncode([]), 200);
+        return http.Response(_groupsEnvelope([]), 200);
+      }
+      return http.Response('Not found', 404);
+    });
+  }
+
+  /// Serves the admin/groups endpoint via [groupsFor] plus empty
+  /// users/invitations so the page loads.
+  void serveGroups(
+    List<Map<String, dynamic>> Function(
+            int page, int pageSize, String sort, String order, String? q)
+        groupsFor, {
+    int total = 25,
+  }) {
+    testAuthHttpClientOverride = _mockClient((request) async {
+      if (request.url.path == '/api/v1/admin/users') {
+        return http.Response(_usersEnvelope([]), 200);
+      }
+      if (request.url.path == '/api/v1/admin/invitations') {
+        return http.Response(emptyInvitationsEnvelope(), 200);
+      }
+      if (request.url.path == '/api/v1/admin/groups') {
+        final page = int.parse(request.url.queryParameters['page'] ?? '1');
+        final pageSize =
+            int.parse(request.url.queryParameters['page_size'] ?? '10');
+        final sort = request.url.queryParameters['sort'] ?? 'name';
+        final order = request.url.queryParameters['order'] ?? 'asc';
+        final q = request.url.queryParameters['q'];
+        return http.Response(
+          _groupsEnvelope(groupsFor(page, pageSize, sort, order, q),
+              page: page, pageSize: pageSize, total: total),
+          200,
+        );
       }
       return http.Response('Not found', 404);
     });
@@ -253,7 +315,7 @@ void main() {
           return http.Response(emptyInvitationsEnvelope(), 200);
         }
         if (request.url.path == '/api/v1/admin/groups') {
-          return http.Response(jsonEncode([]), 200);
+          return http.Response(_groupsEnvelope([]), 200);
         }
         return http.Response('Not found', 404);
       });
@@ -298,7 +360,7 @@ void main() {
           return http.Response(emptyInvitationsEnvelope(), 200);
         }
         if (request.url.path == '/api/v1/admin/groups') {
-          return http.Response(jsonEncode([]), 200);
+          return http.Response(_groupsEnvelope([]), 200);
         }
         return http.Response('Not found', 404);
       });
@@ -328,6 +390,173 @@ void main() {
       await pumpPage(tester);
 
       expect(find.textContaining('Groups:'), findsNothing);
+    });
+  });
+
+  group('AdminUsersPage groups tab', () {
+    /// Pump the page on the users tab, then switch to the Groups tab.
+    Future<void> pumpGroupsTab(WidgetTester tester) async {
+      await pumpPage(tester);
+      await tester.tap(find.text('Groups'));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('renders groups from the paged envelope', (tester) async {
+      serveGroups(
+        (page, pageSize, sort, order, q) => [
+          _group('admins', description: 'Admin team'),
+          _group('editors', description: 'Editor team'),
+        ],
+        total: 2,
+      );
+
+      await pumpGroupsTab(tester);
+
+      expect(find.text('admins', skipOffstage: false), findsOneWidget);
+      expect(find.text('editors', skipOffstage: false), findsOneWidget);
+    });
+
+    testWidgets('shows pagination controls when more than one page',
+        (tester) async {
+      // 25 groups with page_size 10 => 3 pages.
+      serveGroups((page, pageSize, sort, order, q) {
+        final start = (page - 1) * pageSize;
+        return [
+          for (int i = start; i < start + pageSize && i < 25; i++)
+            _group('group$i'),
+        ];
+      });
+
+      await pumpGroupsTab(tester);
+
+      expect(inGroupsToolbar(find.text('1 / 3')), findsOneWidget);
+      // Prev disabled on page 1.
+      expect(
+          tester
+              .widget<IconButton>(inGroupsToolbar(iconButton('Previous page')))
+              .onPressed,
+          isNull);
+      // Next enabled.
+      expect(
+          tester
+              .widget<IconButton>(inGroupsToolbar(iconButton('Next page')))
+              .onPressed,
+          isNotNull);
+    });
+
+    testWidgets('navigates to next and previous pages', (tester) async {
+      var lastPageRequested = 1;
+      serveGroups((page, pageSize, sort, order, q) {
+        lastPageRequested = page;
+        final start = (page - 1) * pageSize;
+        return [
+          for (int i = start; i < start + pageSize && i < 15; i++)
+            _group('group$i'),
+        ];
+      }, total: 15);
+
+      await pumpGroupsTab(tester);
+
+      // 15 groups / 10 => 2 pages.
+      expect(inGroupsToolbar(find.text('1 / 2')), findsOneWidget);
+
+      await tester.tap(inGroupsToolbar(iconButton('Next page')));
+      await tester.pumpAndSettle();
+
+      expect(lastPageRequested, 2);
+      expect(inGroupsToolbar(find.text('2 / 2')), findsOneWidget);
+      expect(
+          tester
+              .widget<IconButton>(inGroupsToolbar(iconButton('Previous page')))
+              .onPressed,
+          isNotNull);
+
+      await tester.tap(inGroupsToolbar(iconButton('Previous page')));
+      await tester.pumpAndSettle();
+
+      expect(lastPageRequested, 1);
+      expect(inGroupsToolbar(find.text('1 / 2')), findsOneWidget);
+    });
+
+    testWidgets('sends sort and order params to the backend', (tester) async {
+      String? capturedSort;
+      String? capturedOrder;
+      testAuthHttpClientOverride = _mockClient((request) async {
+        if (request.url.path == '/api/v1/admin/users') {
+          return http.Response(_usersEnvelope([]), 200);
+        }
+        if (request.url.path == '/api/v1/admin/invitations') {
+          return http.Response(emptyInvitationsEnvelope(), 200);
+        }
+        if (request.url.path == '/api/v1/admin/groups') {
+          capturedSort = request.url.queryParameters['sort'];
+          capturedOrder = request.url.queryParameters['order'];
+          return http.Response(
+            _groupsEnvelope([_group('g')], total: 1),
+            200,
+          );
+        }
+        return http.Response('Not found', 404);
+      });
+
+      await pumpGroupsTab(tester);
+
+      // Defaults: name, ascending. The active Name chip shows ▲. Scope to
+      // the groups toolbar: the users/invitations toolbars are also built
+      // (offstage) inside the IndexedStack.
+      expect(capturedSort, 'name');
+      expect(capturedOrder, 'asc');
+      expect(inGroupsToolbar(find.text('Name ▲')), findsOneWidget);
+
+      // Tap the Created chip to switch sort (defaults to desc for created).
+      await tester.tap(inGroupsToolbar(find.text('Created')));
+      await tester.pumpAndSettle();
+
+      expect(capturedSort, 'created');
+      expect(capturedOrder, 'desc');
+      expect(inGroupsToolbar(find.text('Created ▼')), findsOneWidget);
+
+      // Tap Created again to flip direction to asc.
+      await tester.tap(inGroupsToolbar(find.text('Created ▼')));
+      await tester.pumpAndSettle();
+
+      expect(capturedOrder, 'asc');
+      expect(inGroupsToolbar(find.text('Created ▲')), findsOneWidget);
+    });
+
+    testWidgets('sends name filter query live (debounced)', (tester) async {
+      String? capturedQ;
+      testAuthHttpClientOverride = _mockClient((request) async {
+        if (request.url.path == '/api/v1/admin/users') {
+          return http.Response(_usersEnvelope([]), 200);
+        }
+        if (request.url.path == '/api/v1/admin/invitations') {
+          return http.Response(emptyInvitationsEnvelope(), 200);
+        }
+        if (request.url.path == '/api/v1/admin/groups') {
+          capturedQ = request.url.queryParameters['q'];
+          return http.Response(
+            _groupsEnvelope([_group('needle-group')], total: 1),
+            200,
+          );
+        }
+        return http.Response('Not found', 404);
+      });
+
+      await pumpGroupsTab(tester);
+
+      expect(capturedQ, isNull);
+
+      // The filter re-queries as the user types, debounced — settle past
+      // the debounce timer. Scope to the groups toolbar so we type into the
+      // groups filter, not the offstage users/invitations ones.
+      await tester.enterText(
+        inGroupsToolbar(find.byType(TextField)),
+        'needle',
+      );
+      await tester.pumpAndSettle();
+
+      expect(capturedQ, 'needle');
     });
   });
 }


### PR DESCRIPTION
## Summary

Server-side pagination, sorting, and filtering for the **groups tab** on `/admin/users`, mirroring the pattern shipped for users (#983) and invitations (#991). Closes #949.

The groups tab previously rendered all groups in a single unbounded `ListView.builder`. It now fetches 10-item pages from the backend with sort and filter controls, consistent with the sibling tabs.

## Changes

### Backend
- **`model.py`** — `list_groups()` now accepts `page`, `page_size`, `sort`, `order`, `q` and returns a paged envelope `{groups, page, page_size, total}`. Default sort `name`/`asc`. Sort column validated via an allowlist (`_ADMIN_GROUP_SORT_COLUMNS`); invalid values fall back to the default.
- **`api.py`** — Admin `GET /admin/groups` passes the query params to the model and returns the paged envelope. The non-admin `GET /groups` endpoint unwraps to the bare list (`page_size=200`) to preserve backward compatibility — only the admin endpoint returns the full envelope.

### Frontend
- **`admin_users_page.dart`** — Groups tab rebuilt on the shared `_AdminListToolbar` introduced by #991: columns `Name`/`Created` (asc/desc sort chips), a `Filter by name…` field with debounced live search (300ms), and prev/next page controls with a page indicator. Per-page state (`_groupsPage`, `_groupsTotal`, `_groupsSort`, `_groupsOrder`, `_groupsQuery`) drives `_loadGroups()`.
- **`acl_editor.dart`** — Unwrap the `{groups}`/`{users}` envelopes in both fetches (the groups fetch was required by this change; the users fetch was a pre-existing latent bug from #983).

### Tests
- **Backend** (`test_api.py`) — updated `test_list_groups` for the envelope; added 6 tests (default page size, cross-page navigation, sort by name, sort desc, name filter, invalid-sort fallback). e2e callers updated to unwrap `["groups"]`.
- **Frontend** (`admin_users_page_test.dart`) — added a groups-tab test group (renders, pagination controls, next/prev navigation, sort/order params, debounced name filter), scoped to the groups toolbar key. No e2e changes needed (`api.spec.ts` consumes the create response + members endpoints).

## Notes
- Defaults match prior behavior: groups sort `name`/`asc` (was `ORDER BY name`); the sibling users tab defaults to `created`/`desc`.
- `admin_users_page.dart` is `coverage:ignore-file`, so the coverage gate is unaffected.

## Test results
- Backend (full): **1833 passed**
- Frontend unit (full): **678 passed**
- Frontend e2e `api.spec.ts`: **18 passed**
