### PR TITLE
refactor(wshandler): break up long handler functions (terminal_start, workspace_connect, join_shared)

### DIFF
--- a/src/backend/klangk_backend/wshandler/connection.py
+++ b/src/backend/klangk_backend/wshandler/connection.py
@@ -357,6 +357,65 @@ class Connection:
 
         logger.info("Container ready for workspace %s", workspace_id)
 
+    async def _send_chat_history(self, workspace_id: str) -> None:
+        """Send chat history to the connecting user."""
+        chat_history = await model.get_chat_messages(workspace_id)
+        if chat_history:
+            self.sock.send_json(
+                {"type": "chat_history", "messages": chat_history}
+            )
+
+    async def _send_workspace_members(
+        self, workspace_id: str, workspace: dict
+    ) -> None:
+        """Send workspace members (including agent) for @mention autocomplete."""
+        members = await model.get_workspace_members(workspace_id)
+        owner = await model.get_user_by_id(workspace.get("user_id", ""))
+        if owner and not any(m["id"] == owner["id"] for m in members):
+            members.append(
+                {
+                    "id": owner["id"],
+                    "email": owner["email"],
+                    "handle": owner.get("handle", ""),
+                }
+            )
+        agent_user = await model.get_agent_user()
+        members.append(
+            {
+                "id": model.AGENT_USER_ID,
+                "email": agent_user["email"],
+                "handle": agent_user.get("handle", ""),
+            }
+        )
+        self.sock.send_json({"type": "workspace_members", "members": members})
+
+    async def _broadcast_join(
+        self, workspace_id: str, rejoining: bool
+    ) -> None:
+        """Send presence list and broadcast join to other subscribers."""
+        presence = await _get_presence_list(workspace_id)
+        self.sock.send_json({"type": "presence_list", "users": presence})
+        session = state.get_session(workspace_id)
+        if session and not rejoining:
+            join_msg = {
+                "type": "presence_join",
+                "user_id": self.user["id"],
+                "user_email": self.user["email"],
+                "user_handle": self.user["handle"],
+            }
+            for sock in list(session.subscribers):
+                if sock is not self.sock:
+                    sock.send_json(join_msg)
+
+            sys_msg = await model.add_chat_message(
+                workspace_id,
+                self.user["id"],
+                self.user["email"],
+                f"{self.user.get('handle') or self.user['email']} joined",
+                message_type=model.MSG_SYSTEM,
+            )
+            session.broadcast({"type": "chat_message", **sys_msg})
+
     async def handle_workspace_connect(self, msg: dict) -> None:
 
         t_connect_start = time.monotonic()
@@ -377,11 +436,11 @@ class Connection:
             return
 
         logger.info(
-            "workspace-open: check permissions and fetch workspace from DB: %.3fs",
+            "workspace-open: check permissions and fetch workspace "
+            "from DB: %.3fs",
             time.monotonic() - t_connect_start,
         )
 
-        # Disconnect from any current workspace
         await self.handle_workspace_disconnect()
 
         t_container = time.monotonic()
@@ -391,7 +450,8 @@ class Connection:
             send_error(self.sock, str(exc))
             return
         logger.info(
-            "workspace-open: start or reuse container (see breakdown above): %.3fs",
+            "workspace-open: start or reuse container "
+            "(see breakdown above): %.3fs",
             time.monotonic() - t_container,
         )
 
@@ -400,11 +460,12 @@ class Connection:
         status = getattr(self, "container_status", "created")
         container_name, ports_str = _format_container_info(workspace_id, ports)
         status_msg = {
-            "connected": f"Connected to running container {container_name}{ports_str}",
-            "restarted": f"Restarted stopped container {container_name}{ports_str}",
+            "connected": f"Connected to running container "
+            f"{container_name}{ports_str}",
+            "restarted": f"Restarted stopped container "
+            f"{container_name}{ports_str}",
             "created": f"Created new container {container_name}{ports_str}",
         }.get(status, "Container ready")
-
         status_msg += _format_idle_timeout(container.IDLE_TIMEOUT_SECONDS)
 
         self.sock.send_json(
@@ -417,78 +478,26 @@ class Connection:
                 "userHome": self._user_home,
             }
         )
-        # Send chat history to the connecting user
-        chat_history = await model.get_chat_messages(workspace_id)
-        if chat_history:
-            self.sock.send_json(
-                {"type": "chat_history", "messages": chat_history}
-            )
 
-        # Send workspace members for @mention autocomplete
-        members = await model.get_workspace_members(workspace_id)
-        owner = await model.get_user_by_id(workspace.get("user_id", ""))
-        if owner and not any(m["id"] == owner["id"] for m in members):
-            members.append(
-                {
-                    "id": owner["id"],
-                    "email": owner["email"],
-                    "handle": owner.get("handle", ""),
-                }
-            )
-        # Include the agent so it autocompletes
-        agent_user = await model.get_agent_user()
-        members.append(
-            {
-                "id": model.AGENT_USER_ID,
-                "email": agent_user["email"],
-                "handle": agent_user.get("handle", ""),
-            }
-        )
-        self.sock.send_json({"type": "workspace_members", "members": members})
+        await self._send_chat_history(workspace_id)
+        await self._send_workspace_members(workspace_id, workspace)
 
-        # Start the agent eagerly so it shows as present immediately.
         if self.container_id:
             asyncio.create_task(self._start_agent_if_needed())
 
-        # If this user had a pending leave (reconnecting after a brief
-        # disconnect), cancel it and suppress the join broadcast — other
-        # users never saw them leave so there's nothing to announce.
         rejoining = state.cancel_pending_leave(workspace_id, self.user["id"])
-
-        # Send presence list to joining user and broadcast join to others
-        presence = await _get_presence_list(workspace_id)
-        self.sock.send_json({"type": "presence_list", "users": presence})
-        session = state.get_session(workspace_id)
-        if session and not rejoining:
-            join_msg = {
-                "type": "presence_join",
-                "user_id": self.user["id"],
-                "user_email": self.user["email"],
-                "user_handle": self.user["handle"],
-            }
-            for sock in list(session.subscribers):
-                if sock is not self.sock:
-                    sock.send_json(join_msg)
-
-            # Broadcast a system chat message for the join
-            sys_msg = await model.add_chat_message(
-                workspace_id,
-                self.user["id"],
-                self.user["email"],
-                f"{self.user.get('handle') or self.user['email']} joined",
-                message_type=model.MSG_SYSTEM,
-            )
-            session.broadcast({"type": "chat_message", **sys_msg})
+        await self._broadcast_join(workspace_id, rejoining)
 
         logger.info(
-            "workspace-open: send chat history, members, and presence to client: %.3fs",
+            "workspace-open: send chat history, members, and "
+            "presence to client: %.3fs",
             time.monotonic() - t_post,
         )
 
-        # Store status for when frontend sends ui_ready
         self.pending_status_msg = status_msg
         logger.info(
-            "workspace-open: TOTAL workspace connect (user sees workspace_ready after this): %.3fs",
+            "workspace-open: TOTAL workspace connect (user sees "
+            "workspace_ready after this): %.3fs",
             time.monotonic() - t_connect_start,
         )
         logger.info(

--- a/src/backend/klangk_backend/wshandler/controllers.py
+++ b/src/backend/klangk_backend/wshandler/controllers.py
@@ -340,10 +340,64 @@ class TerminalController:
         self.cols: int = 80
         self.rows: int = 24
 
+    def _register_browser(self, browser_id: str | None) -> None:
+        """Register a browser ID for bridge routing.
+
+        The browser sends its sessionStorage UUID with terminal_start;
+        on refresh the same ID re-registers with the new WebSocket.
+        The CLI sends "klangkshell" as a sentinel — store it in tmux
+        env but don't register it for bridge routing.
+        """
+        if browser_id and browser_id != "klangkshell":
+            container.registry.revoke_browser(self._conn.sock)
+            container.registry.register_browser(
+                browser_id, self._conn.workspace_id, self._conn.sock
+            )
+        self._conn._browser_id = browser_id
+
+    async def _restore_and_sync_windows(self) -> None:
+        """Restore saved window state and sync with tmux.
+
+        On first terminal_start after restart, loads the saved
+        snapshot from the container.  Then lists current tmux
+        windows, syncs in-memory state, and sends the window list
+        and shared terminals to the client.
+        """
+        conn = self._conn
+        sname = conn._tmux_session_name()
+        user_id = conn.user["id"]
+        ws_session = state.get_session(conn.workspace_id)
+
+        if ws_session and user_id not in ws_session.terminal_windows:
+            saved = await terminal.load_workspace_state(conn.container_id)
+            if user_id in saved:
+                saved_windows = saved[user_id]
+                await terminal.restore_windows(
+                    conn.container_id, sname, saved_windows
+                )
+                ws_session.terminal_windows[user_id] = saved_windows
+                for uid, wins in saved.items():
+                    if uid != user_id:
+                        ws_session.terminal_windows.setdefault(uid, wins)
+
+        windows = await terminal.list_windows(conn.container_id, sname)
+        conn._sync_terminal_windows(windows)
+        conn.sock.send_json({"type": "terminal_windows", "windows": windows})
+
+    def _send_shared_terminals(self) -> None:
+        """Send the current shared terminal list to the client."""
+        ws_session = state.get_session(self._conn.workspace_id)
+        if ws_session:
+            terminals = _get_shared_terminals(ws_session)
+            self._conn.sock.send_json(
+                {"type": "shared_terminals", "terminals": terminals}
+            )
+
     async def start(self, msg: dict) -> None:
 
         logger.info(
-            "handle_terminal_start: user=%s workspace=%s container=%s user_home=%s",
+            "handle_terminal_start: user=%s workspace=%s "
+            "container=%s user_home=%s",
             self._conn.user.get("email"),
             self._conn.workspace_id,
             self._conn.container_id,
@@ -367,11 +421,9 @@ class TerminalController:
             send_error(self._conn.sock, "Handle not set")
             return
         if not await self._conn._has_perm("code-in-isolation"):
-            # Spectators can't start isolated terminals but still need
-            # the terminal pane. Send terminal_started (no session) so
-            # the frontend renders shared tabs.
             logger.info(
-                "Skipping isolated terminal for user=%s (no code-in-isolation)",
+                "Skipping isolated terminal for user=%s "
+                "(no code-in-isolation)",
                 self._conn.user.get("email"),
             )
             self._conn.sock.send_json({"type": "terminal_started"})
@@ -392,24 +444,14 @@ class TerminalController:
             ssh_agent_socket=self._conn._ssh_agent_socket,
         )
 
-        # Register browser ID for bridge routing.  The browser sends
-        # its sessionStorage UUID with terminal_start; on refresh the
-        # same ID re-registers with the new WebSocket.  The CLI sends
-        # "klangkshell" as a sentinel — store it in tmux env (so
-        # klangk-copy-to-clipboard can skip the bridge) but don't
-        # register it for bridge routing.
         browser_id = msg.get("browser_id")
-        if browser_id and browser_id != "klangkshell":
-            container.registry.revoke_browser(self._conn.sock)
-            container.registry.register_browser(
-                browser_id, self._conn.workspace_id, self._conn.sock
-            )
-        self._conn._browser_id = browser_id
+        self._register_browser(browser_id)
 
         # Store session immediately so stop_terminal can clean it up
         # if another terminal_start arrives before this one finishes.
         self.session = session
         conn = self._conn
+        ctrl = self
 
         async def _start_terminal() -> None:
             try:
@@ -420,67 +462,20 @@ class TerminalController:
                 )
                 await asyncio.wait_for(
                     session.start(
-                        cols,
-                        rows,
-                        command_override=command_override,
+                        cols, rows, command_override=command_override
                     ),
                     timeout=30,
                 )
-                # Store the browser ID in the container's tmux
-                # environment so klangk-browser-id can read it.
                 if browser_id:
                     await attach_browser(conn.container_id, browser_id)
                 if not await conn._activate_session(session, cols, rows):
                     return
                 conn.sock.send_json({"type": "terminal_started"})
                 try:
-                    sname = conn._tmux_session_name()
-                    user_id = conn.user["id"]
-                    ws_session = state.get_session(conn.workspace_id)
-
-                    # On first terminal_start after restart, restore
-                    # saved window state from the container.
-                    if (
-                        ws_session
-                        and user_id not in ws_session.terminal_windows
-                    ):
-                        saved = await terminal.load_workspace_state(
-                            conn.container_id
-                        )
-                        if user_id in saved:
-                            saved_windows = saved[user_id]
-                            await terminal.restore_windows(
-                                conn.container_id, sname, saved_windows
-                            )
-                            ws_session.terminal_windows[user_id] = (
-                                saved_windows
-                            )
-                            # Restore shared state for ALL users from snapshot
-                            for uid, wins in saved.items():
-                                if uid != user_id:
-                                    ws_session.terminal_windows.setdefault(
-                                        uid, wins
-                                    )
-
-                    windows = await terminal.list_windows(
-                        conn.container_id, sname
-                    )
-                    conn._sync_terminal_windows(windows)
-                    conn.sock.send_json(
-                        {
-                            "type": "terminal_windows",
-                            "windows": windows,
-                        }
-                    )
+                    await ctrl._restore_and_sync_windows()
                 except (TerminalError, OSError):
                     logger.exception("_start_terminal: window list failed")
-                # Also send the shared terminal list from in-memory state.
-                ws_session = state.get_session(conn.workspace_id)
-                if ws_session:
-                    terminals = _get_shared_terminals(ws_session)
-                    conn.sock.send_json(
-                        {"type": "shared_terminals", "terminals": terminals}
-                    )
+                ctrl._send_shared_terminals()
             except asyncio.CancelledError:
                 await session.stop()
                 container.registry.revoke_browser(conn.sock)
@@ -927,6 +922,40 @@ class SharedTerminalController:
         self.broadcast_shared_terminals(ws_session)
         self.save_state_snapshot(ws_session)
 
+    @staticmethod
+    async def _select_shared_window(
+        container_id: str,
+        session: TerminalSession,
+        owner_user_id: str,
+        window_id: str,
+    ) -> None:
+        """Select the target window in the joiner's tmux session.
+
+        Targets the joiner's grouped session so the active window
+        changes for the joiner, not the group owner.  Falls back
+        to bare @N if the session isn't ready yet.
+        """
+        joiner_session = session._tmux_session_name
+        if joiner_session:
+            try:
+                await terminal.tmux_command(
+                    container_id,
+                    joiner_session,
+                    [
+                        "select-window",
+                        "-t",
+                        f"{joiner_session}:{window_id}",
+                    ],
+                )
+            except TerminalError:
+                await terminal.select_window(
+                    container_id, owner_user_id, window_id
+                )
+        else:
+            await terminal.select_window(
+                container_id, owner_user_id, window_id
+            )
+
     async def join_shared_terminal(self, msg: dict) -> None:
         """Join another user's shared window via session group."""
 
@@ -947,7 +976,6 @@ class SharedTerminalController:
             send_error(self._conn.sock, "user_id and window_id required")
             return
 
-        # Verify the window exists and is shared
         ws_session = state.get_session(self._conn.workspace_id)
         if not ws_session:
             return
@@ -967,9 +995,6 @@ class SharedTerminalController:
             or await self._conn._has_perm("share-terminals")
         )
 
-        # Stop the current terminal session and join the owner's
-        # session group on the default tmux server (no -S socket).
-        # tmux session is named by user_id.
         await self._conn.stop_terminal()
         self.viewing_shared = {
             "user_id": owner_user_id,
@@ -993,33 +1018,12 @@ class SharedTerminalController:
         async def _start_shared() -> None:
             try:
                 await session.start(cols, rows)
-                # Select the target window BEFORE activating output
-                # forwarding, so the initial output burst is from
-                # the correct window.  Target the joiner's session
-                # specifically so the active window changes for the
-                # joiner, not the group owner.  Fall back to bare @N
-                # if the session isn't ready yet (race on rapid joins).
-                joiner_session = session._tmux_session_name
-                if joiner_session:
-                    try:
-                        await terminal.tmux_command(
-                            conn.container_id,
-                            joiner_session,
-                            [
-                                "select-window",
-                                "-t",
-                                f"{joiner_session}:{window_id}",
-                            ],
-                        )
-                    except TerminalError:
-                        # Joiner session not ready — fall back to bare @N
-                        await terminal.select_window(
-                            conn.container_id, owner_user_id, window_id
-                        )
-                else:
-                    await terminal.select_window(
-                        conn.container_id, owner_user_id, window_id
-                    )
+                await self._select_shared_window(
+                    conn.container_id,
+                    session,
+                    owner_user_id,
+                    window_id,
+                )
                 if not await conn._activate_session(session, cols, rows):
                     return
                 conn.sock.send_json(
@@ -1030,7 +1034,6 @@ class SharedTerminalController:
                         "readOnly": read_only,
                     }
                 )
-                # Broadcast updated viewer list
                 ws_sess = state.get_session(conn.workspace_id)
                 if ws_sess:
                     conn._broadcast_shared_terminals(ws_sess)
@@ -1040,7 +1043,10 @@ class SharedTerminalController:
             except Exception as e:
                 await session.stop()
                 logger.exception("Shared terminal join failed: %s", e)
-                send_error(conn.sock, f"Failed to join shared terminal: {e}")
+                send_error(
+                    conn.sock,
+                    f"Failed to join shared terminal: {e}",
+                )
 
         self._conn.terminal_task = asyncio.create_task(_start_shared())
 


### PR DESCRIPTION
## Summary

Extract helpers from three oversized wshandler handlers:

- **TerminalController.start** (161L → ~90L): extract `_register_browser`, `_restore_and_sync_windows`, `_send_shared_terminals`
- **Connection.handle_workspace_connect** (140L → ~70L): extract `_send_chat_history`, `_send_workspace_members`, `_broadcast_join`
- **SharedTerminalController.join_shared_terminal** (116L → ~80L): extract `_select_shared_window`

Part of #974

## Test plan
- [x] All 1893 backend tests pass unchanged
- [x] 100% coverage maintained
- [ ] CI green