### PR TITLE
feat(container): add klangk-hosted-url script (#1081)

### DIFF
--- a/docs/features/hosted-apps.md
+++ b/docs/features/hosted-apps.md
@@ -41,6 +41,27 @@ WebSocket connections are supported — tools like Jupyter and Marimo work out o
 
 Extensions and scripts inside the container can use these to construct correct URLs for their hosted apps. Pi's built-in `get_hosted_url` tool does this automatically.
 
+### `klangk-hosted-url` (from inside a container)
+
+The easiest way to get a hosted app URL from the shell is the
+`klangk-hosted-url` script, baked into the workspace image:
+
+```bash
+$ klangk-hosted-url 8000
+http://localhost:8995/hosted/abc123/9000/
+```
+
+Pass the **container port** (8000-8004); it resolves the mapped host port via
+`KLANGK_PORT_MAPPINGS` and combines it with the `KLANGK_HOSTING_*` and
+`KLANGK_WORKSPACE_ID` env vars to print the full URL. Use it from `setup.sh`,
+your `default_command`, a `health_check`, or interactively. Pi's
+`get_hosted_url` tool delegates to this same script, so the URL logic lives in
+one place.
+
+Error cases: no argument prints usage; a container port not present in
+`KLANGK_PORT_MAPPINGS` lists the valid ports; a missing `KLANGK_PORT_MAPPINGS`
+errors out. Each exits non-zero.
+
 ## Behind a reverse proxy
 
 When Klangk runs behind an outer reverse proxy (e.g., on a subpath like `/klangk`), the hosting info is auto-derived from standard headers:

--- a/src/containers/workspace/Dockerfile
+++ b/src/containers/workspace/Dockerfile
@@ -57,6 +57,7 @@ COPY klangk-attach-browser.sh /opt/klangk/bin/klangk-attach-browser
 COPY klangk-browser-id.sh /opt/klangk/bin/klangk-browser-id
 COPY klangk-copy-to-clipboard.py /opt/klangk/bin/klangk-copy-to-clipboard
 COPY klangk-configure-sudo.sh /opt/klangk/bin/klangk-configure-sudo
+COPY klangk-hosted-url.sh /opt/klangk/bin/klangk-hosted-url
 COPY klangk-save-workspace-state.sh /opt/klangk/bin/klangk-save-workspace-state
 COPY klangk-set-workspace-token.sh /opt/klangk/bin/klangk-set-workspace-token
 COPY klangk-workspace-token.sh /opt/klangk/bin/klangk-workspace-token
@@ -67,6 +68,7 @@ RUN chmod +x /opt/klangk/entrypoint.sh \
       /opt/klangk/bin/klangk-browser-id \
       /opt/klangk/bin/klangk-configure-sudo \
       /opt/klangk/bin/klangk-copy-to-clipboard \
+      /opt/klangk/bin/klangk-hosted-url \
       /opt/klangk/bin/klangk-save-workspace-state \
       /opt/klangk/bin/klangk-set-workspace-token \
       /opt/klangk/bin/klangk-workspace-token

--- a/src/containers/workspace/builtin-extensions/port-map.ts
+++ b/src/containers/workspace/builtin-extensions/port-map.ts
@@ -1,16 +1,10 @@
 import { Type } from "@sinclair/typebox";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
 
 export default function (pi: any) {
-  // Parse KLANGK_PORT_MAPPINGS: "8000:9000,8001:9001,8002:9002,..."
-  const portMap: Map<number, number> = new Map();
-  const mappingsStr = process.env.KLANGK_PORT_MAPPINGS || "";
-  for (const pair of mappingsStr.split(",")) {
-    const [container, host] = pair.split(":").map(Number);
-    if (!isNaN(container) && !isNaN(host)) {
-      portMap.set(container, host);
-    }
-  }
-
   pi.registerTool({
     name: "get_hosted_url",
     description:
@@ -28,32 +22,22 @@ export default function (pi: any) {
       _onUpdate: any,
       _ctx: any,
     ) {
-      const port = params.container_port;
-      const externalPort = portMap.get(port);
-      if (externalPort === undefined) {
-        const mapped = Array.from(portMap.keys()).sort((a, b) => a - b);
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Port ${port} is not a mapped port. Mapped container ports: ${mapped.join(", ")}. Use one of these ports for your server.`,
-            },
-          ],
-          details: {},
-        };
+      // Delegate to the `klangk-hosted-url` shell script — the single source
+      // of truth for hosted-URL construction, shared with setup.sh, the
+      // default_command, the health check, and the shell. On success it
+      // prints the URL to stdout; on error it writes a message to stderr and
+      // exits non-zero, which we surface to the agent.
+      let text: string;
+      try {
+        const { stdout } = await execFileAsync("klangk-hosted-url", [
+          String(params.container_port),
+        ]);
+        text = stdout.trim();
+      } catch (err: any) {
+        text = (err.stderr || "").trim() || err.message;
       }
-      const proto = process.env.KLANGK_HOSTING_PROTO || "http";
-      const hostname = process.env.KLANGK_HOSTING_HOSTNAME || "localhost";
-      const basePath = process.env.KLANGK_HOSTING_BASE_PATH || "";
-      const workspaceId = process.env.KLANGK_WORKSPACE_ID || "";
-      const url = `${proto}://${hostname}${basePath}/hosted/${workspaceId}/${externalPort}/`;
       return {
-        content: [
-          {
-            type: "text",
-            text: `Container port ${port} is mapped to external port ${externalPort}. The user can access it at ${url}`,
-          },
-        ],
+        content: [{ type: "text", text }],
         details: {},
       };
     },

--- a/src/containers/workspace/klangk-hosted-url.sh
+++ b/src/containers/workspace/klangk-hosted-url.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+# klangk-hosted-url — print the hosted-app browser URL for a container port.
+#
+# Single source of truth for hosted-URL construction inside workspace
+# containers. The Pi `get_hosted_url` tool (builtin-extensions/port-map.ts)
+# delegates to this script so the shell and the agent share one implementation.
+#
+# Reads KLANGK_PORT_MAPPINGS ("8000:9000,8001:9001,...") to resolve the host
+# port for the given container port, then combines it with the
+# KLANGK_HOSTING_* / KLANGK_WORKSPACE_ID env vars (which the backend injects
+# when the container starts) to print:
+#
+#   {proto}://{hostname}{base_path}/hosted/{workspace_id}/{host_port}/
+#
+# Exit codes:
+#   0  success (URL on stdout)
+#   1  bad args, port not mapped, or missing KLANGK_PORT_MAPPINGS
+set -eu
+
+usage() {
+  echo "Usage: klangk-hosted-url <container_port>" >&2
+  echo "Print the browser URL for a web app running on a container port." >&2
+}
+
+if [ $# -ne 1 ]; then
+  usage
+  exit 1
+fi
+
+container_port=$1
+
+mappings=${KLANGK_PORT_MAPPINGS:-}
+if [ -z "$mappings" ]; then
+  echo "klangk-hosted-url: KLANGK_PORT_MAPPINGS is not set" >&2
+  echo "(this script must run inside a Klangk workspace container)" >&2
+  exit 1
+fi
+
+# Walk the CSV mapping, recording the matching host port (if any) and the
+# full list of valid container ports for the error case. POSIX-sh parsing:
+# peel off one "container:host" pair at a time, then split it on ":".
+host_port=""
+valid_ports=""
+rest=$mappings
+while [ -n "$rest" ]; do
+  pair=${rest%%,*}
+  case "$rest" in
+  *,*) rest=${rest#*,} ;;
+  *) rest= ;;
+  esac
+  c=${pair%%:*}
+  h=${pair##*:}
+  [ "$c" = "$container_port" ] && host_port=$h
+  if [ -z "$valid_ports" ]; then
+    valid_ports=$c
+  else
+    valid_ports="$valid_ports, $c"
+  fi
+done
+
+if [ -z "$host_port" ]; then
+  echo "klangk-hosted-url: container port $container_port is not in KLANGK_PORT_MAPPINGS" >&2
+  echo "Mapped container ports: $valid_ports" >&2
+  exit 1
+fi
+
+proto=${KLANGK_HOSTING_PROTO:-http}
+hostname=${KLANGK_HOSTING_HOSTNAME:-localhost}
+base_path=${KLANGK_HOSTING_BASE_PATH:-}
+workspace_id=${KLANGK_WORKSPACE_ID:-}
+
+printf '%s://%s%s/hosted/%s/%s/\n' \
+  "$proto" "$hostname" "$base_path" "$workspace_id" "$host_port"


### PR DESCRIPTION
Closes #1081.

## What

Adds a `klangk-hosted-url` shell script to the workspace image and refactors the Pi `get_hosted_url` tool to delegate to it, so hosted-URL construction has a single source of truth and is usable outside the agent.

## Why

Per the issue, the hosted URL for a container port was computable **only** through Pi's `get_hosted_url` tool — not from `setup.sh`, a `default_command`, a `health_check` (#1015), or an interactive shell. The openclaw sandbox `setup.sh` re-implements the same env-var munging by hand today. Centralizing it in a script removes the duplication.

## Changes

| File | Change |
|------|--------|
| `src/containers/workspace/klangk-hosted-url.sh` | **New** POSIX-sh script — source of truth. Reads `KLANGK_PORT_MAPPINGS` to resolve the host port, combines with `KLANGK_HOSTING_PROTO`/`HOSTNAME`/`BASE_PATH`/`WORKSPACE_ID`, prints `{proto}://{hostname}{base_path}/hosted/{workspace_id}/{host_port}/`. Error cases (no arg / unmapped port / missing `KLANGK_PORT_MAPPINGS`) print to stderr and exit 1. |
| `src/containers/workspace/Dockerfile` | `COPY` the script into `/opt/klangk/bin/klangk-hosted-url` and add it to the `chmod +x` list, alongside the other `klangk-*` scripts. |
| `src/containers/workspace/builtin-extensions/port-map.ts` | Replace the inline env-parsing + URL-building with a single `execFile("klangk-hosted-url", [...])` call. On success returns the URL from stdout; on non-zero exit surfaces the script's stderr to the agent. |
| `docs/features/hosted-apps.md` | New `### klangk-hosted-url (from inside a container)` subsection documenting usage, error cases, and the delegation. |

## Behavior verified

```bash
$ KLANGK_PORT_MAPPINGS=8000:9000,8001:9001 KLANGK_HOSTING_HOSTNAME=localhost:8995 KLANGK_WORKSPACE_ID=abc123 klangk-hosted-url 8000
http://localhost:8995/hosted/abc123/9000/

# behind a reverse proxy
$ KLANGK_PORT_MAPPINGS=8000:9000 KLANGK_HOSTING_PROTO=https KLANGK_HOSTING_HOSTNAME=example.com KLANGK_HOSTING_BASE_PATH=/klangk KLANGK_WORKSPACE_ID=ws9 klangk-hosted-url 8000
https://example.com/klangk/hosted/ws9/9000/

# error cases → stderr, exit 1
$ klangk-hosted-url 9999   # (with mappings set)
klangk-hosted-url: container port 9999 is not in KLANGK_PORT_MAPPINGS
Mapped container ports: 8000, 8001
```

Defaults match the prior TypeScript behavior (`proto=http`, `hostname=localhost`, `base_path=""`, `workspace_id=""`) so the script is a faithful port. `shellcheck` and `shfmt` clean; pre-commit all green.

## Notes for review

- The script lives directly in `src/containers/workspace/` (per the repo convention for `klangk-*` scripts) rather than the `scripts/` subpath the issue table suggested.
- The TS tool now returns just the URL on success (the script's output) rather than the older "Container port X is mapped to external port Y..." sentence. This is intentional — the script is the single source of truth, and the URL is what the agent needs. Happy to restore richer wording if preferred.