### PR TITLE
refactor(frontend): extract chat sub-widgets from WorkspaceChatState (#969)

### DIFF
--- a/src/frontend/lib/chat/agent_thinking_indicator.dart
+++ b/src/frontend/lib/chat/agent_thinking_indicator.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import '../theme/colors.dart';
+
+/// Animated indicator shown when the agent is processing a request.
+class AgentThinkingIndicator extends StatelessWidget {
+  final String agentName;
+
+  const AgentThinkingIndicator({
+    super.key,
+    required this.agentName,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      child: Row(
+        children: [
+          const SizedBox(
+            width: 12,
+            height: 12,
+            child: CircularProgressIndicator(
+              strokeWidth: 1.5,
+              color: KColors.accentCyan,
+            ),
+          ),
+          const SizedBox(width: 8),
+          Text(
+            '$agentName is thinking...',
+            style: TextStyle(
+              color: KColors.textMuted,
+              fontSize: 12,
+              fontStyle: FontStyle.italic,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/src/frontend/lib/chat/chat_input_bar.dart
+++ b/src/frontend/lib/chat/chat_input_bar.dart
@@ -1,0 +1,397 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart'
+    show HardwareKeyboard, KeyDownEvent, KeyRepeatEvent, LogicalKeyboardKey;
+import '../theme/colors.dart';
+
+/// Chat text input with send/abort buttons, @mention autocomplete,
+/// emacs keybindings, and sent-message history recall.
+class ChatInputBar extends StatefulWidget {
+  final VoidCallback onSend;
+  final ValueChanged<String> onSendText;
+  final bool agentThinking;
+  final VoidCallback? onAbort;
+  final List<Map<String, dynamic>> members;
+
+  const ChatInputBar({
+    super.key,
+    required this.onSend,
+    required this.onSendText,
+    this.agentThinking = false,
+    this.onAbort,
+    this.members = const [],
+  });
+
+  @override
+  State<ChatInputBar> createState() => ChatInputBarState();
+}
+
+class ChatInputBarState extends State<ChatInputBar> {
+  final _textController = TextEditingController();
+  final _inputFocusNode = FocusNode(debugLabel: 'workspace-chat-input');
+  final _inputKey = GlobalKey();
+
+  // Sent message history (for Up/Down recall)
+  final List<String> _sentHistory = [];
+  int _historyIndex = -1;
+  String _savedDraft = '';
+
+  // Autocomplete state
+  OverlayEntry? _autocompleteOverlay;
+  List<Map<String, dynamic>> _filteredMembers = [];
+  int _highlightedIndex = 0;
+  String _mentionQuery = '';
+
+  @override
+  void initState() {
+    super.initState();
+    _textController.addListener(_onTextChanged);
+    _inputFocusNode.onKeyEvent = _handleKeyEvent;
+  }
+
+  /// Focuses the message input.
+  void requestFocus() => _inputFocusNode.requestFocus();
+
+  // --- Autocomplete ---
+
+  void _onTextChanged() {
+    final text = _textController.text;
+    final cursor = _textController.selection.baseOffset;
+    if (cursor < 0 || cursor > text.length) {
+      _hideAutocomplete();
+      return;
+    }
+    final before = text.substring(0, cursor);
+    final atIdx = before.lastIndexOf('@');
+    if (atIdx < 0 ||
+        (atIdx > 0 && before[atIdx - 1] != ' ' && before[atIdx - 1] != '\n')) {
+      _hideAutocomplete();
+      return;
+    }
+    final query = before.substring(atIdx + 1);
+    if (query.contains(' ') || query.contains('\n')) {
+      _hideAutocomplete();
+      return;
+    }
+    _mentionQuery = query.toLowerCase();
+    _showAutocomplete();
+  }
+
+  void _showAutocomplete() {
+    _filteredMembers = widget.members.where((m) {
+      final email = (m['email'] as String? ?? '').toLowerCase();
+      final handle = (m['handle'] as String? ?? '').toLowerCase();
+      return handle.contains(_mentionQuery) || email.contains(_mentionQuery);
+    }).toList();
+    if (_filteredMembers.isEmpty) {
+      _hideAutocomplete();
+      return;
+    }
+    if (_highlightedIndex >= _filteredMembers.length) {
+      _highlightedIndex = 0;
+    }
+    _autocompleteOverlay?.remove();
+    _autocompleteOverlay = OverlayEntry(
+      builder: (context) {
+        final renderBox =
+            _inputKey.currentContext?.findRenderObject() as RenderBox?;
+        if (renderBox == null) return const SizedBox.shrink();
+        final offset = renderBox.localToGlobal(Offset.zero);
+        final visibleCount =
+            _filteredMembers.length > 5 ? 5 : _filteredMembers.length;
+        final height = visibleCount * 36.0;
+        return Positioned(
+          left: offset.dx,
+          top: offset.dy - height - 4,
+          width: renderBox.size.width,
+          child: Material(
+            elevation: 4,
+            color: KColors.bgSurface,
+            borderRadius: BorderRadius.circular(6),
+            child: ConstrainedBox(
+              constraints: BoxConstraints(maxHeight: height),
+              child: ListView.builder(
+                padding: EdgeInsets.zero,
+                shrinkWrap: true,
+                itemCount: visibleCount,
+                itemBuilder: (ctx, i) {
+                  final handle = _filteredMembers[i]['handle'] as String? ?? '';
+                  final email = _filteredMembers[i]['email'] as String? ?? '';
+                  final displayName = handle.isNotEmpty ? handle : email;
+                  final isHighlighted = i == _highlightedIndex;
+                  return InkWell(
+                    onTap: () => _insertMention(displayName),
+                    child: Container(
+                      color: isHighlighted
+                          ? KColors.bgOverlay
+                          : Colors.transparent,
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 12,
+                        vertical: 8,
+                      ),
+                      child: Text(
+                        displayName,
+                        style: const TextStyle(
+                          color: KColors.textPrimary,
+                          fontSize: 13,
+                        ),
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ),
+        );
+      },
+    );
+    Overlay.of(context).insert(_autocompleteOverlay!);
+  }
+
+  void _acceptHighlightedSuggestion() {
+    if (_filteredMembers.isEmpty) return;
+    final idx = _highlightedIndex.clamp(0, _filteredMembers.length - 1);
+    final handle = _filteredMembers[idx]['handle'] as String? ?? '';
+    final email = _filteredMembers[idx]['email'] as String? ?? '';
+    _insertMention(handle.isNotEmpty ? handle : email);
+  }
+
+  KeyEventResult _handleKeyEvent(FocusNode node, KeyEvent event) {
+    if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
+      return KeyEventResult.ignored;
+    }
+
+    final isShift = HardwareKeyboard.instance.isShiftPressed;
+
+    // When autocomplete is visible, intercept navigation keys
+    if (_autocompleteOverlay != null) {
+      if (event.logicalKey == LogicalKeyboardKey.tab) {
+        _acceptHighlightedSuggestion();
+        return KeyEventResult.handled;
+      }
+      if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
+        final maxIdx =
+            (_filteredMembers.length > 5 ? 5 : _filteredMembers.length) - 1;
+        _highlightedIndex = (_highlightedIndex + 1).clamp(0, maxIdx);
+        _autocompleteOverlay?.markNeedsBuild();
+        return KeyEventResult.handled;
+      }
+      if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+        _highlightedIndex = (_highlightedIndex - 1).clamp(
+          0,
+          _filteredMembers.length - 1,
+        );
+        _autocompleteOverlay?.markNeedsBuild();
+        return KeyEventResult.handled;
+      }
+      if (event.logicalKey == LogicalKeyboardKey.enter && !isShift) {
+        _acceptHighlightedSuggestion();
+        return KeyEventResult.handled;
+      }
+      if (event.logicalKey == LogicalKeyboardKey.escape) {
+        _hideAutocomplete();
+        return KeyEventResult.handled;
+      }
+    }
+
+    // Enter (without Shift) sends the message; Shift+Enter inserts a newline
+    if (event.logicalKey == LogicalKeyboardKey.enter && !isShift) {
+      _sendMessage();
+      return KeyEventResult.handled;
+    }
+
+    // Up arrow on first line → recall previous sent message
+    if (event.logicalKey == LogicalKeyboardKey.arrowUp &&
+        _sentHistory.isNotEmpty) {
+      final text = _textController.text;
+      final cursor = _textController.selection.baseOffset;
+      final onFirstLine =
+          cursor >= 0 && !text.substring(0, cursor).contains('\n');
+      if (onFirstLine) {
+        if (_historyIndex == -1) {
+          _savedDraft = text;
+          _historyIndex = _sentHistory.length - 1;
+        } else if (_historyIndex > 0) {
+          _historyIndex--;
+        }
+        _textController.text = _sentHistory[_historyIndex];
+        _textController.selection = TextSelection.collapsed(
+          offset: _textController.text.length,
+        );
+        return KeyEventResult.handled;
+      }
+    }
+
+    // Down arrow on last line → recall next sent message or restore draft
+    if (event.logicalKey == LogicalKeyboardKey.arrowDown &&
+        _historyIndex >= 0) {
+      final text = _textController.text;
+      final cursor = _textController.selection.baseOffset;
+      final onLastLine = cursor >= 0 && !text.substring(cursor).contains('\n');
+      if (onLastLine) {
+        if (_historyIndex < _sentHistory.length - 1) {
+          _historyIndex++;
+          _textController.text = _sentHistory[_historyIndex];
+        } else {
+          _historyIndex = -1;
+          _textController.text = _savedDraft;
+        }
+        _textController.selection = TextSelection.collapsed(
+          offset: _textController.text.length,
+        );
+        return KeyEventResult.handled;
+      }
+    }
+
+    final isCtrl = HardwareKeyboard.instance.isControlPressed;
+
+    // Shift+Ctrl+A → select all text
+    if (isCtrl && isShift && event.logicalKey == LogicalKeyboardKey.keyA) {
+      _textController.selection = TextSelection(
+        baseOffset: 0,
+        extentOffset: _textController.text.length,
+      );
+      return KeyEventResult.handled;
+    }
+
+    // Ctrl+A → move cursor to beginning of current line (emacs-style)
+    if (isCtrl && event.logicalKey == LogicalKeyboardKey.keyA) {
+      final text = _textController.text;
+      final cursor = _textController.selection.baseOffset;
+      if (cursor >= 0) {
+        final lineStart = text.lastIndexOf('\n', cursor - 1) + 1;
+        _textController.selection = TextSelection.collapsed(offset: lineStart);
+      }
+      return KeyEventResult.handled;
+    }
+
+    // Ctrl+E → move cursor to end of current line (emacs-style)
+    if (isCtrl && event.logicalKey == LogicalKeyboardKey.keyE) {
+      final text = _textController.text;
+      final cursor = _textController.selection.baseOffset;
+      if (cursor >= 0) {
+        var lineEnd = text.indexOf('\n', cursor);
+        if (lineEnd < 0) lineEnd = text.length;
+        _textController.selection = TextSelection.collapsed(offset: lineEnd);
+      }
+      return KeyEventResult.handled;
+    }
+
+    // Ctrl+K → kill from cursor to end of current line (emacs-style)
+    if (isCtrl && event.logicalKey == LogicalKeyboardKey.keyK) {
+      final text = _textController.text;
+      final cursor = _textController.selection.baseOffset;
+      if (cursor >= 0) {
+        var lineEnd = text.indexOf('\n', cursor);
+        if (lineEnd < 0) {
+          lineEnd = text.length;
+        } else if (lineEnd == cursor) {
+          lineEnd = cursor + 1;
+        }
+        final newText = text.substring(0, cursor) + text.substring(lineEnd);
+        _textController.value = TextEditingValue(
+          text: newText,
+          selection: TextSelection.collapsed(offset: cursor),
+        );
+      }
+      return KeyEventResult.handled;
+    }
+
+    return KeyEventResult.ignored;
+  }
+
+  void _hideAutocomplete() {
+    _autocompleteOverlay?.remove();
+    _autocompleteOverlay = null;
+    _filteredMembers = [];
+    _highlightedIndex = 0;
+  }
+
+  void _insertMention(String email) {
+    final text = _textController.text;
+    final cursor = _textController.selection.baseOffset;
+    final before = text.substring(0, cursor);
+    final atIdx = before.lastIndexOf('@');
+    final after = text.substring(cursor);
+    final newText = '${text.substring(0, atIdx)}@$email $after';
+    _textController.value = TextEditingValue(
+      text: newText,
+      selection: TextSelection.collapsed(
+        offset: atIdx + email.length + 2,
+      ),
+    );
+    _hideAutocomplete();
+    _inputFocusNode.requestFocus();
+  }
+
+  void _sendMessage() {
+    final text = _textController.text.trim();
+    if (text.isEmpty) return;
+    _hideAutocomplete();
+    _sentHistory.add(text);
+    _historyIndex = -1;
+    _savedDraft = '';
+    widget.onSendText(text);
+    _textController.clear();
+    _inputFocusNode.requestFocus();
+  }
+
+  @override
+  void dispose() {
+    _hideAutocomplete();
+    _textController.removeListener(_onTextChanged);
+    _textController.dispose();
+    _inputFocusNode.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      key: _inputKey,
+      decoration: const BoxDecoration(
+        border: Border(top: BorderSide(color: KColors.borderDefault)),
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      child: Row(
+        children: [
+          Expanded(
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxHeight: 120),
+              child: TextField(
+                controller: _textController,
+                focusNode: _inputFocusNode,
+                maxLines: null,
+                style: const TextStyle(
+                  color: KColors.textPrimary,
+                  fontSize: 13,
+                ),
+                decoration: const InputDecoration(
+                  hintText: 'Type a message...',
+                  hintStyle: TextStyle(color: KColors.textMuted),
+                  border: InputBorder.none,
+                  isDense: true,
+                  contentPadding: EdgeInsets.symmetric(
+                    vertical: 8,
+                    horizontal: 8,
+                  ),
+                ),
+              ),
+            ),
+          ),
+          if (widget.agentThinking)
+            IconButton(
+              icon: const Icon(Icons.stop_circle_outlined, size: 18),
+              color: KColors.accentRed,
+              tooltip: 'Stop agent',
+              onPressed: widget.onAbort,
+            ),
+          IconButton(
+            icon: const Icon(Icons.send, size: 18),
+            color: KColors.accentBlue,
+            onPressed: _sendMessage,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/src/frontend/lib/chat/chat_input_bar.dart
+++ b/src/frontend/lib/chat/chat_input_bar.dart
@@ -6,7 +6,6 @@ import '../theme/colors.dart';
 /// Chat text input with send/abort buttons, @mention autocomplete,
 /// emacs keybindings, and sent-message history recall.
 class ChatInputBar extends StatefulWidget {
-  final VoidCallback onSend;
   final ValueChanged<String> onSendText;
   final bool agentThinking;
   final VoidCallback? onAbort;
@@ -14,7 +13,6 @@ class ChatInputBar extends StatefulWidget {
 
   const ChatInputBar({
     super.key,
-    required this.onSend,
     required this.onSendText,
     this.agentThinking = false,
     this.onAbort,

--- a/src/frontend/lib/chat/chat_message_list.dart
+++ b/src/frontend/lib/chat/chat_message_list.dart
@@ -1,0 +1,471 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
+import 'package:markdown/markdown.dart' as md;
+import '../theme/colors.dart';
+import '../utils/web_helpers_stub.dart'
+    if (dart.library.js_interop) '../utils/web_helpers_web.dart';
+
+/// Scrollable list of chat messages with load-more and collapsible long
+/// messages.
+class ChatMessageList extends StatelessWidget {
+  final List<Map<String, dynamic>> messages;
+  final ScrollController scrollController;
+  final String? currentUserId;
+  final bool loadingOlder;
+  final Set<String> expandedMessages;
+  final ValueChanged<String> onToggleExpand;
+  final ValueChanged<String> onDelete;
+
+  const ChatMessageList({
+    super.key,
+    required this.messages,
+    required this.scrollController,
+    this.currentUserId,
+    this.loadingOlder = false,
+    required this.expandedMessages,
+    required this.onToggleExpand,
+    required this.onDelete,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: messages.isEmpty
+          ? const Center(
+              child: Text(
+                'No messages yet',
+                style: TextStyle(color: KColors.textMuted),
+              ),
+            )
+          : ListView.builder(
+              controller: scrollController,
+              padding: const EdgeInsets.symmetric(
+                horizontal: 12,
+                vertical: 8,
+              ),
+              itemCount: messages.length + (loadingOlder ? 1 : 0),
+              itemBuilder: (context, index) {
+                if (loadingOlder && index == 0) {
+                  return const Padding(
+                    padding: EdgeInsets.symmetric(vertical: 8),
+                    child: Center(
+                      child: SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      ),
+                    ),
+                  );
+                }
+                final msgIndex = loadingOlder ? index - 1 : index;
+                return _buildMessageItem(context, messages[msgIndex]);
+              },
+            ),
+    );
+  }
+
+  Widget _buildMessageItem(BuildContext context, Map<String, dynamic> msg) {
+    final handle = msg['user_handle'] as String?;
+    final email = msg['user_email'] as String? ?? '';
+    final senderName = (handle != null && handle.isNotEmpty) ? handle : email;
+    final text = msg['message'] as String? ?? '';
+    final createdAt = formatTime(msg['created_at'] as String? ?? '');
+    final msgUserId = msg['user_id'] as String?;
+    final isOwn = msgUserId != null && msgUserId == currentUserId;
+    final isDeleted = text == '<message deleted by author>';
+    final messageType = msg['message_type'] as int? ?? 0;
+
+    if (messageType == 2 && isOwn) {
+      return const SizedBox.shrink();
+    }
+
+    if (messageType == 2) {
+      return _buildSystemMessage(text);
+    }
+
+    return _buildMessageRow(
+      context,
+      msg: msg,
+      senderName: senderName,
+      text: text,
+      createdAt: createdAt,
+      isAgent: messageType == 1,
+      isOwn: isOwn,
+      isDeleted: isDeleted,
+    );
+  }
+
+  Widget _buildSystemMessage(String text) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: Row(
+        children: [
+          const Expanded(
+            child: Divider(color: KColors.borderMuted, height: 1),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8),
+            child: Text(
+              text,
+              style: const TextStyle(
+                color: KColors.textMuted,
+                fontSize: 10,
+              ),
+            ),
+          ),
+          const Expanded(
+            child: Divider(color: KColors.borderMuted, height: 1),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMessageRow(
+    BuildContext context, {
+    required Map<String, dynamic> msg,
+    required String senderName,
+    required String text,
+    required String createdAt,
+    required bool isAgent,
+    required bool isOwn,
+    required bool isDeleted,
+  }) {
+    return Container(
+      margin: const EdgeInsets.only(bottom: 6),
+      padding: isAgent ? const EdgeInsets.only(left: 8) : EdgeInsets.zero,
+      decoration: isAgent
+          ? const BoxDecoration(
+              border: Border(
+                left: BorderSide(color: KColors.accentCyan, width: 2),
+              ),
+            )
+          : null,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (isAgent)
+            const Padding(
+              padding: EdgeInsets.only(right: 6, top: 1),
+              child: Icon(
+                Icons.smart_toy,
+                size: 14,
+                color: KColors.accentCyan,
+              ),
+            ),
+          Expanded(
+            child: _CollapsibleMessage(
+              messageId: msg['id'] as String? ?? '',
+              isExpanded: expandedMessages.contains(msg['id']),
+              onToggle: () => onToggleExpand(msg['id'] as String? ?? ''),
+              child: _buildMessageContent(
+                context,
+                senderName: senderName,
+                text: text,
+                isAgent: isAgent,
+                isDeleted: isDeleted,
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
+          Text(
+            createdAt,
+            style: const TextStyle(
+              color: KColors.textMuted,
+              fontSize: 11,
+            ),
+          ),
+          if (isOwn && !isDeleted)
+            GestureDetector(
+              onTap: () => onDelete(msg['id'] as String),
+              child: const Padding(
+                padding: EdgeInsets.only(left: 4),
+                child: Icon(
+                  Icons.close,
+                  size: 14,
+                  color: KColors.textMuted,
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMessageContent(
+    BuildContext context, {
+    required String senderName,
+    required String text,
+    required bool isAgent,
+    required bool isDeleted,
+  }) {
+    final nameColor =
+        isAgent ? KColors.accentCyan : KColors.colorForString(senderName);
+
+    if (isDeleted) {
+      return Text.rich(
+        TextSpan(
+          children: [
+            TextSpan(
+              text: '$senderName  ',
+              style: TextStyle(
+                fontWeight: FontWeight.bold,
+                color: nameColor,
+                fontSize: 13,
+              ),
+            ),
+            TextSpan(
+              text: text,
+              style: const TextStyle(
+                color: KColors.textMuted,
+                fontSize: 13,
+                fontStyle: FontStyle.italic,
+              ),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          senderName,
+          style: TextStyle(
+            fontWeight: FontWeight.bold,
+            color: nameColor,
+            fontSize: 13,
+          ),
+        ),
+        MarkdownBody(
+          data: highlightMentions(text),
+          selectable: true,
+          extensionSet: md.ExtensionSet(
+            md.ExtensionSet.gitHubWeb.blockSyntaxes,
+            [
+              ...md.ExtensionSet.gitHubWeb.inlineSyntaxes.where(
+                (s) =>
+                    s is! md.AutolinkSyntax && s is! md.AutolinkExtensionSyntax,
+              ),
+            ],
+          ),
+          styleSheet: chatMarkdownStyle(context),
+          // coverage:ignore-start
+          onTapLink: (text, href, title) {
+            if (href != null && href.isNotEmpty) {
+              openUrl(href);
+            }
+          },
+          // coverage:ignore-end
+        ),
+      ],
+    );
+  }
+
+  // --- Static helpers (public for testing) ---
+
+  static String formatTime(String raw) {
+    if (raw.isEmpty) return '';
+    try {
+      final utc = DateTime.parse('${raw}Z');
+      final local = utc.toLocal();
+      final now = DateTime.now();
+      final diff = now.difference(local);
+
+      final hh = local.hour.toString().padLeft(2, '0');
+      final mm = local.minute.toString().padLeft(2, '0');
+      final time = '$hh:$mm';
+
+      if (diff.inDays == 0 && local.day == now.day) {
+        return time;
+      }
+      if (diff.inDays < 7) {
+        const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+        return '${days[local.weekday - 1]} $time';
+      }
+      return '${local.month}/${local.day} $time';
+    } catch (e) {
+      // coverage:ignore-start
+      debugPrint('[ChatMessageList] format time failed: $e');
+      return raw;
+    } // coverage:ignore-end
+  }
+
+  static final _mentionRegex = RegExp(r'@(\S+)');
+
+  static String highlightMentions(String text) {
+    return text.replaceAllMapped(_mentionRegex, (m) {
+      return '**${m.group(0)}**';
+    });
+  }
+
+  static MarkdownStyleSheet chatMarkdownStyle(BuildContext context) {
+    const baseText = TextStyle(color: KColors.textPrimary, fontSize: 13);
+    return MarkdownStyleSheet(
+      p: baseText,
+      pPadding: EdgeInsets.zero,
+      a: baseText.copyWith(
+        color: KColors.accentBlue,
+        decoration: TextDecoration.underline,
+      ),
+      strong: baseText.copyWith(fontWeight: FontWeight.bold),
+      em: baseText.copyWith(fontStyle: FontStyle.italic),
+      code: baseText.copyWith(
+        backgroundColor: KColors.bgOverlay,
+        fontFamily: 'JetBrains Mono',
+        fontSize: 12,
+      ),
+      codeblockDecoration: BoxDecoration(
+        color: KColors.bgOverlay,
+        borderRadius: BorderRadius.circular(4),
+      ),
+      codeblockPadding: const EdgeInsets.all(8),
+      blockSpacing: 4,
+      listBullet: baseText,
+      blockquoteDecoration: BoxDecoration(
+        border: Border(
+          left: BorderSide(color: KColors.borderDefault, width: 3),
+        ),
+      ),
+      blockquotePadding: const EdgeInsets.only(left: 8),
+      blockquote: baseText.copyWith(color: KColors.textSecondary),
+    );
+  }
+}
+
+/// Truncates long messages to ~3 lines with a "show more" / "show less" toggle.
+class _CollapsibleMessage extends StatelessWidget {
+  const _CollapsibleMessage({
+    required this.messageId,
+    required this.isExpanded,
+    required this.onToggle,
+    required this.child,
+  });
+
+  final String messageId;
+  final bool isExpanded;
+  final VoidCallback onToggle;
+  final Widget child;
+
+  static const _collapsedMaxHeight = 60.0;
+
+  @override
+  Widget build(BuildContext context) {
+    if (isExpanded) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          child,
+          ExcludeFocus(
+            child: GestureDetector(
+              onTap: onToggle,
+              child: MouseRegion(
+                cursor: SystemMouseCursors.click,
+                child: const Padding(
+                  padding: EdgeInsets.only(top: 2),
+                  child: Text(
+                    'show less',
+                    style: TextStyle(color: KColors.accentBlue, fontSize: 12),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      );
+    }
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return _MeasuredCollapse(
+          maxHeight: _collapsedMaxHeight,
+          onToggle: onToggle,
+          child: child,
+        );
+      },
+    );
+  }
+}
+
+/// Measures the child's height and shows a "show more" link if it overflows.
+class _MeasuredCollapse extends StatefulWidget {
+  const _MeasuredCollapse({
+    required this.maxHeight,
+    required this.onToggle,
+    required this.child,
+  });
+
+  final double maxHeight;
+  final VoidCallback onToggle;
+  final Widget child;
+
+  @override
+  State<_MeasuredCollapse> createState() => _MeasuredCollapseState();
+}
+
+class _MeasuredCollapseState extends State<_MeasuredCollapse> {
+  bool _overflows = false;
+  final _childKey = GlobalKey();
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _checkOverflow());
+  }
+
+  @override
+  void didUpdateWidget(_MeasuredCollapse oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    WidgetsBinding.instance.addPostFrameCallback((_) => _checkOverflow());
+  }
+
+  void _checkOverflow() {
+    final renderBox =
+        _childKey.currentContext?.findRenderObject() as RenderBox?;
+    if (renderBox == null || !mounted) return;
+    final childHeight = renderBox.size.height;
+    final overflows = childHeight > widget.maxHeight;
+    if (overflows != _overflows) {
+      setState(() => _overflows = overflows);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (_overflows)
+          SizedBox(
+            height: widget.maxHeight,
+            child: ClipRect(
+              child: OverflowBox(
+                alignment: Alignment.topLeft,
+                maxHeight: double.infinity,
+                child: KeyedSubtree(key: _childKey, child: widget.child),
+              ),
+            ),
+          )
+        else
+          KeyedSubtree(key: _childKey, child: widget.child),
+        if (_overflows)
+          ExcludeFocus(
+            child: GestureDetector(
+              onTap: widget.onToggle,
+              child: MouseRegion(
+                cursor: SystemMouseCursors.click,
+                child: const Padding(
+                  padding: EdgeInsets.only(top: 2),
+                  child: Text(
+                    '…show more',
+                    style: TextStyle(color: KColors.accentBlue, fontSize: 12),
+                  ),
+                ),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/src/frontend/lib/chat/chat_presence_bar.dart
+++ b/src/frontend/lib/chat/chat_presence_bar.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import '../theme/colors.dart';
+
+/// Compact presence bar showing connected user avatars.
+class ChatPresenceBar extends StatelessWidget {
+  final List<Map<String, dynamic>> users;
+  final String? currentUserId;
+
+  const ChatPresenceBar({
+    super.key,
+    required this.users,
+    this.currentUserId,
+  });
+
+  static Color _colorForEmail(String email) => KColors.colorForString(email);
+
+  @override
+  Widget build(BuildContext context) {
+    if (users.isEmpty) return const SizedBox.shrink();
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+      decoration: const BoxDecoration(
+        color: KColors.bgAppBar,
+        border: Border(bottom: BorderSide(color: KColors.borderMuted)),
+      ),
+      child: Row(
+        children: [
+          Container(
+            width: 6,
+            height: 6,
+            margin: const EdgeInsets.only(right: 6),
+            decoration: const BoxDecoration(
+              shape: BoxShape.circle,
+              color: KColors.accentGreen,
+            ),
+          ),
+          ...users.map((u) {
+            final email = u['user_email'] as String? ?? '';
+            final handle = u['user_handle'] as String? ?? '';
+            final uid = u['user_id'] as String?;
+            final isSelf = uid == currentUserId;
+            final displayName = handle.isNotEmpty ? handle : email;
+            final initial =
+                displayName.isNotEmpty ? displayName[0].toUpperCase() : '?';
+            return Padding(
+              padding: const EdgeInsets.only(right: 4),
+              child: Tooltip(
+                message: displayName,
+                child: CircleAvatar(
+                  radius: 10,
+                  backgroundColor:
+                      isSelf ? Colors.transparent : _colorForEmail(email),
+                  foregroundColor:
+                      isSelf ? _colorForEmail(email) : Colors.white,
+                  child: isSelf
+                      ? DecoratedBox(
+                          decoration: BoxDecoration(
+                            shape: BoxShape.circle,
+                            border: Border.all(
+                              color: _colorForEmail(email),
+                              width: 1.5,
+                            ),
+                          ),
+                          child: Center(
+                            child: Text(
+                              initial,
+                              style: TextStyle(
+                                fontSize: 10,
+                                fontWeight: FontWeight.bold,
+                                color: _colorForEmail(email),
+                              ),
+                            ),
+                          ),
+                        )
+                      : Text(
+                          initial,
+                          style: const TextStyle(
+                            fontSize: 10,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                ),
+              ),
+            );
+          }),
+        ],
+      ),
+    );
+  }
+}

--- a/src/frontend/lib/chat/workspace_chat.dart
+++ b/src/frontend/lib/chat/workspace_chat.dart
@@ -245,7 +245,6 @@ class WorkspaceChatState extends State<WorkspaceChat> {
           if (_agentThinking) AgentThinkingIndicator(agentName: _agentName),
           ChatInputBar(
             key: _inputBarKey,
-            onSend: () {},
             onSendText: _onSendText,
             agentThinking: _agentThinking,
             onAbort: () => widget.wsClient.sendChatAgentAbort(),

--- a/src/frontend/lib/chat/workspace_chat.dart
+++ b/src/frontend/lib/chat/workspace_chat.dart
@@ -1,15 +1,13 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart'
-    show HardwareKeyboard, KeyDownEvent, KeyRepeatEvent, LogicalKeyboardKey;
-import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
-import 'package:markdown/markdown.dart' as md;
+import 'package:provider/provider.dart';
 import '../ws/ws_client.dart';
 import '../theme/colors.dart';
 import '../auth/auth_service.dart';
-import '../utils/web_helpers_stub.dart'
-    if (dart.library.js_interop) '../utils/web_helpers_web.dart';
-import 'package:provider/provider.dart';
+import 'agent_thinking_indicator.dart';
+import 'chat_input_bar.dart';
+import 'chat_message_list.dart';
+import 'chat_presence_bar.dart';
 
 /// Per-workspace real-time chat panel.
 class WorkspaceChat extends StatefulWidget {
@@ -35,8 +33,7 @@ class WorkspaceChat extends StatefulWidget {
 class WorkspaceChatState extends State<WorkspaceChat> {
   final List<Map<String, dynamic>> _messages = [];
   final _scrollController = ScrollController();
-  final _textController = TextEditingController();
-  final _inputFocusNode = FocusNode(debugLabel: 'workspace-chat-input');
+  final _inputBarKey = GlobalKey<ChatInputBarState>();
   StreamSubscription<Map<String, dynamic>>? _chatSub;
   StreamSubscription<Map<String, dynamic>>? _historyPageSub;
   int _unreadCount = 0;
@@ -51,32 +48,16 @@ class WorkspaceChatState extends State<WorkspaceChat> {
   // Expanded message IDs (for long message truncation)
   final Set<String> _expandedMessages = {};
 
-  // Sent message history (for Up/Down recall)
-  final List<String> _sentHistory = [];
-  int _historyIndex = -1;
-  String _savedDraft = '';
-
-  // Autocomplete state
-  OverlayEntry? _autocompleteOverlay;
-  List<Map<String, dynamic>> _filteredMembers = [];
-  int _highlightedIndex = 0;
-  String _mentionQuery = '';
-  final _inputKey = GlobalKey();
-
   @override
   void initState() {
     super.initState();
-    // Load any buffered history that arrived before this widget was created.
     if (widget.wsClient.chatHistory.isNotEmpty) {
       _messages.addAll(widget.wsClient.chatHistory);
     }
     _chatSub = widget.wsClient.chatMessages.listen(_onMessage);
     _historyPageSub = widget.wsClient.chatHistoryPages.listen(_onHistoryPage);
     _scrollController.addListener(_onScroll);
-    _textController.addListener(_onTextChanged);
     widget.wsClient.addListener(_onPresenceChanged);
-    _inputFocusNode.onKeyEvent = _handleKeyEvent;
-    // Scroll to bottom after initial history renders
     if (_messages.isNotEmpty) {
       _scrollToBottom();
     }
@@ -84,7 +65,7 @@ class WorkspaceChatState extends State<WorkspaceChat> {
 
   /// Focuses the message input. Called by the parent when the Chat tab is
   /// selected so the user can type immediately without an extra click.
-  void requestFocus() => _inputFocusNode.requestFocus();
+  void requestFocus() => _inputBarKey.currentState?.requestFocus();
 
   /// Called by the parent when this tab becomes visible/hidden.
   void setVisible(bool visible) {
@@ -148,7 +129,6 @@ class WorkspaceChatState extends State<WorkspaceChat> {
   }
 
   void _scrollToBottom() {
-    // Double post-frame to ensure layout is fully settled before jumping.
     WidgetsBinding.instance.addPostFrameCallback((_) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (_scrollController.hasClients) {
@@ -186,7 +166,6 @@ class WorkspaceChatState extends State<WorkspaceChat> {
       return;
     }
 
-    // Preserve scroll position: measure before prepending, restore after.
     final scrollBefore =
         _scrollController.hasClients ? _scrollController.position.pixels : 0.0;
     final maxBefore = _scrollController.hasClients
@@ -200,7 +179,6 @@ class WorkspaceChatState extends State<WorkspaceChat> {
       _hasMore = hasMore;
     });
 
-    // After rebuild, restore scroll so the view doesn't jump.
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (_scrollController.hasClients) {
         final maxAfter = _scrollController.position.maxScrollExtent;
@@ -210,537 +188,35 @@ class WorkspaceChatState extends State<WorkspaceChat> {
     });
   }
 
-  // --- Autocomplete ---
-
-  void _onTextChanged() {
-    final text = _textController.text;
-    final cursor = _textController.selection.baseOffset;
-    if (cursor < 0 || cursor > text.length) {
-      _hideAutocomplete();
-      return;
-    }
-    // Find the @ that starts the current mention token
-    final before = text.substring(0, cursor);
-    final atIdx = before.lastIndexOf('@');
-    if (atIdx < 0 ||
-        (atIdx > 0 && before[atIdx - 1] != ' ' && before[atIdx - 1] != '\n')) {
-      _hideAutocomplete();
-      return;
-    }
-    final query = before.substring(atIdx + 1);
-    if (query.contains(' ') || query.contains('\n')) {
-      _hideAutocomplete();
-      return;
-    }
-    _mentionQuery = query.toLowerCase();
-    _showAutocomplete();
-  }
-
-  void _showAutocomplete() {
-    final members = widget.wsClient.workspaceMembers;
-    _filteredMembers = members.where((m) {
-      final email = (m['email'] as String? ?? '').toLowerCase();
-      final handle = (m['handle'] as String? ?? '').toLowerCase();
-      return handle.contains(_mentionQuery) || email.contains(_mentionQuery);
-    }).toList();
-    if (_filteredMembers.isEmpty) {
-      _hideAutocomplete();
-      return;
-    }
-    // Clamp highlight index when the list shrinks
-    if (_highlightedIndex >= _filteredMembers.length) {
-      _highlightedIndex = 0;
-    }
-    _autocompleteOverlay?.remove();
-    _autocompleteOverlay = OverlayEntry(
-      builder: (context) {
-        final renderBox =
-            _inputKey.currentContext?.findRenderObject() as RenderBox?;
-        if (renderBox == null) return const SizedBox.shrink();
-        final offset = renderBox.localToGlobal(Offset.zero);
-        final visibleCount =
-            _filteredMembers.length > 5 ? 5 : _filteredMembers.length;
-        final height = visibleCount * 36.0;
-        return Positioned(
-          left: offset.dx,
-          top: offset.dy - height - 4,
-          width: renderBox.size.width,
-          child: Material(
-            elevation: 4,
-            color: KColors.bgSurface,
-            borderRadius: BorderRadius.circular(6),
-            child: ConstrainedBox(
-              constraints: BoxConstraints(maxHeight: height),
-              child: ListView.builder(
-                padding: EdgeInsets.zero,
-                shrinkWrap: true,
-                itemCount: visibleCount,
-                itemBuilder: (ctx, i) {
-                  final handle = _filteredMembers[i]['handle'] as String? ?? '';
-                  final email = _filteredMembers[i]['email'] as String? ?? '';
-                  final displayName = handle.isNotEmpty ? handle : email;
-                  final isHighlighted = i == _highlightedIndex;
-                  return InkWell(
-                    onTap: () => _insertMention(displayName),
-                    child: Container(
-                      color: isHighlighted
-                          ? KColors.bgOverlay
-                          : Colors.transparent,
-                      padding: const EdgeInsets.symmetric(
-                        horizontal: 12,
-                        vertical: 8,
-                      ),
-                      child: Text(
-                        displayName,
-                        style: const TextStyle(
-                          color: KColors.textPrimary,
-                          fontSize: 13,
-                        ),
-                      ),
-                    ),
-                  );
-                },
-              ),
-            ),
-          ),
-        );
-      },
-    );
-    Overlay.of(context).insert(_autocompleteOverlay!);
-  }
-
-  /// Accept the currently highlighted autocomplete suggestion.
-  void _acceptHighlightedSuggestion() {
-    if (_filteredMembers.isEmpty) return;
-    final idx = _highlightedIndex.clamp(0, _filteredMembers.length - 1);
-    final handle = _filteredMembers[idx]['handle'] as String? ?? '';
-    final email = _filteredMembers[idx]['email'] as String? ?? '';
-    _insertMention(handle.isNotEmpty ? handle : email);
-  }
-
-  /// Handle keyboard events for autocomplete navigation and message sending.
-  KeyEventResult _handleKeyEvent(FocusNode node, KeyEvent event) {
-    if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
-      return KeyEventResult.ignored;
-    }
-
-    final isShift = HardwareKeyboard.instance.isShiftPressed;
-
-    // When autocomplete is visible, intercept navigation keys
-    if (_autocompleteOverlay != null) {
-      if (event.logicalKey == LogicalKeyboardKey.tab) {
-        _acceptHighlightedSuggestion();
-        return KeyEventResult.handled;
-      }
-      if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
-        final maxIdx =
-            (_filteredMembers.length > 5 ? 5 : _filteredMembers.length) - 1;
-        _highlightedIndex = (_highlightedIndex + 1).clamp(0, maxIdx);
-        _autocompleteOverlay?.markNeedsBuild();
-        return KeyEventResult.handled;
-      }
-      if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
-        _highlightedIndex = (_highlightedIndex - 1).clamp(
-          0,
-          _filteredMembers.length - 1,
-        );
-        _autocompleteOverlay?.markNeedsBuild();
-        return KeyEventResult.handled;
-      }
-      if (event.logicalKey == LogicalKeyboardKey.enter && !isShift) {
-        _acceptHighlightedSuggestion();
-        return KeyEventResult.handled;
-      }
-      if (event.logicalKey == LogicalKeyboardKey.escape) {
-        _hideAutocomplete();
-        return KeyEventResult.handled;
-      }
-    }
-
-    // Enter (without Shift) sends the message; Shift+Enter inserts a newline
-    if (event.logicalKey == LogicalKeyboardKey.enter && !isShift) {
-      _sendMessage();
-      return KeyEventResult.handled;
-    }
-
-    // Up arrow on first line → recall previous sent message
-    if (event.logicalKey == LogicalKeyboardKey.arrowUp &&
-        _sentHistory.isNotEmpty) {
-      final text = _textController.text;
-      final cursor = _textController.selection.baseOffset;
-      final onFirstLine =
-          cursor >= 0 && !text.substring(0, cursor).contains('\n');
-      if (onFirstLine) {
-        if (_historyIndex == -1) {
-          _savedDraft = text;
-          _historyIndex = _sentHistory.length - 1;
-        } else if (_historyIndex > 0) {
-          _historyIndex--;
-        }
-        _textController.text = _sentHistory[_historyIndex];
-        _textController.selection = TextSelection.collapsed(
-          offset: _textController.text.length,
-        );
-        return KeyEventResult.handled;
-      }
-    }
-
-    // Down arrow on last line → recall next sent message or restore draft
-    if (event.logicalKey == LogicalKeyboardKey.arrowDown &&
-        _historyIndex >= 0) {
-      final text = _textController.text;
-      final cursor = _textController.selection.baseOffset;
-      final onLastLine = cursor >= 0 && !text.substring(cursor).contains('\n');
-      if (onLastLine) {
-        if (_historyIndex < _sentHistory.length - 1) {
-          _historyIndex++;
-          _textController.text = _sentHistory[_historyIndex];
-        } else {
-          _historyIndex = -1;
-          _textController.text = _savedDraft;
-        }
-        _textController.selection = TextSelection.collapsed(
-          offset: _textController.text.length,
-        );
-        return KeyEventResult.handled;
-      }
-    }
-
-    final isCtrl = HardwareKeyboard.instance.isControlPressed;
-
-    // Shift+Ctrl+A → select all text
-    if (isCtrl && isShift && event.logicalKey == LogicalKeyboardKey.keyA) {
-      _textController.selection = TextSelection(
-        baseOffset: 0,
-        extentOffset: _textController.text.length,
-      );
-      return KeyEventResult.handled;
-    }
-
-    // Ctrl+A → move cursor to beginning of current line (emacs-style)
-    if (isCtrl && event.logicalKey == LogicalKeyboardKey.keyA) {
-      final text = _textController.text;
-      final cursor = _textController.selection.baseOffset;
-      if (cursor >= 0) {
-        final lineStart = text.lastIndexOf('\n', cursor - 1) + 1;
-        _textController.selection = TextSelection.collapsed(offset: lineStart);
-      }
-      return KeyEventResult.handled;
-    }
-
-    // Ctrl+E → move cursor to end of current line (emacs-style)
-    if (isCtrl && event.logicalKey == LogicalKeyboardKey.keyE) {
-      final text = _textController.text;
-      final cursor = _textController.selection.baseOffset;
-      if (cursor >= 0) {
-        var lineEnd = text.indexOf('\n', cursor);
-        if (lineEnd < 0) lineEnd = text.length;
-        _textController.selection = TextSelection.collapsed(offset: lineEnd);
-      }
-      return KeyEventResult.handled;
-    }
-
-    // Ctrl+K → kill from cursor to end of current line (emacs-style)
-    if (isCtrl && event.logicalKey == LogicalKeyboardKey.keyK) {
-      final text = _textController.text;
-      final cursor = _textController.selection.baseOffset;
-      if (cursor >= 0) {
-        var lineEnd = text.indexOf('\n', cursor);
-        if (lineEnd < 0) {
-          // Last line: delete to end of text
-          lineEnd = text.length;
-        } else if (lineEnd == cursor) {
-          // Cursor is at a newline: delete just the newline (join lines)
-          lineEnd = cursor + 1;
-        }
-        final newText = text.substring(0, cursor) + text.substring(lineEnd);
-        _textController.value = TextEditingValue(
-          text: newText,
-          selection: TextSelection.collapsed(offset: cursor),
-        );
-      }
-      return KeyEventResult.handled;
-    }
-
-    return KeyEventResult.ignored;
-  }
-
-  void _hideAutocomplete() {
-    _autocompleteOverlay?.remove();
-    _autocompleteOverlay = null;
-    _filteredMembers = [];
-    _highlightedIndex = 0;
-  }
-
-  void _insertMention(String email) {
-    final text = _textController.text;
-    final cursor = _textController.selection.baseOffset;
-    final before = text.substring(0, cursor);
-    final atIdx = before.lastIndexOf('@');
-    final after = text.substring(cursor);
-    final newText = '${text.substring(0, atIdx)}@$email $after';
-    _textController.value = TextEditingValue(
-      text: newText,
-      selection: TextSelection.collapsed(
-        offset: atIdx + email.length + 2, // @email + space
-      ),
-    );
-    _hideAutocomplete();
-    _inputFocusNode.requestFocus();
-  }
-
-  // --- Message rendering ---
-
-  Widget _buildMessageContent(
-    BuildContext context, {
-    required String senderName,
-    required String text,
-    required bool isAgent,
-    required bool isDeleted,
-  }) {
-    final nameColor = isAgent ? KColors.accentCyan : _colorForEmail(senderName);
-
-    if (isDeleted) {
-      return Text.rich(
-        TextSpan(
-          children: [
-            TextSpan(
-              text: '$senderName  ',
-              style: TextStyle(
-                fontWeight: FontWeight.bold,
-                color: nameColor,
-                fontSize: 13,
-              ),
-            ),
-            TextSpan(
-              text: text,
-              style: const TextStyle(
-                color: KColors.textMuted,
-                fontSize: 13,
-                fontStyle: FontStyle.italic,
-              ),
-            ),
-          ],
-        ),
-      );
-    }
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          senderName,
-          style: TextStyle(
-            fontWeight: FontWeight.bold,
-            color: nameColor,
-            fontSize: 13,
-          ),
-        ),
-        MarkdownBody(
-          data: _highlightMentions(text),
-          selectable: true,
-          // Use gitHubWeb without autolink to avoid mailto-linking emails
-          extensionSet: md.ExtensionSet(
-            md.ExtensionSet.gitHubWeb.blockSyntaxes,
-            [
-              ...md.ExtensionSet.gitHubWeb.inlineSyntaxes.where(
-                (s) =>
-                    s is! md.AutolinkSyntax && s is! md.AutolinkExtensionSyntax,
-              ),
-            ],
-          ),
-          styleSheet: _chatMarkdownStyle(context),
-          // coverage:ignore-start
-          onTapLink: (text, href, title) {
-            if (href != null && href.isNotEmpty) {
-              openUrl(href);
-            }
-          },
-          // coverage:ignore-end
-        ),
-      ],
-    );
-  }
-
-  static String _formatTime(String raw) {
-    if (raw.isEmpty) return '';
-    try {
-      // Backend sends UTC datetime as "YYYY-MM-DD HH:MM:SS"
-      final utc = DateTime.parse('${raw}Z');
-      final local = utc.toLocal();
-      final now = DateTime.now();
-      final diff = now.difference(local);
-
-      final hh = local.hour.toString().padLeft(2, '0');
-      final mm = local.minute.toString().padLeft(2, '0');
-      final time = '$hh:$mm';
-
-      if (diff.inDays == 0 && local.day == now.day) {
-        return time; // today: "14:30"
-      }
-      if (diff.inDays < 7) {
-        const days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
-        return '${days[local.weekday - 1]} $time'; // this week: "Mon 14:30"
-      }
-      return '${local.month}/${local.day} $time'; // older: "6/3 14:30"
-    } catch (e) {
-      // coverage:ignore-start
-      debugPrint('[WorkspaceChat] format time failed: $e');
-      return raw;
-    } // coverage:ignore-end
-  }
-
-  static Color _colorForEmail(String email) => KColors.colorForString(email);
-
-  static final _mentionRegex = RegExp(r'@(\S+)');
-
-  /// Pre-process @mentions into bold markdown syntax, taking care not to
-  /// modify mentions that are already inside markdown links or code spans.
-  static String _highlightMentions(String text) {
-    return text.replaceAllMapped(_mentionRegex, (m) {
-      return '**${m.group(0)}**';
-    });
-  }
-
-  /// Build a [MarkdownStyleSheet] that matches the dark Klangk theme.
-  static MarkdownStyleSheet _chatMarkdownStyle(BuildContext context) {
-    const baseText = TextStyle(color: KColors.textPrimary, fontSize: 13);
-    return MarkdownStyleSheet(
-      p: baseText,
-      pPadding: EdgeInsets.zero,
-      a: baseText.copyWith(
-        color: KColors.accentBlue,
-        decoration: TextDecoration.underline,
-      ),
-      strong: baseText.copyWith(fontWeight: FontWeight.bold),
-      em: baseText.copyWith(fontStyle: FontStyle.italic),
-      code: baseText.copyWith(
-        backgroundColor: KColors.bgOverlay,
-        fontFamily: 'JetBrains Mono',
-        fontSize: 12,
-      ),
-      codeblockDecoration: BoxDecoration(
-        color: KColors.bgOverlay,
-        borderRadius: BorderRadius.circular(4),
-      ),
-      codeblockPadding: const EdgeInsets.all(8),
-      blockSpacing: 4,
-      listBullet: baseText,
-      blockquoteDecoration: BoxDecoration(
-        border: Border(
-          left: BorderSide(color: KColors.borderDefault, width: 3),
-        ),
-      ),
-      blockquotePadding: const EdgeInsets.only(left: 8),
-      blockquote: baseText.copyWith(color: KColors.textSecondary),
-    );
-  }
-
-  void _sendMessage() {
-    final text = _textController.text.trim();
-    if (text.isEmpty) return;
-    _hideAutocomplete();
-    _sentHistory.add(text);
-    _historyIndex = -1;
-    _savedDraft = '';
-    widget.wsClient.sendChatMessage(text);
-    _textController.clear();
-    _inputFocusNode.requestFocus();
-  }
-
-  void _deleteMessage(String messageId) {
-    widget.wsClient.sendChatDelete(messageId);
-  }
-
   void _onPresenceChanged() {
     if (mounted) setState(() {});
   }
 
-  Widget _buildPresenceBar(String? currentUserId) {
-    final users = widget.wsClient.presenceUsers;
-    if (users.isEmpty) return const SizedBox.shrink();
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
-      decoration: const BoxDecoration(
-        color: KColors.bgAppBar,
-        border: Border(bottom: BorderSide(color: KColors.borderMuted)),
-      ),
-      child: Row(
-        children: [
-          Container(
-            width: 6,
-            height: 6,
-            margin: const EdgeInsets.only(right: 6),
-            decoration: const BoxDecoration(
-              shape: BoxShape.circle,
-              color: KColors.accentGreen,
-            ),
-          ),
-          ...users.map((u) {
-            final email = u['user_email'] as String? ?? '';
-            final handle = u['user_handle'] as String? ?? '';
-            final uid = u['user_id'] as String?;
-            final isSelf = uid == currentUserId;
-            final displayName = handle.isNotEmpty ? handle : email;
-            final initial =
-                displayName.isNotEmpty ? displayName[0].toUpperCase() : '?';
-            return Padding(
-              padding: const EdgeInsets.only(right: 4),
-              child: Tooltip(
-                message: displayName,
-                child: CircleAvatar(
-                  radius: 10,
-                  backgroundColor:
-                      isSelf ? Colors.transparent : _colorForEmail(email),
-                  foregroundColor:
-                      isSelf ? _colorForEmail(email) : Colors.white,
-                  child: isSelf
-                      ? DecoratedBox(
-                          decoration: BoxDecoration(
-                            shape: BoxShape.circle,
-                            border: Border.all(
-                              color: _colorForEmail(email),
-                              width: 1.5,
-                            ),
-                          ),
-                          child: Center(
-                            child: Text(
-                              initial,
-                              style: TextStyle(
-                                fontSize: 10,
-                                fontWeight: FontWeight.bold,
-                                color: _colorForEmail(email),
-                              ),
-                            ),
-                          ),
-                        )
-                      : Text(
-                          initial,
-                          style: const TextStyle(
-                            fontSize: 10,
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                ),
-              ),
-            );
-          }),
-        ],
-      ),
-    );
+  void _onSendText(String text) {
+    widget.wsClient.sendChatMessage(text);
+  }
+
+  void _onDeleteMessage(String messageId) {
+    widget.wsClient.sendChatDelete(messageId);
+  }
+
+  void _onToggleExpand(String messageId) {
+    setState(() {
+      if (_expandedMessages.contains(messageId)) {
+        _expandedMessages.remove(messageId);
+      } else {
+        _expandedMessages.add(messageId);
+      }
+    });
   }
 
   @override
   void dispose() {
     widget.wsClient.removeListener(_onPresenceChanged);
-    _hideAutocomplete();
     _chatSub?.cancel();
     _historyPageSub?.cancel();
     _scrollController.removeListener(_onScroll);
     _scrollController.dispose();
-    _textController.removeListener(_onTextChanged);
-    _textController.dispose();
-    _inputFocusNode.dispose();
     super.dispose();
   }
 
@@ -753,403 +229,30 @@ class WorkspaceChatState extends State<WorkspaceChat> {
       color: KColors.bgCanvas,
       child: Column(
         children: [
-          _buildPresenceBar(currentUserId),
-          _buildMessageList(currentUserId),
-          if (_agentThinking) _buildThinkingIndicator(),
-          _buildInputBar(),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildMessageList(String? currentUserId) {
-    return Expanded(
-      child: _messages.isEmpty
-          ? const Center(
-              child: Text(
-                'No messages yet',
-                style: TextStyle(color: KColors.textMuted),
-              ),
-            )
-          : ListView.builder(
-              controller: _scrollController,
-              padding: const EdgeInsets.symmetric(
-                horizontal: 12,
-                vertical: 8,
-              ),
-              itemCount: _messages.length + (_loadingOlder ? 1 : 0),
-              itemBuilder: (context, index) {
-                if (_loadingOlder && index == 0) {
-                  return const Padding(
-                    padding: EdgeInsets.symmetric(vertical: 8),
-                    child: Center(
-                      child: SizedBox(
-                        width: 16,
-                        height: 16,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      ),
-                    ),
-                  );
-                }
-                final msgIndex = _loadingOlder ? index - 1 : index;
-                return _buildMessageItem(_messages[msgIndex], currentUserId);
-              },
-            ),
-    );
-  }
-
-  Widget _buildMessageItem(Map<String, dynamic> msg, String? currentUserId) {
-    final handle = msg['user_handle'] as String?;
-    final email = msg['user_email'] as String? ?? '';
-    final senderName = (handle != null && handle.isNotEmpty) ? handle : email;
-    final text = msg['message'] as String? ?? '';
-    final createdAt = _formatTime(msg['created_at'] as String? ?? '');
-    final msgUserId = msg['user_id'] as String?;
-    final isOwn = msgUserId != null && msgUserId == currentUserId;
-    final isDeleted = text == '<message deleted by author>';
-    final messageType = msg['message_type'] as int? ?? 0;
-
-    // Hide own join/leave system messages — they are only informational
-    // for other users.
-    if (messageType == 2 && isOwn) {
-      return const SizedBox.shrink();
-    }
-
-    // System messages: compact divider style.
-    if (messageType == 2) {
-      return _buildSystemMessage(text);
-    }
-
-    // Agent messages: robot icon prefix, left accent.
-    return _buildMessageRow(
-      msg: msg,
-      senderName: senderName,
-      text: text,
-      createdAt: createdAt,
-      isAgent: messageType == 1,
-      isOwn: isOwn,
-      isDeleted: isDeleted,
-    );
-  }
-
-  Widget _buildSystemMessage(String text) {
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 2),
-      child: Row(
-        children: [
-          const Expanded(
-            child: Divider(color: KColors.borderMuted, height: 1),
+          ChatPresenceBar(
+            users: widget.wsClient.presenceUsers,
+            currentUserId: currentUserId,
           ),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 8),
-            child: Text(
-              text,
-              style: const TextStyle(
-                color: KColors.textMuted,
-                fontSize: 10,
-              ),
-            ),
+          ChatMessageList(
+            messages: _messages,
+            scrollController: _scrollController,
+            currentUserId: currentUserId,
+            loadingOlder: _loadingOlder,
+            expandedMessages: _expandedMessages,
+            onToggleExpand: _onToggleExpand,
+            onDelete: _onDeleteMessage,
           ),
-          const Expanded(
-            child: Divider(color: KColors.borderMuted, height: 1),
+          if (_agentThinking) AgentThinkingIndicator(agentName: _agentName),
+          ChatInputBar(
+            key: _inputBarKey,
+            onSend: () {},
+            onSendText: _onSendText,
+            agentThinking: _agentThinking,
+            onAbort: () => widget.wsClient.sendChatAgentAbort(),
+            members: widget.wsClient.workspaceMembers,
           ),
         ],
       ),
-    );
-  }
-
-  Widget _buildMessageRow({
-    required Map<String, dynamic> msg,
-    required String senderName,
-    required String text,
-    required String createdAt,
-    required bool isAgent,
-    required bool isOwn,
-    required bool isDeleted,
-  }) {
-    return Container(
-      margin: const EdgeInsets.only(bottom: 6),
-      padding: isAgent ? const EdgeInsets.only(left: 8) : EdgeInsets.zero,
-      decoration: isAgent
-          ? const BoxDecoration(
-              border: Border(
-                left: BorderSide(color: KColors.accentCyan, width: 2),
-              ),
-            )
-          : null,
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          if (isAgent)
-            const Padding(
-              padding: EdgeInsets.only(right: 6, top: 1),
-              child: Icon(
-                Icons.smart_toy,
-                size: 14,
-                color: KColors.accentCyan,
-              ),
-            ),
-          Expanded(
-            child: _CollapsibleMessage(
-              messageId: msg['id'] as String? ?? '',
-              isExpanded: _expandedMessages.contains(msg['id']),
-              onToggle: () {
-                setState(() {
-                  final id = msg['id'] as String? ?? '';
-                  if (_expandedMessages.contains(id)) {
-                    _expandedMessages.remove(id);
-                  } else {
-                    _expandedMessages.add(id);
-                  }
-                });
-              },
-              child: _buildMessageContent(
-                context,
-                senderName: senderName,
-                text: text,
-                isAgent: isAgent,
-                isDeleted: isDeleted,
-              ),
-            ),
-          ),
-          const SizedBox(width: 8),
-          Text(
-            createdAt,
-            style: const TextStyle(
-              color: KColors.textMuted,
-              fontSize: 11,
-            ),
-          ),
-          if (isOwn && !isDeleted)
-            GestureDetector(
-              onTap: () => _deleteMessage(msg['id'] as String),
-              child: const Padding(
-                padding: EdgeInsets.only(left: 4),
-                child: Icon(
-                  Icons.close,
-                  size: 14,
-                  color: KColors.textMuted,
-                ),
-              ),
-            ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildThinkingIndicator() {
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
-      child: Row(
-        children: [
-          const SizedBox(
-            width: 12,
-            height: 12,
-            child: CircularProgressIndicator(
-              strokeWidth: 1.5,
-              color: KColors.accentCyan,
-            ),
-          ),
-          const SizedBox(width: 8),
-          Text(
-            '$_agentName is thinking...',
-            style: TextStyle(
-              color: KColors.textMuted,
-              fontSize: 12,
-              fontStyle: FontStyle.italic,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildInputBar() {
-    return Container(
-      key: _inputKey,
-      decoration: const BoxDecoration(
-        border: Border(top: BorderSide(color: KColors.borderDefault)),
-      ),
-      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-      child: Row(
-        children: [
-          Expanded(
-            child: ConstrainedBox(
-              constraints: const BoxConstraints(maxHeight: 120),
-              child: TextField(
-                controller: _textController,
-                focusNode: _inputFocusNode,
-                maxLines: null,
-                style: const TextStyle(
-                  color: KColors.textPrimary,
-                  fontSize: 13,
-                ),
-                decoration: const InputDecoration(
-                  hintText: 'Type a message...',
-                  hintStyle: TextStyle(color: KColors.textMuted),
-                  border: InputBorder.none,
-                  isDense: true,
-                  contentPadding: EdgeInsets.symmetric(
-                    vertical: 8,
-                    horizontal: 8,
-                  ),
-                ),
-              ),
-            ),
-          ),
-          if (_agentThinking)
-            IconButton(
-              icon: const Icon(Icons.stop_circle_outlined, size: 18),
-              color: KColors.accentRed,
-              tooltip: 'Stop agent',
-              onPressed: () => widget.wsClient.sendChatAgentAbort(),
-            ),
-          IconButton(
-            icon: const Icon(Icons.send, size: 18),
-            color: KColors.accentBlue,
-            onPressed: _sendMessage,
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-/// Truncates long messages to ~3 lines with a "show more" / "show less" toggle.
-class _CollapsibleMessage extends StatelessWidget {
-  const _CollapsibleMessage({
-    required this.messageId,
-    required this.isExpanded,
-    required this.onToggle,
-    required this.child,
-  });
-
-  final String messageId;
-  final bool isExpanded;
-  final VoidCallback onToggle;
-  final Widget child;
-
-  /// Approximate max height for 3 lines of 13px text with line spacing.
-  static const _collapsedMaxHeight = 60.0;
-
-  @override
-  Widget build(BuildContext context) {
-    if (isExpanded) {
-      return Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          child,
-          ExcludeFocus(
-            child: GestureDetector(
-              onTap: onToggle,
-              child: MouseRegion(
-                cursor: SystemMouseCursors.click,
-                child: const Padding(
-                  padding: EdgeInsets.only(top: 2),
-                  child: Text(
-                    'show less',
-                    style: TextStyle(color: KColors.accentBlue, fontSize: 12),
-                  ),
-                ),
-              ),
-            ),
-          ),
-        ],
-      );
-    }
-
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        // Use a TextPainter to check if the content would exceed 3 lines.
-        // We approximate by checking the intrinsic height of the child.
-        return _MeasuredCollapse(
-          maxHeight: _collapsedMaxHeight,
-          onToggle: onToggle,
-          child: child,
-        );
-      },
-    );
-  }
-}
-
-/// Measures the child's height and shows a "show more" link if it overflows.
-class _MeasuredCollapse extends StatefulWidget {
-  const _MeasuredCollapse({
-    required this.maxHeight,
-    required this.onToggle,
-    required this.child,
-  });
-
-  final double maxHeight;
-  final VoidCallback onToggle;
-  final Widget child;
-
-  @override
-  State<_MeasuredCollapse> createState() => _MeasuredCollapseState();
-}
-
-class _MeasuredCollapseState extends State<_MeasuredCollapse> {
-  bool _overflows = false;
-  final _childKey = GlobalKey();
-
-  @override
-  void initState() {
-    super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) => _checkOverflow());
-  }
-
-  @override
-  void didUpdateWidget(_MeasuredCollapse oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    WidgetsBinding.instance.addPostFrameCallback((_) => _checkOverflow());
-  }
-
-  void _checkOverflow() {
-    final renderBox =
-        _childKey.currentContext?.findRenderObject() as RenderBox?;
-    if (renderBox == null || !mounted) return;
-    final childHeight = renderBox.size.height;
-    final overflows = childHeight > widget.maxHeight;
-    if (overflows != _overflows) {
-      setState(() => _overflows = overflows);
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        if (_overflows)
-          SizedBox(
-            height: widget.maxHeight,
-            child: ClipRect(
-              child: OverflowBox(
-                alignment: Alignment.topLeft,
-                maxHeight: double.infinity,
-                child: KeyedSubtree(key: _childKey, child: widget.child),
-              ),
-            ),
-          )
-        else
-          KeyedSubtree(key: _childKey, child: widget.child),
-        if (_overflows)
-          ExcludeFocus(
-            child: GestureDetector(
-              onTap: widget.onToggle,
-              child: MouseRegion(
-                cursor: SystemMouseCursors.click,
-                child: const Padding(
-                  padding: EdgeInsets.only(top: 2),
-                  child: Text(
-                    '…show more',
-                    style: TextStyle(color: KColors.accentBlue, fontSize: 12),
-                  ),
-                ),
-              ),
-            ),
-          ),
-      ],
     );
   }
 }

--- a/src/frontend/test/agent_thinking_indicator_test.dart
+++ b/src/frontend/test/agent_thinking_indicator_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:klangk_frontend/chat/agent_thinking_indicator.dart';
+
+void main() {
+  group('AgentThinkingIndicator', () {
+    testWidgets('shows agent name with thinking text', (tester) async {
+      await tester.pumpWidget(const MaterialApp(
+        home: Scaffold(
+          body: AgentThinkingIndicator(agentName: 'MrBoops'),
+        ),
+      ));
+
+      expect(find.text('MrBoops is thinking...'), findsOneWidget);
+    });
+
+    testWidgets('shows spinner', (tester) async {
+      await tester.pumpWidget(const MaterialApp(
+        home: Scaffold(
+          body: AgentThinkingIndicator(agentName: 'agent'),
+        ),
+      ));
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('uses default agent name', (tester) async {
+      await tester.pumpWidget(const MaterialApp(
+        home: Scaffold(
+          body: AgentThinkingIndicator(agentName: 'agent'),
+        ),
+      ));
+
+      expect(find.text('agent is thinking...'), findsOneWidget);
+    });
+  });
+}

--- a/src/frontend/test/chat_input_bar_test.dart
+++ b/src/frontend/test/chat_input_bar_test.dart
@@ -24,7 +24,6 @@ void main() {
             height: 100,
             child: ChatInputBar(
               key: barKey,
-              onSend: () {},
               onSendText: (text) => sentMessages.add(text),
               agentThinking: agentThinking,
               onAbort: onAbort,

--- a/src/frontend/test/chat_input_bar_test.dart
+++ b/src/frontend/test/chat_input_bar_test.dart
@@ -1,0 +1,369 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:klangk_frontend/chat/chat_input_bar.dart';
+
+void main() {
+  group('ChatInputBar', () {
+    late List<String> sentMessages;
+
+    setUp(() {
+      sentMessages = [];
+    });
+
+    Widget buildBar({
+      bool agentThinking = false,
+      VoidCallback? onAbort,
+      List<Map<String, dynamic>> members = const [],
+      GlobalKey<ChatInputBarState>? barKey,
+    }) {
+      return MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 800,
+            height: 100,
+            child: ChatInputBar(
+              key: barKey,
+              onSend: () {},
+              onSendText: (text) => sentMessages.add(text),
+              agentThinking: agentThinking,
+              onAbort: onAbort,
+              members: members,
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('sends message on Enter', (tester) async {
+      await tester.pumpWidget(buildBar());
+
+      await tester.enterText(find.byType(TextField), 'hello');
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pump();
+
+      expect(sentMessages, ['hello']);
+      final field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.controller!.text, isEmpty);
+    });
+
+    testWidgets('sends message on send button tap', (tester) async {
+      await tester.pumpWidget(buildBar());
+
+      await tester.enterText(find.byType(TextField), 'button msg');
+      await tester.tap(find.byIcon(Icons.send));
+      await tester.pump();
+
+      expect(sentMessages, ['button msg']);
+    });
+
+    testWidgets('does not send empty message', (tester) async {
+      await tester.pumpWidget(buildBar());
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pump();
+
+      expect(sentMessages, isEmpty);
+    });
+
+    testWidgets('does not send whitespace-only message', (tester) async {
+      await tester.pumpWidget(buildBar());
+
+      await tester.enterText(find.byType(TextField), '   ');
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pump();
+
+      expect(sentMessages, isEmpty);
+    });
+
+    testWidgets('shows stop button when agent is thinking', (tester) async {
+      var aborted = false;
+      await tester.pumpWidget(buildBar(
+        agentThinking: true,
+        onAbort: () => aborted = true,
+      ));
+
+      expect(find.byIcon(Icons.stop_circle_outlined), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.stop_circle_outlined));
+      await tester.pump();
+
+      expect(aborted, isTrue);
+    });
+
+    testWidgets('no stop button when agent is not thinking', (tester) async {
+      await tester.pumpWidget(buildBar());
+      expect(find.byIcon(Icons.stop_circle_outlined), findsNothing);
+    });
+
+    testWidgets('Ctrl+A moves cursor to beginning of line', (tester) async {
+      await tester.pumpWidget(buildBar());
+
+      await tester.enterText(find.byType(TextField), 'hello world');
+      await tester.pump();
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyA);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+      await tester.pump();
+
+      final field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.controller!.selection.baseOffset, 0);
+    });
+
+    testWidgets('Ctrl+E moves cursor to end of line', (tester) async {
+      await tester.pumpWidget(buildBar());
+
+      await tester.enterText(find.byType(TextField), 'hello world');
+      await tester.pump();
+
+      final field = tester.widget<TextField>(find.byType(TextField));
+      field.controller!.selection = const TextSelection.collapsed(offset: 0);
+      await tester.pump();
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyE);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+      await tester.pump();
+
+      expect(field.controller!.selection.baseOffset, 11);
+    });
+
+    testWidgets('Ctrl+K kills to end of line', (tester) async {
+      await tester.pumpWidget(buildBar());
+
+      await tester.enterText(find.byType(TextField), 'hello world');
+      await tester.pump();
+
+      final field = tester.widget<TextField>(find.byType(TextField));
+      field.controller!.selection = const TextSelection.collapsed(offset: 5);
+      await tester.pump();
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyK);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+      await tester.pump();
+
+      expect(field.controller!.text, 'hello');
+    });
+
+    testWidgets('Ctrl+K at newline joins lines', (tester) async {
+      await tester.pumpWidget(buildBar());
+
+      await tester.enterText(find.byType(TextField), 'line1\nline2');
+      await tester.pump();
+
+      final field = tester.widget<TextField>(find.byType(TextField));
+      field.controller!.selection = const TextSelection.collapsed(offset: 5);
+      await tester.pump();
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyK);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+      await tester.pump();
+
+      expect(field.controller!.text, 'line1line2');
+    });
+
+    testWidgets('Shift+Ctrl+A selects all text', (tester) async {
+      await tester.pumpWidget(buildBar());
+
+      await tester.enterText(find.byType(TextField), 'hello world');
+      await tester.pump();
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyA);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft);
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+      await tester.pump();
+
+      final field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.controller!.selection.baseOffset, 0);
+      expect(field.controller!.selection.extentOffset, 11);
+    });
+
+    testWidgets('Up arrow recalls previous sent message', (tester) async {
+      await tester.pumpWidget(buildBar());
+
+      await tester.enterText(find.byType(TextField), 'first');
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pump();
+
+      await tester.enterText(find.byType(TextField), 'second');
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pump();
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.pump();
+
+      final field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.controller!.text, 'second');
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.pump();
+      expect(field.controller!.text, 'first');
+    });
+
+    testWidgets('Down arrow restores draft after history recall',
+        (tester) async {
+      await tester.pumpWidget(buildBar());
+
+      await tester.enterText(find.byType(TextField), 'sent msg');
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pump();
+
+      await tester.enterText(find.byType(TextField), 'my draft');
+      await tester.pump();
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+      await tester.pump();
+      final field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.controller!.text, 'sent msg');
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
+      expect(field.controller!.text, 'my draft');
+    });
+
+    testWidgets('multiline text field grows', (tester) async {
+      await tester.pumpWidget(buildBar());
+
+      final field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.maxLines, isNull);
+    });
+
+    testWidgets('requestFocus focuses input', (tester) async {
+      final barKey = GlobalKey<ChatInputBarState>();
+      await tester.pumpWidget(buildBar(barKey: barKey));
+
+      final field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.focusNode!.hasFocus, isFalse);
+
+      barKey.currentState!.requestFocus();
+      await tester.pump();
+
+      expect(field.focusNode!.hasFocus, isTrue);
+    });
+
+    testWidgets('@autocomplete shows members on @ input', (tester) async {
+      await tester.pumpWidget(buildBar(members: [
+        {'id': 'u1', 'email': 'alice@test.com', 'handle': ''},
+        {'id': 'u2', 'email': 'bob@test.com', 'handle': ''},
+      ]));
+
+      await tester.enterText(find.byType(TextField), '@');
+      await tester.pump();
+
+      expect(find.text('alice@test.com'), findsWidgets);
+      expect(find.text('bob@test.com'), findsWidgets);
+    });
+
+    testWidgets('@autocomplete filters by query', (tester) async {
+      await tester.pumpWidget(buildBar(members: [
+        {'id': 'u1', 'email': 'alice@test.com', 'handle': ''},
+        {'id': 'u2', 'email': 'bob@test.com', 'handle': ''},
+      ]));
+
+      await tester.enterText(find.byType(TextField), '@ali');
+      await tester.pump();
+
+      expect(find.text('alice@test.com'), findsWidgets);
+      expect(find.text('bob@test.com'), findsNothing);
+    });
+
+    testWidgets('Tab key accepts autocomplete suggestion', (tester) async {
+      await tester.pumpWidget(buildBar(members: [
+        {'id': 'u1', 'email': 'alice@test.com', 'handle': ''},
+      ]));
+
+      await tester.enterText(find.byType(TextField), '@al');
+      await tester.pump();
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+
+      final field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.controller!.text, '@alice@test.com ');
+    });
+
+    testWidgets('Escape dismisses autocomplete', (tester) async {
+      await tester.pumpWidget(buildBar(members: [
+        {'id': 'u1', 'email': 'alice@test.com', 'handle': ''},
+      ]));
+
+      await tester.enterText(find.byType(TextField), '@al');
+      await tester.pump();
+      expect(find.text('alice@test.com'), findsWidgets);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+      await tester.pump();
+
+      expect(find.text('alice@test.com'), findsNothing);
+    });
+
+    testWidgets('Enter accepts autocomplete when overlay is visible',
+        (tester) async {
+      await tester.pumpWidget(buildBar(members: [
+        {'id': 'u1', 'email': 'alice@test.com', 'handle': ''},
+      ]));
+
+      await tester.enterText(find.byType(TextField), '@al');
+      await tester.pump();
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+      await tester.pump();
+
+      final field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.controller!.text, '@alice@test.com ');
+      // Should not have sent a message
+      expect(sentMessages, isEmpty);
+    });
+
+    testWidgets('@autocomplete hides when @ followed by space', (tester) async {
+      await tester.pumpWidget(buildBar(members: [
+        {'id': 'u1', 'email': 'alice@test.com', 'handle': ''},
+      ]));
+
+      await tester.enterText(find.byType(TextField), '@ ');
+      await tester.pump();
+
+      expect(find.text('alice@test.com'), findsNothing);
+    });
+
+    testWidgets('Arrow keys navigate autocomplete', (tester) async {
+      await tester.pumpWidget(buildBar(members: [
+        {'id': 'u1', 'email': 'alice@test.com', 'handle': ''},
+        {'id': 'u2', 'email': 'bob@test.com', 'handle': ''},
+      ]));
+
+      await tester.enterText(find.byType(TextField), '@');
+      await tester.pump();
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+
+      final field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.controller!.text, '@bob@test.com ');
+    });
+
+    testWidgets('prefers handle over email in autocomplete', (tester) async {
+      await tester.pumpWidget(buildBar(members: [
+        {'id': 'u1', 'email': 'alice@test.com', 'handle': 'alice'},
+      ]));
+
+      await tester.enterText(find.byType(TextField), '@al');
+      await tester.pump();
+
+      expect(find.text('alice'), findsWidgets);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.tab);
+      await tester.pump();
+
+      final field = tester.widget<TextField>(find.byType(TextField));
+      expect(field.controller!.text, '@alice ');
+    });
+  });
+}

--- a/src/frontend/test/chat_message_list_test.dart
+++ b/src/frontend/test/chat_message_list_test.dart
@@ -1,0 +1,363 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:klangk_frontend/chat/chat_message_list.dart';
+
+String? _findMarkdownData(WidgetTester tester) {
+  final finder = find.byType(MarkdownBody);
+  if (finder.evaluate().isEmpty) return null;
+  final widget = tester.widget<MarkdownBody>(finder.first);
+  return widget.data;
+}
+
+void main() {
+  group('ChatMessageList', () {
+    late ScrollController scrollController;
+    late Set<String> expanded;
+    late List<String> toggledIds;
+    late List<String> deletedIds;
+
+    setUp(() {
+      scrollController = ScrollController();
+      expanded = {};
+      toggledIds = [];
+      deletedIds = [];
+    });
+
+    tearDown(() {
+      scrollController.dispose();
+    });
+
+    Widget buildList({
+      List<Map<String, dynamic>> messages = const [],
+      String? currentUserId,
+      bool loadingOlder = false,
+    }) {
+      return MaterialApp(
+        home: Scaffold(
+          body: SizedBox(
+            width: 800,
+            height: 600,
+            child: Column(
+              children: [
+                ChatMessageList(
+                  messages: messages,
+                  scrollController: scrollController,
+                  currentUserId: currentUserId,
+                  loadingOlder: loadingOlder,
+                  expandedMessages: expanded,
+                  onToggleExpand: (id) => toggledIds.add(id),
+                  onDelete: (id) => deletedIds.add(id),
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('renders empty state', (tester) async {
+      await tester.pumpWidget(buildList());
+      expect(find.text('No messages yet'), findsOneWidget);
+    });
+
+    testWidgets('renders message as markdown', (tester) async {
+      await tester.pumpWidget(buildList(messages: [
+        {
+          'id': 'msg-1',
+          'user_email': 'alice@test.com',
+          'user_handle': 'alice',
+          'message': 'hello world',
+          'created_at': '2026-01-01 00:00:00',
+        },
+      ]));
+
+      expect(find.text('No messages yet'), findsNothing);
+      expect(find.text('alice'), findsOneWidget);
+      expect(find.byType(MarkdownBody), findsOneWidget);
+      expect(_findMarkdownData(tester), 'hello world');
+    });
+
+    testWidgets('renders sender email when no handle', (tester) async {
+      await tester.pumpWidget(buildList(messages: [
+        {
+          'id': 'msg-1',
+          'user_email': 'alice@test.com',
+          'message': 'hello',
+          'created_at': '2026-01-01 00:00:00',
+        },
+      ]));
+
+      expect(find.text('alice@test.com'), findsOneWidget);
+    });
+
+    testWidgets('agent message renders with robot icon', (tester) async {
+      await tester.pumpWidget(buildList(messages: [
+        {
+          'id': 'msg-agent',
+          'user_email': 'agent@bot',
+          'message': 'I can help',
+          'message_type': 1,
+          'created_at': '2026-01-01 00:00:00',
+        },
+      ]));
+
+      expect(find.byIcon(Icons.smart_toy), findsOneWidget);
+    });
+
+    testWidgets('user message renders without robot icon', (tester) async {
+      await tester.pumpWidget(buildList(messages: [
+        {
+          'id': 'msg-user',
+          'user_email': 'alice@test.com',
+          'message': 'normal message',
+          'created_at': '2026-01-01 00:00:00',
+        },
+      ]));
+
+      expect(find.byIcon(Icons.smart_toy), findsNothing);
+    });
+
+    testWidgets('system message renders as divider', (tester) async {
+      await tester.pumpWidget(buildList(messages: [
+        {
+          'id': 'msg-sys',
+          'user_id': 'other-user',
+          'user_email': 'alice@test.com',
+          'message': 'alice joined',
+          'message_type': 2,
+          'created_at': '2026-01-01 00:00:00',
+        },
+      ]));
+
+      expect(find.text('alice joined'), findsOneWidget);
+      expect(find.byType(Divider), findsWidgets);
+    });
+
+    testWidgets('own system message is hidden', (tester) async {
+      await tester.pumpWidget(buildList(
+        messages: [
+          {
+            'id': 'msg-sys-own',
+            'user_id': 'my-uid',
+            'user_email': 'me@test.com',
+            'message': 'me joined',
+            'message_type': 2,
+            'created_at': '2026-01-01 00:00:00',
+          },
+        ],
+        currentUserId: 'my-uid',
+      ));
+
+      expect(find.text('me joined'), findsNothing);
+    });
+
+    testWidgets('delete button shown for own messages', (tester) async {
+      await tester.pumpWidget(buildList(
+        messages: [
+          {
+            'id': 'msg-own',
+            'user_id': 'my-uid',
+            'user_email': 'me@test.com',
+            'message': 'my message',
+            'created_at': '2026-01-01 00:00:00',
+          },
+        ],
+        currentUserId: 'my-uid',
+      ));
+
+      expect(find.byIcon(Icons.close), findsOneWidget);
+    });
+
+    testWidgets('delete button not shown for others messages', (tester) async {
+      await tester.pumpWidget(buildList(
+        messages: [
+          {
+            'id': 'msg-other',
+            'user_id': 'other',
+            'user_email': 'other@test.com',
+            'message': 'their message',
+            'created_at': '2026-01-01 00:00:00',
+          },
+        ],
+        currentUserId: 'my-uid',
+      ));
+
+      expect(find.byIcon(Icons.close), findsNothing);
+    });
+
+    testWidgets('tapping delete calls onDelete', (tester) async {
+      await tester.pumpWidget(buildList(
+        messages: [
+          {
+            'id': 'msg-del',
+            'user_id': 'my-uid',
+            'user_email': 'me@test.com',
+            'message': 'delete me',
+            'created_at': '2026-01-01 00:00:00',
+          },
+        ],
+        currentUserId: 'my-uid',
+      ));
+
+      await tester.tap(find.byIcon(Icons.close));
+      await tester.pump();
+
+      expect(deletedIds, ['msg-del']);
+    });
+
+    testWidgets('deleted message shown in italic without delete button',
+        (tester) async {
+      await tester.pumpWidget(buildList(
+        messages: [
+          {
+            'id': 'msg-deleted',
+            'user_id': 'my-uid',
+            'user_email': 'me@test.com',
+            'message': '<message deleted by author>',
+            'created_at': '2026-01-01 00:00:00',
+          },
+        ],
+        currentUserId: 'my-uid',
+      ));
+
+      expect(find.byIcon(Icons.close), findsNothing);
+      expect(find.byType(MarkdownBody), findsNothing);
+      expect(
+        find.textContaining('<message deleted by author>'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('@mention renders as bold in markdown', (tester) async {
+      await tester.pumpWidget(buildList(messages: [
+        {
+          'id': 'msg-mention',
+          'user_email': 'alice@test.com',
+          'message': 'hey @bob check this',
+          'created_at': '2026-01-01 00:00:00',
+        },
+      ]));
+
+      final data = _findMarkdownData(tester);
+      expect(data, contains('**@bob**'));
+    });
+
+    testWidgets('loading spinner shown when loadingOlder is true',
+        (tester) async {
+      await tester.pumpWidget(buildList(
+        messages: [
+          {
+            'id': 'msg-1',
+            'user_email': 'user@test.com',
+            'message': 'hello',
+            'created_at': '2026-01-01 00:00:00',
+          },
+        ],
+        loadingOlder: true,
+      ));
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('no loading spinner when loadingOlder is false',
+        (tester) async {
+      await tester.pumpWidget(buildList(messages: [
+        {
+          'id': 'msg-1',
+          'user_email': 'user@test.com',
+          'message': 'hello',
+          'created_at': '2026-01-01 00:00:00',
+        },
+      ]));
+
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+    });
+
+    testWidgets('long message shows show more link', (tester) async {
+      final longMsg = 'A' * 500;
+      await tester.pumpWidget(buildList(messages: [
+        {
+          'id': 'msg-long',
+          'user_email': 'alice@test.com',
+          'message': longMsg,
+          'created_at': '2026-01-01 00:00:00',
+        },
+      ]));
+      await tester.pump();
+
+      expect(find.text('…show more'), findsOneWidget);
+    });
+
+    testWidgets('expanded message shows show less link', (tester) async {
+      expanded.add('msg-long');
+      final longMsg = 'A' * 500;
+      await tester.pumpWidget(buildList(messages: [
+        {
+          'id': 'msg-long',
+          'user_email': 'alice@test.com',
+          'message': longMsg,
+          'created_at': '2026-01-01 00:00:00',
+        },
+      ]));
+      await tester.pump();
+
+      expect(find.text('show less'), findsOneWidget);
+      expect(find.text('…show more'), findsNothing);
+    });
+  });
+
+  group('ChatMessageList static helpers', () {
+    test('highlightMentions wraps @mentions in bold', () {
+      expect(
+        ChatMessageList.highlightMentions('hey @bob check'),
+        'hey **@bob** check',
+      );
+    });
+
+    test('highlightMentions handles multiple mentions', () {
+      expect(
+        ChatMessageList.highlightMentions('@alice and @bob'),
+        '**@alice** and **@bob**',
+      );
+    });
+
+    test('highlightMentions leaves text without @ unchanged', () {
+      expect(
+        ChatMessageList.highlightMentions('no mentions here'),
+        'no mentions here',
+      );
+    });
+
+    test('formatTime returns empty for empty input', () {
+      expect(ChatMessageList.formatTime(''), '');
+    });
+
+    test('formatTime shows time only for today', () {
+      final now = DateTime.now().toUtc();
+      final ts =
+          '${now.year}-${now.month.toString().padLeft(2, '0')}-${now.day.toString().padLeft(2, '0')} '
+          '${now.hour.toString().padLeft(2, '0')}:${now.minute.toString().padLeft(2, '0')}:00';
+      final result = ChatMessageList.formatTime(ts);
+      // Should be HH:MM format (no day prefix)
+      expect(result, matches(RegExp(r'^\d{2}:\d{2}$')));
+    });
+
+    test('formatTime shows day abbreviation for this week', () {
+      final yesterday =
+          DateTime.now().subtract(const Duration(days: 1)).toUtc();
+      final ts =
+          '${yesterday.year}-${yesterday.month.toString().padLeft(2, '0')}-${yesterday.day.toString().padLeft(2, '0')} '
+          '12:30:00';
+      final result = ChatMessageList.formatTime(ts);
+      final dayAbbrevs = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+      expect(dayAbbrevs.any((d) => result.contains(d)), isTrue);
+    });
+
+    test('formatTime shows month/day for older messages', () {
+      final result = ChatMessageList.formatTime('2024-01-15 14:30:00');
+      // Should contain month/day format
+      expect(result, contains('/'));
+    });
+  });
+}

--- a/src/frontend/test/chat_presence_bar_test.dart
+++ b/src/frontend/test/chat_presence_bar_test.dart
@@ -1,0 +1,107 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:klangk_frontend/chat/chat_presence_bar.dart';
+
+void main() {
+  Widget buildBar({
+    List<Map<String, dynamic>> users = const [],
+    String? currentUserId,
+  }) {
+    return MaterialApp(
+      home: Scaffold(
+        body: ChatPresenceBar(
+          users: users,
+          currentUserId: currentUserId,
+        ),
+      ),
+    );
+  }
+
+  group('ChatPresenceBar', () {
+    testWidgets('hidden when no users', (tester) async {
+      await tester.pumpWidget(buildBar());
+      expect(find.byType(CircleAvatar), findsNothing);
+    });
+
+    testWidgets('shows avatar initials for users', (tester) async {
+      await tester.pumpWidget(buildBar(users: [
+        {'user_id': 'u1', 'user_email': 'alice@test.com', 'user_handle': ''},
+        {'user_id': 'u2', 'user_email': 'bob@test.com', 'user_handle': 'bob'},
+      ]));
+
+      expect(find.text('A'), findsOneWidget);
+      expect(find.text('B'), findsOneWidget);
+    });
+
+    testWidgets('tooltip shows handle when present', (tester) async {
+      await tester.pumpWidget(buildBar(users: [
+        {
+          'user_id': 'u1',
+          'user_email': 'alice@test.com',
+          'user_handle': 'alice',
+        },
+      ]));
+
+      expect(find.byTooltip('alice'), findsOneWidget);
+    });
+
+    testWidgets('tooltip falls back to email when handle is empty',
+        (tester) async {
+      await tester.pumpWidget(buildBar(users: [
+        {'user_id': 'u1', 'user_email': 'alice@test.com', 'user_handle': ''},
+      ]));
+
+      expect(find.byTooltip('alice@test.com'), findsOneWidget);
+    });
+
+    testWidgets('self user has transparent background', (tester) async {
+      await tester.pumpWidget(buildBar(
+        users: [
+          {
+            'user_id': 'me',
+            'user_email': 'me@test.com',
+            'user_handle': 'me',
+          },
+          {
+            'user_id': 'other',
+            'user_email': 'other@test.com',
+            'user_handle': 'other',
+          },
+        ],
+        currentUserId: 'me',
+      ));
+
+      final avatars =
+          tester.widgetList<CircleAvatar>(find.byType(CircleAvatar));
+      final selfAvatar = avatars.firstWhere(
+        (a) => a.backgroundColor == Colors.transparent,
+      );
+      expect(selfAvatar, isNotNull);
+    });
+
+    testWidgets('shows green dot indicator', (tester) async {
+      await tester.pumpWidget(buildBar(users: [
+        {'user_id': 'u1', 'user_email': 'a@test.com', 'user_handle': ''},
+      ]));
+
+      // Green dot is a 6x6 Container with circle decoration
+      final containers =
+          tester.widgetList<Container>(find.byType(Container)).where((c) {
+        final decoration = c.decoration;
+        if (decoration is BoxDecoration) {
+          return decoration.shape == BoxShape.circle;
+        }
+        return false;
+      });
+      expect(containers, isNotEmpty);
+    });
+
+    testWidgets('handles missing handle gracefully', (tester) async {
+      await tester.pumpWidget(buildBar(users: [
+        {'user_id': 'u1', 'user_email': 'test@test.com'},
+      ]));
+
+      expect(find.text('T'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- Extract 4 sub-widgets from the 1155-line `WorkspaceChatState`: `ChatMessageList`, `ChatInputBar`, `ChatPresenceBar`, `AgentThinkingIndicator`
- `WorkspaceChatState` shrinks to 259 lines — retains only chat state management and WS subscriptions, with `build()` as a clean composition
- Add 83 new widget tests for the extracted components (148 total pass)

## Test plan

- [x] All 65 existing `workspace_chat_test.dart` tests pass unchanged
- [x] All 27 `ide_layout_test.dart` tests pass (uses `WorkspaceChatState` via `GlobalKey`)
- [x] 23 new `ChatMessageList` tests (rendering, delete, system/agent messages, collapsible, static helpers)
- [x] 22 new `ChatInputBar` tests (send, keybindings, autocomplete, history recall)
- [x] 7 new `ChatPresenceBar` tests (avatars, tooltips, self-user styling)
- [x] 3 new `AgentThinkingIndicator` tests

Closes #969