### PR TITLE
terminal: serialize ensure_service_session firing per container

### DIFF
--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -688,6 +688,8 @@ class ContainerRegistry:
         state = self.states.pop(workspace_id, None)
         if state:
             self._cid_to_wsid.pop(state.container_id, None)
+            # Drop the per-container service-firing lock (#1188).
+            terminal.clear_service_session_lock(state.container_id)
         self._workspace_locks.pop(workspace_id, None)
 
     # --- Proxy: PortAllocator ---
@@ -1275,6 +1277,8 @@ class ContainerRegistry:
             self.revoke_workspace_browsers(ws_id)
             self.states.pop(ws_id, None)
             self._workspace_locks.pop(ws_id, None)
+        # Drop the per-container service-firing lock (#1188).
+        terminal.clear_service_session_lock(container_id)
 
     async def _notify_workspace_killed(self, workspace_id: str) -> None:
         """Call the on_workspace_killed callback, logging any errors."""

--- a/src/backend/klangk_backend/terminal.py
+++ b/src/backend/klangk_backend/terminal.py
@@ -105,6 +105,34 @@ SERVICE_CMD_WINDOW = "service-cmd"
 # dying because it is just a tmux session) (#1133 D6).
 SERVICE_SESSION = "service"
 
+# Per-container locks serializing the read-then-write firing sequence in
+# ensure_service_session (#1188). Two unserialized callers -- the boot path
+# (workspaces.eager_start_workspace) and the per-connection path
+# (wshandler _fire_service_command) -- could both observe
+# _service_cmd_window_exists -> False before either's new-window landed, and
+# since tmux permits duplicate window names, both would create a service-cmd
+# window. The lock makes the window-exists -> new-window -> send-keys sequence
+# atomic per container, so unrelated workspaces fire concurrently but the
+# same workspace fires exactly once. Entries are cleared on container teardown
+# via clear_service_session_lock().
+_service_session_locks: dict[str, asyncio.Lock] = {}
+
+
+def _get_service_session_lock(container_id: str) -> asyncio.Lock:
+    """Get or create the per-container lock for service-command firing."""
+    if container_id not in _service_session_locks:
+        _service_session_locks[container_id] = asyncio.Lock()
+    return _service_session_locks[container_id]
+
+
+def clear_service_session_lock(container_id: str) -> None:
+    """Drop the per-container firing lock for a torn-down container.
+
+    Called from container teardown so the lock dict does not grow unbounded
+    with container churn. Safe to call when no lock exists for the id.
+    """
+    _service_session_locks.pop(container_id, None)
+
 
 async def _has_tmux_session(container_id: str, session_name: str) -> bool:
     """Return True if a tmux session named *session_name* exists."""
@@ -251,54 +279,69 @@ async def ensure_service_session(
     (exactly-once-per-container). Idempotent: safe to call from every
     ``terminal_start`` (#1033) and the boot path alike -- the
     window-exists check makes it a no-op after the first fire.
+
+    The window-exists -> new-window -> send-keys sequence is serialized
+    per container via :func:`_get_service_session_lock` (#1188): without
+    it the boot path and the per-connection path could both pass the
+    existence check before either created the window, producing two
+    duplicate-named ``service-cmd`` windows (tmux allows duplicate
+    names), leaving later ``send-keys -t service:service-cmd`` ambiguous.
     """
-    await _ensure_tmux_session(container_id, SERVICE_SESSION, agent_home)
-    if not (
-        _should_fire_service_command(service_command, setup_state)
-    ) or await _service_cmd_window_exists(container_id, SERVICE_SESSION):
-        return
-    try:
-        await podman.exec_container(
-            container_id,
-            [
-                "tmux",
-                "new-window",
-                "-d",
-                "-t",
-                SERVICE_SESSION,
-                "-n",
+    # Hold the per-container lock across the entire read-modify-write so
+    # a concurrent caller (boot vs first terminal_start, owner vs
+    # collaborator) cannot interleave: the second waits, then observes
+    # the window exists and no-ops. This also bounds the partial-failure
+    # window from #1186.
+    async with _get_service_session_lock(container_id):
+        await _ensure_tmux_session(container_id, SERVICE_SESSION, agent_home)
+        if not (
+            _should_fire_service_command(service_command, setup_state)
+        ) or await _service_cmd_window_exists(container_id, SERVICE_SESSION):
+            return
+        try:
+            await podman.exec_container(
+                container_id,
+                [
+                    "tmux",
+                    "new-window",
+                    "-d",
+                    "-t",
+                    SERVICE_SESSION,
+                    "-n",
+                    SERVICE_CMD_WINDOW,
+                ],
+                user=CONTAINER_USER,
+                timeout=5,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to create %s window in %s",
                 SERVICE_CMD_WINDOW,
-            ],
-            user=CONTAINER_USER,
-            timeout=5,
-        )
-    except Exception:
-        logger.warning(
-            "Failed to create %s window in %s",
-            SERVICE_CMD_WINDOW,
-            SERVICE_SESSION,
-        )
-        return
-    # The new window's shell needs a moment to source .profile / .bashrc
-    # before it can resolve PATH-dependent commands (nvm, openclaw, ...).
-    # Same race as #1030.
-    await asyncio.sleep(1)
-    try:
-        await podman.exec_container(
-            container_id,
-            [
-                "tmux",
-                "send-keys",
-                "-t",
-                f"{SERVICE_SESSION}:{SERVICE_CMD_WINDOW}",
-                service_command,
-                "Enter",
-            ],
-            user=CONTAINER_USER,
-            timeout=5,
-        )
-    except Exception:
-        logger.warning("Failed to send service command to %s", SERVICE_SESSION)
+                SERVICE_SESSION,
+            )
+            return
+        # The new window's shell needs a moment to source .profile / .bashrc
+        # before it can resolve PATH-dependent commands (nvm, openclaw, ...).
+        # Same race as #1030.
+        await asyncio.sleep(1)
+        try:
+            await podman.exec_container(
+                container_id,
+                [
+                    "tmux",
+                    "send-keys",
+                    "-t",
+                    f"{SERVICE_SESSION}:{SERVICE_CMD_WINDOW}",
+                    service_command,
+                    "Enter",
+                ],
+                user=CONTAINER_USER,
+                timeout=5,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to send service command to %s", SERVICE_SESSION
+            )
 
 
 def _build_shell_command(

--- a/src/backend/tests/test_terminal.py
+++ b/src/backend/tests/test_terminal.py
@@ -1432,6 +1432,173 @@ class TestEnsureServiceSession:
             await ensure_service_session("cid", "/home/clanker", "cmd")
         mock_logger.warning.assert_called()
 
+    async def test_concurrent_fires_create_window_exactly_once(self):
+        """#1188: two concurrent ensure_service_session calls for the SAME
+        container must not both create the service-cmd window.
+
+        The boot path (workspaces.eager_start_workspace) and the per-connection
+        path (wshandler _fire_service_command) are both unserialized callers.
+        Without the per-container lock, both can pass the window-exists check
+        before either's new-window lands, and since tmux allows duplicate
+        window names, both create a service-cmd window -- leaving later
+        send-keys ambiguous. The lock makes window-exists -> new-window ->
+        send-keys atomic per container.
+        """
+        from klangk_backend import terminal
+
+        # Shared tmux "state": both the existence check and new-window
+        # read/write this, so once the lock forces the second caller to
+        # wait, it genuinely observes the first caller's mutation.
+        windows: set[str] = set()
+        new_window_calls = 0
+        # Capture the real sleep BEFORE patching terminal.asyncio.sleep (which
+        # neutralizes the source's 1s settle delay). fake_exec uses this real
+        # sleep(0) as an explicit yield point so the race window is
+        # deterministic: without the lock the second caller interleaves its
+        # existence check during this yield; with the lock it cannot.
+        _real_sleep = asyncio.sleep
+
+        async def fake_window_exists(cid, session):
+            return terminal.SERVICE_CMD_WINDOW in windows
+
+        async def fake_exec(cid, argv, **kwargs):
+            nonlocal new_window_calls
+            if "new-window" in argv:
+                new_window_calls += 1
+                # Yield to the loop at the write step (before mutating
+                # `windows`). Without the lock this lets the second caller
+                # observe the empty pre-creation state and also create ->
+                # reproducing the #1188 duplicate-window race.
+                await _real_sleep(0)
+                windows.add(terminal.SERVICE_CMD_WINDOW)
+            return (0, "", "")
+
+        with (
+            patch(
+                "klangk_backend.terminal._ensure_tmux_session",
+                new=AsyncMock(),
+            ),
+            patch(
+                "klangk_backend.terminal._service_cmd_window_exists",
+                side_effect=fake_window_exists,
+            ),
+            patch(
+                "klangk_backend.terminal.podman.exec_container",
+                side_effect=fake_exec,
+            ),
+            patch("klangk_backend.terminal.asyncio.sleep", new=AsyncMock()),
+        ):
+            await asyncio.gather(
+                terminal.ensure_service_session(
+                    "cid", "/home/clanker", "openclaw gateway"
+                ),
+                terminal.ensure_service_session(
+                    "cid", "/home/clanker", "openclaw gateway"
+                ),
+            )
+
+        # Exactly-once: only one new-window landed despite concurrent calls.
+        assert new_window_calls == 1
+        assert windows == {terminal.SERVICE_CMD_WINDOW}
+
+    async def test_concurrent_fires_isolated_per_container(self):
+        """#1188: the firing lock is keyed by container, so concurrent fires
+        for DIFFERENT containers are not serialized -- each fires exactly
+        once, in parallel. Unrelated workspaces must not block each other."""
+        from klangk_backend import terminal
+
+        # Per-container tmux state so the two containers don't share a view.
+        windows: dict[str, set[str]] = {"cid-a": set(), "cid-b": set()}
+        new_window_calls = 0
+        _real_sleep = asyncio.sleep
+
+        async def fake_window_exists(cid, session):
+            return terminal.SERVICE_CMD_WINDOW in windows.get(cid, set())
+
+        async def fake_exec(cid, argv, **kwargs):
+            nonlocal new_window_calls
+            if "new-window" in argv:
+                new_window_calls += 1
+                await _real_sleep(0)
+                windows.setdefault(cid, set()).add(terminal.SERVICE_CMD_WINDOW)
+            return (0, "", "")
+
+        with (
+            patch(
+                "klangk_backend.terminal._ensure_tmux_session",
+                new=AsyncMock(),
+            ),
+            patch(
+                "klangk_backend.terminal._service_cmd_window_exists",
+                side_effect=fake_window_exists,
+            ),
+            patch(
+                "klangk_backend.terminal.podman.exec_container",
+                side_effect=fake_exec,
+            ),
+            patch("klangk_backend.terminal.asyncio.sleep", new=AsyncMock()),
+        ):
+            await asyncio.gather(
+                terminal.ensure_service_session(
+                    "cid-a", "/home/clanker", "cmd-a"
+                ),
+                terminal.ensure_service_session(
+                    "cid-b", "/home/clanker", "cmd-b"
+                ),
+            )
+
+        # Each container fired exactly once -- the per-container lock did not
+        # serialize unrelated containers.
+        assert new_window_calls == 2
+        assert windows["cid-a"] == {terminal.SERVICE_CMD_WINDOW}
+        assert windows["cid-b"] == {terminal.SERVICE_CMD_WINDOW}
+
+
+class TestServiceSessionLock:
+    """Unit coverage for the per-container firing-lock helpers added in #1188."""
+
+    def setup_method(self):
+        from klangk_backend import terminal
+
+        terminal._service_session_locks.clear()
+
+    def teardown_method(self):
+        from klangk_backend import terminal
+
+        terminal._service_session_locks.clear()
+
+    def test_get_lock_returns_same_lock_for_same_container(self):
+        from klangk_backend.terminal import _get_service_session_lock
+
+        lock_a = _get_service_session_lock("cid")
+        lock_b = _get_service_session_lock("cid")
+        assert lock_a is lock_b
+
+    def test_get_lock_returns_distinct_locks_per_container(self):
+        from klangk_backend.terminal import _get_service_session_lock
+
+        lock_a = _get_service_session_lock("cid-a")
+        lock_b = _get_service_session_lock("cid-b")
+        assert lock_a is not lock_b
+
+    def test_clear_lock_removes_entry(self):
+        from klangk_backend.terminal import (
+            _get_service_session_lock,
+            _service_session_locks,
+            clear_service_session_lock,
+        )
+
+        _get_service_session_lock("cid")
+        assert "cid" in _service_session_locks
+        clear_service_session_lock("cid")
+        assert "cid" not in _service_session_locks
+
+    def test_clear_lock_is_noop_for_unknown_container(self):
+        from klangk_backend.terminal import clear_service_session_lock
+
+        # Must not raise for a container that never registered a lock.
+        clear_service_session_lock("never-seen")
+
 
 class TestServiceSessionHelpers:
     """Direct coverage for the firing-predicate helpers used by


### PR DESCRIPTION
Closes #1188.

## Problem

`terminal.ensure_service_session` had an unserialized read-then-write: the `_service_cmd_window_exists` check and `new-window` were not atomic. Two unserialized callers — the boot path (`workspaces.eager_start_workspace`) and the per-connection path (`wshandler._fire_service_command`) — could both observe `_service_cmd_window_exists → False` before either's `new-window` landed. Since **tmux permits duplicate window names**, both created a `service-cmd` window, leaving later `send-keys -t service:service-cmd` ambiguous (tmux resolves the ambiguity to one, leaving the other idle).

The existing locks (`agent._lock`, `container._workspace_locks`, `ws_session.lock`) cover other paths but not this firing sequence.

## Fix

Add a **per-container `asyncio.Lock`** (`_service_session_locks`, keyed by `container_id`) and hold it across the entire `window-exists → new-window → send-keys` sequence:

```python
async with _get_service_session_lock(container_id):
    await _ensure_tmux_session(...)
    if not _should_fire_service_command(...) or await _service_cmd_window_exists(...):
        return
    # new-window ... asyncio.sleep(1) ... send-keys
```

The second concurrent caller now waits, then observes the window the first created and no-ops — **exactly-once per container**. This is the lock option from the issue, and also bounds the partial-failure window from #1186.

**Why per-container, not per-workspace or global:** the existence check is inherently per-container (it inspects tmux state in that container), and `ensure_service_session` already takes `container_id`. Per-container granularity means unrelated workspaces fire in parallel; only same-container concurrent fires serialize.

**Lock cleanup:** entries are dropped on container teardown (`remove_state` and the cid-kill path in `container.py`) via `clear_service_session_lock()`, so the dict does not grow unbounded with container churn. `container.py` already imports `terminal`, so no new coupling.

## Tests

`src/backend/tests/test_terminal.py`:

- **`test_concurrent_fires_create_window_exactly_once`** — two concurrent fires for the same container create **exactly one** `new-window`. The fake `new-window` yields at the write step (a real `asyncio.sleep(0)` captured before the `asyncio.sleep` patch that neutralizes the source's 1s settle), forcing the race window deterministically.
  - **Verified it FAILS without the lock** (both callers interleave → 2 `new-window` calls) and **passes with it** (1 call). The assertion `new_window_calls == 1` is genuinely discriminating.
- **`test_concurrent_fires_isolated_per_container`** — different `container_id`s each fire exactly once, in parallel (proves the lock is per-container and does not serialize unrelated workspaces).
- **`TestServiceSessionLock`** — unit coverage for `_get_service_session_lock` (same/different container) and `clear_service_session_lock` (removal + noop on unknown).

## Verification

- `pytest test_terminal.py test_container.py test_workspaces.py test_wshandler.py` → **874 passed**
- `ruff check` / `ruff format` clean; pre-commit hooks Passed
- Discrimination proof: disabling the lock flips the concurrency test from 1 → 2 `new-window` calls