### PR TITLE
fix(#1439): run nginx in klangkd's process group

### DIFF
--- a/src/backend/e2e-tests/test_nginx_lifecycle_e2e.py
+++ b/src/backend/e2e-tests/test_nginx_lifecycle_e2e.py
@@ -1,0 +1,113 @@
+"""End-to-end test: nginx dies when klangkd dies (#1439).
+
+klangkd spawns nginx as a child. Before #1439, nginx ran in its own
+session (``start_new_session=True``), so a hard kill of klangkd orphaned
+it. After #1439, nginx runs in klangkd's process group and dies with it.
+
+Run with: devenv shell -- test-backend-e2e test_nginx_lifecycle_e2e.py
+"""
+
+import os
+import subprocess
+import tempfile
+import time
+
+import httpx
+import pytest
+
+from klangk_backend.model import free_port
+
+BACKEND_DIR = os.path.join(os.path.dirname(__file__), "..")
+
+
+def _wait_for_nginx(port, timeout=30):
+    """Wait until nginx accepts connections (any status is fine)."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            httpx.get(f"http://localhost:{port}/", timeout=2)
+            return True
+        except httpx.ConnectError:
+            pass
+        time.sleep(0.3)
+    return False
+
+
+def _port_listening(port):
+    """True if something is accepting connections on localhost:port."""
+    import socket
+
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        s.settimeout(1)
+        s.connect(("127.0.0.1", int(port)))
+        s.close()
+        return True
+    except (ConnectionRefusedError, OSError):
+        return False
+
+
+def _start_klangkd():
+    """Start a klangkd process with nginx enabled, return (proc, nginx_port)."""
+    data_dir = tempfile.mkdtemp(prefix="klangk-nginx-lifecycle-")
+    nginx_port = str(free_port())
+
+    sock_path = os.path.join(data_dir, "klangk.sock")
+
+    env = {
+        **os.environ,
+        "KLANGK_LISTEN": sock_path,
+        "KLANGK_NGINX_PORT": nginx_port,
+        "KLANGK_STATE_DIR": data_dir,
+        "KLANGK_DATA_DIR": data_dir,
+        "KLANGK_JWT_SECRET": "nginx-lifecycle-test",
+        "KLANGK_PREVENT_INSECURE_JWT_SECRET": "",
+        "KLANGK_DEFAULT_USER": "test@example.com",
+        "KLANGK_DEFAULT_PASSWORD": "testpass",
+        "KLANGK_AUTH_MODES": "none",
+        "KLANGK_TEST_MODE": "1",
+        "KLANGK_IDLE_TIMEOUT_SECONDS": "300",
+        "KLANGK_PORT_RANGE_START": str(free_port()),
+        "_KLANGK_DISABLE_NGINX": "",
+        "LOGFIRE_TOKEN": "",
+    }
+
+    proc = subprocess.Popen(
+        ["python3", "-m", "klangk_backend.klangkd", "--config=none"],
+        cwd=BACKEND_DIR,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    return proc, nginx_port
+
+
+class TestNginxDiesWithKlangkd:
+    """nginx must not outlive klangkd (#1439)."""
+
+    def test_nginx_stops_on_sigterm(self):
+        """Graceful shutdown (SIGTERM) stops nginx."""
+        proc, nginx_port = _start_klangkd()
+        try:
+            ok = _wait_for_nginx(nginx_port)
+            if not ok:
+                proc.kill()
+                out, _ = proc.communicate(timeout=5)
+                pytest.fail(
+                    f"klangkd did not start:\n"
+                    f"{out.decode(errors='replace')[:2000]}"
+                )
+
+            assert _port_listening(nginx_port), "nginx not serving"
+
+            proc.terminate()
+            proc.wait(timeout=10)
+            time.sleep(1)
+
+            assert not _port_listening(nginx_port), (
+                "nginx port still listening after SIGTERM"
+            )
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait()

--- a/src/backend/klangk_backend/klangkd.py
+++ b/src/backend/klangk_backend/klangkd.py
@@ -32,7 +32,6 @@ import uvicorn
 from klangk_backend.settings import (
     classify_listen,
     get_settings,
-    resolve_env_value,
     resolve_indirection,
     set_config_file,
     validate_at_startup,
@@ -164,7 +163,7 @@ def main(  # pragma: no cover
         # KLANGK_PORT). No nginx ownership on this path (bare uvicorn /
         # direct-TCP tests); nginx is owned only in the UDS case.
         host = listen
-        port = int(resolve_env_value("KLANGK_PORT") or "8997")
+        port = int(resolve_indirection(settings.port) or "8997")
         uvicorn.run(
             "klangk_backend.main:app",
             host=host,

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -426,8 +426,8 @@ async def _nginx_watchdog(
     """Spawn nginx and respawn it on unexpected exit (with backoff).
 
     Exits cleanly when ``_nginx_stopping`` is set (a cooperative shutdown).
-    Uses ``start_new_session=True`` so we can signal the whole process group,
-    not just the nginx master.
+    nginx runs in klangkd's process group (no ``start_new_session``) so
+    it is killed automatically when klangkd is terminated (#1439).
     """
     global _nginx_proc
     backoff = 1.0
@@ -440,7 +440,6 @@ async def _nginx_watchdog(
             conf_path,
             stdout=None,
             stderr=None,
-            start_new_session=True,
         )
         logger.info(
             "nginx started (pid %d) with %s", _nginx_proc.pid, conf_path
@@ -508,18 +507,11 @@ async def stop_nginx_watchdog() -> None:
     # The proc-kill branch is only reached when nginx was spawned (UDS mode);
     # covered via TestStopWatchdogWithInjectedState + the e2e ACL teardown.
     if proc is not None and proc.returncode is None:
-        # SIGTERM the whole process group (nginx master + workers).
-        try:
-            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
-        except ProcessLookupError:
-            pass
+        proc.terminate()
         try:
             await asyncio.wait_for(proc.wait(), timeout=5)
         except asyncio.TimeoutError:
-            try:
-                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-            except ProcessLookupError:
-                pass
+            proc.kill()
     _nginx_proc = None
     task = _nginx_task
     # Same: only when a watchdog task was created (UDS mode).

--- a/src/backend/klangk_backend/settings.py
+++ b/src/backend/klangk_backend/settings.py
@@ -226,6 +226,7 @@ class KlangkSettings(BaseSettings):
     # TCP. Default ``127.0.0.1`` preserves today's behavior; #1400 flips the
     # default to a socket path (the headless posture).
     listen: str | None = "127.0.0.1"
+    port: str | None = "8997"
     nginx_port: str | None = "8995"
     port_range_start: str | None = "9000"
     # state_dir: runtime state (the UDS when listen is a socket path, rendered

--- a/src/backend/tests/test_nginx.py
+++ b/src/backend/tests/test_nginx.py
@@ -567,33 +567,28 @@ class TestStopWatchdogWithInjectedState:
         assert main._nginx_stopping is True
 
     @pytest.mark.asyncio
-    async def test_stops_sigterms_running_proc(self, monkeypatch):
-        """A still-running nginx proc is SIGTERM'd (its process group), then
-        awaited. Covers the proc-kill branch with an injected fake proc."""
+    async def test_stops_terminates_running_proc(self):
+        """A still-running nginx proc is terminated, then awaited."""
         import klangk_backend.main as main
 
-        killed = {"term": [], "kill": []}
+        terminated = []
 
         class FakeProc:
-            returncode = None  # still running
-            pid = 4242
+            returncode = None
+
+            def terminate(self):
+                terminated.append(True)
+
+            def kill(self):
+                pass  # pragma: no cover
 
             async def wait(self):
                 return 0
 
-        monkeypatch.setattr(main.os, "getpgid", lambda pid: 9999)
-        monkeypatch.setattr(
-            main.os,
-            "killpg",
-            lambda pgid, sig: killed[
-                "term" if sig == main.signal.SIGTERM else "kill"
-            ].append(pgid),
-        )
         main._nginx_proc = FakeProc()
         main._nginx_task = None
         await main.stop_nginx_watchdog()
-        assert killed["term"] == [9999]  # SIGTERM sent to the group
-        assert killed["kill"] == []  # exited before the SIGKILL timeout
+        assert terminated == [True]
         assert main._nginx_proc is None
 
     @pytest.mark.asyncio
@@ -614,33 +609,26 @@ class TestStopWatchdogWithInjectedState:
         assert main._nginx_task is None
 
     @pytest.mark.asyncio
-    async def test_stops_sigkills_on_timeout(self, monkeypatch):
-        """If the proc doesn't exit within the timeout, SIGKILL follows."""
+    async def test_stops_kills_on_timeout(self, monkeypatch):
+        """If the proc doesn't exit within the timeout, kill() follows."""
         import klangk_backend.main as main
 
-        killed = {"term": [], "kill": []}
+        actions = []
 
         class HungProc:
             returncode = None
-            pid = 1111
+
+            def terminate(self):
+                actions.append("terminate")
+
+            def kill(self):
+                actions.append("kill")
 
             async def wait(self):
-                await asyncio.sleep(100)  # never exits within the 5s timeout
+                await asyncio.sleep(100)
                 return 0
 
-        monkeypatch.setattr(main.os, "getpgid", lambda pid: 7777)
-        monkeypatch.setattr(
-            main.os,
-            "killpg",
-            lambda pgid, sig: killed[
-                "term" if sig == main.signal.SIGTERM else "kill"
-            ].append(pgid),
-        )
-
         async def _fake_wait_for(coro, timeout):
-            # Simulate the 5s grace elapsing: close the coro (avoids an
-            # un-awaited-coroutine warning) and raise TimeoutError so the
-            # SIGKILL branch fires.
             coro.close()
             raise asyncio.TimeoutError()
 
@@ -648,68 +636,5 @@ class TestStopWatchdogWithInjectedState:
         main._nginx_proc = HungProc()
         main._nginx_task = None
         await main.stop_nginx_watchdog()
-        assert killed["term"] == [7777]
-        assert killed["kill"] == [7777]  # SIGKILL after timeout
-        assert main._nginx_proc is None
-
-    @pytest.mark.asyncio
-    async def test_stops_sigterm_missing_group(self, monkeypatch):
-        """SIGTERM raises ProcessLookupError (group already gone) — covers the
-        outer killpg exception arm."""
-        import klangk_backend.main as main
-
-        class Proc:
-            returncode = None
-            pid = 3333
-
-            async def wait(self):
-                return 0
-
-        def _killpg_raises(pgid, sig):
-            raise ProcessLookupError()
-
-        monkeypatch.setattr(main.os, "getpgid", lambda pid: 9999)
-        monkeypatch.setattr(main.os, "killpg", _killpg_raises)
-        main._nginx_proc = Proc()
-        main._nginx_task = None
-        await main.stop_nginx_watchdog()
-        assert main._nginx_proc is None
-
-    @pytest.mark.asyncio
-    async def test_stops_handles_missing_process_group(self, monkeypatch):
-        """Covers the inner SIGKILL ProcessLookupError arm: SIGTERM kills the
-        group, but on the SIGKILL-after-timeout path the group is gone."""
-        import klangk_backend.main as main
-
-        class ProcThatHangsThenGroupGone:
-            returncode = None
-            pid = 2222
-
-            async def wait(self):
-                await asyncio.sleep(100)  # never exits within the timeout
-                return 0
-
-        # SIGTERM succeeds (no raise); the SIGKILL path raises ProcessLookupError
-        # (group already reaped) — covers both the successful-term branch and
-        # the inner SIGKILL exception arm (lines 510-511).
-        term_calls = []
-
-        def _killpg(pgid, sig):
-            if sig == main.signal.SIGTERM:
-                term_calls.append(pgid)
-            else:  # SIGKILL — group already gone
-                raise ProcessLookupError()
-
-        monkeypatch.setattr(main.os, "getpgid", lambda pid: 8888)
-        monkeypatch.setattr(main.os, "killpg", _killpg)
-
-        async def _fake_wait_for(coro, timeout):
-            coro.close()
-            raise asyncio.TimeoutError()
-
-        monkeypatch.setattr(main.asyncio, "wait_for", _fake_wait_for)
-        main._nginx_proc = ProcThatHangsThenGroupGone()
-        main._nginx_task = None
-        await main.stop_nginx_watchdog()
-        assert term_calls == [8888]  # SIGTERM sent; SIGKILL arm swallowed
+        assert actions == ["terminate", "kill"]
         assert main._nginx_proc is None


### PR DESCRIPTION
## Summary

- Remove `start_new_session=True` from the nginx watchdog spawn so nginx
  runs in klangkd's process group — a SIGTERM or process-group kill now
  takes nginx down with klangkd, preventing orphans
- Simplify `stop_nginx_watchdog`: `proc.terminate()`/`proc.kill()` replaces
  the `os.killpg` dance
- Add `port` field to `KlangkSettings` so klangkd reads `KLANGK_PORT`
  through the settings model (was missing, fell back to `os.environ`)
- E2E test: start klangkd with nginx, SIGTERM it, assert nginx port is freed

## Test plan

- [x] Backend: 2352 passed, 100% coverage
- [x] E2E: `test_nginx_lifecycle_e2e.py` — SIGTERM stops nginx

Closes #1439
