### PR TITLE
fix(devenv): run uv sync unconditionally; drop gate that skips stale venv

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -83,8 +83,18 @@ in
     # pre-commit hooks, AND `devenv processes up` -- not just the backend process.
     # `after` pins ordering: devenv must create the venv
     # (devenv:python:virtualenv) first, or it would `rm -rf` our freshly-synced
-    # deps on a cold / interpreter-changed venv. execIfModified makes it a no-op
-    # when nothing changed. Remove once devenv hashes uv.lock upstream
+    # deps on a cold / interpreter-changed venv.
+    #
+    # Deliberately NO execIfModified gate: the gate would fingerprint only the
+    # source files (uv.lock + pyproject.toml), which is a necessary-but-not-
+    # sufficient condition for a correct venv. devenv:python:virtualenv can wipe
+    # the venv (cold start, interpreter bump) independent of any source change,
+    # leaving an empty venv that the gate happily skips -- reproducing the
+    # "No module named uvicorn" startup crash on `devenv processes up`. `uv sync`
+    # is the source of truth: on a current venv it's a ~0.1s no-op
+    # (resolve+check, no installs), so running it unconditionally is cheaper
+    # than getting the gate right. Remove this whole task once devenv hashes
+    # uv.lock AND re-runs sync after virtualenv recreation upstream
     # (poetry/npm/pnpm/yarn/bun already hash their lock files; uv is the lone
     # exception).
     "klangk:uv-sync" = {
@@ -94,12 +104,6 @@ in
       '';
       after = [ "devenv:python:virtualenv" ];
       before = [ "devenv:enterShell" ];
-      execIfModified = [
-        "uv.lock"
-        "pyproject.toml"
-        "src/backend/pyproject.toml"
-        "src/cli/pyproject.toml"
-      ];
     };
     "klangk:flutter-build" = {
       exec = ''exec bash "$DEVENV_ROOT/scripts/flutterbuildweb.sh"'';


### PR DESCRIPTION
## Summary

Fixes a startup regression introduced by #1219.

#1219 wired the `klangk:uv-sync` task into `devenv:enterShell` so deps stay current across all entry points (`devenv shell`, `devenv test`, `devenv processes up`, pre-commit) — not just the backend process. But it kept the task's `execIfModified` gate, which fingerprints **only the source files** (`uv.lock` + `pyproject.toml`).

That is a necessary-but-not-sufficient condition for a correct venv. `devenv:python:virtualenv` wipes the venv (cold start, interpreter bump) **independent of any source change**, leaving an **empty venv** the gate happily skips. Result on `devenv processes up` after a venv recreation:

```
backend: No module named 'uvicorn'
nginx:   klangk-resolve-value: command not found
```

Both fail for one reason: the packages + console scripts live in the venv the gate never re-populated.

## Reproduction (definitive)

With the gate in place:
```bash
rm -rf .devenv/state/venv/lib/python3.13/site-packages/uvicorn*   # simulate a wiped venv
devenv shell -- true
# → "Running klangk:uv-sync in 3.59ms (cached)"  ← skipped!
# uvicorn still missing
```

After this fix (gate removed), the same run takes 81ms (real sync) and restores uvicorn.

## Fix

Drop `execIfModified` so the task always reconciles:

```nix
"klangk:uv-sync" = {
  exec = ''
    cd "$DEVENV_ROOT"
    uv sync -p "$UV_PYTHON"
  '';
  after = [ "devenv:python:virtualenv" ];
  before = [ "devenv:enterShell" ];
};
```

`uv sync` on a current venv is a **~0.1s no-op** (resolve + check, zero installs):

```
Resolved 75 packages in 2ms
Checked 74 packages in 1ms
real    0m0.136s
```

…so running it unconditionally is cheaper than getting a content-hash gate right — the gate can't cheaply represent "venv intact" without hashing the whole venv tree. This matches how poetry/npm/pnpm/yarn devenv projects behave (they hash the lockfile and re-run on every entry).

Refs #1219.