### PR TITLE
ci: add CDK host pentest workflow

### DIFF
--- a/.github/workflows/cdk-host-pentest.yml
+++ b/.github/workflows/cdk-host-pentest.yml
@@ -1,0 +1,232 @@
+name: CDK Host Pentest
+
+# Runs the CDK (cdk-team/CDK) container-penetration toolkit inside the
+# klangk-HOST image — the privileged control plane (rootless-podman-in-
+# container that runs the backend + nginx + nested workspace containers).
+#
+# Unlike the workspace pentest, the host is intentionally privileged
+# (--cap-add SYS_ADMIN, seccomp=unconfined, systempaths=unconfined,
+# /dev/fuse, /dev/net/tun — see scripts/run-host-container.sh) because
+# it has to manage nested containers. So CDK WILL find escape primitives
+# here (SYS_ADMIN chief among them). This workflow is therefore an
+# AUDIT/BASELINE, not a gate: it records the host's escape surface for
+# manual review, and surfaces any NEW primitive that wasn't there last
+# run. `fail-on-escape` defaults OFF.
+#
+# Threat model: this is the nested-escape path. A workspace container
+# that breaks out to the host image still has to escape the host image
+# to reach the real host. Auditing the host's posture catches any
+# capability that shouldn't be there (an accidental extra --cap-add,
+# an unintended --privileged, a writable runtime socket mounted in).
+#
+# `cdk evaluate --full` runs recon. `run-exploits` (default on for the
+# host — findings are expected, so we want the full picture) fires the
+# SYS_ADMIN-relevant escape-class exploits.
+#
+# CDK release: https://github.com/cdk-team/CDK/releases
+
+on:
+  workflow_dispatch:
+    inputs:
+      cdk-version:
+        description: "CDK release tag to use"
+        required: false
+        default: "v1.5.6"
+        type: string
+      fail-on-escape:
+        description: "Fail the run if CDK rates any finding Critical (host is intentionally privileged; OFF by default)"
+        required: false
+        default: false
+        type: boolean
+      run-exploits:
+        description: "Fire escape-class exploits (host findings expected; ON by default)"
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  pentest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Bootstrap devenv
+        uses: ./.github/actions/devenv-setup
+        with:
+          # build-host-image (a devenv *script*, not a task) handles all
+          # its own prerequisites: flutter web + workspace image. So we
+          # only bootstrap devenv here, then build the host in the next
+          # step via `devenv shell -- build-host-image`.
+          build-tasks: ""
+
+      - name: Build host image
+        shell: bash
+        run: |
+          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+          devenv shell -- build-host-image
+
+      - name: Download CDK binary
+        shell: bash
+        run: |
+          set -euo pipefail
+          VER="${{ inputs.cdk-version }}"
+          ARCH="cdk_linux_amd64"
+          URL="https://github.com/cdk-team/CDK/releases/download/${VER}/${ARCH}"
+          echo "Downloading $URL"
+          curl -fL "$URL" -o cdk
+          chmod +x cdk
+          # Expected sha256 for v1.5.6; warn-only if version pinned elsewhere.
+          EXPECTED="c6a222d823fb49a82381dbbcecbc57cd6f9d03c4222ec8c280289b6627beceb9"
+          GOT="$(sha256sum cdk | cut -d' ' -f1)"
+          echo "sha256: $GOT"
+          if [ "$VER" = "v1.5.6" ] && [ "$GOT" != "$EXPECTED" ]; then
+            echo "::warning::CDK sha256 mismatch (expected $EXPECTED)"; exit 1
+          fi
+          ./cdk version || ./cdk --version || true
+
+      - name: Launch host container with real posture
+        shell: bash
+        run: |
+          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+          set -euo pipefail
+          IMAGE="${KLANGK_HOST_IMAGE:-klangk-host}:latest"
+          mkdir -p out
+          # Reproduce scripts/run-host-container.sh posture exactly.
+          # --privileged is intentionally NOT used here (run-host-container
+          # doesn't either) — SYS_ADMIN + seccomp=unconfined is the real
+          # shipped posture. CDK runs as root to see the true cap surface.
+          # Device flags are conditional (runner images may not expose them).
+          DEVS=()
+          [ -e /dev/fuse ] && DEVS+=(--device /dev/fuse)
+          [ -e /dev/net/tun ] && DEVS+=(--device /dev/net/tun)
+          devenv shell -- docker run -d --name cdk-host \
+            --cap-add SYS_ADMIN \
+            "${DEVS[@]}" \
+            --security-opt seccomp=unconfined \
+            --security-opt systempaths=unconfined \
+            -v "$PWD/cdk:/tmp/cdk:ro" \
+            --user root \
+            --entrypoint /bin/sh \
+            "$IMAGE" -c "sleep infinity"
+          devenv shell -- docker exec cdk-host /tmp/cdk version
+
+      - name: CDK evaluate (recon)
+        shell: bash
+        run: |
+          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+          devenv shell -- docker exec cdk-host /tmp/cdk evaluate --full \
+            > out/evaluate.txt 2>&1
+          cat out/evaluate.txt
+
+      - name: CDK escape exploits (default on for host)
+        if: ${{ inputs.run-exploits }}
+        shell: bash
+        run: |
+          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+          # SYS_ADMIN-relevant escape exploits for the host posture.
+          # `id` payload: a successful escape prints host uid instead
+          # of failing. Findings are EXPECTED here (host is privileged);
+          # this is for baseline/triage, not gating.
+          : > out/exploits.txt
+          run_exploits=(
+            "docker-sock-check /var/run/docker.sock"
+            "check-ptrace"
+            "abuse-unpriv-userns id"
+            "cap-dac-read-search"
+            "mount-procfs /mnt/host_proc id"
+            "mount-disk"
+            "mount-cgroup id"
+            "rewrite-cgroup-devices"
+          )
+          for entry in "${run_exploits[@]}"; do
+            # shellcheck disable=SC2086  # intentional word-split on args
+            set -- $entry
+            exp="$1"; shift
+            {
+              echo "=== cdk run $exp $* ==="
+              devenv shell -- docker exec cdk-host /tmp/cdk run "$exp" "$@" 2>&1 \
+                || echo "($exp exited non-zero)"
+            } >> out/exploits.txt
+          done
+          cat out/exploits.txt
+
+      - name: Capture container posture (inspect)
+        if: always()
+        shell: bash
+        run: |
+          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+          devenv shell -- docker inspect cdk-host \
+            > out/container-inspect.json 2>&1 || true
+          devenv shell -- docker exec cdk-host /tmp/cdk evaluate \
+            > out/evaluate-short.txt 2>&1 || true
+
+      - name: Gate on Critical findings (opt-in)
+        if: ${{ inputs.fail-on-escape }}
+        shell: bash
+        run: |
+          if grep -qE '^Critical' out/evaluate.txt; then
+            echo "::error::CDK reports a Critical escape primitive:"
+            grep -E '^Critical' out/evaluate.txt
+            exit 1
+          fi
+          echo "No Critical escape primitives reported."
+
+      - name: Build summary
+        if: always()
+        shell: bash
+        run: |
+          {
+            echo "### 💣 CDK host pentest"
+            echo
+            echo "CDK \`${{ inputs.cdk-version }}\` run inside \`${KLANGK_HOST_IMAGE:-klangk-host}:latest\`"
+            echo "as root, launched with the real host posture (--cap-add SYS_ADMIN,"
+            echo "seccomp=unconfined, systempaths=unconfined, /dev/fuse, /dev/net/tun)."
+            echo
+            echo "**The host is intentionally privileged** (it manages nested workspace"
+            echo "containers). CDK is expected to report escape primitives here — this"
+            echo "run records the baseline; review for anything *new or unexpected*."
+            echo
+            echo "Critical findings:"
+            echo '```'
+            grep -E '^Critical' out/evaluate.txt 2>/dev/null || echo "(none)"
+            echo '```'
+            echo
+            echo "<details><summary>CDK <code>evaluate --full</code> output</summary>"
+            echo
+            echo '```'
+            cat out/evaluate.txt 2>/dev/null
+            echo '```'
+            echo "</details>"
+            if [ "${{ inputs.run-exploits }}" = "true" ]; then
+              echo "<details><summary>CDK escape-exploit output</summary>"
+              echo
+              echo '```'
+              cat out/exploits.txt 2>/dev/null
+              echo '```'
+              echo "</details>"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload CDK artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cdk-host-pentest
+          path: out/
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Cleanup
+        if: always()
+        shell: bash
+        run: |
+          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+          devenv shell -- docker rm -f cdk-host >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch` GitHub Action that runs [CDK](https://github.com/cdk-team/CDK) inside the **klangk-host** image — the privileged control plane (rootless-podman-in-container that manages nested workspace containers).

Companion to **#1377** (workspace pentest). Together they cover both layers of the nested-escape path:

```
workspace container → [breaks out to] → host container → [breaks out to] → real host
       #1377 tests this                         this PR tests this
```

## Why this is an audit, not a gate

The host is **intentionally privileged** — it has to be, to manage nested containers. Posture reproduced exactly from `scripts/run-host-container.sh`:

| Flag | Why |
|---|---|
| `--cap-add SYS_ADMIN` | required for podman-in-container |
| `--security-opt seccomp=unconfined` | required for nested container ops |
| `--security-opt systempaths=unconfined` | required for nested container ops |
| `--device /dev/fuse` | fuse-overlayfs storage |
| `--device /dev/net/tun` | workspace networking |

Not `--privileged` (the real launch doesn't use it either) — SYS_ADMIN + seccomp=unconfined is the shipped config.

So CDK **will** find escape primitives here (SYS_ADMIN is the big one). This workflow records the baseline and surfaces anything *new or unexpected* (an accidental extra `--cap-add`, an unintended `--privileged`, a writable runtime socket). Defaults reflect this:

- **`fail-on-escape`** → **OFF** (Critical findings are expected)
- **`run-exploits`** → **ON** (we want the full picture; findings are for triage)

## What it does

1. Builds the host image via `devenv shell -- build-host-image` (a devenv *script*, not a task — handles its own workspace-image prerequisite, so no redundant build step).
2. Launches it with Docker (host is Docker-deployed, unlike the podman-based workspace).
3. Runs CDK as **root** to surface the true capability surface (the threat is a workspace that's already escaped to the host image, or an agent that's landed there).
4. `evaluate --full` recon + the SYS_ADMIN-relevant escape exploits (`mount-cgroup`, `rewrite-cgroup-devices`) on top of the workspace set. Arg-aware dispatch from #1378.
5. Conditional device flags via array (runner images may not expose `/dev/fuse` or `/dev/net/tun`).

## Test plan

- [ ] Dispatch with defaults; confirm the host builds, CDK runs, summary lists expected Critical findings (SYS_ADMIN).
- [ ] Review exploit output for anything unexpected beyond the known SYS_ADMIN/cgroup primitives.
- [ ] Confirm no *additional* Critical beyond what the documented posture implies.

Companion to #1377.