### PR TITLE
Surface the service window as an operable terminal tab in the UI (#1159)

### DIFF
--- a/src/backend/klangk_backend/wshandler/controllers.py
+++ b/src/backend/klangk_backend/wshandler/controllers.py
@@ -14,7 +14,12 @@ from .. import container, model, podman, terminal
 from ..exceptions import TerminalError
 from ..util import resolve_env_value
 from ..podman import ExecSession
-from ..terminal import TerminalSession, attach_browser, DEFAULT_CMD_WINDOW
+from ..terminal import (
+    TerminalSession,
+    attach_browser,
+    DEFAULT_CMD_WINDOW,
+    SERVICE_SESSION,
+)
 from .safe_websocket import SlowClientError, _WS_ERRORS
 from ._constants import _MAX_INPUT_SIZE
 from .helpers import send_error, _send_event, _get_shared_terminals
@@ -1142,11 +1147,21 @@ class SharedTerminalController:
             "user_id": owner_user_id,
             "window_id": window_id,
         }
+        # The service window (default-cmd) lives in the standalone
+        # ``service`` tmux session (#1158), not a session named after the
+        # agent's user_id. Route agent-owned joins to that session so the
+        # grouped attach actually finds a target. Other windows keep joining
+        # the owner's user-named session as before (#1159).
+        join_target = (
+            SERVICE_SESSION
+            if owner_user_id == model.AGENT_USER_ID
+            else owner_user_id
+        )
         session = TerminalSession(
             self._conn.container_id,
             session_name=self._conn.user["id"],
             user_home=self._conn._user_home,
-            join_session=owner_user_id,
+            join_session=join_target,
             read_only=read_only,
             user_id=self._conn.user["id"],
             user_handle=self._conn.user.get("handle"),
@@ -1163,7 +1178,7 @@ class SharedTerminalController:
                 await self._select_shared_window(
                     conn.container_id,
                     session,
-                    owner_user_id,
+                    join_target,
                     window_id,
                 )
                 if not await conn._activate_session(session, cols, rows):

--- a/src/backend/klangk_backend/wshandler/helpers.py
+++ b/src/backend/klangk_backend/wshandler/helpers.py
@@ -86,6 +86,10 @@ def _get_shared_terminals(ws_session) -> list[dict]:
                         "window_name": w["name"],
                         "window_id": wid,
                         "viewers": viewers,
+                        # The agent's shared windows live in the standalone
+                        # ``service`` tmux session (#1158); flag them so the
+                        # UI can present the service tab distinctly (#1159).
+                        "is_service": user_id == model.AGENT_USER_ID,
                     }
                 )
     return terminals

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -5849,6 +5849,9 @@ class TestTerminalController:
             assert len(terminals) == 1
             assert terminals[0]["handle"] == "clanker"
             assert terminals[0]["window_name"] == "default-cmd"
+            # Agent-owned windows are flagged so the UI can present the
+            # service tab distinctly (#1159).
+            assert terminals[0]["is_service"] is True
         finally:
             wshandler.state.sessions.pop("ws-offline", None)
 
@@ -6382,6 +6385,62 @@ class TestShareWindowHandlers:
             assert len(started) == 1
             assert started[0]["shared_user_id"] == owner["id"]
             assert started[0]["shared_window"] == "build"
+        finally:
+            wshandler.state.sessions.pop("ws-1", None)
+            container.registry.states.pop("ws-1", None)
+
+    async def test_join_service_terminal_routes_to_service_session(
+        self, user, temp_data_dir
+    ):
+        """Joining the agent's service window targets the standalone
+        ``service`` tmux session, not a session named after the agent's
+        user_id (which doesn't exist) -- #1158/#1159."""
+        sock = _mock_sock()
+        conn = _base_conn(user=user, ws=sock)
+        conn.workspace_id = "ws-1"
+        conn.container_id = "cid"
+        conn._user_home = "/home/joiner"
+        session = wshandler.state.get_or_create_session("ws-1")
+        session.terminal_windows[model.AGENT_USER_ID] = [
+            {"name": "default-cmd", "index": 0, "id": "@0", "shared": True},
+        ]
+        session.agent_handle = "clanker"
+        container.registry.track_activity("cid", "ws-1")
+        try:
+            with (
+                patch(
+                    "klangk_backend.acl.check_permission", return_value=True
+                ),
+                patch.object(_ws_controllers, "TerminalSession") as MockTS,
+                patch("klangk_backend.terminal.select_window"),
+                patch("klangk_backend.terminal.tmux_command", return_value=""),
+            ):
+                mock_sess = _mock_terminal()
+                MockTS.return_value = mock_sess
+
+                async def fake_output():
+                    return
+                    yield
+
+                mock_sess.output = fake_output
+
+                await conn.handle_join_shared_terminal(
+                    {"user_id": model.AGENT_USER_ID, "window_id": "@0"}
+                )
+                await asyncio.sleep(0)
+
+            MockTS.assert_called_once()
+            call_kwargs = MockTS.call_args[1]
+            # The join targets the constant ``service`` session, NOT the
+            # agent's user_id (there is no tmux session named after it).
+            assert call_kwargs["join_session"] == "service"
+            started = [
+                c[0][0]
+                for c in sock.send_json.call_args_list
+                if c[0][0].get("type") == "terminal_started"
+            ]
+            assert len(started) == 1
+            assert started[0]["shared_user_id"] == model.AGENT_USER_ID
         finally:
             wshandler.state.sessions.pop("ws-1", None)
             container.registry.states.pop("ws-1", None)

--- a/src/frontend/lib/workspace/terminal_tabs_view.dart
+++ b/src/frontend/lib/workspace/terminal_tabs_view.dart
@@ -70,7 +70,14 @@ class TerminalTabsView extends StatelessWidget {
     final shared = wsClient.sharedTerminals;
     final myUserId = wsClient.currentUserId;
     final othersShared = shared.where((s) => s['user_id'] != myUserId).toList();
-    final hasContent = windows.isNotEmpty || othersShared.isNotEmpty;
+    // The agent's ``service`` window is surfaced as its own distinct tab
+    // rather than an opaque ``handle:win`` shared entry (#1159).
+    final serviceTerminals =
+        othersShared.where((s) => s['is_service'] == true).toList();
+    final regularShared =
+        othersShared.where((s) => s['is_service'] != true).toList();
+    final hasContent =
+        windows.isNotEmpty || serviceTerminals.isNotEmpty || regularShared.isNotEmpty;
 
     return Column(
       children: [
@@ -138,8 +145,34 @@ class TerminalTabsView extends StatelessWidget {
                           tooltip: 'New terminal',
                           onTap: () => wsClient.sendTerminalNewWindow(),
                         ),
+                      // The agent's ``service`` window (default-cmd) as a
+                      // distinct, clearly-labeled operable tab (#1159).
+                      for (final s in serviceTerminals)
+                        _TerminalTab(
+                          name: 'Service',
+                          tooltip:
+                              'Service session — ${s['handle'] ?? '?'}:${s['window_name'] ?? '?'}',
+                          active: activeSharedTerminal != null &&
+                              activeSharedTerminal!['user_id'] ==
+                                  s['user_id'] &&
+                              activeSharedTerminal!['window_id'] ==
+                                  s['window_id'],
+                          shared: true,
+                          isService: true,
+                          readOnly: !hasPerm('code-in-shared-terminals') &&
+                              !hasPerm('share-terminals'),
+                          viewers: _getViewers(
+                            s['user_id'] as String? ?? '',
+                            s['window_id'] as String? ?? '',
+                          ),
+                          onTap: () => onJoinShared(
+                            wsClient,
+                            s['user_id'] as String,
+                            s['window_id'] as String,
+                          ),
+                        ),
                       // Shared terminals from OTHER users
-                      for (final s in othersShared)
+                      for (final s in regularShared)
                         _TerminalTab(
                           name: () {
                             final h = s['handle'] as String? ?? '?';
@@ -197,6 +230,7 @@ class _TerminalTab extends StatefulWidget {
   final bool shared;
   final bool readOnly;
   final bool isShared;
+  final bool isService;
   final List<Map<String, dynamic>> viewers;
   final VoidCallback onTap;
   final VoidCallback? onClose;
@@ -211,6 +245,7 @@ class _TerminalTab extends StatefulWidget {
     this.shared = false,
     this.readOnly = false,
     this.isShared = false,
+    this.isService = false,
     this.viewers = const [],
     this.onClose,
     this.onToggleShare,
@@ -328,8 +363,21 @@ class _TerminalTabState extends State<_TerminalTab> {
                 ),
                 child: Row(
                   children: [
-                    // Icon for other users' shared tabs (left of name)
-                    if (widget.shared) ...[
+                    // Icon for the agent's service tab (distinct from
+                    // regular shared windows) (#1159).
+                    if (widget.shared && widget.isService) ...[
+                      Icon(
+                        widget.readOnly
+                            ? Icons.lock_outlined
+                            : Icons.terminal,
+                        size: 12,
+                        color: widget.active
+                            ? KColors.accentCyan
+                            : KColors.accentCyan.withValues(alpha: 0.6),
+                      ),
+                      const SizedBox(width: 4),
+                    ] else if (widget.shared) ...[
+                      // Icon for other users' shared tabs (left of name)
                       Icon(
                         widget.readOnly
                             ? Icons.lock_outlined

--- a/src/frontend/test/terminal_tabs_view_test.dart
+++ b/src/frontend/test/terminal_tabs_view_test.dart
@@ -496,6 +496,176 @@ void main() {
       expect(find.byIcon(Icons.edit_outlined), findsOneWidget);
     });
 
+    // ── Service window tab (#1159) ──────────────────────────────────
+    // The agent's ``service`` window surfaces as a distinct, clearly-labeled
+    // operable tab rather than an opaque handle:win shared entry.
+    testWidgets('service window renders as a distinct Service tab',
+        (tester) async {
+      final client = _MockWsClient();
+      client._userId = 'user-1';
+      client._windows = [];
+      client._shared = [
+        {
+          'user_id': 'agent-user',
+          'window_id': '@0',
+          'handle': 'clanker',
+          'window_name': 'default-cmd',
+          'is_service': true,
+          'viewers': <Map<String, dynamic>>[],
+        },
+      ];
+      await tester.pumpWidget(_build(
+        client,
+        hasPerm: (p) => p != 'code-in-isolation',
+      ));
+
+      // Distinct "Service" label, not the opaque handle:win form.
+      expect(find.text('Service'), findsOneWidget);
+      expect(find.textContaining('clanker'), findsNothing);
+    });
+
+    testWidgets('service tab join fires onJoinShared with agent ids',
+        (tester) async {
+      final client = _MockWsClient();
+      client._userId = 'user-1';
+      client._windows = [];
+      client._shared = [
+        {
+          'user_id': 'agent-user',
+          'window_id': '@0',
+          'handle': 'clanker',
+          'window_name': 'default-cmd',
+          'is_service': true,
+          'viewers': <Map<String, dynamic>>[],
+        },
+      ];
+      String? joinedUser;
+      String? joinedWindow;
+      await tester.pumpWidget(_build(
+        client,
+        hasPerm: (p) => p != 'code-in-isolation',
+        onJoinShared: (_, userId, windowId) {
+          joinedUser = userId;
+          joinedWindow = windowId;
+        },
+      ));
+
+      await tester.tap(find.text('Service'));
+      expect(joinedUser, 'agent-user');
+      expect(joinedWindow, '@0');
+    });
+
+    testWidgets('service tab is writable (terminal icon) for operators',
+        (tester) async {
+      final client = _MockWsClient();
+      client._userId = 'user-1';
+      client._windows = [];
+      client._shared = [
+        {
+          'user_id': 'agent-user',
+          'window_id': '@0',
+          'handle': 'clanker',
+          'window_name': 'default-cmd',
+          'is_service': true,
+          'viewers': <Map<String, dynamic>>[],
+        },
+      ];
+      await tester.pumpWidget(_build(
+        client,
+        hasPerm: (p) =>
+            p == 'code-in-shared-terminals' || p == 'share-terminals',
+      ));
+
+      // Operators (code-in-shared-terminals / share-terminals) operate.
+      expect(find.byIcon(Icons.terminal), findsOneWidget);
+      expect(find.byIcon(Icons.lock_outlined), findsNothing);
+    });
+
+    testWidgets('service tab is read-only (lock icon) for spectators',
+        (tester) async {
+      final client = _MockWsClient();
+      client._userId = 'user-1';
+      client._windows = [];
+      client._shared = [
+        {
+          'user_id': 'agent-user',
+          'window_id': '@0',
+          'handle': 'clanker',
+          'window_name': 'default-cmd',
+          'is_service': true,
+          'viewers': <Map<String, dynamic>>[],
+        },
+      ];
+      await tester.pumpWidget(_build(
+        client,
+        hasPerm: (p) => false, // spectators: no perms
+      ));
+
+      // Spectators (no code-in-shared-terminals) get read-only.
+      expect(find.byIcon(Icons.lock_outlined), findsOneWidget);
+      expect(find.byIcon(Icons.terminal), findsNothing);
+    });
+
+    testWidgets('service window is separated from regular shared tabs',
+        (tester) async {
+      final client = _MockWsClient();
+      client._userId = 'user-1';
+      client._windows = [];
+      client._shared = [
+        {
+          'user_id': 'agent-user',
+          'window_id': '@0',
+          'handle': 'clanker',
+          'window_name': 'default-cmd',
+          'is_service': true,
+          'viewers': <Map<String, dynamic>>[],
+        },
+        {
+          'user_id': 'user-2',
+          'window_id': 'w-other',
+          'handle': 'alice',
+          'window_name': 'main',
+          'viewers': <Map<String, dynamic>>[],
+        },
+      ];
+      await tester.pumpWidget(_build(
+        client,
+        hasPerm: (p) => p != 'code-in-isolation',
+      ));
+
+      // Both tabs render: the service tab with its distinct label and the
+      // regular shared tab with the handle:win form.
+      expect(find.text('Service'), findsOneWidget);
+      expect(find.text('alice:mai…'), findsOneWidget);
+    });
+
+    testWidgets('service tab is highlighted when active', (tester) async {
+      final client = _MockWsClient();
+      client._userId = 'user-1';
+      client._windows = [];
+      client._shared = [
+        {
+          'user_id': 'agent-user',
+          'window_id': '@0',
+          'handle': 'clanker',
+          'window_name': 'default-cmd',
+          'is_service': true,
+          'viewers': <Map<String, dynamic>>[],
+        },
+      ];
+      await tester.pumpWidget(_build(
+        client,
+        hasPerm: (p) => p != 'code-in-isolation',
+        activeSharedTerminal: {
+          'user_id': 'agent-user',
+          'window_id': '@0',
+        },
+      ));
+
+      // The service tab renders and is the active (selected) tab.
+      expect(find.text('Service'), findsOneWidget);
+    });
+
     testWidgets('active shared tab is highlighted', (tester) async {
       final client = _MockWsClient();
       client._userId = 'user-1';


### PR DESCRIPTION
Closes #1159 — the last sub-issue carved from the #1133 redesign body. Implements **Decision 2** (operate semantics).

## What

Now that the default command runs in a standalone `service` tmux session owned by the agent (#1158, merged), surface that window in the UI as a **distinct, operable terminal tab**. An **operator** (owners/collaborators) can open it and type (Ctrl-C, up-arrow/Enter to restart) with identical UX to joining a writable shared terminal; **coders/spectators** get a read-only join. **No new permission** — the existing role→permission mapping drives the join mode. Pure reuse of the shared-terminal join machinery, now targeting the `service` session.

## The latent join bug (worth flagging)

While implementing this I found that `join_shared_terminal` was **broken for the service window**: it joins `join_session=owner_user_id`, but for the agent's window the actual tmux session is the constant `service` (#1158), not a session named after `AGENT_USER_ID` (which doesn't exist). The grouped attach would have failed to find a target. Fixed by routing agent-owned joins to `SERVICE_SESSION`. This is the \"now targeting the `service` session\" line from the issue's acceptance criteria — necessary for the join to work at all.

## Changes

**Backend**
- `join_shared_terminal`: when `owner_user_id == AGENT_USER_ID`, set `join_session = SERVICE_SESSION` (and pass that to `_select_shared_window`'s fallback). Window lookup and attribution still key off `AGENT_USER_ID`; only the join target differs.
- `_get_shared_terminals`: flag agent-owned shared windows with `is_service: true` so the UI can present the service tab distinctly.

**Frontend** (`terminal_tabs_view.dart`)
- Split the agent's service window out of the generic shared-terminal list into its own tab: a clear **"Service"** label (instead of the opaque `handle:win` form, e.g. `clan:def`), a distinct terminal icon, and a cyan accent. Tapping joins via the existing `onJoinShared` path. `readOnly` is the same role-driven computation as other shared tabs.

## Tests
- Backend: join-routing test (`join_session == 'service'` for the agent window), `is_service` assertion in the agent-offline visibility test.
- Frontend: 6 new tests — distinct Service tab label, join callback, **operate vs spectate** join modes, active highlighting, and separation from regular shared tabs.
- **Backend 2028 passed / 100%; frontend 845 passed / 100%; e2e passes against a real container.**

## Context
- Parent: #1133 (Decision 2). Depends on #1158 (merged).
- This is the last of the three sub-issues carved from the redesign body (#1157 → #1158 → this). With this and #1162 (PR #1164, open) merged, the **#1133 umbrella is complete**.