### PR TITLE
fix(ws_client): stop _send writing to a closed WebSocket sink

### DIFF
--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -387,6 +387,9 @@ class WsClient extends ChangeNotifier {
         terminalWindows = [];
         sharedTerminals = [];
         final code = _channel?.closeCode;
+        // Drop the closed channel so _send can't write to a dead sink
+        // during the reconnect window (it also guards on _connected).
+        _channel = null;
         notifyListeners();
         if (code == 4001 || code == 4002) {
           _errorController.add('Session expired, please log in again');
@@ -404,8 +407,11 @@ class WsClient extends ChangeNotifier {
         presenceUsers = [];
         terminalWindows = [];
         sharedTerminals = [];
-        notifyListeners();
         final code = _channel?.closeCode;
+        // Drop the closed channel so _send can't write to a dead sink
+        // during the reconnect window (it also guards on _connected).
+        _channel = null;
+        notifyListeners();
         if (code == 4001 || code == 4002) {
           _auth?.logout();
         } else {
@@ -500,7 +506,10 @@ class WsClient extends ChangeNotifier {
   }
 
   void _send(Map<String, dynamic> msg) {
-    if (_channel == null) return;
+    // Guard against both a missing channel and a closed one: onDone/onError
+    // set _connected = false (and null _channel) but a send can land in that
+    // window, so check both to avoid writing to a closed sink.
+    if (!_connected || _channel == null) return;
     final cmd = msg['cmd'] as String? ?? '?';
     // Skip noisy terminal_input from debug log
     if (cmd != 'terminal_input') {

--- a/src/frontend/test/ws_client_test.dart
+++ b/src/frontend/test/ws_client_test.dart
@@ -1283,6 +1283,49 @@ void main() {
       expect(client.currentWorkspaceId, isNull);
     });
 
+    test('_send no-ops after server close (no write to closed sink)', () async {
+      // Regression #1265: during the reconnect window _channel was left
+      // non-null while _connected was false, so _send wrote into the
+      // closed sink.
+      channel.serverSend({
+        'type': 'container_ready',
+        'workspaceId': 'ws-1',
+      });
+      await Future.delayed(Duration.zero);
+
+      channel.serverClose();
+      await Future.delayed(Duration.zero);
+      expect(client.connected, isFalse);
+
+      final sentBefore = channel.sentMessages.length;
+
+      // Sends landing in the closed-sink window must be silently dropped.
+      client.sendHeartbeat();
+      client.sendTerminalInput('ls\n');
+      client.connectWorkspace('ws-1');
+
+      expect(channel.sentMessages.length, sentBefore,
+          reason: '_send must not write to a closed sink during reconnect');
+    });
+
+    test('_send no-ops after server error (no write to closed sink)', () async {
+      // Same regression as above, via the onError path.
+      final errors = <String>[];
+      client.errors.listen(errors.add);
+
+      channel.serverError(Exception('boom'));
+      await Future.delayed(Duration.zero);
+      expect(client.connected, isFalse);
+
+      final sentBefore = channel.sentMessages.length;
+
+      client.sendHeartbeat();
+      client.sendTerminalInput('ls\n');
+
+      expect(channel.sentMessages.length, sentBefore,
+          reason: '_send must not write to a closed sink after onError');
+    });
+
     test('server close clears stale presence and terminal data', () async {
       // Populate data first
       channel.serverSend({


### PR DESCRIPTION
## Summary

`WsClient._send` guarded against a `null` `_channel` but **not** against a *closed* one. The stream `onDone`/`onError` handlers set `_connected = false` without nulling `_channel` (they read `_channel?.closeCode` afterward), so during the reconnect window `_send` saw `_channel != null`, passed the guard, and wrote into the closed sink — throwing or silently dropping messages.

Split from the subtle-bugs audit #1197, item **#10 (MEDIUM)**. Closes #1265.

## Changes

`src/frontend/lib/ws/ws_client.dart` — two complementary fixes (the issue suggested either; I applied both for defense-in-depth and a cleaner state invariant):

1. **`_send` now also checks `_connected`** — the direct guard for the closed-sink window:
   ```dart
   if (!_connected || _channel == null) return;
   ```
2. **`onDone` and `onError` null `_channel`** after reading `closeCode`. This makes the teardown state consistent — the invariant `_channel != null` now implies the sink is writable. `closeCode` is captured *before* nulling, so the 4001/4002 (session-expired) logout check is unaffected. (In `onError`, `notifyListeners()` moved to after the null assignment so listeners observe the final state.)

Nulling `_channel` is safe: `_connectWs` reassigns it on the next connect, and `disconnect()` / the `onBeforeUnload` callback both use `_channel?.` (null-aware).

## Tests

Added two regression tests to `ws_client_test.dart` covering both teardown paths:

- `_send no-ops after server close (no write to closed sink)` — `onDone` path
- `_send no-ops after server error (no write to closed sink)` — `onError` path

Each: connect a fake channel, trigger the teardown, then call send methods during the closed-sink window and assert nothing was written. **Both fail against the pre-fix code** (3 messages written after close, 2 after error — verified by stashing the source fix) and pass with it.

- `flutter test test/ws_client_test.dart` → **84 passed** (incl. the 2 new)
- full frontend suite → **873 passed**
- `dart analyze lib/ws/ws_client.dart test/ws_client_test.dart` → **no issues**
