### PR TITLE
Upgrade to klangk-plugin-api v0.2.0 and render plugin app bar actions

### DIFF
--- a/plugins/beep/klangk/pubspec.yaml
+++ b/plugins/beep/klangk/pubspec.yaml
@@ -13,4 +13,4 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
-      ref: add-app-bar-action
+      ref: v0.2.0

--- a/plugins/beep/klangk/pubspec.yaml
+++ b/plugins/beep/klangk/pubspec.yaml
@@ -13,4 +13,4 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
-      ref: v0.1.0
+      ref: add-app-bar-action

--- a/plugins/bobdobbs/klangk/pubspec.yaml
+++ b/plugins/bobdobbs/klangk/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
-      ref: add-app-bar-action
+      ref: v0.2.0
 
 flutter:
   assets:

--- a/plugins/bobdobbs/klangk/pubspec.yaml
+++ b/plugins/bobdobbs/klangk/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
-      ref: v0.1.0
+      ref: add-app-bar-action
 
 flutter:
   assets:

--- a/plugins/boingball/klangk/pubspec.yaml
+++ b/plugins/boingball/klangk/pubspec.yaml
@@ -13,5 +13,5 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
-      ref: v0.1.0
+      ref: add-app-bar-action
   http: ^1.2.0

--- a/plugins/boingball/klangk/pubspec.yaml
+++ b/plugins/boingball/klangk/pubspec.yaml
@@ -13,5 +13,5 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
-      ref: add-app-bar-action
+      ref: v0.2.0
   http: ^1.2.0

--- a/plugins/celebrate/klangk/pubspec.yaml
+++ b/plugins/celebrate/klangk/pubspec.yaml
@@ -13,4 +13,4 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
-      ref: add-app-bar-action
+      ref: v0.2.0

--- a/plugins/celebrate/klangk/pubspec.yaml
+++ b/plugins/celebrate/klangk/pubspec.yaml
@@ -13,4 +13,4 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
-      ref: v0.1.0
+      ref: add-app-bar-action

--- a/plugins/git-credential/klangk/pubspec.yaml
+++ b/plugins/git-credential/klangk/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
-      ref: add-app-bar-action
+      ref: v0.2.0
 
 dev_dependencies:
   flutter_test:

--- a/plugins/git-credential/klangk/pubspec.yaml
+++ b/plugins/git-credential/klangk/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
-      ref: v0.1.0
+      ref: add-app-bar-action
 
 dev_dependencies:
   flutter_test:

--- a/plugins/itstime/klangk/pubspec.yaml
+++ b/plugins/itstime/klangk/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
-      ref: add-app-bar-action
+      ref: v0.2.0
 
 flutter:
   assets:

--- a/plugins/itstime/klangk/pubspec.yaml
+++ b/plugins/itstime/klangk/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
-      ref: v0.1.0
+      ref: add-app-bar-action
 
 flutter:
   assets:

--- a/scripts/import_dart_plugins.py
+++ b/scripts/import_dart_plugins.py
@@ -31,7 +31,7 @@ PLUGIN_API_DEP = {
     "klangk_plugin_api": {
         "git": {
             "url": "https://github.com/mcdonc/klangk-plugin-api.git",
-            "ref": "v0.1.0",
+            "ref": "add-app-bar-action",
         }
     }
 }

--- a/src/frontend/lib/workspace/workspace_page.dart
+++ b/src/frontend/lib/workspace/workspace_page.dart
@@ -405,7 +405,12 @@ class _WorkspacePageState extends State<WorkspacePage> {
         title: AppBarTitle(
           title: _workspaceName.isNotEmpty ? _workspaceName : 'Workspace',
         ),
-        actions: const [AppBarActions()],
+        actions: [
+          for (final plugin in _plugins)
+            if (plugin.buildAppBarAction(context) != null)
+              plugin.buildAppBarAction(context)!,
+          const AppBarActions(),
+        ],
       ),
       body: Stack(
         children: [

--- a/src/frontend/pubspec.yaml
+++ b/src/frontend/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
-      ref: add-app-bar-action
+      ref: v0.2.0
   # Path set by import_plugins.py — do not edit this line
   klangk_plugins:
     path: PLACEHOLDER

--- a/src/frontend/pubspec.yaml
+++ b/src/frontend/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
   klangk_plugin_api:
     git:
       url: https://github.com/mcdonc/klangk-plugin-api.git
-      ref: v0.1.0
+      ref: add-app-bar-action
   # Path set by import_plugins.py — do not edit this line
   klangk_plugins:
     path: PLACEHOLDER


### PR DESCRIPTION
## Summary

- Upgrade `klangk_plugin_api` from v0.1.0 to v0.2.0 (adds `buildAppBarAction()` to `ToolPlugin`)
- Render plugin `buildAppBarAction()` widgets in `AppBar.actions` before the email/admin/logout controls
- Update `import_dart_plugins.py` to use v0.2.0 ref for the generated `klangk_plugins` package
- Update all bundled plugin pubspecs to v0.2.0

Closes #1369

## Test plan

- [x] Soliplex plugin (soliplex/klangk-plugin-soliplex#25) tested with this branch — hub icon renders in app bar
- [x] Plugins without `buildAppBarAction()` are unaffected (method defaults to null)