### PR TITLE
ci(cdk-pentest): schedule both CDK pentests daily at 06:43 UTC

### DIFF
--- a/.github/workflows/cdk-host-pentest.yml
+++ b/.github/workflows/cdk-host-pentest.yml
@@ -26,6 +26,9 @@ name: CDK Host Pentest
 # CDK release: https://github.com/cdk-team/CDK/releases
 
 on:
+  schedule:
+    # Daily 06:43 UTC
+    - cron: "43 6 * * *"
   workflow_dispatch:
     inputs:
       cdk-version:

--- a/.github/workflows/cdk-workspace-pentest.yml
+++ b/.github/workflows/cdk-workspace-pentest.yml
@@ -23,6 +23,9 @@ name: CDK Workspace Pentest
 # CDK release: https://github.com/cdk-team/CDK/releases
 
 on:
+  schedule:
+    # Daily 06:43 UTC
+    - cron: "43 6 * * *"
   workflow_dispatch:
     inputs:
       cdk-version:


### PR DESCRIPTION
## Summary

Adds a daily `schedule` trigger to both CDK pentest workflows:

| Workflow | Schedule | Defaults used by scheduled run |
|---|---|---|
| CDK Workspace Pentest | `43 6 * * *` (06:43 UTC daily) | `fail-on-escape` ON (gate), `run-exploits` OFF |
| CDK Host Pentest | `43 6 * * *` (06:43 UTC daily) | `fail-on-escape` OFF (audit), `run-exploits` ON |

`workflow_dispatch` remains for manual runs with custom inputs.

## Notes

- **06:43 UTC** — GitHub Actions cron is UTC. Off-hour, non-round minute to reduce Actions runner queue contention (the default branch's scheduled workflows from many repos queue on the top of the hour).
- Scheduled runs use each workflow's input **defaults**, preserving the intended roles: workspace pentest is a **gate** (fails CI on Critical posture regressions), host pentest is an **audit/baseline** (records findings for manual review).
- A scheduled workspace-pentest failure (a new `Critical -` finding) will now surface in the Actions tab daily without anyone having to remember to dispatch it.

Refs #1377, #1379.