### PR TITLE
Periodic Trivy workspace scan + no-fix CVE report (#570)

### DIFF
--- a/.github/workflows/trivy-workspace-scan.yml
+++ b/.github/workflows/trivy-workspace-scan.yml
@@ -1,0 +1,77 @@
+name: Trivy Workspace Scan
+
+# Periodic vulnerability scan of the workspace image.
+#
+# Issue #570 tracks HIGH/CRITICAL CVEs in Debian/Node packages that have no
+# upstream fix available yet. Rather than gating CI (these can't be fixed
+# until Debian/NPM ship a patched package), this workflow runs on a schedule,
+# scans a freshly built workspace image, and posts a focused report to the
+# run summary + uploads the raw artifacts. Maintainers review the Actions tab.
+#
+# It never fails the run on findings.
+
+on:
+  schedule:
+    # Mondays 06:00 UTC
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Build workspace image
+        uses: ./.github/actions/devenv-setup
+        with:
+          build-tasks: klangk:build-workspace-image
+
+      - name: Export image to tarball
+        run: |
+          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+          devenv shell -- podman save \
+            -o /tmp/workspace.tar "${KLANGK_IMAGE_NAME:-klangk-workspace}:latest"
+
+      - name: Install Trivy
+        uses: aquasecurity/setup-trivy@v0.2.0
+        with:
+          version: v0.69.3
+          cache: true
+
+      - name: Scan image (HIGH/CRITICAL -> JSON)
+        run: |
+          mkdir -p /tmp/trivy-out
+          trivy image \
+            --scanners vuln \
+            --severity CRITICAL,HIGH \
+            --input /tmp/workspace.tar \
+            --format json \
+            --output /tmp/trivy-out/scan.json
+
+      - name: Build no-fix report
+        run: |
+          {
+            echo "### 🛡️ Trivy workspace scan (HIGH/CRITICAL)"
+            python3 scripts/trivy-report-nofix.py /tmp/trivy-out/scan.json
+          } >> "$GITHUB_STEP_SUMMARY"
+          # Also keep a standalone copy for the artifact.
+          python3 scripts/trivy-report-nofix.py /tmp/trivy-out/scan.json \
+            > /tmp/trivy-out/report.md
+
+      - name: Upload scan artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-workspace-scan
+          path: /tmp/trivy-out/
+          if-no-files-found: warn
+          retention-days: 30

--- a/devenv.nix
+++ b/devenv.nix
@@ -195,6 +195,14 @@ in
   scripts.build-host-image.exec = ''exec bash "$DEVENV_ROOT/scripts/build-host-image.sh" "$@"'';
   scripts.trivy-host.exec = ''exec bash "$DEVENV_ROOT/scripts/trivy-host.sh" "$@"'';
   scripts.trivy-workspace.exec = ''exec bash "$DEVENV_ROOT/scripts/trivy-workspace.sh" "$@"'';
+  scripts.trivy-workspace-report.exec = ''
+    cd $DEVENV_ROOT
+    if [ "$#" -eq 0 ]; then
+      echo "Scanning workspace image and rendering no-fix report..." >&2
+      exec bash "$DEVENV_ROOT/scripts/trivy-workspace.sh" --severity CRITICAL,HIGH --format json \
+        | python3 "$DEVENV_ROOT/scripts/trivy-report-nofix.py" -
+    fi
+    exec python3 "$DEVENV_ROOT/scripts/trivy-report-nofix.py" "$@"'';
 
   scripts.run-host-container.exec = ''exec bash "$DEVENV_ROOT/scripts/run-host-container.sh" "$@"'';
 

--- a/docs/development/building-images.md
+++ b/docs/development/building-images.md
@@ -26,6 +26,30 @@ trivy-workspace                   # scan workspace image
 trivy-host --severity CRITICAL    # critical only
 ```
 
+### No-fix CVEs (tracking)
+
+Most HIGH/CRITICAL findings in the workspace image have no fixed Debian/Node
+package available yet (Trivy status `affected` / `fix_deferred`). These can't
+be resolved by an upgrade until upstream ships a patched package, so they are
+tracked for awareness in [issue #570](https://github.com/mcdonc/klangk/issues/570)
+and re-scanned periodically.
+
+To render a focused report that separates **upgradeable** findings from the
+**no upstream fix yet** set:
+
+```bash
+trivy-workspace-report                          # scan + report in one shot
+trivy-workspace-report scan.json                # render an existing JSON scan
+trivy-workspace --severity CRITICAL,HIGH --format json \
+  | trivy-workspace-report -                    # pipe a scan into the report
+```
+
+The [`trivy-workspace-scan`](https://github.com/mcdonc/klangk/actions/workflows/trivy-workspace-scan.yml)
+workflow automates this: it builds a fresh workspace image weekly (Mondays
+06:00 UTC, or on demand via _Run workflow_), scans it, and posts the report
+plus raw artifacts to the workflow run. It is **informational** — it never
+fails a run — so reviewers check the Actions tab rather than gating CI.
+
 ## Image Versioning
 
 **No `:latest` tags are pushed to the registry.** Every image (host,

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -33,27 +33,28 @@ changes.
 
 Inside `devenv shell`, these commands are available:
 
-| Command                 | Description                                 |
-| ----------------------- | ------------------------------------------- |
-| `test-backend`          | Run backend unit tests                      |
-| `test-cli`              | Run CLI unit tests                          |
-| `test-frontend`         | Run frontend unit tests with coverage       |
-| `test-backend-e2e`      | Run backend E2E tests                       |
-| `test-cli-e2e`          | Run CLI E2E tests                           |
-| `test-frontend-e2e`     | Run frontend E2E tests (Playwright)         |
-| `flutterbuildweb`       | Rebuild Flutter web only                    |
-| `build-workspace-image` | Rebuild workspace image (podman)            |
-| `build-base-image`      | Rebuild workspace base image                |
-| `build-host-image`      | Build host container image                  |
-| `run-host-container`    | Run host container locally                  |
-| `trivy-host`            | Scan host image for vulnerabilities         |
-| `trivy-workspace`       | Scan workspace image for vulnerabilities    |
-| `update-plugins`        | Fetch plugins from plugins.yaml             |
-| `kill-containers`       | Stop and remove all klangk containers       |
-| `restart`               | Rebuild images and restart devenv processes |
-| `rebuild`               | Rebuild workspace image and Flutter web     |
-| `serve-docs`            | Serve docs locally for preview              |
-| `build-docs`            | Build docs for deployment                   |
+| Command                  | Description                                 |
+| ------------------------ | ------------------------------------------- |
+| `test-backend`           | Run backend unit tests                      |
+| `test-cli`               | Run CLI unit tests                          |
+| `test-frontend`          | Run frontend unit tests with coverage       |
+| `test-backend-e2e`       | Run backend E2E tests                       |
+| `test-cli-e2e`           | Run CLI E2E tests                           |
+| `test-frontend-e2e`      | Run frontend E2E tests (Playwright)         |
+| `flutterbuildweb`        | Rebuild Flutter web only                    |
+| `build-workspace-image`  | Rebuild workspace image (podman)            |
+| `build-base-image`       | Rebuild workspace base image                |
+| `build-host-image`       | Build host container image                  |
+| `run-host-container`     | Run host container locally                  |
+| `trivy-host`             | Scan host image for vulnerabilities         |
+| `trivy-workspace`        | Scan workspace image for vulnerabilities    |
+| `trivy-workspace-report` | Scan + report no-fix CVEs (or render JSON)  |
+| `update-plugins`         | Fetch plugins from plugins.yaml             |
+| `kill-containers`        | Stop and remove all klangk containers       |
+| `restart`                | Rebuild images and restart devenv processes |
+| `rebuild`                | Rebuild workspace image and Flutter web     |
+| `serve-docs`             | Serve docs locally for preview              |
+| `build-docs`             | Build docs for deployment                   |
 
 ## Branch Protection
 

--- a/scripts/trivy-report-nofix.py
+++ b/scripts/trivy-report-nofix.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Render a Trivy image-scan JSON result as a focused markdown report.
+
+The report splits HIGH/CRITICAL findings into two buckets:
+
+* **fix available** — a fixed version exists, so an ordinary package/node
+  upgrade resolves the vulnerability (these are actionable now).
+* **no upstream fix yet** — the vulnerability has no fixed Debian/Node
+  package available yet (Trivy statuses ``affected``, ``fix_deferred``,
+  ``will_not_fix`` or ``end_of_life``, i.e. no ``FixedVersion``). These are
+  tracked in the security backlog (issue #570) and re-scanned periodically.
+
+Designed to be piped into ``$GITHUB_STEP_SUMMARY`` by the periodic scan
+workflow, but it is also usable locally::
+
+    trivy-workspace --severity CRITICAL,HIGH --format json \
+        | python3 scripts/trivy-report-nofix.py
+
+Only markdown is written to stdout; diagnostics go to stderr.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+# Vulnerability is considered to have NO upstream fix when Trivy reports one
+# of these statuses (equivalently: no FixedVersion present). Anything else
+# (status == "fixed" / a populated FixedVersion) is upgrade-resolvable.
+NO_FIX_STATUSES = {"affected", "fix_deferred", "will_not_fix", "end_of_life"}
+TRACKING_ISSUE = "https://github.com/mcdonc/klangk/issues/570"
+IMAGE = os.environ.get("KLANGK_IMAGE_NAME", "klangk-workspace") + ":latest"
+SEVERITY_RANK = {"CRITICAL": 0, "HIGH": 1, "MEDIUM": 2, "LOW": 3, "UNKNOWN": 4}
+
+
+def _short(text: str | None, limit: int = 90) -> str:
+    if not text:
+        return ""
+    text = " ".join(text.split())
+    return text if len(text) <= limit else text[: limit - 1] + "…"
+
+
+def _md_escape(text: str) -> str:
+    # Keep table cells safe without over-escaping readable text.
+    return (text or "").replace("|", "\\|").replace("\n", " ").strip()
+
+
+def load_results(path: str | None) -> list[dict]:
+    raw = sys.stdin.read() if not path or path == "-" else open(path).read()
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(f"trivy-report-nofix: invalid JSON: {exc}", file=sys.stderr)
+        sys.exit(2)
+    if not isinstance(data, dict):
+        print("trivy-report-nofix: unexpected JSON shape", file=sys.stderr)
+        sys.exit(2)
+    return data.get("Results", []) or []
+
+
+def collect(results: list[dict]) -> tuple[list[dict], list[dict]]:
+    """Return (no_fix_vulns, fixable_vulns) restricted to HIGH/CRITICAL."""
+    no_fix: list[dict] = []
+    fixable: list[dict] = []
+    for res in results:
+        for v in res.get("Vulnerabilities") or []:
+            if v.get("Severity") not in ("CRITICAL", "HIGH"):
+                continue
+            if v.get("FixedVersion"):
+                fixable.append(v)
+            elif v.get("Status") in NO_FIX_STATUSES:
+                no_fix.append(v)
+            else:
+                # Severity HIGH/CRITICAL with neither a fixed version nor a
+                # known no-fix status — treat as no-fix (can't act on it).
+                no_fix.append(v)
+    return no_fix, fixable
+
+
+def group_by_cve(vulns: list[dict]) -> list[dict]:
+    """Collapse a list of vulns into one entry per CVE.
+
+    ``packages`` maps package name -> (installed_version, fixed_version).
+    """
+    by_cve: dict[str, dict] = {}
+    for v in vulns:
+        cve = v.get("VulnerabilityID") or "UNKNOWN"
+        entry = by_cve.setdefault(
+            cve,
+            {
+                "cve": cve,
+                "severity": v.get("Severity", "UNKNOWN"),
+                "status": v.get("Status", "unknown"),
+                "title": v.get("Title") or v.get("Description", ""),
+                "packages": {},  # pkg -> (installed, fixed)
+            },
+        )
+        # Keep the most severe severity observed.
+        if SEVERITY_RANK.get(v.get("Severity"), 99) < SEVERITY_RANK.get(
+            entry["severity"], 99
+        ):
+            entry["severity"] = v.get("Severity")
+        pkg = v.get("PkgName") or "?"
+        entry["packages"].setdefault(
+            pkg, (v.get("InstalledVersion") or "", v.get("FixedVersion") or "")
+        )
+    # Sort: CRITICAL first, then HIGH, then alphabetical.
+    return sorted(
+        by_cve.values(),
+        key=lambda e: (SEVERITY_RANK.get(e["severity"], 99), e["cve"]),
+    )
+
+
+def render(no_fix: list[dict], fixable: list[dict]) -> str:
+    no_fix_cves = group_by_cve(no_fix)
+    fixable_cves = group_by_cve(fixable)
+    total = len(no_fix) + len(fixable)
+
+    lines: list[str] = []
+    lines.append("## 🛡️ Trivy workspace scan — no-fix CVE report")
+    lines.append("")
+    lines.append(
+        f"Image: `{IMAGE}` · Severity: **HIGH, CRITICAL** · "
+        f"Source: Debian + Node package metadata"
+    )
+    lines.append("")
+    lines.append(f"- **{total}** HIGH/CRITICAL findings")
+    lines.append(
+        f"- **{len(fixable)}** with an available fix "
+        f"(a package/Node upgrade resolves them)"
+    )
+    lines.append(
+        f"- **{len(no_fix)}** ({len(no_fix_cves)} distinct CVEs) with "
+        f"**no upstream fix yet** — tracked in "
+        f"[#570]({TRACKING_ISSUE})"
+    )
+    lines.append("")
+    lines.append(
+        "> This scan is **informational** — it never fails the workflow. "
+        "Re-runs weekly (Mon 06:00 UTC) or on demand via `workflow_dispatch`."
+    )
+    lines.append("")
+
+    if fixable_cves:
+        lines.append(
+            f"### 🔧 Fix available — resolve by upgrading ({len(fixable_cves)} CVEs)"
+        )
+        lines.append("")
+        lines.append("| CVE | Severity | Package | Installed | Fixed |")
+        lines.append("| --- | --- | --- | --- | --- |")
+        for e in fixable_cves:
+            for pkg, (inst, fixed) in sorted(e["packages"].items()):
+                lines.append(
+                    f"| {e['cve']} | {e['severity']} | "
+                    f"{_md_escape(pkg)} | {_md_escape(inst)} | "
+                    f"{_md_escape(fixed)} |"
+                )
+        lines.append("")
+
+    lines.append(
+        f"### ⏳ No upstream fix yet ({len(no_fix_cves)} CVEs, {len(no_fix)} findings)"
+    )
+    lines.append("")
+    if not no_fix_cves:
+        lines.append("_None — all HIGH/CRITICAL findings have an available fix. 🎉_")
+        lines.append("")
+    else:
+        lines.append(
+            "Grouped by CVE. Re-scanned periodically; revisit when Debian "
+            f"publishes fixed packages. See [#570]({TRACKING_ISSUE})."
+        )
+        lines.append("")
+        lines.append("| CVE | Severity | Status | Packages | Title |")
+        lines.append("| --- | --- | --- | --- | --- |")
+        for e in no_fix_cves:
+            pkgs = ", ".join(sorted(e["packages"]))
+            if len(pkgs) > 60:
+                pkgs = pkgs[:59] + "…"
+            lines.append(
+                f"| {e['cve']} | {e['severity']} | `{e['status']}` | "
+                f"{_md_escape(pkgs)} | {_md_escape(_short(e['title']))} |"
+            )
+        lines.append("")
+
+    lines.append("<details><summary>Status legend</summary>")
+    lines.append("")
+    lines.append("- `affected` — no fixed package available yet (fix expected).")
+    lines.append("- `fix_deferred` — Debian has explicitly deferred the fix.")
+    lines.append("- `will_not_fix` / `end_of_life` — no fix planned.")
+    lines.append("- A populated **Fixed** column means an upgrade resolves it.")
+    lines.append("")
+    lines.append("</details>")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str]) -> int:
+    path = argv[1] if len(argv) > 1 else None
+    if path in ("-h", "--help"):
+        print(__doc__)
+        return 0
+    results = load_results(path)
+    no_fix, fixable = collect(results)
+    print(render(no_fix, fixable))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
Closes #570.

## What

A Trivy scan of the workspace image surfaces **152** HIGH/CRITICAL findings, but **148** of them (75 distinct CVEs) have **no upstream fix available yet** (Trivy status `affected` / `fix_deferred`) — only `libssh2-1t64` and `undici` (4 findings) are actually upgradeable today. Those no-fix CVEs can't be resolved until Debian/NPM ship patched packages, so #570 tracks them for awareness and asks for periodic re-scanning. This PR implements that re-scan machinery.

## Changes

- **`scripts/trivy-report-nofix.py`** — renders a Trivy JSON scan as markdown, splitting findings into **🔧 fix available (upgrade)** vs **⏳ no upstream fix yet**, grouped by CVE with severity, status, packages, and title. Reads a file or stdin; only markdown goes to stdout, diagnostics to stderr. Tested against a live scan of `klangk-workspace:latest`.
- **`.github/workflows/trivy-workspace-scan.yml`** — new workflow: weekly cron (Mon 06:00 UTC) + `workflow_dispatch`. Builds a fresh workspace image (via the existing `devenv-setup` action), exports it to a tarball, scans with `setup-trivy`, writes the report to `$GITHUB_STEP_SUMMARY`, and uploads the raw JSON + report as artifacts. **Informational only — it never fails the run** (these CVEs have no fix), so reviewers check the Actions tab. No issue/PR comments, to avoid noise given the repo's default-closed/anti-slop policy.
- **`devenv.nix`** — adds a `trivy-workspace-report` convenience script: with no args it scans + reports in one shot; with a path it renders an existing JSON file.
- **`docs/development/`** — documents the no-fix tracking (#570), the `trivy-workspace-report` command, and the periodic scan workflow.

## Why this shape

- **Non-gating**: a scan that fails CI on unfixable CVEs would just stay permanently red and be ignored. Reporting + artifacts keep the signal useful.
- **No bot comments**: the repo runs a default-closed policy with LLM-assisted slop review; automated issue comments would be unwelcome noise. A weekly Actions run with a rendered summary achieves "re-scanned periodically" cleanly.
- **Reuse**: builds via the same `devenv-setup` action + `klangk:build-workspace-image` task the other image workflows already use.

## Verification

- `python3 scripts/trivy-report-nofix.py /tmp/scan.json` produces the report below (real scan).
- Edge cases checked: empty results (`{"Results":[]}`), stdin piping, invalid JSON (exits 2), `--help`.
- `devenv shell -- true` evaluates cleanly with the new script.
- All pre-commit hooks pass (actionlint, yamllint, ruff, prettier, markdownlint, nixfmt, trufflehog).

### Current baseline (snapshot from the run that motivated this)

> **152** HIGH/CRITICAL findings — **4** upgradeable (`libssh2-1t64`, `undici`), **148** (75 CVEs) with no upstream fix yet.

Notable no-fix CRITICALs: `CVE-2026-42496` (perl `Archive::Tar` symlink path traversal — `fix_deferred`), `CVE-2026-34873`/`CVE-2026-34875` (mbedtls), `CVE-2026-56123` (socat heap overflow), `CVE-2026-43185` (linux-libc-dev/ksmbd), `CVE-2026-8376` (perl heap overflow).