### PR TITLE
ci(cdk-pentest): baseline-allowlist gate for both CDK pentests

### DIFF
--- a/.github/workflows/cdk-host-pentest.yml
+++ b/.github/workflows/cdk-host-pentest.yml
@@ -8,10 +8,12 @@ name: CDK Host Pentest
 # (--cap-add SYS_ADMIN, seccomp=unconfined, systempaths=unconfined,
 # /dev/fuse, /dev/net/tun — see scripts/run-host-container.sh) because
 # it has to manage nested containers. So CDK WILL find escape primitives
-# here (SYS_ADMIN chief among them). This workflow is therefore an
-# AUDIT/BASELINE, not a gate: it records the host's escape surface for
-# manual review, and surfaces any NEW primitive that wasn't there last
-# run. `fail-on-escape` defaults OFF.
+# here (SYS_ADMIN chief among them). The gate therefore diffs CDK's
+# Critical findings against a BASELINE ALLOWLIST of known-expected
+# primitives (currently: SYS_ADMIN) and fails only on a NEW/UNEXPECTED
+# one — an accidental extra --cap-add, an unintended --privileged (which
+# would let mount-cgroup actually escape), a mounted runtime socket, etc.
+# `fail-on-escape` defaults ON so the daily run alarms on regressions.
 #
 # Threat model: this is the nested-escape path. A workspace container
 # that breaks out to the host image still has to escape the host image
@@ -37,9 +39,9 @@ on:
         default: "v1.5.6"
         type: string
       fail-on-escape:
-        description: "Fail the run if CDK rates any finding Critical (host is intentionally privileged; OFF by default)"
+        description: "Fail on a NEW (non-baseline) Critical finding. The gate allowlists SYS_ADMIN, so this has signal. ON by default."
         required: false
-        default: false
+        default: true
         type: boolean
       run-exploits:
         description: "Fire escape-class exploits (host findings expected; ON by default)"
@@ -171,16 +173,39 @@ jobs:
           devenv shell -- docker exec cdk-host /tmp/cdk evaluate \
             > out/evaluate-short.txt 2>&1 || true
 
+      - name: Diff Critical findings against baseline
+        if: always()
+        shell: bash
+        run: |
+          # CDK prefixes concrete escape primitives with "Critical - ". The
+          # ALLOWLIST below names Critical findings that are part of this
+          # posture BY DESIGN and expected on every run. The gate fails only
+          # on Criticals NOT matched here — i.e. new/unexpected primitives.
+          # Add a substring ONLY when a finding is intentionally accepted.
+          ALLOW_PATTERNS=(
+            "SYS_ADMIN Capability Found"
+          )
+          : > out/all-criticals.txt
+          : > out/new-criticals.txt
+          grep -E '^Critical' out/evaluate.txt >> out/all-criticals.txt 2>/dev/null || true
+          cp out/all-criticals.txt out/new-criticals.txt
+          for pat in "${ALLOW_PATTERNS[@]}"; do
+            { grep -vF "$pat" out/new-criticals.txt || true; } > out/new.tmp
+            mv out/new.tmp out/new-criticals.txt
+          done
+          echo "All Critical findings: $(wc -l < out/all-criticals.txt)"
+          echo "New/unexpected (not baseline-allowed): $(wc -l < out/new-criticals.txt)"
+
       - name: Gate on Critical findings (opt-in)
         if: ${{ inputs.fail-on-escape }}
         shell: bash
         run: |
-          if grep -qE '^Critical' out/evaluate.txt; then
-            echo "::error::CDK reports a Critical escape primitive:"
-            grep -E '^Critical' out/evaluate.txt
+          if [ -s out/new-criticals.txt ]; then
+            echo "::error::New/unexpected CDK Critical finding(s) — not in the baseline allowlist:"
+            cat out/new-criticals.txt
             exit 1
           fi
-          echo "No Critical escape primitives reported."
+          echo "No new Critical escape primitives (baseline allowlist satisfied)."
 
       - name: Build summary
         if: always()
@@ -197,9 +222,12 @@ jobs:
             echo "containers). CDK is expected to report escape primitives here — this"
             echo "run records the baseline; review for anything *new or unexpected*."
             echo
-            echo "Critical findings:"
+            ALL=$(wc -l < out/all-criticals.txt 2>/dev/null || echo 0)
+            NEW=$(wc -l < out/new-criticals.txt 2>/dev/null || echo 0)
+            ALLOWED=$((ALL - NEW))
+            echo "Criticals: **$ALL total** ($ALLOWED baseline-allowed, **$NEW new/unexpected**)."
             echo '```'
-            grep -E '^Critical' out/evaluate.txt 2>/dev/null || echo "(none)"
+            cat out/all-criticals.txt 2>/dev/null || echo "(none)"
             echo '```'
             echo
             echo "<details><summary>CDK <code>evaluate --full</code> output</summary>"

--- a/.github/workflows/cdk-workspace-pentest.yml
+++ b/.github/workflows/cdk-workspace-pentest.yml
@@ -159,20 +159,38 @@ jobs:
           devenv shell -- podman exec cdk-target /tmp/cdk evaluate \
             > out/evaluate-short.txt 2>&1 || true
 
+      - name: Diff Critical findings against baseline
+        if: always()
+        shell: bash
+        run: |
+          # CDK prefixes concrete escape primitives with "Critical - ". The
+          # ALLOWLIST names Critical findings that are part of this posture
+          # BY DESIGN. The workspace is unprivileged, so NO Critical is
+          # expected — the allowlist is EMPTY and any Critical fails the gate
+          # (a genuine regression). Add a substring here only if a finding
+          # is ever intentionally accepted.
+          ALLOW_PATTERNS=()
+          : > out/all-criticals.txt
+          : > out/new-criticals.txt
+          grep -E '^Critical' out/evaluate.txt >> out/all-criticals.txt 2>/dev/null || true
+          cp out/all-criticals.txt out/new-criticals.txt
+          for pat in "${ALLOW_PATTERNS[@]}"; do
+            { grep -vF "$pat" out/new-criticals.txt || true; } > out/new.tmp
+            mv out/new.tmp out/new-criticals.txt
+          done
+          echo "All Critical findings: $(wc -l < out/all-criticals.txt)"
+          echo "New/unexpected (not baseline-allowed): $(wc -l < out/new-criticals.txt)"
+
       - name: Gate on Critical findings
         if: ${{ inputs.fail-on-escape }}
         shell: bash
         run: |
-          # CDK prefixes concrete escape primitives with "Critical - "
-          # (e.g. "Critical - SYS_ADMIN Capability Found",
-          #        "Critical - Possible Privileged Container Found").
-          # A well-configured workspace container should produce none.
-          if grep -qE '^Critical' out/evaluate.txt; then
-            echo "::error::CDK reports a Critical escape primitive:"
-            grep -E '^Critical' out/evaluate.txt
+          if [ -s out/new-criticals.txt ]; then
+            echo "::error::New/unexpected CDK Critical finding(s) — not in the baseline allowlist:"
+            cat out/new-criticals.txt
             exit 1
           fi
-          echo "No Critical escape primitives reported."
+          echo "No new Critical escape primitives (baseline allowlist satisfied)."
 
       - name: Build summary
         if: always()
@@ -184,6 +202,14 @@ jobs:
             echo "CDK \`${{ inputs.cdk-version }}\` run inside \`klangk-workspace:latest\`"
             echo "launched with the real klangk posture (keep-id userns, \`--init\`,"
             echo "\`host.containers.internal:host-gateway\`, default caps, not privileged)."
+            echo
+            ALL=$(wc -l < out/all-criticals.txt 2>/dev/null || echo 0)
+            NEW=$(wc -l < out/new-criticals.txt 2>/dev/null || echo 0)
+            ALLOWED=$((ALL - NEW))
+            echo "Criticals: **$ALL total** ($ALLOWED baseline-allowed, **$NEW new/unexpected**)."
+            echo '```'
+            cat out/all-criticals.txt 2>/dev/null || echo "(none)"
+            echo '```'
             echo
             echo "<details><summary>CDK <code>evaluate --full</code> output</summary>"
             echo


### PR DESCRIPTION
## Problem

The host pentest's blanket "fail on any Critical" gate had **no signal**: the host is intentionally privileged (`--cap-add SYS_ADMIN`), so CDK always reports `Critical - SYS_ADMIN Capability Found`. With `fail-on-escape=true`, [run 28908107942](https://github.com/mcdonc/klangk/actions/runs/28908107942) failed on that known finding — and would fail every run regardless of whether anything actually regressed.

The actual escape attempts in that run **correctly failed** (`mount-cgroup → "target container is not privileged"`), confirming the posture is as intended. The gate just couldn't express "SYS_ADMIN is expected, alarm only on something *new*."

## Change

Replace both workflows' gate with a **baseline-allowlist diff**:

- New always-run step `Diff Critical findings against baseline` writes:
  - `out/all-criticals.txt` — every `^Critical` line
  - `out/new-criticals.txt` — Criticals **not** matched by the workflow's `ALLOW_PATTERNS`
- Gate now fails only when `new-criticals.txt` is **non-empty** — i.e. on a *new/unexpected* primitive.
- Both summaries now report `Criticals: N total (M baseline-allowed, K new/unexpected).`

| Workflow | `ALLOW_PATTERNS` | Behavior |
|---|---|---|
| Host | `["SYS_ADMIN Capability Found"]` | SYS_ADMIN passes; anything new (extra cap, unintended `--privileged` that lets `mount-cgroup` escape, mounted socket) fails |
| Workspace | `[]` (empty) | Any Critical fails — identical to before, now with the same extensible structure |

## Host default flipped

`fail-on-escape` default `false → true`. The gate now has signal (SYS_ADMIN is allowlisted), so the daily 06:43 UTC run **alarms on regressions** instead of just logging. Workspace default stays `true`.

## Verification

Tested the diff/gate logic locally against the real failing run's output:

| Case | Expect | Result |
|---|---|---|
| Host, SYS_ADMIN only | pass | ✓ 0 new |
| Host, +new finding | fail | ✓ 1 new (`Possible Privileged Container Found`) |
| Workspace, clean | pass | ✓ 0 new |
| Workspace, any Critical | fail | ✓ 2 new |

Refs run 28908107942.