### PR TITLE
refactor(backend): key workspace storage by workspace_id, not user_id

### DIFF
--- a/src/backend/klangk_backend/agent.py
+++ b/src/backend/klangk_backend/agent.py
@@ -86,8 +86,7 @@ async def ensure_agent_home(workspace_id: str, container_id: str) -> str:
         raise AgentSetupError(
             f"Workspace {workspace_id} not found in database"
         )
-    owner_id = ws["user_id"]
-    workspace_home = workspaces.home_path(owner_id, workspace_id)
+    workspace_home = workspaces.home_path(workspace_id)
 
     agent_handle = await model.agent_handle()
     container_home, created = await workspaces.ensure_home_symlink(

--- a/src/backend/klangk_backend/api/workspaces.py
+++ b/src/backend/klangk_backend/api/workspaces.py
@@ -476,7 +476,7 @@ async def export_workspace(
     if workspace is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
 
-    home_dir = workspaces.home_path(workspace["user_id"], workspace_id)
+    home_dir = workspaces.home_path(workspace_id)
     ws_name = workspace["name"]
 
     metadata = workspaces.workspace_metadata(workspace)
@@ -628,7 +628,7 @@ async def _extract_home_directory(
     archive_path: str, user_id: int, ws_id: int
 ) -> None:
     """Extract the ``home/`` tree from *archive_path* into the workspace home."""
-    home_dir = workspaces.home_path(user_id, ws_id)
+    home_dir = workspaces.home_path(ws_id)
     home_dir.mkdir(parents=True, exist_ok=True)
     check = await asyncio.to_thread(
         subprocess.run,

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -589,7 +589,7 @@ class HealthMonitor:
         # HOME rather than as root in /.
         from . import workspaces as _wm  # noqa: allow-deferred-import
 
-        ws_home = _wm.home_path(owner_id, state.workspace_id)
+        ws_home = _wm.home_path(state.workspace_id)
         user_home, _created = await _wm.ensure_home_symlink(
             ws_home, handle, owner_id
         )

--- a/src/backend/klangk_backend/workspaces.py
+++ b/src/backend/klangk_backend/workspaces.py
@@ -163,15 +163,13 @@ async def archive_user_data(user_id: str, email: str) -> list[Path]:
     re-imported via ``POST /workspaces/import``.
 
     Returns the list of created archive paths (may be empty).
-    After successful archival the user's data directory is removed.
+    After successful archival each workspace's data directory is removed.
     """
-    user_dir = safe_path(user_id)  # lgtm[py/path-injection]
-    if not user_dir.exists():
-        return []
     safe_email = sanitize_filename(email)
 
     # Page through every workspace (list_workspaces paginates).
     archives: list[Path] = []
+    archived_ws_ids: list[str] = []
     offset = 0
     while True:
         page = await model.list_workspaces(user_id, offset=offset)
@@ -191,7 +189,7 @@ async def archive_user_data(user_id: str, email: str) -> list[Path]:
                     ws["name"],
                 )
                 continue
-            home_dir = home_path(user_id, ws["id"])
+            home_dir = home_path(ws["id"])
             metadata = workspace_metadata(ws)
             if await build_workspace_archive(metadata, home_dir, archive_path):
                 # lgtm[py/clear-text-logging-sensitive-data]
@@ -199,30 +197,36 @@ async def archive_user_data(user_id: str, email: str) -> list[Path]:
                     "Archived workspace %s to %s", ws["name"], archive_path
                 )
                 archives.append(archive_path)
+                archived_ws_ids.append(ws["id"])
         if not page["has_more"]:
             break
         offset = page["next_offset"]
 
-    # Remove the user's data directory after all archives are created.
-    if archives:
-        await _async_rmtree(user_dir, f"user data {user_id}")
+    # Remove each archived workspace's data directory.
+    for ws_id in archived_ws_ids:
+        ws_dir = safe_path(ws_id)
+        if ws_dir.exists():
+            await _async_rmtree(ws_dir, f"workspace data {ws_id}")
     return archives
 
 
-def workspace_path(user_id: str, workspace_id: str) -> Path:
-    return home_path(user_id, workspace_id) / "work"
+def workspace_path(workspace_id: str) -> Path:
+    """Build path to /WORKSPACES_ROOT/{workspace_id}/home/work"""
+    return home_path(workspace_id) / "work"
 
 
-def home_path(user_id: str, workspace_id: str) -> Path:
-    return safe_path(user_id, "home", workspace_id)
+def home_path(workspace_id: str) -> Path:
+    """Build path to /WORKSPACES_ROOT/{workspace_id}/home"""
+    return safe_path(workspace_id, "home")
 
 
-def config_path(user_id: str, workspace_id: str) -> Path:
-    return safe_path(user_id, "config", workspace_id)
+def config_path(workspace_id: str) -> Path:
+    """Build path to /WORKSPACES_ROOT/{workspace_id}/config"""
+    return safe_path(workspace_id, "config")
 
 
-def get_config_host_path(user_id: str, workspace_id: str) -> Path:
-    path = config_path(user_id, workspace_id)
+def get_config_host_path(workspace_id: str) -> Path:
+    path = config_path(workspace_id)
     path.mkdir(parents=True, exist_ok=True)
     return path
 
@@ -249,9 +253,9 @@ async def create_workspace(
         setup_state=setup_state or model.SETUP_STATE_COMPLETE,
         health_check=health_check,
     )
-    home = home_path(user_id, workspace["id"])
+    home = home_path(workspace["id"])
     home.mkdir(parents=True, exist_ok=True)
-    work = workspace_path(user_id, workspace["id"])
+    work = workspace_path(workspace["id"])
     work.mkdir(parents=True, exist_ok=True)
     users_dir = home / ".users"
     users_dir.mkdir(exist_ok=True)
@@ -294,19 +298,19 @@ async def delete_workspace(workspace_id: str, user_id: str) -> bool:
 
     deleted = await model.delete_workspace(workspace_id, user_id)
     if deleted:
-        p = home_path(user_id, workspace_id)
-        await _async_rmtree(p, f"workspace {workspace_id}")
+        ws_dir = safe_path(workspace_id)
+        await _async_rmtree(ws_dir, f"workspace {workspace_id}")
     return deleted
 
 
-def get_workspace_host_path(user_id: str, workspace_id: str) -> Path:
-    path = workspace_path(user_id, workspace_id)
+def get_workspace_host_path(workspace_id: str) -> Path:
+    path = workspace_path(workspace_id)
     path.mkdir(parents=True, exist_ok=True)
     return path
 
 
-def get_home_host_path(user_id: str, workspace_id: str) -> Path:
-    path = home_path(user_id, workspace_id)
+def get_home_host_path(workspace_id: str) -> Path:
+    path = home_path(workspace_id)
     path.mkdir(parents=True, exist_ok=True)
     return path
 
@@ -434,9 +438,9 @@ async def start_workspace(ws: dict) -> tuple[str, str]:
     """
     owner_id = ws["user_id"]
     workspace_id = ws["id"]
-    host_path = str(get_workspace_host_path(owner_id, workspace_id))
-    h_path = str(get_home_host_path(owner_id, workspace_id))
-    cfg_path = str(get_config_host_path(owner_id, workspace_id))
+    host_path = str(get_workspace_host_path(workspace_id))
+    h_path = str(get_home_host_path(workspace_id))
+    cfg_path = str(get_config_host_path(workspace_id))
     cid, status = await container.registry.start_container(
         workspace_id,
         host_path,

--- a/src/backend/klangk_backend/wshandler/connection.py
+++ b/src/backend/klangk_backend/wshandler/connection.py
@@ -278,18 +278,15 @@ class Connection:
         self, workspace_id: str, workspace: dict
     ) -> None:
         """Start/restart container for a workspace."""
-        owner_id = workspace.get("user_id", self.user["id"])
-        host_path = str(
-            workspaces.get_workspace_host_path(owner_id, workspace_id)
-        )
-        home_path = str(workspaces.get_home_host_path(owner_id, workspace_id))
-        cfg_path = str(workspaces.get_config_host_path(owner_id, workspace_id))
+        host_path = str(workspaces.get_workspace_host_path(workspace_id))
+        home_path = str(workspaces.get_home_host_path(workspace_id))
+        cfg_path = str(workspaces.get_config_host_path(workspace_id))
 
         # Ensure the per-user home symlink exists BEFORE starting the
         # container, because mounts under /home/{handle}/ need the
         # symlink in place so podman doesn't auto-create a real dir.
         handle = await model.get_user_handle(self.user["id"])
-        workspace_home = workspaces.home_path(owner_id, workspace_id)
+        workspace_home = workspaces.home_path(workspace_id)
         (
             self._user_home,
             self._home_created,
@@ -857,10 +854,7 @@ class Connection:
             # Update the per-workspace symlink.
             workspace = self.workspace
             if workspace:
-                owner_id = workspace.get("user_id", self.user["id"])
-                workspace_home = workspaces.home_path(
-                    owner_id, self.workspace_id
-                )
+                workspace_home = workspaces.home_path(self.workspace_id)
                 container_home, created = await workspaces.ensure_home_symlink(
                     workspace_home, handle, self.user["id"]
                 )

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -5503,19 +5503,19 @@ class TestArchiveUserData:
         import subprocess
 
         # Put a file in the workspace home directory
-        home_dir = ws_mod.home_path(user["id"], workspace["id"])
+        home_dir = ws_mod.home_path(workspace["id"])
         home_dir.mkdir(parents=True, exist_ok=True)
         (home_dir / "hello.txt").write_text("test content")
 
-        user_dir = ws_mod.WORKSPACES_ROOT / user["id"]
+        ws_dir = ws_mod.WORKSPACES_ROOT / workspace["id"]
         result = await ws_mod.archive_user_data(user["id"], user["email"])
         assert len(result) == 1
         archive = result[0]
         assert archive.exists()
         assert archive.name.endswith(".tar.gz")
         assert user["email"].replace("@", "_") in archive.name or True
-        # Original directory should be removed
-        assert not user_dir.exists()
+        # Workspace directory should be removed
+        assert not ws_dir.exists()
 
         # Verify it's in export format (workspace.json + home/)
         meta_out = subprocess.run(
@@ -5540,7 +5540,7 @@ class TestArchiveUserData:
         ws2 = await model.create_workspace(user["id"], "ws-two")
 
         for ws in [ws1, ws2]:
-            home = ws_mod.home_path(user["id"], ws["id"])
+            home = ws_mod.home_path(ws["id"])
             home.mkdir(parents=True, exist_ok=True)
             (home / "file.txt").write_text("data")
 
@@ -5554,7 +5554,7 @@ class TestArchiveUserData:
         """Archival pages through every workspace when there are >10."""
         for i in range(12):
             ws = await model.create_workspace(user["id"], f"ws-{i:02d}")
-            home = ws_mod.home_path(user["id"], ws["id"])
+            home = ws_mod.home_path(ws["id"])
             home.mkdir(parents=True, exist_ok=True)
             (home / "file.txt").write_text("data")
 
@@ -5567,15 +5567,13 @@ class TestArchiveUserData:
         assert result == []
 
     async def test_archive_no_workspaces(self, user):
-        """Returns empty list if user has data dir but no workspaces."""
-        user_dir = ws_mod.WORKSPACES_ROOT / user["id"]
-        user_dir.mkdir(parents=True)
+        """Returns empty list if user has no workspaces."""
         result = await ws_mod.archive_user_data(user["id"], user["email"])
         assert result == []
 
     async def test_archive_tar_failure_skips_workspace(self, user, workspace):
-        """Skips workspaces where tar fails, doesn't remove user dir."""
-        home_dir = ws_mod.home_path(user["id"], workspace["id"])
+        """Skips workspaces where tar fails, doesn't remove workspace dir."""
+        home_dir = ws_mod.home_path(workspace["id"])
         home_dir.mkdir(parents=True, exist_ok=True)
 
         mock_proc = AsyncMock()
@@ -5585,12 +5583,13 @@ class TestArchiveUserData:
         with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
             result = await ws_mod.archive_user_data(user["id"], user["email"])
         assert result == []
-        # User dir not removed since no archives were created
-        assert (ws_mod.WORKSPACES_ROOT / user["id"]).exists()
+        # Workspace dir not removed since no archives were created
+        ws_dir = ws_mod.WORKSPACES_ROOT / workspace["id"]
+        assert ws_dir.exists()
 
     async def test_archive_sanitizes_email(self, user, workspace):
         """Email with path separators is sanitized in archive filename."""
-        home_dir = ws_mod.home_path(user["id"], workspace["id"])
+        home_dir = ws_mod.home_path(workspace["id"])
         home_dir.mkdir(parents=True, exist_ok=True)
 
         result = await ws_mod.archive_user_data(
@@ -5609,7 +5608,7 @@ class TestArchiveUserData:
         """Skips workspace if archive path would escape WORKSPACES_ROOT."""
         from pathlib import PosixPath
 
-        home_dir = ws_mod.home_path(user["id"], workspace["id"])
+        home_dir = ws_mod.home_path(workspace["id"])
         home_dir.mkdir(parents=True, exist_ok=True)
 
         orig_is_relative_to = PosixPath.is_relative_to
@@ -5654,7 +5653,7 @@ class TestWorkspaceExportImport:
         # Write a file into the workspace home dir
         import klangk_backend.workspaces as ws_mod
 
-        home = ws_mod.home_path(user["id"], ws["id"])
+        home = ws_mod.home_path(ws["id"])
         home.mkdir(parents=True, exist_ok=True)
         (home / "work").mkdir(exist_ok=True)
         (home / "work" / "hello.txt").write_text("hello world")
@@ -5719,7 +5718,7 @@ class TestWorkspaceExportImport:
 
         import klangk_backend.workspaces as ws_mod
 
-        home = ws_mod.home_path(user["id"], ws["id"])
+        home = ws_mod.home_path(ws["id"])
         home.mkdir(parents=True, exist_ok=True)
         (home / "work").mkdir(exist_ok=True)
         (home / "work" / "data.txt").write_text("test data")
@@ -5748,7 +5747,7 @@ class TestWorkspaceExportImport:
         assert imported["name"] == "imported-ws"
 
         # Verify the home dir was extracted
-        new_home = ws_mod.home_path(user["id"], imported["id"])
+        new_home = ws_mod.home_path(imported["id"])
         assert (new_home / "work" / "data.txt").exists()
         assert (new_home / "work" / "data.txt").read_text() == "test data"
 
@@ -5874,7 +5873,7 @@ class TestWorkspaceExportImport:
         assert resp.status_code == 200
         ws = resp.json()
 
-        home = ws_mod.home_path(user["id"], ws["id"])
+        home = ws_mod.home_path(ws["id"])
         home.mkdir(parents=True, exist_ok=True)
         (home / "f.txt").write_text("x")
 
@@ -6073,7 +6072,7 @@ class TestWorkspaceExportImport:
         import klangk_backend.workspaces as ws_mod
 
         ws = resp.json()
-        home = ws_mod.home_path(user["id"], ws["id"])
+        home = ws_mod.home_path(ws["id"])
         assert (home / "test.txt").exists()
 
     async def test_export_streams_valid_tarball(
@@ -6088,7 +6087,7 @@ class TestWorkspaceExportImport:
 
         import klangk_backend.workspaces as ws_mod
 
-        home = ws_mod.home_path(user["id"], ws["id"])
+        home = ws_mod.home_path(ws["id"])
         home.mkdir(parents=True, exist_ok=True)
         (home / "work").mkdir(exist_ok=True)
         (home / "work" / "file.txt").write_text("streamed content")
@@ -6123,7 +6122,7 @@ class TestWorkspaceExportImport:
 
         import klangk_backend.workspaces as ws_mod
 
-        home = ws_mod.home_path(user["id"], ws["id"])
+        home = ws_mod.home_path(ws["id"])
         home.mkdir(parents=True, exist_ok=True)
         (home / "work").mkdir(exist_ok=True)
         # Write a large file with random data (incompressible, so gzip
@@ -6159,7 +6158,7 @@ class TestWorkspaceExportImport:
 
         import klangk_backend.workspaces as ws_mod
 
-        home = ws_mod.home_path(user["id"], ws["id"])
+        home = ws_mod.home_path(ws["id"])
         home.mkdir(parents=True, exist_ok=True)
         (home / "work").mkdir(exist_ok=True)
         (home / "work" / "f.txt").write_text("data")
@@ -6256,7 +6255,7 @@ class TestWorkspaceExportImport:
 
         import klangk_backend.workspaces as ws_mod
 
-        home = ws_mod.home_path(user["id"], ws["id"])
+        home = ws_mod.home_path(ws["id"])
         home.mkdir(parents=True, exist_ok=True)
         (home / "work").mkdir(exist_ok=True)
         (home / "work" / "real.txt").write_text("real file")
@@ -6296,7 +6295,7 @@ class TestWorkspaceExportImport:
 
         import klangk_backend.workspaces as ws_mod
 
-        home = ws_mod.home_path(user["id"], ws["id"])
+        home = ws_mod.home_path(ws["id"])
         home.mkdir(parents=True, exist_ok=True)
 
         # Create a deep directory structure with files at various depths
@@ -6368,7 +6367,7 @@ class TestWorkspaceExportImport:
         assert imported["name"] == "deep-imported"
 
         # Verify all files survived
-        imported_home = ws_mod.home_path(user["id"], imported["id"])
+        imported_home = ws_mod.home_path(imported["id"])
         for rel, content in expected_files.items():
             file_path = imported_home / rel
             assert file_path.exists(), f"Missing after import: {rel}"

--- a/src/backend/tests/test_workspaces.py
+++ b/src/backend/tests/test_workspaces.py
@@ -15,11 +15,11 @@ class TestCreateWorkspace:
         assert ws["user_id"] == user["id"]
         assert "id" in ws
 
-        data_path = ws_mod.workspace_path(user["id"], ws["id"])
+        data_path = ws_mod.workspace_path(ws["id"])
         assert data_path.exists()
         assert data_path.is_dir()
 
-        home_dir = ws_mod.home_path(user["id"], ws["id"])
+        home_dir = ws_mod.home_path(ws["id"])
         assert home_dir.exists()
         assert home_dir.is_dir()
 
@@ -207,8 +207,8 @@ class TestGetWorkspace:
 class TestDeleteWorkspace:
     async def test_delete_removes_db_and_dirs(self, user):
         ws = await ws_mod.create_workspace(user["id"], "doomed")
-        data_path = ws_mod.workspace_path(user["id"], ws["id"])
-        home_dir = ws_mod.home_path(user["id"], ws["id"])
+        data_path = ws_mod.workspace_path(ws["id"])
+        home_dir = ws_mod.home_path(ws["id"])
         (data_path / "file.txt").write_text("hello")
         (home_dir / ".bashrc").write_text("# custom")
 
@@ -233,7 +233,7 @@ class TestDeleteWorkspace:
 
     async def test_delete_missing_dirs_ok(self, user):
         ws = await ws_mod.create_workspace(user["id"], "no-dirs")
-        home_dir = ws_mod.home_path(user["id"], ws["id"])
+        home_dir = ws_mod.home_path(ws["id"])
         import shutil
 
         shutil.rmtree(home_dir)
@@ -244,32 +244,32 @@ class TestDeleteWorkspace:
 
 class TestHostPaths:
     def test_workspace_host_path_creates_dir(self, user, temp_data_dir):
-        path = ws_mod.get_workspace_host_path(user["id"], "ws-1")
+        path = ws_mod.get_workspace_host_path("ws-1")
         assert path.exists()
         assert path.is_dir()
 
     def test_home_host_path_creates_dir(self, user, temp_data_dir):
-        path = ws_mod.get_home_host_path(user["id"], "ws-1")
+        path = ws_mod.get_home_host_path("ws-1")
         assert path.exists()
         assert path.is_dir()
 
     def test_workspace_host_path_idempotent(self, user, temp_data_dir):
-        path1 = ws_mod.get_workspace_host_path(user["id"], "ws-1")
-        path2 = ws_mod.get_workspace_host_path(user["id"], "ws-1")
+        path1 = ws_mod.get_workspace_host_path("ws-1")
+        path2 = ws_mod.get_workspace_host_path("ws-1")
         assert path1 == path2
 
     def test_paths_are_under_data_dir(self, user, temp_data_dir):
-        path = ws_mod.get_workspace_host_path(user["id"], "ws-1")
+        path = ws_mod.get_workspace_host_path("ws-1")
         assert str(path).startswith(str(temp_data_dir))
 
-        home = ws_mod.get_home_host_path(user["id"], "ws-1")
+        home = ws_mod.get_home_host_path("ws-1")
         assert str(home).startswith(str(temp_data_dir))
 
 
 class TestEnsureHomeSymlink:
     async def test_creates_symlink(self, user):
         ws = await ws_mod.create_workspace(user["id"], "symlink-ws")
-        home = ws_mod.home_path(user["id"], ws["id"])
+        home = ws_mod.home_path(ws["id"])
         result, created = await ws_mod.ensure_home_symlink(
             home, "alice", "uid-1"
         )
@@ -282,7 +282,7 @@ class TestEnsureHomeSymlink:
 
     async def test_idempotent(self, user):
         ws = await ws_mod.create_workspace(user["id"], "symlink-ws2")
-        home = ws_mod.home_path(user["id"], ws["id"])
+        home = ws_mod.home_path(ws["id"])
         await ws_mod.ensure_home_symlink(home, "bob", "uid-1")
         result, created = await ws_mod.ensure_home_symlink(
             home, "bob", "uid-1"
@@ -292,7 +292,7 @@ class TestEnsureHomeSymlink:
 
     async def test_rename_removes_old_symlink(self, user):
         ws = await ws_mod.create_workspace(user["id"], "symlink-ws3")
-        home = ws_mod.home_path(user["id"], ws["id"])
+        home = ws_mod.home_path(ws["id"])
         await ws_mod.ensure_home_symlink(home, "alice", "uid-1")
         result, created = await ws_mod.ensure_home_symlink(
             home, "alicia", "uid-1"
@@ -308,7 +308,7 @@ class TestEnsureHomeSymlink:
         The old user's files should be adopted into the new user dir.
         """
         ws = await ws_mod.create_workspace(user["id"], "symlink-ws4")
-        home = ws_mod.home_path(user["id"], ws["id"])
+        home = ws_mod.home_path(ws["id"])
         # Simulate imported workspace: symlink for old user ID with files.
         (home / ".users").mkdir(parents=True, exist_ok=True)
         old_dir = home / ".users" / "old-uid"

--- a/src/cli/e2e-tests/test_cli_e2e.py
+++ b/src/cli/e2e-tests/test_cli_e2e.py
@@ -1200,11 +1200,8 @@ class TestExportSymlinks:
         ws = [w for w in resp.json() if w["name"] == "e2e-symlink"][0]
         ws_id = ws["id"]
 
-        # Find the user directory — it's the only subdirectory of workspaces/
         ws_root = Path(server["data_dir"]) / "workspaces"
-        user_dirs = [d for d in ws_root.iterdir() if d.is_dir()]
-        assert len(user_dirs) == 1
-        return user_dirs[0] / "home" / ws_id
+        return ws_root / ws_id / "home"
 
     def test_export_preserves_all_symlinks(self, server, cli_config, tmp_path):
         """All symlinks are preserved (stored as links, not content)."""
@@ -1368,9 +1365,7 @@ class TestExportImport:
             ws = [w for w in resp.json() if w["name"] == "export-symlink"][0]
             ws_id = ws["id"]
             ws_root = Path(server["data_dir"]) / "workspaces"
-            user_dirs = [d for d in ws_root.iterdir() if d.is_dir()]
-            assert len(user_dirs) >= 1
-            home_dir = user_dirs[0] / "home" / ws_id
+            home_dir = ws_root / ws_id / "home"
 
             # Create files and symlinks
             home_dir.mkdir(parents=True, exist_ok=True)
@@ -1444,7 +1439,7 @@ class TestExportImport:
                 for w in resp.json()
                 if w["name"] == "export-symlink-imported"
             ][0]
-            imported_home = user_dirs[0] / "home" / imported["id"]
+            imported_home = ws_root / imported["id"] / "home"
 
             # Verify files and symlinks survived
             assert (

--- a/src/cli/e2e-tests/test_cli_e2e.py
+++ b/src/cli/e2e-tests/test_cli_e2e.py
@@ -1201,9 +1201,7 @@ class TestExportSymlinks:
         ws_id = ws["id"]
 
         ws_root = Path(server["data_dir"]) / "workspaces"
-        home_dir = ws_root / ws_id / "home"
-        assert home_dir.exists(), f"workspace home dir missing: {home_dir}"
-        return home_dir
+        return ws_root / ws_id / "home"
 
     def test_export_preserves_all_symlinks(self, server, cli_config, tmp_path):
         """All symlinks are preserved (stored as links, not content)."""

--- a/src/cli/e2e-tests/test_cli_e2e.py
+++ b/src/cli/e2e-tests/test_cli_e2e.py
@@ -1201,7 +1201,9 @@ class TestExportSymlinks:
         ws_id = ws["id"]
 
         ws_root = Path(server["data_dir"]) / "workspaces"
-        return ws_root / ws_id / "home"
+        home_dir = ws_root / ws_id / "home"
+        assert home_dir.exists(), f"workspace home dir missing: {home_dir}"
+        return home_dir
 
     def test_export_preserves_all_symlinks(self, server, cli_config, tmp_path):
         """All symlinks are preserved (stored as links, not content)."""
@@ -1366,6 +1368,7 @@ class TestExportImport:
             ws_id = ws["id"]
             ws_root = Path(server["data_dir"]) / "workspaces"
             home_dir = ws_root / ws_id / "home"
+            assert home_dir.exists(), f"workspace home dir missing: {home_dir}"
 
             # Create files and symlinks
             home_dir.mkdir(parents=True, exist_ok=True)

--- a/src/frontend/e2e-tests/e2e/klangk.spec.ts
+++ b/src/frontend/e2e-tests/e2e/klangk.spec.ts
@@ -933,15 +933,9 @@ test.describe("Klangk E2E", () => {
       "host-home",
     );
 
-    // Decode user ID from JWT
-    const payload = JSON.parse(
-      Buffer.from(token.split(".")[1], "base64url").toString(),
-    );
-    const userId = payload.sub;
-
     // Write a file to the host home directory before starting the container
     const dataDir = process.env.KLANGK_E2E_DATA_DIR!;
-    const homePath = `${dataDir}/workspaces/${userId}/home/${workspaceId}`;
+    const homePath = `${dataDir}/workspaces/${workspaceId}/home`;
     const { mkdirSync, writeFileSync } = await import("fs");
     mkdirSync(homePath, { recursive: true });
     writeFileSync(`${homePath}/.host-created-file`, "hello-from-host\n");


### PR DESCRIPTION
## Summary

- Storage path helpers (`home_path`, `workspace_path`, `config_path`) now take only `workspace_id` instead of `(user_id, workspace_id)`. New layout: `<data>/workspaces/<ws_id>/{home,config}/` instead of `<data>/workspaces/<user_id>/{home,config}/<ws_id>/`
- `workspaces.user_id` is now a pure owner field with no storage consequence — ownership transfer becomes a simple `UPDATE workspaces SET user_id = ?`
- `archive_user_data` removes per-workspace directories instead of a per-user directory
- `delete_workspace` removes the workspace's top-level directory (`<ws_id>/`) instead of just the home subdirectory
- Updated all call sites: `workspaces.py`, `api/workspaces.py`, `container.py`, `wshandler/connection.py`, `agent.py`

## Test plan

- [x] All 2161 backend tests pass with 100% coverage

Fixes #1092