### PR TITLE
feat: wire up default_command via tmux send-keys

### DIFF
--- a/docs/features/default-command.md
+++ b/docs/features/default-command.md
@@ -1,0 +1,72 @@
+<!-- markdownlint-disable MD013 -->
+
+# Default Command
+
+A workspace can have a **default command** — a shell command that
+runs automatically in the first terminal window when the terminal
+session starts. This is useful for workspaces that serve a
+long-running process like a dev server, AI gateway, or any daemon
+that should be running whenever the workspace is in use.
+
+## How it works
+
+When a workspace has a default command configured, the server sends
+it as keystrokes into the first tmux window immediately after
+creating the terminal session. The command runs as a normal
+foreground process inside a bash login shell.
+
+This means:
+
+- **Ctrl+C** stops the process and returns you to the bash prompt
+- **Up-arrow + Enter** restarts it
+- The terminal scrollback shows the process output
+- The experience is identical to typing the command yourself
+
+If no default command is set, the terminal starts with a plain bash
+prompt as usual.
+
+## Setting the default command
+
+### Web UI
+
+Set the default command when creating a workspace, or change it
+later in the workspace **Settings** tab.
+
+### CLI
+
+```bash
+# Set during creation
+klangkc create my-workspace --default-command 'openclaw gateway'
+
+# Change later
+klangkc edit my-workspace --default-command 'npm run dev'
+
+# Clear it
+klangkc edit my-workspace --default-command ''
+```
+
+### Sandbox config
+
+In `.klangk-sandbox.yaml`:
+
+```yaml
+workspace:
+  default-command: openclaw gateway
+```
+
+## When does the command run?
+
+The default command runs when the terminal session is created —
+typically on the first connection to the workspace after the
+container starts. It does **not** re-run on reconnect; if you
+disconnect and reconnect, you pick up the tmux session exactly
+where you left off (the process may still be running, or you may
+be at a bash prompt if it exited).
+
+## Use cases
+
+- **Dev servers** — `npm run dev`, `python manage.py runserver`
+- **AI agents** — `pi`, `openclaw gateway`
+- **Background services** — any daemon you want running by default
+- **Project setup** — a command that initializes the environment
+  on first terminal open

--- a/docs/features/default-command.md
+++ b/docs/features/default-command.md
@@ -63,6 +63,16 @@ disconnect and reconnect, you pick up the tmux session exactly
 where you left off (the process may still be running, or you may
 be at a bash prompt if it exited).
 
+## Shell features
+
+The command is sent as keystrokes into a bash shell, so any shell
+syntax works — pipes, redirects, `&&` chains, subshells, etc.:
+
+```yaml
+workspace:
+  default-command: openclaw gateway 2>&1 | tee /tmp/gateway.log
+```
+
 ## Use cases
 
 - **Dev servers** — `npm run dev`, `python manage.py runserver`

--- a/docs/features/sandbox.md
+++ b/docs/features/sandbox.md
@@ -53,11 +53,13 @@ placed in `~/work`.
 ```yaml
 workspace:
   image: klangk-workspace
+  default-command: openclaw gateway
 ```
 
-| Field   | Required | Default              | Description                                                   |
-| ------- | -------- | -------------------- | ------------------------------------------------------------- |
-| `image` | no       | server default image | Container image. Must be in the server's allowed images list. |
+| Field             | Required | Default              | Description                                                                                                            |
+| ----------------- | -------- | -------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `image`           | no       | server default image | Container image. Must be in the server's allowed images list.                                                          |
+| `default-command` | no       | (none)               | Command to run automatically in the first terminal window on first connect. See [Default Command](default-command.md). |
 
 The workspace name is not in the config file — it's always
 specified as a positional argument on the command line.

--- a/src/backend/klangk_backend/api/workspaces.py
+++ b/src/backend/klangk_backend/api/workspaces.py
@@ -236,10 +236,6 @@ async def update_workspace(
     )
     if not updated:
         raise HTTPException(status_code=404, detail="Workspace not found")
-    if "default_command" in fields:
-        workspaces.write_default_command(
-            workspace["user_id"], workspace_id, fields["default_command"]
-        )
     return {"status": "updated"}
 
 

--- a/src/backend/klangk_backend/terminal.py
+++ b/src/backend/klangk_backend/terminal.py
@@ -73,7 +73,6 @@ _SENSITIVE_ENV_PREFIXES = (
 
 
 def _build_environment(
-    command_override: str | None,
     user_home: str | None = None,
     user_id: str | None = None,
     user_handle: str | None = None,
@@ -86,8 +85,6 @@ def _build_environment(
         env.append(f"KLANGK_USER_ID={user_id}")
     if user_handle is not None:
         env.append(f"KLANGK_USER_HANDLE={user_handle}")
-    if command_override is not None:
-        env.append(f"KLANGK_CMD_OVERRIDE={command_override}")
     if ssh_agent_socket is not None:
         env.append(f"SSH_AUTH_SOCK={ssh_agent_socket}")
     return env
@@ -101,11 +98,19 @@ async def _ensure_base_session(
     session_name: str,
     user_home: str | None = None,
     ssh_agent_socket: str | None = None,
-) -> None:
+    default_command: str | None = None,
+) -> bool:
     """Create the base tmux session (detached) if it doesn't exist.
 
     Grouped sessions require a target session.  This ensures the base
     session exists before any grouped session tries to link to it.
+
+    If *default_command* is set and the session is freshly created,
+    the command is sent as keystrokes into window 0.  The command
+    runs as a foreground process in the bash shell — Ctrl-C stops
+    it and returns to the prompt.
+
+    Returns ``True`` if the session was freshly created.
     """
     # Check if the session already exists.
     try:
@@ -116,7 +121,7 @@ async def _ensure_base_session(
             timeout=5,
         )
         if rc == 0:
-            return  # already exists
+            return False  # already exists
     except Exception:
         pass  # assume it doesn't exist
 
@@ -136,6 +141,30 @@ async def _ensure_base_session(
         )
     except Exception:
         logger.warning("Failed to create base tmux session %s", session_name)
+        return False
+
+    # Send default command as keystrokes into window 0.
+    if default_command:
+        try:
+            await podman.exec_container(
+                container_id,
+                [
+                    "tmux",
+                    "send-keys",
+                    "-t",
+                    f"{session_name}:0",
+                    default_command,
+                    "Enter",
+                ],
+                user=CONTAINER_USER,
+                timeout=5,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to send default command to session %s", session_name
+            )
+
+    return True
 
 
 def _build_shell_command(
@@ -640,6 +669,7 @@ class TerminalSession:
         user_id: str | None = None,
         user_handle: str | None = None,
         ssh_agent_socket: str | None = None,
+        default_command: str | None = None,
     ):
         self.container_id = container_id
         self.session_name = session_name
@@ -650,6 +680,7 @@ class TerminalSession:
         self.user_id = user_id
         self.user_handle = user_handle
         self.ssh_agent_socket = ssh_agent_socket
+        self.default_command = default_command
         self._shell: ShellProcess | None = None
         self._output_queue: BoundedOutputQueue[str] = BoundedOutputQueue(
             maxsize=64
@@ -662,7 +693,6 @@ class TerminalSession:
         self,
         cols: int = 80,
         rows: int = 24,
-        command_override: str | None = None,
     ) -> None:
         """Start a shell session via ``podman exec`` over a PTY."""
         self._running = True
@@ -680,9 +710,9 @@ class TerminalSession:
                 self.session_name,
                 user_home=self.user_home,
                 ssh_agent_socket=self.ssh_agent_socket,
+                default_command=self.default_command,
             )
         env = _build_environment(
-            command_override,
             self.user_home,
             user_id=self.user_id,
             user_handle=self.user_handle,

--- a/src/backend/klangk_backend/workspaces.py
+++ b/src/backend/klangk_backend/workspaces.py
@@ -224,19 +224,6 @@ def get_config_host_path(user_id: str, workspace_id: str) -> Path:
     return path
 
 
-def write_default_command(
-    user_id: str, workspace_id: str, command: str | None
-) -> None:
-    """Write the default command file to the config directory."""
-    path = config_path(user_id, workspace_id)
-    path.mkdir(parents=True, exist_ok=True)
-    cmd_file = path / "default-command"
-    if command:
-        cmd_file.write_text(command)
-    elif cmd_file.exists():
-        cmd_file.unlink()
-
-
 async def create_workspace(
     user_id: str,
     name: str,
@@ -261,8 +248,6 @@ async def create_workspace(
     users_dir.mkdir(exist_ok=True)
     terminals_dir = home / ".terminals"
     terminals_dir.mkdir(exist_ok=True)
-    if default_command:
-        write_default_command(user_id, workspace["id"], default_command)
     # Allocate ports at creation time so ranges are sequential
     try:
         await container.registry.allocate_ports(

--- a/src/backend/klangk_backend/wshandler/connection.py
+++ b/src/backend/klangk_backend/wshandler/connection.py
@@ -67,6 +67,7 @@ class Connection:
         self.pending_status_msg: str | None = None
         self._browser_id: str | None = None
         self._user_home: str | None = None
+        self._default_command: str | None = None
         self._home_created: bool = False
         self._terminal_cols: int = 80
         self._terminal_rows: int = 24
@@ -318,6 +319,7 @@ class Connection:
         self.container_status = container_status
         self.workspace_id = workspace_id
         self.container_id = container_id
+        self._default_command = workspace.get("default_command")
 
         session = state.get_or_create_session(workspace_id)
         await session.add_subscriber(self.sock, container_id)

--- a/src/backend/klangk_backend/wshandler/controllers.py
+++ b/src/backend/klangk_backend/wshandler/controllers.py
@@ -434,7 +434,6 @@ class TerminalController:
         rows = msg.get("rows", self.rows)
         self.cols = cols
         self.rows = rows
-        command_override = msg.get("commandOverride")
         session = TerminalSession(
             self._conn.container_id,
             session_name=self._conn.user["id"],
@@ -442,6 +441,7 @@ class TerminalController:
             user_id=self._conn.user["id"],
             user_handle=self._conn.user.get("handle"),
             ssh_agent_socket=self._conn._ssh_agent_socket,
+            default_command=self._conn._default_command,
         )
 
         browser_id = msg.get("browser_id")
@@ -461,9 +461,7 @@ class TerminalController:
                     conn.container_id,
                 )
                 await asyncio.wait_for(
-                    session.start(
-                        cols, rows, command_override=command_override
-                    ),
+                    session.start(cols, rows),
                     timeout=30,
                 )
                 if browser_id:

--- a/src/backend/tests/test_model.py
+++ b/src/backend/tests/test_model.py
@@ -600,26 +600,6 @@ class TestDefaultCommand:
         assert match[0]["default_command"] == "pi"
 
 
-class TestWriteDefaultCommand:
-    def test_write_and_clear(self, tmp_path, monkeypatch):
-        from klangk_backend import workspaces
-
-        monkeypatch.setattr(workspaces, "WORKSPACES_ROOT", tmp_path)
-        workspaces.write_default_command("u1", "ws1", "pi")
-        cmd_file = tmp_path / "u1" / "config" / "ws1" / "default-command"
-        assert cmd_file.read_text() == "pi"
-
-        workspaces.write_default_command("u1", "ws1", None)
-        assert not cmd_file.exists()
-
-    def test_clear_nonexistent(self, tmp_path, monkeypatch):
-        from klangk_backend import workspaces
-
-        monkeypatch.setattr(workspaces, "WORKSPACES_ROOT", tmp_path)
-        # Should not raise even if file doesn't exist
-        workspaces.write_default_command("u1", "ws1", None)
-
-
 class TestContainerTracking:
     async def test_update_workspace_container(self, workspace, user):
         await model.update_workspace_container(

--- a/src/backend/tests/test_terminal.py
+++ b/src/backend/tests/test_terminal.py
@@ -183,15 +183,6 @@ class TestStart:
         assert "ANTHROPIC_API_KEY" in unset
         await s.stop()
 
-    async def test_command_override_sets_env_var(self):
-        fake = FakeShell(block_after_chunks=True)
-        with _patch(fake):
-            s = TerminalSession("cid")
-            await s.start(command_override="bash")
-        assert "-e" in fake.argv
-        assert "KLANGK_CMD_OVERRIDE=bash" in fake.argv
-        await s.stop()
-
     async def test_no_command_override_by_default(self):
         fake = FakeShell(block_after_chunks=True)
         with _patch(fake):
@@ -1170,8 +1161,8 @@ class TestEnsureBaseSession:
             new_callable=AsyncMock,
             return_value=(0, "", ""),  # has-session succeeds
         ) as mock_exec:
-            await _ensure_base_session("cid", "my-session")
-        # has-session called, but new-session not called
+            created = await _ensure_base_session("cid", "my-session")
+        assert created is False
         mock_exec.assert_awaited_once()
         assert "has-session" in mock_exec.call_args.args[1]
 
@@ -1184,9 +1175,10 @@ class TestEnsureBaseSession:
             new_callable=AsyncMock,
             side_effect=[(1, "", ""), (0, "", "")],  # has fail, new ok
         ) as mock_exec:
-            await _ensure_base_session(
+            created = await _ensure_base_session(
                 "cid", "my-session", user_home="/home/u"
             )
+        assert created is True
         assert mock_exec.await_count == 2
         new_cmd = mock_exec.call_args_list[1].args[1]
         assert "new-session" in new_cmd
@@ -1202,7 +1194,8 @@ class TestEnsureBaseSession:
             new_callable=AsyncMock,
             side_effect=[OSError("boom"), (0, "", "")],
         ) as mock_exec:
-            await _ensure_base_session("cid", "my-session")
+            created = await _ensure_base_session("cid", "my-session")
+        assert created is True
         assert mock_exec.await_count == 2
 
     async def test_create_failure_logs_warning(self):
@@ -1214,8 +1207,8 @@ class TestEnsureBaseSession:
             new_callable=AsyncMock,
             side_effect=[(1, "", ""), OSError("create failed")],
         ):
-            # Should not raise
-            await _ensure_base_session("cid", "my-session")
+            created = await _ensure_base_session("cid", "my-session")
+        assert created is False
 
     async def test_env_args_passed(self):
         """HOME and SSH_AUTH_SOCK are passed as tmux -e flags."""
@@ -1235,3 +1228,59 @@ class TestEnsureBaseSession:
         new_cmd = mock_exec.call_args_list[1].args[1]
         assert "HOME=/home/u" in new_cmd
         assert "SSH_AUTH_SOCK=/tmp/agent.sock" in new_cmd
+
+    async def test_default_command_sends_keys(self):
+        """Default command is sent as keystrokes after session creation."""
+        from klangk_backend.terminal import _ensure_base_session
+
+        with patch(
+            "klangk_backend.terminal.podman.exec_container",
+            new_callable=AsyncMock,
+            side_effect=[
+                (1, "", ""),  # has-session fails
+                (0, "", ""),  # new-session ok
+                (0, "", ""),  # send-keys ok
+            ],
+        ) as mock_exec:
+            created = await _ensure_base_session(
+                "cid", "my-session", default_command="openclaw gateway"
+            )
+        assert created is True
+        assert mock_exec.await_count == 3
+        send_cmd = mock_exec.call_args_list[2].args[1]
+        assert "send-keys" in send_cmd
+        assert "my-session:0" in send_cmd
+        assert "openclaw gateway" in send_cmd
+        assert "Enter" in send_cmd
+
+    async def test_default_command_skipped_when_session_exists(self):
+        """Default command is not sent if session already exists."""
+        from klangk_backend.terminal import _ensure_base_session
+
+        with patch(
+            "klangk_backend.terminal.podman.exec_container",
+            new_callable=AsyncMock,
+            return_value=(0, "", ""),  # has-session succeeds
+        ) as mock_exec:
+            await _ensure_base_session(
+                "cid", "my-session", default_command="openclaw gateway"
+            )
+        mock_exec.assert_awaited_once()
+
+    async def test_default_command_failure_logs_warning(self):
+        """Warning logged when send-keys fails, session still created."""
+        from klangk_backend.terminal import _ensure_base_session
+
+        with patch(
+            "klangk_backend.terminal.podman.exec_container",
+            new_callable=AsyncMock,
+            side_effect=[
+                (1, "", ""),  # has-session fails
+                (0, "", ""),  # new-session ok
+                OSError("send-keys failed"),
+            ],
+        ):
+            created = await _ensure_base_session(
+                "cid", "my-session", default_command="openclaw gateway"
+            )
+        assert created is True

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -726,6 +726,7 @@ class TestHandleTerminalStart:
             user_id="uid",
             user_handle="testuser",
             ssh_agent_socket=None,
+            default_command=None,
         )
         # Should have sent terminal_windows and shared_terminals
         sent = [c[0][0] for c in sock.send_json.call_args_list]
@@ -739,8 +740,6 @@ class TestHandleTerminalStart:
         )
 
         # browser_id should be registered and stored on the connection
-        start_kwargs = mock_session.start.call_args
-        assert start_kwargs[1]["command_override"] is None
         assert conn._browser_id == "test-browser-id"
         assert conn.terminal_session is mock_session
         assert conn.terminal_task is not None
@@ -1169,12 +1168,13 @@ class TestHandleTerminalStart:
         assert conn._browser_id is None
         mock_attach.assert_not_awaited()
 
-    async def test_passes_command_override(self):
+    async def test_passes_default_command(self):
         sock = _mock_sock()
         conn = _base_conn(ws=sock)
         conn.container_id = "cid"
         conn.workspace_id = "ws"
         conn._user_home = "/home/testuser"
+        conn._default_command = "pi"
 
         async def _perm(*a):
             return True
@@ -1195,15 +1195,19 @@ class TestHandleTerminalStart:
                 {
                     "cols": 80,
                     "rows": 24,
-                    "commandOverride": "bash",
                     "browser_id": "bid-cmd",
                 }
             )
-            # Let the background task run
             await asyncio.sleep(0)
 
-        mock_session.start.assert_awaited_once_with(
-            80, 24, command_override="bash"
+        MockTS.assert_called_once_with(
+            "cid",
+            session_name="uid",
+            user_home="/home/testuser",
+            user_id="uid",
+            user_handle="testuser",
+            ssh_agent_socket=None,
+            default_command="pi",
         )
 
         conn.terminal_task.cancel()
@@ -2960,6 +2964,7 @@ class TestSSHAgentHandlers:
             user_id="uid",
             user_handle="testuser",
             ssh_agent_socket="/tmp/klangk-ssh-agent-uid.sock",
+            default_command=None,
         )
 
 
@@ -5003,6 +5008,7 @@ class TestTerminalController:
             _ssh_agent_socket=None,
             _browser_id=None,
             _viewing_shared=None,
+            _default_command=None,
             user=user,
             _has_perm=AsyncMock(return_value=has_perm),
             _broadcast_shared_terminals=MagicMock(),

--- a/src/cli/e2e-tests/test_cli_e2e.py
+++ b/src/cli/e2e-tests/test_cli_e2e.py
@@ -661,34 +661,19 @@ class TestDefaultCommand:
             env=env,
         )
 
-    def test_default_command_written_to_container(self, cli_config):
-        """set-command → container gets KLANGK_DEFAULT_COMMAND → .klangk-command."""
+    def test_default_command_stored_in_workspace(self, cli_config):
+        """default_command is stored in the workspace via the API."""
         env = cli_config["env"]
         TestDefaultCommand._login(cli_config)
         _run(["klangkc", "create", "e2e-defcmd"], env=env)
         try:
-            # Set command before container starts
+            # Set command
             result = _run(
                 ["klangkc", "edit", "e2e-defcmd", "--command", "echo hello"],
                 env=env,
             )
             assert result.returncode == 0
             assert "Updated" in result.stdout
-
-            # exec triggers container start; config mount has the command
-            result = _run(
-                [
-                    "klangkc",
-                    "exec",
-                    "e2e-defcmd",
-                    "cat",
-                    "/opt/klangk/config/default-command",
-                ],
-                env=env,
-                timeout=120,
-            )
-            assert result.returncode == 0
-            assert result.stdout.strip() == "echo hello"
 
             # Clear
             result = _run(
@@ -698,42 +683,6 @@ class TestDefaultCommand:
             assert "Updated" in result.stdout
         finally:
             _run(["klangkc", "rm", "e2e-defcmd"], env=env)
-
-    def test_default_command_bash_no_infinite_loop(self, cli_config):
-        """Setting default command to bash should not cause infinite recursion."""
-        env = cli_config["env"]
-        TestDefaultCommand._login(cli_config)
-        _run(["klangkc", "create", "e2e-defbash"], env=env)
-        try:
-            _run(
-                ["klangkc", "edit", "e2e-defbash", "--command", "bash"],
-                env=env,
-            )
-            # Start the container first
-            _run(
-                ["klangkc", "exec", "e2e-defbash", "true"],
-                env=env,
-                timeout=30,
-            )
-            # Run an interactive bash inside the container that sources
-            # .bashrc, which would exec bash again without the
-            # KLANGK_CMD_STARTED guard. If recursion happens, this hangs
-            # and times out. We pipe "exit" to terminate the shell.
-            result = _run(
-                [
-                    "klangkc",
-                    "exec",
-                    "e2e-defbash",
-                    "bash",
-                    "-ic",
-                    "exit 0",
-                ],
-                env=env,
-                timeout=15,
-            )
-            assert result.returncode == 0
-        finally:
-            _run(["klangkc", "rm", "e2e-defbash"], env=env)
 
 
 class TestMounts:

--- a/src/cli/klangkc/client.py
+++ b/src/cli/klangkc/client.py
@@ -325,12 +325,15 @@ class KlangkClient:
         self,
         name: str,
         image: str | None = None,
+        default_command: str | None = None,
         mounts: list[str] | None = None,
         env: dict[str, str] | None = None,
     ) -> Workspace:
         body: dict = {"name": name}
         if image:
             body["image"] = image
+        if default_command:
+            body["default_command"] = default_command
         if mounts:
             body["mounts"] = mounts
         if env:
@@ -623,7 +626,6 @@ async def _ws_shell(
     token: str,
     workspace_id: str,
     raw_mode: bool = True,
-    command_override: str | None = None,
     window: str | None = None,
     forward_agent: bool = False,
     sandbox_setup=None,
@@ -633,7 +635,6 @@ async def _ws_shell(
 
     raw_mode controls whether stdin is placed in raw (cbreak) mode.
     Pass False in tests or when stdin is not a real terminal.
-    command_override, if set, overrides the workspace default command.
     window, if set, selects a specific window by name. Use
     ``handle:window_name`` to join another user's shared window.
     sandbox_setup, if set, is an async callable(ws) invoked after the
@@ -709,15 +710,16 @@ async def _ws_shell(
 
         # 2c. Start terminal
         cols, rows = _get_terminal_size()
-        start_msg: dict = {
-            "cmd": "terminal_start",
-            "cols": cols,
-            "rows": rows,
-            "browser_id": "klangkshell",
-        }
-        if command_override is not None:
-            start_msg["commandOverride"] = command_override
-        await ws.send(json.dumps(start_msg))
+        await ws.send(
+            json.dumps(
+                {
+                    "cmd": "terminal_start",
+                    "cols": cols,
+                    "rows": rows,
+                    "browser_id": "klangkshell",
+                }
+            )
+        )
 
         # 3. Drain messages until we have terminal_windows (needed for
         # window selection).  terminal_output may arrive before

--- a/src/cli/klangkc/main.py
+++ b/src/cli/klangkc/main.py
@@ -767,12 +767,6 @@ def shell(
         None,
         help="Terminal name to select (or handle:name for shared)",
     ),
-    command: str | None = typer.Option(
-        None,
-        "--command",
-        "-c",
-        help="Override the default shell command",
-    ),
     forward_agent: bool | None = typer.Option(
         None,
         "--forward-agent/--no-forward-agent",
@@ -780,7 +774,7 @@ def shell(
         help="Forward local SSH agent into the container",
     ),
 ) -> None:
-    """Connect to a workspace and execute the default shell command."""
+    """Connect to a workspace shell."""
     # When called directly (not via typer CLI), forward_agent may be a
     # typer.models.OptionInfo instead of bool/None.  Normalize to None.
     if not isinstance(forward_agent, bool):
@@ -837,7 +831,6 @@ def shell(
                 ws_url,
                 token,
                 ws.id,
-                command_override=command,
                 window=terminal,
                 forward_agent=forward_agent,
                 max_size=_ws_max_size(),
@@ -1006,7 +999,10 @@ def sandbox(
         all_mounts = build_all_mounts(config, sandbox_root, handle)
         _err.print(f"Creating workspace [bold]{workspace}[/bold]...")
         ws = client.create_workspace(
-            workspace, image=config.image, mounts=all_mounts
+            workspace,
+            image=config.image,
+            default_command=config.default_command,
+            mounts=all_mounts,
         )
         _err.print(f"Workspace [bold]{workspace}[/bold] created.")
         created = True

--- a/src/cli/klangkc/sandbox.py
+++ b/src/cli/klangkc/sandbox.py
@@ -15,6 +15,7 @@ class SandboxConfig:
 
     # workspace
     image: str | None = None
+    default_command: str | None = None
     # sandbox
     mount_at: str = "~/work"
     setup: str | None = None
@@ -54,6 +55,9 @@ def load_sandbox_config(sandbox_root: Path) -> SandboxConfig:
 
     return SandboxConfig(
         image=workspace.get("image"),
+        default_command=workspace.get(
+            "default-command", workspace.get("default_command")
+        ),
         mount_at=sandbox.get("mount-at", sandbox.get("mount_at", "~/work")),
         setup=sandbox.get("setup"),
         setup_timeout=setup_timeout,

--- a/src/cli/tests/test_cli.py
+++ b/src/cli/tests/test_cli.py
@@ -2008,6 +2008,23 @@ class TestCreateWorkspaceClient:
         assert body["mounts"] == ["/data:/data"]
         assert body["env"] == {"FOO": "bar"}
 
+    def test_create_workspace_with_default_command(self):
+        client = KlangkClient("http://test:8995", "token")
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "id": "ws-cmd",
+            "name": "svc-ws",
+            "created_at": "2025-01-01",
+        }
+        with patch.object(client, "post", return_value=mock_resp) as mock_post:
+            ws = client.create_workspace(
+                "svc-ws", default_command="openclaw gateway"
+            )
+        assert ws.name == "svc-ws"
+        body = mock_post.call_args.kwargs.get("json")
+        assert body["default_command"] == "openclaw gateway"
+
 
 class TestListImagesClient:
     def test_list_images(self):

--- a/src/cli/tests/test_cli_integration.py
+++ b/src/cli/tests/test_cli_integration.py
@@ -125,65 +125,6 @@ class TestWsShell:
         sent = [c[0][0] for c in ws_mock.send.call_args_list]
         assert any("workspace_connect" in s for s in sent)
         assert any("terminal_start" in s for s in sent)
-        # No commandOverride by default
-        start_msgs = [json.loads(s) for s in sent if "terminal_start" in s]
-        assert "commandOverride" not in start_msgs[0]
-
-    @pytest.mark.asyncio
-    async def test_ws_shell_sends_command_override(self):
-        from klangkc.client import _ws_shell
-
-        ws_mock = MagicMock()
-
-        async def fake_enter(self):
-            return ws_mock
-
-        async def fake_exit(self, *args):
-            return None
-
-        ws_mock.__aenter__ = fake_enter
-        ws_mock.__aexit__ = fake_exit
-        ws_mock.send = AsyncMock()
-        ws_mock.recv = AsyncMock(
-            side_effect=[
-                json.dumps({"type": "workspace_ready", "workspaceId": "ws1"}),
-                json.dumps(
-                    {"type": "terminal_output", "data": "\x1b[2J\x1b[H"}
-                ),
-                json.dumps(
-                    {
-                        "type": "terminal_windows",
-                        "windows": [
-                            {
-                                "id": "@0",
-                                "index": 0,
-                                "name": "bash",
-                                "active": True,
-                            },
-                        ],
-                    }
-                ),
-                Exception("stop"),
-            ]
-        )
-
-        with patch("websockets.connect", return_value=ws_mock):
-            with patch("termios.tcgetattr", return_value=None):
-                with patch("termios.tcsetattr"):
-                    with patch("tty.setraw"):
-                        try:
-                            await _ws_shell(
-                                "ws://localhost/ws",
-                                "token",
-                                "ws1",
-                                command_override="bash",
-                            )
-                        except Exception:
-                            pass
-
-        sent = [c[0][0] for c in ws_mock.send.call_args_list]
-        start_msgs = [json.loads(s) for s in sent if "terminal_start" in s]
-        assert start_msgs[0]["commandOverride"] == "bash"
 
     @pytest.mark.asyncio
     async def test_ws_shell_collects_windows_and_shared(self):

--- a/src/containers/workspace/bash.bashrc
+++ b/src/containers/workspace/bash.bashrc
@@ -51,20 +51,3 @@ for f in /opt/klangk/plugins/*/on-shell-init.sh; do
   "$f" || true
   printf '\033[33m%s\033[0m\n' "$(printf '%*s' 60 '' | tr ' ' '-')"
 done
-
-# Determine which command to exec into (if any).
-# KLANGK_CMD_OVERRIDE (set per-session via podman exec -e) takes priority.
-# Otherwise fall back to the workspace default from the config mount.
-# KLANGK_CMD_STARTED guard prevents infinite recursion if the command is bash.
-if [ -z "$KLANGK_CMD_STARTED" ]; then
-  KLANGK_CMD="${KLANGK_CMD_OVERRIDE:-}"
-  if [ -z "$KLANGK_CMD" ] && [ -f /opt/klangk/config/default-command ]; then
-    KLANGK_CMD=$(cat /opt/klangk/config/default-command)
-  fi
-  if [ -n "$KLANGK_CMD" ]; then
-    export KLANGK_CMD_STARTED=1
-    stty sane 2>/dev/null
-    # shellcheck disable=SC2086
-    exec $KLANGK_CMD
-  fi
-fi

--- a/zensical.toml
+++ b/zensical.toml
@@ -21,6 +21,7 @@ nav = [
     { "Workspaces" = "features/workspaces.md" },
     { "Terminal" = "features/terminal.md" },
     { "The Shell" = "features/the-shell.md" },
+    { "Default Command" = "features/default-command.md" },
     { "Sandbox" = "features/sandbox.md" },
     { "Chat" = "features/chat.md" },
     { "File Viewer" = "features/file-viewer.md" },


### PR DESCRIPTION
## Summary

- Wire up the existing `default_command` workspace field to actually run the command. When a workspace has `default_command` set, the server sends it as keystrokes into tmux window 0 after creating the base session. The command runs as a foreground process in bash — Ctrl-C stops it and returns to the prompt.
- Remove the old `command_override` / `KLANGK_CMD_OVERRIDE` / `KLANGK_CMD` mechanism that `exec`'d into the command from bashrc (replacing bash entirely).
- Remove `write_default_command()` which wrote to `/opt/klangk/config/default-command` inside containers.
- Remove `--command` flag from `klangkc shell`.
- Add `default-command` to `.klangk-sandbox.yaml` workspace section.
- Add `docs/features/default-command.md`.

Closes #775

## Test plan

- [x] 1893 backend tests pass (100% coverage)
- [x] 374 CLI tests pass (100% coverage)
- [x] 54 CLI E2E tests pass