### PR TITLE
feat(frontend): make workspace icon the running/stopped indicator

### DIFF
--- a/src/frontend/lib/workspace/workspace_list_page.dart
+++ b/src/frontend/lib/workspace/workspace_list_page.dart
@@ -642,9 +642,16 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
                       ? Colors.white.withValues(alpha: 0.03)
                       : Colors.transparent,
                   child: ListTile(
-                    leading: _WorkspaceStatusIcon(
-                      running: e.value['running'] as bool? ?? false,
-                      isShared: section.isShared,
+                    leading: Icon(
+                      Icons.terminal,
+                      size: 20,
+                      // The icon itself signals running state: green when
+                      // the container is up, grey when stopped. Owned and
+                      // shared share one color scheme now that they live on
+                      // separate tabs, so no ownership distinction is needed.
+                      color: (e.value['running'] as bool? ?? false)
+                          ? KColors.accentGreen
+                          : KColors.textSecondary,
                     ),
                     title: Text(e.value['name'] as String),
                     subtitle: section.isShared
@@ -803,49 +810,6 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
                 )
               : null,
       body: _buildWorkspacesList(),
-    );
-  }
-}
-
-class _WorkspaceStatusIcon extends StatelessWidget {
-  const _WorkspaceStatusIcon({
-    required this.running,
-    required this.isShared,
-  });
-
-  final bool running;
-  final bool isShared;
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox(
-      width: 24,
-      height: 24,
-      child: Stack(
-        children: [
-          Icon(
-            Icons.terminal,
-            size: 20,
-            color: isShared ? KColors.accentBlue : KColors.accentGreen,
-          ),
-          Positioned(
-            right: 0,
-            bottom: 0,
-            child: Container(
-              width: 8,
-              height: 8,
-              decoration: BoxDecoration(
-                shape: BoxShape.circle,
-                color: running ? KColors.accentGreen : KColors.textMuted,
-                border: Border.all(
-                  color: KColors.bgSurface,
-                  width: 1.5,
-                ),
-              ),
-            ),
-          ),
-        ],
-      ),
     );
   }
 }

--- a/src/frontend/test/workspace_list_page_test.dart
+++ b/src/frontend/test/workspace_list_page_test.dart
@@ -9,6 +9,7 @@ import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:klangk_frontend/auth/auth_service.dart';
 import 'package:klangk_frontend/workspace/workspace_list_page.dart';
+import 'package:klangk_frontend/theme/colors.dart';
 import 'package:klangk_frontend/ws/ws_client.dart';
 import 'package:klangk_frontend/widgets/klangk_logo.dart';
 import 'package:klangk_plugin_api/klangk_plugin_api.dart';
@@ -2171,7 +2172,7 @@ void main() {
       await tester.pump();
     });
 
-    testWidgets('workspace card shows running status dot', (tester) async {
+    testWidgets('workspace card colors icon by running state', (tester) async {
       testAuthHttpClientOverride = withPermissions((request) async {
         if (request.url.path == '/api/v1/workspaces') {
           return http.Response(
@@ -2200,8 +2201,16 @@ void main() {
       await tester.pumpWidget(buildPage());
       await tester.pumpAndSettle();
 
-      // Both workspaces should have status dots (small 8x8 containers)
-      expect(find.byType(ListTile), findsNWidgets(2));
+      // The terminal Icon itself signals running state: green when
+      // running, grey when stopped. The Icon is the ListTile's leading.
+      final tiles = tester.widgetList<ListTile>(find.byType(ListTile)).toList();
+      expect(tiles.length, 2);
+      final runningIcon = tiles[0].leading as Icon;
+      final stoppedIcon = tiles[1].leading as Icon;
+      expect(runningIcon.icon, Icons.terminal);
+      expect(runningIcon.color, KColors.accentGreen);
+      expect(stoppedIcon.icon, Icons.terminal);
+      expect(stoppedIcon.color, KColors.textSecondary);
     });
 
     testWidgets('container_status event updates running state', (tester) async {


### PR DESCRIPTION
Closes #1035.

## Summary

Replaces the small green/grey **status dot** (#1016) with the icon itself as the running/stopped indicator: the terminal icon is `accentGreen` when the container is running and `textSecondary` (grey) when stopped. The redundant corner dot and the owned/shared color distinction are removed — owned and shared cards live on separate tabs, so one color scheme suffices and status is readable at a glance.

## Why

`#1016` shipped an 8×8 status dot in the corner of an always-green terminal icon. The dot is small and low-contrast; making the whole icon reflect state is clearer. A prior attempt at this change was described but never committed/pushed, so it was missing from `main` — this PR lands it properly (#1035).

## Changes

- **`workspace_list_page.dart`** — inline `Icon(Icons.terminal)` at the call site, colored by `running` (`accentGreen` / `textSecondary`). Deleted `_WorkspaceStatusIcon` (the `Stack` + `Positioned` dot + `isShared` branch).
- **`workspace_list_page_test.dart`** — renamed the status test and **strengthened its assertion**: it now checks the leading icon's actual color (green running / grey stopped) instead of only counting `ListTile`s.

## Testing

- All **752 frontend tests pass**.
- The new color assertion is **meaningful**, not vacuous: verified it fails when the colors are flipped (running→grey, stopped→green).
- Web bundle rebuilt (`klangk:flutter-build`); bundle is gitignored so CI rebuilds it.

## Notes

This is the frontend side only; the `running` field on the workspace list API and the `container_status` WS event from #1016 are unchanged. Related: #1034 (the banner-reload cache bug that made the old all-green build stick around).