### PR TITLE
fix(#1433): close ResourceWarning leaks in ssl_trust and test suite

### DIFF
--- a/src/backend/klangk_backend/ssl_trust.py
+++ b/src/backend/klangk_backend/ssl_trust.py
@@ -143,7 +143,8 @@ def write_merged_bundle(bundle_path: str, ssl_dir: str) -> bool:
         sys_bundle = system_ca_bundle(self_bundle=bundle_path)
         if sys_bundle:
             try:
-                out.write(open(sys_bundle).read())
+                with open(sys_bundle) as f:
+                    out.write(f.read())
                 written += 1
             except OSError as exc:
                 logger.warning(
@@ -151,7 +152,8 @@ def write_merged_bundle(bundle_path: str, ssl_dir: str) -> bool:
                 )
         for cert in iter_cert_files(ssl_dir):
             try:
-                out.write(open(cert).read())
+                with open(cert) as f:
+                    out.write(f.read())
                 written += 1
             except OSError as exc:
                 logger.warning("Skipping unreadable cert %s: %s", cert, exc)

--- a/src/backend/tests/test_git_credential.py
+++ b/src/backend/tests/test_git_credential.py
@@ -128,6 +128,7 @@ def bridge_server():
     thread.start()
     yield server, port
     server.shutdown()
+    server.server_close()
 
 
 class TestGetOperation:

--- a/src/backend/tests/test_ssl_trust.py
+++ b/src/backend/tests/test_ssl_trust.py
@@ -10,6 +10,7 @@ import logging
 import os
 import ssl
 import types
+from pathlib import Path
 
 import pytest
 
@@ -121,7 +122,7 @@ class TestApplyBackendSslTrust:
 
         assert bundle is not None
         assert os.path.isfile(bundle)
-        contents = open(bundle).read()
+        contents = Path(bundle).read_text()
         # System bundle first (preserves public-internet trust), then custom.
         assert contents == "FAKE-SYSTEM-CA\nFAKE-CORP-CA\n"
         # All toolchain vars point at the merged bundle.
@@ -146,7 +147,7 @@ class TestApplyBackendSslTrust:
         ssl_trust.apply_backend_ssl_trust()
 
         bundle = os.environ["SSL_CERT_FILE"]
-        contents = open(bundle).read()
+        contents = Path(bundle).read_text()
         assert "SYSTEM-MARKER" in contents  # public-internet CAs preserved
         assert "CORP" in contents  # custom CA present
 
@@ -172,13 +173,15 @@ class TestApplyBackendSslTrust:
         ssl_trust.apply_backend_ssl_trust()
         first = os.environ["SSL_CERT_FILE"]
         size_after_first = os.path.getsize(first)
-        contents_after_first = open(first).read()
+        contents_after_first = Path(first).read_text()
 
         ssl_trust.apply_backend_ssl_trust()
         second = os.environ["SSL_CERT_FILE"]
         assert second == first
         assert os.path.getsize(second) == size_after_first
-        assert open(second).read() == contents_after_first  # no duplication
+        assert (
+            Path(second).read_text() == contents_after_first
+        )  # no duplication
 
     def test_custom_cert_missing_system_bundle_warns(
         self, monkeypatch, tmp_path, caplog
@@ -291,7 +294,7 @@ class TestInternalsAndErrorBranches:
         out = tmp_path / "bundle.crt"
         ok = ssl_trust.write_merged_bundle(str(out), str(cert_dir))
         assert ok is True
-        assert open(out).read() == "CORP\n"  # system skipped, custom kept
+        assert Path(out).read_text() == "CORP\n"  # system skipped, custom kept
 
     def test_write_empty_when_cert_unreadable(self, monkeypatch, tmp_path):
         out = tmp_path / "bundle.crt"


### PR DESCRIPTION
## Summary

- **ssl_trust.py**: wrap bare `open().read()` calls in `with` blocks to close file handles (production code, runs at container bring-up)
- **test_ssl_trust.py**: replace `open().read()` with `Path.read_text()`
- **test_git_credential.py**: call `server_close()` after `shutdown()` on the HTTPServer fixture to close the listening socket

## Test plan

- [x] `python -m pytest src/backend/tests -n auto -W error::ResourceWarning --no-cov` — 2343 passed, 0 warnings
- [x] `test-backend` — 2343 passed, 100% coverage

Closes #1433
