### PR TITLE
Render chat URLs (incl. hosted-app URLs) as clickable links

### DIFF
--- a/src/frontend/lib/chat/chat_message_list.dart
+++ b/src/frontend/lib/chat/chat_message_list.dart
@@ -241,15 +241,12 @@ class ChatMessageList extends StatelessWidget {
         MarkdownBody(
           data: highlightMentions(text),
           selectable: true,
-          extensionSet: md.ExtensionSet(
-            md.ExtensionSet.gitHubWeb.blockSyntaxes,
-            [
-              ...md.ExtensionSet.gitHubWeb.inlineSyntaxes.where(
-                (s) =>
-                    s is! md.AutolinkSyntax && s is! md.AutolinkExtensionSyntax,
-              ),
-            ],
-          ),
+          // Use the full GitHub Web extension set so bare URLs (including
+          // hosted-app URLs) auto-link via AutolinkExtensionSyntax, routing
+          // taps through the onTapLink handler below. Previously the
+          // autolink syntaxes were filtered out, which left URLs as plain
+          // text. See #1200.
+          extensionSet: md.ExtensionSet.gitHubWeb,
           styleSheet: chatMarkdownStyle(context),
           // coverage:ignore-start
           onTapLink: (text, href, title) {

--- a/src/frontend/test/chat_message_list_test.dart
+++ b/src/frontend/test/chat_message_list_test.dart
@@ -2,12 +2,21 @@ import 'package:flutter/material.dart';
 import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:klangk_frontend/chat/chat_message_list.dart';
+import 'package:markdown/markdown.dart' as md;
 
 String? _findMarkdownData(WidgetTester tester) {
   final finder = find.byType(MarkdownBody);
   if (finder.evaluate().isEmpty) return null;
   final widget = tester.widget<MarkdownBody>(finder.first);
   return widget.data;
+}
+
+/// The inline syntax set the rendered [MarkdownBody] was configured with.
+/// Used to assert that bare URLs auto-link (#1200).
+List<md.InlineSyntax> _findMarkdownInlineSyntaxes(WidgetTester tester) {
+  final finder = find.byType(MarkdownBody);
+  final widget = tester.widget<MarkdownBody>(finder.first);
+  return widget.extensionSet?.inlineSyntaxes ?? const [];
 }
 
 void main() {
@@ -241,6 +250,45 @@ void main() {
 
       final data = _findMarkdownData(tester);
       expect(data, contains('**@bob**'));
+    });
+
+    testWidgets('bare http(s) URLs auto-link (#1200)', (tester) async {
+      await tester.pumpWidget(buildList(messages: [
+        {
+          'id': 'msg-url',
+          'user_email': 'alice@test.com',
+          'message': 'see https://example.com and http://foo.dev/path',
+          'created_at': '2026-01-01 00:00:00',
+        },
+      ]));
+
+      // The rendered MarkdownBody must be configured with the GFM autolink
+      // extension syntax so bare URLs become link nodes that route through
+      // onTapLink -> openUrl. Previously these syntaxes were filtered out.
+      final syntaxes = _findMarkdownInlineSyntaxes(tester);
+      expect(
+        syntaxes.any((s) => s is md.AutolinkExtensionSyntax),
+        isTrue,
+        reason: 'GFM bare-URL autolinking must be enabled',
+      );
+    });
+
+    testWidgets('hosted-app URLs auto-link (#1200)', (tester) async {
+      await tester.pumpWidget(buildList(messages: [
+        {
+          'id': 'msg-hosted',
+          'user_email': 'alice@test.com',
+          // Emits by clanker's klangk-hosted-url: a relative /hosted/... URL.
+          'message': 'app ready: https://klangk.dev/hosted/ws-1/8080/',
+          'created_at': '2026-01-01 00:00:00',
+        },
+      ]));
+
+      final syntaxes = _findMarkdownInlineSyntaxes(tester);
+      expect(
+        syntaxes.any((s) => s is md.AutolinkExtensionSyntax),
+        isTrue,
+      );
     });
 
     testWidgets('loading spinner shown when loadingOlder is true',


### PR DESCRIPTION
## Summary

Chat message bodies render bare URLs — including the `/hosted/...` URLs clanker emits — as plain text instead of clickable links. The tap-to-open handler was already wired; only autolinking was disabled. This restores it.

## Root cause

`src/frontend/lib/chat/chat_message_list.dart` rendered chat via `MarkdownBody` with a hand-rolled `ExtensionSet` that explicitly filtered **out** the GFM autolink syntaxes:

```dart
extensionSet: md.ExtensionSet(
  md.ExtensionSet.gitHubWeb.blockSyntaxes,
  [
    ...md.ExtensionSet.gitHubWeb.inlineSyntaxes.where(
      (s) => s is! md.AutolinkSyntax && s is! md.AutolinkExtensionSyntax,
    ),
  ],
),
```

So a bare `https://…` URL never became a link node, and the already-present `onTapLink` → `openUrl(href)` → `window.open('_blank')` path never fired. The filter was introduced incidentally in #1003 (widget extraction) with no rationale.

## Fix

Replace the custom `ExtensionSet` with the standard `md.ExtensionSet.gitHubWeb`, which restores GFM bare-URL autolinking via `AutolinkExtensionSyntax`. Links continue to route through the **existing** `onTapLink` handler, so:

- **Web:** clicking opens in a new browser tab (`openUrl` → `window.open(url, '_blank')`).
- **Non-web stub:** no-op (unchanged behavior).

```diff
-          extensionSet: md.ExtensionSet(
-            md.ExtensionSet.gitHubWeb.blockSyntaxes,
-            [
-              ...md.ExtensionSet.gitHubWeb.inlineSyntaxes.where(
-                (s) =>
-                    s is! md.AutolinkSyntax && s is! md.AutolinkExtensionSyntax,
-              ),
-            ],
-          ),
+          extensionSet: md.ExtensionSet.gitHubWeb,
```

No changes to the tap handler, `openUrl`, or the hosted-apps URL plumbing — those already worked; they were just unreachable because the link nodes were never produced.

## Test plan

- [x] Added two tests in `chat_message_list_test.dart` asserting the rendered `MarkdownBody`'s inline syntax set includes `AutolinkExtensionSyntax` for (a) plain `http(s)://` URLs and (b) hosted-app `/hosted/...` URLs.
- [x] Full frontend suite: **866 passed at 100% coverage**.
- [x] `dart analyze` clean.
- [x] Existing `@mention`-as-bold, markdown-rendering, and link tests still pass.

Closes #1200.
