### PR TITLE
fix(backend): use dynamic versioning so uv sync reinstalls entry points

### DIFF
--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "klangk-backend"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Klangk backend: multi-user Pi coding agent web REPL"
 requires-python = ">=3.12"
 dependencies = [
@@ -35,9 +35,16 @@ addopts = "--capture=no --cov=klangk_backend --cov-report=term-missing --no-cov-
 [tool.ruff]
 line-length = 79
 
+[tool.hatch.version]
+source = "vcs"
+fallback-version = "0.0.0.dev0"
+raw-options.root = "../.."
+raw-options.tag_regex = "^v(?P<version>[vV]?\\d+(?:\\.\\d+){0,2}[^\\+]*)(?:\\+.*)?$"
+raw-options.git_describe_command = ["git", "describe", "--dirty", "--tags", "--long", "--match", "v*"]
+
 [tool.hatch.build.targets.wheel]
 packages = ["klangk_backend"]
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"

--- a/uv.lock
+++ b/uv.lock
@@ -629,7 +629,6 @@ wheels = [
 
 [[package]]
 name = "klangk-backend"
-version = "0.1.0"
 source = { editable = "src/backend" }
 dependencies = [
     { name = "aiosmtplib" },


### PR DESCRIPTION
## Summary

- Replace static `version = "0.1.0"` with `hatch-vcs` dynamic versioning (matching the CLI package pattern but using `v*` tags)
- This ensures `uv sync` detects changes and reinstalls `klangk-backend`, writing new entry points like `klangk-resolve-value` into `venv/bin/`
- Also deleted stale local `v0.test.1` tag that produced invalid PEP 440 versions

Closes #997

## Test plan

- [x] Backend tests pass (1833 passed, 100% coverage)
- [x] `klangk-resolve-value` appears in `venv/bin/` after `devenv shell`
- [x] `klangk-resolve-value 'test-value'` returns `test-value`