### PR TITLE
fix(frontend): route _reconnect through WorkspaceConnector to prevent double workspace_connect

### DIFF
--- a/src/frontend/lib/workspace/workspace_connector.dart
+++ b/src/frontend/lib/workspace/workspace_connector.dart
@@ -48,7 +48,41 @@ class WorkspaceConnector {
   /// Whether [connect] has been called and subscriptions are active.
   bool get isActive => _browserDelegate != null;
 
+  /// Whether a connect/reconnect is currently in progress.
+  bool _inProgress = false;
+
   Future<void> connect() async {
+    if (_inProgress) {
+      debugPrint('[WorkspaceConnector] connect already in progress, skipping');
+      return;
+    }
+    _inProgress = true;
+    try {
+      await _doConnect();
+    } finally {
+      _inProgress = false;
+    }
+  }
+
+  /// Reconnect after a disconnect.  Tears down existing subscriptions
+  /// first so we don't end up with duplicate listeners.
+  Future<void> reconnect() async {
+    if (_inProgress) {
+      debugPrint(
+        '[WorkspaceConnector] reconnect already in progress, skipping',
+      );
+      return;
+    }
+    _inProgress = true;
+    try {
+      dispose();
+      await _doConnect();
+    } finally {
+      _inProgress = false;
+    }
+  }
+
+  Future<void> _doConnect() async {
     debugPrint(
       '[WorkspaceConnector] connect called: ${DateTime.now()}',
     );

--- a/src/frontend/lib/workspace/workspace_page.dart
+++ b/src/frontend/lib/workspace/workspace_page.dart
@@ -369,13 +369,7 @@ class _WorkspacePageState extends State<WorkspacePage> {
 
   Future<void> _reconnect() async {
     setState(() => _connecting = true);
-    final wsClient = context.read<WsClient>();
-    await wsClient.connect();
-    if (wsClient.connected) {
-      wsClient.connectWorkspace(widget.workspaceId);
-    } else {
-      setState(() => _connecting = false);
-    }
+    await _connector?.reconnect();
   }
 
   @override

--- a/src/frontend/test/workspace_connector_test.dart
+++ b/src/frontend/test/workspace_connector_test.dart
@@ -243,6 +243,102 @@ void main() {
       ws.close();
     });
 
+    test('reconnect disposes old subscriptions and reconnects', () async {
+      final ws = _MockWsClient();
+      int connectedCount = 0;
+
+      final connector = WorkspaceConnector(
+        wsClient: ws,
+        workspaceId: 'ws-1',
+        pluginRegistry: ToolPluginRegistry(),
+        onConnected: ({required connected, error}) {
+          if (connected) connectedCount++;
+        },
+        onContainerEvent: (_, __) {},
+        onSharedTerminalDeleted: (_) {},
+        onPermissionError: (_) {},
+      );
+
+      await connector.connect();
+      expect(connectedCount, 1);
+      expect(connector.isActive, isTrue);
+
+      // Simulate disconnect
+      ws._connected = false;
+      ws.connectCalled = false;
+      ws.connectedWorkspaceId = null;
+
+      await connector.reconnect();
+      expect(connectedCount, 2);
+      expect(ws.connectCalled, isTrue);
+      expect(ws.connectedWorkspaceId, 'ws-1');
+      expect(connector.isActive, isTrue);
+
+      connector.dispose();
+      ws.close();
+    });
+
+    test('concurrent connect calls are deduplicated', () async {
+      final ws = _MockWsClient();
+      int connectedCount = 0;
+
+      final connector = WorkspaceConnector(
+        wsClient: ws,
+        workspaceId: 'ws-1',
+        pluginRegistry: ToolPluginRegistry(),
+        onConnected: ({required connected, error}) {
+          if (connected) connectedCount++;
+        },
+        onContainerEvent: (_, __) {},
+        onSharedTerminalDeleted: (_) {},
+        onPermissionError: (_) {},
+      );
+
+      // Fire two connects concurrently
+      final f1 = connector.connect();
+      final f2 = connector.connect();
+      await Future.wait([f1, f2]);
+
+      // Only one should have executed
+      expect(connectedCount, 1);
+
+      connector.dispose();
+      ws.close();
+    });
+
+    test('concurrent reconnect calls are deduplicated', () async {
+      final ws = _MockWsClient();
+      int connectedCount = 0;
+
+      final connector = WorkspaceConnector(
+        wsClient: ws,
+        workspaceId: 'ws-1',
+        pluginRegistry: ToolPluginRegistry(),
+        onConnected: ({required connected, error}) {
+          if (connected) connectedCount++;
+        },
+        onContainerEvent: (_, __) {},
+        onSharedTerminalDeleted: (_) {},
+        onPermissionError: (_) {},
+      );
+
+      await connector.connect();
+      expect(connectedCount, 1);
+
+      ws._connected = false;
+      ws.connectCalled = false;
+
+      final f1 = connector.reconnect();
+      final f2 = connector.reconnect();
+      await Future.wait([f1, f2]);
+
+      // Only one reconnect should have executed
+      expect(connectedCount, 2);
+
+      connector.dispose();
+      ws.close();
+    });
+
     test('dispose cancels subscriptions', () async {
       final ws = _MockWsClient();
 


### PR DESCRIPTION
## Summary
- `_reconnect` was calling `wsClient.connect()` and `connectWorkspace()` directly, bypassing `WorkspaceConnector`. If auto-reconnect fired concurrently with a manual "Reconnect" tap, the server received duplicate `workspace_connect` commands and could fire `ui_ready` twice.
- Added `reconnect()` method to `WorkspaceConnector` that disposes old subscriptions before reconnecting, and an `_inProgress` guard to deduplicate concurrent calls.
- `_WorkspacePageState._reconnect` now delegates to `_connector?.reconnect()`.

## Test plan
- [x] All 10 `workspace_connector_test.dart` tests pass (3 new: reconnect, concurrent connect dedup, concurrent reconnect dedup)
- [ ] Manual: disconnect WebSocket, tap Reconnect — verify single `workspace_connect` sent

Closes #1304