### PR TITLE
feat: allow workspace owner or admin to transfer ownership

### DIFF
--- a/src/backend/klangk_backend/api/workspaces.py
+++ b/src/backend/klangk_backend/api/workspaces.py
@@ -1029,6 +1029,37 @@ async def replace_workspace_acl(
     return await model.get_acl_entries_resolved(resource)
 
 
+# --- Ownership transfer ---
+
+
+class TransferOwnershipRequest(BaseModel):
+    email: str
+
+
+@router.post("/workspaces/{workspace_id}/transfer")
+async def transfer_workspace_ownership(
+    workspace_id: str,
+    body: TransferOwnershipRequest,
+    user: dict = Depends(acl.has_permission("admin", workspace_resource)),
+):
+    """Transfer workspace ownership to another user."""
+    target = await model.get_user_by_email(body.email)
+    if target is None:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    try:
+        ws = await model.transfer_workspace(workspace_id, target["id"])
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    if ws is None:  # pragma: no cover — ACL check rejects first
+        raise HTTPException(status_code=404, detail="Workspace not found")
+
+    wshandler.state.notify_user_workspaces_changed(user["id"])
+    wshandler.state.notify_user_workspaces_changed(target["id"])
+    return ws
+
+
 # --- User search endpoint ---
 
 

--- a/src/backend/klangk_backend/model/__init__.py
+++ b/src/backend/klangk_backend/model/__init__.py
@@ -113,6 +113,7 @@ from .workspaces import (
     list_auto_start_workspaces,
     list_shared_workspaces,
     list_workspaces,
+    transfer_workspace,
     update_workspace,
     update_workspace_container,
     SETUP_STATE_COMPLETE,
@@ -256,6 +257,7 @@ __all__ = (
     "list_auto_start_workspaces",
     "list_shared_workspaces",
     "list_workspaces",
+    "transfer_workspace",
     "update_workspace",
     "update_workspace_container",
     # setup_state lifecycle (#1033)

--- a/src/backend/klangk_backend/model/workspaces.py
+++ b/src/backend/klangk_backend/model/workspaces.py
@@ -594,6 +594,88 @@ async def update_workspace(
         return cursor.rowcount > 0
 
 
+async def transfer_workspace(
+    workspace_id: str,
+    new_owner_id: str,
+) -> dict | None:
+    """Transfer workspace ownership to a different user.
+
+    Updates the workspace ``user_id``, the owner ACE (position 0), and
+    the ``owners`` role group membership atomically.  Returns the
+    updated workspace dict, or ``None`` if the workspace does not exist.
+
+    Raises ``ValueError`` if the new owner already owns a workspace
+    with the same name (violating the UNIQUE constraint) or if the
+    target is the system agent.
+    """
+    if new_owner_id == AGENT_USER_ID:
+        raise AgentPrincipalError(
+            "Cannot transfer a workspace to the system agent"
+        )
+
+    async with transaction() as db:
+        cursor = await db.execute(
+            "SELECT id, user_id, name FROM workspaces WHERE id = ?",
+            (workspace_id,),
+        )
+        row = await cursor.fetchone()
+        if row is None:
+            return None
+
+        old_owner_id = row["user_id"]
+        ws_name = row["name"]
+
+        if old_owner_id == new_owner_id:
+            raise ValueError("Target user is already the owner")
+
+        # Check UNIQUE(user_id, name) won't be violated.
+        dup = await db.execute(
+            "SELECT 1 FROM workspaces"
+            " WHERE user_id = ? AND name = ? AND id != ?",
+            (new_owner_id, ws_name, workspace_id),
+        )
+        if await dup.fetchone():
+            raise ValueError(
+                f"Target user already owns a workspace named {ws_name!r}"
+            )
+
+        # 1. Update workspace owner.
+        await db.execute(
+            "UPDATE workspaces SET user_id = ? WHERE id = ?",
+            (new_owner_id, workspace_id),
+        )
+
+        # 2. Update the owner ACE (position 0) to point at the new owner.
+        resource = f"/workspaces/{workspace_id}"
+        await db.execute(
+            "UPDATE acl_entries SET user_id = ?"
+            " WHERE resource = ? AND position = 0"
+            " AND principal_type = ?",
+            (new_owner_id, resource, PRINCIPAL_USER),
+        )
+
+        # 3. Swap owners-group membership: remove old owner, add new.
+        owners_group_name = f"owners-{workspace_id}"
+        g_cursor = await db.execute(
+            "SELECT id FROM groups WHERE name = ?",
+            (owners_group_name,),
+        )
+        g_row = await g_cursor.fetchone()
+        if g_row:
+            group_id = g_row["id"]
+            await db.execute(
+                "DELETE FROM user_groups WHERE user_id = ? AND group_id = ?",
+                (old_owner_id, group_id),
+            )
+            await db.execute(
+                "INSERT OR IGNORE INTO user_groups"
+                " (user_id, group_id, source) VALUES (?, ?, ?)",
+                (new_owner_id, group_id, "manual"),
+            )
+
+    return await get_workspace_by_id(workspace_id)
+
+
 async def get_user_workspaces_with_containers(user_id: str) -> list[dict]:
     async with transaction() as db:
         cursor = await db.execute(

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -2839,6 +2839,161 @@ class TestChangeWorkspaceRole:
         assert resp.status_code == 200
 
 
+class TestTransferOwnership:
+    async def test_transfer_ownership(self, client, user):
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            headers=headers,
+            json={"name": "transfer-ws"},
+        )
+        assert resp.status_code == 200
+        ws_id = resp.json()["id"]
+
+        target = await model.create_user("xfer-target@test.com", "pass")
+        resp = await client.post(
+            f"/api/v1/workspaces/{ws_id}/transfer",
+            headers=headers,
+            json={"email": "xfer-target@test.com"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["user_id"] == target["id"]
+
+    async def test_transfer_user_not_found(self, client, user):
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            headers=headers,
+            json={"name": "xfer-nf-ws"},
+        )
+        ws_id = resp.json()["id"]
+
+        resp = await client.post(
+            f"/api/v1/workspaces/{ws_id}/transfer",
+            headers=headers,
+            json={"email": "nobody@test.com"},
+        )
+        assert resp.status_code == 404
+        assert "User not found" in resp.json()["detail"]
+
+    async def test_transfer_to_self(self, client, user):
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            headers=headers,
+            json={"name": "xfer-self-ws"},
+        )
+        ws_id = resp.json()["id"]
+
+        resp = await client.post(
+            f"/api/v1/workspaces/{ws_id}/transfer",
+            headers=headers,
+            json={"email": "testuser@example.com"},
+        )
+        assert resp.status_code == 409
+        assert "already the owner" in resp.json()["detail"]
+
+    async def test_transfer_duplicate_name(self, client, user):
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            headers=headers,
+            json={"name": "dup-name-ws"},
+        )
+        ws_id = resp.json()["id"]
+
+        target = await model.create_user("xfer-dup@test.com", "pass")
+        # Create a workspace with the same name owned by the target
+        await model.create_workspace_with_acl(target["id"], "dup-name-ws")
+
+        resp = await client.post(
+            f"/api/v1/workspaces/{ws_id}/transfer",
+            headers=headers,
+            json={"email": "xfer-dup@test.com"},
+        )
+        assert resp.status_code == 409
+        assert "dup-name-ws" in resp.json()["detail"]
+
+    async def test_transfer_non_owner_forbidden(self, client, user):
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            headers=headers,
+            json={"name": "xfer-forbid-ws"},
+        )
+        ws_id = resp.json()["id"]
+
+        other = await model.create_user("xfer-other@test.com", "pass")
+        other_token = auth.create_token(other["id"], other["email"])
+        other_headers = {"Authorization": f"Bearer {other_token}"}
+
+        await model.create_user("xfer-target2@test.com", "pass")
+        resp = await client.post(
+            f"/api/v1/workspaces/{ws_id}/transfer",
+            headers=other_headers,
+            json={"email": "xfer-target2@test.com"},
+        )
+        assert resp.status_code == 403
+
+    async def test_transfer_to_agent_rejected(self, client, user):
+        from klangk_backend.main import seed_agent_user
+
+        await seed_agent_user()
+        agent = await model.get_user_by_id(model.AGENT_USER_ID)
+
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            headers=headers,
+            json={"name": "xfer-agent-ws"},
+        )
+        ws_id = resp.json()["id"]
+
+        resp = await client.post(
+            f"/api/v1/workspaces/{ws_id}/transfer",
+            headers=headers,
+            json={"email": agent["email"]},
+        )
+        assert resp.status_code == 409
+        assert "agent" in resp.json()["detail"].lower()
+
+    async def test_transfer_workspace_not_found(self, client, user):
+        result = await model.transfer_workspace(
+            "nonexistent-ws-id", user["id"]
+        )
+        assert result is None
+
+    async def test_transfer_updates_acl(self, client, user):
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            headers=headers,
+            json={"name": "xfer-acl-ws"},
+        )
+        ws_id = resp.json()["id"]
+
+        target = await model.create_user("xfer-acl@test.com", "pass")
+        resp = await client.post(
+            f"/api/v1/workspaces/{ws_id}/transfer",
+            headers=headers,
+            json={"email": "xfer-acl@test.com"},
+        )
+        assert resp.status_code == 200
+
+        # New owner should be in the owners role group
+        target_token = auth.create_token(target["id"], target["email"])
+        target_headers = {"Authorization": f"Bearer {target_token}"}
+        resp = await client.get(
+            f"/api/v1/workspaces/{ws_id}/roles",
+            headers=target_headers,
+        )
+        assert resp.status_code == 200
+        roles = {r["role"]: r for r in resp.json()}
+        owner_ids = [m["id"] for m in roles["owners"]["members"]]
+        assert target["id"] in owner_ids
+        assert user["id"] not in owner_ids
+
+
 class TestWorkspaceGroupSharing:
     async def test_share_with_group(self, client, admin_user, user):
         headers = await _auth_headers(client)

--- a/src/backend/tests/test_api_package.py
+++ b/src/backend/tests/test_api_package.py
@@ -35,7 +35,7 @@ api_auth = sys.modules["klangk_backend.api.auth"]
 
 # Total HTTP route operations the monolith exposed (per the issue).  The
 # split must preserve this exactly — no dropped or duplicated handlers.
-EXPECTED_ROUTE_COUNT = 86
+EXPECTED_ROUTE_COUNT = 87
 
 # Per-domain submodules and the number of routes each owns.  79 sub-routes
 # + 3 routes defined directly on the main router (version, config,
@@ -43,7 +43,7 @@ EXPECTED_ROUTE_COUNT = 86
 SUBMODULE_ROUTES = {
     "auth": 14,
     "oidc_auth": 2,
-    "workspaces": 23,
+    "workspaces": 24,
     "files": 6,
     "images": 4,
     "browser_delegate": 2,

--- a/src/frontend/lib/workspace/workspace_settings_panel.dart
+++ b/src/frontend/lib/workspace/workspace_settings_panel.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -329,6 +330,8 @@ class _SettingsFormState extends State<_SettingsForm> {
               const SizedBox(height: 16),
               _buildExportCard(),
               const SizedBox(height: 16),
+              _buildTransferCard(),
+              const SizedBox(height: 16),
               _buildDangerZoneCard(),
             ],
           ),
@@ -623,6 +626,181 @@ class _SettingsFormState extends State<_SettingsForm> {
         ),
       ],
     );
+  }
+
+  Widget _buildTransferCard() {
+    return _card(
+      icon: Icons.swap_horiz,
+      title: 'Transfer Ownership',
+      children: [
+        const SizedBox(height: 4),
+        const Text(
+          'Transfer this workspace to another user. '
+          'You will lose owner access.',
+          style: TextStyle(fontSize: 13),
+        ),
+        const SizedBox(height: 12),
+        OutlinedButton.icon(
+          onPressed: () => _showTransferDialog(context),
+          icon: const Icon(Icons.swap_horiz, size: 18),
+          label: const Text('Transfer Ownership'),
+        ),
+      ],
+    );
+  }
+
+  void _showTransferDialog(BuildContext context) {
+    final controller = TextEditingController();
+    final searchResults = ValueNotifier<List<Map<String, dynamic>>>([]);
+    Timer? debounce;
+
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Transfer Ownership'),
+        content: SizedBox(
+          width: 400,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(
+                'Search for the user to transfer this workspace to:',
+                style: TextStyle(fontSize: 13),
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: controller,
+                autofocus: true,
+                decoration: const InputDecoration(
+                  hintText: 'Type email...',
+                  border: OutlineInputBorder(),
+                  prefixIcon: Icon(Icons.person, size: 18),
+                ),
+                onChanged: (q) {
+                  debounce?.cancel();
+                  if (q.trim().isEmpty) {
+                    searchResults.value = [];
+                    return;
+                  }
+                  debounce = Timer(const Duration(milliseconds: 300), () async {
+                    final auth = context.read<AuthService>();
+                    try {
+                      final resp = await auth.authGet(
+                        '/api/v1/users/search?q=${Uri.encodeQueryComponent(q.trim())}',
+                      );
+                      if (resp.statusCode == 200) {
+                        searchResults.value = List<Map<String, dynamic>>.from(
+                          jsonDecode(resp.body) as List,
+                        );
+                      }
+                    } catch (e) {
+                      // coverage:ignore-start
+                      debugPrint(
+                        '[WorkspaceSettingsPanel] user search failed: $e',
+                      );
+                    } // coverage:ignore-end
+                  });
+                },
+                onSubmitted: (value) {
+                  final email = value.trim();
+                  if (email.isNotEmpty) {
+                    Navigator.of(ctx).pop();
+                    _confirmTransfer(context, email);
+                  }
+                },
+              ),
+              const SizedBox(height: 8),
+              ValueListenableBuilder<List<Map<String, dynamic>>>(
+                valueListenable: searchResults,
+                builder: (_, results, __) => Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: results
+                      .map(
+                        (r) => ListTile(
+                          dense: true,
+                          title: Text(
+                            r['email'] as String,
+                            style: const TextStyle(fontSize: 13),
+                          ),
+                          onTap: () {
+                            Navigator.of(ctx).pop();
+                            _confirmTransfer(
+                              context,
+                              r['email'] as String,
+                            );
+                          },
+                        ),
+                      )
+                      .toList(),
+                ),
+              ),
+            ],
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () {
+              debounce?.cancel();
+              Navigator.of(ctx).pop();
+            },
+            child: const Text('Cancel'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _confirmTransfer(BuildContext context, String email) {
+    showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Confirm Transfer'),
+        content: Text(
+          'Transfer this workspace to $email? '
+          'You will lose owner access.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () {
+              Navigator.of(ctx).pop();
+              _executeTransfer(email);
+            },
+            style: FilledButton.styleFrom(backgroundColor: Colors.orange),
+            child: const Text('Transfer'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _executeTransfer(String email) async {
+    final auth = context.read<AuthService>();
+    final resp = await auth.authPost(
+      '/api/v1/workspaces/${widget.workspaceId}/transfer',
+      body: jsonEncode({'email': email}),
+    );
+    if (!mounted) return;
+    if (resp.statusCode == 200) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Workspace transferred to $email')),
+      );
+    } else {
+      String detail;
+      try {
+        detail = (jsonDecode(resp.body) as Map)['detail'] ?? resp.body;
+      } catch (e) {
+        debugPrint('[WorkspaceSettingsPanel] parse transfer error: $e');
+        detail = 'Error: ${resp.statusCode}';
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Transfer failed: $detail')),
+      );
+    }
   }
 
   Widget _buildDangerZoneCard() {

--- a/src/frontend/test/workspace_settings_panel_test.dart
+++ b/src/frontend/test/workspace_settings_panel_test.dart
@@ -65,6 +65,9 @@ http.Client _client({
   int saveStatus = 200,
   int exportStatus = 200,
   bool imagesFail = false,
+  int transferStatus = 200,
+  Map<String, dynamic>? transferResponse,
+  List<Map<String, dynamic>>? searchResults,
 }) {
   final ws = (workspace ?? _workspace);
   return MockClient((request) async {
@@ -94,6 +97,18 @@ http.Client _client({
     if (p == '/api/v1/workspaces/$_wsId/export' && request.method == 'GET') {
       if (exportStatus != 200) return http.Response('err', exportStatus);
       return http.Response.bytes([1, 2, 3], 200);
+    }
+    if (p == '/api/v1/workspaces/$_wsId/transfer' && request.method == 'POST') {
+      return http.Response(
+        jsonEncode(transferResponse ?? {'id': _wsId, 'user_id': 'new-owner'}),
+        transferStatus,
+      );
+    }
+    if (p == '/api/v1/users/search') {
+      return http.Response(
+        jsonEncode(searchResults ?? []),
+        200,
+      );
     }
     return http.Response('not found', 404);
   });
@@ -830,6 +845,302 @@ void main() {
 
       expect(find.textContaining('Failed'), findsOneWidget);
       expect(find.textContaining('400'), findsOneWidget);
+    });
+  });
+
+  group('transfer ownership', () {
+    testWidgets('renders the transfer card', (tester) async {
+      await tester.pumpWidget(_buildPanel());
+      await tester.pumpAndSettle();
+
+      await tester.ensureVisible(find.text('Transfer Ownership').first);
+      await tester.pump();
+      expect(find.text('Transfer Ownership'), findsNWidgets(2));
+      expect(find.textContaining('lose owner access'), findsOneWidget);
+    });
+
+    testWidgets('opens search dialog on button tap', (tester) async {
+      await tester.pumpWidget(_buildPanel());
+      await tester.pumpAndSettle();
+
+      await _scrollToAndTap(
+        tester,
+        find.widgetWithText(OutlinedButton, 'Transfer Ownership'),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Search for the user'), findsOneWidget);
+      expect(find.text('Cancel'), findsOneWidget);
+    });
+
+    testWidgets('cancel dismisses the search dialog', (tester) async {
+      await tester.pumpWidget(_buildPanel());
+      await tester.pumpAndSettle();
+
+      await _scrollToAndTap(
+        tester,
+        find.widgetWithText(OutlinedButton, 'Transfer Ownership'),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Search for the user'), findsNothing);
+    });
+
+    testWidgets('search shows results and tapping opens confirm dialog',
+        (tester) async {
+      testAuthHttpClientOverride = _client(
+        searchResults: [
+          {'id': 'u2', 'email': 'target@test.com', 'handle': 'target'},
+        ],
+      );
+      await tester.pumpWidget(_buildPanel());
+      await tester.pumpAndSettle();
+
+      await _scrollToAndTap(
+        tester,
+        find.widgetWithText(OutlinedButton, 'Transfer Ownership'),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byType(TextField).last,
+        'target',
+      );
+      await tester.pump(const Duration(milliseconds: 400));
+      await tester.pumpAndSettle();
+
+      expect(find.text('target@test.com'), findsOneWidget);
+
+      await tester.tap(find.text('target@test.com'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Confirm Transfer'), findsOneWidget);
+      expect(find.textContaining('target@test.com'), findsOneWidget);
+    });
+
+    testWidgets('confirm executes transfer successfully', (tester) async {
+      testAuthHttpClientOverride = _client(
+        searchResults: [
+          {'id': 'u2', 'email': 'target@test.com', 'handle': 'target'},
+        ],
+      );
+      await tester.pumpWidget(_buildPanel());
+      await tester.pumpAndSettle();
+
+      await _scrollToAndTap(
+        tester,
+        find.widgetWithText(OutlinedButton, 'Transfer Ownership'),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField).last, 'target');
+      await tester.pump(const Duration(milliseconds: 400));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('target@test.com'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Transfer'));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.textContaining('transferred to target@test.com'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('transfer failure shows error snackbar', (tester) async {
+      testAuthHttpClientOverride = _client(
+        searchResults: [
+          {'id': 'u2', 'email': 'target@test.com', 'handle': 'target'},
+        ],
+        transferStatus: 409,
+        transferResponse: {'detail': 'already the owner'},
+      );
+      await tester.pumpWidget(_buildPanel());
+      await tester.pumpAndSettle();
+
+      await _scrollToAndTap(
+        tester,
+        find.widgetWithText(OutlinedButton, 'Transfer Ownership'),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField).last, 'target');
+      await tester.pump(const Duration(milliseconds: 400));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('target@test.com'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Transfer'));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.textContaining('Transfer failed'),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('transfer failure with non-JSON body shows status code',
+        (tester) async {
+      testAuthHttpClientOverride = MockClient((request) async {
+        final p = request.url.path;
+        if (p == '/api/v1/workspaces') {
+          return http.Response(jsonEncode([_workspace]), 200);
+        }
+        if (p == '/api/v1/workspaces/shared') {
+          return http.Response(jsonEncode([]), 200);
+        }
+        if (p == '/api/v1/images') {
+          return http.Response(
+            jsonEncode({
+              'default': 'klangk-pi',
+              'allowed': ['klangk-pi', 'other:latest'],
+            }),
+            200,
+          );
+        }
+        if (p == '/api/v1/users/search') {
+          return http.Response(
+            jsonEncode([
+              {'id': 'u2', 'email': 'target@test.com', 'handle': 'target'},
+            ]),
+            200,
+          );
+        }
+        if (p == '/api/v1/workspaces/$_wsId/transfer' &&
+            request.method == 'POST') {
+          return http.Response('plain text error', 500);
+        }
+        return http.Response('nf', 404);
+      });
+      await tester.pumpWidget(_buildPanel());
+      await tester.pumpAndSettle();
+
+      await _scrollToAndTap(
+        tester,
+        find.widgetWithText(OutlinedButton, 'Transfer Ownership'),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField).last, 'target');
+      await tester.pump(const Duration(milliseconds: 400));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('target@test.com'));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Transfer'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('500'), findsOneWidget);
+    });
+
+    testWidgets('submitting email directly opens confirm dialog',
+        (tester) async {
+      testAuthHttpClientOverride = _client();
+      await tester.pumpWidget(_buildPanel());
+      await tester.pumpAndSettle();
+
+      await _scrollToAndTap(
+        tester,
+        find.widgetWithText(OutlinedButton, 'Transfer Ownership'),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byType(TextField).last,
+        'direct@test.com',
+      );
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Confirm Transfer'), findsOneWidget);
+      expect(find.textContaining('direct@test.com'), findsOneWidget);
+    });
+
+    testWidgets('clearing the search field clears results', (tester) async {
+      testAuthHttpClientOverride = _client(
+        searchResults: [
+          {'id': 'u2', 'email': 'target@test.com', 'handle': 'target'},
+        ],
+      );
+      await tester.pumpWidget(_buildPanel());
+      await tester.pumpAndSettle();
+
+      await _scrollToAndTap(
+        tester,
+        find.widgetWithText(OutlinedButton, 'Transfer Ownership'),
+      );
+      await tester.pumpAndSettle();
+
+      // Type to get results.
+      await tester.enterText(find.byType(TextField).last, 'target');
+      await tester.pump(const Duration(milliseconds: 400));
+      await tester.pumpAndSettle();
+      expect(find.text('target@test.com'), findsOneWidget);
+
+      // Clear the field to trigger the empty-query branch.
+      await tester.enterText(find.byType(TextField).last, '');
+      await tester.pump();
+
+      // Results should be cleared.
+      expect(find.text('target@test.com'), findsNothing);
+    });
+
+    testWidgets('cancel with pending debounce cancels timer', (tester) async {
+      testAuthHttpClientOverride = _client(
+        searchResults: [
+          {'id': 'u2', 'email': 'target@test.com', 'handle': 'target'},
+        ],
+      );
+      await tester.pumpWidget(_buildPanel());
+      await tester.pumpAndSettle();
+
+      await _scrollToAndTap(
+        tester,
+        find.widgetWithText(OutlinedButton, 'Transfer Ownership'),
+      );
+      await tester.pumpAndSettle();
+
+      // Type to trigger debounce timer (don't wait for it to fire).
+      await tester.enterText(find.byType(TextField).last, 'target');
+      await tester.pump();
+
+      // Cancel while the debounce timer is still pending.
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Search for the user'), findsNothing);
+    });
+
+    testWidgets('cancel on confirm dialog dismisses without transferring',
+        (tester) async {
+      testAuthHttpClientOverride = _client();
+      await tester.pumpWidget(_buildPanel());
+      await tester.pumpAndSettle();
+
+      await _scrollToAndTap(
+        tester,
+        find.widgetWithText(OutlinedButton, 'Transfer Ownership'),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(
+        find.byType(TextField).last,
+        'cancel@test.com',
+      );
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Cancel'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Confirm Transfer'), findsNothing);
     });
   });
 }


### PR DESCRIPTION
## Summary

- Add `POST /workspaces/{workspace_id}/transfer` endpoint (requires `admin` permission on the workspace)
- Atomically updates workspace `user_id`, owner ACE (position 0), and `owners-{workspace_id}` group membership
- Rejects transfers to the system agent, to the current owner, and when the target already owns a workspace with the same name (409)
- Frontend adds a Transfer Ownership card in workspace settings with user search autocomplete and two-step confirmation dialog
- Notifies both old and new owners via `notify_user_workspaces_changed`

Closes #1296

## Test plan

- [x] Backend: 8 new tests covering success, user not found, self-transfer, duplicate name, forbidden (non-owner), agent rejection, workspace not found, and ACL verification
- [x] Frontend: 9 new tests covering card render, search dialog open/cancel, search results, confirm/cancel dialogs, success/failure snackbars, non-JSON error fallback, empty-query clearing, and debounce cancellation
- [x] 100% coverage on both backend and frontend