### PR TITLE
feat(health): make service_health WS stream a trustworthy signal

### DIFF
--- a/docs/features/health-check.md
+++ b/docs/features/health-check.md
@@ -51,6 +51,12 @@ For each workspace with a health check configured:
    workspace's current status immediately on connect -- so a pure-WS
    consumer like `klangkc monitor` sees steady-state failures right
    away instead of being blind until the next transition (#1175).
+   Each `service_health` frame also carries three additive fields:
+   `running` (`false` on the terminal **container-death** frame, so a
+   consumer watching only this stream learns the service is down
+   instead of seeing "healthy, then silence"), `health_checked_at`
+   (when the last poll ran), and `seq` (a per-workspace counter to
+   detect a missed transition across a reconnect).
 4. The current status, the **reason** it's unhealthy (a tail of the
    check's stderr/stdout), and the time of the last check are exposed
    via `GET /api/v1/workspaces/{id}/status`.
@@ -123,7 +129,10 @@ Health checks are deliberately conservative:
   during setup would report false negatives (the service isn't running
   yet because `setup.sh` hasn't installed it).
 - **Container stopped/removed** — its health state goes away with the
-  container.
+  container. The server first emits one terminal `service_health` frame
+  with `running=false` (and `healthy=false`) so a consumer watching only
+  that stream learns the service is down; after that the workspace no
+  longer appears on the stream until it restarts.
 
 ### Informational only
 
@@ -152,8 +161,16 @@ miss:
 the web UI does — health transitions, container starts/stops, workspace
 changes — and can run a command for each one. The event JSON is piped
 to the command's stdin, and details are exposed as environment
-variables (`KLANGK_EVENT_TYPE`, `KLANGK_WORKSPACE_ID`, `KLANGK_HEALTHY`,
-and `KLANGK_HEALTH_MESSAGE` — the failure reason, when unhealthy).
+variables. For `service_health` events those are:
+
+- `KLANGK_HEALTHY` — `true` / `false`.
+- `KLANGK_RUNNING` — `true` for live-container frames, `false` on the
+  terminal container-death frame. This lets a command tell "the health
+  check failed" from "the container stopped" without also subscribing
+  to `container_status`.
+- `KLANGK_HEALTH_MESSAGE` — the failure reason, when unhealthy.
+- `KLANGK_HEALTH_CHECKED_AT` — ISO-8601 timestamp of the last poll.
+- `KLANGK_HEALTH_SEQ` — per-workspace monotonic counter.
 
 Fire a desktop notification when a service goes unhealthy:
 
@@ -174,6 +191,15 @@ Just watch the stream (pipe to `jq`):
 ```bash
 klangkc monitor --type service_health | jq .
 ```
+
+Because the stream is deltas-only, silence normally means "nothing
+changed" — but it's indistinguishable from "the server's health loop
+stalled." For a liveness signal, opt into a periodic heartbeat by
+sending `{"cmd": "subscribe_health_heartbeat", "enabled": true}` on
+the socket: the server then emits a `service_health_heartbeat` frame
+at the end of every health-loop tick, so if the loop stalls the
+heartbeats stop. It's its own event type, so `--type service_health`
+filters it out — drop the filter to observe it.
 
 `monitor` reconnects automatically — by default forever, with capped
 exponential backoff — and refreshes its login token on auth failures,

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -238,6 +238,12 @@ class ContainerState:
         # not yet checked.  Surfaced via the status API + service_health
         # event so an unhealthy workspace isn't a black box (#1088).
         self.health_message: str | None = None
+        # Per-workspace monotonic counter carried on every service_health
+        # frame so a reconnecting consumer can detect a missed transition
+        # against the connect-time snapshot (#1175 item 4).  Increments on
+        # each emitted frame (transition and death); resets when the state
+        # is recreated (container restart) -- the snapshot reconciles.
+        self.health_seq: int = 0
         self.health_check: str | None = None  # shell command, None = disabled
         self.owner_id: str | None = None
         self.setup_state: str | None = None
@@ -616,17 +622,15 @@ class HealthMonitor:
                 message,
             )
         if new_status != old_status:
-            self._broadcast(
-                state.workspace_id, new_status, state.health_message
-            )
+            self._broadcast(state, new_status, state.health_message)
 
     def _broadcast(
         self,
-        workspace_id: str,
+        state: ContainerState,
         status: str,
         message: str | None = None,
     ) -> None:
-        """Emit a ``service_health`` event to all connections.
+        """Emit a ``service_health`` transition event to all connections.
 
         Fanned out via :meth:`WsState.notify_service_health` so the
         workspace list page learns about health transitions for
@@ -634,16 +638,61 @@ class HealthMonitor:
         workspace's terminal session (#1015).  The failure *reason*
         rides along as ``health_message`` so operators can see *why*
         it's unhealthy without digging through logs (#1088).
+
+        Also forwards the additive contract fields (#1175):
+        ``running=True`` (this is a live-container frame), the last
+        ``health_checked_at`` (#1175 item 3a), and a per-workspace
+        ``seq`` (#1175 item 4) bumped on every emit so a reconnecting
+        consumer can detect a missed transition.
         """
         # Imported lazily to avoid an import cycle with wshandler.
         from .wshandler import state as _ws_state  # noqa: allow-deferred-import
 
+        state.health_seq += 1
         _ws_state.notify_service_health(
-            workspace_id, healthy=status == "healthy", message=message
+            state.workspace_id,
+            healthy=status == "healthy",
+            message=message,
+            running=True,
+            health_checked_at=state.health_checked_at,
+            seq=state.health_seq,
+        )
+
+    def broadcast_death(self, state: ContainerState) -> None:
+        """Emit the terminal ``service_health`` frame for a dying container.
+
+        When a container dies the server emits
+        ``container_status{running: false}`` and then *silence* on the
+        ``service_health`` stream, because the health loop only polls
+        ``registry.states`` and a dead container's state is removed.  A
+        consumer watching ``service_health`` therefore believes the
+        last-known status (possibly healthy) still holds while the
+        container is gone (#1175 item 2).  This closes the hole by
+        emitting one unambiguous terminal frame with ``running=False``
+        and ``healthy=False`` *before* the state is dropped, so a single
+        stream is a single source of truth.
+        """
+        # Imported lazily to avoid an import cycle with wshandler.
+        from .wshandler import state as _ws_state  # noqa: allow-deferred-import
+
+        state.health_seq += 1
+        _ws_state.notify_service_health(
+            state.workspace_id,
+            healthy=False,
+            message=None,
+            running=False,
+            health_checked_at=state.health_checked_at,
+            seq=state.health_seq,
         )
 
     async def run_health_loop(self) -> None:
-        """Background loop: every interval, poll eligible workspaces."""
+        """Background loop: every interval, poll eligible workspaces.
+
+        After each poll sweep, emits liveness heartbeats to connections
+        that opted in (#1175 item 3b).  Emitting from *this* loop (rather
+        than a standalone task) ties heartbeat presence to the health
+        loop being alive -- if the loop stalls, the heartbeats stop.
+        """
         while True:
             await asyncio.sleep(HEALTH_CHECK_INTERVAL_SECONDS)
             for state in list(self._registry.states.values()):
@@ -659,6 +708,14 @@ class HealthMonitor:
                         state.workspace_id,
                         e,
                     )
+            self._send_heartbeats()
+
+    def _send_heartbeats(self) -> None:
+        """Fan health heartbeats to opt-in connections (lazy ws import)."""
+        # Imported lazily to avoid an import cycle with wshandler.
+        from .wshandler import state as _ws_state  # noqa: allow-deferred-import
+
+        _ws_state.send_health_heartbeats()
 
     def start_health_loop(self) -> None:
         if self.health_task is None:
@@ -1366,6 +1423,17 @@ class ContainerRegistry:
     async def notify_workspace_killed(self, workspace_id: str) -> None:
         """Call the on_workspace_killed callback, logging any errors."""
         self._notify_status_changed(workspace_id, False)
+        # Close the container-death hole (#1175 item 2): without this,
+        # a dying container looks like "healthy, then silence" on the
+        # service_health stream because the health loop only polls
+        # ``registry.states`` and the on_workspace_killed callback below
+        # drops the state.  Emit one terminal frame with ``running=False``
+        # first, so a consumer watching only service_health learns the
+        # service is down.  Only health-checked workspaces ever appeared
+        # on the stream, so only those get a terminal frame.
+        state = self.states.get(workspace_id)
+        if state is not None and state.health_check is not None:
+            self.health.broadcast_death(state)
         if self.on_workspace_killed:
             try:
                 await self.on_workspace_killed(workspace_id)

--- a/src/backend/klangk_backend/wshandler/connection.py
+++ b/src/backend/klangk_backend/wshandler/connection.py
@@ -66,6 +66,10 @@ class Connection:
         self._idle_cb = None
         self.pending_status_msg: str | None = None
         self.browser_id: str | None = None
+        # Opt-in flag for the service_health liveness heartbeat
+        # (#1175 item 3b); toggled by the ``subscribe_health_heartbeat``
+        # command.  Off by default so the heartbeat is opt-in.
+        self.wants_health_heartbeat: bool = False
         self._user_home: str | None = None
         self._service_command: str | None = None
         self._home_created: bool = False

--- a/src/backend/klangk_backend/wshandler/dispatch.py
+++ b/src/backend/klangk_backend/wshandler/dispatch.py
@@ -64,6 +64,7 @@ _WS_CONNECTION_COMMANDS: dict[str, tuple[str, bool]] = {
 _WS_STATE_COMMANDS: dict[str, str] = {
     "browser_response": "handle_browser_response",
     "browser_chunk": "handle_browser_chunk",
+    "subscribe_health_heartbeat": "handle_subscribe_health_heartbeat",
 }
 
 

--- a/src/backend/klangk_backend/wshandler/session.py
+++ b/src/backend/klangk_backend/wshandler/session.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import time
 import uuid
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
@@ -23,20 +24,56 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _iso_utc(ts: float | None) -> str | None:
+    """Render an epoch timestamp as an ISO-8601 UTC string, or ``None``."""
+    if ts is None:
+        return None
+    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+
+
 def _service_health_frame(
-    workspace_id: str, healthy: bool, message: str | None
+    workspace_id: str,
+    *,
+    healthy: bool,
+    message: str | None,
+    running: bool = True,
+    health_checked_at: float | None = None,
+    seq: int = 0,
 ) -> dict:
     """Build a ``service_health`` frame.
 
     Single source of truth for the event shape shared by the transition
-    broadcast (:meth:`WebSocketState.notify_service_health`) and the
-    connect-time snapshot (:meth:`send_service_health_snapshot`).
+    broadcast (:meth:`WebSocketState.notify_service_health`), the
+    container-death broadcast, and the connect-time snapshot
+    (:meth:`send_service_health_snapshot`).
+
+    Fields beyond the original ``healthy`` / ``health_message`` pair are
+    *additive* -- consumers that ignore unknown keys are unaffected
+    (#1175):
+
+    - ``running`` (bool): ``False`` only on the container-death frame,
+      so a consumer watching *only* ``service_health`` learns the
+      service is down instead of seeing "healthy, then silence"
+      (#1175 item 2).  ``True`` for every live-container frame.
+    - ``health_checked_at`` (ISO-8601 str | None): when the check last
+      ran; ``None`` until the first poll completes.  Lets a consumer
+      judge freshness without correlating its own receive clock
+      (#1175 item 3a).
+    - ``seq`` (int): per-workspace monotonic counter, incremented on
+      every emitted frame (transition and death).  On reconnect a
+      consumer reconciles snapshot + seq to detect a missed transition
+      (#1175 item 4).  Resets when the container state is recreated
+      (restart), which is fine -- the connect-time snapshot is the
+      reconciliation authority.
     """
     return {
         "type": "service_health",
         "workspace_id": workspace_id,
         "healthy": healthy,
         "health_message": message,
+        "running": running,
+        "health_checked_at": _iso_utc(health_checked_at),
+        "seq": seq,
     }
 
 
@@ -549,7 +586,14 @@ class WebSocketState:
             asyncio.create_task(conn.cleanup())
 
     def notify_service_health(
-        self, workspace_id: str, healthy: bool, message: str | None = None
+        self,
+        workspace_id: str,
+        *,
+        healthy: bool,
+        message: str | None = None,
+        running: bool = True,
+        health_checked_at: float | None = None,
+        seq: int = 0,
     ) -> None:
         """Broadcast service-health status to all connections.
 
@@ -563,8 +607,21 @@ class WebSocketState:
         check's stderr/stdout) so an unhealthy workspace isn't a black
         box -- operators can see *why* it failed without log access
         (#1088).  ``None`` when healthy.
+
+        ``running`` is ``True`` for live-container transitions and
+        ``False`` for the terminal container-death frame (#1175 item 2);
+        ``health_checked_at`` is the epoch of the last poll (#1175 item
+        3a); ``seq`` is the per-workspace monotonic counter (#1175 item
+        4).  All additive -- defaults preserve the legacy shape.
         """
-        message_dict = _service_health_frame(workspace_id, healthy, message)
+        message_dict = _service_health_frame(
+            workspace_id,
+            healthy=healthy,
+            message=message,
+            running=running,
+            health_checked_at=health_checked_at,
+            seq=seq,
+        )
         dead = []
         for sock, conn in self.connections.items():
             if conn.user.get("id") is None:
@@ -603,14 +660,66 @@ class WebSocketState:
                 sock.send_json(
                     _service_health_frame(
                         cs.workspace_id,
-                        cs.health_status == "healthy",
-                        cs.health_message,
+                        healthy=cs.health_status == "healthy",
+                        message=cs.health_message,
+                        running=True,
+                        health_checked_at=cs.health_checked_at,
+                        seq=cs.health_seq,
                     )
                 )
             except WS_ERRORS:
                 # The just-registered socket is already gone; nothing to
                 # snapshot to.  dispatch.py owns cleanup on disconnect.
                 break
+
+    def send_health_heartbeats(self) -> None:
+        """Send a liveness heartbeat to connections that opted in.
+
+        The ``service_health`` stream is deltas-only, so a consumer
+        can't tell "nothing changed" from "the health loop stalled /
+        the server wedged" -- silence looks like health, the worst
+        failure mode (#1175 item 3b).  This emits a
+        ``service_health_heartbeat`` frame (its own type, so
+        ``--type service_health`` consumers are unaffected) to every
+        connection that asked for it via the
+        ``subscribe_health_heartbeat`` command.
+
+        Called from ``HealthMonitor.run_health_loop`` at the end of
+        each tick, so the heartbeat's presence proves the health loop
+        itself is alive -- if the loop stalls, heartbeats stop.
+        """
+        frame = {
+            "type": "service_health_heartbeat",
+            "timestamp": _iso_utc(time.time()),
+        }
+        dead = []
+        for sock, conn in self.connections.items():
+            if conn.user.get("id") is None:
+                continue
+            if not getattr(conn, "wants_health_heartbeat", False):
+                continue
+            try:
+                sock.send_json(frame)
+            except WS_ERRORS:
+                dead.append((sock, conn))
+        for sock, conn in dead:
+            self.connections.pop(sock, None)
+            asyncio.create_task(conn.cleanup())
+
+    def handle_subscribe_health_heartbeat(
+        self, msg: dict, sock: SafeWebSocket
+    ) -> None:
+        """Opt a connection into (or out of) health heartbeats.
+
+        Request: ``{"cmd": "subscribe_health_heartbeat", "enabled":
+        true}``.  ``enabled`` defaults to True when omitted.  Stores the
+        flag on the connection so :meth:`send_health_heartbeats`
+        includes it on every health-loop tick (#1175 item 3b).
+        """
+        conn = self.connections.get(sock)
+        if conn is None:
+            return
+        conn.wants_health_heartbeat = bool(msg.get("enabled", True))
 
     def notify_user_workspaces_changed(self, user_id: str) -> None:
         """Send ``workspaces_changed`` to all of a user's connections.

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -2296,9 +2296,7 @@ class TestHealthMonitorCheckWorkspace:
         assert st.health_status == "unhealthy"
         assert st.health_message == "connection refused"
         assert st.health_checked_at is not None
-        bcast.assert_called_once_with(
-            "ws-h", "unhealthy", "connection refused"
-        )
+        bcast.assert_called_once_with(st, "unhealthy", "connection refused")
 
     async def test_no_broadcast_when_status_unchanged(self):
         monitor = container.registry.health
@@ -2418,7 +2416,7 @@ class TestHealthMonitorStartupGrace:
             await monitor._check_workspace(st)
         assert st.health_status == "healthy"
         assert st.health_checked_at is not None
-        bcast.assert_called_once_with("ws-h", "healthy", None)
+        bcast.assert_called_once_with(st, "healthy", None)
 
     async def test_unhealthy_after_grace_is_recorded(self):
         # Once the grace window has elapsed, a failing check is a real
@@ -2436,9 +2434,7 @@ class TestHealthMonitorStartupGrace:
             await monitor._check_workspace(st)
         assert st.health_status == "unhealthy"
         assert st.health_message == "connection refused"
-        bcast.assert_called_once_with(
-            "ws-h", "unhealthy", "connection refused"
-        )
+        bcast.assert_called_once_with(st, "unhealthy", "connection refused")
 
     def test_in_startup_grace_uses_anchor_window(self):
         monitor = container.registry.health
@@ -2481,13 +2477,14 @@ class TestHealthMonitorStartupGrace:
 
         monitor = container.registry.health
         sock = _mock_sock_for_health()
+        st = _health_state(health_status="unhealthy")
         try:
             _ws_state.connections[sock] = SimpleNamespace(
                 user={"id": "u1", "email": "a@x"}
             )
             # No WorkspaceSession registered for this workspace — yet
             # the event must still reach the connection.
-            monitor._broadcast("ws-h", "unhealthy", "connection refused")
+            monitor._broadcast(st, "unhealthy", "connection refused")
         finally:
             _ws_state.connections.pop(sock, None)
         sock.send_json.assert_called_once_with(
@@ -2496,6 +2493,10 @@ class TestHealthMonitorStartupGrace:
                 "workspace_id": "ws-h",
                 "healthy": False,
                 "health_message": "connection refused",
+                "running": True,
+                "health_checked_at": None,
+                # _broadcast bumps the per-workspace seq on every emit.
+                "seq": 1,
             }
         )
 
@@ -2568,3 +2569,161 @@ class TestHealthMonitorLoopSkips:
             check.assert_called()
         finally:
             container.registry.states.pop(st.workspace_id, None)
+
+
+class TestHealthMonitorBroadcastSeq:
+    """_broadcast bumps per-workspace seq and forwards live fields."""
+
+    def test_bumps_seq_each_emit_and_forwards_fields(self):
+        from klangk_backend.wshandler import state as _ws_state
+
+        monitor = container.registry.health
+        sock = _mock_sock_for_health()
+        st = _health_state(health_status="unhealthy")
+        st.health_checked_at = 1_700_000_000.0
+        try:
+            _ws_state.connections[sock] = SimpleNamespace(
+                user={"id": "u1", "email": "a@x"}
+            )
+            monitor._broadcast(st, "unhealthy", "connection refused")
+            monitor._broadcast(st, "unhealthy", "connection refused")
+        finally:
+            _ws_state.connections.pop(sock, None)
+        frames = [c[0][0] for c in sock.send_json.call_args_list]
+        assert len(frames) == 2
+        # Monotonic seq across emits; live frames are running=True.
+        assert frames[0]["seq"] == 1
+        assert frames[1]["seq"] == 2
+        assert st.health_seq == 2
+        for f in frames:
+            assert f["running"] is True
+            assert f["health_checked_at"] == "2023-11-14T22:13:20+00:00"
+
+
+class TestHealthMonitorDeath:
+    """broadcast_death + notify_workspace_killed close the death hole.
+
+    A dying container otherwise looks like "healthy, then silence" on
+    the service_health stream (#1175 item 2)."""
+
+    def test_broadcast_death_emits_terminal_frame(self):
+        from klangk_backend.wshandler import state as _ws_state
+
+        monitor = container.registry.health
+        sock = _mock_sock_for_health()
+        st = _health_state(health_status="healthy")
+        st.health_checked_at = 1_700_000_000.0
+        st.health_seq = 4
+        try:
+            _ws_state.connections[sock] = SimpleNamespace(
+                user={"id": "u1", "email": "a@x"}
+            )
+            monitor.broadcast_death(st)
+        finally:
+            _ws_state.connections.pop(sock, None)
+        frame = sock.send_json.call_args[0][0]
+        assert frame["type"] == "service_health"
+        assert frame["healthy"] is False
+        assert frame["running"] is False
+        assert frame["health_checked_at"] == "2023-11-14T22:13:20+00:00"
+        # seq bumped from 4 -> 5.
+        assert frame["seq"] == 5
+        assert st.health_seq == 5
+
+    async def test_notify_workspace_killed_emits_death_for_health_checked(
+        self,
+    ):
+        # A container death fans a terminal service_health frame to
+        # subscribers BEFORE the on_workspace_killed callback drops state.
+        from klangk_backend.wshandler import state as _ws_state
+
+        sock = _mock_sock_for_health()
+        st = _health_state(health_status="healthy")
+        container.registry.states[st.workspace_id] = st
+        seen_state_present = []
+
+        async def on_killed(wid):
+            # The state must still be present when the callback runs --
+            # death emission happens first, before removal.
+            seen_state_present.append(wid in container.registry.states)
+
+        try:
+            _ws_state.connections[sock] = SimpleNamespace(
+                user={"id": "u1", "email": "a@x"}
+            )
+            container.registry.set_on_workspace_killed(on_killed)
+            await container.registry.notify_workspace_killed(st.workspace_id)
+        finally:
+            _ws_state.connections.pop(sock, None)
+            container.registry.states.pop(st.workspace_id, None)
+            container.registry.set_on_workspace_killed(None)
+        frame = sock.send_json.call_args[0][0]
+        assert frame["healthy"] is False
+        assert frame["running"] is False
+        assert seen_state_present == [True]
+
+    async def test_notify_workspace_killed_skips_non_health_checked(self):
+        # A workspace with no health_check never appeared on the stream,
+        # so its death emits no terminal frame.
+        from klangk_backend.wshandler import state as _ws_state
+
+        sock = _mock_sock_for_health()
+        st = _health_state(health_check=None)
+        container.registry.states[st.workspace_id] = st
+        try:
+            _ws_state.connections[sock] = SimpleNamespace(
+                user={"id": "u1", "email": "a@x"}
+            )
+            await container.registry.notify_workspace_killed(st.workspace_id)
+        finally:
+            _ws_state.connections.pop(sock, None)
+            container.registry.states.pop(st.workspace_id, None)
+        sock.send_json.assert_not_called()
+
+    async def test_notify_workspace_killed_no_state_no_emit(self):
+        # If the state is already gone (double-kill), nothing to emit.
+        from klangk_backend.wshandler import state as _ws_state
+
+        sock = _mock_sock_for_health()
+        try:
+            _ws_state.connections[sock] = SimpleNamespace(
+                user={"id": "u1", "email": "a@x"}
+            )
+            await container.registry.notify_workspace_killed("no-such-ws")
+        finally:
+            _ws_state.connections.pop(sock, None)
+        sock.send_json.assert_not_called()
+
+
+class TestHealthLoopHeartbeat:
+    """run_health_loop ticks a heartbeat each sweep (#1175 item 3b).
+
+    Emitting from the loop (not a standalone task) ties heartbeat
+    presence to the loop being alive."""
+
+    async def test_heartbeats_sent_each_tick_to_opted_in(self):
+        from klangk_backend.wshandler import state as _ws_state
+
+        monitor = container.registry.health
+        sock = _mock_sock_for_health()
+        try:
+            _ws_state.connections[sock] = SimpleNamespace(
+                user={"id": "u1", "email": "a@x"},
+                wants_health_heartbeat=True,
+            )
+            with (
+                patch.object(monitor, "_check_workspace", AsyncMock()),
+                patch.object(container, "HEALTH_CHECK_INTERVAL_SECONDS", 0.01),
+            ):
+                task = asyncio.create_task(monitor.run_health_loop())
+                await asyncio.sleep(0.05)
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+        finally:
+            _ws_state.connections.pop(sock, None)
+        frames = [c[0][0] for c in sock.send_json.call_args_list]
+        assert frames  # at least one heartbeat over ~5 ticks
+        assert all(f["type"] == "service_health_heartbeat" for f in frames)

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -4257,6 +4257,9 @@ class TestNotifyServiceHealth:
             "workspace_id": "ws-123",
             "healthy": True,
             "health_message": None,
+            "running": True,
+            "health_checked_at": None,
+            "seq": 0,
         }
         sock_a.send_json.assert_called_once_with(expected)
         sock_b.send_json.assert_called_once_with(expected)
@@ -4411,6 +4414,191 @@ class TestServiceHealthSnapshot:
             container.registry.states.clear()
             container.registry.states.update(saved)
         sock.send_json.assert_not_called()
+
+
+class TestServiceHealthFrame:
+    """_service_health_frame: the additive contract fields (#1175)."""
+
+    def test_defaults_preserve_legacy_shape(self):
+        # Only the required healthy/message need to be supplied; the new
+        # fields default so an old-style caller produces a superset of
+        # the legacy frame (additive, non-breaking).
+        from klangk_backend.wshandler.session import _service_health_frame
+
+        out = _service_health_frame("ws-1", healthy=True, message=None)
+        assert out["type"] == "service_health"
+        assert out["workspace_id"] == "ws-1"
+        assert out["healthy"] is True
+        assert out["health_message"] is None
+        assert out["running"] is True
+        assert out["health_checked_at"] is None
+        assert out["seq"] == 0
+
+    def test_health_checked_at_serialized_as_iso(self):
+        from klangk_backend.wshandler.session import (
+            _service_health_frame,
+            _iso_utc,
+        )
+
+        # A known epoch renders as a fixed ISO-8601 UTC string.
+        ts = 1_700_000_000.0
+        assert _iso_utc(ts) == "2023-11-14T22:13:20+00:00"
+        assert _iso_utc(None) is None
+        out = _service_health_frame(
+            "ws-1", healthy=False, message="x", health_checked_at=ts
+        )
+        assert out["health_checked_at"] == "2023-11-14T22:13:20+00:00"
+
+    def test_running_false_and_seq_forwarded(self):
+        from klangk_backend.wshandler.session import _service_health_frame
+
+        out = _service_health_frame(
+            "ws-1",
+            healthy=False,
+            message=None,
+            running=False,
+            seq=7,
+        )
+        assert out["running"] is False
+        assert out["seq"] == 7
+
+
+class TestNotifyServiceHealthForwarding:
+    """notify_service_health forwards running/checked_at/seq (#1175)."""
+
+    def _register(self, sock, user):
+        conn = _base_conn(user=user, ws=sock)
+        wshandler.state.connections[sock] = conn
+        return conn
+
+    def test_forwards_death_frame_fields(self):
+        # A container-death call passes running=False + a seq; the frame
+        # a subscriber receives carries them (#1175 items 2, 4).
+        sock = _mock_sock()
+        try:
+            self._register(sock, {"id": "uid-1", "email": "a@x"})
+            wshandler.state.notify_service_health(
+                "ws-9",
+                healthy=False,
+                running=False,
+                health_checked_at=1_700_000_000.0,
+                seq=3,
+            )
+        finally:
+            wshandler.state.connections.pop(sock, None)
+        msg = sock.send_json.call_args[0][0]
+        assert msg["running"] is False
+        assert msg["healthy"] is False
+        assert msg["seq"] == 3
+        assert msg["health_checked_at"] == "2023-11-14T22:13:20+00:00"
+
+
+class TestServiceHealthSnapshotFields:
+    """send_service_health_snapshot carries running/seq/checked_at."""
+
+    def _state(self, ws_id, *, checked_at=None, seq=0):
+        cs = container.ContainerState(ws_id, f"cid-{ws_id}")
+        cs.health_check = "true"
+        cs.health_status = "unhealthy"
+        cs.health_message = "down"
+        cs.health_checked_at = checked_at
+        cs.health_seq = seq
+        return cs
+
+    def test_snapshot_frame_carries_live_fields(self):
+        saved = dict(container.registry.states)
+        sock = _mock_sock()
+        try:
+            container.registry.states.clear()
+            container.registry.states["ws-1"] = self._state(
+                "ws-1", checked_at=1_700_000_000.0, seq=5
+            )
+            wshandler.state.send_service_health_snapshot(sock)
+        finally:
+            container.registry.states.clear()
+            container.registry.states.update(saved)
+        frame = sock.send_json.call_args[0][0]
+        # A snapshot is a live-container replay: running=True.
+        assert frame["running"] is True
+        assert frame["seq"] == 5
+        assert frame["health_checked_at"] == "2023-11-14T22:13:20+00:00"
+
+
+class TestHealthHeartbeat:
+    """send_health_heartbeats: opt-in liveness frames (#1175 item 3b)."""
+
+    def _register(self, sock, user, *, wants=False):
+        conn = _base_conn(user=user, ws=sock)
+        conn.wants_health_heartbeat = wants
+        wshandler.state.connections[sock] = conn
+        return conn
+
+    def _frame(self, sock):
+        return sock.send_json.call_args[0][0]
+
+    def test_only_opted_in_connections_receive_it(self):
+        opted = _mock_sock()
+        quiet = _mock_sock()
+        try:
+            self._register(opted, {"id": "u1", "email": "a@x"}, wants=True)
+            self._register(quiet, {"id": "u2", "email": "b@x"}, wants=False)
+            wshandler.state.send_health_heartbeats()
+        finally:
+            wshandler.state.connections.pop(opted, None)
+            wshandler.state.connections.pop(quiet, None)
+        opted.send_json.assert_called_once()
+        frame = self._frame(opted)
+        assert frame["type"] == "service_health_heartbeat"
+        assert "timestamp" in frame
+        # Default-off connections are left alone.
+        quiet.send_json.assert_not_called()
+
+    def test_skips_unauthenticated(self):
+        sock = _mock_sock()
+        try:
+            self._register(sock, {"id": None, "email": ""}, wants=True)
+            wshandler.state.send_health_heartbeats()
+        finally:
+            wshandler.state.connections.pop(sock, None)
+        sock.send_json.assert_not_called()
+
+    async def test_dead_opted_in_socket_is_pruned(self):
+        from klangk_backend.wshandler import WS_ERRORS
+
+        sock = _mock_sock()
+        sock.send_json = MagicMock(side_effect=WS_ERRORS[0]("dead"))
+        try:
+            conn = self._register(
+                sock, {"id": "u1", "email": "a@x"}, wants=True
+            )
+            with patch.object(conn, "cleanup", new_callable=AsyncMock) as mock:
+                wshandler.state.send_health_heartbeats()
+                await asyncio.sleep(0)
+                mock.assert_awaited_once()
+            assert sock not in wshandler.state.connections
+        finally:
+            wshandler.state.connections.pop(sock, None)
+
+    def test_subscribe_command_toggles_flag(self):
+        # The subscribe_health_heartbeat command flips the per-connection
+        # flag; enabled defaults to True when omitted.
+        sock = _mock_sock()
+        try:
+            conn = self._register(sock, {"id": "u1", "email": "a@x"})
+            assert conn.wants_health_heartbeat is False
+            wshandler.state.handle_subscribe_health_heartbeat({}, sock)
+            assert conn.wants_health_heartbeat is True
+            wshandler.state.handle_subscribe_health_heartbeat(
+                {"enabled": False}, sock
+            )
+            assert conn.wants_health_heartbeat is False
+        finally:
+            wshandler.state.connections.pop(sock, None)
+
+    def test_subscribe_unknown_socket_is_noop(self):
+        sock = _mock_sock()
+        # Not registered -- must not raise.
+        wshandler.state.handle_subscribe_health_heartbeat({}, sock)
 
 
 class TestRemoveSessionLocked:

--- a/src/cli/klangkc/main.py
+++ b/src/cli/klangkc/main.py
@@ -980,9 +980,20 @@ def _dispatch_monitor_event(msg: dict, command: list[str]) -> None:
         env["KLANGK_WORKSPACE_ID"] = str(wid)
     if msg.get("type") == "service_health":
         env["KLANGK_HEALTHY"] = "true" if msg.get("healthy") else "false"
+        # ``running`` distinguishes "unhealthy check" from "container
+        # stopped" -- both have healthy=false, but a death frame carries
+        # running=false (#1175 item 2).  Defaults to true for older
+        # servers that don't send the field.
+        env["KLANGK_RUNNING"] = "true" if msg.get("running", True) else "false"
         health_msg = msg.get("health_message")
         if health_msg:
             env["KLANGK_HEALTH_MESSAGE"] = str(health_msg)
+        checked_at = msg.get("health_checked_at")
+        if checked_at:
+            env["KLANGK_HEALTH_CHECKED_AT"] = str(checked_at)
+        seq = msg.get("seq")
+        if seq is not None:
+            env["KLANGK_HEALTH_SEQ"] = str(seq)
     # FileNotFoundError (missing binary) propagates to the caller.
     subprocess.run(command, input=payload.encode(), env=env, check=False)
 
@@ -1155,7 +1166,22 @@ def monitor(
     changes). With no command, events are printed as line-delimited JSON
     (pipe to jq to inspect). With a command after '--', the command's
     stdin gets the event JSON and env vars KLANGK_EVENT_TYPE,
-    KLANGK_WORKSPACE_ID, and KLANGK_HEALTHY are set.
+    KLANGK_WORKSPACE_ID, and (for health events) KLANGK_HEALTHY,
+    KLANGK_RUNNING, KLANGK_HEALTH_MESSAGE, KLANGK_HEALTH_CHECKED_AT and
+    KLANGK_HEALTH_SEQ are set.
+
+    ``service_health`` frames now carry ``running`` (#1175 item 2): a
+    container death emits a frame with ``healthy=false`` *and*
+    ``running=false`` (KLANGK_RUNNING=false), so a command can tell
+    "check failed" from "container stopped" without also subscribing
+    to ``container_status``. ``health_checked_at`` / ``seq`` give
+    freshness and gap detection.
+
+    A separate ``service_health_heartbeat`` event type is available for
+    liveness: send ``{"cmd": "subscribe_health_heartbeat", "enabled":
+    true}`` to opt in, and the server ticks a heartbeat each health-loop
+    interval. It's its own type, so ``--type service_health`` filters it
+    out; drop the filter to observe it.
 
     The monitor reconnects automatically (by default forever, with
     capped exponential backoff) and refreshes its JWT on auth failures,
@@ -1168,6 +1194,8 @@ def monitor(
       klangkc monitor --type service_health | jq .   # pretty health events
       klangkc monitor --type service_health -- sh -c \
         '[ "$KLANGK_HEALTHY" = false ] && notify-send "Service unhealthy"'
+      klangkc monitor --type service_health -- sh -c \
+        '[ "$KLANGK_RUNNING" = false ] && echo "container stopped"'
       klangkc monitor --workspace <id> --type service_health
     """
     require_auth()

--- a/src/cli/tests/test_cli.py
+++ b/src/cli/tests/test_cli.py
@@ -2866,6 +2866,41 @@ class TestMonitor:
         assert env["KLANGK_HEALTH_MESSAGE"] == "curl: connection refused"
 
     @pytest.mark.asyncio
+    async def test_death_frame_exposes_running_and_freshness_env(self):
+        # A container-death frame carries running=false plus the
+        # additive freshness/seq fields (#1175).  The dispatcher must
+        # surface them so a command can tell "stopped" from "unhealthy".
+        from klangkc.main import monitor_connection
+
+        event = {
+            "type": "service_health",
+            "workspace_id": "w1",
+            "healthy": False,
+            "running": False,
+            "health_checked_at": "2023-11-14T22:13:20+00:00",
+            "seq": 7,
+        }
+        conn = _FakeMonitorConn([json.dumps(event)])
+        with patch(
+            "klangkc.main.websockets.connect",
+            return_value=_FakeMonitorCM(conn),
+        ):
+            with patch("klangkc.main.subprocess.run") as run_mock:
+                await monitor_connection(
+                    "ws://x/ws",
+                    "tok",
+                    1024,
+                    command=["notify-send"],
+                    types=[],
+                    workspaces=[],
+                )
+        env = run_mock.call_args.kwargs["env"]
+        assert env["KLANGK_HEALTHY"] == "false"
+        assert env["KLANGK_RUNNING"] == "false"
+        assert env["KLANGK_HEALTH_CHECKED_AT"] == "2023-11-14T22:13:20+00:00"
+        assert env["KLANGK_HEALTH_SEQ"] == "7"
+
+    @pytest.mark.asyncio
     async def test_command_not_found_propagates(self, monkeypatch):
         # A missing command binary propagates FileNotFoundError out of
         # the single-connection loop (the runner turns it into an exit).

--- a/src/frontend/lib/workspace/workspace_list_page.dart
+++ b/src/frontend/lib/workspace/workspace_list_page.dart
@@ -136,13 +136,22 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
   void _onServiceHealth(Map<String, dynamic> msg) {
     if (!mounted) return;
     final wsId = msg['workspace_id'] as String?;
-    final healthy = msg['healthy'] as bool? ?? false;
     if (wsId == null) return;
+    // ``running`` (added in #1175 item 2) distinguishes a live
+    // container's check result from a terminal container-death frame:
+    // a death carries running=false (and healthy=false).  Defaults to
+    // true for older servers that don't send the field, and mirrors
+    // _onContainerStatus so both paths render a dead container grey.
+    final running = msg['running'] as bool? ?? true;
+    final healthy = msg['healthy'] as bool? ?? false;
     setState(() {
       for (final section in [_owned, _shared]) {
         for (final ws in section.workspaces) {
           if (ws['id'] == wsId) {
-            ws['health'] = healthy ? 'healthy' : 'unhealthy';
+            ws['running'] = running;
+            // A stopped container has no health status; a running one
+            // reflects the latest check.
+            ws['health'] = running ? (healthy ? 'healthy' : 'unhealthy') : null;
           }
         }
       }


### PR DESCRIPTION
Closes #1175.

## Summary

The `service_health` WebSocket stream worked for the web UI (REST fallback) but was unreliable for pure-WS consumers like `klangkc monitor`: a dying container looked like "healthy, then silence," events lacked freshness/sequence signals, and there was no liveness heartbeat. (Item 1 — the connect-time snapshot — already shipped in #1210.)

This completes the contract, **staged additively** per the issue's guidance — the breaking pieces (new semantics, new event type) are gated behind the additive group:

- **#2 (correctness):** Added a `running` field to every `service_health` frame and emit a **terminal** `service_health{healthy:false, running:false}` frame when a health-checked container dies, *before* its state is removed. A consumer watching only `service_health` now learns the service is down instead of believing the last-known status. (`HealthMonitor.broadcast_death`; death emitted from `notify_workspace_killed` ahead of the `on_workspace_killed` callback that drops state.)
- **#3a (additive):** Frames now carry `health_checked_at` (ISO-8601 of the last poll) for freshness without correlating a receive clock.
- **#4 (additive):** Frames now carry a per-workspace `seq`, bumped on every emit (transition and death); on reconnect a consumer reconciles snapshot + seq to detect a missed transition.
- **#3b (new event type):** Opt-in `service_health_heartbeat`, emitted from the health loop at the end of each tick (so its presence proves the loop is alive), toggled via the new `subscribe_health_heartbeat` command. Its own type so `--type service_health` consumers are unaffected.

`_service_health_frame` is the single source of truth for the event shape, shared by the transition broadcast, the death broadcast, and the connect-time snapshot. All new fields are additive with defaults that preserve the legacy shape.

### Consumers
- **`klangkc monitor`**: sets `KLANGK_RUNNING`, `KLANGK_HEALTH_CHECKED_AT`, `KLANGK_HEALTH_SEQ`; `running=false` lets a command tell a death from a failing check.
- **Web UI** `_onServiceHealth`: honors `running` so a death frame renders the container grey (consistent with `_onContainerStatus`).

## Acceptance criteria
- [x] #1 — snapshot on connect (already #1210)
- [x] #2 — container death → unambiguous terminal state on `service_health`
- [x] #3a — events carry `health_checked_at`
- [x] #3b — opt-in heartbeat available
- [x] Consumers updated; breaking changes (#2/#3b) additive-first and documented in `docs/features/health-check.md`

(#4 seq landed along with #3a; #5 server-side scoping is left as a follow-up per the issue.)

## Test plan
- Backend: new unit tests for `_service_health_frame`, `notify_service_health` forwarding, snapshot fields, heartbeat (`send_health_heartbeats` opt-in/unauth/dead-socket/subscribe), `_broadcast` seq bump, `broadcast_death`, `notify_workspace_killed` death emission (health-checked / non-health-checked / state-already-gone), and `run_health_loop` heartbeat ticking. Existing `_broadcast`-signature tests updated.
- CLI: new test that a death frame sets `KLANGK_RUNNING=false` + `KLANGK_HEALTH_CHECKED_AT` / `KLANGK_HEALTH_SEQ`.
- Full backend unit suite (2134) and CLI suite (503) green at 100% coverage on changed modules. Dart change analyzer-clean (the standalone analyzer's SDK-resolution noise is pre-existing and present on untouched files too).