### PR TITLE
fix(terminal): kill zombie service-cmd window on send-keys failure

### DIFF
--- a/src/backend/klangk_backend/terminal.py
+++ b/src/backend/klangk_backend/terminal.py
@@ -299,6 +299,27 @@ async def ensure_service_session(
         )
     except Exception:
         logger.warning("Failed to send service command to %s", SERVICE_SESSION)
+        # The window was created above but we never typed the command
+        # into it. Kill it so the next fire re-runs the whole sequence
+        # instead of no-op'ing forever on the half-created window (#1186).
+        try:
+            await podman.exec_container(
+                container_id,
+                [
+                    "tmux",
+                    "kill-window",
+                    "-t",
+                    f"{SERVICE_SESSION}:{SERVICE_CMD_WINDOW}",
+                ],
+                user=CONTAINER_USER,
+                timeout=5,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to clean up %s window in %s",
+                SERVICE_CMD_WINDOW,
+                SERVICE_SESSION,
+            )
 
 
 def _build_shell_command(

--- a/src/backend/tests/test_terminal.py
+++ b/src/backend/tests/test_terminal.py
@@ -1424,13 +1424,53 @@ class TestEnsureServiceSession:
             patch(
                 "klangk_backend.terminal.podman.exec_container",
                 new=AsyncMock(
-                    side_effect=[(0, "", ""), RuntimeError("send broke")]
+                    side_effect=[
+                        (0, "", ""),  # new-window succeeds
+                        RuntimeError("send broke"),  # send-keys fails
+                        (0, "", ""),  # kill-window cleanup
+                    ]
                 ),
             ),
             patch("klangk_backend.terminal.logger") as mock_logger,
         ):
             await ensure_service_session("cid", "/home/clanker", "cmd")
         mock_logger.warning.assert_called()
+
+    async def test_send_keys_failure_kills_half_created_window(self):
+        """A send-keys failure kills the zombie window so the next fire
+        re-runs the whole sequence instead of no-oping forever (#1186)."""
+        from klangk_backend.terminal import ensure_service_session
+
+        with (
+            patch(
+                "klangk_backend.terminal._ensure_tmux_session",
+                new=AsyncMock(),
+            ),
+            patch(
+                "klangk_backend.terminal._service_cmd_window_exists",
+                new=AsyncMock(return_value=False),
+            ),
+            patch(
+                "klangk_backend.terminal.podman.exec_container",
+                new=AsyncMock(
+                    side_effect=[
+                        (0, "", ""),  # new-window succeeds
+                        RuntimeError("send broke"),  # send-keys fails
+                        (0, "", ""),  # kill-window cleanup
+                    ]
+                ),
+            ) as mock_exec,
+            patch("klangk_backend.terminal.logger"),
+        ):
+            await ensure_service_session("cid", "/home/clanker", "cmd")
+
+        # The third exec call must be the kill-window cleanup targeting
+        # the service-cmd window we just created.
+        cleanup_call = mock_exec.call_args_list[2]
+        argv = cleanup_call.args[1]
+        assert "tmux" in argv
+        assert "kill-window" in argv
+        assert "service:service-cmd" in argv
 
 
 class TestServiceSessionHelpers:

--- a/src/backend/tests/test_terminal.py
+++ b/src/backend/tests/test_terminal.py
@@ -1472,6 +1472,36 @@ class TestEnsureServiceSession:
         assert "kill-window" in argv
         assert "service:service-cmd" in argv
 
+    async def test_send_keys_failure_cleanup_failure_is_logged(self):
+        """If the kill-window cleanup itself raises, it's logged but the
+        function still returns without raising (#1186)."""
+        from klangk_backend.terminal import ensure_service_session
+
+        with (
+            patch(
+                "klangk_backend.terminal._ensure_tmux_session",
+                new=AsyncMock(),
+            ),
+            patch(
+                "klangk_backend.terminal._service_cmd_window_exists",
+                new=AsyncMock(return_value=False),
+            ),
+            patch(
+                "klangk_backend.terminal.podman.exec_container",
+                new=AsyncMock(
+                    side_effect=[
+                        (0, "", ""),  # new-window succeeds
+                        RuntimeError("send broke"),  # send-keys fails
+                        RuntimeError("cleanup broke"),  # kill-window fails
+                    ]
+                ),
+            ),
+            patch("klangk_backend.terminal.logger") as mock_logger,
+        ):
+            await ensure_service_session("cid", "/home/clanker", "cmd")
+        # Both the send-keys failure and the cleanup failure are warned.
+        assert mock_logger.warning.call_count == 2
+
 
 class TestServiceSessionHelpers:
     """Direct coverage for the firing-predicate helpers used by


### PR DESCRIPTION
Closes #1186.

## Summary

In `ensure_service_session`, if `tmux new-window` succeeds but the subsequent `tmux send-keys` raises (any transient `podman exec` failure — high load, timeout, exec socket hiccup), the half-created `service-cmd` window was left behind as an idle shell. Every later fire — from both the boot path (`workspaces.eager_start_workspace`) and any `terminal_start` (`wshandler/controllers._fire_service_command`) — sees `_service_cmd_window_exists` → True and no-ops. The service command then **silently never runs for the life of the container**, with no recovery short of recreating the container.

The code was "exactly-once" in name but really *at-most-once with silent permanent failure*.

## Fix

On `send-keys` failure, kill the just-created window so the next fire re-runs the whole sequence instead of locking the command out permanently. Cleanup failure is logged but swallowed (best-effort), matching the existing `new-window` failure-path style.

```python
except Exception:
    logger.warning("Failed to send service command to %s", SERVICE_SESSION)
    # kill the half-created window so the next fire re-runs the sequence (#1186)
    try:
        await podman.exec_container(container_id,
            ["tmux", "kill-window", "-t", f"{SERVICE_SESSION}:{SERVICE_CMD_WINDOW}"],
            user=CONTAINER_USER, timeout=5)
    except Exception:
        logger.warning("Failed to clean up %s window in %s", SERVICE_CMD_WINDOW, SERVICE_SESSION)
```

The `new-window` failure path was already fine (no window was created in that case) — only the `send-keys` path needed cleanup.

## Note on naming

The issue was filed against the older `default_command` / `default-cmd` / `_default_cmd_window_exists` naming. That code has since been refactored (#1133) to `service_command` / `service-cmd` / `_service_cmd_window_exists`, but the bug is identical and the fix applies directly to the renamed identifiers.

## Tests

- Updated `test_send_keys_failure_logs_warning` for the new third (cleanup) `podman.exec_container` call.
- Added `test_send_keys_failure_kills_half_created_window` asserting the `kill-window` cleanup targets `service:service-cmd`.

All 112 tests in `test_terminal.py` pass.