### PR TITLE
fix(backend): snapshot state.connections before iteration (#1069)

### DIFF
--- a/src/backend/klangk_backend/wshandler/connection.py
+++ b/src/backend/klangk_backend/wshandler/connection.py
@@ -550,7 +550,7 @@ class Connection:
         # Update container_id on ALL connections to this workspace
         # so they don't try to exec into the old (removed) container.
         new_cid = self.container_id
-        for sock, conn in state.connections.items():
+        for sock, conn in list(state.connections.items()):
             if conn.workspace_id == workspace_id and conn is not self:
                 conn.container_id = new_cid
 
@@ -602,7 +602,7 @@ class Connection:
                     logger.warning("State save before shutdown failed: %s", e)
 
         # Clear container_id on ALL connections to prevent stale exec attempts.
-        for sock, conn_obj in state.connections.items():
+        for sock, conn_obj in list(state.connections.items()):
             if conn_obj.workspace_id == workspace_id:
                 conn_obj.container_id = None
 

--- a/src/backend/klangk_backend/wshandler/helpers.py
+++ b/src/backend/klangk_backend/wshandler/helpers.py
@@ -97,7 +97,7 @@ async def refresh_user_handle(user_id: str, new_handle: str) -> None:
     old_handle: str | None = None
     affected_workspaces: set[str] = set()
     user_email: str = ""
-    for conn in state.connections.values():
+    for conn in list(state.connections.values()):
         if conn.user["id"] == user_id:
             if old_handle is None:
                 old_handle = conn.user.get("handle", "")


### PR DESCRIPTION
## Summary
- Wrap `state.connections.items()` / `.values()` iterations in `list()` to prevent `RuntimeError: dictionary changed size during iteration` when connections change between `await` points
- Fixes three sites: `handle_restart_container`, `handle_shutdown_container`, and `refresh_user_handle`

Closes #1069

## Test plan
- [x] Backend tests pass (1932 passed)