### PR TITLE
feat(config): KLANGK_PRESET + KLANGK_AUTH_MODES conflict detection (#1397)

### DIFF
--- a/docs/reference/klangkd-config.md
+++ b/docs/reference/klangkd-config.md
@@ -129,6 +129,27 @@ logo_url: https://example.com/logo.png
 
 Every key below corresponds to a `KLANGK_*` environment variable (uppercased, with `KLANGK_` prefix). See [Environment Variables](environment.md) for detailed descriptions of each.
 
+### Deployment profiles
+
+The four deployment _shapes_ — the auth × browser-ingress 2×2 from [#1397](https://github.com/mcdonc/klangk/issues/1397). `preset` is a named alias (`uds-noauth` / `uds-auth` / `ip-noauth` / `ip-auth`); `auth`, `browser_ingress`, and `container_egress_paths` are its orthogonal axis keys. These are accepted from both the config file and env vars today (the config-substrate layer); preset→axis resolution, per-profile egress defaults, and load-time validation are wired up by the rest of #1397.
+
+> **Note:** `auth` is the coarse deployment axis (`none` / `password`) and is distinct from `auth_modes` (the precise auth-backend selector: `none` / `password` / `oidc`).
+
+| Key                      | Default | Env var                         |
+| ------------------------ | ------- | ------------------------------- |
+| `preset`                 |         | `KLANGK_PRESET`                 |
+| `auth`                   |         | `KLANGK_AUTH`                   |
+| `browser_ingress`        |         | `KLANGK_BROWSER_INGRESS`        |
+| `container_egress_paths` |         | `KLANGK_CONTAINER_EGRESS_PATHS` |
+
+```yaml
+# --- Deployment profiles (#1397) ---
+preset: uds-auth # one of uds-noauth|uds-auth|ip-noauth|ip-auth
+auth: password # none|password (coarse axis; cf. auth_modes)
+browser_ingress: "true" # "true"|"false"
+container_egress_paths: "/llm-proxy,/browser-delegate" # CSV; complete override
+```
+
 ### Auth / identity
 
 | Key                           | Default                  | Env var                              |

--- a/docs/reference/klangkd-config.md
+++ b/docs/reference/klangkd-config.md
@@ -142,7 +142,7 @@ Every key below corresponds to a `KLANGK_*` environment variable (uppercased, wi
 
 Everything else is _derived_ from the preset and is **not** individually configurable: the auth gate is the `-auth`/`-noauth` suffix; browser ingress is implied by the `ip-*` presets (a browser can't ingress over a UDS); container egress paths are a fixed per-preset default. The one thing the operator still chooses separately is the auth **backend** (password vs OIDC vs both) via the existing `KLANGK_AUTH_MODES` — that decision can't be made for them.
 
-`KLANGK_PRESET` and `KLANGK_AUTH_MODES` are cross-validated at startup: a `*-noauth` preset requires `KLANGK_AUTH_MODES=none`; a `*-auth` preset requires a gated backend (`password`/`oidc`/`both`). A conflicting config fails fast with a `ConfigurationError`.
+`KLANGK_PRESET` and `KLANGK_AUTH_MODES` are cross-validated at startup: a `*-noauth` preset requires `KLANGK_AUTH_MODES=none`; a `*-auth` preset requires a gated backend (`password`/`oidc`/`both`). A conflicting config fails fast with a `ConfigurationError`. When `KLANGK_AUTH_MODES` is **unset**, it self-defaults to match the preset — `password` for `*-auth`, `none` for `*-noauth` — so a preset alone boots cleanly without an explicit backend. (OIDC is then opt-in by setting `KLANGK_AUTH_MODES=oidc` or `both`.)
 
 | Key      | Default | Env var         |
 | -------- | ------- | --------------- |

--- a/docs/reference/klangkd-config.md
+++ b/docs/reference/klangkd-config.md
@@ -131,23 +131,28 @@ Every key below corresponds to a `KLANGK_*` environment variable (uppercased, wi
 
 ### Deployment profiles
 
-The four deployment _shapes_ — the auth × browser-ingress 2×2 from [#1397](https://github.com/mcdonc/klangk/issues/1397). `preset` is a named alias (`uds-noauth` / `uds-auth` / `ip-noauth` / `ip-auth`); `auth`, `browser_ingress`, and `container_egress_paths` are its orthogonal axis keys. These are accepted from both the config file and env vars today (the config-substrate layer); preset→axis resolution, per-profile egress defaults, and load-time validation are wired up by the rest of #1397.
+`KLANGK_PRESET` (config key `preset`) is the single deployment-shape selector — the new name for the "deployment profiles" from [#1397](https://github.com/mcdonc/klangk/issues/1397). It is one of four corners of the (transport × auth-gate) space:
 
-> **Note:** `auth` is the coarse deployment axis (`none` / `password`) and is distinct from `auth_modes` (the precise auth-backend selector: `none` / `password` / `oidc`).
+| `preset`     | transport | auth gate | browser ingress |
+| ------------ | --------- | --------- | --------------- |
+| `uds-noauth` | UDS       | off       | — (impossible)  |
+| `uds-auth`   | UDS       | on        | — (impossible)  |
+| `ip-noauth`  | TCP       | off       | implied on      |
+| `ip-auth`    | TCP       | on        | implied on      |
 
-| Key                      | Default | Env var                         |
-| ------------------------ | ------- | ------------------------------- |
-| `preset`                 |         | `KLANGK_PRESET`                 |
-| `auth`                   |         | `KLANGK_AUTH`                   |
-| `browser_ingress`        |         | `KLANGK_BROWSER_INGRESS`        |
-| `container_egress_paths` |         | `KLANGK_CONTAINER_EGRESS_PATHS` |
+Everything else is _derived_ from the preset and is **not** individually configurable: the auth gate is the `-auth`/`-noauth` suffix; browser ingress is implied by the `ip-*` presets (a browser can't ingress over a UDS); container egress paths are a fixed per-preset default. The one thing the operator still chooses separately is the auth **backend** (password vs OIDC vs both) via the existing `KLANGK_AUTH_MODES` — that decision can't be made for them.
+
+`KLANGK_PRESET` and `KLANGK_AUTH_MODES` are cross-validated at startup: a `*-noauth` preset requires `KLANGK_AUTH_MODES=none`; a `*-auth` preset requires a gated backend (`password`/`oidc`/`both`). A conflicting config fails fast with a `ConfigurationError`.
+
+| Key      | Default | Env var         |
+| -------- | ------- | --------------- |
+| `preset` |         | `KLANGK_PRESET` |
 
 ```yaml
 # --- Deployment profiles (#1397) ---
-preset: uds-auth # one of uds-noauth|uds-auth|ip-noauth|ip-auth
-auth: password # none|password (coarse axis; cf. auth_modes)
-browser_ingress: "true" # "true"|"false"
-container_egress_paths: "/llm-proxy,/browser-delegate" # CSV; complete override
+# One of: uds-noauth | uds-auth | ip-noauth | ip-auth
+# The auth backend is chosen separately via KLANGK_AUTH_MODES:
+preset: ip-auth # + KLANGK_AUTH_MODES=oidc (a preset with a gate needs a backend)
 ```
 
 ### Auth / identity

--- a/src/backend/klangk_backend/oidc.py
+++ b/src/backend/klangk_backend/oidc.py
@@ -189,17 +189,35 @@ def auth_modes() -> str:
     single-user local-dev mode). ``none`` auto-issues a token for the
     seeded default user via ``POST /api/v1/auth/local``; see #1374.
 
-    When ``KLANGK_AUTH_MODES`` is unset, the default is ``none`` unless an
-    OIDC provider is configured — configuring OIDC is the signal that real
-    multi-user auth is wanted (in which case the default is ``both``). A
-    fresh klangk with nothing configured therefore boots in no-login
+    Resolution order when ``KLANGK_AUTH_MODES`` is unset:
+
+    1. ``KLANGK_PRESET`` (#1397) — a ``*-auth`` preset defaults the mode
+       to ``password`` (the gate is required by the preset; the backend
+       defaults to password). A ``*-noauth`` preset defaults to ``none``.
+    2. otherwise, legacy behaviour: ``none`` unless an OIDC provider is
+       configured — configuring OIDC is the signal that real multi-user
+       auth is wanted (in which case the default is ``both``).
+
+    A fresh klangk with nothing configured therefore boots in no-login
     single-user mode, bound to loopback, and "just works" locally without a
     password. Operators who want the old password-default behaviour (or any
-    other mode) set ``KLANGK_AUTH_MODES`` explicitly.
+    other mode) set ``KLANGK_AUTH_MODES`` explicitly. A preset that requires
+    a different backend (e.g. OIDC) sets ``KLANGK_AUTH_MODES=oidc`` — the
+    preset only owns the *default*, never an override.
     """
     val = resolve_env_value("KLANGK_AUTH_MODES", "")
     if val in ("oidc", "password", "both", "none"):
         return val
+    # ``KLANGK_AUTH_MODES`` unset — let the deployment preset (#1397) own the
+    # default before falling back to the legacy OIDC-promotion rule. A ``*-auth``
+    # preset means the gate is required, so default to password; the preset
+    # never overrides an explicit ``KLANGK_AUTH_MODES`` (handled above). The
+    # OIDC-promotion fallback below is slated for removal in #1392 chunk 7
+    # ("OIDC presence should not change auth_mode") and lives only for
+    # backward compat with pre-#1397 operators.
+    preset = get_settings().preset
+    if preset is not None and preset.endswith("-auth"):
+        return "password"
     if is_enabled():
         return "both"
     return "none"

--- a/src/backend/klangk_backend/settings.py
+++ b/src/backend/klangk_backend/settings.py
@@ -38,6 +38,8 @@ from pydantic_settings import (
     YamlConfigSettingsSource,
 )
 
+from .exceptions import ConfigurationError
+
 logger = logging.getLogger(__name__)
 
 # Re-exported for backward compat — callers that ``from ..util import ...``
@@ -183,28 +185,34 @@ class KlangkSettings(BaseSettings):
         return tuple(sources)
 
     # --- Deployment profiles (#1397) ---
-    # The four deployment shapes (the auth × browser-ingress 2×2). ``preset``
-    # is a named alias (uds-noauth / uds-auth / ip-noauth / ip-auth) that, in
-    # the full #1397 chunk, resolves to the axis values + nginx template/bind
-    # + an egress default; the three axis keys below are its orthogonal
-    # components. These are the config-substrate entries only — each is
-    # settable via its KLANGK_* env var AND via the YAML config file, like
-    # every other field. Preset resolution, per-profile egress defaults, and
-    # load-time cross-field validation arrive with the rest of #1397; here we
-    # just ensure the values are accepted from both config sources.
-    # All default to None so a deployment that sets none of them behaves
-    # identically to pre-#1392 (acceptance criterion: defaults preserved).
+    # ``preset`` is the SINGLE deployment-shape selector — the new name for
+    # the "deployment profiles" from #1392. It is one of the four corners
+    # of the (transport × auth-gate) space:
+    #
+    #     uds-noauth / uds-auth   (UDS transport, gate off / on)
+    #     ip-noauth  / ip-auth    (TCP transport, gate off / on)
+    #
+    # Everything the earlier #1397 draft exposed as separate axis keys is
+    # *derived* from the preset and is NOT individually configurable:
+    #   - the auth GATE is the ``-auth``/``-noauth`` suffix (no KLANGK_AUTH);
+    #   - browser ingress is implied by the ``ip-*`` presets — a browser can't
+    #     ingress over a UDS — so there is no KLANGK_BROWSER_INGRESS;
+    #   - container egress paths have one fixed default per preset, with no
+    #     override, so there is no KLANGK_CONTAINER_EGRESS_PATHS.
+    #
+    # The one thing the operator still chooses separately is the auth
+    # BACKEND (password vs OIDC vs both) via the existing KLANGK_AUTH_MODES —
+    # that decision can't be made for them. The two keys are cross-validated
+    # at config-load: a ``*-noauth`` preset requires ``auth_modes() == none``;
+    # a ``*-auth`` preset requires a gated backend. See
+    # :func:`_validate_preset` (wired into :func:`validate_at_startup`).
     #
     # Naming: ``preset`` (a named bundle of defaults) was chosen over
     # ``profile`` (vague) and ``role`` (collides with klangk's RBAC workspace
     # roles — the wrong mental model for a deployment *shape*).
-    # NOTE: ``auth`` is the coarse 2-value deployment axis (none|password) and
-    # is DISTINCT from ``auth_modes`` (the precise auth-backend selector:
-    # none|password|oidc). The two reconcile in #1392 chunk 7.
+    # Defaults to None so a deployment that sets none of these behaves
+    # identically to pre-#1392 (acceptance criterion: defaults preserved).
     preset: str | None = None
-    auth: str | None = None
-    browser_ingress: str | None = None
-    container_egress_paths: str | None = None
 
     # --- Auth / identity ---
     auth_modes: str | None = None
@@ -381,16 +389,69 @@ def _invalidate_cache() -> None:
     _settings_env_signature = None
 
 
+# The four ``KLANGK_PRESET`` values (#1397) — the (transport × auth-gate)
+# corners. ``-noauth`` means "no auth gate"; ``-auth`` means "gate required".
+# Kept module-level so the nginx renderer (chunk 3 of #1392) can import it as
+# the canonical preset set. See KlangkSettings.preset for the full rationale.
+PRESETS: frozenset[str] = frozenset(
+    {"uds-noauth", "uds-auth", "ip-noauth", "ip-auth"}
+)
+
+
+def _validate_preset() -> None:
+    """Validate ``KLANGK_PRESET`` and its consistency with the auth backend.
+
+    ``KLANGK_PRESET`` is the single deployment-shape selector (#1397); the
+    auth *backend* (password vs OIDC vs both) stays the operator's choice via
+    ``KLANGK_AUTH_MODES``. The two must agree:
+
+    - a ``*-noauth`` preset requires the resolved auth mode to be ``none``;
+    - a ``*-auth``   preset requires it to be ``password`` / ``oidc`` / ``both``.
+
+    Raises :class:`~klangk_backend.exceptions.ConfigurationError` on an
+    unknown preset value or a preset/auth-mode conflict.
+
+    ``klangk_backend.oidc`` is imported lazily to avoid a settings <-> oidc
+    import cycle (``oidc`` imports :func:`get_settings` from this module).
+    """
+    preset = get_settings().preset
+    if preset is None:
+        return  # no preset set → today's pre-#1392 behavior
+    if preset not in PRESETS:
+        raise ConfigurationError(
+            f"KLANGK_PRESET={preset!r} is not one of {sorted(PRESETS)}"
+        )
+    from . import oidc  # noqa: allow-deferred-import  (settings <-> oidc cycle)
+
+    mode = oidc.auth_modes()
+    noauth = preset.endswith("-noauth")
+    if noauth and mode != "none":
+        raise ConfigurationError(
+            f"KLANGK_PRESET={preset!r} requires KLANGK_AUTH_MODES=none, "
+            f"but the resolved auth mode is {mode!r}"
+        )
+    if not noauth and mode == "none":
+        raise ConfigurationError(
+            f"KLANGK_PRESET={preset!r} requires an auth-gated backend "
+            f"(KLANGK_AUTH_MODES=password|oidc|both), but the resolved "
+            f"auth mode is 'none'"
+        )
+
+
 def validate_at_startup() -> KlangkSettings:
     """Instantiate settings eagerly for fail-fast validation at boot.
 
-    Call once from the lifespan startup.  Bogus config (once fields gain strict
-    types) fails here with a :class:`ValidationError` before the server serves
-    traffic.  Returns the validated settings instance (which also primes the
-    cache).
+    Call once from the lifespan startup (and from the ``klangkd`` launcher).
+    Bogus config (once fields gain strict types) fails here with a
+    :class:`ValidationError` before the server serves traffic. Also runs the
+    :func:`_validate_preset` cross-check so a ``KLANGK_PRESET`` that
+    disagrees with the resolved ``KLANGK_AUTH_MODES`` backend fails fast.
+    Returns the validated settings instance (which also primes the cache).
     """
     _invalidate_cache()
-    return get_settings()
+    settings = get_settings()
+    _validate_preset()
+    return settings
 
 
 # ---------------------------------------------------------------------------

--- a/src/backend/klangk_backend/settings.py
+++ b/src/backend/klangk_backend/settings.py
@@ -403,13 +403,18 @@ def _validate_preset() -> None:
 
     ``KLANGK_PRESET`` is the single deployment-shape selector (#1397); the
     auth *backend* (password vs OIDC vs both) stays the operator's choice via
-    ``KLANGK_AUTH_MODES``. The two must agree:
+    ``KLANGK_AUTH_MODES``. The two must agree when ``KLANGK_AUTH_MODES`` is
+    set EXPLICITLY:
 
     - a ``*-noauth`` preset requires the resolved auth mode to be ``none``;
     - a ``*-auth``   preset requires it to be ``password`` / ``oidc`` / ``both``.
 
+    An UNSET ``KLANGK_AUTH_MODES`` never conflicts: :func:`oidc.auth_modes`
+    is preset-aware in the unset path (#1397), self-defaulting to ``password``
+    for ``*-auth`` presets and ``none`` for ``*-noauth``.
+
     Raises :class:`~klangk_backend.exceptions.ConfigurationError` on an
-    unknown preset value or a preset/auth-mode conflict.
+    unknown preset value or an explicit preset/auth-mode conflict.
 
     ``klangk_backend.oidc`` is imported lazily to avoid a settings <-> oidc
     import cycle (``oidc`` imports :func:`get_settings` from this module).

--- a/src/backend/klangk_backend/settings.py
+++ b/src/backend/klangk_backend/settings.py
@@ -182,6 +182,30 @@ class KlangkSettings(BaseSettings):
         sources.append(init_settings)
         return tuple(sources)
 
+    # --- Deployment profiles (#1397) ---
+    # The four deployment shapes (the auth × browser-ingress 2×2). ``preset``
+    # is a named alias (uds-noauth / uds-auth / ip-noauth / ip-auth) that, in
+    # the full #1397 chunk, resolves to the axis values + nginx template/bind
+    # + an egress default; the three axis keys below are its orthogonal
+    # components. These are the config-substrate entries only — each is
+    # settable via its KLANGK_* env var AND via the YAML config file, like
+    # every other field. Preset resolution, per-profile egress defaults, and
+    # load-time cross-field validation arrive with the rest of #1397; here we
+    # just ensure the values are accepted from both config sources.
+    # All default to None so a deployment that sets none of them behaves
+    # identically to pre-#1392 (acceptance criterion: defaults preserved).
+    #
+    # Naming: ``preset`` (a named bundle of defaults) was chosen over
+    # ``profile`` (vague) and ``role`` (collides with klangk's RBAC workspace
+    # roles — the wrong mental model for a deployment *shape*).
+    # NOTE: ``auth`` is the coarse 2-value deployment axis (none|password) and
+    # is DISTINCT from ``auth_modes`` (the precise auth-backend selector:
+    # none|password|oidc). The two reconcile in #1392 chunk 7.
+    preset: str | None = None
+    auth: str | None = None
+    browser_ingress: str | None = None
+    container_egress_paths: str | None = None
+
     # --- Auth / identity ---
     auth_modes: str | None = None
     jwt_secret: str | None = _INSECURE_DEFAULT_SECRET

--- a/src/backend/tests/test_oidc.py
+++ b/src/backend/tests/test_oidc.py
@@ -511,6 +511,52 @@ class TestAuthModes:
             monkeypatch.setenv("KLANGK_AUTH_MODES", mode)
             assert not oidc.local_login_allowed()
 
+    # --- #1397 preset-driven default (KLANGK_AUTH_MODES unset) ---
+    # A ``*-auth`` preset means the gate is required, so the *unset* default
+    # resolves to ``password`` (the operator still picks the backend —
+    # e.g. OIDC — by setting KLANGK_AUTH_MODES explicitly). A ``*-noauth``
+    # preset stays ``none``. With no preset set, today's pre-#1392 default
+    # (the OIDC-promotion rule below) is preserved — removing that promotion
+    # is a separate breaking change, deferred to #1392 chunk 7.
+
+    @pytest.mark.parametrize("preset", ["uds-auth", "ip-auth"])
+    def test_auth_preset_defaults_to_password(self, monkeypatch, preset):
+        monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
+        monkeypatch.setenv("KLANGK_PRESET", preset)
+        assert oidc.auth_modes() == "password"
+        assert oidc.password_login_allowed()
+        assert not oidc.local_login_allowed()
+
+    @pytest.mark.parametrize("preset", ["uds-noauth", "ip-noauth"])
+    def test_noauth_preset_defaults_to_none(self, monkeypatch, preset):
+        monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
+        monkeypatch.setenv("KLANGK_PRESET", preset)
+        assert oidc.auth_modes() == "none"
+        assert oidc.local_login_allowed()
+        assert not oidc.password_login_allowed()
+
+    def test_auth_preset_default_does_not_override_explicit_mode(
+        self, monkeypatch
+    ):
+        # The preset only owns the *default* — an explicit KLANGK_AUTH_MODES
+        # always wins (even a conflicting one; that's what the settings-level
+        # _validate_preset cross-check is for, not auth_modes() itself).
+        monkeypatch.setenv("KLANGK_PRESET", "uds-auth")
+        monkeypatch.setenv("KLANGK_AUTH_MODES", "oidc")
+        oidc._providers.append(_provider())
+        assert oidc.auth_modes() == "oidc"
+        assert oidc.oidc_login_allowed()
+        assert not oidc.password_login_allowed()
+
+    def test_no_preset_preserves_legacy_default(self, monkeypatch):
+        # No preset + AUTH_MODES unset → today's pre-#1397 rule still holds
+        # (none, or both when an OIDC provider is configured).
+        monkeypatch.delenv("KLANGK_PRESET", raising=False)
+        monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
+        assert oidc.auth_modes() == "none"
+        oidc._providers.append(_provider())
+        assert oidc.auth_modes() == "both"
+
 
 class TestClientKwargs:
     def test_no_ca_cert(self):

--- a/src/backend/tests/test_settings.py
+++ b/src/backend/tests/test_settings.py
@@ -333,19 +333,24 @@ class TestPreset:
 
 
 class TestPresetAuthConflict:
-    """``KLANGK_PRESET`` must agree with the resolved ``KLANGK_AUTH_MODES``.
+    """``KLANGK_PRESET`` must agree with an EXPLICIT ``KLANGK_AUTH_MODES``.
 
     The preset fixes whether an auth gate is required (its suffix); the
     operator separately chooses the backend (password / OIDC / both) via
     ``KLANGK_AUTH_MODES``. The two are cross-validated at config-load by
-    :func:`validate_at_startup`, so a conflicting config fails fast at boot:
+    :func:`validate_at_startup`, so an *explicitly conflicting* config fails
+    fast at boot:
 
     - ``*-noauth`` presets require the resolved auth mode to be ``none``;
     - ``*-auth``   presets require it to be non-``none``.
 
-    ``KLANGK_AUTH_MODES`` is set explicitly in every case (the unit-test
-    autouse ``_default_auth_mode`` fixture pins it to ``password``), so these
-    tests don't depend on the OIDC-enabled resolution path.
+    Important: an UNSET ``KLANGK_AUTH_MODES`` never conflicts —
+    ``oidc.auth_modes()`` is preset-aware in the unset path (#1397), so a
+    ``*-auth`` preset defaults the mode to ``password`` and ``*-noauth`` to
+    ``none``. The conflict check only fires on an *explicit* value that
+    disagrees with the preset. These tests set ``KLANGK_AUTH_MODES``
+    explicitly in every case; the unset-no-conflict cases are covered at the
+    end.
     """
 
     def test_unknown_preset_rejected(self, monkeypatch):
@@ -396,6 +401,18 @@ class TestPresetAuthConflict:
         monkeypatch.delenv("KLANGK_PRESET", raising=False)
         monkeypatch.setenv("KLANGK_AUTH_MODES", "none")
         validate_at_startup()  # no raise
+
+    @pytest.mark.parametrize(
+        "preset", ["uds-noauth", "uds-auth", "ip-noauth", "ip-auth"]
+    )
+    def test_unset_auth_mode_never_conflicts(self, monkeypatch, preset):
+        # An unset KLANGK_AUTH_MODES never conflicts: oidc.auth_modes()
+        # self-defaults to match the preset (*-auth → password, *-noauth →
+        # none). So a preset alone boots cleanly with no explicit backend.
+        monkeypatch.setenv("KLANGK_PRESET", preset)
+        monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
+        settings = validate_at_startup()  # no raise
+        assert settings.preset == preset
 
 
 class TestKlangkdLauncher:

--- a/src/backend/tests/test_settings.py
+++ b/src/backend/tests/test_settings.py
@@ -12,8 +12,10 @@ Covers:
 import pytest
 
 from klangk_backend import settings as settings_mod
+from klangk_backend.exceptions import ConfigurationError
 from klangk_backend.settings import (
     KlangkSettings,
+    PRESETS,
     _key_to_field,
     get_config_file,
     get_settings,
@@ -270,75 +272,130 @@ class TestConfigFile:
 
 
 # ---------------------------------------------------------------------------
-# Deployment-profile config keys (#1397): settable via env var AND YAML file
+# KLANGK_PRESET (#1397): the single deployment-shape key
 # ---------------------------------------------------------------------------
 
 
-class TestDeploymentProfileKeys:
-    """The four #1397 deployment-profile values must be settable via BOTH an
-    env var and the YAML config file.
+class TestPreset:
+    """``KLANGK_PRESET`` is the only settable deployment-shape key (#1397).
 
-    The KlangkSettings substrate gives every model field two sources for
-    free: the env source (env_prefix="KLANGK_") and the YAML config-file
-    source (settings_customise_sources). These tests pin that contract for
-    the profile keys so a future change can't silently drop the config-file
-    path for one of them — which is the whole point of #1397's "settable in
-    the config file too" requirement.
+    The earlier #1397 draft exposed four axis keys (preset / auth /
+    browser_ingress / container_egress_paths). The finalized model keeps only
+    ``preset``: the auth GATE is its ``-auth``/``-noauth`` suffix, browser
+    ingress is implied by the ``ip-*`` presets, and container egress paths
+    are a fixed per-preset default. The auth BACKEND (password vs OIDC vs
+    both) stays the operator's choice via the existing ``KLANGK_AUTH_MODES``;
+    the two are cross-validated (see :class:`TestPresetAuthConflict`).
 
-    Note ``KLANGK_AUTH`` is the coarse #1397 axis (none|password), distinct
-    from ``KLANGK_AUTH_MODES`` (the auth-backend selector). ``KLANGK_PRESET``
-    was chosen over ``KLANGK_PROFILE``/``KLANGK_ROLE``: "preset" = a named
-    bundle of defaults; "role" collides with klangk's RBAC workspace roles.
+    These tests pin that ``preset`` is settable via BOTH an env var and the
+    YAML config file (like every other field) so a future change can't
+    silently drop the config-file path.
     """
 
-    # (env var, field name, sample value)
-    CASES = [
-        ("KLANGK_PRESET", "preset", "uds-auth"),
-        ("KLANGK_AUTH", "auth", "password"),
-        ("KLANGK_BROWSER_INGRESS", "browser_ingress", "true"),
-        (
-            "KLANGK_CONTAINER_EGRESS_PATHS",
-            "container_egress_paths",
-            "/llm-proxy,/browser-delegate",
-        ),
-    ]
-    _IDS = [c[1] for c in CASES]
+    def test_field_exists(self):
+        assert "preset" in KlangkSettings.model_fields
+        assert PRESETS == frozenset(
+            {"uds-noauth", "uds-auth", "ip-noauth", "ip-auth"}
+        )
 
-    @pytest.mark.parametrize("env_key,field,value", CASES, ids=_IDS)
-    def test_field_exists(self, env_key, field, value):
-        """All four keys are real fields on the model (hence dual-source)."""
-        assert field in KlangkSettings.model_fields
+    def test_dropped_axis_keys_are_not_fields(self):
+        # auth / browser_ingress / container_egress_paths are NOT individually
+        # settable — everything but preset is derived from the preset.
+        fields = KlangkSettings.model_fields
+        for dropped in ("auth", "browser_ingress", "container_egress_paths"):
+            assert dropped not in fields, dropped
 
-    @pytest.mark.parametrize("env_key,field,value", CASES, ids=_IDS)
-    def test_settable_via_env(self, monkeypatch, env_key, field, value):
+    @pytest.mark.parametrize("value", sorted(PRESETS))
+    def test_settable_via_env(self, monkeypatch, value):
         set_config_file(None)
-        monkeypatch.setenv(env_key, value)
-        assert getattr(get_settings(), field) == value
+        monkeypatch.setenv("KLANGK_PRESET", value)
+        assert get_settings().preset == value
 
-    @pytest.mark.parametrize("env_key,field,value", CASES, ids=_IDS)
-    def test_settable_via_yaml(self, tmp_path, env_key, field, value):
-        # Quoted so YAML yields a str (e.g. "true" stays a string, not a
-        # bool), matching the str|None field type and env-var semantics.
+    @pytest.mark.parametrize("value", sorted(PRESETS))
+    def test_settable_via_yaml(self, tmp_path, value):
         cfg = tmp_path / "config.yaml"
-        cfg.write_text(f'{field}: "{value}"\n')
+        cfg.write_text(f'preset: "{value}"\n')
         set_config_file(str(cfg))
-        assert getattr(get_settings(), field) == value
+        assert get_settings().preset == value
 
-    @pytest.mark.parametrize("env_key,field,value", CASES, ids=_IDS)
-    def test_env_overrides_yaml(
-        self, monkeypatch, tmp_path, env_key, field, value
+    def test_env_overrides_yaml(self, monkeypatch, tmp_path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text('preset: "uds-noauth"\n')
+        set_config_file(str(cfg))
+        monkeypatch.setenv("KLANGK_PRESET", "ip-auth")
+        assert get_settings().preset == "ip-auth"
+
+    def test_default_none_preserves_today(self):
+        # No preset set → None → pre-#1392 behavior; validate_at_startup is a
+        # no-op (no conflict check runs when preset is unset).
+        set_config_file(None)
+        assert get_settings().preset is None
+
+
+class TestPresetAuthConflict:
+    """``KLANGK_PRESET`` must agree with the resolved ``KLANGK_AUTH_MODES``.
+
+    The preset fixes whether an auth gate is required (its suffix); the
+    operator separately chooses the backend (password / OIDC / both) via
+    ``KLANGK_AUTH_MODES``. The two are cross-validated at config-load by
+    :func:`validate_at_startup`, so a conflicting config fails fast at boot:
+
+    - ``*-noauth`` presets require the resolved auth mode to be ``none``;
+    - ``*-auth``   presets require it to be non-``none``.
+
+    ``KLANGK_AUTH_MODES`` is set explicitly in every case (the unit-test
+    autouse ``_default_auth_mode`` fixture pins it to ``password``), so these
+    tests don't depend on the OIDC-enabled resolution path.
+    """
+
+    def test_unknown_preset_rejected(self, monkeypatch):
+        monkeypatch.setenv("KLANGK_PRESET", "bogus")
+        monkeypatch.setenv("KLANGK_AUTH_MODES", "password")
+        with pytest.raises(ConfigurationError, match="not one of"):
+            validate_at_startup()
+
+    @pytest.mark.parametrize("preset", ["uds-noauth", "ip-noauth"])
+    @pytest.mark.parametrize("mode", ["password", "oidc", "both"])
+    def test_noauth_preset_conflicts_with_any_backend(
+        self, monkeypatch, preset, mode
     ):
-        cfg = tmp_path / "config.yaml"
-        cfg.write_text(f'{field}: "from-yaml"\n')
-        set_config_file(str(cfg))
-        monkeypatch.setenv(env_key, value)
-        assert getattr(get_settings(), field) == value
+        monkeypatch.setenv("KLANGK_PRESET", preset)
+        monkeypatch.setenv("KLANGK_AUTH_MODES", mode)
+        with pytest.raises(
+            ConfigurationError, match="requires KLANGK_AUTH_MODES=none"
+        ):
+            validate_at_startup()
 
-    @pytest.mark.parametrize("env_key,field,value", CASES, ids=_IDS)
-    def test_default_none_preserves_today(self, env_key, field, value):
-        # No env, no config file → None for every key (pre-#1392 behavior).
-        set_config_file(None)
-        assert getattr(get_settings(), field) is None
+    @pytest.mark.parametrize("preset", ["uds-noauth", "ip-noauth"])
+    def test_noauth_preset_ok_with_none(self, monkeypatch, preset):
+        monkeypatch.setenv("KLANGK_PRESET", preset)
+        monkeypatch.setenv("KLANGK_AUTH_MODES", "none")
+        settings = validate_at_startup()  # no raise
+        assert settings.preset == preset
+
+    @pytest.mark.parametrize("preset", ["uds-auth", "ip-auth"])
+    def test_auth_preset_conflicts_with_none(self, monkeypatch, preset):
+        monkeypatch.setenv("KLANGK_PRESET", preset)
+        monkeypatch.setenv("KLANGK_AUTH_MODES", "none")
+        with pytest.raises(
+            ConfigurationError, match="requires an auth-gated backend"
+        ):
+            validate_at_startup()
+
+    @pytest.mark.parametrize("preset", ["uds-auth", "ip-auth"])
+    @pytest.mark.parametrize("mode", ["password", "oidc", "both"])
+    def test_auth_preset_ok_with_backend(self, monkeypatch, preset, mode):
+        monkeypatch.setenv("KLANGK_PRESET", preset)
+        monkeypatch.setenv("KLANGK_AUTH_MODES", mode)
+        settings = validate_at_startup()  # no raise
+        assert settings.preset == preset
+
+    def test_no_preset_skips_conflict_check(self, monkeypatch):
+        # preset unset → no validation runs (pre-#1392 behavior preserved),
+        # regardless of the auth mode.
+        monkeypatch.delenv("KLANGK_PRESET", raising=False)
+        monkeypatch.setenv("KLANGK_AUTH_MODES", "none")
+        validate_at_startup()  # no raise
 
 
 class TestKlangkdLauncher:

--- a/src/backend/tests/test_settings.py
+++ b/src/backend/tests/test_settings.py
@@ -269,6 +269,78 @@ class TestConfigFile:
         assert get_config_file() is None
 
 
+# ---------------------------------------------------------------------------
+# Deployment-profile config keys (#1397): settable via env var AND YAML file
+# ---------------------------------------------------------------------------
+
+
+class TestDeploymentProfileKeys:
+    """The four #1397 deployment-profile values must be settable via BOTH an
+    env var and the YAML config file.
+
+    The KlangkSettings substrate gives every model field two sources for
+    free: the env source (env_prefix="KLANGK_") and the YAML config-file
+    source (settings_customise_sources). These tests pin that contract for
+    the profile keys so a future change can't silently drop the config-file
+    path for one of them — which is the whole point of #1397's "settable in
+    the config file too" requirement.
+
+    Note ``KLANGK_AUTH`` is the coarse #1397 axis (none|password), distinct
+    from ``KLANGK_AUTH_MODES`` (the auth-backend selector). ``KLANGK_PRESET``
+    was chosen over ``KLANGK_PROFILE``/``KLANGK_ROLE``: "preset" = a named
+    bundle of defaults; "role" collides with klangk's RBAC workspace roles.
+    """
+
+    # (env var, field name, sample value)
+    CASES = [
+        ("KLANGK_PRESET", "preset", "uds-auth"),
+        ("KLANGK_AUTH", "auth", "password"),
+        ("KLANGK_BROWSER_INGRESS", "browser_ingress", "true"),
+        (
+            "KLANGK_CONTAINER_EGRESS_PATHS",
+            "container_egress_paths",
+            "/llm-proxy,/browser-delegate",
+        ),
+    ]
+    _IDS = [c[1] for c in CASES]
+
+    @pytest.mark.parametrize("env_key,field,value", CASES, ids=_IDS)
+    def test_field_exists(self, env_key, field, value):
+        """All four keys are real fields on the model (hence dual-source)."""
+        assert field in KlangkSettings.model_fields
+
+    @pytest.mark.parametrize("env_key,field,value", CASES, ids=_IDS)
+    def test_settable_via_env(self, monkeypatch, env_key, field, value):
+        set_config_file(None)
+        monkeypatch.setenv(env_key, value)
+        assert getattr(get_settings(), field) == value
+
+    @pytest.mark.parametrize("env_key,field,value", CASES, ids=_IDS)
+    def test_settable_via_yaml(self, tmp_path, env_key, field, value):
+        # Quoted so YAML yields a str (e.g. "true" stays a string, not a
+        # bool), matching the str|None field type and env-var semantics.
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(f'{field}: "{value}"\n')
+        set_config_file(str(cfg))
+        assert getattr(get_settings(), field) == value
+
+    @pytest.mark.parametrize("env_key,field,value", CASES, ids=_IDS)
+    def test_env_overrides_yaml(
+        self, monkeypatch, tmp_path, env_key, field, value
+    ):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(f'{field}: "from-yaml"\n')
+        set_config_file(str(cfg))
+        monkeypatch.setenv(env_key, value)
+        assert getattr(get_settings(), field) == value
+
+    @pytest.mark.parametrize("env_key,field,value", CASES, ids=_IDS)
+    def test_default_none_preserves_today(self, env_key, field, value):
+        # No env, no config file → None for every key (pre-#1392 behavior).
+        set_config_file(None)
+        assert getattr(get_settings(), field) is None
+
+
 class TestKlangkdLauncher:
     """Tests for the klangkd launcher's --config resolution."""
 


### PR DESCRIPTION
## What

Adds the #1397 deployment-shape config as a **single settable key** — `KLANGK_PRESET` — plus a **preset-driven default for `KLANGK_AUTH_MODES`** and cross-validation when it's set explicitly. Both keys are settable via env var **and** the YAML config file.

| `preset` | transport | auth gate | browser ingress | container egress | default `auth_modes` (when unset) |
|---|---|---|---|---|---|
| `uds-noauth` | UDS | off | — (impossible) | fixed default | `none` |
| `uds-auth` | UDS | on | — (impossible) | fixed default | `password` |
| `ip-noauth` | TCP | off | implied on | fixed default | `none` |
| `ip-auth` | TCP | on | implied on | fixed default | `password` |

## Design (finalized in this thread — supersedes #1397's draft)

#1397's written draft exposed **four** axis keys: `preset` / `auth` / `browser_ingress` / `container_egress_paths`. The agreed model keeps only **one** settable key and derives everything else:

- `KLANGK_PRESET` — the single selector (one of the four corners above).
- ~~`KLANGK_AUTH`~~ → the auth **gate** is the `-auth`/`-noauth` **suffix**.
- ~~`KLANGK_BROWSER_INGRESS`~~ → implied by the `ip-*` presets (a browser can't ingress over a UDS).
- ~~`KLANGK_CONTAINER_EGRESS_PATHS`~~ → one **fixed** per-preset default, no override.

The operator still chooses the auth **backend** (password vs OIDC vs both) via the existing `KLANGK_AUTH_MODES` — we can't decide OIDC-vs-password for them — but the **default** when that's unset is now driven by the preset (`*-auth` → `password`, `*-noauth` → `none`). So a preset alone boots cleanly with no explicit backend.

**Naming:** `KLANGK_PRESET` was chosen over `KLANGK_PROFILE` (vague) and `KLANGK_ROLE` (collides with klangk's existing RBAC workspace roles — wrong mental model for a deployment *shape*).

## How it works

1. **`oidc.auth_modes()` is preset-aware in the unset path** (#1397): when `KLANGK_AUTH_MODES` is unset, a `*-auth` preset returns `password`, `*-noauth` returns `none`. An explicit `KLANGK_AUTH_MODES` always wins. This means the runtime login gate (which reads `auth_modes()`) correctly reflects the preset with no separate wiring.

2. **`_validate_preset()`** (wired into `validate_at_startup`, called by both real entry points — `main.py` lifespan and `klangkd`) fails fast at boot with `ConfigurationError` on an **unknown preset** or an **explicit** preset/auth-mode conflict (`*-noauth` + non-`none`; `*-auth` + `none`). Because `auth_modes()` self-defaults to match the preset when unset, **"unset never conflicts."**

`oidc` is imported lazily inside the validator, suppressed with the deferred-imports hook's documented `# noqa: allow-deferred-import`, to avoid a `settings ↔ oidc` import cycle. `PRESETS` is module-level so the nginx renderer (chunk 3 of #1392) can reuse it.

## Defaults preserved (#1397 acceptance criterion #4)

- `preset=None` (unset) → `auth_modes()` behaves exactly as pre-#1397 (none, or `both` when an OIDC provider is configured).
- An explicit `KLANGK_AUTH_MODES` always wins over the preset default.

## Deferred (separate breaking change — do NOT fold into this PR)

The legacy **OIDC-promotion rule** ("unset + OIDC configured → `both`") still fires when **no preset** is set. Removing it entirely (so OIDC settings never change `auth_mode`) is a documented behavior change that would affect existing preset-less operators, so it's tracked separately as a #1392 chunk-7 item, not included here.

## ⚠️ Note re: #1397's acceptance criteria

This finalized model **drops** #1397's individual axis keys, contradicting the issue's written acceptance criterion #1 ("expressible via `KLANGK_PROFILE` **and via the individual axis keys**"). The thread refined the design past the written issue; worth a comment/edit on #1397 so the issue and code agree.

## Tests

- `test_settings.py` + `test_oidc.py`: **146 passed**.
- `TestPreset` — pins the dual-source (env + YAML) contract for the single key; asserts the three dropped axis keys are gone.
- `TestPresetAuthConflict` — full `preset × explicit-auth-mode` conflict matrix + `test_unset_auth_mode_never_conflicts`.
- `TestAuthModes` (oidc) — preset-driven-default cases + explicit-mode-wins + no-preset-legacy-preserved.

Refs #1397.