### PR TITLE
Move _service_session_locks onto ContainerRegistry (#1478)

### DIFF
--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -779,6 +779,12 @@ class ContainerRegistry:
         self._cid_to_wsid: dict[str, str] = {}
         # Per-workspace locks to serialize container creation.
         self._workspace_locks: dict[str, asyncio.Lock] = {}
+        # Per-container locks serializing the service-command fire
+        # sequence (window-exists -> new-window -> send-keys) so the boot
+        # path and the per-connection path can't both create a duplicate
+        # ``service-cmd`` tmux window (#1188). Owned here, not in
+        # terminal.py — terminal reaches it via app_state (#1478).
+        self._service_session_locks: dict[str, asyncio.Lock] = {}
         self.on_workspace_killed = None
         self.on_container_status_changed = None
 
@@ -797,26 +803,53 @@ class ContainerRegistry:
         # #1464). The HealthMonitor reaches it via self._registry.sockets.
         self.sockets = None
 
-    # --- Service-session locks (#1188, moved from terminal.py, #1426) ---
-    # The dict still physically lives in terminal.py (terminal.py can't import
-    # container — circular) and the terminal functions operate on it. These
-    # methods delegate so the registry is the single API surface; the dict
-    # moves fully in Slice 2d (#1465) when tests stop reaching into
-    # terminal._service_session_locks directly.
+    # --- Service-session locks (#1188, #1478) ---
+    # The per-container firing-lock dict lives here on the registry. It used
+    # to live at module scope in terminal.py (terminal.py couldn't import
+    # container — circular); #1477 removed that constraint by threading
+    # app_state through ensure_service_session, so the registry now owns the
+    # dict and terminal reaches it via app_state.container_registry.
 
     def get_service_session_lock(self, container_id: str) -> asyncio.Lock:
         """Get or create the per-container lock for service-command firing."""
-        return terminal.get_service_session_lock(container_id)
+        if container_id not in self._service_session_locks:
+            self._service_session_locks[container_id] = asyncio.Lock()
+        return self._service_session_locks[container_id]
 
     def clear_service_session_lock(self, container_id: str) -> None:
-        """Drop the per-container firing lock for a torn-down container."""
-        terminal.clear_service_session_lock(container_id)
+        """Drop the per-container firing lock for a torn-down container.
+
+        Called from container teardown so the lock dict does not grow
+        unbounded with container churn. Safe to call when no lock exists
+        for the id.
+        """
+        self._service_session_locks.pop(container_id, None)
 
     def prune_service_session_locks(
         self, active_container_ids: set[str]
     ) -> int:
-        """Remove lock entries for containers no longer tracked (#1351)."""
-        return terminal.prune_service_session_locks(active_container_ids)
+        """Remove lock entries for containers no longer tracked (#1351).
+
+        Bounds the ``_service_session_locks`` dict against unbounded growth
+        from container churn: explicit :func:`clear_service_session_lock`
+        calls cover the normal teardown path, but a racing re-bind in
+        ``stop_and_remove_container`` can leave an entry whose container is
+        gone. This opportunistic sweep removes any entry whose container id
+        is no longer in *active_container_ids*.
+
+        Entries whose lock is currently held are skipped: recreating a fresh
+        ``asyncio.Lock`` for an in-flight service-command fire would not
+        serialize against the held one, reopening the duplicate-window race
+        the lock exists to prevent. Returns the number of entries pruned.
+        """
+        stale = [
+            cid
+            for cid, lock in self._service_session_locks.items()
+            if cid not in active_container_ids and not lock.locked()
+        ]
+        for cid in stale:
+            del self._service_session_locks[cid]
+        return len(stale)
 
     def workspace_id_for(self, container_id: str) -> str | None:
         """Return the workspace_id for a container, or None."""

--- a/src/backend/klangk_backend/terminal.py
+++ b/src/backend/klangk_backend/terminal.py
@@ -102,58 +102,10 @@ SERVICE_CMD_WINDOW = "service-cmd"
 # dying because it is just a tmux session) (#1133 D6).
 SERVICE_SESSION = "service"
 
-# Per-container locks serializing the read-then-write firing sequence in
-# ensure_service_session (#1188). Two unserialized callers -- the boot path
-# (workspaces.start_workspace) and the per-connection path
-# (wshandler _fire_service_command) -- could both observe
-# service_cmd_window_exists -> False before either's new-window landed, and
-# since tmux permits duplicate window names, both would create a service-cmd
-# window. The lock makes the window-exists -> new-window -> send-keys sequence
-# atomic per container, so unrelated workspaces fire concurrently but the
-# same workspace fires exactly once. Entries are cleared on container teardown
-# via clear_service_session_lock().
-_service_session_locks: dict[str, asyncio.Lock] = {}
-
-
-def get_service_session_lock(container_id: str) -> asyncio.Lock:
-    """Get or create the per-container lock for service-command firing."""
-    if container_id not in _service_session_locks:
-        _service_session_locks[container_id] = asyncio.Lock()
-    return _service_session_locks[container_id]
-
-
-def clear_service_session_lock(container_id: str) -> None:
-    """Drop the per-container firing lock for a torn-down container.
-
-    Called from container teardown so the lock dict does not grow unbounded
-    with container churn. Safe to call when no lock exists for the id.
-    """
-    _service_session_locks.pop(container_id, None)
-
-
-def prune_service_session_locks(active_container_ids: set[str]) -> int:
-    """Remove lock entries for containers no longer tracked by the registry.
-
-    Bounds the ``_service_session_locks`` dict against unbounded growth from
-    container churn (#1351): explicit :func:`clear_service_session_lock`
-    calls cover the normal teardown path, but a racing re-bind in
-    ``stop_and_remove_container`` can leave an entry whose container is gone.
-    This opportunistic sweep removes any entry whose container id is no longer
-    in *active_container_ids*.
-
-    Entries whose lock is currently held are skipped: recreating a fresh
-    ``asyncio.Lock`` for an in-flight service-command fire would not serialize
-    against the held one, reopening the duplicate-window race the lock exists
-    to prevent. Returns the number of entries pruned.
-    """
-    stale = [
-        cid
-        for cid, lock in _service_session_locks.items()
-        if cid not in active_container_ids and not lock.locked()
-    ]
-    for cid in stale:
-        del _service_session_locks[cid]
-    return len(stale)
+# The per-container service-firing lock lives on ContainerRegistry as
+# _service_session_locks (#1188, #1478). It used to live here at module scope;
+# terminal.ensure_service_session now reaches it via
+# app_state.container_registry.get_service_session_lock().
 
 
 async def has_tmux_session(container_id: str, session_name: str) -> bool:
@@ -304,18 +256,21 @@ async def ensure_service_session(
     window-exists check makes it a no-op after the first fire.
 
     The window-exists -> new-window -> send-keys sequence is serialized
-    per container via :func:`get_service_session_lock` (#1188): without
+    per container via the registry's service-session lock (#1188): without
     it the boot path and the per-connection path could both pass the
     existence check before either created the window, producing two
     duplicate-named ``service-cmd`` windows (tmux allows duplicate
     names), leaving later ``send-keys -t service:service-cmd`` ambiguous.
+    The lock is reached via ``app_state.container_registry`` (#1478).
     """
     # Hold the per-container lock across the entire read-modify-write so
     # a concurrent caller (boot vs first terminal_start, owner vs
     # collaborator) cannot interleave: the second waits, then observes
     # the window exists and no-ops. This also bounds the partial-failure
     # window from #1186.
-    async with get_service_session_lock(container_id):
+    async with app_state.container_registry.get_service_session_lock(
+        container_id
+    ):
         await _ensure_tmux_session(container_id, SERVICE_SESSION, agent_home)
         if not (
             should_fire_service_command(service_command, setup_state)

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -1646,26 +1646,25 @@ class TestStopContainer:
     async def test_stop_prunes_orphaned_service_session_locks(self):
         # stop_and_remove_container sweeps the per-container service-firing
         # lock dict so it does not grow unbounded with container churn (#1351).
-        from klangk_backend import terminal
-
-        terminal._service_session_locks.clear()
+        locks = self.registry._service_session_locks
+        locks.clear()
         try:
             # Tracked container (being stopped) + two orphaned entries whose
             # containers are no longer in the registry.
             self.registry.track_activity("alive", "ws-alive")
-            terminal.get_service_session_lock("alive")
-            terminal.get_service_session_lock("orphan-a")
-            terminal.get_service_session_lock("orphan-b")
-            assert len(terminal._service_session_locks) == 3
+            self.registry.get_service_session_lock("alive")
+            self.registry.get_service_session_lock("orphan-a")
+            self.registry.get_service_session_lock("orphan-b")
+            assert len(locks) == 3
 
             with patch_podman():
                 await self.registry.stop_and_remove_container("alive")
 
             # The stopped container's entry and the orphans are gone; the dict
             # is empty because no container remains tracked.
-            assert terminal._service_session_locks == {}
+            assert locks == {}
         finally:
-            terminal._service_session_locks.clear()
+            locks.clear()
 
     async def test_stop_podman_error(self):
         self.registry.track_activity("cid", "ws")
@@ -3043,46 +3042,72 @@ class TestHealthLoopHeartbeat:
         assert all(f["type"] == "service_health_heartbeat" for f in frames)
 
 
-class TestRegistryServiceSessionLockDelegates:
-    """The registry delegates service-session-lock ops to terminal (#1426 2a)."""
+class TestRegistryServiceSessionLocks:
+    """The registry owns the per-container service-firing lock dict
+    (#1188, #1478). It used to live at module scope in terminal.py and
+    the registry delegated; now the dict is ``self._service_session_locks``
+    and terminal reaches it via app_state."""
 
     def setup_method(self):
-        from klangk_backend import terminal
-
-        terminal._service_session_locks.clear()
         app_state = _make_app_state()
         self.registry = app_state.container_registry
+        self.registry._service_session_locks.clear()
 
     def teardown_method(self):
-        from klangk_backend import terminal
+        self.registry._service_session_locks.clear()
 
-        terminal._service_session_locks.clear()
-
-    def test_get_via_registry(self):
-        from klangk_backend import terminal
-
+    def test_get_lock_returns_same_lock_for_same_container(self):
         reg = self.registry
-        lock = reg.get_service_session_lock("cid")
-        assert lock is terminal.get_service_session_lock("cid")
+        lock_a = reg.get_service_session_lock("cid")
+        lock_b = reg.get_service_session_lock("cid")
+        assert lock_a is lock_b
 
-    def test_clear_via_registry(self):
-        from klangk_backend import terminal
+    def test_get_lock_returns_distinct_locks_per_container(self):
+        reg = self.registry
+        lock_a = reg.get_service_session_lock("cid-a")
+        lock_b = reg.get_service_session_lock("cid-b")
+        assert lock_a is not lock_b
 
+    def test_clear_lock_removes_entry(self):
         reg = self.registry
         reg.get_service_session_lock("cid")
-        assert "cid" in terminal._service_session_locks
+        assert "cid" in reg._service_session_locks
         reg.clear_service_session_lock("cid")
-        assert "cid" not in terminal._service_session_locks
+        assert "cid" not in reg._service_session_locks
 
-    def test_prune_via_registry(self):
-        from klangk_backend import terminal
+    def test_clear_lock_is_noop_for_unknown_container(self):
+        # Must not raise for a container that never registered a lock.
+        self.registry.clear_service_session_lock("never-seen")
 
+    def test_prune_removes_entries_for_untracked_containers(self):
         reg = self.registry
         reg.get_service_session_lock("alive")
-        reg.get_service_session_lock("dead")
+        reg.get_service_session_lock("dead-a")
+        reg.get_service_session_lock("dead-b")
+        assert len(reg._service_session_locks) == 3
+
         removed = reg.prune_service_session_locks({"alive"})
-        assert removed == 1
-        assert "dead" not in terminal._service_session_locks
+        assert removed == 2
+        assert set(reg._service_session_locks) == {"alive"}
+
+    async def test_prune_keeps_held_lock_even_if_untracked(self):
+        reg = self.registry
+        held = reg.get_service_session_lock("held-but-orphaned")
+        await held.acquire()  # simulate an in-flight service-command fire
+        try:
+            removed = reg.prune_service_session_locks(set())
+            # Not pruned: recreating its lock would not serialize against the
+            # in-flight fire (#1188 duplicate-window race).
+            assert removed == 0
+            assert "held-but-orphaned" in reg._service_session_locks
+        finally:
+            held.release()
+
+    def test_prune_noop_when_all_tracked(self):
+        reg = self.registry
+        reg.get_service_session_lock("a")
+        reg.get_service_session_lock("b")
+        assert reg.prune_service_session_locks({"a", "b"}) == 0
 
     def test_registry_takes_settings(self):
         """ContainerRegistry.__init__ accepts settings (#1426)."""

--- a/src/backend/tests/test_terminal.py
+++ b/src/backend/tests/test_terminal.py
@@ -1169,6 +1169,18 @@ class TestEnsureServiceSession:
     identity (#1133 D6). _ensure_tmux_session and service_cmd_window_exists
     are mocked to isolate the firing logic from tmux-session internals."""
 
+    def setup_method(self):
+        # ensure_service_session reaches its per-container firing lock via
+        # app_state.container_registry (#1478). Build one real registry per
+        # test so concurrent same-container calls share the lock dict.
+        import types
+
+        from klangk_backend.container import ContainerRegistry
+        from klangk_backend.settings import KlangkSettings
+
+        registry = ContainerRegistry(KlangkSettings(env={}))
+        self.app_state = types.SimpleNamespace(container_registry=registry)
+
     async def test_creates_window_and_sends_command(self):
         """A fresh service session fires the service command in its
         ``service-cmd`` window -> ``service:service-cmd``."""
@@ -1189,7 +1201,10 @@ class TestEnsureServiceSession:
             ) as mock_exec,
         ):
             await ensure_service_session(
-                "cid", "/home/clanker", "openclaw gateway"
+                "cid",
+                "/home/clanker",
+                "openclaw gateway",
+                app_state=self.app_state,
             )
         cmds = [c.args[1] for c in mock_exec.call_args_list]
         # service-cmd window created in the service session.
@@ -1224,7 +1239,10 @@ class TestEnsureServiceSession:
             ),
         ):
             await ensure_service_session(
-                "cid", "/home/clanker", "openclaw gateway"
+                "cid",
+                "/home/clanker",
+                "openclaw gateway",
+                app_state=self.app_state,
             )
         mock_ensure.assert_awaited_once_with(
             "cid", SERVICE_SESSION, "/home/clanker"
@@ -1249,7 +1267,10 @@ class TestEnsureServiceSession:
             ) as mock_exec,
         ):
             await ensure_service_session(
-                "cid", "/home/clanker", "openclaw gateway"
+                "cid",
+                "/home/clanker",
+                "openclaw gateway",
+                app_state=self.app_state,
             )
         cmds = [c.args[1] for c in mock_exec.call_args_list]
         assert not any("new-window" in c for c in cmds)
@@ -1278,6 +1299,7 @@ class TestEnsureServiceSession:
                 "/home/clanker",
                 "openclaw gateway",
                 setup_state="pending",
+                app_state=self.app_state,
             )
         cmds = [c.args[1] for c in mock_exec.call_args_list]
         assert not any("new-window" in c for c in cmds)
@@ -1302,7 +1324,9 @@ class TestEnsureServiceSession:
             ),
             patch("klangk_backend.terminal.logger") as mock_logger,
         ):
-            await ensure_service_session("cid", "/home/clanker", "cmd")
+            await ensure_service_session(
+                "cid", "/home/clanker", "cmd", app_state=self.app_state
+            )
         mock_logger.warning.assert_called()
 
     async def test_send_keys_failure_logs_warning(self):
@@ -1330,7 +1354,9 @@ class TestEnsureServiceSession:
             ),
             patch("klangk_backend.terminal.logger") as mock_logger,
         ):
-            await ensure_service_session("cid", "/home/clanker", "cmd")
+            await ensure_service_session(
+                "cid", "/home/clanker", "cmd", app_state=self.app_state
+            )
         mock_logger.warning.assert_called()
 
     async def test_firing_resets_health_grace_anchor(self):
@@ -1494,10 +1520,16 @@ class TestEnsureServiceSession:
         ):
             await asyncio.gather(
                 terminal.ensure_service_session(
-                    "cid", "/home/clanker", "openclaw gateway"
+                    "cid",
+                    "/home/clanker",
+                    "openclaw gateway",
+                    app_state=self.app_state,
                 ),
                 terminal.ensure_service_session(
-                    "cid", "/home/clanker", "openclaw gateway"
+                    "cid",
+                    "/home/clanker",
+                    "openclaw gateway",
+                    app_state=self.app_state,
                 ),
             )
 
@@ -1544,10 +1576,16 @@ class TestEnsureServiceSession:
         ):
             await asyncio.gather(
                 terminal.ensure_service_session(
-                    "cid-a", "/home/clanker", "cmd-a"
+                    "cid-a",
+                    "/home/clanker",
+                    "cmd-a",
+                    app_state=self.app_state,
                 ),
                 terminal.ensure_service_session(
-                    "cid-b", "/home/clanker", "cmd-b"
+                    "cid-b",
+                    "/home/clanker",
+                    "cmd-b",
+                    app_state=self.app_state,
                 ),
             )
 
@@ -1583,7 +1621,9 @@ class TestEnsureServiceSession:
             ) as mock_exec,
             patch("klangk_backend.terminal.logger"),
         ):
-            await ensure_service_session("cid", "/home/clanker", "cmd")
+            await ensure_service_session(
+                "cid", "/home/clanker", "cmd", app_state=self.app_state
+            )
 
         # The third exec call must be the kill-window cleanup targeting
         # the service-cmd window we just created.
@@ -1619,99 +1659,11 @@ class TestEnsureServiceSession:
             ),
             patch("klangk_backend.terminal.logger") as mock_logger,
         ):
-            await ensure_service_session("cid", "/home/clanker", "cmd")
+            await ensure_service_session(
+                "cid", "/home/clanker", "cmd", app_state=self.app_state
+            )
         # Both the send-keys failure and the cleanup failure are warned.
         assert mock_logger.warning.call_count == 2
-
-
-class TestServiceSessionLock:
-    """Unit coverage for the per-container firing-lock helpers added in #1188."""
-
-    def setup_method(self):
-        from klangk_backend import terminal
-
-        terminal._service_session_locks.clear()
-
-    def teardown_method(self):
-        from klangk_backend import terminal
-
-        terminal._service_session_locks.clear()
-
-    def test_get_lock_returns_same_lock_for_same_container(self):
-        from klangk_backend.terminal import get_service_session_lock
-
-        lock_a = get_service_session_lock("cid")
-        lock_b = get_service_session_lock("cid")
-        assert lock_a is lock_b
-
-    def test_get_lock_returns_distinct_locks_per_container(self):
-        from klangk_backend.terminal import get_service_session_lock
-
-        lock_a = get_service_session_lock("cid-a")
-        lock_b = get_service_session_lock("cid-b")
-        assert lock_a is not lock_b
-
-    def test_clear_lock_removes_entry(self):
-        from klangk_backend.terminal import (
-            get_service_session_lock,
-            _service_session_locks,
-            clear_service_session_lock,
-        )
-
-        get_service_session_lock("cid")
-        assert "cid" in _service_session_locks
-        clear_service_session_lock("cid")
-        assert "cid" not in _service_session_locks
-
-    def test_clear_lock_is_noop_for_unknown_container(self):
-        from klangk_backend.terminal import clear_service_session_lock
-
-        # Must not raise for a container that never registered a lock.
-        clear_service_session_lock("never-seen")
-
-    def test_prune_removes_entries_for_untracked_containers(self):
-        from klangk_backend.terminal import (
-            _service_session_locks,
-            get_service_session_lock,
-            prune_service_session_locks,
-        )
-
-        get_service_session_lock("alive")
-        get_service_session_lock("dead-a")
-        get_service_session_lock("dead-b")
-        assert len(_service_session_locks) == 3
-
-        removed = prune_service_session_locks({"alive"})
-        assert removed == 2
-        assert set(_service_session_locks) == {"alive"}
-
-    async def test_prune_keeps_held_lock_even_if_untracked(self):
-        from klangk_backend.terminal import (
-            _service_session_locks,
-            get_service_session_lock,
-            prune_service_session_locks,
-        )
-
-        held = get_service_session_lock("held-but-orphaned")
-        await held.acquire()  # simulate an in-flight service-command fire
-        try:
-            removed = prune_service_session_locks(set())
-            # Not pruned: recreating its lock would not serialize against the
-            # in-flight fire (#1188 duplicate-window race).
-            assert removed == 0
-            assert "held-but-orphaned" in _service_session_locks
-        finally:
-            held.release()
-
-    def test_prune_noop_when_all_tracked(self):
-        from klangk_backend.terminal import (
-            get_service_session_lock,
-            prune_service_session_locks,
-        )
-
-        get_service_session_lock("a")
-        get_service_session_lock("b")
-        assert prune_service_session_locks({"a", "b"}) == 0
 
 
 class TestServiceSessionHelpers:


### PR DESCRIPTION
Closes #1478.

## What

The per-container service-firing lock dict (`_service_session_locks`) and its
three helpers lived at **module scope in `terminal.py`**; `ContainerRegistry`
only delegated to them. This was the one unmet acceptance item from **#1462
(Slice 2a)** — the code comment deferred it to "Slice 2d (#1465)", but #1465
closed without moving it (#1478 has the full write-up).

The circular-import constraint that originally forced the dict into `terminal.py`
is gone: **#1477** removed terminal.py's last lazy `container` import and
threaded `app_state` through `ensure_service_session`. `terminal.py` no longer
imports `container` at all, so the registry can own the dict.

## Changes

- **`container.py`** — `_service_session_locks` is now `self._service_session_locks`;
  the three delegating methods own the logic directly.
- **`terminal.py`** — deleted the module-level dict + three functions;
  `ensure_service_session` reaches the lock via
  `app_state.container_registry.get_service_session_lock()`. Both callers
  (`bringup.bringup`, `wshandler/controllers`) already pass `app_state`.
- **tests** — dropped `TestServiceSessionLock` from `test_terminal.py` (module
  functions gone); rewrote `test_container.py`'s
  `TestRegistryServiceSessionLockDelegates` → `TestRegistryServiceSessionLocks`
  to cover the lock mechanics on the registry directly; threaded `app_state`
  through the 15 `ensure_service_session` calls in `TestEnsureServiceSession`
  (concurrent same-container fires share one registry instance so they serialize).

## Verification

- `python -m pytest src/backend/tests -v -n auto` → **2373 passed, 100% coverage**.
- `ruff check` + `ruff format` clean.
