### PR TITLE
fix: wait for shell init before sending default_command keystrokes

### DIFF
--- a/src/backend/klangk_backend/terminal.py
+++ b/src/backend/klangk_backend/terminal.py
@@ -144,7 +144,10 @@ async def _ensure_base_session(
         return False
 
     # Send default command as keystrokes into window 0.
+    # Wait briefly for bash to finish sourcing .profile / .bashrc
+    # so PATH (nvm, etc.) is set before the command runs.
     if default_command:
+        await asyncio.sleep(1)
         try:
             await podman.exec_container(
                 container_id,


### PR DESCRIPTION
## Summary

When `_ensure_base_session` creates a tmux session and sends the `default_command` via `send-keys`, the keystrokes arrive before bash finishes sourcing `.profile` → `.bashrc` → nvm init. Commands like `openclaw gateway` fail with "command not found" because PATH isn't set yet.

Add a 1-second sleep between `tmux new-session` and `tmux send-keys` to let the shell initialize.

## Test plan
- [ ] `klangkc sandbox openclaw ws` → restart server → `openclaw gateway` running in container
- [ ] CI green