### PR TITLE
feat(#1400)!: uvicorn always binds UDS; default is headless

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -101,6 +101,17 @@ set-password <email>` (set a known password for the default user — whose
 
 ### Breaking
 
+- **Direct TCP to uvicorn is gone.** uvicorn now binds only a UNIX socket
+  (`<state_dir>/klangk.sock`); nginx proxies to it. Point external proxies at
+  `KLANGK_NGINX_PORT` (default 8995), not the old port 8997 (#1400).
+- **Default is now headless.** Bare `klangkd` (no `KLANGK_LISTEN` set)
+  defaults to UDS + `none` auth — headless, CLI-only. Set
+  `KLANGK_LISTEN=127.0.0.1` for the browser UI (#1400).
+- **`KLANGK_PORT` is no longer used by klangkd.** uvicorn always binds a UDS;
+  the setting is retained only for bare-uvicorn test harnesses (#1400).
+- **Devenv default changed to browser-first.** `klangkd.yaml.example` now
+  defaults to `listen: 127.0.0.1` + `auth_modes: password`. Delete your local
+  `klangkd.yaml` and re-enter `devenv shell` to regenerate it (#1400).
 - **Default auth mode is now `none`** (no-login single-user, loopback-bound)
   when `KLANGK_AUTH_MODES` is unset and no OIDC provider is configured
   (#1374). Previously the unset default was `password`. A fresh klangk now

--- a/klangkd.yaml.example
+++ b/klangkd.yaml.example
@@ -7,10 +7,10 @@
 # devenv's backend process does this automatically.
 
 # --- Deployment shape ---
-# Socket path → UDS (headless, no browser UI).
-# Change to 127.0.0.1 for TCP (browser UI at http://localhost:$nginx_port).
-listen: /tmp/klangk.sock
-auth_modes: none
+# 127.0.0.1 → TCP, browser UI at http://localhost:$nginx_port.
+# Change to a socket path (e.g. /tmp/klangk.sock) for headless/UDS.
+listen: "127.0.0.1"
+auth_modes: password
 
 # --- Auth / identity ---
 jwt_secret: bark-dev-secret-change-in-production
@@ -18,7 +18,6 @@ default_user: admin@example.com
 default_password: admin
 
 # --- Server / network ---
-port: "8997"
 nginx_port: "8995"
 idle_timeout_seconds: "300"
 

--- a/src/backend/klangk_backend/klangkd.py
+++ b/src/backend/klangk_backend/klangkd.py
@@ -30,7 +30,6 @@ import typer
 import uvicorn
 
 from klangk_backend.settings import (
-    classify_listen,
     get_settings,
     resolve_indirection,
     set_config_file,
@@ -112,18 +111,15 @@ def main(  # pragma: no cover
     # value or a ``file:``/``cmd:`` prefix takes effect the same as an env
     # var (#1394/#1395).
     settings = get_settings()
-    state_dir = resolve_indirection(settings.state_dir) or _default_state_dir()
-    # Re-pin state_dir into env so the lifespan watchdog (which reads the
-    # merged config fresh) sees the same resolved value.
-    os.environ["KLANGK_STATE_DIR"] = state_dir
 
-    # ``KLANGK_LISTEN`` is polymorphic (#1422): a socket path or a TCP
-    # TCP host or socket path. classify_listen picks the transport from its
-    # shape; uvicorn
-    # binds accordingly. The deployment shape is *derived* from listen's shape
-    # + auth_modes — there is no amalgamated UI-mode setting.
-    listen = resolve_indirection(settings.listen) or "127.0.0.1"
-    transport = classify_listen(listen)
+    # uvicorn always binds a UDS (#1400). ``KLANGK_LISTEN`` is polymorphic
+    # (#1422) but only controls what *nginx* does: a socket path → nginx
+    # renders the minimal (headless) template; a TCP address → nginx renders
+    # the full (browser) template and listens on that address. uvicorn never
+    # listens on TCP directly.
+    state_dir = resolve_indirection(settings.state_dir) or _default_state_dir()
+    os.environ["KLANGK_STATE_DIR"] = state_dir
+    uds_path = os.path.join(state_dir, "klangk.sock")
 
     # Read ws_max_size through the typed config (config file > env > default,
     # with file:/cmd:), not raw os.environ (#1394/#1395).
@@ -131,48 +127,32 @@ def main(  # pragma: no cover
         resolve_indirection(settings.ws_msg_size_max) or "16777216"
     )
 
-    if transport == "socket":
-        # Bind the UDS. A stale socket from a kill -9'd process makes the
-        # bind fail with EADDRINUSE — unlink first (the pidfile guard in the
-        # lifespan refuses a concurrent klangkd). Ensure the parent dir is
-        # private (0700) so only the klangk user can open the socket — the
-        # same-uid trust boundary _UDS_MODE relies on.
-        try:
-            os.unlink(listen)
-        except FileNotFoundError:
-            pass
-        Path(listen).parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-        # Arm the internal _UDS_MODE trust flag (util.py): over a UDS,
-        # request.client is None, and a None peer is the trusted reverse
-        # proxy (same-uid socket access). Set here, from the bind decision —
-        # not via a config field (#1422 retired KLANGK_UDS_MODE).
-        set_uds_mode(True)
-        uvicorn.run(
-            "klangk_backend.main:app",
-            uds=listen,
-            # proxy_headers=False: over a UDS request.client is None; our
-            # trust helpers handle header trust via _UDS_MODE. Letting uvicorn
-            # also rewrite client would double-resolve.
-            proxy_headers=False,
-            ws_max_size=ws_max_size,
-            ws_ping_interval=20,
-            ws_ping_timeout=20,
-        )
-    else:
-        # TCP bind. LISTEN is the host (no port — port always comes from
-        # KLANGK_PORT). No nginx ownership on this path (bare uvicorn /
-        # direct-TCP tests); nginx is owned only in the UDS case.
-        host = listen
-        port = int(resolve_indirection(settings.port) or "8997")
-        uvicorn.run(
-            "klangk_backend.main:app",
-            host=host,
-            port=port,
-            proxy_headers=False,
-            ws_max_size=ws_max_size,
-            ws_ping_interval=20,
-            ws_ping_timeout=20,
-        )
+    # Bind the UDS. A stale socket from a kill -9'd process makes the
+    # bind fail with EADDRINUSE — unlink first (the pidfile guard in the
+    # lifespan refuses a concurrent klangkd). Ensure the parent dir is
+    # private (0700) so only the klangk user can open the socket — the
+    # same-uid trust boundary _UDS_MODE relies on.
+    try:
+        os.unlink(uds_path)
+    except FileNotFoundError:
+        pass
+    Path(uds_path).parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    # Arm the internal _UDS_MODE trust flag (util.py): over a UDS,
+    # request.client is None, and a None peer is the trusted reverse
+    # proxy (same-uid socket access). Set here, from the bind decision —
+    # not via a config field (#1422 retired KLANGK_UDS_MODE).
+    set_uds_mode(True)
+    uvicorn.run(
+        "klangk_backend.main:app",
+        uds=uds_path,
+        # proxy_headers=False: over a UDS request.client is None; our
+        # trust helpers handle header trust via _UDS_MODE. Letting uvicorn
+        # also rewrite client would double-resolve.
+        proxy_headers=False,
+        ws_max_size=ws_max_size,
+        ws_ping_interval=20,
+        ws_ping_timeout=20,
+    )
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -48,7 +48,6 @@ from .util import (
     customize_dir,
     resolve_env_bool,
     resolve_env_value,
-    set_uds_mode,
 )
 from .wshandler import handle_websocket
 
@@ -401,25 +400,6 @@ _nginx_task: asyncio.Task | None = None
 _nginx_stopping = False
 
 
-def _socket_path() -> str:
-    """The UDS path klangkd is bound to (only meaningful when listen is a socket).
-
-    Reads ``KLANGK_LISTEN`` directly — under the derive model (#1422) the
-    socket path IS the listen value (e.g. ``/tmp/klangk.sock``), not a
-    separate derived-from-state_dir artifact. When listen is unset/empty,
-    falls back to ``<state_dir>/klangk.sock`` (a sensible default rather than
-    an empty string). The renderer + watchdog use this to know where nginx
-    should ``proxy_pass``.
-    """
-    listen = resolve_indirection(get_settings().listen) or ""
-    if listen:
-        return listen
-    state_dir = (
-        resolve_indirection(get_settings().state_dir) or "/tmp/klangk-state"
-    )
-    return os.path.join(state_dir, "klangk.sock")
-
-
 async def _nginx_watchdog(
     bin_path: str, conf_path: str
 ) -> None:  # pragma: no cover
@@ -456,23 +436,21 @@ async def _nginx_watchdog(
 
 
 def _prepare_nginx() -> tuple[str, str]:
-    """Render nginx.conf for the UDS and return ``(bin_path, conf_path)``.
+    """Render nginx.conf and return ``(bin_path, conf_path)``.
 
-    Pure-ish (writes one file): reads the socket path from ``KLANGK_LISTEN``,
-    arms ``_UDS_MODE``, locates the nginx binary, and renders the config with
-    the UDS upstream. Extracted from :func:`start_nginx_watchdog` so the
-    config-rendering logic is unit-testable without spawning nginx; only the
-    actual ``create_task(_nginx_watchdog(...))`` spawn stays untested (covered
-    at runtime by the e2e ACL suite).
+    uvicorn always binds a UDS (``<state_dir>/klangk.sock``); nginx proxies
+    to that socket regardless of whether ``KLANGK_LISTEN`` is a socket path
+    or a TCP address. ``KLANGK_LISTEN`` only controls the *nginx template*
+    (minimal/headless vs full/browser) and the nginx listen directive, not
+    the upstream.
     """
-    sock = _socket_path()
-    set_uds_mode(True)
     state_dir = (
         resolve_indirection(get_settings().state_dir) or "/tmp/klangk-state"
     )
+    uds_path = os.path.join(state_dir, "klangk.sock")
     conf_path = os.path.join(state_dir, "nginx.conf")
     bin_path = nginx_mod.find_nginx_bin()
-    nginx_mod.write_config(nginx_mod.uds_upstream(sock), conf_path)
+    nginx_mod.write_config(nginx_mod.uds_upstream(uds_path), conf_path)
     return bin_path, conf_path
 
 

--- a/src/backend/klangk_backend/settings.py
+++ b/src/backend/klangk_backend/settings.py
@@ -223,9 +223,9 @@ class KlangkSettings(BaseSettings):
     # is no amalgamated ``KLANGK_UI_MODE``/``KLANGK_PRESET`` setting (it never
     # shipped). Socket ⇒ nginx renders the minimal (headless) template; TCP
     # ⇒ full (browser) template. ``KLANGK_PORT`` applies only when listen is
-    # TCP. Default ``127.0.0.1`` preserves today's behavior; #1400 flips the
-    # default to a socket path (the headless posture).
-    listen: str | None = "127.0.0.1"
+    # TCP. Default is None → klangkd derives a socket path from state_dir
+    # (#1400: headless UDS posture is the production default).
+    listen: str | None = None
     port: str | None = "8997"
     nginx_port: str | None = "8995"
     port_range_start: str | None = "9000"

--- a/src/backend/tests/test_nginx.py
+++ b/src/backend/tests/test_nginx.py
@@ -488,48 +488,19 @@ class TestWatchdogGate:
             main._nginx_proc = None
 
 
-class TestSocketPath:
-    """_socket_path() reads KLANGK_LISTEN (the socket IS the listen value)."""
-
-    def test_returns_listen_value(self):
-        import klangk_backend.main as main
-
-        _set(listen="/tmp/klangk.sock")
-        assert main._socket_path() == "/tmp/klangk.sock"
-
-    def test_falls_back_to_state_dir_when_listen_unset(self, monkeypatch):
-        import klangk_backend.main as main
-
-        # When listen is empty/unset, _socket_path defaults to
-        # <state_dir>/klangk.sock rather than an empty string.
-        _set(listen="", state_dir="/custom/state")
-        assert main._socket_path() == "/custom/state/klangk.sock"
-
-    def test_falls_back_to_tmp_when_both_unset(self, monkeypatch):
-        import klangk_backend.main as main
-
-        _set(listen="", state_dir="")
-        assert main._socket_path() == "/tmp/klangk-state/klangk.sock"
-
-
 class TestPrepareNginx:
-    """_prepare_nginx renders the config + arms UDS mode (no spawn)."""
+    """_prepare_nginx renders nginx.conf with UDS upstream (#1400)."""
 
     def test_renders_config_and_returns_paths(self, monkeypatch, tmp_path):
         import klangk_backend.main as main
 
-        sock = str(tmp_path / "klangk.sock")
-        # Socket LISTEN ⇒ minimal (headless) template (#1398). Set an LLM
-        # base URL so the /llm-proxy location (which carries the UDS
-        # proxy_pass) is actually rendered; without it the minimal server
-        # block serves nothing.
+        # uvicorn always binds <state_dir>/klangk.sock; _prepare_nginx
+        # renders the config pointing at that socket.
         _set(
-            listen=sock,
             state_dir=str(tmp_path),
             nginx_port="19999",
             llm_base_url="http://127.0.0.1:11434",
         )
-        # Stub the binary lookup so the test doesn't depend on PATH.
         monkeypatch.setattr(
             "klangk_backend.nginx.find_nginx_bin", lambda: "/fake/nginx"
         )
@@ -538,17 +509,8 @@ class TestPrepareNginx:
         assert conf_path == str(tmp_path / "nginx.conf")
         assert (tmp_path / "nginx.conf").is_file()
         conf = (tmp_path / "nginx.conf").read_text()
-        # The UDS upstream lands in the /llm-proxy location + its auth_request
-        # subrequest target; the minimal template carries no browser surface.
-        assert f"proxy_pass http://unix:{sock}:" in conf
-        assert "location ~ ^/llm-proxy/" in conf
-        assert "location / {" not in conf
-        assert "/api/v1/auth/local" not in conf
-        # _UDS_MODE armed.
-        import klangk_backend.util as util
-
-        assert util._UDS_MODE is True
-        util.set_uds_mode(False)  # reset for other tests
+        uds_path = str(tmp_path / "klangk.sock")
+        assert f"proxy_pass http://unix:{uds_path}:" in conf
 
 
 class TestStopWatchdogWithInjectedState:


### PR DESCRIPTION
## Summary

**BREAKING** — chunk 7 of #1392 (the gated finale).

### uvicorn always binds a UDS
- klangkd always binds `<state_dir>/klangk.sock` — the TCP path is removed
- `KLANGK_LISTEN` now controls what *nginx* does (socket path → minimal template, TCP address → full template), not what uvicorn does
- `_prepare_nginx` always renders with `uds_upstream(state_dir/klangk.sock)`
- `_socket_path()` removed (no longer needed)

### Default is headless
- `settings.listen` default flipped from `127.0.0.1` to `None` (→ UDS)
- Bare `klangkd` boots UDS + none auth: no browser surface, CLI-only

### Devenv default is browser-first
- `klangkd.yaml.example` defaults to `listen: 127.0.0.1` + `auth_modes: password`
- `port: "8997"` removed from the example (no direct TCP to uvicorn)

## Test plan

- [x] Backend: 2282 passed, 100% coverage
- [x] CLI: 477 passed, 100% coverage
- [x] Pre-commit hooks pass

Closes #1400
