### PR TITLE
docs: note plugins (compile-time) vs sandboxes (runtime) in both chapters

### DIFF
--- a/docs/features/plugins.md
+++ b/docs/features/plugins.md
@@ -5,6 +5,14 @@ and container customizations. A plugin can install system packages
 at image build time, add CLI tools to the container PATH, extend the
 Pi agent with new tools, or add UI widgets to the web frontend.
 
+> **Plugins vs. sandboxes.** Plugins are a _compile-time_ feature:
+> they bake software into the workspace image at build time, so it's
+> already installed and needn't be added later. The tools and UI they
+> add are available to _any_ workspace, but adding or changing a plugin
+> requires rebuilding the Klangk image. For _runtime_ additions of
+> software and configuration scoped to a _particular user within a
+> particular workspace_ instead, use a [sandbox](sandbox.md).
+
 For details on creating plugins, see the
 [Creating Plugins](../development/creating-plugins.md) reference.
 

--- a/docs/features/sandbox.md
+++ b/docs/features/sandbox.md
@@ -21,6 +21,16 @@ This feature is most useful when run with the Klangk server on your own
 machine. It requires the `klangkc` client program. It is not a feature of the
 web UI.
 
+> **Sandboxes vs. plugins.** Sandboxes are a _runtime_ feature: they
+> install software and apply configuration scoped to a _particular
+> user within a particular workspace_ — not to the workspace image as
+> a whole — when the workspace is created, without rebuilding anything.
+> By contrast, [plugins](plugins.md) are a _compile-time_ feature that
+> bakes software into the workspace image at build time so it needn't
+> be installed later — the features they add are available to any user
+> in any workspace, but adding or changing a plugin requires rebuilding
+> the Klangk image.
+
 ## Quick start
 
 Create a `.klangk-sandbox.yaml` in your project root:


### PR DESCRIPTION
Add a cross-referencing note to both the `docs/features/plugins.md` and `docs/features/sandbox.md` chapters clarifying the relationship between the two extension mechanisms:

- **Plugins** are a _compile-time_ feature: they bake software into the workspace image at build time, so it's already installed and needn't be added later. The tools/UI they add are available to _any user in any workspace_, but adding or changing a plugin requires rebuilding the Klangk image.
- **Sandboxes** are a _runtime_ feature: they install software and apply configuration scoped to a _particular user within a particular workspace_ (not the workspace image as a whole), when the workspace is created, without rebuilding anything.

The notes are placed near the top of each chapter and link to the other for easy navigation.