### PR TITLE
docs(hermes): document gateway is not exposed on an HTTP port

### DIFF
--- a/sandboxes/hermes/README.md
+++ b/sandboxes/hermes/README.md
@@ -56,6 +56,27 @@ signal is derived from the printed line rather than the exit code — hermes's
 own process detection (PID file + `/proc` scan) does the work.
 See [docs/features/health-check.md](../../docs/features/health-check.md).
 
+## Network exposure
+
+Unlike the openclaw sandbox (see its README warning), the hermes gateway is
+**not** exposed through Klangk's hosted-app mechanism — there is no port
+mapping and no hosted app URL is printed. The gateway (`hermes gateway run`,
+launched by `default-command`) makes only **outbound** connections: to the
+configured messaging platforms (Telegram/Discord/etc. via polling) and to the
+Klangk LLM proxy. Nothing inside the container accepts inbound HTTP, so the
+gateway is **not** contactable by someone who can reach your Klangk server.
+
+Hermes does ship an OpenAI-compatible HTTP API server, but it is **off by
+default** (`API_SERVER_ENABLED=false`) and, even when enabled, binds
+`127.0.0.1` (loopback) on port `8642`. `setup.sh` never enables it and never
+maps that port, so it is reachable only from within the container.
+
+This is the intended posture. If you later enable the API server and want it
+reachable outside the container, you must do all of the following yourself:
+set `API_SERVER_HOST=0.0.0.0`, set a strong `API_SERVER_KEY` (it is mandatory
+— the server grants full agent tool access, including the terminal), and
+arrange a Klangk port mapping. None of this is done by the sandbox.
+
 ## Why a sandbox, not a plugin
 
 Hermes was previously a compile-time [plugin](../../docs/features/plugins.md)


### PR DESCRIPTION
## Summary

Adds a **Network exposure** section to `sandboxes/hermes/README.md` documenting
whether the hermes gateway is contactable on an HTTP port once the sandbox is
set up — recording the result of the research that produced the openclaw
warning (#1117).

## Findings documented

- **No hosted-app exposure.** Unlike openclaw (which binds a container port,
  maps it via `KLANGK_PORT_MAPPINGS`, and prints a hosted-app URL), the hermes
  sandbox has no port mapping and no hosted-app wiring. The gateway
  (`hermes gateway run`, launched by `default-command`) makes only **outbound**
  connections — to the messaging platforms via polling and to the klangk
  llm-proxy — so it is **not** reachable by someone who can reach the klangk
  server.
- **Upstream API server is off by default.** Hermes ships an OpenAI-compatible
  HTTP API server, but `API_SERVER_ENABLED=false` by default and, even when
  enabled, it binds `127.0.0.1` (loopback) on `8642`. `setup.sh` never enables
  it and never maps that port, so it is reachable only from within the container.
- **Manual-enable path + caveat.** Documents that users who do want external
  access must set `API_SERVER_HOST=0.0.0.0`, set a strong `API_SERVER_KEY`
  (mandatory — it grants full agent tool access, including the terminal), and
  arrange a klangk port mapping themselves; none of this is done by the sandbox.

Cross-references the openclaw README warning for contrast.

## Verification

Grounded in the repo (`sandboxes/hermes/setup.sh`, `klangk-hermes-gateway.sh`,
`healthcheck.sh` — no `API_SERVER_*` / `8642` / port-map references anywhere in
the hermes sandbox) and the upstream API server docs
(https://hermes-agent.nousresearch.com/docs/user-guide/features/api-server).