### PR TITLE
fix(devenv): resolve pubspec.yaml PLACEHOLDER during enterShell

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -405,6 +405,11 @@ in
     fi
 
 
+    # Ensure klangk_plugins stub exists so flutter commands work immediately
+    # in any shell session (not just after devenv up). The script is idempotent
+    # and skips if pubspec_overrides.yaml already exists.
+    bash "$DEVENV_ROOT/scripts/stub_dart_plugins.sh"
+
     # Generate prettierignore (not committed)
     cat > "$DEVENV_ROOT/.prettierignore" <<'PRETTIER'
     node_modules/


### PR DESCRIPTION
## Summary

Closes #1059.

- Run `stub_dart_plugins.sh` in `enterShell` so the `pubspec.yaml` PLACEHOLDER path for `klangk_plugins` is resolved on any `devenv shell` entry, not just during `devenv up`
- The script is idempotent — skips if `pubspec_overrides.yaml` already exists
- Flutter commands (`test-frontend`, `flutter pub get`, etc.) now work immediately in fresh worktrees and shell sessions

## Test plan

- [x] `test-frontend` passes in a fresh worktree without manual plugin setup
- [ ] CI passes