### PR TITLE
_setup_state_for_workspace: fail-closed to 'pending' (don't fire mid-setup)

### DIFF
--- a/src/backend/klangk_backend/wshandler/controllers.py
+++ b/src/backend/klangk_backend/wshandler/controllers.py
@@ -413,19 +413,36 @@ class TerminalController:
     async def _setup_state_for_workspace(self) -> str:
         """Fetch the workspace's setup_state fresh from the DB (#1033).
 
-        Returns the literal lifecycle value, defaulting to 'complete'
+        Returns the literal lifecycle value, deferring to ``pending``
         if the workspace can't be loaded or the lookup fails. A failed
-        lookup must NOT crash terminal_start -- defaulting to
-        'complete' preserves the historical fire-by-default behaviour
-        rather than silently disabling service commands.
+        lookup must NOT crash terminal_start -- but it also must NOT
+        eagerly fire the service command mid-setup (#1187): returning
+        ``pending`` makes :func:`terminal._should_fire_service_command`
+        defer firing until the next successful lookup reads the real,
+        post-setup state. The persisted DB ``setup_state`` stays
+        authoritative; only this terminal_start firing decision is
+        best-effort. (Fail-open-to-'complete' here used to let a
+        transient DB blip fire the default command against a
+        half-installed workspace while setup.sh was still running.)
         """
         try:
             ws = await model.get_workspace(self._conn.workspace_id)
         except Exception:
-            return "complete"
+            # Log + defer firing; don't crash terminal_start (#1187). A
+            # silent swallow would hide real bugs, so record the
+            # traceback -- info level so the failure is visible in
+            # normal operation; the lookup retries on the next
+            # terminal_start.
+            logger.info(
+                "setup_state lookup failed for workspace %s; "
+                "deferring service-command firing",
+                self._conn.workspace_id,
+                exc_info=True,
+            )
+            return model.SETUP_STATE_PENDING
         if ws is None:
-            return "complete"
-        return ws.get("setup_state") or "complete"
+            return model.SETUP_STATE_PENDING  # row genuinely absent
+        return ws.get("setup_state") or model.SETUP_STATE_PENDING
 
     async def _fire_service_command(self) -> None:
         """Fire the service command in the agent's ``service`` session.

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -5493,10 +5493,16 @@ class TestTerminalController:
         assert msg == {"type": "terminal_started"}
         assert ctrl.session is None
 
-    # --- _setup_state_for_workspace: defensive fallbacks (#1033) ---
+    # --- _setup_state_for_workspace: defensive fallbacks (#1033, #1187) ---
 
-    async def test_setup_state_db_error_defaults_to_complete(self):
-        """If the setup_state lookup raises, default to 'complete'."""
+    async def test_setup_state_db_error_defers_to_pending(self):
+        """If the setup_state lookup raises, defer firing (return 'pending').
+
+        Fail-closed, not fail-open: a transient DB failure during a
+        pending/failed workspace must NOT let the service command fire
+        mid-setup (#1187). The next successful lookup reads the real
+        state and fires then.
+        """
         ctrl, _, _ = self._controller()
         with patch.object(
             _ws_controllers.model,
@@ -5505,10 +5511,10 @@ class TestTerminalController:
             side_effect=RuntimeError("db down"),
         ):
             result = await ctrl._setup_state_for_workspace()
-        assert result == "complete"
+        assert result == "pending"
 
-    async def test_setup_state_workspace_missing_defaults_to_complete(self):
-        """If get_workspace returns None, default to 'complete'."""
+    async def test_setup_state_workspace_missing_defers_to_pending(self):
+        """If get_workspace returns None, defer firing (return 'pending')."""
         ctrl, _, _ = self._controller()
         with patch.object(
             _ws_controllers.model,
@@ -5517,7 +5523,24 @@ class TestTerminalController:
             return_value=None,
         ):
             result = await ctrl._setup_state_for_workspace()
-        assert result == "complete"
+        assert result == "pending"
+
+    async def test_setup_state_empty_value_defers_to_pending(self):
+        """A NULL/empty setup_state on the row defers firing (#1187).
+
+        The DB column is NOT NULL DEFAULT 'complete' so this is defensive,
+        but if it ever happens we treat it as unknown (don't fire) rather
+        than assuming complete.
+        """
+        ctrl, _, _ = self._controller()
+        with patch.object(
+            _ws_controllers.model,
+            "get_workspace",
+            new_callable=AsyncMock,
+            return_value={"setup_state": None},
+        ):
+            result = await ctrl._setup_state_for_workspace()
+        assert result == "pending"
 
     async def test_setup_state_returns_workspace_value(self):
         """Returns the workspace's actual setup_state when present (#1033)."""


### PR DESCRIPTION
## Summary

Fixes #1187.

`_setup_state_for_workspace()` (the post-setup `terminal_start` path) returned the literal `"complete"` on **any** exception, missing-workspace, or NULL state. Since `ensure_service_session` → `_should_fire_service_command` fires the service command iff `setup_state == "complete"`, a transient DB lookup failure during a `pending`/`failed` workspace (setup.sh still running or broken) caused the default command to fire **mid-setup** — before the workspace's software was installed.

This flips the helper to **fail-closed**: return `SETUP_STATE_PENDING` on lookup error, missing row, or empty value. `_should_fire_service_command` already treats `"pending"` as "don't fire", so firing is deferred until the next successful lookup reads the real, post-setup state.

## Why fail-closed

- **Preserves the "don't crash terminal_start" guarantee** — the `except` still swallows the error, just with a deferring value instead of an eagerly-firing one.
- **Aligns with the explicit gate** — `_should_fire_service_command` already says `pending`/`failed` block firing; the fail-open-to-`complete` was contradicting that during the exact window it matters most.
- **Self-healing** — the next `terminal_start` reads the DB fresh; once setup.sh completes and the row holds `complete`, the command fires correctly. The persisted DB `setup_state` stays authoritative; only this firing decision is best-effort.

The boot path (`workspaces.eager_start_workspace`, ~line 467) is untouched — it passes `ws.get("setup_state")` straight from the DB row and was already correct.

## Changes

- `src/backend/klangk_backend/wshandler/controllers.py` — `_setup_state_for_workspace` now returns `model.SETUP_STATE_PENDING` on exception / `None` row / empty value; docstring rewritten to document the fail-closed contract and reference #1187.
- `src/backend/tests/test_wshandler.py` — renamed the two existing fail-open tests to `*_defers_to_pending` and asserted `"pending"`; added `test_setup_state_empty_value_defers_to_pending` covering the `or` fallback for a NULL/empty `setup_state`.

## Test plan

- [x] `pytest tests/test_wshandler.py tests/test_terminal.py tests/test_workspaces.py` — 689 passed.
- [x] New/renamed `_setup_state_*` tests assert the deferred `"pending"` value on all three fallback branches.
- [x] Pre-commit hooks (ruff format/check, prettier, trufflehog) pass.