### PR TITLE
fix(workspaces): notify on role-based share so Shared-with-Me updates live

### DIFF
--- a/src/backend/klangk_backend/api/workspaces.py
+++ b/src/backend/klangk_backend/api/workspaces.py
@@ -820,6 +820,9 @@ async def add_to_workspace_role(
     if target is None:
         raise HTTPException(status_code=404, detail="User not found")
     await model.add_user_to_group(target["id"], group["id"])
+    await _broadcast_workspace_members(workspace_id)
+    wshandler.state.notify_user_workspaces_changed(user["id"])
+    wshandler.state.notify_user_workspaces_changed(target["id"])
     return {"ok": True}
 
 
@@ -838,6 +841,9 @@ async def remove_from_workspace_role(
     if group is None:
         raise HTTPException(status_code=404, detail="Role group not found")
     await model.remove_user_from_group(member_id, group["id"])
+    await _broadcast_workspace_members(workspace_id)
+    wshandler.state.notify_user_workspaces_changed(user["id"])
+    wshandler.state.notify_user_workspaces_changed(member_id)
     return {"ok": True}
 
 
@@ -883,6 +889,9 @@ async def change_workspace_role(
             raise HTTPException(status_code=404, detail="Role group not found")
         await model.add_user_to_group(target["id"], group["id"])
 
+    await _broadcast_workspace_members(workspace_id)
+    wshandler.state.notify_user_workspaces_changed(user["id"])
+    wshandler.state.notify_user_workspaces_changed(target["id"])
     return {"ok": True, "email": body.email, "role": body.role}
 
 

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -1931,6 +1931,73 @@ class TestWorkspaceSharingRoutes:
         notified = {call.args[0] for call in mock_notify.call_args_list}
         assert notified == {user["id"], other["id"]}
 
+    async def test_add_to_role_notifies_owner_and_target(self, client, user):
+        headers = await _auth_headers(client)
+        other = await self._create_other_user()
+        resp = await client.post(
+            "/api/v1/workspaces", headers=headers, json={"name": "role-ws"}
+        )
+        ws_id = resp.json()["id"]
+        with patch.object(
+            wshandler.state, "notify_user_workspaces_changed"
+        ) as mock_notify:
+            resp = await client.post(
+                f"/api/v1/workspaces/{ws_id}/roles/collaborators",
+                headers=headers,
+                json={"email": "other@example.com"},
+            )
+        assert resp.status_code == 200
+        notified = {call.args[0] for call in mock_notify.call_args_list}
+        assert notified == {user["id"], other["id"]}
+
+    async def test_remove_from_role_notifies_owner_and_member(
+        self, client, user
+    ):
+        headers = await _auth_headers(client)
+        other = await self._create_other_user()
+        resp = await client.post(
+            "/api/v1/workspaces", headers=headers, json={"name": "role-ws"}
+        )
+        ws_id = resp.json()["id"]
+        await client.post(
+            f"/api/v1/workspaces/{ws_id}/roles/collaborators",
+            headers=headers,
+            json={"email": "other@example.com"},
+        )
+        with patch.object(
+            wshandler.state, "notify_user_workspaces_changed"
+        ) as mock_notify:
+            resp = await client.delete(
+                f"/api/v1/workspaces/{ws_id}"
+                f"/roles/collaborators/{other['id']}",
+                headers=headers,
+            )
+        assert resp.status_code == 200
+        notified = {call.args[0] for call in mock_notify.call_args_list}
+        assert notified == {user["id"], other["id"]}
+
+    async def test_change_role_notifies_owner_and_target(self, client, user):
+        headers = await _auth_headers(client)
+        other = await self._create_other_user()
+        resp = await client.post(
+            "/api/v1/workspaces", headers=headers, json={"name": "role-ws"}
+        )
+        ws_id = resp.json()["id"]
+        with patch.object(
+            wshandler.state, "notify_user_workspaces_changed"
+        ) as mock_notify:
+            resp = await client.patch(
+                f"/api/v1/workspaces/{ws_id}/roles",
+                headers=headers,
+                json={
+                    "email": "other@example.com",
+                    "role": "collaborators",
+                },
+            )
+        assert resp.status_code == 200
+        notified = {call.args[0] for call in mock_notify.call_args_list}
+        assert notified == {user["id"], other["id"]}
+
     async def test_add_member_not_found(self, client, user):
         headers = await _auth_headers(client)
         resp = await client.post(


### PR DESCRIPTION
## Summary

Sharing a workspace via the **Sharing panel** (the `/roles` endpoints) did not
push a live update to the recipient, so a user already viewing their workspace
list kept a stale **Shared with Me** tab until a manual reload. The workspace
was correctly shared in the DB — it just wasn't surfaced live.

## Root cause

The Sharing panel shares through the role-group endpoints:

- `POST   /workspaces/{id}/roles/{role}`        → `add_to_workspace_role`
- `DELETE /workspaces/{id}/roles/{role}/{mid}`  → `remove_from_workspace_role`
- `PATCH  /workspaces/{id}/roles`               → `change_workspace_role`

All three mutate `user_groups` (the membership that grants shared access), but
**none** called `wshandler.state.notify_user_workspaces_changed(...)`, so no
`workspaces_changed` WebSocket push was sent. The frontend's "Shared with Me"
list only refetches on that push (`_refreshWorkspaces` in
`workspace_list_page.dart`), hence the stale view.

The older direct-member endpoints right above them (`/members`) *do* notify
both actor and target — so the bug was specific to the roles path the panel
actually uses.

## Fix

Mirror the `/members` endpoints in all three role handlers: after the
membership change, `_broadcast_workspace_members(workspace_id)` and notify both
the actor (`user["id"]`) and the affected user (`target["id"]` / `member_id`).
`change_workspace_role` always notifies regardless of direction, since the
target's shared-list can both gain and lose the workspace.

## Verification

- `ruff check` / `ruff format` clean.
- New tests mirror the existing `test_add_member_notifies_*` /
  `test_remove_member_notifies_*` coverage:
  - `test_add_to_role_notifies_owner_and_target`
  - `test_remove_from_role_notifies_owner_and_member`
  - `test_change_role_notifies_owner_and_target`
- Full `src/backend/tests/test_api.py` — **419 passed**.