### PR TITLE
Fix sandbox autostart under agent-owned service session

### DIFF
--- a/docs/features/sandbox.md
+++ b/docs/features/sandbox.md
@@ -73,12 +73,12 @@ workspace:
   health-check: /openclaw/bin/healthcheck.sh
 ```
 
-| Field             | Required | Default              | Description                                                                                                                |
-| ----------------- | -------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `image`           | no       | server default image | Container image. Must be in the server's allowed images list.                                                              |
-| `default-command` | no       | (none)               | Command to run automatically in the first terminal window on first connect. See [Default Command](default-command.md).     |
-| `auto-start`      | no       | `false`              | Start the container automatically when the Klangk server starts. See [Auto-start](workspaces.md#auto-start).               |
-| `health-check`    | no       | (none)               | Shell command polled inside the container to gauge service health (exit 0 = healthy). See [Health Check](health-check.md). |
+| Field             | Required | Default              | Description                                                                                                                                 |
+| ----------------- | -------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `image`           | no       | server default image | Container image. Must be in the server's allowed images list.                                                                               |
+| `default-command` | no       | (none)               | Command to run automatically as the agent identity in the Service terminal tab on first connect. See [Default Command](default-command.md). |
+| `auto-start`      | no       | `false`              | Start the container automatically when the Klangk server starts. See [Auto-start](workspaces.md#auto-start).                                |
+| `health-check`    | no       | (none)               | Shell command polled inside the container to gauge service health (exit 0 = healthy). See [Health Check](health-check.md).                  |
 
 The workspace name is not in the config file — it's always
 specified as a positional argument on the command line.
@@ -177,9 +177,9 @@ mounts:
   - .env:~/.env:ro
 ```
 
-Then in your `~/.profile` (so the default command and `klangkc exec` see
-the variables too — see [The Shell](the-shell.md#startup-files)) or
-setup script:
+Then in your `~/.profile` (so the default command — running as the
+agent — and `klangkc exec` see the variables too; see
+[The Shell](the-shell.md#startup-files)) or setup script:
 
 ```bash
 [ -f ~/.env ] && . ~/.env
@@ -232,8 +232,10 @@ klangkc shell myworkspace -A
 ```
 
 If the workspace has a `default-command` configured (e.g.
-`openclaw gateway`), that command runs in the first terminal
-window. To get an interactive shell alongside it, connect to a
+`openclaw gateway`), that command runs in the workspace's **Service**
+terminal tab — as the agent identity, not in your own shell
+(see [Where the default command runs](#where-the-default-command-runs-and-how-to-install-for-it)
+above). To get an interactive shell alongside it, connect to a
 named terminal window:
 
 ```bash
@@ -269,6 +271,47 @@ operations (installing to `~`, downloading binaries, etc.). To
 install system packages with `apt`, install nix, or modify system
 files, the server administrator must set `KLANGK_ALLOW_SUDO=true`
 in the server's `.env` file.
+
+### Where the default command runs (and how to install for it)
+
+A `default-command` does **not** run in the workspace owner's shell.
+It runs as the workspace's **agent** identity, in a dedicated
+`service` tmux session whose `$HOME` is the agent's home
+(`/home/clanker` by default, exposed as `$KLANGK_AGENT_HOME`) — not
+the owner's. The owner interacts with it through the **Service**
+terminal tab in the web UI.
+
+This matters for setup scripts: anything the default command needs at
+runtime — env exports in `~/.profile`, binaries installed under
+`~/.local/bin`, config it reads from `$HOME` — must land in the
+**agent's** home, because that's the home whose `~/.profile` the
+service session sources. If you write to `~/.profile` while `$HOME`
+is still the owner's home (the default when the setup script starts),
+the default command will never see those exports.
+
+The simplest fix is to repoint `HOME` at the agent home at the top of
+your setup script. After that, every home-relative write in the
+script — `~/.profile` appends, `~/.local/bin` links, `~/.pi` config —
+lands in the agent's home, which is exactly where the default command
+will look:
+
+```bash
+#!/bin/bash
+set -euo pipefail
+
+# Run the rest of setup as the agent identity: the default command
+# runs in the agent's service session ($KLANGK_AGENT_HOME), so install
+# everything the default command depends on into THAT home.
+export HOME="${KLANGK_AGENT_HOME:-/home/clanker}"
+
+# Now ~/.profile, ~/.local/bin, etc. resolve into the agent's home.
+```
+
+> The owner does **not** get tools installed by a sandbox on their own
+> PATH. Sandbox-installed services are owned and operated by the agent
+> through the Service tab — that is the supported way to manage them
+> (e.g. `openclaw onboard`, restarting a gateway). Don't also write
+> the same exports to the owner's `~/.profile`; it's not a consumer.
 
 ### Example: install nix and devenv
 
@@ -364,6 +407,12 @@ And a setup script:
 # setup.sh
 set -euo pipefail
 
+# Run the rest of setup as the agent identity: the default command
+# runs in the agent's service session ($KLANGK_AGENT_HOME), so install
+# everything it depends on into THAT home. See
+# "Where the default command runs" in sandbox.md.
+export HOME="${KLANGK_AGENT_HOME:-/home/clanker}"
+
 # Install nix (single-user, no daemon needed in containers).
 if ! nix --version &>/dev/null; then
   rm -rf "$HOME/.local/state/nix" "$HOME/.nix-profile" \
@@ -377,12 +426,12 @@ mkdir -p ~/.config/nix
 grep -q experimental-features ~/.config/nix/nix.conf 2>/dev/null \
   || echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
 
-# Source nix in every login shell -- interactive terminals and the
-# default command all source ~/.profile. Writing this to ~/.bashrc
-# instead would hide it from those non-interactive login shells (its
-# interactivity guard returns early). (The health check is NOT a
-# ~/.profile consumer -- it runs as a non-login bash -c; see
-# health-check.md.) See the-shell.md#startup-files.
+# Source nix in every login shell of the agent -- the default command
+# (running in the service session) sources the agent's ~/.profile.
+# Writing this to ~/.bashrc instead would hide it from non-interactive
+# login shells (its interactivity guard returns early). (The health
+# check is NOT a ~/.profile consumer -- it runs as a non-login bash -c;
+# see health-check.md.) See the-shell.md#startup-files.
 # shellcheck disable=SC2016
 grep -q nix-profile ~/.profile 2>/dev/null \
   || echo '. "$HOME/.nix-profile/etc/profile.d/nix.sh"' >> ~/.profile

--- a/docs/sandboxes/hermes.md
+++ b/docs/sandboxes/hermes.md
@@ -23,9 +23,11 @@ klangkc sandbox hermes
 
 First run fetches and runs the upstream Hermes installer, writes a config
 pointing at the Klangk LLM proxy, and installs the gateway wrapper. The
-gateway starts automatically in the first terminal window.
+gateway starts automatically in the Service terminal tab (it runs as the
+workspace's agent identity in a dedicated `service` tmux session, not in
+your own shell).
 
-To configure messaging platforms after setup:
+To configure messaging platforms after setup, run this in the Service tab:
 
 ```bash
 hermes setup

--- a/docs/sandboxes/openclaw.md
+++ b/docs/sandboxes/openclaw.md
@@ -25,9 +25,11 @@ First run installs Node.js 24 (via nvm), openclaw, writes a config
 pointing at the Klangk LLM proxy, and runs a non-interactive onboard.
 The setup script prints the hosted app URL at the end.
 
-The gateway starts automatically in the first terminal window. To
-add messaging channels (i.e. to configure the authentication the WARNING above
-refers to):
+The gateway starts automatically in the Service terminal tab (it runs as
+the workspace's agent identity in a dedicated `service` tmux session, not
+in your own shell). To add messaging channels (i.e. to configure the
+authentication the WARNING above refers to), run this in the Service
+tab:
 
 ```bash
 openclaw onboard

--- a/sandboxes/hermes/.gitignore
+++ b/sandboxes/hermes/.gitignore
@@ -9,3 +9,7 @@ gateway.pid
 gateway.lock
 gateway_state.json
 logs/
+# Installer markers: --no-skills opt-out flag and the default SOUL.md
+# persona. Written by the upstream installer under $HERMES_HOME.
+.no-bundled-skills
+SOUL.md

--- a/sandboxes/hermes/setup.sh
+++ b/sandboxes/hermes/setup.sh
@@ -14,18 +14,32 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INSTALL_DIR="/hermes"
 
+# Repoint HOME at the agent's home for the rest of this script so every
+# home-relative path -- the ~/.profile exports below, the ~/.local/bin
+# hermes binary link, and the ~/.pi config (klangk-setup-pi at the end) --
+# resolves into the AGENT's home, the identity that runs the default
+# command (#1133/#1158: the gateway runs in the agent's standalone
+# `service` tmux session). The owner manages hermes through the Service
+# terminal tab, not their own shell, so nothing hermes-related belongs in
+# the owner's home (#1171). $KLANGK_AGENT_HOME is injected into the
+# container env at bring-up and inherited by every podman exec (including
+# the WS exec that runs this script); the `:-` fallback defends against an
+# unset var. With HOME repointed, the existing ~/.profile appends below
+# land in the agent's ~/.profile unchanged.
+export HOME="${KLANGK_AGENT_HOME:-/home/clanker}"
+
 # Hermes release branch -- single source of truth for the installed version.
 # The human version (e.g. 0.17.x) tracks this but isn't asserted here.
 HERMES_VERSION=v2026.6.19
 
 # --- Persist env exports to ~/.profile UP FRONT, before the slow install. ---
-# Why ~/.profile: it's the POSIX file sourced by login shells -- the
-# default-command pane (an interactive login shell) and `klangkc exec`
-# (bash -lc). Those need HERMES_HOME + the hermes bin on PATH to launch
-# / inspect the gateway. ~/.bashrc has an interactivity guard that hides
-# its body from non-interactive shells, so these exports cannot live
-# there. Written before the install so a shell spawned mid-setup already
-# sees a complete PATH/HERMES_HOME.
+# Why ~/.profile: it's the POSIX file sourced by login shells -- here,
+# the agent's `service` tmux session that runs the default command (HOME
+# was repointed above to the agent's home). That session needs
+# HERMES_HOME + the hermes bin on PATH to launch the gateway. ~/.bashrc
+# has an interactivity guard that hides its body from non-interactive
+# shells, so these exports cannot live there. Written before the install
+# so a shell spawned mid-setup already sees a complete PATH/HERMES_HOME.
 #
 # NOTE: the workspace health check is NOT a reason to put these in
 # ~/.profile. The check runs as a NON-login shell (`bash -c`) and

--- a/sandboxes/openclaw/setup.sh
+++ b/sandboxes/openclaw/setup.sh
@@ -4,29 +4,43 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 INSTALL_DIR="/openclaw"
 
+# Repoint HOME at the agent's home for the rest of this script so every
+# home-relative path -- the ~/.profile exports below, the nvm/node install
+# under NVM_DIR (which is $INSTALL_DIR/.nvm, unaffected), and any tool link
+# -- resolves into the AGENT's home, the identity that runs the default
+# command (#1133/#1158: the gateway runs in the agent's standalone
+# `service` tmux session). The owner manages openclaw through the Service
+# terminal tab, not their own shell, so nothing openclaw-related belongs in
+# the owner's home (#1171). $KLANGK_AGENT_HOME is injected into the
+# container env at bring-up and inherited by every podman exec (including
+# the WS exec that runs this script); the `:-` fallback defends against an
+# unset var. With HOME repointed, the existing ~/.profile appends below
+# land in the agent's ~/.profile unchanged.
+export HOME="${KLANGK_AGENT_HOME:-/home/clanker}"
+
 # Persist every env export the default_command depends on to ~/.profile
 # UP FRONT, before any long-running install step.
 #
-# Why ~/.profile: it's the POSIX file sourced by login shells --
-# interactive terminals (the default-cmd tmux pane is an interactive
-# login shell) and `klangkc exec` (bash -lc). ~/.bashrc has an
+# Why ~/.profile: it's the POSIX file sourced by login shells -- here,
+# the agent's `service` tmux session that runs the default command (HOME
+# was repointed above to the agent's home). ~/.bashrc has an
 # interactivity guard near its top (`case $- in *i*) ;; *) return`)
 # that hides anything appended below it from non-interactive shells, so
-# exports those commands need cannot live there.
+# exports the default command needs cannot live there.
 #
 # NOTE: the workspace health check is NOT a reason to put these in
 # ~/.profile. The check runs as a NON-login shell (`bash -c`) and
 # sources nothing -- it uses the absolute-path /openclaw/bin/healthcheck.sh
 # wrapper instead. Don't add exports here "for the health check".
 #
-# Why UP FRONT (#1039): a shell that sources ~/.profile while setup is
-# still running (e.g. the default-cmd pane created by an early
+# Why UP FRONT (#1039): a shell that sources the agent's ~/.profile while
+# setup is still running (e.g. the service session created by an early
 # terminal_start during setup -- see #1033) must see the complete
 # pointer set from its very first spawn:
 #   - NVM_DIR + nvm.sh source (so nvm/node load in new shells)
 #   - /openclaw/bin on PATH (so the `openclaw` binary is found)
-#   - OPENCLAW_HOME (so openclaw locates its config; the owning user's
-#     $HOME is /home/<handle>, not /openclaw, so without this openclaw
+#   - OPENCLAW_HOME (so openclaw locates its config; the agent's
+#     $HOME is /home/clanker, not /openclaw, so without this openclaw
 #     looks in the wrong place and reports "Missing config" -- #1039)
 # These used to be appended at three separate points in setup, so a
 # mid-setup pane inherited PATH but not OPENCLAW_HOME. Each line is

--- a/sandboxes/tests/hermes/test_hermes_setup_e2e.py
+++ b/sandboxes/tests/hermes/test_hermes_setup_e2e.py
@@ -61,6 +61,10 @@ PORT = "18999"
 INSTANCE = "hermes-setup-e2e"
 EMAIL = "test@example.com"
 PASSWORD = "testpass"
+# The agent's user id (klangk_backend.model.AGENT_USER_ID). setup.sh
+# repoints HOME at the agent's home (#1171) so the ~/.profile exports
+# land in the agent's home, not the owner's; the test reads that profile.
+AGENT_USER_ID = "00000000-0000-0000-0000-000000000001"
 # Real install (clone NousResearch/hermes-agent + uv sync .[all] + managed
 # Node) can take several minutes, especially on CI. The installer's own
 # estimate is 1-5 min for deps; the clone + Node add to that.
@@ -240,16 +244,22 @@ def _health_status(base_url, token, ws_id):
     return body.get("health"), body.get("health_checked_at")
 
 
-def _owning_profile(data_dir, user_id, ws_id):
-    """Path to the owning user's ~/.profile on the host for *ws_id*."""
+def _agent_profile(data_dir, owner_user_id, ws_id):
+    """Path to the AGENT's ~/.profile on the host for *ws_id*.
+
+    setup.sh repoints HOME at the agent's home (#1171), so the
+    HERMES_HOME / PATH exports it writes land in the agent's home
+    (``.users/<AGENT_USER_ID>``), not the owner's. The per-workspace
+    home tree is ``<data>/workspaces/<owner_uid>/home/<ws_id>/.users/``.
+    """
     return os.path.join(
         data_dir,
         "workspaces",
-        user_id,
+        owner_user_id,
         "home",
         ws_id,
         ".users",
-        user_id,
+        AGENT_USER_ID,
         ".profile",
     )
 
@@ -390,17 +400,20 @@ class TestHermesSetup:
             assert os.path.exists(os.path.join(SANDBOX_DIR, "config.yaml")), (
                 "setup.sh did not write /hermes/config.yaml (llm-proxy config)"
             )
-            # setup.sh wrote ~/.profile exports up front.
-            profile_path = _owning_profile(self._data_dir, self._user_id, ws_id)
+            # setup.sh wrote ~/.profile exports up front (into the AGENT's
+            # home: it repoints HOME at $KLANGK_AGENT_HOME, #1171).
+            profile_path = _agent_profile(self._data_dir, self._user_id, ws_id)
             assert os.path.exists(profile_path), (
-                f"~/.profile not found at {profile_path}"
+                f"agent ~/.profile not found at {profile_path}"
             )
             with open(profile_path) as f:
                 profile = f.read()
             assert 'export HERMES_HOME="/hermes"' in profile, (
-                "HERMES_HOME missing from ~/.profile -- the gateway wrapper "
-                "and health check need it to locate hermes config/PID "
-                "files.\n~/.profile:\n" + profile
+                "HERMES_HOME missing from the agent's ~/.profile -- the "
+                "gateway runs in the agent's service session which sources "
+                "this file, so without it the autostarted gateway cannot "
+                "locate hermes config/PID files (#1171).\n"
+                "~/.profile:\n" + profile
             )
 
             # The gateway (started by default-command) is up and the health

--- a/sandboxes/tests/openclaw/test_openclaw_setup_e2e.py
+++ b/sandboxes/tests/openclaw/test_openclaw_setup_e2e.py
@@ -2,55 +2,50 @@
 
 Covers three invariants:
 
-- #1039 (ordering) + #1087 (location): ``setup.sh`` writes every env
-  export the default_command depends on to ``~/.profile`` up front,
+- #1039 (ordering): ``setup.sh`` writes every env export the
+  default_command depends on into the AGENT's ``~/.profile`` up front,
   before the slow ``npm install``.
+- #1039 (shared mount): a second workspace reusing the populated
+  ``/openclaw`` mount SKIPS the install yet still writes a complete
+  agent ``~/.profile``.
 - #1089: the ``health-check: /openclaw/bin/healthcheck.sh`` config
   reaches the workspace, the health monitor runs it as a non-login
   bash shell (``bash -c``) so it sources nothing, and the status
   endpoint reports ``healthy`` once the gateway (launched by
   ``default-command``) is up.
 
-``sandboxes/openclaw/setup.sh`` persists every env export the
-default_command depends on (``NVM_DIR`` + nvm source, ``/openclaw/bin``
-on ``PATH``, ``OPENCLAW_HOME``) to ``~/.profile`` in one block at the
-very top of setup, before the long ``npm install -g openclaw``. It also
-writes ``/openclaw/bin/healthcheck.sh`` (and symlinks
-``/openclaw/bin/openclaw`` at the nvm-installed binary) so the health
-check can invoke openclaw by absolute path -- the non-login ``bash -c``
-probe does not source ``~/.profile``, so it cannot rely on nvm PATH.
+Under the agent-owns-the-service model (#1133/#1158) the default command
+runs in the agent's standalone ``service`` tmux session, whose login shell
+sources the AGENT's ``~/.profile``. So ``setup.sh`` repoints ``HOME`` at
+``$KLANGK_AGENT_HOME`` and writes its exports there (``NVM_DIR`` + nvm
+source, ``/openclaw/bin`` on ``PATH``, ``OPENCLAW_HOME``); the owner
+manages openclaw through the Service terminal tab, not their own shell, so
+nothing openclaw-related lives in the owner's home (#1171). The health
+check is unaffected: it runs as a non-login ``bash -c`` and uses an
+absolute-path wrapper that bakes in ``OPENCLAW_HOME``.
 
 Why ``~/.profile`` and not ``~/.bashrc`` (#1087): ``~/.profile`` is the
-POSIX file sourced by login shells -- interactive terminals (the
-default-cmd tmux pane is an interactive login shell) and
-``klangkc exec`` (``bash -lc``). ``~/.bashrc`` has an interactivity guard
-that hides its body from non-interactive shells, so exports the health
-check needs cannot live there. ``~/.profile`` is the one file BOTH the
-default_command and the health check reliably source.
+POSIX file sourced by login shells. ``~/.bashrc`` has an interactivity
+guard that hides its body from non-interactive shells.
 
-Previously ``OPENCLAW_HOME`` was appended near the end of setup (and to
-``~/.bashrc``), so a shell spawned mid-setup (e.g. the ``default-cmd``
-pane from an early ``terminal_start`` -- the #1033 race) inherited
-``PATH`` but not ``OPENCLAW_HOME``; with ``OPENCLAW_HOME`` unset,
-``openclaw gateway`` looked for config at ``$HOME/.openclaw`` instead of
-``/openclaw/.openclaw`` and reported "Missing config".
+Previously the exports went to the OWNER's ``~/.profile`` (pre-#1158 the
+default command ran in the owner's session); that left the autostarted
+gateway env-less under the new model -- the service session sourced the
+agent's empty ``~/.profile`` and ``openclaw gateway`` reported "Missing
+config" (#1171).
 
-How the test exercises this deterministically: ``setup.sh`` blocks while
-a sentinel file (``/openclaw/.klangk-test-pause``, i.e. on the bind
+How the test exercises ordering deterministically: ``setup.sh`` blocks
+while a sentinel file (``/openclaw/.klangk-test-pause``, i.e. on the bind
 mount) exists. The sentinel is placed right after the consolidated export
-block and before the slow install, so while setup is parked there the
-test reads ``~/.profile`` straight off the host filesystem and asserts
-the export is already present. On a regression that moves the
-``OPENCLAW_HOME`` append back to the end of setup, ``~/.profile`` lacks it
-at this point and the test fails. Releasing the sentinel lets the real
-``npm install -g openclaw`` run, and the test confirms the binary lands
-on the mount.
+block and before the slow install, so while setup is parked there the test
+reads the agent's ``~/.profile`` straight off the host filesystem and
+asserts the export is already present. Releasing the sentinel lets the
+real ``npm install -g openclaw`` run, and the test confirms the binary
+lands on the mount.
 
 This reads files directly from the host (the per-user home and the
 ``/openclaw`` mount both live under the server data dir / the sandbox
-dir). It deliberately avoids ``klangkc exec``: exec runs a raw command
-with no login shell (#1041), so it would not source ``~/.profile`` and
-would give a false negative.
+dir).
 
 Run locally (the workspace image must be built first):
 
@@ -62,11 +57,8 @@ sandbox, so it never slows the regular CLI/backend e2e suites. Requires
 network (real ``npm install``).
 """
 
-import asyncio
 import glob
-import json
 import os
-import re
 import shutil
 import subprocess
 import tempfile
@@ -74,7 +66,6 @@ import time
 
 import httpx
 import pytest
-import websockets
 
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 SANDBOX_DIR = os.path.join(REPO_ROOT, "sandboxes", "openclaw")
@@ -85,34 +76,27 @@ SENTINEL = os.path.join(SANDBOX_DIR, ".klangk-test-pause")
 WS = "e2e-openclaw-setup"
 # Second workspace pointed at the SAME /openclaw mount. openclaw is
 # already installed there after WS's setup ran, so WS2's setup SKIPS the
-# install but must still write a complete per-workspace ~/.profile. This
-# is the shared-mount + per-workspace-~/.profile interaction at the heart
-# of #1039 -- a regression that moves an export inside the install-skip
+# install but must still write a complete agent ~/.profile. This is the
+# shared-mount + per-workspace-~/.profile interaction at the heart of
+# #1039 -- a regression that moves an export inside the install-skip
 # guard breaks WS2 permanently (not just a race) while WS may still pass.
 WS2 = "e2e-openclaw-setup-2"
-# Third workspace at the same mount, used by the #1033 visitor test.
-# Like WS2 its setup skips the install (mount already populated) and
-# pauses at the sentinel, so the test can drive a VISITOR terminal_start
-# while setup is genuinely mid-flight -- the exact #1033 race.
+# Third workspace at the same mount, used by the #1089 health-check test.
+# Like WS2 its setup skips the install (mount already populated) so it
+# comes up fast; the point is to exercise the end-to-end health-check
+# path (config -> monitor -> status endpoint) against a real gateway, not
+# to re-run the install.
 WS3 = "e2e-openclaw-setup-3"
-# Fourth workspace at the same mount, used by the #1089 health-check
-# test. Like WS2/WS3 its setup skips the install (mount already
-# populated) so it comes up fast; the point is to exercise the
-# end-to-end health-check path (config -> monitor -> status endpoint)
-# against a real gateway, not to re-run the install.
-WS4 = "e2e-openclaw-setup-4"
-# Fifth workspace at the same mount, used by the #1041 klangkc-exec
-# test. setup skips the install (mount populated) so it's fast; the
-# point is to prove `klangkc exec` runs as a login shell so a
-# PATH-only binary (nvm-installed `openclaw`) resolves -- the exact
-# repro in the issue.
-WS5 = "e2e-openclaw-setup-5"
 # Own port + instance id so it never collides with other e2e suites
 # (cli-e2e 18995, autostart 18996/18997).
 PORT = "18998"
 INSTANCE = "openclaw-setup-e2e"
 EMAIL = "test@example.com"
 PASSWORD = "testpass"
+# The agent's user id (klangk_backend.model.AGENT_USER_ID). setup.sh
+# repoints HOME at the agent's home (#1171) so the ~/.profile exports
+# land in the agent's home, not the owner's; the tests read that profile.
+AGENT_USER_ID = "00000000-0000-0000-0000-000000000001"
 # Real npm install of openclaw (nvm + node + global package) can take a
 # while, especially on CI.
 SETUP_TIMEOUT = 900
@@ -302,132 +286,24 @@ def _health_status(base_url, token, ws_id):
     return body.get("health"), body.get("health_checked_at")
 
 
-def _owning_profile(data_dir, user_id, ws_id):
-    """Path to the owning user's ~/.profile on the host for *ws_id*.
+def _agent_profile(data_dir, owner_user_id, ws_id):
+    """Path to the AGENT's ~/.profile on the host for *ws_id*.
 
-    The per-workspace home is bind-mounted at /home; the owning user's
-    real home is ``<data>/workspaces/<uid>/home/<ws_id>/.users/<uid>/``
+    setup.sh repoints HOME at the agent's home (#1171), so the
+    OPENCLAW_HOME / PATH / NVM_DIR exports it writes land in the agent's
+    home (``.users/<AGENT_USER_ID>``), not the owner's. The per-workspace
+    home tree is ``<data>/workspaces/<owner_uid>/home/<ws_id>/.users/``
     (home_path is keyed by workspace id, so this resolves directly).
     """
     return os.path.join(
         data_dir,
         "workspaces",
-        user_id,
+        owner_user_id,
         "home",
         ws_id,
         ".users",
-        user_id,
+        AGENT_USER_ID,
         ".profile",
-    )
-
-
-async def _visitor_two_phase_terminal_env(
-    base_url, token, ws_id, var, between_phases, timeout=25.0
-):
-    """Two-phase visitor probe for the #1033/#1051/#1039 invariants.
-
-    Phase 1 -- mid-setup: fire ``terminal_start`` while setup is parked
-    at the sentinel.  Only the ``bash`` window (window 0) is created;
-    ``default-cmd`` is gated on ``setup_state == complete`` (#1051).
-    The spawned shell sources ``~/.profile`` at that instant; under the
-    #1039 fix the exports are already present, so ``$var`` is set.
-
-    Then ``await between_phases()`` runs -- the caller releases the
-    sentinel and waits for setup to finish (the setup connection's own
-    post-setup ``terminal_start`` creates the ``default-cmd`` window).
-
-    Phase 2 -- post-setup: fire ``terminal_start`` again.  The
-    ``default-cmd`` window now exists; the visitor observes it via the
-    window sync.  (The visitor does not itself receive
-    ``default_command_started`` here -- the setup connection won the
-    race to create the window.  That event is covered by unit tests.)
-
-    Returns ``(mid_windows, post_windows, value)``.
-    """
-    ws_url = base_url.replace("http://", "ws://") + "/ws"
-    async with websockets.connect(f"{ws_url}?token={token}", max_size=2**24) as ws:
-        await ws.send(json.dumps({"cmd": "workspace_connect", "workspaceId": ws_id}))
-        # Drain until container_ready.
-        deadline = asyncio.get_event_loop().time() + timeout
-        while True:
-            remaining = deadline - asyncio.get_event_loop().time()
-            if remaining <= 0:
-                raise asyncio.TimeoutError("visitor: no container_ready")
-            msg = json.loads(await asyncio.wait_for(ws.recv(), remaining))
-            if msg.get("type") == "container_ready":
-                break
-            if msg.get("type") == "error":
-                raise ConnectionError(f"visitor connect failed: {msg}")
-
-        # ---- Phase 1: terminal_start mid-setup ----
-        mid_windows = await _visitor_fire_terminal_start(ws, timeout)
-        value = await _visitor_probe_env(ws, var, timeout)
-
-        # Let setup finish (caller releases sentinel + waits).
-        await between_phases()
-
-        # ---- Phase 2: terminal_start post-setup ----
-        post_windows = await _visitor_fire_terminal_start(ws, timeout)
-
-        return mid_windows, post_windows, value
-
-
-async def _visitor_fire_terminal_start(ws, timeout):
-    """Send terminal_start, drain to terminal_windows, return windows."""
-    await ws.send(
-        json.dumps(
-            {
-                "cmd": "terminal_start",
-                "cols": 80,
-                "rows": 24,
-                "browser_id": "e2e-visitor",
-            }
-        )
-    )
-    deadline = asyncio.get_event_loop().time() + timeout
-    windows = []
-    while True:
-        remaining = deadline - asyncio.get_event_loop().time()
-        if remaining <= 0:
-            raise asyncio.TimeoutError("visitor: no terminal_started")
-        msg = json.loads(await asyncio.wait_for(ws.recv(), remaining))
-        if msg.get("type") == "terminal_started":
-            continue
-        if msg.get("type") == "terminal_windows":
-            windows = msg.get("windows", [])
-            break
-        if msg.get("type") == "error":
-            raise ConnectionError(f"visitor terminal_start: {msg}")
-    return windows
-
-
-async def _visitor_probe_env(ws, var, timeout):
-    """Probe window 0's live ``$var`` via a marker, retrying until ready."""
-    left, right = "MKOPEN", "MKCLOSE"
-    cmd = f"printf '{left}%s{right}\\n' \"${var}\"\r"
-    pattern = re.compile(re.escape(left) + r"(.*?)" + re.escape(right))
-    deadline = asyncio.get_event_loop().time() + timeout
-    buf = ""
-    sent = False
-    while asyncio.get_event_loop().time() < deadline:
-        if not sent:
-            await ws.send(json.dumps({"cmd": "terminal_input", "data": cmd}))
-            sent = True
-        try:
-            raw = await asyncio.wait_for(ws.recv(), timeout=2.0)
-        except asyncio.TimeoutError:
-            sent = False
-            continue
-        msg = json.loads(raw)
-        if msg.get("type") == "terminal_output":
-            buf += msg.get("data", "")
-            for m in pattern.finditer(buf):
-                val = m.group(1)
-                if val != "%s":
-                    return val
-    raise AssertionError(
-        f"visitor probe for ${var} never returned a marker within "
-        f"{timeout}s. Output:\n{buf!r}"
     )
 
 
@@ -608,10 +484,10 @@ class TestOpenclawSetupProfileExports:
                 "regressed.\n" + out
             )
 
-            # WS2's container is up; read ITS own per-workspace ~/.profile
+            # WS2's container is up; read ITS agent ~/.profile
             # (a different ws_id from WS).
             ws2_id = self._await_container(name=WS2)
-            profile_path = _owning_profile(self._data_dir, self._user_id, ws2_id)
+            profile_path = _agent_profile(self._data_dir, self._user_id, ws2_id)
             with open(profile_path) as f:
                 profile = f.read()
 
@@ -625,105 +501,6 @@ class TestOpenclawSetupProfileExports:
             )
             assert 'export PATH="/openclaw/bin:$PATH"' in profile
         finally:
-            if sandbox_proc.poll() is None:
-                sandbox_proc.kill()
-
-    def test_visitor_terminal_start_mid_setup_has_openclaw_home(self):
-        """A VISITOR terminal_start fired while setup is still running
-        spawns a shell whose live environment has OPENCLAW_HOME set.
-
-        Two-phase assertion reflecting #1051's gating of the default
-        command on ``setup_state == complete``:
-
-        Phase 1 (mid-setup): the visitor's ``terminal_start`` creates
-        the ``bash`` window (window 0) but NOT ``default-cmd`` -- #1051
-        gates it.  The spawned shell sources ``~/.profile`` at that
-        instant; under the #1039 fix the exports are already there
-        (written before the slow install), so ``OPENCLAW_HOME`` is set.
-        This is the "Missing config" window that #1039 closes.
-
-        Phase 2 (post-setup): after setup completes, the ``default-cmd``
-        window appears (created by the setup connection's own
-        post-setup ``terminal_start``).  The visitor observes it via a
-        window sync on its second ``terminal_start``.
-        """
-        # WS3 reuses the populated mount, so its setup SKIPS the install
-        # (fast) and pauses at the sentinel -- setup is genuinely
-        # mid-flight when the visitor connects.
-        if os.path.exists(SENTINEL):
-            os.remove(SENTINEL)
-        with open(SENTINEL, "w") as f:
-            f.write("1\n")
-
-        sandbox_proc = subprocess.Popen(
-            ["klangkc", "sandbox", WS3, SANDBOX_DIR],
-            env=self._env,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-        )
-        try:
-            ws3_id = self._await_container(name=WS3)
-            # setup.sh is now parked at the sentinel, AFTER writing the
-            # consolidated ~/.profile exports.
-            self._await_setup_exports(ws3_id)
-
-            async def _release_and_wait_setup():
-                """Release sentinel, wait for sandbox proc to finish."""
-
-                def _wait():
-                    os.remove(SENTINEL)
-                    deadline = time.monotonic() + SETUP_TIMEOUT
-                    while time.monotonic() < deadline:
-                        if sandbox_proc.poll() is not None:
-                            return sandbox_proc.returncode
-                        time.sleep(0.5)
-                    return None
-
-                rc = await asyncio.to_thread(_wait)
-                assert rc == 0, "klangkc sandbox (WS3) failed:\n" + (
-                    sandbox_proc.stdout.read() or ""
-                )
-
-            mid_windows, post_windows, value = asyncio.run(
-                _visitor_two_phase_terminal_env(
-                    self._base_url,
-                    self._token,
-                    ws3_id,
-                    "OPENCLAW_HOME",
-                    _release_and_wait_setup,
-                )
-            )
-
-            # Phase 1 -- mid-setup: default-cmd is gated (#1051).
-            mid_names = [w.get("name") for w in mid_windows]
-            assert "default-cmd" not in mid_names, (
-                "visitor terminal_start mid-setup created the "
-                "default-cmd window, but #1051 should gate it on "
-                "setup_state == complete. Windows seen: " + repr(mid_names)
-            )
-
-            # The shell spawned mid-setup sourced a ~/.profile that
-            # already has OPENCLAW_HOME (the #1039 fix).
-            assert value == "/openclaw", (
-                "a shell spawned by a visitor terminal_start mid-setup "
-                "did NOT have OPENCLAW_HOME set -- the #1033 race bit: "
-                "the mid-setup ~/.profile lacked the export, so the spawned "
-                f"shell's $OPENCLAW_HOME was {value!r} (expected "
-                "'/openclaw'). This is the 'Missing config' window."
-            )
-
-            # Phase 2 -- post-setup: default-cmd now exists (created by
-            # the setup connection's own post-setup terminal_start).
-            post_names = [w.get("name") for w in post_windows]
-            assert "default-cmd" in post_names, (
-                "default-cmd window absent post-setup; the #1051 gate "
-                "should open once setup_state == complete. Windows seen: "
-                + repr(post_names)
-            )
-        finally:
-            if os.path.exists(SENTINEL):
-                os.remove(SENTINEL)
             if sandbox_proc.poll() is None:
                 sandbox_proc.kill()
 
@@ -766,10 +543,10 @@ class TestOpenclawSetupProfileExports:
             "full install"
         )
 
-        # WS4 reuses the populated mount, so its setup SKIPS the install
+        # WS3 reuses the populated mount, so its setup SKIPS the install
         # (fast) -- the point here is the health-check path, not install.
         sandbox_proc = subprocess.Popen(
-            ["klangkc", "sandbox", WS4, SANDBOX_DIR],
+            ["klangkc", "sandbox", WS3, SANDBOX_DIR],
             env=self._env,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
@@ -778,96 +555,21 @@ class TestOpenclawSetupProfileExports:
         try:
             rc = sandbox_proc.wait(timeout=SETUP_TIMEOUT)
             out = sandbox_proc.stdout.read() or ""
-            assert rc == 0, f"klangkc sandbox (WS4) failed:\n{out}"
+            assert rc == 0, f"klangkc sandbox (WS3) failed:\n{out}"
             # The install was genuinely skipped, proving the fast path.
             assert "openclaw already installed, skipping." in out, (
                 "expected setup to SKIP the install (mount already "
                 "populated); it didn't.\n" + out
             )
 
-            ws4_id = self._await_container(name=WS4)
+            ws3_id = self._await_container(name=WS3)
 
             # Wait for the gateway to come up AND the monitor (polling
             # every KLANGK_HEALTH_CHECK_INTERVAL=3s in this fixture) to
             # report healthy. Generous timeout: the gateway binds a few
             # seconds after setup, then the first poll lands within one
             # interval.
-            self._await_health(ws4_id, expected="healthy", timeout=180)
-        finally:
-            if sandbox_proc.poll() is None:
-                sandbox_proc.kill()
-
-    def test_klangkc_exec_resolves_path_only_binary(self):
-        """`klangkc exec` runs as a bash login shell so a PATH-only
-        binary (the nvm-installed `openclaw`) resolves -- the exact #1041
-        repro.
-
-        Before #1041, exec passed raw argv to `podman exec` with no
-        shell, so `~/.profile` was never sourced and `openclaw` (only on
-        PATH via `~/.profile`'s nvm source + `/openclaw/bin`) was not
-        found: `klangkc exec ws openclaw --version` failed with
-        'command not found'. Now exec wraps the command in
-        `bash -lc shlex.join(argv)`, sourcing `~/.profile` exactly like
-        an interactive terminal, so the binary resolves.
-
-        Uses `--raw` as a control: the same command under `--raw` (no
-        shell) must still fail to resolve, proving the login shell is
-        what fixes it and that `--raw` preserves the old raw behavior.
-        """
-        # Precondition: openclaw on the shared mount (full-install test
-        # ran first).
-        assert glob.glob(
-            os.path.join(
-                SANDBOX_DIR, ".nvm", "versions", "node", "v*", "bin", "openclaw"
-            )
-        ), "openclaw not on the shared mount -- run the full-install test first"
-
-        # WS5 reuses the populated mount (setup skips the install --
-        # fast), so we can exercise the exec path without a full setup.
-        sandbox_proc = subprocess.Popen(
-            ["klangkc", "sandbox", WS5, SANDBOX_DIR],
-            env=self._env,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-        )
-        try:
-            rc = sandbox_proc.wait(timeout=SETUP_TIMEOUT)
-            out = sandbox_proc.stdout.read() or ""
-            assert rc == 0, f"klangkc sandbox (WS5) failed:\n{out}"
-            assert "openclaw already installed, skipping." in out
-            self._await_container(name=WS5)
-
-            # The fix: default `klangkc exec` sources ~/.profile (login
-            # shell), so the nvm-installed openclaw resolves.
-            res = _run(
-                ["klangkc", "exec", WS5, "openclaw", "--version"],
-                env=self._env,
-                timeout=120,
-            )
-            assert res.returncode == 0, (
-                "klangkc exec openclaw --version failed under the login "
-                f"shell (should resolve via ~/.profile):\n{res.stderr}"
-            )
-            assert res.stdout.strip(), (
-                "openclaw --version produced no output:\n" + res.stdout
-            )
-
-            # The control: `--raw` skips the login shell, so openclaw is
-            # NOT on PATH (it lives behind the nvm source in ~/.profile)
-            # and the command must fail. This proves the login wrap is
-            # what fixes resolution and that --raw preserves raw argv.
-            res_raw = _run(
-                ["klangkc", "exec", "--raw", WS5, "openclaw", "--version"],
-                env=self._env,
-                timeout=120,
-            )
-            assert res_raw.returncode != 0, (
-                "klangkc exec --raw openclaw --version unexpectedly "
-                "succeeded -- under --raw no shell runs, so ~/.profile "
-                "is not sourced and openclaw should not be on PATH. "
-                f"Output:\n{res_raw.stdout}"
-            )
+            self._await_health(ws3_id, expected="healthy", timeout=180)
         finally:
             if sandbox_proc.poll() is None:
                 sandbox_proc.kill()
@@ -918,21 +620,22 @@ class TestOpenclawSetupProfileExports:
         )
 
     def _await_setup_exports(self, ws_id, timeout=120):
-        """Poll ~/.profile until setup has appended its first export.
+        """Poll the agent's ~/.profile until setup has appended its first export.
 
         setup.sh writes the consolidated export block then blocks on the
         sentinel, so once ``export NVM_DIR`` appears setup is parked.
-        Returns the path to the owning user's .profile.
+        Returns the path to the agent's .profile.
         """
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
-            path = _owning_profile(self._data_dir, self._user_id, ws_id)
+            path = _agent_profile(self._data_dir, self._user_id, ws_id)
             if path and os.path.exists(path):
                 with open(path) as f:
                     if "export NVM_DIR" in f.read():
                         return path
             time.sleep(1)
         raise AssertionError(
-            "setup never wrote ~/.profile exports (sentinel not reached); "
+            "setup never wrote the agent's ~/.profile exports "
+            "(sentinel not reached); "
             f"user_id={self._user_id} data_dir={self._data_dir}"
         )


### PR DESCRIPTION
Closes #1171.

## Problem

Under #1158 the default command runs as the **agent** in a standalone `service` tmux session whose `$HOME` is the agent's (e.g. `/home/clanker`), not the owner's. But `openclaw`/`hermes` `setup.sh` wrote their env exports (`NVM_DIR`, PATH, `OPENCLAW_HOME`/`HERMES_HOME`) to the **owner's** `~/.profile`. The service session sourced the agent's empty `~/.profile`, so the autostarted gateway launched without its env and failed (\"Missing config\").

## Model

Sandbox-installed tools belong to the **agent** (surfaced via the Service tab, #1159), not on the owner's PATH. The owner manages these services — `openclaw onboard`, restart, etc. — through the Service terminal tab, in the agent's session. So nothing sandbox-related belongs in the owner's home.

## Fix

Repoint `HOME` at `$KLANGK_AGENT_HOME` at the top of both `setup.sh`:

```bash
export HOME=\"\${KLANGK_AGENT_HOME:-/home/clanker}\"
```

After that every home-relative write — `~/.profile` exports, `~/.local/bin` links, `~/.pi` config — lands in the agent's home, which is exactly what the default command sources. `\$KLANGK_AGENT_HOME` is injected into the container env at bring-up (`container.py`) and inherited by every `podman exec`, including the WS exec that runs setup. The existing `~/.profile` append logic is otherwise unchanged.

## Why this shape

I considered three alternatives and rejected them:

- **Shared `/home/.profile.d/` sourced by an `/etc/profile.d` snippet** — pollutes every login shell (owner, agent, *and any visitor/collaborator*). Exports are needed by exactly one home (the agent's), so global is wrong scope. (The `~/.profile.d/` pattern itself is a good idea, deferred to #1172, where it's per-user.)
- **Direct append to `\$KLANGK_AGENT_HOME/.profile`** — works, but piecemeal: it handles `~/.profile` while leaving `~/.local/bin`, `~/.pi`, etc. still pointing at the owner's home. The HOME repoint handles all of them wholesale, and is more honest to the \"agent owns these tools\" model.
- **Image-level `/etc/skel/.profile.d/`** — requires an image rebuild; the fix shouldn't depend on one.

## Test changes

Sandbox-installed tools are now the agent's, so two openclaw e2e tests that encoded the removed **owner-shell** capability were dropped:

- `test_klangkc_exec_resolves_path_only_binary` — asserted the *owner* could `klangkc exec openclaw --version` (PATH-resolves a sandbox tool via the owner's profile). By design this no longer resolves; the supported flow is the Service tab.
- `test_visitor_terminal_start_mid_setup_has_openclaw_home` — probed a *visitor's* live shell env mid-setup. Post-#1158/#1051 the service session is gated on `setup_state==complete`, so the #1033 race it targeted is structurally closed; the visitor-shell premise no longer maps to anything.

Kept and re-pointed to the **agent's** `~/.profile`: the #1039 ordering test, the shared-mount skip-path test, and the #1089 health-check test (the real regression validation — the gateway now starts in the agent's service session). All three pass locally.

## Validation

- openclaw e2e: **3/3 pass** (ordering, skip-path, health-check → gateway healthy under agent service session).
- hermes e2e: the single test still times out at the install step in this environment (the upstream hermes installer/clone is slow here), unrelated to this change — the profile-write assertion itself is re-pointed and correct.
- pre-commit: all hooks pass (ruff, shellcheck, markdownlint, prettier, shfmt, trufflehog).

## Docs

- `docs/features/sandbox.md` — new \"Where the default command runs\" subsection explaining the agent context + the `HOME=\$KLANGK_AGENT_HOME` tip; the canonical `setup.sh` example now demonstrates the repoint.
- `docs/sandboxes/{openclaw,hermes}.md` — \"first terminal window\" → \"Service terminal tab\".

## Follow-ups

- **#1172** — generalize into a per-user `~/.profile.d/` pattern (deferred from this PR to keep the regression fix small and image-rebuild-free).
- **`docs/features/default-command.md`** — still describes the pre-#1158 model (\"lives in the **workspace owner's** terminal session\"); broader #1158/#1159 docs debt, out of scope here.