### PR TITLE
fix(frontend): clear stale presence/members/terminals on WebSocket disconnect

### DIFF
--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -358,6 +358,10 @@ class WsClient extends ChangeNotifier {
         _currentWorkspaceId = null;
         _defaultCommand = null;
         _userHome = null;
+        presenceUsers = [];
+        terminalWindows = [];
+        sharedTerminals = [];
+        workspaceMembers = [];
         final code = _channel?.closeCode;
         notifyListeners();
         if (code == 4001 || code == 4002) {
@@ -373,6 +377,10 @@ class WsClient extends ChangeNotifier {
         _connected = false;
         _pendingWorkspaceId ??= _currentWorkspaceId;
         _currentWorkspaceId = null;
+        presenceUsers = [];
+        terminalWindows = [];
+        sharedTerminals = [];
+        workspaceMembers = [];
         notifyListeners();
         final code = _channel?.closeCode;
         if (code == 4001 || code == 4002) {

--- a/src/frontend/test/ws_client_test.dart
+++ b/src/frontend/test/ws_client_test.dart
@@ -1236,6 +1236,96 @@ void main() {
       expect(client.currentWorkspaceId, isNull);
     });
 
+    test('server close clears stale presence and terminal data', () async {
+      // Populate data first
+      channel.serverSend({
+        'type': 'presence_list',
+        'users': [
+          {'user_id': 'u1', 'email': 'a@test.com'}
+        ],
+      });
+      channel.serverSend({
+        'type': 'terminal_windows',
+        'windows': [
+          {'index': 0, 'name': 'bash', 'active': true}
+        ],
+      });
+      channel.serverSend({
+        'type': 'shared_terminals',
+        'terminals': [
+          {
+            'name': 'dev',
+            'sessions': ['alice']
+          }
+        ],
+      });
+      channel.serverSend({
+        'type': 'workspace_members',
+        'members': [
+          {'user_id': 'u1', 'email': 'a@test.com', 'role': 'admin'}
+        ],
+      });
+      await Future.delayed(Duration.zero);
+      expect(client.presenceUsers, isNotEmpty);
+      expect(client.terminalWindows, isNotEmpty);
+      expect(client.sharedTerminals, isNotEmpty);
+      expect(client.workspaceMembers, isNotEmpty);
+
+      // Disconnect
+      channel.serverClose();
+      await Future.delayed(Duration.zero);
+
+      expect(client.presenceUsers, isEmpty);
+      expect(client.terminalWindows, isEmpty);
+      expect(client.sharedTerminals, isEmpty);
+      expect(client.workspaceMembers, isEmpty);
+    });
+
+    test('server error clears stale presence and terminal data', () async {
+      // Populate data first
+      channel.serverSend({
+        'type': 'presence_list',
+        'users': [
+          {'user_id': 'u1', 'email': 'a@test.com'}
+        ],
+      });
+      channel.serverSend({
+        'type': 'terminal_windows',
+        'windows': [
+          {'index': 0, 'name': 'bash', 'active': true}
+        ],
+      });
+      channel.serverSend({
+        'type': 'shared_terminals',
+        'terminals': [
+          {
+            'name': 'dev',
+            'sessions': ['alice']
+          }
+        ],
+      });
+      channel.serverSend({
+        'type': 'workspace_members',
+        'members': [
+          {'user_id': 'u1', 'email': 'a@test.com', 'role': 'admin'}
+        ],
+      });
+      await Future.delayed(Duration.zero);
+      expect(client.presenceUsers, isNotEmpty);
+      expect(client.terminalWindows, isNotEmpty);
+      expect(client.sharedTerminals, isNotEmpty);
+      expect(client.workspaceMembers, isNotEmpty);
+
+      // Error
+      channel.serverError(Exception('boom'));
+      await Future.delayed(Duration.zero);
+
+      expect(client.presenceUsers, isEmpty);
+      expect(client.terminalWindows, isEmpty);
+      expect(client.sharedTerminals, isEmpty);
+      expect(client.workspaceMembers, isEmpty);
+    });
+
     test('server error emits to error stream', () async {
       final errors = <String>[];
       client.errors.listen(errors.add);


### PR DESCRIPTION
## Summary
- Clear `presenceUsers`, `terminalWindows`, `sharedTerminals`, and `workspaceMembers` in both `onDone` and `onError` WebSocket handlers to prevent ghost data between disconnect and reconnect
- Adds tests for both disconnect paths

Closes #1070

## Test plan
- [x] `flutter test test/ws_client_test.dart` — 80/80 pass