### PR TITLE
Make herdr a plugin (opt-in); drop baked-in install + socket setup (#1108)

### DIFF
--- a/docs/features/plugins.md
+++ b/docs/features/plugins.md
@@ -88,8 +88,9 @@ These plugins are included in the default `plugins.yaml`:
 These plugins ship with klangk but are **not** included in the default
 `plugins.yaml`. Add them manually to enable:
 
-| Plugin        | What it does                                           |
-| ------------- | ------------------------------------------------------ |
-| `claude-code` | Installs Claude Code CLI agent at image build time     |
-| `bobdobbs`    | Bob Dobbs overlay via Pi                               |
-| `hermes`      | Hermes agent — NousResearch's terminal-based assistant |
+| Plugin        | What it does                                                                       |
+| ------------- | ---------------------------------------------------------------------------------- |
+| `claude-code` | Installs Claude Code CLI agent at image build time                                 |
+| `bobdobbs`    | Bob Dobbs overlay via Pi                                                           |
+| `hermes`      | Hermes agent — NousResearch's terminal-based assistant                             |
+| `herdr`       | Installs herdr (terminal-based agent runtime) and sets up its per-shell API socket |

--- a/docs/features/the-shell.md
+++ b/docs/features/the-shell.md
@@ -6,8 +6,8 @@ set up the environment before your personal `~/.bashrc` runs:
 - `/etc/profile.d/klangk-*.sh` — environment exports (`PATH=/opt/klangk/bin`,
   `EDITOR`) sourced by **every login shell**, interactive or not. This is
   why one-shot commands like the workspace health check (`bash -lc`) and
-  `klangkc exec` (also `bash -lc`, #1041) still find `pi`, `herdr`, and
-  the `klangk-*` helpers.
+  `klangkc exec` (also `bash -lc`, #1041) still find `pi` and the
+  `klangk-*` helpers.
 - `/etc/bash.bashrc` — interactive-shell setup: waits for container
   readiness, runs `on-shell-init` plugin hooks, and (via the default
   command) launches the workspace's configured service.

--- a/plugins/herdr/README.md
+++ b/plugins/herdr/README.md
@@ -1,0 +1,36 @@
+# @klangk/herdr
+
+Installs [herdr](https://github.com/ogulcancelik/herdr) — the terminal-based
+agent runtime (persistent sessions, pane API) — into workspace containers.
+
+## What it does
+
+- **on-image-build.sh** — Downloads and installs the herdr binary (pinned to
+  v0.6.6) at image build time. Architecture is auto-detected via `uname -m`
+  (x86_64 / aarch64).
+- **on-shell-init.sh** — Sets up herdr's API socket on every shell open. The
+  socket lives on tmpfs (`/tmp`) because virtiofs (macOS) rejects `chmod` on
+  sockets, and uses a per-user, random-suffixed directory to prevent
+  predictable-path attacks and avoid collisions between concurrent shells.
+
+## How herdr finds its socket
+
+herdr resolves its API socket via the `HERDR_SOCKET_PATH` environment variable,
+which `on-shell-init.sh` exports per shell. Because each shell gets its own
+socket directory, concurrent terminals do not collide.
+
+## Opt-in
+
+This plugin is **not** included in the default `plugins.yaml`. To enable it,
+add it manually:
+
+```yaml
+plugins:
+  - name: herdr
+    git: https://github.com/mcdonc/klangk.git
+    path: plugins/herdr
+    ref: main
+```
+
+Without this plugin, the base workspace image contains no herdr binary and sets
+no `HERDR_SOCKET_PATH`.

--- a/plugins/herdr/on-image-build.sh
+++ b/plugins/herdr/on-image-build.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Install herdr — the terminal-based agent runtime (persistent sessions,
+# pane API) from ogulcancelik/herdr GitHub releases.
+#
+# Architecture is detected at build time via `uname -m`. This hook runs
+# inside a Dockerfile RUN loop (the on-image-build plugin hook), so it
+# can't rely on the TARGETARCH build arg the way a top-level Dockerfile
+# line can — but uname sees the real build arch either way.
+set -e
+
+HERDR_VERSION=0.6.6
+
+case "$(uname -m)" in
+x86_64 | amd64) HERDR_ARCH=x86_64 ;;
+aarch64 | arm64) HERDR_ARCH=aarch64 ;;
+*)
+  echo "herdr: unsupported architecture: $(uname -m)" >&2
+  exit 1
+  ;;
+esac
+
+echo "installing herdr ${HERDR_VERSION} (${HERDR_ARCH})"
+curl -fsSL -o /usr/local/bin/herdr \
+  "https://github.com/ogulcancelik/herdr/releases/download/v${HERDR_VERSION}/herdr-linux-${HERDR_ARCH}"
+chmod +x /usr/local/bin/herdr

--- a/plugins/herdr/on-shell-init.sh
+++ b/plugins/herdr/on-shell-init.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Set up herdr's API socket on every shell open.
+#
+# The socket lives on tmpfs (/tmp) rather than the persistent home mount
+# because virtiofs (macOS) rejects chmod on sockets. The path is per-user
+# with a random suffix: it prevents predictable-path attacks in /tmp and
+# avoids collisions between concurrent shells (each shell gets its own
+# socket directory). herdr resolves its socket via HERDR_SOCKET_PATH.
+_herdr_dir=$(mktemp -d "/tmp/herdr-${KLANGK_USER_ID:-default}-XXXXXXXX")
+export HERDR_SOCKET_PATH="$_herdr_dir/herdr.sock"

--- a/plugins/herdr/package.json
+++ b/plugins/herdr/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@klangk/herdr",
+  "version": "1.0.0",
+  "description": "Herdr — terminal-based agent runtime (persistent sessions, pane API)"
+}

--- a/src/containers/workspace/Dockerfile
+++ b/src/containers/workspace/Dockerfile
@@ -39,14 +39,6 @@ RUN curl -LsSf https://astral.sh/uv/0.11.23/install.sh | sh \
     && mv /root/.local/bin/uv /usr/local/bin/uv \
     && mv /root/.local/bin/uvx /usr/local/bin/uvx
 
-# Herdr: terminal-based agent runtime (persistent sessions, pane API)
-ARG HERDR_VERSION=0.6.6
-ARG TARGETARCH
-RUN HERDR_ARCH=$([ "$TARGETARCH" = "arm64" ] && echo "aarch64" || echo "x86_64") \
-    && curl -fsSL -o /usr/local/bin/herdr \
-    "https://github.com/ogulcancelik/herdr/releases/download/v${HERDR_VERSION}/herdr-linux-${HERDR_ARCH}" \
-    && chmod +x /usr/local/bin/herdr
-
 # Entrypoint, system prompt, bash defaults (change frequently during dev)
 COPY system-prompt.md /opt/klangk/system-prompt.md
 COPY entrypoint.sh /opt/klangk/entrypoint.sh

--- a/src/containers/workspace/bash.bashrc
+++ b/src/containers/workspace/bash.bashrc
@@ -14,11 +14,6 @@
 # exits early here.
 [ -f /tmp/.klangk-image-build ] && return 0
 
-# Keep herdr's API socket on tmpfs — virtiofs (macOS) rejects chmod on sockets.
-# Per-user with random suffix to prevent predictable-path attacks in /tmp.
-_herdr_dir=$(mktemp -d "/tmp/herdr-${KLANGK_USER_ID:-default}-XXXXXXXX")
-export HERDR_SOCKET_PATH="$_herdr_dir/herdr.sock"
-
 # Change to the user's home directory (podman exec -w can't use symlinks
 # without resolving them, so we start in /home and cd here instead).
 cd "$HOME" 2>/dev/null

--- a/src/containers/workspace/profile.d/klangk-path.sh
+++ b/src/containers/workspace/profile.d/klangk-path.sh
@@ -4,7 +4,7 @@
 # Why this lives in /etc/profile.d and not /etc/bash.bashrc (issue #1093):
 # /etc/profile resets PATH to a fixed system default for login shells,
 # clobbering the /opt/klangk/bin prefix that the Dockerfile ENV sets. This
-# snippet re-prepends it so EVERY login shell finds pi, herdr, and the
+# snippet re-prepends it so EVERY login shell finds pi and the
 # klangk-* helpers — including non-interactive login shells (`bash -lc`),
 # which is what the workspace health check and `klangkc exec` use.
 # /etc/bash.bashrc was the wrong home because it is only sourced for


### PR DESCRIPTION
Closes #1108.

## Summary

herdr was wired into the core workspace image in two non-plugin places: an unconditional `curl`/`chmod` install in the base `Dockerfile`, and a per-shell `HERDR_SOCKET_PATH` setup in `/etc/bash.bashrc`. Both move into an opt-in `plugins/herdr/` plugin (the `hermes` plugin is the template), and the base image no longer carries herdr at all.

## New plugin

```
plugins/herdr/
  package.json          # @klangk/herdr manifest
  on-image-build.sh     # installs herdr v0.6.6 at image build (arch via uname -m)
  on-shell-init.sh      # sets up the per-shell API socket (moved from bash.bashrc)
  README.md
```

- **`on-image-build.sh`** installs the binary, detecting arch via `uname -m` instead of the Dockerfile `TARGETARCH` build arg — the hook runs inside a `RUN` loop where that arg isn't reliably in scope, and `uname` sees the real (or QEMU-emulated) build arch either way.
- **`on-shell-init.sh`** moves the socket setup verbatim from `bash.bashrc`. It runs via the existing `for f in /opt/klangk/plugins/*/on-shell-init.sh` loop — no core-file change needed.

## Removals

- `src/containers/workspace/Dockerfile`: the `ARG HERDR_VERSION` + `curl`/`RUN` block.
- `src/containers/workspace/bash.bashrc`: the `_herdr_dir` / `HERDR_SOCKET_PATH` block. The `/tmp/.klangk-image-build` build-time bailout **stays** — hermes (#1109) still needs it.

## Opt-in (the #1108 open question)

Per the issue's open question, herdr is **intentionally left out** of `customize/plugins.yaml` and `_DEFAULT_PLUGINS`. Workspaces that need it add it to their `plugins.yaml`; workspaces without it get neither the binary nor the socket env var. This matches how `claude-code` and `hermes` already work.

## Docs

- `plugins.md` — lists herdr under "Additional plugins".
- `the-shell.md` — drops herdr from the list of binaries found by default (it's opt-in now, and was never in `/opt/klangk/bin` anyway).
- `klangk-path.sh` comment — no longer mentions herdr (it lives in `/usr/local/bin`, not `/opt/klangk/bin`, so the PATH snippet never sourced it).

## Test plan

- [x] No Python source changed; backend/CLI unit suites unaffected.
- [x] Confirmed no test (unit or e2e) references `herdr`/`HERDR_SOCKET_PATH`.
- [x] All pre-commit hooks pass (shellcheck, shfmt, markdownlint, prettier).
- [ ] `test-sandbox-e2e` in CI (builds a real image — herdr absent from the default image is the intended change).