### PR TITLE
fix(auth)!: OIDC settings no longer change the auth mode (#1419)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -30,9 +30,9 @@ operators or integrators to act when upgrading.
 - **`KLANGK_AUTH_MODES=none`: no-login single-user (local-dev) mode**
   (#1374). A new `none` auth mode lets the frontend and CLI obtain a token
   for the seeded default user with no password prompt, enabling a frictionless
-  single-user dev/test loop (including the soliplex browser-delegate flow)
-  and serving as the foundation for a "one binary, named deployment
-  profiles" strategy (`local-dev` / `customer-locked` / `team`). The server
+  single-user dev/test loop and serving as the foundation for a "one binary,
+  named deployment profiles" strategy (`local-dev` / `customer-locked` /
+  `team`). The server
   auto-creates the default user at startup; `POST /api/v1/auth/local` mints a
   standard JWT for it. The loopback bind (`KLANGK_LISTEN`, #1375) plus an
   nginx per-location `allow 127.0.0.1/::1; deny all` ACL keep `/auth/local`
@@ -60,17 +60,27 @@ set-password <email>` (set a known password for the default user — whose
   This is safe by construction — `none` refuses to start on a non-loopback
   bind unless `KLANGK_ALLOW_INSECURE_NO_AUTH=1` — but it is a behavior change
   on upgrade: **set `KLANGK_AUTH_MODES=password` (or `oidc`/`both`) explicitly
-  before redeploying if you relied on the old default.** When an OIDC
-  provider is configured (`KLANGK_OIDC_CONFIG`), the unset default stays
-  `both`, unchanged. Note: `none` mode is not yet supported with the published
-  Docker host image (a published port isn't loopback) — the Docker examples
-  set `KLANGK_AUTH_MODES=password`; see #1391.
+  before redeploying if you relied on the old default.** Note: `none` mode is
+  not yet supported with the published Docker host image (a published port
+  isn't loopback) — the Docker examples set `KLANGK_AUTH_MODES=password`; see
+  #1391.
+- **OIDC settings no longer change the auth mode (#1419).** Previously, when
+  `KLANGK_AUTH_MODES` was unset **and** an OIDC provider was configured, the
+  resolved default was silently promoted to `both` (the "OIDC turns auth on"
+  rule). That promotion is removed: the unset default is now **always `none`**,
+  regardless of OIDC config, and `KLANGK_OIDC_*` settings only take effect
+  once the mode is explicitly `oidc` or `both`. **If you relied on OIDC being
+  configured implying `both`, set `KLANGK_AUTH_MODES=oidc` (or `both`)
+  explicitly before redeploying** — otherwise your server will boot in `none`
+  mode (no-login single-user, loopback-bound; safe by construction, but not
+  your intended multi-user posture).
 - **uvicorn now binds `127.0.0.1` by default** instead of `0.0.0.0`
   (`KLANGK_LISTEN`, new). Workspace containers could previously reach the
   backend directly via `host.containers.internal:$KLANGK_PORT`, bypassing nginx
   and therefore every per-location nginx ACL. nginx remains bound to `0.0.0.0`
-  (container-reachable, so soliplex and hosted apps still work) and proxies to
-  uvicorn on the loopback address. Operators who reach the backend directly —
+  (container-reachable, so hosted apps and remote browsers still work) and
+  proxies to uvicorn on the loopback address. Operators who reach the backend
+  directly —
   bypassing nginx — must set `KLANGK_LISTEN=0.0.0.0` to restore the old
   behavior. Applies to both the devenv dev server and the host container.
   (#1375)

--- a/docs/features/auth-modes.md
+++ b/docs/features/auth-modes.md
@@ -10,51 +10,48 @@ customer, only configuration.
 | `none`     | none — auto-login                  | **local-dev** (single user, your own browser) |
 | `oidc`     | SSO buttons only                   | **customer-locked**                           |
 | `password` | email/password only                | small team                                    |
-| `both`     | SSO buttons **and** email/password | **team** (default when OIDC is configured)    |
+| `both`     | SSO buttons **and** email/password | **team**                                      |
 
-The **default is `none`** unless an OIDC provider is configured (then
-`both`). A fresh klangk with nothing set boots in no-login single-user mode,
-bound to loopback — it "just works" locally with no password and is
-unreachable from the network. See [The default](#the-default) below for the
-upgrade implications.
+The **default is `none`**. A fresh klangk with nothing set boots in
+no-login single-user mode, bound to loopback — it "just works" locally with
+no password and is unreachable from the network. See
+[The default](#the-default) below for the upgrade implications.
 
 ## Choosing a mode
 
-- **`none`** — **the default** (unless OIDC is configured). You run klangk on
-  your own machine for development or testing and don't want to type a
-  password. The server auto-logs you in as the seeded default user (see
+- **`none`** — **the default**. You run klangk on your own machine for
+  development or testing and don't want to type a password. The server
+  auto-logs you in as the seeded default user (see
   [no-auth mode](#no-auth-mode-none) below). Must bind loopback.
 - **`password`** — a small trusted group logs in with email/password.
 - **`oidc`** — your organisation manages identity through an OIDC provider
   (Keycloak, Okta, Azure AD, …) and you want to disable local passwords.
   See [OIDC](../reference/oidc.md).
-- **`both`** — the default when an OIDC provider is configured: SSO for most
-  users, plus email/password as a fallback.
+- **`both`** — SSO for most users, plus email/password as a fallback.
 
 ## The default
 
 `KLANGK_AUTH_MODES` defaults to **`none`** — a fresh klangk with nothing
 configured boots in no-login single-user mode, bound to loopback
 (`127.0.0.1`). It "just works" locally: open the browser, you're in, no
-password. The only exception is when an OIDC provider is configured (via
-`KLANGK_OIDC_CONFIG`): configuring OIDC is the signal that real multi-user
-auth is wanted, so the default becomes `both` in that case. Set
-`KLANGK_AUTH_MODES` explicitly to pin any other mode regardless of OIDC
-config.
+password. OIDC settings (`KLANGK_OIDC_*`) do **not** change this default —
+configuring a provider only takes effect once the mode is `oidc` or `both`
+(set explicitly). Set `KLANGK_AUTH_MODES` explicitly to enable password,
+OIDC, or combined login.
 
-> **Upgrading from an earlier version:** if you previously relied on the
-> unset-default being `password` (or `both`), your server will now boot in
-> `none` mode instead. That is safe by construction — `none` refuses to
-> start on a non-loopback bind (see [why this is safe](#why-this-is-safe)) —
-> but you should set `KLANGK_AUTH_MODES=password` (or `oidc`/`both`)
-> explicitly before redeploying to preserve your intended auth posture. See
+> **Upgrading from an earlier version:** if you previously relied on OIDC
+> being configured _implying_ `both` (the old "OIDC turns auth on" rule),
+> your server will now boot in `none` mode instead — no-login single-user,
+> loopback-bound. That is safe by construction — `none` refuses to start on
+> a non-loopback bind (see [why this is safe](#why-this-is-safe)) — but you
+> should set `KLANGK_AUTH_MODES=oidc` (or `both`) explicitly before
+> redeploying to preserve your intended auth posture. See
 > [Switching modes](#switching-modes).
 
 ## No-auth mode (`none`)
 
 `none` is the foundation for a no-friction single-user dev/test loop —
-including the soliplex (pi plugin + browser-delegate) flow against your own
-browser — without standing up the multi-user tier or logging in each session.
+without standing up the multi-user tier or logging in each session.
 
 In `none` mode the server freely issues a JWT for the seeded default user
 (`KLANGK_DEFAULT_USER`, defaulting to `admin@example.com`) with no credentials
@@ -93,7 +90,7 @@ Two complementary controls keep `none` mode local:
    Workspace containers reach the host via pasta NAT and appear as the host's
    _non-loopback_ IP, so a container hitting `/auth/local` is denied with 403
    at nginx — while the host browser (127.0.0.1) succeeds. nginx itself stays
-   bound to `0.0.0.0` (soliplex, hosted apps, and remote browsers rely on it).
+   bound to `0.0.0.0` (hosted apps and remote browsers rely on it).
 
 3. **Backend source-IP self-check.** As a third layer (and to close the
    front-proxy bypass), the `local_login` handler independently verifies the

--- a/docs/reference/oidc.md
+++ b/docs/reference/oidc.md
@@ -63,10 +63,12 @@ KLANGK_OIDC_CONFIG=/path/to/oidc.yaml
 > When both `KLANGK_OIDC_CONFIG` (separate file) and `oidc_providers` (inline) are set, the separate file wins — consistent with the global precedence rule (env vars override config-file values).
 
 1. Optionally set `KLANGK_AUTH_MODES` to control which login methods are available:
-   - `both` (default when OIDC configured) — SSO buttons + email/password form
+   - `both` — SSO buttons + email/password form
    - `oidc` — SSO buttons only, email/password disabled
    - `password` — email/password only
    - `none` — no-login single-user (local-dev) mode; OIDC config is ignored. See [Auth Modes](../features/auth-modes.md).
+
+   The default (when `KLANGK_AUTH_MODES` is unset) is `none`; configuring OIDC no longer implies `both` — set `KLANGK_AUTH_MODES=oidc` (or `both`) to turn OIDC login on (#1419).
 
 ## Provider Config Fields
 

--- a/src/backend/klangk_backend/oidc.py
+++ b/src/backend/klangk_backend/oidc.py
@@ -194,32 +194,30 @@ def auth_modes() -> str:
     1. ``KLANGK_PRESET`` (#1397) — a ``*-auth`` preset defaults the mode
        to ``password`` (the gate is required by the preset; the backend
        defaults to password). A ``*-noauth`` preset defaults to ``none``.
-    2. otherwise, legacy behaviour: ``none`` unless an OIDC provider is
-       configured — configuring OIDC is the signal that real multi-user
-       auth is wanted (in which case the default is ``both``).
+    2. otherwise ``none`` (loopback single-user).
 
-    A fresh klangk with nothing configured therefore boots in no-login
-    single-user mode, bound to loopback, and "just works" locally without a
-    password. Operators who want the old password-default behaviour (or any
-    other mode) set ``KLANGK_AUTH_MODES`` explicitly. A preset that requires
-    a different backend (e.g. OIDC) sets ``KLANGK_AUTH_MODES=oidc`` — the
-    preset only owns the *default*, never an override.
+    OIDC settings (``KLANGK_OIDC_*``) do **not** change the mode (#1419) —
+    they only take effect once the mode is ``oidc`` or ``both`` (set
+    explicitly or via a preset). A fresh klangk with nothing configured
+    therefore boots in no-login single-user mode, bound to loopback, and
+    "just works" locally without a password. Operators who want password
+    login, OIDC, or both set ``KLANGK_AUTH_MODES`` explicitly (or pick an
+    ``*-auth`` preset). A preset that requires a different backend (e.g.
+    OIDC) sets ``KLANGK_AUTH_MODES=oidc`` — the preset only owns the
+    *default*, never an override.
     """
     val = resolve_env_value("KLANGK_AUTH_MODES", "")
     if val in ("oidc", "password", "both", "none"):
         return val
     # ``KLANGK_AUTH_MODES`` unset — let the deployment preset (#1397) own the
-    # default before falling back to the legacy OIDC-promotion rule. A ``*-auth``
-    # preset means the gate is required, so default to password; the preset
-    # never overrides an explicit ``KLANGK_AUTH_MODES`` (handled above). The
-    # OIDC-promotion fallback below is slated for removal in #1392 chunk 7
-    # ("OIDC presence should not change auth_mode") and lives only for
-    # backward compat with pre-#1397 operators.
+    # default; otherwise ``none``. A ``*-auth`` preset means the gate is
+    # required, so default to password; the preset never overrides an
+    # explicit ``KLANGK_AUTH_MODES`` (handled above). OIDC settings no longer
+    # promote the mode (#1419) — they are inert unless the mode is already
+    # ``oidc``/``both``.
     preset = get_settings().preset
     if preset is not None and preset.endswith("-auth"):
         return "password"
-    if is_enabled():
-        return "both"
     return "none"
 
 

--- a/src/backend/tests/test_oidc.py
+++ b/src/backend/tests/test_oidc.py
@@ -471,12 +471,18 @@ class TestAuthModes:
         assert not oidc.password_login_allowed()
         assert oidc.local_login_allowed()
 
-    def test_default_both_when_oidc_enabled(self, monkeypatch):
+    def test_default_none_when_oidc_enabled(self, monkeypatch):
+        # #1419: OIDC settings no longer change auth_mode. An unset
+        # KLANGK_AUTH_MODES resolves to "none" even when an OIDC provider
+        # is configured — OIDC is opt-in via an explicit
+        # KLANGK_AUTH_MODES=oidc (or "both"). (Earlier versions promoted
+        # the unset default to "both" here; that rule was removed.)
         monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
         oidc._providers.append(_provider())
-        assert oidc.auth_modes() == "both"
-        assert oidc.password_login_allowed()
-        assert oidc.oidc_login_allowed()
+        assert oidc.auth_modes() == "none"
+        assert oidc.local_login_allowed()
+        assert not oidc.password_login_allowed()
+        assert not oidc.oidc_login_allowed()
 
     def test_oidc_only(self, monkeypatch):
         monkeypatch.setenv("KLANGK_AUTH_MODES", "oidc")
@@ -549,13 +555,14 @@ class TestAuthModes:
         assert not oidc.password_login_allowed()
 
     def test_no_preset_preserves_legacy_default(self, monkeypatch):
-        # No preset + AUTH_MODES unset → today's pre-#1397 rule still holds
-        # (none, or both when an OIDC provider is configured).
+        # No preset + AUTH_MODES unset → ``none``. OIDC settings no longer
+        # promote the mode (#1419), so configuring a provider does not flip
+        # the default; the operator must set KLANGK_AUTH_MODES=oidc/both.
         monkeypatch.delenv("KLANGK_PRESET", raising=False)
         monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
         assert oidc.auth_modes() == "none"
         oidc._providers.append(_provider())
-        assert oidc.auth_modes() == "both"
+        assert oidc.auth_modes() == "none"
 
 
 class TestClientKwargs:


### PR DESCRIPTION
## What

Removes the implicit "OIDC turns auth on" promotion: when `KLANGK_AUTH_MODES` was unset **and** an OIDC provider was configured, `oidc.auth_modes()` silently returned `both`. That behavior was hard to explain and could silently change an operator's auth posture. Now `KLANGK_OIDC_*` settings are inert unless the mode is explicitly `oidc` or `both` — they never change the mode.

```diff
 def auth_modes() -> str:
     val = resolve_env_value("KLANGK_AUTH_MODES", "")
     if val in ("oidc", "password", "both", "none"):
         return val
-    if is_enabled():
-        return "both"
     return "none"
```

The unset default is now **always `none`** (loopback single-user), regardless of OIDC config.

## Why standalone / chunk-7

This is a **breaking change** for existing preset-less operators, so it was deliberately kept out of #1397 (PR #1418) — #1397's acceptance criterion #4 requires "defaults preserve today's behavior," and this flips the default for anyone with OIDC configured. Filed as #1419 (a #1392 chunk-7 item, alongside #1400) so it's reviewable/revertable on its own.

## ⚠️ Breaking change / migration

Operators who relied on OIDC being configured implying `both` must now set `KLANGK_AUTH_MODES=oidc` (or `both`) explicitly, else the server boots in `none` mode. `none` is safe by construction — loopback-bound, refuses a non-loopback bind — but it's not the intended multi-user posture. Migration guidance is in `docs/changes.md` (new `#1419` Breaking entry) and `docs/features/auth-modes.md` (upgrading note).

## Files

- **`oidc.py`** — drop the `is_enabled()` branch; rewrite the `auth_modes()` docstring.
- **`test_oidc.py`** — `test_default_both_when_oidc_enabled` → `test_default_none_when_oidc_enabled` (asserts the new default; OIDC present + mode unset → `none`, OIDC login disallowed).
- **`docs/features/auth-modes.md`** — strip all promotion language; rewrite "The default" + the upgrading note; drop a stray soliplex mention.
- **`docs/reference/oidc.md`** — drop "(default when OIDC configured)"; add the explicit-default note.
- **`docs/changes.md`** — new `#1419` Breaking entry; trim the now-stale "unset default stays `both` when OIDC configured" clause from the `#1374` entry; remove docs-only soliplex references.

## Merge-order note

This branch is based on `main`, which does **not** yet include PR #1418 (the `KLANGK_PRESET` work, still open). Both touch `oidc.auth_modes()`: #1418 adds a preset-driven default branch *before* the promotion; this PR removes the promotion. They compose cleanly (whichever lands first, the other rebases trivially — there's no logical conflict, both end at "unset → `none` or preset-default, promotion gone").

## Validation

- Full backend unit suite: **2332 passed**.
- `oidc.py` at **100% coverage** (removing the `is_enabled()` branch stranded no uncovered lines).
- All pre-commit hooks green (`deferred-imports`, `markdownlint`, `prettier`, `ruff`, `trufflehog`).

Closes #1419.