### PR TITLE
fix(cli): wrap blocking SSH agent query in run_in_executor

### DIFF
--- a/src/cli/klangkc/client.py
+++ b/src/cli/klangkc/client.py
@@ -1024,7 +1024,10 @@ class _ShellSession:
                     "[ssh-agent] relay: got %d bytes from queue", len(data)
                 )
             try:
-                response = _query_local_ssh_agent(self.ssh_agent_sock, data)
+                loop = asyncio.get_event_loop()
+                response = await loop.run_in_executor(
+                    None, _query_local_ssh_agent, self.ssh_agent_sock, data
+                )
                 if response is not None:
                     if self._debug_agent:  # pragma: no cover
                         logger.info(


### PR DESCRIPTION
## Summary
- Wrap `_query_local_ssh_agent` call in `asyncio.run_in_executor()` so blocking socket I/O doesn't freeze the event loop during SSH agent queries (especially with hardware-token-backed keys)

Closes #1066

## Test plan
- [x] All 398 CLI tests pass with 100% coverage
- [x] SSH agent relay integration tests pass (real Unix socket exercise)