### PR TITLE
fix(frontend): guard _loadFiles against concurrent call desync

### DIFF
--- a/src/frontend/lib/file_viewer/file_viewer_panel.dart
+++ b/src/frontend/lib/file_viewer/file_viewer_panel.dart
@@ -75,6 +75,7 @@ class FileViewerPanelState extends State<FileViewerPanel> {
   late String _currentPath = widget.userHome ?? '/';
   String? _selectedFile;
   bool _loading = false;
+  int _loadGeneration = 0;
   late final FileRendererRegistry _registry;
 
   /// Refresh the file list for the current directory, bypassing the cache
@@ -152,6 +153,7 @@ class FileViewerPanelState extends State<FileViewerPanel> {
 
   Future<void> _loadFiles({bool force = false}) async {
     if (!mounted) return;
+    final generation = ++_loadGeneration;
     // Read-through cache: a fresh-enough hit renders instantly and skips
     // the listing round-trip (~250-440ms), so navigating back to a recently
     // viewed directory feels instantaneous. `force` (manual refresh, or a
@@ -166,26 +168,31 @@ class FileViewerPanelState extends State<FileViewerPanel> {
         return;
       }
     }
+    final requestedPath = _currentPath;
     setState(() => _loading = true);
     try {
       final response = await _client.get(
         Uri.parse(
-          '$_baseUrl/api/v1/workspaces/${widget.workspaceId}/files?path=${Uri.encodeComponent(_currentPath)}',
+          '$_baseUrl/api/v1/workspaces/${widget.workspaceId}/files?path=${Uri.encodeComponent(requestedPath)}',
         ),
         headers: _headers,
       );
+      if (generation != _loadGeneration) return;
       if (response.statusCode == 200) {
         final data = jsonDecode(response.body) as List;
         final entries = data.cast<Map<String, dynamic>>();
-        _fileListCache.put(widget.workspaceId, _currentPath, entries);
+        _fileListCache.put(widget.workspaceId, requestedPath, entries);
         if (mounted) setState(() => _entries = entries);
       } else {
         debugPrint('File listing failed: ${response.statusCode}');
       }
     } catch (e) {
+      if (generation != _loadGeneration) return;
       debugPrint('File listing error: $e');
     } finally {
-      if (mounted) setState(() => _loading = false);
+      if (generation == _loadGeneration && mounted) {
+        setState(() => _loading = false);
+      }
     }
   }
 

--- a/src/frontend/test/file_viewer_panel_test.dart
+++ b/src/frontend/test/file_viewer_panel_test.dart
@@ -1678,4 +1678,98 @@ void main() {
       expect(err.toString(), contains('Failed to download'));
     });
   });
+
+  group('load-generation guard', () {
+    testWidgets('stale response from superseded _loadFiles is discarded',
+        (tester) async {
+      // Two completers let us control when each listing response arrives.
+      final completers = <String, Completer<http.Response>>{};
+      testHttpClientOverride = MockClient((request) async {
+        if (request.method == 'GET' &&
+            request.url.path.contains('/files') &&
+            !request.url.path.contains('/content') &&
+            !request.url.path.contains('/download')) {
+          final path = request.url.queryParameters['path'] ?? '';
+          final c = Completer<http.Response>();
+          completers[path] = c;
+          return c.future;
+        }
+        return http.Response('Not found', 404);
+      });
+      clearFileListCacheForTest();
+
+      final client = _MockWsClient();
+      final key = GlobalKey<FileViewerPanelState>();
+      await tester.pumpWidget(MaterialApp(
+          home: Scaffold(
+              body: SizedBox(
+                  width: 800,
+                  height: 600,
+                  child: buildPanel(wsClient: client, key: key)))));
+      // Don't pumpAndSettle — the initial load is blocked on the completer.
+      await tester.pump();
+
+      // Complete the initial load for /home/tester so the panel is ready.
+      completers['/home/tester']!.complete(http.Response(
+        jsonEncode([
+          {
+            'name': 'sub',
+            'path': '/home/tester/sub',
+            'is_dir': true,
+            'size': null,
+          },
+        ]),
+        200,
+      ));
+      await tester.pumpAndSettle();
+      expect(key.currentState!.currentPathForTest, '/home/tester');
+
+      // Navigate to /home/tester/sub — fires request A.
+      key.currentState!.openDir('/home/tester/sub');
+      await tester.pump();
+
+      // Before A resolves, navigate to /etc — fires request B, superseding A.
+      key.currentState!.openDir('/etc');
+      await tester.pump();
+
+      // Complete request A (the stale one) first.
+      completers['/home/tester/sub']!.complete(http.Response(
+        jsonEncode([
+          {
+            'name': 'stale.txt',
+            'path': '/home/tester/sub/stale.txt',
+            'is_dir': false,
+            'size': 1,
+          },
+        ]),
+        200,
+      ));
+      await tester.pump();
+
+      // The stale response must be discarded — path should still be /etc,
+      // and the stale file should not appear.
+      expect(key.currentState!.currentPathForTest, '/etc');
+      expect(find.text('stale.txt'), findsNothing);
+
+      // Now complete request B (the current one).
+      completers['/etc']!.complete(http.Response(
+        jsonEncode([
+          {
+            'name': 'fresh.txt',
+            'path': '/etc/fresh.txt',
+            'is_dir': false,
+            'size': 2,
+          },
+        ]),
+        200,
+      ));
+      await tester.pumpAndSettle();
+
+      // The current response should be applied.
+      expect(key.currentState!.currentPathForTest, '/etc');
+      expect(find.text('fresh.txt'), findsOneWidget);
+
+      client.close();
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- Add a generation counter to `_loadFiles` so only the most recent in-flight listing response is applied; stale responses from superseded navigations are silently discarded
- Capture `requestedPath` before the await to ensure the cache is keyed correctly even if `_currentPath` changes during the fetch
- Add test that uses `Completer`s to simulate out-of-order response arrival and verifies the stale response is dropped

Fixes #1302

## Test plan
- [x] All 49 file_viewer_panel_test.dart tests pass
- [x] New `load-generation guard` test verifies stale responses are discarded