### PR TITLE
Give the agent operating-environment context (#1140)

### DIFF
--- a/src/backend/klangk_backend/wshandler/agent_mention.py
+++ b/src/backend/klangk_backend/wshandler/agent_mention.py
@@ -55,16 +55,65 @@ async def _addresses_other_user(text: str) -> bool:
     return mention != handle.lower()
 
 
+def _asker_context_header(
+    user_id: str | None,
+    user_handle: str | None,
+    user_home: str | None,
+) -> str | None:
+    """Build the ``[Asking user: ...]`` header that resolves "my".
+
+    The chat agent has no user identity of its own (it runs as the
+    ``klangk`` service user, with no ``KLANGK_USER_ID``), so "my
+    history" / "my terminal" is ambiguous in a multi-collaborator
+    workspace. Injecting the asking user's identity lets the agent
+    target the right per-user tmux session (named after ``user_id``)
+    and home directory. Returns ``None`` when no identity was provided
+    (the caller then omits the header).
+    """
+    if not user_id:
+        return None
+    parts = [f"id {user_id}"]
+    if user_handle:
+        parts.append(f"handle {user_handle}")
+    if user_home:
+        parts.append(f"home {user_home}")
+    return (
+        "[Asking user: "
+        + ", ".join(parts)
+        + '. Their interactive terminals are tmux session "'
+        + user_id
+        + '"; "my"/"my history" refers to that session.]'
+    )
+
+
 async def _handle_agent_mention(
-    workspace_id: str, container_id: str, user_text: str
+    workspace_id: str,
+    container_id: str,
+    user_text: str,
+    *,
+    user_id: str | None = None,
+    user_handle: str | None = None,
+    user_home: str | None = None,
 ) -> None:
-    """Handle an @agent mention by sending the prompt to Pi RPC."""
+    """Handle an @agent mention by sending the prompt to Pi RPC.
+
+    *user_id* / *user_handle* / *user_home* identify the asking user so
+    the agent can resolve "my" (its own process has no user identity).
+    Omitted when ``None`` (e.g. from older call sites); the header is
+    then not injected and "my" is left for the agent to disambiguate.
+    """
 
     agent_handle = await model.agent_handle()
     agent_re = _get_agent_mention_re(agent_handle)
     prompt = agent_re.sub("", user_text).strip()
     if not prompt:
         prompt = "Hello!"
+
+    # Inject the asking user's identity so the agent can target the
+    # asker's own tmux session / home when they say "my".
+    asker_header = _asker_context_header(user_id, user_handle, user_home)
+    if asker_header:
+        prompt = f"{asker_header}\n\n{prompt}"
 
     # Include messages from OTHER users since the agent's last response
     # as context.  The current user's message is already the prompt;

--- a/src/backend/klangk_backend/wshandler/connection.py
+++ b/src/backend/klangk_backend/wshandler/connection.py
@@ -776,9 +776,18 @@ class Connection:
         if should_route and self.container_id:
             # One agent-run slot per workspace: cancel any in-flight run
             # so concurrent @mentions don't orphan the earlier task.
+            # Pass the asking user's identity so the agent can resolve
+            # "my" (its process has no user identity of its own).
             _cancel_agent_task(workspace_id)
             _agent_tasks[workspace_id] = asyncio.create_task(
-                _handle_agent_mention(workspace_id, self.container_id, text)
+                _handle_agent_mention(
+                    workspace_id,
+                    self.container_id,
+                    text,
+                    user_id=self.user.get("id"),
+                    user_handle=self.user.get("handle"),
+                    user_home=self._user_home,
+                )
             )
 
     async def handle_chat_delete(self, msg: dict) -> None:

--- a/src/backend/tests/test_setup_clankers.py
+++ b/src/backend/tests/test_setup_clankers.py
@@ -133,25 +133,31 @@ class TestWriteModels:
         assert models["providers"]["llm-proxy"]["models"] == []
 
 
-class TestBuildSystemPrompt:
+class TestBuildAgentContext:
     def test_copies_prompt(self, fake_home, monkeypatch):
-        prompt_src = sc.IMAGE_DIR.parent / "system-prompt.md"
-        prompt_src.write_text("# System Prompt")
-        monkeypatch.setattr(sc, "SYSTEM_PROMPT_SRC", prompt_src)
+        prompt_src = sc.IMAGE_DIR.parent / "agent-context.md"
+        prompt_src.write_text("# Agent Context")
+        monkeypatch.setattr(sc, "AGENT_CONTEXT_SRC", prompt_src)
 
-        sc.build_system_prompt()
+        sc.build_agent_context()
 
-        assert (fake_home / "AGENTS.md").read_text() == "# System Prompt"
+        # Lands in Pi's global context-file slot, not home root.
+        assert (
+            fake_home / ".pi" / "agent" / "AGENTS.md"
+        ).read_text() == "# Agent Context"
+        assert not (fake_home / "AGENTS.md").exists()  # home-root copy is gone
 
     def test_does_not_overwrite_existing(self, fake_home, monkeypatch):
-        prompt_src = sc.IMAGE_DIR.parent / "system-prompt.md"
+        prompt_src = sc.IMAGE_DIR.parent / "agent-context.md"
         prompt_src.write_text("# New")
-        monkeypatch.setattr(sc, "SYSTEM_PROMPT_SRC", prompt_src)
-        (fake_home / "AGENTS.md").write_text("# User Custom")
+        monkeypatch.setattr(sc, "AGENT_CONTEXT_SRC", prompt_src)
+        agents_md = fake_home / ".pi" / "agent"
+        agents_md.mkdir(parents=True)
+        (agents_md / "AGENTS.md").write_text("# User Custom")
 
-        sc.build_system_prompt()
+        sc.build_agent_context()
 
-        assert (fake_home / "AGENTS.md").read_text() == "# User Custom"
+        assert (agents_md / "AGENTS.md").read_text() == "# User Custom"
 
 
 class TestMain:

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -8427,7 +8427,7 @@ class TestChatSend:
         await session.add_subscriber(sock1, "cid")
         await session.add_subscriber(sock2, "cid")
 
-        async def slow_mention(workspace_id, container_id, text):
+        async def slow_mention(workspace_id, container_id, text, **kwargs):
             await asyncio.sleep(999)
 
         try:
@@ -9694,6 +9694,77 @@ class TestAgentMentionOtherMsgsContext:
             assert len(captured_prompt) == 1
             assert "user2@example.com" in captured_prompt[0]
             assert "interesting point" in captured_prompt[0]
+        finally:
+            await session.remove_subscriber(sock)
+            state.sessions.pop(ws_id, None)
+            wshandler._agent_tasks.pop(ws_id, None)
+
+
+class TestAgentMentionAskerIdentity:
+    """The asking user's identity is injected so the agent can resolve "my"."""
+
+    def test_header_includes_id_handle_home(self):
+        from klangk_backend.wshandler.agent_mention import (
+            _asker_context_header,
+        )
+
+        header = _asker_context_header("uid-123", "alice", "/home/alice")
+
+        assert "id uid-123" in header
+        assert "handle alice" in header
+        assert "home /home/alice" in header
+        # Points the agent at the asker's own tmux session.
+        assert 'tmux session "uid-123"' in header
+        assert '"my"/"my history"' in header
+
+    def test_header_none_without_user_id(self):
+        from klangk_backend.wshandler.agent_mention import (
+            _asker_context_header,
+        )
+
+        assert _asker_context_header(None, "alice", "/home/alice") is None
+
+    async def test_identity_prepended_to_prompt(self, user, agent_user):
+        """An @mention from a user injects that user's identity header."""
+        from klangk_backend.wshandler import _handle_agent_mention
+
+        workspace = await model.create_workspace(user["id"], "id-ws")
+        ws_id = workspace["id"]
+
+        captured_prompt = []
+        mock_session = AsyncMock()
+
+        async def capture_prompt(prompt):
+            captured_prompt.append(prompt)
+            return "response"
+
+        mock_session.send_prompt = capture_prompt
+
+        sock = _mock_sock()
+        session = state.get_or_create_session(ws_id)
+        await session.add_subscriber(sock, "cid")
+
+        try:
+            with patch(
+                "klangk_backend.agent.get_session",
+                return_value=mock_session,
+            ):
+                await _handle_agent_mention(
+                    ws_id,
+                    "cid",
+                    "@MrBoops restart my service",
+                    user_id=user["id"],
+                    user_handle=user.get("handle") or "somebody",
+                    user_home="/home/somebody",
+                )
+
+            assert len(captured_prompt) == 1
+            prompt = captured_prompt[0]
+            # The @mention is stripped and the asker header is present.
+            assert "@MrBoops" not in prompt
+            assert "restart my service" in prompt
+            assert user["id"] in prompt
+            assert "/home/somebody" in prompt
         finally:
             await session.remove_subscriber(sock)
             state.sessions.pop(ws_id, None)

--- a/src/containers/workspace/Dockerfile
+++ b/src/containers/workspace/Dockerfile
@@ -39,8 +39,8 @@ RUN curl -LsSf https://astral.sh/uv/0.11.23/install.sh | sh \
     && mv /root/.local/bin/uv /usr/local/bin/uv \
     && mv /root/.local/bin/uvx /usr/local/bin/uvx
 
-# Entrypoint, system prompt, bash defaults (change frequently during dev)
-COPY system-prompt.md /opt/klangk/system-prompt.md
+# Entrypoint, agent context file, bash defaults (change frequently during dev)
+COPY agent-context.md /opt/klangk/agent-context.md
 COPY entrypoint.sh /opt/klangk/entrypoint.sh
 COPY klangk-otel.sh /opt/klangk/bin/klangk-otel.sh
 COPY klangk-setup-clankers.py /opt/klangk/bin/klangk-setup-clankers

--- a/src/containers/workspace/agent-context.md
+++ b/src/containers/workspace/agent-context.md
@@ -1,4 +1,4 @@
-# System Prompt
+# Klangk Agent Context
 
 You are an expert coding agent working within a container.
 
@@ -122,3 +122,106 @@ When working with CSV, logs, datasets, and other large files:
 - For deeper analysis, write a Python script that processes the file locally
   and prints a summary.
 - Only read small files (< 10KB) directly with the `read` tool.
+
+## Your Operating Environment
+
+This is a **klangk workspace container**. Everything runs as the unix user
+`klangk`. You already have full physical access: files, processes, and the
+shared tmux server. The facts here are **orientation** — they tell you what is
+there and how to discover it, not what to do. When you need current state
+(which sessions exist, what is running, whether a service is up), **introspect
+with your own shell** rather than guessing. Injecting live state here would go
+stale the instant it was written.
+
+- Discover the workspace's environment with `env | grep KLANGK_`. Notable vars:
+  `KLANGK_LLM_PROXY_URL`, `KLANGK_LLM_MODEL`, `KLANGK_PORT_MAPPINGS`, and
+  `KLANGK_WORKSPACE_ID`. (Do not treat this list as exhaustive — re-run the
+  command to see what is actually set.)
+- Decide **your own mechanism** for a task based on what you observe. For
+  example, to restart a service you might send Ctrl-C to a foreground process,
+  `pkill` a daemon, `curl` a health endpoint and wait, edit a config and
+  `SIGHUP`, or call a service's own `*-ctl restart`. Choose; do not follow a
+  fixed script.
+
+## tmux — where everything runs
+
+All workspace processes — the workspace's own service, users' interactive
+terminals, and shared terminals — live as sessions on **one shared tmux
+server** (as user `klangk`). There is no per-user tmux socket; the thing that
+is per-user is the **session name**.
+
+- A user's interactive terminals are a tmux session **named after the user's
+  id** (e.g. `tmux list-sessions` shows one session per user). The workspace's
+  own service runs in a window named **`default-cmd`** inside the **owner's**
+  session.
+- **List** what exists: `tmux list-sessions`, then `tmux list-windows -t
+<session>` and `tmux list-panes -t <session>`.
+- **Observe** a pane: `tmux capture-pane -p -t <session>:<window>.<pane> -S -
+<lines>` (e.g. `-S -5000`). `-S -` captures scrollback _before_ the visible
+  screen; without it you only get the current viewport.
+- **Act** in a pane: `tmux send-keys -t <target> '<command>' Enter`, or send a
+  control character like `tmux send-keys -t <target> C-c`.
+
+## Interaction history ("read my history")
+
+When a user asks you to act on "what I was doing" — e.g. "I'm stuck, read my
+history and finish it" or "explain this error" — what they mean is their
+**interaction history**: the sequence of **prompts and their results**
+(the command they typed _and_ the output it produced, in order).
+
+- **tmux scrollback is the source.** Each pane's scrollback is a faithful
+  rendered record of prompt → command → output → next prompt — which _is_
+  interaction history. Capture it with `tmux capture-pane -p -S -<limit>`.
+- **Do not** treat one screen (a single pane's current viewport) as the whole
+  story. What the user was doing often spans **several panes/windows** and goes
+  further back than the visible screen. Enumerate the relevant session's panes
+  and capture each one's scrollback.
+- **Do not** use `~/.bash_history`. It is bare commands only (no results), is
+  flushed on shell exit, and is racy across concurrent shells — useless for
+  this.
+
+### Whose session is "mine"?
+
+This context serves two readers, and "my" resolves differently for each:
+
+- **A human running `pi` directly in their terminal** is themselves. Their own
+  tmux session is named after their user id, which is in the `$KLANGK_USER_ID`
+  env var in their shell (and their handle in `$KLANGK_USER_HANDLE`). "My
+  history" is `tmux capture-pane -t $KLANGK_USER_ID:…`.
+- **The chat agent** has no user identity of its own — it runs as the `klangk`
+  service user, and its process env has no `KLANGK_USER_ID`. When a user pings
+  it in chat, the asking user's identity (handle, id, home, and tmux session)
+  is injected into the prompt for that request. "My history" = the asking
+  user's session, taken from that injection. (If no identity was provided, ask
+  rather than guessing which session is meant.)
+
+## The LLM proxy
+
+Outbound model calls go through the workspace's LLM proxy at
+`$KLANGK_LLM_PROXY_URL` (discover it with `env | grep KLANGK_`). It
+authenticates with a **workspace-scoped token** (`purpose: workspace`) — that
+is the only credential available to you, and it is good solely for LLM calls
+through the proxy. Use it as your `pi` is already configured to; you do not
+normally need to call it by hand.
+
+## Do not use the workspace's REST / WebSocket API
+
+The workspace has an HTTP/WebSocket API surface (used by the browser UI and
+the CLI client). **It is not a tool for you, and you should not attempt to
+reach it.** Every task you are asked to do is achievable through in-container
+physical means — tmux, files, processes, and the LLM proxy — so you have no
+need for the REST API. Do not construct calls to it, do not look for an API
+key or token beyond the LLM-proxy workspace token, and do not attempt to act
+on workspace settings (roles, shares, etc.) through it. Reach for tmux and the
+filesystem instead.
+
+## Respect other users' terminals
+
+All collaborators share the `klangk` unix identity and the single tmux server,
+so you _can_ technically `capture-pane` or `send-keys` into **any** user's
+session. Treat that as out-of-bounds by default. Steer "my"/"my history" to
+the **asking user's own** session (see "Whose session is 'mine'?"), and do not
+read or type into another user's terminal unless that user plainly owns the
+target — e.g. the workspace owner asking about the shared `default-cmd`
+service window. "Show me what Bob is doing" is not a reason to capture Bob's
+session.

--- a/src/containers/workspace/klangk-setup-clankers.py
+++ b/src/containers/workspace/klangk-setup-clankers.py
@@ -16,7 +16,7 @@ import traceback
 from pathlib import Path
 
 IMAGE_DIR = Path("/opt/klangk/pi-agent")
-SYSTEM_PROMPT_SRC = Path("/opt/klangk/system-prompt.md")
+AGENT_CONTEXT_SRC = Path("/opt/klangk/agent-context.md")
 ERROR_LOG = Path("/tmp/klangk-setup-clankers-errors.log")
 
 
@@ -112,12 +112,21 @@ def write_models():
     (agent / "models.json").write_text(json.dumps(models, indent=2))
 
 
-def build_system_prompt():
-    """Write AGENTS.md to $HOME if not present."""
-    home = Path(os.environ.get("HOME", ""))
-    prompt_path = home / "AGENTS.md"
-    if not prompt_path.exists() and SYSTEM_PROMPT_SRC.is_file():
-        prompt_path.write_text(SYSTEM_PROMPT_SRC.read_text())
+def build_agent_context():
+    """Write AGENTS.md to ~/.pi/agent/ (Pi's global context-file slot).
+
+    Pi loads ``~/.pi/agent/AGENTS.md`` as a *context file* on every run,
+    regardless of cwd (its always-loaded global slot). The prior behavior wrote
+    ``$HOME/AGENTS.md`` (home root) to interop with Claude, which is no longer
+    shipped in the base image; Pi reads the global context file from
+    ``~/.pi/agent/`` instead. This serves both the chat agent (``pi --mode rpc``)
+    and any human running ``pi`` directly.
+    """
+    agent = _agent_dir()
+    agent.mkdir(parents=True, exist_ok=True)
+    prompt_path = agent / "AGENTS.md"
+    if not prompt_path.exists() and AGENT_CONTEXT_SRC.is_file():
+        prompt_path.write_text(AGENT_CONTEXT_SRC.read_text())
 
 
 def _run_step(name, fn):
@@ -155,7 +164,7 @@ def main():
     _run_step("sync_image_packages", sync_image_packages)
     _run_step("write_settings", write_settings)
     _run_step("write_models", write_models)
-    _run_step("build_system_prompt", build_system_prompt)
+    _run_step("build_agent_context", build_agent_context)
 
     if ERROR_LOG.exists():
         print(f"klangk-setup-clankers: some steps failed, see {ERROR_LOG}")


### PR DESCRIPTION
Closes #1140.

## What

The chat agent runs in-container as user \`klangk\` with full physical access to the shared tmux server, the LLM proxy, files, and processes — but it lacked **orientation** about what is there to work with. This adds static operating-environment facts as Pi's global context file, resolves \"my\" for the chat agent, and corrects the delivery path.

## Changes

**Content — `agent-context.md`** (new operating-environment sections):
- Operating environment: introspect with \`env | grep KLANGK_\`; choose your own mechanism (no fixed restart script).
- tmux orientation: one shared server, per-user sessions named by \`user_id\`, \`default-cmd\` window in the owner's session; list / observe (\`capture-pane -S\` for scrollback) / act (\`send-keys\`).
- Interaction history (\"read my history\"): tmux scrollback is the source — prompts **and** results, across panes/sessions; not one screen, not \`~/.bash_history\`.
- \"Whose session is mine?\": humans resolve via \`$KLANGK_USER_ID\`; the chat agent gets the asker injected.
- REST/WebSocket API actively **discouraged** (in-container means only).
- Cross-user privacy norm: stay in the asker's own session.

**Path correction (context file, not system prompt):**
- Rename \`system-prompt.md\` → \`agent-context.md\`; \`SYSTEM_PROMPT_SRC\` → \`AGENT_CONTEXT_SRC\`; \`build_system_prompt()\` → \`build_agent_context()\`.
- Deliver to \`~/.pi/agent/AGENTS.md\` (Pi's global **context-file** slot, per `pi-mono` docs `usage.md:96-102`) instead of \`$HOME/AGENTS.md\` (the dropped Claude-interop copy). Distinct from \`SYSTEM.md\`/\`APPEND_SYSTEM.md\` (system-prompt files), which this issue does **not** use.

**Resolving \"my\":**
- The chat agent has no user identity (workspace-scoped token, no \`KLANGK_USER_ID\`). Thread the asker's \`id\`/\`handle\`/\`home\` from the connection into \`_handle_agent_mention\` and inject a \`[Asking user: …]\` header so the agent targets the asker's tmux session (\`-t <user_id>\`) and home.

## Notes
- References only env vars verified to exist in the container env. \`$KLANGK_AGENT_HOME\` (from the unmerged #1133) is intentionally absent — I used \`$HOME\` + \`env | grep KLANGK_\` instead.
- All 2014 backend tests pass.

## Test plan
- [x] \`test_setup_clankers.py\`: \`build_agent_context()\` writes to \`~/.pi/agent/AGENTS.md\` (not \`$HOME/AGENTS.md\`); doesn't overwrite an existing copy.
- [x] \`test_wshandler.py\`: \`_asker_context_header\` unit tests; identity header is prepended to the prompt when an @mention carries the asker's identity.
- [x] Full backend suite green.