### PR TITLE
fix(e2e): pin webkit executablePath to nix-provided webkit-2287 (#1193)

### DIFF
--- a/src/frontend/e2e-tests/playwright.config.ts
+++ b/src/frontend/e2e-tests/playwright.config.ts
@@ -35,6 +35,10 @@ const firefoxUse = {
 
 const webkitUse = {
   browserName: "webkit" as const,
+  launchOptions: {
+    executablePath:
+      process.env.WEBKIT_PATH || `${BROWSERS}/webkit-2287/pw_run.sh`,
+  },
 };
 
 // Test projects:


### PR DESCRIPTION
## Summary

- Pin `webkitUse.launchOptions.executablePath` to `${BROWSERS}/webkit-2287/pw_run.sh` with a `WEBKIT_PATH` env var override, matching the existing chromium/firefox pattern
- Fixes the nightly cross-browser CI job which has been failing since 2026-06-26 because Playwright's npm metadata expects webkit-2272 but the nix store provides webkit-2287

Closes #1193

## Test plan

- [ ] Nightly E2E cross-browser job passes webkit tests
- [ ] `WEBKIT_PATH` override works for local runs