### PR TITLE
fix(backend): call conn.cleanup() for dead sockets in broadcast methods

### DIFF
--- a/src/backend/klangk_backend/wshandler/session.py
+++ b/src/backend/klangk_backend/wshandler/session.py
@@ -474,9 +474,10 @@ class WebSocketState:
             try:
                 sock.send_json(message)
             except _WS_ERRORS:
-                dead.append(sock)
-        for sock in dead:
+                dead.append((sock, conn))
+        for sock, conn in dead:
             self.connections.pop(sock, None)
+            asyncio.create_task(conn.cleanup())
 
     def notify_user_workspaces_changed(self, user_id: str) -> None:
         """Send ``workspaces_changed`` to all of a user's connections.
@@ -494,9 +495,10 @@ class WebSocketState:
             try:
                 sock.send_json(message)
             except _WS_ERRORS:
-                dead.append(sock)
-        for sock in dead:
+                dead.append((sock, conn))
+        for sock, conn in dead:
             self.connections.pop(sock, None)
+            asyncio.create_task(conn.cleanup())
 
     def handle_browser_response(
         self, msg: dict, sender: SafeWebSocket | None = None

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -3948,16 +3948,17 @@ class TestNotifyUserWorkspacesChanged:
         # Should not raise when the user has no active connections.
         wshandler.state.notify_user_workspaces_changed("nobody")
 
-    def test_dead_socket_is_pruned(self):
+    async def test_dead_socket_is_pruned(self):
         from klangk_backend.wshandler import _WS_ERRORS
 
         sock = _mock_sock()
-        # A send that raises a websocket error simulates a dead client.
         sock.send_json = MagicMock(side_effect=_WS_ERRORS[0]("dead"))
         try:
-            self._register(sock, {"id": "uid-1", "email": "a@x"})
-            wshandler.state.notify_user_workspaces_changed("uid-1")
-            # The dead connection was removed from the registry.
+            conn = self._register(sock, {"id": "uid-1", "email": "a@x"})
+            with patch.object(conn, "cleanup", new_callable=AsyncMock) as mock:
+                wshandler.state.notify_user_workspaces_changed("uid-1")
+                await asyncio.sleep(0)
+                mock.assert_awaited_once()
             assert sock not in wshandler.state.connections
         finally:
             wshandler.state.connections.pop(sock, None)
@@ -4009,14 +4010,17 @@ class TestNotifyContainerStatus:
             wshandler.state.connections.pop(sock, None)
         sock.send_json.assert_not_called()
 
-    def test_dead_socket_is_pruned(self):
+    async def test_dead_socket_is_pruned(self):
         from klangk_backend.wshandler import _WS_ERRORS
 
         sock = _mock_sock()
         sock.send_json = MagicMock(side_effect=_WS_ERRORS[0]("dead"))
         try:
-            self._register(sock, {"id": "uid-1", "email": "a@x"})
-            wshandler.state.notify_container_status("ws-1", True)
+            conn = self._register(sock, {"id": "uid-1", "email": "a@x"})
+            with patch.object(conn, "cleanup", new_callable=AsyncMock) as mock:
+                wshandler.state.notify_container_status("ws-1", True)
+                await asyncio.sleep(0)
+                mock.assert_awaited_once()
             assert sock not in wshandler.state.connections
         finally:
             wshandler.state.connections.pop(sock, None)


### PR DESCRIPTION
## Summary

- Schedule `conn.cleanup()` via `asyncio.create_task` when dead sockets are pruned in `notify_container_status` and `notify_user_workspaces_changed`, preventing leaked terminal/exec sessions, SSH agents, and stale presence state
- Update existing dead-socket tests to verify cleanup is called

Closes #1062