### PR TITLE
Slice 2b: NginxWatchdog class → app.state.nginx_watchdog (#1463)

### DIFF
--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -386,7 +386,7 @@ async def process_shutdown() -> None:
 
 
 # ---------------------------------------------------------------------------
-# nginx child-process ownership (#1396)
+# nginx child-process ownership (#1396, #1463)
 # ---------------------------------------------------------------------------
 # When the server binds a UDS (only klangkd does this), Python owns the nginx
 # child: it renders nginx.conf, spawns nginx pointing at the UDS, and supervises
@@ -395,112 +395,114 @@ async def process_shutdown() -> None:
 # supervisor library — bespoke, matching uvicorn's own precedent. devenv /
 # supervisord remain only the outer restart layer for uvicorn (klangkd).
 
-_nginx_proc: asyncio.subprocess.Process | None = None
-_nginx_task: asyncio.Task | None = None
-_nginx_stopping = False
 
+class NginxWatchdog:
+    """Owns the nginx child process and its supervision task (#1463).
 
-async def _nginx_watchdog(
-    bin_path: str, conf_path: str
-) -> None:  # pragma: no cover
-    """Spawn nginx and respawn it on unexpected exit (with backoff).
-
-    Exits cleanly when ``_nginx_stopping`` is set (a cooperative shutdown).
-    nginx runs in klangkd's process group (no ``start_new_session``) so
-    it is killed automatically when klangkd is terminated (#1439).
+    Constructed with ``settings`` (needed to render nginx.conf via the
+    renderer, which takes settings as of Slice 2a). Stored on
+    ``app.state.nginx_watchdog``; the lifespan calls ``.start()`` /
+    ``.stop()``.
     """
-    global _nginx_proc
-    backoff = 1.0
-    while not _nginx_stopping:
-        _nginx_proc = await asyncio.create_subprocess_exec(
-            bin_path,
-            "-e",
-            "stderr",
-            "-c",
-            conf_path,
-            stdout=None,
-            stderr=None,
+
+    def __init__(self, settings: KlangkSettings) -> None:
+        self._settings = settings
+        self._proc: asyncio.subprocess.Process | None = None
+        self._task: asyncio.Task | None = None
+        self._stopping = False
+
+    async def _watch(
+        self, bin_path: str, conf_path: str
+    ) -> None:  # pragma: no cover
+        """Spawn nginx and respawn it on unexpected exit (with backoff).
+
+        Exits cleanly when ``_stopping`` is set (a cooperative shutdown).
+        nginx runs in klangkd's process group (no ``start_new_session``) so
+        it is killed automatically when klangkd is terminated (#1439).
+        """
+        backoff = 1.0
+        while not self._stopping:
+            self._proc = await asyncio.create_subprocess_exec(
+                bin_path,
+                "-e",
+                "stderr",
+                "-c",
+                conf_path,
+                stdout=None,
+                stderr=None,
+            )
+            logger.info(
+                "nginx started (pid %d) with %s", self._proc.pid, conf_path
+            )
+            rc = await self._proc.wait()
+            self._proc = None
+            if self._stopping:
+                return
+            logger.warning(
+                "nginx exited (rc=%d); restarting in %.1fs", rc, backoff
+            )
+            await asyncio.sleep(backoff)
+            backoff = min(backoff * 2, 30.0)
+
+    def _prepare(self) -> tuple[str, str]:
+        """Render nginx.conf and return ``(bin_path, conf_path)``.
+
+        uvicorn always binds a UDS (``<state_dir>/klangk.sock``); nginx proxies
+        to that socket regardless of whether ``KLANGK_LISTEN`` is a socket path
+        or a TCP address. ``KLANGK_LISTEN`` only controls the *nginx template*
+        (minimal/headless vs full/browser) and the nginx listen directive, not
+        the upstream.
+        """
+        state_dir = (
+            resolve_indirection(self._settings.state_dir)
+            or "/tmp/klangk-state"
         )
-        logger.info(
-            "nginx started (pid %d) with %s", _nginx_proc.pid, conf_path
+        uds_path = os.path.join(state_dir, "klangk.sock")
+        conf_path = os.path.join(state_dir, "nginx.conf")
+        bin_path = nginx_mod.find_nginx_bin(self._settings)
+        nginx_mod.write_config(
+            nginx_mod.uds_upstream(uds_path), conf_path, self._settings
         )
-        rc = await _nginx_proc.wait()
-        _nginx_proc = None
-        if _nginx_stopping:
+        return bin_path, conf_path
+
+    async def start(self) -> None:
+        """Render nginx.conf and start the nginx watchdog.
+
+        Gated only by ``_KLANGK_DISABLE_NGINX`` — an **internal,
+        non-user-facing** env var the test suite sets to suppress nginx spawn
+        (tests boot the app via the lifespan and don't want a real nginx
+        process). Not a documented config knob; no operator-facing name.
+        """
+        if os.environ.get("_KLANGK_DISABLE_NGINX"):
             return
-        logger.warning(
-            "nginx exited (rc=%d); restarting in %.1fs", rc, backoff
-        )
-        await asyncio.sleep(backoff)
-        backoff = min(backoff * 2, 30.0)
+        bin_path, conf_path = self._prepare()
+        self._stopping = False
+        # The real watchdog (nginx spawn + respawn loop) is covered by the
+        # e2e ACL suite; here create_task just schedules the coroutine.
+        self._task = asyncio.create_task(self._watch(bin_path, conf_path))
 
-
-def _prepare_nginx() -> tuple[str, str]:
-    """Render nginx.conf and return ``(bin_path, conf_path)``.
-
-    uvicorn always binds a UDS (``<state_dir>/klangk.sock``); nginx proxies
-    to that socket regardless of whether ``KLANGK_LISTEN`` is a socket path
-    or a TCP address. ``KLANGK_LISTEN`` only controls the *nginx template*
-    (minimal/headless vs full/browser) and the nginx listen directive, not
-    the upstream.
-    """
-    settings = get_settings()
-    state_dir = (
-        resolve_indirection(settings.state_dir) or "/tmp/klangk-state"
-    )
-    uds_path = os.path.join(state_dir, "klangk.sock")
-    conf_path = os.path.join(state_dir, "nginx.conf")
-    bin_path = nginx_mod.find_nginx_bin(settings)
-    nginx_mod.write_config(nginx_mod.uds_upstream(uds_path), conf_path, settings)
-    return bin_path, conf_path
-
-
-async def start_nginx_watchdog() -> None:
-    """Render nginx.conf and start the nginx watchdog.
-
-    nginx is always klangkd's child (rendered + spawned + supervised here),
-    regardless of transport — the bind only changes what nginx proxies to
-    (a UDS upstream vs a TCP upstream), not whether nginx exists. No external
-    supervisor manages klangk's nginx.
-
-    Gated only by ``_KLANGK_DISABLE_NGINX`` — an **internal, non-user-facing**
-    env var the test suite sets to suppress nginx spawn (tests boot the app
-    via the lifespan and don't want a real nginx process). Not a documented
-    config knob; no operator-facing name.
-    """
-    global _nginx_task, _nginx_stopping
-    if os.environ.get("_KLANGK_DISABLE_NGINX"):
-        return
-    bin_path, conf_path = _prepare_nginx()
-    _nginx_stopping = False
-    # The real watchdog (nginx spawn + respawn loop) is covered by the e2e ACL
-    # suite; here create_task just schedules the coroutine.
-    _nginx_task = asyncio.create_task(_nginx_watchdog(bin_path, conf_path))
-
-
-async def stop_nginx_watchdog() -> None:
-    """Stop nginx and cancel the watchdog (cooperative: waits for exit)."""
-    global _nginx_proc, _nginx_task, _nginx_stopping
-    _nginx_stopping = True
-    proc = _nginx_proc
-    # The proc-kill branch is only reached when nginx was spawned (UDS mode);
-    # covered via TestStopWatchdogWithInjectedState + the e2e ACL teardown.
-    if proc is not None and proc.returncode is None:
-        proc.terminate()
-        try:
-            await asyncio.wait_for(proc.wait(), timeout=5)
-        except asyncio.TimeoutError:
-            proc.kill()
-    _nginx_proc = None
-    task = _nginx_task
-    # Same: only when a watchdog task was created (UDS mode).
-    if task is not None:
-        task.cancel()
-        try:
-            await task
-        except asyncio.CancelledError:
-            pass
-    _nginx_task = None
+    async def stop(self) -> None:
+        """Stop nginx and cancel the watchdog (cooperative: waits for exit)."""
+        self._stopping = True
+        proc = self._proc
+        # The proc-kill branch is only reached when nginx was spawned (UDS
+        # mode); covered via TestStopWatchdog + the e2e ACL teardown.
+        if proc is not None and proc.returncode is None:
+            proc.terminate()
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=5)
+            except asyncio.TimeoutError:
+                proc.kill()
+        self._proc = None
+        task = self._task
+        # Same: only when a watchdog task was created (UDS mode).
+        if task is not None:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        self._task = None
 
 
 # Serializes concurrent SIGHUP-triggered restarts so a second signal
@@ -583,7 +585,7 @@ async def lifespan(app: FastAPI):
     await startup()
     # Start nginx (only when bound to a UDS — klangkd; no-op for TCP tests).
     # Rendered + owned by Python (#1396); replaces scripts/nginx.sh.
-    await start_nginx_watchdog()
+    await app.state.nginx_watchdog.start()
     logger.info("Klangk backend started")
 
     # uvicorn only handles SIGINT/SIGTERM, so SIGHUP is ours to claim:
@@ -596,10 +598,11 @@ async def lifespan(app: FastAPI):
         yield
     finally:
         loop.remove_signal_handler(signal.SIGHUP)
-        await stop_nginx_watchdog()
+        await app.state.nginx_watchdog.stop()
         await runtime_shutdown()
         await process_shutdown()
         logger.info("Klangk backend stopped")
+
 
 def setup_logfire(app: FastAPI) -> bool:
     """Enable Logfire instrumentation if LOGFIRE_TOKEN is set."""
@@ -724,6 +727,9 @@ def build_app(settings: KlangkSettings) -> FastAPI:
     # Slice 2 (#1449): the container registry is an owned instance, not a
     # module global. The lifespan reads app.state.container_registry.
     app.state.container_registry = container.ContainerRegistry(settings)
+    # Slice 2b (#1463): nginx watchdog is an owned instance with start/stop
+    # lifecycle methods called by the lifespan.
+    app.state.nginx_watchdog = NginxWatchdog(settings)
 
     app.add_middleware(
         CORSMiddleware,

--- a/src/backend/tests/test_main.py
+++ b/src/backend/tests/test_main.py
@@ -288,6 +288,7 @@ class TestLifespan:
         monkeypatch.setenv("KLANGK_LISTEN", "127.0.0.1")
         monkeypatch.delenv("KLANGK_PREVENT_INSECURE_JWT_SECRET", raising=False)
         app = FastAPI()
+        app.state.nginx_watchdog = main.NginxWatchdog(KlangkSettings(env={}))
         with (
             patch.object(
                 main.container.registry,
@@ -495,6 +496,7 @@ class TestStartupShutdownRestart:
         monkeypatch.setenv("KLANGK_LISTEN", "127.0.0.1")
         monkeypatch.delenv("KLANGK_PREVENT_INSECURE_JWT_SECRET", raising=False)
         app = FastAPI()
+        app.state.nginx_watchdog = main.NginxWatchdog(KlangkSettings(env={}))
         loop = asyncio.get_running_loop()
         with (
             patch.object(
@@ -916,7 +918,11 @@ class TestBuildApp:
 
     def test_build_app_has_ws_endpoint(self):
         app = main.build_app(KlangkSettings(env={}))
-        ws_paths = {r.path for r in app.routes if hasattr(r, "path") and r.path == "/ws"}
+        ws_paths = {
+            r.path
+            for r in app.routes
+            if hasattr(r, "path") and r.path == "/ws"
+        }
         assert "/ws" in ws_paths
 
     def test_build_app_registers_exception_handlers(self):

--- a/src/backend/tests/test_nginx.py
+++ b/src/backend/tests/test_nginx.py
@@ -44,9 +44,7 @@ class TestClientMaxBodySize:
         assert compute_client_max_body_size(s) == "1m"
 
     def test_garbage_falls_back(self):
-        s = KlangkSettings(
-            env={"KLANGK_FILE_UPLOAD_SIZE_MAX": "not-a-number"}
-        )
+        s = KlangkSettings(env={"KLANGK_FILE_UPLOAD_SIZE_MAX": "not-a-number"})
         assert compute_client_max_body_size(s) == "500m"
 
 
@@ -102,9 +100,7 @@ class TestDnsResolvers:
 
     def test_empty_tokens_skipped(self):
         """Trailing commas / empty entries in KLANGK_DNS_SERVERS are skipped."""
-        s = KlangkSettings(
-            env={"KLANGK_DNS_SERVERS": "1.2.3.4,,5.6.7.8,"}
-        )
+        s = KlangkSettings(env={"KLANGK_DNS_SERVERS": "1.2.3.4,,5.6.7.8,"})
         result = detect_dns_resolvers(s)
         assert "1.2.3.4" in result
         assert "5.6.7.8" in result
@@ -171,9 +167,7 @@ class TestRenderConfig:
         assert "deny all;" in block
 
     def test_hosted_disabled(self):
-        s = KlangkSettings(
-            env={"KLANGK_HOSTED_PORTS_PER_WORKSPACE": "0"}
-        )
+        s = KlangkSettings(env={"KLANGK_HOSTED_PORTS_PER_WORKSPACE": "0"})
         conf = render_config(tcp_upstream("127.0.0.1", "8997"), s)
         assert "location ^~ /hosted/ {" in conf
         assert "return 404;" in conf
@@ -436,31 +430,36 @@ class TestKlangkdHelpers:
 
 
 class TestWatchdogGate:
-    """start_nginx_watchdog respects the test kill switch; otherwise prepares+spawns."""
+    """NginxWatchdog.start() respects the test kill switch; otherwise prepares+spawns."""
 
     @pytest.mark.asyncio
     async def test_start_noop_when_disabled(self, monkeypatch):
         """No-op when the test-only _KLANGK_DISABLE_NGINX is set."""
-        import klangk_backend.main as main
+        from klangk_backend.main import NginxWatchdog
 
         monkeypatch.setenv("_KLANGK_DISABLE_NGINX", "1")
-        await main.start_nginx_watchdog()
-        assert main._nginx_task is None  # killed by the switch
+        wd = NginxWatchdog(KlangkSettings(env={}))
+        await wd.start()
+        assert wd._task is None
 
     @pytest.mark.asyncio
     async def test_start_runs_prepare_when_enabled(
         self, monkeypatch, tmp_path
     ):
-        """When not disabled, start_nginx_watchdog runs _prepare_nginx then spawns
-        (a stubbed) watchdog. The real nginx spawn is e2e-covered; here
-        _nginx_watchdog is stubbed so the orchestration (prepare, set
-        _nginx_stopping=False, create_task) is unit-tested."""
-        import klangk_backend.main as main
+        """When not disabled, start() runs _prepare then spawns (a stubbed)
+        watchdog. The real nginx spawn is e2e-covered; here _watch is stubbed
+        so the orchestration (prepare, set _stopping=False, create_task) is
+        unit-tested."""
+        from klangk_backend.main import NginxWatchdog
 
         sock = str(tmp_path / "klangk.sock")
-        monkeypatch.setenv("KLANGK_STATE_DIR", str(tmp_path))
-        monkeypatch.setenv("KLANGK_LISTEN", sock)
-        monkeypatch.setenv("KLANGK_NGINX_PORT", "19999")
+        s = KlangkSettings(
+            env={
+                "KLANGK_STATE_DIR": str(tmp_path),
+                "KLANGK_LISTEN": sock,
+                "KLANGK_NGINX_PORT": "19999",
+            }
+        )
         monkeypatch.delenv("_KLANGK_DISABLE_NGINX", raising=False)
         monkeypatch.setattr(
             "klangk_backend.nginx.find_nginx_bin", lambda *a: "/fake/nginx"
@@ -468,42 +467,43 @@ class TestWatchdogGate:
 
         spawned = {}
 
-        async def _fake_watchdog(bin_path, conf_path):
+        async def _fake_watch(self_wd, bin_path, conf_path):
             spawned["bin"] = bin_path
             spawned["conf"] = conf_path
 
-        monkeypatch.setattr(main, "_nginx_watchdog", _fake_watchdog)
-        await main.start_nginx_watchdog()
+        monkeypatch.setattr(NginxWatchdog, "_watch", _fake_watch)
+        wd = NginxWatchdog(s)
+        await wd.start()
         try:
-            assert main._nginx_task is not None
-            assert main._nginx_stopping is False
-            # prepare ran: config written + paths passed to the watchdog.
+            assert wd._task is not None
+            assert wd._stopping is False
             assert (tmp_path / "nginx.conf").is_file()
-            await main._nginx_task  # let the stub complete
+            await wd._task
             assert spawned["bin"] == "/fake/nginx"
         finally:
             import klangk_backend.util as util
 
             util.set_uds_mode(False)
-            main._nginx_task = None
-            main._nginx_proc = None
 
 
 class TestPrepareNginx:
-    """_prepare_nginx renders nginx.conf with UDS upstream (#1400)."""
+    """NginxWatchdog._prepare() renders nginx.conf with UDS upstream (#1400)."""
 
     def test_renders_config_and_returns_paths(self, monkeypatch, tmp_path):
-        import klangk_backend.main as main
+        from klangk_backend.main import NginxWatchdog
 
-        # uvicorn always binds <state_dir>/klangk.sock; _prepare_nginx
-        # renders the config pointing at that socket.
-        monkeypatch.setenv("KLANGK_STATE_DIR", str(tmp_path))
-        monkeypatch.setenv("KLANGK_NGINX_PORT", "19999")
-        monkeypatch.setenv("KLANGK_LLM_BASE_URL", "http://127.0.0.1:11434")
+        s = KlangkSettings(
+            env={
+                "KLANGK_STATE_DIR": str(tmp_path),
+                "KLANGK_NGINX_PORT": "19999",
+                "KLANGK_LLM_BASE_URL": "http://127.0.0.1:11434",
+            }
+        )
         monkeypatch.setattr(
             "klangk_backend.nginx.find_nginx_bin", lambda *a: "/fake/nginx"
         )
-        bin_path, conf_path = main._prepare_nginx()
+        wd = NginxWatchdog(s)
+        bin_path, conf_path = wd._prepare()
         assert bin_path == "/fake/nginx"
         assert conf_path == str(tmp_path / "nginx.conf")
         assert (tmp_path / "nginx.conf").is_file()
@@ -512,25 +512,24 @@ class TestPrepareNginx:
         assert f"proxy_pass http://unix:{uds_path}:" in conf
 
 
-class TestStopWatchdogWithInjectedState:
-    """stop_nginx_watchdog teardown when a proc/task were injected."""
+class TestStopWatchdog:
+    """NginxWatchdog.stop() teardown when a proc/task were injected."""
 
     @pytest.mark.asyncio
     async def test_stops_no_proc_no_task(self):
         """Nothing spawned: just clears state (the no-op path)."""
-        import klangk_backend.main as main
+        from klangk_backend.main import NginxWatchdog
 
-        main._nginx_proc = None
-        main._nginx_task = None
-        await main.stop_nginx_watchdog()
-        assert main._nginx_proc is None
-        assert main._nginx_task is None
-        assert main._nginx_stopping is True
+        wd = NginxWatchdog(KlangkSettings(env={}))
+        await wd.stop()
+        assert wd._proc is None
+        assert wd._task is None
+        assert wd._stopping is True
 
     @pytest.mark.asyncio
     async def test_stops_terminates_running_proc(self):
         """A still-running nginx proc is terminated, then awaited."""
-        import klangk_backend.main as main
+        from klangk_backend.main import NginxWatchdog
 
         terminated = []
 
@@ -546,18 +545,16 @@ class TestStopWatchdogWithInjectedState:
             async def wait(self):
                 return 0
 
-        main._nginx_proc = FakeProc()
-        main._nginx_task = None
-        await main.stop_nginx_watchdog()
+        wd = NginxWatchdog(KlangkSettings(env={}))
+        wd._proc = FakeProc()
+        await wd.stop()
         assert terminated == [True]
-        assert main._nginx_proc is None
+        assert wd._proc is None
 
     @pytest.mark.asyncio
     async def test_stops_cancels_task(self):
         """A watchdog task is cancelled and awaited. Covers the task branch."""
-        import klangk_backend.main as main
-
-        main._nginx_proc = None  # no proc branch
+        from klangk_backend.main import NginxWatchdog
 
         async def _long_running():
             try:
@@ -565,14 +562,16 @@ class TestStopWatchdogWithInjectedState:
             except asyncio.CancelledError:
                 raise
 
-        main._nginx_task = asyncio.create_task(_long_running())
-        await main.stop_nginx_watchdog()
-        assert main._nginx_task is None
+        wd = NginxWatchdog(KlangkSettings(env={}))
+        wd._task = asyncio.create_task(_long_running())
+        await wd.stop()
+        assert wd._task is None
 
     @pytest.mark.asyncio
     async def test_stops_kills_on_timeout(self, monkeypatch):
         """If the proc doesn't exit within the timeout, kill() follows."""
         import klangk_backend.main as main
+        from klangk_backend.main import NginxWatchdog
 
         actions = []
 
@@ -594,8 +593,8 @@ class TestStopWatchdogWithInjectedState:
             raise asyncio.TimeoutError()
 
         monkeypatch.setattr(main.asyncio, "wait_for", _fake_wait_for)
-        main._nginx_proc = HungProc()
-        main._nginx_task = None
-        await main.stop_nginx_watchdog()
+        wd = NginxWatchdog(KlangkSettings(env={}))
+        wd._proc = HungProc()
+        await wd.stop()
         assert actions == ["terminate", "kill"]
-        assert main._nginx_proc is None
+        assert wd._proc is None

--- a/src/backend/tests/test_nginx.py
+++ b/src/backend/tests/test_nginx.py
@@ -480,6 +480,7 @@ class TestWatchdogGate:
             assert (tmp_path / "nginx.conf").is_file()
             await wd._task
             assert spawned["bin"] == "/fake/nginx"
+            assert spawned["conf"] == str(tmp_path / "nginx.conf")
         finally:
             import klangk_backend.util as util
 


### PR DESCRIPTION
## Summary

Part of #1426 (composition-root refactor). Implements #1463 (Slice 2b of #1449).

- Replace 3 module globals (`_nginx_proc`, `_nginx_task`, `_nginx_stopping`) and 4 free functions (`_nginx_watchdog`, `_prepare_nginx`, `start_nginx_watchdog`, `stop_nginx_watchdog`) with a `NginxWatchdog` class
- `NginxWatchdog(settings)` constructed in `build_app()`, stored on `app.state.nginx_watchdog`
- Lifespan calls `.start()` / `.stop()` on the instance
- `_KLANGK_DISABLE_NGINX` test gate preserved
- Tests construct `NginxWatchdog(KlangkSettings(env={...}))` directly — no module globals to inject into

## Test plan

- [x] 2374 passed, 100% coverage, 0 warnings
- [ ] CI passes (backend + E2E)
