### PR TITLE
fix(db): close aiosqlite connections orphaned by task cancellation

### DIFF
--- a/src/backend/klangk_backend/model/db.py
+++ b/src/backend/klangk_backend/model/db.py
@@ -6,6 +6,7 @@ and :func:`fetchone` defined here.  The engine state (``engine``,
 single, obvious location.
 """
 
+import asyncio
 import logging
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -149,9 +150,28 @@ async def get_db() -> Connection:
     """Acquire a raw database connection from the pool.
 
     Caller is responsible for commit/rollback/close.
+
+    The ``engine.connect()`` await is shielded so that a cancellation
+    delivered mid-acquisition cannot orphan the underlying connection:
+    aiosqlite opens its worker thread (and the real ``sqlite3.Connection``)
+    before the await returns, so interrupting it leaves those resources
+    with no handle to close them -- they then outlive the event loop and
+    surface as ``RuntimeError: Event loop is closed`` / ``ResourceWarning:
+    unclosed database`` (#1250). If we are cancelled, we drain the
+    shielded connect and close whatever it produced before propagating.
     """
     engine = ensure_engine()
-    return Connection(await engine.connect())
+    task = asyncio.ensure_future(engine.connect())
+    try:
+        conn = await asyncio.shield(task)
+    except asyncio.CancelledError:
+        try:
+            conn = await task
+            await conn.close()
+        except Exception:  # pragma: no cover - defensive; close best-effort
+            pass
+        raise
+    return Connection(conn)
 
 
 @asynccontextmanager

--- a/src/backend/klangk_backend/wshandler/controllers.py
+++ b/src/backend/klangk_backend/wshandler/controllers.py
@@ -348,6 +348,7 @@ class TerminalController:
         self._conn = conn
         self.session: TerminalSession | None = None
         self.task: asyncio.Task | None = None
+        self.output_task: asyncio.Task | None = None
         self.cols: int = 80
         self.rows: int = 24
 
@@ -891,7 +892,14 @@ class TerminalController:
         if self.session is not session:
             await session.stop()
             return False
-        self.task = asyncio.create_task(self.forward_output(session))
+        # Track the output-forwarding task separately from the start task
+        # (``self.task``). ``activate_session`` runs *from inside* the
+        # ``_start_terminal`` task; overwriting ``self.task`` here would
+        # orphan that task -- and if it is then cancelled/torn down while
+        # a DB op (e.g. ``_sync_service_windows``) is in flight, the
+        # orphaned transaction's connection leaks past event-loop
+        # teardown (#1250).
+        self.output_task = asyncio.create_task(self.forward_output(session))
         # Resize to force tmux to redraw at the client's terminal size.
         # Without this, reattaching shows a blank screen because tmux
         # skips the redraw when the PTY size matches the default.
@@ -903,14 +911,20 @@ class TerminalController:
 
         was_viewing = self._conn.viewing_shared
         self._conn.viewing_shared = None
-        task = self.task
-        if task:
-            task.cancel()
-            try:
-                await task
-            except asyncio.CancelledError:
-                pass
-            self.task = None
+        # Cancel both the start task and the output-forwarding task.
+        # They are tracked separately (see ``activate_session``) so that
+        # tearing the terminal down cancels the start task even after
+        # output forwarding took over ``self.output_task`` -- otherwise
+        # the start task could be orphaned mid-transaction (#1250).
+        for attr in ("task", "output_task"):
+            task = getattr(self, attr)
+            if task:
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+                setattr(self, attr, None)
         await self.claim_and_stop()
         # Broadcast viewer change so other users see updated viewer list
         if was_viewing and self._conn.workspace_id:

--- a/src/backend/tests/test_model.py
+++ b/src/backend/tests/test_model.py
@@ -1,5 +1,7 @@
 """Tests for model: users, workspaces, messages, port allocations."""
 
+import asyncio
+
 import aiosqlite
 import pytest
 import sqlalchemy.exc
@@ -1536,3 +1538,77 @@ class TestUniqueHandleFallback:
         # Should contain a hex suffix, not a numeric one
         parts = result.rsplit("-", 1)
         assert len(parts[1]) == 8  # sha256[:8]
+
+
+class TestTransactionCancelNoLeak:
+    """Regression: cancelling a task mid ``transaction()`` must not leak
+    the underlying aiosqlite connection (#1250).
+
+    ``engine.connect()`` opens the aiosqlite worker thread (and the real
+    sqlite3 connection) before its await returns. Before the fix, a
+    cancellation delivered during that window left the connection with no
+    handle to close it: its worker thread outlived the event loop
+    (``RuntimeError: Event loop is closed``) and the sqlite3 connection
+    leaked (``ResourceWarning: unclosed database``).
+    """
+
+    @staticmethod
+    def _track_aiosqlite(monkeypatch):
+        open_ids = set()
+        orig_init = aiosqlite.Connection.__init__
+        orig_close = aiosqlite.Connection.close
+
+        def init(self, *a, **kw):
+            orig_init(self, *a, **kw)
+            open_ids.add(id(self))
+
+        def close(self, *a, **kw):
+            open_ids.discard(id(self))
+            return orig_close(self, *a, **kw)
+
+        monkeypatch.setattr(aiosqlite.Connection, "__init__", init)
+        monkeypatch.setattr(aiosqlite.Connection, "close", close)
+        return open_ids
+
+    async def test_cancel_during_acquire_closes_connection(
+        self, temp_data_dir, monkeypatch
+    ):
+        await model.init_db()
+        open_ids = self._track_aiosqlite(monkeypatch)
+
+        async def bg():
+            # fetchone -> transaction -> get_db -> engine.connect().
+            await model.db.fetchone("SELECT 1")
+            await asyncio.sleep(30)  # keep the task alive to cancel
+
+        task = asyncio.create_task(bg())
+        # Let the task enter the DB op (open the connection) before cancel.
+        for _ in range(3):
+            await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        # Every aiosqlite connection that was opened must have been closed,
+        # even though the task was cancelled mid-acquisition.
+        import gc
+
+        gc.collect()
+        assert not open_ids, (
+            f"{len(open_ids)} aiosqlite connection(s) leaked after cancel"
+        )
+
+    async def test_normal_transaction_closes_connection(
+        self, temp_data_dir, monkeypatch
+    ):
+        """Sanity: a transaction that runs to completion closes its conn."""
+        await model.init_db()
+        open_ids = self._track_aiosqlite(monkeypatch)
+
+        async with model.db.transaction() as db:
+            await db.execute("CREATE TABLE IF NOT EXISTS t (x)")
+
+        import gc
+
+        gc.collect()
+        assert not open_ids

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -5852,12 +5852,12 @@ class TestTerminalController:
         with patch.object(container.registry, "record_activity") as rec:
             result = await ctrl.activate_session(session, 80, 24)
         assert result is True
-        assert ctrl.task is not None
+        assert ctrl.output_task is not None
         session.resize.assert_awaited_once_with(80, 24)
         rec.assert_called_once_with("cid")
-        ctrl.task.cancel()
+        ctrl.output_task.cancel()
         try:
-            await ctrl.task
+            await ctrl.output_task
         except asyncio.CancelledError:
             pass
 


### PR DESCRIPTION
Closes #1250.

## Summary

Both warnings in `tests/test_wshandler.py` — the aiosqlite worker thread raising `RuntimeError: Event loop is closed` (in `test_rapid_terminal_start_debounced`) and the `ResourceWarning: unclosed database` (in `test_set_handle_conflict`) — share one root cause: **a DB connection opened by `engine.connect()` is orphaned with no handle to close it, so it outlives the per-test event loop.** The leak fires when a background task holding a transaction is torn down mid-flight.

I traced it with an aiosqlite open/close probe. Two independent gaps caused the orphan; both are fixed here, and **either fix alone is insufficient** (verified).

### Fix 1 — `model/db.py`: shield `get_db()`'s `engine.connect()`
`get_db()` awaited `engine.connect()` unshielded. aiosqlite opens its worker thread (and the real `sqlite3.Connection`) *before* the await returns, so a cancellation delivered during acquisition leaves those resources with no reference — `db` is never bound, so `transaction()`'s `finally` never closes the connection. The fix shields the connect; on cancellation it drains the shielded task and closes whatever it produced before re-raising.

### Fix 2 — `wshandler/controllers.py`: stop orphaning the `_start_terminal` task
`TerminalController.activate_session()` runs *from inside* the `_start_terminal` task and **overwrote `self.task`** with the `forward_output` task. That orphaned the `_start_terminal` task — cancelling `conn.terminal_task` cancelled the wrong (output) task, and the start task was abandoned mid-transaction (e.g. inside `_sync_service_windows` → `model.agent_handle()`) when the loop closed. The output task is now tracked in a separate `output_task` attribute, and `stop()` cancels both.

### Why both are needed (empirically verified)
- get_db fix **alone** → `test_starts_session_restores_saved_state` still leaks 1/1/1 (the start task is never cancelled — just abandoned — so the shield's cancel-branch never runs).
- controllers fix **alone** → still leaks (cancellation lands mid-acquisition, orphaning the connection before `transaction()`'s finally can close it).
- **both** → 0 leaks, 5/5 runs, for all three tests.

## Root-cause evidence
The creation stack of the leaked connection (captured via a temporary probe):
```
_start_terminal → _restore_and_sync_windows → _sync_service_windows
  → model.agent_handle() → get_agent_user → get_user_by_id → fetchone
  → transaction → get_db → ensure_engine  ← opens the aiosqlite conn
```
And the minimal cancellation repro (`get_db` + a cancelled task) reproduced the leak deterministically before the fix and is clean after.

## Tests
- New `TestTransactionCancelNoLeak` in `test_model.py`: cancels a task mid-`transaction()` and asserts no aiosqlite connection leaks. **Verified to fail on the unpatched `get_db`** (`AssertionError: 1 aiosqlite connection(s) leaked after cancel`) and pass with the fix.
- Updated `test_activate_session_wires_forward_task` for the new `output_task` attribute.
- Full backend unit suite: **2147 passed, 0 failures** (the `cov-fail-under=100` gate shows the pre-existing 93% `tests/`-only baseline that e2e closes out in CI; changed modules add no new uncovered lines).

## Out of scope
A separate, pre-existing, **order-dependent** 2-connection leak surfaces for other tests during a full-suite run (different pattern — 2 conns, not 1; clean in isolation). It is not what #1250 reports and is left for a follow-up (likely #1247, which this was split out of).