### PR TITLE
fix(pre-commit): disable MD060 to stop prettier/markdownlint conflict (#1437)

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -541,6 +541,7 @@ in
       # (### Fixed / ### Changed under each ## version).
       siblings_only: true
     MD034: false
+    MD060: false
     MDLINT
   '';
 


### PR DESCRIPTION
## Summary

- Disable MD060 (`table-column-style`) in the generated `.markdownlint.yaml` via `devenv.nix`
- Prettier owns Markdown table formatting (padded/aligned style); MD060's default compact style is irreconcilable

Closes #1437

## Test plan

- [ ] Commit a Markdown file with tables — no more ping-pong between prettier and markdownlint
