### PR TITLE
feat(api): eagerly start container when workspace created with auto_start

### DIFF
--- a/src/backend/klangk_backend/api/workspaces.py
+++ b/src/backend/klangk_backend/api/workspaces.py
@@ -206,6 +206,18 @@ async def create_workspace(
         if group_name.startswith("owners-"):
             await model.add_user_to_group(user["id"], group["id"])
 
+    # Eagerly start the container so it's running by the time the
+    # user connects.  Errors are logged but don't fail the create.
+    if body.auto_start:
+        try:
+            await workspaces.eager_start_workspace(ws)
+        except Exception:
+            logger.warning(
+                "Eager start failed for workspace %s",
+                ws["id"],
+                exc_info=True,
+            )
+
     wshandler.state.notify_user_workspaces_changed(user["id"])
     return ws
 

--- a/src/backend/klangk_backend/workspaces.py
+++ b/src/backend/klangk_backend/workspaces.py
@@ -392,6 +392,35 @@ async def populate_home_skel(
         )
 
 
+async def eager_start_workspace(ws: dict) -> tuple[str, str]:
+    """Start a container for a workspace immediately.
+
+    Sets ``idle_timeout = 0`` so the container does not idle out.
+    Returns ``(container_id, status)``.
+    """
+    owner_id = ws["user_id"]
+    workspace_id = ws["id"]
+    host_path = str(get_workspace_host_path(owner_id, workspace_id))
+    h_path = str(get_home_host_path(owner_id, workspace_id))
+    cfg_path = str(get_config_host_path(owner_id, workspace_id))
+    cid, status = await container.registry.start_container(
+        workspace_id,
+        host_path,
+        h_path,
+        ws.get("container_id"),
+        num_ports=ws.get("num_ports", container.DEFAULT_PORTS_PER_WORKSPACE),
+        image=ws.get("image"),
+        config_path=cfg_path,
+        extra_mounts=ws.get("mounts"),
+        extra_env=ws.get("env"),
+        user_id=owner_id,
+    )
+    state = container.registry.states.get(workspace_id)
+    if state:
+        state.idle_timeout = 0
+    return cid, status
+
+
 async def auto_start_workspaces() -> int:
     """Start containers for all workspaces with auto_start enabled.
 
@@ -406,30 +435,8 @@ async def auto_start_workspaces() -> int:
     for i, ws in enumerate(ws_list):
         if i > 0:
             await asyncio.sleep(random.uniform(0.5, 2.0))
-        owner_id = ws["user_id"]
-        workspace_id = ws["id"]
-        host_path = str(get_workspace_host_path(owner_id, workspace_id))
-        h_path = str(get_home_host_path(owner_id, workspace_id))
-        cfg_path = str(get_config_host_path(owner_id, workspace_id))
         try:
-            cid, status = await container.registry.start_container(
-                workspace_id,
-                host_path,
-                h_path,
-                ws.get("container_id"),
-                num_ports=ws.get(
-                    "num_ports", container.DEFAULT_PORTS_PER_WORKSPACE
-                ),
-                image=ws.get("image"),
-                config_path=cfg_path,
-                extra_mounts=ws.get("mounts"),
-                extra_env=ws.get("env"),
-                user_id=owner_id,
-            )
-            # Auto-started containers should not idle out.
-            state = container.registry.states.get(workspace_id)
-            if state:
-                state.idle_timeout = 0
+            cid, status = await eager_start_workspace(ws)
             logger.info(
                 "Auto-started workspace %s (%s): %s",
                 ws["name"],
@@ -441,7 +448,7 @@ async def auto_start_workspaces() -> int:
             logger.warning(
                 "Failed to auto-start workspace %s (%s)",
                 ws["name"],
-                workspace_id,
+                ws["id"],
                 exc_info=True,
             )
     return started

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -1096,12 +1096,41 @@ class TestWorkspaceRoutes:
 
     async def test_create_auto_start_allowed_with_env(self, client, user):
         headers = await _auth_headers(client)
-        with patch.dict(os.environ, {"KLANGK_ALLOW_AUTOSTART": "1"}):
+        with (
+            patch.dict(os.environ, {"KLANGK_ALLOW_AUTOSTART": "1"}),
+            patch(
+                "klangk_backend.workspaces.eager_start_workspace",
+                new_callable=AsyncMock,
+            ) as mock_start,
+        ):
             resp = await client.post(
                 "/api/v1/workspaces",
                 headers=headers,
                 json={"name": "auto-ws", "auto_start": True},
             )
+        assert resp.status_code == 200
+        assert resp.json()["auto_start"] is True
+        mock_start.assert_awaited_once()
+
+    async def test_create_auto_start_eager_failure_logged(self, client, user):
+        headers = await _auth_headers(client)
+        with (
+            patch.dict(os.environ, {"KLANGK_ALLOW_AUTOSTART": "1"}),
+            patch(
+                "klangk_backend.workspaces.eager_start_workspace",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("podman broke"),
+            ),
+        ):
+            resp = await client.post(
+                "/api/v1/workspaces",
+                headers=headers,
+                json={
+                    "name": "auto-fail-ws",
+                    "auto_start": True,
+                },
+            )
+        # Create succeeds even if eager start fails.
         assert resp.status_code == 200
         assert resp.json()["auto_start"] is True
 

--- a/src/backend/tests/test_workspaces.py
+++ b/src/backend/tests/test_workspaces.py
@@ -297,3 +297,29 @@ class TestAutoStartWorkspaces:
             ):
                 result = await ws_mod.auto_start_workspaces()
         assert result == 0
+
+
+class TestEagerStartWorkspace:
+    async def test_starts_container_and_disables_idle(self, user):
+        ws = await ws_mod.create_workspace(
+            user["id"], "eager-ws", auto_start=True
+        )
+        from klangk_backend.container import ContainerState
+
+        container.registry.states[ws["id"]] = ContainerState(
+            ws["id"], "cid-eager"
+        )
+        try:
+            with patch.object(
+                container.registry,
+                "start_container",
+                new_callable=AsyncMock,
+                return_value=("cid-eager", "created"),
+            ) as mock_start:
+                cid, status = await ws_mod.eager_start_workspace(ws)
+            assert cid == "cid-eager"
+            assert status == "created"
+            mock_start.assert_awaited_once()
+            assert container.registry.states[ws["id"]].idle_timeout == 0
+        finally:
+            container.registry.states.pop(ws["id"], None)


### PR DESCRIPTION
## Summary

- Extract `eager_start_workspace()` from `auto_start_workspaces()` so both the boot-time auto-start loop and the create endpoint can reuse the same logic
- Call `eager_start_workspace()` from `POST /api/v1/workspaces` when `auto_start` is set, so the container is running immediately after creation
- Errors during eager start are logged but don't fail the create

Closes #1024

## Test plan
- [x] All 1908 backend tests pass (2 new: eager start called, eager start failure logged)
- [x] 100% coverage
- [ ] CI green