### PR TITLE
Promote podman.py to a Podman(settings) class (#1468)

### DIFF
--- a/src/backend/klangk_backend/agent.py
+++ b/src/backend/klangk_backend/agent.py
@@ -11,7 +11,8 @@ import logging
 import re
 import time
 
-from . import model, podman, util, workspaces
+from . import model, util, workspaces
+from .podman import subprocess_env
 
 _THINK_RE = re.compile(r"<think>.*?</think>\s*", re.DOTALL)
 
@@ -67,7 +68,9 @@ def is_disabled() -> bool:
     return util.resolve_env_bool("KLANGK_AGENT_DISABLED")
 
 
-async def ensure_agent_home(workspace_id: str, container_id: str) -> str:
+async def ensure_agent_home(
+    workspace_id: str, container_id: str, podman=None
+) -> str:
     """Eagerly provision the agent's home directory with Pi config.
 
     Creates ``/home/.users/{AGENT_USER_ID}`` on the host bind-mount and
@@ -94,14 +97,16 @@ async def ensure_agent_home(workspace_id: str, container_id: str) -> str:
         workspace_home, agent_handle, model.AGENT_USER_ID
     )
     if created:
-        await workspaces.populate_home_skel(container_id, model.AGENT_USER_ID)
+        await workspaces.populate_home_skel(
+            container_id, model.AGENT_USER_ID, podman
+        )
 
     # Run klangk-setup-pi to populate ~/.pi/agent/ with models.json,
     # settings.json, etc.  Unlike real users, the agent has no
     # personal preferences — --force deletes settings.json first so
     # it picks up the current KLANGK_LLM_MODEL env var.
     proc = await asyncio.create_subprocess_exec(
-        podman._podman_bin(),
+        podman.bin,
         "exec",
         "-u",
         "klangk",
@@ -113,7 +118,7 @@ async def ensure_agent_home(workspace_id: str, container_id: str) -> str:
         stdin=asyncio.subprocess.DEVNULL,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
-        env=podman.subprocess_env(),
+        env=subprocess_env(),
     )
     stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
     # Check the return code but do NOT fail the container bring-up over a
@@ -192,7 +197,7 @@ class AgentSession:
             handle = await model.agent_handle()
             return f"/home/{handle}"
         container_home = await ensure_agent_home(
-            self.workspace_id, container_id
+            self.workspace_id, container_id, self.app_state.podman
         )
         self._home_ready = True
         return container_home
@@ -254,13 +259,13 @@ class AgentSession:
                 container_id,
             )
             self._proc = await asyncio.create_subprocess_exec(
-                podman._podman_bin(),
+                self.app_state.podman.bin,
                 *argv,
                 stdin=asyncio.subprocess.PIPE,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 start_new_session=True,
-                env=podman.subprocess_env(),
+                env=subprocess_env(),
             )
             self._monitor_task = asyncio.create_task(
                 self._monitor_process(self._proc)

--- a/src/backend/klangk_backend/api/files.py
+++ b/src/backend/klangk_backend/api/files.py
@@ -51,7 +51,7 @@ async def list_files(
 ):
     cid = _require_container(workspace_id, app_state.container_registry)
     try:
-        return await files.list_files(cid, path)
+        return await files.list_files(cid, path, app_state.podman)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
@@ -65,7 +65,7 @@ async def read_file(
 ):
     cid = _require_container(workspace_id, app_state.container_registry)
     try:
-        content = await files.read_file(cid, path)
+        content = await files.read_file(cid, path, app_state.podman)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     if content is None:
@@ -84,7 +84,7 @@ async def delete_file(
 ):
     cid = _require_container(workspace_id, app_state.container_registry)
     try:
-        deleted = await files.delete_path(cid, path)
+        deleted = await files.delete_path(cid, path, app_state.podman)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except FileNotFoundError:
@@ -108,7 +108,9 @@ async def rename_file(
 ):
     cid = _require_container(workspace_id, app_state.container_registry)
     try:
-        renamed = await files.rename_path(cid, body.old_path, body.new_path)
+        renamed = await files.rename_path(
+            cid, body.old_path, body.new_path, app_state.podman
+        )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except FileNotFoundError:
@@ -131,7 +133,7 @@ async def download_file(
 ):
     cid = _require_container(workspace_id, app_state.container_registry)
     try:
-        info = await files.stat_path(cid, path)
+        info = await files.stat_path(cid, path, app_state.podman)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     if info is None:
@@ -139,14 +141,14 @@ async def download_file(
     name = sanitize_disposition_name(posixpath.basename(path) or "download")
     if not info["is_dir"]:
         return StreamingResponse(
-            files.stream_file(cid, path),
+            files.stream_file(cid, path, app_state.podman),
             media_type="application/octet-stream",
             headers={
                 "Content-Disposition": f'attachment; filename="{name}"',
             },
         )
     return StreamingResponse(
-        files.stream_dir_tar(cid, path),
+        files.stream_dir_tar(cid, path, app_state.podman),
         media_type="application/gzip",
         headers={
             "Content-Disposition": f'attachment; filename="{name}.tar.gz"',
@@ -181,7 +183,9 @@ async def upload_file(
         buf.write(chunk)
 
     try:
-        saved_path = await files.write_file(cid, filename, buf.getvalue())
+        saved_path = await files.write_file(
+            cid, filename, buf.getvalue(), app_state.podman
+        )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except OSError as e:

--- a/src/backend/klangk_backend/api/images.py
+++ b/src/backend/klangk_backend/api/images.py
@@ -13,8 +13,9 @@ from .. import (
     auth,
     container,
     model,
-    podman,
 )
+from ..podman import PodmanError as PodmanError
+from ._common import get_app_state_dep
 
 logger = logging.getLogger(__name__)
 
@@ -33,8 +34,11 @@ async def list_images(_user: dict = Depends(auth.get_current_user)):
 
 
 @router.get("/volumes")
-async def list_volumes(user: dict = Depends(auth.get_current_user)):
-    volumes = await podman.list_volumes(
+async def list_volumes(
+    user: dict = Depends(auth.get_current_user),
+    app_state=Depends(get_app_state_dep),
+):
+    volumes = await app_state.podman.list_volumes(
         f"klangk.instance={model.get_instance_id()}"
     )
     uid = user["id"]
@@ -56,12 +60,13 @@ class CreateVolumeRequest(BaseModel):
 async def create_volume(
     body: CreateVolumeRequest,
     user: dict = Depends(auth.get_current_user),
+    app_state=Depends(get_app_state_dep),
 ):
-    if await podman.inspect_volume(body.name) is not None:
+    if await app_state.podman.inspect_volume(body.name) is not None:
         raise HTTPException(
             status_code=409, detail=f"Volume {body.name!r} already exists"
         )
-    info = await podman.create_volume(
+    info = await app_state.podman.create_volume(
         body.name,
         {
             "klangk.managed": "true",
@@ -74,9 +79,11 @@ async def create_volume(
 
 @router.delete("/volumes/{name}")
 async def delete_volume(
-    name: str, user: dict = Depends(auth.get_current_user)
+    name: str,
+    user: dict = Depends(auth.get_current_user),
+    app_state=Depends(get_app_state_dep),
 ):
-    info = await podman.inspect_volume(name)
+    info = await app_state.podman.inspect_volume(name)
     if info is None:
         raise HTTPException(status_code=404, detail="Volume not found")
     labels = info.get("Labels") or {}
@@ -91,8 +98,8 @@ async def delete_volume(
             detail="Volume belongs to another user",
         )
     try:
-        await podman.remove_volume(name)
-    except podman.PodmanError as e:
+        await app_state.podman.remove_volume(name)
+    except PodmanError as e:
         if e.status == 404:
             raise HTTPException(
                 status_code=404, detail="Volume not found"

--- a/src/backend/klangk_backend/bringup.py
+++ b/src/backend/klangk_backend/bringup.py
@@ -30,7 +30,9 @@ async def bringup(
     Called at the single choke point: every freshly-created container.
     Idempotent via :func:`terminal.ensure_service_session`.
     """
-    agent_home = await agent.ensure_agent_home(workspace_id, container_id)
+    agent_home = await agent.ensure_agent_home(
+        workspace_id, container_id, app_state.podman
+    )
     if not service_command:
         return
     await terminal.ensure_service_session(

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -6,6 +6,7 @@ import os
 import time
 
 from . import auth, bringup, model, plugins, podman, terminal, util
+from .podman import PodmanError
 from .settings import KlangkSettings
 
 logger = logging.getLogger(__name__)
@@ -611,7 +612,7 @@ class HealthMonitor:
             state.health_check,
         )
         try:
-            rc, out, err = await podman.exec_container(
+            rc, out, err = await self._registry.podman.exec_container(
                 state.container_id,
                 # bash -c (NON-login): sources nothing, so the probe is
                 # deterministic and insulated from the user's interactive
@@ -802,6 +803,9 @@ class ContainerRegistry:
         # The WebSocketState instance (set by build_app after construction,
         # #1464). The HealthMonitor reaches it via self._registry.sockets.
         self.sockets = None
+        # The Podman instance (set by build_app after construction, #1468).
+        # Internal callers reach the CLI wrappers via self.podman.X.
+        self.podman = None
 
     # --- Service-session locks (#1188, #1478) ---
     # The per-container firing-lock dict lives here on the registry. It used
@@ -1096,7 +1100,7 @@ class ContainerRegistry:
         still running, or ``None`` if it was removed (or not found)
         and a new one should be created.
         """
-        info = await podman.inspect_container(existing_container_id)
+        info = await self.podman.inspect_container(existing_container_id)
         t_inspect = time.monotonic()
         logger.info(
             "workspace-open: check if old container still exists "
@@ -1123,7 +1127,7 @@ class ContainerRegistry:
                 time.monotonic() - t_start,
             )
             return existing_container_id, "connected"
-        await podman.remove_container(existing_container_id)
+        await self.podman.remove_container(existing_container_id)
         logger.info(
             "workspace-open: delete old stopped container (podman rm): %.3fs",
             time.monotonic() - t_inspect,
@@ -1254,6 +1258,7 @@ class ContainerRegistry:
     async def _ensure_volumes(
         extra_mounts: list[str] | None,
         user_id: str | None,
+        podman=None,
     ) -> None:
         """Create named volumes and validate bind-mount sources."""
         if not extra_mounts:
@@ -1324,7 +1329,7 @@ class ContainerRegistry:
         that hold conflicting ports.
         """
         t_create = time.monotonic()
-        cid = await podman.create_container(
+        cid = await self.podman.create_container(
             container_name, resolved_image, **create_kwargs
         )
         logger.info(
@@ -1341,12 +1346,14 @@ class ContainerRegistry:
         )
         t_podman_start = time.monotonic()
         try:
-            await podman.start_container(cid)
+            await self.podman.start_container(cid)
         except podman.PodmanError as exc:
             if "port is already allocated" not in exc.message:
                 raise
-            await self._resolve_port_conflict(cid, container_name, publish)
-            await podman.start_container(cid)
+            await self._resolve_port_conflict(
+                cid, container_name, publish, self.podman
+            )
+            await self.podman.start_container(cid)
         logger.info(
             "workspace-open: boot container (podman start): %.3fs",
             time.monotonic() - t_podman_start,
@@ -1357,7 +1364,7 @@ class ContainerRegistry:
             sudoers_rule = "klangk ALL=(ALL) NOPASSWD:ALL"
         else:
             sudoers_rule = "klangk ALL=(ALL) !ALL"
-        await podman.exec_container(
+        await self.podman.exec_container(
             cid,
             ["klangk-configure-sudo", sudoers_rule],
             user="root",
@@ -1366,7 +1373,7 @@ class ContainerRegistry:
         # Write the workspace token so container processes can
         # authenticate without an env-var restart.
         workspace_token = auth.create_workspace_token(workspace_id)
-        await terminal.set_workspace_token(cid, workspace_token)
+        await terminal.set_workspace_token(cid, workspace_token, self.podman)
 
         # Block until the entrypoint's one-time setup is done. ``podman
         # start`` returns when the entrypoint has *begun*, not finished;
@@ -1375,7 +1382,7 @@ class ContainerRegistry:
         # terminals, exec, agent, health check — gets a genuine readiness
         # guarantee regardless of shell, closing the race that previously
         # only the in-bashrc gate covered (and only for bash).
-        await podman.wait_for_container_ready(cid)
+        await self.podman.wait_for_container_ready(cid)
 
         return cid
 
@@ -1384,6 +1391,7 @@ class ContainerRegistry:
         cid: str,
         container_name: str,
         publish: list[tuple[int, int]],
+        podman=None,
     ) -> None:
         """Remove stale containers holding conflicting ports."""
         logger.warning(
@@ -1417,7 +1425,7 @@ class ContainerRegistry:
                         stale_id[:12],
                         bound & wanted_ports,
                     )
-                except podman.PodmanError as del_exc:
+                except PodmanError as del_exc:
                     logger.warning(
                         "Could not remove stale container %s: %s",
                         stale_id[:12],
@@ -1495,7 +1503,7 @@ class ContainerRegistry:
             extra_env,
             ssl_dir,
         )
-        await self._ensure_volumes(extra_mounts, user_id)
+        await self._ensure_volumes(extra_mounts, user_id, self.podman)
         binds = self._build_mounts(
             home_path, config_path, extra_mounts, ssl_dir
         )
@@ -1583,7 +1591,7 @@ class ContainerRegistry:
     async def stop_and_remove_container(self, container_id: str) -> None:
         """Stop and remove a container.
 
-        The slow ``podman.remove_container`` call runs *outside* the
+        The slow ``self.podman.remove_container`` call runs *outside* the
         workspace lock; only the registry-state teardown is serialized --
         under the same per-workspace lock :meth:`start_container` uses -- so
         a concurrent start for the same workspace cannot observe a
@@ -1602,7 +1610,7 @@ class ContainerRegistry:
         ever seen and is cleared on process restart.
         """
         try:
-            await podman.remove_container(container_id)
+            await self.podman.remove_container(container_id)
             logger.info("Stopped container %s", container_id)
         except podman.PodmanError as e:
             logger.warning(
@@ -1672,7 +1680,7 @@ class ContainerRegistry:
         """
         t0 = time.monotonic()
         try:
-            cid = await podman.create_container(
+            cid = await self.podman.create_container(
                 "klangk-prewarm",
                 IMAGE_NAME,
                 pull="never",
@@ -1680,7 +1688,7 @@ class ContainerRegistry:
                     "KLANGK_USERNS", "keep-id:uid=1000,gid=1000"
                 ),
             )
-            await podman.remove_container(cid)
+            await self.podman.remove_container(cid)
             logger.info("Podman pre-warmed in %.3fs", time.monotonic() - t0)
         except podman.PodmanError as e:
             logger.warning(
@@ -1691,7 +1699,7 @@ class ContainerRegistry:
 
     async def adopt_orphaned_containers(self) -> None:
         try:
-            containers = await podman.list_containers(
+            containers = await self.podman.list_containers(
                 f"klangk.instance={model.get_instance_id()}"
             )
             for c in containers:
@@ -1702,7 +1710,7 @@ class ContainerRegistry:
                         cid[:12],
                     )
                     try:
-                        await podman.remove_container(cid)
+                        await self.podman.remove_container(cid)
                     except podman.PodmanError as e:
                         logger.warning(
                             "Failed to remove orphaned container %s: %s",
@@ -1742,7 +1750,7 @@ class ContainerRegistry:
         tracked_ids = set(self._cid_to_wsid.keys())
         tasks = [self.stop_and_remove_container(cid) for cid in tracked_ids]
         try:
-            containers = await podman.list_containers(
+            containers = await self.podman.list_containers(
                 f"klangk.instance={model.get_instance_id()}"
             )
             for c in containers:

--- a/src/backend/klangk_backend/files.py
+++ b/src/backend/klangk_backend/files.py
@@ -9,8 +9,6 @@ sandbox; ``validate_path`` provides defense-in-depth.
 import posixpath
 from collections.abc import AsyncGenerator
 
-from . import podman
-
 EXEC_USER = "klangk"
 
 # 255 is the common Linux NAME_MAX; reading at import time is fine.
@@ -43,7 +41,9 @@ def validate_path(path: str) -> str:
     return normalized
 
 
-async def list_files(container_id: str, path: str = "/") -> list[dict]:
+async def list_files(
+    container_id: str, path: str = "/", podman=None
+) -> list[dict]:
     """List files and directories at the given path inside the container."""
     path = validate_path(path)
     rc, out, _err = await podman.exec_container(
@@ -99,7 +99,7 @@ async def list_files(container_id: str, path: str = "/") -> list[dict]:
     return entries
 
 
-async def stat_path(container_id: str, path: str) -> dict | None:
+async def stat_path(container_id: str, path: str, podman=None) -> dict | None:
     """Stat a single path.  Returns ``{"is_dir": bool, "size": int}``
     or ``None`` if the path does not exist."""
     path = validate_path(path)
@@ -122,10 +122,10 @@ async def stat_path(container_id: str, path: str) -> dict | None:
     return {"is_dir": is_dir, "size": size}
 
 
-async def read_file(container_id: str, path: str) -> str | None:
+async def read_file(container_id: str, path: str, podman=None) -> str | None:
     """Read file contents as text.  Returns None if missing or > 1 MB."""
     path = validate_path(path)
-    info = await stat_path(container_id, path)
+    info = await stat_path(container_id, path, podman)
     if info is None or info["is_dir"]:
         return None
     if info["size"] > 1_000_000:
@@ -140,7 +140,9 @@ async def read_file(container_id: str, path: str) -> str | None:
     return out
 
 
-def stream_file(container_id: str, path: str) -> AsyncGenerator[bytes, None]:
+def stream_file(
+    container_id: str, path: str, podman=None
+) -> AsyncGenerator[bytes, None]:
     """Stream file contents as raw bytes for download."""
     path = validate_path(path)
     return podman.exec_container_stream(
@@ -151,7 +153,7 @@ def stream_file(container_id: str, path: str) -> AsyncGenerator[bytes, None]:
 
 
 def stream_dir_tar(
-    container_id: str, path: str
+    container_id: str, path: str, podman=None
 ) -> AsyncGenerator[bytes, None]:
     """Stream a directory as a tar.gz archive for download."""
     path = validate_path(path)
@@ -170,7 +172,7 @@ def stream_dir_tar(
     )
 
 
-async def delete_path(container_id: str, path: str) -> str:
+async def delete_path(container_id: str, path: str, podman=None) -> str:
     """Delete a file or directory.  Returns the path deleted."""
     path = validate_path(path)
     # Check existence first
@@ -191,7 +193,9 @@ async def delete_path(container_id: str, path: str) -> str:
     return path
 
 
-async def rename_path(container_id: str, old_path: str, new_path: str) -> str:
+async def rename_path(
+    container_id: str, old_path: str, new_path: str, podman=None
+) -> str:
     """Rename/move a file or directory.  Returns the new path."""
     old_path = validate_path(old_path)
     new_path = validate_path(new_path)
@@ -229,7 +233,9 @@ async def rename_path(container_id: str, old_path: str, new_path: str) -> str:
     return new_path
 
 
-async def write_file(container_id: str, path: str, content: bytes) -> str:
+async def write_file(
+    container_id: str, path: str, content: bytes, podman=None
+) -> str:
     """Write file contents.  Returns the path written."""
     path = validate_path(path)
     # mkdir -p + cat > file in one sh invocation.

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -24,6 +24,7 @@ from . import (
     nginx as nginx_mod,
     oidc,
     plugins,
+    podman,
     ssl_trust,
     workspaces,
     wshandler,
@@ -747,6 +748,12 @@ def build_app(settings: KlangkSettings) -> FastAPI:
     sockets = wshandler.WebSocketState()
     app.state.sockets = sockets
     app.state.container_registry.sockets = sockets
+    # #1468: Podman(settings) owns the resolved binary path + the ~20 CLI
+    # wrappers. The registry reaches it via self.podman; terminal/files/etc.
+    # thread app.state.podman explicitly.
+    podman_inst = podman.Podman(settings)
+    app.state.podman = podman_inst
+    app.state.container_registry.podman = podman_inst
     app.state.container_registry.app_state = app.state
     # WebSocketState reaches the registry through its own app_state
     # back-reference (send_service_health_snapshot / reset_workspace).

--- a/src/backend/klangk_backend/podman.py
+++ b/src/backend/klangk_backend/podman.py
@@ -9,7 +9,11 @@ HTTP-like codes (404 not-found, 409 conflict/in-use) so callers can
 branch accordingly; anything else maps to 500.
 
 The binary is configurable via the ``podman_bin`` setting (defaults to
-``podman``).
+``podman``). The :class:`Podman` class takes ``KlangkSettings`` once
+(at construction, in :func:`build_app`) and carries the resolved binary
+path on ``self._bin`` — no ``get_settings()`` reacharound (#1468).
+Callers obtain the instance via ``app.state.podman`` (explicit threading,
+the same pattern as ``container_registry`` / ``sockets``).
 """
 
 import asyncio
@@ -20,14 +24,10 @@ import tempfile
 import time
 from collections.abc import AsyncGenerator
 
-from .settings import get_settings, resolve_indirection
+from .settings import KlangkSettings, resolve_indirection
 from .util import BoundedOutputQueue
 
 logger = logging.getLogger(__name__)
-
-
-def _podman_bin() -> str:
-    return resolve_indirection(get_settings().podman_bin) or "podman"
 
 
 def subprocess_env() -> dict[str, str]:
@@ -62,434 +62,462 @@ def classify(stderr: str) -> int:
     return 500
 
 
-async def run(
-    args: list[str],
-    *,
-    check: bool = True,
-    stdin_data: bytes | None = None,
-    timeout: float | None = 30.0,
-) -> tuple[int, str, str]:
-    """Run ``podman <args>`` and return ``(returncode, stdout, stderr)``.
+class Podman:
+    """Owns the resolved podman binary path and the ~20 CLI wrappers.
 
-    Output is captured to temp files rather than ``stdout=PIPE`` +
-    ``communicate()``.  Lifecycle commands such as ``podman start`` can
-    spawn long-lived helpers (``pasta``) that inherit pipe fds, blocking
-    ``communicate()`` forever.  Temp files avoid this.
-
-    *timeout* caps how long we wait for the process (default 30 s).
-    On timeout the process is killed and a ``PodmanError(500, ...)`` is
-    raised (unless *check* is False, in which case rc=-1 is returned).
+    Constructed once in :func:`build_app` and stored on
+    ``app.state.podman`` (#1468). The binary path is resolved once from
+    ``settings.podman_bin``; methods use ``self._bin`` instead of a
+    per-call ``get_settings()`` reacharound.
     """
-    cmd_label = f"podman {args[0]}" if args else "podman"
-    t0 = time.monotonic()
-    with (
-        tempfile.TemporaryFile() as out_f,
-        tempfile.TemporaryFile() as err_f,
-    ):
-        t1 = time.monotonic()
-        proc = await asyncio.create_subprocess_exec(
-            _podman_bin(),
-            *args,
-            stdin=(
-                asyncio.subprocess.PIPE if stdin_data is not None else None
-            ),
-            stdout=out_f,
-            stderr=err_f,
-            env=subprocess_env(),
-        )
-        t2 = time.monotonic()
-        if stdin_data is not None:
-            proc.stdin.write(stdin_data)
-            await proc.stdin.drain()
-            proc.stdin.close()
-        timed_out = False
-        try:
-            await asyncio.wait_for(proc.wait(), timeout=timeout)
-        except asyncio.TimeoutError:
-            timed_out = True
-            logger.warning(
-                "podman-timeout: %s exceeded %.1fs — killing",
-                cmd_label,
-                timeout,
+
+    def __init__(self, settings: KlangkSettings):
+        self._settings = settings
+        self._bin = resolve_indirection(settings.podman_bin) or "podman"
+
+    @property
+    def bin(self) -> str:
+        """The resolved podman binary path (for ``ExecSession`` etc.)."""
+        return self._bin
+
+    async def run(
+        self,
+        args: list[str],
+        *,
+        check: bool = True,
+        stdin_data: bytes | None = None,
+        timeout: float | None = 30.0,
+    ) -> tuple[int, str, str]:
+        """Run ``podman <args>`` and return ``(returncode, stdout, stderr)``.
+
+        Output is captured to temp files rather than ``stdout=PIPE`` +
+        ``communicate()``.  Lifecycle commands such as ``podman start`` can
+        spawn long-lived helpers (``pasta``) that inherit pipe fds, blocking
+        ``communicate()`` forever.  Temp files avoid this.
+
+        *timeout* caps how long we wait for the process (default 30 s).
+        On timeout the process is killed and a ``PodmanError(500, ...)`` is
+        raised (unless *check* is False, in which case rc=-1 is returned).
+        """
+        cmd_label = f"podman {args[0]}" if args else "podman"
+        t0 = time.monotonic()
+        with (
+            tempfile.TemporaryFile() as out_f,
+            tempfile.TemporaryFile() as err_f,
+        ):
+            t1 = time.monotonic()
+            proc = await asyncio.create_subprocess_exec(
+                self._bin,
+                *args,
+                stdin=(
+                    asyncio.subprocess.PIPE if stdin_data is not None else None
+                ),
+                stdout=out_f,
+                stderr=err_f,
+                env=subprocess_env(),
             )
-            proc.kill()
-            await proc.wait()
-        t3 = time.monotonic()
-        out_f.seek(0)
-        err_f.seek(0)
-        out = out_f.read().decode("utf-8", errors="replace")
-        err = err_f.read().decode("utf-8", errors="replace")
-    rc = proc.returncode or 0
-    if timed_out:
-        rc = -1
-        err = err or f"{cmd_label} timed out after {timeout}s"
-    elapsed = t3 - t0
-    logger.debug(
-        "podman-timing: %s tempfile=%.3fs spawn=%.3fs wait=%.3fs total=%.3fs",
-        cmd_label,
-        t1 - t0,
-        t2 - t1,
-        t3 - t2,
-        elapsed,
-    )
-    if elapsed > 2.0 and err.strip():  # pragma: no cover
-        logger.debug("podman-timing: %s stderr: %s", cmd_label, err.strip())
-    if check and rc != 0:
-        raise PodmanError(classify(err), err.strip() or f"podman {args[0]}")
-    return rc, out, err
-
-
-async def run_raw(
-    args: list[str],
-    *,
-    check: bool = True,
-    stdin_data: bytes | None = None,
-    timeout: float | None = 30.0,
-) -> tuple[int, bytes, str]:
-    """Like ``run`` but returns raw stdout bytes (for binary data)."""
-    cmd_label = f"podman {args[0]}" if args else "podman"
-    t0 = time.monotonic()
-    with (
-        tempfile.TemporaryFile() as out_f,
-        tempfile.TemporaryFile() as err_f,
-    ):
-        t1 = time.monotonic()
-        proc = await asyncio.create_subprocess_exec(
-            _podman_bin(),
-            *args,
-            stdin=(
-                asyncio.subprocess.PIPE if stdin_data is not None else None
-            ),
-            stdout=out_f,
-            stderr=err_f,
-            env=subprocess_env(),
+            t2 = time.monotonic()
+            if stdin_data is not None:
+                proc.stdin.write(stdin_data)
+                await proc.stdin.drain()
+                proc.stdin.close()
+            timed_out = False
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=timeout)
+            except asyncio.TimeoutError:
+                timed_out = True
+                logger.warning(
+                    "podman-timeout: %s exceeded %.1fs — killing",
+                    cmd_label,
+                    timeout,
+                )
+                proc.kill()
+                await proc.wait()
+            t3 = time.monotonic()
+            out_f.seek(0)
+            err_f.seek(0)
+            out = out_f.read().decode("utf-8", errors="replace")
+            err = err_f.read().decode("utf-8", errors="replace")
+        rc = proc.returncode or 0
+        if timed_out:
+            rc = -1
+            err = err or f"{cmd_label} timed out after {timeout}s"
+        elapsed = t3 - t0
+        logger.debug(
+            "podman-timing: %s tempfile=%.3fs spawn=%.3fs wait=%.3fs"
+            " total=%.3fs",
+            cmd_label,
+            t1 - t0,
+            t2 - t1,
+            t3 - t2,
+            elapsed,
         )
-        t2 = time.monotonic()
-        if stdin_data is not None:
-            proc.stdin.write(stdin_data)
-            await proc.stdin.drain()
-            proc.stdin.close()
-        timed_out = False
-        try:
-            await asyncio.wait_for(proc.wait(), timeout=timeout)
-        except asyncio.TimeoutError:
-            timed_out = True
-            logger.warning(
-                "podman-timeout: %s exceeded %.1fs — killing",
-                cmd_label,
-                timeout,
+        if elapsed > 2.0 and err.strip():  # pragma: no cover
+            logger.debug(
+                "podman-timing: %s stderr: %s", cmd_label, err.strip()
             )
-            proc.kill()
-            await proc.wait()
-        t3 = time.monotonic()
-        out_f.seek(0)
-        err_f.seek(0)
-        out_bytes = out_f.read()
-        err = err_f.read().decode("utf-8", errors="replace")
-    rc = proc.returncode or 0
-    if timed_out:
-        rc = -1
-        err = err or f"{cmd_label} timed out after {timeout}s"
-    elapsed = t3 - t0
-    logger.debug(
-        "podman-timing: %s tempfile=%.3fs spawn=%.3fs wait=%.3fs total=%.3fs",
-        cmd_label,
-        t1 - t0,
-        t2 - t1,
-        t3 - t2,
-        elapsed,
-    )
-    if elapsed > 2.0 and err.strip():  # pragma: no cover
-        logger.debug("podman-timing: %s stderr: %s", cmd_label, err.strip())
-    if check and rc != 0:
-        raise PodmanError(classify(err), err.strip() or f"podman {args[0]}")
-    return rc, out_bytes, err
+        if check and rc != 0:
+            raise PodmanError(
+                classify(err), err.strip() or f"podman {args[0]}"
+            )
+        return rc, out, err
 
-
-# --- Containers ---
-
-
-async def inspect_container(container_id: str) -> dict | None:
-    """Return the inspect dict for a container, or None if it is gone."""
-    rc, out, _err = await run(
-        ["container", "inspect", container_id], check=False
-    )
-    if rc != 0:
-        return None
-    data = json.loads(out)
-    return data[0] if data else None
-
-
-async def create_container(
-    name: str,
-    image: str,
-    *,
-    labels: dict[str, str] | None = None,
-    binds: list[str] | None = None,
-    tmpfs: dict[str, str] | None = None,
-    publish: list[tuple[int, int]] | None = None,
-    add_hosts: list[str] | None = None,
-    dns: list[str] | None = None,
-    env: list[str] | None = None,
-    init: bool = False,
-    interactive: bool = False,
-    pull: str = "never",
-    replace: bool = True,
-    userns: str | None = None,
-) -> str:
-    """Create a container and return its id.
-
-    ``publish`` is a list of ``(host_port, container_port)`` pairs.
-    ``replace=True`` removes an existing container with the same name.
-    """
-    args = ["create", f"--pull={pull}", "--name", name]
-    if replace:
-        args.append("--replace")
-    if init:
-        args.append("--init")
-    if interactive:
-        args.append("-i")
-    if userns:
-        args += ["--userns", userns]
-    for key, value in (labels or {}).items():
-        args += ["--label", f"{key}={value}"]
-    for bind in binds or []:
-        args += ["-v", bind]
-    for path, opts in (tmpfs or {}).items():
-        args += ["--tmpfs", f"{path}:{opts}"]
-    for host_port, container_port in publish or []:
-        args += ["-p", f"{host_port}:{container_port}"]
-    for host in add_hosts or []:
-        args += ["--add-host", host]
-    for server in dns or []:
-        args += ["--dns", server]
-    for entry in env or []:
-        args += ["-e", entry]
-    args.append(image)
-    _rc, out, _err = await run(args, timeout=120.0)
-    return out.strip()
-
-
-async def start_container(container_id: str) -> None:
-    """Start a created container."""
-    await run(["start", container_id], timeout=120.0)
-
-
-async def wait_for_container_ready(
-    container_id: str, *, timeout: float = 60.0
-) -> None:
-    """Block until the container's entrypoint signals readiness.
-
-    ``podman start`` returns the moment the container reaches "running"
-    state — i.e. the entrypoint has *begun*, not finished. The entrypoint
-    creates ``/tmp/.klangk-ready`` once its one-time setup (on-entrypoint
-    plugin hooks) is done, so this blocks until that sentinel exists and
-    callers can treat the container as fully ready, not just started.
-
-    Implemented as a single ``podman exec`` that spins on the sentinel
-    file: one round-trip, no poll interval, so the only latency is the
-    irreducible entrypoint work itself.
-
-    Raises :class:`PodmanError` if the sentinel does not appear within
-    *timeout* seconds.
-    """
-    rc, _out, _err = await exec_container(
-        container_id,
-        [
-            "sh",
-            "-c",
-            "while [ ! -f /tmp/.klangk-ready ]; do sleep 0.1; done",
-        ],
-        timeout=timeout,
-    )
-    if rc != 0:
-        raise PodmanError(
-            500,
-            f"Container {container_id} did not become ready within "
-            f"{timeout}s (entrypoint did not create /tmp/.klangk-ready)",
+    async def run_raw(
+        self,
+        args: list[str],
+        *,
+        check: bool = True,
+        stdin_data: bytes | None = None,
+        timeout: float | None = 30.0,
+    ) -> tuple[int, bytes, str]:
+        """Like ``run`` but returns raw stdout bytes (for binary data)."""
+        cmd_label = f"podman {args[0]}" if args else "podman"
+        t0 = time.monotonic()
+        with (
+            tempfile.TemporaryFile() as out_f,
+            tempfile.TemporaryFile() as err_f,
+        ):
+            t1 = time.monotonic()
+            proc = await asyncio.create_subprocess_exec(
+                self._bin,
+                *args,
+                stdin=(
+                    asyncio.subprocess.PIPE if stdin_data is not None else None
+                ),
+                stdout=out_f,
+                stderr=err_f,
+                env=subprocess_env(),
+            )
+            t2 = time.monotonic()
+            if stdin_data is not None:
+                proc.stdin.write(stdin_data)
+                await proc.stdin.drain()
+                proc.stdin.close()
+            timed_out = False
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=timeout)
+            except asyncio.TimeoutError:
+                timed_out = True
+                logger.warning(
+                    "podman-timeout: %s exceeded %.1fs — killing",
+                    cmd_label,
+                    timeout,
+                )
+                proc.kill()
+                await proc.wait()
+            t3 = time.monotonic()
+            out_f.seek(0)
+            err_f.seek(0)
+            out_bytes = out_f.read()
+            err = err_f.read().decode("utf-8", errors="replace")
+        rc = proc.returncode or 0
+        if timed_out:
+            rc = -1
+            err = err or f"{cmd_label} timed out after {timeout}s"
+        elapsed = t3 - t0
+        logger.debug(
+            "podman-timing: %s tempfile=%.3fs spawn=%.3fs wait=%.3fs"
+            " total=%.3fs",
+            cmd_label,
+            t1 - t0,
+            t2 - t1,
+            t3 - t2,
+            elapsed,
         )
+        if elapsed > 2.0 and err.strip():  # pragma: no cover
+            logger.debug(
+                "podman-timing: %s stderr: %s", cmd_label, err.strip()
+            )
+        if check and rc != 0:
+            raise PodmanError(
+                classify(err), err.strip() or f"podman {args[0]}"
+            )
+        return rc, out_bytes, err
 
+    # --- Containers ---
 
-def _exec_args(
-    container_id: str,
-    cmd: list[str],
-    *,
-    user: str | None = None,
-    interactive: bool = False,
-    extra_env: dict[str, str] | None = None,
-) -> list[str]:
-    """Build the ``podman exec`` argument list (without the leading binary).
+    async def inspect_container(self, container_id: str) -> dict | None:
+        """Return the inspect dict for a container, or None if it is gone."""
+        rc, out, _err = await self.run(
+            ["container", "inspect", container_id], check=False
+        )
+        if rc != 0:
+            return None
+        data = json.loads(out)
+        return data[0] if data else None
 
-    All options (``-i`` / ``-u`` / ``-e``) precede the container id and
-    command, matching ``podman exec [OPTIONS] CONTAINER [COMMAND...]``.
-    Centralized so the three ``exec_container*`` callers stay in sync and
-    there is a single place to add flags (e.g. ``extra_env``).
-    """
-    args = ["exec"]
-    if interactive:
-        args.append("-i")
-    if user:
-        args += ["-u", user]
-    if extra_env:
-        for key, value in extra_env.items():
-            args += ["-e", f"{key}={value}"]
-    args.append(container_id)
-    args.extend(cmd)
-    return args
+    async def create_container(
+        self,
+        name: str,
+        image: str,
+        *,
+        labels: dict[str, str] | None = None,
+        binds: list[str] | None = None,
+        tmpfs: dict[str, str] | None = None,
+        publish: list[tuple[int, int]] | None = None,
+        add_hosts: list[str] | None = None,
+        dns: list[str] | None = None,
+        env: list[str] | None = None,
+        init: bool = False,
+        interactive: bool = False,
+        pull: str = "never",
+        replace: bool = True,
+        userns: str | None = None,
+    ) -> str:
+        """Create a container and return its id.
 
+        ``publish`` is a list of ``(host_port, container_port)`` pairs.
+        ``replace=True`` removes an existing container with the same name.
+        """
+        args = ["create", f"--pull={pull}", "--name", name]
+        if replace:
+            args.append("--replace")
+        if init:
+            args.append("--init")
+        if interactive:
+            args.append("-i")
+        if userns:
+            args += ["--userns", userns]
+        for key, value in (labels or {}).items():
+            args += ["--label", f"{key}={value}"]
+        for bind in binds or []:
+            args += ["-v", bind]
+        for path, opts in (tmpfs or {}).items():
+            args += ["--tmpfs", f"{path}:{opts}"]
+        for host_port, container_port in publish or []:
+            args += ["-p", f"{host_port}:{container_port}"]
+        for host in add_hosts or []:
+            args += ["--add-host", host]
+        for server in dns or []:
+            args += ["--dns", server]
+        for entry in env or []:
+            args += ["-e", entry]
+        args.append(image)
+        _rc, out, _err = await self.run(args, timeout=120.0)
+        return out.strip()
 
-async def exec_container(
-    container_id: str,
-    cmd: list[str],
-    *,
-    user: str | None = None,
-    stdin_data: bytes | None = None,
-    extra_env: dict[str, str] | None = None,
-    timeout: float | None = 30.0,
-) -> tuple[int, str, str]:
-    """Run a command inside a running container.
+    async def start_container(self, container_id: str) -> None:
+        """Start a created container."""
+        await self.run(["start", container_id], timeout=120.0)
 
-    Returns ``(returncode, stdout, stderr)``.
-    """
-    args = _exec_args(
-        container_id,
-        cmd,
-        user=user,
-        interactive=stdin_data is not None,
-        extra_env=extra_env,
-    )
-    return await run(args, check=False, stdin_data=stdin_data, timeout=timeout)
+    async def wait_for_container_ready(
+        self, container_id: str, *, timeout: float = 60.0
+    ) -> None:
+        """Block until the container's entrypoint signals readiness.
 
+        ``podman start`` returns the moment the container reaches "running"
+        state — i.e. the entrypoint has *begun*, not finished. The entrypoint
+        creates ``/tmp/.klangk-ready`` once its one-time setup (on-entrypoint
+        plugin hooks) is done, so this blocks until that sentinel exists and
+        callers can treat the container as fully ready, not just started.
 
-async def exec_container_bytes(
-    container_id: str,
-    cmd: list[str],
-    *,
-    user: str | None = None,
-    extra_env: dict[str, str] | None = None,
-    timeout: float | None = 30.0,
-) -> tuple[int, bytes, str]:
-    """Like ``exec_container`` but returns raw stdout bytes (for binary data)."""
-    args = _exec_args(container_id, cmd, user=user, extra_env=extra_env)
-    return await run_raw(args, check=False, timeout=timeout)
+        Implemented as a single ``podman exec`` that spins on the sentinel
+        file: one round-trip, no poll interval, so the only latency is the
+        irreducible entrypoint work itself.
 
+        Raises :class:`PodmanError` if the sentinel does not appear within
+        *timeout* seconds.
+        """
+        rc, _out, _err = await self.exec_container(
+            container_id,
+            [
+                "sh",
+                "-c",
+                "while [ ! -f /tmp/.klangk-ready ]; do sleep 0.1; done",
+            ],
+            timeout=timeout,
+        )
+        if rc != 0:
+            raise PodmanError(
+                500,
+                f"Container {container_id} did not become ready within "
+                f"{timeout}s (entrypoint did not create /tmp/.klangk-ready)",
+            )
 
-async def exec_container_stream(
-    container_id: str,
-    cmd: list[str],
-    *,
-    user: str | None = None,
-    extra_env: dict[str, str] | None = None,
-    chunk_size: int = 64 * 1024,
-) -> AsyncGenerator[bytes, None]:
-    """Stream stdout from a command inside a container.
+    @staticmethod
+    def _exec_args(
+        container_id: str,
+        cmd: list[str],
+        *,
+        user: str | None = None,
+        interactive: bool = False,
+        extra_env: dict[str, str] | None = None,
+    ) -> list[str]:
+        """Build the ``podman exec`` argument list (without the leading binary).
 
-    Uses ``stdout=PIPE`` for true end-to-end streaming without buffering
-    to disk.  stderr is discarded to avoid pipe-buffer deadlocks (the
-    process would block if stderr fills while we only drain stdout).
-    """
-    args = _exec_args(container_id, cmd, user=user, extra_env=extra_env)
-    proc = await asyncio.create_subprocess_exec(
-        _podman_bin(),
-        *args,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.DEVNULL,
-        env=subprocess_env(),
-    )
-    yielded = False
-    try:
-        while True:
-            chunk = await proc.stdout.read(chunk_size)
-            if not chunk:
-                break
-            yielded = True
-            yield chunk
-    finally:
-        if proc.returncode is None:
-            proc.kill()
-        await proc.wait()
-    if proc.returncode != 0:
-        logger.warning(
-            "exec_container_stream command failed (rc=%d): %s %s",
-            proc.returncode,
+        All options (``-i`` / ``-u`` / ``-e``) precede the container id and
+        command, matching ``podman exec [OPTIONS] CONTAINER [COMMAND...]``.
+        Centralized so the three ``exec_container*`` callers stay in sync and
+        there is a single place to add flags (e.g. ``extra_env``).
+        """
+        args = ["exec"]
+        if interactive:
+            args.append("-i")
+        if user:
+            args += ["-u", user]
+        if extra_env:
+            for key, value in extra_env.items():
+                args += ["-e", f"{key}={value}"]
+        args.append(container_id)
+        args.extend(cmd)
+        return args
+
+    async def exec_container(
+        self,
+        container_id: str,
+        cmd: list[str],
+        *,
+        user: str | None = None,
+        stdin_data: bytes | None = None,
+        extra_env: dict[str, str] | None = None,
+        timeout: float | None = 30.0,
+    ) -> tuple[int, str, str]:
+        """Run a command inside a running container.
+
+        Returns ``(returncode, stdout, stderr)``.
+        """
+        args = self._exec_args(
             container_id,
             cmd,
+            user=user,
+            interactive=stdin_data is not None,
+            extra_env=extra_env,
         )
-        # Only abort the stream if no data was produced; if data was
-        # yielded the response is already in-flight and may be valid
-        # (e.g. tar exits 1 when files change during archiving).
-        if not yielded:
-            raise PodmanError(
+        return await self.run(
+            args, check=False, stdin_data=stdin_data, timeout=timeout
+        )
+
+    async def exec_container_bytes(
+        self,
+        container_id: str,
+        cmd: list[str],
+        *,
+        user: str | None = None,
+        extra_env: dict[str, str] | None = None,
+        timeout: float | None = 30.0,
+    ) -> tuple[int, bytes, str]:
+        """Like ``exec_container`` but returns raw stdout bytes."""
+        args = self._exec_args(
+            container_id, cmd, user=user, extra_env=extra_env
+        )
+        return await self.run_raw(args, check=False, timeout=timeout)
+
+    async def exec_container_stream(
+        self,
+        container_id: str,
+        cmd: list[str],
+        *,
+        user: str | None = None,
+        extra_env: dict[str, str] | None = None,
+        chunk_size: int = 64 * 1024,
+    ) -> AsyncGenerator[bytes, None]:
+        """Stream stdout from a command inside a container.
+
+        Uses ``stdout=PIPE`` for true end-to-end streaming without buffering
+        to disk.  stderr is discarded to avoid pipe-buffer deadlocks (the
+        process would block if stderr fills while we only drain stdout).
+        """
+        args = self._exec_args(
+            container_id, cmd, user=user, extra_env=extra_env
+        )
+        proc = await asyncio.create_subprocess_exec(
+            self._bin,
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+            env=subprocess_env(),
+        )
+        yielded = False
+        try:
+            while True:
+                chunk = await proc.stdout.read(chunk_size)
+                if not chunk:
+                    break
+                yielded = True
+                yield chunk
+        finally:
+            if proc.returncode is None:
+                proc.kill()
+            await proc.wait()
+        if proc.returncode != 0:
+            logger.warning(
+                "exec_container_stream command failed (rc=%d): %s %s",
                 proc.returncode,
-                f"stream command exited with code {proc.returncode}",
+                container_id,
+                cmd,
             )
+            # Only abort the stream if no data was produced; if data was
+            # yielded the response is already in-flight and may be valid
+            # (e.g. tar exits 1 when files change during archiving).
+            if not yielded:
+                raise PodmanError(
+                    proc.returncode,
+                    f"stream command exited with code {proc.returncode}",
+                )
 
+    async def remove_container(
+        self, container_id: str, *, force: bool = True
+    ) -> None:
+        """Remove a container; never raises on 404."""
+        args = ["rm"]
+        if force:
+            args.append("-f")
+        args.append(container_id)
+        rc, _out, err = await self.run(args, check=False)
+        if rc != 0 and classify(err) != 404:
+            raise PodmanError(classify(err), err.strip() or "podman rm")
 
-async def remove_container(container_id: str, *, force: bool = True) -> None:
-    """Remove a container; never raises on 404."""
-    args = ["rm"]
-    if force:
-        args.append("-f")
-    args.append(container_id)
-    rc, _out, err = await run(args, check=False)
-    if rc != 0 and classify(err) != 404:
-        raise PodmanError(classify(err), err.strip() or "podman rm")
+    async def list_containers(self, label: str) -> list[dict]:
+        """List containers matching ``label`` (``key=value``)."""
+        _rc, out, _err = await self.run(
+            ["ps", "-a", "--filter", f"label={label}", "--format", "json"]
+        )
+        out = out.strip()
+        return json.loads(out) if out else []
 
+    # --- Volumes ---
 
-async def list_containers(label: str) -> list[dict]:
-    """List containers matching ``label`` (``key=value``)."""
-    _rc, out, _err = await run(
-        ["ps", "-a", "--filter", f"label={label}", "--format", "json"]
-    )
-    out = out.strip()
-    return json.loads(out) if out else []
+    async def inspect_volume(self, name: str) -> dict | None:
+        """Return a volume's inspect dict, or None if it does not exist."""
+        rc, out, _err = await self.run(
+            ["volume", "inspect", name], check=False
+        )
+        if rc != 0:
+            return None
+        data = json.loads(out)
+        return data[0] if data else None
 
+    async def create_volume(
+        self, name: str, labels: dict[str, str] | None = None
+    ) -> dict:
+        """Create a labelled volume and return its inspect dict."""
+        args = ["volume", "create"]
+        for key, value in (labels or {}).items():
+            args += ["--label", f"{key}={value}"]
+        args.append(name)
+        await self.run(args)
+        info = await self.inspect_volume(name)
+        if info is None:  # pragma: no cover
+            raise PodmanError(500, f"volume {name!r} vanished after create")
+        return info
 
-# --- Volumes ---
+    async def list_volumes(self, label: str) -> list[dict]:
+        """List volumes matching ``label`` (``key=value``)."""
+        _rc, out, _err = await self.run(
+            ["volume", "ls", "--filter", f"label={label}", "--format", "json"]
+        )
+        out = out.strip()
+        return json.loads(out) if out else []
 
+    async def remove_volume(self, name: str) -> None:
+        """Remove a volume.
 
-async def inspect_volume(name: str) -> dict | None:
-    """Return a volume's inspect dict, or None if it does not exist."""
-    rc, out, _err = await run(["volume", "inspect", name], check=False)
-    if rc != 0:
-        return None
-    data = json.loads(out)
-    return data[0] if data else None
-
-
-async def create_volume(
-    name: str, labels: dict[str, str] | None = None
-) -> dict:
-    """Create a labelled volume and return its inspect dict."""
-    args = ["volume", "create"]
-    for key, value in (labels or {}).items():
-        args += ["--label", f"{key}={value}"]
-    args.append(name)
-    await run(args)
-    info = await inspect_volume(name)
-    if info is None:  # pragma: no cover
-        raise PodmanError(500, f"volume {name!r} vanished after create")
-    return info
-
-
-async def list_volumes(label: str) -> list[dict]:
-    """List volumes matching ``label`` (``key=value``)."""
-    _rc, out, _err = await run(
-        ["volume", "ls", "--filter", f"label={label}", "--format", "json"]
-    )
-    out = out.strip()
-    return json.loads(out) if out else []
-
-
-async def remove_volume(name: str) -> None:
-    """Remove a volume.
-
-    Raises :class:`PodmanError` with status 404 or 409 so callers can
-    map them to HTTP responses.
-    """
-    rc, _out, err = await run(["volume", "rm", name], check=False)
-    if rc != 0:
-        raise PodmanError(classify(err), err.strip() or "podman volume rm")
+        Raises :class:`PodmanError` with status 404 or 409 so callers can
+        map them to HTTP responses.
+        """
+        rc, _out, err = await self.run(["volume", "rm", name], check=False)
+        if rc != 0:
+            raise PodmanError(classify(err), err.strip() or "podman volume rm")
 
 
 # --- Exec sessions ---
@@ -501,10 +529,12 @@ class ExecSession:
     def __init__(
         self,
         container_id: str,
+        podman: Podman,
         env: list[str] | None = None,
         work_dir: str = "/home/work",
     ):
         self.container_id = container_id
+        self._podman = podman
         self.env = env or []
         self.work_dir = work_dir
         self._proc: asyncio.subprocess.Process | None = None
@@ -547,7 +577,7 @@ class ExecSession:
         else:
             argv = command
         exec_cmd = [
-            _podman_bin(),
+            self._podman.bin,
             "exec",
             "-i",
             *env_flags,

--- a/src/backend/klangk_backend/terminal.py
+++ b/src/backend/klangk_backend/terminal.py
@@ -868,6 +868,7 @@ class TerminalSession:
                 self.session_name,
                 user_home=self.user_home,
                 ssh_agent_socket=self.ssh_agent_socket,
+                podman=self._podman,
             )
         env = build_environment(
             self.user_home,

--- a/src/backend/klangk_backend/terminal.py
+++ b/src/backend/klangk_backend/terminal.py
@@ -21,7 +21,7 @@ import termios
 import tty
 from collections.abc import AsyncGenerator
 
-from . import podman
+from .podman import subprocess_env
 from .exceptions import TerminalError
 from .model.workspaces import SETUP_STATE_COMPLETE
 from .util import BoundedOutputQueue, resolve_env_value
@@ -108,7 +108,9 @@ SERVICE_SESSION = "service"
 # app_state.container_registry.get_service_session_lock().
 
 
-async def has_tmux_session(container_id: str, session_name: str) -> bool:
+async def has_tmux_session(
+    container_id: str, session_name: str, podman
+) -> bool:
     """Return True if a tmux session named *session_name* exists."""
     try:
         rc, _, _ = await podman.exec_container(
@@ -123,7 +125,7 @@ async def has_tmux_session(container_id: str, session_name: str) -> bool:
 
 
 async def service_cmd_window_exists(
-    container_id: str, session_name: str
+    container_id: str, session_name: str, podman
 ) -> bool:
     """Return True if the ``service-cmd`` window exists in *session_name*.
 
@@ -182,6 +184,7 @@ async def _ensure_tmux_session(
     session_name: str,
     user_home: str | None = None,
     ssh_agent_socket: str | None = None,
+    podman=None,
 ) -> bool:
     """Ensure a detached base tmux session exists for *session_name*.
 
@@ -191,7 +194,7 @@ async def _ensure_tmux_session(
     not podman's), so the session's window-0 shell sources the right
     profile.
     """
-    if await has_tmux_session(container_id, session_name):
+    if await has_tmux_session(container_id, session_name, podman):
         return False
     env_args: list[str] = []
     if user_home is not None:
@@ -216,6 +219,7 @@ async def ensure_base_session(
     session_name: str,
     user_home: str | None = None,
     ssh_agent_socket: str | None = None,
+    podman=None,
 ) -> bool:
     """Ensure the firing user's base tmux session + window 0 exist.
 
@@ -227,7 +231,7 @@ async def ensure_base_session(
     regardless of setup state (#1133).
     """
     return await _ensure_tmux_session(
-        container_id, session_name, user_home, ssh_agent_socket
+        container_id, session_name, user_home, ssh_agent_socket, podman
     )
 
 
@@ -271,13 +275,17 @@ async def ensure_service_session(
     async with app_state.container_registry.get_service_session_lock(
         container_id
     ):
-        await _ensure_tmux_session(container_id, SERVICE_SESSION, agent_home)
+        await _ensure_tmux_session(
+            container_id, SERVICE_SESSION, agent_home, podman=app_state.podman
+        )
         if not (
             should_fire_service_command(service_command, setup_state)
-        ) or await service_cmd_window_exists(container_id, SERVICE_SESSION):
+        ) or await service_cmd_window_exists(
+            container_id, SERVICE_SESSION, app_state.podman
+        ):
             return
         try:
-            await podman.exec_container(
+            await app_state.podman.exec_container(
                 container_id,
                 [
                     "tmux",
@@ -303,7 +311,7 @@ async def ensure_service_session(
         # Same race as #1030.
         await asyncio.sleep(1)
         try:
-            await podman.exec_container(
+            await app_state.podman.exec_container(
                 container_id,
                 [
                     "tmux",
@@ -332,7 +340,7 @@ async def ensure_service_session(
             # into it. Kill it so the next fire re-runs the whole sequence
             # instead of no-op'ing forever on the half-created window (#1186).
             try:
-                await podman.exec_container(
+                await app_state.podman.exec_container(
                     container_id,
                     [
                         "tmux",
@@ -443,7 +451,7 @@ def _build_exec_argv(
     return argv
 
 
-async def attach_browser(container_id: str, browser_id: str) -> None:
+async def attach_browser(container_id: str, browser_id: str, podman) -> None:
     """Run ``klangk-attach-browser <browser_id>`` inside the container.
 
     This stores the browser ID in the tmux global environment so that
@@ -464,7 +472,7 @@ async def attach_browser(container_id: str, browser_id: str) -> None:
         )
 
 
-async def set_workspace_token(container_id: str, token: str) -> None:
+async def set_workspace_token(container_id: str, token: str, podman) -> None:
     """Write a workspace token to ``/run/klangk/workspace-token`` inside
     the container via ``klangk-set-workspace-token``.
     """
@@ -483,7 +491,7 @@ async def set_workspace_token(container_id: str, token: str) -> None:
 
 
 async def tmux_command(
-    container_id: str, session_name: str, args: list[str]
+    container_id: str, session_name: str, args: list[str], podman
 ) -> str:
     """Run a tmux command in the container and return stdout.
 
@@ -506,7 +514,9 @@ async def tmux_command(
     return ""  # pragma: no cover
 
 
-async def list_windows(container_id: str, session_name: str) -> list[dict]:
+async def list_windows(
+    container_id: str, session_name: str, podman
+) -> list[dict]:
     """List tmux windows for a session. Returns [{index, name}, ...]."""
     output = await tmux_command(
         container_id,
@@ -518,6 +528,7 @@ async def list_windows(container_id: str, session_name: str) -> list[dict]:
             "-F",
             "#{window_id}|||#{window_index}|||#{window_name}|||#{window_active}",
         ],
+        podman,
     )
     windows = []
     for line in output.strip().splitlines():
@@ -535,7 +546,10 @@ async def list_windows(container_id: str, session_name: str) -> list[dict]:
 
 
 async def new_window(
-    container_id: str, session_name: str, name: str | None = None
+    container_id: str,
+    session_name: str,
+    name: str | None = None,
+    podman=None,
 ) -> list[dict]:
     """Create a new tmux window and return the updated window list.
 
@@ -600,7 +614,11 @@ async def new_window(
 
 
 async def rename_window(
-    container_id: str, session_name: str, index: int, name: str
+    container_id: str,
+    session_name: str,
+    index: int,
+    name: str,
+    podman,
 ) -> None:
     """Rename a tmux window.
 
@@ -608,18 +626,22 @@ async def rename_window(
     duplicates another window's name.
     """
     validate_window_name(name)
-    existing = await list_windows(container_id, session_name)
+    existing = await list_windows(container_id, session_name, podman)
     if any(w["name"] == name and w["index"] != index for w in existing):
         raise ValueError(f"Window name '{name}' already exists")
     await tmux_command(
         container_id,
         session_name,
         ["rename-window", "-t", f"{session_name}:{index}", name],
+        podman,
     )
 
 
 async def select_window(
-    container_id: str, session_name: str, target: int | str
+    container_id: str,
+    session_name: str,
+    target: int | str,
+    podman,
 ) -> None:
     """Switch the active tmux window.
 
@@ -636,11 +658,15 @@ async def select_window(
         container_id,
         session_name,
         ["select-window", "-t", t],
+        podman,
     )
 
 
 async def close_window(
-    container_id: str, session_name: str, target: int | str
+    container_id: str,
+    session_name: str,
+    target: int | str,
+    podman,
 ) -> list[dict]:
     """Close a tmux window and return the updated window list.
 
@@ -655,11 +681,14 @@ async def close_window(
         container_id,
         session_name,
         ["kill-window", "-t", t],
+        podman,
     )
-    return await list_windows(container_id, session_name)
+    return await list_windows(container_id, session_name, podman)
 
 
-async def kill_joiner_sessions(container_id: str, owner_handle: str) -> None:
+async def kill_joiner_sessions(
+    container_id: str, owner_handle: str, podman
+) -> None:
     """Kill all session-group sessions except the owner's own session.
 
     Used when unsharing to disconnect spectators/collaborators.
@@ -673,6 +702,7 @@ async def kill_joiner_sessions(container_id: str, owner_handle: str) -> None:
                 "-F",
                 "#{session_name}",
             ],
+            podman,
         )
         for session_name in output.strip().splitlines():
             if session_name != owner_handle:
@@ -681,6 +711,7 @@ async def kill_joiner_sessions(container_id: str, owner_handle: str) -> None:
                         container_id,
                         owner_handle,
                         ["kill-session", "-t", session_name],
+                        podman,
                     )
                 except TerminalError:
                     pass  # Session may have already exited
@@ -698,7 +729,8 @@ class ShellProcess:
     across all terminal sessions.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, podman=None) -> None:
+        self._podman = podman
         self._master_fd: int | None = None
         self._proc: asyncio.subprocess.Process | None = None
         self._read_event: asyncio.Event | None = None
@@ -711,13 +743,13 @@ class ShellProcess:
             tty.setraw(slave_fd)
             _set_winsize(master_fd, rows, cols)
             self._proc = await asyncio.create_subprocess_exec(
-                podman._podman_bin(),
+                self._podman.bin,
                 *argv,
                 stdin=slave_fd,
                 stdout=slave_fd,
                 stderr=slave_fd,
                 start_new_session=True,
-                env=podman.subprocess_env(),
+                env=subprocess_env(),
             )
         finally:
             os.close(slave_fd)
@@ -777,8 +809,8 @@ def _set_winsize(fd: int, rows: int, cols: int) -> None:  # pragma: no cover
     fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", rows, cols, 0, 0))
 
 
-def make_shell_process() -> ShellProcess:
-    return ShellProcess()
+def make_shell_process(podman=None) -> ShellProcess:
+    return ShellProcess(podman)
 
 
 class TerminalSession:
@@ -795,8 +827,10 @@ class TerminalSession:
         user_id: str | None = None,
         user_handle: str | None = None,
         ssh_agent_socket: str | None = None,
+        podman=None,
     ):
         self.container_id = container_id
+        self._podman = podman
         self.session_name = session_name
         self.user_home = user_home
         self.socket_path = socket_path
@@ -873,7 +907,7 @@ class TerminalSession:
         # ignores the `-e` flags — the env var must be set explicitly.
         if self.ssh_agent_socket and self.session_name:
             try:
-                await podman.exec_container(
+                await self._podman.exec_container(
                     self.container_id,
                     [
                         "tmux",
@@ -1000,7 +1034,7 @@ class TerminalSession:
                 socket_args = (
                     ["-S", self.socket_path] if self.socket_path else []
                 )
-                await podman.exec_container(
+                await self._podman.exec_container(
                     self.container_id,
                     [
                         "tmux",

--- a/src/backend/klangk_backend/terminal.py
+++ b/src/backend/klangk_backend/terminal.py
@@ -888,7 +888,7 @@ class TerminalSession:
         argv = _build_exec_argv(self.container_id, env, shell_cmd, work_dir)
 
         logger.info("Terminal exec argv: %s", argv)
-        shell = make_shell_process()
+        shell = make_shell_process(self._podman)
         try:
             await shell.start(argv, rows, cols)
         except Exception:

--- a/src/backend/klangk_backend/workspaces.py
+++ b/src/backend/klangk_backend/workspaces.py
@@ -8,7 +8,7 @@ import shutil
 import tempfile
 from pathlib import Path
 
-from . import container, model, podman
+from . import container, model
 from .model.instance import get_instance_id
 from .util import resolve_env_bool, resolve_env_value
 
@@ -404,6 +404,7 @@ async def ensure_home_symlink(
 async def populate_home_skel(
     container_id: str,
     user_id: str,
+    podman=None,
 ) -> None:
     """Copy /etc/skel into a new user's home directory inside the container.
 

--- a/src/backend/klangk_backend/wshandler/connection.py
+++ b/src/backend/klangk_backend/wshandler/connection.py
@@ -363,7 +363,9 @@ class Connection:
         # Populate skeleton if this is a new user home (symlink was
         # created above, before container start).
         if self._home_created:
-            await workspaces.populate_home_skel(container_id, self.user["id"])
+            await workspaces.populate_home_skel(
+                container_id, self.user["id"], self.app_state.podman
+            )
 
         logger.info("Container ready for workspace %s", workspace_id)
 
@@ -871,7 +873,9 @@ class Connection:
                 )
                 if created and self.container_id:
                     await workspaces.populate_home_skel(
-                        self.container_id, self.user["id"]
+                        self.container_id,
+                        self.user["id"],
+                        self.app_state.podman,
                     )
                 self._user_home = container_home
             self.sock.send_json(

--- a/src/backend/klangk_backend/wshandler/controllers.py
+++ b/src/backend/klangk_backend/wshandler/controllers.py
@@ -592,7 +592,9 @@ class TerminalController:
                 # fire. Done before window sync so discovery picks it up.
                 await ctrl._fire_service_command()
                 if browser_id:
-                    await attach_browser(conn.container_id, browser_id)
+                    await attach_browser(
+                        conn.container_id, browser_id, conn.app_state.podman
+                    )
                 if not await conn.activate_session(session, cols, rows):
                     return
                 conn.sock.send_json({"type": "terminal_started"})
@@ -643,7 +645,9 @@ class TerminalController:
             self._conn.user.get("email"),
             self._conn.workspace_id,
         )
-        await attach_browser(self._conn.container_id, browser_id)
+        await attach_browser(
+            self._conn.container_id, browser_id, self._conn.app_state.podman
+        )
 
     async def input(self, msg: dict) -> None:
         t0 = time.monotonic()

--- a/src/backend/klangk_backend/wshandler/controllers.py
+++ b/src/backend/klangk_backend/wshandler/controllers.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 
 from fastapi import WebSocketDisconnect
 
-from .. import model, podman, terminal
+from .. import model, terminal
 from ..exceptions import TerminalError
 from ..util import resolve_env_value
 from ..podman import ExecSession
@@ -63,12 +63,14 @@ class SshAgentForwarder:
         user_id = self._conn.user["id"]
         sock_path = f"/tmp/klangk-ssh-agent-{user_id}.sock"
         # Remove stale socket if it exists from a previous session.
-        await podman.exec_container(container_id, ["rm", "-f", sock_path])
+        await self._conn.app_state.podman.exec_container(
+            container_id, ["rm", "-f", sock_path]
+        )
         if _debug_agent:
             logger.info("[ssh-agent] starting socat at %s", sock_path)
         # Start socat: listen on the Unix socket, relay to stdin/stdout.
         proc = await asyncio.create_subprocess_exec(
-            podman._podman_bin(),
+            self._conn.app_state.podman.bin,
             "exec",
             "-i",
             container_id,
@@ -188,7 +190,7 @@ class SshAgentForwarder:
         container_id = self._conn.container_id
         if self.socket and container_id:
             try:
-                await podman.exec_container(
+                await self._conn.app_state.podman.exec_container(
                     container_id,
                     ["rm", "-f", self.socket],
                 )
@@ -249,7 +251,12 @@ class ExecController:
         # klangkc exec sends login=true; klangkc exec --raw and the
         # rsync transport send login=false. See #1041.
         login = bool(msg.get("login", False))
-        session = ExecSession(container_id, env=env, work_dir=work_dir)
+        session = ExecSession(
+            container_id,
+            self._conn.app_state.podman,
+            env=env,
+            work_dir=work_dir,
+        )
         await session.start(command, login=login)
         self.session = session
         self.task = asyncio.create_task(self.forward_output(session))
@@ -379,7 +386,9 @@ class TerminalController:
         sname = conn.tmux_session_name()
         ws_session = conn.app_state.sockets.get_session(conn.workspace_id)
 
-        windows = await terminal.list_windows(conn.container_id, sname)
+        windows = await terminal.list_windows(
+            conn.container_id, sname, conn.app_state.podman
+        )
         conn.sync_terminal_windows(windows)
         conn.sock.send_json({"type": "terminal_windows", "windows": windows})
         # Discover the agent's ``service:service-cmd`` window so it shows
@@ -468,7 +477,9 @@ class TerminalController:
             return False
         try:
             windows = await terminal.list_windows(
-                self._conn.container_id, terminal.SERVICE_SESSION
+                self._conn.container_id,
+                terminal.SERVICE_SESSION,
+                self._conn.app_state.podman,
             )
         except (TerminalError, OSError):
             return False  # service session doesn't exist yet
@@ -550,6 +561,7 @@ class TerminalController:
             user_id=self._conn.user["id"],
             user_handle=self._conn.user.get("handle"),
             ssh_agent_socket=self._conn._ssh_agent_socket,
+            podman=self._conn.app_state.podman,
         )
 
         browser_id = msg.get("browser_id")
@@ -774,7 +786,10 @@ class TerminalController:
         name = msg.get("name")
         try:
             windows = await terminal.new_window(
-                self._conn.container_id, session_name, name=name
+                self._conn.container_id,
+                session_name,
+                name=name,
+                podman=self._conn.app_state.podman,
             )
             logger.info(
                 "handle_terminal_new_window: %.3fs",
@@ -802,7 +817,10 @@ class TerminalController:
         target: int | str = msg.get("window_id") or msg.get("index", 0)
         try:
             await terminal.select_window(
-                self._conn.container_id, session_name, target
+                self._conn.container_id,
+                session_name,
+                target,
+                self._conn.app_state.podman,
             )
             logger.info(
                 "handle_terminal_select_window: target=%s %.3fs",
@@ -820,7 +838,10 @@ class TerminalController:
         index = msg.get("index", 0)
         try:
             windows = await terminal.close_window(
-                self._conn.container_id, session_name, index
+                self._conn.container_id,
+                session_name,
+                index,
+                self._conn.app_state.podman,
             )
             self.sync_terminal_windows(windows)
             self.notify_user_terminal_windows(windows)
@@ -839,10 +860,16 @@ class TerminalController:
             return
         try:
             await terminal.rename_window(
-                self._conn.container_id, session_name, index, name
+                self._conn.container_id,
+                session_name,
+                index,
+                name,
+                self._conn.app_state.podman,
             )
             windows = await terminal.list_windows(
-                self._conn.container_id, session_name
+                self._conn.container_id,
+                session_name,
+                self._conn.app_state.podman,
             )
             self.sync_terminal_windows(windows)
             self.notify_user_terminal_windows(windows)
@@ -863,7 +890,9 @@ class TerminalController:
         )
         try:
             windows = await terminal.list_windows(
-                self._conn.container_id, session_name
+                self._conn.container_id,
+                session_name,
+                self._conn.app_state.podman,
             )
             self._conn.sock.send_json(
                 {"type": "terminal_windows", "windows": windows}
@@ -1074,7 +1103,9 @@ class SharedTerminalController:
         # Kick spectators/collaborators
         try:
             await terminal.kill_joiner_sessions(
-                self._conn.container_id, session_name
+                self._conn.container_id,
+                session_name,
+                self._conn.app_state.podman,
             )
         except Exception:
             logger.debug("Failed to kill joiner sessions", exc_info=True)
@@ -1094,6 +1125,7 @@ class SharedTerminalController:
         session: TerminalSession,
         owner_user_id: str,
         window_id: str,
+        podman,
     ) -> None:
         """Select the target window in the joiner's tmux session.
 
@@ -1112,14 +1144,15 @@ class SharedTerminalController:
                         "-t",
                         f"{joiner_session}:{window_id}",
                     ],
+                    podman,
                 )
             except TerminalError:
                 await terminal.select_window(
-                    container_id, owner_user_id, window_id
+                    container_id, owner_user_id, window_id, podman
                 )
         else:
             await terminal.select_window(
-                container_id, owner_user_id, window_id
+                container_id, owner_user_id, window_id, podman
             )
 
     async def join_shared_terminal(self, msg: dict) -> None:
@@ -1186,6 +1219,7 @@ class SharedTerminalController:
             read_only=read_only,
             user_id=self._conn.user["id"],
             user_handle=self._conn.user.get("handle"),
+            podman=self._conn.app_state.podman,
         )
         self._conn.terminal_session = session
         conn = self._conn
@@ -1201,6 +1235,7 @@ class SharedTerminalController:
                     session,
                     join_target,
                     window_id,
+                    conn.app_state.podman,
                 )
                 if not await conn.activate_session(session, cols, rows):
                     return
@@ -1280,7 +1315,10 @@ class SharedTerminalController:
         session_name = self._conn.tmux_session_name()
         try:
             windows = await terminal.new_window(
-                self._conn.container_id, session_name, name=name
+                self._conn.container_id,
+                session_name,
+                name=name,
+                podman=self._conn.app_state.podman,
             )
         except Exception as e:
             send_error(
@@ -1347,10 +1385,15 @@ class SharedTerminalController:
         window_name = match["name"]
         try:
             await terminal.kill_joiner_sessions(
-                self._conn.container_id, owner_user_id
+                self._conn.container_id,
+                owner_user_id,
+                self._conn.app_state.podman,
             )
             await terminal.close_window(
-                self._conn.container_id, owner_user_id, window_id
+                self._conn.container_id,
+                owner_user_id,
+                window_id,
+                self._conn.app_state.podman,
             )
         except Exception as e:
             send_error(

--- a/src/backend/klangk_backend/wshandler/session.py
+++ b/src/backend/klangk_backend/wshandler/session.py
@@ -191,7 +191,9 @@ class WorkspaceSession:
 
             try:
                 new_token = auth.create_workspace_token(self.workspace_id)
-                await terminal.set_workspace_token(container_id, new_token)
+                await terminal.set_workspace_token(
+                    container_id, new_token, self.app_state.podman
+                )
                 self.workspace_token_expiry = datetime.now(
                     timezone.utc
                 ) + timedelta(hours=auth.WORKSPACE_TOKEN_EXPIRE_HOURS)

--- a/src/backend/tests/test_agent.py
+++ b/src/backend/tests/test_agent.py
@@ -20,6 +20,10 @@ from klangk_backend.agent import (
     _agents,
 )
 
+# Mock Podman instance for ensure_agent_home tests (#1468).
+_mock_pod = MagicMock()
+_mock_pod.bin = "podman"
+
 
 class _FakeContainerState:
     def __init__(self, container_id="cid"):
@@ -66,7 +70,10 @@ def _make_app_state(cid="cid"):
 
     mock_registry = MagicMock()
     mock_registry.get_state.return_value = _FakeContainerState(cid)
-    return types.SimpleNamespace(container_registry=mock_registry)
+    mock_pod = MagicMock()
+    return types.SimpleNamespace(
+        container_registry=mock_registry, podman=mock_pod
+    )
 
 
 def _make_session(workspace_id="ws-id"):
@@ -82,7 +89,7 @@ def _fake_stdin() -> AsyncMock:
     """A mocked subprocess stdin (``asyncio.StreamWriter``).
 
     ``write`` and ``is_closing`` are *synchronous* on the real writer, so they
-    must be plain ``MagicMock``\ s.  A bare ``AsyncMock`` makes them return
+    must be plain ``MagicMock`` instances.  A bare ``AsyncMock`` makes them return
     coroutines that ``send_prompt``/``_send_abort`` never await, leaking
     ``RuntimeWarning: coroutine ... was never awaited`` (#1251).  ``drain`` is a
     real coroutine, so it stays an ``AsyncMock``.
@@ -863,13 +870,15 @@ class TestEnsureAgentHome:
                 return_value=mock_proc,
             ) as mock_exec,
         ):
-            result = await ensure_agent_home("ws1", "cid")
+            result = await ensure_agent_home("ws1", "cid", _mock_pod)
 
         assert result == "/home/clanker"
         mock_symlink.assert_called_once()
         # Skeleton files only on first creation (created=True).
         mock_skel.assert_awaited_once_with(
-            "cid", "00000000-0000-0000-0000-000000000001"
+            "cid",
+            "00000000-0000-0000-0000-000000000001",
+            _mock_pod,
         )
         # klangk-setup-pi --force re-writes Pi config each time.  It's
         # invoked by its full install path (bare-name resolution isn't
@@ -913,7 +922,7 @@ class TestEnsureAgentHome:
             patch("asyncio.create_subprocess_exec", return_value=mock_proc),
         ):
             # Must NOT raise -- provisioning is best-effort.
-            result = await agent.ensure_agent_home("ws1", "cid")
+            result = await agent.ensure_agent_home("ws1", "cid", _mock_pod)
 
         assert result == "/home/clanker"
 
@@ -942,7 +951,7 @@ class TestEnsureAgentHome:
                 ),
             ),
         ):
-            result = await ensure_agent_home("ws1", "cid")
+            result = await ensure_agent_home("ws1", "cid", _mock_pod)
 
         assert result == "/home/clanker"
         mock_skel.assert_not_awaited()
@@ -953,7 +962,7 @@ class TestEnsureAgentHome:
 
         with patch.object(model, "get_workspace_by_id", return_value=None):
             with pytest.raises(AgentSetupError, match="not found in database"):
-                await ensure_agent_home("ws-gone", "cid")
+                await ensure_agent_home("ws-gone", "cid", _mock_pod)
 
 
 class TestEnsureHome:
@@ -962,7 +971,7 @@ class TestEnsureHome:
     ):
         from klangk_backend import model, workspaces
 
-        session = AgentSession("ws1")
+        session = AgentSession("ws1", app_state=_make_app_state())
 
         fake_ws = {"user_id": "owner1"}
         fake_home = tmp_path / "home"
@@ -1005,11 +1014,13 @@ class TestEnsureHome:
         assert session._home_ready is True
         mock_symlink.assert_called_once()
         mock_skel.assert_awaited_once_with(
-            "cid", "00000000-0000-0000-0000-000000000001"
+            "cid",
+            "00000000-0000-0000-0000-000000000001",
+            session.app_state.podman,
         )
 
     async def test_ensure_home_cached(self):
-        session = AgentSession("ws-id")
+        session = AgentSession("ws-id", app_state=_make_app_state())
         session._home_ready = True
         result = await session._ensure_home("cid")
         assert result == "/home/clanker"
@@ -1018,7 +1029,7 @@ class TestEnsureHome:
         from klangk_backend import model
         from klangk_backend.agent import AgentSetupError
 
-        session = AgentSession("ws-gone")
+        session = AgentSession("ws-gone", app_state=_make_app_state())
 
         with patch.object(model, "get_workspace_by_id", return_value=None):
             with pytest.raises(AgentSetupError, match="not found in database"):

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -28,6 +28,10 @@ from klangk_backend.container import ContainerRegistry
 from klangk_backend.settings import KlangkSettings
 from klangk_backend.wshandler.session import WebSocketState
 
+# Mock Podman instance wired onto app.state.podman by the app fixture;
+# files/volume-API tests patch its methods via patch.object (#1468).
+_mock_pod = MagicMock()
+
 
 @pytest.fixture
 async def app(db):
@@ -45,6 +49,8 @@ async def app(db):
     registry.sockets = sockets
     registry.app_state = app.state
     sockets.app_state = app.state
+    app.state.podman = _mock_pod
+    registry.podman = _mock_pod
     agent.get_workspace_session = sockets.get_session
 
     app.include_router(api.root_router)
@@ -3782,7 +3788,7 @@ class TestVolumeRoutes:
     async def test_list_volumes(self, client, user):
         headers = await _auth_headers(client)
         with patch.object(
-            podman,
+            _mock_pod,
             "list_volumes",
             AsyncMock(
                 return_value=[
@@ -3818,9 +3824,9 @@ class TestVolumeRoutes:
         )
         with (
             patch.object(
-                podman, "inspect_volume", AsyncMock(return_value=None)
+                _mock_pod, "inspect_volume", AsyncMock(return_value=None)
             ),
-            patch.object(podman, "create_volume", mock_create),
+            patch.object(_mock_pod, "create_volume", mock_create),
         ):
             resp = await client.post(
                 "/api/v1/volumes",
@@ -3835,7 +3841,7 @@ class TestVolumeRoutes:
     async def test_create_duplicate_volume(self, client, user):
         headers = await _auth_headers(client)
         with patch.object(
-            podman,
+            _mock_pod,
             "inspect_volume",
             AsyncMock(return_value={"Name": "dup-vol"}),
         ):
@@ -3850,10 +3856,10 @@ class TestVolumeRoutes:
         headers = await _auth_headers(client)
         with (
             patch.object(
-                podman, "inspect_volume", AsyncMock(return_value=None)
+                _mock_pod, "inspect_volume", AsyncMock(return_value=None)
             ),
             patch.object(
-                podman,
+                _mock_pod,
                 "create_volume",
                 AsyncMock(side_effect=podman.PodmanError(500, "boom")),
             ),
@@ -3869,11 +3875,11 @@ class TestVolumeRoutes:
         headers = await _auth_headers(client)
         with (
             patch.object(
-                podman,
+                _mock_pod,
                 "inspect_volume",
                 AsyncMock(return_value=_managed_volume(user["id"])),
             ),
-            patch.object(podman, "remove_volume", AsyncMock()),
+            patch.object(_mock_pod, "remove_volume", AsyncMock()),
         ):
             resp = await client.delete(
                 "/api/v1/volumes/test-vol", headers=headers
@@ -3883,7 +3889,7 @@ class TestVolumeRoutes:
     async def test_delete_volume_not_found(self, client, user):
         headers = await _auth_headers(client)
         with patch.object(
-            podman, "inspect_volume", AsyncMock(return_value=None)
+            _mock_pod, "inspect_volume", AsyncMock(return_value=None)
         ):
             resp = await client.delete("/api/v1/volumes/nope", headers=headers)
         assert resp.status_code == 404
@@ -3891,7 +3897,7 @@ class TestVolumeRoutes:
     async def test_delete_volume_wrong_instance(self, client, user):
         headers = await _auth_headers(client)
         with patch.object(
-            podman,
+            _mock_pod,
             "inspect_volume",
             AsyncMock(return_value={"Labels": {"klangk.instance": "other"}}),
         ):
@@ -3903,7 +3909,7 @@ class TestVolumeRoutes:
     async def test_delete_volume_wrong_user(self, client, user):
         headers = await _auth_headers(client)
         with patch.object(
-            podman,
+            _mock_pod,
             "inspect_volume",
             AsyncMock(return_value=_managed_volume("someone-else")),
         ):
@@ -3917,12 +3923,12 @@ class TestVolumeRoutes:
         headers = await _auth_headers(client)
         with (
             patch.object(
-                podman,
+                _mock_pod,
                 "inspect_volume",
                 AsyncMock(return_value=_managed_volume(user["id"])),
             ),
             patch.object(
-                podman,
+                _mock_pod,
                 "remove_volume",
                 AsyncMock(side_effect=podman.PodmanError(404, "gone")),
             ),
@@ -3934,12 +3940,12 @@ class TestVolumeRoutes:
         headers = await _auth_headers(client)
         with (
             patch.object(
-                podman,
+                _mock_pod,
                 "inspect_volume",
                 AsyncMock(return_value=_managed_volume(user["id"])),
             ),
             patch.object(
-                podman,
+                _mock_pod,
                 "remove_volume",
                 AsyncMock(side_effect=podman.PodmanError(500, "internal")),
             ),
@@ -3951,12 +3957,12 @@ class TestVolumeRoutes:
         headers = await _auth_headers(client)
         with (
             patch.object(
-                podman,
+                _mock_pod,
                 "inspect_volume",
                 AsyncMock(return_value=_managed_volume(user["id"])),
             ),
             patch.object(
-                podman,
+                _mock_pod,
                 "remove_volume",
                 AsyncMock(side_effect=podman.PodmanError(409, "in use")),
             ),
@@ -3994,8 +4000,9 @@ class TestFileRoutes:
         headers = await _auth_headers(client)
         ws_id = await self._create_workspace(client, headers)
         try:
-            with patch(
-                "klangk_backend.files.podman.exec_container",
+            with patch.object(
+                _mock_pod,
+                "exec_container",
                 new_callable=AsyncMock,
                 return_value=(0, "f.txt\tf\t10\t0.0\t0.0\n", ""),
             ):
@@ -4032,8 +4039,9 @@ class TestFileRoutes:
         headers = await _auth_headers(client)
         ws_id = await self._create_workspace(client, headers)
         try:
-            with patch(
-                "klangk_backend.files.podman.exec_container",
+            with patch.object(
+                _mock_pod,
+                "exec_container",
                 new_callable=AsyncMock,
             ) as mock_exec:
                 # Upload: write_file calls exec once (sh -c)
@@ -4067,8 +4075,9 @@ class TestFileRoutes:
         ws_id = await self._create_workspace(client, headers)
         try:
             self._registry.states[ws_id].last_activity = 0.0
-            with patch(
-                "klangk_backend.files.podman.exec_container",
+            with patch.object(
+                _mock_pod,
+                "exec_container",
                 new_callable=AsyncMock,
                 return_value=(0, "", ""),
             ):
@@ -4113,8 +4122,9 @@ class TestFileRoutes:
         headers = await _auth_headers(client)
         ws_id = await self._create_workspace(client, headers)
         try:
-            with patch(
-                "klangk_backend.files.podman.exec_container",
+            with patch.object(
+                _mock_pod,
+                "exec_container",
                 new_callable=AsyncMock,
                 return_value=(1, "", "No such file"),
             ):
@@ -4160,8 +4170,9 @@ class TestFileRoutes:
         headers = await _auth_headers(client)
         ws_id = await self._create_workspace(client, headers)
         try:
-            with patch(
-                "klangk_backend.files.podman.exec_container",
+            with patch.object(
+                _mock_pod,
+                "exec_container",
                 new_callable=AsyncMock,
             ) as mock_exec:
                 mock_exec.side_effect = [
@@ -4181,8 +4192,9 @@ class TestFileRoutes:
         headers = await _auth_headers(client)
         ws_id = await self._create_workspace(client, headers)
         try:
-            with patch(
-                "klangk_backend.files.podman.exec_container",
+            with patch.object(
+                _mock_pod,
+                "exec_container",
                 new_callable=AsyncMock,
                 return_value=(1, "", ""),
             ):
@@ -4216,8 +4228,9 @@ class TestFileRoutes:
         headers = await _auth_headers(client)
         ws_id = await self._create_workspace(client, headers)
         try:
-            with patch(
-                "klangk_backend.files.podman.exec_container",
+            with patch.object(
+                _mock_pod,
+                "exec_container",
                 new_callable=AsyncMock,
             ) as mock_exec:
                 mock_exec.side_effect = [
@@ -4243,8 +4256,9 @@ class TestFileRoutes:
         headers = await _auth_headers(client)
         ws_id = await self._create_workspace(client, headers)
         try:
-            with patch(
-                "klangk_backend.files.podman.exec_container",
+            with patch.object(
+                _mock_pod,
+                "exec_container",
                 new_callable=AsyncMock,
                 return_value=(1, "", ""),
             ):
@@ -4261,8 +4275,9 @@ class TestFileRoutes:
         headers = await _auth_headers(client)
         ws_id = await self._create_workspace(client, headers)
         try:
-            with patch(
-                "klangk_backend.files.podman.exec_container",
+            with patch.object(
+                _mock_pod,
+                "exec_container",
                 new_callable=AsyncMock,
             ) as mock_exec:
                 mock_exec.side_effect = [
@@ -4309,13 +4324,15 @@ class TestFileRoutes:
                 yield b"download me"
 
             with (
-                patch(
-                    "klangk_backend.files.podman.exec_container",
+                patch.object(
+                    _mock_pod,
+                    "exec_container",
                     new_callable=AsyncMock,
                     return_value=(0, "regular file\t11", ""),
                 ),
-                patch(
-                    "klangk_backend.files.podman.exec_container_stream",
+                patch.object(
+                    _mock_pod,
+                    "exec_container_stream",
                     side_effect=fake_stream,
                 ),
             ):
@@ -4339,13 +4356,15 @@ class TestFileRoutes:
                 yield b"data"
 
             with (
-                patch(
-                    "klangk_backend.files.podman.exec_container",
+                patch.object(
+                    _mock_pod,
+                    "exec_container",
                     new_callable=AsyncMock,
                     return_value=(0, "regular file\t4", ""),
                 ),
-                patch(
-                    "klangk_backend.files.podman.exec_container_stream",
+                patch.object(
+                    _mock_pod,
+                    "exec_container_stream",
                     side_effect=fake_stream,
                 ),
             ):
@@ -4371,13 +4390,15 @@ class TestFileRoutes:
                 yield b"tardata"
 
             with (
-                patch(
-                    "klangk_backend.files.podman.exec_container",
+                patch.object(
+                    _mock_pod,
+                    "exec_container",
                     new_callable=AsyncMock,
                     return_value=(0, "directory\t4096", ""),
                 ),
-                patch(
-                    "klangk_backend.files.podman.exec_container_stream",
+                patch.object(
+                    _mock_pod,
+                    "exec_container_stream",
                     side_effect=fake_stream,
                 ),
             ):
@@ -4395,8 +4416,9 @@ class TestFileRoutes:
         headers = await _auth_headers(client)
         ws_id = await self._create_workspace(client, headers)
         try:
-            with patch(
-                "klangk_backend.files.podman.exec_container",
+            with patch.object(
+                _mock_pod,
+                "exec_container",
                 new_callable=AsyncMock,
                 return_value=(1, "", "No such file"),
             ):
@@ -4515,8 +4537,9 @@ class TestFileRoutes:
         headers = await _auth_headers(client)
         ws_id = await self._create_workspace(client, headers)
         try:
-            with patch(
-                "klangk_backend.files.podman.exec_container",
+            with patch.object(
+                _mock_pod,
+                "exec_container",
                 new_callable=AsyncMock,
                 return_value=(1, "", "Read-only file system"),
             ):

--- a/src/backend/tests/test_bringup.py
+++ b/src/backend/tests/test_bringup.py
@@ -9,9 +9,11 @@ with the right args, and that the service-command half is skipped when
 no command is configured.
 """
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from klangk_backend import bringup
+
+_app_state = MagicMock()
 
 
 class TestBringup:
@@ -33,14 +35,15 @@ class TestBringup:
                 "cid",
                 "openclaw gateway",
                 setup_state="complete",
+                app_state=_app_state,
             )
-        mock_home.assert_awaited_once_with("ws-id", "cid")
+        mock_home.assert_awaited_once_with("ws-id", "cid", _app_state.podman)
         mock_service.assert_awaited_once_with(
             "cid",
             "/home/clanker",
             "openclaw gateway",
             setup_state="complete",
-            app_state=None,
+            app_state=_app_state,
         )
 
     async def test_skips_service_command_when_none(self):
@@ -56,8 +59,10 @@ class TestBringup:
                 new_callable=AsyncMock,
             ) as mock_service,
         ):
-            await bringup.bringup("ws-id", "cid", None, "complete")
-        mock_home.assert_awaited_once_with("ws-id", "cid")
+            await bringup.bringup(
+                "ws-id", "cid", None, "complete", app_state=_app_state
+            )
+        mock_home.assert_awaited_once_with("ws-id", "cid", _app_state.podman)
         mock_service.assert_not_awaited()
 
     async def test_skips_service_command_when_empty(self):
@@ -73,7 +78,9 @@ class TestBringup:
                 new_callable=AsyncMock,
             ) as mock_service,
         ):
-            await bringup.bringup("ws-id", "cid", "", "complete")
+            await bringup.bringup(
+                "ws-id", "cid", "", "complete", app_state=_app_state
+            )
         mock_service.assert_not_awaited()
 
     async def test_threads_setup_state_through_predicate(self):
@@ -95,14 +102,18 @@ class TestBringup:
             ) as mock_service,
         ):
             await bringup.bringup(
-                "ws-id", "cid", "openclaw gateway", setup_state="pending"
+                "ws-id",
+                "cid",
+                "openclaw gateway",
+                setup_state="pending",
+                app_state=_app_state,
             )
         mock_service.assert_awaited_once_with(
             "cid",
             "/home/clanker",
             "openclaw gateway",
             setup_state="pending",
-            app_state=None,
+            app_state=_app_state,
         )
 
     async def test_threads_none_setup_state(self):
@@ -118,11 +129,13 @@ class TestBringup:
                 new_callable=AsyncMock,
             ) as mock_service,
         ):
-            await bringup.bringup("ws-id", "cid", "openclaw gateway", None)
+            await bringup.bringup(
+                "ws-id", "cid", "openclaw gateway", None, app_state=_app_state
+            )
         mock_service.assert_awaited_once_with(
             "cid",
             "/home/clanker",
             "openclaw gateway",
             setup_state=None,
-            app_state=None,
+            app_state=_app_state,
         )

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -32,6 +32,12 @@ def _make_app_state(registry=None, sockets=None):
     registry.sockets = sockets
     registry.app_state = app_state
     sockets.app_state = app_state
+    # #1468: container.py reaches the CLI wrappers via self.podman.
+    if registry.podman is None:
+        from klangk_backend.podman import Podman
+
+        registry.podman = Podman(settings)
+        app_state.podman = registry.podman
     return app_state
 
 
@@ -388,11 +394,13 @@ class TestPortsPerWorkspaceCap:
 
 
 @contextmanager
-def patch_podman(**overrides):
+def patch_podman(registry=None, **overrides):
     """Patch the podman.* calls container.py makes.
 
-    Yields a namespace of the AsyncMocks so tests can assert on them.
-    Override any default by passing ``name=AsyncMock(...)``.
+    container.py reaches the CLI wrappers via ``self.registry.podman.X``
+    (#1468); this patches the methods on that instance. Yields a namespace
+    of the AsyncMocks so tests can assert on them. Override any default by
+    passing ``name=AsyncMock(...)``.
     """
     defaults = {
         "inspect_container": AsyncMock(return_value=None),
@@ -408,9 +416,10 @@ def patch_podman(**overrides):
         ),
     }
     mocks = {**defaults, **overrides}
+    target = registry.podman if registry is not None else podman
     with ExitStack() as stack:
         for name, mock in mocks.items():
-            stack.enter_context(patch.object(podman, name, mock))
+            stack.enter_context(patch.object(target, name, mock))
         yield SimpleNamespace(**mocks)
 
 
@@ -443,7 +452,7 @@ class TestStartContainer:
         self.registry = app_state.container_registry
 
     async def test_create_new_container(self, workspace):
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             cid, status = await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -456,7 +465,7 @@ class TestStartContainer:
 
     async def test_sudo_disabled_by_default(self, workspace, monkeypatch):
         monkeypatch.delenv("KLANGK_ALLOW_SUDO", raising=False)
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
@@ -466,7 +475,7 @@ class TestStartContainer:
 
     async def test_sudo_enabled(self, workspace, monkeypatch):
         monkeypatch.setenv("KLANGK_ALLOW_SUDO", "true")
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
@@ -476,7 +485,7 @@ class TestStartContainer:
 
     async def test_sudo_disabled(self, workspace, monkeypatch):
         monkeypatch.setenv("KLANGK_ALLOW_SUDO", "0")
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
@@ -484,7 +493,7 @@ class TestStartContainer:
 
     async def test_sudo_disabled_false(self, workspace, monkeypatch):
         monkeypatch.setenv("KLANGK_ALLOW_SUDO", "false")
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
@@ -493,7 +502,7 @@ class TestStartContainer:
     async def test_sudo_toggled_off_to_on(self, workspace, monkeypatch):
         """Start with sudo disabled, restart with sudo enabled."""
         monkeypatch.setenv("KLANGK_ALLOW_SUDO", "false")
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
@@ -503,7 +512,7 @@ class TestStartContainer:
         self.registry.states.clear()
         await model.update_workspace_container(workspace["id"], None)
         monkeypatch.setenv("KLANGK_ALLOW_SUDO", "true")
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
@@ -512,7 +521,7 @@ class TestStartContainer:
     async def test_sudo_toggled_on_to_off(self, workspace, monkeypatch):
         """Start with sudo enabled, restart with sudo disabled."""
         monkeypatch.setenv("KLANGK_ALLOW_SUDO", "true")
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
@@ -521,7 +530,7 @@ class TestStartContainer:
         self.registry.states.clear()
         await model.update_workspace_container(workspace["id"], None)
         monkeypatch.setenv("KLANGK_ALLOW_SUDO", "false")
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
@@ -532,7 +541,8 @@ class TestStartContainer:
         # record so the next connect can inspect/recreate it rather than
         # orphaning a created-but-unrecorded container.
         with patch_podman(
-            start_container=AsyncMock(side_effect=RuntimeError("boom"))
+            self.registry,
+            start_container=AsyncMock(side_effect=RuntimeError("boom")),
         ):
             with pytest.raises(RuntimeError, match="boom"):
                 await self.registry.start_container(
@@ -554,7 +564,7 @@ class TestStartContainer:
             await release.wait()
 
         with patch_podman(
-            start_container=AsyncMock(side_effect=slow_start)
+            self.registry, start_container=AsyncMock(side_effect=slow_start)
         ) as p:
             task = asyncio.create_task(
                 self.registry.start_container(
@@ -574,7 +584,9 @@ class TestStartContainer:
         assert workspace["id"] in self.registry.states
 
     async def test_reuse_running_container(self, workspace):
-        with patch_podman(inspect_container=_running(True)) as p:
+        with patch_podman(
+            self.registry, inspect_container=_running(True)
+        ) as p:
             cid, status = await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -587,7 +599,9 @@ class TestStartContainer:
         p.create_container.assert_not_awaited()
 
     async def test_recreate_stopped_container(self, workspace):
-        with patch_podman(inspect_container=_running(False)) as p:
+        with patch_podman(
+            self.registry, inspect_container=_running(False)
+        ) as p:
             cid, status = await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -600,7 +614,7 @@ class TestStartContainer:
 
     async def test_missing_container_creates_new(self, workspace):
         # inspect_container returns None (default) → treated as gone.
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             cid, status = await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -622,7 +636,7 @@ class TestStartContainer:
         monkeypatch.setenv("KLANGK_LLM_MODEL", "gemma4:31b")
         monkeypatch.setenv("KLANGK_NGINX_PORT", "8995")
 
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -653,7 +667,7 @@ class TestStartContainer:
         from klangk_backend import auth, terminal
 
         with (
-            patch_podman(),
+            patch_podman(self.registry),
             patch.object(
                 terminal, "set_workspace_token", new_callable=AsyncMock
             ) as mock_set,
@@ -662,13 +676,13 @@ class TestStartContainer:
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
         mock_set.assert_called_once()
-        cid, token = mock_set.call_args.args
+        cid, token, _podman = mock_set.call_args.args
         assert cid == "new-cid"
         decoded_ws = auth.decode_workspace_token(token)
         assert decoded_ws == workspace["id"]
 
     async def test_pull_policy_default_never(self, workspace):
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
@@ -676,7 +690,7 @@ class TestStartContainer:
 
     async def test_pull_policy_from_env(self, workspace, monkeypatch):
         monkeypatch.setenv("KLANGK_IMAGE_PULL_POLICY", "missing")
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
@@ -684,7 +698,7 @@ class TestStartContainer:
 
     async def test_config_mount_added(self, workspace):
         """Container gets read-only config mount when config_path is set."""
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -696,7 +710,7 @@ class TestStartContainer:
 
     async def test_no_config_mount_without_config_path(self, workspace):
         """Container has no config mount when config_path is not set."""
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -707,7 +721,7 @@ class TestStartContainer:
 
     async def test_home_mounted_at_slash_home(self, workspace):
         """Home path is mounted at /home (not /home/klangk)."""
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -717,7 +731,7 @@ class TestStartContainer:
         assert "/tmp/home:/home" in binds
 
     async def test_hosting_env_vars(self, workspace):
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -748,7 +762,7 @@ class TestStartContainer:
         monkeypatch.delenv("KLANGK_HOSTING_PROTO", raising=False)
         monkeypatch.delenv("KLANGK_HOSTING_BASE_PATH", raising=False)
         monkeypatch.setenv("KLANGK_NGINX_PORT", "8996")
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -761,7 +775,7 @@ class TestStartContainer:
 
     async def test_terminal_banner_default_empty(self, workspace):
         """Default terminal banner is empty, so env var is not passed."""
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -773,7 +787,7 @@ class TestStartContainer:
     async def test_terminal_banner_custom(self, workspace, monkeypatch):
         """Deployer can set a terminal banner via env var."""
         monkeypatch.setattr(container, "TERMINAL_BANNER", "Custom warning")
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -790,7 +804,7 @@ class TestStartContainer:
         ssl_dir.mkdir()
         (ssl_dir / "corp-ca.pem").write_text("-----BEGIN CERTIFICATE-----")
         monkeypatch.setenv("KLANGK_SSL_CERT_DIR", str(ssl_dir))
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -809,7 +823,7 @@ class TestStartContainer:
     ):
         """Without KLANGK_SSL_CERT_DIR there is no mount and no trust env."""
         monkeypatch.delenv("KLANGK_SSL_CERT_DIR", raising=False)
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -828,7 +842,7 @@ class TestStartContainer:
         ssl_dir.mkdir()
         (ssl_dir / "notes.txt").write_text("not a cert")
         monkeypatch.setenv("KLANGK_SSL_CERT_DIR", str(ssl_dir))
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -840,7 +854,7 @@ class TestStartContainer:
         assert not any(e.startswith("SSL_CERT_FILE=") for e in env)
 
     async def test_port_allocation_on_create(self, workspace):
-        with patch_podman():
+        with patch_podman(self.registry):
             await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -856,7 +870,7 @@ class TestStartContainer:
         await model.find_and_allocate_ports(
             workspace["id"], 5, container.PORT_RANGE_START
         )
-        with patch_podman():
+        with patch_podman(self.registry):
             await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -869,7 +883,7 @@ class TestStartContainer:
     async def test_cap_clamps_allocation_down(self, workspace, monkeypatch):
         """KLANGK_HOSTED_PORTS_PER_WORKSPACE clamps num_ports down (#1237)."""
         monkeypatch.setenv("KLANGK_HOSTED_PORTS_PER_WORKSPACE", "3")
-        with patch_podman():
+        with patch_podman(self.registry):
             await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -887,7 +901,7 @@ class TestStartContainer:
         await model.find_and_allocate_ports(
             workspace["id"], 5, container.PORT_RANGE_START
         )
-        with patch_podman():
+        with patch_podman(self.registry):
             await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -900,7 +914,7 @@ class TestStartContainer:
     async def test_cap_zero_omits_hosting_env(self, workspace, monkeypatch):
         """cap=0 suppresses KLANGK_PORT_MAPPINGS / KLANGK_HOSTING_* (#1237)."""
         monkeypatch.setenv("KLANGK_HOSTED_PORTS_PER_WORKSPACE", "0")
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -933,7 +947,7 @@ class TestStartContainer:
     ):
         """Sanity: with the default cap, hosting env is injected as before."""
         monkeypatch.delenv("KLANGK_HOSTED_PORTS_PER_WORKSPACE", raising=False)
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -948,7 +962,7 @@ class TestStartContainer:
         assert "KLANGK_HOSTING_BASE_PATH" in env_dict
 
     async def test_container_config_structure(self, workspace):
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -962,7 +976,7 @@ class TestStartContainer:
         assert kwargs["interactive"] is True
 
     async def test_create_container_with_extra_env(self, workspace):
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -988,7 +1002,7 @@ class TestStartContainer:
             },
         )
         monkeypatch.setattr(plugins, "_values", {"PLUGIN_VAR": "plugin-val"})
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
@@ -1031,6 +1045,7 @@ class TestStartContainerPortConflict:
         }
 
         with patch_podman(
+            self.registry,
             start_container=AsyncMock(side_effect=start_side_effect),
             list_containers=AsyncMock(
                 return_value=[{"Id": "stale-cid", "Labels": {}}]
@@ -1059,6 +1074,7 @@ class TestStartContainerPortConflict:
                 raise podman.PodmanError(500, "port is already allocated")
 
         with patch_podman(
+            self.registry,
             start_container=AsyncMock(side_effect=start_side_effect),
             list_containers=AsyncMock(
                 return_value=[{"Id": "new-cid", "Labels": {}}]
@@ -1089,6 +1105,7 @@ class TestStartContainerPortConflict:
                 raise podman.PodmanError(500, "port is already allocated")
 
         with patch_podman(
+            self.registry,
             start_container=AsyncMock(side_effect=start_side_effect),
             list_containers=AsyncMock(
                 return_value=[{"Id": "other-cid", "Labels": {}}]
@@ -1119,6 +1136,7 @@ class TestStartContainerPortConflict:
                 raise podman.PodmanError(500, "port is already allocated")
 
         with patch_podman(
+            self.registry,
             start_container=AsyncMock(side_effect=start_side_effect),
             list_containers=AsyncMock(
                 return_value=[{"Id": "gone-cid", "Labels": {}}]
@@ -1146,6 +1164,7 @@ class TestStartContainerPortConflict:
                 raise podman.PodmanError(500, "port is already allocated")
 
         with patch_podman(
+            self.registry,
             start_container=AsyncMock(side_effect=start_side_effect),
             list_containers=AsyncMock(
                 return_value=[{"Id": "bad-cid", "Labels": {}}]
@@ -1180,6 +1199,7 @@ class TestStartContainerPortConflict:
                 raise podman.PodmanError(500, "port is already allocated")
 
         with patch_podman(
+            self.registry,
             start_container=AsyncMock(side_effect=start_side_effect),
             list_containers=AsyncMock(
                 return_value=[{"Id": "stuck-cid", "Labels": {}}]
@@ -1204,6 +1224,7 @@ class TestStartContainerPortConflict:
     async def test_non_port_conflict_error_raised(self, workspace):
         with (
             patch_podman(
+                self.registry,
                 start_container=AsyncMock(
                     side_effect=podman.PodmanError(500, "some other error")
                 ),
@@ -1400,7 +1421,7 @@ class TestExtraMountsVolumeCreation:
     async def test_auto_creates_named_volume(self, workspace):
         """Named volumes (no leading /) are auto-created with klangk labels."""
         # inspect_volume returns None (default) → volume is created.
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -1418,6 +1439,7 @@ class TestExtraMountsVolumeCreation:
     async def test_existing_volume_not_recreated(self, workspace):
         """Existing volumes owned by this instance and user are used as-is."""
         with patch_podman(
+            self.registry,
             inspect_volume=AsyncMock(
                 return_value={
                     "Name": "existing",
@@ -1426,7 +1448,7 @@ class TestExtraMountsVolumeCreation:
                         "klangk.user-id": "user-123",
                     },
                 }
-            )
+            ),
         ) as p:
             await self.registry.start_container(
                 workspace["id"],
@@ -1440,12 +1462,13 @@ class TestExtraMountsVolumeCreation:
     async def test_foreign_volume_rejected(self, workspace):
         """A named volume owned by another instance is refused."""
         with patch_podman(
+            self.registry,
             inspect_volume=AsyncMock(
                 return_value={
                     "Name": "stolen",
                     "Labels": {"klangk.instance": "someone-else"},
                 }
-            )
+            ),
         ):
             with pytest.raises(ValueError, match="not managed by this"):
                 await self.registry.start_container(
@@ -1458,7 +1481,8 @@ class TestExtraMountsVolumeCreation:
     async def test_unlabelled_volume_rejected(self, workspace):
         """A named volume with no klangk labels is refused."""
         with patch_podman(
-            inspect_volume=AsyncMock(return_value={"Name": "bare"})
+            self.registry,
+            inspect_volume=AsyncMock(return_value={"Name": "bare"}),
         ):
             with pytest.raises(ValueError, match="not managed by this"):
                 await self.registry.start_container(
@@ -1471,6 +1495,7 @@ class TestExtraMountsVolumeCreation:
     async def test_cross_user_volume_rejected(self, workspace):
         """A volume owned by another user is refused."""
         with patch_podman(
+            self.registry,
             inspect_volume=AsyncMock(
                 return_value={
                     "Name": "private",
@@ -1479,7 +1504,7 @@ class TestExtraMountsVolumeCreation:
                         "klangk.user-id": "user-other",
                     },
                 }
-            )
+            ),
         ):
             with pytest.raises(ValueError, match="belongs to another user"):
                 await self.registry.start_container(
@@ -1493,6 +1518,7 @@ class TestExtraMountsVolumeCreation:
     async def test_volume_without_user_label_allowed(self, workspace):
         """A volume with no user-id label (pre-existing) is allowed."""
         with patch_podman(
+            self.registry,
             inspect_volume=AsyncMock(
                 return_value={
                     "Name": "legacy",
@@ -1500,7 +1526,7 @@ class TestExtraMountsVolumeCreation:
                         "klangk.instance": model.get_instance_id(),
                     },
                 }
-            )
+            ),
         ) as p:
             await self.registry.start_container(
                 workspace["id"],
@@ -1516,7 +1542,7 @@ class TestExtraMountsVolumeCreation:
     ):
         """Bind mounts (starting with /) are not treated as volumes."""
         monkeypatch.setattr("os.path.exists", lambda p: True)
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -1528,7 +1554,7 @@ class TestExtraMountsVolumeCreation:
     async def test_mount_with_multiple_colons(self, workspace, monkeypatch):
         """Mount spec with options (host:container:ro) — source starts with /."""
         monkeypatch.setattr("os.path.exists", lambda p: True)
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -1540,7 +1566,7 @@ class TestExtraMountsVolumeCreation:
 
     async def test_volume_mount_with_options(self, workspace):
         """Named volume with options (vol:container:ro) — auto-creates."""
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -1554,7 +1580,7 @@ class TestExtraMountsVolumeCreation:
     ):
         """A mount source containing slashes is a bind mount, not a volume."""
         monkeypatch.setattr("os.path.exists", lambda p: True)
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -1567,9 +1593,10 @@ class TestExtraMountsVolumeCreation:
         """An error creating a named volume propagates to the caller."""
         with (
             patch_podman(
+                self.registry,
                 create_volume=AsyncMock(
                     side_effect=podman.PodmanError(500, "internal error")
-                )
+                ),
             ),
             pytest.raises(podman.PodmanError),
         ):
@@ -1585,7 +1612,7 @@ class TestExtraMountsVolumeCreation:
     ):
         """Mount source with special/binary-like chars is a bind mount."""
         monkeypatch.setattr("os.path.exists", lambda p: True)
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"],
                 "/tmp/ws",
@@ -1597,7 +1624,7 @@ class TestExtraMountsVolumeCreation:
 
     async def test_missing_bind_mount_source_rejected(self, workspace):
         """A bind mount with a non-existent source path is refused."""
-        with patch_podman():
+        with patch_podman(self.registry):
             with pytest.raises(ValueError, match="does not exist"):
                 await self.registry.start_container(
                     workspace["id"],
@@ -1610,9 +1637,10 @@ class TestExtraMountsVolumeCreation:
         """If container creation fails, the error propagates cleanly."""
         with (
             patch_podman(
+                self.registry,
                 create_container=AsyncMock(
                     side_effect=RuntimeError("podman broke")
-                )
+                ),
             ),
             pytest.raises(RuntimeError, match="podman broke"),
         ):
@@ -1634,7 +1662,7 @@ class TestStopContainer:
         self.registry.track_activity("cid", "ws")
         lock = self.registry._get_workspace_lock("ws")
 
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             await self.registry.stop_and_remove_container("cid")
         p.remove_container.assert_awaited_once_with("cid")
         assert "ws" not in self.registry.states
@@ -1657,7 +1685,7 @@ class TestStopContainer:
             self.registry.get_service_session_lock("orphan-b")
             assert len(locks) == 3
 
-            with patch_podman():
+            with patch_podman(self.registry):
                 await self.registry.stop_and_remove_container("alive")
 
             # The stopped container's entry and the orphans are gone; the dict
@@ -1671,9 +1699,10 @@ class TestStopContainer:
         self.registry._get_workspace_lock("ws")
 
         with patch_podman(
+            self.registry,
             remove_container=AsyncMock(
                 side_effect=podman.PodmanError(404, "gone")
-            )
+            ),
         ):
             await self.registry.stop_and_remove_container("cid")
         # Should still remove from tracking
@@ -1689,7 +1718,7 @@ class TestStopContainer:
         self.registry.track_activity("cid", "ws")
         lock = self.registry._get_workspace_lock("ws")
 
-        with patch_podman():
+        with patch_podman(self.registry):
             async with lock:
                 # While the lock is held (as start_container would hold
                 # it), stop must not be able to remove state.
@@ -1724,7 +1753,7 @@ class TestStopContainer:
             lambda wid: revoked.append(wid),
         )
 
-        with patch_podman():
+        with patch_podman(self.registry):
             async with lock:
                 # Start stop; it runs podman (instant), peeks cid-old->ws,
                 # then blocks on the lock we hold.
@@ -1757,7 +1786,7 @@ class TestStopContainer:
         self.registry.track_activity("cid", "ws")
         lock_before = self.registry._get_workspace_lock("ws")
 
-        with patch_podman():
+        with patch_podman(self.registry):
             await self.registry.stop_and_remove_container("cid")
         assert "ws" in self.registry._workspace_locks
         lock_after = self.registry._get_workspace_lock("ws")
@@ -1773,7 +1802,7 @@ class TestRemoveContainer:
         self.registry.track_activity("cid", "ws")
         lock = self.registry._get_workspace_lock("ws")
 
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             await self.registry.stop_and_remove_container("cid")
         p.remove_container.assert_awaited_once_with("cid")
         assert "ws" not in self.registry.states
@@ -1787,9 +1816,10 @@ class TestRemoveContainer:
         self.registry._get_workspace_lock("ws")
 
         with patch_podman(
+            self.registry,
             remove_container=AsyncMock(
                 side_effect=podman.PodmanError(404, "gone")
-            )
+            ),
         ):
             await self.registry.stop_and_remove_container("cid")
         assert "ws" not in self.registry.states
@@ -1808,7 +1838,7 @@ class TestStopUserContainers:
         await model.update_workspace_container(workspace["id"], "cid")
         self.registry.track_activity("cid", workspace["id"])
 
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             await self.registry.stop_user_containers(user["id"])
         p.remove_container.assert_awaited_once_with("cid")
         assert workspace["id"] not in self.registry.states
@@ -1821,14 +1851,14 @@ class TestStopUserContainers:
         old_cb = self.registry.on_workspace_killed
         self.registry.on_workspace_killed = killed_cb
 
-        with patch_podman():
+        with patch_podman(self.registry):
             await self.registry.stop_user_containers(user["id"])
 
         killed_cb.assert_awaited_once_with(workspace["id"])
         self.registry.on_workspace_killed = old_cb
 
     async def test_stop_user_no_containers(self, user):
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             await self.registry.stop_user_containers(user["id"])
         p.remove_container.assert_not_awaited()
 
@@ -1852,7 +1882,8 @@ class TestShutdown:
         self.registry.track_activity("cid", "ws")
 
         with patch_podman(
-            list_containers=AsyncMock(return_value=[{"Id": "cid"}])
+            self.registry,
+            list_containers=AsyncMock(return_value=[{"Id": "cid"}]),
         ) as p:
             await self.registry.shutdown()
         p.remove_container.assert_awaited_once_with("cid")
@@ -1860,7 +1891,8 @@ class TestShutdown:
 
     async def test_shutdown_stops_orphans(self):
         with patch_podman(
-            list_containers=AsyncMock(return_value=[{"Id": "orphan-cid"}])
+            self.registry,
+            list_containers=AsyncMock(return_value=[{"Id": "orphan-cid"}]),
         ) as p:
             await self.registry.shutdown()
         p.remove_container.assert_awaited_once_with("orphan-cid")
@@ -1873,7 +1905,7 @@ class TestShutdown:
         task = asyncio.create_task(fake_cleanup())
         self.registry.cleanup_task = task
 
-        with patch_podman():
+        with patch_podman(self.registry):
             await self.registry.shutdown()
         assert task.cancelled()
         assert self.registry.cleanup_task is None
@@ -1887,28 +1919,30 @@ class TestShutdown:
         reg = _health_registry()
         reg.health.health_task = task
 
-        with patch_podman():
+        with patch_podman(self.registry):
             await reg.shutdown()
         assert task.cancelled()
         assert reg.health.health_task is None
 
     async def test_shutdown_handles_podman_error(self):
         with patch_podman(
+            self.registry,
             list_containers=AsyncMock(
                 side_effect=OSError("podman connection refused")
-            )
+            ),
         ):
             await self.registry.shutdown()
         # Should not raise
 
     async def test_shutdown_no_podman(self):
-        with patch_podman():
+        with patch_podman(self.registry):
             await self.registry.shutdown()
         assert self.registry.cleanup_task is None
 
     async def test_shutdown_orphan_remove_error(self):
         """Orphan container that errors on removal is handled gracefully."""
         with patch_podman(
+            self.registry,
             list_containers=AsyncMock(return_value=[{"Id": "orphan-cid"}]),
             remove_container=AsyncMock(
                 side_effect=podman.PodmanError(500, "remove failed")
@@ -1931,7 +1965,7 @@ class TestCleanupIdleContainers:
             time.time() - container.IDLE_TIMEOUT_SECONDS - 100
         )
 
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             task = asyncio.create_task(self.registry.cleanup_idle_containers())
             # Let the task enter the Event wait, then wake it
             await asyncio.sleep(0.05)
@@ -1955,7 +1989,7 @@ class TestCleanupIdleContainers:
         old_cb = self.registry.on_workspace_killed
         self.registry.on_workspace_killed = killed_cb
 
-        with patch_podman():
+        with patch_podman(self.registry):
             task = asyncio.create_task(self.registry.cleanup_idle_containers())
             await asyncio.sleep(0.05)
             self.registry.get_cleanup_wake().set()
@@ -1979,7 +2013,7 @@ class TestCleanupIdleContainers:
         old_cb = self.registry.on_workspace_killed
         self.registry.on_workspace_killed = killed_cb
 
-        with patch_podman():
+        with patch_podman(self.registry):
             task = asyncio.create_task(self.registry.cleanup_idle_containers())
             await asyncio.sleep(0.05)
             self.registry.get_cleanup_wake().set()
@@ -1997,7 +2031,7 @@ class TestCleanupIdleContainers:
     async def test_active_container_not_stopped(self):
         self.registry.track_activity("cid", "ws-1")
 
-        with patch_podman():
+        with patch_podman(self.registry):
             task = asyncio.create_task(self.registry.cleanup_idle_containers())
             await asyncio.sleep(0.05)
             self.registry.get_cleanup_wake().set()
@@ -2023,7 +2057,7 @@ class TestCleanupIdleContainers:
 
         self.registry.on_idle_stop("ws-1", on_idle)
 
-        with patch_podman():
+        with patch_podman(self.registry):
             task = asyncio.create_task(self.registry.cleanup_idle_containers())
             await asyncio.sleep(0.05)
             self.registry.get_cleanup_wake().set()
@@ -2046,7 +2080,7 @@ class TestCleanupIdleContainers:
 
         self.registry.on_idle_stop("ws-1", bad_callback)
 
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             task = asyncio.create_task(self.registry.cleanup_idle_containers())
             await asyncio.sleep(0.05)
             self.registry.get_cleanup_wake().set()
@@ -2066,7 +2100,7 @@ class TestCleanupIdleContainers:
         self.registry.states["ws-fast"].idle_timeout = 5
 
         try:
-            with patch_podman() as p:
+            with patch_podman(self.registry) as p:
                 # The Event-based wait will timeout after max(2, 5//2)=2s,
                 # then check containers. We cancel after one iteration.
                 task = asyncio.create_task(
@@ -2092,7 +2126,7 @@ class TestCleanupIdleContainers:
         self.registry.states["ws-fast"].idle_timeout = 4
 
         try:
-            with patch_podman() as p:
+            with patch_podman(self.registry) as p:
                 # Patch wait_for to immediately raise TimeoutError (simulates
                 # the event not being set within the interval)
                 async def fast_timeout(coro, timeout):
@@ -2152,16 +2186,17 @@ class TestPrewarmPodman:
         self.registry = app_state.container_registry
 
     async def test_prewarm_creates_and_removes(self):
-        with patch_podman() as p:
+        with patch_podman(self.registry) as p:
             await self.registry.prewarm_podman()
         p.create_container.assert_awaited_once()
         p.remove_container.assert_awaited_once_with("new-cid")
 
     async def test_prewarm_handles_error(self):
         with patch_podman(
+            self.registry,
             create_container=AsyncMock(
                 side_effect=podman.PodmanError(500, "boom")
-            )
+            ),
         ):
             await self.registry.prewarm_podman()
         # Should not raise
@@ -2174,6 +2209,7 @@ class TestAdoptOrphanedContainers:
 
     async def test_removes_orphaned_containers(self):
         with patch_podman(
+            self.registry,
             list_containers=AsyncMock(
                 return_value=[
                     {
@@ -2191,6 +2227,7 @@ class TestAdoptOrphanedContainers:
 
     async def test_removes_orphan_without_labels(self):
         with patch_podman(
+            self.registry,
             list_containers=AsyncMock(
                 return_value=[{"Id": "orphan-x", "Labels": None}]
             ),
@@ -2203,6 +2240,7 @@ class TestAdoptOrphanedContainers:
     async def test_skips_already_tracked(self):
         self.registry.track_activity("tracked-456", "ws-tracked")
         with patch_podman(
+            self.registry,
             list_containers=AsyncMock(return_value=[{"Id": "tracked-456"}]),
             remove_container=AsyncMock(),
         ) as mocks:
@@ -2213,9 +2251,10 @@ class TestAdoptOrphanedContainers:
 
     async def test_podman_error_handled(self):
         with patch_podman(
+            self.registry,
             list_containers=AsyncMock(
                 side_effect=podman.PodmanError(500, "fail")
-            )
+            ),
         ):
             await self.registry.adopt_orphaned_containers()
         # Should not raise
@@ -2223,6 +2262,7 @@ class TestAdoptOrphanedContainers:
     async def test_remove_podman_error_handled(self):
         """When remove_container raises PodmanError, it is logged but not raised."""
         with patch_podman(
+            self.registry,
             list_containers=AsyncMock(
                 return_value=[
                     {
@@ -2380,7 +2420,9 @@ class TestHealthMonitorRunOne:
         st = _health_state()
         exec_mock = AsyncMock(return_value=(0, "", ""))
         with (
-            patch.object(podman, "exec_container", exec_mock),
+            patch.object(
+                monitor._registry.podman, "exec_container", exec_mock
+            ),
             patch.object(
                 model, "get_user_handle", AsyncMock(return_value="owner")
             ),
@@ -2415,7 +2457,7 @@ class TestHealthMonitorRunOne:
         st = _health_state()
         with (
             patch.object(
-                podman,
+                monitor._registry.podman,
                 "exec_container",
                 AsyncMock(return_value=(1, "", "curl: connection refused")),
             ),
@@ -2440,7 +2482,7 @@ class TestHealthMonitorRunOne:
         st = _health_state()
         with (
             patch.object(
-                podman,
+                monitor._registry.podman,
                 "exec_container",
                 AsyncMock(return_value=(2, "all good on stdout", "")),
             ),
@@ -2465,7 +2507,7 @@ class TestHealthMonitorRunOne:
         st = _health_state()
         with (
             patch.object(
-                podman,
+                monitor._registry.podman,
                 "exec_container",
                 AsyncMock(return_value=(127, "", "")),
             ),
@@ -2500,7 +2542,7 @@ class TestHealthMonitorRunOne:
         st = _health_state()
         with (
             patch.object(
-                podman,
+                monitor._registry.podman,
                 "exec_container",
                 AsyncMock(side_effect=podman.PodmanError(500, "boom")),
             ),
@@ -2522,7 +2564,9 @@ class TestHealthMonitorRunOne:
     async def test_no_owner_is_unhealthy_with_reason(self):
         monitor = _health_registry().health
         st = _health_state(owner_id=None)
-        with patch.object(podman, "exec_container") as exec_mock:
+        with patch.object(
+            monitor._registry.podman, "exec_container"
+        ) as exec_mock:
             status, message = await monitor._run_one(st)
         assert status == "unhealthy"
         assert "owner" in message
@@ -2536,7 +2580,9 @@ class TestHealthMonitorRunOne:
             patch.object(
                 model, "get_user_handle", AsyncMock(return_value=None)
             ),
-            patch.object(podman, "exec_container") as exec_mock,
+            patch.object(
+                monitor._registry.podman, "exec_container"
+            ) as exec_mock,
         ):
             status, message = await monitor._run_one(st)
         assert status == "unhealthy"
@@ -2986,7 +3032,7 @@ class TestHealthMonitorDeath:
             reg.sockets.connections[sock] = SimpleNamespace(
                 user={"id": "u1", "email": "a@x"}
             )
-            with patch_podman():
+            with patch_podman(self.registry):
                 task = asyncio.create_task(reg.cleanup_idle_containers())
                 await asyncio.sleep(0.05)
                 reg.get_cleanup_wake().set()

--- a/src/backend/tests/test_files.py
+++ b/src/backend/tests/test_files.py
@@ -1,14 +1,16 @@
 """Tests for files: exec-based list, read, write, delete, rename, path validation."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from klangk_backend import files
 
+_mock_pod = MagicMock()
+
 CID = "test-container-123"
-EXEC = "klangk_backend.files.podman.exec_container"
-EXEC_STREAM = "klangk_backend.files.podman.exec_container_stream"
+EXEC = "exec_container"
+EXEC_STREAM = "exec_container_stream"
 
 
 class TestValidatePath:
@@ -80,10 +82,15 @@ class TestListFiles:
             "a.txt\tf\t100\t1700000000.0\t1700000001.0\n"
             "subdir\td\t4096\t1700000002.0\t1700000003.0\n"
         )
-        with patch(
-            EXEC, new_callable=AsyncMock, return_value=(0, find_output, "")
+        with patch.object(
+            _mock_pod,
+            EXEC,
+            new_callable=AsyncMock,
+            return_value=(0, find_output, ""),
         ) as mock:
-            entries = await files.list_files(CID, "/home/work")
+            entries = await files.list_files(
+                CID, "/home/work", podman=_mock_pod
+            )
 
         mock.assert_called_once()
         assert mock.call_args.kwargs["user"] == "klangk"
@@ -102,24 +109,36 @@ class TestListFiles:
 
     async def test_list_root(self):
         find_output = "home\td\t4096\t1700000000.0\t1700000000.0\n"
-        with patch(
-            EXEC, new_callable=AsyncMock, return_value=(0, find_output, "")
+        with patch.object(
+            _mock_pod,
+            EXEC,
+            new_callable=AsyncMock,
+            return_value=(0, find_output, ""),
         ):
-            entries = await files.list_files(CID, "/")
+            entries = await files.list_files(CID, "/", podman=_mock_pod)
 
         assert entries[0]["path"] == "/home"
 
     async def test_list_empty_dir(self):
-        with patch(EXEC, new_callable=AsyncMock, return_value=(0, "", "")):
-            entries = await files.list_files(CID, "/home/work")
+        with patch.object(
+            _mock_pod, EXEC, new_callable=AsyncMock, return_value=(0, "", "")
+        ):
+            entries = await files.list_files(
+                CID, "/home/work", podman=_mock_pod
+            )
 
         assert entries == []
 
     async def test_list_nonexistent_dir(self):
-        with patch(
-            EXEC, new_callable=AsyncMock, return_value=(1, "", "No such file")
+        with patch.object(
+            _mock_pod,
+            EXEC,
+            new_callable=AsyncMock,
+            return_value=(1, "", "No such file"),
         ):
-            entries = await files.list_files(CID, "/no/such/dir")
+            entries = await files.list_files(
+                CID, "/no/such/dir", podman=_mock_pod
+            )
 
         assert entries == []
 
@@ -129,82 +148,106 @@ class TestListFiles:
             "a.txt\tf\t1\t0.0\t0.0\n"
             "b.txt\tf\t1\t0.0\t0.0\n"
         )
-        with patch(
-            EXEC, new_callable=AsyncMock, return_value=(0, find_output, "")
+        with patch.object(
+            _mock_pod,
+            EXEC,
+            new_callable=AsyncMock,
+            return_value=(0, find_output, ""),
         ):
-            entries = await files.list_files(CID, "/home")
+            entries = await files.list_files(CID, "/home", podman=_mock_pod)
 
         assert [e["name"] for e in entries] == ["a.txt", "b.txt", "c.txt"]
 
     async def test_list_rejects_relative_path(self):
         with pytest.raises(ValueError, match="absolute"):
-            await files.list_files(CID, "work")
+            await files.list_files(CID, "work", podman=_mock_pod)
 
     async def test_list_symlink_to_dir(self):
         """Symlinks to directories show as is_dir=True (find -printf %Y)."""
         find_output = "link\td\t4096\t0.0\t0.0\n"
-        with patch(
-            EXEC, new_callable=AsyncMock, return_value=(0, find_output, "")
+        with patch.object(
+            _mock_pod,
+            EXEC,
+            new_callable=AsyncMock,
+            return_value=(0, find_output, ""),
         ):
-            entries = await files.list_files(CID, "/home")
+            entries = await files.list_files(CID, "/home", podman=_mock_pod)
         assert entries[0]["is_dir"] is True
 
     async def test_list_symlink_to_file(self):
         """Symlinks to files show as is_dir=False (find -printf %Y returns f)."""
         find_output = "link\tf\t100\t0.0\t0.0\n"
-        with patch(
-            EXEC, new_callable=AsyncMock, return_value=(0, find_output, "")
+        with patch.object(
+            _mock_pod,
+            EXEC,
+            new_callable=AsyncMock,
+            return_value=(0, find_output, ""),
         ):
-            entries = await files.list_files(CID, "/home")
+            entries = await files.list_files(CID, "/home", podman=_mock_pod)
         assert entries[0]["is_dir"] is False
 
     async def test_list_broken_symlink(self):
         """Broken symlinks (find -printf %Y returns N) show as is_dir=False."""
         find_output = "broken\tN\t0\t0.0\t0.0\n"
-        with patch(
-            EXEC, new_callable=AsyncMock, return_value=(0, find_output, "")
+        with patch.object(
+            _mock_pod,
+            EXEC,
+            new_callable=AsyncMock,
+            return_value=(0, find_output, ""),
         ):
-            entries = await files.list_files(CID, "/home")
+            entries = await files.list_files(CID, "/home", podman=_mock_pod)
         assert entries[0]["is_dir"] is False
 
     async def test_list_skips_malformed_lines(self):
         find_output = "good.txt\tf\t10\t0.0\t0.0\nbadline\n"
-        with patch(
-            EXEC, new_callable=AsyncMock, return_value=(0, find_output, "")
+        with patch.object(
+            _mock_pod,
+            EXEC,
+            new_callable=AsyncMock,
+            return_value=(0, find_output, ""),
         ):
-            entries = await files.list_files(CID, "/home")
+            entries = await files.list_files(CID, "/home", podman=_mock_pod)
         assert len(entries) == 1
         assert entries[0]["name"] == "good.txt"
 
     async def test_list_handles_bad_size(self):
         find_output = "f.txt\tf\tnotanumber\t0.0\t0.0\n"
-        with patch(
-            EXEC, new_callable=AsyncMock, return_value=(0, find_output, "")
+        with patch.object(
+            _mock_pod,
+            EXEC,
+            new_callable=AsyncMock,
+            return_value=(0, find_output, ""),
         ):
-            entries = await files.list_files(CID, "/home")
+            entries = await files.list_files(CID, "/home", podman=_mock_pod)
         assert entries[0]["size"] is None
 
     async def test_list_handles_bad_mtime(self):
         find_output = "f.txt\tf\t10\tbad\t0.0\n"
-        with patch(
-            EXEC, new_callable=AsyncMock, return_value=(0, find_output, "")
+        with patch.object(
+            _mock_pod,
+            EXEC,
+            new_callable=AsyncMock,
+            return_value=(0, find_output, ""),
         ):
-            entries = await files.list_files(CID, "/home")
+            entries = await files.list_files(CID, "/home", podman=_mock_pod)
         assert entries[0]["mtime"] == 0.0
 
     async def test_list_handles_bad_ctime(self):
         find_output = "f.txt\tf\t10\t0.0\tbad\n"
-        with patch(
-            EXEC, new_callable=AsyncMock, return_value=(0, find_output, "")
+        with patch.object(
+            _mock_pod,
+            EXEC,
+            new_callable=AsyncMock,
+            return_value=(0, find_output, ""),
         ):
-            entries = await files.list_files(CID, "/home")
+            entries = await files.list_files(CID, "/home", podman=_mock_pod)
         assert entries[0]["ctime"] == 0.0
 
     async def test_list_default_path_is_root(self):
-        with patch(
-            EXEC, new_callable=AsyncMock, return_value=(0, "", "")
+        with patch.object(
+            _mock_pod, EXEC, new_callable=AsyncMock, return_value=(0, "", "")
         ) as mock:
-            await files.list_files(CID)
+            await files.list_files(CID, podman=_mock_pod)
 
         cmd = mock.call_args[0][1]
         assert cmd[2] == "/"
@@ -212,58 +255,71 @@ class TestListFiles:
 
 class TestStatPath:
     async def test_stat_file(self):
-        with patch(
+        with patch.object(
+            _mock_pod,
             EXEC,
             new_callable=AsyncMock,
             return_value=(0, "regular file\t12345", ""),
         ):
-            info = await files.stat_path(CID, "/home/work/f.txt")
+            info = await files.stat_path(
+                CID, "/home/work/f.txt", podman=_mock_pod
+            )
 
         assert info == {"is_dir": False, "size": 12345}
 
     async def test_stat_directory(self):
-        with patch(
+        with patch.object(
+            _mock_pod,
             EXEC,
             new_callable=AsyncMock,
             return_value=(0, "directory\t4096", ""),
         ):
-            info = await files.stat_path(CID, "/home/work")
+            info = await files.stat_path(CID, "/home/work", podman=_mock_pod)
 
         assert info == {"is_dir": True, "size": 4096}
 
     async def test_stat_malformed_output(self):
-        with patch(
-            EXEC, new_callable=AsyncMock, return_value=(0, "garbage", "")
+        with patch.object(
+            _mock_pod,
+            EXEC,
+            new_callable=AsyncMock,
+            return_value=(0, "garbage", ""),
         ):
-            info = await files.stat_path(CID, "/home")
+            info = await files.stat_path(CID, "/home", podman=_mock_pod)
         assert info is None
 
     async def test_stat_bad_size(self):
-        with patch(
+        with patch.object(
+            _mock_pod,
             EXEC,
             new_callable=AsyncMock,
             return_value=(0, "regular file\tnotanumber", ""),
         ):
-            info = await files.stat_path(CID, "/f.txt")
+            info = await files.stat_path(CID, "/f.txt", podman=_mock_pod)
         assert info == {"is_dir": False, "size": 0}
 
     async def test_stat_nonexistent(self):
-        with patch(
-            EXEC, new_callable=AsyncMock, return_value=(1, "", "No such file")
+        with patch.object(
+            _mock_pod,
+            EXEC,
+            new_callable=AsyncMock,
+            return_value=(1, "", "No such file"),
         ):
-            info = await files.stat_path(CID, "/nope")
+            info = await files.stat_path(CID, "/nope", podman=_mock_pod)
 
         assert info is None
 
 
 class TestReadFile:
     async def test_read_file(self):
-        with patch(EXEC, new_callable=AsyncMock) as mock:
+        with patch.object(_mock_pod, EXEC, new_callable=AsyncMock) as mock:
             mock.side_effect = [
                 (0, "regular file\t100", ""),  # stat
                 (0, "hello world", ""),  # cat
             ]
-            content = await files.read_file(CID, "/home/work/hello.txt")
+            content = await files.read_file(
+                CID, "/home/work/hello.txt", podman=_mock_pod
+            )
 
         assert content == "hello world"
         # cat should use -- separator
@@ -271,40 +327,49 @@ class TestReadFile:
         assert "--" in cat_cmd
 
     async def test_read_nonexistent(self):
-        with patch(
-            EXEC, new_callable=AsyncMock, return_value=(1, "", "No such file")
+        with patch.object(
+            _mock_pod,
+            EXEC,
+            new_callable=AsyncMock,
+            return_value=(1, "", "No such file"),
         ):
-            content = await files.read_file(CID, "/nope.txt")
+            content = await files.read_file(CID, "/nope.txt", podman=_mock_pod)
 
         assert content is None
 
     async def test_read_too_large(self):
-        with patch(
+        with patch.object(
+            _mock_pod,
             EXEC,
             new_callable=AsyncMock,
             return_value=(0, "regular file\t2000000", ""),
         ):
-            content = await files.read_file(CID, "/big.bin")
+            content = await files.read_file(CID, "/big.bin", podman=_mock_pod)
 
         assert content is None
 
     async def test_read_directory_returns_none(self):
-        with patch(
+        with patch.object(
+            _mock_pod,
             EXEC,
             new_callable=AsyncMock,
             return_value=(0, "directory\t4096", ""),
         ):
-            content = await files.read_file(CID, "/home/work")
+            content = await files.read_file(
+                CID, "/home/work", podman=_mock_pod
+            )
 
         assert content is None
 
     async def test_read_cat_fails(self):
-        with patch(EXEC, new_callable=AsyncMock) as mock:
+        with patch.object(_mock_pod, EXEC, new_callable=AsyncMock) as mock:
             mock.side_effect = [
                 (0, "regular file\t100", ""),  # stat ok
                 (1, "", "Permission denied"),  # cat fails
             ]
-            content = await files.read_file(CID, "/home/noperm.txt")
+            content = await files.read_file(
+                CID, "/home/noperm.txt", podman=_mock_pod
+            )
 
         assert content is None
 
@@ -315,9 +380,13 @@ class TestStreamFile:
             yield b"chunk1"
             yield b"chunk2"
 
-        with patch(EXEC_STREAM, side_effect=fake_stream) as mock:
+        with patch.object(
+            _mock_pod, EXEC_STREAM, side_effect=fake_stream
+        ) as mock:
             chunks = []
-            async for chunk in files.stream_file(CID, "/home/work/image.png"):
+            async for chunk in files.stream_file(
+                CID, "/home/work/image.png", podman=_mock_pod
+            ):
                 chunks.append(chunk)
 
         assert chunks == [b"chunk1", b"chunk2"]
@@ -329,7 +398,9 @@ class TestStreamFile:
 
     async def test_stream_file_rejects_relative(self):
         with pytest.raises(ValueError, match="absolute"):
-            async for _ in files.stream_file(CID, "relative.txt"):
+            async for _ in files.stream_file(
+                CID, "relative.txt", podman=_mock_pod
+            ):
                 pass  # pragma: no cover
 
 
@@ -339,9 +410,13 @@ class TestStreamDirTar:
             yield b"\x1f\x8b"
             yield b"tardata"
 
-        with patch(EXEC_STREAM, side_effect=fake_stream) as mock:
+        with patch.object(
+            _mock_pod, EXEC_STREAM, side_effect=fake_stream
+        ) as mock:
             chunks = []
-            async for chunk in files.stream_dir_tar(CID, "/home/work/mydir"):
+            async for chunk in files.stream_dir_tar(
+                CID, "/home/work/mydir", podman=_mock_pod
+            ):
                 chunks.append(chunk)
 
         assert chunks == [b"\x1f\x8b", b"tardata"]
@@ -352,18 +427,20 @@ class TestStreamDirTar:
 
     async def test_stream_dir_tar_rejects_relative(self):
         with pytest.raises(ValueError, match="absolute"):
-            async for _ in files.stream_dir_tar(CID, "nope"):
+            async for _ in files.stream_dir_tar(CID, "nope", podman=_mock_pod):
                 pass  # pragma: no cover
 
 
 class TestDeletePath:
     async def test_delete_file(self):
-        with patch(EXEC, new_callable=AsyncMock) as mock:
+        with patch.object(_mock_pod, EXEC, new_callable=AsyncMock) as mock:
             mock.side_effect = [
                 (0, "", ""),  # test -e
                 (0, "", ""),  # rm -rf
             ]
-            result = await files.delete_path(CID, "/home/work/doomed.txt")
+            result = await files.delete_path(
+                CID, "/home/work/doomed.txt", podman=_mock_pod
+            )
 
         assert result == "/home/work/doomed.txt"
         rm_cmd = mock.call_args_list[1][0][1]
@@ -371,23 +448,27 @@ class TestDeletePath:
         assert mock.call_args_list[1].kwargs["user"] == "klangk"
 
     async def test_delete_nonexistent(self):
-        with patch(EXEC, new_callable=AsyncMock, return_value=(1, "", "")):
+        with patch.object(
+            _mock_pod, EXEC, new_callable=AsyncMock, return_value=(1, "", "")
+        ):
             with pytest.raises(FileNotFoundError):
-                await files.delete_path(CID, "/nope.txt")
+                await files.delete_path(CID, "/nope.txt", podman=_mock_pod)
 
     async def test_delete_rm_fails(self):
-        with patch(EXEC, new_callable=AsyncMock) as mock:
+        with patch.object(_mock_pod, EXEC, new_callable=AsyncMock) as mock:
             mock.side_effect = [
                 (0, "", ""),  # test -e ok
                 (1, "", "Permission denied"),  # rm fails
             ]
             with pytest.raises(OSError, match="Permission denied"):
-                await files.delete_path(CID, "/usr/bin/important")
+                await files.delete_path(
+                    CID, "/usr/bin/important", podman=_mock_pod
+                )
 
 
 class TestRenamePath:
     async def test_rename(self):
-        with patch(EXEC, new_callable=AsyncMock) as mock:
+        with patch.object(_mock_pod, EXEC, new_callable=AsyncMock) as mock:
             mock.side_effect = [
                 (0, "", ""),  # test -e old
                 (1, "", ""),  # test -e new (doesn't exist — good)
@@ -395,7 +476,10 @@ class TestRenamePath:
                 (0, "", ""),  # mv
             ]
             result = await files.rename_path(
-                CID, "/home/work/old.txt", "/home/work/new.txt"
+                CID,
+                "/home/work/old.txt",
+                "/home/work/new.txt",
+                podman=_mock_pod,
             )
 
         assert result == "/home/work/new.txt"
@@ -403,21 +487,27 @@ class TestRenamePath:
         assert "--" in mv_cmd
 
     async def test_rename_source_missing(self):
-        with patch(EXEC, new_callable=AsyncMock, return_value=(1, "", "")):
+        with patch.object(
+            _mock_pod, EXEC, new_callable=AsyncMock, return_value=(1, "", "")
+        ):
             with pytest.raises(FileNotFoundError):
-                await files.rename_path(CID, "/nope.txt", "/new.txt")
+                await files.rename_path(
+                    CID, "/nope.txt", "/new.txt", podman=_mock_pod
+                )
 
     async def test_rename_dest_exists(self):
-        with patch(EXEC, new_callable=AsyncMock) as mock:
+        with patch.object(_mock_pod, EXEC, new_callable=AsyncMock) as mock:
             mock.side_effect = [
                 (0, "", ""),  # test -e old — exists
                 (0, "", ""),  # test -e new — also exists
             ]
             with pytest.raises(FileExistsError):
-                await files.rename_path(CID, "/old.txt", "/existing.txt")
+                await files.rename_path(
+                    CID, "/old.txt", "/existing.txt", podman=_mock_pod
+                )
 
     async def test_rename_mv_fails(self):
-        with patch(EXEC, new_callable=AsyncMock) as mock:
+        with patch.object(_mock_pod, EXEC, new_callable=AsyncMock) as mock:
             mock.side_effect = [
                 (0, "", ""),  # test -e old
                 (1, "", ""),  # test -e new (doesn't exist)
@@ -425,15 +515,19 @@ class TestRenamePath:
                 (1, "", "Cross-device link"),  # mv fails
             ]
             with pytest.raises(OSError, match="Cross-device"):
-                await files.rename_path(CID, "/old.txt", "/mnt/new.txt")
+                await files.rename_path(
+                    CID, "/old.txt", "/mnt/new.txt", podman=_mock_pod
+                )
 
 
 class TestWriteFile:
     async def test_write(self):
-        with patch(
-            EXEC, new_callable=AsyncMock, return_value=(0, "", "")
+        with patch.object(
+            _mock_pod, EXEC, new_callable=AsyncMock, return_value=(0, "", "")
         ) as mock:
-            result = await files.write_file(CID, "/home/work/out.txt", b"data")
+            result = await files.write_file(
+                CID, "/home/work/out.txt", b"data", podman=_mock_pod
+            )
 
         assert result == "/home/work/out.txt"
         assert mock.call_args.kwargs["user"] == "klangk"
@@ -446,73 +540,84 @@ class TestWriteFile:
         assert cmd[-1] == "/home/work/out.txt"  # passed as positional arg
 
     async def test_write_fails(self):
-        with patch(
-            EXEC, new_callable=AsyncMock, return_value=(1, "", "Read-only")
+        with patch.object(
+            _mock_pod,
+            EXEC,
+            new_callable=AsyncMock,
+            return_value=(1, "", "Read-only"),
         ):
             with pytest.raises(OSError, match="Read-only"):
-                await files.write_file(CID, "/usr/bin/evil", b"bad")
+                await files.write_file(
+                    CID, "/usr/bin/evil", b"bad", podman=_mock_pod
+                )
 
     async def test_write_rejects_relative_path(self):
         with pytest.raises(ValueError, match="absolute"):
-            await files.write_file(CID, "relative.txt", b"data")
+            await files.write_file(
+                CID, "relative.txt", b"data", podman=_mock_pod
+            )
 
     async def test_write_rejects_null_byte(self):
         with pytest.raises(ValueError, match="Null byte"):
-            await files.write_file(CID, "/home/\x00evil", b"data")
+            await files.write_file(
+                CID, "/home/\x00evil", b"data", podman=_mock_pod
+            )
 
 
 class TestExecUser:
     """All operations must run as the klangk user."""
 
     async def test_list_runs_as_klangk(self):
-        with patch(
-            EXEC, new_callable=AsyncMock, return_value=(0, "", "")
+        with patch.object(
+            _mock_pod, EXEC, new_callable=AsyncMock, return_value=(0, "", "")
         ) as mock:
-            await files.list_files(CID, "/")
+            await files.list_files(CID, "/", podman=_mock_pod)
         assert mock.call_args.kwargs["user"] == "klangk"
 
     async def test_read_runs_as_klangk(self):
-        with patch(EXEC, new_callable=AsyncMock) as mock:
+        with patch.object(_mock_pod, EXEC, new_callable=AsyncMock) as mock:
             mock.side_effect = [
                 (0, "regular file\t10", ""),
                 (0, "content", ""),
             ]
-            await files.read_file(CID, "/f.txt")
+            await files.read_file(CID, "/f.txt", podman=_mock_pod)
         for call in mock.call_args_list:
             assert call.kwargs["user"] == "klangk"
 
     async def test_delete_runs_as_klangk(self):
-        with patch(EXEC, new_callable=AsyncMock) as mock:
+        with patch.object(_mock_pod, EXEC, new_callable=AsyncMock) as mock:
             mock.side_effect = [(0, "", ""), (0, "", "")]
-            await files.delete_path(CID, "/f.txt")
+            await files.delete_path(CID, "/f.txt", podman=_mock_pod)
         for call in mock.call_args_list:
             assert call.kwargs["user"] == "klangk"
 
     async def test_rename_runs_as_klangk(self):
-        with patch(EXEC, new_callable=AsyncMock) as mock:
+        with patch.object(_mock_pod, EXEC, new_callable=AsyncMock) as mock:
             mock.side_effect = [
                 (0, "", ""),
                 (1, "", ""),
                 (0, "", ""),
                 (0, "", ""),
             ]
-            await files.rename_path(CID, "/a.txt", "/b.txt")
+            await files.rename_path(CID, "/a.txt", "/b.txt", podman=_mock_pod)
         for call in mock.call_args_list:
             assert call.kwargs["user"] == "klangk"
 
     async def test_write_runs_as_klangk(self):
-        with patch(
-            EXEC, new_callable=AsyncMock, return_value=(0, "", "")
+        with patch.object(
+            _mock_pod, EXEC, new_callable=AsyncMock, return_value=(0, "", "")
         ) as mock:
-            await files.write_file(CID, "/f.txt", b"x")
+            await files.write_file(CID, "/f.txt", b"x", podman=_mock_pod)
         assert mock.call_args.kwargs["user"] == "klangk"
 
     async def test_stream_file_runs_as_klangk(self):
         async def fake_stream(*a, **kw):
             yield b"x"
 
-        with patch(EXEC_STREAM, side_effect=fake_stream) as mock:
-            async for _ in files.stream_file(CID, "/f.bin"):
+        with patch.object(
+            _mock_pod, EXEC_STREAM, side_effect=fake_stream
+        ) as mock:
+            async for _ in files.stream_file(CID, "/f.bin", podman=_mock_pod):
                 pass
         assert mock.call_args.kwargs["user"] == "klangk"
 
@@ -520,7 +625,9 @@ class TestExecUser:
         async def fake_stream(*a, **kw):
             yield b"x"
 
-        with patch(EXEC_STREAM, side_effect=fake_stream) as mock:
-            async for _ in files.stream_dir_tar(CID, "/dir"):
+        with patch.object(
+            _mock_pod, EXEC_STREAM, side_effect=fake_stream
+        ) as mock:
+            async for _ in files.stream_dir_tar(CID, "/dir", podman=_mock_pod):
                 pass
         assert mock.call_args.kwargs["user"] == "klangk"

--- a/src/backend/tests/test_main.py
+++ b/src/backend/tests/test_main.py
@@ -33,6 +33,11 @@ def _make_app_state(settings=None):
     registry.sockets = sockets
     registry.app_state = app_state
     sockets.app_state = app_state
+    # #1468: container.py / agent.py reach the CLI wrappers via self.podman.
+    from klangk_backend.podman import Podman
+
+    registry.podman = Podman(settings)
+    app_state.podman = registry.podman
     return app_state
 
 

--- a/src/backend/tests/test_podman.py
+++ b/src/backend/tests/test_podman.py
@@ -7,6 +7,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from klangk_backend import podman
+from klangk_backend.settings import KlangkSettings
+
+# Instance whose methods the tests exercise (#1468: the ~20 free
+# functions became Podman methods; classify/PodmanError stay module-level).
+_p = podman.Podman(KlangkSettings(env={}))
 
 EXEC = "klangk_backend.podman.asyncio.create_subprocess_exec"
 
@@ -82,7 +87,7 @@ class TestClassify:
 class TestRun:
     async def test_success(self):
         with patch(EXEC, _exec(("hello\n", "", 0))) as m:
-            rc, out, err = await podman.run(["version"])
+            rc, out, err = await _p.run(["version"])
         assert (rc, out, err) == (0, "hello\n", "")
         assert m.call_args.args[0] == "podman"
         assert m.call_args.kwargs["stdin"] is None
@@ -90,33 +95,33 @@ class TestRun:
     async def test_check_raises_with_classified_status(self):
         with patch(EXEC, _exec(("", "no such container x", 1))):
             with pytest.raises(podman.PodmanError) as exc:
-                await podman.run(["start", "x"])
+                await _p.run(["start", "x"])
         assert exc.value.status == 404
         assert "no such container" in exc.value.message
 
     async def test_check_raises_empty_stderr_fallback(self):
         with patch(EXEC, _exec(("", "", 5))):
             with pytest.raises(podman.PodmanError) as exc:
-                await podman.run(["boom"])
+                await _p.run(["boom"])
         assert exc.value.status == 500
         assert exc.value.message == "podman boom"
 
     async def test_no_check_returns_nonzero(self):
         with patch(EXEC, _exec(("", "bad", 2))):
-            rc, out, err = await podman.run(["x"], check=False)
+            rc, out, err = await _p.run(["x"], check=False)
         assert rc == 2
 
     async def test_stdin_data_uses_pipe(self):
         proc = _procs(("", "", 0))[0]
         with patch(EXEC, AsyncMock(return_value=proc)) as m:
-            await podman.run(["x"], stdin_data=b"payload")
+            await _p.run(["x"], stdin_data=b"payload")
         assert m.call_args.kwargs["stdin"] is not None
         proc.stdin.write.assert_called_once_with(b"payload")
         proc.stdin.close.assert_called_once()
 
     async def test_returncode_none_treated_as_zero(self):
         with patch(EXEC, _exec(("ok", "", None))):
-            rc, _out, _err = await podman.run(["x"], check=False)
+            rc, _out, _err = await _p.run(["x"], check=False)
         assert rc == 0
 
     async def test_timeout_kills_process(self):
@@ -136,7 +141,7 @@ class TestRun:
         proc.kill = MagicMock(side_effect=do_kill)
 
         with patch(EXEC, AsyncMock(return_value=proc)):
-            rc, _out, err = await podman.run(
+            rc, _out, err = await _p.run(
                 ["rm", "-f", "cid"], check=False, timeout=0.1
             )
         assert rc == -1
@@ -161,7 +166,7 @@ class TestRun:
 
         with patch(EXEC, AsyncMock(return_value=proc)):
             with pytest.raises(podman.PodmanError) as exc:
-                await podman.run(["rm", "-f", "cid"], timeout=0.1)
+                await _p.run(["rm", "-f", "cid"], timeout=0.1)
         assert exc.value.status == 500
         assert "timed out" in exc.value.message
 
@@ -172,23 +177,23 @@ class TestRun:
 class TestInspectContainer:
     async def test_missing_returns_none(self):
         with patch(EXEC, _exec(("", "no such container", 1))):
-            assert await podman.inspect_container("c") is None
+            assert await _p.inspect_container("c") is None
 
     async def test_found_returns_first(self):
         payload = json.dumps([{"State": {"Running": True}}])
         with patch(EXEC, _exec((payload, "", 0))):
-            info = await podman.inspect_container("c")
+            info = await _p.inspect_container("c")
         assert info["State"]["Running"] is True
 
     async def test_empty_list_returns_none(self):
         with patch(EXEC, _exec(("[]", "", 0))):
-            assert await podman.inspect_container("c") is None
+            assert await _p.inspect_container("c") is None
 
 
 class TestCreateContainer:
     async def test_minimal(self):
         with patch(EXEC, _exec(("abc123\n", "", 0))) as m:
-            cid = await podman.create_container("n", "img", replace=False)
+            cid = await _p.create_container("n", "img", replace=False)
         assert cid == "abc123"
         assert _args(m) == [
             "create",
@@ -200,7 +205,7 @@ class TestCreateContainer:
 
     async def test_all_flags(self):
         with patch(EXEC, _exec(("id\n", "", 0))) as m:
-            await podman.create_container(
+            await _p.create_container(
                 "n",
                 "img",
                 labels={"a": "1"},
@@ -243,7 +248,7 @@ class TestCreateContainer:
 
     async def test_pull_policy_override(self):
         with patch(EXEC, _exec(("id\n", "", 0))) as m:
-            await podman.create_container(
+            await _p.create_container(
                 "n", "img", pull="missing", replace=False
             )
         args = _args(m)
@@ -254,25 +259,25 @@ class TestCreateContainer:
 class TestStartContainer:
     async def test_start(self):
         with patch(EXEC, _exec(("", "", 0))) as m:
-            await podman.start_container("cid")
+            await _p.start_container("cid")
         assert _args(m) == ["start", "cid"]
 
 
 class TestExecContainer:
     async def test_basic(self):
         with patch(EXEC, _exec(("out", "", 0))) as m:
-            rc, out, err = await podman.exec_container("cid", ["ls", "/"])
+            rc, out, err = await _p.exec_container("cid", ["ls", "/"])
         assert _args(m) == ["exec", "cid", "ls", "/"]
         assert (rc, out, err) == (0, "out", "")
 
     async def test_with_user(self):
         with patch(EXEC, _exec(("", "", 0))) as m:
-            await podman.exec_container("cid", ["id"], user="root")
+            await _p.exec_container("cid", ["id"], user="root")
         assert _args(m) == ["exec", "-u", "root", "cid", "id"]
 
     async def test_nonzero_returned(self):
         with patch(EXEC, _exec(("", "fail", 1))):
-            rc, _out, err = await podman.exec_container("cid", ["false"])
+            rc, _out, err = await _p.exec_container("cid", ["false"])
         assert rc == 1
         assert err == "fail"
 
@@ -280,7 +285,7 @@ class TestExecContainer:
 class TestWaitForContainerReady:
     async def test_returns_when_sentinel_appears(self):
         with patch(EXEC, _exec(("", "", 0))) as m:
-            result = await podman.wait_for_container_ready("cid")
+            result = await _p.wait_for_container_ready("cid")
         assert result is None
         # One podman exec spinning on the sentinel until it exists.
         assert _args(m) == [
@@ -296,7 +301,7 @@ class TestWaitForContainerReady:
         # appeared, so wait_for_container_ready raises PodmanError(500).
         with patch(EXEC, _exec(("", "timed out", -1))):
             with pytest.raises(podman.PodmanError) as exc:
-                await podman.wait_for_container_ready("cid", timeout=0.5)
+                await _p.wait_for_container_ready("cid", timeout=0.5)
         assert exc.value.status == 500
         assert "cid" in exc.value.message
         assert "0.5s" in exc.value.message
@@ -305,7 +310,7 @@ class TestWaitForContainerReady:
 class TestExecContainerWithStdin:
     async def test_stdin_data_adds_interactive_flag(self):
         with patch(EXEC, _exec(("ok", "", 0))) as m:
-            rc, out, err = await podman.exec_container(
+            rc, out, err = await _p.exec_container(
                 "cid", ["cat"], stdin_data=b"hello"
             )
         assert _args(m) == ["exec", "-i", "cid", "cat"]
@@ -313,11 +318,11 @@ class TestExecContainerWithStdin:
 
     async def test_timeout_passed(self):
         with patch(EXEC, _exec(("", "", 0))):
-            await podman.exec_container("cid", ["ls"], timeout=60.0)
+            await _p.exec_container("cid", ["ls"], timeout=60.0)
 
     async def test_extra_env_adds_flags_before_container(self):
         with patch(EXEC, _exec(("", "", 0))) as m:
-            await podman.exec_container(
+            await _p.exec_container(
                 "cid",
                 ["env"],
                 extra_env={"HOME": "/home/x", "FOO": "bar"},
@@ -335,7 +340,7 @@ class TestExecContainerWithStdin:
 
     async def test_extra_env_with_user_and_stdin(self):
         with patch(EXEC, _exec(("", "", 0))) as m:
-            await podman.exec_container(
+            await _p.exec_container(
                 "cid",
                 ["sh"],
                 user="root",
@@ -357,7 +362,7 @@ class TestExecContainerWithStdin:
 class TestExecContainerBytes:
     async def test_returns_raw_bytes(self):
         with patch(EXEC, _exec(("binary\x00data", "", 0))) as m:
-            rc, out, err = await podman.exec_container_bytes(
+            rc, out, err = await _p.exec_container_bytes(
                 "cid", ["cat", "/bin/x"]
             )
         assert _args(m) == ["exec", "cid", "cat", "/bin/x"]
@@ -367,14 +372,12 @@ class TestExecContainerBytes:
 
     async def test_with_user(self):
         with patch(EXEC, _exec(("", "", 0))) as m:
-            await podman.exec_container_bytes(
-                "cid", ["cat", "/f"], user="klangk"
-            )
+            await _p.exec_container_bytes("cid", ["cat", "/f"], user="klangk")
         assert _args(m) == ["exec", "-u", "klangk", "cid", "cat", "/f"]
 
     async def test_extra_env_adds_flags_before_container(self):
         with patch(EXEC, _exec(("", "", 0))) as m:
-            await podman.exec_container_bytes(
+            await _p.exec_container_bytes(
                 "cid", ["env"], extra_env={"HOME": "/home/x"}
             )
         assert _args(m) == [
@@ -387,7 +390,7 @@ class TestExecContainerBytes:
 
     async def test_nonzero_returned(self):
         with patch(EXEC, _exec(("", "err", 1))):
-            rc, out, err = await podman.exec_container_bytes("cid", ["false"])
+            rc, out, err = await _p.exec_container_bytes("cid", ["false"])
         assert rc == 1
         assert out == b""
         assert err == "err"
@@ -410,7 +413,7 @@ class TestExecContainerBytes:
             return mock_proc
 
         with patch(EXEC, AsyncMock(side_effect=side_effect)):
-            rc, out, err = await podman.exec_container_bytes(
+            rc, out, err = await _p.exec_container_bytes(
                 "cid", ["sleep", "999"], timeout=0.001
             )
         assert rc == -1
@@ -418,7 +421,7 @@ class TestExecContainerBytes:
 
     async def test_stdin_data(self):
         with patch(EXEC, _exec(("ok", "", 0))) as m:
-            await podman.exec_container("cid", ["cat"], stdin_data=b"input")
+            await _p.exec_container("cid", ["cat"], stdin_data=b"input")
         # The -i flag is added for stdin
         assert _args(m) == ["exec", "-i", "cid", "cat"]
 
@@ -428,7 +431,7 @@ class TestRunRaw:
 
     async def test_stdin_data(self):
         with patch(EXEC, _exec(("out", "", 0))):
-            rc, out, err = await podman.run_raw(
+            rc, out, err = await _p.run_raw(
                 ["exec", "cid", "cat"], stdin_data=b"hello"
             )
         assert rc == 0
@@ -437,7 +440,7 @@ class TestRunRaw:
     async def test_check_raises_on_error(self):
         with patch(EXEC, _exec(("", "fail", 1))):
             with pytest.raises(podman.PodmanError):
-                await podman.run_raw(["exec", "cid", "false"], check=True)
+                await _p.run_raw(["exec", "cid", "false"], check=True)
 
 
 class TestExecContainerStream:
@@ -452,7 +455,7 @@ class TestExecContainerStream:
 
         with patch(EXEC, AsyncMock(return_value=mock_proc)):
             result = []
-            async for chunk in podman.exec_container_stream(
+            async for chunk in _p.exec_container_stream(
                 "cid", ["tar", "-czf", "-"]
             ):
                 result.append(chunk)
@@ -466,7 +469,7 @@ class TestExecContainerStream:
         mock_proc.wait = AsyncMock(return_value=0)
 
         with patch(EXEC, AsyncMock(return_value=mock_proc)) as m:
-            async for _ in podman.exec_container_stream(
+            async for _ in _p.exec_container_stream(
                 "cid", ["cat", "/f"], user="klangk"
             ):
                 pass
@@ -487,7 +490,7 @@ class TestExecContainerStream:
         mock_proc.wait = AsyncMock(return_value=0)
 
         with patch(EXEC, AsyncMock(return_value=mock_proc)) as m:
-            async for _ in podman.exec_container_stream(
+            async for _ in _p.exec_container_stream(
                 "cid", ["env"], extra_env={"HOME": "/home/x"}
             ):
                 pass
@@ -510,7 +513,7 @@ class TestExecContainerStream:
         mock_proc.wait = AsyncMock(return_value=-9)
 
         with patch(EXEC, AsyncMock(return_value=mock_proc)):
-            gen = podman.exec_container_stream("cid", ["cat"])
+            gen = _p.exec_container_stream("cid", ["cat"])
             await gen.__anext__()
             await gen.aclose()
         mock_proc.kill.assert_called_once()
@@ -524,7 +527,7 @@ class TestExecContainerStream:
 
         with patch(EXEC, AsyncMock(return_value=mock_proc)):
             with pytest.raises(podman.PodmanError):
-                async for _ in podman.exec_container_stream("cid", ["cat"]):
+                async for _ in _p.exec_container_stream("cid", ["cat"]):
                     pass
 
     async def test_nonzero_exit_with_output_does_not_raise(self):
@@ -536,7 +539,7 @@ class TestExecContainerStream:
 
         with patch(EXEC, AsyncMock(return_value=mock_proc)):
             chunks = []
-            async for chunk in podman.exec_container_stream("cid", ["tar"]):
+            async for chunk in _p.exec_container_stream("cid", ["tar"]):
                 chunks.append(chunk)
         assert chunks == [b"partial"]
 
@@ -544,28 +547,28 @@ class TestExecContainerStream:
 class TestRemoveContainer:
     async def test_force_default(self):
         with patch(EXEC, _exec(("", "", 0))) as m:
-            await podman.remove_container("cid")
+            await _p.remove_container("cid")
         assert _args(m) == ["rm", "-f", "cid"]
 
     async def test_no_force(self):
         with patch(EXEC, _exec(("", "", 0))) as m:
-            await podman.remove_container("cid", force=False)
+            await _p.remove_container("cid", force=False)
         assert _args(m) == ["rm", "cid"]
 
     async def test_missing_is_ignored(self):
         with patch(EXEC, _exec(("", "no such container", 1))):
-            await podman.remove_container("cid")  # no raise
+            await _p.remove_container("cid")  # no raise
 
     async def test_other_error_raises(self):
         with patch(EXEC, _exec(("", "in use", 1))):
             with pytest.raises(podman.PodmanError) as exc:
-                await podman.remove_container("cid")
+                await _p.remove_container("cid")
         assert exc.value.status == 409
 
     async def test_other_error_empty_stderr_fallback(self):
         with patch(EXEC, _exec(("", "", 1))):
             with pytest.raises(podman.PodmanError) as exc:
-                await podman.remove_container("cid")
+                await _p.remove_container("cid")
         assert exc.value.message == "podman rm"
 
 
@@ -573,7 +576,7 @@ class TestListContainers:
     async def test_parses_json(self):
         payload = json.dumps([{"Id": "a", "Labels": {"k": "v"}}])
         with patch(EXEC, _exec((payload, "", 0))) as m:
-            result = await podman.list_containers("k=v")
+            result = await _p.list_containers("k=v")
         assert result[0]["Id"] == "a"
         assert _args(m) == [
             "ps",
@@ -586,7 +589,7 @@ class TestListContainers:
 
     async def test_empty_output(self):
         with patch(EXEC, _exec(("  \n", "", 0))):
-            assert await podman.list_containers("k=v") == []
+            assert await _p.list_containers("k=v") == []
 
 
 # --- volumes ---
@@ -595,31 +598,31 @@ class TestListContainers:
 class TestInspectVolume:
     async def test_missing(self):
         with patch(EXEC, _exec(("", "no such volume", 1))):
-            assert await podman.inspect_volume("v") is None
+            assert await _p.inspect_volume("v") is None
 
     async def test_found(self):
         payload = json.dumps([{"Name": "v", "CreatedAt": "now"}])
         with patch(EXEC, _exec((payload, "", 0))):
-            info = await podman.inspect_volume("v")
+            info = await _p.inspect_volume("v")
         assert info["Name"] == "v"
 
     async def test_empty_list(self):
         with patch(EXEC, _exec(("[]", "", 0))):
-            assert await podman.inspect_volume("v") is None
+            assert await _p.inspect_volume("v") is None
 
 
 class TestCreateVolume:
     async def test_with_labels(self):
         info = json.dumps([{"Name": "v", "CreatedAt": "t"}])
         with patch(EXEC, _exec(("v\n", "", 0), (info, "", 0))) as m:
-            result = await podman.create_volume("v", {"a": "1"})
+            result = await _p.create_volume("v", {"a": "1"})
         assert result["Name"] == "v"
         assert ["--label", "a=1"] == _args(m, 0)[2:4]
 
     async def test_without_labels(self):
         info = json.dumps([{"Name": "v", "CreatedAt": "t"}])
         with patch(EXEC, _exec(("v\n", "", 0), (info, "", 0))) as m:
-            await podman.create_volume("v")
+            await _p.create_volume("v")
         assert _args(m, 0) == ["volume", "create", "v"]
 
 
@@ -627,33 +630,33 @@ class TestListVolumes:
     async def test_parses(self):
         payload = json.dumps([{"Name": "v"}])
         with patch(EXEC, _exec((payload, "", 0))):
-            assert (await podman.list_volumes("k=v"))[0]["Name"] == "v"
+            assert (await _p.list_volumes("k=v"))[0]["Name"] == "v"
 
     async def test_empty(self):
         with patch(EXEC, _exec(("", "", 0))):
-            assert await podman.list_volumes("k=v") == []
+            assert await _p.list_volumes("k=v") == []
 
 
 class TestRemoveVolume:
     async def test_success(self):
         with patch(EXEC, _exec(("", "", 0))) as m:
-            await podman.remove_volume("v")
+            await _p.remove_volume("v")
         assert _args(m) == ["volume", "rm", "v"]
 
     async def test_not_found(self):
         with patch(EXEC, _exec(("", "no such volume", 1))):
             with pytest.raises(podman.PodmanError) as exc:
-                await podman.remove_volume("v")
+                await _p.remove_volume("v")
         assert exc.value.status == 404
 
     async def test_in_use(self):
         with patch(EXEC, _exec(("", "volume is being used", 1))):
             with pytest.raises(podman.PodmanError) as exc:
-                await podman.remove_volume("v")
+                await _p.remove_volume("v")
         assert exc.value.status == 409
 
     async def test_empty_stderr_fallback(self):
         with patch(EXEC, _exec(("", "", 1))):
             with pytest.raises(podman.PodmanError) as exc:
-                await podman.remove_volume("v")
+                await _p.remove_volume("v")
         assert exc.value.message == "podman volume rm"

--- a/src/backend/tests/test_podman_exec.py
+++ b/src/backend/tests/test_podman_exec.py
@@ -6,7 +6,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 
-from klangk_backend.podman import ExecSession
+from klangk_backend.podman import ExecSession, Podman
+from klangk_backend.settings import KlangkSettings
+
+_podman = Podman(KlangkSettings(env={}))
 
 
 def _mock_proc(stdout_data=b"", returncode=None):
@@ -36,7 +39,7 @@ def _mock_proc(stdout_data=b"", returncode=None):
 
 class TestExecSession:
     async def test_start_and_output(self):
-        session = ExecSession("cid")
+        session = ExecSession("cid", _podman)
         proc = _mock_proc(b"hello world")
         with patch(
             "asyncio.create_subprocess_exec",
@@ -56,7 +59,7 @@ class TestExecSession:
         transports (rsync) need: their argv must round-trip untouched,
         and a ~/.profile that prints must not corrupt the binary stream.
         """
-        session = ExecSession("cid")
+        session = ExecSession("cid", _podman)
         proc = _mock_proc(b"")
         with patch(
             "asyncio.create_subprocess_exec",
@@ -79,7 +82,7 @@ class TestExecSession:
         command needs an explicit ``bash -c``. Each element survives as
         one word (no shlex/quoting games).
         """
-        session = ExecSession("cid")
+        session = ExecSession("cid", _podman)
         proc = _mock_proc(b"")
         with patch(
             "asyncio.create_subprocess_exec",
@@ -107,7 +110,7 @@ class TestExecSession:
         and the e2e sync tests rely on, and what a naive space-join or
         ``shlex.join`` would each break in a different way.
         """
-        session = ExecSession("cid")
+        session = ExecSession("cid", _podman)
         proc = _mock_proc(b"")
         cmd = ["bash", "-c", "echo remote-data > /home/work/out.txt"]
         with patch(
@@ -123,7 +126,7 @@ class TestExecSession:
         assert argv[-1] == "echo remote-data > /home/work/out.txt"
 
     async def test_write_sends_to_stdin(self):
-        session = ExecSession("cid")
+        session = ExecSession("cid", _podman)
         proc = _mock_proc(b"")
         with patch(
             "asyncio.create_subprocess_exec",
@@ -134,7 +137,7 @@ class TestExecSession:
         proc.stdin.write.assert_called_with(b"input data")
 
     async def test_close_stdin(self):
-        session = ExecSession("cid")
+        session = ExecSession("cid", _podman)
         proc = _mock_proc(b"")
         with patch(
             "asyncio.create_subprocess_exec",
@@ -145,7 +148,7 @@ class TestExecSession:
         proc.stdin.close.assert_called_once()
 
     async def test_stop_terminates_process(self):
-        session = ExecSession("cid")
+        session = ExecSession("cid", _podman)
         proc = _mock_proc(b"", returncode=None)
         proc.wait = AsyncMock()
         with patch(
@@ -158,7 +161,7 @@ class TestExecSession:
         assert session._proc is None
 
     async def test_stop_kills_on_timeout(self):
-        session = ExecSession("cid")
+        session = ExecSession("cid", _podman)
         proc = _mock_proc(b"", returncode=None)
         proc.wait = AsyncMock(side_effect=asyncio.TimeoutError)
         with patch(
@@ -170,7 +173,7 @@ class TestExecSession:
         proc.kill.assert_called_once()
 
     async def test_returncode(self):
-        session = ExecSession("cid")
+        session = ExecSession("cid", _podman)
         proc = _mock_proc(b"", returncode=42)
         with patch(
             "asyncio.create_subprocess_exec",
@@ -180,12 +183,12 @@ class TestExecSession:
         assert session.returncode == 42
 
     async def test_returncode_none_when_no_proc(self):
-        session = ExecSession("cid")
+        session = ExecSession("cid", _podman)
         assert session.returncode is None
 
     async def test_returncode_survives_stop(self):
         """returncode is still accessible after stop() nulls _proc."""
-        session = ExecSession("cid")
+        session = ExecSession("cid", _podman)
         proc = _mock_proc(b"", returncode=7)
         proc.wait = AsyncMock()
         with patch(
@@ -199,23 +202,23 @@ class TestExecSession:
         assert session.returncode == 7
 
     async def test_is_alive_false_when_no_proc(self):
-        session = ExecSession("cid")
+        session = ExecSession("cid", _podman)
         assert not session.is_alive
 
     async def test_write_noop_when_no_proc(self):
-        session = ExecSession("cid")
+        session = ExecSession("cid", _podman)
         await session.write(b"data")  # should not raise
 
     async def test_close_stdin_noop_when_no_proc(self):
-        session = ExecSession("cid")
+        session = ExecSession("cid", _podman)
         await session.close_stdin()  # should not raise
 
     async def test_stop_noop_when_no_proc(self):
-        session = ExecSession("cid")
+        session = ExecSession("cid", _podman)
         await session.stop()  # should not raise
 
     async def test_read_stdout_handles_oserror(self):
-        session = ExecSession("cid")
+        session = ExecSession("cid", _podman)
         proc = _mock_proc(b"")
         proc.stdout.read = AsyncMock(side_effect=OSError("broken"))
         with patch(
@@ -228,7 +231,7 @@ class TestExecSession:
         assert data is None
 
     async def test_read_task_held_after_start(self):
-        session = ExecSession("cid")
+        session = ExecSession("cid", _podman)
         assert session._read_task is None
         proc = _mock_proc(b"hello")
         with patch(
@@ -240,7 +243,7 @@ class TestExecSession:
         assert isinstance(session._read_task, asyncio.Task)
 
     async def test_stop_cancels_read_task(self):
-        session = ExecSession("cid")
+        session = ExecSession("cid", _podman)
         proc = _mock_proc(b"", returncode=None)
         proc.wait = AsyncMock()
         with patch(
@@ -253,7 +256,7 @@ class TestExecSession:
         assert session._read_task is None
 
     async def test_read_stdout_reraises_cancelled_error(self):
-        session = ExecSession("cid")
+        session = ExecSession("cid", _podman)
         proc = _mock_proc(b"")
         blocked = asyncio.Event()
 
@@ -274,7 +277,7 @@ class TestExecSession:
             await session._read_task
 
     async def test_is_alive_false_when_read_task_done(self):
-        session = ExecSession("cid")
+        session = ExecSession("cid", _podman)
         proc = _mock_proc(b"output")
         # returncode stays None so is_alive would be True without
         # the read_task.done() check
@@ -290,7 +293,7 @@ class TestExecSession:
 
     async def test_sentinel_uses_put_nowait(self):
         """_read_stdout uses put_nowait for the sentinel."""
-        session = ExecSession("cid")
+        session = ExecSession("cid", _podman)
         proc = _mock_proc(b"")
         with patch(
             "asyncio.create_subprocess_exec",
@@ -303,7 +306,7 @@ class TestExecSession:
 
     async def test_sentinel_dropped_when_queue_full(self):
         """When queue is full, sentinel is silently dropped (no deadlock)."""
-        session = ExecSession("cid")
+        session = ExecSession("cid", _podman)
         session._running = True
         # Pre-fill the queue to capacity
         for _ in range(64):
@@ -325,7 +328,7 @@ class TestExecSession:
 
     async def test_output_exits_when_running_cleared_without_sentinel(self):
         """output() exits via _running check when sentinel is dropped."""
-        session = ExecSession("cid")
+        session = ExecSession("cid", _podman)
         proc = _mock_proc(b"data")
         with patch(
             "asyncio.create_subprocess_exec",
@@ -356,7 +359,7 @@ class TestExecSession:
     async def test_output_exits_when_read_task_done_without_sentinel(self):
         """When sentinel is dropped and _running is True, output() exits
         via _read_task.done() check after timeout."""
-        session = ExecSession("cid")
+        session = ExecSession("cid", _podman)
         proc = _mock_proc(b"data")
         with patch(
             "asyncio.create_subprocess_exec",
@@ -388,7 +391,7 @@ class TestExecSession:
         await session.stop()
 
     async def test_default_work_dir(self):
-        session = ExecSession("cid")
+        session = ExecSession("cid", _podman)
         proc = _mock_proc(b"")
         with patch(
             "asyncio.create_subprocess_exec",
@@ -403,6 +406,7 @@ class TestExecSession:
     async def test_user_home_sets_env_and_work_dir(self):
         session = ExecSession(
             "cid",
+            _podman,
             env=["HOME=/home/alice"],
             work_dir="/home/alice",
         )
@@ -418,7 +422,7 @@ class TestExecSession:
         assert cmd[w_idx + 1] == "/home/alice"
 
     async def test_no_home_env_without_user_home(self):
-        session = ExecSession("cid")
+        session = ExecSession("cid", _podman)
         proc = _mock_proc(b"")
         with patch(
             "asyncio.create_subprocess_exec",
@@ -431,6 +435,7 @@ class TestExecSession:
     async def test_ssh_agent_socket_in_env(self):
         session = ExecSession(
             "cid",
+            _podman,
             env=["HOME=/home/alice", "SSH_AUTH_SOCK=/tmp/agent.sock"],
             work_dir="/home/alice",
         )

--- a/src/backend/tests/test_terminal.py
+++ b/src/backend/tests/test_terminal.py
@@ -33,6 +33,11 @@ from klangk_backend.terminal import (
 
 SHELL_FACTORY = "klangk_backend.terminal.make_shell_process"
 
+# Mock Podman instance whose methods the tmux-function tests patch via
+# patch.object, then pass to the function under test as its ``podman``
+# arg (#1468).
+_mock_pod = MagicMock()
+
 
 class TestShellProcessFactory:
     """The factory + ctor are pure Python (no PTY); the OS methods that
@@ -125,7 +130,7 @@ def _drain_text(session):
 
 class TestInit:
     def test_initial_state(self):
-        s = TerminalSession("cid")
+        s = TerminalSession("cid", podman=_mock_pod)
         assert s.container_id == "cid"
         assert s._shell is None
         assert s._running is False
@@ -136,7 +141,7 @@ class TestStart:
     async def test_start_builds_exec_argv(self):
         fake = FakeShell(block_after_chunks=True)
         with _patch(fake):
-            s = TerminalSession("cid")
+            s = TerminalSession("cid", podman=_mock_pod)
             await s.start(120, 40)
 
         argv = fake.argv
@@ -156,7 +161,7 @@ class TestStart:
         monkeypatch.setenv("KLANGK_DISABLE_TMUX", "1")
         fake = FakeShell(block_after_chunks=True)
         with _patch(fake):
-            s = TerminalSession("cid", session_name="uid")
+            s = TerminalSession("cid", session_name="uid", podman=_mock_pod)
             await s.start(120, 40)
 
         argv = fake.argv
@@ -170,7 +175,7 @@ class TestStart:
         monkeypatch.setenv("ANTHROPIC_API_KEY", "secret2")
         fake = FakeShell(block_after_chunks=True)
         with _patch(fake):
-            s = TerminalSession("cid")
+            s = TerminalSession("cid", podman=_mock_pod)
             await s.start()
 
         argv = fake.argv
@@ -182,7 +187,7 @@ class TestStart:
     async def test_no_command_override_by_default(self):
         fake = FakeShell(block_after_chunks=True)
         with _patch(fake):
-            s = TerminalSession("cid")
+            s = TerminalSession("cid", podman=_mock_pod)
             await s.start()
         assert not any("KLANGK_CMD_OVERRIDE" in a for a in fake.argv)
         await s.stop()
@@ -191,7 +196,7 @@ class TestStart:
         """browser_id is no longer passed as an env var (uses klangk-attach-browser)."""
         fake = FakeShell(block_after_chunks=True)
         with _patch(fake):
-            s = TerminalSession("cid")
+            s = TerminalSession("cid", podman=_mock_pod)
             await s.start()
         assert not any("KLANGK_BROWSER_ID" in a for a in fake.argv)
         assert not any("KLANGK_BRIDGE_TOKEN" in a for a in fake.argv)
@@ -206,6 +211,7 @@ class TestStart:
                 user_home="/home/alice",
                 user_id="uid-123",
                 user_handle="alice",
+                podman=_mock_pod,
             )
             await s.start(120, 40)
         assert "HOME=/home/alice" in fake.argv
@@ -228,7 +234,7 @@ class TestStart:
     async def test_no_user_home_by_default(self):
         fake = FakeShell(block_after_chunks=True)
         with _patch(fake):
-            s = TerminalSession("cid")
+            s = TerminalSession("cid", podman=_mock_pod)
             await s.start()
         assert not any(a.startswith("HOME=") for a in fake.argv)
         await s.stop()
@@ -236,7 +242,7 @@ class TestStart:
     async def test_start_failure_resets_running(self):
         fake = FakeShell(start_error=RuntimeError("spawn fail"))
         with _patch(fake):
-            s = TerminalSession("cid")
+            s = TerminalSession("cid", podman=_mock_pod)
             try:
                 await s.start()
             except RuntimeError:
@@ -250,8 +256,9 @@ class TestStart:
         fake = FakeShell(block_after_chunks=True)
         with (
             _patch(fake),
-            patch(
-                "klangk_backend.terminal.podman.exec_container",
+            patch.object(
+                _mock_pod,
+                "exec_container",
                 new_callable=AsyncMock,
             ) as mock_exec,
         ):
@@ -259,6 +266,7 @@ class TestStart:
                 "cid",
                 session_name="uid-123",
                 ssh_agent_socket="/tmp/agent.sock",
+                podman=_mock_pod,
             )
             await s.start(120, 40)
 
@@ -278,12 +286,13 @@ class TestStart:
 
 class TestAttachBrowser:
     async def test_runs_klangk_attach_browser(self):
-        with patch(
-            "klangk_backend.terminal.podman.exec_container",
+        with patch.object(
+            _mock_pod,
+            "exec_container",
             new_callable=AsyncMock,
             return_value=(0, "", ""),
         ) as mock_exec:
-            await attach_browser("cid-123", "bid-abc")
+            await attach_browser("cid-123", "bid-abc", podman=_mock_pod)
         mock_exec.assert_awaited_once_with(
             "cid-123",
             ["klangk-attach-browser", "bid-abc"],
@@ -292,23 +301,27 @@ class TestAttachBrowser:
         )
 
     async def test_logs_warning_on_failure(self):
-        with patch(
-            "klangk_backend.terminal.podman.exec_container",
+        with patch.object(
+            _mock_pod,
+            "exec_container",
             new_callable=AsyncMock,
             return_value=(1, "", "attach failed"),
         ):
             # Should not raise
-            await attach_browser("cid-123", "bid-abc")
+            await attach_browser("cid-123", "bid-abc", podman=_mock_pod)
 
 
 class TestSetWorkspaceToken:
     async def test_runs_klangk_set_workspace_token(self):
-        with patch(
-            "klangk_backend.terminal.podman.exec_container",
+        with patch.object(
+            _mock_pod,
+            "exec_container",
             new_callable=AsyncMock,
             return_value=(0, "", ""),
         ) as mock_exec:
-            await set_workspace_token("cid-123", "jwt-token-xyz")
+            await set_workspace_token(
+                "cid-123", "jwt-token-xyz", podman=_mock_pod
+            )
         mock_exec.assert_awaited_once_with(
             "cid-123",
             ["klangk-set-workspace-token", "jwt-token-xyz"],
@@ -317,19 +330,22 @@ class TestSetWorkspaceToken:
         )
 
     async def test_logs_warning_on_failure(self):
-        with patch(
-            "klangk_backend.terminal.podman.exec_container",
+        with patch.object(
+            _mock_pod,
+            "exec_container",
             new_callable=AsyncMock,
             return_value=(1, "", "set failed"),
         ):
-            await set_workspace_token("cid-123", "jwt-token-xyz")
+            await set_workspace_token(
+                "cid-123", "jwt-token-xyz", podman=_mock_pod
+            )
 
 
 class TestReadLoop:
     async def test_output_from_shell(self):
         fake = FakeShell(chunks=[b"prompt", b"hello world"])
         with _patch(fake):
-            s = TerminalSession("cid")
+            s = TerminalSession("cid", podman=_mock_pod)
             await s.start()
 
         await asyncio.sleep(0.05)
@@ -340,7 +356,7 @@ class TestReadLoop:
     async def test_stream_end_signals_none(self):
         fake = FakeShell(chunks=[])  # immediate EOF
         with _patch(fake):
-            s = TerminalSession("cid")
+            s = TerminalSession("cid", podman=_mock_pod)
             await s.start()
 
         await asyncio.sleep(0.05)
@@ -350,7 +366,7 @@ class TestReadLoop:
     async def test_read_loop_handles_exception(self):
         fake = FakeShell(chunks=[b"prompt", RuntimeError("connection lost")])
         with _patch(fake):
-            s = TerminalSession("cid")
+            s = TerminalSession("cid", podman=_mock_pod)
             await s.start()
 
         await asyncio.sleep(0.05)
@@ -365,7 +381,7 @@ class TestReadLoop:
         # decoder must buffer the partial sequence and emit the intact glyph.
         fake = FakeShell(chunks=[b"\xe2\x94", b"\x80 done"])
         with _patch(fake):
-            s = TerminalSession("cid")
+            s = TerminalSession("cid", podman=_mock_pod)
             await s.start()
 
         await asyncio.sleep(0.05)
@@ -379,7 +395,7 @@ class TestReadLoop:
         # as a single replacement char rather than silently dropped.
         fake = FakeShell(chunks=[b"ok\xe2\x94"])  # ends mid '─'
         with _patch(fake):
-            s = TerminalSession("cid")
+            s = TerminalSession("cid", podman=_mock_pod)
             await s.start()
 
         await asyncio.sleep(0.05)
@@ -391,7 +407,7 @@ class TestWrite:
     async def test_write_sends_to_shell(self):
         fake = FakeShell(block_after_chunks=True)
         with _patch(fake):
-            s = TerminalSession("cid")
+            s = TerminalSession("cid", podman=_mock_pod)
             await s.start()
         await s.write("hello")
         assert fake.writes == [b"hello"]
@@ -400,13 +416,13 @@ class TestWrite:
     async def test_write_exception_suppressed(self):
         fake = FakeShell(block_after_chunks=True, write_error=OSError("broke"))
         with _patch(fake):
-            s = TerminalSession("cid")
+            s = TerminalSession("cid", podman=_mock_pod)
             await s.start()
         await s.write("hello")  # should not raise
         await s.stop()
 
     async def test_write_when_stopped(self):
-        s = TerminalSession("cid")
+        s = TerminalSession("cid", podman=_mock_pod)
         await s.write("hello")  # no shell -> no-op
 
 
@@ -414,7 +430,7 @@ class TestResize:
     async def test_resize_calls_shell_resize(self):
         fake = FakeShell(block_after_chunks=True)
         with _patch(fake):
-            s = TerminalSession("cid")
+            s = TerminalSession("cid", podman=_mock_pod)
             await s.start()
         await s.resize(200, 50)
         assert fake.resizes == [(50, 200)]  # (rows, cols)
@@ -427,14 +443,14 @@ class TestResize:
             raise OSError("broke")
 
         with _patch(fake):
-            s = TerminalSession("cid")
+            s = TerminalSession("cid", podman=_mock_pod)
             await s.start()
         fake.resize = boom
         await s.resize(200, 50)  # should not raise
         await s.stop()
 
     async def test_resize_when_stopped(self):
-        s = TerminalSession("cid")
+        s = TerminalSession("cid", podman=_mock_pod)
         await s.resize(80, 24)  # no shell -> no-op
 
 
@@ -442,7 +458,7 @@ class TestStop:
     async def test_stop_cleans_up(self):
         fake = FakeShell(block_after_chunks=True)
         with _patch(fake):
-            s = TerminalSession("cid")
+            s = TerminalSession("cid", podman=_mock_pod)
             await s.start()
         await s.stop()
         assert s._running is False
@@ -455,7 +471,7 @@ class TestStop:
             block_after_chunks=True, close_error=OSError("close fail")
         )
         with _patch(fake):
-            s = TerminalSession("cid")
+            s = TerminalSession("cid", podman=_mock_pod)
             await s.start()
         await s.stop()  # should not raise
         assert s._shell is None
@@ -463,7 +479,7 @@ class TestStop:
     async def test_stop_cancels_blocked_read_loop(self):
         fake = FakeShell(chunks=[b"prompt"], block_after_chunks=True)
         with _patch(fake):
-            s = TerminalSession("cid")
+            s = TerminalSession("cid", podman=_mock_pod)
             await s.start()
         await asyncio.sleep(0.05)  # consume prompt, then block on read
         await s.stop()
@@ -476,7 +492,7 @@ class TestStop:
 
         fake = FakeShell(block_after_chunks=True)
         with _patch(fake):
-            s = TerminalSession("cid")
+            s = TerminalSession("cid", podman=_mock_pod)
             await s.start()
 
         # Replace the read task with one that raises a non-CancelledError.
@@ -492,7 +508,7 @@ class TestStop:
         assert s._read_task is None
 
     async def test_stop_when_not_started(self):
-        s = TerminalSession("cid")
+        s = TerminalSession("cid", podman=_mock_pod)
         await s.stop()
 
     async def test_stop_kills_tmux_session_with_socket(self):
@@ -500,14 +516,18 @@ class TestStop:
         fake = FakeShell(block_after_chunks=True)
         with _patch(fake):
             s = TerminalSession(
-                "cid", session_name="uid", socket_path="/tmp/s.sock"
+                "cid",
+                session_name="uid",
+                socket_path="/tmp/s.sock",
+                podman=_mock_pod,
             )
             await s.start()
         # Manually set tmux session name (normally set by build_shell_command
         # when join_session is used with a socket path)
         s.tmux_session_name = "uid-abc123"
-        with patch(
-            "klangk_backend.terminal.podman.exec_container",
+        with patch.object(
+            _mock_pod,
+            "exec_container",
             new_callable=AsyncMock,
             return_value=(0, "", ""),
         ) as mock_exec:
@@ -523,12 +543,16 @@ class TestStop:
         fake = FakeShell(block_after_chunks=True)
         with _patch(fake):
             s = TerminalSession(
-                "cid", session_name="uid", socket_path="/tmp/s.sock"
+                "cid",
+                session_name="uid",
+                socket_path="/tmp/s.sock",
+                podman=_mock_pod,
             )
             await s.start()
         s.tmux_session_name = "uid-abc123"
-        with patch(
-            "klangk_backend.terminal.podman.exec_container",
+        with patch.object(
+            _mock_pod,
+            "exec_container",
             new_callable=AsyncMock,
             side_effect=OSError("boom"),
         ):
@@ -540,7 +564,7 @@ class TestOutput:
     async def test_output_yields_data(self):
         fake = FakeShell(chunks=[b"prompt", b"output"])
         with _patch(fake):
-            s = TerminalSession("cid")
+            s = TerminalSession("cid", podman=_mock_pod)
             await s.start()
 
         collected = []
@@ -552,7 +576,7 @@ class TestOutput:
 
     async def test_output_exits_when_running_cleared(self):
         """Sentinel dropped: output() exits via the _running check."""
-        s = TerminalSession("cid")
+        s = TerminalSession("cid", podman=_mock_pod)
         s._running = True
         s._read_task = None  # no task -> only _running governs exit
 
@@ -569,7 +593,7 @@ class TestOutput:
         """Sentinel dropped: output() exits via the _read_task.done() check."""
         fake = FakeShell(chunks=[])  # immediate EOF -> read task finishes
         with _patch(fake):
-            s = TerminalSession("cid")
+            s = TerminalSession("cid", podman=_mock_pod)
             await s.start()
 
         await asyncio.sleep(0.05)
@@ -595,7 +619,7 @@ class TestIsAlive:
     async def test_alive_while_running(self):
         fake = FakeShell(chunks=[b"prompt"], block_after_chunks=True)
         with _patch(fake):
-            s = TerminalSession("cid")
+            s = TerminalSession("cid", podman=_mock_pod)
             await s.start()
         assert s.is_alive is True
         await s.stop()
@@ -603,7 +627,7 @@ class TestIsAlive:
     async def test_not_alive_after_stream_ends(self):
         fake = FakeShell(chunks=[])  # EOF
         with _patch(fake):
-            s = TerminalSession("cid")
+            s = TerminalSession("cid", podman=_mock_pod)
             await s.start()
         await asyncio.sleep(0.05)
         assert s.is_alive is False
@@ -612,7 +636,7 @@ class TestIsAlive:
     async def test_not_alive_after_stop(self):
         fake = FakeShell(block_after_chunks=True)
         with _patch(fake):
-            s = TerminalSession("cid")
+            s = TerminalSession("cid", podman=_mock_pod)
             await s.start()
         await s.stop()
         assert s.is_alive is False
@@ -620,12 +644,15 @@ class TestIsAlive:
 
 class TestTmuxCommand:
     async def test_returns_stdout(self):
-        with patch(
-            "klangk_backend.terminal.podman.exec_container",
+        with patch.object(
+            _mock_pod,
+            "exec_container",
             new_callable=AsyncMock,
             return_value=(0, "output\n", ""),
         ) as mock_exec:
-            result = await tmux_command("cid", "sess", ["list-windows"])
+            result = await tmux_command(
+                "cid", "sess", ["list-windows"], podman=_mock_pod
+            )
         assert result == "output\n"
         mock_exec.assert_awaited_once_with(
             "cid",
@@ -635,19 +662,23 @@ class TestTmuxCommand:
         )
 
     async def test_raises_on_failure(self):
-        with patch(
-            "klangk_backend.terminal.podman.exec_container",
+        with patch.object(
+            _mock_pod,
+            "exec_container",
             new_callable=AsyncMock,
             return_value=(1, "", "error msg"),
         ) as mock_exec:
             with pytest.raises(TerminalError, match="error msg"):
-                await tmux_command("cid", "sess", ["bad-cmd"])
+                await tmux_command(
+                    "cid", "sess", ["bad-cmd"], podman=_mock_pod
+                )
         assert mock_exec.await_count == 1  # no retry on non-socket errors
 
     async def test_retries_on_socket_not_found(self):
         with (
-            patch(
-                "klangk_backend.terminal.podman.exec_container",
+            patch.object(
+                _mock_pod,
+                "exec_container",
                 new_callable=AsyncMock,
                 side_effect=[
                     (1, "", "No such file or directory"),
@@ -656,7 +687,9 @@ class TestTmuxCommand:
             ) as mock_exec,
             patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
         ):
-            result = await tmux_command("cid", "sess", ["list-windows"])
+            result = await tmux_command(
+                "cid", "sess", ["list-windows"], podman=_mock_pod
+            )
         assert result == "ok\n"
         assert mock_exec.await_count == 2
         mock_sleep.assert_awaited_once_with(0.5)
@@ -669,7 +702,7 @@ class TestListWindows:
             "klangk_backend.terminal.tmux_command",
             return_value="@0|||0|||bash|||1\n@1|||1|||build|||0\n",
         ):
-            result = await list_windows("cid", "sess")
+            result = await list_windows("cid", "sess", podman=_mock_pod)
         assert result == [
             {"id": "@0", "index": 0, "name": "bash", "active": True},
             {"id": "@1", "index": 1, "name": "build", "active": False},
@@ -677,7 +710,7 @@ class TestListWindows:
 
     async def test_empty_session(self):
         with patch("klangk_backend.terminal.tmux_command", return_value=""):
-            result = await list_windows("cid", "sess")
+            result = await list_windows("cid", "sess", podman=_mock_pod)
         assert result == []
 
 
@@ -702,28 +735,31 @@ class TestValidateWindowName:
 
 class TestNewWindow:
     async def test_creates_window_auto_name(self):
-        with patch(
-            "klangk_backend.terminal.podman.exec_container",
+        with patch.object(
+            _mock_pod,
+            "exec_container",
             new_callable=AsyncMock,
             return_value=(0, "@0|||0|||1|||1\n", ""),
         ) as mock_exec:
-            result = await new_window("cid", "sess")
+            result = await new_window("cid", "sess", podman=_mock_pod)
         assert len(result) == 1
         assert result[0]["name"] == "1"
         assert mock_exec.call_args.args[1][:2] == ["bash", "-c"]
 
     async def test_auto_name_skips_existing(self):
-        with patch(
-            "klangk_backend.terminal.podman.exec_container",
+        with patch.object(
+            _mock_pod,
+            "exec_container",
             new_callable=AsyncMock,
             return_value=(0, "@0|||0|||1|||0\n@1|||1|||2|||1\n", ""),
         ):
-            result = await new_window("cid", "sess")
+            result = await new_window("cid", "sess", podman=_mock_pod)
         assert len(result) == 2
 
     async def test_creates_named_window(self):
-        with patch(
-            "klangk_backend.terminal.podman.exec_container",
+        with patch.object(
+            _mock_pod,
+            "exec_container",
             new_callable=AsyncMock,
             return_value=(
                 0,
@@ -731,7 +767,9 @@ class TestNewWindow:
                 "",
             ),
         ) as mock_exec:
-            result = await new_window("cid", "sess", name="build")
+            result = await new_window(
+                "cid", "sess", name="build", podman=_mock_pod
+            )
         assert len(result) == 2
         assert result[1]["name"] == "build"
         # the name is passed as a positional argv ($1), never interpolated
@@ -744,25 +782,29 @@ class TestNewWindow:
 
     async def test_rejects_shell_injection(self):
         with pytest.raises(ValueError, match="only contain"):
-            await new_window("cid", "sess", name="';rm -rf /;'")
+            await new_window(
+                "cid", "sess", name="';rm -rf /;'", podman=_mock_pod
+            )
 
     async def test_rejects_duplicate_name(self):
-        with patch(
-            "klangk_backend.terminal.podman.exec_container",
+        with patch.object(
+            _mock_pod,
+            "exec_container",
             new_callable=AsyncMock,
             return_value=(1, "DUPLICATE\n", ""),
         ):
             with pytest.raises(ValueError, match="already exists"):
-                await new_window("cid", "sess", name="build")
+                await new_window("cid", "sess", name="build", podman=_mock_pod)
 
     async def test_raises_on_tmux_error(self):
-        with patch(
-            "klangk_backend.terminal.podman.exec_container",
+        with patch.object(
+            _mock_pod,
+            "exec_container",
             new_callable=AsyncMock,
             return_value=(1, "", "session not found"),
         ):
             with pytest.raises(TerminalError, match="session not found"):
-                await new_window("cid", "sess")
+                await new_window("cid", "sess", podman=_mock_pod)
 
 
 class TestSelectWindow:
@@ -771,18 +813,18 @@ class TestSelectWindow:
             "klangk_backend.terminal.tmux_command",
             return_value="",
         ) as mock_cmd:
-            await select_window("cid", "sess", 2)
+            await select_window("cid", "sess", 2, podman=_mock_pod)
         mock_cmd.assert_called_once_with(
-            "cid", "sess", ["select-window", "-t", "sess:2"]
+            "cid", "sess", ["select-window", "-t", "sess:2"], _mock_pod
         )
 
     async def test_selects_by_window_id(self):
         with patch(
             "klangk_backend.terminal.tmux_command",
         ) as mock_cmd:
-            await select_window("cid", "sess", "@5")
+            await select_window("cid", "sess", "@5", podman=_mock_pod)
         mock_cmd.assert_called_once_with(
-            "cid", "sess", ["select-window", "-t", "@5"]
+            "cid", "sess", ["select-window", "-t", "@5"], _mock_pod
         )
 
 
@@ -798,9 +840,9 @@ class TestCloseWindow:
                 return_value=[{"index": 0, "name": "bash", "active": True}],
             ),
         ):
-            result = await close_window("cid", "sess", 1)
+            result = await close_window("cid", "sess", 1, podman=_mock_pod)
         mock_cmd.assert_called_once_with(
-            "cid", "sess", ["kill-window", "-t", "sess:1"]
+            "cid", "sess", ["kill-window", "-t", "sess:1"], _mock_pod
         )
         assert len(result) == 1
 
@@ -815,9 +857,9 @@ class TestCloseWindow:
                 return_value=[],
             ),
         ):
-            await close_window("cid", "sess", "@3")
+            await close_window("cid", "sess", "@3", podman=_mock_pod)
         mock_cmd.assert_called_once_with(
-            "cid", "sess", ["kill-window", "-t", "@3"]
+            "cid", "sess", ["kill-window", "-t", "@3"], _mock_pod
         )
 
 
@@ -835,14 +877,19 @@ class TestRenameWindow:
                 return_value="",
             ) as mock_cmd,
         ):
-            await rename_window("cid", "sess", 0, "build")
+            await rename_window("cid", "sess", 0, "build", podman=_mock_pod)
         mock_cmd.assert_called_once_with(
-            "cid", "sess", ["rename-window", "-t", "sess:0", "build"]
+            "cid",
+            "sess",
+            ["rename-window", "-t", "sess:0", "build"],
+            _mock_pod,
         )
 
     async def test_rejects_shell_injection(self):
         with pytest.raises(ValueError, match="only contain"):
-            await rename_window("cid", "sess", 0, "';rm -rf /;'")
+            await rename_window(
+                "cid", "sess", 0, "';rm -rf /;'", podman=_mock_pod
+            )
 
     async def test_rejects_duplicate_name(self):
         with patch(
@@ -853,7 +900,9 @@ class TestRenameWindow:
             ],
         ):
             with pytest.raises(ValueError, match="already exists"):
-                await rename_window("cid", "sess", 0, "build")
+                await rename_window(
+                    "cid", "sess", 0, "build", podman=_mock_pod
+                )
 
 
 class TestBuildEnvironment:
@@ -980,7 +1029,7 @@ class TestKillJoinerSessions:
                 "",  # kill carol
             ],
         ) as mock_cmd:
-            await kill_joiner_sessions("cid", "admin")
+            await kill_joiner_sessions("cid", "admin", podman=_mock_pod)
         # Should have called list-sessions + kill for bob and carol
         assert mock_cmd.call_count == 3
 
@@ -989,7 +1038,7 @@ class TestKillJoinerSessions:
             "klangk_backend.terminal.tmux_command",
             return_value="admin\n",
         ) as mock_cmd:
-            await kill_joiner_sessions("cid", "admin")
+            await kill_joiner_sessions("cid", "admin", podman=_mock_pod)
         # Only list-sessions, no kills
         assert mock_cmd.call_count == 1
 
@@ -1003,7 +1052,7 @@ class TestKillJoinerSessions:
                 "",  # kill carol succeeds
             ],
         ) as mock_cmd:
-            await kill_joiner_sessions("cid", "admin")
+            await kill_joiner_sessions("cid", "admin", podman=_mock_pod)
         assert mock_cmd.call_count == 3
 
     async def test_no_sessions(self):
@@ -1012,7 +1061,7 @@ class TestKillJoinerSessions:
             side_effect=TerminalError("no sessions"),
         ):
             # Should not raise
-            await kill_joiner_sessions("cid", "admin")
+            await kill_joiner_sessions("cid", "admin", podman=_mock_pod)
 
 
 class TestTerminalSessionJoin:
@@ -1025,6 +1074,7 @@ class TestTerminalSessionJoin:
                 session_name="joiner-uid",
                 user_home="/home/bob",
                 join_session="owner-uid",
+                podman=_mock_pod,
             )
             await s.start(80, 24)
         assert "-S" not in fake.argv
@@ -1041,6 +1091,7 @@ class TestTerminalSessionJoin:
                 user_home="/home/ceo",
                 join_session="owner-uid",
                 read_only=True,
+                podman=_mock_pod,
             )
             await s.start(80, 24)
         assert "switch-client" not in fake.argv
@@ -1053,12 +1104,15 @@ class TestEnsureBaseSession:
         """Skip creation if tmux has-session succeeds."""
         from klangk_backend.terminal import ensure_base_session
 
-        with patch(
-            "klangk_backend.terminal.podman.exec_container",
+        with patch.object(
+            _mock_pod,
+            "exec_container",
             new_callable=AsyncMock,
             return_value=(0, "", ""),  # has-session succeeds
         ) as mock_exec:
-            created = await ensure_base_session("cid", "my-session")
+            created = await ensure_base_session(
+                "cid", "my-session", podman=_mock_pod
+            )
         assert created is False
         mock_exec.assert_awaited_once()
         assert "has-session" in mock_exec.call_args.args[1]
@@ -1067,13 +1121,14 @@ class TestEnsureBaseSession:
         """Create detached session when has-session fails."""
         from klangk_backend.terminal import ensure_base_session
 
-        with patch(
-            "klangk_backend.terminal.podman.exec_container",
+        with patch.object(
+            _mock_pod,
+            "exec_container",
             new_callable=AsyncMock,
             side_effect=[(1, "", ""), (0, "", "")],  # has fail, new ok
         ) as mock_exec:
             created = await ensure_base_session(
-                "cid", "my-session", user_home="/home/u"
+                "cid", "my-session", user_home="/home/u", podman=_mock_pod
             )
         assert created is True
         assert mock_exec.await_count == 2
@@ -1086,12 +1141,15 @@ class TestEnsureBaseSession:
         """Falls through to create if has-session raises."""
         from klangk_backend.terminal import ensure_base_session
 
-        with patch(
-            "klangk_backend.terminal.podman.exec_container",
+        with patch.object(
+            _mock_pod,
+            "exec_container",
             new_callable=AsyncMock,
             side_effect=[OSError("boom"), (0, "", "")],
         ) as mock_exec:
-            created = await ensure_base_session("cid", "my-session")
+            created = await ensure_base_session(
+                "cid", "my-session", podman=_mock_pod
+            )
         assert created is True
         assert mock_exec.await_count == 2
 
@@ -1099,20 +1157,24 @@ class TestEnsureBaseSession:
         """Warning logged when new-session fails."""
         from klangk_backend.terminal import ensure_base_session
 
-        with patch(
-            "klangk_backend.terminal.podman.exec_container",
+        with patch.object(
+            _mock_pod,
+            "exec_container",
             new_callable=AsyncMock,
             side_effect=[(1, "", ""), OSError("create failed")],
         ):
-            created = await ensure_base_session("cid", "my-session")
+            created = await ensure_base_session(
+                "cid", "my-session", podman=_mock_pod
+            )
         assert created is False
 
     async def test_env_args_passed(self):
         """HOME and SSH_AUTH_SOCK are passed as tmux -e flags."""
         from klangk_backend.terminal import ensure_base_session
 
-        with patch(
-            "klangk_backend.terminal.podman.exec_container",
+        with patch.object(
+            _mock_pod,
+            "exec_container",
             new_callable=AsyncMock,
             side_effect=[(1, "", ""), (0, "", "")],
         ) as mock_exec:
@@ -1121,6 +1183,7 @@ class TestEnsureBaseSession:
                 "my-session",
                 user_home="/home/u",
                 ssh_agent_socket="/tmp/agent.sock",
+                podman=_mock_pod,
             )
         new_cmd = mock_exec.call_args_list[1].args[1]
         assert "HOME=/home/u" in new_cmd
@@ -1130,36 +1193,45 @@ class TestEnsureBaseSession:
         """service_cmd_window_exists returns False if list-windows raises."""
         from klangk_backend.terminal import service_cmd_window_exists
 
-        with patch(
-            "klangk_backend.terminal.podman.exec_container",
+        with patch.object(
+            _mock_pod,
+            "exec_container",
             new_callable=AsyncMock,
             side_effect=OSError("boom"),
         ):
-            result = await service_cmd_window_exists("cid", "my-session")
+            result = await service_cmd_window_exists(
+                "cid", "my-session", podman=_mock_pod
+            )
         assert result is False
 
     async def test_service_cmd_window_exists_rc_nonzero_returns_false(self):
         """service_cmd_window_exists returns False if list-windows fails."""
         from klangk_backend.terminal import service_cmd_window_exists
 
-        with patch(
-            "klangk_backend.terminal.podman.exec_container",
+        with patch.object(
+            _mock_pod,
+            "exec_container",
             new_callable=AsyncMock,
             return_value=(1, "", ""),  # list-windows fails
         ):
-            result = await service_cmd_window_exists("cid", "my-session")
+            result = await service_cmd_window_exists(
+                "cid", "my-session", podman=_mock_pod
+            )
         assert result is False
 
     async def test_has_tmux_session_exception_returns_false(self):
         """has_tmux_session returns False if has-session raises."""
         from klangk_backend.terminal import has_tmux_session
 
-        with patch(
-            "klangk_backend.terminal.podman.exec_container",
+        with patch.object(
+            _mock_pod,
+            "exec_container",
             new_callable=AsyncMock,
             side_effect=OSError("boom"),
         ):
-            result = await has_tmux_session("cid", "my-session")
+            result = await has_tmux_session(
+                "cid", "my-session", podman=_mock_pod
+            )
         assert result is False
 
 
@@ -1179,7 +1251,9 @@ class TestEnsureServiceSession:
         from klangk_backend.settings import KlangkSettings
 
         registry = ContainerRegistry(KlangkSettings(env={}))
-        self.app_state = types.SimpleNamespace(container_registry=registry)
+        self.app_state = types.SimpleNamespace(
+            container_registry=registry, podman=_mock_pod
+        )
 
     async def test_creates_window_and_sends_command(self):
         """A fresh service session fires the service command in its
@@ -1195,8 +1269,9 @@ class TestEnsureServiceSession:
                 "klangk_backend.terminal.service_cmd_window_exists",
                 new=AsyncMock(return_value=False),
             ),
-            patch(
-                "klangk_backend.terminal.podman.exec_container",
+            patch.object(
+                _mock_pod,
+                "exec_container",
                 new=AsyncMock(side_effect=[(0, "", ""), (0, "", "")]),
             ) as mock_exec,
         ):
@@ -1245,7 +1320,7 @@ class TestEnsureServiceSession:
                 app_state=self.app_state,
             )
         mock_ensure.assert_awaited_once_with(
-            "cid", SERVICE_SESSION, "/home/clanker"
+            "cid", SERVICE_SESSION, "/home/clanker", podman=_mock_pod
         )
 
     async def test_skips_when_window_already_exists(self):
@@ -1261,8 +1336,9 @@ class TestEnsureServiceSession:
                 "klangk_backend.terminal.service_cmd_window_exists",
                 new=AsyncMock(return_value=True),
             ),
-            patch(
-                "klangk_backend.terminal.podman.exec_container",
+            patch.object(
+                _mock_pod,
+                "exec_container",
                 new=AsyncMock(),
             ) as mock_exec,
         ):
@@ -1289,8 +1365,9 @@ class TestEnsureServiceSession:
                 "klangk_backend.terminal.service_cmd_window_exists",
                 new=AsyncMock(return_value=False),
             ),
-            patch(
-                "klangk_backend.terminal.podman.exec_container",
+            patch.object(
+                _mock_pod,
+                "exec_container",
                 new=AsyncMock(),
             ) as mock_exec,
         ):
@@ -1318,8 +1395,9 @@ class TestEnsureServiceSession:
                 "klangk_backend.terminal.service_cmd_window_exists",
                 new=AsyncMock(return_value=False),
             ),
-            patch(
-                "klangk_backend.terminal.podman.exec_container",
+            patch.object(
+                _mock_pod,
+                "exec_container",
                 new=AsyncMock(side_effect=RuntimeError("tmux broke")),
             ),
             patch("klangk_backend.terminal.logger") as mock_logger,
@@ -1342,8 +1420,9 @@ class TestEnsureServiceSession:
                 "klangk_backend.terminal.service_cmd_window_exists",
                 new=AsyncMock(return_value=False),
             ),
-            patch(
-                "klangk_backend.terminal.podman.exec_container",
+            patch.object(
+                _mock_pod,
+                "exec_container",
                 new=AsyncMock(
                     side_effect=[
                         (0, "", ""),  # new-window succeeds
@@ -1368,7 +1447,9 @@ class TestEnsureServiceSession:
         from klangk_backend.terminal import ensure_service_session
 
         mock_registry = MagicMock()
-        app_state = types.SimpleNamespace(container_registry=mock_registry)
+        app_state = types.SimpleNamespace(
+            container_registry=mock_registry, podman=_mock_pod
+        )
 
         with (
             patch(
@@ -1379,8 +1460,9 @@ class TestEnsureServiceSession:
                 "klangk_backend.terminal.service_cmd_window_exists",
                 new=AsyncMock(return_value=False),
             ),
-            patch(
-                "klangk_backend.terminal.podman.exec_container",
+            patch.object(
+                _mock_pod,
+                "exec_container",
                 new=AsyncMock(side_effect=[(0, "", ""), (0, "", "")]),
             ),
         ):
@@ -1400,7 +1482,9 @@ class TestEnsureServiceSession:
         from klangk_backend.terminal import ensure_service_session
 
         mock_registry = MagicMock()
-        app_state = types.SimpleNamespace(container_registry=mock_registry)
+        app_state = types.SimpleNamespace(
+            container_registry=mock_registry, podman=_mock_pod
+        )
 
         with (
             patch(
@@ -1411,8 +1495,9 @@ class TestEnsureServiceSession:
                 "klangk_backend.terminal.service_cmd_window_exists",
                 new=AsyncMock(return_value=True),
             ),
-            patch(
-                "klangk_backend.terminal.podman.exec_container",
+            patch.object(
+                _mock_pod,
+                "exec_container",
                 new=AsyncMock(),
             ),
         ):
@@ -1432,7 +1517,9 @@ class TestEnsureServiceSession:
         from klangk_backend.terminal import ensure_service_session
 
         mock_registry = MagicMock()
-        app_state = types.SimpleNamespace(container_registry=mock_registry)
+        app_state = types.SimpleNamespace(
+            container_registry=mock_registry, podman=_mock_pod
+        )
 
         with (
             patch(
@@ -1443,8 +1530,9 @@ class TestEnsureServiceSession:
                 "klangk_backend.terminal.service_cmd_window_exists",
                 new=AsyncMock(return_value=False),
             ),
-            patch(
-                "klangk_backend.terminal.podman.exec_container",
+            patch.object(
+                _mock_pod,
+                "exec_container",
                 new=AsyncMock(
                     side_effect=[
                         (0, "", ""),  # new-window succeeds
@@ -1488,7 +1576,7 @@ class TestEnsureServiceSession:
         # existence check during this yield; with the lock it cannot.
         _real_sleep = asyncio.sleep
 
-        async def fake_window_exists(cid, session):
+        async def fake_window_exists(cid, session, podman=None):
             return terminal.SERVICE_CMD_WINDOW in windows
 
         async def fake_exec(cid, argv, **kwargs):
@@ -1512,8 +1600,9 @@ class TestEnsureServiceSession:
                 "klangk_backend.terminal.service_cmd_window_exists",
                 side_effect=fake_window_exists,
             ),
-            patch(
-                "klangk_backend.terminal.podman.exec_container",
+            patch.object(
+                _mock_pod,
+                "exec_container",
                 side_effect=fake_exec,
             ),
             patch("klangk_backend.terminal.asyncio.sleep", new=AsyncMock()),
@@ -1548,7 +1637,7 @@ class TestEnsureServiceSession:
         new_window_calls = 0
         _real_sleep = asyncio.sleep
 
-        async def fake_window_exists(cid, session):
+        async def fake_window_exists(cid, session, podman=None):
             return terminal.SERVICE_CMD_WINDOW in windows.get(cid, set())
 
         async def fake_exec(cid, argv, **kwargs):
@@ -1568,8 +1657,9 @@ class TestEnsureServiceSession:
                 "klangk_backend.terminal.service_cmd_window_exists",
                 side_effect=fake_window_exists,
             ),
-            patch(
-                "klangk_backend.terminal.podman.exec_container",
+            patch.object(
+                _mock_pod,
+                "exec_container",
                 side_effect=fake_exec,
             ),
             patch("klangk_backend.terminal.asyncio.sleep", new=AsyncMock()),
@@ -1609,8 +1699,9 @@ class TestEnsureServiceSession:
                 "klangk_backend.terminal.service_cmd_window_exists",
                 new=AsyncMock(return_value=False),
             ),
-            patch(
-                "klangk_backend.terminal.podman.exec_container",
+            patch.object(
+                _mock_pod,
+                "exec_container",
                 new=AsyncMock(
                     side_effect=[
                         (0, "", ""),  # new-window succeeds
@@ -1647,8 +1738,9 @@ class TestEnsureServiceSession:
                 "klangk_backend.terminal.service_cmd_window_exists",
                 new=AsyncMock(return_value=False),
             ),
-            patch(
-                "klangk_backend.terminal.podman.exec_container",
+            patch.object(
+                _mock_pod,
+                "exec_container",
                 new=AsyncMock(
                     side_effect=[
                         (0, "", ""),  # new-window succeeds
@@ -1673,22 +1765,34 @@ class TestServiceSessionHelpers:
     async def test_service_cmd_window_exists_true_when_present(self):
         from klangk_backend.terminal import service_cmd_window_exists
 
-        with patch(
-            "klangk_backend.terminal.podman.exec_container",
+        with patch.object(
+            _mock_pod,
+            "exec_container",
             new_callable=AsyncMock,
             return_value=(0, "bash\nservice-cmd\n", ""),
         ):
-            assert await service_cmd_window_exists("cid", "service") is True
+            assert (
+                await service_cmd_window_exists(
+                    "cid", "service", podman=_mock_pod
+                )
+                is True
+            )
 
     async def test_service_cmd_window_exists_false_when_absent(self):
         from klangk_backend.terminal import service_cmd_window_exists
 
-        with patch(
-            "klangk_backend.terminal.podman.exec_container",
+        with patch.object(
+            _mock_pod,
+            "exec_container",
             new_callable=AsyncMock,
             return_value=(0, "bash\n", ""),
         ):
-            assert await service_cmd_window_exists("cid", "service") is False
+            assert (
+                await service_cmd_window_exists(
+                    "cid", "service", podman=_mock_pod
+                )
+                is False
+            )
 
     def test_should_fire_returns_false_without_service_command(self):
         from klangk_backend.terminal import should_fire_service_command

--- a/src/backend/tests/test_workspaces.py
+++ b/src/backend/tests/test_workspaces.py
@@ -2,7 +2,7 @@
 
 import os
 import types
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -389,12 +389,14 @@ class TestEnsureHomeSymlink:
 class TestPopulateHomeSkel:
     async def test_execs_setup_home(self):
         """populate_home_skel runs podman exec with klangk-setup-home script."""
-        with patch(
-            "klangk_backend.workspaces.podman.exec_container",
+        mock_pod = MagicMock()
+        with patch.object(
+            mock_pod,
+            "exec_container",
             new_callable=AsyncMock,
             return_value=(0, "", ""),
         ) as mock_exec:
-            await ws_mod.populate_home_skel("cid-123", "uid-456")
+            await ws_mod.populate_home_skel("cid-123", "uid-456", mock_pod)
         mock_exec.assert_awaited_once_with(
             "cid-123",
             ["/opt/klangk/bin/klangk-setup-home", "/home/.users/uid-456"],
@@ -404,13 +406,15 @@ class TestPopulateHomeSkel:
 
     async def test_logs_warning_on_failure(self):
         """populate_home_skel logs but does not raise on failure."""
-        with patch(
-            "klangk_backend.workspaces.podman.exec_container",
+        mock_pod = MagicMock()
+        with patch.object(
+            mock_pod,
+            "exec_container",
             new_callable=AsyncMock,
             side_effect=OSError("podman not found"),
         ):
             # Should not raise
-            await ws_mod.populate_home_skel("cid-123", "uid-456")
+            await ws_mod.populate_home_skel("cid-123", "uid-456", mock_pod)
 
 
 class TestAutoStartWorkspaces:

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -60,6 +60,10 @@ def _trusted_default():
     }
 
 
+_mock_pod = MagicMock()
+_mock_pod.exec_container = AsyncMock(return_value=(0, "", ""))
+
+
 def _make_app_state(registry=None, sockets=None):
     """Build a minimal app_state for tests."""
     from klangk_backend.settings import KlangkSettings
@@ -79,6 +83,8 @@ def _make_app_state(registry=None, sockets=None):
     registry.sockets = sockets
     registry.app_state = app_state
     sockets.app_state = app_state
+    app_state.podman = _mock_pod
+    registry.podman = _mock_pod
     return app_state
 
 
@@ -1126,6 +1132,7 @@ class TestHandleTerminalStart:
             user_id="uid",
             user_handle="testuser",
             ssh_agent_socket=None,
+            podman=_mock_pod,
         )
         # Should have sent terminal_windows and shared_terminals
         sent = [c[0][0] for c in sock.send_json.call_args_list]
@@ -1626,6 +1633,7 @@ class TestHandleTerminalStart:
             user_id="uid",
             user_handle="testuser",
             ssh_agent_socket=None,
+            podman=_mock_pod,
         )
         mock_ess.assert_awaited_once_with(
             "cid",
@@ -1846,7 +1854,7 @@ class TestHandleSetHandle:
             new_callable=AsyncMock,
         ) as mock_skel:
             await conn.handle_set_handle({"handle": "alice"})
-        mock_skel.assert_awaited_once_with("cid", user["id"])
+        mock_skel.assert_awaited_once_with("cid", user["id"], _mock_pod)
         sent = sock.send_json.call_args_list
         assert any(
             call.args[0].get("type") == "handle_set"
@@ -3363,8 +3371,9 @@ class TestSSHAgentHandlers:
         mock_proc.kill = MagicMock()
         mock_proc.wait = AsyncMock()
         with (
-            patch(
-                "klangk_backend.wshandler.controllers.podman.exec_container",
+            patch.object(
+                _mock_pod,
+                "exec_container",
                 new=AsyncMock(),
             ),
             patch(
@@ -3413,8 +3422,9 @@ class TestSSHAgentHandlers:
         conn._ssh_agent_proc = mock_proc
         conn._ssh_agent_socket = "/tmp/test.sock"
         conn._ssh_agent_task = asyncio.create_task(asyncio.sleep(999))
-        with patch(
-            "klangk_backend.wshandler.controllers.podman.exec_container",
+        with patch.object(
+            _mock_pod,
+            "exec_container",
             new=AsyncMock(),
         ):
             await conn.handle_ssh_agent_stop()
@@ -3434,8 +3444,9 @@ class TestSSHAgentHandlers:
         conn._ssh_agent_proc = mock_proc
         conn._ssh_agent_socket = "/tmp/test.sock"
         conn._ssh_agent_task = asyncio.create_task(asyncio.sleep(999))
-        with patch(
-            "klangk_backend.wshandler.controllers.podman.exec_container",
+        with patch.object(
+            _mock_pod,
+            "exec_container",
             new=AsyncMock(),
         ):
             await conn._stop_ssh_agent()
@@ -3516,6 +3527,7 @@ class TestSSHAgentHandlers:
             user_id="uid",
             user_handle="testuser",
             ssh_agent_socket="/tmp/klangk-ssh-agent-uid.sock",
+            podman=_mock_pod,
         )
 
 
@@ -3538,7 +3550,12 @@ class TestSshAgentForwarder:
                 "email": "testuser@example.com",
                 "handle": "testuser",
             }
-        conn = SimpleNamespace(sock=sock, user=user, container_id=container_id)
+        conn = SimpleNamespace(
+            sock=sock,
+            user=user,
+            container_id=container_id,
+            app_state=SimpleNamespace(podman=_mock_pod),
+        )
         return SshAgentForwarder(conn), sock
 
     @asynccontextmanager
@@ -3576,8 +3593,9 @@ class TestSshAgentForwarder:
         mock_proc.stdin = AsyncMock()
         with (
             patch.dict(os.environ, {"KLANGKC_DEBUG_SSH_AGENT": "1"}),
-            patch(
-                "klangk_backend.wshandler.controllers.podman.exec_container",
+            patch.object(
+                _mock_pod,
+                "exec_container",
                 new=AsyncMock(),
             ),
             patch(
@@ -3613,8 +3631,9 @@ class TestSshAgentForwarder:
         mock_proc.stdin = AsyncMock()
         with (
             patch.dict(os.environ, {"KLANGKC_DEBUG_SSH_AGENT": "1"}),
-            patch(
-                "klangk_backend.wshandler.controllers.podman.exec_container",
+            patch.object(
+                _mock_pod,
+                "exec_container",
                 new=AsyncMock(),
             ),
             patch(
@@ -3834,8 +3853,9 @@ class TestSshAgentForwarder:
     async def test_stop_handles_socket_remove_oserror(self):
         fwd, _ = self._forwarder()
         fwd.socket = "/tmp/agent.sock"
-        with patch(
-            "klangk_backend.wshandler.controllers.podman.exec_container",
+        with patch.object(
+            _mock_pod,
+            "exec_container",
             new=AsyncMock(side_effect=OSError("boom")),
         ) as exec_mock:
             with patch("klangk_backend.wshandler.controllers.logger") as lg:
@@ -3853,8 +3873,9 @@ class TestSshAgentForwarder:
         fwd.proc = mock_proc
         fwd.socket = None  # skip socket-removal branch
         fwd.task = asyncio.create_task(asyncio.sleep(999))
-        with patch(
-            "klangk_backend.wshandler.controllers.podman.exec_container",
+        with patch.object(
+            _mock_pod,
+            "exec_container",
             new=AsyncMock(),
         ):
             await fwd.stop()
@@ -5783,7 +5804,9 @@ class TestTerminalWindowHandlers:
             ],
         ) as mock_new:
             await conn.handle_terminal_new_window({"name": "build"})
-        mock_new.assert_called_once_with("cid", "uid", name="build")
+        mock_new.assert_called_once_with(
+            "cid", "uid", name="build", podman=_mock_pod
+        )
 
     async def test_new_window_error(self):
         sock = _mock_sock()
@@ -5807,7 +5830,7 @@ class TestTerminalWindowHandlers:
             "klangk_backend.terminal.select_window",
         ) as mock_sel:
             await conn.handle_terminal_select_window({"index": 2})
-        mock_sel.assert_called_once_with("cid", "uid", 2)
+        mock_sel.assert_called_once_with("cid", "uid", 2, _mock_pod)
 
     async def test_select_window_by_id(self):
         sock = _mock_sock()
@@ -5818,7 +5841,7 @@ class TestTerminalWindowHandlers:
             "klangk_backend.terminal.select_window",
         ) as mock_sel:
             await conn.handle_terminal_select_window({"window_id": "@3"})
-        mock_sel.assert_called_once_with("cid", "uid", "@3")
+        mock_sel.assert_called_once_with("cid", "uid", "@3", _mock_pod)
 
     async def test_select_window_error(self):
         sock = _mock_sock()
@@ -6396,7 +6419,7 @@ class TestTerminalController:
         ctrl.session = session
         with patch("klangk_backend.terminal.select_window") as sel:
             await ctrl.select_window({"window_id": "@2"})
-        sel.assert_called_once_with("cid", "grouped", "@2")
+        sel.assert_called_once_with("cid", "grouped", "@2", _mock_pod)
 
     async def test_select_window_falls_back_to_tmux_session_name(self):
         ctrl, _, _ = self._controller()
@@ -6405,7 +6428,7 @@ class TestTerminalController:
         ctrl.session = session
         with patch("klangk_backend.terminal.select_window") as sel:
             await ctrl.select_window({"index": 1})
-        sel.assert_called_once_with("cid", "uid", 1)
+        sel.assert_called_once_with("cid", "uid", 1, _mock_pod)
 
     # --- sync / notify helpers ---
 
@@ -7368,7 +7391,9 @@ class TestShareWindowHandlers:
                 await asyncio.sleep(0)
 
             # Fell back to select_window with bare @N
-            mock_select.assert_awaited_once_with("cid", owner["id"], "@0")
+            mock_select.assert_awaited_once_with(
+                "cid", owner["id"], "@0", _mock_pod
+            )
         finally:
             sockets.sessions.pop("ws-1", None)
             sockets.connections.pop(sock, None)
@@ -7424,7 +7449,9 @@ class TestShareWindowHandlers:
                 )
                 await asyncio.sleep(0)
 
-            mock_select.assert_awaited_once_with("cid", owner["id"], "@0")
+            mock_select.assert_awaited_once_with(
+                "cid", owner["id"], "@0", _mock_pod
+            )
         finally:
             sockets.sessions.pop("ws-1", None)
             sockets.connections.pop(sock, None)
@@ -7976,7 +8003,7 @@ class TestSharedTerminalController:
             with patch("klangk_backend.terminal.kill_joiner_sessions") as kill:
                 await ctrl.unshare_window({"window_id": "@0"})
             assert ws.terminal_windows[user["id"]][0]["shared"] is False
-            kill.assert_awaited_once_with("cid", "uid")
+            kill.assert_awaited_once_with("cid", "uid", _mock_pod)
         finally:
             sockets.sessions.pop("ws-1", None)
 
@@ -8190,8 +8217,8 @@ class TestSharedTerminalController:
                 await ctrl.delete_shared_terminal(
                     {"user_id": "owner-1", "window_id": "@0"}
                 )
-            kill.assert_awaited_once_with("cid", "owner-1")
-            close.assert_awaited_once_with("cid", "owner-1", "@0")
+            kill.assert_awaited_once_with("cid", "owner-1", _mock_pod)
+            close.assert_awaited_once_with("cid", "owner-1", "@0", _mock_pod)
             remaining = ws.terminal_windows["owner-1"]
             assert [w["id"] for w in remaining] == ["@1"]
             sent = [c[0][0] for c in sock.send_json.call_args_list]
@@ -10106,7 +10133,7 @@ class TestTokenRenewal:
                     pass
 
             assert mock_set.call_count >= 1
-            cid, token = mock_set.call_args.args
+            cid, token, _podman = mock_set.call_args.args
             assert cid == "test-cid"
             decoded = wshandler.auth.decode_workspace_token(token)
             assert decoded == workspace["id"]
@@ -10124,7 +10151,7 @@ class TestTokenRenewal:
         try:
             call_count = 0
 
-            async def fail_then_succeed(cid, token):
+            async def fail_then_succeed(cid, token, podman=None):
                 nonlocal call_count
                 call_count += 1
                 if call_count == 1:

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -1545,7 +1545,7 @@ class TestHandleTerminalStart:
         assert conn.browser_id == "bid-new"
         assert registry.resolve_browser("bid-new") == ("ws", sock)
         assert registry.resolve_browser("bid-old") is None
-        mock_attach.assert_awaited_once_with("cid", "bid-new")
+        mock_attach.assert_awaited_once_with("cid", "bid-new", _mock_pod)
 
         registry.revoke_workspace_browsers("ws")
 
@@ -6720,7 +6720,7 @@ class TestTerminalController:
             await ctrl.browser_reattach({"browser_id": "bid"})
         rev.assert_called_once_with(conn.sock)
         reg.assert_called_once_with("bid", "ws-1", conn.sock)
-        attach.assert_awaited_once_with("cid", "bid")
+        attach.assert_awaited_once_with("cid", "bid", _mock_pod)
         assert conn.browser_id == "bid"
 
     # --- tmux_session_name ---


### PR DESCRIPTION
Closes #1468.

## What

`podman.py` was ~20 stateless subprocess-wrapper free functions that all depended
on settings via a `_podman_bin()` → `get_settings()` reacharound. Promoted them to
a `Podman(settings)` class that resolves the binary path once at construction; the
~20 functions become methods using `self._bin`.

No mutable module state was involved (only `logger`) — this is the **cohesion**
motivation called out in #1468: a shared dependency shouldn't be hidden behind a
reacharound or repeated across 20 signatures. Same framing as #1480 (terminal.py).

## Changes

**Production:**
- **`podman.py`** — `Podman(settings)` class owns `run`/`run_raw`/`inspect_container`/
  `create_container`/`start_container`/`wait_for_container_ready`/`exec_container*`/
  `remove_container`/`list_containers`/`inspect_volume`/`create_volume`/`list_volumes`/
  `remove_volume`. `_podman_bin()` + its `get_settings()` reacharound deleted
  (`self._bin` / `self.bin` instead). `ExecSession` takes the `Podman` instance.
  `classify`/`subprocess_env`/`PodmanError` stay module-level (pure).
- **`main.py`** `build_app` — `app.state.podman = Podman(settings)`; `registry.podman`
  wired (same pattern as `sockets`).
- **`container.py`** — `ContainerRegistry.podman` instance attr; callers use
  `self.podman.X`. Two `@staticmethod`s (`_ensure_volumes`, `_resolve_port_conflict`)
  take `podman` as a param.
- **`terminal.py`/`files.py`/`workspaces.py`/`agent.py`** — free functions take a
  `podman` param; callers thread `app_state.podman`. `TerminalSession`/`ShellProcess`
  carry the instance.
- **`api/files.py`, `api/images.py`, `controllers.py`, `connection.py`, `session.py`,
  `bringup.py`** — thread `app_state.podman` to callees.

**Tests:** mock-Podman instances (module-level `_mock_pod` per file) replace the
`patch("klangk_backend.X.podman.exec_container")` targets with
`patch.object(_mock_pod, ...)`; function calls take the instance as their `podman`
arg.

## Verification

- `python -m pytest src/backend/tests -v -n auto` → **2373 passed, 100% coverage**.
- `ruff check` + `ruff format` clean.
- CLI suite: 485 passed (1 pre-existing failure unrelated to this change, fails on
  clean `main` too).

## Notes

The `terminal.py` free-function param-threading is noisy (~25 signatures) and is
tracked by **#1480** (promote `terminal.py` to a `Terminal` class) for a follow-up
that collapses the repetition into `self.podman`.
