### PR TITLE
fix(backend): prune orphaned service-session lock entries (#1351)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Unreleased
 
+### Fixed
+
+- **The per-container service-command firing-lock dict no longer accumulates orphaned entries.** `clear_service_session_lock()` covered the normal teardown path, but a racing re-bind in `stop_and_remove_container` could leave an entry whose container was already gone, so `_service_session_locks` grew one entry per container ever created until process restart. Both teardown paths (`stop_and_remove_container` and `remove_state`) now call a new `prune_service_session_locks()` that drops entries for containers no longer tracked by the registry, skipping any lock currently held so an in-flight service-command fire keeps its serialization. ([#1351](https://github.com/mcdonc/klangk/issues/1351))
+
 ## v1.0.5
 
 ### Fixed

--- a/devenv.nix
+++ b/devenv.nix
@@ -541,6 +541,10 @@ in
     # Generate markdownlint config (not committed)
     cat > "$DEVENV_ROOT/.markdownlint.yaml" <<'MDLINT'
     MD013: false
+    MD024:
+      # Allow Keep a Changelog's repeated per-version section headings
+      # (### Fixed / ### Changed under each ## version).
+      siblings_only: true
     MD034: false
     MDLINT
   '';

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -871,8 +871,10 @@ class ContainerRegistry:
             state = self.states.pop(workspace_id, None)
             if state:
                 self._cid_to_wsid.pop(state.container_id, None)
-                # Drop the per-container service-firing lock (#1188).
+                # Drop the per-container service-firing lock (#1188), then
+                # sweep any other entries orphaned by container churn (#1351).
                 terminal.clear_service_session_lock(state.container_id)
+                terminal.prune_service_session_locks(set(self._cid_to_wsid))
 
     # --- Proxy: PortAllocator ---
 
@@ -1544,8 +1546,11 @@ class ContainerRegistry:
                     self._cid_to_wsid.pop(container_id, None)
                     self.revoke_workspace_browsers(ws_id)
                     self.states.pop(ws_id, None)
-        # Drop the per-container service-firing lock (#1188).
+        # Drop the per-container service-firing lock (#1188), then sweep any
+        # other entries orphaned by container churn (e.g. a racing re-bind
+        # that popped this container's mapping before teardown) (#1351).
         terminal.clear_service_session_lock(container_id)
+        terminal.prune_service_session_locks(set(self._cid_to_wsid))
 
     async def notify_workspace_killed(self, workspace_id: str) -> None:
         """Call the on_workspace_killed callback, logging any errors.

--- a/src/backend/klangk_backend/terminal.py
+++ b/src/backend/klangk_backend/terminal.py
@@ -131,6 +131,31 @@ def clear_service_session_lock(container_id: str) -> None:
     _service_session_locks.pop(container_id, None)
 
 
+def prune_service_session_locks(active_container_ids: set[str]) -> int:
+    """Remove lock entries for containers no longer tracked by the registry.
+
+    Bounds the ``_service_session_locks`` dict against unbounded growth from
+    container churn (#1351): explicit :func:`clear_service_session_lock`
+    calls cover the normal teardown path, but a racing re-bind in
+    ``stop_and_remove_container`` can leave an entry whose container is gone.
+    This opportunistic sweep removes any entry whose container id is no longer
+    in *active_container_ids*.
+
+    Entries whose lock is currently held are skipped: recreating a fresh
+    ``asyncio.Lock`` for an in-flight service-command fire would not serialize
+    against the held one, reopening the duplicate-window race the lock exists
+    to prevent. Returns the number of entries pruned.
+    """
+    stale = [
+        cid
+        for cid, lock in _service_session_locks.items()
+        if cid not in active_container_ids and not lock.locked()
+    ]
+    for cid in stale:
+        del _service_session_locks[cid]
+    return len(stale)
+
+
 async def has_tmux_session(container_id: str, session_name: str) -> bool:
     """Return True if a tmux session named *session_name* exists."""
     try:

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -1643,6 +1643,30 @@ class TestStopContainer:
         assert "ws" in container.registry._workspace_locks
         assert container.registry._workspace_locks["ws"] is lock
 
+    async def test_stop_prunes_orphaned_service_session_locks(self):
+        # stop_and_remove_container sweeps the per-container service-firing
+        # lock dict so it does not grow unbounded with container churn (#1351).
+        from klangk_backend import terminal
+
+        terminal._service_session_locks.clear()
+        try:
+            # Tracked container (being stopped) + two orphaned entries whose
+            # containers are no longer in the registry.
+            container.registry.track_activity("alive", "ws-alive")
+            terminal.get_service_session_lock("alive")
+            terminal.get_service_session_lock("orphan-a")
+            terminal.get_service_session_lock("orphan-b")
+            assert len(terminal._service_session_locks) == 3
+
+            with patch_podman():
+                await container.registry.stop_and_remove_container("alive")
+
+            # The stopped container's entry and the orphans are gone; the dict
+            # is empty because no container remains tracked.
+            assert terminal._service_session_locks == {}
+        finally:
+            terminal._service_session_locks.clear()
+
     async def test_stop_podman_error(self):
         container.registry.track_activity("cid", "ws")
         container.registry._get_workspace_lock("ws")

--- a/src/backend/tests/test_terminal.py
+++ b/src/backend/tests/test_terminal.py
@@ -1652,6 +1652,50 @@ class TestServiceSessionLock:
         # Must not raise for a container that never registered a lock.
         clear_service_session_lock("never-seen")
 
+    def test_prune_removes_entries_for_untracked_containers(self):
+        from klangk_backend.terminal import (
+            _service_session_locks,
+            get_service_session_lock,
+            prune_service_session_locks,
+        )
+
+        get_service_session_lock("alive")
+        get_service_session_lock("dead-a")
+        get_service_session_lock("dead-b")
+        assert len(_service_session_locks) == 3
+
+        removed = prune_service_session_locks({"alive"})
+        assert removed == 2
+        assert set(_service_session_locks) == {"alive"}
+
+    async def test_prune_keeps_held_lock_even_if_untracked(self):
+        from klangk_backend.terminal import (
+            _service_session_locks,
+            get_service_session_lock,
+            prune_service_session_locks,
+        )
+
+        held = get_service_session_lock("held-but-orphaned")
+        await held.acquire()  # simulate an in-flight service-command fire
+        try:
+            removed = prune_service_session_locks(set())
+            # Not pruned: recreating its lock would not serialize against the
+            # in-flight fire (#1188 duplicate-window race).
+            assert removed == 0
+            assert "held-but-orphaned" in _service_session_locks
+        finally:
+            held.release()
+
+    def test_prune_noop_when_all_tracked(self):
+        from klangk_backend.terminal import (
+            get_service_session_lock,
+            prune_service_session_locks,
+        )
+
+        get_service_session_lock("a")
+        get_service_session_lock("b")
+        assert prune_service_session_locks({"a", "b"}) == 0
+
 
 class TestServiceSessionHelpers:
     """Direct coverage for the firing-predicate helpers used by


### PR DESCRIPTION
## Summary

`_service_session_locks` (keyed by container id) is cleared on normal teardown via `clear_service_session_lock`, but a racing re-bind in `stop_and_remove_container` — where the workspace is already re-bound to a fresh container before teardown runs — can leave an entry whose container is gone. The dict grew one entry per container ever created until process restart.

Fixes [#1351](https://github.com/mcdonc/klangk/issues/1351).

## Changes

- `src/backend/klangk_backend/terminal.py` — new `prune_service_session_locks(active_container_ids)` that drops entries for containers no longer tracked by the registry, **skipping any lock currently held** (recreating a fresh `asyncio.Lock` for an in-flight service-command fire would not serialize against the held one, reopening the #1188 duplicate-window race).
- `src/backend/klangk_backend/container.py` — call it from both teardown paths (`stop_and_remove_container` and `remove_state`), passing `set(self._cid_to_wsid)`.
- `devenv.nix` — set markdownlint `MD024: siblings_only: true` in the generated `.markdownlint.yaml` so Keep a Changelog's repeated per-version section headings (`### Fixed` under each `## version`) lint clean.
- `CHANGES.md` — entry under `## Unreleased`.

## Verification

- Full backend suite with coverage, `-n auto` (matches CI): **2347 passed, 100% coverage** (`terminal.py` and `container.py` both at 100%).
- New tests produce **zero warnings** under `-W error::Warning` (the lone warning seen in a full `devenv shell` run is environmental from the devenv wrapper, not from any test — confirmed by running the suite via the venv directly, which reports 0 warnings).
- New tests:
  - `test_prune_removes_entries_for_untracked_containers` — orphans dropped, tracked kept.
  - `test_prune_keeps_held_lock_even_if_untracked` — a held lock is preserved even when its container is gone.
  - `test_prune_noop_when_all_tracked` — no-op when nothing is stale.
  - `test_stop_prunes_orphaned_service_session_locks` — integration: `stop_and_remove_container` sweeps orphaned terminal lock entries.
