### PR TITLE
fix(frontend): prevent chat history duplication on reconnect

### DIFF
--- a/src/frontend/lib/chat/workspace_chat.dart
+++ b/src/frontend/lib/chat/workspace_chat.dart
@@ -106,7 +106,19 @@ class WorkspaceChatState extends State<WorkspaceChat> {
       return;
     }
 
-    // Regular chat_message or chat_history item
+    // Full history replacement (reconnect / initial load) — clear and replace
+    // to avoid duplicating messages already seeded from the buffer.
+    if (type == 'chat_history_replace') {
+      final messages = msg['messages'] as List? ?? [];
+      setState(() {
+        _messages.clear();
+        _messages.addAll(messages.cast<Map<String, dynamic>>());
+      });
+      _scrollToBottom();
+      return;
+    }
+
+    // Regular chat_message
     setState(() => _messages.add(msg));
 
     // Don't count system messages (join/leave) as unread.

--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -430,11 +430,18 @@ class WsClient extends ChangeNotifier {
   void _onChatHistory(Map<String, dynamic> json) {
     chatHistory.clear();
     final messages = json['messages'] as List? ?? [];
+    final typed = <Map<String, dynamic>>[];
     for (final m in messages) {
       final msg = m as Map<String, dynamic>;
       chatHistory.add(msg);
-      _chatController.add(msg);
+      typed.add(msg);
     }
+    // Emit a single replacement event so listeners can clear-and-replace
+    // instead of appending (which would duplicate buffered messages).
+    _chatController.add({
+      'type': 'chat_history_replace',
+      'messages': typed,
+    });
   }
 
   void _onPresenceList(Map<String, dynamic> json) {

--- a/src/frontend/test/workspace_chat_test.dart
+++ b/src/frontend/test/workspace_chat_test.dart
@@ -486,6 +486,54 @@ void main() {
       expect(field.focusNode!.hasFocus, isTrue);
     });
 
+    testWidgets('chat_history_replace clears and replaces messages',
+        (tester) async {
+      await tester.pumpWidget(buildChat());
+
+      // Seed an initial message via chat_message
+      await tester.runAsync(() async {
+        channel.serverSend({
+          'type': 'chat_message',
+          'id': 'msg-1',
+          'user_email': 'alice@test.com',
+          'message': 'first',
+          'created_at': '2026-01-01 00:00:00',
+        });
+        await Future.delayed(Duration.zero);
+        await Future.delayed(Duration.zero);
+      });
+      await tester.pump();
+      expect(find.byType(MarkdownBody), findsOneWidget);
+
+      // Simulate reconnect: server sends chat_history which becomes
+      // chat_history_replace containing the same message plus a new one.
+      await tester.runAsync(() async {
+        channel.serverSend({
+          'type': 'chat_history',
+          'messages': [
+            {
+              'id': 'msg-1',
+              'user_email': 'alice@test.com',
+              'message': 'first',
+              'created_at': '2026-01-01 00:00:00',
+            },
+            {
+              'id': 'msg-2',
+              'user_email': 'bob@test.com',
+              'message': 'second',
+              'created_at': '2026-01-01 00:01:00',
+            },
+          ],
+        });
+        await Future.delayed(Duration.zero);
+        await Future.delayed(Duration.zero);
+      });
+      await tester.pump();
+
+      // Should have exactly 2 messages, not 3 (no duplicate of msg-1)
+      expect(find.byType(MarkdownBody), findsNWidgets(2));
+    });
+
     testWidgets('loads buffered chat history on init', (tester) async {
       // Pre-populate the buffer before building the widget
       client.chatHistory.addAll([

--- a/src/frontend/test/ws_client_test.dart
+++ b/src/frontend/test/ws_client_test.dart
@@ -1418,7 +1418,7 @@ void main() {
       expect(messages[0]['user_email'], 'alice@test.com');
     });
 
-    test('chat_history messages routed individually', () async {
+    test('chat_history emits single replacement event', () async {
       final messages = <Map<String, dynamic>>[];
       client.chatMessages.listen(messages.add);
 
@@ -1441,9 +1441,12 @@ void main() {
       });
       await Future.delayed(Duration.zero);
 
-      expect(messages.length, 2);
-      expect(messages[0]['message'], 'first');
-      expect(messages[1]['message'], 'second');
+      expect(messages.length, 1);
+      expect(messages[0]['type'], 'chat_history_replace');
+      final inner = messages[0]['messages'] as List<Map<String, dynamic>>;
+      expect(inner.length, 2);
+      expect(inner[0]['message'], 'first');
+      expect(inner[1]['message'], 'second');
     });
 
     test('chat_history clears existing messages before appending', () async {


### PR DESCRIPTION
## Summary
- Fixes #1305
- Changed `WsClient._onChatHistory` to emit a single `chat_history_replace` event instead of individual messages to the chat stream
- `WorkspaceChat._onMessage` handles `chat_history_replace` by clearing and replacing `_messages`, preventing duplication when `initState` already seeded from the buffer

## Test plan
- [x] New test: `chat_history_replace clears and replaces messages` verifies no duplication on reconnect
- [x] Updated test: `chat_history emits single replacement event` verifies WsClient emits batch event
- [x] All 151 existing frontend tests pass