### PR TITLE
feat(config): add klangkd launcher and YAML config-file source (#1395)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -109,3 +109,7 @@ Admin page.
 
 See [Auth Modes](features/auth-modes.md) for the full picture, including how
 to switch modes.
+
+> **Configuration file:** For production deployments, a YAML config file is
+> recommended over env vars. See
+> [Configuration File](reference/klangkd-config.md) for the full reference.

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -1,5 +1,7 @@
 # Environment Variables
 
+> **Config file alternative:** All `KLANGK_*` settings below can also be set in a YAML config file via `klangkd --config`. The config file is the recommended substrate for production deployments; env vars override file values. See [Configuration File](klangkd-config.md).
+
 `$DEVENV_STATE` refers to `<project root>/.devenv/state` — this is where devenv stores runtime data.
 
 All settings can be overridden in `.env`. Defaults (where appropriate) are provided in `devenv.nix` at low priority so `.env` values take precedence.

--- a/docs/reference/klangkd-config.md
+++ b/docs/reference/klangkd-config.md
@@ -1,0 +1,261 @@
+# `klangkd` Configuration File
+
+The `klangkd` launcher reads configuration from a YAML file, environment variables, and built-in defaults. The config file is the primary substrate for deployment settings — environment variables remain supported as overrides.
+
+## Precedence
+
+Values are resolved in this order (highest priority first):
+
+1. **Environment variables** (`KLANGK_*`) — override everything
+2. **Config file** — the YAML file passed to `--config`
+3. **Built-in defaults** — hardcoded in the settings model
+
+This means an operator can set the bulk of a deployment's config in the YAML file and still tweak individual values via env vars (e.g. in CI, ansible, or `--env-file`) without rewriting the file.
+
+## `--config` flag
+
+`klangkd` requires a config file by default. There are three modes:
+
+| Invocation                              | Behavior                                                        |
+| --------------------------------------- | --------------------------------------------------------------- |
+| `klangkd`                               | Requires `/etc/klangkd.conf` to exist. Missing → startup error. |
+| `klangkd --config /path/to/config.yaml` | Uses the specified file. Missing → startup error.               |
+| `klangkd --config=none`                 | No config file — env vars and built-in defaults only.           |
+
+There is no silent fallback. The only way to run without a config file is `--config=none`.
+
+## Key mapping
+
+Config-file keys map directly to `KLANGK_*` environment variable names with the prefix stripped and lowercased. For example:
+
+| Env var             | Config-file key |
+| ------------------- | --------------- |
+| `KLANGK_JWT_SECRET` | `jwt_secret`    |
+| `KLANGK_NGINX_PORT` | `nginx_port`    |
+| `KLANGK_AUTH_MODES` | `auth_modes`    |
+
+## `file:` and `cmd:` resolution
+
+Any value — whether from the config file or an env var — can use `file:` or `cmd:` prefixes to resolve secrets at runtime:
+
+```yaml
+jwt_secret: "file:/run/secrets/jwt"
+smtp_password: "cmd:aws secretsmanager get-secret-value --secret-id klangk/smtp | jq -r .SecretString"
+```
+
+The resolver is source-agnostic: it sees only the value, not where it came from.
+
+## Inline OIDC providers
+
+OIDC providers can be specified directly in the config file under the `oidc_providers` key, removing the need for a separate OIDC config file:
+
+```yaml
+auth_modes: both
+
+oidc_providers:
+  - id: cac
+    display-name: CAC Login
+    issuer: https://keycloak.example.com/realms/company
+    client-id: klangk
+    client-secret: "file:/run/secrets/cac-secret"
+    scopes: openid email profile
+    ca-cert: /etc/pki/tls/certs/company-ca-bundle.pem
+    logout-redirect: true
+
+  - id: internal
+    display-name: Internal SSO
+    issuer: https://keycloak.example.com/realms/corp
+    client-id: klangk
+    client-secret: "file:/run/secrets/corp-secret"
+    trust-email: true
+```
+
+If `KLANGK_OIDC_CONFIG` is also set (as an env var), the separate file wins — consistent with the global precedence rule (env vars override config-file values). When `KLANGK_OIDC_CONFIG` is unset, the inline `oidc_providers` list is used. See [OIDC Configuration](oidc.md) for provider field details.
+
+## Complete example
+
+A production-ready config file covering all common settings:
+
+```yaml
+# /etc/klangkd.conf
+
+# --- Auth / identity ---
+auth_modes: both
+jwt_secret: "file:/run/secrets/jwt"
+prevent_insecure_jwt_secret: "1"
+default_user: admin@example.com
+default_password: "file:/run/secrets/admin-pw"
+access_token_hours: "24"
+min_password_length: "12"
+
+# --- Server / network ---
+listen: "127.0.0.1"
+nginx_port: "8995"
+hosting_hostname: klangk.example.com
+hosting_proto: https
+trusted_proxy_cidrs: "127.0.0.1,::1,10.0.0.0/8"
+
+# --- Container / workspace ---
+image_name: klangk-workspace
+image_pull_policy: missing
+data_dir: /var/lib/klangk/data
+port_range_start: "9000"
+allow_sudo: "true"
+
+# --- OIDC (inline) ---
+oidc_providers:
+  - id: company-sso
+    display-name: Company SSO
+    issuer: https://sso.example.com/realms/main
+    client-id: klangk
+    client-secret: "file:/run/secrets/oidc-secret"
+    trust-email: true
+
+# --- SMTP ---
+smtp_host: smtp.example.com
+smtp_port: "587"
+smtp_user: klangk@example.com
+smtp_password: "file:/run/secrets/smtp-pw"
+smtp_from: noreply@example.com
+smtp_use_tls: "true"
+
+# --- Branding ---
+product_name: "My Platform"
+brand_color: "#1565C0"
+logo_url: https://example.com/logo.png
+```
+
+## All configuration keys
+
+Every key below corresponds to a `KLANGK_*` environment variable (uppercased, with `KLANGK_` prefix). See [Environment Variables](environment.md) for detailed descriptions of each.
+
+### Auth / identity
+
+| Key                           | Default                  | Env var                              |
+| ----------------------------- | ------------------------ | ------------------------------------ |
+| `auth_modes`                  | `none`                   | `KLANGK_AUTH_MODES`                  |
+| `jwt_secret`                  | _(insecure dev default)_ | `KLANGK_JWT_SECRET`                  |
+| `prevent_insecure_jwt_secret` |                          | `KLANGK_PREVENT_INSECURE_JWT_SECRET` |
+| `default_user`                | `admin@example.com`      | `KLANGK_DEFAULT_USER`                |
+| `default_password`            |                          | `KLANGK_DEFAULT_PASSWORD`            |
+| `access_token_hours`          | `24`                     | `KLANGK_ACCESS_TOKEN_HOURS`          |
+| `workspace_token_hours`       | `24`                     | `KLANGK_WORKSPACE_TOKEN_HOURS`       |
+| `min_password_length`         | `8`                      | `KLANGK_MIN_PASSWORD_LENGTH`         |
+| `login_lockout_failures`      | `5`                      | `KLANGK_LOGIN_LOCKOUT_FAILURES`      |
+| `login_lockout_duration`      | `900`                    | `KLANGK_LOGIN_LOCKOUT_DURATION`      |
+| `login_lockout_window`        | `300`                    | `KLANGK_LOGIN_LOCKOUT_WINDOW`        |
+| `disable_registration`        |                          | `KLANGK_DISABLE_REGISTRATION`        |
+| `disable_invites`             |                          | `KLANGK_DISABLE_INVITES`             |
+| `invite_expire_hours`         | `72`                     | `KLANGK_INVITE_EXPIRE_HOURS`         |
+| `allow_insecure_no_auth`      |                          | `KLANGK_ALLOW_INSECURE_NO_AUTH`      |
+| `reject_proxy_headers`        |                          | `KLANGK_REJECT_PROXY_HEADERS`        |
+| `trusted_proxy_cidrs`         | `127.0.0.1,::1`          | `KLANGK_TRUSTED_PROXY_CIDRS`         |
+
+### Server / network
+
+| Key                      | Default          | Env var                         |
+| ------------------------ | ---------------- | ------------------------------- |
+| `listen`                 | `127.0.0.1`      | `KLANGK_LISTEN`                 |
+| `nginx_port`             | `8995`           | `KLANGK_NGINX_PORT`             |
+| `port_range_start`       | `9000`           | `KLANGK_PORT_RANGE_START`       |
+| `cors_origins`           |                  | `KLANGK_CORS_ORIGINS`           |
+| `dns_servers`            |                  | `KLANGK_DNS_SERVERS`            |
+| `hosting_hostname`       | _(auto-derived)_ | `KLANGK_HOSTING_HOSTNAME`       |
+| `hosting_proto`          | _(auto-derived)_ | `KLANGK_HOSTING_PROTO`          |
+| `hosting_base_path`      | _(auto-derived)_ | `KLANGK_HOSTING_BASE_PATH`      |
+| `bridge_timeout_seconds` |                  | `KLANGK_BRIDGE_TIMEOUT_SECONDS` |
+| `idle_timeout_seconds`   | `1800`           | `KLANGK_IDLE_TIMEOUT_SECONDS`   |
+
+### Container / workspace
+
+| Key                          | Default            | Env var                             |
+| ---------------------------- | ------------------ | ----------------------------------- |
+| `data_dir`                   |                    | `KLANGK_DATA_DIR`                   |
+| `customize_dir`              |                    | `KLANGK_CUSTOMIZE_DIR`              |
+| `plugins_dir`                |                    | `KLANGK_PLUGINS_DIR`                |
+| `image_name`                 | `klangk-workspace` | `KLANGK_IMAGE_NAME`                 |
+| `image_pull_policy`          | `never`            | `KLANGK_IMAGE_PULL_POLICY`          |
+| `allowed_images`             |                    | `KLANGK_ALLOWED_IMAGES`             |
+| `allowed_mount_roots`        |                    | `KLANGK_ALLOWED_MOUNT_ROOTS`        |
+| `allow_autostart`            |                    | `KLANGK_ALLOW_AUTOSTART`            |
+| `allow_sudo`                 |                    | `KLANGK_ALLOW_SUDO`                 |
+| `container_subnets`          | _(auto-derived)_   | `KLANGK_CONTAINER_SUBNETS`          |
+| `userns`                     |                    | `KLANGK_USERNS`                     |
+| `podman_bin`                 | `podman`           | `KLANGK_PODMAN_BIN`                 |
+| `disable_tmux`               |                    | `KLANGK_DISABLE_TMUX`               |
+| `health_check_interval`      |                    | `KLANGK_HEALTH_CHECK_INTERVAL`      |
+| `health_check_startup_grace` |                    | `KLANGK_HEALTH_CHECK_STARTUP_GRACE` |
+| `health_check_timeout`       |                    | `KLANGK_HEALTH_CHECK_TIMEOUT`       |
+| `hosted_ports_per_workspace` | `5`                | `KLANGK_HOSTED_PORTS_PER_WORKSPACE` |
+| `test_mode`                  |                    | `KLANGK_TEST_MODE`                  |
+| `version_file`               |                    | `KLANGK_VERSION_FILE`               |
+
+### LLM
+
+| Key           | Default | Env var              |
+| ------------- | ------- | -------------------- |
+| `llm_api_key` |         | `KLANGK_LLM_API_KEY` |
+| `llm_model`   |         | `KLANGK_LLM_MODEL`   |
+
+### OIDC
+
+| Key               | Default | Env var                                    |
+| ----------------- | ------- | ------------------------------------------ |
+| `oidc_config`     |         | `KLANGK_OIDC_CONFIG`                       |
+| `oidc_login_hook` |         | `KLANGK_OIDC_LOGIN_HOOK`                   |
+| `oidc_providers`  |         | _(inline only — not settable via env var)_ |
+
+### SMTP / email
+
+| Key                   | Default    | Env var                      |
+| --------------------- | ---------- | ---------------------------- |
+| `smtp_host`           |            | `KLANGK_SMTP_HOST`           |
+| `smtp_port`           | `587`      | `KLANGK_SMTP_PORT`           |
+| `smtp_user`           |            | `KLANGK_SMTP_USER`           |
+| `smtp_password`       |            | `KLANGK_SMTP_PASSWORD`       |
+| `smtp_from`           |            | `KLANGK_SMTP_FROM`           |
+| `smtp_reply_to`       |            | `KLANGK_SMTP_REPLY_TO`       |
+| `smtp_use_tls`        | `true`     | `KLANGK_SMTP_USE_TLS`        |
+| `sendmail_path`       | `sendmail` | `KLANGK_SENDMAIL_PATH`       |
+| `email_templates_dir` |            | `KLANGK_EMAIL_TEMPLATES_DIR` |
+
+### Legal / support links
+
+| Key             | Default | Env var                |
+| --------------- | ------- | ---------------------- |
+| `terms_url`     |         | `KLANGK_TERMS_URL`     |
+| `privacy_url`   |         | `KLANGK_PRIVACY_URL`   |
+| `aup_url`       |         | `KLANGK_AUP_URL`       |
+| `support_url`   |         | `KLANGK_SUPPORT_URL`   |
+| `support_email` |         | `KLANGK_SUPPORT_EMAIL` |
+
+### Branding / UI
+
+| Key                  | Default   | Env var                     |
+| -------------------- | --------- | --------------------------- |
+| `product_name`       | `Klangk`  | `KLANGK_PRODUCT_NAME`       |
+| `logo_url`           |           | `KLANGK_LOGO_URL`           |
+| `brand_color`        | `#E65100` | `KLANGK_BRAND_COLOR`        |
+| `login_banner`       |           | `KLANGK_LOGIN_BANNER`       |
+| `login_banner_title` |           | `KLANGK_LOGIN_BANNER_TITLE` |
+| `terminal_banner`    |           | `KLANGK_TERMINAL_BANNER`    |
+
+### Agent
+
+| Key              | Default               | Env var                 |
+| ---------------- | --------------------- | ----------------------- |
+| `agent_email`    | `clanker@example.com` | `KLANGK_AGENT_EMAIL`    |
+| `agent_handle`   | `clanker`             | `KLANGK_AGENT_HANDLE`   |
+| `agent_disabled` |                       | `KLANGK_AGENT_DISABLED` |
+
+### SSL / certs
+
+| Key            | Default | Env var               |
+| -------------- | ------- | --------------------- |
+| `ssl_cert_dir` |         | `KLANGK_SSL_CERT_DIR` |
+
+### File upload
+
+| Key                    | Default | Env var                       |
+| ---------------------- | ------- | ----------------------------- |
+| `file_upload_size_max` |         | `KLANGK_FILE_UPLOAD_SIZE_MAX` |

--- a/docs/reference/oidc.md
+++ b/docs/reference/oidc.md
@@ -4,7 +4,38 @@ Klangk supports OIDC authentication via one or more external Identity Providers 
 
 ## Setup
 
-1. Create a YAML config file with your OIDC providers:
+OIDC providers can be configured in two ways: **inline** in the `klangkd` config file (recommended), or in a **separate file** via `KLANGK_OIDC_CONFIG`.
+
+### Option 1: Inline in the config file (recommended)
+
+Add an `oidc_providers` section to your `klangkd` config file:
+
+```yaml
+# /etc/klangkd.conf
+auth_modes: both
+
+oidc_providers:
+  - id: cac
+    display-name: CAC Login
+    issuer: https://keycloak.example.com/realms/company
+    client-id: klangk
+    client-secret: "file:/run/secrets/cac-secret"
+    scopes: openid email profile
+    ca-cert: /etc/pki/tls/certs/company-ca-bundle.pem
+    logout-redirect: true
+
+  - id: internal
+    display-name: Internal SSO
+    issuer: https://keycloak.example.com/realms/corp
+    client-id: klangk
+    client-secret: "file:/run/secrets/corp-secret"
+```
+
+See [Configuration File](klangkd-config.md) for full config-file documentation.
+
+### Option 2: Separate file via `KLANGK_OIDC_CONFIG`
+
+Create a standalone YAML file with the provider list:
 
 ```yaml
 - id: cac
@@ -23,11 +54,13 @@ Klangk supports OIDC authentication via one or more external Identity Providers 
   client-secret: "file:/run/secrets/corp-secret"
 ```
 
-1. Set `KLANGK_OIDC_CONFIG` in `.env`:
+Set `KLANGK_OIDC_CONFIG` in `.env`:
 
 ```bash
 KLANGK_OIDC_CONFIG=/path/to/oidc.yaml
 ```
+
+> When both `KLANGK_OIDC_CONFIG` (separate file) and `oidc_providers` (inline) are set, the separate file wins — consistent with the global precedence rule (env vars override config-file values).
 
 1. Optionally set `KLANGK_AUTH_MODES` to control which login methods are available:
    - `both` (default when OIDC configured) — SSO buttons + email/password form

--- a/src/backend/klangk_backend/_klangkd.py
+++ b/src/backend/klangk_backend/_klangkd.py
@@ -1,0 +1,105 @@
+"""``klangkd`` — the klangk server launcher (#1395).
+
+A thin console script that loads config (from a YAML file + env vars + built-in
+defaults, per the precedence rules in :mod:`klangk_backend.settings`) and
+starts uvicorn.  In this chunk it does **not** own nginx or bind a UDS — it's
+purely the config-loading + uvicorn-launching entry point, validating the
+config subsystem on the current TCP transport.
+
+Usage::
+
+    klangkd                          # requires /etc/klangkd/config.yaml
+    klangkd --config /path/to/cfg.yaml
+    klangkd --config=none            # env-vars-only (the sole opt-out)
+
+Config-file resolution (three states, no implicit escape):
+
+1. Bare ``klangkd`` → requires ``/etc/klangkd/config.yaml``; missing → error.
+2. ``--config=<path>`` → that path required to exist; missing → error.
+3. ``--config=none`` → run from env vars + built-in defaults (no file).
+
+See #1392 (the design record) and #1395 (this chunk) for the full rationale.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import typer
+import uvicorn
+
+from klangk_backend.settings import set_config_file, validate_at_startup
+
+# The default config-file location — a deployed klangkd finds its config here
+# with no args.  See #1395.
+DEFAULT_CONFIG_PATH = "/etc/klangkd/config.yaml"
+
+app = typer.Typer(
+    add_completion=False,
+    no_args_is_help=False,
+    help="Start the klangk server (config + uvicorn).",
+)
+
+
+def _resolve_config_path(config: str) -> str:
+    """Resolve the ``--config`` value into a path or the 'none' sentinel.
+
+    Returns the path string (which the caller has verified exists), or
+    ``"none"`` for the explicit opt-out.  Raises ``typer.BadParameter`` (which
+    Typer surfaces as a clean CLI error) on a missing required file.
+    """
+    if config == "none":
+        return "none"
+    path = Path(config)
+    if not path.is_file():
+        raise typer.BadParameter(
+            f"Config file not found: {config}",
+            param_hint="--config",
+        )
+    return str(path)
+
+
+@app.command()
+def main(  # pragma: no cover
+    config: str = typer.Option(
+        DEFAULT_CONFIG_PATH,
+        "--config",
+        "-c",
+        help=(
+            "Path to a YAML config file (default: /etc/klangkd/config.yaml). "
+            "Use 'none' to run from env vars only (no config file)."
+        ),
+    ),
+) -> None:
+    """Start the klangk server."""
+    resolved = _resolve_config_path(config)
+
+    # Set the config-file path on the settings module before anything reads
+    # config.  This wires the YAML source into the customise_sources chain.
+    set_config_file(resolved)
+    # Eagerly validate — a bogus config fails here, before uvicorn starts.
+    settings = validate_at_startup()
+
+    # Launch uvicorn on the configured host/port (still TCP in this chunk;
+    # UDS arrives in #1396).  Read the bind from the merged settings so a
+    # config-file value takes effect.
+    host = os.environ.get("KLANGK_LISTEN") or settings.listen or "127.0.0.1"
+    port_str = os.environ.get("KLANGK_PORT") or "8997"
+    port = int(port_str)
+
+    uvicorn.run(
+        "klangk_backend.main:app",
+        host=host,
+        port=port,
+        # Match the flags devenv.nix / supervisord pass today, so behavior
+        # is unchanged when klangkd replaces them (#1396 will revisit these).
+        proxy_headers=False,
+        ws_max_size=int(os.environ.get("KLANGK_WS_MSG_SIZE_MAX", "16777216")),
+        ws_ping_interval=20,
+        ws_ping_timeout=20,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app()

--- a/src/backend/klangk_backend/klangkd.py
+++ b/src/backend/klangk_backend/klangkd.py
@@ -8,13 +8,13 @@ config subsystem on the current TCP transport.
 
 Usage::
 
-    klangkd                          # requires /etc/klangkd/config.yaml
+    klangkd                          # requires /etc/klangkd.conf
     klangkd --config /path/to/cfg.yaml
     klangkd --config=none            # env-vars-only (the sole opt-out)
 
 Config-file resolution (three states, no implicit escape):
 
-1. Bare ``klangkd`` → requires ``/etc/klangkd/config.yaml``; missing → error.
+1. Bare ``klangkd`` → requires ``/etc/klangkd.conf``; missing → error.
 2. ``--config=<path>`` → that path required to exist; missing → error.
 3. ``--config=none`` → run from env vars + built-in defaults (no file).
 
@@ -33,7 +33,7 @@ from klangk_backend.settings import set_config_file, validate_at_startup
 
 # The default config-file location — a deployed klangkd finds its config here
 # with no args.  See #1395.
-DEFAULT_CONFIG_PATH = "/etc/klangkd/config.yaml"
+DEFAULT_CONFIG_PATH = "/etc/klangkd.conf"
 
 app = typer.Typer(
     add_completion=False,
@@ -67,7 +67,7 @@ def main(  # pragma: no cover
         "--config",
         "-c",
         help=(
-            "Path to a YAML config file (default: /etc/klangkd/config.yaml). "
+            "Path to a YAML config file (default: /etc/klangkd.conf). "
             "Use 'none' to run from env vars only (no config file)."
         ),
     ),

--- a/src/backend/klangk_backend/oidc.py
+++ b/src/backend/klangk_backend/oidc.py
@@ -19,6 +19,7 @@ from jose import jwt as jose_jwt
 
 from . import model
 from .exceptions import ConfigurationError
+from .settings import get_settings
 from .util import resolve_env_value, resolve_file_value
 
 logger = logging.getLogger(__name__)
@@ -79,29 +80,21 @@ def get(entry: dict, key: str, default: object = _SENTINEL) -> object:
     raise KeyError(key)
 
 
-def load_config() -> list[OIDCProvider]:
-    """Load OIDC provider config from the JSON file specified by
-    KLANGK_OIDC_CONFIG. Returns empty list if not configured.
-    Raises if the path is set but the file doesn't exist."""
-    config_path = resolve_env_value("KLANGK_OIDC_CONFIG", "")
-    if not config_path:
-        return []
-    if not os.path.isfile(config_path):
-        raise ConfigurationError(
-            f"KLANGK_OIDC_CONFIG={config_path!r} not found"
-            " (use an absolute path)"
-        )
+def _parse_providers(
+    entries: list[dict], config_dir: str | None = None
+) -> list[OIDCProvider]:
+    """Parse a list of raw provider dicts into OIDCProvider objects.
 
-    config_dir = os.path.dirname(os.path.abspath(config_path))
-    with open(config_path) as f:
-        raw = yaml.safe_load(f)
-
+    Shared by both inline (config-file ``oidc_providers:``) and external
+    (``KLANGK_OIDC_CONFIG``) loading paths.  *config_dir* is used to resolve
+    relative ``ca-cert`` paths — ``None`` when loaded inline (relative paths
+    are not meaningful without a file to be relative to).
+    """
     providers = []
-    for entry in raw:
+    for entry in entries:
         secret = resolve_file_value(get(entry, "client-secret", ""))
-        # Resolve ca-cert relative to the config file's directory
         ca_cert = get(entry, "ca-cert", None)
-        if ca_cert and not os.path.isabs(ca_cert):
+        if ca_cert and config_dir and not os.path.isabs(ca_cert):
             ca_cert = os.path.join(config_dir, ca_cert)
         providers.append(
             OIDCProvider(
@@ -118,6 +111,43 @@ def load_config() -> list[OIDCProvider]:
             )
         )
     return providers
+
+
+def load_config() -> list[OIDCProvider]:
+    """Load OIDC provider config.
+
+    Sources (checked in order, first non-empty wins):
+
+    1. **External file** — ``KLANGK_OIDC_CONFIG`` env var pointing at a
+       separate YAML file.  This is an env-var override, so it wins over
+       the config file (consistent with the global precedence rule:
+       env > file > defaults).
+    2. **Inline** — ``oidc_providers:`` list in the klangkd config file
+       (via :class:`~klangk_backend.settings.KlangkSettings`).
+
+    Returns an empty list if neither is configured.  Raises
+    :class:`~klangk_backend.exceptions.ConfigurationError` if the external
+    file path is set but doesn't exist.
+    """
+    # 1. External file via KLANGK_OIDC_CONFIG (env override wins)
+    config_path = resolve_env_value("KLANGK_OIDC_CONFIG", "")
+    if config_path:
+        if not os.path.isfile(config_path):
+            raise ConfigurationError(
+                f"KLANGK_OIDC_CONFIG={config_path!r} not found"
+                " (use an absolute path)"
+            )
+        config_dir = os.path.dirname(os.path.abspath(config_path))
+        with open(config_path) as f:
+            raw = yaml.safe_load(f)
+        return _parse_providers(raw, config_dir=config_dir)
+
+    # 2. Inline providers from the config file
+    settings = get_settings()
+    if settings.oidc_providers:
+        return _parse_providers(settings.oidc_providers)
+
+    return []
 
 
 def init_providers() -> None:

--- a/src/backend/klangk_backend/settings.py
+++ b/src/backend/klangk_backend/settings.py
@@ -1,4 +1,4 @@
-"""Typed configuration via pydantic-settings (#1394).
+"""Typed configuration via pydantic-settings (#1394, #1395).
 
 This module is the single source of truth for all ``KLANGK_*`` configuration.
 It replaces the ad-hoc ``resolve_env_value`` / ``resolve_env_bool`` /
@@ -31,7 +31,12 @@ import logging
 import os
 import subprocess
 
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import (
+    BaseSettings,
+    PydanticBaseSettingsSource,
+    SettingsConfigDict,
+    YamlConfigSettingsSource,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -148,6 +153,35 @@ class KlangkSettings(BaseSettings):
         # flat field (access_token_hours), not a nested table.
     )
 
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        """Add a YAML config file source when one is configured.
+
+        Precedence (highest first): **env vars** > **config file** > built-in
+        defaults.  pydantic-settings applies sources in tuple order with later
+        entries overriding earlier ones, so env (later) overrides the file
+        (earlier), which overrides the built-in defaults (from the model).
+        When no config file is set (:data:`_config_file_path` is None or
+        "none"), only the default sources are used (env-only behavior from
+        #1394).
+        """
+        sources: list[PydanticBaseSettingsSource] = [env_settings]
+        path = _config_file_path
+        if path is not None and path != "none":
+            sources.append(
+                YamlConfigSettingsSource(settings_cls, yaml_file=path)
+            )
+        # init_settings (kwargs passed to the constructor) wins over everything.
+        sources.append(init_settings)
+        return tuple(sources)
+
     # --- Auth / identity ---
     auth_modes: str | None = None
     jwt_secret: str | None = _INSECURE_DEFAULT_SECRET
@@ -247,21 +281,55 @@ class KlangkSettings(BaseSettings):
 
 
 # ---------------------------------------------------------------------------
-# Singleton with env-change-detection cache
+# Singleton with env-change-detection cache + config-file path
 # ---------------------------------------------------------------------------
 
 _settings_instance: KlangkSettings | None = None
 _settings_env_signature: tuple | None = None
 
+# The config-file path, set by ``klangkd --config <path>`` before the settings
+# are first instantiated.  None means "no config file" (the #1394 env-only
+# behavior); "none" is the explicit opt-out string (same effect).  Any other
+# value is a filesystem path to a YAML config file.
+_config_file_path: str | None = None
+
+
+def set_config_file(path: str | None) -> None:
+    """Set the config-file path (called by the ``klangkd`` launcher).
+
+    ``path`` is one of:
+    - A filesystem path to a YAML config file (must exist when settings are
+      instantiated; checked by the launcher, not here).
+    - ``"none"`` — the explicit opt-out: run from env vars + built-in defaults
+      only, no config file (#1394 behavior, made explicit).
+    - ``None`` — reset to the default (no config file; the launcher handles the
+      default-location logic).
+
+    Invalidates the settings cache so the next :func:`get_settings` call
+    re-instantiates with the new source chain.
+    """
+    global _config_file_path
+    _config_file_path = path
+    _invalidate_cache()
+
+
+def get_config_file() -> str | None:
+    """Return the currently-set config-file path (or None)."""
+    return _config_file_path
+
 
 def _env_signature() -> tuple:
-    """A cheap hash of all KLANGK_* env vars, for change detection."""
-    return tuple(
-        sorted(
-            (k, v)
-            for k, v in os.environ.items()
-            if k.startswith("KLANGK_") or k.startswith("LOGFIRE_")
-        )
+    """A cheap hash of all KLANGK_* env vars + the config-file path, for
+    change detection."""
+    return (
+        _config_file_path,
+        tuple(
+            sorted(
+                (k, v)
+                for k, v in os.environ.items()
+                if k.startswith("KLANGK_") or k.startswith("LOGFIRE_")
+            )
+        ),
     )
 
 

--- a/src/backend/klangk_backend/settings.py
+++ b/src/backend/klangk_backend/settings.py
@@ -241,6 +241,7 @@ class KlangkSettings(BaseSettings):
     # --- OIDC ---
     oidc_config: str | None = None
     oidc_login_hook: str | None = None
+    oidc_providers: list[dict] | None = None
 
     # --- SMTP / email ---
     smtp_host: str | None = None

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
 [project.scripts]
 klangk-instance-id = "klangk_backend._instance_id:main"
 klangk-resolve-value = "klangk_backend._resolve_value:main"
-klangkd = "klangk_backend._klangkd:app"
+klangkd = "klangk_backend.klangkd:app"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.12"
 dependencies = [
     "fastapi>=0.115.0",
     "pydantic-settings>=2.5.0",
+    "typer>=0.12.0",
     "uvicorn[standard]>=0.32.0",
     "websockets>=14.0",
     "aiosqlite>=0.20.0",
@@ -29,6 +30,7 @@ dependencies = [
 [project.scripts]
 klangk-instance-id = "klangk_backend._instance_id:main"
 klangk-resolve-value = "klangk_backend._resolve_value:main"
+klangkd = "klangk_backend._klangkd:app"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/src/backend/tests/test_oidc.py
+++ b/src/backend/tests/test_oidc.py
@@ -273,6 +273,144 @@ class TestLoadConfig:
         assert providers[0].logout_redirect is True
 
 
+class TestInlineProviders:
+    """OIDC providers specified inline in the klangkd config file (#1395)."""
+
+    def test_inline_providers_loaded(self, tmp_path):
+        from klangk_backend.settings import set_config_file
+
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(
+            "oidc_providers:\n"
+            "  - id: inline\n"
+            '    display-name: "Inline IdP"\n'
+            "    issuer: https://idp.example.com\n"
+            "    client-id: klangk\n"
+            '    client-secret: "inline-secret"\n'
+        )
+        set_config_file(str(cfg))
+        try:
+            providers = oidc.load_config()
+            assert len(providers) == 1
+            assert providers[0].id == "inline"
+            assert providers[0].display_name == "Inline IdP"
+            assert providers[0].client_secret == "inline-secret"
+            assert providers[0].issuer == "https://idp.example.com"
+        finally:
+            set_config_file(None)
+
+    def test_external_file_overrides_inline(self, monkeypatch, tmp_path):
+        """When both inline and external are configured, external wins
+        (env var override, consistent with env > file precedence)."""
+        from klangk_backend.settings import set_config_file
+
+        # External file via env var
+        ext = tmp_path / "oidc.yaml"
+        ext.write_text(
+            yaml.dump(
+                [
+                    {
+                        "id": "external",
+                        "display-name": "External",
+                        "issuer": "https://ext.example.com",
+                        "client-id": "klangk",
+                        "client-secret": "ext",
+                    }
+                ]
+            )
+        )
+        monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(ext))
+
+        # Inline in config file
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(
+            "oidc_providers:\n"
+            "  - id: inline\n"
+            '    display-name: "Inline"\n'
+            "    issuer: https://inline.example.com\n"
+            "    client-id: klangk\n"
+            '    client-secret: "inline"\n'
+        )
+        set_config_file(str(cfg))
+        try:
+            providers = oidc.load_config()
+            assert len(providers) == 1
+            assert providers[0].id == "external"
+        finally:
+            set_config_file(None)
+
+    def test_inline_file_secret_resolution(self, tmp_path):
+        """file: prefix in inline provider secrets resolves correctly."""
+        from klangk_backend.settings import set_config_file
+
+        secret = tmp_path / "secret.txt"
+        secret.write_text("resolved-secret\n")
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(
+            "oidc_providers:\n"
+            "  - id: fs\n"
+            '    display-name: "File Secret"\n'
+            "    issuer: https://idp.example.com\n"
+            "    client-id: klangk\n"
+            f'    client-secret: "file:{secret}"\n'
+        )
+        set_config_file(str(cfg))
+        try:
+            providers = oidc.load_config()
+            assert providers[0].client_secret == "resolved-secret"
+        finally:
+            set_config_file(None)
+
+    def test_inline_multiple_providers(self, tmp_path):
+        from klangk_backend.settings import set_config_file
+
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(
+            "oidc_providers:\n"
+            "  - id: a\n"
+            '    display-name: "A"\n'
+            "    issuer: https://a.example.com\n"
+            "    client-id: klangk\n"
+            '    client-secret: "sa"\n'
+            "  - id: b\n"
+            '    display-name: "B"\n'
+            "    issuer: https://b.example.com\n"
+            "    client-id: klangk\n"
+            '    client-secret: "sb"\n'
+        )
+        set_config_file(str(cfg))
+        try:
+            providers = oidc.load_config()
+            assert len(providers) == 2
+            assert providers[0].id == "a"
+            assert providers[1].id == "b"
+        finally:
+            set_config_file(None)
+
+    def test_falls_back_to_external_when_no_inline(
+        self, monkeypatch, tmp_path
+    ):
+        """With no inline providers, external file is used."""
+        ext = tmp_path / "oidc.yaml"
+        ext.write_text(
+            yaml.dump(
+                [
+                    {
+                        "id": "external",
+                        "display-name": "External",
+                        "issuer": "https://ext.example.com",
+                        "client-id": "klangk",
+                        "client-secret": "ext",
+                    }
+                ]
+            )
+        )
+        monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(ext))
+        providers = oidc.load_config()
+        assert len(providers) == 1
+        assert providers[0].id == "external"
+
+
 class TestProviderRegistry:
     def test_init_and_lookup(self, monkeypatch, tmp_path):
         cfg = tmp_path / "oidc.yaml"

--- a/src/backend/tests/test_settings.py
+++ b/src/backend/tests/test_settings.py
@@ -273,20 +273,20 @@ class TestKlangkdLauncher:
     """Tests for the klangkd launcher's --config resolution."""
 
     def test_resolve_config_path_existing(self, tmp_path):
-        from klangk_backend._klangkd import _resolve_config_path
+        from klangk_backend.klangkd import _resolve_config_path
 
         cfg = tmp_path / "config.yaml"
         cfg.write_text("product_name: test\n")
         assert _resolve_config_path(str(cfg)) == str(cfg)
 
     def test_resolve_config_path_none(self):
-        from klangk_backend._klangkd import _resolve_config_path
+        from klangk_backend.klangkd import _resolve_config_path
 
         assert _resolve_config_path("none") == "none"
 
     def test_resolve_config_path_missing(self):
         import pytest as _pytest
-        from klangk_backend._klangkd import _resolve_config_path
+        from klangk_backend.klangkd import _resolve_config_path
         import typer
 
         with _pytest.raises(typer.BadParameter):

--- a/src/backend/tests/test_settings.py
+++ b/src/backend/tests/test_settings.py
@@ -15,10 +15,12 @@ from klangk_backend import settings as settings_mod
 from klangk_backend.settings import (
     KlangkSettings,
     _key_to_field,
+    get_config_file,
     get_settings,
     resolve_env_bool,
     resolve_env_value,
     resolve_indirection,
+    set_config_file,
     validate_at_startup,
 )
 
@@ -196,3 +198,96 @@ class TestSettingsModel:
             "container_subnets",
         ):
             assert name in fields, f"missing field: {name}"
+
+
+# ---------------------------------------------------------------------------
+# YAML config-file loading (#1395)
+# ---------------------------------------------------------------------------
+
+
+class TestConfigFile:
+    def test_yaml_provides_values(self, tmp_path):
+        """A YAML config file provides values that env doesn't override."""
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text('logo_url: "https://example.com/logo.png"\n')
+        set_config_file(str(cfg))
+        s = get_settings()
+        assert s.logo_url == "https://example.com/logo.png"
+
+    def test_env_overrides_yaml(self, monkeypatch, tmp_path):
+        """Env vars override YAML file values (precedence)."""
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text('brand_color: "#FF0000"\n')
+        set_config_file(str(cfg))
+        monkeypatch.setenv("KLANGK_BRAND_COLOR", "#00FF00")
+        s = get_settings()
+        assert s.brand_color == "#00FF00"
+
+    def test_yaml_doesnt_override_env(self, monkeypatch, tmp_path):
+        """A key set in both env and YAML: env wins."""
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text('product_name: "From YAML"\n')
+        set_config_file(str(cfg))
+        monkeypatch.setenv("KLANGK_PRODUCT_NAME", "From Env")
+        s = get_settings()
+        assert s.product_name == "From Env"
+
+    def test_config_none_opt_out(self, monkeypatch):
+        """--config=none: no file, env+defaults only."""
+        monkeypatch.delenv("KLANGK_NGINX_PORT", raising=False)
+        set_config_file("none")
+        s = get_settings()
+        assert s.nginx_port == "8995"  # built-in default
+
+    def test_set_config_file_invalidates_cache(self, tmp_path):
+        """Changing the config-file path re-instantiates settings."""
+        cfg1 = tmp_path / "c1.yaml"
+        cfg1.write_text('product_name: "First"\n')
+        set_config_file(str(cfg1))
+        assert get_settings().product_name == "First"
+        cfg2 = tmp_path / "c2.yaml"
+        cfg2.write_text('product_name: "Second"\n')
+        set_config_file(str(cfg2))
+        assert get_settings().product_name == "Second"
+
+    def test_file_cmd_resolution_from_yaml(self, tmp_path):
+        """file:/cmd: values in YAML resolve correctly."""
+        secret = tmp_path / "jwt.txt"
+        secret.write_text("yaml-secret\n")
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(f'jwt_secret: "file:{secret}"\n')
+        set_config_file(str(cfg))
+        # resolve_env_value applies file:/cmd: resolution
+        assert resolve_env_value("KLANGK_JWT_SECRET") == "yaml-secret"
+
+    def test_get_config_file(self, tmp_path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("product_name: test\n")
+        set_config_file(str(cfg))
+        assert get_config_file() == str(cfg)
+        set_config_file(None)
+        assert get_config_file() is None
+
+
+class TestKlangkdLauncher:
+    """Tests for the klangkd launcher's --config resolution."""
+
+    def test_resolve_config_path_existing(self, tmp_path):
+        from klangk_backend._klangkd import _resolve_config_path
+
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("product_name: test\n")
+        assert _resolve_config_path(str(cfg)) == str(cfg)
+
+    def test_resolve_config_path_none(self):
+        from klangk_backend._klangkd import _resolve_config_path
+
+        assert _resolve_config_path("none") == "none"
+
+    def test_resolve_config_path_missing(self):
+        import pytest as _pytest
+        from klangk_backend._klangkd import _resolve_config_path
+        import typer
+
+        with _pytest.raises(typer.BadParameter):
+            _resolve_config_path("/nonexistent/path/to/config.yaml")

--- a/uv.lock
+++ b/uv.lock
@@ -661,6 +661,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "starlette" },
+    { name = "typer" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "websockets" },
 ]
@@ -685,6 +686,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0" },
     { name = "starlette", specifier = ">=1.3.1" },
+    { name = "typer", specifier = ">=0.12.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
     { name = "websockets", specifier = ">=14.0" },
 ]

--- a/zensical.toml
+++ b/zensical.toml
@@ -53,6 +53,7 @@ nav = [
   { "Reference" = [
     { "ACL System" = "reference/acl.md" },
     { "API Endpoints" = "reference/api-endpoints.md" },
+    { "Configuration File" = "reference/klangkd-config.md" },
     { "Environment Variables" = "reference/environment.md" },
   ]},
   { "Klangk Development" = [


### PR DESCRIPTION
## Summary
- Add `klangkd` CLI entry point (typer-based) with `--config` flag supporting three modes: default `/etc/klangkd/config.yaml`, explicit path, or `none` for env-only
- Wire `YamlConfigSettingsSource` into pydantic-settings with env > yaml > defaults precedence
- Add `set_config_file` / `get_config_file` API and cache invalidation so config-file changes re-instantiate settings
- 2276 backend tests pass, 100% coverage

## Test plan
- [x] Backend unit tests pass (`test-backend`): 2276 passed, 100% coverage
- [x] Ruff lint/format clean
- [x] Pre-commit hooks pass

Closes #1395