### PR TITLE
docs: add changelog page + wire release notes from it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,34 @@ jobs:
 
       - name: Create GitHub Release
         run: |
-          gh release create "$GITHUB_REF_NAME" \
-            --title "$GITHUB_REF_NAME" \
-            --generate-notes
+          # Release body = GitHub's auto-generated notes, with this version's
+          # section from docs/changes.md prepended (when present).
+          # `gh release create --generate-notes --notes "..."` prepends the
+          # --notes content to the auto-generated notes (per `gh release create --help`).
+          # docs/changes.md is the source of truth; see it and
+          # docs/development/releasing.md.
+          VERSION="$GITHUB_REF_NAME"
+          SECTION=""
+          if [ -f docs/changes.md ]; then
+            # Extract the body of the `## [<version>]` section. Matched as a
+            # prefix so an optional trailing date (`## [v1.0.5] - 2026-07-07`)
+            # still matches. Captured up to the next `## [` heading or EOF.
+            SECTION="$(awk -v ver="$VERSION" '
+              $0 ~ "^## \\[" ver "]" { found=1; next }
+              found && /^## \[/ { exit }
+              found { print }
+            ' docs/changes.md)"
+          fi
+          if [ -n "$SECTION" ]; then
+            gh release create "$VERSION" \
+              --title "$VERSION" \
+              --generate-notes \
+              --notes "$SECTION"
+          else
+            # No changelog section for this version — pure auto-generated notes.
+            gh release create "$VERSION" \
+              --title "$VERSION" \
+              --generate-notes
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,78 @@
+# Klangk agent instructions
+
+Project-specific guidance for coding agents working in this repo.
+
+## Prefix most commands with `devenv shell --`
+
+Klangk uses [devenv](https://devenv.sh) (Nix-based) for its dev environment. **Every command that touches the project toolchain must be run through the devenv shell**, including git. The toolchain — Python venv, Node, Dart/Flutter, podman, pre-commit hooks, etc. — only exists inside the shell.
+
+```bash
+devenv shell -- git commit -m "..."
+devenv shell -- pytest
+```
+
+`devenv shell --` launches an ephemeral shell with the full environment, runs the command, and exits — this is the pattern agents should use for one-off commands. (`devenv shell` with no `--` drops into an interactive shell; not useful for non-interactive agents.) This applies to **all** commands: builds, tests, lint, `git`, `podman`, `flutter`, `gh`.
+
+A long-running interactive `devenv up` (backend + nginx + workspace image build) is a human-facing workflow; agents generally don't run it. If you need the backend up for something, ask.
+
+## Changelog (`docs/changes.md`)
+
+`docs/changes.md` is the single source of truth for human-authored release notes,
+formatted as [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). It has two
+rendering surfaces:
+
+- **Docs site** — the whole file renders as one page at `/changes/`, sidebar entry
+  "Changelog" (nav is in `zensical.toml`). Includes the `## [Unreleased]`
+  section, so in-flight work is visible.
+- **Release tab** — when a `v*` tag is pushed, `release.yml` checks out the code
+  **at the tag**, extracts that version's `## [<version>]` section, and prepends it
+  to GitHub's auto-generated notes (PR list + compare link).
+
+### When to add an entry
+
+Add a bullet under `## [Unreleased]` **in the same PR that introduces the change**
+(not as an afterthought, not after merge). Use the matching subsection:
+
+- **Added** — new feature, config var, CLI flag, endpoint.
+- **Changed** — change to existing behavior, default, or signature.
+- **Deprecated** — soon-to-be-removed.
+- **Removed** — now removed.
+- **Fixed** — notable bug fix.
+- **Security** — vulnerability fix.
+- **Breaking** — sub-section under any version for changes requiring operator/integrator
+  action on upgrade. Call out the migration.
+
+Each entry: one line, reference the issue/PR (`(#1375)`), enough context that an
+operator skimming the changelog understands the impact.
+
+Add an entry for anything an **operator, integrator, or end user** would notice:
+new/changed config or defaults, behavior changes, security fixes, notable fixes,
+new features.
+
+**Skip** entries for: pure internal refactors, test/CI/doc churn with no user-visible
+effect, dependency bumps that don't change behavior. If in doubt, add it — it's easier
+to trim at release time than to reconstruct.
+
+### When to garden for a release
+
+Right before pushing the tag — do this as its own commit on `main`:
+
+1. Rename `## [Unreleased]` → `## [vX.Y.Z] - YYYY-MM-DD`
+   (today's date). The `v` prefix and bracket form **must match the tag exactly**;
+   the `- YYYY-MM-DD` date suffix is optional but conventional. The workflow matches the section
+   heading as a prefix, so `## [v1.0.5] - 2026-07-07` matches tag `v1.0.5`.
+2. Insert a fresh, empty `## [Unreleased]` heading directly above it.
+3. Commit, e.g. `chore(changelog): cut vX.Y.Z`.
+4. Tag and push: `devenv shell -- git tag vX.Y.Z && devenv shell -- git push origin vX.Y.Z`.
+
+**Critical sequencing:** `release.yml` checks out `docs/changes.md` at the tagged
+commit, so the `[Unreleased]` → `[vX.Y.Z]` rename **must land in (or before) the
+commit you tag**. If you tag a commit that still has the changes under
+`[Unreleased]`, the workflow finds no `## [vX.Y.Z]` section and the release body
+falls back to pure auto-generated notes — the human-authored section is silently lost.
+
+### After a release
+
+Nothing to do in `docs/changes.md` itself — the `[Unreleased]` heading you created
+at cut time is already in place for the next cycle's entries. Just start adding new
+entries under it.

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1,0 +1,38 @@
+# Changelog
+
+All notable changes to klangk are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and each version's section is also prepended to its GitHub Release notes (see
+[Releasing](../development/releasing.md)).
+
+Entries use the following conventions:
+
+- **Added** — new features.
+- **Changed** — changes to existing functionality.
+- **Deprecated** — soon-to-be removed features.
+- **Removed** — now removed features.
+- **Fixed** — bug fixes.
+- **Security** — fixes for vulnerabilities, in lieu of or in addition to a
+  dedicated security advisory.
+
+A `Breaking` subsection may appear under any version for changes that require
+operators or integrators to act when upgrading.
+
+<!-- The release workflow prepends each released version's section to its GitHub
+     Release body. Keep one `## [<version>]` section per release; unreleased
+     changes accumulate under `## [Unreleased]`. -->
+
+## [Unreleased]
+
+### Breaking
+
+- **uvicorn now binds `127.0.0.1` by default** instead of `0.0.0.0`
+  (`KLANGK_LISTEN`, new). Workspace containers could previously reach the
+  backend directly via `host.containers.internal:$KLANGK_PORT`, bypassing nginx
+  and therefore every per-location nginx ACL. nginx remains bound to `0.0.0.0`
+  (container-reachable, so soliplex and hosted apps still work) and proxies to
+  uvicorn on the loopback address. Operators who reach the backend directly —
+  bypassing nginx — must set `KLANGK_LISTEN=0.0.0.0` to restore the old
+  behavior. Applies to both the devenv dev server and the host container.
+  (#1375)

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -3,11 +3,15 @@
 Push a semver tag to trigger the `release.yml` workflow:
 
 ```bash
-git tag v0.1.0
-git push origin v0.1.0
+devenv shell -- git tag v0.1.0
+devenv shell -- git push origin v0.1.0
 ```
 
-This builds the host image (including workspace and Flutter web), pushes both `klangk-host` and `klangk-workspace` to GHCR tagged with the version (e.g. `v0.1.0`), and creates a GitHub Release with auto-generated notes. No `:latest` tag is pushed — all images are referenced by explicit version. For patch releases, increment the patch version: `v0.1.1`.
+This builds the host image (including workspace and Flutter web), pushes both `klangk-host` and `klangk-workspace` to GHCR tagged with the version (e.g. `v0.1.0`), and creates a GitHub Release. The release body is GitHub's auto-generated notes (PR list + compare link) **with that version's section from [the changelog](../changes.md) prepended**, when one exists. No `:latest` tag is pushed — all images are referenced by explicit version. For patch releases, increment the patch version: `v0.1.1`.
+
+## Gardening the changelog before a tag
+
+`docs/changes.md` is the source of truth for human-authored release notes. Right before tagging, rename the accumulated `## [Unreleased]` section to `## [vX.Y.Z] - YYYY-MM-DD` and add a fresh empty `## [Unreleased]` above it, in its own commit. The release workflow extracts the `## [vX.Y.Z]` section from the checkout at the tag, so the rename must land in (or before) the commit you tag. See `AGENTS.md` for the full maintenance rules (when to add entries, what qualifies).
 
 ## CI
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -63,6 +63,7 @@ nav = [
     { "Creating Plugins" = "development/creating-plugins.md" },
     { "Stable Branches" = "development/stable-branches.md" },
   ]},
+  { "Changelog" = "changes.md" },
   { "Architecture" = [
     { "Overview" = "architecture/index.md" },
     { "LLM Proxy" = "architecture/llm-proxy.md" },


### PR DESCRIPTION
## What

Introduce a proper changelog for klangk (there wasn't one) and wire it into two surfaces:

- **Docs site** — `docs/changes.md` renders at `/changes/` via a new top-level "Changelog" nav entry in `zensical.toml`.
- **Release tab** — `release.yml` now extracts the tagged version's `## [<version>]` section from `docs/changes.md` and prepends it to GitHub's auto-generated notes (`gh release create --generate-notes --notes "..."`). Falls back to pure auto-generated notes when no section exists.

Also adds a repo-local `AGENTS.md` spelling out maintenance rules for coding agents:

- Prefix commands with `devenv shell --` (the toolchain only exists inside the devenv shell; applies to git, pytest, podman, flutter, gh, etc.).
- Add a changelog entry under `## [Unreleased]` **in the PR that introduces the change**.
- At release time, rename `## [Unreleased]` → `## [vX.Y.Z] - YYYY-MM-DD` in the tagged commit (the workflow reads `docs/changes.md` at the tag, so the rename must land in or before the tagged commit).

`docs/development/releasing.md` is updated to match, including the `devenv shell --` prefix in its tag examples.

## Why a separate PR

This was originally bundled into #1383 (the uvicorn bind fix, #1375), where the `#1375` breaking change is recorded under `## [Unreleased]`. It's a distinct concern — a docs/process change with no code/security impact — so it's split out here. The two PRs are independent; once both merge, `docs/changes.md` will carry the `#1375` entry and the code will carry the fix.

## Files

- `docs/changes.md` (new) — Keep-a-Changelog, source of truth.
- `zensical.toml` — "Changelog" nav entry.
- `.github/workflows/release.yml` — changelog section extraction + prepend to generated notes.
- `docs/development/releasing.md` — changelog gardening step + `devenv shell --` examples.
- `AGENTS.md` (new) — agent maintenance rules.

## Notes for review

- The `release.yml` awk extraction was tested locally against a fixture: correctly extracts a versioned section (with or without a trailing `- date`), handles the last section via EOF, and returns empty for nonexistent versions (triggering the auto-notes fallback).
- `--generate-notes --notes "..."` is the documented way for `gh` to prepend manual notes to auto-generated content; the earlier `--notes-file` + `--generate-notes` combination was invalid and is what motivated splitting this out cleanly.
- No `CHANGES.md` is touched here (the root `CHANGES.md` orphan currently only exists on #1383's branch; on `main` there is none, so this PR introduces `docs/changes.md` cleanly).
