### PR TITLE
Fan out default-cmd window creation to all workspace subscribers (#1114)

### DIFF
--- a/docs/features/default-command.md
+++ b/docs/features/default-command.md
@@ -11,9 +11,10 @@ that should be running whenever the workspace is in use.
 ## How it works
 
 When a workspace has a default command configured, the server sends
-it as keystrokes into the first tmux window immediately after
-creating the terminal session. The command runs as a normal
-foreground process inside a bash login shell.
+it as keystrokes into a **dedicated `default-cmd` tmux window**
+immediately after creating the terminal session. The command runs as a
+normal foreground process inside a bash login shell, leaving your
+interactive window 0 free for a shell.
 
 This means:
 
@@ -69,7 +70,14 @@ If the workspace has [auto-start](workspaces.md#auto-start) enabled,
 the container starts when the Klangk server starts and the default
 command begins running immediately — before any user connects. When
 you later run `klangkc shell`, you walk up to the service already
-running in tmux window 0.
+running in the `default-cmd` tab.
+
+The `default-cmd` tab is surfaced to **every** connected client the
+moment it is created — including a visitor who opened the workspace
+while setup was still running (their initial tab snapshot predates the
+window). Each user has their own tmux session, so a visitor under a
+different account gets the tab in their own session without a manual
+refresh.
 
 ## Shell features
 

--- a/src/backend/e2e-tests/test_default_command_fanout_e2e.py
+++ b/src/backend/e2e-tests/test_default_command_fanout_e2e.py
@@ -1,0 +1,284 @@
+"""End-to-end test for default-command tab fan-out (#1114).
+
+A visitor who opened an auto-started workspace *while setup was still
+running* used to miss the ``default-cmd`` tab forever: their snapshot was
+taken before the window existed, and its later creation was announced
+only to the owning connection.  This test reproduces that race against a
+real server + container and asserts the visitor (under a *different*
+account) receives the tab once the default command fires.
+"""
+
+import asyncio
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+import httpx
+import pytest
+import websockets
+
+
+@pytest.fixture(scope="module")
+def server():
+    """Start a real Klangk server for the test module."""
+    data_dir = tempfile.mkdtemp(prefix="klangk-dcmd-fanout-e2e-")
+    port = "18997"
+
+    env = {
+        **os.environ,
+        "KLANGK_PORT": port,
+        "KLANGK_DATA_DIR": data_dir,
+        "KLANGK_JWT_SECRET": "dcmd-fanout-e2e-secret",
+        "KLANGK_PREVENT_INSECURE_JWT_SECRET": "",
+        "KLANGK_DEFAULT_USER": "test@example.com",
+        "KLANGK_DEFAULT_PASSWORD": "testpass",
+        "KLANGK_TEST_MODE": "1",
+        "KLANGK_INSTANCE_ID": "dcmd-fanout-e2e",
+        "KLANGK_IDLE_TIMEOUT_SECONDS": "0",  # don't idle out mid-test
+        "KLANGK_PORT_RANGE_START": "9400",
+        "LOGFIRE_TOKEN": "",
+        "KLANGK_LLM_BASE_URL": "",
+        "KLANGK_LLM_API_KEY": "",
+        "KLANGK_LLM_MODEL": "",
+    }
+    proc = subprocess.Popen(
+        [
+            "uvicorn",
+            "klangk_backend.main:app",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            port,
+        ],
+        cwd=os.path.join(os.path.dirname(__file__), ".."),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    base_url = f"http://localhost:{port}"
+    for _ in range(60):
+        try:
+            if httpx.get(f"{base_url}/health", timeout=2).status_code == 200:
+                break
+        except Exception:
+            pass
+        time.sleep(1)
+    else:
+        proc.kill()
+        stdout = proc.stdout.read().decode() if proc.stdout else ""
+        raise RuntimeError(f"Server failed to start:\n{stdout}")
+
+    yield {"url": base_url, "port": port, "data_dir": data_dir, "proc": proc}
+
+    try:
+        proc.kill()
+        proc.wait(timeout=5)
+    except (ProcessLookupError, subprocess.TimeoutExpired):
+        pass
+    if proc.stdout:
+        server_log = proc.stdout.read().decode("utf-8", errors="replace")
+        if server_log.strip():
+            sys.stderr.write(
+                f"\n=== dcmd-fanout server log ===\n{server_log}\n===\n"
+            )
+    result = subprocess.run(
+        [
+            "podman",
+            "ps",
+            "-a",
+            "--filter",
+            "label=klangk.instance=dcmd-fanout-e2e",
+            "-q",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.stdout.strip():
+        subprocess.run(
+            ["podman", "rm", "-f", *result.stdout.strip().split()],
+            capture_output=True,
+        )
+    shutil.rmtree(data_dir, ignore_errors=True)
+
+
+def _login(server, email, password):
+    url = server["url"]
+    resp = httpx.post(
+        f"{url}/api/v1/auth/login",
+        json={"email": email, "password": password},
+        timeout=10,
+    )
+    assert resp.status_code == 200, resp.text
+    token = resp.json()["access_token"]
+    return {"token": token, "headers": {"Authorization": f"Bearer {token}"}}
+
+
+def _register(server, email, password):
+    url = server["url"]
+    resp = httpx.post(
+        f"{url}/api/v1/auth/register",
+        json={"email": email, "password": password},
+        timeout=10,
+    )
+    assert resp.status_code == 200, resp.text
+    return _login(server, email, password)
+
+
+@pytest.fixture(scope="module")
+def owner(server):
+    return _login(server, "test@example.com", "testpass")
+
+
+async def _connect(server, auth, workspace_id):
+    """Open a WS, connect to the workspace, wait for container_ready.
+
+    Returns ``(ws, received, reader_task)`` where *received* is a live
+    list a background reader appends every message to — the one-shot
+    ``terminal_windows`` fan-out can land at any moment and must not be
+    missed.
+    """
+    ws_url = server["url"].replace("http://", "ws://")
+    ws = await websockets.connect(
+        f"{ws_url}/ws?token={auth['token']}", max_size=2**20
+    )
+    await ws.send(
+        json.dumps({"cmd": "workspace_connect", "workspaceId": workspace_id})
+    )
+    received: list[dict] = []
+
+    async def _reader():
+        try:
+            async for raw in ws:
+                try:
+                    received.append(json.loads(raw))
+                except json.JSONDecodeError:
+                    pass
+        except websockets.ConnectionClosed:
+            pass
+
+    reader_task = asyncio.create_task(_reader())
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + 60
+    while loop.time() < deadline:
+        if any(m.get("type") == "container_ready" for m in received):
+            break
+        await asyncio.sleep(0.2)
+    else:
+        reader_task.cancel()
+        await ws.close()
+        raise AssertionError("container_ready not received within 60s")
+    return ws, received, reader_task
+
+
+async def _terminal_start(ws):
+    await ws.send(
+        json.dumps({"cmd": "terminal_start", "cols": 80, "rows": 24})
+    )
+
+
+def _has_default_cmd(msg):
+    return msg.get("type") == "terminal_windows" and any(
+        w.get("name") == "default-cmd" for w in msg.get("windows", [])
+    )
+
+
+class TestDefaultCommandFanout:
+    @pytest.mark.asyncio
+    async def test_visitor_gets_default_cmd_tab_after_creation(
+        self, server, owner
+    ):
+        """A different-account visitor sees the tab once it is created."""
+        url = server["url"]
+        # Register a collaborator (the visitor) under a different account.
+        visitor = _register(server, "visitor@example.com", "visitorpass")
+
+        # Create a workspace with a default command, held in 'pending'
+        # setup so the default-cmd window is NOT created yet.
+        resp = httpx.post(
+            f"{url}/api/v1/workspaces",
+            headers=owner["headers"],
+            json={
+                "name": "dcmd-fanout",
+                "default_command": "sleep 600",
+                "setup_state": "pending",
+            },
+            timeout=10,
+        )
+        assert resp.status_code == 200, resp.text
+        workspace_id = resp.json()["id"]
+
+        # Grant the visitor the 'coders' role (has code-in-isolation).
+        resp = httpx.post(
+            f"{url}/api/v1/workspaces/{workspace_id}/roles/coders",
+            headers=owner["headers"],
+            json={"email": "visitor@example.com"},
+            timeout=10,
+        )
+        assert resp.status_code == 200, resp.text
+
+        owner_ws, owner_rx, owner_reader = await _connect(
+            server, owner, workspace_id
+        )
+        try:
+            # Visitor connects and starts a terminal while setup is still
+            # pending: their snapshot must NOT contain default-cmd yet.
+            vis_ws, vis_rx, vis_reader = await _connect(
+                server, visitor, workspace_id
+            )
+            try:
+                await _terminal_start(vis_ws)
+                # Wait for the visitor's first terminal_windows (no tab yet).
+                loop = asyncio.get_event_loop()
+                deadline = loop.time() + 30
+                while loop.time() < deadline:
+                    if any(
+                        m.get("type") == "terminal_windows" for m in vis_rx
+                    ):
+                        break
+                    await asyncio.sleep(0.3)
+                else:
+                    raise AssertionError(
+                        "visitor never received initial terminal_windows"
+                    )
+                # Sanity: no default-cmd tab while setup is pending.
+                assert not any(_has_default_cmd(m) for m in vis_rx), vis_rx
+
+                # Setup completes; the owner fires terminal_start, which
+                # creates the default-cmd window and fans it out.
+                httpx.put(
+                    f"{url}/api/v1/workspaces/{workspace_id}",
+                    headers=owner["headers"],
+                    json={"setup_state": "complete"},
+                    timeout=10,
+                )
+                await _terminal_start(owner_ws)
+
+                # The visitor should now receive a terminal_windows that
+                # includes the default-cmd tab -- without a manual refresh.
+                deadline = loop.time() + 45
+                while loop.time() < deadline:
+                    if any(_has_default_cmd(m) for m in vis_rx):
+                        break
+                    await asyncio.sleep(0.3)
+                else:
+                    raise AssertionError(
+                        "visitor never received the default-cmd tab; "
+                        f"saw {len(vis_rx)} messages: "
+                        f"{[m.get('type') for m in vis_rx]}"
+                    )
+                assert any(_has_default_cmd(m) for m in vis_rx)
+            finally:
+                vis_reader.cancel()
+                await vis_ws.close()
+        finally:
+            owner_reader.cancel()
+            await owner_ws.close()
+            httpx.delete(
+                f"{url}/api/v1/workspaces/{workspace_id}",
+                headers=owner["headers"],
+                timeout=30,
+            )

--- a/src/backend/klangk_backend/wshandler/controllers.py
+++ b/src/backend/klangk_backend/wshandler/controllers.py
@@ -343,6 +343,7 @@ class TerminalController:
         self._conn = conn
         self.session: TerminalSession | None = None
         self.task: asyncio.Task | None = None
+        self._default_cmd_fanout_task: asyncio.Task | None = None
         self.cols: int = 80
         self.rows: int = 24
 
@@ -389,6 +390,115 @@ class TerminalController:
         windows = await terminal.list_windows(conn.container_id, sname)
         conn._sync_terminal_windows(windows)
         conn.sock.send_json({"type": "terminal_windows", "windows": windows})
+
+    async def _on_default_command_started(self) -> None:
+        """Hook fired once the default-cmd window is running (#1114).
+
+        Announces ``default_command_started`` to this connection, then
+        fans a ``terminal_windows`` refresh out to EVERY workspace
+        subscriber (fire-and-forget). The fan-out is what actually
+        fixes the UI: the default-cmd tab is rendered from
+        ``terminal_windows``, and any client whose snapshot predates
+        the window's creation — a second browser of the owner, or a
+        visitor under a different account whose ``terminal_start``
+        fired while setup was still pending — would otherwise never
+        see the tab until a manual re-sync.
+        """
+        try:
+            self._conn.sock.send_json(
+                {
+                    "type": "default_command_started",
+                    "workspaceId": self._conn.workspace_id,
+                    "command": self._conn._default_command,
+                }
+            )
+        except _WS_ERRORS:
+            logger.debug(
+                "default_command_started: socket gone, could not emit"
+            )
+        # Best-effort, non-blocking: must not delay or break the
+        # terminal start that triggered it.
+        self._default_cmd_fanout_task = asyncio.create_task(
+            self._fanout_default_command_windows()
+        )
+
+    async def _fanout_default_command_windows(self) -> None:
+        """Refresh the window list of every workspace subscriber.
+
+        Each user has their own tmux session (named after their user
+        id). For each subscribed user who already has a session, ensure
+        that session now has the default-cmd window, then re-list and
+        send them their OWN window list — not the owner's, which would
+        clobber a visitor's interactive tabs. Users without a tmux
+        session (spectators who never sent ``terminal_start``) are
+        skipped: they have no tabs to refresh, and creating a session
+        for them would spawn a terminal they never asked for (#1114).
+        """
+        ws_session = state.get_session(self._conn.workspace_id)
+        if ws_session is None or not self._conn.container_id:
+            return
+        container_id = self._conn.container_id
+        # One refresh per distinct subscribed user (each owns one
+        # tmux session). A user may have several sockets open.
+        refreshed: set[str] = set()
+        for sock in list(ws_session.subscribers):
+            conn = state.connections.get(sock)
+            uid = conn.user.get("id") if conn is not None else None
+            if not uid or uid in refreshed:
+                continue
+            refreshed.add(uid)
+            try:
+                await self._refresh_user_terminal_windows(container_id, conn)
+            except Exception:
+                logger.exception(
+                    "default-cmd fan-out: window refresh failed for user %s",
+                    uid,
+                )
+
+    async def _refresh_user_terminal_windows(
+        self, container_id: str, conn: "Connection"
+    ) -> None:
+        """Ensure conn's session has the default-cmd window; re-list + send.
+
+        For the owner the window already exists, so ``_ensure_base_session``
+        is a no-op. For a visitor whose ``terminal_start`` predated setup
+        completion it creates the window (the predicate now holds) so the
+        tab appears for them too (#1114).
+        """
+        uid = conn.user["id"]
+        # Skip spectators without a tmux session (see docstring above).
+        if not await terminal._has_tmux_session(container_id, uid):
+            return
+        if conn._user_home and conn._default_command:
+            await terminal._ensure_base_session(
+                container_id,
+                uid,
+                user_home=conn._user_home,
+                ssh_agent_socket=conn._ssh_agent_socket,
+                default_command=conn._default_command,
+                setup_state=terminal.SETUP_STATE_COMPLETE,
+            )
+        windows = await terminal.list_windows(container_id, uid)
+        conn._sync_terminal_windows(windows)
+        self._send_terminal_windows_to_user(conn, windows)
+
+    @staticmethod
+    def _send_terminal_windows_to_user(
+        conn: "Connection", windows: list[dict]
+    ) -> None:
+        """Send ``terminal_windows`` to all of a user's connections."""
+        ws_session = state.get_session(conn.workspace_id)
+        if ws_session is None:
+            return
+        uid = conn.user["id"]
+        msg = {"type": "terminal_windows", "windows": windows}
+        for sock in list(ws_session.subscribers):
+            sc = state.connections.get(sock)
+            if sc is not None and sc.user.get("id") == uid:
+                try:
+                    sock.send_json(msg)
+                except _WS_ERRORS:
+                    pass
 
     def _send_shared_terminals(self) -> None:
         """Send the current shared terminal list to the client."""
@@ -464,21 +574,10 @@ class TerminalController:
         # ``_ensure_base_session`` (terminal.py); the background
         # auto-start path has no connection and passes no callback.
         # A closed socket here must NOT abort the terminal (the
-        # command started fine), so swallow WS errors.
-        async def _emit_default_command_started() -> None:
-            try:
-                self._conn.sock.send_json(
-                    {
-                        "type": "default_command_started",
-                        "workspaceId": self._conn.workspace_id,
-                        "command": self._conn._default_command,
-                    }
-                )
-            except _WS_ERRORS:
-                logger.debug(
-                    "default_command_started: socket gone, could not emit"
-                )
-
+        # command started fine), so swallow WS errors. The callback
+        # ALSO fans a terminal_windows refresh out to every workspace
+        # subscriber so the new default-cmd tab appears for clients
+        # whose snapshot was taken before the window existed (#1114).
         session = TerminalSession(
             self._conn.container_id,
             session_name=self._conn.user["id"],
@@ -494,7 +593,7 @@ class TerminalController:
             # holds 'complete'. A cached value would wrongly block
             # the post-setup fire (#1033).
             setup_state=await self._setup_state_for_workspace(),
-            on_default_command_started=_emit_default_command_started,
+            on_default_command_started=self._on_default_command_started,
         )
 
         browser_id = msg.get("browser_id")
@@ -815,6 +914,14 @@ class TerminalController:
             except asyncio.CancelledError:
                 pass
             self.task = None
+        fanout = self._default_cmd_fanout_task
+        if fanout is not None:
+            fanout.cancel()
+            try:
+                await fanout
+            except asyncio.CancelledError:
+                pass
+            self._default_cmd_fanout_task = None
         await self.claim_and_stop()
         # Broadcast viewer change so other users see updated viewer list
         if was_viewing and self._conn.workspace_id:

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -5742,6 +5742,218 @@ class TestTerminalController:
             wshandler.state.connections.pop(other_sock, None)
             wshandler.state.sessions.pop("ws-1", None)
 
+    # --- default-command window fan-out (#1114) ---
+
+    async def test_fanout_refreshes_second_browser_of_owner(self):
+        """A second browser of the owner (same user) gets the new tab."""
+        owner = {"id": "uid", "email": "a@x", "handle": "a"}
+        sock1 = _mock_sock()
+        sock2 = _mock_sock()
+        conn1 = _base_conn(user=owner, ws=sock1)
+        conn2 = _base_conn(user=owner, ws=sock2)
+        for c in (conn1, conn2):
+            c.workspace_id = "ws-fanout"
+            c.container_id = "cid"
+            c._user_home = "/home/a"
+            c._default_command = "openclaw gateway"
+        ws_session = wshandler.state.get_or_create_session("ws-fanout")
+        await ws_session.add_subscriber(sock1, "cid")
+        await ws_session.add_subscriber(sock2, "cid")
+        wshandler.state.connections[sock1] = conn1
+        wshandler.state.connections[sock2] = conn2
+        windows = [
+            {"id": "@0", "index": 0, "name": "bash", "active": False},
+            {"id": "@1", "index": 1, "name": "default-cmd", "active": True},
+        ]
+        try:
+            with (
+                patch(
+                    "klangk_backend.wshandler.controllers.terminal."
+                    "_has_tmux_session",
+                    new=AsyncMock(return_value=True),
+                ),
+                patch(
+                    "klangk_backend.wshandler.controllers.terminal."
+                    "_ensure_base_session",
+                    new=AsyncMock(),
+                ),
+                patch(
+                    "klangk_backend.wshandler.controllers.terminal."
+                    "list_windows",
+                    new=AsyncMock(return_value=windows),
+                ),
+            ):
+                await conn1.terminal._fanout_default_command_windows()
+            # Both of the owner's connections receive the updated list.
+            for sock in (sock1, sock2):
+                sent = [c[0][0] for c in sock.send_json.call_args_list]
+                assert any(
+                    isinstance(m, dict)
+                    and m.get("type") == "terminal_windows"
+                    and any(w["name"] == "default-cmd" for w in m["windows"])
+                    for m in sent
+                )
+        finally:
+            await ws_session.remove_subscriber(sock1)
+            await ws_session.remove_subscriber(sock2)
+            wshandler.state.connections.pop(sock1, None)
+            wshandler.state.connections.pop(sock2, None)
+            wshandler.state.sessions.pop("ws-fanout", None)
+
+    async def test_fanout_creates_default_cmd_for_different_user_visitor(self):
+        """A visitor under a different account gets the tab too.
+
+        Their own tmux session lacks the default-cmd window (their
+        terminal_start predated setup completion), so the fan-out must
+        create it in their session before re-listing (#1114).
+        """
+        owner = {"id": "owner-uid", "email": "a@x", "handle": "a"}
+        visitor = {"id": "visitor-uid", "email": "b@x", "handle": "b"}
+        owner_sock = _mock_sock()
+        vis_sock = _mock_sock()
+        owner_conn = _base_conn(user=owner, ws=owner_sock)
+        vis_conn = _base_conn(user=visitor, ws=vis_sock)
+        for c in (owner_conn, vis_conn):
+            c.workspace_id = "ws-vis"
+            c.container_id = "cid"
+            c._user_home = "/home/x"
+            c._default_command = "openclaw gateway"
+        ws_session = wshandler.state.get_or_create_session("ws-vis")
+        await ws_session.add_subscriber(owner_sock, "cid")
+        await ws_session.add_subscriber(vis_sock, "cid")
+        wshandler.state.connections[owner_sock] = owner_conn
+        wshandler.state.connections[vis_sock] = vis_conn
+        windows = [
+            {"id": "@1", "index": 1, "name": "default-cmd", "active": True}
+        ]
+        try:
+            with (
+                patch(
+                    "klangk_backend.wshandler.controllers.terminal."
+                    "_has_tmux_session",
+                    new=AsyncMock(return_value=True),
+                ),
+                patch(
+                    "klangk_backend.wshandler.controllers.terminal."
+                    "_ensure_base_session",
+                    new=AsyncMock(),
+                ) as ensure,
+                patch(
+                    "klangk_backend.wshandler.controllers.terminal."
+                    "list_windows",
+                    new=AsyncMock(return_value=windows),
+                ),
+            ):
+                await owner_conn.terminal._fanout_default_command_windows()
+            # _ensure_base_session fired for the visitor's session.
+            session_args = [c.args[1] for c in ensure.call_args_list]
+            assert "visitor-uid" in session_args
+            # The visitor's socket received the default-cmd tab.
+            sent = [c[0][0] for c in vis_sock.send_json.call_args_list]
+            assert any(
+                isinstance(m, dict)
+                and m.get("type") == "terminal_windows"
+                and any(w["name"] == "default-cmd" for w in m["windows"])
+                for m in sent
+            )
+        finally:
+            await ws_session.remove_subscriber(owner_sock)
+            await ws_session.remove_subscriber(vis_sock)
+            wshandler.state.connections.pop(owner_sock, None)
+            wshandler.state.connections.pop(vis_sock, None)
+            wshandler.state.sessions.pop("ws-vis", None)
+
+    async def test_fanout_skips_spectator_without_tmux_session(self):
+        """A subscriber who never started a terminal is left alone.
+
+        They have no tmux session and no tabs; creating one for them
+        would spawn a terminal they never asked for (#1114).
+        """
+        owner = {"id": "uid", "email": "a@x", "handle": "a"}
+        spec = {"id": "spec-uid", "email": "s@x", "handle": "s"}
+        owner_sock = _mock_sock()
+        spec_sock = _mock_sock()
+        owner_conn = _base_conn(user=owner, ws=owner_sock)
+        spec_conn = _base_conn(user=spec, ws=spec_sock)
+        for c in (owner_conn, spec_conn):
+            c.workspace_id = "ws-spec"
+            c.container_id = "cid"
+            c._user_home = "/home/x"
+            c._default_command = "openclaw gateway"
+        ws_session = wshandler.state.get_or_create_session("ws-spec")
+        await ws_session.add_subscriber(owner_sock, "cid")
+        await ws_session.add_subscriber(spec_sock, "cid")
+        wshandler.state.connections[owner_sock] = owner_conn
+        wshandler.state.connections[spec_sock] = spec_conn
+        # Owner has a session; spectator does not.
+        has_session = AsyncMock(side_effect=lambda cid, sn: sn == "uid")
+        try:
+            with (
+                patch(
+                    "klangk_backend.wshandler.controllers.terminal."
+                    "_has_tmux_session",
+                    new=has_session,
+                ),
+                patch(
+                    "klangk_backend.wshandler.controllers.terminal."
+                    "_ensure_base_session",
+                    new=AsyncMock(),
+                ) as ensure,
+                patch(
+                    "klangk_backend.wshandler.controllers.terminal."
+                    "list_windows",
+                    new=AsyncMock(
+                        return_value=[
+                            {
+                                "id": "@1",
+                                "index": 1,
+                                "name": "default-cmd",
+                                "active": True,
+                            }
+                        ]
+                    ),
+                ),
+            ):
+                await owner_conn.terminal._fanout_default_command_windows()
+            # _ensure_base_session called only for the owner, not the
+            # spectator.
+            session_args = [c.args[1] for c in ensure.call_args_list]
+            assert session_args == ["uid"]
+            # Spectator received no terminal_windows.
+            spec_sent = [c[0][0] for c in spec_sock.send_json.call_args_list]
+            assert not any(
+                isinstance(m, dict) and m.get("type") == "terminal_windows"
+                for m in spec_sent
+            )
+        finally:
+            await ws_session.remove_subscriber(owner_sock)
+            await ws_session.remove_subscriber(spec_sock)
+            wshandler.state.connections.pop(owner_sock, None)
+            wshandler.state.connections.pop(spec_sock, None)
+            wshandler.state.sessions.pop("ws-spec", None)
+
+    async def test_on_default_command_started_emits_event_and_task(self):
+        """The callback announces the event to self and schedules fan-out."""
+        ctrl, sock, conn = self._controller()
+        conn.workspace_id = "ws-cb"
+        conn._default_command = "openclaw gateway"
+        with patch.object(
+            ctrl, "_fanout_default_command_windows", new=AsyncMock()
+        ) as fanout:
+            await ctrl._on_default_command_started()
+            # The fan-out runs in a fire-and-forget task; let it run.
+            if ctrl._default_cmd_fanout_task is not None:
+                await ctrl._default_cmd_fanout_task
+        sent = [c[0][0] for c in sock.send_json.call_args_list]
+        assert any(
+            isinstance(m, dict)
+            and m.get("type") == "default_command_started"
+            and m.get("command") == "openclaw gateway"
+            for m in sent
+        )
+        # The fan-out task was created and ran to completion.
+        assert fanout.await_count == 1
+
     # --- browser_reattach ---
 
     async def test_browser_reattach_no_browser_id(self):


### PR DESCRIPTION
## Summary

Fixes #1114.

A visitor who opened an auto-started workspace **while setup was still
running** missed the `default-cmd` tab forever. Their tab snapshot was
taken before the window existed, and its later creation was announced
only to the owning connection — `default_command_started` to
`self._conn.sock`, with no `terminal_windows` fan-out. And even the
existing fan-out (`notify_user_terminal_windows`) was filtered to the
owner's `user_id`, so a visitor under a different account was excluded
anyway.

## The fix

When the `default-cmd` window is created, refresh **every** workspace
subscriber's tab list (`wshandler/controllers.py`):

- `on_default_command_started` (the hook fired once the window exists)
  now sends `default_command_started` to self **and** schedules a
  fire-and-forget `_fanout_default_command_windows()`.
- The fan-out iterates all workspace subscribers. Each user has their
  own tmux session (named after their user id), so for each subscribed
  user who already has a session it:
  - ensures that session now has the `default-cmd` window (creating it
    for a visitor whose `terminal_start` predated setup completion;
    no-op for the owner), then
  - re-lists and sends them **their own** window list — not the owner's,
    which would clobber a visitor's interactive tabs.
- Spectators without a tmux session (never sent `terminal_start`) are
  skipped — they have no tabs to refresh, and creating a session for
  them would spawn a terminal they never asked for.
- The fan-out runs fire-and-forget so it never delays or breaks the
  triggering terminal start, and is cancelled on `stop()`.

This mirrors the `service_health` fan-out fix from #1015 (an event that
should reach every connected client was only sent to the originator).

## Tests

- **Unit** (`test_wshandler.py`):
  - same-user second browser receives the new tab
  - cross-user visitor: `_ensure_base_session` fires for the visitor's
    session and they receive the tab
  - spectator without a tmux session is skipped (no session spawned)
  - the callback emits `default_command_started` and schedules the fan-out
- **Backend e2e** (`test_default_command_fanout_e2e.py`, new): reproduces
  the race against a real server + container. A different-account visitor
  (granted the `coders` role) starts a terminal while `setup_state` is
  `pending` (snapshot omits `default-cmd`); setup completes and the owner
  fires the command; the visitor receives the `default-cmd` tab in their
  own session with **no manual refresh**.

### Test results
- Backend unit: **1976 passed**
- New unit tests: **6 passed**
- Backend e2e (new): **1 passed** (~18s)
- `ruff check` + `ruff format`: clean; all pre-commit hooks passed.

## Acceptance criteria (from #1114)

- [x] A visitor connecting in the window before `default-cmd` exists
      receives the tab once it is created, without a manual refresh.
- [x] The fix covers visitors under a **different** user account (the
      e2e test uses a separate registered user on the `coders` role).

## Docs

`docs/features/default-command.md` updated: clarifies the command runs
in a dedicated `default-cmd` tab (not window 0), and that the tab is
surfaced to every connected client once it exists — including a visitor
who opened the workspace during setup.