### PR TITLE
docs(openclaw): warn the gateway is contactable by anyone on the network

### DIFF
--- a/sandboxes/openclaw/README.md
+++ b/sandboxes/openclaw/README.md
@@ -12,6 +12,10 @@ container auto-starts with the server.
 
 ## Usage
 
+> **WARNING:** OpenClaw will start in a mode where it is contactable by
+> anyone who can contact your klangk server. Configure its authentication
+> immediately after installation if your server answers on a public network.
+
 ```bash
 cd sandboxes/openclaw
 klangkc sandbox openclaw
@@ -22,11 +26,16 @@ pointing at the Klangk LLM proxy, and runs a non-interactive onboard.
 The setup script prints the hosted app URL at the end.
 
 The gateway starts automatically in the first terminal window. To
-add messaging channels:
+add messaging channels (i.e. to configure the authentication the WARNING above
+refers to):
 
 ```bash
 openclaw onboard
 ```
+
+> Note: the [hermes sandbox](../hermes/README.md#network-exposure) is the
+> opposite case — its gateway is not exposed on an HTTP port and is not
+> contactable by someone who can reach your klangk server.
 
 ## What gets installed
 


### PR DESCRIPTION
## Summary

Adds the security WARNING called for in #1117 to `sandboxes/openclaw/README.md`, placed at the top of the `## Usage` section (before the `klangkc sandbox openclaw` command) so it is seen before anyone runs the setup:

> **WARNING:** OpenClaw will start in a mode where it is contactable by anyone who can contact your klangk server. Configure its authentication immediately after installation if your server answers on a public network.

## Why it is accurate

Grounded in the actual setup:

- The gateway auto-starts via `default-command` and the container auto-starts with the server — there is no opt-in (README l.9–10).
- It is bound to container port 8000 on all interfaces, with `allowPrivateNetwork: True` so Klangk's hosted app can reach it (`setup.sh:154–156`); the hosted-app URL is printed at the end of setup (README l.22).
- The onboard is non-interactive (README l.24), so no auth step runs during install — leaving the gateway reachable until the user manually configures authentication.

## Other changes

- Annotates the `openclaw onboard` step as the auth-configuration command the WARNING refers to, so the reader knows where to act.
- Cross-references the hermes sandbox `Network exposure` section (the opposite case — its gateway is not exposed on an HTTP port), which landed in #1118.

Closes #1117.
