### PR TITLE
fix(backend): add setup_state lifecycle to prevent premature default_command (#1033)

### DIFF
--- a/src/backend/klangk_backend/api/workspaces.py
+++ b/src/backend/klangk_backend/api/workspaces.py
@@ -126,6 +126,7 @@ class CreateWorkspaceRequest(BaseModel):
     auto_start: bool = False
     mounts: list[str] | None = None
     env: dict[str, str] | None = None
+    setup_state: Literal["pending", "complete", "failed"] | None = None
 
 
 @router.post("/workspaces")
@@ -157,6 +158,7 @@ async def create_workspace(
             auto_start=body.auto_start,
             mounts=body.mounts,
             env=body.env,
+            setup_state=body.setup_state or "complete",
         )
     except SAIntegrityError:
         raise HTTPException(
@@ -240,6 +242,7 @@ class UpdateWorkspaceRequest(BaseModel):
     auto_start: bool | None = None
     mounts: list[str] | None = None
     env: dict[str, str] | None = None
+    setup_state: Literal["pending", "complete", "failed"] | None = None
 
 
 @router.put("/workspaces/{workspace_id}")

--- a/src/backend/klangk_backend/model/__init__.py
+++ b/src/backend/klangk_backend/model/__init__.py
@@ -111,6 +111,10 @@ from .workspaces import (
     list_workspaces,
     update_workspace,
     update_workspace_container,
+    SETUP_STATE_COMPLETE,
+    SETUP_STATE_FAILED,
+    SETUP_STATE_PENDING,
+    SETUP_STATES,
 )
 from .ports import (
     MAX_PORT,
@@ -246,6 +250,11 @@ __all__ = (
     "list_workspaces",
     "update_workspace",
     "update_workspace_container",
+    # setup_state lifecycle (#1033)
+    "SETUP_STATE_COMPLETE",
+    "SETUP_STATE_FAILED",
+    "SETUP_STATE_PENDING",
+    "SETUP_STATES",
     # ports
     "MAX_PORT",
     "_port_in_use",

--- a/src/backend/klangk_backend/model/schema.py
+++ b/src/backend/klangk_backend/model/schema.py
@@ -78,6 +78,11 @@ async def init_db() -> None:
                 image TEXT,  -- custom container image; NULL means use default
                 default_command TEXT,  -- auto-run in terminal on connect
                 auto_start INTEGER NOT NULL DEFAULT 0,  -- start on server boot
+                -- setup lifecycle: pending (setup expected/running) /
+                -- complete (prereqs met, default cmd may fire) / failed.
+                -- Descriptive, not proscriptive: a workspace is created
+                -- in whichever state matches reality (see #1033).
+                setup_state TEXT NOT NULL DEFAULT 'complete',
                 mounts TEXT,  -- JSON array of host:container mount specs
                 env TEXT,  -- JSON dict of custom environment variables
                 created_at TEXT NOT NULL DEFAULT (datetime('now')),
@@ -91,6 +96,14 @@ async def init_db() -> None:
             await db.execute(
                 "ALTER TABLE workspaces"
                 " ADD COLUMN auto_start INTEGER NOT NULL DEFAULT 0"
+            )
+        # Migration: add setup_state column (#1033). Defaults to
+        # 'complete' so existing workspaces (already set up in their
+        # persisted volumes) keep firing their default command.
+        if "setup_state" not in ws_cols:
+            await db.execute(
+                "ALTER TABLE workspaces"
+                " ADD COLUMN setup_state TEXT NOT NULL DEFAULT 'complete'"
             )
         await db.execute("""
             CREATE TABLE IF NOT EXISTS port_allocations (

--- a/src/backend/klangk_backend/model/workspaces.py
+++ b/src/backend/klangk_backend/model/workspaces.py
@@ -11,6 +11,16 @@ from .users import get_user_group_ids
 # Must match the DB default and container.DEFAULT_PORTS_PER_WORKSPACE.
 _DEFAULT_PORTS_PER_WORKSPACE = 5
 
+# setup_state lifecycle values (#1033). A workspace always holds
+# exactly one. Descriptive, not proscriptive: created in whichever
+# state matches reality.
+SETUP_STATE_PENDING = "pending"
+SETUP_STATE_COMPLETE = "complete"
+SETUP_STATE_FAILED = "failed"
+SETUP_STATES = frozenset(
+    {SETUP_STATE_PENDING, SETUP_STATE_COMPLETE, SETUP_STATE_FAILED}
+)
+
 
 async def create_workspace(
     user_id: str,
@@ -20,7 +30,10 @@ async def create_workspace(
     auto_start: bool = False,
     mounts: list[str] | None = None,
     env: dict[str, str] | None = None,
+    setup_state: str = SETUP_STATE_COMPLETE,
 ) -> dict:
+    if setup_state not in SETUP_STATES:
+        raise ValueError(f"Invalid setup_state: {setup_state!r}")
     async with transaction() as db:
         workspace_id = str(uuid.uuid4())
         created_at = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
@@ -29,8 +42,8 @@ async def create_workspace(
         await db.execute(
             "INSERT INTO workspaces"
             " (id, user_id, name, image, default_command, auto_start,"
-            " mounts, env, created_at)"
-            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            " setup_state, mounts, env, created_at)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 workspace_id,
                 user_id,
@@ -38,6 +51,7 @@ async def create_workspace(
                 image,
                 default_command,
                 1 if auto_start else 0,
+                setup_state,
                 mounts_json,
                 env_json,
                 created_at,
@@ -50,6 +64,7 @@ async def create_workspace(
             "image": image,
             "default_command": default_command,
             "auto_start": auto_start,
+            "setup_state": setup_state,
             "mounts": mounts,
             "env": env,
             "num_ports": _DEFAULT_PORTS_PER_WORKSPACE,
@@ -101,7 +116,8 @@ async def list_workspaces(
     async with transaction() as db:
         cursor = await db.execute(
             "SELECT id, name, container_id, image, default_command,"
-            " auto_start, mounts, env, created_at FROM workspaces"
+            " auto_start, setup_state, mounts, env, created_at"
+            " FROM workspaces"
             f" {where} {order_by} LIMIT ? OFFSET ?",
             tuple(params),
         )
@@ -114,6 +130,7 @@ async def list_workspaces(
                 "image": row["image"],
                 "default_command": row["default_command"],
                 "auto_start": bool(row["auto_start"]),
+                "setup_state": row["setup_state"],
                 "mounts": json.loads(row["mounts"]) if row["mounts"] else None,
                 "env": json.loads(row["env"]) if row["env"] else None,
                 "created_at": row["created_at"],
@@ -156,8 +173,8 @@ async def list_shared_workspaces(
         )
         cursor = await db.execute(
             "SELECT DISTINCT w.id, w.name, w.container_id, w.image,"
-            " w.default_command, w.auto_start, w.mounts, w.env, w.created_at,"
-            " u.email AS owner_email"
+            " w.default_command, w.auto_start, w.setup_state, w.mounts,"
+            " w.env, w.created_at, u.email AS owner_email"
             " FROM workspaces w"
             " JOIN acl_entries ae ON ae.resource = '/workspaces/' || w.id"
             " JOIN users u ON w.user_id = u.id"
@@ -187,6 +204,7 @@ async def list_shared_workspaces(
                 "image": row["image"],
                 "default_command": row["default_command"],
                 "auto_start": bool(row["auto_start"]),
+                "setup_state": row["setup_state"],
                 "mounts": json.loads(row["mounts"]) if row["mounts"] else None,
                 "env": json.loads(row["env"]) if row["env"] else None,
                 "created_at": row["created_at"],
@@ -214,14 +232,14 @@ async def get_workspace(
         if user_id is not None:
             cursor = await db.execute(
                 "SELECT id, user_id, name, container_id, num_ports, image,"
-                " default_command, auto_start, mounts, env"
+                " default_command, auto_start, setup_state, mounts, env"
                 " FROM workspaces WHERE id = ? AND user_id = ?",
                 (workspace_id, user_id),
             )
         else:
             cursor = await db.execute(
                 "SELECT id, user_id, name, container_id, num_ports, image,"
-                " default_command, auto_start, mounts, env"
+                " default_command, auto_start, setup_state, mounts, env"
                 " FROM workspaces WHERE id = ?",
                 (workspace_id,),
             )
@@ -237,6 +255,7 @@ async def get_workspace(
             "image": row["image"],
             "default_command": row["default_command"],
             "auto_start": bool(row["auto_start"]),
+            "setup_state": row["setup_state"],
             "mounts": json.loads(row["mounts"]) if row["mounts"] else None,
             "env": json.loads(row["env"]) if row["env"] else None,
         }
@@ -246,7 +265,7 @@ async def get_workspace_by_id(workspace_id: str) -> dict | None:
     """Get a workspace by ID without access control (for admin use)."""
     row = await _fetchone(
         "SELECT id, user_id, name, container_id, num_ports, image,"
-        " default_command, mounts, env"
+        " default_command, setup_state, mounts, env"
         " FROM workspaces WHERE id = ?",
         (workspace_id,),
     )
@@ -260,6 +279,7 @@ async def get_workspace_by_id(workspace_id: str) -> dict | None:
         "num_ports": row["num_ports"],
         "image": row["image"],
         "default_command": row["default_command"],
+        "setup_state": row["setup_state"],
         "mounts": json.loads(row["mounts"]) if row["mounts"] else None,
         "env": json.loads(row["env"]) if row["env"] else None,
     }
@@ -360,6 +380,7 @@ async def update_workspace(
         "image",
         "default_command",
         "auto_start",
+        "setup_state",
         "mounts",
         "env",
     }
@@ -367,7 +388,11 @@ async def update_workspace(
     for k, v in fields.items():
         if k not in allowed:
             continue
-        if k in ("mounts", "env"):
+        if k == "setup_state":
+            if v not in SETUP_STATES:
+                raise ValueError(f"Invalid setup_state: {v!r}")
+            to_set[k] = v
+        elif k in ("mounts", "env"):
             to_set[k] = json.dumps(v) if v is not None else None
         elif k == "auto_start":
             to_set[k] = 1 if v else 0
@@ -404,7 +429,7 @@ async def list_auto_start_workspaces() -> list[dict]:
     async with transaction() as db:
         cursor = await db.execute(
             "SELECT id, user_id, name, container_id, num_ports, image,"
-            " default_command, auto_start, mounts, env"
+            " default_command, auto_start, setup_state, mounts, env"
             " FROM workspaces WHERE auto_start = 1",
         )
         rows = await cursor.fetchall()
@@ -418,6 +443,7 @@ async def list_auto_start_workspaces() -> list[dict]:
                 "image": row["image"],
                 "default_command": row["default_command"],
                 "auto_start": True,
+                "setup_state": row["setup_state"],
                 "mounts": json.loads(row["mounts"]) if row["mounts"] else None,
                 "env": json.loads(row["env"]) if row["env"] else None,
             }

--- a/src/backend/klangk_backend/terminal.py
+++ b/src/backend/klangk_backend/terminal.py
@@ -24,6 +24,7 @@ from collections.abc import AsyncGenerator
 
 from . import podman
 from .exceptions import TerminalError
+from .model.workspaces import SETUP_STATE_COMPLETE
 from .util import BoundedOutputQueue, resolve_env_value
 
 logger = logging.getLogger(__name__)
@@ -97,28 +98,8 @@ _WORKSPACE_STATE_FILE = ".workspace-state.json"
 DEFAULT_CMD_WINDOW = "default-cmd"
 
 
-async def _ensure_base_session(
-    container_id: str,
-    session_name: str,
-    user_home: str | None = None,
-    ssh_agent_socket: str | None = None,
-    default_command: str | None = None,
-) -> bool:
-    """Create the base tmux session (detached) if it doesn't exist.
-
-    Grouped sessions require a target session.  This ensures the base
-    session exists before any grouped session tries to link to it.
-
-    If *default_command* is set and the session is freshly created,
-    the command is run in a dedicated detached window named
-    ``DEFAULT_CMD_WINDOW`` so the user's window 0 stays free for
-    interactive use.  The command runs as a foreground process in
-    that window's bash shell — Ctrl-C stops it and returns to the
-    prompt.
-
-    Returns ``True`` if the session was freshly created.
-    """
-    # Check if the session already exists.
+async def _has_tmux_session(container_id: str, session_name: str) -> bool:
+    """Return True if a tmux session named *session_name* exists."""
     try:
         rc, _, _ = await podman.exec_container(
             container_id,
@@ -126,34 +107,128 @@ async def _ensure_base_session(
             user=CONTAINER_USER,
             timeout=5,
         )
-        if rc == 0:
-            return False  # already exists
     except Exception:
-        pass  # assume it doesn't exist
+        return False
+    return rc == 0
 
-    # Create detached base session.  HOME / SSH_AUTH_SOCK are passed as
-    # tmux's own ``-e`` flags (part of the command), not podman's.
-    env_args: list[str] = []
-    if user_home is not None:
-        env_args += ["-e", f"HOME={user_home}"]
-    if ssh_agent_socket is not None:
-        env_args += ["-e", f"SSH_AUTH_SOCK={ssh_agent_socket}"]
+
+async def _default_cmd_window_exists(
+    container_id: str, session_name: str
+) -> bool:
+    """Return True if the ``default-cmd`` window exists in *session_name*.
+
+    This is the ephemeral "has the default command already fired in
+    THIS container" check (#1033). Unlike ``setup_state`` it is
+    per-container: it resets on container recreation, so the boot path
+    re-fires the default command for an already-``complete`` workspace.
+    tmux allows duplicate window names, so we must inspect the list
+    rather than rely on ``new-window`` failing.
+    """
     try:
-        await podman.exec_container(
+        rc, stdout, _ = await podman.exec_container(
             container_id,
-            ["tmux", "new-session", "-d", "-s", session_name, *env_args],
+            [
+                "tmux",
+                "list-windows",
+                "-t",
+                session_name,
+                "-F",
+                "#{window_name}",
+            ],
             user=CONTAINER_USER,
-            timeout=10,
+            timeout=5,
         )
     except Exception:
-        logger.warning("Failed to create base tmux session %s", session_name)
         return False
+    if rc != 0:
+        return False
+    return DEFAULT_CMD_WINDOW in {
+        line.strip() for line in stdout.splitlines() if line.strip()
+    }
 
-    # Run the default command in a detached window named
-    # DEFAULT_CMD_WINDOW so the user's window 0 stays free for
-    # interactive use.  ``-d`` keeps window 0 as the active window,
-    # so no select-window is needed afterwards.
-    if default_command:
+
+def _should_fire_default_command(
+    default_command: str | None, setup_state: str
+) -> bool:
+    """The setup-phase half of the firing predicate (#1033).
+
+    The default command may fire iff it is configured AND setup is
+    complete. ``pending`` and ``failed`` both block. ``setup_state`` is
+    always one of the three lifecycle values -- the DB column is
+    ``NOT NULL DEFAULT 'complete'`` and every SELECT includes it -- so
+    there is no ``None`` case to handle here.
+
+    The other half -- "the default-cmd window doesn't already exist" --
+    is checked by the caller via :func:`_default_cmd_window_exists`,
+    since it is per-container and ephemeral.
+    """
+    if not default_command:
+        return False
+    return setup_state == SETUP_STATE_COMPLETE
+
+
+async def _ensure_base_session(
+    container_id: str,
+    session_name: str,
+    user_home: str | None = None,
+    ssh_agent_socket: str | None = None,
+    default_command: str | None = None,
+    setup_state: str = SETUP_STATE_COMPLETE,
+) -> bool:
+    """Ensure the base tmux session exists and maybe fire the default cmd.
+
+    Two independent jobs, split out so that an early visitor's
+    ``terminal_start`` no longer swallows the post-setup one (#1033):
+
+    1. *Base session + window 0* -- created idempotently and ALWAYS.
+       A visitor connecting mid-setup still gets a working interactive
+       shell. This is what every ``terminal_start`` needs regardless of
+       setup state.
+
+    2. *The ``default-cmd`` window* -- created only when the firing
+       predicate holds:
+
+           default_command is set  AND  setup_state == complete
+                                 AND  the window doesn't already exist
+
+       Crucially this runs EVEN IF the session already exists (created
+       by an earlier visitor). Previously the whole function returned
+       ``False`` the moment the session existed, so once an early
+       visitor made the session, the post-setup ``terminal_start`` was
+       a no-op and the default command never ran.
+
+    Returns ``True`` if the base session was freshly created.
+    """
+    session_existed = await _has_tmux_session(container_id, session_name)
+    if not session_existed:
+        # Create detached base session.  HOME / SSH_AUTH_SOCK are passed
+        # as tmux's own ``-e`` flags (part of the command), not
+        # podman's.
+        env_args: list[str] = []
+        if user_home is not None:
+            env_args += ["-e", f"HOME={user_home}"]
+        if ssh_agent_socket is not None:
+            env_args += ["-e", f"SSH_AUTH_SOCK={ssh_agent_socket}"]
+        try:
+            await podman.exec_container(
+                container_id,
+                ["tmux", "new-session", "-d", "-s", session_name, *env_args],
+                user=CONTAINER_USER,
+                timeout=10,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to create base tmux session %s", session_name
+            )
+            return False
+
+    # The default-cmd window: fire iff the predicate holds AND it
+    # doesn't already exist (exactly-once-per-container). This block
+    # is reached even when the session pre-existed (early visitor),
+    # which is the #1033 fix.
+    if _should_fire_default_command(
+        default_command, setup_state
+    ) and not await _default_cmd_window_exists(container_id, session_name):
         try:
             await podman.exec_container(
                 container_id,
@@ -199,7 +274,7 @@ async def _ensure_base_session(
                     "Failed to send default command to %s", session_name
                 )
 
-    return True
+    return not session_existed
 
 
 def _build_shell_command(
@@ -705,6 +780,7 @@ class TerminalSession:
         user_handle: str | None = None,
         ssh_agent_socket: str | None = None,
         default_command: str | None = None,
+        setup_state: str = SETUP_STATE_COMPLETE,
     ):
         self.container_id = container_id
         self.session_name = session_name
@@ -716,6 +792,7 @@ class TerminalSession:
         self.user_handle = user_handle
         self.ssh_agent_socket = ssh_agent_socket
         self.default_command = default_command
+        self.setup_state = setup_state
         self._shell: ShellProcess | None = None
         self._output_queue: BoundedOutputQueue[str] = BoundedOutputQueue(
             maxsize=64
@@ -746,6 +823,7 @@ class TerminalSession:
                 user_home=self.user_home,
                 ssh_agent_socket=self.ssh_agent_socket,
                 default_command=self.default_command,
+                setup_state=self.setup_state,
             )
         env = _build_environment(
             self.user_home,

--- a/src/backend/klangk_backend/workspaces.py
+++ b/src/backend/klangk_backend/workspaces.py
@@ -234,6 +234,7 @@ async def create_workspace(
     auto_start: bool = False,
     mounts: list[str] | None = None,
     env: dict[str, str] | None = None,
+    setup_state: str | None = None,
 ) -> dict:
     workspace = await model.create_workspace(
         user_id,
@@ -243,6 +244,7 @@ async def create_workspace(
         auto_start=auto_start,
         mounts=mounts,
         env=env,
+        setup_state=setup_state or model.SETUP_STATE_COMPLETE,
     )
     home = home_path(user_id, workspace["id"])
     home.mkdir(parents=True, exist_ok=True)
@@ -448,6 +450,7 @@ async def eager_start_workspace(
                 owner_id,
                 user_home=user_home,
                 default_command=default_command,
+                setup_state=ws.get("setup_state"),
             )
 
     return cid, status

--- a/src/backend/klangk_backend/wshandler/controllers.py
+++ b/src/backend/klangk_backend/wshandler/controllers.py
@@ -393,6 +393,23 @@ class TerminalController:
                 {"type": "shared_terminals", "terminals": terminals}
             )
 
+    async def _setup_state_for_workspace(self) -> str:
+        """Fetch the workspace's setup_state fresh from the DB (#1033).
+
+        Returns the literal lifecycle value, defaulting to 'complete'
+        if the workspace can't be loaded or the lookup fails. A failed
+        lookup must NOT crash terminal_start -- defaulting to
+        'complete' preserves the historical fire-by-default behaviour
+        rather than silently disabling default commands.
+        """
+        try:
+            ws = await model.get_workspace(self._conn.workspace_id)
+        except Exception:
+            return "complete"
+        if ws is None:
+            return "complete"
+        return ws.get("setup_state") or "complete"
+
     async def start(self, msg: dict) -> None:
 
         logger.info(
@@ -442,6 +459,13 @@ class TerminalController:
             user_handle=self._conn.user.get("handle"),
             ssh_agent_socket=self._conn._ssh_agent_socket,
             default_command=self._conn._default_command,
+            # Read setup_state FRESH from the DB -- not from a cached
+            # connection field. The setup-owner connection caches its
+            # state as 'pending' at connect time, but by the time it
+            # sends terminal_start (after setup.sh returns) the DB
+            # holds 'complete'. A cached value would wrongly block
+            # the post-setup fire (#1033).
+            setup_state=await self._setup_state_for_workspace(),
         )
 
         browser_id = msg.get("browser_id")

--- a/src/backend/tests/test_terminal.py
+++ b/src/backend/tests/test_terminal.py
@@ -1240,6 +1240,7 @@ class TestEnsureBaseSession:
                 side_effect=[
                     (1, "", ""),  # has-session fails
                     (0, "", ""),  # new-session ok
+                    (0, "", ""),  # list-windows: default-cmd absent
                     (0, "", ""),  # new-window ok
                     (0, "", ""),  # send-keys ok
                 ],
@@ -1252,12 +1253,14 @@ class TestEnsureBaseSession:
                 "cid", "my-session", default_command="openclaw gateway"
             )
         assert created is True
-        assert mock_exec.await_count == 4
-        new_window_cmd = mock_exec.call_args_list[2].args[1]
+        assert mock_exec.await_count == 5
+        list_cmd = mock_exec.call_args_list[2].args[1]
+        assert "list-windows" in list_cmd
+        new_window_cmd = mock_exec.call_args_list[3].args[1]
         assert "new-window" in new_window_cmd
         assert "-d" in new_window_cmd  # detached -> window 0 stays active
         assert "default-cmd" in new_window_cmd
-        send_cmd = mock_exec.call_args_list[3].args[1]
+        send_cmd = mock_exec.call_args_list[4].args[1]
         assert "send-keys" in send_cmd
         assert "my-session:default-cmd" in send_cmd
         assert "openclaw gateway" in send_cmd
@@ -1266,19 +1269,119 @@ class TestEnsureBaseSession:
             "select-window" not in c.args[1] for c in mock_exec.call_args_list
         )
 
-    async def test_default_command_skipped_when_session_exists(self):
-        """Default command is not sent if session already exists."""
+    async def test_default_command_fires_even_when_session_exists(self):
+        """#1033: default-cmd window is created even if session pre-exists.
+
+        An early visitor may have created the base session mid-setup.
+        The post-setup terminal_start must STILL create the default-cmd
+        window. Previously the whole function returned False the moment
+        the session existed, swallowing the post-setup fire.
+        """
+        from klangk_backend.terminal import _ensure_base_session
+
+        with (
+            patch(
+                "klangk_backend.terminal.podman.exec_container",
+                new_callable=AsyncMock,
+                side_effect=[
+                    (0, "", ""),  # has-session succeeds (pre-exists)
+                    (0, "", ""),  # list-windows: default-cmd absent
+                    (0, "", ""),  # new-window ok
+                    (0, "", ""),  # send-keys ok
+                ],
+            ) as mock_exec,
+            patch(
+                "klangk_backend.terminal.asyncio.sleep", new_callable=AsyncMock
+            ),
+        ):
+            created = await _ensure_base_session(
+                "cid",
+                "my-session",
+                default_command="openclaw gateway",
+                setup_state="complete",
+            )
+        # Session pre-existed, so not freshly created.
+        assert created is False
+        # But the default-cmd window WAS created (the #1033 fix).
+        assert mock_exec.await_count == 4
+        assert "new-session" not in mock_exec.call_args_list[0].args[1]
+        assert "new-window" in mock_exec.call_args_list[2].args[1]
+
+    async def test_default_command_skipped_when_window_already_exists(self):
+        """Exactly-once: don't re-create default-cmd if it already exists."""
         from klangk_backend.terminal import _ensure_base_session
 
         with patch(
             "klangk_backend.terminal.podman.exec_container",
             new_callable=AsyncMock,
-            return_value=(0, "", ""),  # has-session succeeds
+            side_effect=[
+                (0, "", ""),  # has-session succeeds
+                (0, "bash\ndefault-cmd\n", ""),  # list-windows: present
+            ],
+        ) as mock_exec:
+            created = await _ensure_base_session(
+                "cid",
+                "my-session",
+                default_command="openclaw gateway",
+                setup_state="complete",
+            )
+        assert created is False
+        # No new-window / send-keys: the window already exists.
+        assert mock_exec.await_count == 2
+        assert all(
+            "new-window" not in c.args[1] for c in mock_exec.call_args_list
+        )
+        assert all(
+            "send-keys" not in c.args[1] for c in mock_exec.call_args_list
+        )
+
+    async def test_default_command_blocked_when_setup_pending(self):
+        """#1033: pending setup_state blocks the default command entirely."""
+        from klangk_backend.terminal import _ensure_base_session
+
+        with patch(
+            "klangk_backend.terminal.podman.exec_container",
+            new_callable=AsyncMock,
+            side_effect=[
+                (1, "", ""),  # has-session fails
+                (0, "", ""),  # new-session ok
+            ],
+        ) as mock_exec:
+            created = await _ensure_base_session(
+                "cid",
+                "my-session",
+                default_command="openclaw gateway",
+                setup_state="pending",
+            )
+        assert created is True
+        # Base session created, but NO default-cmd window (setup pending).
+        assert mock_exec.await_count == 2
+        assert all(
+            "new-window" not in c.args[1] for c in mock_exec.call_args_list
+        )
+
+    async def test_default_command_blocked_when_setup_failed(self):
+        """#1033: failed setup_state also blocks the default command."""
+        from klangk_backend.terminal import _ensure_base_session
+
+        with patch(
+            "klangk_backend.terminal.podman.exec_container",
+            new_callable=AsyncMock,
+            side_effect=[
+                (0, "", ""),  # has-session succeeds
+            ],
         ) as mock_exec:
             await _ensure_base_session(
-                "cid", "my-session", default_command="openclaw gateway"
+                "cid",
+                "my-session",
+                default_command="openclaw gateway",
+                setup_state="failed",
             )
-        mock_exec.assert_awaited_once()
+        # No window creation at all.
+        assert mock_exec.await_count == 1
+        assert all(
+            "new-window" not in c.args[1] for c in mock_exec.call_args_list
+        )
 
     async def test_default_command_window_failure_logs_warning(self):
         """Warning logged when the default-cmd window can't be created."""
@@ -1290,6 +1393,7 @@ class TestEnsureBaseSession:
             side_effect=[
                 (1, "", ""),  # has-session fails
                 (0, "", ""),  # new-session ok
+                (0, "", ""),  # list-windows: default-cmd absent
                 OSError("new-window failed"),  # new-window fails
             ],
         ) as mock_exec:
@@ -1298,7 +1402,7 @@ class TestEnsureBaseSession:
             )
         assert created is True
         # Window creation failed, so the command was never sent.
-        assert mock_exec.await_count == 3
+        assert mock_exec.await_count == 4
         assert all(
             "send-keys" not in c.args[1] for c in mock_exec.call_args_list
         )
@@ -1314,6 +1418,7 @@ class TestEnsureBaseSession:
                 side_effect=[
                     (1, "", ""),  # has-session fails
                     (0, "", ""),  # new-session ok
+                    (0, "", ""),  # list-windows: default-cmd absent
                     (0, "", ""),  # new-window ok
                     OSError("send-keys failed"),  # send-keys fails
                 ],
@@ -1326,4 +1431,40 @@ class TestEnsureBaseSession:
                 "cid", "my-session", default_command="openclaw gateway"
             )
         assert created is True
-        assert mock_exec.await_count == 4
+        assert mock_exec.await_count == 5
+
+    async def test_default_cmd_window_exists_exception_returns_false(self):
+        """_default_cmd_window_exists returns False if list-windows raises."""
+        from klangk_backend.terminal import _default_cmd_window_exists
+
+        with patch(
+            "klangk_backend.terminal.podman.exec_container",
+            new_callable=AsyncMock,
+            side_effect=OSError("boom"),
+        ):
+            result = await _default_cmd_window_exists("cid", "my-session")
+        assert result is False
+
+    async def test_default_cmd_window_exists_rc_nonzero_returns_false(self):
+        """_default_cmd_window_exists returns False if list-windows fails."""
+        from klangk_backend.terminal import _default_cmd_window_exists
+
+        with patch(
+            "klangk_backend.terminal.podman.exec_container",
+            new_callable=AsyncMock,
+            return_value=(1, "", ""),  # list-windows fails
+        ):
+            result = await _default_cmd_window_exists("cid", "my-session")
+        assert result is False
+
+    async def test_has_tmux_session_exception_returns_false(self):
+        """_has_tmux_session returns False if has-session raises."""
+        from klangk_backend.terminal import _has_tmux_session
+
+        with patch(
+            "klangk_backend.terminal.podman.exec_container",
+            new_callable=AsyncMock,
+            side_effect=OSError("boom"),
+        ):
+            result = await _has_tmux_session("cid", "my-session")
+        assert result is False

--- a/src/backend/tests/test_workspaces.py
+++ b/src/backend/tests/test_workspaces.py
@@ -38,6 +38,18 @@ class TestCreateWorkspace:
         with pytest.raises(Exception):
             await ws_mod.create_workspace(user["id"], "unique")
 
+    async def test_invalid_setup_state_rejected(self, user):
+        """Invalid setup_state raises ValueError (#1033)."""
+        with pytest.raises(ValueError, match="Invalid setup_state"):
+            await ws_mod.create_workspace(
+                user["id"], "bad-state", setup_state="bogus"
+            )
+
+    async def test_setup_state_defaults_to_complete(self, user):
+        """Workspaces without a setup command default to 'complete'."""
+        ws = await ws_mod.create_workspace(user["id"], "default-state")
+        assert ws["setup_state"] == "complete"
+
     async def test_allocate_ports_failure_cleans_up(self, user):
         """If allocate_ports raises, DB record and directories are removed."""
         with patch.object(
@@ -56,6 +68,28 @@ class TestCreateWorkspace:
         # Name should be reusable (proves full cleanup)
         ws = await ws_mod.create_workspace(user["id"], "boom")
         assert ws["name"] == "boom"
+
+
+async def test_update_workspace_invalid_setup_state_rejected(user):
+    """update_workspace rejects an invalid setup_state (#1033)."""
+    from klangk_backend.model import update_workspace
+
+    ws = await ws_mod.create_workspace(user["id"], "upd-state")
+    with pytest.raises(ValueError, match="Invalid setup_state"):
+        await update_workspace(ws["id"], ws["user_id"], setup_state="bogus")
+
+
+async def test_update_workspace_sets_setup_state(user):
+    """update_workspace can transition setup_state (#1033)."""
+    from klangk_backend.model import get_workspace, update_workspace
+
+    ws = await ws_mod.create_workspace(
+        user["id"], "upd-ok", setup_state="pending"
+    )
+    assert ws["setup_state"] == "pending"
+    await update_workspace(ws["id"], ws["user_id"], setup_state="complete")
+    refreshed = await get_workspace(ws["id"])
+    assert refreshed["setup_state"] == "complete"
 
 
 class TestListWorkspaces:
@@ -359,6 +393,7 @@ class TestEagerStartWorkspace:
                 user["id"],
                 user_home=mock_session.call_args[1]["user_home"],
                 default_command="openclaw gateway",
+                setup_state="complete",
             )
         finally:
             container.registry.states.pop(ws["id"], None)

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -727,6 +727,7 @@ class TestHandleTerminalStart:
             user_handle="testuser",
             ssh_agent_socket=None,
             default_command=None,
+            setup_state="complete",
         )
         # Should have sent terminal_windows and shared_terminals
         sent = [c[0][0] for c in sock.send_json.call_args_list]
@@ -1208,6 +1209,7 @@ class TestHandleTerminalStart:
             user_handle="testuser",
             ssh_agent_socket=None,
             default_command="pi",
+            setup_state="complete",
         )
 
         conn.terminal_task.cancel()
@@ -2965,6 +2967,7 @@ class TestSSHAgentHandlers:
             user_handle="testuser",
             ssh_agent_socket="/tmp/klangk-ssh-agent-uid.sock",
             default_command=None,
+            setup_state="complete",
         )
 
 
@@ -5097,6 +5100,44 @@ class TestTerminalController:
         msg = sock.send_json.call_args[0][0]
         assert msg == {"type": "terminal_started"}
         assert ctrl.session is None
+
+    # --- _setup_state_for_workspace: defensive fallbacks (#1033) ---
+
+    async def test_setup_state_db_error_defaults_to_complete(self):
+        """If the setup_state lookup raises, default to 'complete'."""
+        ctrl, _, _ = self._controller()
+        with patch.object(
+            _ws_controllers.model,
+            "get_workspace",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("db down"),
+        ):
+            result = await ctrl._setup_state_for_workspace()
+        assert result == "complete"
+
+    async def test_setup_state_workspace_missing_defaults_to_complete(self):
+        """If get_workspace returns None, default to 'complete'."""
+        ctrl, _, _ = self._controller()
+        with patch.object(
+            _ws_controllers.model,
+            "get_workspace",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
+            result = await ctrl._setup_state_for_workspace()
+        assert result == "complete"
+
+    async def test_setup_state_returns_workspace_value(self):
+        """Returns the workspace's actual setup_state when present (#1033)."""
+        ctrl, _, _ = self._controller()
+        with patch.object(
+            _ws_controllers.model,
+            "get_workspace",
+            new_callable=AsyncMock,
+            return_value={"setup_state": "pending"},
+        ):
+            result = await ctrl._setup_state_for_workspace()
+        assert result == "pending"
 
     async def test_start_rapid_debounce_skips(self):
         ctrl, sock, conn = self._controller()

--- a/src/cli/klangkc/client.py
+++ b/src/cli/klangkc/client.py
@@ -351,6 +351,7 @@ class KlangkClient:
         auto_start: bool = False,
         mounts: list[str] | None = None,
         env: dict[str, str] | None = None,
+        setup_state: str | None = None,
     ) -> Workspace:
         body: dict = {"name": name}
         if image:
@@ -363,6 +364,8 @@ class KlangkClient:
             body["mounts"] = mounts
         if env:
             body["env"] = env
+        if setup_state:
+            body["setup_state"] = setup_state
         resp = self.post("/api/v1/workspaces", json=body)
         self._check_auth(resp)
         self._raise_for_status(resp)
@@ -370,6 +373,20 @@ class KlangkClient:
         return Workspace(
             id=w["id"], name=w["name"], created_at=w["created_at"]
         )
+
+    def set_setup_state(self, workspace_id: str, setup_state: str) -> None:
+        """Update a workspace's setup_state lifecycle field (#1033).
+
+        Used by the sandbox driver to mark pending before running
+        setup.sh and complete/failed after it returns. Safe to call
+        from an async context via ``asyncio.to_thread``.
+        """
+        resp = self.put(
+            f"/api/v1/workspaces/{workspace_id}",
+            json={"setup_state": setup_state},
+        )
+        self._check_auth(resp)
+        self._raise_for_status(resp)
 
     def list_images(self) -> dict:
         resp = self.get("/api/v1/images")

--- a/src/cli/klangkc/main.py
+++ b/src/cli/klangkc/main.py
@@ -891,6 +891,9 @@ async def _sandbox_setup(ws, config, sandbox_root, handle):
 
     Called once after workspace creation, before the shell starts.
     The caller has already connected and called _wait_workspace_ready.
+
+    Returns the setup script's exit code, or ``None`` if no setup
+    command was configured (in which case there is nothing to fail).
     """
     # Copy files into container home.
     for host_path, container_dest in build_copy_pairs(
@@ -943,6 +946,8 @@ async def _sandbox_setup(ws, config, sandbox_root, handle):
             _err.print(f"[yellow]Setup timed out after {timeout}s[/yellow]")
         elif exit_code != 0:
             _err.print(f"[yellow]Setup exited with code {exit_code}[/yellow]")
+        return exit_code
+    return None
 
 
 @app.command()
@@ -1008,6 +1013,9 @@ def sandbox(
             default_command=config.default_command,
             auto_start=config.auto_start,
             mounts=all_mounts,
+            setup_state="pending"
+            if resolve_setup_command(config, handle)
+            else None,
         )
         _err.print(f"Workspace [bold]{workspace}[/bold] created.")
         created = True
@@ -1026,6 +1034,7 @@ def sandbox(
                     sandbox_root,
                     handle,
                     max_size=_ws_max_size(),
+                    client=client,
                 )
             )
         except websockets.InvalidStatus as e:  # pragma: no cover
@@ -1054,18 +1063,63 @@ async def _sandbox_setup_only(
     sandbox_root,
     handle,
     max_size=None,
+    client=None,
 ):
-    """Connect to workspace, run setup, then disconnect (no shell)."""
+    """Connect to workspace, run setup, then disconnect (no shell).
+
+    After setup.sh returns, marks the workspace's ``setup_state``
+    (#1033): ``complete`` on success (or when no setup command is
+    configured), ``failed`` otherwise. Only fires the default command
+    via ``terminal_start`` on success -- a failed setup must not
+    auto-run the default command (that is the failure-masquerade the
+    issue objects to). The state is marked BEFORE ``terminal_start``
+    is sent, so the server reads ``complete`` from the DB when it
+    decides whether to create the default-cmd window.
+    """
     kwargs = {}
     if max_size is not None:
         kwargs["max_size"] = max_size
     async with websockets.connect(f"{ws_url}?token={token}", **kwargs) as ws:
         await _wait_workspace_ready(ws, workspace_id)
-        await _sandbox_setup(ws, config, sandbox_root, handle)
+        # Re-enter 'pending' before running setup (#1033). On first
+        # create the workspace is already 'pending', but on --force
+        # re-setup it may be 'complete'/'failed'; either way this is
+        # idempotent and ensures a visitor during (re-)setup is blocked
+        # from firing the default command prematurely.
+        if client is not None:
+            try:
+                await asyncio.to_thread(
+                    client.set_setup_state, workspace_id, "pending"
+                )
+            except Exception as e:  # pragma: no cover
+                _err.print(
+                    f"[yellow]Warning: could not mark setup_state"
+                    f" = pending: {e}[/yellow]"
+                )
+        exit_code = await _sandbox_setup(ws, config, sandbox_root, handle)
+
+        # Mark setup_state before anything else (#1033). 'complete'
+        # when setup ran and returned 0, or when there was no setup
+        # command at all (nothing to fail); 'failed' otherwise.
+        setup_ok = exit_code is None or exit_code == 0
+        new_state = "complete" if setup_ok else "failed"
+        if client is not None:
+            try:
+                await asyncio.to_thread(
+                    client.set_setup_state, workspace_id, new_state
+                )
+            except Exception as e:  # pragma: no cover
+                _err.print(
+                    f"[yellow]Warning: could not mark setup_state"
+                    f" = {new_state}: {e}[/yellow]"
+                )
+
         # After setup, start a terminal so the default command runs
         # in a dedicated "default-cmd" tmux window (visible as a tab
-        # but not occupying the user's interactive window 0).
-        if config.default_command:
+        # but not occupying the user's interactive window 0). Skipped
+        # on setup failure -- the default command's prerequisites are
+        # not met.
+        if config.default_command and setup_ok:
             await ws.send(
                 json.dumps({"cmd": "terminal_start", "cols": 80, "rows": 24})
             )

--- a/src/cli/tests/test_cli.py
+++ b/src/cli/tests/test_cli.py
@@ -2065,6 +2065,31 @@ class TestCreateWorkspaceClient:
         body = mock_post.call_args.kwargs.get("json")
         assert body["auto_start"] is True
 
+    def test_create_workspace_with_setup_state(self):
+        """setup_state is forwarded in the create body (#1033)."""
+        client = KlangkClient("http://test:8995", "token")
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "id": "ws-state",
+            "name": "state-ws",
+            "created_at": "2025-01-01",
+        }
+        with patch.object(client, "post", return_value=mock_resp) as mock_post:
+            client.create_workspace("state-ws", setup_state="pending")
+        body = mock_post.call_args.kwargs.get("json")
+        assert body["setup_state"] == "pending"
+
+    def test_set_setup_state(self):
+        """set_setup_state PUTs the lifecycle field (#1033)."""
+        client = KlangkClient("http://test:8995", "token")
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        with patch.object(client, "put", return_value=mock_resp) as mock_put:
+            client.set_setup_state("ws-123", "complete")
+        assert mock_put.call_args.args[0] == "/api/v1/workspaces/ws-123"
+        assert mock_put.call_args.kwargs["json"] == {"setup_state": "complete"}
+
 
 class TestListImagesClient:
     def test_list_images(self):

--- a/src/cli/tests/test_cli_main.py
+++ b/src/cli/tests/test_cli_main.py
@@ -2870,6 +2870,7 @@ class TestSandboxSetupOnly:
                 return_value=mock_ws
             )
             mock_connect.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_setup.return_value = 0
             await _sandbox_setup_only(
                 "ws://test",
                 "token",
@@ -2909,6 +2910,7 @@ class TestSandboxSetupOnly:
                 return_value=mock_ws
             )
             mock_connect.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_setup.return_value = 0
             await _sandbox_setup_only(
                 "ws://test",
                 "token",
@@ -2948,12 +2950,13 @@ class TestSandboxSetupOnly:
 
         with (
             patch("klangkc.main.websockets.connect") as mock_connect,
-            patch("klangkc.main._sandbox_setup"),
+            patch("klangkc.main._sandbox_setup") as mock_setup,
         ):
             mock_connect.return_value.__aenter__ = AsyncMock(
                 return_value=mock_ws
             )
             mock_connect.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_setup.return_value = 0
             # Must not raise / hang waiting for terminal_started.
             await _sandbox_setup_only(
                 "ws://test",

--- a/src/cli/tests/test_cli_main.py
+++ b/src/cli/tests/test_cli_main.py
@@ -2967,8 +2967,95 @@ class TestSandboxSetupOnly:
                 "admin",
             )
 
+    async def test_marks_setup_state_pending_then_complete(self):
+        """With a client, _sandbox_setup_only marks pending then complete (#1033)."""
+        from pathlib import Path
 
-class TestSandboxSetup:
+        from klangkc.main import _sandbox_setup_only
+        from klangkc.sandbox import SandboxConfig
+
+        config = SandboxConfig(
+            setup="setup.sh", default_command="openclaw gateway"
+        )
+
+        mock_ws = AsyncMock()
+        mock_ws.recv = AsyncMock(
+            side_effect=[
+                json.dumps({"type": "workspace_ready"}),
+                json.dumps({"type": "terminal_started"}),
+            ]
+        )
+        mock_client = MagicMock()
+        mock_client.set_setup_state = MagicMock()
+
+        with (
+            patch("klangkc.main.websockets.connect") as mock_connect,
+            patch("klangkc.main._sandbox_setup") as mock_setup,
+        ):
+            mock_connect.return_value.__aenter__ = AsyncMock(
+                return_value=mock_ws
+            )
+            mock_connect.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_setup.return_value = 0
+            await _sandbox_setup_only(
+                "ws://test",
+                "token",
+                "ws-id",
+                config,
+                Path("/tmp"),
+                "admin",
+                client=mock_client,
+            )
+
+        # set_setup_state called twice: pending (before setup),
+        # complete (after setup returns 0).
+        calls = [c.args for c in mock_client.set_setup_state.call_args_list]
+        assert ("ws-id", "pending") in calls
+        assert ("ws-id", "complete") in calls
+
+    async def test_marks_setup_state_failed_on_setup_failure(self):
+        """A non-zero setup exit marks setup_state as 'failed' (#1033)."""
+        from pathlib import Path
+
+        from klangkc.main import _sandbox_setup_only
+        from klangkc.sandbox import SandboxConfig
+
+        config = SandboxConfig(
+            setup="setup.sh", default_command="openclaw gateway"
+        )
+
+        mock_ws = AsyncMock()
+        mock_ws.recv = AsyncMock(
+            return_value=json.dumps({"type": "workspace_ready"})
+        )
+        mock_client = MagicMock()
+        mock_client.set_setup_state = MagicMock()
+
+        with (
+            patch("klangkc.main.websockets.connect") as mock_connect,
+            patch("klangkc.main._sandbox_setup") as mock_setup,
+        ):
+            mock_connect.return_value.__aenter__ = AsyncMock(
+                return_value=mock_ws
+            )
+            mock_connect.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_setup.return_value = 1  # setup failed
+            await _sandbox_setup_only(
+                "ws://test",
+                "token",
+                "ws-id",
+                config,
+                Path("/tmp"),
+                "admin",
+                client=mock_client,
+            )
+
+        calls = [c.args for c in mock_client.set_setup_state.call_args_list]
+        assert ("ws-id", "failed") in calls
+        # terminal_start NOT sent on failure
+        sent = [json.loads(c.args[0]) for c in mock_ws.send.call_args_list]
+        assert not any(m.get("cmd") == "terminal_start" for m in sent)
+
     async def test_copies_files(self, tmp_path):
         from klangkc.main import _sandbox_setup
         from klangkc.sandbox import SandboxConfig


### PR DESCRIPTION
## Summary

Fixes #1033.

A web UI visit during sandbox setup caused `default_command` to fire prematurely, and because `_ensure_base_session` was create-once at **session** granularity, the later correctly-timed `terminal_start` became a no-op — the default command never ran. This was indistinguishable from a setup-script bug.

Two-part fix, per the [agreed design](https://github.com/mcdonc/klangk/issues/1033#issuecomment-4833962652):

### 1. Persistent `setup_state` field

New DB column (`NOT NULL DEFAULT 'complete'`, migration mirrors the existing `auto_start` one — no backfill). Three states, **descriptive not proscriptive** (a workspace is created in whichever state matches reality):

| state | who enters it | when |
|---|---|---|
| `pending` | `klangkc sandbox` only | between create and `setup.sh` returning |
| `complete` | API create / duplicate / import (immediately); sandbox (after setup) | creation or post-setup |
| `failed` | `klangkc sandbox` when `setup.sh` exits non-zero | setup returns non-zero |

- The controller reads `setup_state` **fresh from the DB** at `terminal_start` time (not cached on the connection) — the setup-owner caches `pending` at connect but needs `complete` read after setup finishes.
- `failed` is terminal: a failed setup does **not** auto-fire the default command (kills the failure-masquerade).

### 2. Window-granularity idempotency in `_ensure_base_session`

Split into:
- **base session + window 0**: created idempotently, always (a mid-setup visitor still gets a working interactive shell).
- **`default-cmd` window**: created only when the firing predicate holds, **even if the session already exists** (the core #1033 fix).

**Firing predicate:**
```
fire ⟺  default_command ≠ ∅
       ∧ setup_state == complete
       ∧ ¬ window_exists("default-cmd")
```

`running` is an **ephemeral observation** (the `default-cmd` window exists in this container), not a persisted state — it resets on container restart so the boot path re-fires for an already-`complete` workspace.

## Test coverage

- **Backend: 1931 tests pass at 100% coverage.** New unit tests cover:
  - `setup_state` validation (invalid values rejected), defaults, and transitions.
  - `_ensure_base_session`: the #1033 fix (fires even when session pre-exists), exactly-once (skips when window exists), `pending`/`failed` blocking, and the `_default_cmd_window_exists`/`_has_tmux_session` exception/rc branches.
  - `_setup_state_for_workspace` defensive fallbacks (DB error → `complete`, missing workspace → `complete`, happy path).
- **CLI unit tests pass** (`_sandbox_setup_only` marks state + only sends `terminal_start` on success).

The e2e test from #1040 (`test_visitor_terminal_start_mid_setup_has_openclaw_home`) already drives a visitor `terminal_start` mid-setup; it can be extended to assert the `default-cmd` window ends up running the command after setup completes even when a visitor fired early.

## Note on `run_default_command`

The `run_default_command` flag from #1032 is left in place — it's complementary, not redundant. Folding it into `setup_state` is a follow-up cleanup, not required for this fix.