### PR TITLE
fix(frontend): add mounted check to FileDropZone.uploadFiles

### DIFF
--- a/src/frontend/lib/file_viewer/file_upload.dart
+++ b/src/frontend/lib/file_viewer/file_upload.dart
@@ -122,9 +122,11 @@ class FileDropZoneState extends State<FileDropZone> {
       }
     }
 
-    setState(() => _uploading = false);
-    await Future.delayed(const Duration(milliseconds: 500));
-    widget.onUploadComplete();
+    if (mounted) {
+      setState(() => _uploading = false);
+      await Future.delayed(const Duration(milliseconds: 500));
+      widget.onUploadComplete();
+    }
   }
 
   @override

--- a/src/frontend/test/file_upload_test.dart
+++ b/src/frontend/test/file_upload_test.dart
@@ -320,6 +320,37 @@ void main() {
         expect(uploaded, isEmpty);
       });
 
+      testWidgets('skips setState and callback when unmounted during upload',
+          (tester) async {
+        bool completed = false;
+        final key = GlobalKey<FileDropZoneState>();
+        final completer = Completer<int>();
+
+        testUploadOverride = (url, headers, filename, bytes) async {
+          return completer.future;
+        };
+
+        await tester.pumpWidget(buildDropZone(
+          key: key,
+          onUploadComplete: () => completed = true,
+        ));
+
+        final file = makeFile('test.txt', [1]);
+        key.currentState!.uploadFiles(makeDropDetails([file]));
+        await tester.pump();
+
+        // Dispose the widget while upload is in progress
+        await tester.pumpWidget(const MaterialApp(home: Scaffold()));
+
+        // Complete the upload after widget is disposed
+        completer.complete(200);
+        await tester.pump();
+        await tester.pump(const Duration(milliseconds: 600));
+
+        // onUploadComplete should NOT have been called
+        expect(completed, isFalse);
+      });
+
       testWidgets('handles upload exception gracefully', (tester) async {
         bool completed = false;
         final key = GlobalKey<FileDropZoneState>();


### PR DESCRIPTION
## Summary
- Guard the final `setState(() => _uploading = false)` and `widget.onUploadComplete()` callback with a `mounted` check to prevent `setState() called after dispose()` when the widget is removed during an async upload.
- Add test that disposes the widget mid-upload and verifies the callback is not invoked.

Closes #1273

## Test plan
- [x] Existing file_upload_test.dart tests pass (26/26)
- [x] New test: "skips setState and callback when unmounted during upload"