### PR TITLE
service_health: send current-health snapshot on connect (#1175 item 1)

### DIFF
--- a/docs/features/health-check.md
+++ b/docs/features/health-check.md
@@ -44,7 +44,13 @@ For each workspace with a health check configured:
 2. **Exit code 0 = healthy.** Any non-zero exit code, a timeout, or an
    error counts as **unhealthy**.
 3. When the status changes, every connected client gets a
-   `service_health` event so the UI can update in real time.
+   `service_health` event so the UI can update in real time. Because the
+   stream is deltas-only (it fires on transitions, not every poll), a
+   client that connects to an _already_-unhealthy workspace also
+   receives a one-time **snapshot** of every health-checked
+   workspace's current status immediately on connect -- so a pure-WS
+   consumer like `klangkc monitor` sees steady-state failures right
+   away instead of being blind until the next transition (#1175).
 4. The current status, the **reason** it's unhealthy (a tail of the
    check's stderr/stdout), and the time of the last check are exposed
    via `GET /api/v1/workspaces/{id}/status`.

--- a/src/backend/klangk_backend/wshandler/dispatch.py
+++ b/src/backend/klangk_backend/wshandler/dispatch.py
@@ -89,6 +89,11 @@ async def handle_websocket(websocket: WebSocket) -> None:
     safe_ws.start_sender()
     conn = Connection(safe_ws, user)
     state.connections[safe_ws] = conn
+    # Replay current health of every health-checked workspace so a
+    # pure-WS consumer (e.g. ``klangkc monitor``) sees steady-state
+    # status immediately instead of being blind until the next
+    # transition (#1175 item 1).
+    state.send_service_health_snapshot(safe_ws)
 
     try:
         while True:

--- a/src/backend/klangk_backend/wshandler/session.py
+++ b/src/backend/klangk_backend/wshandler/session.py
@@ -23,6 +23,23 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _service_health_frame(
+    workspace_id: str, healthy: bool, message: str | None
+) -> dict:
+    """Build a ``service_health`` frame.
+
+    Single source of truth for the event shape shared by the transition
+    broadcast (:meth:`WebSocketState.notify_service_health`) and the
+    connect-time snapshot (:meth:`send_service_health_snapshot`).
+    """
+    return {
+        "type": "service_health",
+        "workspace_id": workspace_id,
+        "healthy": healthy,
+        "health_message": message,
+    }
+
+
 class WorkspaceSession:
     """Shared state for a single workspace.
 
@@ -503,12 +520,7 @@ class WebSocketState:
         box -- operators can see *why* it failed without log access
         (#1088).  ``None`` when healthy.
         """
-        message_dict = {
-            "type": "service_health",
-            "workspace_id": workspace_id,
-            "healthy": healthy,
-            "health_message": message,
-        }
+        message_dict = _service_health_frame(workspace_id, healthy, message)
         dead = []
         for sock, conn in self.connections.items():
             if conn.user.get("id") is None:
@@ -520,6 +532,41 @@ class WebSocketState:
         for sock, conn in dead:
             self.connections.pop(sock, None)
             asyncio.create_task(conn.cleanup())
+
+    def send_service_health_snapshot(self, sock: SafeWebSocket) -> None:
+        """Send the current health of every health-checked workspace.
+
+        The ``service_health`` stream is **deltas only**: it fires on a
+        status transition, not every poll, so a steady-state unhealthy
+        workspace is invisible to a consumer that connects after the
+        transition (#1175).  This closes that hole by replaying the
+        current status of every workspace the registry has *already*
+        checked (``health_check`` configured and at least one poll
+        completed) to a single connection right after it registers.
+
+        Mirrors :meth:`notify_service_health`'s fan-out scope (every
+        workspace, consumer filters): server-side scoping is tracked
+        separately (#1175 item 5).  Consumer-side the frame is applied
+        idempotently, so a transition arriving just after the snapshot
+        is harmless.  Workspaces whose container has died are absent
+        from ``registry.states`` and thus skipped (the container-death
+        hole is #1175 item 2).
+        """
+        for cs in list(container.registry.states.values()):
+            if cs.health_check is None or cs.health_status is None:
+                continue
+            try:
+                sock.send_json(
+                    _service_health_frame(
+                        cs.workspace_id,
+                        cs.health_status == "healthy",
+                        cs.health_message,
+                    )
+                )
+            except _WS_ERRORS:
+                # The just-registered socket is already gone; nothing to
+                # snapshot to.  dispatch.py owns cleanup on disconnect.
+                break
 
     def notify_user_workspaces_changed(self, user_id: str) -> None:
         """Send ``workspaces_changed`` to all of a user's connections.

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -4223,6 +4223,117 @@ class TestNotifyServiceHealth:
             wshandler.state.connections.pop(sock, None)
 
 
+class TestServiceHealthSnapshot:
+    """send_service_health_snapshot replays current health to one socket
+    on connect, closing the steady-state-unhealthy hole (#1175 item 1)."""
+
+    def _state(self, ws_id, *, health_check, health_status, message=None):
+        cs = container.ContainerState(ws_id, f"cid-{ws_id}")
+        cs.health_check = health_check
+        cs.health_status = health_status
+        cs.health_message = message
+        return cs
+
+    def test_replays_only_checked_workspaces(self):
+        """Healthy + unhealthy are sent; unchecked and no-check skipped."""
+        saved = dict(container.registry.states)
+        sock = _mock_sock()
+        try:
+            container.registry.states.clear()
+            container.registry.states["ws-healthy"] = self._state(
+                "ws-healthy",
+                health_check="true",
+                health_status="healthy",
+            )
+            container.registry.states["ws-sick"] = self._state(
+                "ws-sick",
+                health_check="curl localhost",
+                health_status="unhealthy",
+                message="conn refused",
+            )
+            # health check configured but never polled yet
+            container.registry.states["ws-unchecked"] = self._state(
+                "ws-unchecked",
+                health_check="true",
+                health_status=None,
+            )
+            # no health check at all (plain dev workspace)
+            container.registry.states["ws-nocheck"] = self._state(
+                "ws-nocheck",
+                health_check=None,
+                health_status=None,
+            )
+            wshandler.state.send_service_health_snapshot(sock)
+        finally:
+            container.registry.states.clear()
+            container.registry.states.update(saved)
+
+        frames = [c[0][0] for c in sock.send_json.call_args_list]
+        assert len(frames) == 2
+        by_ws = {f["workspace_id"]: f for f in frames}
+        assert by_ws["ws-healthy"]["healthy"] is True
+        assert by_ws["ws-healthy"]["health_message"] is None
+        assert by_ws["ws-sick"]["healthy"] is False
+        assert by_ws["ws-sick"]["health_message"] == "conn refused"
+        assert "ws-unchecked" not in by_ws
+        assert "ws-nocheck" not in by_ws
+        for f in frames:
+            assert f["type"] == "service_health"
+
+    def test_targets_only_the_given_socket(self):
+        saved = dict(container.registry.states)
+        sock = _mock_sock()
+        other = _mock_sock()
+        try:
+            container.registry.states.clear()
+            container.registry.states["ws-1"] = self._state(
+                "ws-1",
+                health_check="true",
+                health_status="healthy",
+            )
+            wshandler.state.send_service_health_snapshot(sock)
+        finally:
+            container.registry.states.clear()
+            container.registry.states.update(saved)
+        sock.send_json.assert_called_once()
+        other.send_json.assert_not_called()
+
+    def test_dead_socket_breaks_cleanly(self):
+        from klangk_backend.wshandler import _WS_ERRORS
+
+        saved = dict(container.registry.states)
+        sock = _mock_sock()
+        sock.send_json = MagicMock(side_effect=_WS_ERRORS[0]("dead"))
+        try:
+            container.registry.states.clear()
+            container.registry.states["ws-1"] = self._state(
+                "ws-1",
+                health_check="true",
+                health_status="healthy",
+            )
+            container.registry.states["ws-2"] = self._state(
+                "ws-2",
+                health_check="true",
+                health_status="unhealthy",
+            )
+            # Must not raise; the dead socket ends the snapshot early.
+            wshandler.state.send_service_health_snapshot(sock)
+        finally:
+            container.registry.states.clear()
+            container.registry.states.update(saved)
+
+    def test_empty_registry_sends_nothing(self):
+        saved = dict(container.registry.states)
+        sock = _mock_sock()
+        try:
+            container.registry.states.clear()
+            wshandler.state.send_service_health_snapshot(sock)
+        finally:
+            container.registry.states.clear()
+            container.registry.states.update(saved)
+        sock.send_json.assert_not_called()
+
+
 class TestRemoveSessionLocked:
     async def test_removes_session(self):
         session = wshandler.state.get_or_create_session("ws-locked-rm")


### PR DESCRIPTION
## Summary

The `service_health` WebSocket stream was **deltas-only**: it fired on a status transition, not every poll. So a pure-WS consumer like `klangkc monitor` that connected to an *already*-unhealthy workspace received nothing until the next transition — blind to steady-state failures. (The REST/UI path was patched in #1173 by annotating the workspace list payload, but that does nothing for WS-only consumers.)

This implements **#1175 item 1** (the highest-impact, lowest-risk slice): on connect, replay the current status of every workspace the registry has already health-checked, then resume delta-only broadcasting.

## Changes

- **`session.py`** — new `WebSocketState.send_service_health_snapshot(sock)`: iterates `container.registry.states`, and for each workspace with a `health_check` configured **and** at least one completed poll (`health_status` not None), sends a `service_health` frame to that one socket. Factored the event shape into a shared `_service_health_frame` helper (single source of truth for the broadcast and the snapshot).
- **`dispatch.py`** — call `state.send_service_health_snapshot(safe_ws)` right after a connection registers, before the command loop starts.
- **`docs/features/health-check.md`** — documents the snapshot-on-connect behavior.

## Design notes

- **Scope** matches the existing transition broadcast (every workspace; the consumer filters what it doesn't display). Server-side scoping is #1175 item 5 (deferred).
- **Skipped on death:** workspaces whose container has died are absent from `registry.states`, so they're naturally skipped. The container-death hole is #1175 item 2 (deferred — a breaking change).
- **Idempotent:** the frame is applied idempotently by consumers, so a transition arriving just after the snapshot is harmless.
- **Safe for all consumers:** verified that `klangkc shell`'s drain loop and `stdout_loop` only match specific message types and silently drop unknown ones (including `service_health`); the web UI applies `service_health` idempotently; `klangkc monitor` is purpose-built for them.
- **Deferred (breaking, follow-ups):** item #2 (tri-state health / `running` field) and #3b (heartbeat) change event semantics and require `klangkc monitor` + the web UI to update in lockstep. This PR lands only the additive slice (#1).

## Tests

New `TestServiceHealthSnapshot` (4 tests): replays only already-checked workspaces (healthy + unhealthy sent; unchecked and no-health-check skipped), targets only the given socket, breaks cleanly on a dead socket, and sends nothing for an empty registry. Existing `TestNotifyServiceHealth` + `TestHandleWebsocketDispatch` cover the refactor and the connect wiring. Full `test_wshandler.py` suite (536 tests) passes; new code lines confirmed fully covered.

Closes item #1 of #1175 (not the whole issue — items #2, #3, #4, #5 remain).
