### PR TITLE
fix(backend): pass LOGFIRE_BASE_URL via logfire.AdvancedOptions (#1410)

### DIFF
--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -489,10 +489,12 @@ def setup_logfire(app: FastAPI) -> bool:
     base_url = resolve_env_value("LOGFIRE_BASE_URL")
     environment = resolve_env_value("LOGFIRE_ENVIRONMENT")
     kwargs: dict = {}
-    if base_url:
-        kwargs["base_url"] = base_url
     if environment:
         kwargs["environment"] = environment
+    if base_url:
+        # The top-level `base_url` argument is deprecated; pass it via
+        # `advanced=logfire.AdvancedOptions(base_url=...)` instead (#1410).
+        kwargs["advanced"] = logfire.AdvancedOptions(base_url=base_url)
     logfire.configure(**kwargs)
     logfire.instrument_fastapi(app)
     logger.info("Logfire instrumentation enabled")

--- a/src/backend/tests/test_main.py
+++ b/src/backend/tests/test_main.py
@@ -683,6 +683,29 @@ class TestSetupLogfire:
         mock_logfire.configure.assert_called_once_with()
         mock_logfire.instrument_fastapi.assert_called_once_with(app)
 
+    def test_base_url_passed_via_advanced_options(self, monkeypatch):
+        # LOGFIRE_BASE_URL must be passed as advanced=AdvancedOptions(base_url=...),
+        # not as the deprecated top-level base_url= argument (#1410).
+        monkeypatch.setenv("LOGFIRE_TOKEN", "test-token")
+        monkeypatch.setenv("LOGFIRE_BASE_URL", "https://logfire.example.com")
+        monkeypatch.delenv("LOGFIRE_ENVIRONMENT", raising=False)
+        mock_logfire = MagicMock()
+        with patch.dict("sys.modules", {"logfire": mock_logfire}):
+            app = FastAPI()
+            result = main.setup_logfire(app)
+        assert result is True
+        mock_logfire.AdvancedOptions.assert_called_once_with(
+            base_url="https://logfire.example.com"
+        )
+        mock_logfire.configure.assert_called_once()
+        configure_kwargs = mock_logfire.configure.call_args.kwargs
+        assert "advanced" in configure_kwargs
+        assert (
+            configure_kwargs["advanced"]
+            is mock_logfire.AdvancedOptions.return_value
+        )
+        assert "base_url" not in configure_kwargs
+
 
 class TestCorsOrigins:
     def test_default_localhost(self, monkeypatch):
@@ -751,8 +774,11 @@ class TestCorsOrigins:
         with patch.dict("sys.modules", {"logfire": mock_logfire}):
             app = FastAPI()
             main.setup_logfire(app)
+        mock_logfire.AdvancedOptions.assert_called_once_with(
+            base_url="https://custom.logfire"
+        )
         mock_logfire.configure.assert_called_once_with(
-            base_url="https://custom.logfire",
+            advanced=mock_logfire.AdvancedOptions.return_value,
             environment="staging",
         )
 


### PR DESCRIPTION
## Summary

`setup_logfire()` passed `LOGFIRE_BASE_URL` as a top-level `base_url=` kwarg to `logfire.configure()`. The installed logfire SDK has deprecated that argument in favor of `advanced=logfire.AdvancedOptions(base_url=...)`, so every startup with `LOGFIRE_BASE_URL` set emitted a `UserWarning`.

Pass `base_url` through `AdvancedOptions` instead.

Fixes [#1410](https://github.com/mcdonc/klangk/issues/1410).

## Changes

- `src/backend/klangk_backend/main.py` — `setup_logfire()`: when `LOGFIRE_BASE_URL` is set, build `logfire.AdvancedOptions(base_url=...)` and pass it as `advanced=` rather than the deprecated top-level `base_url=`. `LOGFIRE_ENVIRONMENT` continues to be a top-level kwarg (still supported by the SDK).
- `src/backend/tests/test_main.py`:
  - Updated the existing `test_with_base_url_and_environment` to the new call shape (`advanced=AdvancedOptions(...)` + `environment=...`).
  - Added `test_base_url_passed_via_advanced_options`, which asserts `base_url` is passed via `advanced=` and **not** as a top-level kwarg — guarding against silent regression to the deprecation path.

## Verification

- Confirmed against the installed SDK: `inspect.signature(logfire.configure)` exposes `advanced` (not `base_url`), and `logfire.AdvancedOptions` is a dataclass with a `base_url` field.
- Ran the real `setup_logfire()` with `LOGFIRE_BASE_URL` set under `python3 -W error::UserWarning` — the deprecated-`base_url` `UserWarning` is gone (the only remaining warning is the unrelated SSL one from #1406).
- Full `tests/test_main.py` + `tests/test_ssl_trust.py`: 90 passed.

## Notes

Independent of #1406/#1407 — fires whenever `LOGFIRE_BASE_URL` is set, public or private CA. Backported to `stable/1.0` in #1412.