### PR TITLE
chore(policy): add runyaga to slop allowlist

### DIFF
--- a/.github/slop-allowlist
+++ b/.github/slop-allowlist
@@ -2,3 +2,4 @@
 # One GitHub login per line (case-sensitive, exactly as on GitHub).
 # Lines starting with '#' are comments; blank lines are ignored.
 mcdonc
+runyaga


### PR DESCRIPTION
Adds @runyaga to `.github/slop-allowlist` so their issues/PRs bypass the default-closed auto-close (once `ENABLE_SLOP_POLICY` is enabled). Trivial allowlist edit; no workflow logic changed.