### PR TITLE
fix(agent): refuse to seed agent with another user's handle

### DIFF
--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -153,10 +153,31 @@ async def seed_agent_user() -> None:
 
     Reads email/handle from env vars (with defaults) and upserts the
     agent row.  This is the ONLY place the env vars are consulted.
+
+    Refuses to seed the agent with a handle already owned by another user.
+    A colliding agent handle is destructive: ``ensure_home_symlink`` would
+    later migrate that user's home files into the agent's tree via its
+    workspace-import adoption branch.  The ``users.handle`` UNIQUE
+    constraint is the structural backstop, but we fail loudly here with an
+    actionable message instead of letting a bare ``IntegrityError`` abort
+    startup mid-sequence.  See #1137.
     """
     email = resolve_env_value("KLANGK_CHAT_AGENT_EMAIL", "MrBoops@example.com")
     handle = resolve_env_value("KLANGK_CHAT_AGENT_HANDLE", "MrBoops")
     async with model.transaction() as db:
+        # Pre-check: refuse a handle already claimed by a non-agent user.
+        # Runs in the same transaction as the upsert so there is no
+        # check-then-act window.
+        cursor = await db.execute(
+            "SELECT id FROM users WHERE handle = ? AND id != ?",
+            (handle, AGENT_USER_ID),
+        )
+        if await cursor.fetchone() is not None:
+            raise RuntimeError(
+                f"Cannot seed chat agent: handle {handle!r} is already used"
+                " by another user. Set KLANGK_CHAT_AGENT_HANDLE to a"
+                " unique value."
+            )
         await db.execute(
             "INSERT INTO users (id, email, password_hash, verified,"
             " provider, handle)"

--- a/src/backend/tests/test_main.py
+++ b/src/backend/tests/test_main.py
@@ -1,12 +1,14 @@
 """Tests for main.py: lifespan, seed user, static files, logfire."""
 
 import os
+import sqlite3
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import FastAPI
 from httpx import AsyncClient, ASGITransport
+from sqlalchemy.exc import IntegrityError as SAIntegrityError
 
 from klangk_backend import main, model
 
@@ -96,6 +98,94 @@ class TestSeedAgentUser:
         # Cache should now reflect DB values
         agent = await model.get_agent_user()
         assert agent["email"] == "MrBoops@example.com"
+
+    async def test_users_handle_has_unique_constraint(self, db):
+        """The users.handle UNIQUE constraint is the structural backstop.
+
+        Confirms a duplicate handle raises IntegrityError at the DB layer,
+        independent of seed_agent_user's pre-check.  See #1137.
+        """
+        async with model.transaction() as db_conn:
+            await db_conn.execute(
+                "INSERT INTO users (id, email, handle)"
+                " VALUES ('uid-a', 'a@x.com', 'alice')"
+            )
+            with pytest.raises(SAIntegrityError) as exc_info:
+                await db_conn.execute(
+                    "INSERT INTO users (id, email, handle)"
+                    " VALUES ('uid-b', 'b@x.com', 'alice')"
+                )
+        # The underlying driver-level cause is the sqlite UNIQUE violation.
+        assert isinstance(exc_info.value.orig, sqlite3.IntegrityError)
+
+    async def test_seed_refuses_handle_collision_with_human(
+        self, db, monkeypatch
+    ):
+        """Seeding the agent with a live user's handle fails cleanly.
+
+        The destructive path is ensure_home_symlink migrating that user's
+        files into the agent's tree; the guard must abort before any such
+        work.  See #1137.
+        """
+        human = await model.create_user(
+            "alice@example.com", "hash", verified=True
+        )
+        assert human["handle"] == "alice"
+        monkeypatch.setenv("KLANGK_CHAT_AGENT_HANDLE", "alice")
+        with pytest.raises(RuntimeError, match="alice"):
+            await main.seed_agent_user()
+        # Human user is untouched.
+        refreshed = await model.get_user_by_id(human["id"])
+        assert refreshed["handle"] == "alice"
+        # Agent was not created with the colliding handle.
+        assert await model.get_user_by_id(model.AGENT_USER_ID) is None
+
+    async def test_seed_rename_to_human_handle_refuses(self, db, monkeypatch):
+        """Re-seeding the agent onto a human's handle fails, leaves agent as-is."""
+        await main.seed_agent_user()  # agent handle = MrBoops
+        human = await model.create_user(
+            "alice@example.com", "hash", verified=True
+        )
+        monkeypatch.setenv("KLANGK_CHAT_AGENT_HANDLE", "alice")
+        with pytest.raises(RuntimeError, match="already used by another user"):
+            await main.seed_agent_user()
+        # Agent keeps its original handle; human untouched.
+        agent = await model.get_user_by_id(model.AGENT_USER_ID)
+        assert agent["handle"] == "MrBoops"
+        refreshed = await model.get_user_by_id(human["id"])
+        assert refreshed["handle"] == "alice"
+
+    async def test_collision_leaves_human_files_untouched(
+        self, db, monkeypatch, tmp_path
+    ):
+        """A handle collision never reaches ensure_home_symlink's adoption.
+
+        Builds the on-disk layout that the destructive branch would migrate
+        (a /home/<handle> symlink -> .users/<human-uid> with files) and
+        confirms a colliding agent seed aborts before any file moves.  See
+        #1137.
+        """
+        human = await model.create_user(
+            "alice@example.com", "hash", verified=True
+        )
+        # Stand up the destructive-branch precondition directly on disk.
+        home = tmp_path / "home"
+        users_dir = home / ".users"
+        users_dir.mkdir(parents=True)
+        human_dir = users_dir / human["id"]
+        human_dir.mkdir()
+        (human_dir / "secret.txt").write_text("alice's secrets")
+        (home / "alice").symlink_to(f".users/{human['id']}")
+
+        monkeypatch.setenv("KLANGK_CHAT_AGENT_HANDLE", "alice")
+        with pytest.raises(RuntimeError):
+            await main.seed_agent_user()
+
+        # Human's files are exactly where they were — nothing migrated.
+        assert (human_dir / "secret.txt").read_text() == "alice's secrets"
+        assert os.readlink(home / "alice") == f".users/{human['id']}"
+        # No agent user directory was created.
+        assert not (users_dir / model.AGENT_USER_ID).exists()
 
 
 # --- Lifespan ---


### PR DESCRIPTION
## Summary

`ensure_home_symlink`'s workspace-import branch silently **migrates files**
from an existing `/home/<handle>` symlink target into a newly-seeded user's
directory. That's correct for import, but the same branch fires for *any*
handle collision — so a deployer setting `KLANGK_CHAT_AGENT_HANDLE` to a live
human user's handle would migrate that user's files into the agent's tree.

The protection was the `users.handle` `UNIQUE` constraint (raises
`IntegrityError` in `seed_agent_user`'s upsert before `ensure_home_symlink`
ever runs), but it was **incidental and unverified**, and a bare
`IntegrityError` aborts startup with an opaque traceback. Closes #1137.

## Root cause

`ensure_home_symlink` (workspaces.py:355-366) adopts an existing symlink
target's content by design (workspace import), but does not — and cannot,
as a filesystem-only sync helper — distinguish the legitimate import case
from a live collision. The only thing standing between a colliding agent
handle and destructive migration was the `users.handle` constraint aborting
`seed_agent_user`'s `ON CONFLICT(id) DO UPDATE`, which raised an opaque
`IntegrityError` rather than a comprehensible startup failure.

## Fix

Make the guard **explicit and the failure comprehensible** in
`seed_agent_user` (main.py): before the upsert, refuse any handle already
owned by a non-agent user — checked in the *same transaction* as the upsert,
so there is no check-then-act window — raising an actionable `RuntimeError`
that names the colliding handle:

```
Cannot seed chat agent: handle 'alice' is already used by another user.
Set KLANGK_CHAT_AGENT_HANDLE to a unique value.
```

The `UNIQUE` constraint remains as the structural backstop. Defense is now
three layers: the seed-time guard (explicit, comprehensible) → the constraint
(backstop) → `agent._ensure_home` re-reading `agent_handle()` live from the
DB (so a rolled-back seed can never reach the symlink code with a colliding
handle).

## Verification

New tests in `test_main.py::TestSeedAgentUser`:

| test | confirms |
|---|---|
| `test_users_handle_has_unique_constraint` | the `UNIQUE` constraint raises `IntegrityError` at the DB layer (the backstop), independent of the guard |
| `test_seed_refuses_handle_collision_with_human` | fresh agent seed onto a human's handle fails cleanly with a `RuntimeError` naming the handle; human row untouched; agent not created with the colliding handle |
| `test_seed_rename_to_human_handle_refuses` | agent rename onto a human's handle fails; agent keeps its original handle |
| `test_collision_leaves_human_files_untouched` | stands up the on-disk layout the destructive branch would migrate (`/home/alice -> .users/<human-uid>` with files) and confirms nothing moves |

- Backend suite: **1997 passed, 100.00% coverage** (`pytest -n auto`).
- `ruff format` / `ruff check` clean; pre-commit hooks green.

## Scope note (optional secondary, not done)

The issue's optional secondary — making `ensure_home_symlink` *locally*
refuse to migrate a live user's directory — is deliberately left as a
follow-up. `ensure_home_symlink` is a generic, filesystem-only, sync helper
shared across workspace-import, real-user-connect, and agent paths; coupling
it to the model layer (to ask "is the old target's UUID a live user?") would
widen its contract for every caller. The seed-time guard covers the
documented agent-collision case precisely, and the constraint is the
verified backstop.

## Acceptance criteria

- [x] Confirmed `users.handle` has a `UNIQUE` constraint (schema.py:18/:36) — verified by `test_users_handle_has_unique_constraint`.
- [x] Test: renaming the agent to a live user's handle fails cleanly before any symlink migration; the human user's files remain untouched.
- [x] The failure surfaces a comprehensible cause (actionable `RuntimeError` naming the handle, not a bare traceback).
- [ ] (Optional) `ensure_home_symlink` locally refuses to migrate a live user's directory — deferred (see Scope note).