### PR TITLE
devenv: sync uv deps before enterShell, not just for the backend process

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -28,7 +28,9 @@ in
     venv.enable = true;
     uv = {
       enable = true;
-      sync.enable = true;
+      # sync.enable left off: its gate only fingerprints the root
+      # pyproject.toml (a bare [tool.uv.workspace] stub here), so it silently
+      # skips and the venv goes stale. klangk:uv-sync below owns dependency sync.
     };
     directory = ".";
   };
@@ -75,14 +77,23 @@ in
     # workspace members or captured in uv.lock never invalidate the checksum and
     # `uv sync` is silently skipped -- the venv goes stale (e.g.
     # "ModuleNotFoundError: No module named 'jinja2'" at backend startup).
-    # Re-sync into the devenv-managed venv when the lock or a member pyproject
-    # changes. Remove once devenv hashes uv.lock upstream (poetry/npm/pnpm/yarn/
-    # bun already hash their lock files; uv is the lone exception).
+    #
+    # Hooked into devenv:enterShell (runs before every shell, process, and test
+    # activation), so deps stay current for `devenv shell`, `devenv test`,
+    # pre-commit hooks, AND `devenv processes up` -- not just the backend process.
+    # `after` pins ordering: devenv must create the venv
+    # (devenv:python:virtualenv) first, or it would `rm -rf` our freshly-synced
+    # deps on a cold / interpreter-changed venv. execIfModified makes it a no-op
+    # when nothing changed. Remove once devenv hashes uv.lock upstream
+    # (poetry/npm/pnpm/yarn/bun already hash their lock files; uv is the lone
+    # exception).
     "klangk:uv-sync" = {
       exec = ''
         cd "$DEVENV_ROOT"
         uv sync -p "$UV_PYTHON"
       '';
+      after = [ "devenv:python:virtualenv" ];
+      before = [ "devenv:enterShell" ];
       execIfModified = [
         "uv.lock"
         "pyproject.toml"
@@ -155,7 +166,6 @@ in
         cd $DEVENV_ROOT/src/backend && exec ${uvicornCmd}
       '';
       after = [
-        "klangk:uv-sync"
         "klangk:flutter-build"
         "klangk:build-workspace-image"
         "klangk:kill-containers"


### PR DESCRIPTION
## Follow-up to #1214

#1214 added `klangk:uv-sync` but wired it **only** into `processes.backend.after`. That fixes `devenv processes up` (the original crash), but leaves every other entry point dependent on the very broken gate it was working around:

- `devenv shell` on a fresh clone
- `devenv test` / `test-backend` / `test-cli` / fuzz
- pre-commit hooks (ruff, deferred-imports check)

devenv's `languages.python.uv.sync` gate fingerprints only the root `pyproject.toml` (a bare `[tool.uv.workspace]` stub here), so it silently no-ops and the venv goes stale everywhere except the backend-process path.

## Fix

Hook the task into `devenv:enterShell` — the lifecycle event that runs before **every** shell, process, and test activation — so deps stay current across all entry points.

```nix
"klangk:uv-sync" = {
  exec = \n    cd "$DEVENV_ROOT"\n    uv sync -p "$UV_PYTHON"\n  ;
  after = [ "devenv:python:virtualenv" ];   # devenv creates the venv first
  before = [ "devenv:enterShell" ];         # then we populate it, before shell entry
  execIfModified = [ "uv.lock" "pyproject.toml"
                     "src/backend/pyproject.toml" "src/cli/pyproject.toml" ];
};
```

### Why `after = [ "devenv:python:virtualenv" ]` is required

Two tasks that both `before = [ "devenv:enterShell" ]` have **undefined** relative order. devenv's venv-init (`initVenvScript`) does, on a cold / interpreter-changed venv:

```bash
if [ -z $venv_python ] || [ $profile_python != $venv_python ]; then
  rm -rf "$VENV_PATH"   # wipes whatever we just synced
  uv venv -p ... "$VENV_PATH"
```

Without the `after` pin, a cold start could run our sync first, then devenv wipes it. `after = [ "devenv:python:virtualenv" ]` guarantees: create venv → populate it → enter shell.

### Why `languages.python.uv.sync.enable` can now be dropped

With `sync.enable` off, devenv still creates + activates the venv and exports `PATH`/`VIRTUAL_ENV` (via the `devenv:python:virtualenv` task) — it only stops running the broken-gated `uv sync`. So the task is now the single owner of dependency sync; the built-in gate is dead weight that silently no-ops. The `# remove once upstream hashes uv.lock` note now means: re-enable `sync.enable` and delete this task.

## Verification

`devenv shell` runs the tasks in the intended order:

```
• Running devenv:python:virtualenv
✓ Running devenv:python:virtualenv in 533ms
• Running klangk:uv-sync
 + jinja2==3.1.6   ... (74 packages installed)
✓ Running klangk:uv-sync in 332ms
• Running devenv:enterShell
✓ Running devenv:enterShell in 14.5ms
```

`jinja2` (the original `ModuleNotFoundError` from #1214) is installed before the shell is entered.

- `nix-instantiate --parse devenv.nix` → OK
- `nixfmt` / `prettier` / `trufflehog` pre-commit hooks → Passed
- Subsequent runs hit `execIfModified` cache (no-op) → `klangk:uv-sync in 2.78ms (cached)`

## Coverage comparison vs #1214

| entry point | #1214 (`backend.after`) | this PR (`before enterShell`) |
|---|---|---|
| `devenv processes up` → backend | ✅ | ✅ |
| `devenv shell` (fresh clone) | ❌ broken gate | ✅ |
| `devenv test` / test scripts | ❌ broken gate | ✅ |
| pre-commit hooks | ❌ broken gate | ✅ |
| single source of truth | ❌ (dead gate still runs) | ✅ |

**Pending:** a Linux/CI `devenv processes up` run (I can't run klangk e2e on macOS).