### PR TITLE
feat: run default_command in tmux on eager container start

### DIFF
--- a/src/backend/klangk_backend/workspaces.py
+++ b/src/backend/klangk_backend/workspaces.py
@@ -8,7 +8,7 @@ import shutil
 import tempfile
 from pathlib import Path
 
-from . import container, model, podman
+from . import container, model, podman, terminal
 from .util import resolve_env_bool, resolve_env_value
 
 logger = logging.getLogger(__name__)
@@ -418,6 +418,24 @@ async def eager_start_workspace(ws: dict) -> tuple[str, str]:
     state = container.registry.states.get(workspace_id)
     if state:
         state.idle_timeout = 0
+
+    # If the workspace has a default command, create a tmux session
+    # and run it now so it's already running when a user connects.
+    default_command = ws.get("default_command")
+    if default_command and status == "created":
+        handle = await model.get_user_handle(owner_id)
+        if handle:
+            ws_home = home_path(owner_id, workspace_id)
+            user_home, created = ensure_home_symlink(ws_home, handle, owner_id)
+            if created:
+                await populate_home_skel(cid, owner_id)
+            await terminal._ensure_base_session(
+                cid,
+                owner_id,
+                user_home=user_home,
+                default_command=default_command,
+            )
+
     return cid, status
 
 

--- a/src/backend/tests/test_workspaces.py
+++ b/src/backend/tests/test_workspaces.py
@@ -323,3 +323,74 @@ class TestEagerStartWorkspace:
             assert container.registry.states[ws["id"]].idle_timeout == 0
         finally:
             container.registry.states.pop(ws["id"], None)
+
+    async def test_runs_default_command_on_create(self, user):
+        ws = await ws_mod.create_workspace(
+            user["id"],
+            "eager-cmd-ws",
+            auto_start=True,
+            default_command="openclaw gateway",
+        )
+        from klangk_backend.container import ContainerState
+
+        container.registry.states[ws["id"]] = ContainerState(
+            ws["id"], "cid-cmd"
+        )
+        try:
+            with (
+                patch.object(
+                    container.registry,
+                    "start_container",
+                    new_callable=AsyncMock,
+                    return_value=("cid-cmd", "created"),
+                ),
+                patch(
+                    "klangk_backend.terminal._ensure_base_session",
+                    new_callable=AsyncMock,
+                ) as mock_session,
+                patch(
+                    "klangk_backend.workspaces.populate_home_skel",
+                    new_callable=AsyncMock,
+                ),
+            ):
+                await ws_mod.eager_start_workspace(ws)
+            mock_session.assert_awaited_once_with(
+                "cid-cmd",
+                user["id"],
+                user_home=mock_session.call_args[1]["user_home"],
+                default_command="openclaw gateway",
+            )
+        finally:
+            container.registry.states.pop(ws["id"], None)
+
+    async def test_skips_default_command_on_reconnect(self, user):
+        ws = await ws_mod.create_workspace(
+            user["id"],
+            "eager-recon-ws",
+            auto_start=True,
+            default_command="openclaw gateway",
+        )
+        from klangk_backend.container import ContainerState
+
+        container.registry.states[ws["id"]] = ContainerState(
+            ws["id"], "cid-recon"
+        )
+        try:
+            with (
+                patch.object(
+                    container.registry,
+                    "start_container",
+                    new_callable=AsyncMock,
+                    return_value=("cid-recon", "connected"),
+                ),
+                patch(
+                    "klangk_backend.terminal._ensure_base_session",
+                    new_callable=AsyncMock,
+                ) as mock_session,
+            ):
+                await ws_mod.eager_start_workspace(ws)
+            # "connected" means container was already running —
+            # don't re-run the default command.
+            mock_session.assert_not_awaited()
+        finally:
+            container.registry.states.pop(ws["id"], None)


### PR DESCRIPTION
## Summary

When a workspace with a `default_command` is eagerly started (via `auto_start` on creation or server boot), create a tmux session and run the command immediately so it's already running when a user connects.

Previously the command only ran on first terminal connect via `_ensure_base_session`. Now `eager_start_workspace` calls `_ensure_base_session` directly after container creation, setting up the owner's home directory and tmux session with the default command.

The command is only run on fresh container creation (`status == "created"`), not when reconnecting to an already-running container (`status == "connected"`).

## Test plan
- [x] All 1911 backend tests pass (2 new: default command runs on create, skipped on reconnect)
- [x] 100% coverage
- [ ] CI green
- [ ] Manual: `klangkc sandbox openclaw ws` → openclaw gateway running in container before shell connect