### PR TITLE
fix(backend): emit health death frame before removing container state

### DIFF
--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -469,8 +469,8 @@ class IdleMonitor:
                             await cb(wid)
                         except Exception as e:
                             logger.error("Idle callback error: %s", e)
-                await self._registry.stop_and_remove_container(cid)
                 await self._registry.notify_workspace_killed(wid)
+                await self._registry.stop_and_remove_container(cid)
 
     def start_cleanup_loop(self) -> None:
         logger.info(
@@ -1548,16 +1548,17 @@ class ContainerRegistry:
         terminal.clear_service_session_lock(container_id)
 
     async def notify_workspace_killed(self, workspace_id: str) -> None:
-        """Call the on_workspace_killed callback, logging any errors."""
+        """Call the on_workspace_killed callback, logging any errors.
+
+        Must be called **before** ``stop_and_remove_container`` so that
+        ``self.states`` still contains the workspace state needed to emit
+        the terminal ``service_health`` death frame.
+        """
         self._notify_status_changed(workspace_id, False)
-        # Close the container-death hole (#1175 item 2): without this,
-        # a dying container looks like "healthy, then silence" on the
-        # service_health stream because the health loop only polls
-        # ``registry.states`` and the on_workspace_killed callback below
-        # drops the state.  Emit one terminal frame with ``running=False``
-        # first, so a consumer watching only service_health learns the
-        # service is down.  Only health-checked workspaces ever appeared
-        # on the stream, so only those get a terminal frame.
+        # Close the container-death hole (#1175 item 2): emit a terminal
+        # ``running=False`` frame so consumers watching only service_health
+        # learn the service is down.  Only health-checked workspaces ever
+        # appeared on the stream, so only those get a terminal frame.
         state = self.states.get(workspace_id)
         if state is not None and state.health_check is not None:
             self.health.broadcast_death(state)
@@ -1576,8 +1577,8 @@ class ContainerRegistry:
         workspaces = await model.get_user_workspaces_with_containers(user_id)
         for ws in workspaces:
             if ws["container_id"]:
-                await self.stop_and_remove_container(ws["container_id"])
                 await self.notify_workspace_killed(ws["id"])
+                await self.stop_and_remove_container(ws["container_id"])
 
     # --- Pre-warm ---
 

--- a/src/backend/klangk_backend/wshandler/connection.py
+++ b/src/backend/klangk_backend/wshandler/connection.py
@@ -573,12 +573,12 @@ class Connection:
             if conn_obj.workspace_id == workspace_id:
                 conn_obj.container_id = None
 
+        await container.registry.notify_workspace_killed(workspace_id)
+
         try:
             await container.registry.stop_and_remove_container(container_id)
         except Exception as e:
             logger.warning("Error stopping container: %s", e)
-
-        await container.registry.notify_workspace_killed(workspace_id)
 
         # Stop the Pi RPC subprocess now that its container is gone.
         await agent.stop_session(workspace_id)

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -2952,6 +2952,54 @@ class TestHealthMonitorDeath:
             _ws_state.connections.pop(sock, None)
         sock.send_json.assert_not_called()
 
+    async def test_idle_cleanup_emits_death_frame(self):
+        """Idle-timeout kills must emit the death frame before removing state.
+
+        Regression test for #1343: cleanup_idle_containers called
+        stop_and_remove_container (which pops state) before
+        notify_workspace_killed (which reads state for the death frame),
+        so the frame was silently skipped.
+        """
+        from klangk_backend.wshandler import state as _ws_state
+
+        sock = _mock_sock_for_health()
+        st = _health_state(
+            workspace_id="ws-idle-death",
+            container_id="cid-idle-death",
+            health_status="healthy",
+        )
+        container.registry.states[st.workspace_id] = st
+        container.registry._cid_to_wsid[st.container_id] = st.workspace_id
+        st.last_activity = time.time() - container.IDLE_TIMEOUT_SECONDS - 100
+
+        try:
+            _ws_state.connections[sock] = SimpleNamespace(
+                user={"id": "u1", "email": "a@x"}
+            )
+            with patch_podman():
+                task = asyncio.create_task(
+                    container.registry.cleanup_idle_containers()
+                )
+                await asyncio.sleep(0.05)
+                container.registry.get_cleanup_wake().set()
+                await asyncio.sleep(0.05)
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+        finally:
+            _ws_state.connections.pop(sock, None)
+            container.registry.states.pop(st.workspace_id, None)
+            container.registry._cid_to_wsid.pop(st.container_id, None)
+
+        # The death frame must have been emitted.
+        sock.send_json.assert_called()
+        frame = sock.send_json.call_args[0][0]
+        assert frame["type"] == "service_health"
+        assert frame["healthy"] is False
+        assert frame["running"] is False
+
 
 class TestHealthLoopHeartbeat:
     """run_health_loop ticks a heartbeat each sweep (#1175 item 3b).


### PR DESCRIPTION
## Summary

- Swap call order at all three callsites (idle cleanup, user logout, WS stop) so `notify_workspace_killed` runs **before** `stop_and_remove_container`, ensuring the health death frame is emitted while workspace state is still present
- Add regression test `test_idle_cleanup_emits_death_frame` that verifies the idle-timeout path emits the terminal `service_health` frame

Closes #1343