### PR TITLE
fix(workspaces): run import/export tar off the event loop

### DIFF
--- a/src/backend/klangk_backend/api/workspaces.py
+++ b/src/backend/klangk_backend/api/workspaces.py
@@ -472,7 +472,8 @@ async def export_workspace(
     estimated_size = 0
     if home_dir.exists():
         try:
-            result = subprocess.run(
+            result = await asyncio.to_thread(
+                subprocess.run,
                 ["du", "-sb", str(home_dir)],
                 capture_output=True,
                 text=True,
@@ -556,9 +557,12 @@ async def _stream_upload_to_tempfile(file: UploadFile) -> str:
     return tmp.name
 
 
-def _extract_archive_metadata(archive_path: str, name: str | None) -> dict:
+async def _extract_archive_metadata(
+    archive_path: str, name: str | None
+) -> dict:
     """Read workspace.json from the archive and return sanitized metadata."""
-    result = subprocess.run(
+    result = await asyncio.to_thread(
+        subprocess.run,
         ["tar", "xzf", archive_path, "-O", "workspace.json"],
         capture_output=True,
         timeout=30,
@@ -613,7 +617,8 @@ async def _extract_home_directory(
     """Extract the ``home/`` tree from *archive_path* into the workspace home."""
     home_dir = workspaces.home_path(user_id, ws_id)
     home_dir.mkdir(parents=True, exist_ok=True)
-    check = subprocess.run(
+    check = await asyncio.to_thread(
+        subprocess.run,
         ["tar", "tzf", archive_path, "home/"],
         capture_output=True,
         timeout=30,
@@ -657,7 +662,7 @@ async def import_workspace(
     archive_path = await _stream_upload_to_tempfile(file)
     ws = None
     try:
-        meta = _extract_archive_metadata(archive_path, name)
+        meta = await _extract_archive_metadata(archive_path, name)
 
         try:
             ws = await workspaces.create_workspace(

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -5751,6 +5751,93 @@ class TestWorkspaceExportImport:
         assert resp.status_code == 200
         mock_notify.assert_called_once_with(user["id"])
 
+    async def test_import_runs_tar_off_event_loop(
+        self, client, admin_user, user
+    ):
+        """Import runs tar subprocesses off the event loop (regression #1261).
+
+        A blocking ``subprocess.run`` in the async import handler freezes the
+        whole server for up to the subprocess timeout. Every tar invocation
+        on the import path must execute in a worker thread, not on the loop.
+        """
+        import io
+        import json
+        import subprocess
+        import tarfile
+        import threading
+
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            meta = json.dumps({"name": "off-loop"}).encode()
+            info = tarfile.TarInfo(name="workspace.json")
+            info.size = len(meta)
+            tar.addfile(info, io.BytesIO(meta))
+        buf.seek(0)
+
+        loop_thread = threading.get_ident()
+        seen = []
+        real_run = subprocess.run
+
+        def spy(*args, **kwargs):
+            seen.append(threading.get_ident())
+            return real_run(*args, **kwargs)
+
+        headers = await self._user_headers(client)
+        with patch.object(subprocess, "run", spy):
+            resp = await client.post(
+                "/api/v1/workspaces/import",
+                headers=headers,
+                files={
+                    "file": (
+                        "archive.tar.gz",
+                        buf.getvalue(),
+                        "application/gzip",
+                    )
+                },
+            )
+        assert resp.status_code == 200
+        # tar ran at least once (metadata extraction)...
+        assert seen
+        # ...and every run was off the event loop's thread.
+        assert all(t != loop_thread for t in seen)
+
+    async def test_export_runs_size_estimate_off_event_loop(
+        self, client, admin_user, user
+    ):
+        """Export's ``du`` size-estimate runs off the event loop (#1261)."""
+        import subprocess
+        import threading
+
+        headers = await self._user_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            headers=headers,
+            json={"name": "export-offloop"},
+        )
+        assert resp.status_code == 200
+        ws = resp.json()
+
+        home = ws_mod.home_path(user["id"], ws["id"])
+        home.mkdir(parents=True, exist_ok=True)
+        (home / "f.txt").write_text("x")
+
+        loop_thread = threading.get_ident()
+        seen = []
+        real_run = subprocess.run
+
+        def spy(*args, **kwargs):
+            seen.append(threading.get_ident())
+            return real_run(*args, **kwargs)
+
+        admin_headers = await self._admin_headers(client)
+        with patch.object(subprocess, "run", spy):
+            resp = await client.get(
+                f"/api/v1/workspaces/{ws['id']}/export", headers=admin_headers
+            )
+        assert resp.status_code == 200
+        assert seen
+        assert all(t != loop_thread for t in seen)
+
     async def test_import_duplicate_name(self, client, user):
         headers = await self._user_headers(client)
         await client.post(


### PR DESCRIPTION
## Summary

The workspace **import** path ran blocking `subprocess.run` (`tar`/`du`, timeout up to 30 s) directly inside `async def` endpoints, freezing the entire asyncio event loop for **all** users during each import/export — every other request, WebSocket read, and health check stalled for the duration.

Split from the subtle-bugs audit #1197, item **#5 (MEDIUM)**. Closes #1261.

## Changes

Move every blocking `subprocess.run` on the import/export path off the loop with `asyncio.to_thread`. This preserves exact `subprocess.run` semantics (return code, captured output, `TimeoutExpired` propagation), so error handling is unchanged.

`src/backend/klangk_backend/api/workspaces.py`:

- **`_extract_archive_metadata`** — now `async`; the `tar xzf … workspace.json` metadata read (timeout 30 s) runs via `await asyncio.to_thread(subprocess.run, …)`. This was the primary bug: a *sync* helper called directly from `async def import_workspace`.
- **`_extract_home_directory`** — the `tar tzf … home/` existence check (timeout 30 s) runs via `to_thread`. (The actual `tar xzf` extraction here was already wrapped in `to_thread`.)
- **`export_workspace`** — the `du -sb` best-effort size estimate (timeout 10 s) runs via `to_thread`. Same bug class on the export path.
- Updated the single caller in `import_workspace` to `await` the now-async helper.

After this change there are no remaining blocking `subprocess.run` calls reachable from async handlers in this module — every one is awaited via `to_thread` (or uses `asyncio.create_subprocess_exec` for the streaming export).

## Tests

Added two regression tests in `TestWorkspaceExportImport` that assert the actual contract of this bug — that the subprocesses run in a **worker thread, not on the event loop thread** (the existing tests only covered functional correctness):

- `test_import_runs_tar_off_event_loop` — spies on `subprocess.run`, performs an import, asserts every invocation ran off the loop thread.
- `test_export_runs_size_estimate_off_event_loop` — same, for the export `du` estimate.

Both tests **fail against the pre-fix code** and pass with the fix (verified by temporarily reverting the source change). Full `test_api.py` + `test_workspaces.py`: **469 passed**.

## Notes

- Chose `asyncio.to_thread` over `create_subprocess_exec` (the issue suggested either) because it is the smallest, lowest-risk change: it keeps the existing `CompletedProcess`/`TimeoutExpired` handling and call sites intact while moving only the blocking work off the loop.
- `import_workspace` already caught `subprocess.TimeoutExpired`; `to_thread` propagates it unchanged, so that handler still works.
