### PR TITLE
ci: fix setup-trivy version (v0.2.0 does not exist)

### DIFF
--- a/.github/workflows/trivy-workspace-scan.yml
+++ b/.github/workflows/trivy-workspace-scan.yml
@@ -42,7 +42,7 @@ jobs:
             -o /tmp/workspace.tar "${KLANGK_IMAGE_NAME:-klangk-workspace}:latest"
 
       - name: Install Trivy
-        uses: aquasecurity/setup-trivy@v0.2.0
+        uses: aquasecurity/setup-trivy@v0.3.1
         with:
           version: v0.69.3
           cache: true


### PR DESCRIPTION
The `trivy-workspace-scan` workflow from #1099 fails immediately at job setup:

> Unable to resolve action `aquasecurity/setup-trivy@v0.2.0`, unable to find version `v0.2.0`

Run: https://github.com/mcdonc/klangk/actions/runs/28460233838

`aquasecurity/setup-trivy` has **no `v0.2.0` tag** — the oldest is `v0.2.6`, latest is `v0.3.1`. The `v0.2.0` reference came from a stale example in the trivy-action README. Bumping to `v0.3.1` (latest stable; matches the repo's tag-pinning convention). Its inputs (`version`, `cache`) are unchanged, so the rest of the workflow is unaffected.

Verified: `v0.69.3` (the trivy binary version pinned) is a real release tag, so that pin is fine — only the action tag was wrong.

/cc #570