### PR TITLE
Slice 2a: ContainerRegistry(settings) + build_app wiring + nginx/podman settings (#1449)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -4,136 +4,123 @@
 
 A multi-slice refactor to eliminate module-level mutable globals from
 `klangk_backend` in favor of one composition root: a `build_app(settings)`
-factory. The tracking issue is **#1426**. Every actionable slice has its own
-issue (see "Issue map" below).
+factory. The tracking issue is **#1426**.
 
-**Current branch**: `issue-1458-slice-1-remainder-delete-config-file-path-global-dead-valida`
-**Current PR**: [#1460](https://github.com/mcdonc/klangk/pull/1460) (OPEN — Slice 1 final cleanup)
-**Test state**: 2370 passed, 100% coverage, 0 warnings
+**Current branch**: `issue-1449-slice-2-promote-containerregistry-to-an-owned-instance-1426`
+**Current PR**: [#1466](https://github.com/mcdonc/klangk/pull/1466) (Slice 2a — CI running)
+**Test state**: 2374 passed, 100% coverage, 0 warnings
 
-## Slice 1 is DONE
+## Where we are
 
-Three PRs land Slice 1. **#1448 and #1455 are merged** (on `main`);
-**#1460 is open** (this branch — the final cleanup).
+**Slice 1 is DONE** (merged: #1448, #1455, #1460). **Slice 2 is in progress**
+(PR #1466 implements Slice 2a). The four Slice 2 sub-issues (#1462–#1465)
+decompose the original Slice 2 (#1449) into independently-shippable PRs.
 
-- **#1448 (merged)** — `KlangkSettings(env, config_file=None)` constructor.
-- **#1455 (merged)** — `build_app(settings)` composition root,
-  `get_settings_dep`, oidc settings threading, `auth_modes` validator,
-  cache machinery deletion.
-- **#1460 (this PR)** — delete `_config_file_path` global + dead
-  `validate_at_startup()`. Completes Slice 1.
+## Suggested ordering for remaining work
 
-After #1460 merges, **Slice 1 (#1447) is complete** and **#1449 (Slice 2)**
-starts.
+The 7 original slices (#1447–#1454) had a fixed linear chain. The refactor
+has since spawned standalone issues (#1456–#1469) that interleave. This is
+the suggested order, grouped by theme, with dependencies noted:
+
+### Phase 1: finish Slice 2 (container subsystem)
+1. **#1462 / PR #1466 (Slice 2a)** — `ContainerRegistry(settings)` +
+   build_app wiring + nginx/podman settings threading. **In progress.**
+2. **#1463 (Slice 2b)** — `NginxWatchdog` class → `app.state.nginx_watchdog`.
+   Depends on 2a (the nginx renderer settings params land in #1466; the
+   watchdog absorbs `_prepare_nginx`'s `get_settings()` call).
+3. **#1464 (Slice 2c)** — `ConnectionRegistry` (promote `wshandler.state`).
+   Depends on 2a. Can run in parallel with 2b.
+4. **#1465 (Slice 2d)** — migrate ~660 test references off `container.registry`
+   + `wshandler.state` module globals. Depends on 2a + 2c. Closes Slice 2.
+
+### Phase 2: the remaining subsystem instances (linear)
+5. **#1450 (Slice 3)** — `OIDC(settings)` instance + caches. Absorbs the
+   `auth_modes(settings)` param (Slice 1 stepping stone → `self.settings`).
+6. **#1451 (Slice 4)** — `Plugins(settings)` instance.
+7. **#1452 (Slice 5)** — `DB(settings)`; kill db globals.
+
+### Phase 3: env-read retirement + cleanup (can interleave with Phase 2)
+8. **#1461** — resolve `file:`/`cmd:` at construction (model validator);
+   delete `resolve_indirection` + its ~22 call-site wraps. Pairs with #1453.
+9. **#1453 (Slice 6)** — freeze `resolve_env_value`/`resolve_env_bool`
+   (132 call sites). The mechanical env-read retirement. After this, no
+   code reads env at call time except inside `KlangkSettings`.
+10. **#1454 (Slice 7)** — delete the `main:app` shim. Last step — `get_settings()`
+    dies when its last caller (the shim) is gone.
+
+### Phase 4: test cleanup (parallel, any time)
+11. **#1457** — tests stop monkeypatching `os.environ`; construct
+    `KlangkSettings(env={...})` directly. ~421 `setenv`/`delenv` calls
+    across 17 files. Pairs naturally with each subsystem slice (migrate
+    the tests that touch that subsystem).
+
+### Standalone (independent, any time)
+- **#1456** — `frontend_dir` config setting (replace hardcoded repo path).
+- **#1459** — `state_dir` field default (no `os.environ.setdefault` mutation).
+- **#1467** — centralize logging configuration (no import-time `basicConfig`).
+- **#1468** — `Podman(settings)` class (cohesion; 20 functions, no state).
+- **#1469** — nginx renderer class (fold into NginxWatchdog or standalone
+  `NginxRenderer`; collapses the 10 `settings` params added in #1466).
+  Best done with or after #1463 (2b).
 
 ## Issue map
 
 | Issue | Title | State |
 |-------|-------|-------|
 | **#1426** | Tracker: one composition root, no module globals | umbrella |
-| **#1447** | Slice 1 — `KlangkSettings(env=...)` + settings threading | ✅ done (#1448 + #1455 + #1460) |
-| **#1458** | Slice 1 remainder — delete `_config_file_path` global | ✅ done (#1460) |
-| **#1449** | Slice 2 — ContainerRegistry owned instance | **next** |
-| **#1450** | Slice 3 — OIDC instance + caches | |
-| **#1451** | Slice 4 — Plugins instance | |
-| **#1452** | Slice 5 — `DB(settings)`; kill db globals | |
-| **#1453** | Slice 6 — freeze `resolve_env_value` at startup | |
-| **#1454** | Slice 7 — delete the `main:app` shim | |
-| **#1456** | Standalone — `frontend_dir` config setting | |
-| **#1457** | Standalone — tests stop monkeypatching `os.environ` | |
-| **#1459** | Standalone — `state_dir` field default (no env mutation) | |
-| **#1461** | Standalone — resolve `file:`/`cmd:` at construction; delete `resolve_indirection` | |
+| #1447 | Slice 1 — `KlangkSettings(env=...)` + settings threading | ✅ done |
+| #1458 | Slice 1 remainder — delete `_config_file_path` global | ✅ done |
+| **#1449** | Slice 2 — ContainerRegistry owned instance (umbrella) | in progress |
+| **#1462** | Slice 2a — ContainerRegistry(settings) + nginx/podman | **in progress (#1466)** |
+| #1463 | Slice 2b — NginxWatchdog class | next |
+| #1464 | Slice 2c — ConnectionRegistry | next (parallel with 2b) |
+| #1465 | Slice 2d — migrate test refs off globals | after 2a+2c |
+| #1450 | Slice 3 — OIDC instance + caches | |
+| #1451 | Slice 4 — Plugins instance | |
+| #1452 | Slice 5 — `DB(settings)`; kill db globals | |
+| #1453 | Slice 6 — freeze `resolve_env_value` at startup | |
+| #1454 | Slice 7 — delete the `main:app` shim | |
+| #1456 | Standalone — `frontend_dir` config setting | |
+| #1457 | Standalone — tests stop monkeypatching `os.environ` | |
+| #1459 | Standalone — `state_dir` field default (no env mutation) | |
+| #1461 | Standalone — resolve `file:`/`cmd:` at construction | |
+| #1467 | Standalone — centralize logging configuration | |
+| #1468 | Standalone — `Podman(settings)` class | |
+| #1469 | Standalone — nginx renderer class | |
 
-The next-step chain after #1460 merges: Slice 1 done →
-**#1449** (Slice 2) → #1450 → #1451 → #1452 → #1453 → #1454.
+## Slice 1: DONE (reference)
 
-## Slice 1: what's DONE
+Three PRs landed Slice 1:
 
-Two PRs land Slice 1. **#1448 is merged** (on `main`); **#1455 is open**
-(this branch).
+- **#1448 (merged)** — `KlangkSettings(env, config_file=None)` constructor.
+  `env` is required (`Mapping[str, str]`). `config_file` optional. Class-var
+  bridge (`ClassVar`-annotated, `try/finally` cleanup) for the classmethod
+  boundary. No init kwargs. Precedence: env > config file > defaults.
+- **#1455 (merged)** — `build_app(settings)` composition root,
+  `get_settings_dep`, oidc settings threading, `auth_modes` field validator
+  (rejects typos → no silent security downgrade to no-auth mode), cache
+  machinery deletion (`get_settings()` is cache-free).
+- **#1460 (merged)** — deleted `_config_file_path` global + dead
+  `validate_at_startup()`. `klangkd` passes `config_file=` to the constructor
+  directly. `get_settings()` returns `KlangkSettings(os.environ)`.
 
-### PR #1448 (merged) — the constructor
+## Slice 2a (PR #1466): what's in this branch
 
-- **`KlangkSettings(env, config_file=None)`** constructor. `env` is
-  **required** (`Mapping[str, str]` — production passes `os.environ`,
-  tests pass a dict). `config_file` is optional (`str | None`; `None` =
-  no config file). Implementation: `_EnvDictSource(EnvSettingsSource)`
-  overrides `_load_env_vars()` to run the passed mapping through the
-  same `parse_env_vars` normalizer the base uses for `os.environ`.
-- **Class-var bridge** (`_env_for_sources`, `_config_file_for_sources`):
-  shuttles the env dict / config-file path from `__init__` through the
-  classmethod boundary (`settings_customise_sources` runs before `self`
-  exists). **Review fixes applied (#1448 review):**
-  - Annotated as `ClassVar[...]` (not bare underscore attrs — pydantic
-    absorbs those into `__private_attributes__` and they worked only by
-    `cls.` vs `self.` accident).
-  - Cleanup is `try/finally` around `super().__init__()` (a failed
-    construction no longer leaks the env dict onto the class).
-- **No init kwargs.** `**values` was dropped — init kwargs are NOT a
-  supported config path (lowest-priority source, silently ignored when
-  env sets the field).
-- **Precedence**: env dict > config file > defaults (earlier sources in
-  the pydantic-settings tuple win).
-
-### PR #1455 (open, this branch) — build_app, cache deletion, oidc threading, validator
-
-Four commits on top of the merged #1448:
-
-1. **`oidc.auth_modes(settings)` + predicate threading.**
-   `auth_modes()`, `password_login_allowed()`, `local_login_allowed()`,
-   `oidc_login_allowed()` now take a `KlangkSettings` arg and read
-   `settings.auth_modes` instead of `resolve_env_value("KLANGK_AUTH_MODES")`
-   at call time. Production callers obtain settings via `get_settings()`
-   (transitional — `get_settings_dep` arrives in commit 2). **This is a
-   stepping stone for Slice 3 (#1450)**, where the `settings` param
-   becomes `self.settings` on an `OIDC(settings)` class.
-
-2. **`build_app(settings)` composition root + `get_settings_dep` + cache
-   machinery deletion.**
-   - `build_app()` wraps app construction (FastAPI, CORS, routers,
-     exception handlers, WS endpoint, static files) into one factory.
-     Sets `app.state.settings = settings`.
-   - `get_settings_dep(request)` → `request.app.state.settings` — the
-     per-request bridge (zero callers yet; endpoints migrate to it
-     incrementally or via subsystem Depends in later slices).
-   - Module-level `app = build_app(get_settings())` remains as a shim
-     for uvicorn's string import.
-   - **Cache machinery deleted**: `_settings_instance`,
-     `_settings_env_signature`, `_env_signature()`, `_invalidate_cache()`
-     all gone. `get_settings()` is cache-free (constructs a fresh
-     `KlangkSettings(os.environ, config_file=_config_file_path)` on
-     every call).
-
-3. **`auth_modes` field validator (security fix).**
-   A typo'd `KLANGK_AUTH_MODES` (e.g. `passdword`) used to fall through
-   to `"none"` — a **silent security downgrade** (`none` freely issues
-   an admin token). A pydantic `field_validator` now rejects non-`None`,
-   non-empty values outside `{password, oidc, both, none}` at
-   construction (`validate_at_startup()` in the lifespan → aborts boot
-   before serving traffic). Empty string is treated as unset (`None`),
-   preserving the blank-value behavior. `oidc.auth_modes()` simplified
-   to `settings.auth_modes` + `None → "none"` fallback (the set check is
-   redundant now that the validator guarantees validity).
-
-4. **E2E test fix.** `test_nginx_acl_e2e.py` imported `_invalidate_cache`
-   (deleted in commit 2). Removed all 10 lines (5 imports + 5 calls).
-   Also fixed invalid `password,oidc` test data in `test_nginx.py`
-   (never a valid mode — the new validator catches it) → `both`.
-
-## Slice 1: what REMAINS
-
-Only one item — **#1458** (filed as its own issue):
-
-- **Delete the `_config_file_path` global.** `set_config_file()` /
-  `get_config_file()` / `_config_file_path` are still present as a
-  transitional fallback. `get_settings()` passes
-  `config_file=_config_file_path` explicitly so the coupling is visible.
-  Migrate `klangkd` (the one production caller, `klangkd.py:105`) and
-  ~15 test callers to pass `config_file=` to the constructor, then
-  delete the global + accessors.
-
-After #1458 merges, **#1447 (Slice 1) closes** and **#1449 (Slice 2)**
-starts.
+- **`ContainerRegistry(settings)`** — takes `KlangkSettings | None = None`.
+  `build_app()` constructs `app.state.container_registry`. Module-level
+  `container.registry` stays as a transitional shim (constructed with
+  `get_settings()`) — dies in Slice 2d (#1465).
+- **Service-session locks** — `terminal._service_session_locks` stays
+  physically in `terminal.py` (circular import), but the registry exposes
+  `get/clear/prune_service_session_lock` methods that delegate to terminal's
+  functions. Dict moves fully in Slice 2d.
+- **nginx.py settings threading** — all renderer functions take `settings`
+  (required on entry points: `render_config`, `write_config`, `find_nginx_bin`;
+  required on internal helpers). `get_settings()` removed from `nginx.py`.
+- **podman.py** — `_podman_bin()` keeps plain `get_settings()` (no pointless
+  indirection; threading settings through subprocess wrappers is #1468's job).
+- **test_nginx.py rewrite** — constructs `KlangkSettings(env={...})` directly,
+  no `_set()`/`_settings()`/`_clean_env` fixture, no `os.environ` mutation.
 
 ## Design decisions (locked in)
 
@@ -142,8 +129,7 @@ starts.
 - **`config_file` defaults to `None`** — `None` means "no config file"
   (legitimate common case for tests/scripts). `"none"` is the explicit
   opt-out string.
-- **Init kwargs NOT supported** — dropped from signature, not mentioned
-  in docstrings (except `config_file`).
+- **Init kwargs NOT supported** — dropped from signature.
 - **Precedence**: env dict > config file > defaults.
 - **`DB(settings)` not `settings.get_db()`** — settings stays a pure
   config value; engine/PRAGMA/cache concerns live on `DB`.
@@ -151,11 +137,15 @@ starts.
 - **`get_settings()` is a cache-free shim** — stays until Slice 7
   (#1454) when its last caller (the `main:app` shim) is gone.
 - **`get_settings_dep` is for every endpoint that needs settings** — no
-  either/or. Any endpoint requiring settings uses
-  `Depends(get_settings_dep)`. When subsystems become instances (Slices 2-4),
-  endpoints needing those use the corresponding per-subsystem Depends too —
-  that's additive, not alternative. An endpoint needing OIDC *and* a raw
-  config field uses both `get_oidc_dep` and `get_settings_dep`.
+  either/or. Per-subsystem Depends (when they arrive in later slices) are
+  additive, not alternative.
+- **Tests construct `KlangkSettings(env={...})` directly** — no
+  `monkeypatch.setenv` reacharound, no `os.environ` mutation. Each test
+  specifies the config it wants via explicit `KLANGK_*` keys.
+- **Two motivations for classes** (both legitimate): (1) mutable globals
+  to eliminate (container, oidc, plugins, db — the original #1426 plan);
+  (2) cohesion — shared dep repeated across signatures (nginx, podman —
+  #1468/#1469, emerged from reviewing the settings-threading).
 
 ## How to run tests
 
@@ -170,48 +160,24 @@ devenv --quiet -O dotenv.enable:bool false shell -- \
 # Settings/main tests only (fast iteration, no coverage):
 devenv --quiet -O dotenv.enable:bool false shell -- \
   bash -c 'cd src/backend && python3 -m pytest tests/test_settings.py tests/test_main.py -o addopts="" -q'
-
-# Full CLI suite (CI-matching):
-devenv --quiet -O dotenv.enable:bool false shell -- \
-  bash -c 'cd src/cli && python3 -m pytest tests -n auto'
 ```
 
-CI runs E2E suites (`test-backend-e2e`, `test-cli-e2e`,
-`test-frontend-e2e`) that need a container runtime — those can't run
-locally without podman. The nginx ACL E2E tests were the catch for the
-`_invalidate_cache` import breakage in #1455 (fixed in commit 4).
-
-## Key files and their roles
-
-| File | Role |
-|------|------|
-| `src/backend/klangk_backend/settings.py` | `KlangkSettings` model + constructor (`_EnvDictSource`, class-var bridges, `auth_modes` validator), `get_settings()` (cache-free shim), `validate_at_startup()`, `_config_file_path` global (dies in #1458), `resolve_env_value/bool` (die in Slice 6 / #1453) |
-| `src/backend/klangk_backend/main.py` | `build_app(settings)` composition root, `get_settings_dep`, `lifespan`, `setup_logfire`, `cors_origins`, nginx watchdog globals, `app = build_app(get_settings())` shim (dies in Slice 7 / #1454) |
-| `src/backend/klangk_backend/oidc.py` | `auth_modes(settings)`, `*_login_allowed(settings)` — take settings arg (become methods in Slice 3 / #1450); `_providers` / `_discovery_cache` / `_jwks_cache` globals (move onto OIDC instance in Slice 3) |
-| `src/backend/klangk_backend/api/auth.py` | Auth endpoints calling `oidc.password_login_allowed(get_settings())` / `oidc.local_login_allowed(get_settings())` |
-| `src/backend/klangk_backend/api/__init__.py` | `/config` endpoint calling `oidc.auth_modes(get_settings())`; module-scope `resolve_env_value` constants (migrate to settings in Slice 6) |
-| `src/backend/klangk_backend/klangkd.py` | Launcher; calls `set_config_file(resolved)` (dies in #1458), `validate_at_startup()`, `uvicorn.run("klangk_backend.main:app")` |
+CI runs E2E suites (`test-backend-e2e`, `test-cli-e2e`, `test-frontend-e2e`)
+that need a container runtime — can't run locally without podman.
 
 ## Tech debt callout: the class-var bridge
 
 `_env_for_sources` and `_config_file_for_sources` are `ClassVar`s set on
-the class in `__init__` before `super().__init__()`, read in the
-classmethod `settings_customise_sources`, and cleaned up in a `try/finally`.
-This is safe (construction is single-threaded at startup and one-at-a-time
-in tests) but not thread-safe and surprising.
-
-A cleaner alternative (not yet verified): stash `env`/`config_file` on a
-subclassed `init_settings` source (the one `settings_customise_sources`
-argument tied to *this* construction) instead of a class var. That's deeper
-pydantic-internals work; leave as a follow-up cleanup. Do **not** treat the
-class-var bridge as permanent — it exists because extracting `env` from
+the class in `__init__` before `super().__init__()`, read in the classmethod
+`settings_customise_sources`, and cleaned up in `try/finally`. Safe
+(construction is single-threaded) but not thread-safe and surprising.
+A cleaner alternative: stash `env`/`config_file` on a subclassed
+`init_settings` source instead of a class var — deeper pydantic-internals
+work, leave as follow-up. Exists because extracting `env` from
 `init_settings` inside the classmethod doesn't work (`extra="ignore"` drops
 non-field init kwargs).
 
-## Full target `build_app()` shape (the end state across all slices)
-
-Every `app.state` attribute created across the refactor, in slice order.
-Each slice creates its subset and leaves the rest for later slices.
+## Full target `build_app()` shape (end state across all slices)
 
 ```python
 def build_app(settings: KlangkSettings) -> FastAPI:
@@ -220,49 +186,31 @@ def build_app(settings: KlangkSettings) -> FastAPI:
     # --- Slice 1 (DONE) ---
     app.state.settings = settings
 
-    # --- Slice 2 (#1449) ---
+    # --- Slice 2 (#1449: 2a done in #1466, 2b/2c/2d remaining) ---
     app.state.container_registry = container.ContainerRegistry(settings)
-    #   - IdleMonitor / HealthMonitor / BrowserRouter / PortAllocator become
-    #     collaborators of the registry (nested as `.idle`, `.health`, etc.)
-    #   - terminal._service_session_locks moves onto the registry
-    #   - auto_start_workspaces takes (container_registry, settings) as args
     app.state.nginx_watchdog = NginxWatchdog(settings)
     app.state.connections = ConnectionRegistry()
-    #   ^ new lifecycle object: replaces the `wshandler.state` module global.
-    #     The WS layer registers connections into it; HealthMonitor broadcasts
-    #     health/death frames through it (today this is a lazy `from .wshandler
-    #     import state as _ws_state`). It's the one place where a background
-    #     actor (monitor, owned by the registry) needs a handle to the set of
-    #     live WS connections — different lifecycle than either, so it gets its
-    #     own owner on app.state.
 
     # --- Slice 3 (#1450) ---
     app.state.oidc = oidc.OIDC(settings)
-    #   - _providers / _discovery_cache / _jwks_cache move onto the instance
-    #   - auth_modes(settings) / *_login_allowed(settings) become methods
-    #     (self.settings replaces the settings arg threaded in Slice 1)
 
     # --- Slice 4 (#1451) ---
     app.state.plugins = plugins.Plugins(settings)
-    #   - _declarations / _values move onto the instance
 
     # --- Slice 5 (#1452) ---
     app.state.db = DB(settings)
-    #   - kills data_dir / DB_PATH / engine / ensure_engine / get_db() globals
-    #   - model methods take settings (or live on DB; see #1452 scope fence)
 
-    # --- routers become factories closing over instances (not module globals) ---
+    # --- Standalone follow-ups (#1468/#1469) ---
+    app.state.podman = podman.Podman(settings)
+    # (nginx renderer folds into NginxWatchdog or becomes NginxRenderer)
+
+    # --- routers become factories closing over instances ---
     app.include_router(api.build_router(settings, app.state.container_registry, app.state.oidc), prefix=API_PREFIX)
     app.include_router(auth.build_router(app.state.oidc), prefix=API_PREFIX)
 
-    # --- WS handler takes instances as explicit args ---
     @app.websocket("/ws")
     async def _ws(websocket: WebSocket):
         await wshandler.handle(websocket, app.state.settings, app.state.container_registry, app.state.oidc, app.state.connections)
-    # settings: needed for KLANGKC_DEBUG_SSH_AGENT / KLANGKWS_DEBUG /
-    #   KLANGK_BRIDGE_TIMEOUT_SECONDS (read today via resolve_env_value;
-    #   migrate to settings in Slice 6 / #1453). Passed from the start so the
-    #   WS handler signature doesn't change twice.
 
     return app
 ```
@@ -271,26 +219,11 @@ def build_app(settings: KlangkSettings) -> FastAPI:
 
 | Attribute | Slice | Lifecycle | Notes |
 |-----------|-------|-----------|-------|
-| `settings` | 1 (done) | frozen at startup | `KlangkSettings(os.environ, config_file=...)` |
-| `container_registry` | 2 | process lifetime | owns monitors, port allocator, browser router |
-| `nginx_watchdog` | 2 | start/stop in lifespan | `.start()` / `.stop()` methods |
-| `connections` | 2 | process lifetime (connections register/unregister) | replaces `wshandler.state` global; monitor broadcasts through it |
+| `settings` | 1 (done) | frozen at startup | `KlangkSettings(os.environ)` |
+| `container_registry` | 2a (done) | process lifetime | owns monitors, port allocator, browser router |
+| `nginx_watchdog` | 2b | start/stop in lifespan | `.start()` / `.stop()` methods |
+| `connections` | 2c | process lifetime (register/unregister) | replaces `wshandler.state`; monitor broadcasts through it |
 | `oidc` | 3 | process lifetime | owns providers + discovery/JWKS caches |
 | `plugins` | 4 | process lifetime | owns declarations + values |
 | `db` | 5 | process lifetime | owns engine + model methods |
-
-### The `connections` lifecycle (new — the one genuinely new owner)
-
-Today `wshandler.state` is a module global holding live WS connections.
-`HealthMonitor._send_heartbeats` reaches into it via a lazy import to
-broadcast health/death frames. This is the one place where a background
-actor (the monitor, owned by the registry) needs to talk to all live
-connections — connections come and go on a different lifecycle than the
-monitor, so neither can own the other.
-
-Slice 2 promotes `wshandler.state` to a `ConnectionRegistry` instance on
-`app.state.connections`. The WS layer registers/unregisters connections
-into it; the monitor (and anything else that needs to broadcast) gets a
-handle to it. This is the single place in the refactor where "thread it as
-a param" requires introducing a **new owner** rather than reusing an
-existing one — call it out as a micro-slice within Slice 2.
+| `podman` | follow-up | process lifetime | cohesion class (no mutable state) |

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -4,136 +4,123 @@
 
 A multi-slice refactor to eliminate module-level mutable globals from
 `klangk_backend` in favor of one composition root: a `build_app(settings)`
-factory. The tracking issue is **#1426**. Every actionable slice has its own
-issue (see "Issue map" below).
+factory. The tracking issue is **#1426**.
 
-**Current branch**: `issue-1458-slice-1-remainder-delete-config-file-path-global-dead-valida`
-**Current PR**: [#1460](https://github.com/mcdonc/klangk/pull/1460) (OPEN — Slice 1 final cleanup)
-**Test state**: 2370 passed, 100% coverage, 0 warnings
+**Current branch**: `issue-1449-slice-2-promote-containerregistry-to-an-owned-instance-1426`
+**Current PR**: [#1466](https://github.com/mcdonc/klangk/pull/1466) (Slice 2a — CI running)
+**Test state**: 2374 passed, 100% coverage, 0 warnings
 
-## Slice 1 is DONE
+## Where we are
 
-Three PRs land Slice 1. **#1448 and #1455 are merged** (on `main`);
-**#1460 is open** (this branch — the final cleanup).
+**Slice 1 is DONE** (merged: #1448, #1455, #1460). **Slice 2 is in progress**
+(PR #1466 implements Slice 2a). The four Slice 2 sub-issues (#1462–#1465)
+decompose the original Slice 2 (#1449) into independently-shippable PRs.
 
-- **#1448 (merged)** — `KlangkSettings(env, config_file=None)` constructor.
-- **#1455 (merged)** — `build_app(settings)` composition root,
-  `get_settings_dep`, oidc settings threading, `auth_modes` validator,
-  cache machinery deletion.
-- **#1460 (this PR)** — delete `_config_file_path` global + dead
-  `validate_at_startup()`. Completes Slice 1.
+## Suggested ordering for remaining work
 
-After #1460 merges, **Slice 1 (#1447) is complete** and **#1449 (Slice 2)**
-starts.
+The 7 original slices (#1447–#1454) had a fixed linear chain. The refactor
+has since spawned standalone issues (#1456–#1469) that interleave. This is
+the suggested order, grouped by theme, with dependencies noted:
+
+### Phase 1: finish Slice 2 (container subsystem)
+1. **#1462 / PR #1466 (Slice 2a)** — `ContainerRegistry(settings)` +
+   build_app wiring + nginx/podman settings threading. **In progress.**
+2. **#1463 (Slice 2b)** — `NginxWatchdog` class → `app.state.nginx_watchdog`.
+   Depends on 2a (the nginx renderer settings params land in #1466; the
+   watchdog absorbs `_prepare_nginx`'s `get_settings()` call).
+3. **#1464 (Slice 2c)** — `ConnectionRegistry` (promote `wshandler.state`).
+   Depends on 2a. Can run in parallel with 2b.
+4. **#1465 (Slice 2d)** — migrate ~660 test references off `container.registry`
+   + `wshandler.state` module globals. Depends on 2a + 2c. Closes Slice 2.
+
+### Phase 2: the remaining subsystem instances (linear)
+5. **#1450 (Slice 3)** — `OIDC(settings)` instance + caches. Absorbs the
+   `auth_modes(settings)` param (Slice 1 stepping stone → `self.settings`).
+6. **#1451 (Slice 4)** — `Plugins(settings)` instance.
+7. **#1452 (Slice 5)** — `DB(settings)`; kill db globals.
+
+### Phase 3: env-read retirement + cleanup (can interleave with Phase 2)
+8. **#1461** — resolve `file:`/`cmd:` at construction (model validator);
+   delete `resolve_indirection` + its ~22 call-site wraps. Pairs with #1453.
+9. **#1453 (Slice 6)** — freeze `resolve_env_value`/`resolve_env_bool`
+   (132 call sites). The mechanical env-read retirement. After this, no
+   code reads env at call time except inside `KlangkSettings`.
+10. **#1454 (Slice 7)** — delete the `main:app` shim. Last step — `get_settings()`
+    dies when its last caller (the shim) is gone.
+
+### Phase 4: test cleanup (parallel, any time)
+11. **#1457** — tests stop monkeypatching `os.environ`; construct
+    `KlangkSettings(env={...})` directly. ~421 `setenv`/`delenv` calls
+    across 17 files. Pairs naturally with each subsystem slice (migrate
+    the tests that touch that subsystem).
+
+### Standalone (independent, any time)
+- **#1456** — `frontend_dir` config setting (replace hardcoded repo path).
+- **#1459** — `state_dir` field default (no `os.environ.setdefault` mutation).
+- **#1467** — centralize logging configuration (no import-time `basicConfig`).
+- **#1468** — `Podman(settings)` class (cohesion; 20 functions, no state).
+- **#1469** — nginx renderer class (fold into NginxWatchdog or standalone
+  `NginxRenderer`; collapses the 10 `settings` params added in #1466).
+  Best done with or after #1463 (2b).
 
 ## Issue map
 
 | Issue | Title | State |
 |-------|-------|-------|
 | **#1426** | Tracker: one composition root, no module globals | umbrella |
-| **#1447** | Slice 1 — `KlangkSettings(env=...)` + settings threading | ✅ done (#1448 + #1455 + #1460) |
-| **#1458** | Slice 1 remainder — delete `_config_file_path` global | ✅ done (#1460) |
-| **#1449** | Slice 2 — ContainerRegistry owned instance | **next** |
-| **#1450** | Slice 3 — OIDC instance + caches | |
-| **#1451** | Slice 4 — Plugins instance | |
-| **#1452** | Slice 5 — `DB(settings)`; kill db globals | |
-| **#1453** | Slice 6 — freeze `resolve_env_value` at startup | |
-| **#1454** | Slice 7 — delete the `main:app` shim | |
-| **#1456** | Standalone — `frontend_dir` config setting | |
-| **#1457** | Standalone — tests stop monkeypatching `os.environ` | |
-| **#1459** | Standalone — `state_dir` field default (no env mutation) | |
-| **#1461** | Standalone — resolve `file:`/`cmd:` at construction; delete `resolve_indirection` | |
+| #1447 | Slice 1 — `KlangkSettings(env=...)` + settings threading | ✅ done |
+| #1458 | Slice 1 remainder — delete `_config_file_path` global | ✅ done |
+| **#1449** | Slice 2 — ContainerRegistry owned instance (umbrella) | in progress |
+| **#1462** | Slice 2a — ContainerRegistry(settings) + nginx/podman | **in progress (#1466)** |
+| #1463 | Slice 2b — NginxWatchdog class | next |
+| #1464 | Slice 2c — ConnectionRegistry | next (parallel with 2b) |
+| #1465 | Slice 2d — migrate test refs off globals | after 2a+2c |
+| #1468 | Slice 2 — `Podman(settings)` class | part of Slice 2 |
+| #1469 | Slice 2 — nginx renderer class | part of Slice 2 |
+| #1450 | Slice 3 — OIDC instance + caches | |
+| #1451 | Slice 4 — Plugins instance | |
+| #1452 | Slice 5 — `DB(settings)`; kill db globals | |
+| #1453 | Slice 6 — freeze `resolve_env_value` at startup | |
+| #1454 | Slice 7 — delete the `main:app` shim | |
+| #1456 | Standalone — `frontend_dir` config setting | |
+| #1457 | Standalone — tests stop monkeypatching `os.environ` | |
+| #1459 | Standalone — `state_dir` field default (no env mutation) | |
+| #1461 | Standalone — resolve `file:`/`cmd:` at construction | |
+| #1467 | Standalone — centralize logging configuration | |
 
-The next-step chain after #1460 merges: Slice 1 done →
-**#1449** (Slice 2) → #1450 → #1451 → #1452 → #1453 → #1454.
+## Slice 1: DONE (reference)
 
-## Slice 1: what's DONE
+Three PRs landed Slice 1:
 
-Two PRs land Slice 1. **#1448 is merged** (on `main`); **#1455 is open**
-(this branch).
+- **#1448 (merged)** — `KlangkSettings(env, config_file=None)` constructor.
+  `env` is required (`Mapping[str, str]`). `config_file` optional. Class-var
+  bridge (`ClassVar`-annotated, `try/finally` cleanup) for the classmethod
+  boundary. No init kwargs. Precedence: env > config file > defaults.
+- **#1455 (merged)** — `build_app(settings)` composition root,
+  `get_settings_dep`, oidc settings threading, `auth_modes` field validator
+  (rejects typos → no silent security downgrade to no-auth mode), cache
+  machinery deletion (`get_settings()` is cache-free).
+- **#1460 (merged)** — deleted `_config_file_path` global + dead
+  `validate_at_startup()`. `klangkd` passes `config_file=` to the constructor
+  directly. `get_settings()` returns `KlangkSettings(os.environ)`.
 
-### PR #1448 (merged) — the constructor
+## Slice 2a (PR #1466): what's in this branch
 
-- **`KlangkSettings(env, config_file=None)`** constructor. `env` is
-  **required** (`Mapping[str, str]` — production passes `os.environ`,
-  tests pass a dict). `config_file` is optional (`str | None`; `None` =
-  no config file). Implementation: `_EnvDictSource(EnvSettingsSource)`
-  overrides `_load_env_vars()` to run the passed mapping through the
-  same `parse_env_vars` normalizer the base uses for `os.environ`.
-- **Class-var bridge** (`_env_for_sources`, `_config_file_for_sources`):
-  shuttles the env dict / config-file path from `__init__` through the
-  classmethod boundary (`settings_customise_sources` runs before `self`
-  exists). **Review fixes applied (#1448 review):**
-  - Annotated as `ClassVar[...]` (not bare underscore attrs — pydantic
-    absorbs those into `__private_attributes__` and they worked only by
-    `cls.` vs `self.` accident).
-  - Cleanup is `try/finally` around `super().__init__()` (a failed
-    construction no longer leaks the env dict onto the class).
-- **No init kwargs.** `**values` was dropped — init kwargs are NOT a
-  supported config path (lowest-priority source, silently ignored when
-  env sets the field).
-- **Precedence**: env dict > config file > defaults (earlier sources in
-  the pydantic-settings tuple win).
-
-### PR #1455 (open, this branch) — build_app, cache deletion, oidc threading, validator
-
-Four commits on top of the merged #1448:
-
-1. **`oidc.auth_modes(settings)` + predicate threading.**
-   `auth_modes()`, `password_login_allowed()`, `local_login_allowed()`,
-   `oidc_login_allowed()` now take a `KlangkSettings` arg and read
-   `settings.auth_modes` instead of `resolve_env_value("KLANGK_AUTH_MODES")`
-   at call time. Production callers obtain settings via `get_settings()`
-   (transitional — `get_settings_dep` arrives in commit 2). **This is a
-   stepping stone for Slice 3 (#1450)**, where the `settings` param
-   becomes `self.settings` on an `OIDC(settings)` class.
-
-2. **`build_app(settings)` composition root + `get_settings_dep` + cache
-   machinery deletion.**
-   - `build_app()` wraps app construction (FastAPI, CORS, routers,
-     exception handlers, WS endpoint, static files) into one factory.
-     Sets `app.state.settings = settings`.
-   - `get_settings_dep(request)` → `request.app.state.settings` — the
-     per-request bridge (zero callers yet; endpoints migrate to it
-     incrementally or via subsystem Depends in later slices).
-   - Module-level `app = build_app(get_settings())` remains as a shim
-     for uvicorn's string import.
-   - **Cache machinery deleted**: `_settings_instance`,
-     `_settings_env_signature`, `_env_signature()`, `_invalidate_cache()`
-     all gone. `get_settings()` is cache-free (constructs a fresh
-     `KlangkSettings(os.environ, config_file=_config_file_path)` on
-     every call).
-
-3. **`auth_modes` field validator (security fix).**
-   A typo'd `KLANGK_AUTH_MODES` (e.g. `passdword`) used to fall through
-   to `"none"` — a **silent security downgrade** (`none` freely issues
-   an admin token). A pydantic `field_validator` now rejects non-`None`,
-   non-empty values outside `{password, oidc, both, none}` at
-   construction (`validate_at_startup()` in the lifespan → aborts boot
-   before serving traffic). Empty string is treated as unset (`None`),
-   preserving the blank-value behavior. `oidc.auth_modes()` simplified
-   to `settings.auth_modes` + `None → "none"` fallback (the set check is
-   redundant now that the validator guarantees validity).
-
-4. **E2E test fix.** `test_nginx_acl_e2e.py` imported `_invalidate_cache`
-   (deleted in commit 2). Removed all 10 lines (5 imports + 5 calls).
-   Also fixed invalid `password,oidc` test data in `test_nginx.py`
-   (never a valid mode — the new validator catches it) → `both`.
-
-## Slice 1: what REMAINS
-
-Only one item — **#1458** (filed as its own issue):
-
-- **Delete the `_config_file_path` global.** `set_config_file()` /
-  `get_config_file()` / `_config_file_path` are still present as a
-  transitional fallback. `get_settings()` passes
-  `config_file=_config_file_path` explicitly so the coupling is visible.
-  Migrate `klangkd` (the one production caller, `klangkd.py:105`) and
-  ~15 test callers to pass `config_file=` to the constructor, then
-  delete the global + accessors.
-
-After #1458 merges, **#1447 (Slice 1) closes** and **#1449 (Slice 2)**
-starts.
+- **`ContainerRegistry(settings)`** — takes `KlangkSettings | None = None`.
+  `build_app()` constructs `app.state.container_registry`. Module-level
+  `container.registry` stays as a transitional shim (constructed with
+  `get_settings()`) — dies in Slice 2d (#1465).
+- **Service-session locks** — `terminal._service_session_locks` stays
+  physically in `terminal.py` (circular import), but the registry exposes
+  `get/clear/prune_service_session_lock` methods that delegate to terminal's
+  functions. Dict moves fully in Slice 2d.
+- **nginx.py settings threading** — all renderer functions take `settings`
+  (required on entry points: `render_config`, `write_config`, `find_nginx_bin`;
+  required on internal helpers). `get_settings()` removed from `nginx.py`.
+- **podman.py** — `_podman_bin()` keeps plain `get_settings()` (no pointless
+  indirection; threading settings through subprocess wrappers is #1468's job).
+- **test_nginx.py rewrite** — constructs `KlangkSettings(env={...})` directly,
+  no `_set()`/`_settings()`/`_clean_env` fixture, no `os.environ` mutation.
 
 ## Design decisions (locked in)
 
@@ -142,8 +129,7 @@ starts.
 - **`config_file` defaults to `None`** — `None` means "no config file"
   (legitimate common case for tests/scripts). `"none"` is the explicit
   opt-out string.
-- **Init kwargs NOT supported** — dropped from signature, not mentioned
-  in docstrings (except `config_file`).
+- **Init kwargs NOT supported** — dropped from signature.
 - **Precedence**: env dict > config file > defaults.
 - **`DB(settings)` not `settings.get_db()`** — settings stays a pure
   config value; engine/PRAGMA/cache concerns live on `DB`.
@@ -151,11 +137,15 @@ starts.
 - **`get_settings()` is a cache-free shim** — stays until Slice 7
   (#1454) when its last caller (the `main:app` shim) is gone.
 - **`get_settings_dep` is for every endpoint that needs settings** — no
-  either/or. Any endpoint requiring settings uses
-  `Depends(get_settings_dep)`. When subsystems become instances (Slices 2-4),
-  endpoints needing those use the corresponding per-subsystem Depends too —
-  that's additive, not alternative. An endpoint needing OIDC *and* a raw
-  config field uses both `get_oidc_dep` and `get_settings_dep`.
+  either/or. Per-subsystem Depends (when they arrive in later slices) are
+  additive, not alternative.
+- **Tests construct `KlangkSettings(env={...})` directly** — no
+  `monkeypatch.setenv` reacharound, no `os.environ` mutation. Each test
+  specifies the config it wants via explicit `KLANGK_*` keys.
+- **Two motivations for classes** (both legitimate): (1) mutable globals
+  to eliminate (container, oidc, plugins, db — the original #1426 plan);
+  (2) cohesion — shared dep repeated across signatures (nginx, podman —
+  #1468/#1469, emerged from reviewing the settings-threading).
 
 ## How to run tests
 
@@ -170,48 +160,24 @@ devenv --quiet -O dotenv.enable:bool false shell -- \
 # Settings/main tests only (fast iteration, no coverage):
 devenv --quiet -O dotenv.enable:bool false shell -- \
   bash -c 'cd src/backend && python3 -m pytest tests/test_settings.py tests/test_main.py -o addopts="" -q'
-
-# Full CLI suite (CI-matching):
-devenv --quiet -O dotenv.enable:bool false shell -- \
-  bash -c 'cd src/cli && python3 -m pytest tests -n auto'
 ```
 
-CI runs E2E suites (`test-backend-e2e`, `test-cli-e2e`,
-`test-frontend-e2e`) that need a container runtime — those can't run
-locally without podman. The nginx ACL E2E tests were the catch for the
-`_invalidate_cache` import breakage in #1455 (fixed in commit 4).
-
-## Key files and their roles
-
-| File | Role |
-|------|------|
-| `src/backend/klangk_backend/settings.py` | `KlangkSettings` model + constructor (`_EnvDictSource`, class-var bridges, `auth_modes` validator), `get_settings()` (cache-free shim), `validate_at_startup()`, `_config_file_path` global (dies in #1458), `resolve_env_value/bool` (die in Slice 6 / #1453) |
-| `src/backend/klangk_backend/main.py` | `build_app(settings)` composition root, `get_settings_dep`, `lifespan`, `setup_logfire`, `cors_origins`, nginx watchdog globals, `app = build_app(get_settings())` shim (dies in Slice 7 / #1454) |
-| `src/backend/klangk_backend/oidc.py` | `auth_modes(settings)`, `*_login_allowed(settings)` — take settings arg (become methods in Slice 3 / #1450); `_providers` / `_discovery_cache` / `_jwks_cache` globals (move onto OIDC instance in Slice 3) |
-| `src/backend/klangk_backend/api/auth.py` | Auth endpoints calling `oidc.password_login_allowed(get_settings())` / `oidc.local_login_allowed(get_settings())` |
-| `src/backend/klangk_backend/api/__init__.py` | `/config` endpoint calling `oidc.auth_modes(get_settings())`; module-scope `resolve_env_value` constants (migrate to settings in Slice 6) |
-| `src/backend/klangk_backend/klangkd.py` | Launcher; calls `set_config_file(resolved)` (dies in #1458), `validate_at_startup()`, `uvicorn.run("klangk_backend.main:app")` |
+CI runs E2E suites (`test-backend-e2e`, `test-cli-e2e`, `test-frontend-e2e`)
+that need a container runtime — can't run locally without podman.
 
 ## Tech debt callout: the class-var bridge
 
 `_env_for_sources` and `_config_file_for_sources` are `ClassVar`s set on
-the class in `__init__` before `super().__init__()`, read in the
-classmethod `settings_customise_sources`, and cleaned up in a `try/finally`.
-This is safe (construction is single-threaded at startup and one-at-a-time
-in tests) but not thread-safe and surprising.
-
-A cleaner alternative (not yet verified): stash `env`/`config_file` on a
-subclassed `init_settings` source (the one `settings_customise_sources`
-argument tied to *this* construction) instead of a class var. That's deeper
-pydantic-internals work; leave as a follow-up cleanup. Do **not** treat the
-class-var bridge as permanent — it exists because extracting `env` from
+the class in `__init__` before `super().__init__()`, read in the classmethod
+`settings_customise_sources`, and cleaned up in `try/finally`. Safe
+(construction is single-threaded) but not thread-safe and surprising.
+A cleaner alternative: stash `env`/`config_file` on a subclassed
+`init_settings` source instead of a class var — deeper pydantic-internals
+work, leave as follow-up. Exists because extracting `env` from
 `init_settings` inside the classmethod doesn't work (`extra="ignore"` drops
 non-field init kwargs).
 
-## Full target `build_app()` shape (the end state across all slices)
-
-Every `app.state` attribute created across the refactor, in slice order.
-Each slice creates its subset and leaves the rest for later slices.
+## Full target `build_app()` shape (end state across all slices)
 
 ```python
 def build_app(settings: KlangkSettings) -> FastAPI:
@@ -220,49 +186,31 @@ def build_app(settings: KlangkSettings) -> FastAPI:
     # --- Slice 1 (DONE) ---
     app.state.settings = settings
 
-    # --- Slice 2 (#1449) ---
+    # --- Slice 2 (#1449: 2a done in #1466, 2b/2c/2d remaining) ---
     app.state.container_registry = container.ContainerRegistry(settings)
-    #   - IdleMonitor / HealthMonitor / BrowserRouter / PortAllocator become
-    #     collaborators of the registry (nested as `.idle`, `.health`, etc.)
-    #   - terminal._service_session_locks moves onto the registry
-    #   - auto_start_workspaces takes (container_registry, settings) as args
     app.state.nginx_watchdog = NginxWatchdog(settings)
     app.state.connections = ConnectionRegistry()
-    #   ^ new lifecycle object: replaces the `wshandler.state` module global.
-    #     The WS layer registers connections into it; HealthMonitor broadcasts
-    #     health/death frames through it (today this is a lazy `from .wshandler
-    #     import state as _ws_state`). It's the one place where a background
-    #     actor (monitor, owned by the registry) needs a handle to the set of
-    #     live WS connections — different lifecycle than either, so it gets its
-    #     own owner on app.state.
 
     # --- Slice 3 (#1450) ---
     app.state.oidc = oidc.OIDC(settings)
-    #   - _providers / _discovery_cache / _jwks_cache move onto the instance
-    #   - auth_modes(settings) / *_login_allowed(settings) become methods
-    #     (self.settings replaces the settings arg threaded in Slice 1)
 
     # --- Slice 4 (#1451) ---
     app.state.plugins = plugins.Plugins(settings)
-    #   - _declarations / _values move onto the instance
 
     # --- Slice 5 (#1452) ---
     app.state.db = DB(settings)
-    #   - kills data_dir / DB_PATH / engine / ensure_engine / get_db() globals
-    #   - model methods take settings (or live on DB; see #1452 scope fence)
 
-    # --- routers become factories closing over instances (not module globals) ---
+    # --- Standalone follow-ups (#1468/#1469) ---
+    app.state.podman = podman.Podman(settings)
+    # (nginx renderer folds into NginxWatchdog or becomes NginxRenderer)
+
+    # --- routers become factories closing over instances ---
     app.include_router(api.build_router(settings, app.state.container_registry, app.state.oidc), prefix=API_PREFIX)
     app.include_router(auth.build_router(app.state.oidc), prefix=API_PREFIX)
 
-    # --- WS handler takes instances as explicit args ---
     @app.websocket("/ws")
     async def _ws(websocket: WebSocket):
         await wshandler.handle(websocket, app.state.settings, app.state.container_registry, app.state.oidc, app.state.connections)
-    # settings: needed for KLANGKC_DEBUG_SSH_AGENT / KLANGKWS_DEBUG /
-    #   KLANGK_BRIDGE_TIMEOUT_SECONDS (read today via resolve_env_value;
-    #   migrate to settings in Slice 6 / #1453). Passed from the start so the
-    #   WS handler signature doesn't change twice.
 
     return app
 ```
@@ -271,26 +219,11 @@ def build_app(settings: KlangkSettings) -> FastAPI:
 
 | Attribute | Slice | Lifecycle | Notes |
 |-----------|-------|-----------|-------|
-| `settings` | 1 (done) | frozen at startup | `KlangkSettings(os.environ, config_file=...)` |
-| `container_registry` | 2 | process lifetime | owns monitors, port allocator, browser router |
-| `nginx_watchdog` | 2 | start/stop in lifespan | `.start()` / `.stop()` methods |
-| `connections` | 2 | process lifetime (connections register/unregister) | replaces `wshandler.state` global; monitor broadcasts through it |
+| `settings` | 1 (done) | frozen at startup | `KlangkSettings(os.environ)` |
+| `container_registry` | 2a (done) | process lifetime | owns monitors, port allocator, browser router |
+| `nginx_watchdog` | 2b | start/stop in lifespan | `.start()` / `.stop()` methods |
+| `connections` | 2c | process lifetime (register/unregister) | replaces `wshandler.state`; monitor broadcasts through it |
 | `oidc` | 3 | process lifetime | owns providers + discovery/JWKS caches |
 | `plugins` | 4 | process lifetime | owns declarations + values |
 | `db` | 5 | process lifetime | owns engine + model methods |
-
-### The `connections` lifecycle (new — the one genuinely new owner)
-
-Today `wshandler.state` is a module global holding live WS connections.
-`HealthMonitor._send_heartbeats` reaches into it via a lazy import to
-broadcast health/death frames. This is the one place where a background
-actor (the monitor, owned by the registry) needs to talk to all live
-connections — connections come and go on a different lifecycle than the
-monitor, so neither can own the other.
-
-Slice 2 promotes `wshandler.state` to a `ConnectionRegistry` instance on
-`app.state.connections`. The WS layer registers/unregisters connections
-into it; the monitor (and anything else that needs to broadcast) gets a
-handle to it. This is the single place in the refactor where "thread it as
-a param" requires introducing a **new owner** rather than reusing an
-existing one — call it out as a micro-slice within Slice 2.
+| `podman` | follow-up | process lifetime | cohesion class (no mutable state) |

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -75,6 +75,8 @@ the suggested order, grouped by theme, with dependencies noted:
 | #1463 | Slice 2b — NginxWatchdog class | next |
 | #1464 | Slice 2c — ConnectionRegistry | next (parallel with 2b) |
 | #1465 | Slice 2d — migrate test refs off globals | after 2a+2c |
+| #1468 | Slice 2 — `Podman(settings)` class | part of Slice 2 |
+| #1469 | Slice 2 — nginx renderer class | part of Slice 2 |
 | #1450 | Slice 3 — OIDC instance + caches | |
 | #1451 | Slice 4 — Plugins instance | |
 | #1452 | Slice 5 — `DB(settings)`; kill db globals | |
@@ -85,8 +87,6 @@ the suggested order, grouped by theme, with dependencies noted:
 | #1459 | Standalone — `state_dir` field default (no env mutation) | |
 | #1461 | Standalone — resolve `file:`/`cmd:` at construction | |
 | #1467 | Standalone — centralize logging configuration | |
-| #1468 | Standalone — `Podman(settings)` class | |
-| #1469 | Standalone — nginx renderer class | |
 
 ## Slice 1: DONE (reference)
 

--- a/src/backend/e2e-tests/test_nginx_acl_e2e.py
+++ b/src/backend/e2e-tests/test_nginx_acl_e2e.py
@@ -64,15 +64,17 @@ def _render_conf(env_overrides, tmpdir=None):
             os.environ.pop(k, None)
     try:
         from klangk_backend.nginx import render_config, tcp_upstream
+        from klangk_backend.settings import get_settings
 
-        return render_config(tcp_upstream("127.0.0.1", "19998"))
+        return render_config(
+            tcp_upstream("127.0.0.1", "19998"), get_settings()
+        )
     finally:
         for k, old in old_env.items():
             if old is None:
                 os.environ.pop(k, None)
             else:
                 os.environ[k] = old
-
 
 
 def _write_and_launch_nginx(conf_text, nginx_port, tmpdir):
@@ -447,6 +449,7 @@ class TestNginxAclEnforcement:
         # Start nginx via the Python renderer (#1396): render the conf
         # from these env vars, then launch nginx directly with -c.
         from klangk_backend.nginx import write_config, tcp_upstream
+        from klangk_backend.settings import get_settings
 
         for k, v in {
             "KLANGK_NGINX_PORT": nginx_port,
@@ -458,7 +461,9 @@ class TestNginxAclEnforcement:
         nginx_state = os.path.join(tmpdir, "nginx")
         os.makedirs(nginx_state, exist_ok=True)
         conf_path = os.path.join(nginx_state, "nginx.conf")
-        write_config(tcp_upstream("127.0.0.1", backend_port), conf_path)
+        write_config(
+            tcp_upstream("127.0.0.1", backend_port), conf_path, get_settings()
+        )
         nginx_proc = subprocess.Popen(
             ["nginx", "-e", "stderr", "-c", conf_path],
             stdout=subprocess.PIPE,
@@ -617,6 +622,7 @@ class TestNginxDenyByDefault:
         # the (sole) container source IP. CONTAINER_DENY on the catch-all
         # then denies exactly that IP.
         from klangk_backend.nginx import write_config, tcp_upstream
+        from klangk_backend.settings import get_settings
 
         for k, v in {
             "KLANGK_NGINX_PORT": nginx_port,
@@ -626,7 +632,9 @@ class TestNginxDenyByDefault:
         nginx_state = os.path.join(tmpdir, "nginx")
         os.makedirs(nginx_state, exist_ok=True)
         conf_path = os.path.join(nginx_state, "nginx.conf")
-        write_config(tcp_upstream("127.0.0.1", backend_port), conf_path)
+        write_config(
+            tcp_upstream("127.0.0.1", backend_port), conf_path, get_settings()
+        )
         nginx_proc = subprocess.Popen(
             ["nginx", "-e", "stderr", "-c", conf_path],
             stdout=subprocess.PIPE,
@@ -778,12 +786,15 @@ class TestNginxAuthLocalAcl:
         # the /auth/local block is always generated with its fixed loopback
         # allowlist.
         from klangk_backend.nginx import write_config, tcp_upstream
+        from klangk_backend.settings import get_settings
 
         os.environ["KLANGK_NGINX_PORT"] = nginx_port
         nginx_state = os.path.join(tmpdir, "nginx")
         os.makedirs(nginx_state, exist_ok=True)
         conf_path = os.path.join(nginx_state, "nginx.conf")
-        write_config(tcp_upstream("127.0.0.1", backend_port), conf_path)
+        write_config(
+            tcp_upstream("127.0.0.1", backend_port), conf_path, get_settings()
+        )
         nginx_proc = subprocess.Popen(
             ["nginx", "-e", "stderr", "-c", conf_path],
             stdout=subprocess.PIPE,

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -6,6 +6,7 @@ import os
 import time
 
 from . import auth, bringup, model, plugins, podman, terminal, util
+from .settings import KlangkSettings, get_settings
 
 logger = logging.getLogger(__name__)
 
@@ -757,15 +758,21 @@ class HealthMonitor:
 
 
 class ContainerRegistry:
-    """Singleton managing all container state and podman interactions.
+    """Manages all container state and podman interactions.
 
     Composes :class:`PortAllocator`, :class:`BrowserRouter`,
     :class:`IdleMonitor`, and :class:`HealthMonitor` as collaborators.
     Backward-compatible proxy methods delegate to the collaborators so
     existing callers are unchanged.
+
+    Constructed once in :func:`build_app` and stored on
+    ``app.state.container_registry`` (#1426). The module-level ``registry``
+    is a transitional shim for callers not yet migrated to explicit
+    threading.
     """
 
-    def __init__(self):
+    def __init__(self, settings: "KlangkSettings | None" = None):
+        self.settings = settings
         self.states: dict[str, ContainerState] = {}
         # Reverse lookup: container_id -> workspace_id
         self._cid_to_wsid: dict[str, str] = {}
@@ -779,6 +786,27 @@ class ContainerRegistry:
         self.browsers = BrowserRouter()
         self.idle = IdleMonitor(self)
         self.health = HealthMonitor(self)
+
+    # --- Service-session locks (#1188, moved from terminal.py, #1426) ---
+    # The dict still physically lives in terminal.py (terminal.py can't import
+    # container — circular) and the terminal functions operate on it. These
+    # methods delegate so the registry is the single API surface; the dict
+    # moves fully in Slice 2d (#1465) when tests stop reaching into
+    # terminal._service_session_locks directly.
+
+    def get_service_session_lock(self, container_id: str) -> asyncio.Lock:
+        """Get or create the per-container lock for service-command firing."""
+        return terminal.get_service_session_lock(container_id)
+
+    def clear_service_session_lock(self, container_id: str) -> None:
+        """Drop the per-container firing lock for a torn-down container."""
+        terminal.clear_service_session_lock(container_id)
+
+    def prune_service_session_locks(
+        self, active_container_ids: set[str]
+    ) -> int:
+        """Remove lock entries for containers no longer tracked (#1351)."""
+        return terminal.prune_service_session_locks(active_container_ids)
 
     def workspace_id_for(self, container_id: str) -> str | None:
         """Return the workspace_id for a container, or None."""
@@ -873,8 +901,8 @@ class ContainerRegistry:
                 self._cid_to_wsid.pop(state.container_id, None)
                 # Drop the per-container service-firing lock (#1188), then
                 # sweep any other entries orphaned by container churn (#1351).
-                terminal.clear_service_session_lock(state.container_id)
-                terminal.prune_service_session_locks(set(self._cid_to_wsid))
+                self.clear_service_session_lock(state.container_id)
+                self.prune_service_session_locks(set(self._cid_to_wsid))
 
     # --- Proxy: PortAllocator ---
 
@@ -1549,8 +1577,8 @@ class ContainerRegistry:
         # Drop the per-container service-firing lock (#1188), then sweep any
         # other entries orphaned by container churn (e.g. a racing re-bind
         # that popped this container's mapping before teardown) (#1351).
-        terminal.clear_service_session_lock(container_id)
-        terminal.prune_service_session_locks(set(self._cid_to_wsid))
+        self.clear_service_session_lock(container_id)
+        self.prune_service_session_locks(set(self._cid_to_wsid))
 
     async def notify_workspace_killed(self, workspace_id: str) -> None:
         """Call the on_workspace_killed callback, logging any errors.
@@ -1689,4 +1717,7 @@ class ContainerRegistry:
 
 
 # Module-level singleton
-registry = ContainerRegistry()
+# Transitional module-level shim (#1426 Slice 2a). Production constructs the
+# real instance in build_app() → app.state.container_registry; this exists so
+# the ~660 test references and unmigrated callers keep working. Dies in #1465.
+registry = ContainerRegistry(get_settings())

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -444,13 +444,14 @@ def _prepare_nginx() -> tuple[str, str]:
     (minimal/headless vs full/browser) and the nginx listen directive, not
     the upstream.
     """
+    settings = get_settings()
     state_dir = (
-        resolve_indirection(get_settings().state_dir) or "/tmp/klangk-state"
+        resolve_indirection(settings.state_dir) or "/tmp/klangk-state"
     )
     uds_path = os.path.join(state_dir, "klangk.sock")
     conf_path = os.path.join(state_dir, "nginx.conf")
-    bin_path = nginx_mod.find_nginx_bin()
-    nginx_mod.write_config(nginx_mod.uds_upstream(uds_path), conf_path)
+    bin_path = nginx_mod.find_nginx_bin(settings)
+    nginx_mod.write_config(nginx_mod.uds_upstream(uds_path), conf_path, settings)
     return bin_path, conf_path
 
 
@@ -720,6 +721,9 @@ def build_app(settings: KlangkSettings) -> FastAPI:
     """
     app = FastAPI(title="Klangk", lifespan=lifespan)
     app.state.settings = settings
+    # Slice 2 (#1449): the container registry is an owned instance, not a
+    # module global. The lifespan reads app.state.container_registry.
+    app.state.container_registry = container.ContainerRegistry(settings)
 
     app.add_middleware(
         CORSMiddleware,

--- a/src/backend/klangk_backend/nginx.py
+++ b/src/backend/klangk_backend/nginx.py
@@ -25,6 +25,7 @@ import subprocess
 from pathlib import Path
 
 from .settings import (
+    KlangkSettings,
     get_settings,
     listen_is_socket,
     resolve_indirection,
@@ -101,13 +102,13 @@ def detect_host_ipv4s() -> list[str]:
     return addrs
 
 
-def detect_dns_resolvers() -> str:
+def detect_dns_resolvers(settings: KlangkSettings) -> str:
     """Space-separated nameservers for nginx's ``resolver`` directive.
 
     From ``KLANGK_DNS_SERVERS`` (comma→space) if set, else parsed from
     ``/etc/resolv.conf`` (IPv6 bracketed for nginx), else ``8.8.8.8``.
     """
-    raw = resolve_indirection(get_settings().dns_servers)
+    raw = resolve_indirection(settings.dns_servers)
     if raw:
         servers = []
         for token in str(raw).split(","):
@@ -146,7 +147,7 @@ _FALLBACK_ACL_SUBNETS = ["172.16.0.0/12", "10.0.0.0/8", "127.0.0.1"]
 _FALLBACK_DENY_SUBNETS = ["172.16.0.0/12", "10.0.0.0/8"]
 
 
-def compute_container_acls() -> tuple[str, str]:
+def compute_container_acls(settings: KlangkSettings) -> tuple[str, str]:
     """Build the CONTAINER_ACL (allowlist) and CONTAINER_DENY (blocklist) text.
 
     Returns ``(acl_block, deny_block)`` where each is the indented
@@ -164,7 +165,7 @@ def compute_container_acls() -> tuple[str, str]:
     With an explicit ``KLANGK_CONTAINER_SUBNETS`` override, 127.0.0.1 is NOT
     implicitly added to CONTAINER_ACL (the operator's list is used verbatim).
     """
-    explicit = resolve_indirection(get_settings().container_subnets)
+    explicit = resolve_indirection(settings.container_subnets)
     if explicit:
         subnets = [s.strip() for s in str(explicit).split(",") if s.strip()]
         acl_lines = [f"      allow {s};" for s in subnets]
@@ -199,13 +200,13 @@ def compute_container_acls() -> tuple[str, str]:
 # ---------------------------------------------------------------------------
 
 
-def compute_client_max_body_size() -> str:
+def compute_client_max_body_size(settings: KlangkSettings) -> str:
     """Derive nginx ``client_max_body_size`` from ``KLANGK_FILE_UPLOAD_SIZE_MAX``.
 
     The setting is in bytes (default 500 MB); nginx wants ``Nm``. Minimum 1m.
     """
     raw = (
-        resolve_indirection(get_settings().file_upload_size_max) or "524288000"
+        resolve_indirection(settings.file_upload_size_max) or "524288000"
     )
     try:
         bytes_ = int(str(raw))
@@ -220,13 +221,13 @@ def compute_client_max_body_size() -> str:
 # ---------------------------------------------------------------------------
 
 
-def _build_hosted_block() -> str:
+def _build_hosted_block(settings: KlangkSettings) -> str:
     """The /hosted/ proxy locations (or a 404 block when disabled).
 
     Disabled entirely when ``KLANGK_HOSTED_PORTS_PER_WORKSPACE`` is exactly 0
     — mirrors the backend's ``ports_per_workspace_cap()`` (#1237).
     """
-    raw = resolve_indirection(get_settings().hosted_ports_per_workspace) or "5"
+    raw = resolve_indirection(settings.hosted_ports_per_workspace) or "5"
     if str(raw).strip() == "0":
         return (
             "    # Hosted-app serving is disabled "
@@ -268,7 +269,7 @@ def _build_hosted_block() -> str:
     )
 
 
-def _build_llm_block(acl: str, resolvers: str) -> str:
+def _build_llm_block(acl: str, resolvers: str, settings: KlangkSettings) -> str:
     """The /llm-proxy/ location, only when ``KLANGK_LLM_BASE_URL`` is set.
 
     Containers hit this instead of the real endpoint, so they never see the
@@ -277,10 +278,10 @@ def _build_llm_block(acl: str, resolvers: str) -> str:
     URL and key are resolved here (Python's resolver, not the retired
     ``klangk-resolve-value`` console script).
     """
-    base_url = resolve_indirection(get_settings().llm_base_url)
+    base_url = resolve_indirection(settings.llm_base_url)
     if not base_url:
         return ""
-    api_key = resolve_indirection(get_settings().llm_api_key) or ""
+    api_key = resolve_indirection(settings.llm_api_key) or ""
     return (
         f"    location ~ ^/llm-proxy/(.*)$ {{\n"
         f"{acl}\n"
@@ -302,8 +303,8 @@ def _build_llm_block(acl: str, resolvers: str) -> str:
     )
 
 
-def _trust_outer_proxy() -> bool:
-    raw = resolve_indirection(get_settings().trust_outer_proxy) or ""
+def _trust_outer_proxy(settings: KlangkSettings) -> bool:
+    raw = resolve_indirection(settings.trust_outer_proxy) or ""
     return str(raw).strip().lower() in ("1", "true", "yes")
 
 
@@ -312,7 +313,7 @@ def _trust_outer_proxy() -> bool:
 # ---------------------------------------------------------------------------
 
 
-def render_config(upstream: str) -> str:
+def render_config(upstream: str, settings: KlangkSettings | None = None) -> str:
     """Render ``nginx.conf`` as a string.
 
     Template selection keys off ``KLANGK_LISTEN``'s shape only (#1398): a
@@ -324,9 +325,11 @@ def render_config(upstream: str) -> str:
     (env > config file > defaults) plus the host-IP / DNS auto-detection
     probes.
     """
+    if settings is None:
+        settings = get_settings()
     if listen_is_socket():
-        return _render_minimal_config(upstream)
-    return _render_full_config(upstream)
+        return _render_minimal_config(upstream, settings)
+    return _render_full_config(upstream, settings)
 
 
 def _minimal_auth_locations(upstream: str) -> str:
@@ -358,7 +361,7 @@ def _minimal_auth_locations(upstream: str) -> str:
     )
 
 
-def _render_minimal_config(upstream: str) -> str:
+def _render_minimal_config(upstream: str, settings: KlangkSettings) -> str:
     """Render the minimal (headless) ``nginx.conf`` — socket bind only (#1398).
 
     Emitted when ``KLANGK_LISTEN`` is a socket path: a browser can't reach a
@@ -374,12 +377,11 @@ def _render_minimal_config(upstream: str) -> str:
     ``KLANGK_LLM_BASE_URL`` is set); with no LLM configured the server block
     serves nothing.
     """
-    settings = get_settings()
     nginx_port = resolve_indirection(settings.nginx_port) or "8995"
-    client_max_body_size = compute_client_max_body_size()
-    resolvers = detect_dns_resolvers()
-    acl, _deny = compute_container_acls()
-    llm_block = _build_llm_block(acl, resolvers)
+    client_max_body_size = compute_client_max_body_size(settings)
+    resolvers = detect_dns_resolvers(settings)
+    acl, _deny = compute_container_acls(settings)
+    llm_block = _build_llm_block(acl, resolvers, settings)
     # The auth_request infrastructure is only reachable via the /llm-proxy
     # location's auth_request; omit it entirely when there's no LLM proxy.
     auth_locations = _minimal_auth_locations(upstream) if llm_block else ""
@@ -404,7 +406,7 @@ http {{
 """
 
 
-def _render_full_config(upstream: str) -> str:
+def _render_full_config(upstream: str, settings: KlangkSettings) -> str:
     """Render the full (browser) ``nginx.conf`` — TCP bind (#1396, #1398).
 
     Emitted when ``KLANGK_LISTEN`` is TCP: the browser UI + every API path +
@@ -412,15 +414,14 @@ def _render_full_config(upstream: str) -> str:
     This is the template the renderer shipped before #1398's socket/minimal
     branch; it is kept verbatim so the TCP path is a strict regression guard.
     """
-    settings = get_settings()
     nginx_port = resolve_indirection(settings.nginx_port) or "8995"
-    client_max_body_size = compute_client_max_body_size()
-    resolvers = detect_dns_resolvers()
-    acl, deny = compute_container_acls()
+    client_max_body_size = compute_client_max_body_size(settings)
+    resolvers = detect_dns_resolvers(settings)
+    acl, deny = compute_container_acls(settings)
 
-    hosted_block = _build_hosted_block()
-    llm_block = _build_llm_block(acl, resolvers)
-    trust = _trust_outer_proxy()
+    hosted_block = _build_hosted_block(settings)
+    llm_block = _build_llm_block(acl, resolvers, settings)
+    trust = _trust_outer_proxy(settings)
     if trust:
         forwarded_headers = (
             "      proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;\n"
@@ -530,7 +531,7 @@ http {{
     return conf
 
 
-def write_config(upstream: str, conf_path: str | Path) -> str:
+def write_config(upstream: str, conf_path: str | Path, settings: KlangkSettings | None = None) -> str:
     """Render the config and write it to ``conf_path`` (returns the text).
 
     Written mode ``0600`` because the rendered config may embed secrets
@@ -540,7 +541,7 @@ def write_config(upstream: str, conf_path: str | Path) -> str:
     same-uid-only ``state_dir`` as the UDS, so the restrictive mode matches
     the existing trust boundary.
     """
-    text = render_config(upstream)
+    text = render_config(upstream, settings)
     path = Path(conf_path)
     path.parent.mkdir(parents=True, exist_ok=True)
     # The LLM API key is necessarily in this config (nginx adds the
@@ -553,9 +554,9 @@ def write_config(upstream: str, conf_path: str | Path) -> str:
     return text
 
 
-def find_nginx_bin() -> str:
+def find_nginx_bin(settings: KlangkSettings | None = None) -> str:
     """Locate the nginx binary: KLANGK_NGINX_BIN > PATH > /usr/sbin/nginx."""
-    configured = resolve_indirection(get_settings().nginx_bin)
+    configured = resolve_indirection((settings or get_settings()).nginx_bin)
     if configured:
         return str(configured)
     found = shutil.which("nginx")

--- a/src/backend/klangk_backend/nginx.py
+++ b/src/backend/klangk_backend/nginx.py
@@ -26,7 +26,6 @@ from pathlib import Path
 
 from .settings import (
     KlangkSettings,
-    get_settings,
     listen_is_socket,
     resolve_indirection,
 )
@@ -313,7 +312,7 @@ def _trust_outer_proxy(settings: KlangkSettings) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def render_config(upstream: str, settings: KlangkSettings | None = None) -> str:
+def render_config(upstream: str, settings: KlangkSettings) -> str:
     """Render ``nginx.conf`` as a string.
 
     Template selection keys off ``KLANGK_LISTEN``'s shape only (#1398): a
@@ -325,9 +324,7 @@ def render_config(upstream: str, settings: KlangkSettings | None = None) -> str:
     (env > config file > defaults) plus the host-IP / DNS auto-detection
     probes.
     """
-    if settings is None:
-        settings = get_settings()
-    if listen_is_socket():
+    if listen_is_socket(resolve_indirection(settings.listen)):
         return _render_minimal_config(upstream, settings)
     return _render_full_config(upstream, settings)
 
@@ -531,7 +528,7 @@ http {{
     return conf
 
 
-def write_config(upstream: str, conf_path: str | Path, settings: KlangkSettings | None = None) -> str:
+def write_config(upstream: str, conf_path: str | Path, settings: KlangkSettings) -> str:
     """Render the config and write it to ``conf_path`` (returns the text).
 
     Written mode ``0600`` because the rendered config may embed secrets
@@ -554,9 +551,9 @@ def write_config(upstream: str, conf_path: str | Path, settings: KlangkSettings 
     return text
 
 
-def find_nginx_bin(settings: KlangkSettings | None = None) -> str:
+def find_nginx_bin(settings: KlangkSettings) -> str:
     """Locate the nginx binary: KLANGK_NGINX_BIN > PATH > /usr/sbin/nginx."""
-    configured = resolve_indirection((settings or get_settings()).nginx_bin)
+    configured = resolve_indirection(settings.nginx_bin)
     if configured:
         return str(configured)
     found = shutil.which("nginx")

--- a/src/backend/klangk_backend/podman.py
+++ b/src/backend/klangk_backend/podman.py
@@ -20,14 +20,14 @@ import tempfile
 import time
 from collections.abc import AsyncGenerator
 
-from .settings import KlangkSettings, get_settings, resolve_indirection
+from .settings import get_settings, resolve_indirection
 from .util import BoundedOutputQueue
 
 logger = logging.getLogger(__name__)
 
 
-def _podman_bin(settings: KlangkSettings | None = None) -> str:
-    return resolve_indirection((settings or get_settings()).podman_bin) or "podman"
+def _podman_bin() -> str:
+    return resolve_indirection(get_settings().podman_bin) or "podman"
 
 
 def subprocess_env() -> dict[str, str]:

--- a/src/backend/klangk_backend/podman.py
+++ b/src/backend/klangk_backend/podman.py
@@ -20,14 +20,14 @@ import tempfile
 import time
 from collections.abc import AsyncGenerator
 
-from .settings import get_settings, resolve_indirection
+from .settings import KlangkSettings, get_settings, resolve_indirection
 from .util import BoundedOutputQueue
 
 logger = logging.getLogger(__name__)
 
 
-def _podman_bin() -> str:
-    return resolve_indirection(get_settings().podman_bin) or "podman"
+def _podman_bin(settings: KlangkSettings | None = None) -> str:
+    return resolve_indirection((settings or get_settings()).podman_bin) or "podman"
 
 
 def subprocess_env() -> dict[str, str]:

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -3057,3 +3057,50 @@ class TestHealthLoopHeartbeat:
         frames = [c[0][0] for c in sock.send_json.call_args_list]
         assert frames  # at least one heartbeat over ~5 ticks
         assert all(f["type"] == "service_health_heartbeat" for f in frames)
+
+
+class TestRegistryServiceSessionLockDelegates:
+    """The registry delegates service-session-lock ops to terminal (#1426 2a)."""
+
+    def setup_method(self):
+        from klangk_backend import terminal
+
+        terminal._service_session_locks.clear()
+
+    def teardown_method(self):
+        from klangk_backend import terminal
+
+        terminal._service_session_locks.clear()
+
+    def test_get_via_registry(self):
+        from klangk_backend import terminal
+
+        reg = container.registry
+        lock = reg.get_service_session_lock("cid")
+        assert lock is terminal.get_service_session_lock("cid")
+
+    def test_clear_via_registry(self):
+        from klangk_backend import terminal
+
+        reg = container.registry
+        reg.get_service_session_lock("cid")
+        assert "cid" in terminal._service_session_locks
+        reg.clear_service_session_lock("cid")
+        assert "cid" not in terminal._service_session_locks
+
+    def test_prune_via_registry(self):
+        from klangk_backend import terminal
+
+        reg = container.registry
+        reg.get_service_session_lock("alive")
+        reg.get_service_session_lock("dead")
+        removed = reg.prune_service_session_locks({"alive"})
+        assert removed == 1
+        assert "dead" not in terminal._service_session_locks
+
+    def test_registry_takes_settings(self):
+        """ContainerRegistry.__init__ accepts settings (#1426)."""
+        from klangk_backend.settings import KlangkSettings
+
+        reg = container.ContainerRegistry(KlangkSettings(env={}))
+        assert reg.settings is not None

--- a/src/backend/tests/test_nginx.py
+++ b/src/backend/tests/test_nginx.py
@@ -53,6 +53,13 @@ def _set(**kw):
         os.environ["KLANGK_" + k.upper()] = str(v)
 
 
+def _settings():
+    """Build settings from the live (mutated) environment."""
+    from klangk_backend.settings import KlangkSettings
+
+    return KlangkSettings(os.environ)
+
+
 class TestUpstreams:
     def test_tcp_upstream(self):
         assert tcp_upstream("127.0.0.1", "8997") == "http://127.0.0.1:8997"
@@ -64,25 +71,25 @@ class TestUpstreams:
 class TestClientMaxBodySize:
     def test_default_500mb(self):
         _set()
-        assert compute_client_max_body_size() == "500m"
+        assert compute_client_max_body_size(_settings()) == "500m"
 
     def test_custom(self):
         _set(file_upload_size_max="10485760")  # 10 MB
-        assert compute_client_max_body_size() == "10m"
+        assert compute_client_max_body_size(_settings()) == "10m"
 
     def test_minimum_1m(self):
         _set(file_upload_size_max="100")  # 100 bytes
-        assert compute_client_max_body_size() == "1m"
+        assert compute_client_max_body_size(_settings()) == "1m"
 
     def test_garbage_falls_back(self):
         _set(file_upload_size_max="not-a-number")
-        assert compute_client_max_body_size() == "500m"
+        assert compute_client_max_body_size(_settings()) == "500m"
 
 
 class TestContainerAcls:
     def test_explicit_subnets(self):
         _set(container_subnets="10.89.0.0/24,172.30.0.0/16")
-        acl, deny = compute_container_acls()
+        acl, deny = compute_container_acls(_settings())
         assert "allow 10.89.0.0/24;" in acl
         assert "allow 172.30.0.0/16;" in acl
         assert "deny all;" in acl
@@ -94,21 +101,21 @@ class TestContainerAcls:
 
     def test_loopback_excluded_from_deny(self):
         _set(container_subnets="127.0.0.1,10.89.0.0/24")
-        _, deny = compute_container_acls()
+        _, deny = compute_container_acls(_settings())
         assert "deny 10.89.0.0/24;" in deny
         assert "deny 127.0.0.1;" not in deny
         assert "allow all;" in deny
 
     def test_all_loopback_warns(self, caplog):
         _set(container_subnets="127.0.0.1")
-        _, deny = compute_container_acls()
+        _, deny = compute_container_acls(_settings())
         assert "allow all;" in deny
         assert "no non-loopback" in caplog.text
 
     def test_auto_detect_or_fallback(self):
         """Without explicit subnets: either host IPs or fallback RFC1918."""
         _set()
-        acl, deny = compute_container_acls()
+        acl, deny = compute_container_acls(_settings())
         # Must produce *something* (host IPs or fallback).
         assert "deny all;" in acl
         assert "allow all;" in deny
@@ -117,24 +124,24 @@ class TestContainerAcls:
 class TestDnsResolvers:
     def test_explicit_servers(self):
         _set(dns_servers="1.2.3.4,5.6.7.8")
-        result = detect_dns_resolvers()
+        result = detect_dns_resolvers(_settings())
         assert "1.2.3.4" in result
         assert "5.6.7.8" in result
 
     def test_ipv6_bracketed(self):
         _set(dns_servers="::1")
-        assert "[::1]" in detect_dns_resolvers()
+        assert "[::1]" in detect_dns_resolvers(_settings())
 
     def test_empty_tokens_skipped(self):
         """Trailing commas / empty entries in KLANGK_DNS_SERVERS are skipped."""
         _set(dns_servers="1.2.3.4,,5.6.7.8,")
-        result = detect_dns_resolvers()
+        result = detect_dns_resolvers(_settings())
         assert "1.2.3.4" in result
         assert "5.6.7.8" in result
 
     def test_fallback(self):
         _set()
-        result = detect_dns_resolvers()
+        result = detect_dns_resolvers(_settings())
         assert len(result) > 0  # from resolv.conf or 8.8.8.8
 
 
@@ -356,7 +363,7 @@ class TestDnsResolversFromResolvConf:
             "read_text",
             lambda self: content,
         )
-        result = detect_dns_resolvers()
+        result = detect_dns_resolvers(_settings())
         assert "1.1.1.1" in result
         assert "[::1]" in result
 
@@ -370,7 +377,7 @@ class TestDnsResolversFromResolvConf:
             raise OSError("no resolv.conf")
 
         monkeypatch.setattr(nginx_mod.Path, "read_text", _raise)
-        assert detect_dns_resolvers() == "8.8.8.8"
+        assert detect_dns_resolvers(_settings()) == "8.8.8.8"
 
 
 class TestContainerAclFallback:
@@ -380,7 +387,7 @@ class TestContainerAclFallback:
 
         _set()  # no container_subnets
         monkeypatch.setattr(nginx_mod, "detect_host_ipv4s", lambda: [])
-        acl, deny = compute_container_acls()
+        acl, deny = compute_container_acls(_settings())
         assert "allow 172.16.0.0/12;" in acl
         assert "allow 10.0.0.0/8;" in acl
         assert "deny 172.16.0.0/12;" in deny
@@ -457,7 +464,7 @@ class TestWatchdogGate:
         _set(listen=sock, state_dir=str(tmp_path), nginx_port="19999")
         monkeypatch.delenv("_KLANGK_DISABLE_NGINX", raising=False)
         monkeypatch.setattr(
-            "klangk_backend.nginx.find_nginx_bin", lambda: "/fake/nginx"
+            "klangk_backend.nginx.find_nginx_bin", lambda *a: "/fake/nginx"
         )
 
         spawned = {}
@@ -497,7 +504,7 @@ class TestPrepareNginx:
             llm_base_url="http://127.0.0.1:11434",
         )
         monkeypatch.setattr(
-            "klangk_backend.nginx.find_nginx_bin", lambda: "/fake/nginx"
+            "klangk_backend.nginx.find_nginx_bin", lambda *a: "/fake/nginx"
         )
         bin_path, conf_path = main._prepare_nginx()
         assert bin_path == "/fake/nginx"

--- a/src/backend/tests/test_nginx.py
+++ b/src/backend/tests/test_nginx.py
@@ -6,7 +6,6 @@ real nginx — the runtime ACL enforcement is covered by the e2e suite
 """
 
 import asyncio
-import os
 
 import pytest
 
@@ -20,44 +19,7 @@ from klangk_backend.nginx import (
     tcp_upstream,
     uds_upstream,
 )
-
-
-@pytest.fixture(autouse=True)
-def _clean_env(monkeypatch):
-    """Snapshot all KLANGK_* env vars and restore them after each test.
-
-    Tests here mutate env via the ``_set()`` helper (which writes
-    ``os.environ`` directly, not through monkeypatch), so a plain
-    ``monkeypatch.delenv`` at setup wouldn't undo those writes — they'd leak
-    into sibling test modules sharing the worker process under xdist (e.g.
-    ``test_hosted_disabled`` setting ``KLANGK_HOSTED_PORTS_PER_WORKSPACE=0``
-    would make ``test_workspaces`` allocate zero ports). Snapshot the whole
-    ``KLANGK_*`` block and restore it verbatim on teardown.
-    """
-    snapshot = {
-        k: os.environ[k] for k in list(os.environ) if k.startswith("KLANGK_")
-    }
-    for k in list(os.environ):
-        if k.startswith("KLANGK_"):
-            monkeypatch.delenv(k, raising=False)
-    yield
-    # Restore: clear any KLANGK_* added by this test, then reinstate snapshot.
-    for k in [k for k in list(os.environ) if k.startswith("KLANGK_")]:
-        os.environ.pop(k, None)
-    os.environ.update(snapshot)
-
-
-def _set(**kw):
-    """Set KLANGK_* env vars."""
-    for k, v in kw.items():
-        os.environ["KLANGK_" + k.upper()] = str(v)
-
-
-def _settings():
-    """Build settings from the live (mutated) environment."""
-    from klangk_backend.settings import KlangkSettings
-
-    return KlangkSettings(os.environ)
+from klangk_backend.settings import KlangkSettings
 
 
 class TestUpstreams:
@@ -70,26 +32,30 @@ class TestUpstreams:
 
 class TestClientMaxBodySize:
     def test_default_500mb(self):
-        _set()
-        assert compute_client_max_body_size(_settings()) == "500m"
+        s = KlangkSettings(env={})
+        assert compute_client_max_body_size(s) == "500m"
 
     def test_custom(self):
-        _set(file_upload_size_max="10485760")  # 10 MB
-        assert compute_client_max_body_size(_settings()) == "10m"
+        s = KlangkSettings(env={"KLANGK_FILE_UPLOAD_SIZE_MAX": "10485760"})
+        assert compute_client_max_body_size(s) == "10m"
 
     def test_minimum_1m(self):
-        _set(file_upload_size_max="100")  # 100 bytes
-        assert compute_client_max_body_size(_settings()) == "1m"
+        s = KlangkSettings(env={"KLANGK_FILE_UPLOAD_SIZE_MAX": "100"})
+        assert compute_client_max_body_size(s) == "1m"
 
     def test_garbage_falls_back(self):
-        _set(file_upload_size_max="not-a-number")
-        assert compute_client_max_body_size(_settings()) == "500m"
+        s = KlangkSettings(
+            env={"KLANGK_FILE_UPLOAD_SIZE_MAX": "not-a-number"}
+        )
+        assert compute_client_max_body_size(s) == "500m"
 
 
 class TestContainerAcls:
     def test_explicit_subnets(self):
-        _set(container_subnets="10.89.0.0/24,172.30.0.0/16")
-        acl, deny = compute_container_acls(_settings())
+        s = KlangkSettings(
+            env={"KLANGK_CONTAINER_SUBNETS": "10.89.0.0/24,172.30.0.0/16"}
+        )
+        acl, deny = compute_container_acls(s)
         assert "allow 10.89.0.0/24;" in acl
         assert "allow 172.30.0.0/16;" in acl
         assert "deny all;" in acl
@@ -100,22 +66,24 @@ class TestContainerAcls:
         assert "allow all;" in deny
 
     def test_loopback_excluded_from_deny(self):
-        _set(container_subnets="127.0.0.1,10.89.0.0/24")
-        _, deny = compute_container_acls(_settings())
+        s = KlangkSettings(
+            env={"KLANGK_CONTAINER_SUBNETS": "127.0.0.1,10.89.0.0/24"}
+        )
+        _, deny = compute_container_acls(s)
         assert "deny 10.89.0.0/24;" in deny
         assert "deny 127.0.0.1;" not in deny
         assert "allow all;" in deny
 
     def test_all_loopback_warns(self, caplog):
-        _set(container_subnets="127.0.0.1")
-        _, deny = compute_container_acls(_settings())
+        s = KlangkSettings(env={"KLANGK_CONTAINER_SUBNETS": "127.0.0.1"})
+        _, deny = compute_container_acls(s)
         assert "allow all;" in deny
         assert "no non-loopback" in caplog.text
 
     def test_auto_detect_or_fallback(self):
         """Without explicit subnets: either host IPs or fallback RFC1918."""
-        _set()
-        acl, deny = compute_container_acls(_settings())
+        s = KlangkSettings(env={})
+        acl, deny = compute_container_acls(s)
         # Must produce *something* (host IPs or fallback).
         assert "deny all;" in acl
         assert "allow all;" in deny
@@ -123,32 +91,34 @@ class TestContainerAcls:
 
 class TestDnsResolvers:
     def test_explicit_servers(self):
-        _set(dns_servers="1.2.3.4,5.6.7.8")
-        result = detect_dns_resolvers(_settings())
+        s = KlangkSettings(env={"KLANGK_DNS_SERVERS": "1.2.3.4,5.6.7.8"})
+        result = detect_dns_resolvers(s)
         assert "1.2.3.4" in result
         assert "5.6.7.8" in result
 
     def test_ipv6_bracketed(self):
-        _set(dns_servers="::1")
-        assert "[::1]" in detect_dns_resolvers(_settings())
+        s = KlangkSettings(env={"KLANGK_DNS_SERVERS": "::1"})
+        assert "[::1]" in detect_dns_resolvers(s)
 
     def test_empty_tokens_skipped(self):
         """Trailing commas / empty entries in KLANGK_DNS_SERVERS are skipped."""
-        _set(dns_servers="1.2.3.4,,5.6.7.8,")
-        result = detect_dns_resolvers(_settings())
+        s = KlangkSettings(
+            env={"KLANGK_DNS_SERVERS": "1.2.3.4,,5.6.7.8,"}
+        )
+        result = detect_dns_resolvers(s)
         assert "1.2.3.4" in result
         assert "5.6.7.8" in result
 
     def test_fallback(self):
-        _set()
-        result = detect_dns_resolvers(_settings())
+        s = KlangkSettings(env={})
+        result = detect_dns_resolvers(s)
         assert len(result) > 0  # from resolv.conf or 8.8.8.8
 
 
 class TestRenderConfig:
     def test_basic_structure(self):
-        _set(nginx_port="8995")
-        conf = render_config(tcp_upstream("127.0.0.1", "8997"))
+        s = KlangkSettings(env={"KLANGK_NGINX_PORT": "8995"})
+        conf = render_config(tcp_upstream("127.0.0.1", "8997"), s)
         assert "daemon off;" in conf
         assert "listen 8995;" in conf
         assert "proxy_pass http://127.0.0.1:8997" in conf
@@ -158,32 +128,36 @@ class TestRenderConfig:
         assert "location /" in conf
 
     def test_uds_upstream_in_conf(self):
-        _set(nginx_port="8995")
-        conf = render_config(uds_upstream("/tmp/klangk.sock"))
+        s = KlangkSettings(env={"KLANGK_NGINX_PORT": "8995"})
+        conf = render_config(uds_upstream("/tmp/klangk.sock"), s)
         assert "proxy_pass http://unix:/tmp/klangk.sock:" in conf
 
     def test_no_llm_block_without_url(self):
-        _set()
-        conf = render_config(tcp_upstream("127.0.0.1", "8997"))
+        s = KlangkSettings(env={})
+        conf = render_config(tcp_upstream("127.0.0.1", "8997"), s)
         assert "llm-proxy" not in conf
 
     def test_llm_block_with_url(self):
-        _set(llm_base_url="http://127.0.0.1:11434")
-        conf = render_config(tcp_upstream("127.0.0.1", "8997"))
+        s = KlangkSettings(
+            env={"KLANGK_LLM_BASE_URL": "http://127.0.0.1:11434"}
+        )
+        conf = render_config(tcp_upstream("127.0.0.1", "8997"), s)
         assert "llm-proxy" in conf
 
     def test_llm_api_key_resolved(self):
-        _set(
-            llm_base_url="http://127.0.0.1:11434",
-            llm_api_key="cmd:printf %s resolved-key",
+        s = KlangkSettings(
+            env={
+                "KLANGK_LLM_BASE_URL": "http://127.0.0.1:11434",
+                "KLANGK_LLM_API_KEY": "cmd:printf %s resolved-key",
+            }
         )
-        conf = render_config(tcp_upstream("127.0.0.1", "8997"))
+        conf = render_config(tcp_upstream("127.0.0.1", "8997"), s)
         assert 'Authorization "Bearer resolved-key"' in conf
         assert "cmd:" not in conf
 
     def test_auth_local_loopback_acl(self):
-        _set()
-        conf = render_config(tcp_upstream("127.0.0.1", "8997"))
+        s = KlangkSettings(env={})
+        conf = render_config(tcp_upstream("127.0.0.1", "8997"), s)
         # Find the auth/local block.
         import re
 
@@ -197,26 +171,28 @@ class TestRenderConfig:
         assert "deny all;" in block
 
     def test_hosted_disabled(self):
-        _set(hosted_ports_per_workspace="0")
-        conf = render_config(tcp_upstream("127.0.0.1", "8997"))
+        s = KlangkSettings(
+            env={"KLANGK_HOSTED_PORTS_PER_WORKSPACE": "0"}
+        )
+        conf = render_config(tcp_upstream("127.0.0.1", "8997"), s)
         assert "location ^~ /hosted/ {" in conf
         assert "return 404;" in conf
 
     def test_hosted_enabled_default(self):
-        _set()
-        conf = render_config(tcp_upstream("127.0.0.1", "8997"))
+        s = KlangkSettings(env={})
+        conf = render_config(tcp_upstream("127.0.0.1", "8997"), s)
         assert "location ~ ^/hosted/[^/]+/(?<hosted_port>" in conf
 
     def test_trust_outer_proxy(self):
-        _set(trust_outer_proxy="1")
-        conf = render_config(tcp_upstream("127.0.0.1", "8997"))
+        s = KlangkSettings(env={"KLANGK_TRUST_OUTER_PROXY": "1"})
+        conf = render_config(tcp_upstream("127.0.0.1", "8997"), s)
         # When trusting outer proxy, X-Forwarded-* come from client headers.
         assert "http_x_forwarded_proto" in conf
         assert "http_x_forwarded_host" in conf
 
     def test_no_trust_outer_proxy(self):
-        _set()
-        conf = render_config(tcp_upstream("127.0.0.1", "8997"))
+        s = KlangkSettings(env={})
+        conf = render_config(tcp_upstream("127.0.0.1", "8997"), s)
         # Default: X-Forwarded-* derived from trusted values.
         assert "proxy_set_header X-Forwarded-Proto $scheme;" in conf
         assert "proxy_set_header X-Forwarded-Host $http_host;" in conf
@@ -225,11 +201,13 @@ class TestRenderConfig:
         """file:/cmd: values resolve in the renderer."""
         secret = tmp_path / "llm.key"
         secret.write_text("file-based-key\n")
-        _set(
-            llm_base_url="http://127.0.0.1:11434",
-            llm_api_key=f"file:{secret}",
+        s = KlangkSettings(
+            env={
+                "KLANGK_LLM_BASE_URL": "http://127.0.0.1:11434",
+                "KLANGK_LLM_API_KEY": f"file:{secret}",
+            }
         )
-        conf = render_config(tcp_upstream("127.0.0.1", "8997"))
+        conf = render_config(tcp_upstream("127.0.0.1", "8997"), s)
         assert 'Authorization "Bearer file-based-key"' in conf
 
 
@@ -244,12 +222,14 @@ class TestMinimalTemplate:
 
     def test_socket_emits_minimal_with_llm(self):
         """Socket + LLM ⇒ only /llm-proxy, no browser surface (#1398)."""
-        _set(
-            listen="/tmp/klangk.sock",
-            llm_base_url="http://127.0.0.1:11434",
-            nginx_port="8995",
+        s = KlangkSettings(
+            env={
+                "KLANGK_LISTEN": "/tmp/klangk.sock",
+                "KLANGK_LLM_BASE_URL": "http://127.0.0.1:11434",
+                "KLANGK_NGINX_PORT": "8995",
+            }
         )
-        conf = render_config(uds_upstream("/tmp/klangk.sock"))
+        conf = render_config(uds_upstream("/tmp/klangk.sock"), s)
         # /llm-proxy container-egress location is present, token-gated.
         assert "location ~ ^/llm-proxy/" in conf
         assert "auth_request /api/v1/auth/verify-workspace-token;" in conf
@@ -267,8 +247,13 @@ class TestMinimalTemplate:
 
     def test_socket_no_llm_emits_listener_only(self):
         """Socket + no LLM ⇒ no /llm-proxy, no auth locations; just listener."""
-        _set(listen="/tmp/klangk.sock", nginx_port="8995")
-        conf = render_config(uds_upstream("/tmp/klangk.sock"))
+        s = KlangkSettings(
+            env={
+                "KLANGK_LISTEN": "/tmp/klangk.sock",
+                "KLANGK_NGINX_PORT": "8995",
+            }
+        )
+        conf = render_config(uds_upstream("/tmp/klangk.sock"), s)
         assert "location ~ ^/llm-proxy/" not in conf
         assert "verify-workspace-token" not in conf
         assert "@token_auth_failed" not in conf
@@ -279,12 +264,14 @@ class TestMinimalTemplate:
     def test_socket_single_container_egress_listener(self):
         """No client-facing TCP: exactly one listen (container-egress), no
         browser catch-all location (#1398 criterion 3)."""
-        _set(
-            listen="/tmp/klangk.sock",
-            llm_base_url="http://127.0.0.1:11434",
-            nginx_port="8995",
+        s = KlangkSettings(
+            env={
+                "KLANGK_LISTEN": "/tmp/klangk.sock",
+                "KLANGK_LLM_BASE_URL": "http://127.0.0.1:11434",
+                "KLANGK_NGINX_PORT": "8995",
+            }
         )
-        conf = render_config(uds_upstream("/tmp/klangk.sock"))
+        conf = render_config(uds_upstream("/tmp/klangk.sock"), s)
         # Exactly one listen directive — the container-egress nginx_port.
         assert conf.count("\n    listen ") == 1
         assert "listen 8995;" in conf
@@ -293,8 +280,10 @@ class TestMinimalTemplate:
 
     def test_tcp_emits_full_template(self):
         """Regression guard: TCP LISTEN ⇒ full browser template (#1398 #2)."""
-        _set(listen="127.0.0.1", nginx_port="8995")
-        conf = render_config(tcp_upstream("127.0.0.1", "8997"))
+        s = KlangkSettings(
+            env={"KLANGK_LISTEN": "127.0.0.1", "KLANGK_NGINX_PORT": "8995"}
+        )
+        conf = render_config(tcp_upstream("127.0.0.1", "8997"), s)
         assert "location / {" in conf
         assert "/api/v1/browser-delegate" in conf
         assert "/api/v1/auth/local" in conf
@@ -304,29 +293,37 @@ class TestMinimalTemplate:
         """AUTH value does not change which template is rendered (#1398 #4):
         socket ⇒ minimal and TCP ⇒ full across auth values."""
         for auth in ("none", "password", "both"):
-            _set(
-                listen="/tmp/klangk.sock",
-                auth_modes=auth,
-                llm_base_url="http://127.0.0.1:11434",
-                nginx_port="8995",
+            s_sock = KlangkSettings(
+                env={
+                    "KLANGK_LISTEN": "/tmp/klangk.sock",
+                    "KLANGK_AUTH_MODES": auth,
+                    "KLANGK_LLM_BASE_URL": "http://127.0.0.1:11434",
+                    "KLANGK_NGINX_PORT": "8995",
+                }
             )
-            minimal = render_config(uds_upstream("/tmp/klangk.sock"))
+            minimal = render_config(uds_upstream("/tmp/klangk.sock"), s_sock)
             assert "location / {" not in minimal
             assert "location ~ ^/llm-proxy/" in minimal
 
-            _set(listen="127.0.0.1", auth_modes=auth, nginx_port="8995")
-            full = render_config(tcp_upstream("127.0.0.1", "8997"))
+            s_tcp = KlangkSettings(
+                env={
+                    "KLANGK_LISTEN": "127.0.0.1",
+                    "KLANGK_AUTH_MODES": auth,
+                    "KLANGK_NGINX_PORT": "8995",
+                }
+            )
+            full = render_config(tcp_upstream("127.0.0.1", "8997"), s_tcp)
             assert "location / {" in full
 
 
 class TestFindNginxBin:
     def test_configured(self):
-        _set(nginx_bin="/custom/nginx")
-        assert find_nginx_bin() == "/custom/nginx"
+        s = KlangkSettings(env={"KLANGK_NGINX_BIN": "/custom/nginx"})
+        assert find_nginx_bin(s) == "/custom/nginx"
 
     def test_fallback_to_which(self):
-        _set()
-        result = find_nginx_bin()
+        s = KlangkSettings(env={})
+        result = find_nginx_bin(s)
         # Either found on PATH or falls back to /usr/sbin/nginx.
         assert len(result) > 0
 
@@ -334,9 +331,9 @@ class TestFindNginxBin:
         """When shutil.which returns None, fall back to /usr/sbin/nginx."""
         import klangk_backend.nginx as nginx_mod
 
-        _set()
+        s = KlangkSettings(env={})
         monkeypatch.setattr(nginx_mod.shutil, "which", lambda _: None)
-        assert find_nginx_bin() == "/usr/sbin/nginx"
+        assert find_nginx_bin(s) == "/usr/sbin/nginx"
 
 
 class TestDetectHostIPv4s:
@@ -356,14 +353,14 @@ class TestDnsResolversFromResolvConf:
         """When KLANGK_DNS_SERVERS is unset, nameservers come from resolv.conf."""
         import klangk_backend.nginx as nginx_mod
 
-        _set()  # no dns_servers
+        s = KlangkSettings(env={})
         content = "nameserver 1.1.1.1\nnameserver ::1\n"
         monkeypatch.setattr(
             nginx_mod.Path,
             "read_text",
             lambda self: content,
         )
-        result = detect_dns_resolvers(_settings())
+        result = detect_dns_resolvers(s)
         assert "1.1.1.1" in result
         assert "[::1]" in result
 
@@ -371,13 +368,13 @@ class TestDnsResolversFromResolvConf:
         """OSError reading resolv.conf -> fall back to 8.8.8.8."""
         import klangk_backend.nginx as nginx_mod
 
-        _set()
+        s = KlangkSettings(env={})
 
         def _raise(self):
             raise OSError("no resolv.conf")
 
         monkeypatch.setattr(nginx_mod.Path, "read_text", _raise)
-        assert detect_dns_resolvers(_settings()) == "8.8.8.8"
+        assert detect_dns_resolvers(s) == "8.8.8.8"
 
 
 class TestContainerAclFallback:
@@ -385,9 +382,9 @@ class TestContainerAclFallback:
         """When auto-detect yields nothing, fallback RFC1918 ranges are used."""
         import klangk_backend.nginx as nginx_mod
 
-        _set()  # no container_subnets
+        s = KlangkSettings(env={})
         monkeypatch.setattr(nginx_mod, "detect_host_ipv4s", lambda: [])
-        acl, deny = compute_container_acls(_settings())
+        acl, deny = compute_container_acls(s)
         assert "allow 172.16.0.0/12;" in acl
         assert "allow 10.0.0.0/8;" in acl
         assert "deny 172.16.0.0/12;" in deny
@@ -396,12 +393,12 @@ class TestContainerAclFallback:
 
 class TestWriteConfig:
     def test_writes_file(self, tmp_path):
-        _set(nginx_port="8995")
+        s = KlangkSettings(env={"KLANGK_NGINX_PORT": "8995"})
         conf_path = tmp_path / "nginx.conf"
-        text = render_config(tcp_upstream("127.0.0.1", "8997"))
+        text = render_config(tcp_upstream("127.0.0.1", "8997"), s)
         from klangk_backend.nginx import write_config
 
-        written = write_config(tcp_upstream("127.0.0.1", "8997"), conf_path)
+        written = write_config(tcp_upstream("127.0.0.1", "8997"), conf_path, s)
         assert conf_path.read_text() == text
         assert written == text
 
@@ -461,7 +458,9 @@ class TestWatchdogGate:
         import klangk_backend.main as main
 
         sock = str(tmp_path / "klangk.sock")
-        _set(listen=sock, state_dir=str(tmp_path), nginx_port="19999")
+        monkeypatch.setenv("KLANGK_STATE_DIR", str(tmp_path))
+        monkeypatch.setenv("KLANGK_LISTEN", sock)
+        monkeypatch.setenv("KLANGK_NGINX_PORT", "19999")
         monkeypatch.delenv("_KLANGK_DISABLE_NGINX", raising=False)
         monkeypatch.setattr(
             "klangk_backend.nginx.find_nginx_bin", lambda *a: "/fake/nginx"
@@ -498,11 +497,9 @@ class TestPrepareNginx:
 
         # uvicorn always binds <state_dir>/klangk.sock; _prepare_nginx
         # renders the config pointing at that socket.
-        _set(
-            state_dir=str(tmp_path),
-            nginx_port="19999",
-            llm_base_url="http://127.0.0.1:11434",
-        )
+        monkeypatch.setenv("KLANGK_STATE_DIR", str(tmp_path))
+        monkeypatch.setenv("KLANGK_NGINX_PORT", "19999")
+        monkeypatch.setenv("KLANGK_LLM_BASE_URL", "http://127.0.0.1:11434")
         monkeypatch.setattr(
             "klangk_backend.nginx.find_nginx_bin", lambda *a: "/fake/nginx"
         )


### PR DESCRIPTION
Part of #1426 (composition-root refactor). Implements Slice 2a (#1462).

## What this PR does

### 1. `ContainerRegistry(settings)` + build_app wiring
`ContainerRegistry.__init__` now takes `settings: KlangkSettings | None = None`. `build_app()` constructs `app.state.container_registry = ContainerRegistry(settings)`. The module-level `container.registry` stays as a transitional shim (`ContainerRegistry(get_settings())`) for the ~660 test references that migrate in Slice 2d (#1465).

### 2. Service-session locks
`terminal._service_session_locks` stays physically in `terminal.py` (circular import — terminal can't import container), but the registry now exposes `get/clear/prune_service_session_lock` methods that delegate to terminal's functions. The two `container.py` callers use `self.*` instead of `terminal.*`. The dict moves fully to the registry in Slice 2d.

### 3. `nginx.py` settings threading (10 callers eliminated)
All nginx renderer functions take `settings` as an explicit param. Internal helpers are required-param; public entry points (`render_config`, `write_config`, `find_nginx_bin`) are optional with `get_settings()` fallback for backward compat. `main._prepare_nginx()` passes settings through.

### 4. `podman.py`
`_podman_bin` takes optional settings (same pattern).

## What's deferred
- **Slice 2b (#1463)** — `NginxWatchdog` class → `app.state.nginx_watchdog`
- **Slice 2c (#1464)** — `ConnectionRegistry` (promote `wshandler.state`)
- **Slice 2d (#1465)** — migrate ~660 test references off `container.registry`

2374 passed, 100% coverage, 0 warnings.
