### PR TITLE
Run the default command as the agent in a standalone service session (#1158)

### DIFF
--- a/src/backend/e2e-tests/test_default_command_shared_e2e.py
+++ b/src/backend/e2e-tests/test_default_command_shared_e2e.py
@@ -1,20 +1,25 @@
-"""End-to-end test for the default-command shared singleton (#1114).
+"""End-to-end test for the default-command service session (#1133).
 
 The default command is a per-workspace singleton that runs exactly once,
-in the OWNER's tmux session -- like a global service. A visitor under a
-different account must NOT spawn their own copy; instead they see the
-owner's ``default-cmd`` window as a joinable shared terminal.
+in a standalone ``service`` tmux session owned by the AGENT identity
+(``service:default-cmd``) -- decoupled from both the owner's interactive
+session and the ``pi --mode rpc`` subprocess. A visitor under a different
+account must NOT spawn their own copy; instead they see the
+``default-cmd`` window as a joinable shared terminal attributed to the
+agent.
 
 This reproduces the whole model against a real server + container:
 
-* the owner fires ``terminal_start`` and sees ``default-cmd`` as their
-  own tab;
+* the owner fires ``terminal_start`` and gets their own interactive
+  shell (the ``default-cmd`` window is NOT one of their own tabs -- it
+  lives in the ``service`` session);
+* the owner nonetheless sees ``default-cmd`` in the shared-terminals
+  list (attributed to the agent), so the service is visible;
 * a visitor (granted the ``coders`` role) fires ``terminal_start`` and
   gets their own interactive shell -- with NO ``default-cmd`` tab of
   their own (exactly-once: the command is not re-run for them);
-* the visitor nonetheless sees the owner's ``default-cmd`` window in the
-  shared-terminals list, so the service is visible without the owner
-  having to reshare anything.
+* the visitor sees the ``default-cmd`` window in the shared-terminals
+  list too.
 """
 
 import asyncio
@@ -208,11 +213,18 @@ def _has_default_cmd(windows):
     return any(w.get("name") == "default-cmd" for w in (windows or []))
 
 
+def _shared_has_default_cmd(shared):
+    """True if the shared_terminals payload includes default-cmd."""
+    return any(t.get("window_name") == "default-cmd" for t in (shared or []))
+
+
 class TestDefaultCommandSharedSingleton:
     @pytest.mark.asyncio
-    async def test_visitor_sees_shared_not_own(self, server, owner):
-        """The owner gets default-cmd as their own tab; a visitor gets their
-        own shell only and sees the owner's window as shared (#1114)."""
+    async def test_service_window_shared_not_own(self, server, owner):
+        """The default command runs in the agent's ``service`` session
+        (#1133): neither the owner nor a visitor has ``default-cmd`` as
+        their own tab, but both see it as a shared (agent-attributed)
+        terminal, and it is a singleton (not re-run per user)."""
         url = server["url"]
         visitor = _register(server, "visitor@example.com", "visitorpass")
 
@@ -241,20 +253,37 @@ class TestDefaultCommandSharedSingleton:
             server, owner, workspace_id
         )
         try:
-            # Owner starts the terminal -> default-cmd window created in
-            # the owner's session.
+            # Owner starts the terminal -> service command fires in the
+            # ``service`` session. The owner gets their own shell; the
+            # ``default-cmd`` window is NOT one of their own tabs.
             await _terminal_start(owner_ws)
             loop = asyncio.get_event_loop()
+            # Wait for the owner's own windows, then confirm the service
+            # window surfaces as shared (nudge list_shared_terminals).
             deadline = loop.time() + 45
             while loop.time() < deadline:
-                if _has_default_cmd(_own_windows(owner_rx)):
+                if _own_windows(owner_rx) is not None:
                     break
                 await asyncio.sleep(0.3)
-            else:
-                raise AssertionError(
-                    "owner never saw their own default-cmd tab; msgs: "
-                    f"{[m.get('type') for m in owner_rx]}"
+            await asyncio.sleep(1)  # let the service command fire + settle
+            if not _shared_has_default_cmd(_shared(owner_rx)):
+                await owner_ws.send(
+                    json.dumps({"cmd": "list_shared_terminals"})
                 )
+                deadline = loop.time() + 20
+                while loop.time() < deadline:
+                    if _shared_has_default_cmd(_shared(owner_rx)):
+                        break
+                    await asyncio.sleep(0.3)
+            # The default-cmd window is the agent's, not the owner's own.
+            assert not _has_default_cmd(_own_windows(owner_rx)), (
+                "owner has default-cmd as an OWN tab; it should live in the "
+                f"service session. own windows: {_own_windows(owner_rx)}"
+            )
+            assert _shared_has_default_cmd(_shared(owner_rx)), (
+                "owner never saw the service default-cmd as shared; msgs: "
+                f"{[m.get('type') for m in owner_rx]}"
+            )
 
             # Visitor connects and starts their own terminal.
             vis_ws, vis_rx, vis_reader = await _connect(
@@ -271,13 +300,13 @@ class TestDefaultCommandSharedSingleton:
                 # Give the shared broadcast a moment to land, then
                 # nudge an explicit list if needed.
                 await asyncio.sleep(1)
-                if not _shared(vis_rx):
+                if not _shared_has_default_cmd(_shared(vis_rx)):
                     await vis_ws.send(
                         json.dumps({"cmd": "list_shared_terminals"})
                     )
                     deadline = loop.time() + 20
                     while loop.time() < deadline:
-                        if _shared(vis_rx):
+                        if _shared_has_default_cmd(_shared(vis_rx)):
                             break
                         await asyncio.sleep(0.3)
 
@@ -291,14 +320,14 @@ class TestDefaultCommandSharedSingleton:
                 )
 
                 shared = _shared(vis_rx)
-                # Shared visibility: the owner's default-cmd is joinable.
+                # Shared visibility: the service default-cmd is joinable.
                 assert shared, (
                     "visitor never received shared_terminals; msgs: "
                     f"{[m.get('type') for m in vis_rx]}"
                 )
-                assert any(
-                    t.get("window_name") == "default-cmd" for t in shared
-                ), f"owner's default-cmd not in shared list: {shared}"
+                assert _shared_has_default_cmd(shared), (
+                    f"service default-cmd not in shared list: {shared}"
+                )
             finally:
                 vis_reader.cancel()
                 await vis_ws.close()

--- a/src/backend/klangk_backend/terminal.py
+++ b/src/backend/klangk_backend/terminal.py
@@ -20,7 +20,7 @@ import signal
 import struct
 import termios
 import tty
-from collections.abc import AsyncGenerator, Awaitable, Callable
+from collections.abc import AsyncGenerator
 
 from . import podman
 from .exceptions import TerminalError
@@ -96,6 +96,14 @@ _WORKSPACE_STATE_FILE = ".workspace-state.json"
 # Name of the dedicated tmux window that runs a workspace's
 # default_command, leaving the user's interactive window 0 free.
 DEFAULT_CMD_WINDOW = "default-cmd"
+
+# The standalone tmux session that runs the workspace's default command,
+# owned by the agent identity (not the owner). Constant name -- keyed in
+# the session map by AGENT_USER_ID, never the renameable handle -- and
+# decoupled from both the owner's interactive session and the
+# ``pi --mode rpc`` subprocess lifecycle (it survives the agent process
+# dying because it is just a tmux session) (#1133 D6).
+SERVICE_SESSION = "service"
 
 
 async def _has_tmux_session(container_id: str, session_name: str) -> bool:
@@ -206,126 +214,91 @@ async def _ensure_base_session(
     session_name: str,
     user_home: str | None = None,
     ssh_agent_socket: str | None = None,
-    default_command: str | None = None,
-    setup_state: str = SETUP_STATE_COMPLETE,
-    on_default_command_started: Callable[[], Awaitable[None]] | None = None,
-    default_cmd_session_name: str | None = None,
-    default_cmd_user_home: str | None = None,
 ) -> bool:
-    """Ensure the base tmux session exists and maybe fire the default cmd.
+    """Ensure the firing user's base tmux session + window 0 exist.
 
-    Two independent jobs, split out so that an early visitor's
-    ``terminal_start`` no longer swallows the post-setup one (#1033):
-
-    1. *Firing user's base session + window 0* -- created idempotently
-       and ALWAYS. A visitor connecting mid-setup still gets a working
-       interactive shell. This is what every ``terminal_start`` needs
-       regardless of setup state.
-
-    2. *The ``default-cmd`` window* -- a per-workspace singleton that
-       lives in the **owner's** tmux session, regardless of who fired
-       ``terminal_start`` (#1114). It is created only when the firing
-       predicate holds:
-
-           default_command is set  AND  setup_state == complete
-                                 AND  the window doesn't already exist
-
-       ``default_cmd_session_name`` (the owner id) targets the owner's
-       session; when omitted it falls back to *session_name*, which is
-       the historical single-user / boot-path behaviour (the boot path
-       already passes the owner id as ``session_name``). The owner's
-       session is ensured here too, so a visitor whose
-       ``terminal_start`` is the workspace's first can still spawn the
-       service in the owner's session.
-
-       Crucially this runs EVEN IF the firing user's session already
-       existed (created by an earlier visitor). Previously the whole
-       function returned ``False`` the moment the session existed, so
-       once an early visitor made the session, the post-setup
-       ``terminal_start`` was a no-op and the default command never
-       ran (#1033).
-
-    Returns ``True`` if the firing user's base session was freshly
-    created.
+    Idempotent: returns ``True`` if the session was freshly created.
+    The default command no longer lives in any user's session -- it
+    runs in the standalone ``service`` session owned by the agent
+    identity (see :func:`ensure_service_session`), so this is purely
+    the interactive-shell session every ``terminal_start`` needs
+    regardless of setup state (#1133).
     """
-    created = await _ensure_tmux_session(
+    return await _ensure_tmux_session(
         container_id, session_name, user_home, ssh_agent_socket
     )
-    session_existed = not created
 
-    # The default-cmd window targets the owner's session when told to,
-    # otherwise the firing user's (single-user / boot-path fallback).
-    dc_target = default_cmd_session_name or session_name
-    if dc_target != session_name:
-        # The owner's session may not exist yet (owner never connected,
-        # auto-start didn't run). Ensure it so ``new-window`` succeeds.
-        await _ensure_tmux_session(
+
+async def ensure_service_session(
+    container_id: str,
+    agent_home: str,
+    default_command: str,
+    setup_state: str = SETUP_STATE_COMPLETE,
+) -> None:
+    """Ensure the standalone ``service`` session; maybe fire default-cmd.
+
+    The workspace's default command runs in a tmux session with a
+    CONSTANT name ``service`` (not the owner's id), with the
+    ``default-cmd`` window inside it -> ``service:default-cmd``. The
+    session is owned by the agent identity and decoupled from both the
+    owner's interactive session and the ``pi --mode rpc`` subprocess
+    lifecycle -- it survives the agent subprocess dying/restarting
+    because it is just a tmux session (#1133 D6).
+
+    *agent_home* (e.g. ``/home/clanker``) is the session's HOME. The
+    default command fires iff the predicate holds (configured AND setup
+    complete) AND the ``default-cmd`` window doesn't already exist
+    (exactly-once-per-container). Idempotent: safe to call from every
+    ``terminal_start`` (#1033) and the boot path alike -- the
+    window-exists check makes it a no-op after the first fire.
+    """
+    await _ensure_tmux_session(container_id, SERVICE_SESSION, agent_home)
+    if not (
+        _should_fire_default_command(default_command, setup_state)
+    ) or await _default_cmd_window_exists(container_id, SERVICE_SESSION):
+        return
+    try:
+        await podman.exec_container(
             container_id,
-            dc_target,
-            default_cmd_user_home,
-            ssh_agent_socket,
-        )
-
-    # Fire iff the predicate holds AND the window doesn't already exist
-    # (exactly-once-per-container, checked against the target session).
-    # Reached even when the firing user's session pre-existed (#1033).
-    if _should_fire_default_command(
-        default_command, setup_state
-    ) and not await _default_cmd_window_exists(container_id, dc_target):
-        try:
-            await podman.exec_container(
-                container_id,
-                [
-                    "tmux",
-                    "new-window",
-                    "-d",
-                    "-t",
-                    dc_target,
-                    "-n",
-                    DEFAULT_CMD_WINDOW,
-                ],
-                user=CONTAINER_USER,
-                timeout=5,
-            )
-        except Exception:
-            logger.warning(
-                "Failed to create %s window in %s",
+            [
+                "tmux",
+                "new-window",
+                "-d",
+                "-t",
+                SERVICE_SESSION,
+                "-n",
                 DEFAULT_CMD_WINDOW,
-                dc_target,
-            )
-        else:
-            # The new window's shell needs a moment to source
-            # .profile / .bashrc before it can resolve PATH-dependent
-            # commands (nvm, openclaw, ...).  Same race as #1030.
-            await asyncio.sleep(1)
-            try:
-                await podman.exec_container(
-                    container_id,
-                    [
-                        "tmux",
-                        "send-keys",
-                        "-t",
-                        f"{dc_target}:{DEFAULT_CMD_WINDOW}",
-                        default_command,
-                        "Enter",
-                    ],
-                    user=CONTAINER_USER,
-                    timeout=5,
-                )
-            except Exception:
-                logger.warning(
-                    "Failed to send default command to %s", dc_target
-                )
-            else:
-                # The command is genuinely running in the default-cmd
-                # window now. Notify the caller (e.g. the WS controller)
-                # so it can surface a ``default_command_started`` event
-                # to interested clients. Skipped on the background
-                # auto-start path, which passes no callback.
-                if on_default_command_started is not None:
-                    await on_default_command_started()
-
-    return not session_existed
+            ],
+            user=CONTAINER_USER,
+            timeout=5,
+        )
+    except Exception:
+        logger.warning(
+            "Failed to create %s window in %s",
+            DEFAULT_CMD_WINDOW,
+            SERVICE_SESSION,
+        )
+        return
+    # The new window's shell needs a moment to source .profile / .bashrc
+    # before it can resolve PATH-dependent commands (nvm, openclaw, ...).
+    # Same race as #1030.
+    await asyncio.sleep(1)
+    try:
+        await podman.exec_container(
+            container_id,
+            [
+                "tmux",
+                "send-keys",
+                "-t",
+                f"{SERVICE_SESSION}:{DEFAULT_CMD_WINDOW}",
+                default_command,
+                "Enter",
+            ],
+            user=CONTAINER_USER,
+            timeout=5,
+        )
+    except Exception:
+        logger.warning("Failed to send default command to %s", SERVICE_SESSION)
 
 
 def _build_shell_command(
@@ -830,12 +803,6 @@ class TerminalSession:
         user_id: str | None = None,
         user_handle: str | None = None,
         ssh_agent_socket: str | None = None,
-        default_command: str | None = None,
-        setup_state: str = SETUP_STATE_COMPLETE,
-        on_default_command_started: Callable[[], Awaitable[None]]
-        | None = None,
-        default_cmd_session_name: str | None = None,
-        default_cmd_user_home: str | None = None,
     ):
         self.container_id = container_id
         self.session_name = session_name
@@ -846,14 +813,6 @@ class TerminalSession:
         self.user_id = user_id
         self.user_handle = user_handle
         self.ssh_agent_socket = ssh_agent_socket
-        self.default_command = default_command
-        self.setup_state = setup_state
-        self.on_default_command_started = on_default_command_started
-        # The default-cmd window is a per-workspace singleton that lives
-        # in the OWNER's session, not the firing user's (#1114). When set,
-        # ``_ensure_base_session`` targets this session for the window.
-        self.default_cmd_session_name = default_cmd_session_name
-        self.default_cmd_user_home = default_cmd_user_home
         self._shell: ShellProcess | None = None
         self._output_queue: BoundedOutputQueue[str] = BoundedOutputQueue(
             maxsize=64
@@ -883,11 +842,6 @@ class TerminalSession:
                 self.session_name,
                 user_home=self.user_home,
                 ssh_agent_socket=self.ssh_agent_socket,
-                default_command=self.default_command,
-                setup_state=self.setup_state,
-                on_default_command_started=self.on_default_command_started,
-                default_cmd_session_name=self.default_cmd_session_name,
-                default_cmd_user_home=self.default_cmd_user_home,
             )
         env = _build_environment(
             self.user_home,

--- a/src/backend/klangk_backend/workspaces.py
+++ b/src/backend/klangk_backend/workspaces.py
@@ -444,27 +444,32 @@ async def eager_start_workspace(
     # points at a populated directory for every process (#1157).  The
     # home lives on the persisted bind-mount volume, so only provision
     # for a freshly-created container; on re-attach/restart it already
-    # exists.
+    # exists.  Capture the container path to target the service session.
+    agent_home: str | None = None
     if status == "created":
-        await agent.ensure_agent_home(workspace_id, cid)
+        agent_home = await agent.ensure_agent_home(workspace_id, cid)
 
-    # If the workspace has a default command, create a tmux session
-    # and run it now so it's already running when a user connects.
+    # If the workspace has a default command, fire it in the standalone
+    # ``service`` tmux session owned by the agent identity -- not in the
+    # owner's session (#1133 D5/D6).  The session is decoupled from the
+    # ``pi --mode rpc`` subprocess and keyed by AGENT_USER_ID (constant
+    # name ``service``), so it survives the agent process dying and is
+    # always attributable.  Gated on a freshly-created container (the
+    # persisted service session survives restart) and run_default_command
+    # (fresh creates defer this -- setup.sh hasn't run yet).
     default_command = ws.get("default_command")
-    if default_command and status == "created" and run_default_command:
-        handle = await model.get_user_handle(owner_id)
-        if handle:
-            ws_home = home_path(owner_id, workspace_id)
-            user_home, created = ensure_home_symlink(ws_home, handle, owner_id)
-            if created:
-                await populate_home_skel(cid, owner_id)
-            await terminal._ensure_base_session(
-                cid,
-                owner_id,
-                user_home=user_home,
-                default_command=default_command,
-                setup_state=ws.get("setup_state"),
-            )
+    if (
+        default_command
+        and status == "created"
+        and run_default_command
+        and agent_home is not None
+    ):
+        await terminal.ensure_service_session(
+            cid,
+            agent_home,
+            default_command,
+            setup_state=ws.get("setup_state"),
+        )
 
     return cid, status
 

--- a/src/backend/klangk_backend/wshandler/controllers.py
+++ b/src/backend/klangk_backend/wshandler/controllers.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 
 from fastapi import WebSocketDisconnect
 
-from .. import container, model, podman, terminal, workspaces
+from .. import container, model, podman, terminal
 from ..exceptions import TerminalError
 from ..util import resolve_env_value
 from ..podman import ExecSession
@@ -389,11 +389,12 @@ class TerminalController:
         windows = await terminal.list_windows(conn.container_id, sname)
         conn._sync_terminal_windows(windows)
         conn.sock.send_json({"type": "terminal_windows", "windows": windows})
-        # Make the owner's default-cmd window discoverable as shared for
-        # other subscribers (e.g. a visitor connecting after auto-start
-        # created it, before the owner ever connected) (#1114).
+        # Discover the agent's ``service:default-cmd`` window so it shows
+        # up as shared (e.g. a visitor connecting after auto-start fired
+        # it) -- the service session is owned by the agent, not any user
+        # who has connected (#1133).
         if ws_session:
-            await self._sync_owner_windows(ws_session)
+            await self._sync_service_windows(ws_session)
 
     def _send_shared_terminals(self) -> None:
         """Send the current shared terminal list to the client."""
@@ -421,125 +422,78 @@ class TerminalController:
             return "complete"
         return ws.get("setup_state") or "complete"
 
-    async def _owner_default_cmd_target(self) -> tuple[str | None, str | None]:
-        """Resolve the owner's tmux session name + home for default-cmd.
+    async def _fire_service_command(self) -> None:
+        """Fire the default command in the agent's ``service`` session.
 
-        The default-cmd window lives in the owner's session (#1114).
-        Returns ``(owner_id, owner_home)``; either may be ``None`` if the
-        workspace or owner can't be resolved, in which case
-        ``_ensure_base_session`` falls back to the firing user's session
-        (the historical single-user behaviour).
+        The post-setup path (#1033): a non-auto-start workspace's service
+        command first fires here when a ``terminal_start`` lands after
+        setup completes. It runs in the standalone ``service`` session
+        owned by the agent identity, not any user's session (#1133).
+        Idempotent via the window-exists check, so every terminal_start
+        calling it is safe.
         """
-        workspace = self._conn.workspace
-        if not workspace:
-            return None, None
-        owner_id = workspace.get("user_id")
-        if not owner_id:
-            return None, None
-        owner_home = await self._resolve_user_home(owner_id)
-        return owner_id, owner_home
-
-    async def _resolve_user_home(self, user_id: str) -> str | None:
-        """Resolve a user's in-container home path, creating the symlink.
-
-        Mirrors the boot path (``workspaces.eager_start_workspace``): the
-        per-user ``/home/{handle} -> .users/{user_id}`` symlink must exist
-        so the default-cmd window's shell sources the right profile. Used
-        to give the OWNER's session a correct HOME when a visitor's
-        ``terminal_start`` is the one that creates it.
-        """
-        handle = await model.get_user_handle(user_id)
-        if not handle:
-            return None
-        ws_home = workspaces.home_path(user_id, self._conn.workspace_id)
-        owner_home, _ = workspaces.ensure_home_symlink(
-            ws_home, handle, user_id
-        )
-        return owner_home
-
-    async def _on_default_command_started(self) -> None:
-        """Hook fired once the default-cmd window is running (#1114).
-
-        Three effects:
-        1. Tell the firing connection the command is up (stops polling).
-        2. Sync the owner's windows into the session map so the window is
-           marked shared and attributable even if the owner never connects.
-        3. Broadcast ``shared_terminals`` so every subscriber -- including
-           visitors whose snapshot predated the window -- now sees the
-           default-cmd tab as a joinable shared terminal without a reload.
-           This is the #1114 race fix: creation is announced, not just
-           snapshotted at connect time.
-        """
-        try:
-            self._conn.sock.send_json(
-                {
-                    "type": "default_command_started",
-                    "workspaceId": self._conn.workspace_id,
-                    "command": self._conn._default_command,
-                }
-            )
-        except _WS_ERRORS:
-            logger.debug(
-                "default_command_started: socket gone, could not emit"
-            )
-        ws_session = state.get_session(self._conn.workspace_id)
-        if not ws_session:
+        default_command = self._conn._default_command
+        if not default_command or not self._conn.container_id:
             return
-        try:
-            await self._sync_owner_windows(ws_session)
-        except Exception:
-            logger.debug(
-                "default_command_started: owner window sync failed",
-                exc_info=True,
-            )
-        try:
-            self._conn._broadcast_shared_terminals(ws_session)
-        except Exception:
-            logger.debug(
-                "default_command_started: shared broadcast failed",
-                exc_info=True,
-            )
+        # Read setup_state FRESH from the DB -- not a cached connection
+        # field. The setup-owner connection caches 'pending' at connect
+        # time, but by terminal_start (after setup.sh returns) the DB
+        # holds 'complete' (#1033).
+        setup_state = await self._setup_state_for_workspace()
+        # The agent home is eagerly provisioned at container create
+        # (#1157) and persists in the bind-mount volume, so resolving the
+        # path here is cheap and correct -- no provisioning needed.
+        agent_home = f"/home/{await model.agent_handle()}"
+        await terminal.ensure_service_session(
+            self._conn.container_id,
+            agent_home,
+            default_command,
+            setup_state=setup_state,
+        )
 
-    async def _sync_owner_windows(self, ws_session) -> bool:
-        """Sync the workspace owner's tmux windows into the session map.
+    async def _sync_service_windows(self, ws_session) -> bool:
+        """Discover the agent's ``service`` session windows (#1133).
 
-        The default-cmd window lives in the owner's session and is shared
-        by definition (#1114). But ``ws_session.terminal_windows`` is only
-        populated when a user connects + syncs; if the owner hasn't
-        connected (auto-start at boot, or still mid-setup) visitors would
-        never see the window in the shared list. This lists the owner's
-        session from tmux and merges the result, marking default-cmd
-        shared and caching the owner's handle.
+        The default command runs in a standalone ``service`` tmux
+        session owned by the agent identity (``AGENT_USER_ID``), not in
+        any user's session. ``ws_session.terminal_windows`` is only
+        populated when a user connects + syncs, so without this the
+        ``service:default-cmd`` window would never appear in the shared
+        list. This lists the ``service`` session from tmux and merges the
+        result, attributing it to the agent (whose handle is always
+        resolvable via ``model.agent_handle()`` -- the agent is never
+        "offline" the way the owner could be under the old model).
 
-        Returns ``True`` if the owner's windows were (re)synced from tmux.
+        Returns ``True`` if the service windows were (re)synced from tmux.
         """
-        workspace = self._conn.workspace
-        if not workspace or not self._conn.container_id:
-            return False
-        owner_id = workspace.get("user_id")
-        if not owner_id:
+        if not self._conn.container_id:
             return False
         try:
             windows = await terminal.list_windows(
-                self._conn.container_id, owner_id
+                self._conn.container_id, terminal.SERVICE_SESSION
             )
         except (TerminalError, OSError):
-            return False  # owner session doesn't exist yet
+            return False  # service session doesn't exist yet
         if not windows:
             return False
-        handle = await model.get_user_handle(owner_id)
-        if handle:
-            ws_session.shared_handles[owner_id] = handle
-        self._merge_owner_windows(ws_session, owner_id, windows)
+        # Best-effort attribution: if the agent handle can't be resolved
+        # (e.g. a transient DB issue), skip discovery this round -- it
+        # retries on the next connect / list_shared_terminals. Never let
+        # discovery break the terminal-start flow.
+        try:
+            ws_session.agent_handle = await model.agent_handle()
+        except Exception:
+            return False
+        self._merge_service_windows(ws_session, windows)
         return True
 
     @staticmethod
     def _window_shared(name: str, prev_shared: bool) -> bool:
         """A window is shared if flagged so before, OR it is default-cmd.
 
-        The default-cmd window is shared by definition (#1114): it is the
-        workspace's singleton service terminal, owned by the workspace
-        owner and joinable by every subscriber.
+        The default-cmd window is shared by definition (#1114): it is
+        the workspace's singleton service terminal, owned by the agent
+        and joinable by every subscriber.
         """
         return name == DEFAULT_CMD_WINDOW or prev_shared
 
@@ -585,13 +539,12 @@ class TerminalController:
         self.cols = cols
         self.rows = rows
 
-        # The default-cmd window is a per-workspace singleton that lives
-        # in the OWNER's tmux session (#1114), not the firing user's.
-        # Resolve the owner's session name + home so ``_ensure_base_session``
-        # targets the owner's session for the window. The firing user still
-        # gets their own base session + window 0 for an interactive shell.
-        owner_id, owner_home = await self._owner_default_cmd_target()
-
+        # The default command no longer lives in any user's session --
+        # it runs in the standalone ``service`` session owned by the agent
+        # identity (#1133). ``TerminalSession`` is purely the firing user's
+        # interactive shell now; the service command is fired separately
+        # in ``_start_terminal`` (after the shell session is up) so a
+        # post-setup ``terminal_start`` still triggers it (#1033).
         session = TerminalSession(
             self._conn.container_id,
             session_name=self._conn.user["id"],
@@ -599,17 +552,6 @@ class TerminalController:
             user_id=self._conn.user["id"],
             user_handle=self._conn.user.get("handle"),
             ssh_agent_socket=self._conn._ssh_agent_socket,
-            default_command=self._conn._default_command,
-            # Read setup_state FRESH from the DB -- not from a cached
-            # connection field. The setup-owner connection caches its
-            # state as 'pending' at connect time, but by the time it
-            # sends terminal_start (after setup.sh returns) the DB
-            # holds 'complete'. A cached value would wrongly block
-            # the post-setup fire (#1033).
-            setup_state=await self._setup_state_for_workspace(),
-            on_default_command_started=self._on_default_command_started,
-            default_cmd_session_name=owner_id,
-            default_cmd_user_home=owner_home,
         )
 
         browser_id = msg.get("browser_id")
@@ -632,6 +574,13 @@ class TerminalController:
                     session.start(cols, rows),
                     timeout=30,
                 )
+                # Fire the default command in the agent's ``service``
+                # session. This handles the post-setup case (#1033): a
+                # non-auto-start workspace's service command first fires
+                # here once setup is complete, not in any user's session.
+                # The window-exists check makes it a no-op after the first
+                # fire. Done before window sync so discovery picks it up.
+                await ctrl._fire_service_command()
                 if browser_id:
                     await attach_browser(conn.container_id, browser_id)
                 if not await conn._activate_session(session, cols, rows):
@@ -771,19 +720,16 @@ class TerminalController:
             self._conn._broadcast_shared_terminals(ws_session)
         self._conn._save_state_snapshot(ws_session)
 
-    def _merge_owner_windows(
-        self, ws_session, owner_id: str, windows: list[dict]
-    ) -> None:
-        """Merge the owner's tmux windows into the session map.
+    def _merge_service_windows(self, ws_session, windows: list[dict]) -> None:
+        """Merge the agent's ``service`` session windows into the map.
 
         Unlike ``sync_terminal_windows`` (which serves the firing user and
         broadcasts/saves), this is a quiet merge used by
-        ``_sync_owner_windows`` to make the owner's default-cmd window
-        discoverable as shared for visitors -- typically when the owner
-        has not connected. It preserves prior ``shared`` flags for
-        non-default-cmd windows and forces default-cmd shared (#1114).
+        ``_sync_service_windows`` to make the ``service:default-cmd`` window
+        discoverable as shared. Windows are attributed to the agent
+        (``AGENT_USER_ID``) and ``default-cmd`` is forced shared (#1133).
         """
-        old = ws_session.terminal_windows.get(owner_id, [])
+        old = ws_session.terminal_windows.get(model.AGENT_USER_ID, [])
         old_by_id = {w["id"]: w for w in old if "id" in w}
         old_by_name = {w["name"]: w for w in old if "name" in w}
         new_entries = []
@@ -798,7 +744,7 @@ class TerminalController:
                     "shared": self._window_shared(w["name"], prev_shared),
                 }
             )
-        ws_session.terminal_windows[owner_id] = new_entries
+        ws_session.terminal_windows[model.AGENT_USER_ID] = new_entries
 
     def notify_user_terminal_windows(self, windows: list[dict]) -> None:
         """Send terminal_windows to all connections for this user."""
@@ -1259,10 +1205,10 @@ class SharedTerminalController:
                 {"type": "shared_terminals", "terminals": []}
             )
             return
-        # Discover the owner's default-cmd window (shared by definition)
-        # in case the owner hasn't connected since it was created -- e.g.
-        # an auto-started workspace a visitor is the first to open (#1114).
-        await self._conn.terminal._sync_owner_windows(ws_session)
+        # Discover the agent's ``service:default-cmd`` window in case it
+        # was fired (e.g. auto-start) before anyone connected to discover
+        # it (#1133).
+        await self._conn.terminal._sync_service_windows(ws_session)
         terminals = _get_shared_terminals(ws_session)
         self._conn.sock.send_json(
             {"type": "shared_terminals", "terminals": terminals}

--- a/src/backend/klangk_backend/wshandler/helpers.py
+++ b/src/backend/klangk_backend/wshandler/helpers.py
@@ -60,18 +60,19 @@ def _get_shared_terminals(ws_session) -> list[dict]:
 
     terminals = []
     for user_id, windows in ws_session.terminal_windows.items():
-        # Look up the user's handle from any active connection, falling
-        # back to the session's cached handle so shared windows stay
-        # visible when their owner has no active connection (#1114) --
-        # e.g. the default-cmd window after the owner logs out.
+        # Look up the user's handle from any active connection. The
+        # agent (AGENT_USER_ID) has no WS connection, so its handle is
+        # the cached ``agent_handle`` populated by ``_sync_service_windows``
+        # -- the agent is always attributable, never "offline" (#1133).
         handle = None
-        for sock in ws_session.subscribers:
-            conn = state.connections.get(sock)
-            if conn and conn.user.get("id") == user_id:
-                handle = conn.user.get("handle")
-                break
-        if not handle:
-            handle = ws_session.shared_handles.get(user_id)
+        if user_id == model.AGENT_USER_ID:
+            handle = ws_session.agent_handle
+        else:
+            for sock in ws_session.subscribers:
+                conn = state.connections.get(sock)
+                if conn and conn.user.get("id") == user_id:
+                    handle = conn.user.get("handle")
+                    break
         if not handle:
             continue
         for w in windows:

--- a/src/backend/klangk_backend/wshandler/session.py
+++ b/src/backend/klangk_backend/wshandler/session.py
@@ -38,14 +38,15 @@ class WorkspaceSession:
         # Per-user terminal window state, keyed by user_id.
         # Each value is a list of {"name": str, "shared": bool}.
         # This is the in-memory authority; snapshots are persisted
-        # to /home/.workspace-state.json for crash recovery.
+        # to /home/.workspace-state.json for crash recovery. The agent's
+        # ``service`` session windows are keyed by AGENT_USER_ID (#1133).
         self.terminal_windows: dict[str, list[dict]] = {}
-        # user_id -> handle cache so shared windows remain attributable
-        # (and thus visible in the shared list) even when their owner has
-        # no active connection -- e.g. the default-cmd window after the
-        # owner logs out, or an auto-started window the owner never saw
-        # (#1114). Populated on sync/owner-reconcile.
-        self.shared_handles: dict[str, str] = {}
+        # Cached agent handle so the ``service:default-cmd`` window stays
+        # attributable (and visible in the shared list) even though the
+        # agent has no active WS connection -- the agent is never
+        # "offline" the way the owner could be under the old model
+        # (#1133). Populated by ``_sync_service_windows``.
+        self.agent_handle: str | None = None
         self._save_lock = asyncio.Lock()
         # Workspace token renewal tracking.
         self.workspace_token_expiry: datetime | None = None
@@ -55,7 +56,7 @@ class WorkspaceSession:
         self.subscribers.clear()
         self.browser_subscribers.clear()
         self.terminal_windows.clear()
-        self.shared_handles.clear()
+        self.agent_handle = None
         # Cancel the token renewal loop so it doesn't keep renewing
         # tokens for a container that has been killed or reset.
         task = self._token_renewal_task

--- a/src/backend/tests/test_terminal.py
+++ b/src/backend/tests/test_terminal.py
@@ -1229,273 +1229,6 @@ class TestEnsureBaseSession:
         assert "HOME=/home/u" in new_cmd
         assert "SSH_AUTH_SOCK=/tmp/agent.sock" in new_cmd
 
-    async def test_default_command_sends_keys(self):
-        """Default command runs in a detached 'default-cmd' window."""
-        from klangk_backend.terminal import _ensure_base_session
-
-        with (
-            patch(
-                "klangk_backend.terminal.podman.exec_container",
-                new_callable=AsyncMock,
-                side_effect=[
-                    (1, "", ""),  # has-session fails
-                    (0, "", ""),  # new-session ok
-                    (0, "", ""),  # list-windows: default-cmd absent
-                    (0, "", ""),  # new-window ok
-                    (0, "", ""),  # send-keys ok
-                ],
-            ) as mock_exec,
-            patch(
-                "klangk_backend.terminal.asyncio.sleep", new_callable=AsyncMock
-            ),
-        ):
-            created = await _ensure_base_session(
-                "cid", "my-session", default_command="openclaw gateway"
-            )
-        assert created is True
-        assert mock_exec.await_count == 5
-        list_cmd = mock_exec.call_args_list[2].args[1]
-        assert "list-windows" in list_cmd
-        new_window_cmd = mock_exec.call_args_list[3].args[1]
-        assert "new-window" in new_window_cmd
-        assert "-d" in new_window_cmd  # detached -> window 0 stays active
-        assert "default-cmd" in new_window_cmd
-        send_cmd = mock_exec.call_args_list[4].args[1]
-        assert "send-keys" in send_cmd
-        assert "my-session:default-cmd" in send_cmd
-        assert "openclaw gateway" in send_cmd
-        # No select-window: -d kept window 0 active.
-        assert all(
-            "select-window" not in c.args[1] for c in mock_exec.call_args_list
-        )
-
-    async def test_default_command_fires_even_when_session_exists(self):
-        """#1033: default-cmd window is created even if session pre-exists.
-
-        An early visitor may have created the base session mid-setup.
-        The post-setup terminal_start must STILL create the default-cmd
-        window. Previously the whole function returned False the moment
-        the session existed, swallowing the post-setup fire.
-        """
-        from klangk_backend.terminal import _ensure_base_session
-
-        with (
-            patch(
-                "klangk_backend.terminal.podman.exec_container",
-                new_callable=AsyncMock,
-                side_effect=[
-                    (0, "", ""),  # has-session succeeds (pre-exists)
-                    (0, "", ""),  # list-windows: default-cmd absent
-                    (0, "", ""),  # new-window ok
-                    (0, "", ""),  # send-keys ok
-                ],
-            ) as mock_exec,
-            patch(
-                "klangk_backend.terminal.asyncio.sleep", new_callable=AsyncMock
-            ),
-        ):
-            created = await _ensure_base_session(
-                "cid",
-                "my-session",
-                default_command="openclaw gateway",
-                setup_state="complete",
-            )
-        # Session pre-existed, so not freshly created.
-        assert created is False
-        # But the default-cmd window WAS created (the #1033 fix).
-        assert mock_exec.await_count == 4
-        assert "new-session" not in mock_exec.call_args_list[0].args[1]
-        assert "new-window" in mock_exec.call_args_list[2].args[1]
-
-    async def test_default_command_skipped_when_window_already_exists(self):
-        """Exactly-once: don't re-create default-cmd if it already exists."""
-        from klangk_backend.terminal import _ensure_base_session
-
-        with patch(
-            "klangk_backend.terminal.podman.exec_container",
-            new_callable=AsyncMock,
-            side_effect=[
-                (0, "", ""),  # has-session succeeds
-                (0, "bash\ndefault-cmd\n", ""),  # list-windows: present
-            ],
-        ) as mock_exec:
-            created = await _ensure_base_session(
-                "cid",
-                "my-session",
-                default_command="openclaw gateway",
-                setup_state="complete",
-            )
-        assert created is False
-        # No new-window / send-keys: the window already exists.
-        assert mock_exec.await_count == 2
-        assert all(
-            "new-window" not in c.args[1] for c in mock_exec.call_args_list
-        )
-        assert all(
-            "send-keys" not in c.args[1] for c in mock_exec.call_args_list
-        )
-
-    async def test_default_command_blocked_when_setup_pending(self):
-        """#1033: pending setup_state blocks the default command entirely."""
-        from klangk_backend.terminal import _ensure_base_session
-
-        with patch(
-            "klangk_backend.terminal.podman.exec_container",
-            new_callable=AsyncMock,
-            side_effect=[
-                (1, "", ""),  # has-session fails
-                (0, "", ""),  # new-session ok
-            ],
-        ) as mock_exec:
-            created = await _ensure_base_session(
-                "cid",
-                "my-session",
-                default_command="openclaw gateway",
-                setup_state="pending",
-            )
-        assert created is True
-        # Base session created, but NO default-cmd window (setup pending).
-        assert mock_exec.await_count == 2
-        assert all(
-            "new-window" not in c.args[1] for c in mock_exec.call_args_list
-        )
-
-    async def test_default_command_blocked_when_setup_failed(self):
-        """#1033: failed setup_state also blocks the default command."""
-        from klangk_backend.terminal import _ensure_base_session
-
-        with patch(
-            "klangk_backend.terminal.podman.exec_container",
-            new_callable=AsyncMock,
-            side_effect=[
-                (0, "", ""),  # has-session succeeds
-            ],
-        ) as mock_exec:
-            await _ensure_base_session(
-                "cid",
-                "my-session",
-                default_command="openclaw gateway",
-                setup_state="failed",
-            )
-        # No window creation at all.
-        assert mock_exec.await_count == 1
-        assert all(
-            "new-window" not in c.args[1] for c in mock_exec.call_args_list
-        )
-
-    async def test_default_command_window_failure_logs_warning(self):
-        """Warning logged when the default-cmd window can't be created."""
-        from klangk_backend.terminal import _ensure_base_session
-
-        with patch(
-            "klangk_backend.terminal.podman.exec_container",
-            new_callable=AsyncMock,
-            side_effect=[
-                (1, "", ""),  # has-session fails
-                (0, "", ""),  # new-session ok
-                (0, "", ""),  # list-windows: default-cmd absent
-                OSError("new-window failed"),  # new-window fails
-            ],
-        ) as mock_exec:
-            created = await _ensure_base_session(
-                "cid", "my-session", default_command="openclaw gateway"
-            )
-        assert created is True
-        # Window creation failed, so the command was never sent.
-        assert mock_exec.await_count == 4
-        assert all(
-            "send-keys" not in c.args[1] for c in mock_exec.call_args_list
-        )
-
-    async def test_default_command_send_keys_failure_logs_warning(self):
-        """Warning logged when send-keys fails; session still created."""
-        from klangk_backend.terminal import _ensure_base_session
-
-        with (
-            patch(
-                "klangk_backend.terminal.podman.exec_container",
-                new_callable=AsyncMock,
-                side_effect=[
-                    (1, "", ""),  # has-session fails
-                    (0, "", ""),  # new-session ok
-                    (0, "", ""),  # list-windows: default-cmd absent
-                    (0, "", ""),  # new-window ok
-                    OSError("send-keys failed"),  # send-keys fails
-                ],
-            ) as mock_exec,
-            patch(
-                "klangk_backend.terminal.asyncio.sleep", new_callable=AsyncMock
-            ),
-        ):
-            created = await _ensure_base_session(
-                "cid", "my-session", default_command="openclaw gateway"
-            )
-        assert created is True
-        assert mock_exec.await_count == 5
-
-    async def test_default_command_started_callback_invoked(self):
-        """The on_default_command_started callback fires once the default
-        command is genuinely running (send-keys succeeded)."""
-        from klangk_backend.terminal import _ensure_base_session
-
-        callback = AsyncMock()
-        with (
-            patch(
-                "klangk_backend.terminal.podman.exec_container",
-                new_callable=AsyncMock,
-                side_effect=[
-                    (1, "", ""),  # has-session fails
-                    (0, "", ""),  # new-session ok
-                    (0, "", ""),  # list-windows: default-cmd absent
-                    (0, "", ""),  # new-window ok
-                    (0, "", ""),  # send-keys ok
-                ],
-            ),
-            patch(
-                "klangk_backend.terminal.asyncio.sleep", new_callable=AsyncMock
-            ),
-        ):
-            created = await _ensure_base_session(
-                "cid",
-                "my-session",
-                default_command="openclaw gateway",
-                on_default_command_started=callback,
-            )
-        assert created is True
-        callback.assert_awaited_once_with()
-
-    async def test_default_command_started_callback_not_invoked_on_failure(
-        self,
-    ):
-        """The callback does NOT fire when send-keys fails -- the command
-        never actually ran."""
-        from klangk_backend.terminal import _ensure_base_session
-
-        callback = AsyncMock()
-        with (
-            patch(
-                "klangk_backend.terminal.podman.exec_container",
-                new_callable=AsyncMock,
-                side_effect=[
-                    (1, "", ""),  # has-session fails
-                    (0, "", ""),  # new-session ok
-                    (0, "", ""),  # list-windows: default-cmd absent
-                    (0, "", ""),  # new-window ok
-                    OSError("send-keys failed"),  # send-keys fails
-                ],
-            ),
-            patch(
-                "klangk_backend.terminal.asyncio.sleep", new_callable=AsyncMock
-            ),
-        ):
-            await _ensure_base_session(
-                "cid",
-                "my-session",
-                default_command="openclaw gateway",
-                on_default_command_started=callback,
-            )
-        callback.assert_not_awaited()
-
     async def test_default_cmd_window_exists_exception_returns_false(self):
         """_default_cmd_window_exists returns False if list-windows raises."""
         from klangk_backend.terminal import _default_cmd_window_exists
@@ -1532,91 +1265,200 @@ class TestEnsureBaseSession:
             result = await _has_tmux_session("cid", "my-session")
         assert result is False
 
-    # --- #1114: default-cmd is a per-workspace singleton in the OWNER's session ---
 
-    async def test_default_command_targets_owner_session(self):
-        """A visitor's terminal_start fires the default command in the
-        OWNER's session, not the visitor's (#1114).
+class TestEnsureServiceSession:
+    """Tests for ensure_service_session -- the standalone ``service`` tmux
+    session that runs the workspace's default command, owned by the agent
+    identity (#1133 D6). _ensure_tmux_session and _default_cmd_window_exists
+    are mocked to isolate the firing logic from tmux-session internals."""
 
-        The firing user ("visitor") still gets their own base session for
-        an interactive shell, but the default-cmd window is created in
-        the owner's session ("owner"), which is ensured first.
-        """
-        from klangk_backend.terminal import _ensure_base_session
+    async def test_creates_window_and_sends_command(self):
+        """A fresh service session fires the default command in its
+        ``default-cmd`` window -> ``service:default-cmd``."""
+        from klangk_backend.terminal import ensure_service_session
 
         with (
             patch(
-                "klangk_backend.terminal.podman.exec_container",
-                new_callable=AsyncMock,
-                side_effect=[
-                    (1, "", ""),  # has-session visitor: fails
-                    (0, "", ""),  # new-session visitor: ok
-                    (1, "", ""),  # has-session owner: fails (not yet)
-                    (0, "", ""),  # new-session owner: ok
-                    (0, "", ""),  # list-windows owner: default-cmd absent
-                    (0, "", ""),  # new-window owner: ok
-                    (0, "", ""),  # send-keys owner: ok
-                ],
-            ) as mock_exec,
+                "klangk_backend.terminal._ensure_tmux_session",
+                new=AsyncMock(),
+            ),
             patch(
-                "klangk_backend.terminal.asyncio.sleep",
-                new_callable=AsyncMock,
+                "klangk_backend.terminal._default_cmd_window_exists",
+                new=AsyncMock(return_value=False),
+            ),
+            patch(
+                "klangk_backend.terminal.podman.exec_container",
+                new=AsyncMock(side_effect=[(0, "", ""), (0, "", "")]),
+            ) as mock_exec,
+        ):
+            await ensure_service_session(
+                "cid", "/home/clanker", "openclaw gateway"
+            )
+        cmds = [c.args[1] for c in mock_exec.call_args_list]
+        # default-cmd window created in the service session.
+        assert any(
+            "new-window" in c and "service" in c and "default-cmd" in c
+            for c in cmds
+        )
+        # Command sent to service:default-cmd.
+        assert any(
+            "send-keys" in c
+            and "service:default-cmd" in c
+            and "openclaw gateway" in c
+            for c in cmds
+        )
+
+    async def test_ensures_service_session_with_agent_home(self):
+        """The service session is ensured with the constant name and the
+        agent home as its HOME."""
+        from klangk_backend.terminal import (
+            SERVICE_SESSION,
+            ensure_service_session,
+        )
+
+        with (
+            patch(
+                "klangk_backend.terminal._ensure_tmux_session",
+                new=AsyncMock(),
+            ) as mock_ensure,
+            patch(
+                "klangk_backend.terminal._default_cmd_window_exists",
+                new=AsyncMock(return_value=True),
             ),
         ):
-            created = await _ensure_base_session(
-                "cid",
-                "visitor",
-                default_command="openclaw gateway",
-                setup_state="complete",
-                default_cmd_session_name="owner",
-                default_cmd_user_home="/home/owner",
+            await ensure_service_session(
+                "cid", "/home/clanker", "openclaw gateway"
             )
-        # Visitor's base session was freshly created.
-        assert created is True
-        # The default-cmd window targets the OWNER's session.
-        new_window_cmd = mock_exec.call_args_list[5].args[1]
-        assert "new-window" in new_window_cmd
-        assert "owner" in new_window_cmd
-        send_cmd = mock_exec.call_args_list[6].args[1]
-        assert "owner:default-cmd" in send_cmd
-        # The owner's session was created with the owner's HOME.
-        owner_new_session = mock_exec.call_args_list[3].args[1]
-        assert "new-session" in owner_new_session
-        assert "owner" in owner_new_session
+        mock_ensure.assert_awaited_once_with(
+            "cid", SERVICE_SESSION, "/home/clanker"
+        )
 
-    async def test_default_command_skipped_when_owner_has_window(self):
-        """Exactly-once: a visitor's terminal_start is a no-op for the
-        default command once the owner's session already has the window.
+    async def test_skips_when_window_already_exists(self):
+        """Exactly-once: no new-window/send-keys if default-cmd exists."""
+        from klangk_backend.terminal import ensure_service_session
 
-        The existence check is scoped to the owner's session, so no
-        matter how many users fire terminal_start, the singleton command
-        is started only once (#1114).
-        """
-        from klangk_backend.terminal import _ensure_base_session
+        with (
+            patch(
+                "klangk_backend.terminal._ensure_tmux_session",
+                new=AsyncMock(),
+            ),
+            patch(
+                "klangk_backend.terminal._default_cmd_window_exists",
+                new=AsyncMock(return_value=True),
+            ),
+            patch(
+                "klangk_backend.terminal.podman.exec_container",
+                new=AsyncMock(),
+            ) as mock_exec,
+        ):
+            await ensure_service_session(
+                "cid", "/home/clanker", "openclaw gateway"
+            )
+        cmds = [c.args[1] for c in mock_exec.call_args_list]
+        assert not any("new-window" in c for c in cmds)
+        assert not any("send-keys" in c for c in cmds)
+
+    async def test_blocked_when_setup_pending(self):
+        """The default command does not fire while setup is pending (#1033)."""
+        from klangk_backend.terminal import ensure_service_session
+
+        with (
+            patch(
+                "klangk_backend.terminal._ensure_tmux_session",
+                new=AsyncMock(),
+            ),
+            patch(
+                "klangk_backend.terminal._default_cmd_window_exists",
+                new=AsyncMock(return_value=False),
+            ),
+            patch(
+                "klangk_backend.terminal.podman.exec_container",
+                new=AsyncMock(),
+            ) as mock_exec,
+        ):
+            await ensure_service_session(
+                "cid",
+                "/home/clanker",
+                "openclaw gateway",
+                setup_state="pending",
+            )
+        cmds = [c.args[1] for c in mock_exec.call_args_list]
+        assert not any("new-window" in c for c in cmds)
+        assert not any("send-keys" in c for c in cmds)
+
+    async def test_new_window_failure_logs_warning(self):
+        """A tmux new-window failure is logged but doesn't raise."""
+        from klangk_backend.terminal import ensure_service_session
+
+        with (
+            patch(
+                "klangk_backend.terminal._ensure_tmux_session",
+                new=AsyncMock(),
+            ),
+            patch(
+                "klangk_backend.terminal._default_cmd_window_exists",
+                new=AsyncMock(return_value=False),
+            ),
+            patch(
+                "klangk_backend.terminal.podman.exec_container",
+                new=AsyncMock(side_effect=RuntimeError("tmux broke")),
+            ),
+            patch("klangk_backend.terminal.logger") as mock_logger,
+        ):
+            await ensure_service_session("cid", "/home/clanker", "cmd")
+        mock_logger.warning.assert_called()
+
+    async def test_send_keys_failure_logs_warning(self):
+        """A send-keys failure is logged but doesn't raise."""
+        from klangk_backend.terminal import ensure_service_session
+
+        with (
+            patch(
+                "klangk_backend.terminal._ensure_tmux_session",
+                new=AsyncMock(),
+            ),
+            patch(
+                "klangk_backend.terminal._default_cmd_window_exists",
+                new=AsyncMock(return_value=False),
+            ),
+            patch(
+                "klangk_backend.terminal.podman.exec_container",
+                new=AsyncMock(
+                    side_effect=[(0, "", ""), RuntimeError("send broke")]
+                ),
+            ),
+            patch("klangk_backend.terminal.logger") as mock_logger,
+        ):
+            await ensure_service_session("cid", "/home/clanker", "cmd")
+        mock_logger.warning.assert_called()
+
+
+class TestServiceSessionHelpers:
+    """Direct coverage for the firing-predicate helpers used by
+    ensure_service_session."""
+
+    async def test_default_cmd_window_exists_true_when_present(self):
+        from klangk_backend.terminal import _default_cmd_window_exists
 
         with patch(
             "klangk_backend.terminal.podman.exec_container",
             new_callable=AsyncMock,
-            side_effect=[
-                (1, "", ""),  # has-session visitor: fails
-                (0, "", ""),  # new-session visitor: ok
-                (0, "", ""),  # has-session owner: succeeds (exists)
-                (0, "bash\ndefault-cmd\n", ""),  # list-windows owner: present
-            ],
-        ) as mock_exec:
-            created = await _ensure_base_session(
-                "cid",
-                "visitor",
-                default_command="openclaw gateway",
-                setup_state="complete",
-                default_cmd_session_name="owner",
-                default_cmd_user_home="/home/owner",
-            )
-        assert created is True  # visitor session created
-        # No new-window / send-keys: the owner already has the window.
-        assert all(
-            "new-window" not in c.args[1] for c in mock_exec.call_args_list
-        )
-        assert all(
-            "send-keys" not in c.args[1] for c in mock_exec.call_args_list
-        )
+            return_value=(0, "bash\ndefault-cmd\n", ""),
+        ):
+            assert await _default_cmd_window_exists("cid", "service") is True
+
+    async def test_default_cmd_window_exists_false_when_absent(self):
+        from klangk_backend.terminal import _default_cmd_window_exists
+
+        with patch(
+            "klangk_backend.terminal.podman.exec_container",
+            new_callable=AsyncMock,
+            return_value=(0, "bash\n", ""),
+        ):
+            assert await _default_cmd_window_exists("cid", "service") is False
+
+    def test_should_fire_returns_false_without_default_command(self):
+        from klangk_backend.terminal import _should_fire_default_command
+
+        assert _should_fire_default_command(None, "complete") is False
+        assert _should_fire_default_command("", "complete") is False

--- a/src/backend/tests/test_workspaces.py
+++ b/src/backend/tests/test_workspaces.py
@@ -461,24 +461,22 @@ class TestEagerStartWorkspace:
                     return_value=("cid-cmd", "created"),
                 ),
                 patch(
-                    "klangk_backend.terminal._ensure_base_session",
+                    "klangk_backend.terminal.ensure_service_session",
                     new_callable=AsyncMock,
-                ) as mock_session,
-                patch(
-                    "klangk_backend.workspaces.populate_home_skel",
-                    new_callable=AsyncMock,
-                ),
+                ) as mock_service,
                 patch(
                     "klangk_backend.agent.ensure_agent_home",
                     new_callable=AsyncMock,
+                    return_value="/home/clanker",
                 ),
             ):
                 await ws_mod.eager_start_workspace(ws)
-            mock_session.assert_awaited_once_with(
+            # The default command fires in the standalone service session
+            # owned by the agent identity, not the owner's (#1133).
+            mock_service.assert_awaited_once_with(
                 "cid-cmd",
-                user["id"],
-                user_home=mock_session.call_args[1]["user_home"],
-                default_command="openclaw gateway",
+                "/home/clanker",
+                "openclaw gateway",
                 setup_state="complete",
             )
         finally:

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
 import pytest
-from unittest.mock import ANY, AsyncMock, MagicMock, patch, PropertyMock
+from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
 
 from fastapi import WebSocketDisconnect
 
@@ -696,6 +696,11 @@ class TestHandleTerminalStart:
             ),
             patch("klangk_backend.terminal.restore_windows"),
             patch.object(_ws_controllers, "attach_browser"),
+            patch.object(
+                _ws_controllers.TerminalController,
+                "_sync_service_windows",
+                new=AsyncMock(return_value=False),
+            ),
         ):
             mock_session = _mock_terminal()
             MockTS.return_value = mock_session
@@ -719,11 +724,6 @@ class TestHandleTerminalStart:
             user_id="uid",
             user_handle="testuser",
             ssh_agent_socket=None,
-            default_command=None,
-            setup_state="complete",
-            on_default_command_started=ANY,
-            default_cmd_session_name=None,
-            default_cmd_user_home=None,
         )
         # Should have sent terminal_windows and shared_terminals
         sent = [c[0][0] for c in sock.send_json.call_args_list]
@@ -763,15 +763,17 @@ class TestHandleTerminalStart:
         container.registry.revoke_workspace_browsers("ws")
         container.registry.states.pop("ws", None)
 
-    async def test_default_command_started_event_emitted(self):
-        """The on_default_command_started callback passed to TerminalSession
-        emits a default_command_started WS event once the command runs."""
+    async def test_terminal_start_fires_service_command(self):
+        """terminal_start fires the default command in the agent's service
+        session (the post-setup path, #1033/#1133) -- not in any user's
+        session. The on_default_command_started callback is gone; the
+        service command is fired via _fire_service_command."""
         sock = _mock_sock()
         conn = _base_conn(ws=sock)
         conn.container_id = "cid"
         conn.workspace_id = "ws"
         conn._user_home = "/home/testuser"
-        conn._default_command = "openclaw gateway"
+        conn._default_command = "./serve"
 
         async def _perm(*a):
             return True
@@ -796,6 +798,19 @@ class TestHandleTerminalStart:
             ),
             patch("klangk_backend.terminal.restore_windows"),
             patch.object(_ws_controllers, "attach_browser"),
+            patch(
+                "klangk_backend.wshandler.controllers.model.get_workspace",
+                new=AsyncMock(return_value={"setup_state": "complete"}),
+            ),
+            patch(
+                "klangk_backend.wshandler.controllers.model.agent_handle",
+                new=AsyncMock(return_value="clanker"),
+            ),
+            patch(
+                "klangk_backend.wshandler.controllers.terminal."
+                "ensure_service_session",
+                new=AsyncMock(),
+            ) as mock_ess,
         ):
             mock_session = _mock_terminal()
             MockTS.return_value = mock_session
@@ -809,77 +824,12 @@ class TestHandleTerminalStart:
             await conn.handle_terminal_start({"cols": 80, "rows": 24})
             await asyncio.sleep(0)
 
-            # Grab the callback the controller wired through.
-            cb = MockTS.call_args.kwargs["on_default_command_started"]
-            await cb()
-
-        sent = [c[0][0] for c in sock.send_json.call_args_list]
-        assert any(
-            isinstance(m, dict)
-            and m.get("type") == "default_command_started"
-            and m.get("workspaceId") == "ws"
-            and m.get("command") == "openclaw gateway"
-            for m in sent
+        # Fired in the service session with the agent home, not threaded
+        # into the user's TerminalSession (no default_command kwarg).
+        mock_ess.assert_awaited_once_with(
+            "cid", "/home/clanker", "./serve", setup_state="complete"
         )
-
-        wshandler.state.sessions.pop("ws", None)
-        wshandler.state.connections.pop(sock, None)
-        conn.terminal_task.cancel()
-        try:
-            await conn.terminal_task
-        except asyncio.CancelledError:
-            pass
-        container.registry.revoke_workspace_browsers("ws")
-        container.registry.states.pop("ws", None)
-
-    async def test_default_command_started_swallows_socket_error(self):
-        """If the socket is gone when the callback fires, it must NOT
-        raise -- the command started fine; notification is best-effort."""
-        sock = _mock_sock()
-        sock.send_json.side_effect = SlowClientError("gone")
-        conn = _base_conn(ws=sock)
-        conn.container_id = "cid"
-        conn.workspace_id = "ws"
-        conn._user_home = "/home/testuser"
-        conn._default_command = "openclaw gateway"
-
-        async def _perm(*a):
-            return True
-
-        conn._has_perm = _perm  # type: ignore[method-assign]
-        container.registry.track_activity("cid", "ws")
-        session = wshandler.state.get_or_create_session("ws")
-        await session.add_subscriber(sock, "cid")
-        wshandler.state.connections[sock] = conn
-
-        with (
-            patch.object(_ws_controllers, "TerminalSession") as MockTS,
-            patch(
-                "klangk_backend.terminal.list_windows",
-                return_value=[],
-            ),
-            patch(
-                "klangk_backend.terminal.load_workspace_state",
-                return_value={},
-            ),
-            patch("klangk_backend.terminal.restore_windows"),
-            patch.object(_ws_controllers, "attach_browser"),
-        ):
-            mock_session = _mock_terminal()
-            MockTS.return_value = mock_session
-
-            async def fake_output():
-                return
-                yield
-
-            mock_session.output = fake_output
-
-            await conn.handle_terminal_start({"cols": 80, "rows": 24})
-            await asyncio.sleep(0)
-
-            cb = MockTS.call_args.kwargs["on_default_command_started"]
-            # Must not raise even though send_json explodes.
-            await cb()
+        assert "default_command" not in MockTS.call_args.kwargs
 
         wshandler.state.sessions.pop("ws", None)
         wshandler.state.connections.pop(sock, None)
@@ -1315,6 +1265,19 @@ class TestHandleTerminalStart:
                 "klangk_backend.wshandler.controllers.TerminalSession", MockTS
             ),
             patch.object(_ws_controllers, "attach_browser"),
+            patch(
+                "klangk_backend.wshandler.controllers.model.get_workspace",
+                new=AsyncMock(return_value={"setup_state": "complete"}),
+            ),
+            patch(
+                "klangk_backend.wshandler.controllers.model.agent_handle",
+                new=AsyncMock(return_value="clanker"),
+            ),
+            patch(
+                "klangk_backend.wshandler.controllers.terminal."
+                "ensure_service_session",
+                new=AsyncMock(),
+            ) as mock_ess,
         ):
             await conn.handle_terminal_start(
                 {
@@ -1325,6 +1288,8 @@ class TestHandleTerminalStart:
             )
             await asyncio.sleep(0)
 
+        # The default command is NOT threaded into the user's session --
+        # it fires in the standalone service session (#1133).
         MockTS.assert_called_once_with(
             "cid",
             session_name="uid",
@@ -1332,11 +1297,9 @@ class TestHandleTerminalStart:
             user_id="uid",
             user_handle="testuser",
             ssh_agent_socket=None,
-            default_command="pi",
-            setup_state="complete",
-            on_default_command_started=ANY,
-            default_cmd_session_name=None,
-            default_cmd_user_home=None,
+        )
+        mock_ess.assert_awaited_once_with(
+            "cid", "/home/clanker", "pi", setup_state="complete"
         )
 
         conn.terminal_task.cancel()
@@ -3134,11 +3097,6 @@ class TestSSHAgentHandlers:
             user_id="uid",
             user_handle="testuser",
             ssh_agent_socket="/tmp/klangk-ssh-agent-uid.sock",
-            default_command=None,
-            setup_state="complete",
-            on_default_command_started=ANY,
-            default_cmd_session_name=None,
-            default_cmd_user_home=None,
         )
 
 
@@ -5776,12 +5734,13 @@ class TestTerminalController:
         finally:
             wshandler.state.sessions.pop("ws-1", None)
 
-    async def test_sync_owner_windows_injects_default_cmd_shared(self):
-        """Discovery: a visitor's connect syncs the owner's default-cmd window
-        into the session map (marked shared + handle cached) even though the
-        owner has never connected (#1114)."""
+    async def test_sync_service_windows_injects_default_cmd_shared(self):
+        """Discovery: connecting syncs the agent's service:default-cmd window
+        into the session map (keyed by AGENT_USER_ID, marked shared, handle
+        cached) even though the agent has no WS connection (#1133)."""
+        from klangk_backend import model
+
         ctrl, _, conn = self._controller()
-        conn.workspace = {"user_id": "owner-uid"}
         ws_session = wshandler.state.get_or_create_session("ws-1")
         try:
             with (
@@ -5800,176 +5759,145 @@ class TestTerminalController:
                     ),
                 ),
                 patch(
-                    "klangk_backend.wshandler.controllers.model."
-                    "get_user_handle",
-                    new=AsyncMock(return_value="owner-handle"),
+                    "klangk_backend.wshandler.controllers.model.agent_handle",
+                    new=AsyncMock(return_value="clanker"),
                 ),
             ):
-                synced = await ctrl._sync_owner_windows(ws_session)
+                synced = await ctrl._sync_service_windows(ws_session)
             assert synced is True
-            owner_wins = ws_session.terminal_windows["owner-uid"]
-            assert owner_wins[0]["name"] == "default-cmd"
-            assert owner_wins[0]["shared"] is True
-            # Handle cached so the window stays attributable when the
-            # owner is offline.
-            assert ws_session.shared_handles["owner-uid"] == "owner-handle"
+            agent_wins = ws_session.terminal_windows[model.AGENT_USER_ID]
+            assert agent_wins[0]["name"] == "default-cmd"
+            assert agent_wins[0]["shared"] is True
+            # Handle cached so the window stays attributable.
+            assert ws_session.agent_handle == "clanker"
         finally:
             wshandler.state.sessions.pop("ws-1", None)
 
-    async def test_get_shared_terminals_visible_when_owner_offline(self):
-        """A shared window stays in the list when its owner has logged out,
-        via the session's handle cache (#1114)."""
-        from klangk_backend.wshandler.helpers import _get_shared_terminals
-
-        ws_session = wshandler.state.get_or_create_session("ws-offline")
-        try:
-            ws_session.terminal_windows["owner-uid"] = [
-                {"id": "@1", "index": 1, "name": "default-cmd", "shared": True}
-            ]
-            ws_session.shared_handles["owner-uid"] = "owner-handle"
-            # No active connection for the owner.
-            terminals = _get_shared_terminals(ws_session)
-            assert len(terminals) == 1
-            assert terminals[0]["handle"] == "owner-handle"
-            assert terminals[0]["window_name"] == "default-cmd"
-        finally:
-            wshandler.state.sessions.pop("ws-offline", None)
-
-    # --- #1114: owner-target / discovery error & guard branches ---
-
-    async def test_owner_default_cmd_target_no_workspace(self):
-        ctrl, _, _ = self._controller()
-        ctrl._conn.workspace = None
-        assert await ctrl._owner_default_cmd_target() == (None, None)
-
-    async def test_owner_default_cmd_target_no_owner_id(self):
-        ctrl, _, _ = self._controller()
-        ctrl._conn.workspace = {"name": "ws"}  # no user_id
-        assert await ctrl._owner_default_cmd_target() == (None, None)
-
-    async def test_owner_default_cmd_target_resolves_owner_home(self):
-        ctrl, _, _ = self._controller()
-        ctrl._conn.workspace = {"user_id": "owner-uid"}
-        with (
-            patch(
-                "klangk_backend.wshandler.controllers.model.get_user_handle",
-                new=AsyncMock(return_value="owner-handle"),
-            ),
-            patch(
-                "klangk_backend.wshandler.controllers.workspaces.home_path",
-                return_value="/data/.users/owner-uid",
-            ),
-            patch(
-                "klangk_backend.wshandler.controllers.workspaces."
-                "ensure_home_symlink",
-                return_value=("/home/owner-handle", None),
-            ),
-        ):
-            owner_id, owner_home = await ctrl._owner_default_cmd_target()
-        assert owner_id == "owner-uid"
-        assert owner_home == "/home/owner-handle"
-
-    async def test_resolve_user_home_no_handle_returns_none(self):
-        ctrl, _, _ = self._controller()
-        with patch(
-            "klangk_backend.wshandler.controllers.model.get_user_handle",
-            new=AsyncMock(return_value=None),
-        ):
-            assert await ctrl._resolve_user_home("uid") is None
-
-    async def test_on_default_command_started_no_ws_session_returns(self):
-        ctrl, sock, _ = self._controller()
-        ctrl._conn._default_command = "openclaw gateway"
-        with patch(
-            "klangk_backend.wshandler.controllers.state.get_session",
-            return_value=None,
-        ):
-            await ctrl._on_default_command_started()
-        # Event emitted to the firing socket, then bailed before sync.
-        assert any(
-            c[0][0].get("type") == "default_command_started"
-            for c in sock.send_json.call_args_list
-        )
-
-    async def test_on_default_command_started_sync_error_swallowed(self):
-        """A failure in _sync_owner_windows must not abort the shared
-        broadcast (#1114): creation notification is best-effort."""
-        ctrl, _, _ = self._controller()
-        ctrl._conn._default_command = "openclaw gateway"
+    async def test_sync_service_windows_no_container_returns_false(self):
+        ctrl, _, _ = self._controller(container_id=None)
         ws_session = wshandler.state.get_or_create_session("ws-1")
         try:
-            with (
-                patch.object(
-                    ctrl,
-                    "_sync_owner_windows",
-                    new=AsyncMock(side_effect=RuntimeError("boom")),
-                ),
-                patch.object(
-                    ctrl._conn, "_broadcast_shared_terminals"
-                ) as mock_bcast,
-            ):
-                await ctrl._on_default_command_started()
-            # Broadcast still ran despite the sync failure.
-            mock_bcast.assert_called_once_with(ws_session)
+            assert await ctrl._sync_service_windows(ws_session) is False
         finally:
             wshandler.state.sessions.pop("ws-1", None)
 
-    async def test_on_default_command_started_broadcast_error_swallowed(self):
+    async def test_sync_service_windows_list_error_returns_false(self):
         ctrl, _, _ = self._controller()
-        ctrl._conn._default_command = "openclaw gateway"
-        wshandler.state.get_or_create_session("ws-1")
-        ctrl._conn._broadcast_shared_terminals.side_effect = RuntimeError(
-            "boom"
-        )
-        try:
-            # Must not raise even though the broadcast explodes.
-            await ctrl._on_default_command_started()
-        finally:
-            wshandler.state.sessions.pop("ws-1", None)
-
-    async def test_sync_owner_windows_no_workspace(self):
-        ctrl, _, _ = self._controller()
-        ctrl._conn.workspace = None
-        ws_session = wshandler.state.get_or_create_session("ws-1")
-        try:
-            assert await ctrl._sync_owner_windows(ws_session) is False
-        finally:
-            wshandler.state.sessions.pop("ws-1", None)
-
-    async def test_sync_owner_windows_no_owner_id(self):
-        ctrl, _, _ = self._controller()
-        ctrl._conn.workspace = {"name": "ws"}  # no user_id
-        ws_session = wshandler.state.get_or_create_session("ws-1")
-        try:
-            assert await ctrl._sync_owner_windows(ws_session) is False
-        finally:
-            wshandler.state.sessions.pop("ws-1", None)
-
-    async def test_sync_owner_windows_list_error_returns_false(self):
-        ctrl, _, _ = self._controller()
-        ctrl._conn.workspace = {"user_id": "owner-uid"}
         ws_session = wshandler.state.get_or_create_session("ws-1")
         try:
             with patch(
                 "klangk_backend.wshandler.controllers.terminal.list_windows",
-                new=AsyncMock(side_effect=TerminalError("no session")),
+                new=AsyncMock(side_effect=TerminalError),
             ):
-                assert await ctrl._sync_owner_windows(ws_session) is False
+                assert await ctrl._sync_service_windows(ws_session) is False
         finally:
             wshandler.state.sessions.pop("ws-1", None)
 
-    async def test_sync_owner_windows_empty_returns_false(self):
+    async def test_sync_service_windows_empty_returns_false(self):
         ctrl, _, _ = self._controller()
-        ctrl._conn.workspace = {"user_id": "owner-uid"}
         ws_session = wshandler.state.get_or_create_session("ws-1")
         try:
             with patch(
                 "klangk_backend.wshandler.controllers.terminal.list_windows",
                 new=AsyncMock(return_value=[]),
             ):
-                assert await ctrl._sync_owner_windows(ws_session) is False
+                assert await ctrl._sync_service_windows(ws_session) is False
         finally:
             wshandler.state.sessions.pop("ws-1", None)
+
+    async def test_sync_service_windows_agent_handle_error_returns_false(self):
+        """If the agent handle can't be resolved, discovery is skipped
+        (best-effort) rather than breaking the caller (#1133)."""
+        ctrl, _, _ = self._controller()
+        ws_session = wshandler.state.get_or_create_session("ws-1")
+        try:
+            with (
+                patch(
+                    "klangk_backend.wshandler.controllers.terminal."
+                    "list_windows",
+                    new=AsyncMock(
+                        return_value=[
+                            {"id": "@1", "index": 1, "name": "default-cmd"}
+                        ]
+                    ),
+                ),
+                patch(
+                    "klangk_backend.wshandler.controllers.model.agent_handle",
+                    new=AsyncMock(side_effect=RuntimeError("db down")),
+                ),
+            ):
+                assert await ctrl._sync_service_windows(ws_session) is False
+            assert ws_session.agent_handle is None
+        finally:
+            wshandler.state.sessions.pop("ws-1", None)
+
+    async def test_get_shared_terminals_visible_when_agent_offline(self):
+        """The service window stays in the shared list (attributed to the
+        agent) via the cached agent_handle, though the agent has no WS
+        connection (#1133)."""
+        from klangk_backend import model
+        from klangk_backend.wshandler.helpers import _get_shared_terminals
+
+        ws_session = wshandler.state.get_or_create_session("ws-offline")
+        try:
+            ws_session.terminal_windows[model.AGENT_USER_ID] = [
+                {"id": "@1", "index": 1, "name": "default-cmd", "shared": True}
+            ]
+            ws_session.agent_handle = "clanker"
+            # No active connection for the agent.
+            terminals = _get_shared_terminals(ws_session)
+            assert len(terminals) == 1
+            assert terminals[0]["handle"] == "clanker"
+            assert terminals[0]["window_name"] == "default-cmd"
+        finally:
+            wshandler.state.sessions.pop("ws-offline", None)
+
+    async def test_fire_service_command_invokes_ensure_service_session(self):
+        """_fire_service_command reads fresh setup_state from the DB,
+        resolves the agent home, and targets the service session (#1133)."""
+        ctrl, _, conn = self._controller()
+        conn._default_command = "./run.sh"
+        with (
+            patch(
+                "klangk_backend.wshandler.controllers.model.get_workspace",
+                new=AsyncMock(return_value={"setup_state": "complete"}),
+            ),
+            patch(
+                "klangk_backend.wshandler.controllers.model.agent_handle",
+                new=AsyncMock(return_value="clanker"),
+            ),
+            patch(
+                "klangk_backend.wshandler.controllers.terminal."
+                "ensure_service_session",
+                new=AsyncMock(),
+            ) as mock_ess,
+        ):
+            await ctrl._fire_service_command()
+        mock_ess.assert_awaited_once_with(
+            "cid", "/home/clanker", "./run.sh", setup_state="complete"
+        )
+
+    async def test_fire_service_command_no_default_command_noop(self):
+        ctrl, _, conn = self._controller()
+        conn._default_command = None
+        with patch(
+            "klangk_backend.wshandler.controllers.terminal."
+            "ensure_service_session",
+            new=AsyncMock(),
+        ) as mock_ess:
+            await ctrl._fire_service_command()
+        mock_ess.assert_not_awaited()
+
+    async def test_fire_service_command_no_container_noop(self):
+        ctrl, _, conn = self._controller(container_id=None)
+        conn._default_command = "./run.sh"
+        with patch(
+            "klangk_backend.wshandler.controllers.terminal."
+            "ensure_service_session",
+            new=AsyncMock(),
+        ) as mock_ess:
+            await ctrl._fire_service_command()
+        mock_ess.assert_not_awaited()
 
     # --- browser_reattach ---
 
@@ -7028,7 +6956,7 @@ class TestSharedTerminalController:
                 self.terminal = SimpleNamespace(
                     session=None,
                     task=None,
-                    _sync_owner_windows=AsyncMock(return_value=False),
+                    _sync_service_windows=AsyncMock(return_value=False),
                 )
 
             @property

--- a/src/containers/workspace/agent-context.md
+++ b/src/containers/workspace/agent-context.md
@@ -153,8 +153,11 @@ is per-user is the **session name**.
 
 - A user's interactive terminals are a tmux session **named after the user's
   id** (e.g. `tmux list-sessions` shows one session per user). The workspace's
-  own service runs in a window named **`default-cmd`** inside the **owner's**
-  session.
+  own service runs in a standalone tmux session named **`service`** — owned by
+  the agent identity (you), not any user — with the command in a window named
+  **`default-cmd`** (`service:default-cmd`). It is decoupled from both the
+  owner's interactive session and your `pi --mode rpc` subprocess: it is just
+  a tmux session, so it survives your RPC process dying or restarting.
 - **List** what exists: `tmux list-sessions`, then `tmux list-windows -t
 <session>` and `tmux list-panes -t <session>`.
 - **Observe** a pane: `tmux capture-pane -p -t <session>:<window>.<pane> -S -


### PR DESCRIPTION
Closes #1158. The core of the #1133 ownership-model change — the riskiest piece of the umbrella.

## What

The workspace's default command moves out of the **owner's** tmux session into a standalone **`service`** tmux session owned by the **agent** identity (`service:default-cmd`). This is the actual ownership-model change: the **agent** becomes the service entity, decoupled from both the owner's interactive session and the `pi --mode rpc` subprocess lifecycle. Implements decisions **D5, D6**. Supersedes #1125.

The `service` session has a **constant name** (`service`, keyed in the session map by `AGENT_USER_ID` — never the renameable handle) and **survives the agent subprocess dying/restarting** because it is just a tmux session.

## Production changes

- **`terminal.py`** — new `ensure_service_session()` fires the default command in the constant-name `service` session with the agent home. `_ensure_base_session` is stripped back to *only* ensuring the firing user's base session. `TerminalSession` loses all default-command params.
- **`workspaces.py`** — the boot firing block resolves the agent identity, reuses the agent home (#1157), and calls `ensure_service_session`. Gating triple preserved (command set + freshly created + `run_default_command`).
- **`controllers.py`** — new `_fire_service_command` fires from `terminal_start` (the post-setup #1033 path, reading setup_state FRESH from the DB). `_sync_service_windows`/`_merge_service_windows` discover the service session. **All #1125 machinery deleted**: `_owner_default_cmd_target`, `_resolve_user_home`, `_on_default_command_started`, `_sync_owner_windows`, `_merge_owner_windows`.
- **`session.py`** — deleted `shared_handles` (owner-attribution dict); replaced with a single `agent_handle` field.
- **`helpers.py`** — agent windows resolve their handle via the cached `agent_handle` (the agent is never "offline" the way the owner could be).
- **`agent-context.md`** — tmux prose now describes the standalone `service` session.

## One judgment call worth flagging

The issue's deletion list said to remove `_on_default_command_started` and its callback. That callback was how the frontend learned the service window was created (a `default_command_started` broadcast). With it gone, the service window is instead discovered via `_sync_service_windows` on connect / `list_shared_terminals` (the natural flow), rather than announced proactively at fire-time. The acceptance criteria don't require the proactive event, and the discover-on-connect path covers visibility. Flagging in case you'd prefer to keep a proactive broadcast.

## Tests

- Deleted the #1125-machinery tests; added coverage for `ensure_service_session`, `_sync_service_windows`, `_merge_service_windows`, `_fire_service_command`, and the service-session helpers.
- **Full backend suite: 2026 passed, 100% coverage.**
- **E2E passes against a real container** — the rewritten `test_default_command_shared_e2e` verifies neither owner nor visitor has `default-cmd` as an *own* tab, but both see it as a shared (agent-attributed) terminal, and it's a singleton (not re-run per user).

## Context

- Parent: #1133 (D5, D6). Depends on #1157 (merged).
- This is the riskiest piece for the coverage gate: Step 5 deletes heavily-tested code, so deletion + new-behavior coverage landed together.
- The operate-semantics UI issue (#1159) depends on this — it surfaces the `service` window.