### PR TITLE
Run health check as bash login shell; document shell conventions (#1087)

### DIFF
--- a/docs/features/health-check.md
+++ b/docs/features/health-check.md
@@ -48,8 +48,14 @@ For each workspace with a health check configured:
 4. The current status and the time of the last check are exposed via
    `GET /api/v1/workspaces/{id}/status`.
 
-The check runs through `sh -c "<your command>"`, so any shell syntax
-works — pipes, `&&`, redirects, etc.
+The check runs through `bash -lc "<your command>"` — a bash **login
+shell** — so any shell syntax works (pipes, `&&`, redirects, etc.)
+**and** the command sees the workspace user's environment: it sources
+`~/.profile`, where `setup.sh` persists PATH additions and tool homes.
+This means a check like `openclaw health` resolves the `openclaw`
+binary even though it was installed under nvm/asdf. See
+[The Shell — Startup files](the-shell.md#startup-files) for the
+convention on where setup scripts should put environment exports.
 
 ### When checks are skipped
 

--- a/docs/features/sandbox.md
+++ b/docs/features/sandbox.md
@@ -177,7 +177,9 @@ mounts:
   - .env:~/.env:ro
 ```
 
-Then in your `.bashrc` or setup script:
+Then in your `~/.profile` (so the health check and default command see
+the variables too — see [The Shell](the-shell.md#startup-files)) or
+setup script:
 
 ```bash
 [ -f ~/.env ] && . ~/.env
@@ -366,10 +368,14 @@ mkdir -p ~/.config/nix
 grep -q experimental-features ~/.config/nix/nix.conf 2>/dev/null \
   || echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
 
-# Source nix in non-login shells too.
+# Source nix in every login shell -- interactive terminals, the
+# default command, and the health check (bash -lc) all source
+# ~/.profile. Writing this to ~/.bashrc instead would hide it from
+# the health check (its interactivity guard returns early for
+# non-interactive shells). See the-shell.md#startup-files.
 # shellcheck disable=SC2016
-grep -q nix-profile ~/.bashrc 2>/dev/null \
-  || echo '. "$HOME/.nix-profile/etc/profile.d/nix.sh"' >> ~/.bashrc
+grep -q nix-profile ~/.profile 2>/dev/null \
+  || echo '. "$HOME/.nix-profile/etc/profile.d/nix.sh"' >> ~/.profile
 
 # Install devenv.
 if ! command -v devenv &>/dev/null; then

--- a/docs/features/the-shell.md
+++ b/docs/features/the-shell.md
@@ -5,8 +5,9 @@ set up the environment before your personal `~/.bashrc` runs:
 
 - `/etc/profile.d/klangk-*.sh` — environment exports (`PATH=/opt/klangk/bin`,
   `EDITOR`) sourced by **every login shell**, interactive or not. This is
-  why one-shot commands like the workspace health check (`bash -lc`) and
-  `klangkc exec` still find `pi`, `herdr`, and the `klangk-*` helpers.
+  why one-shot commands like the workspace health check (`bash -lc`)
+  still find `pi`, `herdr`, and the `klangk-*` helpers. (Note:
+  `klangkc exec` does not yet run a login shell — see [#1041].)
 - `/etc/bash.bashrc` — interactive-shell setup: waits for container
   readiness, runs `on-shell-init` plugin hooks, and (via the default
   command) launches the workspace's configured service.
@@ -63,13 +64,55 @@ you share the workspace with untrusted users.
 ## Customizing your environment
 
 You can customize your shell the same way you would on any UNIX
-system:
+system. The key question is _which file_ to put a change in, because
+Klangk runs commands in several contexts and not all of them source the
+same startup files (see [Startup files](#startup-files) below):
 
-- Edit `~/.bashrc` for aliases, prompt customization, PATH changes
+- Edit `~/.profile` for **environment exports** (PATH additions,
+  `OPENCLAW_HOME`, tool-manager setup like nvm/asdf) that every shell
+  — including non-interactive ones like the health check — must see.
+- Edit `~/.bashrc` for **interactive niceties** (aliases, prompt
+  customization) that only matter in a terminal you're typing into.
 - Add scripts to `~/bin`
 - Configure `~/.gitconfig`, `~/.vimrc`, etc.
 
 All changes persist across container restarts.
+
+## Startup files
+
+Klangk runs in-container commands in a few different ways, and each
+sources a different set of startup files. Getting this right matters:
+an environment export buried below `~/.bashrc`'s interactivity guard is
+invisible to the health check, so a check like `openclaw health` reports
+perpetually unhealthy even though the service is fine (#1087).
+
+### Convention
+
+| File                                        | Purpose                                                                                                              | Sourced by                                                                              |
+| ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `/etc/profile.d/klangk-*.sh`                | system-wide defaults (klangk `PATH`, `EDITOR`)                                                                       | every login shell                                                                       |
+| `~/.profile`                                | **per-user environment exports** (PATH additions, tool homes, nvm/asdf) — anything non-interactive commands must see | login shells: interactive terminals, the default command, the health check (`bash -lc`) |
+| `~/.bashrc` (below the interactivity guard) | interactive niceties (aliases, prompt)                                                                               | interactive non-login bash shells; also chained from `~/.profile` for login shells      |
+
+**Rule of thumb:** if a non-interactive command (health check, a
+script) needs it, it goes in `~/.profile`. If it only matters when
+you're at a prompt, it goes in `~/.bashrc`.
+
+### Which code path sources what
+
+| In-container command                         | How Klangk runs it                            | Sources `~/.profile`? |
+| -------------------------------------------- | --------------------------------------------- | --------------------- |
+| Interactive terminal                         | `tmux new-session` (login shell) or `bash -l` | yes                   |
+| `default_command` (the `default-cmd` window) | login shell (tmux window 0)                   | yes                   |
+| Workspace health check                       | `bash -lc` (a login shell, #1087)             | yes                   |
+| `klangkc exec`                               | raw command (no shell)                        | no — see [#1041]      |
+
+This is why workspace setup scripts (`sandboxes/*/setup.sh`) persist
+their env exports to `~/.profile` rather than `~/.bashrc`: the exports
+must be visible to the health check and the default command, both of
+which are login shells that source `~/.profile`. `~/.bashrc`'s
+interactivity guard (`case $- in *i*) ;; *) return`) hides its body
+from those non-interactive login shells.
 
 ## Using zsh instead
 

--- a/sandboxes/openclaw/setup.sh
+++ b/sandboxes/openclaw/setup.sh
@@ -4,12 +4,24 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INSTALL_DIR="/openclaw"
 
-# Persist every env export the default_command depends on to ~/.bashrc UP
-# FRONT, before any long-running install step. A shell that sources
-# ~/.bashrc while setup is still running (e.g. the default-cmd pane
-# created by an early terminal_start during setup -- see #1033) must see
-# the complete pointer set from its very first spawn:
-#   - NVM_DIR (so nvm/node load in new shells)
+# Persist every env export the default_command depends on to ~/.profile
+# UP FRONT, before any long-running install step.
+#
+# Why ~/.profile and not ~/.bashrc (#1087): ~/.profile is the POSIX file
+# sourced by ALL login shells -- interactive terminals (the default-cmd
+# tmux pane is an interactive login shell) AND non-interactive
+# `bash -lc` (which the health check uses). ~/.bashrc has an
+# interactivity guard near its top (`case $- in *i*) ;; *) return`)
+# that hides anything appended below it from non-interactive shells, so
+# exports the health check needs cannot live there. ~/.profile is the
+# one file BOTH the default_command and the health check reliably
+# source.
+#
+# Why UP FRONT (#1039): a shell that sources ~/.profile while setup is
+# still running (e.g. the default-cmd pane created by an early
+# terminal_start during setup -- see #1033) must see the complete
+# pointer set from its very first spawn:
+#   - NVM_DIR + nvm.sh source (so nvm/node load in new shells)
 #   - /openclaw/bin on PATH (so the `openclaw` binary is found)
 #   - OPENCLAW_HOME (so openclaw locates its config; the owning user's
 #     $HOME is /home/<handle>, not /openclaw, so without this openclaw
@@ -18,25 +30,25 @@ INSTALL_DIR="/openclaw"
 # mid-setup pane inherited PATH but not OPENCLAW_HOME. Each line is
 # guarded so re-running setup never duplicates it.
 # shellcheck disable=SC2016
-if ! grep -q NVM_DIR ~/.bashrc 2>/dev/null; then
-  cat >>~/.bashrc <<BASH
+if ! grep -q NVM_DIR ~/.profile 2>/dev/null; then
+  cat >>~/.profile <<BASH
 export NVM_DIR="$INSTALL_DIR/.nvm"
 [ -s "\$NVM_DIR/nvm.sh" ] && . "\$NVM_DIR/nvm.sh"
 BASH
 fi
 # shellcheck disable=SC2016
-if ! grep -q "$INSTALL_DIR/bin" ~/.bashrc 2>/dev/null; then
-  echo "export PATH=\"$INSTALL_DIR/bin:\$PATH\"" >>~/.bashrc
+if ! grep -q "$INSTALL_DIR/bin" ~/.profile 2>/dev/null; then
+  echo "export PATH=\"$INSTALL_DIR/bin:\$PATH\"" >>~/.profile
 fi
 # shellcheck disable=SC2016
-if ! grep -q OPENCLAW_HOME ~/.bashrc 2>/dev/null; then
-  echo "export OPENCLAW_HOME=\"$INSTALL_DIR\"" >>~/.bashrc
+if ! grep -q OPENCLAW_HOME ~/.profile 2>/dev/null; then
+  echo "export OPENCLAW_HOME=\"$INSTALL_DIR\"" >>~/.profile
 fi
 
 # Test hook (no-op in production): the e2e test in sandboxes/tests/openclaw/
 # drops a sentinel file on the mount to hold setup here, spawns a terminal
 # mid-setup, and asserts the exports above are already in the spawned
-# shell's environment. This guards the #1039 invariant: every .bashrc
+# shell's environment. This guards the #1039 invariant: every ~/.profile
 # export the default_command depends on must be written before any
 # long-running step, so a shell spawned at any point sees the full set.
 # The sentinel never exists outside that test.

--- a/sandboxes/tests/openclaw/test_openclaw_setup_e2e.py
+++ b/sandboxes/tests/openclaw/test_openclaw_setup_e2e.py
@@ -1,33 +1,43 @@
-"""E2E test: openclaw sandbox writes all .bashrc exports before slow setup steps.
+"""E2E test: openclaw sandbox writes all ~/.profile exports before slow setup steps.
 
-Guards the #1039 fix. ``sandboxes/openclaw/setup.sh`` appends every env
-export the default_command depends on (``NVM_DIR``, ``/openclaw/bin`` on
-``PATH``, ``OPENCLAW_HOME``) to ``~/.bashrc`` in one block at the very
-top of setup, before the long ``npm install -g openclaw``. Previously
-``OPENCLAW_HOME`` was appended near the end, so a shell spawned mid-setup
-(e.g. the ``default-cmd`` pane from an early ``terminal_start`` -- the
-#1033 race) inherited ``PATH`` but not ``OPENCLAW_HOME``; with
-``OPENCLAW_HOME`` unset, ``openclaw gateway`` looked for config at
-``$HOME/.openclaw`` instead of ``/openclaw/.openclaw`` and reported
-"Missing config".
+Guards #1039 (ordering) and #1087 (location).
+``sandboxes/openclaw/setup.sh`` persists every env export the
+default_command depends on (``NVM_DIR`` + nvm source, ``/openclaw/bin``
+on ``PATH``, ``OPENCLAW_HOME``) to ``~/.profile`` in one block at the
+very top of setup, before the long ``npm install -g openclaw``.
+
+Why ``~/.profile`` and not ``~/.bashrc`` (#1087): ``~/.profile`` is the
+POSIX file sourced by ALL login shells -- interactive terminals (the
+default-cmd tmux pane is an interactive login shell) AND non-interactive
+``bash -lc`` (which the health check uses, ``container.py``
+``HealthMonitor._run_one``). ``~/.bashrc`` has an interactivity guard
+that hides its body from non-interactive shells, so exports the health
+check needs cannot live there. ``~/.profile`` is the one file BOTH the
+default_command and the health check reliably source.
+
+Previously ``OPENCLAW_HOME`` was appended near the end of setup (and to
+``~/.bashrc``), so a shell spawned mid-setup (e.g. the ``default-cmd``
+pane from an early ``terminal_start`` -- the #1033 race) inherited
+``PATH`` but not ``OPENCLAW_HOME``; with ``OPENCLAW_HOME`` unset,
+``openclaw gateway`` looked for config at ``$HOME/.openclaw`` instead of
+``/openclaw/.openclaw`` and reported "Missing config".
 
 How the test exercises this deterministically: ``setup.sh`` blocks while
 a sentinel file (``/openclaw/.klangk-test-pause``, i.e. on the bind
 mount) exists. The sentinel is placed right after the consolidated export
 block and before the slow install, so while setup is parked there the
-test reads ``~/.bashrc`` straight off the host filesystem and asserts
+test reads ``~/.profile`` straight off the host filesystem and asserts
 the export is already present. On a regression that moves the
-``OPENCLAW_HOME`` append back to the end of setup, ``~/.bashrc`` lacks it
+``OPENCLAW_HOME`` append back to the end of setup, ``~/.profile`` lacks it
 at this point and the test fails. Releasing the sentinel lets the real
 ``npm install -g openclaw`` run, and the test confirms the binary lands
 on the mount.
 
 This reads files directly from the host (the per-user home and the
 ``/openclaw`` mount both live under the server data dir / the sandbox
-dir). It deliberately avoids ``klangkc exec``: exec runs a
-non-interactive shell that short-circuits ``~/.bashrc`` at its
-interactivity guard (#1041), so it would not see these exports and would
-give a false negative.
+dir). It deliberately avoids ``klangkc exec``: exec runs a raw command
+with no login shell (#1041), so it would not source ``~/.profile`` and
+would give a false negative.
 
 Run locally (the workspace image must be built first):
 
@@ -62,8 +72,8 @@ SENTINEL = os.path.join(SANDBOX_DIR, ".klangk-test-pause")
 WS = "e2e-openclaw-setup"
 # Second workspace pointed at the SAME /openclaw mount. openclaw is
 # already installed there after WS's setup ran, so WS2's setup SKIPS the
-# install but must still write a complete per-workspace ~/.bashrc. This
-# is the shared-mount + per-workspace-.bashrc interaction at the heart
+# install but must still write a complete per-workspace ~/.profile. This
+# is the shared-mount + per-workspace-~/.profile interaction at the heart
 # of #1039 -- a regression that moves an export inside the install-skip
 # guard breaks WS2 permanently (not just a race) while WS may still pass.
 WS2 = "e2e-openclaw-setup-2"
@@ -244,8 +254,8 @@ def _container_up(base_url, token, ws_id):
     return bool(r.json().get("container_id"))
 
 
-def _owning_bashrc(data_dir, user_id, ws_id):
-    """Path to the owning user's ~/.bashrc on the host for *ws_id*.
+def _owning_profile(data_dir, user_id, ws_id):
+    """Path to the owning user's ~/.profile on the host for *ws_id*.
 
     The per-workspace home is bind-mounted at /home; the owning user's
     real home is ``<data>/workspaces/<uid>/home/<ws_id>/.users/<uid>/``
@@ -259,7 +269,7 @@ def _owning_bashrc(data_dir, user_id, ws_id):
         ws_id,
         ".users",
         user_id,
-        ".bashrc",
+        ".profile",
     )
 
 
@@ -271,7 +281,7 @@ async def _visitor_two_phase_terminal_env(
     Phase 1 -- mid-setup: fire ``terminal_start`` while setup is parked
     at the sentinel.  Only the ``bash`` window (window 0) is created;
     ``default-cmd`` is gated on ``setup_state == complete`` (#1051).
-    The spawned shell sources ``~/.bashrc`` at that instant; under the
+    The spawned shell sources ``~/.profile`` at that instant; under the
     #1039 fix the exports are already present, so ``$var`` is set.
 
     Then ``await between_phases()`` runs -- the caller releases the
@@ -373,8 +383,8 @@ async def _visitor_probe_env(ws, var, timeout):
     )
 
 
-class TestOpenclawSetupBashrcExports:
-    """Real openclaw sandbox: .bashrc exports precede the slow install."""
+class TestOpenclawSetupProfileExports:
+    """Real openclaw sandbox: ~/.profile exports precede the slow install."""
 
     @pytest.fixture(autouse=True, scope="class")
     @staticmethod
@@ -430,20 +440,20 @@ class TestOpenclawSetupBashrcExports:
         with open(log_path) as f:
             return "".join(f.readlines()[-n:])
 
-    def test_bashrc_has_openclaw_home_before_slow_install(self):
-        """~/.bashrc contains OPENCLAW_HOME before the npm install runs.
+    def test_profile_has_openclaw_home_before_slow_install(self):
+        """~/.profile contains OPENCLAW_HOME before the npm install runs.
 
         This is the #1039 invariant: every export the default_command
         depends on is written up front, so a shell spawned at any point
         during setup (here, held by the sentinel after the export block
-        but before the npm install) sources a complete ~/.bashrc. Under
+        but before the npm install) sources a complete ~/.profile. Under
         the original bug OPENCLAW_HOME was appended after the install, so
-        .bashrc would be missing it at this point.
+        .profile would be missing it at this point.
         """
         env = self._env
 
         # Run the sandbox in the background; it blocks on the sentinel
-        # right after writing the consolidated .bashrc exports.
+        # right after writing the consolidated ~/.profile exports.
         sandbox_proc = subprocess.Popen(
             ["klangkc", "sandbox", WS, SANDBOX_DIR],
             env=env,
@@ -455,19 +465,20 @@ class TestOpenclawSetupBashrcExports:
             # Wait for the container to be up (setup is running, held by
             # the sentinel after the export block).
             ws_id = self._await_container()
-            bashrc_path = self._await_setup_exports(ws_id)
-            with open(bashrc_path) as f:
-                bashrc = f.read()
+            profile_path = self._await_setup_exports(ws_id)
+            with open(profile_path) as f:
+                profile = f.read()
 
             # The invariant under test: OPENCLAW_HOME is already in
-            # .bashrc while setup is still parked before the slow install.
-            assert 'export OPENCLAW_HOME="/openclaw"' in bashrc, (
-                "OPENCLAW_HOME missing from ~/.bashrc before the slow "
+            # ~/.profile while setup is still parked before the slow
+            # install.
+            assert 'export OPENCLAW_HOME="/openclaw"' in profile, (
+                "OPENCLAW_HOME missing from ~/.profile before the slow "
                 "install step -- the #1039 export ordering regressed; a "
                 "shell spawned during setup cannot locate openclaw "
-                "config.\n.bashrc:\n" + bashrc
+                "config.\n~/.profile:\n" + profile
             )
-            assert 'export PATH="/openclaw/bin:$PATH"' in bashrc
+            assert 'export PATH="/openclaw/bin:$PATH"' in profile
 
             # Release setup.sh and let the real openclaw install finish.
             os.remove(SENTINEL)
@@ -494,13 +505,13 @@ class TestOpenclawSetupBashrcExports:
                 if out:
                     print(f"--- klangkc sandbox output ---\n{out}")
 
-    def test_second_workspace_reuses_install_but_writes_own_bashrc(self):
+    def test_second_workspace_reuses_install_but_writes_own_profile(self):
         """A second workspace at the same /openclaw mount SKIPS the install
         (openclaw is already there) yet must still write a complete
-        per-workspace ~/.bashrc.
+        per-workspace ~/.profile.
 
-        This is the shared-mount + per-workspace-.bashrc interaction at
-        the heart of #1039. ``~/.bashrc`` is fresh per workspace (the
+        This is the shared-mount + per-workspace-~/.profile interaction
+        at the heart of #1039. ``~/.profile`` is fresh per workspace (the
         owning user's home is per-workspace), while the ``/openclaw``
         mount (nvm/node/openclaw) is shared. A regression that moves an
         export INSIDE the install-skip guard breaks this workspace
@@ -541,7 +552,7 @@ class TestOpenclawSetupBashrcExports:
 
             # The install was genuinely skipped -- proving we're on the
             # skip path, not a vacuous pass where a regression re-ran
-            # the full install and wrote .bashrc that way.
+            # the full install and wrote ~/.profile that way.
             assert "openclaw already installed, skipping." in out, (
                 "expected setup to SKIP the install (mount already "
                 "populated); it didn't print the skip message -- either "
@@ -549,22 +560,22 @@ class TestOpenclawSetupBashrcExports:
                 "regressed.\n" + out
             )
 
-            # WS2's container is up; read ITS own per-workspace .bashrc
+            # WS2's container is up; read ITS own per-workspace ~/.profile
             # (a different ws_id from WS).
             ws2_id = self._await_container(name=WS2)
-            bashrc_path = _owning_bashrc(self._data_dir, self._user_id, ws2_id)
-            with open(bashrc_path) as f:
-                bashrc = f.read()
+            profile_path = _owning_profile(self._data_dir, self._user_id, ws2_id)
+            with open(profile_path) as f:
+                profile = f.read()
 
-            assert 'export OPENCLAW_HOME="/openclaw"' in bashrc, (
+            assert 'export OPENCLAW_HOME="/openclaw"' in profile, (
                 "OPENCLAW_HOME missing from the second workspace's "
-                "~/.bashrc even though setup completed -- a regression "
+                "~/.profile even though setup completed -- a regression "
                 "that moved the export inside the install-skip guard "
                 "leaves it out permanently here (the install is skipped, "
                 "so the guard body never runs). This is the #1039 "
-                "shared-mount failure mode.\n.bashrc:\n" + bashrc
+                "shared-mount failure mode.\n~/.profile:\n" + profile
             )
-            assert 'export PATH="/openclaw/bin:$PATH"' in bashrc
+            assert 'export PATH="/openclaw/bin:$PATH"' in profile
         finally:
             if sandbox_proc.poll() is None:
                 sandbox_proc.kill()
@@ -578,7 +589,7 @@ class TestOpenclawSetupBashrcExports:
 
         Phase 1 (mid-setup): the visitor's ``terminal_start`` creates
         the ``bash`` window (window 0) but NOT ``default-cmd`` -- #1051
-        gates it.  The spawned shell sources ``~/.bashrc`` at that
+        gates it.  The spawned shell sources ``~/.profile`` at that
         instant; under the #1039 fix the exports are already there
         (written before the slow install), so ``OPENCLAW_HOME`` is set.
         This is the "Missing config" window that #1039 closes.
@@ -606,7 +617,7 @@ class TestOpenclawSetupBashrcExports:
         try:
             ws3_id = self._await_container(name=WS3)
             # setup.sh is now parked at the sentinel, AFTER writing the
-            # consolidated .bashrc exports.
+            # consolidated ~/.profile exports.
             self._await_setup_exports(ws3_id)
 
             async def _release_and_wait_setup():
@@ -644,12 +655,12 @@ class TestOpenclawSetupBashrcExports:
                 "setup_state == complete. Windows seen: " + repr(mid_names)
             )
 
-            # The shell spawned mid-setup sourced a ~/.bashrc that
+            # The shell spawned mid-setup sourced a ~/.profile that
             # already has OPENCLAW_HOME (the #1039 fix).
             assert value == "/openclaw", (
                 "a shell spawned by a visitor terminal_start mid-setup "
                 "did NOT have OPENCLAW_HOME set -- the #1033 race bit: "
-                "the mid-setup .bashrc lacked the export, so the spawned "
+                "the mid-setup ~/.profile lacked the export, so the spawned "
                 f"shell's $OPENCLAW_HOME was {value!r} (expected "
                 "'/openclaw'). This is the 'Missing config' window."
             )
@@ -686,21 +697,21 @@ class TestOpenclawSetupBashrcExports:
         )
 
     def _await_setup_exports(self, ws_id, timeout=120):
-        """Poll ~/.bashrc until setup has appended its first export.
+        """Poll ~/.profile until setup has appended its first export.
 
         setup.sh writes the consolidated export block then blocks on the
         sentinel, so once ``export NVM_DIR`` appears setup is parked.
-        Returns the path to the owning user's .bashrc.
+        Returns the path to the owning user's .profile.
         """
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
-            path = _owning_bashrc(self._data_dir, self._user_id, ws_id)
+            path = _owning_profile(self._data_dir, self._user_id, ws_id)
             if path and os.path.exists(path):
                 with open(path) as f:
                     if "export NVM_DIR" in f.read():
                         return path
             time.sleep(1)
         raise AssertionError(
-            "setup never wrote .bashrc exports (sentinel not reached); "
+            "setup never wrote ~/.profile exports (sentinel not reached); "
             f"user_id={self._user_id} data_dir={self._data_dir}"
         )

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -422,7 +422,12 @@ class HealthMonitor:
 
         Resolves the owner's container home (same logic as
         ``eager_start_workspace``) and invokes the check via
-        ``podman exec`` as the creating user with HOME set.  Errors and
+        ``podman exec`` as the creating user with HOME set.  The check
+        runs as a bash *login* shell (``bash -lc``) so it sources
+        ``~/.profile`` -- the POSIX file where workspace setup persists
+        env exports (PATH, tool homes) that the check may depend on
+        (#1087).  A non-login ``sh -c`` would source nothing and fail
+        to resolve e.g. an asdf/nvm-installed binary.  Errors and
         timeouts count as ``"unhealthy"``.
         """
         owner_id = state.owner_id
@@ -450,7 +455,11 @@ class HealthMonitor:
         try:
             rc, _out, _err = await podman.exec_container(
                 state.container_id,
-                ["sh", "-c", state.health_check],
+                # bash -lc: login shell sources ~/.profile so the
+                # check sees the user's env (PATH, tool homes). See
+                # #1087. Skipped until setup_state == complete, so the
+                # exports are guaranteed present by the time this runs.
+                ["bash", "-lc", state.health_check],
                 user="klangk",
                 extra_env={"HOME": user_home},
                 timeout=HEALTH_CHECK_TIMEOUT_SECONDS,

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -2024,6 +2024,11 @@ class TestHealthMonitorRunOne:
         assert call.kwargs["user"] == "klangk"
         assert call.kwargs["extra_env"] == {"HOME": "/home/klangk"}
         assert call.kwargs["timeout"] == container.HEALTH_CHECK_TIMEOUT_SECONDS
+        # #1087: the check runs as a bash LOGIN shell (bash -lc) so it
+        # sources ~/.profile and sees the user's env (PATH, tool homes).
+        # A regression to "sh -c" would hide asdf/nvm-installed binaries.
+        assert call.args[1][:2] == ["bash", "-lc"]
+        assert call.args[1][2] == st.health_check
 
     async def test_nonzero_exit_is_unhealthy(self):
         monitor = container.registry.health


### PR DESCRIPTION
Closes #1087.

## Summary

The workspace health check ran via `sh -c \"<cmd>\"`, which sources no startup files — so a check whose command resolved a PATH-only binary (e.g. an openclaw/asdf/nvm-installed tool whose home setup.sh wrote to `~/.bashrc`) reported perpetually unhealthy. This fixes the bug at three layers: the invocation, the convention, and the root-cause location of setup exports.

## Changes

**The fix** (`container.py`):
- `HealthMonitor._run_one` now runs `[\"bash\", \"-lc\", state.health_check]` instead of `[\"sh\", \"-c\", ...]`. A bash login shell sources `~/.profile`, so the check sees the user's environment (PATH, tool homes). New unit test asserts the login-shell shape so it can't regress.

**The convention** (`docs/features/the-shell.md`):
- New \"Startup files\" section: `~/.profile` = env every shell needs (interactive, default-cmd, health check); `~/.bashrc` = interactive niceties. Includes a code-path table showing which invocations source `~/.profile`.
- Corrects the inaccurate #1094-era claim that `klangkc exec` sources `/etc/profile.d` (it doesn't — separately tracked as #1041).

**The root-cause follow-through** (setup scripts + docs):
- `sandboxes/openclaw/setup.sh`: relocates its env exports (NVM_DIR, `/openclaw/bin`, `OPENCLAW_HOME`) from `~/.bashrc` → `~/.profile` — the one file both the default command and the health check reliably source. (Carried over from the abandoned #1015-era worktree via rebase.)
- `docs/features/sandbox.md`: the nix example now writes to `~/.profile` (was `~/.bashrc` — same bug class); the `.env` sourcing guidance points at `~/.profile`.
- `docs/features/health-check.md`: documents that the check is a login shell and links the startup-files convention.
- E2e test (`test_openclaw_setup_e2e.py`): the `.bashrc`-content assertions move to `~/.profile` to match.

## Why ~/.profile and not ~/.bashrc

`~/.profile` is the POSIX file sourced by **all** login shells — interactive terminals, the default-command window, and the health check's `bash -lc`. `~/.bashrc` has an interactivity guard (`case \$- in *i*) ;; *) return`) that hides its body from non-interactive shells, so exports the health check needs cannot live there.

## Acceptance criteria (#1087)

- [x] A health check whose command is only resolvable via the user's `~/.profile` PATH reports healthy, not perpetually unhealthy.
- [x] Documented convention for which startup file user environment setup should live in, and which code paths source it.

## Out of scope

`klangkc exec` still runs a raw command with no login shell (#1041) — separately tracked, since it's a user-facing CLI behavior change worth its own discussion.

## Test plan

- [x] Backend unit suite: 1958 pass, **100% coverage gate green** (the new login-shell assertion is covered).
- [ ] `test-sandbox-e2e` in CI (the relocated `.profile` assertions).