### PR TITLE
feat(cli): automatic JWT refresh for klangkc

### DIFF
--- a/src/cli/e2e-tests/test_cli_e2e.py
+++ b/src/cli/e2e-tests/test_cli_e2e.py
@@ -14,6 +14,7 @@ import shutil
 import subprocess
 import tempfile
 import time
+from pathlib import Path
 
 import pytest
 
@@ -1996,3 +1997,161 @@ class TestWorkspaceSharing:
             ],
             env=env,
         )
+
+
+# --- Token refresh E2E ---
+
+
+@pytest.fixture(scope="module")
+def short_token_server():
+    """Start a server with very short token lifetime (~7 seconds)."""
+    data_dir = tempfile.mkdtemp(prefix="klangk-refresh-e2e-")
+    proc, base_url = _start_server(
+        data_dir,
+        "18997",
+        "cli-refresh-e2e",
+        extra_env={"KLANGK_ACCESS_TOKEN_HOURS": "0.002"},
+    )
+    yield {"url": base_url, "data_dir": data_dir, "proc": proc}
+    _stop_server(proc, data_dir, "cli-refresh-e2e")
+
+
+@pytest.fixture(scope="module")
+def short_token_cli_config(short_token_server, tmp_path_factory):
+    """Create a CLI config pointing at the short-token server."""
+    config_dir = tmp_path_factory.mktemp("klangk-refresh-config")
+    env = {**os.environ, "HOME": str(config_dir)}
+    klangk_config_dir = config_dir / ".config" / "klangk"
+    klangk_config_dir.mkdir(parents=True)
+    return {
+        "env": env,
+        "config_dir": klangk_config_dir,
+        "server_url": short_token_server["url"],
+    }
+
+
+def _read_state_token(home_dir, server_url):
+    """Read the stored token from state.yaml under *home_dir*."""
+    import yaml
+
+    state_path = home_dir / ".config" / "klangk" / "state.yaml"
+    if not state_path.exists():
+        return None
+    data = yaml.safe_load(state_path.read_text()) or {}
+    server = data.get(server_url, {})
+    active_user = server.get("active-user")
+    if not active_user:
+        return None
+    users = server.get("users", {})
+    return users.get(active_user, {}).get("token")
+
+
+class TestTokenRefresh:
+    """E2E tests for automatic JWT refresh.
+
+    Uses a dedicated server with ~7-second token lifetime.
+    """
+
+    def _login(self, cli_config):
+        result = _run(
+            [
+                "klangkc",
+                "login",
+                cli_config["server_url"],
+                "test@example.com",
+                "--password-file",
+                "-",
+            ],
+            input="testpass\n",
+            env=cli_config["env"],
+        )
+        assert result.returncode == 0, result.stderr
+        return result
+
+    def test_proactive_refresh_on_http(
+        self, short_token_server, short_token_cli_config
+    ):
+        """After token nears expiry, klangkc ls should refresh transparently."""
+        self._login(short_token_cli_config)
+        original_token = _read_state_token(
+            Path(short_token_cli_config["env"]["HOME"]),
+            short_token_cli_config["server_url"],
+        )
+        assert original_token is not None
+
+        # Wait for the token to be within the refresh margin.
+        # Token lifetime is 0.002 hours = 7.2 seconds.
+        # Refresh margin is 300 seconds, so the token is *already*
+        # within the refresh window from the moment it's issued.
+        # A simple ls should trigger proactive refresh.
+        result = _run(
+            ["klangkc", "ls"],
+            env=short_token_cli_config["env"],
+        )
+        assert result.returncode == 0, result.stderr
+
+        new_token = _read_state_token(
+            Path(short_token_cli_config["env"]["HOME"]),
+            short_token_cli_config["server_url"],
+        )
+        assert new_token is not None
+        assert new_token != original_token
+
+    def test_401_retry_refreshes_and_succeeds(
+        self, short_token_server, short_token_cli_config
+    ):
+        """After token expires, 401 retry should refresh and succeed."""
+        self._login(short_token_cli_config)
+        original_token = _read_state_token(
+            Path(short_token_cli_config["env"]["HOME"]),
+            short_token_cli_config["server_url"],
+        )
+
+        # Wait for the token to fully expire (7.2 seconds + buffer)
+        time.sleep(9)
+
+        result = _run(
+            ["klangkc", "ls"],
+            env=short_token_cli_config["env"],
+        )
+        # The proactive refresh should have gotten a new token before
+        # the request, so this should succeed. If the proactive refresh
+        # also fails (expired), then the 401 retry kicks in — but the
+        # backend refresh endpoint rejects expired tokens unless they
+        # were previously refreshed. In that case the command should
+        # fail with a clean error (no traceback).
+        if result.returncode == 0:
+            new_token = _read_state_token(
+                Path(short_token_cli_config["env"]["HOME"]),
+                short_token_cli_config["server_url"],
+            )
+            assert new_token != original_token
+        else:
+            # Clean error, no traceback
+            assert "Traceback" not in result.stderr
+            assert (
+                "Session expired" in result.stderr
+                or "login" in result.stderr.lower()
+            )
+
+    def test_token_persisted_after_refresh(
+        self, short_token_server, short_token_cli_config
+    ):
+        """After a successful refresh, state.yaml has the new token."""
+        self._login(short_token_cli_config)
+        original_token = _read_state_token(
+            Path(short_token_cli_config["env"]["HOME"]),
+            short_token_cli_config["server_url"],
+        )
+        # The short lifetime means proactive refresh fires immediately
+        result = _run(
+            ["klangkc", "ls"],
+            env=short_token_cli_config["env"],
+        )
+        assert result.returncode == 0, result.stderr
+        new_token = _read_state_token(
+            Path(short_token_cli_config["env"]["HOME"]),
+            short_token_cli_config["server_url"],
+        )
+        assert new_token is not None
+        assert new_token != original_token

--- a/src/cli/klangkc/auth.py
+++ b/src/cli/klangkc/auth.py
@@ -256,6 +256,39 @@ def login(
     _out.print(f"Logged in as [bold]{email}[/bold]")
 
 
+def refresh_token(server_url: str, token: str) -> str | None:
+    """Exchange *token* for a fresh one via the server's refresh endpoint.
+
+    On success the new token is persisted to state.yaml and returned.
+    Returns ``None`` on any failure (expired, revoked, network error).
+    """
+    try:
+        resp = httpx.post(
+            f"{server_url}/api/v1/auth/refresh",
+            headers={"Authorization": f"Bearer {token}"},
+            timeout=10.0,
+        )
+        if resp.status_code != 200:
+            return None
+        new_token = resp.json().get("access_token")
+        if not new_token:
+            return None
+        # Decode email from the new token so we can update state
+        try:
+            payload = new_token.split(".")[1]
+            payload += "=" * (4 - len(payload) % 4)
+            claims = json.loads(base64.urlsafe_b64decode(payload))
+            email = claims.get("email", "unknown")
+        except Exception:
+            email = "unknown"
+        state = CLIState.load()
+        state.set_credentials(server_url, email, new_token)
+        state.save()
+        return new_token
+    except httpx.HTTPError:
+        return None
+
+
 def logout(server_url: str) -> None:
     """Clear stored credentials for a server."""
     state = CLIState.load()

--- a/src/cli/klangkc/client.py
+++ b/src/cli/klangkc/client.py
@@ -24,6 +24,8 @@ import time as _time
 import httpx
 import websockets
 
+from .auth import refresh_token as _refresh_token
+
 
 _WS_MAX_SIZE = int(os.environ.get("KLANGK_WS_MSG_SIZE_MAX", 2**24))
 
@@ -163,56 +165,88 @@ def _get_terminal_size() -> tuple[int, int]:
     return 80, 24
 
 
+_REFRESH_MARGIN_SECONDS = 300  # refresh 5 minutes before expiry
+
+
+def _token_expires_soon(token: str) -> bool:
+    """Return True if *token* expires within ``_REFRESH_MARGIN_SECONDS``.
+
+    Decodes the JWT payload without verifying the signature (no secret
+    needed) and compares the ``exp`` claim against the current time.
+    Returns ``False`` on any decode failure so callers fall through to
+    the normal request path.
+    """
+    try:
+        payload = token.split(".")[1]
+        payload += "=" * (4 - len(payload) % 4)
+        claims = json.loads(base64.urlsafe_b64decode(payload))
+        exp = claims.get("exp")
+        if exp is None:
+            return False
+        return _time.time() >= (exp - _REFRESH_MARGIN_SECONDS)
+    except Exception:
+        return False
+
+
 class KlangkClient:
     def __init__(self, server_url: str, token: str | None = None):
         self.server_url = server_url
         self.token = token
+        self._refreshed = False  # guard against infinite retry loops
 
     # --- HTTP helpers ---
 
+    def _try_refresh(self) -> bool:
+        """Attempt to refresh the current token.
+
+        On success, updates ``self.token`` and returns ``True``.
+        """
+        if not self.token:
+            return False
+        new_token = _refresh_token(self.server_url, self.token)
+        if new_token:
+            self.token = new_token
+            return True
+        return False
+
     def _headers(self) -> dict[str, str]:
+        if self.token and _token_expires_soon(self.token):
+            self._try_refresh()
         token = self.token or ""
         return {"Authorization": f"Bearer {token}"}
 
-    def get(self, path: str, **kwargs) -> httpx.Response:
-        return _request_with_retry(
-            "GET",
+    def _request(self, method: str, path: str, **kwargs) -> httpx.Response:
+        resp = _request_with_retry(
+            method,
             f"{self.server_url}{path}",
             headers=self._headers(),
             **kwargs,
         )
+        if resp.status_code == 401 and not self._refreshed:
+            self._refreshed = True
+            if self._try_refresh():
+                resp = _request_with_retry(
+                    method,
+                    f"{self.server_url}{path}",
+                    headers=self._headers(),
+                    **kwargs,
+                )
+        return resp
+
+    def get(self, path: str, **kwargs) -> httpx.Response:
+        return self._request("GET", path, **kwargs)
 
     def post(self, path: str, **kwargs) -> httpx.Response:
-        return _request_with_retry(
-            "POST",
-            f"{self.server_url}{path}",
-            headers=self._headers(),
-            **kwargs,
-        )
+        return self._request("POST", path, **kwargs)
 
     def put(self, path: str, **kwargs) -> httpx.Response:
-        return _request_with_retry(
-            "PUT",
-            f"{self.server_url}{path}",
-            headers=self._headers(),
-            **kwargs,
-        )
+        return self._request("PUT", path, **kwargs)
 
     def patch(self, path: str, **kwargs) -> httpx.Response:
-        return _request_with_retry(
-            "PATCH",
-            f"{self.server_url}{path}",
-            headers=self._headers(),
-            **kwargs,
-        )
+        return self._request("PATCH", path, **kwargs)
 
     def delete(self, path: str, **kwargs) -> httpx.Response:
-        return _request_with_retry(
-            "DELETE",
-            f"{self.server_url}{path}",
-            headers=self._headers(),
-            **kwargs,
-        )
+        return self._request("DELETE", path, **kwargs)
 
     # --- REST API ---
 
@@ -902,12 +936,20 @@ async def _ws_shell(
         if raw_mode:
             old_settings = _raw_mode_enter()
             tty.setraw(sys.stdin)
+        # Derive the HTTP base URL from the WebSocket URL for token refresh.
+        _http_url = ws_url.replace("wss://", "https://").replace(
+            "ws://", "http://"
+        )
+        if _http_url.endswith("/ws"):
+            _http_url = _http_url[:-3]
         try:
             await _run_shell(
                 ws,
                 cols,
                 rows,
                 ssh_agent_sock=local_agent_sock if ssh_agent_active else None,
+                server_url=_http_url,
+                token=token,
             )
         finally:
             if raw_mode:
@@ -1020,6 +1062,8 @@ class _TerminalSession(_ShellSession):
         stdin: io.RawIOBase | None = None,
         stdout: io.TextIOBase | None = None,
         ssh_agent_sock: str | None = None,
+        server_url: str | None = None,
+        token: str | None = None,
     ):
         super().__init__(ws, ssh_agent_sock)
         self.stdin = stdin if stdin is not None else sys.stdin.buffer
@@ -1027,6 +1071,8 @@ class _TerminalSession(_ShellSession):
         self._cols = cols
         self._rows = rows
         self._loop = asyncio.get_event_loop()
+        self.server_url = server_url
+        self.token = token
 
     async def _send_resize(self) -> None:
         await self.ws.send(
@@ -1128,7 +1174,19 @@ class _TerminalSession(_ShellSession):
         except websockets.ConnectionClosed as exc:
             if not self.stop.is_set():
                 _code = exc.rcvd.code if exc.rcvd else None
-                if _code in (4001, 4002):
+                if _code == 4002 and self.token:
+                    new = _refresh_token(self.server_url, self.token)
+                    if new:
+                        self.stdout.write(
+                            "\r\nSession refreshed."
+                            " Run your command again to reconnect.\r\n"
+                        )
+                    else:
+                        self.stdout.write(
+                            "\r\nSession expired. Run `klangkc login`"
+                            " to re-authenticate.\r\n"
+                        )
+                elif _code in (4001, 4002):
                     self.stdout.write(
                         "\r\nSession expired. Run `klangkc login` to"
                         " re-authenticate.\r\n"
@@ -1317,6 +1375,8 @@ async def _run_shell(
     stdin: io.RawIOBase | None = None,
     stdout: io.TextIOBase | None = None,
     ssh_agent_sock: str | None = None,
+    server_url: str | None = None,
+    token: str | None = None,
 ) -> None:
     """Run stdin/stdout forwarding loop with SIGWINCH support."""
     session = _TerminalSession(
@@ -1326,6 +1386,8 @@ async def _run_shell(
         stdin=stdin,
         stdout=stdout,
         ssh_agent_sock=ssh_agent_sock,
+        server_url=server_url,
+        token=token,
     )
     await session.run()
 

--- a/src/cli/tests/test_cli.py
+++ b/src/cli/tests/test_cli.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+import websockets
 import io
 from io import BytesIO
 
@@ -27,7 +28,9 @@ from klangkc.client import (
     Workspace,
     WorkspaceNotFoundError,
     _request_with_retry,
+    _token_expires_soon,
 )
+from klangkc.auth import refresh_token
 
 
 # --- CLIConfig tests ---
@@ -1300,6 +1303,250 @@ class TestKlangkClient:
         client = KlangkClient("http://test:8995")
         headers = client._headers()
         assert headers["Authorization"] == "Bearer "
+
+
+# --- Token refresh ---
+
+
+def _make_jwt(exp: float, email: str = "test@example.com") -> str:
+    """Build a fake JWT with the given exp timestamp (no real signature)."""
+    import base64
+
+    header = base64.urlsafe_b64encode(b'{"alg":"HS256"}').rstrip(b"=")
+    payload = base64.urlsafe_b64encode(
+        json.dumps({"sub": "u1", "email": email, "exp": exp}).encode()
+    ).rstrip(b"=")
+    return f"{header.decode()}.{payload.decode()}.fakesig"
+
+
+class TestTokenExpiresSoon:
+    def test_returns_true_when_expiring_soon(self):
+        import time
+
+        token = _make_jwt(time.time() + 60)  # expires in 60s
+        assert _token_expires_soon(token) is True
+
+    def test_returns_false_when_not_expiring_soon(self):
+        import time
+
+        token = _make_jwt(time.time() + 600)  # expires in 10 min
+        assert _token_expires_soon(token) is False
+
+    def test_returns_false_for_invalid_token(self):
+        assert _token_expires_soon("not-a-jwt") is False
+
+    def test_returns_false_for_empty_token(self):
+        assert _token_expires_soon("") is False
+
+    def test_returns_false_when_no_exp(self):
+        import base64
+
+        header = base64.urlsafe_b64encode(b'{"alg":"HS256"}').rstrip(b"=")
+        payload = base64.urlsafe_b64encode(
+            b'{"sub":"u1","email":"a@b.com"}'
+        ).rstrip(b"=")
+        token = f"{header.decode()}.{payload.decode()}.sig"
+        assert _token_expires_soon(token) is False
+
+
+class TestRefreshToken:
+    def test_returns_new_token_on_success(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("klangkc.config._STATE_PATH", tmp_path / "s.yaml")
+        new_jwt = _make_jwt(9999999999.0, email="me@test.com")
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"access_token": new_jwt}
+        with patch("klangkc.auth.httpx.post", return_value=mock_resp):
+            result = refresh_token("http://srv", "old-token")
+        assert result == new_jwt
+        # Verify state was persisted
+        state = CLIState.load()
+        assert state.get_token("http://srv") == new_jwt
+
+    def test_returns_none_on_401(self):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 401
+        with patch("klangkc.auth.httpx.post", return_value=mock_resp):
+            assert refresh_token("http://srv", "old-token") is None
+
+    def test_returns_none_on_network_error(self):
+        with patch(
+            "klangkc.auth.httpx.post", side_effect=httpx.ConnectError("")
+        ):
+            assert refresh_token("http://srv", "old-token") is None
+
+    def test_returns_none_when_no_access_token_in_response(self):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {}
+        with patch("klangkc.auth.httpx.post", return_value=mock_resp):
+            assert refresh_token("http://srv", "old-token") is None
+
+    def test_handles_unparseable_jwt_email(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("klangkc.config._STATE_PATH", tmp_path / "s.yaml")
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        # A token whose payload is not valid base64/JSON
+        mock_resp.json.return_value = {"access_token": "a.!!!.c"}
+        with patch("klangkc.auth.httpx.post", return_value=mock_resp):
+            result = refresh_token("http://srv", "old-token")
+        assert result == "a.!!!.c"
+        state = CLIState.load()
+        assert state.get_token("http://srv") == "a.!!!.c"
+
+
+class TestClientTryRefresh:
+    def test_try_refresh_updates_token(self):
+        client = KlangkClient("http://test:8995", "old-token")
+        with patch("klangkc.client._refresh_token", return_value="new-token"):
+            assert client._try_refresh() is True
+        assert client.token == "new-token"
+
+    def test_try_refresh_returns_false_on_failure(self):
+        client = KlangkClient("http://test:8995", "old-token")
+        with patch("klangkc.client._refresh_token", return_value=None):
+            assert client._try_refresh() is False
+        assert client.token == "old-token"
+
+    def test_try_refresh_returns_false_without_token(self):
+        client = KlangkClient("http://test:8995")
+        assert client._try_refresh() is False
+
+
+class TestClientRetryOn401:
+    def test_retries_once_on_401_then_succeeds(self):
+        client = KlangkClient("http://test:8995", "old-token")
+        resp_401 = MagicMock()
+        resp_401.status_code = 401
+        resp_200 = MagicMock()
+        resp_200.status_code = 200
+        with (
+            patch(
+                "klangkc.client._request_with_retry",
+                side_effect=[resp_401, resp_200],
+            ),
+            patch("klangkc.client._refresh_token", return_value="new-token"),
+        ):
+            result = client.get("/api/v1/workspaces")
+        assert result.status_code == 200
+        assert client.token == "new-token"
+
+    def test_no_retry_when_refresh_fails(self):
+        client = KlangkClient("http://test:8995", "old-token")
+        resp_401 = MagicMock()
+        resp_401.status_code = 401
+        with (
+            patch(
+                "klangkc.client._request_with_retry",
+                return_value=resp_401,
+            ),
+            patch("klangkc.client._refresh_token", return_value=None),
+        ):
+            result = client.get("/api/v1/workspaces")
+        assert result.status_code == 401
+
+    def test_no_infinite_retry_loop(self):
+        client = KlangkClient("http://test:8995", "old-token")
+        resp_401 = MagicMock()
+        resp_401.status_code = 401
+        call_count = 0
+
+        def counting_refresh(server_url, token):
+            nonlocal call_count
+            call_count += 1
+            return "refreshed-token"
+
+        with (
+            patch(
+                "klangkc.client._request_with_retry",
+                return_value=resp_401,
+            ),
+            patch(
+                "klangkc.client._refresh_token",
+                side_effect=counting_refresh,
+            ),
+        ):
+            result = client.get("/api/v1/workspaces")
+        assert result.status_code == 401
+        assert call_count == 1  # refresh called only once
+
+    def test_proactive_refresh_in_headers(self):
+        import time
+
+        token = _make_jwt(time.time() + 60)  # expiring soon
+        client = KlangkClient("http://test:8995", token)
+        with patch("klangkc.client._refresh_token", return_value="refreshed"):
+            headers = client._headers()
+        assert headers["Authorization"] == "Bearer refreshed"
+        assert client.token == "refreshed"
+
+
+class TestWs4002Refresh:
+    @pytest.mark.asyncio
+    async def test_ws_4002_refresh_success(self):
+        from klangkc.client import _TerminalSession
+
+        ws = AsyncMock()
+        close_frame = MagicMock()
+        close_frame.code = 4002
+        ws.recv = AsyncMock(
+            side_effect=websockets.ConnectionClosed(close_frame, None)
+        )
+
+        captured = []
+
+        class CaptureWriter:
+            def write(self, data):
+                captured.append(data)
+
+            def flush(self):
+                pass
+
+        session = _TerminalSession(
+            ws,
+            80,
+            24,
+            stdout=CaptureWriter(),
+            server_url="http://test:8995",
+            token="old-token",
+        )
+        with patch("klangkc.client._refresh_token", return_value="new-token"):
+            await session.stdout_loop()
+        output = "".join(captured)
+        assert "Session refreshed" in output
+
+    @pytest.mark.asyncio
+    async def test_ws_4002_refresh_failure(self):
+        from klangkc.client import _TerminalSession
+
+        ws = AsyncMock()
+        close_frame = MagicMock()
+        close_frame.code = 4002
+        ws.recv = AsyncMock(
+            side_effect=websockets.ConnectionClosed(close_frame, None)
+        )
+
+        captured = []
+
+        class CaptureWriter:
+            def write(self, data):
+                captured.append(data)
+
+            def flush(self):
+                pass
+
+        session = _TerminalSession(
+            ws,
+            80,
+            24,
+            stdout=CaptureWriter(),
+            server_url="http://test:8995",
+            token="old-token",
+        )
+        with patch("klangkc.client._refresh_token", return_value=None):
+            await session.stdout_loop()
+        output = "".join(captured)
+        assert "Session expired" in output
 
 
 # --- Shell protocol ---


### PR DESCRIPTION
## Summary

Closes #758

- Add `refresh_token()` in `auth.py` that calls `POST /api/v1/auth/refresh`, persists the new token to state.yaml
- Proactively refresh tokens in `KlangkClient._headers()` when within 5 minutes of expiry
- Retry HTTP requests once on 401 after refreshing (centralized in `_request()`)
- Attempt refresh on WebSocket 4002 close code before showing "Session expired"
- Unit tests for token expiry detection, refresh, 401 retry, and infinite loop guard
- E2E tests with a short-lived token server (~7s lifetime) verifying transparent refresh

## Test plan

- [x] All 143 CLI unit tests pass
- [x] All 91 backend auth tests pass
- [ ] E2E `TestTokenRefresh` tests (require running server with podman)