### PR TITLE
feat(#1443): add Caddy to devenv and fastcaddy to backend deps

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -50,6 +50,7 @@ in
       git # "error: Failed to find git" during devenv:git-hooks:install
       gzip
       gnutar
+      caddy # reverse proxy; will replace nginx (#1443)
       nginx
       podman
       ruff

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -42,6 +42,10 @@ operators or integrators to act when upgrading.
 - **Direct UDS login:** `client_is_loopback` treats direct UDS connections
   (no nginx proxy) as loopback, so `klangkc login /path/to/sock` works in
   no-auth mode (#1399).
+- **Caddy dev dependency:** `caddy` is now a devenv package and
+  `fastcaddy` (Caddy API wrapper) a backend Python dependency, in
+  preparation for replacing nginx with Caddy as the reverse proxy
+  (#1443). nginx is unchanged for now.
 
 ### Removed
 

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "logfire[fastapi]>=3.0.0",
     "pyyaml>=6.0",
     "httpx>=0.28.0",
+    "fastcaddy",  # Caddy API wrapper; nginx→Caddy reverse proxy (#1443)
     "pytest>=8.0.0",
     "pytest-asyncio>=0.24.0",
     "pytest-cov>=6.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -458,6 +458,28 @@ wheels = [
 ]
 
 [[package]]
+name = "fastcaddy"
+version = "0.0.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastcore" },
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ba/a8/22a3c12f3dfeea79de87c07d8b2bc3f8df00e7d9192a436645727e67fb30/fastcaddy-0.0.10.tar.gz", hash = "sha256:f1bd6dbd21ef3cf5675d02519b78e4ac946cb4a5e12a5a52d7bf631e0bb54e00", size = 116923, upload-time = "2026-03-04T21:15:57.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/9c/a38efe9a5a362df1e924a7af7531a3fd8831596986105032ffa9fe216856/fastcaddy-0.0.10-py3-none-any.whl", hash = "sha256:eb3a0483c5dbaa8ad1caf8b6e241c0864886b294155be94390de151260029838", size = 115674, upload-time = "2026-03-04T21:15:56.019Z" },
+]
+
+[[package]]
+name = "fastcore"
+version = "2.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/3a/6ab189da89201ea24cd294bc56a20b6de621b7899485b6497c9240963a5b/fastcore-2.0.4.tar.gz", hash = "sha256:5b65f7fc39ab716c62e9117746c6ea897ae111f9d71f4d7d6d0c08daac8c9480", size = 103215, upload-time = "2026-07-11T04:46:52.234Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/25/4094eede4ca19d712c646402a9db5c9ab67cba4e6ff192754805655ec8a9/fastcore-2.0.4-py3-none-any.whl", hash = "sha256:15a4044114dc54d1c6bfdfec1a6c0e5b64c9b115d5881e9ef879de2a0f9b9a97", size = 108099, upload-time = "2026-07-11T04:46:50.641Z" },
+]
+
+[[package]]
 name = "googleapis-common-protos"
 version = "1.75.0"
 source = { registry = "https://pypi.org/simple" }
@@ -648,6 +670,7 @@ dependencies = [
     { name = "bcrypt" },
     { name = "cryptography" },
     { name = "fastapi" },
+    { name = "fastcaddy" },
     { name = "httpx" },
     { name = "jinja2" },
     { name = "logfire", extra = ["fastapi"] },
@@ -673,6 +696,7 @@ requires-dist = [
     { name = "bcrypt", specifier = ">=4.0.0" },
     { name = "cryptography", specifier = ">=48.0.1" },
     { name = "fastapi", specifier = ">=0.115.0" },
+    { name = "fastcaddy" },
     { name = "httpx", specifier = ">=0.28.0" },
     { name = "jinja2", specifier = ">=3.1" },
     { name = "logfire", extras = ["fastapi"], specifier = ">=3.0.0" },


### PR DESCRIPTION
## Summary

Prep for replacing nginx with Caddy as the reverse proxy: adds `caddy` to the devenv packages (alongside nginx, which is unchanged for now) and `fastcaddy` (a Python wrapper for the Caddy API) to the backend dependencies.

Closes #1443.

## Changes

- **`devenv.nix`** — `caddy` package added next to `nginx`.
- **`src/backend/pyproject.toml`** — `fastcaddy` dependency added.
- **`uv.lock`** — regenerated (+`fastcaddy`, +`fastcore`).
- **`docs/changes.md`** — `### Added` entry under `## [Unreleased]`.

## Verification

All three acceptance criteria from #1443 met:

- ✅ `caddy` is available in `devenv shell` → `caddy version` → **2.11.4**
- ✅ `fastcaddy` imports cleanly → **0.0.10**, exposes `add_reverse_proxy`
- ✅ Backend suite green at 100% coverage → `python -m pytest src/backend/tests -v -n auto` → **2349 passed**

## Notes

- This is a pure dependency addition — no proxy behavior changes yet; nginx remains the active reverse proxy. The actual nginx→Caddy swap is follow-up work.
- Based on `issue-1400-migration-breaking-changes-no-direct-tcp-to-uvicorn-default` (not `main`), since the Caddy work builds on the #1400 UDS-bind changes. PR base set accordingly.
