### PR TITLE
fix(backend): guard OIDC session minting and update_email against system agent

### DIFF
--- a/src/backend/klangk_backend/api/oidc_auth.py
+++ b/src/backend/klangk_backend/api/oidc_auth.py
@@ -168,13 +168,27 @@ async def _exchange_and_validate_token(provider, code, cookie_data):
 
 
 async def _find_or_create_user(provider_id, sub, email):
-    """Locate an existing user by OIDC identity or create one via JIT provisioning."""
+    """Locate an existing user by OIDC identity or create one via JIT provisioning.
+
+    Raises ``HTTPException(403)`` if the resolved user is the system agent —
+    OIDC must never mint a session as the agent (#1225).
+    """
     user = await model.get_user_by_external_id(provider_id, sub)
     if user is not None:
+        if user["id"] == model.AGENT_USER_ID:
+            raise HTTPException(
+                status_code=403,
+                detail="Cannot log in as the system agent",
+            )
         return user
 
     existing = await model.get_user_by_email(email)
     if existing is not None:
+        if existing["id"] == model.AGENT_USER_ID:
+            raise HTTPException(
+                status_code=403,
+                detail="Cannot log in as the system agent",
+            )
         await model.link_oidc_identity(existing["id"], provider_id, sub)
         return existing
 

--- a/src/backend/klangk_backend/model/users.py
+++ b/src/backend/klangk_backend/model/users.py
@@ -658,7 +658,14 @@ async def delete_user(user_id: str) -> bool:
 
 
 async def update_email(user_id: str, email: str) -> None:
-    """Update a user's email."""
+    """Update a user's email.
+
+    Raises ``AgentPrincipalError`` if the target is the system agent.
+    """
+    if user_id == AGENT_USER_ID:
+        raise AgentPrincipalError(
+            "Cannot change the email of the system agent user"
+        )
     async with transaction() as db:
         await db.execute(
             "UPDATE users SET email = ? WHERE id = ?", (email, user_id)

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -8056,6 +8056,87 @@ class TestOIDCCallback:
         assert resp.status_code == 400
 
 
+class TestOIDCCallbackAgentGuard:
+    """OIDC callback must never mint a session as the system agent (#1225)."""
+
+    async def _setup_callback(self, client, monkeypatch, db, claims=None):
+        import json as json_mod
+
+        provider = api.oidc.OIDCProvider(
+            id="test",
+            display_name="Test",
+            issuer="https://idp.example.com",
+            client_id="klangk",
+            client_secret="s",
+        )
+        monkeypatch.setattr(api.oidc, "get_provider", lambda _: provider)
+        monkeypatch.setattr(
+            api.oidc,
+            "exchange_code",
+            AsyncMock(
+                return_value={
+                    "id_token": "fake-id-token",
+                    "access_token": "at",
+                }
+            ),
+        )
+        default_claims = {
+            "sub": "agent-oidc-sub",
+            "email": "clanker@example.com",
+            "email_verified": True,
+        }
+        if claims:
+            default_claims.update(claims)
+        monkeypatch.setattr(
+            api.oidc,
+            "validate_id_token",
+            AsyncMock(return_value=default_claims),
+        )
+        cookie_data = json_mod.dumps(
+            {
+                "state": "test-state",
+                "verifier": "test-verifier",
+                "redirect_uri": "https://klangk.example.com/auth/oidc/test/callback",
+                "cli_redirect": None,
+            }
+        )
+        return provider, cookie_data
+
+    async def test_oidc_rejects_agent_email(
+        self, client, monkeypatch, db, agent_user
+    ):
+        """OIDC login with the agent's email is rejected with 403."""
+        _, cookie_data = await self._setup_callback(client, monkeypatch, db)
+        client.cookies.set("oidc_test", cookie_data)
+        resp = await client.get(
+            "/api/v1/auth/oidc/test/callback",
+            params={"code": "auth-code", "state": "test-state"},
+        )
+        assert resp.status_code == 403
+        assert "system agent" in resp.json()["detail"]
+
+    async def test_oidc_rejects_agent_by_external_id(
+        self, client, monkeypatch, db, agent_user
+    ):
+        """OIDC login resolving the agent by external_id is rejected."""
+        # The DB trigger blocks linking OIDC identity to the agent, so
+        # mock get_user_by_external_id to simulate a pre-linked agent.
+        agent = await model.get_user_by_id(model.AGENT_USER_ID)
+        monkeypatch.setattr(
+            model,
+            "get_user_by_external_id",
+            AsyncMock(return_value=agent),
+        )
+        _, cookie_data = await self._setup_callback(client, monkeypatch, db)
+        client.cookies.set("oidc_test", cookie_data)
+        resp = await client.get(
+            "/api/v1/auth/oidc/test/callback",
+            params={"code": "auth-code", "state": "test-state"},
+        )
+        assert resp.status_code == 403
+        assert "system agent" in resp.json()["detail"]
+
+
 class TestOIDCLogout:
     async def test_logout_returns_oidc_logout_url(self, client, db):
         """OIDC user with logout_redirect gets IdP logout URL in response."""

--- a/src/backend/tests/test_model.py
+++ b/src/backend/tests/test_model.py
@@ -1504,6 +1504,12 @@ class TestUpdatePasswordAgentGuard:
             await model.update_password(model.AGENT_USER_ID, "hash")
 
 
+class TestUpdateEmailAgentGuard:
+    async def test_update_email_rejects_agent_user(self, db):
+        with pytest.raises(model.AgentPrincipalError, match="system agent"):
+            await model.update_email(model.AGENT_USER_ID, "new@example.com")
+
+
 class TestDeleteUserAgentGuard:
     async def test_delete_user_rejects_agent_user(self, db):
         with pytest.raises(model.AgentPrincipalError, match="system agent"):


### PR DESCRIPTION
## Summary
- Fixes #1225
- `_find_or_create_user` in OIDC callback now rejects the system agent with HTTP 403 before `create_token`, whether resolved by email or external_id
- `model.update_email` now raises `AgentPrincipalError` for `AGENT_USER_ID`, matching the existing choke-point pattern in `update_password`, `delete_user`, and `add_user_to_group`
- Boot-time re-seeding (`ON CONFLICT DO UPDATE SET email`) is unaffected since it uses raw SQL, not the guarded `update_email` function

## Test plan
- [x] `test_oidc_rejects_agent_email` — OIDC login with agent's email returns 403
- [x] `test_oidc_rejects_agent_by_external_id` — OIDC login resolving agent by external_id returns 403
- [x] `test_update_email_rejects_agent_user` — `update_email` raises `AgentPrincipalError`
- [x] All 2178 backend tests pass with 100% coverage