### PR TITLE
refactor(frontend): break up oversized build() methods (login_page, ide_layout)

### DIFF
--- a/src/frontend/lib/auth/login_page.dart
+++ b/src/frontend/lib/auth/login_page.dart
@@ -53,8 +53,9 @@ class _LoginPageState extends State<LoginPage> {
         if (mounted) {
           setState(() {
             _registrationEnabled = data['registration_enabled'] ?? true;
-            _oidcProviders =
-                List<Map<String, dynamic>>.from(data['oidc_providers'] ?? []);
+            _oidcProviders = List<Map<String, dynamic>>.from(
+              data['oidc_providers'] ?? [],
+            );
             _authModes = data['auth_modes'] ?? 'password';
           });
         }
@@ -116,6 +117,162 @@ class _LoginPageState extends State<LoginPage> {
     });
   }
 
+  List<Widget> _buildOidcButtons() {
+    return [
+      const SizedBox(height: 24),
+      for (final provider in _oidcProviders)
+        Padding(
+          padding: const EdgeInsets.only(bottom: 8),
+          child: SizedBox(
+            width: double.infinity,
+            child: OutlinedButton.icon(
+              icon: const Icon(Icons.login),
+              label: Text('Log in with ${provider['display_name']}'),
+              onPressed: () {
+                final id = provider['id'];
+                final url = '${baseUrl}/api/v1/auth/oidc/$id/login';
+                navigateTo(url);
+              },
+            ),
+          ),
+        ),
+      if (_showPasswordForm) ...[
+        const SizedBox(height: 8),
+        Row(
+          children: [
+            const Expanded(child: Divider()),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Text('or', style: TextStyle(color: KColors.textMuted)),
+            ),
+            const Expanded(child: Divider()),
+          ],
+        ),
+      ],
+    ];
+  }
+
+  List<Widget> _buildErrorSection(BuildContext context) {
+    if (_error == null) return [];
+    return [
+      const SizedBox(height: 16),
+      Text(
+        _error!,
+        style: TextStyle(color: Theme.of(context).colorScheme.error),
+      ),
+      if (_needsVerification) ...[
+        const SizedBox(height: 8),
+        TextButton(
+          onPressed: _resending ? null : _resendVerification,
+          child: _resending
+              ? const SizedBox(
+                  height: 16,
+                  width: 16,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Text('Resend verification email'),
+        ),
+      ],
+    ];
+  }
+
+  List<Widget> _buildPasswordForm(BuildContext context, AuthService auth) {
+    return [
+      const SizedBox(height: 24),
+      TextFormField(
+        controller: _emailController,
+        decoration: InputDecoration(
+          labelText: 'Email',
+          border: const OutlineInputBorder(),
+        ),
+        validator: (v) {
+          if (v == null || v.trim().isEmpty) return 'Required';
+          if (!RegExp(r'^[^@\s]+@[^@\s]+\.[^@\s]+$').hasMatch(v.trim())) {
+            return 'Enter a valid email address';
+          }
+          return null;
+        },
+        onFieldSubmitted: (_) => _submit(),
+      ),
+      const SizedBox(height: 16),
+      TextFormField(
+        controller: _passwordController,
+        decoration: InputDecoration(
+          labelText: 'Password',
+          border: const OutlineInputBorder(),
+          suffixIcon: IconButton(
+            icon: Icon(
+              _obscurePassword ? Icons.visibility_off : Icons.visibility,
+            ),
+            onPressed: () {
+              setState(() {
+                _obscurePassword = !_obscurePassword;
+              });
+            },
+          ),
+        ),
+        obscureText: _obscurePassword,
+        validator: (v) {
+          if (v == null || v.isEmpty) return 'Required';
+          if (_isRegister && v.length < 4) return 'Min 4 characters';
+          return null;
+        },
+        onFieldSubmitted: (_) => _submit(),
+      ),
+      ..._buildErrorSection(context),
+      const SizedBox(height: 24),
+      SizedBox(
+        width: double.infinity,
+        child: FilledButton(
+          onPressed: auth.loading ? null : _submit,
+          style: _isRegister
+              ? FilledButton.styleFrom(
+                  backgroundColor: KColors.accentGreen,
+                  foregroundColor: Colors.white,
+                )
+              : null,
+          child: auth.loading
+              ? const SizedBox(
+                  height: 20,
+                  width: 20,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : Text(_isRegister ? 'Create Account' : 'Log In'),
+        ),
+      ),
+      if (pendingRedirect != null) ...[
+        const SizedBox(height: 12),
+        Text(
+          'Please log in to continue.',
+          style: TextStyle(color: Theme.of(context).colorScheme.error),
+        ),
+      ],
+      if (_registrationEnabled) ...[
+        const SizedBox(height: 8),
+        TextButton(
+          onPressed: () {
+            setState(() {
+              _isRegister = !_isRegister;
+              _error = null;
+            });
+          },
+          child: Text(
+            _isRegister
+                ? 'Already have an account? Log in'
+                : 'Need an account? Create one',
+          ),
+        ),
+      ],
+      // coverage:ignore-start
+      if (!_isRegister)
+        TextButton(
+          onPressed: () => context.go('/forgot-password'),
+          child: const Text('Forgot password?'),
+        ),
+      // coverage:ignore-end
+    ];
+  }
+
   @override
   Widget build(BuildContext context) {
     final auth = context.watch<AuthService>();
@@ -138,160 +295,8 @@ class _LoginPageState extends State<LoginPage> {
                       _isRegister ? 'Create Account' : 'Log In',
                       style: Theme.of(context).textTheme.titleLarge,
                     ),
-                    if (_oidcProviders.isNotEmpty) ...[
-                      const SizedBox(height: 24),
-                      for (final provider in _oidcProviders)
-                        Padding(
-                          padding: const EdgeInsets.only(bottom: 8),
-                          child: SizedBox(
-                            width: double.infinity,
-                            child: OutlinedButton.icon(
-                              icon: const Icon(Icons.login),
-                              label: Text(
-                                  'Log in with ${provider['display_name']}'),
-                              onPressed: () {
-                                final id = provider['id'];
-                                final url =
-                                    '${baseUrl}/api/v1/auth/oidc/$id/login';
-                                navigateTo(url);
-                              },
-                            ),
-                          ),
-                        ),
-                      if (_showPasswordForm) ...[
-                        const SizedBox(height: 8),
-                        Row(
-                          children: [
-                            const Expanded(child: Divider()),
-                            Padding(
-                              padding:
-                                  const EdgeInsets.symmetric(horizontal: 16),
-                              child: Text('or',
-                                  style: TextStyle(color: KColors.textMuted)),
-                            ),
-                            const Expanded(child: Divider()),
-                          ],
-                        ),
-                      ],
-                    ],
-                    if (_showPasswordForm) ...[
-                      const SizedBox(height: 24),
-                      TextFormField(
-                        controller: _emailController,
-                        decoration: InputDecoration(
-                          labelText: 'Email',
-                          border: const OutlineInputBorder(),
-                        ),
-                        validator: (v) {
-                          if (v == null || v.trim().isEmpty) return 'Required';
-                          if (!RegExp(r'^[^@\s]+@[^@\s]+\.[^@\s]+$')
-                              .hasMatch(v.trim())) {
-                            return 'Enter a valid email address';
-                          }
-                          return null;
-                        },
-                        onFieldSubmitted: (_) => _submit(),
-                      ),
-                      const SizedBox(height: 16),
-                      TextFormField(
-                        controller: _passwordController,
-                        decoration: InputDecoration(
-                          labelText: 'Password',
-                          border: const OutlineInputBorder(),
-                          suffixIcon: IconButton(
-                            icon: Icon(_obscurePassword
-                                ? Icons.visibility_off
-                                : Icons.visibility),
-                            onPressed: () {
-                              setState(() {
-                                _obscurePassword = !_obscurePassword;
-                              });
-                            },
-                          ),
-                        ),
-                        obscureText: _obscurePassword,
-                        validator: (v) {
-                          if (v == null || v.isEmpty) return 'Required';
-                          if (_isRegister && v.length < 4)
-                            return 'Min 4 characters';
-                          return null;
-                        },
-                        onFieldSubmitted: (_) => _submit(),
-                      ),
-                      if (_error != null) ...[
-                        const SizedBox(height: 16),
-                        Text(_error!,
-                            style: TextStyle(
-                                color: Theme.of(context).colorScheme.error)),
-                        if (_needsVerification) ...[
-                          const SizedBox(height: 8),
-                          TextButton(
-                            onPressed: _resending ? null : _resendVerification,
-                            child: _resending
-                                ? const SizedBox(
-                                    height: 16,
-                                    width: 16,
-                                    child: CircularProgressIndicator(
-                                        strokeWidth: 2),
-                                  )
-                                : const Text('Resend verification email'),
-                          ),
-                        ],
-                      ],
-                      const SizedBox(height: 24),
-                      SizedBox(
-                        width: double.infinity,
-                        child: FilledButton(
-                          onPressed: auth.loading ? null : _submit,
-                          style: _isRegister
-                              ? FilledButton.styleFrom(
-                                  backgroundColor: KColors.accentGreen,
-                                  foregroundColor: Colors.white,
-                                )
-                              : null,
-                          child: auth.loading
-                              ? const SizedBox(
-                                  height: 20,
-                                  width: 20,
-                                  child:
-                                      CircularProgressIndicator(strokeWidth: 2),
-                                )
-                              : Text(_isRegister ? 'Create Account' : 'Log In'),
-                        ),
-                      ),
-                      if (pendingRedirect != null) ...[
-                        const SizedBox(height: 12),
-                        Text(
-                          'Please log in to continue.',
-                          style: TextStyle(
-                            color: Theme.of(context).colorScheme.error,
-                          ),
-                        ),
-                      ],
-                      if (_registrationEnabled) ...[
-                        const SizedBox(height: 8),
-                        TextButton(
-                          onPressed: () {
-                            setState(() {
-                              _isRegister = !_isRegister;
-                              _error = null;
-                            });
-                          },
-                          child: Text(
-                            _isRegister
-                                ? 'Already have an account? Log in'
-                                : 'Need an account? Create one',
-                          ),
-                        ),
-                      ],
-                      // coverage:ignore-start
-                      if (!_isRegister)
-                        TextButton(
-                          onPressed: () => context.go('/forgot-password'),
-                          child: const Text('Forgot password?'),
-                        ),
-                      // coverage:ignore-end
-                    ], // end _showPasswordForm
+                    if (_oidcProviders.isNotEmpty) ..._buildOidcButtons(),
+                    if (_showPasswordForm) ..._buildPasswordForm(context, auth),
                   ],
                 ),
               ),

--- a/src/frontend/lib/layout/ide_layout.dart
+++ b/src/frontend/lib/layout/ide_layout.dart
@@ -137,13 +137,8 @@ class IdeLayoutState extends State<IdeLayout> {
     });
   }
 
-  @override
-  Widget build(BuildContext context) {
-    final hasDebug = widget.debug != null;
-    final hasChat = widget.chat != null;
-    final hasSettings = widget.settings != null;
-
-    // Build dynamic tab list: Terminal(0), Files(1), Chat?(2), Settings?(last)
+  /// Build the dynamic tab bar and content pane lists.
+  ({List<Widget> tabs, List<Widget> content}) _buildTabsAndContent() {
     final tabs = <Widget>[
       SkeuoTab(
         label: 'Terminal',
@@ -164,59 +159,94 @@ class IdeLayoutState extends State<IdeLayout> {
         padding: const EdgeInsets.only(left: 6, top: 4),
         child: widget.terminal,
       ),
-      // Material (not a plain ColoredBox) so the file viewer's ListTiles paint
-      // their background/ink on a Material ancestor instead of this pane's
-      // colored box — newer Flutter asserts on ListTile-in-ColoredBox.
-      Material(
-        color: KColors.bgCanvas,
-        child: widget.fileViewer,
-      ),
+      Material(color: KColors.bgCanvas, child: widget.fileViewer),
     ];
-    if (hasChat) {
-      final chatIndex = tabs.length;
-      tabs.add(SkeuoTab(
-        label: 'Chat',
-        icon: Icons.chat_outlined,
-        isSelected: _selectedIndex == chatIndex,
+
+    void addTab(
+      String label,
+      IconData icon,
+      Widget child, {
+      int? badge,
+      bool badgeHighlight = false,
+    }) {
+      final index = tabs.length;
+      tabs.add(
+        SkeuoTab(
+          label: label,
+          icon: icon,
+          isSelected: _selectedIndex == index,
+          badge: badge,
+          badgeHighlight: badgeHighlight,
+          onTap: () => _selectTab(index),
+        ),
+      );
+      content.add(Container(color: KColors.bgCanvas, child: child));
+    }
+
+    if (widget.chat != null) {
+      addTab(
+        'Chat',
+        Icons.chat_outlined,
+        widget.chat!,
         badge: widget.chatUnread > 0 ? widget.chatUnread : null,
         badgeHighlight: widget.chatMentioned,
-        onTap: () => _selectTab(chatIndex),
-      ));
-      content.add(Container(
-        color: KColors.bgCanvas,
-        child: widget.chat!,
-      ));
+      );
     }
     if (widget.sharing != null) {
-      final sharingIndex = tabs.length;
-      tabs.add(SkeuoTab(
-        label: 'Sharing',
-        icon: Icons.people_outline,
-        isSelected: _selectedIndex == sharingIndex,
-        onTap: () => _selectTab(sharingIndex),
-      ));
-      content.add(Container(
-        color: KColors.bgCanvas,
-        child: widget.sharing!,
-      ));
+      addTab('Sharing', Icons.people_outline, widget.sharing!);
     }
-    if (hasSettings) {
-      final settingsIndex = tabs.length;
-      tabs.add(SkeuoTab(
-        label: 'Settings',
-        icon: Icons.settings,
-        isSelected: _selectedIndex == settingsIndex,
-        onTap: () => _selectTab(settingsIndex),
-      ));
-      content.add(Container(
-        color: KColors.bgCanvas,
-        child: widget.settings!,
-      ));
+    if (widget.settings != null) {
+      addTab('Settings', Icons.settings, widget.settings!);
     }
+
+    return (tabs: tabs, content: content);
+  }
+
+  List<Widget> _buildDebugPane() {
+    if (widget.debug == null) return [];
+    return [
+      GestureDetector(
+        onVerticalDragUpdate: (details) {
+          setState(() {
+            _debugHeight = (_debugHeight - details.delta.dy).clamp(
+              _minDebugHeight,
+              _maxDebugHeight,
+            );
+          });
+        },
+        onDoubleTap: () {
+          setState(() {
+            _debugHeight = _debugHeight > 0 ? 0 : 200;
+          });
+        },
+        child: MouseRegion(
+          cursor: SystemMouseCursors.resizeRow,
+          child: Container(
+            height: _dividerHeight,
+            color: KColors.borderMuted,
+            child: Center(
+              child: Container(
+                width: 40,
+                height: 3,
+                decoration: BoxDecoration(
+                  color: KColors.textMuted,
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+      SizedBox(height: _debugHeight, child: widget.debug!),
+    ];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final (:tabs, :content) = _buildTabsAndContent();
 
     return Column(
       children: [
-        // Tab bar
         Container(
           height: 40,
           color: KColors.bgCanvas,
@@ -225,52 +255,12 @@ class IdeLayoutState extends State<IdeLayout> {
             children: tabs.map((t) => Expanded(child: t)).toList(),
           ),
         ),
-        // Content area
         Expanded(
           child: ClipRect(
-            child: IndexedStack(
-              index: _selectedIndex,
-              children: content,
-            ),
+            child: IndexedStack(index: _selectedIndex, children: content),
           ),
         ),
-        // Debug divider + pane
-        if (hasDebug) ...[
-          GestureDetector(
-            onVerticalDragUpdate: (details) {
-              setState(() {
-                _debugHeight = (_debugHeight - details.delta.dy)
-                    .clamp(_minDebugHeight, _maxDebugHeight);
-              });
-            },
-            onDoubleTap: () {
-              setState(() {
-                _debugHeight = _debugHeight > 0 ? 0 : 200;
-              });
-            },
-            child: MouseRegion(
-              cursor: SystemMouseCursors.resizeRow,
-              child: Container(
-                height: _dividerHeight,
-                color: KColors.borderMuted,
-                child: Center(
-                  child: Container(
-                    width: 40,
-                    height: 3,
-                    decoration: BoxDecoration(
-                      color: KColors.textMuted,
-                      borderRadius: BorderRadius.circular(2),
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          ),
-          SizedBox(
-            height: _debugHeight,
-            child: widget.debug!,
-          ),
-        ],
+        ..._buildDebugPane(),
       ],
     );
   }


### PR DESCRIPTION
## Summary

Extract helpers from two long Dart `build()` methods:

- **`_LoginPageState.build`** (184L → ~25L): extract `_buildOidcButtons`, `_buildPasswordForm`, `_buildErrorSection`
- **`IdeLayoutState.build`** (136L → ~25L): extract `_buildTabsAndContent` (with local `addTab` helper to eliminate repetitive tab/content registration), `_buildDebugPane`

Part of #976

## Test plan
- [x] All 60 login_page + ide_layout tests pass
- [ ] CI green