### PR TITLE
fix(util): close file handle in read_file_value

### DIFF
--- a/src/backend/klangk_backend/util.py
+++ b/src/backend/klangk_backend/util.py
@@ -28,7 +28,8 @@ def read_file_value(value: str) -> tuple[str | None, OSError | None]:
     """
     path = value[5:]
     try:
-        return open(path).read().strip(), None
+        with open(path) as f:
+            return f.read().strip(), None
     except OSError as e:
         e.filename = e.filename or path
         return None, e


### PR DESCRIPTION
## Summary
- Use a `with` statement in `read_file_value` so the file descriptor is closed immediately instead of leaking until GC collects it.

Closes #1275

## Test plan
- [x] All 2159 backend tests pass with 100% coverage