### PR TITLE
refactor(cli): divorce sandbox from shell connection (#1009)

### DIFF
--- a/docs/features/sandbox.md
+++ b/docs/features/sandbox.md
@@ -215,6 +215,19 @@ To forward your SSH agent into the container:
 klangkc shell myworkspace -A
 ```
 
+If the workspace has a `default-command` configured (e.g.
+`openclaw gateway`), that command runs in the first terminal
+window. To get an interactive shell alongside it, connect to a
+named terminal window:
+
+```bash
+klangkc shell myworkspace dev
+```
+
+This creates a new terminal window called `dev` where you can
+work interactively while the default command continues running in
+the first window.
+
 The copy and setup steps only run during `klangkc sandbox`. On
 `klangkc shell`, the command connects directly to the existing
 workspace. This means:

--- a/docs/features/sandbox.md
+++ b/docs/features/sandbox.md
@@ -2,17 +2,17 @@
 
 # Sandbox
 
-`klangkc sandbox` creates and connects to a workspace using a
-project-level config file. It's the single command for "get me into
-this project" — create the workspace on the first run, reconnect on
-subsequent runs.
+`klangkc sandbox` creates a workspace using a project-level config
+file. It reads `.klangk-sandbox.yaml`, creates the workspace with the
+configured image, mounts, and volumes, copies files, and runs the
+setup script. Use `klangkc shell` afterwards to connect.
 
 `klangkc sandbox` is a quality-of-life feature of the
 [`klangkc` CLI](../reference/cli.md) that combines several of
 Klangk's individual features — workspace creation, bind mounts,
-file copying, command execution, and shell access — into a single
-step driven by a config file. Everything it does can be done manually
-with `klangkc create`, `klangkc exec`, and `klangkc shell`, but the
+file copying, and command execution — into a single step driven by
+a config file. Everything it does can be done manually with
+`klangkc create`, `klangkc exec`, and `klangkc shell`, but the
 sandbox command makes it easy to check a `.klangk-sandbox.yaml` into
 your repo so you or your teammates can spin up an identical sandboxed
 environment with one command.
@@ -34,11 +34,16 @@ Then run:
 
 ```bash
 klangkc sandbox myworkspace
+klangkc shell myworkspace
 ```
 
-This creates a workspace named `myproj`, mounts the sandbox root
-into the myworkspace container at `~/myproj`, and drops you into a shell.
-Run the same command again to reconnect to the existing workspace.
+The first command creates a workspace named `myworkspace`, mounts the
+sandbox root into the container at `~/myproj`, and runs any setup
+script. The second command connects you to an interactive shell.
+
+Run `klangkc sandbox myworkspace` again on an existing workspace and
+it will error — pass `--force` to re-apply the config and re-run
+setup.
 
 ## Config file reference
 
@@ -79,8 +84,8 @@ sandbox:
 | `setup`         | no       | (none)   | Script to run inside the container after creation. Relative to `mount-at`, or absolute if starts with `/`. |
 | `setup-timeout` | no       | `300`    | Maximum seconds the setup script may run before being killed. Set to `0` to disable.                       |
 
-The setup script runs once — on workspace creation, not on reconnect.
-It runs as the `klangk` user inside the container. If
+The setup script runs once — on workspace creation, not on
+reconnect. It runs as the `klangk` user inside the container. If
 `KLANGK_ALLOW_SUDO` is enabled on the server, the script can use
 `sudo` for system-level setup (installing packages, etc.).
 
@@ -170,16 +175,14 @@ next shell session without recreating the workspace.
 ## Command reference
 
 ```text
-klangkc sandbox WORKSPACE [PATH] [--forward-agent/-A] [--force-setup] [--open/-o MODE]
+klangkc sandbox WORKSPACE [PATH] [--force]
 ```
 
-| Argument/Flag        | Default | Description                                                             |
-| -------------------- | ------- | ----------------------------------------------------------------------- |
-| `WORKSPACE`          |         | Workspace name (required).                                              |
-| `PATH`               | `.`     | Path to the sandbox root (directory containing `.klangk-sandbox.yaml`). |
-| `--forward-agent/-A` | `false` | Forward local SSH agent into the container.                             |
-| `--force-setup`      | `false` | Re-run copy and setup steps even if the workspace exists.               |
-| `--open/-o MODE`     | `shell` | What to open after setup: `shell` (default), `browser`, or `none`.      |
+| Argument/Flag | Default | Description                                                             |
+| ------------- | ------- | ----------------------------------------------------------------------- |
+| `WORKSPACE`   |         | Workspace name (required).                                              |
+| `PATH`        | `.`     | Path to the sandbox root (directory containing `.klangk-sandbox.yaml`). |
+| `--force`     | `false` | Re-apply config and re-run setup on an existing workspace.              |
 
 ### Behavior
 
@@ -191,59 +194,45 @@ klangkc sandbox WORKSPACE [PATH] [--forward-agent/-A] [--force-setup] [--open/-o
 3. Mount the sandbox root at `mount-at`
 4. Copy files listed in `copy` into the container home
 5. Run the `setup` script inside the container (if configured)
-6. Connect to the workspace shell
+6. Print a message to run `klangkc shell` to connect
 
 **Subsequent runs** (workspace already exists):
 
-1. Connect to the existing workspace shell
+- Without `--force`: error with a message to use `--force`
+- With `--force`: re-apply config and re-run the copy and setup steps
 
-### Open modes
+### Connecting after sandbox
 
-The `--open` / `-o` flag controls what happens after the workspace is
-ready:
-
-- **`shell`** (default): Open an interactive terminal shell inside the
-  container. This is the original behavior.
-- **`browser`**: Open the workspace in your default web browser
-  (Klangk's web UI). Setup still runs if needed, but no CLI shell is
-  started.
-- **`none`**: Create the workspace and run setup, then exit. Useful for
-  provisioning workspaces in scripts or CI without opening anything.
-
-Examples:
+After `klangkc sandbox` completes, connect with:
 
 ```bash
-klangkc sandbox myws -o browser      # create + open in browser
-klangkc sandbox myws -o none         # create + setup only, no shell
-klangkc sandbox myws                 # create + open shell (default)
+klangkc shell myworkspace
 ```
 
-The copy and setup steps only run on first creation. On reconnect,
-the command skips straight to the shell — it does not re-copy files
-or re-run the setup script. This means:
+To forward your SSH agent into the container:
+
+```bash
+klangkc shell myworkspace -A
+```
+
+The copy and setup steps only run during `klangkc sandbox`. On
+`klangkc shell`, the command connects directly to the existing
+workspace. This means:
 
 - **Mounts** are always current (they're live links to host paths).
 - **Copied files** reflect the state at creation time. To update
-  them, delete the workspace and recreate it.
+  them, delete the workspace and recreate it, or use `--force`.
 - **Setup script changes** are not re-applied automatically. Use
-  `--force-setup` to re-run the copy and setup steps on an existing
+  `--force` to re-run the copy and setup steps on an existing
   workspace.
 - **Config changes** (new mounts, different image) require
-  restarting (`klangkc restart myws`) or deleting and recreating
-  the workspace. A warning is shown if the config has changed
-  since creation.
+  deleting and recreating the workspace.
 
 ## Setup scripts
 
 The setup script runs inside the container as the `klangk` user. It
 has access to everything that's been mounted and copied. The working
 directory is the sandbox root (the `mount-at` path).
-
-**SSH agent forwarding** is active during setup when `-A` /
-`--forward-agent` is used. This means `git clone git@github.com:...`
-and other SSH operations work in your setup script without any extra
-configuration. SSH host key checking is set to `accept-new` during
-setup (new hosts are automatically trusted on first connect).
 
 **Important:** The `klangk` user does not have sudo access by
 default. Without it, setup scripts are limited to user-space
@@ -278,10 +267,10 @@ fi
 If the setup script is interrupted (Ctrl+C, network failure, etc.),
 the workspace is left in an inconsistent state. To recover:
 
-- **If your script is idempotent:** re-run with `--force-setup`:
-  `klangkc sandbox myws --force-setup`
+- **If your script is idempotent:** re-run with `--force`:
+  `klangkc sandbox myws --force`
 - **If not:** restart the container and try again:
-  `klangkc restart myws && klangkc sandbox myws --force-setup`.
+  `klangkc restart myws && klangkc sandbox myws --force`.
   Or delete the workspace entirely and start over:
   `klangkc rm myws && klangkc sandbox myws`.
 
@@ -289,12 +278,12 @@ the workspace is left in an inconsistent state. To recover:
 
 - **Make scripts idempotent.** Check if tools are already installed
   before installing them (e.g. `if ! command -v nix`). This makes
-  `--force-setup` safe to use after interruptions. If your script
-  isn't idempotent, an interrupted setup means you'll need to
-  destroy the workspace and recreate it.
+  `--force` safe to use after interruptions. If your script isn't
+  idempotent, an interrupted setup means you'll need to destroy the
+  workspace and recreate it.
 - **Use named volumes for large installs.** Mount `/nix` as a named
   volume so the nix store persists across workspace recreations.
-- **Keep it fast.** The setup script blocks before you get a shell.
+- **Keep it fast.** The setup script blocks before you can connect.
   Move slow one-time setup into a volume that persists.
 
 ## Example
@@ -363,9 +352,11 @@ Usage:
 
 ```bash
 cd ~/projects/klangk
-klangkc sandbox myproj -A
-# First run: creates workspace, mounts everything, installs nix, drops into shell
-# Subsequent runs: reconnects to existing workspace
+klangkc sandbox myproj
+klangkc shell myproj -A
+# First sandbox: creates workspace, mounts everything, installs nix
+# shell: connects with SSH agent forwarding
+# Subsequent sandbox calls: error unless --force
 ```
 
 ## Interaction with server settings

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -154,11 +154,9 @@ klangkc edit my-project --env FOO=bar    # set env var via flag
 klangkc dup my-project my-copy           # duplicate a workspace
 klangkc shell my-project                 # drop into bash inside the container
 klangkc shell my-project debug           # attach to the "debug" terminal window (created if it doesn't exist)
-klangkc sandbox myws                     # create/reconnect from .klangk-sandbox.yaml
+klangkc sandbox myws                     # create workspace from .klangk-sandbox.yaml
 klangkc sandbox myws ~/projects/myapp    # specify sandbox root explicitly
-klangkc sandbox myws --force-setup       # re-run copy and setup on existing workspace
-klangkc sandbox myws -o browser          # create/reconnect and open in web browser
-klangkc sandbox myws -o none             # create and run setup only, no shell or browser
+klangkc sandbox myws --force             # re-apply config and re-run setup on existing workspace
 klangkc exec my-project ls /home/klangk/work         # run a command in the container
 klangkc sync ~/src my-project:/home/klangk/work      # sync files to/from the container
 klangkc rm my-project                # delete a workspace

--- a/src/cli/klangkc/main.py
+++ b/src/cli/klangkc/main.py
@@ -10,7 +10,6 @@ import os
 import shutil
 import subprocess
 import sys
-import webbrowser
 from pathlib import Path
 
 import httpx
@@ -936,27 +935,18 @@ def sandbox(
         ".",
         help="Path to sandbox root (directory containing .klangk/)",
     ),
-    forward_agent: bool | None = typer.Option(
-        None,
-        "--forward-agent/--no-forward-agent",
-        "-A",
-        help="Forward local SSH agent into the container",
-    ),
-    force_setup: bool = typer.Option(
+    force: bool = typer.Option(
         False,
-        "--force-setup",
-        help="Re-run copy and setup even if the workspace already exists",
-    ),
-    open_mode: str = typer.Option(
-        "shell",
-        "--open",
-        "-o",
-        help="What to open after setup: shell (default), browser, or none",
+        "--force",
+        help="Re-apply config and re-run setup on an existing workspace",
     ),
 ) -> None:
-    """Create or reconnect to a sandbox workspace."""
-    if not isinstance(forward_agent, bool):
-        forward_agent = None
+    """Create a sandbox workspace from .klangk-sandbox.yaml.
+
+    Creates the workspace with the configured image, mounts, and
+    volumes, copies files, and runs the setup script.  Use
+    ``klangkc shell`` afterwards to connect.
+    """
     token = _state().get_token(_server_url())
     if not token:  # pragma: no cover
         _err.print(
@@ -976,25 +966,22 @@ def sandbox(
 
     client = _client()
     handle = client.get_handle()
-    server_url = _server_url().rstrip("/")
-    ws_url = _build_ws_url(server_url)
+    ws_url = _build_ws_url(_server_url().rstrip("/"))
     created = False
 
     # Check if workspace already exists.
     try:
         ws = client.resolve_workspace(workspace)
-        _err.print(f"Workspace [bold]{workspace}[/bold] exists, connecting...")
-        # Warn if the config has changed since the workspace was created.
-        desired_mounts = sorted(build_all_mounts(config, sandbox_root, handle))
-        current_mounts = sorted(ws.mounts or [])
-        if desired_mounts != current_mounts:
+        if not force:
             _err.print(
-                "[yellow]Warning: sandbox config has changed since"
-                " this workspace was created. Run"
-                " [bold]klangkc rm " + workspace + "[/bold] and re-run"
-                " [bold]klangkc sandbox[/bold] to apply"
-                " changes.[/yellow]"
+                f"[red]Workspace [bold]{workspace}[/bold] already"
+                " exists.[/red] Pass [bold]--force[/bold] to re-apply"
+                " config and re-run setup."
             )
+            raise typer.Exit(code=1)
+        _err.print(
+            f"Workspace [bold]{workspace}[/bold] exists, re-applying config..."
+        )
     except WorkspaceNotFoundError:
         all_mounts = build_all_mounts(config, sandbox_root, handle)
         _err.print(f"Creating workspace [bold]{workspace}[/bold]...")
@@ -1007,84 +994,38 @@ def sandbox(
         _err.print(f"Workspace [bold]{workspace}[/bold] created.")
         created = True
 
-    need_setup = created or force_setup
-    open_mode = open_mode.lower()
-    if open_mode not in ("shell", "browser", "none"):
-        _err.print(
-            f"[red]Invalid --open mode:[/red] {open_mode!r}"
-            " (expected shell, browser, or none)"
-        )
-        raise typer.Exit(code=1)
+    need_setup = created or force
 
-    if open_mode in ("browser", "none"):
-        # Run setup if needed, then open browser or just exit.
-        if need_setup:
-            _err.print(f"Connecting to [bold]{workspace}[/bold] for setup...")
-            try:
-                asyncio.run(
-                    _sandbox_setup_only(
-                        ws_url,
-                        token,
-                        ws.id,
-                        config,
-                        sandbox_root,
-                        handle,
-                        max_size=_ws_max_size(),
-                    )
+    if need_setup:
+        _err.print(f"Connecting to [bold]{workspace}[/bold] for setup...")
+        try:
+            asyncio.run(
+                _sandbox_setup_only(
+                    ws_url,
+                    token,
+                    ws.id,
+                    config,
+                    sandbox_root,
+                    handle,
+                    max_size=_ws_max_size(),
                 )
-            except websockets.InvalidStatus as e:  # pragma: no cover
-                if e.response.status_code in (4001, 4002):
-                    _err.print(
-                        "[red]Session expired.[/red] Run"
-                        " [bold]klangkc login[/bold] to re-authenticate."
-                    )
-                    raise typer.Exit(code=1) from None
-                raise
-            except ConnectionError as e:
-                _err.print(f"[red]{e}[/red]")
+            )
+        except websockets.InvalidStatus as e:  # pragma: no cover
+            if e.response.status_code in (4001, 4002):
+                _err.print(
+                    "[red]Session expired.[/red] Run"
+                    " [bold]klangkc login[/bold] to re-authenticate."
+                )
                 raise typer.Exit(code=1) from None
-
-        if open_mode == "browser":
-            workspace_url = f"{server_url}/#/workspace/{ws.id}"
-            _err.print(f"Opening [bold]{workspace_url}[/bold]")
-            webbrowser.open(workspace_url)
-        return
-
-    # Single WebSocket connection: setup (if new) then shell.
-    forward_agent = _resolve_forward_agent(
-        forward_agent,
-        config_default=_cfg().get_forward_agent(_server_url()) or False,
-    )
-    _err.print(f"Connecting to [bold]{workspace}[/bold]...")
-    _err.print("[dim]Escape: Enter, then ~.[/dim]")
-    try:
-        asyncio.run(
-            _sandbox_connect(
-                ws_url,
-                token,
-                ws.id,
-                config=config if need_setup else None,
-                sandbox_root=sandbox_root,
-                handle=handle,
-                forward_agent=forward_agent,
-                max_size=_ws_max_size(),
-            )
-        )
-    except websockets.InvalidStatus as e:  # pragma: no cover
-        reset_terminal()
-        _drain_stdin()
-        if e.response.status_code in (4001, 4002):
-            _err.print(
-                "[red]Session expired.[/red] Run"
-                " [bold]klangkc login[/bold] to re-authenticate."
-            )
+            raise
+        except ConnectionError as e:
+            _err.print(f"[red]{e}[/red]")
             raise typer.Exit(code=1) from None
-        raise
-    except ConnectionError as e:
-        reset_terminal()
-        _drain_stdin()
-        _err.print(f"[red]{e}[/red]")
-        raise typer.Exit(code=1) from None
+
+    _err.print(
+        f"[green]Done.[/green] Run [bold]klangkc shell"
+        f" {workspace}[/bold] to connect."
+    )
 
 
 async def _sandbox_setup_only(
@@ -1103,38 +1044,6 @@ async def _sandbox_setup_only(
     async with websockets.connect(f"{ws_url}?token={token}", **kwargs) as ws:
         await _wait_workspace_ready(ws, workspace_id)
         await _sandbox_setup(ws, config, sandbox_root, handle)
-
-
-async def _sandbox_connect(  # pragma: no cover
-    ws_url,
-    token,
-    workspace_id,
-    config=None,
-    sandbox_root=None,
-    handle=None,
-    forward_agent=False,
-    max_size=None,
-):
-    """Connect to workspace, run setup if needed, then shell.
-
-    Uses a single WebSocket connection for everything.  If *config*
-    is not None, copy files and run setup before starting the shell.
-    """
-    kwargs = {}
-    if max_size is not None:
-        kwargs["max_size"] = max_size
-    await _ws_shell(
-        ws_url,
-        token,
-        workspace_id,
-        forward_agent=forward_agent,
-        sandbox_setup=(
-            (lambda ws: _sandbox_setup(ws, config, sandbox_root, handle))
-            if config
-            else None
-        ),
-        **kwargs,
-    )
 
 
 terminal_app = typer.Typer(

--- a/src/cli/tests/test_cli_main.py
+++ b/src/cli/tests/test_cli_main.py
@@ -2700,12 +2700,12 @@ class TestSandboxCommand:
         client.resolve_workspace.side_effect = WorkspaceNotFoundError("myws")
         client.create_workspace.return_value = ws
 
-        async def fake_connect(*args, **kwargs):
+        async def fake_setup(*args, **kwargs):
             pass
 
         with (
             patch.object(main, "_client", return_value=client),
-            patch.object(main, "_sandbox_connect", fake_connect),
+            patch.object(main, "_sandbox_setup_only", fake_setup),
         ):
             from typer.testing import CliRunner
 
@@ -2718,111 +2718,11 @@ class TestSandboxCommand:
         call_kwargs = client.create_workspace.call_args
         assert call_kwargs[0][0] == "myws"
         assert "Creating workspace" in result.output
+        assert "klangkc shell" in result.output
 
-    def test_reconnects_existing(self, logged_in_cfg, tmp_path):
-        from klangkc import main
-
-        (tmp_path / ".klangk-sandbox.yaml").write_text(
-            "sandbox:\n  mount-at: ~/test\n"
-        )
-
-        ws = Workspace(
-            id="ws1" + "0" * 52,
-            name="myws",
-            created_at="2025-01-01T00:00:00Z",
-            mounts=[f"{tmp_path.resolve()}:/home/admin/test"],
-        )
-        client = MagicMock()
-        client.get_handle.return_value = "admin"
-        client.resolve_workspace.return_value = ws
-
-        async def fake_connect(*args, **kwargs):
-            pass
-
-        with (
-            patch.object(main, "_client", return_value=client),
-            patch.object(main, "_sandbox_connect", fake_connect),
-        ):
-            from typer.testing import CliRunner
-
-            runner = CliRunner()
-            result = runner.invoke(
-                main.app, ["sandbox", "myws", str(tmp_path)]
-            )
-        assert result.exit_code == 0
-        client.create_workspace.assert_not_called()
-        assert "exists" in result.output
-
-    def test_config_changed_warning(self, logged_in_cfg, tmp_path):
-        from klangkc import main
-
-        (tmp_path / ".klangk-sandbox.yaml").write_text(
-            "sandbox:\n  mount-at: ~/test\nmounts:\n  - /extra:/extra\n"
-        )
-
-        ws = Workspace(
-            id="ws1" + "0" * 52,
-            name="myws",
-            created_at="2025-01-01T00:00:00Z",
-            mounts=[f"{tmp_path.resolve()}:/home/admin/test"],
-        )
-        client = MagicMock()
-        client.get_handle.return_value = "admin"
-        client.resolve_workspace.return_value = ws
-
-        async def fake_connect(*args, **kwargs):
-            pass
-
-        with (
-            patch.object(main, "_client", return_value=client),
-            patch.object(main, "_sandbox_connect", fake_connect),
-        ):
-            from typer.testing import CliRunner
-
-            runner = CliRunner()
-            result = runner.invoke(
-                main.app, ["sandbox", "myws", str(tmp_path)]
-            )
-        assert result.exit_code == 0
-        assert "config has changed" in result.output
-
-    def test_force_setup_passes_config(self, logged_in_cfg, tmp_path):
-        from klangkc import main
-
-        (tmp_path / ".klangk-sandbox.yaml").write_text(
-            "sandbox:\n  mount-at: ~/test\n"
-        )
-
-        ws = Workspace(
-            id="ws1" + "0" * 52,
-            name="myws",
-            created_at="2025-01-01T00:00:00Z",
-            mounts=[f"{tmp_path.resolve()}:/home/admin/test"],
-        )
-        client = MagicMock()
-        client.get_handle.return_value = "admin"
-        client.resolve_workspace.return_value = ws
-
-        captured_kwargs = {}
-
-        async def fake_connect(*args, **kwargs):
-            captured_kwargs.update(kwargs)
-
-        with (
-            patch.object(main, "_client", return_value=client),
-            patch.object(main, "_sandbox_connect", fake_connect),
-        ):
-            from typer.testing import CliRunner
-
-            runner = CliRunner()
-            result = runner.invoke(
-                main.app,
-                ["sandbox", "myws", str(tmp_path), "--force-setup"],
-            )
-        assert result.exit_code == 0
-        assert captured_kwargs.get("config") is not None
-
-    def test_invalid_open_mode_exits(self, logged_in_cfg, tmp_path):
+    def test_existing_workspace_errors_without_force(
+        self, logged_in_cfg, tmp_path
+    ):
         from klangkc import main
 
         (tmp_path / ".klangk-sandbox.yaml").write_text(
@@ -2844,12 +2744,13 @@ class TestSandboxCommand:
 
             runner = CliRunner()
             result = runner.invoke(
-                main.app,
-                ["sandbox", "myws", str(tmp_path), "--open", "invalid"],
+                main.app, ["sandbox", "myws", str(tmp_path)]
             )
-        assert result.exit_code != 0
+        assert result.exit_code == 1
+        assert "already exists" in result.output
+        assert "--force" in result.output
 
-    def test_open_browser_existing_workspace(self, logged_in_cfg, tmp_path):
+    def test_force_reruns_setup(self, logged_in_cfg, tmp_path):
         from klangkc import main
 
         (tmp_path / ".klangk-sandbox.yaml").write_text(
@@ -2866,123 +2767,27 @@ class TestSandboxCommand:
         client.get_handle.return_value = "admin"
         client.resolve_workspace.return_value = ws
 
+        setup_called = []
+
+        async def fake_setup(*args, **kwargs):
+            setup_called.append(True)
+
         with (
             patch.object(main, "_client", return_value=client),
-            patch("webbrowser.open") as mock_wb_open,
+            patch.object(main, "_sandbox_setup_only", fake_setup),
         ):
             from typer.testing import CliRunner
 
             runner = CliRunner()
             result = runner.invoke(
                 main.app,
-                ["sandbox", "myws", str(tmp_path), "--open", "browser"],
+                ["sandbox", "myws", str(tmp_path), "--force"],
             )
         assert result.exit_code == 0
-        mock_wb_open.assert_called_once()
-        url = mock_wb_open.call_args[0][0]
-        assert "/#/workspace/" in url
-        assert ws.id in url
+        assert setup_called == [True]
+        assert "re-applying config" in result.output
 
-    def test_open_browser_new_workspace_runs_setup(
-        self, logged_in_cfg, tmp_path
-    ):
-        from klangkc import main
-
-        (tmp_path / ".klangk-sandbox.yaml").write_text(
-            "sandbox:\n  mount-at: ~/test\n"
-        )
-
-        ws = Workspace(
-            id="ws1" + "0" * 52,
-            name="myws",
-            created_at="2025-01-01T00:00:00Z",
-        )
-        client = MagicMock()
-        client.get_handle.return_value = "admin"
-        client.resolve_workspace.side_effect = WorkspaceNotFoundError("myws")
-        client.create_workspace.return_value = ws
-
-        async def fake_setup_only(*args, **kwargs):
-            pass
-
-        with (
-            patch.object(main, "_client", return_value=client),
-            patch.object(main, "_sandbox_setup_only", fake_setup_only),
-            patch("webbrowser.open") as mock_wb_open,
-        ):
-            from typer.testing import CliRunner
-
-            runner = CliRunner()
-            result = runner.invoke(
-                main.app,
-                ["sandbox", "myws", str(tmp_path), "--open", "browser"],
-            )
-        assert result.exit_code == 0
-        mock_wb_open.assert_called_once()
-
-    def test_open_none_existing_workspace(self, logged_in_cfg, tmp_path):
-        from klangkc import main
-
-        (tmp_path / ".klangk-sandbox.yaml").write_text(
-            "sandbox:\n  mount-at: ~/test\n"
-        )
-
-        ws = Workspace(
-            id="ws1" + "0" * 52,
-            name="myws",
-            created_at="2025-01-01T00:00:00Z",
-            mounts=[f"{tmp_path.resolve()}:/home/admin/test"],
-        )
-        client = MagicMock()
-        client.get_handle.return_value = "admin"
-        client.resolve_workspace.return_value = ws
-
-        with patch.object(main, "_client", return_value=client):
-            from typer.testing import CliRunner
-
-            runner = CliRunner()
-            result = runner.invoke(
-                main.app,
-                ["sandbox", "myws", str(tmp_path), "--open", "none"],
-            )
-        assert result.exit_code == 0
-
-    def test_open_none_new_workspace_runs_setup(self, logged_in_cfg, tmp_path):
-        from klangkc import main
-
-        (tmp_path / ".klangk-sandbox.yaml").write_text(
-            "sandbox:\n  mount-at: ~/test\n"
-        )
-
-        ws = Workspace(
-            id="ws1" + "0" * 52,
-            name="myws",
-            created_at="2025-01-01T00:00:00Z",
-        )
-        client = MagicMock()
-        client.get_handle.return_value = "admin"
-        client.resolve_workspace.side_effect = WorkspaceNotFoundError("myws")
-        client.create_workspace.return_value = ws
-
-        async def fake_setup_only(*args, **kwargs):
-            pass
-
-        with (
-            patch.object(main, "_client", return_value=client),
-            patch.object(main, "_sandbox_setup_only", fake_setup_only),
-        ):
-            from typer.testing import CliRunner
-
-            runner = CliRunner()
-            result = runner.invoke(
-                main.app,
-                ["sandbox", "myws", str(tmp_path), "--open", "none"],
-            )
-        assert result.exit_code == 0
-
-    def test_open_browser_setup_connection_error(
-        self, logged_in_cfg, tmp_path
-    ):
+    def test_setup_connection_error(self, logged_in_cfg, tmp_path):
         from klangkc import main
 
         (tmp_path / ".klangk-sandbox.yaml").write_text(
@@ -3011,7 +2816,7 @@ class TestSandboxCommand:
             runner = CliRunner()
             result = runner.invoke(
                 main.app,
-                ["sandbox", "myws", str(tmp_path), "--open", "browser"],
+                ["sandbox", "myws", str(tmp_path)],
             )
         assert result.exit_code == 1
         assert "connection refused" in result.output


### PR DESCRIPTION
## Summary

- `klangkc sandbox` now only creates/configures the workspace and runs setup — no longer connects to a shell
- Remove `--open`/`-o` and `--forward-agent`/`-A` flags; rename `--force-setup` to `--force`
- Error on existing workspace unless `--force` is passed
- Remove unused `_sandbox_connect` function and `webbrowser` import
- Update sandbox docs: two-step workflow (`sandbox` then `shell`), default-command terminal guidance, `--force` behavior

## Test plan

- [x] All 238 CLI tests pass
- [x] `main.py` at 100% coverage, `sandbox.py` at 100% coverage
- [x] 6 sandbox command tests updated: create, existing-errors, force-reruns, connection-error, config errors

Depends on #1012
Closes #1009