### PR TITLE
refactor(frontend): break up oversized build() methods

### DIFF
--- a/src/frontend/lib/admin/admin_users_page.dart
+++ b/src/frontend/lib/admin/admin_users_page.dart
@@ -958,105 +958,101 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
     return types;
   }
 
-  @override
-  Widget build(BuildContext context) {
-    // Re-resolve on each build: AuthService loads permissions asynchronously,
-    // so the first build (before they arrive) would otherwise show no tabs.
-    _resolvePermissions();
+  (List<SkeuoTab>, List<Widget>) _buildTabsAndViews() {
     final pendingCount = _invitationsPending;
     final tabs = <SkeuoTab>[];
     final views = <Widget>[];
     final tabTypes = _tabTypes;
 
-    if (_canUsers) {
+    void addTab({
+      required String label,
+      required IconData icon,
+      required Widget view,
+      int? badge,
+    }) {
       final idx = tabs.length;
       tabs.add(
         SkeuoTab(
-          label: 'Users',
-          icon: Icons.people,
+          label: label,
+          icon: icon,
           isSelected: _selectedIndex == idx,
+          badge: badge,
           onTap: () => setState(() => _selectedIndex = idx),
         ),
       );
-      views.add(_buildUsersTab());
-    }
-    if (_canGroups) {
-      final idx = tabs.length;
-      tabs.add(
-        SkeuoTab(
-          label: 'Groups',
-          icon: Icons.group,
-          isSelected: _selectedIndex == idx,
-          onTap: () => setState(() => _selectedIndex = idx),
-        ),
-      );
-      views.add(_buildGroupsTab());
-    }
-    if (_canInvitations) {
-      final idx = tabs.length;
-      tabs.add(
-        SkeuoTab(
-          label: 'Invitations',
-          icon: Icons.mail_outline,
-          isSelected: _selectedIndex == idx,
-          badge: pendingCount > 0 ? pendingCount : null,
-          onTap: () => setState(() => _selectedIndex = idx),
-        ),
-      );
-      views.add(_buildInvitationsTab());
+      views.add(view);
     }
 
-    // ACL tab — always visible for admins
-    if (tabTypes.isNotEmpty) {
-      final idx = tabs.length;
-      tabs.add(
-        SkeuoTab(
-          label: 'Access Control',
-          icon: Icons.security,
-          isSelected: _selectedIndex == idx,
-          onTap: () => setState(() => _selectedIndex = idx),
-        ),
+    if (_canUsers) {
+      addTab(label: 'Users', icon: Icons.people, view: _buildUsersTab());
+    }
+    if (_canGroups) {
+      addTab(label: 'Groups', icon: Icons.group, view: _buildGroupsTab());
+    }
+    if (_canInvitations) {
+      addTab(
+        label: 'Invitations',
+        icon: Icons.mail_outline,
+        badge: pendingCount > 0 ? pendingCount : null,
+        view: _buildInvitationsTab(),
       );
-      views.add(const _AclBrowserTab());
+    }
+    if (tabTypes.isNotEmpty) {
+      addTab(
+        label: 'Access Control',
+        icon: Icons.security,
+        view: const _AclBrowserTab(),
+      );
     }
 
     if (tabs.isEmpty) {
       views.add(const Center(child: Text('No admin sections available')));
     }
 
-    Widget? fab;
+    return (tabs, views);
+  }
+
+  Widget? _buildFab() {
+    final tabTypes = _tabTypes;
     final currentType = tabTypes.isNotEmpty && _selectedIndex < tabTypes.length
         ? tabTypes[_selectedIndex]
         : '';
-    if (currentType == 'users') {
-      fab = FloatingActionButton(
-        heroTag: 'add',
-        onPressed: _addUser,
-        tooltip: 'Add user',
-        child: const Icon(Icons.person_add),
-      );
-    } else if (currentType == 'invitations') {
-      fab = FloatingActionButton(
-        heroTag: 'invite',
-        onPressed: _inviteUser,
-        tooltip: 'Invite user',
-        child: const Icon(Icons.mail_outline),
-      );
-    } else if (currentType == 'groups') {
-      fab = FloatingActionButton(
-        heroTag: 'add-group',
-        onPressed: _createGroup,
-        tooltip: 'Create group',
-        child: const Icon(Icons.group_add),
-      );
-    }
+    return switch (currentType) {
+      'users' => FloatingActionButton(
+          heroTag: 'add',
+          onPressed: _addUser,
+          tooltip: 'Add user',
+          child: const Icon(Icons.person_add),
+        ),
+      'invitations' => FloatingActionButton(
+          heroTag: 'invite',
+          onPressed: _inviteUser,
+          tooltip: 'Invite user',
+          child: const Icon(Icons.mail_outline),
+        ),
+      'groups' => FloatingActionButton(
+          heroTag: 'add-group',
+          onPressed: _createGroup,
+          tooltip: 'Create group',
+          child: const Icon(Icons.group_add),
+        ),
+      _ => null,
+    };
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Re-resolve on each build: AuthService loads permissions asynchronously,
+    // so the first build (before they arrive) would otherwise show no tabs.
+    _resolvePermissions();
+    final (tabs, views) = _buildTabsAndViews();
 
     return Scaffold(
       appBar: AppBar(
         title: const AppBarTitle(title: 'Admin'),
         actions: const [AppBarActions()],
       ),
-      floatingActionButton: fab,
+      floatingActionButton: _buildFab(),
       body: Column(
         children: [
           if (tabs.isNotEmpty)

--- a/src/frontend/lib/widgets/acl_editor.dart
+++ b/src/frontend/lib/widgets/acl_editor.dart
@@ -343,6 +343,145 @@ class AclEditorState extends State<AclEditor> {
     });
   }
 
+  Widget _buildHeader() {
+    return Row(
+      children: [
+        const Text('Access Control Entries',
+            style: TextStyle(fontWeight: FontWeight.bold, fontSize: 13)),
+        const Spacer(),
+        TextButton.icon(
+          onPressed: _addEntry,
+          icon: const Icon(Icons.add, size: 16),
+          label: const Text('Add'),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildMessage() {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 8),
+      child: Text(
+        _message!,
+        style: TextStyle(
+          color: _message!.startsWith('Failed')
+              ? KColors.accentRed
+              : KColors.accentGreen,
+          fontSize: 12,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildEntryRow(int i) {
+    final entry = _entries[i];
+    final action = entry['action'] as int;
+    final principal = entry['principal'] as String? ?? '?';
+    final permission = entry['permission'] as String;
+
+    return ReorderableDragStartListener(
+      key: ValueKey('ace-$i-${entry['id'] ?? i}'),
+      index: i,
+      child: Card(
+        margin: const EdgeInsets.only(bottom: 2),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+          child: Row(
+            children: [
+              const Icon(Icons.drag_handle, size: 18, color: KColors.textMuted),
+              const SizedBox(width: 4),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                decoration: BoxDecoration(
+                  color: action == 1
+                      ? KColors.accentGreen.withValues(alpha: 0.2)
+                      : KColors.accentRed.withValues(alpha: 0.2),
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                child: Text(
+                  action == 1 ? 'Allow' : 'Deny',
+                  style: TextStyle(
+                    fontSize: 11,
+                    fontWeight: FontWeight.bold,
+                    color:
+                        action == 1 ? KColors.accentGreen : KColors.accentRed,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(principal, style: const TextStyle(fontSize: 12)),
+              ),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                decoration: BoxDecoration(
+                  color: KColors.bgCanvas,
+                  borderRadius: BorderRadius.circular(4),
+                  border: Border.all(color: KColors.borderDefault),
+                ),
+                child: Text(permission, style: const TextStyle(fontSize: 11)),
+              ),
+              const SizedBox(width: 4),
+              InkWell(
+                onTap: () => _removeEntry(i),
+                child:
+                    const Icon(Icons.close, size: 16, color: KColors.textMuted),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildEntryList() {
+    if (_entries.isEmpty) {
+      return const Padding(
+        padding: EdgeInsets.symmetric(vertical: 8),
+        child: Text('No ACL entries',
+            style: TextStyle(color: KColors.textSecondary, fontSize: 12)),
+      );
+    }
+    return ReorderableListView.builder(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      itemCount: _entries.length,
+      onReorder: (oldIndex, newIndex) {
+        setState(() {
+          if (newIndex > oldIndex) newIndex--;
+          final item = _entries.removeAt(oldIndex);
+          _entries.insert(newIndex, item);
+        });
+      },
+      buildDefaultDragHandles: false,
+      itemBuilder: (context, i) => _buildEntryRow(i),
+    );
+  }
+
+  Widget _buildDirtyFooter() {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.end,
+      children: [
+        TextButton(
+          onPressed: _discard,
+          child: const Text('Discard'),
+        ),
+        const SizedBox(width: 8),
+        FilledButton.icon(
+          onPressed: _saving ? null : _save,
+          icon: _saving
+              ? const SizedBox(
+                  width: 14,
+                  height: 14,
+                  child: CircularProgressIndicator(
+                      strokeWidth: 2, color: Colors.white))
+              : const Icon(Icons.save, size: 16),
+          label: const Text('Save ACL'),
+        ),
+      ],
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     if (_loading) {
@@ -352,145 +491,12 @@ class AclEditorState extends State<AclEditor> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Row(
-          children: [
-            const Text('Access Control Entries',
-                style: TextStyle(fontWeight: FontWeight.bold, fontSize: 13)),
-            const Spacer(),
-            TextButton.icon(
-              onPressed: _addEntry,
-              icon: const Icon(Icons.add, size: 16),
-              label: const Text('Add'),
-            ),
-          ],
-        ),
-        if (_message != null)
-          Padding(
-            padding: const EdgeInsets.only(bottom: 8),
-            child: Text(
-              _message!,
-              style: TextStyle(
-                color: _message!.startsWith('Failed')
-                    ? KColors.accentRed
-                    : KColors.accentGreen,
-                fontSize: 12,
-              ),
-            ),
-          ),
-        if (_entries.isEmpty)
-          const Padding(
-            padding: EdgeInsets.symmetric(vertical: 8),
-            child: Text('No ACL entries',
-                style: TextStyle(color: KColors.textSecondary, fontSize: 12)),
-          )
-        else
-          ReorderableListView.builder(
-            shrinkWrap: true,
-            physics: const NeverScrollableScrollPhysics(),
-            itemCount: _entries.length,
-            onReorder: (oldIndex, newIndex) {
-              setState(() {
-                if (newIndex > oldIndex) newIndex--;
-                final item = _entries.removeAt(oldIndex);
-                _entries.insert(newIndex, item);
-              });
-            },
-            buildDefaultDragHandles: false,
-            itemBuilder: (context, i) {
-              final entry = _entries[i];
-              final action = entry['action'] as int;
-              final principal = entry['principal'] as String? ?? '?';
-              final permission = entry['permission'] as String;
-
-              return ReorderableDragStartListener(
-                key: ValueKey('ace-$i-${entry['id'] ?? i}'),
-                index: i,
-                child: Card(
-                  margin: const EdgeInsets.only(bottom: 2),
-                  child: Padding(
-                    padding:
-                        const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-                    child: Row(
-                      children: [
-                        const Icon(Icons.drag_handle,
-                            size: 18, color: KColors.textMuted),
-                        const SizedBox(width: 4),
-                        // Allow/Deny badge
-                        Container(
-                          padding: const EdgeInsets.symmetric(
-                              horizontal: 6, vertical: 2),
-                          decoration: BoxDecoration(
-                            color: action == 1
-                                ? KColors.accentGreen.withValues(alpha: 0.2)
-                                : KColors.accentRed.withValues(alpha: 0.2),
-                            borderRadius: BorderRadius.circular(4),
-                          ),
-                          child: Text(
-                            action == 1 ? 'Allow' : 'Deny',
-                            style: TextStyle(
-                              fontSize: 11,
-                              fontWeight: FontWeight.bold,
-                              color: action == 1
-                                  ? KColors.accentGreen
-                                  : KColors.accentRed,
-                            ),
-                          ),
-                        ),
-                        const SizedBox(width: 8),
-                        // Principal
-                        Expanded(
-                          child: Text(principal,
-                              style: const TextStyle(fontSize: 12)),
-                        ),
-                        // Permission
-                        Container(
-                          padding: const EdgeInsets.symmetric(
-                              horizontal: 6, vertical: 2),
-                          decoration: BoxDecoration(
-                            color: KColors.bgCanvas,
-                            borderRadius: BorderRadius.circular(4),
-                            border: Border.all(color: KColors.borderDefault),
-                          ),
-                          child: Text(permission,
-                              style: const TextStyle(fontSize: 11)),
-                        ),
-                        const SizedBox(width: 4),
-                        // Remove
-                        InkWell(
-                          onTap: () => _removeEntry(i),
-                          child: const Icon(Icons.close,
-                              size: 16, color: KColors.textMuted),
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              );
-            },
-          ),
+        _buildHeader(),
+        if (_message != null) _buildMessage(),
+        _buildEntryList(),
         if (_dirty) ...[
           const SizedBox(height: 8),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.end,
-            children: [
-              TextButton(
-                onPressed: _discard,
-                child: const Text('Discard'),
-              ),
-              const SizedBox(width: 8),
-              FilledButton.icon(
-                onPressed: _saving ? null : _save,
-                icon: _saving
-                    ? const SizedBox(
-                        width: 14,
-                        height: 14,
-                        child: CircularProgressIndicator(
-                            strokeWidth: 2, color: Colors.white))
-                    : const Icon(Icons.save, size: 16),
-                label: const Text('Save ACL'),
-              ),
-            ],
-          ),
+          _buildDirtyFooter(),
         ],
       ],
     );


### PR DESCRIPTION
## Summary

Closes #976

Of the 6 files listed in the issue, 4 were already refactored in prior work. This PR addresses the remaining 2:

- **AclEditor** (`acl_editor.dart`): 151-line `build()` → 15 lines, extracting `_buildHeader()`, `_buildMessage()`, `_buildEntryRow()`, `_buildEntryList()`, `_buildDirtyFooter()`
- **AdminUsersPage** (`admin_users_page.dart`): 119-line `build()` → 25 lines, extracting `_buildTabsAndViews()` (with local `addTab` helper) and `_buildFab()` (using Dart 3 switch expression)

## Test plan

- [x] All frontend unit tests pass with 100% coverage
- [x] `flutter analyze` passes (via build)
- [x] `dart format` passes