### PR TITLE
refactor(#1422): derive deployment shape from LISTEN+AUTH; drop amalgamated setting

### DIFF
--- a/docs/reference/klangkd-config.md
+++ b/docs/reference/klangkd-config.md
@@ -129,30 +129,61 @@ logo_url: https://example.com/logo.png
 
 Every key below corresponds to a `KLANGK_*` environment variable (uppercased, with `KLANGK_` prefix). See [Environment Variables](environment.md) for detailed descriptions of each.
 
-### Deployment profiles
+### Deployment shape (derived from `KLANGK_LISTEN` + `KLANGK_AUTH_MODE`)
 
-`KLANGK_PRESET` (config key `preset`) is the single deployment-shape selector — the new name for the "deployment profiles" from [#1397](https://github.com/mcdonc/klangk/issues/1397). It is one of four corners of the (transport × auth-gate) space:
+The deployment shape is **derived** from two knobs: the bind address (`KLANGK_LISTEN`) and the auth gate (`KLANGK_AUTH_MODE`). klangk picks the nginx template and enforces its one safety rule from their combination — there is no separate "mode" to set.
 
-| `preset`     | transport | auth gate | browser ingress |
-| ------------ | --------- | --------- | --------------- |
-| `uds-noauth` | UDS       | off       | — (impossible)  |
-| `uds-auth`   | UDS       | on        | — (impossible)  |
-| `ip-noauth`  | TCP       | off       | implied on      |
-| `ip-auth`    | TCP       | on        | implied on      |
+**`KLANGK_LISTEN`** is **polymorphic**: either a UNIX socket path (e.g.
+`/tmp/klangk.sock`) or a TCP host (e.g. `127.0.0.1`, `0.0.0.0`). The port is
+NOT part of listen — it comes from `KLANGK_PORT` when listen is TCP.
+Classification: an absolute path with no `://` scheme ⇒ socket; otherwise TCP.
+`KLANGK_PORT` applies only when LISTEN is TCP.
 
-Everything else is _derived_ from the preset and is **not** individually configurable: the auth gate is the `-auth`/`-noauth` suffix; browser ingress is implied by the `ip-*` presets (a browser can't ingress over a UDS); container egress paths are a fixed per-preset default. The one thing the operator still chooses separately is the auth **backend** (password vs OIDC vs both) via the existing `KLANGK_AUTH_MODES` — that decision can't be made for them.
+**`KLANGK_AUTH_MODE`** is the sole authority on the auth gate (`none` /
+`password` / `oidc` / `both`). When unset it defaults to `none`; OIDC settings
+never promote it.
 
-`KLANGK_PRESET` and `KLANGK_AUTH_MODES` are cross-validated at startup: a `*-noauth` preset requires `KLANGK_AUTH_MODES=none`; a `*-auth` preset requires a gated backend (`password`/`oidc`/`both`). A conflicting config fails fast with a `ConfigurationError`. When `KLANGK_AUTH_MODES` is **unset**, it self-defaults to match the preset — `password` for `*-auth`, `none` for `*-noauth` — so a preset alone boots cleanly without an explicit backend. (OIDC is then opt-in by setting `KLANGK_AUTH_MODES=oidc` or `both`.)
+For each combination, klangk renders the **maximum-feature nginx template
+the combination can service**:
 
-| Key      | Default | Env var         |
-| -------- | ------- | --------------- |
-| `preset` |         | `KLANGK_PRESET` |
+| `KLANGK_LISTEN`  | `KLANGK_AUTH_MODE`     | nginx template | browser?    | status                                               |
+| ---------------- | ---------------------- | -------------- | ----------- | ---------------------------------------------------- |
+| socket (UDS)     | none                   | minimal        | no          | ✅ **default** (most-secure-convenient)              |
+| socket (UDS)     | password / oidc / both | minimal        | no          | ✅ (most secure, less convenient)                    |
+| loopback TCP     | none                   | full           | yes (local) | ✅ (local-dev "just works")                          |
+| loopback TCP     | password / oidc / both | full           | yes (local) | ✅                                                   |
+| non-loopback TCP | none                   | —              | —           | ⚠️ rejected unless `KLANGK_ALLOW_INSECURE_NO_AUTH=1` |
+| non-loopback TCP | password / oidc / both | full           | yes (net)   | ✅ (least secure; operator opted in)                 |
+
+- **Template selection keys off LISTEN's shape only**: socket ⇒ minimal
+  (container-egress `/llm-proxy` only — no browser UI, since a browser can't
+  reach a UDS); TCP ⇒ full. `KLANGK_AUTH_MODE` does **not** change which
+  template renders.
+- **The one gate** (`none` on non-loopback TCP) is enforced by
+  `enforce_no_auth_bind_safety()` at boot — refused unless
+  `KLANGK_ALLOW_INSECURE_NO_AUTH=1` is set (e.g. a throwaway VM on an
+  isolated network). No-auth mode freely issues an admin token, so exposing
+  it off-loopback is opt-in, not silent.
+
+**Security ordering** (most → least secure): UDS+password > UDS+none
+(default) > loopback TCP (local) > non-loopback TCP+gate. The default
+(UDS+none) is the most-secure-_convenient_ posture: same-uid-only socket
+access, no password to manage, and — via the minimal template — no
+browser/TCP surface. A future release will flip `KLANGK_LISTEN`'s default
+to a socket path so bare `klangkd` boots this posture.
+
+| Key      | Default     | Env var         |
+| -------- | ----------- | --------------- |
+| `listen` | `127.0.0.1` | `KLANGK_LISTEN` |
 
 ```yaml
-# --- Deployment profiles (#1397) ---
-# One of: uds-noauth | uds-auth | ip-noauth | ip-auth
-# The auth backend is chosen separately via KLANGK_AUTH_MODES:
-preset: ip-auth # + KLANGK_AUTH_MODES=oidc (a preset with a gate needs a backend)
+# --- Deployment shape ---
+# listen is polymorphic: a socket path (UDS, minimal/headless template) or
+# a TCP host (full/browser template). Today the default is 127.0.0.1
+# (TCP); a future release will default it to a socket path (headless).
+listen: 127.0.0.1
+# auth_modes is the sole auth authority; unset defaults to none.
+# auth_modes: password  # or oidc / both / none
 ```
 
 ### Auth / identity

--- a/sandboxes/tests/hermes/test_hermes_setup_e2e.py
+++ b/sandboxes/tests/hermes/test_hermes_setup_e2e.py
@@ -101,12 +101,14 @@ def _login(base_url):
 def _start_server(data_dir, port, extra_env=None):
     env = {
         **os.environ,
+        "_KLANGK_DISABLE_NGINX": "1",  # bare uvicorn; lifespan must not spawn nginx
         "KLANGK_PORT": port,
         "KLANGK_DATA_DIR": data_dir,
         "KLANGK_JWT_SECRET": "hermes-e2e-test-secret",
         "KLANGK_PREVENT_INSECURE_JWT_SECRET": "",
         "KLANGK_DEFAULT_USER": EMAIL,
         "KLANGK_DEFAULT_PASSWORD": PASSWORD,
+        "KLANGK_AUTH_MODES": "password",  # these tests use password login
         "KLANGK_TEST_MODE": "1",
         "KLANGK_IDLE_TIMEOUT_SECONDS": "300",
         # Poll health every 3s so the health-check test sees the healthy

--- a/sandboxes/tests/openclaw/test_openclaw_setup_e2e.py
+++ b/sandboxes/tests/openclaw/test_openclaw_setup_e2e.py
@@ -134,12 +134,14 @@ def _login(base_url):
 def _start_server(data_dir, port, extra_env=None):
     env = {
         **os.environ,
+        "_KLANGK_DISABLE_NGINX": "1",  # bare uvicorn; lifespan must not spawn nginx
         "KLANGK_PORT": port,
         "KLANGK_DATA_DIR": data_dir,
         "KLANGK_JWT_SECRET": "openclaw-e2e-test-secret",
         "KLANGK_PREVENT_INSECURE_JWT_SECRET": "",
         "KLANGK_DEFAULT_USER": EMAIL,
         "KLANGK_DEFAULT_PASSWORD": PASSWORD,
+        "KLANGK_AUTH_MODES": "password",  # these tests use password login
         "KLANGK_TEST_MODE": "1",
         "KLANGK_IDLE_TIMEOUT_SECONDS": "300",
         # Poll health every 3s instead of the 30s default so the

--- a/src/backend/e2e-tests/conftest.py
+++ b/src/backend/e2e-tests/conftest.py
@@ -19,6 +19,27 @@ import pytest
 
 
 @pytest.fixture(scope="session", autouse=True)
+def _e2e_disable_nginx():
+    """Suppress the lifespan's nginx watchdog across the E2E suite.
+
+    nginx ownership is unconditional in real runs, but these tests launch the
+    backend via bare ``uvicorn`` and (in dev) another nginx already holds
+    ``KLANGK_NGINX_PORT``; a second spawned by the lifespan would fight it for
+    the port (and on CI, loop forever). Sets the internal, non-user-facing
+    ``_KLANGK_DISABLE_NGINX`` kill switch — same as the unit-suite fixture.
+    """
+    old = os.environ.get("_KLANGK_DISABLE_NGINX")
+    os.environ["_KLANGK_DISABLE_NGINX"] = "1"
+    try:
+        yield
+    finally:
+        if old is None:
+            os.environ.pop("_KLANGK_DISABLE_NGINX", None)
+        else:
+            os.environ["_KLANGK_DISABLE_NGINX"] = old
+
+
+@pytest.fixture(scope="session", autouse=True)
 def _e2e_default_auth_mode():
     """Pin E2E servers to ``password`` mode for the whole session.
 

--- a/src/backend/klangk_backend/klangkd.py
+++ b/src/backend/klangk_backend/klangkd.py
@@ -1,8 +1,9 @@
 """``klangkd`` — the klangk server launcher (#1395, #1396).
 
 Loads config (from a YAML file + env vars + built-in defaults, per the
-precedence rules in :mod:`klangk_backend.settings`), binds uvicorn to a UNIX
-domain socket (UDS), and owns the nginx child that fronts it (#1396).
+precedence rules in :mod:`klangk_backend.settings`), binds uvicorn (to a
+UNIX domain socket when ``KLANGK_LISTEN`` is a path, or a TCP host
+otherwise), and owns the nginx child that fronts it.
 
 Usage::
 
@@ -29,11 +30,14 @@ import typer
 import uvicorn
 
 from klangk_backend.settings import (
+    classify_listen,
     get_settings,
+    resolve_env_value,
     resolve_indirection,
     set_config_file,
     validate_at_startup,
 )
+from klangk_backend.util import set_uds_mode
 
 # The default config-file location — a deployed klangkd finds its config here
 # with no args.  See #1395.
@@ -90,7 +94,7 @@ def main(  # pragma: no cover
         ),
     ),
 ) -> None:
-    """Start the klangk server (uvicorn on a UDS + nginx child)."""
+    """Start the klangk server (uvicorn + nginx child)."""
     resolved = _resolve_config_path(config)
 
     # Seed the state_dir default into the env so the settings model can pick
@@ -106,59 +110,70 @@ def main(  # pragma: no cover
 
     # Everything below reads through the typed config (config file > env >
     # defaults, with file:/cmd: resolution), NOT raw os.environ — so a YAML
-    # ``state_dir:``/``ws_msg_size_max:`` value or a ``file:``/``cmd:`` prefix
-    # takes effect the same as an env var (#1394/#1395).
+    # value or a ``file:``/``cmd:`` prefix takes effect the same as an env
+    # var (#1394/#1395).
     settings = get_settings()
     state_dir = resolve_indirection(settings.state_dir) or _default_state_dir()
-    socket_path = os.path.join(state_dir, "klangk.sock")
-
-    # Arm the lifespan's nginx watchdog: this is the honest "are we in UDS
-    # mode?" switch (#1396). Only klangkd sets it; bare uvicorn / unit tests
-    # never do, so the watchdog no-ops there. Read through the typed config so
-    # ``uds_mode: true`` in the config file works too.
-    uds_mode = resolve_indirection(settings.uds_mode) or "1"
-    os.environ["KLANGK_UDS_MODE"] = uds_mode
     # Re-pin state_dir into env so the lifespan watchdog (which reads the
     # merged config fresh) sees the same resolved value.
     os.environ["KLANGK_STATE_DIR"] = state_dir
 
-    # uvicorn creates the socket, but a stale socket from a kill -9'd process
-    # makes the bind fail with EADDRINUSE. Unlink it first (accept that a race
-    # with a concurrent klangkd is the operator's problem — the pidfile guard
-    # in the lifespan already refuses a second instance). #1396.
-    try:
-        os.unlink(socket_path)
-    except FileNotFoundError:
-        pass
+    # ``KLANGK_LISTEN`` is polymorphic (#1422): a socket path or a TCP
+    # TCP host or socket path. classify_listen picks the transport from its
+    # shape; uvicorn
+    # binds accordingly. The deployment shape is *derived* from listen's shape
+    # + auth_modes — there is no amalgamated UI-mode setting.
+    listen = resolve_indirection(settings.listen) or "127.0.0.1"
+    transport = classify_listen(listen)
 
-    # Ensure the socket's parent dir exists and is private (0700) so only the
-    # klangk user can open the socket — the same-uid trust boundary the
-    # _UDS_MODE flag in util.py relies on.
-    Path(socket_path).parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-
-    # uvicorn is single-bind: host/port XOR uds XOR fd. We bind the UDS only —
-    # no TCP listener on uvicorn in any mode (the security win of #1396).
-    # nginx (started by the lifespan watchdog) proxies the TCP listener
-    # (KLANGK_NGINX_PORT) to this socket for browser + CLI clients.
     # Read ws_max_size through the typed config (config file > env > default,
     # with file:/cmd:), not raw os.environ (#1394/#1395).
     ws_max_size = int(
         resolve_indirection(settings.ws_msg_size_max) or "16777216"
     )
 
-    uvicorn.run(
-        "klangk_backend.main:app",
-        uds=socket_path,
-        # proxy_headers=False (default): over a UDS request.client is None, and
-        # we do NOT want uvicorn to populate it from X-Forwarded-* — our trust
-        # helpers (_connection_peer_is_trusted) handle header trust explicitly
-        # via the _UDS_MODE flag. Letting uvicorn also rewrite client would
-        # double-resolve and bypass the trusted-proxy gate.
-        proxy_headers=False,
-        ws_max_size=ws_max_size,
-        ws_ping_interval=20,
-        ws_ping_timeout=20,
-    )
+    if transport == "socket":
+        # Bind the UDS. A stale socket from a kill -9'd process makes the
+        # bind fail with EADDRINUSE — unlink first (the pidfile guard in the
+        # lifespan refuses a concurrent klangkd). Ensure the parent dir is
+        # private (0700) so only the klangk user can open the socket — the
+        # same-uid trust boundary _UDS_MODE relies on.
+        try:
+            os.unlink(listen)
+        except FileNotFoundError:
+            pass
+        Path(listen).parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        # Arm the internal _UDS_MODE trust flag (util.py): over a UDS,
+        # request.client is None, and a None peer is the trusted reverse
+        # proxy (same-uid socket access). Set here, from the bind decision —
+        # not via a config field (#1422 retired KLANGK_UDS_MODE).
+        set_uds_mode(True)
+        uvicorn.run(
+            "klangk_backend.main:app",
+            uds=listen,
+            # proxy_headers=False: over a UDS request.client is None; our
+            # trust helpers handle header trust via _UDS_MODE. Letting uvicorn
+            # also rewrite client would double-resolve.
+            proxy_headers=False,
+            ws_max_size=ws_max_size,
+            ws_ping_interval=20,
+            ws_ping_timeout=20,
+        )
+    else:
+        # TCP bind. LISTEN is the host (no port — port always comes from
+        # KLANGK_PORT). No nginx ownership on this path (bare uvicorn /
+        # direct-TCP tests); nginx is owned only in the UDS case.
+        host = listen
+        port = int(resolve_env_value("KLANGK_PORT") or "8997")
+        uvicorn.run(
+            "klangk_backend.main:app",
+            host=host,
+            port=port,
+            proxy_headers=False,
+            ws_max_size=ws_max_size,
+            ws_ping_interval=20,
+            ws_ping_timeout=20,
+        )
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -28,7 +28,11 @@ from . import (
     workspaces,
     wshandler,
 )
-from .settings import get_settings, resolve_indirection, validate_at_startup
+from .settings import (
+    get_settings,
+    resolve_indirection,
+    validate_at_startup,
+)
 from .api import root_router, router
 from .util import API_PREFIX, derive_hosting_info
 from .model import (
@@ -393,23 +397,19 @@ _nginx_task: asyncio.Task | None = None
 _nginx_stopping = False
 
 
-def _uds_enabled() -> bool:
-    """True when the server is bound to a UDS (only klangkd sets this).
-
-    The honest mode switch (#1396): klangkd sets ``KLANGK_UDS_MODE`` to arm the
-    nginx watchdog; bare uvicorn / unit tests never set it, so the watchdog
-    no-ops and ``_UDS_MODE`` stays False. A flag, not a path — the socket
-    path is derived from ``state_dir``.
-    """
-    raw = resolve_indirection(get_settings().uds_mode) or ""
-    return raw.strip().lower() in ("1", "true", "yes")
-
-
 def _socket_path() -> str:
-    """The UDS path: ``<state_dir>/klangk.sock``.
+    """The UDS path klangkd is bound to (only meaningful when listen is a socket).
 
-    Single path knob (``state_dir``); the socket always lives under it.
+    Reads ``KLANGK_LISTEN`` directly — under the derive model (#1422) the
+    socket path IS the listen value (e.g. ``/tmp/klangk.sock``), not a
+    separate derived-from-state_dir artifact. When listen is unset/empty,
+    falls back to ``<state_dir>/klangk.sock`` (a sensible default rather than
+    an empty string). The renderer + watchdog use this to know where nginx
+    should ``proxy_pass``.
     """
+    listen = resolve_indirection(get_settings().listen) or ""
+    if listen:
+        return listen
     state_dir = (
         resolve_indirection(get_settings().state_dir) or "/tmp/klangk-state"
     )
@@ -455,7 +455,7 @@ async def _nginx_watchdog(
 def _prepare_nginx() -> tuple[str, str]:
     """Render nginx.conf for the UDS and return ``(bin_path, conf_path)``.
 
-    Pure-ish (writes one file): resolves the socket path from ``state_dir``,
+    Pure-ish (writes one file): reads the socket path from ``KLANGK_LISTEN``,
     arms ``_UDS_MODE``, locates the nginx binary, and renders the config with
     the UDS upstream. Extracted from :func:`start_nginx_watchdog` so the
     config-rendering logic is unit-testable without spawning nginx; only the
@@ -467,20 +467,27 @@ def _prepare_nginx() -> tuple[str, str]:
     state_dir = (
         resolve_indirection(get_settings().state_dir) or "/tmp/klangk-state"
     )
-    conf_path = os.path.join(state_dir, "nginx", "nginx.conf")
+    conf_path = os.path.join(state_dir, "nginx.conf")
     bin_path = nginx_mod.find_nginx_bin()
     nginx_mod.write_config(nginx_mod.uds_upstream(sock), conf_path)
     return bin_path, conf_path
 
 
 async def start_nginx_watchdog() -> None:
-    """Render nginx.conf for the UDS and start the nginx watchdog.
+    """Render nginx.conf and start the nginx watchdog.
 
-    No-op when ``KLANGK_UDS_MODE`` is unset (bare uvicorn, TCP tests) — only
-    klangkd sets it, so direct-uvicorn paths never spawn nginx.
+    nginx is always klangkd's child (rendered + spawned + supervised here),
+    regardless of transport — the bind only changes what nginx proxies to
+    (a UDS upstream vs a TCP upstream), not whether nginx exists. No external
+    supervisor manages klangk's nginx.
+
+    Gated only by ``_KLANGK_DISABLE_NGINX`` — an **internal, non-user-facing**
+    env var the test suite sets to suppress nginx spawn (tests boot the app
+    via the lifespan and don't want a real nginx process). Not a documented
+    config knob; no operator-facing name.
     """
     global _nginx_task, _nginx_stopping
-    if not _uds_enabled():
+    if os.environ.get("_KLANGK_DISABLE_NGINX"):
         return
     bin_path, conf_path = _prepare_nginx()
     _nginx_stopping = False

--- a/src/backend/klangk_backend/oidc.py
+++ b/src/backend/klangk_backend/oidc.py
@@ -189,35 +189,22 @@ def auth_modes() -> str:
     single-user local-dev mode). ``none`` auto-issues a token for the
     seeded default user via ``POST /api/v1/auth/local``; see #1374.
 
-    Resolution order when ``KLANGK_AUTH_MODES`` is unset:
+    When ``KLANGK_AUTH_MODES`` is unset the default is ``none``. OIDC
+    settings (``KLANGK_OIDC_*``) do **not** change the mode (#1419) — they
+    only take effect once the mode is ``oidc`` or ``both`` (set explicitly).
+    A fresh klangk with nothing configured therefore boots in no-login
+    single-user mode, bound to loopback, and "just works" locally without a
+    password. Operators who want password login, OIDC, or both set
+    ``KLANGK_AUTH_MODES`` explicitly.
 
-    1. ``KLANGK_PRESET`` (#1397) — a ``*-auth`` preset defaults the mode
-       to ``password`` (the gate is required by the preset; the backend
-       defaults to password). A ``*-noauth`` preset defaults to ``none``.
-    2. otherwise ``none`` (loopback single-user).
-
-    OIDC settings (``KLANGK_OIDC_*``) do **not** change the mode (#1419) —
-    they only take effect once the mode is ``oidc`` or ``both`` (set
-    explicitly or via a preset). A fresh klangk with nothing configured
-    therefore boots in no-login single-user mode, bound to loopback, and
-    "just works" locally without a password. Operators who want password
-    login, OIDC, or both set ``KLANGK_AUTH_MODES`` explicitly (or pick an
-    ``*-auth`` preset). A preset that requires a different backend (e.g.
-    OIDC) sets ``KLANGK_AUTH_MODES=oidc`` — the preset only owns the
-    *default*, never an override.
+    ``KLANGK_AUTH_MODES`` is the sole authority on auth — nothing else
+    defaults or overrides it (#1422 removed the deployment-shape setting
+    that used to default it). The deployment shape is derived from this
+    knob plus ``KLANGK_LISTEN``.
     """
     val = resolve_env_value("KLANGK_AUTH_MODES", "")
     if val in ("oidc", "password", "both", "none"):
         return val
-    # ``KLANGK_AUTH_MODES`` unset — let the deployment preset (#1397) own the
-    # default; otherwise ``none``. A ``*-auth`` preset means the gate is
-    # required, so default to password; the preset never overrides an
-    # explicit ``KLANGK_AUTH_MODES`` (handled above). OIDC settings no longer
-    # promote the mode (#1419) — they are inert unless the mode is already
-    # ``oidc``/``both``.
-    preset = get_settings().preset
-    if preset is not None and preset.endswith("-auth"):
-        return "password"
     return "none"
 
 

--- a/src/backend/klangk_backend/settings.py
+++ b/src/backend/klangk_backend/settings.py
@@ -38,8 +38,6 @@ from pydantic_settings import (
     YamlConfigSettingsSource,
 )
 
-from .exceptions import ConfigurationError
-
 logger = logging.getLogger(__name__)
 
 # Re-exported for backward compat — callers that ``from ..util import ...``
@@ -197,36 +195,6 @@ class KlangkSettings(BaseSettings):
         sources.append(init_settings)
         return tuple(sources)
 
-    # --- Deployment profiles (#1397) ---
-    # ``preset`` is the SINGLE deployment-shape selector — the new name for
-    # the "deployment profiles" from #1392. It is one of the four corners
-    # of the (transport × auth-gate) space:
-    #
-    #     uds-noauth / uds-auth   (UDS transport, gate off / on)
-    #     ip-noauth  / ip-auth    (TCP transport, gate off / on)
-    #
-    # Everything the earlier #1397 draft exposed as separate axis keys is
-    # *derived* from the preset and is NOT individually configurable:
-    #   - the auth GATE is the ``-auth``/``-noauth`` suffix (no KLANGK_AUTH);
-    #   - browser ingress is implied by the ``ip-*`` presets — a browser can't
-    #     ingress over a UDS — so there is no KLANGK_BROWSER_INGRESS;
-    #   - container egress paths have one fixed default per preset, with no
-    #     override, so there is no KLANGK_CONTAINER_EGRESS_PATHS.
-    #
-    # The one thing the operator still chooses separately is the auth
-    # BACKEND (password vs OIDC vs both) via the existing KLANGK_AUTH_MODES —
-    # that decision can't be made for them. The two keys are cross-validated
-    # at config-load: a ``*-noauth`` preset requires ``auth_modes() == none``;
-    # a ``*-auth`` preset requires a gated backend. See
-    # :func:`_validate_preset` (wired into :func:`validate_at_startup`).
-    #
-    # Naming: ``preset`` (a named bundle of defaults) was chosen over
-    # ``profile`` (vague) and ``role`` (collides with klangk's RBAC workspace
-    # roles — the wrong mental model for a deployment *shape*).
-    # Defaults to None so a deployment that sets none of these behaves
-    # identically to pre-#1392 (acceptance criterion: defaults preserved).
-    preset: str | None = None
-
     # --- Auth / identity ---
     auth_modes: str | None = None
     jwt_secret: str | None = _INSECURE_DEFAULT_SECRET
@@ -247,20 +215,23 @@ class KlangkSettings(BaseSettings):
     trusted_proxy_cidrs: str | None = "127.0.0.1,::1"
 
     # --- Server / network ---
+    # listen: the uvicorn bind spec — **polymorphic** (#1422). Either a TCP
+    # host (e.g. ``127.0.0.1``, ``0.0.0.0``) or a UNIX socket path
+    # (e.g. ``/tmp/klangk.sock``). Classification (see :func:`classify_listen`):
+    # an absolute path with no ``://`` scheme ⇒ socket; otherwise TCP. The
+    # deployment shape is *derived* from listen's shape + auth_modes — there
+    # is no amalgamated ``KLANGK_UI_MODE``/``KLANGK_PRESET`` setting (it never
+    # shipped). Socket ⇒ nginx renders the minimal (headless) template; TCP
+    # ⇒ full (browser) template. ``KLANGK_PORT`` applies only when listen is
+    # TCP. Default ``127.0.0.1`` preserves today's behavior; #1400 flips the
+    # default to a socket path (the headless posture).
     listen: str | None = "127.0.0.1"
     nginx_port: str | None = "8995"
     port_range_start: str | None = "9000"
-    # uds_mode: the honest "are we in UDS mode?" switch (#1396). Set only by
-    # klangkd (the launcher that binds a UDS and owns nginx); bare uvicorn /
-    # unit tests never set it, so the lifespan's nginx watchdog no-ops and
-    # _UDS_MODE stays False. A mode switch, not a path — the socket path is
-    # derived from state_dir (<state_dir>/klangk.sock) so there's one path
-    # knob, not two.
-    uds_mode: str | None = None
-    # state_dir: runtime state (the UDS, rendered nginx.conf, pid). Defaults to
-    # a klangk subdir under the system temp; devenv pins it to DEVENV_STATE and
-    # the host container to /tmp/klangk-state. The UDS lives at
-    # <state_dir>/klangk.sock.
+    # state_dir: runtime state (the UDS when listen is a socket path, rendered
+    # nginx.conf, pid). Defaults to a klangk subdir under the system temp;
+    # devenv pins it to DEVENV_STATE and the host container to
+    # /tmp/klangk-state.
     state_dir: str | None = None
     # nginx_bin: the nginx executable the renderer spawns. Falls back to
     # shutil.which("nginx") then /usr/sbin/nginx at render time.
@@ -430,74 +401,64 @@ def _invalidate_cache() -> None:
     _settings_env_signature = None
 
 
-# The four ``KLANGK_PRESET`` values (#1397) — the (transport × auth-gate)
-# corners. ``-noauth`` means "no auth gate"; ``-auth`` means "gate required".
-# Kept module-level so the nginx renderer (chunk 3 of #1392) can import it as
-# the canonical preset set. See KlangkSettings.preset for the full rationale.
-PRESETS: frozenset[str] = frozenset(
-    {"uds-noauth", "uds-auth", "ip-noauth", "ip-auth"}
-)
-
-
-def _validate_preset() -> None:
-    """Validate ``KLANGK_PRESET`` and its consistency with the auth backend.
-
-    ``KLANGK_PRESET`` is the single deployment-shape selector (#1397); the
-    auth *backend* (password vs OIDC vs both) stays the operator's choice via
-    ``KLANGK_AUTH_MODES``. The two must agree when ``KLANGK_AUTH_MODES`` is
-    set EXPLICITLY:
-
-    - a ``*-noauth`` preset requires the resolved auth mode to be ``none``;
-    - a ``*-auth``   preset requires it to be ``password`` / ``oidc`` / ``both``.
-
-    An UNSET ``KLANGK_AUTH_MODES`` never conflicts: :func:`oidc.auth_modes`
-    is preset-aware in the unset path (#1397), self-defaulting to ``password``
-    for ``*-auth`` presets and ``none`` for ``*-noauth``.
-
-    Raises :class:`~klangk_backend.exceptions.ConfigurationError` on an
-    unknown preset value or an explicit preset/auth-mode conflict.
-
-    ``klangk_backend.oidc`` is imported lazily to avoid a settings <-> oidc
-    import cycle (``oidc`` imports :func:`get_settings` from this module).
-    """
-    preset = get_settings().preset
-    if preset is None:
-        return  # no preset set → today's pre-#1392 behavior
-    if preset not in PRESETS:
-        raise ConfigurationError(
-            f"KLANGK_PRESET={preset!r} is not one of {sorted(PRESETS)}"
-        )
-    from . import oidc  # noqa: allow-deferred-import  (settings <-> oidc cycle)
-
-    mode = oidc.auth_modes()
-    noauth = preset.endswith("-noauth")
-    if noauth and mode != "none":
-        raise ConfigurationError(
-            f"KLANGK_PRESET={preset!r} requires KLANGK_AUTH_MODES=none, "
-            f"but the resolved auth mode is {mode!r}"
-        )
-    if not noauth and mode == "none":
-        raise ConfigurationError(
-            f"KLANGK_PRESET={preset!r} requires an auth-gated backend "
-            f"(KLANGK_AUTH_MODES=password|oidc|both), but the resolved "
-            f"auth mode is 'none'"
-        )
-
-
 def validate_at_startup() -> KlangkSettings:
     """Instantiate settings eagerly for fail-fast validation at boot.
 
     Call once from the lifespan startup (and from the ``klangkd`` launcher).
     Bogus config (once fields gain strict types) fails here with a
-    :class:`ValidationError` before the server serves traffic. Also runs the
-    :func:`_validate_preset` cross-check so a ``KLANGK_PRESET`` that
-    disagrees with the resolved ``KLANGK_AUTH_MODES`` backend fails fast.
-    Returns the validated settings instance (which also primes the cache).
+    :class:`ValidationError` before the server serves traffic. Returns the
+    validated settings instance (which also primes the cache).
     """
     _invalidate_cache()
     settings = get_settings()
-    _validate_preset()
     return settings
+
+
+# ---------------------------------------------------------------------------
+# Bind-spec classification (polymorphic KLANGK_LISTEN, #1422)
+# ---------------------------------------------------------------------------
+
+
+def classify_listen(value: str | None) -> str:
+    """Classify a ``KLANGK_LISTEN`` value as ``"socket"`` or ``"tcp"``.
+
+    ``KLANGK_LISTEN`` is polymorphic: a UNIX socket path (e.g.
+    ``/tmp/klangk.sock``) or a TCP host (e.g. ``127.0.0.1``). The port is NOT
+    part of listen — it comes from ``KLANGK_PORT`` when listen is TCP.
+    Classification rule (shared with the CLI ``--server`` resolver, #1399):
+
+    - an **absolute path** with no ``://`` scheme ⇒ ``"socket"``;
+    - otherwise ⇒ ``"tcp"`` (a bare hostname/IP, e.g. ``127.0.0.1``).
+
+    A bare/relative non-scheme value (e.g. ``klangk.sock``) is ambiguous and
+    is classified as ``"tcp"`` — callers that need a socket should pass an
+    absolute path. This mirrors #1399's "socket paths must be absolute" rule
+    and keeps the classifier total (no exceptions). ``None`` ⇒ ``"tcp"``
+    (the default bind is loopback TCP until #1400 flips it to a socket).
+    """
+    if not value:
+        return "tcp"
+    if "://" in value:
+        return "tcp"  # http(s)://... — TCP (CLI-style absolute URL)
+    if value.startswith("/"):
+        return "socket"  # absolute path, no scheme — UDS
+    return "tcp"  # bare hostname/IP — TCP
+
+
+def listen_is_socket(value: str | None = None) -> bool:
+    """True iff the resolved ``KLANGK_LISTEN`` is a socket path.
+
+    Convenience wrapper around :func:`classify_listen` that reads the merged
+    setting when *value* is omitted. This is what the nginx renderer and the
+    lifespan watchdog key off to decide "headless/minimal template + UDS
+    bind" vs "full template + TCP bind."
+    """
+    v = (
+        value
+        if value is not None
+        else resolve_indirection(get_settings().listen)
+    )
+    return classify_listen(v) == "socket"
 
 
 # ---------------------------------------------------------------------------

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -27,6 +27,17 @@ _TEST_PASSWORD_HASH = bcrypt.hashpw(
 
 
 @pytest.fixture(autouse=True)
+def _disable_nginx(monkeypatch):
+    """Suppress nginx spawn across the suite.
+
+    The lifespan's nginx watchdog is unconditional in real runs; tests boot
+    the app (often via the lifespan) and never want a real nginx process.
+    Sets the internal, non-user-facing ``_KLANGK_DISABLE_NGINX`` kill switch.
+    """
+    monkeypatch.setenv("_KLANGK_DISABLE_NGINX", "1")
+
+
+@pytest.fixture(autouse=True)
 def _default_auth_mode(monkeypatch):
     """Pin the test suite to ``password`` mode.
 

--- a/src/backend/tests/test_nginx.py
+++ b/src/backend/tests/test_nginx.py
@@ -309,7 +309,7 @@ class TestContainerAclFallback:
 class TestWriteConfig:
     def test_writes_file(self, tmp_path):
         _set(nginx_port="8995")
-        conf_path = tmp_path / "nginx" / "nginx.conf"
+        conf_path = tmp_path / "nginx.conf"
         text = render_config(tcp_upstream("127.0.0.1", "8997"))
         from klangk_backend.nginx import write_config
 
@@ -345,33 +345,36 @@ class TestKlangkdHelpers:
         assert _default_state_dir() == "/tmp/klangk-state"
 
 
-# socket path is now derived (<state_dir>/klangk.sock), not a setting —
-# covered by main._socket_path() which is exercised via the watchdog tests.
+# The watchdog is gated only by the internal _KLANGK_DISABLE_NGINX kill
+# switch (test-only); nginx is owned unconditionally in real runs. Covered
+# below.
 
 
-class TestWatchdogNoop:
-    """The watchdog no-ops when KLANGK_UDS_MODE is unset (TCP / tests)."""
+class TestWatchdogGate:
+    """start_nginx_watchdog respects the test kill switch; otherwise prepares+spawns."""
 
     @pytest.mark.asyncio
-    async def test_start_noop_without_uds_mode(self, monkeypatch):
-        """start_nginx_watchdog returns immediately when KLANGK_UDS_MODE unset."""
+    async def test_start_noop_when_disabled(self, monkeypatch):
+        """No-op when the test-only _KLANGK_DISABLE_NGINX is set."""
         import klangk_backend.main as main
 
-        monkeypatch.delenv("KLANGK_UDS_MODE", raising=False)
-        _invalidate_cache()
+        monkeypatch.setenv("_KLANGK_DISABLE_NGINX", "1")
         await main.start_nginx_watchdog()
-        # No task was created.
-        assert main._nginx_task is None
+        assert main._nginx_task is None  # killed by the switch
 
     @pytest.mark.asyncio
-    async def test_start_runs_prepare_in_uds_mode(self, monkeypatch, tmp_path):
-        """In UDS mode, start_nginx_watchdog runs _prepare_nginx then spawns
-        (a stubbed) watchdog task. The real nginx spawn is e2e-covered; here
-        we stub _nginx_watchdog to a no-op coroutine so the orchestration —
-        prepare, set _nginx_stopping=False, create_task — is unit-tested."""
+    async def test_start_runs_prepare_when_enabled(
+        self, monkeypatch, tmp_path
+    ):
+        """When not disabled, start_nginx_watchdog runs _prepare_nginx then spawns
+        (a stubbed) watchdog. The real nginx spawn is e2e-covered; here
+        _nginx_watchdog is stubbed so the orchestration (prepare, set
+        _nginx_stopping=False, create_task) is unit-tested."""
         import klangk_backend.main as main
 
-        _set(uds_mode="1", state_dir=str(tmp_path), nginx_port="19999")
+        sock = str(tmp_path / "klangk.sock")
+        _set(listen=sock, state_dir=str(tmp_path), nginx_port="19999")
+        monkeypatch.delenv("_KLANGK_DISABLE_NGINX", raising=False)
         monkeypatch.setattr(
             "klangk_backend.nginx.find_nginx_bin", lambda: "/fake/nginx"
         )
@@ -388,7 +391,7 @@ class TestWatchdogNoop:
             assert main._nginx_task is not None
             assert main._nginx_stopping is False
             # prepare ran: config written + paths passed to the watchdog.
-            assert (tmp_path / "nginx" / "nginx.conf").is_file()
+            assert (tmp_path / "nginx.conf").is_file()
             await main._nginx_task  # let the stub complete
             assert spawned["bin"] == "/fake/nginx"
         finally:
@@ -399,39 +402,27 @@ class TestWatchdogNoop:
             main._nginx_proc = None
 
 
-class TestUdsEnabledAndSocketPath:
-    """_uds_enabled (the mode switch) and _socket_path (derived path)."""
+class TestSocketPath:
+    """_socket_path() reads KLANGK_LISTEN (the socket IS the listen value)."""
 
-    def test_uds_enabled_false_by_default(self):
+    def test_returns_listen_value(self):
         import klangk_backend.main as main
 
-        _set()  # no uds_mode
-        assert main._uds_enabled() is False
+        _set(listen="/tmp/klangk.sock")
+        assert main._socket_path() == "/tmp/klangk.sock"
 
-    def test_uds_enabled_truthy_values(self):
+    def test_falls_back_to_state_dir_when_listen_unset(self, monkeypatch):
         import klangk_backend.main as main
 
-        for val in ("1", "true", "yes", "TRUE", "Yes"):
-            _set(uds_mode=val)
-            assert main._uds_enabled() is True, val
-
-    def test_uds_enabled_falsy_values(self):
-        import klangk_backend.main as main
-
-        for val in ("", "0", "false", "no", "garbage"):
-            _set(uds_mode=val)
-            assert main._uds_enabled() is False, val
-
-    def test_socket_path_derived_from_state_dir(self):
-        import klangk_backend.main as main
-
-        _set(state_dir="/custom/state")
+        # When listen is empty/unset, _socket_path defaults to
+        # <state_dir>/klangk.sock rather than an empty string.
+        _set(listen="", state_dir="/custom/state")
         assert main._socket_path() == "/custom/state/klangk.sock"
 
-    def test_socket_path_falls_back_to_tmp(self):
+    def test_falls_back_to_tmp_when_both_unset(self, monkeypatch):
         import klangk_backend.main as main
 
-        _set()  # no state_dir
+        _set(listen="", state_dir="")
         assert main._socket_path() == "/tmp/klangk-state/klangk.sock"
 
 
@@ -441,18 +432,19 @@ class TestPrepareNginx:
     def test_renders_config_and_returns_paths(self, monkeypatch, tmp_path):
         import klangk_backend.main as main
 
-        _set(state_dir=str(tmp_path), nginx_port="19999")
+        sock = str(tmp_path / "klangk.sock")
+        _set(listen=sock, state_dir=str(tmp_path), nginx_port="19999")
         # Stub the binary lookup so the test doesn't depend on PATH.
         monkeypatch.setattr(
             "klangk_backend.nginx.find_nginx_bin", lambda: "/fake/nginx"
         )
         bin_path, conf_path = main._prepare_nginx()
         assert bin_path == "/fake/nginx"
-        assert conf_path == str(tmp_path / "nginx" / "nginx.conf")
-        assert (tmp_path / "nginx" / "nginx.conf").is_file()
-        # The rendered config targets the derived socket.
-        conf = (tmp_path / "nginx" / "nginx.conf").read_text()
-        assert f"proxy_pass http://unix:{tmp_path}/klangk.sock:" in conf
+        assert conf_path == str(tmp_path / "nginx.conf")
+        assert (tmp_path / "nginx.conf").is_file()
+        # The rendered config targets the LISTEN socket path.
+        conf = (tmp_path / "nginx.conf").read_text()
+        assert f"proxy_pass http://unix:{sock}:" in conf
         # _UDS_MODE armed.
         import klangk_backend.util as util
 

--- a/src/backend/tests/test_oidc.py
+++ b/src/backend/tests/test_oidc.py
@@ -517,48 +517,20 @@ class TestAuthModes:
             monkeypatch.setenv("KLANGK_AUTH_MODES", mode)
             assert not oidc.local_login_allowed()
 
-    # --- #1397 preset-driven default (KLANGK_AUTH_MODES unset) ---
-    # A ``*-auth`` preset means the gate is required, so the *unset* default
-    # resolves to ``password`` (the operator still picks the backend —
-    # e.g. OIDC — by setting KLANGK_AUTH_MODES explicitly). A ``*-noauth``
-    # preset stays ``none``. With no preset set, today's pre-#1392 default
-    # (the OIDC-promotion rule below) is preserved — removing that promotion
-    # is a separate breaking change, deferred to #1392 chunk 7.
+    # --- AUTH_MODES unset defaults to ``none`` (no amalgamated setting) ---
+    # #1422 removed KLANGK_PRESET/KLANGK_UI_MODE — AUTH_MODES is the sole
+    # authority on auth, and its unset default is ``none`` unconditionally
+    # (OIDC settings don't promote it, per #1419; no preset defaults it).
 
-    @pytest.mark.parametrize("preset", ["uds-auth", "ip-auth"])
-    def test_auth_preset_defaults_to_password(self, monkeypatch, preset):
+    def test_unset_defaults_to_none(self, monkeypatch):
         monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
-        monkeypatch.setenv("KLANGK_PRESET", preset)
-        assert oidc.auth_modes() == "password"
-        assert oidc.password_login_allowed()
-        assert not oidc.local_login_allowed()
-
-    @pytest.mark.parametrize("preset", ["uds-noauth", "ip-noauth"])
-    def test_noauth_preset_defaults_to_none(self, monkeypatch, preset):
-        monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
-        monkeypatch.setenv("KLANGK_PRESET", preset)
         assert oidc.auth_modes() == "none"
         assert oidc.local_login_allowed()
         assert not oidc.password_login_allowed()
 
-    def test_auth_preset_default_does_not_override_explicit_mode(
-        self, monkeypatch
-    ):
-        # The preset only owns the *default* — an explicit KLANGK_AUTH_MODES
-        # always wins (even a conflicting one; that's what the settings-level
-        # _validate_preset cross-check is for, not auth_modes() itself).
-        monkeypatch.setenv("KLANGK_PRESET", "uds-auth")
-        monkeypatch.setenv("KLANGK_AUTH_MODES", "oidc")
-        oidc._providers.append(_provider())
-        assert oidc.auth_modes() == "oidc"
-        assert oidc.oidc_login_allowed()
-        assert not oidc.password_login_allowed()
-
-    def test_no_preset_preserves_legacy_default(self, monkeypatch):
-        # No preset + AUTH_MODES unset → ``none``. OIDC settings no longer
-        # promote the mode (#1419), so configuring a provider does not flip
-        # the default; the operator must set KLANGK_AUTH_MODES=oidc/both.
-        monkeypatch.delenv("KLANGK_PRESET", raising=False)
+    def test_unset_stays_none_with_oidc_configured(self, monkeypatch):
+        # OIDC presence never flips the mode (#1419) — operator must set
+        # KLANGK_AUTH_MODES=oidc/both explicitly.
         monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
         assert oidc.auth_modes() == "none"
         oidc._providers.append(_provider())

--- a/src/backend/tests/test_settings.py
+++ b/src/backend/tests/test_settings.py
@@ -12,15 +12,15 @@ Covers:
 import pytest
 
 from klangk_backend import settings as settings_mod
-from klangk_backend.exceptions import ConfigurationError
 from klangk_backend.settings import (
     KlangkSettings,
-    PRESETS,
     _key_to_field,
     get_config_file,
     get_settings,
     resolve_env_bool,
     resolve_env_value,
+    classify_listen,
+    listen_is_socket,
     resolve_indirection,
     set_config_file,
     validate_at_startup,
@@ -272,147 +272,67 @@ class TestConfigFile:
 
 
 # ---------------------------------------------------------------------------
-# KLANGK_PRESET (#1397): the single deployment-shape key
+# classify_listen / listen_is_socket (polymorphic KLANGK_LISTEN, #1422)
 # ---------------------------------------------------------------------------
+# KLANGK_LISTEN is polymorphic: a socket path or a TCP host (no port —
+# the port comes from KLANGK_PORT). The
+# deployment shape is *derived* from listen's shape + auth_modes (there is
+# no amalgamated UI-mode/preset setting — it never shipped). These pin the
+# classifier that the renderer, the klangkd bind, and the CLI (#1399) share.
 
 
-class TestPreset:
-    """``KLANGK_PRESET`` is the only settable deployment-shape key (#1397).
+class TestClassifyListen:
+    def test_absolute_path_is_socket(self):
+        assert classify_listen("/tmp/klangk.sock") == "socket"
+        assert classify_listen("/run/user/1000/klangk.sock") == "socket"
 
-    The earlier #1397 draft exposed four axis keys (preset / auth /
-    browser_ingress / container_egress_paths). The finalized model keeps only
-    ``preset``: the auth GATE is its ``-auth``/``-noauth`` suffix, browser
-    ingress is implied by the ``ip-*`` presets, and container egress paths
-    are a fixed per-preset default. The auth BACKEND (password vs OIDC vs
-    both) stays the operator's choice via the existing ``KLANGK_AUTH_MODES``;
-    the two are cross-validated (see :class:`TestPresetAuthConflict`).
+    def test_tcp_host_is_tcp(self):
+        assert classify_listen("127.0.0.1") == "tcp"
+        assert classify_listen("0.0.0.0") == "tcp"
+        assert classify_listen("::1") == "tcp"
 
-    These tests pin that ``preset`` is settable via BOTH an env var and the
-    YAML config file (like every other field) so a future change can't
-    silently drop the config-file path.
-    """
+    def test_value_with_port_is_tcp(self):
+        # LISTEN never carries a port (it comes from KLANGK_PORT), but if a
+        # port-bearing value did appear it must classify as TCP, not socket —
+        # the classifier never mis-classifies a non-socket.
+        assert classify_listen("127.0.0.1:8997") == "tcp"
+        assert classify_listen("0.0.0.0:8997") == "tcp"
+        assert classify_listen("[::1]:8997") == "tcp"
 
-    def test_field_exists(self):
-        assert "preset" in KlangkSettings.model_fields
-        assert PRESETS == frozenset(
-            {"uds-noauth", "uds-auth", "ip-noauth", "ip-auth"}
-        )
+    def test_http_scheme_is_tcp(self):
+        # CLI-style absolute URL — TCP (shared convention with #1399).
+        assert classify_listen("http://host:8995") == "tcp"
+        assert classify_listen("https://host") == "tcp"
 
-    def test_dropped_axis_keys_are_not_fields(self):
-        # auth / browser_ingress / container_egress_paths are NOT individually
-        # settable — everything but preset is derived from the preset.
-        fields = KlangkSettings.model_fields
-        for dropped in ("auth", "browser_ingress", "container_egress_paths"):
-            assert dropped not in fields, dropped
+    def test_none_is_tcp(self):
+        # None ⇒ the TCP default (loopback until #1400 flips it to a socket).
+        assert classify_listen(None) == "tcp"
+        assert classify_listen("") == "tcp"
 
-    @pytest.mark.parametrize("value", sorted(PRESETS))
-    def test_settable_via_env(self, monkeypatch, value):
-        set_config_file(None)
-        monkeypatch.setenv("KLANGK_PRESET", value)
-        assert get_settings().preset == value
-
-    @pytest.mark.parametrize("value", sorted(PRESETS))
-    def test_settable_via_yaml(self, tmp_path, value):
-        cfg = tmp_path / "config.yaml"
-        cfg.write_text(f'preset: "{value}"\n')
-        set_config_file(str(cfg))
-        assert get_settings().preset == value
-
-    def test_env_overrides_yaml(self, monkeypatch, tmp_path):
-        cfg = tmp_path / "config.yaml"
-        cfg.write_text('preset: "uds-noauth"\n')
-        set_config_file(str(cfg))
-        monkeypatch.setenv("KLANGK_PRESET", "ip-auth")
-        assert get_settings().preset == "ip-auth"
-
-    def test_default_none_preserves_today(self):
-        # No preset set → None → pre-#1392 behavior; validate_at_startup is a
-        # no-op (no conflict check runs when preset is unset).
-        set_config_file(None)
-        assert get_settings().preset is None
+    def test_bare_relative_is_tcp(self):
+        # Ambiguous (no scheme, no leading slash) — classified as TCP, not a
+        # socket. Callers needing a socket must pass an absolute path; this
+        # keeps the classifier total (mirrors #1399's absolute-path rule).
+        assert classify_listen("klangk.sock") == "tcp"
+        assert classify_listen("localhost") == "tcp"
 
 
-class TestPresetAuthConflict:
-    """``KLANGK_PRESET`` must agree with an EXPLICIT ``KLANGK_AUTH_MODES``.
+class TestListenIsSocket:
+    def test_true_when_listen_is_socket_path(self, monkeypatch):
+        monkeypatch.setenv("KLANGK_LISTEN", "/tmp/klangk.sock")
+        settings_mod._invalidate_cache()
+        assert listen_is_socket() is True
 
-    The preset fixes whether an auth gate is required (its suffix); the
-    operator separately chooses the backend (password / OIDC / both) via
-    ``KLANGK_AUTH_MODES``. The two are cross-validated at config-load by
-    :func:`validate_at_startup`, so an *explicitly conflicting* config fails
-    fast at boot:
+    def test_false_when_listen_is_tcp(self, monkeypatch):
+        monkeypatch.setenv("KLANGK_LISTEN", "127.0.0.1")
+        settings_mod._invalidate_cache()
+        assert listen_is_socket() is False
 
-    - ``*-noauth`` presets require the resolved auth mode to be ``none``;
-    - ``*-auth``   presets require it to be non-``none``.
-
-    Important: an UNSET ``KLANGK_AUTH_MODES`` never conflicts —
-    ``oidc.auth_modes()`` is preset-aware in the unset path (#1397), so a
-    ``*-auth`` preset defaults the mode to ``password`` and ``*-noauth`` to
-    ``none``. The conflict check only fires on an *explicit* value that
-    disagrees with the preset. These tests set ``KLANGK_AUTH_MODES``
-    explicitly in every case; the unset-no-conflict cases are covered at the
-    end.
-    """
-
-    def test_unknown_preset_rejected(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_PRESET", "bogus")
-        monkeypatch.setenv("KLANGK_AUTH_MODES", "password")
-        with pytest.raises(ConfigurationError, match="not one of"):
-            validate_at_startup()
-
-    @pytest.mark.parametrize("preset", ["uds-noauth", "ip-noauth"])
-    @pytest.mark.parametrize("mode", ["password", "oidc", "both"])
-    def test_noauth_preset_conflicts_with_any_backend(
-        self, monkeypatch, preset, mode
-    ):
-        monkeypatch.setenv("KLANGK_PRESET", preset)
-        monkeypatch.setenv("KLANGK_AUTH_MODES", mode)
-        with pytest.raises(
-            ConfigurationError, match="requires KLANGK_AUTH_MODES=none"
-        ):
-            validate_at_startup()
-
-    @pytest.mark.parametrize("preset", ["uds-noauth", "ip-noauth"])
-    def test_noauth_preset_ok_with_none(self, monkeypatch, preset):
-        monkeypatch.setenv("KLANGK_PRESET", preset)
-        monkeypatch.setenv("KLANGK_AUTH_MODES", "none")
-        settings = validate_at_startup()  # no raise
-        assert settings.preset == preset
-
-    @pytest.mark.parametrize("preset", ["uds-auth", "ip-auth"])
-    def test_auth_preset_conflicts_with_none(self, monkeypatch, preset):
-        monkeypatch.setenv("KLANGK_PRESET", preset)
-        monkeypatch.setenv("KLANGK_AUTH_MODES", "none")
-        with pytest.raises(
-            ConfigurationError, match="requires an auth-gated backend"
-        ):
-            validate_at_startup()
-
-    @pytest.mark.parametrize("preset", ["uds-auth", "ip-auth"])
-    @pytest.mark.parametrize("mode", ["password", "oidc", "both"])
-    def test_auth_preset_ok_with_backend(self, monkeypatch, preset, mode):
-        monkeypatch.setenv("KLANGK_PRESET", preset)
-        monkeypatch.setenv("KLANGK_AUTH_MODES", mode)
-        settings = validate_at_startup()  # no raise
-        assert settings.preset == preset
-
-    def test_no_preset_skips_conflict_check(self, monkeypatch):
-        # preset unset → no validation runs (pre-#1392 behavior preserved),
-        # regardless of the auth mode.
-        monkeypatch.delenv("KLANGK_PRESET", raising=False)
-        monkeypatch.setenv("KLANGK_AUTH_MODES", "none")
-        validate_at_startup()  # no raise
-
-    @pytest.mark.parametrize(
-        "preset", ["uds-noauth", "uds-auth", "ip-noauth", "ip-auth"]
-    )
-    def test_unset_auth_mode_never_conflicts(self, monkeypatch, preset):
-        # An unset KLANGK_AUTH_MODES never conflicts: oidc.auth_modes()
-        # self-defaults to match the preset (*-auth → password, *-noauth →
-        # none). So a preset alone boots cleanly with no explicit backend.
-        monkeypatch.setenv("KLANGK_PRESET", preset)
-        monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
-        settings = validate_at_startup()  # no raise
-        assert settings.preset == preset
+    def test_false_for_default(self, monkeypatch):
+        # The default (127.0.0.1) is TCP; #1400 will flip this to a socket.
+        monkeypatch.delenv("KLANGK_LISTEN", raising=False)
+        settings_mod._invalidate_cache()
+        assert listen_is_socket() is False
 
 
 class TestKlangkdLauncher:

--- a/src/cli/e2e-tests/conftest.py
+++ b/src/cli/e2e-tests/conftest.py
@@ -19,6 +19,25 @@ import pytest
 
 
 @pytest.fixture(scope="session", autouse=True)
+def _e2e_disable_nginx():
+    """Suppress the lifespan's nginx watchdog across the CLI E2E suite.
+
+    Mirrors the backend E2E fixture: these tests launch bare ``uvicorn`` and
+    don't want the lifespan spawning nginx. Sets the internal, non-user-facing
+    ``_KLANGK_DISABLE_NGINX`` kill switch.
+    """
+    old = os.environ.get("_KLANGK_DISABLE_NGINX")
+    os.environ["_KLANGK_DISABLE_NGINX"] = "1"
+    try:
+        yield
+    finally:
+        if old is None:
+            os.environ.pop("_KLANGK_DISABLE_NGINX", None)
+        else:
+            os.environ["_KLANGK_DISABLE_NGINX"] = old
+
+
+@pytest.fixture(scope="session", autouse=True)
 def _e2e_default_auth_mode():
     """Pin E2E servers to ``password`` mode for the whole session.
 

--- a/src/containers/host/entrypoint.sh
+++ b/src/containers/host/entrypoint.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Ensure state/data dirs exist
-mkdir -p "${KLANGK_STATE_DIR:-${DEVENV_STATE:-/tmp/klangk-state}}/nginx" "$KLANGK_DATA_DIR"
+mkdir -p "${KLANGK_STATE_DIR:-${DEVENV_STATE:-/tmp/klangk-state}}" "$KLANGK_DATA_DIR"
 
 # Load the embedded workspace image into podman on first startup.
 WORKSPACE_TAR="$HOME/workspace.tar"

--- a/src/frontend/e2e-tests/global-setup.ts
+++ b/src/frontend/e2e-tests/global-setup.ts
@@ -125,6 +125,9 @@ async function globalSetup() {
       stdio: ["ignore", "pipe", "pipe"],
       env: {
         ...process.env,
+        // Bare uvicorn; the lifespan must not spawn nginx (frontend e2e
+        // runs its own nginx via the old scripts/nginx.sh path).
+        _KLANGK_DISABLE_NGINX: "1",
         KLANGK_PORT: backendPort,
         KLANGK_NGINX_PORT: nginxPort,
         KLANGK_DATA_DIR: dataDir,


### PR DESCRIPTION
Closes #1422.

## Summary

Eliminates the amalgamated deployment-shape setting (`KLANGK_PRESET`/`KLANGK_UI_MODE` — never shipped in a release) in favor of **deriving** the deployment shape from the two primitive knobs the operator already sets. A config value that changes other config values ("this preset defaults that mode") is magic; this removes the magic.

**The two primitives:**
- **`KLANGK_AUTH_MODE`** — the sole authority on the auth gate (`none`/`password`/`oidc`/`both`). Unset now always defaults to `none` (no preset defaults it).
- **`KLANGK_LISTEN`** — **now polymorphic**: a socket path (UDS) or TCP host[:port]. Classification (`classify_listen()`): absolute path with no `://` scheme ⇒ socket; otherwise TCP. `KLANGK_PORT` applies only when LISTEN is TCP.

AUTH governs the gate; LISTEN governs the template richness (socket ⇒ minimal/headless; TCP ⇒ full/browser). They compose, never rewrite each other.

## Removed

- `KLANGK_PRESET`/`KLANGK_UI_MODE` field, `PRESETS`/`UI_MODES` constant, `_validate_preset`/`_validate_ui_mode`, and the `auth_modes()` preset-default branch.
- `KLANGK_UDS_MODE` (retired) — LISTEN's value does the job the flag was doing.
- The whole preset/auth-mode cross-validation machinery (no longer needed: AUTH is the sole authority).

## Added

- **`classify_listen(value)`** / **`listen_is_socket()`** — the single classifier (absolute path, no scheme ⇒ socket; else TCP). Shared with #1399's CLI `--server` convention, so server bind and client connect use one addressing scheme.
- **klangkd** reads LISTEN, classifies, binds uvicorn to UDS-or-TCP accordingly. The nginx watchdog keys off `listen_is_socket()` (not a flag). `_UDS_MODE` (the internal trust flag in `util.py`) is now armed by the launcher from the bind decision, not a config field.

## Derived matrix (internal — not a setting)

| LISTEN | AUTH | template | browser? |
|---|---|---|---|
| socket | none | minimal | no (default — most-secure-convenient) |
| socket | password/oidc/both | minimal | no |
| loopback TCP | none | full | yes (local) |
| loopback TCP | password/oidc/both | full | yes (local) |
| non-loopback TCP | none | — | rejected (bind-safety, the one existing rule) |
| non-loopback TCP | password/oidc/both | full | yes (net) |

Template selection keys off LISTEN's shape only — AUTH doesn't change which template renders.

## Note: default not flipped here

Bare `klangkd` still defaults LISTEN to `127.0.0.1` (today's behavior). Flipping the default to a socket path (the headless posture) is **#1400** (chunk 7, breaking changes) — this chunk ships the *mechanism* (polymorphic LISTEN + derivation), #1400 flips the default.

## Test results

- **Backend unit tests:** 2340 passed, **100% coverage**
- **Backend e2e ACL tests:** 26 passed
- **All pre-commit hooks** pass

## Footprint

- `src/backend/klangk_backend/settings.py` — removed preset/PRESETS/_validate_preset/uds_mode; added classify_listen/listen_is_socket
- `src/backend/klangk_backend/oidc.py` — auth_modes() preset branch removed
- `src/backend/klangk_backend/main.py` — watchdog keys off listen_is_socket()
- `src/backend/klangk_backend/klangkd.py` — polymorphic bind (UDS-or-TCP)
- `src/backend/tests/{test_settings,test_oidc,test_nginx}.py` — updated
- `docs/reference/klangkd-config.md` — derive-model section replaces the preset section