### PR TITLE
Demote podman-timing log lines from INFO to DEBUG

### DIFF
--- a/src/backend/klangk_backend/podman.py
+++ b/src/backend/klangk_backend/podman.py
@@ -123,7 +123,7 @@ async def _run(
         rc = -1
         err = err or f"{cmd_label} timed out after {timeout}s"
     elapsed = t3 - t0
-    logger.info(
+    logger.debug(
         "podman-timing: %s tempfile=%.3fs spawn=%.3fs wait=%.3fs total=%.3fs",
         cmd_label,
         t1 - t0,
@@ -132,7 +132,7 @@ async def _run(
         elapsed,
     )
     if elapsed > 2.0 and err.strip():  # pragma: no cover
-        logger.info("podman-timing: %s stderr: %s", cmd_label, err.strip())
+        logger.debug("podman-timing: %s stderr: %s", cmd_label, err.strip())
     if check and rc != 0:
         raise PodmanError(_classify(err), err.strip() or f"podman {args[0]}")
     return rc, out, err
@@ -190,7 +190,7 @@ async def _run_raw(
         rc = -1
         err = err or f"{cmd_label} timed out after {timeout}s"
     elapsed = t3 - t0
-    logger.info(
+    logger.debug(
         "podman-timing: %s tempfile=%.3fs spawn=%.3fs wait=%.3fs total=%.3fs",
         cmd_label,
         t1 - t0,
@@ -199,7 +199,7 @@ async def _run_raw(
         elapsed,
     )
     if elapsed > 2.0 and err.strip():  # pragma: no cover
-        logger.info("podman-timing: %s stderr: %s", cmd_label, err.strip())
+        logger.debug("podman-timing: %s stderr: %s", cmd_label, err.strip())
     if check and rc != 0:
         raise PodmanError(_classify(err), err.strip() or f"podman {args[0]}")
     return rc, out_bytes, err


### PR DESCRIPTION
Fixes #1131.

## Summary

The `podman-timing` log lines are emitted on **every** podman exec and
flood the backend logs at `INFO`:

```
04:20:18 INFO:klangk_backend.podman:podman-timing: podman exec tempfile=0.001s spawn=0.018s wait=0.270s total=0.288s
```

They're performance-debugging diagnostics, so they now log at `DEBUG` —
visible only when debugging perf, not at normal verbosity.

## Changes

In `src/backend/klangk_backend/podman.py`, four `logger.info(...)`
→ `logger.debug(...)` across both exec paths (`_run` and `_run_raw`):

- the per-call `podman-timing: ... tempfile=... spawn=... wait=... total=...` line (the main offender), and
- the `>2.0s` gated `podman-timing: ... stderr: ...` follow-on.

No control-flow change; the `# pragma: no cover` on the stderr gate is
unchanged.

## Verification

- Backend suite: **1993 passed**, **100.00% coverage** (podman.py at 100%).
- `ruff format` + `ruff check`: clean; all pre-commit hooks pass.