### PR TITLE
fix(backend): acquire save_lock in handle_shutdown_container

### DIFF
--- a/src/backend/klangk_backend/wshandler/connection.py
+++ b/src/backend/klangk_backend/wshandler/connection.py
@@ -578,10 +578,15 @@ class Connection:
                 for uid, wins in session.terminal_windows.items()
             }
             if snapshot:
-                try:
-                    await terminal.save_workspace_state(container_id, snapshot)
-                except Exception as e:
-                    logger.warning("State save before shutdown failed: %s", e)
+                async with session.save_lock:
+                    try:
+                        await terminal.save_workspace_state(
+                            container_id, snapshot
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            "State save before shutdown failed: %s", e
+                        )
 
         # Clear container_id on ALL connections to prevent stale exec attempts.
         for sock, conn_obj in list(state.connections.items()):

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -5273,6 +5273,44 @@ class TestHandleShutdownContainer:
         assert user["id"] in saved_snapshot
         wshandler.state.sessions.pop(ws["id"], None)
 
+    async def test_shutdown_acquires_save_lock(self, user):
+        sock = _mock_sock()
+        conn = _base_conn(user=user, ws=sock)
+        ws = await _create_workspace_with_acl(user["id"], "shutdown-lock")
+        conn.workspace_id = ws["id"]
+        conn.container_id = "cid"
+
+        session = wshandler.state.get_or_create_session(ws["id"])
+        session.terminal_windows[user["id"]] = [
+            {"name": "bash", "index": 0, "id": "@0", "shared": False},
+        ]
+        await session.add_subscriber(sock, "cid")
+
+        lock_was_held = False
+        original_save = AsyncMock()
+
+        async def check_lock(*args, **kwargs):
+            nonlocal lock_was_held
+            lock_was_held = session.save_lock.locked()
+            return await original_save(*args, **kwargs)
+
+        with (
+            patch.object(
+                container.registry,
+                "stop_and_remove_container",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "klangk_backend.terminal.save_workspace_state",
+                new_callable=AsyncMock,
+                side_effect=check_lock,
+            ),
+        ):
+            await conn.handle_shutdown_container()
+
+        assert lock_was_held
+        wshandler.state.sessions.pop(ws["id"], None)
+
     async def test_shutdown_state_save_failure_does_not_block(self, user):
         sock = _mock_sock()
         conn = _base_conn(user=user, ws=sock)


### PR DESCRIPTION
## Summary
- Wrap the `save_workspace_state` call in `handle_shutdown_container` with `session.save_lock` so concurrent admin shutdown calls serialize state file writes, matching the documented contract
- Add `test_shutdown_acquires_save_lock` to verify the lock is held during the save

Closes #1300

## Test plan
- [x] `test_shutdown_acquires_save_lock` — asserts lock is held when `save_workspace_state` is called
- [x] All 12 `TestHandleShutdownContainer` tests pass