### PR TITLE
fix(backend): remove workspace state save/restore (#1316)

### DIFF
--- a/src/backend/klangk_backend/terminal.py
+++ b/src/backend/klangk_backend/terminal.py
@@ -11,7 +11,6 @@ import asyncio
 import codecs
 import fcntl
 import re
-import json
 import logging
 import os
 import pty
@@ -90,8 +89,6 @@ def build_environment(
         env.append(f"SSH_AUTH_SOCK={ssh_agent_socket}")
     return env
 
-
-_WORKSPACE_STATE_FILE = ".workspace-state.json"
 
 # Name of the dedicated tmux window that runs a workspace's
 # service_command, leaving the user's interactive window 0 free.
@@ -681,64 +678,6 @@ async def close_window(
         ["kill-window", "-t", t],
     )
     return await list_windows(container_id, session_name)
-
-
-_STATE_PATH = f"/home/{_WORKSPACE_STATE_FILE}"
-
-
-async def load_workspace_state(container_id: str) -> dict:
-    """Read per-user workspace state from /home/.workspace-state.json.
-
-    Returns a dict keyed by handle, e.g.
-    ``{"admin": {"terminal_windows": [...], ...}, ...}``.
-    Returns empty dict if the file doesn't exist or is corrupt.
-    Used for restoring state after container restart.
-    """
-    rc, stdout, _ = await podman.exec_container(
-        container_id,
-        ["cat", _STATE_PATH],
-        user=CONTAINER_USER,
-        timeout=10,
-    )
-    if rc != 0:
-        return {}
-    try:
-        return json.loads(stdout)
-    except (json.JSONDecodeError, ValueError):
-        return {}
-
-
-async def save_workspace_state(container_id: str, state: dict) -> None:
-    """Snapshot per-user workspace state.
-
-    Delegates to ``klangk-save-workspace-state`` inside the container,
-    which atomically writes stdin to the target path via mktemp + rename.
-    Callers should serialize access via WorkspaceSession.save_lock.
-    """
-    data = json.dumps(state, indent=2)
-    await podman.exec_container(
-        container_id,
-        ["klangk-save-workspace-state", _STATE_PATH],
-        user=CONTAINER_USER,
-        stdin_data=data.encode(),
-        timeout=10,
-    )
-
-
-async def restore_windows(
-    container_id: str, session_name: str, saved_windows: list[dict]
-) -> None:
-    """Create any missing tmux windows from saved state.
-
-    Compares saved window names against existing windows and creates
-    any that are missing.
-    """
-    existing = await list_windows(container_id, session_name)
-    existing_names = {w["name"] for w in existing}
-    for win in saved_windows:
-        name = win.get("name", "")
-        if name and name not in existing_names:
-            await new_window(container_id, session_name, name=name)
 
 
 async def kill_joiner_sessions(container_id: str, owner_handle: str) -> None:

--- a/src/backend/klangk_backend/wshandler/connection.py
+++ b/src/backend/klangk_backend/wshandler/connection.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta, timezone
 
 
 from .. import acl as _acl
-from .. import agent, auth, container, model, terminal, workspaces
+from .. import agent, auth, container, model, workspaces
 from ..terminal import TerminalSession
 from ..podman import ExecSession
 from ..util import derive_hosting_info
@@ -566,20 +566,7 @@ class Connection:
 
         workspace_id = self.workspace_id
         container_id = self.container_id
-
-        # Save terminal state before shutting down so it can be restored
-        # when the container restarts.
         session = state.get_session(workspace_id)
-        if session:
-            snapshot = {
-                uid: [dict(w) for w in wins]
-                for uid, wins in session.terminal_windows.items()
-            }
-            if snapshot:
-                try:
-                    await terminal.save_workspace_state(container_id, snapshot)
-                except Exception as e:
-                    logger.warning("State save before shutdown failed: %s", e)
 
         # Clear container_id on ALL connections to prevent stale exec attempts.
         for sock, conn_obj in list(state.connections.items()):

--- a/src/backend/klangk_backend/wshandler/controllers.py
+++ b/src/backend/klangk_backend/wshandler/controllers.py
@@ -367,30 +367,12 @@ class TerminalController:
             )
         self._conn.browser_id = browser_id
 
-    async def _restore_and_sync_windows(self) -> None:
-        """Restore saved window state and sync with tmux.
-
-        On first terminal_start after restart, loads the saved
-        snapshot from the container.  Then lists current tmux
-        windows, syncs in-memory state, and sends the window list
-        and shared terminals to the client.
-        """
+    async def _sync_windows(self) -> None:
+        """List current tmux windows, sync in-memory state, and send
+        the window list and shared terminals to the client."""
         conn = self._conn
         sname = conn.tmux_session_name()
-        user_id = conn.user["id"]
         ws_session = state.get_session(conn.workspace_id)
-
-        if ws_session and user_id not in ws_session.terminal_windows:
-            saved = await terminal.load_workspace_state(conn.container_id)
-            if user_id in saved:
-                saved_windows = saved[user_id]
-                await terminal.restore_windows(
-                    conn.container_id, sname, saved_windows
-                )
-                ws_session.terminal_windows[user_id] = saved_windows
-                for uid, wins in saved.items():
-                    if uid != user_id:
-                        ws_session.terminal_windows.setdefault(uid, wins)
 
         windows = await terminal.list_windows(conn.container_id, sname)
         conn.sync_terminal_windows(windows)
@@ -593,7 +575,7 @@ class TerminalController:
                     return
                 conn.sock.send_json({"type": "terminal_started"})
                 try:
-                    await ctrl._restore_and_sync_windows()
+                    await ctrl._sync_windows()
                 except (TerminalError, OSError):
                     logger.exception("_start_terminal: window list failed")
                 ctrl._send_shared_terminals()

--- a/src/backend/klangk_backend/wshandler/session.py
+++ b/src/backend/klangk_backend/wshandler/session.py
@@ -91,9 +91,8 @@ class WorkspaceSession:
         self.lock = asyncio.Lock()
         # Per-user terminal window state, keyed by user_id.
         # Each value is a list of {"name": str, "shared": bool}.
-        # This is the in-memory authority; snapshots are persisted
-        # to /home/.workspace-state.json for crash recovery. The agent's
-        # ``service`` session windows are keyed by AGENT_USER_ID (#1133).
+        # The agent's ``service`` session windows are keyed by
+        # AGENT_USER_ID (#1133).
         self.terminal_windows: dict[str, list[dict]] = {}
         # Cached agent handle so the ``service:service-cmd`` window stays
         # attributable (and visible in the shared list) even though the
@@ -101,7 +100,6 @@ class WorkspaceSession:
         # "offline" the way the owner could be under the old model
         # (#1133). Populated by ``_sync_service_windows``.
         self.agent_handle: str | None = None
-        self.save_lock = asyncio.Lock()
         # Workspace token renewal tracking.
         self.workspace_token_expiry: datetime | None = None
         self._token_renewal_task: asyncio.Task | None = None

--- a/src/backend/tests/test_terminal.py
+++ b/src/backend/tests/test_terminal.py
@@ -7,7 +7,6 @@ lifecycle/queue logic against an injected fake shell.
 
 import asyncio
 import contextlib
-import json
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -25,11 +24,8 @@ from klangk_backend.terminal import (
     close_window,
     kill_joiner_sessions,
     list_windows,
-    load_workspace_state,
     new_window,
     rename_window,
-    restore_windows,
-    save_workspace_state,
     select_window,
     terminal_tmux_enabled,
     tmux_command,
@@ -972,105 +968,6 @@ class TestBuildShellCommandTmuxDisabled:
         )
         assert "tmux" in cmd
         assert unique is not None
-
-
-class TestLoadWorkspaceState:
-    async def test_loads_state(self):
-        state = {"admin": [{"name": "1", "shared": False}]}
-        with patch(
-            "klangk_backend.terminal.podman.exec_container",
-            new_callable=AsyncMock,
-            return_value=(0, json.dumps(state), ""),
-        ) as mock_exec:
-            result = await load_workspace_state("cid")
-        assert result == state
-        mock_exec.assert_awaited_once_with(
-            "cid",
-            ["cat", "/home/.workspace-state.json"],
-            user=CONTAINER_USER,
-            timeout=10,
-        )
-
-    async def test_missing_file(self):
-        with patch(
-            "klangk_backend.terminal.podman.exec_container",
-            new_callable=AsyncMock,
-            return_value=(1, "", "No such file"),
-        ):
-            result = await load_workspace_state("cid")
-        assert result == {}
-
-    async def test_corrupt_json(self):
-        with patch(
-            "klangk_backend.terminal.podman.exec_container",
-            new_callable=AsyncMock,
-            return_value=(0, "not json{", ""),
-        ):
-            result = await load_workspace_state("cid")
-        assert result == {}
-
-
-class TestSaveWorkspaceState:
-    async def test_saves_state(self):
-        with patch(
-            "klangk_backend.terminal.podman.exec_container",
-            new_callable=AsyncMock,
-            return_value=(0, "", ""),
-        ) as mock_exec:
-            await save_workspace_state(
-                "cid", {"admin": [{"name": "1", "shared": False}]}
-            )
-        mock_exec.assert_awaited_once()
-        cmd = mock_exec.call_args.args[1]
-        assert cmd == [
-            "klangk-save-workspace-state",
-            "/home/.workspace-state.json",
-        ]
-        assert mock_exec.call_args.kwargs["user"] == CONTAINER_USER
-        assert b'"admin"' in mock_exec.call_args.kwargs["stdin_data"]
-
-
-class TestRestoreWindows:
-    async def test_creates_missing_windows(self):
-        with patch(
-            "klangk_backend.terminal.list_windows",
-            return_value=[{"name": "1", "index": 0, "active": True}],
-        ):
-            with patch(
-                "klangk_backend.terminal.new_window",
-                return_value=[],
-            ) as mock_new:
-                await restore_windows(
-                    "cid",
-                    "admin",
-                    [
-                        {"name": "1", "shared": False},
-                        {"name": "build", "shared": True},
-                    ],
-                )
-        # Only "build" should be created (1 already exists)
-        mock_new.assert_called_once_with("cid", "admin", name="build")
-
-    async def test_no_missing_windows(self):
-        with patch(
-            "klangk_backend.terminal.list_windows",
-            return_value=[
-                {"name": "1", "index": 0, "active": True},
-                {"name": "build", "index": 1, "active": False},
-            ],
-        ):
-            with patch(
-                "klangk_backend.terminal.new_window",
-            ) as mock_new:
-                await restore_windows(
-                    "cid",
-                    "admin",
-                    [
-                        {"name": "1", "shared": False},
-                        {"name": "build", "shared": True},
-                    ],
-                )
-        mock_new.assert_not_called()
 
 
 class TestKillJoinerSessions:

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -822,11 +822,6 @@ class TestHandleTerminalStart:
                     {"id": "@0", "index": 0, "name": "bash", "active": True}
                 ],
             ),
-            patch(
-                "klangk_backend.terminal.load_workspace_state",
-                return_value={},
-            ),
-            patch("klangk_backend.terminal.restore_windows"),
             patch.object(_ws_controllers, "attach_browser"),
             patch.object(
                 _ws_controllers.TerminalController,
@@ -924,11 +919,6 @@ class TestHandleTerminalStart:
                     {"id": "@0", "index": 0, "name": "bash", "active": True}
                 ],
             ),
-            patch(
-                "klangk_backend.terminal.load_workspace_state",
-                return_value={},
-            ),
-            patch("klangk_backend.terminal.restore_windows"),
             patch.object(_ws_controllers, "attach_browser"),
             patch(
                 "klangk_backend.wshandler.controllers.model.get_workspace",
@@ -970,96 +960,6 @@ class TestHandleTerminalStart:
             await conn.terminal_task
         except asyncio.CancelledError:
             pass
-        container.registry.revoke_workspace_browsers("ws")
-        container.registry.states.pop("ws", None)
-
-    async def test_starts_session_restores_saved_state(self):
-        """On first terminal_start, saved state is loaded and restored."""
-        sock = _mock_sock()
-        conn = _base_conn(ws=sock)
-        conn.container_id = "cid"
-        conn.workspace_id = "ws"
-        conn._user_home = "/home/testuser"
-
-        async def _perm(*a):
-            return True
-
-        conn._has_perm = _perm  # type: ignore[method-assign]
-        container.registry.track_activity("cid", "ws")
-
-        session = wshandler.state.get_or_create_session("ws")
-        # Do NOT pre-populate terminal_windows — simulates restart
-        await session.add_subscriber(sock, "cid")
-        wshandler.state.connections[sock] = conn
-
-        saved_state = {
-            "uid": [
-                {"name": "1", "index": 0, "id": "@0", "shared": False},
-                {"name": "build", "index": 1, "id": "@1", "shared": True},
-            ],
-            "other-uid": [
-                {"name": "1", "shared": False},
-                {"name": "dev", "shared": True},
-            ],
-        }
-
-        with (
-            patch.object(_ws_controllers, "TerminalSession") as MockTS,
-            patch(
-                "klangk_backend.terminal.list_windows",
-                return_value=[
-                    {"id": "@0", "index": 0, "name": "1", "active": True},
-                    {"id": "@1", "index": 1, "name": "build", "active": False},
-                ],
-            ),
-            patch("klangk_backend.terminal.tmux_command", return_value=""),
-            patch(
-                "klangk_backend.terminal.load_workspace_state",
-                return_value=saved_state,
-            ),
-            patch("klangk_backend.terminal.restore_windows") as mock_restore,
-            patch("klangk_backend.terminal.save_workspace_state"),
-        ):
-            mock_session = _mock_terminal()
-            MockTS.return_value = mock_session
-
-            async def fake_output():
-                return
-                yield
-
-            mock_session.output = fake_output
-
-            await conn.handle_terminal_start({"cols": 80, "rows": 24})
-            await asyncio.sleep(0)
-
-        # restore_windows called with saved windows
-        mock_restore.assert_awaited_once_with(
-            "cid",
-            "uid",
-            saved_state["uid"],
-        )
-        # terminal_windows populated from saved state
-        ws_session = wshandler.state.sessions["ws"]
-        assert "uid" in ws_session.terminal_windows
-        # "build" should retain shared=True from saved state
-        build_win = [
-            w
-            for w in ws_session.terminal_windows["uid"]
-            if w["name"] == "build"
-        ]
-        assert len(build_win) == 1
-        assert build_win[0]["shared"] is True
-        # Other user's state also restored
-        assert "other-uid" in ws_session.terminal_windows
-        assert ws_session.terminal_windows["other-uid"][1]["shared"] is True
-
-        conn.terminal_task.cancel()
-        try:
-            await conn.terminal_task
-        except asyncio.CancelledError:
-            pass
-        wshandler.state.sessions.pop("ws", None)
-        wshandler.state.connections.pop(sock, None)
         container.registry.revoke_workspace_browsers("ws")
         container.registry.states.pop("ws", None)
 
@@ -3210,10 +3110,6 @@ class TestSSHAgentHandlers:
                 "klangk_backend.terminal.list_windows",
                 return_value=[],
             ),
-            patch(
-                "klangk_backend.terminal.load_workspace_state",
-                return_value=None,
-            ),
             patch.object(
                 conn,
                 "_has_perm",
@@ -5240,73 +5136,6 @@ class TestHandleShutdownContainer:
 
         wshandler.state.connections.pop(sock1, None)
         wshandler.state.connections.pop(sock2, None)
-        wshandler.state.sessions.pop(ws["id"], None)
-
-    async def test_shutdown_saves_terminal_state(self, user):
-        sock = _mock_sock()
-        conn = _base_conn(user=user, ws=sock)
-        ws = await _create_workspace_with_acl(user["id"], "shutdown-save")
-        conn.workspace_id = ws["id"]
-        conn.container_id = "cid"
-
-        session = wshandler.state.get_or_create_session(ws["id"])
-        session.terminal_windows[user["id"]] = [
-            {"name": "bash", "index": 0, "id": "@0", "shared": False},
-        ]
-        await session.add_subscriber(sock, "cid")
-
-        with (
-            patch.object(
-                container.registry,
-                "stop_and_remove_container",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "klangk_backend.terminal.save_workspace_state",
-                new_callable=AsyncMock,
-            ) as mock_save,
-        ):
-            await conn.handle_shutdown_container()
-
-        mock_save.assert_awaited_once()
-        saved_snapshot = mock_save.call_args[0][1]
-        assert user["id"] in saved_snapshot
-        wshandler.state.sessions.pop(ws["id"], None)
-
-    async def test_shutdown_state_save_failure_does_not_block(self, user):
-        sock = _mock_sock()
-        conn = _base_conn(user=user, ws=sock)
-        ws = await _create_workspace_with_acl(user["id"], "shutdown-savefail")
-        conn.workspace_id = ws["id"]
-        conn.container_id = "cid"
-
-        session = wshandler.state.get_or_create_session(ws["id"])
-        session.terminal_windows[user["id"]] = [
-            {"name": "bash", "index": 0, "id": "@0", "shared": False},
-        ]
-        await session.add_subscriber(sock, "cid")
-
-        with (
-            patch.object(
-                container.registry,
-                "stop_and_remove_container",
-                new_callable=AsyncMock,
-            ),
-            patch(
-                "klangk_backend.terminal.save_workspace_state",
-                new_callable=AsyncMock,
-                side_effect=RuntimeError("write failed"),
-            ),
-        ):
-            await conn.handle_shutdown_container()
-
-        # Should not raise; container_stopped event still sent
-        sent = [c[0][0] for c in sock.send_json.call_args_list]
-        assert any(
-            isinstance(m, dict)
-            and m.get("event", {}).get("name") == "container_stopped"
-            for m in sent
-        )
         wshandler.state.sessions.pop(ws["id"], None)
 
     async def test_shutdown_handles_stop_error(self, user):

--- a/src/containers/workspace/Dockerfile
+++ b/src/containers/workspace/Dockerfile
@@ -50,7 +50,6 @@ COPY klangk-browser-id.sh /opt/klangk/bin/klangk-browser-id
 COPY klangk-copy-to-clipboard.py /opt/klangk/bin/klangk-copy-to-clipboard
 COPY klangk-configure-sudo.sh /opt/klangk/bin/klangk-configure-sudo
 COPY klangk-hosted-url.sh /opt/klangk/bin/klangk-hosted-url
-COPY klangk-save-workspace-state.sh /opt/klangk/bin/klangk-save-workspace-state
 COPY klangk-set-workspace-token.sh /opt/klangk/bin/klangk-set-workspace-token
 COPY klangk-workspace-token.sh /opt/klangk/bin/klangk-workspace-token
 RUN chmod +x /opt/klangk/entrypoint.sh \
@@ -61,7 +60,6 @@ RUN chmod +x /opt/klangk/entrypoint.sh \
       /opt/klangk/bin/klangk-configure-sudo \
       /opt/klangk/bin/klangk-copy-to-clipboard \
       /opt/klangk/bin/klangk-hosted-url \
-      /opt/klangk/bin/klangk-save-workspace-state \
       /opt/klangk/bin/klangk-set-workspace-token \
       /opt/klangk/bin/klangk-workspace-token
 # System-wide environment exports for ALL login shells (interactive AND

--- a/src/containers/workspace/klangk-save-workspace-state.sh
+++ b/src/containers/workspace/klangk-save-workspace-state.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-# Atomically write stdin to a target file via mktemp + rename.
-# Usage: klangk-save-workspace-state <path>
-set -e
-target="${1:-/home/.workspace-state.json}"
-t=$(mktemp "${target}.XXXXXX")
-trap 'rm -f "$t"' EXIT
-cat >"$t" && mv "$t" "$target"
-trap - EXIT


### PR DESCRIPTION
## Summary
- Remove `load_workspace_state()`, `save_workspace_state()`, `restore_windows()`, `_STATE_PATH`, `_WORKSPACE_STATE_FILE` from `terminal.py`
- Remove `save_lock` from `WorkspaceSession`
- Remove snapshot-building + save call from `handle_shutdown_container` in `connection.py`
- Replace `_restore_and_sync_windows()` with `_sync_windows()` in `controllers.py` (restore logic removed, sync retained)
- Delete `klangk-save-workspace-state.sh` and its Dockerfile COPY/chmod
- Remove all related tests

Closes #1316

## Test plan
- [x] All backend tests pass (2154 passed)
- [x] No remaining references to removed functions