### PR TITLE
test(model): close pooled connections in migration tests

### DIFF
--- a/src/backend/tests/test_model.py
+++ b/src/backend/tests/test_model.py
@@ -98,16 +98,16 @@ class TestMigration:
         await model.init_db()
 
         # Verify column was added and old data survived
-        db = await model.get_db()
-        cursor = await db.execute("PRAGMA table_info(workspaces)")
-        cols = {row[1] for row in await cursor.fetchall()}
-        assert "auto_start" in cols
+        async with model.transaction() as db:
+            cursor = await db.execute("PRAGMA table_info(workspaces)")
+            cols = {row[1] for row in await cursor.fetchall()}
+            assert "auto_start" in cols
 
-        cursor = await db.execute(
-            "SELECT auto_start FROM workspaces WHERE id = 'ws1'"
-        )
-        row = await cursor.fetchone()
-        assert row[0] == 0  # default value
+            cursor = await db.execute(
+                "SELECT auto_start FROM workspaces WHERE id = 'ws1'"
+            )
+            row = await cursor.fetchone()
+            assert row[0] == 0  # default value
 
     async def test_migrate_workspaces_renames_default_command(
         self, temp_data_dir
@@ -163,17 +163,17 @@ class TestMigration:
         await model.init_db()
 
         # Column was renamed (old gone, new present) and data survived.
-        db = await model.get_db()
-        cursor = await db.execute("PRAGMA table_info(workspaces)")
-        cols = {row[1] for row in await cursor.fetchall()}
-        assert "service_command" in cols
-        assert "default_command" not in cols
+        async with model.transaction() as db:
+            cursor = await db.execute("PRAGMA table_info(workspaces)")
+            cols = {row[1] for row in await cursor.fetchall()}
+            assert "service_command" in cols
+            assert "default_command" not in cols
 
-        cursor = await db.execute(
-            "SELECT service_command FROM workspaces WHERE id = 'ws1'"
-        )
-        row = await cursor.fetchone()
-        assert row[0] == "echo hello"
+            cursor = await db.execute(
+                "SELECT service_command FROM workspaces WHERE id = 'ws1'"
+            )
+            row = await cursor.fetchone()
+            assert row[0] == "echo hello"
 
 
 class TestUsers:


### PR DESCRIPTION
Closes #1248.

## Root cause

The issue body guessed the leak was `TestHandles::test_set_user_handle_conflict`, but that was a mis-attribution: pytest pins `<sys>:0:` GC warnings to whatever test is *current* when the collector runs, not to the test that leaked. Running `TestHandles` alone produces **zero** warnings — that test's `transaction()` context manager closes its connection correctly on the conflict path.

Instrumenting the connection checkout (recording a traceback on every `get_db()` and reporting any still-checked-out connections at process exit) traced the real source to the two workspace-migration tests, which read back the migrated schema through `model.get_db()` and then **dropped the connection without closing it**:

- `test_migrate_workspaces_adds_auto_start`
- `test_migrate_workspaces_renames_default_command`

Each left one connection checked out. The next test's `temp_data_dir` fixture then set `engine = None` (orphaning the engine without disposing it), and GC eventually collected the leaked `AdaptedConnection`s, emitting the two `SAWarning: ... non-checked-in connection` messages.

## Fix

Wrap each verification block in `async with model.transaction() as db:` — the same context manager `fetchone()` and the rest of the model layer already use for reads. It auto-closes the connection on every exit path (success or exception).

```diff
-        db = await model.get_db()
-        cursor = await db.execute("PRAGMA table_info(workspaces)")
-        ...
+        async with model.transaction() as db:
+            cursor = await db.execute("PRAGMA table_info(workspaces)")
+            ...
```

## Verification

- `tests/test_model.py`: 147 passed, **0** `non-checked-in connection` warnings (was 2).
- Full backend suite: **2145 passed**, no `SAWarning` in the warnings summary (only pre-existing unrelated `RuntimeWarning`/`ResourceWarning`/`DeprecationWarning` noise).
- Connection-checkout trace confirms **0 leaked connections at exit**.

## Why it looked conflict-test-specific

The leak only surfaces when running the migration tests *and* at least one later test (so `temp_data_dir` orphans the leaked engine and GC collects it). In the default suite ordering that GC happened to land during `test_set_user_handle_conflict`'s window, so that's where pytest reported it — hence the misleading issue title.