### PR TITLE
fix(backend): make get_or_create_session atomic with setdefault

### DIFF
--- a/src/backend/klangk_backend/wshandler/session.py
+++ b/src/backend/klangk_backend/wshandler/session.py
@@ -375,9 +375,11 @@ class WebSocketState:
         return self.sessions.get(workspace_id)
 
     def get_or_create_session(self, workspace_id: str) -> WorkspaceSession:
-        if workspace_id not in self.sessions:
-            self.sessions[workspace_id] = WorkspaceSession(workspace_id)
-        return self.sessions[workspace_id]
+        try:
+            return self.sessions[workspace_id]
+        except KeyError:
+            session = WorkspaceSession(workspace_id)
+            return self.sessions.setdefault(workspace_id, session)
 
     async def remove_session(self, workspace_id: str) -> None:
         """Remove workspace session (acquires session lock).

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -4573,6 +4573,36 @@ class TestRemoveSessionLocked:
             wshandler.state.sessions.pop("ws-locked-rm", None)
 
 
+class TestGetOrCreateSessionAtomicity:
+    async def test_returns_same_session_for_same_workspace(self):
+        """Concurrent calls return the same WorkspaceSession, not duplicates."""
+        wshandler.state.sessions.pop("ws-atomic", None)
+        try:
+            s1 = wshandler.state.get_or_create_session("ws-atomic")
+            s2 = wshandler.state.get_or_create_session("ws-atomic")
+            assert s1 is s2
+        finally:
+            wshandler.state.sessions.pop("ws-atomic", None)
+
+    async def test_concurrent_get_or_create_via_gather(self):
+        """Two coroutines that both call get_or_create_session end up
+        with the identical session object (no orphaned duplicates)."""
+        wshandler.state.sessions.pop("ws-gather", None)
+        sessions = []
+
+        async def grab():
+            s = wshandler.state.get_or_create_session("ws-gather")
+            await asyncio.sleep(0)  # yield to let the other coroutine run
+            sessions.append(s)
+
+        try:
+            await asyncio.gather(grab(), grab())
+            assert len(sessions) == 2
+            assert sessions[0] is sessions[1]
+        finally:
+            wshandler.state.sessions.pop("ws-gather", None)
+
+
 class TestCleanupSubscriberRace:
     async def test_new_subscriber_not_lost_during_cleanup(self):
         """A subscriber added under the lock while cleanup runs is not lost."""


### PR DESCRIPTION
## Summary
- Replace check-then-set pattern in `get_or_create_session` with `try`/`except KeyError` + `dict.setdefault`, ensuring concurrent callers always get the same `WorkspaceSession` instance
- Prevents orphaned sessions and split-brain subscriber broadcasts described in #1297
- Added `TestGetOrCreateSessionAtomicity` with identity and `asyncio.gather` concurrency tests

## Test plan
- [x] New unit tests pass (`TestGetOrCreateSessionAtomicity`)
- [x] Full backend test suite passes (2163 tests, 100% coverage)
- [ ] CI green

Closes #1297