### PR TITLE
Install supervisor into the workspace base image

### DIFF
--- a/docs/features/container-packages.md
+++ b/docs/features/container-packages.md
@@ -44,6 +44,7 @@ so common development tasks work out of the box.
 | `tree`           | Directory tree listing                     |
 | `htop`           | Interactive process viewer                 |
 | `tmux`           | Terminal multiplexer (backs terminal tabs) |
+| `supervisor`     | Process manager (`supervisord`)            |
 | `less`           | Pager                                      |
 | `rsync`          | File synchronization                       |
 | `file`           | File type detection                        |

--- a/src/containers/workspace/Dockerfile.base
+++ b/src/containers/workspace/Dockerfile.base
@@ -40,6 +40,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     bsdextrautils \
     tmux \
     socat \
+    supervisor \
     locales \
     zsh \
     && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
Adds the Debian `supervisor` package to the workspace base image (`Dockerfile.base`), making `/usr/bin/supervisord` available in the container.

## What

One-line change to the apt-get install list (grouped with `tmux`/`socat`):

```diff
     tmux \
     socat \
+    supervisor \
     locales \
```

## Context

This mirrors the **host** image, which already installs the same package (`src/containers/host/Dockerfile:15`) and runs `supervisord` as its PID 1. Here it's installed as a tool only — same spirit as the base image pre-installing `tmux`, `socat`, `htop`, `zsh`, etc.

## What this does *not* do

It does **not** change the process model. The current architecture is:

- **PID 1** = `entrypoint.sh` → `exec sleep infinity` (keeps the namespace alive)
- Everything else — terminals, the Pi agent — is launched by the **host backend** via `podman exec` / tmux

The host backend is the real supervisor today; `supervisord` is installed-but-unused in the workspace container. Wiring it up to actually run (e.g. as PID 1 managing in-container daemons) would be a separate, larger change touching `entrypoint.sh`, the readiness sentinel the backend polls, and how the agent is launched.

## Rebuild note

The base image is tagged by date+sha (`ghcr.io/mcdonc/klangk/klangk-workspace-base:2026.06.24-fc6981c`, referenced as `ARG WORKSPACE_BASE_IMAGE` in `Dockerfile`). Changing `Dockerfile.base` requires rebuilding the base image and bumping that tag. The base-image CI workflow (`.github/workflows/image-workspace-base.yml`) handles the rebuild + tag bump on merge.