### PR TITLE
feat: runtime SSL/CA cert injection into workspaces + backend (#1181)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,14 @@ KLANGK_DEFAULT_USER=admin@example.com
 # built-in tree from src/backend/klangk_backend/email_templates/ to get started.
 # KLANGK_EMAIL_TEMPLATES_DIR=/etc/klangk/email-templates
 
+# Custom SSL/CA certificates (optional). Drop .pem/.crt files into this
+# directory to make workspace containers AND the backend process trust
+# your private CAs at runtime (no image rebuild). Applies to OpenSSL,
+# Python, curl, and Node; the bundle is merged with the system CAs so
+# public-internet TLS keeps working. Restart workspaces/backend to rotate.
+# See docs/deployment/customizing.md.
+# KLANGK_SSL_CERT_DIR=/etc/klangk/ssl
+
 # OIDC authentication (optional — see docs at https://mcdonc.github.io/klangk/reference/oidc/)
 # KLANGK_OIDC_CONFIG=/path/to/oidc.yaml
 # password | oidc | both

--- a/docs/deployment/customizing.md
+++ b/docs/deployment/customizing.md
@@ -186,13 +186,13 @@ Extends `klangk-host:latest` and replaces four things:
 
 ## Build Options
 
-| Variable              | Default                                    | Description                                                            |
-| --------------------- | ------------------------------------------ | ---------------------------------------------------------------------- |
-| `KLANGK_REF`          | `main`                                     | Klangk branch, tag, or commit SHA to build against                     |
-| `KLANGK_REPO`         | `https://github.com/mcdonc/klangk.git`     | Klangk repo URL                                                        |
-| `KLANGK_HOST_IMAGE`   | `ghcr.io/mcdonc/klangk/klangk-host-custom` | Output image name                                                      |
-| `KLANGK_PLATFORM`     | `linux/amd64`                              | Target platform                                                        |
-| `KLANGK_SSL_CERT_DIR` | `./ssl`                                    | Directory containing `.pem`/`.crt` CA certs to inject into both images |
+| Variable              | Default                                    | Description                                                                                                                                                                                                                          |
+| --------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `KLANGK_REF`          | `main`                                     | Klangk branch, tag, or commit SHA to build against                                                                                                                                                                                   |
+| `KLANGK_REPO`         | `https://github.com/mcdonc/klangk.git`     | Klangk repo URL                                                                                                                                                                                                                      |
+| `KLANGK_HOST_IMAGE`   | `ghcr.io/mcdonc/klangk/klangk-host-custom` | Output image name                                                                                                                                                                                                                    |
+| `KLANGK_PLATFORM`     | `linux/amd64`                              | Target platform                                                                                                                                                                                                                      |
+| `KLANGK_SSL_CERT_DIR` | `./ssl`                                    | Directory containing `.pem`/`.crt` CA certs to inject into both images (build-time). The same variable is also honored **at runtime** to trust private CAs without a rebuild — see [Custom CA Certificates](#custom-ca-certificates) |
 
 ## Plugins
 
@@ -211,7 +211,32 @@ See the [Creating Plugins](../development/creating-plugins.md) reference for plu
 
 ## Custom CA Certificates
 
-Place `.pem` or `.crt` files in the `ssl/` directory (or set `KLANGK_SSL_CERT_DIR`). They are installed into the system CA store of both the host and workspace images. This is needed when services (e.g., Logfire, OIDC providers) use certificates signed by a private CA. The `ssl/` directory is gitignored — certs must be provided at build time.
+Klangk supports custom CA certificates in two complementary ways: a **build-time** path that bakes the certs into the images (requires a rebuild to rotate), and a **runtime** path that mounts the certs and points each toolchain at them (rotate by restarting containers, no rebuild).
+
+Both honor the same directory: place `.pem` or `.crt` files there. This is needed when services (e.g., Logfire, OIDC providers, internal package mirrors, SMTP relays) use certificates signed by a private CA — common behind corporate MITM proxies or in air-gapped/offline deployments.
+
+### Build-time (baked into the images)
+
+Place `.pem` or `.crt` files in the `ssl/` directory (or set `KLANGK_SSL_CERT_DIR`). They are installed into the system CA store of both the host and workspace images. The `ssl/` directory is gitignored — certs must be provided at build time.
+
+### Runtime (mounted, no rebuild) — `KLANGK_SSL_CERT_DIR`
+
+Point `KLANGK_SSL_CERT_DIR` at a directory of `.pem`/`.crt` files on the host and **restart** workspaces (or the backend). Klangk makes those CAs trusted at startup **without rebuilding any image**, in **two scopes**:
+
+- **Workspace containers** — the directory is bind-mounted read-only into each container, and the container entrypoint builds a merged CA bundle (the container's system CAs **plus** your custom certs) on the writable `/tmp` tmpfs. The toolchain trust env vars (`SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `NODE_EXTRA_CA_CERTS`) are set to point at it, so OpenSSL, Python (`requests`/`certifi`), `curl`, and Node all honor your CAs. Because the bundle is **merged with the system CAs**, public-internet TLS (e.g. `npm install`, `pip install`, `git clone https://...`) keeps working. This applies to shells, `podman exec`, and the agent subprocess alike.
+- **Backend process** — at startup the backend concatenates your certs with its own system bundle and sets the same trust env vars, so its own outbound TLS (OIDC discovery, SMTP relay, the LLM-proxy upstream) trusts your private CAs too.
+
+```bash
+docker run -d \
+  ...
+  -e KLANGK_SSL_CERT_DIR=/certs \
+  -v ./my-corporate-cas:/certs:ro \
+  ghcr.io/mcdonc/klangk/klangk-host-custom
+```
+
+Rotating a cert is just a file change plus a workspace/backend restart — no image rebuild. The build-time path remains available; the runtime path is additive.
+
+> **Why a merged bundle?** The `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE` / `CURL_CA_BUNDLE` variables _replace_ the default trust store rather than add to it, so a custom-only bundle would break public-internet TLS. Klangk therefore prepends the system CAs before your custom certs. (`NODE_EXTRA_CA_CERTS` is additive, but pointing it at the same merged bundle is harmless.)
 
 ## OIDC Authentication
 

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -174,6 +174,17 @@ def parse_idle_timeout() -> tuple[int, int]:
 
 IDLE_TIMEOUT_SECONDS, CHECK_INTERVAL_SECONDS = parse_idle_timeout()
 
+
+# --- Runtime SSL/CA certificate injection (#1181) -------------------------
+# The detection (ssl_cert_dir), container env vars (ssl_env_vars) and the
+# in-container mount/bundle paths live in :mod:`ssl_trust`, which also owns
+# the backend-process trust path.  See that module for the full design.
+from .ssl_trust import (  # noqa: E402
+    SSL_MOUNT_DEST as _SSL_MOUNT_DEST,
+    ssl_cert_dir,
+    ssl_env_vars,
+)
+
 PORT_RANGE_START = int(
     util.resolve_env_value("KLANGK_PORT_RANGE_START") or "9000"
 )
@@ -891,6 +902,7 @@ class ContainerRegistry:
         hosting_base_path: str,
         agent_home: str,
         extra_env: dict[str, str] | None,
+        ssl_dir: str | None = None,
     ) -> list[str]:
         """Build the container environment variable list."""
         env_vars: list[str] = []
@@ -922,6 +934,12 @@ class ContainerRegistry:
         env_vars.append(f"KLANGK_HOSTING_BASE_PATH={hosting_base_path}")
         if TERMINAL_BANNER:
             env_vars.append(f"KLANGK_TERMINAL_BANNER={TERMINAL_BANNER}")
+
+        # Runtime SSL/CA trust (#1181): point OpenSSL/Python/curl/Node
+        # at the bundle the entrypoint builds from the mounted certs.
+        # Appended before plugin/extra env so a deployer can override if
+        # ever needed. Emitted only when a trustable cert dir is present.
+        env_vars.extend(ssl_env_vars(ssl_dir))
 
         for k, v in plugins.container_env().items():
             env_vars.append(f"{k}={v}")
@@ -972,11 +990,15 @@ class ContainerRegistry:
         home_path: str,
         config_path: str | None,
         extra_mounts: list[str] | None,
+        ssl_dir: str | None = None,
     ) -> list[str]:
         """Build the bind-mount list for the container."""
         binds = [f"{home_path}:/home"]
         if config_path:
             binds.append(f"{config_path}:/opt/klangk/config:ro")
+        if ssl_dir:
+            # Read-only mount of deployer CA certs (#1181).
+            binds.append(f"{ssl_dir}:{_SSL_MOUNT_DEST}:ro")
         binds += extra_mounts or []
         return binds
 
@@ -1150,6 +1172,13 @@ class ContainerRegistry:
         # Resolve the agent home at this async seam (``_build_env`` is
         # sync) so every exec process inherits KLANGK_AGENT_HOME (#1157).
         agent_home = f"/home/{await model.agent_handle()}"
+        ssl_dir = ssl_cert_dir()
+        if ssl_dir:
+            logger.info(
+                "Runtime SSL trust enabled: mounting %s at %s",
+                ssl_dir,
+                _SSL_MOUNT_DEST,
+            )
         env_vars = self._build_env(
             workspace_id,
             host_ports,
@@ -1158,9 +1187,12 @@ class ContainerRegistry:
             hosting_base_path,
             agent_home,
             extra_env,
+            ssl_dir,
         )
         await self._ensure_volumes(extra_mounts, user_id)
-        binds = self._build_mounts(home_path, config_path, extra_mounts)
+        binds = self._build_mounts(
+            home_path, config_path, extra_mounts, ssl_dir
+        )
 
         publish = [
             (host_port, CONTAINER_PORT_START + i)

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -13,7 +13,16 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 
-from . import auth, container, model, oidc, plugins, workspaces, wshandler
+from . import (
+    auth,
+    container,
+    model,
+    oidc,
+    plugins,
+    ssl_trust,
+    workspaces,
+    wshandler,
+)
 from .api import root_router, router
 from .util import API_PREFIX
 from .model import (
@@ -275,6 +284,11 @@ async def lifespan(app: FastAPI):
         )
         raise SystemExit(1)
     write_pid_file()
+
+    # Make the backend process itself trust deployer-supplied CAs (#1181)
+    # before any outbound TLS happens (OIDC discovery, SMTP relay, LLM-proxy
+    # upstream). No-op when KLANGK_SSL_CERT_DIR is unset or empty of certs.
+    ssl_trust.apply_backend_ssl_trust()
 
     auth.require_secure_jwt_secret()
     plugins.load()

--- a/src/backend/klangk_backend/ssl_trust.py
+++ b/src/backend/klangk_backend/ssl_trust.py
@@ -1,0 +1,204 @@
+"""Runtime SSL/CA certificate trust, without an image rebuild (#1181).
+
+A deployer drops ``.pem``/``.crt`` CA certificates into ``KLANGK_SSL_CERT_DIR``
+and both trust scopes consume them at runtime:
+
+* **Workspace containers** — :mod:`container` mounts the directory read-only at
+  :data:`SSL_MOUNT_DEST` and emits the :data:`SSL_TRUST_VARS` env vars pointing
+  at :data:`SSL_BUNDLE_DEST`, the in-container bundle the entrypoint builds
+  from the mounted certs plus the container's system bundle.
+
+* **Backend process** — :func:`apply_backend_ssl_trust` builds a host-side
+  bundle and sets the trust vars in :data:`os.environ` so the backend's own
+  outbound TLS (OIDC IdP, SMTP relay, LLM-proxy upstream) honors the private
+  CAs.  Called once at startup (:func:`klangk_backend.main.lifespan`).
+
+**Both bundles are *merged* (system CAs + custom certs).** The
+``SSL_CERT_FILE`` / ``REQUESTS_CA_BUNDLE`` / ``CURL_CA_BUNDLE`` vars *replace*
+the default trust store rather than augment it, so a custom-only bundle would
+break public-internet TLS (``npm``/``pip``/``git``, public OIDC, Gmail SMTP).
+``NODE_EXTRA_CA_CERTS`` is additive, but pointing it at the merged bundle is
+harmless (Node de-duplicates).  The build-time path
+(``customize/ssl`` -> ``update-ca-certificates``) remains available; this is
+additive, for rotating trust roots without a rebuild.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import ssl
+
+import certifi
+
+from . import util
+
+logger = logging.getLogger(__name__)
+
+# File extensions that count as CA certificates (matched case-insensitively).
+SSL_CERT_EXTS = (".pem", ".crt")
+# In-container mount point for the read-only deployer cert directory.
+SSL_MOUNT_DEST = "/opt/klangk/ssl"
+# In-container CA bundle path.  Built by the container entrypoint at startup
+# from the mounted certs plus the container's system bundle, on the writable
+# /tmp tmpfs (the entrypoint runs as non-root UID 1000).
+SSL_BUNDLE_DEST = "/tmp/klangk/ca-bundle.crt"
+# Toolchains whose trust we redirect at the merged bundle.  SSL_CERT_FILE is
+# OpenSSL / the stdlib ``ssl`` module / smtplib; REQUESTS_CA_BUNDLE is
+# ``requests``; CURL_CA_BUNDLE is curl; NODE_EXTRA_CA_CERTS is Node.
+SSL_TRUST_VARS = (
+    "SSL_CERT_FILE",
+    "REQUESTS_CA_BUNDLE",
+    "CURL_CA_BUNDLE",
+    "NODE_EXTRA_CA_CERTS",
+)
+
+
+def _iter_cert_files(ssl_dir: str):
+    """Yield absolute paths of ``*.pem``/``*.crt`` files in ``ssl_dir``.
+
+    Sorted for deterministic bundle contents; case-insensitive extension
+    match.  Empty when the directory is unreadable or contains no certs.
+    """
+    try:
+        names = sorted(os.listdir(ssl_dir))
+    except OSError:
+        return
+    for name in names:
+        if name.lower().endswith(SSL_CERT_EXTS):
+            yield os.path.join(ssl_dir, name)
+
+
+def ssl_cert_dir() -> str | None:
+    """Return the deployer SSL cert dir if it should be trusted, else ``None``.
+
+    Resolves ``KLANGK_SSL_CERT_DIR``.  Returns the absolute path when the
+    directory exists and contains at least one ``.pem``/``.crt`` file;
+    ``None`` otherwise (unset, missing, or empty of certs).  Never raises —
+    a misconfigured path simply disables runtime trust.
+    """
+    raw = util.resolve_env_value("KLANGK_SSL_CERT_DIR")
+    if not raw:
+        return None
+    path = os.path.realpath(raw)
+    if not os.path.isdir(path):
+        return None
+    return path if any(True for _ in _iter_cert_files(path)) else None
+
+
+def ssl_env_vars(ssl_dir: str | None) -> list[str]:
+    """Container env vars pointing toolchains at the in-container bundle.
+
+    Empty unless a trustable cert dir is configured (see :func:`ssl_cert_dir`).
+    The bundle itself is built by the container entrypoint at startup from the
+    mounted certs plus the container's system bundle.
+    """
+    if not ssl_dir:
+        return []
+    return [f"{name}={SSL_BUNDLE_DEST}" for name in SSL_TRUST_VARS]
+
+
+def _system_ca_bundle(self_bundle: str | None = None) -> str | None:
+    """Best-effort path to the host's default (system) CA bundle.
+
+    The trust env vars *replace* the default store, so a merged bundle must
+    include the system CAs to preserve public-internet trust.  Prefers the
+    compiled-in OpenSSL default (``openssl_cafile`` — not influenced by the
+    ``SSL_CERT_FILE`` env var) over ``cafile`` to avoid a self-reference when
+    this function runs after we have already set ``SSL_CERT_FILE`` (idempotent
+    re-entry / tests).  Skips any candidate equal to ``self_bundle``.  Falls
+    back to ``certifi`` (an httpx dependency).
+    """
+    dvp = ssl.get_default_verify_paths()
+    candidates: list[str] = []
+    if dvp.openssl_cafile:
+        candidates.append(dvp.openssl_cafile)
+    if dvp.cafile and dvp.cafile != dvp.openssl_cafile:
+        candidates.append(dvp.cafile)
+    self_real = os.path.realpath(self_bundle) if self_bundle else None
+    for cand in candidates:
+        if self_real and os.path.realpath(cand) == self_real:
+            continue
+        if os.path.isfile(cand):
+            return cand
+    where = certifi.where()
+    if where and (not self_real or os.path.realpath(where) != self_real):
+        if os.path.isfile(where):
+            return where
+    return None
+
+
+def _write_merged_bundle(bundle_path: str, ssl_dir: str) -> bool:
+    """Write system CAs + custom certs to ``bundle_path``.
+
+    Returns ``True`` if a non-empty bundle was written.  System bundle is read
+    first so it is never lost; unreadable files are skipped with a warning.
+    """
+    written = 0
+    with open(bundle_path, "w") as out:
+        sys_bundle = _system_ca_bundle(self_bundle=bundle_path)
+        if sys_bundle:
+            try:
+                out.write(open(sys_bundle).read())
+                written += 1
+            except OSError as exc:
+                logger.warning(
+                    "Could not read system CA bundle %s: %s", sys_bundle, exc
+                )
+        for cert in _iter_cert_files(ssl_dir):
+            try:
+                out.write(open(cert).read())
+                written += 1
+            except OSError as exc:
+                logger.warning("Skipping unreadable cert %s: %s", cert, exc)
+    return written > 0 and os.path.getsize(bundle_path) > 0
+
+
+def apply_backend_ssl_trust() -> str | None:
+    """Make the backend process trust the deployer's custom CAs.
+
+    Builds a merged bundle (system + custom) under ``<data_dir>/ssl`` and sets
+    :data:`SSL_TRUST_VARS` in :data:`os.environ`, so the backend's outbound TLS
+    (OIDC discovery, SMTP relay, LLM-proxy upstream) honors the private CAs.
+    Idempotent and safe to call at startup; a no-op when no cert dir is
+    configured.  Refuses to apply trust when the system bundle can't be found
+    *and* no cert was written (would risk losing public-internet trust).
+
+    Returns the bundle path, or ``None`` if trust was not applied.
+    """
+    ssl_dir = ssl_cert_dir()
+    if not ssl_dir:
+        return None
+    default_data = os.path.expanduser("~/.klangk/data")
+    data_dir = (
+        util.resolve_env_value("KLANGK_DATA_DIR", default_data) or default_data
+    )
+    bundle_dir = os.path.join(data_dir, "ssl")
+    try:
+        os.makedirs(bundle_dir, exist_ok=True)
+    except OSError as exc:
+        logger.error("Cannot create SSL bundle dir %s: %s", bundle_dir, exc)
+        return None
+    bundle_path = os.path.join(bundle_dir, "ca-bundle.crt")
+    if not _write_merged_bundle(bundle_path, ssl_dir):
+        logger.warning(
+            "SSL bundle %s is empty (no system bundle and no custom certs); "
+            "not applying backend trust",
+            bundle_path,
+        )
+        return None
+    if not _system_ca_bundle(self_bundle=bundle_path):
+        logger.warning(
+            "Applying backend SSL trust without a system bundle: the trust "
+            "vars replace the default store, so public-internet TLS endpoints "
+            "may fail. Provide a system CA bundle or unset KLANGK_SSL_CERT_DIR."
+        )
+    for name in SSL_TRUST_VARS:
+        os.environ[name] = bundle_path
+    logger.info(
+        "Backend SSL trust applied: %s -> %d env var(s) (custom certs from %s)",
+        bundle_path,
+        len(SSL_TRUST_VARS),
+        ssl_dir,
+    )
+    return bundle_path

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -43,6 +43,52 @@ class TestParseIdleTimeout:
         assert interval == 60  # clamped to max 60
 
 
+class TestSslCertDir:
+    """Runtime SSL/CA certificate injection (#1181): ssl_cert_dir() resolver."""
+
+    def test_unset_returns_none(self, monkeypatch):
+        monkeypatch.delenv("KLANGK_SSL_CERT_DIR", raising=False)
+        assert container.ssl_cert_dir() is None
+
+    def test_missing_dir_returns_none(self, monkeypatch, tmp_path):
+        gone = tmp_path / "does-not-exist"
+        monkeypatch.setenv("KLANGK_SSL_CERT_DIR", str(gone))
+        assert container.ssl_cert_dir() is None
+
+    def test_empty_dir_returns_none(self, monkeypatch, tmp_path):
+        # Dir exists but contains no .pem/.crt.
+        (tmp_path / "readme.txt").write_text("no certs here")
+        monkeypatch.setenv("KLANGK_SSL_CERT_DIR", str(tmp_path))
+        assert container.ssl_cert_dir() is None
+
+    def test_dir_with_pem_returns_path(self, monkeypatch, tmp_path):
+        (tmp_path / "ca.pem").write_text("-----BEGIN CERTIFICATE-----")
+        monkeypatch.setenv("KLANGK_SSL_CERT_DIR", str(tmp_path))
+        assert container.ssl_cert_dir() == str(tmp_path.resolve())
+
+    def test_dir_with_crt_returns_path(self, monkeypatch, tmp_path):
+        (tmp_path / "my-ca.crt").write_text("-----BEGIN CERTIFICATE-----")
+        monkeypatch.setenv("KLANGK_SSL_CERT_DIR", str(tmp_path))
+        assert container.ssl_cert_dir() == str(tmp_path.resolve())
+
+    def test_extension_case_insensitive(self, monkeypatch, tmp_path):
+        (tmp_path / "CA.PEM").write_text("-----BEGIN CERTIFICATE-----")
+        monkeypatch.setenv("KLANGK_SSL_CERT_DIR", str(tmp_path))
+        assert container.ssl_cert_dir() == str(tmp_path.resolve())
+
+    def test_ssl_env_vars_empty_without_dir(self):
+        assert container.ssl_env_vars(None) == []
+
+    def test_ssl_env_vars_point_at_bundle(self):
+        vars_ = container.ssl_env_vars("/some/dir")
+        assert vars_ == [
+            "SSL_CERT_FILE=/tmp/klangk/ca-bundle.crt",
+            "REQUESTS_CA_BUNDLE=/tmp/klangk/ca-bundle.crt",
+            "CURL_CA_BUNDLE=/tmp/klangk/ca-bundle.crt",
+            "NODE_EXTRA_CA_CERTS=/tmp/klangk/ca-bundle.crt",
+        ]
+
+
 class TestImagePullPolicy:
     def test_default_is_never(self, monkeypatch):
         monkeypatch.delenv("KLANGK_IMAGE_PULL_POLICY", raising=False)
@@ -658,6 +704,63 @@ class TestStartContainer:
             )
         env = p.create_container.call_args.kwargs["env"]
         assert "KLANGK_TERMINAL_BANNER=Custom warning" in env
+
+    async def test_ssl_trust_mounted_when_cert_dir_configured(
+        self, workspace, monkeypatch, tmp_path
+    ):
+        """A configured KLANGK_SSL_CERT_DIR is bind-mounted ro and env set (#1181)."""
+        ssl_dir = tmp_path / "ssl"
+        ssl_dir.mkdir()
+        (ssl_dir / "corp-ca.pem").write_text("-----BEGIN CERTIFICATE-----")
+        monkeypatch.setenv("KLANGK_SSL_CERT_DIR", str(ssl_dir))
+        with patch_podman() as p:
+            await container.registry.start_container(
+                workspace["id"],
+                "/tmp/ws",
+                "/tmp/home",
+            )
+        binds = p.create_container.call_args.kwargs["binds"]
+        assert f"{ssl_dir.resolve()}:/opt/klangk/ssl:ro" in binds
+        env = p.create_container.call_args.kwargs["env"]
+        assert "SSL_CERT_FILE=/tmp/klangk/ca-bundle.crt" in env
+        assert "REQUESTS_CA_BUNDLE=/tmp/klangk/ca-bundle.crt" in env
+        assert "CURL_CA_BUNDLE=/tmp/klangk/ca-bundle.crt" in env
+        assert "NODE_EXTRA_CA_CERTS=/tmp/klangk/ca-bundle.crt" in env
+
+    async def test_no_ssl_trust_when_cert_dir_unset(
+        self, workspace, monkeypatch
+    ):
+        """Without KLANGK_SSL_CERT_DIR there is no mount and no trust env."""
+        monkeypatch.delenv("KLANGK_SSL_CERT_DIR", raising=False)
+        with patch_podman() as p:
+            await container.registry.start_container(
+                workspace["id"],
+                "/tmp/ws",
+                "/tmp/home",
+            )
+        binds = p.create_container.call_args.kwargs["binds"]
+        assert not any("/opt/klangk/ssl" in b for b in binds)
+        env = p.create_container.call_args.kwargs["env"]
+        assert not any(e.startswith("SSL_CERT_FILE=") for e in env)
+
+    async def test_no_ssl_trust_when_dir_has_no_certs(
+        self, workspace, monkeypatch, tmp_path
+    ):
+        """A cert dir with no .pem/.crt is not mounted (#1181)."""
+        ssl_dir = tmp_path / "ssl"
+        ssl_dir.mkdir()
+        (ssl_dir / "notes.txt").write_text("not a cert")
+        monkeypatch.setenv("KLANGK_SSL_CERT_DIR", str(ssl_dir))
+        with patch_podman() as p:
+            await container.registry.start_container(
+                workspace["id"],
+                "/tmp/ws",
+                "/tmp/home",
+            )
+        binds = p.create_container.call_args.kwargs["binds"]
+        assert not any("/opt/klangk/ssl" in b for b in binds)
+        env = p.create_container.call_args.kwargs["env"]
+        assert not any(e.startswith("SSL_CERT_FILE=") for e in env)
 
     async def test_port_allocation_on_create(self, workspace):
         with patch_podman():

--- a/src/backend/tests/test_ssl_trust.py
+++ b/src/backend/tests/test_ssl_trust.py
@@ -1,0 +1,312 @@
+"""Tests for runtime SSL/CA certificate trust (#1181).
+
+Covers the shared resolver (:func:`ssl_trust.ssl_cert_dir`), the
+backend-process trust path (:func:`ssl_trust.apply_backend_ssl_trust`),
+and the merged-bundle semantics (system + custom) that keep
+public-internet TLS working.
+"""
+
+import logging
+import os
+import ssl
+import types
+
+import pytest
+
+from klangk_backend import ssl_trust
+
+
+@pytest.fixture(autouse=True)
+def _restore_trust_env(monkeypatch):
+    """Snapshot/restore the trust env vars around each test.
+
+    ``apply_backend_ssl_trust`` mutates ``os.environ`` directly (it must, so
+    OpenSSL/httpx/smtplib pick the bundle up), so a manual restore keeps tests
+    isolated and avoids leaking a host-path bundle into later tests.
+    """
+    snapshot = {k: os.environ.get(k) for k in ssl_trust.SSL_TRUST_VARS}
+    yield
+    for k, v in snapshot.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+
+
+class TestSslCertDir:
+    def test_unset_returns_none(self, monkeypatch):
+        monkeypatch.delenv("KLANGK_SSL_CERT_DIR", raising=False)
+        assert ssl_trust.ssl_cert_dir() is None
+
+    def test_missing_dir_returns_none(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("KLANGK_SSL_CERT_DIR", str(tmp_path / "nope"))
+        assert ssl_trust.ssl_cert_dir() is None
+
+    def test_empty_dir_returns_none(self, monkeypatch, tmp_path):
+        (tmp_path / "readme.txt").write_text("no certs")
+        monkeypatch.setenv("KLANGK_SSL_CERT_DIR", str(tmp_path))
+        assert ssl_trust.ssl_cert_dir() is None
+
+    def test_pem_and_crt_detected(self, monkeypatch, tmp_path):
+        (tmp_path / "a.pem").write_text("CERTA")
+        (tmp_path / "b.CRT").write_text("CERTB")
+        monkeypatch.setenv("KLANGK_SSL_CERT_DIR", str(tmp_path))
+        assert ssl_trust.ssl_cert_dir() == str(tmp_path.resolve())
+
+
+class TestSslEnvVars:
+    def test_empty_without_dir(self):
+        assert ssl_trust.ssl_env_vars(None) == []
+
+    def test_all_four_toolchain_vars(self):
+        vars_ = ssl_trust.ssl_env_vars("/some/dir")
+        assert vars_ == [
+            "SSL_CERT_FILE=/tmp/klangk/ca-bundle.crt",
+            "REQUESTS_CA_BUNDLE=/tmp/klangk/ca-bundle.crt",
+            "CURL_CA_BUNDLE=/tmp/klangk/ca-bundle.crt",
+            "NODE_EXTRA_CA_CERTS=/tmp/klangk/ca-bundle.crt",
+        ]
+
+
+class TestApplyBackendSslTrust:
+    def test_noop_when_unset(self, monkeypatch):
+        monkeypatch.delenv("KLANGK_SSL_CERT_DIR", raising=False)
+        assert ssl_trust.apply_backend_ssl_trust() is None
+        for k in ssl_trust.SSL_TRUST_VARS:
+            assert k not in os.environ
+
+    def test_noop_when_dir_has_no_certs(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("KLANGK_SSL_CERT_DIR", str(tmp_path))
+        assert ssl_trust.apply_backend_ssl_trust() is None
+        for k in ssl_trust.SSL_TRUST_VARS:
+            assert k not in os.environ
+
+    def test_applies_merged_bundle_and_env_vars(self, monkeypatch, tmp_path):
+        cert_dir = tmp_path / "ssl"
+        cert_dir.mkdir()
+        (cert_dir / "corp-ca.pem").write_text("FAKE-CORP-CA\n")
+        monkeypatch.setenv("KLANGK_SSL_CERT_DIR", str(cert_dir))
+        monkeypatch.setattr(
+            ssl_trust,
+            "_system_ca_bundle",
+            lambda self_bundle=None: str(tmp_path / "sys.pem"),
+        )
+        (tmp_path / "sys.pem").write_text("FAKE-SYSTEM-CA\n")
+        data_dir = tmp_path / "data"
+        monkeypatch.setenv("KLANGK_DATA_DIR", str(data_dir))
+
+        bundle = ssl_trust.apply_backend_ssl_trust()
+
+        assert bundle is not None
+        assert os.path.isfile(bundle)
+        contents = open(bundle).read()
+        # System bundle first (preserves public-internet trust), then custom.
+        assert contents == "FAKE-SYSTEM-CA\nFAKE-CORP-CA\n"
+        # All toolchain vars point at the merged bundle.
+        for k in ssl_trust.SSL_TRUST_VARS:
+            assert os.environ[k] == bundle
+
+    def test_bundle_is_merged_not_custom_only(self, monkeypatch, tmp_path):
+        """The bundle must include system CAs so public-internet TLS still works
+        (SSL_CERT_FILE/REQUESTS_CA_BUNDLE/CURL_CA_BUNDLE REPLACE the store)."""
+        cert_dir = tmp_path / "ssl"
+        cert_dir.mkdir()
+        (cert_dir / "corp-ca.crt").write_text("CORP\n")
+        monkeypatch.setenv("KLANGK_SSL_CERT_DIR", str(cert_dir))
+        monkeypatch.setattr(
+            ssl_trust,
+            "_system_ca_bundle",
+            lambda self_bundle=None: str(tmp_path / "sys.pem"),
+        )
+        (tmp_path / "sys.pem").write_text("SYSTEM-MARKER\n")
+        monkeypatch.setenv("KLANGK_DATA_DIR", str(tmp_path / "data"))
+
+        ssl_trust.apply_backend_ssl_trust()
+
+        bundle = os.environ["SSL_CERT_FILE"]
+        contents = open(bundle).read()
+        assert "SYSTEM-MARKER" in contents  # public-internet CAs preserved
+        assert "CORP" in contents  # custom CA present
+
+    def test_idempotent_no_bundle_growth(self, monkeypatch, tmp_path):
+        """Re-applying (e.g. lifespan re-entry) must not duplicate contents.
+
+        Guards against a self-reference: once SSL_CERT_FILE is set, a naive
+        system-bundle lookup could read our own merged bundle and re-append
+        the custom certs on each call, growing unbounded.
+        """
+        cert_dir = tmp_path / "ssl"
+        cert_dir.mkdir()
+        (cert_dir / "corp-ca.pem").write_text("CORP\n")
+        monkeypatch.setenv("KLANGK_SSL_CERT_DIR", str(cert_dir))
+        monkeypatch.setattr(
+            ssl_trust,
+            "_system_ca_bundle",
+            lambda self_bundle=None: str(tmp_path / "sys.pem"),
+        )
+        (tmp_path / "sys.pem").write_text("SYSTEM\n")
+        monkeypatch.setenv("KLANGK_DATA_DIR", str(tmp_path / "data"))
+
+        ssl_trust.apply_backend_ssl_trust()
+        first = os.environ["SSL_CERT_FILE"]
+        size_after_first = os.path.getsize(first)
+        contents_after_first = open(first).read()
+
+        ssl_trust.apply_backend_ssl_trust()
+        second = os.environ["SSL_CERT_FILE"]
+        assert second == first
+        assert os.path.getsize(second) == size_after_first
+        assert open(second).read() == contents_after_first  # no duplication
+
+    def test_custom_cert_missing_system_bundle_warns(
+        self, monkeypatch, tmp_path, caplog
+    ):
+        """When no system bundle is available we warn (public-internet risk)."""
+        cert_dir = tmp_path / "ssl"
+        cert_dir.mkdir()
+        (cert_dir / "corp-ca.pem").write_text("CORP\n")
+        monkeypatch.setenv("KLANGK_SSL_CERT_DIR", str(cert_dir))
+        monkeypatch.setattr(ssl_trust, "_system_ca_bundle", lambda **kw: None)
+        monkeypatch.setenv("KLANGK_DATA_DIR", str(tmp_path / "data"))
+
+        with caplog.at_level(logging.WARNING):
+            ssl_trust.apply_backend_ssl_trust()
+        # Still applied (custom certs present), but warned about system loss.
+        assert os.environ["SSL_CERT_FILE"]
+        assert any("system bundle" in r.message for r in caplog.records)
+
+
+class TestSystemCaBundle:
+    """_system_ca_bundle() resolution, fallback chain, and self-reference guard."""
+
+    def test_real_host_bundle_resolves(self):
+        # Real call: openssl_cafile resolves to a file on the test host (or
+        # certifi fallback). Never raises; result is an existing file or None.
+        got = ssl_trust._system_ca_bundle()
+        assert got is None or os.path.isfile(got)
+
+    @staticmethod
+    def _dvp(cafile, openssl_cafile):
+        return ssl.DefaultVerifyPaths(
+            cafile=cafile,
+            capath=None,
+            openssl_cafile_env="SSL_CERT_FILE",
+            openssl_cafile=openssl_cafile,
+            openssl_capath_env="SSL_CERT_DIR",
+            openssl_capath="",
+        )
+
+    def test_distinct_cafile_candidate_used(self, monkeypatch, tmp_path):
+        sys_pem = tmp_path / "sys.pem"
+        sys_pem.write_text("SYS")
+        # openssl_cafile empty; distinct cafile present and readable.
+        monkeypatch.setattr(
+            ssl_trust.ssl,
+            "get_default_verify_paths",
+            lambda: self._dvp(str(sys_pem), ""),
+        )
+        assert ssl_trust._system_ca_bundle() == str(sys_pem)
+
+    def test_certifi_fallback_when_no_candidates(self, monkeypatch):
+        import certifi
+
+        monkeypatch.setattr(
+            ssl_trust.ssl,
+            "get_default_verify_paths",
+            lambda: self._dvp("", ""),
+        )
+        assert ssl_trust._system_ca_bundle() == certifi.where()
+
+    def test_none_when_no_candidates_and_certifi_missing_file(
+        self, monkeypatch
+    ):
+        # No default-path candidates, and certifi.where() points at a file
+        # that doesn't exist -> no resolvable system bundle.
+        monkeypatch.setattr(
+            ssl_trust.ssl,
+            "get_default_verify_paths",
+            lambda: self._dvp("", ""),
+        )
+        monkeypatch.setattr(
+            ssl_trust,
+            "certifi",
+            types.SimpleNamespace(where=lambda: "/no/such/cacert.pem"),
+        )
+        assert ssl_trust._system_ca_bundle() is None
+
+    def test_skips_self_reference(self, monkeypatch, tmp_path):
+        me = tmp_path / "me.crt"
+        me.write_text("ME")
+        # The only candidate equals self_bundle -> skipped -> certifi fallback.
+        monkeypatch.setattr(
+            ssl_trust.ssl,
+            "get_default_verify_paths",
+            lambda: self._dvp(str(me), str(me)),
+        )
+        assert ssl_trust._system_ca_bundle(self_bundle=str(me)) != str(me)
+
+
+class TestInternalsAndErrorBranches:
+    """Cover defensive error branches for full line coverage."""
+
+    def test_iter_cert_files_oserror(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            ssl_trust.os,
+            "listdir",
+            lambda p: (_ for _ in ()).throw(OSError("denied")),
+        )
+        assert list(ssl_trust._iter_cert_files(str(tmp_path))) == []
+
+    def test_write_skips_unreadable_system_bundle(self, monkeypatch, tmp_path):
+        cert_dir = tmp_path / "ssl"
+        cert_dir.mkdir()
+        (cert_dir / "corp.pem").write_text("CORP\n")
+        monkeypatch.setattr(
+            ssl_trust,
+            "_system_ca_bundle",
+            lambda self_bundle=None: "/no/such/sys.pem",
+        )
+        out = tmp_path / "bundle.crt"
+        ok = ssl_trust._write_merged_bundle(str(out), str(cert_dir))
+        assert ok is True
+        assert open(out).read() == "CORP\n"  # system skipped, custom kept
+
+    def test_write_empty_when_cert_unreadable(self, monkeypatch, tmp_path):
+        out = tmp_path / "bundle.crt"
+        monkeypatch.setattr(
+            ssl_trust, "_iter_cert_files", lambda d: ["/no/such/cert.pem"]
+        )
+        monkeypatch.setattr(
+            ssl_trust, "_system_ca_bundle", lambda self_bundle=None: None
+        )
+        assert ssl_trust._write_merged_bundle(str(out), str(tmp_path)) is False
+
+    def test_apply_returns_none_when_makedirs_fails(
+        self, monkeypatch, tmp_path
+    ):
+        cert_dir = tmp_path / "ssl"
+        cert_dir.mkdir()
+        (cert_dir / "c.pem").write_text("C")
+        monkeypatch.setenv("KLANGK_SSL_CERT_DIR", str(cert_dir))
+        monkeypatch.setenv("KLANGK_DATA_DIR", str(tmp_path / "data"))
+        monkeypatch.setattr(
+            ssl_trust.os,
+            "makedirs",
+            lambda *a, **k: (_ for _ in ()).throw(OSError("nope")),
+        )
+        assert ssl_trust.apply_backend_ssl_trust() is None
+
+    def test_apply_warns_on_empty_bundle(self, monkeypatch, tmp_path, caplog):
+        cert_dir = tmp_path / "ssl"
+        cert_dir.mkdir()
+        monkeypatch.setenv("KLANGK_SSL_CERT_DIR", str(cert_dir))
+        monkeypatch.setenv("KLANGK_DATA_DIR", str(tmp_path / "data"))
+        monkeypatch.setattr(
+            ssl_trust, "_system_ca_bundle", lambda self_bundle=None: None
+        )
+        monkeypatch.setattr(
+            ssl_trust, "_iter_cert_files", lambda d: ["/nope/cert.pem"]
+        )
+        with caplog.at_level(logging.WARNING):
+            assert ssl_trust.apply_backend_ssl_trust() is None
+        assert any("empty" in r.message for r in caplog.records)

--- a/src/containers/workspace/entrypoint.sh
+++ b/src/containers/workspace/entrypoint.sh
@@ -22,6 +22,35 @@ done
 # Create the workspace token directory.
 mkdir -p /tmp/klangk
 
+# Build the CA bundle from mounted deployer certs (runtime trust
+# injection, #1181). The backend mounts KLANGK_SSL_CERT_DIR read-only
+# at /opt/klangk/ssl when it contains .pem/.crt CAs, and sets
+# SSL_CERT_FILE / REQUESTS_CA_BUNDLE / CURL_CA_BUNDLE /
+# NODE_EXTRA_CA_CERTS to point at this bundle. Those vars REPLACE the
+# default trust store, so the bundle must contain the system CAs too --
+# a custom-only bundle would break public-internet TLS (npm/pip/git).
+# Concatenate system bundle first, then custom certs, on the writable
+# /tmp tmpfs (the entrypoint runs as non-root UID 1000). Built BEFORE
+# the readiness sentinel so every later process -- shells, podman exec,
+# the agent subprocess -- finds it present. POSIX-sh under `set -e`:
+# use an explicit `if` so an unmatched glob doesn't abort the script.
+if [ -d /opt/klangk/ssl ]; then
+  bundle=/tmp/klangk/ca-bundle.crt
+  : >"$bundle"
+  # System CAs first (preserve public-internet trust).
+  if [ -f /etc/ssl/certs/ca-certificates.crt ]; then
+    cat /etc/ssl/certs/ca-certificates.crt >>"$bundle"
+  fi
+  for f in /opt/klangk/ssl/*.pem /opt/klangk/ssl/*.crt; do
+    if [ -f "$f" ]; then
+      cat "$f" >>"$bundle"
+    fi
+  done
+  if [ ! -s "$bundle" ]; then
+    rm -f "$bundle"
+  fi
+fi
+
 # Signal that the entrypoint's one-time setup is done. The backend polls
 # this sentinel (podman.wait_for_container_ready) before reporting the
 # container as ready, so every consumer — terminals, exec, agent, health


### PR DESCRIPTION
## Summary

Closes #1181. Lets a deployer drop `.pem`/`.crt` CA certificates into `KLANGK_SSL_CERT_DIR` and have them trusted at startup **with no image rebuild**, covering **both** trust scopes flagged in the issue's open question #1:

1. **Workspace containers** — the cert dir is bind-mounted read-only at `/opt/klangk/ssl`; the container entrypoint builds a merged CA bundle (system CAs + custom certs) on the writable `/tmp` tmpfs, and the toolchain trust env vars (`SSL_CERT_FILE`, `REQUESTS_CA_BUNDLE`, `CURL_CA_BUNDLE`, `NODE_EXTRA_CA_CERTS`) point OpenSSL / Python / curl / Node at it. Applies to shells, `podman exec`, and the agent subprocess alike.
2. **Backend process** — `ssl_trust.apply_backend_ssl_trust()` builds a host-side merged bundle under `<data_dir>/ssl` and sets the same trust vars at startup (before any outbound TLS), so OIDC discovery, SMTP relay, and the LLM-proxy upstream honor private CAs too.

### Key design decision: merged bundles, not custom-only

The `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE` / `CURL_CA_BUNDLE` variables **replace** the default trust store rather than augment it, so a custom-only bundle would break public-internet TLS (`npm`/`pip`/`git`, public OIDC, gmail SMTP). I verified this empirically against stdlib `ssl` and `httpx`: setting `SSL_CERT_FILE` to a custom-only bundle drops `get_ca_certs()` from 168 → 1. Both bundles therefore **prepend the system CAs** before the custom certs. (`NODE_EXTRA_CA_CERTS` is additive, but pointing it at the merged bundle is harmless — Node de-duplicates.)

### What's where

- **New module `klangk_backend/ssl_trust.py`** — owns detection (`ssl_cert_dir`), container env vars (`ssl_env_vars`), mount/bundle path constants, and the backend-process trust path (`apply_backend_ssl_trust`). `container.py` re-exports the two helpers it needs.
- **`container.py`** — `_build_env` / `_build_mounts` thread `ssl_dir` through; emit the trust vars + the read-only bind mount.
- **`main.py`** — calls `ssl_trust.apply_backend_ssl_trust()` at the top of `lifespan`, before any outbound TLS.
- **`entrypoint.sh`** — builds the in-container merged bundle (system first, then custom) before the readiness sentinel, so every later process finds it.

The build-time `KLANGK_SSL_CERT_DIR` path (`customize/ssl` → `update-ca-certificates`) remains available; the runtime path is additive. Rotating a cert is a file change + restart — no rebuild.

## Acceptance criteria (from issue)

- [x] Deployer places a CA `.pem` in the configured dir; a freshly started workspace container trusts TLS endpoints signed by that CA with no image rebuild (system+custom merged bundle; trust vars point at it).
- [x] Trust applies to shells, `podman exec`, and the agent subprocess (env vars set at container create; agent is `podman exec pi`, inherits container env).
- [x] Rotating a cert and restarting the container picks up the new trust root (mount is read of the live dir; entrypoint rebuilds the bundle each start).
- [x] Build-time `KLANGK_SSL_CERT_DIR` path still works (additive change).
- [x] Documented in `docs/deployment/customizing.md` + `.env.example`.
- [x] Resolved open question #1: the backend process **also** consumes the same bundle via its own merged-bundle path.

## Test plan

- Backend: **2077 tests pass, 100% coverage** (incl. new `test_ssl_trust.py` covering the resolver, merged-bundle semantics, idempotent re-entry, error branches, and the self-reference guard; `test_container.py` covers the mount + env-var integration).
- Pre-commit: all hooks green (deferred-imports, ruff, shellcheck, shfmt, markdownlint, prettier, trufflehog).

## Notes

- `certifi` is a hard dependency (ships with `httpx`, which `oidc.py` already imports at module level), so it's a plain top-level import — no `try/except ImportError`.
- The `_system_ca_bundle` resolver prefers the compiled-in `openssl_cafile` over `cafile` and skips any candidate equal to the bundle it just wrote, so idempotent re-entry (lifespan re-entry / tests) doesn't append the custom certs a second time.
