### PR TITLE
feat(api): add GET /workspaces/{id}/status endpoint

### DIFF
--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -1331,6 +1331,46 @@ No request body.
 
 ---
 
+### GET `/api/v1/workspaces/{id}/status`
+
+Return the container status for a workspace.
+
+**Auth:** JWT required. User must have `terminal` permission on
+`/workspaces/{id}`.
+
+No request body.
+
+**Response when running:**
+
+```json
+{
+  "running": true,
+  "container_id": "abc123...",
+  "health": null,
+  "idle_seconds": 42.5,
+  "idle_timeout": 1800,
+  "ports": [9000, 9001]
+}
+```
+
+**Response when stopped:**
+
+```json
+{
+  "running": false,
+  "container_id": null,
+  "health": null,
+  "idle_seconds": null,
+  "idle_timeout": null,
+  "ports": []
+}
+```
+
+The `health` field is a placeholder (`null`) until a container
+health check is implemented (#1015).
+
+---
+
 ### POST `/api/v1/workspaces/{id}/roles/{role}`
 
 Add a user to a workspace role. Valid roles: `owners`, `coders`,

--- a/src/backend/klangk_backend/api/workspaces.py
+++ b/src/backend/klangk_backend/api/workspaces.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+import time
 from typing import Literal
 
 from fastapi import (
@@ -347,6 +348,45 @@ async def restart_workspace(
         await container.registry.stop_and_remove_container(cid)
     await wshandler.reset_workspace_state(workspace_id)
     return {"status": "restarted"}
+
+
+@router.get("/workspaces/{workspace_id}/status")
+async def workspace_status(
+    workspace_id: str,
+    user: dict = Depends(acl.has_permission("terminal", _workspace_resource)),
+):
+    """Return container status for a workspace.
+
+    Returns running state, container health, idle timeout info,
+    and allocated ports.
+    """
+    workspace = await model.get_workspace(workspace_id)
+    if workspace is None:
+        raise HTTPException(status_code=404, detail="Workspace not found")
+
+    live_state = container.registry.get_state(workspace_id)
+    if live_state is None:
+        return {
+            "running": False,
+            "container_id": None,
+            "health": None,
+            "idle_seconds": None,
+            "idle_timeout": None,
+            "ports": [],
+        }
+
+    idle_secs = time.time() - live_state.last_activity
+    idle_timeout = live_state.get_idle_timeout()
+    ports = await container.registry.get_workspace_ports(workspace_id)
+
+    return {
+        "running": True,
+        "container_id": live_state.container_id,
+        "health": None,  # placeholder for #1015
+        "idle_seconds": round(idle_secs, 1),
+        "idle_timeout": idle_timeout,
+        "ports": ports,
+    }
 
 
 # --- Workspace export/import endpoints ---

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -1291,6 +1291,72 @@ class TestWorkspaceRoutes:
         )
         assert resp.status_code == 404
 
+    async def test_workspace_status_running(self, client, user):
+        headers = await _auth_headers(client)
+        create_resp = await client.post(
+            "/api/v1/workspaces",
+            headers=headers,
+            json={"name": "status-ws"},
+        )
+        ws_id = create_resp.json()["id"]
+
+        # Simulate a running container.
+        api.container.registry.track_activity("cid-status", ws_id)
+
+        resp = await client.get(
+            f"/api/v1/workspaces/{ws_id}/status",
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["running"] is True
+        assert data["container_id"] == "cid-status"
+        assert data["health"] is None  # placeholder
+        assert isinstance(data["idle_seconds"], (int, float))
+        assert data["idle_timeout"] == api.container.IDLE_TIMEOUT_SECONDS
+        assert isinstance(data["ports"], list)
+
+        # Clean up registry state.
+        api.container.registry.states.pop(ws_id, None)
+        api.container.registry._cid_to_wsid.pop("cid-status", None)
+
+    async def test_workspace_status_not_running(self, client, user):
+        headers = await _auth_headers(client)
+        create_resp = await client.post(
+            "/api/v1/workspaces",
+            headers=headers,
+            json={"name": "status-stopped"},
+        )
+        ws_id = create_resp.json()["id"]
+
+        resp = await client.get(
+            f"/api/v1/workspaces/{ws_id}/status",
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["running"] is False
+        assert data["container_id"] is None
+        assert data["idle_seconds"] is None
+        assert data["ports"] == []
+
+    async def test_workspace_status_not_found(self, client, user):
+        headers = await _auth_headers(client)
+        fake_id = "fake-status-id"
+        await model.add_acl_entry(
+            f"/workspaces/{fake_id}",
+            0,
+            model.ACTION_ALLOW,
+            "terminal",
+            model.PRINCIPAL_USER,
+            user_id=user["id"],
+        )
+        resp = await client.get(
+            f"/api/v1/workspaces/{fake_id}/status",
+            headers=headers,
+        )
+        assert resp.status_code == 404
+
     async def test_list_no_auth(self, client):
         resp = await client.get("/api/v1/workspaces")
         assert resp.status_code == 401

--- a/src/backend/tests/test_api_package.py
+++ b/src/backend/tests/test_api_package.py
@@ -35,7 +35,7 @@ api_auth = sys.modules["klangk_backend.api.auth"]
 
 # Total HTTP route operations the monolith exposed (per the issue).  The
 # split must preserve this exactly — no dropped or duplicated handlers.
-EXPECTED_ROUTE_COUNT = 84
+EXPECTED_ROUTE_COUNT = 85
 
 # Per-domain submodules and the number of routes each owns.  79 sub-routes
 # + 3 routes defined directly on the main router (version, config,
@@ -43,7 +43,7 @@ EXPECTED_ROUTE_COUNT = 84
 SUBMODULE_ROUTES = {
     "auth": 14,
     "oidc_auth": 2,
-    "workspaces": 22,
+    "workspaces": 23,
     "files": 6,
     "images": 4,
     "browser_delegate": 2,


### PR DESCRIPTION
## Summary

- Add `GET /api/v1/workspaces/{id}/status` endpoint that returns container running state, idle timeout info, and allocated ports
- `health` field is a placeholder (`null`) until #1015 is implemented
- Enables workspace cards UI (#1016) and CLI tooling to show status without a WebSocket connection

Closes #1017

## Test plan
- [x] All 1896 backend tests pass (3 new: running, stopped, not-found)
- [x] 100% coverage
- [x] API docs updated in `docs/reference/api-endpoints.md`
- [x] Route count parity tests updated
- [ ] CI green