### PR TITLE
Surface health-check failure reason (stdout/stderr) (#1088)

### DIFF
--- a/docs/features/health-check.md
+++ b/docs/features/health-check.md
@@ -45,8 +45,15 @@ For each workspace with a health check configured:
    error counts as **unhealthy**.
 3. When the status changes, every connected client gets a
    `service_health` event so the UI can update in real time.
-4. The current status and the time of the last check are exposed via
-   `GET /api/v1/workspaces/{id}/status`.
+4. The current status, the **reason** it's unhealthy (a tail of the
+   check's stderr/stdout), and the time of the last check are exposed
+   via `GET /api/v1/workspaces/{id}/status`.
+
+A failing check is **not a black box**: the tail of its output (stderr
+preferred) is logged when the status flips to unhealthy, retained on
+the workspace as `health_message`, and carried on the `service_health`
+event -- so you can see _why_ it's unhealthy without `podman exec`'ing
+in by hand.
 
 The check runs through `bash -lc "<your command>"` — a bash **login
 shell** — so any shell syntax works (pipes, `&&`, redirects, etc.)
@@ -83,8 +90,11 @@ miss:
 - **Web UI** — the workspace list shows a health-colored icon (green =
   healthy, amber = unhealthy, grey = stopped), updated live as checks run.
   The **Settings** tab shows the configured check command.
-- **`GET /api/v1/workspaces/{id}/status`** — returns `health` plus the
-  time of the last check (`health_checked_at`).
+- **`GET /api/v1/workspaces/{id}/status`** — returns `health`, the failure
+  `health_message` (a bounded tail of the check's stderr/stdout, or `null`
+  when healthy), plus the time of the last check (`health_checked_at`).
+- **Server logs** — on each transition to unhealthy, the check's output is
+  logged at `INFO` (steady-state unhealthy polls log it at `DEBUG`).
 - **`klangkc monitor`** — stream events and optionally **run a command**
   when something changes. This is the automation hook.
 
@@ -94,13 +104,14 @@ miss:
 the web UI does — health transitions, container starts/stops, workspace
 changes — and can run a command for each one. The event JSON is piped
 to the command's stdin, and details are exposed as environment
-variables (`KLANGK_EVENT_TYPE`, `KLANGK_WORKSPACE_ID`, `KLANGK_HEALTHY`).
+variables (`KLANGK_EVENT_TYPE`, `KLANGK_WORKSPACE_ID`, `KLANGK_HEALTHY`,
+and `KLANGK_HEALTH_MESSAGE` — the failure reason, when unhealthy).
 
 Fire a desktop notification when a service goes unhealthy:
 
 ```bash
 klangkc monitor --type service_health -- \
-  sh -c '[ "$KLANGK_HEALTHY" = false ] && notify-send "klangk" "Service unhealthy"'
+  sh -c '[ "$KLANGK_HEALTHY" = false ] && notify-send "klangk" "$KLANGK_HEALTH_MESSAGE"'
 ```
 
 Page yourself (or a Slack webhook) on any health change:

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -1347,6 +1347,7 @@ No request body.
   "running": true,
   "container_id": "abc123...",
   "health": null,
+  "health_message": null,
   "idle_seconds": 42.5,
   "idle_timeout": 1800,
   "ports": [9000, 9001]
@@ -1360,14 +1361,18 @@ No request body.
   "running": false,
   "container_id": null,
   "health": null,
+  "health_message": null,
   "idle_seconds": null,
   "idle_timeout": null,
   "ports": []
 }
 ```
 
-The `health` field is a placeholder (`null`) until a container
-health check is implemented (#1015).
+The `health` field is the check status (`"healthy"`, `"unhealthy"`, or
+`null` when no check is configured or no container is running). When
+unhealthy, `health_message` carries a bounded tail of the check's
+stderr/stdout explaining _why_ it failed (`null` otherwise) — so a
+failing check isn't a black box (#1088).
 
 ---
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -164,7 +164,7 @@ klangkc sandbox myws --force             # re-apply config and re-run setup on e
 klangkc exec my-project ls /home/klangk/work         # run a command in the container
 klangkc monitor                                        # stream all server events as JSON
 klangkc monitor --type service_health | jq .           # pretty-print health transitions
-klangkc monitor --type service_health -- notify-send "Service unhealthy"  # react to unhealthy events
+klangkc monitor --type service_health -- sh -c '[ "$KLANGK_HEALTHY" = false ] && notify-send "klangk" "$KLANGK_HEALTH_MESSAGE"'  # alert with the failure reason
 klangkc sync ~/src my-project:/home/klangk/work      # sync files to/from the container
 klangkc rm my-project                # delete a workspace
 klangkc restart my-project           # restart the container for a workspace (owner only)

--- a/src/backend/e2e-tests/test_health_check_e2e.py
+++ b/src/backend/e2e-tests/test_health_check_e2e.py
@@ -1,0 +1,319 @@
+"""End-to-end tests for workspace health-check failure surfacing (#1088).
+
+A failing health check used to discard its stdout/stderr, leaving an
+"unhealthy" workspace a black box.  These tests start a real server
+with a short poll interval, configure a workspace with a check that
+writes a distinctive marker to stderr and exits non-zero, and assert
+that the marker surfaces both via the status API and the live
+``service_health`` WebSocket event.
+
+Requires: podman available, klangk image built.
+
+Run with: devenv shell -- test-backend-e2e test_health_check_e2e.py
+"""
+
+import asyncio
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+
+import httpx
+import pytest
+import websockets
+
+
+@pytest.fixture(scope="module")
+def server():
+    """Start a real Klangk server with a fast health-check poll interval."""
+    data_dir = tempfile.mkdtemp(prefix="klangk-health-e2e-")
+    port = "18998"
+
+    env = {
+        **os.environ,
+        "KLANGK_PORT": port,
+        "KLANGK_DATA_DIR": data_dir,
+        "KLANGK_JWT_SECRET": "health-e2e-secret",
+        "KLANGK_PREVENT_INSECURE_JWT_SECRET": "",
+        "KLANGK_DEFAULT_USER": "test@example.com",
+        "KLANGK_DEFAULT_PASSWORD": "testpass",
+        "KLANGK_TEST_MODE": "1",
+        "KLANGK_INSTANCE_ID": "health-e2e",
+        "KLANGK_IDLE_TIMEOUT_SECONDS": "300",
+        "KLANGK_PORT_RANGE_START": "9300",
+        # Poll every 2s so an unhealthy transition shows up quickly.
+        "KLANGK_HEALTH_CHECK_INTERVAL": "2",
+        "LOGFIRE_TOKEN": "",
+        # Clear LLM vars so .env values don't leak in.
+        "KLANGK_LLM_BASE_URL": "",
+        "KLANGK_LLM_API_KEY": "",
+        "KLANGK_LLM_MODEL": "",
+    }
+    proc = subprocess.Popen(
+        [
+            "uvicorn",
+            "klangk_backend.main:app",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            port,
+        ],
+        cwd=os.path.join(os.path.dirname(__file__), ".."),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    base_url = f"http://localhost:{port}"
+    for _ in range(60):
+        try:
+            resp = httpx.get(f"{base_url}/health", timeout=2)
+            if resp.status_code == 200:
+                break
+        except Exception:
+            pass
+        time.sleep(1)
+    else:
+        proc.kill()
+        stdout = proc.stdout.read().decode() if proc.stdout else ""
+        raise RuntimeError(f"Server failed to start:\n{stdout}")
+
+    yield {
+        "url": base_url,
+        "port": port,
+        "data_dir": data_dir,
+        "proc": proc,
+    }
+
+    try:
+        proc.kill()
+        proc.wait(timeout=5)
+    except (ProcessLookupError, subprocess.TimeoutExpired):
+        pass
+    if proc.stdout:
+        server_log = proc.stdout.read().decode("utf-8", errors="replace")
+        if server_log.strip():
+            sys.stderr.write(
+                f"\n=== Health e2e server log ===\n{server_log}\n===\n"
+            )
+    result = subprocess.run(
+        [
+            "podman",
+            "ps",
+            "-a",
+            "--filter",
+            "label=klangk.instance=health-e2e",
+            "-q",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.stdout.strip():
+        subprocess.run(
+            ["podman", "rm", "-f", *result.stdout.strip().split()],
+            capture_output=True,
+        )
+    shutil.rmtree(data_dir, ignore_errors=True)
+
+
+@pytest.fixture(scope="module")
+def auth(server):
+    """Login as the default user and return token + headers."""
+    url = server["url"]
+    resp = httpx.post(
+        f"{url}/api/v1/auth/login",
+        json={"email": "test@example.com", "password": "testpass"},
+        timeout=10,
+    )
+    assert resp.status_code == 200
+    token = resp.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+    return {"token": token, "headers": headers}
+
+
+_ws_counter = 0
+
+
+def create_workspace(server, auth, *, health_check):
+    """Create a workspace with a health check, return (id, cleanup_fn)."""
+    global _ws_counter  # noqa: PLW0603
+    _ws_counter += 1
+    name = f"health-{_ws_counter}"
+    url = server["url"]
+    resp = httpx.post(
+        f"{url}/api/v1/workspaces",
+        headers=auth["headers"],
+        json={"name": name, "health_check": health_check},
+        timeout=10,
+    )
+    assert resp.status_code == 200
+    workspace_id = resp.json()["id"]
+
+    def cleanup():
+        try:
+            httpx.delete(
+                f"{url}/api/v1/workspaces/{workspace_id}",
+                headers=auth["headers"],
+                timeout=30,
+            )
+        except httpx.ReadTimeout:
+            pass  # container cleanup may take a while
+
+    return workspace_id, cleanup
+
+
+async def ws_connect(server, auth, workspace_id):
+    """Open a WS, connect to the workspace, wait for container_ready.
+
+    Keeping the socket open holds the container alive (idle timeout) so
+    the health monitor has a running container to poll.  Returns
+    ``(ws, received, reader_task)`` where *received* is a live list that
+    a background reader appends **every** message to from the moment of
+    connect -- so the one-shot ``service_health`` transition event
+    (which can fire while we're still draining ``container_ready``) is
+    never lost.
+    """
+    ws_url = server["url"].replace("http://", "ws://")
+    ws = await websockets.connect(
+        f"{ws_url}/ws?token={auth['token']}", max_size=2**20
+    )
+    await ws.send(
+        json.dumps({"cmd": "workspace_connect", "workspaceId": workspace_id})
+    )
+    received: list[dict] = []
+
+    async def _reader():
+        try:
+            async for raw in ws:
+                try:
+                    received.append(json.loads(raw))
+                except json.JSONDecodeError:
+                    pass
+        except websockets.ConnectionClosed:
+            pass
+
+    reader_task = asyncio.create_task(_reader())
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + 60
+    while loop.time() < deadline:
+        if any(m.get("type") == "container_ready" for m in received):
+            break
+        await asyncio.sleep(0.2)
+    else:
+        reader_task.cancel()
+        await ws.close()
+        raise AssertionError("container_ready not received within 60s")
+    await ws.send(json.dumps({"cmd": "ui_ready"}))
+    return ws, received, reader_task
+
+
+async def wait_for_received(received, predicate, timeout=45):
+    """Poll the shared *received* buffer until predicate matches."""
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
+        for msg in received:
+            if predicate(msg):
+                return True
+        await asyncio.sleep(0.5)
+    return False
+
+
+def _wait_for_status(server, auth, workspace_id, predicate, timeout=45):
+    """Poll the status endpoint until predicate(state) is true."""
+    url = server["url"]
+    deadline = time.time() + timeout
+    last = None
+    while time.time() < deadline:
+        resp = httpx.get(
+            f"{url}/api/v1/workspaces/{workspace_id}/status",
+            headers=auth["headers"],
+            timeout=10,
+        )
+        if resp.status_code == 200:
+            last = resp.json()
+            if predicate(last):
+                return last
+        time.sleep(1)
+    raise AssertionError(
+        f"status never satisfied predicate within {timeout}s; last={last!r}"
+    )
+
+
+class TestHealthCheckFailureSurfacing:
+    @pytest.mark.asyncio
+    async def test_status_api_surfaces_failure_reason(self, server, auth):
+        """A failing check's stderr shows up in the status API (#1088)."""
+        marker = f"klangk-health-failure-{uuid.uuid4().hex[:8]}"
+        # Writes a distinctive line to stderr, then exits non-zero.
+        health_check = f"echo {marker} 1>&2; exit 3"
+        workspace_id, cleanup = create_workspace(
+            server, auth, health_check=health_check
+        )
+        try:
+            ws, _received, reader_task = await ws_connect(
+                server, auth, workspace_id
+            )
+            try:
+                state = _wait_for_status(
+                    server,
+                    auth,
+                    workspace_id,
+                    lambda s: (
+                        s.get("health") == "unhealthy"
+                        and marker in (s.get("health_message") or "")
+                    ),
+                )
+            finally:
+                reader_task.cancel()
+                await ws.close()
+        finally:
+            cleanup()
+
+        assert state["health"] == "unhealthy"
+        # The exit code is reported alongside the captured output.
+        assert "exited 3" in state["health_message"]
+        assert marker in state["health_message"]
+
+    @pytest.mark.asyncio
+    async def test_service_health_event_carries_reason(self, server, auth):
+        """The live service_health WS event carries the failure reason."""
+        marker = f"klangk-health-failure-{uuid.uuid4().hex[:8]}"
+        health_check = f"echo {marker} 1>&2; exit 7"
+        workspace_id, cleanup = create_workspace(
+            server, auth, health_check=health_check
+        )
+        try:
+            ws, received, reader_task = await ws_connect(
+                server, auth, workspace_id
+            )
+            try:
+
+                def is_unhealthy(msg):
+                    return (
+                        msg.get("type") == "service_health"
+                        and msg.get("workspace_id") == workspace_id
+                        and msg.get("healthy") is False
+                    )
+
+                found = await wait_for_received(
+                    received, is_unhealthy, timeout=45
+                )
+            finally:
+                reader_task.cancel()
+                await ws.close()
+        finally:
+            cleanup()
+
+        assert found, (
+            f"no unhealthy service_health event received; "
+            f"saw {len(received)} messages: "
+            f"{[m.get('type') for m in received]}"
+        )
+        events = [m for m in received if is_unhealthy(m)]
+        # The reason rides along on the broadcast (#1088).
+        assert marker in (events[0].get("health_message") or "")
+        assert "exited 7" in events[0]["health_message"]

--- a/src/backend/klangk_backend/api/workspaces.py
+++ b/src/backend/klangk_backend/api/workspaces.py
@@ -250,6 +250,7 @@ async def update_workspace(
             # Reset the cached status so the next poll re-broadcasts.
             live_state.health_status = None
             live_state.health_checked_at = None
+            live_state.health_message = None
 
     return {"status": "updated"}
 
@@ -377,6 +378,7 @@ async def workspace_status(
             "running": False,
             "container_id": None,
             "health": None,
+            "health_message": None,
             "health_checked_at": None,
             "idle_seconds": None,
             "idle_timeout": None,
@@ -403,6 +405,10 @@ async def workspace_status(
         "running": True,
         "container_id": live_state.container_id,
         "health": health,
+        # Why the last check failed (bounded stderr/stdout tail), or
+        # None when healthy -- so an unhealthy workspace isn't a black
+        # box (#1088).
+        "health_message": live_state.health_message,
         "health_checked_at": checked_at,
         "idle_seconds": round(idle_secs, 1),
         "idle_timeout": idle_timeout,

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -188,6 +188,10 @@ HEALTH_CHECK_INTERVAL_SECONDS = int(
 HEALTH_CHECK_TIMEOUT_SECONDS = float(
     util.resolve_env_value("KLANGK_HEALTH_CHECK_TIMEOUT") or "10"
 )
+# Maximum bytes of check output retained as the failure reason (#1088).
+# A bounded tail keeps a verbose check from growing memory unbounded
+# across many workspaces while still capturing *why* it failed.
+HEALTH_MESSAGE_MAX_BYTES = 512
 
 
 class ContainerState:
@@ -203,6 +207,11 @@ class ContainerState:
         # time so HealthMonitor can poll without a DB lookup per tick.
         self.health_status: str | None = None  # "healthy" | "unhealthy"
         self.health_checked_at: float | None = None  # time.time() of last
+        # Short, human-readable reason for the last unhealthy result
+        # (stderr/stdout tail or exception text).  None when healthy or
+        # not yet checked.  Surfaced via the status API + service_health
+        # event so an unhealthy workspace isn't a black box (#1088).
+        self.health_message: str | None = None
         self.health_check: str | None = None  # shell command, None = disabled
         self.owner_id: str | None = None
         self.setup_state: str | None = None
@@ -389,6 +398,21 @@ class IdleMonitor:
             )
 
 
+def _unhealthy_message(rc: int, out: str, err: str) -> str:
+    """Build a bounded failure reason from a check's exit code/output.
+
+    Prefers stderr (where shells/diagnostics write their failures);
+    falls back to a tail of stdout; if both are empty, reports just
+    the exit code.  Truncated to ``HEALTH_MESSAGE_MAX_BYTES`` so a
+    verbose check can't grow memory unbounded across workspaces --
+    the goal is "why did it fail", not a full transcript (#1088).
+    """
+    body = (err or "").strip() or (out or "").strip()
+    if body and len(body) > HEALTH_MESSAGE_MAX_BYTES:
+        body = "..." + body[-HEALTH_MESSAGE_MAX_BYTES:]
+    return f"exited {rc}: {body}" if body else f"exited {rc}"
+
+
 class HealthMonitor:
     """Periodically poll container service health via ``podman exec``.
 
@@ -417,8 +441,15 @@ class HealthMonitor:
         """
         return state.setup_state == "complete"
 
-    async def _run_one(self, state: ContainerState) -> str:
-        """Run a single workspace's health check, returning the new status.
+    async def _run_one(self, state: ContainerState) -> tuple[str, str]:
+        """Run a single workspace's health check.
+
+        Returns ``(status, message)`` where *status* is ``"healthy"`` or
+        ``"unhealthy"`` and *message* is a short, human-readable reason
+        for an unhealthy result (a bounded tail of the check's
+        stderr/stdout, or the exception text) -- empty when healthy.
+        Surfacing the reason turns an ``unhealthy`` status from a black
+        box into a diagnosable failure instead of "good luck" (#1088).
 
         Resolves the owner's container home (same logic as
         ``eager_start_workspace``) and invokes the check via
@@ -432,10 +463,10 @@ class HealthMonitor:
         """
         owner_id = state.owner_id
         if owner_id is None:
-            return "unhealthy"
+            return "unhealthy", "no owner recorded for workspace"
         handle = await model.get_user_handle(owner_id)
         if not handle:
-            return "unhealthy"
+            return "unhealthy", f"owner {owner_id} has no handle"
         # Resolve the owner's container home the same way
         # eager_start_workspace does, so the check runs in the right
         # HOME rather than as root in /.
@@ -453,7 +484,7 @@ class HealthMonitor:
             state.health_check,
         )
         try:
-            rc, _out, _err = await podman.exec_container(
+            rc, out, err = await podman.exec_container(
                 state.container_id,
                 # bash -lc: login shell sources ~/.profile so the
                 # check sees the user's env (PATH, tool homes). See
@@ -465,43 +496,56 @@ class HealthMonitor:
                 timeout=HEALTH_CHECK_TIMEOUT_SECONDS,
             )
         except (podman.PodmanError, asyncio.TimeoutError, OSError) as e:
-            logger.info(
-                "Health check for container %s (workspace %s) failed: %s",
-                cid_short,
-                state.workspace_id,
-                e,
-            )
-            return "unhealthy"
-        logger.debug(
-            "Health check: container %s (workspace %s) exited %d",
-            cid_short,
-            state.workspace_id,
-            rc,
-        )
-        return "healthy" if rc == 0 else "unhealthy"
+            return "unhealthy", f"{type(e).__name__}: {e}"
+        if rc == 0:
+            return "healthy", ""
+        return "unhealthy", _unhealthy_message(rc, out, err)
 
     async def _check_workspace(self, state: ContainerState) -> None:
-        """Poll one workspace and broadcast on status transition."""
-        new_status = await self._run_one(state)
+        """Poll one workspace, record the reason, and broadcast on change."""
+        new_status, message = await self._run_one(state)
         old_status = state.health_status
         state.health_status = new_status
+        # Clear the reason once healthy again so a stale failure message
+        # can't linger next to a "healthy" status (#1088).
+        state.health_message = message if new_status == "unhealthy" else None
         state.health_checked_at = time.time()
+        if new_status == "unhealthy":
+            # Log the reason at info on a fresh transition (so it's
+            # visible without debug logs), debug on steady-state polls
+            # so a persistently-broken check doesn't spam at info (#1088).
+            log = logger.info if old_status != "unhealthy" else logger.debug
+            log(
+                "Health check for workspace %s (container %s) unhealthy: %s",
+                state.workspace_id,
+                state.container_id[:12],
+                message,
+            )
         if new_status != old_status:
-            self._broadcast(state.workspace_id, new_status)
+            self._broadcast(
+                state.workspace_id, new_status, state.health_message
+            )
 
-    def _broadcast(self, workspace_id: str, status: str) -> None:
+    def _broadcast(
+        self,
+        workspace_id: str,
+        status: str,
+        message: str | None = None,
+    ) -> None:
         """Emit a ``service_health`` event to all connections.
 
         Fanned out via :meth:`WsState.notify_service_health` so the
         workspace list page learns about health transitions for
         auto-started services even when nobody is connected to the
-        workspace's terminal session (#1015).
+        workspace's terminal session (#1015).  The failure *reason*
+        rides along as ``health_message`` so operators can see *why*
+        it's unhealthy without digging through logs (#1088).
         """
         # Imported lazily to avoid an import cycle with wshandler.
         from .wshandler import state as _ws_state  # noqa: allow-deferred-import
 
         _ws_state.notify_service_health(
-            workspace_id, healthy=status == "healthy"
+            workspace_id, healthy=status == "healthy", message=message
         )
 
     async def run_health_loop(self) -> None:

--- a/src/backend/klangk_backend/wshandler/session.py
+++ b/src/backend/klangk_backend/wshandler/session.py
@@ -479,7 +479,9 @@ class WebSocketState:
             self.connections.pop(sock, None)
             asyncio.create_task(conn.cleanup())
 
-    def notify_service_health(self, workspace_id: str, healthy: bool) -> None:
+    def notify_service_health(
+        self, workspace_id: str, healthy: bool, message: str | None = None
+    ) -> None:
         """Broadcast service-health status to all connections.
 
         Fanned out to every connection (like
@@ -487,18 +489,24 @@ class WebSocketState:
         reflect health transitions for auto-started services even when no
         one is connected to that workspace's terminal session (#1015).
         The frontend ignores events for workspaces it doesn't display.
+
+        ``message`` carries the failure *reason* (a bounded tail of the
+        check's stderr/stdout) so an unhealthy workspace isn't a black
+        box -- operators can see *why* it failed without log access
+        (#1088).  ``None`` when healthy.
         """
-        message = {
+        message_dict = {
             "type": "service_health",
             "workspace_id": workspace_id,
             "healthy": healthy,
+            "health_message": message,
         }
         dead = []
         for sock, conn in self.connections.items():
             if conn.user.get("id") is None:
                 continue
             try:
-                sock.send_json(message)
+                sock.send_json(message_dict)
             except _WS_ERRORS:
                 dead.append((sock, conn))
         for sock, conn in dead:

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -1501,6 +1501,7 @@ class TestWorkspaceRoutes:
         )
         live = container.registry.get_state(ws_id)
         live.health_status = "healthy"  # will be reset on edit
+        live.health_message = "stale reason"  # also reset on edit (#1088)
         try:
             resp = await client.put(
                 f"/api/v1/workspaces/{ws_id}",
@@ -1516,6 +1517,7 @@ class TestWorkspaceRoutes:
             # Editing health_check resets the cached status.
             assert live.health_status is None
             assert live.health_checked_at is None
+            assert live.health_message is None
         finally:
             container.registry.remove_state(ws_id)
 

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -1999,7 +1999,7 @@ def _health_state(
 
 
 class TestHealthMonitorRunOne:
-    """_run_one: rc 0 → healthy, non-zero/error → unhealthy."""
+    """_run_one: rc 0 → healthy, non-zero/error → unhealthy (with reason)."""
 
     async def test_exit_zero_is_healthy(self):
         monitor = container.registry.health
@@ -2016,7 +2016,7 @@ class TestHealthMonitorRunOne:
                 return_value=("/home/klangk", False),
             ),
         ):
-            assert await monitor._run_one(st) == "healthy"
+            assert await monitor._run_one(st) == ("healthy", "")
         # The check runs as the workspace user with HOME set, and is
         # logged with the container id (first 12 chars).
         call = exec_mock.call_args
@@ -2030,14 +2030,16 @@ class TestHealthMonitorRunOne:
         assert call.args[1][:2] == ["bash", "-lc"]
         assert call.args[1][2] == st.health_check
 
-    async def test_nonzero_exit_is_unhealthy(self):
+    async def test_nonzero_exit_is_unhealthy_with_stderr_reason(self):
+        # The stderr that explains the non-zero exit is captured as the
+        # reason instead of being thrown away (#1088).
         monitor = container.registry.health
         st = _health_state()
         with (
             patch.object(
                 podman,
                 "exec_container",
-                AsyncMock(return_value=(1, "", "err")),
+                AsyncMock(return_value=(1, "", "curl: connection refused")),
             ),
             patch.object(
                 model, "get_user_handle", AsyncMock(return_value="owner")
@@ -2048,16 +2050,20 @@ class TestHealthMonitorRunOne:
                 return_value=("/home/klangk", False),
             ),
         ):
-            assert await monitor._run_one(st) == "unhealthy"
+            status, message = await monitor._run_one(st)
+        assert status == "unhealthy"
+        assert "connection refused" in message
+        assert "exited 1" in message
 
-    async def test_exec_error_is_unhealthy(self):
+    async def test_nonzero_exit_falls_back_to_stdout(self):
+        # No stderr → the reason uses stdout instead.
         monitor = container.registry.health
         st = _health_state()
         with (
             patch.object(
                 podman,
                 "exec_container",
-                AsyncMock(side_effect=podman.PodmanError(500, "nope")),
+                AsyncMock(return_value=(2, "all good on stdout", "")),
             ),
             patch.object(
                 model, "get_user_handle", AsyncMock(return_value="owner")
@@ -2068,16 +2074,79 @@ class TestHealthMonitorRunOne:
                 return_value=("/home/klangk", False),
             ),
         ):
-            assert await monitor._run_one(st) == "unhealthy"
+            status, message = await monitor._run_one(st)
+        assert status == "unhealthy"
+        assert "all good on stdout" in message
 
-    async def test_no_owner_is_unhealthy(self):
+    async def test_nonzero_exit_no_output_reports_exit_code(self):
+        # Non-zero exit but no output at all → still surface the exit
+        # code so it isn't a complete black box (#1088).
+        monitor = container.registry.health
+        st = _health_state()
+        with (
+            patch.object(
+                podman,
+                "exec_container",
+                AsyncMock(return_value=(127, "", "")),
+            ),
+            patch.object(
+                model, "get_user_handle", AsyncMock(return_value="owner")
+            ),
+            patch("klangk_backend.workspaces.home_path", return_value="/h/p"),
+            patch(
+                "klangk_backend.workspaces.ensure_home_symlink",
+                return_value=("/home/klangk", False),
+            ),
+        ):
+            status, message = await monitor._run_one(st)
+        assert status == "unhealthy"
+        assert message == "exited 127"
+
+    async def test_message_truncated_to_bounded_tail(self):
+        # A verbose check can't grow the retained reason unbounded; only
+        # the last HEALTH_MESSAGE_MAX_BYTES bytes are kept (#1088).
+        big = "x" * (container.HEALTH_MESSAGE_MAX_BYTES * 4)
+        assert len(
+            container._unhealthy_message(1, "", big)
+        ) == container.HEALTH_MESSAGE_MAX_BYTES + len("...") + len(
+            "exited 1: "
+        )
+
+    async def test_exec_error_is_unhealthy_with_reason(self):
+        # The podman/timeout failure text is captured as the reason
+        # instead of being discarded (#1088).
+        monitor = container.registry.health
+        st = _health_state()
+        with (
+            patch.object(
+                podman,
+                "exec_container",
+                AsyncMock(side_effect=podman.PodmanError(500, "boom")),
+            ),
+            patch.object(
+                model, "get_user_handle", AsyncMock(return_value="owner")
+            ),
+            patch("klangk_backend.workspaces.home_path", return_value="/h/p"),
+            patch(
+                "klangk_backend.workspaces.ensure_home_symlink",
+                return_value=("/home/klangk", False),
+            ),
+        ):
+            status, message = await monitor._run_one(st)
+        assert status == "unhealthy"
+        assert "PodmanError" in message
+        assert "boom" in message
+
+    async def test_no_owner_is_unhealthy_with_reason(self):
         monitor = container.registry.health
         st = _health_state(owner_id=None)
         with patch.object(podman, "exec_container") as exec_mock:
-            assert await monitor._run_one(st) == "unhealthy"
+            status, message = await monitor._run_one(st)
+        assert status == "unhealthy"
+        assert "owner" in message
         exec_mock.assert_not_called()
 
-    async def test_no_handle_is_unhealthy(self):
+    async def test_no_handle_is_unhealthy_with_reason(self):
         # Owner exists in the state but has no handle resolved.
         monitor = container.registry.health
         st = _health_state(owner_id="uid-owner")
@@ -2087,39 +2156,105 @@ class TestHealthMonitorRunOne:
             ),
             patch.object(podman, "exec_container") as exec_mock,
         ):
-            assert await monitor._run_one(st) == "unhealthy"
+            status, message = await monitor._run_one(st)
+        assert status == "unhealthy"
+        assert "handle" in message
         exec_mock.assert_not_called()
 
 
 class TestHealthMonitorCheckWorkspace:
-    """_check_workspace: records status and broadcasts on transitions."""
+    """_check_workspace: records status + reason and broadcasts changes."""
 
     async def test_broadcasts_on_transition_to_unhealthy(self):
         monitor = container.registry.health
         st = _health_state(health_status=None)  # unknown → unhealthy
         with (
             patch.object(
-                monitor, "_run_one", AsyncMock(return_value="unhealthy")
+                monitor,
+                "_run_one",
+                AsyncMock(return_value=("unhealthy", "connection refused")),
             ),
             patch.object(monitor, "_broadcast") as bcast,
         ):
             await monitor._check_workspace(st)
         assert st.health_status == "unhealthy"
+        assert st.health_message == "connection refused"
         assert st.health_checked_at is not None
-        bcast.assert_called_once_with("ws-h", "unhealthy")
+        bcast.assert_called_once_with(
+            "ws-h", "unhealthy", "connection refused"
+        )
 
     async def test_no_broadcast_when_status_unchanged(self):
         monitor = container.registry.health
         st = _health_state(health_status="healthy")  # stays healthy
         with (
             patch.object(
-                monitor, "_run_one", AsyncMock(return_value="healthy")
+                monitor, "_run_one", AsyncMock(return_value=("healthy", ""))
             ),
             patch.object(monitor, "_broadcast") as bcast,
         ):
             await monitor._check_workspace(st)
         assert st.health_status == "healthy"
         bcast.assert_not_called()
+
+    async def test_clears_message_when_becomes_healthy(self):
+        # A stale failure reason must not linger next to a "healthy"
+        # status once the check starts passing again (#1088).
+        monitor = container.registry.health
+        st = _health_state(health_status="unhealthy")
+        st.health_message = "old reason"
+        with patch.object(
+            monitor, "_run_one", AsyncMock(return_value=("healthy", ""))
+        ):
+            await monitor._check_workspace(st)
+        assert st.health_status == "healthy"
+        assert st.health_message is None
+
+    async def test_logs_reason_at_info_on_transition_to_unhealthy(
+        self, caplog
+    ):
+        # Acceptance criterion: a failing check's reason appears in the
+        # logs at least once per unhealthy transition, at info (#1088).
+        import logging
+
+        monitor = container.registry.health
+        st = _health_state(health_status=None)
+        with patch.object(
+            monitor,
+            "_run_one",
+            AsyncMock(return_value=("unhealthy", "curl: connection refused")),
+        ):
+            with caplog.at_level(
+                logging.INFO, logger="klangk_backend.container"
+            ):
+                await monitor._check_workspace(st)
+        assert any(
+            "connection refused" in r.message and r.levelno == logging.INFO
+            for r in caplog.records
+        )
+
+    async def test_logs_reason_at_debug_on_steady_unhealthy(self, caplog):
+        # A persistently-failing check doesn't spam at info; steady-state
+        # polls log the reason at debug (#1088).
+        import logging
+
+        monitor = container.registry.health
+        st = _health_state(health_status="unhealthy")
+        with patch.object(
+            monitor,
+            "_run_one",
+            AsyncMock(return_value=("unhealthy", "still down")),
+        ):
+            with caplog.at_level(
+                logging.DEBUG, logger="klangk_backend.container"
+            ):
+                await monitor._check_workspace(st)
+        info_records = [r for r in caplog.records if r.levelno == logging.INFO]
+        assert not any("still down" in r.message for r in info_records)
+        assert any(
+            "still down" in r.message and r.levelno == logging.DEBUG
+            for r in caplog.records
+        )
 
 
 class TestHealthMonitorBroadcast:
@@ -2136,7 +2271,7 @@ class TestHealthMonitorBroadcast:
             )
             # No WorkspaceSession registered for this workspace — yet
             # the event must still reach the connection.
-            monitor._broadcast("ws-h", "unhealthy")
+            monitor._broadcast("ws-h", "unhealthy", "connection refused")
         finally:
             _ws_state.connections.pop(sock, None)
         sock.send_json.assert_called_once_with(
@@ -2144,6 +2279,7 @@ class TestHealthMonitorBroadcast:
                 "type": "service_health",
                 "workspace_id": "ws-h",
                 "healthy": False,
+                "health_message": "connection refused",
             }
         )
 

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -4172,20 +4172,26 @@ class TestNotifyServiceHealth:
             "type": "service_health",
             "workspace_id": "ws-123",
             "healthy": True,
+            "health_message": None,
         }
         sock_a.send_json.assert_called_once_with(expected)
         sock_b.send_json.assert_called_once_with(expected)
 
-    def test_sends_unhealthy(self):
+    def test_sends_unhealthy_with_reason(self):
+        # The failure reason rides along on the broadcast so operators
+        # can see *why* it's unhealthy (#1088).
         sock = _mock_sock()
         try:
             self._register(sock, {"id": "uid-1", "email": "a@x"})
-            wshandler.state.notify_service_health("ws-9", healthy=False)
+            wshandler.state.notify_service_health(
+                "ws-9", healthy=False, message="curl: connection refused"
+            )
         finally:
             wshandler.state.connections.pop(sock, None)
         msg = sock.send_json.call_args[0][0]
         assert msg["healthy"] is False
         assert msg["type"] == "service_health"
+        assert msg["health_message"] == "curl: connection refused"
 
     def test_skips_unauthenticated(self):
         sock = _mock_sock()

--- a/src/cli/klangkc/main.py
+++ b/src/cli/klangkc/main.py
@@ -900,7 +900,8 @@ def _dispatch_monitor_event(msg: dict, command: list[str]) -> None:
     With no *command*, the event is streamed as line-delimited JSON to
     stdout. With a command, its stdin gets the event JSON and env vars
     ``KLANGK_EVENT``, ``KLANGK_EVENT_TYPE``, ``KLANGK_WORKSPACE_ID`` and
-    (for health events) ``KLANGK_HEALTHY`` are set.
+    (for health events) ``KLANGK_HEALTHY`` / ``KLANGK_HEALTH_MESSAGE``
+    are set.
 
     Pure (no WebSocket) so it can be unit-tested in isolation.
     """
@@ -917,6 +918,9 @@ def _dispatch_monitor_event(msg: dict, command: list[str]) -> None:
         env["KLANGK_WORKSPACE_ID"] = str(wid)
     if msg.get("type") == "service_health":
         env["KLANGK_HEALTHY"] = "true" if msg.get("healthy") else "false"
+        health_msg = msg.get("health_message")
+        if health_msg:
+            env["KLANGK_HEALTH_MESSAGE"] = str(health_msg)
     # FileNotFoundError (missing binary) propagates to the caller.
     subprocess.run(command, input=payload.encode(), env=env, check=False)
 

--- a/src/cli/tests/test_cli.py
+++ b/src/cli/tests/test_cli.py
@@ -2653,6 +2653,36 @@ class TestMonitor:
         assert "KLANGK_EVENT" in env
 
     @pytest.mark.asyncio
+    async def test_health_message_env_set_when_present(self):
+        # The failure reason is exposed as KLANGK_HEALTH_MESSAGE so a
+        # monitor command can act on / report *why* it's unhealthy (#1088).
+        from klangkc.main import _monitor_connection
+
+        event = {
+            "type": "service_health",
+            "workspace_id": "w1",
+            "healthy": False,
+            "health_message": "curl: connection refused",
+        }
+        conn = _FakeMonitorConn([json.dumps(event)])
+        with patch(
+            "klangkc.main.websockets.connect",
+            return_value=_FakeMonitorCM(conn),
+        ):
+            with patch("klangkc.main.subprocess.run") as run_mock:
+                await _monitor_connection(
+                    "ws://x/ws",
+                    "tok",
+                    1024,
+                    command=["notify-send"],
+                    types=[],
+                    workspaces=[],
+                )
+        env = run_mock.call_args.kwargs["env"]
+        assert env["KLANGK_HEALTHY"] == "false"
+        assert env["KLANGK_HEALTH_MESSAGE"] == "curl: connection refused"
+
+    @pytest.mark.asyncio
     async def test_command_not_found_propagates(self, monkeypatch):
         # A missing command binary propagates FileNotFoundError out of
         # the single-connection loop (the runner turns it into an exit).


### PR DESCRIPTION
## Summary

Fixes #1088.

A failing health check discarded its stdout/stderr, leaving an
"unhealthy" workspace a black box — you saw the status flip and nothing
else. This captures the check output and surfaces the reason everywhere
an operator looks, so "it's unhealthy, good luck" becomes "it's
unhealthy because X".

## Changes

- **`container.py`** — `HealthMonitor._run_one` now returns
  `(status, message)` instead of throwing away `_out`/`_err`. The
  message is a bounded tail (stderr preferred, falls back to stdout,
  else the exit code; exception text on podman/timeout errors). New
  `ContainerState.health_message` field, cleared on healthy transitions
  and on `health_check` edits. Logging is transition-aware: **INFO** on
  a fresh unhealthy transition, **DEBUG** on steady-state polls. New
  `HEALTH_MESSAGE_MAX_BYTES = 512` cap so a verbose check can't grow
  memory unbounded across workspaces.
- **`api/workspaces.py`** — status endpoint exposes `health_message`
  (both running and stopped responses); resets it when `health_check`
  is edited.
- **`wshandler/session.py`** — the `service_health` WS event carries
  `health_message`.
- **`cli/klangkc/main.py`** — `klangkc monitor` exposes
  `KLANGK_HEALTH_MESSAGE` for command reactions (alongside the existing
  `KLANGK_HEALTHY`).

## Surfacing (proposal points 1-3)

| Surface | What you now see |
| --- | --- |
| Server logs | stderr tail + exit code at **INFO** on transition, **DEBUG** steady-state |
| `GET /workspaces/{id}/status` | `health_message` field |
| `service_health` WS event | `health_message` field |
| `klangkc monitor` command | `KLANGK_HEALTH_MESSAGE` env var |

The retained output is capped to `HEALTH_MESSAGE_MAX_BYTES` (512 bytes,
keeping the tail) so a verbose check can't grow memory unbounded across
workspaces.

## Tests

- **Unit**: reason capture (stderr/stdout/exit-code/expression paths),
  truncation to the bounded tail, transition-aware logging (INFO vs
  DEBUG), message cleared on healthy, status-API reset on edit,
  broadcast carries the reason, `KLANGK_HEALTH_MESSAGE` env.
- **Backend e2e** (new `test_health_check_e2e.py`): starts a real server
  with a 2s poll interval, configures a workspace with a failing check
  that writes a distinctive marker to stderr (`echo <marker> 1>&2; exit N`),
  and asserts the marker surfaces **both** via the status API
  `health_message` **and** the live `service_health` WS event. Uses a
  lossless background WS reader so the one-shot transition event can't
  be missed. The server log confirms the criterion directly:
  ```
  Health check for workspace ... unhealthy: exited 7: klangk-health-failure-...
  ```

### Test results
- Backend unit: **1966 passed**
- CLI unit: **165 passed**
- Backend e2e (new): **2 passed** (~9s)
- `ruff check` + `ruff format`: clean; all pre-commit hooks passed.

## Acceptance criteria (from #1088)

- [x] When a health check exits non-zero, its stderr (and a tail of
      stdout) appears in the server logs at least once per unhealthy
      transition.
- [x] An operator can determine *why* a workspace is unhealthy without
      manually running `podman exec` — via logs, the API
      (`health_message`), and `klangkc monitor` (`KLANGK_HEALTH_MESSAGE`).

## Docs

`docs/features/health-check.md`, `docs/reference/api-endpoints.md`, and
`docs/reference/cli.md` updated for the new field / env var, including a
`notify-send` example that reports the failure reason.