### PR TITLE
fix(cli): cancel all tasks in _TerminalSession.run() on failure

### DIFF
--- a/src/cli/klangkc/client.py
+++ b/src/cli/klangkc/client.py
@@ -1210,15 +1210,21 @@ class _TerminalSession(_ShellSession):
                 await self._send_resize()
 
     async def run(self) -> None:
-        tasks = [
+        coros = [
             self.stdin_loop(),
             self.stdout_loop(),
             self.resize_loop(),
             self.heartbeat_loop(),
         ]
         if self.ssh_agent_sock:
-            tasks.append(self.ssh_agent_relay_loop())
-        await asyncio.gather(*tasks)
+            coros.append(self.ssh_agent_relay_loop())
+        tasks = [asyncio.create_task(c) for c in coros]
+        try:
+            await asyncio.gather(*tasks)
+        finally:
+            for t in tasks:
+                t.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
 
 
 class _ExecSession(_ShellSession):

--- a/src/cli/tests/test_cli.py
+++ b/src/cli/tests/test_cli.py
@@ -2375,3 +2375,57 @@ class TestSendIgnoreClosed:
         ws.send = AsyncMock(side_effect=OSError("broken"))
         # Should not raise
         await _send_ignore_closed(ws, "hello")
+
+
+class TestTerminalSessionRunCancellation:
+    async def test_run_cancels_all_tasks_on_failure(self):
+        """Tasks must be cancelled when one raises, not left orphaned."""
+        from klangkc.client import _TerminalSession
+
+        ws = AsyncMock()
+
+        class DummyWriter:
+            def write(self, data):
+                pass
+
+            def flush(self):
+                pass
+
+        session = _TerminalSession(ws, 80, 24, stdout=DummyWriter())
+
+        boom = RuntimeError("stdin exploded")
+        cancelled = []
+
+        async def fake_stdin():
+            raise boom
+
+        async def fake_stdout():
+            try:
+                await asyncio.sleep(3600)
+            except asyncio.CancelledError:
+                cancelled.append("stdout")
+                raise
+
+        async def fake_resize():
+            try:
+                await asyncio.sleep(3600)
+            except asyncio.CancelledError:
+                cancelled.append("resize")
+                raise
+
+        async def fake_heartbeat():
+            try:
+                await asyncio.sleep(3600)
+            except asyncio.CancelledError:
+                cancelled.append("heartbeat")
+                raise
+
+        session.stdin_loop = fake_stdin
+        session.stdout_loop = fake_stdout
+        session.resize_loop = fake_resize
+        session.heartbeat_loop = fake_heartbeat
+
+        with pytest.raises(RuntimeError, match="stdin exploded"):
+            await session.run()
+
+        assert sorted(cancelled) == ["heartbeat", "resize", "stdout"]


### PR DESCRIPTION
## Summary

- Wrap `asyncio.gather(*tasks)` in `_TerminalSession.run()` with `try/finally` that cancels all tasks, preventing orphaned background tasks when one raises
- Add test verifying all sibling tasks are cancelled when one fails

Closes #1065