### PR TITLE
Run klangkc exec as a bash login shell; --raw for transports (#1041)

### DIFF
--- a/docs/features/the-shell.md
+++ b/docs/features/the-shell.md
@@ -5,9 +5,9 @@ set up the environment before your personal `~/.bashrc` runs:
 
 - `/etc/profile.d/klangk-*.sh` — environment exports (`PATH=/opt/klangk/bin`,
   `EDITOR`) sourced by **every login shell**, interactive or not. This is
-  why one-shot commands like the workspace health check (`bash -lc`)
-  still find `pi`, `herdr`, and the `klangk-*` helpers. (Note:
-  `klangkc exec` does not yet run a login shell — see [#1041].)
+  why one-shot commands like the workspace health check (`bash -lc`) and
+  `klangkc exec` (also `bash -lc`, #1041) still find `pi`, `herdr`, and
+  the `klangk-*` helpers.
 - `/etc/bash.bashrc` — interactive-shell setup: waits for container
   readiness, runs `on-shell-init` plugin hooks, and (via the default
   command) launches the workspace's configured service.
@@ -100,12 +100,13 @@ you're at a prompt, it goes in `~/.bashrc`.
 
 ### Which code path sources what
 
-| In-container command                         | How Klangk runs it                            | Sources `~/.profile`? |
-| -------------------------------------------- | --------------------------------------------- | --------------------- |
-| Interactive terminal                         | `tmux new-session` (login shell) or `bash -l` | yes                   |
-| `default_command` (the `default-cmd` window) | login shell (tmux window 0)                   | yes                   |
-| Workspace health check                       | `bash -lc` (a login shell, #1087)             | yes                   |
-| `klangkc exec`                               | raw command (no shell)                        | no — see [#1041]      |
+| In-container command                         | How Klangk runs it                            | Sources `~/.profile`?                                              |
+| -------------------------------------------- | --------------------------------------------- | ------------------------------------------------------------------ |
+| Interactive terminal                         | `tmux new-session` (login shell) or `bash -l` | yes                                                                |
+| `default_command` (the `default-cmd` window) | login shell (tmux window 0)                   | yes                                                                |
+| Workspace health check                       | `bash -lc` (a login shell, #1087)             | yes                                                                |
+| `klangkc exec` (default)                     | `bash -lc` (a login shell, #1041)             | yes                                                                |
+| `klangkc exec --raw` / `klangkc sync`        | raw command (no shell)                        | no — programmatic transports (rsync) must not source startup files |
 
 This is why workspace setup scripts (`sandboxes/*/setup.sh`) persist
 their env exports to `~/.profile` rather than `~/.bashrc`: the exports

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -161,7 +161,8 @@ klangkc shell my-project debug           # attach to the "debug" terminal window
 klangkc sandbox myws                     # create workspace from .klangk-sandbox.yaml
 klangkc sandbox myws ~/projects/myapp    # specify sandbox root explicitly
 klangkc sandbox myws --force             # re-apply config and re-run setup on existing workspace
-klangkc exec my-project ls /home/klangk/work         # run a command in the container
+klangkc exec my-project ls /home/klangk/work         # run a command in the container (login shell: sources ~/.profile)
+klangkc exec --raw my-project rsync --server ...      # raw argv, no shell (for transports like rsync)
 klangkc monitor                                        # stream all server events as JSON
 klangkc monitor --type service_health | jq .           # pretty-print health transitions
 klangkc monitor --type service_health -- notify-send "Service unhealthy"  # react to unhealthy events

--- a/sandboxes/tests/openclaw/test_openclaw_setup_e2e.py
+++ b/sandboxes/tests/openclaw/test_openclaw_setup_e2e.py
@@ -97,6 +97,12 @@ WS3 = "e2e-openclaw-setup-3"
 # end-to-end health-check path (config -> monitor -> status endpoint)
 # against a real gateway, not to re-run the install.
 WS4 = "e2e-openclaw-setup-4"
+# Fifth workspace at the same mount, used by the #1041 klangkc-exec
+# test. setup skips the install (mount populated) so it's fast; the
+# point is to prove `klangkc exec` runs as a login shell so a
+# PATH-only binary (nvm-installed `openclaw`) resolves -- the exact
+# repro in the issue.
+WS5 = "e2e-openclaw-setup-5"
 # Own port + instance id so it never collides with other e2e suites
 # (cli-e2e 18995, autostart 18996/18997).
 PORT = "18998"
@@ -782,6 +788,81 @@ class TestOpenclawSetupProfileExports:
             # seconds after setup, then the first poll lands within one
             # interval.
             self._await_health(ws4_id, expected="healthy", timeout=180)
+        finally:
+            if sandbox_proc.poll() is None:
+                sandbox_proc.kill()
+
+    def test_klangkc_exec_resolves_path_only_binary(self):
+        """`klangkc exec` runs as a bash login shell so a PATH-only
+        binary (the nvm-installed `openclaw`) resolves -- the exact #1041
+        repro.
+
+        Before #1041, exec passed raw argv to `podman exec` with no
+        shell, so `~/.profile` was never sourced and `openclaw` (only on
+        PATH via `~/.profile`'s nvm source + `/openclaw/bin`) was not
+        found: `klangkc exec ws openclaw --version` failed with
+        'command not found'. Now exec wraps the command in
+        `bash -lc shlex.join(argv)`, sourcing `~/.profile` exactly like
+        an interactive terminal, so the binary resolves.
+
+        Uses `--raw` as a control: the same command under `--raw` (no
+        shell) must still fail to resolve, proving the login shell is
+        what fixes it and that `--raw` preserves the old raw behavior.
+        """
+        # Precondition: openclaw on the shared mount (full-install test
+        # ran first).
+        assert glob.glob(
+            os.path.join(
+                SANDBOX_DIR, ".nvm", "versions", "node", "v*", "bin", "openclaw"
+            )
+        ), "openclaw not on the shared mount -- run the full-install test first"
+
+        # WS5 reuses the populated mount (setup skips the install --
+        # fast), so we can exercise the exec path without a full setup.
+        sandbox_proc = subprocess.Popen(
+            ["klangkc", "sandbox", WS5, SANDBOX_DIR],
+            env=self._env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        try:
+            rc = sandbox_proc.wait(timeout=SETUP_TIMEOUT)
+            out = sandbox_proc.stdout.read() or ""
+            assert rc == 0, f"klangkc sandbox (WS5) failed:\n{out}"
+            assert "openclaw already installed, skipping." in out
+            self._await_container(name=WS5)
+
+            # The fix: default `klangkc exec` sources ~/.profile (login
+            # shell), so the nvm-installed openclaw resolves.
+            res = _run(
+                ["klangkc", "exec", WS5, "openclaw", "--version"],
+                env=self._env,
+                timeout=120,
+            )
+            assert res.returncode == 0, (
+                "klangkc exec openclaw --version failed under the login "
+                f"shell (should resolve via ~/.profile):\n{res.stderr}"
+            )
+            assert res.stdout.strip(), (
+                "openclaw --version produced no output:\n" + res.stdout
+            )
+
+            # The control: `--raw` skips the login shell, so openclaw is
+            # NOT on PATH (it lives behind the nvm source in ~/.profile)
+            # and the command must fail. This proves the login wrap is
+            # what fixes resolution and that --raw preserves raw argv.
+            res_raw = _run(
+                ["klangkc", "exec", "--raw", WS5, "openclaw", "--version"],
+                env=self._env,
+                timeout=120,
+            )
+            assert res_raw.returncode != 0, (
+                "klangkc exec --raw openclaw --version unexpectedly "
+                "succeeded -- under --raw no shell runs, so ~/.profile "
+                "is not sourced and openclaw should not be on PATH. "
+                f"Output:\n{res_raw.stdout}"
+            )
         finally:
             if sandbox_proc.poll() is None:
                 sandbox_proc.kill()

--- a/src/backend/klangk_backend/podman.py
+++ b/src/backend/klangk_backend/podman.py
@@ -16,6 +16,7 @@ import asyncio
 import json
 import logging
 import os
+import shlex
 import tempfile
 import time
 from collections.abc import AsyncGenerator
@@ -515,11 +516,32 @@ class ExecSession:
         self._read_task: asyncio.Task | None = None
         self._returncode: int | None = None
 
-    async def start(self, command: list[str]) -> None:
-        """Start a command via podman exec with piped stdin/stdout."""
+    async def start(self, command: list[str], *, login: bool = False) -> None:
+        """Start a command via podman exec with piped stdin/stdout.
+
+        By default *command* is passed to ``podman exec`` as raw argv
+        (no shell) -- the right thing for programmatic transports like
+        ``klangkc sync``'s rsync, which must NOT source startup files: a
+        ``~/.profile`` that prints to stdout would corrupt the binary
+        rsync stream (the classic ssh/scp footgun), and rsync's argv is
+        shell-quoted precisely so a non-login round-trips cleanly.
+
+        When *login* is set the command is wrapped in
+        ``bash -lc shlex.join(command)`` so it runs as a **login shell**
+        and sources ``~/.profile`` -- matching what an interactive
+        terminal sees. This is what ``klangkc exec`` uses by default
+        (#1041): a user typing ``klangkc exec ws openclaw --version``
+        expects the nvm-installed binary on PATH, exactly like a
+        terminal. ``shlex.join`` re-quots so a re-parse by bash
+        round-trips to the same argv.
+        """
         env_flags: list[str] = []
         for entry in self.env:
             env_flags += ["-e", entry]
+        if login:
+            argv = ["bash", "-lc", shlex.join(command)]
+        else:
+            argv = command
         exec_cmd = [
             PODMAN_BIN,
             "exec",
@@ -530,7 +552,7 @@ class ExecSession:
             "-w",
             self.work_dir,
             self.container_id,
-            *command,
+            *argv,
         ]
 
         self._running = True
@@ -543,8 +565,9 @@ class ExecSession:
         )
         self._read_task = asyncio.create_task(self._read_stdout())
         logger.info(
-            "Exec session started for container %s: %s",
+            "Exec session started for container %s (login=%s): %s",
             self.container_id,
+            login,
             command,
         )
 

--- a/src/backend/klangk_backend/wshandler/controllers.py
+++ b/src/backend/klangk_backend/wshandler/controllers.py
@@ -239,8 +239,14 @@ class ExecController:
         ssh_agent_socket = self._conn._ssh_agent_socket
         if ssh_agent_socket is not None:
             env.append(f"SSH_AUTH_SOCK={ssh_agent_socket}")
+        # `login` (default raw) selects whether the command runs as a
+        # bash login shell (sources ~/.profile, like a terminal) or as
+        # raw argv (no shell, for programmatic transports like rsync).
+        # klangkc exec sends login=true; klangkc exec --raw and the
+        # rsync transport send login=false. See #1041.
+        login = bool(msg.get("login", False))
         session = ExecSession(container_id, env=env, work_dir=work_dir)
-        await session.start(command)
+        await session.start(command, login=login)
         self.session = session
         self.task = asyncio.create_task(self.forward_output(session))
         container.registry.record_activity(container_id)

--- a/src/backend/tests/test_podman_exec.py
+++ b/src/backend/tests/test_podman_exec.py
@@ -1,6 +1,7 @@
 """Tests for podman ExecSession: raw podman exec without PTY."""
 
 import asyncio
+import shlex
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -49,6 +50,61 @@ class TestExecSession:
         async for data in session.output():
             chunks.append(data)
         assert b"hello world" in b"".join(chunks)
+
+    async def test_start_default_is_raw_argv(self):
+        """#1041: with no ``login`` flag the command is spliced into the
+        podman exec argv verbatim -- no shell. This is what programmatic
+        transports (rsync) need: their argv must round-trip untouched,
+        and a ~/.profile that prints must not corrupt the binary stream.
+        """
+        session = ExecSession("cid")
+        proc = _mock_proc(b"")
+        with patch(
+            "asyncio.create_subprocess_exec",
+            return_value=proc,
+        ) as mock_exec:
+            await session.start(["echo", "hello"])
+        argv = mock_exec.call_args.args
+        # raw: the command words are the tail of the argv, no wrapper.
+        assert argv[-2:] == ("echo", "hello")
+        assert "bash" not in argv
+        assert "-lc" not in argv
+
+    async def test_start_login_wraps_in_bash_login_shell(self):
+        """#1041: ``login=True`` wraps the command in
+        ``bash -lc shlex.join(command)`` so it sources ~/.profile and a
+        PATH-only binary (e.g. an nvm-installed tool) resolves, matching
+        an interactive terminal.
+        """
+        session = ExecSession("cid")
+        proc = _mock_proc(b"")
+        with patch(
+            "asyncio.create_subprocess_exec",
+            return_value=proc,
+        ) as mock_exec:
+            await session.start(["openclaw", "--version"], login=True)
+        argv = mock_exec.call_args.args
+        # ... bash -lc 'openclaw --version'
+        assert argv[-3:-1] == ("bash", "-lc")
+        assert argv[-1] == "openclaw --version"
+
+    async def test_start_login_shlex_round_trips_metachars(self):
+        """#1041: shell-special characters survive the shlex.join ->
+        bash re-parse round trip, so a command's argv still parses back
+        to the same words (spaces, $, quotes) after the login wrap.
+        """
+        session = ExecSession("cid")
+        proc = _mock_proc(b"")
+        cmd = ["echo", "a b", "$X", "o'reilly"]
+        with patch(
+            "asyncio.create_subprocess_exec",
+            return_value=proc,
+        ) as mock_exec:
+            await session.start(cmd, login=True)
+        argv = mock_exec.call_args.args
+        assert argv[-2] == "-lc"
+        # bash -lc would re-tokenise this string back to ``cmd``.
+        assert argv[-1] == shlex.join(cmd)
 
     async def test_write_sends_to_stdin(self):
         session = ExecSession("cid")

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -2696,6 +2696,47 @@ class TestExecController:
         assert kwargs["env"] == []
         assert kwargs["work_dir"] == "/home/work"
 
+    async def test_start_default_login_false(self):
+        """#1041: a message with no ``login`` key runs raw argv (no
+        shell) -- the safe default for any caller, and what rsync needs."""
+        ctrl, _, _ = self._controller()
+        with (
+            patch(
+                "klangk_backend.wshandler.controllers.ExecSession"
+            ) as MockExec,
+            patch.object(container.registry, "record_activity"),
+        ):
+            mock_session = MockExec.return_value
+            mock_session.start = AsyncMock()
+            await ctrl.start({"command": ["ls"]})
+            ctrl.task.cancel()
+            try:
+                await ctrl.task
+            except asyncio.CancelledError:
+                pass
+        mock_session.start.assert_awaited_with(["ls"], login=False)
+
+    async def test_start_login_true_threads_through(self):
+        """#1041: ``login: True`` in the message reaches ExecSession.start
+        so the command runs as a bash login shell (sources ~/.profile).
+        This is the klangkc exec default."""
+        ctrl, _, _ = self._controller()
+        with (
+            patch(
+                "klangk_backend.wshandler.controllers.ExecSession"
+            ) as MockExec,
+            patch.object(container.registry, "record_activity"),
+        ):
+            mock_session = MockExec.return_value
+            mock_session.start = AsyncMock()
+            await ctrl.start({"command": ["ls"], "login": True})
+            ctrl.task.cancel()
+            try:
+                await ctrl.task
+            except asyncio.CancelledError:
+                pass
+        mock_session.start.assert_awaited_with(["ls"], login=True)
+
     async def test_input_no_session(self):
         ctrl, _, _ = self._controller()
         await ctrl.input({"data": base64.b64encode(b"x").decode()})

--- a/src/cli/klangkc/client.py
+++ b/src/cli/klangkc/client.py
@@ -1245,6 +1245,7 @@ class _ExecSession(_ShellSession):
         stdin: io.RawIOBase | None = None,
         stdout: io.RawIOBase | None = None,
         timeout: int | None = None,
+        login: bool = True,
     ):
         local_sock = os.environ.get("SSH_AUTH_SOCK")
         sock = (
@@ -1255,6 +1256,11 @@ class _ExecSession(_ShellSession):
         self.stdin = stdin
         self.stdout = stdout
         self.timeout = timeout
+        # ``login`` (default True): run the command as a bash login shell
+        # so it sources ~/.profile, matching a terminal (#1041). Set
+        # False for programmatic transports (rsync) that must not source
+        # startup files.
+        self.login = login
         self.exit_code = 1
         self._loop = asyncio.get_event_loop()
         self._stdout_fd = -1
@@ -1339,7 +1345,13 @@ class _ExecSession(_ShellSession):
 
     async def run(self) -> int:
         await self.ws.send(
-            json.dumps({"cmd": "exec_start", "command": self.command})
+            json.dumps(
+                {
+                    "cmd": "exec_start",
+                    "command": self.command,
+                    "login": self.login,
+                }
+            )
         )
 
         stdout_task = asyncio.create_task(self.stdout_forward())
@@ -1412,10 +1424,15 @@ async def _exec_on_ws(
     stdin: io.RawIOBase | None = None,
     stdout: io.RawIOBase | None = None,
     timeout: int | None = None,
+    login: bool = False,
 ) -> int:
     """Run a command on an already-connected WebSocket.
 
-    Returns the remote process exit code.
+    Returns the remote process exit code.  ``login`` defaults to False
+    (raw argv) -- this is the low-level primitive used by setup/file-copy
+    paths that already build their own ``sh -c`` command; the
+    interactive ``klangkc exec`` entrypoint (_ws_exec) overrides it to
+    True. See #1041.
     """
     session = _ExecSession(
         ws,
@@ -1423,6 +1440,7 @@ async def _exec_on_ws(
         stdin=stdin,
         stdout=stdout,
         timeout=timeout,
+        login=login,
     )
     return await session.run()
 
@@ -1433,17 +1451,25 @@ async def _ws_exec(
     workspace_id: str,
     command: list[str],
     max_size: int = _WS_MAX_SIZE,
+    login: bool = True,
 ) -> int:
     """Run a command interactively, piping real stdin/stdout.
 
-    Returns the remote process exit code.
+    Returns the remote process exit code.  Defaults to ``login=True``
+    (run as a bash login shell so ~/.profile is sourced, like a
+    terminal -- #1041); ``klangkc exec --raw`` and the rsync transport
+    pass False for raw argv.
     """
     async with websockets.connect(
         f"{ws_url}?token={token}", max_size=max_size
     ) as ws:
         await _wait_container_ready(ws, workspace_id)
         return await _exec_on_ws(
-            ws, command, stdin=sys.stdin.buffer, stdout=sys.stdout.buffer
+            ws,
+            command,
+            stdin=sys.stdin.buffer,
+            stdout=sys.stdout.buffer,
+            login=login,
         )
 
 

--- a/src/cli/klangkc/main.py
+++ b/src/cli/klangkc/main.py
@@ -1720,10 +1720,27 @@ def unshare_terminal(
 def exec_cmd(
     ctx: typer.Context,
     workspace: str = typer.Argument(..., help="Workspace name"),
+    raw: bool = typer.Option(
+        False,
+        "--raw",
+        help=(
+            "Pass the command as raw argv (no login shell). Defaults off, "
+            "so commands run as a bash login shell and source ~/.profile "
+            "just like a terminal (#1041). Intended for programmatic "
+            "transports such as rsync; not for interactive use."
+        ),
+    ),
 ) -> None:
     """Run a command in a workspace container.
 
-    Also usable as an rsync transport: rsync -avz -e "klangkc exec" src/ ws:/dest/
+    By default the command runs as a bash login shell (``bash -lc``) so
+    it sources ``~/.profile`` and sees the same environment an
+    interactive terminal does -- PATH additions, tool homes
+    (OPENCLAW_HOME, nvm/asdf), etc. (#1041). Pass ``--raw`` to run raw
+    argv with no shell (used by ``klangkc sync``'s rsync transport).
+
+    Also usable as an rsync transport:
+    rsync -avz -e "klangkc exec --raw" src/ ws:/dest/
     """
     _require_auth()
 
@@ -1744,7 +1761,14 @@ def exec_cmd(
     token = _state().get_token(_server_url())
 
     exit_code = asyncio.run(
-        _ws_exec(ws_url, token, ws.id, command, max_size=_ws_max_size())
+        _ws_exec(
+            ws_url,
+            token,
+            ws.id,
+            command,
+            max_size=_ws_max_size(),
+            login=not raw,
+        )
     )
     raise typer.Exit(code=exit_code)
 
@@ -1794,7 +1818,11 @@ def sync(
         "-avz",
         "--blocking-io",
         "-e",
-        f"{klangkc_bin} exec",
+        # ``--raw`` so the rsync transport runs raw argv (no login
+        # shell): rsync's binary protocol must not be corrupted by a
+        # ~/.profile that prints to stdout, and rsync shell-quotes its
+        # argv so a non-login round-trips cleanly. See #1041.
+        f"{klangkc_bin} exec --raw",
         *ctx.args,
         src,
         dest,

--- a/src/cli/tests/test_cli_main.py
+++ b/src/cli/tests/test_cli_main.py
@@ -2178,6 +2178,7 @@ class TestMainCLI:
     def test_exec_runs_command(self, logged_in_cfg, monkeypatch):
         from klangkc import main
         from klangkc.client import Workspace
+        from typer.testing import CliRunner
 
         ws = Workspace(
             id="ws1" + "0" * 52,
@@ -2187,16 +2188,45 @@ class TestMainCLI:
         client = MagicMock()
         client.resolve_workspace.return_value = ws
 
-        async def fake_exec(*args, **kwargs):
-            return 0
-
-        ctx = MagicMock()
-        ctx.args = ["ls", "-la"]
         with patch.object(main, "_client", return_value=client):
-            with patch.object(main, "_ws_exec", fake_exec):
-                with pytest.raises(typer.Exit) as exc_info:
-                    main.exec_cmd(ctx, workspace="my-ws")
-                assert exc_info.value.exit_code == 0
+            with patch.object(
+                main, "_ws_exec", AsyncMock(return_value=0)
+            ) as mock_exec:
+                runner = CliRunner()
+                result = runner.invoke(
+                    main.app, ["exec", "my-ws", "echo", "hi"]
+                )
+        assert result.exit_code == 0
+        # #1041: default exec runs as a login shell so ~/.profile is
+        # sourced (login=True); the command list is passed through.
+        assert mock_exec.call_args.kwargs["login"] is True
+        assert mock_exec.call_args.args[3] == ["echo", "hi"]
+
+    def test_exec_raw_flag_passes_login_false(self, logged_in_cfg):
+        """#1041: ``--raw`` opts out of the login shell so the command
+        runs as raw argv -- used by programmatic transports (rsync)."""
+        from klangkc import main
+        from klangkc.client import Workspace
+        from typer.testing import CliRunner
+
+        ws = Workspace(
+            id="ws1" + "0" * 52,
+            name="my-ws",
+            created_at="2025-01-01T00:00:00Z",
+        )
+        client = MagicMock()
+        client.resolve_workspace.return_value = ws
+
+        with patch.object(main, "_client", return_value=client):
+            with patch.object(
+                main, "_ws_exec", AsyncMock(return_value=0)
+            ) as mock_exec:
+                runner = CliRunner()
+                result = runner.invoke(
+                    main.app, ["exec", "--raw", "my-ws", "echo", "hi"]
+                )
+        assert result.exit_code == 0
+        assert mock_exec.call_args.kwargs["login"] is False
 
     def test_exec_no_command(self, logged_in_cfg):
         from klangkc import main
@@ -2238,7 +2268,10 @@ class TestMainCLI:
         assert "-avz" in cmd
         assert "/tmp/foo" in cmd
         assert "ws:/work/foo" in cmd
-        assert "klangkc exec" in " ".join(cmd)
+        # #1041: sync uses ``exec --raw`` as the rsync transport so the
+        # remote command runs raw (no login shell) -- a ~/.profile that
+        # prints would otherwise corrupt the binary rsync stream.
+        assert "klangkc exec --raw" in " ".join(cmd)
 
     def test_sync_no_rsync(self, logged_in_cfg):
         from klangkc import main


### PR DESCRIPTION
Closes #1041.

## Summary

`klangkc exec` passed raw argv to `podman exec` with no shell, so `~/.profile` was never sourced. A PATH-only binary (e.g. an nvm/asdf-installed tool whose home `setup.sh` wrote to `~/.profile`) was not found — `klangkc exec ws openclaw --version` → "command not found", even though an interactive terminal in the same workspace found it fine. This is the last in-container command path that didn't match a terminal; after this PR every path (terminals, default-command, health check, exec) sources `~/.profile`.

## Change

`klangkc exec` now runs the command as `bash -lc shlex.join(argv)` (a login shell) by default, matching what a terminal sees. `shlex.join` re-quotes so a bash re-parse round-trips to the same argv. `--raw` opts out to raw argv (the old behavior), for programmatic transports. `klangkc sync` switches its rsync transport to `exec --raw`.

### Why sync uses --raw

rsync's binary protocol must not be corrupted by a `~/.profile` that prints to stdout (the classic ssh/scp footgun), and rsync shell-quotes its argv so a non-login round-trips cleanly — the same reason ssh runs the remote rsync transport as a non-login shell. This keeps `sync` byte-identical to today; only interactive `exec` changes.

### Threading

- `ExecSession.start(command, *, login=False)` — default raw (no shell); `login` wraps in `bash -lc shlex.join(command)`.
- `ExecController.start` reads `msg["login"]` (default `False`).
- `exec_start` WS message gains `"login"`.
- `_ExecSession` / `_ws_exec` default `login=True` (interactive path); `_exec_on_ws` defaults `False` (low-level primitive used by setup/file-copy, which build their own `sh -c`).

**Net behavioral change:** only interactive `klangkc exec` now sources `~/.profile`. `sync` and the internal setup/copy paths are unchanged.

## Tests

- **podman `ExecSession`**: `login=False` splices raw argv; `login=True` wraps in `bash -lc`; shell metachars round-trip via `shlex.join`.
- **`ExecController`**: default message → `login=False`; `msg["login"]=True` → `login=True`.
- **CLI**: `exec WS cmd` sends `login=True`; `exec --raw WS cmd` sends `False`; `sync` uses `exec --raw` in the rsync `-e` string.
- **openclaw e2e**: `klangkc exec WS openclaw --version` succeeds (the nvm binary resolves via the login shell); the same command under `--raw` fails (control: no shell → not on PATH). This is the exact repro from the issue.
- Backend **100%** + CLI **100%** coverage gates green.

## Test plan

- [x] Backend unit suite: 1965 pass, 100% coverage.
- [x] CLI unit suite: 422 pass, 100% coverage.
- [ ] `test-sandbox-e2e` in CI (the `openclaw --version` exec validation).