### PR TITLE
refactor(wshandler): remove dead save_state_snapshot

### DIFF
--- a/src/backend/klangk_backend/wshandler/connection.py
+++ b/src/backend/klangk_backend/wshandler/connection.py
@@ -667,9 +667,6 @@ class Connection:
     def broadcast_shared_terminals(self, ws_session) -> None:
         self.shared.broadcast_shared_terminals(ws_session)
 
-    def _save_state_snapshot(self, ws_session) -> None:
-        self.shared.save_state_snapshot(ws_session)
-
     async def handle_create_shared_terminal(self, msg: dict) -> None:
         await self.shared.create_shared_terminal(msg)
 

--- a/src/backend/klangk_backend/wshandler/controllers.py
+++ b/src/backend/klangk_backend/wshandler/controllers.py
@@ -724,7 +724,6 @@ class TerminalController:
         }
         if old_shared != new_shared or old_shared_names != new_shared_names:
             self._conn.broadcast_shared_terminals(ws_session)
-        self._conn._save_state_snapshot(ws_session)
 
     def _merge_service_windows(self, ws_session, windows: list[dict]) -> None:
         """Merge the agent's ``service`` session windows into the map.
@@ -1041,7 +1040,6 @@ class SharedTerminalController:
             return
         match["shared"] = True
         self.broadcast_shared_terminals(ws_session)
-        self.save_state_snapshot(ws_session)
 
     async def unshare_window(self, msg: dict) -> None:
         """Remove sharing from a window and kick joiners."""
@@ -1081,7 +1079,6 @@ class SharedTerminalController:
             }
         )
         self.broadcast_shared_terminals(ws_session)
-        self.save_state_snapshot(ws_session)
 
     @staticmethod
     async def _select_shared_window(
@@ -1250,27 +1247,6 @@ class SharedTerminalController:
             {"type": "shared_terminals", "terminals": terminals}
         )
 
-    def save_state_snapshot(self, ws_session) -> None:
-        """Schedule a serialized save of workspace state to the container.
-
-        Callers must ensure ``container_id`` is set.
-        Uses the session's save_lock so concurrent saves don't overlap.
-        """
-        return  # temporarily disabled for debugging
-
-        container_id = self._conn.container_id
-        # Snapshot the state now — the dict may mutate before the task runs.
-        snapshot = {
-            uid: [dict(w) for w in wins]
-            for uid, wins in ws_session.terminal_windows.items()
-        }
-
-        async def _do_save() -> None:
-            async with ws_session.save_lock:
-                await terminal.save_workspace_state(container_id, snapshot)
-
-        asyncio.create_task(_do_save())
-
     # Keep old handler name for backwards compat with existing E2E tests
     async def create_shared_terminal(self, msg: dict) -> None:
         """Create a new shared terminal (legacy API — creates a new window
@@ -1307,7 +1283,6 @@ class SharedTerminalController:
                 w["shared"] = True
                 break
         self.broadcast_shared_terminals(ws_session)
-        self.save_state_snapshot(ws_session)
 
     async def delete_shared_terminal(self, msg: dict) -> None:
         """Delete a shared terminal (legacy API — unshares and closes
@@ -1375,7 +1350,6 @@ class SharedTerminalController:
             }
         )
         self.broadcast_shared_terminals(ws_session)
-        self.save_state_snapshot(ws_session)
 
     # Legacy error handler kept for coverage
     async def handle_list_error(

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -5615,7 +5615,6 @@ class TestTerminalController:
             workspace=None,
             _has_perm=AsyncMock(return_value=has_perm),
             broadcast_shared_terminals=MagicMock(),
-            _save_state_snapshot=MagicMock(),
         )
         return TerminalController(conn), sock, conn
 
@@ -7312,8 +7311,8 @@ class TestSharedTerminalController:
     Connection-level tests reach only indirectly — notably the
     ``Connection._handle_list_error`` backward-compat delegate, the
     ``join_shared_terminal`` ``asyncio.CancelledError`` re-raise, and
-    the ``find_window``/``broadcast_shared_terminals``/
-    ``save_state_snapshot`` helpers as controller methods.
+    the ``find_window``/``broadcast_shared_terminals`` helpers as
+    controller methods.
     """
 
     def _controller(
@@ -7545,7 +7544,7 @@ class TestSharedTerminalController:
         finally:
             wshandler.state.sessions.pop("ws-1", None)
 
-    # --- broadcast_shared_terminals / save_state_snapshot ---
+    # --- broadcast_shared_terminals ---
 
     async def test_broadcast_shared_terminals_broadcasts(self, user):
         ctrl, sock, conn = self._controller(user=user)
@@ -7557,16 +7556,6 @@ class TestSharedTerminalController:
             assert any(s.get("type") == "shared_terminals" for s in sent)
         finally:
             await ws.remove_subscriber(sock)
-            wshandler.state.sessions.pop("ws-1", None)
-
-    async def test_save_state_snapshot_is_noop_when_disabled(self, user):
-        """The snapshot save is currently disabled (early return)."""
-        ctrl, _, _ = self._controller(user=user)
-        ws = self._ws_session()
-        try:
-            # Must not raise and must not schedule any task.
-            ctrl.save_state_snapshot(ws)
-        finally:
             wshandler.state.sessions.pop("ws-1", None)
 
     # --- create_shared_terminal (legacy) ---
@@ -7901,16 +7890,6 @@ class TestSharedTerminalController:
         try:
             with patch.object(conn.shared, "broadcast_shared_terminals") as m:
                 conn.broadcast_shared_terminals(ws)
-            m.assert_called_once_with(ws)
-        finally:
-            wshandler.state.sessions.pop("ws-1", None)
-
-    async def test_connection_save_state_snapshot_delegate(self, user):
-        conn = _base_conn(user=user)
-        ws = wshandler.state.get_or_create_session("ws-1")
-        try:
-            with patch.object(conn.shared, "save_state_snapshot") as m:
-                conn._save_state_snapshot(ws)
             m.assert_called_once_with(ws)
         finally:
             wshandler.state.sessions.pop("ws-1", None)


### PR DESCRIPTION
Closes #1260.

`SharedTerminalController.save_state_snapshot` was entirely dead code: its first executable statement was an unconditional `return` left over from debugging (comment: *"temporarily disabled for debugging"*), so the scheduled incremental save of terminal-window state (shared/unshared flags, names, order) never ran. The five call sites invoked it after every share/unshare/create/delete/sync, but it always no-op'd.

## Changes

Removed the dead method, the `Connection._save_state_snapshot` delegate, and all five call sites:

- `wshandler/controllers.py` — `save_state_snapshot` method + 4 call sites (`share_window`, `unshare_window`, `create_shared_terminal`, `delete_shared_terminal`)
- `wshandler/controllers.py` — 1 call site in `TerminalController.sync_terminal_windows` (used the delegate)
- `wshandler/connection.py` — `_save_state_snapshot` delegate method

## Behavior

**No observable behavior change** — the function body after the early `return` never executed. Terminal-window state is still persisted on shutdown via the active path in `Connection.handle_shutdown_container`, which calls `terminal.save_workspace_state` directly. That function and its tests (`test_terminal.py`, the two `handle_shutdown_container` tests in `test_wshandler.py`) are untouched.

## Tests

Removed the two tests that asserted the dead-code no-op behavior (`test_save_state_snapshot_is_noop_when_disabled`, `test_connection_save_state_snapshot_delegate`) and the fake-conn `_save_state_snapshot` mock attribute. Backend suite: **2152 passed**.