### PR TITLE
fix(workspaces): run ensure_home_symlink FS I/O off the event loop (#1262)

### DIFF
--- a/src/backend/klangk_backend/agent.py
+++ b/src/backend/klangk_backend/agent.py
@@ -90,7 +90,7 @@ async def ensure_agent_home(workspace_id: str, container_id: str) -> str:
     workspace_home = workspaces.home_path(owner_id, workspace_id)
 
     agent_handle = await model.agent_handle()
-    container_home, created = workspaces.ensure_home_symlink(
+    container_home, created = await workspaces.ensure_home_symlink(
         workspace_home, agent_handle, model.AGENT_USER_ID
     )
     if created:

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -590,7 +590,7 @@ class HealthMonitor:
         from . import workspaces as _wm  # noqa: allow-deferred-import
 
         ws_home = _wm.home_path(owner_id, state.workspace_id)
-        user_home, _created = _wm.ensure_home_symlink(
+        user_home, _created = await _wm.ensure_home_symlink(
             ws_home, handle, owner_id
         )
         cid_short = state.container_id[:12]

--- a/src/backend/klangk_backend/workspaces.py
+++ b/src/backend/klangk_backend/workspaces.py
@@ -314,21 +314,17 @@ def get_home_host_path(user_id: str, workspace_id: str) -> Path:
 # --- Handle management ---
 
 
-def ensure_home_symlink(
+def _ensure_home_symlink_sync(
     workspace_home: Path,
     handle: str,
     user_id: str,
 ) -> tuple[str, bool]:
-    """Ensure the ``/home/{handle} -> .users/{user_id}`` symlink exists.
+    """Synchronous ``ensure_home_symlink`` implementation.
 
-    Creates the ``.users/{user_id}`` directory and symlink if missing.
-    If the symlink exists and already points to the right target, no-op.
-    If the handle changed (old symlink for this user_id exists), removes
-    the old one and creates the new one.
-
-    Returns ``(container_home_path, created)`` where *created* is True
-    when a new user directory was created (caller should populate it
-    with skeleton files).
+    Performs blocking filesystem calls (``Path.exists``, ``readlink``,
+    ``symlink_to``, ``Path.iterdir``, …) and must not run on the event
+    loop — callers go through ``ensure_home_symlink``, which offloads
+    this to a worker thread via ``asyncio.to_thread`` (#1262).
     """
     users_dir = workspace_home / ".users"
     users_dir.mkdir(parents=True, exist_ok=True)
@@ -366,6 +362,31 @@ def ensure_home_symlink(
 
     symlink.symlink_to(target)
     return f"/home/{handle}", created
+
+
+async def ensure_home_symlink(
+    workspace_home: Path,
+    handle: str,
+    user_id: str,
+) -> tuple[str, bool]:
+    """Ensure the ``/home/{handle} -> .users/{user_id}`` symlink exists.
+
+    Creates the ``.users/{user_id}`` directory and symlink if missing.
+    If the symlink exists and already points to the right target, no-op.
+    If the handle changed (old symlink for this user_id exists), removes
+    the old one and creates the new one.
+
+    The blocking filesystem work runs in a worker thread via
+    ``asyncio.to_thread`` so connect / container-start paths do not
+    stall the event loop on disk latency (#1262).
+
+    Returns ``(container_home_path, created)`` where *created* is True
+    when a new user directory was created (caller should populate it
+    with skeleton files).
+    """
+    return await asyncio.to_thread(
+        _ensure_home_symlink_sync, workspace_home, handle, user_id
+    )
 
 
 async def populate_home_skel(

--- a/src/backend/klangk_backend/wshandler/connection.py
+++ b/src/backend/klangk_backend/wshandler/connection.py
@@ -290,7 +290,10 @@ class Connection:
         # symlink in place so podman doesn't auto-create a real dir.
         handle = await model.get_user_handle(self.user["id"])
         workspace_home = workspaces.home_path(owner_id, workspace_id)
-        self._user_home, self._home_created = workspaces.ensure_home_symlink(
+        (
+            self._user_home,
+            self._home_created,
+        ) = await workspaces.ensure_home_symlink(
             workspace_home, handle, self.user["id"]
         )
 
@@ -861,7 +864,7 @@ class Connection:
                 workspace_home = workspaces.home_path(
                     owner_id, self.workspace_id
                 )
-                container_home, created = workspaces.ensure_home_symlink(
+                container_home, created = await workspaces.ensure_home_symlink(
                     workspace_home, handle, self.user["id"]
                 )
                 if created and self.container_id:

--- a/src/backend/tests/test_agent.py
+++ b/src/backend/tests/test_agent.py
@@ -797,6 +797,7 @@ class TestEnsureAgentHome:
             patch.object(
                 workspaces,
                 "ensure_home_symlink",
+                new_callable=AsyncMock,
                 return_value=("/home/clanker", True),
             ) as mock_symlink,
             patch.object(
@@ -848,6 +849,7 @@ class TestEnsureAgentHome:
             patch.object(
                 workspaces,
                 "ensure_home_symlink",
+                new_callable=AsyncMock,
                 return_value=("/home/clanker", True),
             ),
             patch.object(
@@ -872,6 +874,7 @@ class TestEnsureAgentHome:
             patch.object(
                 workspaces,
                 "ensure_home_symlink",
+                new_callable=AsyncMock,
                 return_value=("/home/clanker", False),
             ),
             patch.object(
@@ -928,6 +931,7 @@ class TestEnsureHome:
             patch.object(
                 workspaces,
                 "ensure_home_symlink",
+                new_callable=AsyncMock,
                 return_value=("/home/clanker", True),
             ) as mock_symlink,
             patch.object(

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -2275,6 +2275,7 @@ class TestHealthMonitorRunOne:
             patch("klangk_backend.workspaces.home_path", return_value="/h/p"),
             patch(
                 "klangk_backend.workspaces.ensure_home_symlink",
+                new_callable=AsyncMock,
                 return_value=("/home/klangk", False),
             ),
         ):
@@ -2312,6 +2313,7 @@ class TestHealthMonitorRunOne:
             patch("klangk_backend.workspaces.home_path", return_value="/h/p"),
             patch(
                 "klangk_backend.workspaces.ensure_home_symlink",
+                new_callable=AsyncMock,
                 return_value=("/home/klangk", False),
             ),
         ):
@@ -2336,6 +2338,7 @@ class TestHealthMonitorRunOne:
             patch("klangk_backend.workspaces.home_path", return_value="/h/p"),
             patch(
                 "klangk_backend.workspaces.ensure_home_symlink",
+                new_callable=AsyncMock,
                 return_value=("/home/klangk", False),
             ),
         ):
@@ -2360,6 +2363,7 @@ class TestHealthMonitorRunOne:
             patch("klangk_backend.workspaces.home_path", return_value="/h/p"),
             patch(
                 "klangk_backend.workspaces.ensure_home_symlink",
+                new_callable=AsyncMock,
                 return_value=("/home/klangk", False),
             ),
         ):
@@ -2394,6 +2398,7 @@ class TestHealthMonitorRunOne:
             patch("klangk_backend.workspaces.home_path", return_value="/h/p"),
             patch(
                 "klangk_backend.workspaces.ensure_home_symlink",
+                new_callable=AsyncMock,
                 return_value=("/home/klangk", False),
             ),
         ):

--- a/src/backend/tests/test_workspaces.py
+++ b/src/backend/tests/test_workspaces.py
@@ -270,7 +270,9 @@ class TestEnsureHomeSymlink:
     async def test_creates_symlink(self, user):
         ws = await ws_mod.create_workspace(user["id"], "symlink-ws")
         home = ws_mod.home_path(user["id"], ws["id"])
-        result, created = ws_mod.ensure_home_symlink(home, "alice", "uid-1")
+        result, created = await ws_mod.ensure_home_symlink(
+            home, "alice", "uid-1"
+        )
         assert result == "/home/alice"
         assert created is True
         symlink = home / "alice"
@@ -281,16 +283,20 @@ class TestEnsureHomeSymlink:
     async def test_idempotent(self, user):
         ws = await ws_mod.create_workspace(user["id"], "symlink-ws2")
         home = ws_mod.home_path(user["id"], ws["id"])
-        ws_mod.ensure_home_symlink(home, "bob", "uid-1")
-        result, created = ws_mod.ensure_home_symlink(home, "bob", "uid-1")
+        await ws_mod.ensure_home_symlink(home, "bob", "uid-1")
+        result, created = await ws_mod.ensure_home_symlink(
+            home, "bob", "uid-1"
+        )
         assert result == "/home/bob"
         assert created is False
 
     async def test_rename_removes_old_symlink(self, user):
         ws = await ws_mod.create_workspace(user["id"], "symlink-ws3")
         home = ws_mod.home_path(user["id"], ws["id"])
-        ws_mod.ensure_home_symlink(home, "alice", "uid-1")
-        result, created = ws_mod.ensure_home_symlink(home, "alicia", "uid-1")
+        await ws_mod.ensure_home_symlink(home, "alice", "uid-1")
+        result, created = await ws_mod.ensure_home_symlink(
+            home, "alicia", "uid-1"
+        )
         assert result == "/home/alicia"
         assert created is False
         assert not (home / "alice").exists()
@@ -311,7 +317,9 @@ class TestEnsureHomeSymlink:
         (old_dir / ".profile").write_text("# old profile")
         (home / "admin").symlink_to(".users/old-uid")
         # New user connects — different user ID, same handle.
-        result, created = ws_mod.ensure_home_symlink(home, "admin", "new-uid")
+        result, created = await ws_mod.ensure_home_symlink(
+            home, "admin", "new-uid"
+        )
         assert result == "/home/admin"
         assert created is False  # content adopted, no skel needed
         assert (home / "admin").is_symlink()


### PR DESCRIPTION
## Summary

Closes #1262 (subtle-bugs audit #1197, item #6 — MEDIUM).

`workspaces.ensure_home_symlink` performed synchronous filesystem calls
(`Path.exists`, `Path.is_symlink`, `os.readlink`, `Path.iterdir`,
`Path.symlink_to`, `Path.unlink`, …) but was invoked from `async`
WebSocket / container-start paths, blocking the event loop on every
connect.

## Changes

- **`workspaces.py`** — Split the blocking body into
  `_ensure_home_symlink_sync` and made the public `ensure_home_symlink`
  `async`, offloading the FS work to a worker thread via
  `asyncio.to_thread`. This mirrors the existing `_async_rmtree` /
  `rmtree` pattern already in this module.
- **Callers** updated to `await` (all were already inside `async def`):
  - `agent.ensure_agent_home`
  - `container.HealthMonitor._run_one` (health-check path)
  - `wshandler/connection.py` — `start_workspace_container` and
    `handle_set_handle`
- **Tests** — direct callers in `test_workspaces.py` now `await`;
  patched-out sites in `test_agent.py` (4) and `test_container.py` (5)
  use `AsyncMock`.

The public async API (name, args, return tuple) is unchanged, so the
only caller-side change is adding `await`.

## Verification

Full backend unit suite passes (2151 passed). `ruff check` /
`ruff format` clean.