### PR TITLE
fix(frontend): resolve shared workspace name in app bar

### DIFF
--- a/src/frontend/e2e-tests/e2e/shared-workspace-name.spec.ts
+++ b/src/frontend/e2e-tests/e2e/shared-workspace-name.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from "@playwright/test";
+import {
+  registerUser,
+  createWorkspace,
+  openWorkspace,
+  API_BASE,
+} from "./helpers";
+
+test.describe("shared workspace name in app bar", () => {
+  test("displays the workspace name for a shared workspace member", async ({
+    page,
+    request,
+  }) => {
+    // Owner creates a workspace with a distinctive name
+    const ownerEmail = `share-name-owner-${Date.now()}@test.example.com`;
+    const owner = await registerUser(request, ownerEmail);
+    const wsName = `SharedNameTest-${Date.now()}`;
+    const { workspaceId, cleanup } = await createWorkspace(
+      request,
+      owner.headers,
+      wsName,
+    );
+
+    try {
+      // Register a second user and share the workspace with them
+      const memberEmail = `share-name-member-${Date.now()}@test.example.com`;
+      await registerUser(request, memberEmail);
+      const addResp = await request.post(
+        `${API_BASE}/api/v1/workspaces/${workspaceId}/members`,
+        { headers: owner.headers, data: { email: memberEmail } },
+      );
+      expect(addResp.ok()).toBe(true);
+
+      // Member opens the shared workspace
+      await openWorkspace(page, memberEmail, workspaceId);
+
+      // The page title should contain the workspace name, not just "Workspace"
+      await expect(page).toHaveTitle(new RegExp(wsName), { timeout: 15_000 });
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/frontend/e2e-tests/playwright.config.ts
+++ b/src/frontend/e2e-tests/playwright.config.ts
@@ -85,6 +85,7 @@ export default defineConfig({
         "per-user-home.spec.ts",
         "terminal-tabs.spec.ts",
         "shared-terminals.spec.ts",
+        "shared-workspace-name.spec.ts",
         "tab-speed.spec.ts",
         "sudo.spec.ts",
         "ws-connect-speed.spec.ts",

--- a/src/frontend/lib/workspace/workspace_page.dart
+++ b/src/frontend/lib/workspace/workspace_page.dart
@@ -134,18 +134,12 @@ class _WorkspacePageState extends State<WorkspacePage> {
   Future<void> _fetchWorkspaceName() async {
     final auth = context.read<AuthService>();
     try {
-      final response = await auth.authGet('/api/v1/workspaces');
-      if (response.statusCode == 200) {
-        final workspaces = jsonDecode(response.body) as List;
-        for (final ws in workspaces) {
-          if (ws['id'] == widget.workspaceId) {
-            if (mounted) {
-              setState(() => _workspaceName = ws['name'] as String);
-              setPageTitle(_workspaceName);
-            }
-            break;
-          }
-        }
+      final name =
+          await _findWorkspaceName(auth, '/api/v1/workspaces') ??
+          await _findWorkspaceName(auth, '/api/v1/workspaces/shared');
+      if (name != null && mounted) {
+        setState(() => _workspaceName = name);
+        setPageTitle(_workspaceName);
       }
     } catch (e) {
       debugPrint('[WorkspacePage] fetch workspace name failed: $e');
@@ -168,6 +162,19 @@ class _WorkspacePageState extends State<WorkspacePage> {
     } catch (e) {
       debugPrint('[WorkspacePage] fetch permissions failed: $e');
     }
+  }
+
+  Future<String?> _findWorkspaceName(AuthService auth, String url) async {
+    final response = await auth.authGet(url);
+    if (response.statusCode == 200) {
+      final workspaces = jsonDecode(response.body) as List;
+      for (final ws in workspaces) {
+        if (ws['id'] == widget.workspaceId) {
+          return ws['name'] as String;
+        }
+      }
+    }
+    return null;
   }
 
   bool _hasPerm(String perm) =>
@@ -214,7 +221,8 @@ class _WorkspacePageState extends State<WorkspacePage> {
         final deletedUserId = msg['user_id'] as String? ?? '';
         final deletedWindow = msg['window_name'] as String? ?? '';
         final deletedWid = msg['window_id'] as String? ?? '';
-        final wasViewing = _activeSharedTerminal != null &&
+        final wasViewing =
+            _activeSharedTerminal != null &&
             _activeSharedTerminal!['user_id'] == deletedUserId &&
             _activeSharedTerminal!['window_id'] == deletedWid;
         if (wasViewing) {
@@ -293,8 +301,9 @@ class _WorkspacePageState extends State<WorkspacePage> {
       // Track selected own-window: initialize on first message, or
       // reset if the selected window was closed.
       if (wsClient.terminalWindows.isNotEmpty) {
-        final ids =
-            wsClient.terminalWindows.map((w) => w['id'] as String?).toSet();
+        final ids = wsClient.terminalWindows
+            .map((w) => w['id'] as String?)
+            .toSet();
         if (_selectedOwnWindowId == null) {
           // First load — select window 0 (grouped sessions start there).
           _selectedOwnWindowId = wsClient.terminalWindows[0]['id'] as String?;
@@ -312,10 +321,7 @@ class _WorkspacePageState extends State<WorkspacePage> {
         final userId = first['user_id'] as String?;
         final windowId = first['window_id'] as String?;
         if (userId != null && windowId != null) {
-          _activeSharedTerminal = {
-            'user_id': userId,
-            'window_id': windowId,
-          };
+          _activeSharedTerminal = {'user_id': userId, 'window_id': windowId};
           wsClient.sendJoinSharedTerminal(userId, windowId);
         }
       }
@@ -356,10 +362,7 @@ class _WorkspacePageState extends State<WorkspacePage> {
 
   void _joinShared(WsClient wsClient, String userId, String windowId) {
     setState(
-      () => _activeSharedTerminal = {
-        'user_id': userId,
-        'window_id': windowId,
-      },
+      () => _activeSharedTerminal = {'user_id': userId, 'window_id': windowId},
     );
     // Clear the terminal so stale content from the previous session
     // doesn't linger while the join is in progress.


### PR DESCRIPTION
## Summary
- Fall back to `/api/v1/workspaces/shared` when the workspace isn't found in owned workspaces, so shared workspace names display correctly in the app bar
- Extracted lookup logic into `_findWorkspaceName` helper to avoid duplication

## Test plan
- [ ] Open a workspace you own — name displays as before
- [ ] Open a workspace shared with you — name now displays instead of generic "Workspace"

Fixes #1346