### PR TITLE
Slice 1 remainder: delete _config_file_path global + dead validate_at_startup() (#1426)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -7,18 +7,33 @@ A multi-slice refactor to eliminate module-level mutable globals from
 factory. The tracking issue is **#1426**. Every actionable slice has its own
 issue (see "Issue map" below).
 
-**Current branch**: `issue-1447-klangksettings-env-constructor-for-injectable-env-dicts-1426`
-**Current PR**: [#1455](https://github.com/mcdonc/klangk/pull/1455) (OPEN)
-**Test state**: 2377 passed, 100% coverage, 0 warnings
+**Current branch**: `issue-1458-slice-1-remainder-delete-config-file-path-global-dead-valida`
+**Current PR**: [#1460](https://github.com/mcdonc/klangk/pull/1460) (OPEN — Slice 1 final cleanup)
+**Test state**: 2370 passed, 100% coverage, 0 warnings
+
+## Slice 1 is DONE
+
+Three PRs land Slice 1. **#1448 and #1455 are merged** (on `main`);
+**#1460 is open** (this branch — the final cleanup).
+
+- **#1448 (merged)** — `KlangkSettings(env, config_file=None)` constructor.
+- **#1455 (merged)** — `build_app(settings)` composition root,
+  `get_settings_dep`, oidc settings threading, `auth_modes` validator,
+  cache machinery deletion.
+- **#1460 (this PR)** — delete `_config_file_path` global + dead
+  `validate_at_startup()`. Completes Slice 1.
+
+After #1460 merges, **Slice 1 (#1447) is complete** and **#1449 (Slice 2)**
+starts.
 
 ## Issue map
 
 | Issue | Title | State |
 |-------|-------|-------|
 | **#1426** | Tracker: one composition root, no module globals | umbrella |
-| **#1447** | Slice 1 — `KlangkSettings(env=...)` + settings threading | in progress (#1455) |
-| **#1458** | Slice 1 remainder — delete `_config_file_path` global | next |
-| **#1449** | Slice 2 — ContainerRegistry owned instance | |
+| **#1447** | Slice 1 — `KlangkSettings(env=...)` + settings threading | ✅ done (#1448 + #1455 + #1460) |
+| **#1458** | Slice 1 remainder — delete `_config_file_path` global | ✅ done (#1460) |
+| **#1449** | Slice 2 — ContainerRegistry owned instance | **next** |
 | **#1450** | Slice 3 — OIDC instance + caches | |
 | **#1451** | Slice 4 — Plugins instance | |
 | **#1452** | Slice 5 — `DB(settings)`; kill db globals | |
@@ -26,8 +41,10 @@ issue (see "Issue map" below).
 | **#1454** | Slice 7 — delete the `main:app` shim | |
 | **#1456** | Standalone — `frontend_dir` config setting | |
 | **#1457** | Standalone — tests stop monkeypatching `os.environ` | |
+| **#1459** | Standalone — `state_dir` field default (no env mutation) | |
+| **#1461** | Standalone — resolve `file:`/`cmd:` at construction; delete `resolve_indirection` | |
 
-The next-step chain after #1455 merges: **#1458** → Slice 1 done →
+The next-step chain after #1460 merges: Slice 1 done →
 **#1449** (Slice 2) → #1450 → #1451 → #1452 → #1453 → #1454.
 
 ## Slice 1: what's DONE

--- a/src/backend/klangk_backend/klangkd.py
+++ b/src/backend/klangk_backend/klangkd.py
@@ -30,10 +30,8 @@ import typer
 import uvicorn
 
 from klangk_backend.settings import (
-    get_settings,
+    KlangkSettings,
     resolve_indirection,
-    set_config_file,
-    validate_at_startup,
 )
 from klangk_backend.util import set_uds_mode
 
@@ -97,20 +95,15 @@ def main(  # pragma: no cover
 
     # Seed the state_dir default into the env so the settings model can pick
     # it up as the lowest-priority default (config file > env > this). Done
-    # before set_config_file so the YAML source sees a consistent env.
+    # before constructing settings so the YAML source sees a consistent env.
     os.environ.setdefault("KLANGK_STATE_DIR", _default_state_dir())
-
-    # Set the config-file path on the settings module before anything reads
-    # config. This wires the YAML source into the customise_sources chain.
-    set_config_file(resolved)
-    # Eagerly validate — a bogus config fails here, before uvicorn starts.
-    validate_at_startup()
 
     # Everything below reads through the typed config (config file > env >
     # defaults, with file:/cmd: resolution), NOT raw os.environ — so a YAML
     # value or a ``file:``/``cmd:`` prefix takes effect the same as an env
-    # var (#1394/#1395).
-    settings = get_settings()
+    # var (#1394/#1395). Construction runs field validators (fail-fast on
+    # bogus config) before uvicorn starts.
+    settings = KlangkSettings(os.environ, config_file=resolved)
 
     # uvicorn always binds a UDS (#1400). ``KLANGK_LISTEN`` is polymorphic
     # (#1422) but only controls what *nginx* does: a socket path → nginx

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -32,7 +32,6 @@ from .settings import (
     KlangkSettings,
     get_settings,
     resolve_indirection,
-    validate_at_startup,
 )
 from .api import root_router, router
 from .util import API_PREFIX, derive_hosting_info
@@ -544,12 +543,6 @@ def on_sighup() -> None:
 async def lifespan(app: FastAPI):
     await model.init_db()
     await model.resolve_instance_id()
-
-    # Eagerly validate all config at startup (#1394).  Instantiate the
-    # KlangkSettings singleton so bogus values fail fast before the server
-    # serves traffic.  (Fields are Optional[str] in this chunk; strict types
-    # arrive incrementally as call sites migrate to settings.field access.)
-    validate_at_startup()
 
     existing_pid = check_pid_file()
     if existing_pid is not None:

--- a/src/backend/klangk_backend/settings.py
+++ b/src/backend/klangk_backend/settings.py
@@ -16,13 +16,12 @@ Design (see #1392, #1394):
   Both paths produce identical results regardless of whether the value came
   from an env var or (future) a config file — capability is a property of the
   value, not the source.
-- **Env-change-detection cache** (:func:`get_settings`): the settings singleton
-  is re-instantiated whenever any ``KLANGK_*`` env var changes, so
-  ``monkeypatch.setenv`` / ``monkeypatch.delenv`` in tests invalidates the
-  cache automatically — preserving the call-time env-reading behavior that
-  ~337 test env-manipulations rely on.
-- **Startup validation**: :func:`validate_at_startup` instantiates the model
-  eagerly so bogus config fails fast, before the server serves traffic.
+- **Env-change-detection cache** (:func:`get_settings`): cache-free —
+  re-constructs on every call, so ``monkeypatch.setenv`` /
+  ``monkeypatch.delenv`` in tests is picked up automatically.
+- **Startup validation**: field validators (e.g. ``auth_modes``) run at
+  construction, so bogus config fails fast when ``KlangkSettings(...)`` is
+  first built in ``build_app(settings)``.
 """
 
 from __future__ import annotations
@@ -59,7 +58,6 @@ __all__ = [
     "resolve_env_value",
     "resolve_env_bool",
     "resolve_indirection",
-    "validate_at_startup",
 ]
 
 # ---------------------------------------------------------------------------
@@ -275,13 +273,8 @@ class KlangkSettings(BaseSettings):
             else env_settings
         )
         sources: list[PydanticBaseSettingsSource] = [active_env]
-        # config_file from the constructor (class-var bridge) takes precedence
-        # over the legacy module global (_config_file_path / set_config_file).
-        # The module global dies once all callers (klangkd + tests) migrate to
-        # passing config_file= to the constructor (follow-up to this commit).
+        # config_file from the constructor (class-var bridge).
         path = cls._config_file_for_sources
-        if path is None:
-            path = _config_file_path
         if path is not None and path != "none":
             sources.append(
                 YamlConfigSettingsSource(settings_cls, yaml_file=path)
@@ -432,8 +425,9 @@ class KlangkSettings(BaseSettings):
         unset case, which legitimately means "default to none"); only a
         *set-but-garbage* value is rejected.
 
-        Runs at construction (``KlangkSettings(...)`` → ``validate_at_startup``
-        in the lifespan), so the bad value aborts boot before traffic.
+        Runs at construction (``KlangkSettings(...)``), so the bad value aborts
+        boot (via ``build_app(settings)`` → ``app.state.settings``) before
+        traffic.
         """
         if v is None or v == "":
             # Unset or empty → default to ``none`` at read time (in
@@ -452,36 +446,6 @@ class KlangkSettings(BaseSettings):
 # Singleton with env-change-detection cache + config-file path
 # ---------------------------------------------------------------------------
 
-# The config-file path, set by ``klangkd --config <path>`` before the settings
-# are first instantiated.  None means "no config file" (the #1394 env-only
-# behavior); "none" is the explicit opt-out string (same effect).  Any other
-# value is a filesystem path to a YAML config file.
-_config_file_path: str | None = None
-
-
-def set_config_file(path: str | None) -> None:
-    """Set the config-file path (called by the ``klangkd`` launcher).
-
-    ``path`` is one of:
-    - A filesystem path to a YAML config file (must exist when settings are
-      instantiated; checked by the launcher, not here).
-    - ``"none"`` — the explicit opt-out: run from env vars + built-in defaults
-      only, no config file (#1394 behavior, made explicit).
-    - ``None`` — reset to the default (no config file; the launcher handles the
-      default-location logic).
-
-    ``get_settings()`` is cache-free (re-constructs on every call), so there
-    is no cache to invalidate — the next call simply picks up the new path.
-    """
-    global _config_file_path
-    _config_file_path = path
-
-
-def get_config_file() -> str | None:
-    """Return the currently-set config-file path (or None)."""
-    return _config_file_path
-
-
 def get_settings() -> KlangkSettings:
     """Return a fresh ``KlangkSettings`` from the live environment.
 
@@ -492,18 +456,7 @@ def get_settings() -> KlangkSettings:
     this function is the transitional shim for callers not yet migrated to
     explicit settings threading (#1426).
     """
-    return KlangkSettings(os.environ, config_file=_config_file_path)
-
-
-def validate_at_startup() -> KlangkSettings:
-    """Instantiate settings eagerly for fail-fast validation at boot.
-
-    Call once from the lifespan startup (and from the ``klangkd`` launcher).
-    Bogus config (once fields gain strict types) fails here with a
-    :class:`ValidationError` before the server serves traffic. Returns the
-    validated settings instance.
-    """
-    return get_settings()
+    return KlangkSettings(os.environ)
 
 
 # ---------------------------------------------------------------------------

--- a/src/backend/tests/test_oidc.py
+++ b/src/backend/tests/test_oidc.py
@@ -283,9 +283,7 @@ class TestLoadConfig:
 class TestInlineProviders:
     """OIDC providers specified inline in the klangkd config file (#1395)."""
 
-    def test_inline_providers_loaded(self, tmp_path):
-        from klangk_backend.settings import set_config_file
-
+    def test_inline_providers_loaded(self, tmp_path, monkeypatch):
         cfg = tmp_path / "config.yaml"
         cfg.write_text(
             "oidc_providers:\n"
@@ -295,22 +293,23 @@ class TestInlineProviders:
             "    client-id: klangk\n"
             '    client-secret: "inline-secret"\n'
         )
-        set_config_file(str(cfg))
-        try:
-            providers = oidc.load_config()
-            assert len(providers) == 1
-            assert providers[0].id == "inline"
-            assert providers[0].display_name == "Inline IdP"
-            assert providers[0].client_secret == "inline-secret"
-            assert providers[0].issuer == "https://idp.example.com"
-        finally:
-            set_config_file(None)
+        from klangk_backend.settings import KlangkSettings
+
+        monkeypatch.setattr(
+            oidc,
+            "get_settings",
+            lambda: KlangkSettings(env={}, config_file=str(cfg)),
+        )
+        providers = oidc.load_config()
+        assert len(providers) == 1
+        assert providers[0].id == "inline"
+        assert providers[0].display_name == "Inline IdP"
+        assert providers[0].client_secret == "inline-secret"
+        assert providers[0].issuer == "https://idp.example.com"
 
     def test_external_file_overrides_inline(self, monkeypatch, tmp_path):
         """When both inline and external are configured, external wins
         (env var override, consistent with env > file precedence)."""
-        from klangk_backend.settings import set_config_file
-
         # External file via env var
         ext = tmp_path / "oidc.yaml"
         ext.write_text(
@@ -338,18 +337,19 @@ class TestInlineProviders:
             "    client-id: klangk\n"
             '    client-secret: "inline"\n'
         )
-        set_config_file(str(cfg))
-        try:
-            providers = oidc.load_config()
-            assert len(providers) == 1
-            assert providers[0].id == "external"
-        finally:
-            set_config_file(None)
+        from klangk_backend.settings import KlangkSettings
 
-    def test_inline_file_secret_resolution(self, tmp_path):
+        monkeypatch.setattr(
+            oidc,
+            "get_settings",
+            lambda: KlangkSettings(env={}, config_file=str(cfg)),
+        )
+        providers = oidc.load_config()
+        assert len(providers) == 1
+        assert providers[0].id == "external"
+
+    def test_inline_file_secret_resolution(self, tmp_path, monkeypatch):
         """file: prefix in inline provider secrets resolves correctly."""
-        from klangk_backend.settings import set_config_file
-
         secret = tmp_path / "secret.txt"
         secret.write_text("resolved-secret\n")
         cfg = tmp_path / "config.yaml"
@@ -361,16 +361,17 @@ class TestInlineProviders:
             "    client-id: klangk\n"
             f'    client-secret: "file:{secret}"\n'
         )
-        set_config_file(str(cfg))
-        try:
-            providers = oidc.load_config()
-            assert providers[0].client_secret == "resolved-secret"
-        finally:
-            set_config_file(None)
+        from klangk_backend.settings import KlangkSettings
 
-    def test_inline_multiple_providers(self, tmp_path):
-        from klangk_backend.settings import set_config_file
+        monkeypatch.setattr(
+            oidc,
+            "get_settings",
+            lambda: KlangkSettings(env={}, config_file=str(cfg)),
+        )
+        providers = oidc.load_config()
+        assert providers[0].client_secret == "resolved-secret"
 
+    def test_inline_multiple_providers(self, tmp_path, monkeypatch):
         cfg = tmp_path / "config.yaml"
         cfg.write_text(
             "oidc_providers:\n"
@@ -385,14 +386,17 @@ class TestInlineProviders:
             "    client-id: klangk\n"
             '    client-secret: "sb"\n'
         )
-        set_config_file(str(cfg))
-        try:
-            providers = oidc.load_config()
-            assert len(providers) == 2
-            assert providers[0].id == "a"
-            assert providers[1].id == "b"
-        finally:
-            set_config_file(None)
+        from klangk_backend.settings import KlangkSettings
+
+        monkeypatch.setattr(
+            oidc,
+            "get_settings",
+            lambda: KlangkSettings(env={}, config_file=str(cfg)),
+        )
+        providers = oidc.load_config()
+        assert len(providers) == 2
+        assert providers[0].id == "a"
+        assert providers[1].id == "b"
 
     def test_falls_back_to_external_when_no_inline(
         self, monkeypatch, tmp_path

--- a/src/backend/tests/test_settings.py
+++ b/src/backend/tests/test_settings.py
@@ -2,30 +2,23 @@
 
 Covers:
 - file: / cmd: indirection resolution (success + error paths)
-- get_settings env-change-detection cache
+- KlangkSettings(env=...) constructor + config_file= param
 - resolve_env_value (KLANGK_ and non-KLANGK_ keys)
 - resolve_env_bool
-- validate_at_startup
 - _key_to_field mapping
 """
 
-import os
-
 import pytest
 
-from klangk_backend import settings as settings_mod
 from klangk_backend.settings import (
     KlangkSettings,
     _key_to_field,
-    get_config_file,
     get_settings,
     resolve_env_bool,
     resolve_env_value,
     classify_listen,
     listen_is_socket,
     resolve_indirection,
-    set_config_file,
-    validate_at_startup,
 )
 
 
@@ -164,24 +157,6 @@ class TestResolveEnvBool:
         assert resolve_env_bool("KLANGK_NONEXISTENT", True) is True
 
 
-class TestValidateAtStartup:
-    def test_returns_settings(self):
-        s = validate_at_startup()
-        assert isinstance(s, KlangkSettings)
-
-    def test_reads_env(self, monkeypatch):
-        # validate_at_startup() is cache-free now (no cache to prime); it just
-        # constructs settings from the live env.
-        monkeypatch.setenv("KLANGK_NGINX_PORT", "5555")
-        s = validate_at_startup()
-        assert s.nginx_port == "5555"
-
-    def test_re_validates_after_env_change(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_NGINX_PORT", "5555")
-        validate_at_startup()
-        assert get_settings().nginx_port == "5555"
-
-
 class TestSettingsModel:
     def test_extra_ignored(self, monkeypatch):
         """Unknown KLANGK_ keys are tolerated (extra='ignore')."""
@@ -215,45 +190,31 @@ class TestConfigFile:
         """A YAML config file provides values that env doesn't override."""
         cfg = tmp_path / "config.yaml"
         cfg.write_text('logo_url: "https://example.com/logo.png"\n')
-        set_config_file(str(cfg))
-        s = get_settings()
+        s = KlangkSettings(env={}, config_file=str(cfg))
         assert s.logo_url == "https://example.com/logo.png"
 
-    def test_env_overrides_yaml(self, monkeypatch, tmp_path):
+    def test_env_overrides_yaml(self, tmp_path):
         """Env vars override YAML file values (precedence)."""
         cfg = tmp_path / "config.yaml"
         cfg.write_text('brand_color: "#FF0000"\n')
-        set_config_file(str(cfg))
-        monkeypatch.setenv("KLANGK_BRAND_COLOR", "#00FF00")
-        s = get_settings()
+        s = KlangkSettings(
+            env={"KLANGK_BRAND_COLOR": "#00FF00"}, config_file=str(cfg)
+        )
         assert s.brand_color == "#00FF00"
 
-    def test_yaml_doesnt_override_env(self, monkeypatch, tmp_path):
+    def test_yaml_doesnt_override_env(self, tmp_path):
         """A key set in both env and YAML: env wins."""
         cfg = tmp_path / "config.yaml"
         cfg.write_text('product_name: "From YAML"\n')
-        set_config_file(str(cfg))
-        monkeypatch.setenv("KLANGK_PRODUCT_NAME", "From Env")
-        s = get_settings()
+        s = KlangkSettings(
+            env={"KLANGK_PRODUCT_NAME": "From Env"}, config_file=str(cfg)
+        )
         assert s.product_name == "From Env"
 
-    def test_config_none_opt_out(self, monkeypatch):
-        """--config=none: no file, env+defaults only."""
-        monkeypatch.delenv("KLANGK_NGINX_PORT", raising=False)
-        set_config_file("none")
-        s = get_settings()
+    def test_config_none_opt_out(self):
+        """config_file='none': no file, env+defaults only."""
+        s = KlangkSettings(env={}, config_file="none")
         assert s.nginx_port == "8995"  # built-in default
-
-    def test_set_config_file_invalidates_cache(self, tmp_path):
-        """Changing the config-file path re-instantiates settings."""
-        cfg1 = tmp_path / "c1.yaml"
-        cfg1.write_text('product_name: "First"\n')
-        set_config_file(str(cfg1))
-        assert get_settings().product_name == "First"
-        cfg2 = tmp_path / "c2.yaml"
-        cfg2.write_text('product_name: "Second"\n')
-        set_config_file(str(cfg2))
-        assert get_settings().product_name == "Second"
 
     def test_file_cmd_resolution_from_yaml(self, tmp_path):
         """file:/cmd: values in YAML resolve correctly."""
@@ -261,17 +222,8 @@ class TestConfigFile:
         secret.write_text("yaml-secret\n")
         cfg = tmp_path / "config.yaml"
         cfg.write_text(f'jwt_secret: "file:{secret}"\n')
-        set_config_file(str(cfg))
-        # resolve_env_value applies file:/cmd: resolution
-        assert resolve_env_value("KLANGK_JWT_SECRET") == "yaml-secret"
-
-    def test_get_config_file(self, tmp_path):
-        cfg = tmp_path / "config.yaml"
-        cfg.write_text("product_name: test\n")
-        set_config_file(str(cfg))
-        assert get_config_file() == str(cfg)
-        set_config_file(None)
-        assert get_config_file() is None
+        s = KlangkSettings(env={}, config_file=str(cfg))
+        assert resolve_indirection(s.jwt_secret) == "yaml-secret"
 
 
 # ---------------------------------------------------------------------------
@@ -379,13 +331,6 @@ class TestEnvConstructor:
         assert s.default_user == "admin@example.com"
         assert s.min_password_length == "8"
 
-    def test_default_reads_os_environ(self, monkeypatch):
-        # KlangkSettings(os.environ) reads from os.environ; monkeypatch.setenv
-        # mutates os.environ, so the constructed settings see the value.
-        monkeypatch.setenv("KLANGK_AUTH_MODES", "oidc")
-        s = KlangkSettings(os.environ)
-        assert s.auth_modes == "oidc"
-
     def test_env_for_sources_reset_after_construction(self):
         # The class-var bridge is cleaned up after construction so it doesn't
         # leak between instances.
@@ -405,29 +350,11 @@ class TestEnvConstructor:
         assert s.default_user == "admin@test.com"
 
     def test_config_file_param_loads_yaml(self, tmp_path):
-        # The config_file= constructor param wires a YAML source in, with no
-        # help from the module-global set_config_file().
+        # The config_file= constructor param wires a YAML source in.
         cfg = tmp_path / "config.yaml"
         cfg.write_text("product_name: FromConfigFile\n")
         s = KlangkSettings(env={}, config_file=str(cfg))
         assert s.product_name == "FromConfigFile"
-
-    def test_config_file_param_beats_module_global(self, tmp_path, monkeypatch):
-        # When both the constructor param and the module global are set, the
-        # constructor param wins (it's the intended path; the global is the
-        # legacy fallback slated for deletion).
-        from klangk_backend.settings import set_config_file
-
-        global_cfg = tmp_path / "global.yaml"
-        global_cfg.write_text("product_name: FromGlobal\n")
-        param_cfg = tmp_path / "param.yaml"
-        param_cfg.write_text("product_name: FromParam\n")
-        set_config_file(str(global_cfg))
-        try:
-            s = KlangkSettings(env={}, config_file=str(param_cfg))
-            assert s.product_name == "FromParam"
-        finally:
-            set_config_file(None)
 
     def test_env_overrides_config_file(self, tmp_path):
         # Precedence: env dict > config file.


### PR DESCRIPTION
Closes #1458. Completes Slice 1 (#1447).

## What this PR does

### 1. Delete the `_config_file_path` global
The `_config_file_path` module global (plus `set_config_file()` / `get_config_file()`) was the last module-level mutable global in `settings.py`. The `config_file=` constructor param (landed in #1448) is the replacement; this migrates the last callers and deletes the global.

- **klangkd.py**: `set_config_file(resolved)` → `KlangkSettings(os.environ, config_file=resolved)` directly.
- **settings.py**: deleted `_config_file_path`, `set_config_file()`, `get_config_file()`. `get_settings()` returns `KlangkSettings(os.environ)` (no config_file — the shim is for the `main:app` import only). `settings_customise_sources` reads config_file from the class-var bridge only (no global fallback).
- **Tests migrated**: `TestConfigFile` uses `config_file=` constructor param; `TestInlineProviders` (test_oidc.py) monkeypatches `oidc.get_settings` to return a `KlangkSettings(env={}, config_file=...)` (since `load_config()` reads `get_settings()` internally — migrates to explicit settings in Slice 3 / #1450).

### 2. Delete dead `validate_at_startup()`
`validate_at_startup()` was a one-line alias (`return get_settings()`) after the cache machinery deletion (#1455). The validation it's named for is now just `KlangkSettings` construction (field validators run on every build). Both call sites were redundant. Deleted the def + `__all__` entry, both call sites, `TestValidateAtStartup` class, and docstring references.

### 3. Cleanup
- Removed `test_default_reads_os_environ` (mistitled/unnecessary — covered by `test_reads_from_env_dict`).
- Removed dead imports (`os`, `settings_mod`) from `test_settings.py`.

## State after this PR
**Slice 1 (#1447) is complete.** Next: Slice 2 (#1449 — ContainerRegistry owned instance).

2370 passed, 100% coverage, 0 warnings.
