### PR TITLE
refactor(#1422): rename KLANGK_PRESET → KLANGK_UI_MODE + value renames

### DIFF
--- a/docs/reference/klangkd-config.md
+++ b/docs/reference/klangkd-config.md
@@ -129,30 +129,30 @@ logo_url: https://example.com/logo.png
 
 Every key below corresponds to a `KLANGK_*` environment variable (uppercased, with `KLANGK_` prefix). See [Environment Variables](environment.md) for detailed descriptions of each.
 
-### Deployment profiles
+### Deployment UI mode
 
-`KLANGK_PRESET` (config key `preset`) is the single deployment-shape selector — the new name for the "deployment profiles" from [#1397](https://github.com/mcdonc/klangk/issues/1397). It is one of four corners of the (transport × auth-gate) space:
+`KLANGK_UI_MODE` (config key `ui_mode`) is the single deployment-shape selector — selects one of four corners of the (UI × auth-gate) space, with values named for the operator _experience_ (do I get a UI?) rather than the transport:
 
-| `preset`     | transport | auth gate | browser ingress |
-| ------------ | --------- | --------- | --------------- |
-| `uds-noauth` | UDS       | off       | — (impossible)  |
-| `uds-auth`   | UDS       | on        | — (impossible)  |
-| `ip-noauth`  | TCP       | off       | implied on      |
-| `ip-auth`    | TCP       | on        | implied on      |
+| `ui_mode`    | UI             | transport | auth gate |
+| ------------ | -------------- | --------- | --------- |
+| `cli-noauth` | headless (CLI) | UDS       | off       |
+| `cli-auth`   | headless (CLI) | UDS       | on        |
+| `web-noauth` | browser        | TCP       | off       |
+| `web-auth`   | browser        | TCP       | on        |
 
-Everything else is _derived_ from the preset and is **not** individually configurable: the auth gate is the `-auth`/`-noauth` suffix; browser ingress is implied by the `ip-*` presets (a browser can't ingress over a UDS); container egress paths are a fixed per-preset default. The one thing the operator still chooses separately is the auth **backend** (password vs OIDC vs both) via the existing `KLANGK_AUTH_MODES` — that decision can't be made for them.
+Everything else is _derived_ from the ui_mode and is **not** individually configurable: the auth gate is the `-auth`/`-noauth` suffix; UI presence is the `cli-`/`web-` prefix (a browser can't ingress over a UDS, so `cli-*` is headless and `web-*` is browser-facing); container egress paths are a fixed per-ui_mode default. The one thing the operator still chooses separately is the auth **backend** (password vs OIDC vs both) via the existing `KLANGK_AUTH_MODES` — that decision can't be made for them.
 
-`KLANGK_PRESET` and `KLANGK_AUTH_MODES` are cross-validated at startup: a `*-noauth` preset requires `KLANGK_AUTH_MODES=none`; a `*-auth` preset requires a gated backend (`password`/`oidc`/`both`). A conflicting config fails fast with a `ConfigurationError`. When `KLANGK_AUTH_MODES` is **unset**, it self-defaults to match the preset — `password` for `*-auth`, `none` for `*-noauth` — so a preset alone boots cleanly without an explicit backend. (OIDC is then opt-in by setting `KLANGK_AUTH_MODES=oidc` or `both`.)
+`KLANGK_UI_MODE` and `KLANGK_AUTH_MODES` are cross-validated at startup: a `*-noauth` ui_mode requires `KLANGK_AUTH_MODES=none`; a `*-auth` ui_mode requires a gated backend (`password`/`oidc`/`both`). A conflicting config fails fast with a `ConfigurationError`. When `KLANGK_AUTH_MODES` is **unset**, it self-defaults to match the ui_mode — `password` for `*-auth`, `none` for `*-noauth` — so a ui_mode alone boots cleanly without an explicit backend. (OIDC is then opt-in by setting `KLANGK_AUTH_MODES=oidc` or `both`.)
 
-| Key      | Default | Env var         |
-| -------- | ------- | --------------- |
-| `preset` |         | `KLANGK_PRESET` |
+| Key       | Default | Env var          |
+| --------- | ------- | ---------------- |
+| `ui_mode` |         | `KLANGK_UI_MODE` |
 
 ```yaml
-# --- Deployment profiles (#1397) ---
-# One of: uds-noauth | uds-auth | ip-noauth | ip-auth
+# --- Deployment UI mode (#1397) ---
+# One of: cli-noauth | cli-auth | web-noauth | web-auth
 # The auth backend is chosen separately via KLANGK_AUTH_MODES:
-preset: ip-auth # + KLANGK_AUTH_MODES=oidc (a preset with a gate needs a backend)
+ui_mode: web-auth # + KLANGK_AUTH_MODES=oidc (a ui_mode with a gate needs a backend)
 ```
 
 ### Auth / identity

--- a/src/backend/klangk_backend/oidc.py
+++ b/src/backend/klangk_backend/oidc.py
@@ -191,32 +191,32 @@ def auth_modes() -> str:
 
     Resolution order when ``KLANGK_AUTH_MODES`` is unset:
 
-    1. ``KLANGK_PRESET`` (#1397) — a ``*-auth`` preset defaults the mode
-       to ``password`` (the gate is required by the preset; the backend
-       defaults to password). A ``*-noauth`` preset defaults to ``none``.
+    1. ``KLANGK_UI_MODE`` (#1397) — a ``*-auth`` ui_mode defaults the mode
+       to ``password`` (the gate is required by the ui_mode; the backend
+       defaults to password). A ``*-noauth`` ui_mode defaults to ``none``.
     2. otherwise ``none`` (loopback single-user).
 
     OIDC settings (``KLANGK_OIDC_*``) do **not** change the mode (#1419) —
     they only take effect once the mode is ``oidc`` or ``both`` (set
-    explicitly or via a preset). A fresh klangk with nothing configured
+    explicitly or via a ui_mode). A fresh klangk with nothing configured
     therefore boots in no-login single-user mode, bound to loopback, and
     "just works" locally without a password. Operators who want password
     login, OIDC, or both set ``KLANGK_AUTH_MODES`` explicitly (or pick an
-    ``*-auth`` preset). A preset that requires a different backend (e.g.
-    OIDC) sets ``KLANGK_AUTH_MODES=oidc`` — the preset only owns the
+    ``*-auth`` ui_mode). A ui_mode that requires a different backend (e.g.
+    OIDC) sets ``KLANGK_AUTH_MODES=oidc`` — the ui_mode only owns the
     *default*, never an override.
     """
     val = resolve_env_value("KLANGK_AUTH_MODES", "")
     if val in ("oidc", "password", "both", "none"):
         return val
-    # ``KLANGK_AUTH_MODES`` unset — let the deployment preset (#1397) own the
-    # default; otherwise ``none``. A ``*-auth`` preset means the gate is
-    # required, so default to password; the preset never overrides an
+    # ``KLANGK_AUTH_MODES`` unset — let the deployment ui_mode (#1397) own
+    # the default; otherwise ``none``. A ``*-auth`` ui_mode means the gate
+    # is required, so default to password; the ui_mode never overrides an
     # explicit ``KLANGK_AUTH_MODES`` (handled above). OIDC settings no longer
     # promote the mode (#1419) — they are inert unless the mode is already
     # ``oidc``/``both``.
-    preset = get_settings().preset
-    if preset is not None and preset.endswith("-auth"):
+    ui_mode = get_settings().ui_mode
+    if ui_mode is not None and ui_mode.endswith("-auth"):
         return "password"
     return "none"
 

--- a/src/backend/klangk_backend/settings.py
+++ b/src/backend/klangk_backend/settings.py
@@ -197,35 +197,36 @@ class KlangkSettings(BaseSettings):
         sources.append(init_settings)
         return tuple(sources)
 
-    # --- Deployment profiles (#1397) ---
-    # ``preset`` is the SINGLE deployment-shape selector — the new name for
-    # the "deployment profiles" from #1392. It is one of the four corners
-    # of the (transport × auth-gate) space:
+    # --- Deployment UI mode (#1397) ---
+    # ``ui_mode`` is the SINGLE deployment-shape selector — selects one of the
+    # four corners of the (UI × auth-gate) space, with values named for the
+    # operator *experience* rather than the transport:
     #
-    #     uds-noauth / uds-auth   (UDS transport, gate off / on)
-    #     ip-noauth  / ip-auth    (TCP transport, gate off / on)
+    #     cli-noauth / cli-auth   (headless / CLI-driven, UDS transport)
+    #     web-noauth  / web-auth  (browser-facing,    TCP transport)
     #
     # Everything the earlier #1397 draft exposed as separate axis keys is
-    # *derived* from the preset and is NOT individually configurable:
+    # *derived* from the ui_mode and is NOT individually configurable:
     #   - the auth GATE is the ``-auth``/``-noauth`` suffix (no KLANGK_AUTH);
-    #   - browser ingress is implied by the ``ip-*`` presets — a browser can't
-    #     ingress over a UDS — so there is no KLANGK_BROWSER_INGRESS;
-    #   - container egress paths have one fixed default per preset, with no
+    #   - UI presence is the ``cli-``/``web-`` prefix — a browser can't ingress
+    #     over a UDS, so ``cli-*`` is headless and ``web-*`` is browser-facing;
+    #     there is no KLANGK_BROWSER_INGRESS;
+    #   - container egress paths have one fixed default per ui_mode, with no
     #     override, so there is no KLANGK_CONTAINER_EGRESS_PATHS.
     #
     # The one thing the operator still chooses separately is the auth
     # BACKEND (password vs OIDC vs both) via the existing KLANGK_AUTH_MODES —
     # that decision can't be made for them. The two keys are cross-validated
-    # at config-load: a ``*-noauth`` preset requires ``auth_modes() == none``;
-    # a ``*-auth`` preset requires a gated backend. See
-    # :func:`_validate_preset` (wired into :func:`validate_at_startup`).
+    # at config-load: a ``*-noauth`` ui_mode requires ``auth_modes() == none``;
+    # a ``*-auth`` ui_mode requires a gated backend. See
+    # :func:`_validate_ui_mode` (wired into :func:`validate_at_startup`).
     #
-    # Naming: ``preset`` (a named bundle of defaults) was chosen over
-    # ``profile`` (vague) and ``role`` (collides with klangk's RBAC workspace
-    # roles — the wrong mental model for a deployment *shape*).
+    # Naming: ``KLANGK_UI_MODE`` with values ``cli-*``/``web-*`` — both the key
+    # and the values answer the operator's actual question ("do I get a
+    # UI?"), not the implementation detail (socket vs TCP).
     # Defaults to None so a deployment that sets none of these behaves
     # identically to pre-#1392 (acceptance criterion: defaults preserved).
-    preset: str | None = None
+    ui_mode: str | None = None
 
     # --- Auth / identity ---
     auth_modes: str | None = None
@@ -430,55 +431,55 @@ def _invalidate_cache() -> None:
     _settings_env_signature = None
 
 
-# The four ``KLANGK_PRESET`` values (#1397) — the (transport × auth-gate)
+# The four ``KLANGK_UI_MODE`` values (#1397) — the (transport × auth-gate)
 # corners. ``-noauth`` means "no auth gate"; ``-auth`` means "gate required".
 # Kept module-level so the nginx renderer (chunk 3 of #1392) can import it as
-# the canonical preset set. See KlangkSettings.preset for the full rationale.
-PRESETS: frozenset[str] = frozenset(
-    {"uds-noauth", "uds-auth", "ip-noauth", "ip-auth"}
+# the canonical set. See KlangkSettings.ui_mode for the full rationale.
+UI_MODES: frozenset[str] = frozenset(
+    {"cli-noauth", "cli-auth", "web-noauth", "web-auth"}
 )
 
 
-def _validate_preset() -> None:
-    """Validate ``KLANGK_PRESET`` and its consistency with the auth backend.
+def _validate_ui_mode() -> None:
+    """Validate ``KLANGK_UI_MODE`` and its consistency with the auth backend.
 
-    ``KLANGK_PRESET`` is the single deployment-shape selector (#1397); the
+    ``KLANGK_UI_MODE`` is the single deployment-shape selector (#1397); the
     auth *backend* (password vs OIDC vs both) stays the operator's choice via
     ``KLANGK_AUTH_MODES``. The two must agree when ``KLANGK_AUTH_MODES`` is
     set EXPLICITLY:
 
-    - a ``*-noauth`` preset requires the resolved auth mode to be ``none``;
-    - a ``*-auth``   preset requires it to be ``password`` / ``oidc`` / ``both``.
+    - a ``*-noauth`` ui_mode requires the resolved auth mode to be ``none``;
+    - a ``*-auth``   ui_mode requires it to be ``password`` / ``oidc`` / ``both``.
 
     An UNSET ``KLANGK_AUTH_MODES`` never conflicts: :func:`oidc.auth_modes`
-    is preset-aware in the unset path (#1397), self-defaulting to ``password``
-    for ``*-auth`` presets and ``none`` for ``*-noauth``.
+    is ui_mode-aware in the unset path (#1397), self-defaulting to ``password``
+    for ``*-auth`` ui_modes and ``none`` for ``*-noauth``.
 
     Raises :class:`~klangk_backend.exceptions.ConfigurationError` on an
-    unknown preset value or an explicit preset/auth-mode conflict.
+    unknown ui_mode value or an explicit ui_mode/auth-mode conflict.
 
     ``klangk_backend.oidc`` is imported lazily to avoid a settings <-> oidc
     import cycle (``oidc`` imports :func:`get_settings` from this module).
     """
-    preset = get_settings().preset
-    if preset is None:
-        return  # no preset set → today's pre-#1392 behavior
-    if preset not in PRESETS:
+    ui_mode = get_settings().ui_mode
+    if ui_mode is None:
+        return  # no ui_mode set → today's pre-#1392 behavior
+    if ui_mode not in UI_MODES:
         raise ConfigurationError(
-            f"KLANGK_PRESET={preset!r} is not one of {sorted(PRESETS)}"
+            f"KLANGK_UI_MODE={ui_mode!r} is not one of {sorted(UI_MODES)}"
         )
     from . import oidc  # noqa: allow-deferred-import  (settings <-> oidc cycle)
 
     mode = oidc.auth_modes()
-    noauth = preset.endswith("-noauth")
+    noauth = ui_mode.endswith("-noauth")
     if noauth and mode != "none":
         raise ConfigurationError(
-            f"KLANGK_PRESET={preset!r} requires KLANGK_AUTH_MODES=none, "
+            f"KLANGK_UI_MODE={ui_mode!r} requires KLANGK_AUTH_MODES=none, "
             f"but the resolved auth mode is {mode!r}"
         )
     if not noauth and mode == "none":
         raise ConfigurationError(
-            f"KLANGK_PRESET={preset!r} requires an auth-gated backend "
+            f"KLANGK_UI_MODE={ui_mode!r} requires an auth-gated backend "
             f"(KLANGK_AUTH_MODES=password|oidc|both), but the resolved "
             f"auth mode is 'none'"
         )
@@ -490,13 +491,13 @@ def validate_at_startup() -> KlangkSettings:
     Call once from the lifespan startup (and from the ``klangkd`` launcher).
     Bogus config (once fields gain strict types) fails here with a
     :class:`ValidationError` before the server serves traffic. Also runs the
-    :func:`_validate_preset` cross-check so a ``KLANGK_PRESET`` that
+    :func:`_validate_ui_mode` cross-check so a ``KLANGK_UI_MODE`` that
     disagrees with the resolved ``KLANGK_AUTH_MODES`` backend fails fast.
     Returns the validated settings instance (which also primes the cache).
     """
     _invalidate_cache()
     settings = get_settings()
-    _validate_preset()
+    _validate_ui_mode()
     return settings
 
 

--- a/src/backend/tests/test_oidc.py
+++ b/src/backend/tests/test_oidc.py
@@ -517,48 +517,48 @@ class TestAuthModes:
             monkeypatch.setenv("KLANGK_AUTH_MODES", mode)
             assert not oidc.local_login_allowed()
 
-    # --- #1397 preset-driven default (KLANGK_AUTH_MODES unset) ---
-    # A ``*-auth`` preset means the gate is required, so the *unset* default
+    # --- #1397 ui_mode-driven default (KLANGK_AUTH_MODES unset) ---
+    # A ``*-auth`` ui_mode means the gate is required, so the *unset* default
     # resolves to ``password`` (the operator still picks the backend —
     # e.g. OIDC — by setting KLANGK_AUTH_MODES explicitly). A ``*-noauth``
-    # preset stays ``none``. With no preset set, today's pre-#1392 default
+    # ui_mode stays ``none``. With no ui_mode set, today's pre-#1392 default
     # (the OIDC-promotion rule below) is preserved — removing that promotion
     # is a separate breaking change, deferred to #1392 chunk 7.
 
-    @pytest.mark.parametrize("preset", ["uds-auth", "ip-auth"])
-    def test_auth_preset_defaults_to_password(self, monkeypatch, preset):
+    @pytest.mark.parametrize("ui_mode", ["cli-auth", "web-auth"])
+    def test_auth_ui_mode_defaults_to_password(self, monkeypatch, ui_mode):
         monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
-        monkeypatch.setenv("KLANGK_PRESET", preset)
+        monkeypatch.setenv("KLANGK_UI_MODE", ui_mode)
         assert oidc.auth_modes() == "password"
         assert oidc.password_login_allowed()
         assert not oidc.local_login_allowed()
 
-    @pytest.mark.parametrize("preset", ["uds-noauth", "ip-noauth"])
-    def test_noauth_preset_defaults_to_none(self, monkeypatch, preset):
+    @pytest.mark.parametrize("ui_mode", ["cli-noauth", "web-noauth"])
+    def test_noauth_ui_mode_defaults_to_none(self, monkeypatch, ui_mode):
         monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
-        monkeypatch.setenv("KLANGK_PRESET", preset)
+        monkeypatch.setenv("KLANGK_UI_MODE", ui_mode)
         assert oidc.auth_modes() == "none"
         assert oidc.local_login_allowed()
         assert not oidc.password_login_allowed()
 
-    def test_auth_preset_default_does_not_override_explicit_mode(
+    def test_auth_ui_mode_default_does_not_override_explicit_mode(
         self, monkeypatch
     ):
-        # The preset only owns the *default* — an explicit KLANGK_AUTH_MODES
+        # The ui_mode only owns the *default* — an explicit KLANGK_AUTH_MODES
         # always wins (even a conflicting one; that's what the settings-level
-        # _validate_preset cross-check is for, not auth_modes() itself).
-        monkeypatch.setenv("KLANGK_PRESET", "uds-auth")
+        # _validate_ui_mode cross-check is for, not auth_modes() itself).
+        monkeypatch.setenv("KLANGK_UI_MODE", "cli-auth")
         monkeypatch.setenv("KLANGK_AUTH_MODES", "oidc")
         oidc._providers.append(_provider())
         assert oidc.auth_modes() == "oidc"
         assert oidc.oidc_login_allowed()
         assert not oidc.password_login_allowed()
 
-    def test_no_preset_preserves_legacy_default(self, monkeypatch):
-        # No preset + AUTH_MODES unset → ``none``. OIDC settings no longer
+    def test_no_ui_mode_preserves_legacy_default(self, monkeypatch):
+        # No ui_mode + AUTH_MODES unset → ``none``. OIDC settings no longer
         # promote the mode (#1419), so configuring a provider does not flip
         # the default; the operator must set KLANGK_AUTH_MODES=oidc/both.
-        monkeypatch.delenv("KLANGK_PRESET", raising=False)
+        monkeypatch.delenv("KLANGK_UI_MODE", raising=False)
         monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
         assert oidc.auth_modes() == "none"
         oidc._providers.append(_provider())

--- a/src/backend/tests/test_settings.py
+++ b/src/backend/tests/test_settings.py
@@ -15,7 +15,7 @@ from klangk_backend import settings as settings_mod
 from klangk_backend.exceptions import ConfigurationError
 from klangk_backend.settings import (
     KlangkSettings,
-    PRESETS,
+    UI_MODES,
     _key_to_field,
     get_config_file,
     get_settings,
@@ -272,147 +272,149 @@ class TestConfigFile:
 
 
 # ---------------------------------------------------------------------------
-# KLANGK_PRESET (#1397): the single deployment-shape key
+# KLANGK_UI_MODE (#1397): the single deployment-shape key
 # ---------------------------------------------------------------------------
 
 
-class TestPreset:
-    """``KLANGK_PRESET`` is the only settable deployment-shape key (#1397).
+class TestUiMode:
+    """``KLANGK_UI_MODE`` is the only settable deployment-shape key (#1397).
 
-    The earlier #1397 draft exposed four axis keys (preset / auth /
+    The earlier #1397 draft exposed four axis keys (auth /
     browser_ingress / container_egress_paths). The finalized model keeps only
-    ``preset``: the auth GATE is its ``-auth``/``-noauth`` suffix, browser
-    ingress is implied by the ``ip-*`` presets, and container egress paths
-    are a fixed per-preset default. The auth BACKEND (password vs OIDC vs
-    both) stays the operator's choice via the existing ``KLANGK_AUTH_MODES``;
-    the two are cross-validated (see :class:`TestPresetAuthConflict`).
+    ``ui_mode``: the auth GATE is its ``-auth``/``-noauth`` suffix, UI
+    presence is its ``cli-``/``web-`` prefix (a browser can't ingress over a
+    UDS, so ``cli-*`` is headless and ``web-*`` is browser-facing), and
+    container egress paths are a fixed per-ui_mode default. The auth BACKEND
+    (password vs OIDC vs both) stays the operator's choice via the existing
+    ``KLANGK_AUTH_MODES``; the two are cross-validated (see
+    :class:`TestUiModeAuthConflict`).
 
-    These tests pin that ``preset`` is settable via BOTH an env var and the
+    These tests pin that ``ui_mode`` is settable via BOTH an env var and the
     YAML config file (like every other field) so a future change can't
     silently drop the config-file path.
     """
 
     def test_field_exists(self):
-        assert "preset" in KlangkSettings.model_fields
-        assert PRESETS == frozenset(
-            {"uds-noauth", "uds-auth", "ip-noauth", "ip-auth"}
+        assert "ui_mode" in KlangkSettings.model_fields
+        assert UI_MODES == frozenset(
+            {"cli-noauth", "cli-auth", "web-noauth", "web-auth"}
         )
 
     def test_dropped_axis_keys_are_not_fields(self):
         # auth / browser_ingress / container_egress_paths are NOT individually
-        # settable — everything but preset is derived from the preset.
+        # settable — everything but ui_mode is derived from the ui_mode.
         fields = KlangkSettings.model_fields
         for dropped in ("auth", "browser_ingress", "container_egress_paths"):
             assert dropped not in fields, dropped
 
-    @pytest.mark.parametrize("value", sorted(PRESETS))
+    @pytest.mark.parametrize("value", sorted(UI_MODES))
     def test_settable_via_env(self, monkeypatch, value):
         set_config_file(None)
-        monkeypatch.setenv("KLANGK_PRESET", value)
-        assert get_settings().preset == value
+        monkeypatch.setenv("KLANGK_UI_MODE", value)
+        assert get_settings().ui_mode == value
 
-    @pytest.mark.parametrize("value", sorted(PRESETS))
+    @pytest.mark.parametrize("value", sorted(UI_MODES))
     def test_settable_via_yaml(self, tmp_path, value):
         cfg = tmp_path / "config.yaml"
-        cfg.write_text(f'preset: "{value}"\n')
+        cfg.write_text(f'ui_mode: "{value}"\n')
         set_config_file(str(cfg))
-        assert get_settings().preset == value
+        assert get_settings().ui_mode == value
 
     def test_env_overrides_yaml(self, monkeypatch, tmp_path):
         cfg = tmp_path / "config.yaml"
-        cfg.write_text('preset: "uds-noauth"\n')
+        cfg.write_text('ui_mode: "cli-noauth"\n')
         set_config_file(str(cfg))
-        monkeypatch.setenv("KLANGK_PRESET", "ip-auth")
-        assert get_settings().preset == "ip-auth"
+        monkeypatch.setenv("KLANGK_UI_MODE", "web-auth")
+        assert get_settings().ui_mode == "web-auth"
 
     def test_default_none_preserves_today(self):
-        # No preset set → None → pre-#1392 behavior; validate_at_startup is a
-        # no-op (no conflict check runs when preset is unset).
+        # No ui_mode set → None → pre-#1392 behavior; validate_at_startup is a
+        # no-op (no conflict check runs when ui_mode is unset).
         set_config_file(None)
-        assert get_settings().preset is None
+        assert get_settings().ui_mode is None
 
 
-class TestPresetAuthConflict:
-    """``KLANGK_PRESET`` must agree with an EXPLICIT ``KLANGK_AUTH_MODES``.
+class TestUiModeAuthConflict:
+    """``KLANGK_UI_MODE`` must agree with an EXPLICIT ``KLANGK_AUTH_MODES``.
 
-    The preset fixes whether an auth gate is required (its suffix); the
+    The ui_mode fixes whether an auth gate is required (its suffix); the
     operator separately chooses the backend (password / OIDC / both) via
     ``KLANGK_AUTH_MODES``. The two are cross-validated at config-load by
     :func:`validate_at_startup`, so an *explicitly conflicting* config fails
     fast at boot:
 
-    - ``*-noauth`` presets require the resolved auth mode to be ``none``;
-    - ``*-auth``   presets require it to be non-``none``.
+    - ``*-noauth`` ui_modes require the resolved auth mode to be ``none``;
+    - ``*-auth``   ui_modes require it to be non-``none``.
 
     Important: an UNSET ``KLANGK_AUTH_MODES`` never conflicts —
-    ``oidc.auth_modes()`` is preset-aware in the unset path (#1397), so a
-    ``*-auth`` preset defaults the mode to ``password`` and ``*-noauth`` to
+    ``oidc.auth_modes()`` is ui_mode-aware in the unset path (#1397), so a
+    ``*-auth`` ui_mode defaults the mode to ``password`` and ``*-noauth`` to
     ``none``. The conflict check only fires on an *explicit* value that
-    disagrees with the preset. These tests set ``KLANGK_AUTH_MODES``
+    disagrees with the ui_mode. These tests set ``KLANGK_AUTH_MODES``
     explicitly in every case; the unset-no-conflict cases are covered at the
     end.
     """
 
-    def test_unknown_preset_rejected(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_PRESET", "bogus")
+    def test_unknown_ui_mode_rejected(self, monkeypatch):
+        monkeypatch.setenv("KLANGK_UI_MODE", "bogus")
         monkeypatch.setenv("KLANGK_AUTH_MODES", "password")
         with pytest.raises(ConfigurationError, match="not one of"):
             validate_at_startup()
 
-    @pytest.mark.parametrize("preset", ["uds-noauth", "ip-noauth"])
+    @pytest.mark.parametrize("ui_mode", ["cli-noauth", "web-noauth"])
     @pytest.mark.parametrize("mode", ["password", "oidc", "both"])
-    def test_noauth_preset_conflicts_with_any_backend(
-        self, monkeypatch, preset, mode
+    def test_noauth_ui_mode_conflicts_with_any_backend(
+        self, monkeypatch, ui_mode, mode
     ):
-        monkeypatch.setenv("KLANGK_PRESET", preset)
+        monkeypatch.setenv("KLANGK_UI_MODE", ui_mode)
         monkeypatch.setenv("KLANGK_AUTH_MODES", mode)
         with pytest.raises(
             ConfigurationError, match="requires KLANGK_AUTH_MODES=none"
         ):
             validate_at_startup()
 
-    @pytest.mark.parametrize("preset", ["uds-noauth", "ip-noauth"])
-    def test_noauth_preset_ok_with_none(self, monkeypatch, preset):
-        monkeypatch.setenv("KLANGK_PRESET", preset)
+    @pytest.mark.parametrize("ui_mode", ["cli-noauth", "web-noauth"])
+    def test_noauth_ui_mode_ok_with_none(self, monkeypatch, ui_mode):
+        monkeypatch.setenv("KLANGK_UI_MODE", ui_mode)
         monkeypatch.setenv("KLANGK_AUTH_MODES", "none")
         settings = validate_at_startup()  # no raise
-        assert settings.preset == preset
+        assert settings.ui_mode == ui_mode
 
-    @pytest.mark.parametrize("preset", ["uds-auth", "ip-auth"])
-    def test_auth_preset_conflicts_with_none(self, monkeypatch, preset):
-        monkeypatch.setenv("KLANGK_PRESET", preset)
+    @pytest.mark.parametrize("ui_mode", ["cli-auth", "web-auth"])
+    def test_auth_ui_mode_conflicts_with_none(self, monkeypatch, ui_mode):
+        monkeypatch.setenv("KLANGK_UI_MODE", ui_mode)
         monkeypatch.setenv("KLANGK_AUTH_MODES", "none")
         with pytest.raises(
             ConfigurationError, match="requires an auth-gated backend"
         ):
             validate_at_startup()
 
-    @pytest.mark.parametrize("preset", ["uds-auth", "ip-auth"])
+    @pytest.mark.parametrize("ui_mode", ["cli-auth", "web-auth"])
     @pytest.mark.parametrize("mode", ["password", "oidc", "both"])
-    def test_auth_preset_ok_with_backend(self, monkeypatch, preset, mode):
-        monkeypatch.setenv("KLANGK_PRESET", preset)
+    def test_auth_ui_mode_ok_with_backend(self, monkeypatch, ui_mode, mode):
+        monkeypatch.setenv("KLANGK_UI_MODE", ui_mode)
         monkeypatch.setenv("KLANGK_AUTH_MODES", mode)
         settings = validate_at_startup()  # no raise
-        assert settings.preset == preset
+        assert settings.ui_mode == ui_mode
 
-    def test_no_preset_skips_conflict_check(self, monkeypatch):
-        # preset unset → no validation runs (pre-#1392 behavior preserved),
+    def test_no_ui_mode_skips_conflict_check(self, monkeypatch):
+        # ui_mode unset → no validation runs (pre-#1392 behavior preserved),
         # regardless of the auth mode.
-        monkeypatch.delenv("KLANGK_PRESET", raising=False)
+        monkeypatch.delenv("KLANGK_UI_MODE", raising=False)
         monkeypatch.setenv("KLANGK_AUTH_MODES", "none")
         validate_at_startup()  # no raise
 
     @pytest.mark.parametrize(
-        "preset", ["uds-noauth", "uds-auth", "ip-noauth", "ip-auth"]
+        "ui_mode", ["cli-noauth", "cli-auth", "web-noauth", "web-auth"]
     )
-    def test_unset_auth_mode_never_conflicts(self, monkeypatch, preset):
+    def test_unset_auth_mode_never_conflicts(self, monkeypatch, ui_mode):
         # An unset KLANGK_AUTH_MODES never conflicts: oidc.auth_modes()
-        # self-defaults to match the preset (*-auth → password, *-noauth →
-        # none). So a preset alone boots cleanly with no explicit backend.
-        monkeypatch.setenv("KLANGK_PRESET", preset)
+        # self-defaults to match the ui_mode (*-auth → password, *-noauth →
+        # none). So a ui_mode alone boots cleanly with no explicit backend.
+        monkeypatch.setenv("KLANGK_UI_MODE", ui_mode)
         monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
         settings = validate_at_startup()  # no raise
-        assert settings.preset == preset
+        assert settings.ui_mode == ui_mode
 
 
 class TestKlangkdLauncher:


### PR DESCRIPTION
Closes #1422.

## Summary

Pure rename of the deployment-shape config so the key **and** the values answer the operator's actual question ("do I get a UI?"), not the implementation detail (socket vs TCP):

| kind | before | after |
|---|---|---|
| key | `KLANGK_PRESET` | `KLANGK_UI_MODE` |
| settings field | `preset` | `ui_mode` |
| constant | `PRESETS` | `UI_MODES` |
| function | `_validate_preset` | `_validate_ui_mode` |
| value | `uds-noauth` / `uds-auth` | `cli-noauth` / `cli-auth` (headless/CLI) |
| value | `ip-noauth` / `ip-auth` | `web-noauth` / `web-auth` (browser) |

Both value axes are now experience-named: `cli-`/`web-` for the UI axis, `-auth`/`-noauth` for the gate. Transport (UDS/TCP) drops out of the operator-facing names entirely.

**Semantics unchanged** — pure rename. No behavior change; the validation, defaulting, and the four-way matrix are identical.

## Why no rename-history comments

`KLANGK_PRESET` never shipped in a release, so the code reads as if `KLANGK_UI_MODE`/`cli-*`/`web-*` were always the names — no "was previously called..." comments anywhere.

## Footprint

- `src/backend/klangk_backend/settings.py` — field, `UI_MODES` constant, `_validate_ui_mode`, error messages, comments
- `src/backend/klangk_backend/oidc.py` — `auth_modes()` ui_mode-default branch + docstring
- `src/backend/tests/test_settings.py` + `test_oidc.py` — env vars, parametrize values, test names, local vars
- `docs/reference/klangkd-config.md` — the canonical reference, value matrix reframed (UI × auth-gate, experience-named)

## Test results

- **Backend unit tests:** 2372 passed, **100% coverage**
- **All pre-commit hooks** pass (ruff, prettier, markdownlint, deferred-imports)