### PR TITLE
Promote terminal.py to a Terminal(podman, registry) class (#1480)

### DIFF
--- a/src/backend/klangk_backend/bringup.py
+++ b/src/backend/klangk_backend/bringup.py
@@ -15,7 +15,7 @@ workspaces whose ``setup.sh`` has not run yet is handled by gating on
 completes and the WS connect path runs.
 """
 
-from . import agent, terminal
+from . import agent
 
 
 async def bringup(
@@ -35,10 +35,9 @@ async def bringup(
     )
     if not service_command:
         return
-    await terminal.ensure_service_session(
+    await app_state.terminal.ensure_service_session(
         container_id,
         agent_home,
         service_command,
         setup_state=setup_state,
-        app_state=app_state,
     )

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -5,7 +5,7 @@ import logging
 import os
 import time
 
-from . import auth, bringup, model, plugins, podman, terminal, util
+from . import auth, bringup, model, plugins, podman, util
 from .podman import PodmanError
 from .settings import KlangkSettings
 
@@ -1373,7 +1373,7 @@ class ContainerRegistry:
         # Write the workspace token so container processes can
         # authenticate without an env-var restart.
         workspace_token = auth.create_workspace_token(workspace_id)
-        await terminal.set_workspace_token(cid, workspace_token, self.podman)
+        await self.app_state.terminal.set_workspace_token(cid, workspace_token)
 
         # Block until the entrypoint's one-time setup is done. ``podman
         # start`` returns when the entrypoint has *begun*, not finished;

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -26,6 +26,7 @@ from . import (
     plugins,
     podman,
     ssl_trust,
+    terminal,
     workspaces,
     wshandler,
 )
@@ -755,6 +756,11 @@ def build_app(settings: KlangkSettings) -> FastAPI:
     app.state.podman = podman_inst
     app.state.container_registry.podman = podman_inst
     app.state.container_registry.app_state = app.state
+    # #1480: Terminal(podman, registry) groups the ~25 tmux-session
+    # management functions that share a Podman dependency.
+    app.state.terminal = terminal.Terminal(
+        podman_inst, app.state.container_registry
+    )
     # WebSocketState reaches the registry through its own app_state
     # back-reference (send_service_health_snapshot / reset_workspace).
     # The unit-test fixtures set this explicitly; build_app must too, or

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -756,11 +756,10 @@ def build_app(settings: KlangkSettings) -> FastAPI:
     app.state.podman = podman_inst
     app.state.container_registry.podman = podman_inst
     app.state.container_registry.app_state = app.state
-    # #1480: Terminal(podman, registry) groups the ~25 tmux-session
-    # management functions that share a Podman dependency.
-    app.state.terminal = terminal.Terminal(
-        podman_inst, app.state.container_registry
-    )
+    # #1480: Terminal(app_state) groups the ~25 tmux-session
+    # management functions that share a Podman dependency. Reaches podman,
+    # the registry, and settings through the single app_state reference.
+    app.state.terminal = terminal.Terminal(app.state)
     # WebSocketState reaches the registry through its own app_state
     # back-reference (send_service_health_snapshot / reset_workspace).
     # The unit-test fixtures set this explicitly; build_app must too, or

--- a/src/backend/klangk_backend/terminal.py
+++ b/src/backend/klangk_backend/terminal.py
@@ -24,7 +24,7 @@ from collections.abc import AsyncGenerator
 from .podman import Podman, subprocess_env
 from .exceptions import TerminalError
 from .model.workspaces import SETUP_STATE_COMPLETE
-from .util import BoundedOutputQueue, resolve_env_value
+from .util import BoundedOutputQueue
 
 logger = logging.getLogger(__name__)
 
@@ -51,19 +51,6 @@ def validate_window_name(name: str) -> None:
             "Window name may only contain letters, digits,"
             " spaces, hyphens, underscores, and dots"
         )
-
-
-def terminal_tmux_enabled() -> bool:
-    """Whether new terminal sessions are wrapped in tmux.
-
-    Defaults to enabled (the historical behaviour).  Set
-    ``KLANGK_DISABLE_TMUX`` to a truthy value (``1``/``true``/``yes``) to
-    drop users straight into a plain login shell instead.  Note this only
-    affects the default per-user terminal; shared/joined terminals are
-    built on tmux session groups and always use tmux regardless.
-    """
-    val = resolve_env_value("KLANGK_DISABLE_TMUX", "") or ""
-    return val.lower() not in ("1", "true", "yes")
 
 
 # Backend env vars stripped from the in-container shell.
@@ -230,14 +217,34 @@ class Terminal:
     :class:`~klangk_backend.podman.Podman` dependency.
 
     Constructed once in :func:`build_app` and stored on
-    ``app.state.terminal`` (#1480). The podman instance carries the
-    resolved binary path + CLI wrappers; the registry provides the
-    per-container service-firing lock (#1188).
+    ``app.state.terminal`` (#1480). Reaches its dependencies — podman
+    (resolved binary path + CLI wrappers), the container registry
+    (per-container service-firing lock, #1188), and settings — through a
+    single ``app_state`` reference rather than three separate ctor args.
     """
 
-    def __init__(self, podman: Podman, registry):
-        self.podman = podman
-        self._registry = registry
+    def __init__(self, app_state=None):
+        self._app_state = app_state
+
+    @property
+    def podman(self) -> Podman:
+        return self._app_state.podman
+
+    @property
+    def registry(self):
+        return self._app_state.container_registry
+
+    def tmux_enabled(self) -> bool:
+        """Whether new terminal sessions are wrapped in tmux.
+
+        Defaults to enabled (the historical behaviour).  Set
+        ``KLANGK_DISABLE_TMUX`` to a truthy value (``1``/``true``/``yes``) to
+        drop users straight into a plain login shell instead.  Note this only
+        affects the default per-user terminal; shared/joined terminals are
+        built on tmux session groups and always use tmux regardless.
+        """
+        val = (self._app_state.settings.disable_tmux or "").lower()
+        return val not in ("1", "true", "yes")
 
     # --- tmux session / window queries ---
 
@@ -382,7 +389,7 @@ class Terminal:
         # collaborator) cannot interleave: the second waits, then observes
         # the window exists and no-ops. This also bounds the partial-failure
         # window from #1186.
-        async with self._registry.get_service_session_lock(container_id):
+        async with self.registry.get_service_session_lock(container_id):
             await self._ensure_tmux_session(
                 container_id, SERVICE_SESSION, agent_home
             )
@@ -439,7 +446,7 @@ class Terminal:
                 # on a successful send-keys; the except path below never
                 # launched the command, so it must not start the grace
                 # window.
-                self._registry.mark_service_started(container_id)
+                self.registry.mark_service_started(container_id)
             except Exception:
                 logger.warning(
                     "Failed to send service command to %s", SERVICE_SESSION
@@ -881,7 +888,7 @@ class TerminalSession:
             self.session_name
             and not self.join_session
             and not self.socket_path
-            and terminal_tmux_enabled()
+            and self._terminal.tmux_enabled()
         ):
             await self._terminal.ensure_base_session(
                 self.container_id,
@@ -901,7 +908,7 @@ class TerminalSession:
             socket_path=self.socket_path,
             join_session=self.join_session,
             read_only=self.read_only,
-            tmux_enabled=terminal_tmux_enabled(),
+            tmux_enabled=self._terminal.tmux_enabled(),
             ssh_agent_socket=self.ssh_agent_socket,
         )
         work_dir = "/home"

--- a/src/backend/klangk_backend/terminal.py
+++ b/src/backend/klangk_backend/terminal.py
@@ -21,7 +21,7 @@ import termios
 import tty
 from collections.abc import AsyncGenerator
 
-from .podman import subprocess_env
+from .podman import Podman, subprocess_env
 from .exceptions import TerminalError
 from .model.workspaces import SETUP_STATE_COMPLETE
 from .util import BoundedOutputQueue, resolve_env_value
@@ -33,6 +33,11 @@ CONTAINER_USER = "klangk"
 
 _SAFE_WINDOW_NAME = re.compile(r"^[A-Za-z0-9 _.\-]+$")
 _MAX_WINDOW_NAME_LEN = 64
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers (no podman dependency — stay module-level)
+# ---------------------------------------------------------------------------
 
 
 def validate_window_name(name: str) -> None:
@@ -102,62 +107,6 @@ SERVICE_CMD_WINDOW = "service-cmd"
 # dying because it is just a tmux session) (#1133 D6).
 SERVICE_SESSION = "service"
 
-# The per-container service-firing lock lives on ContainerRegistry as
-# _service_session_locks (#1188, #1478). It used to live here at module scope;
-# terminal.ensure_service_session now reaches it via
-# app_state.container_registry.get_service_session_lock().
-
-
-async def has_tmux_session(
-    container_id: str, session_name: str, podman
-) -> bool:
-    """Return True if a tmux session named *session_name* exists."""
-    try:
-        rc, _, _ = await podman.exec_container(
-            container_id,
-            ["tmux", "has-session", "-t", session_name],
-            user=CONTAINER_USER,
-            timeout=5,
-        )
-    except Exception:
-        return False
-    return rc == 0
-
-
-async def service_cmd_window_exists(
-    container_id: str, session_name: str, podman
-) -> bool:
-    """Return True if the ``service-cmd`` window exists in *session_name*.
-
-    This is the ephemeral "has the service command already fired in
-    THIS container" check (#1033). Unlike ``setup_state`` it is
-    per-container: it resets on container recreation, so the boot path
-    re-fires the service command for an already-``complete`` workspace.
-    tmux allows duplicate window names, so we must inspect the list
-    rather than rely on ``new-window`` failing.
-    """
-    try:
-        rc, stdout, _ = await podman.exec_container(
-            container_id,
-            [
-                "tmux",
-                "list-windows",
-                "-t",
-                session_name,
-                "-F",
-                "#{window_name}",
-            ],
-            user=CONTAINER_USER,
-            timeout=5,
-        )
-    except Exception:
-        return False
-    if rc != 0:
-        return False
-    return SERVICE_CMD_WINDOW in {
-        line.strip() for line in stdout.splitlines() if line.strip()
-    }
-
 
 def should_fire_service_command(
     service_command: str | None, setup_state: str
@@ -171,192 +120,12 @@ def should_fire_service_command(
     there is no ``None`` case to handle here.
 
     The other half -- "the service-cmd window doesn't already exist" --
-    is checked by the caller via :func:`service_cmd_window_exists`,
+    is checked by the caller via :meth:`Terminal.service_cmd_window_exists`,
     since it is per-container and ephemeral.
     """
     if not service_command:
         return False
     return setup_state == SETUP_STATE_COMPLETE
-
-
-async def _ensure_tmux_session(
-    container_id: str,
-    session_name: str,
-    user_home: str | None = None,
-    ssh_agent_socket: str | None = None,
-    podman=None,
-) -> bool:
-    """Ensure a detached base tmux session exists for *session_name*.
-
-    Idempotent: returns ``True`` if the session was freshly created,
-    ``False`` if it already existed or could not be created. HOME and
-    SSH_AUTH_SOCK are passed as tmux ``-e`` flags (part of the command,
-    not podman's), so the session's window-0 shell sources the right
-    profile.
-    """
-    if await has_tmux_session(container_id, session_name, podman):
-        return False
-    env_args: list[str] = []
-    if user_home is not None:
-        env_args += ["-e", f"HOME={user_home}"]
-    if ssh_agent_socket is not None:
-        env_args += ["-e", f"SSH_AUTH_SOCK={ssh_agent_socket}"]
-    try:
-        await podman.exec_container(
-            container_id,
-            ["tmux", "new-session", "-d", "-s", session_name, *env_args],
-            user=CONTAINER_USER,
-            timeout=10,
-        )
-    except Exception:
-        logger.warning("Failed to create base tmux session %s", session_name)
-        return False
-    return True
-
-
-async def ensure_base_session(
-    container_id: str,
-    session_name: str,
-    user_home: str | None = None,
-    ssh_agent_socket: str | None = None,
-    podman=None,
-) -> bool:
-    """Ensure the firing user's base tmux session + window 0 exist.
-
-    Idempotent: returns ``True`` if the session was freshly created.
-    The service command no longer lives in any user's session -- it
-    runs in the standalone ``service`` session owned by the agent
-    identity (see :func:`ensure_service_session`), so this is purely
-    the interactive-shell session every ``terminal_start`` needs
-    regardless of setup state (#1133).
-    """
-    return await _ensure_tmux_session(
-        container_id, session_name, user_home, ssh_agent_socket, podman
-    )
-
-
-async def ensure_service_session(
-    container_id: str,
-    agent_home: str,
-    service_command: str,
-    setup_state: str = SETUP_STATE_COMPLETE,
-    app_state=None,
-) -> None:
-    """Ensure the standalone ``service`` session; maybe fire service-cmd.
-
-    The workspace's service command runs in a tmux session with a
-    CONSTANT name ``service`` (not the owner's id), with the
-    ``service-cmd`` window inside it -> ``service:service-cmd``. The
-    session is owned by the agent identity and decoupled from both the
-    owner's interactive session and the ``pi --mode rpc`` subprocess
-    lifecycle -- it survives the agent subprocess dying/restarting
-    because it is just a tmux session (#1133 D6).
-
-    *agent_home* (e.g. ``/home/clanker``) is the session's HOME. The
-    service command fires iff the predicate holds (configured AND setup
-    complete) AND the ``service-cmd`` window doesn't already exist
-    (exactly-once-per-container). Idempotent: safe to call from every
-    ``terminal_start`` (#1033) and the boot path alike -- the
-    window-exists check makes it a no-op after the first fire.
-
-    The window-exists -> new-window -> send-keys sequence is serialized
-    per container via the registry's service-session lock (#1188): without
-    it the boot path and the per-connection path could both pass the
-    existence check before either created the window, producing two
-    duplicate-named ``service-cmd`` windows (tmux allows duplicate
-    names), leaving later ``send-keys -t service:service-cmd`` ambiguous.
-    The lock is reached via ``app_state.container_registry`` (#1478).
-    """
-    # Hold the per-container lock across the entire read-modify-write so
-    # a concurrent caller (boot vs first terminal_start, owner vs
-    # collaborator) cannot interleave: the second waits, then observes
-    # the window exists and no-ops. This also bounds the partial-failure
-    # window from #1186.
-    async with app_state.container_registry.get_service_session_lock(
-        container_id
-    ):
-        await _ensure_tmux_session(
-            container_id, SERVICE_SESSION, agent_home, podman=app_state.podman
-        )
-        if not (
-            should_fire_service_command(service_command, setup_state)
-        ) or await service_cmd_window_exists(
-            container_id, SERVICE_SESSION, app_state.podman
-        ):
-            return
-        try:
-            await app_state.podman.exec_container(
-                container_id,
-                [
-                    "tmux",
-                    "new-window",
-                    "-d",
-                    "-t",
-                    SERVICE_SESSION,
-                    "-n",
-                    SERVICE_CMD_WINDOW,
-                ],
-                user=CONTAINER_USER,
-                timeout=5,
-            )
-        except Exception:
-            logger.warning(
-                "Failed to create %s window in %s",
-                SERVICE_CMD_WINDOW,
-                SERVICE_SESSION,
-            )
-            return
-        # The new window's shell needs a moment to source .profile / .bashrc
-        # before it can resolve PATH-dependent commands (nvm, openclaw, ...).
-        # Same race as #1030.
-        await asyncio.sleep(1)
-        try:
-            await app_state.podman.exec_container(
-                container_id,
-                [
-                    "tmux",
-                    "send-keys",
-                    "-t",
-                    f"{SERVICE_SESSION}:{SERVICE_CMD_WINDOW}",
-                    service_command,
-                    "Enter",
-                ],
-                user=CONTAINER_USER,
-                timeout=5,
-            )
-            # The service command just fired -- reset the health-check
-            # startup-grace anchor so the monitor gives the service time
-            # to boot before a failing poll can flag it unhealthy (e.g.
-            # a gateway that isn't accepting connections yet).  Set only
-            # on a successful send-keys; the except path below never
-            # launched the command, so it must not start the grace
-            # window.
-            app_state.container_registry.mark_service_started(container_id)
-        except Exception:
-            logger.warning(
-                "Failed to send service command to %s", SERVICE_SESSION
-            )
-            # The window was created above but we never typed the command
-            # into it. Kill it so the next fire re-runs the whole sequence
-            # instead of no-op'ing forever on the half-created window (#1186).
-            try:
-                await app_state.podman.exec_container(
-                    container_id,
-                    [
-                        "tmux",
-                        "kill-window",
-                        "-t",
-                        f"{SERVICE_SESSION}:{SERVICE_CMD_WINDOW}",
-                    ],
-                    user=CONTAINER_USER,
-                    timeout=5,
-                )
-            except Exception:
-                logger.warning(
-                    "Failed to clean up %s window in %s",
-                    SERVICE_CMD_WINDOW,
-                    SERVICE_SESSION,
-                )
 
 
 def build_shell_command(
@@ -451,272 +220,513 @@ def _build_exec_argv(
     return argv
 
 
-async def attach_browser(container_id: str, browser_id: str, podman) -> None:
-    """Run ``klangk-attach-browser <browser_id>`` inside the container.
+# ---------------------------------------------------------------------------
+# Terminal — tmux-session management (cohesion over a shared Podman dep, #1480)
+# ---------------------------------------------------------------------------
 
-    This stores the browser ID in the tmux global environment so that
-    ``klangk-browser-id`` can read it dynamically.  Called after each
-    ``terminal_start`` (including re-attach after browser refresh).
+
+class Terminal:
+    """Groups the ~25 tmux-session management functions that share a
+    :class:`~klangk_backend.podman.Podman` dependency.
+
+    Constructed once in :func:`build_app` and stored on
+    ``app.state.terminal`` (#1480). The podman instance carries the
+    resolved binary path + CLI wrappers; the registry provides the
+    per-container service-firing lock (#1188).
     """
-    rc, _stdout, stderr = await podman.exec_container(
-        container_id,
-        ["klangk-attach-browser", browser_id],
-        user=CONTAINER_USER,
-        timeout=10,
-    )
-    if rc != 0:
-        logger.warning(
-            "klangk-attach-browser failed (rc=%d): %s",
-            rc,
-            stderr.strip(),
+
+    def __init__(self, podman: Podman, registry):
+        self.podman = podman
+        self._registry = registry
+
+    # --- tmux session / window queries ---
+
+    async def has_tmux_session(
+        self, container_id: str, session_name: str
+    ) -> bool:
+        """Return True if a tmux session named *session_name* exists."""
+        try:
+            rc, _, _ = await self.podman.exec_container(
+                container_id,
+                ["tmux", "has-session", "-t", session_name],
+                user=CONTAINER_USER,
+                timeout=5,
+            )
+        except Exception:
+            return False
+        return rc == 0
+
+    async def service_cmd_window_exists(
+        self, container_id: str, session_name: str
+    ) -> bool:
+        """Return True if the ``service-cmd`` window exists in *session_name*.
+
+        This is the ephemeral "has the service command already fired in
+        THIS container" check (#1033). Unlike ``setup_state`` it is
+        per-container: it resets on container recreation, so the boot path
+        re-fires the service command for an already-``complete`` workspace.
+        tmux allows duplicate window names, so we must inspect the list
+        rather than rely on ``new-window`` failing.
+        """
+        try:
+            rc, stdout, _ = await self.podman.exec_container(
+                container_id,
+                [
+                    "tmux",
+                    "list-windows",
+                    "-t",
+                    session_name,
+                    "-F",
+                    "#{window_name}",
+                ],
+                user=CONTAINER_USER,
+                timeout=5,
+            )
+        except Exception:
+            return False
+        if rc != 0:
+            return False
+        return SERVICE_CMD_WINDOW in {
+            line.strip() for line in stdout.splitlines() if line.strip()
+        }
+
+    async def _ensure_tmux_session(
+        self,
+        container_id: str,
+        session_name: str,
+        user_home: str | None = None,
+        ssh_agent_socket: str | None = None,
+    ) -> bool:
+        """Ensure a detached base tmux session exists for *session_name*.
+
+        Idempotent: returns ``True`` if the session was freshly created,
+        ``False`` if it already existed or could not be created. HOME and
+        SSH_AUTH_SOCK are passed as tmux ``-e`` flags (part of the command,
+        not podman's), so the session's window-0 shell sources the right
+        profile.
+        """
+        if await self.has_tmux_session(container_id, session_name):
+            return False
+        env_args: list[str] = []
+        if user_home is not None:
+            env_args += ["-e", f"HOME={user_home}"]
+        if ssh_agent_socket is not None:
+            env_args += ["-e", f"SSH_AUTH_SOCK={ssh_agent_socket}"]
+        try:
+            await self.podman.exec_container(
+                container_id,
+                ["tmux", "new-session", "-d", "-s", session_name, *env_args],
+                user=CONTAINER_USER,
+                timeout=10,
+            )
+        except Exception:
+            logger.warning(
+                "Failed to create base tmux session %s", session_name
+            )
+            return False
+        return True
+
+    async def ensure_base_session(
+        self,
+        container_id: str,
+        session_name: str,
+        user_home: str | None = None,
+        ssh_agent_socket: str | None = None,
+    ) -> bool:
+        """Ensure the firing user's base tmux session + window 0 exist.
+
+        Idempotent: returns ``True`` if the session was freshly created.
+        The service command no longer lives in any user's session -- it
+        runs in the standalone ``service`` session owned by the agent
+        identity (see :meth:`ensure_service_session`), so this is purely
+        the interactive-shell session every ``terminal_start`` needs
+        regardless of setup state (#1133).
+        """
+        return await self._ensure_tmux_session(
+            container_id, session_name, user_home, ssh_agent_socket
         )
 
+    async def ensure_service_session(
+        self,
+        container_id: str,
+        agent_home: str,
+        service_command: str,
+        setup_state: str = SETUP_STATE_COMPLETE,
+    ) -> None:
+        """Ensure the standalone ``service`` session; maybe fire service-cmd.
 
-async def set_workspace_token(container_id: str, token: str, podman) -> None:
-    """Write a workspace token to ``/run/klangk/workspace-token`` inside
-    the container via ``klangk-set-workspace-token``.
-    """
-    rc, _stdout, stderr = await podman.exec_container(
-        container_id,
-        ["klangk-set-workspace-token", token],
-        user=CONTAINER_USER,
-        timeout=10,
-    )
-    if rc != 0:
-        logger.warning(
-            "klangk-set-workspace-token failed (rc=%d): %s",
-            rc,
-            stderr.strip(),
-        )
+        The workspace's service command runs in a tmux session with a
+        CONSTANT name ``service`` (not the owner's id), with the
+        ``service-cmd`` window inside it -> ``service:service-cmd``. The
+        session is owned by the agent identity and decoupled from both the
+        owner's interactive session and the ``pi --mode rpc`` subprocess
+        lifecycle -- it survives the agent subprocess dying/restarting
+        because it is just a tmux session (#1133 D6).
 
+        *agent_home* (e.g. ``/home/clanker``) is the session's HOME. The
+        service command fires iff the predicate holds (configured AND setup
+        complete) AND the ``service-cmd`` window doesn't already exist
+        (exactly-once-per-container). Idempotent: safe to call from every
+        ``terminal_start`` (#1033) and the boot path alike -- the
+        window-exists check makes it a no-op after the first fire.
 
-async def tmux_command(
-    container_id: str, session_name: str, args: list[str], podman
-) -> str:
-    """Run a tmux command in the container and return stdout.
+        The window-exists -> new-window -> send-keys sequence is serialized
+        per container via the registry's service-session lock (#1188): without
+        it the boot path and the per-connection path could both pass the
+        existence check before either created the window, producing two
+        duplicate-named ``service-cmd`` windows (tmux allows duplicate
+        names), leaving later ``send-keys -t service:service-cmd`` ambiguous.
+        """
+        # Hold the per-container lock across the entire read-modify-write so
+        # a concurrent caller (boot vs first terminal_start, owner vs
+        # collaborator) cannot interleave: the second waits, then observes
+        # the window exists and no-ops. This also bounds the partial-failure
+        # window from #1186.
+        async with self._registry.get_service_session_lock(container_id):
+            await self._ensure_tmux_session(
+                container_id, SERVICE_SESSION, agent_home
+            )
+            if not (
+                should_fire_service_command(service_command, setup_state)
+            ) or await self.service_cmd_window_exists(
+                container_id, SERVICE_SESSION
+            ):
+                return
+            try:
+                await self.podman.exec_container(
+                    container_id,
+                    [
+                        "tmux",
+                        "new-window",
+                        "-d",
+                        "-t",
+                        SERVICE_SESSION,
+                        "-n",
+                        SERVICE_CMD_WINDOW,
+                    ],
+                    user=CONTAINER_USER,
+                    timeout=5,
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to create %s window in %s",
+                    SERVICE_CMD_WINDOW,
+                    SERVICE_SESSION,
+                )
+                return
+            # The new window's shell needs a moment to source .profile / .bashrc
+            # before it can resolve PATH-dependent commands (nvm, openclaw, ...).
+            # Same race as #1030.
+            await asyncio.sleep(1)
+            try:
+                await self.podman.exec_container(
+                    container_id,
+                    [
+                        "tmux",
+                        "send-keys",
+                        "-t",
+                        f"{SERVICE_SESSION}:{SERVICE_CMD_WINDOW}",
+                        service_command,
+                        "Enter",
+                    ],
+                    user=CONTAINER_USER,
+                    timeout=5,
+                )
+                # The service command just fired -- reset the health-check
+                # startup-grace anchor so the monitor gives the service time
+                # to boot before a failing poll can flag it unhealthy (e.g.
+                # a gateway that isn't accepting connections yet).  Set only
+                # on a successful send-keys; the except path below never
+                # launched the command, so it must not start the grace
+                # window.
+                self._registry.mark_service_started(container_id)
+            except Exception:
+                logger.warning(
+                    "Failed to send service command to %s", SERVICE_SESSION
+                )
+                # The window was created above but we never typed the command
+                # into it. Kill it so the next fire re-runs the whole sequence
+                # instead of no-op'ing forever on the half-created window (#1186).
+                try:
+                    await self.podman.exec_container(
+                        container_id,
+                        [
+                            "tmux",
+                            "kill-window",
+                            "-t",
+                            f"{SERVICE_SESSION}:{SERVICE_CMD_WINDOW}",
+                        ],
+                        user=CONTAINER_USER,
+                        timeout=5,
+                    )
+                except Exception:
+                    logger.warning(
+                        "Failed to clean up %s window in %s",
+                        SERVICE_CMD_WINDOW,
+                        SERVICE_SESSION,
+                    )
 
-    Retries up to 3 times on socket-not-found errors, which can occur
-    when the tmux server is still starting in a fresh container.
-    """
-    for attempt in range(3):
-        rc, stdout, stderr = await podman.exec_container(
+    # --- container-side helpers ---
+
+    async def attach_browser(self, container_id: str, browser_id: str) -> None:
+        """Run ``klangk-attach-browser <browser_id>`` inside the container.
+
+        This stores the browser ID in the tmux global environment so that
+        ``klangk-browser-id`` can read it dynamically.  Called after each
+        ``terminal_start`` (including re-attach after browser refresh).
+        """
+        rc, _stdout, stderr = await self.podman.exec_container(
             container_id,
-            ["tmux", *args],
+            ["klangk-attach-browser", browser_id],
             user=CONTAINER_USER,
             timeout=10,
         )
-        if rc == 0:
-            return stdout
-        if "No such file or directory" in stderr and attempt < 2:
-            await asyncio.sleep(0.5)
-            continue
-        raise TerminalError(f"tmux command failed: {stderr.strip()}")
-    return ""  # pragma: no cover
-
-
-async def list_windows(
-    container_id: str, session_name: str, podman
-) -> list[dict]:
-    """List tmux windows for a session. Returns [{index, name}, ...]."""
-    output = await tmux_command(
-        container_id,
-        session_name,
-        [
-            "list-windows",
-            "-t",
-            session_name,
-            "-F",
-            "#{window_id}|||#{window_index}|||#{window_name}|||#{window_active}",
-        ],
-        podman,
-    )
-    windows = []
-    for line in output.strip().splitlines():
-        parts = line.split("|||")
-        if len(parts) >= 4:
-            windows.append(
-                {
-                    "id": parts[0],  # e.g. "@0" — unique, never reused
-                    "index": int(parts[1]),
-                    "name": parts[2],
-                    "active": parts[3] == "1",
-                }
+        if rc != 0:
+            logger.warning(
+                "klangk-attach-browser failed (rc=%d): %s",
+                rc,
+                stderr.strip(),
             )
-    return windows
 
-
-async def new_window(
-    container_id: str,
-    session_name: str,
-    name: str | None = None,
-    podman=None,
-) -> list[dict]:
-    """Create a new tmux window and return the updated window list.
-
-    If *name* is not provided, auto-generates a unique name.
-    Raises ``ValueError`` if *name* duplicates an existing window name.
-
-    Uses a single podman exec with a shell script to minimize
-    round-trips (list + create + list in one call).
-    """
-    if name is not None:
-        validate_window_name(name)
-        # Explicit name — check + create + list in one exec. The window
-        # name and session name are passed as positional argv ($1/$2),
-        # never interpolated into the script, so shell metacharacters in
-        # either are harmless (name is validated above regardless).
-        script = (
-            'name="$1"; sn="$2";'
-            ' existing=$(tmux list-windows -t "$sn"'
-            " -F '#{window_name}' 2>/dev/null);"
-            ' echo "$existing" | grep -qx "$name"'
-            " && echo 'DUPLICATE' && exit 1;"
-            ' tmux new-window -t "$sn" -n "$name";'
-            ' tmux list-windows -t "$sn"'
-            " -F '#{window_id}|||#{window_index}|||#{window_name}|||#{window_active}'"
-        )
-        argv = ["bash", "-c", script, "bash", name, session_name]
-    else:
-        # Auto-name — find next number, create, list. session_name is $1.
-        script = (
-            'sn="$1";'
-            ' names=$(tmux list-windows -t "$sn"'
-            " -F '#{window_name}' 2>/dev/null);"
-            ' n=1; while echo "$names" | grep -qx "$n"; do n=$((n+1)); done;'
-            ' tmux new-window -t "$sn" -n "$n";'
-            ' tmux list-windows -t "$sn"'
-            " -F '#{window_id}|||#{window_index}|||#{window_name}|||#{window_active}'"
-        )
-        argv = ["bash", "-c", script, "bash", session_name]
-    rc, output, stderr = await podman.exec_container(
-        container_id,
-        argv,
-        user=CONTAINER_USER,
-        timeout=10,
-    )
-    if rc != 0:
-        if "DUPLICATE" in output:
-            raise ValueError(f"Window name '{name}' already exists")
-        raise TerminalError(f"new_window failed: {stderr.strip()}")
-    windows = []
-    for line in output.strip().splitlines():
-        parts = line.split("|||")
-        if len(parts) >= 4:
-            windows.append(
-                {
-                    "id": parts[0],
-                    "index": int(parts[1]),
-                    "name": parts[2],
-                    "active": parts[3] == "1",
-                }
-            )
-    return windows
-
-
-async def rename_window(
-    container_id: str,
-    session_name: str,
-    index: int,
-    name: str,
-    podman,
-) -> None:
-    """Rename a tmux window.
-
-    Raises ``ValueError`` if *name* contains unsafe characters or
-    duplicates another window's name.
-    """
-    validate_window_name(name)
-    existing = await list_windows(container_id, session_name, podman)
-    if any(w["name"] == name and w["index"] != index for w in existing):
-        raise ValueError(f"Window name '{name}' already exists")
-    await tmux_command(
-        container_id,
-        session_name,
-        ["rename-window", "-t", f"{session_name}:{index}", name],
-        podman,
-    )
-
-
-async def select_window(
-    container_id: str,
-    session_name: str,
-    target: int | str,
-    podman,
-) -> None:
-    """Switch the active tmux window.
-
-    *target* can be a window index (int), window name (str), or
-    window id (``@N`` string — preferred, globally unique).
-    """
-    # Window IDs (@N) can be used directly as targets without
-    # a session prefix.
-    if isinstance(target, str) and target.startswith("@"):
-        t = target
-    else:
-        t = f"{session_name}:{target}"
-    await tmux_command(
-        container_id,
-        session_name,
-        ["select-window", "-t", t],
-        podman,
-    )
-
-
-async def close_window(
-    container_id: str,
-    session_name: str,
-    target: int | str,
-    podman,
-) -> list[dict]:
-    """Close a tmux window and return the updated window list.
-
-    *target* can be a window index (int), window name (str), or
-    window id (``@N`` string — preferred, globally unique).
-    """
-    if isinstance(target, str) and target.startswith("@"):
-        t = target
-    else:
-        t = f"{session_name}:{target}"
-    await tmux_command(
-        container_id,
-        session_name,
-        ["kill-window", "-t", t],
-        podman,
-    )
-    return await list_windows(container_id, session_name, podman)
-
-
-async def kill_joiner_sessions(
-    container_id: str, owner_handle: str, podman
-) -> None:
-    """Kill all session-group sessions except the owner's own session.
-
-    Used when unsharing to disconnect spectators/collaborators.
-    """
-    try:
-        output = await tmux_command(
+    async def set_workspace_token(self, container_id: str, token: str) -> None:
+        """Write a workspace token to ``/run/klangk/workspace-token`` inside
+        the container via ``klangk-set-workspace-token``.
+        """
+        rc, _stdout, stderr = await self.podman.exec_container(
             container_id,
-            owner_handle,
-            [
-                "list-sessions",
-                "-F",
-                "#{session_name}",
-            ],
-            podman,
+            ["klangk-set-workspace-token", token],
+            user=CONTAINER_USER,
+            timeout=10,
         )
-        for session_name in output.strip().splitlines():
-            if session_name != owner_handle:
-                try:
-                    await tmux_command(
-                        container_id,
-                        owner_handle,
-                        ["kill-session", "-t", session_name],
-                        podman,
-                    )
-                except TerminalError:
-                    pass  # Session may have already exited
-    except TerminalError:
-        pass  # No sessions
+        if rc != 0:
+            logger.warning(
+                "klangk-set-workspace-token failed (rc=%d): %s",
+                rc,
+                stderr.strip(),
+            )
+
+    # --- tmux command primitives ---
+
+    async def tmux_command(
+        self, container_id: str, session_name: str, args: list[str]
+    ) -> str:
+        """Run a tmux command in the container and return stdout.
+
+        Retries up to 3 times on socket-not-found errors, which can occur
+        when the tmux server is still starting in a fresh container.
+        """
+        for attempt in range(3):
+            rc, stdout, stderr = await self.podman.exec_container(
+                container_id,
+                ["tmux", *args],
+                user=CONTAINER_USER,
+                timeout=10,
+            )
+            if rc == 0:
+                return stdout
+            if "No such file or directory" in stderr and attempt < 2:
+                await asyncio.sleep(0.5)
+                continue
+            raise TerminalError(f"tmux command failed: {stderr.strip()}")
+        return ""  # pragma: no cover
+
+    async def list_windows(
+        self, container_id: str, session_name: str
+    ) -> list[dict]:
+        """List tmux windows for a session. Returns [{index, name}, ...]."""
+        output = await self.tmux_command(
+            container_id,
+            session_name,
+            [
+                "list-windows",
+                "-t",
+                session_name,
+                "-F",
+                "#{window_id}|||#{window_index}|||#{window_name}|||#{window_active}",
+            ],
+        )
+        windows = []
+        for line in output.strip().splitlines():
+            parts = line.split("|||")
+            if len(parts) >= 4:
+                windows.append(
+                    {
+                        "id": parts[0],  # e.g. "@0" — unique, never reused
+                        "index": int(parts[1]),
+                        "name": parts[2],
+                        "active": parts[3] == "1",
+                    }
+                )
+        return windows
+
+    async def new_window(
+        self,
+        container_id: str,
+        session_name: str,
+        name: str | None = None,
+    ) -> list[dict]:
+        """Create a new tmux window and return the updated window list.
+
+        If *name* is not provided, auto-generates a unique name.
+        Raises ``ValueError`` if *name* duplicates an existing window name.
+
+        Uses a single podman exec with a shell script to minimize
+        round-trips (list + create + list in one call).
+        """
+        if name is not None:
+            validate_window_name(name)
+            # Explicit name — check + create + list in one exec. The window
+            # name and session name are passed as positional argv ($1/$2),
+            # never interpolated into the script, so shell metacharacters in
+            # either are harmless (name is validated above regardless).
+            script = (
+                'name="$1"; sn="$2";'
+                ' existing=$(tmux list-windows -t "$sn"'
+                " -F '#{window_name}' 2>/dev/null);"
+                ' echo "$existing" | grep -qx "$name"'
+                " && echo 'DUPLICATE' && exit 1;"
+                ' tmux new-window -t "$sn" -n "$name";'
+                ' tmux list-windows -t "$sn"'
+                " -F '#{window_id}|||#{window_index}|||#{window_name}|||#{window_active}'"
+            )
+            argv = ["bash", "-c", script, "bash", name, session_name]
+        else:
+            # Auto-name — find next number, create, list. session_name is $1.
+            script = (
+                'sn="$1";'
+                ' names=$(tmux list-windows -t "$sn"'
+                " -F '#{window_name}' 2>/dev/null);"
+                ' n=1; while echo "$names" | grep -qx "$n"; do n=$((n+1)); done;'
+                ' tmux new-window -t "$sn" -n "$n";'
+                ' tmux list-windows -t "$sn"'
+                " -F '#{window_id}|||#{window_index}|||#{window_name}|||#{window_active}'"
+            )
+            argv = ["bash", "-c", script, "bash", session_name]
+        rc, output, stderr = await self.podman.exec_container(
+            container_id,
+            argv,
+            user=CONTAINER_USER,
+            timeout=10,
+        )
+        if rc != 0:
+            if "DUPLICATE" in output:
+                raise ValueError(f"Window name '{name}' already exists")
+            raise TerminalError(f"new_window failed: {stderr.strip()}")
+        windows = []
+        for line in output.strip().splitlines():
+            parts = line.split("|||")
+            if len(parts) >= 4:
+                windows.append(
+                    {
+                        "id": parts[0],
+                        "index": int(parts[1]),
+                        "name": parts[2],
+                        "active": parts[3] == "1",
+                    }
+                )
+        return windows
+
+    async def rename_window(
+        self,
+        container_id: str,
+        session_name: str,
+        index: int,
+        name: str,
+    ) -> None:
+        """Rename a tmux window.
+
+        Raises ``ValueError`` if *name* contains unsafe characters or
+        duplicates another window's name.
+        """
+        validate_window_name(name)
+        existing = await self.list_windows(container_id, session_name)
+        if any(w["name"] == name and w["index"] != index for w in existing):
+            raise ValueError(f"Window name '{name}' already exists")
+        await self.tmux_command(
+            container_id,
+            session_name,
+            ["rename-window", "-t", f"{session_name}:{index}", name],
+        )
+
+    async def select_window(
+        self,
+        container_id: str,
+        session_name: str,
+        target: int | str,
+    ) -> None:
+        """Switch the active tmux window.
+
+        *target* can be a window index (int), window name (str), or
+        window id (``@N`` string — preferred, globally unique).
+        """
+        # Window IDs (@N) can be used directly as targets without
+        # a session prefix.
+        if isinstance(target, str) and target.startswith("@"):
+            t = target
+        else:
+            t = f"{session_name}:{target}"
+        await self.tmux_command(
+            container_id,
+            session_name,
+            ["select-window", "-t", t],
+        )
+
+    async def close_window(
+        self,
+        container_id: str,
+        session_name: str,
+        target: int | str,
+    ) -> list[dict]:
+        """Close a tmux window and return the updated window list.
+
+        *target* can be a window index (int), window name (str), or
+        window id (``@N`` string — preferred, globally unique).
+        """
+        if isinstance(target, str) and target.startswith("@"):
+            t = target
+        else:
+            t = f"{session_name}:{target}"
+        await self.tmux_command(
+            container_id,
+            session_name,
+            ["kill-window", "-t", t],
+        )
+        return await self.list_windows(container_id, session_name)
+
+    async def kill_joiner_sessions(
+        self, container_id: str, owner_handle: str
+    ) -> None:
+        """Kill all session-group sessions except the owner's own session.
+
+        Used when unsharing to disconnect spectators/collaborators.
+        """
+        try:
+            output = await self.tmux_command(
+                container_id,
+                owner_handle,
+                [
+                    "list-sessions",
+                    "-F",
+                    "#{session_name}",
+                ],
+            )
+            for session_name in output.strip().splitlines():
+                if session_name != owner_handle:
+                    try:
+                        await self.tmux_command(
+                            container_id,
+                            owner_handle,
+                            ["kill-session", "-t", session_name],
+                        )
+                    except TerminalError:
+                        pass  # Session may have already exited
+        except TerminalError:
+            pass  # No sessions
+
+
+# ---------------------------------------------------------------------------
+# Shell process (PTY layer — needs podman.bin, no Terminal ref)
+# ---------------------------------------------------------------------------
 
 
 class ShellProcess:
@@ -813,6 +823,11 @@ def make_shell_process(podman=None) -> ShellProcess:
     return ShellProcess(podman)
 
 
+# ---------------------------------------------------------------------------
+# Interactive terminal session (PTY shell — orchestrates Terminal + ShellProcess)
+# ---------------------------------------------------------------------------
+
+
 class TerminalSession:
     """Manages an interactive shell session over a PTY."""
 
@@ -827,10 +842,10 @@ class TerminalSession:
         user_id: str | None = None,
         user_handle: str | None = None,
         ssh_agent_socket: str | None = None,
-        podman=None,
+        terminal: Terminal | None = None,
     ):
         self.container_id = container_id
-        self._podman = podman
+        self._terminal = terminal
         self.session_name = session_name
         self.user_home = user_home
         self.socket_path = socket_path
@@ -846,6 +861,11 @@ class TerminalSession:
         self._running = False
         self._read_task: asyncio.Task | None = None
         self.tmux_session_name: str | None = None
+
+    @property
+    def _podman(self):
+        """Reach podman via the Terminal instance (#1480)."""
+        return self._terminal.podman
 
     async def start(
         self,
@@ -863,12 +883,11 @@ class TerminalSession:
             and not self.socket_path
             and terminal_tmux_enabled()
         ):
-            await ensure_base_session(
+            await self._terminal.ensure_base_session(
                 self.container_id,
                 self.session_name,
                 user_home=self.user_home,
                 ssh_agent_socket=self.ssh_agent_socket,
-                podman=self._podman,
             )
         env = build_environment(
             self.user_home,

--- a/src/backend/klangk_backend/wshandler/controllers.py
+++ b/src/backend/klangk_backend/wshandler/controllers.py
@@ -454,7 +454,6 @@ class TerminalController:
             agent_home,
             service_command,
             setup_state=setup_state,
-            app_state=self._conn.app_state,
         )
 
     async def _sync_service_windows(self, ws_session) -> bool:

--- a/src/backend/klangk_backend/wshandler/controllers.py
+++ b/src/backend/klangk_backend/wshandler/controllers.py
@@ -10,13 +10,12 @@ from typing import TYPE_CHECKING
 
 from fastapi import WebSocketDisconnect
 
-from .. import model, terminal
+from .. import model
 from ..exceptions import TerminalError
 from ..util import resolve_env_value
 from ..podman import ExecSession
 from ..terminal import (
     TerminalSession,
-    attach_browser,
     SERVICE_CMD_WINDOW,
     SERVICE_SESSION,
 )
@@ -386,8 +385,8 @@ class TerminalController:
         sname = conn.tmux_session_name()
         ws_session = conn.app_state.sockets.get_session(conn.workspace_id)
 
-        windows = await terminal.list_windows(
-            conn.container_id, sname, conn.app_state.podman
+        windows = await conn.app_state.terminal.list_windows(
+            conn.container_id, sname
         )
         conn.sync_terminal_windows(windows)
         conn.sock.send_json({"type": "terminal_windows", "windows": windows})
@@ -450,7 +449,7 @@ class TerminalController:
         # (#1157) and persists in the bind-mount volume, so resolving the
         # path here is cheap and correct -- no provisioning needed.
         agent_home = f"/home/{await model.agent_handle()}"
-        await terminal.ensure_service_session(
+        await self._conn.app_state.terminal.ensure_service_session(
             self._conn.container_id,
             agent_home,
             service_command,
@@ -476,10 +475,9 @@ class TerminalController:
         if not self._conn.container_id:
             return False
         try:
-            windows = await terminal.list_windows(
+            windows = await self._conn.app_state.terminal.list_windows(
                 self._conn.container_id,
-                terminal.SERVICE_SESSION,
-                self._conn.app_state.podman,
+                SERVICE_SESSION,
             )
         except (TerminalError, OSError):
             return False  # service session doesn't exist yet
@@ -561,7 +559,7 @@ class TerminalController:
             user_id=self._conn.user["id"],
             user_handle=self._conn.user.get("handle"),
             ssh_agent_socket=self._conn._ssh_agent_socket,
-            podman=self._conn.app_state.podman,
+            terminal=self._conn.app_state.terminal,
         )
 
         browser_id = msg.get("browser_id")
@@ -592,8 +590,8 @@ class TerminalController:
                 # fire. Done before window sync so discovery picks it up.
                 await ctrl._fire_service_command()
                 if browser_id:
-                    await attach_browser(
-                        conn.container_id, browser_id, conn.app_state.podman
+                    await conn.app_state.terminal.attach_browser(
+                        conn.container_id, browser_id
                     )
                 if not await conn.activate_session(session, cols, rows):
                     return
@@ -645,8 +643,8 @@ class TerminalController:
             self._conn.user.get("email"),
             self._conn.workspace_id,
         )
-        await attach_browser(
-            self._conn.container_id, browser_id, self._conn.app_state.podman
+        await self._conn.app_state.terminal.attach_browser(
+            self._conn.container_id, browser_id
         )
 
     async def input(self, msg: dict) -> None:
@@ -789,11 +787,10 @@ class TerminalController:
         session_name = self.tmux_session_name()
         name = msg.get("name")
         try:
-            windows = await terminal.new_window(
+            windows = await self._conn.app_state.terminal.new_window(
                 self._conn.container_id,
                 session_name,
                 name=name,
-                podman=self._conn.app_state.podman,
             )
             logger.info(
                 "handle_terminal_new_window: %.3fs",
@@ -820,11 +817,10 @@ class TerminalController:
         # Prefer @N window_id (stable); fall back to index for compat.
         target: int | str = msg.get("window_id") or msg.get("index", 0)
         try:
-            await terminal.select_window(
+            await self._conn.app_state.terminal.select_window(
                 self._conn.container_id,
                 session_name,
                 target,
-                self._conn.app_state.podman,
             )
             logger.info(
                 "handle_terminal_select_window: target=%s %.3fs",
@@ -841,11 +837,10 @@ class TerminalController:
         session_name = self.tmux_session_name()
         index = msg.get("index", 0)
         try:
-            windows = await terminal.close_window(
+            windows = await self._conn.app_state.terminal.close_window(
                 self._conn.container_id,
                 session_name,
                 index,
-                self._conn.app_state.podman,
             )
             self.sync_terminal_windows(windows)
             self.notify_user_terminal_windows(windows)
@@ -863,17 +858,15 @@ class TerminalController:
             send_error(self._conn.sock, "Name required")
             return
         try:
-            await terminal.rename_window(
+            await self._conn.app_state.terminal.rename_window(
                 self._conn.container_id,
                 session_name,
                 index,
                 name,
-                self._conn.app_state.podman,
             )
-            windows = await terminal.list_windows(
+            windows = await self._conn.app_state.terminal.list_windows(
                 self._conn.container_id,
                 session_name,
-                self._conn.app_state.podman,
             )
             self.sync_terminal_windows(windows)
             self.notify_user_terminal_windows(windows)
@@ -893,10 +886,9 @@ class TerminalController:
             else self.tmux_session_name()
         )
         try:
-            windows = await terminal.list_windows(
+            windows = await self._conn.app_state.terminal.list_windows(
                 self._conn.container_id,
                 session_name,
-                self._conn.app_state.podman,
             )
             self._conn.sock.send_json(
                 {"type": "terminal_windows", "windows": windows}
@@ -1106,10 +1098,9 @@ class SharedTerminalController:
         match["shared"] = False
         # Kick spectators/collaborators
         try:
-            await terminal.kill_joiner_sessions(
+            await self._conn.app_state.terminal.kill_joiner_sessions(
                 self._conn.container_id,
                 session_name,
-                self._conn.app_state.podman,
             )
         except Exception:
             logger.debug("Failed to kill joiner sessions", exc_info=True)
@@ -1129,7 +1120,7 @@ class SharedTerminalController:
         session: TerminalSession,
         owner_user_id: str,
         window_id: str,
-        podman,
+        terminal,
     ) -> None:
         """Select the target window in the joiner's tmux session.
 
@@ -1148,15 +1139,14 @@ class SharedTerminalController:
                         "-t",
                         f"{joiner_session}:{window_id}",
                     ],
-                    podman,
                 )
             except TerminalError:
                 await terminal.select_window(
-                    container_id, owner_user_id, window_id, podman
+                    container_id, owner_user_id, window_id
                 )
         else:
             await terminal.select_window(
-                container_id, owner_user_id, window_id, podman
+                container_id, owner_user_id, window_id
             )
 
     async def join_shared_terminal(self, msg: dict) -> None:
@@ -1223,7 +1213,7 @@ class SharedTerminalController:
             read_only=read_only,
             user_id=self._conn.user["id"],
             user_handle=self._conn.user.get("handle"),
-            podman=self._conn.app_state.podman,
+            terminal=self._conn.app_state.terminal,
         )
         self._conn.terminal_session = session
         conn = self._conn
@@ -1239,7 +1229,7 @@ class SharedTerminalController:
                     session,
                     join_target,
                     window_id,
-                    conn.app_state.podman,
+                    conn.app_state.terminal,
                 )
                 if not await conn.activate_session(session, cols, rows):
                     return
@@ -1318,11 +1308,10 @@ class SharedTerminalController:
             return
         session_name = self._conn.tmux_session_name()
         try:
-            windows = await terminal.new_window(
+            windows = await self._conn.app_state.terminal.new_window(
                 self._conn.container_id,
                 session_name,
                 name=name,
-                podman=self._conn.app_state.podman,
             )
         except Exception as e:
             send_error(
@@ -1388,16 +1377,14 @@ class SharedTerminalController:
             return
         window_name = match["name"]
         try:
-            await terminal.kill_joiner_sessions(
+            await self._conn.app_state.terminal.kill_joiner_sessions(
                 self._conn.container_id,
                 owner_user_id,
-                self._conn.app_state.podman,
             )
-            await terminal.close_window(
+            await self._conn.app_state.terminal.close_window(
                 self._conn.container_id,
                 owner_user_id,
                 window_id,
-                self._conn.app_state.podman,
             )
         except Exception as e:
             send_error(

--- a/src/backend/klangk_backend/wshandler/session.py
+++ b/src/backend/klangk_backend/wshandler/session.py
@@ -10,7 +10,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
-from .. import agent, auth, model, terminal
+from .. import agent, auth, model
 from .safe_websocket import SafeWebSocket, WS_ERRORS, broadcast_to_set
 from .constants import (
     agent_conversations,
@@ -191,8 +191,8 @@ class WorkspaceSession:
 
             try:
                 new_token = auth.create_workspace_token(self.workspace_id)
-                await terminal.set_workspace_token(
-                    container_id, new_token, self.app_state.podman
+                await self.app_state.terminal.set_workspace_token(
+                    container_id, new_token
                 )
                 self.workspace_token_expiry = datetime.now(
                     timezone.utc

--- a/src/backend/tests/test_bringup.py
+++ b/src/backend/tests/test_bringup.py
@@ -3,7 +3,7 @@
 ``bringup`` runs inside ``start_container`` for every fresh container.
 It provisions the agent home and fires the service command. The
 underlying primitives (``agent.ensure_agent_home``,
-``terminal.ensure_service_session``) have their own coverage; these
+``Terminal.ensure_service_session``) have their own coverage; these
 tests pin the orchestration: that both are called in the right order
 with the right args, and that the service-command half is skipped when
 no command is configured.
@@ -14,22 +14,20 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from klangk_backend import bringup
 
 _app_state = MagicMock()
+_app_state.terminal.ensure_service_session = AsyncMock()
 
 
 class TestBringup:
+    def setup_method(self):
+        _app_state.terminal.ensure_service_session.reset_mock()
+
     async def test_provisions_home_and_fires_service_command(self):
         """A configured service command fires after the home is ready."""
-        with (
-            patch(
-                "klangk_backend.bringup.agent.ensure_agent_home",
-                new_callable=AsyncMock,
-                return_value="/home/clanker",
-            ) as mock_home,
-            patch(
-                "klangk_backend.bringup.terminal.ensure_service_session",
-                new_callable=AsyncMock,
-            ) as mock_service,
-        ):
+        with patch(
+            "klangk_backend.bringup.agent.ensure_agent_home",
+            new_callable=AsyncMock,
+            return_value="/home/clanker",
+        ) as mock_home:
             await bringup.bringup(
                 "ws-id",
                 "cid",
@@ -38,50 +36,37 @@ class TestBringup:
                 app_state=_app_state,
             )
         mock_home.assert_awaited_once_with("ws-id", "cid", _app_state.podman)
-        mock_service.assert_awaited_once_with(
+        _app_state.terminal.ensure_service_session.assert_awaited_once_with(
             "cid",
             "/home/clanker",
             "openclaw gateway",
             setup_state="complete",
-            app_state=_app_state,
         )
 
     async def test_skips_service_command_when_none(self):
         """No service_command -> only the agent home is provisioned."""
-        with (
-            patch(
-                "klangk_backend.bringup.agent.ensure_agent_home",
-                new_callable=AsyncMock,
-                return_value="/home/clanker",
-            ) as mock_home,
-            patch(
-                "klangk_backend.bringup.terminal.ensure_service_session",
-                new_callable=AsyncMock,
-            ) as mock_service,
-        ):
+        with patch(
+            "klangk_backend.bringup.agent.ensure_agent_home",
+            new_callable=AsyncMock,
+            return_value="/home/clanker",
+        ) as mock_home:
             await bringup.bringup(
                 "ws-id", "cid", None, "complete", app_state=_app_state
             )
         mock_home.assert_awaited_once_with("ws-id", "cid", _app_state.podman)
-        mock_service.assert_not_awaited()
+        _app_state.terminal.ensure_service_session.assert_not_awaited()
 
     async def test_skips_service_command_when_empty(self):
         """An empty service_command string is treated as 'none'."""
-        with (
-            patch(
-                "klangk_backend.bringup.agent.ensure_agent_home",
-                new_callable=AsyncMock,
-                return_value="/home/clanker",
-            ),
-            patch(
-                "klangk_backend.bringup.terminal.ensure_service_session",
-                new_callable=AsyncMock,
-            ) as mock_service,
+        with patch(
+            "klangk_backend.bringup.agent.ensure_agent_home",
+            new_callable=AsyncMock,
+            return_value="/home/clanker",
         ):
             await bringup.bringup(
                 "ws-id", "cid", "", "complete", app_state=_app_state
             )
-        mock_service.assert_not_awaited()
+        _app_state.terminal.ensure_service_session.assert_not_awaited()
 
     async def test_threads_setup_state_through_predicate(self):
         """setup_state flows to ensure_service_session, which gates on it.
@@ -90,16 +75,10 @@ class TestBringup:
         gating happens inside it via should_fire_service_command), so the
         orchestrator's job is just to pass the value through unchanged.
         """
-        with (
-            patch(
-                "klangk_backend.bringup.agent.ensure_agent_home",
-                new_callable=AsyncMock,
-                return_value="/home/clanker",
-            ),
-            patch(
-                "klangk_backend.bringup.terminal.ensure_service_session",
-                new_callable=AsyncMock,
-            ) as mock_service,
+        with patch(
+            "klangk_backend.bringup.agent.ensure_agent_home",
+            new_callable=AsyncMock,
+            return_value="/home/clanker",
         ):
             await bringup.bringup(
                 "ws-id",
@@ -108,34 +87,30 @@ class TestBringup:
                 setup_state="pending",
                 app_state=_app_state,
             )
-        mock_service.assert_awaited_once_with(
+        _app_state.terminal.ensure_service_session.assert_awaited_once_with(
             "cid",
             "/home/clanker",
             "openclaw gateway",
             setup_state="pending",
-            app_state=_app_state,
         )
 
     async def test_threads_none_setup_state(self):
         """A None setup_state (caller omitted it) is passed through."""
-        with (
-            patch(
-                "klangk_backend.bringup.agent.ensure_agent_home",
-                new_callable=AsyncMock,
-                return_value="/home/clanker",
-            ),
-            patch(
-                "klangk_backend.bringup.terminal.ensure_service_session",
-                new_callable=AsyncMock,
-            ) as mock_service,
+        with patch(
+            "klangk_backend.bringup.agent.ensure_agent_home",
+            new_callable=AsyncMock,
+            return_value="/home/clanker",
         ):
             await bringup.bringup(
-                "ws-id", "cid", "openclaw gateway", None, app_state=_app_state
+                "ws-id",
+                "cid",
+                "openclaw gateway",
+                None,
+                app_state=_app_state,
             )
-        mock_service.assert_awaited_once_with(
+        _app_state.terminal.ensure_service_session.assert_awaited_once_with(
             "cid",
             "/home/clanker",
             "openclaw gateway",
             setup_state=None,
-            app_state=_app_state,
         )

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -38,6 +38,10 @@ def _make_app_state(registry=None, sockets=None):
 
         registry.podman = Podman(settings)
         app_state.podman = registry.podman
+    # #1480: container.py reaches set_workspace_token via app_state.terminal.
+    from klangk_backend.terminal import Terminal
+
+    app_state.terminal = Terminal(app_state.podman, registry)
     return app_state
 
 
@@ -664,19 +668,22 @@ class TestStartContainer:
 
     async def test_workspace_token_written_to_container(self, workspace):
         """Workspace token is written to the container via set_workspace_token."""
-        from klangk_backend import auth, terminal
+        from klangk_backend import auth
 
         with (
             patch_podman(self.registry),
             patch.object(
-                terminal, "set_workspace_token", new_callable=AsyncMock
+                self.registry.app_state.terminal,
+                "set_workspace_token",
+                new_callable=AsyncMock,
             ) as mock_set,
         ):
             await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
         mock_set.assert_called_once()
-        cid, token, _podman = mock_set.call_args.args
+        cid, token = mock_set.call_args.args
+        assert cid == "new-cid"
         assert cid == "new-cid"
         decoded_ws = auth.decode_workspace_token(token)
         assert decoded_ws == workspace["id"]

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -41,7 +41,7 @@ def _make_app_state(registry=None, sockets=None):
     # #1480: container.py reaches set_workspace_token via app_state.terminal.
     from klangk_backend.terminal import Terminal
 
-    app_state.terminal = Terminal(app_state.podman, registry)
+    app_state.terminal = Terminal(app_state)
     return app_state
 
 

--- a/src/backend/tests/test_terminal.py
+++ b/src/backend/tests/test_terminal.py
@@ -36,8 +36,12 @@ _mock_pod = MagicMock()
 _mock_registry = MagicMock()
 _mock_registry.get_service_session_lock.return_value = asyncio.Lock()
 _mock_registry.mark_service_started = MagicMock()
-# Minimal app_state carrying podman + registry + settings so Terminal can
-# reach all three through its single ctor arg (#1480).
+
+# These are rebuilt per-test by the _fresh_terminal fixture so a value a
+# test writes onto settings (e.g. disable_tmux) can't leak into the next
+# one. _mock_pod / _mock_registry stay module-scoped (their resets live
+# in per-class setup_method / patch.object auto-restore); only the
+# settings-bearing wrapper + Terminal are recreated.
 _mock_settings = MagicMock()
 _mock_settings.disable_tmux = None
 _app_state = types.SimpleNamespace(
@@ -46,6 +50,27 @@ _app_state = types.SimpleNamespace(
     settings=_mock_settings,
 )
 _terminal = Terminal(_app_state)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_terminal():
+    """Recreate settings (and the app_state/Terminal carrying it) per test.
+
+    Terminal.tmux_enabled() reads disable_tmux off settings instead of the
+    env (so monkeypatch.setenv no longer isolates it). Tests mutate that
+    attribute directly; without a fresh settings object each test, the
+    mutation leaks to whatever runs next in the same worker.
+    """
+    global _mock_settings, _app_state, _terminal
+    _mock_settings = MagicMock()
+    _mock_settings.disable_tmux = None
+    _app_state = types.SimpleNamespace(
+        podman=_mock_pod,
+        container_registry=_mock_registry,
+        settings=_mock_settings,
+    )
+    _terminal = Terminal(_app_state)
+    yield
 
 
 class TestShellProcessFactory:

--- a/src/backend/tests/test_terminal.py
+++ b/src/backend/tests/test_terminal.py
@@ -14,21 +14,14 @@ import pytest
 from klangk_backend.exceptions import TerminalError
 from klangk_backend.terminal import (
     CONTAINER_USER,
+    SERVICE_SESSION,
+    Terminal,
     TerminalSession,
-    set_workspace_token,
     build_environment,
     build_shell_command,
     make_shell_process,
     validate_window_name,
-    attach_browser,
-    close_window,
-    kill_joiner_sessions,
-    list_windows,
-    new_window,
-    rename_window,
-    select_window,
     terminal_tmux_enabled,
-    tmux_command,
 )
 
 SHELL_FACTORY = "klangk_backend.terminal.make_shell_process"
@@ -37,6 +30,13 @@ SHELL_FACTORY = "klangk_backend.terminal.make_shell_process"
 # patch.object, then pass to the function under test as its ``podman``
 # arg (#1468).
 _mock_pod = MagicMock()
+
+# Terminal instance whose methods the tmux-function tests exercise
+# (#1480: the ~25 free functions became Terminal methods).
+_mock_registry = MagicMock()
+_mock_registry.get_service_session_lock.return_value = asyncio.Lock()
+_mock_registry.mark_service_started = MagicMock()
+_terminal = Terminal(_mock_pod, _mock_registry)
 
 
 class TestShellProcessFactory:
@@ -109,8 +109,9 @@ class FakeShell:
 def _patch(fake):
     with (
         patch(SHELL_FACTORY, return_value=fake),
-        patch(
-            "klangk_backend.terminal.ensure_base_session",
+        patch.object(
+            _terminal,
+            "ensure_base_session",
             new_callable=AsyncMock,
         ),
     ):
@@ -130,7 +131,7 @@ def _drain_text(session):
 
 class TestInit:
     def test_initial_state(self):
-        s = TerminalSession("cid", podman=_mock_pod)
+        s = TerminalSession("cid", terminal=_terminal)
         assert s.container_id == "cid"
         assert s._shell is None
         assert s._running is False
@@ -141,7 +142,7 @@ class TestStart:
     async def test_start_builds_exec_argv(self):
         fake = FakeShell(block_after_chunks=True)
         with _patch(fake):
-            s = TerminalSession("cid", podman=_mock_pod)
+            s = TerminalSession("cid", terminal=_terminal)
             await s.start(120, 40)
 
         argv = fake.argv
@@ -161,7 +162,7 @@ class TestStart:
         monkeypatch.setenv("KLANGK_DISABLE_TMUX", "1")
         fake = FakeShell(block_after_chunks=True)
         with _patch(fake):
-            s = TerminalSession("cid", session_name="uid", podman=_mock_pod)
+            s = TerminalSession("cid", session_name="uid", terminal=_terminal)
             await s.start(120, 40)
 
         argv = fake.argv
@@ -175,7 +176,7 @@ class TestStart:
         monkeypatch.setenv("ANTHROPIC_API_KEY", "secret2")
         fake = FakeShell(block_after_chunks=True)
         with _patch(fake):
-            s = TerminalSession("cid", podman=_mock_pod)
+            s = TerminalSession("cid", terminal=_terminal)
             await s.start()
 
         argv = fake.argv
@@ -187,7 +188,7 @@ class TestStart:
     async def test_no_command_override_by_default(self):
         fake = FakeShell(block_after_chunks=True)
         with _patch(fake):
-            s = TerminalSession("cid", podman=_mock_pod)
+            s = TerminalSession("cid", terminal=_terminal)
             await s.start()
         assert not any("KLANGK_CMD_OVERRIDE" in a for a in fake.argv)
         await s.stop()
@@ -196,7 +197,7 @@ class TestStart:
         """browser_id is no longer passed as an env var (uses klangk-attach-browser)."""
         fake = FakeShell(block_after_chunks=True)
         with _patch(fake):
-            s = TerminalSession("cid", podman=_mock_pod)
+            s = TerminalSession("cid", terminal=_terminal)
             await s.start()
         assert not any("KLANGK_BROWSER_ID" in a for a in fake.argv)
         assert not any("KLANGK_BRIDGE_TOKEN" in a for a in fake.argv)
@@ -211,7 +212,7 @@ class TestStart:
                 user_home="/home/alice",
                 user_id="uid-123",
                 user_handle="alice",
-                podman=_mock_pod,
+                terminal=_terminal,
             )
             await s.start(120, 40)
         assert "HOME=/home/alice" in fake.argv
@@ -234,7 +235,7 @@ class TestStart:
     async def test_no_user_home_by_default(self):
         fake = FakeShell(block_after_chunks=True)
         with _patch(fake):
-            s = TerminalSession("cid", podman=_mock_pod)
+            s = TerminalSession("cid", terminal=_terminal)
             await s.start()
         assert not any(a.startswith("HOME=") for a in fake.argv)
         await s.stop()
@@ -242,7 +243,7 @@ class TestStart:
     async def test_start_failure_resets_running(self):
         fake = FakeShell(start_error=RuntimeError("spawn fail"))
         with _patch(fake):
-            s = TerminalSession("cid", podman=_mock_pod)
+            s = TerminalSession("cid", terminal=_terminal)
             try:
                 await s.start()
             except RuntimeError:
@@ -266,7 +267,7 @@ class TestStart:
                 "cid",
                 session_name="uid-123",
                 ssh_agent_socket="/tmp/agent.sock",
-                podman=_mock_pod,
+                terminal=_terminal,
             )
             await s.start(120, 40)
 
@@ -292,7 +293,7 @@ class TestAttachBrowser:
             new_callable=AsyncMock,
             return_value=(0, "", ""),
         ) as mock_exec:
-            await attach_browser("cid-123", "bid-abc", podman=_mock_pod)
+            await _terminal.attach_browser("cid-123", "bid-abc")
         mock_exec.assert_awaited_once_with(
             "cid-123",
             ["klangk-attach-browser", "bid-abc"],
@@ -308,7 +309,7 @@ class TestAttachBrowser:
             return_value=(1, "", "attach failed"),
         ):
             # Should not raise
-            await attach_browser("cid-123", "bid-abc", podman=_mock_pod)
+            await _terminal.attach_browser("cid-123", "bid-abc")
 
 
 class TestSetWorkspaceToken:
@@ -319,9 +320,7 @@ class TestSetWorkspaceToken:
             new_callable=AsyncMock,
             return_value=(0, "", ""),
         ) as mock_exec:
-            await set_workspace_token(
-                "cid-123", "jwt-token-xyz", podman=_mock_pod
-            )
+            await _terminal.set_workspace_token("cid-123", "jwt-token-xyz")
         mock_exec.assert_awaited_once_with(
             "cid-123",
             ["klangk-set-workspace-token", "jwt-token-xyz"],
@@ -336,16 +335,14 @@ class TestSetWorkspaceToken:
             new_callable=AsyncMock,
             return_value=(1, "", "set failed"),
         ):
-            await set_workspace_token(
-                "cid-123", "jwt-token-xyz", podman=_mock_pod
-            )
+            await _terminal.set_workspace_token("cid-123", "jwt-token-xyz")
 
 
 class TestReadLoop:
     async def test_output_from_shell(self):
         fake = FakeShell(chunks=[b"prompt", b"hello world"])
         with _patch(fake):
-            s = TerminalSession("cid", podman=_mock_pod)
+            s = TerminalSession("cid", terminal=_terminal)
             await s.start()
 
         await asyncio.sleep(0.05)
@@ -356,7 +353,7 @@ class TestReadLoop:
     async def test_stream_end_signals_none(self):
         fake = FakeShell(chunks=[])  # immediate EOF
         with _patch(fake):
-            s = TerminalSession("cid", podman=_mock_pod)
+            s = TerminalSession("cid", terminal=_terminal)
             await s.start()
 
         await asyncio.sleep(0.05)
@@ -366,7 +363,7 @@ class TestReadLoop:
     async def test_read_loop_handles_exception(self):
         fake = FakeShell(chunks=[b"prompt", RuntimeError("connection lost")])
         with _patch(fake):
-            s = TerminalSession("cid", podman=_mock_pod)
+            s = TerminalSession("cid", terminal=_terminal)
             await s.start()
 
         await asyncio.sleep(0.05)
@@ -381,7 +378,7 @@ class TestReadLoop:
         # decoder must buffer the partial sequence and emit the intact glyph.
         fake = FakeShell(chunks=[b"\xe2\x94", b"\x80 done"])
         with _patch(fake):
-            s = TerminalSession("cid", podman=_mock_pod)
+            s = TerminalSession("cid", terminal=_terminal)
             await s.start()
 
         await asyncio.sleep(0.05)
@@ -395,7 +392,7 @@ class TestReadLoop:
         # as a single replacement char rather than silently dropped.
         fake = FakeShell(chunks=[b"ok\xe2\x94"])  # ends mid '─'
         with _patch(fake):
-            s = TerminalSession("cid", podman=_mock_pod)
+            s = TerminalSession("cid", terminal=_terminal)
             await s.start()
 
         await asyncio.sleep(0.05)
@@ -407,7 +404,7 @@ class TestWrite:
     async def test_write_sends_to_shell(self):
         fake = FakeShell(block_after_chunks=True)
         with _patch(fake):
-            s = TerminalSession("cid", podman=_mock_pod)
+            s = TerminalSession("cid", terminal=_terminal)
             await s.start()
         await s.write("hello")
         assert fake.writes == [b"hello"]
@@ -416,13 +413,13 @@ class TestWrite:
     async def test_write_exception_suppressed(self):
         fake = FakeShell(block_after_chunks=True, write_error=OSError("broke"))
         with _patch(fake):
-            s = TerminalSession("cid", podman=_mock_pod)
+            s = TerminalSession("cid", terminal=_terminal)
             await s.start()
         await s.write("hello")  # should not raise
         await s.stop()
 
     async def test_write_when_stopped(self):
-        s = TerminalSession("cid", podman=_mock_pod)
+        s = TerminalSession("cid", terminal=_terminal)
         await s.write("hello")  # no shell -> no-op
 
 
@@ -430,7 +427,7 @@ class TestResize:
     async def test_resize_calls_shell_resize(self):
         fake = FakeShell(block_after_chunks=True)
         with _patch(fake):
-            s = TerminalSession("cid", podman=_mock_pod)
+            s = TerminalSession("cid", terminal=_terminal)
             await s.start()
         await s.resize(200, 50)
         assert fake.resizes == [(50, 200)]  # (rows, cols)
@@ -443,14 +440,14 @@ class TestResize:
             raise OSError("broke")
 
         with _patch(fake):
-            s = TerminalSession("cid", podman=_mock_pod)
+            s = TerminalSession("cid", terminal=_terminal)
             await s.start()
         fake.resize = boom
         await s.resize(200, 50)  # should not raise
         await s.stop()
 
     async def test_resize_when_stopped(self):
-        s = TerminalSession("cid", podman=_mock_pod)
+        s = TerminalSession("cid", terminal=_terminal)
         await s.resize(80, 24)  # no shell -> no-op
 
 
@@ -458,7 +455,7 @@ class TestStop:
     async def test_stop_cleans_up(self):
         fake = FakeShell(block_after_chunks=True)
         with _patch(fake):
-            s = TerminalSession("cid", podman=_mock_pod)
+            s = TerminalSession("cid", terminal=_terminal)
             await s.start()
         await s.stop()
         assert s._running is False
@@ -471,7 +468,7 @@ class TestStop:
             block_after_chunks=True, close_error=OSError("close fail")
         )
         with _patch(fake):
-            s = TerminalSession("cid", podman=_mock_pod)
+            s = TerminalSession("cid", terminal=_terminal)
             await s.start()
         await s.stop()  # should not raise
         assert s._shell is None
@@ -479,7 +476,7 @@ class TestStop:
     async def test_stop_cancels_blocked_read_loop(self):
         fake = FakeShell(chunks=[b"prompt"], block_after_chunks=True)
         with _patch(fake):
-            s = TerminalSession("cid", podman=_mock_pod)
+            s = TerminalSession("cid", terminal=_terminal)
             await s.start()
         await asyncio.sleep(0.05)  # consume prompt, then block on read
         await s.stop()
@@ -492,7 +489,7 @@ class TestStop:
 
         fake = FakeShell(block_after_chunks=True)
         with _patch(fake):
-            s = TerminalSession("cid", podman=_mock_pod)
+            s = TerminalSession("cid", terminal=_terminal)
             await s.start()
 
         # Replace the read task with one that raises a non-CancelledError.
@@ -508,7 +505,7 @@ class TestStop:
         assert s._read_task is None
 
     async def test_stop_when_not_started(self):
-        s = TerminalSession("cid", podman=_mock_pod)
+        s = TerminalSession("cid", terminal=_terminal)
         await s.stop()
 
     async def test_stop_kills_tmux_session_with_socket(self):
@@ -519,7 +516,7 @@ class TestStop:
                 "cid",
                 session_name="uid",
                 socket_path="/tmp/s.sock",
-                podman=_mock_pod,
+                terminal=_terminal,
             )
             await s.start()
         # Manually set tmux session name (normally set by build_shell_command
@@ -546,7 +543,7 @@ class TestStop:
                 "cid",
                 session_name="uid",
                 socket_path="/tmp/s.sock",
-                podman=_mock_pod,
+                terminal=_terminal,
             )
             await s.start()
         s.tmux_session_name = "uid-abc123"
@@ -564,7 +561,7 @@ class TestOutput:
     async def test_output_yields_data(self):
         fake = FakeShell(chunks=[b"prompt", b"output"])
         with _patch(fake):
-            s = TerminalSession("cid", podman=_mock_pod)
+            s = TerminalSession("cid", terminal=_terminal)
             await s.start()
 
         collected = []
@@ -576,7 +573,7 @@ class TestOutput:
 
     async def test_output_exits_when_running_cleared(self):
         """Sentinel dropped: output() exits via the _running check."""
-        s = TerminalSession("cid", podman=_mock_pod)
+        s = TerminalSession("cid", terminal=_terminal)
         s._running = True
         s._read_task = None  # no task -> only _running governs exit
 
@@ -593,7 +590,7 @@ class TestOutput:
         """Sentinel dropped: output() exits via the _read_task.done() check."""
         fake = FakeShell(chunks=[])  # immediate EOF -> read task finishes
         with _patch(fake):
-            s = TerminalSession("cid", podman=_mock_pod)
+            s = TerminalSession("cid", terminal=_terminal)
             await s.start()
 
         await asyncio.sleep(0.05)
@@ -619,7 +616,7 @@ class TestIsAlive:
     async def test_alive_while_running(self):
         fake = FakeShell(chunks=[b"prompt"], block_after_chunks=True)
         with _patch(fake):
-            s = TerminalSession("cid", podman=_mock_pod)
+            s = TerminalSession("cid", terminal=_terminal)
             await s.start()
         assert s.is_alive is True
         await s.stop()
@@ -627,7 +624,7 @@ class TestIsAlive:
     async def test_not_alive_after_stream_ends(self):
         fake = FakeShell(chunks=[])  # EOF
         with _patch(fake):
-            s = TerminalSession("cid", podman=_mock_pod)
+            s = TerminalSession("cid", terminal=_terminal)
             await s.start()
         await asyncio.sleep(0.05)
         assert s.is_alive is False
@@ -636,7 +633,7 @@ class TestIsAlive:
     async def test_not_alive_after_stop(self):
         fake = FakeShell(block_after_chunks=True)
         with _patch(fake):
-            s = TerminalSession("cid", podman=_mock_pod)
+            s = TerminalSession("cid", terminal=_terminal)
             await s.start()
         await s.stop()
         assert s.is_alive is False
@@ -650,8 +647,8 @@ class TestTmuxCommand:
             new_callable=AsyncMock,
             return_value=(0, "output\n", ""),
         ) as mock_exec:
-            result = await tmux_command(
-                "cid", "sess", ["list-windows"], podman=_mock_pod
+            result = await _terminal.tmux_command(
+                "cid", "sess", ["list-windows"]
             )
         assert result == "output\n"
         mock_exec.assert_awaited_once_with(
@@ -669,9 +666,7 @@ class TestTmuxCommand:
             return_value=(1, "", "error msg"),
         ) as mock_exec:
             with pytest.raises(TerminalError, match="error msg"):
-                await tmux_command(
-                    "cid", "sess", ["bad-cmd"], podman=_mock_pod
-                )
+                await _terminal.tmux_command("cid", "sess", ["bad-cmd"])
         assert mock_exec.await_count == 1  # no retry on non-socket errors
 
     async def test_retries_on_socket_not_found(self):
@@ -687,8 +682,8 @@ class TestTmuxCommand:
             ) as mock_exec,
             patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
         ):
-            result = await tmux_command(
-                "cid", "sess", ["list-windows"], podman=_mock_pod
+            result = await _terminal.tmux_command(
+                "cid", "sess", ["list-windows"]
             )
         assert result == "ok\n"
         assert mock_exec.await_count == 2
@@ -698,19 +693,20 @@ class TestTmuxCommand:
 
 class TestListWindows:
     async def test_parses_output(self):
-        with patch(
-            "klangk_backend.terminal.tmux_command",
+        with patch.object(
+            _terminal,
+            "tmux_command",
             return_value="@0|||0|||bash|||1\n@1|||1|||build|||0\n",
         ):
-            result = await list_windows("cid", "sess", podman=_mock_pod)
+            result = await _terminal.list_windows("cid", "sess")
         assert result == [
             {"id": "@0", "index": 0, "name": "bash", "active": True},
             {"id": "@1", "index": 1, "name": "build", "active": False},
         ]
 
     async def test_empty_session(self):
-        with patch("klangk_backend.terminal.tmux_command", return_value=""):
-            result = await list_windows("cid", "sess", podman=_mock_pod)
+        with patch.object(_terminal, "tmux_command", return_value=""):
+            result = await _terminal.list_windows("cid", "sess")
         assert result == []
 
 
@@ -741,7 +737,7 @@ class TestNewWindow:
             new_callable=AsyncMock,
             return_value=(0, "@0|||0|||1|||1\n", ""),
         ) as mock_exec:
-            result = await new_window("cid", "sess", podman=_mock_pod)
+            result = await _terminal.new_window("cid", "sess")
         assert len(result) == 1
         assert result[0]["name"] == "1"
         assert mock_exec.call_args.args[1][:2] == ["bash", "-c"]
@@ -753,7 +749,7 @@ class TestNewWindow:
             new_callable=AsyncMock,
             return_value=(0, "@0|||0|||1|||0\n@1|||1|||2|||1\n", ""),
         ):
-            result = await new_window("cid", "sess", podman=_mock_pod)
+            result = await _terminal.new_window("cid", "sess")
         assert len(result) == 2
 
     async def test_creates_named_window(self):
@@ -767,9 +763,7 @@ class TestNewWindow:
                 "",
             ),
         ) as mock_exec:
-            result = await new_window(
-                "cid", "sess", name="build", podman=_mock_pod
-            )
+            result = await _terminal.new_window("cid", "sess", name="build")
         assert len(result) == 2
         assert result[1]["name"] == "build"
         # the name is passed as a positional argv ($1), never interpolated
@@ -782,9 +776,7 @@ class TestNewWindow:
 
     async def test_rejects_shell_injection(self):
         with pytest.raises(ValueError, match="only contain"):
-            await new_window(
-                "cid", "sess", name="';rm -rf /;'", podman=_mock_pod
-            )
+            await _terminal.new_window("cid", "sess", name="';rm -rf /;'")
 
     async def test_rejects_duplicate_name(self):
         with patch.object(
@@ -794,7 +786,7 @@ class TestNewWindow:
             return_value=(1, "DUPLICATE\n", ""),
         ):
             with pytest.raises(ValueError, match="already exists"):
-                await new_window("cid", "sess", name="build", podman=_mock_pod)
+                await _terminal.new_window("cid", "sess", name="build")
 
     async def test_raises_on_tmux_error(self):
         with patch.object(
@@ -804,105 +796,109 @@ class TestNewWindow:
             return_value=(1, "", "session not found"),
         ):
             with pytest.raises(TerminalError, match="session not found"):
-                await new_window("cid", "sess", podman=_mock_pod)
+                await _terminal.new_window("cid", "sess")
 
 
 class TestSelectWindow:
     async def test_selects_window(self):
-        with patch(
-            "klangk_backend.terminal.tmux_command",
+        with patch.object(
+            _terminal,
+            "tmux_command",
             return_value="",
         ) as mock_cmd:
-            await select_window("cid", "sess", 2, podman=_mock_pod)
+            await _terminal.select_window("cid", "sess", 2)
         mock_cmd.assert_called_once_with(
-            "cid", "sess", ["select-window", "-t", "sess:2"], _mock_pod
+            "cid", "sess", ["select-window", "-t", "sess:2"]
         )
 
     async def test_selects_by_window_id(self):
-        with patch(
-            "klangk_backend.terminal.tmux_command",
+        with patch.object(
+            _terminal,
+            "tmux_command",
         ) as mock_cmd:
-            await select_window("cid", "sess", "@5", podman=_mock_pod)
+            await _terminal.select_window("cid", "sess", "@5")
         mock_cmd.assert_called_once_with(
-            "cid", "sess", ["select-window", "-t", "@5"], _mock_pod
+            "cid", "sess", ["select-window", "-t", "@5"]
         )
 
 
 class TestCloseWindow:
     async def test_closes_window(self):
         with (
-            patch(
-                "klangk_backend.terminal.tmux_command",
+            patch.object(
+                _terminal,
+                "tmux_command",
                 return_value="",
             ) as mock_cmd,
-            patch(
-                "klangk_backend.terminal.list_windows",
+            patch.object(
+                _terminal,
+                "list_windows",
                 return_value=[{"index": 0, "name": "bash", "active": True}],
             ),
         ):
-            result = await close_window("cid", "sess", 1, podman=_mock_pod)
+            result = await _terminal.close_window("cid", "sess", 1)
         mock_cmd.assert_called_once_with(
-            "cid", "sess", ["kill-window", "-t", "sess:1"], _mock_pod
+            "cid", "sess", ["kill-window", "-t", "sess:1"]
         )
         assert len(result) == 1
 
     async def test_closes_by_window_id(self):
         with (
-            patch(
-                "klangk_backend.terminal.tmux_command",
+            patch.object(
+                _terminal,
+                "tmux_command",
                 return_value="",
             ) as mock_cmd,
-            patch(
-                "klangk_backend.terminal.list_windows",
+            patch.object(
+                _terminal,
+                "list_windows",
                 return_value=[],
             ),
         ):
-            await close_window("cid", "sess", "@3", podman=_mock_pod)
+            await _terminal.close_window("cid", "sess", "@3")
         mock_cmd.assert_called_once_with(
-            "cid", "sess", ["kill-window", "-t", "@3"], _mock_pod
+            "cid", "sess", ["kill-window", "-t", "@3"]
         )
 
 
 class TestRenameWindow:
     async def test_renames_window(self):
         with (
-            patch(
-                "klangk_backend.terminal.list_windows",
+            patch.object(
+                _terminal,
+                "list_windows",
                 return_value=[
                     {"index": 0, "name": "bash", "active": True},
                 ],
             ),
-            patch(
-                "klangk_backend.terminal.tmux_command",
+            patch.object(
+                _terminal,
+                "tmux_command",
                 return_value="",
             ) as mock_cmd,
         ):
-            await rename_window("cid", "sess", 0, "build", podman=_mock_pod)
+            await _terminal.rename_window("cid", "sess", 0, "build")
         mock_cmd.assert_called_once_with(
             "cid",
             "sess",
             ["rename-window", "-t", "sess:0", "build"],
-            _mock_pod,
         )
 
     async def test_rejects_shell_injection(self):
         with pytest.raises(ValueError, match="only contain"):
-            await rename_window(
-                "cid", "sess", 0, "';rm -rf /;'", podman=_mock_pod
-            )
+            await _terminal.rename_window("cid", "sess", 0, "';rm -rf /;'")
 
     async def test_rejects_duplicate_name(self):
-        with patch(
-            "klangk_backend.terminal.list_windows",
+        with patch.object(
+            _terminal,
+            "list_windows",
             return_value=[
                 {"index": 0, "name": "bash", "active": True},
                 {"index": 1, "name": "build", "active": False},
             ],
         ):
             with pytest.raises(ValueError, match="already exists"):
-                await rename_window(
-                    "cid", "sess", 0, "build", podman=_mock_pod
-                )
+                await _terminal.rename_window("cid", "sess", 0, "build")
 
 
 class TestBuildEnvironment:
@@ -1021,47 +1017,51 @@ class TestBuildShellCommandTmuxDisabled:
 
 class TestKillJoinerSessions:
     async def test_kills_non_owner_sessions(self):
-        with patch(
-            "klangk_backend.terminal.tmux_command",
+        with patch.object(
+            _terminal,
+            "tmux_command",
             side_effect=[
                 "admin\nbob-abc123\ncarol-def456\n",  # list-sessions
                 "",  # kill bob
                 "",  # kill carol
             ],
         ) as mock_cmd:
-            await kill_joiner_sessions("cid", "admin", podman=_mock_pod)
+            await _terminal.kill_joiner_sessions("cid", "admin")
         # Should have called list-sessions + kill for bob and carol
         assert mock_cmd.call_count == 3
 
     async def test_no_joiners(self):
-        with patch(
-            "klangk_backend.terminal.tmux_command",
+        with patch.object(
+            _terminal,
+            "tmux_command",
             return_value="admin\n",
         ) as mock_cmd:
-            await kill_joiner_sessions("cid", "admin", podman=_mock_pod)
+            await _terminal.kill_joiner_sessions("cid", "admin")
         # Only list-sessions, no kills
         assert mock_cmd.call_count == 1
 
     async def test_kill_session_error_ignored(self):
         """If kill-session fails for a joiner, continue with others."""
-        with patch(
-            "klangk_backend.terminal.tmux_command",
+        with patch.object(
+            _terminal,
+            "tmux_command",
             side_effect=[
                 "admin\nbob-abc\ncarol-def\n",  # list-sessions
                 TerminalError("already exited"),  # kill bob fails
                 "",  # kill carol succeeds
             ],
         ) as mock_cmd:
-            await kill_joiner_sessions("cid", "admin", podman=_mock_pod)
+            await _terminal.kill_joiner_sessions("cid", "admin")
         assert mock_cmd.call_count == 3
 
     async def test_no_sessions(self):
-        with patch(
-            "klangk_backend.terminal.tmux_command",
+        with patch.object(
+            _terminal,
+            "tmux_command",
             side_effect=TerminalError("no sessions"),
         ):
             # Should not raise
-            await kill_joiner_sessions("cid", "admin", podman=_mock_pod)
+            await _terminal.kill_joiner_sessions("cid", "admin")
 
 
 class TestTerminalSessionJoin:
@@ -1074,7 +1074,7 @@ class TestTerminalSessionJoin:
                 session_name="joiner-uid",
                 user_home="/home/bob",
                 join_session="owner-uid",
-                podman=_mock_pod,
+                terminal=_terminal,
             )
             await s.start(80, 24)
         assert "-S" not in fake.argv
@@ -1091,7 +1091,7 @@ class TestTerminalSessionJoin:
                 user_home="/home/ceo",
                 join_session="owner-uid",
                 read_only=True,
-                podman=_mock_pod,
+                terminal=_terminal,
             )
             await s.start(80, 24)
         assert "switch-client" not in fake.argv
@@ -1102,7 +1102,6 @@ class TestTerminalSessionJoin:
 class TestEnsureBaseSession:
     async def test_session_already_exists(self):
         """Skip creation if tmux has-session succeeds."""
-        from klangk_backend.terminal import ensure_base_session
 
         with patch.object(
             _mock_pod,
@@ -1110,16 +1109,13 @@ class TestEnsureBaseSession:
             new_callable=AsyncMock,
             return_value=(0, "", ""),  # has-session succeeds
         ) as mock_exec:
-            created = await ensure_base_session(
-                "cid", "my-session", podman=_mock_pod
-            )
+            created = await _terminal.ensure_base_session("cid", "my-session")
         assert created is False
         mock_exec.assert_awaited_once()
         assert "has-session" in mock_exec.call_args.args[1]
 
     async def test_session_does_not_exist(self):
         """Create detached session when has-session fails."""
-        from klangk_backend.terminal import ensure_base_session
 
         with patch.object(
             _mock_pod,
@@ -1127,8 +1123,8 @@ class TestEnsureBaseSession:
             new_callable=AsyncMock,
             side_effect=[(1, "", ""), (0, "", "")],  # has fail, new ok
         ) as mock_exec:
-            created = await ensure_base_session(
-                "cid", "my-session", user_home="/home/u", podman=_mock_pod
+            created = await _terminal.ensure_base_session(
+                "cid", "my-session", user_home="/home/u"
             )
         assert created is True
         assert mock_exec.await_count == 2
@@ -1139,7 +1135,6 @@ class TestEnsureBaseSession:
 
     async def test_has_session_exception(self):
         """Falls through to create if has-session raises."""
-        from klangk_backend.terminal import ensure_base_session
 
         with patch.object(
             _mock_pod,
@@ -1147,15 +1142,12 @@ class TestEnsureBaseSession:
             new_callable=AsyncMock,
             side_effect=[OSError("boom"), (0, "", "")],
         ) as mock_exec:
-            created = await ensure_base_session(
-                "cid", "my-session", podman=_mock_pod
-            )
+            created = await _terminal.ensure_base_session("cid", "my-session")
         assert created is True
         assert mock_exec.await_count == 2
 
     async def test_create_failure_logs_warning(self):
         """Warning logged when new-session fails."""
-        from klangk_backend.terminal import ensure_base_session
 
         with patch.object(
             _mock_pod,
@@ -1163,14 +1155,11 @@ class TestEnsureBaseSession:
             new_callable=AsyncMock,
             side_effect=[(1, "", ""), OSError("create failed")],
         ):
-            created = await ensure_base_session(
-                "cid", "my-session", podman=_mock_pod
-            )
+            created = await _terminal.ensure_base_session("cid", "my-session")
         assert created is False
 
     async def test_env_args_passed(self):
         """HOME and SSH_AUTH_SOCK are passed as tmux -e flags."""
-        from klangk_backend.terminal import ensure_base_session
 
         with patch.object(
             _mock_pod,
@@ -1178,12 +1167,11 @@ class TestEnsureBaseSession:
             new_callable=AsyncMock,
             side_effect=[(1, "", ""), (0, "", "")],
         ) as mock_exec:
-            await ensure_base_session(
+            await _terminal.ensure_base_session(
                 "cid",
                 "my-session",
                 user_home="/home/u",
                 ssh_agent_socket="/tmp/agent.sock",
-                podman=_mock_pod,
             )
         new_cmd = mock_exec.call_args_list[1].args[1]
         assert "HOME=/home/u" in new_cmd
@@ -1191,7 +1179,6 @@ class TestEnsureBaseSession:
 
     async def test_service_cmd_window_exists_exception_returns_false(self):
         """service_cmd_window_exists returns False if list-windows raises."""
-        from klangk_backend.terminal import service_cmd_window_exists
 
         with patch.object(
             _mock_pod,
@@ -1199,14 +1186,13 @@ class TestEnsureBaseSession:
             new_callable=AsyncMock,
             side_effect=OSError("boom"),
         ):
-            result = await service_cmd_window_exists(
-                "cid", "my-session", podman=_mock_pod
+            result = await _terminal.service_cmd_window_exists(
+                "cid", "my-session"
             )
         assert result is False
 
     async def test_service_cmd_window_exists_rc_nonzero_returns_false(self):
         """service_cmd_window_exists returns False if list-windows fails."""
-        from klangk_backend.terminal import service_cmd_window_exists
 
         with patch.object(
             _mock_pod,
@@ -1214,14 +1200,13 @@ class TestEnsureBaseSession:
             new_callable=AsyncMock,
             return_value=(1, "", ""),  # list-windows fails
         ):
-            result = await service_cmd_window_exists(
-                "cid", "my-session", podman=_mock_pod
+            result = await _terminal.service_cmd_window_exists(
+                "cid", "my-session"
             )
         assert result is False
 
     async def test_has_tmux_session_exception_returns_false(self):
         """has_tmux_session returns False if has-session raises."""
-        from klangk_backend.terminal import has_tmux_session
 
         with patch.object(
             _mock_pod,
@@ -1229,9 +1214,7 @@ class TestEnsureBaseSession:
             new_callable=AsyncMock,
             side_effect=OSError("boom"),
         ):
-            result = await has_tmux_session(
-                "cid", "my-session", podman=_mock_pod
-            )
+            result = await _terminal.has_tmux_session("cid", "my-session")
         assert result is False
 
 
@@ -1242,31 +1225,26 @@ class TestEnsureServiceSession:
     are mocked to isolate the firing logic from tmux-session internals."""
 
     def setup_method(self):
-        # ensure_service_session reaches its per-container firing lock via
-        # app_state.container_registry (#1478). Build one real registry per
-        # test so concurrent same-container calls share the lock dict.
-        import types
-
-        from klangk_backend.container import ContainerRegistry
-        from klangk_backend.settings import KlangkSettings
-
-        registry = ContainerRegistry(KlangkSettings(env={}))
-        self.app_state = types.SimpleNamespace(
-            container_registry=registry, podman=_mock_pod
-        )
+        # ensure_service_session is a Terminal method that reaches the
+        # registry for its firing lock + mark_service_started (#1480).
+        # Reset the module-level mock_registry so call counts are clean.
+        _mock_registry.reset_mock()
+        _mock_registry.get_service_session_lock.return_value = asyncio.Lock()
+        _mock_registry.mark_service_started = MagicMock()
 
     async def test_creates_window_and_sends_command(self):
         """A fresh service session fires the service command in its
         ``service-cmd`` window -> ``service:service-cmd``."""
-        from klangk_backend.terminal import ensure_service_session
 
         with (
-            patch(
-                "klangk_backend.terminal._ensure_tmux_session",
+            patch.object(
+                _terminal,
+                "_ensure_tmux_session",
                 new=AsyncMock(),
             ),
-            patch(
-                "klangk_backend.terminal.service_cmd_window_exists",
+            patch.object(
+                _terminal,
+                "service_cmd_window_exists",
                 new=AsyncMock(return_value=False),
             ),
             patch.object(
@@ -1275,11 +1253,10 @@ class TestEnsureServiceSession:
                 new=AsyncMock(side_effect=[(0, "", ""), (0, "", "")]),
             ) as mock_exec,
         ):
-            await ensure_service_session(
+            await _terminal.ensure_service_session(
                 "cid",
                 "/home/clanker",
                 "openclaw gateway",
-                app_state=self.app_state,
             )
         cmds = [c.args[1] for c in mock_exec.call_args_list]
         # service-cmd window created in the service session.
@@ -1298,42 +1275,40 @@ class TestEnsureServiceSession:
     async def test_ensures_service_session_with_agent_home(self):
         """The service session is ensured with the constant name and the
         agent home as its HOME."""
-        from klangk_backend.terminal import (
-            SERVICE_SESSION,
-            ensure_service_session,
-        )
 
         with (
-            patch(
-                "klangk_backend.terminal._ensure_tmux_session",
+            patch.object(
+                _terminal,
+                "_ensure_tmux_session",
                 new=AsyncMock(),
             ) as mock_ensure,
-            patch(
-                "klangk_backend.terminal.service_cmd_window_exists",
+            patch.object(
+                _terminal,
+                "service_cmd_window_exists",
                 new=AsyncMock(return_value=True),
             ),
         ):
-            await ensure_service_session(
+            await _terminal.ensure_service_session(
                 "cid",
                 "/home/clanker",
                 "openclaw gateway",
-                app_state=self.app_state,
             )
         mock_ensure.assert_awaited_once_with(
-            "cid", SERVICE_SESSION, "/home/clanker", podman=_mock_pod
+            "cid", SERVICE_SESSION, "/home/clanker"
         )
 
     async def test_skips_when_window_already_exists(self):
         """Exactly-once: no new-window/send-keys if service-cmd exists."""
-        from klangk_backend.terminal import ensure_service_session
 
         with (
-            patch(
-                "klangk_backend.terminal._ensure_tmux_session",
+            patch.object(
+                _terminal,
+                "_ensure_tmux_session",
                 new=AsyncMock(),
             ),
-            patch(
-                "klangk_backend.terminal.service_cmd_window_exists",
+            patch.object(
+                _terminal,
+                "service_cmd_window_exists",
                 new=AsyncMock(return_value=True),
             ),
             patch.object(
@@ -1342,11 +1317,10 @@ class TestEnsureServiceSession:
                 new=AsyncMock(),
             ) as mock_exec,
         ):
-            await ensure_service_session(
+            await _terminal.ensure_service_session(
                 "cid",
                 "/home/clanker",
                 "openclaw gateway",
-                app_state=self.app_state,
             )
         cmds = [c.args[1] for c in mock_exec.call_args_list]
         assert not any("new-window" in c for c in cmds)
@@ -1354,15 +1328,16 @@ class TestEnsureServiceSession:
 
     async def test_blocked_when_setup_pending(self):
         """The service command does not fire while setup is pending (#1033)."""
-        from klangk_backend.terminal import ensure_service_session
 
         with (
-            patch(
-                "klangk_backend.terminal._ensure_tmux_session",
+            patch.object(
+                _terminal,
+                "_ensure_tmux_session",
                 new=AsyncMock(),
             ),
-            patch(
-                "klangk_backend.terminal.service_cmd_window_exists",
+            patch.object(
+                _terminal,
+                "service_cmd_window_exists",
                 new=AsyncMock(return_value=False),
             ),
             patch.object(
@@ -1371,12 +1346,11 @@ class TestEnsureServiceSession:
                 new=AsyncMock(),
             ) as mock_exec,
         ):
-            await ensure_service_session(
+            await _terminal.ensure_service_session(
                 "cid",
                 "/home/clanker",
                 "openclaw gateway",
                 setup_state="pending",
-                app_state=self.app_state,
             )
         cmds = [c.args[1] for c in mock_exec.call_args_list]
         assert not any("new-window" in c for c in cmds)
@@ -1384,15 +1358,16 @@ class TestEnsureServiceSession:
 
     async def test_new_window_failure_logs_warning(self):
         """A tmux new-window failure is logged but doesn't raise."""
-        from klangk_backend.terminal import ensure_service_session
 
         with (
-            patch(
-                "klangk_backend.terminal._ensure_tmux_session",
+            patch.object(
+                _terminal,
+                "_ensure_tmux_session",
                 new=AsyncMock(),
             ),
-            patch(
-                "klangk_backend.terminal.service_cmd_window_exists",
+            patch.object(
+                _terminal,
+                "service_cmd_window_exists",
                 new=AsyncMock(return_value=False),
             ),
             patch.object(
@@ -1402,22 +1377,23 @@ class TestEnsureServiceSession:
             ),
             patch("klangk_backend.terminal.logger") as mock_logger,
         ):
-            await ensure_service_session(
-                "cid", "/home/clanker", "cmd", app_state=self.app_state
+            await _terminal.ensure_service_session(
+                "cid", "/home/clanker", "cmd"
             )
         mock_logger.warning.assert_called()
 
     async def test_send_keys_failure_logs_warning(self):
         """A send-keys failure is logged but doesn't raise."""
-        from klangk_backend.terminal import ensure_service_session
 
         with (
-            patch(
-                "klangk_backend.terminal._ensure_tmux_session",
+            patch.object(
+                _terminal,
+                "_ensure_tmux_session",
                 new=AsyncMock(),
             ),
-            patch(
-                "klangk_backend.terminal.service_cmd_window_exists",
+            patch.object(
+                _terminal,
+                "service_cmd_window_exists",
                 new=AsyncMock(return_value=False),
             ),
             patch.object(
@@ -1433,8 +1409,8 @@ class TestEnsureServiceSession:
             ),
             patch("klangk_backend.terminal.logger") as mock_logger,
         ):
-            await ensure_service_session(
-                "cid", "/home/clanker", "cmd", app_state=self.app_state
+            await _terminal.ensure_service_session(
+                "cid", "/home/clanker", "cmd"
             )
         mock_logger.warning.assert_called()
 
@@ -1442,22 +1418,15 @@ class TestEnsureServiceSession:
         """Firing the service command resets the health-check startup-grace
         anchor so the monitor gives the freshly-launched service time to
         boot before a failing poll can flag it unhealthy."""
-        import types
-
-        from klangk_backend.terminal import ensure_service_session
-
-        mock_registry = MagicMock()
-        app_state = types.SimpleNamespace(
-            container_registry=mock_registry, podman=_mock_pod
-        )
-
         with (
-            patch(
-                "klangk_backend.terminal._ensure_tmux_session",
+            patch.object(
+                _terminal,
+                "_ensure_tmux_session",
                 new=AsyncMock(),
             ),
-            patch(
-                "klangk_backend.terminal.service_cmd_window_exists",
+            patch.object(
+                _terminal,
+                "service_cmd_window_exists",
                 new=AsyncMock(return_value=False),
             ),
             patch.object(
@@ -1466,33 +1435,30 @@ class TestEnsureServiceSession:
                 new=AsyncMock(side_effect=[(0, "", ""), (0, "", "")]),
             ),
         ):
-            await ensure_service_session(
+            await _terminal.ensure_service_session(
                 "cid",
                 "/home/clanker",
                 "openclaw gateway",
-                app_state=app_state,
             )
-        mock_registry.mark_service_started.assert_called_once_with("cid")
+        _mock_registry.mark_service_started.assert_called_once_with("cid")
 
     async def test_existing_window_does_not_reset_grace_anchor(self):
         """The no-op path (service-cmd window already exists) never
         re-launched the service, so it must not restart the grace window."""
         import types
 
-        from klangk_backend.terminal import ensure_service_session
-
         mock_registry = MagicMock()
-        app_state = types.SimpleNamespace(
-            container_registry=mock_registry, podman=_mock_pod
-        )
+        types.SimpleNamespace(container_registry=mock_registry)
 
         with (
-            patch(
-                "klangk_backend.terminal._ensure_tmux_session",
+            patch.object(
+                _terminal,
+                "_ensure_tmux_session",
                 new=AsyncMock(),
             ),
-            patch(
-                "klangk_backend.terminal.service_cmd_window_exists",
+            patch.object(
+                _terminal,
+                "service_cmd_window_exists",
                 new=AsyncMock(return_value=True),
             ),
             patch.object(
@@ -1501,11 +1467,10 @@ class TestEnsureServiceSession:
                 new=AsyncMock(),
             ),
         ):
-            await ensure_service_session(
+            await _terminal.ensure_service_session(
                 "cid",
                 "/home/clanker",
                 "openclaw gateway",
-                app_state=app_state,
             )
         mock_registry.mark_service_started.assert_not_called()
 
@@ -1514,20 +1479,18 @@ class TestEnsureServiceSession:
         grace anchor must not advance (no service is booting)."""
         import types
 
-        from klangk_backend.terminal import ensure_service_session
-
         mock_registry = MagicMock()
-        app_state = types.SimpleNamespace(
-            container_registry=mock_registry, podman=_mock_pod
-        )
+        types.SimpleNamespace(container_registry=mock_registry)
 
         with (
-            patch(
-                "klangk_backend.terminal._ensure_tmux_session",
+            patch.object(
+                _terminal,
+                "_ensure_tmux_session",
                 new=AsyncMock(),
             ),
-            patch(
-                "klangk_backend.terminal.service_cmd_window_exists",
+            patch.object(
+                _terminal,
+                "service_cmd_window_exists",
                 new=AsyncMock(return_value=False),
             ),
             patch.object(
@@ -1542,11 +1505,10 @@ class TestEnsureServiceSession:
                 ),
             ),
         ):
-            await ensure_service_session(
+            await _terminal.ensure_service_session(
                 "cid",
                 "/home/clanker",
                 "cmd",
-                app_state=app_state,
             )
         mock_registry.mark_service_started.assert_not_called()
 
@@ -1592,12 +1554,14 @@ class TestEnsureServiceSession:
             return (0, "", "")
 
         with (
-            patch(
-                "klangk_backend.terminal._ensure_tmux_session",
+            patch.object(
+                _terminal,
+                "_ensure_tmux_session",
                 new=AsyncMock(),
             ),
-            patch(
-                "klangk_backend.terminal.service_cmd_window_exists",
+            patch.object(
+                _terminal,
+                "service_cmd_window_exists",
                 side_effect=fake_window_exists,
             ),
             patch.object(
@@ -1608,17 +1572,15 @@ class TestEnsureServiceSession:
             patch("klangk_backend.terminal.asyncio.sleep", new=AsyncMock()),
         ):
             await asyncio.gather(
-                terminal.ensure_service_session(
+                _terminal.ensure_service_session(
                     "cid",
                     "/home/clanker",
                     "openclaw gateway",
-                    app_state=self.app_state,
                 ),
-                terminal.ensure_service_session(
+                _terminal.ensure_service_session(
                     "cid",
                     "/home/clanker",
                     "openclaw gateway",
-                    app_state=self.app_state,
                 ),
             )
 
@@ -1649,12 +1611,14 @@ class TestEnsureServiceSession:
             return (0, "", "")
 
         with (
-            patch(
-                "klangk_backend.terminal._ensure_tmux_session",
+            patch.object(
+                _terminal,
+                "_ensure_tmux_session",
                 new=AsyncMock(),
             ),
-            patch(
-                "klangk_backend.terminal.service_cmd_window_exists",
+            patch.object(
+                _terminal,
+                "service_cmd_window_exists",
                 side_effect=fake_window_exists,
             ),
             patch.object(
@@ -1665,17 +1629,15 @@ class TestEnsureServiceSession:
             patch("klangk_backend.terminal.asyncio.sleep", new=AsyncMock()),
         ):
             await asyncio.gather(
-                terminal.ensure_service_session(
+                _terminal.ensure_service_session(
                     "cid-a",
                     "/home/clanker",
                     "cmd-a",
-                    app_state=self.app_state,
                 ),
-                terminal.ensure_service_session(
+                _terminal.ensure_service_session(
                     "cid-b",
                     "/home/clanker",
                     "cmd-b",
-                    app_state=self.app_state,
                 ),
             )
 
@@ -1688,15 +1650,16 @@ class TestEnsureServiceSession:
     async def test_send_keys_failure_kills_half_created_window(self):
         """A send-keys failure kills the zombie window so the next fire
         re-runs the whole sequence instead of no-oping forever (#1186)."""
-        from klangk_backend.terminal import ensure_service_session
 
         with (
-            patch(
-                "klangk_backend.terminal._ensure_tmux_session",
+            patch.object(
+                _terminal,
+                "_ensure_tmux_session",
                 new=AsyncMock(),
             ),
-            patch(
-                "klangk_backend.terminal.service_cmd_window_exists",
+            patch.object(
+                _terminal,
+                "service_cmd_window_exists",
                 new=AsyncMock(return_value=False),
             ),
             patch.object(
@@ -1712,8 +1675,8 @@ class TestEnsureServiceSession:
             ) as mock_exec,
             patch("klangk_backend.terminal.logger"),
         ):
-            await ensure_service_session(
-                "cid", "/home/clanker", "cmd", app_state=self.app_state
+            await _terminal.ensure_service_session(
+                "cid", "/home/clanker", "cmd"
             )
 
         # The third exec call must be the kill-window cleanup targeting
@@ -1727,15 +1690,16 @@ class TestEnsureServiceSession:
     async def test_send_keys_failure_cleanup_failure_is_logged(self):
         """If the kill-window cleanup itself raises, it's logged but the
         function still returns without raising (#1186)."""
-        from klangk_backend.terminal import ensure_service_session
 
         with (
-            patch(
-                "klangk_backend.terminal._ensure_tmux_session",
+            patch.object(
+                _terminal,
+                "_ensure_tmux_session",
                 new=AsyncMock(),
             ),
-            patch(
-                "klangk_backend.terminal.service_cmd_window_exists",
+            patch.object(
+                _terminal,
+                "service_cmd_window_exists",
                 new=AsyncMock(return_value=False),
             ),
             patch.object(
@@ -1751,8 +1715,8 @@ class TestEnsureServiceSession:
             ),
             patch("klangk_backend.terminal.logger") as mock_logger,
         ):
-            await ensure_service_session(
-                "cid", "/home/clanker", "cmd", app_state=self.app_state
+            await _terminal.ensure_service_session(
+                "cid", "/home/clanker", "cmd"
             )
         # Both the send-keys failure and the cleanup failure are warned.
         assert mock_logger.warning.call_count == 2
@@ -1763,7 +1727,6 @@ class TestServiceSessionHelpers:
     ensure_service_session."""
 
     async def test_service_cmd_window_exists_true_when_present(self):
-        from klangk_backend.terminal import service_cmd_window_exists
 
         with patch.object(
             _mock_pod,
@@ -1772,14 +1735,11 @@ class TestServiceSessionHelpers:
             return_value=(0, "bash\nservice-cmd\n", ""),
         ):
             assert (
-                await service_cmd_window_exists(
-                    "cid", "service", podman=_mock_pod
-                )
+                await _terminal.service_cmd_window_exists("cid", "service")
                 is True
             )
 
     async def test_service_cmd_window_exists_false_when_absent(self):
-        from klangk_backend.terminal import service_cmd_window_exists
 
         with patch.object(
             _mock_pod,
@@ -1788,9 +1748,7 @@ class TestServiceSessionHelpers:
             return_value=(0, "bash\n", ""),
         ):
             assert (
-                await service_cmd_window_exists(
-                    "cid", "service", podman=_mock_pod
-                )
+                await _terminal.service_cmd_window_exists("cid", "service")
                 is False
             )
 

--- a/src/backend/tests/test_terminal.py
+++ b/src/backend/tests/test_terminal.py
@@ -7,6 +7,7 @@ lifecycle/queue logic against an injected fake shell.
 
 import asyncio
 import contextlib
+import types
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -21,7 +22,6 @@ from klangk_backend.terminal import (
     build_shell_command,
     make_shell_process,
     validate_window_name,
-    terminal_tmux_enabled,
 )
 
 SHELL_FACTORY = "klangk_backend.terminal.make_shell_process"
@@ -36,7 +36,16 @@ _mock_pod = MagicMock()
 _mock_registry = MagicMock()
 _mock_registry.get_service_session_lock.return_value = asyncio.Lock()
 _mock_registry.mark_service_started = MagicMock()
-_terminal = Terminal(_mock_pod, _mock_registry)
+# Minimal app_state carrying podman + registry + settings so Terminal can
+# reach all three through its single ctor arg (#1480).
+_mock_settings = MagicMock()
+_mock_settings.disable_tmux = None
+_app_state = types.SimpleNamespace(
+    podman=_mock_pod,
+    container_registry=_mock_registry,
+    settings=_mock_settings,
+)
+_terminal = Terminal(_app_state)
 
 
 class TestShellProcessFactory:
@@ -156,10 +165,8 @@ class TestStart:
         assert s._running is True
         await s.stop()
 
-    async def test_start_uses_plain_shell_when_tmux_disabled(
-        self, monkeypatch
-    ):
-        monkeypatch.setenv("KLANGK_DISABLE_TMUX", "1")
+    async def test_start_uses_plain_shell_when_tmux_disabled(self):
+        _mock_settings.disable_tmux = "1"
         fake = FakeShell(block_after_chunks=True)
         with _patch(fake):
             s = TerminalSession("cid", session_name="uid", terminal=_terminal)
@@ -962,19 +969,19 @@ class TestBuildShellCommandJoinSession:
 
 
 class TestTerminalTmuxEnabled:
-    def test_default_enabled(self, monkeypatch):
-        monkeypatch.delenv("KLANGK_DISABLE_TMUX", raising=False)
-        assert terminal_tmux_enabled() is True
+    def test_default_enabled(self):
+        _mock_settings.disable_tmux = None
+        assert _terminal.tmux_enabled() is True
 
     @pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "Yes"])
-    def test_truthy_disables(self, monkeypatch, val):
-        monkeypatch.setenv("KLANGK_DISABLE_TMUX", val)
-        assert terminal_tmux_enabled() is False
+    def test_truthy_disables(self, val):
+        _mock_settings.disable_tmux = val
+        assert _terminal.tmux_enabled() is False
 
     @pytest.mark.parametrize("val", ["", "0", "false", "no", "off"])
-    def test_other_values_keep_enabled(self, monkeypatch, val):
-        monkeypatch.setenv("KLANGK_DISABLE_TMUX", val)
-        assert terminal_tmux_enabled() is True
+    def test_other_values_keep_enabled(self, val):
+        _mock_settings.disable_tmux = val
+        assert _terminal.tmux_enabled() is True
 
 
 class TestBuildShellCommandTmuxDisabled:

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -1261,7 +1261,6 @@ class TestHandleTerminalStart:
             "/home/clanker",
             "./serve",
             setup_state="complete",
-            app_state=app_state,
         )
         assert "service_command" not in MockTS.call_args.kwargs
 
@@ -1673,7 +1672,6 @@ class TestHandleTerminalStart:
             "/home/clanker",
             "pi",
             setup_state="complete",
-            app_state=app_state,
         )
 
         conn.terminal_task.cancel()
@@ -6698,7 +6696,6 @@ class TestTerminalController:
         """_fire_service_command reads fresh setup_state from the DB,
         resolves the agent home, and targets the service session (#1133)."""
         ctrl, _, conn = self._controller()
-        app_state = conn.app_state
         conn._service_command = "./run.sh"
         with (
             patch(
@@ -6721,7 +6718,6 @@ class TestTerminalController:
             "/home/clanker",
             "./run.sh",
             setup_state="complete",
-            app_state=app_state,
         )
 
     async def test_fire_service_command_no_service_command_noop(self):

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -63,6 +63,24 @@ def _trusted_default():
 _mock_pod = MagicMock()
 _mock_pod.exec_container = AsyncMock(return_value=(0, "", ""))
 
+# #1480: shared mock Terminal whose methods tests patch via
+# patch.object(_mock_term, ...).
+_mock_term = MagicMock()
+_mock_term.podman = _mock_pod
+_mock_term.ensure_base_session = AsyncMock()
+_mock_term.attach_browser = AsyncMock()
+_mock_term.set_workspace_token = AsyncMock()
+_mock_term.list_windows = AsyncMock(return_value=[])
+_mock_term.ensure_service_session = AsyncMock()
+_mock_term.tmux_command = AsyncMock(return_value="")
+_mock_term.new_window = AsyncMock(return_value=[])
+_mock_term.select_window = AsyncMock()
+_mock_term.close_window = AsyncMock(return_value=[])
+_mock_term.rename_window = AsyncMock()
+_mock_term.kill_joiner_sessions = AsyncMock()
+_mock_term.has_tmux_session = AsyncMock(return_value=False)
+_mock_term.service_cmd_window_exists = AsyncMock(return_value=False)
+
 
 def _make_app_state(registry=None, sockets=None):
     """Build a minimal app_state for tests."""
@@ -85,6 +103,9 @@ def _make_app_state(registry=None, sockets=None):
     sockets.app_state = app_state
     app_state.podman = _mock_pod
     registry.podman = _mock_pod
+    # #1480: shared mock Terminal wired onto app_state. Tests patch
+    # its methods via patch.object(_mock_term, ...).
+    app_state.terminal = _mock_term
     return app_state
 
 
@@ -1097,13 +1118,14 @@ class TestHandleTerminalStart:
 
         with (
             patch.object(_ws_controllers, "TerminalSession") as MockTS,
-            patch(
-                "klangk_backend.terminal.list_windows",
+            patch.object(
+                _mock_term,
+                "list_windows",
                 return_value=[
                     {"id": "@0", "index": 0, "name": "bash", "active": True}
                 ],
             ),
-            patch.object(_ws_controllers, "attach_browser"),
+            patch.object(_mock_term, "attach_browser", new_callable=AsyncMock),
             patch.object(
                 _ws_controllers.TerminalController,
                 "_sync_service_windows",
@@ -1132,7 +1154,7 @@ class TestHandleTerminalStart:
             user_id="uid",
             user_handle="testuser",
             ssh_agent_socket=None,
-            podman=_mock_pod,
+            terminal=_mock_term,
         )
         # Should have sent terminal_windows and shared_terminals
         sent = [c[0][0] for c in sock.send_json.call_args_list]
@@ -1198,13 +1220,14 @@ class TestHandleTerminalStart:
 
         with (
             patch.object(_ws_controllers, "TerminalSession") as MockTS,
-            patch(
-                "klangk_backend.terminal.list_windows",
+            patch.object(
+                _mock_term,
+                "list_windows",
                 return_value=[
                     {"id": "@0", "index": 0, "name": "bash", "active": True}
                 ],
             ),
-            patch.object(_ws_controllers, "attach_browser"),
+            patch.object(_mock_term, "attach_browser", new_callable=AsyncMock),
             patch(
                 "klangk_backend.wshandler.controllers.model.get_workspace",
                 new=AsyncMock(return_value={"setup_state": "complete"}),
@@ -1213,8 +1236,8 @@ class TestHandleTerminalStart:
                 "klangk_backend.wshandler.controllers.model.agent_handle",
                 new=AsyncMock(return_value="clanker"),
             ),
-            patch(
-                "klangk_backend.wshandler.controllers.terminal."
+            patch.object(
+                _mock_term,
                 "ensure_service_session",
                 new=AsyncMock(),
             ) as mock_ess,
@@ -1330,14 +1353,16 @@ class TestHandleTerminalStart:
 
         with (
             patch.object(_ws_controllers, "TerminalSession") as MockTS,
-            patch(
-                "klangk_backend.terminal.list_windows",
+            patch.object(
+                _mock_term,
+                "list_windows",
                 return_value=[
                     {"id": "@0", "index": 0, "name": "bash", "active": True}
                 ],
             ),
-            patch(
-                "klangk_backend.terminal.tmux_command",
+            patch.object(
+                _mock_term,
+                "tmux_command",
                 side_effect=RuntimeError("rename failed"),
             ),
         ):
@@ -1388,8 +1413,9 @@ class TestHandleTerminalStart:
 
         with (
             patch.object(_ws_controllers, "TerminalSession") as MockTS,
-            patch(
-                "klangk_backend.terminal.list_windows",
+            patch.object(
+                _mock_term,
+                "list_windows",
                 side_effect=TerminalError("tmux not ready"),
             ),
         ):
@@ -1436,13 +1462,14 @@ class TestHandleTerminalStart:
 
         with (
             patch.object(_ws_controllers, "TerminalSession") as MockTS,
-            patch(
-                "klangk_backend.terminal.list_windows",
+            patch.object(
+                _mock_term,
+                "list_windows",
                 return_value=[
                     {"id": "@0", "index": 0, "name": "1", "active": True}
                 ],
             ),
-            patch("klangk_backend.terminal.tmux_command", return_value=""),
+            patch.object(_mock_term, "tmux_command", return_value=""),
         ):
             mock_session = _mock_terminal()
             MockTS.return_value = mock_session
@@ -1486,7 +1513,7 @@ class TestHandleTerminalStart:
 
         with (
             patch.object(_ws_controllers, "TerminalSession") as MockTS,
-            patch.object(_ws_controllers, "attach_browser"),
+            patch.object(_mock_term, "attach_browser", new_callable=AsyncMock),
         ):
             mock_session = _mock_terminal()
             MockTS.return_value = mock_session
@@ -1539,13 +1566,15 @@ class TestHandleTerminalStart:
         registry.register_browser("bid-old", "ws", sock)
         conn.browser_id = "bid-old"
 
-        with patch.object(_ws_controllers, "attach_browser") as mock_attach:
+        with patch.object(
+            _mock_term, "attach_browser", new_callable=AsyncMock
+        ) as mock_attach:
             await conn.handle_browser_reattach({"browser_id": "bid-new"})
 
         assert conn.browser_id == "bid-new"
         assert registry.resolve_browser("bid-new") == ("ws", sock)
         assert registry.resolve_browser("bid-old") is None
-        mock_attach.assert_awaited_once_with("cid", "bid-new", _mock_pod)
+        mock_attach.assert_awaited_once_with("cid", "bid-new")
 
         registry.revoke_workspace_browsers("ws")
 
@@ -1557,7 +1586,9 @@ class TestHandleTerminalStart:
         conn.workspace_id = "ws"
         conn.browser_id = "bid-existing"
 
-        with patch.object(_ws_controllers, "attach_browser") as mock_attach:
+        with patch.object(
+            _mock_term, "attach_browser", new_callable=AsyncMock
+        ) as mock_attach:
             await conn.handle_browser_reattach({})
 
         assert conn.browser_id == "bid-existing"
@@ -1570,7 +1601,9 @@ class TestHandleTerminalStart:
         conn.container_id = None
         conn.workspace_id = "ws"
 
-        with patch.object(_ws_controllers, "attach_browser") as mock_attach:
+        with patch.object(
+            _mock_term, "attach_browser", new_callable=AsyncMock
+        ) as mock_attach:
             await conn.handle_browser_reattach({"browser_id": "bid-new"})
 
         assert conn.browser_id is None
@@ -1600,7 +1633,7 @@ class TestHandleTerminalStart:
             patch(
                 "klangk_backend.wshandler.controllers.TerminalSession", MockTS
             ),
-            patch.object(_ws_controllers, "attach_browser"),
+            patch.object(_mock_term, "attach_browser", new_callable=AsyncMock),
             patch(
                 "klangk_backend.wshandler.controllers.model.get_workspace",
                 new=AsyncMock(return_value={"setup_state": "complete"}),
@@ -1609,8 +1642,8 @@ class TestHandleTerminalStart:
                 "klangk_backend.wshandler.controllers.model.agent_handle",
                 new=AsyncMock(return_value="clanker"),
             ),
-            patch(
-                "klangk_backend.wshandler.controllers.terminal."
+            patch.object(
+                _mock_term,
                 "ensure_service_session",
                 new=AsyncMock(),
             ) as mock_ess,
@@ -1633,7 +1666,7 @@ class TestHandleTerminalStart:
             user_id="uid",
             user_handle="testuser",
             ssh_agent_socket=None,
-            podman=_mock_pod,
+            terminal=_mock_term,
         )
         mock_ess.assert_awaited_once_with(
             "cid",
@@ -1854,7 +1887,9 @@ class TestHandleSetHandle:
             new_callable=AsyncMock,
         ) as mock_skel:
             await conn.handle_set_handle({"handle": "alice"})
-        mock_skel.assert_awaited_once_with("cid", user["id"], _mock_pod)
+        mock_skel.assert_awaited_once_with(
+            "cid", user["id"], conn.app_state.podman
+        )
         sent = sock.send_json.call_args_list
         assert any(
             call.args[0].get("type") == "handle_set"
@@ -3500,12 +3535,14 @@ class TestSSHAgentHandlers:
                 return_value=mock_session,
             ) as MockTS,
             patch.object(registry, "record_activity"),
-            patch(
-                "klangk_backend.wshandler.controllers.attach_browser",
+            patch.object(
+                _mock_term,
+                "attach_browser",
                 new=AsyncMock(),
             ),
-            patch(
-                "klangk_backend.terminal.list_windows",
+            patch.object(
+                _mock_term,
+                "list_windows",
                 return_value=[],
             ),
             patch.object(
@@ -3527,7 +3564,7 @@ class TestSSHAgentHandlers:
             user_id="uid",
             user_handle="testuser",
             ssh_agent_socket="/tmp/klangk-ssh-agent-uid.sock",
-            podman=_mock_pod,
+            terminal=_mock_term,
         )
 
 
@@ -3554,7 +3591,7 @@ class TestSshAgentForwarder:
             sock=sock,
             user=user,
             container_id=container_id,
-            app_state=SimpleNamespace(podman=_mock_pod),
+            app_state=SimpleNamespace(podman=_mock_pod, terminal=_mock_term),
         )
         return SshAgentForwarder(conn), sock
 
@@ -5779,8 +5816,9 @@ class TestTerminalWindowHandlers:
         conn = _base_conn(ws=sock)
         conn.container_id = "cid"
         conn._user_home = "/home/alice"
-        with patch(
-            "klangk_backend.terminal.new_window",
+        with patch.object(
+            _mock_term,
+            "new_window",
             return_value=[
                 {"id": "@0", "index": 0, "name": "bash", "active": False},
                 {"id": "@1", "index": 1, "name": "bash", "active": True},
@@ -5796,25 +5834,25 @@ class TestTerminalWindowHandlers:
         conn = _base_conn(ws=sock)
         conn.container_id = "cid"
         conn._user_home = "/home/alice"
-        with patch(
-            "klangk_backend.terminal.new_window",
+        with patch.object(
+            _mock_term,
+            "new_window",
             return_value=[
                 {"id": "@0", "index": 0, "name": "bash", "active": False},
                 {"id": "@1", "index": 1, "name": "build", "active": True},
             ],
         ) as mock_new:
             await conn.handle_terminal_new_window({"name": "build"})
-        mock_new.assert_called_once_with(
-            "cid", "uid", name="build", podman=_mock_pod
-        )
+        mock_new.assert_called_once_with("cid", "uid", name="build")
 
     async def test_new_window_error(self):
         sock = _mock_sock()
         conn = _base_conn(ws=sock)
         conn.container_id = "cid"
         conn._user_home = "/home/alice"
-        with patch(
-            "klangk_backend.terminal.new_window",
+        with patch.object(
+            _mock_term,
+            "new_window",
             side_effect=ValueError("already exists"),
         ):
             await conn.handle_terminal_new_window({"name": "dup"})
@@ -5826,30 +5864,33 @@ class TestTerminalWindowHandlers:
         conn = _base_conn(ws=sock)
         conn.container_id = "cid"
         conn._user_home = "/home/alice"
-        with patch(
-            "klangk_backend.terminal.select_window",
+        with patch.object(
+            _mock_term,
+            "select_window",
         ) as mock_sel:
             await conn.handle_terminal_select_window({"index": 2})
-        mock_sel.assert_called_once_with("cid", "uid", 2, _mock_pod)
+        mock_sel.assert_called_once_with("cid", "uid", 2)
 
     async def test_select_window_by_id(self):
         sock = _mock_sock()
         conn = _base_conn(ws=sock)
         conn.container_id = "cid"
         conn._user_home = "/home/alice"
-        with patch(
-            "klangk_backend.terminal.select_window",
+        with patch.object(
+            _mock_term,
+            "select_window",
         ) as mock_sel:
             await conn.handle_terminal_select_window({"window_id": "@3"})
-        mock_sel.assert_called_once_with("cid", "uid", "@3", _mock_pod)
+        mock_sel.assert_called_once_with("cid", "uid", "@3")
 
     async def test_select_window_error(self):
         sock = _mock_sock()
         conn = _base_conn(ws=sock)
         conn.container_id = "cid"
         conn._user_home = "/home/alice"
-        with patch(
-            "klangk_backend.terminal.select_window",
+        with patch.object(
+            _mock_term,
+            "select_window",
             side_effect=TerminalError("no such window"),
         ):
             await conn.handle_terminal_select_window({"index": 99})
@@ -5861,8 +5902,9 @@ class TestTerminalWindowHandlers:
         conn = _base_conn(ws=sock)
         conn.container_id = "cid"
         conn._user_home = "/home/alice"
-        with patch(
-            "klangk_backend.terminal.close_window",
+        with patch.object(
+            _mock_term,
+            "close_window",
             return_value=[
                 {"id": "@0", "index": 0, "name": "bash", "active": True}
             ],
@@ -5880,8 +5922,9 @@ class TestTerminalWindowHandlers:
                 {"name": "bash", "index": 0, "id": "@0", "shared": True},
                 {"name": "1", "index": 1, "id": "@1", "shared": False},
             ]
-            with patch(
-                "klangk_backend.terminal.close_window",
+            with patch.object(
+                _mock_term,
+                "close_window",
                 return_value=[
                     {"id": "@1", "index": 1, "name": "1", "active": True}
                 ],
@@ -5901,8 +5944,9 @@ class TestTerminalWindowHandlers:
         conn = _base_conn(ws=sock)
         conn.container_id = "cid"
         conn._user_home = "/home/alice"
-        with patch(
-            "klangk_backend.terminal.close_window",
+        with patch.object(
+            _mock_term,
+            "close_window",
             side_effect=TerminalError("no such window"),
         ):
             await conn.handle_terminal_close_window({"index": 99})
@@ -5915,11 +5959,13 @@ class TestTerminalWindowHandlers:
         conn.container_id = "cid"
         conn._user_home = "/home/alice"
         with (
-            patch(
-                "klangk_backend.terminal.rename_window",
+            patch.object(
+                _mock_term,
+                "rename_window",
             ),
-            patch(
-                "klangk_backend.terminal.list_windows",
+            patch.object(
+                _mock_term,
+                "list_windows",
                 return_value=[
                     {"id": "@0", "index": 0, "name": "build", "active": True}
                 ],
@@ -5946,8 +5992,9 @@ class TestTerminalWindowHandlers:
         conn = _base_conn(ws=sock)
         conn.container_id = "cid"
         conn._user_home = "/home/alice"
-        with patch(
-            "klangk_backend.terminal.rename_window",
+        with patch.object(
+            _mock_term,
+            "rename_window",
             side_effect=ValueError("already exists"),
         ):
             await conn.handle_terminal_rename_window(
@@ -5961,8 +6008,9 @@ class TestTerminalWindowHandlers:
         conn = _base_conn(ws=sock)
         conn.container_id = "cid"
         conn._user_home = "/home/alice"
-        with patch(
-            "klangk_backend.terminal.list_windows",
+        with patch.object(
+            _mock_term,
+            "list_windows",
             return_value=[
                 {"id": "@0", "index": 0, "name": "bash", "active": True}
             ],
@@ -5977,8 +6025,9 @@ class TestTerminalWindowHandlers:
         conn = _base_conn(ws=sock)
         conn.container_id = "cid"
         conn._user_home = "/home/alice"
-        with patch(
-            "klangk_backend.terminal.list_windows",
+        with patch.object(
+            _mock_term,
+            "list_windows",
             side_effect=TerminalError("tmux not running"),
         ):
             await conn.handle_terminal_list_windows()
@@ -6376,8 +6425,9 @@ class TestTerminalController:
 
     async def test_new_window_error_sends_error(self):
         ctrl, sock, _ = self._controller()
-        with patch(
-            "klangk_backend.terminal.new_window",
+        with patch.object(
+            _mock_term,
+            "new_window",
             side_effect=ValueError("boom"),
         ):
             await ctrl.new_window({"name": "x"})
@@ -6400,8 +6450,9 @@ class TestTerminalController:
 
     async def test_list_windows_error_sends_error(self):
         ctrl, sock, _ = self._controller()
-        with patch(
-            "klangk_backend.terminal.list_windows",
+        with patch.object(
+            _mock_term,
+            "list_windows",
             side_effect=OSError("boom"),
         ):
             await ctrl.list_windows()
@@ -6417,18 +6468,18 @@ class TestTerminalController:
         session = MagicMock()
         session.tmux_session_name = "grouped"
         ctrl.session = session
-        with patch("klangk_backend.terminal.select_window") as sel:
+        with patch.object(_mock_term, "select_window") as sel:
             await ctrl.select_window({"window_id": "@2"})
-        sel.assert_called_once_with("cid", "grouped", "@2", _mock_pod)
+        sel.assert_called_once_with("cid", "grouped", "@2")
 
     async def test_select_window_falls_back_to_tmux_session_name(self):
         ctrl, _, _ = self._controller()
         session = MagicMock()
         session.tmux_session_name = None
         ctrl.session = session
-        with patch("klangk_backend.terminal.select_window") as sel:
+        with patch.object(_mock_term, "select_window") as sel:
             await ctrl.select_window({"index": 1})
-        sel.assert_called_once_with("cid", "uid", 1, _mock_pod)
+        sel.assert_called_once_with("cid", "uid", 1)
 
     # --- sync / notify helpers ---
 
@@ -6520,8 +6571,8 @@ class TestTerminalController:
         ws_session = sockets.get_or_create_session("ws-1", app_state)
         try:
             with (
-                patch(
-                    "klangk_backend.wshandler.controllers.terminal."
+                patch.object(
+                    _mock_term,
                     "list_windows",
                     new=AsyncMock(
                         return_value=[
@@ -6565,8 +6616,9 @@ class TestTerminalController:
         ctrl, _, _ = self._controller(app_state=app_state)
         ws_session = sockets.get_or_create_session("ws-1", app_state)
         try:
-            with patch(
-                "klangk_backend.wshandler.controllers.terminal.list_windows",
+            with patch.object(
+                _mock_term,
+                "list_windows",
                 new=AsyncMock(side_effect=TerminalError),
             ):
                 assert await ctrl._sync_service_windows(ws_session) is False
@@ -6579,8 +6631,9 @@ class TestTerminalController:
         ctrl, _, _ = self._controller(app_state=app_state)
         ws_session = sockets.get_or_create_session("ws-1", app_state)
         try:
-            with patch(
-                "klangk_backend.wshandler.controllers.terminal.list_windows",
+            with patch.object(
+                _mock_term,
+                "list_windows",
                 new=AsyncMock(return_value=[]),
             ):
                 assert await ctrl._sync_service_windows(ws_session) is False
@@ -6596,8 +6649,8 @@ class TestTerminalController:
         ws_session = sockets.get_or_create_session("ws-1", app_state)
         try:
             with (
-                patch(
-                    "klangk_backend.wshandler.controllers.terminal."
+                patch.object(
+                    _mock_term,
                     "list_windows",
                     new=AsyncMock(
                         return_value=[
@@ -6656,8 +6709,8 @@ class TestTerminalController:
                 "klangk_backend.wshandler.controllers.model.agent_handle",
                 new=AsyncMock(return_value="clanker"),
             ),
-            patch(
-                "klangk_backend.wshandler.controllers.terminal."
+            patch.object(
+                _mock_term,
                 "ensure_service_session",
                 new=AsyncMock(),
             ) as mock_ess,
@@ -6674,8 +6727,8 @@ class TestTerminalController:
     async def test_fire_service_command_no_service_command_noop(self):
         ctrl, _, conn = self._controller()
         conn._service_command = None
-        with patch(
-            "klangk_backend.wshandler.controllers.terminal."
+        with patch.object(
+            _mock_term,
             "ensure_service_session",
             new=AsyncMock(),
         ) as mock_ess:
@@ -6685,8 +6738,8 @@ class TestTerminalController:
     async def test_fire_service_command_no_container_noop(self):
         ctrl, _, conn = self._controller(container_id=None)
         conn._service_command = "./run.sh"
-        with patch(
-            "klangk_backend.wshandler.controllers.terminal."
+        with patch.object(
+            _mock_term,
             "ensure_service_session",
             new=AsyncMock(),
         ) as mock_ess:
@@ -6712,15 +6765,16 @@ class TestTerminalController:
         with (
             patch.object(registry, "revoke_browser") as rev,
             patch.object(registry, "register_browser") as reg,
-            patch(
-                "klangk_backend.wshandler.controllers.attach_browser",
+            patch.object(
+                _mock_term,
+                "attach_browser",
                 new=AsyncMock(),
             ) as attach,
         ):
             await ctrl.browser_reattach({"browser_id": "bid"})
         rev.assert_called_once_with(conn.sock)
         reg.assert_called_once_with("bid", "ws-1", conn.sock)
-        attach.assert_awaited_once_with("cid", "bid", _mock_pod)
+        attach.assert_awaited_once_with("cid", "bid")
         assert conn.browser_id == "bid"
 
     # --- tmux_session_name ---
@@ -6878,9 +6932,7 @@ class TestShareWindowHandlers:
                 patch(
                     "klangk_backend.acl.check_permission", return_value=True
                 ),
-                patch(
-                    "klangk_backend.terminal.kill_joiner_sessions"
-                ) as mock_kill,
+                patch.object(_mock_term, "kill_joiner_sessions") as mock_kill,
             ):
                 await conn.handle_unshare_window({"window_id": "@0"})
             assert session.terminal_windows[user["id"]][0]["shared"] is False
@@ -6988,8 +7040,9 @@ class TestShareWindowHandlers:
                 patch(
                     "klangk_backend.acl.check_permission", return_value=True
                 ),
-                patch(
-                    "klangk_backend.terminal.new_window",
+                patch.object(
+                    _mock_term,
+                    "new_window",
                     return_value=[
                         {"id": "@0", "index": 0, "name": "1", "active": False},
                         {
@@ -7136,8 +7189,9 @@ class TestShareWindowHandlers:
                 patch(
                     "klangk_backend.acl.check_permission", return_value=True
                 ),
-                patch(
-                    "klangk_backend.terminal.kill_joiner_sessions",
+                patch.object(
+                    _mock_term,
+                    "kill_joiner_sessions",
                     side_effect=TerminalError("no sessions"),
                 ),
             ):
@@ -7169,8 +7223,8 @@ class TestShareWindowHandlers:
                     "klangk_backend.acl.check_permission", return_value=True
                 ),
                 patch.object(_ws_controllers, "TerminalSession") as MockTS,
-                patch("klangk_backend.terminal.select_window"),
-                patch("klangk_backend.terminal.tmux_command", return_value=""),
+                patch.object(_mock_term, "select_window"),
+                patch.object(_mock_term, "tmux_command", return_value=""),
             ):
                 mock_sess = _mock_terminal()
                 MockTS.return_value = mock_sess
@@ -7225,8 +7279,8 @@ class TestShareWindowHandlers:
                     "klangk_backend.acl.check_permission", return_value=True
                 ),
                 patch.object(_ws_controllers, "TerminalSession") as MockTS,
-                patch("klangk_backend.terminal.select_window"),
-                patch("klangk_backend.terminal.tmux_command", return_value=""),
+                patch.object(_mock_term, "select_window"),
+                patch.object(_mock_term, "tmux_command", return_value=""),
             ):
                 mock_sess = _mock_terminal()
                 MockTS.return_value = mock_sess
@@ -7316,8 +7370,9 @@ class TestShareWindowHandlers:
                     "klangk_backend.acl.check_permission", return_value=True
                 ),
                 patch.object(_ws_controllers, "TerminalSession") as MockTS,
-                patch(
-                    "klangk_backend.terminal.tmux_command",
+                patch.object(
+                    _mock_term,
+                    "tmux_command",
                     new_callable=AsyncMock,
                 ),
             ):
@@ -7365,13 +7420,15 @@ class TestShareWindowHandlers:
                     "klangk_backend.acl.check_permission", return_value=True
                 ),
                 patch.object(_ws_controllers, "TerminalSession") as MockTS,
-                patch(
-                    "klangk_backend.terminal.tmux_command",
+                patch.object(
+                    _mock_term,
+                    "tmux_command",
                     new_callable=AsyncMock,
                     side_effect=TerminalError("can't find session"),
                 ),
-                patch(
-                    "klangk_backend.terminal.select_window",
+                patch.object(
+                    _mock_term,
+                    "select_window",
                     new_callable=AsyncMock,
                 ) as mock_select,
             ):
@@ -7391,9 +7448,7 @@ class TestShareWindowHandlers:
                 await asyncio.sleep(0)
 
             # Fell back to select_window with bare @N
-            mock_select.assert_awaited_once_with(
-                "cid", owner["id"], "@0", _mock_pod
-            )
+            mock_select.assert_awaited_once_with("cid", owner["id"], "@0")
         finally:
             sockets.sessions.pop("ws-1", None)
             sockets.connections.pop(sock, None)
@@ -7428,8 +7483,9 @@ class TestShareWindowHandlers:
                     "klangk_backend.acl.check_permission", return_value=True
                 ),
                 patch.object(_ws_controllers, "TerminalSession") as MockTS,
-                patch(
-                    "klangk_backend.terminal.select_window",
+                patch.object(
+                    _mock_term,
+                    "select_window",
                     new_callable=AsyncMock,
                 ) as mock_select,
             ):
@@ -7449,9 +7505,7 @@ class TestShareWindowHandlers:
                 )
                 await asyncio.sleep(0)
 
-            mock_select.assert_awaited_once_with(
-                "cid", owner["id"], "@0", _mock_pod
-            )
+            mock_select.assert_awaited_once_with("cid", owner["id"], "@0")
         finally:
             sockets.sessions.pop("ws-1", None)
             sockets.connections.pop(sock, None)
@@ -7544,8 +7598,8 @@ class TestShareWindowHandlers:
                 patch(
                     "klangk_backend.acl.check_permission", return_value=True
                 ),
-                patch("klangk_backend.terminal.kill_joiner_sessions"),
-                patch("klangk_backend.terminal.close_window", return_value=[]),
+                patch.object(_mock_term, "kill_joiner_sessions"),
+                patch.object(_mock_term, "close_window", return_value=[]),
             ):
                 await conn.handle_delete_shared_terminal(
                     {"user_id": user["id"], "window_id": "@1"}
@@ -7663,8 +7717,8 @@ class TestShareWindowHandlers:
                 patch(
                     "klangk_backend.acl.check_permission", return_value=True
                 ),
-                patch("klangk_backend.terminal.kill_joiner_sessions"),
-                patch("klangk_backend.terminal.close_window", return_value=[]),
+                patch.object(_mock_term, "kill_joiner_sessions"),
+                patch.object(_mock_term, "close_window", return_value=[]),
             ):
                 await conn.handle_delete_shared_terminal(
                     {"user_id": other["id"], "window_id": "@0"}
@@ -7687,8 +7741,9 @@ class TestShareWindowHandlers:
                 patch(
                     "klangk_backend.acl.check_permission", return_value=True
                 ),
-                patch(
-                    "klangk_backend.terminal.kill_joiner_sessions",
+                patch.object(
+                    _mock_term,
+                    "kill_joiner_sessions",
                     side_effect=RuntimeError("boom"),
                 ),
             ):
@@ -7708,7 +7763,7 @@ class TestShareWindowHandlers:
         conn.workspace_id = "no-session"
         with (
             patch("klangk_backend.acl.check_permission", return_value=True),
-            patch("klangk_backend.terminal.new_window", return_value=[]),
+            patch.object(_mock_term, "new_window", return_value=[]),
         ):
             await conn.handle_create_shared_terminal({"name": "dev"})
         # Early return after new_window — no crash
@@ -7757,8 +7812,9 @@ class TestShareWindowHandlers:
         conn.workspace_id = "ws-1"
         with (
             patch("klangk_backend.acl.check_permission", return_value=True),
-            patch(
-                "klangk_backend.terminal.new_window",
+            patch.object(
+                _mock_term,
+                "new_window",
                 side_effect=RuntimeError("fail"),
             ),
         ):
@@ -8000,10 +8056,10 @@ class TestSharedTerminalController:
             {"id": "@0", "name": "a", "shared": True}
         ]
         try:
-            with patch("klangk_backend.terminal.kill_joiner_sessions") as kill:
+            with patch.object(_mock_term, "kill_joiner_sessions") as kill:
                 await ctrl.unshare_window({"window_id": "@0"})
             assert ws.terminal_windows[user["id"]][0]["shared"] is False
-            kill.assert_awaited_once_with("cid", "uid", _mock_pod)
+            kill.assert_awaited_once_with("cid", "uid")
         finally:
             sockets.sessions.pop("ws-1", None)
 
@@ -8017,8 +8073,9 @@ class TestSharedTerminalController:
             {"id": "@0", "name": "a", "shared": True}
         ]
         try:
-            with patch(
-                "klangk_backend.terminal.kill_joiner_sessions",
+            with patch.object(
+                _mock_term,
+                "kill_joiner_sessions",
                 side_effect=OSError("boom"),
             ):
                 # Should not raise.
@@ -8106,8 +8163,9 @@ class TestSharedTerminalController:
         ws = self._ws_session(app_state=app_state)
         await ws.add_subscriber(sock, "cid")
         try:
-            with patch(
-                "klangk_backend.terminal.new_window",
+            with patch.object(
+                _mock_term,
+                "new_window",
                 return_value=[{"id": "@0", "index": 0, "name": "build"}],
             ):
                 await ctrl.create_shared_terminal({"name": "build"})
@@ -8128,8 +8186,9 @@ class TestSharedTerminalController:
         self, user, temp_data_dir
     ):
         ctrl, sock, _ = self._controller(user=user)
-        with patch(
-            "klangk_backend.terminal.new_window",
+        with patch.object(
+            _mock_term,
+            "new_window",
             side_effect=OSError("boom"),
         ):
             await ctrl.create_shared_terminal({"name": "x"})
@@ -8137,8 +8196,9 @@ class TestSharedTerminalController:
 
     async def test_create_shared_terminal_no_session(self, user):
         ctrl, _, _ = self._controller(user=user, workspace_id="none")
-        with patch(
-            "klangk_backend.terminal.new_window",
+        with patch.object(
+            _mock_term,
+            "new_window",
             return_value=[{"id": "@0", "index": 0, "name": "x"}],
         ):
             await ctrl.create_shared_terminal({"name": "x"})
@@ -8211,14 +8271,14 @@ class TestSharedTerminalController:
                     "klangk_backend.model.get_workspace_by_id",
                     new=AsyncMock(return_value={"user_id": user["id"]}),
                 ),
-                patch("klangk_backend.terminal.kill_joiner_sessions") as kill,
-                patch("klangk_backend.terminal.close_window") as close,
+                patch.object(_mock_term, "kill_joiner_sessions") as kill,
+                patch.object(_mock_term, "close_window") as close,
             ):
                 await ctrl.delete_shared_terminal(
                     {"user_id": "owner-1", "window_id": "@0"}
                 )
-            kill.assert_awaited_once_with("cid", "owner-1", _mock_pod)
-            close.assert_awaited_once_with("cid", "owner-1", "@0", _mock_pod)
+            kill.assert_awaited_once_with("cid", "owner-1")
+            close.assert_awaited_once_with("cid", "owner-1", "@0")
             remaining = ws.terminal_windows["owner-1"]
             assert [w["id"] for w in remaining] == ["@1"]
             sent = [c[0][0] for c in sock.send_json.call_args_list]
@@ -8240,8 +8300,9 @@ class TestSharedTerminalController:
             {"id": "@0", "index": 0, "name": "build", "shared": True}
         ]
         try:
-            with patch(
-                "klangk_backend.terminal.kill_joiner_sessions",
+            with patch.object(
+                _mock_term,
+                "kill_joiner_sessions",
                 side_effect=OSError("boom"),
             ):
                 await ctrl.delete_shared_terminal(
@@ -8298,8 +8359,8 @@ class TestSharedTerminalController:
         try:
             with (
                 patch.object(_ws_controllers, "TerminalSession") as MockTS,
-                patch("klangk_backend.terminal.tmux_command"),
-                patch("klangk_backend.terminal.select_window"),
+                patch.object(_mock_term, "tmux_command"),
+                patch.object(_mock_term, "select_window"),
             ):
                 mock_sess = _mock_terminal()
                 MockTS.return_value = mock_sess
@@ -8331,11 +8392,12 @@ class TestSharedTerminalController:
         try:
             with (
                 patch.object(_ws_controllers, "TerminalSession") as MockTS,
-                patch(
-                    "klangk_backend.terminal.tmux_command",
+                patch.object(
+                    _mock_term,
+                    "tmux_command",
                     side_effect=TerminalError("nope"),
                 ),
-                patch("klangk_backend.terminal.select_window"),
+                patch.object(_mock_term, "select_window"),
             ):
                 mock_sess = _mock_terminal()
                 mock_sess.start = AsyncMock(side_effect=OSError("boom"))
@@ -10118,8 +10180,9 @@ class TestTokenRenewal:
                     "WORKSPACE_TOKEN_EXPIRE_HOURS",
                     0.0001,
                 ),
-                patch(
-                    "klangk_backend.terminal.set_workspace_token",
+                patch.object(
+                    _mock_term,
+                    "set_workspace_token",
                     new_callable=AsyncMock,
                 ) as mock_set,
             ):
@@ -10133,7 +10196,7 @@ class TestTokenRenewal:
                     pass
 
             assert mock_set.call_count >= 1
-            cid, token, _podman = mock_set.call_args.args
+            cid, token = mock_set.call_args.args
             assert cid == "test-cid"
             decoded = wshandler.auth.decode_workspace_token(token)
             assert decoded == workspace["id"]
@@ -10151,7 +10214,7 @@ class TestTokenRenewal:
         try:
             call_count = 0
 
-            async def fail_then_succeed(cid, token, podman=None):
+            async def fail_then_succeed(cid, token):
                 nonlocal call_count
                 call_count += 1
                 if call_count == 1:
@@ -10169,8 +10232,9 @@ class TestTokenRenewal:
                     "WORKSPACE_TOKEN_EXPIRE_HOURS",
                     0.0001,
                 ),
-                patch(
-                    "klangk_backend.terminal.set_workspace_token",
+                patch.object(
+                    _mock_term,
+                    "set_workspace_token",
                     side_effect=fail_then_succeed,
                 ),
                 patch("asyncio.sleep", side_effect=fast_sleep),
@@ -10209,8 +10273,9 @@ class TestTokenRenewal:
                     "WORKSPACE_TOKEN_EXPIRE_HOURS",
                     0.0001,
                 ),
-                patch(
-                    "klangk_backend.terminal.set_workspace_token",
+                patch.object(
+                    _mock_term,
+                    "set_workspace_token",
                     new_callable=AsyncMock,
                 ) as mock_set,
             ):
@@ -10241,8 +10306,9 @@ class TestTokenRenewal:
         session = sockets.get_or_create_session(workspace["id"], app_state)
 
         try:
-            with patch(
-                "klangk_backend.terminal.set_workspace_token",
+            with patch.object(
+                _mock_term,
+                "set_workspace_token",
                 new_callable=AsyncMock,
             ):
                 expiry = datetime.now(timezone.utc) + timedelta(hours=1)
@@ -10770,8 +10836,9 @@ class TestTokenRenewalFailureLogged:
             patch.object(
                 wshandler.auth, "WORKSPACE_TOKEN_EXPIRE_HOURS", 0.0001
             ),
-            patch(
-                "klangk_backend.terminal.set_workspace_token",
+            patch.object(
+                _mock_term,
+                "set_workspace_token",
                 side_effect=RuntimeError("boom"),
             ),
         ):


### PR DESCRIPTION
Closes #1480.

## What

`terminal.py` was ~25 tmux-session management free functions that all depended on a
`Podman` instance via a `podman` parameter threaded through every signature (#1468).
Promoted them to a `Terminal(podman, registry)` class — the podman dep is explicit
once (constructor), `self.podman` carries it, and the registry provides the
per-container service-firing lock (#1188).

No mutable module state — this is the **cohesion** motivation: a shared dependency
shouldn't be repeated across ~25 signatures.

## Changes

**Production:**
- **`terminal.py`** — `Terminal` class owns `has_tmux_session`,
  `service_cmd_window_exists`, `_ensure_tmux_session`, `ensure_base_session`,
  `ensure_service_session`, `attach_browser`, `set_workspace_token`,
  `tmux_command`, `list_windows`, `new_window`, `rename_window`, `select_window`,
  `close_window`, `kill_joiner_sessions`. The `podman` param is gone from every
  signature (`self.podman` instead). `ensure_service_session` uses `self._registry`
  for the lock + `mark_service_started` (was `app_state`). Pure helpers
  (`validate_window_name`, `build_environment`, `build_shell_command`, etc.) stay
  module-level. `TerminalSession` takes `terminal=` instead of `podman=`, reaching
  podman via `_terminal.podman`.
- **`main.py`** `build_app` — `app.state.terminal = Terminal(podman, registry)`.
- **`controllers.py`** — all `terminal.X(..., podman)` calls →
  `self._conn.app_state.terminal.X(...)`. `_select_shared_window` (@staticmethod)
  takes `terminal` param. Stripped unused `terminal` module import.
- **`container.py`, `session.py`, `bringup.py`** — reach terminal via
  `app_state.terminal`.

**Tests:** mock `Terminal` instances replace module-level function patches;
`TerminalSession` constructions take `terminal=`. 100% coverage maintained.

## Verification

- `python -m pytest src/backend/tests -v -n auto` → **2373 passed, 100% coverage**.
- `ruff check` + `ruff format` clean.
