### PR TITLE
test(main): make TestStartupShutdownRestart order/isolation-independent

### DIFF
--- a/src/backend/tests/test_main.py
+++ b/src/backend/tests/test_main.py
@@ -244,6 +244,17 @@ class TestLifespan:
 
 
 class TestStartupShutdownRestart:
+    @pytest.fixture(autouse=True)
+    def _reset_restart_lock(self):
+        # ``main._restart_lock`` is a module-global lazily created on first
+        # use. Without a reset, lock state leaks across tests, making them
+        # order-dependent (and breaking some tests in isolation or under
+        # pytest-randomly's shuffle). Reset to the pre-first-use floor before
+        # every test in this class so each one is self-contained (#1242).
+        main._restart_lock = None
+        yield
+        main._restart_lock = None
+
     async def test_startup_calls_container_sequence(self):
         with (
             patch.object(
@@ -327,6 +338,11 @@ class TestStartupShutdownRestart:
         assert main._restart_lock is not None
 
     async def test_restart_runtime_reuses_existing_lock(self):
+        # Seed a lock explicitly; ``restart_runtime`` must reuse it rather
+        # than create a new one. (Previously this relied on a prior test's
+        # side effect of populating the module-global, which made it
+        # order-dependent and broken in isolation — #1242.)
+        main._restart_lock = asyncio.Lock()
         existing = main._restart_lock
         with (
             patch(


### PR DESCRIPTION
Closes #1242.

## Problem

`test_restart_runtime_reuses_existing_lock` was order/isolation-dependent. `main._restart_lock` is a module-global lazily created on first use; `test_restart_runtime_creates_lock` populated it as a side effect, and `test_restart_runtime_reuses_existing_lock` relied on that inherited state (captured `existing = main._restart_lock`, asserted identity).

When "reuses" ran in a **fresh process** — in isolation, or under `pytest-xdist -n auto` (which distributes tests across workers that may split the two tests) — `_restart_lock` was `None`, `restart_runtime()` created a new lock, and the identity assertion failed:

```
assert main._restart_lock is existing
AssertionError: assert <Lock ... [unlocked]> is None
```

This made `-n auto` intermittently red (pre-existing on `main`).

## Fix

An **autouse fixture** resets `main._restart_lock = None` before and after every test in `TestStartupShutdownRestart`, so each test is self-contained and the whole class is order-independent. The "reuses" test now seeds its own lock explicitly (`main._restart_lock = asyncio.Lock()`) before asserting it is reused.

## Verification

- `test_restart_runtime_reuses_existing_lock` now **passes in isolation** ✅
- Full suite `-n auto`: **2114 passed, 100% coverage** (was red before) ✅
- ruff/prettier/trufflehog clean ✅
