### PR TITLE
ci: add CDK workspace pentest workflow

### DIFF
--- a/.github/workflows/cdk-workspace-pentest.yml
+++ b/.github/workflows/cdk-workspace-pentest.yml
@@ -1,0 +1,198 @@
+name: CDK Workspace Pentest
+
+# Runs the CDK (cdk-team/CDK) container-penetration toolkit inside the
+# latest workspace image, launched with klangk's *real* runtime posture
+# (keep-id userns, --init, host.containers.internal add-host, default
+# caps, NOT privileged). This is the offensive counterpart to the
+# trivy-workspace-scan: trivy statically scans packages; CDK tests the
+# runtime escape surface — the container-escape adversary the project
+# actually cares about.
+#
+# `cdk evaluate --full` runs the recon pass (capabilities, mounts,
+# kernel, sockets, namespaces) and is always informational. A finding
+# CDK rates "Critical" (a concrete escape primitive in posture, e.g.
+# SYS_ADMIN / privileged / writable docker.sock) fails the run when
+# `fail-on-escape` is on (default) — turning this into a regression
+# gate that complements #1376 (nginx deny-by-default from containers).
+#
+# `run-exploits` (opt-in) additionally fires CDK's escape-class
+# exploits against the ephemeral container for manual triage. Some are
+# destructive in nature (runc overwrite); the container is disposable,
+# so this is safe here but never run unattended.
+#
+# CDK release: https://github.com/cdk-team/CDK/releases
+
+on:
+  workflow_dispatch:
+    inputs:
+      cdk-version:
+        description: "CDK release tag to use"
+        required: false
+        default: "v1.5.6"
+        type: string
+      fail-on-escape:
+        description: "Fail the run if CDK rates any finding Critical"
+        required: false
+        default: true
+        type: boolean
+      run-exploits:
+        description: "Also fire escape-class exploits (destructive; manual triage)"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  pentest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Build workspace image
+        uses: ./.github/actions/devenv-setup
+        with:
+          build-tasks: klangk:build-workspace-image
+
+      - name: Download CDK binary
+        id: cdk
+        shell: bash
+        run: |
+          set -euo pipefail
+          VER="${{ inputs.cdk-version }}"
+          ARCH="cdk_linux_amd64"
+          URL="https://github.com/cdk-team/CDK/releases/download/${VER}/${ARCH}"
+          echo "Downloading $URL"
+          curl -fL "$URL" -o cdk
+          chmod +x cdk
+          # Expected sha256 for v1.5.6; warn-only if version pinned elsewhere.
+          EXPECTED="c6a222d823fb49a82381dbbcecbc57cd6f9d03c4222ec8c280289b6627beceb9"
+          GOT="$(sha256sum cdk | cut -d' ' -f1)"
+          echo "sha256: $GOT"
+          if [ "$VER" = "v1.5.6" ] && [ "$GOT" != "$EXPECTED" ]; then
+            echo "::warning::CDK sha256 mismatch (expected $EXPECTED)"; exit 1
+          fi
+          ./cdk version || ./cdk --version || true
+
+      - name: Launch workspace container with real posture
+        shell: bash
+        run: |
+          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+          set -euo pipefail
+          IMAGE="${KLANGK_IMAGE_NAME:-klangk-workspace}:latest"
+          mkdir -p out
+          devenv shell -- podman run -d --name cdk-target \
+            --userns keep-id:uid=1000,gid=1000 \
+            --init \
+            --add-host host.containers.internal:host-gateway \
+            --tmpfs /tmp:rw,exec,nosuid,size=2g \
+            --tmpfs /run:rw,noexec,nosuid,size=256m \
+            --tmpfs /var/log:rw,noexec,nosuid,size=256m \
+            -v "$PWD/cdk:/tmp/cdk:ro" \
+            --entrypoint /bin/sh \
+            "$IMAGE" -c "sleep infinity"
+          devenv shell -- podman exec cdk-target /tmp/cdk version
+
+      - name: CDK evaluate (recon)
+        shell: bash
+        run: |
+          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+          devenv shell -- podman exec cdk-target /tmp/cdk evaluate --full \
+            > out/evaluate.txt 2>&1
+          cat out/evaluate.txt
+
+      - name: CDK escape exploits (opt-in)
+        if: ${{ inputs.run-exploits }}
+        shell: bash
+        run: |
+          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+          # Escape-class exploits relevant to a rootless podman workspace
+          # (K8s/dockerd-specific ones omitted). Validated against
+          # `cdk run --list`. Each is non-fatal here; output is for
+          # manual triage.
+          : > out/exploits.txt
+          for exp in \
+              docker-sock-check check-ptrace abuse-unpriv-userns \
+              cap-dac-read-search mount-procfs mount-disk ; do
+            {
+              echo "=== cdk run $exp ==="
+              devenv shell -- podman exec cdk-target /tmp/cdk run "$exp" 2>&1 \
+                || echo "($exp exited non-zero)"
+            } >> out/exploits.txt
+          done
+          cat out/exploits.txt
+
+      - name: Capture container posture (inspect)
+        if: always()
+        shell: bash
+        run: |
+          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+          devenv shell -- podman inspect cdk-target \
+            > out/container-inspect.json 2>&1 || true
+          # CDK's own view of the sandbox boundary.
+          devenv shell -- podman exec cdk-target /tmp/cdk evaluate \
+            > out/evaluate-short.txt 2>&1 || true
+
+      - name: Gate on Critical findings
+        if: ${{ inputs.fail-on-escape }}
+        shell: bash
+        run: |
+          # CDK prefixes concrete escape primitives with "Critical - "
+          # (e.g. "Critical - SYS_ADMIN Capability Found",
+          #        "Critical - Possible Privileged Container Found").
+          # A well-configured workspace container should produce none.
+          if grep -qE '^Critical' out/evaluate.txt; then
+            echo "::error::CDK reports a Critical escape primitive:"
+            grep -E '^Critical' out/evaluate.txt
+            exit 1
+          fi
+          echo "No Critical escape primitives reported."
+
+      - name: Build summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "### 💣 CDK workspace pentest"
+            echo
+            echo "CDK \`${{ inputs.cdk-version }}\` run inside \`klangk-workspace:latest\`"
+            echo "launched with the real klangk posture (keep-id userns, \`--init\`,"
+            echo "\`host.containers.internal:host-gateway\`, default caps, not privileged)."
+            echo
+            echo "<details><summary>CDK <code>evaluate --full</code> output</summary>"
+            echo
+            echo '```'
+            cat out/evaluate.txt 2>/dev/null
+            echo '```'
+            echo "</details>"
+            if [ "${{ inputs.run-exploits }}" = "true" ]; then
+              echo "<details><summary>CDK escape-exploit output</summary>"
+              echo
+              echo '```'
+              cat out/exploits.txt 2>/dev/null
+              echo '```'
+              echo "</details>"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload CDK artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cdk-workspace-pentest
+          path: out/
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Cleanup
+        if: always()
+        shell: bash
+        run: |
+          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+          devenv shell -- podman rm -f cdk-target >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch` GitHub Action that runs the [CDK](https://github.com/cdk-team/CDK) container-penetration toolkit inside the latest `klangk-workspace` image.

This is the **offensive counterpart** to `trivy-workspace-scan.yml`: trivy statically scans packages; CDK tests the **runtime container-escape surface** — the actual adversary the project cares about (code/agent escaping its container to the host).

## Why

Barring a kernel/runtime bug, the realistic container-escape vector is an agent brute-forcing posture for a misconfig or a writable socket. A periodic offensive scan catches posture regressions (an accidental `--privileged`, a stray `--cap-add`, an exposed docker.sock) before they ship — and complements **#1376** (nginx deny-by-default from container IPs, the API-surface cap).

## What it does

Launches `klangk-workspace:latest` with klangk's **real** runtime posture — not a generic `podman run`, so findings reflect production:

| Flag | Source |
|---|---|
| `--userns keep-id:uid=1000,gid=1000` | `container.py:1455` |
| `--init` | `container.py:1444` |
| `--add-host host.containers.internal:host-gateway` | `container.py:1449` |
| tmpfs `/tmp`, `/run`, `/var/log` | `container.py:1439-1443` |
| no `--privileged`, no `--cap-add` | rootless defaults |

Then runs CDK inside it. The binary is bind-mounted read-only (`-v .../cdk:/tmp/cdk:ro`) to sidestep keep-id ownership issues.

## Inputs

- **`cdk-version`** (default `v1.5.6`, latest) — sha256-pinned and verified.
- **`fail-on-escape`** (default `true`) — gates on CDK's `Critical -` findings (`SYS_ADMIN` / privileged / writable docker.sock). Turns this into a regression gate.
- **`run-exploits`** (default `false`) — opt-in: fires escape-class exploits relevant to a rootless podman workspace for manual triage: `docker-sock-check`, `check-ptrace`, `abuse-unpriv-userns`, `cap-dac-read-search`, `mount-procfs`, `mount-disk` (names verified against CDK's `RegisterExploit` registry; K8s/dockerd-specific ones omitted).

## Output

- Job summary: collapsible `evaluate --full` + (if enabled) exploit output.
- Artifact `cdk-workspace-pentest`: `evaluate.txt`, `exploits.txt`, `container-inspect.json`.
- Container always cleaned up (`podman rm -f`, `if: always()`).

## Test plan

- [ ] Dispatch the workflow with defaults; confirm `cdk evaluate --full` runs and the gate passes (no `Critical -` findings against the current posture).
- [ ] Dispatch with `run-exploits=true`; confirm exploit output is captured.
- [ ] (Negative test) Dispatch against a temporarily `--privileged` image variant; confirm the gate fails.

Refs #1374, #1375, #1376