### PR TITLE
fix(frontend): clear chatHistory on chat_history to prevent duplicates (#1064)

### DIFF
--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -405,6 +405,7 @@ class WsClient extends ChangeNotifier {
   }
 
   void _onChatHistory(Map<String, dynamic> json) {
+    chatHistory.clear();
     final messages = json['messages'] as List? ?? [];
     for (final m in messages) {
       final msg = m as Map<String, dynamic>;

--- a/src/frontend/test/ws_client_test.dart
+++ b/src/frontend/test/ws_client_test.dart
@@ -1384,6 +1384,33 @@ void main() {
       expect(messages[1]['message'], 'second');
     });
 
+    test('chat_history clears existing messages before appending', () async {
+      // Regression: after reconnect, chat_history appended to the old list,
+      // causing duplicate messages in the UI.
+      channel.serverSend({
+        'type': 'chat_history',
+        'messages': [
+          {'id': 'msg-1', 'message': 'old', 'created_at': '2026-01-01'},
+        ],
+      });
+      await Future.delayed(Duration.zero);
+      expect(client.chatHistory.length, 1);
+
+      // Second chat_history (as sent on reconnect) must replace, not append.
+      channel.serverSend({
+        'type': 'chat_history',
+        'messages': [
+          {'id': 'msg-1', 'message': 'old', 'created_at': '2026-01-01'},
+          {'id': 'msg-2', 'message': 'new', 'created_at': '2026-01-02'},
+        ],
+      });
+      await Future.delayed(Duration.zero);
+      expect(client.chatHistory.length, 2,
+          reason: 'chat_history must clear before appending');
+      expect(client.chatHistory[0]['id'], 'msg-1');
+      expect(client.chatHistory[1]['id'], 'msg-2');
+    });
+
     test('chat_updated routed to chatMessages stream', () async {
       final messages = <Map<String, dynamic>>[];
       client.chatMessages.listen(messages.add);


### PR DESCRIPTION
## Summary
- Clear `chatHistory` in `_onChatHistory` before appending server messages so reconnects replace rather than duplicate chat entries
- Added regression test verifying second `chat_history` event replaces rather than appends

Closes #1064

## Test plan
- [x] Frontend tests pass (100% coverage)
- [x] New regression test for duplicate-on-reconnect scenario