### PR TITLE
refactor(frontend): break up SettingsPage and FileViewerPanel god widgets

### DIFF
--- a/src/frontend/lib/auth/settings_page.dart
+++ b/src/frontend/lib/auth/settings_page.dart
@@ -17,35 +17,6 @@ class SettingsPage extends StatefulWidget {
 }
 
 class _SettingsPageState extends State<SettingsPage> {
-  // Password change
-  final _currentPasswordController = TextEditingController();
-  final _newPasswordController = TextEditingController();
-  final _confirmPasswordController = TextEditingController();
-  final _passwordFormKey = GlobalKey<FormState>();
-  bool _changingPassword = false;
-  String? _passwordMessage;
-  bool _passwordSuccess = false;
-  bool _obscureCurrentPassword = true;
-  bool _obscureNewPassword = true;
-
-  // Email change
-  final _newEmailController = TextEditingController();
-  final _emailPasswordController = TextEditingController();
-  final _emailFormKey = GlobalKey<FormState>();
-  bool _changingEmail = false;
-  String? _emailMessage;
-  bool _emailSuccess = false;
-  bool _obscureEmailPassword = true;
-
-  // Handle change
-  final _newHandleController = TextEditingController();
-  final _handlePasswordController = TextEditingController();
-  final _handleFormKey = GlobalKey<FormState>();
-  bool _changingHandle = false;
-  String? _handleMessage;
-  bool _handleSuccess = false;
-  bool _obscureHandlePassword = true;
-
   String? _currentHandle;
 
   @override
@@ -68,173 +39,6 @@ class _SettingsPageState extends State<SettingsPage> {
       }
     } catch (e) {
       debugPrint('[SettingsPage] fetch current handle failed: $e');
-    }
-  }
-
-  @override
-  void dispose() {
-    _currentPasswordController.dispose();
-    _newPasswordController.dispose();
-    _confirmPasswordController.dispose();
-    _newEmailController.dispose();
-    _emailPasswordController.dispose();
-    _newHandleController.dispose();
-    _handlePasswordController.dispose();
-    super.dispose();
-  }
-
-  Future<void> _changePassword() async {
-    if (!_passwordFormKey.currentState!.validate()) return;
-    setState(() {
-      _changingPassword = true;
-      _passwordMessage = null;
-    });
-
-    final auth = context.read<AuthService>();
-    try {
-      final resp = await auth.authPost(
-        '/api/v1/auth/change-password',
-        body: jsonEncode({
-          'current_password': _currentPasswordController.text,
-          'new_password': _newPasswordController.text,
-        }),
-      );
-      if (!mounted) return;
-      if (resp.statusCode == 200) {
-        setState(() {
-          _passwordSuccess = true;
-          _passwordMessage = 'Password updated.';
-          _changingPassword = false;
-        });
-        _currentPasswordController.clear();
-        _newPasswordController.clear();
-        _confirmPasswordController.clear();
-      } else {
-        final data = jsonDecode(resp.body);
-        setState(() {
-          _passwordSuccess = false;
-          _passwordMessage = data['detail'] ?? 'Failed to change password.';
-          _changingPassword = false;
-        });
-      }
-    } catch (e) {
-      if (!mounted) return;
-      setState(() {
-        _passwordSuccess = false;
-        _passwordMessage = 'Network error.';
-        _changingPassword = false;
-      });
-    }
-  }
-
-  Future<void> _changeHandle() async {
-    if (!_handleFormKey.currentState!.validate()) return;
-    final newHandle = _newHandleController.text.trim();
-    final confirmed = await showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('Change Handle?'),
-        content: Text(
-          'Change your handle from @${_currentHandle ?? ''} to @$newHandle?\n\n'
-          'This will affect your terminal home directory and how others see you in chat.',
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(ctx, false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.pop(ctx, true),
-            child: const Text('Change'),
-          ),
-        ],
-      ),
-    );
-    if (confirmed != true) return;
-    setState(() {
-      _changingHandle = true;
-      _handleMessage = null;
-    });
-
-    final auth = context.read<AuthService>();
-    try {
-      final resp = await auth.authPost(
-        '/api/v1/auth/change-handle',
-        body: jsonEncode({
-          'handle': _newHandleController.text.trim(),
-          'password': _handlePasswordController.text,
-        }),
-      );
-      if (!mounted) return;
-      if (resp.statusCode == 200) {
-        final data = jsonDecode(resp.body);
-        setState(() {
-          _handleSuccess = true;
-          _handleMessage = 'Handle updated.';
-          _changingHandle = false;
-          _currentHandle = data['handle'] as String?;
-        });
-        _newHandleController.clear();
-        _handlePasswordController.clear();
-      } else {
-        final data = jsonDecode(resp.body);
-        setState(() {
-          _handleSuccess = false;
-          _handleMessage = data['detail'] ?? 'Failed to change handle.';
-          _changingHandle = false;
-        });
-      }
-    } catch (e) {
-      if (!mounted) return;
-      setState(() {
-        _handleSuccess = false;
-        _handleMessage = 'Network error.';
-        _changingHandle = false;
-      });
-    }
-  }
-
-  Future<void> _changeEmail() async {
-    if (!_emailFormKey.currentState!.validate()) return;
-    setState(() {
-      _changingEmail = true;
-      _emailMessage = null;
-    });
-
-    final auth = context.read<AuthService>();
-    try {
-      final resp = await auth.authPost(
-        '/api/v1/auth/change-email',
-        body: jsonEncode({
-          'email': _newEmailController.text.trim(),
-          'password': _emailPasswordController.text,
-        }),
-      );
-      if (!mounted) return;
-      if (resp.statusCode == 200) {
-        setState(() {
-          _emailSuccess = true;
-          _emailMessage =
-              'Email updated. Check your inbox to verify the new address.';
-          _changingEmail = false;
-        });
-        _newEmailController.clear();
-        _emailPasswordController.clear();
-      } else {
-        final data = jsonDecode(resp.body);
-        setState(() {
-          _emailSuccess = false;
-          _emailMessage = data['detail'] ?? 'Failed to change email.';
-          _changingEmail = false;
-        });
-      }
-    } catch (e) {
-      if (!mounted) return;
-      setState(() {
-        _emailSuccess = false;
-        _emailMessage = 'Network error.';
-        _changingEmail = false;
-      });
     }
   }
 
@@ -279,24 +83,28 @@ class _SettingsPageState extends State<SettingsPage> {
                   ],
                 ),
                 const SizedBox(height: 32),
-                Card(
+                const Card(
                   child: Padding(
-                    padding: const EdgeInsets.all(24),
-                    child: _buildPasswordSection(),
+                    padding: EdgeInsets.all(24),
+                    child: _PasswordSection(),
                   ),
                 ),
                 const SizedBox(height: 24),
                 Card(
                   child: Padding(
                     padding: const EdgeInsets.all(24),
-                    child: _buildHandleSection(),
+                    child: _HandleSection(
+                      currentHandle: _currentHandle,
+                      onHandleChanged: (handle) =>
+                          setState(() => _currentHandle = handle),
+                    ),
                   ),
                 ),
                 const SizedBox(height: 24),
-                Card(
+                const Card(
                   child: Padding(
-                    padding: const EdgeInsets.all(24),
-                    child: _buildEmailSection(),
+                    padding: EdgeInsets.all(24),
+                    child: _EmailSection(),
                   ),
                 ),
               ],
@@ -306,10 +114,82 @@ class _SettingsPageState extends State<SettingsPage> {
       ),
     );
   }
+}
 
-  Widget _buildPasswordSection() {
+class _PasswordSection extends StatefulWidget {
+  const _PasswordSection();
+
+  @override
+  State<_PasswordSection> createState() => _PasswordSectionState();
+}
+
+class _PasswordSectionState extends State<_PasswordSection> {
+  final _currentPasswordController = TextEditingController();
+  final _newPasswordController = TextEditingController();
+  final _confirmPasswordController = TextEditingController();
+  final _formKey = GlobalKey<FormState>();
+  bool _changing = false;
+  String? _message;
+  bool _success = false;
+  bool _obscureCurrent = true;
+  bool _obscureNew = true;
+
+  @override
+  void dispose() {
+    _currentPasswordController.dispose();
+    _newPasswordController.dispose();
+    _confirmPasswordController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _changePassword() async {
+    if (!_formKey.currentState!.validate()) return;
+    setState(() {
+      _changing = true;
+      _message = null;
+    });
+
+    final auth = context.read<AuthService>();
+    try {
+      final resp = await auth.authPost(
+        '/api/v1/auth/change-password',
+        body: jsonEncode({
+          'current_password': _currentPasswordController.text,
+          'new_password': _newPasswordController.text,
+        }),
+      );
+      if (!mounted) return;
+      if (resp.statusCode == 200) {
+        setState(() {
+          _success = true;
+          _message = 'Password updated.';
+          _changing = false;
+        });
+        _currentPasswordController.clear();
+        _newPasswordController.clear();
+        _confirmPasswordController.clear();
+      } else {
+        final data = jsonDecode(resp.body);
+        setState(() {
+          _success = false;
+          _message = data['detail'] ?? 'Failed to change password.';
+          _changing = false;
+        });
+      }
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _success = false;
+        _message = 'Network error.';
+        _changing = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return Form(
-      key: _passwordFormKey,
+      key: _formKey,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -336,14 +216,13 @@ class _SettingsPageState extends State<SettingsPage> {
               floatingLabelBehavior: FloatingLabelBehavior.always,
               border: const OutlineInputBorder(),
               suffixIcon: IconButton(
-                icon: Icon(_obscureCurrentPassword
-                    ? Icons.visibility_off
-                    : Icons.visibility),
-                onPressed: () => setState(
-                    () => _obscureCurrentPassword = !_obscureCurrentPassword),
+                icon: Icon(
+                    _obscureCurrent ? Icons.visibility_off : Icons.visibility),
+                onPressed: () =>
+                    setState(() => _obscureCurrent = !_obscureCurrent),
               ),
             ),
-            obscureText: _obscureCurrentPassword,
+            obscureText: _obscureCurrent,
             validator: (v) => v == null || v.isEmpty ? 'Required' : null,
           ),
           const SizedBox(height: 12),
@@ -356,14 +235,12 @@ class _SettingsPageState extends State<SettingsPage> {
               floatingLabelBehavior: FloatingLabelBehavior.always,
               border: const OutlineInputBorder(),
               suffixIcon: IconButton(
-                icon: Icon(_obscureNewPassword
-                    ? Icons.visibility_off
-                    : Icons.visibility),
-                onPressed: () =>
-                    setState(() => _obscureNewPassword = !_obscureNewPassword),
+                icon:
+                    Icon(_obscureNew ? Icons.visibility_off : Icons.visibility),
+                onPressed: () => setState(() => _obscureNew = !_obscureNew),
               ),
             ),
-            obscureText: _obscureNewPassword,
+            obscureText: _obscureNew,
             validator: (v) {
               if (v == null || v.isEmpty) return 'Required';
               if (v.length < 4) return 'Min 4 characters';
@@ -380,14 +257,12 @@ class _SettingsPageState extends State<SettingsPage> {
               floatingLabelBehavior: FloatingLabelBehavior.always,
               border: const OutlineInputBorder(),
               suffixIcon: IconButton(
-                icon: Icon(_obscureNewPassword
-                    ? Icons.visibility_off
-                    : Icons.visibility),
-                onPressed: () =>
-                    setState(() => _obscureNewPassword = !_obscureNewPassword),
+                icon:
+                    Icon(_obscureNew ? Icons.visibility_off : Icons.visibility),
+                onPressed: () => setState(() => _obscureNew = !_obscureNew),
               ),
             ),
-            obscureText: _obscureNewPassword,
+            obscureText: _obscureNew,
             validator: (v) {
               if (v != _newPasswordController.text) {
                 return 'Passwords do not match';
@@ -396,12 +271,12 @@ class _SettingsPageState extends State<SettingsPage> {
             },
             onFieldSubmitted: (_) => _changePassword(),
           ),
-          if (_passwordMessage != null) ...[
+          if (_message != null) ...[
             const SizedBox(height: 12),
             Text(
-              _passwordMessage!,
+              _message!,
               style: TextStyle(
-                color: _passwordSuccess
+                color: _success
                     ? Colors.green
                     : Theme.of(context).colorScheme.error,
               ),
@@ -409,8 +284,8 @@ class _SettingsPageState extends State<SettingsPage> {
           ],
           const SizedBox(height: 16),
           FilledButton(
-            onPressed: _changingPassword ? null : _changePassword,
-            child: _changingPassword
+            onPressed: _changing ? null : _changePassword,
+            child: _changing
                 ? const SizedBox(
                     height: 20,
                     width: 20,
@@ -422,10 +297,109 @@ class _SettingsPageState extends State<SettingsPage> {
       ),
     );
   }
+}
 
-  Widget _buildHandleSection() {
+class _HandleSection extends StatefulWidget {
+  final String? currentHandle;
+  final ValueChanged<String?> onHandleChanged;
+
+  const _HandleSection({
+    required this.currentHandle,
+    required this.onHandleChanged,
+  });
+
+  @override
+  State<_HandleSection> createState() => _HandleSectionState();
+}
+
+class _HandleSectionState extends State<_HandleSection> {
+  final _newHandleController = TextEditingController();
+  final _passwordController = TextEditingController();
+  final _formKey = GlobalKey<FormState>();
+  bool _changing = false;
+  String? _message;
+  bool _success = false;
+  bool _obscurePassword = true;
+
+  @override
+  void dispose() {
+    _newHandleController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _changeHandle() async {
+    if (!_formKey.currentState!.validate()) return;
+    final newHandle = _newHandleController.text.trim();
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Change Handle?'),
+        content: Text(
+          'Change your handle from @${widget.currentHandle ?? ''} to @$newHandle?\n\n'
+          'This will affect your terminal home directory and how others see you in chat.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Change'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+    setState(() {
+      _changing = true;
+      _message = null;
+    });
+
+    final auth = context.read<AuthService>();
+    try {
+      final resp = await auth.authPost(
+        '/api/v1/auth/change-handle',
+        body: jsonEncode({
+          'handle': _newHandleController.text.trim(),
+          'password': _passwordController.text,
+        }),
+      );
+      if (!mounted) return;
+      if (resp.statusCode == 200) {
+        final data = jsonDecode(resp.body);
+        final handle = data['handle'] as String?;
+        setState(() {
+          _success = true;
+          _message = 'Handle updated.';
+          _changing = false;
+        });
+        widget.onHandleChanged(handle);
+        _newHandleController.clear();
+        _passwordController.clear();
+      } else {
+        final data = jsonDecode(resp.body);
+        setState(() {
+          _success = false;
+          _message = data['detail'] ?? 'Failed to change handle.';
+          _changing = false;
+        });
+      }
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _success = false;
+        _message = 'Network error.';
+        _changing = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return Form(
-      key: _handleFormKey,
+      key: _formKey,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -442,10 +416,10 @@ class _SettingsPageState extends State<SettingsPage> {
                       letterSpacing: 0.3)),
             ],
           ),
-          if (_currentHandle != null) ...[
+          if (widget.currentHandle != null) ...[
             const SizedBox(height: 12),
             Text(
-              'Current handle: @$_currentHandle',
+              'Current handle: @${widget.currentHandle}',
               style: const TextStyle(color: KColors.textSecondary),
             ),
           ],
@@ -471,7 +445,7 @@ class _SettingsPageState extends State<SettingsPage> {
           ),
           const SizedBox(height: 12),
           TextFormField(
-            controller: _handlePasswordController,
+            controller: _passwordController,
             decoration: InputDecoration(
               labelText: 'Password (to confirm)',
               labelStyle: TextStyle(color: KColors.textSecondary),
@@ -479,23 +453,22 @@ class _SettingsPageState extends State<SettingsPage> {
               floatingLabelBehavior: FloatingLabelBehavior.always,
               border: const OutlineInputBorder(),
               suffixIcon: IconButton(
-                icon: Icon(_obscureHandlePassword
-                    ? Icons.visibility_off
-                    : Icons.visibility),
-                onPressed: () => setState(
-                    () => _obscureHandlePassword = !_obscureHandlePassword),
+                icon: Icon(
+                    _obscurePassword ? Icons.visibility_off : Icons.visibility),
+                onPressed: () =>
+                    setState(() => _obscurePassword = !_obscurePassword),
               ),
             ),
-            obscureText: _obscureHandlePassword,
+            obscureText: _obscurePassword,
             validator: (v) => v == null || v.isEmpty ? 'Required' : null,
             onFieldSubmitted: (_) => _changeHandle(),
           ),
-          if (_handleMessage != null) ...[
+          if (_message != null) ...[
             const SizedBox(height: 12),
             Text(
-              _handleMessage!,
+              _message!,
               style: TextStyle(
-                color: _handleSuccess
+                color: _success
                     ? Colors.green
                     : Theme.of(context).colorScheme.error,
               ),
@@ -503,8 +476,8 @@ class _SettingsPageState extends State<SettingsPage> {
           ],
           const SizedBox(height: 16),
           FilledButton(
-            onPressed: _changingHandle ? null : _changeHandle,
-            child: _changingHandle
+            onPressed: _changing ? null : _changeHandle,
+            child: _changing
                 ? const SizedBox(
                     height: 20,
                     width: 20,
@@ -516,10 +489,79 @@ class _SettingsPageState extends State<SettingsPage> {
       ),
     );
   }
+}
 
-  Widget _buildEmailSection() {
+class _EmailSection extends StatefulWidget {
+  const _EmailSection();
+
+  @override
+  State<_EmailSection> createState() => _EmailSectionState();
+}
+
+class _EmailSectionState extends State<_EmailSection> {
+  final _newEmailController = TextEditingController();
+  final _passwordController = TextEditingController();
+  final _formKey = GlobalKey<FormState>();
+  bool _changing = false;
+  String? _message;
+  bool _success = false;
+  bool _obscurePassword = true;
+
+  @override
+  void dispose() {
+    _newEmailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _changeEmail() async {
+    if (!_formKey.currentState!.validate()) return;
+    setState(() {
+      _changing = true;
+      _message = null;
+    });
+
+    final auth = context.read<AuthService>();
+    try {
+      final resp = await auth.authPost(
+        '/api/v1/auth/change-email',
+        body: jsonEncode({
+          'email': _newEmailController.text.trim(),
+          'password': _passwordController.text,
+        }),
+      );
+      if (!mounted) return;
+      if (resp.statusCode == 200) {
+        setState(() {
+          _success = true;
+          _message =
+              'Email updated. Check your inbox to verify the new address.';
+          _changing = false;
+        });
+        _newEmailController.clear();
+        _passwordController.clear();
+      } else {
+        final data = jsonDecode(resp.body);
+        setState(() {
+          _success = false;
+          _message = data['detail'] ?? 'Failed to change email.';
+          _changing = false;
+        });
+      }
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _success = false;
+        _message = 'Network error.';
+        _changing = false;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return Form(
-      key: _emailFormKey,
+      key: _formKey,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -556,7 +598,7 @@ class _SettingsPageState extends State<SettingsPage> {
           ),
           const SizedBox(height: 12),
           TextFormField(
-            controller: _emailPasswordController,
+            controller: _passwordController,
             decoration: InputDecoration(
               labelText: 'Password (to confirm)',
               labelStyle: TextStyle(color: KColors.textSecondary),
@@ -564,23 +606,22 @@ class _SettingsPageState extends State<SettingsPage> {
               floatingLabelBehavior: FloatingLabelBehavior.always,
               border: const OutlineInputBorder(),
               suffixIcon: IconButton(
-                icon: Icon(_obscureEmailPassword
-                    ? Icons.visibility_off
-                    : Icons.visibility),
-                onPressed: () => setState(
-                    () => _obscureEmailPassword = !_obscureEmailPassword),
+                icon: Icon(
+                    _obscurePassword ? Icons.visibility_off : Icons.visibility),
+                onPressed: () =>
+                    setState(() => _obscurePassword = !_obscurePassword),
               ),
             ),
-            obscureText: _obscureEmailPassword,
+            obscureText: _obscurePassword,
             validator: (v) => v == null || v.isEmpty ? 'Required' : null,
             onFieldSubmitted: (_) => _changeEmail(),
           ),
-          if (_emailMessage != null) ...[
+          if (_message != null) ...[
             const SizedBox(height: 12),
             Text(
-              _emailMessage!,
+              _message!,
               style: TextStyle(
-                color: _emailSuccess
+                color: _success
                     ? Colors.green
                     : Theme.of(context).colorScheme.error,
               ),
@@ -588,8 +629,8 @@ class _SettingsPageState extends State<SettingsPage> {
           ],
           const SizedBox(height: 16),
           FilledButton(
-            onPressed: _changingEmail ? null : _changeEmail,
-            child: _changingEmail
+            onPressed: _changing ? null : _changeEmail,
+            child: _changing
                 ? const SizedBox(
                     height: 20,
                     width: 20,

--- a/src/frontend/lib/file_viewer/file_viewer_panel.dart
+++ b/src/frontend/lib/file_viewer/file_viewer_panel.dart
@@ -568,6 +568,95 @@ class FileViewerPanelState extends State<FileViewerPanel> {
     );
   }
 
+  Widget _buildPathBar() {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(8, 1, 8, 1),
+      decoration: BoxDecoration(color: KColors.bgCanvas),
+      child: Row(
+        children: [
+          InkWell(
+            onTap: () => _navigateTo(widget.userHome ?? '/'),
+            child: const Icon(Icons.home, size: 16),
+          ),
+          const SizedBox(width: 4),
+          Expanded(child: _buildBreadcrumbs()),
+          if (_currentPath != '/')
+            IconButton(
+              icon: const Icon(Icons.arrow_upward, size: 28),
+              onPressed: () {
+                final lastSlash = _currentPath.lastIndexOf('/');
+                final parent =
+                    lastSlash <= 0 ? '/' : _currentPath.substring(0, lastSlash);
+                _navigateTo(parent);
+              },
+              iconSize: 28,
+              tooltip: 'Up',
+            ),
+          IconButton(
+            icon: const Icon(Icons.refresh, size: 28),
+            onPressed: () => _loadFiles(force: true),
+            iconSize: 28,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildContent() {
+    if (_selectedFile != null) {
+      return _FileViewer(
+        // Key by path so switching files (e.g. PDF → .md) directly —
+        // without going through the list — recreates the viewer with
+        // the new file's renderers instead of reusing stale ones.
+        key: ValueKey(_selectedFile),
+        registry: _registry,
+        file: _renderableFor(_selectedFile!),
+        onClose: () => setState(() => _selectedFile = null),
+        onDownload: () {
+          final path = _selectedFile!;
+          final name = path.contains('/')
+              ? path.substring(path.lastIndexOf('/') + 1)
+              : path;
+          _downloadPath(path, name, false);
+        },
+      );
+    }
+    return _buildFileList();
+  }
+
+  Widget _buildFileListItem(int index) {
+    final entry = _entries[index];
+    final isDir = entry['is_dir'] as bool;
+    final name = entry['name'] as String;
+    final path = entry['path'] as String;
+    return GestureDetector(
+      onSecondaryTapDown: (details) {
+        _showContextMenu(details.globalPosition, path, name, isDir);
+      },
+      child: ListTile(
+        dense: true,
+        leading: Icon(
+          isDir ? Icons.folder : Icons.insert_drive_file,
+          size: 18,
+        ),
+        title: Text(name, style: const TextStyle(fontSize: 13)),
+        subtitle: isDir
+            ? null
+            : Text(
+                '${entry['size'] ?? 0} bytes  ${formatMtime(entry['mtime'])}',
+                style: const TextStyle(fontSize: 11),
+              ),
+        onTap: () {
+          if (isDir) {
+            _navigateTo(path);
+          } else {
+            setState(() => _selectedFile = path);
+          }
+        },
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return SuppressBrowserContextMenu(
@@ -579,60 +668,8 @@ class FileViewerPanelState extends State<FileViewerPanel> {
         onUploadComplete: _onUploadComplete,
         child: Column(
           children: [
-            // Path bar
-            Container(
-              padding: const EdgeInsets.fromLTRB(8, 1, 8, 1),
-              decoration: BoxDecoration(color: KColors.bgCanvas),
-              child: Row(
-                children: [
-                  InkWell(
-                    onTap: () => _navigateTo(widget.userHome ?? '/'),
-                    child: const Icon(Icons.home, size: 16),
-                  ),
-                  const SizedBox(width: 4),
-                  Expanded(child: _buildBreadcrumbs()),
-                  if (_currentPath != '/')
-                    IconButton(
-                      icon: const Icon(Icons.arrow_upward, size: 28),
-                      onPressed: () {
-                        final lastSlash = _currentPath.lastIndexOf('/');
-                        final parent = lastSlash <= 0
-                            ? '/'
-                            : _currentPath.substring(0, lastSlash);
-                        _navigateTo(parent);
-                      },
-                      iconSize: 28,
-                      tooltip: 'Up',
-                    ),
-                  IconButton(
-                    icon: const Icon(Icons.refresh, size: 28),
-                    onPressed: () => _loadFiles(force: true),
-                    iconSize: 28,
-                  ),
-                ],
-              ),
-            ),
-            // File list or content
-            Expanded(
-              child: _selectedFile != null
-                  ? _FileViewer(
-                      // Key by path so switching files (e.g. PDF → .md) directly —
-                      // without going through the list — recreates the viewer with
-                      // the new file's renderers instead of reusing stale ones.
-                      key: ValueKey(_selectedFile),
-                      registry: _registry,
-                      file: _renderableFor(_selectedFile!),
-                      onClose: () => setState(() => _selectedFile = null),
-                      onDownload: () {
-                        final path = _selectedFile!;
-                        final name = path.contains('/')
-                            ? path.substring(path.lastIndexOf('/') + 1)
-                            : path;
-                        _downloadPath(path, name, false);
-                      },
-                    )
-                  : _buildFileList(),
-            ),
+            _buildPathBar(),
+            Expanded(child: _buildContent()),
           ],
         ),
       ),
@@ -661,38 +698,7 @@ class FileViewerPanelState extends State<FileViewerPanel> {
           child: ListView.builder(
             padding: EdgeInsets.zero,
             itemCount: _entries.length,
-            itemBuilder: (context, index) {
-              final entry = _entries[index];
-              final isDir = entry['is_dir'] as bool;
-              final name = entry['name'] as String;
-              final path = entry['path'] as String;
-              return GestureDetector(
-                onSecondaryTapDown: (details) {
-                  _showContextMenu(details.globalPosition, path, name, isDir);
-                },
-                child: ListTile(
-                  dense: true,
-                  leading: Icon(
-                    isDir ? Icons.folder : Icons.insert_drive_file,
-                    size: 18,
-                  ),
-                  title: Text(name, style: const TextStyle(fontSize: 13)),
-                  subtitle: isDir
-                      ? null
-                      : Text(
-                          '${entry['size'] ?? 0} bytes  ${formatMtime(entry['mtime'])}',
-                          style: const TextStyle(fontSize: 11),
-                        ),
-                  onTap: () {
-                    if (isDir) {
-                      _navigateTo(path);
-                    } else {
-                      setState(() => _selectedFile = path);
-                    }
-                  },
-                ),
-              );
-            },
+            itemBuilder: (context, index) => _buildFileListItem(index),
           ),
         ),
         Padding(


### PR DESCRIPTION
## Summary

Closes #973.

- Extract `_SettingsPageState` (586L) into three self-contained `StatefulWidget`s: `_PasswordSection`, `_HandleSection`, `_EmailSection`. Each owns its own controllers, form keys, loading state, and async logic. The parent `_SettingsPageState` drops to ~88L.
- Extract `_buildPathBar()`, `_buildContent()`, and `_buildFileListItem()` from `FileViewerPanelState.build()`, reducing it from 68L to 13L.

Pure widget extraction — no behavior change. All frontend tests pass at 100% coverage.

## Test plan

- [x] `test-frontend` passes with 100% coverage
- [ ] CI passes