### PR TITLE
feat: health-check-aware monitoring and klangkc monitor (#1015)

### DIFF
--- a/docs/features/auto-start.md
+++ b/docs/features/auto-start.md
@@ -68,18 +68,22 @@ alongside the running service.
 ## Typical setup
 
 A service workspace usually combines auto-start with a default
-command:
+command, and often a health check to confirm the service is actually
+serving:
 
 ```yaml
 workspace:
   default-command: openclaw gateway
   auto-start: true
+  health-check: curl -sf http://localhost:8080/health
 ```
 
 This gives you:
 
 1. Server starts → container starts → `openclaw gateway` runs
-2. User runs `klangkc shell my-service` → sees gateway output
-3. User runs `klangkc shell my-service shell` → gets a bash prompt
+2. Health check confirms the gateway is responding — see
+   [Health Check](health-check.md)
+3. User runs `klangkc shell my-service` → sees gateway output
+4. User runs `klangkc shell my-service shell` → gets a bash prompt
    in a separate tmux window
-4. Ctrl+C in the gateway window stops it; up-arrow + Enter restarts
+5. Ctrl+C in the gateway window stops it; up-arrow + Enter restarts

--- a/docs/features/health-check.md
+++ b/docs/features/health-check.md
@@ -1,0 +1,186 @@
+<!-- markdownlint-disable MD013 -->
+
+# Health Check
+
+A workspace can have a **health check** — a shell command that Klangk
+runs inside the container at regular intervals to tell whether the
+service running there is actually healthy. Without one, a running
+container only proves the container is alive; it says nothing about
+the process inside it.
+
+Health checks are most useful for **service workspaces** that
+combine two other features:
+
+- an **[Auto-start](auto-start.md)** workspace whose container boots
+  on server startup (before any user connects), and
+- a **[Default Command](default-command.md)** that launches a
+  long-running process (a dev server, AI gateway, daemon).
+
+In that combination the container is up and the process is launched
+unattended — the health check is what turns "the container is
+running" into "the service inside it is actually responding." For an
+interactive workspace where you're already in the terminal watching
+the output, a health check adds little; for an auto-started service
+no one is watching, it's the difference between _available_ and
+_known-good_.
+
+Less essential, but still handy: a health check lets a shared
+workspace's other members see at a glance (via the status icon and
+`GET /api/v1/workspaces/{id}/status`) whether the service is up,
+without opening a terminal.
+
+## How it works
+
+Klangk polls container health from **outside** the container using
+`podman exec`. There is no agent baked into the container image and no
+extra connection back to the server — the container stays a clean
+sandbox that knows nothing about Klangk internals.
+
+For each workspace with a health check configured:
+
+1. Every 30 seconds (configurable), Klangk runs your health check
+   command inside the container as the creating user, with that user's
+   `HOME` set.
+2. **Exit code 0 = healthy.** Any non-zero exit code, a timeout, or an
+   error counts as **unhealthy**.
+3. When the status changes, every connected client gets a
+   `service_health` event so the UI can update in real time.
+4. The current status and the time of the last check are exposed via
+   `GET /api/v1/workspaces/{id}/status`.
+
+The check runs through `sh -c "<your command>"`, so any shell syntax
+works — pipes, `&&`, redirects, etc.
+
+### When checks are skipped
+
+Health checks are deliberately conservative:
+
+- **No health check configured** — nothing is polled; status stays
+  `null` (unknown).
+- **Setup not finished** — checks are skipped until the workspace's
+  [`setup_state`](sandbox.md#setup-scripts) is `complete`. Polling
+  during setup would report false negatives (the service isn't running
+  yet because `setup.sh` hasn't installed it).
+- **Container stopped/removed** — its health state goes away with the
+  container.
+
+### Informational only
+
+Health status is **informational only**. Klangk does not automatically
+restart an unhealthy container. Auto-restart may build on this later.
+
+## Seeing health status
+
+Health is surfaced in several places so a failing service is hard to
+miss:
+
+- **Web UI** — the workspace list shows a health-colored icon (green =
+  healthy, amber = unhealthy, grey = stopped), updated live as checks run.
+  The **Settings** tab shows the configured check command.
+- **`GET /api/v1/workspaces/{id}/status`** — returns `health` plus the
+  time of the last check (`health_checked_at`).
+- **`klangkc monitor`** — stream events and optionally **run a command**
+  when something changes. This is the automation hook.
+
+### Reacting to failures automatically with `klangkc monitor`
+
+`klangkc monitor` connects to the server and receives the same events
+the web UI does — health transitions, container starts/stops, workspace
+changes — and can run a command for each one. The event JSON is piped
+to the command's stdin, and details are exposed as environment
+variables (`KLANGK_EVENT_TYPE`, `KLANGK_WORKSPACE_ID`, `KLANGK_HEALTHY`).
+
+Fire a desktop notification when a service goes unhealthy:
+
+```bash
+klangkc monitor --type service_health -- \
+  sh -c '[ "$KLANGK_HEALTHY" = false ] && notify-send "klangk" "Service unhealthy"'
+```
+
+Page yourself (or a Slack webhook) on any health change:
+
+```bash
+klangkc monitor --type service_health --workspace $WS_ID -- \
+  sh -c 'curl -s -d "klangk health: $KLANGK_HEALTHY" https://hooks.example.com/alerts'
+```
+
+Just watch the stream (pipe to `jq`):
+
+```bash
+klangkc monitor --type service_health | jq .
+```
+
+`monitor` reconnects automatically — by default forever, with capped
+exponential backoff — and refreshes its login token on auth failures,
+so it survives server restarts and token expiry as a long-running
+daemon. Bound it with `--max-reconnects N`, or disable reconnect with
+`--no-reconnect`. See `klangkc monitor --help`.
+
+## Setting the health check
+
+### Web UI
+
+Set the health check when creating a workspace, or change it later in
+the workspace **Settings** tab.
+
+### CLI
+
+```bash
+# Set during creation
+klangkc create my-service --health-check 'curl -sf http://localhost:8080/health'
+
+# Change it later
+klangkc edit my-service --health-check 'pgrep -f "openclaw gateway"'
+
+# Clear it
+klangkc edit my-service --health-check ''
+```
+
+### Sandbox config
+
+In `.klangk-sandbox.yaml` (see [Sandbox](sandbox.md)):
+
+```yaml
+workspace:
+  health-check: curl -sf http://localhost:8080/health
+```
+
+## Example commands
+
+A health check is any command that exits 0 when things are good:
+
+```yaml
+# HTTP health endpoint
+curl -sf http://localhost:8080/health
+
+# Process is running
+pgrep -f 'openclaw gateway'
+
+# A unix socket exists
+test -S /tmp/my.sock
+
+# A port is accepting connections
+nc -z localhost 5432
+```
+
+## Server tuning
+
+The polling interval and the per-check timeout are configurable via
+environment variables on the server:
+
+| Variable                       | Default | Description                                                                 |
+| ------------------------------ | ------- | --------------------------------------------------------------------------- |
+| `KLANGK_HEALTH_CHECK_INTERVAL` | `30`    | Seconds between polls for each workspace.                                   |
+| `KLANGK_HEALTH_CHECK_TIMEOUT`  | `10`    | Seconds before a single `podman exec` check is killed and marked unhealthy. |
+
+`podman exec` is a local Unix socket call to the Podman API, not a
+network round-trip, so running a check every 30 seconds per container
+is negligible overhead.
+
+## Related
+
+- [Default Command](default-command.md) — the command that usually
+  runs the service being health-checked.
+- [Auto-start](auto-start.md) — start service workspaces on server
+  boot.
+- [Sandbox](sandbox.md) — the `workspace.health-check` config field.

--- a/docs/features/sandbox.md
+++ b/docs/features/sandbox.md
@@ -70,13 +70,15 @@ workspace:
   image: klangk-workspace
   default-command: openclaw gateway
   auto-start: true
+  health-check: curl -sf http://localhost:8080/health
 ```
 
-| Field             | Required | Default              | Description                                                                                                            |
-| ----------------- | -------- | -------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| `image`           | no       | server default image | Container image. Must be in the server's allowed images list.                                                          |
-| `default-command` | no       | (none)               | Command to run automatically in the first terminal window on first connect. See [Default Command](default-command.md). |
-| `auto-start`      | no       | `false`              | Start the container automatically when the Klangk server starts. See [Auto-start](workspaces.md#auto-start).           |
+| Field             | Required | Default              | Description                                                                                                                |
+| ----------------- | -------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `image`           | no       | server default image | Container image. Must be in the server's allowed images list.                                                              |
+| `default-command` | no       | (none)               | Command to run automatically in the first terminal window on first connect. See [Default Command](default-command.md).     |
+| `auto-start`      | no       | `false`              | Start the container automatically when the Klangk server starts. See [Auto-start](workspaces.md#auto-start).               |
+| `health-check`    | no       | (none)               | Shell command polled inside the container to gauge service health (exit 0 = healthy). See [Health Check](health-check.md). |
 
 The workspace name is not in the config file — it's always
 specified as a positional argument on the command line.
@@ -324,6 +326,10 @@ and SSH access to GitHub:
 sandbox:
   mount-at: ~/klangk
   setup: setup.sh
+
+workspace:
+  default-command: openclaw gateway
+  health-check: pgrep -f 'openclaw gateway'
 
 copy:
   - ~/.gitconfig:~/.gitconfig

--- a/docs/features/workspaces.md
+++ b/docs/features/workspaces.md
@@ -21,6 +21,9 @@ optionally configure:
   Klangk server starts. Useful for service workspaces that should
   be running before any user connects. If the workspace also has a
   default command, it will already be running when you connect.
+- **Health check** — a shell command Klangk polls inside the
+  container to verify the service is actually healthy (exit 0 =
+  healthy). See [Health Check](health-check.md).
 - **Bind mounts** — mount host directories into the container.
   If `KLANGK_ALLOWED_MOUNT_ROOTS` is set (comma-separated list of
   paths), only directories under those roots can be bind-mounted.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -150,7 +150,8 @@ klangkc create my-project --auto-start   # create with auto-start on server boot
 klangkc create my-project --mount ~/src:/home/klangk/work/src          # with bind mount
 klangkc create my-project --mount nix-store:/nix           # with named volume
 klangkc create my-project --env FOO=bar                      # with env vars
-klangkc edit my-project                  # interactive edit (name, image, command, mounts, env)
+klangkc create my-project --health-check 'curl -sf http://localhost:8080/health'  # with a service health check
+klangkc edit my-project                  # interactive edit (name, image, command, health check, mounts, env)
 klangkc edit my-project --auto-start     # enable auto-start on server boot
 klangkc edit my-project --no-auto-start  # disable auto-start
 klangkc edit my-project --env FOO=bar    # set env var via flag
@@ -161,6 +162,9 @@ klangkc sandbox myws                     # create workspace from .klangk-sandbox
 klangkc sandbox myws ~/projects/myapp    # specify sandbox root explicitly
 klangkc sandbox myws --force             # re-apply config and re-run setup on existing workspace
 klangkc exec my-project ls /home/klangk/work         # run a command in the container
+klangkc monitor                                        # stream all server events as JSON
+klangkc monitor --type service_health | jq .           # pretty-print health transitions
+klangkc monitor --type service_health -- notify-send "Service unhealthy"  # react to unhealthy events
 klangkc sync ~/src my-project:/home/klangk/work      # sync files to/from the container
 klangkc rm my-project                # delete a workspace
 klangkc restart my-project           # restart the container for a workspace (owner only)

--- a/src/backend/klangk_backend/api/workspaces.py
+++ b/src/backend/klangk_backend/api/workspaces.py
@@ -8,6 +8,7 @@ import shutil
 import subprocess
 import tempfile
 import time
+from datetime import datetime, timezone
 from typing import Literal
 
 from fastapi import (
@@ -127,6 +128,7 @@ class CreateWorkspaceRequest(BaseModel):
     mounts: list[str] | None = None
     env: dict[str, str] | None = None
     setup_state: Literal["pending", "complete", "failed"] | None = None
+    health_check: str | None = None
 
 
 async def _grant_owner_and_create_role_groups(ws: dict, user_id: str) -> None:
@@ -212,6 +214,7 @@ async def create_workspace(
             mounts=body.mounts,
             env=body.env,
             setup_state=body.setup_state or "complete",
+            health_check=body.health_check,
         )
     except SAIntegrityError:
         raise HTTPException(
@@ -248,6 +251,7 @@ class UpdateWorkspaceRequest(BaseModel):
     mounts: list[str] | None = None
     env: dict[str, str] | None = None
     setup_state: Literal["pending", "complete", "failed"] | None = None
+    health_check: str | None = None
 
 
 @router.put("/workspaces/{workspace_id}")
@@ -286,6 +290,21 @@ async def update_workspace(
     )
     if not updated:
         raise HTTPException(status_code=404, detail="Workspace not found")
+
+    # Propagate health-relevant config changes to the live container
+    # state (#1015) so HealthMonitor picks them up without a container
+    # restart: setup_state may flip to "complete" after setup finishes,
+    # and health_check may be edited at any time.
+    live_state = container.registry.get_state(workspace_id)
+    if live_state is not None:
+        if "setup_state" in fields:
+            live_state.setup_state = fields["setup_state"]
+        if "health_check" in fields:
+            live_state.health_check = fields["health_check"] or None
+            # Reset the cached status so the next poll re-broadcasts.
+            live_state.health_status = None
+            live_state.health_checked_at = None
+
     return {"status": "updated"}
 
 
@@ -311,6 +330,7 @@ async def duplicate_workspace(
             auto_start=source.get("auto_start", False),
             mounts=source.get("mounts"),
             env=source.get("env"),
+            health_check=source.get("health_check"),
         )
     except SAIntegrityError:
         raise HTTPException(
@@ -412,6 +432,7 @@ async def workspace_status(
             "running": False,
             "container_id": None,
             "health": None,
+            "health_checked_at": None,
             "idle_seconds": None,
             "idle_timeout": None,
             "ports": [],
@@ -421,10 +442,23 @@ async def workspace_status(
     idle_timeout = live_state.get_idle_timeout()
     ports = await container.registry.get_workspace_ports(workspace_id)
 
+    # Map the internal status to the API shape.  ``health`` is None
+    # until the first check completes (or when no health_check is
+    # configured) (#1015).
+    health = live_state.health_status
+    checked_at = (
+        datetime.fromtimestamp(
+            live_state.health_checked_at, tz=timezone.utc
+        ).isoformat()
+        if live_state.health_checked_at is not None
+        else None
+    )
+
     return {
         "running": True,
         "container_id": live_state.container_id,
-        "health": None,  # placeholder for #1015
+        "health": health,
+        "health_checked_at": checked_at,
         "idle_seconds": round(idle_secs, 1),
         "idle_timeout": idle_timeout,
         "ports": ports,
@@ -591,6 +625,7 @@ def _extract_archive_metadata(archive_path: str, name: str | None) -> dict:
         "auto_start": metadata.get("auto_start", False),
         "mounts": mounts,
         "env": env,
+        "health_check": metadata.get("health_check"),
     }
 
 
@@ -655,6 +690,7 @@ async def import_workspace(
                 auto_start=meta["auto_start"],
                 mounts=meta["mounts"],
                 env=meta["env"],
+                health_check=meta["health_check"],
             )
         except SAIntegrityError:
             raise HTTPException(

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -180,6 +180,15 @@ PORT_RANGE_START = int(
 CONTAINER_PORT_START = 8000
 DEFAULT_PORTS_PER_WORKSPACE = 5
 
+# Health-check polling interval (seconds) for HealthMonitor.  See #1015.
+HEALTH_CHECK_INTERVAL_SECONDS = int(
+    util.resolve_env_value("KLANGK_HEALTH_CHECK_INTERVAL") or "30"
+)
+# Per-invocation timeout for a single `podman exec` health check.
+HEALTH_CHECK_TIMEOUT_SECONDS = float(
+    util.resolve_env_value("KLANGK_HEALTH_CHECK_TIMEOUT") or "10"
+)
+
 
 class ContainerState:
     """Per-workspace container lifecycle state."""
@@ -190,6 +199,13 @@ class ContainerState:
         self.last_activity = time.time()
         self.idle_timeout: int | None = None
         self.idle_callbacks: list = []
+        # Health-monitoring state (#1015).  Populated at container start
+        # time so HealthMonitor can poll without a DB lookup per tick.
+        self.health_status: str | None = None  # "healthy" | "unhealthy"
+        self.health_checked_at: float | None = None  # time.time() of last
+        self.health_check: str | None = None  # shell command, None = disabled
+        self.owner_id: str | None = None
+        self.setup_state: str | None = None
 
     def record_activity(self) -> None:
         self.last_activity = time.time()
@@ -373,13 +389,142 @@ class IdleMonitor:
             )
 
 
+class HealthMonitor:
+    """Periodically poll container service health via ``podman exec``.
+
+    Mirrors :class:`IdleMonitor` in shape.  For each workspace with a
+    running container and a configured ``health_check`` command, runs
+    the command inside the container as the creating user with their
+    HOME set.  Exit 0 -> healthy; anything else (non-zero, timeout,
+    error) -> unhealthy.  Status transitions are broadcast to
+    connected clients as ``service_health`` events.
+
+    See #1015 for the design rationale (external polling beats a
+    container-side WS agent here).
+    """
+
+    def __init__(self, registry: "ContainerRegistry") -> None:
+        self._registry = registry
+        self.health_task: asyncio.Task | None = None
+
+    def _setup_complete(self, state: ContainerState) -> bool:
+        """True if health checks may run for this workspace.
+
+        Checks are skipped until setup has finished (setup_state ==
+        "complete"); running them during setup would report false
+        negatives (the service isn't running yet because setup.sh
+        hasn't installed it).
+        """
+        return state.setup_state == "complete"
+
+    async def _run_one(self, state: ContainerState) -> str:
+        """Run a single workspace's health check, returning the new status.
+
+        Resolves the owner's container home (same logic as
+        ``eager_start_workspace``) and invokes the check via
+        ``podman exec`` as the creating user with HOME set.  Errors and
+        timeouts count as ``"unhealthy"``.
+        """
+        owner_id = state.owner_id
+        if owner_id is None:
+            return "unhealthy"
+        handle = await model.get_user_handle(owner_id)
+        if not handle:
+            return "unhealthy"
+        # Resolve the owner's container home the same way
+        # eager_start_workspace does, so the check runs in the right
+        # HOME rather than as root in /.
+        from . import workspaces as _wm  # noqa: allow-deferred-import
+
+        ws_home = _wm.home_path(owner_id, state.workspace_id)
+        user_home, _created = _wm.ensure_home_symlink(
+            ws_home, handle, owner_id
+        )
+        cid_short = state.container_id[:12]
+        logger.debug(
+            "Health check: container %s (workspace %s) running %r",
+            cid_short,
+            state.workspace_id,
+            state.health_check,
+        )
+        try:
+            rc, _out, _err = await podman.exec_container(
+                state.container_id,
+                ["sh", "-c", state.health_check],
+                user="klangk",
+                extra_env={"HOME": user_home},
+                timeout=HEALTH_CHECK_TIMEOUT_SECONDS,
+            )
+        except (podman.PodmanError, asyncio.TimeoutError, OSError) as e:
+            logger.info(
+                "Health check for container %s (workspace %s) failed: %s",
+                cid_short,
+                state.workspace_id,
+                e,
+            )
+            return "unhealthy"
+        logger.debug(
+            "Health check: container %s (workspace %s) exited %d",
+            cid_short,
+            state.workspace_id,
+            rc,
+        )
+        return "healthy" if rc == 0 else "unhealthy"
+
+    async def _check_workspace(self, state: ContainerState) -> None:
+        """Poll one workspace and broadcast on status transition."""
+        new_status = await self._run_one(state)
+        old_status = state.health_status
+        state.health_status = new_status
+        state.health_checked_at = time.time()
+        if new_status != old_status:
+            self._broadcast(state.workspace_id, new_status)
+
+    def _broadcast(self, workspace_id: str, status: str) -> None:
+        """Emit a ``service_health`` event to all connections.
+
+        Fanned out via :meth:`WsState.notify_service_health` so the
+        workspace list page learns about health transitions for
+        auto-started services even when nobody is connected to the
+        workspace's terminal session (#1015).
+        """
+        # Imported lazily to avoid an import cycle with wshandler.
+        from .wshandler import state as _ws_state  # noqa: allow-deferred-import
+
+        _ws_state.notify_service_health(
+            workspace_id, healthy=status == "healthy"
+        )
+
+    async def run_health_loop(self) -> None:
+        """Background loop: every interval, poll eligible workspaces."""
+        while True:
+            await asyncio.sleep(HEALTH_CHECK_INTERVAL_SECONDS)
+            for state in list(self._registry.states.values()):
+                if not state.health_check:
+                    continue
+                if not self._setup_complete(state):
+                    continue
+                try:
+                    await self._check_workspace(state)
+                except Exception as e:  # pragma: no cover - defensive
+                    logger.error(
+                        "Health check error for workspace %s: %s",
+                        state.workspace_id,
+                        e,
+                    )
+
+    def start_health_loop(self) -> None:
+        if self.health_task is None:
+            self.health_task = asyncio.create_task(self.run_health_loop())
+
+
 class ContainerRegistry:
     """Singleton managing all container state and podman interactions.
 
-    Composes :class:`PortAllocator`, :class:`BrowserRouter`, and
-    :class:`IdleMonitor` as collaborators.  Backward-compatible proxy
-    methods delegate to the collaborators so existing callers are
-    unchanged.
+    Composes :class:`PortAllocator`, :class:`BrowserRouter`,
+    :class:`IdleMonitor`, and :class:`HealthMonitor` as collaborators.
+    Backward-compatible proxy methods delegate to the collaborators so
+    existing callers are unchanged.
     """
 
     def __init__(self):
@@ -395,6 +540,7 @@ class ContainerRegistry:
         self.ports = PortAllocator()
         self.browsers = BrowserRouter()
         self.idle = IdleMonitor(self)
+        self.health = HealthMonitor(self)
 
     def workspace_id_for(self, container_id: str) -> str | None:
         """Return the workspace_id for a container, or None."""
@@ -408,7 +554,15 @@ class ContainerRegistry:
 
     # --- State tracking ---
 
-    def track_activity(self, container_id: str, workspace_id: str) -> None:
+    def track_activity(
+        self,
+        container_id: str,
+        workspace_id: str,
+        *,
+        health_check: str | None = None,
+        owner_id: str | None = None,
+        setup_state: str | None = None,
+    ) -> None:
         state = self.states.get(workspace_id)
         was_new = state is None
         if was_new:
@@ -421,6 +575,13 @@ class ContainerRegistry:
             state.container_id = container_id
         self._cid_to_wsid[container_id] = workspace_id
         state.record_activity()
+        # Health-monitoring metadata (#1015).  Always refresh so a
+        # config change (or a recreated container) is picked up.
+        state.health_check = health_check
+        if owner_id is not None:
+            state.owner_id = owner_id
+        if setup_state is not None:
+            state.setup_state = setup_state
         if was_new:
             self._notify_status_changed(workspace_id, True)
 
@@ -523,6 +684,15 @@ class ContainerRegistry:
     def start_cleanup_loop(self) -> None:
         self.idle.start_cleanup_loop()
 
+    # --- Proxy: HealthMonitor ---
+
+    @property
+    def health_task(self) -> asyncio.Task | None:
+        return self.health.health_task
+
+    def start_health_loop(self) -> None:
+        self.health.start_health_loop()
+
     # --- Container lifecycle ---
 
     async def start_container(
@@ -540,6 +710,8 @@ class ContainerRegistry:
         extra_mounts: list[str] | None = None,
         extra_env: dict[str, str] | None = None,
         user_id: str | None = None,
+        health_check: str | None = None,
+        setup_state: str | None = None,
     ) -> tuple[str, str]:
         """Start (or restart) a Pi container for a workspace.
 
@@ -564,6 +736,8 @@ class ContainerRegistry:
                 extra_mounts=extra_mounts,
                 extra_env=extra_env,
                 user_id=user_id,
+                health_check=health_check,
+                setup_state=setup_state,
             )
 
     async def _handle_existing_container(
@@ -571,6 +745,10 @@ class ContainerRegistry:
         existing_container_id: str,
         workspace_id: str,
         t_start: float,
+        *,
+        health_check: str | None = None,
+        owner_id: str | None = None,
+        setup_state: str | None = None,
     ) -> tuple[str, str] | None:
         """Check an existing container and reuse/remove it.
 
@@ -592,7 +770,13 @@ class ContainerRegistry:
             )
             return None
         if info["State"]["Running"]:
-            self.track_activity(existing_container_id, workspace_id)
+            self.track_activity(
+                existing_container_id,
+                workspace_id,
+                health_check=health_check,
+                owner_id=owner_id,
+                setup_state=setup_state,
+            )
             logger.info(
                 "workspace-open: DONE — container was already running, "
                 "no work needed: %.3fs",
@@ -734,6 +918,10 @@ class ContainerRegistry:
         publish: list[tuple[int, int]],
         allow_sudo: bool,
         create_kwargs: dict,
+        *,
+        health_check: str | None = None,
+        owner_id: str | None = None,
+        setup_state: str | None = None,
     ) -> str:
         """Create the container, persist it, start it, and configure it.
 
@@ -749,7 +937,13 @@ class ContainerRegistry:
             time.monotonic() - t_create,
         )
         await model.update_workspace_container(workspace_id, cid)
-        self.track_activity(cid, workspace_id)
+        self.track_activity(
+            cid,
+            workspace_id,
+            health_check=health_check,
+            owner_id=owner_id,
+            setup_state=setup_state,
+        )
         t_podman_start = time.monotonic()
         try:
             await podman.start_container(cid)
@@ -839,6 +1033,8 @@ class ContainerRegistry:
         extra_mounts: list[str] | None = None,
         extra_env: dict[str, str] | None = None,
         user_id: str | None = None,
+        health_check: str | None = None,
+        setup_state: str | None = None,
     ) -> tuple[str, str]:
         """Inner implementation of start_container (called under lock)."""
         t_start = time.monotonic()
@@ -852,7 +1048,12 @@ class ContainerRegistry:
         # Reuse a running container or remove a stopped one.
         if existing_container_id:
             result = await self._handle_existing_container(
-                existing_container_id, workspace_id, t_start
+                existing_container_id,
+                workspace_id,
+                t_start,
+                health_check=health_check,
+                owner_id=user_id,
+                setup_state=setup_state,
             )
             if result is not None:
                 return result
@@ -925,6 +1126,9 @@ class ContainerRegistry:
                 publish,
                 allow_sudo,
                 create_kwargs,
+                health_check=health_check,
+                owner_id=user_id,
+                setup_state=setup_state,
             )
         )
 
@@ -1044,6 +1248,13 @@ class ContainerRegistry:
             except asyncio.CancelledError:
                 pass
             self.cleanup_task = None
+        if self.health_task:
+            self.health_task.cancel()
+            try:
+                await self.health_task
+            except asyncio.CancelledError:
+                pass
+            self.health.health_task = None
         # Skip container cleanup when running inside a container
         # (developing klangk in klangk -- don't kill our own container).
         if os.path.exists("/.dockerenv") or os.path.exists(

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -268,6 +268,7 @@ async def lifespan(app: FastAPI):
     await container.registry.prewarm_podman()
     await container.registry.adopt_orphaned_containers()
     container.registry.start_cleanup_loop()
+    container.registry.start_health_loop()
     n = await workspaces.auto_start_workspaces()
     if n:  # pragma: no cover
         logger.info("Auto-started %d workspace(s)", n)

--- a/src/backend/klangk_backend/model/schema.py
+++ b/src/backend/klangk_backend/model/schema.py
@@ -83,6 +83,10 @@ async def init_db() -> None:
                 -- Descriptive, not proscriptive: a workspace is created
                 -- in whichever state matches reality (see #1033).
                 setup_state TEXT NOT NULL DEFAULT 'complete',
+                -- shell command polled via `podman exec` to gauge
+                -- service health inside the container (see #1015).
+                -- NULL means no health monitoring.
+                health_check TEXT,
                 mounts TEXT,  -- JSON array of host:container mount specs
                 env TEXT,  -- JSON dict of custom environment variables
                 created_at TEXT NOT NULL DEFAULT (datetime('now')),
@@ -104,6 +108,12 @@ async def init_db() -> None:
             await db.execute(
                 "ALTER TABLE workspaces"
                 " ADD COLUMN setup_state TEXT NOT NULL DEFAULT 'complete'"
+            )
+        # Migration: add health_check column (#1015). NULL by default
+        # so existing workspaces keep the no-health-monitoring behavior.
+        if "health_check" not in ws_cols:
+            await db.execute(
+                "ALTER TABLE workspaces ADD COLUMN health_check TEXT"
             )
         await db.execute("""
             CREATE TABLE IF NOT EXISTS port_allocations (

--- a/src/backend/klangk_backend/model/workspaces.py
+++ b/src/backend/klangk_backend/model/workspaces.py
@@ -31,6 +31,7 @@ async def create_workspace(
     mounts: list[str] | None = None,
     env: dict[str, str] | None = None,
     setup_state: str = SETUP_STATE_COMPLETE,
+    health_check: str | None = None,
 ) -> dict:
     if setup_state not in SETUP_STATES:
         raise ValueError(f"Invalid setup_state: {setup_state!r}")
@@ -42,8 +43,8 @@ async def create_workspace(
         await db.execute(
             "INSERT INTO workspaces"
             " (id, user_id, name, image, default_command, auto_start,"
-            " setup_state, mounts, env, created_at)"
-            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            " setup_state, health_check, mounts, env, created_at)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 workspace_id,
                 user_id,
@@ -52,6 +53,7 @@ async def create_workspace(
                 default_command,
                 1 if auto_start else 0,
                 setup_state,
+                health_check,
                 mounts_json,
                 env_json,
                 created_at,
@@ -65,6 +67,7 @@ async def create_workspace(
             "default_command": default_command,
             "auto_start": auto_start,
             "setup_state": setup_state,
+            "health_check": health_check,
             "mounts": mounts,
             "env": env,
             "num_ports": _DEFAULT_PORTS_PER_WORKSPACE,
@@ -116,7 +119,8 @@ async def list_workspaces(
     async with transaction() as db:
         cursor = await db.execute(
             "SELECT id, name, container_id, image, default_command,"
-            " auto_start, setup_state, mounts, env, created_at"
+            " auto_start, setup_state, health_check, mounts, env,"
+            " created_at"
             " FROM workspaces"
             f" {where} {order_by} LIMIT ? OFFSET ?",
             tuple(params),
@@ -131,6 +135,7 @@ async def list_workspaces(
                 "default_command": row["default_command"],
                 "auto_start": bool(row["auto_start"]),
                 "setup_state": row["setup_state"],
+                "health_check": row["health_check"],
                 "mounts": json.loads(row["mounts"]) if row["mounts"] else None,
                 "env": json.loads(row["env"]) if row["env"] else None,
                 "created_at": row["created_at"],
@@ -173,8 +178,9 @@ async def list_shared_workspaces(
         )
         cursor = await db.execute(
             "SELECT DISTINCT w.id, w.name, w.container_id, w.image,"
-            " w.default_command, w.auto_start, w.setup_state, w.mounts,"
-            " w.env, w.created_at, u.email AS owner_email"
+            " w.default_command, w.auto_start, w.setup_state,"
+            " w.health_check, w.mounts, w.env, w.created_at,"
+            " u.email AS owner_email"
             " FROM workspaces w"
             " JOIN acl_entries ae ON ae.resource = '/workspaces/' || w.id"
             " JOIN users u ON w.user_id = u.id"
@@ -205,6 +211,7 @@ async def list_shared_workspaces(
                 "default_command": row["default_command"],
                 "auto_start": bool(row["auto_start"]),
                 "setup_state": row["setup_state"],
+                "health_check": row["health_check"],
                 "mounts": json.loads(row["mounts"]) if row["mounts"] else None,
                 "env": json.loads(row["env"]) if row["env"] else None,
                 "created_at": row["created_at"],
@@ -232,14 +239,16 @@ async def get_workspace(
         if user_id is not None:
             cursor = await db.execute(
                 "SELECT id, user_id, name, container_id, num_ports, image,"
-                " default_command, auto_start, setup_state, mounts, env"
+                " default_command, auto_start, setup_state, health_check,"
+                " mounts, env"
                 " FROM workspaces WHERE id = ? AND user_id = ?",
                 (workspace_id, user_id),
             )
         else:
             cursor = await db.execute(
                 "SELECT id, user_id, name, container_id, num_ports, image,"
-                " default_command, auto_start, setup_state, mounts, env"
+                " default_command, auto_start, setup_state, health_check,"
+                " mounts, env"
                 " FROM workspaces WHERE id = ?",
                 (workspace_id,),
             )
@@ -256,6 +265,7 @@ async def get_workspace(
             "default_command": row["default_command"],
             "auto_start": bool(row["auto_start"]),
             "setup_state": row["setup_state"],
+            "health_check": row["health_check"],
             "mounts": json.loads(row["mounts"]) if row["mounts"] else None,
             "env": json.loads(row["env"]) if row["env"] else None,
         }
@@ -265,7 +275,7 @@ async def get_workspace_by_id(workspace_id: str) -> dict | None:
     """Get a workspace by ID without access control (for admin use)."""
     row = await _fetchone(
         "SELECT id, user_id, name, container_id, num_ports, image,"
-        " default_command, setup_state, mounts, env"
+        " default_command, setup_state, health_check, mounts, env"
         " FROM workspaces WHERE id = ?",
         (workspace_id,),
     )
@@ -280,6 +290,7 @@ async def get_workspace_by_id(workspace_id: str) -> dict | None:
         "image": row["image"],
         "default_command": row["default_command"],
         "setup_state": row["setup_state"],
+        "health_check": row["health_check"],
         "mounts": json.loads(row["mounts"]) if row["mounts"] else None,
         "env": json.loads(row["env"]) if row["env"] else None,
     }
@@ -381,6 +392,7 @@ async def update_workspace(
         "default_command",
         "auto_start",
         "setup_state",
+        "health_check",
         "mounts",
         "env",
     }
@@ -429,7 +441,8 @@ async def list_auto_start_workspaces() -> list[dict]:
     async with transaction() as db:
         cursor = await db.execute(
             "SELECT id, user_id, name, container_id, num_ports, image,"
-            " default_command, auto_start, setup_state, mounts, env"
+            " default_command, auto_start, setup_state, health_check,"
+            " mounts, env"
             " FROM workspaces WHERE auto_start = 1",
         )
         rows = await cursor.fetchall()
@@ -444,6 +457,7 @@ async def list_auto_start_workspaces() -> list[dict]:
                 "default_command": row["default_command"],
                 "auto_start": True,
                 "setup_state": row["setup_state"],
+                "health_check": row["health_check"],
                 "mounts": json.loads(row["mounts"]) if row["mounts"] else None,
                 "env": json.loads(row["env"]) if row["env"] else None,
             }

--- a/src/backend/klangk_backend/workspaces.py
+++ b/src/backend/klangk_backend/workspaces.py
@@ -65,6 +65,7 @@ def workspace_metadata(ws: dict) -> dict:
         "auto_start": ws.get("auto_start", False),
         "mounts": ws.get("mounts"),
         "env": ws.get("env"),
+        "health_check": ws.get("health_check"),
         "num_ports": ws.get("num_ports", 5),
     }
 
@@ -235,6 +236,7 @@ async def create_workspace(
     mounts: list[str] | None = None,
     env: dict[str, str] | None = None,
     setup_state: str | None = None,
+    health_check: str | None = None,
 ) -> dict:
     workspace = await model.create_workspace(
         user_id,
@@ -245,6 +247,7 @@ async def create_workspace(
         mounts=mounts,
         env=env,
         setup_state=setup_state or model.SETUP_STATE_COMPLETE,
+        health_check=health_check,
     )
     home = home_path(user_id, workspace["id"])
     home.mkdir(parents=True, exist_ok=True)
@@ -430,6 +433,8 @@ async def eager_start_workspace(
         extra_mounts=ws.get("mounts"),
         extra_env=ws.get("env"),
         user_id=owner_id,
+        health_check=ws.get("health_check"),
+        setup_state=ws.get("setup_state"),
     )
     state = container.registry.states.get(workspace_id)
     if state:

--- a/src/backend/klangk_backend/wshandler/connection.py
+++ b/src/backend/klangk_backend/wshandler/connection.py
@@ -315,6 +315,8 @@ class Connection:
             extra_mounts=workspace.get("mounts"),
             extra_env=workspace.get("env"),
             user_id=self.user["id"],
+            health_check=workspace.get("health_check"),
+            setup_state=workspace.get("setup_state"),
         )
         self.container_status = container_status
         self.workspace_id = workspace_id

--- a/src/backend/klangk_backend/wshandler/session.py
+++ b/src/backend/klangk_backend/wshandler/session.py
@@ -479,6 +479,32 @@ class WebSocketState:
             self.connections.pop(sock, None)
             asyncio.create_task(conn.cleanup())
 
+    def notify_service_health(self, workspace_id: str, healthy: bool) -> None:
+        """Broadcast service-health status to all connections.
+
+        Fanned out to every connection (like
+        :meth:`notify_container_status`) so the workspace list page can
+        reflect health transitions for auto-started services even when no
+        one is connected to that workspace's terminal session (#1015).
+        The frontend ignores events for workspaces it doesn't display.
+        """
+        message = {
+            "type": "service_health",
+            "workspace_id": workspace_id,
+            "healthy": healthy,
+        }
+        dead = []
+        for sock, conn in self.connections.items():
+            if conn.user.get("id") is None:
+                continue
+            try:
+                sock.send_json(message)
+            except _WS_ERRORS:
+                dead.append((sock, conn))
+        for sock, conn in dead:
+            self.connections.pop(sock, None)
+            asyncio.create_task(conn.cleanup())
+
     def notify_user_workspaces_changed(self, user_id: str) -> None:
         """Send ``workspaces_changed`` to all of a user's connections.
 

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -5094,6 +5094,7 @@ class TestWorkspaceMetadata:
             "auto_start": True,
             "mounts": ["/data:/data"],
             "env": {"FOO": "bar"},
+            "health_check": None,
             "num_ports": 3,
         }
 

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -1476,6 +1476,49 @@ class TestWorkspaceRoutes:
         assert match[0]["name"] == "renamed"
         assert match[0]["default_command"] == "pi"
 
+    async def test_update_workspace_propagates_to_live_state(
+        self, client, user
+    ):
+        # Editing setup_state/health_check on a workspace whose
+        # container is live updates the cached ContainerState so the
+        # health monitor picks it up without a restart (#1015).
+        import klangk_backend.container as container
+
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            json={"name": "live-ws"},
+            headers=headers,
+        )
+        ws_id = resp.json()["id"]
+
+        # Simulate a running container by registering a live state.
+        container.registry.track_activity(
+            "cid-live",
+            ws_id,
+            health_check="old-cmd",
+            setup_state="pending",
+        )
+        live = container.registry.get_state(ws_id)
+        live.health_status = "healthy"  # will be reset on edit
+        try:
+            resp = await client.put(
+                f"/api/v1/workspaces/{ws_id}",
+                json={
+                    "health_check": "curl -sf http://localhost:8080/h",
+                    "setup_state": "complete",
+                },
+                headers=headers,
+            )
+            assert resp.status_code == 200
+            assert live.health_check == ("curl -sf http://localhost:8080/h")
+            assert live.setup_state == "complete"
+            # Editing health_check resets the cached status.
+            assert live.health_status is None
+            assert live.health_checked_at is None
+        finally:
+            container.registry.remove_state(ws_id)
+
     async def test_update_workspace_no_permission(self, client, user):
         headers = await _auth_headers(client)
         resp = await client.put(

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -132,6 +132,27 @@ class TestActivityTracking:
     def test_get_state_returns_none_for_unknown(self):
         assert container.registry.get_state("nonexistent") is None
 
+    def test_track_activity_stores_health_metadata(self):
+        # health_check, owner_id, and setup_state are cached on the
+        # ContainerState for the health monitor to read on each poll.
+        container.registry.track_activity(
+            "cid-hm",
+            "ws-hm",
+            health_check="curl -sf http://localhost:8080/health",
+            owner_id="uid-owner",
+            setup_state="complete",
+        )
+        try:
+            state = container.registry.states["ws-hm"]
+            assert state.health_check == (
+                "curl -sf http://localhost:8080/health"
+            )
+            assert state.owner_id == "uid-owner"
+            assert state.setup_state == "complete"
+        finally:
+            container.registry.states.pop("ws-hm", None)
+            container.registry._cid_to_wsid.pop("cid-hm", None)
+
 
 def _noop_callback(ws):
     pass
@@ -1488,6 +1509,19 @@ class TestShutdown:
         assert task.cancelled()
         assert container.registry.cleanup_task is None
 
+    async def test_shutdown_cancels_health_task(self):
+        # A running health loop task is cancelled on shutdown.
+        async def fake_health():
+            await asyncio.sleep(999)
+
+        task = asyncio.create_task(fake_health())
+        container.registry.health.health_task = task
+
+        with patch_podman():
+            await container.registry.shutdown()
+        assert task.cancelled()
+        assert container.registry.health.health_task is None
+
     async def test_shutdown_handles_podman_error(self):
         with patch_podman(
             list_containers=AsyncMock(
@@ -2034,6 +2068,19 @@ class TestHealthMonitorRunOne:
         monitor = container.registry.health
         st = _health_state(owner_id=None)
         with patch.object(podman, "exec_container") as exec_mock:
+            assert await monitor._run_one(st) == "unhealthy"
+        exec_mock.assert_not_called()
+
+    async def test_no_handle_is_unhealthy(self):
+        # Owner exists in the state but has no handle resolved.
+        monitor = container.registry.health
+        st = _health_state(owner_id="uid-owner")
+        with (
+            patch.object(
+                model, "get_user_handle", AsyncMock(return_value=None)
+            ),
+            patch.object(podman, "exec_container") as exec_mock,
+        ):
             assert await monitor._run_one(st) == "unhealthy"
         exec_mock.assert_not_called()
 

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -1934,3 +1934,232 @@ class TestTrackActivityContainerChanged:
         assert "old-cid" not in container.registry._cid_to_wsid
         container.registry.states.pop("ws-chg", None)
         container.registry._cid_to_wsid.pop("new-cid", None)
+
+
+def _mock_sock_for_health():
+    """A minimal mock websocket for health broadcast fan-out tests."""
+    from unittest.mock import MagicMock
+
+    sock = MagicMock()
+    sock.send_json = MagicMock()
+    return sock
+
+
+def _health_state(
+    *,
+    workspace_id="ws-h",
+    container_id="cid1234567890",
+    health_check="curl -sf http://localhost:8080/health",
+    owner_id="uid-owner",
+    setup_state="complete",
+    health_status=None,
+):
+    """Build a ContainerState wired up for health checks."""
+    st = container.ContainerState(workspace_id, container_id)
+    st.health_check = health_check
+    st.owner_id = owner_id
+    st.setup_state = setup_state
+    st.health_status = health_status
+    return st
+
+
+class TestHealthMonitorRunOne:
+    """_run_one: rc 0 → healthy, non-zero/error → unhealthy."""
+
+    async def test_exit_zero_is_healthy(self):
+        monitor = container.registry.health
+        st = _health_state()
+        exec_mock = AsyncMock(return_value=(0, "", ""))
+        with (
+            patch.object(podman, "exec_container", exec_mock),
+            patch.object(
+                model, "get_user_handle", AsyncMock(return_value="owner")
+            ),
+            patch("klangk_backend.workspaces.home_path", return_value="/h/p"),
+            patch(
+                "klangk_backend.workspaces.ensure_home_symlink",
+                return_value=("/home/klangk", False),
+            ),
+        ):
+            assert await monitor._run_one(st) == "healthy"
+        # The check runs as the workspace user with HOME set, and is
+        # logged with the container id (first 12 chars).
+        call = exec_mock.call_args
+        assert call.args[0] == "cid1234567890"
+        assert call.kwargs["user"] == "klangk"
+        assert call.kwargs["extra_env"] == {"HOME": "/home/klangk"}
+        assert call.kwargs["timeout"] == container.HEALTH_CHECK_TIMEOUT_SECONDS
+
+    async def test_nonzero_exit_is_unhealthy(self):
+        monitor = container.registry.health
+        st = _health_state()
+        with (
+            patch.object(
+                podman,
+                "exec_container",
+                AsyncMock(return_value=(1, "", "err")),
+            ),
+            patch.object(
+                model, "get_user_handle", AsyncMock(return_value="owner")
+            ),
+            patch("klangk_backend.workspaces.home_path", return_value="/h/p"),
+            patch(
+                "klangk_backend.workspaces.ensure_home_symlink",
+                return_value=("/home/klangk", False),
+            ),
+        ):
+            assert await monitor._run_one(st) == "unhealthy"
+
+    async def test_exec_error_is_unhealthy(self):
+        monitor = container.registry.health
+        st = _health_state()
+        with (
+            patch.object(
+                podman,
+                "exec_container",
+                AsyncMock(side_effect=podman.PodmanError(500, "nope")),
+            ),
+            patch.object(
+                model, "get_user_handle", AsyncMock(return_value="owner")
+            ),
+            patch("klangk_backend.workspaces.home_path", return_value="/h/p"),
+            patch(
+                "klangk_backend.workspaces.ensure_home_symlink",
+                return_value=("/home/klangk", False),
+            ),
+        ):
+            assert await monitor._run_one(st) == "unhealthy"
+
+    async def test_no_owner_is_unhealthy(self):
+        monitor = container.registry.health
+        st = _health_state(owner_id=None)
+        with patch.object(podman, "exec_container") as exec_mock:
+            assert await monitor._run_one(st) == "unhealthy"
+        exec_mock.assert_not_called()
+
+
+class TestHealthMonitorCheckWorkspace:
+    """_check_workspace: records status and broadcasts on transitions."""
+
+    async def test_broadcasts_on_transition_to_unhealthy(self):
+        monitor = container.registry.health
+        st = _health_state(health_status=None)  # unknown → unhealthy
+        with (
+            patch.object(
+                monitor, "_run_one", AsyncMock(return_value="unhealthy")
+            ),
+            patch.object(monitor, "_broadcast") as bcast,
+        ):
+            await monitor._check_workspace(st)
+        assert st.health_status == "unhealthy"
+        assert st.health_checked_at is not None
+        bcast.assert_called_once_with("ws-h", "unhealthy")
+
+    async def test_no_broadcast_when_status_unchanged(self):
+        monitor = container.registry.health
+        st = _health_state(health_status="healthy")  # stays healthy
+        with (
+            patch.object(
+                monitor, "_run_one", AsyncMock(return_value="healthy")
+            ),
+            patch.object(monitor, "_broadcast") as bcast,
+        ):
+            await monitor._check_workspace(st)
+        assert st.health_status == "healthy"
+        bcast.assert_not_called()
+
+
+class TestHealthMonitorBroadcast:
+    """_broadcast fans out to ALL connections, not just the session."""
+
+    def test_fans_out_via_notify_service_health(self):
+        from klangk_backend.wshandler import state as _ws_state
+
+        monitor = container.registry.health
+        sock = _mock_sock_for_health()
+        try:
+            _ws_state.connections[sock] = SimpleNamespace(
+                user={"id": "u1", "email": "a@x"}
+            )
+            # No WorkspaceSession registered for this workspace — yet
+            # the event must still reach the connection.
+            monitor._broadcast("ws-h", "unhealthy")
+        finally:
+            _ws_state.connections.pop(sock, None)
+        sock.send_json.assert_called_once_with(
+            {
+                "type": "service_health",
+                "workspace_id": "ws-h",
+                "healthy": False,
+            }
+        )
+
+
+class TestHealthMonitorLoopSkips:
+    """run_health_loop skips setup-incomplete and checkless workspaces."""
+
+    async def test_skips_setup_incomplete(self):
+        monitor = container.registry.health
+        st = _health_state(setup_state="pending")
+        container.registry.states[st.workspace_id] = st
+        try:
+            with (
+                patch.object(
+                    monitor, "_check_workspace", AsyncMock()
+                ) as check,
+                patch.object(container, "HEALTH_CHECK_INTERVAL_SECONDS", 0.01),
+            ):
+                task = asyncio.create_task(monitor.run_health_loop())
+                await asyncio.sleep(0.05)
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+            check.assert_not_called()
+        finally:
+            container.registry.states.pop(st.workspace_id, None)
+
+    async def test_skips_when_no_health_check(self):
+        monitor = container.registry.health
+        st = _health_state(health_check=None)
+        container.registry.states[st.workspace_id] = st
+        try:
+            with (
+                patch.object(
+                    monitor, "_check_workspace", AsyncMock()
+                ) as check,
+                patch.object(container, "HEALTH_CHECK_INTERVAL_SECONDS", 0.01),
+            ):
+                task = asyncio.create_task(monitor.run_health_loop())
+                await asyncio.sleep(0.05)
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+            check.assert_not_called()
+        finally:
+            container.registry.states.pop(st.workspace_id, None)
+
+    async def test_runs_when_setup_complete(self):
+        monitor = container.registry.health
+        st = _health_state(setup_state="complete")
+        container.registry.states[st.workspace_id] = st
+        try:
+            with (
+                patch.object(
+                    monitor, "_check_workspace", AsyncMock()
+                ) as check,
+                patch.object(container, "HEALTH_CHECK_INTERVAL_SECONDS", 0.01),
+            ):
+                task = asyncio.create_task(monitor.run_health_loop())
+                await asyncio.sleep(0.05)
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+            check.assert_called()
+        finally:
+            container.registry.states.pop(st.workspace_id, None)

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -4026,6 +4026,53 @@ class TestNotifyContainerStatus:
             wshandler.state.connections.pop(sock, None)
 
 
+class TestNotifyServiceHealth:
+    """notify_service_health fans health events out to all connections."""
+
+    def _register(self, sock, user):
+        conn = _base_conn(user=user, ws=sock)
+        wshandler.state.connections[sock] = conn
+        return conn
+
+    def test_sends_healthy_to_all_authenticated(self):
+        sock_a = _mock_sock()
+        sock_b = _mock_sock()
+        try:
+            self._register(sock_a, {"id": "uid-1", "email": "a@x"})
+            self._register(sock_b, {"id": "uid-2", "email": "b@x"})
+            wshandler.state.notify_service_health("ws-123", healthy=True)
+        finally:
+            wshandler.state.connections.pop(sock_a, None)
+            wshandler.state.connections.pop(sock_b, None)
+        expected = {
+            "type": "service_health",
+            "workspace_id": "ws-123",
+            "healthy": True,
+        }
+        sock_a.send_json.assert_called_once_with(expected)
+        sock_b.send_json.assert_called_once_with(expected)
+
+    def test_sends_unhealthy(self):
+        sock = _mock_sock()
+        try:
+            self._register(sock, {"id": "uid-1", "email": "a@x"})
+            wshandler.state.notify_service_health("ws-9", healthy=False)
+        finally:
+            wshandler.state.connections.pop(sock, None)
+        msg = sock.send_json.call_args[0][0]
+        assert msg["healthy"] is False
+        assert msg["type"] == "service_health"
+
+    def test_skips_unauthenticated(self):
+        sock = _mock_sock()
+        try:
+            self._register(sock, {"id": None, "email": ""})
+            wshandler.state.notify_service_health("ws-1", healthy=True)
+        finally:
+            wshandler.state.connections.pop(sock, None)
+        sock.send_json.assert_not_called()
+
+
 class TestRemoveSessionLocked:
     async def test_removes_session(self):
         session = wshandler.state.get_or_create_session("ws-locked-rm")

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -4072,6 +4072,21 @@ class TestNotifyServiceHealth:
             wshandler.state.connections.pop(sock, None)
         sock.send_json.assert_not_called()
 
+    async def test_dead_socket_is_pruned(self):
+        from klangk_backend.wshandler import _WS_ERRORS
+
+        sock = _mock_sock()
+        sock.send_json = MagicMock(side_effect=_WS_ERRORS[0]("dead"))
+        try:
+            conn = self._register(sock, {"id": "uid-1", "email": "a@x"})
+            with patch.object(conn, "cleanup", new_callable=AsyncMock) as mock:
+                wshandler.state.notify_service_health("ws-1", healthy=True)
+                await asyncio.sleep(0)
+                mock.assert_awaited_once()
+            assert sock not in wshandler.state.connections
+        finally:
+            wshandler.state.connections.pop(sock, None)
+
 
 class TestRemoveSessionLocked:
     async def test_removes_session(self):

--- a/src/cli/klangkc/client.py
+++ b/src/cli/klangkc/client.py
@@ -154,6 +154,7 @@ class Workspace:
     auto_start: bool = False
     mounts: list[str] | None = None
     env: dict[str, str] | None = None
+    health_check: str | None = None
     owner_email: str | None = None
 
 
@@ -374,6 +375,7 @@ class KlangkClient:
             auto_start=bool(w.get("auto_start", False)),
             mounts=w.get("mounts"),
             env=w.get("env"),
+            health_check=w.get("health_check"),
             owner_email=w.get("owner_email") if shared else None,
         )
 
@@ -386,6 +388,7 @@ class KlangkClient:
         mounts: list[str] | None = None,
         env: dict[str, str] | None = None,
         setup_state: str | None = None,
+        health_check: str | None = None,
     ) -> Workspace:
         body: dict = {"name": name}
         if image:
@@ -400,6 +403,8 @@ class KlangkClient:
             body["env"] = env
         if setup_state:
             body["setup_state"] = setup_state
+        if health_check:
+            body["health_check"] = health_check
         resp = self.post("/api/v1/workspaces", json=body)
         self._check_auth(resp)
         self._raise_for_status(resp)

--- a/src/cli/klangkc/main.py
+++ b/src/cli/klangkc/main.py
@@ -1108,7 +1108,7 @@ def monitor(
     server_url = _server_url().rstrip("/")
     ws_url = _build_ws_url(server_url)
     token = _state().get_token(server_url)
-    if not token:
+    if not token:  # pragma: no cover  # _require_auth already guards this
         _err.print("[red]Not logged in. Run `klangkc login` first.[/red]")
         raise typer.Exit(code=1)
     effective_max = 0 if no_reconnect else max_reconnects

--- a/src/cli/klangkc/main.py
+++ b/src/cli/klangkc/main.py
@@ -7,6 +7,7 @@ import asyncio
 import io
 import json
 import os
+import random
 import shutil
 import subprocess
 import sys
@@ -27,7 +28,7 @@ from rich.spinner import Spinner
 from rich.table import Table
 from rich.text import Text
 
-from .auth import login, logout as do_logout
+from .auth import login, logout as do_logout, refresh_token
 from .client import (
     AuthError,
     KlangkClient,
@@ -294,6 +295,14 @@ def create(
         "--auto-start",
         help="Start container automatically on server boot",
     ),
+    health_check: str | None = typer.Option(
+        None,
+        "--health-check",
+        help=(
+            "Shell command polled inside the container to gauge service "
+            "health (exit 0 = healthy). See the Health Check docs."
+        ),
+    ),
     mount: list[str] | None = typer.Option(
         None,
         "--mount",
@@ -321,6 +330,7 @@ def create(
             auto_start=auto_start,
             mounts=mount or None,
             env=env_dict,
+            health_check=health_check,
         )
     except httpx.HTTPStatusError as exc:
         detail = exc.response.json().get("detail", exc.response.text)
@@ -572,6 +582,14 @@ def edit(
         "--auto-start/--no-auto-start",
         help="Start container automatically on server boot",
     ),
+    health_check: str | None = typer.Option(
+        None,
+        "--health-check",
+        help=(
+            "Shell command polled inside the container to gauge service "
+            "health (exit 0 = healthy). Use '' to clear."
+        ),
+    ),
     mount: list[str] | None = typer.Option(
         None,
         "--mount",
@@ -601,6 +619,7 @@ def edit(
         or image is not None
         or command is not None
         or auto_start is not None
+        or health_check is not None
         or isinstance(mount, list)
         or isinstance(env, list)
     )
@@ -609,6 +628,7 @@ def edit(
         new_name = _prompt("Name", ws.name)
         new_image = _prompt("Container Image", ws.image)
         new_command = _prompt("Default shell command", ws.default_command)
+        new_health_check = _prompt("Health check command", ws.health_check)
 
         # Interactive mount editing loop
         current_mounts = list(ws.mounts or [])
@@ -706,6 +726,8 @@ def edit(
             body["image"] = new_image or None
         if new_command is not _SENTINEL:
             body["default_command"] = new_command or None
+        if new_health_check is not _SENTINEL:
+            body["health_check"] = new_health_check or None
         if mounts_changed:
             body["mounts"] = current_mounts or None
         if env_changed:
@@ -721,6 +743,8 @@ def edit(
             body["default_command"] = command or None
         if auto_start is not None:
             body["auto_start"] = auto_start
+        if health_check is not None:
+            body["health_check"] = health_check or None
         if isinstance(mount, list):
             for m in mount:
                 err = validate_mount_spec(m)
@@ -870,6 +894,247 @@ def shell(
         raise typer.Exit(code=1) from None
 
 
+def _dispatch_monitor_event(msg: dict, command: list[str]) -> None:
+    """Act on one server event.
+
+    With no *command*, the event is streamed as line-delimited JSON to
+    stdout. With a command, its stdin gets the event JSON and env vars
+    ``KLANGK_EVENT``, ``KLANGK_EVENT_TYPE``, ``KLANGK_WORKSPACE_ID`` and
+    (for health events) ``KLANGK_HEALTHY`` are set.
+
+    Pure (no WebSocket) so it can be unit-tested in isolation.
+    """
+    payload = json.dumps(msg)
+    if not command:
+        sys.stdout.write(payload + "\n")
+        sys.stdout.flush()
+        return
+    env = dict(os.environ)
+    env["KLANGK_EVENT"] = payload
+    env["KLANGK_EVENT_TYPE"] = str(msg.get("type", ""))
+    wid = msg.get("workspace_id")
+    if wid is not None:
+        env["KLANGK_WORKSPACE_ID"] = str(wid)
+    if msg.get("type") == "service_health":
+        env["KLANGK_HEALTHY"] = "true" if msg.get("healthy") else "false"
+    # FileNotFoundError (missing binary) propagates to the caller.
+    subprocess.run(command, input=payload.encode(), env=env, check=False)
+
+
+async def _monitor_connection(
+    ws_url: str,
+    token: str,
+    max_size: int,
+    command: list[str],
+    types: list[str],
+    workspaces: list[str],
+) -> None:
+    """One connection: dispatch events until the socket closes.
+
+    Network/auth errors propagate to :func:`_monitor_run`, which owns
+    reconnect + refresh. Filtering by event type and workspace id is
+    applied here so the dispatcher only sees relevant events.
+    """
+    type_filter = {t for t in types}
+    ws_filter = {w for w in workspaces}
+    async with websockets.connect(
+        f"{ws_url}?token={token}", max_size=max_size
+    ) as conn:
+        async for raw in conn:
+            try:
+                msg = json.loads(raw)
+            except json.JSONDecodeError:
+                continue
+            etype = msg.get("type")
+            if etype is None:
+                continue  # control/ack messages aren't events
+            if type_filter and etype not in type_filter:
+                continue
+            wid = msg.get("workspace_id")
+            if ws_filter and (wid is None or wid not in ws_filter):
+                continue
+            _dispatch_monitor_event(msg, command)
+
+
+def _monitor_backoff(attempt: int, max_delay: float) -> float:
+    """Capped exponential backoff with jitter (mirrors the web UI)."""
+    base = min(1 << attempt, max_delay)
+    jitter = random.random() * base
+    return (base + jitter) / 2
+
+
+async def _refresh_token_threaded(server_url: str, token: str) -> str | None:
+    """Refresh the JWT off-loop; returns the new token or None."""
+    return await asyncio.to_thread(refresh_token, server_url, token)
+
+
+async def _monitor_run(
+    server_url: str,
+    ws_url: str,
+    token: str,
+    max_size: int,
+    command: list[str],
+    types: list[str],
+    workspaces: list[str],
+    *,
+    max_reconnects: int | None,
+    max_delay: float,
+) -> None:
+    """Run the monitor with automatic reconnect + JWT refresh.
+
+    Reconnects indefinitely when *max_reconnects* is ``None`` (the
+    default), or up to that many times, with capped exponential
+    backoff. On an auth-related close (HTTP/WS 4001 or 4002) it tries
+    to refresh the JWT via the server's refresh endpoint before
+    reconnecting; if refresh fails it keeps retrying with the current
+    token so the monitor self-heals once the server/token recovers.
+    """
+    current_token = token
+    _err.print("[green]Monitoring events. Press Ctrl+C to stop.[/green]")
+    attempt = 0
+    while True:
+        auth_close = False
+        try:
+            await _monitor_connection(
+                ws_url, current_token, max_size, command, types, workspaces
+            )
+            reason = "connection closed"
+        except websockets.ConnectionClosed as exc:
+            code = exc.rcvd.code if exc.rcvd else None
+            auth_close = code in (4001, 4002)
+            reason = f"closed (code {code})"
+        except websockets.InvalidStatus as exc:
+            code = exc.response.status_code
+            auth_close = code in (4001, 4002)
+            reason = f"rejected (HTTP {code})"
+        except (OSError, asyncio.TimeoutError) as exc:
+            reason = f"network error: {exc}"
+
+        # On an auth-related close, try to refresh the JWT. A successful
+        # refresh lets the next attempt authenticate cleanly; a failed
+        # one still reconnects (the server/token may recover).
+        if auth_close:
+            new = await _refresh_token_threaded(server_url, current_token)
+            if new:
+                current_token = new
+                _err.print("[green]Token refreshed.[/green]")
+            else:
+                _err.print(
+                    "[yellow]Token refresh failed; retrying with the"
+                    " current token.[/yellow]"
+                )
+
+        if max_reconnects is not None and attempt >= max_reconnects:
+            _err.print(
+                f"[red]{reason}; max reconnects ({max_reconnects})"
+                " reached, giving up.[/red]"
+            )
+            raise typer.Exit(code=1)
+        attempt += 1
+        delay = _monitor_backoff(attempt, max_delay)
+        _err.print(
+            f"[yellow]{reason}; reconnecting in {delay:.1f}s"
+            f" (attempt {attempt})...[/yellow]"
+        )
+        await asyncio.sleep(delay)
+
+
+@app.command()
+def monitor(
+    command: list[str] = typer.Argument(
+        None,
+        help=(
+            "Optional command to run for each event. Pass it after '--' "
+            "so its own flags aren't parsed by klangkc."
+        ),
+    ),
+    event_type: list[str] = typer.Option(
+        [],
+        "--type",
+        "-t",
+        help=(
+            "Only react to these event types (repeatable). Common: "
+            "service_health, container_status, workspaces_changed."
+        ),
+    ),
+    workspace: list[str] = typer.Option(
+        [],
+        "--workspace",
+        "-w",
+        help="Only react to events for these workspace ids (repeatable).",
+    ),
+    no_reconnect: bool = typer.Option(
+        False,
+        "--no-reconnect",
+        help="Exit after the first disconnect instead of reconnecting.",
+    ),
+    max_reconnects: int | None = typer.Option(
+        None,
+        "--max-reconnects",
+        help=(
+            "Stop after this many failed reconnects. Default: retry"
+            " forever. Implied as 0 by --no-reconnect."
+        ),
+    ),
+    max_delay: float = typer.Option(
+        60.0,
+        "--max-delay",
+        help="Cap (seconds) on the reconnect backoff.",
+    ),
+) -> None:
+    """Stream server events, optionally running a command for each.
+
+    Connects to the server and listens for the same events the web UI
+    receives (health-check transitions, container starts/stops, workspace
+    changes). With no command, events are printed as line-delimited JSON
+    (pipe to jq to inspect). With a command after '--', the command's
+    stdin gets the event JSON and env vars KLANGK_EVENT_TYPE,
+    KLANGK_WORKSPACE_ID, and KLANGK_HEALTHY are set.
+
+    The monitor reconnects automatically (by default forever, with
+    capped exponential backoff) and refreshes its JWT on auth failures,
+    so it survives server restarts and token expiry. Use
+    ``--max-reconnects`` or ``--no-reconnect`` to bound it.
+
+    \b
+    Examples:
+      klangkc monitor                                # stream all events
+      klangkc monitor --type service_health | jq .   # pretty health events
+      klangkc monitor --type service_health -- sh -c \
+        '[ "$KLANGK_HEALTHY" = false ] && notify-send "Service unhealthy"'
+      klangkc monitor --workspace <id> --type service_health
+    """
+    _require_auth()
+    server_url = _server_url().rstrip("/")
+    ws_url = _build_ws_url(server_url)
+    token = _state().get_token(server_url)
+    if not token:
+        _err.print("[red]Not logged in. Run `klangkc login` first.[/red]")
+        raise typer.Exit(code=1)
+    effective_max = 0 if no_reconnect else max_reconnects
+    try:
+        asyncio.run(
+            _monitor_run(
+                server_url,
+                ws_url,
+                token,
+                max_size=_ws_max_size(),
+                command=list(command) if command else [],
+                types=event_type,
+                workspaces=workspace,
+                max_reconnects=effective_max,
+                max_delay=max_delay,
+            )
+        )
+    except websockets.InvalidStatus as e:
+        # A rejection during the very first connect (before the loop's
+        # reconnect path is established).
+        _err.print(f"[red]Connection rejected: {e}[/red]")
+        raise typer.Exit(code=1) from None
+    except KeyboardInterrupt:
+        _err.print("[dim]Stopped.[/dim]")
+
+
 def _resolve_workspace_and_url(
     workspace_name: str,
 ) -> tuple:
@@ -1016,6 +1281,7 @@ def sandbox(
             setup_state="pending"
             if resolve_setup_command(config, handle)
             else None,
+            health_check=config.health_check,
         )
         _err.print(f"Workspace [bold]{workspace}[/bold] created.")
         created = True

--- a/src/cli/klangkc/sandbox.py
+++ b/src/cli/klangkc/sandbox.py
@@ -17,6 +17,7 @@ class SandboxConfig:
     image: str | None = None
     default_command: str | None = None
     auto_start: bool = False
+    health_check: str | None = None
     # sandbox
     mount_at: str = "~/work"
     setup: str | None = None
@@ -61,6 +62,9 @@ def load_sandbox_config(sandbox_root: Path) -> SandboxConfig:
         ),
         auto_start=bool(
             workspace.get("auto-start", workspace.get("auto_start", False))
+        ),
+        health_check=workspace.get(
+            "health-check", workspace.get("health_check")
         ),
         mount_at=sandbox.get("mount-at", sandbox.get("mount_at", "~/work")),
         setup=sandbox.get("setup"),

--- a/src/cli/tests/test_cli.py
+++ b/src/cli/tests/test_cli.py
@@ -2299,6 +2299,22 @@ class TestCreateWorkspaceClient:
         body = mock_post.call_args.kwargs.get("json")
         assert body["default_command"] == "openclaw gateway"
 
+    def test_create_workspace_with_health_check(self):
+        client = KlangkClient("http://test:8995", "token")
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "id": "ws-hc",
+            "name": "hc-ws",
+            "created_at": "2025-01-01",
+        }
+        with patch.object(client, "post", return_value=mock_resp) as mock_post:
+            client.create_workspace(
+                "hc-ws", health_check="curl -sf http://localhost:8080/h"
+            )
+        body = mock_post.call_args.kwargs.get("json")
+        assert body["health_check"] == "curl -sf http://localhost:8080/h"
+
     def test_create_workspace_with_auto_start(self):
         client = KlangkClient("http://test:8995", "token")
         mock_resp = MagicMock()
@@ -2852,3 +2868,82 @@ class TestMonitor:
         for attempt in range(1, 20):
             delay = _monitor_backoff(attempt, max_delay=30.0)
             assert 0 < delay <= 30.0
+
+    @pytest.mark.asyncio
+    async def test_connection_skips_invalid_json(self, capsys):
+        # Malformed frames are ignored rather than crashing the monitor.
+        from klangkc.main import _monitor_connection
+
+        messages = [
+            "this is not json",
+            json.dumps(
+                {
+                    "type": "service_health",
+                    "workspace_id": "w1",
+                    "healthy": True,
+                }
+            ),
+        ]
+        conn = _FakeMonitorConn(messages)
+        with patch(
+            "klangkc.main.websockets.connect",
+            return_value=_FakeMonitorCM(conn),
+        ):
+            await _monitor_connection(
+                "ws://x/ws", "tok", 1024, command=[], types=[], workspaces=[]
+            )
+        out = capsys.readouterr().out.strip().splitlines()
+        assert len(out) == 1
+        assert json.loads(out[0])["type"] == "service_health"
+
+    @pytest.mark.asyncio
+    async def test_refresh_token_threaded_delegates(self):
+        # _refresh_token_threaded runs the sync refresh_token off-loop
+        # and returns whatever it yields.
+        from klangkc import main as main_mod
+
+        with patch.object(
+            main_mod, "refresh_token", return_value="FRESH"
+        ) as mock_refresh:
+            result = await main_mod._refresh_token_threaded("http://x", "OLD")
+        assert result == "FRESH"
+        mock_refresh.assert_called_once_with("http://x", "OLD")
+
+    @pytest.mark.asyncio
+    async def test_invalid_status_4001_triggers_refresh(self):
+        # An HTTP 4001 rejection (InvalidStatus) is treated as auth-related
+        # and triggers a token refresh before reconnecting.
+        from klangkc import main as main_mod
+
+        seen_tokens = []
+
+        async def fake_conn(ws_url, token, *args, **kwargs):
+            seen_tokens.append(token)
+            raise websockets.InvalidStatus(MagicMock(status_code=4001))
+
+        async def fake_refresh(server_url, token):
+            return "NEW_TOKEN"
+
+        async def fake_sleep(delay):
+            pass
+
+        with (
+            patch.object(main_mod, "_monitor_connection", fake_conn),
+            patch.object(main_mod, "_refresh_token_threaded", fake_refresh),
+            patch.object(main_mod.asyncio, "sleep", fake_sleep),
+            patch.object(main_mod, "_monitor_backoff", lambda a, m: 0.0),
+        ):
+            with pytest.raises(typer.Exit):
+                await main_mod._monitor_run(
+                    "http://x",
+                    "ws://x/ws",
+                    "OLD_TOKEN",
+                    1024,
+                    command=[],
+                    types=[],
+                    workspaces=[],
+                    max_reconnects=1,
+                    max_delay=1.0,
+                )
+        assert seen_tokens[0] == "OLD_TOKEN"
+        assert seen_tokens[1] == "NEW_TOKEN"

--- a/src/cli/tests/test_cli.py
+++ b/src/cli/tests/test_cli.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+import typer
 import websockets
 import io
 from io import BytesIO
@@ -2457,3 +2458,397 @@ class TestExecSessionRunClosedWs:
         session = _ExecSession(ws, command=["echo", "hi"], stdin=None)
         exit_code = await session.run()
         assert exit_code == 0
+
+
+class _FakeMonitorConn:
+    """Async-iterator WS stub for ``klangkc monitor``."""
+
+    def __init__(self, messages: list[str]):
+        self._messages = list(messages)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._messages:
+            raise StopAsyncIteration
+        return self._messages.pop(0)
+
+
+class _ClosedStub(websockets.ConnectionClosed):
+    """A ConnectionClosed with a specific close code (for reconnect tests)."""
+
+    def __init__(self, code: int):
+        rcvd = MagicMock()
+        rcvd.code = code
+        super().__init__(rcvd=rcvd, sent=None)
+
+
+class _FakeMonitorCM:
+    def __init__(self, conn):
+        self._conn = conn
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, *args):
+        return None
+
+
+class TestMonitor:
+    @pytest.mark.asyncio
+    async def test_no_command_streams_json(self, capsys):
+        from klangkc.main import _monitor_connection
+
+        messages = [
+            json.dumps(
+                {
+                    "type": "service_health",
+                    "workspace_id": "w1",
+                    "healthy": True,
+                }
+            ),
+            json.dumps({"cmd": "terminal_ack"}),  # no type → skipped
+            json.dumps(
+                {
+                    "type": "container_status",
+                    "workspace_id": "w1",
+                    "running": False,
+                }
+            ),
+        ]
+        conn = _FakeMonitorConn(messages)
+        with patch(
+            "klangkc.main.websockets.connect",
+            return_value=_FakeMonitorCM(conn),
+        ):
+            await _monitor_connection(
+                "ws://x/ws", "tok", 1024, command=[], types=[], workspaces=[]
+            )
+        out = capsys.readouterr().out.strip().splitlines()
+        assert len(out) == 2
+        assert json.loads(out[0])["type"] == "service_health"
+        assert json.loads(out[1])["type"] == "container_status"
+
+    @pytest.mark.asyncio
+    async def test_type_filter(self, capsys):
+        from klangkc.main import _monitor_connection
+
+        messages = [
+            json.dumps(
+                {
+                    "type": "service_health",
+                    "workspace_id": "w1",
+                    "healthy": False,
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "container_status",
+                    "workspace_id": "w1",
+                    "running": True,
+                }
+            ),
+        ]
+        conn = _FakeMonitorConn(messages)
+        with patch(
+            "klangkc.main.websockets.connect",
+            return_value=_FakeMonitorCM(conn),
+        ):
+            await _monitor_connection(
+                "ws://x/ws",
+                "tok",
+                1024,
+                command=[],
+                types=["service_health"],
+                workspaces=[],
+            )
+        out = capsys.readouterr().out.strip().splitlines()
+        assert len(out) == 1
+        assert json.loads(out[0])["type"] == "service_health"
+
+    @pytest.mark.asyncio
+    async def test_workspace_filter_skips_others(self, capsys):
+        from klangkc.main import _monitor_connection
+
+        messages = [
+            json.dumps(
+                {
+                    "type": "service_health",
+                    "workspace_id": "w2",
+                    "healthy": False,
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "service_health",
+                    "workspace_id": "w1",
+                    "healthy": True,
+                }
+            ),
+        ]
+        conn = _FakeMonitorConn(messages)
+        with patch(
+            "klangkc.main.websockets.connect",
+            return_value=_FakeMonitorCM(conn),
+        ):
+            await _monitor_connection(
+                "ws://x/ws",
+                "tok",
+                1024,
+                command=[],
+                types=[],
+                workspaces=["w1"],
+            )
+        out = capsys.readouterr().out.strip().splitlines()
+        assert len(out) == 1
+        assert json.loads(out[0])["workspace_id"] == "w1"
+
+    @pytest.mark.asyncio
+    async def test_runs_command_with_payload_and_env(self):
+        from klangkc.main import _monitor_connection
+
+        event = {
+            "type": "service_health",
+            "workspace_id": "w1",
+            "healthy": False,
+        }
+        conn = _FakeMonitorConn([json.dumps(event)])
+        with patch(
+            "klangkc.main.websockets.connect",
+            return_value=_FakeMonitorCM(conn),
+        ):
+            with patch("klangkc.main.subprocess.run") as run_mock:
+                await _monitor_connection(
+                    "ws://x/ws",
+                    "tok",
+                    1024,
+                    command=["notify-send"],
+                    types=[],
+                    workspaces=[],
+                )
+        run_mock.assert_called_once()
+        _, kwargs = run_mock.call_args
+        assert kwargs["input"] == json.dumps(event).encode()
+        env = kwargs["env"]
+        assert env["KLANGK_EVENT_TYPE"] == "service_health"
+        assert env["KLANGK_WORKSPACE_ID"] == "w1"
+        assert env["KLANGK_HEALTHY"] == "false"
+        assert "KLANGK_EVENT" in env
+
+    @pytest.mark.asyncio
+    async def test_command_not_found_propagates(self, monkeypatch):
+        # A missing command binary propagates FileNotFoundError out of
+        # the single-connection loop (the runner turns it into an exit).
+        from klangkc.main import _monitor_connection
+
+        event = {
+            "type": "service_health",
+            "workspace_id": "w1",
+            "healthy": True,
+        }
+        conn = _FakeMonitorConn([json.dumps(event)])
+        with patch(
+            "klangkc.main.websockets.connect",
+            return_value=_FakeMonitorCM(conn),
+        ):
+            monkeypatch.setattr(
+                "klangkc.main.subprocess.run",
+                MagicMock(side_effect=FileNotFoundError()),
+            )
+            with pytest.raises(FileNotFoundError):
+                await _monitor_connection(
+                    "ws://x/ws",
+                    "tok",
+                    1024,
+                    command=["nope"],
+                    types=[],
+                    workspaces=[],
+                )
+
+    @pytest.mark.asyncio
+    async def test_reconnects_after_disconnect(self):
+        # Two clean closes → _monitor_connection called twice, with a
+        # backoff sleep in between.
+        from klangkc import main as main_mod
+
+        calls = {"conn": 0, "sleep": 0}
+
+        async def fake_conn(*args, **kwargs):
+            calls["conn"] += 1
+            if calls["conn"] >= 2:
+                raise typer.Exit(code=0)  # break the infinite loop
+            return None  # clean close → triggers reconnect
+
+        async def fake_sleep(delay):
+            calls["sleep"] += 1
+            assert delay > 0
+
+        with (
+            patch.object(main_mod, "_monitor_connection", fake_conn),
+            patch.object(main_mod.asyncio, "sleep", fake_sleep),
+            patch.object(main_mod, "_monitor_backoff", lambda a, m: 0.01),
+        ):
+            with pytest.raises(typer.Exit) as exc_info:
+                await main_mod._monitor_run(
+                    "http://x",
+                    "ws://x/ws",
+                    "tok",
+                    1024,
+                    command=[],
+                    types=[],
+                    workspaces=[],
+                    max_reconnects=None,
+                    max_delay=1.0,
+                )
+        assert exc_info.value.exit_code == 0
+        assert calls["conn"] == 2
+        assert calls["sleep"] == 1
+
+    @pytest.mark.asyncio
+    async def test_stops_after_max_reconnects(self):
+        from klangkc import main as main_mod
+
+        async def fake_conn(*args, **kwargs):
+            raise OSError("boom")
+
+        sleeps = []
+
+        async def fake_sleep(delay):
+            sleeps.append(delay)
+
+        with (
+            patch.object(main_mod, "_monitor_connection", fake_conn),
+            patch.object(main_mod.asyncio, "sleep", fake_sleep),
+            patch.object(main_mod, "_monitor_backoff", lambda a, m: 0.0),
+        ):
+            with pytest.raises(typer.Exit) as exc_info:
+                await main_mod._monitor_run(
+                    "http://x",
+                    "ws://x/ws",
+                    "tok",
+                    1024,
+                    command=[],
+                    types=[],
+                    workspaces=[],
+                    max_reconnects=2,
+                    max_delay=1.0,
+                )
+        assert exc_info.value.exit_code == 1
+        # 2 reconnects attempted before giving up.
+        assert len(sleeps) == 2
+
+    @pytest.mark.asyncio
+    async def test_no_reconnect_gives_up_immediately(self):
+        from klangkc import main as main_mod
+
+        async def fake_conn(*args, **kwargs):
+            raise OSError("boom")
+
+        async def fake_sleep(delay):
+            pytest.fail("should not sleep before giving up")
+
+        with (
+            patch.object(main_mod, "_monitor_connection", fake_conn),
+            patch.object(main_mod.asyncio, "sleep", fake_sleep),
+        ):
+            with pytest.raises(typer.Exit) as exc_info:
+                await main_mod._monitor_run(
+                    "http://x",
+                    "ws://x/ws",
+                    "tok",
+                    1024,
+                    command=[],
+                    types=[],
+                    workspaces=[],
+                    max_reconnects=0,
+                    max_delay=1.0,
+                )
+        assert exc_info.value.exit_code == 1
+
+    @pytest.mark.asyncio
+    async def test_refreshes_token_on_4002_close(self):
+        # A 4002 close triggers refresh; the refreshed token is used on
+        # the next attempt.
+        from klangkc import main as main_mod
+
+        seen_tokens = []
+
+        async def fake_conn(ws_url, token, *args, **kwargs):
+            seen_tokens.append(token)
+            # First call: simulate a 4002 close.
+            raise _ClosedStub(4002)
+
+        async def fake_refresh(server_url, token):
+            return "NEW_TOKEN"
+
+        async def fake_sleep(delay):
+            pass
+
+        with (
+            patch.object(main_mod, "_monitor_connection", fake_conn),
+            patch.object(main_mod, "_refresh_token_threaded", fake_refresh),
+            patch.object(main_mod.asyncio, "sleep", fake_sleep),
+            patch.object(main_mod, "_monitor_backoff", lambda a, m: 0.0),
+        ):
+            # Stop the loop after the second connect via max_reconnects.
+            with pytest.raises(typer.Exit):
+                await main_mod._monitor_run(
+                    "http://x",
+                    "ws://x/ws",
+                    "OLD_TOKEN",
+                    1024,
+                    command=[],
+                    types=[],
+                    workspaces=[],
+                    max_reconnects=1,
+                    max_delay=1.0,
+                )
+        assert seen_tokens[0] == "OLD_TOKEN"
+        assert seen_tokens[1] == "NEW_TOKEN"
+
+    @pytest.mark.asyncio
+    async def test_refresh_failure_keeps_current_token(self):
+        from klangkc import main as main_mod
+
+        seen_tokens = []
+
+        async def fake_conn(ws_url, token, *args, **kwargs):
+            seen_tokens.append(token)
+            raise _ClosedStub(4002)
+
+        async def fake_refresh(server_url, token):
+            return None  # refresh failed
+
+        async def fake_sleep(delay):
+            pass
+
+        with (
+            patch.object(main_mod, "_monitor_connection", fake_conn),
+            patch.object(main_mod, "_refresh_token_threaded", fake_refresh),
+            patch.object(main_mod.asyncio, "sleep", fake_sleep),
+            patch.object(main_mod, "_monitor_backoff", lambda a, m: 0.0),
+        ):
+            with pytest.raises(typer.Exit):
+                await main_mod._monitor_run(
+                    "http://x",
+                    "ws://x/ws",
+                    "OLD_TOKEN",
+                    1024,
+                    command=[],
+                    types=[],
+                    workspaces=[],
+                    max_reconnects=1,
+                    max_delay=1.0,
+                )
+        # Token unchanged after failed refresh.
+        assert seen_tokens[0] == "OLD_TOKEN"
+        assert seen_tokens[1] == "OLD_TOKEN"
+
+    def test_backoff_is_capped(self):
+        from klangkc.main import _monitor_backoff
+
+        # Small attempts grow; large attempts never exceed the cap.
+        for attempt in range(1, 20):
+            delay = _monitor_backoff(attempt, max_delay=30.0)
+            assert 0 < delay <= 30.0

--- a/src/cli/tests/test_cli_main.py
+++ b/src/cli/tests/test_cli_main.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 import typer
+import websockets
 
 from klangkc.client import WorkspaceNotFoundError
 from klangkc.config import (
@@ -1431,6 +1432,33 @@ class TestMainCLI:
         assert body["default_command"] == "pi"
         assert "image" not in body  # not provided, not sent
 
+    def test_edit_with_health_check_flag(self, logged_in_cfg, monkeypatch):
+        from klangkc import main
+
+        ws = Workspace(
+            id="ws1" + "0" * 52,
+            name="my-ws",
+            created_at="2025-01-01T00:00:00Z",
+            image="klangk",
+            default_command="klangk-pi",
+        )
+        client = MagicMock()
+        client.resolve_workspace.return_value = ws
+        client.put.return_value = MagicMock(status_code=200)
+
+        with patch.object(main, "_client", return_value=client):
+            from typer.testing import CliRunner
+
+            runner = CliRunner()
+            result = runner.invoke(
+                main.app,
+                ["edit", "my-ws", "--health-check", "curl -sf http://x/h"],
+            )
+            assert result.exit_code == 0
+
+        body = client.put.call_args[1]["json"]
+        assert body["health_check"] == "curl -sf http://x/h"
+
     def test_edit_clear_command(self, logged_in_cfg, monkeypatch):
         from klangkc import main
 
@@ -1486,6 +1514,36 @@ class TestMainCLI:
         assert "name" not in body  # kept current
         assert "image" not in body  # kept current
         assert body["default_command"] == "pi"
+
+    def test_edit_interactive_health_check(self, logged_in_cfg, monkeypatch):
+        from klangkc import main
+
+        ws = Workspace(
+            id="ws1" + "0" * 52,
+            name="my-ws",
+            created_at="2025-01-01T00:00:00Z",
+            image="klangk",
+            default_command="klangk-pi",
+        )
+        client = MagicMock()
+        client.resolve_workspace.return_value = ws
+        client.put.return_value = MagicMock(status_code=200)
+
+        # keep name/image/command, set health check, skip mounts/env
+        with patch.object(main, "_client", return_value=client):
+            with patch(
+                "builtins.input",
+                side_effect=["", "", "", "curl -sf http://x/h", "", ""],
+            ):
+                from typer.testing import CliRunner
+
+                runner = CliRunner()
+                result = runner.invoke(main.app, ["edit", "my-ws"])
+                assert result.exit_code == 0
+
+        body = client.put.call_args[1]["json"]
+        assert body["health_check"] == "curl -sf http://x/h"
+        assert "default_command" not in body  # kept current
 
     def test_edit_interactive_change_all(self, logged_in_cfg, monkeypatch):
         from klangkc import main
@@ -3265,3 +3323,63 @@ class TestSandboxSetupOnly:
             )
         assert result.exit_code == 1
         assert "Bind mount source does not exist" in result.output
+
+
+class TestMonitorCommand:
+    def test_monitor_invokes_run_when_logged_in(self, logged_in_cfg):
+        from klangkc import main
+
+        mock_run = AsyncMock(return_value=None)
+        with patch.object(main, "_monitor_run", new=mock_run):
+            from typer.testing import CliRunner
+
+            runner = CliRunner()
+            result = runner.invoke(main.app, ["monitor"])
+            assert result.exit_code == 0
+
+        assert mock_run.await_count == 1
+        args, kwargs = mock_run.call_args
+        assert args[0] == "http://localhost:8995"  # server_url
+        assert args[1] == "ws://localhost:8995/ws"  # ws_url
+        assert args[2] == "test-token"  # token
+        assert kwargs["max_reconnects"] != 0  # reconnects by default
+
+    def test_monitor_no_reconnect_passes_zero(self, logged_in_cfg):
+        from klangkc import main
+
+        mock_run = AsyncMock(return_value=None)
+        with patch.object(main, "_monitor_run", new=mock_run):
+            from typer.testing import CliRunner
+
+            runner = CliRunner()
+            result = runner.invoke(main.app, ["monitor", "--no-reconnect"])
+            assert result.exit_code == 0
+        assert mock_run.call_args.kwargs["max_reconnects"] == 0
+
+    def test_monitor_invalid_status_exits(self, logged_in_cfg):
+        from klangkc import main
+
+        async def _raise(*a, **kw):
+            raise websockets.InvalidStatus(MagicMock(status_code=4001))
+
+        with patch.object(main, "_monitor_run", new=_raise):
+            from typer.testing import CliRunner
+
+            runner = CliRunner()
+            result = runner.invoke(main.app, ["monitor"])
+            assert result.exit_code == 1
+            assert "Connection rejected" in result.output
+
+    def test_monitor_keyboard_interrupt_stops_cleanly(self, logged_in_cfg):
+        from klangkc import main
+
+        async def _kb(*a, **kw):
+            raise KeyboardInterrupt
+
+        with patch.object(main, "_monitor_run", new=_kb):
+            from typer.testing import CliRunner
+
+            runner = CliRunner()
+            result = runner.invoke(main.app, ["monitor"])
+            assert result.exit_code == 0
+            assert "Stopped" in result.output

--- a/src/cli/tests/test_cli_main.py
+++ b/src/cli/tests/test_cli_main.py
@@ -1472,7 +1472,9 @@ class TestMainCLI:
 
         # keep name, keep image, change command, skip add mount, skip add env
         with patch.object(main, "_client", return_value=client):
-            with patch("builtins.input", side_effect=["", "", "pi", "", ""]):
+            with patch(
+                "builtins.input", side_effect=["", "", "pi", "", "", ""]
+            ):
                 from typer.testing import CliRunner
 
                 runner = CliRunner()
@@ -1503,7 +1505,7 @@ class TestMainCLI:
         with patch.object(main, "_client", return_value=client):
             with patch(
                 "builtins.input",
-                side_effect=["renamed", "klangk-custom", "pi", "", ""],
+                side_effect=["renamed", "klangk-custom", "pi", "", "", ""],
             ):
                 from typer.testing import CliRunner
 
@@ -1533,7 +1535,7 @@ class TestMainCLI:
         with patch.object(main, "_client", return_value=client):
             with patch(
                 "builtins.input",
-                side_effect=["", "", "", "/host:/container", "", "", ""],
+                side_effect=["", "", "", "", "/host:/container", "", "", ""],
             ):
                 from typer.testing import CliRunner
 
@@ -1561,7 +1563,7 @@ class TestMainCLI:
         with patch.object(main, "_client", return_value=client):
             with patch(
                 "builtins.input",
-                side_effect=["", "", "", "", "1", "", "", ""],
+                side_effect=["", "", "", "", "", "1", "", "", ""],
             ):
                 from typer.testing import CliRunner
 
@@ -1592,7 +1594,7 @@ class TestMainCLI:
         with patch.object(main, "_client", return_value=client):
             with patch(
                 "builtins.input",
-                side_effect=["", "", "", "/new:/new", "", "1", "", "", ""],
+                side_effect=["", "", "", "", "/new:/new", "", "1", "", "", ""],
             ):
                 from typer.testing import CliRunner
 
@@ -1623,7 +1625,7 @@ class TestMainCLI:
         with patch.object(main, "_client", return_value=client):
             with patch(
                 "builtins.input",
-                side_effect=["", "", "", "", "99", "", "abc", "", "", ""],
+                side_effect=["", "", "", "", "", "99", "", "abc", "", "", ""],
             ):
                 from typer.testing import CliRunner
 
@@ -1653,7 +1655,7 @@ class TestMainCLI:
         with patch.object(main, "_client", return_value=client):
             with patch(
                 "builtins.input",
-                side_effect=["", "", "", "", "1", "", ""],
+                side_effect=["", "", "", "", "", "1", "", ""],
             ):
                 from typer.testing import CliRunner
 
@@ -1683,7 +1685,7 @@ class TestMainCLI:
         with patch.object(main, "_client", return_value=client):
             with patch(
                 "builtins.input",
-                side_effect=["", "", "", "bad", "/a:/b", "", "", ""],
+                side_effect=["", "", "", "", "bad", "/a:/b", "", "", ""],
             ):
                 from typer.testing import CliRunner
 
@@ -1798,7 +1800,7 @@ class TestMainCLI:
 
         # keep name, image, command; skip add mount (no mounts, no remove prompt)
         with patch.object(main, "_client", return_value=client):
-            with patch("builtins.input", side_effect=["", "", "", "", ""]):
+            with patch("builtins.input", side_effect=["", "", "", "", "", ""]):
                 from typer.testing import CliRunner
 
                 runner = CliRunner()
@@ -1824,7 +1826,7 @@ class TestMainCLI:
         with patch.object(main, "_client", return_value=client):
             with patch(
                 "builtins.input",
-                side_effect=["", "", "", "", "FOO=bar", "", ""],
+                side_effect=["", "", "", "", "", "FOO=bar", "", ""],
             ):
                 from typer.testing import CliRunner
 
@@ -1853,7 +1855,7 @@ class TestMainCLI:
         with patch.object(main, "_client", return_value=client):
             with patch(
                 "builtins.input",
-                side_effect=["", "", "", "", "bad", "A=1", "", ""],
+                side_effect=["", "", "", "", "", "bad", "A=1", "", ""],
             ):
                 from typer.testing import CliRunner
 
@@ -1888,6 +1890,7 @@ class TestMainCLI:
             auto_start=False,
             mounts=None,
             env={"FOO": "bar", "X": "1"},
+            health_check=None,
         )
 
     def test_create_with_invalid_env_flag(self, logged_in_cfg, monkeypatch):
@@ -1920,7 +1923,7 @@ class TestMainCLI:
         with patch.object(main, "_client", return_value=client):
             with patch(
                 "builtins.input",
-                side_effect=["", "", "", "", "", "1", "", ""],
+                side_effect=["", "", "", "", "", "", "1", "", ""],
             ):
                 from typer.testing import CliRunner
 
@@ -1950,7 +1953,7 @@ class TestMainCLI:
         with patch.object(main, "_client", return_value=client):
             with patch(
                 "builtins.input",
-                side_effect=["", "", "", "", "", "99", "", "abc", "", ""],
+                side_effect=["", "", "", "", "", "", "99", "", "abc", "", ""],
             ):
                 from typer.testing import CliRunner
 

--- a/src/frontend/lib/workspace/create_workspace_dialog.dart
+++ b/src/frontend/lib/workspace/create_workspace_dialog.dart
@@ -26,6 +26,7 @@ class CreateWorkspaceDialog extends StatefulWidget {
 class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
   final _nameController = TextEditingController();
   final _cmdController = TextEditingController();
+  final _healthCheckController = TextEditingController();
   final _mountController = TextEditingController();
   final _envController = TextEditingController();
   late String _selectedImage;
@@ -50,6 +51,7 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
   void dispose() {
     _nameController.dispose();
     _cmdController.dispose();
+    _healthCheckController.dispose();
     _mountController.dispose();
     _envController.dispose();
     super.dispose();
@@ -98,11 +100,13 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
     final name = _nameController.text.trim();
     if (name.isEmpty) return;
     final command = _cmdController.text.trim();
+    final healthCheck = _healthCheckController.text.trim();
     final body = <String, dynamic>{'name': name};
     if (command.isNotEmpty) body['default_command'] = command;
     if (_selectedImage != widget.defaultImage) {
       body['image'] = _selectedImage;
     }
+    if (healthCheck.isNotEmpty) body['health_check'] = healthCheck;
     if (_mounts.isNotEmpty) body['mounts'] = List<String>.from(_mounts);
     if (_envVars.isNotEmpty) {
       body['env'] = Map<String, String>.from(_envVars);
@@ -144,9 +148,7 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
               if (_errorMessage != null) ...[
                 Text(
                   _errorMessage!,
-                  style: TextStyle(
-                    color: Theme.of(context).colorScheme.error,
-                  ),
+                  style: TextStyle(color: Theme.of(context).colorScheme.error),
                 ),
                 const SizedBox(height: 12),
               ],
@@ -177,9 +179,8 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
                       (img) => DropdownMenuItem(value: img, child: Text(img)),
                     )
                     .toList(),
-                onChanged: (v) => setState(
-                  () => _selectedImage = v ?? widget.defaultImage,
-                ),
+                onChanged: (v) =>
+                    setState(() => _selectedImage = v ?? widget.defaultImage),
               ),
               const SizedBox(height: 16),
               TextField(
@@ -190,6 +191,19 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
                   floatingLabelStyle: _labelStyle,
                   floatingLabelBehavior: FloatingLabelBehavior.always,
                   border: const OutlineInputBorder(),
+                ),
+                onSubmitted: (_) => _submit(),
+              ),
+              const SizedBox(height: 16),
+              TextField(
+                controller: _healthCheckController,
+                decoration: InputDecoration(
+                  labelText: 'Health check command (optional)',
+                  labelStyle: _labelStyle,
+                  floatingLabelStyle: _labelStyle,
+                  floatingLabelBehavior: FloatingLabelBehavior.always,
+                  border: const OutlineInputBorder(),
+                  hintText: 'e.g. curl -sf http://localhost:8080/health',
                 ),
                 onSubmitted: (_) => _submit(),
               ),
@@ -205,10 +219,7 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
           style: TextButton.styleFrom(foregroundColor: KColors.accentRed),
           child: const Text('Cancel'),
         ),
-        FilledButton(
-          onPressed: _submit,
-          child: const Text('Create'),
-        ),
+        FilledButton(onPressed: _submit, child: const Text('Create')),
       ],
     );
   }
@@ -219,35 +230,35 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
       Text('Mounts', style: _labelStyle),
       const SizedBox(height: 8),
       ..._mounts.asMap().entries.map(
-            (e) => Padding(
-              padding: const EdgeInsets.only(bottom: 4),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: SelectableText(
-                      e.value,
-                      style: const TextStyle(fontSize: 13),
-                    ),
-                  ),
-                  IconButton(
-                    icon: const Icon(Icons.copy, size: 16),
-                    tooltip: 'Copy',
-                    onPressed: () =>
-                        Clipboard.setData(ClipboardData(text: e.value)),
-                    padding: EdgeInsets.zero,
-                    constraints: const BoxConstraints(),
-                  ),
-                  const SizedBox(width: 4),
-                  IconButton(
-                    icon: const Icon(Icons.close, size: 18),
-                    onPressed: () => setState(() => _mounts.removeAt(e.key)),
-                    padding: EdgeInsets.zero,
-                    constraints: const BoxConstraints(),
-                  ),
-                ],
+        (e) => Padding(
+          padding: const EdgeInsets.only(bottom: 4),
+          child: Row(
+            children: [
+              Expanded(
+                child: SelectableText(
+                  e.value,
+                  style: const TextStyle(fontSize: 13),
+                ),
               ),
-            ),
+              IconButton(
+                icon: const Icon(Icons.copy, size: 16),
+                tooltip: 'Copy',
+                onPressed: () =>
+                    Clipboard.setData(ClipboardData(text: e.value)),
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints(),
+              ),
+              const SizedBox(width: 4),
+              IconButton(
+                icon: const Icon(Icons.close, size: 18),
+                onPressed: () => setState(() => _mounts.removeAt(e.key)),
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints(),
+              ),
+            ],
           ),
+        ),
+      ),
       if (_mountError != null) ...[
         Text(
           _mountError!,
@@ -285,37 +296,36 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
       Text('Environment Variables', style: _labelStyle),
       const SizedBox(height: 8),
       ..._envVars.entries.toList().asMap().entries.map(
-            (e) => Padding(
-              padding: const EdgeInsets.only(bottom: 4),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: SelectableText(
-                      '${e.value.key}=${e.value.value}',
-                      style: const TextStyle(fontSize: 13),
-                    ),
-                  ),
-                  IconButton(
-                    icon: const Icon(Icons.copy, size: 16),
-                    tooltip: 'Copy',
-                    onPressed: () => Clipboard.setData(
-                      ClipboardData(text: '${e.value.key}=${e.value.value}'),
-                    ),
-                    padding: EdgeInsets.zero,
-                    constraints: const BoxConstraints(),
-                  ),
-                  const SizedBox(width: 4),
-                  IconButton(
-                    icon: const Icon(Icons.close, size: 18),
-                    onPressed: () =>
-                        setState(() => _envVars.remove(e.value.key)),
-                    padding: EdgeInsets.zero,
-                    constraints: const BoxConstraints(),
-                  ),
-                ],
+        (e) => Padding(
+          padding: const EdgeInsets.only(bottom: 4),
+          child: Row(
+            children: [
+              Expanded(
+                child: SelectableText(
+                  '${e.value.key}=${e.value.value}',
+                  style: const TextStyle(fontSize: 13),
+                ),
               ),
-            ),
+              IconButton(
+                icon: const Icon(Icons.copy, size: 16),
+                tooltip: 'Copy',
+                onPressed: () => Clipboard.setData(
+                  ClipboardData(text: '${e.value.key}=${e.value.value}'),
+                ),
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints(),
+              ),
+              const SizedBox(width: 4),
+              IconButton(
+                icon: const Icon(Icons.close, size: 18),
+                onPressed: () => setState(() => _envVars.remove(e.value.key)),
+                padding: EdgeInsets.zero,
+                constraints: const BoxConstraints(),
+              ),
+            ],
           ),
+        ),
+      ),
       if (_envError != null) ...[
         Text(
           _envError!,

--- a/src/frontend/lib/workspace/create_workspace_dialog.dart
+++ b/src/frontend/lib/workspace/create_workspace_dialog.dart
@@ -194,6 +194,8 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
                 ),
                 onSubmitted: (_) => _submit(),
               ),
+              ..._buildMountsEditor(),
+              ..._buildEnvVarsEditor(),
               const SizedBox(height: 16),
               TextField(
                 controller: _healthCheckController,
@@ -207,8 +209,6 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
                 ),
                 onSubmitted: (_) => _submit(),
               ),
-              ..._buildMountsEditor(),
-              ..._buildEnvVarsEditor(),
             ],
           ),
         ),
@@ -230,35 +230,35 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
       Text('Mounts', style: _labelStyle),
       const SizedBox(height: 8),
       ..._mounts.asMap().entries.map(
-        (e) => Padding(
-          padding: const EdgeInsets.only(bottom: 4),
-          child: Row(
-            children: [
-              Expanded(
-                child: SelectableText(
-                  e.value,
-                  style: const TextStyle(fontSize: 13),
-                ),
+            (e) => Padding(
+              padding: const EdgeInsets.only(bottom: 4),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: SelectableText(
+                      e.value,
+                      style: const TextStyle(fontSize: 13),
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.copy, size: 16),
+                    tooltip: 'Copy',
+                    onPressed: () =>
+                        Clipboard.setData(ClipboardData(text: e.value)),
+                    padding: EdgeInsets.zero,
+                    constraints: const BoxConstraints(),
+                  ),
+                  const SizedBox(width: 4),
+                  IconButton(
+                    icon: const Icon(Icons.close, size: 18),
+                    onPressed: () => setState(() => _mounts.removeAt(e.key)),
+                    padding: EdgeInsets.zero,
+                    constraints: const BoxConstraints(),
+                  ),
+                ],
               ),
-              IconButton(
-                icon: const Icon(Icons.copy, size: 16),
-                tooltip: 'Copy',
-                onPressed: () =>
-                    Clipboard.setData(ClipboardData(text: e.value)),
-                padding: EdgeInsets.zero,
-                constraints: const BoxConstraints(),
-              ),
-              const SizedBox(width: 4),
-              IconButton(
-                icon: const Icon(Icons.close, size: 18),
-                onPressed: () => setState(() => _mounts.removeAt(e.key)),
-                padding: EdgeInsets.zero,
-                constraints: const BoxConstraints(),
-              ),
-            ],
+            ),
           ),
-        ),
-      ),
       if (_mountError != null) ...[
         Text(
           _mountError!,
@@ -296,36 +296,37 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
       Text('Environment Variables', style: _labelStyle),
       const SizedBox(height: 8),
       ..._envVars.entries.toList().asMap().entries.map(
-        (e) => Padding(
-          padding: const EdgeInsets.only(bottom: 4),
-          child: Row(
-            children: [
-              Expanded(
-                child: SelectableText(
-                  '${e.value.key}=${e.value.value}',
-                  style: const TextStyle(fontSize: 13),
-                ),
+            (e) => Padding(
+              padding: const EdgeInsets.only(bottom: 4),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: SelectableText(
+                      '${e.value.key}=${e.value.value}',
+                      style: const TextStyle(fontSize: 13),
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.copy, size: 16),
+                    tooltip: 'Copy',
+                    onPressed: () => Clipboard.setData(
+                      ClipboardData(text: '${e.value.key}=${e.value.value}'),
+                    ),
+                    padding: EdgeInsets.zero,
+                    constraints: const BoxConstraints(),
+                  ),
+                  const SizedBox(width: 4),
+                  IconButton(
+                    icon: const Icon(Icons.close, size: 18),
+                    onPressed: () =>
+                        setState(() => _envVars.remove(e.value.key)),
+                    padding: EdgeInsets.zero,
+                    constraints: const BoxConstraints(),
+                  ),
+                ],
               ),
-              IconButton(
-                icon: const Icon(Icons.copy, size: 16),
-                tooltip: 'Copy',
-                onPressed: () => Clipboard.setData(
-                  ClipboardData(text: '${e.value.key}=${e.value.value}'),
-                ),
-                padding: EdgeInsets.zero,
-                constraints: const BoxConstraints(),
-              ),
-              const SizedBox(width: 4),
-              IconButton(
-                icon: const Icon(Icons.close, size: 18),
-                onPressed: () => setState(() => _envVars.remove(e.value.key)),
-                padding: EdgeInsets.zero,
-                constraints: const BoxConstraints(),
-              ),
-            ],
+            ),
           ),
-        ),
-      ),
       if (_envError != null) ...[
         Text(
           _envError!,

--- a/src/frontend/lib/workspace/workspace_list_page.dart
+++ b/src/frontend/lib/workspace/workspace_list_page.dart
@@ -76,7 +76,8 @@ class _Section {
   /// sort/order/filter query params.
   String path(int offset) {
     final base = isShared ? '/api/v1/workspaces/shared' : '/api/v1/workspaces';
-    var p = '$base?limit=${_WorkspaceListPageState._pageSize}&offset=$offset'
+    var p =
+        '$base?limit=${_WorkspaceListPageState._pageSize}&offset=$offset'
         '&sort=$sort&order=$order';
     if (query.isNotEmpty) p += '&q=${Uri.encodeQueryComponent(query)}';
     return p;
@@ -100,6 +101,7 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
   bool _loading = true;
   StreamSubscription<void>? _workspacesChangedSub;
   StreamSubscription<Map<String, dynamic>>? _containerStatusSub;
+  StreamSubscription<Map<String, dynamic>>? _serviceHealthSub;
 
   @override
   void initState() {
@@ -111,6 +113,7 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
       _refreshWorkspaces();
     });
     _containerStatusSub = wsClient.containerStatus.listen(_onContainerStatus);
+    _serviceHealthSub = wsClient.serviceHealth.listen(_onServiceHealth);
   }
 
   void _onContainerStatus(Map<String, dynamic> msg) {
@@ -123,6 +126,24 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
         for (final ws in section.workspaces) {
           if (ws['id'] == wsId) {
             ws['running'] = running;
+            // A stopped container has no health status.
+            if (!running) ws['health'] = null;
+          }
+        }
+      }
+    });
+  }
+
+  void _onServiceHealth(Map<String, dynamic> msg) {
+    if (!mounted) return;
+    final wsId = msg['workspace_id'] as String?;
+    final healthy = msg['healthy'] as bool? ?? false;
+    if (wsId == null) return;
+    setState(() {
+      for (final section in [_owned, _shared]) {
+        for (final ws in section.workspaces) {
+          if (ws['id'] == wsId) {
+            ws['health'] = healthy ? 'healthy' : 'unhealthy';
           }
         }
       }
@@ -133,6 +154,7 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
   void dispose() {
     _workspacesChangedSub?.cancel();
     _containerStatusSub?.cancel();
+    _serviceHealthSub?.cancel();
     _owned.dispose();
     _shared.dispose();
     super.dispose();
@@ -142,21 +164,22 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
 
   /// Parse a paginated envelope response into its items + cursors.
   static ({List<Map<String, dynamic>> items, bool hasMore, int? nextOffset})
-      _parseEnvelope(String body) {
+  _parseEnvelope(String body) {
     final json = jsonDecode(body) as Map<String, dynamic>;
     final items = (json['items'] as List).cast<Map<String, dynamic>>();
     return (
       items: items,
       hasMore: json['has_more'] == true,
-      nextOffset:
-          json['next_offset'] is int ? json['next_offset'] as int : null,
+      nextOffset: json['next_offset'] is int
+          ? json['next_offset'] as int
+          : null,
     );
   }
 
   /// Fetch one page for [section] at [offset]. Returns the parsed page or
   /// null on failure. Caller handles members + state.
   Future<({List<Map<String, dynamic>> items, bool hasMore, int? nextOffset})?>
-      _fetchPage(_Section section, int offset) async {
+  _fetchPage(_Section section, int offset) async {
     try {
       final resp = await _auth.authGet(section.path(offset));
       if (resp.statusCode != 200) return null;
@@ -448,8 +471,9 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
     return ActionChip(
       label: Text(active ? '$label $arrow' : label),
       onPressed: () => _changeSort(section, sortKey),
-      backgroundColor:
-          active ? KColors.accentBlue.withValues(alpha: 0.2) : null,
+      backgroundColor: active
+          ? KColors.accentBlue.withValues(alpha: 0.2)
+          : null,
     );
   }
 
@@ -494,82 +518,92 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           ...section.workspaces.asMap().entries.map(
-                (e) => Material(
-                  color: e.key.isEven
-                      ? Colors.white.withValues(alpha: 0.03)
-                      : Colors.transparent,
-                  child: ListTile(
-                    leading: Icon(
-                      Icons.terminal,
-                      size: 20,
-                      // The icon itself signals running state: green when
-                      // the container is up, grey when stopped. Owned and
-                      // shared share one color scheme now that they live on
-                      // separate tabs, so no ownership distinction is needed.
-                      color: (e.value['running'] as bool? ?? false)
-                          ? KColors.accentGreen
-                          : KColors.textSecondary,
-                    ),
-                    title: Text(e.value['name'] as String),
-                    subtitle: section.isShared
-                        ? Text(
-                            '${e.value['owner_email']} · ${_formatCreatedAt(e.value['created_at'] as String?)}',
-                          )
-                        : Builder(builder: (context) {
-                            final wsMembers =
-                                _workspaceMembers[e.value['id'] as String] ??
-                                    [];
-                            return Row(
-                              children: [
-                                Text(_formatCreatedAt(
+            (e) => Material(
+              color: e.key.isEven
+                  ? Colors.white.withValues(alpha: 0.03)
+                  : Colors.transparent,
+              child: ListTile(
+                leading: Icon(
+                  Icons.terminal,
+                  size: 20,
+                  // The icon signals container/health state: green
+                  // when healthy (or running with no health check),
+                  // amber when running but the health check failed,
+                  // grey when stopped.
+                  color: () {
+                    final running = (e.value['running'] as bool? ?? false);
+                    if (!running) return KColors.textSecondary;
+                    final health = e.value['health'] as String?;
+                    if (health == 'unhealthy') {
+                      return Colors.orange;
+                    }
+                    return KColors.accentGreen;
+                  }(),
+                ),
+                title: Text(e.value['name'] as String),
+                subtitle: section.isShared
+                    ? Text(
+                        '${e.value['owner_email']} · ${_formatCreatedAt(e.value['created_at'] as String?)}',
+                      )
+                    : Builder(
+                        builder: (context) {
+                          final wsMembers =
+                              _workspaceMembers[e.value['id'] as String] ?? [];
+                          return Row(
+                            children: [
+                              Text(
+                                _formatCreatedAt(
                                   e.value['created_at'] as String?,
-                                )),
-                                if (wsMembers.isNotEmpty) ...[
-                                  const SizedBox(width: 8),
-                                  ...wsMembers.map((m) {
-                                    final email = m['email'] as String;
-                                    final letter = email.isNotEmpty
-                                        ? email[0].toUpperCase()
-                                        : '?';
-                                    return Padding(
-                                      padding: const EdgeInsets.only(right: 2),
-                                      child: Tooltip(
-                                        message: email,
-                                        child: CircleAvatar(
-                                          radius: 10,
-                                          backgroundColor:
-                                              KColors.colorForString(email),
-                                          child: Text(
-                                            letter,
-                                            style: const TextStyle(
-                                              fontSize: 10,
-                                              color: Colors.white,
-                                              fontWeight: FontWeight.bold,
-                                            ),
+                                ),
+                              ),
+                              if (wsMembers.isNotEmpty) ...[
+                                const SizedBox(width: 8),
+                                ...wsMembers.map((m) {
+                                  final email = m['email'] as String;
+                                  final letter = email.isNotEmpty
+                                      ? email[0].toUpperCase()
+                                      : '?';
+                                  return Padding(
+                                    padding: const EdgeInsets.only(right: 2),
+                                    child: Tooltip(
+                                      message: email,
+                                      child: CircleAvatar(
+                                        radius: 10,
+                                        backgroundColor: KColors.colorForString(
+                                          email,
+                                        ),
+                                        child: Text(
+                                          letter,
+                                          style: const TextStyle(
+                                            fontSize: 10,
+                                            color: Colors.white,
+                                            fontWeight: FontWeight.bold,
                                           ),
                                         ),
                                       ),
-                                    );
-                                  }),
-                                ],
+                                    ),
+                                  );
+                                }),
                               ],
-                            );
-                          }),
-                    trailing: section.isShared
-                        ? null
-                        : IconButton(
-                            icon: const Icon(Icons.delete_outline),
-                            tooltip: 'Delete workspace',
-                            onPressed: () =>
-                                _deleteWorkspace(e.value['id'] as String),
-                          ),
-                    onTap: () =>
-                        // coverage:ignore-start
-                        context.go('/workspace/${e.value['id']}'),
-                    // coverage:ignore-end
-                  ),
-                ),
+                            ],
+                          );
+                        },
+                      ),
+                trailing: section.isShared
+                    ? null
+                    : IconButton(
+                        icon: const Icon(Icons.delete_outline),
+                        tooltip: 'Delete workspace',
+                        onPressed: () =>
+                            _deleteWorkspace(e.value['id'] as String),
+                      ),
+                onTap: () =>
+                    // coverage:ignore-start
+                    context.go('/workspace/${e.value['id']}'),
+                // coverage:ignore-end
               ),
+            ),
+          ),
           _loadMoreButton(
             section.isShared
                 ? 'Load more shared workspaces'
@@ -596,8 +630,8 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
               child: Text(
                 section.query.isEmpty
                     ? (section.isShared
-                        ? 'No workspaces shared with you.'
-                        : 'No workspaces yet. Create one to get started.')
+                          ? 'No workspaces shared with you.'
+                          : 'No workspaces yet. Create one to get started.')
                     : 'No workspaces match.',
               ),
             ),
@@ -627,10 +661,7 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
           ),
           Expanded(
             child: TabBarView(
-              children: [
-                _buildTabBody(_owned),
-                _buildTabBody(_shared),
-              ],
+              children: [_buildTabBody(_owned), _buildTabBody(_shared)],
             ),
           ),
         ],
@@ -647,25 +678,25 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
       ),
       floatingActionButton:
           context.watch<AuthService>().hasPermission('/workspaces', 'create')
-              ? Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    FloatingActionButton.small(
-                      heroTag: 'import',
-                      onPressed: _showImportDialog,
-                      tooltip: 'Import Workspace',
-                      child: const Icon(Icons.upload),
-                    ),
-                    const SizedBox(height: 12),
-                    FloatingActionButton(
-                      heroTag: 'create',
-                      onPressed: _createWorkspace,
-                      tooltip: 'New Workspace',
-                      child: const Icon(Icons.add),
-                    ),
-                  ],
-                )
-              : null,
+          ? Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                FloatingActionButton.small(
+                  heroTag: 'import',
+                  onPressed: _showImportDialog,
+                  tooltip: 'Import Workspace',
+                  child: const Icon(Icons.upload),
+                ),
+                const SizedBox(height: 12),
+                FloatingActionButton(
+                  heroTag: 'create',
+                  onPressed: _createWorkspace,
+                  tooltip: 'New Workspace',
+                  child: const Icon(Icons.add),
+                ),
+              ],
+            )
+          : null,
       body: _buildWorkspacesList(),
     );
   }

--- a/src/frontend/lib/workspace/workspace_settings_panel.dart
+++ b/src/frontend/lib/workspace/workspace_settings_panel.dart
@@ -49,9 +49,9 @@ class WorkspaceSettingsPanelState extends State<WorkspaceSettingsPanel> {
     }
 
     var ws = workspaces.cast<Map<String, dynamic>?>().firstWhere(
-          (w) => w!['id'] == widget.workspaceId,
-          orElse: () => null,
-        );
+      (w) => w!['id'] == widget.workspaceId,
+      orElse: () => null,
+    );
 
     // Try shared workspaces if not found in owned
     if (ws == null) {
@@ -62,9 +62,9 @@ class WorkspaceSettingsPanelState extends State<WorkspaceSettingsPanel> {
           jsonDecode(sharedResp.body),
         );
         ws = shared.cast<Map<String, dynamic>?>().firstWhere(
-              (w) => w!['id'] == widget.workspaceId,
-              orElse: () => null,
-            );
+          (w) => w!['id'] == widget.workspaceId,
+          orElse: () => null,
+        );
       }
     }
 
@@ -161,6 +161,7 @@ class _SettingsForm extends StatefulWidget {
 class _SettingsFormState extends State<_SettingsForm> {
   late TextEditingController _nameCtrl;
   late TextEditingController _cmdCtrl;
+  late TextEditingController _healthCheckCtrl;
   final _mountCtrl = TextEditingController();
   final _envCtrl = TextEditingController();
   late String _selectedImage;
@@ -179,6 +180,9 @@ class _SettingsFormState extends State<_SettingsForm> {
     );
     _cmdCtrl = TextEditingController(
       text: widget.workspace['default_command'] as String? ?? '',
+    );
+    _healthCheckCtrl = TextEditingController(
+      text: widget.workspace['health_check'] as String? ?? '',
     );
     _selectedImage =
         widget.workspace['image'] as String? ?? widget.defaultImage;
@@ -207,12 +211,17 @@ class _SettingsFormState extends State<_SettingsForm> {
         widget.workspace['default_command']) {
       _cmdCtrl.text = widget.workspace['default_command'] as String? ?? '';
     } // coverage:ignore-end
+    if (old.workspace['health_check'] != widget.workspace['health_check']) {
+      // coverage:ignore-start
+      _healthCheckCtrl.text = widget.workspace['health_check'] as String? ?? '';
+    } // coverage:ignore-end
   }
 
   @override
   void dispose() {
     _nameCtrl.dispose();
     _cmdCtrl.dispose();
+    _healthCheckCtrl.dispose();
     _mountCtrl.dispose();
     _envCtrl.dispose();
     super.dispose();
@@ -223,8 +232,12 @@ class _SettingsFormState extends State<_SettingsForm> {
     await widget.onSave({
       'name': _nameCtrl.text.trim(),
       'image': _selectedImage,
-      'default_command':
-          _cmdCtrl.text.trim().isEmpty ? null : _cmdCtrl.text.trim(),
+      'default_command': _cmdCtrl.text.trim().isEmpty
+          ? null
+          : _cmdCtrl.text.trim(),
+      'health_check': _healthCheckCtrl.text.trim().isEmpty
+          ? null
+          : _healthCheckCtrl.text.trim(),
       'mounts': _mounts.isNotEmpty ? _mounts : null,
       'env': _envVars.isNotEmpty ? _envVars : null,
     });
@@ -372,9 +385,7 @@ class _SettingsFormState extends State<_SettingsForm> {
               border: const OutlineInputBorder(),
             ),
             items: widget.allowedImages
-                .map(
-                  (img) => DropdownMenuItem(value: img, child: Text(img)),
-                )
+                .map((img) => DropdownMenuItem(value: img, child: Text(img)))
                 .toList(),
             onChanged: (v) =>
                 setState(() => _selectedImage = v ?? widget.defaultImage),
@@ -388,6 +399,17 @@ class _SettingsFormState extends State<_SettingsForm> {
             floatingLabelBehavior: FloatingLabelBehavior.always,
             border: const OutlineInputBorder(),
             hintText: 'Optional — runs on terminal open',
+          ),
+        ),
+        const SizedBox(height: 16),
+        TextField(
+          controller: _healthCheckCtrl,
+          decoration: InputDecoration(
+            labelText: 'Health Check Command',
+            labelStyle: labelStyle,
+            floatingLabelBehavior: FloatingLabelBehavior.always,
+            border: const OutlineInputBorder(),
+            hintText: 'Optional — polled to gauge service health',
           ),
         ),
         const SizedBox(height: 16),
@@ -425,12 +447,12 @@ class _SettingsFormState extends State<_SettingsForm> {
       error: _mountError,
       onAdd: _tryAddMount,
       items: _mounts.asMap().entries.map(
-            (e) => _buildEditableListItem(
-              text: e.value,
-              onCopy: e.value,
-              onRemove: () => setState(() => _mounts.removeAt(e.key)),
-            ),
-          ),
+        (e) => _buildEditableListItem(
+          text: e.value,
+          onCopy: e.value,
+          onRemove: () => setState(() => _mounts.removeAt(e.key)),
+        ),
+      ),
     );
   }
 
@@ -443,12 +465,12 @@ class _SettingsFormState extends State<_SettingsForm> {
       error: _envError,
       onAdd: _tryAddEnv,
       items: _envVars.entries.toList().asMap().entries.map(
-            (e) => _buildEditableListItem(
-              text: '${e.value.key}=${e.value.value}',
-              onCopy: '${e.value.key}=${e.value.value}',
-              onRemove: () => setState(() => _envVars.remove(e.value.key)),
-            ),
-          ),
+        (e) => _buildEditableListItem(
+          text: '${e.value.key}=${e.value.value}',
+          onCopy: '${e.value.key}=${e.value.value}',
+          onRemove: () => setState(() => _envVars.remove(e.value.key)),
+        ),
+      ),
     );
   }
 
@@ -514,10 +536,7 @@ class _SettingsFormState extends State<_SettingsForm> {
       child: Row(
         children: [
           Expanded(
-            child: SelectableText(
-              text,
-              style: const TextStyle(fontSize: 13),
-            ),
+            child: SelectableText(text, style: const TextStyle(fontSize: 13)),
           ),
           IconButton(
             icon: const Icon(Icons.copy, size: 16),

--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -17,7 +17,7 @@ class WsDebugEntry {
   final Map<String, dynamic>? data;
 
   WsDebugEntry({required this.direction, required this.summary, this.data})
-      : timestamp = DateTime.now();
+    : timestamp = DateTime.now();
 }
 
 /// Manages WebSocket connection to the Klangk backend, sending commands
@@ -108,6 +108,8 @@ class WsClient extends ChangeNotifier {
   final _workspacesChangedController = StreamController<void>.broadcast();
   final _containerStatusController =
       StreamController<Map<String, dynamic>>.broadcast();
+  final _serviceHealthController =
+      StreamController<Map<String, dynamic>>.broadcast();
   final _debugLogController = StreamController<WsDebugEntry>.broadcast();
 
   Stream<String> get errors => _errorController.stream;
@@ -154,6 +156,8 @@ class WsClient extends ChangeNotifier {
   /// Fires when a container starts or stops.
   Stream<Map<String, dynamic>> get containerStatus =>
       _containerStatusController.stream;
+  Stream<Map<String, dynamic>> get serviceHealth =>
+      _serviceHealthController.stream;
 
   /// Debug log of all WebSocket messages (sent and received).
   Stream<WsDebugEntry> get debugLog => _debugLogController.stream;
@@ -226,8 +230,10 @@ class WsClient extends ChangeNotifier {
     _reconnectTimer?.cancel();
     _reconnectTimer = null;
     if (_connected || _connecting || _auth?.token == null) {
-      debugPrint('[WsClient] connect() early return: connected=$_connected '
-          'connecting=$_connecting token=${_auth?.token != null}');
+      debugPrint(
+        '[WsClient] connect() early return: connected=$_connected '
+        'connecting=$_connecting token=${_auth?.token != null}',
+      );
       return;
     }
 
@@ -245,7 +251,8 @@ class WsClient extends ChangeNotifier {
     debugPrint('[WsClient] _waitForServer() start: ${DateTime.now()}');
     final serverUp = await _waitForServer();
     debugPrint(
-        '[WsClient] _waitForServer() done: serverUp=$serverUp ${DateTime.now()}');
+      '[WsClient] _waitForServer() done: serverUp=$serverUp ${DateTime.now()}',
+    );
     if (!serverUp) {
       return;
     }
@@ -263,10 +270,12 @@ class WsClient extends ChangeNotifier {
       // coverage:ignore-start
       final uri = Uri.parse('$_wsBaseUrl?token=${_auth!.token}');
       debugPrint(
-          '[WsClient] WebSocketChannel.connect() start: ${DateTime.now()}');
+        '[WsClient] WebSocketChannel.connect() start: ${DateTime.now()}',
+      );
       _channel = WebSocketChannel.connect(uri);
       debugPrint(
-          '[WsClient] WebSocketChannel.connect() returned: ${DateTime.now()}');
+        '[WsClient] WebSocketChannel.connect() returned: ${DateTime.now()}',
+      );
       // coverage:ignore-end
     }
 
@@ -326,6 +335,7 @@ class WsClient extends ChangeNotifier {
     'shared_terminal_deleted': _onSharedTerminalDeleted,
     'workspaces_changed': (json) => _workspacesChangedController.add(null),
     'container_status': _containerStatusController.add,
+    'service_health': _serviceHealthController.add,
     'event': _customEventController.add,
   };
 
@@ -450,9 +460,7 @@ class WsClient extends ChangeNotifier {
   }
 
   void _onTerminalWindows(Map<String, dynamic> json) {
-    debugPrint(
-      '[WsClient] terminal_windows received: ${DateTime.now()}',
-    );
+    debugPrint('[WsClient] terminal_windows received: ${DateTime.now()}');
     final windows = json['windows'] as List? ?? [];
     terminalWindows = windows.cast<Map<String, dynamic>>();
     notifyListeners();
@@ -548,7 +556,7 @@ class WsClient extends ChangeNotifier {
       debugPrint('[WsClient] browser_reattach: $bid'); // coverage:ignore-start
       _send({
         'cmd': 'browser_reattach',
-        'browser_id': bid
+        'browser_id': bid,
       }); // coverage:ignore-end
     }
   }
@@ -729,6 +737,7 @@ class WsClient extends ChangeNotifier {
     _sharedTerminalDeletedController.close();
     _workspacesChangedController.close();
     _containerStatusController.close();
+    _serviceHealthController.close();
     _debugLogController.close();
     super.dispose();
   }

--- a/src/frontend/test/create_workspace_dialog_test.dart
+++ b/src/frontend/test/create_workspace_dialog_test.dart
@@ -129,6 +129,43 @@ void main() {
       expect(postedBody!['name'], 'My WS');
     });
 
+    testWidgets('submits health_check when provided', (tester) async {
+      Map<String, dynamic>? postedBody;
+      testAuthHttpClientOverride = mockClient((request) async {
+        if (request.url.path == '/api/v1/workspaces' &&
+            request.method == 'POST') {
+          postedBody = jsonDecode(request.body) as Map<String, dynamic>;
+          return http.Response(
+            jsonEncode({'id': 'ws-1', 'name': 'My WS', 'created_at': ''}),
+            200,
+          );
+        }
+        return http.Response('Not found', 404);
+      });
+      await tester.pumpWidget(buildDialog());
+      await tester.pump(); // post-frame callback
+      await tester.pump(); // dialog renders
+
+      await tester.enterText(find.byType(TextField).first, 'My WS');
+      final healthCheckField = find.byWidgetPredicate(
+        (w) =>
+            w is TextField &&
+            w.decoration?.labelText == 'Health check command (optional)',
+      );
+      await tester.ensureVisible(healthCheckField);
+      await tester.enterText(
+        healthCheckField,
+        'curl -sf http://localhost:8080/health',
+      );
+      await tester.tap(find.text('Create'));
+      await tester.pump();
+      await tester.pump();
+
+      expect(postedBody, isNotNull);
+      expect(
+          postedBody!['health_check'], 'curl -sf http://localhost:8080/health');
+    });
+
     testWidgets('shows error on failure', (tester) async {
       testAuthHttpClientOverride = mockClient((request) async {
         if (request.method == 'POST') {

--- a/src/frontend/test/create_workspace_dialog_test.dart
+++ b/src/frontend/test/create_workspace_dialog_test.dart
@@ -157,7 +157,10 @@ void main() {
         healthCheckField,
         'curl -sf http://localhost:8080/health',
       );
-      await tester.tap(find.text('Create'));
+      // Submit via Enter key in the health-check field — exercises its
+      // onSubmitted -> _submit() path (the 'Create' tap is covered by
+      // the basic submit test above).
+      await tester.testTextInput.receiveAction(TextInputAction.done);
       await tester.pump();
       await tester.pump();
 

--- a/src/frontend/test/create_workspace_dialog_test.dart
+++ b/src/frontend/test/create_workspace_dialog_test.dart
@@ -83,7 +83,7 @@ void main() {
       expect(find.text('New Workspace'), findsOneWidget);
       expect(find.text('Cancel'), findsOneWidget);
       expect(find.text('Create'), findsOneWidget);
-      expect(find.byType(TextField), findsNWidgets(4));
+      expect(find.byType(TextField), findsNWidgets(5));
       expect(find.byType(DropdownButtonFormField<String>), findsOneWidget);
     });
 
@@ -210,6 +210,7 @@ void main() {
 
       // 4th TextField is env input
       await tester.enterText(find.byType(TextField).at(3), 'FOO=bar');
+      await tester.ensureVisible(find.byIcon(Icons.add).at(1));
       await tester.tap(find.byIcon(Icons.add).at(1));
       await tester.pump();
 
@@ -225,6 +226,7 @@ void main() {
       await tester.pump(); // dialog renders
 
       await tester.enterText(find.byType(TextField).at(3), 'NOEQUALS');
+      await tester.ensureVisible(find.byIcon(Icons.add).at(1));
       await tester.tap(find.byIcon(Icons.add).at(1));
       await tester.pump();
 
@@ -240,6 +242,7 @@ void main() {
       await tester.pump(); // dialog renders
 
       await tester.enterText(find.byType(TextField).at(3), '=value');
+      await tester.ensureVisible(find.byIcon(Icons.add).at(1));
       await tester.tap(find.byIcon(Icons.add).at(1));
       await tester.pump();
 
@@ -255,6 +258,7 @@ void main() {
       await tester.pump(); // dialog renders
 
       await tester.enterText(find.byType(TextField).at(3), 'MYKEY=val');
+      await tester.ensureVisible(find.byIcon(Icons.add).at(1));
       await tester.tap(find.byIcon(Icons.add).at(1));
       await tester.pumpAndSettle();
       expect(find.widgetWithText(SelectableText, 'MYKEY=val'), findsOneWidget);
@@ -366,12 +370,14 @@ void main() {
 
       // Invalid env
       await tester.enterText(envInput, 'bad');
+      await tester.ensureVisible(find.byIcon(Icons.add).at(1));
       await tester.tap(find.byIcon(Icons.add).at(1));
       await tester.pumpAndSettle();
       expect(find.text('Expected KEY=VALUE format'), findsOneWidget);
 
       // Valid env clears error
       await tester.enterText(envInput, 'OK=yes');
+      await tester.ensureVisible(find.byIcon(Icons.add).at(1));
       await tester.tap(find.byIcon(Icons.add).at(1));
       await tester.pumpAndSettle();
       expect(find.text('Expected KEY=VALUE format'), findsNothing);

--- a/src/frontend/test/workspace_list_page_test.dart
+++ b/src/frontend/test/workspace_list_page_test.dart
@@ -963,7 +963,7 @@ void main() {
       expect(
           find.descendant(
               of: find.byType(AlertDialog), matching: find.byType(TextField)),
-          findsNWidgets(4));
+          findsNWidgets(5));
       expect(find.byType(DropdownButtonFormField<String>), findsOneWidget);
     });
 
@@ -2096,6 +2096,7 @@ void main() {
                   matching: find.byType(TextField))
               .at(3),
           'FOO=bar');
+      await tester.ensureVisible(find.byIcon(Icons.add).at(2));
       await tester.tap(find.byIcon(Icons.add).at(2));
       await tester.pumpAndSettle();
       expect(find.text('FOO=bar'), findsOneWidget);
@@ -2114,6 +2115,7 @@ void main() {
 
       // Remove the first env var via X button
       // close icons: mount has none, env has 2 (FOO=bar, X=1)
+      await tester.ensureVisible(find.byIcon(Icons.close).first);
       await tester.tap(find.byIcon(Icons.close).first);
       await tester.pumpAndSettle();
       expect(find.text('FOO=bar'), findsNothing);

--- a/src/frontend/test/workspace_list_page_test.dart
+++ b/src/frontend/test/workspace_list_page_test.dart
@@ -28,12 +28,17 @@ class _MockWsClient extends WsClient {
       StreamController<void>.broadcast();
   final StreamController<Map<String, dynamic>> _containerStatus =
       StreamController<Map<String, dynamic>>.broadcast();
+  final StreamController<Map<String, dynamic>> _serviceHealth =
+      StreamController<Map<String, dynamic>>.broadcast();
 
   @override
   Stream<void> get workspacesChanged => _workspacesChanged.stream;
 
   @override
   Stream<Map<String, dynamic>> get containerStatus => _containerStatus.stream;
+
+  @override
+  Stream<Map<String, dynamic>> get serviceHealth => _serviceHealth.stream;
 
   void emitWorkspacesChanged() => _workspacesChanged.add(null);
 
@@ -44,10 +49,18 @@ class _MockWsClient extends WsClient {
         'running': running,
       });
 
+  void emitServiceHealth(String workspaceId, bool healthy) =>
+      _serviceHealth.add({
+        'type': 'service_health',
+        'workspace_id': workspaceId,
+        'healthy': healthy,
+      });
+
   @override
   void dispose() {
     _workspacesChanged.close();
     _containerStatus.close();
+    _serviceHealth.close();
     super.dispose();
   }
 }
@@ -2323,6 +2336,62 @@ void main() {
 
       // Widget should still be rendered (no errors)
       expect(find.text('My WS'), findsOneWidget);
+    });
+
+    testWidgets('service_health event recolours the list icon', (tester) async {
+      final ws = _MockWsClient();
+      testAuthHttpClientOverride = withPermissions((request) async {
+        if (request.url.path == '/api/v1/workspaces') {
+          return http.Response(
+            jsonEncode(_envelope([
+              {
+                'id': 'ws-1',
+                'name': 'My WS',
+                'container_id': null,
+                'created_at': '2026-01-01',
+                'running': false,
+              },
+            ])),
+            200,
+          );
+        }
+        return http.Response('Not found', 404);
+      });
+
+      await tester.pumpWidget(buildPage(wsClient: ws));
+      await tester.pumpAndSettle();
+
+      // Start the container, then report it as unhealthy.  The
+      // leading terminal icon should turn amber for an unhealthy
+      // container and green for a healthy one.
+      ws.emitContainerStatus('ws-1', true);
+      await tester.pump();
+
+      ws.emitServiceHealth('ws-1', false);
+      // The broadcast stream delivers on a microtask; a single pump may
+      // build its frame before the microtask runs. Pump twice so the
+      // handler's setState is flushed into a real rebuild.
+      await tester.pump();
+      await tester.pump();
+      final unhealthyTile = tester.widget<ListTile>(
+        find.ancestor(
+          of: find.text('My WS'),
+          matching: find.byType(ListTile),
+        ),
+      );
+      expect((unhealthyTile.leading as Icon).color, Colors.orange);
+
+      ws.emitServiceHealth('ws-1', true);
+      // Same microtask flush as above.
+      await tester.pump();
+      await tester.pump();
+      final healthyTile = tester.widget<ListTile>(
+        find.ancestor(
+          of: find.text('My WS'),
+          matching: find.byType(ListTile),
+        ),
+      );
+      expect((healthyTile.leading as Icon).color, KColors.accentGreen);
     });
   });
 }

--- a/src/frontend/test/workspace_list_page_test.dart
+++ b/src/frontend/test/workspace_list_page_test.dart
@@ -2338,6 +2338,60 @@ void main() {
       expect(find.text('My WS'), findsOneWidget);
     });
 
+    testWidgets('container stopping clears stale health status',
+        (tester) async {
+      final ws = _MockWsClient();
+      testAuthHttpClientOverride = withPermissions((request) async {
+        if (request.url.path == '/api/v1/workspaces') {
+          return http.Response(
+            jsonEncode(_envelope([
+              {
+                'id': 'ws-1',
+                'name': 'My WS',
+                'container_id': null,
+                'created_at': '2026-01-01',
+                'running': false,
+              },
+            ])),
+            200,
+          );
+        }
+        return http.Response('Not found', 404);
+      });
+
+      await tester.pumpWidget(buildPage(wsClient: ws));
+      await tester.pumpAndSettle();
+
+      // Start the container, report it unhealthy (amber), then stop it —
+      // a stopped container has no health status, so the icon must drop
+      // back to grey rather than lingering on the stale unhealthy colour.
+      ws.emitContainerStatus('ws-1', true);
+      await tester.pump();
+      await tester.pump();
+
+      ws.emitServiceHealth('ws-1', false);
+      await tester.pump();
+      await tester.pump();
+      final unhealthyTile = tester.widget<ListTile>(
+        find.ancestor(
+          of: find.text('My WS'),
+          matching: find.byType(ListTile),
+        ),
+      );
+      expect((unhealthyTile.leading as Icon).color, Colors.orange);
+
+      ws.emitContainerStatus('ws-1', false);
+      await tester.pump();
+      await tester.pump();
+      final stoppedTile = tester.widget<ListTile>(
+        find.ancestor(
+          of: find.text('My WS'),
+          matching: find.byType(ListTile),
+        ),
+      );
+      expect((stoppedTile.leading as Icon).color, KColors.textSecondary);
+    });
+
     testWidgets('service_health event recolours the list icon', (tester) async {
       final ws = _MockWsClient();
       testAuthHttpClientOverride = withPermissions((request) async {

--- a/src/frontend/test/workspace_settings_panel_test.dart
+++ b/src/frontend/test/workspace_settings_panel_test.dart
@@ -290,6 +290,60 @@ void main() {
       await tester.pumpAndSettle();
     });
 
+    testWidgets('save sends health_check when a command is set',
+        (tester) async {
+      Map<String, dynamic>? savedBody;
+      testAuthHttpClientOverride = MockClient((request) async {
+        final p = request.url.path;
+        if (p == '/api/v1/workspaces') {
+          return http.Response(jsonEncode([_workspace]), 200);
+        }
+        if (p == '/api/v1/workspaces/shared') {
+          return http.Response(jsonEncode([]), 200);
+        }
+        if (p == '/api/v1/images') {
+          return http.Response(
+            jsonEncode({
+              'default': 'klangk-pi',
+              'allowed': ['klangk-pi', 'other:latest'],
+            }),
+            200,
+          );
+        }
+        if (p == '/api/v1/workspaces/$_wsId' && request.method == 'PUT') {
+          savedBody = jsonDecode(request.body) as Map<String, dynamic>;
+          return http.Response(
+            jsonEncode({'status': 'updated'}),
+            200,
+          );
+        }
+        return http.Response('not found', 404);
+      });
+      await tester.pumpWidget(_buildPanel());
+      await tester.pumpAndSettle();
+
+      final healthCheckField = find.byWidgetPredicate(
+        (w) =>
+            w is TextField && w.decoration?.labelText == 'Health Check Command',
+      );
+      await tester.ensureVisible(healthCheckField);
+      await tester.pump();
+      await tester.enterText(
+        healthCheckField,
+        'curl -sf http://localhost:8080/',
+      );
+
+      await _scrollToAndTap(tester, find.text('Save'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(savedBody, isNotNull);
+      expect(savedBody!['health_check'], 'curl -sf http://localhost:8080/');
+      // Drain the 2s auto-clear timer.
+      await tester.pump(const Duration(seconds: 2));
+      await tester.pumpAndSettle();
+    });
+
     testWidgets('save failure shows a "Failed:" message', (tester) async {
       testAuthHttpClientOverride = _client(
         saveStatus: 400,

--- a/src/frontend/test/workspace_settings_panel_test.dart
+++ b/src/frontend/test/workspace_settings_panel_test.dart
@@ -164,7 +164,7 @@ void main() {
       await tester.pumpAndSettle();
 
       await tester.enterText(
-        find.byType(TextField).at(2), // mounts add-row input
+        find.byType(TextField).at(3), // mounts add-row input
         '/etc:/etc',
       );
       await tester.testTextInput.receiveAction(TextInputAction.done);
@@ -179,7 +179,7 @@ void main() {
       await tester.pumpAndSettle();
 
       await tester.enterText(
-        find.byType(TextField).at(2),
+        find.byType(TextField).at(3),
         'no-colon',
       );
       await tester.testTextInput.receiveAction(TextInputAction.done);

--- a/zensical.toml
+++ b/zensical.toml
@@ -23,6 +23,7 @@ nav = [
     { "The Shell" = "features/the-shell.md" },
     { "Default Command" = "features/default-command.md" },
     { "Auto-Start" = "features/auto-start.md" },
+    { "Health Check" = "features/health-check.md" },
     { "Sandbox" = "features/sandbox.md" },
     { "Chat" = "features/chat.md" },
     { "File Viewer" = "features/file-viewer.md" },


### PR DESCRIPTION
Closes #1015.

## What this changes

Replaces the blind "container is up" signal with **server-side health polling**. Workspaces gain an optional `health_check` — a shell command the server runs inside the container every 30s via `podman exec` (as the creating user, `HOME` set, 10s timeout). Exit 0 = healthy; non-zero / timeout / error = unhealthy. Checks are skipped until `setup_state == "complete"` and when no command is configured. **No container image or entrypoint changes** — polling is purely external.

**Backend**
- `model/schema.py` + `model/workspaces.py`: `health_check TEXT` column + migration, threaded through all CRUD queries.
- `container.py`: `HealthMonitor` class (mirrors `IdleMonitor`) with the poll loop; `health_status` / `health_checked_at` / `health_check` / `owner_id` / `setup_state` on `ContainerState`; started in `main.py` lifespan.
- `wshandler/session.py`: new `notify_service_health()` that **fans health events out to ALL connections** (like `notify_container_status`), not just the workspace's terminal-session subscribers.
- `api/workspaces.py`: `health_check` on create/update/duplicate/import; status endpoint returns live `health` + `health_checked_at`; propagates `setup_state` transitions to live state.

**CLI**
- `create` / `edit` get `--health-check`; `sandbox` config supports `workspace.health-check`.
- **New `klangkc monitor` command** — streams the same server events the web UI sees and optionally runs a command per event (payload on stdin + `KLANGK_EVENT_TYPE` / `KLANGK_WORKSPACE_ID` / `KLANGK_HEALTHY` env). Reconnects automatically (forever by default, capped backoff) and refreshes its JWT on auth failures.

**Frontend**
- `health_check` field in the create dialog + settings panel; `service_health` event routed in `ws_client`; workspace-list icon goes green (healthy) / amber (unhealthy) / grey (stopped), live.

**Docs**
- New `docs/features/health-check.md` (with a "Seeing health status" + "Reacting to failures with `klangkc monitor`" section); cross-references in `auto-start.md`, `workspaces.md`, `sandbox.md`, `cli.md`, and `zensical.toml`.

## Why

With service workspaces (#775) and auto-start (#1007), a *running* container says nothing about whether the service inside it is actually responding. A failing service was previously nearly invisible: the old `service_health` event only reached a workspace's terminal-session subscribers, which only exist while someone is connected — so the most important case (an auto-started service, nobody connected) got nothing. This makes health discoverable everywhere it's needed: the workspace list, the status endpoint, and an automation hook (`klangkc monitor`) so you can page/notify on unhealthy transitions.

Health status remains **informational only** — no automatic restart (that can build on this later).

## How it was tested

- **Backend**: +10 `HealthMonitor` tests (`test_container.py`) covering rc-0/non-zero/exec-error/missing-owner, transition-broadcast-vs-no-op, skip-on-setup-incomplete, skip-when-no-check; +3 `notify_service_health` fan-out tests (`test_wshandler.py`) proving an event reaches a connection with **no** registered session. Full backend suite: **1947 passed**.
- **CLI**: +11 `TestMonitor` tests covering dispatch/filtering, reconnect-after-disconnect, `--max-reconnects` cap, `--no-reconnect`, JWT-refresh-on-4002, refresh-failure-keeps-token, and backoff cap; updated the interactive `edit` / `create` suite for the new `health_check` prompt + field. Full CLI suite: **411 passed**.
- Frontend: `dart analyze` clean on edited files (the analyzer's broad errors are pre-existing SDK-resolution noise, not from these edits).
- All pre-commit hooks green (incl. `deferred-imports`, `markdownlint`, prettier, ruff, dart-format).

> Note: the backend and CLI suites produce fixture/event-loop errors *only* when run in a single combined `pytest` invocation — a pre-existing cross-suite issue. Each suite is green on its own.

## Checklist

- [x] I've described what and why above.
- [x] I've noted how I tested this.
- [x] This is collaborative, reviewed work — the design was steered and signed off through the session (not an unreviewed drive-by).