### PR TITLE
docs: update image version references to v1.0

### DIFF
--- a/docs/deployment/customizing.md
+++ b/docs/deployment/customizing.md
@@ -177,7 +177,7 @@ cd customize
 ./build.sh
 
 # Or pin to a specific Klangk release:
-KLANGK_REF=v2026.06.10-1 ./build.sh
+KLANGK_REF=v1.0 ./build.sh
 ```
 
 The resulting image is tagged `ghcr.io/mcdonc/klangk/klangk-host-custom:latest` by default. Override with `KLANGK_HOST_IMAGE`.

--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -28,7 +28,7 @@ docker run -d \
   -e KLANGK_LLM_BASE_URL=https://ollama.com/v1 \
   -e KLANGK_LLM_API_KEY=your-api-key \
   -e KLANGK_LLM_MODEL=gemma4:31b \
-  ghcr.io/mcdonc/klangk/klangk-host:v2026.06.10
+  ghcr.io/mcdonc/klangk/klangk-host:v1.0
 ```
 
 Open <http://localhost:8995> and log in with the email and password
@@ -79,7 +79,7 @@ Create a `docker-compose.yml`:
 ```yaml
 services:
   klangk:
-    image: ghcr.io/mcdonc/klangk/klangk-host:v2026.06.10
+    image: ghcr.io/mcdonc/klangk/klangk-host:v1.0
     ports:
       - "8995:8995"
     volumes:
@@ -109,7 +109,7 @@ Then: `docker compose up -d`
 ## Updating
 
 ```bash
-docker pull ghcr.io/mcdonc/klangk/klangk-host:v2026.06.15
+docker pull ghcr.io/mcdonc/klangk/klangk-host:v1.0
 docker stop klangk
 docker rm klangk
 # Run the same docker run command with the new version tag

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -24,7 +24,7 @@ docker run -d \
   -e KLANGK_LLM_BASE_URL=https://ollama.com/v1 \
   -e KLANGK_LLM_API_KEY=your-api-key \
   -e KLANGK_LLM_MODEL=gemma4:31b \
-  ghcr.io/mcdonc/klangk/klangk-host:v2026.06.10
+  ghcr.io/mcdonc/klangk/klangk-host:v1.0
 ```
 
 Open <http://localhost:8995> and log in with the email and password


### PR DESCRIPTION
## Summary
- Update all `v2026.06.10` and `v2026.06.15` image tag references in docs to `v1.0`
- Affected files: getting-started.md, deployment/docker.md, deployment/customizing.md

## Test plan
- [ ] Verify docs render correctly after merge