### PR TITLE
fix(frontend): clear all 20 pre-existing dart analyze warnings

### DIFF
--- a/src/frontend/lib/admin/admin_users_page.dart
+++ b/src/frontend/lib/admin/admin_users_page.dart
@@ -125,17 +125,6 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
     }
   }
 
-  void _showSnack(dynamic resp) {
-    String msg;
-    try {
-      msg = jsonDecode(resp.body)['detail'] ?? 'Error';
-    } catch (e) {
-      debugPrint('[AdminUsersPage] parse error detail failed: $e');
-      msg = 'Error: ${resp.statusCode}';
-    }
-    ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(msg)));
-  }
-
   Future<void> _addUser() async {
     final result = await showDialog<Map<String, dynamic>>(
       context: context,

--- a/src/frontend/lib/auth/auth_service.dart
+++ b/src/frontend/lib/auth/auth_service.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:math';
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';

--- a/src/frontend/lib/auth/settings_page.dart
+++ b/src/frontend/lib/auth/settings_page.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 // ignore: unused_import
 import '../theme/colors.dart';
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'auth_service.dart';
 import '../utils/page_title.dart';

--- a/src/frontend/lib/file_viewer/file_upload.dart
+++ b/src/frontend/lib/file_viewer/file_upload.dart
@@ -44,9 +44,7 @@ class FileDropZoneState extends State<FileDropZone> {
   List<(String, DropItem)> collectFiles(List<DropItem> items, String prefix) {
     final result = <(String, DropItem)>[];
     for (final item in items) {
-      final path = prefix.isEmpty
-          ? (item.name ?? 'unnamed')
-          : '$prefix/${item.name ?? 'unnamed'}';
+      final path = prefix.isEmpty ? item.name : '$prefix/${item.name}';
       if (item is DropItemDirectory) {
         result.addAll(collectFiles(item.children, path));
       } else {
@@ -62,7 +60,7 @@ class FileDropZoneState extends State<FileDropZone> {
         widget.currentEntries.map((e) => e['name'] as String).toSet();
     final conflicts = <String>[];
     for (final item in details.files) {
-      final name = item.name ?? 'unnamed';
+      final name = item.name;
       if (existingNames.contains(name)) {
         conflicts.add(name);
       }
@@ -101,14 +99,14 @@ class FileDropZoneState extends State<FileDropZone> {
         }
         int statusCode;
         if (testUploadOverride != null) {
-          statusCode = await testUploadOverride!(
-              url, headers, file.name ?? 'unnamed', bytes);
+          statusCode =
+              await testUploadOverride!(url, headers, file.name, bytes);
         } else {
           // coverage:ignore-start
           final request = http.MultipartRequest('POST', Uri.parse(url));
           request.headers.addAll(headers);
-          request.files.add(http.MultipartFile.fromBytes('file', bytes,
-              filename: file.name ?? 'unnamed'));
+          request.files.add(
+              http.MultipartFile.fromBytes('file', bytes, filename: file.name));
           final response = await request.send();
           statusCode = response.statusCode;
           // coverage:ignore-end
@@ -143,7 +141,8 @@ class FileDropZoneState extends State<FileDropZone> {
           widget.child,
           if (_dragging)
             Container(
-              color: Theme.of(context).colorScheme.primary.withOpacity(0.2),
+              color:
+                  Theme.of(context).colorScheme.primary.withValues(alpha: 0.2),
               child: const Center(
                 child: Column(
                   mainAxisSize: MainAxisSize.min,

--- a/src/frontend/lib/widgets/acl_editor.dart
+++ b/src/frontend/lib/widgets/acl_editor.dart
@@ -150,7 +150,7 @@ class AclEditorState extends State<AclEditor> {
               mainAxisSize: MainAxisSize.min,
               children: [
                 DropdownButtonFormField<int>(
-                  value: selectedAction,
+                  initialValue: selectedAction,
                   decoration: const InputDecoration(
                     labelText: 'Action',
                     border: OutlineInputBorder(),
@@ -164,7 +164,7 @@ class AclEditorState extends State<AclEditor> {
                 ),
                 const SizedBox(height: 12),
                 DropdownButtonFormField<int>(
-                  value: principalType,
+                  initialValue: principalType,
                   decoration: const InputDecoration(
                     labelText: 'Principal Type',
                     border: OutlineInputBorder(),
@@ -182,7 +182,7 @@ class AclEditorState extends State<AclEditor> {
                 const SizedBox(height: 12),
                 if (principalType == 1 && users.isNotEmpty)
                   DropdownButtonFormField<String>(
-                    value: selectedUserId,
+                    initialValue: selectedUserId,
                     decoration: const InputDecoration(
                       labelText: 'User',
                       border: OutlineInputBorder(),
@@ -196,7 +196,7 @@ class AclEditorState extends State<AclEditor> {
                   ),
                 if (principalType == 2 && groups.isNotEmpty)
                   DropdownButtonFormField<String>(
-                    value: selectedGroupId,
+                    initialValue: selectedGroupId,
                     decoration: const InputDecoration(
                       labelText: 'Group',
                       border: OutlineInputBorder(),
@@ -210,7 +210,7 @@ class AclEditorState extends State<AclEditor> {
                   ),
                 if (principalType == 0) ...[
                   DropdownButtonFormField<int>(
-                    value: selectedSystemPrincipal,
+                    initialValue: selectedSystemPrincipal,
                     decoration: const InputDecoration(
                       labelText: 'System Principal',
                       border: OutlineInputBorder(),
@@ -225,7 +225,7 @@ class AclEditorState extends State<AclEditor> {
                 ],
                 const SizedBox(height: 12),
                 DropdownButtonFormField<String>(
-                  value: selectedPermission,
+                  initialValue: selectedPermission,
                   decoration: const InputDecoration(
                     labelText: 'Permission',
                     border: OutlineInputBorder(),

--- a/src/frontend/lib/widgets/app_bar_actions.dart
+++ b/src/frontend/lib/widgets/app_bar_actions.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import '../theme/colors.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
-import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 import '../auth/auth_service.dart';
 import '../utils/web_helpers_stub.dart'
     if (dart.library.js_interop) '../utils/web_helpers_web.dart';

--- a/src/frontend/lib/workspace/create_workspace_dialog.dart
+++ b/src/frontend/lib/workspace/create_workspace_dialog.dart
@@ -206,7 +206,7 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
               ),
               const SizedBox(height: 16),
               DropdownButtonFormField<String>(
-                value: _selectedImage,
+                initialValue: _selectedImage,
                 decoration: InputDecoration(
                   labelText: 'Container Image',
                   labelStyle: _labelStyle,

--- a/src/frontend/lib/workspace/workspace_list_page.dart
+++ b/src/frontend/lib/workspace/workspace_list_page.dart
@@ -6,7 +6,6 @@ import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import '../auth/auth_service.dart';
 import '../ws/ws_client.dart';
-import 'package:klangk_plugin_api/klangk_plugin_api.dart';
 import '../utils/page_title.dart';
 import '../widgets/app_bar_actions.dart';
 import '../widgets/app_bar_title.dart';

--- a/src/frontend/lib/workspace/workspace_page.dart
+++ b/src/frontend/lib/workspace/workspace_page.dart
@@ -8,7 +8,6 @@ import 'package:provider/provider.dart';
 import '../ws/ws_client.dart';
 import '../auth/auth_service.dart';
 import 'package:klangk_plugin_api/klangk_plugin_api.dart';
-import 'package:klangk_plugins/klangk_plugins.dart';
 import '../utils/page_title.dart';
 import '../widgets/app_bar_actions.dart';
 import '../widgets/app_bar_title.dart';

--- a/src/frontend/lib/workspace/workspace_settings_panel.dart
+++ b/src/frontend/lib/workspace/workspace_settings_panel.dart
@@ -413,7 +413,7 @@ class _SettingsFormState extends State<_SettingsForm> {
         const SizedBox(height: 16),
         if (widget.allowedImages.isNotEmpty)
           DropdownButtonFormField<String>(
-            value: _selectedImage,
+            initialValue: _selectedImage,
             decoration: InputDecoration(
               labelText: 'Container Image',
               labelStyle: labelStyle,


### PR DESCRIPTION
## Summary

Clears all 20 pre-existing `dart analyze lib/` warnings on `main`, which now reports **"No issues found!"**. Closes #1127.

## What changed (by category)

**Deprecations (9)** — applied via `dart fix --apply lib/` (the 8 `value` renames) + one hand-fix:
- `DropdownButtonFormField` `value:` → `initialValue:` — ×6 in `widgets/acl_editor.dart`, ×1 in `workspace/create_workspace_dialog.dart`, ×1 in `workspace/workspace_settings_panel.dart`
- `Color.withOpacity(0.2)` → `.withValues(alpha: 0.2)` — `file_viewer/file_upload.dart`

**Unused imports (5)** — `auth_service` (`dart:math`), `settings_page` (`go_router`), `app_bar_actions` (`klangk_plugin_api`), `workspace_list_page` (`klangk_plugin_api`), `workspace_page` (`klangk_plugins`).

**Dead null-aware expressions (5)** — `file_upload.dart` had `item.name ?? 'unnamed'` / `file.name ?? 'unnamed'`, but `DropItem.name` / `XFile.name` are now statically non-nullable, so the `?? 'unnamed'` fallbacks were unreachable. Dropped them (no behavior change — the dead branch could never run).

**Unused element (1)** — `admin_users_page._showSnack` was never called. The add/delete/edit handlers each inline their own snackbar with a *more specific* message ("Failed to add user", etc.), so wiring them to the generic helper would regress UX; deleted the dead helper. (A separate `_showSnack` in the invitations state class **is** used — left untouched.)

## Notes

- **Two of the 20** weren't enumerated in #1127's body because they appeared *after* the issue was filed (`workspace_page` unused import, `workspace_settings_panel` deprecated `.value`). Same categories, cleared here so the acceptance criterion ("No issues found!") is actually met.
- **Committed with `SKIP=dart-format`**: `workspace_list_page.dart` has **pre-existing format drift** on `main` (the project deliberately uses `SKIP=dart-format` and has no format gate, per #1127). Reformatting it would drag ~100 lines of unrelated reindent into this PR. The other nine files are format-clean.
- **Out of scope, surfaced en route**: `dart fix` also wanted to add `web`/`google_fonts`/`markdown` to `pubspec.yaml` (a `missing_dependency` fix) and clean up 3 unused imports in `test/`. Both are separate from the `lib/` warnings this issue targets, so I left them alone — flagging here in case you want a follow-up.

## Verification

- `dart analyze lib/` → **No issues found!** (exit 0)
- Targeted tests pass (190 tests): `file_upload`, `admin_users_page`, `create_workspace_dialog`, `workspace_settings_panel`, `workspace_list_page`, `auth_service`.
- pre-commit: `prettier`, `trufflehog` pass (`dart-format` skipped per above).

## Reproduce

```bash
cd src/frontend
flutter pub get   # fresh worktrees need this; otherwise the analyzer floods with false override warnings
dart analyze lib/
# → No issues found!
```
