### PR TITLE
fix(backend): apply CA trust before Logfire's startup probe (#1406)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## Unreleased
+
+## v1.0.5
+
+### Fixed
+
+- **Custom CA trust is now applied before Logfire's startup probe.** `setup_logfire()` previously ran at module scope (import time), before the FastAPI lifespan applied backend SSL trust, so `logfire.configure()`'s API connectivity probe fired before the `SSL_CERT_FILE`/`REQUESTS_CA_BUNDLE` env vars were set. With a `LOGFIRE_BASE_URL` whose certificate is signed by a private CA supplied via `$KLANGK_CUSTOMIZE_DIR/certs/`, this caused a spurious `Logfire API is unreachable` / `CERTIFICATE_VERIFY_FAILED` warning at every startup even though the merged CA bundle and env vars were otherwise correct. `setup_logfire()` now runs in the lifespan, immediately after `apply_backend_ssl_trust()`. ([#1406](https://github.com/mcdonc/klangk/issues/1406))

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -440,6 +440,14 @@ async def lifespan(app: FastAPI):
     # upstream). No-op when KLANGK_SSL_CERT_DIR is unset or empty of certs.
     ssl_trust.apply_backend_ssl_trust()
 
+    # Configure Logfire *after* SSL trust is applied. logfire.configure()
+    # probes the Logfire API at configuration time, so it must run once the
+    # SSL_* env vars (pointing at the merged CA bundle) are set, or it
+    # emits an unreachable-API warning against a private-CA endpoint (#1406).
+    # Was previously called at module scope, which runs before this lifespan
+    # and therefore before trust is applied.
+    setup_logfire(app)
+
     auth.require_secure_jwt_secret()
     plugins.load()
     oidc.init_providers()
@@ -489,9 +497,6 @@ def setup_logfire(app: FastAPI) -> bool:
     logfire.instrument_fastapi(app)
     logger.info("Logfire instrumentation enabled")
     return True
-
-
-setup_logfire(app)
 
 
 def cors_origins() -> list[str]:


### PR DESCRIPTION
## Summary

Cherry-pick of [#1407](https://github.com/mcdonc/klangk/pull/1407) (merged to `stable/1.0` as `3e7c3ff7`) onto `main`.

Custom CA trust supplied via `$KLANGK_CUSTOMIZE_DIR/certs/` was being applied **after** Logfire had already made its unreachable-API probe at import time, so the probe failed verification and emitted a spurious `Logfire API is unreachable` warning at every startup — the very failure the custom-CA mechanism is meant to prevent.

Root cause: `setup_logfire(app)` ran at **module scope** (import time), while `ssl_trust.apply_backend_ssl_trust()` runs inside the **FastAPI lifespan**. `logfire.configure()` probes the Logfire API during configuration, before any `SSL_*` env var was set.

Fixes [#1406](https://github.com/mcdonc/klangk/issues/1406).

## Changes

- `src/backend/klangk_backend/main.py` — moved `setup_logfire(app)` from module scope into the lifespan, immediately after `ssl_trust.apply_backend_ssl_trust()`. Function and tests unchanged; only the call site moved.
- `CHANGES.md` — entry under `## v1.0.5` (carried over from the stable/1.0 PR).

## Verification

- Cherry-pick applied cleanly (auto-merge on `main.py`; identical structure to `stable/1.0`).
- All 88 tests in `tests/test_main.py` + `tests/test_ssl_trust.py` pass on `main`, including the lifespan tests that now exercise the moved call site.
- Root-cause isolation (from the original investigation, applies equally to `main`): the merged CA bundle was always correct — `httpx` with `SSL_CERT_FILE=<bundle>` succeeds (HTTP 401, TLS OK); `httpx` with no `SSL_*` env var reproduces the exact `CERTIFICATE_VERIFY_FAILED` error Logfire prints. So this is purely a timing fix.

## Backport

This is the forward-port to `main` of the `stable/1.0` fix in #1407.