### PR TITLE
Config loader: route all config reads through pydantic-settings (#1394)

### DIFF
--- a/src/backend/klangk_backend/api/__init__.py
+++ b/src/backend/klangk_backend/api/__init__.py
@@ -181,11 +181,11 @@ PRODUCT_NAME = resolve_env_value("KLANGK_PRODUCT_NAME", "Klangk") or "Klangk"
 # resolution). A deployer pointing these at sensitive internal resources
 # would be exposing them to the world. Empty string when unset, matching the
 # logo_url convention the frontend already falls back from.
-TERMS_URL = os.environ.get("KLANGK_TERMS_URL", "")
-PRIVACY_URL = os.environ.get("KLANGK_PRIVACY_URL", "")
-AUP_URL = os.environ.get("KLANGK_AUP_URL", "")
-SUPPORT_URL = os.environ.get("KLANGK_SUPPORT_URL", "")
-SUPPORT_EMAIL = os.environ.get("KLANGK_SUPPORT_EMAIL", "")
+TERMS_URL = resolve_env_value("KLANGK_TERMS_URL") or ""
+PRIVACY_URL = resolve_env_value("KLANGK_PRIVACY_URL") or ""
+AUP_URL = resolve_env_value("KLANGK_AUP_URL") or ""
+SUPPORT_URL = resolve_env_value("KLANGK_SUPPORT_URL") or ""
+SUPPORT_EMAIL = resolve_env_value("KLANGK_SUPPORT_EMAIL") or ""
 
 
 @router.get("/config")

--- a/src/backend/klangk_backend/emailsvc.py
+++ b/src/backend/klangk_backend/emailsvc.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import logging
-import os
 import shutil
 from dataclasses import dataclass
 from email.message import EmailMessage
@@ -151,11 +150,11 @@ def _brand_ctx() -> dict:
         # file:/cmd: resolution -- they are public and shown in the email
         # footer to all recipients. Mirrors what /config exposes to the
         # frontend; the base template renders whatever is set.
-        "terms_url": os.environ.get("KLANGK_TERMS_URL", ""),
-        "privacy_url": os.environ.get("KLANGK_PRIVACY_URL", ""),
-        "aup_url": os.environ.get("KLANGK_AUP_URL", ""),
-        "support_url": os.environ.get("KLANGK_SUPPORT_URL", ""),
-        "support_email": os.environ.get("KLANGK_SUPPORT_EMAIL", ""),
+        "terms_url": resolve_env_value("KLANGK_TERMS_URL") or "",
+        "privacy_url": resolve_env_value("KLANGK_PRIVACY_URL") or "",
+        "aup_url": resolve_env_value("KLANGK_AUP_URL") or "",
+        "support_url": resolve_env_value("KLANGK_SUPPORT_URL") or "",
+        "support_email": resolve_env_value("KLANGK_SUPPORT_EMAIL") or "",
     }
 
 

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -27,6 +27,7 @@ from . import (
     workspaces,
     wshandler,
 )
+from .settings import validate_at_startup
 from .api import root_router, router
 from .util import API_PREFIX, derive_hosting_info
 from .model import (
@@ -416,6 +417,12 @@ def on_sighup() -> None:
 async def lifespan(app: FastAPI):
     await model.init_db()
     await model.resolve_instance_id()
+
+    # Eagerly validate all config at startup (#1394).  Instantiate the
+    # KlangkSettings singleton so bogus values fail fast before the server
+    # serves traffic.  (Fields are Optional[str] in this chunk; strict types
+    # arrive incrementally as call sites migrate to settings.field access.)
+    validate_at_startup()
 
     existing_pid = check_pid_file()
     if existing_pid is not None:

--- a/src/backend/klangk_backend/settings.py
+++ b/src/backend/klangk_backend/settings.py
@@ -1,0 +1,349 @@
+"""Typed configuration via pydantic-settings (#1394).
+
+This module is the single source of truth for all ``KLANGK_*`` configuration.
+It replaces the ad-hoc ``resolve_env_value`` / ``resolve_env_bool`` /
+``os.environ.get`` reads that were scattered across the codebase.
+
+Design (see #1392, #1394):
+
+- **pydantic-settings** reads env vars (``env_prefix="KLANGK_"``) into a typed
+  ``KlangkSettings`` model.  Fields are ``Optional[str]`` in this chunk to
+  preserve the exact string-returning behavior of the legacy
+  ``resolve_env_value``; typed fields (``int`` / ``bool`` / ``list``) arrive
+  incrementally as call sites migrate to direct ``settings.field`` access.
+- **``file:`` / ``cmd:`` resolution** is applied by :func:`resolve_indirection`,
+  shared between :func:`resolve_env_value` (legacy) and direct settings access.
+  Both paths produce identical results regardless of whether the value came
+  from an env var or (future) a config file — capability is a property of the
+  value, not the source.
+- **Env-change-detection cache** (:func:`get_settings`): the settings singleton
+  is re-instantiated whenever any ``KLANGK_*`` env var changes, so
+  ``monkeypatch.setenv`` / ``monkeypatch.delenv`` in tests invalidates the
+  cache automatically — preserving the call-time env-reading behavior that
+  ~337 test env-manipulations rely on.
+- **Startup validation**: :func:`validate_at_startup` instantiates the model
+  eagerly so bogus config fails fast, before the server serves traffic.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+logger = logging.getLogger(__name__)
+
+# Re-exported for backward compat — callers that ``from ..util import ...``
+# still work because util.py re-exports these.
+__all__ = [
+    "KlangkSettings",
+    "get_settings",
+    "resolve_env_value",
+    "resolve_env_bool",
+    "resolve_indirection",
+    "validate_at_startup",
+]
+
+# ---------------------------------------------------------------------------
+# file: / cmd: indirection resolver (shared by all read paths)
+# ---------------------------------------------------------------------------
+
+_CMD_TIMEOUT_SECONDS = 10
+
+
+def _read_file(value: str) -> tuple[str | None, OSError | None]:
+    """Strip a ``file:`` prefix and read the referenced file."""
+    path = value[5:]
+    try:
+        with open(path) as f:
+            return f.read().strip(), None
+    except OSError as e:
+        e.filename = e.filename or path
+        return None, e
+
+
+def _run_cmd(value: str) -> tuple[str | None, str | None]:
+    """Strip a ``cmd:`` prefix and run the referenced command."""
+    command = value[4:]
+    try:
+        proc = subprocess.run(
+            command,
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=_CMD_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return None, f"timed out after {_CMD_TIMEOUT_SECONDS}s"
+    except OSError as e:  # pragma: no cover — shell=True means /bin/sh spawns; OSError only if sh itself is missing
+        return None, str(e)
+    if proc.returncode != 0:
+        return (
+            None,
+            f"exited with code {proc.returncode}: {proc.stderr.strip()}",
+        )
+    return proc.stdout.strip(), None
+
+
+def resolve_indirection(value: str | None, key: str = "") -> str | None:
+    """Resolve ``file:`` / ``cmd:`` prefixes on a raw config value.
+
+    If *value* starts with ``file:`` the remainder is a file path (contents
+    returned stripped).  If it starts with ``cmd:`` the remainder is a shell
+    command (stdout returned stripped).  Otherwise the value is returned
+    as-is.  On resolution failure, logs an error and returns ``None``.
+
+    *key* is used only for error messages (identifying which config var
+    failed to resolve).
+    """
+    if value is None:
+        return None
+    if value.startswith("file:"):
+        contents, err = _read_file(value)
+        if err is not None:
+            label = key or value
+            logger.error(
+                "Cannot read %s from %s: %s", label, err.filename, err
+            )
+            return None
+        return contents
+    if value.startswith("cmd:"):
+        contents, err = _run_cmd(value)
+        if err is not None:
+            label = key or value
+            logger.error("Cannot resolve %s via cmd: %s", label, err)
+            return None
+        return contents
+    return value
+
+
+# ---------------------------------------------------------------------------
+# KlangkSettings model
+# ---------------------------------------------------------------------------
+
+# The insecure default JWT secret — matches the constant in auth.py.
+_INSECURE_DEFAULT_SECRET = "change-this-to-a-random-secret"
+
+
+class KlangkSettings(BaseSettings):
+    """Typed configuration for all ``KLANGK_*`` environment variables.
+
+    Fields are ``Optional[str]`` (default ``None``) in this chunk to preserve
+    the exact behavior of the legacy ``resolve_env_value`` function: a call
+    with no default returns ``None`` when unset; a call with a default returns
+    the default.  Typed fields (``int``, ``bool``, ``list[str]``, ``Literal``)
+    arrive incrementally as call sites migrate to ``settings.field`` access.
+
+    ``extra="ignore"`` preserves the lenient behavior for unknown keys (typo'd
+    *keys* are tolerated; only typo'd *values* of known keys newly reject once
+    fields gain strict types).
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix="KLANGK_",
+        extra="ignore",
+        # Do NOT set env_nested_delimiter — KLANGK_ACCESS_TOKEN_HOURS is a
+        # flat field (access_token_hours), not a nested table.
+    )
+
+    # --- Auth / identity ---
+    auth_modes: str | None = None
+    jwt_secret: str | None = _INSECURE_DEFAULT_SECRET
+    prevent_insecure_jwt_secret: str | None = None
+    default_user: str | None = "admin@example.com"
+    default_password: str | None = None
+    access_token_hours: str | None = "24"
+    workspace_token_hours: str | None = "24"
+    min_password_length: str | None = "8"
+    login_lockout_failures: str | None = "5"
+    login_lockout_duration: str | None = "900"
+    login_lockout_window: str | None = "300"
+    disable_registration: str | None = None
+    disable_invites: str | None = None
+    invite_expire_hours: str | None = "72"
+    allow_insecure_no_auth: str | None = None
+    reject_proxy_headers: str | None = None
+    trusted_proxy_cidrs: str | None = "127.0.0.1,::1"
+
+    # --- Server / network ---
+    listen: str | None = "127.0.0.1"
+    nginx_port: str | None = "8995"
+    port_range_start: str | None = "9000"
+    cors_origins: str | None = None
+    dns_servers: str | None = None
+    hosting_hostname: str | None = None
+    hosting_proto: str | None = None
+    hosting_base_path: str | None = None
+    bridge_timeout_seconds: str | None = None
+    idle_timeout_seconds: str | None = None
+
+    # --- Container / workspace ---
+    data_dir: str | None = None
+    customize_dir: str | None = None
+    plugins_dir: str | None = None
+    image_name: str | None = "klangk-workspace"
+    image_pull_policy: str | None = "never"
+    allowed_images: str | None = None
+    allowed_mount_roots: str | None = None
+    allow_autostart: str | None = None
+    allow_sudo: str | None = None
+    container_subnets: str | None = None
+    userns: str | None = None
+    podman_bin: str | None = "podman"
+    disable_tmux: str | None = None
+    health_check_interval: str | None = None
+    health_check_startup_grace: str | None = None
+    health_check_timeout: str | None = None
+    hosted_ports_per_workspace: str | None = None
+    test_mode: str | None = None
+    version_file: str | None = None
+
+    # --- LLM ---
+    llm_api_key: str | None = None
+    llm_model: str | None = None
+
+    # --- OIDC ---
+    oidc_config: str | None = None
+    oidc_login_hook: str | None = None
+
+    # --- SMTP / email ---
+    smtp_host: str | None = None
+    smtp_port: str | None = "587"
+    smtp_user: str | None = None
+    smtp_password: str | None = None
+    smtp_from: str | None = None
+    smtp_reply_to: str | None = None
+    smtp_use_tls: str | None = "true"
+    sendmail_path: str | None = "sendmail"
+    email_templates_dir: str | None = None
+
+    # --- Legal / support links ---
+    terms_url: str | None = None
+    privacy_url: str | None = None
+    aup_url: str | None = None
+    support_url: str | None = None
+    support_email: str | None = None
+
+    # --- Branding / UI ---
+    product_name: str | None = "Klangk"
+    logo_url: str | None = None
+    brand_color: str | None = "#E65100"
+    login_banner: str | None = None
+    login_banner_title: str | None = None
+    terminal_banner: str | None = None
+
+    # --- Agent ---
+    agent_email: str | None = "clanker@example.com"
+    agent_handle: str | None = "clanker"
+    agent_disabled: str | None = None
+
+    # --- SSL / certs ---
+    ssl_cert_dir: str | None = None
+
+    # --- File upload ---
+    file_upload_size_max: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Singleton with env-change-detection cache
+# ---------------------------------------------------------------------------
+
+_settings_instance: KlangkSettings | None = None
+_settings_env_signature: tuple | None = None
+
+
+def _env_signature() -> tuple:
+    """A cheap hash of all KLANGK_* env vars, for change detection."""
+    return tuple(
+        sorted(
+            (k, v)
+            for k, v in os.environ.items()
+            if k.startswith("KLANGK_") or k.startswith("LOGFIRE_")
+        )
+    )
+
+
+def get_settings() -> KlangkSettings:
+    """Return the settings singleton, re-instantiating if env has changed.
+
+    The env-change detection makes this safe for tests: ``monkeypatch.setenv``
+    / ``monkeypatch.delenv`` changes ``os.environ``, which invalidates the
+    cache, so the next read sees the updated value.  In production (where env
+    is stable), the cache holds for the process lifetime after first access.
+    """
+    global _settings_instance, _settings_env_signature
+    sig = _env_signature()
+    if _settings_instance is None or sig != _settings_env_signature:
+        _settings_instance = KlangkSettings()
+        _settings_env_signature = sig
+    return _settings_instance
+
+
+def _invalidate_cache() -> None:
+    """Force the next :func:`get_settings` call to re-instantiate."""
+    global _settings_instance, _settings_env_signature
+    _settings_instance = None
+    _settings_env_signature = None
+
+
+def validate_at_startup() -> KlangkSettings:
+    """Instantiate settings eagerly for fail-fast validation at boot.
+
+    Call once from the lifespan startup.  Bogus config (once fields gain strict
+    types) fails here with a :class:`ValidationError` before the server serves
+    traffic.  Returns the validated settings instance (which also primes the
+    cache).
+    """
+    _invalidate_cache()
+    return get_settings()
+
+
+# ---------------------------------------------------------------------------
+# Legacy read functions (delegate to settings, apply file:/cmd: resolution)
+# ---------------------------------------------------------------------------
+
+
+def _key_to_field(key: str) -> str:
+    """Map an env-var name (``KLANGK_JWT_SECRET``) to a field name (``jwt_secret``)."""
+    if key.startswith("KLANGK_"):
+        return key[len("KLANGK_") :].lower()
+    return key.lower()
+
+
+def resolve_env_value(key: str, default: str | None = None) -> str | None:
+    """Read a config value, dereferencing ``file:`` / ``cmd:`` prefixes.
+
+    Delegates to the settings singleton (which reads ``os.environ`` via
+    pydantic-settings) and applies :func:`resolve_indirection` to the result.
+    If the value is unset (``None``), returns *default*.
+
+    Non-``KLANGK_`` keys (``LOGFIRE_TOKEN``, ``KLANGKC_DEBUG_SSH_AGENT``,
+    etc.) fall back to ``os.environ.get`` directly, since they're outside the
+    settings model's ``env_prefix``.
+    """
+    if key.startswith("KLANGK_"):
+        field = _key_to_field(key)
+        settings = get_settings()
+        raw = getattr(settings, field, None)
+    else:
+        # Non-KLANGK_ env vars (LOGFIRE_*, KLANGKC_*, etc.) are outside the
+        # settings model's env_prefix. Read directly from os.environ.
+        raw = os.environ.get(key)
+    if raw is None:
+        return default
+    resolved = resolve_indirection(raw, key)
+    return resolved if resolved is not None else default
+
+
+def resolve_env_bool(key: str, default: bool = False) -> bool:
+    """Read a config value as a boolean.
+
+    Truthy values: ``"1"``, ``"true"``, ``"yes"`` (case-insensitive).
+    Everything else is falsy.  Unset returns *default*.
+    """
+    val = resolve_env_value(key)
+    if val is None:
+        return default
+    return val.strip().lower() in ("1", "true", "yes")

--- a/src/backend/klangk_backend/util.py
+++ b/src/backend/klangk_backend/util.py
@@ -1,4 +1,4 @@
-"""Shared utilities: env var resolution, bounded async queue."""
+"""Shared utilities: env var resolution, bounded async queue, hosting info."""
 
 import asyncio
 import ipaddress
@@ -6,6 +6,12 @@ import logging
 import os
 import subprocess
 from typing import TypeVar
+
+# resolve_env_value / resolve_env_bool now live in the settings module (#1394)
+# and delegate to the KlangkSettings singleton.  Re-exported here for backward
+# compat — the ~85 call sites that do ``from .util import resolve_env_value``
+# keep working without changes.
+from .settings import resolve_env_value, resolve_env_bool
 
 T = TypeVar("T")
 
@@ -74,43 +80,9 @@ def run_cmd_value(value: str) -> tuple[str | None, str | None]:
     return proc.stdout.strip(), None
 
 
-def resolve_env_value(key: str, default: str | None = None) -> str | None:
-    """Read an env var, dereferencing 'file:' and 'cmd:' prefixed values.
-
-    If the value starts with 'file:', the remainder is treated as a
-    file path and the file contents (stripped) are returned. If it starts
-    with 'cmd:', the remainder is run as a shell command and its stdout
-    (stripped) is returned. On either failing, logs an error and returns
-    None. Otherwise the raw value is returned.
-    """
-    val = os.environ.get(key)
-    if val is None:
-        return default
-    if val.startswith("file:"):
-        contents, err = read_file_value(val)
-        if err is not None:
-            logger.error("Cannot read %s from %s: %s", key, err.filename, err)
-            return None
-        return contents
-    if val.startswith("cmd:"):
-        contents, err = run_cmd_value(val)
-        if err is not None:
-            logger.error("Cannot resolve %s via cmd: %s", key, err)
-            return None
-        return contents
-    return val
-
-
-def resolve_env_bool(key: str, default: bool = False) -> bool:
-    """Read an env var as a boolean.
-
-    Truthy values: "1", "true", "yes" (case-insensitive).
-    Everything else is falsy.  Unset returns *default*.
-    """
-    val = os.environ.get(key)
-    if val is None:
-        return default
-    return val.strip().lower() in ("1", "true", "yes")
+# NOTE: resolve_env_value / resolve_env_bool are imported from .settings
+# at the top of this module.  The implementations that lived here have been
+# moved to klangk_backend.settings (#1394).
 
 
 def resolve_file_value(value: str) -> str:
@@ -182,7 +154,7 @@ def load_trusted_proxy_cidrs() -> set[ipaddress._BaseAddress]:
     # it via os.environ rather than resolve_env_value (which treats its input
     # as a secret and would both support an unwanted "file:" prefix and trip
     # CodeQL's clear-text-logging taint check when we log invalid entries).
-    raw = os.environ.get("KLANGK_TRUSTED_PROXY_CIDRS", "127.0.0.1,::1")
+    raw = resolve_env_value("KLANGK_TRUSTED_PROXY_CIDRS")
     trusted: set[ipaddress._BaseAddress] = set()
     for token in (raw or "").split(","):
         token = token.strip()

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -5,6 +5,7 @@ description = "Klangk backend: multi-user Pi coding agent web REPL"
 requires-python = ">=3.12"
 dependencies = [
     "fastapi>=0.115.0",
+    "pydantic-settings>=2.5.0",
     "uvicorn[standard]>=0.32.0",
     "websockets>=14.0",
     "aiosqlite>=0.20.0",

--- a/src/backend/tests/test_settings.py
+++ b/src/backend/tests/test_settings.py
@@ -1,0 +1,198 @@
+"""Tests for the KlangkSettings config loader (#1394).
+
+Covers:
+- file: / cmd: indirection resolution (success + error paths)
+- get_settings env-change-detection cache
+- resolve_env_value (KLANGK_ and non-KLANGK_ keys)
+- resolve_env_bool
+- validate_at_startup
+- _key_to_field mapping
+"""
+
+import pytest
+
+from klangk_backend import settings as settings_mod
+from klangk_backend.settings import (
+    KlangkSettings,
+    _key_to_field,
+    get_settings,
+    resolve_env_bool,
+    resolve_env_value,
+    resolve_indirection,
+    validate_at_startup,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_settings_cache():
+    """Clear the settings cache before and after each test."""
+    settings_mod._invalidate_cache()
+    yield
+    settings_mod._invalidate_cache()
+
+
+class TestKeyToField:
+    def test_klangk_prefix(self):
+        assert _key_to_field("KLANGK_JWT_SECRET") == "jwt_secret"
+
+    def test_multi_word(self):
+        assert (
+            _key_to_field("KLANGK_ACCESS_TOKEN_HOURS") == "access_token_hours"
+        )
+
+    def test_non_klangk(self):
+        assert _key_to_field("LOGFIRE_TOKEN") == "logfire_token"
+
+
+class TestResolveIndirection:
+    def test_none_returns_none(self):
+        assert resolve_indirection(None) is None
+
+    def test_plain_value(self):
+        assert resolve_indirection("hello") == "hello"
+
+    def test_file_prefix(self, tmp_path):
+        secret = tmp_path / "secret.txt"
+        secret.write_text("the-secret\n")
+        assert resolve_indirection(f"file:{secret}") == "the-secret"
+
+    def test_file_failure_returns_none(self):
+        result = resolve_indirection("file:/nonexistent/path/to/secret")
+        assert result is None
+
+    def test_cmd_prefix(self):
+        result = resolve_indirection("cmd:echo hello")
+        assert result == "hello"
+
+    def test_cmd_failure_returns_none(self):
+        result = resolve_indirection("cmd:false")
+        assert result is None
+
+    def test_cmd_nonzero_exit_returns_none(self):
+        result = resolve_indirection("cmd:exit 1")
+        assert result is None
+
+    def test_cmd_oserror(self):
+        # A command that can't be spawned (no such binary)
+        result = resolve_indirection("cmd:/nonexistent/binary/path")
+        assert result is None
+
+    def test_cmd_timeout(self):
+        # A command that sleeps longer than the timeout
+        result = resolve_indirection("cmd:sleep 100")
+        assert result is None
+
+
+class TestGetSettings:
+    def test_reads_env(self, monkeypatch):
+        monkeypatch.setenv("KLANGK_NGINX_PORT", "12345")
+        s = get_settings()
+        assert s.nginx_port == "12345"
+
+    def test_cache_invalidated_on_env_change(self, monkeypatch):
+        monkeypatch.setenv("KLANGK_NGINX_PORT", "1111")
+        assert get_settings().nginx_port == "1111"
+        monkeypatch.setenv("KLANGK_NGINX_PORT", "2222")
+        assert get_settings().nginx_port == "2222"
+
+    def test_cache_holds_when_env_stable(self, monkeypatch):
+        monkeypatch.setenv("KLANGK_NGINX_PORT", "3333")
+        s1 = get_settings()
+        s2 = get_settings()
+        assert s1 is s2
+
+    def test_delenv_invalidates(self, monkeypatch):
+        monkeypatch.setenv("KLANGK_AUTH_MODES", "none")
+        assert get_settings().auth_modes == "none"
+        monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
+        assert get_settings().auth_modes is None
+
+    def test_defaults(self):
+        s = get_settings()
+        assert s.product_name == "Klangk"
+        assert s.podman_bin == "podman"
+
+
+class TestResolveEnvValue:
+    def test_klangk_key(self, monkeypatch):
+        monkeypatch.setenv("KLANGK_JWT_SECRET", "secret123")
+        assert resolve_env_value("KLANGK_JWT_SECRET") == "secret123"
+
+    def test_klangk_key_default(self):
+        assert (
+            resolve_env_value("KLANGK_NONEXISTENT", "fallback") == "fallback"
+        )
+
+    def test_klangk_key_unset_no_default(self):
+        assert resolve_env_value("KLANGK_NONEXISTENT") is None
+
+    def test_non_klangk_key(self, monkeypatch):
+        monkeypatch.setenv("LOGFIRE_TOKEN", "lf-token")
+        assert resolve_env_value("LOGFIRE_TOKEN") == "lf-token"
+
+    def test_non_klangk_key_default(self):
+        assert resolve_env_value("SOME_OTHER_VAR", "def") == "def"
+
+    def test_file_resolution(self, monkeypatch, tmp_path):
+        secret = tmp_path / "jwt"
+        secret.write_text("file-secret\n")
+        monkeypatch.setenv("KLANGK_JWT_SECRET", f"file:{secret}")
+        assert resolve_env_value("KLANGK_JWT_SECRET") == "file-secret"
+
+    def test_cmd_resolution(self, monkeypatch):
+        monkeypatch.setenv("KLANGK_JWT_SECRET", "cmd:echo cmd-secret")
+        assert resolve_env_value("KLANGK_JWT_SECRET") == "cmd-secret"
+
+
+class TestResolveEnvBool:
+    def test_truthy_values(self, monkeypatch):
+        for val in ("1", "true", "TRUE", "yes", "Yes"):
+            monkeypatch.setenv("KLANGK_TEST_MODE", val)
+            assert resolve_env_bool("KLANGK_TEST_MODE") is True, val
+
+    def test_falsy_values(self, monkeypatch):
+        for val in ("0", "false", "no", "", "banana"):
+            monkeypatch.setenv("KLANGK_TEST_MODE", val)
+            assert resolve_env_bool("KLANGK_TEST_MODE") is False, val
+
+    def test_unset_default(self):
+        assert resolve_env_bool("KLANGK_NONEXISTENT") is False
+        assert resolve_env_bool("KLANGK_NONEXISTENT", True) is True
+
+
+class TestValidateAtStartup:
+    def test_returns_settings(self):
+        s = validate_at_startup()
+        assert isinstance(s, KlangkSettings)
+
+    def test_primes_cache(self):
+        s = validate_at_startup()
+        assert get_settings() is s
+
+    def test_re_validates_after_env_change(self, monkeypatch):
+        monkeypatch.setenv("KLANGK_NGINX_PORT", "5555")
+        validate_at_startup()
+        assert get_settings().nginx_port == "5555"
+
+
+class TestSettingsModel:
+    def test_extra_ignored(self, monkeypatch):
+        """Unknown KLANGK_ keys are tolerated (extra='ignore')."""
+        monkeypatch.setenv("KLANGK_BOGUS_KEY", "whatever")
+        # Should not raise
+        s = get_settings()
+        assert not hasattr(s, "bogus_key")
+
+    def test_all_klangk_fields_present(self):
+        """Spot-check a few fields exist on the model."""
+        fields = KlangkSettings.model_fields
+        for name in (
+            "jwt_secret",
+            "auth_modes",
+            "data_dir",
+            "nginx_port",
+            "llm_api_key",
+            "trusted_proxy_cidrs",
+            "container_subnets",
+        ):
+            assert name in fields, f"missing field: {name}"

--- a/uv.lock
+++ b/uv.lock
@@ -651,6 +651,7 @@ dependencies = [
     { name = "httpx" },
     { name = "jinja2" },
     { name = "logfire", extra = ["fastapi"] },
+    { name = "pydantic-settings" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -674,6 +675,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "jinja2", specifier = ">=3.1" },
     { name = "logfire", extras = ["fastapi"], specifier = ">=3.0.0" },
+    { name = "pydantic-settings", specifier = ">=2.5.0" },
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.24.0" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
@@ -1101,6 +1103,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
     { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
     { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Chunk 1 of 7 from #1392. Adopts **pydantic-settings** as the config substrate:

- New `KlangkSettings(BaseSettings)` model covering all 74 `KLANGK_*` env vars (`env_prefix="KLANGK_"`, `extra="ignore"`)
- Fields are `Optional[str]` in this chunk (matching legacy `resolve_env_value` behavior); strict types arrive incrementally
- `resolve_env_value`/`resolve_env_bool` moved to `settings.py` with an **env-change-detection cache** — re-instantiates when any `KLANGK_*` env var changes, so `monkeypatch.setenv`/`delenv` in 337 test env-manipulations invalidates the cache automatically
- Shared `resolve_indirection()` for `file:`/`cmd:` prefixes (used by both `resolve_env_value` and available for direct `settings.field` access)
- `validate_at_startup()` called from the lifespan for eager fail-fast validation
- ~11 raw `os.environ.get("KLANGK_*")` sites converted to `resolve_env_value` (TRUSTED_PROXY_CIDRS, TERMS_URL, PRIVACY_URL, AUP_URL, SUPPORT_URL, SUPPORT_EMAIL)
- `pydantic-settings>=2.5.0` added as a dependency
- 31 new tests in `test_settings.py`

## Why pydantic-settings (not hand-rolled)

Research showed a hand-rolled Config object re-implements what pydantic-settings does natively: env+file merge with precedence, typed validation, structured values. The project already uses pydantic v2 (via FastAPI). See #1394 for the full rationale.

## Test plan

- [x] 2266 backend tests pass at 100% coverage (`-n auto`)
- [x] All 31 new settings tests pass
- [x] Env-change-detection cache verified (setenv/delenv invalidation)
- [x] No behavior change for valid config

Closes #1394.