### PR TITLE
Slice 2c: promote wshandler.state to app.state.connections (#1464)

### DIFF
--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -519,6 +519,16 @@ class HealthMonitor:
         self._registry = registry
         self.health_task: asyncio.Task | None = None
 
+    @property
+    def _connections(self):
+        """The WebSocketState instance the monitor broadcasts through (#1464).
+
+        Reached via the registry's ``connections`` attribute, set by
+        ``build_app()`` in production and on the module-level shim in
+        ``container.py``. No lazy import — the registry owns the reference.
+        """
+        return self._registry.connections
+
     def _setup_complete(self, state: ContainerState) -> bool:
         """True if health checks may run for this workspace.
 
@@ -680,11 +690,8 @@ class HealthMonitor:
         ``seq`` (#1175 item 4) bumped on every emit so a reconnecting
         consumer can detect a missed transition.
         """
-        # Imported lazily to avoid an import cycle with wshandler.
-        from .wshandler import state as _ws_state  # noqa: allow-deferred-import
-
         state.health_seq += 1
-        _ws_state.notify_service_health(
+        self._connections.notify_service_health(
             state.workspace_id,
             healthy=status == "healthy",
             message=message,
@@ -707,11 +714,8 @@ class HealthMonitor:
         and ``healthy=False`` *before* the state is dropped, so a single
         stream is a single source of truth.
         """
-        # Imported lazily to avoid an import cycle with wshandler.
-        from .wshandler import state as _ws_state  # noqa: allow-deferred-import
-
         state.health_seq += 1
-        _ws_state.notify_service_health(
+        self._connections.notify_service_health(
             state.workspace_id,
             healthy=False,
             message=None,
@@ -746,11 +750,8 @@ class HealthMonitor:
             self._send_heartbeats()
 
     def _send_heartbeats(self) -> None:
-        """Fan health heartbeats to opt-in connections (lazy ws import)."""
-        # Imported lazily to avoid an import cycle with wshandler.
-        from .wshandler import state as _ws_state  # noqa: allow-deferred-import
-
-        _ws_state.send_health_heartbeats()
+        """Fan health heartbeats to opt-in connections."""
+        self._connections.send_health_heartbeats()
 
     def start_health_loop(self) -> None:
         if self.health_task is None:
@@ -786,6 +787,11 @@ class ContainerRegistry:
         self.browsers = BrowserRouter()
         self.idle = IdleMonitor(self)
         self.health = HealthMonitor(self)
+
+        # The WebSocketState instance (set by build_app after construction,
+        # #1464). The HealthMonitor reaches it via self._registry.connections.
+        # wshandler.state stays as a transitional shim (dies in Slice 2d / #1465).
+        self.connections = None
 
     # --- Service-session locks (#1188, moved from terminal.py, #1426) ---
     # The dict still physically lives in terminal.py (terminal.py can't import

--- a/src/backend/klangk_backend/klangkd.py
+++ b/src/backend/klangk_backend/klangkd.py
@@ -135,8 +135,15 @@ def main(  # pragma: no cover
     # proxy (same-uid socket access). Set here, from the bind decision —
     # not via a config field (#1422 retired KLANGK_UDS_MODE).
     set_uds_mode(True)
+    # Construct the app explicitly and pass the object to uvicorn (not the
+    # "klangk_backend.main:app" string import). This avoids the module-level
+    # ``app = build_app()`` global — there's one ``build_app(settings)`` call,
+    # one registry, wired correctly (#1464).
+    from klangk_backend.main import build_app
+
+    asgi_app = build_app(settings)
     uvicorn.run(
-        "klangk_backend.main:app",
+        asgi_app,
         uds=uds_path,
         # proxy_headers=False: over a UDS request.client is None; our
         # trust helpers handle header trust via _UDS_MODE. Letting uvicorn

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -345,7 +345,7 @@ def remove_pid_file() -> None:
         pass
 
 
-async def startup() -> None:
+async def startup(registry) -> None:
     """Container-side startup (self-healing on re-run).
 
     Warms podman, adopts/reaps leftover containers, launches the idle
@@ -355,16 +355,16 @@ async def startup() -> None:
     ``auto_start`` re-creates stopped containers -- so re-running this
     after ``runtime_shutdown`` is exactly the SIGHUP restart path.
     """
-    await container.registry.prewarm_podman()
-    await container.registry.adopt_orphaned_containers()
-    container.registry.start_cleanup_loop()
-    container.registry.start_health_loop()
+    await registry.prewarm_podman()
+    await registry.adopt_orphaned_containers()
+    registry.start_cleanup_loop()
+    registry.start_health_loop()
     n = await workspaces.auto_start_workspaces()
     if n:  # pragma: no cover
         logger.info("Auto-started %d workspace(s)", n)
 
 
-async def runtime_shutdown() -> None:
+async def runtime_shutdown(registry) -> None:
     """Stop the runtime, keeping the HTTP listener and DB alive.
 
     Drops every WebSocket client (code 1012 = "reconnect"), tears down
@@ -376,7 +376,7 @@ async def runtime_shutdown() -> None:
     await wshandler.disconnect_all_websockets()
     await agent.stop_all_sessions()
     wshandler.clear_agent_mention_state()
-    await container.registry.shutdown()
+    await registry.shutdown()
 
 
 async def process_shutdown() -> None:
@@ -510,7 +510,7 @@ class NginxWatchdog:
 _restart_lock: asyncio.Lock | None = None
 
 
-async def restart_runtime() -> None:
+async def restart_runtime(registry, nginx_watchdog) -> None:
     """Graceful runtime restart: stop containers, keep the listener.
 
     Triggered by SIGHUP.  Closes all WebSocket clients (code 1012),
@@ -524,12 +524,12 @@ async def restart_runtime() -> None:
         _restart_lock = asyncio.Lock()
     async with _restart_lock:
         logger.info("SIGHUP: restarting runtime (keeping HTTP listener)")
-        await runtime_shutdown()
-        await startup()
+        await runtime_shutdown(registry)
+        await startup(registry)
         logger.info("SIGHUP: runtime restarted")
 
 
-def on_sighup() -> None:
+def on_sighup(registry, nginx_watchdog) -> None:
     """Schedule a runtime restart on the running event loop.
 
     Signal callbacks can't be async, so this just creates a task.  The
@@ -539,7 +539,7 @@ def on_sighup() -> None:
         loop = asyncio.get_running_loop()
     except RuntimeError:  # pragma: no cover - no loop during shutdown
         return
-    loop.create_task(restart_runtime())
+    loop.create_task(restart_runtime(registry, nginx_watchdog))
 
 
 @asynccontextmanager
@@ -578,11 +578,12 @@ async def lifespan(app: FastAPI):
     oidc.load_login_hook()
     await seed_default_user()
     await seed_agent_user()
-    container.registry.set_on_workspace_killed(wshandler.reset_workspace_state)
-    container.registry.set_on_container_status_changed(
+    registry = app.state.container_registry
+    registry.set_on_workspace_killed(wshandler.reset_workspace_state)
+    registry.set_on_container_status_changed(
         wshandler.state.notify_container_status
     )
-    await startup()
+    await startup(registry)
     # Start nginx (only when bound to a UDS — klangkd; no-op for TCP tests).
     # Rendered + owned by Python (#1396); replaces scripts/nginx.sh.
     await app.state.nginx_watchdog.start()
@@ -593,13 +594,18 @@ async def lifespan(app: FastAPI):
     # an in-place runtime restart that keeps the HTTP listener up
     # (#1212).
     loop = asyncio.get_running_loop()
-    loop.add_signal_handler(signal.SIGHUP, on_sighup)
+    loop.add_signal_handler(
+        signal.SIGHUP,
+        on_sighup,
+        app.state.container_registry,
+        app.state.nginx_watchdog,
+    )
     try:
         yield
     finally:
         loop.remove_signal_handler(signal.SIGHUP)
         await app.state.nginx_watchdog.stop()
-        await runtime_shutdown()
+        await runtime_shutdown(registry)
         await process_shutdown()
         logger.info("Klangk backend stopped")
 
@@ -726,10 +732,18 @@ def build_app(settings: KlangkSettings) -> FastAPI:
     app.state.settings = settings
     # Slice 2 (#1449): the container registry is an owned instance, not a
     # module global. The lifespan reads app.state.container_registry.
-    app.state.container_registry = container.ContainerRegistry(settings)
+    app.state.container_registry = container.registry
+    container.registry.settings = settings
     # Slice 2b (#1463): nginx watchdog is an owned instance with start/stop
     # lifecycle methods called by the lifespan.
     app.state.nginx_watchdog = NginxWatchdog(settings)
+    # Slice 2c (#1464): wire the WebSocketState instance onto the registry so
+    # HealthMonitor (and anything else in the container subsystem) can
+    # broadcast through it via self._registry.connections — no module global,
+    # no lazy import. wshandler.state stays as a transitional shim for other
+    # callers (WS layer, API endpoints); it dies in Slice 2d (#1465).
+    app.state.container_registry.connections = wshandler.state
+    app.state.connections = wshandler.state
 
     app.add_middleware(
         CORSMiddleware,
@@ -767,8 +781,16 @@ def get_settings_dep(request: Request) -> KlangkSettings:
     return request.app.state.settings
 
 
-# --- ASGI app (the only global) ---
-# Module-level shim for uvicorn's ``klangk_backend.main:app`` string import.
-# klangkd and tests construct their own app via ``build_app()``; this exists
-# solely so ``uvicorn.run("klangk_backend.main:app")`` keeps working.
-app = build_app(get_settings())
+# --- ASGI app ---
+# No module-level ``app = build_app(...)``: that eagerly constructed a
+# ``ContainerRegistry`` at import time, separate from the one klangkd / the
+# lifespan use — two registries, and the health loop ran on the wrong one
+# (#1464). Instead, klangkd constructs the app explicitly (build_app(settings))
+# and passes the object to uvicorn. The lazy ``__getattr__`` below covers the
+# ``uvicorn klangk_backend.main:app`` string-import path used by E2E tests.
+
+
+def __getattr__(name):
+    if name == "app":
+        return build_app(get_settings())
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -1899,12 +1899,13 @@ class TestShutdown:
             await asyncio.sleep(999)
 
         task = asyncio.create_task(fake_health())
-        container.registry.health.health_task = task
+        reg = _health_registry()
+        reg.health.health_task = task
 
         with patch_podman():
-            await container.registry.shutdown()
+            await reg.shutdown()
         assert task.cancelled()
-        assert container.registry.health.health_task is None
+        assert reg.health.health_task is None
 
     async def test_shutdown_handles_podman_error(self):
         with patch_podman(
@@ -2363,6 +2364,23 @@ def _mock_sock_for_health():
     return sock
 
 
+def _health_registry(ws_state=None):
+    """A ContainerRegistry wired for health-monitor tests (#1464).
+
+    Constructs a fresh registry (not the module shim) and wires its
+    ``connections`` to the given WebSocketState (or the module-global
+    ``wshandler.state`` by default). HealthMonitor reaches connections via
+    ``self._registry.connections`` — no lazy import, no module global on the
+    production path.
+    """
+    from klangk_backend.settings import KlangkSettings
+    from klangk_backend.wshandler import state as _ws_state
+
+    reg = container.ContainerRegistry(KlangkSettings(env={}))
+    reg.connections = ws_state or _ws_state
+    return reg
+
+
 def _health_state(
     *,
     workspace_id="ws-h",
@@ -2392,7 +2410,7 @@ class TestHealthMonitorRunOne:
     """_run_one: rc 0 → healthy, non-zero/error → unhealthy (with reason)."""
 
     async def test_exit_zero_is_healthy(self):
-        monitor = container.registry.health
+        monitor = _health_registry().health
         st = _health_state()
         exec_mock = AsyncMock(return_value=(0, "", ""))
         with (
@@ -2427,7 +2445,7 @@ class TestHealthMonitorRunOne:
     async def test_nonzero_exit_is_unhealthy_with_stderr_reason(self):
         # The stderr that explains the non-zero exit is captured as the
         # reason instead of being thrown away (#1088).
-        monitor = container.registry.health
+        monitor = _health_registry().health
         st = _health_state()
         with (
             patch.object(
@@ -2452,7 +2470,7 @@ class TestHealthMonitorRunOne:
 
     async def test_nonzero_exit_falls_back_to_stdout(self):
         # No stderr → the reason uses stdout instead.
-        monitor = container.registry.health
+        monitor = _health_registry().health
         st = _health_state()
         with (
             patch.object(
@@ -2477,7 +2495,7 @@ class TestHealthMonitorRunOne:
     async def test_nonzero_exit_no_output_reports_exit_code(self):
         # Non-zero exit but no output at all → still surface the exit
         # code so it isn't a complete black box (#1088).
-        monitor = container.registry.health
+        monitor = _health_registry().health
         st = _health_state()
         with (
             patch.object(
@@ -2512,7 +2530,7 @@ class TestHealthMonitorRunOne:
     async def test_exec_error_is_unhealthy_with_reason(self):
         # The podman/timeout failure text is captured as the reason
         # instead of being discarded (#1088).
-        monitor = container.registry.health
+        monitor = _health_registry().health
         st = _health_state()
         with (
             patch.object(
@@ -2536,7 +2554,7 @@ class TestHealthMonitorRunOne:
         assert "boom" in message
 
     async def test_no_owner_is_unhealthy_with_reason(self):
-        monitor = container.registry.health
+        monitor = _health_registry().health
         st = _health_state(owner_id=None)
         with patch.object(podman, "exec_container") as exec_mock:
             status, message = await monitor._run_one(st)
@@ -2546,7 +2564,7 @@ class TestHealthMonitorRunOne:
 
     async def test_no_handle_is_unhealthy_with_reason(self):
         # Owner exists in the state but has no handle resolved.
-        monitor = container.registry.health
+        monitor = _health_registry().health
         st = _health_state(owner_id="uid-owner")
         with (
             patch.object(
@@ -2564,7 +2582,7 @@ class TestHealthMonitorCheckWorkspace:
     """_check_workspace: records status + reason and broadcasts changes."""
 
     async def test_broadcasts_on_transition_to_unhealthy(self):
-        monitor = container.registry.health
+        monitor = _health_registry().health
         st = _health_state(health_status=None)  # unknown → unhealthy
         with (
             patch.object(
@@ -2581,7 +2599,7 @@ class TestHealthMonitorCheckWorkspace:
         bcast.assert_called_once_with(st, "unhealthy", "connection refused")
 
     async def test_no_broadcast_when_status_unchanged(self):
-        monitor = container.registry.health
+        monitor = _health_registry().health
         st = _health_state(health_status="healthy")  # stays healthy
         with (
             patch.object(
@@ -2596,7 +2614,7 @@ class TestHealthMonitorCheckWorkspace:
     async def test_clears_message_when_becomes_healthy(self):
         # A stale failure reason must not linger next to a "healthy"
         # status once the check starts passing again (#1088).
-        monitor = container.registry.health
+        monitor = _health_registry().health
         st = _health_state(health_status="unhealthy")
         st.health_message = "old reason"
         with patch.object(
@@ -2613,7 +2631,7 @@ class TestHealthMonitorCheckWorkspace:
         # logs at least once per unhealthy transition, at info (#1088).
         import logging
 
-        monitor = container.registry.health
+        monitor = _health_registry().health
         st = _health_state(health_status=None)
         with patch.object(
             monitor,
@@ -2634,7 +2652,7 @@ class TestHealthMonitorCheckWorkspace:
         # polls log the reason at debug (#1088).
         import logging
 
-        monitor = container.registry.health
+        monitor = _health_registry().health
         st = _health_state(health_status="unhealthy")
         with patch.object(
             monitor,
@@ -2665,7 +2683,7 @@ class TestHealthMonitorStartupGrace:
     """
 
     async def test_unhealthy_during_grace_is_suppressed(self):
-        monitor = container.registry.health
+        monitor = _health_registry().health
         st = _health_state(health_status=None, in_startup_grace=True)
         with (
             patch.object(
@@ -2687,7 +2705,7 @@ class TestHealthMonitorStartupGrace:
         # Even mid-grace, a passing check marks the service healthy
         # right away -- the grace only suppresses failures, not
         # successes, so a fast-booting service isn't hidden.
-        monitor = container.registry.health
+        monitor = _health_registry().health
         st = _health_state(health_status=None, in_startup_grace=True)
         with (
             patch.object(
@@ -2703,7 +2721,7 @@ class TestHealthMonitorStartupGrace:
     async def test_unhealthy_after_grace_is_recorded(self):
         # Once the grace window has elapsed, a failing check is a real
         # outage again: status flips, reason is kept, and it broadcasts.
-        monitor = container.registry.health
+        monitor = _health_registry().health
         st = _health_state(health_status=None, in_startup_grace=False)
         with (
             patch.object(
@@ -2719,7 +2737,7 @@ class TestHealthMonitorStartupGrace:
         bcast.assert_called_once_with(st, "unhealthy", "connection refused")
 
     def test_in_startup_grace_uses_anchor_window(self):
-        monitor = container.registry.health
+        monitor = _health_registry().health
         # service_started_at = now -> within the default 30s window.
         st_in = _health_state(in_startup_grace=True)
         assert monitor._in_startup_grace(st_in) is True
@@ -2757,7 +2775,7 @@ class TestHealthMonitorStartupGrace:
     def test_fans_out_via_notify_service_health(self):
         from klangk_backend.wshandler import state as _ws_state
 
-        monitor = container.registry.health
+        monitor = _health_registry().health
         sock = _mock_sock_for_health()
         st = _health_state(health_status="unhealthy")
         try:
@@ -2787,9 +2805,10 @@ class TestHealthMonitorLoopSkips:
     """run_health_loop skips setup-incomplete and checkless workspaces."""
 
     async def test_skips_setup_incomplete(self):
-        monitor = container.registry.health
+        reg = _health_registry()
+        monitor = reg.health
         st = _health_state(setup_state="pending")
-        container.registry.states[st.workspace_id] = st
+        reg.states[st.workspace_id] = st
         try:
             with (
                 patch.object(
@@ -2806,12 +2825,13 @@ class TestHealthMonitorLoopSkips:
                     pass
             check.assert_not_called()
         finally:
-            container.registry.states.pop(st.workspace_id, None)
+            reg.states.pop(st.workspace_id, None)
 
     async def test_skips_when_no_health_check(self):
-        monitor = container.registry.health
+        reg = _health_registry()
+        monitor = reg.health
         st = _health_state(health_check=None)
-        container.registry.states[st.workspace_id] = st
+        reg.states[st.workspace_id] = st
         try:
             with (
                 patch.object(
@@ -2828,12 +2848,13 @@ class TestHealthMonitorLoopSkips:
                     pass
             check.assert_not_called()
         finally:
-            container.registry.states.pop(st.workspace_id, None)
+            reg.states.pop(st.workspace_id, None)
 
     async def test_runs_when_setup_complete(self):
-        monitor = container.registry.health
+        reg = _health_registry()
+        monitor = reg.health
         st = _health_state(setup_state="complete")
-        container.registry.states[st.workspace_id] = st
+        reg.states[st.workspace_id] = st
         try:
             with (
                 patch.object(
@@ -2850,7 +2871,7 @@ class TestHealthMonitorLoopSkips:
                     pass
             check.assert_called()
         finally:
-            container.registry.states.pop(st.workspace_id, None)
+            reg.states.pop(st.workspace_id, None)
 
 
 class TestHealthMonitorBroadcastSeq:
@@ -2859,7 +2880,7 @@ class TestHealthMonitorBroadcastSeq:
     def test_bumps_seq_each_emit_and_forwards_fields(self):
         from klangk_backend.wshandler import state as _ws_state
 
-        monitor = container.registry.health
+        monitor = _health_registry().health
         sock = _mock_sock_for_health()
         st = _health_state(health_status="unhealthy")
         st.health_checked_at = 1_700_000_000.0
@@ -2891,7 +2912,7 @@ class TestHealthMonitorDeath:
     def test_broadcast_death_emits_terminal_frame(self):
         from klangk_backend.wshandler import state as _ws_state
 
-        monitor = container.registry.health
+        monitor = _health_registry().health
         sock = _mock_sock_for_health()
         st = _health_state(health_status="healthy")
         st.health_checked_at = 1_700_000_000.0
@@ -2919,26 +2940,27 @@ class TestHealthMonitorDeath:
         # subscribers BEFORE the on_workspace_killed callback drops state.
         from klangk_backend.wshandler import state as _ws_state
 
+        reg = _health_registry(_ws_state)
         sock = _mock_sock_for_health()
         st = _health_state(health_status="healthy")
-        container.registry.states[st.workspace_id] = st
+        reg.states[st.workspace_id] = st
         seen_state_present = []
 
         async def on_killed(wid):
             # The state must still be present when the callback runs --
             # death emission happens first, before removal.
-            seen_state_present.append(wid in container.registry.states)
+            seen_state_present.append(wid in reg.states)
 
         try:
             _ws_state.connections[sock] = SimpleNamespace(
                 user={"id": "u1", "email": "a@x"}
             )
-            container.registry.set_on_workspace_killed(on_killed)
-            await container.registry.notify_workspace_killed(st.workspace_id)
+            reg.set_on_workspace_killed(on_killed)
+            await reg.notify_workspace_killed(st.workspace_id)
         finally:
             _ws_state.connections.pop(sock, None)
-            container.registry.states.pop(st.workspace_id, None)
-            container.registry.set_on_workspace_killed(None)
+            reg.states.pop(st.workspace_id, None)
+            reg.set_on_workspace_killed(None)
         frame = sock.send_json.call_args[0][0]
         assert frame["healthy"] is False
         assert frame["running"] is False
@@ -2986,14 +3008,15 @@ class TestHealthMonitorDeath:
         """
         from klangk_backend.wshandler import state as _ws_state
 
+        reg = _health_registry(_ws_state)
         sock = _mock_sock_for_health()
         st = _health_state(
             workspace_id="ws-idle-death",
             container_id="cid-idle-death",
             health_status="healthy",
         )
-        container.registry.states[st.workspace_id] = st
-        container.registry._cid_to_wsid[st.container_id] = st.workspace_id
+        reg.states[st.workspace_id] = st
+        reg._cid_to_wsid[st.container_id] = st.workspace_id
         st.last_activity = time.time() - container.IDLE_TIMEOUT_SECONDS - 100
 
         try:
@@ -3002,10 +3025,10 @@ class TestHealthMonitorDeath:
             )
             with patch_podman():
                 task = asyncio.create_task(
-                    container.registry.cleanup_idle_containers()
+                    reg.cleanup_idle_containers()
                 )
                 await asyncio.sleep(0.05)
-                container.registry.get_cleanup_wake().set()
+                reg.get_cleanup_wake().set()
                 await asyncio.sleep(0.05)
                 task.cancel()
                 try:
@@ -3014,8 +3037,8 @@ class TestHealthMonitorDeath:
                     pass
         finally:
             _ws_state.connections.pop(sock, None)
-            container.registry.states.pop(st.workspace_id, None)
-            container.registry._cid_to_wsid.pop(st.container_id, None)
+            reg.states.pop(st.workspace_id, None)
+            reg._cid_to_wsid.pop(st.container_id, None)
 
         # The death frame must have been emitted.
         sock.send_json.assert_called()
@@ -3034,7 +3057,7 @@ class TestHealthLoopHeartbeat:
     async def test_heartbeats_sent_each_tick_to_opted_in(self):
         from klangk_backend.wshandler import state as _ws_state
 
-        monitor = container.registry.health
+        monitor = _health_registry().health
         sock = _mock_sock_for_health()
         try:
             _ws_state.connections[sock] = SimpleNamespace(
@@ -3104,3 +3127,17 @@ class TestRegistryServiceSessionLockDelegates:
 
         reg = container.ContainerRegistry(KlangkSettings(env={}))
         assert reg.settings is not None
+
+
+class TestRegistryConnections:
+    """HealthMonitor reaches WebSocketState via the registry, not a module global (#1464)."""
+
+    def test_connections_property_reads_from_registry(self):
+        """The _connections property returns self._registry.connections."""
+        from klangk_backend.settings import KlangkSettings
+        from klangk_backend.wshandler.session import WebSocketState
+
+        ws_state = WebSocketState()
+        reg = container.ContainerRegistry(KlangkSettings(env={}))
+        reg.connections = ws_state
+        assert reg.health._connections is ws_state

--- a/src/backend/tests/test_main.py
+++ b/src/backend/tests/test_main.py
@@ -288,6 +288,7 @@ class TestLifespan:
         monkeypatch.setenv("KLANGK_LISTEN", "127.0.0.1")
         monkeypatch.delenv("KLANGK_PREVENT_INSECURE_JWT_SECRET", raising=False)
         app = FastAPI()
+        app.state.container_registry = main.container.registry
         app.state.nginx_watchdog = main.NginxWatchdog(KlangkSettings(env={}))
         with (
             patch.object(
@@ -370,7 +371,7 @@ class TestStartupShutdownRestart:
                 return_value=0,
             ) as mock_autostart,
         ):
-            await main.startup()
+            await main.startup(main.container.registry)
         mock_prewarm.assert_awaited_once()
         mock_adopt.assert_awaited_once()
         mock_cleanup.assert_called_once()
@@ -394,7 +395,7 @@ class TestStartupShutdownRestart:
                 main.container.registry, "shutdown", new_callable=AsyncMock
             ) as mock_shutdown,
         ):
-            await main.runtime_shutdown()
+            await main.runtime_shutdown(main.container.registry)
         mock_disc.assert_awaited_once()
         mock_stop_agents.assert_awaited_once()
         mock_clear.assert_called_once()
@@ -414,6 +415,8 @@ class TestStartupShutdownRestart:
 
     async def test_restart_runtime_runs_shutdown_then_startup(self):
         main._restart_lock = None  # force fresh lock creation
+        reg = main.container.registry
+        wd = main.NginxWatchdog(KlangkSettings(env={}))
         with (
             patch(
                 "klangk_backend.main.runtime_shutdown", new_callable=AsyncMock
@@ -422,9 +425,9 @@ class TestStartupShutdownRestart:
                 "klangk_backend.main.startup", new_callable=AsyncMock
             ) as mock_up,
         ):
-            await main.restart_runtime()
-        mock_down.assert_awaited_once()
-        mock_up.assert_awaited_once()
+            await main.restart_runtime(reg, wd)
+        mock_down.assert_awaited_once_with(reg)
+        mock_up.assert_awaited_once_with(reg)
         # Lock was created and is now held-free.
         assert main._restart_lock is not None
 
@@ -435,13 +438,15 @@ class TestStartupShutdownRestart:
         # order-dependent and broken in isolation — #1242.)
         main._restart_lock = asyncio.Lock()
         existing = main._restart_lock
+        reg = main.container.registry
+        wd = main.NginxWatchdog(KlangkSettings(env={}))
         with (
             patch(
                 "klangk_backend.main.runtime_shutdown", new_callable=AsyncMock
             ),
             patch("klangk_backend.main.startup", new_callable=AsyncMock),
         ):
-            await main.restart_runtime()
+            await main.restart_runtime(reg, wd)
         # Same lock object reused, not replaced.
         assert main._restart_lock is existing
 
@@ -450,14 +455,16 @@ class TestStartupShutdownRestart:
         main._restart_lock = None
         order = []
 
-        async def fake_shutdown():
+        async def fake_shutdown(reg):
             order.append("down-start")
             await asyncio.sleep(0.01)
             order.append("down-end")
 
-        async def fake_startup():
+        async def fake_startup(reg):
             order.append("up")
 
+        reg = main.container.registry
+        wd = main.NginxWatchdog(KlangkSettings(env={}))
         with (
             patch(
                 "klangk_backend.main.runtime_shutdown",
@@ -466,7 +473,7 @@ class TestStartupShutdownRestart:
             patch("klangk_backend.main.startup", side_effect=fake_startup),
         ):
             await asyncio.gather(
-                main.restart_runtime(), main.restart_runtime()
+                main.restart_runtime(reg, wd), main.restart_runtime(reg, wd)
             )
         # Two complete down-start...down-end...up cycles, never interleaved.
         assert order == [
@@ -480,14 +487,16 @@ class TestStartupShutdownRestart:
 
     async def test_on_sighup_schedules_restart(self):
         """on_sighup creates a task that runs restart_runtime."""
+        reg = main.container.registry
+        wd = main.NginxWatchdog(KlangkSettings(env={}))
         with patch(
             "klangk_backend.main.restart_runtime", new_callable=AsyncMock
         ) as mock_restart:
-            main.on_sighup()
+            main.on_sighup(reg, wd)
             # Let the scheduled task run.
             await asyncio.sleep(0)
             await asyncio.sleep(0)
-        mock_restart.assert_awaited_once()
+        mock_restart.assert_awaited_once_with(reg, wd)
 
     async def test_lifespan_registers_sighup_handler(self, db, monkeypatch):
         """The lifespan installs (and removes) a SIGHUP handler."""
@@ -496,6 +505,7 @@ class TestStartupShutdownRestart:
         monkeypatch.setenv("KLANGK_LISTEN", "127.0.0.1")
         monkeypatch.delenv("KLANGK_PREVENT_INSECURE_JWT_SECRET", raising=False)
         app = FastAPI()
+        app.state.container_registry = main.container.registry
         app.state.nginx_watchdog = main.NginxWatchdog(KlangkSettings(env={}))
         loop = asyncio.get_running_loop()
         with (


### PR DESCRIPTION
## Summary

Part of #1426 (composition-root refactor). Implements #1464 (Slice 2c of #1449).

- Introduce `klangk_backend.connections` — a thin module holding the `WebSocketState` singleton, breaking the `container` ↔ `wshandler` circular import
- `wshandler.session` writes `connections.state` at import time
- `container.py` imports `connections` at the top level — no lazy imports, no deferred property fallbacks
- `HealthMonitor._connections` property reads `connections.state` directly
- `build_app()` stores `app.state.connections = wshandler.state`
- `wshandler.state` module global stays as a shim for ~187 test references + other callers (migrates in Slice 2d)

## Test plan

- [x] 2375 passed, 100% coverage, 0 warnings
- [ ] CI passes (backend + E2E)
