### PR TITLE
fix(container): serialize state teardown under the workspace lock

### DIFF
--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -859,13 +859,21 @@ class ContainerRegistry:
         if self.on_container_status_changed:
             self.on_container_status_changed(workspace_id, running)
 
-    def remove_state(self, workspace_id: str) -> None:
-        state = self.states.pop(workspace_id, None)
-        if state:
-            self._cid_to_wsid.pop(state.container_id, None)
-            # Drop the per-container service-firing lock (#1188).
-            terminal.clear_service_session_lock(state.container_id)
-        self._workspace_locks.pop(workspace_id, None)
+    async def remove_state(self, workspace_id: str) -> None:
+        """Remove tracked state for a workspace.
+
+        Serialized under the per-workspace lock (the same one
+        :meth:`start_container` holds) so a racing start cannot observe a
+        half-cleaned registry (#1258). The per-workspace lock entry is
+        deliberately *not* removed here -- see :meth:`stop_and_remove_container`
+        for why popping it would reopen the race.
+        """
+        async with self._get_workspace_lock(workspace_id):
+            state = self.states.pop(workspace_id, None)
+            if state:
+                self._cid_to_wsid.pop(state.container_id, None)
+                # Drop the per-container service-firing lock (#1188).
+                terminal.clear_service_session_lock(state.container_id)
 
     # --- Proxy: PortAllocator ---
 
@@ -1492,7 +1500,26 @@ class ContainerRegistry:
         return container_id, "created"
 
     async def stop_and_remove_container(self, container_id: str) -> None:
-        """Stop and remove a container."""
+        """Stop and remove a container.
+
+        The slow ``podman.remove_container`` call runs *outside* the
+        workspace lock; only the registry-state teardown is serialized --
+        under the same per-workspace lock :meth:`start_container` uses -- so
+        a concurrent start for the same workspace cannot observe a
+        half-cleaned registry (#1258). Under the lock we re-check that
+        ``container_id`` still maps to this workspace: a racing
+        ``start_container`` may already have re-bound the workspace to a
+        fresh container, in which case we must not tear down the new state
+        (or revoke its browsers).
+
+        The per-workspace lock entry is deliberately *not* popped. Popping
+        it while another coroutine is waiting on (or holding) that exact
+        ``asyncio.Lock`` would let a subsequent ``_get_workspace_lock``
+        create a brand-new lock object that does not serialize against the
+        in-flight one -- reopening the very race this method exists to
+        prevent. The retained entry is a single small object per workspace
+        ever seen and is cleared on process restart.
+        """
         try:
             await podman.remove_container(container_id)
             logger.info("Stopped container %s", container_id)
@@ -1502,11 +1529,16 @@ class ContainerRegistry:
                 container_id,
                 e,
             )
-        ws_id = self._cid_to_wsid.pop(container_id, None)
+        ws_id = self._cid_to_wsid.get(container_id)
         if ws_id:
-            self.revoke_workspace_browsers(ws_id)
-            self.states.pop(ws_id, None)
-            self._workspace_locks.pop(ws_id, None)
+            async with self._get_workspace_lock(ws_id):
+                # Re-verify under the lock: a racing start_container may
+                # have re-bound this workspace to a new container while we
+                # waited for the lock. Only tear down state we still own.
+                if self._cid_to_wsid.get(container_id) == ws_id:
+                    self._cid_to_wsid.pop(container_id, None)
+                    self.revoke_workspace_browsers(ws_id)
+                    self.states.pop(ws_id, None)
         # Drop the per-container service-firing lock (#1188).
         terminal.clear_service_session_lock(container_id)
 

--- a/src/backend/klangk_backend/wshandler/session.py
+++ b/src/backend/klangk_backend/wshandler/session.py
@@ -336,7 +336,7 @@ class WorkspaceSession:
         manual stop) so the next workspace_connect starts fresh.
         """
         await state.remove_session(self.workspace_id)
-        container.registry.remove_state(self.workspace_id)
+        await container.registry.remove_state(self.workspace_id)
         logger.info("Reset workspace state for %s", self.workspace_id)
 
 
@@ -528,7 +528,7 @@ class WebSocketState:
         if session:
             await session.full_reset()
         else:
-            container.registry.remove_state(workspace_id)
+            await container.registry.remove_state(workspace_id)
             logger.info("Reset workspace state for %s", workspace_id)
 
         # Clean up module-level agent state for this workspace.

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -1069,7 +1069,7 @@ class TestWorkspaceRoutes:
             ws = next(w for w in items if w["id"] == ws_id)
             assert ws["running"] is True
         finally:
-            container.registry.remove_state(ws_id)
+            await container.registry.remove_state(ws_id)
 
         # Also works for bare list (no pagination params)
         resp = await client.get("/api/v1/workspaces", headers=headers)
@@ -1121,7 +1121,7 @@ class TestWorkspaceRoutes:
             assert ws["health"] == "healthy"
             assert ws["health_message"] is None
         finally:
-            container.registry.remove_state(ws_id)
+            await container.registry.remove_state(ws_id)
 
         # Stopped workspace: no health fields beyond running=False.
         resp = await client.get("/api/v1/workspaces?limit=10", headers=headers)
@@ -1684,7 +1684,7 @@ class TestWorkspaceRoutes:
             assert live.health_checked_at is None
             assert live.health_message is None
         finally:
-            container.registry.remove_state(ws_id)
+            await container.registry.remove_state(ws_id)
 
     async def test_update_workspace_no_permission(self, client, user):
         headers = await _auth_headers(client)

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -170,18 +170,23 @@ class TestActivityTracking:
         finally:
             container.registry.on_container_status_changed = None
 
-    def test_remove_state_cleans_up_reverse_mapping(self):
+    async def test_remove_state_cleans_up_reverse_mapping(self):
         container.registry.track_activity("cid-rm", "ws-rm")
         assert "cid-rm" in container.registry._cid_to_wsid
-        container.registry.remove_state("ws-rm")
+        await container.registry.remove_state("ws-rm")
         assert "ws-rm" not in container.registry.states
         assert "cid-rm" not in container.registry._cid_to_wsid
 
-    def test_remove_state_cleans_up_workspace_lock(self):
-        container.registry._get_workspace_lock("ws-lock-rm")
+    async def test_remove_state_retains_workspace_lock(self):
+        # remove_state must NOT pop _workspace_locks[ws] (#1258): doing so
+        # would let a subsequent _get_workspace_lock hand out a fresh,
+        # non-mutually-exclusive lock object while a coroutine may still be
+        # waiting on the original. The lock entry is cheap to retain.
+        lock = container.registry._get_workspace_lock("ws-lock-rm")
         assert "ws-lock-rm" in container.registry._workspace_locks
-        container.registry.remove_state("ws-lock-rm")
-        assert "ws-lock-rm" not in container.registry._workspace_locks
+        await container.registry.remove_state("ws-lock-rm")
+        assert "ws-lock-rm" in container.registry._workspace_locks
+        assert container.registry._workspace_locks["ws-lock-rm"] is lock
 
     def test_get_state_returns_state(self):
         container.registry.track_activity("cid-1", "ws-1")
@@ -1617,23 +1622,30 @@ class TestExtraMountsVolumeCreation:
 class TestStopContainer:
     def setup_method(self):
         container.registry.states.clear()
+        container.registry._cid_to_wsid.clear()
+        container.registry._workspace_locks.clear()
 
     def teardown_method(self):
         container.registry.states.clear()
+        container.registry._cid_to_wsid.clear()
+        container.registry._workspace_locks.clear()
 
     async def test_stop_running(self):
         container.registry.track_activity("cid", "ws")
-        container.registry._workspace_locks["ws"] = asyncio.Lock()
+        lock = container.registry._get_workspace_lock("ws")
 
         with patch_podman() as p:
             await container.registry.stop_and_remove_container("cid")
         p.remove_container.assert_awaited_once_with("cid")
         assert "ws" not in container.registry.states
-        assert "ws" not in container.registry._workspace_locks
+        assert "cid" not in container.registry._cid_to_wsid
+        # The workspace lock entry is deliberately retained (#1258).
+        assert "ws" in container.registry._workspace_locks
+        assert container.registry._workspace_locks["ws"] is lock
 
     async def test_stop_podman_error(self):
         container.registry.track_activity("cid", "ws")
-        container.registry._workspace_locks["ws"] = asyncio.Lock()
+        container.registry._get_workspace_lock("ws")
 
         with patch_podman(
             remove_container=AsyncMock(
@@ -1643,29 +1655,119 @@ class TestStopContainer:
             await container.registry.stop_and_remove_container("cid")
         # Should still remove from tracking
         assert "ws" not in container.registry.states
-        assert "ws" not in container.registry._workspace_locks
+        assert "cid" not in container.registry._cid_to_wsid
+        # The workspace lock entry is deliberately retained (#1258).
+        assert "ws" in container.registry._workspace_locks
+
+    async def test_stop_serializes_under_workspace_lock(self):
+        # stop_and_remove_container must acquire the workspace lock before
+        # mutating state, so it cannot tear down a registry entry while a
+        # start_container holds the lock (#1258).
+        container.registry.track_activity("cid", "ws")
+        lock = container.registry._get_workspace_lock("ws")
+
+        with patch_podman():
+            async with lock:
+                # While the lock is held (as start_container would hold
+                # it), stop must not be able to remove state.
+                task = asyncio.create_task(
+                    container.registry.stop_and_remove_container("cid")
+                )
+                # Yield repeatedly so the stop task has a chance to run;
+                # it should be blocked on the lock.
+                for _ in range(5):
+                    await asyncio.sleep(0)
+                assert not task.done()
+                assert "ws" in container.registry.states
+                assert container.registry._cid_to_wsid.get("cid") == "ws"
+            # Releasing the lock lets stop proceed and clean up.
+            await task
+        assert "ws" not in container.registry.states
+        assert "cid" not in container.registry._cid_to_wsid
+
+    async def test_stop_skips_teardown_when_container_rebound(
+        self, monkeypatch
+    ):
+        # A racing start_container may re-bind the workspace to a new
+        # container while stop waits for the lock. When stop finally
+        # acquires the lock, container_id no longer maps to this ws, so it
+        # must NOT tear down the fresh state or revoke its browsers.
+        container.registry.track_activity("cid-old", "ws")
+        lock = container.registry._get_workspace_lock("ws")
+        revoked = []
+        monkeypatch.setattr(
+            container.registry,
+            "revoke_workspace_browsers",
+            lambda wid: revoked.append(wid),
+        )
+
+        with patch_podman():
+            async with lock:
+                # Start stop; it runs podman (instant), peeks cid-old->ws,
+                # then blocks on the lock we hold.
+                task = asyncio.create_task(
+                    container.registry.stop_and_remove_container("cid-old")
+                )
+                for _ in range(5):
+                    await asyncio.sleep(0)
+                # While stop is blocked, a racing start re-binds the
+                # workspace to a new container (track_activity drops the
+                # old cid reverse-mapping).
+                container.registry.track_activity("cid-new", "ws")
+            # Releasing the lock lets stop acquire it; under the lock the
+            # re-check sees cid-old no longer maps to ws, so it bails.
+            await task
+        # The new container's state survives untouched.
+        assert "ws" in container.registry.states
+        assert container.registry.states["ws"].container_id == "cid-new"
+        assert container.registry._cid_to_wsid.get("cid-new") == "ws"
+        assert "cid-old" not in container.registry._cid_to_wsid
+        # Browsers for the still-alive workspace were not revoked. (Without
+        # the under-lock re-check, stop would have already torn the old
+        # state down and revoked browsers before the rebind.)
+        assert revoked == []
+
+    async def test_stop_does_not_replace_workspace_lock(self):
+        # Regression for the lock-replacement race: even after stop tears
+        # down state, _get_workspace_lock must return the SAME lock object,
+        # so a subsequent start serializes against any in-flight acquirer.
+        container.registry.track_activity("cid", "ws")
+        lock_before = container.registry._get_workspace_lock("ws")
+
+        with patch_podman():
+            await container.registry.stop_and_remove_container("cid")
+        assert "ws" in container.registry._workspace_locks
+        lock_after = container.registry._get_workspace_lock("ws")
+        assert lock_after is lock_before
 
 
 class TestRemoveContainer:
     def setup_method(self):
         container.registry.states.clear()
+        container.registry._cid_to_wsid.clear()
+        container.registry._workspace_locks.clear()
 
     def teardown_method(self):
         container.registry.states.clear()
+        container.registry._cid_to_wsid.clear()
+        container.registry._workspace_locks.clear()
 
     async def test_remove(self):
         container.registry.track_activity("cid", "ws")
-        container.registry._workspace_locks["ws"] = asyncio.Lock()
+        lock = container.registry._get_workspace_lock("ws")
 
         with patch_podman() as p:
             await container.registry.stop_and_remove_container("cid")
         p.remove_container.assert_awaited_once_with("cid")
         assert "ws" not in container.registry.states
-        assert "ws" not in container.registry._workspace_locks
+        assert "cid" not in container.registry._cid_to_wsid
+        # The workspace lock entry is deliberately retained (#1258).
+        assert "ws" in container.registry._workspace_locks
+        assert container.registry._workspace_locks["ws"] is lock
 
     async def test_remove_podman_error(self):
         container.registry.track_activity("cid", "ws")
-        container.registry._workspace_locks["ws"] = asyncio.Lock()
+        container.registry._get_workspace_lock("ws")
 
         with patch_podman(
             remove_container=AsyncMock(
@@ -1674,7 +1776,9 @@ class TestRemoveContainer:
         ):
             await container.registry.stop_and_remove_container("cid")
         assert "ws" not in container.registry.states
-        assert "ws" not in container.registry._workspace_locks
+        assert "cid" not in container.registry._cid_to_wsid
+        # The workspace lock entry is deliberately retained (#1258).
+        assert "ws" in container.registry._workspace_locks
 
 
 class TestStopUserContainers:


### PR DESCRIPTION
Closes #1258.

## Summary

`ContainerRegistry.stop_and_remove_container` popped entries from the shared state dicts (`_cid_to_wsid`, `states`, `_workspace_locks`) **without acquiring the per-workspace lock** that `start_container` holds. A concurrent `start_container` for the same workspace could race the cleanup and observe a half-cleaned registry — orphaned containers / corrupted state. (Split from the HIGH-severity audit item #3 in #1197.)

Two changes, both required:

### 1. `stop_and_remove_container` serializes teardown under the workspace lock
- The slow `podman.remove_container` call stays **outside** the lock.
- The registry-state teardown (`_cid_to_wsid` / `states` / browser revocation) runs under `async with self._get_workspace_lock(ws_id)` — the same lock `start_container` uses.
- **Under the lock it re-checks** that `container_id` still maps to this workspace before tearing anything down: a racing `start_container` may have re-bound the workspace to a fresh container while we waited, in which case the new state (and its browsers) must be left intact. (The pre-fix code would wrongly revoke browsers for a still-alive, re-bound workspace.)

### 2. Stop popping `_workspace_locks[ws_id]` (the lock-replacement race)
Neither `stop_and_remove_container` nor `remove_state` pops the per-workspace lock entry anymore. Popping the lock object while another coroutine is waiting on it lets a subsequent `_get_workspace_lock` hand out a **brand-new lock object that does not serialize against the in-flight one** — reopening the very race being fixed. The retained entry is one small object per workspace ever seen and clears on process restart. (This is the option the issue's "fix direction" suggested: *"consider leaving the lock entry in place and only cleaning the other dicts."*)

`remove_state` (the symmetric teardown path, called from `session.full_reset` / `reset_workspace`) is made `async` so it can take the same lock; its callers are updated to `await` it. Both teardown paths now serialize identically against `start_container`, matching the issue's "Expected": *"All mutations to states, _cid_to_wsid, and _workspace_locks are serialized under the workspace lock."*

### Deadlock analysis
The workspace lock is acquired only in `start_container` and now in these two teardown methods. `start_container`'s locked region (`_start_container_inner`) does not call either teardown method, and the kill path calls `stop_and_remove_container` → `notify_workspace_killed` → `remove_state` **sequentially** (lock released between them), so there is no nested acquisition. asyncio locks are non-reentrant, so this was verified explicitly.

## Tests
Four new/updated regression tests in `TestStopContainer` + one in the `remove_state` group, **each verified to fail on the unpatched code and pass with the fix**:
- `test_stop_serializes_under_workspace_lock` — holds the lock as `start_container` would; asserts stop cannot mutate state until the lock is released.
- `test_stop_does_not_replace_workspace_lock` / `test_remove_state_retains_workspace_lock` — the lock object identity is preserved after teardown (the lock-replacement race).
- `test_stop_skips_teardown_when_container_rebound` — a workspace re-bound to a new container while stop waits on the lock keeps its fresh state and does **not** get its browsers revoked (fails `assert ['ws'] == []` on unpatched code).
- Existing stop/remove tests updated: they now assert the lock entry is **retained** rather than removed, and `_cid_to_wsid` is cleaned.

Full backend unit suite: **2154 passed**; `container.py` and `wshandler/session.py` at **100%** coverage (the `cov-fail-under=100` gate's 93% total is the pre-existing `tests/`-only baseline that e2e closes out in CI).