### PR TITLE
fix(workspaces): fire service command on every fresh container create

### DIFF
--- a/docs/features/auto-start.md
+++ b/docs/features/auto-start.md
@@ -57,13 +57,14 @@ workspace:
 When the Klangk server starts, after initializing the database and
 cleaning up orphaned containers, it queries all workspaces with
 auto-start enabled and starts their containers. If a workspace also
-has a [service command](service-command.md), the command is sent as
-keystrokes into tmux window 0 — so the service is already running
-by the time any user connects.
+has a [service command](service-command.md), the command runs in the
+workspace's `service-cmd` terminal window — so the service is already
+running by the time any user connects. Auto-started containers are
+pinned alive (they do not idle out between connections).
 
-Users connect later with `klangkc shell` and see the service
-output in tmux window 0. They can open a second window for a shell
-alongside the running service.
+Users connect later with `klangkc shell` and see the service output in
+the `service-cmd` tab. They can open another tab for a shell alongside
+the running service.
 
 ## Typical setup
 

--- a/docs/features/service-command.md
+++ b/docs/features/service-command.md
@@ -74,19 +74,20 @@ workspace:
 
 ## When does the command run?
 
-The service command runs when the terminal session is created —
-typically on the first connection to the workspace after the
-container starts. It does **not** re-run on reconnect; if you
-disconnect and reconnect, you pick up the tmux session exactly
-where you left off (the process may still be running, or you may
-be at a bash prompt if it exited).
+The service command runs whenever a **fresh container** is created
+for the workspace — at workspace creation, on `klangkc restart`, at
+server boot (for [auto-start](#auto-start-workspaces) workspaces), or
+on the first connection that starts the container. It does **not**
+re-run on reconnect; if you disconnect and reconnect, you pick up the
+tmux session exactly where you left off (the process may still be
+running, or you may be at a bash prompt if it exited).
 
 ### Auto-start workspaces
 
 If the workspace has [auto-start](workspaces.md#auto-start) enabled,
-the container starts when the Klangk server starts and the default
-command begins running immediately — before any user connects. When
-you later run `klangkc shell`, you walk up to the service already
+the container also starts when the Klangk server starts (boot), so
+the service is already running before any user connects. When you
+later run `klangkc shell`, you walk up to the service already
 running in the `service-cmd` tab. Visitors who open the workspace see
 it as a shared terminal without any action from the owner.
 

--- a/src/backend/e2e-tests/test_agent_home_e2e.py
+++ b/src/backend/e2e-tests/test_agent_home_e2e.py
@@ -13,7 +13,7 @@ only *mock*:
    ``~/.pi/agent/``) is provisioned **eagerly at bring-up** via
    ``ensure_agent_home`` -- not lazily at the first chat mention.
 
-   Crucially, eager provisioning lives only in ``eager_start_workspace``
+   Crucially, eager provisioning lives only in ``start_workspace``
    (triggered by ``auto_start=True`` on workspace creation), *not* the
    normal WS connect path.  So the eager test creates a workspace with
    ``auto_start=True`` and inspects the filesystem via ``podman exec``
@@ -54,7 +54,7 @@ def server():
 
     KLANGK_ALLOW_AUTOSTART=1 is required so the eager-provisioning test
     can create a workspace with auto_start=True (which routes through
-    eager_start_workspace -> ensure_agent_home).
+    start_workspace -> ensure_agent_home).
     """
     data_dir = tempfile.mkdtemp(prefix="klangk-agent-home-e2e-")
     port = "18997"
@@ -301,24 +301,24 @@ class TestAgentHomeE2E:
     @pytest.mark.asyncio
     async def test_agent_home_provisioned_eagerly(self, server, auth):
         """The agent home exists immediately after a container is brought
-        up via eager_start_workspace -- with NO chat mention and NO WS
+        up via start_workspace -- with NO chat mention and NO WS
         connection preceding the check (#1157).
 
-        auto_start=True routes creation through eager_start_workspace,
+        auto_start=True routes creation through start_workspace,
         which calls ensure_agent_home on a freshly-created container
         (status == "created").  We then inspect the filesystem directly
         via podman exec, as root, so the check is independent of any
         user's read permissions.
         """
-        # auto_start triggers eager_start_workspace (run_service_command
-        # is False on the create path, but agent-home provisioning runs
-        # regardless -- it precedes the service-command block).
+        # auto_start triggers start_workspace. The service command fires
+        # at the create choke point (bringup), but only once setup_state
+        # is complete; agent-home provisioning always runs at create.
         workspace_id, cleanup = create_workspace(
             server, auth, auto_start=True, setup_state="complete"
         )
         try:
             # Wait for the eagerly-started container to be running.
-            # create_workspace awaits eager_start_workspace, so the
+            # create_workspace awaits start_workspace, so the
             # container is up by the time the POST returned; poll as a
             # belt-and-suspenders against scheduling latency.  Filter by
             # the deterministic container name so we target THIS

--- a/src/backend/klangk_backend/api/workspaces.py
+++ b/src/backend/klangk_backend/api/workspaces.py
@@ -194,11 +194,12 @@ async def create_workspace(
 
     # Eagerly start the container so it's running by the time the
     # user connects.  Errors are logged but don't fail the create.
+    # The service command fires at the create choke point inside
+    # start_container (see bringup.bringup, #1244), gated on setup_state
+    # so workspaces whose setup.sh hasn't run yet defer until complete.
     if body.auto_start:
         try:
-            await workspaces.eager_start_workspace(
-                ws, run_service_command=False
-            )
+            await workspaces.start_workspace(ws)
         except Exception:
             logger.warning(
                 "Eager start failed for workspace %s",
@@ -361,8 +362,10 @@ async def restart_workspace(
 ):
     """Restart a workspace container.
 
-    Stops and removes the running container.  The next WebSocket
-    connect will start a fresh one with the same workspace config.
+    Stops and removes the running container, then eagerly starts a
+    fresh one with the same workspace config (#1244). The service
+    command re-fires at the create choke point, so a service workspace
+    recovers to healthy.
     """
     workspace = await model.get_workspace(workspace_id)
     if workspace is None:
@@ -376,6 +379,9 @@ async def restart_workspace(
     if cid:
         await container.registry.stop_and_remove_container(cid)
     await wshandler.reset_workspace_state(workspace_id)
+    # Start a fresh container; the service command fires via the
+    # create choke point in start_container.
+    await workspaces.start_workspace(workspace)
     return {"status": "restarted"}
 
 

--- a/src/backend/klangk_backend/bringup.py
+++ b/src/backend/klangk_backend/bringup.py
@@ -1,0 +1,40 @@
+"""Container bring-up: provision agent home, fire the service command.
+
+This is the single choke point reached after ``container.registry.
+start_container`` creates a *fresh* container (status ``"created"``).
+``container`` cannot import ``agent`` directly (``agent`` already
+imports ``container`` for ``registry.get_state``), so the
+bring-up step lives here to keep that boundary clean.
+
+``ensure_service_session`` is idempotent (per-container lock +
+window-exists check), so calling this on every fresh create is safe:
+after the first fire it is a no-op. The create-time deferral for
+workspaces whose ``setup.sh`` has not run yet is handled by gating on
+``setup_state`` -- the CLI sandbox driver marks such workspaces
+``"pending"`` at create, and the fire lands later once setup
+completes and the WS connect path runs.
+"""
+
+from . import agent, terminal
+
+
+async def bringup(
+    workspace_id: str,
+    container_id: str,
+    service_command: str | None,
+    setup_state: str | None,
+) -> None:
+    """Provision the agent home and fire the service command.
+
+    Called at the single choke point: every freshly-created container.
+    Idempotent via :func:`terminal.ensure_service_session`.
+    """
+    agent_home = await agent.ensure_agent_home(workspace_id, container_id)
+    if not service_command:
+        return
+    await terminal.ensure_service_session(
+        container_id,
+        agent_home,
+        service_command,
+        setup_state=setup_state,
+    )

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -5,7 +5,7 @@ import logging
 import os
 import time
 
-from . import auth, model, plugins, podman, terminal, util
+from . import auth, bringup, model, plugins, podman, terminal, util
 
 logger = logging.getLogger(__name__)
 
@@ -556,7 +556,7 @@ class HealthMonitor:
         box into a diagnosable failure instead of "good luck" (#1088).
 
         Resolves the owner's container home (same logic as
-        ``eager_start_workspace``) and invokes the check via
+        ``start_workspace``) and invokes the check via
         ``podman exec`` as the creating user with HOME set.  The check
         runs as a **non-login** bash shell (``bash -c``) on purpose: it
         is an operational probe, not a user session, so it deliberately
@@ -585,7 +585,7 @@ class HealthMonitor:
         if not handle:
             return "unhealthy", f"owner {owner_id} has no handle"
         # Resolve the owner's container home the same way
-        # eager_start_workspace does, so the check runs in the right
+        # start_workspace does, so the check runs in the right
         # HOME rather than as root in /.
         from . import workspaces as _wm  # noqa: allow-deferred-import
 
@@ -968,6 +968,7 @@ class ContainerRegistry:
         user_id: str | None = None,
         health_check: str | None = None,
         setup_state: str | None = None,
+        service_command: str | None = None,
     ) -> tuple[str, str]:
         """Start (or restart) a Pi container for a workspace.
 
@@ -994,6 +995,7 @@ class ContainerRegistry:
                 user_id=user_id,
                 health_check=health_check,
                 setup_state=setup_state,
+                service_command=service_command,
             )
 
     async def _handle_existing_container(
@@ -1093,7 +1095,7 @@ class ContainerRegistry:
         ``hosting_hostname``/``hosting_proto``/``hosting_base_path`` are
         optional: callers with a live request pass the values they derived
         from its headers (``wshandler.connection``), and callers without one
-        (``eager_start_workspace`` — autostart/create, no connection yet) pass
+        (``start_workspace`` — autostart/create, no connection yet) pass
         ``None``. Resolving the floor here, at the single choke point, means
         no start path can bypass the override: when a caller omits them we
         derive the env / bare-localhost floor via ``derive_hosting_info``
@@ -1352,6 +1354,7 @@ class ContainerRegistry:
         user_id: str | None = None,
         health_check: str | None = None,
         setup_state: str | None = None,
+        service_command: str | None = None,
     ) -> tuple[str, str]:
         """Inner implementation of start_container (called under lock)."""
         t_start = time.monotonic()
@@ -1463,6 +1466,19 @@ class ContainerRegistry:
             )
         )
 
+        # Fresh create: provision the agent home and fire the service
+        # command (#1244). This is the single choke point -- every
+        # start path (boot autostart, create, connect, klangkc restart)
+        # routes through start_container, so the bring-up runs once per
+        # fresh container regardless of caller. ensure_service_session
+        # is idempotent, and setup_state gates the create-time deferral
+        # for workspaces whose setup.sh has not run yet.
+        await bringup.bringup(
+            workspace_id,
+            container_id,
+            service_command,
+            setup_state,
+        )
         logger.info(
             "workspace-open: DONE — new container created and started: %.3fs",
             time.monotonic() - t_start,

--- a/src/backend/klangk_backend/terminal.py
+++ b/src/backend/klangk_backend/terminal.py
@@ -107,7 +107,7 @@ SERVICE_SESSION = "service"
 
 # Per-container locks serializing the read-then-write firing sequence in
 # ensure_service_session (#1188). Two unserialized callers -- the boot path
-# (workspaces.eager_start_workspace) and the per-connection path
+# (workspaces.start_workspace) and the per-connection path
 # (wshandler _fire_service_command) -- could both observe
 # service_cmd_window_exists -> False before either's new-window landed, and
 # since tmux permits duplicate window names, both would create a service-cmd

--- a/src/backend/klangk_backend/util.py
+++ b/src/backend/klangk_backend/util.py
@@ -233,7 +233,7 @@ def derive_hosting_info(
     verification/reset/OIDC links the backend generates.
 
     Both args are optional so the same resolver serves callers that have no
-    request in hand — chiefly ``eager_start_workspace`` (autostart/create,
+    request in hand — chiefly ``start_workspace`` (autostart/create,
     which runs at boot with no connection). With no headers the request
     branches are skipped and the env vars are the sole source, falling back
     to bare ``localhost`` / ``http`` / ``""``.

--- a/src/backend/klangk_backend/workspaces.py
+++ b/src/backend/klangk_backend/workspaces.py
@@ -8,7 +8,7 @@ import shutil
 import tempfile
 from pathlib import Path
 
-from . import agent, container, model, podman, terminal
+from . import container, model, podman
 from .util import resolve_env_bool, resolve_env_value
 
 logger = logging.getLogger(__name__)
@@ -397,23 +397,17 @@ async def populate_home_skel(
         )
 
 
-async def eager_start_workspace(
-    ws: dict, *, run_service_command: bool = True
-) -> tuple[str, str]:
+async def start_workspace(ws: dict) -> tuple[str, str]:
     """Start a container for a workspace immediately.
 
-    Sets ``idle_timeout = 0`` so the container does not idle out.
+    Thin wrapper around ``container.registry.start_container`` that
+    unpacks the workspace dict. The agent home provisioning and the
+    service command firing happen at the single create choke point
+    inside ``start_container`` (see ``bringup.bringup``, #1244), so
+    they no longer live here.
 
-    There are two callers with different needs:
-
-    * **Server boot** (``auto_start_workspaces``) leaves
-      *run_service_command* at its default ``True`` — the workspace's
-      software is already installed in the persisted volume, so the
-      service command is safe to run now.
-    * **Workspace creation** (``api/workspaces.create_workspace``)
-      passes ``run_service_command=False`` — ``setup.sh`` has not run
-      yet, so the service command would fail.  The CLI sandbox driver
-      sends ``terminal_start`` after setup completes to trigger it.
+    ``idle_timeout`` is left at its default; only
+    ``auto_start_workspaces`` (the boot path) pins it to 0.
 
     Returns ``(container_id, status)``.
     """
@@ -435,42 +429,8 @@ async def eager_start_workspace(
         user_id=owner_id,
         health_check=ws.get("health_check"),
         setup_state=ws.get("setup_state"),
+        service_command=ws.get("service_command"),
     )
-    state = container.registry.states.get(workspace_id)
-    if state:
-        state.idle_timeout = 0
-
-    # Eagerly provision the agent home at bring-up so $KLANGK_AGENT_HOME
-    # points at a populated directory for every process (#1157).  The
-    # home lives on the persisted bind-mount volume, so only provision
-    # for a freshly-created container; on re-attach/restart it already
-    # exists.  Capture the container path to target the service session.
-    agent_home: str | None = None
-    if status == "created":
-        agent_home = await agent.ensure_agent_home(workspace_id, cid)
-
-    # If the workspace has a service command, fire it in the standalone
-    # ``service`` tmux session owned by the agent identity -- not in the
-    # owner's session (#1133 D5/D6).  The session is decoupled from the
-    # ``pi --mode rpc`` subprocess and keyed by AGENT_USER_ID (constant
-    # name ``service``), so it survives the agent process dying and is
-    # always attributable.  Gated on a freshly-created container (the
-    # persisted service session survives restart) and run_service_command
-    # (fresh creates defer this -- setup.sh hasn't run yet).
-    service_command = ws.get("service_command")
-    if (
-        service_command
-        and status == "created"
-        and run_service_command
-        and agent_home is not None
-    ):
-        await terminal.ensure_service_session(
-            cid,
-            agent_home,
-            service_command,
-            setup_state=ws.get("setup_state"),
-        )
-
     return cid, status
 
 
@@ -489,7 +449,14 @@ async def auto_start_workspaces() -> int:
         if i > 0:
             await asyncio.sleep(random.uniform(0.5, 2.0))
         try:
-            cid, status = await eager_start_workspace(ws)
+            cid, status = await start_workspace(ws)
+            # Auto-started containers are boot services: pin them alive
+            # so they do not idle out between user connections. Only the
+            # boot path does this -- create/restart use the default idle
+            # timeout (#1244).
+            state = container.registry.states.get(ws["id"])
+            if state:
+                state.idle_timeout = 0
             logger.info(
                 "Auto-started workspace %s (%s): %s",
                 ws["name"],

--- a/src/backend/klangk_backend/wshandler/connection.py
+++ b/src/backend/klangk_backend/wshandler/connection.py
@@ -321,6 +321,7 @@ class Connection:
             user_id=self.user["id"],
             health_check=workspace.get("health_check"),
             setup_state=workspace.get("setup_state"),
+            service_command=workspace.get("service_command"),
         )
         self.container_status = container_status
         self.workspace_id = workspace_id

--- a/src/backend/tests/test_agent.py
+++ b/src/backend/tests/test_agent.py
@@ -748,7 +748,7 @@ class TestGetSession:
 class TestEnsureAgentHome:
     """Direct tests for the eager-provisioning function (#1157).
 
-    Called from eager_start_workspace at container bring-up (every exec
+    Called from start_workspace at container bring-up (every exec
     process inherits $KLANGK_AGENT_HOME) and again from chat-start, which
     caches the result per AgentSession (see TestEnsureHome).
     """

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -1285,7 +1285,7 @@ class TestWorkspaceRoutes:
         with (
             patch.dict(os.environ, {"KLANGK_ALLOW_AUTOSTART": "1"}),
             patch(
-                "klangk_backend.workspaces.eager_start_workspace",
+                "klangk_backend.workspaces.start_workspace",
                 new_callable=AsyncMock,
             ) as mock_start,
         ):
@@ -1303,7 +1303,7 @@ class TestWorkspaceRoutes:
         with (
             patch.dict(os.environ, {"KLANGK_ALLOW_AUTOSTART": "1"}),
             patch(
-                "klangk_backend.workspaces.eager_start_workspace",
+                "klangk_backend.workspaces.start_workspace",
                 new_callable=AsyncMock,
                 side_effect=RuntimeError("podman broke"),
             ),

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -1498,17 +1498,27 @@ class TestWorkspaceRoutes:
         # Simulate a running container so the stop path is exercised.
         api.container.registry.track_activity("cid-restart", ws_id)
 
-        with patch.object(
-            api.container.registry,
-            "stop_and_remove_container",
-            new_callable=AsyncMock,
-        ) as mock_stop:
+        with (
+            patch.object(
+                api.container.registry,
+                "stop_and_remove_container",
+                new_callable=AsyncMock,
+            ) as mock_stop,
+            patch(
+                "klangk_backend.workspaces.start_workspace",
+                new_callable=AsyncMock,
+            ) as mock_start,
+        ):
             resp = await client.post(
                 f"/api/v1/workspaces/{ws_id}/restart", headers=headers
             )
         assert resp.status_code == 200
         assert resp.json()["status"] == "restarted"
         mock_stop.assert_awaited_once_with("cid-restart")
+        # #1244: restart re-starts the container (not just stop+remove),
+        # so the service command re-fires at the create choke point and
+        # the workspace recovers.
+        mock_start.assert_awaited_once()
 
         # Clean up registry state.
         api.container.registry.states.pop(ws_id, None)

--- a/src/backend/tests/test_bringup.py
+++ b/src/backend/tests/test_bringup.py
@@ -1,0 +1,125 @@
+"""Tests for bringup: the create choke-point orchestrator (#1244).
+
+``bringup`` runs inside ``start_container`` for every fresh container.
+It provisions the agent home and fires the service command. The
+underlying primitives (``agent.ensure_agent_home``,
+``terminal.ensure_service_session``) have their own coverage; these
+tests pin the orchestration: that both are called in the right order
+with the right args, and that the service-command half is skipped when
+no command is configured.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+from klangk_backend import bringup
+
+
+class TestBringup:
+    async def test_provisions_home_and_fires_service_command(self):
+        """A configured service command fires after the home is ready."""
+        with (
+            patch(
+                "klangk_backend.bringup.agent.ensure_agent_home",
+                new_callable=AsyncMock,
+                return_value="/home/clanker",
+            ) as mock_home,
+            patch(
+                "klangk_backend.bringup.terminal.ensure_service_session",
+                new_callable=AsyncMock,
+            ) as mock_service,
+        ):
+            await bringup.bringup(
+                "ws-id",
+                "cid",
+                "openclaw gateway",
+                setup_state="complete",
+            )
+        mock_home.assert_awaited_once_with("ws-id", "cid")
+        mock_service.assert_awaited_once_with(
+            "cid",
+            "/home/clanker",
+            "openclaw gateway",
+            setup_state="complete",
+        )
+
+    async def test_skips_service_command_when_none(self):
+        """No service_command -> only the agent home is provisioned."""
+        with (
+            patch(
+                "klangk_backend.bringup.agent.ensure_agent_home",
+                new_callable=AsyncMock,
+                return_value="/home/clanker",
+            ) as mock_home,
+            patch(
+                "klangk_backend.bringup.terminal.ensure_service_session",
+                new_callable=AsyncMock,
+            ) as mock_service,
+        ):
+            await bringup.bringup("ws-id", "cid", None, "complete")
+        mock_home.assert_awaited_once_with("ws-id", "cid")
+        mock_service.assert_not_awaited()
+
+    async def test_skips_service_command_when_empty(self):
+        """An empty service_command string is treated as 'none'."""
+        with (
+            patch(
+                "klangk_backend.bringup.agent.ensure_agent_home",
+                new_callable=AsyncMock,
+                return_value="/home/clanker",
+            ),
+            patch(
+                "klangk_backend.bringup.terminal.ensure_service_session",
+                new_callable=AsyncMock,
+            ) as mock_service,
+        ):
+            await bringup.bringup("ws-id", "cid", "", "complete")
+        mock_service.assert_not_awaited()
+
+    async def test_threads_setup_state_through_predicate(self):
+        """setup_state flows to ensure_service_session, which gates on it.
+
+        A 'pending' setup_state still calls ensure_service_session (the
+        gating happens inside it via should_fire_service_command), so the
+        orchestrator's job is just to pass the value through unchanged.
+        """
+        with (
+            patch(
+                "klangk_backend.bringup.agent.ensure_agent_home",
+                new_callable=AsyncMock,
+                return_value="/home/clanker",
+            ),
+            patch(
+                "klangk_backend.bringup.terminal.ensure_service_session",
+                new_callable=AsyncMock,
+            ) as mock_service,
+        ):
+            await bringup.bringup(
+                "ws-id", "cid", "openclaw gateway", setup_state="pending"
+            )
+        mock_service.assert_awaited_once_with(
+            "cid",
+            "/home/clanker",
+            "openclaw gateway",
+            setup_state="pending",
+        )
+
+    async def test_threads_none_setup_state(self):
+        """A None setup_state (caller omitted it) is passed through."""
+        with (
+            patch(
+                "klangk_backend.bringup.agent.ensure_agent_home",
+                new_callable=AsyncMock,
+                return_value="/home/clanker",
+            ),
+            patch(
+                "klangk_backend.bringup.terminal.ensure_service_session",
+                new_callable=AsyncMock,
+            ) as mock_service,
+        ):
+            await bringup.bringup("ws-id", "cid", "openclaw gateway", None)
+        mock_service.assert_awaited_once_with(
+            "cid",
+            "/home/clanker",
+            "openclaw gateway",
+            setup_state=None,
+        )

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -9,7 +9,21 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from klangk_backend import container, model, plugins, podman
+from klangk_backend import bringup, container, model, plugins, podman
+
+
+@pytest.fixture(autouse=True)
+def _stub_bringup(monkeypatch):
+    """Block every container-mechanics test from spawning real processes.
+
+    ``start_container`` calls ``bringup.bringup`` at the create choke
+    point (#1244), which otherwise reaches ``agent.ensure_agent_home``
+    and spawns a real ``podman exec`` subprocess. These tests exercise
+    port/sudo/reuse mechanics against a fake ``new-cid`` — they must
+    never touch real podman. Bring-up has its own dedicated coverage
+    (test_bringup.py).
+    """
+    monkeypatch.setattr(bringup, "bringup", AsyncMock())
 
 
 class TestParseIdleTimeout:

--- a/src/backend/tests/test_terminal.py
+++ b/src/backend/tests/test_terminal.py
@@ -1526,7 +1526,7 @@ class TestEnsureServiceSession:
         """#1188: two concurrent ensure_service_session calls for the SAME
         container must not both create the service-cmd window.
 
-        The boot path (workspaces.eager_start_workspace) and the per-connection
+        The boot path (workspaces.start_workspace) and the per-connection
         path (wshandler _fire_service_command) are both unserialized callers.
         Without the per-container lock, both can pass the window-exists check
         before either's new-window lands, and since tmux allows duplicate

--- a/src/backend/tests/test_workspaces.py
+++ b/src/backend/tests/test_workspaces.py
@@ -409,107 +409,64 @@ class TestAutoStartWorkspaces:
         assert result == 0
 
 
-class TestEagerStartWorkspace:
-    async def test_starts_container_and_disables_idle(self, user):
-        ws = await ws_mod.create_workspace(
-            user["id"], "eager-ws", auto_start=True
-        )
-        from klangk_backend.container import ContainerState
+class TestStartWorkspace:
+    """Tests for start_workspace: the thin dict-unpacking wrapper.
 
-        container.registry.states[ws["id"]] = ContainerState(
-            ws["id"], "cid-eager"
-        )
-        try:
-            with (
-                patch.object(
-                    container.registry,
-                    "start_container",
-                    new_callable=AsyncMock,
-                    return_value=("cid-eager", "created"),
-                ) as mock_start,
-                patch(
-                    "klangk_backend.agent.ensure_agent_home",
-                    new_callable=AsyncMock,
-                ),
-            ):
-                cid, status = await ws_mod.eager_start_workspace(ws)
-            assert cid == "cid-eager"
-            assert status == "created"
-            mock_start.assert_awaited_once()
-            assert container.registry.states[ws["id"]].idle_timeout == 0
-        finally:
-            container.registry.states.pop(ws["id"], None)
+    The service-command firing and agent-home provisioning moved to
+    the create choke point inside start_container (see bringup.bringup,
+    #1244), and idle_timeout pinning moved to auto_start_workspaces
+    (boot path only). So start_workspace itself only unpacks the
+    workspace dict and delegates to registry.start_container.
+    """
 
-    async def test_runs_service_command_on_create(self, user):
+    async def test_unpacks_dict_and_starts_container(self, user):
         ws = await ws_mod.create_workspace(
             user["id"],
-            "eager-cmd-ws",
+            "start-ws",
             auto_start=True,
             service_command="openclaw gateway",
         )
-        from klangk_backend.container import ContainerState
-
-        container.registry.states[ws["id"]] = ContainerState(
-            ws["id"], "cid-cmd"
-        )
         try:
-            with (
-                patch.object(
-                    container.registry,
-                    "start_container",
-                    new_callable=AsyncMock,
-                    return_value=("cid-cmd", "created"),
-                ),
-                patch(
-                    "klangk_backend.terminal.ensure_service_session",
-                    new_callable=AsyncMock,
-                ) as mock_service,
-                patch(
-                    "klangk_backend.agent.ensure_agent_home",
-                    new_callable=AsyncMock,
-                    return_value="/home/clanker",
-                ),
-            ):
-                await ws_mod.eager_start_workspace(ws)
-            # The service command fires in the standalone service session
-            # owned by the agent identity, not the owner's (#1133).
-            mock_service.assert_awaited_once_with(
-                "cid-cmd",
-                "/home/clanker",
-                "openclaw gateway",
-                setup_state="complete",
+            with patch.object(
+                container.registry,
+                "start_container",
+                new_callable=AsyncMock,
+                return_value=("cid-x", "created"),
+            ) as mock_start:
+                cid, status = await ws_mod.start_workspace(ws)
+            assert cid == "cid-x"
+            assert status == "created"
+            mock_start.assert_awaited_once()
+            # The service_command is threaded through to start_container
+            # so the create choke point (bringup) can fire it.
+            assert mock_start.call_args.kwargs["service_command"] == (
+                "openclaw gateway"
             )
         finally:
             container.registry.states.pop(ws["id"], None)
 
-    async def test_skips_service_command_on_reconnect(self, user):
+    async def test_does_not_pin_idle_timeout(self, user):
+        """Only the boot path (auto_start_workspaces) pins idle_timeout."""
         ws = await ws_mod.create_workspace(
-            user["id"],
-            "eager-recon-ws",
-            auto_start=True,
-            service_command="openclaw gateway",
+            user["id"], "start-ws-no-idle", auto_start=True
         )
         from klangk_backend.container import ContainerState
 
-        container.registry.states[ws["id"]] = ContainerState(
-            ws["id"], "cid-recon"
-        )
+        # Registry default idle timeout is non-zero; start_workspace
+        # must not clobber it.
+        default_timeout = ContainerState(ws["id"], "cid-y").idle_timeout
+        container.registry.states[ws["id"]] = ContainerState(ws["id"], "cid-y")
         try:
-            with (
-                patch.object(
-                    container.registry,
-                    "start_container",
-                    new_callable=AsyncMock,
-                    return_value=("cid-recon", "connected"),
-                ),
-                patch(
-                    "klangk_backend.terminal.ensure_base_session",
-                    new_callable=AsyncMock,
-                ) as mock_session,
+            with patch.object(
+                container.registry,
+                "start_container",
+                new_callable=AsyncMock,
+                return_value=("cid-y", "created"),
             ):
-                await ws_mod.eager_start_workspace(ws)
-            # "connected" means container was already running —
-            # don't re-run the service command.
-            mock_session.assert_not_awaited()
+                await ws_mod.start_workspace(ws)
+            assert (
+                container.registry.states[ws["id"]].idle_timeout
+                == default_timeout
+            )
         finally:
             container.registry.states.pop(ws["id"], None)

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -632,7 +632,7 @@ class TestDeriveHostingInfo:
         assert b == ""
 
     # --- no request in hand (eager start: autostart / workspace create) ---
-    # These exercise the path eager_start_workspace takes: no connection
+    # These exercise the path start_workspace takes: no connection
     # exists at boot, so derive_hosting_info is called with no headers and
     # must still return a port-correct floor (the bug was that the eager
     # path used to bypass this entirely and inject bare "localhost").

--- a/src/cli/e2e-tests/test_cli_e2e.py
+++ b/src/cli/e2e-tests/test_cli_e2e.py
@@ -909,9 +909,9 @@ class TestSandboxAutoStartServiceCommand:
 
             # (3) The service command ran at/after setup completed.
             # setup-done is written last in setup.sh; service-cmd-when is
-            # written by myapp when the service command runs.  Under the
-            # run_service_command=True regression myapp wouldn't exist at
-            # eager-start, so service-cmd-when would never be written.
+            # written by myapp when the service command runs.  The service
+            # command only fires once setup is complete (it is gated on
+            # setup_state), so service-cmd-when is written after setup-done.
             ordering = _run(
                 [
                     "klangkc",


### PR DESCRIPTION
## Summary

Fixes #1244 — and the broader bug it exposed.

`klangkc restart` stopped+removed the container but never brought it back: for a service workspace the gateway vanished and only returned if a user later attached a terminal. The endpoint's own docstring admitted the lazy behavior ("the next WebSocket connect will start a fresh one").

The root cause was broader than #1244: the service command fired on only **two of five** start paths (boot autostart + a lazy WS-connect `terminal_start`), so create / restart / connect paths were all subtly broken for service workspaces that no one terminal-attached to.

## The fix: one choke point

Centralized bring-up inside `start_container`: it now calls `bringup.bringup(...)` right before returning `status == "created"`. **Every** start path (boot autostart, create, connect, `klangkc restart`) routes through it, so any container with a service command fires it exactly once per fresh container.

- `ensure_service_session` is already idempotent (per-container lock + window-exists check), so this is safe to call everywhere.
- `setup_state` gates the create-time deferral for workspaces whose `setup.sh` hasn't run yet — the CLI sandbox driver marks those `"pending"` and the fire lands later once setup completes.

New file **`bringup.py`** holds the orchestrator. `container.py` can't import `agent` directly (`agent` already imports `container` for `registry.get_state`), so the bring-up step lives in its own module to keep that boundary clean — no lazy imports.

`start_container` gains a `service_command` param, threaded through by all callers.

## Simplifications the choke point enables

- **`eager_start_workspace` → `start_workspace`**: collapsed from ~50 lines to ~20. Dropped the `run_service_command` param, the `idle_timeout = 0` line, and the agent-home / service-command blocks (all moved to `bringup` / the boot path). Renamed because "eager" now distinguishes nothing — every start is eager; the only difference is the *call site* (boot vs. user command).
- **`idle_timeout = 0`** moved into `auto_start_workspaces` (boot path only). Create/restart use the default idle timeout — a freshly-created or just-restarted workspace shouldn't be pinned alive forever.
- **`create_workspace`** drops `run_service_command=False`; the choke point gates purely on `setup_state` now.
- **`restart_workspace`** (#1244): after stop+remove+reset, calls `start_workspace` → container comes back, service command re-fires, workspace recovers to healthy.

## What stays

`_fire_service_command` (WS connect path, `controllers.py`) is still load-bearing for the `pending → complete` transition: a workspace created with `setup.sh` pending runs setup, then the first `terminal_start` fires. It becomes a no-op in the common case (window already exists from create).

## Docs

`service-command.md` and `auto-start.md` corrected:
- The command fires on **every fresh container create** (not "on first connect" / "into tmux window 0").
- `auto-start` is now strictly "start at server boot" — every container starts at create + restart regardless.

## Tests

- **Autouse `_stub_bringup` fixture** in `test_container.py` blocks container-mechanics tests from spawning real `podman exec` subprocesses via `bringup` (verified by probe — without the stub, `agent.ensure_agent_home` reaches a real `asyncio.create_subprocess_exec`).
- New **`test_bringup.py`** covers the orchestrator (5 tests, 100% of `bringup.py`).
- `TestEagerStartWorkspace` → `TestStartWorkspace`, rewritten for the thin-wrapper reality.

## Validation

- ✅ `test-backend`: **2139 passed, 100% coverage**
- ✅ `test-backend-e2e`: **48 passed / 26 failed — identical to clean `main`** (the 26 are pre-existing isolation/ordering flakes, zero regressions; `test_containers_stopped_then_autostarted` and `test_service_window_shared_not_own` pass in isolation)
- ✅ ruff, markdownlint, prettier, trufflehog all clean

Closes #1244.
