### PR TITLE
fix(backend): disable uvicorn ProxyHeadersMiddleware for outer proxy compatibility

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -10,6 +10,7 @@ let
        --host 0.0.0.0 \
        --port $KLANGK_PORT \
        --no-access-log \
+       --no-proxy-headers \
        --ws-max-size ''${KLANGK_WS_MSG_SIZE_MAX:-16777216} \
        --ws-ping-interval 20 \
        --ws-ping-timeout 20'';

--- a/src/containers/host/supervisord.conf
+++ b/src/containers/host/supervisord.conf
@@ -9,6 +9,7 @@ pidfile=/tmp/supervisord.pid
 command=python3 -m uvicorn klangk_backend.main:app
     --host 0.0.0.0
     --port %(ENV_KLANGK_PORT)s
+    --no-proxy-headers
     --ws-max-size 16777216
     --ws-ping-interval 20
     --ws-ping-timeout 20


### PR DESCRIPTION
## Summary

- Adds `--no-proxy-headers` to uvicorn in both devenv (devenv.nix) and Docker (supervisord.conf)
- Fixes OIDC login failing with "invalid parameter: redirect_uri" when klangk runs behind an outer reverse proxy (e.g. nginx doing TLS termination)

The root cause: uvicorn's default `ProxyHeadersMiddleware` rewrites `request.client` to the end-user IP from `X-Forwarded-For`. This conflicts with the peer-based proxy trust check in `derive_hosting_info` (added in #937), which expects `request.client` to be the TCP peer (e.g. `127.0.0.1`). Behind an outer proxy, the backend saw the browser's IP instead of the proxy's, rejected the forwarded headers, and built OIDC redirect URIs with `http://` and no base path.

This would also influence the URLs generated by klangk-hosted-url.

## Test plan

- [x] Backend unit tests pass (2183 passed, 100% coverage)
- [x] Verified on demo.toughserv.com — OIDC login now works correctly with `https` and `/klangk` base path