### PR TITLE
refactor(backend): decompose import_workspace and oidc_callback

### DIFF
--- a/src/backend/klangk_backend/api/oidc_auth.py
+++ b/src/backend/klangk_backend/api/oidc_auth.py
@@ -99,26 +99,10 @@ async def oidc_login(
     return response
 
 
-@router.get("/auth/oidc/{provider_id}/callback")
-async def oidc_callback(
-    provider_id: str,
-    request: Request,
-    code: str = "",
-    state: str = "",
-    error: str | None = None,
-):
-    """Handle the OIDC callback from the IdP."""
-    if error:
-        logger.warning(
-            "OIDC IdP error for provider %s: %s", provider_id, error
-        )
-        raise HTTPException(status_code=400, detail="Login failed")
-
-    provider = oidc.get_provider(provider_id)
-    if provider is None:
-        raise HTTPException(status_code=404, detail="Unknown OIDC provider")
-
-    # Retrieve and validate state from cookie
+def _validate_state_cookie(
+    request: Request, provider_id: str, state: str
+) -> dict:
+    """Parse and validate the OIDC state cookie, returning its data."""
     cookie_name = f"oidc_{provider_id}"
     cookie_raw = request.cookies.get(cookie_name)
     if not cookie_raw:
@@ -136,7 +120,15 @@ async def oidc_callback(
     if cookie_data.get("state") != state:
         raise HTTPException(status_code=400, detail="State mismatch")
 
-    # Exchange code for tokens
+    return cookie_data
+
+
+async def _exchange_and_validate_token(provider, code, cookie_data):
+    """Exchange the authorization code for tokens and validate the ID token.
+
+    Returns ``(claims, tokens)`` where *claims* contains at least ``sub``
+    and ``email``.
+    """
     try:
         tokens = await oidc.exchange_code(
             provider,
@@ -150,7 +142,6 @@ async def oidc_callback(
             status_code=502, detail="Token exchange failed"
         ) from None
 
-    # Validate ID token
     id_token = tokens.get("id_token")
     if not id_token:
         raise HTTPException(status_code=502, detail="No ID token in response")
@@ -172,12 +163,84 @@ async def oidc_callback(
             status_code=502,
             detail="ID token missing sub or email claim",
         )
+
+    return claims, tokens
+
+
+async def _find_or_create_user(provider_id, sub, email):
+    """Locate an existing user by OIDC identity or create one via JIT provisioning."""
+    user = await model.get_user_by_external_id(provider_id, sub)
+    if user is not None:
+        return user
+
+    existing = await model.get_user_by_email(email)
+    if existing is not None:
+        await model.link_oidc_identity(existing["id"], provider_id, sub)
+        return existing
+
+    return await model.create_user(
+        email=email,
+        password_hash=None,
+        verified=True,
+        provider=provider_id,
+        external_id=sub,
+    )
+
+
+def _build_redirect_response(
+    request: Request,
+    provider_id: str,
+    access_token: str,
+    cookie_data: dict,
+) -> RedirectResponse:
+    """Build the final redirect response (CLI or web flow)."""
+    cli_redirect = cookie_data.get("cli_redirect")
+
+    if _valid_cli_redirect(cli_redirect):
+        redirect_url = f"{cli_redirect}?token={access_token}"
+    else:
+        hostname, proto, base_path = derive_hosting_info(
+            request.headers, request.client.host if request.client else None
+        )
+        redirect_url = (
+            f"{proto}://{hostname}{base_path}"
+            f"/#/oidc-complete?token={access_token}"
+        )
+
+    cookie_name = f"oidc_{provider_id}"
+    response = RedirectResponse(url=redirect_url, status_code=302)
+    response.delete_cookie(cookie_name, path="/")
+    return response
+
+
+@router.get("/auth/oidc/{provider_id}/callback")
+async def oidc_callback(
+    provider_id: str,
+    request: Request,
+    code: str = "",
+    state: str = "",
+    error: str | None = None,
+):
+    """Handle the OIDC callback from the IdP."""
+    if error:
+        logger.warning(
+            "OIDC IdP error for provider %s: %s", provider_id, error
+        )
+        raise HTTPException(status_code=400, detail="Login failed")
+
+    provider = oidc.get_provider(provider_id)
+    if provider is None:
+        raise HTTPException(status_code=404, detail="Unknown OIDC provider")
+
+    cookie_data = _validate_state_cookie(request, provider_id, state)
+    claims, tokens = await _exchange_and_validate_token(
+        provider, code, cookie_data
+    )
+
+    email = claims["email"]
     auth.validate_email(email)
 
-    # Call the OIDC login hook (if configured). The hook can:
-    # - raise an exception to reject the login (HTTP 403)
-    # - return None to allow the login without group sync
-    # - return a set of group names to allow login and sync groups
+    # Call the OIDC login hook (if configured).
     try:
         hook_groups = await oidc.call_login_hook(
             provider, claims, email, tokens
@@ -189,55 +252,15 @@ async def oidc_callback(
             detail="Login denied by server policy",
         ) from None
 
-    # Find or create user
-    user = await model.get_user_by_external_id(provider_id, sub)
-    if user is None:
-        # Check for existing local user with same email
-        existing = await model.get_user_by_email(email)
-        if existing is not None:
-            # Link OIDC identity to existing user
-            await model.link_oidc_identity(existing["id"], provider_id, sub)
-            user = existing
-        else:
-            # JIT provisioning
-            user = await model.create_user(
-                email=email,
-                password_hash=None,
-                verified=True,
-                provider=provider_id,
-                external_id=sub,
-            )
+    user = await _find_or_create_user(provider_id, claims["sub"], email)
 
-    # Sync group memberships if the hook returned group names
     if hook_groups is not None:
         await oidc.sync_oidc_groups(user["id"], hook_groups)
 
-    # Issue Klangk JWT
     access_token = auth.create_token(user["id"], email)
-
-    # Clear the state cookie
-    cli_redirect = cookie_data.get("cli_redirect")
-
-    if _valid_cli_redirect(cli_redirect):
-        # CLI flow: redirect to the CLI's localhost server with the token.
-        # Re-validate here because the state cookie is unsigned and
-        # client-controlled — a tampered cli_redirect must not leak the
-        # access token to an arbitrary host (#936).
-        redirect_url = f"{cli_redirect}?token={access_token}"
-    else:
-        # Web flow (also the safe fallback when the cookie's
-        # cli_redirect was missing or tampered to a non-localhost host).
-        hostname, proto, base_path = derive_hosting_info(
-            request.headers, request.client.host if request.client else None
-        )
-        redirect_url = (
-            f"{proto}://{hostname}{base_path}"
-            f"/#/oidc-complete?token={access_token}"
-        )
-
-    response = RedirectResponse(url=redirect_url, status_code=302)
-    response.delete_cookie(cookie_name, path="/")
-    return response
+    return _build_redirect_response(
+        request, provider_id, access_token, cookie_data
+    )
 
 
 # --- Workspace endpoints ---

--- a/src/backend/klangk_backend/api/workspaces.py
+++ b/src/backend/klangk_backend/api/workspaces.py
@@ -522,18 +522,12 @@ async def export_workspace(
     )
 
 
-@router.post("/workspaces/import")
-async def import_workspace(
-    file: UploadFile,
-    name: str | None = None,
-    user: dict = Depends(auth.get_current_user),
-):
-    """Import a workspace from a .tar.gz archive.
+async def _stream_upload_to_tempfile(file: UploadFile) -> str:
+    """Stream *file* to a temp file, enforcing the upload size limit.
 
-    Creates a new workspace with metadata from workspace.json and
-    extracts the home directory from the archive.
+    Returns the path to the temp file.  Caller is responsible for
+    deleting it.
     """
-    # Stream upload to a temp file — abort if over the configured limit.
     max_upload = FILE_UPLOAD_SIZE_MAX
     tmp = tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False)
     total = 0
@@ -547,75 +541,130 @@ async def import_workspace(
                 )
             tmp.write(chunk)
         tmp.close()
-    except HTTPException:
+    except BaseException:
         os.unlink(tmp.name)
         raise
-    except Exception:
-        os.unlink(tmp.name)
-        raise
+    return tmp.name
 
-    # Extract workspace.json from the archive using tar (fast, no Python parsing).
+
+def _extract_archive_metadata(archive_path: str, name: str | None) -> dict:
+    """Read workspace.json from the archive and return sanitized metadata."""
+    result = subprocess.run(
+        ["tar", "xzf", archive_path, "-O", "workspace.json"],
+        capture_output=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise HTTPException(
+            status_code=400,
+            detail="Archive missing workspace.json or is corrupt",
+        )
+    metadata = json.loads(result.stdout)
+
+    ws_name = name or metadata.get("name")
+    if not ws_name:
+        raise HTTPException(
+            status_code=400,
+            detail="No workspace name in archive or request",
+        )
+
+    image = metadata.get("image")
+    if image and image not in container.ALLOWED_IMAGES:
+        image = None
+
+    mounts = metadata.get("mounts")
+    if mounts and container.validate_mounts(mounts):
+        mounts = None
+
+    raw_env = metadata.get("env")
+    if isinstance(raw_env, dict):
+        blocked = {"LD_PRELOAD", "LD_LIBRARY_PATH", "PATH"}
+        env = {
+            k: v
+            for k, v in raw_env.items()
+            if not k.startswith("KLANGK_") and k not in blocked
+        }
+    else:
+        env = None
+
+    return {
+        "name": ws_name,
+        "image": image,
+        "default_command": metadata.get("default_command"),
+        "auto_start": metadata.get("auto_start", False),
+        "mounts": mounts,
+        "env": env,
+    }
+
+
+async def _extract_home_directory(
+    archive_path: str, user_id: int, ws_id: int
+) -> None:
+    """Extract the ``home/`` tree from *archive_path* into the workspace home."""
+    home_dir = workspaces.home_path(user_id, ws_id)
+    home_dir.mkdir(parents=True, exist_ok=True)
+    check = subprocess.run(
+        ["tar", "tzf", archive_path, "home/"],
+        capture_output=True,
+        timeout=30,
+    )
+    if check.returncode != 0:
+        return
+    result = await asyncio.to_thread(
+        subprocess.run,
+        [
+            "tar",
+            "xzf",
+            archive_path,
+            "--strip-components=1",
+            "--no-same-owner",
+            "--no-same-permissions",
+            "-C",
+            str(home_dir),
+            "home/",
+        ],
+        capture_output=True,
+        timeout=300,
+    )
+    if result.returncode != 0:
+        raise HTTPException(
+            status_code=400,
+            detail="Failed to extract home directory from archive",
+        )
+
+
+@router.post("/workspaces/import")
+async def import_workspace(
+    file: UploadFile,
+    name: str | None = None,
+    user: dict = Depends(auth.get_current_user),
+):
+    """Import a workspace from a .tar.gz archive.
+
+    Creates a new workspace with metadata from workspace.json and
+    extracts the home directory from the archive.
+    """
+    archive_path = await _stream_upload_to_tempfile(file)
     ws = None
     try:
-        result = subprocess.run(
-            ["tar", "xzf", tmp.name, "-O", "workspace.json"],
-            capture_output=True,
-            timeout=30,
-        )
-        if result.returncode != 0:
-            raise HTTPException(
-                status_code=400,
-                detail="Archive missing workspace.json or is corrupt",
-            )
-        metadata = json.loads(result.stdout)
-
-        ws_name = name or metadata.get("name")
-        if not ws_name:
-            raise HTTPException(
-                status_code=400,
-                detail="No workspace name in archive or request",
-            )
-
-        image = metadata.get("image")
-        if image and image not in container.ALLOWED_IMAGES:
-            image = None  # fall back to default
-
-        mounts = metadata.get("mounts")
-        if mounts and container.validate_mounts(mounts):
-            mounts = None  # invalid mounts, drop them
-
-        # Sanitize env: drop keys that could interfere with
-        # container startup (KLANGK_*, LD_*, PATH, etc.)
-        raw_env = metadata.get("env")
-        if isinstance(raw_env, dict):
-            blocked = {"LD_PRELOAD", "LD_LIBRARY_PATH", "PATH"}
-            env = {
-                k: v
-                for k, v in raw_env.items()
-                if not k.startswith("KLANGK_") and k not in blocked
-            }
-        else:
-            env = None
+        meta = _extract_archive_metadata(archive_path, name)
 
         try:
             ws = await workspaces.create_workspace(
                 user["id"],
-                ws_name,
-                image=image,
-                default_command=metadata.get("default_command"),
-                auto_start=metadata.get("auto_start", False),
-                mounts=mounts,
-                env=env,
+                meta["name"],
+                image=meta["image"],
+                default_command=meta["default_command"],
+                auto_start=meta["auto_start"],
+                mounts=meta["mounts"],
+                env=meta["env"],
             )
         except SAIntegrityError:
             raise HTTPException(
                 status_code=409,
-                detail=f"A workspace named {ws_name!r} already exists",
+                detail=f"A workspace named {meta['name']!r} already exists",
             )
 
-        # Grant owner full access via ACL (mirrors create_workspace). Without
-        # this an imported workspace has no ACL entries, so even its owner is
-        # denied terminal/exec/files access.
         await model.add_acl_entry(
             f"/workspaces/{ws['id']}",
             0,
@@ -625,39 +674,11 @@ async def import_workspace(
             user_id=user["id"],
         )
 
-        # Extract home directory using tar (much faster than Python tarfile
-        # for archives with many members). --strip-components=1 removes
-        # the "home/" prefix. Only extract if home/ exists in the archive.
-        home_dir = workspaces.home_path(user["id"], ws["id"])
-        home_dir.mkdir(parents=True, exist_ok=True)
-        check = subprocess.run(
-            ["tar", "tzf", tmp.name, "home/"],
-            capture_output=True,
-            timeout=30,
-        )
-        if check.returncode == 0:
-            result = await asyncio.to_thread(
-                subprocess.run,
-                [
-                    "tar",
-                    "xzf",
-                    tmp.name,
-                    "--strip-components=1",
-                    "--no-same-owner",
-                    "--no-same-permissions",
-                    "-C",
-                    str(home_dir),
-                    "home/",
-                ],
-                capture_output=True,
-                timeout=300,
-            )
-            if result.returncode != 0:
-                await workspaces.delete_workspace(ws["id"], user["id"])
-                raise HTTPException(
-                    status_code=400,
-                    detail="Failed to extract home directory from archive",
-                )
+        try:
+            await _extract_home_directory(archive_path, user["id"], ws["id"])
+        except HTTPException:
+            await workspaces.delete_workspace(ws["id"], user["id"])
+            raise
 
     except HTTPException:
         raise
@@ -668,7 +689,7 @@ async def import_workspace(
             status_code=400, detail="Invalid or corrupt archive"
         )
     finally:
-        os.unlink(tmp.name)
+        os.unlink(archive_path)
 
     wshandler.state.notify_user_workspaces_changed(user["id"])
     return ws

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -7236,6 +7236,32 @@ class TestOIDCCallback:
             await model.get_user_by_email("oidcuser@example.com") is not None
         )
 
+    async def test_callback_returning_user(self, client, monkeypatch, db):
+        """A user who already has the OIDC identity linked logs in without
+        JIT provisioning or email lookup."""
+        _, cookie_data = await self._setup_callback(client, monkeypatch, db)
+        # First callback — creates the user via JIT provisioning.
+        resp = await client.get(
+            "/api/v1/auth/oidc/test/callback",
+            params={"code": "auth-code", "state": "test-state"},
+            cookies={"oidc_test": cookie_data},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 302
+        user = await model.get_user_by_external_id("test", "oidc-sub-123")
+        assert user is not None
+
+        # Second callback — returning user, found by external ID.
+        _, cookie_data2 = await self._setup_callback(client, monkeypatch, db)
+        resp2 = await client.get(
+            "/api/v1/auth/oidc/test/callback",
+            params={"code": "auth-code", "state": "test-state"},
+            cookies={"oidc_test": cookie_data2},
+            follow_redirects=False,
+        )
+        assert resp2.status_code == 302
+        assert "token=" in resp2.headers["location"]
+
     async def test_callback_unknown_provider(self, client, monkeypatch, db):
         monkeypatch.setattr(api.oidc, "get_provider", lambda _: None)
         resp = await client.get(


### PR DESCRIPTION
## Summary

- Extract helpers from `import_workspace` (149L → 59L) and `oidc_callback` (138L → 47L) to improve readability and testability
- Add `test_callback_returning_user` covering the existing-user-by-external-ID path
- All 1932 backend tests pass with 100% coverage

Closes #974