### PR TITLE
fix(backend): handle invalid JSON in workspace archive import

### DIFF
--- a/src/backend/klangk_backend/api/workspaces.py
+++ b/src/backend/klangk_backend/api/workspaces.py
@@ -585,7 +585,13 @@ async def _extract_archive_metadata(
             status_code=400,
             detail="Archive missing workspace.json or is corrupt",
         )
-    metadata = json.loads(result.stdout)
+    try:
+        metadata = json.loads(result.stdout)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        raise HTTPException(
+            status_code=400,
+            detail="workspace.json is corrupt or contains invalid JSON",
+        )
 
     ws_name = name or metadata.get("name")
     if not ws_name:


### PR DESCRIPTION
## Summary
- Wrap `json.loads(result.stdout)` in a try-except for `JSONDecodeError` and `UnicodeDecodeError` so a corrupted `workspace.json` in an imported archive returns a 400 with a clear message instead of an unhandled 500

## Test plan
- [x] Existing `test_import_invalid_json_in_metadata` now passes (was previously relying on the 500 being caught elsewhere)

Closes #1332
Closes #1333