### PR TITLE
fix(agent): serialize _ensure_started spawn to prevent double-spawn

### DIFF
--- a/src/backend/klangk_backend/agent.py
+++ b/src/backend/klangk_backend/agent.py
@@ -148,7 +148,16 @@ class AgentSession:
     def __init__(self, workspace_id: str) -> None:
         self.workspace_id = workspace_id
         self._proc: asyncio.subprocess.Process | None = None
+        # Serializes prompt round-trips so two concurrent prompts can't
+        # interleave their stdin writes / stdout reads on one subprocess.
         self._lock = asyncio.Lock()
+        # Serializes the check-then-spawn in ``_ensure_started`` so the
+        # auto-restart path (``_monitor_process``) and the lazy-start
+        # path (``send_prompt``) can't both spawn a subprocess for the
+        # same dead process (#1189).  Separate from ``_lock`` because
+        # ``send_prompt`` already holds ``_lock`` when it calls
+        # ``_ensure_started``, and ``asyncio.Lock`` is not reentrant.
+        self._spawn_lock = asyncio.Lock()
         self._home_ready = False
         self._monitor_task: asyncio.Task | None = None
         self._restart_attempts = 0
@@ -204,44 +213,58 @@ class AgentSession:
                 "Agent gave up restarting for workspace %s" % self.workspace_id
             )
 
-        container_id = self._resolve_container_id()
-        container_home = await self._ensure_home(container_id)
-        agent_handle = await model.agent_handle()
-        system_prompt = _CHAT_SYSTEM_PROMPT.format(name=agent_handle)
-        argv = [
-            "exec",
-            "-i",
-            "-u",
-            "klangk",
-            "-e",
-            f"HOME={container_home}",
-            "-w",
-            container_home,
-            container_id,
-            "pi",
-            "--mode",
-            "rpc",
-            "--append-system-prompt",
-            system_prompt,
-        ]
-        logger.info(
-            "Starting Pi RPC for workspace %s (container %s)",
-            self.workspace_id,
-            container_id,
-        )
-        self._proc = await asyncio.create_subprocess_exec(
-            podman.PODMAN_BIN,
-            *argv,
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            start_new_session=True,
-            env=podman.subprocess_env(),
-        )
-        self._monitor_task = asyncio.create_task(
-            self._monitor_process(self._proc)
-        )
-        return self._proc
+        # Serialize the check-then-spawn.  ``_ensure_started`` has two
+        # concurrent callers on this singleton session: ``_monitor_process``
+        # (auto-restart, no other lock) and ``send_prompt`` (lazy start,
+        # under ``self._lock``).  Between the fast-path check above and the
+        # spawn below sits ``_ensure_home``, which does real podman work,
+        # so the race window is seconds wide — without this lock both
+        # callers observe ``self._proc is None`` and each spawns a
+        # ``pi --mode rpc`` subprocess, orphaning the loser (#1189).  The
+        # re-check inside the lock makes the spawn idempotent: the caller
+        # that lost the race finds the process the winner already started
+        # and returns it instead of spawning again.
+        async with self._spawn_lock:
+            if self._proc is not None and self._proc.returncode is None:
+                return self._proc
+            container_id = self._resolve_container_id()
+            container_home = await self._ensure_home(container_id)
+            agent_handle = await model.agent_handle()
+            system_prompt = _CHAT_SYSTEM_PROMPT.format(name=agent_handle)
+            argv = [
+                "exec",
+                "-i",
+                "-u",
+                "klangk",
+                "-e",
+                f"HOME={container_home}",
+                "-w",
+                container_home,
+                container_id,
+                "pi",
+                "--mode",
+                "rpc",
+                "--append-system-prompt",
+                system_prompt,
+            ]
+            logger.info(
+                "Starting Pi RPC for workspace %s (container %s)",
+                self.workspace_id,
+                container_id,
+            )
+            self._proc = await asyncio.create_subprocess_exec(
+                podman.PODMAN_BIN,
+                *argv,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                start_new_session=True,
+                env=podman.subprocess_env(),
+            )
+            self._monitor_task = asyncio.create_task(
+                self._monitor_process(self._proc)
+            )
+            return self._proc
 
     async def _monitor_process(self, proc: asyncio.subprocess.Process) -> None:
         """Wait for the agent subprocess to exit, broadcast disconnect, and restart."""

--- a/src/backend/tests/test_agent.py
+++ b/src/backend/tests/test_agent.py
@@ -1013,6 +1013,58 @@ class TestAnyRunning:
         assert not any_running()
 
 
+class TestSpawnSerialization:
+    """``_ensure_started``'s check-then-spawn must be atomic (#1189).
+
+    ``_monitor_process`` (auto-restart) and ``send_prompt`` (lazy start)
+    call ``_ensure_started`` concurrently on the same singleton session
+    while ``self._proc`` is None.  ``_ensure_home`` does slow podman work
+    between the live-process check and the spawn, so without the spawn
+    lock both callers observe None and each spawn a ``pi --mode rpc``
+    subprocess — the loser is orphaned.  The lock plus the re-check must
+    guarantee exactly one spawn and that both callers share it.
+    """
+
+    async def test_concurrent_starts_spawn_once_and_share_proc(self):
+        session = _make_session("ws-race")
+
+        # Force the first caller to yield between its fast-path check
+        # and the spawn (where ``_ensure_home`` sits in real code),
+        # handing control to a second caller that has also observed
+        # ``self._proc is None``.  On unfixed code both then spawn.
+        async def slow_ensure_home(container_id):
+            await asyncio.sleep(0.05)
+            return "/home/clanker"
+
+        session._ensure_home = slow_ensure_home  # type: ignore[assignment]
+
+        spawns: list[tuple] = []
+
+        async def fake_exec(*args, **kwargs):
+            spawns.append(args)
+            proc = AsyncMock()
+            proc.returncode = None
+            proc.stdin = AsyncMock()
+            proc.stdout = asyncio.StreamReader()
+            proc.stderr = asyncio.StreamReader()
+            return proc
+
+        with (
+            patch("asyncio.create_subprocess_exec", side_effect=fake_exec),
+            # Avoid starting real monitor tasks: this test only exercises
+            # spawn serialization, not the monitor loop.
+            patch("asyncio.create_task", new=MagicMock()),
+        ):
+            proc_a, proc_b = await asyncio.gather(
+                session._ensure_started(),
+                session._ensure_started(),
+            )
+
+        assert len(spawns) == 1, f"expected one spawn, got {len(spawns)}"
+        # Both callers share the single spawned process (idempotent).
+        assert proc_a is proc_b
+
+
 class TestMonitorProcess:
     async def test_monitor_broadcasts_on_death(self):
         from klangk_backend import model


### PR DESCRIPTION
Closes #1189.

## Problem

`AgentSession._ensure_started()` read `self._proc`, awaited the slow `_ensure_home()` (real podman work — `klangk-setup-pi` with a 30s timeout), and only *then* spawned the `pi --mode rpc` subprocess. That check-then-spawn had **no lock and no re-check after the await**. Three callers can hit it concurrently on the same per-workspace singleton session, and only one of them holds `self._lock`:

- `_monitor_process` — auto-restart, **no lock**
- `send_prompt` — lazy start, holds `self._lock`
- `wshandler` `_start_agent_if_needed` — eager presence-start via `create_task`, **no lock**

Two could both observe `self._proc is None`, both run `_ensure_home`, and both reach `create_subprocess_exec` → `self._proc = ...`. Last writer wins; the loser subprocess is orphaned as an unmanaged, LLM-capable process inside the container. The window is seconds wide (not microseconds) because of the podman work between the check and the spawn.

## Fix

Add a dedicated `_spawn_lock` held across the check-then-spawn in `_ensure_started`, with a **re-check inside the lock** (double-checked locking). The lock is separate from `self._lock` because `send_prompt` already holds `self._lock` when it calls `_ensure_started`, and `asyncio.Lock` is not reentrant.

This is the issue's "cleanest" approach rather than its "simplest" (just wrapping the monitor's call): it centralizes the protection *inside* `_ensure_started` itself, so **all** callers — including the eager presence-start path in `wshandler` that the issue did not call out — are safe without each caller having to remember to take a lock. A future caller can't reintroduce the bug.

The lock-free fast path (process already alive) is preserved, so the common per-prompt case pays no lock contention; the lock is only taken when a spawn is actually needed.

## Verification

- New `TestSpawnSerialization::test_concurrent_starts_spawn_once_and_share_proc` forces two concurrent starts past the fast-path check and asserts exactly one spawn and that both callers share it. Confirmed it **fails on the unfixed code** (`expected one spawn, got 2`) and passes after the fix.
- Full `tests/test_agent.py` passes (70 tests); `agent.py` remains at **100% coverage**.
- `ruff check` / `ruff format` clean.