### PR TITLE
fix(security): enforce email_verified in OIDC callback with per-IdP trust-email

### DIFF
--- a/docs/reference/oidc.md
+++ b/docs/reference/oidc.md
@@ -36,17 +36,35 @@ KLANGK_OIDC_CONFIG=/path/to/oidc.yaml
 
 ## Provider Config Fields
 
-| Field                  | Required | Description                                                                                                                 |
-| ---------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `id`                   | Yes      | URL-safe slug, used in endpoint paths (`/api/v1/auth/oidc/{id}/login`) and stored as `provider` on users                    |
-| `display-name`         | Yes      | Button label on the login page (e.g., "CAC Login", "Google")                                                                |
-| `issuer`               | Yes      | OIDC issuer URL. Discovery via `{issuer}/.well-known/openid-configuration`                                                  |
-| `client-id`            | Yes      | OIDC client ID registered with the IdP                                                                                      |
-| `client-secret`        | Yes      | OIDC client secret. Supports `file:`/`cmd:` prefix for secret management                                                    |
-| `scopes`               | No       | Space-separated scopes (default: `openid email profile`)                                                                    |
-| `ca-cert`              | No       | Path to a CA certificate PEM file for IdPs with custom/private CAs                                                          |
-| `token-validation-pem` | No       | Inline RSA/EC public key PEM for static token validation (skips JWKS discovery)                                             |
-| `logout-redirect`      | No       | If `true`, logout redirects to the IdP's `end_session_endpoint` (RP-Initiated Logout). Default: `false` (local-only logout) |
+| Field                  | Required | Description                                                                                                                                                                           |
+| ---------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                   | Yes      | URL-safe slug, used in endpoint paths (`/api/v1/auth/oidc/{id}/login`) and stored as `provider` on users                                                                              |
+| `display-name`         | Yes      | Button label on the login page (e.g., "CAC Login", "Google")                                                                                                                          |
+| `issuer`               | Yes      | OIDC issuer URL. Discovery via `{issuer}/.well-known/openid-configuration`                                                                                                            |
+| `client-id`            | Yes      | OIDC client ID registered with the IdP                                                                                                                                                |
+| `client-secret`        | Yes      | OIDC client secret. Supports `file:`/`cmd:` prefix for secret management                                                                                                              |
+| `scopes`               | No       | Space-separated scopes (default: `openid email profile`)                                                                                                                              |
+| `ca-cert`              | No       | Path to a CA certificate PEM file for IdPs with custom/private CAs                                                                                                                    |
+| `token-validation-pem` | No       | Inline RSA/EC public key PEM for static token validation (skips JWKS discovery)                                                                                                       |
+| `logout-redirect`      | No       | If `true`, logout redirects to the IdP's `end_session_endpoint` (RP-Initiated Logout). Default: `false` (local-only logout)                                                           |
+| `trust-email`          | No       | If `true`, skip the `email_verified` check for this provider. Default: `false` (require `email_verified: true` in the ID token). See [Email Verification](#email-verification) below. |
+
+## Email Verification
+
+By default, Klangk requires the OIDC ID token to contain `email_verified: true`. If the claim is missing or `false`, the login is rejected with HTTP 403. This prevents an IdP that asserts an unverified email from being used to take over an existing account.
+
+Not all IdPs include the `email_verified` claim. If your IdP does not emit it, or you trust it to only return verified emails, set `trust-email: true` on that provider entry:
+
+```yaml
+- id: company-idp
+  display-name: Company SSO
+  issuer: https://sso.company.com
+  client-id: klangk
+  client-secret: "file:/run/secrets/oidc-secret"
+  trust-email: true # skip email_verified check — we trust this IdP
+```
+
+This is configured per provider, so a deployment with multiple IdPs can trust some and not others.
 
 ## How It Works
 
@@ -69,7 +87,7 @@ KLANGK_OIDC_CONFIG=/path/to/oidc.yaml
 
 ## OIDC Login Hook
 
-A single Python hook handles both login validation and group mapping on every OIDC login.
+A single Python hook handles both login validation and group mapping on every OIDC login. The hook runs after the `email_verified` check (see [Email Verification](#email-verification)), so it only sees logins that have already passed that gate.
 
 **Configuration:**
 
@@ -77,7 +95,7 @@ A single Python hook handles both login validation and group mapping on every OI
 KLANGK_OIDC_LOGIN_HOOK=my_module.on_login
 ```
 
-The value is a dotted Python path where the last component is the function name. If not set, all OIDC logins are accepted with no group sync.
+The value is a dotted Python path where the last component is the function name. If not set, all OIDC logins that pass the `email_verified` check are accepted with no group sync.
 
 **Hook signature:**
 
@@ -98,10 +116,6 @@ def on_login(provider, claims, email, tokens):
     Raises:
         Any exception — login rejected (message shown to user)
     """
-    # Example: reject unverified emails
-    if claims.get("email_verified") is not True:
-        raise ValueError("Email not verified by identity provider")
-
     # Example: map IdP roles to groups
     groups = set()
     roles = claims.get("realm_access", {}).get("roles", [])
@@ -114,7 +128,7 @@ Async hooks are also supported (`async def`).
 
 **Behavior:**
 
-- Called after ID token validation, before user provisioning
+- Called after ID token validation and `email_verified` check, before user provisioning
 - **Raise** an exception — login rejected (HTTP 403, exception message shown)
 - **Return** `None` — login allowed, no group sync
 - **Return** a `set[str]` — login allowed, memberships synced to those groups
@@ -122,14 +136,9 @@ Async hooks are also supported (`async def`).
 - Memberships are tracked with `source='oidc_sync'` — only these are added/removed
 - Manual group memberships (`source='manual'`) are never touched
 
-**Security note:** The hook is entirely responsible for login validation and group mapping. There is no default hook — the hook is written by the deploying organization, and it is their responsibility to validate IdP claims as appropriate. Without a hook, all OIDC logins are accepted (including those with unverified emails).
-
-**Built-in example hooks:**
+**Built-in example hook:**
 
 ```bash
-# Reject logins with unverified emails
-KLANGK_OIDC_LOGIN_HOOK=klangk_backend.oidc.example_require_verified_email
-
 # Map Keycloak klangk-admin role to the admin group
 KLANGK_OIDC_LOGIN_HOOK=klangk_backend.oidc.example_admin_hook
 ```

--- a/src/backend/klangk_backend/api/oidc_auth.py
+++ b/src/backend/klangk_backend/api/oidc_auth.py
@@ -240,6 +240,14 @@ async def oidc_callback(
     email = claims["email"]
     auth.validate_email(email)
 
+    # Require email_verified unless the operator trusts this IdP's
+    # email claims (trust-email: true in the provider config).
+    if not provider.trust_email and claims.get("email_verified") is not True:
+        raise HTTPException(
+            status_code=403,
+            detail="Email not verified by identity provider",
+        )
+
     # Call the OIDC login hook (if configured).
     try:
         hook_groups = await oidc.call_login_hook(

--- a/src/backend/klangk_backend/oidc.py
+++ b/src/backend/klangk_backend/oidc.py
@@ -39,6 +39,7 @@ class OIDCProvider:
     ca_cert: str | None = None  # path to CA cert PEM for custom trust
     token_validation_pem: str | None = None  # static RSA/EC public key PEM
     logout_redirect: bool = False  # redirect to IdP logout on user logout
+    trust_email: bool = False  # skip email_verified check for this IdP
 
 
 @dataclass
@@ -113,6 +114,7 @@ def load_config() -> list[OIDCProvider]:
                 ca_cert=ca_cert,
                 token_validation_pem=get(entry, "token-validation-pem", None),
                 logout_redirect=get(entry, "logout-redirect", False),
+                trust_email=get(entry, "trust-email", False),
             )
         )
     return providers
@@ -362,24 +364,6 @@ def example_admin_hook(
     if isinstance(value, str) and value == claim_value:
         return {"admin"}
     return set()
-
-
-def example_require_verified_email(
-    provider: OIDCProvider,  # noqa: ARG001
-    claims: dict,
-    email: str,  # noqa: ARG001
-    tokens: dict,  # noqa: ARG001
-) -> None:
-    """Example hook: reject logins where email_verified is not true.
-
-    To use: KLANGK_OIDC_LOGIN_HOOK=klangk_backend.oidc.example_require_verified_email
-
-    Raise an exception to reject the login. The exception message is
-    returned as the HTTP 403 detail.  Return None to allow the login
-    without group sync, or return a set of group names to sync.
-    """
-    if claims.get("email_verified") is not True:
-        raise ValueError("Email not verified by identity provider")
 
 
 def load_login_hook() -> None:

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -7894,18 +7894,17 @@ class TestOIDCCallback:
 
     async def test_callback_login_hook_rejects(self, client, monkeypatch, db):
         """A login validation hook can reject an OIDC login."""
+
+        def reject_hook(provider, claims, email, tokens):
+            raise ValueError("Denied by hook")
+
+        monkeypatch.setattr(oidc, "_login_hook", reject_hook)
+        monkeypatch.setattr(oidc, "_login_hook_is_async", False)
         _, cookie_data = await self._setup_callback(
             client,
             monkeypatch,
             db,
-            claims={"email_verified": False},
         )
-        monkeypatch.setattr(
-            oidc,
-            "_login_hook",
-            oidc.example_require_verified_email,
-        )
-        monkeypatch.setattr(oidc, "_login_hook_is_async", False)
         client.cookies.set("oidc_test", cookie_data)
         resp = await client.get(
             "/api/v1/auth/oidc/test/callback",
@@ -7916,17 +7915,66 @@ class TestOIDCCallback:
         assert resp.json()["detail"] == "Login denied by server policy"
         assert await model.get_user_by_email("oidcuser@example.com") is None
 
-    async def test_callback_no_login_hook_allows_unverified(
+    async def test_callback_rejects_unverified_email_by_default(
         self, client, monkeypatch, db
     ):
-        """Without a login hook, unverified emails are accepted."""
+        """Unverified email is rejected when trust-email is false (default)."""
         _, cookie_data = await self._setup_callback(
             client,
             monkeypatch,
             db,
             claims={"email_verified": False},
         )
-        monkeypatch.setattr(oidc, "_login_hook", None)
+        client.cookies.set("oidc_test", cookie_data)
+        resp = await client.get(
+            "/api/v1/auth/oidc/test/callback",
+            params={"code": "auth-code", "state": "test-state"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 403
+        assert "not verified" in resp.json()["detail"]
+        assert await model.get_user_by_email("oidcuser@example.com") is None
+
+    async def test_callback_rejects_missing_email_verified(
+        self, client, monkeypatch, db
+    ):
+        """Missing email_verified claim is rejected (same as False)."""
+        _, cookie_data = await self._setup_callback(
+            client,
+            monkeypatch,
+            db,
+            claims={"sub": "no-ev-sub", "email": "noev@example.com"},
+        )
+        # Override claims to omit email_verified entirely
+        monkeypatch.setattr(
+            api.oidc,
+            "validate_id_token",
+            AsyncMock(
+                return_value={
+                    "sub": "no-ev-sub",
+                    "email": "noev@example.com",
+                }
+            ),
+        )
+        client.cookies.set("oidc_test", cookie_data)
+        resp = await client.get(
+            "/api/v1/auth/oidc/test/callback",
+            params={"code": "auth-code", "state": "test-state"},
+            follow_redirects=False,
+        )
+        assert resp.status_code == 403
+
+    async def test_callback_trust_email_allows_unverified(
+        self, client, monkeypatch, db
+    ):
+        """With trust-email: true, unverified emails are accepted."""
+        provider, cookie_data = await self._setup_callback(
+            client,
+            monkeypatch,
+            db,
+            claims={"email_verified": False},
+        )
+        provider.trust_email = True
         client.cookies.set("oidc_test", cookie_data)
         resp = await client.get(
             "/api/v1/auth/oidc/test/callback",

--- a/src/backend/tests/test_oidc.py
+++ b/src/backend/tests/test_oidc.py
@@ -177,6 +177,45 @@ class TestLoadConfig:
         providers = oidc.load_config()
         assert providers[0].ca_cert is None
 
+    def test_trust_email(self, monkeypatch, tmp_path):
+        cfg = tmp_path / "oidc.yaml"
+        cfg.write_text(
+            yaml.dump(
+                [
+                    {
+                        "id": "trusted",
+                        "display-name": "Trusted",
+                        "issuer": "https://idp.example.com",
+                        "client-id": "klangk",
+                        "client-secret": "s",
+                        "trust-email": True,
+                    }
+                ]
+            )
+        )
+        monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(cfg))
+        providers = oidc.load_config()
+        assert providers[0].trust_email is True
+
+    def test_trust_email_defaults_false(self, monkeypatch, tmp_path):
+        cfg = tmp_path / "oidc.yaml"
+        cfg.write_text(
+            yaml.dump(
+                [
+                    {
+                        "id": "default",
+                        "display-name": "Default",
+                        "issuer": "https://idp.example.com",
+                        "client-id": "klangk",
+                        "client-secret": "s",
+                    }
+                ]
+            )
+        )
+        monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(cfg))
+        providers = oidc.load_config()
+        assert providers[0].trust_email is False
+
     def test_multiple_providers(self, monkeypatch, tmp_path):
         cfg = tmp_path / "oidc.yaml"
         cfg.write_text(
@@ -693,22 +732,6 @@ class TestCallLoginHook:
         oidc._login_hook_is_async = True
         with pytest.raises(ValueError, match="async denied"):
             await oidc.call_login_hook(_provider(), {}, "x@example.com", {})
-
-    async def test_example_require_verified_email_rejects(self):
-        oidc._login_hook = oidc.example_require_verified_email
-        oidc._login_hook_is_async = False
-        with pytest.raises(ValueError, match="not verified"):
-            await oidc.call_login_hook(
-                _provider(), {"email_verified": False}, "a@b.com", {}
-            )
-
-    async def test_example_require_verified_email_allows(self):
-        oidc._login_hook = oidc.example_require_verified_email
-        oidc._login_hook_is_async = False
-        result = await oidc.call_login_hook(
-            _provider(), {"email_verified": True}, "a@b.com", {}
-        )
-        assert result is None
 
 
 class TestSyncOidcGroups:


### PR DESCRIPTION
## Summary

- By default, require `email_verified: true` in the OIDC ID token. Missing or `false` rejects the login with 403.
- Add per-IdP `trust-email` config flag in `oidc.yaml` — when `true`, skips the `email_verified` check (operator vouches for this IdP's email claims)
- Remove `example_require_verified_email` hook (its behavior is now the built-in default)
- Update OIDC docs with new `trust-email` field, Email Verification section, and updated hook documentation

Closes #1226

## Test plan

- [x] `test_callback_rejects_unverified_email_by_default` — unverified email rejected (403) with default config
- [x] `test_callback_rejects_missing_email_verified` — missing claim also rejected
- [x] `test_callback_trust_email_allows_unverified` — unverified accepted when `trust_email=True`
- [x] `test_callback_creates_user` — verified email still works (existing test, `email_verified: true` in default claims)
- [x] `test_trust_email` / `test_trust_email_defaults_false` — config parsing tests
- [x] 100% backend coverage