### PR TITLE
fix(frontend): add mounted checks to terminal link tap callbacks

### DIFF
--- a/src/frontend/lib/workspace/workspace_page.dart
+++ b/src/frontend/lib/workspace/workspace_page.dart
@@ -100,14 +100,20 @@ class _WorkspacePageState extends State<WorkspacePage> {
         path: path,
         authToken: authToken,
       ),
-      openFile: (path) => context.go(
-        '/workspace/${widget.workspaceId}'
-        '?file=${Uri.encodeQueryComponent(path)}',
-      ),
-      openDirectory: (path) => context.go(
-        '/workspace/${widget.workspaceId}'
-        '?dir=${Uri.encodeQueryComponent(path)}',
-      ),
+      openFile: (path) {
+        if (!mounted) return;
+        context.go(
+          '/workspace/${widget.workspaceId}'
+          '?file=${Uri.encodeQueryComponent(path)}',
+        );
+      },
+      openDirectory: (path) {
+        if (!mounted) return;
+        context.go(
+          '/workspace/${widget.workspaceId}'
+          '?dir=${Uri.encodeQueryComponent(path)}',
+        );
+      },
     );
     unawaited(
       actions.handle(token: e.token, uri: e.uri, pwd: e.pwd, tail: e.tail),


### PR DESCRIPTION
## Summary
- Add `mounted` guards to `openFile` and `openDirectory` closures in `_handleTerminalPathTap` to prevent `context.go()` from being called on an unmounted widget after the async `statPath` HTTP call completes.

## Test plan
- [x] All 871 frontend tests pass

Fixes #1271