### PR TITLE
fix(nginx): raise worker_connections from 64 to 1024

### DIFF
--- a/scripts/nginx.sh
+++ b/scripts/nginx.sh
@@ -198,7 +198,7 @@ cat >"$NGINX_STATE/nginx.conf" <<EOF_SECURE
 daemon off;
 pid /tmp/nginx.pid;
 error_log stderr;
-events { worker_connections 64; }
+events { worker_connections 1024; }
 http {
   access_log /dev/stdout;
   client_body_temp_path /tmp/nginx_client_body;


### PR DESCRIPTION
## Summary
- Bump nginx `worker_connections` from 64 to 1024 (the standard default), removing the ~30 concurrent user cap on a multi-user platform.

## Test plan
- [x] shellcheck/shfmt pass

Fixes #1277