### PR TITLE
Pin webkit executablePath to fix E2E cross-browser job

### DIFF
--- a/src/frontend/e2e-tests/playwright.config.ts
+++ b/src/frontend/e2e-tests/playwright.config.ts
@@ -35,6 +35,16 @@ const firefoxUse = {
 
 const webkitUse = {
   browserName: "webkit" as const,
+  launchOptions: {
+    // The nix playwright-driver bundles webkit build 2287, but @playwright/test
+    // 1.59.1 looks for build 2272 by default ("Executable doesn't exist at
+    // .../webkit-2272/pw_run.sh"). Like chromium/firefox above, pin the path to
+    // the nix-provided build so Playwright uses it directly instead of its
+    // npm-version-derived revision. WEBKIT_PATH mirrors CHROME/FIREFOX_PATH
+    // for local overrides. See #1193.
+    executablePath:
+      process.env.WEBKIT_PATH || `${BROWSERS}/webkit-2287/pw_run.sh`,
+  },
 };
 
 // Test projects:


### PR DESCRIPTION
Closes #1193.

## Problem

The nightly **E2E: Cross-Browser Tests** job (run [#57](https://github.com/mcdonc/klangk/actions/runs/28572118251) and the 7 scheduled runs before it) fails every `--project=webkit` test in 3–14 ms:

```
Error: browserType.launch: Executable doesn't exist at
.../webkit-2272/pw_run.sh
```

`firefox` passes; only `webkit` is broken. The job is non-blocking, so it's been red since at least 2026-06-26 without blocking merges.

## Root cause

In `playwright.config.ts`, `chromiumUse` and `firefoxUse` already hardcode their nix browser revision as `executablePath` (`chromium-1223`, `firefox-1522`). `webkitUse` did **not** — it only set `browserName: "webkit"`.

Without a pinned path, Playwright falls back to the revision its npm version expects. `@playwright/test` 1.59.1 looks for **webkit-2272**, but the nix `playwright-driver.browsers` (also labelled 1.59.1) bundles **webkit-2287** — a nixpkgs packaging skew. The nix store path is identical on CI and locally, and it contains `webkit-2287/pw_run.sh`, not `2272`, so webkit can't launch.

## Fix

Pin `webkitUse.launchOptions.executablePath` to the nix build's `pw_run.sh`, exactly mirroring the chromium/firefox pattern, with a `WEBKIT_PATH` override for local runs:

```ts
executablePath:
  process.env.WEBKIT_PATH || `${BROWSERS}/webkit-2287/pw_run.sh`,
```

## Verification

Locally, `--project=webkit` previously instant-failed; it now launches and passes tests across both webkit spec files:

- `klangk.spec.ts` — *login with wrong password fails*, *workspace shows terminal tab*, *navigate back to workspaces* ✓
- `terminal-keymap.spec.ts` — *Ctrl+B is not intercepted (no tmux prefix key)* ✓

## Trade-off

The pinned `2287` will need bumping when the nix `playwright-driver` is updated — the same maintenance the existing `chromium-1223`/`firefox-1522` pins already carry.