### PR TITLE
Fix klangkc shell shared service-cmd join (wait for shared_terminals)

### DIFF
--- a/src/cli/klangkc/client.py
+++ b/src/cli/klangkc/client.py
@@ -808,13 +808,18 @@ async def _ws_shell(
             )
         )
 
-        # 3. Drain messages until we have terminal_windows (needed for
-        # window selection).  terminal_output may arrive before
-        # terminal_windows due to async output forwarding, so we buffer
-        # early output and don't stop until the window list is in.
+        # 3. Drain messages until we have what window selection needs.
+        # terminal_output may arrive before terminal_windows due to async
+        # output forwarding, so we buffer early output and don't stop until
+        # the window list is in. When joining a shared terminal
+        # (``handle:window_name``) we must ALSO wait for shared_terminals,
+        # which the server sends AFTER terminal_windows (see #1208):
+        # breaking on terminal_windows alone leaves shared_terminals empty
+        # and the join fails with "Shared terminal not found".
         own_windows: list[dict] = []
         shared_terminals: list[dict] = []
         buffered_output: list[str] = []
+        needs_shared = window is not None and ":" in window
         try:
             deadline = asyncio.get_event_loop().time() + 30
             while True:
@@ -825,9 +830,12 @@ async def _ws_shell(
                 msg = json.loads(raw)
                 if msg.get("type") == "terminal_windows":
                     own_windows = msg.get("windows", [])
-                    break
+                    if not needs_shared:
+                        break
                 elif msg.get("type") == "shared_terminals":
                     shared_terminals = msg.get("terminals", [])
+                    if needs_shared:
+                        break
                 elif msg.get("type") == "terminal_output":
                     buffered_output.append(msg.get("data", ""))
                 elif msg.get("type") == "error":  # pragma: no cover

--- a/src/cli/tests/test_cli.py
+++ b/src/cli/tests/test_cli.py
@@ -1860,6 +1860,144 @@ class TestRunShell:
             assert "Connection failed" in str(exc_info.value)
 
     @pytest.mark.asyncio
+    async def test_ws_shell_joins_shared_terminal_after_terminal_windows(
+        self,
+    ):
+        """A shared join must wait for shared_terminals, which the server
+        sends AFTER terminal_windows (#1208).
+
+        Scripts the real on-the-wire order (chat, terminal_started,
+        terminal_output, terminal_windows, THEN shared_terminals) and
+        asserts the join resolves the match and sends
+        join_shared_terminal rather than raising "not found".
+        """
+        from klangkc.client import _ws_shell
+
+        # Message sequence matches a live connect (see #1208 trace):
+        # the service-cmd window arrives only in shared_terminals, which
+        # lands AFTER terminal_windows.
+        msgs = [
+            {"type": "container_ready"},
+            {"type": "terminal_started"},
+            {"type": "terminal_output", "data": "boot..."},
+            {"type": "terminal_windows", "windows": []},
+            {
+                "type": "shared_terminals",
+                "terminals": [
+                    {
+                        "user_id": "agent-uid",
+                        "handle": "clanker",
+                        "window_name": "service-cmd",
+                        "window_id": "win-1",
+                        "is_service": True,
+                    }
+                ],
+            },
+            # join confirmation
+            {"type": "terminal_started"},
+        ]
+        idx = {"i": 0}
+
+        ws_mock = MagicMock()
+
+        async def fake_enter(self):
+            return ws_mock
+
+        async def fake_exit(self, *args):
+            return None
+
+        ws_mock.__aenter__ = fake_enter
+        ws_mock.__aexit__ = fake_exit
+
+        async def fake_recv(*a, **kw):
+            i = idx["i"]
+            idx["i"] += 1
+            if i < len(msgs):
+                return json.dumps(msgs[i])
+            # After the scripted messages, signal the stdin loop to end.
+            import websockets
+
+            raise websockets.ConnectionClosed(None, None)
+
+        ws_mock.recv = fake_recv
+        ws_mock.send = AsyncMock()
+        ws_mock.close = AsyncMock()
+
+        sent_cmds = []
+
+        async def capture_send(payload, *a, **kw):
+            sent_cmds.append(json.loads(payload))
+
+        ws_mock.send = capture_send
+
+        with patch("websockets.connect", return_value=ws_mock):
+            with patch("klangkc.client._run_shell", new=AsyncMock()):
+                # Should NOT raise "Shared terminal not found".
+                await _ws_shell(
+                    "ws://localhost/ws",
+                    "token",
+                    "ws1",
+                    raw_mode=False,
+                    window="clanker:service-cmd",
+                )
+
+        # The join command was sent with the resolved ids.
+        join = next(
+            (c for c in sent_cmds if c.get("cmd") == "join_shared_terminal"),
+            None,
+        )
+        assert join is not None, "join_shared_terminal was never sent"
+        assert join["user_id"] == "agent-uid"
+        assert join["window_id"] == "win-1"
+
+    @pytest.mark.asyncio
+    async def test_ws_shell_shared_terminal_not_found_when_absent(self):
+        """Sanity: if the window truly isn't shared, we still raise."""
+        from klangkc.client import _ws_shell
+
+        msgs = [
+            {"type": "container_ready"},
+            {"type": "terminal_started"},
+            {"type": "terminal_windows", "windows": []},
+            {"type": "shared_terminals", "terminals": []},
+        ]
+        idx = {"i": 0}
+
+        ws_mock = MagicMock()
+
+        async def fake_enter(self):
+            return ws_mock
+
+        async def fake_exit(self, *args):
+            return None
+
+        ws_mock.__aenter__ = fake_enter
+        ws_mock.__aexit__ = fake_exit
+
+        async def fake_recv(*a, **kw):
+            i = idx["i"]
+            idx["i"] += 1
+            if i < len(msgs):
+                return json.dumps(msgs[i])
+            import websockets
+
+            raise websockets.ConnectionClosed(None, None)
+
+        ws_mock.recv = fake_recv
+        ws_mock.send = AsyncMock()
+
+        with patch("websockets.connect", return_value=ws_mock):
+            with pytest.raises(ConnectionError) as exc_info:
+                await _ws_shell(
+                    "ws://localhost/ws",
+                    "token",
+                    "ws1",
+                    raw_mode=False,
+                    window="clanker:service-cmd",
+                )
+            assert "not found" in str(exc_info.value)
+
+    @pytest.mark.asyncio
     async def test_tilde_dot_disconnects(self):
         """Enter then ~ then . cleanly exits the shell."""
         from klangkc.client import _run_shell


### PR DESCRIPTION
## Summary

`klangkc shell <workspace> clanker:service-cmd` failed with `Shared terminal 'clanker:service-cmd' not found`, even though the service window was provably running and published as shared. The backend was correct; the CLI was too impatient to receive the shared-terminal list.

## Root cause

Confirmed by tracing the WebSocket message order on connect (`terminal_start` then drain):

```
  0: chat_history
  4: terminal_started
  7: terminal_output
  8: terminal_windows      <- CLI drain loop BROKE here
  9: shared_terminals      -> handle=clanker window=service-cmd is_service=True
 10: terminal_output
```

In `_ws_shell`, the drain loop captured `shared_terminals` but did `break` the instant `terminal_windows` arrived — one message **before** `shared_terminals`. So when the caller resolved a `handle:window_name` shared target, the `shared_terminals` list was still empty and the join died with "Shared terminal not found".

The backend sends `terminal_windows` (the firing user's own windows) then `shared_terminals` (including the agent's service window) — a sensible order; the web UI works because it keeps listening. The own-window path in the CLI was unaffected (it owns the `terminal_windows` it breaks on), so plain `klangkc shell <ws>` still worked.

## Fix

When a shared-terminal join is pending (`window` contains `:`), keep draining past `terminal_windows` until `shared_terminals` also arrives, bounded by the existing deadline. The `terminal_windows` break shortcut is only safe for the own-window path.

Verified end-to-end against a live workspace with a running service command: before → "Shared terminal not found"; after → the CLI joins the `service-cmd` pane and renders its output.

## Tests

- `test_ws_shell_joins_shared_terminal_after_terminal_windows` — scripts the real message ordering (`terminal_windows` before `shared_terminals`) and asserts the join resolves the match and sends `join_shared_terminal` with the right ids, rather than raising.
- `test_ws_shell_shared_terminal_not_found_when_absent` — sanity: a genuinely-absent window still raises "not found".

Closes #1208.
