### PR TITLE
fix(frontend): add mounted check in _reconnect after async gap

### DIFF
--- a/src/frontend/lib/workspace/workspace_page.dart
+++ b/src/frontend/lib/workspace/workspace_page.dart
@@ -365,6 +365,7 @@ class _WorkspacePageState extends State<WorkspacePage> {
     setState(() => _connecting = true);
     final wsClient = context.read<WsClient>();
     await wsClient.connect();
+    if (!mounted) return;
     if (wsClient.connected) {
       wsClient.connectWorkspace(widget.workspaceId);
     } else {


### PR DESCRIPTION
## Summary

- Add `if (!mounted) return` guard after `await wsClient.connect()` in `_reconnect()` to prevent `setState` on a disposed widget when the user navigates away during reconnection.

Fixes #1272