### PR TITLE
Add e2e tests for agent-home behaviors + fix silent klangk-setup-pi failure (#1162)

### DIFF
--- a/src/backend/e2e-tests/test_agent_home_e2e.py
+++ b/src/backend/e2e-tests/test_agent_home_e2e.py
@@ -1,0 +1,359 @@
+"""End-to-end tests for the agent-home behaviors added in #1157.
+
+#1157 shipped two container-bringup behaviors that the unit suite can
+only *mock*:
+
+1. ``KLANGK_AGENT_HOME=/home/<agent_handle>`` is baked into the
+   container env at creation (``_build_env``), so **every** exec
+   process inside the container inherits it.  The unit test only proves
+   ``_build_env`` emits the string; here we prove podman actually
+   inherits it across a real ``exec``.
+
+2. The agent home (``/home/<agent_handle>`` + a populated
+   ``~/.pi/agent/``) is provisioned **eagerly at bring-up** via
+   ``ensure_agent_home`` -- not lazily at the first chat mention.
+
+   Crucially, eager provisioning lives only in ``eager_start_workspace``
+   (triggered by ``auto_start=True`` on workspace creation), *not* the
+   normal WS connect path.  So the eager test creates a workspace with
+   ``auto_start=True`` and inspects the filesystem via ``podman exec``
+   **without ever connecting or chatting** -- the behavioral lock that
+   the home exists at start, before any mention.
+
+Requires: podman available, klangk image built.
+
+Run with: devenv shell -- test-backend-e2e
+"""
+
+import asyncio
+import base64
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+import httpx
+import pytest
+import websockets
+
+# Default agent handle (see model/users.py: _DEFAULT_AGENT_HANDLE).  Not
+# imported from the backend to keep the e2e test decoupled from the
+# server's internals -- the test asserts against observable container
+# state, not the Python API.
+AGENT_HANDLE = "clanker"
+AGENT_HOME = f"/home/{AGENT_HANDLE}"
+INSTANCE_ID = "agent-home-e2e"
+
+
+@pytest.fixture(scope="module")
+def server():
+    """Start a real Klangk server for the test module.
+
+    KLANGK_ALLOW_AUTOSTART=1 is required so the eager-provisioning test
+    can create a workspace with auto_start=True (which routes through
+    eager_start_workspace -> ensure_agent_home).
+    """
+    data_dir = tempfile.mkdtemp(prefix="klangk-agent-home-e2e-")
+    port = "18997"
+
+    env = {
+        **os.environ,
+        "KLANGK_PORT": port,
+        "KLANGK_DATA_DIR": data_dir,
+        "KLANGK_JWT_SECRET": "agent-home-e2e-secret",
+        "KLANGK_PREVENT_INSECURE_JWT_SECRET": "",
+        "KLANGK_DEFAULT_USER": "test@example.com",
+        "KLANGK_DEFAULT_PASSWORD": "testpass",
+        "KLANGK_TEST_MODE": "1",
+        "KLANGK_INSTANCE_ID": INSTANCE_ID,
+        "KLANGK_IDLE_TIMEOUT_SECONDS": "300",
+        "KLANGK_PORT_RANGE_START": "9400",
+        "KLANGK_ALLOW_AUTOSTART": "1",
+        "LOGFIRE_TOKEN": "",
+        "KLANGK_LLM_BASE_URL": "",
+        "KLANGK_LLM_API_KEY": "",
+        "KLANGK_LLM_MODEL": "",
+    }
+    proc = subprocess.Popen(
+        [
+            "uvicorn",
+            "klangk_backend.main:app",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            port,
+        ],
+        cwd=os.path.join(os.path.dirname(__file__), ".."),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    base_url = f"http://localhost:{port}"
+    for _ in range(120):
+        try:
+            if httpx.get(f"{base_url}/health", timeout=2).status_code == 200:
+                break
+        except Exception:
+            pass
+        time.sleep(1)
+    else:  # pragma: no cover
+        proc.kill()
+        stdout = proc.stdout.read().decode() if proc.stdout else ""
+        raise RuntimeError(f"Server failed to start:\n{stdout}")
+
+    yield {"url": base_url, "port": port, "data_dir": data_dir, "proc": proc}
+
+    try:
+        proc.kill()
+        proc.wait(timeout=5)
+    except (ProcessLookupError, subprocess.TimeoutExpired):
+        pass
+    if proc.stdout:
+        server_log = proc.stdout.read().decode("utf-8", errors="replace")
+        if server_log.strip():
+            sys.stderr.write(
+                f"\n=== agent-home-e2e server log ===\n{server_log}\n===\n"
+            )
+    _rm_containers()
+    shutil.rmtree(data_dir, ignore_errors=True)
+
+
+def _rm_containers():
+    """Remove any containers labeled with our instance id."""
+    result = subprocess.run(
+        [
+            "podman",
+            "ps",
+            "-a",
+            "--filter",
+            f"label=klangk.instance={INSTANCE_ID}",
+            "-q",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.stdout.strip():
+        subprocess.run(
+            ["podman", "rm", "-f", *result.stdout.strip().split()],
+            capture_output=True,
+        )
+
+
+def _container_id_for_workspace(workspace_id):
+    """Return the running container id for a specific workspace.
+
+    The container name is deterministic (``klangk-{INSTANCE_ID}-{ws[:12]}``),
+    so filtering by name targets the exact workspace -- never a stale
+    container left over from another test/run under the same instance.
+    """
+    name = f"klangk-{INSTANCE_ID}-{workspace_id[:12]}"
+    result = subprocess.run(
+        [
+            "podman",
+            "ps",
+            "--filter",
+            f"name=^{name}$",
+            "-q",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    return [c for c in result.stdout.strip().split() if c]
+
+
+@pytest.fixture(scope="module")
+def auth(server):
+    url = server["url"]
+    resp = httpx.post(
+        f"{url}/api/v1/auth/login",
+        json={"email": "test@example.com", "password": "testpass"},
+        timeout=10,
+    )
+    assert resp.status_code == 200, resp.text
+    token = resp.json()["access_token"]
+    return {"token": token, "headers": {"Authorization": f"Bearer {token}"}}
+
+
+_ws_counter = 0
+
+
+def create_workspace(server, auth, **fields):
+    """Create a workspace; return (id, cleanup). Extra fields go in the body."""
+    global _ws_counter  # noqa: PLW0603
+    _ws_counter += 1
+    name = fields.pop("name", f"agent-home-e2e-{_ws_counter}")
+    url = server["url"]
+    resp = httpx.post(
+        f"{url}/api/v1/workspaces",
+        headers=auth["headers"],
+        json={"name": name, **fields},
+        timeout=30,
+    )
+    assert resp.status_code == 200, resp.text
+    workspace_id = resp.json()["id"]
+
+    def cleanup():
+        try:
+            httpx.delete(
+                f"{url}/api/v1/workspaces/{workspace_id}",
+                headers=auth["headers"],
+                timeout=30,
+            )
+        except httpx.ReadTimeout:
+            pass
+
+    return workspace_id, cleanup
+
+
+# --- WS / exec helpers (modeled on test_per_user_home.py) ---
+
+
+def _is_container_ready(msg):
+    if msg.get("type") == "container_ready":
+        return True
+    if msg.get("type") == "event":
+        event = msg.get("event", {})
+        return (
+            event.get("type") == "CUSTOM"
+            and event.get("name") == "container_ready"
+        )
+    return False
+
+
+def _is_exec_exit(msg):
+    return msg.get("type") == "exec_exit"
+
+
+async def recv_until(ws, predicate, timeout=30):
+    deadline = asyncio.get_event_loop().time() + timeout
+    messages = []
+    while asyncio.get_event_loop().time() < deadline:
+        try:
+            msg = await asyncio.wait_for(ws.recv(), timeout=1)
+            data = json.loads(msg)
+            messages.append(data)
+            if predicate(data):
+                return messages
+        except asyncio.TimeoutError:
+            continue
+    return messages
+
+
+async def ws_connect(server, auth, workspace_id):
+    """Open a WS, connect, wait for container_ready."""
+    ws_url = server["url"].replace("http://", "ws://")
+    ws = await websockets.connect(
+        f"{ws_url}/ws?token={auth['token']}", max_size=2**20
+    )
+    await ws.send(
+        json.dumps({"cmd": "workspace_connect", "workspaceId": workspace_id})
+    )
+    deadline = asyncio.get_event_loop().time() + 60
+    while asyncio.get_event_loop().time() < deadline:
+        msg = json.loads(await asyncio.wait_for(ws.recv(), timeout=60))
+        if _is_container_ready(msg):
+            break
+    else:
+        await ws.close()
+        raise AssertionError("container_ready not received within 60s")
+    return ws
+
+
+async def exec_command(ws, command):
+    """Run a command via the WS exec path; return decoded stdout+stderr."""
+    await ws.send(json.dumps({"cmd": "exec_start", "command": command}))
+    msgs = await recv_until(ws, _is_exec_exit, timeout=15)
+    outputs = [m for m in msgs if m.get("type") == "exec_output"]
+    return b"".join(base64.b64decode(m["data"]) for m in outputs).decode()
+
+
+class TestAgentHomeE2E:
+    @pytest.mark.asyncio
+    async def test_agent_home_env_present_in_exec(self, server, auth):
+        """KLANGK_AGENT_HOME is baked at container start and inherited by
+        every exec process (#1157).  The WS exec path spawns a process
+        inside the container via the server's exec machinery (the same
+        path terminals use) -- it does *not* pass the var per-call, so
+        observing it here proves podman inherited it from the container
+        env, not that _build_env merely emitted a string.
+        """
+        workspace_id, cleanup = create_workspace(server, auth)
+        try:
+            ws = await ws_connect(server, auth, workspace_id)
+            try:
+                output = await exec_command(
+                    ws,
+                    ["bash", "-c", 'echo "$KLANGK_AGENT_HOME"'],
+                )
+                # Exact value: the default agent handle's home.
+                assert output.strip() == AGENT_HOME, (
+                    f"expected KLANGK_AGENT_HOME={AGENT_HOME!r}, "
+                    f"got {output!r}"
+                )
+            finally:
+                await ws.close()
+        finally:
+            cleanup()
+
+    @pytest.mark.asyncio
+    async def test_agent_home_provisioned_eagerly(self, server, auth):
+        """The agent home exists immediately after a container is brought
+        up via eager_start_workspace -- with NO chat mention and NO WS
+        connection preceding the check (#1157).
+
+        auto_start=True routes creation through eager_start_workspace,
+        which calls ensure_agent_home on a freshly-created container
+        (status == "created").  We then inspect the filesystem directly
+        via podman exec, as root, so the check is independent of any
+        user's read permissions.
+        """
+        # auto_start triggers eager_start_workspace (run_default_command
+        # is False on the create path, but agent-home provisioning runs
+        # regardless -- it precedes the default-command block).
+        workspace_id, cleanup = create_workspace(
+            server, auth, auto_start=True, setup_state="complete"
+        )
+        try:
+            # Wait for the eagerly-started container to be running.
+            # create_workspace awaits eager_start_workspace, so the
+            # container is up by the time the POST returned; poll as a
+            # belt-and-suspenders against scheduling latency.  Filter by
+            # the deterministic container name so we target THIS
+            # workspace's container, never a stale one.
+            cids = []
+            deadline = time.monotonic() + 60
+            while time.monotonic() < deadline:
+                cids = _container_id_for_workspace(workspace_id)
+                if cids:
+                    break
+                time.sleep(0.5)
+            assert cids, (
+                "eagerly-started container never appeared in podman ps"
+            )
+            cid = cids[0]
+
+            # Verify the agent home dir + populated ~/.pi/agent/ exist.
+            # Run as root so the existence check is independent of
+            # per-user read permissions on the agent's home.
+            check = (
+                "test -d {home}"
+                " && test -f {home}/.pi/agent/settings.json"
+                " && test -f {home}/.pi/agent/models.json"
+                " && echo ALL_PRESENT"
+            ).format(home=AGENT_HOME)
+            result = subprocess.run(
+                ["podman", "exec", "-u", "root", cid, "bash", "-c", check],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            assert "ALL_PRESENT" in result.stdout, (
+                f"agent home not fully provisioned at {AGENT_HOME}"
+                f" (rc={result.returncode}):\n{result.stdout}\n"
+                f"--- stderr ---\n{result.stderr}"
+            )
+        finally:
+            cleanup()

--- a/src/backend/klangk_backend/agent.py
+++ b/src/backend/klangk_backend/agent.py
@@ -108,19 +108,37 @@ async def ensure_agent_home(workspace_id: str, container_id: str) -> str:
         "-e",
         f"HOME={container_home}",
         container_id,
-        "klangk-setup-pi",
+        "/opt/klangk/bin/klangk-setup-pi",
         "--force",
         stdin=asyncio.subprocess.DEVNULL,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
         env=podman.subprocess_env(),
     )
-    await asyncio.wait_for(proc.communicate(), timeout=30)
-    logger.info(
-        "Agent home ready at %s for container %s",
-        container_home,
-        container_id,
-    )
+    stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
+    # Check the return code but do NOT fail the container bring-up over a
+    # provisioning hiccup: the workspace stays usable, and the lazy
+    # chat-start path (AgentSession._ensure_home) will retry on first
+    # mention.  Surface the failure loudly, though, so it's not silently
+    # swallowed (a previous silent-unconditional "ready" log hid a
+    # missing ~/.pi/agent entirely). #1162
+    if proc.returncode != 0:
+        logger.warning(
+            "klangk-setup-pi exited %s for container %s; agent home at "
+            "%s may be incomplete (chat will retry on first mention):\n"
+            "stdout: %s\nstderr: %s",
+            proc.returncode,
+            container_id,
+            container_home,
+            stdout.decode(errors="replace") if stdout else "",
+            stderr.decode(errors="replace") if stderr else "",
+        )
+    else:
+        logger.info(
+            "Agent home ready at %s for container %s",
+            container_home,
+            container_id,
+        )
     return container_home
 
 

--- a/src/backend/tests/test_agent.py
+++ b/src/backend/tests/test_agent.py
@@ -760,6 +760,7 @@ class TestEnsureAgentHome:
         fake_home.mkdir()
         mock_proc = AsyncMock()
         mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+        mock_proc.returncode = 0
 
         with (
             patch.object(model, "get_workspace_by_id", return_value=fake_ws),
@@ -785,10 +786,50 @@ class TestEnsureAgentHome:
         mock_skel.assert_awaited_once_with(
             "cid", "00000000-0000-0000-0000-000000000001"
         )
-        # klangk-setup-pi --force re-writes Pi config each time.
+        # klangk-setup-pi --force re-writes Pi config each time.  It's
+        # invoked by its full install path (bare-name resolution isn't
+        # reliable across podman/OCI runtimes) -- matching the existing
+        # klangk-setup-home pattern.
         argv = mock_exec.call_args.args
-        assert "klangk-setup-pi" in argv
+        assert "/opt/klangk/bin/klangk-setup-pi" in argv
         assert "--force" in argv
+
+    async def test_setup_failure_does_not_abort_but_logs(self, tmp_path):
+        """klangk-setup-pi failure logs a warning but doesn't raise.
+
+        Provisioning is best-effort: the workspace stays usable, and
+        the lazy chat-start path retries on first mention (#1162).
+        The return value (container home) is unaffected by the rc.
+        """
+        from klangk_backend import agent, model, workspaces
+
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        mock_proc = AsyncMock()
+        mock_proc.communicate = AsyncMock(
+            return_value=(b"setup out", b"setup err")
+        )
+        mock_proc.returncode = 127  # script missing / crashed
+
+        with (
+            patch.object(
+                model, "get_workspace_by_id", return_value={"user_id": "o"}
+            ),
+            patch.object(workspaces, "home_path", return_value=fake_home),
+            patch.object(
+                workspaces,
+                "ensure_home_symlink",
+                return_value=("/home/clanker", True),
+            ),
+            patch.object(
+                workspaces, "populate_home_skel", new_callable=AsyncMock
+            ),
+            patch("asyncio.create_subprocess_exec", return_value=mock_proc),
+        ):
+            # Must NOT raise -- provisioning is best-effort.
+            result = await agent.ensure_agent_home("ws1", "cid")
+
+        assert result == "/home/clanker"
 
     async def test_skips_skel_when_home_already_exists(self, tmp_path):
         from klangk_backend import model, workspaces
@@ -842,6 +883,7 @@ class TestEnsureHome:
 
         mock_proc = AsyncMock()
         mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+        mock_proc.returncode = 0
 
         with (
             patch.object(


### PR DESCRIPTION
Closes #1162.

## What

Adds the backend e2e tests for the two container-bringup behaviors #1157 shipped with only unit-level (mocked) coverage, and fixes a latent bug the e2e work surfaced.

## E2E tests (`src/backend/e2e-tests/test_agent_home_e2e.py`)

Both model on `test_default_command_shared_e2e.py` (real server fixture, httpx/websockets, real `podman exec`) and run under the existing `backend-e2e-tests.yml` workflow:

1. **`test_agent_home_env_present_in_exec`** — `KLANGK_AGENT_HOME=/home/clanker` is present in a started container's env, observed via the WS `exec_start` path. The exec path doesn't pass the var per-call, so observing it proves podman **inherited** it from the container env (baked at `_build_env`/create), not that `_build_env` merely emitted a string. ✅ *acceptance criterion 1*
2. **`test_agent_home_provisioned_eagerly`** — `/home/clanker` + a populated `~/.pi/agent/` (`settings.json`, `models.json`) exist immediately after an `auto_start` workspace is created, inspected via `podman exec` as root, **with no chat mention and no WS connection preceding the check**. The behavioral lock of "eager." ✅ *acceptance criterion 2*

The eager test creates the workspace with `auto_start=True` because eager provisioning lives only in `eager_start_workspace` (triggered by auto-start / server boot), **not** the normal WS connect path — that distinction is load-bearing for the test design.

## The bug this surfaced (the \"fix\" half)

`ensure_agent_home` invoked `klangk-setup-pi` by **bare name**, which fails with rc 127 across podman/OCI runtimes that don't resolve the bare name from the container PATH. `populate_home_skel` already used the **full path** (`/opt/klangk/bin/klangk-setup-home`) for exactly this reason; the agent path didn't, so the agent's `~/.pi/agent/` was **never actually populated by the eager path** — it only ever appeared later via the lazy chat-start path.

Worse: `ensure_agent_home` logged `\"Agent home ready\"` **unconditionally** — the failure was completely silent. This is why the eager test caught it while the unit suite (which mocks `create_subprocess_exec`) couldn't.

Two fixes:
- Invoke `klangk-setup-pi` by its full install path (`/opt/klangk/bin/klangk-setup-pi`), matching the `klangk-setup-home` pattern.
- Check the return code and log a **WARNING** (with stdout/stderr) on non-zero, but **do not abort** the container bring-up — provisioning is best-effort, and the lazy chat-start path (`AgentSession._ensure_home`) retries on first mention.

## Tests

- New e2e tests (both pass against a real server + freshly-built image).
- Unit: updated `test_provisions_home_and_runs_setup` to assert the full path, and added `test_setup_failure_does_not_abort_but_logs` covering the best-effort contract (non-zero rc → no raise, returns the home path).
- Full suite: **2031 passed, 100% coverage.**

## Note for review

The bug fix is technically outside #1162's literal scope (\"add e2e tests\"), but it was *found by* this work and the e2e test cannot pass without it. Kept in one PR since splitting would ship a knowingly-failing e2e test on main. Happy to split if you'd prefer.