### PR TITLE
docs(agents): fix devenv flags and move demo recording section (#1404)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,16 +2,16 @@
 
 Project-specific guidance for coding agents working in this repo.
 
-## Prefix most commands with `devenv shell --`
+## Prefix most commands with `devenv --quiet -O dotenv.enable:bool false shell --`
 
 Klangk uses [devenv](https://devenv.sh) (Nix-based) for its dev environment. **Every command that touches the project toolchain must be run through the devenv shell**, including git. The toolchain — Python venv, Node, Dart/Flutter, podman, pre-commit hooks, etc. — only exists inside the shell.
 
 ```bash
-devenv shell -- git commit -m "..."
-devenv shell -- pytest
+devenv --quiet -O dotenv.enable:bool false shell -- git commit -m "..."
+devenv --quiet -O dotenv.enable:bool false shell -- pytest
 ```
 
-`devenv shell --` launches an ephemeral shell with the full environment, runs the command, and exits — this is the pattern agents should use for one-off commands. (`devenv shell` with no `--` drops into an interactive shell; not useful for non-interactive agents.) This applies to **all** commands: builds, tests, lint, `git`, `podman`, `flutter`, `gh`.
+The flags: `--quiet` suppresses noisy devenv output; `-O dotenv.enable:bool false` prevents devenv from loading `.env` (which can interfere with test environments that set their own env vars via monkeypatch). `shell --` launches an ephemeral shell with the full environment, runs the command, and exits — this is the pattern agents should use for one-off commands. (`devenv shell` with no `--` drops into an interactive shell; not useful for non-interactive agents.) This applies to **all** commands: builds, tests, lint, `git`, `podman`, `flutter`, `gh`.
 
 A long-running interactive `devenv up` (backend + nginx + workspace image build) is a human-facing workflow; agents generally don't run it. If you need the backend up for something, ask.
 
@@ -22,13 +22,13 @@ are:
 
 ```bash
 # Backend (100% coverage gate)
-devenv shell -- python -m pytest src/backend/tests -v -n auto
+devenv --quiet -O dotenv.enable:bool false shell -- python -m pytest src/backend/tests -v -n auto
 
 # CLI (100% coverage gate)
-devenv shell -- python -m pytest src/cli/tests -v -n auto
+devenv --quiet -O dotenv.enable:bool false shell -- python -m pytest src/cli/tests -v -n auto
 
 # Frontend
-devenv shell -- flutter test --coverage
+devenv --quiet -O dotenv.enable:bool false shell -- flutter test --coverage
 ```
 
 `-n auto` (pytest-xdist) is **not optional** for the Python suites — it's how
@@ -112,7 +112,7 @@ Right before pushing the tag — do this as its own commit on `main`:
    heading as a prefix, so `## [v1.0.5] - 2026-07-07` matches tag `v1.0.5`.
 2. Insert a fresh, empty `## [Unreleased]` heading directly above it.
 3. Commit, e.g. `chore(changelog): cut vX.Y.Z`.
-4. Tag and push: `devenv shell -- git tag vX.Y.Z && devenv shell -- git push origin vX.Y.Z`.
+4. Tag and push: `devenv --quiet -O dotenv.enable:bool false shell -- git tag vX.Y.Z && devenv --quiet -O dotenv.enable:bool false shell -- git push origin vX.Y.Z`.
 
 **Critical sequencing:** `release.yml` checks out `docs/changes.md` at the tagged
 commit, so the `[Unreleased]` → `[vX.Y.Z]` rename **must land in (or before) the
@@ -125,3 +125,23 @@ falls back to pure auto-generated notes — the human-authored section is silent
 Nothing to do in `docs/changes.md` itself — the `[Unreleased]` heading you created
 at cut time is already in place for the next cycle's entries. Just start adding new
 entries under it.
+
+## Demo video recording
+
+Before **every** full recording run (CLI + browser scenes, or a re-run of just
+the browser half), you MUST first destroy the hero account so all its
+workspaces + containers cascade-delete with it. This is the only reliable way
+to get a clean slate — a prior interrupted run or a browser-only re-run leaves
+stale workspaces/tabs that corrupt the continuity later scenes assume.
+
+Do it as an explicit step 0 before `record-cli.sh`, using the seed's reset
+(which deletes the hero via `DELETE /admin/users/<id>` → cascades, then
+recreates the hero + Potemkin workspaces):
+
+```bash
+devenv --quiet -O dotenv.enable:bool false shell -- node --experimental-strip-types \
+  src/frontend/e2e-tests/demo/demo-seed.ts --reset
+```
+
+`record-cli.sh`'s Scene 2 prep also calls `--reset`, but do NOT rely on that
+alone — run the destroy consciously and explicitly every time.


### PR DESCRIPTION
## Summary
- Use `devenv --quiet -O dotenv.enable:bool false shell --` for all commands in AGENTS.md to suppress noise and prevent `.env` from interfering with test envs
- Move demo video recording section from `~/.pi/agent/AGENTS.md` into the repo's AGENTS.md where it belongs

## Test plan
- [x] Markdownlint passes
- [x] Pre-commit hooks pass

Closes #1404