### PR TITLE
fix(backend): pass LOGFIRE_BASE_URL via logfire.AdvancedOptions (#1410)

### DIFF
--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -421,10 +421,12 @@ def setup_logfire(app: FastAPI) -> bool:
     base_url = resolve_env_value("LOGFIRE_BASE_URL")
     environment = resolve_env_value("LOGFIRE_ENVIRONMENT")
     kwargs: dict = {}
-    if base_url:
-        kwargs["base_url"] = base_url
     if environment:
         kwargs["environment"] = environment
+    if base_url:
+        # The top-level `base_url` argument is deprecated; pass it via
+        # `advanced=logfire.AdvancedOptions(base_url=...)` instead (#1410).
+        kwargs["advanced"] = logfire.AdvancedOptions(base_url=base_url)
     logfire.configure(**kwargs)
     logfire.instrument_fastapi(app)
     logger.info("Logfire instrumentation enabled")

--- a/src/backend/tests/test_main.py
+++ b/src/backend/tests/test_main.py
@@ -599,6 +599,29 @@ class TestSetupLogfire:
         mock_logfire.configure.assert_called_once_with()
         mock_logfire.instrument_fastapi.assert_called_once_with(app)
 
+    def test_base_url_passed_via_advanced_options(self, monkeypatch):
+        # LOGFIRE_BASE_URL must be passed as advanced=AdvancedOptions(base_url=...),
+        # not as the deprecated top-level base_url= argument (#1410).
+        monkeypatch.setenv("LOGFIRE_TOKEN", "test-token")
+        monkeypatch.setenv("LOGFIRE_BASE_URL", "https://logfire.example.com")
+        monkeypatch.delenv("LOGFIRE_ENVIRONMENT", raising=False)
+        mock_logfire = MagicMock()
+        with patch.dict("sys.modules", {"logfire": mock_logfire}):
+            app = FastAPI()
+            result = main.setup_logfire(app)
+        assert result is True
+        mock_logfire.AdvancedOptions.assert_called_once_with(
+            base_url="https://logfire.example.com"
+        )
+        mock_logfire.configure.assert_called_once()
+        configure_kwargs = mock_logfire.configure.call_args.kwargs
+        assert "advanced" in configure_kwargs
+        assert (
+            configure_kwargs["advanced"]
+            is mock_logfire.AdvancedOptions.return_value
+        )
+        assert "base_url" not in configure_kwargs
+
 
 class TestCorsOrigins:
     def test_default_localhost(self, monkeypatch):
@@ -667,8 +690,11 @@ class TestCorsOrigins:
         with patch.dict("sys.modules", {"logfire": mock_logfire}):
             app = FastAPI()
             main.setup_logfire(app)
+        mock_logfire.AdvancedOptions.assert_called_once_with(
+            base_url="https://custom.logfire"
+        )
         mock_logfire.configure.assert_called_once_with(
-            base_url="https://custom.logfire",
+            advanced=mock_logfire.AdvancedOptions.return_value,
             environment="staging",
         )
 


### PR DESCRIPTION
## Summary

Backport of [#1411](https://github.com/mcdonc/klangk/pull/1411) (merged to `main` as `ad169732`) onto `stable/1.0`.

`setup_logfire()` passed `LOGFIRE_BASE_URL` as a top-level `base_url=` kwarg to `logfire.configure()`. The installed logfire SDK deprecated that argument in favor of `advanced=logfire.AdvancedOptions(base_url=...)`, so every startup with `LOGFIRE_BASE_URL` set emitted a `UserWarning`.

Pass `base_url` through `AdvancedOptions` instead.

Fixes [#1410](https://github.com/mcdonc/klangk/issues/1410).

## Changes

- `src/backend/klangk_backend/main.py` — `setup_logfire()`: when `LOGFIRE_BASE_URL` is set, build `logfire.AdvancedOptions(base_url=...)` and pass it as `advanced=` rather than the deprecated top-level `base_url=`. `LOGFIRE_ENVIRONMENT` continues as a top-level kwarg (still supported).
- `src/backend/tests/test_main.py` — updated `test_with_base_url_and_environment` to the new call shape; added `test_base_url_passed_via_advanced_options` (regression guard asserting `base_url` is passed via `advanced=`, not as a top-level kwarg).

## Verification

- Cherry-pick applied cleanly (auto-merge on both files).
- Full `tests/test_main.py` + `tests/test_ssl_trust.py`: **80 passed** on `stable/1.0`.
- Real end-to-end (on `main`): `setup_logfire()` with `LOGFIRE_BASE_URL` under `python3 -W error::UserWarning` — the deprecation warning is gone.

## Backport

This is the `stable/1.0` backport of the `main` fix in #1411. Note this branch already has the #1407 SSL-trust-ordering fix (the prior backport), so `setup_logfire` is in the lifespan here as on `main`.