### PR TITLE
feat(#1398): nginx minimal (headless) template on a socket bind

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -27,6 +27,22 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **Headless single-user profile: nginx minimal template on a socket bind**
+  (#1398, chunk 5 of #1392). When `KLANGK_LISTEN` is a UNIX socket path,
+  the nginx renderer now emits a minimal (headless) template — only the
+  container-egress `/llm-proxy` location (with its workspace-token
+  `auth_request` gate + `CONTAINER_ACL`) on the single container-egress
+  listener, and nothing else: no `location /`, no `/api/v1/*`, no static
+  UI, no `/auth/local`. A browser can't reach a UDS and uvicorn exposes no
+  browser-facing TCP, so no browser surface is serviceable — the attack
+  surface is two channels (operator→UDS, container→llm-proxy) and nothing
+  else. Template selection keys off `KLANGK_LISTEN`'s shape alone; the
+  `KLANGK_AUTH_MODE` value does not participate (socket ⇒ minimal, TCP ⇒
+  full browser template, across all auth values). The TCP path is a strict
+  regression guard (byte-for-byte identical output). This makes the
+  UDS+none default posture's "eliminate the browser/TCP surface" a real
+  property rather than a claim; the default-flip itself is #1400.
+
 - **`test-all` / `test-unit` devenv scripts and concurrency-safe test corpus**
   (#1393). The whole test corpus is now runnable concurrently: every E2E
   harness free-allocates its server port and `KLANGK_PORT_RANGE_START`

--- a/src/backend/klangk_backend/nginx.py
+++ b/src/backend/klangk_backend/nginx.py
@@ -24,7 +24,11 @@ import shutil
 import subprocess
 from pathlib import Path
 
-from .settings import get_settings, resolve_indirection
+from .settings import (
+    get_settings,
+    listen_is_socket,
+    resolve_indirection,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -309,12 +313,104 @@ def _trust_outer_proxy() -> bool:
 
 
 def render_config(upstream: str) -> str:
-    """Render the full ``nginx.conf`` as a string.
+    """Render ``nginx.conf`` as a string.
 
-    ``upstream`` is the ``proxy_pass`` base: :func:`uds_upstream` for the
-    production socket bind, :func:`tcp_upstream` for tests. All other values
-    come from the merged settings (env > config file > defaults) plus the
-    host-IP / DNS auto-detection probes.
+    Template selection keys off ``KLANGK_LISTEN``'s shape only (#1398): a
+    socket path ⇒ the minimal (headless) template; TCP ⇒ the full (browser)
+    template. The AUTH value does not participate in template selection —
+    only the bind does. ``upstream`` is the ``proxy_pass`` base
+    (:func:`uds_upstream` for the production socket bind, :func:`tcp_upstream`
+    for tests). All other values come from the merged settings
+    (env > config file > defaults) plus the host-IP / DNS auto-detection
+    probes.
+    """
+    if listen_is_socket():
+        return _render_minimal_config(upstream)
+    return _render_full_config(upstream)
+
+
+def _minimal_auth_locations(upstream: str) -> str:
+    """The workspace-token ``auth_request`` subrequest target + JSON 401 page.
+
+    Minimal-template counterpart of the inline blocks in the full template.
+    Extracted because the minimal server block emits them adjacent to the
+    ``/llm-proxy`` location that gates on them; the full template interleaves
+    them with the browser/auth-local locations, so it keeps them inline.
+    """
+    return (
+        "    # Workspace token verification subrequest"
+        " (nginx auth_request target).\n"
+        "    location = /api/v1/auth/verify-workspace-token {\n"
+        "      internal;\n"
+        f"      proxy_pass {upstream}/api/v1/auth/verify-workspace-token;\n"
+        "      proxy_pass_request_body off;\n"
+        '      proxy_set_header Content-Length "";\n'
+        "      proxy_set_header Authorization $http_authorization;\n"
+        "    }\n"
+        "\n"
+        "    # JSON 401 error page for auth_request failures.\n"
+        "    location @token_auth_failed {\n"
+        "      internal;\n"
+        "      default_type application/json;\n"
+        '      return 401 \'{"error":"$auth_token_error",'
+        '"detail":"Workspace token $auth_token_error"}\';\n'
+        "    }\n"
+    )
+
+
+def _render_minimal_config(upstream: str) -> str:
+    """Render the minimal (headless) ``nginx.conf`` — socket bind only (#1398).
+
+    Emitted when ``KLANGK_LISTEN`` is a socket path: a browser can't reach a
+    UDS and uvicorn exposes no browser-facing TCP, so no browser UI is
+    serviceable. The only served surface is the container-egress
+    ``/llm-proxy`` location (with its workspace-token ``auth_request`` gate +
+    CONTAINER_ACL) on the single container-egress listener. No ``location /``,
+    no ``/api/v1/*``, no static UI, no ``/auth/local`` — the attack surface is
+    two channels (operator→UDS, container→llm-proxy) and nothing else.
+
+    The ``auth_request`` subrequest target + JSON 401 page are emitted only
+    when an ``/llm-proxy`` location exists to gate on them (i.e. when
+    ``KLANGK_LLM_BASE_URL`` is set); with no LLM configured the server block
+    serves nothing.
+    """
+    settings = get_settings()
+    nginx_port = resolve_indirection(settings.nginx_port) or "8995"
+    client_max_body_size = compute_client_max_body_size()
+    resolvers = detect_dns_resolvers()
+    acl, _deny = compute_container_acls()
+    llm_block = _build_llm_block(acl, resolvers)
+    # The auth_request infrastructure is only reachable via the /llm-proxy
+    # location's auth_request; omit it entirely when there's no LLM proxy.
+    auth_locations = _minimal_auth_locations(upstream) if llm_block else ""
+    return f"""daemon off;
+pid /tmp/nginx.pid;
+error_log stderr;
+events {{ worker_connections 1024; }}
+http {{
+  access_log /dev/stdout;
+  client_body_temp_path /tmp/nginx_client_body;
+  proxy_temp_path /tmp/nginx_proxy;
+  fastcgi_temp_path /tmp/nginx_fastcgi;
+  uwsgi_temp_path /tmp/nginx_uwsgi;
+  scgi_temp_path /tmp/nginx_scgi;
+
+  client_max_body_size {client_max_body_size};
+
+  server {{
+    listen {nginx_port};
+{llm_block}{auth_locations}  }}
+}}
+"""
+
+
+def _render_full_config(upstream: str) -> str:
+    """Render the full (browser) ``nginx.conf`` — TCP bind (#1396, #1398).
+
+    Emitted when ``KLANGK_LISTEN`` is TCP: the browser UI + every API path +
+    static files + the no-auth ``/auth/local`` handout are all serviceable.
+    This is the template the renderer shipped before #1398's socket/minimal
+    branch; it is kept verbatim so the TCP path is a strict regression guard.
     """
     settings = get_settings()
     nginx_port = resolve_indirection(settings.nginx_port) or "8995"

--- a/src/backend/tests/test_nginx.py
+++ b/src/backend/tests/test_nginx.py
@@ -231,6 +231,92 @@ class TestRenderConfig:
         assert 'Authorization "Bearer file-based-key"' in conf
 
 
+class TestMinimalTemplate:
+    """Socket LISTEN ⇒ minimal (headless) template (#1398).
+
+    Template selection keys off ``KLANGK_LISTEN``'s shape alone: a socket
+    path emits only the container-egress ``/llm-proxy`` location (+ its
+    workspace-token ``auth_request`` gate + CONTAINER_ACL); TCP emits the
+    full browser template. AUTH does not participate.
+    """
+
+    def test_socket_emits_minimal_with_llm(self):
+        """Socket + LLM ⇒ only /llm-proxy, no browser surface (#1398)."""
+        _set(
+            listen="/tmp/klangk.sock",
+            llm_base_url="http://127.0.0.1:11434",
+            nginx_port="8995",
+        )
+        conf = render_config(uds_upstream("/tmp/klangk.sock"))
+        # /llm-proxy container-egress location is present, token-gated.
+        assert "location ~ ^/llm-proxy/" in conf
+        assert "auth_request /api/v1/auth/verify-workspace-token;" in conf
+        # The auth_request subrequest target + 401 page ride along.
+        assert "location = /api/v1/auth/verify-workspace-token" in conf
+        assert "location @token_auth_failed" in conf
+        # UDS upstream lands in the proxied locations.
+        assert "proxy_pass http://unix:/tmp/klangk.sock:" in conf
+        # No browser surface whatsoever.
+        assert "location / {" not in conf  # no catch-all
+        assert "/api/v1/browser-delegate" not in conf
+        assert "/api/v1/auth/local" not in conf
+        assert "post-chat-message" not in conf
+        assert "/hosted/" not in conf  # no hosted/static UI
+
+    def test_socket_no_llm_emits_listener_only(self):
+        """Socket + no LLM ⇒ no /llm-proxy, no auth locations; just listener."""
+        _set(listen="/tmp/klangk.sock", nginx_port="8995")
+        conf = render_config(uds_upstream("/tmp/klangk.sock"))
+        assert "location ~ ^/llm-proxy/" not in conf
+        assert "verify-workspace-token" not in conf
+        assert "@token_auth_failed" not in conf
+        # Still a valid server block with the container-egress listener.
+        assert "listen 8995;" in conf
+        assert "daemon off;" in conf
+
+    def test_socket_single_container_egress_listener(self):
+        """No client-facing TCP: exactly one listen (container-egress), no
+        browser catch-all location (#1398 criterion 3)."""
+        _set(
+            listen="/tmp/klangk.sock",
+            llm_base_url="http://127.0.0.1:11434",
+            nginx_port="8995",
+        )
+        conf = render_config(uds_upstream("/tmp/klangk.sock"))
+        # Exactly one listen directive — the container-egress nginx_port.
+        assert conf.count("\n    listen ") == 1
+        assert "listen 8995;" in conf
+        # No browser catch-all is served off it.
+        assert "location / {" not in conf
+
+    def test_tcp_emits_full_template(self):
+        """Regression guard: TCP LISTEN ⇒ full browser template (#1398 #2)."""
+        _set(listen="127.0.0.1", nginx_port="8995")
+        conf = render_config(tcp_upstream("127.0.0.1", "8997"))
+        assert "location / {" in conf
+        assert "/api/v1/browser-delegate" in conf
+        assert "/api/v1/auth/local" in conf
+        assert "listen 8995;" in conf
+
+    def test_template_keys_off_listen_not_auth(self):
+        """AUTH value does not change which template is rendered (#1398 #4):
+        socket ⇒ minimal and TCP ⇒ full across auth values."""
+        for auth in ("none", "password", "password,oidc"):
+            _set(
+                listen="/tmp/klangk.sock",
+                auth_modes=auth,
+                llm_base_url="http://127.0.0.1:11434",
+                nginx_port="8995",
+            )
+            minimal = render_config(uds_upstream("/tmp/klangk.sock"))
+            assert "location / {" not in minimal
+            assert "location ~ ^/llm-proxy/" in minimal
+
+            _set(listen="127.0.0.1", auth_modes=auth, nginx_port="8995")
+            full = render_config(tcp_upstream("127.0.0.1", "8997"))
+            assert "location / {" in full
+
+
 class TestFindNginxBin:
     def test_configured(self):
         _set(nginx_bin="/custom/nginx")
@@ -433,7 +519,16 @@ class TestPrepareNginx:
         import klangk_backend.main as main
 
         sock = str(tmp_path / "klangk.sock")
-        _set(listen=sock, state_dir=str(tmp_path), nginx_port="19999")
+        # Socket LISTEN ⇒ minimal (headless) template (#1398). Set an LLM
+        # base URL so the /llm-proxy location (which carries the UDS
+        # proxy_pass) is actually rendered; without it the minimal server
+        # block serves nothing.
+        _set(
+            listen=sock,
+            state_dir=str(tmp_path),
+            nginx_port="19999",
+            llm_base_url="http://127.0.0.1:11434",
+        )
         # Stub the binary lookup so the test doesn't depend on PATH.
         monkeypatch.setattr(
             "klangk_backend.nginx.find_nginx_bin", lambda: "/fake/nginx"
@@ -442,9 +537,13 @@ class TestPrepareNginx:
         assert bin_path == "/fake/nginx"
         assert conf_path == str(tmp_path / "nginx.conf")
         assert (tmp_path / "nginx.conf").is_file()
-        # The rendered config targets the LISTEN socket path.
         conf = (tmp_path / "nginx.conf").read_text()
+        # The UDS upstream lands in the /llm-proxy location + its auth_request
+        # subrequest target; the minimal template carries no browser surface.
         assert f"proxy_pass http://unix:{sock}:" in conf
+        assert "location ~ ^/llm-proxy/" in conf
+        assert "location / {" not in conf
+        assert "/api/v1/auth/local" not in conf
         # _UDS_MODE armed.
         import klangk_backend.util as util
 


### PR DESCRIPTION
## Summary

Chunk 5 of #1392 — closes #1398.

When `KLANGK_LISTEN` is a UNIX socket path, the nginx renderer now emits a **minimal (headless) template**: only the container-egress `/llm-proxy` location (token-gated via `auth_request` + `CONTAINER_ACL`) on the single container-egress listener, and nothing else. No `location /`, no `/api/v1/*`, no static UI, no `/auth/local`. A browser can't reach a UDS and uvicorn exposes no browser-facing TCP, so no browser surface is serviceable — **the attack surface is two channels (operator→UDS, container→llm-proxy) and nothing else.**

This is the first *behaviorally new* product (headless single-user) and delivers the optimal-security default posture. It's what makes the UDS+none default's "eliminate the browser/TCP surface" a real property rather than a claim.

## What changes

`render_config` now dispatches on `listen_is_socket()` (the polymorphic-LISTEN classifier from #1422):

- **socket path** ⇒ `_render_minimal_config` — `/llm-proxy` container-egress location + its `auth_request` gate + `CONTAINER_ACL` only
- **TCP host** ⇒ `_render_full_config` — the full browser template (unchanged)

Template selection keys off `KLANGK_LISTEN`'s shape **alone**; `KLANGK_AUTH_MODE` does not participate (socket ⇒ minimal, TCP ⇒ full, across all auth values). The TCP path is byte-for-byte identical to the pre-change `render_config` output — a strict regression guard.

With no `KLANGK_LLM_BASE_URL`, the minimal server block serves nothing (no `/llm-proxy`, no `auth_request` infrastructure) — just the listener.

## Acceptance criteria (#1398)

- [x] When `KLANGK_LISTEN` is a socket path, the renderer emits only the `/llm-proxy` container-egress location (no browser UI, no `/auth/local`, no `location /`, no static) — `TestMinimalTemplate::test_socket_emits_minimal_with_llm`
- [x] When `KLANGK_LISTEN` is TCP, the renderer emits the full template unchanged (regression guard) — `test_tcp_emits_full_template`, + full-template output byte-diffed against `origin/main` (identical)
- [x] No client-facing TCP listener exists in the socket/minimal case — `test_socket_single_container_egress_listener` (exactly one `listen`, no browser catch-all)
- [x] Template selection keys off LISTEN's shape only — AUTH value does not change which template is rendered — `test_template_keys_off_listen_not_auth` (across `none`/`password`/`password,oidc`)
- [x] 100% coverage maintained — backend suite 2348 passed, `nginx.py` at 100%

The minimal config was also validated as syntactically valid nginx via `nginx -t` (`the configuration file ... syntax is ok`), and the nginx_acl E2E config tests (full template, devenv TCP LISTEN) still pass.

## Non-goals (deferred per #1398)

- CLI transport resolver — chunk 6 / #1399 (needed to actually *use* the headless server from the CLI over the UDS)
- The default-flip (bare `klangkd` → UDS+none) — chunk 7 / #1400

## Related

- Filed #1433 (the `ResourceWarning` leaks surfaced during this work — `ssl_trust.py` file-handle leaks + unclosed sockets in the test suite) — separate, not blocking.
