### PR TITLE
fix(backend): add application-layer WebSocket receive timeout

### DIFF
--- a/src/backend/klangk_backend/wshandler/__init__.py
+++ b/src/backend/klangk_backend/wshandler/__init__.py
@@ -29,6 +29,7 @@ from .. import workspaces as workspaces  # noqa: F401
 from ._constants import (
     _MAX_INPUT_SIZE as _MAX_INPUT_SIZE,
     _SEND_QUEUE_SIZE as _SEND_QUEUE_SIZE,
+    _WS_RECEIVE_TIMEOUT as _WS_RECEIVE_TIMEOUT,
     _WS_DEBUG as _WS_DEBUG,
     _agent_conversations as _agent_conversations,
     _agent_tasks as _agent_tasks,
@@ -38,6 +39,7 @@ from ._constants import (
     bridge_idle_timeout as bridge_idle_timeout,
 )
 from .safe_websocket import (
+    ReceiveTimeoutError as ReceiveTimeoutError,
     SafeWebSocket as SafeWebSocket,
     SlowClientError as SlowClientError,
     _WS_ERRORS as _WS_ERRORS,

--- a/src/backend/klangk_backend/wshandler/_constants.py
+++ b/src/backend/klangk_backend/wshandler/_constants.py
@@ -22,6 +22,12 @@ _MAX_INPUT_SIZE = 65536
 # Max outbound messages before we declare the client too slow and close.
 _SEND_QUEUE_SIZE = 256
 
+# Seconds to wait for any inbound WebSocket message before assuming the
+# connection is dead.  The client sends heartbeats every 60 s, so 90 s
+# gives 50 % headroom.  This is a belt-and-suspenders guard on top of
+# uvicorn's protocol-level --ws-ping-interval / --ws-ping-timeout.
+_WS_RECEIVE_TIMEOUT = 90
+
 
 def bridge_idle_timeout() -> float:
     """Max seconds between streamed browser chunks before giving up.

--- a/src/backend/klangk_backend/wshandler/dispatch.py
+++ b/src/backend/klangk_backend/wshandler/dispatch.py
@@ -6,7 +6,7 @@ import logging
 from fastapi import WebSocket, WebSocketDisconnect
 
 from .. import auth
-from .safe_websocket import SafeWebSocket, SlowClientError
+from .safe_websocket import SafeWebSocket, SlowClientError, ReceiveTimeoutError
 from .helpers import send_error, _log_ws_msg
 from .session import state
 from .connection import Connection
@@ -125,6 +125,8 @@ async def handle_websocket(websocket: WebSocket) -> None:
         logger.info("WebSocket disconnected for user %s: %s", user["email"], e)
     except SlowClientError:
         logger.warning("Slow client dropped for user %s", user["email"])
+    except ReceiveTimeoutError:
+        logger.warning("Receive timeout for user %s", user["email"])
     except Exception as e:
         logger.exception("WebSocket error: %s", e)
     finally:

--- a/src/backend/klangk_backend/wshandler/safe_websocket.py
+++ b/src/backend/klangk_backend/wshandler/safe_websocket.py
@@ -5,7 +5,7 @@ import logging
 
 from fastapi import WebSocket, WebSocketDisconnect
 
-from ._constants import _SEND_QUEUE_SIZE
+from ._constants import _SEND_QUEUE_SIZE, _WS_RECEIVE_TIMEOUT
 
 logger = logging.getLogger(__name__)
 
@@ -14,9 +14,14 @@ class SlowClientError(Exception):
     """Raised when the outbound queue is full (client can't keep up)."""
 
 
+class ReceiveTimeoutError(Exception):
+    """Raised when no inbound message arrives within the deadline."""
+
+
 # Exceptions that indicate a dead or broken WebSocket connection.
 _WS_ERRORS = (
     SlowClientError,
+    ReceiveTimeoutError,
     WebSocketDisconnect,
     RuntimeError,
     ConnectionError,
@@ -99,7 +104,14 @@ class SafeWebSocket:
         await self._sock.accept()
 
     async def receive_text(self) -> str:
-        return await self._sock.receive_text()
+        try:
+            return await asyncio.wait_for(
+                self._sock.receive_text(), timeout=_WS_RECEIVE_TIMEOUT
+            )
+        except asyncio.TimeoutError:
+            raise ReceiveTimeoutError(
+                f"no message received for {_WS_RECEIVE_TIMEOUT}s"
+            )
 
     async def close(self, code: int = 1000) -> None:
         await self._sock.close(code=code)

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -33,6 +33,7 @@ from klangk_backend.wshandler import (
     ExecController,
     SafeWebSocket,
     SharedTerminalController,
+    ReceiveTimeoutError,
     SlowClientError,
     SshAgentForwarder,
     TerminalController,
@@ -7403,6 +7404,42 @@ class TestSendQueueBehavior:
         with patch.object(container.registry, "record_activity"):
             await conn.forward_exec_output(session)
         # Should not raise
+
+
+class TestReceiveTimeout:
+    """Tests for application-layer receive timeout on ghost connections."""
+
+    async def test_receive_text_raises_on_timeout(self):
+        """SafeWebSocket.receive_text raises ReceiveTimeoutError when idle."""
+        raw = AsyncMock()
+
+        async def hang_forever():
+            await asyncio.sleep(3600)
+
+        raw.receive_text = hang_forever
+        sw = SafeWebSocket(raw)
+        with patch(
+            "klangk_backend.wshandler.safe_websocket._WS_RECEIVE_TIMEOUT", 0.05
+        ):
+            with pytest.raises(ReceiveTimeoutError):
+                await sw.receive_text()
+
+    async def test_timeout_closes_connection(self, user):
+        """handle_websocket exits cleanly on ReceiveTimeoutError."""
+        from klangk_backend import auth as auth_mod
+
+        token = auth_mod.create_token(user["id"], user["email"])
+        websocket = _mock_raw_sock(query_params={"token": token})
+
+        async def hang_forever():
+            await asyncio.sleep(3600)
+
+        websocket.receive_text = hang_forever
+
+        with patch(
+            "klangk_backend.wshandler.safe_websocket._WS_RECEIVE_TIMEOUT", 0.05
+        ):
+            await asyncio.wait_for(handle_websocket(websocket), timeout=5.0)
 
 
 class TestMentionsAgent:


### PR DESCRIPTION
## Summary
- Add 90-second receive timeout to `SafeWebSocket.receive_text()` so ghost connections (laptop close, network drop without TCP RST) are detected and cleaned up
- New `ReceiveTimeoutError` exception, handled in `handle_websocket` dispatch loop alongside existing `SlowClientError`
- Complements uvicorn's protocol-level `--ws-ping-interval 20 --ws-ping-timeout 20` as defense-in-depth

Closes #1063

## Test plan
- [x] All 1936 backend tests pass with 100% coverage
- [x] New tests: `receive_text` raises `ReceiveTimeoutError` on idle, `handle_websocket` exits cleanly on timeout