### PR TITLE
Allowlist github-actions[bot] so base-image bump PRs aren't auto-closed

### DIFF
--- a/.github/slop-allowlist
+++ b/.github/slop-allowlist
@@ -6,3 +6,12 @@ runyaga
 tseaver
 bd-mkt
 Shridharrrr
+# --- Bots ---
+# github-actions[bot] opens the "Bump workspace base image" PRs from
+# .github/workflows/image-workspace-base.yml (it runs `gh pr create` with
+# secrets.GITHUB_TOKEN, which GitHub attributes to github-actions[bot]).
+# Allowlist it so the default-closed slop policy doesn't auto-close the
+# bumper's PRs. (Note: the GraphQL/REST API surfaces this actor as
+# `app/github-actions`; the webhook `.pull_request.user.login` that
+# auto-close.yml matches is `github-actions[bot]`.)
+github-actions[bot]


### PR DESCRIPTION
## Summary

`image-workspace-base.yml` opens a **Bump workspace base image** PR every time `Dockerfile.base` changes (it runs `gh pr create` with `secrets.GITHUB_TOKEN`, so GitHub attributes the PR to **`github-actions[bot]``). That actor isn`t on `.github/slop-allowlist`, so once `ENABLE_SLOP_POLICY=true` the default-closed policy will auto-close each bump PR the instant it opens.

## Change

Add `github-actions[bot]` to `.github/slop-allowlist`.

## Why this exact login

`auto-close.yml` reads the **webhook** field `.pull_request.user.login` (REST form), which for a `GITHUB_TOKEN`-authored PR is `github-actions[bot]` — that`s the exact line the allowlist`s `grep -Fxq` must contain. The GraphQL/REST `author` representation `app/github-actions` (what `gh pr view --json author` shows) is the **same actor** but is not what the webhook delivers, so it is intentionally not added.

Verified against the four existing merged bump PRs (#584, #650, #707, #804): each is `author.login = app/github-actions`, `is_bot = true`, branch `auto/bump-workspace-base-*` in mcdonc`s namespace (mcdonc is the branch owner, not the author).

## Note on scope

Allowlisting by author means *any* future PR opened by `github-actions[bot]` also bypasses auto-close. Today the base-image bumper is the only workflow in the repo that opens a PR as `github-actions[bot]`, so this is equivalent to allowlisting just the bump PRs. If more such workflows are added later and per-PR targeting is wanted, that`s a follow-up (e.g. branch-prefix or label bypass in `auto-close.yml`).