### PR TITLE
Split system env out of bash.bashrc into /etc/profile.d (#1093)

### DIFF
--- a/docs/features/the-shell.md
+++ b/docs/features/the-shell.md
@@ -1,9 +1,15 @@
 # The Shell
 
-Bash is the default shell for all workspace terminals. The system-wide
-`/etc/bash.bashrc` handles terminal setup (waiting for container readiness,
-running plugin hooks, and launching default commands), then sources your
-personal `~/.bashrc`.
+Bash is the default shell for all workspace terminals. Two system files
+set up the environment before your personal `~/.bashrc` runs:
+
+- `/etc/profile.d/klangk-*.sh` — environment exports (`PATH=/opt/klangk/bin`,
+  `EDITOR`) sourced by **every login shell**, interactive or not. This is
+  why one-shot commands like the workspace health check (`bash -lc`) and
+  `klangkc exec` still find `pi`, `herdr`, and the `klangk-*` helpers.
+- `/etc/bash.bashrc` — interactive-shell setup: waits for container
+  readiness, runs `on-shell-init` plugin hooks, and (via the default
+  command) launches the workspace's configured service.
 
 Your `~/.bashrc` persists across container restarts (it lives on the
 bind-mounted home directory), so any customizations you make are permanent.

--- a/src/containers/workspace/Dockerfile
+++ b/src/containers/workspace/Dockerfile
@@ -70,6 +70,11 @@ RUN chmod +x /opt/klangk/entrypoint.sh \
       /opt/klangk/bin/klangk-save-workspace-state \
       /opt/klangk/bin/klangk-set-workspace-token \
       /opt/klangk/bin/klangk-workspace-token
+# System-wide environment exports for ALL login shells (interactive AND
+# non-interactive, e.g. the health check's `bash -lc`). /etc/profile sources
+# these unconditionally via run-parts. See issue #1093 for why env must live
+# here rather than in /etc/bash.bashrc (which non-interactive shells skip).
+COPY profile.d/ /etc/profile.d/
 COPY bash.bashrc /etc/bash.bashrc
 COPY tmux.conf /etc/tmux.conf
 

--- a/src/containers/workspace/bash.bashrc
+++ b/src/containers/workspace/bash.bashrc
@@ -1,9 +1,12 @@
 # shellcheck shell=bash
 # System-wide bash defaults for Klangk containers.
 # Users can override these in ~/.bashrc on the persistent home mount.
-
-# Plugin tools on PATH (ENV in Dockerfile is overridden by login shells).
-export PATH="/opt/klangk/bin:$PATH"
+#
+# NOTE: environment exports (PATH=/opt/klangk/bin, EDITOR) live in
+# /etc/profile.d/klangk-*.sh so that non-interactive login shells (bash -lc
+# — the health check, klangkc exec) see them too. This file is only sourced
+# for interactive shells, so anything placed here is invisible to one-shot
+# non-interactive commands. See issue #1093.
 
 # Nothing below here is meaningful during image build. The Dockerfile touches
 # /tmp/.klangk-image-build before running plugin hooks and removes it after;
@@ -15,9 +18,6 @@ export PATH="/opt/klangk/bin:$PATH"
 # Per-user with random suffix to prevent predictable-path attacks in /tmp.
 _herdr_dir=$(mktemp -d "/tmp/herdr-${KLANGK_USER_ID:-default}-XXXXXXXX")
 export HERDR_SOCKET_PATH="$_herdr_dir/herdr.sock"
-
-# Default editor for git commit, crontab -e, etc.
-export EDITOR=nano
 
 # Block interactive shells until the entrypoint signals that setup is done.
 # /tmp is a tmpfs, so .klangk-ready starts absent on every container boot

--- a/src/containers/workspace/profile.d/klangk-editor.sh
+++ b/src/containers/workspace/profile.d/klangk-editor.sh
@@ -1,0 +1,8 @@
+# shellcheck shell=sh
+# Default editor for git commit messages, crontab -e, etc.
+#
+# In /etc/profile.d (not /etc/bash.bashrc) so that non-interactive login
+# shells — e.g. a health check or `klangkc exec` that runs `git commit` —
+# see EDITOR too. /etc/bash.bashrc only loads for interactive shells,
+# which would hide this from one-shot commands. See issue #1093.
+export EDITOR=nano

--- a/src/containers/workspace/profile.d/klangk-path.sh
+++ b/src/containers/workspace/profile.d/klangk-path.sh
@@ -1,0 +1,20 @@
+# shellcheck shell=sh
+# Klangk plugin tools on PATH.
+#
+# Why this lives in /etc/profile.d and not /etc/bash.bashrc (issue #1093):
+# /etc/profile resets PATH to a fixed system default for login shells,
+# clobbering the /opt/klangk/bin prefix that the Dockerfile ENV sets. This
+# snippet re-prepends it so EVERY login shell finds pi, herdr, and the
+# klangk-* helpers — including non-interactive login shells (`bash -lc`),
+# which is what the workspace health check and `klangkc exec` use.
+# /etc/bash.bashrc was the wrong home because it is only sourced for
+# interactive shells; a non-interactive login shell never saw the export.
+#
+# Sourced by /etc/profile via run-parts for every login shell. /etc/profile
+# runs profile.d unconditionally (no PS1 guard), so this covers `bash -lc`
+# even though that shell never goes interactive. Keep POSIX-sh-clean: dash
+# (the /bin/sh that /etc/profile runs under) sources this, not just bash.
+case ":${PATH}:" in
+*:/opt/klangk/bin:*) ;;
+*) export PATH="/opt/klangk/bin:$PATH" ;;
+esac


### PR DESCRIPTION
Part of #1093.

## What

Moves the two environment exports (`PATH=/opt/klangk/bin`, `EDITOR=nano`) out of the vendored `/etc/bash.bashrc` and into `/etc/profile.d/klangk-*.sh`, which `/etc/profile` sources unconditionally via `run-parts` for every login shell.

## Why

`/etc/bash.bashrc` is only sourced for **interactive** shells. Non-interactive login shells — the workspace health check (`bash -lc`, per #1087) and `klangkc exec` — never saw those exports.

Today the health check sidesteps this by running `sh -c` (sources nothing, relies on the Dockerfile `ENV PATH`). But the planned #1087 move to `bash -lc` would break: `/etc/profile` resets `PATH` to a fixed system default for login shells, clobbering the `ENV` prefix — so `/opt/klangk/bin` (where `pi`, `herdr`, and the `klangk-*` helpers live) would fall off `PATH`.

This is a strict improvement: identical behavior for every existing shell, plus it fills the one gap (non-interactive login shells).

## Verification

Built a throwaway image on the pinned base (`ghcr.io/mcdonc/klangk/klangk-workspace-base:2026.06.24-fc6981c`) reproducing the Dockerfile's `PATH` situation + the changed files, then tested invocation modes:

| Shell | Before | After |
|---|---|---|
| `bash -c` (non-interactive, non-login) | PATH ✓ (ENV), EDITOR empty | PATH ✓ (ENV), EDITOR empty |
| **`bash -lc` (non-interactive, login — the healthcheck case)** | PATH via ENV reset risk, **EDITOR empty** | **PATH ✓, EDITOR=nano, klangk-marker FOUND** |

The `bash -lc` row is the fix. (`bash -ic` / `bash -lic` are interactive — unchanged behavior; they also hit the readiness gate so weren't tested in isolation.)

## Scope — what this does NOT do

Bucket 3 of #1093 (herdr socket, readiness gate, `klangk-setup-clankers`) is **deferred**:

- **Readiness gate** (`while [ ! -f /tmp/.klangk-ready ]`) is interactive-shell-startup logic — its only sensible home *is* the bashrc family (the entrypoint doesn't spawn shells).
- **`HERDR_SOCKET_PATH`** is consumed only by the external `herdr` binary (a Rust release artifact, not in-repo); its lifecycle can't be validated locally and no in-repo test exercises it.
- Moving these blindly would risk the agent runtime with no local safety net.

These stay in `/etc/bash.bashrc` and are tracked as follow-ups. The build-time bailout (`/tmp/.klangk-image-build`) also stays — it only becomes safe to remove once bucket 3 moves.

## Files

- `src/containers/workspace/profile.d/klangk-path.sh` — new, re-prepends `/opt/klangk/bin` (idempotent, POSIX-sh-clean for dash)
- `src/containers/workspace/profile.d/klangk-editor.sh` — new, `EDITOR=nano`
- `src/containers/workspace/Dockerfile` — `COPY profile.d/ /etc/profile.d/`
- `src/containers/workspace/bash.bashrc` — removed the two exports, added a comment explaining the convention
- `docs/features/the-shell.md` — documents the two-file setup