### PR TITLE
Web UI: expose Auto start checkbox + normalize workspace dialog fields

### DIFF
--- a/src/backend/klangk_backend/api/__init__.py
+++ b/src/backend/klangk_backend/api/__init__.py
@@ -54,7 +54,7 @@ from .. import (
 # name to the logic module after the submodule imports (see below) so the
 # instance endpoints reference klangk_backend.auth, not the route module.
 from .. import auth as _auth_logic
-from ..util import resolve_env_value
+from ..util import resolve_env_bool, resolve_env_value
 
 # Route submodules, aliased because their names collide with the logic
 # modules imported above (api/auth.py vs klangk_backend.auth, etc.) and we
@@ -184,6 +184,10 @@ async def get_config():
         "oidc_providers": oidc.list_providers(),
         "auth_modes": oidc.auth_modes(),
         "instance_id": container.INSTANCE_ID,
+        # Whether per-workspace auto-start (start the container on server
+        # boot) is permitted. The web UI gates its "Auto start" checkbox on
+        # this so users can't toggle a setting the server will reject (#1115).
+        "allow_autostart": resolve_env_bool("KLANGK_ALLOW_AUTOSTART"),
     }
     config.update(plugins.frontend_config())
     return config

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -6761,6 +6761,20 @@ class TestInvitations:
         assert resp.status_code == 200
         assert "invitations_enabled" in resp.json()
 
+    async def test_config_advertises_allow_autostart(
+        self, client, monkeypatch
+    ):
+        # Default: flag unset -> not allowed, so the UI hides its checkbox.
+        monkeypatch.delenv("KLANGK_ALLOW_AUTOSTART", raising=False)
+        resp = await client.get("/api/v1/config")
+        assert resp.status_code == 200
+        assert resp.json()["allow_autostart"] is False
+
+        # Flag set -> advertised as true so the UI may show the checkbox.
+        monkeypatch.setenv("KLANGK_ALLOW_AUTOSTART", "1")
+        resp = await client.get("/api/v1/config")
+        assert resp.json()["allow_autostart"] is True
+
 
 # --- OIDC endpoints ---
 

--- a/src/frontend/lib/auth/auth_service.dart
+++ b/src/frontend/lib/auth/auth_service.dart
@@ -22,6 +22,7 @@ class AuthService extends ChangeNotifier {
   String _bannerText = '';
   bool _bannerAccepted = false;
   String _instanceId = 'default';
+  bool _allowAutostart = false;
   Timer? _permissionTimer;
   Timer? _refreshTimer;
 
@@ -34,6 +35,12 @@ class AuthService extends ChangeNotifier {
   bool get bannerAccepted => _bannerAccepted;
   bool get bannerRequired => _bannerText.isNotEmpty && !_bannerAccepted;
   String get instanceId => _instanceId;
+
+  /// Whether the server permits per-workspace auto-start
+  /// (KLANGK_ALLOW_AUTOSTART). The UI gates its "Auto start" checkbox
+  /// on this — setting auto_start on a server that rejects it would
+  /// 400 (#1115).
+  bool get allowAutostart => _allowAutostart;
 
   /// Decode the JWT payload.
   Map<String, dynamic>? get _payload {
@@ -90,6 +97,7 @@ class AuthService extends ChangeNotifier {
         _bannerTitle = (data['login_banner_title'] as String?) ?? '';
         _bannerText = (data['login_banner'] as String?) ?? '';
         _instanceId = (data['instance_id'] as String?) ?? 'default';
+        _allowAutostart = (data['allow_autostart'] as bool?) ?? false;
       }
     } catch (e) {
       // coverage:ignore-start

--- a/src/frontend/lib/workspace/create_workspace_dialog.dart
+++ b/src/frontend/lib/workspace/create_workspace_dialog.dart
@@ -5,18 +5,26 @@ import '../auth/auth_service.dart';
 import '../theme/colors.dart';
 import 'workspace_list_page.dart' show validateMountSpec;
 
-/// Dialog for creating a new workspace with name, image, command,
-/// mounts, and environment variables.
+/// Dialog for creating a new workspace. Fields, top to bottom:
+/// Name, Mounts, Environment Variables, Default shell command, Health
+/// check command, Container Image, and (when the server permits
+/// auto-start) an Auto start checkbox. The same field set and order is
+/// used by the Workspace Configuration card in the settings panel.
 class CreateWorkspaceDialog extends StatefulWidget {
   final AuthService auth;
   final String defaultImage;
   final List<String> allowedImages;
+
+  /// Whether to render the Auto start checkbox. The caller derives this
+  /// from AuthService.allowAutostart (server's KLANGK_ALLOW_AUTOSTART).
+  final bool allowAutostart;
 
   const CreateWorkspaceDialog({
     super.key,
     required this.auth,
     required this.defaultImage,
     required this.allowedImages,
+    this.allowAutostart = false,
   });
 
   @override
@@ -32,6 +40,7 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
   late String _selectedImage;
   final _mounts = <String>[];
   final _envVars = <String, String>{};
+  bool _autoStart = false;
   String? _errorMessage;
   String? _mountError;
   String? _envError;
@@ -111,6 +120,9 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
     if (_envVars.isNotEmpty) {
       body['env'] = Map<String, String>.from(_envVars);
     }
+    if (widget.allowAutostart && _autoStart) {
+      body['auto_start'] = true;
+    }
 
     try {
       final response = await widget.auth.authPost(
@@ -164,6 +176,34 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
                 autofocus: true,
                 onSubmitted: (_) => _submit(),
               ),
+              ..._buildMountsEditor(),
+              ..._buildEnvVarsEditor(),
+              const SizedBox(height: 16),
+              TextField(
+                controller: _cmdController,
+                decoration: InputDecoration(
+                  labelText: 'Default Shell Command',
+                  labelStyle: _labelStyle,
+                  floatingLabelStyle: _labelStyle,
+                  floatingLabelBehavior: FloatingLabelBehavior.always,
+                  border: const OutlineInputBorder(),
+                  hintText: 'Optional — runs on terminal open',
+                ),
+                onSubmitted: (_) => _submit(),
+              ),
+              const SizedBox(height: 16),
+              TextField(
+                controller: _healthCheckController,
+                decoration: InputDecoration(
+                  labelText: 'Health Check Command',
+                  labelStyle: _labelStyle,
+                  floatingLabelStyle: _labelStyle,
+                  floatingLabelBehavior: FloatingLabelBehavior.always,
+                  border: const OutlineInputBorder(),
+                  hintText: 'Optional — polled to gauge service health',
+                ),
+                onSubmitted: (_) => _submit(),
+              ),
               const SizedBox(height: 16),
               DropdownButtonFormField<String>(
                 value: _selectedImage,
@@ -182,33 +222,19 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
                 onChanged: (v) =>
                     setState(() => _selectedImage = v ?? widget.defaultImage),
               ),
-              const SizedBox(height: 16),
-              TextField(
-                controller: _cmdController,
-                decoration: InputDecoration(
-                  labelText: 'Default shell command (optional)',
-                  labelStyle: _labelStyle,
-                  floatingLabelStyle: _labelStyle,
-                  floatingLabelBehavior: FloatingLabelBehavior.always,
-                  border: const OutlineInputBorder(),
+              if (widget.allowAutostart) ...[
+                const SizedBox(height: 8),
+                CheckboxListTile(
+                  value: _autoStart,
+                  onChanged: (v) => setState(() => _autoStart = v ?? false),
+                  title: const Text('Auto start'),
+                  subtitle: const Text(
+                    'Start this workspace when the server starts',
+                  ),
+                  controlAffinity: ListTileControlAffinity.leading,
+                  contentPadding: EdgeInsets.zero,
                 ),
-                onSubmitted: (_) => _submit(),
-              ),
-              ..._buildMountsEditor(),
-              ..._buildEnvVarsEditor(),
-              const SizedBox(height: 16),
-              TextField(
-                controller: _healthCheckController,
-                decoration: InputDecoration(
-                  labelText: 'Health check command (optional)',
-                  labelStyle: _labelStyle,
-                  floatingLabelStyle: _labelStyle,
-                  floatingLabelBehavior: FloatingLabelBehavior.always,
-                  border: const OutlineInputBorder(),
-                  hintText: 'e.g. curl -sf http://localhost:8080/health',
-                ),
-                onSubmitted: (_) => _submit(),
-              ),
+              ],
             ],
           ),
         ),

--- a/src/frontend/lib/workspace/workspace_list_page.dart
+++ b/src/frontend/lib/workspace/workspace_list_page.dart
@@ -344,6 +344,7 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
         auth: _auth,
         defaultImage: defaultImage,
         allowedImages: allowedImages,
+        allowAutostart: _auth.allowAutostart,
       ),
     );
 

--- a/src/frontend/lib/workspace/workspace_settings_panel.dart
+++ b/src/frontend/lib/workspace/workspace_settings_panel.dart
@@ -131,6 +131,8 @@ class WorkspaceSettingsPanelState extends State<WorkspaceSettingsPanel> {
       workspace: _workspace!,
       allowedImages: _allowedImages,
       defaultImage: _defaultImage,
+      allowAutostart:
+          context.select<AuthService, bool>((a) => a.allowAutostart),
       saveMessage: _saveMessage,
       onSave: _saveSettings,
     );
@@ -142,6 +144,7 @@ class _SettingsForm extends StatefulWidget {
   final Map<String, dynamic> workspace;
   final List<String> allowedImages;
   final String defaultImage;
+  final bool allowAutostart;
   final String? saveMessage;
   final Future<void> Function(Map<String, dynamic>) onSave;
 
@@ -150,6 +153,7 @@ class _SettingsForm extends StatefulWidget {
     required this.workspace,
     required this.allowedImages,
     required this.defaultImage,
+    required this.allowAutostart,
     required this.saveMessage,
     required this.onSave,
   });
@@ -167,6 +171,7 @@ class _SettingsFormState extends State<_SettingsForm> {
   late String _selectedImage;
   late List<String> _mounts;
   late Map<String, String> _envVars;
+  bool _autoStart = false;
   String? _mountError;
   String? _envError;
   bool _saving = false;
@@ -196,6 +201,7 @@ class _SettingsFormState extends State<_SettingsForm> {
       (widget.workspace['env'] as Map?)?.cast<String, String>() ??
           <String, String>{},
     );
+    _autoStart = (widget.workspace['auto_start'] as bool?) ?? false;
   }
 
   @override
@@ -214,6 +220,10 @@ class _SettingsFormState extends State<_SettingsForm> {
     if (old.workspace['health_check'] != widget.workspace['health_check']) {
       // coverage:ignore-start
       _healthCheckCtrl.text = widget.workspace['health_check'] as String? ?? '';
+    } // coverage:ignore-end
+    if (old.workspace['auto_start'] != widget.workspace['auto_start']) {
+      // coverage:ignore-start
+      _autoStart = (widget.workspace['auto_start'] as bool?) ?? false;
     } // coverage:ignore-end
   }
 
@@ -239,6 +249,7 @@ class _SettingsFormState extends State<_SettingsForm> {
           : _healthCheckCtrl.text.trim(),
       'mounts': _mounts.isNotEmpty ? _mounts : null,
       'env': _envVars.isNotEmpty ? _envVars : null,
+      if (widget.allowAutostart) 'auto_start': _autoStart,
     });
     if (mounted) setState(() => _saving = false);
   }
@@ -367,28 +378,16 @@ class _SettingsFormState extends State<_SettingsForm> {
         TextField(
           controller: _nameCtrl,
           decoration: InputDecoration(
-            labelText: 'Workspace Name',
+            labelText: 'Name',
             labelStyle: labelStyle,
             floatingLabelBehavior: FloatingLabelBehavior.always,
             border: const OutlineInputBorder(),
           ),
         ),
         const SizedBox(height: 16),
-        if (widget.allowedImages.isNotEmpty)
-          DropdownButtonFormField<String>(
-            value: _selectedImage,
-            decoration: InputDecoration(
-              labelText: 'Container Image',
-              labelStyle: labelStyle,
-              floatingLabelBehavior: FloatingLabelBehavior.always,
-              border: const OutlineInputBorder(),
-            ),
-            items: widget.allowedImages
-                .map((img) => DropdownMenuItem(value: img, child: Text(img)))
-                .toList(),
-            onChanged: (v) =>
-                setState(() => _selectedImage = v ?? widget.defaultImage),
-          ),
+        _buildMountsEditor(labelStyle),
+        const SizedBox(height: 16),
+        _buildEnvVarsEditor(labelStyle),
         const SizedBox(height: 16),
         TextField(
           controller: _cmdCtrl,
@@ -412,9 +411,34 @@ class _SettingsFormState extends State<_SettingsForm> {
           ),
         ),
         const SizedBox(height: 16),
-        _buildMountsEditor(labelStyle),
-        const SizedBox(height: 16),
-        _buildEnvVarsEditor(labelStyle),
+        if (widget.allowedImages.isNotEmpty)
+          DropdownButtonFormField<String>(
+            value: _selectedImage,
+            decoration: InputDecoration(
+              labelText: 'Container Image',
+              labelStyle: labelStyle,
+              floatingLabelBehavior: FloatingLabelBehavior.always,
+              border: const OutlineInputBorder(),
+            ),
+            items: widget.allowedImages
+                .map((img) => DropdownMenuItem(value: img, child: Text(img)))
+                .toList(),
+            onChanged: (v) =>
+                setState(() => _selectedImage = v ?? widget.defaultImage),
+          ),
+        if (widget.allowAutostart) ...[
+          const SizedBox(height: 8),
+          CheckboxListTile(
+            value: _autoStart,
+            onChanged: (v) => setState(() => _autoStart = v ?? false),
+            title: const Text('Auto start'),
+            subtitle: const Text(
+              'Start this workspace when the server starts',
+            ),
+            controlAffinity: ListTileControlAffinity.leading,
+            contentPadding: EdgeInsets.zero,
+          ),
+        ],
         const SizedBox(height: 16),
         Align(
           alignment: Alignment.centerRight,

--- a/src/frontend/lib/workspace/workspace_settings_panel.dart
+++ b/src/frontend/lib/workspace/workspace_settings_panel.dart
@@ -428,15 +428,21 @@ class _SettingsFormState extends State<_SettingsForm> {
           ),
         if (widget.allowAutostart) ...[
           const SizedBox(height: 8),
-          CheckboxListTile(
-            value: _autoStart,
-            onChanged: (v) => setState(() => _autoStart = v ?? false),
-            title: const Text('Auto start'),
-            subtitle: const Text(
-              'Start this workspace when the server starts',
+          // Wrap in a transparent Material so the CheckboxListTile's ink
+          // splash paints above this card's opaque background surface
+          // (the _card() Container would otherwise hide it).
+          Material(
+            type: MaterialType.transparency,
+            child: CheckboxListTile(
+              value: _autoStart,
+              onChanged: (v) => setState(() => _autoStart = v ?? false),
+              title: const Text('Auto start'),
+              subtitle: const Text(
+                'Start this workspace when the server starts',
+              ),
+              controlAffinity: ListTileControlAffinity.leading,
+              contentPadding: EdgeInsets.zero,
             ),
-            controlAffinity: ListTileControlAffinity.leading,
-            contentPadding: EdgeInsets.zero,
           ),
         ],
         const SizedBox(height: 16),

--- a/src/frontend/test/auth_service_test.dart
+++ b/src/frontend/test/auth_service_test.dart
@@ -82,6 +82,7 @@ void main() {
       String bannerTitle = '',
       String bannerText = '',
       String instanceId = 'default',
+      bool allowAutostart = false,
     }) {
       return MockClient((request) async {
         if (request.url.path.contains('/api/v1/config')) {
@@ -90,6 +91,7 @@ void main() {
               'login_banner_title': bannerTitle,
               'login_banner': bannerText,
               'instance_id': instanceId,
+              'allow_autostart': allowAutostart,
             }),
             200,
           );
@@ -120,6 +122,20 @@ void main() {
       await Future.delayed(Duration.zero);
 
       expect(service.instanceId, 'prod');
+    });
+
+    test('loads allow_autostart from /api/config', () async {
+      // Defaults to false when the flag is absent.
+      testAuthHttpClientOverride = _bannerClient();
+      final service = AuthService();
+      await Future.delayed(Duration.zero);
+      expect(service.allowAutostart, isFalse);
+
+      // Set when the server advertises it.
+      testAuthHttpClientOverride = _bannerClient(allowAutostart: true);
+      final service2 = AuthService();
+      await Future.delayed(Duration.zero);
+      expect(service2.allowAutostart, isTrue);
     });
 
     test('bannerRequired is false when no banner text', () async {

--- a/src/frontend/test/create_workspace_dialog_test.dart
+++ b/src/frontend/test/create_workspace_dialog_test.dart
@@ -47,6 +47,7 @@ void main() {
     AuthService? auth,
     String defaultImage = 'klangk-pi',
     List<String>? allowedImages,
+    bool allowAutostart = false,
   }) {
     final a = auth ?? AuthService();
     return MaterialApp(
@@ -61,6 +62,7 @@ void main() {
                   auth: a,
                   defaultImage: defaultImage,
                   allowedImages: allowedImages ?? [defaultImage, 'klangk-full'],
+                  allowAutostart: allowAutostart,
                 ),
               );
             });
@@ -149,8 +151,7 @@ void main() {
       await tester.enterText(find.byType(TextField).first, 'My WS');
       final healthCheckField = find.byWidgetPredicate(
         (w) =>
-            w is TextField &&
-            w.decoration?.labelText == 'Health check command (optional)',
+            w is TextField && w.decoration?.labelText == 'Health Check Command',
       );
       await tester.ensureVisible(healthCheckField);
       await tester.enterText(
@@ -200,7 +201,7 @@ void main() {
       await tester.pump(); // dialog renders
 
       // 3rd TextField is mount input
-      await tester.enterText(find.byType(TextField).at(2), '/host:/container');
+      await tester.enterText(find.byType(TextField).at(1), '/host:/container');
       await tester.tap(find.byIcon(Icons.add).first);
       await tester.pump();
 
@@ -215,7 +216,7 @@ void main() {
       await tester.pump(); // post-frame callback
       await tester.pump(); // dialog renders
 
-      await tester.enterText(find.byType(TextField).at(2), 'invalid');
+      await tester.enterText(find.byType(TextField).at(1), 'invalid');
       await tester.tap(find.byIcon(Icons.add).first);
       await tester.pump();
 
@@ -230,7 +231,7 @@ void main() {
       await tester.pump(); // post-frame callback
       await tester.pump(); // dialog renders
 
-      await tester.enterText(find.byType(TextField).at(2), '/a:/b');
+      await tester.enterText(find.byType(TextField).at(1), '/a:/b');
       await tester.tap(find.byIcon(Icons.add).first);
       await tester.pump();
       expect(find.text('/a:/b'), findsOneWidget);
@@ -249,7 +250,7 @@ void main() {
       await tester.pump(); // dialog renders
 
       // 4th TextField is env input
-      await tester.enterText(find.byType(TextField).at(3), 'FOO=bar');
+      await tester.enterText(find.byType(TextField).at(2), 'FOO=bar');
       await tester.ensureVisible(find.byIcon(Icons.add).at(1));
       await tester.tap(find.byIcon(Icons.add).at(1));
       await tester.pump();
@@ -265,7 +266,7 @@ void main() {
       await tester.pump(); // post-frame callback
       await tester.pump(); // dialog renders
 
-      await tester.enterText(find.byType(TextField).at(3), 'NOEQUALS');
+      await tester.enterText(find.byType(TextField).at(2), 'NOEQUALS');
       await tester.ensureVisible(find.byIcon(Icons.add).at(1));
       await tester.tap(find.byIcon(Icons.add).at(1));
       await tester.pump();
@@ -281,7 +282,7 @@ void main() {
       await tester.pump(); // post-frame callback
       await tester.pump(); // dialog renders
 
-      await tester.enterText(find.byType(TextField).at(3), '=value');
+      await tester.enterText(find.byType(TextField).at(2), '=value');
       await tester.ensureVisible(find.byIcon(Icons.add).at(1));
       await tester.tap(find.byIcon(Icons.add).at(1));
       await tester.pump();
@@ -297,7 +298,7 @@ void main() {
       await tester.pump(); // post-frame callback
       await tester.pump(); // dialog renders
 
-      await tester.enterText(find.byType(TextField).at(3), 'MYKEY=val');
+      await tester.enterText(find.byType(TextField).at(2), 'MYKEY=val');
       await tester.ensureVisible(find.byIcon(Icons.add).at(1));
       await tester.tap(find.byIcon(Icons.add).at(1));
       await tester.pumpAndSettle();
@@ -316,7 +317,7 @@ void main() {
       await tester.pump(); // post-frame callback
       await tester.pump(); // dialog renders
 
-      await tester.enterText(find.byType(TextField).at(2), '/a:/b');
+      await tester.enterText(find.byType(TextField).at(1), '/a:/b');
       await tester.testTextInput.receiveAction(TextInputAction.done);
       await tester.pump();
 
@@ -339,7 +340,9 @@ void main() {
       await tester.pump(); // post-frame callback
       await tester.pump(); // dialog renders
 
-      // Open dropdown and select non-default
+      // Open dropdown and select non-default (now near the dialog's
+      // bottom after the field reordering, so scroll it into view first).
+      await tester.ensureVisible(find.byType(DropdownButtonFormField<String>));
       await tester.tap(find.byType(DropdownButtonFormField<String>));
       await tester.pumpAndSettle();
       await tester.tap(find.text('klangk-full').last);
@@ -386,13 +389,13 @@ void main() {
       await tester.pump(); // dialog renders
 
       // First: invalid mount to trigger error
-      await tester.enterText(find.byType(TextField).at(2), 'bad');
+      await tester.enterText(find.byType(TextField).at(1), 'bad');
       await tester.tap(find.byIcon(Icons.add).first);
       await tester.pump();
       expect(find.textContaining('Expected'), findsOneWidget);
 
       // Then: valid mount clears error
-      await tester.enterText(find.byType(TextField).at(2), '/a:/b');
+      await tester.enterText(find.byType(TextField).at(1), '/a:/b');
       await tester.tap(find.byIcon(Icons.add).first);
       await tester.pump();
       expect(find.textContaining('Expected'), findsNothing);
@@ -421,6 +424,81 @@ void main() {
       await tester.tap(find.byIcon(Icons.add).at(1));
       await tester.pumpAndSettle();
       expect(find.text('Expected KEY=VALUE format'), findsNothing);
+    });
+
+    testWidgets('hides auto-start checkbox when not allowed', (tester) async {
+      testAuthHttpClientOverride = mockClient(
+        (_) async => http.Response('Not found', 404),
+      );
+      await tester.pumpWidget(buildDialog()); // allowAutostart defaults false
+      await tester.pump(); // post-frame callback
+      await tester.pump(); // dialog renders
+
+      expect(find.text('Auto start'), findsNothing);
+      expect(find.byType(Checkbox), findsNothing);
+    });
+
+    testWidgets('shows auto-start checkbox and sends auto_start when allowed',
+        (tester) async {
+      Map<String, dynamic>? postedBody;
+      testAuthHttpClientOverride = mockClient((request) async {
+        if (request.url.path == '/api/v1/workspaces' &&
+            request.method == 'POST') {
+          postedBody = jsonDecode(request.body) as Map<String, dynamic>;
+          return http.Response(
+            jsonEncode({'id': 'ws-1', 'name': 'Auto', 'created_at': ''}),
+            200,
+          );
+        }
+        return http.Response('Not found', 404);
+      });
+      await tester.pumpWidget(buildDialog(allowAutostart: true));
+      await tester.pump(); // post-frame callback
+      await tester.pump(); // dialog renders
+
+      expect(find.text('Auto start'), findsOneWidget);
+      // Toggle the checkbox on, then submit (checkbox is at the bottom of
+      // the dialog, so ensure it's visible before tapping).
+      final checkbox = find.byType(Checkbox);
+      await tester.ensureVisible(checkbox);
+      await tester.tap(checkbox);
+      await tester.pump();
+      await tester.enterText(find.byType(TextField).first, 'Auto');
+      await tester.tap(find.text('Create'));
+      await tester.pump();
+      await tester.pump();
+
+      expect(postedBody, isNotNull);
+      expect(postedBody!['auto_start'], true);
+    });
+
+    testWidgets('does not send auto_start when checkbox is left off',
+        (tester) async {
+      Map<String, dynamic>? postedBody;
+      testAuthHttpClientOverride = mockClient((request) async {
+        if (request.url.path == '/api/v1/workspaces' &&
+            request.method == 'POST') {
+          postedBody = jsonDecode(request.body) as Map<String, dynamic>;
+          return http.Response(
+            jsonEncode({'id': 'ws-1', 'name': 'Auto', 'created_at': ''}),
+            200,
+          );
+        }
+        return http.Response('Not found', 404);
+      });
+      await tester.pumpWidget(buildDialog(allowAutostart: true));
+      await tester.pump(); // post-frame callback
+      await tester.pump(); // dialog renders
+
+      // Checkbox is present but unchecked.
+      expect(find.byType(Checkbox), findsOneWidget);
+      await tester.enterText(find.byType(TextField).first, 'Auto');
+      await tester.tap(find.text('Create'));
+      await tester.pump();
+      await tester.pump();
+
+      expect(postedBody, isNotNull);
+      expect(postedBody!.containsKey('auto_start'), isFalse);
     });
   });
 }

--- a/src/frontend/test/workspace_list_page_test.dart
+++ b/src/frontend/test/workspace_list_page_test.dart
@@ -1454,7 +1454,9 @@ void main() {
       // Dropdown should show the default image (logo also contains 'klangk')
       expect(find.text('klangk'), findsWidgets);
 
-      // Select non-default image
+      // Select non-default image (dropdown is near the dialog's bottom
+      // after the field reorder, so scroll it into view first).
+      await tester.ensureVisible(find.byType(DropdownButtonFormField<String>));
       await tester.tap(find.byType(DropdownButtonFormField<String>));
       await tester.pumpAndSettle();
       await tester.tap(find.text('klangk-custom').last);
@@ -1519,7 +1521,7 @@ void main() {
               .descendant(
                   of: find.byType(AlertDialog),
                   matching: find.byType(TextField))
-              .at(1),
+              .at(3),
           'klangk-pi');
       await tester.tap(find.text('Create'));
       await tester.pumpAndSettle();
@@ -1586,7 +1588,7 @@ void main() {
               .descendant(
                   of: find.byType(AlertDialog),
                   matching: find.byType(TextField))
-              .at(1),
+              .at(3),
           'pi');
       await tester.testTextInput.receiveAction(TextInputAction.done);
       await tester.pumpAndSettle();
@@ -1897,7 +1899,7 @@ void main() {
               .descendant(
                   of: find.byType(AlertDialog),
                   matching: find.byType(TextField))
-              .at(2),
+              .at(1),
           '/host/src:/work/src');
       // Tap the add (+) button next to the mount input
       // The FAB also has an add icon, so find the one inside the dialog
@@ -1915,7 +1917,7 @@ void main() {
               .descendant(
                   of: find.byType(AlertDialog),
                   matching: find.byType(TextField))
-              .at(2),
+              .at(1),
           'nix-vol:/nix');
       await tester.tap(find.byIcon(Icons.add).at(1));
       await tester.pumpAndSettle();
@@ -1979,7 +1981,7 @@ void main() {
               .descendant(
                   of: find.byType(AlertDialog),
                   matching: find.byType(TextField))
-              .at(2),
+              .at(1),
           '/a:/b');
       await tester.testTextInput.receiveAction(TextInputAction.done);
       await tester.pumpAndSettle();
@@ -2014,7 +2016,7 @@ void main() {
               .descendant(
                   of: find.byType(AlertDialog),
                   matching: find.byType(TextField))
-              .at(2),
+              .at(1),
           'bad-mount');
       await tester.tap(find.byIcon(Icons.add).at(1));
       await tester.pumpAndSettle();
@@ -2029,7 +2031,7 @@ void main() {
               .descendant(
                   of: find.byType(AlertDialog),
                   matching: find.byType(TextField))
-              .at(2),
+              .at(1),
           '/host:relative');
       await tester.tap(find.byIcon(Icons.add).at(1));
       await tester.pumpAndSettle();
@@ -2042,7 +2044,7 @@ void main() {
               .descendant(
                   of: find.byType(AlertDialog),
                   matching: find.byType(TextField))
-              .at(2),
+              .at(1),
           '/host:/container:bogus');
       await tester.tap(find.byIcon(Icons.add).at(1));
       await tester.pumpAndSettle();
@@ -2055,7 +2057,7 @@ void main() {
               .descendant(
                   of: find.byType(AlertDialog),
                   matching: find.byType(TextField))
-              .at(2),
+              .at(1),
           '/a:/b');
       await tester.tap(find.byIcon(Icons.add).at(1));
       await tester.pumpAndSettle();
@@ -2107,7 +2109,7 @@ void main() {
               .descendant(
                   of: find.byType(AlertDialog),
                   matching: find.byType(TextField))
-              .at(3),
+              .at(2),
           'FOO=bar');
       await tester.ensureVisible(find.byIcon(Icons.add).at(2));
       await tester.tap(find.byIcon(Icons.add).at(2));
@@ -2120,7 +2122,7 @@ void main() {
               .descendant(
                   of: find.byType(AlertDialog),
                   matching: find.byType(TextField))
-              .at(3),
+              .at(2),
           'X=1');
       await tester.testTextInput.receiveAction(TextInputAction.done);
       await tester.pumpAndSettle();
@@ -2163,7 +2165,7 @@ void main() {
               .descendant(
                   of: find.byType(AlertDialog),
                   matching: find.byType(TextField))
-              .at(3),
+              .at(2),
           'NOEQ');
       await tester.tap(find.byIcon(Icons.add).at(2));
       await tester.pumpAndSettle();
@@ -2175,7 +2177,7 @@ void main() {
               .descendant(
                   of: find.byType(AlertDialog),
                   matching: find.byType(TextField))
-              .at(3),
+              .at(2),
           '=value');
       await tester.tap(find.byIcon(Icons.add).at(2));
       await tester.pumpAndSettle();
@@ -2187,7 +2189,7 @@ void main() {
               .descendant(
                   of: find.byType(AlertDialog),
                   matching: find.byType(TextField))
-              .at(3),
+              .at(2),
           'A=1');
       await tester.tap(find.byIcon(Icons.add).at(2));
       await tester.pumpAndSettle();
@@ -2219,7 +2221,7 @@ void main() {
               .descendant(
                   of: find.byType(AlertDialog),
                   matching: find.byType(TextField))
-              .at(2),
+              .at(1),
           '/src:/work');
       await tester.tap(find.byIcon(Icons.add).at(1));
       await tester.pumpAndSettle();
@@ -2253,7 +2255,7 @@ void main() {
               .descendant(
                   of: find.byType(AlertDialog),
                   matching: find.byType(TextField))
-              .at(3),
+              .at(2),
           'FOO=bar');
       await tester.tap(find.byIcon(Icons.add).at(2));
       await tester.pumpAndSettle();

--- a/src/frontend/test/workspace_settings_panel_test.dart
+++ b/src/frontend/test/workspace_settings_panel_test.dart
@@ -164,7 +164,7 @@ void main() {
       await tester.pumpAndSettle();
 
       await tester.enterText(
-        find.byType(TextField).at(3), // mounts add-row input
+        find.byType(TextField).at(1), // mounts add-row input
         '/etc:/etc',
       );
       await tester.testTextInput.receiveAction(TextInputAction.done);
@@ -179,7 +179,7 @@ void main() {
       await tester.pumpAndSettle();
 
       await tester.enterText(
-        find.byType(TextField).at(3),
+        find.byType(TextField).at(1),
         'no-colon',
       );
       await tester.testTextInput.receiveAction(TextInputAction.done);
@@ -218,7 +218,7 @@ void main() {
 
       // Env add-row is the last TextField.
       await tester.enterText(
-        find.byType(TextField).last,
+        find.byType(TextField).at(2),
         'BAR=baz',
       );
       await tester.testTextInput.receiveAction(TextInputAction.done);
@@ -231,7 +231,7 @@ void main() {
       await tester.pumpWidget(_buildPanel());
       await tester.pumpAndSettle();
 
-      await tester.enterText(find.byType(TextField).last, 'NOEQUALS');
+      await tester.enterText(find.byType(TextField).at(2), 'NOEQUALS');
       await tester.testTextInput.receiveAction(TextInputAction.done);
       await tester.pump();
 
@@ -248,7 +248,7 @@ void main() {
       await tester.pumpWidget(_buildPanel());
       await tester.pumpAndSettle();
 
-      await tester.enterText(find.byType(TextField).last, '=val');
+      await tester.enterText(find.byType(TextField).at(2), '=val');
       await tester.testTextInput.receiveAction(TextInputAction.done);
       await tester.pump();
 
@@ -359,6 +359,79 @@ void main() {
       expect(find.textContaining('Failed'), findsOneWidget);
       expect(find.textContaining('bad mounts'), findsOneWidget);
       // Drain the 2s auto-clear timer (see save-success test).
+      await tester.pumpAndSettle();
+    });
+  });
+
+  group('auto start', () {
+    testWidgets('hides the checkbox when auto-start is not allowed',
+        (tester) async {
+      // Default _client returns 404 for /config -> allow_autostart false.
+      testAuthHttpClientOverride = _client();
+      await tester.pumpWidget(_buildPanel());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Auto start'), findsNothing);
+      expect(find.byType(Checkbox), findsNothing);
+    });
+
+    testWidgets('shows the checkbox and round-trips auto_start when allowed',
+        (tester) async {
+      Map<String, dynamic>? savedBody;
+      testAuthHttpClientOverride = MockClient((request) async {
+        final p = request.url.path;
+        if (p == '/api/v1/config') {
+          return http.Response(
+            jsonEncode({'allow_autostart': true}),
+            200,
+          );
+        }
+        if (p == '/api/v1/workspaces') {
+          return http.Response(
+            jsonEncode([
+              {..._workspace, 'auto_start': true}
+            ]),
+            200,
+          );
+        }
+        if (p == '/api/v1/workspaces/shared') {
+          return http.Response(jsonEncode([]), 200);
+        }
+        if (p == '/api/v1/images') {
+          return http.Response(
+            jsonEncode({
+              'default': 'klangk-pi',
+              'allowed': ['klangk-pi'],
+            }),
+            200,
+          );
+        }
+        if (p == '/api/v1/workspaces/$_wsId' && request.method == 'PUT') {
+          savedBody = jsonDecode(request.body) as Map<String, dynamic>;
+          return http.Response(jsonEncode({'status': 'updated'}), 200);
+        }
+        return http.Response('nf', 404);
+      });
+      await tester.pumpWidget(_buildPanel());
+      await tester.pumpAndSettle();
+
+      // Checkbox present + checked (workspace had auto_start: true).
+      final checkbox = find.byType(Checkbox);
+      expect(checkbox, findsOneWidget);
+      expect(tester.widget<Checkbox>(checkbox).value, isTrue);
+
+      // Toggle it off and save.
+      await tester.ensureVisible(checkbox);
+      await tester.tap(checkbox);
+      await tester.pump();
+      await _scrollToAndTap(tester, find.text('Save'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(savedBody, isNotNull);
+      expect(savedBody!['auto_start'], false);
+      // Drain the 2s auto-clear timer (see save-success test).
+      await tester.pump(const Duration(seconds: 2));
       await tester.pumpAndSettle();
     });
   });
@@ -486,8 +559,10 @@ void main() {
       await tester.pumpWidget(_buildPanel());
       await tester.pumpAndSettle();
 
-      // Open the dropdown and pick the non-default image.
-      await tester.tap(find.text('klangk-pi'));
+      // Open the dropdown and pick the non-default image. The dropdown
+      // sits at the bottom of the config card (after the field reorder),
+      // so scroll it into view first.
+      await _scrollToAndTap(tester, find.text('klangk-pi'));
       await tester.pumpAndSettle();
       await tester.tap(find.text('other:latest').last);
       await tester.pumpAndSettle();


### PR DESCRIPTION
## Summary

The backend and CLI have supported per-workspace `auto_start` (start the container on server boot, gated by `KLANGK_ALLOW_AUTOSTART`) since #1007/#1024, but the **web frontend never exposed it** — UI users couldn't set or toggle auto-start. This PR adds an **Auto start** checkbox to both workspace dialogs, shown **only when the server advertises `allow_autostart`** (so users can't toggle a setting a non-autostart server will 400 on). It also normalizes the field ordering and labels between the two dialogs, which had drifted.

## Changes

### Backend
- `GET /api/v1/config` now returns `allow_autostart` (`resolve_env_bool("KLANGK_ALLOW_AUTOSTART")`), so the UI can gate the control. (`auto_start` was already in the workspace API response.)

### Frontend
- **AuthService** parses + exposes `allowAutostart` from `/config`.
- **CreateWorkspaceDialog**: new `allowAutostart` param; renders the checkbox (CheckboxListTile) when true; sends `auto_start` on create. Field order normalized + labels unified; doc-comment updated.
- **WorkspaceSettingsPanel**: threads `allowAutostart` into `_SettingsForm` via `context.select` (reactive to config); checkbox in the config card initialized from `workspace.auto_start` and sent on save; same canonical order + labels.
- **workspace_list_page**: passes `allowAutostart` from AuthService.

### Canonical field order (both dialogs)
`Name → Mounts → Environment Variables → Default Shell Command → Health Check Command → Container Image`, with the **Auto start** checkbox appended last when `allow_autostart` is on. (This moves Container Image to the bottom and lifts Mounts/Env up; previously Image was 2nd.) Labels unified to Title Case + hint text (dropped the `'(optional)'` suffix drift; `'Workspace Name' → 'Name'`).

## Test plan

- [x] Backend: `test_config_advertises_allow_autostart` (false default + true when flag set). Full gate **100%** locally (`-n auto`, 1973 passed).
- [x] Frontend: AuthService config test; create-dialog checkbox show/hide + submit-with-`auto_start`; settings-panel checkbox round-trip; updated TextField indices + dropdown-visibility for the reordered layout. Full suite **100%** locally (816 passed).
- [x] No dart-format churn committed (`SKIP=dart-format`; per-project convention — CI has no dart-format gate).
- [ ] CI: backend, frontend, and e2e gates green.

Closes #1115.