### PR TITLE
chore(policy): add tseaver to slop allowlist

### DIFF
--- a/.github/slop-allowlist
+++ b/.github/slop-allowlist
@@ -3,3 +3,4 @@
 # Lines starting with '#' are comments; blank lines are ignored.
 mcdonc
 runyaga
+tseaver


### PR DESCRIPTION
Adds @tseaver to `.github/slop-allowlist` so their issues/PRs bypass the default-closed auto-close (once `ENABLE_SLOP_POLICY` is enabled). Trivial allowlist edit; no workflow logic changed.