### PR TITLE
feat: run default_command in dedicated tmux window, trigger after sandbox setup

### DIFF
--- a/src/backend/klangk_backend/api/workspaces.py
+++ b/src/backend/klangk_backend/api/workspaces.py
@@ -210,7 +210,9 @@ async def create_workspace(
     # user connects.  Errors are logged but don't fail the create.
     if body.auto_start:
         try:
-            await workspaces.eager_start_workspace(ws)
+            await workspaces.eager_start_workspace(
+                ws, run_default_command=False
+            )
         except Exception:
             logger.warning(
                 "Eager start failed for workspace %s",

--- a/src/backend/klangk_backend/terminal.py
+++ b/src/backend/klangk_backend/terminal.py
@@ -92,6 +92,10 @@ def _build_environment(
 
 _WORKSPACE_STATE_FILE = ".workspace-state.json"
 
+# Name of the dedicated tmux window that runs a workspace's
+# default_command, leaving the user's interactive window 0 free.
+DEFAULT_CMD_WINDOW = "default-cmd"
+
 
 async def _ensure_base_session(
     container_id: str,
@@ -106,9 +110,11 @@ async def _ensure_base_session(
     session exists before any grouped session tries to link to it.
 
     If *default_command* is set and the session is freshly created,
-    the command is sent as keystrokes into window 0.  The command
-    runs as a foreground process in the bash shell — Ctrl-C stops
-    it and returns to the prompt.
+    the command is run in a dedicated detached window named
+    ``DEFAULT_CMD_WINDOW`` so the user's window 0 stays free for
+    interactive use.  The command runs as a foreground process in
+    that window's bash shell — Ctrl-C stops it and returns to the
+    prompt.
 
     Returns ``True`` if the session was freshly created.
     """
@@ -143,8 +149,10 @@ async def _ensure_base_session(
         logger.warning("Failed to create base tmux session %s", session_name)
         return False
 
-    # Run the default command in a new window named "default-cmd"
-    # so the user's window 0 stays free for interactive use.
+    # Run the default command in a detached window named
+    # DEFAULT_CMD_WINDOW so the user's window 0 stays free for
+    # interactive use.  ``-d`` keeps window 0 as the active window,
+    # so no select-window is needed afterwards.
     if default_command:
         try:
             await podman.exec_container(
@@ -152,62 +160,46 @@ async def _ensure_base_session(
                 [
                     "tmux",
                     "new-window",
+                    "-d",
                     "-t",
                     session_name,
                     "-n",
-                    "default-cmd",
+                    DEFAULT_CMD_WINDOW,
                 ],
                 user=CONTAINER_USER,
                 timeout=5,
             )
         except Exception:
             logger.warning(
-                "Failed to create default-cmd window in %s",
+                "Failed to create %s window in %s",
+                DEFAULT_CMD_WINDOW,
                 session_name,
             )
         else:
-            await send_keys(
-                container_id,
-                f"{session_name}:default-cmd",
-                default_command,
-            )
-            # Switch back to window 0 so the user lands there.
+            # The new window's shell needs a moment to source
+            # .profile / .bashrc before it can resolve PATH-dependent
+            # commands (nvm, openclaw, ...).  Same race as #1030.
+            await asyncio.sleep(1)
             try:
                 await podman.exec_container(
                     container_id,
                     [
                         "tmux",
-                        "select-window",
+                        "send-keys",
                         "-t",
-                        f"{session_name}:0",
+                        f"{session_name}:{DEFAULT_CMD_WINDOW}",
+                        default_command,
+                        "Enter",
                     ],
                     user=CONTAINER_USER,
                     timeout=5,
                 )
-            except Exception:  # pragma: no cover
-                pass
+            except Exception:
+                logger.warning(
+                    "Failed to send default command to %s", session_name
+                )
 
     return True
-
-
-async def send_keys(container_id: str, target: str, command: str) -> None:
-    """Send keystrokes to a tmux target (e.g. ``session:0``)."""
-    try:
-        await podman.exec_container(
-            container_id,
-            [
-                "tmux",
-                "send-keys",
-                "-t",
-                target,
-                command,
-                "Enter",
-            ],
-            user=CONTAINER_USER,
-            timeout=5,
-        )
-    except Exception:  # pragma: no cover
-        logger.warning("Failed to send keys to %s", target)
 
 
 def _build_shell_command(

--- a/src/backend/klangk_backend/terminal.py
+++ b/src/backend/klangk_backend/terminal.py
@@ -143,31 +143,71 @@ async def _ensure_base_session(
         logger.warning("Failed to create base tmux session %s", session_name)
         return False
 
-    # Send default command as keystrokes into window 0.
-    # Wait briefly for bash to finish sourcing .profile / .bashrc
-    # so PATH (nvm, etc.) is set before the command runs.
+    # Run the default command in a new window named "default-cmd"
+    # so the user's window 0 stays free for interactive use.
     if default_command:
-        await asyncio.sleep(1)
         try:
             await podman.exec_container(
                 container_id,
                 [
                     "tmux",
-                    "send-keys",
+                    "new-window",
                     "-t",
-                    f"{session_name}:0",
-                    default_command,
-                    "Enter",
+                    session_name,
+                    "-n",
+                    "default-cmd",
                 ],
                 user=CONTAINER_USER,
                 timeout=5,
             )
         except Exception:
             logger.warning(
-                "Failed to send default command to session %s", session_name
+                "Failed to create default-cmd window in %s",
+                session_name,
             )
+        else:
+            await send_keys(
+                container_id,
+                f"{session_name}:default-cmd",
+                default_command,
+            )
+            # Switch back to window 0 so the user lands there.
+            try:
+                await podman.exec_container(
+                    container_id,
+                    [
+                        "tmux",
+                        "select-window",
+                        "-t",
+                        f"{session_name}:0",
+                    ],
+                    user=CONTAINER_USER,
+                    timeout=5,
+                )
+            except Exception:  # pragma: no cover
+                pass
 
     return True
+
+
+async def send_keys(container_id: str, target: str, command: str) -> None:
+    """Send keystrokes to a tmux target (e.g. ``session:0``)."""
+    try:
+        await podman.exec_container(
+            container_id,
+            [
+                "tmux",
+                "send-keys",
+                "-t",
+                target,
+                command,
+                "Enter",
+            ],
+            user=CONTAINER_USER,
+            timeout=5,
+        )
+    except Exception:  # pragma: no cover
+        logger.warning("Failed to send keys to %s", target)
 
 
 def _build_shell_command(

--- a/src/backend/klangk_backend/workspaces.py
+++ b/src/backend/klangk_backend/workspaces.py
@@ -398,8 +398,18 @@ async def eager_start_workspace(
     """Start a container for a workspace immediately.
 
     Sets ``idle_timeout = 0`` so the container does not idle out.
-    When *run_default_command* is False the tmux session and default
-    command are skipped (the CLI sends terminal_start after setup).
+
+    There are two callers with different needs:
+
+    * **Server boot** (``auto_start_workspaces``) leaves
+      *run_default_command* at its default ``True`` — the workspace's
+      software is already installed in the persisted volume, so the
+      default command is safe to run now.
+    * **Workspace creation** (``api/workspaces.create_workspace``)
+      passes ``run_default_command=False`` — ``setup.sh`` has not run
+      yet, so the default command would fail.  The CLI sandbox driver
+      sends ``terminal_start`` after setup completes to trigger it.
+
     Returns ``(container_id, status)``.
     """
     owner_id = ws["user_id"]

--- a/src/backend/klangk_backend/workspaces.py
+++ b/src/backend/klangk_backend/workspaces.py
@@ -392,10 +392,14 @@ async def populate_home_skel(
         )
 
 
-async def eager_start_workspace(ws: dict) -> tuple[str, str]:
+async def eager_start_workspace(
+    ws: dict, *, run_default_command: bool = True
+) -> tuple[str, str]:
     """Start a container for a workspace immediately.
 
     Sets ``idle_timeout = 0`` so the container does not idle out.
+    When *run_default_command* is False the tmux session and default
+    command are skipped (the CLI sends terminal_start after setup).
     Returns ``(container_id, status)``.
     """
     owner_id = ws["user_id"]
@@ -422,7 +426,7 @@ async def eager_start_workspace(ws: dict) -> tuple[str, str]:
     # If the workspace has a default command, create a tmux session
     # and run it now so it's already running when a user connects.
     default_command = ws.get("default_command")
-    if default_command and status == "created":
+    if default_command and status == "created" and run_default_command:
         handle = await model.get_user_handle(owner_id)
         if handle:
             ws_home = home_path(owner_id, workspace_id)

--- a/src/backend/tests/test_terminal.py
+++ b/src/backend/tests/test_terminal.py
@@ -1230,35 +1230,41 @@ class TestEnsureBaseSession:
         assert "SSH_AUTH_SOCK=/tmp/agent.sock" in new_cmd
 
     async def test_default_command_sends_keys(self):
-        """Default command runs in a dedicated 'default-cmd' window."""
+        """Default command runs in a detached 'default-cmd' window."""
         from klangk_backend.terminal import _ensure_base_session
 
-        with patch(
-            "klangk_backend.terminal.podman.exec_container",
-            new_callable=AsyncMock,
-            side_effect=[
-                (1, "", ""),  # has-session fails
-                (0, "", ""),  # new-session ok
-                (0, "", ""),  # new-window ok
-                (0, "", ""),  # send-keys ok
-                (0, "", ""),  # select-window ok
-            ],
-        ) as mock_exec:
+        with (
+            patch(
+                "klangk_backend.terminal.podman.exec_container",
+                new_callable=AsyncMock,
+                side_effect=[
+                    (1, "", ""),  # has-session fails
+                    (0, "", ""),  # new-session ok
+                    (0, "", ""),  # new-window ok
+                    (0, "", ""),  # send-keys ok
+                ],
+            ) as mock_exec,
+            patch(
+                "klangk_backend.terminal.asyncio.sleep", new_callable=AsyncMock
+            ),
+        ):
             created = await _ensure_base_session(
                 "cid", "my-session", default_command="openclaw gateway"
             )
         assert created is True
-        assert mock_exec.await_count == 5
+        assert mock_exec.await_count == 4
         new_window_cmd = mock_exec.call_args_list[2].args[1]
         assert "new-window" in new_window_cmd
+        assert "-d" in new_window_cmd  # detached -> window 0 stays active
         assert "default-cmd" in new_window_cmd
         send_cmd = mock_exec.call_args_list[3].args[1]
         assert "send-keys" in send_cmd
         assert "my-session:default-cmd" in send_cmd
         assert "openclaw gateway" in send_cmd
-        select_cmd = mock_exec.call_args_list[4].args[1]
-        assert "select-window" in select_cmd
-        assert "my-session:0" in select_cmd
+        # No select-window: -d kept window 0 active.
+        assert all(
+            "select-window" not in c.args[1] for c in mock_exec.call_args_list
+        )
 
     async def test_default_command_skipped_when_session_exists(self):
         """Default command is not sent if session already exists."""
@@ -1274,8 +1280,8 @@ class TestEnsureBaseSession:
             )
         mock_exec.assert_awaited_once()
 
-    async def test_default_command_failure_logs_warning(self):
-        """Warning logged when send-keys fails, session still created."""
+    async def test_default_command_window_failure_logs_warning(self):
+        """Warning logged when the default-cmd window can't be created."""
         from klangk_backend.terminal import _ensure_base_session
 
         with patch(
@@ -1284,10 +1290,40 @@ class TestEnsureBaseSession:
             side_effect=[
                 (1, "", ""),  # has-session fails
                 (0, "", ""),  # new-session ok
-                OSError("send-keys failed"),
+                OSError("new-window failed"),  # new-window fails
             ],
+        ) as mock_exec:
+            created = await _ensure_base_session(
+                "cid", "my-session", default_command="openclaw gateway"
+            )
+        assert created is True
+        # Window creation failed, so the command was never sent.
+        assert mock_exec.await_count == 3
+        assert all(
+            "send-keys" not in c.args[1] for c in mock_exec.call_args_list
+        )
+
+    async def test_default_command_send_keys_failure_logs_warning(self):
+        """Warning logged when send-keys fails; session still created."""
+        from klangk_backend.terminal import _ensure_base_session
+
+        with (
+            patch(
+                "klangk_backend.terminal.podman.exec_container",
+                new_callable=AsyncMock,
+                side_effect=[
+                    (1, "", ""),  # has-session fails
+                    (0, "", ""),  # new-session ok
+                    (0, "", ""),  # new-window ok
+                    OSError("send-keys failed"),  # send-keys fails
+                ],
+            ) as mock_exec,
+            patch(
+                "klangk_backend.terminal.asyncio.sleep", new_callable=AsyncMock
+            ),
         ):
             created = await _ensure_base_session(
                 "cid", "my-session", default_command="openclaw gateway"
             )
         assert created is True
+        assert mock_exec.await_count == 4

--- a/src/backend/tests/test_terminal.py
+++ b/src/backend/tests/test_terminal.py
@@ -1230,7 +1230,7 @@ class TestEnsureBaseSession:
         assert "SSH_AUTH_SOCK=/tmp/agent.sock" in new_cmd
 
     async def test_default_command_sends_keys(self):
-        """Default command is sent as keystrokes after session creation."""
+        """Default command runs in a dedicated 'default-cmd' window."""
         from klangk_backend.terminal import _ensure_base_session
 
         with patch(
@@ -1239,19 +1239,26 @@ class TestEnsureBaseSession:
             side_effect=[
                 (1, "", ""),  # has-session fails
                 (0, "", ""),  # new-session ok
+                (0, "", ""),  # new-window ok
                 (0, "", ""),  # send-keys ok
+                (0, "", ""),  # select-window ok
             ],
         ) as mock_exec:
             created = await _ensure_base_session(
                 "cid", "my-session", default_command="openclaw gateway"
             )
         assert created is True
-        assert mock_exec.await_count == 3
-        send_cmd = mock_exec.call_args_list[2].args[1]
+        assert mock_exec.await_count == 5
+        new_window_cmd = mock_exec.call_args_list[2].args[1]
+        assert "new-window" in new_window_cmd
+        assert "default-cmd" in new_window_cmd
+        send_cmd = mock_exec.call_args_list[3].args[1]
         assert "send-keys" in send_cmd
-        assert "my-session:0" in send_cmd
+        assert "my-session:default-cmd" in send_cmd
         assert "openclaw gateway" in send_cmd
-        assert "Enter" in send_cmd
+        select_cmd = mock_exec.call_args_list[4].args[1]
+        assert "select-window" in select_cmd
+        assert "my-session:0" in select_cmd
 
     async def test_default_command_skipped_when_session_exists(self):
         """Default command is not sent if session already exists."""

--- a/src/cli/e2e-tests/test_cli_e2e.py
+++ b/src/cli/e2e-tests/test_cli_e2e.py
@@ -762,6 +762,176 @@ class TestAutoStart:
         assert "not enabled" in result.stdout or "not enabled" in result.stderr
 
 
+def _poll_exec(env, workspace, shell_cmd, expect, timeout=30, interval=1.0):
+    """Run ``klangkc exec`` repeatedly until *expect* appears in stdout.
+
+    The default command runs asynchronously in a tmux window, so its
+    effect isn't visible the instant ``klangkc sandbox`` returns.  This
+    polls until it is (or fails loudly on timeout).
+    """
+    deadline = time.monotonic() + timeout
+    last = ""
+    while time.monotonic() < deadline:
+        r = _run(
+            ["klangkc", "exec", workspace, "bash", "-c", shell_cmd],
+            env=env,
+            timeout=30,
+        )
+        last = r.stdout
+        if expect in r.stdout:
+            return r.stdout
+        time.sleep(interval)
+    raise AssertionError(
+        f"timed out after {timeout}s waiting for {expect!r} from"
+        f" `klangkc exec {workspace} {shell_cmd}`; last stdout:"
+        f" {last!r}"
+    )
+
+
+class TestSandboxAutoStartDefaultCommand:
+    """Auto-started workspace: default_command runs only after setup.
+
+    This is the path PR #1032 guarantees: when a workspace is created
+    with ``auto_start`` the default command is *not* run eagerly at
+    container start (the software isn't installed yet).  ``klangkc
+    sandbox`` runs ``setup.sh`` (which installs the command), then sends
+    ``terminal_start``, which launches the command in a dedicated tmux
+    window.  We verify the command actually ran *and* that it only
+    succeeded after the thing ``setup.sh`` installs became available --
+    which fails if the eager-start path regresses to running the default
+    command before setup.
+    """
+
+    WS = "e2e-sandbox-defcmd"
+    # Own port + instance id so it never collides with TestAutoStart
+    # (18996) or the session server (18995).
+    PORT = "18997"
+
+    @pytest.fixture(autouse=True, scope="class")
+    @staticmethod
+    def autostart_server(tmp_path_factory, request):
+        data_dir = tempfile.mkdtemp(prefix="klangk-sandbox-defcmd-")
+        proc, base_url = _start_server(
+            data_dir,
+            TestSandboxAutoStartDefaultCommand.PORT,
+            "sandbox-defcmd-e2e",
+            extra_env={"KLANGK_ALLOW_AUTOSTART": "1"},
+        )
+        config_dir = tmp_path_factory.mktemp("klangk-sandbox-defcmd-config")
+        env = {**os.environ, "HOME": str(config_dir)}
+        klangk_config_dir = config_dir / ".config" / "klangk"
+        klangk_config_dir.mkdir(parents=True)
+        _run(
+            [
+                "klangkc",
+                "login",
+                base_url,
+                "test@example.com",
+                "--password-file",
+                "-",
+            ],
+            input="testpass\n",
+            env=env,
+        )
+        request.cls._env = env
+        yield
+        _stop_server(proc, data_dir, "sandbox-defcmd-e2e")
+
+    def test_default_command_runs_only_after_setup(self, tmp_path):
+        """default_command (installed by setup.sh) runs post-setup.
+
+        ``setup.sh`` sleeps ~5s to simulate installing software, then
+        creates ``/tmp/myapp``.  The workspace's default_command is
+        ``/tmp/myapp``, which does not exist until setup runs -- so it
+        can only succeed once the sandbox setup phase has completed.
+        """
+        env = self._env
+
+        sandbox_root = tmp_path / "sb"
+        sandbox_root.mkdir()
+        (sandbox_root / ".klangk-sandbox.yaml").write_text(
+            "sandbox:\n"
+            "  mount-at: /sandbox\n"
+            "  setup: setup.sh\n"
+            "workspace:\n"
+            "  default-command: /tmp/myapp\n"
+            "  auto-start: true\n"
+        )
+        # setup.sh: slow "install", then drop a marker-writing script at
+        # /tmp/myapp and record (epoch seconds) when setup finished.
+        # Must be executable: _sandbox_setup runs it directly
+        # (``bash -c '/sandbox/setup.sh'``), not via ``bash <script>``.
+        setup_sh = sandbox_root / "setup.sh"
+        setup_sh.write_text(
+            "#!/bin/sh\n"
+            "# Simulate a slow software install (e.g. openclaw).\n"
+            "sleep 5\n"
+            "cat > /tmp/myapp <<'APP'\n"
+            "#!/bin/sh\n"
+            "date +%s > /tmp/default-cmd-when\n"
+            "echo ran > /tmp/default-cmd-ran\n"
+            "APP\n"
+            "chmod +x /tmp/myapp\n"
+            "date +%s > /tmp/setup-done\n"
+        )
+        setup_sh.chmod(0o755)
+        try:
+            # Sandbox creates the auto-start workspace, runs setup.sh
+            # (sleep 5 + install), then sends terminal_start so the
+            # default command runs in the persistent default-cmd window.
+            result = _run(
+                ["klangkc", "sandbox", self.WS, str(sandbox_root)],
+                env=env,
+                timeout=120,
+            )
+            assert result.returncode == 0, result.stderr
+
+            # (1) The default command actually ran (async in tmux).
+            _poll_exec(
+                env,
+                self.WS,
+                "cat /tmp/default-cmd-ran 2>/dev/null",
+                expect="ran",
+                timeout=30,
+            )
+
+            # (2) setup.sh did install /tmp/myapp -- proving setup ran
+            # and therefore myapp did NOT exist at eager-start time.
+            installed = _run(
+                ["klangkc", "exec", self.WS, "test", "-x", "/tmp/myapp"],
+                env=env,
+                timeout=30,
+            )
+            assert installed.returncode == 0, (
+                "/tmp/myapp missing or not executable; setup never installed it"
+            )
+
+            # (3) The default command ran at/after setup completed.
+            # setup-done is written last in setup.sh; default-cmd-when is
+            # written by myapp when the default command runs.  Under the
+            # run_default_command=True regression myapp wouldn't exist at
+            # eager-start, so default-cmd-when would never be written.
+            ordering = _run(
+                [
+                    "klangkc",
+                    "exec",
+                    self.WS,
+                    "bash",
+                    "-c",
+                    '[ "$(cat /tmp/setup-done)" -le'
+                    ' "$(cat /tmp/default-cmd-when)" ] && echo ordered',
+                ],
+                env=env,
+                timeout=30,
+            )
+            assert "ordered" in ordering.stdout, (
+                "default command ran before setup completed: "
+                f"{ordering.stdout!r}"
+            )
+        finally:
+            _run(["klangkc", "rm", self.WS], env=env, timeout=60)
+
+
 class TestMounts:
     @staticmethod
     def _login(cli_config):

--- a/src/cli/klangkc/main.py
+++ b/src/cli/klangkc/main.py
@@ -1062,6 +1062,20 @@ async def _sandbox_setup_only(
     async with websockets.connect(f"{ws_url}?token={token}", **kwargs) as ws:
         await _wait_workspace_ready(ws, workspace_id)
         await _sandbox_setup(ws, config, sandbox_root, handle)
+        # After setup, start a terminal so the default command runs
+        # in a dedicated "default-cmd" tmux window (visible as a tab
+        # but not occupying the user's interactive window 0).
+        if config.default_command:
+            await ws.send(
+                json.dumps({"cmd": "terminal_start", "cols": 80, "rows": 24})
+            )
+            try:
+                async for raw in ws:
+                    msg = json.loads(raw)
+                    if msg.get("type") == "terminal_started":
+                        break
+            except websockets.ConnectionClosed:
+                pass
 
 
 terminal_app = typer.Typer(

--- a/src/cli/klangkc/main.py
+++ b/src/cli/klangkc/main.py
@@ -1069,13 +1069,20 @@ async def _sandbox_setup_only(
             await ws.send(
                 json.dumps({"cmd": "terminal_start", "cols": 80, "rows": 24})
             )
-            try:
-                async for raw in ws:
-                    msg = json.loads(raw)
-                    if msg.get("type") == "terminal_started":
-                        break
-            except websockets.ConnectionClosed:
-                pass
+            # Wait (bounded) for the terminal to start so the default
+            # command actually runs before we disconnect.  Other
+            # messages are ignored.
+            deadline = asyncio.get_event_loop().time() + 30
+            while True:
+                remaining = deadline - asyncio.get_event_loop().time()
+                if remaining <= 0:  # pragma: no cover
+                    break
+                try:
+                    raw = await asyncio.wait_for(ws.recv(), timeout=remaining)
+                except (asyncio.TimeoutError, websockets.ConnectionClosed):
+                    break
+                if json.loads(raw).get("type") == "terminal_started":
+                    break
 
 
 terminal_app = typer.Typer(

--- a/src/cli/tests/test_cli_main.py
+++ b/src/cli/tests/test_cli_main.py
@@ -2883,6 +2883,87 @@ class TestSandboxSetupOnly:
                 mock_ws, config, Path("/tmp"), "admin"
             )
 
+    async def test_starts_terminal_after_setup_when_default_command(self):
+        from pathlib import Path
+
+        from klangkc.main import _sandbox_setup_only
+        from klangkc.sandbox import SandboxConfig
+
+        config = SandboxConfig(
+            setup="setup.sh", default_command="openclaw gateway"
+        )
+
+        mock_ws = AsyncMock()
+        mock_ws.recv = AsyncMock(
+            side_effect=[
+                json.dumps({"type": "workspace_ready"}),
+                json.dumps({"type": "terminal_started"}),
+            ]
+        )
+
+        with (
+            patch("klangkc.main.websockets.connect") as mock_connect,
+            patch("klangkc.main._sandbox_setup") as mock_setup,
+        ):
+            mock_connect.return_value.__aenter__ = AsyncMock(
+                return_value=mock_ws
+            )
+            mock_connect.return_value.__aexit__ = AsyncMock(return_value=False)
+            await _sandbox_setup_only(
+                "ws://test",
+                "token",
+                "ws-id",
+                config,
+                Path("/tmp"),
+                "admin",
+            )
+            mock_setup.assert_called_once_with(
+                mock_ws, config, Path("/tmp"), "admin"
+            )
+
+        # terminal_start was sent after setup so the default command runs.
+        sent = [json.loads(c.args[0]) for c in mock_ws.send.call_args_list]
+        assert any(m.get("cmd") == "terminal_start" for m in sent)
+
+    async def test_terminal_start_disconnect_is_not_fatal(self):
+        """A closed connection while awaiting terminal_started is tolerated."""
+        from pathlib import Path
+
+        import websockets
+
+        from klangkc.main import _sandbox_setup_only
+        from klangkc.sandbox import SandboxConfig
+
+        config = SandboxConfig(
+            setup="setup.sh", default_command="openclaw gateway"
+        )
+
+        mock_ws = AsyncMock()
+        mock_ws.recv = AsyncMock(
+            side_effect=[
+                json.dumps({"type": "workspace_ready"}),
+                websockets.ConnectionClosed(None, None),
+            ]
+        )
+
+        with (
+            patch("klangkc.main.websockets.connect") as mock_connect,
+            patch("klangkc.main._sandbox_setup"),
+        ):
+            mock_connect.return_value.__aenter__ = AsyncMock(
+                return_value=mock_ws
+            )
+            mock_connect.return_value.__aexit__ = AsyncMock(return_value=False)
+            # Must not raise / hang waiting for terminal_started.
+            await _sandbox_setup_only(
+                "ws://test",
+                "token",
+                "ws-id",
+                config,
+                Path("/tmp"),
+                "admin",
+            )
+
 
 class TestSandboxSetup:
     async def test_copies_files(self, tmp_path):


### PR DESCRIPTION
## Summary

Reworks how `default_command` runs in workspace containers:

- **Dedicated tmux window**: `_ensure_base_session` now creates a "default-cmd" tmux window for the command instead of sending keystrokes into window 0. The user's interactive terminal stays free — they see the command running in a separate tab.
- **CLI triggers after setup**: The sandbox CLI sends `terminal_start` after `setup.sh` completes, so the default command only runs once the software is actually installed.
- **Server boot still works**: `eager_start_workspace` on server boot runs the command directly (software is already installed in the volume from a previous sandbox run). The API create endpoint passes `run_default_command=False` since setup hasn't run yet.

Tested 4x: sandbox create → openclaw running; server restart → openclaw running.

## Test plan
- [x] All 1911 backend tests pass
- [x] 100% coverage
- [x] Interactive: 4x create + 4x restart all PASS
- [ ] CI green