### PR TITLE
fix(ci/cdk-pentest): apply input defaults on schedule trigger

### DIFF
--- a/.github/workflows/cdk-host-pentest.yml
+++ b/.github/workflows/cdk-host-pentest.yml
@@ -52,6 +52,19 @@ on:
 permissions:
   contents: read
 
+# `workflow_dispatch` input defaults do NOT apply on the `schedule`
+# trigger — the `inputs` context is empty on cron. Without coalescing
+# here, the daily run got CDK_VERSION="" (404 on the download), the
+# gate was silently skipped (so the daily run did NOT alarm on
+# regressions despite `fail-on-escape` defaulting on), and run-exploits
+# was skipped despite defaulting on for the host. These defaults mirror
+# the `workflow_dispatch` input defaults below.
+# See https://github.com/mcdonc/klangk/actions/runs/29010504270
+env:
+  CDK_VERSION: ${{ inputs.cdk-version || 'v1.5.6' }}
+  FAIL_ON_ESCAPE: ${{ inputs.fail-on-escape }}
+  RUN_EXPLOITS: ${{ inputs.run-exploits }}
+
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
@@ -82,7 +95,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          VER="${{ inputs.cdk-version }}"
+          VER="${{ env.CDK_VERSION }}"
           ARCH="cdk_linux_amd64"
           URL="https://github.com/cdk-team/CDK/releases/download/${VER}/${ARCH}"
           echo "Downloading $URL"
@@ -132,7 +145,7 @@ jobs:
           cat out/evaluate.txt
 
       - name: CDK escape exploits (default on for host)
-        if: ${{ inputs.run-exploits }}
+        if: ${{ env.RUN_EXPLOITS != 'false' }}
         shell: bash
         run: |
           . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
@@ -197,7 +210,7 @@ jobs:
           echo "New/unexpected (not baseline-allowed): $(wc -l < out/new-criticals.txt)"
 
       - name: Gate on Critical findings (opt-in)
-        if: ${{ inputs.fail-on-escape }}
+        if: ${{ env.FAIL_ON_ESCAPE != 'false' }}
         shell: bash
         run: |
           if [ -s out/new-criticals.txt ]; then
@@ -214,7 +227,7 @@ jobs:
           {
             echo "### 💣 CDK host pentest"
             echo
-            echo "CDK \`${{ inputs.cdk-version }}\` run inside \`${KLANGK_HOST_IMAGE:-klangk-host}:latest\`"
+            echo "CDK \`${{ env.CDK_VERSION }}\` run inside \`${KLANGK_HOST_IMAGE:-klangk-host}:latest\`"
             echo "as root, launched with the real host posture (--cap-add SYS_ADMIN,"
             echo "seccomp=unconfined, systempaths=unconfined, /dev/fuse, /dev/net/tun)."
             echo
@@ -236,7 +249,7 @@ jobs:
             cat out/evaluate.txt 2>/dev/null
             echo '```'
             echo "</details>"
-            if [ "${{ inputs.run-exploits }}" = "true" ]; then
+            if [ "${{ env.RUN_EXPLOITS }}" = "true" ]; then
               echo "<details><summary>CDK escape-exploit output</summary>"
               echo
               echo '```'

--- a/.github/workflows/cdk-workspace-pentest.yml
+++ b/.github/workflows/cdk-workspace-pentest.yml
@@ -47,6 +47,18 @@ on:
 permissions:
   contents: read
 
+# `workflow_dispatch` input defaults do NOT apply on the `schedule`
+# trigger — the `inputs` context is empty on cron. Without coalescing
+# here, the daily run got CDK_VERSION="" (404 on the download), and the
+# gate / run-exploits steps were silently skipped because their
+# `inputs.*` conditions evaluated falsy. These defaults mirror the
+# `workflow_dispatch` input defaults below.
+# See https://github.com/mcdonc/klangk/actions/runs/29010480831
+env:
+  CDK_VERSION: ${{ inputs.cdk-version || 'v1.5.6' }}
+  FAIL_ON_ESCAPE: ${{ inputs.fail-on-escape }}
+  RUN_EXPLOITS: ${{ inputs.run-exploits }}
+
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: false
@@ -68,7 +80,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          VER="${{ inputs.cdk-version }}"
+          VER="${{ env.CDK_VERSION }}"
           ARCH="cdk_linux_amd64"
           URL="https://github.com/cdk-team/CDK/releases/download/${VER}/${ARCH}"
           echo "Downloading $URL"
@@ -111,7 +123,7 @@ jobs:
           cat out/evaluate.txt
 
       - name: CDK escape exploits (opt-in)
-        if: ${{ inputs.run-exploits }}
+        if: ${{ env.RUN_EXPLOITS == 'true' }}
         shell: bash
         run: |
           . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
@@ -182,7 +194,7 @@ jobs:
           echo "New/unexpected (not baseline-allowed): $(wc -l < out/new-criticals.txt)"
 
       - name: Gate on Critical findings
-        if: ${{ inputs.fail-on-escape }}
+        if: ${{ env.FAIL_ON_ESCAPE != 'false' }}
         shell: bash
         run: |
           if [ -s out/new-criticals.txt ]; then
@@ -199,7 +211,7 @@ jobs:
           {
             echo "### 💣 CDK workspace pentest"
             echo
-            echo "CDK \`${{ inputs.cdk-version }}\` run inside \`klangk-workspace:latest\`"
+            echo "CDK \`${{ env.CDK_VERSION }}\` run inside \`klangk-workspace:latest\`"
             echo "launched with the real klangk posture (keep-id userns, \`--init\`,"
             echo "\`host.containers.internal:host-gateway\`, default caps, not privileged)."
             echo
@@ -217,7 +229,7 @@ jobs:
             cat out/evaluate.txt 2>/dev/null
             echo '```'
             echo "</details>"
-            if [ "${{ inputs.run-exploits }}" = "true" ]; then
+            if [ "${{ env.RUN_EXPLOITS }}" = "true" ]; then
               echo "<details><summary>CDK escape-exploit output</summary>"
               echo
               echo '```'


### PR DESCRIPTION
## What

Fixes both daily CDK pentest workflows that failed on the `schedule` (cron) trigger:

- CDK Workspace Pentest #4 — https://github.com/mcdonc/klangk/actions/runs/29010480831
- CDK Host Pentest #3 — https://github.com/mcdonc/klangk/actions/runs/29010504270

## Root cause

Both workflows run on a daily `schedule` cron **in addition to** `workflow_dispatch`. GitHub Actions only applies `workflow_dispatch` input `default:` values on the **dispatch** trigger — on `schedule` the entire `inputs` context is empty. So every runtime reference to `inputs.*` evaluated to empty on the daily run:

1. **`CDK_VERSION` became `""`** → the download URL collapsed to `…/releases/download//cdk_linux_amd64` → **HTTP 404 (exit 22)**. This is the actual failure that turned both runs red:
   ```
   Downloading https://github.com/cdk-team/CDK/releases/download//cdk_linux_amd64
   curl: (22) The requested URL returned error: 404
   ```
2. **The Gate step was silently skipped** — `if: ${{ inputs.fail-on-escape }}` is falsy on schedule, so the daily run did **not** alarm on regressions despite `fail-on-escape` defaulting on (you can see `Gate on Critical findings` marked `-` skipped in both failed runs). This defeats the entire purpose of the daily gate.
3. **The host `run-exploits` pass was skipped** — `if: ${{ inputs.run-exploits }}` is falsy on schedule, even though it defaults on for the host.

## Fix

Add a top-level `env:` block to each workflow that coalesces each input to its intended default, then point every runtime use at `env.*` instead of `inputs.*`:

```yaml
env:
  CDK_VERSION: ${{ inputs.cdk-version || 'v1.5.6' }}
  FAIL_ON_ESCAPE: ${{ inputs.fail-on-escape }}
  RUN_EXPLOITS: ${{ inputs.run-exploits }}
```

The booleans render to strings and are compared explicitly so the "default true" semantics hold on **every** trigger:

| step `if:`                                 | schedule (`""`) | dispatch `true` | dispatch `false` |
|--------------------------------------------|-----------------|-----------------|------------------|
| `env.FAIL_ON_ESCAPE != 'false'` (both)     | runs ✅         | runs ✅         | skipped ✅       |
| `env.RUN_EXPLOITS == 'true'` (workspace)   | skipped ✅      | runs ✅         | skipped ✅       |
| `env.RUN_EXPLOITS != 'false'` (host)       | runs ✅         | runs ✅         | skipped ✅       |

The `workflow_dispatch` input `default:` values are kept (they populate the dispatch UI form); the `env` block mirrors them and is the runtime source of truth.

## Validation

- `actionlint` clean on both files (no expression/context errors introduced).
- Pre-commit hooks pass (yamllint, trufflehog).
- Confirmed `https://github.com/cdk-team/CDK/releases/download/v1.5.6/cdk_linux_amd64` resolves **HTTP 200**, so pinning the default resolves the 404.

## Untested

I have not re-run the workflows from this branch (they take ~4–6 min each and build container images). Recommend dispatching both from this PR with defaults to confirm green before/after merge; the next daily cron at 06:43 UTC will also exercise the schedule path.

\@mcdonc