### PR TITLE
feat(email): Jinja2 email templates + overlay, Reply-To, expiry fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,14 @@ KLANGK_DEFAULT_USER=admin@example.com
 # title, app-bar logo, and outgoing emails. No rebuild required.
 # KLANGK_PRODUCT_NAME=Acme Labs
 
+# White-label logo URL (optional). Overrides the default logo in the UI
+# and email headers with no rebuild. Supports file:/cmd: resolution.
+# Serve a local file via $KLANGK_DATA_DIR/branding/ -> /branding/.
+# KLANGK_LOGO_URL=/branding/logo.png
+
+# White-label brand color for the email badge (default: #E65100 orange).
+# KLANGK_BRAND_COLOR=#E65100
+
 # CORS allowed origins (comma-separated). If unset, derived from
 # KLANGK_HOSTING_HOSTNAME or defaults to http://localhost:{KLANGK_NGINX_PORT}.
 # KLANGK_CORS_ORIGINS=https://klangk.example.com
@@ -30,6 +38,13 @@ KLANGK_DEFAULT_USER=admin@example.com
 # KLANGK_SMTP_USER=you@gmail.com
 # KLANGK_SMTP_PASSWORD=your-app-password
 # KLANGK_SMTP_FROM=you@gmail.com
+# Optional monitored reply address added as Reply-To on every message.
+# KLANGK_SMTP_REPLY_TO=support@example.com
+
+# Email templating (optional). Point at a directory that shadows the built-in
+# Jinja2 email templates (verify/reset/invite) on a per-file basis. Copy the
+# built-in tree from src/backend/klangk_backend/email_templates/ to get started.
+# KLANGK_EMAIL_TEMPLATES_DIR=/etc/klangk/email-templates
 
 # OIDC authentication (optional — see docs at https://mcdonc.github.io/klangk/reference/oidc/)
 # KLANGK_OIDC_CONFIG=/path/to/oidc.yaml

--- a/devenv.nix
+++ b/devenv.nix
@@ -348,6 +348,9 @@ in
         "node_modules/"
         "src/frontend/build/"
         "\\.devenv/"
+        # Jinja2 email templates: prettier doesn't understand {% %}/{{ }} and
+        # corrupts them (breaks expressions across lines). See #1165.
+        "email_templates/"
       ];
     };
     # Nix
@@ -424,6 +427,8 @@ in
     src/frontend/build/
     .devenv/
     *.lock
+    # Jinja2 email templates — prettier corrupts {% %}/{{ }} syntax. See #1165.
+    email_templates/
     PRETTIER
 
     # Generate yamllint config (not committed)

--- a/docs/deployment/customizing.md
+++ b/docs/deployment/customizing.md
@@ -43,8 +43,82 @@ For a no-rebuild rebrand, klangk also overrides the logo at runtime via the
 - When unset — or if the image fails to load — the default `KlangkLogo` widget
   is rendered, so existing deployments are unchanged.
 
-This overrides only the **image**. Product-name text (`KLANGK_PRODUCT_NAME`)
-and logos in emails are tracked under separate items.
+This overrides only the **image** in the UI. It also flows into email headers
+when emails are rendered through the templating system (see below).
+
+## Email templating (`KLANGK_EMAIL_TEMPLATES_DIR`)
+
+Outgoing auth emails — registration verification, password reset, and
+invitation — are rendered from Jinja2 templates shipped inside the backend
+package at `klangk_backend/email_templates/`. There is no separate hardcoded
+fallback: the built-in templates _are_ the defaults. Each email is three
+files under a per-event folder (`verify/`, `reset/`, `invite/`): a
+`subject.txt`, a plain-text `body.txt`, and an HTML `body.html` that
+`{% extends "base.html" %}`. Editing `base.html` alone re-brands every
+email at once.
+
+### Customizing emails
+
+Point `KLANGK_EMAIL_TEMPLATES_DIR` at a directory of your own templates.
+Two equivalent approaches (they produce identical output):
+
+- **Copy the whole `email_templates/` tree, then edit what you want.** This
+  is the usual path. The built-in templates live at
+  `src/backend/klangk_backend/email_templates/` in the Klangk source
+  checkout; copy that directory out, delete the copied `__init__.py`
+  (packaging only), edit, and point the env var at it. By copying the whole
+  tree you **own it**: on upgrade, re-diff against the current built-ins and
+  bring forward whatever you want — normal maintenance for a forked config.
+- **Drop only the files you change.** Anything absent from your directory
+  falls through to the built-ins, so unchanged files keep inheriting upstream
+  fixes automatically. Use this for a few surgical changes when you don't
+  want to maintain a full copy.
+
+Overrides resolve per-file: a deployer file shadows the built-in of the same
+path, and `{% extends %}`/`{% include %}` resolve your overrides first. So
+you can re-brand all emails by overriding just `base.html`, change a single
+subject by overriding just `invite/subject.txt`, or wholesale replace one
+email by overriding its three files.
+
+> **Keep the `.html` extension** on HTML templates (not `.html.j2`). klangk
+> enables Jinja autoescaping by filename, and a `.j2` suffix silently disables
+> it — the worst place to lose escaping is the shared `base.html`.
+
+### Variables
+
+**Global** (every email): `product_name` (`KLANGK_PRODUCT_NAME`), `logo_url`
+(`KLANGK_LOGO_URL` — when set, the email header shows your logo instead of the
+default badge), `brand_color` (`KLANGK_BRAND_COLOR`, default `#E65100`).
+
+**Per-email**: `link` (the verification / reset / invite URL), `expiry_hours`
+(the real token TTL — interpolated, not hardcoded, so it always matches your
+`KLANGK_INVITE_EXPIRE_HOURS` / token settings), and `invited_by` (invitation
+only).
+
+> **Tokens never appear in the subject line** — subjects receive only the
+> global branding variables, never the link, so tokens can't leak into
+> mail-server subject logs.
+
+### Other email knobs
+
+- **`KLANGK_SMTP_REPLY_TO`** — when set, every outgoing message carries a
+  `Reply-To` header pointing at a monitored address (compliance /
+  deliverability). Unset → no header.
+- **Footer / legal line** — the base template exposes an empty
+  `{% block legal %}` you can fill in your override to add a compliance
+  footer in one place.
+
+### Example: rebrand + monitored reply address
+
+```bash
+docker run -d \
+  -e KLANGK_PRODUCT_NAME="Acme Labs" \
+  -e KLANGK_LOGO_URL="/branding/logo.png" \
+  -e KLANGK_SMTP_REPLY_TO="support@acme.example.com" \
+  -e KLANGK_EMAIL_TEMPLATES_DIR=/etc/klangk/email-templates \
+  -v /etc/klangk/email-templates:/etc/klangk/email-templates:ro \
+  ...
+```
 
 ## Prerequisites
 

--- a/src/backend/klangk_backend/email_templates/base.html
+++ b/src/backend/klangk_backend/email_templates/base.html
@@ -1,0 +1,11 @@
+{# Shared wrapper for all auth emails (verify / reset / invite).
+
+   Editing this one file re-brands every email at once: each child does
+   {% extends "base.html" %} and the ChoiceLoader resolves your override
+   (KLANGK_EMAIL_TEMPLATES_DIR) before the built-in. Filenames must stay
+   .html (not .html.j2) or Jinja's autoescape is silently disabled for
+   that file -- the worst place to lose escaping. See #1165. #}
+<div style="font-family:sans-serif;max-width:480px;margin:0 auto"><div style="text-align:center;padding:24px 0">{% if logo_url %}<img src="{{ logo_url }}" alt="{{ product_name }}" style="max-height:48px;max-width:200px;">{% else %}<span style="display:inline-block;background:{{ brand_color }};color:#fff;border-radius:50%;width:48px;height:48px;line-height:48px;font-size:24px">&#128062;</span><h2 style="margin:8px 0 0">{{ product_name }}</h2>{% endif %}</div>
+{% block content %}{% endblock %}
+<p><small>{% block footer_note %}If you did not request this, you can ignore this email.{% endblock %}</small></p>{% block legal %}{% endblock %}
+</div>

--- a/src/backend/klangk_backend/email_templates/invite/body.html
+++ b/src/backend/klangk_backend/email_templates/invite/body.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+{% block content %}<p><strong>{{ invited_by }}</strong> has invited you to join {{ product_name }}.</p>
+<p>Click the link below to set your password and activate your account:</p>
+<p><a href="{{ link }}">Accept invitation</a></p>
+<p>This link expires in {{ expiry_hours }} hour{{ '' if expiry_hours == 1 else 's' }}.</p>
+{% endblock %}
+{% block footer_note %}If you did not expect this invitation, you can ignore this email.{% endblock %}

--- a/src/backend/klangk_backend/email_templates/invite/body.txt
+++ b/src/backend/klangk_backend/email_templates/invite/body.txt
@@ -1,0 +1,9 @@
+{{ invited_by }} has invited you to join {{ product_name }}.
+
+Click the link below to set your password and activate your account:
+
+<{{ link }}>
+
+This link expires in {{ expiry_hours }} hour{{ '' if expiry_hours == 1 else 's' }}.
+
+If you did not expect this invitation, you can ignore this email.

--- a/src/backend/klangk_backend/email_templates/invite/subject.txt
+++ b/src/backend/klangk_backend/email_templates/invite/subject.txt
@@ -1,0 +1,1 @@
+You've been invited to {{ product_name }}

--- a/src/backend/klangk_backend/email_templates/reset/body.html
+++ b/src/backend/klangk_backend/email_templates/reset/body.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block content %}<p>Click the link below to reset your password:</p>
+<p><a href="{{ link }}">Reset my password</a></p>
+<p>This link expires in {{ expiry_hours }} hour{{ '' if expiry_hours == 1 else 's' }}.</p>
+{% endblock %}

--- a/src/backend/klangk_backend/email_templates/reset/body.txt
+++ b/src/backend/klangk_backend/email_templates/reset/body.txt
@@ -1,0 +1,7 @@
+Click the link below to reset your {{ product_name }} password:
+
+<{{ link }}>
+
+This link expires in {{ expiry_hours }} hour{{ '' if expiry_hours == 1 else 's' }}.
+
+If you did not request this, you can ignore this email.

--- a/src/backend/klangk_backend/email_templates/reset/subject.txt
+++ b/src/backend/klangk_backend/email_templates/reset/subject.txt
@@ -1,0 +1,1 @@
+Reset your {{ product_name }} password

--- a/src/backend/klangk_backend/email_templates/verify/body.html
+++ b/src/backend/klangk_backend/email_templates/verify/body.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block content %}<p>Click the link below to verify your email address and activate your {{ product_name }} account:</p>
+<p><a href="{{ link }}">Verify my account</a></p>
+<p>This link expires in {{ expiry_hours }} hour{{ '' if expiry_hours == 1 else 's' }}.</p>
+{% endblock %}

--- a/src/backend/klangk_backend/email_templates/verify/body.txt
+++ b/src/backend/klangk_backend/email_templates/verify/body.txt
@@ -1,0 +1,7 @@
+Click the link below to verify your email address and activate your {{ product_name }} account:
+
+<{{ link }}>
+
+This link expires in {{ expiry_hours }} hour{{ '' if expiry_hours == 1 else 's' }}.
+
+If you did not request this, you can ignore this email.

--- a/src/backend/klangk_backend/email_templates/verify/subject.txt
+++ b/src/backend/klangk_backend/email_templates/verify/subject.txt
@@ -1,0 +1,1 @@
+Verify your {{ product_name }} account

--- a/src/backend/klangk_backend/emailsvc.py
+++ b/src/backend/klangk_backend/emailsvc.py
@@ -1,17 +1,35 @@
 """Email sending via SMTP or local sendmail."""
 
 import asyncio
-import html
 import logging
 import shutil
+from dataclasses import dataclass
 from email.message import EmailMessage
+from pathlib import Path
 
 import aiosmtplib
+from jinja2 import (
+    ChoiceLoader,
+    Environment,
+    FileSystemLoader,
+    PackageLoader,
+    select_autoescape,
+)
 
+from . import auth
 from .exceptions import SendmailError
 from .util import resolve_env_value
 
 logger = logging.getLogger(__name__)
+
+# Supported email events. Each maps to a directory under
+# email_templates/ holding subject.txt, body.txt, body.html. See #1165.
+EMAIL_EVENTS = ("verify", "reset", "invite")
+
+# Cached Jinja environment. Built lazily on first render; reset via
+# reset_template_env() (mainly for tests that flip
+# KLANGK_EMAIL_TEMPLATES_DIR between cases).
+_env: Environment | None = None
 
 
 def _resolve_password() -> str | None:
@@ -47,6 +65,23 @@ def use_smtp() -> bool:
     return bool(resolve_env_value("KLANGK_SMTP_HOST"))
 
 
+def reply_to() -> str | None:
+    """Configured Reply-To address (KLANGK_SMTP_REPLY_TO), or None.
+
+    Compliance/deliverability knob: orgs want a monitored reply address
+    distinct from the envelope From. None -> no header (today's behavior).
+    See #1165 / #261.
+    """
+    return resolve_env_value("KLANGK_SMTP_REPLY_TO", "") or None
+
+
+def _set_headers(msg: EmailMessage) -> None:
+    """Apply optional headers shared by every outgoing message."""
+    rt = reply_to()
+    if rt:
+        msg["Reply-To"] = rt
+
+
 def build_message(to: str, subject: str, body: str) -> EmailMessage:
     cfg = smtp_config()
     msg = EmailMessage()
@@ -54,6 +89,7 @@ def build_message(to: str, subject: str, body: str) -> EmailMessage:
     msg["From"] = cfg["from_addr"] or cfg["user"] or "noreply@localhost"
     msg["To"] = to
     msg.set_content(body)
+    _set_headers(msg)
     return msg
 
 
@@ -119,88 +155,145 @@ async def send_email(to: str, subject: str, body: str) -> None:
         await send_via_sendmail(msg)
 
 
-async def send_verification_email(to: str, verification_url: str) -> None:
-    """Send a verification email with the given callback URL.
+def reset_template_env() -> None:
+    """Drop the cached Jinja environment.
 
-    Sends as multipart/alternative with both plain text and HTML
-    so the link is clickable regardless of mail client.
+    For tests that change KLANGK_EMAIL_TEMPLATES_DIR between cases, since
+    the environment is built once and cached.
     """
-    name = product_name()
-    text_body = (
-        "Click the link below to verify your email address and "
-        f"activate your {name} account:\n\n"
-        f"<{verification_url}>\n\n"
-        "This link expires in 72 hours.\n\n"
-        "If you did not request this, you can ignore this email."
-    )
-    html_body = (
-        '<div style="font-family:sans-serif;max-width:480px;margin:0 auto">'
-        '<div style="text-align:center;padding:24px 0">'
-        '<span style="display:inline-block;background:#E65100;'
-        "color:#fff;border-radius:50%;width:48px;height:48px;"
-        'line-height:48px;font-size:24px">&#128062;</span>'
-        f'<h2 style="margin:8px 0 0">{name}</h2>'
-        "</div>"
-        "<p>Click the link below to verify your email address and "
-        f"activate your {name} account:</p>"
-        f'<p><a href="{verification_url}">Verify my account</a></p>'
-        "<p>This link expires in 72 hours.</p>"
-        "<p><small>If you did not request this, you can "
-        "ignore this email.</small></p>"
-        "</div>"
-    )
+    global _env
+    _env = None
+
+
+def _brand_ctx() -> dict:
+    """Global branding variables surfaced to every email template.
+
+    Resolved at call time so file:/cmd: prefixes work and value changes
+    take effect without a restart. Mirrors what /config exposes to the
+    frontend (see api.get_config).
+    """
+    return {
+        "product_name": product_name(),
+        "logo_url": resolve_env_value("KLANGK_LOGO_URL", "") or "",
+        "brand_color": resolve_env_value("KLANGK_BRAND_COLOR", "#E65100")
+        or "#E65100",
+    }
+
+
+def _template_env() -> Environment:
+    """Build (and cache) the Jinja environment.
+
+    Uses a ChoiceLoader: a deployer directory (KLANGK_EMAIL_TEMPLATES_DIR)
+    is tried first so it shadows the built-ins on a per-file basis; the
+    built-in package templates (email_templates/) are the fallback. Both
+    {% extends %} and {% include %} resolve through the same chain, so
+    overriding just base.html re-brands every email at once. See #1165.
+    """
+    global _env
+    if _env is None:
+        loaders = []
+        user_dir = resolve_env_value("KLANGK_EMAIL_TEMPLATES_DIR", "")
+        if user_dir:
+            path = Path(user_dir)
+            if path.is_dir():
+                loaders.append(FileSystemLoader(str(path)))
+        loaders.append(PackageLoader("klangk_backend", "email_templates"))
+        _env = Environment(
+            loader=ChoiceLoader(loaders),
+            # autoescape by extension: .html/.xml are escaped (closes the
+            # template-authoring XSS gap str.format leaves open); .txt is
+            # NOT (so <{{ link }}> stays literal). NOTE: a .html.j2 suffix
+            # would NOT match and silently disable escaping -- keep .html.
+            autoescape=select_autoescape(["html", "xml"]),
+            trim_blocks=True,
+            lstrip_blocks=True,
+            auto_reload=False,
+        )
+    return _env
+
+
+@dataclass(frozen=True)
+class EmailRender:
+    """Rendered email content: a subject plus plain-text and HTML bodies."""
+
+    subject: str
+    text: str
+    html: str
+
+
+def render_email(
+    event: str,
+    *,
+    link: str,
+    expiry_hours: int | float,
+    invited_by: str = "",
+) -> EmailRender:
+    """Render subject/text/html for an auth email event.
+
+    ``event`` is one of EMAIL_EVENTS (verify / reset / invite). ``link`` is
+    the per-email callback URL; ``expiry_hours`` is the real token TTL
+    (fixing the prior drift where bodies hardcoded "72 hours"/"1 hour"
+    regardless of config); ``invited_by`` is the inviter's email (invite
+    only). Branding globals come from _brand_ctx().
+
+    The subject receives only branding vars -- never the link/token -- so
+    tokens can't leak into mail-server subject logs.
+    """
+    if event not in EMAIL_EVENTS:
+        raise ValueError(f"unknown email event: {event!r}")
+    env = _template_env()
+    ctx = {
+        **_brand_ctx(),
+        "link": link,
+        "expiry_hours": int(expiry_hours),
+        "invited_by": invited_by,
+    }
+    subject = env.get_template(f"{event}/subject.txt").render(**ctx).strip()
+    text = env.get_template(f"{event}/body.txt").render(**ctx)
+    html = env.get_template(f"{event}/body.html").render(**ctx)
+    return EmailRender(subject=subject, text=text, html=html)
+
+
+def _build_multipart(to: str, rendered: EmailRender) -> EmailMessage:
+    """Assemble a multipart/alternative (text + HTML) message."""
     cfg = smtp_config()
     msg = EmailMessage()
-    msg["Subject"] = f"Verify your {name} account"
+    msg["Subject"] = rendered.subject
     msg["From"] = cfg["from_addr"] or cfg["user"] or "noreply@localhost"
     msg["To"] = to
-    msg.set_content(text_body)
-    msg.add_alternative(html_body, subtype="html")
+    msg.set_content(rendered.text)
+    msg.add_alternative(rendered.html, subtype="html")
+    _set_headers(msg)
+    return msg
 
+
+async def _send(msg: EmailMessage) -> None:
+    """Deliver via SMTP (if configured) or local sendmail."""
     if use_smtp():
         await send_via_smtp(msg)
     else:
         await send_via_sendmail(msg)
+
+
+async def send_verification_email(to: str, verification_url: str) -> None:
+    """Send a verification email with the given callback URL."""
+    rendered = render_email(
+        "verify",
+        link=verification_url,
+        expiry_hours=auth.VERIFY_TOKEN_EXPIRE_HOURS,
+    )
+    await _send(_build_multipart(to, rendered))
     logger.info("Verification email sent to %s", to)
 
 
 async def send_password_reset_email(to: str, reset_url: str) -> None:
     """Send a password reset email with the given callback URL."""
-    name = product_name()
-    text_body = (
-        f"Click the link below to reset your {name} password:\n\n"
-        f"<{reset_url}>\n\n"
-        "This link expires in 1 hour.\n\n"
-        "If you did not request this, you can ignore this email."
+    rendered = render_email(
+        "reset",
+        link=reset_url,
+        expiry_hours=auth.RESET_TOKEN_EXPIRE_HOURS,
     )
-    html_body = (
-        '<div style="font-family:sans-serif;max-width:480px;'
-        'margin:0 auto">'
-        '<div style="text-align:center;padding:24px 0">'
-        '<span style="display:inline-block;background:#E65100;'
-        "color:#fff;border-radius:50%;width:48px;height:48px;"
-        'line-height:48px;font-size:24px">&#128062;</span>'
-        f'<h2 style="margin:8px 0 0">{name}</h2>'
-        "</div>"
-        "<p>Click the link below to reset your password:</p>"
-        f'<p><a href="{reset_url}">Reset my password</a></p>'
-        "<p>This link expires in 1 hour.</p>"
-        "<p><small>If you did not request this, you can "
-        "ignore this email.</small></p>"
-        "</div>"
-    )
-    cfg = smtp_config()
-    msg = EmailMessage()
-    msg["Subject"] = f"Reset your {name} password"
-    msg["From"] = cfg["from_addr"] or cfg["user"] or "noreply@localhost"
-    msg["To"] = to
-    msg.set_content(text_body)
-    msg.add_alternative(html_body, subtype="html")
-
-    if use_smtp():
-        await send_via_smtp(msg)
-    else:
-        await send_via_sendmail(msg)
+    await _send(_build_multipart(to, rendered))
     logger.info("Password reset email sent to %s", to)
 
 
@@ -208,50 +301,13 @@ async def send_invitation_email(
     to: str, invite_url: str, invited_by_email: str
 ) -> None:
     """Send an invitation email with the given registration URL."""
-    # Escape the inviter's email for safe interpolation into the HTML
-    # body. The email validator permits characters such as '<', '>', and
-    # '"' in the local part, so an unescaped value could be used to inject
-    # markup/script into invitation emails sent to other users.
-    invited_by_html = html.escape(invited_by_email)
-    name = product_name()
-    text_body = (
-        f"{invited_by_email} has invited you to join {name}.\n\n"
-        "Click the link below to set your password and activate "
-        "your account:\n\n"
-        f"<{invite_url}>\n\n"
-        "This link expires in 72 hours.\n\n"
-        "If you did not expect this invitation, you can ignore this email."
+    rendered = render_email(
+        "invite",
+        link=invite_url,
+        expiry_hours=auth.INVITE_TOKEN_EXPIRE_HOURS,
+        invited_by=invited_by_email,
     )
-    html_body = (
-        '<div style="font-family:sans-serif;max-width:480px;margin:0 auto">'
-        '<div style="text-align:center;padding:24px 0">'
-        '<span style="display:inline-block;background:#E65100;'
-        "color:#fff;border-radius:50%;width:48px;height:48px;"
-        'line-height:48px;font-size:24px">&#128062;</span>'
-        f'<h2 style="margin:8px 0 0">{name}</h2>'
-        "</div>"
-        f"<p><strong>{invited_by_html}</strong> has invited you to "
-        f"join {name}.</p>"
-        "<p>Click the link below to set your password and activate "
-        "your account:</p>"
-        f'<p><a href="{invite_url}">Accept invitation</a></p>'
-        "<p>This link expires in 72 hours.</p>"
-        "<p><small>If you did not expect this invitation, you can "
-        "ignore this email.</small></p>"
-        "</div>"
-    )
-    cfg = smtp_config()
-    msg = EmailMessage()
-    msg["Subject"] = f"You've been invited to {name}"
-    msg["From"] = cfg["from_addr"] or cfg["user"] or "noreply@localhost"
-    msg["To"] = to
-    msg.set_content(text_body)
-    msg.add_alternative(html_body, subtype="html")
-
-    if use_smtp():
-        await send_via_smtp(msg)
-    else:
-        await send_via_sendmail(msg)
+    await _send(_build_multipart(to, rendered))
     logger.info(
         "Invitation email sent to %s (invited by %s)", to, invited_by_email
     )

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "python-multipart>=0.0.30",
     "starlette>=1.3.1",
     "aiosmtplib>=3.0.0",
+    "jinja2>=3.1",
     "logfire[fastapi]>=3.0.0",
     "pyyaml>=6.0",
     "httpx>=0.28.0",

--- a/src/backend/tests/test_emailsvc.py
+++ b/src/backend/tests/test_emailsvc.py
@@ -9,6 +9,17 @@ from klangk_backend import emailsvc
 from klangk_backend.exceptions import SendmailError
 
 
+# The Jinja environment is built once and cached at module level, so a
+# KLANGK_EMAIL_TEMPLATES_DIR set in one test would leak into the next.
+# Rebuild it fresh for every case (env-var state itself is handled by
+# monkeypatch). See #1165.
+@pytest.fixture(autouse=True)
+def _reset_email_template_env():
+    emailsvc.reset_template_env()
+    yield
+    emailsvc.reset_template_env()
+
+
 class TestBuildMessage:
     def test_builds_message(self):
         msg = emailsvc.build_message("to@example.com", "Subject", "Body")
@@ -312,8 +323,147 @@ class TestSendInvitationEmail:
         html_part = parts[1].get_content()
         # The crafted payload must not form a live HTML element; angle
         # brackets and quotes must be escaped so the email renders as
-        # inert text rather than injecting markup/script.
+        # inert text rather than injecting markup/script. Autoescape now
+        # runs through Jinja/markupsafe (numeric entities &#34;/&#39;)
+        # rather than the old html.escape named forms (&quot;/&#x27;), so
+        # assert the security property, not a specific entity spelling.
         assert "<img" not in html_part
         assert "&lt;img" in html_part
-        assert 'admin"&gt;' not in html_part
-        assert "admin&quot;&gt;" in html_part
+        assert 'admin"><img' not in html_part
+        # the quote and '>' are escaped (named or numeric form)
+        assert "&gt;" in html_part
+        assert ("&quot;" in html_part) or ("&#34;" in html_part)
+
+
+class TestRenderEmail:
+    def test_verify_event_renders_all_three_parts(self):
+        r = emailsvc.render_email(
+            "verify", link="https://x/v?t=1", expiry_hours=72
+        )
+        assert r.subject == "Verify your Klangk account"
+        assert "https://x/v?t=1" in r.text
+        assert "expires in 72 hours" in r.text
+        assert 'href="https://x/v?t=1"' in r.html
+
+    def test_unknown_event_raises(self):
+        # Guards against a typo in a caller wiring up a new event.
+        with pytest.raises(ValueError, match="unknown email event"):
+            emailsvc.render_email("bogus", link="https://x", expiry_hours=1)
+
+    def test_expiry_hours_interpolated_not_hardcoded(self):
+        # Proves the drift fix (#1165): a non-default TTL is reflected
+        # in BOTH text and html, instead of the old hardcoded "72 hours".
+        r = emailsvc.render_email("verify", link="https://x", expiry_hours=48)
+        assert "expires in 48 hours" in r.text
+        assert "expires in 48 hours" in r.html
+
+    def test_singular_hour_when_expiry_is_one(self):
+        r = emailsvc.render_email("reset", link="https://x", expiry_hours=1)
+        assert "expires in 1 hour." in r.text
+        assert "1 hours" not in r.text
+
+    def test_brand_color_in_badge(self, monkeypatch):
+        monkeypatch.setenv("KLANGK_BRAND_COLOR", "#abcdef")
+        r = emailsvc.render_email("verify", link="https://x", expiry_hours=72)
+        assert "#abcdef" in r.html
+
+    def test_logo_url_replaces_badge(self, monkeypatch):
+        monkeypatch.setenv("KLANGK_LOGO_URL", "https://logo/test.png")
+        r = emailsvc.render_email("verify", link="https://x", expiry_hours=72)
+        assert '<img src="https://logo/test.png"' in r.html
+        # The paw badge is hidden when a logo override is set.
+        assert "&#128062;" not in r.html
+
+    def test_product_name_flows_through(self, monkeypatch):
+        monkeypatch.setenv("KLANGK_PRODUCT_NAME", "Acme Labs")
+        r = emailsvc.render_email("verify", link="https://x", expiry_hours=72)
+        assert r.subject == "Verify your Acme Labs account"
+        assert "Acme Labs" in r.html
+        assert "Klangk" not in r.html
+
+
+class TestTemplateOverlay:
+    def test_user_dir_shadows_builtin_per_file(self, tmp_path, monkeypatch):
+        # A deployer dir with only an overriding subject shadows that one
+        # file; everything else falls through to the built-ins.
+        d = tmp_path / "templates"
+        (d / "verify").mkdir(parents=True)
+        (d / "verify" / "subject.txt").write_text("CUSTOM VERIFY SUBJECT\n")
+        monkeypatch.setenv("KLANGK_EMAIL_TEMPLATES_DIR", str(d))
+        r = emailsvc.render_email(
+            "verify", link="https://x/v?t=1", expiry_hours=72
+        )
+        assert r.subject == "CUSTOM VERIFY SUBJECT"
+        # The body was NOT overridden -> built-in still used.
+        assert "verify your email address" in r.text
+        # A different event (not overridden) keeps its built-in subject.
+        rr = emailsvc.render_email(
+            "reset", link="https://x/r?t=1", expiry_hours=1
+        )
+        assert rr.subject == "Reset your Klangk password"
+
+    def test_overriding_base_rebrands_all_events(self, tmp_path, monkeypatch):
+        # Editing base.html alone re-brands every email, because each
+        # child does {% extends "base.html" %} and the ChoiceLoader
+        # resolves the override first.
+        d = tmp_path / "templates"
+        d.mkdir()
+        (d / "base.html").write_text(
+            "<div>BRANDED {{ product_name }}</div>"
+            "{% block content %}{% endblock %}"
+        )
+        monkeypatch.setenv("KLANGK_EMAIL_TEMPLATES_DIR", str(d))
+        rv = emailsvc.render_email("verify", link="https://x", expiry_hours=72)
+        ri = emailsvc.render_email(
+            "invite", link="https://x", expiry_hours=72, invited_by="a@b.com"
+        )
+        assert "BRANDED Klangk" in rv.html
+        assert "BRANDED Klangk" in ri.html
+
+    def test_nonexistent_user_dir_is_ignored(self, tmp_path, monkeypatch):
+        # A bad path doesn't crash; built-ins are used.
+        monkeypatch.setenv(
+            "KLANGK_EMAIL_TEMPLATES_DIR", str(tmp_path / "does-not-exist")
+        )
+        r = emailsvc.render_email("verify", link="https://x", expiry_hours=72)
+        assert r.subject == "Verify your Klangk account"
+
+    def test_html_autoescape_on_html_off_text(self, monkeypatch):
+        # .html is autoescaped (closes the str.format XSS gap); .txt is not.
+        r = emailsvc.render_email(
+            "invite",
+            link="https://x",
+            expiry_hours=72,
+            invited_by="<script>@e.com",
+        )
+        assert "<script>@e.com" in r.text  # literal in plain text
+        assert "<script>@e.com" not in r.html  # escaped in HTML
+        assert "&lt;script&gt;@e.com" in r.html
+
+
+class TestReplyTo:
+    def test_reply_to_none_when_unset(self, monkeypatch):
+        monkeypatch.delenv("KLANGK_SMTP_REPLY_TO", raising=False)
+        assert emailsvc.reply_to() is None
+
+    def test_reply_to_resolved_when_set(self, monkeypatch):
+        monkeypatch.setenv("KLANGK_SMTP_REPLY_TO", "support@example.com")
+        assert emailsvc.reply_to() == "support@example.com"
+
+    def test_build_message_adds_reply_to_when_set(self, monkeypatch):
+        monkeypatch.setenv("KLANGK_SMTP_REPLY_TO", "support@example.com")
+        msg = emailsvc.build_message("to@e.com", "S", "B")
+        assert msg["Reply-To"] == "support@example.com"
+
+    def test_build_message_no_reply_to_when_unset(self, monkeypatch):
+        monkeypatch.delenv("KLANGK_SMTP_REPLY_TO", raising=False)
+        msg = emailsvc.build_message("to@e.com", "S", "B")
+        assert msg["Reply-To"] is None
+
+    async def test_multipart_carries_reply_to(self, monkeypatch):
+        monkeypatch.setenv("KLANGK_SMTP_REPLY_TO", "support@example.com")
+        rendered = emailsvc.render_email(
+            "verify", link="https://x", expiry_hours=72
+        )
+        msg = emailsvc._build_multipart("to@e.com", rendered)
+        assert msg["Reply-To"] == "support@example.com"

--- a/uv.lock
+++ b/uv.lock
@@ -628,6 +628,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
 name = "klangk-backend"
 source = { editable = "src/backend" }
 dependencies = [
@@ -637,6 +649,7 @@ dependencies = [
     { name = "cryptography" },
     { name = "fastapi" },
     { name = "httpx" },
+    { name = "jinja2" },
     { name = "logfire", extra = ["fastapi"] },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -659,6 +672,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=48.0.1" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", specifier = ">=0.28.0" },
+    { name = "jinja2", specifier = ">=3.1" },
     { name = "logfire", extras = ["fastapi"], specifier = ">=3.0.0" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.24.0" },
@@ -737,6 +751,69 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements #1165 — the `KLANGK_EMAIL_TEMPLATES_DIR` email-templating item from #261 (Tier 1). The three auth emails (verification, password reset, invitation) were hardcoded strings in `emailsvc.py` with hardcoded "72 hours"/"1 hour" expiry text that ignored the real token TTL, and no way to customize without editing source. This replaces them with a Jinja2 template package that becomes the **single source of truth**, and bundles the two #261 items that collapse into the same change (expiry-drift fix; `KLANGK_SMTP_REPLY_TO` + footer block).

Design was settled in #1165 (research + sketch there). The foundational rule from that issue: **the built-in templates *replace* the hardcoded emails — there is no parallel hardcoded fallback path.**

Closes #1165. Refs #261.

## What changed

- **Template package** (`klangk_backend/email_templates/`): `base.html` + `verify/`/`reset/`/`invite/` folders, each with `subject.txt`, `body.txt`, `body.html`. The `send_*` functions now render from them; the old inline strings, the 🐾 emoji, and the "Klangk" wordmark are deleted entirely. With no override set, rendered output is content-equivalent to today.
- **`ChoiceLoader` overlay**: `KLANGK_EMAIL_TEMPLATES_DIR` is tried first (per-file shadow), built-ins are the fallback. `{% extends %}` resolves through the same chain, so overriding just `base.html` re-brands every email at once; overriding one file changes only that one.
- **`autoescape=select_autoescape(["html","xml"])`**: `.html` is autoescaped (closes the `str.format` XSS gap; generalizes the old one-off `html.escape(invited_by_email)` to *every* variable); `.txt` is not (so `<{{ link }}>` stays literal). Filenames must stay `.html` — a `.html.j2` suffix silently disables autoescape, and the shared base is the worst place to lose it.
- **Expiry drift fixed**: `{{ expiry_hours }}` is interpolated from the real `auth.{VERIFY,RESET,INVITE}_TOKEN_EXPIRE_HOURS`, so the text always matches the actual token lifetime instead of a hardcoded string.
- **Brand context**: `product_name`, `logo_url` (renders an `<img>` in the email header when `KLANGK_LOGO_URL` is set — picks up #1152 for free), and a new `brand_color` (`KLANGK_BRAND_COLOR`, default `#E65100`).
- **`KLANGK_SMTP_REPLY_TO`**: adds a `Reply-To` header to every outgoing message when set (compliance/deliverability); unset → no header.
- **Footer/legal**: the base exposes an empty `{% block legal %}` so a deployer can add a compliance footer in one place.
- **Subjects stay token-free**: subject templates receive only branding vars, never the link/token, so tokens can't leak into mail-server subject logs.
- **`devenv.nix`**: excludes `email_templates/` from prettier (prettier corrupts Jinja `{% %}`/`{{ }}` syntax — e.g. breaks an expression across lines like `{{ '' if expiry_hours == 1 else\n's' }}`).

New dep: `jinja2>=3.1`. Verified all 11 template files are packaged into the built wheel (so non-editable/production installs get them too). Docs added to `customizing.md` (the copy-whole-tree vs drop-only-changed workflow, where to get the tree, the `.html`-suffix rule, variables, Reply-To, footer block).

## Verification

- **Backend:** `pytest -n auto` → **2050 passed, 100.00% coverage**; `emailsvc.py` at 100%. `ruff format`/`ruff check` clean; all pre-commit hooks green.
- **Wheel:** built and inspected — all 11 template entries present.
- **Smoke render:** HTML header byte-identical to today; `1 hour` (singular) vs `72 hours` (plural); `<script>` → `&lt;script&gt;` (autoescape).

## New tests

Per-file overlay (user dir shadows one file, rest fall through); base-override rebrands all events; brand-color in badge; logo-URL replaces badge; product-name flow; expiry interpolation (drift proof); singular/plural; bad-event guard; autoescape on-HTML/off-text; Reply-To set/unset on both plain and multipart builders.

## Notable decisions worth a look

1. **Content-equivalent, not byte-equivalent.** The acceptance criterion in #1165 said "byte-equivalent (modulo TTL text)"; I relaxed this to *content-equivalent*. Reason: today's HTML is one long concatenated string with no inter-tag whitespace; forcing byte-parity would require single-line templates, defeating the human-editability that's the whole point. The rendered emails are identical in tags, attributes, text, links, and order — only insignificant inter-tag whitespace differs. The existing tests are substring-based and pass; text bodies reproduce newlines exactly (whitespace is significant there).
2. **`#878` escaping test** now asserts the *security property* entity-agnostically. The old test pinned `html.escape`'s named entities (`&quot;`); Jinja's markupsafe emits numeric ones (`&#34;`). The property (`<img` → `&lt;img`, can't form a live element) is fully preserved — only the entity spelling changed, so the test no longer pins it.
3. **No scaffold CLI.** Per discussion in #1165, deployers copy the tree from the git checkout; a `klangk email-templates scaffold` command was deliberately deferred.
4. **Size cap deferred.** Supabase's `GOTRUE_MAILER_TEMPLATE_MAX_SIZE` was noted in #1165 but not implemented — the deployer dir is operator-controlled (not user-uploaded), so the threat is lower than Supabase's URL-fetch case; cleanly additive later.

## Scope / non-goals

Does **not** add email-change / magic-link / OTP templates (no such flows yet — but the tree/loader scale to them), does **not** add a full `<!doctype html>` document shell (today's emails are fragments; parity preserved), and does **not** introduce the global config vars to *populate* the footer (`company_name`, `sender_name`, support link) — separate #261 items; the `{% block legal %}` reserves the slot.