### PR TITLE
fix(sandbox): configure openclaw allowedOrigins and trustedProxies for hosted proxy

### DIFF
--- a/sandboxes/openclaw/setup.sh
+++ b/sandboxes/openclaw/setup.sh
@@ -103,6 +103,18 @@ cfg['gateway']['port'] = 8000
 cfg['models']['providers']['llm-proxy']['request'] = {'allowPrivateNetwork': True}
 cfg['gateway']['bind'] = 'lan'
 cfg['gateway']['http'] = {'endpoints': {'chatCompletions': {'enabled': True}}}
+# Trust the Klangk reverse proxy and allow the hosted origin for
+# WebSocket connections (required since openclaw v2026.2.26).
+hosting_proto = os.environ.get('KLANGK_HOSTING_PROTO', 'http')
+hosting_hostname = os.environ.get('KLANGK_HOSTING_HOSTNAME', 'localhost:8995')
+hosted_origin = f'{hosting_proto}://{hosting_hostname}'
+cfg['gateway']['controlUi'] = cfg.get('gateway', {}).get('controlUi', {})
+cfg['gateway']['controlUi']['allowedOrigins'] = [
+    hosted_origin,
+    'http://localhost:8000',
+    'http://127.0.0.1:8000',
+]
+cfg['gateway']['trustedProxies'] = ['0.0.0.0/0']
 cfg['secrets'] = {
     'providers': {
         'klangk': {


### PR DESCRIPTION
## Summary

The openclaw gateway rejects WebSocket connections when accessed through Klangk's hosted app proxy because:

1. **`allowedOrigins`** — the gateway auto-seeds allowed origins as `localhost:8000` but the browser connects from `localhost:8995` (the nginx port). Added the Klangk hosting origin to `gateway.controlUi.allowedOrigins`.

2. **`trustedProxies`** — the gateway sees X-Forwarded-For headers from nginx but doesn't trust the proxy address, so it rejects the connection as non-local. Added `gateway.trustedProxies` config.

Closes #1022

## Test plan
- [ ] `klangkc sandbox --force openclaw ws` re-applies config
- [ ] Restart gateway, navigate to hosted URL — WebSocket connects