### PR TITLE
fix(ws): raise WebSocket max message size to 16 MB in production

### DIFF
--- a/src/backend/klangk_backend/wshandler/constants.py
+++ b/src/backend/klangk_backend/wshandler/constants.py
@@ -17,7 +17,9 @@ logger = logging.getLogger(__name__)
 WS_DEBUG = bool(resolve_env_value("KLANGKWS_DEBUG"))
 
 # Max size for terminal/exec input data (base64-decoded bytes).
-MAX_INPUT_SIZE = 65536
+# Matches uvicorn's --ws-max-size (16 MB) so the app-level cap isn't
+# stricter than the transport cap — see #1257.
+MAX_INPUT_SIZE = 16777216
 
 # Max outbound messages before we declare the client too slow and close.
 SEND_QUEUE_SIZE = 256

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -731,7 +731,7 @@ class TestHandleTerminalInput:
         conn.container_id = "cid"
         container.registry.track_activity("cid", "ws")
 
-        big_data = "x" * 70000
+        big_data = "x" * (_ws_constants.MAX_INPUT_SIZE + 1)
         await conn.handle_terminal_input({"data": big_data})
         t.write.assert_not_awaited()
         container.registry.states.pop("ws", None)
@@ -2588,7 +2588,9 @@ class TestExecHandlers:
         conn = _base_conn()
         conn.container_id = "cid"
         conn.exec_session = session
-        big_data = base64.b64encode(b"x" * 70000).decode()
+        big_data = base64.b64encode(
+            b"x" * (_ws_constants.MAX_INPUT_SIZE + 1)
+        ).decode()
         await conn.handle_exec_input({"data": big_data})
         session.write.assert_not_awaited()
 
@@ -2853,7 +2855,9 @@ class TestExecController:
         session = AsyncMock()
         session.is_alive = True
         ctrl.session = session
-        big = base64.b64encode(b"x" * 70000).decode()
+        big = base64.b64encode(
+            b"x" * (_ws_constants.MAX_INPUT_SIZE + 1)
+        ).decode()
         with patch.object(container.registry, "record_activity"):
             await ctrl.input({"data": big})
         session.write.assert_not_awaited()
@@ -5749,7 +5753,7 @@ class TestTerminalController:
         session.is_alive = True
         session.read_only = False
         ctrl.session = session
-        await ctrl.input({"data": "x" * 70000})
+        await ctrl.input({"data": "x" * (_ws_constants.MAX_INPUT_SIZE + 1)})
         session.write.assert_not_awaited()
 
     async def test_input_writes_and_records_activity(self):

--- a/src/containers/host/supervisord.conf
+++ b/src/containers/host/supervisord.conf
@@ -9,7 +9,7 @@ pidfile=/tmp/supervisord.pid
 command=python3 -m uvicorn klangk_backend.main:app
     --host 0.0.0.0
     --port %(ENV_KLANGK_PORT)s
-    --ws-max-size 65536
+    --ws-max-size 16777216
     --ws-ping-interval 20
     --ws-ping-timeout 20
 stdout_logfile=/dev/fd/1


### PR DESCRIPTION
Closes #1257.

The host container's `supervisord.conf` hardcoded `--ws-max-size 65536` (64 KB) for the uvicorn WebSocket bridge, while the dev path uses uvicorn's 16 MB default (256× larger). In production this silently dropped file uploads and large terminal bursts that work fine in dev — a dev/prod mismatch that only surfaces after deployment.

## Changes

Raised both WebSocket message-size caps to `16777216` (16 MB) so the transport cap and the app-level cap agree:

| File | Before | After |
|---|---|---|
| `src/containers/host/supervisord.conf` (`--ws-max-size`) | 65536 | 16777216 |
| `wshandler/constants.py` (`MAX_INPUT_SIZE`) | 65536 | 16777216 |

`MAX_INPUT_SIZE` is the app-level cap enforced in `controllers.py` on terminal/exec input (`if len(raw) > MAX_INPUT_SIZE: drop`). It's raised in lockstep so it isn't stricter than the transport cap — otherwise a 16 MB frame could pass uvicorn only to be dropped by the app.

## Test updates

The four `test_*_oversized_*_dropped` tests hard-coded a 70000-byte payload (just over the old 65536 cap). With the cap at 16 MB they no longer tripped the drop. Sized each to `MAX_INPUT_SIZE + 1` so they stay correct as the cap changes.

## Verification

Backend suite: **2151 passed**.