### PR TITLE
fix(backend): apply CA trust before Logfire's startup probe (#1406)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## Unreleased
+
+## v1.0.5
+
+### Fixed
+
+- **Custom CA trust is now applied before Logfire's startup probe.** `setup_logfire()` previously ran at module scope (import time), before the FastAPI lifespan applied backend SSL trust, so `logfire.configure()`'s API connectivity probe fired before the `SSL_CERT_FILE`/`REQUESTS_CA_BUNDLE` env vars were set. With a `LOGFIRE_BASE_URL` whose certificate is signed by a private CA supplied via `$KLANGK_CUSTOMIZE_DIR/certs/`, this caused a spurious `Logfire API is unreachable` / `CERTIFICATE_VERIFY_FAILED` warning at every startup even though the merged CA bundle and env vars were otherwise correct. `setup_logfire()` now runs in the lifespan, immediately after `apply_backend_ssl_trust()`. ([#1406](https://github.com/mcdonc/klangk/issues/1406))

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -373,6 +373,14 @@ async def lifespan(app: FastAPI):
     # upstream). No-op when KLANGK_SSL_CERT_DIR is unset or empty of certs.
     ssl_trust.apply_backend_ssl_trust()
 
+    # Configure Logfire *after* SSL trust is applied. logfire.configure()
+    # probes the Logfire API at configuration time, so it must run once the
+    # SSL_* env vars (pointing at the merged CA bundle) are set, or it
+    # emits an unreachable-API warning against a private-CA endpoint (#1406).
+    # Was previously called at module scope, which runs before this lifespan
+    # and therefore before trust is applied.
+    setup_logfire(app)
+
     auth.require_secure_jwt_secret()
     plugins.load()
     oidc.init_providers()
@@ -421,9 +429,6 @@ def setup_logfire(app: FastAPI) -> bool:
     logfire.instrument_fastapi(app)
     logger.info("Logfire instrumentation enabled")
     return True
-
-
-setup_logfire(app)
 
 
 def cors_origins() -> list[str]:


### PR DESCRIPTION
-