### PR TITLE
fix(workspaces): reject system agent in role grants (#1135)

### DIFF
--- a/src/backend/klangk_backend/api/admin.py
+++ b/src/backend/klangk_backend/api/admin.py
@@ -250,11 +250,6 @@ async def delete_user(
 ):
     if user_id == admin["id"]:
         raise HTTPException(status_code=400, detail="Cannot delete yourself")
-    if user_id == model.AGENT_USER_ID:
-        raise HTTPException(
-            status_code=400,
-            detail="Cannot delete the system agent user",
-        )
     user = await model.get_user_by_id(user_id)
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
@@ -286,11 +281,6 @@ async def update_user(
     if req.email is not None:
         await model.update_email(user_id, req.email)
     if req.password is not None:
-        if user_id == model.AGENT_USER_ID:
-            raise HTTPException(
-                status_code=400,
-                detail="Cannot set a password on the system agent user",
-            )
         auth.validate_password_length(req.password)
         password_hash = auth.hash_password(req.password)
         await model.update_password(user_id, password_hash)
@@ -439,12 +429,6 @@ async def user_add_group_member(
     target = await model.get_user_by_id(req.user_id)
     if target is None:
         raise HTTPException(status_code=404, detail="User not found")
-    if target["id"] == model.AGENT_USER_ID:
-        raise HTTPException(
-            status_code=400,
-            detail="The system agent cannot be added to groups"
-            " (global fixed UUID — granting it cross-workspace blast radius).",
-        )
     await model.add_user_to_group(req.user_id, group_id)
     return {"status": "added"}
 
@@ -549,12 +533,6 @@ async def add_group_member(
     user = await model.get_user_by_id(req.user_id)
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
-    if user["id"] == model.AGENT_USER_ID:
-        raise HTTPException(
-            status_code=400,
-            detail="The system agent cannot be added to groups"
-            " (global fixed UUID — granting it cross-workspace blast radius).",
-        )
     await model.add_user_to_group(req.user_id, group_id)
     return {"status": "added"}
 

--- a/src/backend/klangk_backend/api/admin.py
+++ b/src/backend/klangk_backend/api/admin.py
@@ -439,6 +439,12 @@ async def user_add_group_member(
     target = await model.get_user_by_id(req.user_id)
     if target is None:
         raise HTTPException(status_code=404, detail="User not found")
+    if target["id"] == model.AGENT_USER_ID:
+        raise HTTPException(
+            status_code=400,
+            detail="The system agent cannot be added to groups"
+            " (global fixed UUID — granting it cross-workspace blast radius).",
+        )
     await model.add_user_to_group(req.user_id, group_id)
     return {"status": "added"}
 
@@ -543,6 +549,12 @@ async def add_group_member(
     user = await model.get_user_by_id(req.user_id)
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
+    if user["id"] == model.AGENT_USER_ID:
+        raise HTTPException(
+            status_code=400,
+            detail="The system agent cannot be added to groups"
+            " (global fixed UUID — granting it cross-workspace blast radius).",
+        )
     await model.add_user_to_group(req.user_id, group_id)
     return {"status": "added"}
 

--- a/src/backend/klangk_backend/api/workspaces.py
+++ b/src/backend/klangk_backend/api/workspaces.py
@@ -714,12 +714,6 @@ async def add_workspace_member(
     target = await model.get_user_by_email(body.email)
     if target is None:
         raise HTTPException(status_code=404, detail="User not found")
-    if target["id"] == model.AGENT_USER_ID:
-        raise HTTPException(
-            status_code=400,
-            detail="The system agent cannot be added as a workspace member"
-            " (global fixed UUID — granting it cross-workspace blast radius).",
-        )
     if target["id"] == user["id"]:
         raise HTTPException(
             status_code=400, detail="Cannot share with yourself"
@@ -825,12 +819,6 @@ async def add_to_workspace_role(
     target = await model.get_user_by_email(body.email)
     if target is None:
         raise HTTPException(status_code=404, detail="User not found")
-    if target["id"] == model.AGENT_USER_ID:
-        raise HTTPException(
-            status_code=400,
-            detail="The system agent cannot be added to workspace roles"
-            " (global fixed UUID — granting it cross-workspace blast radius).",
-        )
     await model.add_user_to_group(target["id"], group["id"])
     await _broadcast_workspace_members(workspace_id)
     wshandler.state.notify_user_workspaces_changed(user["id"])
@@ -879,13 +867,6 @@ async def change_workspace_role(
     target = await model.get_user_by_email(body.email)
     if target is None:
         raise HTTPException(status_code=404, detail="User not found")
-
-    if body.role is not None and target["id"] == model.AGENT_USER_ID:
-        raise HTTPException(
-            status_code=400,
-            detail="The system agent cannot be added to workspace roles"
-            " (global fixed UUID — granting it cross-workspace blast radius).",
-        )
 
     if body.role is not None and body.role not in ROLE_GROUP_SUFFIXES:
         raise HTTPException(

--- a/src/backend/klangk_backend/api/workspaces.py
+++ b/src/backend/klangk_backend/api/workspaces.py
@@ -714,6 +714,12 @@ async def add_workspace_member(
     target = await model.get_user_by_email(body.email)
     if target is None:
         raise HTTPException(status_code=404, detail="User not found")
+    if target["id"] == model.AGENT_USER_ID:
+        raise HTTPException(
+            status_code=400,
+            detail="The system agent cannot be added as a workspace member"
+            " (global fixed UUID — granting it cross-workspace blast radius).",
+        )
     if target["id"] == user["id"]:
         raise HTTPException(
             status_code=400, detail="Cannot share with yourself"

--- a/src/backend/klangk_backend/api/workspaces.py
+++ b/src/backend/klangk_backend/api/workspaces.py
@@ -819,6 +819,12 @@ async def add_to_workspace_role(
     target = await model.get_user_by_email(body.email)
     if target is None:
         raise HTTPException(status_code=404, detail="User not found")
+    if target["id"] == model.AGENT_USER_ID:
+        raise HTTPException(
+            status_code=400,
+            detail="The system agent cannot be added to workspace roles"
+            " (global fixed UUID — granting it cross-workspace blast radius).",
+        )
     await model.add_user_to_group(target["id"], group["id"])
     await _broadcast_workspace_members(workspace_id)
     wshandler.state.notify_user_workspaces_changed(user["id"])
@@ -867,6 +873,13 @@ async def change_workspace_role(
     target = await model.get_user_by_email(body.email)
     if target is None:
         raise HTTPException(status_code=404, detail="User not found")
+
+    if body.role is not None and target["id"] == model.AGENT_USER_ID:
+        raise HTTPException(
+            status_code=400,
+            detail="The system agent cannot be added to workspace roles"
+            " (global fixed UUID — granting it cross-workspace blast radius).",
+        )
 
     if body.role is not None and body.role not in ROLE_GROUP_SUFFIXES:
         raise HTTPException(

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import bcrypt
 from fastapi import FastAPI, WebSocket
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 from . import auth, container, model, oidc, plugins, workspaces, wshandler
@@ -332,6 +333,30 @@ app.add_middleware(
 
 app.include_router(root_router)
 app.include_router(router, prefix=API_PREFIX)
+
+
+async def _agent_principal_error_handler(request, exc):  # noqa: ARG001
+    """Reject any operation that would make the agent an ACL principal.
+
+    Raised at the model choke points (``add_user_to_group``,
+    ``add_acl_entry``, ``delete_user``, ``update_password``); translated
+    to HTTP 400 here so route handlers carry no per-endpoint guard code.
+    """
+    return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+
+def register_exception_handlers(application: FastAPI) -> None:
+    """Register global exception handlers on a FastAPI application.
+
+    Called for the production app below and by the test app fixture so
+    both surface the same handler wiring without duplicating the handler.
+    """
+    application.add_exception_handler(
+        model.AgentPrincipalError, _agent_principal_error_handler
+    )
+
+
+register_exception_handlers(app)
 
 
 # --- WebSocket ---

--- a/src/backend/klangk_backend/model/__init__.py
+++ b/src/backend/klangk_backend/model/__init__.py
@@ -36,6 +36,7 @@ from ._core import (
 from .schema import init_db
 from .users import (
     AGENT_USER_ID,
+    AgentPrincipalError,
     _ADMIN_USER_SORT_COLUMNS,
     _HANDLE_RE,
     _MAX_HANDLE_LEN,
@@ -178,6 +179,7 @@ __all__ = (
     "init_db",
     # users
     "AGENT_USER_ID",
+    "AgentPrincipalError",
     "_ADMIN_USER_SORT_COLUMNS",
     "_HANDLE_RE",
     "_MAX_HANDLE_LEN",

--- a/src/backend/klangk_backend/model/acl.py
+++ b/src/backend/klangk_backend/model/acl.py
@@ -1,6 +1,7 @@
 """ACL entries (access-control list rows) and principal/action constants."""
 
 from ._core import transaction
+from .users import AGENT_USER_ID, AgentPrincipalError
 
 # ACL constants
 ACTION_DENY = 0
@@ -24,7 +25,17 @@ async def add_acl_entry(
     group_id: str | None = None,
     system_principal: int | None = None,
 ) -> int:
-    """Add an ACL entry. Returns the entry ID."""
+    """Add an ACL entry. Returns the entry ID.
+
+    Raises ``AgentPrincipalError`` if the entry would make the system
+    agent a user principal.
+    """
+    if user_id == AGENT_USER_ID:
+        raise AgentPrincipalError(
+            "The system agent cannot hold ACL entries"
+            " (global fixed UUID — granting it cross-workspace"
+            " blast radius)."
+        )
     async with transaction() as db:
         cursor = await db.execute(
             "INSERT INTO acl_entries"

--- a/src/backend/klangk_backend/model/acl.py
+++ b/src/backend/klangk_backend/model/acl.py
@@ -158,7 +158,24 @@ async def get_acl_entries_resolved(resource: str) -> list[dict]:
 
 
 async def replace_acl_entries(resource: str, entries: list[dict]) -> None:
-    """Replace all ACL entries for a resource."""
+    """Replace all ACL entries for a resource.
+
+    Raises ``AgentPrincipalError`` if any entry would make the system
+    agent a user principal. This is the second writer into
+    ``acl_entries`` (a raw INSERT, fed request-body ``user_id`` by the
+    PUT-acl endpoints) and must be guarded alongside :func:`add_acl_entry`
+    so neither writer can make the agent a principal.
+    """
+    for entry in entries:
+        if (
+            entry.get("principal_type") == PRINCIPAL_USER
+            and entry.get("user_id") == AGENT_USER_ID
+        ):
+            raise AgentPrincipalError(
+                "The system agent cannot hold ACL entries"
+                " (global fixed UUID — granting it cross-workspace"
+                " blast radius)."
+            )
     async with transaction() as db:
         await db.execute(
             "DELETE FROM acl_entries WHERE resource = ?", (resource,)

--- a/src/backend/klangk_backend/model/schema.py
+++ b/src/backend/klangk_backend/model/schema.py
@@ -98,15 +98,21 @@ async def init_db() -> None:
         # NOT guarded here -- it is legitimately re-seeded from env at boot
         # (ON CONFLICT DO UPDATE SET email); its policy lives at the fn
         # layer (#1145).
+        _agent_identity_msg = (
+            "Cannot mutate the system agent identity columns"
+            " (provider/external_id are the OIDC-link columns)"
+        )
+        # The message is interpolated as a single quoted SQL literal so
+        # SQLite sees one string token -- SQLite does not concatenate
+        # adjacent literals (unlike Python) and pre-3.x rejects `||` inside
+        # RAISE(), so both ways of splitting it are syntax errors there.
         await db.execute(f"""
             CREATE TRIGGER IF NOT EXISTS agent_user_identity_immutable
             BEFORE UPDATE OF provider, external_id ON users
             FOR EACH ROW
             WHEN OLD.id = '{AGENT_USER_ID}'
             BEGIN
-                SELECT RAISE(ABORT,
-                    'Cannot mutate the system agent identity columns'
-                    || ' (provider/external_id are the OIDC-link columns)');
+                SELECT RAISE(ABORT, '{_agent_identity_msg}');
             END
         """)  # noqa: S608
         await db.execute(f"""

--- a/src/backend/klangk_backend/model/schema.py
+++ b/src/backend/klangk_backend/model/schema.py
@@ -1,13 +1,14 @@
 """Database schema creation and in-place migrations (``init_db``)."""
 
 from ._core import get_db
-from .users import _backfill_handles
+from .acl import PRINCIPAL_USER
+from .users import AGENT_USER_ID, _backfill_handles
 
 
 async def init_db() -> None:
     db = await get_db()
     try:
-        await db.execute("""
+        await db.execute(f"""
             CREATE TABLE IF NOT EXISTS users (
                 id TEXT PRIMARY KEY,
                 email TEXT UNIQUE NOT NULL,
@@ -16,9 +17,11 @@ async def init_db() -> None:
                 provider TEXT NOT NULL DEFAULT 'local',
                 external_id TEXT,
                 handle TEXT UNIQUE,
-                created_at TEXT NOT NULL DEFAULT (datetime('now'))
+                created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                -- (D) the system agent must never carry a password.
+                CHECK (id != '{AGENT_USER_ID}' OR password_hash IS NULL)
             )
-        """)
+        """)  # noqa: S608
         # Migration: make password_hash nullable, add OIDC columns, add handle.
         # SQLite can't ALTER COLUMN, so we recreate the table if needed.
         cursor = await db.execute("PRAGMA table_info(users)")
@@ -32,7 +35,7 @@ async def init_db() -> None:
         if "handle" not in columns:
             needs_recreate = True
         if needs_recreate:
-            await db.execute("""
+            await db.execute(f"""
                 CREATE TABLE users_new (
                     id TEXT PRIMARY KEY,
                     email TEXT UNIQUE NOT NULL,
@@ -41,9 +44,10 @@ async def init_db() -> None:
                     provider TEXT NOT NULL DEFAULT 'local',
                     external_id TEXT,
                     handle TEXT UNIQUE,
-                    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+                    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                    CHECK (id != '{AGENT_USER_ID}' OR password_hash IS NULL)
                 )
-            """)
+            """)  # noqa: S608
             # Copy existing data — old tables may lack some columns
             old_cols = list(columns.keys())
             shared = [
@@ -68,7 +72,44 @@ async def init_db() -> None:
             await db.execute("ALTER TABLE users_new RENAME TO users")
         # Backfill handles for existing users that don't have one.
         await _backfill_handles(db)
-        await db.execute("""
+        # --- Data-model belt-and-suspenders for the system agent (#1135) ---
+        # The function-layer AgentPrincipalError guards are the *friendly*
+        # choke point (typed error, HTTP 400). These schema constraints are
+        # the *terminal* backstop: they fire at the DB regardless of which
+        # Python function wrote the row, so a raw-SQL writer (the exact bug
+        # class the re-audit found twice: replace_acl_entries, the seed
+        # path) cannot make the agent an ACL principal, mutate its identity,
+        # or delete it. The agent UUID is a fixed, source-published constant,
+        # so it can be baked in here. (E,F are triggers because CHECK cannot
+        # express "row must exist" or compare OLD vs NEW.)
+        # (E) the agent row must never be deleted.
+        await db.execute(f"""
+            CREATE TRIGGER IF NOT EXISTS agent_user_cannot_be_deleted
+            BEFORE DELETE ON users
+            FOR EACH ROW
+            WHEN OLD.id = '{AGENT_USER_ID}'
+            BEGIN
+                SELECT RAISE(ABORT, 'Cannot delete the system agent user');
+            END
+        """)  # noqa: S608
+        # (F) the agent's identity columns are immutable: it must stay
+        # provider='system' with no linked OIDC identity (external_id),
+        # which is the #1145 skeleton-key vector. email is intentionally
+        # NOT guarded here -- it is legitimately re-seeded from env at boot
+        # (ON CONFLICT DO UPDATE SET email); its policy lives at the fn
+        # layer (#1145).
+        await db.execute(f"""
+            CREATE TRIGGER IF NOT EXISTS agent_user_identity_immutable
+            BEFORE UPDATE OF provider, external_id ON users
+            FOR EACH ROW
+            WHEN OLD.id = '{AGENT_USER_ID}'
+            BEGIN
+                SELECT RAISE(ABORT,
+                    'Cannot mutate the system agent identity columns'
+                    || ' (provider/external_id are the OIDC-link columns)');
+            END
+        """)  # noqa: S608
+        await db.execute(f"""
             CREATE TABLE IF NOT EXISTS workspaces (
                 id TEXT PRIMARY KEY,
                 user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
@@ -90,9 +131,11 @@ async def init_db() -> None:
                 mounts TEXT,  -- JSON array of host:container mount specs
                 env TEXT,  -- JSON dict of custom environment variables
                 created_at TEXT NOT NULL DEFAULT (datetime('now')),
-                UNIQUE(user_id, name)
+                UNIQUE(user_id, name),
+                -- (C) the system agent must never own a workspace.
+                CHECK (user_id != '{AGENT_USER_ID}')
             )
-        """)
+        """)  # noqa: S608
         # Migration: add auto_start column to existing workspaces tables
         cursor = await db.execute("PRAGMA table_info(workspaces)")
         ws_cols = {row[1] for row in await cursor.fetchall()}
@@ -129,15 +172,18 @@ async def init_db() -> None:
                 created_at TEXT NOT NULL DEFAULT (datetime('now'))
             )
         """)
-        await db.execute("""
+        await db.execute(f"""
             CREATE TABLE IF NOT EXISTS user_groups (
                 user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
                 group_id TEXT NOT NULL REFERENCES groups(id) ON DELETE CASCADE,
                 source TEXT NOT NULL DEFAULT 'manual',
-                PRIMARY KEY (user_id, group_id)
+                PRIMARY KEY (user_id, group_id),
+                -- (B) the system agent must never be a group member
+                -- (role grants, group-member adds, OIDC group sync).
+                CHECK (user_id != '{AGENT_USER_ID}')
             )
-        """)
-        await db.execute("""
+        """)  # noqa: S608
+        await db.execute(f"""
             CREATE TABLE IF NOT EXISTS acl_entries (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 resource TEXT NOT NULL,
@@ -148,9 +194,13 @@ async def init_db() -> None:
                 group_id TEXT REFERENCES groups(id) ON DELETE CASCADE,
                 system_principal INTEGER,  -- 0 = Everyone, 1 = Authenticated
                 permission TEXT NOT NULL,
-                UNIQUE(resource, position)
+                UNIQUE(resource, position),
+                -- (A) the system agent must never hold a user-principal ACE
+                -- (covers both writers: add_acl_entry and replace_acl_entries).
+                CHECK (NOT (principal_type = {PRINCIPAL_USER}
+                            AND user_id = '{AGENT_USER_ID}'))
             )
-        """)
+        """)  # noqa: S608
         await db.execute("""
             CREATE TABLE IF NOT EXISTS token_blocklist (
                 jti TEXT PRIMARY KEY,

--- a/src/backend/klangk_backend/model/users.py
+++ b/src/backend/klangk_backend/model/users.py
@@ -9,6 +9,21 @@ from ._core import _fetchone, transaction
 # Agent identity
 AGENT_USER_ID = "00000000-0000-0000-0000-000000000001"
 
+
+class AgentPrincipalError(ValueError):
+    """Raised when an operation would make the agent an ACL principal.
+
+    The system agent realizes its capabilities through in-container
+    physical access, never ACL principalship (the "physical not
+    principal" rule). Granting it a role, group membership, or ACE entry
+    makes its global fixed UUID a privileged principal — a skeleton key
+    if ever forgeable. Guarded at the model choke points
+    (``add_user_to_group``, ``add_acl_entry``, ``delete_user``,
+    ``update_password``); a global handler translates this to HTTP 400.
+    Subclasses ``ValueError`` for compatibility with existing handlers.
+    """
+
+
 # Cached agent user dict (populated after seeding).
 _agent_user_cache: dict | None = None
 
@@ -383,7 +398,16 @@ async def update_group(
 async def add_user_to_group(
     user_id: str, group_id: str, source: str = "manual"
 ) -> None:
-    """Add a user to a group (idempotent)."""
+    """Add a user to a group (idempotent).
+
+    Raises ``AgentPrincipalError`` if the target is the system agent.
+    """
+    if user_id == AGENT_USER_ID:
+        raise AgentPrincipalError(
+            "The system agent cannot be added to groups"
+            " (global fixed UUID — granting it cross-workspace"
+            " blast radius)."
+        )
     async with transaction() as db:
         await db.execute(
             "INSERT OR IGNORE INTO user_groups (user_id, group_id, source)"
@@ -549,10 +573,10 @@ async def list_users(
 async def delete_user(user_id: str) -> bool:
     """Delete a user. Returns True if deleted, False if not found.
 
-    Raises ``ValueError`` if the target is the system agent user.
+    Raises ``AgentPrincipalError`` if the target is the system agent.
     """
     if user_id == AGENT_USER_ID:
-        raise ValueError("Cannot delete the system agent user")
+        raise AgentPrincipalError("Cannot delete the system agent user")
     async with transaction() as db:
         cursor = await db.execute("DELETE FROM users WHERE id = ?", (user_id,))
         return cursor.rowcount > 0
@@ -569,11 +593,13 @@ async def update_email(user_id: str, email: str) -> None:
 async def update_password(user_id: str, password_hash: str) -> None:
     """Update a user's password hash.
 
-    Raises ``ValueError`` if the target is the system agent user
+    Raises ``AgentPrincipalError`` if the target is the system agent
     (the agent must never have a password).
     """
     if user_id == AGENT_USER_ID:
-        raise ValueError("Cannot set a password on the system agent user")
+        raise AgentPrincipalError(
+            "Cannot set a password on the system agent user"
+        )
     async with transaction() as db:
         await db.execute(
             "UPDATE users SET password_hash = ? WHERE id = ?",

--- a/src/backend/klangk_backend/model/workspaces.py
+++ b/src/backend/klangk_backend/model/workspaces.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 
 from ._core import _fetchone, transaction
 from .acl import ACTION_ALLOW, PRINCIPAL_GROUP, PRINCIPAL_USER
-from .users import get_user_group_ids
+from .users import AGENT_USER_ID, AgentPrincipalError, get_user_group_ids
 
 # Must match the DB default and container.DEFAULT_PORTS_PER_WORKSPACE.
 _DEFAULT_PORTS_PER_WORKSPACE = 5
@@ -185,6 +185,12 @@ async def create_workspace_with_acl(
     cleaned up by :func:`delete_workspace`, which removes everything
     this function wrote.
     """
+    if user_id == AGENT_USER_ID:
+        raise AgentPrincipalError(
+            "The system agent cannot own a workspace (seeding it a"
+            " wildcard owner ACE + owners-group membership makes its"
+            " UUID a privileged principal) — system agent"
+        )
     if setup_state not in SETUP_STATES:
         raise ValueError(f"Invalid setup_state: {setup_state!r}")
     async with transaction() as db:

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -2929,6 +2929,45 @@ class TestUserGroupEndpoints:
         )
         assert resp.status_code == 200
 
+    async def test_add_group_member_rejects_system_agent(
+        self, client, user, db
+    ):
+        # Skeleton-key guardrail (#1135): anyone with manage_members on a
+        # group adds members by UUID, and the agent's UUID is published
+        # in source — so adding it makes the agent a group principal that
+        # can hold cross-workspace grants via group shares.
+        from klangk_backend.main import seed_agent_user
+
+        await seed_agent_user()
+        agent = await model.get_user_by_id(model.AGENT_USER_ID)
+        headers = await _auth_headers(client)
+        # Allow the (non-admin) user to create groups; the creator gets
+        # manage_members on the group they create.
+        await model.add_acl_entry(
+            "/groups",
+            0,
+            model.ACTION_ALLOW,
+            "create",
+            model.PRINCIPAL_SYSTEM,
+            system_principal=model.SYSTEM_AUTHENTICATED,
+        )
+        resp = await client.post(
+            "/api/v1/groups",
+            headers=headers,
+            json={"name": "agent-guard-group"},
+        )
+        group_id = resp.json()["id"]
+        resp = await client.post(
+            f"/api/v1/groups/{group_id}/members",
+            headers=headers,
+            json={"user_id": agent["id"]},
+        )
+        assert resp.status_code == 400
+        assert "system agent" in resp.json()["detail"]
+        # Confirm the guard actually blocked the grant.
+        members = await model.get_group_members(group_id)
+        assert not any(m["id"] == agent["id"] for m in members)
+
     async def test_update_nonexistent_group(self, client, user):
         headers = await _auth_headers(client)
         # Grant * on fake group so ACL passes
@@ -4843,6 +4882,33 @@ class TestGroupEndpoints:
             json={"user_id": "x"},
         )
         assert resp.status_code == 404
+
+    async def test_add_admin_group_member_rejects_system_agent(
+        self, client, admin_user, db
+    ):
+        # Skeleton-key guardrail (#1135): the admin group-member-add path
+        # resolves the target by UUID, and the agent's UUID is published in
+        # source — same blast-radius risk as the workspace grant paths.
+        from klangk_backend.main import seed_agent_user
+
+        await seed_agent_user()
+        agent = await model.get_user_by_id(model.AGENT_USER_ID)
+        headers = await self._admin_headers(client)
+        resp = await client.post(
+            "/api/v1/admin/groups",
+            headers=headers,
+            json={"name": "agent-guard-group"},
+        )
+        group_id = resp.json()["id"]
+        resp = await client.post(
+            f"/api/v1/admin/groups/{group_id}/members",
+            headers=headers,
+            json={"user_id": agent["id"]},
+        )
+        assert resp.status_code == 400
+        assert "system agent" in resp.json()["detail"]
+        members = await model.get_group_members(group_id)
+        assert not any(m["id"] == agent["id"] for m in members)
 
     async def test_remove_group_member(self, client, admin_user, user):
         headers = await self._admin_headers(client)

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -2106,6 +2106,35 @@ class TestWorkspaceSharingRoutes:
         assert resp.status_code == 400
         assert "yourself" in resp.json()["detail"]
 
+    async def test_add_member_rejects_system_agent(self, client, user, db):
+        # Skeleton-key guardrail (#1135): granting the system agent direct
+        # ACE entries (view/terminal/files/chat as PRINCIPAL_USER) makes
+        # its public UUID a privileged principal — same blast-radius risk
+        # as the role-grant path.
+        from klangk_backend.main import seed_agent_user
+
+        await seed_agent_user()
+        agent = await model.get_user_by_id(model.AGENT_USER_ID)
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            headers=headers,
+            json={"name": "share-ws"},
+        )
+        ws_id = resp.json()["id"]
+        resp = await client.post(
+            f"/api/v1/workspaces/{ws_id}/members",
+            headers=headers,
+            json={"email": agent["email"]},
+        )
+        assert resp.status_code == 400
+        assert "system agent" in resp.json()["detail"]
+        # Confirm the guard actually blocked the grant: no ACE entry on
+        # this workspace names the agent as the user principal.
+        resource = f"/workspaces/{ws_id}"
+        entries = await model.get_acl_entries(resource)
+        assert not any(e["user_id"] == agent["id"] for e in entries)
+
     async def test_remove_member(self, client, user):
         headers = await _auth_headers(client)
         other = await self._create_other_user()

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -2006,6 +2006,78 @@ class TestWorkspaceSharingRoutes:
         notified = {call.args[0] for call in mock_notify.call_args_list}
         assert notified == {user["id"], other["id"]}
 
+    async def test_add_role_rejects_system_agent(self, client, user, db):
+        # Skeleton-key guardrail (#1135): the system agent is a global,
+        # fixed, source-published UUID that must never become an ACL
+        # principal via a role grant.
+        from klangk_backend.main import seed_agent_user
+
+        await seed_agent_user()
+        agent = await model.get_user_by_id(model.AGENT_USER_ID)
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            headers=headers,
+            json={"name": "role-ws"},
+        )
+        ws_id = resp.json()["id"]
+        resp = await client.post(
+            f"/api/v1/workspaces/{ws_id}/roles/collaborators",
+            headers=headers,
+            json={"email": agent["email"]},
+        )
+        assert resp.status_code == 400
+        assert "system agent" in resp.json()["detail"]
+        # Confirm the guard actually blocked the grant.
+        group = await model.get_group_by_name(f"collaborators-{ws_id}")
+        members = await model.get_group_members(group["id"])
+        assert not any(m["id"] == agent["id"] for m in members)
+
+    async def test_change_role_rejects_system_agent_on_grant(
+        self, client, user, db
+    ):
+        from klangk_backend.main import seed_agent_user
+
+        await seed_agent_user()
+        agent = await model.get_user_by_id(model.AGENT_USER_ID)
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            headers=headers,
+            json={"name": "role-ws"},
+        )
+        ws_id = resp.json()["id"]
+        resp = await client.patch(
+            f"/api/v1/workspaces/{ws_id}/roles",
+            headers=headers,
+            json={"email": agent["email"], "role": "collaborators"},
+        )
+        assert resp.status_code == 400
+        assert "system agent" in resp.json()["detail"]
+
+    async def test_change_role_allows_system_agent_removal(
+        self, client, user, db
+    ):
+        # role=None is removal-from-all-roles — harmless cleanup, so the
+        # guard (which only fires on a grant) must let it through.
+        from klangk_backend.main import seed_agent_user
+
+        await seed_agent_user()
+        agent = await model.get_user_by_id(model.AGENT_USER_ID)
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            headers=headers,
+            json={"name": "role-ws"},
+        )
+        ws_id = resp.json()["id"]
+        resp = await client.patch(
+            f"/api/v1/workspaces/{ws_id}/roles",
+            headers=headers,
+            json={"email": agent["email"], "role": None},
+        )
+        assert resp.status_code == 200
+
     async def test_add_member_not_found(self, client, user):
         headers = await _auth_headers(client)
         resp = await client.post(

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -30,9 +30,11 @@ async def app(db):
     """Create a minimal FastAPI app with just the API router."""
     app = FastAPI()
     from klangk_backend.util import API_PREFIX
+    from klangk_backend.main import register_exception_handlers
 
     app.include_router(api.root_router)
     app.include_router(api.router, prefix=API_PREFIX)
+    register_exception_handlers(app)
     return app
 
 
@@ -2006,55 +2008,6 @@ class TestWorkspaceSharingRoutes:
         notified = {call.args[0] for call in mock_notify.call_args_list}
         assert notified == {user["id"], other["id"]}
 
-    async def test_add_role_rejects_system_agent(self, client, user, db):
-        # Skeleton-key guardrail (#1135): the system agent is a global,
-        # fixed, source-published UUID that must never become an ACL
-        # principal via a role grant.
-        from klangk_backend.main import seed_agent_user
-
-        await seed_agent_user()
-        agent = await model.get_user_by_id(model.AGENT_USER_ID)
-        headers = await _auth_headers(client)
-        resp = await client.post(
-            "/api/v1/workspaces",
-            headers=headers,
-            json={"name": "role-ws"},
-        )
-        ws_id = resp.json()["id"]
-        resp = await client.post(
-            f"/api/v1/workspaces/{ws_id}/roles/collaborators",
-            headers=headers,
-            json={"email": agent["email"]},
-        )
-        assert resp.status_code == 400
-        assert "system agent" in resp.json()["detail"]
-        # Confirm the guard actually blocked the grant.
-        group = await model.get_group_by_name(f"collaborators-{ws_id}")
-        members = await model.get_group_members(group["id"])
-        assert not any(m["id"] == agent["id"] for m in members)
-
-    async def test_change_role_rejects_system_agent_on_grant(
-        self, client, user, db
-    ):
-        from klangk_backend.main import seed_agent_user
-
-        await seed_agent_user()
-        agent = await model.get_user_by_id(model.AGENT_USER_ID)
-        headers = await _auth_headers(client)
-        resp = await client.post(
-            "/api/v1/workspaces",
-            headers=headers,
-            json={"name": "role-ws"},
-        )
-        ws_id = resp.json()["id"]
-        resp = await client.patch(
-            f"/api/v1/workspaces/{ws_id}/roles",
-            headers=headers,
-            json={"email": agent["email"], "role": "collaborators"},
-        )
-        assert resp.status_code == 400
-        assert "system agent" in resp.json()["detail"]
-
     async def test_change_role_allows_system_agent_removal(
         self, client, user, db
     ):
@@ -2107,10 +2060,11 @@ class TestWorkspaceSharingRoutes:
         assert "yourself" in resp.json()["detail"]
 
     async def test_add_member_rejects_system_agent(self, client, user, db):
-        # Skeleton-key guardrail (#1135): granting the system agent direct
-        # ACE entries (view/terminal/files/chat as PRINCIPAL_USER) makes
-        # its public UUID a privileged principal — same blast-radius risk
-        # as the role-grant path.
+        # End-to-end smoke for the #1135 refactor: the guard now lives at
+        # the model choke point (model.add_acl_entry), and a global
+        # handler translates AgentPrincipalError to HTTP 400. This is the
+        # one HTTP-level grant test kept to prove the wiring; the choke
+        # points themselves are unit-tested in test_model.py.
         from klangk_backend.main import seed_agent_user
 
         await seed_agent_user()
@@ -2928,45 +2882,6 @@ class TestUserGroupEndpoints:
             headers=headers,
         )
         assert resp.status_code == 200
-
-    async def test_add_group_member_rejects_system_agent(
-        self, client, user, db
-    ):
-        # Skeleton-key guardrail (#1135): anyone with manage_members on a
-        # group adds members by UUID, and the agent's UUID is published
-        # in source — so adding it makes the agent a group principal that
-        # can hold cross-workspace grants via group shares.
-        from klangk_backend.main import seed_agent_user
-
-        await seed_agent_user()
-        agent = await model.get_user_by_id(model.AGENT_USER_ID)
-        headers = await _auth_headers(client)
-        # Allow the (non-admin) user to create groups; the creator gets
-        # manage_members on the group they create.
-        await model.add_acl_entry(
-            "/groups",
-            0,
-            model.ACTION_ALLOW,
-            "create",
-            model.PRINCIPAL_SYSTEM,
-            system_principal=model.SYSTEM_AUTHENTICATED,
-        )
-        resp = await client.post(
-            "/api/v1/groups",
-            headers=headers,
-            json={"name": "agent-guard-group"},
-        )
-        group_id = resp.json()["id"]
-        resp = await client.post(
-            f"/api/v1/groups/{group_id}/members",
-            headers=headers,
-            json={"user_id": agent["id"]},
-        )
-        assert resp.status_code == 400
-        assert "system agent" in resp.json()["detail"]
-        # Confirm the guard actually blocked the grant.
-        members = await model.get_group_members(group_id)
-        assert not any(m["id"] == agent["id"] for m in members)
 
     async def test_update_nonexistent_group(self, client, user):
         headers = await _auth_headers(client)
@@ -4587,7 +4502,7 @@ class TestAdminEndpoints:
         headers = await self._admin_headers(client)
         resp = await client.patch(
             f"/api/v1/admin/users/{model.AGENT_USER_ID}",
-            json={"password": "sneaky"},
+            json={"password": "sneaky123"},
             headers=headers,
         )
         assert resp.status_code == 400
@@ -4882,33 +4797,6 @@ class TestGroupEndpoints:
             json={"user_id": "x"},
         )
         assert resp.status_code == 404
-
-    async def test_add_admin_group_member_rejects_system_agent(
-        self, client, admin_user, db
-    ):
-        # Skeleton-key guardrail (#1135): the admin group-member-add path
-        # resolves the target by UUID, and the agent's UUID is published in
-        # source — same blast-radius risk as the workspace grant paths.
-        from klangk_backend.main import seed_agent_user
-
-        await seed_agent_user()
-        agent = await model.get_user_by_id(model.AGENT_USER_ID)
-        headers = await self._admin_headers(client)
-        resp = await client.post(
-            "/api/v1/admin/groups",
-            headers=headers,
-            json={"name": "agent-guard-group"},
-        )
-        group_id = resp.json()["id"]
-        resp = await client.post(
-            f"/api/v1/admin/groups/{group_id}/members",
-            headers=headers,
-            json={"user_id": agent["id"]},
-        )
-        assert resp.status_code == 400
-        assert "system agent" in resp.json()["detail"]
-        members = await model.get_group_members(group_id)
-        assert not any(m["id"] == agent["id"] for m in members)
 
     async def test_remove_group_member(self, client, admin_user, user):
         headers = await self._admin_headers(client)

--- a/src/backend/tests/test_model.py
+++ b/src/backend/tests/test_model.py
@@ -2,6 +2,7 @@
 
 import aiosqlite
 import pytest
+import sqlalchemy.exc
 
 from klangk_backend import model
 
@@ -1299,6 +1300,99 @@ class TestCreateWorkspaceWithAclAgentGuard:
         # add_acl_entry), so the public entry point guards the creator.
         with pytest.raises(model.AgentPrincipalError, match="system agent"):
             await model.create_workspace_with_acl(model.AGENT_USER_ID, "ws")
+
+
+class TestSchemaAgentBackstops:
+    """Data-model belt-and-suspenders (#1135): the schema constraints that
+    backstop the function-layer AgentPrincipalError guards. Each test writes
+    raw SQL that bypasses the Python guards, proving the DB itself rejects
+    making the agent a principal / mutating its identity / deleting it --
+    the terminal backstop for the raw-SQL-writer bug class the re-audit
+    found (replace_acl_entries, the seed path).
+    """
+
+    async def test_acl_entries_rejects_agent_user_principal(self, agent_user):
+        # (A) CHECK on acl_entries: covers both writers (add_acl_entry and
+        # replace_acl_entries).
+        with pytest.raises(sqlalchemy.exc.IntegrityError):
+            async with model.transaction() as db:
+                await db.execute(
+                    "INSERT INTO acl_entries"
+                    " (resource, position, action, principal_type,"
+                    "  permission, user_id)"
+                    " VALUES ('/x', 0, 1, 1, '*', ?)",
+                    (model.AGENT_USER_ID,),
+                )
+
+    async def test_user_groups_rejects_agent(self, agent_user):
+        # (B) CHECK on user_groups: role grants, member adds, OIDC sync.
+        group = await model.create_group("g")
+        with pytest.raises(sqlalchemy.exc.IntegrityError):
+            async with model.transaction() as db:
+                await db.execute(
+                    "INSERT INTO user_groups (user_id, group_id, source)"
+                    " VALUES (?, ?, 'manual')",
+                    (model.AGENT_USER_ID, group["id"]),
+                )
+
+    async def test_workspaces_rejects_agent_owner(self, agent_user):
+        # (C) CHECK on workspaces.user_id (the owner column).
+        with pytest.raises(sqlalchemy.exc.IntegrityError):
+            async with model.transaction() as db:
+                await db.execute(
+                    "INSERT INTO workspaces (id, user_id, name)"
+                    " VALUES ('ws', ?, 'n')",
+                    (model.AGENT_USER_ID,),
+                )
+
+    async def test_users_rejects_agent_password(self, agent_user):
+        # (D) CHECK: the agent must never carry a password.
+        with pytest.raises(sqlalchemy.exc.IntegrityError):
+            async with model.transaction() as db:
+                await db.execute(
+                    "UPDATE users SET password_hash = ? WHERE id = ?",
+                    ("x", model.AGENT_USER_ID),
+                )
+
+    async def test_agent_row_cannot_be_deleted(self, agent_user):
+        # (E) BEFORE DELETE trigger: the agent row is undeletable.
+        with pytest.raises(sqlalchemy.exc.IntegrityError):
+            async with model.transaction() as db:
+                await db.execute(
+                    "DELETE FROM users WHERE id = ?",
+                    (model.AGENT_USER_ID,),
+                )
+
+    async def test_agent_identity_columns_immutable(self, agent_user):
+        # (F) BEFORE UPDATE trigger on provider/external_id: the agent must
+        # stay provider='system' with no linked OIDC identity (the #1145
+        # skeleton-key vector). link_oidc_identity sets exactly these.
+        with pytest.raises(sqlalchemy.exc.IntegrityError):
+            async with model.transaction() as db:
+                await db.execute(
+                    "UPDATE users SET provider = ? WHERE id = ?",
+                    ("oidc", model.AGENT_USER_ID),
+                )
+        with pytest.raises(sqlalchemy.exc.IntegrityError):
+            async with model.transaction() as db:
+                await db.execute(
+                    "UPDATE users SET external_id = ? WHERE id = ?",
+                    ("sub", model.AGENT_USER_ID),
+                )
+
+    async def test_agent_email_remains_mutable(self, agent_user):
+        # F deliberately does NOT guard email: it is legitimately re-seeded
+        # from env at boot (ON CONFLICT DO UPDATE SET email). Email policy
+        # lives at the fn layer (#1145), not the schema. This test pins that
+        # decision so a future "add an email trigger" change can't silently
+        # break boot-time re-seeding.
+        async with model.transaction() as db:
+            await db.execute(
+                "UPDATE users SET email = ? WHERE id = ?",
+                ("new@example.com", model.AGENT_USER_ID),
+            )
+        agent = await model.get_user_by_id(model.AGENT_USER_ID)
+        assert agent["email"] == "new@example.com"
 
 
 class TestHashFallbackHandle:

--- a/src/backend/tests/test_model.py
+++ b/src/backend/tests/test_model.py
@@ -1270,6 +1270,37 @@ class TestAddAclEntryAgentGuard:
             )
 
 
+class TestReplaceAclEntriesAgentGuard:
+    async def test_replace_acl_entries_rejects_agent(self, db):
+        # Choke-point guard (#1135): replace_acl_entries is the second
+        # writer into acl_entries (a raw INSERT, fed request-body
+        # user_id by the PUT-acl endpoints) — guarded like add_acl_entry.
+        with pytest.raises(model.AgentPrincipalError, match="system agent"):
+            await model.replace_acl_entries(
+                "/workspaces/x",
+                [
+                    {
+                        "position": 0,
+                        "action": model.ACTION_ALLOW,
+                        "principal_type": model.PRINCIPAL_USER,
+                        "permission": "*",
+                        "user_id": model.AGENT_USER_ID,
+                        "group_id": None,
+                        "system_principal": None,
+                    }
+                ],
+            )
+
+
+class TestCreateWorkspaceWithAclAgentGuard:
+    async def test_create_workspace_with_acl_rejects_agent(self, db):
+        # Choke-point guard (#1135): the owner ACE is written by
+        # _seed_workspace_acl via raw SQL (can't call the guarded
+        # add_acl_entry), so the public entry point guards the creator.
+        with pytest.raises(model.AgentPrincipalError, match="system agent"):
+            await model.create_workspace_with_acl(model.AGENT_USER_ID, "ws")
+
+
 class TestHashFallbackHandle:
     def test_returns_hash_based_handle(self):
         from klangk_backend.model import _hash_fallback_handle

--- a/src/backend/tests/test_model.py
+++ b/src/backend/tests/test_model.py
@@ -1237,14 +1237,37 @@ class TestOIDCUsers:
 
 class TestUpdatePasswordAgentGuard:
     async def test_update_password_rejects_agent_user(self, db):
-        with pytest.raises(ValueError, match="system agent"):
+        with pytest.raises(model.AgentPrincipalError, match="system agent"):
             await model.update_password(model.AGENT_USER_ID, "hash")
 
 
 class TestDeleteUserAgentGuard:
     async def test_delete_user_rejects_agent_user(self, db):
-        with pytest.raises(ValueError, match="system agent"):
+        with pytest.raises(model.AgentPrincipalError, match="system agent"):
             await model.delete_user(model.AGENT_USER_ID)
+
+
+class TestAddUserToGroupAgentGuard:
+    async def test_add_user_to_group_rejects_agent(self, db):
+        # Choke-point guard (#1135): every add_user_to_group caller
+        # (role grants, group-member add, OIDC sync) is covered here.
+        with pytest.raises(model.AgentPrincipalError, match="system agent"):
+            await model.add_user_to_group(model.AGENT_USER_ID, "g")
+
+
+class TestAddAclEntryAgentGuard:
+    async def test_add_acl_entry_rejects_agent(self, db):
+        # Choke-point guard (#1135): direct PRINCIPAL_USER ACE grants
+        # (e.g. add_workspace_member) are covered here.
+        with pytest.raises(model.AgentPrincipalError, match="system agent"):
+            await model.add_acl_entry(
+                "/workspaces/x",
+                0,
+                model.ACTION_ALLOW,
+                "*",
+                model.PRINCIPAL_USER,
+                user_id=model.AGENT_USER_ID,
+            )
 
 
 class TestHashFallbackHandle:


### PR DESCRIPTION
## Summary

Closes #1135.

Enforces the "physical not principal" rule (#1133 D1.5) at **two layers**: the model choke points (friendly — typed error → HTTP 400) **and** the database schema itself (terminal — catches any raw-SQL writer that bypasses the functions). The system agent (`AGENT_USER_ID`, a global fixed source-published UUID) can never become an ACL principal, acquire an OIDC identity, carry a password, or be deleted — regardless of which Python function (or future raw-SQL writer) attempts it.

## Two-layer defense in depth

The function guards produce the good error; the schema is the backstop that fires only when a function guard is missing. Both are needed: every guard added in this PR sits at the Python-function layer, which a brand-new raw `INSERT` sails past — exactly the bug class the re-audit found twice.

```
API ─→ model fn: AgentPrincipalError → HTTP 400        (friendly; intended path)
          └→ SQL ─→ table CHECK / trigger → IntegrityError  (terminal; raw-SQL backstop)
```

### Layer 1 — function choke points (commit 2)

```
model.add_user_to_group         ─┐  rejects AGENT_USER_ID
model.add_acl_entry             ─┤  rejects AGENT_USER_ID as user principal
model.replace_acl_entries       ─┤  rejects agent in ANY entry (PUT-acl endpoints)
model.create_workspace_with_acl ─┤  rejects agent as workspace owner
model.delete_user               ─┤  (migrated from bare ValueError)
model.update_password           ─┘  (migrated from bare ValueError)
                                  ↓
                          AgentPrincipalError(ValueError) → global handler → HTTP 400
```

`register_exception_handlers(app)` wires the handler once for both the production app and the test app fixture.

### Layer 2 — schema belt-and-suspenders (commit 3)

The agent UUID is fixed and source-published, so it can be baked into the schema as a literal — giving a backstop nothing can bypass:

| # | Invariant | Table | Mechanism |
|---|-----------|-------|-----------|
| **A** | Agent never holds a user-principal ACE | `acl_entries` | `CHECK` — covers **both** writers (`add_acl_entry` + `replace_acl_entries`) |
| **B** | Agent never in a group | `user_groups` | `CHECK` |
| **C** | Agent never owns a workspace | `workspaces` | `CHECK` |
| **D** | Agent never has a password | `users` | `CHECK (id != AGENT OR password_hash IS NULL)` |
| **E** | Agent row can't be deleted | `users` | `BEFORE DELETE` trigger |
| **F** | Agent identity cols immutable (`provider`, `external_id`) | `users` | `BEFORE UPDATE OF` trigger — guards the #1145 OIDC-link vector |

`email` is **deliberately not** in F: it's legitimately re-seeded from env at boot (`ON CONFLICT DO UPDATE SET email`), so its policy lives at the fn layer (#1145), not the schema. (A test pins this so a future "add an email trigger" can't silently break boot.)

Seeding is compatible: `password_hash = NULL` passes D; INSERT never fires E/F; re-seed's `DO UPDATE SET email, handle` doesn't touch F's columns.

## The re-audit (why this isn't just "two choke points")

The first version of this PR guarded `add_user_to_group` and `add_acl_entry` and claimed completeness. Re-auditing **every raw INSERT** into `acl_entries` / `user_groups` found two more writers the guards didn't cover:

1. **`replace_acl_entries`** (`acl.py`) — the *second* writer into `acl_entries`, a raw INSERT fed **request-body `user_id`** by the PUT-acl endpoints (`PUT /workspaces/{id}/acl`, `PUT /admin/.../acl`). A workspace owner could PUT `[{principal_type: USER, user_id: AGENT_USER_ID, ...}]` and grant the agent a direct ACE, **bypassing the guarded `add_acl_entry` entirely**. Now guarded at both layers.
2. **`create_workspace_with_acl`** (`workspaces.py`) — the owner ACE + owners-group membership are written by `_seed_workspace_acl` via raw SQL (runs on the caller's transaction for atomicity, so it can't call the guarded functions). No live vector (creator is auth-derived) but guarded at both layers as defense-in-depth.

The lesson the audit proved twice: guarding each fan-out leaf means every new writer is a future leak. There are a *fixed* number of raw writers that materialize a grant, and all are now guarded at both the function and the DB.

## What changed

**Schema (`model/schema.py`):** 4 CHECK constraints + 2 triggers, literals f-stringed from `AGENT_USER_ID` / `PRINCIPAL_USER` (single source of truth).

**Model layer (`model/users.py`, `acl.py`, `workspaces.py`, `__init__.py`):** `AgentPrincipalError(ValueError)`; guards in `add_user_to_group`, `add_acl_entry`, `replace_acl_entries`, `create_workspace_with_acl`; `delete_user`/`update_password` migrated from bare `ValueError`.

**App layer (`main.py`):** `register_exception_handlers(app)` → HTTP 400.

**API layer — net deletion:** all endpoint-layer guards removed (7 total, including 2 pre-existing in `admin.py`).

**Net across the PR:** the friendly layer is −66 lines; the terminal backstop adds the schema constraints.

## Tests

- `test_model.py` — **6 function-choke-point tests** (`AgentPrincipalError`) + **7 schema-backstop tests** (raw SQL bypassing the fn guards, asserting `sqlalchemy.exc.IntegrityError`, including the email-mutability pin).
- `test_api.py` — 1 end-to-end smoke (`add_workspace_member` → 400) + admin delete/update-password handler coverage.

## Verification

- `python -m pytest src/backend/tests -n auto` → **2006 passed, 100% coverage**.
- ruff format + ruff check clean; all pre-commit hooks passed.

## Related

- **#1145** — OIDC email-collision takeover. This PR closes two of its halves at the DB for free: the **group-sync** half (commit 1, `add_user_to_group`) and the **OIDC-identity-binding** half (commit 3, invariant F). The **session-minting** and **email-repointing** halves remain #1145's job (fn layer). #1145 updated to reflect the new state.
