### PR TITLE
fix(backend): serialize get_session/stop_session to prevent race (#1298)

### DIFF
--- a/src/backend/klangk_backend/agent.py
+++ b/src/backend/klangk_backend/agent.py
@@ -49,6 +49,7 @@ class AgentSetupError(AgentError):
 
 # Registry of active agent sessions keyed by workspace ID.
 _agents: dict[str, "AgentSession"] = {}
+_agents_lock = asyncio.Lock()
 
 # Callback to get a workspace session for broadcasting.
 # Set by wshandler at import time to break the circular dependency.
@@ -555,12 +556,17 @@ async def get_session(workspace_id: str) -> AgentSession:
     The session resolves the current container ID from the container
     registry on each startup, so it automatically picks up container
     restarts without needing to be told the new ID.
+
+    Serialized with ``stop_session`` via ``_agents_lock`` so that a new
+    session is never installed for a container that ``stop_session`` has
+    already torn down (#1298).
     """
-    session = _agents.get(workspace_id)
-    if session is None:
-        session = AgentSession(workspace_id)
-        _agents[workspace_id] = session
-    return session
+    async with _agents_lock:
+        session = _agents.get(workspace_id)
+        if session is None:
+            session = AgentSession(workspace_id)
+            _agents[workspace_id] = session
+        return session
 
 
 def is_running(workspace_id: str) -> bool:
@@ -580,10 +586,16 @@ def any_running() -> bool:
 
 
 async def stop_session(workspace_id: str) -> None:
-    """Stop and remove the agent session for a workspace."""
-    session = _agents.pop(workspace_id, None)
-    if session:
-        await session.stop()
+    """Stop and remove the agent session for a workspace.
+
+    Serialized with ``get_session`` via ``_agents_lock`` so that a
+    concurrent ``get_session`` cannot install a new session for a
+    container that is being torn down (#1298).
+    """
+    async with _agents_lock:
+        session = _agents.pop(workspace_id, None)
+        if session:
+            await session.stop()
 
 
 async def stop_all_sessions() -> None:

--- a/src/backend/tests/test_agent.py
+++ b/src/backend/tests/test_agent.py
@@ -772,6 +772,46 @@ class TestGetSession:
         s2 = await get_session("ws-1")
         assert s1 is s2
 
+    async def test_get_session_blocked_during_stop(self):
+        """get_session must not install a session while stop_session is
+        tearing one down for the same workspace (#1298)."""
+        session = await get_session("ws-race")
+        session._proc = AsyncMock()
+        session._proc.returncode = None
+        session._proc.kill = MagicMock()
+        session._proc.wait = AsyncMock()
+
+        # Record the order of operations.
+        order: list[str] = []
+
+        async def slow_stop():
+            """Simulate session.stop() taking time (real stop awaits
+            proc.wait)."""
+            order.append("stop_begin")
+            await asyncio.sleep(0.05)
+            order.append("stop_end")
+
+        session.stop = slow_stop  # type: ignore[assignment]
+
+        async def do_get():
+            s = await get_session("ws-race")
+            order.append("get_done")
+            return s
+
+        # Launch stop and get concurrently.  Without the lock, get_session
+        # would see the workspace missing from _agents (already popped) and
+        # install a brand-new session before stop finishes.
+        _, new_session = await asyncio.gather(
+            stop_session("ws-race"),
+            do_get(),
+        )
+
+        # stop must fully complete before get_session creates a new entry.
+        assert order == ["stop_begin", "stop_end", "get_done"]
+        # The returned session is a fresh one (not the stopped one).
+        assert new_session is not session
+        assert "ws-race" in _agents
+
 
 class TestEnsureAgentHome:
     """Direct tests for the eager-provisioning function (#1157).


### PR DESCRIPTION
## Summary
- Add `_agents_lock` (`asyncio.Lock`) to serialize `get_session` and `stop_session`, preventing a race where `get_session` installs a new `AgentSession` for a container that `stop_session` is concurrently tearing down
- Add test verifying `get_session` blocks until `stop_session` completes

Closes #1298

## Test plan
- [x] New test `test_get_session_blocked_during_stop` verifies ordering
- [x] All 2162 backend tests pass with 100% coverage