### PR TITLE
fix(health): give the startup command a grace period before health checks can flag unhealthy

### DIFF
--- a/docs/features/health-check.md
+++ b/docs/features/health-check.md
@@ -55,6 +55,27 @@ For each workspace with a health check configured:
    check's stderr/stdout), and the time of the last check are exposed
    via `GET /api/v1/workspaces/{id}/status`.
 
+### Startup grace period
+
+A service that was _just_ launched needs time to boot. To avoid the
+very first poll false-flagging a freshly-started service as unhealthy
+(e.g. "Gateway not yet ready to accept connections" while an AI gateway
+is still coming up), Klangk applies a **startup grace window** —
+modelled on Docker's `HEALTHCHECK --start-period`:
+
+- For `KLANGK_HEALTH_CHECK_STARTUP_GRACE` seconds (default 30) after
+  the service command fires, a **failing** check does _not_ transition
+  the workspace to unhealthy, broadcast, or log a failure — the blip is
+  treated as expected boot-up noise.
+- A **passing** check is still recorded immediately, so a fast-booting
+  service shows up healthy the moment it actually responds rather than
+  after the whole window.
+
+The window is anchored to when the service command actually launches
+(so it covers the real boot), and falls back to container start for
+health-checked workspaces that have no service command. After the
+window elapses, failures are reported normally.
+
 A failing check is **not a black box**: the tail of its output (stderr
 preferred) is logged when the status flips to unhealthy, retained on
 the workspace as `health_message`, and carried on the `service_health`
@@ -250,13 +271,14 @@ probe.
 
 ## Server tuning
 
-The polling interval and the per-check timeout are configurable via
-environment variables on the server:
+The polling interval, the per-check timeout, and the startup grace
+period are configurable via environment variables on the server:
 
-| Variable                       | Default | Description                                                                 |
-| ------------------------------ | ------- | --------------------------------------------------------------------------- |
-| `KLANGK_HEALTH_CHECK_INTERVAL` | `30`    | Seconds between polls for each workspace.                                   |
-| `KLANGK_HEALTH_CHECK_TIMEOUT`  | `10`    | Seconds before a single `podman exec` check is killed and marked unhealthy. |
+| Variable                            | Default | Description                                                                                   |
+| ----------------------------------- | ------- | --------------------------------------------------------------------------------------------- |
+| `KLANGK_HEALTH_CHECK_INTERVAL`      | `30`    | Seconds between polls for each workspace.                                                     |
+| `KLANGK_HEALTH_CHECK_TIMEOUT`       | `10`    | Seconds before a single `podman exec` check is killed and marked unhealthy.                   |
+| `KLANGK_HEALTH_CHECK_STARTUP_GRACE` | `30`    | Seconds after the service launches during which a failing check is not unhealthy (see below). |
 
 `podman exec` is a local Unix socket call to the Podman API, not a
 network round-trip, so running a check every 30 seconds per container

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -199,6 +199,21 @@ HEALTH_CHECK_INTERVAL_SECONDS = int(
 HEALTH_CHECK_TIMEOUT_SECONDS = float(
     util.resolve_env_value("KLANGK_HEALTH_CHECK_TIMEOUT") or "10"
 )
+# Startup grace period (seconds).  After a service begins starting,
+# failing health checks do NOT count as unhealthy until this much time
+# has elapsed -- mirroring Docker's HEALTHCHECK `--start-period`.  The
+# service command (a dev server, AI gateway, daemon) needs time to boot
+# after it's launched; without a grace window the very first poll fires
+# while it's still coming up and false-flags the workspace unhealthy
+# (e.g. "Gateway not yet ready to accept connections").  A *healthy*
+# result is still recorded immediately, so a fast-booting service shows
+# up as healthy as soon as it actually responds.  The window is anchored
+# to when the service command fires (see ``mark_service_started``) and
+# falls back to when the container state was first tracked, so
+# health-checked workspaces with no service command also get a grace.
+HEALTH_CHECK_STARTUP_GRACE_SECONDS = float(
+    util.resolve_env_value("KLANGK_HEALTH_CHECK_STARTUP_GRACE") or "30"
+)
 # Maximum bytes of check output retained as the failure reason (#1088).
 # A bounded tail keeps a verbose check from growing memory unbounded
 # across many workspaces while still capturing *why* it failed.
@@ -226,9 +241,30 @@ class ContainerState:
         self.health_check: str | None = None  # shell command, None = disabled
         self.owner_id: str | None = None
         self.setup_state: str | None = None
+        # Anchor for the startup grace window
+        # (HEALTH_CHECK_STARTUP_GRACE_SECONDS): the moment the monitored
+        # service began starting.  Defaults to now (container-state
+        # creation) so health-checked workspaces with no service command
+        # still get a grace window; reset to "now" by
+        # ``mark_service_started`` when the service command actually
+        # fires, which is the precise point the service begins booting.
+        self.service_started_at: float = time.time()
 
     def record_activity(self) -> None:
         self.last_activity = time.time()
+
+    def mark_service_started(self) -> None:
+        """Record that the service command just fired.
+
+        Resets the startup-grace anchor to now.  Called from
+        ``terminal.ensure_service_session`` right after it launches the
+        service command, so the grace window is measured from the real
+        start of the service rather than from the (earlier) container
+        creation -- important for the per-connection fire path where a
+        freshly-created workspace launches its service command on first
+        ``terminal_start``, possibly long after the container started.
+        """
+        self.service_started_at = time.time()
 
     def get_idle_timeout(self) -> int:
         if self.idle_timeout is not None:
@@ -452,6 +488,22 @@ class HealthMonitor:
         """
         return state.setup_state == "complete"
 
+    def _in_startup_grace(self, state: ContainerState) -> bool:
+        """True while the service is still within its startup grace window.
+
+        Mirrors Docker's HEALTHCHECK ``--start-period``: while the
+        service command is booting, a failing check is expected rather
+        than a real outage, so :meth:`_check_workspace` ignores
+        unhealthy results here (but still records a *healthy* result so
+        a fast-booting service is marked up immediately).  Anchored to
+        ``service_started_at`` (when the command fired, or container
+        creation as a fallback).
+        """
+        return (
+            time.time() - state.service_started_at
+            < HEALTH_CHECK_STARTUP_GRACE_SECONDS
+        )
+
     async def _run_one(self, state: ContainerState) -> tuple[str, str]:
         """Run a single workspace's health check.
 
@@ -530,6 +582,22 @@ class HealthMonitor:
     async def _check_workspace(self, state: ContainerState) -> None:
         """Poll one workspace, record the reason, and broadcast on change."""
         new_status, message = await self._run_one(state)
+        # Startup grace window: the service command may still be
+        # booting, so an unhealthy result here is expected, not a real
+        # outage.  Don't transition to unhealthy, broadcast, or log a
+        # failure (mirrors Docker HEALTHCHECK --start-period).  A
+        # healthy result is still recorded below so a fast-booting
+        # service is marked up the moment it actually responds.
+        if new_status == "unhealthy" and self._in_startup_grace(state):
+            logger.debug(
+                "Health check for workspace %s (container %s) failing "
+                "but within startup grace (%.0fs elapsed); not flagging "
+                "unhealthy",
+                state.workspace_id,
+                state.container_id[:12],
+                time.time() - state.service_started_at,
+            )
+            return
         old_status = state.health_status
         state.health_status = new_status
         # Clear the reason once healthy again so a stale failure message
@@ -670,6 +738,21 @@ class ContainerRegistry:
             state = self.states.get(ws_id)
             if state:
                 state.record_activity()
+
+    def mark_service_started(self, container_id: str) -> None:
+        """Reset the startup-grace anchor for a container's service.
+
+        Called by ``terminal.ensure_service_session`` right after it
+        launches the service command, so the health monitor's grace
+        window is measured from the real start of the service.  No-op
+        if the container isn't tracked (e.g. the service session fired
+        before the state was registered).
+        """
+        ws_id = self._cid_to_wsid.get(container_id)
+        if ws_id:
+            state = self.states.get(ws_id)
+            if state:
+                state.mark_service_started()
 
     def get_state(self, workspace_id: str) -> ContainerState | None:
         return self.states.get(workspace_id)

--- a/src/backend/klangk_backend/terminal.py
+++ b/src/backend/klangk_backend/terminal.py
@@ -338,6 +338,16 @@ async def ensure_service_session(
                 user=CONTAINER_USER,
                 timeout=5,
             )
+            # The service command just fired -- reset the health-check
+            # startup-grace anchor so the monitor gives the service time
+            # to boot before a failing poll can flag it unhealthy (e.g.
+            # a gateway that isn't accepting connections yet).  Set only
+            # on a successful send-keys; the except path below never
+            # launched the command, so it must not start the grace
+            # window.  Lazy import breaks the container<->terminal cycle.
+            from . import container as _container  # noqa: allow-deferred-import
+
+            _container.registry.mark_service_started(container_id)
         except Exception:
             logger.warning(
                 "Failed to send service command to %s", SERVICE_SESSION

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -2094,13 +2094,20 @@ def _health_state(
     owner_id="uid-owner",
     setup_state="complete",
     health_status=None,
+    in_startup_grace=False,
 ):
-    """Build a ContainerState wired up for health checks."""
+    """Build a ContainerState wired up for health checks.
+
+    *in_startup_grace* defaults to False so the core healthy/unhealthy
+    tests exercise post-grace behavior; the startup-grace tests opt in.
+    """
     st = container.ContainerState(workspace_id, container_id)
     st.health_check = health_check
     st.owner_id = owner_id
     st.setup_state = setup_state
     st.health_status = health_status
+    # 0.0 = epoch, comfortably outside any real grace window.
+    st.service_started_at = time.time() if in_startup_grace else 0.0
     return st
 
 
@@ -2366,7 +2373,107 @@ class TestHealthMonitorCheckWorkspace:
         )
 
 
-class TestHealthMonitorBroadcast:
+class TestHealthMonitorStartupGrace:
+    """A failing check inside the startup grace window is not an outage.
+
+    Mirrors Docker's HEALTHCHECK --start-period: while the service
+    command is booting, unhealthy results are suppressed (no status
+    change, no broadcast, no health_checked_at), but a *healthy* result
+    is still recorded so a fast-booting service is marked up the moment
+    it responds.  Prevents the boot-time false "unhealthy: Gateway not
+    yet ready to accept connections" the very first poll produced.
+    """
+
+    async def test_unhealthy_during_grace_is_suppressed(self):
+        monitor = container.registry.health
+        st = _health_state(health_status=None, in_startup_grace=True)
+        with (
+            patch.object(
+                monitor,
+                "_run_one",
+                AsyncMock(return_value=("unhealthy", "connection refused")),
+            ),
+            patch.object(monitor, "_broadcast") as bcast,
+        ):
+            await monitor._check_workspace(st)
+        # Status, reason, and last-checked are all untouched: the grace
+        # window swallowed the failure as an expected boot-time blip.
+        assert st.health_status is None
+        assert st.health_message is None
+        assert st.health_checked_at is None
+        bcast.assert_not_called()
+
+    async def test_healthy_during_grace_recorded_immediately(self):
+        # Even mid-grace, a passing check marks the service healthy
+        # right away -- the grace only suppresses failures, not
+        # successes, so a fast-booting service isn't hidden.
+        monitor = container.registry.health
+        st = _health_state(health_status=None, in_startup_grace=True)
+        with (
+            patch.object(
+                monitor, "_run_one", AsyncMock(return_value=("healthy", ""))
+            ),
+            patch.object(monitor, "_broadcast") as bcast,
+        ):
+            await monitor._check_workspace(st)
+        assert st.health_status == "healthy"
+        assert st.health_checked_at is not None
+        bcast.assert_called_once_with("ws-h", "healthy", None)
+
+    async def test_unhealthy_after_grace_is_recorded(self):
+        # Once the grace window has elapsed, a failing check is a real
+        # outage again: status flips, reason is kept, and it broadcasts.
+        monitor = container.registry.health
+        st = _health_state(health_status=None, in_startup_grace=False)
+        with (
+            patch.object(
+                monitor,
+                "_run_one",
+                AsyncMock(return_value=("unhealthy", "connection refused")),
+            ),
+            patch.object(monitor, "_broadcast") as bcast,
+        ):
+            await monitor._check_workspace(st)
+        assert st.health_status == "unhealthy"
+        assert st.health_message == "connection refused"
+        bcast.assert_called_once_with(
+            "ws-h", "unhealthy", "connection refused"
+        )
+
+    def test_in_startup_grace_uses_anchor_window(self):
+        monitor = container.registry.health
+        # service_started_at = now -> within the default 30s window.
+        st_in = _health_state(in_startup_grace=True)
+        assert monitor._in_startup_grace(st_in) is True
+        # service_started_at = epoch -> long past the window.
+        st_out = _health_state(in_startup_grace=False)
+        assert monitor._in_startup_grace(st_out) is False
+
+    def test_mark_service_started_resets_anchor(self):
+        # mark_service_started pushes the anchor forward, restarting the
+        # grace window (e.g. the service command re-fires after a
+        # container restart).
+        st = _health_state(in_startup_grace=False)
+        assert st.service_started_at == 0.0
+        st.mark_service_started()
+        assert time.time() - st.service_started_at < 1
+
+    def test_registry_mark_service_started_looks_up_state(self):
+        # The registry proxy resolves container_id -> workspace and
+        # resets that workspace's anchor; unknown containers no-op.
+        st = _health_state(in_startup_grace=False)
+        container.registry.states[st.workspace_id] = st
+        container.registry._cid_to_wsid[st.container_id] = st.workspace_id
+        try:
+            assert st.service_started_at == 0.0
+            container.registry.mark_service_started(st.container_id)
+            assert time.time() - st.service_started_at < 1
+            # Unknown container is a safe no-op.
+            container.registry.mark_service_started("no-such-cid")
+        finally:
+            container.registry.states.pop(st.workspace_id, None)
+            container.registry._cid_to_wsid.pop(st.container_id, None)
+
     """_broadcast fans out to ALL connections, not just the session."""
 
     def test_fans_out_via_notify_service_health(self):

--- a/src/backend/tests/test_terminal.py
+++ b/src/backend/tests/test_terminal.py
@@ -1436,6 +1436,92 @@ class TestEnsureServiceSession:
             await ensure_service_session("cid", "/home/clanker", "cmd")
         mock_logger.warning.assert_called()
 
+    async def test_firing_resets_health_grace_anchor(self):
+        """Firing the service command resets the health-check startup-grace
+        anchor so the monitor gives the freshly-launched service time to
+        boot before a failing poll can flag it unhealthy."""
+        from klangk_backend.terminal import ensure_service_session
+
+        with (
+            patch(
+                "klangk_backend.terminal._ensure_tmux_session",
+                new=AsyncMock(),
+            ),
+            patch(
+                "klangk_backend.terminal._service_cmd_window_exists",
+                new=AsyncMock(return_value=False),
+            ),
+            patch(
+                "klangk_backend.terminal.podman.exec_container",
+                new=AsyncMock(side_effect=[(0, "", ""), (0, "", "")]),
+            ),
+            patch(
+                "klangk_backend.container.registry.mark_service_started"
+            ) as mock_mark,
+        ):
+            await ensure_service_session(
+                "cid", "/home/clanker", "openclaw gateway"
+            )
+        mock_mark.assert_called_once_with("cid")
+
+    async def test_existing_window_does_not_reset_grace_anchor(self):
+        """The no-op path (service-cmd window already exists) never
+        re-launched the service, so it must not restart the grace window."""
+        from klangk_backend.terminal import ensure_service_session
+
+        with (
+            patch(
+                "klangk_backend.terminal._ensure_tmux_session",
+                new=AsyncMock(),
+            ),
+            patch(
+                "klangk_backend.terminal._service_cmd_window_exists",
+                new=AsyncMock(return_value=True),
+            ),
+            patch(
+                "klangk_backend.terminal.podman.exec_container",
+                new=AsyncMock(),
+            ),
+            patch(
+                "klangk_backend.container.registry.mark_service_started"
+            ) as mock_mark,
+        ):
+            await ensure_service_session(
+                "cid", "/home/clanker", "openclaw gateway"
+            )
+        mock_mark.assert_not_called()
+
+    async def test_send_keys_failure_does_not_reset_grace_anchor(self):
+        """If send-keys itself failed the command never launched, so the
+        grace anchor must not advance (no service is booting)."""
+        from klangk_backend.terminal import ensure_service_session
+
+        with (
+            patch(
+                "klangk_backend.terminal._ensure_tmux_session",
+                new=AsyncMock(),
+            ),
+            patch(
+                "klangk_backend.terminal._service_cmd_window_exists",
+                new=AsyncMock(return_value=False),
+            ),
+            patch(
+                "klangk_backend.terminal.podman.exec_container",
+                new=AsyncMock(
+                    side_effect=[
+                        (0, "", ""),  # new-window succeeds
+                        RuntimeError("send broke"),  # send-keys fails
+                        (0, "", ""),  # kill-window cleanup
+                    ]
+                ),
+            ),
+            patch(
+                "klangk_backend.container.registry.mark_service_started"
+            ) as mock_mark,
+        ):
+            await ensure_service_session("cid", "/home/clanker", "cmd")
+        mock_mark.assert_not_called()
+
     async def test_concurrent_fires_create_window_exactly_once(self):
         """#1188: two concurrent ensure_service_session calls for the SAME
         container must not both create the service-cmd window.


### PR DESCRIPTION
## Problem

Health checks fire immediately after a container starts. The health monitors only gate is `setup_state == "complete"`, which is **immediately true** for auto-started / server-restarted workspaces (the software is already installed in the persisted volume). So the very first poll runs while the **service command** (e.g. the `openclaw` gateway) is still booting, and false-flags the workspace unhealthy:

```
09:09:44  container created and started
09:09:55  Health check ... unhealthy: ... Gateway not yet ready to accept connections
           Possible causes:
           - Gateway not yet ready to accept connections (retry after a moment)
```

The check commands own output literally says *"retry after a moment"* — there was no moment to be had.

## Fix

Add a **startup grace period** modelled on Dockers `HEALTHCHECK --start-period`, configurable via `KLANGK_HEALTH_CHECK_STARTUP_GRACE` (default `30`s):

- For grace seconds after the service command fires, a **failing** check does **not** transition to unhealthy, broadcast a `service_health` event, log a failure, or set `health_message` — the blip is treated as expected boot-up noise.
- A **passing** check is still recorded immediately, so a fast-booting service shows up healthy the **moment** it actually responds. The grace suppresses failures only, never successes — no extra latency for services that boot quickly.

The grace window is anchored to when the service command **actually launches**: `terminal.ensure_service_session` calls `registry.mark_service_started(container_id)` right after the `tmux send-keys` that fires the command. This matters for the per-connection fire path, where a freshly-created workspace launches its service on first `terminal_start` (after `setup.sh` completes) — possibly long after the container itself started, so a container-start-time anchor would already have expired. For health-checked workspaces that have *no* service command, the anchor falls back to container-state creation time so they still get a grace window.

## Why this shape (not a plain delay)

A pure "skip checks for N seconds" would hide a genuinely-broken service during boot *and* delay a healthy status by the full window. The chosen "check but dont penalize failure" shape (Dockers `--start-period` semantics) gives the service settle time **and** reports healthy as soon as its really up.

## Changes

- `container.py`: `HEALTH_CHECK_STARTUP_GRACE_SECONDS` constant; `ContainerState.service_started_at` (+ `mark_service_started`); `HealthMonitor._in_startup_grace`; `_check_workspace` suppresses unhealthy results during grace; `ContainerRegistry.mark_service_started` proxy.
- `terminal.py`: `ensure_service_session` resets the grace anchor after a successful `send-keys` (not on the no-op / failure paths).
- `docs/features/health-check.md`: new "Startup grace period" section + the `KLANGK_HEALTH_CHECK_STARTUP_GRACE` env var.
- Tests: `TestHealthMonitorStartupGrace` (suppress / record-healthy / post-grace / anchor window / `mark_service_started` on state + registry) and three `ensure_service_session` tests (anchor reset on fire; not reset on existing-window no-op or send-keys failure).

## Verification

- Full backend suite: **2195 passed**.
- `container.py` and `terminal.py` both remain at **100% coverage**.
- `ruff check`/`format`, `markdownlint`, `prettier`, `deferred-imports`, `trufflehog` all clean.