### PR TITLE
fix(backend): remove duplicate cleanup from broadcast iteration helpers

### DIFF
--- a/src/backend/klangk_backend/wshandler/session.py
+++ b/src/backend/klangk_backend/wshandler/session.py
@@ -558,9 +558,8 @@ class WebSocketState:
                 sock.send_json(message)
             except WS_ERRORS:
                 dead.append((sock, conn))
-        for sock, conn in dead:
+        for sock, _conn in dead:
             self.connections.pop(sock, None)
-            asyncio.create_task(conn.cleanup())
 
     def notify_service_health(
         self,
@@ -607,9 +606,8 @@ class WebSocketState:
                 sock.send_json(message_dict)
             except WS_ERRORS:
                 dead.append((sock, conn))
-        for sock, conn in dead:
+        for sock, _conn in dead:
             self.connections.pop(sock, None)
-            asyncio.create_task(conn.cleanup())
 
     def send_service_health_snapshot(self, sock: SafeWebSocket) -> None:
         """Send the current health of every health-checked workspace.
@@ -679,9 +677,8 @@ class WebSocketState:
                 sock.send_json(frame)
             except WS_ERRORS:
                 dead.append((sock, conn))
-        for sock, conn in dead:
+        for sock, _conn in dead:
             self.connections.pop(sock, None)
-            asyncio.create_task(conn.cleanup())
 
     def handle_subscribe_health_heartbeat(
         self, msg: dict, sock: SafeWebSocket
@@ -715,9 +712,8 @@ class WebSocketState:
                 sock.send_json(message)
             except WS_ERRORS:
                 dead.append((sock, conn))
-        for sock, conn in dead:
+        for sock, _conn in dead:
             self.connections.pop(sock, None)
-            asyncio.create_task(conn.cleanup())
 
     def handle_browser_response(
         self, msg: dict, sender: SafeWebSocket | None = None

--- a/src/backend/klangk_backend/wshandler/session.py
+++ b/src/backend/klangk_backend/wshandler/session.py
@@ -558,7 +558,7 @@ class WebSocketState:
                 sock.send_json(message)
             except WS_ERRORS:
                 dead.append((sock, conn))
-        for sock, _conn in dead:
+        for sock, _ in dead:
             self.connections.pop(sock, None)
 
     def notify_service_health(
@@ -606,7 +606,7 @@ class WebSocketState:
                 sock.send_json(message_dict)
             except WS_ERRORS:
                 dead.append((sock, conn))
-        for sock, _conn in dead:
+        for sock, _ in dead:
             self.connections.pop(sock, None)
 
     def send_service_health_snapshot(self, sock: SafeWebSocket) -> None:
@@ -677,7 +677,7 @@ class WebSocketState:
                 sock.send_json(frame)
             except WS_ERRORS:
                 dead.append((sock, conn))
-        for sock, _conn in dead:
+        for sock, _ in dead:
             self.connections.pop(sock, None)
 
     def handle_subscribe_health_heartbeat(
@@ -712,7 +712,7 @@ class WebSocketState:
                 sock.send_json(message)
             except WS_ERRORS:
                 dead.append((sock, conn))
-        for sock, _conn in dead:
+        for sock, _ in dead:
             self.connections.pop(sock, None)
 
     def handle_browser_response(

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -4117,17 +4117,14 @@ class TestNotifyUserWorkspacesChanged:
         # Should not raise when the user has no active connections.
         wshandler.state.notify_user_workspaces_changed("nobody")
 
-    async def test_dead_socket_is_pruned(self):
+    def test_dead_socket_is_pruned(self):
         from klangk_backend.wshandler import WS_ERRORS
 
         sock = _mock_sock()
         sock.send_json = MagicMock(side_effect=WS_ERRORS[0]("dead"))
         try:
-            conn = self._register(sock, {"id": "uid-1", "email": "a@x"})
-            with patch.object(conn, "cleanup", new_callable=AsyncMock) as mock:
-                wshandler.state.notify_user_workspaces_changed("uid-1")
-                await asyncio.sleep(0)
-                mock.assert_awaited_once()
+            self._register(sock, {"id": "uid-1", "email": "a@x"})
+            wshandler.state.notify_user_workspaces_changed("uid-1")
             assert sock not in wshandler.state.connections
         finally:
             wshandler.state.connections.pop(sock, None)
@@ -4179,17 +4176,14 @@ class TestNotifyContainerStatus:
             wshandler.state.connections.pop(sock, None)
         sock.send_json.assert_not_called()
 
-    async def test_dead_socket_is_pruned(self):
+    def test_dead_socket_is_pruned(self):
         from klangk_backend.wshandler import WS_ERRORS
 
         sock = _mock_sock()
         sock.send_json = MagicMock(side_effect=WS_ERRORS[0]("dead"))
         try:
-            conn = self._register(sock, {"id": "uid-1", "email": "a@x"})
-            with patch.object(conn, "cleanup", new_callable=AsyncMock) as mock:
-                wshandler.state.notify_container_status("ws-1", True)
-                await asyncio.sleep(0)
-                mock.assert_awaited_once()
+            self._register(sock, {"id": "uid-1", "email": "a@x"})
+            wshandler.state.notify_container_status("ws-1", True)
             assert sock not in wshandler.state.connections
         finally:
             wshandler.state.connections.pop(sock, None)
@@ -4250,17 +4244,14 @@ class TestNotifyServiceHealth:
             wshandler.state.connections.pop(sock, None)
         sock.send_json.assert_not_called()
 
-    async def test_dead_socket_is_pruned(self):
+    def test_dead_socket_is_pruned(self):
         from klangk_backend.wshandler import WS_ERRORS
 
         sock = _mock_sock()
         sock.send_json = MagicMock(side_effect=WS_ERRORS[0]("dead"))
         try:
-            conn = self._register(sock, {"id": "uid-1", "email": "a@x"})
-            with patch.object(conn, "cleanup", new_callable=AsyncMock) as mock:
-                wshandler.state.notify_service_health("ws-1", healthy=True)
-                await asyncio.sleep(0)
-                mock.assert_awaited_once()
+            self._register(sock, {"id": "uid-1", "email": "a@x"})
+            wshandler.state.notify_service_health("ws-1", healthy=True)
             assert sock not in wshandler.state.connections
         finally:
             wshandler.state.connections.pop(sock, None)
@@ -4523,19 +4514,14 @@ class TestHealthHeartbeat:
             wshandler.state.connections.pop(sock, None)
         sock.send_json.assert_not_called()
 
-    async def test_dead_opted_in_socket_is_pruned(self):
+    def test_dead_opted_in_socket_is_pruned(self):
         from klangk_backend.wshandler import WS_ERRORS
 
         sock = _mock_sock()
         sock.send_json = MagicMock(side_effect=WS_ERRORS[0]("dead"))
         try:
-            conn = self._register(
-                sock, {"id": "u1", "email": "a@x"}, wants=True
-            )
-            with patch.object(conn, "cleanup", new_callable=AsyncMock) as mock:
-                wshandler.state.send_health_heartbeats()
-                await asyncio.sleep(0)
-                mock.assert_awaited_once()
+            self._register(sock, {"id": "u1", "email": "a@x"}, wants=True)
+            wshandler.state.send_health_heartbeats()
             assert sock not in wshandler.state.connections
         finally:
             wshandler.state.connections.pop(sock, None)


### PR DESCRIPTION
## Summary
- Remove `asyncio.create_task(conn.cleanup())` from four broadcast iteration helpers (`notify_container_status`, `notify_service_health`, `send_health_heartbeats`, `notify_user_workspaces_changed`)
- Keep the inline `connections.pop()` to prevent retrying dead sockets on the next broadcast
- `dispatch.py`'s `finally` block is now the single owner of connection cleanup, eliminating the double-cleanup race

Closes #1301