### PR TITLE
fix(model): pagination off-by-one in has_more

### DIFF
--- a/src/backend/klangk_backend/model/workspaces.py
+++ b/src/backend/klangk_backend/model/workspaces.py
@@ -284,7 +284,7 @@ async def list_workspaces(
     if q:
         where += " AND name LIKE '%' || ? || '%'"
         params.append(q)
-    params.extend([limit, offset])
+    params.extend([limit + 1, offset])
     async with transaction() as db:
         cursor = await db.execute(
             "SELECT id, name, container_id, image, service_command,"
@@ -311,7 +311,8 @@ async def list_workspaces(
             }
             for row in rows
         ]
-        has_more = len(items) == limit
+        has_more = len(items) > limit
+        items = items[:limit]
         return {
             "items": items,
             "has_more": has_more,
@@ -366,7 +367,7 @@ async def list_shared_workspaces(
                 user_id,
                 *group_ids,
                 *([q] if q else []),
-                limit,
+                limit + 1,
                 offset,
             ),
         )
@@ -388,7 +389,8 @@ async def list_shared_workspaces(
             }
             for row in rows
         ]
-        has_more = len(items) == limit
+        has_more = len(items) > limit
+        items = items[:limit]
         return {
             "items": items,
             "has_more": has_more,

--- a/src/backend/tests/test_model.py
+++ b/src/backend/tests/test_model.py
@@ -462,6 +462,15 @@ class TestWorkspaces:
         page2_ids = {ws["id"] for ws in page2["items"]}
         assert page1_ids.isdisjoint(page2_ids)
 
+    async def test_list_workspaces_exact_page_no_extra_fetch(self, user):
+        """When total items == limit, has_more must be False (no phantom page)."""
+        for i in range(2):
+            await model.create_workspace(user["id"], f"exact{i}")
+        result = await model.list_workspaces(user["id"], limit=2, offset=0)
+        assert len(result["items"]) == 2
+        assert result["has_more"] is False
+        assert result["next_offset"] is None
+
     async def test_list_workspaces_offset_beyond_end(self, user):
         await model.create_workspace(user["id"], "only")
         result = await model.list_workspaces(user["id"], offset=10)
@@ -637,6 +646,21 @@ class TestWorkspaceSharing:
         assert len(page2["items"]) == 1
         assert page2["has_more"] is False
         assert page2["next_offset"] is None
+
+    async def test_list_shared_workspaces_exact_page_no_extra_fetch(
+        self, user
+    ):
+        """When total shared items == limit, has_more must be False."""
+        other = await model.create_user("sharer2@example.com", "hash")
+        for i in range(2):
+            ws = await model.create_workspace(user["id"], f"exact_shared{i}")
+            await self._share(ws["id"], other["id"])
+        result = await model.list_shared_workspaces(
+            other["id"], limit=2, offset=0
+        )
+        assert len(result["items"]) == 2
+        assert result["has_more"] is False
+        assert result["next_offset"] is None
 
 
 class TestSearchUsers:


### PR DESCRIPTION
## Summary

- Fix off-by-one in `list_workspaces` and `list_shared_workspaces`: fetch `limit + 1` rows and check `len > limit` instead of `len == limit`, so `has_more` is `False` when results are an exact multiple of page size (no phantom empty page).
- Add exact-page-boundary tests for both functions.

Fixes #1274