### PR TITLE
Health check runs as a non-login bash shell (bash -c)

### DIFF
--- a/docs/features/health-check.md
+++ b/docs/features/health-check.md
@@ -55,14 +55,35 @@ the workspace as `health_message`, and carried on the `service_health`
 event -- so you can see _why_ it's unhealthy without `podman exec`'ing
 in by hand.
 
-The check runs through `bash -lc "<your command>"` — a bash **login
-shell** — so any shell syntax works (pipes, `&&`, redirects, etc.)
-**and** the command sees the workspace user's environment: it sources
-`~/.profile`, where `setup.sh` persists PATH additions and tool homes.
-This means a check like `openclaw health` resolves the `openclaw`
-binary even though it was installed under nvm/asdf. See
-[The Shell — Startup files](the-shell.md#startup-files) for the
-convention on where setup scripts should put environment exports.
+The check runs through `bash -c "<your command>"` — a bash
+**non-login** shell. It sources **no** startup file: not `~/.profile`,
+not `~/.bashrc`, not `/etc/profile.d/*`. This is deliberate — the
+health check is an **operational probe**, not a user session (think
+Kubernetes liveness probe), so it must stay deterministic and
+decoupled from the owning user's interactive shell setup. A slow
+`nvm` load, a broken `~/.profile` edit, or a stray `read` prompt must
+never make an unattended 30-second poll flap "unhealthy".
+
+The trade-off: the check command **cannot rely on the user's PATH or
+environment**. It sees only the container's image `PATH` (so
+`/opt/klangk/bin` and system tools like `grep`, `pgrep`, `curl`
+resolve) plus `HOME`. So:
+
+- **Use absolute paths** for the binary you're checking — a tool
+  installed by `setup.sh` (under nvm, a venv, a sandbox mount) is on
+  the _user's_ PATH, not the probe's.
+- For anything non-trivial, **point `health-check` at an executable
+  script with a shebang** (e.g. `/openclaw/bin/healthcheck.sh`). The
+  script's shebang dictates its interpreter (a script with
+  `#!/usr/bin/env bash` runs under bash regardless of the probe's
+  shell), you can `export` whatever `PATH`/env vars it needs, and you
+  can run it locally by hand to test. Both bundled sandboxes ship their
+  check this way (see below). Inline one-liners (`pgrep -x …`,
+  `curl -sf …`, `test -S …`) are fine for trivial checks and run
+  under the probe's `bash`.
+
+See [The Shell — Startup files](the-shell.md#startup-files) for why
+login-shell exports don't reach the probe.
 
 ### When checks are skipped
 
@@ -159,42 +180,67 @@ In `.klangk-sandbox.yaml` (see [Sandbox](sandbox.md)):
 
 ```yaml
 workspace:
-  health-check: openclaw health
+  health-check: /openclaw/bin/healthcheck.sh
 ```
 
 This is exactly what the [openclaw sandbox](https://github.com/mcdonc/klangk/tree/main/sandboxes/openclaw)
-ships: `openclaw health` connects to the running gateway over
-WebSocket and exits non-zero if it's unreachable — a liveness check
-for the service the `default-command` (`openclaw gateway`) launches.
-Because the check runs as a bash login shell (`bash -lc`), it sources
-`~/.profile` and resolves the nvm-installed `openclaw` binary — see
-[The Shell](the-shell.md#startup-files).
+ships. Rather than a bare `openclaw health` (which would need the
+user's nvm `PATH` + `OPENCLAW_HOME` from `~/.profile` — invisible to
+the non-login probe), `setup.sh` writes `/openclaw/bin/healthcheck.sh`:
+a tiny script with `#!/usr/bin/env bash` that `export`s `OPENCLAW_HOME`
+and `exec`s `/openclaw/bin/openclaw health` by absolute path. The
+config points `health-check` at that absolute path. The [hermes
+sandbox](https://github.com/mcdonc/klangk/tree/main/sandboxes/hermes)
+does the same. This is the recommended pattern for any non-trivial
+check. See [The Shell](the-shell.md#startup-files) for why the probe
+can't see the user's `~/.profile`.
 
 ## Example commands
 
-A health check is any command that exits 0 when things are good. The
-canonical real-world example is the openclaw sandbox's own check:
+A health check is any command that exits 0 when things are good.
+Because the check runs as a **non-login** `bash -c` (it sources
+nothing — see above), the reliable patterns are either a **trivial
+inline one-liner** using only system tools, or a **wrapper script at
+an absolute path** for anything that needs a sandbox-installed binary
+or custom env.
 
-```yaml
-# A real service's own health command (openclaw ships this)
-openclaw health
-```
-
-Other common patterns:
+A trivial one-liner (system tools resolve on the image `PATH`):
 
 ```yaml
 # HTTP health endpoint
-curl -sf http://localhost:8080/health
+health-check: curl -sf http://localhost:8080/health
 
 # Process is running
-pgrep -f 'openclaw gateway'
+health-check: pgrep -f 'openclaw gateway'
 
 # A unix socket exists
-test -S /tmp/my.sock
+health-check: test -S /tmp/my.sock
 
 # A port is accepting connections
-nc -z localhost 5432
+health-check: nc -z localhost 5432
 ```
+
+A non-trivial check — point at a script your `setup.sh` writes, so the
+binary path and any env (`OPENCLAW_HOME`, `HERMES_HOME`, …) are baked
+in and never depend on the user's `~/.profile`:
+
+```yaml
+health-check: /openclaw/bin/healthcheck.sh
+```
+
+```bash
+# /openclaw/bin/healthcheck.sh — what the openclaw sandbox ships
+#!/usr/bin/env bash
+export OPENCLAW_HOME=/openclaw
+exec /openclaw/bin/openclaw health
+```
+
+The script's shebang dictates its interpreter, so you can test it
+locally (`/openclaw/bin/healthcheck.sh`) and it behaves identically
+when the probe runs it. Avoid inline commands that depend on the
+user's `PATH` (e.g. a bare `openclaw health`) — they'll work in a
+login shell but report perpetually unhealthy under the non-login
+probe.
 
 ## Server tuning
 

--- a/docs/features/sandbox.md
+++ b/docs/features/sandbox.md
@@ -70,7 +70,7 @@ workspace:
   image: klangk-workspace
   default-command: openclaw gateway
   auto-start: true
-  health-check: openclaw health
+  health-check: /openclaw/bin/healthcheck.sh
 ```
 
 | Field             | Required | Default              | Description                                                                                                                |
@@ -177,7 +177,7 @@ mounts:
   - .env:~/.env:ro
 ```
 
-Then in your `~/.profile` (so the health check and default command see
+Then in your `~/.profile` (so the default command and `klangkc exec` see
 the variables too — see [The Shell](the-shell.md#startup-files)) or
 setup script:
 
@@ -342,7 +342,7 @@ sandbox:
 
 workspace:
   default-command: openclaw gateway
-  health-check: openclaw health
+  health-check: /openclaw/bin/healthcheck.sh
 
 copy:
   - ~/.gitconfig:~/.gitconfig
@@ -379,11 +379,12 @@ mkdir -p ~/.config/nix
 grep -q experimental-features ~/.config/nix/nix.conf 2>/dev/null \
   || echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
 
-# Source nix in every login shell -- interactive terminals, the
-# default command, and the health check (bash -lc) all source
-# ~/.profile. Writing this to ~/.bashrc instead would hide it from
-# the health check (its interactivity guard returns early for
-# non-interactive shells). See the-shell.md#startup-files.
+# Source nix in every login shell -- interactive terminals and the
+# default command all source ~/.profile. Writing this to ~/.bashrc
+# instead would hide it from those non-interactive login shells (its
+# interactivity guard returns early). (The health check is NOT a
+# ~/.profile consumer -- it runs as a non-login bash -c; see
+# health-check.md.) See the-shell.md#startup-files.
 # shellcheck disable=SC2016
 grep -q nix-profile ~/.profile 2>/dev/null \
   || echo '. "$HOME/.nix-profile/etc/profile.d/nix.sh"' >> ~/.profile

--- a/docs/features/the-shell.md
+++ b/docs/features/the-shell.md
@@ -5,9 +5,10 @@ set up the environment before your personal `~/.bashrc` runs:
 
 - `/etc/profile.d/klangk-*.sh` — environment exports (`PATH=/opt/klangk/bin`,
   `EDITOR`) sourced by **every login shell**, interactive or not. This is
-  why one-shot commands like the workspace health check (`bash -lc`) and
-  `klangkc exec` (also `bash -lc`, #1041) still find `pi` and the
-  `klangk-*` helpers.
+  why one-shot commands like `klangkc exec` (`bash -lc`, #1041) still find
+  `pi` and the `klangk-*` helpers. (The workspace health check is the
+  exception — it runs as a non-login `bash -c` and sources nothing; see
+  [Health Check](health-check.md).)
 - `/etc/bash.bashrc` — interactive-shell setup: waits for container
   readiness, runs `on-shell-init` plugin hooks, and (via the default
   command) launches the workspace's configured service.
@@ -69,8 +70,10 @@ Klangk runs commands in several contexts and not all of them source the
 same startup files (see [Startup files](#startup-files) below):
 
 - Edit `~/.profile` for **environment exports** (PATH additions,
-  `OPENCLAW_HOME`, tool-manager setup like nvm/asdf) that every shell
-  — including non-interactive ones like the health check — must see.
+  `OPENCLAW_HOME`, tool-manager setup like nvm/asdf) that login-shell
+  commands — interactive terminals, the default command, and `klangkc
+exec` — must see. (The health check is deliberately _not_ a profile
+  consumer; see [Health Check](health-check.md).)
 - Edit `~/.bashrc` for **interactive niceties** (aliases, prompt
   customization) that only matter in a terminal you're typing into.
 - Add scripts to `~/bin`
@@ -83,37 +86,46 @@ All changes persist across container restarts.
 Klangk runs in-container commands in a few different ways, and each
 sources a different set of startup files. Getting this right matters:
 an environment export buried below `~/.bashrc`'s interactivity guard is
-invisible to the health check, so a check like `openclaw health` reports
-perpetually unhealthy even though the service is fine (#1087).
+invisible to `klangkc exec`, so a one-shot command run there can fail
+to find a tool even though an interactive terminal finds it fine.
+
+The one deliberate exception is the **health check**: it runs as a
+non-login `bash -c` and sources _nothing_, so it stays deterministic
+and immune to your interactive setup. It uses absolute paths instead.
+See [Health Check](health-check.md).
 
 ### Convention
 
-| File                                        | Purpose                                                                                                              | Sourced by                                                                              |
-| ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| `/etc/profile.d/klangk-*.sh`                | system-wide defaults (klangk `PATH`, `EDITOR`)                                                                       | every login shell                                                                       |
-| `~/.profile`                                | **per-user environment exports** (PATH additions, tool homes, nvm/asdf) — anything non-interactive commands must see | login shells: interactive terminals, the default command, the health check (`bash -lc`) |
-| `~/.bashrc` (below the interactivity guard) | interactive niceties (aliases, prompt)                                                                               | interactive non-login bash shells; also chained from `~/.profile` for login shells      |
+| File                                        | Purpose                                                                                                          | Sourced by                                                                            |
+| ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `/etc/profile.d/klangk-*.sh`                | system-wide defaults (klangk `PATH`, `EDITOR`)                                                                   | every login shell                                                                     |
+| `~/.profile`                                | **per-user environment exports** (PATH additions, tool homes, nvm/asdf) — anything login-shell commands must see | login shells: interactive terminals, the default command, `klangkc exec` (`bash -lc`) |
+| `~/.bashrc` (below the interactivity guard) | interactive niceties (aliases, prompt)                                                                           | interactive non-login bash shells; also chained from `~/.profile` for login shells    |
 
-**Rule of thumb:** if a non-interactive command (health check, a
-script) needs it, it goes in `~/.profile`. If it only matters when
-you're at a prompt, it goes in `~/.bashrc`.
+**Rule of thumb:** if a login-shell command (`klangkc exec`, a setup
+script, the default command) needs it, it goes in `~/.profile`. If it
+only matters when you're at a prompt, it goes in `~/.bashrc`. The
+health check is not a `~/.profile` consumer — see
+[Health Check](health-check.md).
 
 ### Which code path sources what
 
-| In-container command                         | How Klangk runs it                            | Sources `~/.profile`?                                              |
-| -------------------------------------------- | --------------------------------------------- | ------------------------------------------------------------------ |
-| Interactive terminal                         | `tmux new-session` (login shell) or `bash -l` | yes                                                                |
-| `default_command` (the `default-cmd` window) | login shell (tmux window 0)                   | yes                                                                |
-| Workspace health check                       | `bash -lc` (a login shell, #1087)             | yes                                                                |
-| `klangkc exec` (default)                     | `bash -lc` (a login shell, #1041)             | yes                                                                |
-| `klangkc exec --raw` / `klangkc sync`        | raw command (no shell)                        | no — programmatic transports (rsync) must not source startup files |
+| In-container command                         | How Klangk runs it                            | Sources `~/.profile`?                                                                      |
+| -------------------------------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| Interactive terminal                         | `tmux new-session` (login shell) or `bash -l` | yes                                                                                        |
+| `default_command` (the `default-cmd` window) | login shell (tmux window 0)                   | yes                                                                                        |
+| Workspace health check                       | `bash -c` (a **non-login** shell)             | no — the probe is deterministic; uses absolute paths (see [Health Check](health-check.md)) |
+| `klangkc exec` (default)                     | `bash -lc` (a login shell, #1041)             | yes                                                                                        |
+| `klangkc exec --raw` / `klangkc sync`        | raw command (no shell)                        | no — programmatic transports (rsync) must not source startup files                         |
 
 This is why workspace setup scripts (`sandboxes/*/setup.sh`) persist
 their env exports to `~/.profile` rather than `~/.bashrc`: the exports
-must be visible to the health check and the default command, both of
+must be visible to the default command and `klangkc exec`, both of
 which are login shells that source `~/.profile`. `~/.bashrc`'s
 interactivity guard (`case $- in *i*) ;; *) return`) hides its body
-from those non-interactive login shells.
+from those non-interactive login shells. The health check is the
+exception — it deliberately sources nothing (see
+[Health Check](health-check.md)).
 
 ## Using zsh instead
 

--- a/sandboxes/hermes/.klangk-sandbox.yaml
+++ b/sandboxes/hermes/.klangk-sandbox.yaml
@@ -4,14 +4,11 @@ sandbox:
 
 workspace:
   default-command: klangk-hermes-gateway
-  # `hermes gateway status` reports whether the gateway process (launched by
-  # default-command) is alive, but always exits 0 regardless of state, so the
-  # liveness signal is derived from its output. "Gateway is running" is NOT a
-  # substring of "Gateway is not running" (the word after "is " differs), so
-  # the grep is unambiguous. hermes's own status detection (PID file + /proc
-  # cmdline scan + PID-reuse fingerprinting) does the heavy lifting.
-  #
-  # Runs as a bash login shell (bash -lc, #1087) so it sources ~/.profile and
-  # resolves the hermes binary + HERMES_HOME. See docs/features/health-check.md.
-  health-check: hermes gateway status 2>&1 | grep -q 'Gateway is running'
+  # Liveness probe for the gateway launched by default-command. Points
+  # at an absolute-path wrapper script (NOT bare `hermes gateway ...`)
+  # because the host monitor runs it via `bash -c` -- a NON-login shell
+  # that sources no startup file, so the user's PATH / HERMES_HOME from
+  # ~/.profile are not in effect. The script bakes those in. See
+  # docs/features/health-check.md.
+  health-check: /hermes/bin/healthcheck.sh
   auto-start: true

--- a/sandboxes/hermes/README.md
+++ b/sandboxes/hermes/README.md
@@ -46,10 +46,14 @@ Everything installs to `/hermes` (the sandbox mount point):
 
 ## Health check
 
-`health-check` runs `hermes gateway status` and greps its output for the
-running marker. `hermes gateway status` always exits 0 (it only prints state),
-so the liveness signal is derived from the printed line rather than the exit
-code — hermes's own process detection (PID file + `/proc` scan) does the work.
+`health-check` points at `/hermes/bin/healthcheck.sh`, a wrapper that sets
+`HERMES_HOME` and runs the venv `hermes gateway status` by absolute path,
+grepping its output for the running marker. The host monitor runs the check
+via `bash -c` (a non-login shell that sources no startup file), so the wrapper
+bakes in everything it needs instead of relying on the user's `~/.profile`.
+`hermes gateway status` always exits 0 (it only prints state), so the liveness
+signal is derived from the printed line rather than the exit code — hermes's
+own process detection (PID file + `/proc` scan) does the work.
 See [docs/features/health-check.md](../../docs/features/health-check.md).
 
 ## Why a sandbox, not a plugin

--- a/sandboxes/hermes/healthcheck.sh
+++ b/sandboxes/hermes/healthcheck.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# klangk health check for the hermes sandbox.
+#
+# The host health monitor runs this via `bash -c` -- a NON-login shell,
+# so ~/.profile, ~/.bashrc, and /etc/profile.d are NOT sourced and
+# nothing the owning user set up interactively is in effect. This is
+# deliberate: the probe must stay deterministic and immune to the user
+# editing their shell startup (a slow nvm load or a broken ~/.profile
+# must never make a 30s poll flap "unhealthy").
+#
+# Consequence: the hermes binary and HERMES_HOME are referenced by
+# absolute path here, not via PATH. setup.sh copies this script to
+# /hermes/bin/healthcheck.sh; the sandbox config points `health-check`
+# at that absolute path. See docs/features/health-check.md.
+set -euo pipefail
+export HERMES_HOME=/hermes
+
+# `hermes gateway status` always exits 0 (it only prints state), so the
+# liveness signal is derived from its output: "Gateway is running" is
+# NOT a substring of "Gateway is not running" (the word after "is "
+# differs), so the grep is unambiguous. hermes's own process detection
+# (PID file + /proc scan + PID-reuse fingerprinting) does the work.
+#
+# The venv entry point has an absolute shebang to its interpreter, so it
+# runs standalone without hermes/node on PATH.
+/hermes/hermes-agent/venv/bin/hermes gateway status 2>&1 |
+  grep -q 'Gateway is running'

--- a/sandboxes/hermes/setup.sh
+++ b/sandboxes/hermes/setup.sh
@@ -19,12 +19,18 @@ INSTALL_DIR="/hermes"
 HERMES_VERSION=v2026.6.19
 
 # --- Persist env exports to ~/.profile UP FRONT, before the slow install. ---
-# Why ~/.profile (#1087): it's the POSIX file sourced by ALL login shells --
-# the default-command pane (interactive login shell), the health check
-# (bash -lc), and `klangkc exec`. ~/.bashrc has an interactivity guard that
-# hides its body from non-interactive shells, so these exports cannot live
-# there. Written before the install so a shell spawned mid-setup already sees
-# a complete PATH/HERMES_HOME.
+# Why ~/.profile: it's the POSIX file sourced by login shells -- the
+# default-command pane (an interactive login shell) and `klangkc exec`
+# (bash -lc). Those need HERMES_HOME + the hermes bin on PATH to launch
+# / inspect the gateway. ~/.bashrc has an interactivity guard that hides
+# its body from non-interactive shells, so these exports cannot live
+# there. Written before the install so a shell spawned mid-setup already
+# sees a complete PATH/HERMES_HOME.
+#
+# NOTE: the workspace health check is NOT a reason to put these in
+# ~/.profile. The check runs as a NON-login shell (`bash -c`) and
+# sources nothing -- it uses the absolute-path /hermes/bin/healthcheck.sh
+# wrapper instead. Don't add exports here "for the health check".
 # shellcheck disable=SC2016
 if ! grep -q 'HERMES_HOME' ~/.profile 2>/dev/null; then
   echo "export HERMES_HOME=\"$INSTALL_DIR\"" >>~/.profile
@@ -101,11 +107,16 @@ OPENAI_API_KEY=${token}
 EOF
 fi
 
-# --- Install the gateway wrapper (default-command). ---
-# Refreshes the workspace token into .env, then execs the foreground gateway.
-# Copied (not bind-used directly) so it lands on PATH at $INSTALL_DIR/bin/.
+# --- Install the gateway wrapper (default-command) + the health-check
+# script. Both are copied (not bind-used) so they land on the /hermes
+# mount at stable absolute paths. The health-check wrapper is invoked
+# by the host monitor via `bash -c` (NON-login), so it must not depend
+# on ~/.profile -- it sets HERMES_HOME and calls the venv binary by
+# absolute path itself. ---
 cp "$SCRIPT_DIR/klangk-hermes-gateway.sh" "$INSTALL_DIR/bin/klangk-hermes-gateway"
 chmod +x "$INSTALL_DIR/bin/klangk-hermes-gateway"
+cp "$SCRIPT_DIR/healthcheck.sh" "$INSTALL_DIR/bin/healthcheck.sh"
+chmod +x "$INSTALL_DIR/bin/healthcheck.sh"
 
 # Refresh Pi agent config (extensions, settings, models, skills).
 /opt/klangk/bin/klangk-setup-clankers

--- a/sandboxes/openclaw/.klangk-sandbox.yaml
+++ b/sandboxes/openclaw/.klangk-sandbox.yaml
@@ -4,10 +4,11 @@ sandbox:
 
 workspace:
   default-command: openclaw gateway
-  # `openclaw health` connects to the running gateway over WebSocket
-  # and exits non-zero if it is unreachable -- a liveness check for the
-  # service the default-command launches. It runs as a bash login shell
-  # (bash -lc, #1087) so it sources ~/.profile and resolves the
-  # nvm-installed `openclaw` binary. See docs/features/health-check.md.
-  health-check: openclaw health
+  # Liveness probe for the gateway launched by default-command. Points
+  # at an absolute-path wrapper script (NOT bare `openclaw health`)
+  # because the host monitor runs it via `bash -c` -- a NON-login shell
+  # that sources no startup file, so the user's nvm PATH / OPENCLAW_HOME
+  # from ~/.profile are not in effect. The script bakes those in.
+  # See docs/features/health-check.md.
+  health-check: /openclaw/bin/healthcheck.sh
   auto-start: true

--- a/sandboxes/openclaw/healthcheck.sh
+++ b/sandboxes/openclaw/healthcheck.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# klangk health check for the openclaw sandbox.
+#
+# The host health monitor runs this via `bash -c` -- a NON-login shell,
+# so ~/.profile, ~/.bashrc, and /etc/profile.d are NOT sourced and
+# nothing the owning user set up interactively is in effect. This is
+# deliberate: the probe must stay deterministic and immune to the user
+# editing their shell startup (a slow nvm load or a broken ~/.profile
+# must never make a 30s poll flap "unhealthy").
+#
+# Consequence: the openclaw binary and OPENCLAW_HOME are referenced by
+# absolute path here, not via PATH. setup.sh points
+# /openclaw/bin/openclaw at the nvm-installed binary (npm rewrites its
+# shebang to an absolute node path, so it runs standalone without node
+# on PATH) and copies this script to /openclaw/bin/healthcheck.sh; the
+# sandbox config points `health-check` at that absolute path.
+# See docs/features/health-check.md.
+set -euo pipefail
+export OPENCLAW_HOME=/openclaw
+
+# `openclaw health` connects to the running gateway over WebSocket and
+# exits non-zero if it is unreachable -- a liveness check for the
+# service the default-command (`openclaw gateway`) launches.
+exec /openclaw/bin/openclaw health

--- a/sandboxes/openclaw/setup.sh
+++ b/sandboxes/openclaw/setup.sh
@@ -7,15 +7,17 @@ INSTALL_DIR="/openclaw"
 # Persist every env export the default_command depends on to ~/.profile
 # UP FRONT, before any long-running install step.
 #
-# Why ~/.profile and not ~/.bashrc (#1087): ~/.profile is the POSIX file
-# sourced by ALL login shells -- interactive terminals (the default-cmd
-# tmux pane is an interactive login shell) AND non-interactive
-# `bash -lc` (which the health check uses). ~/.bashrc has an
+# Why ~/.profile: it's the POSIX file sourced by login shells --
+# interactive terminals (the default-cmd tmux pane is an interactive
+# login shell) and `klangkc exec` (bash -lc). ~/.bashrc has an
 # interactivity guard near its top (`case $- in *i*) ;; *) return`)
 # that hides anything appended below it from non-interactive shells, so
-# exports the health check needs cannot live there. ~/.profile is the
-# one file BOTH the default_command and the health check reliably
-# source.
+# exports those commands need cannot live there.
+#
+# NOTE: the workspace health check is NOT a reason to put these in
+# ~/.profile. The check runs as a NON-login shell (`bash -c`) and
+# sources nothing -- it uses the absolute-path /openclaw/bin/healthcheck.sh
+# wrapper instead. Don't add exports here "for the health check".
 #
 # Why UP FRONT (#1039): a shell that sources ~/.profile while setup is
 # still running (e.g. the default-cmd pane created by an early
@@ -87,6 +89,19 @@ fi
 mkdir -p "$INSTALL_DIR/bin"
 cp "$SCRIPT_DIR/klangk-secret-provider.sh" "$INSTALL_DIR/bin/klangk-secret-provider"
 chmod +x "$INSTALL_DIR/bin/klangk-secret-provider"
+
+# Stable symlink so the health check can invoke openclaw by absolute
+# path. The host monitor runs the check via `bash -c` (NON-login), so
+# it does not source ~/.profile / nvm -- bare `openclaw` would not
+# resolve. npm rewrote openclaw's shebang to an absolute node path, so
+# this symlink runs standalone without node on PATH.
+ln -sf "$(command -v openclaw)" "$INSTALL_DIR/bin/openclaw"
+
+# Copy the health-check wrapper to a stable absolute path (same reason:
+# the NON-login check cannot rely on PATH). It sets OPENCLAW_HOME and
+# execs /openclaw/bin/openclaw health.
+cp "$SCRIPT_DIR/healthcheck.sh" "$INSTALL_DIR/bin/healthcheck.sh"
+chmod +x "$INSTALL_DIR/bin/healthcheck.sh"
 
 export PATH="$INSTALL_DIR/bin:$PATH"
 

--- a/sandboxes/tests/hermes/test_hermes_setup_e2e.py
+++ b/sandboxes/tests/hermes/test_hermes_setup_e2e.py
@@ -6,10 +6,14 @@ Covers two invariants (#1109):
   upstream Hermes installer at runtime (per-workspace, as the non-root
   ``klangk`` user), writes ``~/.profile`` exports + the llm-proxy config, and
   lands the ``hermes`` binary.
-- **Health-check works.** The ``health-check: hermes gateway status ... grep``
-  config reaches the workspace, the health monitor runs it as a bash login
-  shell (``bash -lc``, #1087), and the status endpoint reports ``healthy``
-  once the gateway (launched by ``default-command``) is up.
+- **Health-check works.** The
+  ``health-check: /hermes/bin/healthcheck.sh`` config reaches the
+  workspace, the health monitor runs it as a non-login bash shell
+  (``bash -c``) so it sources nothing, and the status endpoint reports
+  ``healthy`` once the gateway (launched by ``default-command``) is up.
+  ``setup.sh`` writes the wrapper to ``/hermes/bin/healthcheck.sh``; it
+  sets ``HERMES_HOME`` and calls the venv binary by absolute path,
+  grepping its output for the running marker.
 
   ``hermes gateway status`` always exits 0 (it only prints state), so the
   liveness signal is derived from its printed output -- hermes's own process
@@ -357,10 +361,12 @@ class TestHermesSetup:
         3. setup completes -> ``default-command`` (``klangk-hermes-gateway``)
            fires; the wrapper refreshes the token then runs
            ``hermes gateway run``.
-        4. the monitor runs ``bash -lc "hermes gateway status ... | grep"``;
-           the login shell sources ``~/.profile`` (#1087) so ``hermes``
-           resolves, and hermes's process detection finds the running
-           gateway -> status endpoint reports ``healthy``.
+        4. the monitor runs ``bash -c /hermes/bin/healthcheck.sh``; the
+           non-login shell sources nothing, but the wrapper sets
+           ``HERMES_HOME`` and calls the venv ``hermes gateway status``
+           by absolute path, grepping for the running marker.
+           hermes's process detection finds the running gateway ->
+           status endpoint reports ``healthy``.
         """
         sandbox_proc = subprocess.Popen(
             ["klangkc", "sandbox", WS, SANDBOX_DIR],

--- a/sandboxes/tests/openclaw/test_openclaw_setup_e2e.py
+++ b/sandboxes/tests/openclaw/test_openclaw_setup_e2e.py
@@ -5,21 +5,25 @@ Covers three invariants:
 - #1039 (ordering) + #1087 (location): ``setup.sh`` writes every env
   export the default_command depends on to ``~/.profile`` up front,
   before the slow ``npm install``.
-- #1089: the ``health-check: openclaw health`` config reaches the
-  workspace, the health monitor runs it as a bash login shell
-  (``bash -lc``, #1087), and the status endpoint reports ``healthy``
-  once the gateway (launched by ``default-command``) is up.
+- #1089: the ``health-check: /openclaw/bin/healthcheck.sh`` config
+  reaches the workspace, the health monitor runs it as a non-login
+  bash shell (``bash -c``) so it sources nothing, and the status
+  endpoint reports ``healthy`` once the gateway (launched by
+  ``default-command``) is up.
 
 ``sandboxes/openclaw/setup.sh`` persists every env export the
 default_command depends on (``NVM_DIR`` + nvm source, ``/openclaw/bin``
 on ``PATH``, ``OPENCLAW_HOME``) to ``~/.profile`` in one block at the
-very top of setup, before the long ``npm install -g openclaw``.
+very top of setup, before the long ``npm install -g openclaw``. It also
+writes ``/openclaw/bin/healthcheck.sh`` (and symlinks
+``/openclaw/bin/openclaw`` at the nvm-installed binary) so the health
+check can invoke openclaw by absolute path -- the non-login ``bash -c``
+probe does not source ``~/.profile``, so it cannot rely on nvm PATH.
 
 Why ``~/.profile`` and not ``~/.bashrc`` (#1087): ``~/.profile`` is the
-POSIX file sourced by ALL login shells -- interactive terminals (the
-default-cmd tmux pane is an interactive login shell) AND non-interactive
-``bash -lc`` (which the health check uses, ``container.py``
-``HealthMonitor._run_one``). ``~/.bashrc`` has an interactivity guard
+POSIX file sourced by login shells -- interactive terminals (the
+default-cmd tmux pane is an interactive login shell) and
+``klangkc exec`` (``bash -lc``). ``~/.bashrc`` has an interactivity guard
 that hides its body from non-interactive shells, so exports the health
 check needs cannot live there. ``~/.profile`` is the one file BOTH the
 default_command and the health check reliably source.
@@ -724,11 +728,11 @@ class TestOpenclawSetupProfileExports:
                 sandbox_proc.kill()
 
     def test_health_check_reports_healthy_when_gateway_up(self):
-        """The ``health-check: openclaw health`` config reaches the
-        workspace, the health monitor runs it as a bash login shell
-        (``bash -lc``, #1087), and the status endpoint reports
-        ``healthy`` once the gateway (launched by ``default-command``)
-        is up.
+        """The ``health-check: /openclaw/bin/healthcheck.sh`` config reaches
+        the workspace, the health monitor runs it as a non-login bash
+        shell (``bash -c``) so it sources nothing, and the status
+        endpoint reports ``healthy`` once the gateway (launched by
+        ``default-command``) is up.
 
         This is the #1089 end-to-end validation. The whole chain must
         work for the status to flip to healthy:
@@ -739,10 +743,11 @@ class TestOpenclawSetupProfileExports:
            skips checks until then).
         3. ``default-command: openclaw gateway`` fires and the gateway
            binds its port.
-        4. the monitor runs ``bash -lc "openclaw health"``; the login
-           shell sources ``~/.profile`` (#1087) so the nvm-installed
-           ``openclaw`` binary resolves and the command connects to
-           the gateway over WebSocket, exiting 0.
+        4. the monitor runs ``bash -c /openclaw/bin/healthcheck.sh``;
+           the non-login shell sources nothing, but the wrapper script
+           sets ``OPENCLAW_HOME`` and execs the symlinked
+           ``/openclaw/bin/openclaw health`` by absolute path, which
+           connects to the gateway over WebSocket and exits 0.
 
         The gateway takes a few seconds to bind after setup, so an
         initial ``unhealthy`` window is expected and tolerated -- the

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -454,12 +454,25 @@ class HealthMonitor:
         Resolves the owner's container home (same logic as
         ``eager_start_workspace``) and invokes the check via
         ``podman exec`` as the creating user with HOME set.  The check
-        runs as a bash *login* shell (``bash -lc``) so it sources
-        ``~/.profile`` -- the POSIX file where workspace setup persists
-        env exports (PATH, tool homes) that the check may depend on
-        (#1087).  A non-login ``sh -c`` would source nothing and fail
-        to resolve e.g. an asdf/nvm-installed binary.  Errors and
-        timeouts count as ``"unhealthy"``.
+        runs as a **non-login** bash shell (``bash -c``) on purpose: it
+        is an operational probe, not a user session, so it deliberately
+        sources *no* startup file -- not ``~/.profile``, ``~/.bashrc``,
+        nor ``/etc/profile.d/*``.  This keeps the probe deterministic
+        and decoupled from the owning user's interactive setup: a slow
+        ``nvm`` load, a broken ``~/.profile`` edit, or a stray ``read``
+        prompt must never make an unattended 30s poll flap "unhealthy".
+
+        The flip side is that the check command must not rely on the
+        user's PATH or env.  It inherits only the container's image
+        ``PATH`` (so ``/opt/klangk/bin`` and system tools like
+        ``grep``/``curl`` resolve) plus ``HOME``.  Anything the checked
+        service needs -- a sandbox-installed binary, ``OPENCLAW_HOME`` /
+        ``HERMES_HOME``, a custom ``PATH`` -- must be referenced by
+        **absolute path** in the check command, or wrapped in an
+        executable script whose shebang and ``export`` lines bake those
+        in (the recommended pattern for non-trivial checks; see
+        ``docs/features/health-check.md``).  Errors and timeouts count
+        as ``"unhealthy"``.
         """
         owner_id = state.owner_id
         if owner_id is None:
@@ -486,11 +499,13 @@ class HealthMonitor:
         try:
             rc, out, err = await podman.exec_container(
                 state.container_id,
-                # bash -lc: login shell sources ~/.profile so the
-                # check sees the user's env (PATH, tool homes). See
-                # #1087. Skipped until setup_state == complete, so the
-                # exports are guaranteed present by the time this runs.
-                ["bash", "-lc", state.health_check],
+                # bash -c (NON-login): sources nothing, so the probe is
+                # deterministic and insulated from the user's interactive
+                # shell setup. Only the image PATH + HOME are visible,
+                # so health_check commands must use absolute paths (or a
+                # wrapper script). See docs/features/health-check.md.
+                # Skipped until setup_state == complete.
+                ["bash", "-c", state.health_check],
                 user="klangk",
                 extra_env={"HOME": user_home},
                 timeout=HEALTH_CHECK_TIMEOUT_SECONDS,

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -2024,10 +2024,13 @@ class TestHealthMonitorRunOne:
         assert call.kwargs["user"] == "klangk"
         assert call.kwargs["extra_env"] == {"HOME": "/home/klangk"}
         assert call.kwargs["timeout"] == container.HEALTH_CHECK_TIMEOUT_SECONDS
-        # #1087: the check runs as a bash LOGIN shell (bash -lc) so it
-        # sources ~/.profile and sees the user's env (PATH, tool homes).
-        # A regression to "sh -c" would hide asdf/nvm-installed binaries.
-        assert call.args[1][:2] == ["bash", "-lc"]
+        # The health check runs as a NON-login bash shell (bash -c) on
+        # purpose: it sources nothing, so the probe is deterministic and
+        # decoupled from the user's interactive ~/.profile / ~/.bashrc.
+        # The check command must therefore use absolute paths (or a
+        # wrapper script with a shebang) -- it cannot rely on the user's
+        # PATH. See docs/features/health-check.md.
+        assert call.args[1][:2] == ["bash", "-c"]
         assert call.args[1][2] == st.health_check
 
     async def test_nonzero_exit_is_unhealthy_with_stderr_reason(self):

--- a/src/containers/workspace/Dockerfile
+++ b/src/containers/workspace/Dockerfile
@@ -65,9 +65,11 @@ RUN chmod +x /opt/klangk/entrypoint.sh \
       /opt/klangk/bin/klangk-set-workspace-token \
       /opt/klangk/bin/klangk-workspace-token
 # System-wide environment exports for ALL login shells (interactive AND
-# non-interactive, e.g. the health check's `bash -lc`). /etc/profile sources
+# non-interactive, e.g. `klangkc exec`'s `bash -lc`). /etc/profile sources
 # these unconditionally via run-parts. See issue #1093 for why env must live
 # here rather than in /etc/bash.bashrc (which non-interactive shells skip).
+# (The workspace health check is an exception: it runs a non-login `bash -c`
+# and sources nothing — see docs/features/health-check.md.)
 COPY profile.d/ /etc/profile.d/
 COPY bash.bashrc /etc/bash.bashrc
 COPY tmux.conf /etc/tmux.conf

--- a/src/containers/workspace/bash.bashrc
+++ b/src/containers/workspace/bash.bashrc
@@ -4,9 +4,11 @@
 #
 # NOTE: environment exports (PATH=/opt/klangk/bin, EDITOR) live in
 # /etc/profile.d/klangk-*.sh so that non-interactive login shells (bash -lc
-# — the health check, klangkc exec) see them too. This file is only sourced
+# — e.g. `klangkc exec`) see them too. This file is only sourced
 # for interactive shells, so anything placed here is invisible to one-shot
-# non-interactive commands. See issue #1093.
+# non-interactive commands. See issue #1093. (The workspace health check is
+# the exception: it runs a non-login `bash -c` and sources nothing — see
+# docs/features/health-check.md.)
 
 # Change to the user's home directory (podman exec -w can't use symlinks
 # without resolving them, so we start in /home and cd here instead).

--- a/src/containers/workspace/profile.d/klangk-editor.sh
+++ b/src/containers/workspace/profile.d/klangk-editor.sh
@@ -2,7 +2,9 @@
 # Default editor for git commit messages, crontab -e, etc.
 #
 # In /etc/profile.d (not /etc/bash.bashrc) so that non-interactive login
-# shells — e.g. a health check or `klangkc exec` that runs `git commit` —
-# see EDITOR too. /etc/bash.bashrc only loads for interactive shells,
-# which would hide this from one-shot commands. See issue #1093.
+# shells — e.g. `klangkc exec` running `git commit` — see EDITOR too.
+# /etc/bash.bashrc only loads for interactive shells, which would hide
+# this from one-shot commands. See issue #1093.
+# (The workspace health check is NOT a consumer of this: it runs a
+# non-login `bash -c` and sources nothing. See docs/features/health-check.md.)
 export EDITOR=nano

--- a/src/containers/workspace/profile.d/klangk-path.sh
+++ b/src/containers/workspace/profile.d/klangk-path.sh
@@ -6,9 +6,13 @@
 # clobbering the /opt/klangk/bin prefix that the Dockerfile ENV sets. This
 # snippet re-prepends it so EVERY login shell finds pi and the
 # klangk-* helpers — including non-interactive login shells (`bash -lc`),
-# which is what the workspace health check and `klangkc exec` use.
+# which is what `klangkc exec` uses.
 # /etc/bash.bashrc was the wrong home because it is only sourced for
 # interactive shells; a non-interactive login shell never saw the export.
+#
+# (The workspace health check is NOT a consumer of this: it runs a
+# non-login `bash -c` and sources nothing. See
+# docs/features/health-check.md.)
 #
 # Sourced by /etc/profile via run-parts for every login shell. /etc/profile
 # runs profile.d unconditionally (no PS1 guard), so this covers `bash -lc`


### PR DESCRIPTION
## Summary

The workspace health check is an **operational probe** (Kubernetes liveness-probe semantics), not a user session. #1087 ran it as a login shell (`bash -lc`) so it would source `~/.profile` and resolve sandbox-installed binaries — but coupling a 30 s-poll / 10 s-timeout probe to the owning user's interactive shell setup is a category error: a slow `nvm` load, a broken `~/.profile` edit, or a stray `read` prompt makes an unattended auto-started workspace flap "unhealthy" even though the service itself is fine.

This PR changes `HealthMonitor._run_one` to run a **non-login** `bash -c` that sources **nothing** (no `~/.profile`, `~/.bashrc`, `/etc/profile.d/*`). The probe inherits only the image `PATH` (`/opt/klangk/bin` + system tools) plus `HOME`, so it stays deterministic and decoupled from personalization.

Consequence: sandbox health checks can no longer rely on the user's `PATH` or env. The recommended pattern is to point `health-check` at an absolute-path wrapper script (with a shebang) whose `export` lines and absolute binary references bake in what the check needs.

## Changes

- **`container.py`**: `["bash", "-lc", cmd]` → `["bash", "-c", cmd]`; docstring + comment rewritten to explain the non-login rationale.
- **`test_container.py`**: assert `["bash", "-c"]`.
- **`sandboxes/openclaw/healthcheck.sh`** (new): sets `OPENCLAW_HOME`, `exec /openclaw/bin/openclaw health`. `setup.sh` now symlinks `/openclaw/bin/openclaw` at the nvm-installed binary and copies the wrapper; `.klangk-sandbox.yaml` points `health-check` at `/openclaw/bin/healthcheck.sh`.
- **`sandboxes/hermes/healthcheck.sh`** (new): sets `HERMES_HOME`, runs the venv `hermes gateway status | grep 'Gateway is running'`. `setup.sh` copies it; `.klangk-sandbox.yaml` points `health-check` at `/hermes/bin/healthcheck.sh`.
- **Docs**: `health-check.md`, `sandbox.md`, `the-shell.md` updated to document the non-login behavior and the absolute-path / wrapper-script pattern.
- **Container comments**: `Dockerfile`, `bash.bashrc`, `profile.d/*.sh` drop the health-check-as-login-shell justification for `profile.d` (it stays for `klangkc exec` / terminals / default-command).
- **e2e docstrings** updated for both sandboxes.

## Why `bash -c` and not `sh -c`

Consistency: the rest of the container's non-interactive command paths (`terminal.py`) already use `bash -c`. Using `bash` (not `sh`) keeps the check's syntax consistent with those paths and with the bash the user writes scripts against, while still sourcing nothing. A non-login `bash -c` does **not** reset `PATH`, so the image `PATH` is inherited intact — only sandbox-specific paths/env are missing (handled by the wrapper scripts).

## Test plan

- [x] `test_container.py` — 169/169 pass locally (single-file run).
- [x] shfmt + shellcheck clean on all new/edited shell scripts.
- [x] All pre-commit hooks pass.
- [ ] CI: full backend coverage gate (100%).
- [ ] CI: sandbox e2e (openclaw + hermes) green.

Closes #1112. Supersedes #1087.