### PR TITLE
feat(cli): add --command/-c flag to klangkc create

### DIFF
--- a/docs/features/service-command.md
+++ b/docs/features/service-command.md
@@ -49,12 +49,14 @@ later in the workspace **Settings** tab.
 
 ### CLI
 
-`klangkc create` does not expose a flag for the service command — set it
-in the Web UI when creating the workspace, or via [sandbox config](#sandbox-config)
-for `klangkc sandbox`. On an existing workspace, use `klangkc edit`:
+`klangkc create` accepts `--command`/`-c` to set the service command at
+creation time. On an existing workspace, use `klangkc edit`:
 
 ```bash
-# Set or change it
+# Set it when creating the workspace
+klangkc create my-workspace --command 'npm run dev'
+
+# Set or change it on an existing workspace
 klangkc edit my-workspace --command 'npm run dev'
 
 # Clear it

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -151,6 +151,8 @@ klangkc create my-project --mount ~/src:/home/klangk/work/src          # with bi
 klangkc create my-project --mount nix-store:/nix           # with named volume
 klangkc create my-project --env FOO=bar                      # with env vars
 klangkc create my-project --health-check 'curl -sf http://localhost:8080/health'  # with a service health check
+klangkc create my-project --command 'npm run dev'  # with a service command
+klangkc create my-project -c 'npm run dev'         # short form of --command
 klangkc edit my-project                  # interactive edit (name, image, command, health check, mounts, env)
 klangkc edit my-project --auto-start     # enable auto-start on server boot
 klangkc edit my-project --no-auto-start  # disable auto-start

--- a/src/cli/klangkc/main.py
+++ b/src/cli/klangkc/main.py
@@ -358,6 +358,12 @@ def create(
             "health (exit 0 = healthy). See the Health Check docs."
         ),
     ),
+    command: str | None = typer.Option(
+        None,
+        "--command",
+        "-c",
+        help="Service shell command (see `klangkc edit --command`).",
+    ),
     mount: list[str] | None = typer.Option(
         None,
         "--mount",
@@ -382,6 +388,7 @@ def create(
         ws = _client().create_workspace(
             name,
             image=image,
+            service_command=command,
             auto_start=auto_start,
             mounts=mount or None,
             env=env_dict,

--- a/src/cli/tests/test_cli_main.py
+++ b/src/cli/tests/test_cli_main.py
@@ -2031,9 +2031,35 @@ class TestMainCLI:
         client.create_workspace.assert_called_once_with(
             "ws",
             image=None,
+            service_command=None,
             auto_start=False,
             mounts=None,
             env={"FOO": "bar", "X": "1"},
+            health_check=None,
+        )
+
+    def test_create_with_command_flag(self, logged_in_cfg, monkeypatch):
+        from klangkc import main
+
+        ws = Workspace(
+            id="new-id", name="ws", created_at="2025-01-01T00:00:00Z"
+        )
+        client = MagicMock()
+        client.create_workspace.return_value = ws
+        monkeypatch.setattr(main, "_client", lambda: client)
+
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+        result = runner.invoke(main.app, ["create", "ws", "-c", "npm run dev"])
+        assert result.exit_code == 0
+        client.create_workspace.assert_called_once_with(
+            "ws",
+            image=None,
+            service_command="npm run dev",
+            auto_start=False,
+            mounts=None,
+            env=None,
             health_check=None,
         )
 


### PR DESCRIPTION
Closes #1085.

## Summary

`klangkc create` now accepts `--command`/`-c` to set a workspace's service command at creation time, consistent with `klangkc edit --command` and the sandbox `default-command` config field.

The `KlangkClient.create_workspace(...)` already accepted `service_command`, so this is pure CLI wiring (plus docs and tests). The issue referred to the field as `default_command`, but the actual parameter/field name throughout the codebase is `service_command` (exposed as `--command`), so that's what this wires through.

## Changes

- `src/cli/klangkc/main.py` — add `--command`/`-c` option to the `create` command; forward to `create_workspace(..., service_command=command)`.
- `src/cli/tests/test_cli_main.py` — update `test_create_with_env_flag` for the new kwarg; add `test_create_with_command_flag`.
- `docs/features/service-command.md` — replace the "create does not expose a flag" note with the new usage.
- `docs/reference/cli.md` — add `--command` / `-c` examples for `create`.

## Acceptance criteria (from #1085)

- [x] `klangkc create NAME -c 'CMD'` creates a workspace whose default command is `CMD`.
- [x] `klangkc create NAME` (no flag) still creates a workspace with no default command.
- [x] Documented alongside the existing `--command` reference for `edit`.