### PR TITLE
scripts: pass --signature-policy to podman build/pull

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -200,10 +200,14 @@ in
     config.devenv.root + "/.devenv/state/klangk/plugins"
   );
   env.KLANGK_IMAGE_NAME = lib.mkOverride 1500 "klangk-workspace";
-  # Rootless podman from nix (Linux) has no default policy.json; it is
-  # generated in enterShell. CONTAINERS_SIGNATURE_POLICY tells podman
-  # where to find it.  On macOS podman runs in *remote* mode against
-  # the VM, which has its own policy, so leave this empty there.
+  # Rootless podman from nix (Linux) ships no default policy.json, so a build/pull
+  # fails with "no policy.json file found". enterShell generates a permissive one
+  # at this path, and the build/pull scripts consume this var and pass it to podman
+  # via `--signature-policy`. NOTE: podman's build/pull/push path does NOT read an
+  # env var for the policy (the --signature-policy flag, which sets
+  # SystemContext.SignaturePolicyPath, is the only way to point it at a non-default
+  # file). On macOS podman runs in *remote* mode against the VM, which has its own
+  # policy, so leave this empty there.
   env.CONTAINERS_SIGNATURE_POLICY = lib.mkOverride 1500 (
     if pkgs.stdenv.hostPlatform.isDarwin then
       ""

--- a/scripts/_podman_common.sh
+++ b/scripts/_podman_common.sh
@@ -1,0 +1,31 @@
+# shellcheck shell=bash
+# Shared helpers for podman build/pull scripts. Sourced (not executed) by:
+#   build-workspace-image.sh, build-backend-image.sh, build-base-image.sh,
+#   pull-base-image.sh
+#
+# Sets SIG_POLICY_ARGS, expanded into every `podman build` / `podman pull`
+# invocation via "${SIG_POLICY_ARGS[@]}".
+#
+# Rootless podman from Nix ships no default /etc/containers/policy.json, so a
+# build/pull that verifies image signatures fails in a fresh environment
+# (#1230). devenv sets CONTAINERS_SIGNATURE_POLICY to a project-managed
+# policy on Linux (and leaves it empty on macOS, where podman runs in a VM
+# with its own policy). We pass --signature-policy only when that var is set
+# and non-empty, and ensure the file exists on first run as a safety net for
+# direct script invocation (enterShell normally generates it).
+#
+# We deliberately do NOT fall back to /etc/containers/policy.json: that file
+# is not guaranteed to exist and is the wrong place on Nix/rootless setups.
+
+# shellcheck disable=SC2034 # SIG_POLICY_ARGS is consumed by the sourcing script
+SIG_POLICY_ARGS=()
+if [ -n "${CONTAINERS_SIGNATURE_POLICY:-}" ]; then
+  if [ ! -f "$CONTAINERS_SIGNATURE_POLICY" ]; then
+    mkdir -p "$(dirname "$CONTAINERS_SIGNATURE_POLICY")"
+    # Same permissive policy as enterShell generates. A permissive default is
+    # correct for dev: images are pulled from our own GHCR or built locally.
+    echo '{"default": [{"type": "insecureAcceptAnything"}]}' \
+      >"$CONTAINERS_SIGNATURE_POLICY"
+  fi
+  SIG_POLICY_ARGS=(--signature-policy "$CONTAINERS_SIGNATURE_POLICY")
+fi

--- a/scripts/build-backend-image.sh
+++ b/scripts/build-backend-image.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "${DEVENV_ROOT:-$SCRIPT_DIR/..}"
 PODMAN="${KLANGK_PODMAN_BIN:-podman}"
+# shellcheck source=_podman_common.sh disable=SC1091
+source "$SCRIPT_DIR/_podman_common.sh"
 
 STAMP="$DEVENV_STATE/klangk/.backend-image-hash"
 
@@ -46,6 +48,7 @@ fi
 
 # Build workspace image on top of the base
 "$PODMAN" build \
+  "${SIG_POLICY_ARGS[@]}" \
   --pull=newer \
   --platform "${KLANGK_PLATFORM:-linux/amd64}" \
   --build-context plugins="$STAGING/plugins" \

--- a/scripts/build-base-image.sh
+++ b/scripts/build-base-image.sh
@@ -8,6 +8,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "${DEVENV_ROOT:-$SCRIPT_DIR/..}"
 PODMAN="${KLANGK_PODMAN_BIN:-podman}"
+# shellcheck source=_podman_common.sh disable=SC1091
+source "$SCRIPT_DIR/_podman_common.sh"
 
 COMMIT="$(git rev-parse --short HEAD)"
 CALVER="$(date -u +%Y.%m.%d)"
@@ -16,6 +18,7 @@ IMAGE="ghcr.io/mcdonc/klangk/klangk-workspace-base"
 
 echo "==> Building base image $VERSION (${KLANGK_PLATFORM:-linux/amd64})"
 "$PODMAN" build \
+  "${SIG_POLICY_ARGS[@]}" \
   --platform "${KLANGK_PLATFORM:-linux/amd64}" \
   -f src/containers/workspace/Dockerfile.base \
   -t "$IMAGE:latest" \

--- a/scripts/build-workspace-image.sh
+++ b/scripts/build-workspace-image.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "${DEVENV_ROOT:-$SCRIPT_DIR/..}"
 PODMAN="${KLANGK_PODMAN_BIN:-podman}"
+# shellcheck source=_podman_common.sh disable=SC1091
+source "$SCRIPT_DIR/_podman_common.sh"
 
 STAMP="$DEVENV_STATE/klangk/.backend-image-hash"
 
@@ -64,6 +66,7 @@ for old_tag in $("$PODMAN" images --format '{{.Tag}}' --filter "reference=${KLAN
   esac
 done
 "$PODMAN" build \
+  "${SIG_POLICY_ARGS[@]}" \
   --pull=newer \
   --platform "${KLANGK_PLATFORM:-linux/amd64}" \
   --build-context plugins="$STAGING/plugins" \

--- a/scripts/pull-base-image.sh
+++ b/scripts/pull-base-image.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PODMAN="${KLANGK_PODMAN_BIN:-podman}"
+# shellcheck source=_podman_common.sh disable=SC1091
+source "$SCRIPT_DIR/_podman_common.sh"
 "$PODMAN" pull \
+  "${SIG_POLICY_ARGS[@]}" \
   ghcr.io/mcdonc/klangk/klangk-workspace-base:latest


### PR DESCRIPTION
Closes #1230.

## Problem

In a fresh environment, `podman build`/`pull` failed on the base-image pull. Rootless podman from Nix ships no default `/etc/containers/policy.json`, and the build/pull scripts never passed `--signature-policy` — so `--pull=newer` in `build-workspace-image.sh` (and the other build/pull scripts) failed with "no policy.json file found".

The reported workaround (`--signature-policy "\${CONTAINERS_SIGNATURE_POLICY:-/etc/containers/policy.json}"`) is **not correct**: `/etc/containers/policy.json` is not guaranteed to exist and is the wrong place on Nix/rootless setups.

## Why explicit flags (not an env var)?

A natural question: devenv already sets `CONTAINERS_SIGNATURE_POLICY` — why can't podman just read it? Because **podman's `build`/`pull`/`push` code path does not read any environment variable for the policy path.** The resolution (`defaultPolicyPathWithHomeDir` in containers/image) is, in order:

1. `--signature-policy` CLI flag (sets `SystemContext.SignaturePolicyPath`)
2. `$HOME/.config/containers/policy.json` (if it exists)
3. `/etc/containers/policy.json` (if it exists)
4. → **error** "no policy.json file found"

There is no `os.Getenv` in that function — neither `CONTAINERS_SIGNATURE_POLICY` (which devenv sets, but is not a real podman var) nor the "standard" `CONTAINERS_POLICY_JSON` (read only by the newer `containers/common` configfile parser used by `podman image trust show/set`, *not* by the legacy build/pull path). Confirmed three ways: empirical `strace` on the project's podman 5.8.2 (both env vars → 0 opens of the override file; 1 open of `/etc/containers/policy.json` in every case), the upstream source (`signature/policy_config.go`), and the docs. So the `--signature-policy` flag is the only reliable way to point build/pull at a non-default policy file — hence the explicit flags.

This PR also corrects the devenv.nix comment whose false premise ("CONTAINERS_SIGNATURE_POLICY tells podman where to find it") was the root of the confusion.

## Fix

Add a shared sourced helper, `scripts/_podman_common.sh`, that sets `SIG_POLICY_ARGS` (a bash array) consumed via `"\${SIG_POLICY_ARGS[@]}"` by every `podman build`/`pull` invocation:

- **Linux** — `CONTAINERS_SIGNATURE_POLICY` is set (by `devenv.nix`) to the devenv-managed policy at `\$DEVENV_STATE/klangk/podman/policy.json`, so emit `--signature-policy <path>`. It also **defensively generates the permissive policy file on first run** as a safety net for direct script invocation — `enterShell` normally does this, but a script may run first in a fresh shell/CI.
- **macOS** — `CONTAINERS_SIGNATURE_POLICY` is empty (podman runs in a VM with its own policy), so it emits **no flag** — passing an empty path would be wrong.
- **No `/etc/containers/policy.json` fallback** — exactly as the issue prescribes; that file is not guaranteed to exist.

This leverages infrastructure that already exists (`devenv.nix` already sets the var on Linux and `enterShell` already generates the policy); the only gap was that the build scripts didn't consume it and pass it via the flag.

### Scripts wired

| script | podman call | policy needed? |
|---|---|---|
| `build-workspace-image.sh` | `build --pull=newer` | ✅ |
| `build-backend-image.sh` | `build --pull=newer` | ✅ |
| `build-base-image.sh` | `build` (FROM pulls base) | ✅ |
| `pull-base-image.sh` | `pull` | ✅ |
| `build-host-image.sh` | `save` (export) | ❌ no pull/build |
| `push-base-image.sh` | `push` | ❌ no verify |

### Why a shared helper

All four build/pull scripts need identical logic (conditional flag + first-run policy generation). A sourced `scripts/_podman_common.sh` avoids 4× duplication and drift. It's a sourced library (mode 0644, `# shellcheck shell=bash`), not executed directly. Each consumer sources it with the `# shellcheck source=... disable=SC1091` directive.

## Verification

Behavior tested directly across the four cases:

| scenario | result |
|---|---|
| Linux, fresh (no policy file) | generates permissive policy + `--signature-policy <path>` ✅ |
| Linux, existing file | reuses it (NOT overwritten) + flag ✅ |
| macOS (empty var) | no flag (uses VM policy) ✅ |
| unset var (under `set -u`) | no flag, no error ✅ |

- `shellcheck` exit 0; `shfmt` clean; `bash -n` clean on all 5 files; `nixfmt --width=80` clean
- pre-commit hooks Passed (nixfmt, shellcheck, shfmt, check-executables-have-shebangs, prettier, trufflehog)