### PR TITLE
fix(nginx): proxy WebSocket upgrades to the slash-less /hosted/<ws>/<port> root

### DIFF
--- a/scripts/nginx.sh
+++ b/scripts/nginx.sh
@@ -153,6 +153,13 @@ http {
     "" close;
   }
 
+  # WebSocket upgrade specifically (not h2c/other Upgrade tokens); gates the
+  # slash-less hosted location's redirect-vs-proxy choice below.
+  map \$http_upgrade \$hosted_is_ws {
+    default 0;
+    "~*^websocket\$" 1;
+  }
+
   client_max_body_size ${KLANGK_NGINX_CLIENT_MAX_BODY_SIZE};
 
   server {
@@ -163,8 +170,25 @@ http {
     # hosted apps emit relative asset paths (./assets/...) that resolve against
     # the browser's base URL, so without the slash every asset 404s. Redirect to
     # the canonical trailing-slash form so the base URL is correct.
-    location ~ ^/hosted/[^/]+/\d+\$ {
-      return 308 \$uri/\$is_args\$args;
+    # Named capture (not \$1): the \$hosted_is_ws regex map clobbers positional
+    # captures, which would leave proxy_pass with an empty port.
+    location ~ ^/hosted/[^/]+/(?<hosted_port>\d+)\$ {
+      # Non-WebSocket: redirect to the trailing-slash form so relative assets
+      # (./assets/...) resolve. Only \`return\` inside \`if\` -> "if is evil" N/A.
+      if (\$hosted_is_ws = 0) {
+        return 308 \$uri/\$is_args\$args;
+      }
+      # WebSocket clients cannot follow a 308 (RFC 6455 4.1); some apps open
+      # their socket at this slash-less root. Proxy instead. \$is_args\$args:
+      # a variable in proxy_pass drops the query (e.g. auth token) otherwise.
+      proxy_pass http://127.0.0.1:\$hosted_port/\$is_args\$args;
+      proxy_set_header Host \$http_host;
+      proxy_set_header X-Real-IP \$remote_addr;
+      proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+      proxy_set_header X-Forwarded-Proto \$scheme;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade \$http_upgrade;
+      proxy_set_header Connection \$connection_upgrade;
     }
 
     # Hosted app proxy: extract port from URL and proxy directly to container


### PR DESCRIPTION
## What

Proxy slash-less `/hosted/<ws>/<port>` **WebSocket** upgrades to the app root
instead of 308-redirecting them. Non-WebSocket requests keep the existing
trailing-slash redirect.

Fixes #1232.

## Why

Hosted control UIs (e.g. the OpenClaw sandbox) open their WebSocket at the
slash-less app root `ws://host/hosted/<ws>/<port>`. That matched the
redirect-only location and got a `308`; a browser WebSocket handshake cannot
follow a redirect (RFC 6455 §4.1), so it failed with *"Unexpected response
code: 308"*. Affects any hosted app that opens a WebSocket at its root.

## Change (`scripts/nginx.sh`)

- Redirect only **non-WebSocket** requests in the slash-less location; proxy WS
  upgrades to the app root. The trailing-slash 308 (needed so relative
  `./assets/...` resolve) is preserved for documents.
- Select WebSocket via a `map` matching `~*^websocket$`, so other `Upgrade`
  tokens (e.g. `h2c`) still get the asset-preserving 308.
- Use a named capture `(?<hosted_port>)` — the regex `map` clobbers positional
  `$1..$9`, which would otherwise leave `proxy_pass` with an empty port.
- Keep `$is_args$args` on `proxy_pass`: a variable in `proxy_pass` disables the
  implicit request-URI passthrough, so query params (e.g. a handshake token)
  would be dropped without it.

## Testing

Standalone nginx 1.30.2 + a generic WebSocket backend on unrelated ports,
arbitrary workspace id:

| request | before | after |
|---------|--------|-------|
| slash-less WS | 308 | **101** |
| slash-less WS `?token=…` | 308 | **101** (query delivered to backend) |
| `Upgrade: h2c` (non-WS) | 308 | 308 |
| plain GET | 308 | 308 (→ `/<port>/`) |

Also verified against a live klangk instance: the OpenClaw Control UI connects
(gateway status Online) and completes a chat round-trip.
