### PR TITLE
Delete container.registry + wshandler.state module globals (#1475)

### DIFF
--- a/src/backend/klangk_backend/agent.py
+++ b/src/backend/klangk_backend/agent.py
@@ -11,7 +11,7 @@ import logging
 import re
 import time
 
-from . import container, model, podman, util, workspaces
+from . import model, podman, util, workspaces
 
 _THINK_RE = re.compile(r"<think>.*?</think>\s*", re.DOTALL)
 
@@ -145,8 +145,9 @@ async def ensure_agent_home(workspace_id: str, container_id: str) -> str:
 class AgentSession:
     """Wraps a ``pi --mode rpc`` subprocess inside a container."""
 
-    def __init__(self, workspace_id: str) -> None:
+    def __init__(self, workspace_id: str, app_state=None) -> None:
         self.workspace_id = workspace_id
+        self.app_state = app_state
         self._proc: asyncio.subprocess.Process | None = None
         # Serializes prompt round-trips so two concurrent prompts can't
         # interleave their stdin writes / stdout reads on one subprocess.
@@ -166,7 +167,7 @@ class AgentSession:
 
     def _resolve_container_id(self) -> str:
         """Look up the current container ID for this workspace."""
-        state = container.registry.get_state(self.workspace_id)
+        state = self.app_state.container_registry.get_state(self.workspace_id)
         if state is None:
             raise AgentError(
                 f"No container running for workspace {self.workspace_id}"
@@ -305,7 +306,10 @@ class AgentSession:
         if self._proc is not None:
             return  # something else already restarted it
         # If the container is gone (workspace deleted), don't restart.
-        if container.registry.get_state(self.workspace_id) is None:
+        if (
+            self.app_state.container_registry.get_state(self.workspace_id)
+            is None
+        ):
             logger.info(
                 "Container gone for workspace %s, not restarting agent",
                 self.workspace_id,
@@ -550,7 +554,7 @@ class AgentSession:
         self._proc = None
 
 
-async def get_session(workspace_id: str) -> AgentSession:
+async def get_session(workspace_id: str, app_state=None) -> AgentSession:
     """Get or create an AgentSession for the given workspace.
 
     The session resolves the current container ID from the container
@@ -564,7 +568,7 @@ async def get_session(workspace_id: str) -> AgentSession:
     async with _agents_lock:
         session = _agents.get(workspace_id)
         if session is None:
-            session = AgentSession(workspace_id)
+            session = AgentSession(workspace_id, app_state=app_state)
             _agents[workspace_id] = session
         return session
 

--- a/src/backend/klangk_backend/api/__init__.py
+++ b/src/backend/klangk_backend/api/__init__.py
@@ -46,6 +46,7 @@ from .. import (
     plugins,
     wshandler,
 )
+from ._common import get_app_state_dep
 
 # Imported under an alias: the ``from . import auth as _auth_routes`` line
 # below pulls in the api/auth.py *submodule*, and the import machinery writes
@@ -123,11 +124,14 @@ async def version():
 if resolve_env_value("KLANGK_TEST_MODE"):  # pragma: no cover
 
     @router.get("/test/idle-timeout")
-    async def get_idle_timeout(workspace_id: str | None = None):
+    async def get_idle_timeout(
+        workspace_id: str | None = None,
+        app_state=Depends(get_app_state_dep),
+    ):
         """Get the idle timeout (per-workspace or global default)."""
         if workspace_id:
             return {
-                "idle_timeout_seconds": container.registry.get_workspace_idle_timeout(
+                "idle_timeout_seconds": app_state.container_registry.get_workspace_idle_timeout(
                     workspace_id
                 )
             }
@@ -138,12 +142,15 @@ if resolve_env_value("KLANGK_TEST_MODE"):  # pragma: no cover
         workspace_id: str | None = None
 
     @router.post("/test/set-idle-timeout")
-    async def set_idle_timeout(body: SetIdleTimeoutRequest):
+    async def set_idle_timeout(
+        body: SetIdleTimeoutRequest,
+        app_state=Depends(get_app_state_dep),
+    ):
         """Set the idle timeout. Per-workspace if workspace_id given, else global."""
         seconds = body.seconds
         workspace_id = body.workspace_id
         if workspace_id:
-            container.registry.set_workspace_idle_timeout(
+            app_state.container_registry.set_workspace_idle_timeout(
                 workspace_id, seconds
             )
         else:
@@ -157,14 +164,20 @@ if resolve_env_value("KLANGK_TEST_MODE"):  # pragma: no cover
         return {"token": auth.create_workspace_token(workspace_id)}
 
     @router.get("/test/browsers/{workspace_id}")
-    async def get_browsers(workspace_id: str):
+    async def get_browsers(
+        workspace_id: str,
+        app_state=Depends(get_app_state_dep),
+    ):
         """Return all active browser registrations for a workspace (test only)."""
         browsers = []
-        for bid, (ws_id, sock) in container.registry._browsers.items():
+        for bid, (
+            ws_id,
+            sock,
+        ) in app_state.container_registry._browsers.items():
             if ws_id == workspace_id:
                 email = None
                 if sock is not None:
-                    conn = wshandler.state.connections.get(sock)
+                    conn = app_state.sockets.connections.get(sock)
                     if conn:
                         email = conn.user.get("email")
                 browsers.append({"browser_id": bid, "email": email})

--- a/src/backend/klangk_backend/api/_common.py
+++ b/src/backend/klangk_backend/api/_common.py
@@ -65,6 +65,16 @@ async def require_workspace_token(request: Request) -> str:
     return result
 
 
+def get_app_state_dep(request: Request):
+    """Per-request bridge to ``app.state`` (no global read).
+
+    Request handlers obtain app state via
+    ``app_state = Depends(get_app_state_dep)`` instead of
+    reaching for module-level globals (#1426, #1475).
+    """
+    return request.app.state
+
+
 class WorkspaceAclEntry(BaseModel):
     action: int  # 0=deny, 1=allow
     principal_type: int  # 0=system, 1=user, 2=group

--- a/src/backend/klangk_backend/api/admin.py
+++ b/src/backend/klangk_backend/api/admin.py
@@ -15,12 +15,12 @@ from pydantic import BaseModel
 from .. import (
     acl,
     auth,
-    container,
     emailsvc,
     model,
     wshandler,
     workspaces,
 )
+from ._common import get_app_state_dep
 from ..model import (
     ACTION_ALLOW,
     PRINCIPAL_GROUP,
@@ -266,7 +266,9 @@ async def list_user_workspaces(
 
 @router.delete("/admin/users/{user_id}")
 async def delete_user(
-    user_id: str, admin: dict = Depends(acl.has_permission("admin"))
+    user_id: str,
+    admin: dict = Depends(acl.has_permission("admin")),
+    app_state=Depends(get_app_state_dep),
 ):
     if user_id == admin["id"]:
         raise HTTPException(status_code=400, detail="Cannot delete yourself")
@@ -274,7 +276,7 @@ async def delete_user(
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
     # Stop all containers for this user before deleting
-    await container.registry.stop_user_containers(user_id)
+    await app_state.container_registry.stop_user_containers(user_id)
     # Archive workspace data before deletion
     await workspaces.archive_user_data(user_id, user["email"])
     deleted = await model.delete_user(user_id)
@@ -294,6 +296,7 @@ async def update_user(
     user_id: str,
     req: UpdateUserRequest,
     admin: dict = Depends(acl.has_permission("admin")),
+    app_state=Depends(get_app_state_dep),
 ):
     user = await model.get_user_by_id(user_id)
     if user is None:
@@ -309,7 +312,9 @@ async def update_user(
             await model.set_user_handle(user_id, req.handle)
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
-        await wshandler.refresh_user_handle(user_id, req.handle)
+        await wshandler.refresh_user_handle(
+            app_state.sockets, user_id, req.handle
+        )
     return {"status": "updated"}
 
 

--- a/src/backend/klangk_backend/api/auth.py
+++ b/src/backend/klangk_backend/api/auth.py
@@ -22,6 +22,7 @@ from .. import (
     oidc,
     wshandler,
 )
+from ._common import get_app_state_dep
 from ..settings import get_settings
 from ..util import (
     client_is_loopback,
@@ -437,6 +438,7 @@ class ChangeHandleRequest(auth.BaseModel):
 async def change_handle(
     req: ChangeHandleRequest,
     user: dict = Depends(auth.get_current_user),
+    app_state=Depends(get_app_state_dep),
 ):
     """Change the current user's handle. Requires password confirmation."""
     stored = await model.get_user_by_email(user["email"])
@@ -455,7 +457,9 @@ async def change_handle(
         await model.set_user_handle(user["id"], req.handle)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
-    await wshandler.refresh_user_handle(user["id"], req.handle)
+    await wshandler.refresh_user_handle(
+        app_state.sockets, user["id"], req.handle
+    )
     return {"status": "updated", "handle": req.handle}
 
 

--- a/src/backend/klangk_backend/api/browser_delegate.py
+++ b/src/backend/klangk_backend/api/browser_delegate.py
@@ -13,9 +13,9 @@ from fastapi.responses import (
 from pydantic import BaseModel
 
 from .. import (
-    container,
     wshandler,
 )
+from ._common import get_app_state_dep
 from ._common import (
     require_workspace_token,
 )
@@ -31,18 +31,20 @@ class BrowserDelegateRequest(BaseModel):
     browser_id: str
 
 
-def _resolve_bridge_target(body: BrowserDelegateRequest):
+def _resolve_bridge_target(
+    body: BrowserDelegateRequest, container_registry, sockets
+):
     """Resolve a browser ID to (session, target_sock, payload).
 
     Raises HTTPException (403/502) if the browser ID is unknown, the
     workspace has no session, or the target browser is not subscribed.
     """
-    resolved = container.registry.resolve_browser(body.browser_id)
+    resolved = container_registry.resolve_browser(body.browser_id)
     if resolved is None:
         raise HTTPException(status_code=403, detail="Unknown browser ID")
     workspace_id, target_sock = resolved
 
-    session = wshandler.state.get_session(workspace_id)
+    session = sockets.get_session(workspace_id)
     if not session:
         raise HTTPException(
             status_code=502,
@@ -61,6 +63,7 @@ def _resolve_bridge_target(body: BrowserDelegateRequest):
 async def browser_delegate(
     body: BrowserDelegateRequest,
     workspace_id: str = Depends(require_workspace_token),
+    app_state=Depends(get_app_state_dep),
 ):
     """Bridge endpoint for container processes to delegate actions to the browser.
 
@@ -68,7 +71,9 @@ async def browser_delegate(
     and includes it in the POST.  The backend resolves the ID to the
     specific browser tab's WebSocket and relays the request.
     """
-    session, target_sock, payload = _resolve_bridge_target(body)
+    session, target_sock, payload = _resolve_bridge_target(
+        body, app_state.container_registry, app_state.sockets
+    )
     # Credential get operations may wait for user interaction (PAT dialog
     # or OAuth device flow) — allow up to 15 minutes (matching GitHub's
     # device code expiry).
@@ -90,6 +95,7 @@ async def browser_delegate(
 async def browser_delegate_stream(
     body: BrowserDelegateRequest,
     workspace_id: str = Depends(require_workspace_token),
+    app_state=Depends(get_app_state_dep),
 ):
     """Streaming bridge: relay browser output chunks back as NDJSON.
 
@@ -98,7 +104,9 @@ async def browser_delegate_stream(
     to the caller immediately, so there is no single bounded round-trip — the
     only limit is the per-chunk idle timeout.
     """
-    session, target_sock, payload = _resolve_bridge_target(body)
+    session, target_sock, payload = _resolve_bridge_target(
+        body, app_state.container_registry, app_state.sockets
+    )
     return StreamingResponse(
         session.dispatch_browser_request_stream_to(
             target_sock, payload, wshandler.bridge_idle_timeout()

--- a/src/backend/klangk_backend/api/chat.py
+++ b/src/backend/klangk_backend/api/chat.py
@@ -11,8 +11,8 @@ from pydantic import BaseModel
 
 from .. import (
     model,
-    wshandler,
 )
+from ._common import get_app_state_dep
 from ._common import (
     require_workspace_token,
 )
@@ -30,6 +30,7 @@ class WorkspaceChatRequest(BaseModel):
 async def workspace_chat(
     body: WorkspaceChatRequest,
     workspace_id: str = Depends(require_workspace_token),
+    app_state=Depends(get_app_state_dep),
 ):
     """Post a chat message from a container using a workspace JWT.
 
@@ -51,7 +52,7 @@ async def workspace_chat(
         text,
         message_type=model.MSG_AGENT,
     )
-    session = wshandler.state.get_session(workspace_id)
+    session = app_state.sockets.get_session(workspace_id)
     if session:
         session.broadcast({"type": "chat_message", **chat_msg})
     return chat_msg

--- a/src/backend/klangk_backend/api/files.py
+++ b/src/backend/klangk_backend/api/files.py
@@ -17,9 +17,9 @@ from pydantic import BaseModel
 
 from .. import (
     acl,
-    container,
     files,
 )
+from ._common import get_app_state_dep
 from ..util import (
     sanitize_disposition_name,
 )
@@ -33,9 +33,9 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-def _require_container(workspace_id: str) -> str:
+def _require_container(workspace_id: str, container_registry) -> str:
     """Return the container_id for a running workspace, or raise 409."""
-    state = container.registry.get_state(workspace_id)
+    state = container_registry.get_state(workspace_id)
     if state is None:
         raise HTTPException(status_code=409, detail="Container not running")
     state.record_activity()
@@ -47,8 +47,9 @@ async def list_files(
     workspace_id: str,
     path: str = "/",
     user: dict = Depends(acl.has_permission("files", workspace_resource)),
+    app_state=Depends(get_app_state_dep),
 ):
-    cid = _require_container(workspace_id)
+    cid = _require_container(workspace_id, app_state.container_registry)
     try:
         return await files.list_files(cid, path)
     except ValueError as e:
@@ -60,8 +61,9 @@ async def read_file(
     workspace_id: str,
     path: str,
     user: dict = Depends(acl.has_permission("files", workspace_resource)),
+    app_state=Depends(get_app_state_dep),
 ):
-    cid = _require_container(workspace_id)
+    cid = _require_container(workspace_id, app_state.container_registry)
     try:
         content = await files.read_file(cid, path)
     except ValueError as e:
@@ -78,8 +80,9 @@ async def delete_file(
     workspace_id: str,
     path: str,
     user: dict = Depends(acl.has_permission("files", workspace_resource)),
+    app_state=Depends(get_app_state_dep),
 ):
-    cid = _require_container(workspace_id)
+    cid = _require_container(workspace_id, app_state.container_registry)
     try:
         deleted = await files.delete_path(cid, path)
     except ValueError as e:
@@ -101,8 +104,9 @@ async def rename_file(
     workspace_id: str,
     body: RenameFileRequest,
     user: dict = Depends(acl.has_permission("files", workspace_resource)),
+    app_state=Depends(get_app_state_dep),
 ):
-    cid = _require_container(workspace_id)
+    cid = _require_container(workspace_id, app_state.container_registry)
     try:
         renamed = await files.rename_path(cid, body.old_path, body.new_path)
     except ValueError as e:
@@ -123,8 +127,9 @@ async def download_file(
     workspace_id: str,
     path: str,
     user: dict = Depends(acl.has_permission("files", workspace_resource)),
+    app_state=Depends(get_app_state_dep),
 ):
-    cid = _require_container(workspace_id)
+    cid = _require_container(workspace_id, app_state.container_registry)
     try:
         info = await files.stat_path(cid, path)
     except ValueError as e:
@@ -155,8 +160,9 @@ async def upload_file(
     file: UploadFile,
     path: str = "",
     user: dict = Depends(acl.has_permission("files", workspace_resource)),
+    app_state=Depends(get_app_state_dep),
 ):
-    cid = _require_container(workspace_id)
+    cid = _require_container(workspace_id, app_state.container_registry)
 
     filename = path if path else posixpath.basename(file.filename or "")
     if not filename:  # pragma: no cover

--- a/src/backend/klangk_backend/api/workspaces.py
+++ b/src/backend/klangk_backend/api/workspaces.py
@@ -33,6 +33,7 @@ from .. import (
     wshandler,
     workspaces,
 )
+from ._common import get_app_state_dep
 from ..model import (
     ACTION_ALLOW,
     PRINCIPAL_GROUP,
@@ -66,7 +67,7 @@ router = APIRouter()
 BARE_LIST_LIMIT = 500
 
 
-def _annotate_running(items: list[dict]) -> list[dict]:
+def _annotate_running(items: list[dict], container_registry) -> list[dict]:
     """Annotate each workspace dict with live container/health state.
 
     Adds ``running`` (bool) and, for running workspaces, the live
@@ -86,7 +87,7 @@ def _annotate_running(items: list[dict]) -> list[dict]:
     lookup cost. See #1173.
     """
     for ws in items:
-        state = container.registry.get_state(ws["id"])
+        state = container_registry.get_state(ws["id"])
         ws["running"] = state is not None
         if state is not None:
             ws["health"] = state.health_status
@@ -97,6 +98,7 @@ def _annotate_running(items: list[dict]) -> list[dict]:
 @router.get("/workspaces")
 async def list_workspaces(
     user: dict = Depends(auth.get_current_user),
+    app_state=Depends(get_app_state_dep),
     limit: int | None = Query(None, ge=1, le=100),
     offset: int | None = Query(None, ge=0),
     sort: Literal["name", "created"] = Query("created"),
@@ -120,7 +122,7 @@ async def list_workspaces(
         order=order,
         q=q,
     )
-    _annotate_running(result["items"])
+    _annotate_running(result["items"], app_state.container_registry)
     if bare:
         return result["items"]
     return result
@@ -129,6 +131,7 @@ async def list_workspaces(
 @router.get("/workspaces/shared")
 async def list_shared_workspaces(
     user: dict = Depends(auth.get_current_user),
+    app_state=Depends(get_app_state_dep),
     limit: int | None = Query(None, ge=1, le=100),
     offset: int | None = Query(None, ge=0),
     sort: Literal["name", "created"] = Query("created"),
@@ -149,7 +152,7 @@ async def list_shared_workspaces(
         order=order,
         q=q,
     )
-    _annotate_running(result["items"])
+    _annotate_running(result["items"], app_state.container_registry)
     if bare:
         return result["items"]
     return result
@@ -168,7 +171,9 @@ class CreateWorkspaceRequest(BaseModel):
 
 @router.post("/workspaces")
 async def create_workspace(
-    body: CreateWorkspaceRequest, user: dict = Depends(auth.get_current_user)
+    body: CreateWorkspaceRequest,
+    user: dict = Depends(auth.get_current_user),
+    app_state=Depends(get_app_state_dep),
 ):
     if body.auto_start and not resolve_env_bool("KLANGK_ALLOW_AUTOSTART"):
         raise HTTPException(
@@ -197,6 +202,7 @@ async def create_workspace(
             env=body.env,
             setup_state=body.setup_state or "complete",
             health_check=body.health_check,
+            app_state=app_state,
         )
     except SAIntegrityError:
         raise HTTPException(
@@ -213,7 +219,7 @@ async def create_workspace(
     # so workspaces whose setup.sh hasn't run yet defer until complete.
     if body.auto_start:
         try:
-            await workspaces.start_workspace(ws)
+            await workspaces.start_workspace(ws, app_state)
         except Exception:
             logger.warning(
                 "Eager start failed for workspace %s",
@@ -221,7 +227,7 @@ async def create_workspace(
                 exc_info=True,
             )
 
-    wshandler.state.notify_user_workspaces_changed(user["id"])
+    app_state.sockets.notify_user_workspaces_changed(user["id"])
     return ws
 
 
@@ -241,6 +247,7 @@ async def update_workspace(
     workspace_id: str,
     body: UpdateWorkspaceRequest,
     user: dict = Depends(acl.has_permission("edit", workspace_resource)),
+    app_state=Depends(get_app_state_dep),
 ):
     fields = body.model_dump(exclude_unset=True)
     if fields.get("auto_start") and not resolve_env_bool(
@@ -277,7 +284,7 @@ async def update_workspace(
     # state (#1015) so HealthMonitor picks them up without a container
     # restart: setup_state may flip to "complete" after setup finishes,
     # and health_check may be edited at any time.
-    live_state = container.registry.get_state(workspace_id)
+    live_state = app_state.container_registry.get_state(workspace_id)
     if live_state is not None:
         if "setup_state" in fields:
             live_state.setup_state = fields["setup_state"]
@@ -300,6 +307,7 @@ async def duplicate_workspace(
     workspace_id: str,
     body: DuplicateWorkspaceRequest,
     user: dict = Depends(acl.has_permission("create", workspace_resource)),
+    app_state=Depends(get_app_state_dep),
 ):
     source = await model.get_workspace(workspace_id)
     if source is None:  # pragma: no cover — race after ACL check
@@ -314,6 +322,7 @@ async def duplicate_workspace(
             mounts=source.get("mounts"),
             env=source.get("env"),
             health_check=source.get("health_check"),
+            app_state=app_state,
         )
     except SAIntegrityError:
         raise HTTPException(
@@ -327,6 +336,7 @@ async def duplicate_workspace(
 async def delete_workspace(
     workspace_id: str,
     user: dict = Depends(acl.has_permission("delete", workspace_resource)),
+    app_state=Depends(get_app_state_dep),
 ):
     workspace = await model.get_workspace(workspace_id)
     if workspace is None:
@@ -339,7 +349,7 @@ async def delete_workspace(
     # Prefer the live container_id from the registry (tracks the currently
     # running container) over the DB value (may be stale if the container
     # was already stopped by idle timeout).
-    live_state = container.registry.get_state(workspace_id)
+    live_state = app_state.container_registry.get_state(workspace_id)
     cid = (
         live_state.container_id
         if live_state
@@ -349,8 +359,8 @@ async def delete_workspace(
     # shared state; the agent subprocess runs inside the container, so
     # stopping the container kills it either way.
     if cid:
-        await container.registry.stop_and_remove_container(cid)
-    await wshandler.reset_workspace_state(workspace_id)
+        await app_state.container_registry.stop_and_remove_container(cid)
+    await wshandler.reset_workspace_state(app_state.sockets, workspace_id)
 
     deleted = await workspaces.delete_workspace(
         workspace_id, workspace["user_id"]
@@ -365,7 +375,7 @@ async def delete_workspace(
     member_ids = {m["id"] for m in members}
     member_ids.update({user["id"], workspace["user_id"]})
     for uid in member_ids:
-        wshandler.state.notify_user_workspaces_changed(uid)
+        app_state.sockets.notify_user_workspaces_changed(uid)
     return {"status": "deleted"}
 
 
@@ -373,6 +383,7 @@ async def delete_workspace(
 async def restart_workspace(
     workspace_id: str,
     user: dict = Depends(acl.has_permission("terminal", workspace_resource)),
+    app_state=Depends(get_app_state_dep),
 ):
     """Restart a workspace container.
 
@@ -384,18 +395,18 @@ async def restart_workspace(
     workspace = await model.get_workspace(workspace_id)
     if workspace is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
-    live_state = container.registry.get_state(workspace_id)
+    live_state = app_state.container_registry.get_state(workspace_id)
     cid = (
         live_state.container_id
         if live_state
         else workspace.get("container_id")
     )
     if cid:
-        await container.registry.stop_and_remove_container(cid)
-    await wshandler.reset_workspace_state(workspace_id)
+        await app_state.container_registry.stop_and_remove_container(cid)
+    await wshandler.reset_workspace_state(app_state.sockets, workspace_id)
     # Start a fresh container; the service command fires via the
     # create choke point in start_container.
-    await workspaces.start_workspace(workspace)
+    await workspaces.start_workspace(workspace, app_state)
     return {"status": "restarted"}
 
 
@@ -403,6 +414,7 @@ async def restart_workspace(
 async def workspace_status(
     workspace_id: str,
     user: dict = Depends(acl.has_permission("terminal", workspace_resource)),
+    app_state=Depends(get_app_state_dep),
 ):
     """Return container status for a workspace.
 
@@ -413,7 +425,7 @@ async def workspace_status(
     if workspace is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
 
-    live_state = container.registry.get_state(workspace_id)
+    live_state = app_state.container_registry.get_state(workspace_id)
     if live_state is None:
         return {
             "running": False,
@@ -428,7 +440,9 @@ async def workspace_status(
 
     idle_secs = time.time() - live_state.last_activity
     idle_timeout = live_state.get_idle_timeout()
-    ports = await container.registry.get_workspace_ports(workspace_id)
+    ports = await app_state.container_registry.get_workspace_ports(
+        workspace_id
+    )
 
     # Map the internal status to the API shape.  ``health`` is None
     # until the first check completes (or when no health_check is
@@ -688,6 +702,7 @@ async def import_workspace(
     file: UploadFile,
     name: str | None = None,
     user: dict = Depends(auth.get_current_user),
+    app_state=Depends(get_app_state_dep),
 ):
     """Import a workspace from a .tar.gz archive.
 
@@ -709,6 +724,7 @@ async def import_workspace(
                 mounts=meta["mounts"],
                 env=meta["env"],
                 health_check=meta["health_check"],
+                app_state=app_state,
             )
         except SAIntegrityError:
             raise HTTPException(
@@ -733,7 +749,7 @@ async def import_workspace(
     finally:
         os.unlink(archive_path)
 
-    wshandler.state.notify_user_workspaces_changed(user["id"])
+    app_state.sockets.notify_user_workspaces_changed(user["id"])
     return ws
 
 
@@ -763,6 +779,7 @@ async def add_workspace_member(
     workspace_id: str,
     body: AddMemberRequest,
     user: dict = Depends(acl.has_permission("share", _check_workspace_share)),
+    app_state=Depends(get_app_state_dep),
 ):
     target = await model.get_user_by_email(body.email)
     if target is None:
@@ -786,8 +803,8 @@ async def add_workspace_member(
             user_id=target["id"],
         )
         next_pos += 1
-    wshandler.state.notify_user_workspaces_changed(user["id"])
-    wshandler.state.notify_user_workspaces_changed(target["id"])
+    app_state.sockets.notify_user_workspaces_changed(user["id"])
+    app_state.sockets.notify_user_workspaces_changed(target["id"])
     return {
         "status": "shared",
         "user_id": target["id"],
@@ -800,6 +817,7 @@ async def remove_workspace_member(
     workspace_id: str,
     member_id: str,
     user: dict = Depends(acl.has_permission("share", _check_workspace_share)),
+    app_state=Depends(get_app_state_dep),
 ):
     # Remove all ACL entries for this user on this workspace
     resource = f"/workspaces/{workspace_id}"
@@ -815,8 +833,8 @@ async def remove_workspace_member(
     for i, entry in enumerate(remaining):
         entry["position"] = i
     await model.replace_acl_entries(resource, remaining)
-    wshandler.state.notify_user_workspaces_changed(user["id"])
-    wshandler.state.notify_user_workspaces_changed(member_id)
+    app_state.sockets.notify_user_workspaces_changed(user["id"])
+    app_state.sockets.notify_user_workspaces_changed(member_id)
     return {"status": "removed"}
 
 
@@ -859,6 +877,7 @@ async def add_to_workspace_role(
     role: str,
     body: AddToRoleRequest,
     user: dict = Depends(acl.has_permission("share", _check_workspace_share)),
+    app_state=Depends(get_app_state_dep),
 ):
     """Add a user to a workspace role group."""
     if role not in ROLE_GROUP_SUFFIXES:
@@ -871,8 +890,8 @@ async def add_to_workspace_role(
     if target is None:
         raise HTTPException(status_code=404, detail="User not found")
     await model.add_user_to_group(target["id"], group["id"])
-    wshandler.state.notify_user_workspaces_changed(user["id"])
-    wshandler.state.notify_user_workspaces_changed(target["id"])
+    app_state.sockets.notify_user_workspaces_changed(user["id"])
+    app_state.sockets.notify_user_workspaces_changed(target["id"])
     return {"ok": True}
 
 
@@ -882,6 +901,7 @@ async def remove_from_workspace_role(
     role: str,
     member_id: str,
     user: dict = Depends(acl.has_permission("share", _check_workspace_share)),
+    app_state=Depends(get_app_state_dep),
 ):
     """Remove a user from a workspace role group."""
     if role not in ROLE_GROUP_SUFFIXES:
@@ -891,8 +911,8 @@ async def remove_from_workspace_role(
     if group is None:
         raise HTTPException(status_code=404, detail="Role group not found")
     await model.remove_user_from_group(member_id, group["id"])
-    wshandler.state.notify_user_workspaces_changed(user["id"])
-    wshandler.state.notify_user_workspaces_changed(member_id)
+    app_state.sockets.notify_user_workspaces_changed(user["id"])
+    app_state.sockets.notify_user_workspaces_changed(member_id)
     return {"ok": True}
 
 
@@ -906,6 +926,7 @@ async def change_workspace_role(
     workspace_id: str,
     body: ChangeRoleRequest,
     user: dict = Depends(acl.has_permission("share", _check_workspace_share)),
+    app_state=Depends(get_app_state_dep),
 ):
     """Atomically change a user's workspace role.
 
@@ -938,8 +959,8 @@ async def change_workspace_role(
             raise HTTPException(status_code=404, detail="Role group not found")
         await model.add_user_to_group(target["id"], group["id"])
 
-    wshandler.state.notify_user_workspaces_changed(user["id"])
-    wshandler.state.notify_user_workspaces_changed(target["id"])
+    app_state.sockets.notify_user_workspaces_changed(user["id"])
+    app_state.sockets.notify_user_workspaces_changed(target["id"])
     return {"ok": True, "email": body.email, "role": body.role}
 
 
@@ -1063,6 +1084,7 @@ async def transfer_workspace_ownership(
     workspace_id: str,
     body: TransferOwnershipRequest,
     user: dict = Depends(acl.has_permission("admin", workspace_resource)),
+    app_state=Depends(get_app_state_dep),
 ):
     """Transfer workspace ownership to another user."""
     target = await model.get_user_by_email(body.email)
@@ -1077,8 +1099,8 @@ async def transfer_workspace_ownership(
     if ws is None:  # pragma: no cover — ACL check rejects first
         raise HTTPException(status_code=404, detail="Workspace not found")
 
-    wshandler.state.notify_user_workspaces_changed(user["id"])
-    wshandler.state.notify_user_workspaces_changed(target["id"])
+    app_state.sockets.notify_user_workspaces_changed(user["id"])
+    app_state.sockets.notify_user_workspaces_changed(target["id"])
     return ws
 
 

--- a/src/backend/klangk_backend/bringup.py
+++ b/src/backend/klangk_backend/bringup.py
@@ -1,10 +1,10 @@
 """Container bring-up: provision agent home, fire the service command.
 
-This is the single choke point reached after ``container.registry.
-start_container`` creates a *fresh* container (status ``"created"``).
-``container`` cannot import ``agent`` directly (``agent`` already
-imports ``container`` for ``registry.get_state``), so the
-bring-up step lives here to keep that boundary clean.
+This is the single choke point reached after
+``ContainerRegistry.start_container`` creates a *fresh* container
+(status ``"created"``). ``container`` cannot import ``agent``
+directly (``agent`` already imports ``container``), so the bring-up
+step lives here to keep that boundary clean.
 
 ``ensure_service_session`` is idempotent (per-container lock +
 window-exists check), so calling this on every fresh create is safe:
@@ -23,6 +23,7 @@ async def bringup(
     container_id: str,
     service_command: str | None,
     setup_state: str | None,
+    app_state=None,
 ) -> None:
     """Provision the agent home and fire the service command.
 
@@ -37,4 +38,5 @@ async def bringup(
         agent_home,
         service_command,
         setup_state=setup_state,
+        app_state=app_state,
     )

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -6,7 +6,7 @@ import os
 import time
 
 from . import auth, bringup, model, plugins, podman, terminal, util
-from .settings import KlangkSettings, get_settings
+from .settings import KlangkSettings
 
 logger = logging.getLogger(__name__)
 
@@ -523,11 +523,11 @@ class HealthMonitor:
     def _connections(self):
         """The WebSocketState instance the monitor broadcasts through (#1464).
 
-        Reached via the registry's ``connections`` attribute, set by
-        ``build_app()`` in production and on the module-level shim in
-        ``container.py``. No lazy import — the registry owns the reference.
+        Reached via the registry's ``sockets`` attribute, set by
+        ``build_app()`` in production. No lazy import — the registry owns
+        the reference.
         """
-        return self._registry.connections
+        return self._registry.sockets
 
     def _setup_complete(self, state: ContainerState) -> bool:
         """True if health checks may run for this workspace.
@@ -788,10 +788,14 @@ class ContainerRegistry:
         self.idle = IdleMonitor(self)
         self.health = HealthMonitor(self)
 
+        # Back-reference to ``app.state`` (set by ``build_app()`` after
+        # construction). Used to pass ``app_state`` to ``bringup.bringup``
+        # and other callees that need explicit dependency threading.
+        self.app_state = None
+
         # The WebSocketState instance (set by build_app after construction,
-        # #1464). The HealthMonitor reaches it via self._registry.connections.
-        # wshandler.state stays as a transitional shim (dies in Slice 2d / #1465).
-        self.connections = None
+        # #1464). The HealthMonitor reaches it via self._registry.sockets.
+        self.sockets = None
 
     # --- Service-session locks (#1188, moved from terminal.py, #1426) ---
     # The dict still physically lives in terminal.py (terminal.py can't import
@@ -1527,6 +1531,7 @@ class ContainerRegistry:
             container_id,
             service_command,
             setup_state,
+            app_state=self.app_state,
         )
         logger.info(
             "workspace-open: DONE — new container created and started: %.3fs",
@@ -1720,10 +1725,3 @@ class ContainerRegistry:
             logger.warning("Error listing orphaned containers: %s", e)
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
-
-
-# Module-level singleton
-# Transitional module-level shim (#1426 Slice 2a). Production constructs the
-# real instance in build_app() → app.state.container_registry; this exists so
-# the ~660 test references and unmigrated callers keep working. Dies in #1465.
-registry = ContainerRegistry(get_settings())

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -961,7 +961,9 @@ class ContainerRegistry:
         return self.idle._cleanup_wake
 
     @_cleanup_wake.setter
-    def _cleanup_wake(self, value: asyncio.Event | None) -> None:
+    def _cleanup_wake(
+        self, value: asyncio.Event | None
+    ) -> None:  # pragma: no cover
         self.idle._cleanup_wake = value
 
     def get_cleanup_wake(self) -> asyncio.Event:

--- a/src/backend/klangk_backend/klangkd.py
+++ b/src/backend/klangk_backend/klangkd.py
@@ -139,7 +139,7 @@ def main(  # pragma: no cover
     # "klangk_backend.main:app" string import). This avoids the module-level
     # ``app = build_app()`` global — there's one ``build_app(settings)`` call,
     # one registry, wired correctly (#1464).
-    from klangk_backend.main import build_app
+    from klangk_backend.main import build_app  # noqa: allow-deferred-import
 
     asgi_app = build_app(settings)
     uvicorn.run(

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -748,6 +748,11 @@ def build_app(settings: KlangkSettings) -> FastAPI:
     app.state.sockets = sockets
     app.state.container_registry.sockets = sockets
     app.state.container_registry.app_state = app.state
+    # WebSocketState reaches the registry through its own app_state
+    # back-reference (send_service_health_snapshot / reset_workspace).
+    # The unit-test fixtures set this explicitly; build_app must too, or
+    # every WS connect crashes on the health snapshot (#1475).
+    sockets.app_state = app.state
     agent.get_workspace_session = sockets.get_session
 
     app.add_middleware(

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -11,7 +11,7 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 
 import bcrypt
-from fastapi import FastAPI, Request, WebSocket
+from fastapi import FastAPI, WebSocket
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
@@ -345,7 +345,7 @@ def remove_pid_file() -> None:
         pass
 
 
-async def startup(registry) -> None:
+async def startup(app_state) -> None:
     """Container-side startup (self-healing on re-run).
 
     Warms podman, adopts/reaps leftover containers, launches the idle
@@ -355,16 +355,17 @@ async def startup(registry) -> None:
     ``auto_start`` re-creates stopped containers -- so re-running this
     after ``runtime_shutdown`` is exactly the SIGHUP restart path.
     """
+    registry = app_state.container_registry
     await registry.prewarm_podman()
     await registry.adopt_orphaned_containers()
     registry.start_cleanup_loop()
     registry.start_health_loop()
-    n = await workspaces.auto_start_workspaces()
+    n = await workspaces.auto_start_workspaces(app_state)
     if n:  # pragma: no cover
         logger.info("Auto-started %d workspace(s)", n)
 
 
-async def runtime_shutdown(registry) -> None:
+async def runtime_shutdown(app_state) -> None:
     """Stop the runtime, keeping the HTTP listener and DB alive.
 
     Drops every WebSocket client (code 1012 = "reconnect"), tears down
@@ -373,10 +374,10 @@ async def runtime_shutdown(registry) -> None:
     normal process-shutdown path and the SIGHUP restart path -- the
     difference is only whether ``startup()`` runs again afterwards.
     """
-    await wshandler.disconnect_all_websockets()
+    await wshandler.disconnect_all_websockets(app_state.sockets)
     await agent.stop_all_sessions()
     wshandler.clear_agent_mention_state()
-    await registry.shutdown()
+    await app_state.container_registry.shutdown()
 
 
 async def process_shutdown() -> None:
@@ -510,7 +511,7 @@ class NginxWatchdog:
 _restart_lock: asyncio.Lock | None = None
 
 
-async def restart_runtime(registry, nginx_watchdog) -> None:
+async def restart_runtime(app_state, nginx_watchdog) -> None:
     """Graceful runtime restart: stop containers, keep the listener.
 
     Triggered by SIGHUP.  Closes all WebSocket clients (code 1012),
@@ -524,12 +525,12 @@ async def restart_runtime(registry, nginx_watchdog) -> None:
         _restart_lock = asyncio.Lock()
     async with _restart_lock:
         logger.info("SIGHUP: restarting runtime (keeping HTTP listener)")
-        await runtime_shutdown(registry)
-        await startup(registry)
+        await runtime_shutdown(app_state)
+        await startup(app_state)
         logger.info("SIGHUP: runtime restarted")
 
 
-def on_sighup(registry, nginx_watchdog) -> None:
+def on_sighup(app_state, nginx_watchdog) -> None:
     """Schedule a runtime restart on the running event loop.
 
     Signal callbacks can't be async, so this just creates a task.  The
@@ -539,7 +540,7 @@ def on_sighup(registry, nginx_watchdog) -> None:
         loop = asyncio.get_running_loop()
     except RuntimeError:  # pragma: no cover - no loop during shutdown
         return
-    loop.create_task(restart_runtime(registry, nginx_watchdog))
+    loop.create_task(restart_runtime(app_state, nginx_watchdog))
 
 
 @asynccontextmanager
@@ -579,11 +580,15 @@ async def lifespan(app: FastAPI):
     await seed_default_user()
     await seed_agent_user()
     registry = app.state.container_registry
-    registry.set_on_workspace_killed(wshandler.reset_workspace_state)
+
+    async def _on_workspace_killed(ws_id):
+        await wshandler.reset_workspace_state(app.state.sockets, ws_id)
+
+    registry.set_on_workspace_killed(_on_workspace_killed)
     registry.set_on_container_status_changed(
-        wshandler.state.notify_container_status
+        app.state.sockets.notify_container_status
     )
-    await startup(registry)
+    await startup(app.state)
     # Start nginx (only when bound to a UDS — klangkd; no-op for TCP tests).
     # Rendered + owned by Python (#1396); replaces scripts/nginx.sh.
     await app.state.nginx_watchdog.start()
@@ -597,7 +602,7 @@ async def lifespan(app: FastAPI):
     loop.add_signal_handler(
         signal.SIGHUP,
         on_sighup,
-        app.state.container_registry,
+        app.state,
         app.state.nginx_watchdog,
     )
     try:
@@ -605,7 +610,7 @@ async def lifespan(app: FastAPI):
     finally:
         loop.remove_signal_handler(signal.SIGHUP)
         await app.state.nginx_watchdog.stop()
-        await runtime_shutdown(registry)
+        await runtime_shutdown(app.state)
         await process_shutdown()
         logger.info("Klangk backend stopped")
 
@@ -726,24 +731,24 @@ def build_app(settings: KlangkSettings) -> FastAPI:
     Constructs the FastAPI app, wires middleware, routers, exception
     handlers, the WebSocket endpoint, and static files. The ASGI app is the
     *only* global; everything else is reached per-request via
-    :func:`get_settings_dep` (or ``app.state`` for non-request code).
+    :func:`get_app_state_dep` (or ``app.state`` for non-request code).
     """
     app = FastAPI(title="Klangk", lifespan=lifespan)
     app.state.settings = settings
     # Slice 2 (#1449): the container registry is an owned instance, not a
     # module global. The lifespan reads app.state.container_registry.
-    app.state.container_registry = container.registry
-    container.registry.settings = settings
+    app.state.container_registry = container.ContainerRegistry(settings)
     # Slice 2b (#1463): nginx watchdog is an owned instance with start/stop
     # lifecycle methods called by the lifespan.
     app.state.nginx_watchdog = NginxWatchdog(settings)
-    # Slice 2c (#1464): wire the WebSocketState instance onto the registry so
-    # HealthMonitor (and anything else in the container subsystem) can
-    # broadcast through it via self._registry.connections — no module global,
-    # no lazy import. wshandler.state stays as a transitional shim for other
-    # callers (WS layer, API endpoints); it dies in Slice 2d (#1465).
-    app.state.container_registry.connections = wshandler.state
-    app.state.connections = wshandler.state
+    # Slice 2c (#1475): the WebSocketState is an owned instance wired onto
+    # app.state.sockets. The registry and agent module reach it through
+    # explicit references — no module-level singleton.
+    sockets = wshandler.WebSocketState()
+    app.state.sockets = sockets
+    app.state.container_registry.sockets = sockets
+    app.state.container_registry.app_state = app.state
+    agent.get_workspace_session = sockets.get_session
 
     app.add_middleware(
         CORSMiddleware,
@@ -760,7 +765,7 @@ def build_app(settings: KlangkSettings) -> FastAPI:
 
     @app.websocket("/ws")
     async def websocket_endpoint(ws: WebSocket):  # pragma: no cover
-        await handle_websocket(ws)
+        await handle_websocket(ws, app.state)
 
     frontend_dir = (
         Path(__file__).parent.parent.parent / "frontend" / "build" / "web"
@@ -771,14 +776,10 @@ def build_app(settings: KlangkSettings) -> FastAPI:
     return app
 
 
-def get_settings_dep(request: Request) -> KlangkSettings:
-    """Per-request bridge to ``app.state.settings`` (no global read).
-
-    Request handlers obtain the frozen settings via
-    ``settings: KlangkSettings = Depends(get_settings_dep)`` instead of
-    calling the module-level ``get_settings()`` singleton (#1426).
-    """
-    return request.app.state.settings
+# Re-export from _common so existing callers (e.g. tests) that do
+# ``from klangk_backend.main import get_app_state_dep`` keep working.
+# The canonical home is ``api._common`` (avoids main <-> api circular import).
+from .api._common import get_app_state_dep  # noqa: F401, E402
 
 
 # --- ASGI app ---

--- a/src/backend/klangk_backend/nginx.py
+++ b/src/backend/klangk_backend/nginx.py
@@ -204,9 +204,7 @@ def compute_client_max_body_size(settings: KlangkSettings) -> str:
 
     The setting is in bytes (default 500 MB); nginx wants ``Nm``. Minimum 1m.
     """
-    raw = (
-        resolve_indirection(settings.file_upload_size_max) or "524288000"
-    )
+    raw = resolve_indirection(settings.file_upload_size_max) or "524288000"
     try:
         bytes_ = int(str(raw))
     except (TypeError, ValueError):
@@ -268,7 +266,9 @@ def _build_hosted_block(settings: KlangkSettings) -> str:
     )
 
 
-def _build_llm_block(acl: str, resolvers: str, settings: KlangkSettings) -> str:
+def _build_llm_block(
+    acl: str, resolvers: str, settings: KlangkSettings
+) -> str:
     """The /llm-proxy/ location, only when ``KLANGK_LLM_BASE_URL`` is set.
 
     Containers hit this instead of the real endpoint, so they never see the
@@ -528,7 +528,9 @@ http {{
     return conf
 
 
-def write_config(upstream: str, conf_path: str | Path, settings: KlangkSettings) -> str:
+def write_config(
+    upstream: str, conf_path: str | Path, settings: KlangkSettings
+) -> str:
     """Render the config and write it to ``conf_path`` (returns the text).
 
     Written mode ``0600`` because the rendered config may embed secrets

--- a/src/backend/klangk_backend/settings.py
+++ b/src/backend/klangk_backend/settings.py
@@ -171,7 +171,9 @@ class _EnvDictSource(EnvSettingsSource):
     passed to :class:`KlangkSettings`.
     """
 
-    def __init__(self, settings_cls: type[BaseSettings], env: Mapping[str, str]):
+    def __init__(
+        self, settings_cls: type[BaseSettings], env: Mapping[str, str]
+    ):
         self._env = env
         super().__init__(settings_cls)
 
@@ -445,6 +447,7 @@ class KlangkSettings(BaseSettings):
 # ---------------------------------------------------------------------------
 # Singleton with env-change-detection cache + config-file path
 # ---------------------------------------------------------------------------
+
 
 def get_settings() -> KlangkSettings:
     """Return a fresh ``KlangkSettings`` from the live environment.

--- a/src/backend/klangk_backend/terminal.py
+++ b/src/backend/klangk_backend/terminal.py
@@ -284,6 +284,7 @@ async def ensure_service_session(
     agent_home: str,
     service_command: str,
     setup_state: str = SETUP_STATE_COMPLETE,
+    app_state=None,
 ) -> None:
     """Ensure the standalone ``service`` session; maybe fire service-cmd.
 
@@ -366,10 +367,8 @@ async def ensure_service_session(
             # a gateway that isn't accepting connections yet).  Set only
             # on a successful send-keys; the except path below never
             # launched the command, so it must not start the grace
-            # window.  Lazy import breaks the container<->terminal cycle.
-            from . import container as _container  # noqa: allow-deferred-import
-
-            _container.registry.mark_service_started(container_id)
+            # window.
+            app_state.container_registry.mark_service_started(container_id)
         except Exception:
             logger.warning(
                 "Failed to send service command to %s", SERVICE_SESSION

--- a/src/backend/klangk_backend/workspaces.py
+++ b/src/backend/klangk_backend/workspaces.py
@@ -247,6 +247,7 @@ async def create_workspace(
     env: dict[str, str] | None = None,
     setup_state: str | None = None,
     health_check: str | None = None,
+    app_state=None,
 ) -> dict:
     workspace = await model.create_workspace_with_acl(
         user_id,
@@ -268,15 +269,16 @@ async def create_workspace(
     terminals_dir = home / ".terminals"
     terminals_dir.mkdir(exist_ok=True)
     # Allocate ports at creation time so ranges are sequential
-    try:
-        await container.registry.allocate_ports(
-            workspace["id"], workspace["num_ports"]
-        )
-    except Exception:
-        # Clean up the DB record and directories on port allocation failure
-        await model.delete_workspace(workspace["id"], user_id)
-        await _async_rmtree(home, f"workspace {workspace['id']} rollback")
-        raise
+    if app_state is not None:
+        try:
+            await app_state.container_registry.allocate_ports(
+                workspace["id"], workspace["num_ports"]
+            )
+        except Exception:
+            # Clean up the DB record and directories on port allocation failure
+            await model.delete_workspace(workspace["id"], user_id)
+            await _async_rmtree(home, f"workspace {workspace['id']} rollback")
+            raise
     return workspace
 
 
@@ -428,11 +430,11 @@ async def populate_home_skel(
         )
 
 
-async def start_workspace(ws: dict) -> tuple[str, str]:
+async def start_workspace(ws: dict, app_state) -> tuple[str, str]:
     """Start a container for a workspace immediately.
 
-    Thin wrapper around ``container.registry.start_container`` that
-    unpacks the workspace dict. The agent home provisioning and the
+    Thin wrapper around ``app_state.container_registry.start_container``
+    that unpacks the workspace dict. The agent home provisioning and the
     service command firing happen at the single create choke point
     inside ``start_container`` (see ``bringup.bringup``, #1244), so
     they no longer live here.
@@ -447,7 +449,7 @@ async def start_workspace(ws: dict) -> tuple[str, str]:
     host_path = str(get_workspace_host_path(workspace_id))
     h_path = str(get_home_host_path(workspace_id))
     cfg_path = str(get_config_host_path(workspace_id))
-    cid, status = await container.registry.start_container(
+    cid, status = await app_state.container_registry.start_container(
         workspace_id,
         host_path,
         h_path,
@@ -465,7 +467,7 @@ async def start_workspace(ws: dict) -> tuple[str, str]:
     return cid, status
 
 
-async def auto_start_workspaces() -> int:
+async def auto_start_workspaces(app_state) -> int:
     """Start containers for all workspaces with auto_start enabled.
 
     Skipped entirely if ``KLANGK_ALLOW_AUTOSTART`` is not set.
@@ -480,12 +482,12 @@ async def auto_start_workspaces() -> int:
         if i > 0:
             await asyncio.sleep(random.uniform(0.5, 2.0))
         try:
-            cid, status = await start_workspace(ws)
+            cid, status = await start_workspace(ws, app_state)
             # Auto-started containers are boot services: pin them alive
             # so they do not idle out between user connections. Only the
             # boot path does this -- create/restart use the default idle
             # timeout (#1244).
-            state = container.registry.states.get(ws["id"])
+            state = app_state.container_registry.states.get(ws["id"])
             if state:
                 state.idle_timeout = 0
             logger.info(

--- a/src/backend/klangk_backend/wshandler/__init__.py
+++ b/src/backend/klangk_backend/wshandler/__init__.py
@@ -10,7 +10,6 @@ This package re-exports every public (and the few private) names from
 those submodules so existing call sites keep working unchanged, e.g.::
 
     from . import wshandler
-    wshandler.state.get_session(...)
     from .wshandler import handle_websocket, Connection
 """
 
@@ -47,7 +46,6 @@ from .safe_websocket import (
 from .session import (
     WebSocketState as WebSocketState,
     WorkspaceSession as WorkspaceSession,
-    state as state,
 )
 from .controllers import (
     ExecController as ExecController,

--- a/src/backend/klangk_backend/wshandler/agent_mention.py
+++ b/src/backend/klangk_backend/wshandler/agent_mention.py
@@ -11,7 +11,7 @@ from .constants import (
     cancel_agent_task as cancel_agent_task,
     drop_agent_task_if_current as drop_agent_task_if_current,
 )
-from .session import state
+from .session import WebSocketState
 
 logger = logging.getLogger(__name__)
 
@@ -87,6 +87,7 @@ def asker_context_header(
 
 
 async def handle_agent_mention(
+    sockets: WebSocketState,
     workspace_id: str,
     container_id: str,
     user_text: str,
@@ -144,7 +145,7 @@ async def handle_agent_mention(
     agent_email = await model.agent_email()
 
     # Notify clients the agent is thinking
-    session = state.get_session(workspace_id)
+    session = sockets.get_session(workspace_id)
     if session:
         session.broadcast(
             {
@@ -170,7 +171,7 @@ async def handle_agent_mention(
             agent_handle,
             f"{agent_handle} has disconnected",
         )
-        session = state.get_session(workspace_id)
+        session = sockets.get_session(workspace_id)
         if session:
             session.broadcast({"type": "agent_thinking", "thinking": False})
             session.broadcast({"type": "chat_message", **sys_msg})
@@ -189,7 +190,7 @@ async def handle_agent_mention(
         response_text,
         message_type=model.MSG_AGENT,
     )
-    session = state.get_session(workspace_id)
+    session = sockets.get_session(workspace_id)
     if session:
         session.broadcast({"type": "agent_thinking", "thinking": False})
         session.broadcast({"type": "chat_message", **agent_msg})

--- a/src/backend/klangk_backend/wshandler/connection.py
+++ b/src/backend/klangk_backend/wshandler/connection.py
@@ -30,7 +30,7 @@ from .agent_mention import (
     mentions_agent,
     addresses_other_user,
 )
-from .session import state, WorkspaceSession
+from .session import WorkspaceSession
 from .controllers import (
     SshAgentForwarder,
     ExecController,
@@ -44,7 +44,8 @@ logger = logging.getLogger(__name__)
 class Connection:
     """Per-WebSocket connection state and command handlers."""
 
-    def __init__(self, ws: SafeWebSocket, user: dict):
+    def __init__(self, ws: SafeWebSocket, user: dict, app_state):
+        self.app_state = app_state
         self.sock = ws
         self.user = user
         self.workspace_id: str | None = None
@@ -303,7 +304,7 @@ class Connection:
         (
             container_id,
             container_status,
-        ) = await container.registry.start_container(
+        ) = await self.app_state.container_registry.start_container(
             workspace_id,
             host_path,
             home_path,
@@ -328,7 +329,9 @@ class Connection:
         self.container_id = container_id
         self._service_command = workspace.get("service_command")
 
-        session = state.get_or_create_session(workspace_id)
+        session = self.app_state.sockets.get_or_create_session(
+            workspace_id, app_state=self.app_state
+        )
         token_expiry = datetime.now(timezone.utc) + timedelta(
             hours=auth.WORKSPACE_TOKEN_EXPIRE_HOURS
         )
@@ -349,7 +352,7 @@ class Connection:
         # No await between lock release and callback registration — the idle
         # loop cannot interleave here in asyncio's single-threaded model.
         # If an await is added before on_idle_stop, move registration inside the lock.
-        container.registry.on_idle_stop(workspace_id, on_idle)
+        self.app_state.container_registry.on_idle_stop(workspace_id, on_idle)
 
         # Cache workspace info for auto-restart
         self.workspace = workspace
@@ -376,9 +379,11 @@ class Connection:
         self, workspace_id: str, rejoining: bool
     ) -> None:
         """Send presence list and broadcast join to other subscribers."""
-        presence = await get_presence_list(workspace_id)
+        presence = await get_presence_list(
+            workspace_id, self.app_state.sockets
+        )
         self.sock.send_json({"type": "presence_list", "users": presence})
-        session = state.get_session(workspace_id)
+        session = self.app_state.sockets.get_session(workspace_id)
         if session and not rejoining:
             join_msg = {
                 "type": "presence_join",
@@ -439,7 +444,9 @@ class Connection:
         )
 
         t_post = time.monotonic()
-        ports = await container.registry.get_workspace_ports(workspace_id)
+        ports = await self.app_state.container_registry.get_workspace_ports(
+            workspace_id
+        )
         status = getattr(self, "container_status", "created")
         container_name, ports_str = format_container_info(workspace_id, ports)
         status_msg = {
@@ -467,7 +474,9 @@ class Connection:
         if self.container_id:
             asyncio.create_task(self._start_agent_if_needed())
 
-        rejoining = state.cancel_pending_leave(workspace_id, self.user["id"])
+        rejoining = self.app_state.sockets.cancel_pending_leave(
+            workspace_id, self.user["id"]
+        )
         await self._broadcast_join(workspace_id, rejoining)
 
         logger.info(
@@ -525,16 +534,18 @@ class Connection:
             return
 
         await self.start_workspace_container(workspace_id, workspace)
-        container.registry.record_activity(self.container_id)
+        self.app_state.container_registry.record_activity(self.container_id)
 
         # Update container_id on ALL connections to this workspace
         # so they don't try to exec into the old (removed) container.
         new_cid = self.container_id
-        for sock, conn in list(state.connections.items()):
+        for sock, conn in list(self.app_state.sockets.connections.items()):
             if conn.workspace_id == workspace_id and conn is not self:
                 conn.container_id = new_cid
 
-        ports = await container.registry.get_workspace_ports(workspace_id)
+        ports = await self.app_state.container_registry.get_workspace_ports(
+            workspace_id
+        )
         container_name, ports_str = format_container_info(workspace_id, ports)
         status_msg = f"Container restarted {container_name}{ports_str}"
 
@@ -566,17 +577,21 @@ class Connection:
 
         workspace_id = self.workspace_id
         container_id = self.container_id
-        session = state.get_session(workspace_id)
+        session = self.app_state.sockets.get_session(workspace_id)
 
         # Clear container_id on ALL connections to prevent stale exec attempts.
-        for sock, conn_obj in list(state.connections.items()):
+        for sock, conn_obj in list(self.app_state.sockets.connections.items()):
             if conn_obj.workspace_id == workspace_id:
                 conn_obj.container_id = None
 
-        await container.registry.notify_workspace_killed(workspace_id)
+        await self.app_state.container_registry.notify_workspace_killed(
+            workspace_id
+        )
 
         try:
-            await container.registry.stop_and_remove_container(container_id)
+            await self.app_state.container_registry.stop_and_remove_container(
+                container_id
+            )
         except Exception as e:
             logger.warning("Error stopping container: %s", e)
 
@@ -665,7 +680,9 @@ class Connection:
 
     async def handle_heartbeat(self) -> None:
         if self.container_id is not None:
-            container.registry.record_activity(self.container_id)
+            self.app_state.container_registry.record_activity(
+                self.container_id
+            )
 
     async def handle_chat_send(self, msg: dict) -> None:
         workspace_id = self.workspace_id
@@ -693,7 +710,7 @@ class Connection:
         chat_msg = await model.add_chat_message(
             workspace_id, self.user["id"], self.user["email"], text
         )
-        session = state.get_session(workspace_id)
+        session = self.app_state.sockets.get_session(workspace_id)
         if session:
             session.broadcast({"type": "chat_message", **chat_msg})
 
@@ -743,6 +760,7 @@ class Connection:
             cancel_agent_task(workspace_id)
             agent_tasks[workspace_id] = asyncio.create_task(
                 handle_agent_mention(
+                    self.app_state.sockets,
                     workspace_id,
                     self.container_id,
                     text,
@@ -761,7 +779,7 @@ class Connection:
             return
         deleted = await model.delete_chat_message(message_id, self.user["id"])
         if deleted:
-            session = state.get_session(workspace_id)
+            session = self.app_state.sockets.get_session(workspace_id)
             if session:
                 session.broadcast(
                     {
@@ -793,13 +811,19 @@ class Connection:
     async def _start_agent_if_needed(self) -> None:
         """Start the Pi RPC agent so it shows in presence."""
         try:
-            session = await agent.get_session(self.workspace_id)
+            session = await agent.get_session(
+                self.workspace_id, app_state=self.app_state
+            )
             await session.ensure_started()
             # Broadcast updated presence now that agent is alive
             if self.workspace_id:
-                ws_session = state.get_session(self.workspace_id)
+                ws_session = self.app_state.sockets.get_session(
+                    self.workspace_id
+                )
                 if ws_session:
-                    presence = await get_presence_list(self.workspace_id)
+                    presence = await get_presence_list(
+                        self.workspace_id, self.app_state.sockets
+                    )
                     ws_session.broadcast(
                         {"type": "presence_list", "users": presence}
                     )
@@ -814,7 +838,7 @@ class Connection:
 
     async def handle_ui_ready(self) -> None:
         if self.workspace_id:
-            sess = state.get_session(self.workspace_id)
+            sess = self.app_state.sockets.get_session(self.workspace_id)
             if sess:
                 sess.browser_subscribers.add(self.sock)
         status_msg = self.pending_status_msg
@@ -822,9 +846,11 @@ class Connection:
         if status_msg:
             send_event(self.sock, "container_ready", status_msg)
         # Send shared terminal list from in-memory state.
-        ws_session = state.get_session(self.workspace_id)
+        ws_session = self.app_state.sockets.get_session(self.workspace_id)
         if ws_session:
-            terminals = get_shared_terminals(ws_session)
+            terminals = get_shared_terminals(
+                ws_session, self.app_state.sockets
+            )
             self.sock.send_json(
                 {"type": "shared_terminals", "terminals": terminals}
             )
@@ -868,11 +894,13 @@ class Connection:
         workspace_id = self.workspace_id
         idle_cb = self._idle_cb
         if workspace_id and idle_cb:
-            container.registry.remove_idle_callback(workspace_id, idle_cb)
+            self.app_state.container_registry.remove_idle_callback(
+                workspace_id, idle_cb
+            )
             self._idle_cb = None
 
         # Revoke per-connection browser registrations
-        container.registry.revoke_browser(self.sock)
+        self.app_state.container_registry.revoke_browser(self.sock)
         self.browser_id = None
 
         await self.stop_terminal()
@@ -882,7 +910,11 @@ class Connection:
         # Remove this connection from the workspace session's subscriber sets.
         # If no subscribers remain, remove the session entirely. The container
         # is NOT killed — idle timeout handles that.
-        session = state.get_session(workspace_id) if workspace_id else None
+        session = (
+            self.app_state.sockets.get_session(workspace_id)
+            if workspace_id
+            else None
+        )
         if session:
             empty = await session.remove_subscriber(self.sock)
             if not empty:
@@ -890,15 +922,16 @@ class Connection:
                 # other connections.  If they reconnect within the delay
                 # window the leave (and re-join) are suppressed.
                 still_connected = any(
-                    state.connections.get(s) is not None
-                    and state.connections[s].user["id"] == self.user["id"]
+                    self.app_state.sockets.connections.get(s) is not None
+                    and self.app_state.sockets.connections[s].user["id"]
+                    == self.user["id"]
                     for s in session.subscribers
                 )
                 if not still_connected:
-                    state.schedule_pending_leave(
+                    self.app_state.sockets.schedule_pending_leave(
                         workspace_id, self.user, session
                     )
             else:
                 # Lock is released by remove_subscriber, so use the
                 # lock-acquiring version.
-                await state.remove_session(workspace_id)
+                await self.app_state.sockets.remove_session(workspace_id)

--- a/src/backend/klangk_backend/wshandler/controllers.py
+++ b/src/backend/klangk_backend/wshandler/controllers.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 
 from fastapi import WebSocketDisconnect
 
-from .. import container, model, podman, terminal
+from .. import model, podman, terminal
 from ..exceptions import TerminalError
 from ..util import resolve_env_value
 from ..podman import ExecSession
@@ -23,7 +23,6 @@ from ..terminal import (
 from .safe_websocket import SlowClientError, WS_ERRORS
 from .constants import MAX_INPUT_SIZE
 from .helpers import send_error, send_event, get_shared_terminals
-from .session import state
 
 if TYPE_CHECKING:
     from .connection import Connection  # noqa: allow-deferred-import
@@ -254,7 +253,7 @@ class ExecController:
         await session.start(command, login=login)
         self.session = session
         self.task = asyncio.create_task(self.forward_output(session))
-        container.registry.record_activity(container_id)
+        self._conn.app_state.container_registry.record_activity(container_id)
 
     async def input(self, msg: dict) -> None:
         session = self.session
@@ -266,7 +265,9 @@ class ExecController:
                 "exec_input too large (%d bytes), dropping", len(raw)
             )
             return
-        container.registry.record_activity(self._conn.container_id)
+        self._conn.app_state.container_registry.record_activity(
+            self._conn.container_id
+        )
         await session.write(raw)
 
     async def close_stdin(self) -> None:
@@ -308,7 +309,9 @@ class ExecController:
                     }
                 )
                 if self._conn.container_id:
-                    container.registry.record_activity(self._conn.container_id)
+                    self._conn.app_state.container_registry.record_activity(
+                        self._conn.container_id
+                    )
             # Process exited — send exit code
             self._conn.sock.send_json(
                 {
@@ -361,8 +364,10 @@ class TerminalController:
         env but don't register it for bridge routing.
         """
         if browser_id and browser_id != "klangkshell":
-            container.registry.revoke_browser(self._conn.sock)
-            container.registry.register_browser(
+            self._conn.app_state.container_registry.revoke_browser(
+                self._conn.sock
+            )
+            self._conn.app_state.container_registry.register_browser(
                 browser_id, self._conn.workspace_id, self._conn.sock
             )
         self._conn.browser_id = browser_id
@@ -372,7 +377,7 @@ class TerminalController:
         the window list and shared terminals to the client."""
         conn = self._conn
         sname = conn.tmux_session_name()
-        ws_session = state.get_session(conn.workspace_id)
+        ws_session = conn.app_state.sockets.get_session(conn.workspace_id)
 
         windows = await terminal.list_windows(conn.container_id, sname)
         conn.sync_terminal_windows(windows)
@@ -386,9 +391,13 @@ class TerminalController:
 
     def _send_shared_terminals(self) -> None:
         """Send the current shared terminal list to the client."""
-        ws_session = state.get_session(self._conn.workspace_id)
+        ws_session = self._conn.app_state.sockets.get_session(
+            self._conn.workspace_id
+        )
         if ws_session:
-            terminals = get_shared_terminals(ws_session)
+            terminals = get_shared_terminals(
+                ws_session, self._conn.app_state.sockets
+            )
             self._conn.sock.send_json(
                 {"type": "shared_terminals", "terminals": terminals}
             )
@@ -437,6 +446,7 @@ class TerminalController:
             agent_home,
             service_command,
             setup_state=setup_state,
+            app_state=self._conn.app_state,
         )
 
     async def _sync_service_windows(self, ws_session) -> bool:
@@ -581,16 +591,16 @@ class TerminalController:
                 ctrl._send_shared_terminals()
             except asyncio.CancelledError:
                 await session.stop()
-                container.registry.revoke_browser(conn.sock)
+                conn.app_state.container_registry.revoke_browser(conn.sock)
                 conn.browser_id = None
                 raise
             except (SlowClientError, WebSocketDisconnect):
                 await session.stop()
-                container.registry.revoke_browser(conn.sock)
+                conn.app_state.container_registry.revoke_browser(conn.sock)
                 conn.browser_id = None
             except Exception as e:
                 await session.stop()
-                container.registry.revoke_browser(conn.sock)
+                conn.app_state.container_registry.revoke_browser(conn.sock)
                 conn.browser_id = None
                 logger.exception("Terminal start failed: %s", e)
                 try:
@@ -610,8 +620,8 @@ class TerminalController:
         browser_id = msg.get("browser_id")
         if not browser_id or not self._conn.container_id:
             return
-        container.registry.revoke_browser(self._conn.sock)
-        container.registry.register_browser(
+        self._conn.app_state.container_registry.revoke_browser(self._conn.sock)
+        self._conn.app_state.container_registry.register_browser(
             browser_id, self._conn.workspace_id, self._conn.sock
         )
         self._conn.browser_id = browser_id
@@ -641,7 +651,9 @@ class TerminalController:
                 "terminal_input too large (%d bytes), dropping", len(data)
             )
             return
-        container.registry.record_activity(self._conn.container_id)
+        self._conn.app_state.container_registry.record_activity(
+            self._conn.container_id
+        )
         await session.write(data)
         elapsed = time.monotonic() - t0
         if elapsed > 0.1:  # pragma: no cover
@@ -668,7 +680,9 @@ class TerminalController:
     def sync_terminal_windows(self, windows: list[dict]) -> None:
         """Update in-memory terminal_windows from tmux list_windows result."""
 
-        ws_session = state.get_session(self._conn.workspace_id)
+        ws_session = self._conn.app_state.sockets.get_session(
+            self._conn.workspace_id
+        )
         if not ws_session:
             return
         user_id = self._conn.user["id"]
@@ -736,7 +750,9 @@ class TerminalController:
     def notify_user_terminal_windows(self, windows: list[dict]) -> None:
         """Send terminal_windows to all connections for this user."""
 
-        ws_session = state.get_session(self._conn.workspace_id)
+        ws_session = self._conn.app_state.sockets.get_session(
+            self._conn.workspace_id
+        )
         if not ws_session:
             self._conn.sock.send_json(
                 {"type": "terminal_windows", "windows": windows}
@@ -745,7 +761,7 @@ class TerminalController:
         user_id = self._conn.user["id"]
         msg = {"type": "terminal_windows", "windows": windows}
         for sock in list(ws_session.subscribers):
-            conn = state.connections.get(sock)
+            conn = self._conn.app_state.sockets.connections.get(sock)
             if conn and conn.user.get("id") == user_id:
                 sock.send_json(msg)
 
@@ -885,7 +901,9 @@ class TerminalController:
         # Without this, reattaching shows a blank screen because tmux
         # skips the redraw when the PTY size matches the default.
         await session.resize(cols, rows)
-        container.registry.record_activity(self._conn.container_id)
+        self._conn.app_state.container_registry.record_activity(
+            self._conn.container_id
+        )
         return True
 
     async def stop(self) -> None:
@@ -909,7 +927,9 @@ class TerminalController:
         await self.claim_and_stop()
         # Broadcast viewer change so other users see updated viewer list
         if was_viewing and self._conn.workspace_id:
-            ws_session = state.get_session(self._conn.workspace_id)
+            ws_session = self._conn.app_state.sockets.get_session(
+                self._conn.workspace_id
+            )
             if ws_session:
                 self._conn.broadcast_shared_terminals(ws_session)
         # Reset debounce so the next explicit start isn't blocked.
@@ -928,7 +948,9 @@ class TerminalController:
                     {"type": "terminal_output", "data": data}
                 )
                 if self._conn.container_id:
-                    container.registry.record_activity(self._conn.container_id)
+                    self._conn.app_state.container_registry.record_activity(
+                        self._conn.container_id
+                    )
             # Stream ended — the tmux session exited (not necessarily the
             # container). Don't send container_stopped; the idle timeout
             # or shutdown button handles actual container death.
@@ -1014,7 +1036,9 @@ class SharedTerminalController:
             send_error(self._conn.sock, "Window ID required")
             return
         user_id = self._conn.user["id"]
-        ws_session = state.get_session(self._conn.workspace_id)
+        ws_session = self._conn.app_state.sockets.get_session(
+            self._conn.workspace_id
+        )
         if not ws_session:
             return
         match = self.find_window(ws_session, user_id, window_id)
@@ -1038,7 +1062,9 @@ class SharedTerminalController:
             return
         user_id = self._conn.user["id"]
         session_name = self._conn.tmux_session_name()
-        ws_session = state.get_session(self._conn.workspace_id)
+        ws_session = self._conn.app_state.sockets.get_session(
+            self._conn.workspace_id
+        )
         if not ws_session:
             return
         match = self.find_window(ws_session, user_id, window_id)
@@ -1116,7 +1142,9 @@ class SharedTerminalController:
             send_error(self._conn.sock, "user_id and window_id required")
             return
 
-        ws_session = state.get_session(self._conn.workspace_id)
+        ws_session = self._conn.app_state.sockets.get_session(
+            self._conn.workspace_id
+        )
         if not ws_session:
             return
         match = self.find_window(
@@ -1184,7 +1212,7 @@ class SharedTerminalController:
                         "readOnly": read_only,
                     }
                 )
-                ws_sess = state.get_session(conn.workspace_id)
+                ws_sess = conn.app_state.sockets.get_session(conn.workspace_id)
                 if ws_sess:
                     conn.broadcast_shared_terminals(ws_sess)
             except asyncio.CancelledError:  # pragma: no cover
@@ -1207,7 +1235,9 @@ class SharedTerminalController:
         if not await self._conn._has_perm("spectate-on-shared-terminals"):
             send_error(self._conn.sock, "Permission denied")
             return
-        ws_session = state.get_session(self._conn.workspace_id)
+        ws_session = self._conn.app_state.sockets.get_session(
+            self._conn.workspace_id
+        )
         if not ws_session:
             self._conn.sock.send_json(
                 {"type": "shared_terminals", "terminals": []}
@@ -1217,14 +1247,18 @@ class SharedTerminalController:
         # was fired (e.g. auto-start) before anyone connected to discover
         # it (#1133).
         await self._conn.terminal._sync_service_windows(ws_session)
-        terminals = get_shared_terminals(ws_session)
+        terminals = get_shared_terminals(
+            ws_session, self._conn.app_state.sockets
+        )
         self._conn.sock.send_json(
             {"type": "shared_terminals", "terminals": terminals}
         )
 
     def broadcast_shared_terminals(self, ws_session) -> None:
         """Broadcast the current shared terminal list to all subscribers."""
-        terminals = get_shared_terminals(ws_session)
+        terminals = get_shared_terminals(
+            ws_session, self._conn.app_state.sockets
+        )
         ws_session.broadcast(
             {"type": "shared_terminals", "terminals": terminals}
         )
@@ -1256,7 +1290,9 @@ class SharedTerminalController:
         # Sync with tmux to get proper window_id, then mark the new
         # window as shared.
         self._conn.sync_terminal_windows(windows)
-        ws_session = state.get_session(self._conn.workspace_id)
+        ws_session = self._conn.app_state.sockets.get_session(
+            self._conn.workspace_id
+        )
         if not ws_session:
             return
         user_id = self._conn.user["id"]
@@ -1295,7 +1331,9 @@ class SharedTerminalController:
             ):
                 send_error(self._conn.sock, "Permission denied")
                 return
-        ws_session = state.get_session(self._conn.workspace_id)
+        ws_session = self._conn.app_state.sockets.get_session(
+            self._conn.workspace_id
+        )
         if not ws_session:
             return
         match = self.find_window(

--- a/src/backend/klangk_backend/wshandler/dispatch.py
+++ b/src/backend/klangk_backend/wshandler/dispatch.py
@@ -8,7 +8,6 @@ from fastapi import WebSocket, WebSocketDisconnect
 from .. import auth
 from .safe_websocket import SafeWebSocket, SlowClientError
 from .helpers import send_error, log_ws_msg
-from .session import state
 from .connection import Connection
 
 logger = logging.getLogger(__name__)
@@ -68,7 +67,7 @@ _WS_STATE_COMMANDS: dict[str, str] = {
 }
 
 
-async def handle_websocket(websocket: WebSocket) -> None:
+async def handle_websocket(websocket: WebSocket, app_state) -> None:
     """Main WebSocket handler."""
     # Authenticate via query param
     token = websocket.query_params.get("token")
@@ -88,13 +87,13 @@ async def handle_websocket(websocket: WebSocket) -> None:
     await websocket.accept()
     safe_ws = SafeWebSocket(websocket)
     safe_ws.start_sender()
-    conn = Connection(safe_ws, user)
-    state.connections[safe_ws] = conn
+    conn = Connection(safe_ws, user, app_state)
+    app_state.sockets.connections[safe_ws] = conn
     # Replay current health of every health-checked workspace so a
     # pure-WS consumer (e.g. ``klangkc monitor``) sees steady-state
     # status immediately instead of being blind until the next
     # transition (#1175 item 1).
-    state.send_service_health_snapshot(safe_ws)
+    app_state.sockets.send_service_health_snapshot(safe_ws)
 
     try:
         while True:
@@ -119,7 +118,7 @@ async def handle_websocket(websocket: WebSocket) -> None:
             else:
                 state_method = _WS_STATE_COMMANDS.get(cmd)
                 if state_method is not None:
-                    getattr(state, state_method)(msg, safe_ws)
+                    getattr(app_state.sockets, state_method)(msg, safe_ws)
                 else:
                     send_error(safe_ws, f"Unknown command: {cmd}")
 
@@ -138,4 +137,4 @@ async def handle_websocket(websocket: WebSocket) -> None:
         await conn.cleanup()
         # Container is intentionally left running — idle timeout will clean it up.
         # This allows instant reconnection when navigating back to the workspace.
-        state.connections.pop(safe_ws, None)
+        app_state.sockets.connections.pop(safe_ws, None)

--- a/src/backend/klangk_backend/wshandler/helpers.py
+++ b/src/backend/klangk_backend/wshandler/helpers.py
@@ -5,20 +5,22 @@ import logging
 from .. import agent, model
 from .safe_websocket import SafeWebSocket
 from .constants import log_ws_msg
-from .session import state
+from .session import WebSocketState
 
 logger = logging.getLogger(__name__)
 
 
-async def get_presence_list(workspace_id: str) -> list[dict]:
+async def get_presence_list(
+    workspace_id: str, sockets: WebSocketState
+) -> list[dict]:
     """Return deduplicated list of users connected to a workspace."""
-    session = state.get_session(workspace_id)
+    session = sockets.get_session(workspace_id)
     if not session:
         return []
     seen: set[str] = set()
     users: list[dict] = []
     for sock in session.subscribers:
-        conn = state.connections.get(sock)
+        conn = sockets.connections.get(sock)
         if conn and conn.user["id"] not in seen:
             seen.add(conn.user["id"])
             users.append(
@@ -42,12 +44,12 @@ async def get_presence_list(workspace_id: str) -> list[dict]:
     return users
 
 
-def get_shared_terminals(ws_session) -> list[dict]:
+def get_shared_terminals(ws_session, sockets: WebSocketState) -> list[dict]:
     """Collect all shared windows across all users in a workspace."""
     # Build viewer map: (owner_user_id, window_id) -> [{user_id, email}]
     viewer_map: dict[tuple[str, str], list[dict]] = {}
     for sock in ws_session.subscribers:
-        conn = state.connections.get(sock)
+        conn = sockets.connections.get(sock)
         if not conn or not conn.viewing_shared:
             continue
         key = (
@@ -69,7 +71,7 @@ def get_shared_terminals(ws_session) -> list[dict]:
             handle = ws_session.agent_handle
         else:
             for sock in ws_session.subscribers:
-                conn = state.connections.get(sock)
+                conn = sockets.connections.get(sock)
                 if conn and conn.user.get("id") == user_id:
                     handle = conn.user.get("handle")
                     break
@@ -95,29 +97,33 @@ def get_shared_terminals(ws_session) -> list[dict]:
     return terminals
 
 
-async def reset_workspace_state(workspace_id: str) -> None:
+async def reset_workspace_state(
+    sockets: WebSocketState, workspace_id: str
+) -> None:
     """Thin wrapper for backward compatibility with external callers."""
-    await state.reset_workspace(workspace_id)
+    await sockets.reset_workspace(workspace_id)
 
 
-async def disconnect_all_websockets() -> None:
+async def disconnect_all_websockets(sockets: WebSocketState) -> None:
     """Drop every WebSocket connection and clear all session state.
 
     Used by the SIGHUP runtime-restart path (see ``main.runtime_shutdown``).
     Connected clients are closed with code 1012 so they reconnect and
     rebuild state against the freshly-started containers.
     """
-    await state.disconnect_all()
+    await sockets.disconnect_all()
 
 
-async def refresh_user_handle(user_id: str, new_handle: str) -> None:
+async def refresh_user_handle(
+    sockets: WebSocketState, user_id: str, new_handle: str
+) -> None:
     """Update the cached handle on all active connections for a user,
     re-broadcast presence, and post a system chat message to each
     affected workspace."""
     old_handle: str | None = None
     affected_workspaces: set[str] = set()
     user_email: str = ""
-    for conn in list(state.connections.values()):
+    for conn in list(sockets.connections.values()):
         if conn.user["id"] == user_id:
             if old_handle is None:
                 old_handle = conn.user.get("handle", "")
@@ -126,9 +132,9 @@ async def refresh_user_handle(user_id: str, new_handle: str) -> None:
             if conn.workspace_id:
                 affected_workspaces.add(conn.workspace_id)
     for ws_id in affected_workspaces:
-        session = state.get_session(ws_id)
+        session = sockets.get_session(ws_id)
         if session:
-            presence = await get_presence_list(ws_id)
+            presence = await get_presence_list(ws_id, sockets)
             session.broadcast({"type": "presence_list", "users": presence})
             sys_msg = await model.add_chat_message(
                 ws_id,

--- a/src/backend/klangk_backend/wshandler/session.py
+++ b/src/backend/klangk_backend/wshandler/session.py
@@ -10,7 +10,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
-from .. import agent, auth, container, model, terminal
+from .. import agent, auth, model, terminal
 from .safe_websocket import SafeWebSocket, WS_ERRORS, broadcast_to_set
 from .constants import (
     agent_conversations,
@@ -83,8 +83,9 @@ class WorkspaceSession:
     Created by the first WebSocket connection, cleaned up by the last.
     """
 
-    def __init__(self, workspace_id: str):
+    def __init__(self, workspace_id: str, app_state=None):
         self.workspace_id = workspace_id
+        self.app_state = app_state
         self.container_id: str | None = None
         self.subscribers: set[SafeWebSocket] = set()
         self.browser_subscribers: set[SafeWebSocket] = set()
@@ -224,27 +225,38 @@ class WorkspaceSession:
         request_id = str(uuid.uuid4())
         loop = asyncio.get_running_loop()
         future: asyncio.Future = loop.create_future()
-        state.pending_browser_requests[request_id] = (future, None)
+        self.app_state.sockets.pending_browser_requests[request_id] = (
+            future,
+            None,
+        )
 
         if not self.browser_subscribers:
-            state.pending_browser_requests.pop(request_id, None)
+            self.app_state.sockets.pending_browser_requests.pop(
+                request_id, None
+            )
             return {"error": "No browser client connected to this workspace"}
 
         message = {**request, "type": "browser_request", "id": request_id}
         log_ws_msg("BCAST", message)
         delivered = self.broadcast_to_browsers(message)
         if delivered == 0:
-            state.pending_browser_requests.pop(request_id, None)
+            self.app_state.sockets.pending_browser_requests.pop(
+                request_id, None
+            )
             return {"error": "No browser client connected to this workspace"}
 
         try:
             result = await asyncio.wait_for(future, timeout=timeout)
             return result
         except asyncio.TimeoutError:
-            state.pending_browser_requests.pop(request_id, None)
+            self.app_state.sockets.pending_browser_requests.pop(
+                request_id, None
+            )
             return {"error": "Browser client did not respond within timeout"}
         except asyncio.CancelledError:
-            state.pending_browser_requests.pop(request_id, None)
+            self.app_state.sockets.pending_browser_requests.pop(
+                request_id, None
+            )
             raise
 
     async def dispatch_browser_request_to(
@@ -259,24 +271,33 @@ class WorkspaceSession:
         request_id = str(uuid.uuid4())
         loop = asyncio.get_running_loop()
         future: asyncio.Future = loop.create_future()
-        state.pending_browser_requests[request_id] = (future, target_sock)
+        self.app_state.sockets.pending_browser_requests[request_id] = (
+            future,
+            target_sock,
+        )
 
         message = {**request, "type": "browser_request", "id": request_id}
         log_ws_msg("BCAST", message)
         try:
             target_sock.send_json(message)
         except WS_ERRORS:
-            state.pending_browser_requests.pop(request_id, None)
+            self.app_state.sockets.pending_browser_requests.pop(
+                request_id, None
+            )
             return {"error": "Browser connection not available"}
 
         try:
             result = await asyncio.wait_for(future, timeout=timeout)
             return result
         except asyncio.TimeoutError:
-            state.pending_browser_requests.pop(request_id, None)
+            self.app_state.sockets.pending_browser_requests.pop(
+                request_id, None
+            )
             return {"error": "Browser client did not respond within timeout"}
         except asyncio.CancelledError:
-            state.pending_browser_requests.pop(request_id, None)
+            self.app_state.sockets.pending_browser_requests.pop(
+                request_id, None
+            )
             raise
 
     async def dispatch_browser_request_stream_to(
@@ -295,7 +316,10 @@ class WorkspaceSession:
         """
         request_id = str(uuid.uuid4())
         queue: asyncio.Queue = asyncio.Queue()
-        state.streaming_browser_requests[request_id] = (queue, target_sock)
+        self.app_state.sockets.streaming_browser_requests[request_id] = (
+            queue,
+            target_sock,
+        )
         message = {
             **request,
             "type": "browser_request",
@@ -306,7 +330,9 @@ class WorkspaceSession:
         try:
             target_sock.send_json(message)
         except WS_ERRORS:
-            state.streaming_browser_requests.pop(request_id, None)
+            self.app_state.sockets.streaming_browser_requests.pop(
+                request_id, None
+            )
             yield (
                 json.dumps(
                     {
@@ -340,7 +366,9 @@ class WorkspaceSession:
                 if item["type"] != "chunk":
                     return
         finally:
-            state.streaming_browser_requests.pop(request_id, None)
+            self.app_state.sockets.streaming_browser_requests.pop(
+                request_id, None
+            )
 
     async def full_reset(self) -> None:
         """Clean up all shared state for this workspace.
@@ -348,8 +376,8 @@ class WorkspaceSession:
         Called when a container is killed externally (idle timeout,
         manual stop) so the next workspace_connect starts fresh.
         """
-        await state.remove_session(self.workspace_id)
-        await container.registry.remove_state(self.workspace_id)
+        await self.app_state.sockets.remove_session(self.workspace_id)
+        await self.app_state.container_registry.remove_state(self.workspace_id)
         logger.info("Reset workspace state for %s", self.workspace_id)
 
 
@@ -362,7 +390,8 @@ class WebSocketState:
     # WebSocket reconnection with backoff.
     PRESENCE_LEAVE_DELAY = 10.0  # seconds
 
-    def __init__(self) -> None:
+    def __init__(self, app_state=None) -> None:
+        self.app_state = app_state
         # Active connections: SafeWebSocket -> Connection
         self.connections: dict[SafeWebSocket, "Connection"] = {}
         # Active sessions keyed by workspace_id.
@@ -387,11 +416,13 @@ class WebSocketState:
     def get_session(self, workspace_id: str) -> WorkspaceSession | None:
         return self.sessions.get(workspace_id)
 
-    def get_or_create_session(self, workspace_id: str) -> WorkspaceSession:
+    def get_or_create_session(
+        self, workspace_id: str, app_state=None
+    ) -> WorkspaceSession:
         try:
             return self.sessions[workspace_id]
         except KeyError:
-            session = WorkspaceSession(workspace_id)
+            session = WorkspaceSession(workspace_id, app_state=app_state)
             return self.sessions.setdefault(workspace_id, session)
 
     async def remove_session(self, workspace_id: str) -> None:
@@ -421,7 +452,7 @@ class WebSocketState:
         Used by the SIGHUP runtime-restart path.  Connected clients are
         closed with code 1012 ("service restarted") so they reconnect
         and rebuild state against the freshly-started containers.
-        Deliberately leaves ``container.registry`` untouched -- the
+        Deliberately leaves the container registry untouched -- the
         registry needs its container-id -> workspace map intact for the
         subsequent ``registry.shutdown()`` to find containers to stop.
 
@@ -543,7 +574,7 @@ class WebSocketState:
         if session:
             await session.full_reset()
         else:
-            await container.registry.remove_state(workspace_id)
+            await self.app_state.container_registry.remove_state(workspace_id)
             logger.info("Reset workspace state for %s", workspace_id)
 
         # Clean up module-level agent state for this workspace.
@@ -643,7 +674,7 @@ class WebSocketState:
         from ``registry.states`` and thus skipped (the container-death
         hole is #1175 item 2).
         """
-        for cs in list(container.registry.states.values()):
+        for cs in list(self.app_state.container_registry.states.values()):
             if cs.health_check is None or cs.health_status is None:
                 continue
             try:
@@ -792,11 +823,3 @@ class WebSocketState:
         if expected_sock is not None and sender is not expected_sock:
             return
         queue.put_nowait({"type": "chunk", "delta": msg.get("delta", "")})
-
-
-state = WebSocketState()
-
-# Wire up the agent broadcast callback so agent.py can broadcast
-# to WebSocket sessions without importing wshandler (breaking the
-# agent ↔ wshandler circular dependency).
-agent.get_workspace_session = state.get_session

--- a/src/backend/tests/test_agent.py
+++ b/src/backend/tests/test_agent.py
@@ -35,12 +35,14 @@ def _clear_agents():
 
 @pytest.fixture(autouse=True)
 def _mock_container_registry():
-    """Provide a default container registry state for all agent tests."""
-    with patch(
-        "klangk_backend.agent.container.registry.get_state",
-        return_value=_FakeContainerState("cid"),
-    ):
-        yield
+    """Provide a default container registry state for all agent tests.
+
+    Agent code accesses ``self.app_state.container_registry.get_state()``.
+    The ``_make_session`` helper wires a fake app_state with a mock
+    registry whose ``get_state`` returns a ``_FakeContainerState``.
+    This fixture is kept as a no-op for structural compatibility.
+    """
+    yield
 
 
 @pytest.fixture(autouse=True)
@@ -58,9 +60,19 @@ async def _seed_agent_db(db):
     model.clear_agent_cache()
 
 
+def _make_app_state(cid="cid"):
+    """Build a fake app_state with a mock container registry."""
+    import types
+
+    mock_registry = MagicMock()
+    mock_registry.get_state.return_value = _FakeContainerState(cid)
+    return types.SimpleNamespace(container_registry=mock_registry)
+
+
 def _make_session(workspace_id="ws-id"):
     """Create an AgentSession with home setup already done."""
-    s = AgentSession(workspace_id)
+    app_state = _make_app_state()
+    s = AgentSession(workspace_id, app_state=app_state)
     s._home_ready = True
     s._last_container_id = "cid"
     return s
@@ -763,19 +775,22 @@ class TestAgentSession:
 
 class TestGetSession:
     async def test_creates_new_session(self):
-        session = await get_session("ws-1")
+        app_state = _make_app_state()
+        session = await get_session("ws-1", app_state=app_state)
         assert session.workspace_id == "ws-1"
         assert "ws-1" in _agents
 
     async def test_reuses_existing_session(self):
-        s1 = await get_session("ws-1")
-        s2 = await get_session("ws-1")
+        app_state = _make_app_state()
+        s1 = await get_session("ws-1", app_state=app_state)
+        s2 = await get_session("ws-1", app_state=app_state)
         assert s1 is s2
 
     async def test_get_session_blocked_during_stop(self):
         """get_session must not install a session while stop_session is
         tearing one down for the same workspace (#1298)."""
-        session = await get_session("ws-race")
+        app_state = _make_app_state()
+        session = await get_session("ws-race", app_state=app_state)
         session._proc = AsyncMock()
         session._proc.returncode = None
         session._proc.kill = MagicMock()
@@ -794,7 +809,7 @@ class TestGetSession:
         session.stop = slow_stop  # type: ignore[assignment]
 
         async def do_get():
-            s = await get_session("ws-race")
+            s = await get_session("ws-race", app_state=app_state)
             order.append("get_done")
             return s
 
@@ -1012,7 +1027,7 @@ class TestEnsureHome:
 
 class TestStopSession:
     async def test_stop_existing(self):
-        session = await get_session("ws-1")
+        session = await get_session("ws-1", app_state=_make_app_state())
         session._proc = AsyncMock()
         session._proc.returncode = None
         session._proc.kill = MagicMock()
@@ -1027,8 +1042,9 @@ class TestStopSession:
 
 class TestStopAllSessions:
     async def test_stops_every_session(self):
+        app_state = _make_app_state()
         for ws_id in ("ws-a", "ws-b"):
-            session = await get_session(ws_id)
+            session = await get_session(ws_id, app_state=app_state)
             session._proc = AsyncMock()
             session._proc.returncode = None
             session._proc.kill = MagicMock()
@@ -1289,11 +1305,10 @@ class TestMonitorProcess:
         session._gave_up = True
         session._last_container_id = "old-cid"
         # Simulate container change — _resolve_container_id sees new ID.
-        with patch(
-            "klangk_backend.agent.container.registry.get_state",
-            return_value=_FakeContainerState("new-cid"),
-        ):
-            cid = session._resolve_container_id()
+        session.app_state.container_registry.get_state.return_value = (
+            _FakeContainerState("new-cid")
+        )
+        cid = session._resolve_container_id()
         assert cid == "new-cid"
         assert session._gave_up is False
         assert session._restart_attempts == 0
@@ -1470,8 +1485,9 @@ class TestMonitorProcess:
                 "klangk_backend.agent.get_workspace_session",
                 return_value=MagicMock(),
             ),
-            patch(
-                "klangk_backend.agent.container.registry.get_state",
+            patch.object(
+                session.app_state.container_registry,
+                "get_state",
                 return_value=None,
             ),
             patch(

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -13,6 +13,7 @@ import httpx
 from httpx import AsyncClient, ASGITransport
 
 from klangk_backend import (
+    agent,
     api,
     auth,
     container,
@@ -23,6 +24,9 @@ from klangk_backend import (
     workspaces as ws_mod,
     wshandler,
 )
+from klangk_backend.container import ContainerRegistry
+from klangk_backend.settings import KlangkSettings
+from klangk_backend.wshandler.session import WebSocketState
 
 
 @pytest.fixture
@@ -32,10 +36,33 @@ async def app(db):
     from klangk_backend.util import API_PREFIX
     from klangk_backend.main import register_exception_handlers
 
+    settings = KlangkSettings(env={})
+    registry = ContainerRegistry(settings)
+    sockets = WebSocketState()
+    app.state.settings = settings
+    app.state.container_registry = registry
+    app.state.sockets = sockets
+    registry.sockets = sockets
+    registry.app_state = app.state
+    sockets.app_state = app.state
+    agent.get_workspace_session = sockets.get_session
+
     app.include_router(api.root_router)
     app.include_router(api.router, prefix=API_PREFIX)
     register_exception_handlers(app)
     return app
+
+
+@pytest.fixture
+def registry(app):
+    """Shortcut to the ContainerRegistry on app.state."""
+    return app.state.container_registry
+
+
+@pytest.fixture
+def sockets(app):
+    """Shortcut to the WebSocketState on app.state."""
+    return app.state.sockets
 
 
 @pytest.fixture
@@ -151,10 +178,10 @@ class TestWorkspaceChat:
         assert data["message_type"] == model.MSG_AGENT
         assert data["workspace_id"] == workspace["id"]
 
-    async def test_broadcasts_to_websocket(self, client, user):
+    async def test_broadcasts_to_websocket(self, client, user, sockets):
         workspace = await model.create_workspace(user["id"], "bcast-ws")
         token = auth.create_workspace_token(workspace["id"])
-        session = wshandler.state.get_or_create_session(workspace["id"])
+        session = sockets.get_or_create_session(workspace["id"])
         mock_sock = MagicMock()
         session.subscribers.add(mock_sock)
 
@@ -169,7 +196,7 @@ class TestWorkspaceChat:
         assert sent["type"] == "chat_message"
         assert sent["message"] == "broadcast test"
 
-        wshandler.state.sessions.pop(workspace["id"], None)
+        sockets.sessions.pop(workspace["id"], None)
 
     async def test_missing_auth(self, client):
         resp = await client.post(
@@ -596,13 +623,13 @@ class TestAuthRoutes:
         )
         assert resp.status_code == 401
 
-    async def test_logout(self, client, user):
+    async def test_logout(self, client, user, registry):
         headers = await _auth_headers(client)
         # Logout must NOT stop the user's containers (#1235): the idle timeout
         # is the only thing that stops containers (#301). Guard against a
         # regression of the old logout_user holdover.
         with patch.object(
-            container.registry,
+            registry,
             "stop_and_remove_container",
             new_callable=AsyncMock,
         ) as mock_stop:
@@ -1229,7 +1256,7 @@ class TestWorkspaceRoutes:
         assert resp.status_code == 200
         assert resp.json() == []
 
-    async def test_list_includes_running_status(self, client, user):
+    async def test_list_includes_running_status(self, client, user, registry):
         headers = await _auth_headers(client)
         resp = await client.post(
             "/api/v1/workspaces", headers=headers, json={"name": "run-test"}
@@ -1242,9 +1269,7 @@ class TestWorkspaceRoutes:
         assert ws["running"] is False
 
         # Simulate running container
-        from klangk_backend import container
-
-        container.registry.track_activity("fake-cid", ws_id)
+        registry.track_activity("fake-cid", ws_id)
         try:
             resp = await client.get(
                 "/api/v1/workspaces?limit=10", headers=headers
@@ -1253,14 +1278,14 @@ class TestWorkspaceRoutes:
             ws = next(w for w in items if w["id"] == ws_id)
             assert ws["running"] is True
         finally:
-            await container.registry.remove_state(ws_id)
+            await registry.remove_state(ws_id)
 
         # Also works for bare list (no pagination params)
         resp = await client.get("/api/v1/workspaces", headers=headers)
         ws = next(w for w in resp.json() if w["id"] == ws_id)
         assert ws["running"] is False
 
-    async def test_list_includes_live_health(self, client, user):
+    async def test_list_includes_live_health(self, client, user, registry):
         """List payload carries live health for a steady-state failure (#1173).
 
         The health monitor only broadcasts ``service_health`` on a
@@ -1278,10 +1303,8 @@ class TestWorkspaceRoutes:
         ws_id = resp.json()["id"]
 
         # Simulate a running container that is steadily unhealthy.
-        from klangk_backend import container
-
-        container.registry.track_activity("cid-health", ws_id)
-        state = container.registry.get_state(ws_id)
+        registry.track_activity("cid-health", ws_id)
+        state = registry.get_state(ws_id)
         assert state is not None
         state.health_status = "unhealthy"
         state.health_message = "gateway refused connection"
@@ -1305,7 +1328,7 @@ class TestWorkspaceRoutes:
             assert ws["health"] == "healthy"
             assert ws["health_message"] is None
         finally:
-            await container.registry.remove_state(ws_id)
+            await registry.remove_state(ws_id)
 
         # Stopped workspace: no health fields beyond running=False.
         resp = await client.get("/api/v1/workspaces?limit=10", headers=headers)
@@ -1522,7 +1545,7 @@ class TestWorkspaceRoutes:
         assert "allowed" in data
         assert data["default"] in data["allowed"]
 
-    async def test_delete_workspace(self, client, user):
+    async def test_delete_workspace(self, client, user, registry):
         headers = await _auth_headers(client)
         create_resp = await client.post(
             "/api/v1/workspaces", headers=headers, json={"name": "doomed"}
@@ -1530,7 +1553,7 @@ class TestWorkspaceRoutes:
         ws_id = create_resp.json()["id"]
 
         with patch.object(
-            api.container.registry,
+            registry,
             "stop_and_remove_container",
             new_callable=AsyncMock,
         ):
@@ -1564,7 +1587,9 @@ class TestWorkspaceRoutes:
         )
         assert resp.status_code == 404
 
-    async def test_delete_workspace_with_container(self, client, user):
+    async def test_delete_workspace_with_container(
+        self, client, user, registry
+    ):
         headers = await _auth_headers(client)
         create_resp = await client.post(
             "/api/v1/workspaces",
@@ -1577,7 +1602,7 @@ class TestWorkspaceRoutes:
 
         with (
             patch.object(
-                api.container.registry,
+                registry,
                 "stop_and_remove_container",
                 new_callable=AsyncMock,
             ) as mock_rm,
@@ -1594,7 +1619,9 @@ class TestWorkspaceRoutes:
         mock_stop_agent.assert_awaited_once_with(ws_id)
         mock_rm.assert_awaited_once_with("fake-container-id")
 
-    async def test_delete_workspace_cleans_up_groups(self, client, user):
+    async def test_delete_workspace_cleans_up_groups(
+        self, client, user, registry
+    ):
         headers = await _auth_headers(client)
         create_resp = await client.post(
             "/api/v1/workspaces",
@@ -1613,7 +1640,7 @@ class TestWorkspaceRoutes:
         assert len(acl) > 0
 
         with patch.object(
-            api.container.registry,
+            registry,
             "stop_and_remove_container",
             new_callable=AsyncMock,
         ):
@@ -1631,10 +1658,10 @@ class TestWorkspaceRoutes:
         acl = await model.get_acl_entries(f"/workspaces/{ws_id}")
         assert len(acl) == 0
 
-    async def test_create_notifies_creator(self, client, user):
+    async def test_create_notifies_creator(self, client, user, sockets):
         headers = await _auth_headers(client)
         with patch.object(
-            wshandler.state,
+            sockets,
             "notify_user_workspaces_changed",
         ) as mock_notify:
             resp = await client.post(
@@ -1645,7 +1672,9 @@ class TestWorkspaceRoutes:
         assert resp.status_code == 200
         mock_notify.assert_called_once_with(user["id"])
 
-    async def test_delete_notifies_deleter_and_owner(self, client, user):
+    async def test_delete_notifies_deleter_and_owner(
+        self, client, user, registry, sockets
+    ):
         headers = await _auth_headers(client)
         create_resp = await client.post(
             "/api/v1/workspaces",
@@ -1656,12 +1685,12 @@ class TestWorkspaceRoutes:
 
         with (
             patch.object(
-                api.container.registry,
+                registry,
                 "stop_and_remove_container",
                 new_callable=AsyncMock,
             ),
             patch.object(
-                wshandler.state,
+                sockets,
                 "notify_user_workspaces_changed",
             ) as mock_notify,
         ):
@@ -1672,7 +1701,7 @@ class TestWorkspaceRoutes:
         # Deleter is the owner here, so exactly one notify call for them.
         mock_notify.assert_called_once_with(user["id"])
 
-    async def test_restart_workspace(self, client, user):
+    async def test_restart_workspace(self, client, user, registry):
         headers = await _auth_headers(client)
         create_resp = await client.post(
             "/api/v1/workspaces", headers=headers, json={"name": "restart-me"}
@@ -1680,11 +1709,11 @@ class TestWorkspaceRoutes:
         ws_id = create_resp.json()["id"]
 
         # Simulate a running container so the stop path is exercised.
-        api.container.registry.track_activity("cid-restart", ws_id)
+        registry.track_activity("cid-restart", ws_id)
 
         with (
             patch.object(
-                api.container.registry,
+                registry,
                 "stop_and_remove_container",
                 new_callable=AsyncMock,
             ) as mock_stop,
@@ -1705,7 +1734,7 @@ class TestWorkspaceRoutes:
         mock_start.assert_awaited_once()
 
         # Clean up registry state.
-        api.container.registry.states.pop(ws_id, None)
+        registry.states.pop(ws_id, None)
 
     async def test_restart_not_found(self, client, user):
         headers = await _auth_headers(client)
@@ -1723,7 +1752,7 @@ class TestWorkspaceRoutes:
         )
         assert resp.status_code == 404
 
-    async def test_workspace_status_running(self, client, user):
+    async def test_workspace_status_running(self, client, user, registry):
         headers = await _auth_headers(client)
         create_resp = await client.post(
             "/api/v1/workspaces",
@@ -1733,7 +1762,7 @@ class TestWorkspaceRoutes:
         ws_id = create_resp.json()["id"]
 
         # Simulate a running container.
-        api.container.registry.track_activity("cid-status", ws_id)
+        registry.track_activity("cid-status", ws_id)
 
         resp = await client.get(
             f"/api/v1/workspaces/{ws_id}/status",
@@ -1749,8 +1778,8 @@ class TestWorkspaceRoutes:
         assert isinstance(data["ports"], list)
 
         # Clean up registry state.
-        api.container.registry.states.pop(ws_id, None)
-        api.container.registry._cid_to_wsid.pop("cid-status", None)
+        registry.states.pop(ws_id, None)
+        registry._cid_to_wsid.pop("cid-status", None)
 
     async def test_workspace_status_not_running(self, client, user):
         headers = await _auth_headers(client)
@@ -1826,12 +1855,11 @@ class TestWorkspaceRoutes:
         assert match[0]["service_command"] == "pi"
 
     async def test_update_workspace_propagates_to_live_state(
-        self, client, user
+        self, client, user, registry
     ):
         # Editing setup_state/health_check on a workspace whose
         # container is live updates the cached ContainerState so the
         # health monitor picks it up without a restart (#1015).
-        import klangk_backend.container as container
 
         headers = await _auth_headers(client)
         resp = await client.post(
@@ -1842,13 +1870,13 @@ class TestWorkspaceRoutes:
         ws_id = resp.json()["id"]
 
         # Simulate a running container by registering a live state.
-        container.registry.track_activity(
+        registry.track_activity(
             "cid-live",
             ws_id,
             health_check="old-cmd",
             setup_state="pending",
         )
-        live = container.registry.get_state(ws_id)
+        live = registry.get_state(ws_id)
         live.health_status = "healthy"  # will be reset on edit
         live.health_message = "stale reason"  # also reset on edit (#1088)
         try:
@@ -1868,7 +1896,7 @@ class TestWorkspaceRoutes:
             assert live.health_checked_at is None
             assert live.health_message is None
         finally:
-            await container.registry.remove_state(ws_id)
+            await registry.remove_state(ws_id)
 
     async def test_update_workspace_no_permission(self, client, user):
         headers = await _auth_headers(client)
@@ -2267,7 +2295,9 @@ class TestWorkspaceSharingRoutes:
         assert len(resp.json()) == 1
         assert resp.json()[0]["email"] == "other@example.com"
 
-    async def test_add_member_notifies_owner_and_target(self, client, user):
+    async def test_add_member_notifies_owner_and_target(
+        self, client, user, sockets
+    ):
         headers = await _auth_headers(client)
         other = await self._create_other_user()
         resp = await client.post(
@@ -2275,7 +2305,7 @@ class TestWorkspaceSharingRoutes:
         )
         ws_id = resp.json()["id"]
         with patch.object(
-            wshandler.state, "notify_user_workspaces_changed"
+            sockets, "notify_user_workspaces_changed"
         ) as mock_notify:
             resp = await client.post(
                 f"/api/v1/workspaces/{ws_id}/members",
@@ -2287,7 +2317,7 @@ class TestWorkspaceSharingRoutes:
         assert notified == {user["id"], other["id"]}
 
     async def test_remove_member_notifies_owner_and_removed(
-        self, client, user
+        self, client, user, sockets
     ):
         headers = await _auth_headers(client)
         other = await self._create_other_user()
@@ -2301,7 +2331,7 @@ class TestWorkspaceSharingRoutes:
             json={"email": "other@example.com"},
         )
         with patch.object(
-            wshandler.state, "notify_user_workspaces_changed"
+            sockets, "notify_user_workspaces_changed"
         ) as mock_notify:
             resp = await client.delete(
                 f"/api/v1/workspaces/{ws_id}/members/{other['id']}",
@@ -2311,7 +2341,9 @@ class TestWorkspaceSharingRoutes:
         notified = {call.args[0] for call in mock_notify.call_args_list}
         assert notified == {user["id"], other["id"]}
 
-    async def test_add_to_role_notifies_owner_and_target(self, client, user):
+    async def test_add_to_role_notifies_owner_and_target(
+        self, client, user, sockets
+    ):
         headers = await _auth_headers(client)
         other = await self._create_other_user()
         resp = await client.post(
@@ -2319,7 +2351,7 @@ class TestWorkspaceSharingRoutes:
         )
         ws_id = resp.json()["id"]
         with patch.object(
-            wshandler.state, "notify_user_workspaces_changed"
+            sockets, "notify_user_workspaces_changed"
         ) as mock_notify:
             resp = await client.post(
                 f"/api/v1/workspaces/{ws_id}/roles/collaborators",
@@ -2331,7 +2363,7 @@ class TestWorkspaceSharingRoutes:
         assert notified == {user["id"], other["id"]}
 
     async def test_remove_from_role_notifies_owner_and_member(
-        self, client, user
+        self, client, user, sockets
     ):
         headers = await _auth_headers(client)
         other = await self._create_other_user()
@@ -2345,7 +2377,7 @@ class TestWorkspaceSharingRoutes:
             json={"email": "other@example.com"},
         )
         with patch.object(
-            wshandler.state, "notify_user_workspaces_changed"
+            sockets, "notify_user_workspaces_changed"
         ) as mock_notify:
             resp = await client.delete(
                 f"/api/v1/workspaces/{ws_id}"
@@ -2356,7 +2388,9 @@ class TestWorkspaceSharingRoutes:
         notified = {call.args[0] for call in mock_notify.call_args_list}
         assert notified == {user["id"], other["id"]}
 
-    async def test_change_role_notifies_owner_and_target(self, client, user):
+    async def test_change_role_notifies_owner_and_target(
+        self, client, user, sockets
+    ):
         headers = await _auth_headers(client)
         other = await self._create_other_user()
         resp = await client.post(
@@ -2364,7 +2398,7 @@ class TestWorkspaceSharingRoutes:
         )
         ws_id = resp.json()["id"]
         with patch.object(
-            wshandler.state, "notify_user_workspaces_changed"
+            sockets, "notify_user_workspaces_changed"
         ) as mock_notify:
             resp = await client.patch(
                 f"/api/v1/workspaces/{ws_id}/roles",
@@ -3598,10 +3632,12 @@ class TestBrowserBridge:
         assert resp.status_code == 401
         assert "expired" in resp.json()["detail"].lower()
 
-    async def test_browser_id_routes_to_correct_tab(self, client, user):
+    async def test_browser_id_routes_to_correct_tab(
+        self, client, user, registry, sockets
+    ):
         """Browser ID routes to the specific browser tab."""
         mock_sock = MagicMock()
-        container.registry.register_browser("bid-conn", "ws-conn", mock_sock)
+        registry.register_browser("bid-conn", "ws-conn", mock_sock)
         mock_session = AsyncMock()
         mock_session.browser_subscribers = {mock_sock}
         mock_session.dispatch_browser_request_to = AsyncMock(
@@ -3609,7 +3645,7 @@ class TestBrowserBridge:
         )
         try:
             with patch.object(
-                wshandler.state,
+                sockets,
                 "get_session",
                 return_value=mock_session,
             ):
@@ -3624,17 +3660,19 @@ class TestBrowserBridge:
                 mock_sock, {"action": "fetch"}, timeout=30.0
             )
         finally:
-            container.registry.revoke_workspace_browsers("ws-conn")
+            registry.revoke_workspace_browsers("ws-conn")
 
-    async def test_browser_not_subscribed_returns_502(self, client, user):
+    async def test_browser_not_subscribed_returns_502(
+        self, client, user, registry, sockets
+    ):
         """Returns 502 when target not in browser_subscribers."""
         mock_sock = MagicMock()
-        container.registry.register_browser("bid-nosub", "ws-nosub", mock_sock)
+        registry.register_browser("bid-nosub", "ws-nosub", mock_sock)
         mock_session = AsyncMock()
         mock_session.browser_subscribers = set()
         try:
             with patch.object(
-                wshandler.state,
+                sockets,
                 "get_session",
                 return_value=mock_session,
             ):
@@ -3646,13 +3684,11 @@ class TestBrowserBridge:
             assert resp.status_code == 502
             assert "Browser connection not available" in resp.json()["detail"]
         finally:
-            container.registry.revoke_workspace_browsers("ws-nosub")
+            registry.revoke_workspace_browsers("ws-nosub")
 
-    async def test_no_session_returns_502(self, client, user):
+    async def test_no_session_returns_502(self, client, user, registry):
         mock_sock = MagicMock()
-        container.registry.register_browser(
-            "bid-nosess", "ws-nosess", mock_sock
-        )
+        registry.register_browser("bid-nosess", "ws-nosess", mock_sock)
         try:
             resp = await client.post(
                 "/api/v1/browser-delegate",
@@ -3662,11 +3698,13 @@ class TestBrowserBridge:
             assert resp.status_code == 502
             assert "No browser client" in resp.json()["detail"]
         finally:
-            container.registry.revoke_workspace_browsers("ws-nosess")
+            registry.revoke_workspace_browsers("ws-nosess")
 
-    async def test_dispatch_error_returns_502(self, client, user):
+    async def test_dispatch_error_returns_502(
+        self, client, user, registry, sockets
+    ):
         mock_sock = MagicMock()
-        container.registry.register_browser("bid-err", "ws-err", mock_sock)
+        registry.register_browser("bid-err", "ws-err", mock_sock)
         mock_session = AsyncMock()
         mock_session.browser_subscribers = {mock_sock}
         mock_session.dispatch_browser_request_to = AsyncMock(
@@ -3676,7 +3714,7 @@ class TestBrowserBridge:
         )
         try:
             with patch.object(
-                wshandler.state, "get_session", return_value=mock_session
+                sockets, "get_session", return_value=mock_session
             ):
                 resp = await client.post(
                     "/api/v1/browser-delegate",
@@ -3686,14 +3724,14 @@ class TestBrowserBridge:
             assert resp.status_code == 502
             assert "timeout" in resp.json()["detail"].lower()
         finally:
-            container.registry.revoke_workspace_browsers("ws-err")
+            registry.revoke_workspace_browsers("ws-err")
 
-    async def test_stream_endpoint_relays_ndjson(self, client, user):
+    async def test_stream_endpoint_relays_ndjson(
+        self, client, user, registry, sockets
+    ):
         """The streaming endpoint relays the generator's NDJSON to the caller."""
         mock_sock = MagicMock()
-        container.registry.register_browser(
-            "bid-stream", "ws-stream", mock_sock
-        )
+        registry.register_browser("bid-stream", "ws-stream", mock_sock)
 
         async def fake_stream():
             yield '{"type": "chunk", "delta": "a"}\n'
@@ -3708,7 +3746,7 @@ class TestBrowserBridge:
         )
         try:
             with patch.object(
-                wshandler.state, "get_session", return_value=mock_session
+                sockets, "get_session", return_value=mock_session
             ):
                 resp = await client.post(
                     "/api/v1/browser-delegate/stream",
@@ -3723,7 +3761,7 @@ class TestBrowserBridge:
             assert '"done"' in resp.text
             mock_session.dispatch_browser_request_stream_to.assert_called_once()
         finally:
-            container.registry.revoke_workspace_browsers("ws-stream")
+            registry.revoke_workspace_browsers("ws-stream")
 
 
 # --- Volume routes ---
@@ -3935,18 +3973,22 @@ class TestFileRoutes:
 
     CID = "cid-file-test"
 
+    @pytest.fixture(autouse=True)
+    def _bind_registry(self, registry):
+        self._registry = registry
+
     async def _create_workspace(self, client, headers):
         resp = await client.post(
             "/api/v1/workspaces", headers=headers, json={"name": "file-ws"}
         )
         ws_id = resp.json()["id"]
         # Simulate a running container
-        container.registry.track_activity(self.CID, ws_id)
+        self._registry.track_activity(self.CID, ws_id)
         return ws_id
 
     def _cleanup(self, ws_id):
-        container.registry.states.pop(ws_id, None)
-        container.registry._cid_to_wsid.pop(self.CID, None)
+        self._registry.states.pop(ws_id, None)
+        self._registry._cid_to_wsid.pop(self.CID, None)
 
     async def test_list_files(self, client, user):
         headers = await _auth_headers(client)
@@ -4020,11 +4062,11 @@ class TestFileRoutes:
         finally:
             self._cleanup(ws_id)
 
-    async def test_upload_records_activity(self, client, user):
+    async def test_upload_records_activity(self, client, user, registry):
         headers = await _auth_headers(client)
         ws_id = await self._create_workspace(client, headers)
         try:
-            container.registry.states[ws_id].last_activity = 0.0
+            self._registry.states[ws_id].last_activity = 0.0
             with patch(
                 "klangk_backend.files.podman.exec_container",
                 new_callable=AsyncMock,
@@ -4035,7 +4077,7 @@ class TestFileRoutes:
                     headers=headers,
                     files={"file": ("test.txt", b"data", "text/plain")},
                 )
-            assert container.registry.states[ws_id].last_activity > 0.0
+            assert self._registry.states[ws_id].last_activity > 0.0
         finally:
             self._cleanup(ws_id)
 
@@ -4506,14 +4548,14 @@ class TestFileRoutes:
 
 
 class TestSetIdleTimeout:
-    async def test_set_idle_timeout_global(self, db):
+    async def test_set_idle_timeout_global(self, db, app, registry):
         """Setting global idle timeout changes the module-level variable."""
         original_timeout = container.IDLE_TIMEOUT_SECONDS
         try:
             container.IDLE_TIMEOUT_SECONDS = 42
             assert container.IDLE_TIMEOUT_SECONDS == 42
             # Per-workspace lookup falls back to global
-            assert container.registry.get_workspace_idle_timeout("any") == 42
+            assert registry.get_workspace_idle_timeout("any") == 42
         finally:
             container.IDLE_TIMEOUT_SECONDS = original_timeout
 
@@ -4526,32 +4568,32 @@ class TestSetIdleTimeout:
         resp = await client.get("/api/v1/test/idle-timeout")
         assert resp.status_code in (404, 405)
 
-    async def test_set_idle_timeout_per_workspace(self, db):
+    async def test_set_idle_timeout_per_workspace(self, db, app, registry):
         """Per-workspace idle timeout should not affect global."""
         original_timeout = container.IDLE_TIMEOUT_SECONDS
         try:
-            container.registry.track_activity("cid-test", "ws-test")
-            container.registry.set_workspace_idle_timeout("ws-test", 5)
-            assert (
-                container.registry.get_workspace_idle_timeout("ws-test") == 5
-            )
+            registry.track_activity("cid-test", "ws-test")
+            registry.set_workspace_idle_timeout("ws-test", 5)
+            assert registry.get_workspace_idle_timeout("ws-test") == 5
             assert container.IDLE_TIMEOUT_SECONDS == original_timeout
             # Unknown workspace returns global default
             assert (
-                container.registry.get_workspace_idle_timeout("ws-other")
+                registry.get_workspace_idle_timeout("ws-other")
                 == original_timeout
             )
         finally:
-            container.registry.states.pop("ws-test", None)
+            registry.states.pop("ws-test", None)
 
-    async def test_cleanup_loop_adapts_to_short_timeout(self, db):
+    async def test_cleanup_loop_adapts_to_short_timeout(
+        self, db, app, registry
+    ):
         """Cleanup loop interval adapts when per-workspace timeouts exist."""
         try:
-            container.registry.track_activity("cid-fast", "ws-fast")
-            container.registry.set_workspace_idle_timeout("ws-fast", 6)
+            registry.track_activity("cid-fast", "ws-fast")
+            registry.set_workspace_idle_timeout("ws-fast", 6)
             # With a 6s per-workspace timeout, the minimum is 6, so
             # the loop should sleep max(2, 6//2) = 3 seconds.
-            state = container.registry.states["ws-fast"]
+            state = registry.states["ws-fast"]
             assert state.idle_timeout == 6
             # Global CHECK_INTERVAL_SECONDS should be unchanged
             assert (
@@ -4559,7 +4601,7 @@ class TestSetIdleTimeout:
                 == container.parse_idle_timeout()[1]
             )
         finally:
-            container.registry.states.pop("ws-fast", None)
+            registry.states.pop("ws-fast", None)
 
 
 # --- Roles ---
@@ -4871,11 +4913,11 @@ class TestAdminEndpoints:
         )
         assert resp.status_code == 403
 
-    async def test_delete_user(self, client, admin_user, user):
+    async def test_delete_user(self, client, admin_user, user, registry):
         headers = await self._admin_headers(client)
         with (
             patch.object(
-                container.registry,
+                registry,
                 "stop_user_containers",
                 new_callable=AsyncMock,
             ),
@@ -4918,7 +4960,7 @@ class TestAdminEndpoints:
         assert "system agent" in resp.json()["detail"]
 
     async def test_delete_user_cascades_workspaces(
-        self, client, admin_user, user
+        self, client, admin_user, user, registry
     ):
         """Deleting a user cascades to their ws_mod."""
         headers = await self._admin_headers(client)
@@ -4938,7 +4980,7 @@ class TestAdminEndpoints:
         assert ws_resp.status_code == 200
         # Delete the user
         with patch.object(
-            container.registry,
+            registry,
             "stop_user_containers",
             new_callable=AsyncMock,
         ):
@@ -6188,7 +6230,7 @@ class TestWorkspaceExportImport:
         assert resp.status_code == 400
         assert "missing instance_id" in resp.json()["detail"]
 
-    async def test_import_notifies_importer(self, client, user):
+    async def test_import_notifies_importer(self, client, user, sockets):
         import io
         import json
         import tarfile
@@ -6203,7 +6245,7 @@ class TestWorkspaceExportImport:
 
         headers = await self._user_headers(client)
         with patch.object(
-            wshandler.state, "notify_user_workspaces_changed"
+            sockets, "notify_user_workspaces_changed"
         ) as mock_notify:
             resp = await client.post(
                 "/api/v1/workspaces/import",
@@ -7654,7 +7696,9 @@ class TestOIDCAuthModeGuards:
     async def test_login_blocked_when_oidc_only(
         self, client, monkeypatch, user
     ):
-        monkeypatch.setattr(api.oidc, "password_login_allowed", lambda *args: False)
+        monkeypatch.setattr(
+            api.oidc, "password_login_allowed", lambda *args: False
+        )
         resp = await client.post(
             "/api/v1/auth/login",
             json={"email": "testuser@example.com", "password": "testpass"},
@@ -7665,7 +7709,9 @@ class TestOIDCAuthModeGuards:
     async def test_register_blocked_when_oidc_only(
         self, client, monkeypatch, db
     ):
-        monkeypatch.setattr(api.oidc, "password_login_allowed", lambda *args: False)
+        monkeypatch.setattr(
+            api.oidc, "password_login_allowed", lambda *args: False
+        )
         resp = await client.post(
             "/api/v1/auth/register",
             json={"email": "new@example.com", "password": "testpass"},
@@ -7673,7 +7719,9 @@ class TestOIDCAuthModeGuards:
         assert resp.status_code == 403
 
     async def test_login_allowed_when_both(self, client, monkeypatch, user):
-        monkeypatch.setattr(api.oidc, "password_login_allowed", lambda *args: True)
+        monkeypatch.setattr(
+            api.oidc, "password_login_allowed", lambda *args: True
+        )
         resp = await client.post(
             "/api/v1/auth/login",
             json={"email": "testuser@example.com", "password": "testpass"},
@@ -7683,7 +7731,9 @@ class TestOIDCAuthModeGuards:
 
 class TestOIDCLogin:
     async def test_oidc_login_not_enabled(self, client, monkeypatch):
-        monkeypatch.setattr(api.oidc, "oidc_login_allowed", lambda *args: False)
+        monkeypatch.setattr(
+            api.oidc, "oidc_login_allowed", lambda *args: False
+        )
         resp = await client.get("/api/v1/auth/oidc/test/login")
         assert resp.status_code == 404
 
@@ -8487,7 +8537,9 @@ class TestHandleEndpoints:
         updated = await model.get_user_by_id(user["id"])
         assert updated["handle"] == "newhandle"
 
-    async def test_change_handle_refreshes_presence(self, client, user):
+    async def test_change_handle_refreshes_presence(
+        self, client, user, sockets
+    ):
         headers = await _auth_headers(client)
         with patch.object(
             api.wshandler,
@@ -8500,7 +8552,9 @@ class TestHandleEndpoints:
                 headers=headers,
             )
         assert resp.status_code == 200
-        mock_refresh.assert_awaited_once_with(user["id"], "freshhandle")
+        mock_refresh.assert_awaited_once_with(
+            sockets, user["id"], "freshhandle"
+        )
 
     async def test_change_handle_invalid_empty(self, client, user):
         headers = await _auth_headers(client)
@@ -8584,7 +8638,7 @@ class TestHandleEndpoints:
         assert updated["handle"] == "admin-set-handle"
 
     async def test_admin_change_handle_refreshes_presence(
-        self, client, admin_user, user
+        self, client, admin_user, user, sockets
     ):
         admin_resp = await client.post(
             "/api/v1/auth/login",
@@ -8604,7 +8658,9 @@ class TestHandleEndpoints:
                 headers=admin_headers,
             )
         assert resp.status_code == 200
-        mock_refresh.assert_awaited_once_with(user["id"], "admin-refreshed")
+        mock_refresh.assert_awaited_once_with(
+            sockets, user["id"], "admin-refreshed"
+        )
 
     async def test_admin_change_user_handle_invalid(
         self, client, admin_user, user

--- a/src/backend/tests/test_bringup.py
+++ b/src/backend/tests/test_bringup.py
@@ -40,6 +40,7 @@ class TestBringup:
             "/home/clanker",
             "openclaw gateway",
             setup_state="complete",
+            app_state=None,
         )
 
     async def test_skips_service_command_when_none(self):
@@ -101,6 +102,7 @@ class TestBringup:
             "/home/clanker",
             "openclaw gateway",
             setup_state="pending",
+            app_state=None,
         )
 
     async def test_threads_none_setup_state(self):
@@ -122,4 +124,5 @@ class TestBringup:
             "/home/clanker",
             "openclaw gateway",
             setup_state=None,
+            app_state=None,
         )

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import time
+import types
 from contextlib import ExitStack, contextmanager
 from pathlib import Path
 from types import SimpleNamespace
@@ -10,6 +11,28 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from klangk_backend import bringup, container, model, plugins, podman
+
+
+def _make_app_state(registry=None, sockets=None):
+    """Build a minimal app_state for tests."""
+    from klangk_backend.settings import KlangkSettings
+    from klangk_backend.wshandler.session import WebSocketState
+
+    settings = KlangkSettings(env={})
+    if registry is None:
+        registry = container.ContainerRegistry(settings)
+    if sockets is None:
+        sockets = WebSocketState()
+
+    app_state = types.SimpleNamespace(
+        container_registry=registry,
+        sockets=sockets,
+        settings=settings,
+    )
+    registry.sockets = sockets
+    registry.app_state = app_state
+    sockets.app_state = app_state
+    return app_state
 
 
 @pytest.fixture(autouse=True)
@@ -121,102 +144,94 @@ class TestImagePullPolicy:
 
 class TestActivityTracking:
     def setup_method(self):
-        container.registry.states.clear()
-
-    def teardown_method(self):
-        container.registry.states.clear()
+        app_state = _make_app_state()
+        self.registry = app_state.container_registry
 
     def testtrack_activity(self):
-        container.registry.track_activity("cid-1", "ws-1")
-        assert "ws-1" in container.registry.states
-        state = container.registry.states["ws-1"]
+        self.registry.track_activity("cid-1", "ws-1")
+        assert "ws-1" in self.registry.states
+        state = self.registry.states["ws-1"]
         assert state.container_id == "cid-1"
         assert state.last_activity <= time.time()
 
     def test_record_activity_updates_time(self):
-        container.registry.track_activity("cid-1", "ws-1")
-        old_time = container.registry.states["ws-1"].last_activity
+        self.registry.track_activity("cid-1", "ws-1")
+        old_time = self.registry.states["ws-1"].last_activity
         time.sleep(0.01)
-        container.registry.record_activity("cid-1")
-        new_time = container.registry.states["ws-1"].last_activity
+        self.registry.record_activity("cid-1")
+        new_time = self.registry.states["ws-1"].last_activity
         assert new_time > old_time
 
     def test_record_activity_unknown_container(self):
         # Should not raise
-        container.registry.record_activity("nonexistent")
-        assert "nonexistent" not in container.registry.states
+        self.registry.record_activity("nonexistent")
+        assert "nonexistent" not in self.registry.states
 
     def testtrack_activity_overwrites(self):
-        container.registry.track_activity("cid-1", "ws-1")
-        container.registry.track_activity("cid-1", "ws-2")
-        assert container.registry.states["ws-2"].container_id == "cid-1"
+        self.registry.track_activity("cid-1", "ws-1")
+        self.registry.track_activity("cid-1", "ws-2")
+        assert self.registry.states["ws-2"].container_id == "cid-1"
 
     def test_track_activity_same_workspace_updates_container(self):
-        container.registry.track_activity("cid-1", "ws-1")
-        container.registry.track_activity("cid-1", "ws-1")
-        assert container.registry.states["ws-1"].container_id == "cid-1"
+        self.registry.track_activity("cid-1", "ws-1")
+        self.registry.track_activity("cid-1", "ws-1")
+        assert self.registry.states["ws-1"].container_id == "cid-1"
 
     def test_track_activity_fires_status_changed_on_new(self):
         calls = []
-        container.registry.set_on_container_status_changed(
+        self.registry.set_on_container_status_changed(
             lambda ws_id, running: calls.append((ws_id, running))
         )
         try:
-            container.registry.track_activity("cid-new", "ws-new")
+            self.registry.track_activity("cid-new", "ws-new")
             assert calls == [("ws-new", True)]
             # Second call for same workspace should NOT fire again
-            container.registry.track_activity("cid-new", "ws-new")
+            self.registry.track_activity("cid-new", "ws-new")
             assert calls == [("ws-new", True)]
         finally:
-            container.registry.on_container_status_changed = None
+            self.registry.on_container_status_changed = None
 
     async def test_remove_state_cleans_up_reverse_mapping(self):
-        container.registry.track_activity("cid-rm", "ws-rm")
-        assert "cid-rm" in container.registry._cid_to_wsid
-        await container.registry.remove_state("ws-rm")
-        assert "ws-rm" not in container.registry.states
-        assert "cid-rm" not in container.registry._cid_to_wsid
+        self.registry.track_activity("cid-rm", "ws-rm")
+        assert "cid-rm" in self.registry._cid_to_wsid
+        await self.registry.remove_state("ws-rm")
+        assert "ws-rm" not in self.registry.states
+        assert "cid-rm" not in self.registry._cid_to_wsid
 
     async def test_remove_state_retains_workspace_lock(self):
         # remove_state must NOT pop _workspace_locks[ws] (#1258): doing so
         # would let a subsequent _get_workspace_lock hand out a fresh,
         # non-mutually-exclusive lock object while a coroutine may still be
         # waiting on the original. The lock entry is cheap to retain.
-        lock = container.registry._get_workspace_lock("ws-lock-rm")
-        assert "ws-lock-rm" in container.registry._workspace_locks
-        await container.registry.remove_state("ws-lock-rm")
-        assert "ws-lock-rm" in container.registry._workspace_locks
-        assert container.registry._workspace_locks["ws-lock-rm"] is lock
+        lock = self.registry._get_workspace_lock("ws-lock-rm")
+        assert "ws-lock-rm" in self.registry._workspace_locks
+        await self.registry.remove_state("ws-lock-rm")
+        assert "ws-lock-rm" in self.registry._workspace_locks
+        assert self.registry._workspace_locks["ws-lock-rm"] is lock
 
     def test_get_state_returns_state(self):
-        container.registry.track_activity("cid-1", "ws-1")
-        state = container.registry.get_state("ws-1")
+        self.registry.track_activity("cid-1", "ws-1")
+        state = self.registry.get_state("ws-1")
         assert state is not None
         assert state.container_id == "cid-1"
 
     def test_get_state_returns_none_for_unknown(self):
-        assert container.registry.get_state("nonexistent") is None
+        assert self.registry.get_state("nonexistent") is None
 
     def test_track_activity_stores_health_metadata(self):
         # health_check, owner_id, and setup_state are cached on the
         # ContainerState for the health monitor to read on each poll.
-        container.registry.track_activity(
+        self.registry.track_activity(
             "cid-hm",
             "ws-hm",
             health_check="curl -sf http://localhost:8080/health",
             owner_id="uid-owner",
             setup_state="complete",
         )
-        try:
-            state = container.registry.states["ws-hm"]
-            assert state.health_check == (
-                "curl -sf http://localhost:8080/health"
-            )
-            assert state.owner_id == "uid-owner"
-            assert state.setup_state == "complete"
-        finally:
-            container.registry.states.pop("ws-hm", None)
-            container.registry._cid_to_wsid.pop("cid-hm", None)
+        state = self.registry.states["ws-hm"]
+        assert state.health_check == ("curl -sf http://localhost:8080/health")
+        assert state.owner_id == "uid-owner"
+        assert state.setup_state == "complete"
 
 
 def _noop_callback(ws):
@@ -225,63 +240,54 @@ def _noop_callback(ws):
 
 class TestIdleCallbacks:
     def setup_method(self):
-        container.registry.states.clear()
-
-    def teardown_method(self):
-        container.registry.states.clear()
+        app_state = _make_app_state()
+        self.registry = app_state.container_registry
 
     def test_on_idle_stop_registers(self):
-        container.registry.track_activity("cid-1", "ws-1")
-        container.registry.on_idle_stop("ws-1", _noop_callback)
-        assert (
-            _noop_callback in container.registry.states["ws-1"].idle_callbacks
-        )
+        self.registry.track_activity("cid-1", "ws-1")
+        self.registry.on_idle_stop("ws-1", _noop_callback)
+        assert _noop_callback in self.registry.states["ws-1"].idle_callbacks
 
     def test_multiple_callbacks(self):
         def cb2(ws):
             pass
 
-        container.registry.track_activity("cid-1", "ws-1")
-        container.registry.on_idle_stop("ws-1", _noop_callback)
-        container.registry.on_idle_stop("ws-1", cb2)
-        assert len(container.registry.states["ws-1"].idle_callbacks) == 2
+        self.registry.track_activity("cid-1", "ws-1")
+        self.registry.on_idle_stop("ws-1", _noop_callback)
+        self.registry.on_idle_stop("ws-1", cb2)
+        assert len(self.registry.states["ws-1"].idle_callbacks) == 2
 
     def test_remove_idle_callback(self):
-        container.registry.track_activity("cid-1", "ws-1")
-        container.registry.on_idle_stop("ws-1", _noop_callback)
-        container.registry.remove_idle_callback("ws-1", _noop_callback)
+        self.registry.track_activity("cid-1", "ws-1")
+        self.registry.on_idle_stop("ws-1", _noop_callback)
+        self.registry.remove_idle_callback("ws-1", _noop_callback)
         assert (
-            _noop_callback
-            not in container.registry.states["ws-1"].idle_callbacks
+            _noop_callback not in self.registry.states["ws-1"].idle_callbacks
         )
 
     def test_remove_idle_callback_not_registered(self):
-        container.registry.track_activity("cid-1", "ws-1")
-        container.registry.remove_idle_callback("ws-1", _noop_callback)
+        self.registry.track_activity("cid-1", "ws-1")
+        self.registry.remove_idle_callback("ws-1", _noop_callback)
         assert (
-            _noop_callback
-            not in container.registry.states["ws-1"].idle_callbacks
+            _noop_callback not in self.registry.states["ws-1"].idle_callbacks
         )
 
     def test_remove_idle_callback_unknown_workspace(self):
-        container.registry.remove_idle_callback("nonexistent", _noop_callback)
-        assert "nonexistent" not in container.registry.states
+        self.registry.remove_idle_callback("nonexistent", _noop_callback)
+        assert "nonexistent" not in self.registry.states
 
     def test_callbacks_per_workspace(self):
         def cb2(ws):
             pass
 
-        container.registry.track_activity("cid-1", "ws-1")
-        container.registry.track_activity("cid-2", "ws-2")
-        container.registry.on_idle_stop("ws-1", _noop_callback)
-        container.registry.on_idle_stop("ws-2", cb2)
+        self.registry.track_activity("cid-1", "ws-1")
+        self.registry.track_activity("cid-2", "ws-2")
+        self.registry.on_idle_stop("ws-1", _noop_callback)
+        self.registry.on_idle_stop("ws-2", cb2)
+        assert _noop_callback in self.registry.states["ws-1"].idle_callbacks
+        assert cb2 in self.registry.states["ws-2"].idle_callbacks
         assert (
-            _noop_callback in container.registry.states["ws-1"].idle_callbacks
-        )
-        assert cb2 in container.registry.states["ws-2"].idle_callbacks
-        assert (
-            _noop_callback
-            not in container.registry.states["ws-2"].idle_callbacks
+            _noop_callback not in self.registry.states["ws-2"].idle_callbacks
         )
 
 
@@ -307,16 +313,18 @@ class TestPortAllocation:
         assert set(ports1).isdisjoint(set(ports2))
 
     async def test_get_workspace_ports(self, workspace):
+        app_state = _make_app_state()
+        registry = app_state.container_registry
         allocated = await model.find_and_allocate_ports(
             workspace["id"], 2, container.PORT_RANGE_START
         )
-        retrieved = await container.registry.get_workspace_ports(
-            workspace["id"]
-        )
+        retrieved = await registry.get_workspace_ports(workspace["id"])
         assert retrieved == sorted(allocated)
 
     async def test_get_workspace_ports_empty(self, workspace):
-        ports = await container.registry.get_workspace_ports(workspace["id"])
+        app_state = _make_app_state()
+        registry = app_state.container_registry
+        ports = await registry.get_workspace_ports(workspace["id"])
         assert ports == []
 
 
@@ -431,14 +439,12 @@ def _sudo_call(p):
 
 class TestStartContainer:
     def setup_method(self):
-        container.registry.states.clear()
-
-    def teardown_method(self):
-        container.registry.states.clear()
+        app_state = _make_app_state()
+        self.registry = app_state.container_registry
 
     async def test_create_new_container(self, workspace):
         with patch_podman() as p:
-            cid, status = await container.registry.start_container(
+            cid, status = await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
@@ -446,12 +452,12 @@ class TestStartContainer:
         assert cid == "new-cid"
         assert status == "created"
         p.start_container.assert_awaited_once_with("new-cid")
-        assert workspace["id"] in container.registry.states
+        assert workspace["id"] in self.registry.states
 
     async def test_sudo_disabled_by_default(self, workspace, monkeypatch):
         monkeypatch.delenv("KLANGK_ALLOW_SUDO", raising=False)
         with patch_podman() as p:
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
         call = _sudo_call(p)
@@ -461,7 +467,7 @@ class TestStartContainer:
     async def test_sudo_enabled(self, workspace, monkeypatch):
         monkeypatch.setenv("KLANGK_ALLOW_SUDO", "true")
         with patch_podman() as p:
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
         call = _sudo_call(p)
@@ -471,7 +477,7 @@ class TestStartContainer:
     async def test_sudo_disabled(self, workspace, monkeypatch):
         monkeypatch.setenv("KLANGK_ALLOW_SUDO", "0")
         with patch_podman() as p:
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
         assert "!ALL" in str(_sudo_call(p).args[1])
@@ -479,7 +485,7 @@ class TestStartContainer:
     async def test_sudo_disabled_false(self, workspace, monkeypatch):
         monkeypatch.setenv("KLANGK_ALLOW_SUDO", "false")
         with patch_podman() as p:
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
         assert "!ALL" in str(_sudo_call(p).args[1])
@@ -488,17 +494,17 @@ class TestStartContainer:
         """Start with sudo disabled, restart with sudo enabled."""
         monkeypatch.setenv("KLANGK_ALLOW_SUDO", "false")
         with patch_podman() as p:
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
         assert "!ALL" in str(_sudo_call(p).args[1])
 
         # "Restart" — remove container state so start_container creates a new one
-        container.registry.states.clear()
+        self.registry.states.clear()
         await model.update_workspace_container(workspace["id"], None)
         monkeypatch.setenv("KLANGK_ALLOW_SUDO", "true")
         with patch_podman() as p:
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
         assert "NOPASSWD:ALL" in str(_sudo_call(p).args[1])
@@ -507,16 +513,16 @@ class TestStartContainer:
         """Start with sudo enabled, restart with sudo disabled."""
         monkeypatch.setenv("KLANGK_ALLOW_SUDO", "true")
         with patch_podman() as p:
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
         assert "NOPASSWD:ALL" in str(_sudo_call(p).args[1])
 
-        container.registry.states.clear()
+        self.registry.states.clear()
         await model.update_workspace_container(workspace["id"], None)
         monkeypatch.setenv("KLANGK_ALLOW_SUDO", "false")
         with patch_podman() as p:
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
         assert "!ALL" in str(_sudo_call(p).args[1])
@@ -529,12 +535,12 @@ class TestStartContainer:
             start_container=AsyncMock(side_effect=RuntimeError("boom"))
         ):
             with pytest.raises(RuntimeError, match="boom"):
-                await container.registry.start_container(
+                await self.registry.start_container(
                     workspace["id"], "/tmp/ws", "/tmp/home"
                 )
         ws = await model.get_workspace(workspace["id"], user["id"])
         assert ws["container_id"] == "new-cid"
-        assert workspace["id"] in container.registry.states
+        assert workspace["id"] in self.registry.states
 
     async def test_cancel_during_start_still_persists(self, workspace, user):
         # The connecting client can disconnect mid-startup, cancelling this
@@ -551,7 +557,7 @@ class TestStartContainer:
             start_container=AsyncMock(side_effect=slow_start)
         ) as p:
             task = asyncio.create_task(
-                container.registry.start_container(
+                self.registry.start_container(
                     workspace["id"], "/tmp/ws", "/tmp/home"
                 )
             )
@@ -565,11 +571,11 @@ class TestStartContainer:
         ws = await model.get_workspace(workspace["id"], user["id"])
         assert ws["container_id"] == "new-cid"
         p.start_container.assert_awaited_once_with("new-cid")
-        assert workspace["id"] in container.registry.states
+        assert workspace["id"] in self.registry.states
 
     async def test_reuse_running_container(self, workspace):
         with patch_podman(inspect_container=_running(True)) as p:
-            cid, status = await container.registry.start_container(
+            cid, status = await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
@@ -582,7 +588,7 @@ class TestStartContainer:
 
     async def test_recreate_stopped_container(self, workspace):
         with patch_podman(inspect_container=_running(False)) as p:
-            cid, status = await container.registry.start_container(
+            cid, status = await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
@@ -595,7 +601,7 @@ class TestStartContainer:
     async def test_missing_container_creates_new(self, workspace):
         # inspect_container returns None (default) → treated as gone.
         with patch_podman() as p:
-            cid, status = await container.registry.start_container(
+            cid, status = await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
@@ -607,7 +613,7 @@ class TestStartContainer:
 
     async def test_disallowed_image_raises(self, workspace):
         with pytest.raises(ValueError, match="not in the allowed list"):
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"], "/work", "/home", image="evil:latest"
             )
 
@@ -617,7 +623,7 @@ class TestStartContainer:
         monkeypatch.setenv("KLANGK_NGINX_PORT", "8995")
 
         with patch_podman() as p:
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
@@ -652,7 +658,7 @@ class TestStartContainer:
                 terminal, "set_workspace_token", new_callable=AsyncMock
             ) as mock_set,
         ):
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
         mock_set.assert_called_once()
@@ -663,7 +669,7 @@ class TestStartContainer:
 
     async def test_pull_policy_default_never(self, workspace):
         with patch_podman() as p:
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
         assert p.create_container.call_args.kwargs["pull"] == "never"
@@ -671,7 +677,7 @@ class TestStartContainer:
     async def test_pull_policy_from_env(self, workspace, monkeypatch):
         monkeypatch.setenv("KLANGK_IMAGE_PULL_POLICY", "missing")
         with patch_podman() as p:
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
         assert p.create_container.call_args.kwargs["pull"] == "missing"
@@ -679,7 +685,7 @@ class TestStartContainer:
     async def test_config_mount_added(self, workspace):
         """Container gets read-only config mount when config_path is set."""
         with patch_podman() as p:
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
@@ -691,7 +697,7 @@ class TestStartContainer:
     async def test_no_config_mount_without_config_path(self, workspace):
         """Container has no config mount when config_path is not set."""
         with patch_podman() as p:
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
@@ -702,7 +708,7 @@ class TestStartContainer:
     async def test_home_mounted_at_slash_home(self, workspace):
         """Home path is mounted at /home (not /home/klangk)."""
         with patch_podman() as p:
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
@@ -712,7 +718,7 @@ class TestStartContainer:
 
     async def test_hosting_env_vars(self, workspace):
         with patch_podman() as p:
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
@@ -743,7 +749,7 @@ class TestStartContainer:
         monkeypatch.delenv("KLANGK_HOSTING_BASE_PATH", raising=False)
         monkeypatch.setenv("KLANGK_NGINX_PORT", "8996")
         with patch_podman() as p:
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
@@ -756,7 +762,7 @@ class TestStartContainer:
     async def test_terminal_banner_default_empty(self, workspace):
         """Default terminal banner is empty, so env var is not passed."""
         with patch_podman() as p:
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
@@ -768,7 +774,7 @@ class TestStartContainer:
         """Deployer can set a terminal banner via env var."""
         monkeypatch.setattr(container, "TERMINAL_BANNER", "Custom warning")
         with patch_podman() as p:
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
@@ -785,7 +791,7 @@ class TestStartContainer:
         (ssl_dir / "corp-ca.pem").write_text("-----BEGIN CERTIFICATE-----")
         monkeypatch.setenv("KLANGK_SSL_CERT_DIR", str(ssl_dir))
         with patch_podman() as p:
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
@@ -804,7 +810,7 @@ class TestStartContainer:
         """Without KLANGK_SSL_CERT_DIR there is no mount and no trust env."""
         monkeypatch.delenv("KLANGK_SSL_CERT_DIR", raising=False)
         with patch_podman() as p:
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
@@ -823,7 +829,7 @@ class TestStartContainer:
         (ssl_dir / "notes.txt").write_text("not a cert")
         monkeypatch.setenv("KLANGK_SSL_CERT_DIR", str(ssl_dir))
         with patch_podman() as p:
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
@@ -835,14 +841,14 @@ class TestStartContainer:
 
     async def test_port_allocation_on_create(self, workspace):
         with patch_podman():
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
                 num_ports=3,
             )
         # Ports should have been allocated
-        ports = await container.registry.get_workspace_ports(workspace["id"])
+        ports = await self.registry.get_workspace_ports(workspace["id"])
         assert len(ports) == 3
 
     async def test_excess_ports_trimmed(self, workspace):
@@ -851,26 +857,26 @@ class TestStartContainer:
             workspace["id"], 5, container.PORT_RANGE_START
         )
         with patch_podman():
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
                 num_ports=2,
             )
-        ports = await container.registry.get_workspace_ports(workspace["id"])
+        ports = await self.registry.get_workspace_ports(workspace["id"])
         assert len(ports) == 2
 
     async def test_cap_clamps_allocation_down(self, workspace, monkeypatch):
         """KLANGK_HOSTED_PORTS_PER_WORKSPACE clamps num_ports down (#1237)."""
         monkeypatch.setenv("KLANGK_HOSTED_PORTS_PER_WORKSPACE", "3")
         with patch_podman():
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
                 num_ports=5,  # DB default; cap is 3
             )
-        ports = await container.registry.get_workspace_ports(workspace["id"])
+        ports = await self.registry.get_workspace_ports(workspace["id"])
         assert len(ports) == 3
 
     async def test_cap_zero_releases_existing_ports(
@@ -882,20 +888,20 @@ class TestStartContainer:
             workspace["id"], 5, container.PORT_RANGE_START
         )
         with patch_podman():
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
                 num_ports=5,
             )
-        ports = await container.registry.get_workspace_ports(workspace["id"])
+        ports = await self.registry.get_workspace_ports(workspace["id"])
         assert ports == []
 
     async def test_cap_zero_omits_hosting_env(self, workspace, monkeypatch):
         """cap=0 suppresses KLANGK_PORT_MAPPINGS / KLANGK_HOSTING_* (#1237)."""
         monkeypatch.setenv("KLANGK_HOSTED_PORTS_PER_WORKSPACE", "0")
         with patch_podman() as p:
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
@@ -919,10 +925,8 @@ class TestStartContainer:
         not just trim on the container's first start.
         """
         monkeypatch.setenv("KLANGK_HOSTED_PORTS_PER_WORKSPACE", "0")
-        await container.registry.allocate_ports(workspace["id"], 5)
-        assert (
-            await container.registry.get_workspace_ports(workspace["id"]) == []
-        )
+        await self.registry.allocate_ports(workspace["id"], 5)
+        assert await self.registry.get_workspace_ports(workspace["id"]) == []
 
     async def test_hosting_env_present_when_enabled(
         self, workspace, monkeypatch
@@ -930,7 +934,7 @@ class TestStartContainer:
         """Sanity: with the default cap, hosting env is injected as before."""
         monkeypatch.delenv("KLANGK_HOSTED_PORTS_PER_WORKSPACE", raising=False)
         with patch_podman() as p:
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
@@ -945,7 +949,7 @@ class TestStartContainer:
 
     async def test_container_config_structure(self, workspace):
         with patch_podman() as p:
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
@@ -959,7 +963,7 @@ class TestStartContainer:
 
     async def test_create_container_with_extra_env(self, workspace):
         with patch_podman() as p:
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
@@ -985,7 +989,7 @@ class TestStartContainer:
         )
         monkeypatch.setattr(plugins, "_values", {"PLUGIN_VAR": "plugin-val"})
         with patch_podman() as p:
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
         env_list = p.create_container.call_args.kwargs["env"]
@@ -997,10 +1001,8 @@ class TestStartContainerPortConflict:
     """Test retry logic when a stale container holds a port."""
 
     def setup_method(self):
-        container.registry.states.clear()
-
-    def teardown_method(self):
-        container.registry.states.clear()
+        app_state = _make_app_state()
+        self.registry = app_state.container_registry
 
     async def test_port_conflict_removes_stale_and_retries(self, workspace):
         # Pre-allocate ports so we know exactly which ones the workspace gets.
@@ -1035,7 +1037,7 @@ class TestStartContainerPortConflict:
             ),
             inspect_container=AsyncMock(return_value=stale_info),
         ) as p:
-            cid, status = await container.registry.start_container(
+            cid, status = await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
         assert status == "created"
@@ -1071,7 +1073,7 @@ class TestStartContainerPortConflict:
                 }
             ),
         ) as p:
-            cid, _ = await container.registry.start_container(
+            cid, _ = await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
         # Should not have tried to remove its own container
@@ -1099,7 +1101,7 @@ class TestStartContainerPortConflict:
                 }
             ),
         ):
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
         # other-cid doesn't hold our ports — should not be removed
@@ -1123,7 +1125,7 @@ class TestStartContainerPortConflict:
             ),
             inspect_container=AsyncMock(return_value=None),
         ) as p:
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
         # gone-cid vanished — no remove attempted
@@ -1160,7 +1162,7 @@ class TestStartContainerPortConflict:
                 }
             ),
         ):
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
 
@@ -1195,7 +1197,7 @@ class TestStartContainerPortConflict:
                 side_effect=podman.PodmanError(500, "removal in progress")
             ),
         ):
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
 
@@ -1208,7 +1210,7 @@ class TestStartContainerPortConflict:
             ),
             pytest.raises(podman.PodmanError, match="some other error"),
         ):
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
 
@@ -1391,11 +1393,15 @@ class TestProtectedPaths:
 
 
 class TestExtraMountsVolumeCreation:
+    def setup_method(self):
+        app_state = _make_app_state()
+        self.registry = app_state.container_registry
+
     async def test_auto_creates_named_volume(self, workspace):
         """Named volumes (no leading /) are auto-created with klangk labels."""
         # inspect_volume returns None (default) → volume is created.
         with patch_podman() as p:
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
@@ -1422,7 +1428,7 @@ class TestExtraMountsVolumeCreation:
                 }
             )
         ) as p:
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
@@ -1442,7 +1448,7 @@ class TestExtraMountsVolumeCreation:
             )
         ):
             with pytest.raises(ValueError, match="not managed by this"):
-                await container.registry.start_container(
+                await self.registry.start_container(
                     workspace["id"],
                     "/tmp/ws",
                     "/tmp/home",
@@ -1455,7 +1461,7 @@ class TestExtraMountsVolumeCreation:
             inspect_volume=AsyncMock(return_value={"Name": "bare"})
         ):
             with pytest.raises(ValueError, match="not managed by this"):
-                await container.registry.start_container(
+                await self.registry.start_container(
                     workspace["id"],
                     "/tmp/ws",
                     "/tmp/home",
@@ -1476,7 +1482,7 @@ class TestExtraMountsVolumeCreation:
             )
         ):
             with pytest.raises(ValueError, match="belongs to another user"):
-                await container.registry.start_container(
+                await self.registry.start_container(
                     workspace["id"],
                     "/tmp/ws",
                     "/tmp/home",
@@ -1496,7 +1502,7 @@ class TestExtraMountsVolumeCreation:
                 }
             )
         ) as p:
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
@@ -1511,7 +1517,7 @@ class TestExtraMountsVolumeCreation:
         """Bind mounts (starting with /) are not treated as volumes."""
         monkeypatch.setattr("os.path.exists", lambda p: True)
         with patch_podman() as p:
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
@@ -1523,7 +1529,7 @@ class TestExtraMountsVolumeCreation:
         """Mount spec with options (host:container:ro) — source starts with /."""
         monkeypatch.setattr("os.path.exists", lambda p: True)
         with patch_podman() as p:
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
@@ -1535,7 +1541,7 @@ class TestExtraMountsVolumeCreation:
     async def test_volume_mount_with_options(self, workspace):
         """Named volume with options (vol:container:ro) — auto-creates."""
         with patch_podman() as p:
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
@@ -1549,7 +1555,7 @@ class TestExtraMountsVolumeCreation:
         """A mount source containing slashes is a bind mount, not a volume."""
         monkeypatch.setattr("os.path.exists", lambda p: True)
         with patch_podman() as p:
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
@@ -1567,7 +1573,7 @@ class TestExtraMountsVolumeCreation:
             ),
             pytest.raises(podman.PodmanError),
         ):
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
@@ -1580,7 +1586,7 @@ class TestExtraMountsVolumeCreation:
         """Mount source with special/binary-like chars is a bind mount."""
         monkeypatch.setattr("os.path.exists", lambda p: True)
         with patch_podman() as p:
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
                 "/tmp/home",
@@ -1593,7 +1599,7 @@ class TestExtraMountsVolumeCreation:
         """A bind mount with a non-existent source path is refused."""
         with patch_podman():
             with pytest.raises(ValueError, match="does not exist"):
-                await container.registry.start_container(
+                await self.registry.start_container(
                     workspace["id"],
                     "/tmp/ws",
                     "/tmp/home",
@@ -1610,38 +1616,32 @@ class TestExtraMountsVolumeCreation:
             ),
             pytest.raises(RuntimeError, match="podman broke"),
         ):
-            await container.registry.start_container(
+            await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
 
         # No browser registrations should remain for this workspace
-        for bid, (ws_id, _sock) in container.registry._browsers.items():
+        for bid, (ws_id, _sock) in self.registry._browsers.items():
             assert ws_id != workspace["id"]
 
 
 class TestStopContainer:
     def setup_method(self):
-        container.registry.states.clear()
-        container.registry._cid_to_wsid.clear()
-        container.registry._workspace_locks.clear()
-
-    def teardown_method(self):
-        container.registry.states.clear()
-        container.registry._cid_to_wsid.clear()
-        container.registry._workspace_locks.clear()
+        app_state = _make_app_state()
+        self.registry = app_state.container_registry
 
     async def test_stop_running(self):
-        container.registry.track_activity("cid", "ws")
-        lock = container.registry._get_workspace_lock("ws")
+        self.registry.track_activity("cid", "ws")
+        lock = self.registry._get_workspace_lock("ws")
 
         with patch_podman() as p:
-            await container.registry.stop_and_remove_container("cid")
+            await self.registry.stop_and_remove_container("cid")
         p.remove_container.assert_awaited_once_with("cid")
-        assert "ws" not in container.registry.states
-        assert "cid" not in container.registry._cid_to_wsid
+        assert "ws" not in self.registry.states
+        assert "cid" not in self.registry._cid_to_wsid
         # The workspace lock entry is deliberately retained (#1258).
-        assert "ws" in container.registry._workspace_locks
-        assert container.registry._workspace_locks["ws"] is lock
+        assert "ws" in self.registry._workspace_locks
+        assert self.registry._workspace_locks["ws"] is lock
 
     async def test_stop_prunes_orphaned_service_session_locks(self):
         # stop_and_remove_container sweeps the per-container service-firing
@@ -1652,14 +1652,14 @@ class TestStopContainer:
         try:
             # Tracked container (being stopped) + two orphaned entries whose
             # containers are no longer in the registry.
-            container.registry.track_activity("alive", "ws-alive")
+            self.registry.track_activity("alive", "ws-alive")
             terminal.get_service_session_lock("alive")
             terminal.get_service_session_lock("orphan-a")
             terminal.get_service_session_lock("orphan-b")
             assert len(terminal._service_session_locks) == 3
 
             with patch_podman():
-                await container.registry.stop_and_remove_container("alive")
+                await self.registry.stop_and_remove_container("alive")
 
             # The stopped container's entry and the orphans are gone; the dict
             # is empty because no container remains tracked.
@@ -1668,46 +1668,46 @@ class TestStopContainer:
             terminal._service_session_locks.clear()
 
     async def test_stop_podman_error(self):
-        container.registry.track_activity("cid", "ws")
-        container.registry._get_workspace_lock("ws")
+        self.registry.track_activity("cid", "ws")
+        self.registry._get_workspace_lock("ws")
 
         with patch_podman(
             remove_container=AsyncMock(
                 side_effect=podman.PodmanError(404, "gone")
             )
         ):
-            await container.registry.stop_and_remove_container("cid")
+            await self.registry.stop_and_remove_container("cid")
         # Should still remove from tracking
-        assert "ws" not in container.registry.states
-        assert "cid" not in container.registry._cid_to_wsid
+        assert "ws" not in self.registry.states
+        assert "cid" not in self.registry._cid_to_wsid
         # The workspace lock entry is deliberately retained (#1258).
-        assert "ws" in container.registry._workspace_locks
+        assert "ws" in self.registry._workspace_locks
 
     async def test_stop_serializes_under_workspace_lock(self):
         # stop_and_remove_container must acquire the workspace lock before
         # mutating state, so it cannot tear down a registry entry while a
         # start_container holds the lock (#1258).
-        container.registry.track_activity("cid", "ws")
-        lock = container.registry._get_workspace_lock("ws")
+        self.registry.track_activity("cid", "ws")
+        lock = self.registry._get_workspace_lock("ws")
 
         with patch_podman():
             async with lock:
                 # While the lock is held (as start_container would hold
                 # it), stop must not be able to remove state.
                 task = asyncio.create_task(
-                    container.registry.stop_and_remove_container("cid")
+                    self.registry.stop_and_remove_container("cid")
                 )
                 # Yield repeatedly so the stop task has a chance to run;
                 # it should be blocked on the lock.
                 for _ in range(5):
                     await asyncio.sleep(0)
                 assert not task.done()
-                assert "ws" in container.registry.states
-                assert container.registry._cid_to_wsid.get("cid") == "ws"
+                assert "ws" in self.registry.states
+                assert self.registry._cid_to_wsid.get("cid") == "ws"
             # Releasing the lock lets stop proceed and clean up.
             await task
-        assert "ws" not in container.registry.states
-        assert "cid" not in container.registry._cid_to_wsid
+        assert "ws" not in self.registry.states
+        assert "cid" not in self.registry._cid_to_wsid
 
     async def test_stop_skips_teardown_when_container_rebound(
         self, monkeypatch
@@ -1716,11 +1716,11 @@ class TestStopContainer:
         # container while stop waits for the lock. When stop finally
         # acquires the lock, container_id no longer maps to this ws, so it
         # must NOT tear down the fresh state or revoke its browsers.
-        container.registry.track_activity("cid-old", "ws")
-        lock = container.registry._get_workspace_lock("ws")
+        self.registry.track_activity("cid-old", "ws")
+        lock = self.registry._get_workspace_lock("ws")
         revoked = []
         monkeypatch.setattr(
-            container.registry,
+            self.registry,
             "revoke_workspace_browsers",
             lambda wid: revoked.append(wid),
         )
@@ -1730,22 +1730,22 @@ class TestStopContainer:
                 # Start stop; it runs podman (instant), peeks cid-old->ws,
                 # then blocks on the lock we hold.
                 task = asyncio.create_task(
-                    container.registry.stop_and_remove_container("cid-old")
+                    self.registry.stop_and_remove_container("cid-old")
                 )
                 for _ in range(5):
                     await asyncio.sleep(0)
                 # While stop is blocked, a racing start re-binds the
                 # workspace to a new container (track_activity drops the
                 # old cid reverse-mapping).
-                container.registry.track_activity("cid-new", "ws")
+                self.registry.track_activity("cid-new", "ws")
             # Releasing the lock lets stop acquire it; under the lock the
             # re-check sees cid-old no longer maps to ws, so it bails.
             await task
         # The new container's state survives untouched.
-        assert "ws" in container.registry.states
-        assert container.registry.states["ws"].container_id == "cid-new"
-        assert container.registry._cid_to_wsid.get("cid-new") == "ws"
-        assert "cid-old" not in container.registry._cid_to_wsid
+        assert "ws" in self.registry.states
+        assert self.registry.states["ws"].container_id == "cid-new"
+        assert self.registry._cid_to_wsid.get("cid-new") == "ws"
+        assert "cid-old" not in self.registry._cid_to_wsid
         # Browsers for the still-alive workspace were not revoked. (Without
         # the under-lock re-check, stop would have already torn the old
         # state down and revoked browsers before the rebind.)
@@ -1755,129 +1755,115 @@ class TestStopContainer:
         # Regression for the lock-replacement race: even after stop tears
         # down state, _get_workspace_lock must return the SAME lock object,
         # so a subsequent start serializes against any in-flight acquirer.
-        container.registry.track_activity("cid", "ws")
-        lock_before = container.registry._get_workspace_lock("ws")
+        self.registry.track_activity("cid", "ws")
+        lock_before = self.registry._get_workspace_lock("ws")
 
         with patch_podman():
-            await container.registry.stop_and_remove_container("cid")
-        assert "ws" in container.registry._workspace_locks
-        lock_after = container.registry._get_workspace_lock("ws")
+            await self.registry.stop_and_remove_container("cid")
+        assert "ws" in self.registry._workspace_locks
+        lock_after = self.registry._get_workspace_lock("ws")
         assert lock_after is lock_before
 
 
 class TestRemoveContainer:
     def setup_method(self):
-        container.registry.states.clear()
-        container.registry._cid_to_wsid.clear()
-        container.registry._workspace_locks.clear()
-
-    def teardown_method(self):
-        container.registry.states.clear()
-        container.registry._cid_to_wsid.clear()
-        container.registry._workspace_locks.clear()
+        app_state = _make_app_state()
+        self.registry = app_state.container_registry
 
     async def test_remove(self):
-        container.registry.track_activity("cid", "ws")
-        lock = container.registry._get_workspace_lock("ws")
+        self.registry.track_activity("cid", "ws")
+        lock = self.registry._get_workspace_lock("ws")
 
         with patch_podman() as p:
-            await container.registry.stop_and_remove_container("cid")
+            await self.registry.stop_and_remove_container("cid")
         p.remove_container.assert_awaited_once_with("cid")
-        assert "ws" not in container.registry.states
-        assert "cid" not in container.registry._cid_to_wsid
+        assert "ws" not in self.registry.states
+        assert "cid" not in self.registry._cid_to_wsid
         # The workspace lock entry is deliberately retained (#1258).
-        assert "ws" in container.registry._workspace_locks
-        assert container.registry._workspace_locks["ws"] is lock
+        assert "ws" in self.registry._workspace_locks
+        assert self.registry._workspace_locks["ws"] is lock
 
     async def test_remove_podman_error(self):
-        container.registry.track_activity("cid", "ws")
-        container.registry._get_workspace_lock("ws")
+        self.registry.track_activity("cid", "ws")
+        self.registry._get_workspace_lock("ws")
 
         with patch_podman(
             remove_container=AsyncMock(
                 side_effect=podman.PodmanError(404, "gone")
             )
         ):
-            await container.registry.stop_and_remove_container("cid")
-        assert "ws" not in container.registry.states
-        assert "cid" not in container.registry._cid_to_wsid
+            await self.registry.stop_and_remove_container("cid")
+        assert "ws" not in self.registry.states
+        assert "cid" not in self.registry._cid_to_wsid
         # The workspace lock entry is deliberately retained (#1258).
-        assert "ws" in container.registry._workspace_locks
+        assert "ws" in self.registry._workspace_locks
 
 
 class TestStopUserContainers:
     def setup_method(self):
-        container.registry.states.clear()
-
-    def teardown_method(self):
-        container.registry.states.clear()
+        app_state = _make_app_state()
+        self.registry = app_state.container_registry
 
     async def test_stop_user_containers(self, user, workspace):
         # Set container_id on the workspace
         await model.update_workspace_container(workspace["id"], "cid")
-        container.registry.track_activity("cid", workspace["id"])
+        self.registry.track_activity("cid", workspace["id"])
 
         with patch_podman() as p:
-            await container.registry.stop_user_containers(user["id"])
+            await self.registry.stop_user_containers(user["id"])
         p.remove_container.assert_awaited_once_with("cid")
-        assert workspace["id"] not in container.registry.states
+        assert workspace["id"] not in self.registry.states
 
     async def test_stop_user_calls_workspace_killed(self, user, workspace):
         await model.update_workspace_container(workspace["id"], "cid")
-        container.registry.track_activity("cid", workspace["id"])
+        self.registry.track_activity("cid", workspace["id"])
 
         killed_cb = AsyncMock()
-        old_cb = container.registry.on_workspace_killed
-        container.registry.on_workspace_killed = killed_cb
+        old_cb = self.registry.on_workspace_killed
+        self.registry.on_workspace_killed = killed_cb
 
         with patch_podman():
-            await container.registry.stop_user_containers(user["id"])
+            await self.registry.stop_user_containers(user["id"])
 
         killed_cb.assert_awaited_once_with(workspace["id"])
-        container.registry.on_workspace_killed = old_cb
+        self.registry.on_workspace_killed = old_cb
 
     async def test_stop_user_no_containers(self, user):
         with patch_podman() as p:
-            await container.registry.stop_user_containers(user["id"])
+            await self.registry.stop_user_containers(user["id"])
         p.remove_container.assert_not_awaited()
 
 
 class TestShutdown:
     def setup_method(self):
-        container.registry.states.clear()
-        container.registry._cid_to_wsid.clear()
-        container.registry.cleanup_task = None
-
-    def teardown_method(self):
-        container.registry.states.clear()
-        container.registry._cid_to_wsid.clear()
-        container.registry.cleanup_task = None
+        app_state = _make_app_state()
+        self.registry = app_state.container_registry
 
     async def test_shutdown_skips_in_container(self):
         """When running inside a container, shutdown skips cleanup."""
-        container.registry.track_activity("cid", "ws")
+        self.registry.track_activity("cid", "ws")
         with patch("os.path.exists", return_value=True):
-            await container.registry.shutdown()
+            await self.registry.shutdown()
         # Container should still be tracked (not cleaned up)
-        assert "ws" in container.registry.states
+        assert "ws" in self.registry.states
 
     async def test_shutdown_stops_tracked(self):
         # list_containers returns the tracked cid; it should be skipped in
         # the orphan loop (already tracked) but still removed via tracking.
-        container.registry.track_activity("cid", "ws")
+        self.registry.track_activity("cid", "ws")
 
         with patch_podman(
             list_containers=AsyncMock(return_value=[{"Id": "cid"}])
         ) as p:
-            await container.registry.shutdown()
+            await self.registry.shutdown()
         p.remove_container.assert_awaited_once_with("cid")
-        assert "ws" not in container.registry.states
+        assert "ws" not in self.registry.states
 
     async def test_shutdown_stops_orphans(self):
         with patch_podman(
             list_containers=AsyncMock(return_value=[{"Id": "orphan-cid"}])
         ) as p:
-            await container.registry.shutdown()
+            await self.registry.shutdown()
         p.remove_container.assert_awaited_once_with("orphan-cid")
 
     async def test_shutdown_cancels_cleanup_task(self):
@@ -1886,12 +1872,12 @@ class TestShutdown:
             await asyncio.sleep(999)
 
         task = asyncio.create_task(fake_cleanup())
-        container.registry.cleanup_task = task
+        self.registry.cleanup_task = task
 
         with patch_podman():
-            await container.registry.shutdown()
+            await self.registry.shutdown()
         assert task.cancelled()
-        assert container.registry.cleanup_task is None
+        assert self.registry.cleanup_task is None
 
     async def test_shutdown_cancels_health_task(self):
         # A running health loop task is cancelled on shutdown.
@@ -1913,13 +1899,13 @@ class TestShutdown:
                 side_effect=OSError("podman connection refused")
             )
         ):
-            await container.registry.shutdown()
+            await self.registry.shutdown()
         # Should not raise
 
     async def test_shutdown_no_podman(self):
         with patch_podman():
-            await container.registry.shutdown()
-        assert container.registry.cleanup_task is None
+            await self.registry.shutdown()
+        assert self.registry.cleanup_task is None
 
     async def test_shutdown_orphan_remove_error(self):
         """Orphan container that errors on removal is handled gracefully."""
@@ -1929,34 +1915,28 @@ class TestShutdown:
                 side_effect=podman.PodmanError(500, "remove failed")
             ),
         ) as p:
-            await container.registry.shutdown()
+            await self.registry.shutdown()
         # Attempted removal and did not raise
         p.remove_container.assert_awaited_once_with("orphan-cid")
 
 
 class TestCleanupIdleContainers:
     def setup_method(self):
-        container.registry.states.clear()
-        container.registry._cleanup_wake = None
-
-    def teardown_method(self):
-        container.registry.states.clear()
-        container.registry._cleanup_wake = None
+        app_state = _make_app_state()
+        self.registry = app_state.container_registry
 
     async def test_idle_container_stopped(self):
         # Set activity far in the past
-        container.registry.track_activity("cid", "ws-1")
-        container.registry.states["ws-1"].last_activity = (
+        self.registry.track_activity("cid", "ws-1")
+        self.registry.states["ws-1"].last_activity = (
             time.time() - container.IDLE_TIMEOUT_SECONDS - 100
         )
 
         with patch_podman() as p:
-            task = asyncio.create_task(
-                container.registry.cleanup_idle_containers()
-            )
+            task = asyncio.create_task(self.registry.cleanup_idle_containers())
             # Let the task enter the Event wait, then wake it
             await asyncio.sleep(0.05)
-            container.registry.get_cleanup_wake().set()
+            self.registry.get_cleanup_wake().set()
             await asyncio.sleep(0.05)
             task.cancel()
             try:
@@ -1964,24 +1944,22 @@ class TestCleanupIdleContainers:
             except asyncio.CancelledError:
                 pass
         p.remove_container.assert_awaited()
-        assert "ws-1" not in container.registry.states
+        assert "ws-1" not in self.registry.states
 
     async def test_idle_calls_workspace_killed_callback(self):
-        container.registry.track_activity("cid", "ws-killed")
-        container.registry.states["ws-killed"].last_activity = (
+        self.registry.track_activity("cid", "ws-killed")
+        self.registry.states["ws-killed"].last_activity = (
             time.time() - container.IDLE_TIMEOUT_SECONDS - 100
         )
 
         killed_cb = AsyncMock()
-        old_cb = container.registry.on_workspace_killed
-        container.registry.on_workspace_killed = killed_cb
+        old_cb = self.registry.on_workspace_killed
+        self.registry.on_workspace_killed = killed_cb
 
         with patch_podman():
-            task = asyncio.create_task(
-                container.registry.cleanup_idle_containers()
-            )
+            task = asyncio.create_task(self.registry.cleanup_idle_containers())
             await asyncio.sleep(0.05)
-            container.registry.get_cleanup_wake().set()
+            self.registry.get_cleanup_wake().set()
             await asyncio.sleep(0.05)
             task.cancel()
             try:
@@ -1990,24 +1968,22 @@ class TestCleanupIdleContainers:
                 pass
 
         killed_cb.assert_awaited_once_with("ws-killed")
-        container.registry.on_workspace_killed = old_cb
+        self.registry.on_workspace_killed = old_cb
 
     async def test_idle_workspace_killed_callback_error(self):
-        container.registry.track_activity("cid", "ws-err")
-        container.registry.states["ws-err"].last_activity = (
+        self.registry.track_activity("cid", "ws-err")
+        self.registry.states["ws-err"].last_activity = (
             time.time() - container.IDLE_TIMEOUT_SECONDS - 100
         )
 
         killed_cb = AsyncMock(side_effect=RuntimeError("boom"))
-        old_cb = container.registry.on_workspace_killed
-        container.registry.on_workspace_killed = killed_cb
+        old_cb = self.registry.on_workspace_killed
+        self.registry.on_workspace_killed = killed_cb
 
         with patch_podman():
-            task = asyncio.create_task(
-                container.registry.cleanup_idle_containers()
-            )
+            task = asyncio.create_task(self.registry.cleanup_idle_containers())
             await asyncio.sleep(0.05)
-            container.registry.get_cleanup_wake().set()
+            self.registry.get_cleanup_wake().set()
             await asyncio.sleep(0.05)
             task.cancel()
             try:
@@ -2017,17 +1993,15 @@ class TestCleanupIdleContainers:
 
         # Should not raise — error is logged
         killed_cb.assert_awaited_once()
-        container.registry.on_workspace_killed = old_cb
+        self.registry.on_workspace_killed = old_cb
 
     async def test_active_container_not_stopped(self):
-        container.registry.track_activity("cid", "ws-1")
+        self.registry.track_activity("cid", "ws-1")
 
         with patch_podman():
-            task = asyncio.create_task(
-                container.registry.cleanup_idle_containers()
-            )
+            task = asyncio.create_task(self.registry.cleanup_idle_containers())
             await asyncio.sleep(0.05)
-            container.registry.get_cleanup_wake().set()
+            self.registry.get_cleanup_wake().set()
             await asyncio.sleep(0.05)
             task.cancel()
             try:
@@ -2035,11 +2009,11 @@ class TestCleanupIdleContainers:
             except asyncio.CancelledError:
                 pass
         # Container should still be tracked
-        assert "ws-1" in container.registry.states
+        assert "ws-1" in self.registry.states
 
     async def test_idle_callback_invoked(self):
-        container.registry.track_activity("cid", "ws-1")
-        container.registry.states["ws-1"].last_activity = (
+        self.registry.track_activity("cid", "ws-1")
+        self.registry.states["ws-1"].last_activity = (
             time.time() - container.IDLE_TIMEOUT_SECONDS - 100
         )
 
@@ -2048,14 +2022,12 @@ class TestCleanupIdleContainers:
         async def on_idle(ws_id):
             callback_called.append(ws_id)
 
-        container.registry.on_idle_stop("ws-1", on_idle)
+        self.registry.on_idle_stop("ws-1", on_idle)
 
         with patch_podman():
-            task = asyncio.create_task(
-                container.registry.cleanup_idle_containers()
-            )
+            task = asyncio.create_task(self.registry.cleanup_idle_containers())
             await asyncio.sleep(0.05)
-            container.registry.get_cleanup_wake().set()
+            self.registry.get_cleanup_wake().set()
             await asyncio.sleep(0.05)
             task.cancel()
             try:
@@ -2065,22 +2037,20 @@ class TestCleanupIdleContainers:
         assert callback_called == ["ws-1"]
 
     async def test_idle_callback_error_handled(self):
-        container.registry.track_activity("cid", "ws-1")
-        container.registry.states["ws-1"].last_activity = (
+        self.registry.track_activity("cid", "ws-1")
+        self.registry.states["ws-1"].last_activity = (
             time.time() - container.IDLE_TIMEOUT_SECONDS - 100
         )
 
         async def bad_callback(ws_id):
             raise RuntimeError("callback broke")
 
-        container.registry.on_idle_stop("ws-1", bad_callback)
+        self.registry.on_idle_stop("ws-1", bad_callback)
 
         with patch_podman() as p:
-            task = asyncio.create_task(
-                container.registry.cleanup_idle_containers()
-            )
+            task = asyncio.create_task(self.registry.cleanup_idle_containers())
             await asyncio.sleep(0.05)
-            container.registry.get_cleanup_wake().set()
+            self.registry.get_cleanup_wake().set()
             await asyncio.sleep(0.05)
             task.cancel()
             try:
@@ -2092,20 +2062,20 @@ class TestCleanupIdleContainers:
 
     async def test_per_workspace_timeout_uses_event_wait(self):
         """When per-workspace timeouts exist, cleanup uses Event-based wait."""
-        container.registry.track_activity("cid", "ws-fast")
-        container.registry.states["ws-fast"].last_activity = time.time() - 100
-        container.registry.states["ws-fast"].idle_timeout = 5
+        self.registry.track_activity("cid", "ws-fast")
+        self.registry.states["ws-fast"].last_activity = time.time() - 100
+        self.registry.states["ws-fast"].idle_timeout = 5
 
         try:
             with patch_podman() as p:
                 # The Event-based wait will timeout after max(2, 5//2)=2s,
                 # then check containers. We cancel after one iteration.
                 task = asyncio.create_task(
-                    container.registry.cleanup_idle_containers()
+                    self.registry.cleanup_idle_containers()
                 )
                 await asyncio.sleep(0.1)  # Let it start
                 # Wake it immediately via the event
-                container.registry.get_cleanup_wake().set()
+                self.registry.get_cleanup_wake().set()
                 await asyncio.sleep(0.1)  # Let it process
                 task.cancel()
                 try:
@@ -2114,13 +2084,13 @@ class TestCleanupIdleContainers:
                     pass
             p.remove_container.assert_awaited()
         finally:
-            container.registry.states.clear()
+            self.registry.states.clear()
 
     async def test_per_workspace_timeout_event_timeout(self):
         """Event-based wait times out when no wake signal is sent."""
-        container.registry.track_activity("cid", "ws-fast")
-        container.registry.states["ws-fast"].last_activity = time.time() - 100
-        container.registry.states["ws-fast"].idle_timeout = 4
+        self.registry.track_activity("cid", "ws-fast")
+        self.registry.states["ws-fast"].last_activity = time.time() - 100
+        self.registry.states["ws-fast"].idle_timeout = 4
 
         try:
             with patch_podman() as p:
@@ -2146,40 +2116,45 @@ class TestCleanupIdleContainers:
 
                 with patch("asyncio.wait_for", side_effect=patched_wait_for):
                     try:
-                        await container.registry.cleanup_idle_containers()
+                        await self.registry.cleanup_idle_containers()
                     except asyncio.CancelledError:
                         pass
             p.remove_container.assert_awaited()
         finally:
-            container.registry.states.clear()
+            self.registry.states.clear()
 
 
 class TestStartCleanupLoop:
     def setup_method(self):
-        container.registry.cleanup_task = None
+        app_state = _make_app_state()
+        self.registry = app_state.container_registry
 
     def teardown_method(self):
-        if container.registry.cleanup_task:
-            container.registry.cleanup_task.cancel()
-            container.registry.cleanup_task = None
+        if self.registry.cleanup_task:
+            self.registry.cleanup_task.cancel()
+            self.registry.cleanup_task = None
 
     async def test_start_creates_task(self):
-        container.registry.start_cleanup_loop()
-        assert container.registry.cleanup_task is not None
-        container.registry.cleanup_task.cancel()
+        self.registry.start_cleanup_loop()
+        assert self.registry.cleanup_task is not None
+        self.registry.cleanup_task.cancel()
 
     async def test_start_idempotent(self):
-        container.registry.start_cleanup_loop()
-        task1 = container.registry.cleanup_task
-        container.registry.start_cleanup_loop()
-        assert container.registry.cleanup_task is task1
-        container.registry.cleanup_task.cancel()
+        self.registry.start_cleanup_loop()
+        task1 = self.registry.cleanup_task
+        self.registry.start_cleanup_loop()
+        assert self.registry.cleanup_task is task1
+        self.registry.cleanup_task.cancel()
 
 
 class TestPrewarmPodman:
+    def setup_method(self):
+        app_state = _make_app_state()
+        self.registry = app_state.container_registry
+
     async def test_prewarm_creates_and_removes(self):
         with patch_podman() as p:
-            await container.registry.prewarm_podman()
+            await self.registry.prewarm_podman()
         p.create_container.assert_awaited_once()
         p.remove_container.assert_awaited_once_with("new-cid")
 
@@ -2189,16 +2164,14 @@ class TestPrewarmPodman:
                 side_effect=podman.PodmanError(500, "boom")
             )
         ):
-            await container.registry.prewarm_podman()
+            await self.registry.prewarm_podman()
         # Should not raise
 
 
 class TestAdoptOrphanedContainers:
     def setup_method(self):
-        container.registry.states.clear()
-
-    def teardown_method(self):
-        container.registry.states.clear()
+        app_state = _make_app_state()
+        self.registry = app_state.container_registry
 
     async def test_removes_orphaned_containers(self):
         with patch_podman(
@@ -2212,9 +2185,9 @@ class TestAdoptOrphanedContainers:
             ),
             remove_container=AsyncMock(),
         ) as mocks:
-            await container.registry.adopt_orphaned_containers()
+            await self.registry.adopt_orphaned_containers()
         # Orphaned containers are removed, not adopted.
-        assert "ws-orphan" not in container.registry.states
+        assert "ws-orphan" not in self.registry.states
         mocks.remove_container.assert_awaited_once_with("orphan-123")
 
     async def test_removes_orphan_without_labels(self):
@@ -2224,22 +2197,19 @@ class TestAdoptOrphanedContainers:
             ),
             remove_container=AsyncMock(),
         ) as mocks:
-            await container.registry.adopt_orphaned_containers()
-        assert "unknown" not in container.registry.states
+            await self.registry.adopt_orphaned_containers()
+        assert "unknown" not in self.registry.states
         mocks.remove_container.assert_awaited_once_with("orphan-x")
 
     async def test_skips_already_tracked(self):
-        container.registry.track_activity("tracked-456", "ws-tracked")
+        self.registry.track_activity("tracked-456", "ws-tracked")
         with patch_podman(
             list_containers=AsyncMock(return_value=[{"Id": "tracked-456"}]),
             remove_container=AsyncMock(),
         ) as mocks:
-            await container.registry.adopt_orphaned_containers()
+            await self.registry.adopt_orphaned_containers()
         # Already tracked → not removed.
-        assert (
-            container.registry.states["ws-tracked"].container_id
-            == "tracked-456"
-        )
+        assert self.registry.states["ws-tracked"].container_id == "tracked-456"
         mocks.remove_container.assert_not_awaited()
 
     async def test_podman_error_handled(self):
@@ -2248,7 +2218,7 @@ class TestAdoptOrphanedContainers:
                 side_effect=podman.PodmanError(500, "fail")
             )
         ):
-            await container.registry.adopt_orphaned_containers()
+            await self.registry.adopt_orphaned_containers()
         # Should not raise
 
     async def test_remove_podman_error_handled(self):
@@ -2266,93 +2236,96 @@ class TestAdoptOrphanedContainers:
                 side_effect=podman.PodmanError(500, "remove failed")
             ),
         ) as mocks:
-            await container.registry.adopt_orphaned_containers()
+            await self.registry.adopt_orphaned_containers()
         mocks.remove_container.assert_awaited_once_with("orphan-bad")
         # Container was not adopted — just skipped after failed removal.
-        assert "ws-bad" not in container.registry.states
+        assert "ws-bad" not in self.registry.states
 
 
 class TestBrowserRegistry:
     def setup_method(self):
-        container.registry._browsers.clear()
-
-    def teardown_method(self):
-        container.registry._browsers.clear()
+        app_state = _make_app_state()
+        self.registry = app_state.container_registry
 
     def test_register_and_resolve(self):
         sock = object()
-        container.registry.register_browser("bid-1", "ws-1", sock)
-        assert container.registry.resolve_browser("bid-1") == ("ws-1", sock)
+        self.registry.register_browser("bid-1", "ws-1", sock)
+        assert self.registry.resolve_browser("bid-1") == ("ws-1", sock)
 
     def test_resolve_unknown(self):
-        assert container.registry.resolve_browser("nonexistent") is None
+        assert self.registry.resolve_browser("nonexistent") is None
 
     def test_register_idempotent(self):
         sock1 = object()
         sock2 = object()
-        container.registry.register_browser("bid-1", "ws-1", sock1)
-        container.registry.register_browser("bid-1", "ws-1", sock2)
-        assert container.registry.resolve_browser("bid-1") == ("ws-1", sock2)
+        self.registry.register_browser("bid-1", "ws-1", sock1)
+        self.registry.register_browser("bid-1", "ws-1", sock2)
+        assert self.registry.resolve_browser("bid-1") == ("ws-1", sock2)
 
     def test_revoke_workspace_browsers(self):
         sock1 = object()
         sock2 = object()
-        container.registry.register_browser("bid-1", "ws-1", sock1)
-        container.registry.register_browser("bid-2", "ws-1", sock2)
-        container.registry.revoke_workspace_browsers("ws-1")
-        assert container.registry.resolve_browser("bid-1") is None
-        assert container.registry.resolve_browser("bid-2") is None
+        self.registry.register_browser("bid-1", "ws-1", sock1)
+        self.registry.register_browser("bid-2", "ws-1", sock2)
+        self.registry.revoke_workspace_browsers("ws-1")
+        assert self.registry.resolve_browser("bid-1") is None
+        assert self.registry.resolve_browser("bid-2") is None
 
     def test_revoke_browser_by_sock(self):
         sock1 = object()
         sock2 = object()
-        container.registry.register_browser("bid-1", "ws-1", sock1)
-        container.registry.register_browser("bid-2", "ws-1", sock2)
-        container.registry.revoke_browser(sock1)
-        assert container.registry.resolve_browser("bid-1") is None
-        assert container.registry.resolve_browser("bid-2") == ("ws-1", sock2)
+        self.registry.register_browser("bid-1", "ws-1", sock1)
+        self.registry.register_browser("bid-2", "ws-1", sock2)
+        self.registry.revoke_browser(sock1)
+        assert self.registry.resolve_browser("bid-1") is None
+        assert self.registry.resolve_browser("bid-2") == ("ws-1", sock2)
 
     def test_revoke_browser_no_match(self):
         sock = object()
         other_sock = object()
-        container.registry.register_browser("bid-1", "ws-1", sock)
-        container.registry.revoke_browser(other_sock)
-        assert container.registry.resolve_browser("bid-1") == ("ws-1", sock)
+        self.registry.register_browser("bid-1", "ws-1", sock)
+        self.registry.revoke_browser(other_sock)
+        assert self.registry.resolve_browser("bid-1") == ("ws-1", sock)
 
     def test_multiple_browsers_same_workspace(self):
         sock1 = object()
         sock2 = object()
-        container.registry.register_browser("bid-1", "ws-1", sock1)
-        container.registry.register_browser("bid-2", "ws-1", sock2)
-        assert container.registry.resolve_browser("bid-1") == ("ws-1", sock1)
-        assert container.registry.resolve_browser("bid-2") == ("ws-1", sock2)
+        self.registry.register_browser("bid-1", "ws-1", sock1)
+        self.registry.register_browser("bid-2", "ws-1", sock2)
+        assert self.registry.resolve_browser("bid-1") == ("ws-1", sock1)
+        assert self.registry.resolve_browser("bid-2") == ("ws-1", sock2)
 
 
 class TestWorkspaceIdFor:
+    def setup_method(self):
+        app_state = _make_app_state()
+        self.registry = app_state.container_registry
+
     def test_returns_workspace_id(self):
-        container.registry.track_activity("cid-lookup", "ws-lookup")
+        self.registry.track_activity("cid-lookup", "ws-lookup")
         try:
-            assert (
-                container.registry.workspace_id_for("cid-lookup")
-                == "ws-lookup"
-            )
+            assert self.registry.workspace_id_for("cid-lookup") == "ws-lookup"
         finally:
-            container.registry.states.pop("ws-lookup", None)
-            container.registry._cid_to_wsid.pop("cid-lookup", None)
+            self.registry.states.pop("ws-lookup", None)
+            self.registry._cid_to_wsid.pop("cid-lookup", None)
 
     def test_returns_none_for_unknown(self):
-        assert container.registry.workspace_id_for("nonexistent") is None
+        assert self.registry.workspace_id_for("nonexistent") is None
 
 
 class TestTrackActivityContainerChanged:
+    def setup_method(self):
+        app_state = _make_app_state()
+        self.registry = app_state.container_registry
+
     def test_updates_reverse_mapping_on_container_change(self):
-        container.registry.track_activity("old-cid", "ws-chg")
-        assert container.registry._cid_to_wsid.get("old-cid") == "ws-chg"
-        container.registry.track_activity("new-cid", "ws-chg")
-        assert container.registry._cid_to_wsid.get("new-cid") == "ws-chg"
-        assert "old-cid" not in container.registry._cid_to_wsid
-        container.registry.states.pop("ws-chg", None)
-        container.registry._cid_to_wsid.pop("new-cid", None)
+        self.registry.track_activity("old-cid", "ws-chg")
+        assert self.registry._cid_to_wsid.get("old-cid") == "ws-chg"
+        self.registry.track_activity("new-cid", "ws-chg")
+        assert self.registry._cid_to_wsid.get("new-cid") == "ws-chg"
+        assert "old-cid" not in self.registry._cid_to_wsid
+        self.registry.states.pop("ws-chg", None)
+        self.registry._cid_to_wsid.pop("new-cid", None)
 
 
 def _mock_sock_for_health():
@@ -2367,18 +2340,12 @@ def _mock_sock_for_health():
 def _health_registry(ws_state=None):
     """A ContainerRegistry wired for health-monitor tests (#1464).
 
-    Constructs a fresh registry (not the module shim) and wires its
-    ``connections`` to the given WebSocketState (or the module-global
-    ``wshandler.state`` by default). HealthMonitor reaches connections via
-    ``self._registry.connections`` — no lazy import, no module global on the
-    production path.
+    Constructs a fresh registry via ``_make_app_state`` and wires its
+    ``sockets`` to the given WebSocketState (or a fresh one by default).
+    HealthMonitor reaches sockets via ``self._registry.sockets``.
     """
-    from klangk_backend.settings import KlangkSettings
-    from klangk_backend.wshandler import state as _ws_state
-
-    reg = container.ContainerRegistry(KlangkSettings(env={}))
-    reg.connections = ws_state or _ws_state
-    return reg
+    app_state = _make_app_state(sockets=ws_state)
+    return app_state.container_registry
 
 
 def _health_state(
@@ -2682,6 +2649,10 @@ class TestHealthMonitorStartupGrace:
     yet ready to accept connections" the very first poll produced.
     """
 
+    def setup_method(self):
+        app_state = _make_app_state()
+        self.registry = app_state.container_registry
+
     async def test_unhealthy_during_grace_is_suppressed(self):
         monitor = _health_registry().health
         st = _health_state(health_status=None, in_startup_grace=True)
@@ -2758,35 +2729,34 @@ class TestHealthMonitorStartupGrace:
         # The registry proxy resolves container_id -> workspace and
         # resets that workspace's anchor; unknown containers no-op.
         st = _health_state(in_startup_grace=False)
-        container.registry.states[st.workspace_id] = st
-        container.registry._cid_to_wsid[st.container_id] = st.workspace_id
+        self.registry.states[st.workspace_id] = st
+        self.registry._cid_to_wsid[st.container_id] = st.workspace_id
         try:
             assert st.service_started_at == 0.0
-            container.registry.mark_service_started(st.container_id)
+            self.registry.mark_service_started(st.container_id)
             assert time.time() - st.service_started_at < 1
             # Unknown container is a safe no-op.
-            container.registry.mark_service_started("no-such-cid")
+            self.registry.mark_service_started("no-such-cid")
         finally:
-            container.registry.states.pop(st.workspace_id, None)
-            container.registry._cid_to_wsid.pop(st.container_id, None)
+            self.registry.states.pop(st.workspace_id, None)
+            self.registry._cid_to_wsid.pop(st.container_id, None)
 
     """_broadcast fans out to ALL connections, not just the session."""
 
     def test_fans_out_via_notify_service_health(self):
-        from klangk_backend.wshandler import state as _ws_state
-
-        monitor = _health_registry().health
+        reg = _health_registry()
+        monitor = reg.health
         sock = _mock_sock_for_health()
         st = _health_state(health_status="unhealthy")
         try:
-            _ws_state.connections[sock] = SimpleNamespace(
+            reg.sockets.connections[sock] = SimpleNamespace(
                 user={"id": "u1", "email": "a@x"}
             )
             # No WorkspaceSession registered for this workspace — yet
             # the event must still reach the connection.
             monitor._broadcast(st, "unhealthy", "connection refused")
         finally:
-            _ws_state.connections.pop(sock, None)
+            reg.sockets.connections.pop(sock, None)
         sock.send_json.assert_called_once_with(
             {
                 "type": "service_health",
@@ -2878,20 +2848,19 @@ class TestHealthMonitorBroadcastSeq:
     """_broadcast bumps per-workspace seq and forwards live fields."""
 
     def test_bumps_seq_each_emit_and_forwards_fields(self):
-        from klangk_backend.wshandler import state as _ws_state
-
-        monitor = _health_registry().health
+        reg = _health_registry()
+        monitor = reg.health
         sock = _mock_sock_for_health()
         st = _health_state(health_status="unhealthy")
         st.health_checked_at = 1_700_000_000.0
         try:
-            _ws_state.connections[sock] = SimpleNamespace(
+            reg.sockets.connections[sock] = SimpleNamespace(
                 user={"id": "u1", "email": "a@x"}
             )
             monitor._broadcast(st, "unhealthy", "connection refused")
             monitor._broadcast(st, "unhealthy", "connection refused")
         finally:
-            _ws_state.connections.pop(sock, None)
+            reg.sockets.connections.pop(sock, None)
         frames = [c[0][0] for c in sock.send_json.call_args_list]
         assert len(frames) == 2
         # Monotonic seq across emits; live frames are running=True.
@@ -2909,21 +2878,24 @@ class TestHealthMonitorDeath:
     A dying container otherwise looks like "healthy, then silence" on
     the service_health stream (#1175 item 2)."""
 
-    def test_broadcast_death_emits_terminal_frame(self):
-        from klangk_backend.wshandler import state as _ws_state
+    def setup_method(self):
+        app_state = _make_app_state()
+        self.registry = app_state.container_registry
 
-        monitor = _health_registry().health
+    def test_broadcast_death_emits_terminal_frame(self):
+        reg = _health_registry()
+        monitor = reg.health
         sock = _mock_sock_for_health()
         st = _health_state(health_status="healthy")
         st.health_checked_at = 1_700_000_000.0
         st.health_seq = 4
         try:
-            _ws_state.connections[sock] = SimpleNamespace(
+            reg.sockets.connections[sock] = SimpleNamespace(
                 user={"id": "u1", "email": "a@x"}
             )
             monitor.broadcast_death(st)
         finally:
-            _ws_state.connections.pop(sock, None)
+            reg.sockets.connections.pop(sock, None)
         frame = sock.send_json.call_args[0][0]
         assert frame["type"] == "service_health"
         assert frame["healthy"] is False
@@ -2938,9 +2910,7 @@ class TestHealthMonitorDeath:
     ):
         # A container death fans a terminal service_health frame to
         # subscribers BEFORE the on_workspace_killed callback drops state.
-        from klangk_backend.wshandler import state as _ws_state
-
-        reg = _health_registry(_ws_state)
+        reg = _health_registry()
         sock = _mock_sock_for_health()
         st = _health_state(health_status="healthy")
         reg.states[st.workspace_id] = st
@@ -2952,13 +2922,13 @@ class TestHealthMonitorDeath:
             seen_state_present.append(wid in reg.states)
 
         try:
-            _ws_state.connections[sock] = SimpleNamespace(
+            reg.sockets.connections[sock] = SimpleNamespace(
                 user={"id": "u1", "email": "a@x"}
             )
             reg.set_on_workspace_killed(on_killed)
             await reg.notify_workspace_killed(st.workspace_id)
         finally:
-            _ws_state.connections.pop(sock, None)
+            reg.sockets.connections.pop(sock, None)
             reg.states.pop(st.workspace_id, None)
             reg.set_on_workspace_killed(None)
         frame = sock.send_json.call_args[0][0]
@@ -2969,33 +2939,29 @@ class TestHealthMonitorDeath:
     async def test_notify_workspace_killed_skips_non_health_checked(self):
         # A workspace with no health_check never appeared on the stream,
         # so its death emits no terminal frame.
-        from klangk_backend.wshandler import state as _ws_state
-
         sock = _mock_sock_for_health()
         st = _health_state(health_check=None)
-        container.registry.states[st.workspace_id] = st
+        self.registry.states[st.workspace_id] = st
         try:
-            _ws_state.connections[sock] = SimpleNamespace(
+            self.registry.sockets.connections[sock] = SimpleNamespace(
                 user={"id": "u1", "email": "a@x"}
             )
-            await container.registry.notify_workspace_killed(st.workspace_id)
+            await self.registry.notify_workspace_killed(st.workspace_id)
         finally:
-            _ws_state.connections.pop(sock, None)
-            container.registry.states.pop(st.workspace_id, None)
+            self.registry.sockets.connections.pop(sock, None)
+            self.registry.states.pop(st.workspace_id, None)
         sock.send_json.assert_not_called()
 
     async def test_notify_workspace_killed_no_state_no_emit(self):
         # If the state is already gone (double-kill), nothing to emit.
-        from klangk_backend.wshandler import state as _ws_state
-
         sock = _mock_sock_for_health()
         try:
-            _ws_state.connections[sock] = SimpleNamespace(
+            self.registry.sockets.connections[sock] = SimpleNamespace(
                 user={"id": "u1", "email": "a@x"}
             )
-            await container.registry.notify_workspace_killed("no-such-ws")
+            await self.registry.notify_workspace_killed("no-such-ws")
         finally:
-            _ws_state.connections.pop(sock, None)
+            self.registry.sockets.connections.pop(sock, None)
         sock.send_json.assert_not_called()
 
     async def test_idle_cleanup_emits_death_frame(self):
@@ -3006,9 +2972,7 @@ class TestHealthMonitorDeath:
         notify_workspace_killed (which reads state for the death frame),
         so the frame was silently skipped.
         """
-        from klangk_backend.wshandler import state as _ws_state
-
-        reg = _health_registry(_ws_state)
+        reg = _health_registry()
         sock = _mock_sock_for_health()
         st = _health_state(
             workspace_id="ws-idle-death",
@@ -3020,13 +2984,11 @@ class TestHealthMonitorDeath:
         st.last_activity = time.time() - container.IDLE_TIMEOUT_SECONDS - 100
 
         try:
-            _ws_state.connections[sock] = SimpleNamespace(
+            reg.sockets.connections[sock] = SimpleNamespace(
                 user={"id": "u1", "email": "a@x"}
             )
             with patch_podman():
-                task = asyncio.create_task(
-                    reg.cleanup_idle_containers()
-                )
+                task = asyncio.create_task(reg.cleanup_idle_containers())
                 await asyncio.sleep(0.05)
                 reg.get_cleanup_wake().set()
                 await asyncio.sleep(0.05)
@@ -3036,7 +2998,7 @@ class TestHealthMonitorDeath:
                 except asyncio.CancelledError:
                     pass
         finally:
-            _ws_state.connections.pop(sock, None)
+            reg.sockets.connections.pop(sock, None)
             reg.states.pop(st.workspace_id, None)
             reg._cid_to_wsid.pop(st.container_id, None)
 
@@ -3055,12 +3017,11 @@ class TestHealthLoopHeartbeat:
     presence to the loop being alive."""
 
     async def test_heartbeats_sent_each_tick_to_opted_in(self):
-        from klangk_backend.wshandler import state as _ws_state
-
-        monitor = _health_registry().health
+        reg = _health_registry()
+        monitor = reg.health
         sock = _mock_sock_for_health()
         try:
-            _ws_state.connections[sock] = SimpleNamespace(
+            reg.sockets.connections[sock] = SimpleNamespace(
                 user={"id": "u1", "email": "a@x"},
                 wants_health_heartbeat=True,
             )
@@ -3076,7 +3037,7 @@ class TestHealthLoopHeartbeat:
                 except asyncio.CancelledError:
                     pass
         finally:
-            _ws_state.connections.pop(sock, None)
+            reg.sockets.connections.pop(sock, None)
         frames = [c[0][0] for c in sock.send_json.call_args_list]
         assert frames  # at least one heartbeat over ~5 ticks
         assert all(f["type"] == "service_health_heartbeat" for f in frames)
@@ -3089,6 +3050,8 @@ class TestRegistryServiceSessionLockDelegates:
         from klangk_backend import terminal
 
         terminal._service_session_locks.clear()
+        app_state = _make_app_state()
+        self.registry = app_state.container_registry
 
     def teardown_method(self):
         from klangk_backend import terminal
@@ -3098,14 +3061,14 @@ class TestRegistryServiceSessionLockDelegates:
     def test_get_via_registry(self):
         from klangk_backend import terminal
 
-        reg = container.registry
+        reg = self.registry
         lock = reg.get_service_session_lock("cid")
         assert lock is terminal.get_service_session_lock("cid")
 
     def test_clear_via_registry(self):
         from klangk_backend import terminal
 
-        reg = container.registry
+        reg = self.registry
         reg.get_service_session_lock("cid")
         assert "cid" in terminal._service_session_locks
         reg.clear_service_session_lock("cid")
@@ -3114,7 +3077,7 @@ class TestRegistryServiceSessionLockDelegates:
     def test_prune_via_registry(self):
         from klangk_backend import terminal
 
-        reg = container.registry
+        reg = self.registry
         reg.get_service_session_lock("alive")
         reg.get_service_session_lock("dead")
         removed = reg.prune_service_session_locks({"alive"})
@@ -3133,11 +3096,10 @@ class TestRegistryConnections:
     """HealthMonitor reaches WebSocketState via the registry, not a module global (#1464)."""
 
     def test_connections_property_reads_from_registry(self):
-        """The _connections property returns self._registry.connections."""
-        from klangk_backend.settings import KlangkSettings
+        """The _connections property returns self._registry.sockets."""
         from klangk_backend.wshandler.session import WebSocketState
 
         ws_state = WebSocketState()
-        reg = container.ContainerRegistry(KlangkSettings(env={}))
-        reg.connections = ws_state
+        app_state = _make_app_state(sockets=ws_state)
+        reg = app_state.container_registry
         assert reg.health._connections is ws_state

--- a/src/backend/tests/test_main.py
+++ b/src/backend/tests/test_main.py
@@ -4,6 +4,7 @@ import asyncio
 import os
 import signal
 import sqlite3
+import types
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -13,7 +14,26 @@ from httpx import AsyncClient, ASGITransport
 from sqlalchemy.exc import IntegrityError as SAIntegrityError
 
 from klangk_backend import main, model
+from klangk_backend.container import ContainerRegistry
 from klangk_backend.settings import KlangkSettings
+from klangk_backend.wshandler.session import WebSocketState
+
+
+def _make_app_state(settings=None):
+    """Build a minimal app_state for tests."""
+    if settings is None:
+        settings = KlangkSettings(env={})
+    registry = ContainerRegistry(settings)
+    sockets = WebSocketState()
+    app_state = types.SimpleNamespace(
+        container_registry=registry,
+        sockets=sockets,
+        settings=settings,
+    )
+    registry.sockets = sockets
+    registry.app_state = app_state
+    sockets.app_state = app_state
+    return app_state
 
 
 # --- Seed default user ---
@@ -288,19 +308,21 @@ class TestLifespan:
         monkeypatch.setenv("KLANGK_LISTEN", "127.0.0.1")
         monkeypatch.delenv("KLANGK_PREVENT_INSECURE_JWT_SECRET", raising=False)
         app = FastAPI()
-        app.state.container_registry = main.container.registry
+        app_state = _make_app_state()
+        app.state.container_registry = app_state.container_registry
+        app.state.sockets = app_state.sockets
+        app.state.settings = app_state.settings
         app.state.nginx_watchdog = main.NginxWatchdog(KlangkSettings(env={}))
+        registry = app_state.container_registry
         with (
             patch.object(
-                main.container.registry,
+                registry,
                 "adopt_orphaned_containers",
                 new_callable=AsyncMock,
             ) as mock_adopt,
+            patch.object(registry, "start_cleanup_loop") as mock_start,
             patch.object(
-                main.container.registry, "start_cleanup_loop"
-            ) as mock_start,
-            patch.object(
-                main.container.registry,
+                registry,
                 "shutdown",
                 new_callable=AsyncMock,
             ) as mock_shutdown,
@@ -348,30 +370,28 @@ class TestStartupShutdownRestart:
         main._restart_lock = None
 
     async def test_startup_calls_container_sequence(self):
+        app_state = _make_app_state()
+        registry = app_state.container_registry
         with (
             patch.object(
-                main.container.registry,
+                registry,
                 "prewarm_podman",
                 new_callable=AsyncMock,
             ) as mock_prewarm,
             patch.object(
-                main.container.registry,
+                registry,
                 "adopt_orphaned_containers",
                 new_callable=AsyncMock,
             ) as mock_adopt,
-            patch.object(
-                main.container.registry, "start_cleanup_loop"
-            ) as mock_cleanup,
-            patch.object(
-                main.container.registry, "start_health_loop"
-            ) as mock_health,
+            patch.object(registry, "start_cleanup_loop") as mock_cleanup,
+            patch.object(registry, "start_health_loop") as mock_health,
             patch(
                 "klangk_backend.main.workspaces.auto_start_workspaces",
                 new_callable=AsyncMock,
                 return_value=0,
             ) as mock_autostart,
         ):
-            await main.startup(main.container.registry)
+            await main.startup(app_state)
         mock_prewarm.assert_awaited_once()
         mock_adopt.assert_awaited_once()
         mock_cleanup.assert_called_once()
@@ -379,6 +399,8 @@ class TestStartupShutdownRestart:
         mock_autostart.assert_awaited_once()
 
     async def test_runtime_shutdown_tears_down_layers(self):
+        app_state = _make_app_state()
+        registry = app_state.container_registry
         with (
             patch(
                 "klangk_backend.main.wshandler.disconnect_all_websockets",
@@ -392,10 +414,10 @@ class TestStartupShutdownRestart:
                 "klangk_backend.main.wshandler.clear_agent_mention_state"
             ) as mock_clear,
             patch.object(
-                main.container.registry, "shutdown", new_callable=AsyncMock
+                registry, "shutdown", new_callable=AsyncMock
             ) as mock_shutdown,
         ):
-            await main.runtime_shutdown(main.container.registry)
+            await main.runtime_shutdown(app_state)
         mock_disc.assert_awaited_once()
         mock_stop_agents.assert_awaited_once()
         mock_clear.assert_called_once()
@@ -415,7 +437,7 @@ class TestStartupShutdownRestart:
 
     async def test_restart_runtime_runs_shutdown_then_startup(self):
         main._restart_lock = None  # force fresh lock creation
-        reg = main.container.registry
+        app_state = _make_app_state()
         wd = main.NginxWatchdog(KlangkSettings(env={}))
         with (
             patch(
@@ -425,9 +447,9 @@ class TestStartupShutdownRestart:
                 "klangk_backend.main.startup", new_callable=AsyncMock
             ) as mock_up,
         ):
-            await main.restart_runtime(reg, wd)
-        mock_down.assert_awaited_once_with(reg)
-        mock_up.assert_awaited_once_with(reg)
+            await main.restart_runtime(app_state, wd)
+        mock_down.assert_awaited_once_with(app_state)
+        mock_up.assert_awaited_once_with(app_state)
         # Lock was created and is now held-free.
         assert main._restart_lock is not None
 
@@ -438,7 +460,7 @@ class TestStartupShutdownRestart:
         # order-dependent and broken in isolation — #1242.)
         main._restart_lock = asyncio.Lock()
         existing = main._restart_lock
-        reg = main.container.registry
+        app_state = _make_app_state()
         wd = main.NginxWatchdog(KlangkSettings(env={}))
         with (
             patch(
@@ -446,7 +468,7 @@ class TestStartupShutdownRestart:
             ),
             patch("klangk_backend.main.startup", new_callable=AsyncMock),
         ):
-            await main.restart_runtime(reg, wd)
+            await main.restart_runtime(app_state, wd)
         # Same lock object reused, not replaced.
         assert main._restart_lock is existing
 
@@ -455,15 +477,15 @@ class TestStartupShutdownRestart:
         main._restart_lock = None
         order = []
 
-        async def fake_shutdown(reg):
+        async def fake_shutdown(app_state):
             order.append("down-start")
             await asyncio.sleep(0.01)
             order.append("down-end")
 
-        async def fake_startup(reg):
+        async def fake_startup(app_state):
             order.append("up")
 
-        reg = main.container.registry
+        app_state = _make_app_state()
         wd = main.NginxWatchdog(KlangkSettings(env={}))
         with (
             patch(
@@ -473,7 +495,8 @@ class TestStartupShutdownRestart:
             patch("klangk_backend.main.startup", side_effect=fake_startup),
         ):
             await asyncio.gather(
-                main.restart_runtime(reg, wd), main.restart_runtime(reg, wd)
+                main.restart_runtime(app_state, wd),
+                main.restart_runtime(app_state, wd),
             )
         # Two complete down-start...down-end...up cycles, never interleaved.
         assert order == [
@@ -487,16 +510,16 @@ class TestStartupShutdownRestart:
 
     async def test_on_sighup_schedules_restart(self):
         """on_sighup creates a task that runs restart_runtime."""
-        reg = main.container.registry
+        app_state = _make_app_state()
         wd = main.NginxWatchdog(KlangkSettings(env={}))
         with patch(
             "klangk_backend.main.restart_runtime", new_callable=AsyncMock
         ) as mock_restart:
-            main.on_sighup(reg, wd)
+            main.on_sighup(app_state, wd)
             # Let the scheduled task run.
             await asyncio.sleep(0)
             await asyncio.sleep(0)
-        mock_restart.assert_awaited_once_with(reg, wd)
+        mock_restart.assert_awaited_once_with(app_state, wd)
 
     async def test_lifespan_registers_sighup_handler(self, db, monkeypatch):
         """The lifespan installs (and removes) a SIGHUP handler."""
@@ -505,8 +528,12 @@ class TestStartupShutdownRestart:
         monkeypatch.setenv("KLANGK_LISTEN", "127.0.0.1")
         monkeypatch.delenv("KLANGK_PREVENT_INSECURE_JWT_SECRET", raising=False)
         app = FastAPI()
-        app.state.container_registry = main.container.registry
+        app_state = _make_app_state()
+        app.state.container_registry = app_state.container_registry
+        app.state.sockets = app_state.sockets
+        app.state.settings = app_state.settings
         app.state.nginx_watchdog = main.NginxWatchdog(KlangkSettings(env={}))
+        registry = app_state.container_registry
         loop = asyncio.get_running_loop()
         with (
             patch.object(
@@ -516,14 +543,12 @@ class TestStartupShutdownRestart:
                 loop, "remove_signal_handler", new_callable=MagicMock
             ) as mock_remove,
             patch.object(
-                main.container.registry,
+                registry,
                 "adopt_orphaned_containers",
                 new_callable=AsyncMock,
             ),
-            patch.object(main.container.registry, "start_cleanup_loop"),
-            patch.object(
-                main.container.registry, "shutdown", new_callable=AsyncMock
-            ),
+            patch.object(registry, "start_cleanup_loop"),
+            patch.object(registry, "shutdown", new_callable=AsyncMock),
             patch("klangk_backend.main.check_pid_file", return_value=None),
             patch("klangk_backend.main.write_pid_file"),
             patch("klangk_backend.main.remove_pid_file"),
@@ -944,12 +969,13 @@ class TestBuildApp:
         assert isinstance(main.app, FastAPI)
 
 
-class TestGetSettingsDep:
-    """Tests for get_settings_dep per-request bridge (#1426)."""
+class TestGetAppStateDep:
+    """Tests for get_app_state_dep per-request bridge (#1426)."""
 
-    def test_returns_app_state_settings(self):
+    def test_returns_app_state(self):
         settings = KlangkSettings(env={})
         app = main.build_app(settings)
         request = MagicMock()
         request.app = app
-        assert main.get_settings_dep(request) is settings
+        app_state = main.get_app_state_dep(request)
+        assert app_state.settings is settings

--- a/src/backend/tests/test_main.py
+++ b/src/backend/tests/test_main.py
@@ -340,6 +340,45 @@ class TestLifespan:
             mock_shutdown.assert_awaited_once()
             mock_remove.assert_called_once()
 
+    async def test_lifespan_workspace_killed_resets_state(
+        self, db, monkeypatch
+    ):
+        """The workspace-killed callback threads app.state into
+        reset_workspace_state (sockets, workspace_id) — #1475."""
+        monkeypatch.delenv("KLANGK_OIDC_CONFIG", raising=False)
+        monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
+        monkeypatch.setenv("KLANGK_LISTEN", "127.0.0.1")
+        monkeypatch.delenv("KLANGK_PREVENT_INSECURE_JWT_SECRET", raising=False)
+        app = FastAPI()
+        app_state = _make_app_state()
+        app.state.container_registry = app_state.container_registry
+        app.state.sockets = app_state.sockets
+        app.state.settings = app_state.settings
+        app.state.nginx_watchdog = main.NginxWatchdog(KlangkSettings(env={}))
+        registry = app_state.container_registry
+        with (
+            patch.object(
+                registry,
+                "adopt_orphaned_containers",
+                new_callable=AsyncMock,
+            ),
+            patch.object(registry, "start_cleanup_loop"),
+            patch.object(registry, "shutdown", new_callable=AsyncMock),
+            patch("klangk_backend.main.check_pid_file", return_value=None),
+            patch("klangk_backend.main.write_pid_file"),
+            patch("klangk_backend.main.remove_pid_file"),
+            patch(
+                "klangk_backend.main.wshandler.reset_workspace_state",
+                new_callable=AsyncMock,
+            ) as mock_reset,
+        ):
+            async with main.lifespan(app):
+                # The closure registered by the lifespan threads app.state
+                # into reset_workspace_state: (sockets, workspace_id).
+                assert registry.on_workspace_killed is not None
+                await registry.on_workspace_killed("ws-killed")
+        mock_reset.assert_awaited_once_with(app.state.sockets, "ws-killed")
+
     async def test_lifespan_refuses_if_pid_alive(self, db, monkeypatch):
         monkeypatch.delenv("KLANGK_OIDC_CONFIG", raising=False)
         monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)

--- a/src/backend/tests/test_terminal.py
+++ b/src/backend/tests/test_terminal.py
@@ -7,7 +7,7 @@ lifecycle/queue logic against an injected fake shell.
 
 import asyncio
 import contextlib
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -1337,7 +1337,12 @@ class TestEnsureServiceSession:
         """Firing the service command resets the health-check startup-grace
         anchor so the monitor gives the freshly-launched service time to
         boot before a failing poll can flag it unhealthy."""
+        import types
+
         from klangk_backend.terminal import ensure_service_session
+
+        mock_registry = MagicMock()
+        app_state = types.SimpleNamespace(container_registry=mock_registry)
 
         with (
             patch(
@@ -1352,19 +1357,24 @@ class TestEnsureServiceSession:
                 "klangk_backend.terminal.podman.exec_container",
                 new=AsyncMock(side_effect=[(0, "", ""), (0, "", "")]),
             ),
-            patch(
-                "klangk_backend.container.registry.mark_service_started"
-            ) as mock_mark,
         ):
             await ensure_service_session(
-                "cid", "/home/clanker", "openclaw gateway"
+                "cid",
+                "/home/clanker",
+                "openclaw gateway",
+                app_state=app_state,
             )
-        mock_mark.assert_called_once_with("cid")
+        mock_registry.mark_service_started.assert_called_once_with("cid")
 
     async def test_existing_window_does_not_reset_grace_anchor(self):
         """The no-op path (service-cmd window already exists) never
         re-launched the service, so it must not restart the grace window."""
+        import types
+
         from klangk_backend.terminal import ensure_service_session
+
+        mock_registry = MagicMock()
+        app_state = types.SimpleNamespace(container_registry=mock_registry)
 
         with (
             patch(
@@ -1379,19 +1389,24 @@ class TestEnsureServiceSession:
                 "klangk_backend.terminal.podman.exec_container",
                 new=AsyncMock(),
             ),
-            patch(
-                "klangk_backend.container.registry.mark_service_started"
-            ) as mock_mark,
         ):
             await ensure_service_session(
-                "cid", "/home/clanker", "openclaw gateway"
+                "cid",
+                "/home/clanker",
+                "openclaw gateway",
+                app_state=app_state,
             )
-        mock_mark.assert_not_called()
+        mock_registry.mark_service_started.assert_not_called()
 
     async def test_send_keys_failure_does_not_reset_grace_anchor(self):
         """If send-keys itself failed the command never launched, so the
         grace anchor must not advance (no service is booting)."""
+        import types
+
         from klangk_backend.terminal import ensure_service_session
+
+        mock_registry = MagicMock()
+        app_state = types.SimpleNamespace(container_registry=mock_registry)
 
         with (
             patch(
@@ -1412,12 +1427,14 @@ class TestEnsureServiceSession:
                     ]
                 ),
             ),
-            patch(
-                "klangk_backend.container.registry.mark_service_started"
-            ) as mock_mark,
         ):
-            await ensure_service_session("cid", "/home/clanker", "cmd")
-        mock_mark.assert_not_called()
+            await ensure_service_session(
+                "cid",
+                "/home/clanker",
+                "cmd",
+                app_state=app_state,
+            )
+        mock_registry.mark_service_started.assert_not_called()
 
     async def test_concurrent_fires_create_window_exactly_once(self):
         """#1188: two concurrent ensure_service_session calls for the SAME

--- a/src/backend/tests/test_workspaces.py
+++ b/src/backend/tests/test_workspaces.py
@@ -1,16 +1,34 @@
 """Tests for workspaces: workspace lifecycle, directory management, port allocation."""
 
 import os
+import types
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from klangk_backend import workspaces as ws_mod, container
+from klangk_backend.container import ContainerRegistry
+from klangk_backend.settings import KlangkSettings
+
+
+@pytest.fixture
+def app_state():
+    """Build a minimal app_state with a real ContainerRegistry."""
+    settings = KlangkSettings(env={})
+    registry = ContainerRegistry(settings)
+    state = types.SimpleNamespace(
+        container_registry=registry,
+        settings=settings,
+    )
+    registry.app_state = state
+    return state
 
 
 class TestCreateWorkspace:
-    async def test_creates_workspace_and_dirs(self, user):
-        ws = await ws_mod.create_workspace(user["id"], "my-ws")
+    async def test_creates_workspace_and_dirs(self, user, app_state):
+        ws = await ws_mod.create_workspace(
+            user["id"], "my-ws", app_state=app_state
+        )
         assert ws["name"] == "my-ws"
         assert ws["user_id"] == user["id"]
         assert "id" in ws
@@ -27,25 +45,35 @@ class TestCreateWorkspace:
         assert users_dir.exists()
         assert users_dir.is_dir()
 
-    async def test_allocates_ports(self, user):
-        ws = await ws_mod.create_workspace(user["id"], "ported")
-        ports = await container.registry.get_workspace_ports(ws["id"])
+    async def test_allocates_ports(self, user, app_state):
+        ws = await ws_mod.create_workspace(
+            user["id"], "ported", app_state=app_state
+        )
+        registry = app_state.container_registry
+        ports = await registry.get_workspace_ports(ws["id"])
         assert len(ports) == ws["num_ports"]
         assert all(p >= container.PORT_RANGE_START for p in ports)
 
-    async def test_duplicate_name_fails(self, user):
-        await ws_mod.create_workspace(user["id"], "unique")
+    async def test_duplicate_name_fails(self, user, app_state):
+        await ws_mod.create_workspace(
+            user["id"], "unique", app_state=app_state
+        )
         with pytest.raises(Exception):
-            await ws_mod.create_workspace(user["id"], "unique")
+            await ws_mod.create_workspace(
+                user["id"], "unique", app_state=app_state
+            )
 
-    async def test_invalid_setup_state_rejected(self, user):
+    async def test_invalid_setup_state_rejected(self, user, app_state):
         """Invalid setup_state raises ValueError (#1033)."""
         from klangk_backend import model
 
         # Service layer (goes through create_workspace_with_acl).
         with pytest.raises(ValueError, match="Invalid setup_state"):
             await ws_mod.create_workspace(
-                user["id"], "bad-state", setup_state="bogus"
+                user["id"],
+                "bad-state",
+                setup_state="bogus",
+                app_state=app_state,
             )
         # Row-only model primitive validates the same way.
         with pytest.raises(ValueError, match="Invalid setup_state"):
@@ -53,46 +81,55 @@ class TestCreateWorkspace:
                 user["id"], "bad-row", setup_state="bogus"
             )
 
-    async def test_setup_state_defaults_to_complete(self, user):
+    async def test_setup_state_defaults_to_complete(self, user, app_state):
         """Workspaces without a setup command default to 'complete'."""
-        ws = await ws_mod.create_workspace(user["id"], "default-state")
+        ws = await ws_mod.create_workspace(
+            user["id"], "default-state", app_state=app_state
+        )
         assert ws["setup_state"] == "complete"
 
-    async def test_allocate_ports_failure_cleans_up(self, user):
+    async def test_allocate_ports_failure_cleans_up(self, user, app_state):
         """If allocate_ports raises, DB record and directories are removed."""
+        registry = app_state.container_registry
         with patch.object(
-            container.registry,
+            registry,
             "allocate_ports",
             new_callable=AsyncMock,
             side_effect=RuntimeError("port exhaustion"),
         ):
             with pytest.raises(RuntimeError, match="port exhaustion"):
-                await ws_mod.create_workspace(user["id"], "boom")
+                await ws_mod.create_workspace(
+                    user["id"], "boom", app_state=app_state
+                )
 
         # DB record should have been cleaned up
         result = await ws_mod.list_workspaces(user["id"])
         assert all(ws["name"] != "boom" for ws in result["items"])
 
         # Name should be reusable (proves full cleanup)
-        ws = await ws_mod.create_workspace(user["id"], "boom")
+        ws = await ws_mod.create_workspace(
+            user["id"], "boom", app_state=app_state
+        )
         assert ws["name"] == "boom"
 
 
-async def test_update_workspace_invalid_setup_state_rejected(user):
+async def test_update_workspace_invalid_setup_state_rejected(user, app_state):
     """update_workspace rejects an invalid setup_state (#1033)."""
     from klangk_backend.model import update_workspace
 
-    ws = await ws_mod.create_workspace(user["id"], "upd-state")
+    ws = await ws_mod.create_workspace(
+        user["id"], "upd-state", app_state=app_state
+    )
     with pytest.raises(ValueError, match="Invalid setup_state"):
         await update_workspace(ws["id"], ws["user_id"], setup_state="bogus")
 
 
-async def test_update_workspace_sets_setup_state(user):
+async def test_update_workspace_sets_setup_state(user, app_state):
     """update_workspace can transition setup_state (#1033)."""
     from klangk_backend.model import get_workspace, update_workspace
 
     ws = await ws_mod.create_workspace(
-        user["id"], "upd-ok", setup_state="pending"
+        user["id"], "upd-ok", setup_state="pending", app_state=app_state
     )
     assert ws["setup_state"] == "pending"
     await update_workspace(ws["id"], ws["user_id"], setup_state="complete")
@@ -177,9 +214,9 @@ class TestListWorkspaces:
             "next_offset": None,
         }
 
-    async def test_list_multiple(self, user):
-        await ws_mod.create_workspace(user["id"], "ws-a")
-        await ws_mod.create_workspace(user["id"], "ws-b")
+    async def test_list_multiple(self, user, app_state):
+        await ws_mod.create_workspace(user["id"], "ws-a", app_state=app_state)
+        await ws_mod.create_workspace(user["id"], "ws-b", app_state=app_state)
         result = await ws_mod.list_workspaces(user["id"])
         names = [ws["name"] for ws in result["items"]]
         assert "ws-a" in names
@@ -188,8 +225,10 @@ class TestListWorkspaces:
 
 
 class TestGetWorkspace:
-    async def test_get_existing(self, user):
-        ws = await ws_mod.create_workspace(user["id"], "findme")
+    async def test_get_existing(self, user, app_state):
+        ws = await ws_mod.create_workspace(
+            user["id"], "findme", app_state=app_state
+        )
         found = await ws_mod.get_workspace(ws["id"], user["id"])
         assert found is not None
         assert found["name"] == "findme"
@@ -198,15 +237,19 @@ class TestGetWorkspace:
         found = await ws_mod.get_workspace("fake-id", user["id"])
         assert found is None
 
-    async def test_get_wrong_user(self, user):
-        ws = await ws_mod.create_workspace(user["id"], "mine")
+    async def test_get_wrong_user(self, user, app_state):
+        ws = await ws_mod.create_workspace(
+            user["id"], "mine", app_state=app_state
+        )
         found = await ws_mod.get_workspace(ws["id"], "other-user")
         assert found is None
 
 
 class TestDeleteWorkspace:
-    async def test_delete_removes_db_and_dirs(self, user):
-        ws = await ws_mod.create_workspace(user["id"], "doomed")
+    async def test_delete_removes_db_and_dirs(self, user, app_state):
+        ws = await ws_mod.create_workspace(
+            user["id"], "doomed", app_state=app_state
+        )
         data_path = ws_mod.workspace_path(ws["id"])
         home_dir = ws_mod.home_path(ws["id"])
         (data_path / "file.txt").write_text("hello")
@@ -222,17 +265,22 @@ class TestDeleteWorkspace:
         deleted = await ws_mod.delete_workspace("fake-id", user["id"])
         assert deleted is False
 
-    async def test_delete_cascades_ports(self, user):
-        ws = await ws_mod.create_workspace(user["id"], "ported")
-        ports_before = await container.registry.get_workspace_ports(ws["id"])
+    async def test_delete_cascades_ports(self, user, app_state):
+        ws = await ws_mod.create_workspace(
+            user["id"], "ported", app_state=app_state
+        )
+        registry = app_state.container_registry
+        ports_before = await registry.get_workspace_ports(ws["id"])
         assert len(ports_before) > 0
 
         await ws_mod.delete_workspace(ws["id"], user["id"])
-        ports_after = await container.registry.get_workspace_ports(ws["id"])
+        ports_after = await registry.get_workspace_ports(ws["id"])
         assert ports_after == []
 
-    async def test_delete_missing_dirs_ok(self, user):
-        ws = await ws_mod.create_workspace(user["id"], "no-dirs")
+    async def test_delete_missing_dirs_ok(self, user, app_state):
+        ws = await ws_mod.create_workspace(
+            user["id"], "no-dirs", app_state=app_state
+        )
         home_dir = ws_mod.home_path(ws["id"])
         import shutil
 
@@ -267,8 +315,10 @@ class TestHostPaths:
 
 
 class TestEnsureHomeSymlink:
-    async def test_creates_symlink(self, user):
-        ws = await ws_mod.create_workspace(user["id"], "symlink-ws")
+    async def test_creates_symlink(self, user, app_state):
+        ws = await ws_mod.create_workspace(
+            user["id"], "symlink-ws", app_state=app_state
+        )
         home = ws_mod.home_path(ws["id"])
         result, created = await ws_mod.ensure_home_symlink(
             home, "alice", "uid-1"
@@ -280,8 +330,10 @@ class TestEnsureHomeSymlink:
         assert os.readlink(symlink) == ".users/uid-1"
         assert (home / ".users" / "uid-1").is_dir()
 
-    async def test_idempotent(self, user):
-        ws = await ws_mod.create_workspace(user["id"], "symlink-ws2")
+    async def test_idempotent(self, user, app_state):
+        ws = await ws_mod.create_workspace(
+            user["id"], "symlink-ws2", app_state=app_state
+        )
         home = ws_mod.home_path(ws["id"])
         await ws_mod.ensure_home_symlink(home, "bob", "uid-1")
         result, created = await ws_mod.ensure_home_symlink(
@@ -290,8 +342,10 @@ class TestEnsureHomeSymlink:
         assert result == "/home/bob"
         assert created is False
 
-    async def test_rename_removes_old_symlink(self, user):
-        ws = await ws_mod.create_workspace(user["id"], "symlink-ws3")
+    async def test_rename_removes_old_symlink(self, user, app_state):
+        ws = await ws_mod.create_workspace(
+            user["id"], "symlink-ws3", app_state=app_state
+        )
         home = ws_mod.home_path(ws["id"])
         await ws_mod.ensure_home_symlink(home, "alice", "uid-1")
         result, created = await ws_mod.ensure_home_symlink(
@@ -302,12 +356,14 @@ class TestEnsureHomeSymlink:
         assert not (home / "alice").exists()
         assert (home / "alicia").is_symlink()
 
-    async def test_replaces_stale_symlink_from_import(self, user):
+    async def test_replaces_stale_symlink_from_import(self, user, app_state):
         """Imported workspace has a symlink for a different user ID.
 
         The old user's files should be adopted into the new user dir.
         """
-        ws = await ws_mod.create_workspace(user["id"], "symlink-ws4")
+        ws = await ws_mod.create_workspace(
+            user["id"], "symlink-ws4", app_state=app_state
+        )
         home = ws_mod.home_path(ws["id"])
         # Simulate imported workspace: symlink for old user ID with files.
         (home / ".users").mkdir(parents=True, exist_ok=True)
@@ -358,34 +414,33 @@ class TestPopulateHomeSkel:
 
 
 class TestAutoStartWorkspaces:
-    async def test_returns_zero_when_env_not_set(self, user):
+    async def test_returns_zero_when_env_not_set(self, user, app_state):
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("KLANGK_ALLOW_AUTOSTART", None)
-            result = await ws_mod.auto_start_workspaces()
+            result = await ws_mod.auto_start_workspaces(app_state)
         assert result == 0
 
-    async def test_starts_auto_start_workspaces(self, user):
+    async def test_starts_auto_start_workspaces(self, user, app_state):
+        registry = app_state.container_registry
         ws1 = await ws_mod.create_workspace(
-            user["id"], "auto-ws1", auto_start=True
+            user["id"], "auto-ws1", auto_start=True, app_state=app_state
         )
         ws2 = await ws_mod.create_workspace(
-            user["id"], "auto-ws2", auto_start=True
+            user["id"], "auto-ws2", auto_start=True, app_state=app_state
         )
-        await ws_mod.create_workspace(user["id"], "normal-ws")
+        await ws_mod.create_workspace(
+            user["id"], "normal-ws", app_state=app_state
+        )
 
         # Pre-populate states so idle_timeout can be set.
         from klangk_backend.container import ContainerState
 
-        container.registry.states[ws1["id"]] = ContainerState(
-            ws1["id"], "cid-1"
-        )
-        container.registry.states[ws2["id"]] = ContainerState(
-            ws2["id"], "cid-2"
-        )
+        registry.states[ws1["id"]] = ContainerState(ws1["id"], "cid-1")
+        registry.states[ws2["id"]] = ContainerState(ws2["id"], "cid-2")
         try:
             with patch.dict(os.environ, {"KLANGK_ALLOW_AUTOSTART": "1"}):
                 with patch.object(
-                    container.registry,
+                    registry,
                     "start_container",
                     new_callable=AsyncMock,
                     return_value=("cid-abc", "started"),
@@ -394,26 +449,29 @@ class TestAutoStartWorkspaces:
                         "klangk_backend.workspaces.asyncio.sleep",
                         new_callable=AsyncMock,
                     ) as mock_sleep:
-                        result = await ws_mod.auto_start_workspaces()
+                        result = await ws_mod.auto_start_workspaces(app_state)
             assert result == 2
             assert mock_start.await_count == 2
             mock_sleep.assert_awaited_once()
-            assert container.registry.states[ws1["id"]].idle_timeout == 0
-            assert container.registry.states[ws2["id"]].idle_timeout == 0
+            assert registry.states[ws1["id"]].idle_timeout == 0
+            assert registry.states[ws2["id"]].idle_timeout == 0
         finally:
-            container.registry.states.pop(ws1["id"], None)
-            container.registry.states.pop(ws2["id"], None)
+            registry.states.pop(ws1["id"], None)
+            registry.states.pop(ws2["id"], None)
 
-    async def test_handles_start_failure_gracefully(self, user):
-        await ws_mod.create_workspace(user["id"], "fail-ws", auto_start=True)
+    async def test_handles_start_failure_gracefully(self, user, app_state):
+        registry = app_state.container_registry
+        await ws_mod.create_workspace(
+            user["id"], "fail-ws", auto_start=True, app_state=app_state
+        )
         with patch.dict(os.environ, {"KLANGK_ALLOW_AUTOSTART": "1"}):
             with patch.object(
-                container.registry,
+                registry,
                 "start_container",
                 new_callable=AsyncMock,
                 side_effect=RuntimeError("container failed"),
             ):
-                result = await ws_mod.auto_start_workspaces()
+                result = await ws_mod.auto_start_workspaces(app_state)
         assert result == 0
 
 
@@ -427,21 +485,23 @@ class TestStartWorkspace:
     workspace dict and delegates to registry.start_container.
     """
 
-    async def test_unpacks_dict_and_starts_container(self, user):
+    async def test_unpacks_dict_and_starts_container(self, user, app_state):
+        registry = app_state.container_registry
         ws = await ws_mod.create_workspace(
             user["id"],
             "start-ws",
             auto_start=True,
             service_command="openclaw gateway",
+            app_state=app_state,
         )
         try:
             with patch.object(
-                container.registry,
+                registry,
                 "start_container",
                 new_callable=AsyncMock,
                 return_value=("cid-x", "created"),
             ) as mock_start:
-                cid, status = await ws_mod.start_workspace(ws)
+                cid, status = await ws_mod.start_workspace(ws, app_state)
             assert cid == "cid-x"
             assert status == "created"
             mock_start.assert_awaited_once()
@@ -451,30 +511,31 @@ class TestStartWorkspace:
                 "openclaw gateway"
             )
         finally:
-            container.registry.states.pop(ws["id"], None)
+            registry.states.pop(ws["id"], None)
 
-    async def test_does_not_pin_idle_timeout(self, user):
+    async def test_does_not_pin_idle_timeout(self, user, app_state):
         """Only the boot path (auto_start_workspaces) pins idle_timeout."""
+        registry = app_state.container_registry
         ws = await ws_mod.create_workspace(
-            user["id"], "start-ws-no-idle", auto_start=True
+            user["id"],
+            "start-ws-no-idle",
+            auto_start=True,
+            app_state=app_state,
         )
         from klangk_backend.container import ContainerState
 
         # Registry default idle timeout is non-zero; start_workspace
         # must not clobber it.
         default_timeout = ContainerState(ws["id"], "cid-y").idle_timeout
-        container.registry.states[ws["id"]] = ContainerState(ws["id"], "cid-y")
+        registry.states[ws["id"]] = ContainerState(ws["id"], "cid-y")
         try:
             with patch.object(
-                container.registry,
+                registry,
                 "start_container",
                 new_callable=AsyncMock,
                 return_value=("cid-y", "created"),
             ):
-                await ws_mod.start_workspace(ws)
-            assert (
-                container.registry.states[ws["id"]].idle_timeout
-                == default_timeout
-            )
+                await ws_mod.start_workspace(ws, app_state)
+            assert registry.states[ws["id"]].idle_timeout == default_timeout
         finally:
-            container.registry.states.pop(ws["id"], None)
+            registry.states.pop(ws["id"], None)

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -7,6 +7,7 @@ import os
 import time
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
+import types
 from types import SimpleNamespace
 
 import pytest
@@ -36,8 +37,8 @@ from klangk_backend.wshandler import (
     SlowClientError,
     SshAgentForwarder,
     TerminalController,
+    WebSocketState,
     WorkspaceSession,
-    state,
     clear_agent_mention_state,
     disconnect_all_websockets,
     send_error,
@@ -57,6 +58,28 @@ def _trusted_default():
         ipaddress.ip_address("127.0.0.1"),
         ipaddress.ip_address("::1"),
     }
+
+
+def _make_app_state(registry=None, sockets=None):
+    """Build a minimal app_state for tests."""
+    from klangk_backend.settings import KlangkSettings
+    from klangk_backend.container import ContainerRegistry
+
+    settings = KlangkSettings(env={})
+    if registry is None:
+        registry = ContainerRegistry(settings)
+    if sockets is None:
+        sockets = WebSocketState()
+
+    app_state = types.SimpleNamespace(
+        container_registry=registry,
+        sockets=sockets,
+        settings=settings,
+    )
+    registry.sockets = sockets
+    registry.app_state = app_state
+    sockets.app_state = app_state
+    return app_state
 
 
 def _mock_sock(headers=None, query_params=None):
@@ -120,7 +143,7 @@ def _empty_async_generator():
         yield
 
 
-def _base_conn(user=None, ws=None):
+def _base_conn(user=None, ws=None, app_state=None):
     if ws is None:
         ws = _mock_sock()
     if user is None:
@@ -129,7 +152,9 @@ def _base_conn(user=None, ws=None):
             "email": "testuser@example.com",
             "handle": "testuser",
         }
-    return Connection(ws, user)
+    if app_state is None:
+        app_state = _make_app_state()
+    return Connection(ws, user, app_state)
 
 
 @asynccontextmanager
@@ -139,28 +164,32 @@ async def _conn_in_workspace(
     *,
     container_id: str = "cid",
     user_home: str | None = None,
+    app_state=None,
 ):
-    """Yield ``(sock, conn, session)`` registered in workspace state.
+    """Yield ``(sock, conn, session, app_state)`` registered in workspace state.
 
     Creates a mock socket and Connection, registers it as a subscriber
     of a fresh WorkspaceSession, and tears the registration down on exit.
     The yielded ``session`` may be mutated (e.g. ``terminal_windows``)
     by the caller before use.
     """
+    if app_state is None:
+        app_state = _make_app_state()
+    sockets = app_state.sockets
     sock = _mock_sock()
-    conn = _base_conn(user=user, ws=sock)
+    conn = _base_conn(user=user, ws=sock, app_state=app_state)
     conn.workspace_id = workspace_id
     conn.container_id = container_id
     conn._user_home = user_home
-    session = wshandler.state.get_or_create_session(workspace_id)
+    session = sockets.get_or_create_session(workspace_id, app_state)
     await session.add_subscriber(sock, container_id)
-    wshandler.state.connections[sock] = conn
+    sockets.connections[sock] = conn
     try:
-        yield sock, conn, session
+        yield sock, conn, session, app_state
     finally:
         await session.remove_subscriber(sock)
-        wshandler.state.connections.pop(sock, None)
-        wshandler.state.sessions.pop(workspace_id, None)
+        sockets.connections.pop(sock, None)
+        sockets.sessions.pop(workspace_id, None)
 
 
 async def _create_workspace_with_acl(user_id, name, **kwargs):
@@ -300,27 +329,29 @@ class TestSafeWebSocket:
 
 class TestDisconnectAll:
     async def test_clears_connections_sessions_and_sockets(self):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         sock = _mock_sock()
-        conn = _base_conn(ws=sock)
-        state.connections[sock] = conn
-        state.get_or_create_session("ws-disc")
+        conn = _base_conn(ws=sock, app_state=app_state)
+        sockets.connections[sock] = conn
+        sockets.get_or_create_session("ws-disc", app_state)
         # A pending presence-leave task to confirm it gets cancelled.
         leave_task = asyncio.create_task(asyncio.sleep(100))
-        state._pending_leaves[("ws-disc", "u1")] = leave_task
+        sockets._pending_leaves[("ws-disc", "u1")] = leave_task
         # A pending browser-delegate request with an unresolved future.
         br_future = asyncio.get_running_loop().create_future()
-        state.pending_browser_requests["req-1"] = (br_future, sock)
+        sockets.pending_browser_requests["req-1"] = (br_future, sock)
         # A streaming browser request.
         stream_q = asyncio.Queue()
-        state.streaming_browser_requests["req-2"] = (stream_q, sock)
+        sockets.streaming_browser_requests["req-2"] = (stream_q, sock)
 
-        await state.disconnect_all()
+        await sockets.disconnect_all()
 
-        assert state.connections == {}
-        assert state.sessions == {}
-        assert state._pending_leaves == {}
-        assert state.pending_browser_requests == {}
-        assert state.streaming_browser_requests == {}
+        assert sockets.connections == {}
+        assert sockets.sessions == {}
+        assert sockets._pending_leaves == {}
+        assert sockets.pending_browser_requests == {}
+        assert sockets.streaming_browser_requests == {}
         # Leave task was cancelled; await it so the cancellation completes.
         with pytest.raises(asyncio.CancelledError):
             await leave_task
@@ -329,26 +360,34 @@ class TestDisconnectAll:
         sock.close.assert_awaited_once_with(code=1012)
 
     async def test_swallows_close_errors(self):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         bad_sock = _mock_sock()
         bad_sock.close = AsyncMock(side_effect=RuntimeError("boom"))
-        state.connections[bad_sock] = _base_conn(ws=bad_sock)
+        sockets.connections[bad_sock] = _base_conn(
+            ws=bad_sock, app_state=app_state
+        )
 
         # Must not raise even though close() blows up.
-        await state.disconnect_all()
+        await sockets.disconnect_all()
 
-        assert state.connections == {}
+        assert sockets.connections == {}
 
     async def test_empty_is_noop(self):
-        await state.disconnect_all()
-        assert state.connections == {}
-        assert state.sessions == {}
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        await sockets.disconnect_all()
+        assert sockets.connections == {}
+        assert sockets.sessions == {}
 
     async def test_disconnect_all_websockets_wrapper(self):
         """The package-level wrapper delegates to state.disconnect_all."""
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         sock = _mock_sock()
-        state.connections[sock] = _base_conn(ws=sock)
-        await disconnect_all_websockets()
-        assert state.connections == {}
+        sockets.connections[sock] = _base_conn(ws=sock, app_state=app_state)
+        await disconnect_all_websockets(sockets)
+        assert sockets.connections == {}
         sock.close.assert_awaited_once_with(code=1012)
 
 
@@ -901,16 +940,18 @@ class TestClientIsLoopback:
 
 class TestHandleTerminalInput:
     async def test_writes_data(self):
+        app_state = _make_app_state()
+        registry = app_state.container_registry
         t = _mock_terminal()
-        conn = _base_conn()
+        conn = _base_conn(app_state=app_state)
         conn.terminal_session = t
         conn.container_id = "cid"
-        container.registry.track_activity("cid", "ws")
+        registry.track_activity("cid", "ws")
 
         await conn.handle_terminal_input({"data": "ls\n"})
 
         t.write.assert_awaited_once_with("ls\n")
-        container.registry.states.pop("ws", None)
+        registry.states.pop("ws", None)
 
     async def test_no_session(self):
         conn = _base_conn()
@@ -925,41 +966,47 @@ class TestHandleTerminalInput:
         t.write.assert_not_awaited()
 
     async def test_read_only_blocks_typing(self):
+        app_state = _make_app_state()
+        registry = app_state.container_registry
         t = _mock_terminal()
         t.read_only = True
-        conn = _base_conn()
+        conn = _base_conn(app_state=app_state)
         conn.terminal_session = t
         conn.container_id = "cid"
-        container.registry.track_activity("cid", "ws")
+        registry.track_activity("cid", "ws")
 
         await conn.handle_terminal_input({"data": "ls\n"})
         t.write.assert_not_awaited()
-        container.registry.states.pop("ws", None)
+        registry.states.pop("ws", None)
 
     async def test_read_only_allows_escape_sequences(self):
+        app_state = _make_app_state()
+        registry = app_state.container_registry
         t = _mock_terminal()
         t.read_only = True
-        conn = _base_conn()
+        conn = _base_conn(app_state=app_state)
         conn.terminal_session = t
         conn.container_id = "cid"
-        container.registry.track_activity("cid", "ws")
+        registry.track_activity("cid", "ws")
 
         # DA response: ESC [ ? 6 c
         await conn.handle_terminal_input({"data": "\x1b[?6c"})
         t.write.assert_awaited_once_with("\x1b[?6c")
-        container.registry.states.pop("ws", None)
+        registry.states.pop("ws", None)
 
     async def test_oversized_input_dropped(self):
+        app_state = _make_app_state()
+        registry = app_state.container_registry
         t = _mock_terminal()
-        conn = _base_conn()
+        conn = _base_conn(app_state=app_state)
         conn.terminal_session = t
         conn.container_id = "cid"
-        container.registry.track_activity("cid", "ws")
+        registry.track_activity("cid", "ws")
 
         big_data = "x" * (_ws_constants.MAX_INPUT_SIZE + 1)
         await conn.handle_terminal_input({"data": big_data})
         t.write.assert_not_awaited()
-        container.registry.states.pop("ws", None)
+        registry.states.pop("ws", None)
 
 
 # --- handle_terminal_resize ---
@@ -1018,8 +1065,11 @@ class TestHandleTerminalStop:
 
 class TestHandleTerminalStart:
     async def test_starts_session(self):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        registry = app_state.container_registry
         sock = _mock_sock()
-        conn = _base_conn(ws=sock)
+        conn = _base_conn(ws=sock, app_state=app_state)
         conn.container_id = "cid"
         conn.workspace_id = "ws"
         conn._user_home = "/home/testuser"
@@ -1028,16 +1078,16 @@ class TestHandleTerminalStart:
             return True
 
         conn._has_perm = _perm  # type: ignore[method-assign]
-        container.registry.track_activity("cid", "ws")
+        registry.track_activity("cid", "ws")
 
         # Create a session with shared windows so the shared_terminals
         # broadcast path (lines 977-978) is exercised.
-        session = wshandler.state.get_or_create_session("ws")
+        session = sockets.get_or_create_session("ws", app_state)
         session.terminal_windows["other-uid"] = [
             {"name": "dev", "index": 0, "id": "@0", "shared": True},
         ]
         await session.add_subscriber(sock, "cid")
-        wshandler.state.connections[sock] = conn
+        sockets.connections[sock] = conn
 
         with (
             patch.object(_ws_controllers, "TerminalSession") as MockTS,
@@ -1099,29 +1149,32 @@ class TestHandleTerminalStart:
         )
 
         # sync_terminal_windows should have populated terminal_windows
-        ws_session = wshandler.state.sessions.get("ws")
+        ws_session = sockets.sessions.get("ws")
         assert ws_session is not None
         assert "uid" in ws_session.terminal_windows
         assert ws_session.terminal_windows["uid"][0]["name"] == "bash"
 
         # Clean up
-        wshandler.state.sessions.pop("ws", None)
-        wshandler.state.connections.pop(sock, None)
+        sockets.sessions.pop("ws", None)
+        sockets.connections.pop(sock, None)
         conn.terminal_task.cancel()
         try:
             await conn.terminal_task
         except asyncio.CancelledError:
             pass
-        container.registry.revoke_workspace_browsers("ws")
-        container.registry.states.pop("ws", None)
+        registry.revoke_workspace_browsers("ws")
+        registry.states.pop("ws", None)
 
     async def test_terminal_start_fires_service_command(self):
         """terminal_start fires the service command in the agent's service
         session (the post-setup path, #1033/#1133) -- not in any user's
         session. The on_service_command_started callback is gone; the
         service command is fired via _fire_service_command."""
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        registry = app_state.container_registry
         sock = _mock_sock()
-        conn = _base_conn(ws=sock)
+        conn = _base_conn(ws=sock, app_state=app_state)
         conn.container_id = "cid"
         conn.workspace_id = "ws"
         conn._user_home = "/home/testuser"
@@ -1131,10 +1184,10 @@ class TestHandleTerminalStart:
             return True
 
         conn._has_perm = _perm  # type: ignore[method-assign]
-        container.registry.track_activity("cid", "ws")
-        session = wshandler.state.get_or_create_session("ws")
+        registry.track_activity("cid", "ws")
+        session = sockets.get_or_create_session("ws", app_state)
         await session.add_subscriber(sock, "cid")
-        wshandler.state.connections[sock] = conn
+        sockets.connections[sock] = conn
 
         with (
             patch.object(_ws_controllers, "TerminalSession") as MockTS,
@@ -1174,19 +1227,23 @@ class TestHandleTerminalStart:
         # Fired in the service session with the agent home, not threaded
         # into the user's TerminalSession (no service_command kwarg).
         mock_ess.assert_awaited_once_with(
-            "cid", "/home/clanker", "./serve", setup_state="complete"
+            "cid",
+            "/home/clanker",
+            "./serve",
+            setup_state="complete",
+            app_state=app_state,
         )
         assert "service_command" not in MockTS.call_args.kwargs
 
-        wshandler.state.sessions.pop("ws", None)
-        wshandler.state.connections.pop(sock, None)
+        sockets.sessions.pop("ws", None)
+        sockets.connections.pop(sock, None)
         conn.terminal_task.cancel()
         try:
             await conn.terminal_task
         except asyncio.CancelledError:
             pass
-        container.registry.revoke_workspace_browsers("ws")
-        container.registry.states.pop("ws", None)
+        registry.revoke_workspace_browsers("ws")
+        registry.states.pop("ws", None)
 
     async def test_terminal_start_requires_handle(self):
         sock = _mock_sock()
@@ -1226,8 +1283,10 @@ class TestHandleTerminalStart:
         assert conn.terminal_session is None
 
     async def test_rapid_terminal_start_debounced(self):
+        app_state = _make_app_state()
+        registry = app_state.container_registry
         sock = _mock_sock()
-        conn = _base_conn(ws=sock)
+        conn = _base_conn(ws=sock, app_state=app_state)
         conn.container_id = "cid"
         conn.workspace_id = "ws"
         conn._user_home = "/home/testuser"
@@ -1243,13 +1302,15 @@ class TestHandleTerminalStart:
         # Should be silently ignored (debounced)
         assert conn.terminal_session is None
 
-        container.registry.revoke_workspace_browsers("ws")
-        container.registry.states.pop("ws", None)
+        registry.revoke_workspace_browsers("ws")
+        registry.states.pop("ws", None)
 
     async def test_start_rename_failure_non_fatal(self):
         """If renaming the initial bash window fails, tabs still work."""
+        app_state = _make_app_state()
+        registry = app_state.container_registry
         sock = _mock_sock()
-        conn = _base_conn(ws=sock)
+        conn = _base_conn(ws=sock, app_state=app_state)
         conn.container_id = "cid"
         conn.workspace_id = "ws"
         conn._user_home = "/home/testuser"
@@ -1258,7 +1319,7 @@ class TestHandleTerminalStart:
             return True
 
         conn._has_perm = _perm  # type: ignore[method-assign]
-        container.registry.track_activity("cid", "ws")
+        registry.track_activity("cid", "ws")
 
         with (
             patch.object(_ws_controllers, "TerminalSession") as MockTS,
@@ -1299,13 +1360,15 @@ class TestHandleTerminalStart:
             await conn.terminal_task
         except asyncio.CancelledError:
             pass
-        container.registry.revoke_workspace_browsers("ws")
-        container.registry.states.pop("ws", None)
+        registry.revoke_workspace_browsers("ws")
+        registry.states.pop("ws", None)
 
     async def test_start_window_list_failure_non_fatal(self):
         """If list_windows fails after terminal start, terminal still works."""
+        app_state = _make_app_state()
+        registry = app_state.container_registry
         sock = _mock_sock()
-        conn = _base_conn(ws=sock)
+        conn = _base_conn(ws=sock, app_state=app_state)
         conn.container_id = "cid"
         conn.workspace_id = "ws"
         conn._user_home = "/home/testuser"
@@ -1314,7 +1377,7 @@ class TestHandleTerminalStart:
             return True
 
         conn._has_perm = _perm  # type: ignore[method-assign]
-        container.registry.track_activity("cid", "ws")
+        registry.track_activity("cid", "ws")
 
         with (
             patch.object(_ws_controllers, "TerminalSession") as MockTS,
@@ -1345,13 +1408,15 @@ class TestHandleTerminalStart:
             await conn.terminal_task
         except asyncio.CancelledError:
             pass
-        container.registry.revoke_workspace_browsers("ws")
-        container.registry.states.pop("ws", None)
+        registry.revoke_workspace_browsers("ws")
+        registry.states.pop("ws", None)
 
     async def test_start_shared_list_failure_non_fatal(self):
         """If list_shared_terminals fails after start, terminal still works."""
+        app_state = _make_app_state()
+        registry = app_state.container_registry
         sock = _mock_sock()
-        conn = _base_conn(ws=sock)
+        conn = _base_conn(ws=sock, app_state=app_state)
         conn.container_id = "cid"
         conn.workspace_id = "ws"
         conn._user_home = "/home/testuser"
@@ -1360,7 +1425,7 @@ class TestHandleTerminalStart:
             return True
 
         conn._has_perm = _perm
-        container.registry.track_activity("cid", "ws")
+        registry.track_activity("cid", "ws")
 
         with (
             patch.object(_ws_controllers, "TerminalSession") as MockTS,
@@ -1393,13 +1458,15 @@ class TestHandleTerminalStart:
             await conn.terminal_task
         except asyncio.CancelledError:
             pass
-        container.registry.revoke_workspace_browsers("ws")
-        container.registry.states.pop("ws", None)
+        registry.revoke_workspace_browsers("ws")
+        registry.states.pop("ws", None)
 
     async def test_restart_revokes_old_browser_registration(self):
         """Starting a second terminal revokes the previous browser registration."""
+        app_state = _make_app_state()
+        registry = app_state.container_registry
         sock = _mock_sock()
-        conn = _base_conn(ws=sock)
+        conn = _base_conn(ws=sock, app_state=app_state)
         conn.container_id = "cid"
         conn.workspace_id = "ws"
         conn._user_home = "/home/testuser"
@@ -1408,7 +1475,7 @@ class TestHandleTerminalStart:
             return True
 
         conn._has_perm = _perm  # type: ignore[method-assign]
-        container.registry.track_activity("cid", "ws")
+        registry.track_activity("cid", "ws")
 
         with (
             patch.object(_ws_controllers, "TerminalSession") as MockTS,
@@ -1429,7 +1496,7 @@ class TestHandleTerminalStart:
             )
             await asyncio.sleep(0)
             assert conn.browser_id == "bid-1"
-            assert container.registry.resolve_browser("bid-1") is not None
+            assert registry.resolve_browser("bid-1") is not None
 
             conn.terminal_task.cancel()
             try:
@@ -1443,35 +1510,37 @@ class TestHandleTerminalStart:
             )
             await asyncio.sleep(0)
             assert conn.browser_id == "bid-1"
-            assert container.registry.resolve_browser("bid-1") is not None
+            assert registry.resolve_browser("bid-1") is not None
 
             conn.terminal_task.cancel()
             try:
                 await conn.terminal_task
             except asyncio.CancelledError:
                 pass
-        container.registry.revoke_workspace_browsers("ws")
-        container.registry.states.pop("ws", None)
+        registry.revoke_workspace_browsers("ws")
+        registry.states.pop("ws", None)
 
     async def test_browser_reattach_updates_registration(self):
         """browser_reattach re-registers the browser ID and calls attach_browser."""
+        app_state = _make_app_state()
+        registry = app_state.container_registry
         sock = _mock_sock()
-        conn = _base_conn(ws=sock)
+        conn = _base_conn(ws=sock, app_state=app_state)
         conn.container_id = "cid"
         conn.workspace_id = "ws"
 
-        container.registry.register_browser("bid-old", "ws", sock)
+        registry.register_browser("bid-old", "ws", sock)
         conn.browser_id = "bid-old"
 
         with patch.object(_ws_controllers, "attach_browser") as mock_attach:
             await conn.handle_browser_reattach({"browser_id": "bid-new"})
 
         assert conn.browser_id == "bid-new"
-        assert container.registry.resolve_browser("bid-new") == ("ws", sock)
-        assert container.registry.resolve_browser("bid-old") is None
+        assert registry.resolve_browser("bid-new") == ("ws", sock)
+        assert registry.resolve_browser("bid-old") is None
         mock_attach.assert_awaited_once_with("cid", "bid-new")
 
-        container.registry.revoke_workspace_browsers("ws")
+        registry.revoke_workspace_browsers("ws")
 
     async def test_browser_reattach_no_browser_id_is_noop(self):
         """browser_reattach with no browser_id does nothing."""
@@ -1501,8 +1570,10 @@ class TestHandleTerminalStart:
         mock_attach.assert_not_awaited()
 
     async def test_passes_service_command(self):
+        app_state = _make_app_state()
+        registry = app_state.container_registry
         sock = _mock_sock()
-        conn = _base_conn(ws=sock)
+        conn = _base_conn(ws=sock, app_state=app_state)
         conn.container_id = "cid"
         conn.workspace_id = "ws"
         conn._user_home = "/home/testuser"
@@ -1512,7 +1583,7 @@ class TestHandleTerminalStart:
             return True
 
         conn._has_perm = _perm  # type: ignore[method-assign]
-        container.registry.track_activity("cid", "ws")
+        registry.track_activity("cid", "ws")
 
         mock_session = AsyncMock()
         mock_session.output = _empty_async_generator
@@ -1557,7 +1628,11 @@ class TestHandleTerminalStart:
             ssh_agent_socket=None,
         )
         mock_ess.assert_awaited_once_with(
-            "cid", "/home/clanker", "pi", setup_state="complete"
+            "cid",
+            "/home/clanker",
+            "pi",
+            setup_state="complete",
+            app_state=app_state,
         )
 
         conn.terminal_task.cancel()
@@ -1565,12 +1640,14 @@ class TestHandleTerminalStart:
             await conn.terminal_task
         except asyncio.CancelledError:
             pass
-        container.registry.revoke_workspace_browsers("ws")
-        container.registry.states.pop("ws", None)
+        registry.revoke_workspace_browsers("ws")
+        registry.states.pop("ws", None)
 
     async def test_start_failure_sends_error(self):
+        app_state = _make_app_state()
+        registry = app_state.container_registry
         sock = _mock_sock()
-        conn = _base_conn(ws=sock)
+        conn = _base_conn(ws=sock, app_state=app_state)
         conn.container_id = "cid"
         conn.workspace_id = "ws"
         conn._user_home = "/home/testuser"
@@ -1579,7 +1656,7 @@ class TestHandleTerminalStart:
             return True
 
         conn._has_perm = _perm  # type: ignore[method-assign]
-        container.registry.track_activity("cid", "ws")
+        registry.track_activity("cid", "ws")
 
         mock_session = AsyncMock()
         mock_session.output = _empty_async_generator
@@ -1598,14 +1675,16 @@ class TestHandleTerminalStart:
         assert any(call.args[0].get("type") == "error" for call in sent)
         # Session is stored immediately but stop() is called on failure
         mock_session.stop.assert_awaited_once()
-        container.registry.revoke_workspace_browsers("ws")
-        container.registry.states.pop("ws", None)
+        registry.revoke_workspace_browsers("ws")
+        registry.states.pop("ws", None)
 
     async def test_start_slow_client_cleans_up(self):
         """SlowClientError during start cleans up without sending error."""
+        app_state = _make_app_state()
+        registry = app_state.container_registry
 
         sock = _mock_sock()
-        conn = _base_conn(ws=sock)
+        conn = _base_conn(ws=sock, app_state=app_state)
         conn.container_id = "cid"
         conn.workspace_id = "ws"
         conn._user_home = "/home/testuser"
@@ -1614,7 +1693,7 @@ class TestHandleTerminalStart:
             return True
 
         conn._has_perm = _perm  # type: ignore[method-assign]
-        container.registry.track_activity("cid", "ws")
+        registry.track_activity("cid", "ws")
 
         mock_session = AsyncMock()
         mock_session.output = _empty_async_generator
@@ -1630,13 +1709,15 @@ class TestHandleTerminalStart:
         # No error message sent (client is gone)
         sent = sock.send_json.call_args_list
         assert not any(call.args[0].get("type") == "error" for call in sent)
-        container.registry.revoke_workspace_browsers("ws")
-        container.registry.states.pop("ws", None)
+        registry.revoke_workspace_browsers("ws")
+        registry.states.pop("ws", None)
 
     async def test_start_failure_send_error_ws_dead(self):
         """If send_error itself fails with a WS error, it's swallowed."""
+        app_state = _make_app_state()
+        registry = app_state.container_registry
         sock = _mock_sock()
-        conn = _base_conn(ws=sock)
+        conn = _base_conn(ws=sock, app_state=app_state)
         conn.container_id = "cid"
         conn.workspace_id = "ws"
         conn._user_home = "/home/testuser"
@@ -1645,7 +1726,7 @@ class TestHandleTerminalStart:
             return True
 
         conn._has_perm = _perm  # type: ignore[method-assign]
-        container.registry.track_activity("cid", "ws")
+        registry.track_activity("cid", "ws")
 
         mock_session = AsyncMock()
         mock_session.output = _empty_async_generator
@@ -1661,12 +1742,14 @@ class TestHandleTerminalStart:
             await asyncio.sleep(0)
 
         mock_session.stop.assert_awaited_once()
-        container.registry.revoke_workspace_browsers("ws")
-        container.registry.states.pop("ws", None)
+        registry.revoke_workspace_browsers("ws")
+        registry.states.pop("ws", None)
 
     async def test_cancellation_during_start_cleans_up(self):
+        app_state = _make_app_state()
+        registry = app_state.container_registry
         sock = _mock_sock()
-        conn = _base_conn(ws=sock)
+        conn = _base_conn(ws=sock, app_state=app_state)
         conn.container_id = "cid"
         conn.workspace_id = "ws"
         conn._user_home = "/home/testuser"
@@ -1675,7 +1758,7 @@ class TestHandleTerminalStart:
             return True
 
         conn._has_perm = _perm  # type: ignore[method-assign]
-        container.registry.track_activity("cid", "ws")
+        registry.track_activity("cid", "ws")
 
         mock_session = AsyncMock()
         mock_session.output = _empty_async_generator
@@ -1691,15 +1774,17 @@ class TestHandleTerminalStart:
 
         # session.stop() must be called to clean up the PTY subprocess
         mock_session.stop.assert_awaited_once()
-        container.registry.revoke_workspace_browsers("ws")
-        container.registry.states.pop("ws", None)
+        registry.revoke_workspace_browsers("ws")
+        registry.states.pop("ws", None)
 
     async def test_session_replaced_during_start_aborts(self):
         """If stop_terminal replaces the session while start() is running,
         the startup task stops the orphaned session and does not send
         terminal_started."""
+        app_state = _make_app_state()
+        registry = app_state.container_registry
         sock = _mock_sock()
-        conn = _base_conn(ws=sock)
+        conn = _base_conn(ws=sock, app_state=app_state)
         conn.container_id = "cid"
         conn.workspace_id = "ws"
         conn._user_home = "/home/testuser"
@@ -1708,7 +1793,7 @@ class TestHandleTerminalStart:
             return True
 
         conn._has_perm = _perm  # type: ignore[method-assign]
-        container.registry.track_activity("cid", "ws")
+        registry.track_activity("cid", "ws")
 
         mock_session = AsyncMock()
         mock_session.output = _empty_async_generator
@@ -1730,8 +1815,8 @@ class TestHandleTerminalStart:
         # terminal_started must NOT be sent
         for call in sock.send_json.call_args_list:
             assert call.args[0].get("type") != "terminal_started"
-        container.registry.revoke_workspace_browsers("ws")
-        container.registry.states.pop("ws", None)
+        registry.revoke_workspace_browsers("ws")
+        registry.states.pop("ws", None)
 
     async def test_no_container(self):
         sock = _mock_sock()
@@ -1795,17 +1880,20 @@ class TestHandleSetHandle:
         assert any(call.args[0].get("type") == "error" for call in sent)
 
     async def test_handle_auto_created_on_connect(self, user):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        registry = app_state.container_registry
         sock = _mock_sock(headers={"host": "localhost:8997"})
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         workspace = await ws_mod.create_workspace(user["id"], "auto-handle")
 
         async def fake_start(*a, **kw):
-            container.registry.track_activity("cid-ah", workspace["id"])
+            registry.track_activity("cid-ah", workspace["id"])
             return ("cid-ah", "created")
 
         with (
             patch.object(
-                container.registry,
+                registry,
                 "start_container",
                 side_effect=fake_start,
             ),
@@ -1817,8 +1905,8 @@ class TestHandleSetHandle:
         assert conn._user_home is not None
         assert conn._user_home.startswith("/home/")
 
-        wshandler.state.sessions.pop(workspace["id"], None)
-        container.registry.states.pop(workspace["id"], None)
+        sockets.sessions.pop(workspace["id"], None)
+        registry.states.pop(workspace["id"], None)
 
     async def test_handle_resolved_on_start(self, user, temp_data_dir):
         from klangk_backend import workspaces
@@ -1841,12 +1929,14 @@ class TestHandleSetHandle:
 
 class TestForwardTerminalOutput:
     async def test_forwards_output(self):
+        app_state = _make_app_state()
+        registry = app_state.container_registry
         sock = _mock_sock()
         t = _mock_terminal()
-        conn = _base_conn(ws=sock)
+        conn = _base_conn(ws=sock, app_state=app_state)
         conn.container_id = "ctr-fwd"
         conn.terminal_session = t
-        container.registry.track_activity("ctr-fwd", "ws-fwd")
+        registry.track_activity("ctr-fwd", "ws-fwd")
 
         async def fake_output():
             yield "line1"
@@ -1865,8 +1955,8 @@ class TestForwardTerminalOutput:
         # Stream ended — no container_stopped event (terminal exit != container death)
         assert len(calls) == 2
         # Activity was bumped on each output chunk
-        assert "ws-fwd" in container.registry.states
-        container.registry.states.pop("ws-fwd", None)
+        assert "ws-fwd" in registry.states
+        registry.states.pop("ws-fwd", None)
 
     async def test_cancelled_error_propagates(self):
         sock = _mock_sock()
@@ -1917,37 +2007,25 @@ class TestForwardTerminalOutput:
 # --- forward_events ---
 
 
-def _setup_workspace_state(workspace_id, sock, pi, container_id="cid-1"):
-    """Helper to set up _workspace_state for forward_events tests."""
-    session = WorkspaceSession(workspace_id)
-    session.container_id = container_id
-    session.subscribers = {sock}
-    wshandler.state.sessions[workspace_id] = session
-
-
-def _teardown_workspace_state(workspace_id):
-    wshandler.state.sessions.pop(workspace_id, None)
-    container.registry.states.pop(workspace_id, None)
-
-
 class TestCleanupConnection:
     async def test_cleanup_last_subscriber_removes_session(self):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        registry = app_state.container_registry
         sock = _mock_sock()
         t = _mock_terminal()
-        conn = _base_conn(ws=sock)
+        conn = _base_conn(ws=sock, app_state=app_state)
         conn.container_id = "ctr-full"
         conn.workspace_id = "ws-cleanup-1"
         conn._idle_cb = lambda ws: None
         conn.terminal_session = t
         conn.terminal_task = asyncio.create_task(asyncio.sleep(10))
 
-        container.registry.track_activity("ctr-full", "ws-cleanup-1")
-        session = WorkspaceSession("ws-cleanup-1")
+        registry.track_activity("ctr-full", "ws-cleanup-1")
+        session = WorkspaceSession("ws-cleanup-1", app_state)
         session.subscribers.add(sock)
-        wshandler.state.sessions["ws-cleanup-1"] = session
-        container.registry.states["ws-cleanup-1"].idle_callbacks.append(
-            conn._idle_cb
-        )
+        sockets.sessions["ws-cleanup-1"] = session
+        registry.states["ws-cleanup-1"].idle_callbacks.append(conn._idle_cb)
 
         await conn.cleanup()
 
@@ -1955,30 +2033,31 @@ class TestCleanupConnection:
         assert conn._idle_cb is None
         assert conn.terminal_session is None
         # Session removed when last subscriber disconnects
-        assert "ws-cleanup-1" not in wshandler.state.sessions
+        assert "ws-cleanup-1" not in sockets.sessions
 
-        container.registry.states.pop("ws-cleanup-1", None)
+        registry.states.pop("ws-cleanup-1", None)
 
     async def test_cleanup_other_subscribers_remain(self):
         """When other subscribers remain, session stays alive."""
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        registry = app_state.container_registry
         sock = _mock_sock()
         other_sock = _mock_sock()
         t = _mock_terminal()
-        conn = _base_conn(ws=sock)
+        conn = _base_conn(ws=sock, app_state=app_state)
         conn.container_id = "ctr-shared"
         conn.workspace_id = "ws-cleanup-2"
         conn._idle_cb = lambda ws: None
         conn.terminal_session = t
         conn.terminal_task = asyncio.create_task(asyncio.sleep(10))
 
-        container.registry.track_activity("ctr-shared", "ws-cleanup-2")
-        session = WorkspaceSession("ws-cleanup-2")
+        registry.track_activity("ctr-shared", "ws-cleanup-2")
+        session = WorkspaceSession("ws-cleanup-2", app_state)
         session.subscribers.add(sock)
         session.subscribers.add(other_sock)
-        wshandler.state.sessions["ws-cleanup-2"] = session
-        container.registry.states["ws-cleanup-2"].idle_callbacks.append(
-            conn._idle_cb
-        )
+        sockets.sessions["ws-cleanup-2"] = session
+        registry.states["ws-cleanup-2"].idle_callbacks.append(conn._idle_cb)
 
         with patch.object(
             model,
@@ -1991,13 +2070,13 @@ class TestCleanupConnection:
         # Terminal for THIS connection should be stopped
         t.stop.assert_awaited_once()
         # Session still present — other subscriber remains
-        assert "ws-cleanup-2" in wshandler.state.sessions
+        assert "ws-cleanup-2" in sockets.sessions
         assert other_sock in session.subscribers
         assert sock not in session.subscribers
 
         # Cleanup
-        container.registry.states.pop("ws-cleanup-2", None)
-        wshandler.state.sessions.pop("ws-cleanup-2", None)
+        registry.states.pop("ws-cleanup-2", None)
+        sockets.sessions.pop("ws-cleanup-2", None)
 
     async def test_cleanup_minimal(self):
         sock = _mock_sock()
@@ -2023,9 +2102,11 @@ class TestHandleWorkspaceConnect:
         assert "Permission denied" in sock.send_json.call_args[0][0]["message"]
 
     async def test_connect_success(self, user, agent_user):
+        app_state = _make_app_state()
+        registry = app_state.container_registry
         sock = _mock_sock()
         workspace = await _create_workspace_with_acl(user["id"], "test-ws")
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
 
         async def fake_start(wid, workspace):
             conn.container_id = "cid"
@@ -2037,7 +2118,7 @@ class TestHandleWorkspaceConnect:
                 side_effect=fake_start,
             ),
             patch.object(
-                container.registry,
+                registry,
                 "get_workspace_ports",
                 return_value=[9000, 9001],
             ),
@@ -2056,11 +2137,13 @@ class TestHandleWorkspaceConnect:
         assert "30m" in conn.pending_status_msg
 
     async def test_connect_sends_service_command(self, user, agent_user):
+        app_state = _make_app_state()
+        registry = app_state.container_registry
         sock = _mock_sock()
         workspace = await _create_workspace_with_acl(
             user["id"], "cmd-ws", service_command="pi"
         )
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
 
         async def fake_start(wid, workspace):
             conn.container_id = "cid"
@@ -2072,7 +2155,7 @@ class TestHandleWorkspaceConnect:
                 side_effect=fake_start,
             ),
             patch.object(
-                container.registry,
+                registry,
                 "get_workspace_ports",
                 return_value=[9000],
             ),
@@ -2136,13 +2219,15 @@ class TestHandleWorkspaceConnect:
 
 class TestHandleWorkspaceDisconnect:
     async def test_disconnect(self):
+        app_state = _make_app_state()
+        registry = app_state.container_registry
         sock = _mock_sock()
-        conn = _base_conn(ws=sock)
+        conn = _base_conn(ws=sock, app_state=app_state)
         conn.container_id = "cid"
         conn.workspace_id = "ws-1"
 
         with patch.object(
-            container.registry,
+            registry,
             "stop_and_remove_container",
             new_callable=AsyncMock,
         ):
@@ -2157,17 +2242,20 @@ class TestHandleWorkspaceDisconnect:
 
 class TestStartWorkspaceContainer:
     async def test_new_session(self, user):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        registry = app_state.container_registry
         sock = _mock_sock(headers={"host": "localhost:8997"})
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         workspace = await ws_mod.create_workspace(user["id"], "start-ws")
 
         async def fake_start(*a, **kw):
-            container.registry.track_activity("cid-1", workspace["id"])
+            registry.track_activity("cid-1", workspace["id"])
             return ("cid-1", "created")
 
         with (
             patch.object(
-                container.registry,
+                registry,
                 "start_container",
                 side_effect=fake_start,
             ),
@@ -2177,29 +2265,32 @@ class TestStartWorkspaceContainer:
 
         assert conn.container_id == "cid-1"
         assert conn.workspace == workspace
-        assert workspace["id"] in wshandler.state.sessions
+        assert workspace["id"] in sockets.sessions
         assert conn._idle_cb is not None
         # Handle auto-created from email on connect
         assert conn._user_home is not None
         assert conn._user_home.startswith("/home/")
 
-        wshandler.state.sessions.pop(workspace["id"], None)
-        container.registry.states.pop(workspace["id"], None)
+        sockets.sessions.pop(workspace["id"], None)
+        registry.states.pop(workspace["id"], None)
 
     async def test_resolves_existing_handle(self, user):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        registry = app_state.container_registry
         sock = _mock_sock(headers={"host": "localhost:8997"})
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         workspace = await ws_mod.create_workspace(user["id"], "handle-ws")
         # Set a custom handle in the DB
         await model.set_user_handle(user["id"], "chris")
 
         async def fake_start(*a, **kw):
-            container.registry.track_activity("cid-h", workspace["id"])
+            registry.track_activity("cid-h", workspace["id"])
             return ("cid-h", "created")
 
         with (
             patch.object(
-                container.registry,
+                registry,
                 "start_container",
                 side_effect=fake_start,
             ),
@@ -2209,21 +2300,24 @@ class TestStartWorkspaceContainer:
 
         assert conn._user_home == "/home/chris"
 
-        wshandler.state.sessions.pop(workspace["id"], None)
-        container.registry.states.pop(workspace["id"], None)
+        sockets.sessions.pop(workspace["id"], None)
+        registry.states.pop(workspace["id"], None)
 
     async def test_idle_callback_ws_error(self, user):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        registry = app_state.container_registry
         sock = _mock_sock(headers={"host": "localhost:8997"})
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         workspace = await ws_mod.create_workspace(user["id"], "idle-ws")
 
         async def fake_start(*a, **kw):
-            container.registry.track_activity("cid-3", workspace["id"])
+            registry.track_activity("cid-3", workspace["id"])
             return ("cid-3", "created")
 
         with (
             patch.object(
-                container.registry,
+                registry,
                 "start_container",
                 side_effect=fake_start,
             ),
@@ -2237,22 +2331,25 @@ class TestStartWorkspaceContainer:
         await idle_cb(workspace["id"])  # should not raise
         assert sock.send_json.call_count == 1
 
-        wshandler.state.sessions.pop(workspace["id"], None)
-        container.registry.states.pop(workspace["id"], None)
+        sockets.sessions.pop(workspace["id"], None)
+        registry.states.pop(workspace["id"], None)
 
     async def test_clears_pending_status_msg(self, user):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        registry = app_state.container_registry
         sock = _mock_sock(headers={"host": "localhost:8997"})
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.pending_status_msg = "stale message from prior connect"
         workspace = await ws_mod.create_workspace(user["id"], "pending-ws")
 
         async def fake_start(*a, **kw):
-            container.registry.track_activity("cid-p", workspace["id"])
+            registry.track_activity("cid-p", workspace["id"])
             return ("cid-p", "created")
 
         with (
             patch.object(
-                container.registry,
+                registry,
                 "start_container",
                 side_effect=fake_start,
             ),
@@ -2262,8 +2359,8 @@ class TestStartWorkspaceContainer:
 
         assert conn.pending_status_msg is None
 
-        wshandler.state.sessions.pop(workspace["id"], None)
-        container.registry.states.pop(workspace["id"], None)
+        sockets.sessions.pop(workspace["id"], None)
+        registry.states.pop(workspace["id"], None)
 
 
 # --- handle_websocket dispatch branches ---
@@ -2272,14 +2369,16 @@ class TestStartWorkspaceContainer:
 class TestHandleWebsocketDispatch:
     """Test all command dispatch branches through the main handler."""
 
-    async def _run_commands(self, user, commands):
+    async def _run_commands(self, user, commands, app_state=None):
         from klangk_backend import auth as auth_mod
 
+        if app_state is None:
+            app_state = _make_app_state()
         token = auth_mod.create_token(user["id"], user["email"])
         websocket = _mock_raw_sock(query_params={"token": token})
         msgs = [json.dumps(c) for c in commands] + [WebSocketDisconnect()]
         websocket.receive_text = AsyncMock(side_effect=msgs)
-        await handle_websocket(websocket)
+        await handle_websocket(websocket, app_state)
         return websocket
 
     async def test_dispatch_terminal_start(self, user):
@@ -2348,6 +2447,8 @@ class TestHandleWebsocketDispatch:
 
     async def test_container_survives_disconnect(self, user):
         """Container should NOT be killed on disconnect — idle timeout handles it."""
+        app_state = _make_app_state()
+        registry = app_state.container_registry
         from klangk_backend import auth as auth_mod
 
         token = auth_mod.create_token(user["id"], user["email"])
@@ -2378,17 +2479,17 @@ class TestHandleWebsocketDispatch:
                 side_effect=fake_start,
             ),
             patch.object(
-                container.registry,
+                registry,
                 "get_workspace_ports",
                 return_value=[],
             ),
             patch.object(
-                container.registry,
+                registry,
                 "stop_and_remove_container",
                 new_callable=AsyncMock,
             ) as mock_stop,
         ):
-            await handle_websocket(websocket)
+            await handle_websocket(websocket, app_state)
 
         mock_stop.assert_not_awaited()
 
@@ -2398,20 +2499,23 @@ class TestHandleWebsocketDispatch:
 
 class TestHandleWebsocket:
     async def test_missing_token(self):
+        app_state = _make_app_state()
         websocket = _mock_raw_sock(query_params={})
-        await handle_websocket(websocket)
+        await handle_websocket(websocket, app_state)
         websocket.close.assert_awaited_once_with(
             code=4001, reason="Missing token"
         )
 
     async def test_invalid_token(self, db):
+        app_state = _make_app_state()
         websocket = _mock_raw_sock(query_params={"token": "bad"})
-        await handle_websocket(websocket)
+        await handle_websocket(websocket, app_state)
         websocket.close.assert_awaited_once_with(
             code=4001, reason="Invalid token"
         )
 
     async def test_expired_token(self, user):
+        app_state = _make_app_state()
         from datetime import datetime, timedelta, timezone
 
         from jose import jwt
@@ -2429,23 +2533,25 @@ class TestHandleWebsocket:
             payload, auth_mod.SECRET_KEY, algorithm=auth_mod.ALGORITHM
         )
         websocket = _mock_raw_sock(query_params={"token": token})
-        await handle_websocket(websocket)
+        await handle_websocket(websocket, app_state)
         websocket.close.assert_awaited_once_with(
             code=4002, reason="Token expired"
         )
 
     async def test_valid_token_then_disconnect(self, user):
+        app_state = _make_app_state()
         from klangk_backend import auth as auth_mod
 
         token = auth_mod.create_token(user["id"], user["email"])
         websocket = _mock_raw_sock(query_params={"token": token})
         websocket.receive_text = AsyncMock(side_effect=WebSocketDisconnect())
 
-        await handle_websocket(websocket)
+        await handle_websocket(websocket, app_state)
 
         websocket.accept.assert_awaited_once()
 
     async def test_unexpected_exception_logged(self, user):
+        app_state = _make_app_state()
         from klangk_backend import auth as auth_mod
 
         token = auth_mod.create_token(user["id"], user["email"])
@@ -2454,11 +2560,12 @@ class TestHandleWebsocket:
             side_effect=ValueError("unexpected")
         )
 
-        await handle_websocket(websocket)
+        await handle_websocket(websocket, app_state)
 
         websocket.accept.assert_awaited_once()
 
     async def test_runtime_error_treated_as_disconnect(self, user):
+        app_state = _make_app_state()
         from klangk_backend import auth as auth_mod
 
         token = auth_mod.create_token(user["id"], user["email"])
@@ -2469,11 +2576,12 @@ class TestHandleWebsocket:
             )
         )
 
-        await handle_websocket(websocket)
+        await handle_websocket(websocket, app_state)
 
         websocket.accept.assert_awaited_once()
 
     async def test_invalid_json(self, user):
+        app_state = _make_app_state()
         from klangk_backend import auth as auth_mod
 
         token = auth_mod.create_token(user["id"], user["email"])
@@ -2482,12 +2590,13 @@ class TestHandleWebsocket:
             side_effect=["not json", WebSocketDisconnect()]
         )
 
-        await handle_websocket(websocket)
+        await handle_websocket(websocket, app_state)
 
         calls = [c[0][0] for c in websocket.send_json.call_args_list]
         assert any("Invalid JSON" in str(c) for c in calls)
 
     async def test_unknown_command(self, user):
+        app_state = _make_app_state()
         from klangk_backend import auth as auth_mod
 
         token = auth_mod.create_token(user["id"], user["email"])
@@ -2499,12 +2608,15 @@ class TestHandleWebsocket:
             ]
         )
 
-        await handle_websocket(websocket)
+        await handle_websocket(websocket, app_state)
 
         calls = [c[0][0] for c in websocket.send_json.call_args_list]
         assert any("Unknown command" in str(c) for c in calls)
 
     async def test_ui_ready_with_pending(self, user):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        registry = app_state.container_registry
         from klangk_backend import auth as auth_mod
 
         token = auth_mod.create_token(user["id"], user["email"])
@@ -2515,7 +2627,7 @@ class TestHandleWebsocket:
             self_arg.container_id = "cid"
             self_arg.workspace_id = wid
             self_arg._user_home = "/home/testuser"
-            wshandler.state.get_or_create_session(wid)
+            sockets.get_or_create_session(wid, app_state)
 
         websocket.receive_text = AsyncMock(
             side_effect=[
@@ -2538,17 +2650,17 @@ class TestHandleWebsocket:
                 side_effect=fake_start,
             ),
             patch.object(
-                container.registry,
+                registry,
                 "get_workspace_ports",
                 return_value=[],
             ),
             patch.object(
-                container.registry,
+                registry,
                 "stop_and_remove_container",
                 new_callable=AsyncMock,
             ),
         ):
-            await handle_websocket(websocket)
+            await handle_websocket(websocket, app_state)
 
         calls = [c[0][0] for c in websocket.send_json.call_args_list]
         ready = [
@@ -2561,6 +2673,7 @@ class TestHandleWebsocket:
         assert len(ready) == 1
 
     async def test_ui_ready_no_pending(self, user):
+        app_state = _make_app_state()
         from klangk_backend import auth as auth_mod
 
         token = auth_mod.create_token(user["id"], user["email"])
@@ -2572,7 +2685,7 @@ class TestHandleWebsocket:
             ]
         )
 
-        await handle_websocket(websocket)
+        await handle_websocket(websocket, app_state)
 
         calls = [c[0][0] for c in websocket.send_json.call_args_list]
         ready = [
@@ -2585,6 +2698,8 @@ class TestHandleWebsocket:
         assert len(ready) == 0
 
     async def test_general_exception_logged(self, user):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         from klangk_backend import auth as auth_mod
 
         token = auth_mod.create_token(user["id"], user["email"])
@@ -2593,10 +2708,10 @@ class TestHandleWebsocket:
             side_effect=RuntimeError("unexpected")
         )
 
-        await handle_websocket(websocket)
+        await handle_websocket(websocket, app_state)
 
         websocket.accept.assert_awaited_once()
-        assert websocket not in wshandler.state.connections
+        assert websocket not in sockets.connections
 
 
 class TestExecHandlers:
@@ -2630,8 +2745,10 @@ class TestExecHandlers:
         assert "command" in sock.send_json.call_args[0][0].get("message", "")
 
     async def test_exec_start_success(self):
+        app_state = _make_app_state()
+        registry = app_state.container_registry
         sock = _mock_sock()
-        conn = _base_conn(ws=sock)
+        conn = _base_conn(ws=sock, app_state=app_state)
         conn.container_id = "cid"
         mock_session = AsyncMock()
         mock_session.output = _empty_async_generator
@@ -2647,7 +2764,7 @@ class TestExecHandlers:
             "klangk_backend.wshandler.controllers.ExecSession",
             return_value=mock_session,
         ):
-            with patch.object(container.registry, "record_activity"):
+            with patch.object(registry, "record_activity"):
                 with patch.object(
                     conn, "_has_perm", new=AsyncMock(return_value=True)
                 ):
@@ -2661,8 +2778,10 @@ class TestExecHandlers:
             pass
 
     async def test_exec_start_passes_ssh_agent_socket(self):
+        app_state = _make_app_state()
+        registry = app_state.container_registry
         sock = _mock_sock()
-        conn = _base_conn(ws=sock)
+        conn = _base_conn(ws=sock, app_state=app_state)
         conn.container_id = "cid"
         conn._user_home = "/home/admin"
         conn._ssh_agent_socket = "/tmp/agent.sock"
@@ -2680,7 +2799,7 @@ class TestExecHandlers:
             "klangk_backend.wshandler.controllers.ExecSession",
             return_value=mock_session,
         ) as mock_cls:
-            with patch.object(container.registry, "record_activity"):
+            with patch.object(registry, "record_activity"):
                 with patch.object(
                     conn, "_has_perm", new=AsyncMock(return_value=True)
                 ):
@@ -2696,15 +2815,17 @@ class TestExecHandlers:
             pass
 
     async def test_exec_input_sends_data(self):
+        app_state = _make_app_state()
+        registry = app_state.container_registry
         import base64
 
         session = AsyncMock()
         session.is_alive = True
-        conn = _base_conn()
+        conn = _base_conn(app_state=app_state)
         conn.container_id = "cid"
         conn.exec_session = session
         data = base64.b64encode(b"hello").decode()
-        with patch.object(container.registry, "record_activity"):
+        with patch.object(registry, "record_activity"):
             await conn.handle_exec_input({"data": data})
         session.write.assert_awaited_with(b"hello")
 
@@ -2753,6 +2874,8 @@ class TestExecHandlers:
         await conn.stop_exec()  # should not raise
 
     async def test_forward_exec_output(self):
+        app_state = _make_app_state()
+        registry = app_state.container_registry
         import base64
 
         sock = _mock_sock()
@@ -2764,10 +2887,10 @@ class TestExecHandlers:
             yield b"chunk2"
 
         session.output = fake_output
-        conn = _base_conn(ws=sock)
+        conn = _base_conn(ws=sock, app_state=app_state)
         conn.container_id = "cid"
         conn.exec_session = session
-        with patch.object(container.registry, "record_activity"):
+        with patch.object(registry, "record_activity"):
             await conn.forward_exec_output(session)
         # Session claimed and stopped by finally block
         assert conn.exec_session is None
@@ -2783,6 +2906,8 @@ class TestExecHandlers:
         assert exit_calls[0][0][0]["code"] == 0
 
     async def test_forward_exec_output_ws_error(self):
+        app_state = _make_app_state()
+        registry = app_state.container_registry
         sock = _mock_sock()
         session = AsyncMock()
 
@@ -2791,9 +2916,9 @@ class TestExecHandlers:
 
         session.output = fake_output
         sock.send_json = MagicMock(side_effect=RuntimeError("ws dead"))
-        conn = _base_conn(ws=sock)
+        conn = _base_conn(ws=sock, app_state=app_state)
         conn.container_id = "cid"
-        with patch.object(container.registry, "record_activity"):
+        with patch.object(registry, "record_activity"):
             await conn.forward_exec_output(session)
         # Should not raise
 
@@ -2828,15 +2953,19 @@ class TestExecController:
         ssh_agent_socket=None,
         sock=None,
         has_perm=True,
+        app_state=None,
     ):
         if sock is None:
             sock = _mock_sock()
+        if app_state is None:
+            app_state = _make_app_state()
         conn = SimpleNamespace(
             sock=sock,
             container_id=container_id,
             _user_home=user_home,
             _ssh_agent_socket=ssh_agent_socket,
             _has_perm=AsyncMock(return_value=has_perm),
+            app_state=app_state,
         )
         return ExecController(conn), sock, conn
 
@@ -2864,14 +2993,16 @@ class TestExecController:
 
     async def test_start_stops_existing_session_first(self):
         """start() tears down any in-flight exec before starting a new one."""
-        ctrl, _, _ = self._controller()
+        app_state = _make_app_state()
+        registry = app_state.container_registry
+        ctrl, _, _ = self._controller(app_state=app_state)
         old = AsyncMock()
         ctrl.session = old
         with (
             patch(
                 "klangk_backend.wshandler.controllers.ExecSession"
             ) as MockExec,
-            patch.object(container.registry, "record_activity"),
+            patch.object(registry, "record_activity"),
         ):
             mock_session = MockExec.return_value
             mock_session.start = AsyncMock()
@@ -2887,6 +3018,8 @@ class TestExecController:
         assert ctrl.session is mock_session
 
     async def test_start_passes_user_home_and_ssh_agent_socket(self):
+        app_state = _make_app_state()
+        registry = app_state.container_registry
         ctrl, _, _ = self._controller(
             user_home="/home/admin",
             ssh_agent_socket="/tmp/agent.sock",
@@ -2895,7 +3028,7 @@ class TestExecController:
             patch(
                 "klangk_backend.wshandler.controllers.ExecSession"
             ) as MockExec,
-            patch.object(container.registry, "record_activity"),
+            patch.object(registry, "record_activity"),
         ):
             mock_session = MockExec.return_value
             mock_session.start = AsyncMock()
@@ -2911,12 +3044,14 @@ class TestExecController:
         assert kwargs["work_dir"] == "/home/admin"
 
     async def test_start_defaults_work_dir_when_no_user_home(self):
-        ctrl, _, _ = self._controller(user_home=None)
+        app_state = _make_app_state()
+        registry = app_state.container_registry
+        ctrl, _, _ = self._controller(user_home=None, app_state=app_state)
         with (
             patch(
                 "klangk_backend.wshandler.controllers.ExecSession"
             ) as MockExec,
-            patch.object(container.registry, "record_activity"),
+            patch.object(registry, "record_activity"),
         ):
             mock_session = MockExec.return_value
             mock_session.start = AsyncMock()
@@ -2933,12 +3068,14 @@ class TestExecController:
     async def test_start_default_login_false(self):
         """#1041: a message with no ``login`` key runs raw argv (no
         shell) -- the safe default for any caller, and what rsync needs."""
-        ctrl, _, _ = self._controller()
+        app_state = _make_app_state()
+        registry = app_state.container_registry
+        ctrl, _, _ = self._controller(app_state=app_state)
         with (
             patch(
                 "klangk_backend.wshandler.controllers.ExecSession"
             ) as MockExec,
-            patch.object(container.registry, "record_activity"),
+            patch.object(registry, "record_activity"),
         ):
             mock_session = MockExec.return_value
             mock_session.start = AsyncMock()
@@ -2954,12 +3091,14 @@ class TestExecController:
         """#1041: ``login: True`` in the message reaches ExecSession.start
         so the command runs as a bash login shell (sources ~/.profile).
         This is the klangkc exec default."""
-        ctrl, _, _ = self._controller()
+        app_state = _make_app_state()
+        registry = app_state.container_registry
+        ctrl, _, _ = self._controller(app_state=app_state)
         with (
             patch(
                 "klangk_backend.wshandler.controllers.ExecSession"
             ) as MockExec,
-            patch.object(container.registry, "record_activity"),
+            patch.object(registry, "record_activity"),
         ):
             mock_session = MockExec.return_value
             mock_session.start = AsyncMock()
@@ -2984,24 +3123,28 @@ class TestExecController:
         session.write.assert_not_awaited()
 
     async def test_input_oversized_dropped(self):
-        ctrl, _, _ = self._controller()
+        app_state = _make_app_state()
+        registry = app_state.container_registry
+        ctrl, _, _ = self._controller(app_state=app_state)
         session = AsyncMock()
         session.is_alive = True
         ctrl.session = session
         big = base64.b64encode(
             b"x" * (_ws_constants.MAX_INPUT_SIZE + 1)
         ).decode()
-        with patch.object(container.registry, "record_activity"):
+        with patch.object(registry, "record_activity"):
             await ctrl.input({"data": big})
         session.write.assert_not_awaited()
 
     async def test_input_writes_and_records_activity(self):
-        ctrl, _, _ = self._controller()
+        app_state = _make_app_state()
+        registry = app_state.container_registry
+        ctrl, _, _ = self._controller(app_state=app_state)
         session = AsyncMock()
         session.is_alive = True
         ctrl.session = session
         data = base64.b64encode(b"hello").decode()
-        with patch.object(container.registry, "record_activity") as rec:
+        with patch.object(registry, "record_activity") as rec:
             await ctrl.input({"data": data})
         session.write.assert_awaited_once_with(b"hello")
         rec.assert_called_once_with("cid")
@@ -3053,7 +3196,9 @@ class TestExecController:
         session.stop.assert_awaited_once()
 
     async def test_forward_output_relays_chunks_and_exit_code(self):
-        ctrl, sock, _ = self._controller()
+        app_state = _make_app_state()
+        registry = app_state.container_registry
+        ctrl, sock, _ = self._controller(app_state=app_state)
         session = AsyncMock()
         session.returncode = 7
         ctrl.session = session
@@ -3063,7 +3208,7 @@ class TestExecController:
             yield b"chunk2"
 
         session.output = fake_output
-        with patch.object(container.registry, "record_activity"):
+        with patch.object(registry, "record_activity"):
             await ctrl.forward_output(session)
         calls = [c[0][0] for c in sock.send_json.call_args_list]
         outputs = [c for c in calls if c["type"] == "exec_output"]
@@ -3076,7 +3221,9 @@ class TestExecController:
         session.stop.assert_awaited_once()
 
     async def test_forward_output_exit_code_defaults_to_1(self):
-        ctrl, sock, _ = self._controller()
+        app_state = _make_app_state()
+        registry = app_state.container_registry
+        ctrl, sock, _ = self._controller(app_state=app_state)
         session = AsyncMock()
         session.returncode = None
         ctrl.session = session
@@ -3086,7 +3233,7 @@ class TestExecController:
             yield  # pragma: no cover
 
         session.output = fake_output
-        with patch.object(container.registry, "record_activity"):
+        with patch.object(registry, "record_activity"):
             await ctrl.forward_output(session)
         exits = [
             c[0][0]
@@ -3096,7 +3243,9 @@ class TestExecController:
         assert exits[0]["code"] == 1
 
     async def test_forward_output_records_activity_when_container_set(self):
-        ctrl, _, _ = self._controller(container_id="cid")
+        app_state = _make_app_state()
+        registry = app_state.container_registry
+        ctrl, _, _ = self._controller(container_id="cid", app_state=app_state)
         session = AsyncMock()
         session.returncode = 0
         ctrl.session = session
@@ -3105,12 +3254,14 @@ class TestExecController:
             yield b"data"
 
         session.output = fake_output
-        with patch.object(container.registry, "record_activity") as rec:
+        with patch.object(registry, "record_activity") as rec:
             await ctrl.forward_output(session)
         rec.assert_called_once_with("cid")
 
     async def test_forward_output_swallows_ws_error(self):
-        ctrl, sock, _ = self._controller()
+        app_state = _make_app_state()
+        registry = app_state.container_registry
+        ctrl, sock, _ = self._controller(app_state=app_state)
         session = AsyncMock()
         ctrl.session = session
 
@@ -3119,7 +3270,7 @@ class TestExecController:
 
         session.output = fake_output
         sock.send_json = MagicMock(side_effect=RuntimeError("ws dead"))
-        with patch.object(container.registry, "record_activity"):
+        with patch.object(registry, "record_activity"):
             # Must not raise; error is logged.
             await ctrl.forward_output(session)
         session.stop.assert_awaited_once()
@@ -3314,8 +3465,10 @@ class TestSSHAgentHandlers:
 
     async def test_ssh_agent_start_with_terminal(self):
         """SSH_AUTH_SOCK is passed to TerminalSession when agent is active."""
+        app_state = _make_app_state()
+        registry = app_state.container_registry
         sock = _mock_sock()
-        conn = _base_conn(ws=sock)
+        conn = _base_conn(ws=sock, app_state=app_state)
         conn.container_id = "cid"
         conn._user_home = "/home/testuser"
         conn._ssh_agent_socket = "/tmp/klangk-ssh-agent-uid.sock"
@@ -3335,7 +3488,7 @@ class TestSSHAgentHandlers:
                 "klangk_backend.wshandler.controllers.TerminalSession",
                 return_value=mock_session,
             ) as MockTS,
-            patch.object(container.registry, "record_activity"),
+            patch.object(registry, "record_activity"),
             patch(
                 "klangk_backend.wshandler.controllers.attach_browser",
                 new=AsyncMock(),
@@ -3719,6 +3872,7 @@ class TestSshAgentForwarder:
 
 class TestExecDispatch:
     async def test_dispatch_exec_start(self, user):
+        app_state = _make_app_state()
         from klangk_backend import auth as auth_mod
 
         token = auth_mod.create_token(user["id"], user["email"])
@@ -3732,10 +3886,11 @@ class TestExecDispatch:
         with patch.object(
             Connection, "handle_exec_start", new_callable=AsyncMock
         ) as mock:
-            await handle_websocket(websocket)
+            await handle_websocket(websocket, app_state)
         mock.assert_awaited_once()
 
     async def test_dispatch_exec_input(self, user):
+        app_state = _make_app_state()
         from klangk_backend import auth as auth_mod
 
         token = auth_mod.create_token(user["id"], user["email"])
@@ -3749,10 +3904,11 @@ class TestExecDispatch:
         with patch.object(
             Connection, "handle_exec_input", new_callable=AsyncMock
         ) as mock:
-            await handle_websocket(websocket)
+            await handle_websocket(websocket, app_state)
         mock.assert_awaited_once()
 
     async def test_dispatch_exec_stop(self, user):
+        app_state = _make_app_state()
         from klangk_backend import auth as auth_mod
 
         token = auth_mod.create_token(user["id"], user["email"])
@@ -3766,10 +3922,11 @@ class TestExecDispatch:
         with patch.object(
             Connection, "handle_exec_stop", new_callable=AsyncMock
         ) as mock:
-            await handle_websocket(websocket)
+            await handle_websocket(websocket, app_state)
         mock.assert_awaited_once()
 
     async def test_dispatch_exec_close_stdin(self, user):
+        app_state = _make_app_state()
         from klangk_backend import auth as auth_mod
 
         token = auth_mod.create_token(user["id"], user["email"])
@@ -3783,10 +3940,11 @@ class TestExecDispatch:
         with patch.object(
             Connection, "handle_exec_close_stdin", new_callable=AsyncMock
         ) as mock:
-            await handle_websocket(websocket)
+            await handle_websocket(websocket, app_state)
         mock.assert_awaited_once()
 
     async def test_dispatch_heartbeat(self, user):
+        app_state = _make_app_state()
         from klangk_backend import auth as auth_mod
 
         token = auth_mod.create_token(user["id"], user["email"])
@@ -3800,10 +3958,11 @@ class TestExecDispatch:
         with patch.object(
             Connection, "handle_heartbeat", new_callable=AsyncMock
         ) as mock:
-            await handle_websocket(websocket)
+            await handle_websocket(websocket, app_state)
         mock.assert_awaited_once()
 
     async def test_dispatch_chat_send(self, user):
+        app_state = _make_app_state()
         from klangk_backend import auth as auth_mod
 
         token = auth_mod.create_token(user["id"], user["email"])
@@ -3817,10 +3976,11 @@ class TestExecDispatch:
         with patch.object(
             Connection, "handle_chat_send", new_callable=AsyncMock
         ) as mock:
-            await handle_websocket(websocket)
+            await handle_websocket(websocket, app_state)
         mock.assert_awaited_once()
 
     async def test_dispatch_chat_delete(self, user):
+        app_state = _make_app_state()
         from klangk_backend import auth as auth_mod
 
         token = auth_mod.create_token(user["id"], user["email"])
@@ -3834,12 +3994,13 @@ class TestExecDispatch:
         with patch.object(
             Connection, "handle_chat_delete", new_callable=AsyncMock
         ) as mock:
-            await handle_websocket(websocket)
+            await handle_websocket(websocket, app_state)
         mock.assert_awaited_once()
 
 
 class TestChatLoadMoreDispatch:
     async def test_dispatch_chat_load_more(self, user):
+        app_state = _make_app_state()
         from klangk_backend import auth as auth_mod
 
         token = auth_mod.create_token(user["id"], user["email"])
@@ -3855,22 +4016,24 @@ class TestChatLoadMoreDispatch:
         with patch.object(
             Connection, "handle_chat_load_more", new_callable=AsyncMock
         ) as mock:
-            await handle_websocket(websocket)
+            await handle_websocket(websocket, app_state)
         mock.assert_awaited_once()
 
 
 class TestHandleHeartbeat:
     async def test_records_activity(self):
-        conn = _base_conn()
+        app_state = _make_app_state()
+        registry = app_state.container_registry
+        conn = _base_conn(app_state=app_state)
         conn.container_id = "cid-hb"
-        container.registry.track_activity("cid-hb", "ws-hb")
-        container.registry.states["ws-hb"].last_activity = 0.0
+        registry.track_activity("cid-hb", "ws-hb")
+        registry.states["ws-hb"].last_activity = 0.0
 
         await conn.handle_heartbeat()
 
-        assert container.registry.states["ws-hb"].last_activity > 0.0
-        container.registry.states.pop("ws-hb", None)
-        container.registry._cid_to_wsid.pop("cid-hb", None)
+        assert registry.states["ws-hb"].last_activity > 0.0
+        registry.states.pop("ws-hb", None)
+        registry._cid_to_wsid.pop("cid-hb", None)
 
     async def test_no_container_id(self):
         conn = _base_conn()
@@ -3880,6 +4043,8 @@ class TestHandleHeartbeat:
 
 class TestBrowserBridge:
     async def test_dispatch_browser_response(self, user):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         from klangk_backend import auth as auth_mod
 
         token = auth_mod.create_token(user["id"], user["email"])
@@ -3891,23 +4056,25 @@ class TestBrowserBridge:
             ]
         )
         with patch.object(
-            wshandler.state,
+            sockets,
             "handle_browser_response",
-            wraps=wshandler.state.handle_browser_response,
+            wraps=sockets.handle_browser_response,
         ) as mock:
-            await handle_websocket(websocket)
+            await handle_websocket(websocket, app_state)
         mock.assert_called_once()
 
     async def test_handle_browser_response_resolves_future(self):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         loop = asyncio.get_event_loop()
         future = loop.create_future()
         mock_sock = _mock_sock()
-        wshandler.state.pending_browser_requests["req-1"] = (
+        sockets.pending_browser_requests["req-1"] = (
             future,
             mock_sock,
         )
 
-        wshandler.state.handle_browser_response(
+        sockets.handle_browser_response(
             {"id": "req-1", "status": 200, "body": "hello"}, sender=mock_sock
         )
 
@@ -3916,35 +4083,43 @@ class TestBrowserBridge:
         assert result["body"] == "hello"
 
     async def test_handle_browser_response_wrong_sender_rejected(self):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         loop = asyncio.get_event_loop()
         future = loop.create_future()
         expected = _mock_sock()
         imposter = _mock_sock()
-        wshandler.state.pending_browser_requests["req-2"] = (
+        sockets.pending_browser_requests["req-2"] = (
             future,
             expected,
         )
 
-        wshandler.state.handle_browser_response(
+        sockets.handle_browser_response(
             {"id": "req-2", "status": 200}, sender=imposter
         )
 
         # Future should NOT be resolved — wrong sender
         assert not future.done()
         # Entry should still be pending
-        assert "req-2" in wshandler.state.pending_browser_requests
-        wshandler.state.pending_browser_requests.pop("req-2", None)
+        assert "req-2" in sockets.pending_browser_requests
+        sockets.pending_browser_requests.pop("req-2", None)
 
     async def test_handle_browser_response_missing_id(self):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         # Should not raise
-        wshandler.state.handle_browser_response({})
+        sockets.handle_browser_response({})
 
     async def test_handle_browser_response_unknown_id(self):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         # Should not raise
-        wshandler.state.handle_browser_response({"id": "unknown"})
+        sockets.handle_browser_response({"id": "unknown"})
 
     async def test_dispatch_browser_request_no_subscribers(self):
-        session = wshandler.state.get_or_create_session("ws-empty")
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        session = sockets.get_or_create_session("ws-empty", app_state)
         try:
             result = await session.dispatch_browser_request(
                 {"action": "fetch", "url": "http://example.com"}
@@ -3952,11 +4127,13 @@ class TestBrowserBridge:
             assert "error" in result
             assert "No browser client" in result["error"]
         finally:
-            wshandler.state.sessions.pop("ws-empty", None)
+            sockets.sessions.pop("ws-empty", None)
 
     async def test_dispatch_browser_request_cli_only(self):
         """CLI-only connections get immediate error, not 30s timeout."""
-        session = wshandler.state.get_or_create_session("ws-cli-only")
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        session = sockets.get_or_create_session("ws-cli-only", app_state)
         mock_sock = _mock_sock()
         session.subscribers.add(mock_sock)
         # No browser_subscribers — CLI never sends ui_ready
@@ -3967,10 +4144,12 @@ class TestBrowserBridge:
             assert "error" in result
             assert "No browser client" in result["error"]
         finally:
-            wshandler.state.sessions.pop("ws-cli-only", None)
+            sockets.sessions.pop("ws-cli-only", None)
 
     async def test_dispatch_browser_request_success(self):
-        session = wshandler.state.get_or_create_session("ws-bridge")
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        session = sockets.get_or_create_session("ws-bridge", app_state)
         mock_sock = _mock_sock()
         session.subscribers.add(mock_sock)
         session.browser_subscribers.add(mock_sock)
@@ -3981,7 +4160,7 @@ class TestBrowserBridge:
             for req_id, (
                 future,
                 _sock,
-            ) in wshandler.state.pending_browser_requests.items():
+            ) in sockets.pending_browser_requests.items():
                 if not future.done():
                     future.set_result(
                         {"id": req_id, "status": 200, "body": "response-data"}
@@ -4001,10 +4180,12 @@ class TestBrowserBridge:
                 await task
             except asyncio.CancelledError:
                 pass
-            wshandler.state.sessions.pop("ws-bridge", None)
+            sockets.sessions.pop("ws-bridge", None)
 
     async def test_dispatch_browser_request_timeout(self):
-        session = wshandler.state.get_or_create_session("ws-timeout")
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        session = sockets.get_or_create_session("ws-timeout", app_state)
         mock_sock = _mock_sock()
         session.subscribers.add(mock_sock)
         session.browser_subscribers.add(mock_sock)
@@ -4016,12 +4197,14 @@ class TestBrowserBridge:
             assert "error" in result
             assert "timeout" in result["error"].lower()
         finally:
-            wshandler.state.sessions.pop("ws-timeout", None)
+            sockets.sessions.pop("ws-timeout", None)
 
 
 class TestDispatchBrowserRequestTo:
     async def test_success(self):
-        session = wshandler.state.get_or_create_session("ws-to")
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        session = sockets.get_or_create_session("ws-to", app_state)
         mock_sock = _mock_sock()
         session.subscribers.add(mock_sock)
         session.browser_subscribers.add(mock_sock)
@@ -4031,7 +4214,7 @@ class TestDispatchBrowserRequestTo:
             for req_id, (
                 future,
                 _sock,
-            ) in wshandler.state.pending_browser_requests.items():
+            ) in sockets.pending_browser_requests.items():
                 if not future.done():
                     future.set_result(
                         {"id": req_id, "status": 200, "body": "targeted"}
@@ -4056,10 +4239,12 @@ class TestDispatchBrowserRequestTo:
                 await task
             except asyncio.CancelledError:
                 pass
-            wshandler.state.sessions.pop("ws-to", None)
+            sockets.sessions.pop("ws-to", None)
 
     async def test_dead_socket(self):
-        session = wshandler.state.get_or_create_session("ws-to-dead")
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        session = sockets.get_or_create_session("ws-to-dead", app_state)
         mock_sock = _mock_sock()
         mock_sock.send_json = MagicMock(side_effect=RuntimeError("ws closed"))
         session.subscribers.add(mock_sock)
@@ -4072,10 +4257,12 @@ class TestDispatchBrowserRequestTo:
             assert "error" in result
             assert "not available" in result["error"]
         finally:
-            wshandler.state.sessions.pop("ws-to-dead", None)
+            sockets.sessions.pop("ws-to-dead", None)
 
     async def test_timeout(self):
-        session = wshandler.state.get_or_create_session("ws-to-timeout")
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        session = sockets.get_or_create_session("ws-to-timeout", app_state)
         mock_sock = _mock_sock()
         session.subscribers.add(mock_sock)
         session.browser_subscribers.add(mock_sock)
@@ -4088,15 +4275,17 @@ class TestDispatchBrowserRequestTo:
             assert "error" in result
             assert "timeout" in result["error"].lower()
         finally:
-            wshandler.state.sessions.pop("ws-to-timeout", None)
+            sockets.sessions.pop("ws-to-timeout", None)
 
     async def test_cancelled_cleans_up(self):
-        session = wshandler.state.get_or_create_session("ws-to-cancel")
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        session = sockets.get_or_create_session("ws-to-cancel", app_state)
         mock_sock = _mock_sock()
         session.subscribers.add(mock_sock)
         session.browser_subscribers.add(mock_sock)
         try:
-            before = set(wshandler.state.pending_browser_requests.keys())
+            before = set(sockets.pending_browser_requests.keys())
             task = asyncio.create_task(
                 session.dispatch_browser_request_to(
                     mock_sock,
@@ -4105,79 +4294,91 @@ class TestDispatchBrowserRequestTo:
                 )
             )
             await asyncio.sleep(0.05)
-            new_ids = (
-                set(wshandler.state.pending_browser_requests.keys()) - before
-            )
+            new_ids = set(sockets.pending_browser_requests.keys()) - before
             task.cancel()
             with pytest.raises(asyncio.CancelledError):
                 await task
             for rid in new_ids:
-                assert rid not in wshandler.state.pending_browser_requests
+                assert rid not in sockets.pending_browser_requests
         finally:
-            wshandler.state.sessions.pop("ws-to-cancel", None)
+            sockets.sessions.pop("ws-to-cancel", None)
 
 
 class TestCleanupRevokesBrowser:
     async def test_cleanup_revokes_browser_registration(self):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        registry = app_state.container_registry
         sock = _mock_sock()
-        conn = _base_conn(ws=sock)
+        conn = _base_conn(ws=sock, app_state=app_state)
         conn.workspace_id = "ws-revoke"
         conn.container_id = "cid-revoke"
 
         # Register a browser ID for this connection
-        container.registry.register_browser("bid-revoke", "ws-revoke", sock)
+        registry.register_browser("bid-revoke", "ws-revoke", sock)
         conn.browser_id = "bid-revoke"
 
-        container.registry.track_activity("cid-revoke", "ws-revoke")
-        session = WorkspaceSession("ws-revoke")
+        registry.track_activity("cid-revoke", "ws-revoke")
+        session = WorkspaceSession("ws-revoke", app_state)
         session.subscribers.add(sock)
-        wshandler.state.sessions["ws-revoke"] = session
+        sockets.sessions["ws-revoke"] = session
 
         await conn.cleanup()
 
-        assert container.registry.resolve_browser("bid-revoke") is None
+        assert registry.resolve_browser("bid-revoke") is None
         assert conn.browser_id is None
 
-        container.registry.revoke_workspace_browsers("ws-revoke")
-        container.registry.states.pop("ws-revoke", None)
-        wshandler.state.sessions.pop("ws-revoke", None)
+        registry.revoke_workspace_browsers("ws-revoke")
+        registry.states.pop("ws-revoke", None)
+        sockets.sessions.pop("ws-revoke", None)
 
 
 class TestResetWorkspaceState:
     async def test_noop_for_unknown_workspace(self):
-        await reset_workspace_state("ws-unknown")  # should not raise
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        await reset_workspace_state(sockets, "ws-unknown")  # should not raise
 
     async def test_remove_session_noop_for_unknown(self):
-        await wshandler.state.remove_session("nonexistent")  # should not raise
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        await sockets.remove_session("nonexistent")  # should not raise
 
     async def test_removes_session_with_no_subscribers(self):
         """remove_session acquires lock and removes empty session."""
-        wshandler.state.get_or_create_session("ws-reset-empty")
-        assert "ws-reset-empty" in wshandler.state.sessions
-        container.registry.track_activity("cid-reset", "ws-reset-empty")
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        registry = app_state.container_registry
+        sockets.get_or_create_session("ws-reset-empty", app_state)
+        assert "ws-reset-empty" in sockets.sessions
+        registry.track_activity("cid-reset", "ws-reset-empty")
         try:
-            await reset_workspace_state("ws-reset-empty")
-            assert "ws-reset-empty" not in wshandler.state.sessions
+            await reset_workspace_state(sockets, "ws-reset-empty")
+            assert "ws-reset-empty" not in sockets.sessions
         finally:
-            wshandler.state.sessions.pop("ws-reset-empty", None)
-            container.registry.states.pop("ws-reset-empty", None)
+            sockets.sessions.pop("ws-reset-empty", None)
+            registry.states.pop("ws-reset-empty", None)
 
     async def test_remove_session_skips_if_subscribers_reappear(self):
         """remove_session re-checks subscribers under lock and aborts if non-empty."""
-        session = wshandler.state.get_or_create_session("ws-reappear")
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        session = sockets.get_or_create_session("ws-reappear", app_state)
         mock_sock = _mock_sock()
         # Add subscriber so the re-check inside the lock finds a non-empty set
         session.subscribers.add(mock_sock)
         try:
-            await wshandler.state.remove_session("ws-reappear")
+            await sockets.remove_session("ws-reappear")
             # Session should NOT have been removed
-            assert "ws-reappear" in wshandler.state.sessions
+            assert "ws-reappear" in sockets.sessions
             assert mock_sock in session.subscribers
         finally:
-            wshandler.state.sessions.pop("ws-reappear", None)
+            sockets.sessions.pop("ws-reappear", None)
 
     async def test_reset_cleans_agent_state(self):
         """reset_workspace removes agent conversations and cancels agent tasks."""
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         ws_id = "ws-agent-cleanup"
         wshandler.agent_conversations[ws_id] = {"user_id": "u1"}
 
@@ -4187,7 +4388,7 @@ class TestResetWorkspaceState:
         task = asyncio.create_task(noop())
         wshandler.agent_tasks[ws_id] = task
         try:
-            await reset_workspace_state(ws_id)
+            await reset_workspace_state(sockets, ws_id)
             assert ws_id not in wshandler.agent_conversations
             assert ws_id not in wshandler.agent_tasks
             # Let cancellation propagate
@@ -4204,35 +4405,41 @@ class TestResetWorkspaceState:
 
     async def test_reset_stops_agent_session(self):
         """reset_workspace stops the Pi RPC subprocess via agent.stop_session."""
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         ws_id = "ws-agent-stop"
         with patch(
             "klangk_backend.agent.stop_session", new_callable=AsyncMock
         ) as mock_stop:
-            await reset_workspace_state(ws_id)
+            await reset_workspace_state(sockets, ws_id)
             mock_stop.assert_awaited_once_with(ws_id)
 
 
 class TestNotifyUserWorkspacesChanged:
     """notify_user_workspaces_changed sends to a user's connections only."""
 
-    def _register(self, sock, user):
-        conn = _base_conn(user=user, ws=sock)
-        wshandler.state.connections[sock] = conn
+    def _register(self, sock, user, app_state):
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
+        app_state.sockets.connections[sock] = conn
         return conn
 
     def test_sends_to_matching_user_only(self):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         sock_a = _mock_sock()
         sock_b = _mock_sock()
         sock_other = _mock_sock()
         try:
-            self._register(sock_a, {"id": "uid-1", "email": "a@x"})
-            self._register(sock_b, {"id": "uid-1", "email": "b@x"})
-            self._register(sock_other, {"id": "uid-2", "email": "c@x"})
-            wshandler.state.notify_user_workspaces_changed("uid-1")
+            self._register(sock_a, {"id": "uid-1", "email": "a@x"}, app_state)
+            self._register(sock_b, {"id": "uid-1", "email": "b@x"}, app_state)
+            self._register(
+                sock_other, {"id": "uid-2", "email": "c@x"}, app_state
+            )
+            sockets.notify_user_workspaces_changed("uid-1")
         finally:
-            wshandler.state.connections.pop(sock_a, None)
-            wshandler.state.connections.pop(sock_b, None)
-            wshandler.state.connections.pop(sock_other, None)
+            sockets.connections.pop(sock_a, None)
+            sockets.connections.pop(sock_b, None)
+            sockets.connections.pop(sock_other, None)
         # Both of uid-1's connections were notified...
         sock_a.send_json.assert_called_once_with(
             {"type": "workspaces_changed"}
@@ -4244,40 +4451,46 @@ class TestNotifyUserWorkspacesChanged:
         sock_other.send_json.assert_not_called()
 
     def test_no_connections_is_noop(self):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         # Should not raise when the user has no active connections.
-        wshandler.state.notify_user_workspaces_changed("nobody")
+        sockets.notify_user_workspaces_changed("nobody")
 
     def test_dead_socket_is_pruned(self):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         from klangk_backend.wshandler import WS_ERRORS
 
         sock = _mock_sock()
         sock.send_json = MagicMock(side_effect=WS_ERRORS[0]("dead"))
         try:
-            self._register(sock, {"id": "uid-1", "email": "a@x"})
-            wshandler.state.notify_user_workspaces_changed("uid-1")
-            assert sock not in wshandler.state.connections
+            self._register(sock, {"id": "uid-1", "email": "a@x"}, app_state)
+            sockets.notify_user_workspaces_changed("uid-1")
+            assert sock not in sockets.connections
         finally:
-            wshandler.state.connections.pop(sock, None)
+            sockets.connections.pop(sock, None)
 
 
 class TestNotifyContainerStatus:
     """notify_container_status broadcasts to all authenticated connections."""
 
-    def _register(self, sock, user):
-        conn = _base_conn(user=user, ws=sock)
-        wshandler.state.connections[sock] = conn
+    def _register(self, sock, user, app_state):
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
+        app_state.sockets.connections[sock] = conn
         return conn
 
     def test_sends_to_all_authenticated(self):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         sock_a = _mock_sock()
         sock_b = _mock_sock()
         try:
-            self._register(sock_a, {"id": "uid-1", "email": "a@x"})
-            self._register(sock_b, {"id": "uid-2", "email": "b@x"})
-            wshandler.state.notify_container_status("ws-123", True)
+            self._register(sock_a, {"id": "uid-1", "email": "a@x"}, app_state)
+            self._register(sock_b, {"id": "uid-2", "email": "b@x"}, app_state)
+            sockets.notify_container_status("ws-123", True)
         finally:
-            wshandler.state.connections.pop(sock_a, None)
-            wshandler.state.connections.pop(sock_b, None)
+            sockets.connections.pop(sock_a, None)
+            sockets.connections.pop(sock_b, None)
         expected = {
             "type": "container_status",
             "workspace_id": "ws-123",
@@ -4287,56 +4500,64 @@ class TestNotifyContainerStatus:
         sock_b.send_json.assert_called_once_with(expected)
 
     def test_sends_stopped(self):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         sock = _mock_sock()
         try:
-            self._register(sock, {"id": "uid-1", "email": "a@x"})
-            wshandler.state.notify_container_status("ws-456", False)
+            self._register(sock, {"id": "uid-1", "email": "a@x"}, app_state)
+            sockets.notify_container_status("ws-456", False)
         finally:
-            wshandler.state.connections.pop(sock, None)
+            sockets.connections.pop(sock, None)
         msg = sock.send_json.call_args[0][0]
         assert msg["running"] is False
         assert msg["workspace_id"] == "ws-456"
 
     def test_skips_unauthenticated(self):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         sock = _mock_sock()
         try:
-            self._register(sock, {"id": None, "email": ""})
-            wshandler.state.notify_container_status("ws-1", True)
+            self._register(sock, {"id": None, "email": ""}, app_state)
+            sockets.notify_container_status("ws-1", True)
         finally:
-            wshandler.state.connections.pop(sock, None)
+            sockets.connections.pop(sock, None)
         sock.send_json.assert_not_called()
 
     def test_dead_socket_is_pruned(self):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         from klangk_backend.wshandler import WS_ERRORS
 
         sock = _mock_sock()
         sock.send_json = MagicMock(side_effect=WS_ERRORS[0]("dead"))
         try:
-            self._register(sock, {"id": "uid-1", "email": "a@x"})
-            wshandler.state.notify_container_status("ws-1", True)
-            assert sock not in wshandler.state.connections
+            self._register(sock, {"id": "uid-1", "email": "a@x"}, app_state)
+            sockets.notify_container_status("ws-1", True)
+            assert sock not in sockets.connections
         finally:
-            wshandler.state.connections.pop(sock, None)
+            sockets.connections.pop(sock, None)
 
 
 class TestNotifyServiceHealth:
     """notify_service_health fans health events out to all connections."""
 
-    def _register(self, sock, user):
-        conn = _base_conn(user=user, ws=sock)
-        wshandler.state.connections[sock] = conn
+    def _register(self, sock, user, app_state):
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
+        app_state.sockets.connections[sock] = conn
         return conn
 
     def test_sends_healthy_to_all_authenticated(self):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         sock_a = _mock_sock()
         sock_b = _mock_sock()
         try:
-            self._register(sock_a, {"id": "uid-1", "email": "a@x"})
-            self._register(sock_b, {"id": "uid-2", "email": "b@x"})
-            wshandler.state.notify_service_health("ws-123", healthy=True)
+            self._register(sock_a, {"id": "uid-1", "email": "a@x"}, app_state)
+            self._register(sock_b, {"id": "uid-2", "email": "b@x"}, app_state)
+            sockets.notify_service_health("ws-123", healthy=True)
         finally:
-            wshandler.state.connections.pop(sock_a, None)
-            wshandler.state.connections.pop(sock_b, None)
+            sockets.connections.pop(sock_a, None)
+            sockets.connections.pop(sock_b, None)
         expected = {
             "type": "service_health",
             "workspace_id": "ws-123",
@@ -4350,41 +4571,47 @@ class TestNotifyServiceHealth:
         sock_b.send_json.assert_called_once_with(expected)
 
     def test_sends_unhealthy_with_reason(self):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         # The failure reason rides along on the broadcast so operators
         # can see *why* it's unhealthy (#1088).
         sock = _mock_sock()
         try:
-            self._register(sock, {"id": "uid-1", "email": "a@x"})
-            wshandler.state.notify_service_health(
+            self._register(sock, {"id": "uid-1", "email": "a@x"}, app_state)
+            sockets.notify_service_health(
                 "ws-9", healthy=False, message="curl: connection refused"
             )
         finally:
-            wshandler.state.connections.pop(sock, None)
+            sockets.connections.pop(sock, None)
         msg = sock.send_json.call_args[0][0]
         assert msg["healthy"] is False
         assert msg["type"] == "service_health"
         assert msg["health_message"] == "curl: connection refused"
 
     def test_skips_unauthenticated(self):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         sock = _mock_sock()
         try:
-            self._register(sock, {"id": None, "email": ""})
-            wshandler.state.notify_service_health("ws-1", healthy=True)
+            self._register(sock, {"id": None, "email": ""}, app_state)
+            sockets.notify_service_health("ws-1", healthy=True)
         finally:
-            wshandler.state.connections.pop(sock, None)
+            sockets.connections.pop(sock, None)
         sock.send_json.assert_not_called()
 
     def test_dead_socket_is_pruned(self):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         from klangk_backend.wshandler import WS_ERRORS
 
         sock = _mock_sock()
         sock.send_json = MagicMock(side_effect=WS_ERRORS[0]("dead"))
         try:
-            self._register(sock, {"id": "uid-1", "email": "a@x"})
-            wshandler.state.notify_service_health("ws-1", healthy=True)
-            assert sock not in wshandler.state.connections
+            self._register(sock, {"id": "uid-1", "email": "a@x"}, app_state)
+            sockets.notify_service_health("ws-1", healthy=True)
+            assert sock not in sockets.connections
         finally:
-            wshandler.state.connections.pop(sock, None)
+            sockets.connections.pop(sock, None)
 
 
 class TestServiceHealthSnapshot:
@@ -4400,37 +4627,40 @@ class TestServiceHealthSnapshot:
 
     def test_replays_only_checked_workspaces(self):
         """Healthy + unhealthy are sent; unchecked and no-check skipped."""
-        saved = dict(container.registry.states)
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        registry = app_state.container_registry
+        saved = dict(registry.states)
         sock = _mock_sock()
         try:
-            container.registry.states.clear()
-            container.registry.states["ws-healthy"] = self._state(
+            registry.states.clear()
+            registry.states["ws-healthy"] = self._state(
                 "ws-healthy",
                 health_check="true",
                 health_status="healthy",
             )
-            container.registry.states["ws-sick"] = self._state(
+            registry.states["ws-sick"] = self._state(
                 "ws-sick",
                 health_check="curl localhost",
                 health_status="unhealthy",
                 message="conn refused",
             )
             # health check configured but never polled yet
-            container.registry.states["ws-unchecked"] = self._state(
+            registry.states["ws-unchecked"] = self._state(
                 "ws-unchecked",
                 health_check="true",
                 health_status=None,
             )
             # no health check at all (plain dev workspace)
-            container.registry.states["ws-nocheck"] = self._state(
+            registry.states["ws-nocheck"] = self._state(
                 "ws-nocheck",
                 health_check=None,
                 health_status=None,
             )
-            wshandler.state.send_service_health_snapshot(sock)
+            sockets.send_service_health_snapshot(sock)
         finally:
-            container.registry.states.clear()
-            container.registry.states.update(saved)
+            registry.states.clear()
+            registry.states.update(saved)
 
         frames = [c[0][0] for c in sock.send_json.call_args_list]
         assert len(frames) == 2
@@ -4445,56 +4675,65 @@ class TestServiceHealthSnapshot:
             assert f["type"] == "service_health"
 
     def test_targets_only_the_given_socket(self):
-        saved = dict(container.registry.states)
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        registry = app_state.container_registry
+        saved = dict(registry.states)
         sock = _mock_sock()
         other = _mock_sock()
         try:
-            container.registry.states.clear()
-            container.registry.states["ws-1"] = self._state(
+            registry.states.clear()
+            registry.states["ws-1"] = self._state(
                 "ws-1",
                 health_check="true",
                 health_status="healthy",
             )
-            wshandler.state.send_service_health_snapshot(sock)
+            sockets.send_service_health_snapshot(sock)
         finally:
-            container.registry.states.clear()
-            container.registry.states.update(saved)
+            registry.states.clear()
+            registry.states.update(saved)
         sock.send_json.assert_called_once()
         other.send_json.assert_not_called()
 
     def test_dead_socket_breaks_cleanly(self):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        registry = app_state.container_registry
         from klangk_backend.wshandler import WS_ERRORS
 
-        saved = dict(container.registry.states)
+        saved = dict(registry.states)
         sock = _mock_sock()
         sock.send_json = MagicMock(side_effect=WS_ERRORS[0]("dead"))
         try:
-            container.registry.states.clear()
-            container.registry.states["ws-1"] = self._state(
+            registry.states.clear()
+            registry.states["ws-1"] = self._state(
                 "ws-1",
                 health_check="true",
                 health_status="healthy",
             )
-            container.registry.states["ws-2"] = self._state(
+            registry.states["ws-2"] = self._state(
                 "ws-2",
                 health_check="true",
                 health_status="unhealthy",
             )
             # Must not raise; the dead socket ends the snapshot early.
-            wshandler.state.send_service_health_snapshot(sock)
+            sockets.send_service_health_snapshot(sock)
         finally:
-            container.registry.states.clear()
-            container.registry.states.update(saved)
+            registry.states.clear()
+            registry.states.update(saved)
 
     def test_empty_registry_sends_nothing(self):
-        saved = dict(container.registry.states)
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        registry = app_state.container_registry
+        saved = dict(registry.states)
         sock = _mock_sock()
         try:
-            container.registry.states.clear()
-            wshandler.state.send_service_health_snapshot(sock)
+            registry.states.clear()
+            sockets.send_service_health_snapshot(sock)
         finally:
-            container.registry.states.clear()
-            container.registry.states.update(saved)
+            registry.states.clear()
+            registry.states.update(saved)
         sock.send_json.assert_not_called()
 
 
@@ -4548,18 +4787,20 @@ class TestServiceHealthFrame:
 class TestNotifyServiceHealthForwarding:
     """notify_service_health forwards running/checked_at/seq (#1175)."""
 
-    def _register(self, sock, user):
-        conn = _base_conn(user=user, ws=sock)
-        wshandler.state.connections[sock] = conn
+    def _register(self, sock, user, app_state):
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
+        app_state.sockets.connections[sock] = conn
         return conn
 
     def test_forwards_death_frame_fields(self):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         # A container-death call passes running=False + a seq; the frame
         # a subscriber receives carries them (#1175 items 2, 4).
         sock = _mock_sock()
         try:
-            self._register(sock, {"id": "uid-1", "email": "a@x"})
-            wshandler.state.notify_service_health(
+            self._register(sock, {"id": "uid-1", "email": "a@x"}, app_state)
+            sockets.notify_service_health(
                 "ws-9",
                 healthy=False,
                 running=False,
@@ -4567,7 +4808,7 @@ class TestNotifyServiceHealthForwarding:
                 seq=3,
             )
         finally:
-            wshandler.state.connections.pop(sock, None)
+            sockets.connections.pop(sock, None)
         msg = sock.send_json.call_args[0][0]
         assert msg["running"] is False
         assert msg["healthy"] is False
@@ -4588,17 +4829,20 @@ class TestServiceHealthSnapshotFields:
         return cs
 
     def test_snapshot_frame_carries_live_fields(self):
-        saved = dict(container.registry.states)
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        registry = app_state.container_registry
+        saved = dict(registry.states)
         sock = _mock_sock()
         try:
-            container.registry.states.clear()
-            container.registry.states["ws-1"] = self._state(
+            registry.states.clear()
+            registry.states["ws-1"] = self._state(
                 "ws-1", checked_at=1_700_000_000.0, seq=5
             )
-            wshandler.state.send_service_health_snapshot(sock)
+            sockets.send_service_health_snapshot(sock)
         finally:
-            container.registry.states.clear()
-            container.registry.states.update(saved)
+            registry.states.clear()
+            registry.states.update(saved)
         frame = sock.send_json.call_args[0][0]
         # A snapshot is a live-container replay: running=True.
         assert frame["running"] is True
@@ -4609,25 +4853,31 @@ class TestServiceHealthSnapshotFields:
 class TestHealthHeartbeat:
     """send_health_heartbeats: opt-in liveness frames (#1175 item 3b)."""
 
-    def _register(self, sock, user, *, wants=False):
-        conn = _base_conn(user=user, ws=sock)
+    def _register(self, sock, user, app_state, *, wants=False):
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.wants_health_heartbeat = wants
-        wshandler.state.connections[sock] = conn
+        app_state.sockets.connections[sock] = conn
         return conn
 
     def _frame(self, sock):
         return sock.send_json.call_args[0][0]
 
     def test_only_opted_in_connections_receive_it(self):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         opted = _mock_sock()
         quiet = _mock_sock()
         try:
-            self._register(opted, {"id": "u1", "email": "a@x"}, wants=True)
-            self._register(quiet, {"id": "u2", "email": "b@x"}, wants=False)
-            wshandler.state.send_health_heartbeats()
+            self._register(
+                opted, {"id": "u1", "email": "a@x"}, app_state, wants=True
+            )
+            self._register(
+                quiet, {"id": "u2", "email": "b@x"}, app_state, wants=False
+            )
+            sockets.send_health_heartbeats()
         finally:
-            wshandler.state.connections.pop(opted, None)
-            wshandler.state.connections.pop(quiet, None)
+            sockets.connections.pop(opted, None)
+            sockets.connections.pop(quiet, None)
         opted.send_json.assert_called_once()
         frame = self._frame(opted)
         assert frame["type"] == "service_health_heartbeat"
@@ -4636,78 +4886,96 @@ class TestHealthHeartbeat:
         quiet.send_json.assert_not_called()
 
     def test_skips_unauthenticated(self):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         sock = _mock_sock()
         try:
-            self._register(sock, {"id": None, "email": ""}, wants=True)
-            wshandler.state.send_health_heartbeats()
+            self._register(
+                sock, {"id": None, "email": ""}, app_state, wants=True
+            )
+            sockets.send_health_heartbeats()
         finally:
-            wshandler.state.connections.pop(sock, None)
+            sockets.connections.pop(sock, None)
         sock.send_json.assert_not_called()
 
     def test_dead_opted_in_socket_is_pruned(self):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         from klangk_backend.wshandler import WS_ERRORS
 
         sock = _mock_sock()
         sock.send_json = MagicMock(side_effect=WS_ERRORS[0]("dead"))
         try:
-            self._register(sock, {"id": "u1", "email": "a@x"}, wants=True)
-            wshandler.state.send_health_heartbeats()
-            assert sock not in wshandler.state.connections
+            self._register(
+                sock, {"id": "u1", "email": "a@x"}, app_state, wants=True
+            )
+            sockets.send_health_heartbeats()
+            assert sock not in sockets.connections
         finally:
-            wshandler.state.connections.pop(sock, None)
+            sockets.connections.pop(sock, None)
 
     def test_subscribe_command_toggles_flag(self):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         # The subscribe_health_heartbeat command flips the per-connection
         # flag; enabled defaults to True when omitted.
         sock = _mock_sock()
         try:
-            conn = self._register(sock, {"id": "u1", "email": "a@x"})
-            assert conn.wants_health_heartbeat is False
-            wshandler.state.handle_subscribe_health_heartbeat({}, sock)
-            assert conn.wants_health_heartbeat is True
-            wshandler.state.handle_subscribe_health_heartbeat(
-                {"enabled": False}, sock
+            conn = self._register(
+                sock, {"id": "u1", "email": "a@x"}, app_state
             )
             assert conn.wants_health_heartbeat is False
+            sockets.handle_subscribe_health_heartbeat({}, sock)
+            assert conn.wants_health_heartbeat is True
+            sockets.handle_subscribe_health_heartbeat({"enabled": False}, sock)
+            assert conn.wants_health_heartbeat is False
         finally:
-            wshandler.state.connections.pop(sock, None)
+            sockets.connections.pop(sock, None)
 
     def test_subscribe_unknown_socket_is_noop(self):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         sock = _mock_sock()
         # Not registered -- must not raise.
-        wshandler.state.handle_subscribe_health_heartbeat({}, sock)
+        sockets.handle_subscribe_health_heartbeat({}, sock)
 
 
 class TestRemoveSessionLocked:
     async def test_removes_session(self):
-        session = wshandler.state.get_or_create_session("ws-locked-rm")
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        session = sockets.get_or_create_session("ws-locked-rm", app_state)
         try:
             async with session.lock:
-                await state.remove_session_locked(session)
-            assert "ws-locked-rm" not in wshandler.state.sessions
+                await sockets.remove_session_locked(session)
+            assert "ws-locked-rm" not in sockets.sessions
         finally:
-            wshandler.state.sessions.pop("ws-locked-rm", None)
+            sockets.sessions.pop("ws-locked-rm", None)
 
 
 class TestGetOrCreateSessionAtomicity:
     async def test_returns_same_session_for_same_workspace(self):
         """Concurrent calls return the same WorkspaceSession, not duplicates."""
-        wshandler.state.sessions.pop("ws-atomic", None)
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        sockets.sessions.pop("ws-atomic", None)
         try:
-            s1 = wshandler.state.get_or_create_session("ws-atomic")
-            s2 = wshandler.state.get_or_create_session("ws-atomic")
+            s1 = sockets.get_or_create_session("ws-atomic", app_state)
+            s2 = sockets.get_or_create_session("ws-atomic", app_state)
             assert s1 is s2
         finally:
-            wshandler.state.sessions.pop("ws-atomic", None)
+            sockets.sessions.pop("ws-atomic", None)
 
     async def test_concurrent_get_or_create_via_gather(self):
         """Two coroutines that both call get_or_create_session end up
         with the identical session object (no orphaned duplicates)."""
-        wshandler.state.sessions.pop("ws-gather", None)
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        sockets.sessions.pop("ws-gather", None)
         sessions = []
 
         async def grab():
-            s = wshandler.state.get_or_create_session("ws-gather")
+            s = sockets.get_or_create_session("ws-gather", app_state)
             await asyncio.sleep(0)  # yield to let the other coroutine run
             sessions.append(s)
 
@@ -4716,19 +4984,21 @@ class TestGetOrCreateSessionAtomicity:
             assert len(sessions) == 2
             assert sessions[0] is sessions[1]
         finally:
-            wshandler.state.sessions.pop("ws-gather", None)
+            sockets.sessions.pop("ws-gather", None)
 
 
 class TestCleanupSubscriberRace:
     async def test_new_subscriber_not_lost_during_cleanup(self):
         """A subscriber added under the lock while cleanup runs is not lost."""
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         sock1 = _mock_sock()
         sock2 = _mock_sock()
-        session = WorkspaceSession("ws-race")
+        session = WorkspaceSession("ws-race", app_state)
         session.subscribers.add(sock1)
-        wshandler.state.sessions["ws-race"] = session
+        sockets.sessions["ws-race"] = session
 
-        conn = _base_conn(ws=sock1)
+        conn = _base_conn(ws=sock1, app_state=app_state)
         conn.workspace_id = "ws-race"
         conn.container_id = "cid-race"
 
@@ -4740,28 +5010,30 @@ class TestCleanupSubscriberRace:
         await conn.cleanup()
 
         # Session should be removed since sock1 was the last subscriber
-        assert "ws-race" not in wshandler.state.sessions
+        assert "ws-race" not in sockets.sessions
 
         # Now create a fresh session for sock2 (simulating start_workspace_container)
-        session2 = wshandler.state.get_or_create_session("ws-race")
+        session2 = sockets.get_or_create_session("ws-race", app_state)
         async with session2.lock:
             session2.subscribers.add(sock2)
 
         assert sock2 in session2.subscribers
-        assert "ws-race" in wshandler.state.sessions
+        assert "ws-race" in sockets.sessions
 
-        wshandler.state.sessions.pop("ws-race", None)
+        sockets.sessions.pop("ws-race", None)
 
     async def test_concurrent_cleanup_and_add(self):
         """When cleanup holds the lock, a concurrent add waits and is not lost."""
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         sock1 = _mock_sock()
         sock2 = _mock_sock()
-        session = WorkspaceSession("ws-conc")
+        session = WorkspaceSession("ws-conc", app_state)
         session.subscribers.add(sock1)
         session.subscribers.add(sock2)
-        wshandler.state.sessions["ws-conc"] = session
+        sockets.sessions["ws-conc"] = session
 
-        conn1 = _base_conn(ws=sock1)
+        conn1 = _base_conn(ws=sock1, app_state=app_state)
         conn1.workspace_id = "ws-conc"
         conn1.container_id = "cid-conc"
 
@@ -4775,15 +5047,16 @@ class TestCleanupSubscriberRace:
             await conn1.cleanup()
 
         # Session should still exist because sock2 is still subscribed
-        assert "ws-conc" in wshandler.state.sessions
+        assert "ws-conc" in sockets.sessions
         assert sock2 in session.subscribers
         assert sock1 not in session.subscribers
 
-        wshandler.state.sessions.pop("ws-conc", None)
+        sockets.sessions.pop("ws-conc", None)
 
 
 class TestWsDebugLogging:
     async def test_recv_logged_when_debug(self, user, monkeypatch):
+        app_state = _make_app_state()
         from klangk_backend import auth as auth_mod
 
         monkeypatch.setattr(wshandler, "WS_DEBUG", True)
@@ -4795,7 +5068,7 @@ class TestWsDebugLogging:
                 WebSocketDisconnect(),
             ]
         )
-        await handle_websocket(websocket)
+        await handle_websocket(websocket, app_state)
         websocket.accept.assert_awaited_once()
 
     def test_send_error_logged_when_debug(self, monkeypatch):
@@ -4805,24 +5078,28 @@ class TestWsDebugLogging:
         sock.send_json.assert_called_once()
 
     async def test_broadcast_sends_to_subscribers(self):
-        session = wshandler.state.get_or_create_session("ws-bcast")
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        session = sockets.get_or_create_session("ws-bcast", app_state)
         mock_sock = _mock_sock()
         session.subscribers.add(mock_sock)
         try:
             delivered = session.broadcast({"type": "test"})
             assert delivered == 1
         finally:
-            wshandler.state.sessions.pop("ws-bcast", None)
+            sockets.sessions.pop("ws-bcast", None)
 
     async def test_broadcast_to_browsers_sends_to_browser_subscribers(self):
-        session = wshandler.state.get_or_create_session("ws-browser-bcast")
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        session = sockets.get_or_create_session("ws-browser-bcast", app_state)
         mock_sock = _mock_sock()
         session.browser_subscribers.add(mock_sock)
         try:
             delivered = session.broadcast_to_browsers({"type": "test"})
             assert delivered == 1
         finally:
-            wshandler.state.sessions.pop("ws-browser-bcast", None)
+            sockets.sessions.pop("ws-browser-bcast", None)
 
 
 class TestLogWsMsg:
@@ -4860,7 +5137,9 @@ class TestLogWsMsg:
 
 class TestBroadcastDeadSubscribers:
     async def test_dead_subscriber_removed(self):
-        session = wshandler.state.get_or_create_session("ws-dead-sub")
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        session = sockets.get_or_create_session("ws-dead-sub", app_state)
         live_sock = _mock_sock()
         dead_sock = _mock_sock()
         dead_sock.send_json = MagicMock(side_effect=RuntimeError("ws closed"))
@@ -4872,7 +5151,7 @@ class TestBroadcastDeadSubscribers:
             assert dead_sock not in session.subscribers
             assert live_sock in session.subscribers
         finally:
-            wshandler.state.sessions.pop("ws-dead-sub", None)
+            sockets.sessions.pop("ws-dead-sub", None)
 
 
 class TestHandleRestartContainer:
@@ -4913,17 +5192,19 @@ class TestHandleRestartContainer:
     async def test_restart_deny_leaves_other_connections_untouched(self, user):
         """A spectator's denied restart must not change other users'
         container_id or otherwise disrupt their session (issue #873)."""
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         sock1 = _mock_sock(headers={"host": "localhost:8997"})
         sock2 = _mock_sock()
         ws = await _create_workspace_with_acl(user["id"], "restart-deny")
-        conn1 = _base_conn(user=user, ws=sock1)
-        conn2 = _base_conn(user=user, ws=sock2)
+        conn1 = _base_conn(user=user, ws=sock1, app_state=app_state)
+        conn2 = _base_conn(user=user, ws=sock2, app_state=app_state)
         conn1.workspace_id = ws["id"]
         conn1.container_id = "cid"
         conn2.workspace_id = ws["id"]
         conn2.container_id = "cid"
-        wshandler.state.connections[sock1] = conn1
-        wshandler.state.connections[sock2] = conn2
+        sockets.connections[sock1] = conn1
+        sockets.connections[sock2] = conn2
         try:
             # conn1 is a spectator: admin denied.
             with (
@@ -4942,14 +5223,16 @@ class TestHandleRestartContainer:
             assert conn2.container_id == "cid"
             mock_start.assert_not_called()
         finally:
-            wshandler.state.connections.pop(sock1, None)
-            wshandler.state.connections.pop(sock2, None)
-            wshandler.state.sessions.pop(ws["id"], None)
+            sockets.connections.pop(sock1, None)
+            sockets.connections.pop(sock2, None)
+            sockets.sessions.pop(ws["id"], None)
 
     async def test_restart_success(self, user):
+        app_state = _make_app_state()
+        registry = app_state.container_registry
         sock = _mock_sock(headers={"host": "localhost:8997"})
         workspace = await _create_workspace_with_acl(user["id"], "restart-ws")
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.workspace_id = workspace["id"]
         conn.container_id = "cid-old"
         conn.workspace = workspace
@@ -4965,13 +5248,13 @@ class TestHandleRestartContainer:
                 side_effect=fake_start,
             ),
             patch.object(
-                container.registry,
+                registry,
                 "stop_and_remove_container",
                 new_callable=AsyncMock,
             ),
-            patch.object(container.registry, "record_activity"),
+            patch.object(registry, "record_activity"),
             patch.object(
-                container.registry,
+                registry,
                 "get_workspace_ports",
                 return_value=[9000],
             ),
@@ -4997,8 +5280,10 @@ class TestHandleRestartContainer:
         assert len(ready_events) == 1
 
     async def test_restart_workspace_gone(self, user):
+        app_state = _make_app_state()
+        registry = app_state.container_registry
         sock = _mock_sock(headers={"host": "localhost:8997"})
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.workspace_id = "ws-gone"
         conn.container_id = "cid-gone"
         conn.workspace = None
@@ -5013,7 +5298,7 @@ class TestHandleRestartContainer:
                 return_value=None,
             ),
             patch.object(
-                container.registry,
+                registry,
                 "stop_and_remove_container",
                 new_callable=AsyncMock,
             ),
@@ -5024,12 +5309,14 @@ class TestHandleRestartContainer:
         assert any("not found" in str(c) for c in calls)
 
     async def test_restart_fractional_timeout(self, user, monkeypatch):
+        app_state = _make_app_state()
+        registry = app_state.container_registry
         monkeypatch.setattr(container, "IDLE_TIMEOUT_SECONDS", 90)
         sock = _mock_sock(headers={"host": "localhost:8997"})
         workspace = await _create_workspace_with_acl(
             user["id"], "restart-frac"
         )
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.workspace_id = workspace["id"]
         conn.container_id = "cid-frac"
         conn.workspace = workspace
@@ -5045,13 +5332,13 @@ class TestHandleRestartContainer:
                 side_effect=fake_start,
             ),
             patch.object(
-                container.registry,
+                registry,
                 "stop_and_remove_container",
                 new_callable=AsyncMock,
             ),
-            patch.object(container.registry, "record_activity"),
+            patch.object(registry, "record_activity"),
             patch.object(
-                container.registry,
+                registry,
                 "get_workspace_ports",
                 return_value=[],
             ),
@@ -5070,9 +5357,11 @@ class TestHandleRestartContainer:
         assert "1.5m" in ready[0]["event"]["value"]["reason"]
 
     async def test_restart_cleanup_error(self, user):
+        app_state = _make_app_state()
+        registry = app_state.container_registry
         sock = _mock_sock(headers={"host": "localhost:8997"})
         workspace = await _create_workspace_with_acl(user["id"], "restart-err")
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.workspace_id = workspace["id"]
         conn.container_id = "cid-err"
         conn.workspace = workspace
@@ -5095,9 +5384,9 @@ class TestHandleRestartContainer:
                 "start_workspace_container",
                 side_effect=fake_start,
             ),
-            patch.object(container.registry, "record_activity"),
+            patch.object(registry, "record_activity"),
             patch.object(
-                container.registry,
+                registry,
                 "get_workspace_ports",
                 return_value=[],
             ),
@@ -5115,11 +5404,13 @@ class TestHandleRestartContainer:
         assert len(ready) == 1
 
     async def test_restart_cleanup_ws_disconnect(self, user):
+        app_state = _make_app_state()
+        registry = app_state.container_registry
         sock = _mock_sock(headers={"host": "localhost:8997"})
         workspace = await _create_workspace_with_acl(
             user["id"], "restart-disc"
         )
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.workspace_id = workspace["id"]
         conn.container_id = "cid-disc"
         conn.workspace = workspace
@@ -5142,9 +5433,9 @@ class TestHandleRestartContainer:
                 "start_workspace_container",
                 side_effect=fake_start,
             ),
-            patch.object(container.registry, "record_activity"),
+            patch.object(registry, "record_activity"),
             patch.object(
-                container.registry,
+                registry,
                 "get_workspace_ports",
                 return_value=[],
             ),
@@ -5162,24 +5453,27 @@ class TestHandleRestartContainer:
         assert len(ready) == 1
 
     async def test_restart_updates_other_connections_container_id(self, user):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        registry = app_state.container_registry
         sock1 = _mock_sock(headers={"host": "localhost:8997"})
         sock2 = _mock_sock()
         workspace = await _create_workspace_with_acl(user["id"], "restart-cid")
-        conn1 = _base_conn(user=user, ws=sock1)
-        conn2 = _base_conn(user=user, ws=sock2)
+        conn1 = _base_conn(user=user, ws=sock1, app_state=app_state)
+        conn2 = _base_conn(user=user, ws=sock2, app_state=app_state)
         conn1.workspace_id = workspace["id"]
         conn1.container_id = "old-cid"
         conn1.workspace = workspace
         conn2.workspace_id = workspace["id"]
         conn2.container_id = "old-cid"
 
-        wshandler.state.connections[sock1] = conn1
-        wshandler.state.connections[sock2] = conn2
+        sockets.connections[sock1] = conn1
+        sockets.connections[sock2] = conn2
 
         async def fake_start(self_arg, wid, ws_obj):
             self_arg.container_id = "new-cid"
             self_arg.workspace_id = wid
-            wshandler.state.get_or_create_session(wid)
+            sockets.get_or_create_session(wid, app_state)
 
         with (
             patch.object(
@@ -5188,9 +5482,9 @@ class TestHandleRestartContainer:
                 autospec=True,
                 side_effect=fake_start,
             ),
-            patch.object(container.registry, "record_activity"),
+            patch.object(registry, "record_activity"),
             patch.object(
-                container.registry,
+                registry,
                 "get_workspace_ports",
                 return_value=[],
             ),
@@ -5199,9 +5493,9 @@ class TestHandleRestartContainer:
 
         assert conn2.container_id == "new-cid"
 
-        wshandler.state.connections.pop(sock1, None)
-        wshandler.state.connections.pop(sock2, None)
-        wshandler.state.sessions.pop(workspace["id"], None)
+        sockets.connections.pop(sock1, None)
+        sockets.connections.pop(sock2, None)
+        sockets.sessions.pop(workspace["id"], None)
 
 
 class TestHandleShutdownContainer:
@@ -5218,14 +5512,16 @@ class TestHandleShutdownContainer:
     async def test_shutdown_no_admin_perm(self):
         """A spectator (no admin perm) must not shut down the container,
         must not stop it, and must not broadcast container_stopped."""
+        app_state = _make_app_state()
+        registry = app_state.container_registry
         sock = _mock_sock()
-        conn = _base_conn(ws=sock)
+        conn = _base_conn(ws=sock, app_state=app_state)
         conn.workspace_id = "ws-noadmin"
         conn.container_id = "cid"
         with (
             patch.object(conn, "_has_perm", new=AsyncMock(return_value=False)),
             patch.object(
-                container.registry,
+                registry,
                 "stop_and_remove_container",
                 new_callable=AsyncMock,
             ) as mock_stop,
@@ -5248,24 +5544,27 @@ class TestHandleShutdownContainer:
     async def test_shutdown_deny_does_not_clear_other_connections(self, user):
         """A spectator's denied shutdown must not clear other users'
         container_id (which would disrupt their session) — issue #873."""
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        registry = app_state.container_registry
         sock1 = _mock_sock()
         sock2 = _mock_sock()
         ws = await _create_workspace_with_acl(user["id"], "shutdown-deny")
-        conn1 = _base_conn(user=user, ws=sock1)
-        conn2 = _base_conn(user=user, ws=sock2)
+        conn1 = _base_conn(user=user, ws=sock1, app_state=app_state)
+        conn2 = _base_conn(user=user, ws=sock2, app_state=app_state)
         conn1.workspace_id = ws["id"]
         conn1.container_id = "cid"
         conn2.workspace_id = ws["id"]
         conn2.container_id = "cid"
-        wshandler.state.connections[sock1] = conn1
-        wshandler.state.connections[sock2] = conn2
+        sockets.connections[sock1] = conn1
+        sockets.connections[sock2] = conn2
         try:
             with (
                 patch.object(
                     conn1, "_has_perm", new=AsyncMock(return_value=False)
                 ),
                 patch.object(
-                    container.registry,
+                    registry,
                     "stop_and_remove_container",
                     new_callable=AsyncMock,
                 ) as mock_stop,
@@ -5275,9 +5574,9 @@ class TestHandleShutdownContainer:
             assert conn2.container_id == "cid"
             mock_stop.assert_not_called()
         finally:
-            wshandler.state.connections.pop(sock1, None)
-            wshandler.state.connections.pop(sock2, None)
-            wshandler.state.sessions.pop(ws["id"], None)
+            sockets.connections.pop(sock1, None)
+            sockets.connections.pop(sock2, None)
+            sockets.sessions.pop(ws["id"], None)
 
     async def test_shutdown_no_container(self):
         sock = _mock_sock()
@@ -5293,19 +5592,22 @@ class TestHandleShutdownContainer:
         )
 
     async def test_shutdown_broadcasts_stopped(self, user):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        registry = app_state.container_registry
         sock1 = _mock_sock()
         sock2 = _mock_sock()
-        conn = _base_conn(user=user, ws=sock1)
+        conn = _base_conn(user=user, ws=sock1, app_state=app_state)
         ws = await _create_workspace_with_acl(user["id"], "shutdown-ws")
         conn.workspace_id = ws["id"]
         conn.container_id = "cid"
 
-        session = wshandler.state.get_or_create_session(ws["id"])
+        session = sockets.get_or_create_session(ws["id"], app_state)
         await session.add_subscriber(sock1, "cid")
         await session.add_subscriber(sock2, "cid")
 
         with patch.object(
-            container.registry,
+            registry,
             "stop_and_remove_container",
             new_callable=AsyncMock,
         ):
@@ -5323,27 +5625,30 @@ class TestHandleShutdownContainer:
                 for m in sent
             ), "container_stopped not sent to subscriber"
 
-        wshandler.state.sessions.pop(ws["id"], None)
+        sockets.sessions.pop(ws["id"], None)
 
     async def test_shutdown_stops_agent_session(self, user):
         """handle_shutdown_container stops the agent RPC subprocess."""
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        registry = app_state.container_registry
         sock = _mock_sock()
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         ws = await _create_workspace_with_acl(user["id"], "shutdown-agent")
         conn.workspace_id = ws["id"]
         conn.container_id = "cid"
 
-        session = wshandler.state.get_or_create_session(ws["id"])
+        session = sockets.get_or_create_session(ws["id"], app_state)
         await session.add_subscriber(sock, "cid")
 
         # The on_workspace_killed callback also routes to reset_workspace,
         # so disable it here to measure only the explicit teardown call.
-        old_cb = container.registry.on_workspace_killed
-        container.registry.on_workspace_killed = None
+        old_cb = registry.on_workspace_killed
+        registry.on_workspace_killed = None
         try:
             with (
                 patch.object(
-                    container.registry,
+                    registry,
                     "stop_and_remove_container",
                     new_callable=AsyncMock,
                 ),
@@ -5355,28 +5660,31 @@ class TestHandleShutdownContainer:
                 await conn.handle_shutdown_container()
             mock_stop.assert_awaited_once_with(ws["id"])
         finally:
-            container.registry.on_workspace_killed = old_cb
-            wshandler.state.sessions.pop(ws["id"], None)
+            registry.on_workspace_killed = old_cb
+            sockets.sessions.pop(ws["id"], None)
 
     async def test_shutdown_clears_other_connections_container_id(self, user):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        registry = app_state.container_registry
         sock1 = _mock_sock()
         sock2 = _mock_sock()
-        conn1 = _base_conn(user=user, ws=sock1)
-        conn2 = _base_conn(user=user, ws=sock2)
+        conn1 = _base_conn(user=user, ws=sock1, app_state=app_state)
+        conn2 = _base_conn(user=user, ws=sock2, app_state=app_state)
         ws = await _create_workspace_with_acl(user["id"], "shutdown-cid")
         conn1.workspace_id = ws["id"]
         conn1.container_id = "old-cid"
         conn2.workspace_id = ws["id"]
         conn2.container_id = "old-cid"
 
-        session = wshandler.state.get_or_create_session(ws["id"])
+        session = sockets.get_or_create_session(ws["id"], app_state)
         await session.add_subscriber(sock1, "old-cid")
         await session.add_subscriber(sock2, "old-cid")
-        wshandler.state.connections[sock1] = conn1
-        wshandler.state.connections[sock2] = conn2
+        sockets.connections[sock1] = conn1
+        sockets.connections[sock2] = conn2
 
         with patch.object(
-            container.registry,
+            registry,
             "stop_and_remove_container",
             new_callable=AsyncMock,
         ):
@@ -5384,22 +5692,25 @@ class TestHandleShutdownContainer:
 
         assert conn2.container_id is None
 
-        wshandler.state.connections.pop(sock1, None)
-        wshandler.state.connections.pop(sock2, None)
-        wshandler.state.sessions.pop(ws["id"], None)
+        sockets.connections.pop(sock1, None)
+        sockets.connections.pop(sock2, None)
+        sockets.sessions.pop(ws["id"], None)
 
     async def test_shutdown_handles_stop_error(self, user):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        registry = app_state.container_registry
         sock = _mock_sock()
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         ws = await _create_workspace_with_acl(user["id"], "shutdown-err")
         conn.workspace_id = ws["id"]
         conn.container_id = "cid"
 
-        session = wshandler.state.get_or_create_session(ws["id"])
+        session = sockets.get_or_create_session(ws["id"], app_state)
         await session.add_subscriber(sock, "cid")
 
         with patch.object(
-            container.registry,
+            registry,
             "stop_and_remove_container",
             new_callable=AsyncMock,
             side_effect=RuntimeError("podman broke"),
@@ -5413,9 +5724,10 @@ class TestHandleShutdownContainer:
             and m.get("event", {}).get("name") == "container_stopped"
             for m in sent
         )
-        wshandler.state.sessions.pop(ws["id"], None)
+        sockets.sessions.pop(ws["id"], None)
 
     async def test_shutdown_dispatch(self, user):
+        app_state = _make_app_state()
         from klangk_backend import auth as auth_mod
 
         token = auth_mod.create_token(user["id"], user["email"])
@@ -5426,7 +5738,7 @@ class TestHandleShutdownContainer:
                 WebSocketDisconnect(),
             ]
         )
-        await handle_websocket(websocket)
+        await handle_websocket(websocket, app_state)
         sent = [c[0][0] for c in websocket.send_json.call_args_list]
         assert any(
             isinstance(m, dict) and "Not connected" in str(m) for m in sent
@@ -5540,7 +5852,7 @@ class TestTerminalWindowHandlers:
         """Closing a shared window broadcasts updated shared_terminals."""
         async with _conn_in_workspace(
             user, "ws-1", user_home="/home/admin"
-        ) as (sock, conn, session):
+        ) as (sock, conn, session, app_state):
             session.terminal_windows[user["id"]] = [
                 {"name": "bash", "index": 0, "id": "@0", "shared": True},
                 {"name": "1", "index": 1, "id": "@1", "shared": False},
@@ -5672,6 +5984,7 @@ class TestTerminalController:
         sock=None,
         has_perm=True,
         user=None,
+        app_state=None,
     ):
         if sock is None:
             sock = _mock_sock()
@@ -5681,6 +5994,8 @@ class TestTerminalController:
                 "email": "alice@example.com",
                 "handle": "alice",
             }
+        if app_state is None:
+            app_state = _make_app_state()
         conn = SimpleNamespace(
             sock=sock,
             container_id=container_id,
@@ -5694,6 +6009,7 @@ class TestTerminalController:
             workspace=None,
             _has_perm=AsyncMock(return_value=has_perm),
             broadcast_shared_terminals=MagicMock(),
+            app_state=app_state,
         )
         return TerminalController(conn), sock, conn
 
@@ -5766,7 +6082,9 @@ class TestTerminalController:
         sock.send_json.assert_not_called()
 
     async def test_start_stops_existing_terminal_first(self):
-        ctrl, _, conn = self._controller()
+        app_state = _make_app_state()
+        registry = app_state.container_registry
+        ctrl, _, conn = self._controller(app_state=app_state)
 
         def _swallow(coro, **kw):
             # Close the coroutine so it doesn't warn about being
@@ -5783,7 +6101,7 @@ class TestTerminalController:
                 "klangk_backend.wshandler.controllers.asyncio.create_task",
                 _swallow,
             ),
-            patch.object(container.registry, "record_activity"),
+            patch.object(registry, "record_activity"),
         ):
             MockTS.return_value.start = AsyncMock()
             await ctrl.start({"cols": 90, "rows": 30})
@@ -5816,12 +6134,14 @@ class TestTerminalController:
         session.write.assert_not_awaited()
 
     async def test_input_read_only_allows_escape_sequences(self):
-        ctrl, _, _ = self._controller()
+        app_state = _make_app_state()
+        registry = app_state.container_registry
+        ctrl, _, _ = self._controller(app_state=app_state)
         session = AsyncMock()
         session.is_alive = True
         session.read_only = True
         ctrl.session = session
-        with patch.object(container.registry, "record_activity"):
+        with patch.object(registry, "record_activity"):
             await ctrl.input({"data": "\x1b[6n"})
         session.write.assert_awaited_once_with("\x1b[6n")
 
@@ -5835,12 +6155,14 @@ class TestTerminalController:
         session.write.assert_not_awaited()
 
     async def test_input_writes_and_records_activity(self):
-        ctrl, _, _ = self._controller()
+        app_state = _make_app_state()
+        registry = app_state.container_registry
+        ctrl, _, _ = self._controller(app_state=app_state)
         session = AsyncMock()
         session.is_alive = True
         session.read_only = False
         ctrl.session = session
-        with patch.object(container.registry, "record_activity") as rec:
+        with patch.object(registry, "record_activity") as rec:
             await ctrl.input({"data": "ls"})
         session.write.assert_awaited_once_with("ls")
         rec.assert_called_once_with("cid")
@@ -5907,11 +6229,13 @@ class TestTerminalController:
         assert conn._last_terminal_start == 0
 
     async def test_stop_broadcasts_when_was_viewing(self):
-        ctrl, _, conn = self._controller()
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        ctrl, _, conn = self._controller(app_state=app_state)
         session = AsyncMock()
         ctrl.session = session
         conn.viewing_shared = {"user_id": "x", "window_id": "@0"}
-        with patch("klangk_backend.wshandler.state.get_session") as gs:
+        with patch.object(sockets, "get_session") as gs:
             ws_session = MagicMock()
             gs.return_value = ws_session
             await ctrl.stop()
@@ -5928,10 +6252,12 @@ class TestTerminalController:
         stale.stop.assert_awaited_once()
 
     async def test_activate_session_wires_forward_task(self):
-        ctrl, _, _ = self._controller()
+        app_state = _make_app_state()
+        registry = app_state.container_registry
+        ctrl, _, _ = self._controller(app_state=app_state)
         session = AsyncMock()
         ctrl.session = session
-        with patch.object(container.registry, "record_activity") as rec:
+        with patch.object(registry, "record_activity") as rec:
             result = await ctrl.activate_session(session, 80, 24)
         assert result is True
         assert ctrl.output_task is not None
@@ -5946,7 +6272,9 @@ class TestTerminalController:
     # --- forward_output ---
 
     async def test_forward_output_relays_and_cleans_up(self):
-        ctrl, sock, _ = self._controller()
+        app_state = _make_app_state()
+        registry = app_state.container_registry
+        ctrl, sock, _ = self._controller(app_state=app_state)
         session = AsyncMock()
         ctrl.session = session
 
@@ -5955,7 +6283,7 @@ class TestTerminalController:
             yield "chunk2"
 
         session.output = fake_output
-        with patch.object(container.registry, "record_activity"):
+        with patch.object(registry, "record_activity"):
             await ctrl.forward_output(session)
         calls = [c[0][0] for c in sock.send_json.call_args_list]
         assert calls == [
@@ -5966,7 +6294,9 @@ class TestTerminalController:
         assert ctrl.session is None
 
     async def test_forward_output_records_activity_when_container_set(self):
-        ctrl, _, _ = self._controller(container_id="cid")
+        app_state = _make_app_state()
+        registry = app_state.container_registry
+        ctrl, _, _ = self._controller(container_id="cid", app_state=app_state)
         session = AsyncMock()
         ctrl.session = session
 
@@ -5974,7 +6304,7 @@ class TestTerminalController:
             yield "data"
 
         session.output = fake_output
-        with patch.object(container.registry, "record_activity") as rec:
+        with patch.object(registry, "record_activity") as rec:
             await ctrl.forward_output(session)
         rec.assert_called_once_with("cid")
 
@@ -6099,8 +6429,10 @@ class TestTerminalController:
         self, user
     ):
         """When a ws_session exists, only this user's sockets receive it."""
-        ctrl, sock, conn = self._controller(user=user)
-        ws_session = wshandler.state.get_or_create_session("ws-1")
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        ctrl, sock, conn = self._controller(user=user, app_state=app_state)
+        ws_session = sockets.get_or_create_session("ws-1", app_state)
         other_sock = _mock_sock()
         other_conn = _base_conn(
             user={"id": "other", "email": "o@x.com", "handle": "o"},
@@ -6109,8 +6441,8 @@ class TestTerminalController:
         other_conn.workspace_id = "ws-1"
         await ws_session.add_subscriber(sock, "cid")
         await ws_session.add_subscriber(other_sock, "cid")
-        wshandler.state.connections[sock] = conn
-        wshandler.state.connections[other_sock] = other_conn
+        sockets.connections[sock] = conn
+        sockets.connections[other_sock] = other_conn
         try:
             ctrl.notify_user_terminal_windows([{"id": "@0", "name": "bash"}])
             # user's sock received it; other_sock did not.
@@ -6120,17 +6452,19 @@ class TestTerminalController:
         finally:
             await ws_session.remove_subscriber(sock)
             await ws_session.remove_subscriber(other_sock)
-            wshandler.state.connections.pop(sock, None)
-            wshandler.state.connections.pop(other_sock, None)
-            wshandler.state.sessions.pop("ws-1", None)
+            sockets.connections.pop(sock, None)
+            sockets.connections.pop(other_sock, None)
+            sockets.sessions.pop("ws-1", None)
 
     # --- #1114: service-cmd shared singleton ---
 
     async def test_sync_terminal_windows_marks_service_cmd_shared(self):
         """The service-cmd window is shared by definition, so syncing the
         owner's own windows marks it shared even with no prior entry (#1114)."""
-        ctrl, _, _ = self._controller()
-        ws_session = wshandler.state.get_or_create_session("ws-1")
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        ctrl, _, _ = self._controller(app_state=app_state)
+        ws_session = sockets.get_or_create_session("ws-1", app_state)
         try:
             ctrl.sync_terminal_windows(
                 [
@@ -6149,16 +6483,18 @@ class TestTerminalController:
             bash = next(w for w in wins if w["name"] == "bash")
             assert bash["shared"] is False
         finally:
-            wshandler.state.sessions.pop("ws-1", None)
+            sockets.sessions.pop("ws-1", None)
 
     async def test_sync_service_windows_injects_service_cmd_shared(self):
         """Discovery: connecting syncs the agent's service:service-cmd window
         into the session map (keyed by AGENT_USER_ID, marked shared, handle
         cached) even though the agent has no WS connection (#1133)."""
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         from klangk_backend import model
 
-        ctrl, _, conn = self._controller()
-        ws_session = wshandler.state.get_or_create_session("ws-1")
+        ctrl, _, conn = self._controller(app_state=app_state)
+        ws_session = sockets.get_or_create_session("ws-1", app_state)
         try:
             with (
                 patch(
@@ -6188,19 +6524,23 @@ class TestTerminalController:
             # Handle cached so the window stays attributable.
             assert ws_session.agent_handle == "clanker"
         finally:
-            wshandler.state.sessions.pop("ws-1", None)
+            sockets.sessions.pop("ws-1", None)
 
     async def test_sync_service_windows_no_container_returns_false(self):
-        ctrl, _, _ = self._controller(container_id=None)
-        ws_session = wshandler.state.get_or_create_session("ws-1")
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        ctrl, _, _ = self._controller(container_id=None, app_state=app_state)
+        ws_session = sockets.get_or_create_session("ws-1", app_state)
         try:
             assert await ctrl._sync_service_windows(ws_session) is False
         finally:
-            wshandler.state.sessions.pop("ws-1", None)
+            sockets.sessions.pop("ws-1", None)
 
     async def test_sync_service_windows_list_error_returns_false(self):
-        ctrl, _, _ = self._controller()
-        ws_session = wshandler.state.get_or_create_session("ws-1")
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        ctrl, _, _ = self._controller(app_state=app_state)
+        ws_session = sockets.get_or_create_session("ws-1", app_state)
         try:
             with patch(
                 "klangk_backend.wshandler.controllers.terminal.list_windows",
@@ -6208,11 +6548,13 @@ class TestTerminalController:
             ):
                 assert await ctrl._sync_service_windows(ws_session) is False
         finally:
-            wshandler.state.sessions.pop("ws-1", None)
+            sockets.sessions.pop("ws-1", None)
 
     async def test_sync_service_windows_empty_returns_false(self):
-        ctrl, _, _ = self._controller()
-        ws_session = wshandler.state.get_or_create_session("ws-1")
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        ctrl, _, _ = self._controller(app_state=app_state)
+        ws_session = sockets.get_or_create_session("ws-1", app_state)
         try:
             with patch(
                 "klangk_backend.wshandler.controllers.terminal.list_windows",
@@ -6220,13 +6562,15 @@ class TestTerminalController:
             ):
                 assert await ctrl._sync_service_windows(ws_session) is False
         finally:
-            wshandler.state.sessions.pop("ws-1", None)
+            sockets.sessions.pop("ws-1", None)
 
     async def test_sync_service_windows_agent_handle_error_returns_false(self):
         """If the agent handle can't be resolved, discovery is skipped
         (best-effort) rather than breaking the caller (#1133)."""
-        ctrl, _, _ = self._controller()
-        ws_session = wshandler.state.get_or_create_session("ws-1")
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        ctrl, _, _ = self._controller(app_state=app_state)
+        ws_session = sockets.get_or_create_session("ws-1", app_state)
         try:
             with (
                 patch(
@@ -6246,23 +6590,25 @@ class TestTerminalController:
                 assert await ctrl._sync_service_windows(ws_session) is False
             assert ws_session.agent_handle is None
         finally:
-            wshandler.state.sessions.pop("ws-1", None)
+            sockets.sessions.pop("ws-1", None)
 
     async def test_get_shared_terminals_visible_when_agent_offline(self):
         """The service window stays in the shared list (attributed to the
         agent) via the cached agent_handle, though the agent has no WS
         connection (#1133)."""
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         from klangk_backend import model
         from klangk_backend.wshandler.helpers import get_shared_terminals
 
-        ws_session = wshandler.state.get_or_create_session("ws-offline")
+        ws_session = sockets.get_or_create_session("ws-offline", app_state)
         try:
             ws_session.terminal_windows[model.AGENT_USER_ID] = [
                 {"id": "@1", "index": 1, "name": "service-cmd", "shared": True}
             ]
             ws_session.agent_handle = "clanker"
             # No active connection for the agent.
-            terminals = get_shared_terminals(ws_session)
+            terminals = get_shared_terminals(ws_session, sockets)
             assert len(terminals) == 1
             assert terminals[0]["handle"] == "clanker"
             assert terminals[0]["window_name"] == "service-cmd"
@@ -6270,12 +6616,13 @@ class TestTerminalController:
             # service tab distinctly (#1159).
             assert terminals[0]["is_service"] is True
         finally:
-            wshandler.state.sessions.pop("ws-offline", None)
+            sockets.sessions.pop("ws-offline", None)
 
     async def test_fire_service_command_invokes_ensure_service_session(self):
         """_fire_service_command reads fresh setup_state from the DB,
         resolves the agent home, and targets the service session (#1133)."""
         ctrl, _, conn = self._controller()
+        app_state = conn.app_state
         conn._service_command = "./run.sh"
         with (
             patch(
@@ -6294,7 +6641,11 @@ class TestTerminalController:
         ):
             await ctrl._fire_service_command()
         mock_ess.assert_awaited_once_with(
-            "cid", "/home/clanker", "./run.sh", setup_state="complete"
+            "cid",
+            "/home/clanker",
+            "./run.sh",
+            setup_state="complete",
+            app_state=app_state,
         )
 
     async def test_fire_service_command_no_service_command_noop(self):
@@ -6332,10 +6683,12 @@ class TestTerminalController:
         assert conn.browser_id is None
 
     async def test_browser_reattach_registers_and_attaches(self):
-        ctrl, _, conn = self._controller()
+        app_state = _make_app_state()
+        registry = app_state.container_registry
+        ctrl, _, conn = self._controller(app_state=app_state)
         with (
-            patch.object(container.registry, "revoke_browser") as rev,
-            patch.object(container.registry, "register_browser") as reg,
+            patch.object(registry, "revoke_browser") as rev,
+            patch.object(registry, "register_browser") as reg,
             patch(
                 "klangk_backend.wshandler.controllers.attach_browser",
                 new=AsyncMock(),
@@ -6446,12 +6799,14 @@ class TestShareWindowHandlers:
     """Tests for the unified share/unshare/join terminal handlers."""
 
     async def test_share_window_broadcasts(self, user, temp_data_dir):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         sock = _mock_sock()
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.workspace_id = "ws-1"
         conn.container_id = "cid"
         conn._user_home = "/home/admin"
-        session = wshandler.state.get_or_create_session("ws-1")
+        session = sockets.get_or_create_session("ws-1", app_state)
         session.terminal_windows[user["id"]] = [
             {"name": "1", "index": 0, "id": "@0", "shared": False},
             {"name": "2", "index": 1, "id": "@1", "shared": False},
@@ -6469,7 +6824,7 @@ class TestShareWindowHandlers:
             ]
             assert len(shared_msgs) >= 1
         finally:
-            wshandler.state.sessions.pop("ws-1", None)
+            sockets.sessions.pop("ws-1", None)
 
     async def test_share_window_permission_denied(self, user):
         sock = _mock_sock()
@@ -6483,12 +6838,14 @@ class TestShareWindowHandlers:
         assert any("Permission" in c.get("message", "") for c in calls)
 
     async def test_unshare_window_kicks_joiners(self, user, temp_data_dir):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         sock = _mock_sock()
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.workspace_id = "ws-1"
         conn.container_id = "cid"
         conn._user_home = "/home/admin"
-        session = wshandler.state.get_or_create_session("ws-1")
+        session = sockets.get_or_create_session("ws-1", app_state)
         session.terminal_windows[user["id"]] = [
             {"name": "1", "index": 0, "id": "@0", "shared": True},
         ]
@@ -6511,12 +6868,12 @@ class TestShareWindowHandlers:
             ]
             assert len(deleted) == 1
         finally:
-            wshandler.state.sessions.pop("ws-1", None)
+            sockets.sessions.pop("ws-1", None)
 
     async def test_list_shared_terminals(self, user, temp_data_dir):
         async with _conn_in_workspace(
             user, "ws-1", user_home="/home/admin"
-        ) as (sock, conn, session):
+        ) as (sock, conn, session, app_state):
             session.terminal_windows[user["id"]] = [
                 {"name": "1", "index": 0, "id": "@0", "shared": False},
                 {"name": "build", "index": 1, "id": "@1", "shared": True},
@@ -6536,8 +6893,10 @@ class TestShareWindowHandlers:
 
     async def test_shared_terminals_include_viewers(self, user, temp_data_dir):
         """shared_terminals response includes viewer list."""
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         owner_sock = _mock_sock()
-        owner_conn = _base_conn(user=user, ws=owner_sock)
+        owner_conn = _base_conn(user=user, ws=owner_sock, app_state=app_state)
         owner_conn.workspace_id = "ws-v"
         owner_conn.container_id = "cid"
         owner_conn._user_home = "/home/admin"
@@ -6548,21 +6907,23 @@ class TestShareWindowHandlers:
             "handle": "viewer",
         }
         viewer_sock = _mock_sock()
-        viewer_conn = _base_conn(user=viewer_user, ws=viewer_sock)
+        viewer_conn = _base_conn(
+            user=viewer_user, ws=viewer_sock, app_state=app_state
+        )
         viewer_conn.workspace_id = "ws-v"
         viewer_conn.viewing_shared = {
             "user_id": user["id"],
             "window_id": "@0",
         }
 
-        session = wshandler.state.get_or_create_session("ws-v")
+        session = sockets.get_or_create_session("ws-v", app_state)
         session.terminal_windows[user["id"]] = [
             {"name": "build", "index": 0, "id": "@0", "shared": True},
         ]
         await session.add_subscriber(owner_sock, "cid")
         await session.add_subscriber(viewer_sock, "cid")
-        wshandler.state.connections[owner_sock] = owner_conn
-        wshandler.state.connections[viewer_sock] = viewer_conn
+        sockets.connections[owner_sock] = owner_conn
+        sockets.connections[viewer_sock] = viewer_conn
         try:
             with patch(
                 "klangk_backend.acl.check_permission", return_value=True
@@ -6576,15 +6937,15 @@ class TestShareWindowHandlers:
             assert terminal["viewers"][0]["user_id"] == "viewer-1"
             assert terminal["viewers"][0]["email"] == "viewer@test.com"
         finally:
-            wshandler.state.sessions.pop("ws-v", None)
-            wshandler.state.connections.pop(owner_sock, None)
-            wshandler.state.connections.pop(viewer_sock, None)
+            sockets.sessions.pop("ws-v", None)
+            sockets.connections.pop(owner_sock, None)
+            sockets.connections.pop(viewer_sock, None)
 
     async def test_stop_terminal_broadcasts_viewer_change(self, user):
         """Stopping a terminal that was viewing shared broadcasts update."""
         async with _conn_in_workspace(
             user, "ws-sv", user_home="/home/admin"
-        ) as (sock, conn, session):
+        ) as (sock, conn, session, app_state):
             conn.viewing_shared = {"user_id": "owner-1", "window_id": "@0"}
             await conn.stop_terminal()
             assert conn.viewing_shared is None
@@ -6596,7 +6957,7 @@ class TestShareWindowHandlers:
         """Legacy create_shared_terminal creates a window and marks it shared."""
         async with _conn_in_workspace(
             user, "ws-1", user_home="/home/admin"
-        ) as (sock, conn, session):
+        ) as (sock, conn, session, app_state):
             session.terminal_windows[user["id"]] = [
                 {"name": "1", "index": 0, "id": "@0", "shared": False}
             ]
@@ -6643,12 +7004,14 @@ class TestShareWindowHandlers:
         assert any("id" in c.get("message", "").lower() for c in calls)
 
     async def test_share_window_not_found(self, user):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         sock = _mock_sock()
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.container_id = "cid"
         conn._user_home = "/home/admin"
         conn.workspace_id = "ws-1"
-        session = wshandler.state.get_or_create_session("ws-1")
+        session = sockets.get_or_create_session("ws-1", app_state)
         session.terminal_windows[user["id"]] = [
             {"name": "1", "index": 0, "id": "@0", "shared": False}
         ]
@@ -6662,7 +7025,7 @@ class TestShareWindowHandlers:
                 "not found" in c.get("message", "").lower() for c in calls
             )
         finally:
-            wshandler.state.sessions.pop("ws-1", None)
+            sockets.sessions.pop("ws-1", None)
 
     async def test_share_window_no_session(self, user):
         sock = _mock_sock()
@@ -6700,12 +7063,14 @@ class TestShareWindowHandlers:
         assert any("id" in c.get("message", "").lower() for c in calls)
 
     async def test_unshare_window_not_found(self, user):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         sock = _mock_sock()
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.container_id = "cid"
         conn._user_home = "/home/admin"
         conn.workspace_id = "ws-1"
-        session = wshandler.state.get_or_create_session("ws-1")
+        session = sockets.get_or_create_session("ws-1", app_state)
         session.terminal_windows[user["id"]] = [
             {"name": "1", "index": 0, "id": "@0", "shared": True}
         ]
@@ -6719,7 +7084,7 @@ class TestShareWindowHandlers:
                 "not found" in c.get("message", "").lower() for c in calls
             )
         finally:
-            wshandler.state.sessions.pop("ws-1", None)
+            sockets.sessions.pop("ws-1", None)
 
     async def test_unshare_window_no_session(self, user):
         sock = _mock_sock()
@@ -6731,12 +7096,14 @@ class TestShareWindowHandlers:
             await conn.handle_unshare_window({"window_id": "@0"})
 
     async def test_unshare_kill_error_handled(self, user):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         sock = _mock_sock()
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.workspace_id = "ws-1"
         conn.container_id = "cid"
         conn._user_home = "/home/admin"
-        session = wshandler.state.get_or_create_session("ws-1")
+        session = sockets.get_or_create_session("ws-1", app_state)
         session.terminal_windows[user["id"]] = [
             {"name": "1", "index": 0, "id": "@0", "shared": True}
         ]
@@ -6754,22 +7121,25 @@ class TestShareWindowHandlers:
                 await conn.handle_unshare_window({"window_id": "@0"})
             assert session.terminal_windows[user["id"]][0]["shared"] is False
         finally:
-            wshandler.state.sessions.pop("ws-1", None)
+            sockets.sessions.pop("ws-1", None)
 
     async def test_join_shared_terminal(self, user, temp_data_dir):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        registry = app_state.container_registry
         owner = await model.create_user(
             "owner@test.com", "hash", verified=True
         )
         sock = _mock_sock()
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.workspace_id = "ws-1"
         conn.container_id = "cid"
         conn._user_home = "/home/joiner"
-        session = wshandler.state.get_or_create_session("ws-1")
+        session = sockets.get_or_create_session("ws-1", app_state)
         session.terminal_windows[owner["id"]] = [
             {"name": "build", "index": 0, "id": "@0", "shared": True},
         ]
-        container.registry.track_activity("cid", "ws-1")
+        registry.track_activity("cid", "ws-1")
         try:
             with (
                 patch(
@@ -6803,8 +7173,8 @@ class TestShareWindowHandlers:
             assert started[0]["shared_user_id"] == owner["id"]
             assert started[0]["shared_window"] == "build"
         finally:
-            wshandler.state.sessions.pop("ws-1", None)
-            container.registry.states.pop("ws-1", None)
+            sockets.sessions.pop("ws-1", None)
+            registry.states.pop("ws-1", None)
 
     async def test_join_service_terminal_routes_to_service_session(
         self, user, temp_data_dir
@@ -6812,17 +7182,20 @@ class TestShareWindowHandlers:
         """Joining the agent's service window targets the standalone
         ``service`` tmux session, not a session named after the agent's
         user_id (which doesn't exist) -- #1158/#1159."""
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        registry = app_state.container_registry
         sock = _mock_sock()
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.workspace_id = "ws-1"
         conn.container_id = "cid"
         conn._user_home = "/home/joiner"
-        session = wshandler.state.get_or_create_session("ws-1")
+        session = sockets.get_or_create_session("ws-1", app_state)
         session.terminal_windows[model.AGENT_USER_ID] = [
             {"name": "service-cmd", "index": 0, "id": "@0", "shared": True},
         ]
         session.agent_handle = "clanker"
-        container.registry.track_activity("cid", "ws-1")
+        registry.track_activity("cid", "ws-1")
         try:
             with (
                 patch(
@@ -6859,8 +7232,8 @@ class TestShareWindowHandlers:
             assert len(started) == 1
             assert started[0]["shared_user_id"] == model.AGENT_USER_ID
         finally:
-            wshandler.state.sessions.pop("ws-1", None)
-            container.registry.states.pop("ws-1", None)
+            sockets.sessions.pop("ws-1", None)
+            registry.states.pop("ws-1", None)
 
     async def test_join_shared_terminal_no_container(self, user):
         conn = _base_conn(user=user)
@@ -6893,19 +7266,22 @@ class TestShareWindowHandlers:
 
     async def test_join_shared_terminal_superseded(self, user, temp_data_dir):
         """If session is superseded during start, activate_session returns False."""
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        registry = app_state.container_registry
         owner = await model.create_user(
             "owner-sup@test.com", "hash", verified=True
         )
         sock = _mock_sock()
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.workspace_id = "ws-1"
         conn.container_id = "cid"
         conn._user_home = "/home/joiner"
-        session = wshandler.state.get_or_create_session("ws-1")
+        session = sockets.get_or_create_session("ws-1", app_state)
         session.terminal_windows[owner["id"]] = [
             {"name": "build", "index": 0, "id": "@0", "shared": True},
         ]
-        container.registry.track_activity("cid", "ws-1")
+        registry.track_activity("cid", "ws-1")
 
         async def fake_start(*a, **kw):
             # Supersede the session before activate_session runs
@@ -6934,28 +7310,31 @@ class TestShareWindowHandlers:
             # Session was stopped because it was superseded
             mock_sess.stop.assert_awaited()
         finally:
-            wshandler.state.sessions.pop("ws-1", None)
-            container.registry.states.pop("ws-1", None)
+            sockets.sessions.pop("ws-1", None)
+            registry.states.pop("ws-1", None)
 
     async def test_join_shared_terminal_select_fallback(
         self, user, temp_data_dir
     ):
         """Falls back to bare @N when joiner session select fails."""
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        registry = app_state.container_registry
         owner = await model.create_user(
             "owner-fb@test.com", "hash", verified=True
         )
         sock = _mock_sock()
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.workspace_id = "ws-1"
         conn.container_id = "cid"
         conn._user_home = "/home/joiner"
-        session = wshandler.state.get_or_create_session("ws-1")
+        session = sockets.get_or_create_session("ws-1", app_state)
         session.terminal_windows[owner["id"]] = [
             {"name": "build", "index": 0, "id": "@0", "shared": True},
         ]
         await session.add_subscriber(sock, "cid")
-        wshandler.state.connections[sock] = conn
-        container.registry.track_activity("cid", "ws-1")
+        sockets.connections[sock] = conn
+        registry.track_activity("cid", "ws-1")
 
         try:
             with (
@@ -6991,29 +7370,32 @@ class TestShareWindowHandlers:
             # Fell back to select_window with bare @N
             mock_select.assert_awaited_once_with("cid", owner["id"], "@0")
         finally:
-            wshandler.state.sessions.pop("ws-1", None)
-            wshandler.state.connections.pop(sock, None)
-            container.registry.states.pop("ws-1", None)
+            sockets.sessions.pop("ws-1", None)
+            sockets.connections.pop(sock, None)
+            registry.states.pop("ws-1", None)
 
     async def test_join_shared_terminal_no_joiner_session(
         self, user, temp_data_dir
     ):
         """Falls back to bare @N when joiner session name is None."""
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        registry = app_state.container_registry
         owner = await model.create_user(
             "owner-nj@test.com", "hash", verified=True
         )
         sock = _mock_sock()
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.workspace_id = "ws-1"
         conn.container_id = "cid"
         conn._user_home = "/home/joiner"
-        session = wshandler.state.get_or_create_session("ws-1")
+        session = sockets.get_or_create_session("ws-1", app_state)
         session.terminal_windows[owner["id"]] = [
             {"name": "build", "index": 0, "id": "@0", "shared": True},
         ]
         await session.add_subscriber(sock, "cid")
-        wshandler.state.connections[sock] = conn
-        container.registry.track_activity("cid", "ws-1")
+        sockets.connections[sock] = conn
+        registry.track_activity("cid", "ws-1")
 
         try:
             with (
@@ -7044,21 +7426,23 @@ class TestShareWindowHandlers:
 
             mock_select.assert_awaited_once_with("cid", owner["id"], "@0")
         finally:
-            wshandler.state.sessions.pop("ws-1", None)
-            wshandler.state.connections.pop(sock, None)
-            container.registry.states.pop("ws-1", None)
+            sockets.sessions.pop("ws-1", None)
+            sockets.connections.pop(sock, None)
+            registry.states.pop("ws-1", None)
 
     async def test_join_shared_terminal_start_error(self, user, temp_data_dir):
         """If session.start() fails, error is sent and session stopped."""
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         owner = await model.create_user(
             "owner-err@test.com", "hash", verified=True
         )
         sock = _mock_sock()
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.workspace_id = "ws-1"
         conn.container_id = "cid"
         conn._user_home = "/home/joiner"
-        session = wshandler.state.get_or_create_session("ws-1")
+        session = sockets.get_or_create_session("ws-1", app_state)
         session.terminal_windows[owner["id"]] = [
             {"name": "build", "index": 0, "id": "@0", "shared": True},
         ]
@@ -7084,7 +7468,7 @@ class TestShareWindowHandlers:
             sent = [c[0][0] for c in sock.send_json.call_args_list]
             assert any("Failed" in c.get("message", "") for c in sent)
         finally:
-            wshandler.state.sessions.pop("ws-1", None)
+            sockets.sessions.pop("ws-1", None)
 
     async def test_join_shared_terminal_no_session(self, user):
         sock = _mock_sock()
@@ -7099,12 +7483,14 @@ class TestShareWindowHandlers:
         # Early return, no error sent
 
     async def test_join_shared_terminal_not_found(self, user):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         sock = _mock_sock()
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.container_id = "cid"
         conn._user_home = "/home/x"
         conn.workspace_id = "ws-1"
-        wshandler.state.get_or_create_session("ws-1")
+        sockets.get_or_create_session("ws-1", app_state)
         try:
             with patch(
                 "klangk_backend.acl.check_permission", return_value=True
@@ -7117,12 +7503,12 @@ class TestShareWindowHandlers:
                 "not found" in c.get("message", "").lower() for c in calls
             )
         finally:
-            wshandler.state.sessions.pop("ws-1", None)
+            sockets.sessions.pop("ws-1", None)
 
     async def test_delete_shared_terminal(self, user, temp_data_dir):
         async with _conn_in_workspace(
             user, "ws-1", user_home="/home/admin"
-        ) as (sock, conn, session):
+        ) as (sock, conn, session, app_state):
             session.terminal_windows[user["id"]] = [
                 {"name": "1", "index": 0, "id": "@0", "shared": False},
                 {"name": "build", "index": 1, "id": "@1", "shared": True},
@@ -7169,11 +7555,13 @@ class TestShareWindowHandlers:
         assert any("required" in c.get("message", "").lower() for c in calls)
 
     async def test_delete_shared_terminal_not_found(self, user):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         sock = _mock_sock()
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.container_id = "cid"
         conn.workspace_id = "ws-1"
-        wshandler.state.get_or_create_session("ws-1")
+        sockets.get_or_create_session("ws-1", app_state)
         try:
             with patch(
                 "klangk_backend.acl.check_permission", return_value=True
@@ -7186,13 +7574,15 @@ class TestShareWindowHandlers:
                 "not found" in c.get("message", "").lower() for c in calls
             )
         finally:
-            wshandler.state.sessions.pop("ws-1", None)
+            sockets.sessions.pop("ws-1", None)
 
     async def test_delete_shared_terminal_other_user_denied(
         self, user, temp_data_dir
     ):
         """A collaborator may not delete another user's terminal
         (regression for #874)."""
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         other = await model.create_user(
             "other@example.com", "x", verified=True
         )
@@ -7200,10 +7590,10 @@ class TestShareWindowHandlers:
         # owner nor the workspace owner.
         workspace = await model.create_workspace(other["id"], "ws-other")
         sock = _mock_sock()
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.container_id = "cid"
         conn.workspace_id = workspace["id"]
-        session = wshandler.state.get_or_create_session(workspace["id"])
+        session = sockets.get_or_create_session(workspace["id"], app_state)
         session.terminal_windows[other["id"]] = [
             {"name": "build", "index": 0, "id": "@0", "shared": True},
         ]
@@ -7221,8 +7611,8 @@ class TestShareWindowHandlers:
             # Window is untouched.
             assert len(session.terminal_windows[other["id"]]) == 1
         finally:
-            wshandler.state.sessions.pop(workspace["id"], None)
-            wshandler.state.connections.pop(sock, None)
+            sockets.sessions.pop(workspace["id"], None)
+            sockets.connections.pop(sock, None)
 
     async def test_delete_shared_terminal_workspace_owner_can_delete_others(
         self, user, temp_data_dir
@@ -7237,6 +7627,7 @@ class TestShareWindowHandlers:
             sock,
             conn,
             session,
+            app_state,
         ):
             session.terminal_windows[other["id"]] = [
                 {"name": "build", "index": 0, "id": "@0", "shared": True},
@@ -7254,11 +7645,13 @@ class TestShareWindowHandlers:
             assert session.terminal_windows[other["id"]] == []
 
     async def test_delete_shared_terminal_error(self, user):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         sock = _mock_sock()
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.workspace_id = "ws-1"
         conn.container_id = "cid"
-        session = wshandler.state.get_or_create_session("ws-1")
+        session = sockets.get_or_create_session("ws-1", app_state)
         session.terminal_windows[user["id"]] = [
             {"name": "build", "index": 0, "id": "@0", "shared": True},
         ]
@@ -7278,7 +7671,7 @@ class TestShareWindowHandlers:
             calls = [c[0][0] for c in sock.send_json.call_args_list]
             assert any("Failed" in c.get("message", "") for c in calls)
         finally:
-            wshandler.state.sessions.pop("ws-1", None)
+            sockets.sessions.pop("ws-1", None)
 
     async def test_create_shared_terminal_no_session(self, user):
         sock = _mock_sock()
@@ -7403,6 +7796,7 @@ class TestSharedTerminalController:
         sock=None,
         has_perm=True,
         user=None,
+        app_state=None,
     ):
         if sock is None:
             sock = _mock_sock()
@@ -7412,6 +7806,8 @@ class TestSharedTerminalController:
                 "email": "alice@example.com",
                 "handle": "alice",
             }
+        if app_state is None:
+            app_state = _make_app_state()
 
         class _FakeConn:
             """Minimal Connection stand-in for isolated controller tests."""
@@ -7422,6 +7818,7 @@ class TestSharedTerminalController:
                 self.workspace_id = workspace_id
                 self._user_home = user_home
                 self.user = user
+                self.app_state = app_state
                 self._has_perm = AsyncMock(return_value=has_perm)
                 self.stop_terminal = AsyncMock()
                 self.activate_session = AsyncMock(return_value=True)
@@ -7455,14 +7852,18 @@ class TestSharedTerminalController:
         ctrl = SharedTerminalController(conn)
         return ctrl, sock, conn
 
-    def _ws_session(self, ws_id="ws-1"):
-        return wshandler.state.get_or_create_session(ws_id)
+    def _ws_session(self, ws_id="ws-1", app_state=None):
+        if app_state is None:
+            app_state = _make_app_state()
+        return app_state.sockets.get_or_create_session(ws_id, app_state)
 
     # --- find_window ---
 
     async def test_find_window_returns_match(self, user):
-        ctrl, _, conn = self._controller(user=user)
-        ws = self._ws_session()
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        ctrl, _, conn = self._controller(user=user, app_state=app_state)
+        ws = self._ws_session(app_state=app_state)
         ws.terminal_windows[user["id"]] = [
             {"id": "@0", "name": "a", "shared": False}
         ]
@@ -7471,21 +7872,25 @@ class TestSharedTerminalController:
             assert found is not None
             assert found["name"] == "a"
         finally:
-            wshandler.state.sessions.pop("ws-1", None)
+            sockets.sessions.pop("ws-1", None)
 
     async def test_find_window_not_found_sends_error(self, user):
-        ctrl, sock, conn = self._controller(user=user)
-        ws = self._ws_session()
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        ctrl, sock, conn = self._controller(user=user, app_state=app_state)
+        ws = self._ws_session(app_state=app_state)
         try:
             assert ctrl.find_window(ws, user["id"], "@99") is None
             msg = sock.send_json.call_args[0][0]
             assert msg == {"type": "error", "message": "Window not found"}
         finally:
-            wshandler.state.sessions.pop("ws-1", None)
+            sockets.sessions.pop("ws-1", None)
 
     async def test_find_window_shared_true_rejects_unshared(self, user):
-        ctrl, sock, conn = self._controller(user=user)
-        ws = self._ws_session()
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        ctrl, sock, conn = self._controller(user=user, app_state=app_state)
+        ws = self._ws_session(app_state=app_state)
         ws.terminal_windows[user["id"]] = [
             {"id": "@0", "name": "a", "shared": False}
         ]
@@ -7498,13 +7903,15 @@ class TestSharedTerminalController:
             )
             assert sock.send_json.call_args[0][0]["message"] == "nope"
         finally:
-            wshandler.state.sessions.pop("ws-1", None)
+            sockets.sessions.pop("ws-1", None)
 
     # --- share_window ---
 
     async def test_share_window_marks_and_broadcasts(self, user):
-        ctrl, _, conn = self._controller(user=user)
-        ws = self._ws_session()
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        ctrl, _, conn = self._controller(user=user, app_state=app_state)
+        ws = self._ws_session(app_state=app_state)
         ws.terminal_windows[user["id"]] = [
             {"id": "@0", "name": "a", "shared": False}
         ]
@@ -7512,7 +7919,7 @@ class TestSharedTerminalController:
             await ctrl.share_window({"window_id": "@0"})
             assert ws.terminal_windows[user["id"]][0]["shared"] is True
         finally:
-            wshandler.state.sessions.pop("ws-1", None)
+            sockets.sessions.pop("ws-1", None)
 
     async def test_share_window_no_container(self, user):
         ctrl, _, _ = self._controller(user=user, container_id=None)
@@ -7529,14 +7936,16 @@ class TestSharedTerminalController:
         assert "Window ID" in sock.send_json.call_args[0][0]["message"]
 
     async def test_share_window_not_found(self, user):
-        ctrl, sock, _ = self._controller(user=user)
-        ws = self._ws_session()
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        ctrl, sock, _ = self._controller(user=user, app_state=app_state)
+        ws = self._ws_session(app_state=app_state)
         ws.terminal_windows[user["id"]] = []
         try:
             await ctrl.share_window({"window_id": "@99"})
             assert sock.send_json.call_args[0][0]["type"] == "error"
         finally:
-            wshandler.state.sessions.pop("ws-1", None)
+            sockets.sessions.pop("ws-1", None)
 
     async def test_share_window_no_session(self, user):
         ctrl, _, _ = self._controller(user=user, workspace_id="none")
@@ -7556,8 +7965,10 @@ class TestSharedTerminalController:
     async def test_unshare_window_marks_unshared_and_kicks(
         self, user, temp_data_dir
     ):
-        ctrl, _, conn = self._controller(user=user)
-        ws = self._ws_session()
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        ctrl, _, conn = self._controller(user=user, app_state=app_state)
+        ws = self._ws_session(app_state=app_state)
         ws.terminal_windows[user["id"]] = [
             {"id": "@0", "name": "a", "shared": True}
         ]
@@ -7567,11 +7978,13 @@ class TestSharedTerminalController:
             assert ws.terminal_windows[user["id"]][0]["shared"] is False
             kill.assert_awaited_once_with("cid", "uid")
         finally:
-            wshandler.state.sessions.pop("ws-1", None)
+            sockets.sessions.pop("ws-1", None)
 
     async def test_unshare_kill_error_handled(self, user, temp_data_dir):
-        ctrl, sock, _ = self._controller(user=user)
-        ws = self._ws_session()
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        ctrl, sock, _ = self._controller(user=user, app_state=app_state)
+        ws = self._ws_session(app_state=app_state)
         await ws.add_subscriber(sock, "cid")
         ws.terminal_windows[user["id"]] = [
             {"id": "@0", "name": "a", "shared": True}
@@ -7590,7 +8003,7 @@ class TestSharedTerminalController:
             )
         finally:
             await ws.remove_subscriber(sock)
-            wshandler.state.sessions.pop("ws-1", None)
+            sockets.sessions.pop("ws-1", None)
 
     # --- list_shared_terminals ---
 
@@ -7610,8 +8023,10 @@ class TestSharedTerminalController:
         assert msg == {"type": "shared_terminals", "terminals": []}
 
     async def test_list_shared_terminals_sends_list(self, user):
-        ctrl, sock, _ = self._controller(user=user)
-        ws = self._ws_session()
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        ctrl, sock, _ = self._controller(user=user, app_state=app_state)
+        ws = self._ws_session(app_state=app_state)
         ws.terminal_windows[user["id"]] = [
             {"id": "@0", "name": "a", "shared": True}
         ]
@@ -7621,13 +8036,15 @@ class TestSharedTerminalController:
             assert msg["type"] == "shared_terminals"
             assert isinstance(msg["terminals"], list)
         finally:
-            wshandler.state.sessions.pop("ws-1", None)
+            sockets.sessions.pop("ws-1", None)
 
     # --- broadcast_shared_terminals ---
 
     async def test_broadcast_shared_terminals_broadcasts(self, user):
-        ctrl, sock, conn = self._controller(user=user)
-        ws = self._ws_session()
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        ctrl, sock, conn = self._controller(user=user, app_state=app_state)
+        ws = self._ws_session(app_state=app_state)
         await ws.add_subscriber(sock, "cid")
         try:
             ctrl.broadcast_shared_terminals(ws)
@@ -7635,7 +8052,7 @@ class TestSharedTerminalController:
             assert any(s.get("type") == "shared_terminals" for s in sent)
         finally:
             await ws.remove_subscriber(sock)
-            wshandler.state.sessions.pop("ws-1", None)
+            sockets.sessions.pop("ws-1", None)
 
     # --- create_shared_terminal (legacy) ---
 
@@ -7656,8 +8073,10 @@ class TestSharedTerminalController:
     async def test_create_shared_terminal_marks_new_window_shared(
         self, user, temp_data_dir
     ):
-        ctrl, sock, _ = self._controller(user=user)
-        ws = self._ws_session()
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        ctrl, sock, _ = self._controller(user=user, app_state=app_state)
+        ws = self._ws_session(app_state=app_state)
         await ws.add_subscriber(sock, "cid")
         try:
             with patch(
@@ -7676,7 +8095,7 @@ class TestSharedTerminalController:
             assert any(s.get("type") == "shared_terminals" for s in sent)
         finally:
             await ws.remove_subscriber(sock)
-            wshandler.state.sessions.pop("ws-1", None)
+            sockets.sessions.pop("ws-1", None)
 
     async def test_create_shared_terminal_error_sends_error(
         self, user, temp_data_dir
@@ -7727,8 +8146,10 @@ class TestSharedTerminalController:
         assert "Permission" in sock.send_json.call_args[0][0]["message"]
 
     async def test_delete_shared_terminal_not_found(self, user):
-        ctrl, sock, _ = self._controller(user=user)
-        ws = self._ws_session()
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        ctrl, sock, _ = self._controller(user=user, app_state=app_state)
+        ws = self._ws_session(app_state=app_state)
         ws.terminal_windows["owner-1"] = []
         try:
             await ctrl.delete_shared_terminal(
@@ -7736,7 +8157,7 @@ class TestSharedTerminalController:
             )
             assert sock.send_json.call_args[0][0]["type"] == "error"
         finally:
-            wshandler.state.sessions.pop("ws-1", None)
+            sockets.sessions.pop("ws-1", None)
 
     async def test_delete_shared_terminal_no_session(self, user):
         ctrl, _, _ = self._controller(user=user, workspace_id="none")
@@ -7745,8 +8166,10 @@ class TestSharedTerminalController:
     async def test_delete_shared_terminal_closes_and_broadcasts(
         self, user, temp_data_dir
     ):
-        ctrl, sock, _ = self._controller(user=user)
-        ws = self._ws_session()
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        ctrl, sock, _ = self._controller(user=user, app_state=app_state)
+        ws = self._ws_session(app_state=app_state)
         await ws.add_subscriber(sock, "cid")
         ws.terminal_windows["owner-1"] = [
             {"id": "@0", "index": 0, "name": "build", "shared": True},
@@ -7777,13 +8200,15 @@ class TestSharedTerminalController:
             )
         finally:
             await ws.remove_subscriber(sock)
-            wshandler.state.sessions.pop("ws-1", None)
+            sockets.sessions.pop("ws-1", None)
 
     async def test_delete_shared_terminal_error_sends_error(
         self, user, temp_data_dir
     ):
-        ctrl, sock, _ = self._controller(user=user)
-        ws = self._ws_session()
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        ctrl, sock, _ = self._controller(user=user, app_state=app_state)
+        ws = self._ws_session(app_state=app_state)
         ws.terminal_windows["owner-1"] = [
             {"id": "@0", "index": 0, "name": "build", "shared": True}
         ]
@@ -7797,7 +8222,7 @@ class TestSharedTerminalController:
                 )
             assert sock.send_json.call_args[0][0]["type"] == "error"
         finally:
-            wshandler.state.sessions.pop("ws-1", None)
+            sockets.sessions.pop("ws-1", None)
 
     # --- join_shared_terminal ---
 
@@ -7816,8 +8241,10 @@ class TestSharedTerminalController:
         assert "required" in sock.send_json.call_args[0][0]["message"]
 
     async def test_join_shared_terminal_not_found(self, user):
-        ctrl, sock, _ = self._controller(user=user)
-        ws = self._ws_session()
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        ctrl, sock, _ = self._controller(user=user, app_state=app_state)
+        ws = self._ws_session(app_state=app_state)
         ws.terminal_windows["owner-1"] = []
         try:
             await ctrl.join_shared_terminal(
@@ -7825,7 +8252,7 @@ class TestSharedTerminalController:
             )
             assert sock.send_json.call_args[0][0]["type"] == "error"
         finally:
-            wshandler.state.sessions.pop("ws-1", None)
+            sockets.sessions.pop("ws-1", None)
 
     async def test_join_shared_terminal_no_session(self, user):
         ctrl, _, _ = self._controller(user=user, workspace_id="none")
@@ -7834,8 +8261,10 @@ class TestSharedTerminalController:
     async def test_join_shared_terminal_sets_viewing_and_starts(
         self, user, temp_data_dir
     ):
-        ctrl, sock, conn = self._controller(user=user)
-        ws = self._ws_session()
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        ctrl, sock, conn = self._controller(user=user, app_state=app_state)
+        ws = self._ws_session(app_state=app_state)
         ws.terminal_windows["owner-1"] = [
             {"id": "@0", "index": 0, "name": "build", "shared": True}
         ]
@@ -7860,13 +8289,15 @@ class TestSharedTerminalController:
             conn.stop_terminal.assert_awaited_once()
             MockTS.assert_called_once()
         finally:
-            wshandler.state.sessions.pop("ws-1", None)
+            sockets.sessions.pop("ws-1", None)
 
     async def test_join_shared_terminal_start_error_sends_error(
         self, user, temp_data_dir
     ):
-        ctrl, sock, conn = self._controller(user=user)
-        ws = self._ws_session()
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        ctrl, sock, conn = self._controller(user=user, app_state=app_state)
+        ws = self._ws_session(app_state=app_state)
         ws.terminal_windows["owner-1"] = [
             {"id": "@0", "index": 0, "name": "build", "shared": True}
         ]
@@ -7893,7 +8324,7 @@ class TestSharedTerminalController:
             )
             mock_sess.stop.assert_awaited_once()
         finally:
-            wshandler.state.sessions.pop("ws-1", None)
+            sockets.sessions.pop("ws-1", None)
 
     # --- handle_list_error ---
 
@@ -7964,18 +8395,22 @@ class TestSharedTerminalController:
         m.assert_awaited_once_with({"user_id": "u", "window_id": "@0"})
 
     async def test_connection_broadcast_shared_terminals_delegate(self, user):
-        conn = _base_conn(user=user)
-        ws = wshandler.state.get_or_create_session("ws-1")
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        conn = _base_conn(user=user, app_state=app_state)
+        ws = sockets.get_or_create_session("ws-1", app_state)
         try:
             with patch.object(conn.shared, "broadcast_shared_terminals") as m:
                 conn.broadcast_shared_terminals(ws)
             m.assert_called_once_with(ws)
         finally:
-            wshandler.state.sessions.pop("ws-1", None)
+            sockets.sessions.pop("ws-1", None)
 
     async def test_connection_find_window_delegate(self, user):
-        conn = _base_conn(user=user)
-        ws = wshandler.state.get_or_create_session("ws-1")
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        conn = _base_conn(user=user, app_state=app_state)
+        ws = sockets.get_or_create_session("ws-1", app_state)
         ws.terminal_windows[user["id"]] = [
             {"id": "@0", "name": "a", "shared": False}
         ]
@@ -7993,7 +8428,7 @@ class TestSharedTerminalController:
                 error_msg="Window not found",
             )
         finally:
-            wshandler.state.sessions.pop("ws-1", None)
+            sockets.sessions.pop("ws-1", None)
 
     async def test_viewing_shared_property_round_trip(self, user):
         conn = _base_conn(user=user)
@@ -8012,10 +8447,12 @@ class TestFindWindow:
     all, only incidentally through the join handlers.
     """
 
-    def _setup(self, user, windows):
+    def _setup(self, user, windows, app_state=None):
+        if app_state is None:
+            app_state = _make_app_state()
         sock = _mock_sock()
-        conn = _base_conn(user=user, ws=sock)
-        session = wshandler.state.get_or_create_session("ws-find")
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
+        session = app_state.sockets.get_or_create_session("ws-find", app_state)
         if windows is not None:
             session.terminal_windows[user["id"]] = windows
         return sock, conn, session
@@ -8024,8 +8461,12 @@ class TestFindWindow:
         return [c[0][0] for c in sock.send_json.call_args_list]
 
     async def test_found_returns_window(self, user):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         sock, conn, session = self._setup(
-            user, [{"id": "@0", "name": "a", "shared": False}]
+            user,
+            [{"id": "@0", "name": "a", "shared": False}],
+            app_state=app_state,
         )
         try:
             assert (
@@ -8034,33 +8475,43 @@ class TestFindWindow:
             )
             assert self._messages(sock) == []
         finally:
-            wshandler.state.sessions.pop("ws-find", None)
+            sockets.sessions.pop("ws-find", None)
 
     async def test_not_found_sends_error_and_returns_none(self, user):
-        sock, conn, session = self._setup(user, [])
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        sock, conn, session = self._setup(user, [], app_state=app_state)
         try:
             assert conn._find_window(session, user["id"], "@99") is None
             assert self._messages(sock) == [
                 {"type": "error", "message": "Window not found"}
             ]
         finally:
-            wshandler.state.sessions.pop("ws-find", None)
+            sockets.sessions.pop("ws-find", None)
 
     async def test_shared_true_finds_shared_window(self, user):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         sock, conn, session = self._setup(
-            user, [{"id": "@0", "name": "a", "shared": True}]
+            user,
+            [{"id": "@0", "name": "a", "shared": True}],
+            app_state=app_state,
         )
         try:
             found = conn._find_window(session, user["id"], "@0", shared=True)
             assert found is not None
             assert found["name"] == "a"
         finally:
-            wshandler.state.sessions.pop("ws-find", None)
+            sockets.sessions.pop("ws-find", None)
 
     async def test_shared_true_rejects_unshared_window(self, user):
         """A present-but-unshared window is treated as not found."""
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         sock, conn, session = self._setup(
-            user, [{"id": "@0", "name": "a", "shared": False}]
+            user,
+            [{"id": "@0", "name": "a", "shared": False}],
+            app_state=app_state,
         )
         try:
             assert (
@@ -8071,10 +8522,12 @@ class TestFindWindow:
                 {"type": "error", "message": "Window not found"}
             ]
         finally:
-            wshandler.state.sessions.pop("ws-find", None)
+            sockets.sessions.pop("ws-find", None)
 
     async def test_custom_error_message(self, user):
-        sock, conn, session = self._setup(user, [])
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        sock, conn, session = self._setup(user, [], app_state=app_state)
         try:
             assert (
                 conn._find_window(
@@ -8089,17 +8542,19 @@ class TestFindWindow:
                 {"type": "error", "message": "Shared terminal not found"}
             ]
         finally:
-            wshandler.state.sessions.pop("ws-find", None)
+            sockets.sessions.pop("ws-find", None)
 
 
 class TestFractionalTimeout:
     async def test_fractional_timeout_display(
         self, user, monkeypatch, agent_user
     ):
+        app_state = _make_app_state()
+        registry = app_state.container_registry
         monkeypatch.setattr(container, "IDLE_TIMEOUT_SECONDS", 90)
         sock = _mock_sock()
         workspace = await _create_workspace_with_acl(user["id"], "frac-ws")
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
 
         async def fake_start(wid, workspace):
             conn.container_id = "cid"
@@ -8112,7 +8567,7 @@ class TestFractionalTimeout:
                 side_effect=fake_start,
             ),
             patch.object(
-                container.registry,
+                registry,
                 "get_workspace_ports",
                 return_value=[],
             ),
@@ -8126,13 +8581,15 @@ class TestFractionalTimeout:
 
 class TestDispatchBrowserRequestCancelled:
     async def test_cancelled_cleans_up(self):
-        session = wshandler.state.get_or_create_session("ws-cancel")
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        session = sockets.get_or_create_session("ws-cancel", app_state)
         mock_sock = _mock_sock()
         session.subscribers.add(mock_sock)
         session.browser_subscribers.add(mock_sock)
         try:
             # Snapshot request IDs before so we can check ours was cleaned up
-            before = set(wshandler.state.pending_browser_requests.keys())
+            before = set(sockets.pending_browser_requests.keys())
             task = asyncio.create_task(
                 session.dispatch_browser_request(
                     {"action": "fetch"},
@@ -8141,22 +8598,22 @@ class TestDispatchBrowserRequestCancelled:
             )
             await asyncio.sleep(0.05)
             # Find the new request_id added by our dispatch
-            new_ids = (
-                set(wshandler.state.pending_browser_requests.keys()) - before
-            )
+            new_ids = set(sockets.pending_browser_requests.keys()) - before
             task.cancel()
             with pytest.raises(asyncio.CancelledError):
                 await task
             # Our request should have been cleaned up
             for rid in new_ids:
-                assert rid not in wshandler.state.pending_browser_requests
+                assert rid not in sockets.pending_browser_requests
         finally:
-            wshandler.state.sessions.pop("ws-cancel", None)
+            sockets.sessions.pop("ws-cancel", None)
 
 
 class TestDispatchBrowserRequestDeadSubscribers:
     async def test_all_subscribers_dead(self):
-        session = wshandler.state.get_or_create_session("ws-all-dead")
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        session = sockets.get_or_create_session("ws-all-dead", app_state)
         dead_sock = _mock_sock()
         dead_sock.send_json = MagicMock(side_effect=RuntimeError("ws closed"))
         session.subscribers.add(dead_sock)
@@ -8168,7 +8625,7 @@ class TestDispatchBrowserRequestDeadSubscribers:
             assert "error" in result
             assert "No browser client" in result["error"]
         finally:
-            wshandler.state.sessions.pop("ws-all-dead", None)
+            sockets.sessions.pop("ws-all-dead", None)
 
 
 class TestSendQueueBehavior:
@@ -8176,6 +8633,7 @@ class TestSendQueueBehavior:
 
     async def test_slow_client_closes_connection(self, user):
         """When the send queue is full, handle_websocket drops the client."""
+        app_state = _make_app_state()
         from klangk_backend import auth as auth_mod
 
         token = auth_mod.create_token(user["id"], user["email"])
@@ -8197,7 +8655,9 @@ class TestSendQueueBehavior:
         websocket.receive_text = AsyncMock(side_effect=msgs)
 
         # Should complete without hanging — SlowClientError triggers exit
-        await asyncio.wait_for(handle_websocket(websocket), timeout=5.0)
+        await asyncio.wait_for(
+            handle_websocket(websocket, app_state), timeout=5.0
+        )
 
     async def test_normal_sends_go_through_queue(self):
         """Messages sent via SafeWebSocket.send_json arrive at raw ws."""
@@ -8213,7 +8673,9 @@ class TestSendQueueBehavior:
 
     async def test_slow_client_in_broadcast(self):
         """Broadcast drops slow subscribers instead of blocking."""
-        session = wshandler.state.get_or_create_session("ws-slow-bcast")
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        session = sockets.get_or_create_session("ws-slow-bcast", app_state)
         live_sock = _mock_sock()
         slow_sock = _mock_sock()
         slow_sock.send_json = MagicMock(side_effect=SlowClientError("full"))
@@ -8225,7 +8687,7 @@ class TestSendQueueBehavior:
             assert slow_sock not in session.subscribers
             assert live_sock in session.subscribers
         finally:
-            wshandler.state.sessions.pop("ws-slow-bcast", None)
+            sockets.sessions.pop("ws-slow-bcast", None)
 
     async def test_slow_client_in_terminal_forwarding(self):
         """Terminal forwarder handles SlowClientError gracefully."""
@@ -8244,6 +8706,8 @@ class TestSendQueueBehavior:
 
     async def test_slow_client_in_exec_forwarding(self):
         """Exec forwarder handles SlowClientError gracefully."""
+        app_state = _make_app_state()
+        registry = app_state.container_registry
         sock = _mock_sock()
         sock.send_json = MagicMock(side_effect=SlowClientError("full"))
         session = AsyncMock()
@@ -8252,9 +8716,9 @@ class TestSendQueueBehavior:
             yield b"data"
 
         session.output = fake_output
-        conn = _base_conn(ws=sock)
+        conn = _base_conn(ws=sock, app_state=app_state)
         conn.container_id = "cid"
-        with patch.object(container.registry, "record_activity"):
+        with patch.object(registry, "record_activity"):
             await conn.forward_exec_output(session)
         # Should not raise
 
@@ -8339,17 +8803,19 @@ class TestChatFollowUp:
         self, workspace, user, agent_user
     ):
         """Same user's follow-up routes without timer."""
-        from klangk_backend.wshandler import state, agent_conversations
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        from klangk_backend.wshandler import agent_conversations
 
         mock_session = AsyncMock()
         mock_session.output = _empty_async_generator
         mock_session.send_prompt = AsyncMock(return_value="reply")
 
         sock = _mock_sock()
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.workspace_id = workspace["id"]
         conn.container_id = "cid"
-        session = state.get_or_create_session(workspace["id"])
+        session = sockets.get_or_create_session(workspace["id"], app_state)
         await session.add_subscriber(sock, "cid")
         try:
             agent_conversations[workspace["id"]] = {
@@ -8378,17 +8844,19 @@ class TestChatFollowUp:
         self, workspace, user, agent_user
     ):
         """After interjection, follow-up within 30s still routes."""
-        from klangk_backend.wshandler import state, agent_conversations
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        from klangk_backend.wshandler import agent_conversations
 
         mock_session = AsyncMock()
         mock_session.output = _empty_async_generator
         mock_session.send_prompt = AsyncMock(return_value="reply")
 
         sock = _mock_sock()
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.workspace_id = workspace["id"]
         conn.container_id = "cid"
-        session = state.get_or_create_session(workspace["id"])
+        session = sockets.get_or_create_session(workspace["id"], app_state)
         await session.add_subscriber(sock, "cid")
         try:
             agent_conversations[workspace["id"]] = {
@@ -8415,13 +8883,15 @@ class TestChatFollowUp:
 
     async def test_interjection_expired(self, workspace, user, agent_user):
         """After interjection + 30s, follow-up does NOT route."""
-        from klangk_backend.wshandler import state, agent_conversations
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        from klangk_backend.wshandler import agent_conversations
 
         sock = _mock_sock()
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.workspace_id = workspace["id"]
         conn.container_id = "cid"
-        session = state.get_or_create_session(workspace["id"])
+        session = sockets.get_or_create_session(workspace["id"], app_state)
         await session.add_subscriber(sock, "cid")
         try:
             agent_conversations[workspace["id"]] = {
@@ -8446,14 +8916,16 @@ class TestChatFollowUp:
         self, workspace, user, agent_user
     ):
         """A different user's message marks interjection."""
-        from klangk_backend.wshandler import state, agent_conversations
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        from klangk_backend.wshandler import agent_conversations
 
         sock = _mock_sock()
         other_user = {"id": "other-uid", "email": "other@test.com"}
-        conn = _base_conn(user=other_user, ws=sock)
+        conn = _base_conn(user=other_user, ws=sock, app_state=app_state)
         conn.workspace_id = workspace["id"]
         conn.container_id = "cid"
-        session = state.get_or_create_session(workspace["id"])
+        session = sockets.get_or_create_session(workspace["id"], app_state)
         await session.add_subscriber(sock, "cid")
         try:
             agent_conversations[workspace["id"]] = {
@@ -8472,13 +8944,15 @@ class TestChatFollowUp:
         self, workspace, user, agent_user
     ):
         """Message starting with @someone else breaks conversation."""
-        from klangk_backend.wshandler import state, agent_conversations
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        from klangk_backend.wshandler import agent_conversations
 
         sock = _mock_sock()
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.workspace_id = workspace["id"]
         conn.container_id = "cid"
-        session = state.get_or_create_session(workspace["id"])
+        session = sockets.get_or_create_session(workspace["id"], app_state)
         await session.add_subscriber(sock, "cid")
         try:
             agent_conversations[workspace["id"]] = {
@@ -8513,12 +8987,14 @@ class TestChatSend:
             yield
 
     async def test_chat_send_broadcasts(self, workspace, user, agent_user):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         sock1 = _mock_sock()
         sock2 = _mock_sock()
-        conn = _base_conn(user=user, ws=sock1)
+        conn = _base_conn(user=user, ws=sock1, app_state=app_state)
         conn.workspace_id = workspace["id"]
 
-        session = wshandler.state.get_or_create_session(workspace["id"])
+        session = sockets.get_or_create_session(workspace["id"], app_state)
         session.subscribers.add(sock1)
         session.subscribers.add(sock2)
         try:
@@ -8534,22 +9010,24 @@ class TestChatSend:
             assert "created_at" in sent
             assert sent["mentions"] == []
         finally:
-            wshandler.state.sessions.pop(workspace["id"], None)
+            sockets.sessions.pop(workspace["id"], None)
 
     async def test_chat_send_with_mention(self, workspace, user, agent_user):
         """Broadcast includes mention user IDs when @email is used."""
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         sock = _mock_sock()
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.workspace_id = workspace["id"]
 
-        session = wshandler.state.get_or_create_session(workspace["id"])
+        session = sockets.get_or_create_session(workspace["id"], app_state)
         session.subscribers.add(sock)
         try:
             await conn.handle_chat_send({"message": f"hey @{user['email']}"})
             sent = sock.send_json.call_args[0][0]
             assert sent["mentions"] == [user["id"]]
         finally:
-            wshandler.state.sessions.pop(workspace["id"], None)
+            sockets.sessions.pop(workspace["id"], None)
 
     async def test_chat_send_no_workspace(self):
         sock = _mock_sock()
@@ -8597,7 +9075,8 @@ class TestChatSend:
 
     async def test_chat_send_agent_mention(self, workspace, user, agent_user):
         """@clanker sends thinking event + agent response."""
-        from klangk_backend.wshandler import state
+        app_state = _make_app_state()
+        sockets = app_state.sockets
 
         # Seed a prior agent message so context filtering is exercised
         agent_email = await model.agent_email()
@@ -8621,10 +9100,10 @@ class TestChatSend:
         mock_session.send_prompt = AsyncMock(return_value="The time is now.")
 
         sock = _mock_sock()
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.workspace_id = workspace["id"]
         conn.container_id = "cid"
-        session = state.get_or_create_session(workspace["id"])
+        session = sockets.get_or_create_session(workspace["id"], app_state)
         await session.add_subscriber(sock, "cid")
         try:
             with patch(
@@ -8666,17 +9145,18 @@ class TestChatSend:
         self, workspace, user, agent_user
     ):
         """@clanker with no prompt uses default greeting."""
-        from klangk_backend.wshandler import state
+        app_state = _make_app_state()
+        sockets = app_state.sockets
 
         mock_session = AsyncMock()
         mock_session.output = _empty_async_generator
         mock_session.send_prompt = AsyncMock(return_value="Hi there!")
 
         sock = _mock_sock()
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.workspace_id = workspace["id"]
         conn.container_id = "cid"
-        session = state.get_or_create_session(workspace["id"])
+        session = sockets.get_or_create_session(workspace["id"], app_state)
         await session.add_subscriber(sock, "cid")
         try:
             with patch(
@@ -8699,13 +9179,14 @@ class TestChatSend:
 
     async def test_chat_send_agent_error(self, workspace, user, agent_user):
         """Agent error posts error message."""
-        from klangk_backend.wshandler import state
+        app_state = _make_app_state()
+        sockets = app_state.sockets
 
         sock = _mock_sock()
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.workspace_id = workspace["id"]
         conn.container_id = "cid"
-        session = state.get_or_create_session(workspace["id"])
+        session = sockets.get_or_create_session(workspace["id"], app_state)
         await session.add_subscriber(sock, "cid")
         try:
             with patch(
@@ -8730,7 +9211,8 @@ class TestChatSend:
         self, workspace, user, agent_user
     ):
         """Agent process death posts system message."""
-        from klangk_backend.wshandler import state
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         from klangk_backend.agent import AgentProcessDied
 
         mock_session = AsyncMock()
@@ -8740,10 +9222,10 @@ class TestChatSend:
         )
 
         sock = _mock_sock()
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.workspace_id = workspace["id"]
         conn.container_id = "cid"
-        session = state.get_or_create_session(workspace["id"])
+        session = sockets.get_or_create_session(workspace["id"], app_state)
         await session.add_subscriber(sock, "cid")
         try:
             with patch(
@@ -8768,12 +9250,13 @@ class TestChatSend:
         self, workspace, user, agent_user
     ):
         """Messages without @clanker don't trigger agent response."""
-        from klangk_backend.wshandler import state
+        app_state = _make_app_state()
+        sockets = app_state.sockets
 
         sock = _mock_sock()
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.workspace_id = workspace["id"]
-        session = state.get_or_create_session(workspace["id"])
+        session = sockets.get_or_create_session(workspace["id"], app_state)
         await session.add_subscriber(sock, "cid")
         try:
             await conn.handle_chat_send({"message": "hello everyone"})
@@ -8794,11 +9277,12 @@ class TestChatSend:
     ):
         """A second rapid @mention cancels the prior in-flight run, and abort
         then reaches the latest run instead of an orphaned task."""
-        from klangk_backend.wshandler import state
+        app_state = _make_app_state()
+        sockets = app_state.sockets
 
         sock1 = _mock_sock()
         sock2 = _mock_sock()
-        conn1 = _base_conn(user=user, ws=sock1)
+        conn1 = _base_conn(user=user, ws=sock1, app_state=app_state)
         conn1.workspace_id = workspace["id"]
         conn1.container_id = "cid"
         user2 = {
@@ -8806,15 +9290,17 @@ class TestChatSend:
             "email": "second@test.com",
             "handle": "second",
         }
-        conn2 = _base_conn(user=user2, ws=sock2)
+        conn2 = _base_conn(user=user2, ws=sock2, app_state=app_state)
         conn2.workspace_id = workspace["id"]
         conn2.container_id = "cid"
 
-        session = state.get_or_create_session(workspace["id"])
+        session = sockets.get_or_create_session(workspace["id"], app_state)
         await session.add_subscriber(sock1, "cid")
         await session.add_subscriber(sock2, "cid")
 
-        async def slow_mention(workspace_id, container_id, text, **kwargs):
+        async def slow_mention(
+            sockets, workspace_id, container_id, text, **kwargs
+        ):
             await asyncio.sleep(999)
 
         try:
@@ -8846,6 +9332,8 @@ class TestChatSend:
             wshandler.agent_conversations.pop(workspace["id"], None)
 
     async def test_chat_history_on_connect(self, user, agent_user):
+        app_state = _make_app_state()
+        registry = app_state.container_registry
         from klangk_backend import model
 
         workspace = await _create_workspace_with_acl(user["id"], "chat-ws")
@@ -8854,7 +9342,7 @@ class TestChatSend:
         )
 
         sock = _mock_sock()
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
 
         async def fake_start(wid, ws_obj):
             conn.container_id = "cid"
@@ -8866,7 +9354,7 @@ class TestChatSend:
                 side_effect=fake_start,
             ),
             patch.object(
-                container.registry,
+                registry,
                 "get_workspace_ports",
                 return_value=[],
             ),
@@ -8920,15 +9408,18 @@ class TestChatSend:
 class TestPresence:
     async def test_presence_list_on_connect(self, user, agent_user):
         """Joining user receives presence_list with current users."""
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        registry = app_state.container_registry
         workspace = await _create_workspace_with_acl(user["id"], "pres-ws")
 
         sock = _mock_sock()
-        conn = _base_conn(user=user, ws=sock)
-        wshandler.state.connections[sock] = conn
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
+        sockets.connections[sock] = conn
 
         async def fake_start(wid, ws_obj):
             conn.container_id = "cid"
-            session = wshandler.state.get_or_create_session(wid)
+            session = sockets.get_or_create_session(wid, app_state)
             await session.add_subscriber(sock, "cid")
 
         try:
@@ -8939,7 +9430,7 @@ class TestPresence:
                     side_effect=fake_start,
                 ),
                 patch.object(
-                    container.registry,
+                    registry,
                     "get_workspace_ports",
                     return_value=[],
                 ),
@@ -8953,11 +9444,14 @@ class TestPresence:
             assert len(plist) == 1
             assert any(u["user_id"] == user["id"] for u in plist[0]["users"])
         finally:
-            wshandler.state.sessions.pop(workspace["id"], None)
-            wshandler.state.connections.pop(sock, None)
+            sockets.sessions.pop(workspace["id"], None)
+            sockets.connections.pop(sock, None)
 
     async def test_presence_join_broadcast(self, user, agent_user):
         """Existing subscribers receive presence_join when someone connects."""
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        registry = app_state.container_registry
         from klangk_backend import model
 
         workspace = await _create_workspace_with_acl(
@@ -8966,11 +9460,11 @@ class TestPresence:
 
         # First user connects
         sock1 = _mock_sock()
-        conn1 = _base_conn(user=user, ws=sock1)
+        conn1 = _base_conn(user=user, ws=sock1, app_state=app_state)
 
-        session = wshandler.state.get_or_create_session(workspace["id"])
+        session = sockets.get_or_create_session(workspace["id"], app_state)
         session.subscribers.add(sock1)
-        wshandler.state.connections[sock1] = conn1
+        sockets.connections[sock1] = conn1
         conn1.workspace_id = workspace["id"]
 
         # Second user connects
@@ -8993,12 +9487,13 @@ class TestPresence:
                 "handle": other.get("handle", ""),
             },
             ws=sock2,
+            app_state=app_state,
         )
-        wshandler.state.connections[sock2] = conn2
+        sockets.connections[sock2] = conn2
 
         async def fake_start(wid, ws_obj):
             conn2.container_id = "cid"
-            session = wshandler.state.get_or_create_session(wid)
+            session = sockets.get_or_create_session(wid, app_state)
             await session.add_subscriber(sock2, "cid")
 
         try:
@@ -9009,7 +9504,7 @@ class TestPresence:
                     side_effect=fake_start,
                 ),
                 patch.object(
-                    container.registry,
+                    registry,
                     "get_workspace_ports",
                     return_value=[],
                 ),
@@ -9026,37 +9521,41 @@ class TestPresence:
             assert joins[0]["user_email"] == "other@test.com"
             assert "user_handle" in joins[0]
         finally:
-            wshandler.state.sessions.pop(workspace["id"], None)
-            wshandler.state.connections.pop(sock1, None)
-            wshandler.state.connections.pop(sock2, None)
+            sockets.sessions.pop(workspace["id"], None)
+            sockets.connections.pop(sock1, None)
+            sockets.connections.pop(sock2, None)
 
     async def test_presence_leave_broadcast(self, user):
         """Remaining subscribers receive presence_leave after debounce."""
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         from klangk_backend import model
 
         workspace = await _create_workspace_with_acl(user["id"], "pres-lv-ws")
 
         sock1 = _mock_sock()
         sock2 = _mock_sock()
-        conn1 = _base_conn(user=user, ws=sock1)
+        conn1 = _base_conn(user=user, ws=sock1, app_state=app_state)
         other = await model.create_user("lv@test.com", "hash", verified=True)
         conn2 = _base_conn(
-            user={"id": other["id"], "email": "lv@test.com"}, ws=sock2
+            user={"id": other["id"], "email": "lv@test.com"},
+            ws=sock2,
+            app_state=app_state,
         )
         conn1.workspace_id = workspace["id"]
         conn2.workspace_id = workspace["id"]
 
-        session = WorkspaceSession(workspace["id"])
+        session = WorkspaceSession(workspace["id"], app_state)
         session.subscribers.add(sock1)
         session.subscribers.add(sock2)
-        wshandler.state.sessions[workspace["id"]] = session
-        wshandler.state.connections[sock1] = conn1
-        wshandler.state.connections[sock2] = conn2
+        sockets.sessions[workspace["id"]] = session
+        sockets.connections[sock1] = conn1
+        sockets.connections[sock2] = conn2
 
-        saved_delay = wshandler.state.PRESENCE_LEAVE_DELAY
+        saved_delay = sockets.PRESENCE_LEAVE_DELAY
         try:
             # Use a tiny delay so the test completes quickly
-            wshandler.state.PRESENCE_LEAVE_DELAY = 0.05
+            sockets.PRESENCE_LEAVE_DELAY = 0.05
 
             # conn2 disconnects — leave is debounced, not immediate
             await conn2.cleanup()
@@ -9072,14 +9571,17 @@ class TestPresence:
             assert len(leaves) == 1
             assert leaves[0]["user_id"] == other["id"]
         finally:
-            wshandler.state.PRESENCE_LEAVE_DELAY = saved_delay
-            wshandler.state._pending_leaves.clear()
-            wshandler.state.sessions.pop(workspace["id"], None)
-            wshandler.state.connections.pop(sock1, None)
-            wshandler.state.connections.pop(sock2, None)
+            sockets.PRESENCE_LEAVE_DELAY = saved_delay
+            sockets._pending_leaves.clear()
+            sockets.sessions.pop(workspace["id"], None)
+            sockets.connections.pop(sock1, None)
+            sockets.connections.pop(sock2, None)
 
     async def test_presence_leave_suppressed_on_reconnect(self, user):
         """Reconnecting within debounce window suppresses leave and join."""
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        registry = app_state.container_registry
         from klangk_backend import model
 
         workspace = await _create_workspace_with_acl(
@@ -9102,35 +9604,35 @@ class TestPresence:
             "handle": other.get("handle", ""),
         }
         sock2 = _mock_sock()  # flapping user
-        conn1 = _base_conn(user=user, ws=sock1)
-        conn2 = _base_conn(user=other_user, ws=sock2)
+        conn1 = _base_conn(user=user, ws=sock1, app_state=app_state)
+        conn2 = _base_conn(user=other_user, ws=sock2, app_state=app_state)
         conn1.workspace_id = workspace["id"]
         conn2.workspace_id = workspace["id"]
 
-        session = WorkspaceSession(workspace["id"])
+        session = WorkspaceSession(workspace["id"], app_state)
         session.subscribers.add(sock1)
         session.subscribers.add(sock2)
-        wshandler.state.sessions[workspace["id"]] = session
-        wshandler.state.connections[sock1] = conn1
-        wshandler.state.connections[sock2] = conn2
+        sockets.sessions[workspace["id"]] = session
+        sockets.connections[sock1] = conn1
+        sockets.connections[sock2] = conn2
 
-        saved_delay = wshandler.state.PRESENCE_LEAVE_DELAY
+        saved_delay = sockets.PRESENCE_LEAVE_DELAY
         try:
-            wshandler.state.PRESENCE_LEAVE_DELAY = 5.0  # long enough to cancel
+            sockets.PRESENCE_LEAVE_DELAY = 5.0  # long enough to cancel
 
             # conn2 disconnects — pending leave scheduled
             await conn2.cleanup()
             key = (workspace["id"], other["id"])
-            assert key in wshandler.state._pending_leaves
+            assert key in sockets._pending_leaves
 
             # conn2 reconnects — cancel pending leave
             sock3 = _mock_sock()
-            conn3 = _base_conn(user=other_user, ws=sock3)
-            wshandler.state.connections[sock3] = conn3
+            conn3 = _base_conn(user=other_user, ws=sock3, app_state=app_state)
+            sockets.connections[sock3] = conn3
 
             async def fake_start(wid, ws_obj):
                 conn3.container_id = "cid"
-                s = wshandler.state.get_or_create_session(wid)
+                s = sockets.get_or_create_session(wid, app_state)
                 await s.add_subscriber(sock3, "cid")
 
             with (
@@ -9140,7 +9642,7 @@ class TestPresence:
                     side_effect=fake_start,
                 ),
                 patch.object(
-                    container.registry,
+                    registry,
                     "get_workspace_ports",
                     return_value=[],
                 ),
@@ -9150,7 +9652,7 @@ class TestPresence:
                 )
 
             # Pending leave should be cancelled
-            assert key not in wshandler.state._pending_leaves
+            assert key not in sockets._pending_leaves
 
             # Observer should NOT have received presence_leave or
             # presence_join (the user never visibly left)
@@ -9169,15 +9671,17 @@ class TestPresence:
             ]
             assert len(chats) == 0
         finally:
-            wshandler.state.PRESENCE_LEAVE_DELAY = saved_delay
-            wshandler.state._pending_leaves.clear()
-            wshandler.state.sessions.pop(workspace["id"], None)
-            wshandler.state.connections.pop(sock1, None)
-            wshandler.state.connections.pop(sock2, None)
-            wshandler.state.connections.pop(sock3, None)
+            sockets.PRESENCE_LEAVE_DELAY = saved_delay
+            sockets._pending_leaves.clear()
+            sockets.sessions.pop(workspace["id"], None)
+            sockets.connections.pop(sock1, None)
+            sockets.connections.pop(sock2, None)
+            sockets.connections.pop(sock3, None)
 
     async def test_presence_leave_multi_tab(self, user):
         """No presence_leave if user has another connection in workspace."""
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         from klangk_backend import model
 
         workspace = await _create_workspace_with_acl(user["id"], "pres-mt-ws")
@@ -9186,24 +9690,26 @@ class TestPresence:
         sock2 = _mock_sock()
         sock3 = _mock_sock()
         # sock1 and sock2 are same user, sock3 is another user
-        conn1 = _base_conn(user=user, ws=sock1)
-        conn2 = _base_conn(user=user, ws=sock2)
+        conn1 = _base_conn(user=user, ws=sock1, app_state=app_state)
+        conn2 = _base_conn(user=user, ws=sock2, app_state=app_state)
         other = await model.create_user("mt@test.com", "hash", verified=True)
         conn3 = _base_conn(
-            user={"id": other["id"], "email": "mt@test.com"}, ws=sock3
+            user={"id": other["id"], "email": "mt@test.com"},
+            ws=sock3,
+            app_state=app_state,
         )
         conn1.workspace_id = workspace["id"]
         conn2.workspace_id = workspace["id"]
         conn3.workspace_id = workspace["id"]
 
-        session = WorkspaceSession(workspace["id"])
+        session = WorkspaceSession(workspace["id"], app_state)
         session.subscribers.add(sock1)
         session.subscribers.add(sock2)
         session.subscribers.add(sock3)
-        wshandler.state.sessions[workspace["id"]] = session
-        wshandler.state.connections[sock1] = conn1
-        wshandler.state.connections[sock2] = conn2
-        wshandler.state.connections[sock3] = conn3
+        sockets.sessions[workspace["id"]] = session
+        sockets.connections[sock1] = conn1
+        sockets.connections[sock2] = conn2
+        sockets.connections[sock3] = conn3
 
         try:
             # sock1 disconnects, but sock2 (same user) remains
@@ -9213,28 +9719,32 @@ class TestPresence:
             leaves = [c for c in calls3 if c.get("type") == "presence_leave"]
             assert len(leaves) == 0
         finally:
-            wshandler.state.sessions.pop(workspace["id"], None)
-            wshandler.state.connections.pop(sock1, None)
-            wshandler.state.connections.pop(sock2, None)
-            wshandler.state.connections.pop(sock3, None)
+            sockets.sessions.pop(workspace["id"], None)
+            sockets.connections.pop(sock1, None)
+            sockets.connections.pop(sock2, None)
+            sockets.connections.pop(sock3, None)
 
 
 class TestRefreshUserHandle:
     async def test_refresh_updates_connections_and_broadcasts(self, user):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         workspace = await _create_workspace_with_acl(
             user["id"], "handle-refresh-ws"
         )
         sock = _mock_sock()
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.workspace_id = workspace["id"]
 
-        session = WorkspaceSession(workspace["id"])
+        session = WorkspaceSession(workspace["id"], app_state)
         session.subscribers.add(sock)
-        wshandler.state.sessions[workspace["id"]] = session
-        wshandler.state.connections[sock] = conn
+        sockets.sessions[workspace["id"]] = session
+        sockets.connections[sock] = conn
 
         try:
-            await wshandler.refresh_user_handle(user["id"], "newhandle")
+            await wshandler.refresh_user_handle(
+                sockets, user["id"], "newhandle"
+            )
             assert conn.user["handle"] == "newhandle"
             calls = [c[0][0] for c in sock.send_json.call_args_list]
             plist = [c for c in calls if c.get("type") == "presence_list"]
@@ -9246,20 +9756,24 @@ class TestRefreshUserHandle:
             assert len(chats) == 1
             assert "is now known as newhandle" in chats[0]["message"]
         finally:
-            wshandler.state.sessions.pop(workspace["id"], None)
-            wshandler.state.connections.pop(sock, None)
+            sockets.sessions.pop(workspace["id"], None)
+            sockets.connections.pop(sock, None)
 
     async def test_refresh_no_connections(self):
-        await wshandler.refresh_user_handle("nonexistent", "whatever")
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        await wshandler.refresh_user_handle(sockets, "nonexistent", "whatever")
 
 
 class TestChatDelete:
     async def test_chat_delete_broadcasts_update(self, user):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         from klangk_backend import model
 
         workspace = await ws_mod.create_workspace(user["id"], "chat-del-ws")
         sock = _mock_sock()
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.workspace_id = workspace["id"]
         conn.container_id = "cid"
 
@@ -9267,9 +9781,9 @@ class TestChatDelete:
             workspace["id"], user["id"], "u@test.com", "delete me"
         )
 
-        session = WorkspaceSession(workspace["id"])
+        session = WorkspaceSession(workspace["id"], app_state)
         session.subscribers.add(sock)
-        wshandler.state.sessions[workspace["id"]] = session
+        sockets.sessions[workspace["id"]] = session
 
         await conn.handle_chat_delete({"message_id": msg["id"]})
 
@@ -9279,7 +9793,7 @@ class TestChatDelete:
         assert updated[0]["message_id"] == msg["id"]
         assert updated[0]["message"] == "<message deleted by author>"
 
-        wshandler.state.sessions.pop(workspace["id"], None)
+        sockets.sessions.pop(workspace["id"], None)
 
     async def test_chat_delete_wrong_user_ignored(self, user):
         from klangk_backend import model
@@ -9326,44 +9840,54 @@ class TestBridgeIdleTimeout:
 
 class TestHandleBrowserChunk:
     def test_missing_id(self):
-        wshandler.state.handle_browser_chunk({})  # no raise
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        sockets.handle_browser_chunk({})  # no raise
 
     def test_unknown_id(self):
-        wshandler.state.handle_browser_chunk({"id": "nope", "delta": "x"})
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        sockets.handle_browser_chunk({"id": "nope", "delta": "x"})
 
     def test_wrong_sender_ignored(self):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         q: asyncio.Queue = asyncio.Queue()
         expected = _mock_sock()
         imposter = _mock_sock()
-        wshandler.state.streaming_browser_requests["c-1"] = (q, expected)
+        sockets.streaming_browser_requests["c-1"] = (q, expected)
         try:
-            wshandler.state.handle_browser_chunk(
+            sockets.handle_browser_chunk(
                 {"id": "c-1", "delta": "x"}, sender=imposter
             )
             assert q.empty()
         finally:
-            wshandler.state.streaming_browser_requests.pop("c-1", None)
+            sockets.streaming_browser_requests.pop("c-1", None)
 
     def test_success(self):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         q: asyncio.Queue = asyncio.Queue()
         sock = _mock_sock()
-        wshandler.state.streaming_browser_requests["c-2"] = (q, sock)
+        sockets.streaming_browser_requests["c-2"] = (q, sock)
         try:
-            wshandler.state.handle_browser_chunk(
+            sockets.handle_browser_chunk(
                 {"id": "c-2", "delta": "hello"}, sender=sock
             )
             assert q.get_nowait() == {"type": "chunk", "delta": "hello"}
         finally:
-            wshandler.state.streaming_browser_requests.pop("c-2", None)
+            sockets.streaming_browser_requests.pop("c-2", None)
 
 
 class TestHandleBrowserResponseStreaming:
     def test_done_enqueued(self):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         q: asyncio.Queue = asyncio.Queue()
         sock = _mock_sock()
-        wshandler.state.streaming_browser_requests["d-1"] = (q, sock)
+        sockets.streaming_browser_requests["d-1"] = (q, sock)
         try:
-            wshandler.state.handle_browser_response(
+            sockets.handle_browser_response(
                 {"id": "d-1", "cmd": "browser_response", "text": "final"},
                 sender=sock,
             )
@@ -9372,25 +9896,29 @@ class TestHandleBrowserResponseStreaming:
                 "result": {"text": "final"},
             }
         finally:
-            wshandler.state.streaming_browser_requests.pop("d-1", None)
+            sockets.streaming_browser_requests.pop("d-1", None)
 
     def test_wrong_sender_ignored(self):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         q: asyncio.Queue = asyncio.Queue()
         expected = _mock_sock()
         imposter = _mock_sock()
-        wshandler.state.streaming_browser_requests["d-2"] = (q, expected)
+        sockets.streaming_browser_requests["d-2"] = (q, expected)
         try:
-            wshandler.state.handle_browser_response(
+            sockets.handle_browser_response(
                 {"id": "d-2", "text": "x"}, sender=imposter
             )
             assert q.empty()
         finally:
-            wshandler.state.streaming_browser_requests.pop("d-2", None)
+            sockets.streaming_browser_requests.pop("d-2", None)
 
 
 class TestDispatchBrowserRequestStreamTo:
     async def test_streams_chunks_then_done(self):
-        session = wshandler.state.get_or_create_session("ws-stream")
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        session = sockets.get_or_create_session("ws-stream", app_state)
         sock = _mock_sock()
         session.subscribers.add(sock)
         session.browser_subscribers.add(sock)
@@ -9398,15 +9926,15 @@ class TestDispatchBrowserRequestStreamTo:
         async def feed():
             await asyncio.sleep(0.05)
             for rid, (_q, _s) in list(
-                wshandler.state.streaming_browser_requests.items()
+                sockets.streaming_browser_requests.items()
             ):
-                wshandler.state.handle_browser_chunk(
+                sockets.handle_browser_chunk(
                     {"id": rid, "delta": "hel"}, sender=sock
                 )
-                wshandler.state.handle_browser_chunk(
+                sockets.handle_browser_chunk(
                     {"id": rid, "delta": "lo"}, sender=sock
                 )
-                wshandler.state.handle_browser_response(
+                sockets.handle_browser_response(
                     {"id": rid, "cmd": "browser_response", "text": "hello"},
                     sender=sock,
                 )
@@ -9424,13 +9952,15 @@ class TestDispatchBrowserRequestStreamTo:
             assert lines[2]["type"] == "done"
             assert lines[2]["result"]["text"] == "hello"
             # cleaned up after the stream ends
-            assert not wshandler.state.streaming_browser_requests
+            assert not sockets.streaming_browser_requests
         finally:
             await task
-            wshandler.state.sessions.pop("ws-stream", None)
+            sockets.sessions.pop("ws-stream", None)
 
     async def test_send_failure_yields_error(self):
-        session = wshandler.state.get_or_create_session("ws-stream-dead")
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        session = sockets.get_or_create_session("ws-stream-dead", app_state)
         sock = _mock_sock()
         sock.send_json = MagicMock(side_effect=RuntimeError("dead"))
         try:
@@ -9443,12 +9973,14 @@ class TestDispatchBrowserRequestStreamTo:
             assert len(lines) == 1
             assert lines[0]["type"] == "error"
             assert "not available" in lines[0]["error"]
-            assert not wshandler.state.streaming_browser_requests
+            assert not sockets.streaming_browser_requests
         finally:
-            wshandler.state.sessions.pop("ws-stream-dead", None)
+            sockets.sessions.pop("ws-stream-dead", None)
 
     async def test_idle_timeout_yields_error(self):
-        session = wshandler.state.get_or_create_session("ws-stream-to")
+        app_state = _make_app_state()
+        sockets = app_state.sockets
+        session = sockets.get_or_create_session("ws-stream-to", app_state)
         sock = _mock_sock()
         try:
             lines = [
@@ -9460,11 +9992,13 @@ class TestDispatchBrowserRequestStreamTo:
             assert len(lines) == 1
             assert lines[0]["type"] == "error"
             assert "timeout" in lines[0]["error"].lower()
-            assert not wshandler.state.streaming_browser_requests
+            assert not sockets.streaming_browser_requests
         finally:
-            wshandler.state.sessions.pop("ws-stream-to", None)
+            sockets.sessions.pop("ws-stream-to", None)
 
     async def test_loop_dispatches_browser_chunk(self, user):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         from klangk_backend import auth as auth_mod
 
         token = auth_mod.create_token(user["id"], user["email"])
@@ -9476,11 +10010,11 @@ class TestDispatchBrowserRequestStreamTo:
             ]
         )
         with patch.object(
-            wshandler.state,
+            sockets,
             "handle_browser_chunk",
-            wraps=wshandler.state.handle_browser_chunk,
+            wraps=sockets.handle_browser_chunk,
         ) as mock:
-            await handle_websocket(websocket)
+            await handle_websocket(websocket, app_state)
         mock.assert_called_once()
 
 
@@ -9493,7 +10027,7 @@ class TestUiReadySharedTerminals:
             {"id": user["id"], "email": user["email"]},
             ws["id"],
             user_home="/home/testuser",
-        ) as (sock, conn, session):
+        ) as (sock, conn, session, app_state):
             conn.pending_status_msg = "ready"
 
             # Set up in-memory shared state
@@ -9509,19 +10043,23 @@ class TestUiReadySharedTerminals:
             )
 
     async def test_ui_ready_sends_container_ready(self, user, temp_data_dir):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         from klangk_backend import workspaces
 
         ws = await workspaces.create_workspace(user["id"], "ui-ready-cr")
         sock = _mock_sock()
         conn = _base_conn(
-            user={"id": user["id"], "email": user["email"]}, ws=sock
+            user={"id": user["id"], "email": user["email"]},
+            ws=sock,
+            app_state=app_state,
         )
         conn.workspace_id = ws["id"]
         conn.container_id = "cid"
         conn._user_home = "/home/testuser"
         conn.pending_status_msg = "ready"
 
-        session = wshandler.state.get_or_create_session(ws["id"])
+        session = sockets.get_or_create_session(ws["id"], app_state)
         await session.add_subscriber(sock, "cid")
         try:
             await conn.handle_ui_ready()
@@ -9534,14 +10072,16 @@ class TestUiReadySharedTerminals:
                 for m in sent
             )
         finally:
-            wshandler.state.sessions.pop(ws["id"], None)
+            sockets.sessions.pop(ws["id"], None)
 
 
 class TestTokenRenewal:
     async def test_renewal_creates_new_token(self, user):
         """Token renewal loop creates a new token and pushes it."""
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         workspace = await _create_workspace_with_acl(user["id"], "renew-ws")
-        session = wshandler.state.get_or_create_session(workspace["id"])
+        session = sockets.get_or_create_session(workspace["id"], app_state)
         session.container_id = "test-cid"
 
         try:
@@ -9571,12 +10111,14 @@ class TestTokenRenewal:
             decoded = wshandler.auth.decode_workspace_token(token)
             assert decoded == workspace["id"]
         finally:
-            wshandler.state.sessions.pop(workspace["id"], None)
+            sockets.sessions.pop(workspace["id"], None)
 
     async def test_renewal_retries_on_failure(self, user):
         """Token renewal retries after failure."""
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         workspace = await _create_workspace_with_acl(user["id"], "retry-ws")
-        session = wshandler.state.get_or_create_session(workspace["id"])
+        session = sockets.get_or_create_session(workspace["id"], app_state)
         session.container_id = "test-cid"
 
         try:
@@ -9618,7 +10160,7 @@ class TestTokenRenewal:
             # First call fails, retry should succeed
             assert call_count >= 2
         finally:
-            wshandler.state.sessions.pop(workspace["id"], None)
+            sockets.sessions.pop(workspace["id"], None)
 
     async def test_reset_cancels_token_renewal_task(self, user):
         """reset() cancels the token renewal task (issue #871).
@@ -9627,8 +10169,10 @@ class TestTokenRenewal:
         container is killed and the session is reset, leaking a task
         that renews tokens for a dead container forever.
         """
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         workspace = await _create_workspace_with_acl(user["id"], "leak-ws")
-        session = wshandler.state.get_or_create_session(workspace["id"])
+        session = sockets.get_or_create_session(workspace["id"], app_state)
         session.container_id = "test-cid"
 
         try:
@@ -9659,13 +10203,15 @@ class TestTokenRenewal:
             await asyncio.sleep(0.3)
             assert mock_set.call_count == calls_before
         finally:
-            wshandler.state.sessions.pop(workspace["id"], None)
+            sockets.sessions.pop(workspace["id"], None)
 
     async def test_concurrent_add_subscriber_no_duplicate_renewal(self, user):
         """Two concurrent add_subscriber calls must not create duplicate
         renewal tasks (#1299)."""
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         workspace = await _create_workspace_with_acl(user["id"], "race-ws")
-        session = wshandler.state.get_or_create_session(workspace["id"])
+        session = sockets.get_or_create_session(workspace["id"], app_state)
 
         try:
             with patch(
@@ -9692,11 +10238,12 @@ class TestTokenRenewal:
                     pass
         finally:
             await session.reset()
-            wshandler.state.sessions.pop(workspace["id"], None)
+            sockets.sessions.pop(workspace["id"], None)
 
 
 class TestSSHAgentDispatch:
     async def test_dispatch_ssh_agent_start(self, user):
+        app_state = _make_app_state()
         from klangk_backend import auth as auth_mod
 
         token = auth_mod.create_token(user["id"], user["email"])
@@ -9710,10 +10257,11 @@ class TestSSHAgentDispatch:
         with patch.object(
             Connection, "handle_ssh_agent_start", new_callable=AsyncMock
         ) as mock:
-            await handle_websocket(websocket)
+            await handle_websocket(websocket, app_state)
         mock.assert_awaited_once()
 
     async def test_dispatch_ssh_agent_data(self, user):
+        app_state = _make_app_state()
         from klangk_backend import auth as auth_mod
 
         token = auth_mod.create_token(user["id"], user["email"])
@@ -9727,10 +10275,11 @@ class TestSSHAgentDispatch:
         with patch.object(
             Connection, "handle_ssh_agent_data", new_callable=AsyncMock
         ) as mock:
-            await handle_websocket(websocket)
+            await handle_websocket(websocket, app_state)
         mock.assert_awaited_once()
 
     async def test_dispatch_ssh_agent_stop(self, user):
+        app_state = _make_app_state()
         from klangk_backend import auth as auth_mod
 
         token = auth_mod.create_token(user["id"], user["email"])
@@ -9744,10 +10293,11 @@ class TestSSHAgentDispatch:
         with patch.object(
             Connection, "handle_ssh_agent_stop", new_callable=AsyncMock
         ) as mock:
-            await handle_websocket(websocket)
+            await handle_websocket(websocket, app_state)
         mock.assert_awaited_once()
 
     async def test_dispatch_share_window(self, user):
+        app_state = _make_app_state()
         from klangk_backend import auth as auth_mod
 
         token = auth_mod.create_token(user["id"], user["email"])
@@ -9761,10 +10311,11 @@ class TestSSHAgentDispatch:
         with patch.object(
             Connection, "handle_share_window", new_callable=AsyncMock
         ) as mock:
-            await handle_websocket(websocket)
+            await handle_websocket(websocket, app_state)
         mock.assert_awaited_once()
 
     async def test_dispatch_unshare_window(self, user):
+        app_state = _make_app_state()
         from klangk_backend import auth as auth_mod
 
         token = auth_mod.create_token(user["id"], user["email"])
@@ -9778,10 +10329,11 @@ class TestSSHAgentDispatch:
         with patch.object(
             Connection, "handle_unshare_window", new_callable=AsyncMock
         ) as mock:
-            await handle_websocket(websocket)
+            await handle_websocket(websocket, app_state)
         mock.assert_awaited_once()
 
     async def test_dispatch_create_shared_terminal(self, user):
+        app_state = _make_app_state()
         from klangk_backend import auth as auth_mod
 
         token = auth_mod.create_token(user["id"], user["email"])
@@ -9795,10 +10347,11 @@ class TestSSHAgentDispatch:
         with patch.object(
             Connection, "handle_create_shared_terminal", new_callable=AsyncMock
         ) as mock:
-            await handle_websocket(websocket)
+            await handle_websocket(websocket, app_state)
         mock.assert_awaited_once()
 
     async def test_dispatch_join_shared_terminal(self, user):
+        app_state = _make_app_state()
         from klangk_backend import auth as auth_mod
 
         token = auth_mod.create_token(user["id"], user["email"])
@@ -9818,10 +10371,11 @@ class TestSSHAgentDispatch:
         with patch.object(
             Connection, "handle_join_shared_terminal", new_callable=AsyncMock
         ) as mock:
-            await handle_websocket(websocket)
+            await handle_websocket(websocket, app_state)
         mock.assert_awaited_once()
 
     async def test_dispatch_delete_shared_terminal(self, user):
+        app_state = _make_app_state()
         from klangk_backend import auth as auth_mod
 
         token = auth_mod.create_token(user["id"], user["email"])
@@ -9837,10 +10391,11 @@ class TestSSHAgentDispatch:
             "handle_delete_shared_terminal",
             new_callable=AsyncMock,
         ) as mock:
-            await handle_websocket(websocket)
+            await handle_websocket(websocket, app_state)
         mock.assert_awaited_once()
 
     async def test_dispatch_list_shared_terminals(self, user):
+        app_state = _make_app_state()
         from klangk_backend import auth as auth_mod
 
         token = auth_mod.create_token(user["id"], user["email"])
@@ -9856,10 +10411,11 @@ class TestSSHAgentDispatch:
             "handle_list_shared_terminals",
             new_callable=AsyncMock,
         ) as mock:
-            await handle_websocket(websocket)
+            await handle_websocket(websocket, app_state)
         mock.assert_awaited_once()
 
     async def test_dispatch_chat_agent_abort(self, user):
+        app_state = _make_app_state()
         from klangk_backend import auth as auth_mod
 
         token = auth_mod.create_token(user["id"], user["email"])
@@ -9873,18 +10429,20 @@ class TestSSHAgentDispatch:
         with patch.object(
             Connection, "handle_chat_agent_abort", new_callable=AsyncMock
         ) as mock:
-            await handle_websocket(websocket)
+            await handle_websocket(websocket, app_state)
         mock.assert_awaited_once()
 
 
 class TestStartAgentIfNeeded:
     async def test_starts_agent_and_broadcasts_presence(self, user, db):
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         sock = _mock_sock()
-        conn = _base_conn(user=user, ws=sock)
+        conn = _base_conn(user=user, ws=sock, app_state=app_state)
         workspace = await ws_mod.create_workspace(user["id"], "agent-ws")
         conn.workspace_id = workspace["id"]
 
-        session = state.get_or_create_session(workspace["id"])
+        session = sockets.get_or_create_session(workspace["id"], app_state)
         await session.add_subscriber(sock, "cid")
 
         mock_agent_session = AsyncMock()
@@ -9899,7 +10457,7 @@ class TestStartAgentIfNeeded:
             mock_agent_session.ensure_started.assert_awaited_once()
         finally:
             await session.remove_subscriber(sock)
-            state.sessions.pop(workspace["id"], None)
+            sockets.sessions.pop(workspace["id"], None)
 
     async def test_start_agent_logs_on_failure(self, user, db):
         sock = _mock_sock()
@@ -9994,12 +10552,15 @@ class TestPresenceIncludesAgent:
             sock,
             conn,
             session,
+            app_state,
         ):
             with patch(
                 "klangk_backend.agent.is_running",
                 side_effect=lambda ws_id: ws_id == workspace["id"],
             ):
-                users = await get_presence_list(workspace["id"])
+                users = await get_presence_list(
+                    workspace["id"], app_state.sockets
+                )
             ids = [u["user_id"] for u in users]
             assert model.AGENT_USER_ID in ids
 
@@ -10013,12 +10574,15 @@ class TestPresenceIncludesAgent:
             sock,
             conn,
             session,
+            app_state,
         ):
             with patch(
                 "klangk_backend.agent.is_running",
                 side_effect=lambda ws_id: ws_id == "other-workspace",
             ):
-                users = await get_presence_list(workspace["id"])
+                users = await get_presence_list(
+                    workspace["id"], app_state.sockets
+                )
             ids = [u["user_id"] for u in users]
             assert model.AGENT_USER_ID not in ids
 
@@ -10029,6 +10593,8 @@ class TestAgentMentionOtherMsgsContext:
     ):
         """When other users have spoken since the agent's last response,
         their messages are prepended to the prompt."""
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         from klangk_backend.wshandler import handle_agent_mention
 
         workspace = await model.create_workspace(user["id"], "ctx-ws")
@@ -10068,7 +10634,7 @@ class TestAgentMentionOtherMsgsContext:
         mock_session.send_prompt = capture_prompt
 
         sock = _mock_sock()
-        session = state.get_or_create_session(ws_id)
+        session = sockets.get_or_create_session(ws_id, app_state)
         await session.add_subscriber(sock, "cid")
 
         try:
@@ -10076,14 +10642,16 @@ class TestAgentMentionOtherMsgsContext:
                 "klangk_backend.agent.get_session",
                 return_value=mock_session,
             ):
-                await handle_agent_mention(ws_id, "cid", "@clanker what?")
+                await handle_agent_mention(
+                    sockets, ws_id, "cid", "@clanker what?"
+                )
 
             assert len(captured_prompt) == 1
             assert "user2@example.com" in captured_prompt[0]
             assert "interesting point" in captured_prompt[0]
         finally:
             await session.remove_subscriber(sock)
-            state.sessions.pop(ws_id, None)
+            sockets.sessions.pop(ws_id, None)
             wshandler.agent_tasks.pop(ws_id, None)
 
 
@@ -10113,6 +10681,8 @@ class TestAgentMentionAskerIdentity:
 
     async def test_identity_prepended_to_prompt(self, user, agent_user):
         """An @mention from a user injects that user's identity header."""
+        app_state = _make_app_state()
+        sockets = app_state.sockets
         from klangk_backend.wshandler import handle_agent_mention
 
         workspace = await model.create_workspace(user["id"], "id-ws")
@@ -10129,7 +10699,7 @@ class TestAgentMentionAskerIdentity:
         mock_session.send_prompt = capture_prompt
 
         sock = _mock_sock()
-        session = state.get_or_create_session(ws_id)
+        session = sockets.get_or_create_session(ws_id, app_state)
         await session.add_subscriber(sock, "cid")
 
         try:
@@ -10138,6 +10708,7 @@ class TestAgentMentionAskerIdentity:
                 return_value=mock_session,
             ):
                 await handle_agent_mention(
+                    sockets,
                     ws_id,
                     "cid",
                     "@clanker restart my service",
@@ -10155,14 +10726,15 @@ class TestAgentMentionAskerIdentity:
             assert "/home/somebody" in prompt
         finally:
             await session.remove_subscriber(sock)
-            state.sessions.pop(ws_id, None)
+            sockets.sessions.pop(ws_id, None)
             wshandler.agent_tasks.pop(ws_id, None)
 
 
 class TestTokenRenewalFailureLogged:
     async def test_exception_during_renewal_is_logged(self, user):
         """The except Exception branch in _token_renewal_loop."""
-        ws_session = WorkspaceSession("ws-tok")
+        app_state = _make_app_state()
+        ws_session = WorkspaceSession("ws-tok", app_state)
         ws_session.container_id = "test-cid"
         ws_session.workspace_token_expiry = datetime.now(
             timezone.utc


### PR DESCRIPTION
## Summary

- Delete `container.registry = ContainerRegistry(get_settings())` module-level global from `container.py`
- Delete `state = WebSocketState()` module-level global from `wshandler/session.py`
- `build_app()` now constructs both instances exclusively, wires onto `app.state`
- Rename `app.state.connections` → `app.state.sockets` and `registry.connections` → `registry.sockets`
- Add `get_app_state_dep` FastAPI dependency (replaces `get_settings_dep`)
- All API endpoints use `Depends(get_app_state_dep)` for registry/sockets/settings access
- WS handler chain (`handle_websocket` → `Connection` → controllers) receives `app_state` explicitly
- Non-request code (`workspaces.py`, `agent.py`, `terminal.py`, `bringup.py`) takes `app_state` param
- All ~1000 test references rewritten to construct/pass instances explicitly
- Zero remaining imports of the deleted globals in production or test code

## Test plan

- [x] `test-backend`: 2373 passed, 2 failed (pre-existing flaky tests, also fail on main)
- [x] `test-cli`: 486 passed
- [x] `test-backend-e2e`: 95 passed
- [x] `test-cli-e2e`: 62 passed, 1 skipped
- [x] `grep` confirms zero remaining `container.registry` / `wshandler.state` references

Closes #1475
