### PR TITLE
fix(frontend): guard showMenu .then callback with mounted check

### DIFF
--- a/src/frontend/lib/file_viewer/file_viewer_panel.dart
+++ b/src/frontend/lib/file_viewer/file_viewer_panel.dart
@@ -491,6 +491,7 @@ class FileViewerPanelState extends State<FileViewerPanel> {
         ),
       ],
     ).then((action) {
+      if (!mounted || action == null) return;
       if (action == 'download') {
         _downloadPath(path, name, isDir);
       } else if (action == 'rename') {


### PR DESCRIPTION
## Summary
- Add `mounted` guard in the `showMenu().then` callback so `_deletePath`, `_renamePath`, and `_downloadPath` are not called after the widget is disposed (#1306)

## Test plan
- [x] All 49 file_viewer_panel tests pass

Closes #1306