### PR TITLE
Delete dead build_message() and send_email() from emailsvc

### DIFF
--- a/src/backend/klangk_backend/emailsvc.py
+++ b/src/backend/klangk_backend/emailsvc.py
@@ -82,17 +82,6 @@ def _set_headers(msg: EmailMessage) -> None:
         msg["Reply-To"] = rt
 
 
-def build_message(to: str, subject: str, body: str) -> EmailMessage:
-    cfg = smtp_config()
-    msg = EmailMessage()
-    msg["Subject"] = subject
-    msg["From"] = cfg["from_addr"] or cfg["user"] or "noreply@localhost"
-    msg["To"] = to
-    msg.set_content(body)
-    _set_headers(msg)
-    return msg
-
-
 async def send_via_smtp(msg: EmailMessage) -> None:
     cfg = smtp_config()
     logger.debug(
@@ -133,26 +122,6 @@ async def send_via_sendmail(msg: EmailMessage) -> None:
             f"sendmail ({sendmail}) exited with code {proc.returncode}: {stderr.decode()}"
         )
     logger.info("Email sent via sendmail to %s", msg["To"])
-
-
-async def send_email(to: str, subject: str, body: str) -> None:
-    """Send an email via SMTP (if configured) or local sendmail."""
-    msg = build_message(to, subject, body)
-    logger.info(
-        "From: %s, To: %s, Subject: %s", msg["From"], to, msg["Subject"]
-    )
-    if use_smtp():
-        logger.info(
-            "Sending email to %s via SMTP (%s)",
-            to,
-            resolve_env_value("KLANGK_SMTP_HOST"),
-        )
-        await send_via_smtp(msg)
-    else:
-        logger.info(
-            "Sending email to %s via sendmail (no KLANGK_SMTP_HOST set)", to
-        )
-        await send_via_sendmail(msg)
 
 
 def reset_template_env() -> None:

--- a/src/backend/tests/test_emailsvc.py
+++ b/src/backend/tests/test_emailsvc.py
@@ -20,32 +20,6 @@ def _reset_email_template_env():
     emailsvc.reset_template_env()
 
 
-class TestBuildMessage:
-    def test_builds_message(self):
-        msg = emailsvc.build_message("to@example.com", "Subject", "Body")
-        assert isinstance(msg, EmailMessage)
-        assert msg["To"] == "to@example.com"
-        assert msg["Subject"] == "Subject"
-        assert msg.get_content().strip() == "Body"
-
-    def test_from_uses_smtp_from(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_SMTP_FROM", "custom@example.com")
-        msg = emailsvc.build_message("to@example.com", "Hi", "Body")
-        assert msg["From"] == "custom@example.com"
-
-    def test_from_falls_back_to_smtp_user(self, monkeypatch):
-        monkeypatch.delenv("KLANGK_SMTP_FROM", raising=False)
-        monkeypatch.setenv("KLANGK_SMTP_USER", "user@example.com")
-        msg = emailsvc.build_message("to@example.com", "Hi", "Body")
-        assert msg["From"] == "user@example.com"
-
-    def test_from_falls_back_to_noreply(self, monkeypatch):
-        monkeypatch.delenv("KLANGK_SMTP_FROM", raising=False)
-        monkeypatch.delenv("KLANGK_SMTP_USER", raising=False)
-        msg = emailsvc.build_message("to@example.com", "Hi", "Body")
-        assert msg["From"] == "noreply@localhost"
-
-
 class TestResolvePassword:
     def test_plain_password(self, monkeypatch):
         monkeypatch.setenv("KLANGK_SMTP_PASSWORD", "secret123")
@@ -76,6 +50,16 @@ class TestUseSmtp:
         assert emailsvc.use_smtp() is False
 
 
+def _plain_msg(to="to@example.com", subject="Hi", body="Body"):
+    """Build a minimal EmailMessage for transport-layer tests."""
+    msg = EmailMessage()
+    msg["Subject"] = subject
+    msg["From"] = "test@example.com"
+    msg["To"] = to
+    msg.set_content(body)
+    return msg
+
+
 class TestSendViaSmtp:
     async def test_calls_aiosmtplib_send(self, monkeypatch):
         monkeypatch.setenv("KLANGK_SMTP_HOST", "smtp.example.com")
@@ -86,8 +70,7 @@ class TestSendViaSmtp:
 
         mock_send = AsyncMock()
         with patch.object(emailsvc.aiosmtplib, "send", mock_send):
-            msg = emailsvc.build_message("to@example.com", "Hi", "Body")
-            await emailsvc.send_via_smtp(msg)
+            await emailsvc.send_via_smtp(_plain_msg())
 
         mock_send.assert_awaited_once()
         kwargs = mock_send.call_args[1]
@@ -106,8 +89,7 @@ class TestSendViaSmtp:
 
         mock_send = AsyncMock()
         with patch.object(emailsvc.aiosmtplib, "send", mock_send):
-            msg = emailsvc.build_message("to@example.com", "Hi", "Body")
-            await emailsvc.send_via_smtp(msg)
+            await emailsvc.send_via_smtp(_plain_msg())
 
         kwargs = mock_send.call_args[1]
         assert "username" not in kwargs
@@ -124,8 +106,7 @@ class TestSendViaSendmail:
         with patch(
             "asyncio.create_subprocess_exec", return_value=mock_proc
         ) as mock_exec:
-            msg = emailsvc.build_message("to@example.com", "Hi", "Body")
-            await emailsvc.send_via_sendmail(msg)
+            await emailsvc.send_via_sendmail(_plain_msg())
 
         mock_exec.assert_awaited_once()
         assert mock_exec.call_args[0][0] == "sendmail"
@@ -141,8 +122,7 @@ class TestSendViaSendmail:
         with patch(
             "asyncio.create_subprocess_exec", return_value=mock_proc
         ) as mock_exec:
-            msg = emailsvc.build_message("to@example.com", "Hi", "Body")
-            await emailsvc.send_via_sendmail(msg)
+            await emailsvc.send_via_sendmail(_plain_msg())
 
         assert (
             mock_exec.call_args[0][0] == "/run/current-system/sw/bin/sendmail"
@@ -154,25 +134,8 @@ class TestSendViaSendmail:
         mock_proc.returncode = 1
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
-            msg = emailsvc.build_message("to@example.com", "Hi", "Body")
             with pytest.raises(SendmailError, match="exited with code 1"):
-                await emailsvc.send_via_sendmail(msg)
-
-
-class TestSendEmail:
-    async def test_uses_smtp_when_configured(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_SMTP_HOST", "smtp.example.com")
-        mock_smtp = AsyncMock()
-        with patch.object(emailsvc, "send_via_smtp", mock_smtp):
-            await emailsvc.send_email("to@example.com", "Hi", "Body")
-        mock_smtp.assert_awaited_once()
-
-    async def test_uses_sendmail_when_no_smtp(self, monkeypatch):
-        monkeypatch.delenv("KLANGK_SMTP_HOST", raising=False)
-        mock_sendmail = AsyncMock()
-        with patch.object(emailsvc, "send_via_sendmail", mock_sendmail):
-            await emailsvc.send_email("to@example.com", "Hi", "Body")
-        mock_sendmail.assert_awaited_once()
+                await emailsvc.send_via_sendmail(_plain_msg())
 
 
 class TestSendVerificationEmail:
@@ -450,16 +413,6 @@ class TestReplyTo:
         monkeypatch.setenv("KLANGK_SMTP_REPLY_TO", "support@example.com")
         assert emailsvc.reply_to() == "support@example.com"
 
-    def test_build_message_adds_reply_to_when_set(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_SMTP_REPLY_TO", "support@example.com")
-        msg = emailsvc.build_message("to@e.com", "S", "B")
-        assert msg["Reply-To"] == "support@example.com"
-
-    def test_build_message_no_reply_to_when_unset(self, monkeypatch):
-        monkeypatch.delenv("KLANGK_SMTP_REPLY_TO", raising=False)
-        msg = emailsvc.build_message("to@e.com", "S", "B")
-        assert msg["Reply-To"] is None
-
     async def test_multipart_carries_reply_to(self, monkeypatch):
         monkeypatch.setenv("KLANGK_SMTP_REPLY_TO", "support@example.com")
         rendered = emailsvc.render_email(
@@ -467,3 +420,11 @@ class TestReplyTo:
         )
         msg = emailsvc._build_multipart("to@e.com", rendered)
         assert msg["Reply-To"] == "support@example.com"
+
+    def test_multipart_no_reply_to_when_unset(self, monkeypatch):
+        monkeypatch.delenv("KLANGK_SMTP_REPLY_TO", raising=False)
+        rendered = emailsvc.render_email(
+            "verify", link="https://x", expiry_hours=72
+        )
+        msg = emailsvc._build_multipart("to@e.com", rendered)
+        assert msg["Reply-To"] is None


### PR DESCRIPTION
## Summary

- Delete `build_message()` and `send_email()` from `emailsvc.py` — zero production callers after the #1165 templated email rewrite
- Remove duplicated `From`-header fallback logic (now only in `_build_multipart()`)
- Delete `TestBuildMessage` (4 tests) and `TestSendEmail` (2 tests), update remaining transport-layer tests to use a local `_plain_msg()` helper
- Replace `build_message`-based Reply-To tests with `_build_multipart`-based equivalents

Closes #1185

## Test plan

- [x] `test_emailsvc.py` — 34 tests pass, emailsvc.py at 100% coverage
- [ ] CI backend tests pass