### PR TITLE
Remove the now-unused workspace_members WebSocket event

### DIFF
--- a/src/backend/klangk_backend/api/workspaces.py
+++ b/src/backend/klangk_backend/api/workspaces.py
@@ -679,20 +679,6 @@ async def _check_workspace_share(request: Request, user: dict) -> str:
     return f"/workspaces/{workspace_id}"
 
 
-async def _broadcast_workspace_members(workspace_id: str) -> None:
-    """Push updated workspace members to all connected subscribers."""
-    session = wshandler.state.get_session(workspace_id)
-    if not session:
-        return
-    members = await model.get_workspace_members(workspace_id)
-    workspace = await model.get_workspace(workspace_id)
-    if workspace:
-        owner = await model.get_user_by_id(workspace.get("user_id", ""))
-        if owner and not any(m["id"] == owner["id"] for m in members):
-            members.append({"id": owner["id"], "email": owner["email"]})
-    session.broadcast({"type": "workspace_members", "members": members})
-
-
 @router.get("/workspaces/{workspace_id}/members")
 async def get_workspace_members(
     workspace_id: str,
@@ -733,7 +719,6 @@ async def add_workspace_member(
             user_id=target["id"],
         )
         next_pos += 1
-    await _broadcast_workspace_members(workspace_id)
     wshandler.state.notify_user_workspaces_changed(user["id"])
     wshandler.state.notify_user_workspaces_changed(target["id"])
     return {
@@ -763,7 +748,6 @@ async def remove_workspace_member(
     for i, entry in enumerate(remaining):
         entry["position"] = i
     await model.replace_acl_entries(resource, remaining)
-    await _broadcast_workspace_members(workspace_id)
     wshandler.state.notify_user_workspaces_changed(user["id"])
     wshandler.state.notify_user_workspaces_changed(member_id)
     return {"status": "removed"}
@@ -820,7 +804,6 @@ async def add_to_workspace_role(
     if target is None:
         raise HTTPException(status_code=404, detail="User not found")
     await model.add_user_to_group(target["id"], group["id"])
-    await _broadcast_workspace_members(workspace_id)
     wshandler.state.notify_user_workspaces_changed(user["id"])
     wshandler.state.notify_user_workspaces_changed(target["id"])
     return {"ok": True}
@@ -841,7 +824,6 @@ async def remove_from_workspace_role(
     if group is None:
         raise HTTPException(status_code=404, detail="Role group not found")
     await model.remove_user_from_group(member_id, group["id"])
-    await _broadcast_workspace_members(workspace_id)
     wshandler.state.notify_user_workspaces_changed(user["id"])
     wshandler.state.notify_user_workspaces_changed(member_id)
     return {"ok": True}
@@ -889,7 +871,6 @@ async def change_workspace_role(
             raise HTTPException(status_code=404, detail="Role group not found")
         await model.add_user_to_group(target["id"], group["id"])
 
-    await _broadcast_workspace_members(workspace_id)
     wshandler.state.notify_user_workspaces_changed(user["id"])
     wshandler.state.notify_user_workspaces_changed(target["id"])
     return {"ok": True, "email": body.email, "role": body.role}

--- a/src/backend/klangk_backend/wshandler/connection.py
+++ b/src/backend/klangk_backend/wshandler/connection.py
@@ -369,30 +369,6 @@ class Connection:
                 {"type": "chat_history", "messages": chat_history}
             )
 
-    async def _send_workspace_members(
-        self, workspace_id: str, workspace: dict
-    ) -> None:
-        """Send workspace members (including agent) for @mention autocomplete."""
-        members = await model.get_workspace_members(workspace_id)
-        owner = await model.get_user_by_id(workspace.get("user_id", ""))
-        if owner and not any(m["id"] == owner["id"] for m in members):
-            members.append(
-                {
-                    "id": owner["id"],
-                    "email": owner["email"],
-                    "handle": owner.get("handle", ""),
-                }
-            )
-        agent_user = await model.get_agent_user()
-        members.append(
-            {
-                "id": model.AGENT_USER_ID,
-                "email": agent_user["email"],
-                "handle": agent_user.get("handle", ""),
-            }
-        )
-        self.sock.send_json({"type": "workspace_members", "members": members})
-
     async def _broadcast_join(
         self, workspace_id: str, rejoining: bool
     ) -> None:
@@ -484,7 +460,6 @@ class Connection:
         )
 
         await self._send_chat_history(workspace_id)
-        await self._send_workspace_members(workspace_id, workspace)
 
         if self.container_id:
             asyncio.create_task(self._start_agent_if_needed())

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -2146,40 +2146,6 @@ class TestWorkspaceSharingRoutes:
         )
         assert resp.status_code == 403
 
-    async def test_add_member_broadcasts_workspace_members(self, client, user):
-        """Adding a member broadcasts updated workspace_members to WS."""
-        from klangk_backend.wshandler import WorkspaceSession
-
-        headers = await _auth_headers(client)
-        await self._create_other_user()
-        resp = await client.post(
-            "/api/v1/workspaces",
-            headers=headers,
-            json={"name": "broadcast-ws"},
-        )
-        ws_id = resp.json()["id"]
-        mock_sock = MagicMock()
-        mock_sock.send_json = MagicMock()
-        session = WorkspaceSession(ws_id)
-        session.subscribers.add(mock_sock)
-        wshandler.state.sessions[ws_id] = session
-        try:
-            resp = await client.post(
-                f"/api/v1/workspaces/{ws_id}/members",
-                headers=headers,
-                json={"email": "other@example.com"},
-            )
-            assert resp.status_code == 200
-            calls = [c[0][0] for c in mock_sock.send_json.call_args_list]
-            members_msgs = [
-                c for c in calls if c.get("type") == "workspace_members"
-            ]
-            assert len(members_msgs) == 1
-            emails = [m["email"] for m in members_msgs[0]["members"]]
-            assert "other@example.com" in emails
-        finally:
-            wshandler.state.sessions.pop(ws_id, None)
-
     async def test_members_no_permission(self, client, user):
         """User without share permission gets 403 on nonexistent workspace."""
         headers = await _auth_headers(client)

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -8529,40 +8529,6 @@ class TestChatSend:
         await conn.handle_chat_load_more({})
         sock.send_json.assert_not_called()
 
-    async def test_workspace_members_on_connect(self, user, agent_user):
-        """Workspace members list is sent on connect."""
-        workspace = await _create_workspace_with_acl(user["id"], "members-ws")
-
-        sock = _mock_sock()
-        conn = _base_conn(user=user, ws=sock)
-
-        async def fake_start(wid, ws_obj):
-            conn.container_id = "cid"
-
-        with (
-            patch.object(
-                Connection,
-                "start_workspace_container",
-                side_effect=fake_start,
-            ),
-            patch.object(
-                container.registry,
-                "get_workspace_ports",
-                return_value=[],
-            ),
-        ):
-            await conn.handle_workspace_connect(
-                {"workspaceId": workspace["id"]}
-            )
-
-        calls = [c[0][0] for c in sock.send_json.call_args_list]
-        members_msgs = [
-            c for c in calls if c.get("type") == "workspace_members"
-        ]
-        assert len(members_msgs) == 1
-        member_ids = [m["id"] for m in members_msgs[0]["members"]]
-        assert user["id"] in member_ids
-
 
 class TestPresence:
     async def test_presence_list_on_connect(self, user, agent_user):

--- a/src/frontend/e2e-tests/e2e/klangk.spec.ts
+++ b/src/frontend/e2e-tests/e2e/klangk.spec.ts
@@ -1506,7 +1506,7 @@ test.describe("Klangk E2E", () => {
     });
   });
 
-  test("workspace_members broadcast on member add and chat @mention", async ({
+  test("workspace roster via REST after member add; chat @mention carries mentions", async ({
     browser,
     request,
   }) => {
@@ -1530,6 +1530,18 @@ test.describe("Klangk E2E", () => {
       data: { email: memberEmail },
     });
 
+    // The workspace member roster is served by the REST endpoint, not (since
+    // #1148) pushed over the WebSocket. Assert it reflects the membership.
+    const initialRosterResp = await request.get(
+      `${API_BASE}/api/v1/workspaces/${workspaceId}/members`,
+      { headers: ownerHeaders },
+    );
+    expect(initialRosterResp.ok()).toBeTruthy();
+    const initialEmails = (await initialRosterResp.json()).map(
+      (m: { email: string }) => m.email,
+    );
+    expect(initialEmails).toContain(memberEmail);
+
     // Capture WS on owner page to send commands
     const wsCaptureScript = `(() => {
       const Orig = window.WebSocket;
@@ -1549,15 +1561,11 @@ test.describe("Klangk E2E", () => {
     await ctx1.addInitScript(wsCaptureScript);
     const page1 = await ctx1.newPage();
 
-    // Collect workspace_members and chat_message on owner page
-    const ownerWsMessages: string[] = [];
+    // Collect chat_message on owner page
     const ownerChatMessages: string[] = [];
     page1.on("websocket", (ws) => {
       ws.on("framereceived", (frame: { payload: string | Buffer }) => {
         const text = frame.payload.toString();
-        if (text.includes("workspace_members")) {
-          ownerWsMessages.push(text);
-        }
         if (text.includes("chat_message")) {
           ownerChatMessages.push(text);
         }
@@ -1568,28 +1576,16 @@ test.describe("Klangk E2E", () => {
       waitForTerminal: true,
     });
 
-    // Initial workspace_members should have been received on connect
-    expect(ownerWsMessages.length).toBeGreaterThan(0);
-    const initial = JSON.parse(ownerWsMessages[ownerWsMessages.length - 1]);
-    expect(initial.type).toBe("workspace_members");
-    const initialEmails = initial.members.map(
-      (m: { email: string }) => m.email,
-    );
-    expect(initialEmails).toContain(memberEmail);
-    expect(initialEmails).toContain(ownerEmail);
-
-    // Now add a late member while owner is connected
-    const countBefore = ownerWsMessages.length;
+    // Add a late member and confirm the REST roster reflects it.
     await request.post(`${API_BASE}/api/v1/workspaces/${workspaceId}/members`, {
       headers: ownerHeaders,
       data: { email: lateEmail },
     });
-
-    // Wait for the broadcast
-    await page1.waitForTimeout(2000);
-    expect(ownerWsMessages.length).toBeGreaterThan(countBefore);
-    const updated = JSON.parse(ownerWsMessages[ownerWsMessages.length - 1]);
-    const updatedEmails = updated.members.map(
+    const updatedRosterResp = await request.get(
+      `${API_BASE}/api/v1/workspaces/${workspaceId}/members`,
+      { headers: ownerHeaders },
+    );
+    const updatedEmails = (await updatedRosterResp.json()).map(
       (m: { email: string }) => m.email,
     );
     expect(updatedEmails).toContain(lateEmail);

--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -120,9 +120,6 @@ class WsClient extends ChangeNotifier {
   /// Buffered chat history — populated from chat_history and chat_message.
   final List<Map<String, dynamic>> chatHistory = [];
 
-  /// Workspace members for @mention autocomplete.
-  List<Map<String, dynamic>> workspaceMembers = [];
-
   /// Users currently connected to the workspace.
   List<Map<String, dynamic>> presenceUsers = [];
 
@@ -345,7 +342,6 @@ class WsClient extends ChangeNotifier {
     'chat_history_page': _chatHistoryPageController.add,
     'chat_updated': _chatController.add,
     'agent_thinking': _chatController.add,
-    'workspace_members': _onWorkspaceMembers,
     'presence_list': _onPresenceList,
     'presence_join': _onPresenceJoin,
     'presence_leave': _onPresenceLeave,
@@ -390,7 +386,6 @@ class WsClient extends ChangeNotifier {
         presenceUsers = [];
         terminalWindows = [];
         sharedTerminals = [];
-        workspaceMembers = [];
         final code = _channel?.closeCode;
         notifyListeners();
         if (code == 4001 || code == 4002) {
@@ -409,7 +404,6 @@ class WsClient extends ChangeNotifier {
         presenceUsers = [];
         terminalWindows = [];
         sharedTerminals = [];
-        workspaceMembers = [];
         notifyListeners();
         final code = _channel?.closeCode;
         if (code == 4001 || code == 4002) {
@@ -441,12 +435,6 @@ class WsClient extends ChangeNotifier {
       chatHistory.add(msg);
       _chatController.add(msg);
     }
-  }
-
-  void _onWorkspaceMembers(Map<String, dynamic> json) {
-    final members = json['members'] as List? ?? [];
-    workspaceMembers = members.cast<Map<String, dynamic>>();
-    notifyListeners();
   }
 
   void _onPresenceList(Map<String, dynamic> json) {
@@ -543,7 +531,6 @@ class WsClient extends ChangeNotifier {
     _send({'cmd': 'workspace_disconnect'});
     _currentWorkspaceId = null;
     chatHistory.clear();
-    workspaceMembers = [];
     presenceUsers = [];
     notifyListeners();
   }

--- a/src/frontend/test/ws_client_test.dart
+++ b/src/frontend/test/ws_client_test.dart
@@ -1306,17 +1306,10 @@ void main() {
           }
         ],
       });
-      channel.serverSend({
-        'type': 'workspace_members',
-        'members': [
-          {'user_id': 'u1', 'email': 'a@test.com', 'role': 'admin'}
-        ],
-      });
       await Future.delayed(Duration.zero);
       expect(client.presenceUsers, isNotEmpty);
       expect(client.terminalWindows, isNotEmpty);
       expect(client.sharedTerminals, isNotEmpty);
-      expect(client.workspaceMembers, isNotEmpty);
 
       // Disconnect
       channel.serverClose();
@@ -1325,7 +1318,6 @@ void main() {
       expect(client.presenceUsers, isEmpty);
       expect(client.terminalWindows, isEmpty);
       expect(client.sharedTerminals, isEmpty);
-      expect(client.workspaceMembers, isEmpty);
     });
 
     test('server error clears stale presence and terminal data', () async {
@@ -1351,17 +1343,10 @@ void main() {
           }
         ],
       });
-      channel.serverSend({
-        'type': 'workspace_members',
-        'members': [
-          {'user_id': 'u1', 'email': 'a@test.com', 'role': 'admin'}
-        ],
-      });
       await Future.delayed(Duration.zero);
       expect(client.presenceUsers, isNotEmpty);
       expect(client.terminalWindows, isNotEmpty);
       expect(client.sharedTerminals, isNotEmpty);
-      expect(client.workspaceMembers, isNotEmpty);
 
       // Error
       channel.serverError(Exception('boom'));
@@ -1370,7 +1355,6 @@ void main() {
       expect(client.presenceUsers, isEmpty);
       expect(client.terminalWindows, isEmpty);
       expect(client.sharedTerminals, isEmpty);
-      expect(client.workspaceMembers, isEmpty);
     });
 
     test('server error emits to error stream', () async {
@@ -1496,50 +1480,6 @@ void main() {
       expect(client.chatMessages.isBroadcast, isTrue);
     });
 
-    test('workspace_members populates workspaceMembers', () async {
-      channel.serverSend({
-        'type': 'workspace_members',
-        'members': [
-          {'id': 'u1', 'email': 'alice@test.com'},
-          {'id': 'u2', 'email': 'bob@test.com'},
-        ],
-      });
-      await Future.delayed(Duration.zero);
-
-      expect(client.workspaceMembers.length, 2);
-      expect(client.workspaceMembers[0]['email'], 'alice@test.com');
-      expect(client.workspaceMembers[1]['email'], 'bob@test.com');
-    });
-
-    test('workspace_members notifies listeners', () async {
-      bool notified = false;
-      client.addListener(() => notified = true);
-
-      channel.serverSend({
-        'type': 'workspace_members',
-        'members': [
-          {'id': 'u1', 'email': 'alice@test.com'},
-        ],
-      });
-      await Future.delayed(Duration.zero);
-
-      expect(notified, isTrue);
-    });
-
-    test('disconnectWorkspace clears workspaceMembers', () async {
-      channel.serverSend({
-        'type': 'workspace_members',
-        'members': [
-          {'id': 'u1', 'email': 'alice@test.com'},
-        ],
-      });
-      await Future.delayed(Duration.zero);
-      expect(client.workspaceMembers.length, 1);
-
-      client.disconnectWorkspace();
-      expect(client.workspaceMembers, isEmpty);
-    });
-
     test('presence_list populates presenceUsers', () async {
       channel.serverSend({
         'type': 'presence_list',
@@ -1627,23 +1567,10 @@ void main() {
       expect(client.presenceUsers, isEmpty);
     });
 
-    test('mentionCandidates uses presence, not the static member roster',
-        () async {
-      // The roster is populated... but must NOT feed autocomplete under the
-      // presence-only model: mentioning is synchronous, offline members can't
-      // receive it, so they aren't suggested.
-      channel.serverSend({
-        'type': 'workspace_members',
-        'members': [
-          {'id': 'u1', 'email': 'alice@test.com', 'handle': 'alice'},
-          {'id': 'u2', 'email': 'bob@test.com', 'handle': 'bob'},
-        ],
-      });
-      await Future.delayed(Duration.zero);
+    test('mentionCandidates reflects presence (normalized keys)', () async {
       channel.serverSend({
         'type': 'presence_list',
         'users': [
-          // Only u1 is present; u2 is in the roster but offline.
           {
             'user_id': 'u1',
             'user_email': 'alice@test.com',
@@ -1654,10 +1581,7 @@ void main() {
       await Future.delayed(Duration.zero);
 
       final candidates = client.mentionCandidates;
-      final ids = candidates.map((m) => m['id']).toSet();
-      expect(ids, {'u1'});
-      // Offline roster member must not be suggested.
-      expect(ids.contains('u2'), isFalse);
+      expect(candidates.map((m) => m['id']).toSet(), {'u1'});
       // presence rows (user_* keys) normalized to {id,email,handle}.
       final alice = candidates.firstWhere((m) => m['id'] == 'u1');
       expect(alice['email'], 'alice@test.com');


### PR DESCRIPTION
## Summary

Removes the `workspace_members` WebSocket event, which became dead on the frontend after #1147 repointed `@mention` autocomplete to use **presence** instead of the static ACL roster.

## Why it's dead

`WsClient._onWorkspaceMembers` populated `WsClient.workspaceMembers`, but after #1147 **nothing read that field** — it was write-only. The backend was still building the list on every workspace connect and broadcasting it on every member/role change, all to feed a field the client ignored.

Verified before changing anything:
- `grep -rn workspaceMembers src/frontend/lib/` → the field was written in 5 places (declare + 3 clears + handler populate) and read **nowhere** outside `ws_client.dart`.
- The only other `workspaceMembers`-named symbol, `_workspaceMembers` in `workspace_list_page.dart`, is a **separate REST-sourced** private variable (`GET /workspaces/{id}/members`), unrelated to the WS event.

## Removed

**Backend:**
- `Connection._send_workspace_members` (sent on connect)
- `api/workspaces._broadcast_workspace_members` + its 5 call sites (`add_workspace_member`, `remove_workspace_member`, `add_to_workspace_role`, `remove_from_workspace_role`, `change_workspace_role`)
- The `notify_user_workspaces_changed` calls that followed each broadcast are **retained**.

**Frontend:**
- `WsClient.workspaceMembers` field, `_onWorkspaceMembers` handler, its dispatch-map entry, and the 3 clear sites (on server-close, on-error, and in `disconnectWorkspace`).

**Tests:** the 2 backend tests (`test_workspace_members_on_connect`, `test_add_member_broadcasts_workspace_members`) and 3 frontend tests that asserted the removed behavior. One existing `mentionCandidates` test was simplified — its "roster doesn't leak" framing is now unexpressable (the roster WS event is gone), so it just asserts presence feeds `mentionCandidates`.

## Kept

- **REST endpoint** `GET /workspaces/{id}/members` (`model.get_workspace_members`) — still serves workspace member management, used by the CLI (`klangkc`) and `workspace_list_page.dart`.
- **`WsClient.mentionCandidates`** — the presence-only getter #1147 introduced for `@mention` autocomplete.
- The private `_workspaceMembers` in `workspace_list_page.dart` (REST-sourced, untouched).

## Test plan

- [x] Backend coverage gate: **100%** (2015 passed).
- [x] Frontend: **830 passed** (−3 from the removed dead tests).
- [x] CLI unaffected (uses the kept REST endpoint).
- [x] ruff, dart analyze, prettier, deferred-imports all clean.

Closes #1148.
