### PR TITLE
chore: remove claude-code from default plugins list

### DIFF
--- a/docs/features/container-packages.md
+++ b/docs/features/container-packages.md
@@ -62,8 +62,9 @@ so common development tasks work out of the box.
 
 - **Pi** (`@earendil-works/pi-coding-agent`) — terminal-based coding
   agent; see [AI Coding Harnesses](ai-coding-harnesses.md)
-- **Claude Code** (`@anthropic-ai/claude-code`) — installed via the
-  `claude-code` plugin (included in default plugins.yaml)
+- **Claude Code** (`@anthropic-ai/claude-code`) — available via the
+  `claude-code` plugin (not included by default; add it to your
+  `plugins.yaml` to enable)
 - **Herdr** — terminal agent runtime for persistent sessions and pane
   management
 

--- a/docs/features/plugins.md
+++ b/docs/features/plugins.md
@@ -67,7 +67,6 @@ These plugins are included in the default `plugins.yaml`:
 
 | Plugin           | What it does                                              |
 | ---------------- | --------------------------------------------------------- |
-| `claude-code`    | Installs Claude Code CLI agent at image build time        |
 | `git-credential` | Git credential helper with browser-based PAT/OAuth dialog |
 | `word-count`     | File stats tool for Pi (lines, words, characters, size)   |
 | `pig-latin`      | Text-to-Pig-Latin converter for Pi                        |
@@ -75,3 +74,14 @@ These plugins are included in the default `plugins.yaml`:
 | `beep`           | Plays an audible beep via Web Audio API                   |
 | `browser-fetch`  | HTTP fetch using browser session cookies via Pi           |
 | `boingball`      | Bouncing Boing Ball animation overlay via Pi              |
+
+## Additional plugins
+
+These plugins ship with klangk but are **not** included in the default
+`plugins.yaml`. Add them manually to enable:
+
+| Plugin        | What it does                                           |
+| ------------- | ------------------------------------------------------ |
+| `claude-code` | Installs Claude Code CLI agent at image build time     |
+| `bobdobbs`    | Bob Dobbs overlay via Pi                               |
+| `hermes`      | Hermes agent — NousResearch's terminal-based assistant |

--- a/scripts/update_plugins.py
+++ b/scripts/update_plugins.py
@@ -36,7 +36,6 @@ _DEFAULT_PLUGINS = [
     "browser-fetch",
     "boingball",
     "git-credential",
-    "claude-code",
 ]
 
 


### PR DESCRIPTION
## Summary

Closes #809

- Remove `claude-code` from `_DEFAULT_PLUGINS` in `scripts/update_plugins.py`
- Remove `claude-code` row from the default plugins table in `docs/features/plugins.md`
- Add "Additional plugins" section listing `claude-code`, `bobdobbs`, and `hermes` as opt-in
- Update `docs/features/container-packages.md` to clarify claude-code is not included by default

## Test plan

- [ ] Verify `update-plugins` generates a `plugins.yaml` without `claude-code`
- [ ] Verify docs render correctly