### PR TITLE
Provision the agent home eagerly and inject KLANGK_AGENT_HOME (#1157)

### DIFF
--- a/src/backend/klangk_backend/agent.py
+++ b/src/backend/klangk_backend/agent.py
@@ -66,6 +66,64 @@ def is_disabled() -> bool:
     return util.resolve_env_bool("KLANGK_AGENT_DISABLED")
 
 
+async def ensure_agent_home(workspace_id: str, container_id: str) -> str:
+    """Eagerly provision the agent's home directory with Pi config.
+
+    Creates ``/home/.users/{AGENT_USER_ID}`` on the host bind-mount and
+    populates it via ``klangk-setup-pi`` (the same path real users
+    take).  Returns the container path, e.g. ``/home/clanker``.
+
+    Idempotent: ``ensure_home_symlink`` is a no-op when the symlink
+    already exists (skeleton files only on first creation), and
+    ``klangk-setup-pi --force`` re-writes Pi config to pick up env-var
+    changes.  Called eagerly at container bring-up (so
+    ``$KLANGK_AGENT_HOME`` points at a populated directory for every
+    process) and again from chat-start, which caches the result per
+    ``AgentSession``.
+    """
+    ws = await model.get_workspace_by_id(workspace_id)
+    if not ws:
+        raise AgentSetupError(
+            f"Workspace {workspace_id} not found in database"
+        )
+    owner_id = ws["user_id"]
+    workspace_home = workspaces.home_path(owner_id, workspace_id)
+
+    agent_handle = await model.agent_handle()
+    container_home, created = workspaces.ensure_home_symlink(
+        workspace_home, agent_handle, model.AGENT_USER_ID
+    )
+    if created:
+        await workspaces.populate_home_skel(container_id, model.AGENT_USER_ID)
+
+    # Run klangk-setup-pi to populate ~/.pi/agent/ with models.json,
+    # settings.json, etc.  Unlike real users, the agent has no
+    # personal preferences — --force deletes settings.json first so
+    # it picks up the current KLANGK_LLM_MODEL env var.
+    proc = await asyncio.create_subprocess_exec(
+        podman.PODMAN_BIN,
+        "exec",
+        "-u",
+        "klangk",
+        "-e",
+        f"HOME={container_home}",
+        container_id,
+        "klangk-setup-pi",
+        "--force",
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=podman.subprocess_env(),
+    )
+    await asyncio.wait_for(proc.communicate(), timeout=30)
+    logger.info(
+        "Agent home ready at %s for container %s",
+        container_home,
+        container_id,
+    )
+    return container_home
+
+
 class AgentSession:
     """Wraps a ``pi --mode rpc`` subprocess inside a container."""
 
@@ -96,60 +154,19 @@ class AgentSession:
         return cid
 
     async def _ensure_home(self, container_id: str) -> str:
-        """Ensure the agent has a home directory with Pi config.
+        """Ensure the agent has a home directory with Pi config (cached).
 
-        Creates ``/home/.users/{AGENT_USER_ID}`` on the host bind-mount
-        and populates it via ``klangk-setup-pi`` (the same path real
-        users take) by running a login shell.  Returns the container
-        path, e.g. ``/home/clanker``.
+        Thin per-instance cache over :func:`ensure_agent_home`.  The
+        actual provisioning — and the eager bring-up call site — live
+        there.  Returns the container path, e.g. ``/home/clanker``.
         """
         if self._home_ready:
             handle = await model.agent_handle()
             return f"/home/{handle}"
-
-        ws = await model.get_workspace_by_id(self.workspace_id)
-        if not ws:
-            raise AgentSetupError(
-                f"Workspace {self.workspace_id} not found in database"
-            )
-        owner_id = ws["user_id"]
-        workspace_home = workspaces.home_path(owner_id, self.workspace_id)
-
-        agent_handle = await model.agent_handle()
-        container_home, created = workspaces.ensure_home_symlink(
-            workspace_home, agent_handle, model.AGENT_USER_ID
+        container_home = await ensure_agent_home(
+            self.workspace_id, container_id
         )
-        if created:
-            await workspaces.populate_home_skel(
-                container_id, model.AGENT_USER_ID
-            )
-
-        # Run klangk-setup-pi to populate ~/.pi/agent/ with models.json,
-        # settings.json, etc.  Unlike real users, the agent has no
-        # personal preferences — --force deletes settings.json first so
-        # it picks up the current KLANGK_LLM_MODEL env var.
-        proc = await asyncio.create_subprocess_exec(
-            podman.PODMAN_BIN,
-            "exec",
-            "-u",
-            "klangk",
-            "-e",
-            f"HOME={container_home}",
-            container_id,
-            "klangk-setup-pi",
-            "--force",
-            stdin=asyncio.subprocess.DEVNULL,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            env=podman.subprocess_env(),
-        )
-        await asyncio.wait_for(proc.communicate(), timeout=30)
         self._home_ready = True
-        logger.info(
-            "Agent home ready at %s for container %s",
-            container_home,
-            container_id,
-        )
         return container_home
 
     async def _ensure_started(self) -> asyncio.subprocess.Process:

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -889,6 +889,7 @@ class ContainerRegistry:
         hosting_hostname: str,
         hosting_proto: str,
         hosting_base_path: str,
+        agent_home: str,
         extra_env: dict[str, str] | None,
     ) -> list[str]:
         """Build the container environment variable list."""
@@ -912,6 +913,7 @@ class ContainerRegistry:
         ]
         env_vars.append(f"KLANGK_PORT_MAPPINGS={','.join(mappings)}")
         env_vars.append(f"KLANGK_WORKSPACE_ID={workspace_id}")
+        env_vars.append(f"KLANGK_AGENT_HOME={agent_home}")
         env_vars.append(
             f"KLANGK_BRIDGE_URL=http://host.containers.internal:{nginx_port}"
         )
@@ -1145,12 +1147,16 @@ class ContainerRegistry:
 
         # Build environment and mounts.
         t_env = time.monotonic()
+        # Resolve the agent home at this async seam (``_build_env`` is
+        # sync) so every exec process inherits KLANGK_AGENT_HOME (#1157).
+        agent_home = f"/home/{await model.agent_handle()}"
         env_vars = self._build_env(
             workspace_id,
             host_ports,
             hosting_hostname,
             hosting_proto,
             hosting_base_path,
+            agent_home,
             extra_env,
         )
         await self._ensure_volumes(extra_mounts, user_id)

--- a/src/backend/klangk_backend/workspaces.py
+++ b/src/backend/klangk_backend/workspaces.py
@@ -8,7 +8,7 @@ import shutil
 import tempfile
 from pathlib import Path
 
-from . import container, model, podman, terminal
+from . import agent, container, model, podman, terminal
 from .util import resolve_env_bool, resolve_env_value
 
 logger = logging.getLogger(__name__)
@@ -439,6 +439,14 @@ async def eager_start_workspace(
     state = container.registry.states.get(workspace_id)
     if state:
         state.idle_timeout = 0
+
+    # Eagerly provision the agent home at bring-up so $KLANGK_AGENT_HOME
+    # points at a populated directory for every process (#1157).  The
+    # home lives on the persisted bind-mount volume, so only provision
+    # for a freshly-created container; on re-attach/restart it already
+    # exists.
+    if status == "created":
+        await agent.ensure_agent_home(workspace_id, cid)
 
     # If the workspace has a default command, create a tmux session
     # and run it now so it's already running when a user connects.

--- a/src/backend/tests/test_agent.py
+++ b/src/backend/tests/test_agent.py
@@ -11,6 +11,7 @@ from klangk_backend.agent import (
     AgentProcessDied,
     AgentSession,
     any_running,
+    ensure_agent_home,
     get_session,
     is_disabled,
     is_running,
@@ -741,6 +742,90 @@ class TestGetSession:
         s1 = await get_session("ws-1")
         s2 = await get_session("ws-1")
         assert s1 is s2
+
+
+class TestEnsureAgentHome:
+    """Direct tests for the eager-provisioning function (#1157).
+
+    Called from eager_start_workspace at container bring-up (every exec
+    process inherits $KLANGK_AGENT_HOME) and again from chat-start, which
+    caches the result per AgentSession (see TestEnsureHome).
+    """
+
+    async def test_provisions_home_and_runs_setup(self, tmp_path):
+        from klangk_backend import model, workspaces
+
+        fake_ws = {"user_id": "owner1"}
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+
+        with (
+            patch.object(model, "get_workspace_by_id", return_value=fake_ws),
+            patch.object(workspaces, "home_path", return_value=fake_home),
+            patch.object(
+                workspaces,
+                "ensure_home_symlink",
+                return_value=("/home/clanker", True),
+            ) as mock_symlink,
+            patch.object(
+                workspaces, "populate_home_skel", new_callable=AsyncMock
+            ) as mock_skel,
+            patch(
+                "asyncio.create_subprocess_exec",
+                return_value=mock_proc,
+            ) as mock_exec,
+        ):
+            result = await ensure_agent_home("ws1", "cid")
+
+        assert result == "/home/clanker"
+        mock_symlink.assert_called_once()
+        # Skeleton files only on first creation (created=True).
+        mock_skel.assert_awaited_once_with(
+            "cid", "00000000-0000-0000-0000-000000000001"
+        )
+        # klangk-setup-pi --force re-writes Pi config each time.
+        argv = mock_exec.call_args.args
+        assert "klangk-setup-pi" in argv
+        assert "--force" in argv
+
+    async def test_skips_skel_when_home_already_exists(self, tmp_path):
+        from klangk_backend import model, workspaces
+
+        # created=False -> home dir already existed, no skel needed.
+        with (
+            patch.object(
+                model, "get_workspace_by_id", return_value={"user_id": "o"}
+            ),
+            patch.object(workspaces, "home_path", return_value=tmp_path),
+            patch.object(
+                workspaces,
+                "ensure_home_symlink",
+                return_value=("/home/clanker", False),
+            ),
+            patch.object(
+                workspaces, "populate_home_skel", new_callable=AsyncMock
+            ) as mock_skel,
+            patch(
+                "asyncio.create_subprocess_exec",
+                return_value=AsyncMock(
+                    communicate=AsyncMock(return_value=(b"", b""))
+                ),
+            ),
+        ):
+            result = await ensure_agent_home("ws1", "cid")
+
+        assert result == "/home/clanker"
+        mock_skel.assert_not_awaited()
+
+    async def test_raises_when_workspace_missing(self):
+        from klangk_backend import model
+        from klangk_backend.agent import AgentSetupError
+
+        with patch.object(model, "get_workspace_by_id", return_value=None):
+            with pytest.raises(AgentSetupError, match="not found in database"):
+                await ensure_agent_home("ws-gone", "cid")
 
 
 class TestEnsureHome:

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -540,6 +540,9 @@ class TestStartContainer:
             "http://host.containers.internal:8995/llm-proxy"
         )
         assert env_dict["KLANGK_LLM_MODEL"] == "gemma4:31b"
+        # The agent's home is injected at container start so every exec
+        # process (terminals, default command, health check) inherits it.
+        assert env_dict["KLANGK_AGENT_HOME"] == "/home/clanker"
         assert (
             env_dict["KLANGK_BRIDGE_URL"]
             == "http://host.containers.internal:8995"

--- a/src/backend/tests/test_workspaces.py
+++ b/src/backend/tests/test_workspaces.py
@@ -420,12 +420,18 @@ class TestEagerStartWorkspace:
             ws["id"], "cid-eager"
         )
         try:
-            with patch.object(
-                container.registry,
-                "start_container",
-                new_callable=AsyncMock,
-                return_value=("cid-eager", "created"),
-            ) as mock_start:
+            with (
+                patch.object(
+                    container.registry,
+                    "start_container",
+                    new_callable=AsyncMock,
+                    return_value=("cid-eager", "created"),
+                ) as mock_start,
+                patch(
+                    "klangk_backend.agent.ensure_agent_home",
+                    new_callable=AsyncMock,
+                ),
+            ):
                 cid, status = await ws_mod.eager_start_workspace(ws)
             assert cid == "cid-eager"
             assert status == "created"
@@ -460,6 +466,10 @@ class TestEagerStartWorkspace:
                 ) as mock_session,
                 patch(
                     "klangk_backend.workspaces.populate_home_skel",
+                    new_callable=AsyncMock,
+                ),
+                patch(
+                    "klangk_backend.agent.ensure_agent_home",
                     new_callable=AsyncMock,
                 ),
             ):

--- a/src/containers/workspace/agent-context.md
+++ b/src/containers/workspace/agent-context.md
@@ -134,9 +134,10 @@ with your own shell** rather than guessing. Injecting live state here would go
 stale the instant it was written.
 
 - Discover the workspace's environment with `env | grep KLANGK_`. Notable vars:
-  `KLANGK_LLM_PROXY_URL`, `KLANGK_LLM_MODEL`, `KLANGK_PORT_MAPPINGS`, and
-  `KLANGK_WORKSPACE_ID`. (Do not treat this list as exhaustive — re-run the
-  command to see what is actually set.)
+  `KLANGK_LLM_PROXY_URL`, `KLANGK_LLM_MODEL`, `KLANGK_PORT_MAPPINGS`,
+  `KLANGK_WORKSPACE_ID`, and `KLANGK_AGENT_HOME` (your own home directory,
+  `/home/<agent_handle>`, injected at container start). (Do not treat this
+  list as exhaustive — re-run the command to see what is actually set.)
 - Decide **your own mechanism** for a task based on what you observe. For
   example, to restart a service you might send Ctrl-C to a foreground process,
   `pkill` a daemon, `curl` a health endpoint and wait, edit a config and


### PR DESCRIPTION
Closes #1157.

## What

The first of three sub-issues carved out of the #1133 redesign body — the **enabler** for #1158 (repoint the default command to the agent's \`service\` session). Today the agent's home is provisioned **lazily at chat-start**, and there is no \`KLANGK_AGENT_HOME\`. This PR:

1. extracts an **eager \`ensure_agent_home()\`** seam (called at container bring-up), and
2. injects **\`KLANGK_AGENT_HOME=/home/<agent_handle>\`** at container start,

so every \`podman exec\` (interactive terminals, the default command, the health check) inherits it. Implements **#1133 Decision 1 corollary**.

**Nothing else changes** — the default command still fires in the owner's session; that swap is #1158. This is purely the enabler.

## Changes

- **\`agent.py\`** — lift provisioning out of \`AgentSession._ensure_home\` into a module-level \`ensure_agent_home(workspace_id, container_id)\`. \`_ensure_home\` becomes a thin per-instance cache over it (the home lives on the persisted bind-mount volume; \`klangk-setup-pi --force\` is idempotent, so the eager bring-up + lazy chat-start overlap is harmless).
- **\`workspaces.py\`** — \`eager_start_workspace\` calls \`ensure_agent_home()\` right after \`start_container\` returns \`"created"\` (before the firing block). The \`workspaces\`↔\`agent\` reference is call-time-only on both sides, so the top-level import is cycle-safe (verified).
- **\`container.py\`** — resolve \`f"/home/{await model.agent_handle()}"\` at the async seam (\`_start_container_inner\`) and pass it into \`_build_env\` (which stays sync), appending \`KLANGK_AGENT_HOME\` alongside the \`KLANGK_*\` family. **Zero changes** to \`_exec_args\` or its call sites — every \`podman exec\` inherits the container env by default.
- **\`agent-context.md\`** — names \`KLANGK_AGENT_HOME\` in the env-discovery guidance (the file shipped in #1140 documented env vars that didn't exist yet).

## Tests

- New \`TestEnsureAgentHome\` covers the eager function: provision + \`klangk-setup-pi --force\`; skel skipped when home already exists; raises when workspace missing.
- The two \`workspaces.py\` "created" tests now patch \`ensure_agent_home\` — they were previously **silently spawning a real \`podman exec\`** against a nonexistent container id (it failed, but \`ensure_agent_home\` doesn't check returncode). Fixed.
- Container env test asserts \`KLANGK_AGENT_HOME=/home/clanker\`.

## Out of scope (filed separately)

- **#1160** — surfaced while implementing this: a human can take the agent's live handle. Pre-existing (the home has lived at \`/home/<agent_handle>\` since long before this PR), and lives in the registration layer, not the provisioning layer. This PR should not block on it.

## Notes for review

- Coverage gate left to **CI** (\`--cov-fail-under=100\`). The 270 affected-file tests pass locally; the full suite is the gate's job.
- \`dart-format\` pre-commit hook skipped locally (no \`dart\` binary in this Python devenv); no \`.dart\` files changed here anyway.