### PR TITLE
refactor(frontend): extract ImportWorkspaceDialog with full test coverage

### DIFF
--- a/src/frontend/lib/workspace/import_workspace_dialog.dart
+++ b/src/frontend/lib/workspace/import_workspace_dialog.dart
@@ -1,0 +1,167 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+import '../auth/auth_service.dart';
+import '../theme/colors.dart';
+import 'package:klangk_plugin_api/klangk_plugin_api.dart';
+import '../utils/web_helpers_stub.dart'
+    if (dart.library.js_interop) '../utils/web_helpers_web.dart';
+
+/// Override for testing — set to intercept the file picker.
+@visibleForTesting
+Future<List<int>?> Function({String accept})? testPickFileBytesOverride;
+
+/// Dialog for importing a workspace from a .tar.gz archive.
+class ImportWorkspaceDialog extends StatefulWidget {
+  final AuthService auth;
+
+  const ImportWorkspaceDialog({super.key, required this.auth});
+
+  @override
+  State<ImportWorkspaceDialog> createState() => _ImportWorkspaceDialogState();
+}
+
+class _ImportWorkspaceDialogState extends State<ImportWorkspaceDialog> {
+  final _nameController = TextEditingController();
+  List<int>? _selectedBytes;
+  String? _fileName;
+  String? _errorMessage;
+  bool _importing = false;
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _pickFile() async {
+    final picker = testPickFileBytesOverride ?? pickFileBytes;
+    final bytes = await picker(accept: '.tar.gz,.tgz');
+    if (bytes != null) {
+      setState(() {
+        _selectedBytes = bytes;
+        _fileName = 'workspace.tar.gz';
+      });
+    }
+  }
+
+  Future<void> _submit() async {
+    if (_selectedBytes == null) return;
+    setState(() {
+      _importing = true;
+      _errorMessage = null;
+    });
+    final name = _nameController.text.trim();
+    var url = '$baseUrl/api/v1/workspaces/import';
+    if (name.isNotEmpty) {
+      url += '?name=${Uri.encodeComponent(name)}';
+    }
+    final client =
+        testAuthHttpClientOverride ?? http.Client(); // coverage:ignore-line
+    try {
+      final request = http.MultipartRequest('POST', Uri.parse(url));
+      request.headers['Authorization'] = 'Bearer ${widget.auth.token}';
+      request.files.add(
+        http.MultipartFile.fromBytes(
+          'file',
+          _selectedBytes!,
+          filename: 'workspace.tar.gz',
+        ),
+      );
+      final streamed = await client.send(request);
+      final resp = await http.Response.fromStream(streamed);
+      if (resp.statusCode == 200 || resp.statusCode == 201) {
+        if (mounted) Navigator.pop(context, true);
+      } else {
+        String detail;
+        try {
+          detail = (jsonDecode(resp.body) as Map)['detail'] as String? ??
+              '${resp.statusCode}';
+        } catch (_) {
+          detail = '${resp.statusCode}';
+        }
+        setState(() {
+          _importing = false;
+          _errorMessage = 'Import failed: $detail';
+        });
+      }
+    } catch (_) {
+      setState(() {
+        _importing = false;
+        _errorMessage = 'Import failed';
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(
+        'Import Workspace',
+        style: TextStyle(color: KColors.textPrimary),
+      ),
+      content: SizedBox(
+        width: 400,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (_errorMessage != null) ...[
+              Text(
+                _errorMessage!,
+                style: TextStyle(
+                  color: Theme.of(context).colorScheme.error,
+                ),
+              ),
+              const SizedBox(height: 12),
+            ],
+            OutlinedButton.icon(
+              onPressed: _importing ? null : _pickFile,
+              icon: const Icon(Icons.file_open, size: 18),
+              label: Text(_fileName ?? 'Select .tar.gz file'),
+            ),
+            if (_selectedBytes != null) ...[
+              const SizedBox(height: 4),
+              Text(
+                '${(_selectedBytes!.length / 1024).toStringAsFixed(0)} KB',
+                style: const TextStyle(
+                  color: KColors.textSecondary,
+                  fontSize: 12,
+                ),
+              ),
+            ],
+            const SizedBox(height: 16),
+            TextField(
+              controller: _nameController,
+              decoration: const InputDecoration(
+                labelText: 'Workspace Name (optional)',
+                hintText: 'Uses name from archive if empty',
+                border: OutlineInputBorder(),
+              ),
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: _importing ? null : () => Navigator.pop(context),
+          style: TextButton.styleFrom(foregroundColor: KColors.accentRed),
+          child: const Text('Cancel'),
+        ),
+        FilledButton(
+          onPressed: _selectedBytes == null || _importing ? null : _submit,
+          child: _importing
+              ? const SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    color: Colors.white,
+                  ),
+                )
+              : const Text('Import'),
+        ),
+      ],
+    );
+  }
+}

--- a/src/frontend/lib/workspace/workspace_list_page.dart
+++ b/src/frontend/lib/workspace/workspace_list_page.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
 import 'package:flutter/material.dart';
-import 'package:http/http.dart' as http;
 import '../theme/colors.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
@@ -9,11 +8,10 @@ import '../auth/auth_service.dart';
 import '../ws/ws_client.dart';
 import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 import '../utils/page_title.dart';
-import '../utils/web_helpers_stub.dart'
-    if (dart.library.js_interop) '../utils/web_helpers_web.dart';
 import '../widgets/app_bar_actions.dart';
 import '../widgets/app_bar_title.dart';
 import 'create_workspace_dialog.dart';
+import 'import_workspace_dialog.dart';
 
 const _validMountOptions = {
   'ro',
@@ -331,157 +329,16 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
     }
   }
 
-  // coverage:ignore-start
   Future<void> _showImportDialog() async {
-    final nameController = TextEditingController();
-    List<int>? selectedBytes;
-    String? fileName;
-    String? errorMessage;
-    bool importing = false;
-
     final imported = await showDialog<bool>(
       context: context,
-      builder: (context) => StatefulBuilder(
-        builder: (context, setDialogState) => AlertDialog(
-          title: Text(
-            'Import Workspace',
-            style: TextStyle(color: KColors.textPrimary),
-          ),
-          content: SizedBox(
-            width: 400,
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                if (errorMessage != null) ...[
-                  Text(
-                    errorMessage!,
-                    style: TextStyle(
-                      color: Theme.of(context).colorScheme.error,
-                    ),
-                  ),
-                  const SizedBox(height: 12),
-                ],
-                OutlinedButton.icon(
-                  onPressed: importing
-                      ? null
-                      : () async {
-                          final bytes = await pickFileBytes(
-                            accept: '.tar.gz,.tgz',
-                          );
-                          if (bytes != null) {
-                            setDialogState(() {
-                              selectedBytes = bytes;
-                              fileName = 'workspace.tar.gz';
-                            });
-                          }
-                        },
-                  icon: const Icon(Icons.file_open, size: 18),
-                  label: Text(fileName ?? 'Select .tar.gz file'),
-                ),
-                if (selectedBytes != null) ...[
-                  const SizedBox(height: 4),
-                  Text(
-                    '${(selectedBytes!.length / 1024).toStringAsFixed(0)} KB',
-                    style: const TextStyle(
-                      color: KColors.textSecondary,
-                      fontSize: 12,
-                    ),
-                  ),
-                ],
-                const SizedBox(height: 16),
-                TextField(
-                  controller: nameController,
-                  decoration: const InputDecoration(
-                    labelText: 'Workspace Name (optional)',
-                    hintText: 'Uses name from archive if empty',
-                    border: OutlineInputBorder(),
-                  ),
-                ),
-              ],
-            ),
-          ),
-          actions: [
-            TextButton(
-              onPressed: importing ? null : () => Navigator.pop(context),
-              style: TextButton.styleFrom(foregroundColor: KColors.accentRed),
-              child: const Text('Cancel'),
-            ),
-            FilledButton(
-              onPressed: selectedBytes == null || importing
-                  ? null
-                  : () async {
-                      setDialogState(() {
-                        importing = true;
-                        errorMessage = null;
-                      });
-                      final name = nameController.text.trim();
-                      var url = '$baseUrl/api/v1/workspaces/import';
-                      if (name.isNotEmpty) {
-                        url += '?name=${Uri.encodeComponent(name)}';
-                      }
-                      try {
-                        final request = http.MultipartRequest(
-                          'POST',
-                          Uri.parse(url),
-                        );
-                        request.headers['Authorization'] =
-                            'Bearer ${_auth.token}';
-                        request.files.add(
-                          http.MultipartFile.fromBytes(
-                            'file',
-                            selectedBytes!,
-                            filename: 'workspace.tar.gz',
-                          ),
-                        );
-                        final streamed = await request.send();
-                        final resp = await http.Response.fromStream(streamed);
-                        if (resp.statusCode == 200 || resp.statusCode == 201) {
-                          if (context.mounted) {
-                            Navigator.pop(context, true);
-                          }
-                        } else {
-                          String detail;
-                          try {
-                            detail = (jsonDecode(resp.body) as Map)['detail']
-                                    as String? ??
-                                '${resp.statusCode}';
-                          } catch (_) {
-                            detail = '${resp.statusCode}';
-                          }
-                          setDialogState(() {
-                            importing = false;
-                            errorMessage = 'Import failed: $detail';
-                          });
-                        }
-                      } catch (_) {
-                        setDialogState(() {
-                          importing = false;
-                          errorMessage = 'Import failed';
-                        });
-                      }
-                    },
-              child: importing
-                  ? const SizedBox(
-                      width: 16,
-                      height: 16,
-                      child: CircularProgressIndicator(
-                        strokeWidth: 2,
-                        color: Colors.white,
-                      ),
-                    )
-                  : const Text('Import'),
-            ),
-          ],
-        ),
-      ),
+      builder: (context) => ImportWorkspaceDialog(auth: _auth),
     );
 
     if (imported == true) {
       await _loadWorkspaces();
     }
   }
-  // coverage:ignore-end
 
   Future<void> _deleteWorkspace(String id) async {
     final confirmed = await showDialog<bool>(
@@ -795,7 +652,7 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
                   children: [
                     FloatingActionButton.small(
                       heroTag: 'import',
-                      onPressed: _showImportDialog, // coverage:ignore-line
+                      onPressed: _showImportDialog,
                       tooltip: 'Import Workspace',
                       child: const Icon(Icons.upload),
                     ),

--- a/src/frontend/test/import_workspace_dialog_test.dart
+++ b/src/frontend/test/import_workspace_dialog_test.dart
@@ -1,0 +1,335 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:klangk_frontend/auth/auth_service.dart';
+import 'package:klangk_frontend/workspace/import_workspace_dialog.dart';
+import 'package:klangk_plugin_api/klangk_plugin_api.dart';
+
+void main() {
+  setUp(() {
+    testBaseUrlOverride = 'http://localhost:8997';
+    SharedPreferences.setMockInitialValues({});
+    testPickFileBytesOverride = null;
+  });
+
+  tearDown(() {
+    testBaseUrlOverride = null;
+    testAuthHttpClientOverride = null;
+    testPickFileBytesOverride = null;
+  });
+
+  http.Client mockClient(Future<http.Response> Function(http.Request) handler) {
+    return MockClient((request) async {
+      if (request.url.path.contains('/api/v1/config')) {
+        return http.Response(
+          jsonEncode({'login_banner_title': '', 'login_banner': ''}),
+          200,
+        );
+      }
+      if (request.url.path.contains('/api/v1/my-permissions')) {
+        return http.Response(
+          jsonEncode({
+            'user_id': 'test',
+            'email': 'test@example.com',
+            'permissions': {},
+            'groups': [],
+          }),
+          200,
+        );
+      }
+      return handler(request);
+    });
+  }
+
+  Widget buildDialog({AuthService? auth}) {
+    final a = auth ?? AuthService();
+    return MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (context) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              showDialog(
+                context: context,
+                builder: (_) => ImportWorkspaceDialog(auth: a),
+              );
+            });
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+  }
+
+  group('ImportWorkspaceDialog', () {
+    testWidgets('renders title, buttons, and file picker', (tester) async {
+      testAuthHttpClientOverride = mockClient(
+        (_) async => http.Response('Not found', 404),
+      );
+      await tester.pumpWidget(buildDialog());
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('Import Workspace'), findsOneWidget);
+      expect(find.text('Cancel'), findsOneWidget);
+      expect(find.text('Import'), findsOneWidget);
+      expect(find.text('Select .tar.gz file'), findsOneWidget);
+      expect(find.byType(TextField), findsOneWidget);
+    });
+
+    testWidgets('Import button disabled without file', (tester) async {
+      testAuthHttpClientOverride = mockClient(
+        (_) async => http.Response('Not found', 404),
+      );
+      await tester.pumpWidget(buildDialog());
+      await tester.pump();
+      await tester.pump();
+
+      final importButton = tester.widget<FilledButton>(
+        find.widgetWithText(FilledButton, 'Import'),
+      );
+      expect(importButton.onPressed, isNull);
+    });
+
+    testWidgets('file picker sets bytes and shows size', (tester) async {
+      testAuthHttpClientOverride = mockClient(
+        (_) async => http.Response('Not found', 404),
+      );
+      testPickFileBytesOverride = ({String accept = ''}) async {
+        return List<int>.filled(2048, 0);
+      };
+
+      await tester.pumpWidget(buildDialog());
+      await tester.pump();
+      await tester.pump();
+
+      await tester.tap(find.text('Select .tar.gz file'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('workspace.tar.gz'), findsOneWidget);
+      expect(find.text('2 KB'), findsOneWidget);
+
+      // Import button should now be enabled
+      final importButton = tester.widget<FilledButton>(
+        find.widgetWithText(FilledButton, 'Import'),
+      );
+      expect(importButton.onPressed, isNotNull);
+    });
+
+    testWidgets('file picker returning null does not change state',
+        (tester) async {
+      testAuthHttpClientOverride = mockClient(
+        (_) async => http.Response('Not found', 404),
+      );
+      testPickFileBytesOverride = ({String accept = ''}) async => null;
+
+      await tester.pumpWidget(buildDialog());
+      await tester.pump();
+      await tester.pump();
+
+      await tester.tap(find.text('Select .tar.gz file'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Select .tar.gz file'), findsOneWidget);
+      final importButton = tester.widget<FilledButton>(
+        find.widgetWithText(FilledButton, 'Import'),
+      );
+      expect(importButton.onPressed, isNull);
+    });
+
+    testWidgets('successful import closes dialog with true', (tester) async {
+      testAuthHttpClientOverride = mockClient((request) async {
+        if (request.url.path == '/api/v1/workspaces/import') {
+          return http.Response(
+            jsonEncode({'id': 'ws-imp', 'name': 'Imported'}),
+            200,
+          );
+        }
+        return http.Response('Not found', 404);
+      });
+      testPickFileBytesOverride = ({String accept = ''}) async {
+        return [1, 2, 3];
+      };
+
+      await tester.pumpWidget(buildDialog());
+      await tester.pump();
+      await tester.pump();
+
+      // Pick file
+      await tester.tap(find.text('Select .tar.gz file'));
+      await tester.pumpAndSettle();
+
+      // Tap Import
+      await tester.tap(find.text('Import'));
+      await tester.pumpAndSettle();
+
+      // Dialog should be closed
+      expect(find.text('Import Workspace'), findsNothing);
+    });
+
+    testWidgets('import with custom name sends query param', (tester) async {
+      String? requestedUrl;
+      testAuthHttpClientOverride = mockClient((request) async {
+        if (request.url.path == '/api/v1/workspaces/import') {
+          requestedUrl = request.url.toString();
+          return http.Response(
+            jsonEncode({'id': 'ws-imp', 'name': 'Custom'}),
+            200,
+          );
+        }
+        return http.Response('Not found', 404);
+      });
+      testPickFileBytesOverride = ({String accept = ''}) async => [1, 2, 3];
+
+      await tester.pumpWidget(buildDialog());
+      await tester.pump();
+      await tester.pump();
+
+      await tester.tap(find.text('Select .tar.gz file'));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), 'Custom Name');
+      await tester.tap(find.text('Import'));
+      await tester.pumpAndSettle();
+
+      expect(requestedUrl, contains('name=Custom%20Name'));
+    });
+
+    testWidgets('import failure shows error message', (tester) async {
+      testAuthHttpClientOverride = mockClient((request) async {
+        if (request.url.path == '/api/v1/workspaces/import') {
+          return http.Response(
+            jsonEncode({'detail': 'Archive is corrupt'}),
+            400,
+          );
+        }
+        return http.Response('Not found', 404);
+      });
+      testPickFileBytesOverride = ({String accept = ''}) async => [1, 2, 3];
+
+      await tester.pumpWidget(buildDialog());
+      await tester.pump();
+      await tester.pump();
+
+      await tester.tap(find.text('Select .tar.gz file'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Import'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Import failed: Archive is corrupt'), findsOneWidget);
+    });
+
+    testWidgets('import failure without detail shows status code',
+        (tester) async {
+      testAuthHttpClientOverride = mockClient((request) async {
+        if (request.url.path == '/api/v1/workspaces/import') {
+          return http.Response('not json', 500);
+        }
+        return http.Response('Not found', 404);
+      });
+      testPickFileBytesOverride = ({String accept = ''}) async => [1, 2, 3];
+
+      await tester.pumpWidget(buildDialog());
+      await tester.pump();
+      await tester.pump();
+
+      await tester.tap(find.text('Select .tar.gz file'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Import'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Import failed: 500'), findsOneWidget);
+    });
+
+    testWidgets('network exception shows generic error', (tester) async {
+      testAuthHttpClientOverride = mockClient((request) async {
+        if (request.url.path == '/api/v1/workspaces/import') {
+          throw Exception('Connection refused');
+        }
+        return http.Response('Not found', 404);
+      });
+      testPickFileBytesOverride = ({String accept = ''}) async => [1, 2, 3];
+
+      await tester.pumpWidget(buildDialog());
+      await tester.pump();
+      await tester.pump();
+
+      await tester.tap(find.text('Select .tar.gz file'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Import'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Import failed'), findsOneWidget);
+    });
+
+    testWidgets('cancel closes dialog', (tester) async {
+      testAuthHttpClientOverride = mockClient(
+        (_) async => http.Response('Not found', 404),
+      );
+      await tester.pumpWidget(buildDialog());
+      await tester.pump();
+      await tester.pump();
+
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Import Workspace'), findsNothing);
+    });
+
+    testWidgets('import failure with null detail shows status code',
+        (tester) async {
+      testAuthHttpClientOverride = mockClient((request) async {
+        if (request.url.path == '/api/v1/workspaces/import') {
+          return http.Response(
+            jsonEncode({'detail': null}),
+            400,
+          );
+        }
+        return http.Response('Not found', 404);
+      });
+      testPickFileBytesOverride = ({String accept = ''}) async => [1, 2, 3];
+
+      await tester.pumpWidget(buildDialog());
+      await tester.pump();
+      await tester.pump();
+
+      await tester.tap(find.text('Select .tar.gz file'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Import'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Import failed: 400'), findsOneWidget);
+    });
+
+    testWidgets('201 status also closes dialog', (tester) async {
+      testAuthHttpClientOverride = mockClient((request) async {
+        if (request.url.path == '/api/v1/workspaces/import') {
+          return http.Response(
+            jsonEncode({'id': 'ws-imp', 'name': 'Created'}),
+            201,
+          );
+        }
+        return http.Response('Not found', 404);
+      });
+      testPickFileBytesOverride = ({String accept = ''}) async => [1, 2, 3];
+
+      await tester.pumpWidget(buildDialog());
+      await tester.pump();
+      await tester.pump();
+
+      await tester.tap(find.text('Select .tar.gz file'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Import'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Import Workspace'), findsNothing);
+    });
+  });
+}

--- a/src/frontend/test/workspace_list_page_test.dart
+++ b/src/frontend/test/workspace_list_page_test.dart
@@ -9,6 +9,7 @@ import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:klangk_frontend/auth/auth_service.dart';
 import 'package:klangk_frontend/workspace/workspace_list_page.dart';
+import 'package:klangk_frontend/workspace/import_workspace_dialog.dart';
 import 'package:klangk_frontend/theme/colors.dart';
 import 'package:klangk_frontend/ws/ws_client.dart';
 import 'package:klangk_frontend/widgets/klangk_logo.dart';
@@ -121,6 +122,7 @@ void main() {
   tearDown(() {
     testBaseUrlOverride = null;
     testAuthHttpClientOverride = null;
+    testPickFileBytesOverride = null;
   });
 
   String makeJwt(Map<String, dynamic> payload) {
@@ -769,6 +771,83 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.textContaining('No workspaces'), findsOneWidget);
+    });
+
+    testWidgets('import FAB opens import workspace dialog', (tester) async {
+      testAuthHttpClientOverride = withPermissions((request) async {
+        if (request.url.path == '/api/v1/workspaces' &&
+            request.method == 'GET') {
+          return http.Response(jsonEncode(_envelope([])), 200);
+        }
+        return http.Response('Not found', 404);
+      });
+
+      await tester.pumpWidget(buildPage());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byTooltip('Import Workspace'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Import Workspace'), findsOneWidget);
+      expect(find.text('Select .tar.gz file'), findsOneWidget);
+      expect(find.text('Cancel'), findsOneWidget);
+      expect(find.text('Import'), findsOneWidget);
+
+      // Cancel closes it
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Import Workspace'), findsNothing);
+    });
+
+    testWidgets('successful import refreshes workspace list', (tester) async {
+      var importCalled = false;
+      testAuthHttpClientOverride = withPermissions((request) async {
+        if (request.url.path == '/api/v1/workspaces' &&
+            request.method == 'GET') {
+          if (importCalled) {
+            return http.Response(
+              jsonEncode(_envelope([
+                {
+                  'id': 'ws-imp',
+                  'name': 'Imported WS',
+                  'container_id': null,
+                  'created_at': '2026-06-29',
+                },
+              ])),
+              200,
+            );
+          }
+          return http.Response(jsonEncode(_envelope([])), 200);
+        }
+        if (request.url.path == '/api/v1/workspaces/import' &&
+            request.method == 'POST') {
+          importCalled = true;
+          return http.Response(
+            jsonEncode({'id': 'ws-imp', 'name': 'Imported WS'}),
+            200,
+          );
+        }
+        return http.Response('Not found', 404);
+      });
+      testPickFileBytesOverride = ({String accept = ''}) async => [1, 2, 3];
+
+      await tester.pumpWidget(buildPage());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byTooltip('Import Workspace'));
+      await tester.pumpAndSettle();
+
+      // Pick a file
+      await tester.tap(find.text('Select .tar.gz file'));
+      await tester.pumpAndSettle();
+
+      // Tap Import
+      await tester.tap(find.text('Import'));
+      await tester.pumpAndSettle();
+
+      expect(importCalled, isTrue);
+      expect(find.text('Imported WS'), findsOneWidget);
     });
 
     testWidgets('shows delete button for each workspace', (tester) async {


### PR DESCRIPTION
## Summary

Closes #953.

- Extract the 149-line inlined `_showImportDialog` `StatefulBuilder` from `workspace_list_page.dart` into a standalone `ImportWorkspaceDialog` `StatefulWidget` in its own file
- Add `testPickFileBytesOverride` for test-injectable file picking (same pattern as `testHttpClientOverride`)
- Remove `coverage:ignore` from the import flow — now fully tested
- Add 10 tests for `ImportWorkspaceDialog` covering: rendering, file picking, successful import (200/201), failure with detail, failure with null detail, failure with non-JSON, network exception, cancel
- Add 2 tests to `workspace_list_page_test` for the import FAB: open/cancel and successful import that refreshes the list

## Test plan

- [x] `test-frontend` passes with 100% coverage
- [ ] CI passes