### PR TITLE
fix(schema): migrate workspaces tables to add mounts/env columns (#1264)

### DIFF
--- a/src/backend/klangk_backend/model/schema.py
+++ b/src/backend/klangk_backend/model/schema.py
@@ -174,6 +174,14 @@ async def init_db() -> None:
             await db.execute(
                 "ALTER TABLE workspaces ADD COLUMN health_check TEXT"
             )
+        # Migration: add mounts/env columns (#1264). These are in the
+        # CREATE TABLE above but had no ADD COLUMN migration, so DBs
+        # created before they shipped lacked them and errored on any
+        # read/write of mounts/env. NULL by default (no mounts/overrides).
+        if "mounts" not in ws_cols:
+            await db.execute("ALTER TABLE workspaces ADD COLUMN mounts TEXT")
+        if "env" not in ws_cols:
+            await db.execute("ALTER TABLE workspaces ADD COLUMN env TEXT")
         await db.execute("""
             CREATE TABLE IF NOT EXISTS port_allocations (
                 port INTEGER PRIMARY KEY,

--- a/src/backend/tests/test_model.py
+++ b/src/backend/tests/test_model.py
@@ -178,6 +178,75 @@ class TestMigration:
             row = await cursor.fetchone()
             assert row[0] == "echo hello"
 
+    async def test_migrate_workspaces_adds_mounts_and_env(self, temp_data_dir):
+        """init_db adds mounts/env columns to tables that predate them (#1264).
+
+        These columns exist in CREATE TABLE but had no ADD COLUMN migration,
+        so a DB created before they shipped lacked them. init_db must add
+        them on upgrade (NULL by default) without touching existing rows.
+        """
+        db = await aiosqlite.connect(str(model.db.DB_PATH))
+        model.db.DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            await db.execute("""
+                CREATE TABLE users (
+                    id TEXT PRIMARY KEY,
+                    email TEXT UNIQUE NOT NULL,
+                    password_hash TEXT,
+                    verified INTEGER NOT NULL DEFAULT 0,
+                    provider TEXT NOT NULL DEFAULT 'local',
+                    external_id TEXT,
+                    handle TEXT UNIQUE,
+                    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+                )
+            """)
+            await db.execute(
+                "INSERT INTO users (id, email, password_hash, verified)"
+                " VALUES ('u1', 'owner@example.com', 'hash', 1)"
+            )
+            # Pre-mounts/env workspaces table — has the columns that existed
+            # *before* mounts/env shipped, but NOT mounts/env themselves.
+            await db.execute("""
+                CREATE TABLE workspaces (
+                    id TEXT PRIMARY KEY,
+                    user_id TEXT NOT NULL REFERENCES users(id),
+                    name TEXT NOT NULL,
+                    container_id TEXT,
+                    num_ports INTEGER NOT NULL DEFAULT 5,
+                    image TEXT,
+                    service_command TEXT,
+                    auto_start INTEGER NOT NULL DEFAULT 0,
+                    setup_state TEXT NOT NULL DEFAULT 'complete',
+                    health_check TEXT,
+                    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+                    UNIQUE(user_id, name)
+                )
+            """)
+            await db.execute(
+                "INSERT INTO workspaces (id, user_id, name)"
+                " VALUES ('ws1', 'u1', 'old-ws')"
+            )
+            await db.commit()
+        finally:
+            await db.close()
+
+        await model.init_db()
+
+        # Both columns added; old row survived and reads back as NULL
+        # (no mounts, no env overrides).
+        async with model.transaction() as conn:
+            cursor = await conn.execute("PRAGMA table_info(workspaces)")
+            cols = {row[1] for row in await cursor.fetchall()}
+            assert "mounts" in cols
+            assert "env" in cols
+
+            cursor = await conn.execute(
+                "SELECT mounts, env FROM workspaces WHERE id = 'ws1'"
+            )
+            mounts, env = await cursor.fetchone()
+            assert mounts is None
+            assert env is None
+
 
 class TestUsers:
     async def test_create_user(self, db):


### PR DESCRIPTION
## What

Add the missing `ALTER TABLE ... ADD COLUMN` migrations for the workspaces
table's `mounts` and `env` columns, so databases created before those columns
shipped get upgraded in place.

Closes #1264 (split from MEDIUM audit item #8 in #1197).

## The bug

The `workspaces` table's `mounts` and `env` columns are defined in the
fresh-install `CREATE TABLE IF NOT EXISTS workspaces`, but the migration block
that follows — which uses `PRAGMA table_info(workspaces)` to conditionally
`ADD COLUMN` for `auto_start`, `setup_state`, `health_check`, and the
`default_command → service_command` rename — **had no equivalent for
`mounts` or `env`**.

Result: a database created before `mounts`/`env` shipped would be upgraded
in place *without* them, so any code reading/writing those columns (mounts
specs, custom env) errored on those DBs.

## The fix

Two guarded migrations mirroring the existing pattern, added right after the
`health_check` migration:

```python
if "mounts" not in ws_cols:
    await db.execute("ALTER TABLE workspaces ADD COLUMN mounts TEXT")
if "env" not in ws_cols:
    await db.execute("ALTER TABLE workspaces ADD COLUMN env TEXT")
```

Both default to `NULL` (no mounts, no env overrides), matching the
`CREATE TABLE` definition and the no-op behavior for existing workspaces.

## Testing

`test_migrate_workspaces_adds_mounts_and_env` — builds a pre-`mounts`/`env`
`workspaces` table (has the columns that existed before they shipped, but not
the two new ones), inserts a row, runs `init_db()`, then asserts:
- both columns are now present (`PRAGMA table_info`)
- the existing row survived and reads back `mounts IS NULL`, `env IS NULL`

**Verified the test catches the regression:** with the migration removed it
fails (`'mounts' not in {'auto_start', 'container_id', ...}`); with the fix it
passes.

Full backend suite: **2155 passed**. Pre-commit (ruff, prettier,
deferred-imports, trufflehog) clean.

## Notes

- Idempotent and safe on fresh installs (the `not in ws_cols` guard skips
  them, same as every other migration in the block).
- No data backfill needed — `NULL` is the correct default for "no mounts / no
  custom env", exactly what `CREATE TABLE` uses for fresh rows.
