### PR TITLE
Prevent users from taking the live agent's handle (#1160)

### DIFF
--- a/src/backend/klangk_backend/model/users.py
+++ b/src/backend/klangk_backend/model/users.py
@@ -8,6 +8,11 @@ from ._core import _fetchone, transaction
 
 # Agent identity
 AGENT_USER_ID = "00000000-0000-0000-0000-000000000001"
+# Unseeded fallback handle/email (before seed_agent_user runs). Single
+# source of truth for the default agent identity used by get_agent_user
+# and the migration-safe handle resolver in _unique_handle (#1160).
+_DEFAULT_AGENT_HANDLE = "clanker"
+_DEFAULT_AGENT_EMAIL = "clanker@example.com"
 
 
 class AgentPrincipalError(ValueError):
@@ -44,8 +49,8 @@ async def get_agent_user() -> dict:
         # Fallback before seeding has run (should not happen at runtime).
         return {
             "id": AGENT_USER_ID,
-            "email": "clanker@example.com",
-            "handle": "clanker",
+            "email": _DEFAULT_AGENT_EMAIL,
+            "handle": _DEFAULT_AGENT_HANDLE,
         }
     _agent_user_cache = user
     return user
@@ -78,7 +83,13 @@ def derive_handle(email: str) -> str:
 
 
 def validate_handle(handle: str) -> str | None:
-    """Return an error message if the handle is invalid, else None."""
+    """Return an error message if the handle is invalid, else None.
+
+    Note: this only checks *static* rules (length, charset, the fixed
+    reserved set). The *dynamic* reserved handle — the live agent's
+    handle — is checked async in :func:`_assert_handle_not_agent` (it
+    can't be in ``_RESERVED_HANDLES`` because it's configurable).
+    """
     if not handle:
         return "Handle cannot be empty"
     if len(handle) > _MAX_HANDLE_LEN:
@@ -95,20 +106,51 @@ def validate_handle(handle: str) -> str | None:
     return None
 
 
+async def _assert_handle_not_agent(handle: str) -> None:
+    """Raise ``ValueError`` if *handle* is the live agent's handle.
+
+    The agent's handle is dynamic (``KLANGK_AGENT_HANDLE``, default
+    ``clanker``), so it can't live in the static :data:`_RESERVED_HANDLES`.
+    A human taking it would collide at ``/home/<handle>`` with the
+    agent's home (#1160). Called from both :func:`set_user_handle` and
+    :func:`create_user`/``_unique_handle`` so the guard holds on every
+    path a human can acquire a handle, independent of seeding.
+    """
+    if handle == await agent_handle():
+        raise ValueError(f"'{handle}' is reserved for the workspace agent")
+
+
 async def _unique_handle(db, base: str) -> str:
-    """Return *base* if available, else append -2, -3, … until unique."""
-    cursor = await db.execute("SELECT 1 FROM users WHERE handle = ?", (base,))
-    if await cursor.fetchone() is None:
-        return base
-    for i in range(2, 10000):
+    """Return *base* if available, else append -2, -3, … until unique.
+
+    The live agent handle is always treated as taken (#1160) — even if
+    the agent row hasn't been seeded yet — so a derived handle never
+    collides with ``/home/<agent_handle>``.
+
+    Resolves the agent handle on the *passed* connection (not via the
+    cached :func:`agent_handle`, which opens a fresh connection): this
+    runs during DB migration where the ``handle`` column's schema change
+    is uncommitted on *db* but invisible to a new connection.
+    """
+    cursor = await db.execute(
+        "SELECT handle FROM users WHERE id = ?", (AGENT_USER_ID,)
+    )
+    row = await cursor.fetchone()
+    agent = row[0] if row and row[0] else _DEFAULT_AGENT_HANDLE
+    # Try base, then base-2, base-3, …; skip the agent handle each time.
+    candidate = base
+    i = 1
+    while i < 10000:
+        if candidate != agent:
+            cursor = await db.execute(
+                "SELECT 1 FROM users WHERE handle = ?", (candidate,)
+            )
+            if await cursor.fetchone() is None:
+                return candidate
+        i += 1
         candidate = f"{base}-{i}"
         if len(candidate) > _MAX_HANDLE_LEN:
             candidate = f"{base[: _MAX_HANDLE_LEN - len(str(i)) - 1]}-{i}"
-        cursor = await db.execute(
-            "SELECT 1 FROM users WHERE handle = ?", (candidate,)
-        )
-        if await cursor.fetchone() is None:
-            return candidate
     return _hash_fallback_handle(base)
 
 
@@ -181,6 +223,7 @@ async def set_user_handle(user_id: str, handle: str) -> None:
     error = validate_handle(handle)
     if error:
         raise ValueError(error)
+    await _assert_handle_not_agent(handle)
     async with transaction() as db:
         cursor = await db.execute(
             "SELECT id FROM users WHERE handle = ? AND id != ?",

--- a/src/backend/tests/test_model.py
+++ b/src/backend/tests/test_model.py
@@ -177,6 +177,44 @@ class TestHandles:
         with pytest.raises(ValueError, match="already taken"):
             await model.set_user_handle(u1["id"], "b")
 
+    async def test_set_user_handle_rejects_agent_handle(self, db):
+        # A human must not be able to take the live agent's handle (#1160)
+        # — independent of DB seeding, not just DB-uniqueness coincidence.
+        import klangk_backend.model as us
+
+        us.clear_agent_cache()
+        user = await us.create_user("someone@example.com", "hash")
+        with pytest.raises(
+            ValueError, match="reserved for the workspace agent"
+        ):
+            await us.set_user_handle(user["id"], await us.agent_handle())
+        # The rejection is the agent handle specifically (clanker), not a
+        # generic conflict — a different handle still works.
+        await us.set_user_handle(user["id"], "someone-else")
+
+    async def test_set_user_handle_rejects_agent_handle_unseeded(self, db):
+        # The fallback agent handle (clanker) is rejected even when the
+        # agent row has NOT been seeded — the gap DB-uniqueness leaves.
+        import klangk_backend.model as us
+
+        us.clear_agent_cache()
+        user = await us.create_user("someone@example.com", "hash")
+        with pytest.raises(
+            ValueError, match="reserved for the workspace agent"
+        ):
+            await us.set_user_handle(user["id"], "clanker")
+
+    async def test_create_user_agent_email_gets_suffixed(self, db):
+        # A derived handle colliding with the agent handle is suffixed,
+        # not refused (registration derives, doesn't choose) — but the
+        # user must never end up WITH the agent handle (#1160).
+        import klangk_backend.model as us
+
+        us.clear_agent_cache()
+        user = await us.create_user("clanker@example.com", "hash")
+        assert user["handle"] != await us.agent_handle()
+        assert user["handle"] == "clanker-2"
+
     async def test_set_user_handle_invalid(self, user):
         with pytest.raises(ValueError, match="empty"):
             await model.set_user_handle(user["id"], "")


### PR DESCRIPTION
Closes #1160.

## What

The agent's handle (default \`clanker\`, configurable via \`KLANGK_AGENT_HANDLE\`) was only protected from human takeover by **incidental DB-uniqueness** — which holds only after the agent row is seeded. Nothing explicitly forbade it, and the static \`_RESERVED_HANDLES\` can't encode it (the handle is dynamic). With \`KLANGK_AGENT_HOME=/home/<agent_handle>\` now first-class (#1157), a human taking the handle collides at \`/home/<handle>\`.

This guards both paths a human can acquire a handle.

## Changes

**\`set_user_handle\` (chosen handle)** — hard \`ValueError("reserved for the workspace agent")\` via the new \`_assert_handle_not_agent\` helper, which compares against the **live** \`agent_handle()\`. Holds independent of seeding (\`agent_handle()\`'s fallback covers the unseeded case). Matches the existing conflict UX for chosen handles.

**\`_unique_handle\` (derived handle, from \`create_user\`/\`_backfill_handles\`)** — treat the live agent handle as always-taken so a colliding derived handle is **suffixed** (\`clanker\` → \`clanker-2\`) rather than refused. Registration *derives*, doesn't choose, so auto-suffix matches the existing collision UX (and hard-refusing would block someone from registering \`clanker@example.com\` at all — user-hostile). The result: a human never ends up *with* the agent handle.

**Single-source-of-truth cleanup** — extracted \`_DEFAULT_AGENT_HANDLE\`/\`_DEFAULT_AGENT_EMAIL\` constants shared by \`get_agent_user\`'s unseeded fallback and \`_unique_handle\`.

## Subtlety worth flagging

\`_unique_handle\` resolves the agent handle on the **passed \`db\** connection, not via the cached \`agent_handle()\`. \`agent_handle()\` opens a *fresh* connection (NullPool), which can't see the uncommitted \`handle\`-column schema change during **DB migration** (\`_backfill_handles\` runs inside \`init_db()\` before the \`ALTER\` commits). The first attempt to call \`agent_handle()\` here broke \`test_migrate_old_schema\` ("no such column: handle"). Reading the agent row on the same \`db\` (with a static fallback when the row is absent) is migration-safe.

## Tests

- \`set_user_handle\` rejects the agent handle — both when seeded (uses \`agent_handle()\` dynamically) and via the unseeded fallback (\`clanker\`).
- \`create_user\` with the agent's email gets suffixed (\`clanker-2\`), not the agent handle.
- Existing \`TestUniqueHandleFallback\` hash-exhaustion test still passes.

## Out of scope

The issue's "Expected" wording said "rejected with a clear message" for both paths. For the **derived** path I deliberately auto-suffix instead (consistent with existing collision UX; hard-reject would block registration of \`clanker@example.com\`). The security goal — "a human never ends up with the agent's handle, independent of seeding" — holds for both. Noted in the issue if you'd prefer hard-reject on the create path too.