### PR TITLE
chore(policy): add bd-mkt and Shridharrrr to slop allowlist

### DIFF
--- a/.github/slop-allowlist
+++ b/.github/slop-allowlist
@@ -4,3 +4,5 @@
 mcdonc
 runyaga
 tseaver
+bd-mkt
+Shridharrrr


### PR DESCRIPTION
Adds @bd-mkt and @Shridharrrr to `.github/slop-allowlist` so their issues/PRs bypass the default-closed auto-close (once `ENABLE_SLOP_POLICY` is enabled). Logins use exact GitHub canonical casing (the allowlist match is case-sensitive). Trivial allowlist edit; no workflow logic changed.