### PR TITLE
fix(frontend): replace lazy List.cast() with eager List.from() in WsClient

### DIFF
--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -439,7 +439,7 @@ class WsClient extends ChangeNotifier {
 
   void _onPresenceList(Map<String, dynamic> json) {
     final users = json['users'] as List? ?? [];
-    presenceUsers = users.cast<Map<String, dynamic>>();
+    presenceUsers = List<Map<String, dynamic>>.from(users);
     notifyListeners();
   }
 
@@ -469,13 +469,13 @@ class WsClient extends ChangeNotifier {
   void _onTerminalWindows(Map<String, dynamic> json) {
     debugPrint('[WsClient] terminal_windows received: ${DateTime.now()}');
     final windows = json['windows'] as List? ?? [];
-    terminalWindows = windows.cast<Map<String, dynamic>>();
+    terminalWindows = List<Map<String, dynamic>>.from(windows);
     notifyListeners();
   }
 
   void _onSharedTerminals(Map<String, dynamic> json) {
     final terminals = json['terminals'] as List? ?? [];
-    sharedTerminals = terminals.cast<Map<String, dynamic>>();
+    sharedTerminals = List<Map<String, dynamic>>.from(terminals);
     notifyListeners();
   }
 

--- a/src/frontend/test/ws_client_test.dart
+++ b/src/frontend/test/ws_client_test.dart
@@ -1123,6 +1123,21 @@ void main() {
       expect(client.terminalWindows[1]['name'], 'build');
     });
 
+    test('terminalWindows is an eager list, not a lazy cast', () async {
+      channel.serverSend({
+        'type': 'terminal_windows',
+        'windows': [
+          {'index': 0, 'name': 'bash', 'active': true},
+        ],
+      });
+      await Future.delayed(Duration.zero);
+      // List.from produces a growable List, not a CastList lazy wrapper
+      expect(client.terminalWindows, isA<List<Map<String, dynamic>>>());
+      client.terminalWindows
+          .add({'index': 1, 'name': 'added', 'active': false});
+      expect(client.terminalWindows.length, 2);
+    });
+
     test('shared_terminals message updates sharedTerminals', () async {
       channel.serverSend({
         'type': 'shared_terminals',
@@ -1136,6 +1151,22 @@ void main() {
       await Future.delayed(Duration.zero);
       expect(client.sharedTerminals.length, 1);
       expect(client.sharedTerminals[0]['name'], 'dev');
+    });
+
+    test('sharedTerminals is an eager list, not a lazy cast', () async {
+      channel.serverSend({
+        'type': 'shared_terminals',
+        'terminals': [
+          {
+            'name': 'dev',
+            'sessions': ['alice']
+          },
+        ],
+      });
+      await Future.delayed(Duration.zero);
+      expect(client.sharedTerminals, isA<List<Map<String, dynamic>>>());
+      client.sharedTerminals.add({'name': 'added', 'sessions': []});
+      expect(client.sharedTerminals.length, 2);
     });
 
     test('shared_terminal_deleted fires stream', () async {
@@ -1492,6 +1523,19 @@ void main() {
 
       expect(client.presenceUsers.length, 2);
       expect(client.presenceUsers[0]['user_email'], 'alice@test.com');
+    });
+
+    test('presenceUsers is an eager list, not a lazy cast', () async {
+      channel.serverSend({
+        'type': 'presence_list',
+        'users': [
+          {'user_id': 'u1', 'user_email': 'alice@test.com'},
+        ],
+      });
+      await Future.delayed(Duration.zero);
+      expect(client.presenceUsers, isA<List<Map<String, dynamic>>>());
+      client.presenceUsers.add({'user_id': 'u2', 'user_email': 'bob@test.com'});
+      expect(client.presenceUsers.length, 2);
     });
 
     test('presence_join adds user', () async {


### PR DESCRIPTION
## Summary
- Replace three `List.cast<Map<String, dynamic>>()` calls with `List<Map<String, dynamic>>.from()` in `WsClient` (`presenceUsers`, `terminalWindows`, `sharedTerminals`)
- `.cast()` creates a lazy wrapper that defers type errors until element access; `.from()` evaluates eagerly at parse time, surfacing malformed server data immediately
- Add tests verifying the lists are eager (growable, properly typed)

Closes #1279

## Test plan
- [x] All 85 ws_client_test.dart tests pass
- [x] New tests: eager list verification for presenceUsers, terminalWindows, sharedTerminals