### PR TITLE
devenv: re-run uv sync when uv.lock or a member pyproject changes

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -70,6 +70,26 @@ in
   env.PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS = "true";
 
   tasks = {
+    # WORKAROUND: devenv's languages.python.uv.sync gate only hashes the root
+    # pyproject.toml (a bare [tool.uv.workspace] stub), so dependency changes in
+    # workspace members or captured in uv.lock never invalidate the checksum and
+    # `uv sync` is silently skipped -- the venv goes stale (e.g.
+    # "ModuleNotFoundError: No module named 'jinja2'" at backend startup).
+    # Re-sync into the devenv-managed venv when the lock or a member pyproject
+    # changes. Remove once devenv hashes uv.lock upstream (poetry/npm/pnpm/yarn/
+    # bun already hash their lock files; uv is the lone exception).
+    "klangk:uv-sync" = {
+      exec = ''
+        cd "$DEVENV_ROOT"
+        uv sync -p "$UV_PYTHON"
+      '';
+      execIfModified = [
+        "uv.lock"
+        "pyproject.toml"
+        "src/backend/pyproject.toml"
+        "src/cli/pyproject.toml"
+      ];
+    };
     "klangk:flutter-build" = {
       exec = ''exec bash "$DEVENV_ROOT/scripts/flutterbuildweb.sh"'';
       showOutput = true;
@@ -135,6 +155,7 @@ in
         cd $DEVENV_ROOT/src/backend && exec ${uvicornCmd}
       '';
       after = [
+        "klangk:uv-sync"
         "klangk:flutter-build"
         "klangk:build-workspace-image"
         "klangk:kill-containers"


### PR DESCRIPTION
## Problem

`devenv processes up --no-tui` starts nginx, then the `backend` process crashes at import time:

```
File ".../klangk_backend/emailsvc.py", line 12, in <module>
    from jinja2 import (...)
ModuleNotFoundError: No module named 'jinja2'
```

The venv is stale: `jinja2>=3.1` is declared in `src/backend/pyproject.toml` and resolved in `uv.lock`, but is not installed in `.devenv/state/venv`. devenv is not re-running `uv sync` when dependencies change.

## Root cause (upstream devenv)

devenv's uv-sync gate only fingerprints the `pyproject.toml` in `languages.python.directory` — not `uv.lock`, and not workspace-member pyprojects.

`src/modules/languages/python/default.nix:227`:
```nix
local ACTUAL_UV_CHECKSUM="${cfg.package.interpreter}:${config.lib._fileChecksum "pyproject.toml"}:${UV_SYNC_COMMAND[@]}"
```

Here `languages.python.directory = "."` and the root `pyproject.toml` is a bare `[tool.uv.workspace]` stub. Real deps live in the members and in `uv.lock`, so the checksum is effectively constant — adding `jinja2` never invalidates it and `uv sync` is skipped.

uv is the **only** package manager in devenv that omits its lock file from the gate; poetry (same file, line 287) and npm/pnpm/yarn/bun all hash their lock. This is an upstream devenv gap.

## Fix (project-level workaround)

Add a `klangk:uv-sync` task gated by `execIfModified` on `uv.lock` + the member pyprojects, and make the `backend` process depend on it. devenv's own content-hash tracking makes it a no-op when nothing changed; when the lock or a member dep moves, it re-syncs the devenv-managed venv (`uv sync -p "$UV_PYTHON"`). Remove once devenv hashes `uv.lock` upstream.

## Verification

- `nix-instantiate --parse devenv.nix` → OK
- `devenv tasks list` registers `klangk:uv-sync (watches: uv.lock, pyproject.toml, src/backend/pyproject.toml, src/cli/pyproject.toml)`
- **Pending:** a full `devenv processes up` run (builds the workspace image + starts containers) to confirm the backend boots after a resync. klangk e2e can't run on macOS, so this needs a Linux/CI run.