### PR TITLE
fix(frontend): clear pendingRedirect after consumption

### DIFF
--- a/src/frontend/lib/app_guards.dart
+++ b/src/frontend/lib/app_guards.dart
@@ -82,7 +82,9 @@ String? guardLoggedInPublicRoute({
   required Set<String> pluginPaths,
 }) {
   if (isLoggedIn && publicRoutes.contains(loc) && !pluginPaths.contains(loc)) {
-    return pendingRedirect ?? '/workspaces';
+    final target = pendingRedirect ?? '/workspaces';
+    pendingRedirect = null;
+    return target;
   }
   return null;
 }

--- a/src/frontend/test/app_guards_test.dart
+++ b/src/frontend/test/app_guards_test.dart
@@ -128,6 +128,17 @@ void main() {
       );
     });
 
+    test('clears pendingRedirect after consuming it', () {
+      pendingRedirect = '/workspace/abc';
+      guardLoggedInPublicRoute(
+        isLoggedIn: true,
+        loc: '/login',
+        publicRoutes: routes,
+        pluginPaths: pluginPaths,
+      );
+      expect(pendingRedirect, isNull);
+    });
+
     test('falls back to /workspaces with no pending redirect', () {
       expect(
         guardLoggedInPublicRoute(


### PR DESCRIPTION
## Summary
- Set `pendingRedirect = null` after consuming it in `guardLoggedInPublicRoute`, preventing stale redirects from persisting for the entire app session
- Added test verifying the redirect is cleared after use

## Test plan
- [x] New test `clears pendingRedirect after consuming it` asserts `pendingRedirect` is null after guard returns
- [x] All 25 existing `app_guards_test.dart` tests pass

Closes #1344