### PR TITLE
Slice 1 remainder: build_app() composition root + oidc settings threading + cache deletion (#1426)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -2,49 +2,141 @@
 
 ## What this is
 
-This is a large, multi-slice refactor to eliminate module-level mutable globals from `klangk_backend`. The tracking issue is **#1426** (read its full body for the complete design).
+A multi-slice refactor to eliminate module-level mutable globals from
+`klangk_backend` in favor of one composition root: a `build_app(settings)`
+factory. The tracking issue is **#1426**. Every actionable slice has its own
+issue (see "Issue map" below).
 
-Branch: `refactor/1426-composition-root`, based on `origin/main`.
+**Current branch**: `issue-1447-klangksettings-env-constructor-for-injectable-env-dicts-1426`
+**Current PR**: [#1455](https://github.com/mcdonc/klangk/pull/1455) (OPEN)
+**Test state**: 2377 passed, 100% coverage, 0 warnings
 
-## What's been done (commit `7040610e`)
+## Issue map
 
-**Slice 1, step 1: `KlangkSettings(env=...)` constructor.** Done and tested.
+| Issue | Title | State |
+|-------|-------|-------|
+| **#1426** | Tracker: one composition root, no module globals | umbrella |
+| **#1447** | Slice 1 — `KlangkSettings(env=...)` + settings threading | in progress (#1455) |
+| **#1458** | Slice 1 remainder — delete `_config_file_path` global | next |
+| **#1449** | Slice 2 — ContainerRegistry owned instance | |
+| **#1450** | Slice 3 — OIDC instance + caches | |
+| **#1451** | Slice 4 — Plugins instance | |
+| **#1452** | Slice 5 — `DB(settings)`; kill db globals | |
+| **#1453** | Slice 6 — freeze `resolve_env_value` at startup | |
+| **#1454** | Slice 7 — delete the `main:app` shim | |
+| **#1456** | Standalone — `frontend_dir` config setting | |
+| **#1457** | Standalone — tests stop monkeypatching `os.environ` | |
 
-`KlangkSettings` now accepts an optional `env` dict parameter:
+The next-step chain after #1455 merges: **#1458** → Slice 1 done →
+**#1449** (Slice 2) → #1450 → #1451 → #1452 → #1453 → #1454.
 
-```python
-KlangkSettings()              # reads os.environ (production default)
-KlangkSettings(env={...})     # reads the dict only; os.environ ignored (tests)
-```
+## Slice 1: what's DONE
 
-Implementation: `_EnvDictSource(EnvSettingsSource)` overrides `_load_env_vars()` to run the passed dict through the same `parse_env_vars` normalizer the base uses for `os.environ`. A class-var bridge (`_env_for_sources`) shuttles the env dict from `__init__` through the classmethod boundary (`settings_customise_sources` runs before `self` exists), cleaned up after construction so it doesn't leak.
+Two PRs land Slice 1. **#1448 is merged** (on `main`); **#1455 is open**
+(this branch).
 
-**Known tech debt — the class-var bridge (`_env_for_sources`, `_config_file_for_sources`).** This is nasty but works: `__init__` sets a class var, `super().__init__()` reads it in the classmethod, then `__init__` resets it to `None`. It's safe because construction is single-threaded (startup + tests construct one at a time), but it's not thread-safe and it's surprising. A cleaner alternative to investigate: stash `env`/`config_file` on a subclassed `init_settings` source (the one `settings_customise_sources` argument tied to *this* construction) instead of a class var. That's deeper pydantic-internals work and wasn't verified under time pressure; leave as a follow-up cleanup. Do **not** treat the class-var bridge as permanent.
+### PR #1448 (merged) — the constructor
 
-**Precedence note**: env > config file > defaults. (pydantic-settings gives earlier sources in the tuple higher priority. Init kwargs / field overrides are not a supported configuration path — don't use them.)
+- **`KlangkSettings(env, config_file=None)`** constructor. `env` is
+  **required** (`Mapping[str, str]` — production passes `os.environ`,
+  tests pass a dict). `config_file` is optional (`str | None`; `None` =
+  no config file). Implementation: `_EnvDictSource(EnvSettingsSource)`
+  overrides `_load_env_vars()` to run the passed mapping through the
+  same `parse_env_vars` normalizer the base uses for `os.environ`.
+- **Class-var bridge** (`_env_for_sources`, `_config_file_for_sources`):
+  shuttles the env dict / config-file path from `__init__` through the
+  classmethod boundary (`settings_customise_sources` runs before `self`
+  exists). **Review fixes applied (#1448 review):**
+  - Annotated as `ClassVar[...]` (not bare underscore attrs — pydantic
+    absorbs those into `__private_attributes__` and they worked only by
+    `cls.` vs `self.` accident).
+  - Cleanup is `try/finally` around `super().__init__()` (a failed
+    construction no longer leaks the env dict onto the class).
+- **No init kwargs.** `**values` was dropped — init kwargs are NOT a
+  supported config path (lowest-priority source, silently ignored when
+  env sets the field).
+- **Precedence**: env dict > config file > defaults (earlier sources in
+  the pydantic-settings tuple win).
 
-**Tests**: 57 settings tests pass (6 new `TestEnvConstructor` tests). Full suite: 2354 pass, 1 pre-existing flaky WS test fails under `-n auto` (passes in isolation), 0 warnings from new tests.
+### PR #1455 (open, this branch) — build_app, cache deletion, oidc threading, validator
 
-## What remains for Slice 1
+Four commits on top of the merged #1448:
 
-The rest of Slice 1 (see #1426 for acceptance criteria):
+1. **`oidc.auth_modes(settings)` + predicate threading.**
+   `auth_modes()`, `password_login_allowed()`, `local_login_allowed()`,
+   `oidc_login_allowed()` now take a `KlangkSettings` arg and read
+   `settings.auth_modes` instead of `resolve_env_value("KLANGK_AUTH_MODES")`
+   at call time. Production callers obtain settings via `get_settings()`
+   (transitional — `get_settings_dep` arrives in commit 2). **This is a
+   stepping stone for Slice 3 (#1450)**, where the `settings` param
+   becomes `self.settings` on an `OIDC(settings)` class.
 
-1. **`build_app(settings)` factory.** Wrap the module-level `app = FastAPI()` + `add_middleware` + `include_router` in `main.py` into a `build_app()` function. Keep `main:app` as a shim (`app = build_app(get_settings())`) so uvicorn's string import still works. The factory takes `settings: KlangkSettings` and stores it on `app.state.settings`.
+2. **`build_app(settings)` composition root + `get_settings_dep` + cache
+   machinery deletion.**
+   - `build_app()` wraps app construction (FastAPI, CORS, routers,
+     exception handlers, WS endpoint, static files) into one factory.
+     Sets `app.state.settings = settings`.
+   - `get_settings_dep(request)` → `request.app.state.settings` — the
+     per-request bridge (zero callers yet; endpoints migrate to it
+     incrementally or via subsystem Depends in later slices).
+   - Module-level `app = build_app(get_settings())` remains as a shim
+     for uvicorn's string import.
+   - **Cache machinery deleted**: `_settings_instance`,
+     `_settings_env_signature`, `_env_signature()`, `_invalidate_cache()`
+     all gone. `get_settings()` is cache-free (constructs a fresh
+     `KlangkSettings(os.environ, config_file=_config_file_path)` on
+     every call).
 
-2. **`get_settings_dep` FastAPI dependency.** Add a per-request dependency that reads `request.app.state.settings`:
+3. **`auth_modes` field validator (security fix).**
+   A typo'd `KLANGK_AUTH_MODES` (e.g. `passdword`) used to fall through
+   to `"none"` — a **silent security downgrade** (`none` freely issues
+   an admin token). A pydantic `field_validator` now rejects non-`None`,
+   non-empty values outside `{password, oidc, both, none}` at
+   construction (`validate_at_startup()` in the lifespan → aborts boot
+   before serving traffic). Empty string is treated as unset (`None`),
+   preserving the blank-value behavior. `oidc.auth_modes()` simplified
+   to `settings.auth_modes` + `None → "none"` fallback (the set check is
+   redundant now that the validator guarantees validity).
 
-   ```python
-   def get_settings_dep(request: Request) -> KlangkSettings:
-       return request.app.state.settings
-   ```
+4. **E2E test fix.** `test_nginx_acl_e2e.py` imported `_invalidate_cache`
+   (deleted in commit 2). Removed all 10 lines (5 imports + 5 calls).
+   Also fixed invalid `password,oidc` test data in `test_nginx.py`
+   (never a valid mode — the new validator catches it) → `both`.
 
-3. **Thread `settings` into `oidc.auth_modes()` and the `*_login_allowed` predicates.** These currently call `get_settings()` internally. Change them to take a `settings: KlangkSettings` arg. Update all callers (the FastAPI auth dependencies in `api/auth.py`, the `/config` endpoint in `api/__init__.py`, and startup callers).
+## Slice 1: what REMAINS
 
-4. **Drop the cache machinery.** Delete `_settings_instance`, `_settings_env_signature`, `_env_signature()`, `_invalidate_cache()`, and the env-change detection in `get_settings()`. `get_settings()` either goes away entirely or becomes a test-only constructor.
+Only one item — **#1458** (filed as its own issue):
 
-5. **Migrate tests.** Tests that use `monkeypatch.setenv` + `_invalidate_cache()` should migrate to `KlangkSettings(env={...})` where practical. Some tests may keep monkeypatch if they test code paths that still call `resolve_env_value` (those retire in Slice 6).
+- **Delete the `_config_file_path` global.** `set_config_file()` /
+  `get_config_file()` / `_config_file_path` are still present as a
+  transitional fallback. `get_settings()` passes
+  `config_file=_config_file_path` explicitly so the coupling is visible.
+  Migrate `klangkd` (the one production caller, `klangkd.py:105`) and
+  ~15 test callers to pass `config_file=` to the constructor, then
+  delete the global + accessors.
 
-6. **Update `validate_at_startup()`** to construct `KlangkSettings(os.environ)` instead of calling `get_settings()`.
+After #1458 merges, **#1447 (Slice 1) closes** and **#1449 (Slice 2)**
+starts.
+
+## Design decisions (locked in)
+
+- **`env` is required on `KlangkSettings.__init__`** — forces explicit
+  config source. `os.environ` is never read unless explicitly passed.
+- **`config_file` defaults to `None`** — `None` means "no config file"
+  (legitimate common case for tests/scripts). `"none"` is the explicit
+  opt-out string.
+- **Init kwargs NOT supported** — dropped from signature, not mentioned
+  in docstrings (except `config_file`).
+- **Precedence**: env dict > config file > defaults.
+- **`DB(settings)` not `settings.get_db()`** — settings stays a pure
+  config value; engine/PRAGMA/cache concerns live on `DB`.
+- **No ContextVar** — Pyramid discipline; all threaded explicitly.
+- **`get_settings()` is a cache-free shim** — stays until Slice 7
+  (#1454) when its last caller (the `main:app` shim) is gone.
+- **`get_settings_dep` is NOT for every endpoint** — its real audience
+  is endpoints reading config fields directly. Endpoints delegating to
+  subsystem objects (oidc/container/plugins) use per-subsystem Depends
+  once those become instances (Slices 2-4).
 
 ## How to run tests
 
@@ -52,66 +144,69 @@ The rest of Slice 1 (see #1426 for acceptance criteria):
 # Always use this prefix (devenv project):
 devenv --quiet -O dotenv.enable:bool false shell --
 
-# Settings tests only (fast iteration):
-devenv --quiet -O dotenv.enable:bool false shell -- bash -c 'cd src/backend && python3 -m pytest tests/test_settings.py -o addopts="" -q'
+# Full backend suite (CI-matching, with coverage + xdist):
+devenv --quiet -O dotenv.enable:bool false shell -- \
+  bash -c 'cd src/backend && python3 -m pytest tests -n auto'
 
-# Full backend suite (CI-matching, with coverage):
-devenv --quiet -O dotenv.enable:bool false shell -- bash -c 'cd src/backend && python3 -m pytest tests -n auto'
+# Settings/main tests only (fast iteration, no coverage):
+devenv --quiet -O dotenv.enable:bool false shell -- \
+  bash -c 'cd src/backend && python3 -m pytest tests/test_settings.py tests/test_main.py -o addopts="" -q'
 
-# Quick run without coverage (for fast iteration):
-devenv --quiet -O dotenv.enable:bool false shell -- bash -c 'cd src/backend && python3 -m pytest tests/test_settings.py tests/test_main.py -o addopts="" -q'
+# Full CLI suite (CI-matching):
+devenv --quiet -O dotenv.enable:bool false shell -- \
+  bash -c 'cd src/cli && python3 -m pytest tests -n auto'
 ```
+
+CI runs E2E suites (`test-backend-e2e`, `test-cli-e2e`,
+`test-frontend-e2e`) that need a container runtime — those can't run
+locally without podman. The nginx ACL E2E tests were the catch for the
+`_invalidate_cache` import breakage in #1455 (fixed in commit 4).
 
 ## Key files and their roles
 
-| File                                         | Role                                                                                                                                                  |
-| -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `src/backend/klangk_backend/settings.py`     | `KlangkSettings` model, `get_settings()` singleton (to be removed), `validate_at_startup()`, `resolve_env_value/bool` (Slice 6)                       |
-| `src/backend/klangk_backend/main.py`         | Lifespan, `app = FastAPI()`, `setup_logfire`, `cors_origins`, nginx watchdog. The `build_app()` factory goes here.                                    |
-| `src/backend/klangk_backend/oidc.py`         | `auth_modes()`, `password_login_allowed()`, `oidc_login_allowed()`, `local_login_allowed()` — the per-request predicates that need settings threading |
-| `src/backend/klangk_backend/api/auth.py`     | Auth dependencies (`require_auth`, etc.) that call `oidc.auth_modes()`                                                                                |
-| `src/backend/klangk_backend/api/__init__.py` | The `/config` endpoint that reads `oidc.auth_modes()`                                                                                                 |
-| `src/backend/klangk_backend/klangkd.py`      | The launcher entry point; calls `validate_at_startup()` and `uvicorn.run("klangk_backend.main:app")`                                                  |
+| File | Role |
+|------|------|
+| `src/backend/klangk_backend/settings.py` | `KlangkSettings` model + constructor (`_EnvDictSource`, class-var bridges, `auth_modes` validator), `get_settings()` (cache-free shim), `validate_at_startup()`, `_config_file_path` global (dies in #1458), `resolve_env_value/bool` (die in Slice 6 / #1453) |
+| `src/backend/klangk_backend/main.py` | `build_app(settings)` composition root, `get_settings_dep`, `lifespan`, `setup_logfire`, `cors_origins`, nginx watchdog globals, `app = build_app(get_settings())` shim (dies in Slice 7 / #1454) |
+| `src/backend/klangk_backend/oidc.py` | `auth_modes(settings)`, `*_login_allowed(settings)` — take settings arg (become methods in Slice 3 / #1450); `_providers` / `_discovery_cache` / `_jwks_cache` globals (move onto OIDC instance in Slice 3) |
+| `src/backend/klangk_backend/api/auth.py` | Auth endpoints calling `oidc.password_login_allowed(get_settings())` / `oidc.local_login_allowed(get_settings())` |
+| `src/backend/klangk_backend/api/__init__.py` | `/config` endpoint calling `oidc.auth_modes(get_settings())`; module-scope `resolve_env_value` constants (migrate to settings in Slice 6) |
+| `src/backend/klangk_backend/klangkd.py` | Launcher; calls `set_config_file(resolved)` (dies in #1458), `validate_at_startup()`, `uvicorn.run("klangk_backend.main:app")` |
 
-## Design rules (from #1426)
+## Tech debt callout: the class-var bridge
 
-- **No implicit lookups.** All threaded explicitly as constructor/param args — no `ContextVar`, no module global, no `app.state`-as-registry. The lifespan closes over the instances it constructs and passes them into the background actors and WS/router factories.
-- **ASGI app is the only global.** Everything else is an instance owned by `app.state` or an explicit constructor arg.
-- **`app.state.x = ...` only inside `build_app()` or the lifespan.**
-- **`KlangkSettings(os.environ)`** in production; `KlangkSettings(env={...})` in tests.
-- **100% coverage maintained** at every commit.
-- **Warnings in tests you touched must be squashed** before pushing.
+`_env_for_sources` and `_config_file_for_sources` are `ClassVar`s set on
+the class in `__init__` before `super().__init__()`, read in the
+classmethod `settings_customise_sources`, and cleaned up in a `try/finally`.
+This is safe (construction is single-threaded at startup and one-at-a-time
+in tests) but not thread-safe and surprising.
 
-## Remaining slices (beyond Slice 1)
-
-See #1426 for the full design. Summary:
-
-- **Slice 2**: promote `ContainerRegistry` to `app.state.container_registry`; move `_service_session_locks`; make `IdleMonitor`/`HealthMonitor`/`BrowserRouter`/`PortAllocator` take `settings` in constructors; `auto_start_workspaces` becomes a `ContainerRegistry` method; `NginxWatchdog` → `app.state.nginx_watchdog`; `wshandler.state` → `ConnectionRegistry`.
-- **Slice 3**: `OIDC` instance + caches → `app.state.oidc`.
-- **Slice 4**: `Plugins` instance → `app.state.plugins`.
-- **Slice 5**: `DB(settings)` — kill `data_dir`/`DB_PATH`/`get_db()` globals in `model/db.py`.
-- **Slice 6**: freeze `resolve_env_value` at startup (132 call sites).
-- **Slice 7**: delete the `main:app` shim.
+A cleaner alternative (not yet verified): stash `env`/`config_file` on a
+subclassed `init_settings` source (the one `settings_customise_sources`
+argument tied to *this* construction) instead of a class var. That's deeper
+pydantic-internals work; leave as a follow-up cleanup. Do **not** treat the
+class-var bridge as permanent — it exists because extracting `env` from
+`init_settings` inside the classmethod doesn't work (`extra="ignore"` drops
+non-field init kwargs).
 
 ## Full target `build_app()` shape (the end state across all slices)
 
-Every `app.state` attribute created across the refactor, in slice order. The
-HANDOFF model should understand this is the target — each slice creates its
-subset and leaves the rest for later slices.
+Every `app.state` attribute created across the refactor, in slice order.
+Each slice creates its subset and leaves the rest for later slices.
 
 ```python
 def build_app(settings: KlangkSettings) -> FastAPI:
     app = FastAPI(title="Klangk", lifespan=_lifespan(settings))
 
-    # --- Slice 1 ---
+    # --- Slice 1 (DONE) ---
     app.state.settings = settings
 
-    # --- Slice 2 ---
+    # --- Slice 2 (#1449) ---
     app.state.container_registry = container.ContainerRegistry(settings)
     #   - IdleMonitor / HealthMonitor / BrowserRouter / PortAllocator become
     #     collaborators of the registry (nested as `.idle`, `.health`, etc.)
     #   - terminal._service_session_locks moves onto the registry
-    #   - auto_start_workspaces becomes a ContainerRegistry method
+    #   - auto_start_workspaces takes (container_registry, settings) as args
     app.state.nginx_watchdog = NginxWatchdog(settings)
     app.state.connections = ConnectionRegistry()
     #   ^ new lifecycle object: replaces the `wshandler.state` module global.
@@ -122,15 +217,17 @@ def build_app(settings: KlangkSettings) -> FastAPI:
     #     live WS connections — different lifecycle than either, so it gets its
     #     own owner on app.state.
 
-    # --- Slice 3 ---
+    # --- Slice 3 (#1450) ---
     app.state.oidc = oidc.OIDC(settings)
     #   - _providers / _discovery_cache / _jwks_cache move onto the instance
+    #   - auth_modes(settings) / *_login_allowed(settings) become methods
+    #     (self.settings replaces the settings arg threaded in Slice 1)
 
-    # --- Slice 4 ---
+    # --- Slice 4 (#1451) ---
     app.state.plugins = plugins.Plugins(settings)
     #   - _declarations / _values move onto the instance
 
-    # --- Slice 5 ---
+    # --- Slice 5 (#1452) ---
     app.state.db = DB(settings)
     #   - kills data_dir / DB_PATH / engine / ensure_engine / get_db() globals
     #   - model methods take settings (or live on DB; see #1452 scope fence)
@@ -145,8 +242,8 @@ def build_app(settings: KlangkSettings) -> FastAPI:
         await wshandler.handle(websocket, app.state.settings, app.state.container_registry, app.state.oidc, app.state.connections)
     # settings: needed for KLANGKC_DEBUG_SSH_AGENT / KLANGKWS_DEBUG /
     #   KLANGK_BRIDGE_TIMEOUT_SECONDS (read today via resolve_env_value;
-    #   migrate to settings in Slice 6). Passed from the start so the WS
-    #   handler signature doesn't change twice.
+    #   migrate to settings in Slice 6 / #1453). Passed from the start so the
+    #   WS handler signature doesn't change twice.
 
     return app
 ```
@@ -155,7 +252,7 @@ def build_app(settings: KlangkSettings) -> FastAPI:
 
 | Attribute | Slice | Lifecycle | Notes |
 |-----------|-------|-----------|-------|
-| `settings` | 1 | frozen at startup | `KlangkSettings(os.environ, config_file=...)` |
+| `settings` | 1 (done) | frozen at startup | `KlangkSettings(os.environ, config_file=...)` |
 | `container_registry` | 2 | process lifetime | owns monitors, port allocator, browser router |
 | `nginx_watchdog` | 2 | start/stop in lifespan | `.start()` / `.stop()` methods |
 | `connections` | 2 | process lifetime (connections register/unregister) | replaces `wshandler.state` global; monitor broadcasts through it |

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -133,10 +133,12 @@ starts.
 - **No ContextVar** — Pyramid discipline; all threaded explicitly.
 - **`get_settings()` is a cache-free shim** — stays until Slice 7
   (#1454) when its last caller (the `main:app` shim) is gone.
-- **`get_settings_dep` is NOT for every endpoint** — its real audience
-  is endpoints reading config fields directly. Endpoints delegating to
-  subsystem objects (oidc/container/plugins) use per-subsystem Depends
-  once those become instances (Slices 2-4).
+- **`get_settings_dep` is for every endpoint that needs settings** — no
+  either/or. Any endpoint requiring settings uses
+  `Depends(get_settings_dep)`. When subsystems become instances (Slices 2-4),
+  endpoints needing those use the corresponding per-subsystem Depends too —
+  that's additive, not alternative. An endpoint needing OIDC *and* a raw
+  config field uses both `get_oidc_dep` and `get_settings_dep`.
 
 ## How to run tests
 

--- a/src/backend/e2e-tests/test_nginx_acl_e2e.py
+++ b/src/backend/e2e-tests/test_nginx_acl_e2e.py
@@ -28,7 +28,7 @@ def _render_conf(env_overrides, tmpdir=None):
 
     Replaces the old ``_run_nginx_sh`` (which ran ``scripts/nginx.sh`` and
     killed it after config generation). Sets KLANGK_* env vars, invalidates
-    the settings cache, renders via :func:`klangk_backend.nginx.render_config`,
+    the live env (read by render_config via get_settings), renders via :func:`klangk_backend.nginx.render_config`,
     then restores the env. Returns the conf text.
 
     Keys the renderer consults but that aren't in ``env_overrides`` are
@@ -63,10 +63,8 @@ def _render_conf(env_overrides, tmpdir=None):
             # render, regardless of what a prior test left behind.
             os.environ.pop(k, None)
     try:
-        from klangk_backend.settings import _invalidate_cache
         from klangk_backend.nginx import render_config, tcp_upstream
 
-        _invalidate_cache()
         return render_config(tcp_upstream("127.0.0.1", "19998"))
     finally:
         for k, old in old_env.items():
@@ -74,9 +72,7 @@ def _render_conf(env_overrides, tmpdir=None):
                 os.environ.pop(k, None)
             else:
                 os.environ[k] = old
-        from klangk_backend.settings import _invalidate_cache
 
-        _invalidate_cache()
 
 
 def _write_and_launch_nginx(conf_text, nginx_port, tmpdir):
@@ -450,7 +446,6 @@ class TestNginxAclEnforcement:
 
         # Start nginx via the Python renderer (#1396): render the conf
         # from these env vars, then launch nginx directly with -c.
-        from klangk_backend.settings import _invalidate_cache
         from klangk_backend.nginx import write_config, tcp_upstream
 
         for k, v in {
@@ -460,7 +455,6 @@ class TestNginxAclEnforcement:
             "KLANGK_LLM_API_KEY": "fake-key",
         }.items():
             os.environ[k] = v
-        _invalidate_cache()
         nginx_state = os.path.join(tmpdir, "nginx")
         os.makedirs(nginx_state, exist_ok=True)
         conf_path = os.path.join(nginx_state, "nginx.conf")
@@ -622,7 +616,6 @@ class TestNginxDenyByDefault:
         # Start nginx via the Python renderer (#1396) with the host IP as
         # the (sole) container source IP. CONTAINER_DENY on the catch-all
         # then denies exactly that IP.
-        from klangk_backend.settings import _invalidate_cache
         from klangk_backend.nginx import write_config, tcp_upstream
 
         for k, v in {
@@ -630,7 +623,6 @@ class TestNginxDenyByDefault:
             "KLANGK_CONTAINER_SUBNETS": host_ip,
         }.items():
             os.environ[k] = v
-        _invalidate_cache()
         nginx_state = os.path.join(tmpdir, "nginx")
         os.makedirs(nginx_state, exist_ok=True)
         conf_path = os.path.join(nginx_state, "nginx.conf")
@@ -785,11 +777,9 @@ class TestNginxAuthLocalAcl:
         # nginx via the Python renderer (#1396) with no container subnets —
         # the /auth/local block is always generated with its fixed loopback
         # allowlist.
-        from klangk_backend.settings import _invalidate_cache
         from klangk_backend.nginx import write_config, tcp_upstream
 
         os.environ["KLANGK_NGINX_PORT"] = nginx_port
-        _invalidate_cache()
         nginx_state = os.path.join(tmpdir, "nginx")
         os.makedirs(nginx_state, exist_ok=True)
         conf_path = os.path.join(nginx_state, "nginx.conf")

--- a/src/backend/klangk_backend/api/__init__.py
+++ b/src/backend/klangk_backend/api/__init__.py
@@ -54,6 +54,7 @@ from .. import (
 # name to the logic module after the submodule imports (see below) so the
 # instance endpoints reference klangk_backend.auth, not the route module.
 from .. import auth as _auth_logic
+from ..settings import get_settings
 from ..util import resolve_env_bool, resolve_env_value
 
 # Route submodules, aliased because their names collide with the logic
@@ -200,7 +201,7 @@ async def get_config():
         "login_banner_title": LOGIN_BANNER_TITLE,
         "login_banner": LOGIN_BANNER,
         "oidc_providers": oidc.list_providers(),
-        "auth_modes": oidc.auth_modes(),
+        "auth_modes": oidc.auth_modes(get_settings()),
         "instance_id": model.get_instance_id(),
         # Whether per-workspace auto-start (start the container on server
         # boot) is permitted. The web UI gates its "Auto start" checkbox on

--- a/src/backend/klangk_backend/api/auth.py
+++ b/src/backend/klangk_backend/api/auth.py
@@ -22,6 +22,7 @@ from .. import (
     oidc,
     wshandler,
 )
+from ..settings import get_settings
 from ..util import (
     client_is_loopback,
     derive_hosting_info,
@@ -69,7 +70,7 @@ async def register(
     req: auth.RegisterRequest,
     request: Request,
 ):
-    if not oidc.password_login_allowed():
+    if not oidc.password_login_allowed(get_settings()):
         raise HTTPException(
             status_code=403,
             detail="Password registration is disabled",
@@ -280,7 +281,7 @@ async def reset_password(req: ResetPasswordRequest):
 
 @router.post("/auth/login", response_model=auth.TokenResponse)
 async def login(req: auth.LoginRequest):
-    if not oidc.password_login_allowed():
+    if not oidc.password_login_allowed(get_settings()):
         raise HTTPException(
             status_code=403, detail="Password login is disabled"
         )
@@ -309,7 +310,7 @@ async def local_login(request: Request):
     appear to come from 127.0.0.1), the backend independently verifies
     the *effective* client is loopback via :func:`util.client_is_loopback`.
     """
-    if not oidc.local_login_allowed():
+    if not oidc.local_login_allowed(get_settings()):
         raise HTTPException(
             status_code=403,
             detail="Local login is not enabled (auth mode is not 'none')",

--- a/src/backend/klangk_backend/api/oidc_auth.py
+++ b/src/backend/klangk_backend/api/oidc_auth.py
@@ -19,6 +19,7 @@ from .. import (
     model,
     oidc,
 )
+from ..settings import get_settings
 from ..util import (
     API_PREFIX,
     derive_hosting_info,
@@ -52,7 +53,7 @@ async def oidc_login(
     cli_redirect: str | None = None,
 ):
     """Redirect to the OIDC IdP for authentication."""
-    if not oidc.oidc_login_allowed():
+    if not oidc.oidc_login_allowed(get_settings()):
         raise HTTPException(status_code=404, detail="OIDC not enabled")
 
     provider = oidc.get_provider(provider_id)

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -165,11 +165,11 @@ def enforce_no_auth_bind_safety() -> None:
     ``KLANGK_ALLOW_INSECURE_NO_AUTH=1`` when you knowingly expose a no-auth
     server (e.g. a throwaway VM on an isolated network). #1374.
 
-    Runs in the lifespan so ``auth_modes()`` goes through ``resolve_env_value``
-    (supports ``@file:`` indirection) — something a bash gate in the
+    Runs in the lifespan so ``auth_modes(settings)`` reads the resolved
+    setting (supports ``@file:`` indirection resolved at startup) — something a bash gate in the
     old nginx.sh couldn't replicate.
     """
-    if oidc.auth_modes() != "none":
+    if oidc.auth_modes(get_settings()) != "none":
         return
     host = resolve_env_value("KLANGK_LISTEN", "127.0.0.1") or "127.0.0.1"
     if _is_loopback_bind(host):

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -11,7 +11,7 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 
 import bcrypt
-from fastapi import FastAPI, WebSocket
+from fastapi import FastAPI, Request, WebSocket
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
@@ -29,6 +29,7 @@ from . import (
     wshandler,
 )
 from .settings import (
+    KlangkSettings,
     get_settings,
     resolve_indirection,
     validate_at_startup,
@@ -606,10 +607,6 @@ async def lifespan(app: FastAPI):
         await process_shutdown()
         logger.info("Klangk backend stopped")
 
-
-app = FastAPI(title="Klangk", lifespan=lifespan)
-
-
 def setup_logfire(app: FastAPI) -> bool:
     """Enable Logfire instrumentation if LOGFIRE_TOKEN is set."""
     if not resolve_env_value("LOGFIRE_TOKEN"):
@@ -650,18 +647,6 @@ def cors_origins() -> list[str]:
     return [f"{proto}://{hostname}"]
 
 
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=cors_origins(),
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
-
-app.include_router(root_router)
-app.include_router(router, prefix=API_PREFIX)
-
-
 async def _agent_principal_error_handler(request, exc):  # noqa: ARG001
     """Reject any operation that would make the agent an ACL principal.
 
@@ -675,23 +660,13 @@ async def _agent_principal_error_handler(request, exc):  # noqa: ARG001
 def register_exception_handlers(application: FastAPI) -> None:
     """Register global exception handlers on a FastAPI application.
 
-    Called for the production app below and by the test app fixture so
-    both surface the same handler wiring without duplicating the handler.
+    Called for the production app (in :func:`build_app`) and by the test
+    app fixture so both surface the same handler wiring without
+    duplicating the handler.
     """
     application.add_exception_handler(
         model.AgentPrincipalError, _agent_principal_error_handler
     )
-
-
-register_exception_handlers(app)
-
-
-# --- WebSocket ---
-
-
-@app.websocket("/ws")
-async def websocket_endpoint(ws: WebSocket):  # pragma: no cover
-    await handle_websocket(ws)
 
 
 # --- Static files (Flutter Web) ---
@@ -742,8 +717,55 @@ def setup_static_files(app: FastAPI, frontend_dir: Path) -> None:
     app.mount("/", static_app, name="frontend")
 
 
-_frontend_dir = (
-    Path(__file__).parent.parent.parent / "frontend" / "build" / "web"
-)
-if _frontend_dir.exists():  # pragma: no cover
-    setup_static_files(app, _frontend_dir)
+def build_app(settings: KlangkSettings) -> FastAPI:
+    """Single composition root (#1426).
+
+    Constructs the FastAPI app, wires middleware, routers, exception
+    handlers, the WebSocket endpoint, and static files. The ASGI app is the
+    *only* global; everything else is reached per-request via
+    :func:`get_settings_dep` (or ``app.state`` for non-request code).
+    """
+    app = FastAPI(title="Klangk", lifespan=lifespan)
+    app.state.settings = settings
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=cors_origins(),
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    app.include_router(root_router)
+    app.include_router(router, prefix=API_PREFIX)
+
+    register_exception_handlers(app)
+
+    @app.websocket("/ws")
+    async def websocket_endpoint(ws: WebSocket):  # pragma: no cover
+        await handle_websocket(ws)
+
+    frontend_dir = (
+        Path(__file__).parent.parent.parent / "frontend" / "build" / "web"
+    )
+    if frontend_dir.exists():  # pragma: no cover
+        setup_static_files(app, frontend_dir)
+
+    return app
+
+
+def get_settings_dep(request: Request) -> KlangkSettings:
+    """Per-request bridge to ``app.state.settings`` (no global read).
+
+    Request handlers obtain the frozen settings via
+    ``settings: KlangkSettings = Depends(get_settings_dep)`` instead of
+    calling the module-level ``get_settings()`` singleton (#1426).
+    """
+    return request.app.state.settings
+
+
+# --- ASGI app (the only global) ---
+# Module-level shim for uvicorn's ``klangk_backend.main:app`` string import.
+# klangkd and tests construct their own app via ``build_app()``; this exists
+# solely so ``uvicorn.run("klangk_backend.main:app")`` keeps working.
+app = build_app(get_settings())

--- a/src/backend/klangk_backend/oidc.py
+++ b/src/backend/klangk_backend/oidc.py
@@ -207,7 +207,7 @@ def auth_modes(settings: KlangkSettings) -> str:
     ``settings.auth_modes`` (resolved once at startup), not re-read from
     the environment at call time.
     """
-    val = settings.auth_modes or ""
+    val = settings.auth_modes
     if val in ("oidc", "password", "both", "none"):
         return val
     return "none"

--- a/src/backend/klangk_backend/oidc.py
+++ b/src/backend/klangk_backend/oidc.py
@@ -19,7 +19,7 @@ from jose import jwt as jose_jwt
 
 from . import model
 from .exceptions import ConfigurationError
-from .settings import get_settings
+from .settings import KlangkSettings, get_settings
 from .util import resolve_env_value, resolve_file_value
 
 logger = logging.getLogger(__name__)
@@ -158,7 +158,7 @@ def init_providers() -> None:
     """
     global _providers
     _providers = load_config()
-    mode = auth_modes()
+    mode = auth_modes(get_settings())
     if mode in ("oidc", "both") and not _providers:
         raise ConfigurationError(
             f"KLANGK_AUTH_MODES={mode!r} but no OIDC providers configured"
@@ -182,7 +182,7 @@ def is_enabled() -> bool:
     return len(_providers) > 0
 
 
-def auth_modes() -> str:
+def auth_modes(settings: KlangkSettings) -> str:
     """Return the configured auth mode.
 
     One of ``password``, ``oidc``, ``both``, or ``none`` (no-login
@@ -201,24 +201,29 @@ def auth_modes() -> str:
     defaults or overrides it (#1422 removed the deployment-shape setting
     that used to default it). The deployment shape is derived from this
     knob plus ``KLANGK_LISTEN``.
+
+    Takes the frozen :class:`KlangkSettings` explicitly (no global read) —
+    part of the composition-root refactor (#1426): the mode is read from
+    ``settings.auth_modes`` (resolved once at startup), not re-read from
+    the environment at call time.
     """
-    val = resolve_env_value("KLANGK_AUTH_MODES", "")
+    val = settings.auth_modes or ""
     if val in ("oidc", "password", "both", "none"):
         return val
     return "none"
 
 
-def password_login_allowed() -> bool:
-    return auth_modes() in ("password", "both")
+def password_login_allowed(settings: KlangkSettings) -> bool:
+    return auth_modes(settings) in ("password", "both")
 
 
-def local_login_allowed() -> bool:
+def local_login_allowed(settings: KlangkSettings) -> bool:
     """True when no-login single-user mode is active (``none``)."""
-    return auth_modes() == "none"
+    return auth_modes(settings) == "none"
 
 
-def oidc_login_allowed() -> bool:
-    return auth_modes() in ("oidc", "both") and is_enabled()
+def oidc_login_allowed(settings: KlangkSettings) -> bool:
+    return auth_modes(settings) in ("oidc", "both") and is_enabled()
 
 
 # --- PKCE ---

--- a/src/backend/klangk_backend/settings.py
+++ b/src/backend/klangk_backend/settings.py
@@ -39,9 +39,17 @@ from pydantic_settings import (
     SettingsConfigDict,
     YamlConfigSettingsSource,
 )
+from pydantic import field_validator
 from pydantic_settings.sources.providers.env import parse_env_vars
 
 logger = logging.getLogger(__name__)
+
+# Valid values for ``KLANGK_AUTH_MODES``. ``None`` (unset) defaults to ``none``
+# at *read* time (in ``oidc.auth_modes``), but a non-None value must be one of
+# these — rejecting typos at construction so a misspelled mode fails loudly at
+# boot instead of silently downgrading to the no-auth ``none`` mode (which
+# freely issues an admin token). See the ``auth_modes`` field validator below.
+_VALID_AUTH_MODES = frozenset({"password", "oidc", "both", "none"})
 
 # Re-exported for backward compat — callers that ``from ..util import ...``
 # still work because util.py re-exports these.
@@ -411,6 +419,33 @@ class KlangkSettings(BaseSettings):
 
     # --- File upload ---
     file_upload_size_max: str | None = None
+
+    @field_validator("auth_modes")
+    @classmethod
+    def _validate_auth_modes(cls, v: str | None) -> str | None:
+        """Reject typo'd auth modes so a misspelling fails loudly at boot.
+
+        Without this, ``KLANGK_AUTH_MODES=passdword`` (or any value outside the
+        valid set) would fall through ``oidc.auth_modes()`` to the ``none``
+        default — a *silent security downgrade*: ``none`` freely issues an
+        admin token via ``POST /api/v1/auth/local``. ``None`` is allowed (the
+        unset case, which legitimately means "default to none"); only a
+        *set-but-garbage* value is rejected.
+
+        Runs at construction (``KlangkSettings(...)`` → ``validate_at_startup``
+        in the lifespan), so the bad value aborts boot before traffic.
+        """
+        if v is None or v == "":
+            # Unset or empty → default to ``none`` at read time (in
+            # ``oidc.auth_modes``). Legitimate: the operator didn't set a mode.
+            return None
+        if v not in _VALID_AUTH_MODES:
+            raise ValueError(
+                f"KLANGK_AUTH_MODES={v!r} is invalid. "
+                f"Must be one of {sorted(_VALID_AUTH_MODES)} (or unset "
+                "→ defaults to 'none')."
+            )
+        return v
 
 
 # ---------------------------------------------------------------------------

--- a/src/backend/klangk_backend/settings.py
+++ b/src/backend/klangk_backend/settings.py
@@ -417,9 +417,6 @@ class KlangkSettings(BaseSettings):
 # Singleton with env-change-detection cache + config-file path
 # ---------------------------------------------------------------------------
 
-_settings_instance: KlangkSettings | None = None
-_settings_env_signature: tuple | None = None
-
 # The config-file path, set by ``klangkd --config <path>`` before the settings
 # are first instantiated.  None means "no config file" (the #1394 env-only
 # behavior); "none" is the explicit opt-out string (same effect).  Any other
@@ -438,12 +435,11 @@ def set_config_file(path: str | None) -> None:
     - ``None`` — reset to the default (no config file; the launcher handles the
       default-location logic).
 
-    Invalidates the settings cache so the next :func:`get_settings` call
-    re-instantiates with the new source chain.
+    ``get_settings()`` is cache-free (re-constructs on every call), so there
+    is no cache to invalidate — the next call simply picks up the new path.
     """
     global _config_file_path
     _config_file_path = path
-    _invalidate_cache()
 
 
 def get_config_file() -> str | None:
@@ -451,42 +447,17 @@ def get_config_file() -> str | None:
     return _config_file_path
 
 
-def _env_signature() -> tuple:
-    """A cheap hash of all KLANGK_* env vars + the config-file path, for
-    change detection."""
-    return (
-        _config_file_path,
-        tuple(
-            sorted(
-                (k, v)
-                for k, v in os.environ.items()
-                if k.startswith("KLANGK_") or k.startswith("LOGFIRE_")
-            )
-        ),
-    )
-
-
 def get_settings() -> KlangkSettings:
-    """Return the settings singleton, re-instantiating if env has changed.
+    """Return a fresh ``KlangkSettings`` from the live environment.
 
-    The env-change detection makes this safe for tests: ``monkeypatch.setenv``
-    / ``monkeypatch.delenv`` changes ``os.environ``, which invalidates the
-    cache, so the next read sees the updated value.  In production (where env
-    is stable), the cache holds for the process lifetime after first access.
+    Cache-free: constructs on every call.  Tests that change the environment
+    via ``monkeypatch.setenv`` / ``delenv`` are automatically correct — the
+    next call reads the updated env.  Production constructs exactly one
+    instance in ``build_app(settings)`` (stored on ``app.state.settings``);
+    this function is the transitional shim for callers not yet migrated to
+    explicit settings threading (#1426).
     """
-    global _settings_instance, _settings_env_signature
-    sig = _env_signature()
-    if _settings_instance is None or sig != _settings_env_signature:
-        _settings_instance = KlangkSettings(os.environ, config_file=_config_file_path)
-        _settings_env_signature = sig
-    return _settings_instance
-
-
-def _invalidate_cache() -> None:
-    """Force the next :func:`get_settings` call to re-instantiate."""
-    global _settings_instance, _settings_env_signature
-    _settings_instance = None
-    _settings_env_signature = None
+    return KlangkSettings(os.environ, config_file=_config_file_path)
 
 
 def validate_at_startup() -> KlangkSettings:
@@ -495,11 +466,9 @@ def validate_at_startup() -> KlangkSettings:
     Call once from the lifespan startup (and from the ``klangkd`` launcher).
     Bogus config (once fields gain strict types) fails here with a
     :class:`ValidationError` before the server serves traffic. Returns the
-    validated settings instance (which also primes the cache).
+    validated settings instance.
     """
-    _invalidate_cache()
-    settings = get_settings()
-    return settings
+    return get_settings()
 
 
 # ---------------------------------------------------------------------------

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -7643,7 +7643,7 @@ class TestOIDCConfig:
             "list_providers",
             lambda: [{"id": "test", "display_name": "Test"}],
         )
-        monkeypatch.setattr(api.oidc, "auth_modes", lambda: "both")
+        monkeypatch.setattr(api.oidc, "auth_modes", lambda *args: "both")
         resp = await client.get("/api/v1/config")
         data = resp.json()
         assert len(data["oidc_providers"]) == 1
@@ -7654,7 +7654,7 @@ class TestOIDCAuthModeGuards:
     async def test_login_blocked_when_oidc_only(
         self, client, monkeypatch, user
     ):
-        monkeypatch.setattr(api.oidc, "password_login_allowed", lambda: False)
+        monkeypatch.setattr(api.oidc, "password_login_allowed", lambda *args: False)
         resp = await client.post(
             "/api/v1/auth/login",
             json={"email": "testuser@example.com", "password": "testpass"},
@@ -7665,7 +7665,7 @@ class TestOIDCAuthModeGuards:
     async def test_register_blocked_when_oidc_only(
         self, client, monkeypatch, db
     ):
-        monkeypatch.setattr(api.oidc, "password_login_allowed", lambda: False)
+        monkeypatch.setattr(api.oidc, "password_login_allowed", lambda *args: False)
         resp = await client.post(
             "/api/v1/auth/register",
             json={"email": "new@example.com", "password": "testpass"},
@@ -7673,7 +7673,7 @@ class TestOIDCAuthModeGuards:
         assert resp.status_code == 403
 
     async def test_login_allowed_when_both(self, client, monkeypatch, user):
-        monkeypatch.setattr(api.oidc, "password_login_allowed", lambda: True)
+        monkeypatch.setattr(api.oidc, "password_login_allowed", lambda *args: True)
         resp = await client.post(
             "/api/v1/auth/login",
             json={"email": "testuser@example.com", "password": "testpass"},
@@ -7683,12 +7683,12 @@ class TestOIDCAuthModeGuards:
 
 class TestOIDCLogin:
     async def test_oidc_login_not_enabled(self, client, monkeypatch):
-        monkeypatch.setattr(api.oidc, "oidc_login_allowed", lambda: False)
+        monkeypatch.setattr(api.oidc, "oidc_login_allowed", lambda *args: False)
         resp = await client.get("/api/v1/auth/oidc/test/login")
         assert resp.status_code == 404
 
     async def test_unknown_provider(self, client, monkeypatch):
-        monkeypatch.setattr(api.oidc, "oidc_login_allowed", lambda: True)
+        monkeypatch.setattr(api.oidc, "oidc_login_allowed", lambda *args: True)
         monkeypatch.setattr(api.oidc, "get_provider", lambda _: None)
         resp = await client.get("/api/v1/auth/oidc/nope/login")
         assert resp.status_code == 404
@@ -7701,7 +7701,7 @@ class TestOIDCLogin:
             client_id="klangk",
             client_secret="s",
         )
-        monkeypatch.setattr(api.oidc, "oidc_login_allowed", lambda: True)
+        monkeypatch.setattr(api.oidc, "oidc_login_allowed", lambda *args: True)
         monkeypatch.setattr(api.oidc, "get_provider", lambda _: provider)
         resp = await client.get(
             "/api/v1/auth/oidc/test/login",
@@ -7718,7 +7718,7 @@ class TestOIDCLogin:
             client_id="klangk",
             client_secret="s",
         )
-        monkeypatch.setattr(api.oidc, "oidc_login_allowed", lambda: True)
+        monkeypatch.setattr(api.oidc, "oidc_login_allowed", lambda *args: True)
         monkeypatch.setattr(api.oidc, "get_provider", lambda _: provider)
         monkeypatch.setattr(
             api.oidc,

--- a/src/backend/tests/test_main.py
+++ b/src/backend/tests/test_main.py
@@ -13,6 +13,7 @@ from httpx import AsyncClient, ASGITransport
 from sqlalchemy.exc import IntegrityError as SAIntegrityError
 
 from klangk_backend import main, model
+from klangk_backend.settings import KlangkSettings
 
 
 # --- Seed default user ---
@@ -893,3 +894,46 @@ class TestPidFile:
         result = main.runtime_dir()
         assert result == tmp_path / ".klangk" / "run"
         assert result.exists()
+
+
+class TestBuildApp:
+    """Tests for build_app() composition root (#1426)."""
+
+    def test_build_app_returns_fastapi(self):
+        settings = KlangkSettings(env={})
+        app = main.build_app(settings)
+        assert isinstance(app, FastAPI)
+
+    def test_build_app_sets_state_settings(self):
+        settings = KlangkSettings(env={})
+        app = main.build_app(settings)
+        assert app.state.settings is settings
+
+    def test_build_app_includes_routers(self):
+        app = main.build_app(KlangkSettings(env={}))
+        paths = set(app.openapi()["paths"].keys())
+        assert "/api/v1/config" in paths  # api router with prefix
+
+    def test_build_app_has_ws_endpoint(self):
+        app = main.build_app(KlangkSettings(env={}))
+        ws_paths = {r.path for r in app.routes if hasattr(r, "path") and r.path == "/ws"}
+        assert "/ws" in ws_paths
+
+    def test_build_app_registers_exception_handlers(self):
+        app = main.build_app(KlangkSettings(env={}))
+        assert model.AgentPrincipalError in app.exception_handlers
+
+    def test_module_app_is_built(self):
+        """The module-level ``app`` shim is a real FastAPI app."""
+        assert isinstance(main.app, FastAPI)
+
+
+class TestGetSettingsDep:
+    """Tests for get_settings_dep per-request bridge (#1426)."""
+
+    def test_returns_app_state_settings(self):
+        settings = KlangkSettings(env={})
+        app = main.build_app(settings)
+        request = MagicMock()
+        request.app = app
+        assert main.get_settings_dep(request) is settings

--- a/src/backend/tests/test_mode_switching.py
+++ b/src/backend/tests/test_mode_switching.py
@@ -7,7 +7,7 @@ steps, then flipping the mode) and asserts the behaviour the
 the docs honest — if a documented flow stops working, these tests fail.
 
 Mode is read live from the environment on every request
-(``oidc.auth_modes()``), so "restart with a different mode" is simulated by
+(``oidc.auth_modes(settings)``), so "restart with a different mode" is simulated by
 re-seeding (the real lifespan step that touches identity) against the *same*
 persistent test database, then changing ``KLANGK_AUTH_MODES`` and continuing
 to hit the same API.

--- a/src/backend/tests/test_nginx.py
+++ b/src/backend/tests/test_nginx.py
@@ -10,7 +10,6 @@ import os
 
 import pytest
 
-from klangk_backend.settings import _invalidate_cache
 from klangk_backend.nginx import (
     compute_client_max_body_size,
     compute_container_acls,
@@ -41,21 +40,17 @@ def _clean_env(monkeypatch):
     for k in list(os.environ):
         if k.startswith("KLANGK_"):
             monkeypatch.delenv(k, raising=False)
-    _invalidate_cache()
     yield
     # Restore: clear any KLANGK_* added by this test, then reinstate snapshot.
     for k in [k for k in list(os.environ) if k.startswith("KLANGK_")]:
         os.environ.pop(k, None)
     os.environ.update(snapshot)
-    _invalidate_cache()
-    _invalidate_cache()
 
 
 def _set(**kw):
-    """Set KLANGK_* env vars + invalidate cache."""
+    """Set KLANGK_* env vars."""
     for k, v in kw.items():
         os.environ["KLANGK_" + k.upper()] = str(v)
-    _invalidate_cache()
 
 
 class TestUpstreams:

--- a/src/backend/tests/test_nginx.py
+++ b/src/backend/tests/test_nginx.py
@@ -296,7 +296,7 @@ class TestMinimalTemplate:
     def test_template_keys_off_listen_not_auth(self):
         """AUTH value does not change which template is rendered (#1398 #4):
         socket ⇒ minimal and TCP ⇒ full across auth values."""
-        for auth in ("none", "password", "password,oidc"):
+        for auth in ("none", "password", "both"):
             _set(
                 listen="/tmp/klangk.sock",
                 auth_modes=auth,

--- a/src/backend/tests/test_oidc.py
+++ b/src/backend/tests/test_oidc.py
@@ -1,5 +1,6 @@
 """Tests for OIDC client module."""
 
+import os
 import time
 from unittest.mock import AsyncMock, patch
 
@@ -9,6 +10,12 @@ import pytest
 
 from klangk_backend import oidc
 from klangk_backend.exceptions import ConfigurationError
+from klangk_backend.settings import KlangkSettings
+
+
+def _settings() -> KlangkSettings:
+    """Build settings from the live (monkeypatched) environment."""
+    return KlangkSettings(os.environ)
 
 
 @pytest.fixture(autouse=True)
@@ -467,9 +474,9 @@ class TestAuthModes:
         # Production default (no OIDC, mode unset) is now ``none`` — a fresh
         # klangk boots in no-login single-user local-dev mode (#1374).
         monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
-        assert oidc.auth_modes() == "none"
-        assert not oidc.password_login_allowed()
-        assert oidc.local_login_allowed()
+        assert oidc.auth_modes(_settings()) == "none"
+        assert not oidc.password_login_allowed(_settings())
+        assert oidc.local_login_allowed(_settings())
 
     def test_default_none_when_oidc_enabled(self, monkeypatch):
         # #1419: OIDC settings no longer change auth_mode. An unset
@@ -479,43 +486,43 @@ class TestAuthModes:
         # the unset default to "both" here; that rule was removed.)
         monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
         oidc._providers.append(_provider())
-        assert oidc.auth_modes() == "none"
-        assert oidc.local_login_allowed()
-        assert not oidc.password_login_allowed()
-        assert not oidc.oidc_login_allowed()
+        assert oidc.auth_modes(_settings()) == "none"
+        assert oidc.local_login_allowed(_settings())
+        assert not oidc.password_login_allowed(_settings())
+        assert not oidc.oidc_login_allowed(_settings())
 
     def test_oidc_only(self, monkeypatch):
         monkeypatch.setenv("KLANGK_AUTH_MODES", "oidc")
         oidc._providers.append(_provider())
-        assert oidc.auth_modes() == "oidc"
-        assert not oidc.password_login_allowed()
-        assert oidc.oidc_login_allowed()
+        assert oidc.auth_modes(_settings()) == "oidc"
+        assert not oidc.password_login_allowed(_settings())
+        assert oidc.oidc_login_allowed(_settings())
 
     def test_password_only(self, monkeypatch):
         monkeypatch.setenv("KLANGK_AUTH_MODES", "password")
         oidc._providers.append(_provider())
-        assert oidc.auth_modes() == "password"
-        assert oidc.password_login_allowed()
-        assert not oidc.oidc_login_allowed()
+        assert oidc.auth_modes(_settings()) == "password"
+        assert oidc.password_login_allowed(_settings())
+        assert not oidc.oidc_login_allowed(_settings())
 
     def test_none_mode(self, monkeypatch):
         monkeypatch.setenv("KLANGK_AUTH_MODES", "none")
-        assert oidc.auth_modes() == "none"
-        assert not oidc.password_login_allowed()
-        assert not oidc.oidc_login_allowed()
-        assert oidc.local_login_allowed()
+        assert oidc.auth_modes(_settings()) == "none"
+        assert not oidc.password_login_allowed(_settings())
+        assert not oidc.oidc_login_allowed(_settings())
+        assert oidc.local_login_allowed(_settings())
 
     def test_none_mode_ignores_oidc_config(self, monkeypatch):
         # OIDC config may be present but is irrelevant in none mode.
         oidc._providers.append(_provider())
         monkeypatch.setenv("KLANGK_AUTH_MODES", "none")
-        assert oidc.auth_modes() == "none"
-        assert oidc.local_login_allowed()
+        assert oidc.auth_modes(_settings()) == "none"
+        assert oidc.local_login_allowed(_settings())
 
     def test_local_login_false_in_other_modes(self, monkeypatch):
         for mode in ("password", "oidc", "both"):
             monkeypatch.setenv("KLANGK_AUTH_MODES", mode)
-            assert not oidc.local_login_allowed()
+            assert not oidc.local_login_allowed(_settings())
 
     # --- AUTH_MODES unset defaults to ``none`` (no amalgamated setting) ---
     # #1422 removed KLANGK_PRESET/KLANGK_UI_MODE — AUTH_MODES is the sole
@@ -524,17 +531,17 @@ class TestAuthModes:
 
     def test_unset_defaults_to_none(self, monkeypatch):
         monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
-        assert oidc.auth_modes() == "none"
-        assert oidc.local_login_allowed()
-        assert not oidc.password_login_allowed()
+        assert oidc.auth_modes(_settings()) == "none"
+        assert oidc.local_login_allowed(_settings())
+        assert not oidc.password_login_allowed(_settings())
 
     def test_unset_stays_none_with_oidc_configured(self, monkeypatch):
         # OIDC presence never flips the mode (#1419) — operator must set
         # KLANGK_AUTH_MODES=oidc/both explicitly.
         monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
-        assert oidc.auth_modes() == "none"
+        assert oidc.auth_modes(_settings()) == "none"
         oidc._providers.append(_provider())
-        assert oidc.auth_modes() == "none"
+        assert oidc.auth_modes(_settings()) == "none"
 
 
 class TestClientKwargs:

--- a/src/backend/tests/test_settings.py
+++ b/src/backend/tests/test_settings.py
@@ -29,16 +29,6 @@ from klangk_backend.settings import (
 )
 
 
-@pytest.fixture(autouse=True)
-def _reset_settings():
-    """Ensure a clean KLANGK_* environment around each test.
-
-    get_settings() is cache-free (constructs on every call), so there is no
-    cache to clear — the fixture just ensures a clean env snapshot.
-    """
-    yield
-
-
 class TestKeyToField:
     def test_klangk_prefix(self):
         assert _key_to_field("KLANGK_JWT_SECRET") == "jwt_secret"
@@ -447,3 +437,47 @@ class TestEnvConstructor:
             env={"KLANGK_PRODUCT_NAME": "FromEnv"}, config_file=str(cfg)
         )
         assert s.product_name == "FromEnv"
+
+
+class TestAuthModesValidator:
+    """KLANGK_AUTH_MODES is security-sensitive: a typo must fail at
+    construction (boot), not silently downgrade to the no-auth ``none`` mode
+    (which freely issues an admin token)."""
+
+    @pytest.mark.parametrize("mode", ["password", "oidc", "both", "none"])
+    def test_valid_modes_accepted(self, mode):
+        s = KlangkSettings(env={"KLANGK_AUTH_MODES": mode})
+        assert s.auth_modes == mode
+
+    def test_unset_allowed_means_none(self):
+        # None = unset = "default to none at read time" (legitimate).
+        s = KlangkSettings(env={})
+        assert s.auth_modes is None
+
+    @pytest.mark.parametrize(
+        "bad", ["passdword", "PASSWORD", " true", "x", "None"]
+    )
+    def test_typo_rejected_at_construction(self, bad):
+        # A set-but-garbage value must raise (not silently become "none").
+        import pytest as _pytest
+        from pydantic import ValidationError
+
+        with _pytest.raises(ValidationError):
+            KlangkSettings(env={"KLANGK_AUTH_MODES": bad})
+
+    def test_empty_string_treated_as_unset(self):
+        # KLANGK_AUTH_MODES="" (set but blank) is treated as unset → None →
+        # "none" at read time, preserving the pre-validator behavior.
+        # (Not a security risk: blank is a config mistake, not a typo'd
+        # secure-mode name silently degrading.)
+        s = KlangkSettings(env={"KLANGK_AUTH_MODES": ""})
+        assert s.auth_modes is None
+
+    def test_typo_error_message_lists_valid_modes(self):
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError) as exc_info:
+            KlangkSettings(env={"KLANGK_AUTH_MODES": "passdword"})
+        msg = str(exc_info.value)
+        assert "passdword" in msg
+        assert "password" in msg  # valid modes listed in the message

--- a/src/backend/tests/test_settings.py
+++ b/src/backend/tests/test_settings.py
@@ -30,11 +30,13 @@ from klangk_backend.settings import (
 
 
 @pytest.fixture(autouse=True)
-def _reset_settings_cache():
-    """Clear the settings cache before and after each test."""
-    settings_mod._invalidate_cache()
+def _reset_settings():
+    """Ensure a clean KLANGK_* environment around each test.
+
+    get_settings() is cache-free (constructs on every call), so there is no
+    cache to clear — the fixture just ensures a clean env snapshot.
+    """
     yield
-    settings_mod._invalidate_cache()
 
 
 class TestKeyToField:
@@ -96,16 +98,22 @@ class TestGetSettings:
         assert s.nginx_port == "12345"
 
     def test_cache_invalidated_on_env_change(self, monkeypatch):
+        # get_settings() is cache-free — constructs on every call. Env
+        # changes are automatically picked up (no cache to invalidate).
         monkeypatch.setenv("KLANGK_NGINX_PORT", "1111")
         assert get_settings().nginx_port == "1111"
         monkeypatch.setenv("KLANGK_NGINX_PORT", "2222")
         assert get_settings().nginx_port == "2222"
 
-    def test_cache_holds_when_env_stable(self, monkeypatch):
+    def test_cache_free_fresh_each_call(self, monkeypatch):
+        # get_settings() constructs a new instance every call (cache machinery
+        # deleted in #1426 Slice 1). Two calls return equivalent but distinct
+        # objects.
         monkeypatch.setenv("KLANGK_NGINX_PORT", "3333")
         s1 = get_settings()
         s2 = get_settings()
-        assert s1 is s2
+        assert s1 is not s2
+        assert s1 == s2
 
     def test_delenv_invalidates(self, monkeypatch):
         monkeypatch.setenv("KLANGK_AUTH_MODES", "none")
@@ -171,9 +179,12 @@ class TestValidateAtStartup:
         s = validate_at_startup()
         assert isinstance(s, KlangkSettings)
 
-    def test_primes_cache(self):
+    def test_reads_env(self, monkeypatch):
+        # validate_at_startup() is cache-free now (no cache to prime); it just
+        # constructs settings from the live env.
+        monkeypatch.setenv("KLANGK_NGINX_PORT", "5555")
         s = validate_at_startup()
-        assert get_settings() is s
+        assert s.nginx_port == "5555"
 
     def test_re_validates_after_env_change(self, monkeypatch):
         monkeypatch.setenv("KLANGK_NGINX_PORT", "5555")
@@ -322,18 +333,15 @@ class TestClassifyListen:
 class TestListenIsSocket:
     def test_true_when_listen_is_socket_path(self, monkeypatch):
         monkeypatch.setenv("KLANGK_LISTEN", "/tmp/klangk.sock")
-        settings_mod._invalidate_cache()
         assert listen_is_socket() is True
 
     def test_false_when_listen_is_tcp(self, monkeypatch):
         monkeypatch.setenv("KLANGK_LISTEN", "127.0.0.1")
-        settings_mod._invalidate_cache()
         assert listen_is_socket() is False
 
     def test_false_for_default(self, monkeypatch):
         # The default (127.0.0.1) is TCP; #1400 will flip this to a socket.
         monkeypatch.delenv("KLANGK_LISTEN", raising=False)
-        settings_mod._invalidate_cache()
         assert listen_is_socket() is False
 
 


### PR DESCRIPTION
Part of #1426 (composition-root refactor). Completes the remaining Slice 1 (#1447) work after the `env`/`config_file` constructor landed in #1448.

## What this PR does

### 1. `build_app(settings)` composition root
- Wraps app construction (FastAPI, CORS, routers, exception handlers, WS endpoint, static files) into a single factory function.
- Sets `app.state.settings = settings` at construction time.
- Module-level `app = build_app(get_settings())` remains as a shim for uvicorn's string import.

### 2. `get_settings_dep(request)` per-request bridge
- Returns `request.app.state.settings`. Request handlers obtain frozen settings via `Depends(get_settings_dep)` instead of the module-level global.

### 3. Cache machinery deleted
- `_settings_instance`, `_settings_env_signature`, `_env_signature()`, `_invalidate_cache()` all removed. `get_settings()` is now cache-free (constructs a fresh `KlangkSettings` on every call). The env-signature cache was the most complex global in `settings.py`; it's gone.

### 4. `oidc.auth_modes(settings)` + predicates
- `auth_modes()`, `password_login_allowed()`, `local_login_allowed()`, `oidc_login_allowed()` now take a `KlangkSettings` arg and read `settings.auth_modes` instead of `resolve_env_value("KLANGK_AUTH_MODES")` at call time. Stepping stone — Slice 3 (#1450) absorbs the `settings` param into `self.settings` when these become methods on `OIDC(settings)`.

## What's deferred
- **`_config_file_path` global / `set_config_file()` / `get_config_file()` deletion** — deferred to a follow-up (klangkd + ~15 test callers need migration). `get_settings()` passes `config_file=_config_file_path` explicitly so the coupling is visible.

## Test changes
- `test_settings.py`: cache-identity tests → distinct-object tests; `_invalidate_cache()` calls removed.
- `test_nginx.py`: `_invalidate_cache()` calls + import removed.
- `test_oidc.py`: constructs `KlangkSettings(os.environ)` after monkeypatch for the auth-modes tests.
- `test_api.py`: oidc lambda mocks accept `*args`.
- `test_main.py`: new `TestBuildApp` + `TestGetSettingsDep` classes.

2365 passed, 100% coverage, 0 warnings.
