### PR TITLE
Show workspace health/running status in klangkc ls

### DIFF
--- a/src/cli/klangkc/client.py
+++ b/src/cli/klangkc/client.py
@@ -156,6 +156,9 @@ class Workspace:
     env: dict[str, str] | None = None
     health_check: str | None = None
     owner_email: str | None = None
+    running: bool = False
+    health: str | None = None
+    health_message: str | None = None
 
 
 def _get_terminal_size() -> tuple[int, int]:
@@ -377,6 +380,9 @@ class KlangkClient:
             env=w.get("env"),
             health_check=w.get("health_check"),
             owner_email=w.get("owner_email") if shared else None,
+            running=bool(w.get("running", False)),
+            health=w.get("health"),
+            health_message=w.get("health_message"),
         )
 
     def create_workspace(

--- a/src/cli/klangkc/main.py
+++ b/src/cli/klangkc/main.py
@@ -200,17 +200,26 @@ def status(
 def _workspace_status(ws) -> tuple[str, str]:
     """Return ``(label, rich_markup)`` describing a workspace's runtime state.
 
-    The label is terminal-safe plain text (``healthy`` / ``unhealthy`` /
-    ``starting`` / ``stopped``); the markup is the colorized form for the rich
-    table. Color mirrors the web UI's health dot:
+    The label is terminal-safe plain text; the markup is the colorized form
+    for the rich table. Collapses two independent backend fields --
+    ``running`` (container process up?) and ``health`` (the health-check
+    probe result, if any) -- into one readable word:
 
-    - running + healthy   -> green
-    - running + unhealthy -> red
-    - running, no health  -> yellow (container up, first poll pending)
-    - not running         -> dim (stopped)
+    - not running                       -> stopped   (dim)
+    - running, no health-check configured-> running   (green)
+    - running + health=healthy          -> healthy   (green)
+    - running + health=unhealthy        -> unhealthy (red)
+    - running, health-check set, no
+      probe completed yet              -> starting  (yellow)
+
+    A workspace with no ``health_check`` never gets probed, so ``health``
+    stays None forever -- ``starting`` would be a lie. ``running`` is the
+    honest label: the container is up, and we make no health claim.
     """
     if not ws.running:
         return "stopped", "[dim]stopped[/dim]"
+    if not ws.health_check:
+        return "running", "[green]running[/green]"
     if ws.health == "healthy":
         return "healthy", "[green]healthy[/green]"
     if ws.health == "unhealthy":

--- a/src/cli/klangkc/main.py
+++ b/src/cli/klangkc/main.py
@@ -197,6 +197,38 @@ def status(
     console.print(table)
 
 
+def _workspace_status(ws) -> tuple[str, str]:
+    """Return ``(label, rich_markup)`` describing a workspace's runtime state.
+
+    The label is terminal-safe plain text (``healthy`` / ``unhealthy`` /
+    ``starting`` / ``stopped``); the markup is the colorized form for the rich
+    table. Color mirrors the web UI's health dot:
+
+    - running + healthy   -> green
+    - running + unhealthy -> red
+    - running, no health  -> yellow (container up, first poll pending)
+    - not running         -> dim (stopped)
+    """
+    if not ws.running:
+        return "stopped", "[dim]stopped[/dim]"
+    if ws.health == "healthy":
+        return "healthy", "[green]healthy[/green]"
+    if ws.health == "unhealthy":
+        return "unhealthy", "[red]unhealthy[/red]"
+    return "starting", "[yellow]starting[/yellow]"
+
+
+def _short_id(ws_id: str) -> str:
+    """Shorten a workspace id to ``abc…xyz`` (first 3 + ellipsis + last 3).
+
+    Long ids crowd the table; this keeps the column narrow while still
+    distinguishing workspaces at a glance. Short ids are returned as-is.
+    """
+    if len(ws_id) <= 7:
+        return ws_id
+    return f"{ws_id[:3]}…{ws_id[-3:]}"
+
+
 @app.command("ls")
 def list_workspaces(
     plain: bool = typer.Option(False, "--plain", help="Plain text output"),
@@ -256,31 +288,45 @@ def list_workspaces(
         return
     if plain:
         for ws in workspaces:
-            typer.echo(f"  {ws.name}  ({ws.id[:12]})  {ws.created_at[:10]}")
+            status, _ = _workspace_status(ws)
+            typer.echo(
+                f"  {ws.name}  ({_short_id(ws.id)})  "
+                f"{status}  {ws.created_at[:10]}"
+            )
         if shared_workspaces:
             typer.echo("Shared with me:")
             for ws in shared_workspaces:
+                status, _ = _workspace_status(ws)
                 owner = f"  by {ws.owner_email}" if ws.owner_email else ""
                 typer.echo(
-                    f"  {ws.name}  ({ws.id[:12]})  {ws.created_at[:10]}{owner}"
+                    f"  {ws.name}  ({_short_id(ws.id)})  "
+                    f"{status}  {ws.created_at[:10]}{owner}"
                 )
         return
     console = Console()
     table = Table(box=None, pad_edge=False)
     table.add_column("Name", style="bold")
     table.add_column("ID")
+    table.add_column("Status")
     table.add_column("Created")
     if shared:
         table.add_column("Owner")
     for ws in workspaces:
-        row = [ws.name, ws.id[:12], ws.created_at[:10]]
+        _, markup = _workspace_status(ws)
+        row = [ws.name, _short_id(ws.id), markup, ws.created_at[:10]]
         if shared:
             row.append("")
         table.add_row(*row)
     for ws in shared_workspaces:
-        table.add_row(
-            ws.name, ws.id[:12], ws.created_at[:10], ws.owner_email or ""
-        )
+        _, markup = _workspace_status(ws)
+        row = [
+            ws.name,
+            _short_id(ws.id),
+            markup,
+            ws.created_at[:10],
+            ws.owner_email or "",
+        ]
+        table.add_row(*row)
     console.print(table)
 
 

--- a/src/cli/tests/test_cli.py
+++ b/src/cli/tests/test_cli.py
@@ -1035,6 +1035,51 @@ class TestKlangkClient:
         assert workspaces[0].name == "alpha"
         assert workspaces[1].id == "ws2"
 
+    def test_list_workspaces_parses_health_status(self):
+        client = KlangkClient("http://test:8995", "valid-token")
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "items": [
+                {
+                    "id": "ws1",
+                    "name": "alpha",
+                    "created_at": "2025-01-01T00:00:00Z",
+                    "running": True,
+                    "health": "unhealthy",
+                    "health_message": "curl failed",
+                },
+            ],
+            "has_more": False,
+            "next_offset": None,
+        }
+        with patch.object(client, "get", return_value=mock_resp):
+            workspaces = client.list_workspaces()
+        assert workspaces[0].running is True
+        assert workspaces[0].health == "unhealthy"
+        assert workspaces[0].health_message == "curl failed"
+
+    def test_list_workspaces_health_defaults_when_absent(self):
+        client = KlangkClient("http://test:8995", "valid-token")
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "items": [
+                {
+                    "id": "ws1",
+                    "name": "alpha",
+                    "created_at": "2025-01-01T00:00:00Z",
+                },
+            ],
+            "has_more": False,
+            "next_offset": None,
+        }
+        with patch.object(client, "get", return_value=mock_resp):
+            workspaces = client.list_workspaces()
+        assert workspaces[0].running is False
+        assert workspaces[0].health is None
+        assert workspaces[0].health_message is None
+
     def test_list_shared_workspaces_parses_response(self):
         client = KlangkClient("http://test:8995", "valid-token")
         mock_resp = MagicMock()

--- a/src/cli/tests/test_cli_main.py
+++ b/src/cli/tests/test_cli_main.py
@@ -370,6 +370,7 @@ class TestMainCLI:
             name="demo",
             created_at="2025-01-01T00:00:00Z",
             running=True,
+            health_check="/path/to/check.sh",
             health="healthy",
         )
         client = MagicMock()
@@ -399,6 +400,7 @@ class TestMainCLI:
             name="demo",
             created_at="2025-01-01T00:00:00Z",
             running=True,
+            health_check="/path/to/check.sh",
             health="unhealthy",
         )
         client = MagicMock()
@@ -428,6 +430,7 @@ class TestMainCLI:
             created_at="2025-01-01T00:00:00Z",
             owner_email="owner@example.com",
             running=True,
+            health_check="/path/to/check.sh",
             health="healthy",
         )
         client = MagicMock()
@@ -2824,6 +2827,18 @@ class TestWorkspaceStatus:
         assert label == "stopped"
         assert "dim" in markup
 
+    def test_running_when_no_health_check_configured(self):
+        from klangkc.main import _workspace_status
+
+        ws = Workspace(
+            id="x", name="n", created_at="2025-01-01T00:00:00Z", running=True
+        )
+        # No health_check configured -> never probed -> must not show
+        # "starting" (which would imply a pending poll that never comes).
+        label, markup = _workspace_status(ws)
+        assert label == "running"
+        assert "green" in markup
+
     def test_healthy(self):
         from klangkc.main import _workspace_status
 
@@ -2832,6 +2847,7 @@ class TestWorkspaceStatus:
             name="n",
             created_at="2025-01-01T00:00:00Z",
             running=True,
+            health_check="/path/to/check.sh",
             health="healthy",
         )
         label, markup = _workspace_status(ws)
@@ -2846,6 +2862,7 @@ class TestWorkspaceStatus:
             name="n",
             created_at="2025-01-01T00:00:00Z",
             running=True,
+            health_check="/path/to/check.sh",
             health="unhealthy",
         )
         label, markup = _workspace_status(ws)
@@ -2856,7 +2873,11 @@ class TestWorkspaceStatus:
         from klangkc.main import _workspace_status
 
         ws = Workspace(
-            id="x", name="n", created_at="2025-01-01T00:00:00Z", running=True
+            id="x",
+            name="n",
+            created_at="2025-01-01T00:00:00Z",
+            running=True,
+            health_check="/path/to/check.sh",
         )
         label, markup = _workspace_status(ws)
         assert label == "starting"

--- a/src/cli/tests/test_cli_main.py
+++ b/src/cli/tests/test_cli_main.py
@@ -360,6 +360,89 @@ class TestMainCLI:
         assert "my-workspace" in output
         assert "2025-01-01" in output
 
+    def test_list_workspaces_plain_shows_status_and_short_id(
+        self, logged_in_cfg, monkeypatch
+    ):
+        from klangkc import main
+
+        ws = Workspace(
+            id="abc" + "0" * 40 + "xyz",
+            name="demo",
+            created_at="2025-01-01T00:00:00Z",
+            running=True,
+            health="healthy",
+        )
+        client = MagicMock()
+        client.list_workspaces.return_value = [ws]
+        monkeypatch.setattr(main, "_client", lambda: client)
+
+        with patch("typer.echo") as mock_echo:
+            main.list_workspaces(plain=True)
+        line = next(
+            str(c) for c in mock_echo.call_args_list if "demo" in str(c)
+        )
+        assert "healthy" in line  # plain status label
+        assert "\x1b" not in line  # no ANSI color in --plain
+        assert "abc…xyz" in line  # shortened id
+
+    def test_list_workspaces_rich_shows_status_column(
+        self, logged_in_cfg, monkeypatch
+    ):
+        from io import StringIO
+
+        from rich.console import Console
+
+        from klangkc import main
+
+        ws = Workspace(
+            id="abc" + "0" * 40 + "xyz",
+            name="demo",
+            created_at="2025-01-01T00:00:00Z",
+            running=True,
+            health="unhealthy",
+        )
+        client = MagicMock()
+        client.list_workspaces.return_value = [ws]
+        monkeypatch.setattr(main, "_client", lambda: client)
+
+        buf = StringIO()
+        with patch.object(
+            main,
+            "Console",
+            return_value=Console(file=buf, force_terminal=True),
+        ):
+            main.list_workspaces(plain=False)
+        output = buf.getvalue()
+        assert "Status" in output  # column header
+        assert "unhealthy" in output  # status label text renders
+        assert "abc…xyz" in output  # shortened id
+
+    def test_list_shared_workspaces_plain_shows_status(
+        self, logged_in_cfg, monkeypatch
+    ):
+        from klangkc import main
+
+        shared_ws = Workspace(
+            id="abc" + "0" * 40 + "xyz",
+            name="shared-ws",
+            created_at="2025-01-01T00:00:00Z",
+            owner_email="owner@example.com",
+            running=True,
+            health="healthy",
+        )
+        client = MagicMock()
+        client.list_workspaces.return_value = []
+        client.list_shared_workspaces.return_value = [shared_ws]
+        monkeypatch.setattr(main, "_client", lambda: client)
+
+        with patch("typer.echo") as mock_echo:
+            main.list_workspaces(plain=True, shared=True)
+        line = next(
+            str(c) for c in mock_echo.call_args_list if "shared-ws" in str(c)
+        )
+        assert "healthy" in line
+        assert "\x1b" not in line
+
     def test_list_workspaces_all_passes_pagination_flag(
         self, logged_in_cfg, monkeypatch
     ):
@@ -2730,6 +2813,71 @@ class TestBuildWsUrl:
         from klangkc.main import _build_ws_url
 
         assert _build_ws_url("example.com") == "ws://example.com/ws"
+
+
+class TestWorkspaceStatus:
+    def test_stopped_when_not_running(self):
+        from klangkc.main import _workspace_status
+
+        ws = Workspace(id="x", name="n", created_at="2025-01-01T00:00:00Z")
+        label, markup = _workspace_status(ws)
+        assert label == "stopped"
+        assert "dim" in markup
+
+    def test_healthy(self):
+        from klangkc.main import _workspace_status
+
+        ws = Workspace(
+            id="x",
+            name="n",
+            created_at="2025-01-01T00:00:00Z",
+            running=True,
+            health="healthy",
+        )
+        label, markup = _workspace_status(ws)
+        assert label == "healthy"
+        assert "green" in markup
+
+    def test_unhealthy(self):
+        from klangkc.main import _workspace_status
+
+        ws = Workspace(
+            id="x",
+            name="n",
+            created_at="2025-01-01T00:00:00Z",
+            running=True,
+            health="unhealthy",
+        )
+        label, markup = _workspace_status(ws)
+        assert label == "unhealthy"
+        assert "red" in markup
+
+    def test_starting_when_running_but_no_health(self):
+        from klangkc.main import _workspace_status
+
+        ws = Workspace(
+            id="x", name="n", created_at="2025-01-01T00:00:00Z", running=True
+        )
+        label, markup = _workspace_status(ws)
+        assert label == "starting"
+        assert "yellow" in markup
+
+
+class TestShortId:
+    def test_long_id_is_truncated(self):
+        from klangkc.main import _short_id
+
+        assert _short_id("abcdefgh") == "abc…fgh"
+
+    def test_seven_char_id_returned_unchanged(self):
+        from klangkc.main import _short_id
+
+        assert _short_id("abcdefg") == "abcdefg"
+
+    def test_short_id_returned_unchanged(self):
+        from klangkc.main import _short_id
+
+        assert _short_id("abc") == "abc"
 
 
 class TestResolveForwardAgent:


### PR DESCRIPTION
## Summary

`klangkc ls` showed only Name · ID · Created, even though the backend already annotates every workspace with live `running` / `health` / `health_message` state. From the command line there was no way to tell whether a workspace's container was up, healthy, or unhealthy without opening the web UI.

This adds a **Status** column to `klangkc ls` and parses the live fields in the CLI client model.

| state | label | color |
| --- | --- | --- |
| running + healthy | `healthy` | green |
| running + unhealthy | `unhealthy` | red |
| running, no health (poll pending) | `starting` | yellow |
| not running | `stopped` | dim |

The plain-text label is the source of truth so output stays readable on non-color terminals and when piped; `--plain` strips color entirely. The ID column is also shortened to `abc…xyz` (first 3 + ellipsis + last 3) to keep the table narrow.

## Changes

- `src/cli/klangkc/client.py` — `Workspace` model gains `running` / `health` / `health_message`; `_workspace_from_json` parses them.
- `src/cli/klangkc/main.py` — `_workspace_status()` and `_short_id()` helpers; `list_workspaces` renders a Status column in both the rich table and `--plain` output, for own and `--shared` workspaces.
- Tests — each status state, the short-id helper, the API parse (present + defaulted), and both rich/plain renderings.

## Example

```
$ klangkc ls
 Name     ID      Status    Created
 demo     abc…xyz healthy   2025-07-02
 openclaw def…uvw stopped   2025-06-30
```

No backend changes — the API already returns all the data.

Closes #1206.
