### PR TITLE
ci(cdk-pentest): pass required args to exploits that need them

### DIFF
--- a/.github/workflows/cdk-workspace-pentest.yml
+++ b/.github/workflows/cdk-workspace-pentest.yml
@@ -116,13 +116,30 @@ jobs:
           # (K8s/dockerd-specific ones omitted). Validated against
           # `cdk run --list`. Each is non-fatal here; output is for
           # manual triage.
+          #
+          # Several exploits REQUIRE args (discovered in the first
+          # run-exploits dispatch, which printed usage and exited for
+          # docker-sock-check / abuse-unpriv-userns / mount-procfs).
+          # Benign payloads only: `id` (observable, side-effect-free).
+          # Any successful escape would print the host uid in the
+          # output instead of failing.
           : > out/exploits.txt
-          for exp in \
-              docker-sock-check check-ptrace abuse-unpriv-userns \
-              cap-dac-read-search mount-procfs mount-disk ; do
+          #  <name> <args...>  — args per `cdk run --list` / each exploit's usage.
+          run_exploits=(
+            "docker-sock-check /var/run/docker.sock"
+            "check-ptrace"
+            "abuse-unpriv-userns id"
+            "cap-dac-read-search"
+            "mount-procfs /mnt/host_proc id"
+            "mount-disk"
+          )
+          for entry in "${run_exploits[@]}"; do
+            # shellcheck disable=SC2086  # intentional word-split on args
+            set -- $entry
+            exp="$1"; shift
             {
-              echo "=== cdk run $exp ==="
-              devenv shell -- podman exec cdk-target /tmp/cdk run "$exp" 2>&1 \
+              echo "=== cdk run $exp $* ==="
+              devenv shell -- podman exec cdk-target /tmp/cdk run "$exp" "$@" 2>&1 \
                 || echo "($exp exited non-zero)"
             } >> out/exploits.txt
           done


### PR DESCRIPTION
## Summary

Fixes a gap in the `run-exploits` path of the CDK workspace pentest workflow (#1377). The first `run-exploits=true` dispatch ([run 28906713412](https://github.com/mcdonc/klangk/actions/runs/28906713412)) revealed that **3 of the 6 escape exploits printed usage and exited non-zero** because they require arguments:

| Exploit | Required args | Before |
|---|---|---|
| `docker-sock-check` | `<sock_path>` | `invalid input args` → exit |
| `abuse-unpriv-userns` | `\"shell-cmd-payloads\"` | `Invalid Input Args` → exit |
| `mount-procfs` | `<dir> \"<shell-payload>\"` | `Invalid input args` → exit |

So half the offensive checks were no-ops.

## Fix

Restructure the loop into an arg-aware dispatch (name + args per entry) and supply benign payloads:

```
docker-sock-check /var/run/docker.sock
abuse-unpriv-userns id
mount-procfs /mnt/host_proc id
```

`id` is observable and side-effect-free — a successful escape would print the **host** uid in the output instead of failing. The three arg-less exploits (`check-ptrace`, `cap-dac-read-search`, `mount-disk`) are unchanged.

## Context from the prior run (posture held)

For reference, all six checks passed cleanly against the current keep-id posture — no `Critical -` findings; `check-ptrace` → `SYS_PTRACE disabled`; `cap-dac-read-search` → `OpenByHandleAt: operation not permitted`; `mount-disk` → `mount error: target container is not privileged`. This PR makes the remaining three actually run.

## Test plan

- [ ] Dispatch with `run-exploits=true`; confirm all six exploits produce real output (not usage text) and none indicates a successful escape (no host uid leak).