### PR TITLE
feat(admin): list workspaces in the delete-user confirmation

### DIFF
--- a/src/backend/klangk_backend/api/admin.py
+++ b/src/backend/klangk_backend/api/admin.py
@@ -7,6 +7,7 @@ from fastapi import (
     APIRouter,
     Depends,
     HTTPException,
+    Query,
     Request,
 )
 from pydantic import BaseModel
@@ -242,6 +243,27 @@ async def admin_create_user(
     password_hash = auth.hash_password(req.password)
     user = await model.create_user(req.email, password_hash, verified=True)
     return {"id": user["id"], "email": user["email"], "status": "created"}
+
+
+@router.get("/admin/users/{user_id}/workspaces")
+async def list_user_workspaces(
+    user_id: str,
+    limit: int | None = Query(None, ge=1, le=200),
+    offset: int | None = Query(None, ge=0),
+    admin: dict = Depends(acl.has_permission("admin")),
+):
+    """List workspaces owned by a user (admin only).
+
+    Used by the admin UI to show what a delete-user will destroy (#1224).
+    Returns the standard pagination envelope
+    ``{"items": [...], "has_more": bool, "next_offset": int | None}``.
+    """
+    user = await model.get_user_by_id(user_id)
+    if user is None:
+        raise HTTPException(status_code=404, detail="User not found")
+    return await workspaces.list_workspaces(
+        user_id, limit=limit or 100, offset=offset or 0
+    )
 
 
 @router.delete("/admin/users/{user_id}")

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -4564,6 +4564,46 @@ class TestAdminEndpoints:
         ws_list = await model.get_user_workspaces_with_containers(user["id"])
         assert len(ws_list) == 0
 
+    async def test_list_user_workspaces_admin(self, client, admin_user, user):
+        """Admin can list another user's workspaces (#1224)."""
+        headers = await self._admin_headers(client)
+        # The `user` fixture owns no workspaces yet.
+        resp = await client.get(
+            f"/api/v1/admin/users/{user['id']}/workspaces", headers=headers
+        )
+        assert resp.status_code == 200
+        assert resp.json()["items"] == []
+        assert resp.json()["has_more"] is False
+
+        # Create a workspace as that user, then it should appear.
+        user_login = await client.post(
+            "/api/v1/auth/login",
+            json={"email": "testuser@example.com", "password": "testpass"},
+        )
+        user_headers = {
+            "Authorization": f"Bearer {user_login.json()['access_token']}"
+        }
+        ws_resp = await client.post(
+            "/api/v1/workspaces",
+            headers=user_headers,
+            json={"name": "doomed"},
+        )
+        assert ws_resp.status_code == 200
+        resp = await client.get(
+            f"/api/v1/admin/users/{user['id']}/workspaces", headers=headers
+        )
+        assert resp.status_code == 200
+        names = [ws["name"] for ws in resp.json()["items"]]
+        assert names == ["doomed"]
+
+    async def test_list_user_workspaces_admin_404(self, client, admin_user):
+        """Listing workspaces for a nonexistent user 404s."""
+        headers = await self._admin_headers(client)
+        resp = await client.get(
+            "/api/v1/admin/users/nonexistent-id/workspaces", headers=headers
+        )
+        assert resp.status_code == 404
+
     async def test_update_email(self, client, admin_user, user):
         headers = await self._admin_headers(client)
         resp = await client.patch(

--- a/src/backend/tests/test_api_package.py
+++ b/src/backend/tests/test_api_package.py
@@ -35,7 +35,7 @@ api_auth = sys.modules["klangk_backend.api.auth"]
 
 # Total HTTP route operations the monolith exposed (per the issue).  The
 # split must preserve this exactly — no dropped or duplicated handlers.
-EXPECTED_ROUTE_COUNT = 85
+EXPECTED_ROUTE_COUNT = 86
 
 # Per-domain submodules and the number of routes each owns.  79 sub-routes
 # + 3 routes defined directly on the main router (version, config,
@@ -48,7 +48,7 @@ SUBMODULE_ROUTES = {
     "images": 4,
     "browser_delegate": 2,
     "chat": 1,
-    "admin": 28,
+    "admin": 29,
 }
 
 # One representative path from every domain (and the cross-cutting

--- a/src/frontend/lib/admin/admin_users_page.dart
+++ b/src/frontend/lib/admin/admin_users_page.dart
@@ -163,12 +163,41 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
   }
 
   Future<void> _deleteUser(String userId, String email) async {
+    final auth = context.read<AuthService>();
+
+    // Fetch the user's owned workspaces up front so the confirmation can
+    // show exactly what a delete will destroy (#1224). On failure we fall
+    // back to the old generic message.
+    List<String> workspaceNames = [];
+    var hasMoreWorkspaces = false;
+    var fetchFailed = false;
+    try {
+      final wsResp = await auth.authGet(
+        '/api/v1/admin/users/$userId/workspaces?limit=100',
+      );
+      if (wsResp.statusCode == 200) {
+        final body = jsonDecode(wsResp.body);
+        final items = body['items'] as List? ?? [];
+        workspaceNames = items.map((w) => w['name'] as String? ?? '').toList();
+        hasMoreWorkspaces = body['has_more'] as bool? ?? false;
+      } else {
+        fetchFailed = true;
+      }
+    } catch (_) {
+      fetchFailed = true;
+    }
+
+    if (!mounted) return;
+
     final confirm = await showDialog<bool>(
       context: context,
       builder: (ctx) => AlertDialog(
         title: const Text('Delete User'),
-        content: Text(
-          'Delete user "$email"? This will delete all their workspaces and data.',
+        content: _deleteUserDialogContent(
+          email,
+          workspaceNames,
+          hasMoreWorkspaces,
+          fetchFailed,
         ),
         actions: [
           TextButton(
@@ -189,7 +218,6 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
     );
     if (confirm != true) return;
 
-    final auth = context.read<AuthService>();
     final resp = await auth.authDelete('/api/v1/admin/users/$userId');
     if (resp.statusCode == 200) {
       _loadUsers();
@@ -201,6 +229,78 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
         );
       }
     }
+  }
+
+  /// Body for the delete-user confirmation dialog. Lists the workspaces
+  /// that will be destroyed so the admin can sanity-check before
+  /// committing (#1224). Falls back to a generic message when the
+  /// workspace fetch failed.
+  Widget _deleteUserDialogContent(
+    String email,
+    List<String> workspaceNames,
+    bool hasMoreWorkspaces,
+    bool fetchFailed,
+  ) {
+    final count = workspaceNames.length;
+    final word = count == 1 ? 'workspace' : 'workspaces';
+
+    String summary;
+    if (fetchFailed) {
+      summary = 'Delete user "$email"? This will permanently delete all their '
+          'workspaces and data.';
+    } else if (count == 0) {
+      summary = 'Delete user "$email"? They own no workspaces.';
+    } else if (hasMoreWorkspaces) {
+      summary = 'Delete user "$email"? This will permanently delete '
+          '100+ workspaces and all their data:';
+    } else {
+      summary = 'Delete user "$email"? This will permanently delete '
+          '$count $word and all their data:';
+    }
+
+    final children = <Widget>[
+      Text(summary),
+    ];
+
+    // List the names (capped at 100 by the fetch; scrollable so a long
+    // list doesn't blow out the dialog).
+    if (!fetchFailed && count > 0) {
+      children.add(
+        const SizedBox(height: 12),
+      );
+      children.add(
+        ConstrainedBox(
+          constraints: const BoxConstraints(maxHeight: 240),
+          child: SingleChildScrollView(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                for (final name in workspaceNames)
+                  Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 1),
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        const Text('•  '),
+                        Expanded(child: Text(name)),
+                      ],
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      );
+    }
+
+    return SizedBox(
+      width: double.maxFinite,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: children,
+      ),
+    );
   }
 
   Future<void> _editUser(Map<String, dynamic> user) async {

--- a/src/frontend/test/admin_users_page_test.dart
+++ b/src/frontend/test/admin_users_page_test.dart
@@ -940,4 +940,124 @@ void main() {
       expect(writes, isEmpty);
     });
   });
+
+  group('AdminUsersPage delete-user confirmation', () {
+    /// Serves a single user plus [workspaces] for that user's
+    /// `/admin/users/{id}/workspaces` endpoint, and captures the DELETE.
+    void serveDeleteUser(
+      List<Map<String, dynamic>> workspaces, {
+      bool hasMore = false,
+      List<String> deletedIds = const [],
+    }) {
+      testAuthHttpClientOverride = _mockClient((request) async {
+        final path = request.url.path;
+        if (path == '/api/v1/admin/users') {
+          return http.Response(
+            _usersEnvelope([_user('alice@example.com', id: 'u1')], total: 1),
+            200,
+          );
+        }
+        if (path == '/api/v1/admin/users/u1/workspaces') {
+          return http.Response(
+            jsonEncode({
+              'items': workspaces,
+              'has_more': hasMore,
+              'next_offset': hasMore ? 100 : null,
+            }),
+            200,
+          );
+        }
+        if (path == '/api/v1/admin/users/u1' && request.method == 'DELETE') {
+          deletedIds.add('u1');
+          return http.Response(jsonEncode({'status': 'deleted'}), 200);
+        }
+        if (path == '/api/v1/admin/invitations') {
+          return http.Response(emptyInvitationsEnvelope(), 200);
+        }
+        if (path == '/api/v1/admin/groups') {
+          return http.Response(_groupsEnvelope([]), 200);
+        }
+        return http.Response('Not found', 404);
+      });
+    }
+
+    Map<String, dynamic> _ws(String name) => {'name': name};
+
+    testWidgets('lists owned workspaces and their count', (tester) async {
+      final deleted = <String>[];
+      serveDeleteUser(
+        [_ws('my-app'), _ws('staging-env'), _ws('scratch')],
+        deletedIds: deleted,
+      );
+      await pumpPage(tester);
+
+      await tester.tap(find.byTooltip('Delete user'));
+      await tester.pumpAndSettle();
+
+      // Count + each name appears in the confirmation.
+      expect(find.textContaining('3 workspaces'), findsOneWidget);
+      expect(find.text('my-app'), findsOneWidget);
+      expect(find.text('staging-env'), findsOneWidget);
+      expect(find.text('scratch'), findsOneWidget);
+
+      // Confirming issues the DELETE.
+      await tester.tap(find.widgetWithText(FilledButton, 'Delete'));
+      await tester.pumpAndSettle();
+      expect(deleted, ['u1']);
+    });
+
+    testWidgets('singular "workspace" for a single owned workspace',
+        (tester) async {
+      serveDeleteUser([_ws('lonely')]);
+      await pumpPage(tester);
+
+      await tester.tap(find.byTooltip('Delete user'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('1 workspace'), findsOneWidget);
+      expect(find.text('lonely'), findsOneWidget);
+    });
+
+    testWidgets('zero workspaces does not imply workspace data loss',
+        (tester) async {
+      serveDeleteUser([]);
+      await pumpPage(tester);
+
+      await tester.tap(find.byTooltip('Delete user'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('no workspaces'), findsOneWidget);
+      // No bulleted workspace list rendered.
+      expect(find.text('•'), findsNothing);
+    });
+
+    testWidgets('100+ workspaces handled gracefully when has_more',
+        (tester) async {
+      serveDeleteUser(
+        [for (var i = 0; i < 100; i++) _ws('ws$i')],
+        hasMore: true,
+      );
+      await pumpPage(tester);
+
+      await tester.tap(find.byTooltip('Delete user'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('100+ workspaces'), findsOneWidget);
+    });
+
+    testWidgets('cancel closes the dialog without deleting', (tester) async {
+      final deleted = <String>[];
+      serveDeleteUser([_ws('my-app')], deletedIds: deleted);
+      await pumpPage(tester);
+
+      await tester.tap(find.byTooltip('Delete user'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.widgetWithText(TextButton, 'Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AlertDialog), findsNothing);
+      expect(deleted, isEmpty);
+    });
+  });
 }


### PR DESCRIPTION
Closes #1224.

## Summary

The delete-user confirmation showed a generic *"this will delete all their workspaces and data"* message with **no count and no names**, so an admin couldn't tell whether they were destroying 0 or 50 workspaces. Workspace deletion is irreversible — the confirmation now shows the consequence concretely: the count and a bulleted list of workspace names.

## Changes

**Backend** — `src/backend/klangk_backend/api/admin.py`
- New admin endpoint `GET /admin/users/{user_id}/workspaces` (admin-scoped) that returns the standard pagination envelope by reusing `workspaces.list_workspaces(user_id, ...)`. Previously `/workspaces` only listed the *current* user's workspaces, so the UI had no way to list another user's.

**Frontend** — `src/frontend/lib/admin/admin_users_page.dart`
- `_deleteUser` now fetches the user's workspaces (`?limit=100`) before showing the dialog.
- The confirmation shows:
  - count with singular/plural (`3 workspaces` / `1 workspace`),
  - a scrollable, capped bulleted list of names,
  - **zero workspaces** → *"They own no workspaces."* (no implied workspace data loss),
  - **100+** (`has_more`) → *"100+ workspaces"*,
  - **fetch failure** → falls back to the original generic message.
- The Cancel action and the `DELETE /admin/users/{id}` call are unchanged.

## Tests

- Backend: `test_list_user_workspaces_admin` (lists another user's ws), `test_list_user_workspaces_admin_404`; bumped route-count parity (`EXPECTED_ROUTE_COUNT` 85→86, `admin` 28→29).
- Frontend (`admin_users_page_test.dart`): 5 new tests — count+names, singular, zero-workspaces, 100+ graceful, cancel-doesn't-delete.

All 2109 backend tests pass (100% coverage); all 871 frontend tests pass.

## Acceptance criteria (from #1224)

- [x] Confirmation shows the count of workspaces that will be deleted.
- [x] Confirmation lists the workspace names (scrollable/capped for many).
- [x] A user who owns zero workspaces shows "no workspaces" rather than implying data loss that won't happen.