### PR TITLE
fix(ci): strip Determinate binary-cache substituter to stop store flakes (#1420)

### DIFF
--- a/.github/actions/devenv-setup/action.yml
+++ b/.github/actions/devenv-setup/action.yml
@@ -11,6 +11,24 @@ runs:
   steps:
     - uses: DeterminateSystems/determinate-nix-action@v3
 
+    - name: Disable Determinate binary-cache substituter
+      shell: bash
+      run: |
+        # The Determinate Nix installer configures install.determinate.systems
+        # as a binary-cache substituter in /etc/nix/nix.conf. Its NARs
+        # intermittently arrive corrupt/partial on GitHub hosted runners,
+        # causing "error: path '...' is not valid" mid-evaluation (#1420).
+        #
+        # nix.conf processes lines in order: a bare `substituters =` line
+        # REPLACES the accumulated value (including any `extra-substituters`
+        # the installer added), so appending one here leaves only
+        # cache.nixos.org. The bootstrap step's `cachix use` later appends
+        # devenv.cachix.org via `extra-substituters`. Result: paths come
+        # only from the two reliable caches — no Determinate store caching.
+        echo 'substituters = https://cache.nixos.org/' \
+          | sudo tee -a /etc/nix/nix.conf
+        sudo systemctl restart nix-daemon
+
     - name: Free disk space
       shell: bash
       run: |


### PR DESCRIPTION
## What

Stops the intermittent `devenv-setup` CI flake where `file-5.47` (a transitive dep of devenv) fails with `error: path '...' is not valid` — before any test code runs.

## Root cause

`determinate-nix-action@v3` hardcodes `determinate: true`, which installs Determinate Nix and configures **`install.determinate.systems`** as a binary-cache substituter in `/etc/nix/nix.conf`. The failing-run log confirms paths are actively copied from it:

```
copying path '/nix/store/hbnbbbx1...-gcc-15.2.0-libgcc' from 'https://install.determinate.systems'...
copying path '/nix/store/p7jg95rz...-libunistring-1.4.1' from 'https://install.determinate.systems'...
```

Its NARs intermittently arrive **corrupt/partial** on GitHub hosted runners. The nix daemon registers the path as valid but the content is missing → `"path '...' is not valid"` when the derivation is later evaluated. The same corrupt path recurs across unrelated PRs and passes on a simple re-run, confirming it's a substituter/runner issue.

This is the **store caching** the issue title refers to — Determinate's binary cache serving bad NARs.

## Fix

Append an explicit `substituters = https://cache.nixos.org/` line to `/etc/nix/nix.conf` right after the installer runs:

```yaml
- name: Disable Determinate binary-cache substituter
  shell: bash
  run: |
    echo 'substituters = https://cache.nixos.org/' \
      | sudo tee -a /etc/nix/nix.conf
    sudo systemctl restart nix-daemon
```

**Why this works:** per [nix.conf semantics](https://manual.determinate.systems/command-ref/conf-file.html), lines are processed in order — a bare `substituters =` line **REPLACES** the accumulated value (including any `extra-substituters` the Determinate installer added). The `bootstrap` step's `cachix use` later appends `devenv.cachix.org` via `extra-substituters`. Result: paths come only from the two reliable caches — **no Determinate store caching**.

| substituter | before | after |
|---|---|---|
| `install.determinate.systems` | ✅ (Determinate installer default) | ❌ stripped |
| `cache.nixos.org` | ✅ | ✅ (explicit) |
| `devenv.cachix.org` | ✅ (bootstrap `cachix use`) | ✅ (unchanged) |

## Why not other options from the issue

- **Retry-on-error** — masks the symptom without fixing the root cause; a corrupt path could still poison downstream steps before the retry.
- **Pin nixpkgs** — the corrupt path is a substituter-delivery issue, not a nixpkgs-revision issue.
- **`determinate: false` / upstream Nix** — the Determinate Nix Installer only installs Determinate Nix after Jan 1, 2026 ([announcement](https://determinate.systems/blog/installer-dropping-upstream/)); `--prefer-upstream-nix` no longer has an effect.

## Untested in CI

I can't reproduce the flake locally (it's intermittent on GitHub hosted runners). The fix is exercised by every job that uses `devenv-setup` — if the Determinate substituter was the source, the flake stops. The first few merged PRs will confirm.

Closes #1420.