### PR TITLE
fix(backend): validate OIDC state cookie is a dict before accessing keys

### DIFF
--- a/src/backend/klangk_backend/api/oidc_auth.py
+++ b/src/backend/klangk_backend/api/oidc_auth.py
@@ -112,12 +112,12 @@ def _validate_state_cookie(
 
     try:
         cookie_data = json.loads(cookie_raw)
-    except json.JSONDecodeError:
+    except (json.JSONDecodeError, UnicodeDecodeError):
         raise HTTPException(
             status_code=400, detail="Invalid OIDC state cookie"
         )
 
-    if cookie_data.get("state") != state:
+    if not isinstance(cookie_data, dict) or cookie_data.get("state") != state:
         raise HTTPException(status_code=400, detail="State mismatch")
 
     return cookie_data

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -7988,6 +7988,25 @@ class TestOIDCCallback:
         )
         assert resp.status_code == 400
 
+    async def test_callback_non_dict_cookie_json(
+        self, client, monkeypatch, db
+    ):
+        """Non-dict JSON in the state cookie returns 400, not 500 (#1334)."""
+        provider = api.oidc.OIDCProvider(
+            id="test",
+            display_name="Test",
+            issuer="https://idp.example.com",
+            client_id="klangk",
+            client_secret="s",
+        )
+        monkeypatch.setattr(api.oidc, "get_provider", lambda _: provider)
+        client.cookies.set("oidc_test", "[1, 2, 3]")
+        resp = await client.get(
+            "/api/v1/auth/oidc/test/callback",
+            params={"code": "code", "state": "s"},
+        )
+        assert resp.status_code == 400
+
 
 class TestOIDCLogout:
     async def test_logout_returns_oidc_logout_url(self, client, db):


### PR DESCRIPTION
## Summary
- Add `isinstance(cookie_data, dict)` check in `_validate_state_cookie` so non-dict JSON (e.g. `[1,2,3]`) returns 400 instead of crashing with `AttributeError` (500)
- Also catch `UnicodeDecodeError` alongside `JSONDecodeError`

## Test plan
- [x] New `test_callback_non_dict_cookie_json` verifies non-dict JSON returns 400
- [x] Existing `test_callback_invalid_cookie_json` still passes

Closes #1334