### PR TITLE
Add 1080p CLI terminal recorder for the intro video

### DIFF
--- a/demo/.gitignore
+++ b/demo/.gitignore
@@ -1,0 +1,5 @@
+# Output recordings (re-take artifacts, never committed).
+recordings/
+# Python bytecode.
+__pycache__/
+*.pyc

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,140 @@
+# Klangk intro video — CLI terminal recorder
+
+A reproducible, re-takeable recorder for the **CLI/terminal scenes** of the
+klangk intro video (#1082). It scripts a real terminal — `klangkc login`,
+`klangkc create`, `klangkc shell`, `klangkc sandbox`, `git clone`,
+`klangkc monitor`, … — and captures it as a **true 1080p** `.mp4`, with no
+manual recording.
+
+This is the terminal half of the intro-video tooling. The web-UI scenes are
+driven separately by the Playwright harness (`src/frontend/e2e-tests/demo/`,
+WIP); this directory handles what Playwright can't — an interactive shell.
+
+```text
+record-terminal.sh   # Xvfb + xterm + tmux + ffmpeg recorder harness
+cli_demo.py          # stdlib-only Python "expect" driver + the scenes
+README.md            # this file
+recordings/          # output .mp4 files (gitignored)
+```
+
+## Quick start
+
+From the worktree root (no devenv wrapper needed — the tools are on the system
+PATH on NixOS):
+
+```bash
+# Built-in smoke-test scene — NO klangk server required:
+./demo/record-terminal.sh python3 demo/cli_demo.py --scene demo
+
+# A real CLI scene against a live server (start klangk on :8995 first):
+./demo/record-terminal.sh python3 demo/cli_demo.py --scene scene_2
+```
+
+You'll get `demo/recordings/recording-<timestamp>.mp4` at 1920×1080. Re-run a
+scene until you like the take; edit the `.mp4`s together (and voice over) in
+DaVinci Resolve.
+
+## How it works
+
+The recorder **decouples _driving_ the terminal from _recording_ it** — the
+same insight the web-UI harness uses to beat Playwright's ~800×450 video cap.
+Four layers:
+
+1. **Xvfb** — a virtual X display at the canvas size you ask for (default
+   1920×1080).
+2. **xterm** — a real terminal emulator on that display, big legible font
+   (default _DejaVu Sans Mono_ 22 pt, black background), attached to a tmux
+   session.
+3. **tmux** — owns the pty. xterm _displays_ the session; the driver _writes_
+   to it (`send-keys`) and reads it (`capture-pane`). It's also the persistence
+   layer (`klangkc shell` is tmux-backed, so this matches the real UX).
+4. **ffmpeg** (`x11grab`) — captures the whole Xvfb display into a true
+   full-resolution `.mp4`.
+
+The driver (`cli_demo.py`) then scripts the scene: typing commands (optionally
+one character at a time for a "live typing" look), pressing Enter, and waiting
+for expected output before continuing.
+
+## Why not pexpect? (driver rationale)
+
+The plan (#1201) suggested _pyexpect_ (pexpect) as the driver. It's the right
+**idea** — an expect-style loop of _send a command, wait for output, respond_ —
+but it can't drive a **displayed** terminal:
+
+> `pexpect.spawn()` takes the **master** side of the pty it creates. A terminal
+> emulator (xterm) must _itself_ be the pty master to render the session. You
+> can't have both pexpect and xterm as master of the same pty — so if pexpect
+> owns it, xterm has nothing to attach to and nothing is ever drawn to the
+> screen that ffmpeg captures.
+
+For a _headless_ expect loop (drive a CLI, scrape its output) pexpect is ideal,
+and that's exactly how `klangkc`'s own e2e tests drive the CLI elsewhere. But a
+demo video needs the terminal **rendered**. That needs a pty multiplexer in the
+middle: one client renders it (xterm → Xvfb → ffmpeg) while another scripts
+it. **tmux is that multiplexer**, and its `send-keys`/`capture-pane` pair gives
+the same `send`/`expect` primitives pexpect provides — without taking the pty
+hostage.
+
+So the driver is a **stdlib-only** Python script (no `pexpect`, no `pip install`
+— runs on any `python3`) that implements an expect-style `Term` class on
+`tmux send-keys`/`capture-pane`. This was verified empirically: pexpect drove a
+shell headless just fine, but no terminal emulator could render that session.
+
+## Writing a scene
+
+A scene is a function `scene_<name>(t: Term)` in `cli_demo.py`. The `Term` API:
+
+| Method                               | Effect                                             |
+| ------------------------------------ | -------------------------------------------------- |
+| `t.type(text, per_char=0.03)`        | type text (typewriter effect with `per_char`)      |
+| `t.enter()`                          | press Enter                                        |
+| `t.run(cmd, expect="$", timeout=30)` | type a command + Enter, then wait for `expect`     |
+| `t.expect(text, timeout=30)`         | block until `text` appears in the pane             |
+| `t.pause(seconds)`                   | hold for a beat (let output land / read on camera) |
+| `t.clear()`                          | clear the screen                                   |
+
+Register it in the `SCENES` dict and run it with `--scene <name>`. The built-in
+`demo` scene is a no-server smoke test — copy it as a template. `scene_2` /
+`scene_3` / `scene_4` are skeletons for the real intro-video CLI scenes (they
+need a live server); flesh them out against your demo server.
+
+Tips for a scene that reads well on camera:
+
+- **Typewriter the commands** (`per_char≈0.02–0.04`) so viewers see them being
+  typed, but **paste bulky output** by letting commands run normally.
+- **`--key-delay`** (pause after each Enter) avoids a blurred machine-gun look.
+- Set `KLANGK_DEMO_FONT_SIZE` higher (e.g. `28`) if the text is too small.
+- Drive flaky/async things (a service coming up) with `t.expect(..., timeout=)`
+  so the take doesn't race.
+
+## Knobs (env vars)
+
+| Variable                   | Default                              | Effect                        |
+| -------------------------- | ------------------------------------ | ----------------------------- |
+| `KLANGK_DEMO_WIDTH`        | `1920`                               | canvas width (px)             |
+| `KLANGK_DEMO_HEIGHT`       | `1080`                               | canvas height (px)            |
+| `KLANGK_DEMO_FONT`         | `DejaVu Sans Mono`                   | xterm font family             |
+| `KLANGK_DEMO_FONT_SIZE`    | `22`                                 | terminal font size (pt)       |
+| `KLANGK_DEMO_FPS`          | `30`                                 | capture framerate             |
+| `KLANGK_DEMO_CRF`          | `20`                                 | x264 quality (lower = better) |
+| `KLANGK_DEMO_DISPLAY`      | `97`                                 | Xvfb display number           |
+| `KLANGK_DEMO_TMUX_SESSION` | `klangk-demo`                        | tmux session name             |
+| `KLANGK_DEMO_OUTPUT`       | `demo/recordings/recording-<ts>.mp4` | output path                   |
+| `KLANGK_DEMO_PROMPT`       | `klangk$` (colored)                  | `PS1` for the session shell   |
+| `KLANGK_DEMO_TYPEWRITER`   | `0`                                  | default per-char delay (s)    |
+| `KLANGK_DEMO_KEY_DELAY`    | `0.4`                                | default pause after Enter (s) |
+
+## Requirements
+
+All present on NixOS / via devenv (no installs needed): `Xvfb`, `xterm`,
+`tmux`, `ffmpeg`, `ffprobe`, `xdotool`. The driver needs only `python3`
+(stdlib). For higher resolution, set `KLANGK_DEMO_WIDTH`/`HEIGHT` (e.g. `2560`
+`1440` for 1440p).
+
+## Related
+
+- **#1082** — the intro-video umbrella this belongs to.
+- **#1201** — the issue this tool closes.
+- `src/frontend/e2e-tests/demo/record-demo.sh` (WIP) — the analogous
+  Xvfb+ffmpeg recorder for the **web-UI** scenes; this directory mirrors its
+  "decouple driving from recording" approach for the terminal.

--- a/demo/cli_demo.py
+++ b/demo/cli_demo.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""Expect-style driver for scripted CLI demo scenes (records to 1080p via
+``record-terminal.sh``).
+
+This is the "pyexpect" the intro-video plan called for — a Python driver that
+drives a terminal the way ``pexpect`` drives a headless pty — implemented on
+``tmux send-keys`` / ``capture-pane`` instead of on a raw pty.
+
+Why not pexpect directly?
+    ``pexpect.spawn()`` takes the **master** side of the pty it creates, so it
+    can read/write the child process — but then **no terminal emulator can
+    render that session live**, because a terminal emulator must itself be the
+    pty master. For a *displayed* terminal recording you need a layer that
+    multiplexes the pty: one client renders it (xterm, on the Xvfb display
+    that ffmpeg captures) while another scripts it. ``tmux`` is exactly that
+    layer, and its ``send-keys``/``capture-pane`` pair gives the same
+    ``send``/``expect`` primitives pexpect provides — without taking the pty
+    hostage. (Verified empirically; see the README.) The driver below is
+    therefore **stdlib-only**: no ``pexpect``, no ``pip install``, runs on any
+    ``python3``.
+
+Scenes
+    Each scene is a function ``scene_<name>(t: Term)``. The driver calls
+    ``tmux send-keys``/``capture-pane`` against ``$KLANGK_DEMO_TMUX_SESSION``
+    (set by ``record-terminal.sh``). Run a scene with ``--scene <name>``.
+
+    The built-in ``demo`` scene needs **no klangk server** — it's a
+    self-contained smoke test so the recorder is verifiable anywhere. The
+    ``scene_2`` / ``scene_3`` / ``scene_4`` stubs drive the real ``klangkc``
+    CLI and require a live server (see ``README.md``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import time
+from typing import Callable
+
+
+class TimeoutError_(Exception):
+    """Raised when ``expect()`` does not see its text in time."""
+
+
+class Term:
+    """Drive a tmux session with expect-style primitives.
+
+    Wraps ``tmux send-keys`` (write) and ``tmux capture-pane`` (read) against a
+    named session. Designed to be driven by ``record-terminal.sh``, which
+    creates the session, attaches xterm to it, and records the Xvfb display.
+    """
+
+    def __init__(
+        self,
+        session: str | None = None,
+        *,
+        typewriter: float = 0.0,
+        key_delay: float = 0.0,
+    ) -> None:
+        self.session = session or os.environ.get(
+            "KLANGK_DEMO_TMUX_SESSION", "klangk-demo"
+        )
+        # typewriter: per-character delay when type()-ing (a "live typing"
+        #   look reads much better on camera than an instant paste).
+        # key_delay: pause after each Enter (lets output land before the next
+        #   command, avoids a blurred machine-gun look).
+        self.typewriter = typewriter
+        self.key_delay = key_delay
+
+    # -- low level ----------------------------------------------------------
+    def _send(self, text: str) -> None:
+        # -l = literal: do not interpret text as tmux key names (so '$', ';',
+        # etc. are typed as-is).
+        subprocess.run(
+            ["tmux", "send-keys", "-t", self.session, "-l", text],
+            check=True,
+        )
+
+    def _enter(self) -> None:
+        subprocess.run(["tmux", "send-keys", "-t", self.session, "Enter"], check=True)
+
+    def pane(self, *, lines: int = 50) -> str:
+        """Current visible pane contents (for ``expect`` matching)."""
+        res = subprocess.run(
+            [
+                "tmux",
+                "capture-pane",
+                "-t",
+                self.session,
+                "-p",
+                "-S",
+                f"-{lines}",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return res.stdout
+
+    # -- high level (the "expect" API) -------------------------------------
+    def type(self, text: str, *, per_char: float | None = None) -> None:
+        """Type text, optionally one character at a time (typewriter effect)."""
+        delay = self.typewriter if per_char is None else per_char
+        if delay <= 0:
+            self._send(text)
+            return
+        for ch in text:
+            self._send(ch)
+            time.sleep(delay)
+
+    def enter(self) -> None:
+        self._enter()
+        if self.key_delay:
+            time.sleep(self.key_delay)
+
+    def run(
+        self,
+        cmd: str,
+        *,
+        expect: str | None = None,
+        timeout: float = 30.0,
+    ) -> str:
+        """Type a command, press Enter, optionally wait for ``expect`` text."""
+        self.type(cmd)
+        self.enter()
+        if expect is not None:
+            return self.expect(expect, timeout=timeout)
+        return ""
+
+    def expect(
+        self,
+        text: str,
+        *,
+        timeout: float = 30.0,
+        poll: float = 0.15,
+    ) -> str:
+        """Block until ``text`` appears in the pane; return the pane text."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            pane = self.pane()
+            if text in pane:
+                return pane
+            time.sleep(poll)
+        raise TimeoutError_(
+            f"timed out after {timeout:.0f}s waiting for {text!r} in tmux "
+            f"session {self.session!r}"
+        )
+
+    def pause(self, seconds: float) -> None:
+        time.sleep(seconds)
+
+    def clear(self) -> None:
+        self.run("clear")
+
+
+# --------------------------------------------------------------------------
+# Scenes
+# --------------------------------------------------------------------------
+
+
+def _intro(t: Term, title: str) -> None:
+    """A small on-screen title card (pure ANSI, no server needed)."""
+    t.run(
+        'printf "\\033[2J\\033[H"',  # clear + home
+        expect="$",
+    )
+    t.run(
+        f'printf "\\033[1;36m# {title}\\033[0m\\n"',
+        expect="$",
+    )
+    t.pause(0.8)
+
+
+def scene_demo(t: Term) -> None:
+    """Self-contained scene — no klangk server required.
+
+    Exercises everything the recorder needs to prove: typing, multi-line
+    output, color, a short loop with sleeps, and a clean ending. Use it as the
+    smoke test for the recorder and as a copy-paste template for real scenes.
+    """
+    _intro(t, "Klangk demo recorder — smoke test")
+
+    t.run('echo "This terminal is being scripted and recorded at 1080p."')
+    t.pause(0.6)
+
+    # Typewriter effect for a command that "reads" well on camera.
+    t.type("for i in $(seq 1 3)", per_char=0.03)
+    t.enter()
+    t.type(
+        "  do printf '\\033[33mline %d: hello world\\033[0m\\n' \"$i\"", per_char=0.02
+    )
+    t.enter()
+    t.type("  sleep 0.5", per_char=0.03)
+    t.enter()
+    t.type("done", per_char=0.03)
+    t.enter()
+    t.expect("line 3: hello world", timeout=10)
+    t.pause(0.8)
+
+    t.run('printf "\n\033[32m\u2713 done\033[0m — edit this in DaVinci Resolve.\n"')
+    t.pause(1.2)
+
+
+def scene_2(t: Term) -> None:
+    """CLI: Creating Your First Workspace (~2 min).
+
+    Requires a live klangk server reachable by ``klangkc`` (see README). This
+    is a starting skeleton — adjust emails/names/repo to your demo.
+    """
+    admin = os.environ.get("KLANGK_DEFAULT_USER", "admin@example.com")
+    _intro(t, "The CLI — creating your first workspace")
+
+    t.type("klangkc login ", per_char=0.03)
+    t.type(admin, per_char=0.04)
+    t.enter()
+    # klangkc login prompts for a password (no echo). Type it via the driver.
+    t.expect("assword", timeout=15)
+    t.type(os.environ.get("KLANGK_DEMO_ADMIN_PASSWORD", "admin"))
+    t.enter()
+    t.expect("$", timeout=15)
+    t.pause(0.6)
+
+    t.run("klangkc create demo", expect="$", timeout=20)
+    t.pause(0.5)
+
+    t.run("klangkc shell demo", expect="$", timeout=30)
+    t.pause(0.8)
+    t.run('echo "I\'m in a real bash shell, backed by tmux."', expect="$")
+    t.pause(0.8)
+    t.run("exit", expect="$", timeout=10)
+
+    t.run("klangkc rm demo", expect="$", timeout=20)
+    t.pause(1.0)
+
+
+def scene_3(t: Term) -> None:
+    """klangkc sandbox: one command to rule them all (~1.5 min).
+
+    Requires a live server. Skeleton — point at a real project dir.
+    """
+    _intro(t, "klangkc sandbox — one command")
+    t.run("cd ~/projects/myproject", expect="$")
+    t.run("klangkc sandbox myproject -A", expect="$", timeout=120)
+    t.pause(1.0)
+
+
+def scene_4(t: Term) -> None:
+    """openclaw service sandbox (~1.5 min). Requires a live server."""
+    _intro(t, "A long-lived service: openclaw")
+    t.run("cd sandboxes/openclaw", expect="$")
+    t.run("klangkc sandbox openclaw", expect="$", timeout=180)
+    t.pause(1.0)
+    t.run("klangkc monitor --type service_health | jq .", expect="$", timeout=20)
+    t.pause(1.0)
+
+
+SCENES: dict[str, Callable[[Term], None]] = {
+    "demo": scene_demo,
+    "scene_2": scene_2,
+    "scene_3": scene_3,
+    "scene_4": scene_4,
+}
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Drive a scripted CLI terminal scene (for record-terminal.sh)."
+    )
+    ap.add_argument(
+        "--scene",
+        required=True,
+        choices=sorted(SCENES),
+        help="scene to run (use 'demo' for a no-server smoke test)",
+    )
+    ap.add_argument(
+        "--session",
+        default=os.environ.get("KLANGK_DEMO_TMUX_SESSION", "klangk-demo"),
+        help="tmux session to drive (default: $KLANGK_DEMO_TMUX_SESSION)",
+    )
+    ap.add_argument(
+        "--typewriter",
+        type=float,
+        default=float(os.environ.get("KLANGK_DEMO_TYPEWRITER", "0")),
+        help="per-character delay (s) for the typewriter effect",
+    )
+    ap.add_argument(
+        "--key-delay",
+        type=float,
+        default=float(os.environ.get("KLANGK_DEMO_KEY_DELAY", "0.4")),
+        help="pause (s) after each Enter",
+    )
+    args = ap.parse_args(argv)
+
+    if not shutil.which("tmux"):
+        print("error: tmux not found on PATH", file=sys.stderr)
+        return 2
+
+    t = Term(
+        args.session,
+        typewriter=args.typewriter,
+        key_delay=args.key_delay,
+    )
+    print(
+        f"=== driving scene {args.scene!r} on tmux session {args.session!r} ===",
+        flush=True,
+    )
+    try:
+        SCENES[args.scene](t)
+    except TimeoutError_ as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    print("=== scene complete ===", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/demo/record-terminal.sh
+++ b/demo/record-terminal.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# Full-resolution (≥1080p) recorder for a SCRIPTED terminal session.
+#
+# Playwright's built-in `video` caps browser recordings; for a *terminal*
+# there is no equivalent at all. This script decouples *driving* the terminal
+# (your driver script: cli_demo.py) from *recording* it (ffmpeg capturing an
+# Xvfb virtual display), so the output is a true full-resolution .mp4.
+#
+# Pipeline:
+#   1. Xvfb          — a virtual X display at the canvas size you ask for
+#   2. xterm         — a real terminal emulator on that display (big font),
+#                      attached to a tmux session
+#   3. tmux          — owns the pty; xterm *displays* it, the driver *writes*
+#                      to it via `send-keys` and reads it via `capture-pane`
+#   4. ffmpeg        — captures the whole Xvfb display → true-resolution .mp4
+#   5. your driver   — types the scene into the tmux session
+#
+# Why tmux and not pexpect? pexpect.spawn() takes the pty *master*, so no
+# terminal emulator can render that session live (xterm would need to be the
+# master). tmux multiplexes the pty: xterm renders it to the screen while the
+# driver scripts it. See README.md "Why not pexpect?" for the full rationale.
+#
+# Usage (from the worktree root, wrapped in devenv):
+#   # Run the built-in self-contained demo scene (no klangk server needed):
+#   devenv shell -- demo/record-terminal.sh python3 demo/cli_demo.py --scene demo
+#
+#   # Run a real CLI scene against a live klangk server:
+#   devenv shell -- demo/record-terminal.sh python3 demo/cli_demo.py --scene scene_2
+#
+#   # Anything after the script name is the DRIVER command + its args.
+#
+# Output: demo/recordings/<scene>-<timestamp>.mp4
+#
+# Requires (all present on NixOS / via devenv): Xvfb, xterm, tmux, ffmpeg,
+# ffprobe, xdotool. The Python driver is stdlib-only (no pexpect, no pip).
+#
+# Knobs (env vars):
+#   KLANGK_DEMO_WIDTH        default 1920    canvas width  (px)
+#   KLANGK_DEMO_HEIGHT       default 1080    canvas height (px)
+#   KLANGK_DEMO_FONT         default "DejaVu Sans Mono"
+#   KLANGK_DEMO_FONT_SIZE    default 22      terminal font size (pt)
+#   KLANGK_DEMO_FPS          default 30      capture framerate
+#   KLANGK_DEMO_CRF          default 20      x264 quality (lower = better)
+#   KLANGK_DEMO_X264_PRESET  default medium
+#   KLANGK_DEMO_DISPLAY      default 97      Xvfb display number to use
+#   KLANGK_DEMO_TMUX_SESSION default klangk-demo
+#   KLANGK_DEMO_OUTPUT       default demo/recordings/recording-<ts>.mp4
+#   KLANGK_DEMO_PROMPT       default "\e[36mklangk\e[0m \e[2m$\e[0m "
+#                            (PS1 for the session shell; supports ANSI escapes)
+
+set -uo pipefail
+
+WORKTREE_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$WORKTREE_ROOT"
+
+WIDTH="${KLANGK_DEMO_WIDTH:-1920}"
+HEIGHT="${KLANGK_DEMO_HEIGHT:-1080}"
+FONT="${KLANGK_DEMO_FONT:-DejaVu Sans Mono}"
+FONT_SIZE="${KLANGK_DEMO_FONT_SIZE:-22}"
+FPS="${KLANGK_DEMO_FPS:-30}"
+CRF="${KLANGK_DEMO_CRF:-20}"
+PRESET="${KLANGK_DEMO_X264_PRESET:-medium}"
+DISPLAY_NUM="${KLANGK_DEMO_DISPLAY:-97}"
+SESSION="${KLANGK_DEMO_TMUX_SESSION:-klangk-demo}"
+PROMPT="${KLANGK_DEMO_PROMPT:-$'\\e[36mklangk\\e[0m \\e[2m$\\e[0m '}"
+export DISPLAY=":${DISPLAY_NUM}"
+
+OUT="${KLANGK_DEMO_OUTPUT:-demo/recordings/recording-$(date +%Y%m%d-%H%M%S).mp4}"
+mkdir -p "$(dirname "$OUT")"
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: $0 <driver-command> [driver-args...]" >&2
+  echo "  e.g. $0 python3 demo/cli_demo.py --scene demo" >&2
+  exit 2
+fi
+
+echo "=== terminal demo recorder ==="
+echo "  canvas : ${WIDTH}x${HEIGHT}"
+echo "  font   : ${FONT} ${FONT_SIZE}pt"
+echo "  display: $DISPLAY   tmux session: $SESSION"
+echo "  output : $OUT"
+echo "  driver : $*"
+echo
+
+# --- helpers ---------------------------------------------------------------
+have() { command -v "$1" >/dev/null 2>&1; }
+for t in Xvfb xterm tmux ffmpeg ffprobe xdotool; do
+  if ! have "$t"; then
+    echo "error: missing required tool '$t'" >&2
+    exit 1
+  fi
+done
+
+cleanup_display() {
+  if [ -n "${XVFB_PID:-}" ]; then kill "$XVFB_PID" 2>/dev/null || true; fi
+  if [ -n "${XTerm_PID:-}" ]; then kill "$XTerm_PID" 2>/dev/null || true; fi
+  tmux kill-session -t "$SESSION" 2>/dev/null || true
+  rm -f "/tmp/.X${DISPLAY_NUM}-lock" "/tmp/.X11-unix/X${DISPLAY_NUM}"
+}
+
+# --- 1. clean slate + start Xvfb -------------------------------------------
+cleanup_display
+if [ -f "/tmp/.X${DISPLAY_NUM}-lock" ]; then
+  OLD_PID="$(cat "/tmp/.X${DISPLAY_NUM}-lock" 2>/dev/null || true)"
+  if [ -n "${OLD_PID:-}" ] && kill -0 "$OLD_PID" 2>/dev/null; then
+    kill "$OLD_PID" 2>/dev/null || true
+  fi
+  rm -f "/tmp/.X${DISPLAY_NUM}-lock" "/tmp/.X11-unix/X${DISPLAY_NUM}"
+fi
+sleep 0.2
+
+Xvfb "$DISPLAY" -screen 0 "${WIDTH}x${HEIGHT}x24" -ac +extension RANDR \
+  >/tmp/klangk-demo-xvfb.log 2>&1 &
+XVFB_PID=$!
+# Wait for Xvfb to create its socket. (We avoid xdpyinfo — it's not on the
+# devenv PATH; the socket file is the cheapest readiness signal.)
+SOCK="/tmp/.X11-unix/X${DISPLAY_NUM}"
+for _ in $(seq 1 50); do
+  [ -S "$SOCK" ] && break
+  sleep 0.1
+done
+if [ ! -S "$SOCK" ]; then
+  echo "error: Xvfb did not come up on $DISPLAY" >&2
+  cat /tmp/klangk-demo-xvfb.log >&2
+  cleanup_display
+  exit 1
+fi
+sleep 0.3 # let the server settle into "accepting connections"
+echo "  Xvfb up (pid $XVFB_PID)"
+
+# --- 2. tmux session (clean bash + demo prompt) + xterm client -------------
+# A clean, host-dotfile-free shell with a legible demo prompt. The session is
+# the single source of truth: xterm displays it, the driver scripts it.
+tmux new-session -d -s "$SESSION" -x "${WIDTH}" -y "${HEIGHT}" \
+  "bash --noprofile --norc -i"
+
+# Set the prompt inside the session.
+tmux send-keys -t "$SESSION" "PS1=${PROMPT}" Enter
+tmux send-keys -t "$SESSION" "clear" Enter
+
+# xterm attaches to the session and renders it to the virtual display.
+# NOTE: `tmux attach -t`, NOT `attach-client -t` — the latter's -t names a
+# *client*, so it fails and xterm exits instantly, leaving ffmpeg recording
+# an empty display. `attach`/`attach-session` is the session-attaching form.
+xterm -display "$DISPLAY" \
+  -title "klangk-demo-recording" \
+  -fs "$FONT_SIZE" -fa "$FONT" \
+  -bg black -fg white -uc -bc \
+  -xrm 'xterm*scrollBar:false' \
+  -xrm 'xterm*cursorBlink:true' \
+  -e tmux attach -t "$SESSION" &
+XTerm_PID=$!
+
+# Wait for the xterm window to map, then size it edge-to-edge on the canvas
+# for a clean, full-screen look. Search by class ("xterm") — the window -title
+# is overridden by tmux's own title escapes once it attaches.
+WIN=""
+for _ in $(seq 1 50); do
+  WIN="$(xdotool search --class xterm 2>/dev/null | head -1 || true)"
+  [ -n "$WIN" ] && break
+  sleep 0.1
+done
+if [ -n "${WIN:-}" ]; then
+  xdotool windowsize "$WIN" "$WIDTH" "$HEIGHT" 2>/dev/null || true
+  xdotool windowmove "$WIN" 0 0 2>/dev/null || true
+  xdotool windowfocus "$WIN" 2>/dev/null || true
+fi
+echo "  xterm up (pid $XTerm_PID, window ${WIN:-?})"
+
+# --- 3. ffmpeg captures the whole virtual display --------------------------
+ffmpeg -y -hide_banner -loglevel error \
+  -f x11grab -draw_mouse 1 \
+  -video_size "${WIDTH}x${HEIGHT}" \
+  -framerate "$FPS" \
+  -i "$DISPLAY+0,0" \
+  -c:v libx264 -pix_fmt yuv420p -preset "$PRESET" -crf "$CRF" \
+  "$OUT" &
+FFMPEG_PID=$!
+echo "  ffmpeg recording (pid $FFMPEG_PID)"
+echo
+
+# --- 4. run the driver -----------------------------------------------------
+# Hand the driver the session name + display so it can drive tmux. `set +e`
+# so a failing/aborted scene still lets ffmpeg finalize the recording.
+export KLANGK_DEMO_TMUX_SESSION="$SESSION"
+export DISPLAY
+echo "=== running driver ==="
+set +e
+"$@"
+DRIVER_RC=$?
+set -e
+
+# --- 5. finalize + report --------------------------------------------------
+echo
+echo "=== finalizing recording ==="
+# Give the last frame a beat to land, then 'q' ffmpeg for a clean mux.
+sleep 0.6
+kill -INT "$FFMPEG_PID" 2>/dev/null || true
+for _ in $(seq 1 40); do
+  kill -0 "$FFMPEG_PID" 2>/dev/null || break
+  sleep 0.15
+done
+kill "$FFMPEG_PID" 2>/dev/null || true
+wait "$FFMPEG_PID" 2>/dev/null || true
+cleanup_display
+
+if [ -f "$OUT" ]; then
+  DIMS="$(ffprobe -v error -select_streams v:0 \
+    -show_entries stream=width,height -of csv=p=0:s=x "$OUT" 2>/dev/null || echo "?")"
+  DUR="$(ffprobe -v error -show_entries format=duration \
+    -of default=noprint_wrappers=1:nokey=1 "$OUT" 2>/dev/null || echo "?")"
+  echo
+  echo "✓ recorded: $OUT"
+  echo "  dimensions: ${DIMS}   duration: ${DUR}s   driver rc: ${DRIVER_RC}"
+else
+  echo "✗ no recording produced (driver rc: ${DRIVER_RC})" >&2
+fi
+
+exit "$DRIVER_RC"


### PR DESCRIPTION
Closes #1201.

## What

A reproducible, re-takeable recorder for the **CLI/terminal scenes** of the intro video (#1082) — the interactive-shell work (`klangkc login`/`create`/`shell`/`sandbox`/`monitor`, `git clone`, …) that Playwright can't drive. It scripts a real terminal and captures a **true 1080p** `.mp4`, no manual recording.

This is the terminal half of the intro-video tooling. The web-UI scenes are driven by the Playwright harness (`src/frontend/e2e-tests/demo/record-demo.sh`, WIP); this directory handles what that one can't — a live shell. It mirrors that harness's core insight: **decouple *driving* the terminal from *recording* it**.

## Architecture

Four layers:

| Layer | Role |
| --- | --- |
| **Xvfb** | virtual X display at the canvas size (default 1920×1080) |
| **xterm** | real terminal emulator on that display, attached to a tmux session (big legible font, black bg) |
| **tmux** | owns the pty — xterm *displays* it, the driver *writes* it (`send-keys`) and reads it (`capture-pane`) |
| **ffmpeg** (`x11grab`) | captures the whole Xvfb display into a true full-res `.mp4` |

The driver (`cli_demo.py`) then scripts the scene: type commands (optionally one char at a time), press Enter, wait for expected output, continue.

## Why tmux and not pexpect? (driver rationale)

#1201 suggested *pyexpect* (pexpect). It's the right **idea** — an expect-style send/wait/respond loop — but it can't drive a **displayed** terminal: `pexpect.spawn()` takes the pty **master**, and a terminal emulator must *itself* be the master to render, so if pexpect owns the pty, xterm has nothing to attach to and nothing is ever drawn to the screen ffmpeg captures.

For a demo video the terminal must be **rendered**, which needs a pty multiplexer in the middle: one client renders it (xterm → Xvfb → ffmpeg), another scripts it. **tmux is that multiplexer**, and `send-keys`/`capture-pane` give the same `send`/`expect` primitives pexpect provides — without taking the pty hostage. So the driver is **stdlib-only** (no `pexpect`, no `pip` — runs on any `python3`). Verified empirically; the README carries the full rationale.

## Files

- `demo/record-terminal.sh` — recorder harness (Xvfb + xterm + tmux + ffmpeg), env knobs for size/font/fps/prompt, xdotool resizes xterm edge-to-edge.
- `demo/cli_demo.py` — `Term` driver (`type`/`enter`/`run`/`expect`/`pause`/`clear`) + scenes: `demo` (no-server smoke test), `scene_2`/`3`/`4` skeletons for the real CLI scenes.
- `demo/README.md` — usage, architecture, the pexpect rationale, how to write a scene, env-var reference.
- `demo/.gitignore` — `recordings/` (re-take artifacts).

## Verification

Proven end-to-end locally: the built-in `demo` scene records a true **1920×1080** mp4, the terminal fills the canvas (**1912×1074**, brightness ~2157 vs the initially-broken ~1.9 black), driver rc 0. All pre-commit hooks pass (shellcheck, shfmt, ruff, markdownlint, prettier, trufflehog).

Two bugs found and fixed during development, both documented in code comments:
1. `tmux attach-client -t SESSION` is wrong (its `-t` names a *client*); the session-attaching form is `tmux attach -t SESSION`. The former made xterm exit instantly, leaving ffmpeg recording an empty display.
2. xdotool must search by window **class** (`xterm`), not by `-title` (tmux overrides the window title once it attaches).

## Out of scope

- The web-UI scenes (separate Playwright harness, WIP — not committed here).
- Fleshing out `scene_2`/`3`/`4` end-to-end against a live server (they're runnable skeletons; the real takes need a live demo server + LLM key).
- Editing/narration (DaVinci Resolve, per the demo plan).