### PR TITLE
feat(frontend): stream workspace export to disk (#700)

### DIFF
--- a/src/frontend/e2e-tests/e2e/workspace-export.spec.ts
+++ b/src/frontend/e2e-tests/e2e/workspace-export.spec.ts
@@ -1,0 +1,354 @@
+import { test, expect } from "@playwright/test";
+import { execSync } from "child_process";
+import { mkdtempSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  API_BASE,
+  loginViaUI,
+  waitForFlutter,
+  connectContainer,
+  createWorkspace,
+  seedFile,
+  vp,
+  flutterClick,
+} from "./helpers";
+
+// The File System Access API's showSaveFilePicker() opens a native file dialog
+// that Playwright cannot drive (microsoft/playwright#8850 — no filechooser /
+// download event is raised for it, and the W3C web-platform-tests for it are
+// themselves manual). So we inject a fake showSaveFilePicker() that records the
+// chunks the real streaming code writes — exercising the actual production path
+// (authenticated fetch → ReadableStream reader loop → chunked write) against an
+// in-memory sink instead of disk. See workspace_settings_panel._exportWorkspace
+// → downloadStreamedUrl (#700).
+const INSTALL_FSA_SHIM = `
+(() => {
+  window.__exportChunks = [];
+  window.__exportDone = false;
+  window.__exportPickerCalled = false;
+  window.__exportSuggestedName = null;
+  window.__exportError = null;
+  window.showSaveFilePicker = function (options) {
+    window.__exportPickerCalled = true;
+    window.__exportSuggestedName = (options && options.suggestedName) || null;
+    return Promise.resolve({
+      createWritable: function () {
+        return Promise.resolve({
+          write: function (chunk) {
+            try {
+              // chunk is a Uint8Array from the real ReadableStream reader.
+              // Copy it — the underlying buffer is reused across reads.
+              window.__exportChunks.push(new Uint8Array(chunk));
+            } catch (e) {
+              window.__exportError = String(e);
+            }
+            return Promise.resolve();
+          },
+          close: function () {
+            window.__exportDone = true;
+            return Promise.resolve();
+          },
+        });
+      },
+    });
+  };
+})();
+`;
+
+// Admin account provisioned by global-setup (KLANGK_DEFAULT_USER / PASSWORD).
+// The export endpoint is admin-only (workspaces.py: has_permission("admin")).
+const ADMIN_EMAIL = "admin@example.com";
+const ADMIN_PASSWORD = "admin";
+
+/** Poll the shim's window globals until the stream finishes (or errors).
+ *  Returns only cheap status fields — the bytes themselves are retrieved
+ *  separately by retrieveStreamedBytes() so a large archive isn't squeezed
+ *  through a single page.evaluate return (which CDP truncates). */
+async function pollStreamedExport(
+  page: import("@playwright/test").Page,
+  timeout = 60_000,
+): Promise<{
+  pickerCalled: boolean;
+  done: boolean;
+  error: string | null;
+  suggestedName: string | null;
+  length: number;
+}> {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    const r = await readShimState(page);
+    if (r.done || r.error) return r;
+    await page.waitForTimeout(250);
+  }
+  const final = await readShimState(page);
+  throw new Error(
+    `Streamed export did not complete within ${timeout}ms. Final shim state: ${JSON.stringify(
+      {
+        pickerCalled: final.pickerCalled,
+        done: final.done,
+        error: final.error,
+        suggestedName: final.suggestedName,
+        length: final.length,
+      },
+    )}`,
+  );
+}
+
+/** Read the shim's cheap status fields. */
+async function readShimState(page: import("@playwright/test").Page) {
+  return page.evaluate(() => {
+    const w = window as any;
+    const chunks: Uint8Array[] = w.__exportChunks || [];
+    let total = 0;
+    for (const c of chunks) total += c.length;
+    return {
+      pickerCalled: w.__exportPickerCalled === true,
+      done: w.__exportDone === true,
+      error: w.__exportError || null,
+      suggestedName: w.__exportSuggestedName || null,
+      length: total,
+    };
+  });
+}
+
+/** Retrieve the full streamed byte buffer from the shim, in fixed-size slices.
+ *  Returning the whole archive through one page.evaluate call gets truncated
+ *  by CDP, so fetch it in 4 MB raw slices (~5.3 MB base64 each). */
+async function retrieveStreamedBytes(
+  page: import("@playwright/test").Page,
+): Promise<Buffer> {
+  // Materialise the merged buffer once on the page side.
+  await page.evaluate(() => {
+    const chunks: Uint8Array[] = (window as any).__exportChunks || [];
+    let total = 0;
+    for (const c of chunks) total += c.length;
+    const merged = new Uint8Array(total);
+    let o = 0;
+    for (const c of chunks) {
+      merged.set(c, o);
+      o += c.length;
+    }
+    (window as any).__exportMerged = merged;
+  });
+  const total: number = await page.evaluate(
+    () => (window as any).__exportMerged.length,
+  );
+  const SLICE = 4 * 1024 * 1024;
+  const parts: Buffer[] = [];
+  for (let off = 0; off < total; off += SLICE) {
+    const len = Math.min(SLICE, total - off);
+    const b64 = await page.evaluate(
+      ([start, n]) => {
+        const m: Uint8Array = (window as any).__exportMerged;
+        const slice = m.subarray(start, start + n);
+        let s = "";
+        for (let i = 0; i < slice.length; i++)
+          s += String.fromCharCode(slice[i]);
+        return btoa(s);
+      },
+      [off, len] as [number, number],
+    );
+    parts.push(Buffer.from(b64, "base64"));
+  }
+  return Buffer.concat(parts);
+}
+
+test.describe("Workspace export streaming (#700)", () => {
+  test("streams the export through the File System Access API on chromium", async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(180_000);
+
+    // --- 1. Admin setup via API: workspace + running container + marker file.
+    // Track the export network request/response so a failed/missing fetch is
+    // visible in the failure message rather than a silent 60s timeout.
+    const exportReqs: { method: string; status: number; url: string }[] = [];
+    page.on("response", (resp) => {
+      if (resp.url().includes("/export")) {
+        exportReqs.push({
+          method: resp.request().method(),
+          status: resp.status(),
+          url: resp.url(),
+        });
+      }
+    });
+    const loginResp = await request.post(`${API_BASE}/api/v1/auth/login`, {
+      data: { email: ADMIN_EMAIL, password: ADMIN_PASSWORD },
+    });
+    expect(loginResp.ok()).toBeTruthy();
+    const adminToken = (await loginResp.json()).access_token;
+    const adminHeaders = { Authorization: `Bearer ${adminToken}` };
+
+    const { workspaceId, cleanup } = await createWorkspace(
+      request,
+      adminHeaders,
+      "e2e-export-stream",
+    );
+    await connectContainer(workspaceId, adminToken);
+
+    const marker = `streaming-export-marker-${Date.now()}\n`;
+    const markerPath = "/home/work/export_marker.txt";
+    await seedFile(request, workspaceId, markerPath, marker, adminHeaders);
+
+    try {
+      // --- 2. Install the FSA shim before the app loads.
+      await page.addInitScript(INSTALL_FSA_SHIM);
+
+      // --- 3. Log in as admin and open the workspace, waiting for the UI to
+      //         finish connecting (container_ready) so the page is stable
+      //         before we touch accessibility semantics. Mirrors openWorkspace.
+      const uiReady = new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(
+          () => reject(new Error("UI did not report container_ready")),
+          120_000,
+        );
+        page.on(
+          "websocket",
+          (ws: { on: (e: string, cb: Function) => void }) => {
+            ws.on("framereceived", (frame: { payload: string | Buffer }) => {
+              if (frame.payload.toString().includes("container_ready")) {
+                clearTimeout(timer);
+                resolve();
+              }
+            });
+          },
+        );
+      });
+      await loginViaUI(page, ADMIN_EMAIL, ADMIN_PASSWORD);
+      await page.goto(`/#/workspace/${workspaceId}`, { waitUntil: "load" });
+      await waitForFlutter(page);
+      await uiReady;
+      await page.waitForTimeout(1000); // let the terminal render
+
+      // --- 4. Enable Flutter Web accessibility semantics. The app renders to a
+      //         <canvas>; until a11y is on, real widgets (tabs, the Export
+      //         button) are invisible to role locators. Flutter injects an
+      //         "Enable accessibility" invoker a few seconds after load (often in
+      //         shadow DOM, parked off-screen), so wait for it to attach, then
+      //         click it programmatically via the resolved element — that bypasses
+      //         both the off-screen position and the actionability checks a normal
+      //         or force click enforces. Enabling populates <flt-semantics>, which
+      //         we wait for before proceeding.
+      const a11yInvoker = page.getByRole("button", {
+        name: /^Enable accessibility$/i,
+      });
+      await a11yInvoker.waitFor({ state: "attached", timeout: 30_000 });
+      await a11yInvoker.evaluate((el) => (el as HTMLElement).click());
+      await expect
+        .poll(
+          () =>
+            page.evaluate(
+              () => document.querySelectorAll("flt-semantics *").length,
+            ),
+          { timeout: 15_000, message: "flt-semantics tree populated" },
+        )
+        .toBeGreaterThan(0);
+
+      // --- 5. Open the Settings tab (5th of 5 owner tabs, at y~76).
+      const { width } = vp(page);
+      const tabWidth = width / 5;
+      await flutterClick(page, tabWidth * 4 + tabWidth / 2, 76);
+      await page.waitForTimeout(800);
+
+      // --- 6. Click "Export Workspace" via its accessible role (it's left-
+      //         aligned in a centered 500px column, so a coordinate click is
+      //         unreliable). Its name includes the download icon + label.
+      const exportBtn = page.getByRole("button", { name: /Export Workspace/i });
+      await exportBtn.click({ timeout: 15_000 });
+
+      // --- 7. Wait for the stream to finish and read back what the shim captured.
+      let result;
+      try {
+        result = await pollStreamedExport(page);
+      } catch (e) {
+        // Surface the export network activity so a missing/failed fetch is
+        // diagnosable instead of a bare 60s timeout.
+        // eslint-disable-next-line no-console
+        console.log("EXPORT_REQS_AT_FAILURE:", JSON.stringify(exportReqs));
+        throw e;
+      }
+
+      // The streaming path was actually taken (not the buffered fallback).
+      expect(
+        result.pickerCalled,
+        "showSaveFilePicker was invoked",
+      ).toBeTruthy();
+      expect(result.error, "no error during writable.write()").toBeNull();
+      expect(result.done, "writable.close() was called").toBeTruthy();
+      expect(result.suggestedName, "suggested name ends in .tar.gz").toMatch(
+        /\.tar\.gz$/,
+      );
+
+      // --- 7. The captured bytes are a valid gzip archive.
+      const streamed = await retrieveStreamedBytes(page);
+      expect(streamed.length, "archive is non-empty").toBeGreaterThan(0);
+      expect(streamed[0]).toBe(0x1f); // gzip magic
+      expect(streamed[1]).toBe(0x8b);
+
+      // --- 8. Strongest check: the archive gunzips, lists, and the seeded
+      //         marker file round-trips byte-for-byte (proves the streamed
+      //         download is complete and correct, not just plausible bytes).
+      const tmpDir = mkdtempSync(join(tmpdir(), "klangk-export-stream-"));
+      const archivePath = join(tmpDir, "export.tar.gz");
+      writeFileSync(archivePath, streamed);
+
+      let entries: string;
+      try {
+        entries = execSync(`tar tzf "${archivePath}"`, { encoding: "utf-8" });
+      } catch (e) {
+        // Diagnose a malformed archive: is the capture truncated vs. the
+        // ground-truth API export, reordered, or just not gzip?
+        const apiExport = await request.get(
+          `${API_BASE}/api/v1/workspaces/${workspaceId}/export`,
+          { headers: adminHeaders },
+        );
+        const apiBody = apiExport.ok()
+          ? await apiExport.body()
+          : Buffer.alloc(0);
+        const gunzipTest = (() => {
+          try {
+            execSync(`gunzip -t "${archivePath}"`, {
+              encoding: "utf-8",
+              stdio: "pipe",
+            });
+            return "ok";
+          } catch (ge: any) {
+            return (ge.stderr || ge.message || "").toString().trim();
+          }
+        })();
+        // eslint-disable-next-line no-console
+        console.log(
+          "TAR_FAIL_DIAG:",
+          JSON.stringify({
+            streamedLength: streamed.length,
+            apiLength: apiBody.length,
+            prefixMatch:
+              apiBody.length >= streamed.length &&
+              apiBody.subarray(0, streamed.length).equals(streamed),
+            gunzipTest,
+          }),
+        );
+        throw e;
+      }
+      const markerEntry = entries
+        .split("\n")
+        .find((l) => l.endsWith("home/work/export_marker.txt"));
+      expect(
+        markerEntry,
+        "seeded marker file is present in the archive",
+      ).toBeTruthy();
+
+      const extracted = execSync(
+        `tar -xOzf "${archivePath}" "${markerEntry}"`,
+        {
+          encoding: "utf-8",
+        },
+      );
+      expect(extracted).toBe(marker);
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/frontend/e2e-tests/playwright.config.ts
+++ b/src/frontend/e2e-tests/playwright.config.ts
@@ -78,6 +78,7 @@ export default defineConfig({
         "tab-speed.spec.ts",
         "sudo.spec.ts",
         "ws-connect-speed.spec.ts",
+        "workspace-export.spec.ts",
       ],
       use: chromiumUse,
     },

--- a/src/frontend/lib/auth/auth_service.dart
+++ b/src/frontend/lib/auth/auth_service.dart
@@ -187,6 +187,12 @@ class AuthService extends ChangeNotifier {
         if (_token != null) 'Authorization': 'Bearer $_token',
       };
 
+  /// Public access to the auth headers, for callers that issue their own
+  /// authenticated requests outside the `http` package (e.g. the streaming
+  /// workspace export, which uses `fetch()` directly to stream the body to
+  /// disk without buffering it in memory).
+  Map<String, String> get authHeaders => _authHeaders;
+
   Future<String?> register(String email, String password) async {
     _loading = true;
     notifyListeners();

--- a/src/frontend/lib/utils/web_helpers_stub.dart
+++ b/src/frontend/lib/utils/web_helpers_stub.dart
@@ -52,3 +52,12 @@ String getBuildHash() => '';
 
 /// Stub — no file picker outside the browser.
 Future<List<int>?> pickFileBytes({String accept = ''}) async => null;
+
+/// Stub — File System Access API is browser-only; signal "not handled" so the
+/// caller falls back to a buffered download (or no-op in VM tests).
+Future<bool> downloadStreamedUrl(
+  String url, {
+  required String filename,
+  Map<String, String>? headers,
+}) async =>
+    false;

--- a/src/frontend/lib/utils/web_helpers_web.dart
+++ b/src/frontend/lib/utils/web_helpers_web.dart
@@ -269,7 +269,10 @@ extension type _FetchResponse._(JSObject _) implements JSObject {
 
 @JS()
 extension type _ReadableStream._(JSObject _) implements JSObject {
-  external JSPromise getReader();
+  // getReader() is SYNCHRONOUS in the standard (returns the reader directly,
+  // not a Promise) — declaring it as a promise and awaiting it would call
+  // .then on a non-thenable and reject (#700 e2e caught this).
+  external _StreamReader getReader();
 }
 
 @JS()
@@ -338,7 +341,7 @@ Future<bool> downloadStreamedUrl(
       .toDart) as _FileSystemFileHandle;
   final writable =
       (await handle.createWritable().toDart) as _FileSystemWritableFileStream;
-  final reader = (await body.getReader().toDart) as _StreamReader;
+  final reader = body.getReader();
   try {
     while (true) {
       final result = (await reader.read().toDart) as _ReadResult;

--- a/src/frontend/lib/utils/web_helpers_web.dart
+++ b/src/frontend/lib/utils/web_helpers_web.dart
@@ -225,3 +225,169 @@ Widget buildSuppressor(Widget child) {
     child: child,
   );
 }
+
+// --- Streaming download via the File System Access API ---------------------
+//
+// `downloadBytes` buffers the whole response in memory (it builds a Blob),
+// which for a large workspace export can be hundreds of MB of RAM. Where the
+// browser supports the File System Access API (Chrome, Edge, Opera, and most
+// desktop Chromium derivatives), we instead `fetch()` the URL with the auth
+// header and stream the response body straight to a user-chosen file on disk,
+// one chunk at a time — so memory use stays flat regardless of archive size.
+//
+// Firefox and Safari don't implement `showSaveFilePicker`; there the function
+// returns `false` so the caller can fall back to the buffered path. This is
+// the reason `downloadStreamedUrl` is `Future<bool>` rather than `void`.
+
+@JS()
+extension type _SaveFilePickerOptions._(JSObject _) implements JSObject {
+  external factory _SaveFilePickerOptions({JSString suggestedName});
+}
+
+@JS()
+extension type _FileSystemFileHandle._(JSObject _) implements JSObject {
+  external JSPromise createWritable();
+}
+
+@JS()
+extension type _FileSystemWritableFileStream._(JSObject _) implements JSObject {
+  external JSPromise write(JSUint8Array chunk);
+  external JSPromise close();
+}
+
+@JS()
+extension type _FetchOptions._(JSObject _) implements JSObject {
+  external factory _FetchOptions({JSString method, JSObject headers});
+}
+
+@JS()
+extension type _FetchResponse._(JSObject _) implements JSObject {
+  external int get status;
+  external JSString get statusText;
+  external _ReadableStream? get body;
+}
+
+@JS()
+extension type _ReadableStream._(JSObject _) implements JSObject {
+  external JSPromise getReader();
+}
+
+@JS()
+extension type _StreamReader._(JSObject _) implements JSObject {
+  external JSPromise read();
+  external void releaseLock();
+}
+
+@JS()
+extension type _ReadResult._(JSObject _) implements JSObject {
+  external bool get done;
+  external JSUint8Array? get value;
+}
+
+@JS('fetch')
+external JSPromise _streamFetch(JSString url, _FetchOptions options);
+
+@JS()
+extension type _WindowWithSavePicker._(JSObject _) implements JSObject {
+  external JSPromise showSaveFilePicker(_SaveFilePickerOptions options);
+}
+
+/// Download [url] (issuing [headers], e.g. `Authorization`) by streaming the
+/// response body straight to a file on disk via the File System Access API.
+///
+/// Returns `true` if the download was handled (streamed to disk). Returns
+/// `false` if the browser lacks `showSaveFilePicker` (Firefox/Safari) — the
+/// caller should then fall back to a buffered download. Throws on a non-200
+/// response or on an I/O error mid-stream.
+Future<bool> downloadStreamedUrl(
+  String url, {
+  required String filename,
+  Map<String, String>? headers,
+}) async {
+  // Feature-detect the File System Access API. Absent in Firefox/Safari.
+  // `Reflect.has` is a plain JS global; `package:web`'s Window doesn't
+  // expose an index operator in this version, so we probe via Reflect.
+  if (!_reflectHas(web.window, 'showSaveFilePicker'.toJS)) {
+    return false;
+  }
+
+  // Issue the request first (without reading the body). The body stays a
+  // pending stream, so nothing is buffered yet; the backend's tar process is
+  // simply held open by backpressure until we start reading.
+  final fetchOpts = _FetchOptions(
+    method: 'GET'.toJS,
+    headers: _headersToJS(headers),
+  );
+  final response =
+      (await _streamFetch(url.toJS, fetchOpts).toDart) as _FetchResponse;
+  if (response.status != 200) {
+    throw StreamedDownloadException(
+        response.status, response.statusText.toDart);
+  }
+  final body = response.body;
+  if (body == null) {
+    throw StreamedDownloadException(response.status, 'response had no body');
+  }
+
+  // Now prompt for the destination. Doing this after the fetch lets us bail
+  // (no empty file created) on auth/server errors.
+  final handle = (await (web.window as _WindowWithSavePicker)
+      .showSaveFilePicker(
+        _SaveFilePickerOptions(suggestedName: filename.toJS),
+      )
+      .toDart) as _FileSystemFileHandle;
+  final writable =
+      (await handle.createWritable().toDart) as _FileSystemWritableFileStream;
+  final reader = (await body.getReader().toDart) as _StreamReader;
+  try {
+    while (true) {
+      final result = (await reader.read().toDart) as _ReadResult;
+      if (result.done) break;
+      final chunk = result.value;
+      if (chunk != null && chunk.toDart.length > 0) {
+        await writable.write(chunk).toDart;
+      }
+    }
+    await writable.close().toDart;
+  } catch (e) {
+    // Best-effort close so we don't leave a dangling writable; the partial
+    // file remains on disk, which is better than a locked handle.
+    try {
+      await writable.close().toDart;
+    } catch (_) {}
+    rethrow;
+  } finally {
+    reader.releaseLock();
+  }
+  return true;
+}
+
+/// Build a plain JS headers object from a Dart map, via `Object.fromEntries`.
+/// (`package:web` 1.1 has no JSObject index setter; this avoids needing it.)
+@JS('Object.fromEntries')
+external JSObject _objectFromEntries(JSArray entries);
+
+/// `Reflect.has(target, key)` — property probe that works on any JS object.
+@JS('Reflect.has')
+external bool _reflectHas(JSObject target, JSString key);
+
+JSObject _headersToJS(Map<String, String>? headers) {
+  if (headers == null || headers.isEmpty) {
+    return _objectFromEntries([] as JSArray);
+  }
+  // Build [[k, v], ...] as JSArray<JSArray<JSString>>.
+  final entries = <JSArray>[];
+  headers.forEach((k, v) {
+    entries.add([k.toJS, v.toJS].toJS);
+  });
+  return _objectFromEntries(entries.toJS);
+}
+
+/// Thrown by [downloadStreamedUrl] when the response isn't 200.
+class StreamedDownloadException implements Exception {
+  final int status;
+  final String statusText;
+  StreamedDownloadException(this.status, this.statusText);
+  @override
+  String toString() => 'StreamedDownloadException: $status $statusText';
+}

--- a/src/frontend/lib/workspace/workspace_settings_panel.dart
+++ b/src/frontend/lib/workspace/workspace_settings_panel.dart
@@ -49,9 +49,9 @@ class WorkspaceSettingsPanelState extends State<WorkspaceSettingsPanel> {
     }
 
     var ws = workspaces.cast<Map<String, dynamic>?>().firstWhere(
-      (w) => w!['id'] == widget.workspaceId,
-      orElse: () => null,
-    );
+          (w) => w!['id'] == widget.workspaceId,
+          orElse: () => null,
+        );
 
     // Try shared workspaces if not found in owned
     if (ws == null) {
@@ -62,9 +62,9 @@ class WorkspaceSettingsPanelState extends State<WorkspaceSettingsPanel> {
           jsonDecode(sharedResp.body),
         );
         ws = shared.cast<Map<String, dynamic>?>().firstWhere(
-          (w) => w!['id'] == widget.workspaceId,
-          orElse: () => null,
-        );
+              (w) => w!['id'] == widget.workspaceId,
+              orElse: () => null,
+            );
       }
     }
 
@@ -232,9 +232,8 @@ class _SettingsFormState extends State<_SettingsForm> {
     await widget.onSave({
       'name': _nameCtrl.text.trim(),
       'image': _selectedImage,
-      'default_command': _cmdCtrl.text.trim().isEmpty
-          ? null
-          : _cmdCtrl.text.trim(),
+      'default_command':
+          _cmdCtrl.text.trim().isEmpty ? null : _cmdCtrl.text.trim(),
       'health_check': _healthCheckCtrl.text.trim().isEmpty
           ? null
           : _healthCheckCtrl.text.trim(),
@@ -447,12 +446,12 @@ class _SettingsFormState extends State<_SettingsForm> {
       error: _mountError,
       onAdd: _tryAddMount,
       items: _mounts.asMap().entries.map(
-        (e) => _buildEditableListItem(
-          text: e.value,
-          onCopy: e.value,
-          onRemove: () => setState(() => _mounts.removeAt(e.key)),
-        ),
-      ),
+            (e) => _buildEditableListItem(
+              text: e.value,
+              onCopy: e.value,
+              onRemove: () => setState(() => _mounts.removeAt(e.key)),
+            ),
+          ),
     );
   }
 
@@ -465,12 +464,12 @@ class _SettingsFormState extends State<_SettingsForm> {
       error: _envError,
       onAdd: _tryAddEnv,
       items: _envVars.entries.toList().asMap().entries.map(
-        (e) => _buildEditableListItem(
-          text: '${e.value.key}=${e.value.value}',
-          onCopy: '${e.value.key}=${e.value.value}',
-          onRemove: () => setState(() => _envVars.remove(e.value.key)),
-        ),
-      ),
+            (e) => _buildEditableListItem(
+              text: '${e.value.key}=${e.value.value}',
+              onCopy: '${e.value.key}=${e.value.value}',
+              onRemove: () => setState(() => _envVars.remove(e.value.key)),
+            ),
+          ),
     );
   }
 
@@ -606,17 +605,28 @@ class _SettingsFormState extends State<_SettingsForm> {
     setState(() => _exporting = true);
     try {
       final auth = context.read<AuthService>();
-      final resp = await auth.authGet(
-        '/api/v1/workspaces/${widget.workspaceId}/export',
+      final name = widget.workspace['name'] as String? ?? 'workspace';
+      final filename = '$name.tar.gz';
+      final exportPath = '/api/v1/workspaces/${widget.workspaceId}/export';
+
+      // Prefer streaming straight to disk (no in-memory buffering) when the
+      // browser supports the File System Access API. Falls back to the
+      // buffered path on Firefox/Safari/older browsers (#700).
+      final streamed = await downloadStreamedUrl(
+        exportPath,
+        filename: filename,
+        headers: auth.authHeaders,
       );
-      if (resp.statusCode == 200) {
-        final name = widget.workspace['name'] as String? ?? 'workspace';
-        downloadBytes(resp.bodyBytes, '$name.tar.gz');
-      } else {
-        if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text('Export failed: ${resp.statusCode}')),
-          );
+      if (!streamed) {
+        final resp = await auth.authGet(exportPath);
+        if (resp.statusCode == 200) {
+          downloadBytes(resp.bodyBytes, filename);
+        } else {
+          if (mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text('Export failed: ${resp.statusCode}')),
+            );
+          }
         }
       }
     } catch (_) {


### PR DESCRIPTION
Closes #700.

## Problem

The workspace export UI called `authGet` + `downloadBytes`, which buffers the **entire** `.tar.gz` response in browser memory (a Blob) before triggering the download. The backend already streams (`StreamingResponse` + chunked `tar`), but the client re-buffered it all — significant RAM for large workspaces.

Per the issue discussion: we do **not** need a temporary authenticated URL. The export endpoint already returns a streaming `application/gzip` body behind a `Bearer` token; we just need to stream that body straight to disk instead of into a Blob.

## What

Added `downloadStreamedUrl()` to the web helpers: where the browser supports the **File System Access API** (Chrome, Edge, Opera, desktop Chromium), it `fetch()`es the URL with the `Authorization` header and streams the response body straight to a user-chosen file via `showSaveFilePicker` → `createWritable` → a `ReadableStream` reader loop. Memory stays flat regardless of archive size.

On **Firefox/Safari** (no `showSaveFilePicker`), `downloadStreamedUrl` returns `false` and the caller falls back to the existing buffered path — graceful degradation, no broken exports.

## Changes

| File | Change |
|------|--------|
| `lib/utils/web_helpers_web.dart` | New `downloadStreamedUrl()`: `fetch` + `showSaveFilePicker` + `createWritable` + `ReadableStream.getReader()` loop. Minimal `@JS()` interop shims (`Object.fromEntries` for the headers object, `Reflect.has` for the feature detect) because `package:web` 1.1 lacks `JSObject` index accessors. |
| `lib/utils/web_helpers_stub.dart` | Stub returning `false` (VM tests, non-browser targets). |
| `lib/auth/auth_service.dart` | Expose `authHeaders` so the streamer can issue its own authenticated `fetch` outside the `http` package. |
| `lib/workspace/workspace_settings_panel.dart` | `_exportWorkspace()` tries streaming first; on `false` falls back to `authGet` + `downloadBytes`. |

## Behavior

- **Chrome/Edge/etc.:** `fetch` the export URL with the Bearer token → user picks destination → body is streamed chunk-by-chunk to disk. No buffering.
- **Firefox/Safari:** transparent fallback to the old buffered download (unchanged behavior).
- **Non-200 / network error / auth failure:** surfaced via the existing `Export failed` snackbar.

## Verification

- `flutter analyze` on all 4 touched files: clean (the 2 remaining warnings — unused `dart:math` import and a `value:` form-field deprecation — are pre-existing on `main`, unrelated to this change).
- `flutter test test/workspace_settings_panel_test.dart`: **all 23 tests pass** (VM tests exercise the fallback path since the stub returns `false`).
- Streaming itself is browser-gated, so it is covered by the feature-detect + graceful fallback rather than a unit test; manual browser verification (Chrome) recommended at review.

## Notes for review

- The fallback path is intentionally unchanged — Firefox/Safari users get exactly today's behavior, so there is no regression risk there.
- I deliberately kept the request authenticated with the existing JWT in the `Authorization` header rather than minting a temporary URL (per the issue discussion). The streaming is what fixes the memory problem; no backend changes were needed since it already streams.
