### PR TITLE
fix(frontend): replace raw exception strings with user-friendly error messages

### DIFF
--- a/src/frontend/lib/admin/admin_users_page.dart
+++ b/src/frontend/lib/admin/admin_users_page.dart
@@ -118,8 +118,9 @@ class _AdminUsersPageState extends State<AdminUsersPage> {
         });
       }
     } catch (e) {
+      debugPrint('Load users error: $e');
       setState(() {
-        _error = 'Error: $e';
+        _error = 'Could not load users. Please try again.';
         _loading = false;
       });
     }

--- a/src/frontend/lib/file_viewer/file_viewer_panel.dart
+++ b/src/frontend/lib/file_viewer/file_viewer_panel.dart
@@ -339,10 +339,13 @@ class FileViewerPanelState extends State<FileViewerPanel> {
         }
       }
     } catch (e) {
+      debugPrint('Delete error: $e');
       if (mounted) {
         ScaffoldMessenger.of(
           context,
-        ).showSnackBar(SnackBar(content: Text('Delete error: $e')));
+        ).showSnackBar(
+          const SnackBar(content: Text('Could not delete. Please try again.')),
+        );
       }
     }
   }
@@ -411,10 +414,13 @@ class FileViewerPanelState extends State<FileViewerPanel> {
         }
       }
     } catch (e) {
+      debugPrint('Rename error: $e');
       if (mounted) {
         ScaffoldMessenger.of(
           context,
-        ).showSnackBar(SnackBar(content: Text('Rename error: $e')));
+        ).showSnackBar(
+          const SnackBar(content: Text('Could not rename. Please try again.')),
+        );
       }
     }
   }
@@ -447,10 +453,15 @@ class FileViewerPanelState extends State<FileViewerPanel> {
       final filename = isDir ? '$name.tar.gz' : name;
       downloadBytes(response.bodyBytes, filename);
     } catch (e) {
+      debugPrint('Download error: $e');
       if (mounted) {
         ScaffoldMessenger.of(
           context,
-        ).showSnackBar(SnackBar(content: Text('Download error: $e')));
+        ).showSnackBar(
+          const SnackBar(
+            content: Text('Could not download. Please try again.'),
+          ),
+        );
       }
     }
   }

--- a/src/frontend/lib/file_viewer/renderers/code_editor_renderer.dart
+++ b/src/frontend/lib/file_viewer/renderers/code_editor_renderer.dart
@@ -61,7 +61,8 @@ class _CodeEditorViewState extends State<_CodeEditorView> {
       await save(_controller.text);
       if (mounted) setState(() => _status = 'Saved');
     } catch (e) {
-      if (mounted) setState(() => _status = 'Save failed: $e');
+      debugPrint('Save failed: $e');
+      if (mounted) setState(() => _status = 'Save failed. Please try again.');
     } finally {
       if (mounted) setState(() => _saving = false);
     }

--- a/src/frontend/lib/workspace/create_workspace_dialog.dart
+++ b/src/frontend/lib/workspace/create_workspace_dialog.dart
@@ -139,7 +139,10 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
         });
       }
     } catch (e) {
-      setState(() => _errorMessage = 'Error: $e');
+      debugPrint('Create workspace error: $e');
+      setState(
+        () => _errorMessage = 'Could not create workspace. Please try again.',
+      );
     }
   }
 

--- a/src/frontend/lib/workspace/workspace_list_page.dart
+++ b/src/frontend/lib/workspace/workspace_list_page.dart
@@ -403,12 +403,13 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
       await _auth.authDelete('/api/v1/workspaces/$id');
       await _loadWorkspaces();
     } catch (e) {
+      debugPrint('Workspace delete error: $e');
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            duration: const Duration(days: 1),
+          const SnackBar(
+            duration: Duration(days: 1),
             showCloseIcon: true,
-            content: Text('Error: $e'),
+            content: Text('Could not delete workspace. Please try again.'),
           ),
         );
       }

--- a/src/frontend/lib/ws/ws_client.dart
+++ b/src/frontend/lib/ws/ws_client.dart
@@ -306,7 +306,8 @@ class WsClient extends ChangeNotifier {
         _errorController.add('Session expired, please log in again');
         _auth?.logout();
       } else {
-        _errorController.add('Connection failed: $e');
+        debugPrint('WebSocket connection failed: $e');
+        _errorController.add('Connection failed. Please try again.');
       }
       return;
     }

--- a/src/frontend/test/file_viewer_panel_test.dart
+++ b/src/frontend/test/file_viewer_panel_test.dart
@@ -951,7 +951,7 @@ void main() {
       await tester.pumpAndSettle();
       await tester.tap(find.widgetWithText(FilledButton, 'Delete'));
       await tester.pumpAndSettle();
-      expect(find.textContaining('Delete error'), findsOneWidget);
+      expect(find.textContaining('Could not delete'), findsOneWidget);
       client.close();
     });
 
@@ -994,7 +994,7 @@ void main() {
       await tester.testTextInput.receiveAction(TextInputAction.done);
       await tester.pump();
       await tester.pump(const Duration(milliseconds: 100));
-      expect(find.textContaining('Rename error'), findsOneWidget);
+      expect(find.textContaining('Could not rename'), findsOneWidget);
       client.close();
     });
 
@@ -1031,7 +1031,7 @@ void main() {
       await tester.pumpAndSettle();
       await tester.tap(find.text('Download'));
       await tester.pumpAndSettle();
-      expect(find.textContaining('Download error'), findsOneWidget);
+      expect(find.textContaining('Could not download'), findsOneWidget);
       client.close();
     });
 

--- a/src/frontend/test/workspace_list_page_test.dart
+++ b/src/frontend/test/workspace_list_page_test.dart
@@ -1659,7 +1659,10 @@ void main() {
       await tester.tap(find.text('Create'));
       await tester.pumpAndSettle();
 
-      expect(find.textContaining('Error:'), findsOneWidget);
+      expect(
+        find.textContaining('Could not create workspace'),
+        findsOneWidget,
+      );
     });
 
     testWidgets('delete workspace exception shows error snackbar',
@@ -1695,7 +1698,10 @@ void main() {
       await tester.tap(find.text('Delete'));
       await tester.pumpAndSettle();
 
-      expect(find.textContaining('Error:'), findsOneWidget);
+      expect(
+        find.textContaining('Could not delete workspace'),
+        findsOneWidget,
+      );
     });
 
     testWidgets('logout button calls logout and navigates', (tester) async {

--- a/src/frontend/test/ws_client_test.dart
+++ b/src/frontend/test/ws_client_test.dart
@@ -313,7 +313,7 @@ void main() {
       await Future.delayed(Duration.zero);
       expect(client.connected, isFalse);
       expect(errors.length, 1);
-      expect(errors[0], startsWith('Connection failed:'));
+      expect(errors[0], 'Connection failed. Please try again.');
       client.dispose();
     });
 


### PR DESCRIPTION
## Summary
- Replace raw `$e` exception strings in catch blocks with human-readable messages across 6 frontend files
- Add `debugPrint` calls so the original exceptions are still available in dev console for diagnostics
- Affected: file viewer (delete/rename/download), workspace list (delete), create workspace dialog, admin users page, code editor save, WebSocket client connection

## Test plan
- [x] All 249 affected frontend tests pass (updated 3 test files to match new messages)

Closes #1330