### PR TITLE
Promote oidc.py to an OIDC(app_state) instance (#1450)

### DIFF
--- a/src/backend/klangk_backend/api/__init__.py
+++ b/src/backend/klangk_backend/api/__init__.py
@@ -55,7 +55,6 @@ from ._common import get_app_state_dep
 # name to the logic module after the submodule imports (see below) so the
 # instance endpoints reference klangk_backend.auth, not the route module.
 from .. import auth as _auth_logic
-from ..settings import get_settings
 from ..util import resolve_env_bool, resolve_env_value
 
 # Route submodules, aliased because their names collide with the logic
@@ -203,7 +202,7 @@ SUPPORT_EMAIL = resolve_env_value("KLANGK_SUPPORT_EMAIL") or ""
 
 
 @router.get("/config")
-async def get_config():
+async def get_config(app_state=Depends(get_app_state_dep)):
     config = {
         "registration_enabled": auth.registration_enabled(),
         "invitations_enabled": auth.invitations_enabled(),
@@ -213,8 +212,8 @@ async def get_config():
         "product_name": PRODUCT_NAME,
         "login_banner_title": LOGIN_BANNER_TITLE,
         "login_banner": LOGIN_BANNER,
-        "oidc_providers": oidc.list_providers(),
-        "auth_modes": oidc.auth_modes(get_settings()),
+        "oidc_providers": app_state.oidc.list_providers(),
+        "auth_modes": app_state.oidc.auth_modes(),
         "instance_id": model.get_instance_id(),
         # Whether per-workspace auto-start (start the container on server
         # boot) is permitted. The web UI gates its "Auto start" checkbox on

--- a/src/backend/klangk_backend/api/auth.py
+++ b/src/backend/klangk_backend/api/auth.py
@@ -19,11 +19,9 @@ from .. import (
     auth,
     emailsvc,
     model,
-    oidc,
     wshandler,
 )
 from ._common import get_app_state_dep
-from ..settings import get_settings
 from ..util import (
     client_is_loopback,
     derive_hosting_info,
@@ -71,7 +69,7 @@ async def register(
     req: auth.RegisterRequest,
     request: Request,
 ):
-    if not oidc.password_login_allowed(get_settings()):
+    if not request.app.state.oidc.password_login_allowed():
         raise HTTPException(
             status_code=403,
             detail="Password registration is disabled",
@@ -281,8 +279,11 @@ async def reset_password(req: ResetPasswordRequest):
 
 
 @router.post("/auth/login", response_model=auth.TokenResponse)
-async def login(req: auth.LoginRequest):
-    if not oidc.password_login_allowed(get_settings()):
+async def login(
+    req: auth.LoginRequest,
+    request: Request,
+):
+    if not request.app.state.oidc.password_login_allowed():
         raise HTTPException(
             status_code=403, detail="Password login is disabled"
         )
@@ -311,7 +312,7 @@ async def local_login(request: Request):
     appear to come from 127.0.0.1), the backend independently verifies
     the *effective* client is loopback via :func:`util.client_is_loopback`.
     """
-    if not oidc.local_login_allowed(get_settings()):
+    if not request.app.state.oidc.local_login_allowed():
         raise HTTPException(
             status_code=403,
             detail="Local login is not enabled (auth mode is not 'none')",
@@ -493,14 +494,16 @@ async def logout(
     result: dict = {"status": "ok"}
     db_user = await model.get_user_by_email(user["email"])
     if db_user and db_user.get("provider", "local") != "local":
-        provider = oidc.get_provider(db_user["provider"])
+        provider = request.app.state.oidc.get_provider(db_user["provider"])
         if provider:
             hostname, proto, base_path = derive_hosting_info(
                 request.headers,
                 request.client.host if request.client else None,
             )
             post_logout_uri = f"{proto}://{hostname}{base_path}/#/login"
-            logout_url = await oidc.build_logout_url(provider, post_logout_uri)
+            logout_url = await request.app.state.oidc.build_logout_url(
+                provider, post_logout_uri
+            )
             if logout_url:
                 result["oidc_logout_url"] = logout_url
     return result

--- a/src/backend/klangk_backend/api/oidc_auth.py
+++ b/src/backend/klangk_backend/api/oidc_auth.py
@@ -19,7 +19,6 @@ from .. import (
     model,
     oidc,
 )
-from ..settings import get_settings
 from ..util import (
     API_PREFIX,
     derive_hosting_info,
@@ -53,10 +52,11 @@ async def oidc_login(
     cli_redirect: str | None = None,
 ):
     """Redirect to the OIDC IdP for authentication."""
-    if not oidc.oidc_login_allowed(get_settings()):
+    oidc_inst = request.app.state.oidc
+    if not oidc_inst.oidc_login_allowed():
         raise HTTPException(status_code=404, detail="OIDC not enabled")
 
-    provider = oidc.get_provider(provider_id)
+    provider = oidc_inst.get_provider(provider_id)
     if provider is None:
         raise HTTPException(status_code=404, detail="Unknown OIDC provider")
 
@@ -75,7 +75,7 @@ async def oidc_login(
     )
     redirect_uri = f"{proto}://{hostname}{base_path}{API_PREFIX}/auth/oidc/{provider_id}/callback"
 
-    auth_url = await oidc.build_auth_url(
+    auth_url = await oidc_inst.build_auth_url(
         provider, redirect_uri, state, challenge
     )
 
@@ -124,14 +124,14 @@ def _validate_state_cookie(
     return cookie_data
 
 
-async def _exchange_and_validate_token(provider, code, cookie_data):
+async def _exchange_and_validate_token(oidc_inst, provider, code, cookie_data):
     """Exchange the authorization code for tokens and validate the ID token.
 
     Returns ``(claims, tokens)`` where *claims* contains at least ``sub``
     and ``email``.
     """
     try:
-        tokens = await oidc.exchange_code(
+        tokens = await oidc_inst.exchange_code(
             provider,
             code,
             cookie_data["redirect_uri"],
@@ -148,7 +148,7 @@ async def _exchange_and_validate_token(provider, code, cookie_data):
         raise HTTPException(status_code=502, detail="No ID token in response")
 
     try:
-        claims = await oidc.validate_id_token(
+        claims = await oidc_inst.validate_id_token(
             provider, id_token, access_token=tokens.get("access_token")
         )
     except Exception as exc:
@@ -243,13 +243,13 @@ async def oidc_callback(
         )
         raise HTTPException(status_code=400, detail="Login failed")
 
-    provider = oidc.get_provider(provider_id)
+    provider = request.app.state.oidc.get_provider(provider_id)
     if provider is None:
         raise HTTPException(status_code=404, detail="Unknown OIDC provider")
 
     cookie_data = _validate_state_cookie(request, provider_id, state)
     claims, tokens = await _exchange_and_validate_token(
-        provider, code, cookie_data
+        request.app.state.oidc, provider, code, cookie_data
     )
 
     email = claims["email"]
@@ -265,7 +265,7 @@ async def oidc_callback(
 
     # Call the OIDC login hook (if configured).
     try:
-        hook_groups = await oidc.call_login_hook(
+        hook_groups = await request.app.state.oidc.call_login_hook(
             provider, claims, email, tokens
         )
     except Exception:

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -155,7 +155,7 @@ def _is_loopback_bind(host: str) -> bool:
         return False
 
 
-def enforce_no_auth_bind_safety() -> None:
+def enforce_no_auth_bind_safety(app_state=None) -> None:
     """Refuse to start in ``none`` auth mode unless the bind is loopback.
 
     ``KLANGK_AUTH_MODES=none`` freely issues a token for the seeded default
@@ -167,11 +167,12 @@ def enforce_no_auth_bind_safety() -> None:
     ``KLANGK_ALLOW_INSECURE_NO_AUTH=1`` when you knowingly expose a no-auth
     server (e.g. a throwaway VM on an isolated network). #1374.
 
-    Runs in the lifespan so ``auth_modes(settings)`` reads the resolved
-    setting (supports ``@file:`` indirection resolved at startup) — something a bash gate in the
-    old nginx.sh couldn't replicate.
+    Reads auth mode from ``app_state.oidc.auth_modes()`` (#1450) so the
+    setting (supports ``@file:`` indirection resolved at startup) is read
+    once at construction — something a bash gate in the old nginx.sh
+    couldn't replicate.
     """
-    if oidc.auth_modes(get_settings()) != "none":
+    if app_state.oidc.auth_modes() != "none":
         return
     host = resolve_env_value("KLANGK_LISTEN", "127.0.0.1") or "127.0.0.1"
     if _is_loopback_bind(host):
@@ -576,9 +577,9 @@ async def lifespan(app: FastAPI):
 
     auth.require_secure_jwt_secret()
     plugins.load()
-    oidc.init_providers()
-    enforce_no_auth_bind_safety()
-    oidc.load_login_hook()
+    app.state.oidc.init_providers()
+    enforce_no_auth_bind_safety(app.state)
+    app.state.oidc.load_login_hook()
     await seed_default_user()
     await seed_agent_user()
     registry = app.state.container_registry
@@ -760,6 +761,10 @@ def build_app(settings: KlangkSettings) -> FastAPI:
     # management functions that share a Podman dependency. Reaches podman,
     # the registry, and settings through the single app_state reference.
     app.state.terminal = terminal.Terminal(app.state)
+    # #1450: OIDC(app_state) owns the provider registry, discovery/JWKS
+    # caches, and login-hook state (previously module globals). Reaches
+    # config through self.settings.
+    app.state.oidc = oidc.OIDC(app.state)
     # WebSocketState reaches the registry through its own app_state
     # back-reference (send_service_health_snapshot / reset_workspace).
     # The unit-test fixtures set this explicitly; build_app must too, or

--- a/src/backend/klangk_backend/oidc.py
+++ b/src/backend/klangk_backend/oidc.py
@@ -19,8 +19,7 @@ from jose import jwt as jose_jwt
 
 from . import model
 from .exceptions import ConfigurationError
-from .settings import KlangkSettings, get_settings
-from .util import resolve_env_value, resolve_file_value
+from .util import resolve_file_value
 
 logger = logging.getLogger(__name__)
 
@@ -53,13 +52,6 @@ class CachedDiscovery:
 class _CachedJWKS:
     keys: dict
     fetched_at: float
-
-
-_discovery_cache: dict[str, CachedDiscovery] = {}
-_jwks_cache: dict[str, _CachedJWKS] = {}
-
-# Provider registry — loaded once at startup
-_providers: list[OIDCProvider] = []
 
 
 _SENTINEL = object()
@@ -113,289 +105,6 @@ def _parse_providers(
     return providers
 
 
-def load_config() -> list[OIDCProvider]:
-    """Load OIDC provider config.
-
-    Sources (checked in order, first non-empty wins):
-
-    1. **External file** — ``KLANGK_OIDC_CONFIG`` env var pointing at a
-       separate YAML file.  This is an env-var override, so it wins over
-       the config file (consistent with the global precedence rule:
-       env > file > defaults).
-    2. **Inline** — ``oidc_providers:`` list in the klangkd config file
-       (via :class:`~klangk_backend.settings.KlangkSettings`).
-
-    Returns an empty list if neither is configured.  Raises
-    :class:`~klangk_backend.exceptions.ConfigurationError` if the external
-    file path is set but doesn't exist.
-    """
-    # 1. External file via KLANGK_OIDC_CONFIG (env override wins)
-    config_path = resolve_env_value("KLANGK_OIDC_CONFIG", "")
-    if config_path:
-        if not os.path.isfile(config_path):
-            raise ConfigurationError(
-                f"KLANGK_OIDC_CONFIG={config_path!r} not found"
-                " (use an absolute path)"
-            )
-        config_dir = os.path.dirname(os.path.abspath(config_path))
-        with open(config_path) as f:
-            raw = yaml.safe_load(f)
-        return _parse_providers(raw, config_dir=config_dir)
-
-    # 2. Inline providers from the config file
-    settings = get_settings()
-    if settings.oidc_providers:
-        return _parse_providers(settings.oidc_providers)
-
-    return []
-
-
-def init_providers() -> None:
-    """Load providers into the module-level registry.
-
-    Raises ConfigurationError if KLANGK_AUTH_MODES requires OIDC but no
-    providers are configured or the config file is missing.
-    """
-    global _providers
-    _providers = load_config()
-    mode = auth_modes(get_settings())
-    if mode in ("oidc", "both") and not _providers:
-        raise ConfigurationError(
-            f"KLANGK_AUTH_MODES={mode!r} but no OIDC providers configured"
-        )
-    if _providers:
-        names = ", ".join(p.id for p in _providers)
-        logger.info("OIDC providers loaded: %s", names)
-
-
-def get_provider(provider_id: str) -> OIDCProvider | None:
-    """Look up a provider by ID."""
-    return next((p for p in _providers if p.id == provider_id), None)
-
-
-def list_providers() -> list[dict]:
-    """Return public info for all configured providers."""
-    return [{"id": p.id, "display_name": p.display_name} for p in _providers]
-
-
-def is_enabled() -> bool:
-    return len(_providers) > 0
-
-
-def auth_modes(settings: KlangkSettings) -> str:
-    """Return the configured auth mode.
-
-    One of ``password``, ``oidc``, ``both``, or ``none`` (no-login
-    single-user local-dev mode). ``none`` auto-issues a token for the
-    seeded default user via ``POST /api/v1/auth/local``; see #1374.
-
-    When ``KLANGK_AUTH_MODES`` is unset the default is ``none``. OIDC
-    settings (``KLANGK_OIDC_*``) do **not** change the mode (#1419) — they
-    only take effect once the mode is ``oidc`` or ``both`` (set explicitly).
-    A fresh klangk with nothing configured therefore boots in no-login
-    single-user mode, bound to loopback, and "just works" locally without a
-    password. Operators who want password login, OIDC, or both set
-    ``KLANGK_AUTH_MODES`` explicitly.
-
-    ``KLANGK_AUTH_MODES`` is the sole authority on auth — nothing else
-    defaults or overrides it (#1422 removed the deployment-shape setting
-    that used to default it). The deployment shape is derived from this
-    knob plus ``KLANGK_LISTEN``.
-
-    Takes the frozen :class:`KlangkSettings` explicitly (no global read) —
-    part of the composition-root refactor (#1426): the mode is read from
-    ``settings.auth_modes`` (resolved once at startup), not re-read from
-    the environment at call time.
-    """
-    val = settings.auth_modes
-    if val in ("oidc", "password", "both", "none"):
-        return val
-    return "none"
-
-
-def password_login_allowed(settings: KlangkSettings) -> bool:
-    return auth_modes(settings) in ("password", "both")
-
-
-def local_login_allowed(settings: KlangkSettings) -> bool:
-    """True when no-login single-user mode is active (``none``)."""
-    return auth_modes(settings) == "none"
-
-
-def oidc_login_allowed(settings: KlangkSettings) -> bool:
-    return auth_modes(settings) in ("oidc", "both") and is_enabled()
-
-
-# --- PKCE ---
-
-
-def generate_pkce() -> tuple[str, str]:
-    """Generate PKCE verifier and challenge (S256)."""
-    verifier = secrets.token_urlsafe(64)
-    digest = hashlib.sha256(verifier.encode("ascii")).digest()
-    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
-    return verifier, challenge
-
-
-# --- HTTP client ---
-
-
-def client_kwargs(provider: OIDCProvider) -> dict:
-    """Return httpx.AsyncClient kwargs for a provider, including
-    custom CA cert if configured."""
-    kwargs: dict = {}
-    if provider.ca_cert:
-        kwargs["verify"] = provider.ca_cert
-    return kwargs
-
-
-# --- Discovery ---
-
-
-async def discover(provider: OIDCProvider) -> dict:
-    """Fetch OIDC discovery document, cached."""
-    now = time.time()
-    cached = _discovery_cache.get(provider.id)
-    if cached and now - cached.fetched_at < _DISCOVERY_TTL:
-        return cached.data
-
-    url = f"{provider.issuer}/.well-known/openid-configuration"
-    async with httpx.AsyncClient(**client_kwargs(provider)) as client:
-        resp = await client.get(url, timeout=10)
-        resp.raise_for_status()
-        data = resp.json()
-
-    _discovery_cache[provider.id] = CachedDiscovery(data=data, fetched_at=now)
-    return data
-
-
-async def get_jwks(provider: OIDCProvider) -> dict:
-    """Fetch JWKS keys for token validation, cached."""
-    now = time.time()
-    cached = _jwks_cache.get(provider.id)
-    if cached and now - cached.fetched_at < _JWKS_TTL:
-        return cached.keys
-
-    disc = await discover(provider)
-    jwks_uri = disc["jwks_uri"]
-    async with httpx.AsyncClient(**client_kwargs(provider)) as client:
-        resp = await client.get(jwks_uri, timeout=10)
-        resp.raise_for_status()
-        keys = resp.json()
-
-    _jwks_cache[provider.id] = _CachedJWKS(keys=keys, fetched_at=now)
-    return keys
-
-
-# --- Authorization URL ---
-
-
-async def build_auth_url(
-    provider: OIDCProvider,
-    redirect_uri: str,
-    state: str,
-    code_challenge: str,
-) -> str:
-    """Build the authorization URL to redirect the user to the IdP."""
-    disc = await discover(provider)
-    params = {
-        "response_type": "code",
-        "client_id": provider.client_id,
-        "redirect_uri": redirect_uri,
-        "scope": provider.scopes,
-        "state": state,
-        "code_challenge": code_challenge,
-        "code_challenge_method": "S256",
-    }
-    return f"{disc['authorization_endpoint']}?{urlencode(params)}"
-
-
-# --- Token Exchange ---
-
-
-async def exchange_code(
-    provider: OIDCProvider,
-    code: str,
-    redirect_uri: str,
-    code_verifier: str,
-) -> dict:
-    """Exchange an authorization code for tokens."""
-    disc = await discover(provider)
-    data = {
-        "grant_type": "authorization_code",
-        "code": code,
-        "redirect_uri": redirect_uri,
-        "client_id": provider.client_id,
-        "client_secret": provider.client_secret,
-        "code_verifier": code_verifier,
-    }
-    async with httpx.AsyncClient(**client_kwargs(provider)) as client:
-        resp = await client.post(
-            disc["token_endpoint"],
-            data=data,
-            timeout=15,
-        )
-        resp.raise_for_status()
-        return resp.json()
-
-
-# --- ID Token Validation ---
-
-
-async def validate_id_token(
-    provider: OIDCProvider,
-    id_token: str,
-    access_token: str | None = None,
-) -> dict:
-    """Validate and decode an ID token. Returns the claims dict.
-
-    Uses the static token_validation_pem if configured, otherwise
-    fetches JWKS from the IdP's discovery endpoint. Pass access_token
-    so jose can verify the at_hash claim if present.
-    """
-    if provider.token_validation_pem:
-        key = provider.token_validation_pem
-    else:
-        key = await get_jwks(provider)
-    claims = jose_jwt.decode(
-        id_token,
-        key,
-        algorithms=["RS256", "ES256"],
-        audience=provider.client_id,
-        issuer=provider.issuer,
-        access_token=access_token,
-    )
-    return claims
-
-
-async def build_logout_url(
-    provider: OIDCProvider,
-    post_logout_redirect_uri: str,
-) -> str | None:
-    """Build the IdP logout URL for RP-Initiated Logout.
-
-    Returns None if logout_redirect is disabled or the IdP doesn't
-    advertise an end_session_endpoint.
-    """
-    if not provider.logout_redirect:
-        return None
-    disc = await discover(provider)
-    endpoint = disc.get("end_session_endpoint")
-    if not endpoint:
-        return None
-    params = {
-        "client_id": provider.client_id,
-        "post_logout_redirect_uri": post_logout_redirect_uri,
-    }
-    return f"{endpoint}?{urlencode(params)}"
-
-
-# --- OIDC login hook ---
-
-_login_hook: Callable | None = None
-_login_hook_is_async: bool = False
-
-
 def _parse_hook_value(raw: str) -> tuple[str, str]:
     """Parse KLANGK_OIDC_LOGIN_HOOK into (file_path, func_name).
 
@@ -411,75 +120,21 @@ def _parse_hook_value(raw: str) -> tuple[str, str]:
     return path, func_name
 
 
-def load_login_hook() -> None:
-    """Load the OIDC login hook from KLANGK_OIDC_LOGIN_HOOK.
-
-    The value is a file path to a Python script, optionally followed
-    by ``:func_name``.  If the function name is omitted it defaults
-    to ``on_login``.  The file is loaded directly via
-    ``importlib.util`` — it does **not** need to be on ``PYTHONPATH``.
-
-    The hook is called after ID token validation and before user
-    provisioning.  It combines login validation and group mapping:
-
-    - **Raise** any exception → login rejected (HTTP 403, message
-      from the exception).
-    - **Return** ``None`` → login allowed, no group sync.
-    - **Return** a ``set[str]`` of group names → login allowed,
-      memberships synced to those groups.
-
-    If not set, all OIDC logins are accepted with no group sync.
-    """
-    global _login_hook, _login_hook_is_async
-    raw = resolve_env_value("KLANGK_OIDC_LOGIN_HOOK")
-    if not raw:
-        _login_hook = None
-        _login_hook_is_async = False
-        return
-    path, func_name = _parse_hook_value(raw)
-    if not os.path.isfile(path):
-        raise ConfigurationError(
-            f"KLANGK_OIDC_LOGIN_HOOK: file not found: {path!r}"
-        )
-    spec = importlib.util.spec_from_file_location("_klangk_login_hook", path)
-    if spec is None or spec.loader is None:  # pragma: no cover
-        raise ConfigurationError(
-            f"KLANGK_OIDC_LOGIN_HOOK: could not load: {path!r}"
-        )
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    hook = getattr(mod, func_name, None)
-    if hook is None or not callable(hook):
-        raise ConfigurationError(
-            f"KLANGK_OIDC_LOGIN_HOOK: {func_name!r} not found or not "
-            f"callable in {path!r}"
-        )
-    _login_hook = hook
-    _login_hook_is_async = asyncio.iscoroutinefunction(hook)
-    logger.info("OIDC login hook loaded: %s", raw)
+def generate_pkce() -> tuple[str, str]:
+    """Generate PKCE verifier and challenge (S256)."""
+    verifier = secrets.token_urlsafe(64)
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return verifier, challenge
 
 
-async def call_login_hook(
-    provider: OIDCProvider,
-    claims: dict,
-    email: str,
-    tokens: dict,
-) -> set[str] | None:
-    """Call the OIDC login hook.
-
-    Returns group names to sync, or None if no groups.
-    Raises the hook's exception if login is rejected.
-    If no hook is configured, returns None (login allowed, no sync).
-    """
-    if _login_hook is None:
-        return None
-    if _login_hook_is_async:
-        result = await _login_hook(provider, claims, email, tokens)
-    else:
-        result = _login_hook(provider, claims, email, tokens)
-    if result is None:
-        return None
-    return set(result)
+def client_kwargs(provider: OIDCProvider) -> dict:
+    """Return httpx.AsyncClient kwargs for a provider, including
+    custom CA cert if configured."""
+    kwargs: dict = {}
+    if provider.ca_cert:
+        kwargs["verify"] = provider.ca_cert
+    return kwargs
 
 
 async def sync_oidc_groups(
@@ -504,10 +159,344 @@ async def sync_oidc_groups(
         await model.remove_user_from_group(user_id, gid)
 
 
-def clear_caches() -> None:
-    """Clear all caches (for testing)."""
-    global _login_hook, _login_hook_is_async
-    _discovery_cache.clear()
-    _jwks_cache.clear()
-    _login_hook = None
-    _login_hook_is_async = False
+# ---------------------------------------------------------------------------
+# OIDC — instance with provider registry, caches, and login-hook state (#1450)
+# ---------------------------------------------------------------------------
+
+
+class OIDC:
+    """OIDC provider registry, discovery/JWKS caches, and login-hook state.
+
+    Constructed once in :func:`build_app` and stored on
+    ``app.state.oidc`` (#1450). Reaches config through a single
+    ``app_state`` reference — ``self.settings`` derives everything.
+    The provider list, caches, and hook state are instance attrs so they
+    don't leak across test runs (previously module globals).
+    """
+
+    def __init__(self, app_state=None):
+        self.app_state = app_state
+        self.settings = app_state.settings
+        self.providers: list[OIDCProvider] = []
+        self.discovery_cache: dict[str, CachedDiscovery] = {}
+        self.jwks_cache: dict[str, _CachedJWKS] = {}
+        self.login_hook: Callable | None = None
+        self.login_hook_is_async: bool = False
+
+    # --- config loading ---
+
+    def load_config(self) -> list[OIDCProvider]:
+        """Load OIDC provider config.
+
+        Sources (checked in order, first non-empty wins):
+
+        1. **External file** — ``KLANGK_OIDC_CONFIG`` (``self.settings.oidc_config``)
+           pointing at a separate YAML file.  This is an env-var override, so it
+           wins over the config file (consistent with the global precedence rule:
+           env > file > defaults).
+        2. **Inline** — ``oidc_providers:`` list in the klangkd config file
+          (``self.settings.oidc_providers``).
+
+        Returns an empty list if neither is configured.  Raises
+        :class:`~klangk_backend.exceptions.ConfigurationError` if the external
+        file path is set but doesn't exist.
+        """
+        # 1. External file via KLANGK_OIDC_CONFIG (env override wins)
+        config_path = self.settings.oidc_config
+        if config_path:
+            if not os.path.isfile(config_path):
+                raise ConfigurationError(
+                    f"KLANGK_OIDC_CONFIG={config_path!r} not found"
+                    " (use an absolute path)"
+                )
+            config_dir = os.path.dirname(os.path.abspath(config_path))
+            with open(config_path) as f:
+                raw = yaml.safe_load(f)
+            return _parse_providers(raw, config_dir=config_dir)
+
+        # 2. Inline providers from the config file
+        if self.settings.oidc_providers:
+            return _parse_providers(self.settings.oidc_providers)
+
+        return []
+
+    def init_providers(self) -> None:
+        """Load providers into the instance registry.
+
+        Raises ConfigurationError if KLANGK_AUTH_MODES requires OIDC but no
+        providers are configured or the config file is missing.
+        """
+        self.providers = self.load_config()
+        mode = self.auth_modes()
+        if mode in ("oidc", "both") and not self.providers:
+            raise ConfigurationError(
+                f"KLANGK_AUTH_MODES={mode!r} but no OIDC providers configured"
+            )
+        if self.providers:
+            names = ", ".join(p.id for p in self.providers)
+            logger.info("OIDC providers loaded: %s", names)
+
+    # --- provider registry ---
+
+    def get_provider(self, provider_id: str) -> OIDCProvider | None:
+        """Look up a provider by ID."""
+        return next((p for p in self.providers if p.id == provider_id), None)
+
+    def list_providers(self) -> list[dict]:
+        """Return public info for all configured providers."""
+        return [
+            {"id": p.id, "display_name": p.display_name}
+            for p in self.providers
+        ]
+
+    def is_enabled(self) -> bool:
+        return len(self.providers) > 0
+
+    # --- auth modes ---
+
+    def auth_modes(self) -> str:
+        """Return the configured auth mode.
+
+        One of ``password``, ``oidc``, ``both``, or ``none`` (no-login
+        single-user local-dev mode). ``none`` auto-issues a token for the
+        seeded default user via ``POST /api/v1/auth/local``; see #1374.
+
+        When ``KLANGK_AUTH_MODES`` is unset the default is ``none``. OIDC
+        settings (``KLANGK_OIDC_*``) do **not** change the mode (#1419) — they
+        only take effect once the mode is ``oidc`` or ``both`` (set explicitly).
+        A fresh klangk with nothing configured therefore boots in no-login
+        single-user mode, bound to loopback, and "just works" locally without a
+        password. Operators who want password login, OIDC, or both set
+        ``KLANGK_AUTH_MODES`` explicitly.
+
+        ``KLANGK_AUTH_MODES`` is the sole authority on auth — nothing else
+        defaults or overrides it (#1422 removed the deployment-shape setting
+        that used to default it). The deployment shape is derived from this
+        knob plus ``KLANGK_LISTEN``.
+
+        Reads ``self.settings.auth_modes`` (resolved once at construction) —
+        part of the composition-root refactor (#1426): the mode is not re-read
+        from the environment at call time.
+        """
+        val = self.settings.auth_modes
+        if val in ("oidc", "password", "both", "none"):
+            return val
+        return "none"
+
+    def password_login_allowed(self) -> bool:
+        return self.auth_modes() in ("password", "both")
+
+    def local_login_allowed(self) -> bool:
+        """True when no-login single-user mode is active (``none``)."""
+        return self.auth_modes() == "none"
+
+    def oidc_login_allowed(self) -> bool:
+        return self.auth_modes() in ("oidc", "both") and self.is_enabled()
+
+    # --- discovery / JWKS ---
+
+    async def discover(self, provider: OIDCProvider) -> dict:
+        """Fetch OIDC discovery document, cached."""
+        now = time.time()
+        cached = self.discovery_cache.get(provider.id)
+        if cached and now - cached.fetched_at < _DISCOVERY_TTL:
+            return cached.data
+
+        url = f"{provider.issuer}/.well-known/openid-configuration"
+        async with httpx.AsyncClient(**client_kwargs(provider)) as client:
+            resp = await client.get(url, timeout=10)
+            resp.raise_for_status()
+            data = resp.json()
+
+        self.discovery_cache[provider.id] = CachedDiscovery(
+            data=data, fetched_at=now
+        )
+        return data
+
+    async def get_jwks(self, provider: OIDCProvider) -> dict:
+        """Fetch JWKS keys for token validation, cached."""
+        now = time.time()
+        cached = self.jwks_cache.get(provider.id)
+        if cached and now - cached.fetched_at < _JWKS_TTL:
+            return cached.keys
+
+        disc = await self.discover(provider)
+        jwks_uri = disc["jwks_uri"]
+        async with httpx.AsyncClient(**client_kwargs(provider)) as client:
+            resp = await client.get(jwks_uri, timeout=10)
+            resp.raise_for_status()
+            keys = resp.json()
+
+        self.jwks_cache[provider.id] = _CachedJWKS(keys=keys, fetched_at=now)
+        return keys
+
+    # --- authorization URL / token exchange ---
+
+    async def build_auth_url(
+        self,
+        provider: OIDCProvider,
+        redirect_uri: str,
+        state: str,
+        code_challenge: str,
+    ) -> str:
+        """Build the authorization URL to redirect the user to the IdP."""
+        disc = await self.discover(provider)
+        params = {
+            "response_type": "code",
+            "client_id": provider.client_id,
+            "redirect_uri": redirect_uri,
+            "scope": provider.scopes,
+            "state": state,
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+        }
+        return f"{disc['authorization_endpoint']}?{urlencode(params)}"
+
+    async def exchange_code(
+        self,
+        provider: OIDCProvider,
+        code: str,
+        redirect_uri: str,
+        code_verifier: str,
+    ) -> dict:
+        """Exchange an authorization code for tokens."""
+        disc = await self.discover(provider)
+        data = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": redirect_uri,
+            "client_id": provider.client_id,
+            "client_secret": provider.client_secret,
+            "code_verifier": code_verifier,
+        }
+        async with httpx.AsyncClient(**client_kwargs(provider)) as client:
+            resp = await client.post(
+                disc["token_endpoint"],
+                data=data,
+                timeout=15,
+            )
+            resp.raise_for_status()
+            return resp.json()
+
+    # --- ID token validation ---
+
+    async def validate_id_token(
+        self,
+        provider: OIDCProvider,
+        id_token: str,
+        access_token: str | None = None,
+    ) -> dict:
+        """Validate and decode an ID token. Returns the claims dict.
+
+        Uses the static token_validation_pem if configured, otherwise
+        fetches JWKS from the IdP's discovery endpoint. Pass access_token
+        so jose can verify the at_hash claim if present.
+        """
+        if provider.token_validation_pem:
+            key = provider.token_validation_pem
+        else:
+            key = await self.get_jwks(provider)
+        claims = jose_jwt.decode(
+            id_token,
+            key,
+            algorithms=["RS256", "ES256"],
+            audience=provider.client_id,
+            issuer=provider.issuer,
+            access_token=access_token,
+        )
+        return claims
+
+    async def build_logout_url(
+        self,
+        provider: OIDCProvider,
+        post_logout_redirect_uri: str,
+    ) -> str | None:
+        """Build the IdP logout URL for RP-Initiated Logout.
+
+        Returns None if logout_redirect is disabled or the IdP doesn't
+        advertise an end_session_endpoint.
+        """
+        if not provider.logout_redirect:
+            return None
+        disc = await self.discover(provider)
+        endpoint = disc.get("end_session_endpoint")
+        if not endpoint:
+            return None
+        params = {
+            "client_id": provider.client_id,
+            "post_logout_redirect_uri": post_logout_redirect_uri,
+        }
+        return f"{endpoint}?{urlencode(params)}"
+
+    # --- login hook ---
+
+    def load_login_hook(self) -> None:
+        """Load the OIDC login hook from KLANGK_OIDC_LOGIN_HOOK.
+
+        The value is a file path to a Python script, optionally followed
+        by ``:func_name``.  If the function name is omitted it defaults
+        to ``on_login``.  The file is loaded directly via
+        ``importlib.util`` — it does **not** need to be on ``PYTHONPATH``.
+
+        The hook is called after ID token validation and before user
+        provisioning.  It combines login validation and group mapping:
+
+        - **Raise** any exception → login rejected (HTTP 403, message
+          from the exception).
+        - **Return** ``None`` → login allowed, no group sync.
+        - **Return** a ``set[str]`` of group names → login allowed,
+          memberships synced to those groups.
+
+        If not set, all OIDC logins are accepted with no group sync.
+        """
+        raw = self.settings.oidc_login_hook
+        if not raw:
+            self.login_hook = None
+            self.login_hook_is_async = False
+            return
+        path, func_name = _parse_hook_value(raw)
+        if not os.path.isfile(path):
+            raise ConfigurationError(
+                f"KLANGK_OIDC_LOGIN_HOOK: file not found: {path!r}"
+            )
+        spec = importlib.util.spec_from_file_location(
+            "_klangk_login_hook", path
+        )
+        if spec is None or spec.loader is None:  # pragma: no cover
+            raise ConfigurationError(
+                f"KLANGK_OIDC_LOGIN_HOOK: could not load: {path!r}"
+            )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        hook = getattr(mod, func_name, None)
+        if hook is None or not callable(hook):
+            raise ConfigurationError(
+                f"KLANGK_OIDC_LOGIN_HOOK: {func_name!r} not found or not "
+                f"callable in {path!r}"
+            )
+        self.login_hook = hook
+        self.login_hook_is_async = asyncio.iscoroutinefunction(hook)
+        logger.info("OIDC login hook loaded: %s", raw)
+
+    async def call_login_hook(
+        self,
+        provider: OIDCProvider,
+        claims: dict,
+        email: str,
+        tokens: dict,
+    ) -> set[str] | None:
+        """Call the OIDC login hook.
+
+        Returns group names to sync, or None if no groups.
+        Raises the hook's exception if login is rejected.
+        If no hook is configured, returns None (login allowed, no sync).
+        """
+        if self.login_hook is None:
+            return None
+        if self.login_hook_is_async:
+            result = await self.login_hook(provider, claims, email, tokens)
+        else:
+            result = self.login_hook(provider, claims, email, tokens)
+        if result is None:
+            return None
+        return set(result)

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -18,13 +18,13 @@ from klangk_backend import (
     auth,
     container,
     model,
-    oidc,
     plugins,
     podman,
     workspaces as ws_mod,
     wshandler,
 )
 from klangk_backend.container import ContainerRegistry
+from klangk_backend import oidc as oidc_mod
 from klangk_backend.settings import KlangkSettings
 from klangk_backend.wshandler.session import WebSocketState
 
@@ -40,7 +40,7 @@ async def app(db):
     from klangk_backend.util import API_PREFIX
     from klangk_backend.main import register_exception_handlers
 
-    settings = KlangkSettings(env={})
+    settings = KlangkSettings(env={"KLANGK_AUTH_MODES": "password"})
     registry = ContainerRegistry(settings)
     sockets = WebSocketState()
     app.state.settings = settings
@@ -51,6 +51,7 @@ async def app(db):
     sockets.app_state = app.state
     app.state.podman = _mock_pod
     registry.podman = _mock_pod
+    app.state.oidc = oidc_mod.OIDC(app.state)
     agent.get_workspace_session = sockets.get_session
 
     app.include_router(api.root_router)
@@ -266,7 +267,7 @@ class TestVersion:
         assert "plugins" in data
 
     async def test_version_includes_plugins(
-        self, client, tmp_path, monkeypatch
+        self, client, app, tmp_path, monkeypatch
     ):
         monkeypatch.delenv("KLANGK_VERSION_FILE", raising=False)
         plugin_dir = tmp_path / "plugins" / "myplugin"
@@ -287,7 +288,7 @@ class TestVersion:
         assert plugins[0]["description"] == "A test plugin"
 
     async def test_version_includes_variant_when_present(
-        self, client, tmp_path, monkeypatch
+        self, client, app, tmp_path, monkeypatch
     ):
         # When version.json carries a "variant" field (a downstream product
         # identity string, set via KLANGK_VARIANT in generate-version.sh), the
@@ -306,7 +307,7 @@ class TestVersion:
         assert data["variant"] == "Custom 1.0.0"
 
     async def test_version_omits_variant_when_absent(
-        self, client, tmp_path, monkeypatch
+        self, client, app, tmp_path, monkeypatch
     ):
         # Stock klangk builds omit the variant field entirely (it is absent
         # from version.json, not null). The endpoint must not synthesize one —
@@ -375,7 +376,7 @@ class TestConfig:
         assert data["min_password_length"] == auth.MIN_PASSWORD_LENGTH
 
     async def test_get_config_logo_url_defaults_empty(
-        self, client, monkeypatch
+        self, client, app, monkeypatch
     ):
         # No KLANGK_LOGO_URL set -> empty string (UI renders default widget).
         monkeypatch.delenv("KLANGK_LOGO_URL", raising=False)
@@ -405,7 +406,7 @@ class TestConfig:
             assert data[key] == ""
 
     async def test_get_config_legal_links_reflect_env(
-        self, client, monkeypatch
+        self, client, app, monkeypatch
     ):
         # Each link is surfaced verbatim from its module constant (resolved
         # from env at import time, like PRODUCT_NAME / LOGIN_BANNER).
@@ -426,7 +427,7 @@ class TestConfig:
         assert data["support_email"] == "help@example.com"
 
     async def test_get_config_legal_links_are_plain_env_not_resolved(
-        self, client, monkeypatch, tmp_path
+        self, client, app, monkeypatch, tmp_path
     ):
         # Legal/support links are PUBLIC URLs shown to unauthenticated
         # users, so they must NOT get file:/cmd: secret resolution -- a
@@ -439,7 +440,7 @@ class TestConfig:
         assert resp.json()["terms_url"] == "file:///etc/shadow"
 
     async def test_get_config_logo_url_resolves_file_secret(
-        self, client, tmp_path, monkeypatch
+        self, client, app, tmp_path, monkeypatch
     ):
         # file:/cmd: resolution works like other secrets (#1152).
         secret = tmp_path / "logo_url"
@@ -669,9 +670,9 @@ class TestLocalLogin:
     """POST /api/v1/auth/local — no-login single-user mode token handout."""
 
     async def test_returns_token_for_seeded_default_user(
-        self, client, db, monkeypatch
+        self, client, app, db, monkeypatch
     ):
-        monkeypatch.setenv("KLANGK_AUTH_MODES", "none")
+        monkeypatch.setattr(app.state.oidc, "auth_modes", lambda: "none")
         monkeypatch.setenv("KLANGK_DEFAULT_USER", "local@example.com")
         await model.create_user(
             "local@example.com",
@@ -688,8 +689,10 @@ class TestLocalLogin:
         claims = auth.decode_token(token)
         assert claims["email"] == "local@example.com"
 
-    async def test_token_authorizes_requests(self, client, db, monkeypatch):
-        monkeypatch.setenv("KLANGK_AUTH_MODES", "none")
+    async def test_token_authorizes_requests(
+        self, client, app, db, monkeypatch
+    ):
+        monkeypatch.setattr(app.state.oidc, "auth_modes", lambda: "none")
         monkeypatch.setenv("KLANGK_DEFAULT_USER", "local@example.com")
         await model.create_user(
             "local@example.com",
@@ -707,30 +710,32 @@ class TestLocalLogin:
         assert resp.status_code == 200
         assert resp.json()["email"] == "local@example.com"
 
-    async def test_disabled_when_not_none_mode(self, client, db, monkeypatch):
+    async def test_disabled_when_not_none_mode(
+        self, client, app, db, monkeypatch
+    ):
         # In password mode (the explicit opposite of none) the endpoint refuses.
-        monkeypatch.setenv("KLANGK_AUTH_MODES", "password")
+        monkeypatch.setattr(app.state.oidc, "auth_modes", lambda: "password")
         resp = await client.post("/api/v1/auth/local")
         assert resp.status_code == 403
 
-    async def test_disabled_in_both_mode(self, client, db, monkeypatch):
-        monkeypatch.setenv("KLANGK_AUTH_MODES", "both")
+    async def test_disabled_in_both_mode(self, client, app, db, monkeypatch):
+        monkeypatch.setattr(app.state.oidc, "auth_modes", lambda: "both")
         resp = await client.post("/api/v1/auth/local")
         assert resp.status_code == 403
 
     async def test_500_when_default_user_missing(
-        self, client, db, monkeypatch
+        self, client, app, db, monkeypatch
     ):
         # seed_default_user() runs in the lifespan, which the minimal test
         # app skips — so if it were somehow bypassed at runtime the endpoint
         # surfaces a 500 rather than minting a token for a ghost user.
-        monkeypatch.setenv("KLANGK_AUTH_MODES", "none")
+        monkeypatch.setattr(app.state.oidc, "auth_modes", lambda: "none")
         monkeypatch.setenv("KLANGK_DEFAULT_USER", "ghost@example.com")
         resp = await client.post("/api/v1/auth/local")
         assert resp.status_code == 500
 
-    async def test_no_body_required(self, client, db, monkeypatch):
-        monkeypatch.setenv("KLANGK_AUTH_MODES", "none")
+    async def test_no_body_required(self, client, app, db, monkeypatch):
+        monkeypatch.setattr(app.state.oidc, "auth_modes", lambda: "none")
         monkeypatch.setenv("KLANGK_DEFAULT_USER", "local@example.com")
         await model.create_user(
             "local@example.com",
@@ -750,11 +755,11 @@ class TestLocalLogin:
     # non-loopback X-Real-IP even when the immediate peer is loopback.
 
     async def test_rejects_nonloopback_real_client_via_nginx(
-        self, client, db, monkeypatch
+        self, client, app, db, monkeypatch
     ):
         """Front-proxy bypass: peer is loopback (nginx) but X-Real-IP is the
         real client (a workspace container) -> backend refuses independently."""
-        monkeypatch.setenv("KLANGK_AUTH_MODES", "none")
+        monkeypatch.setattr(app.state.oidc, "auth_modes", lambda: "none")
         monkeypatch.setenv("KLANGK_DEFAULT_USER", "local@example.com")
         await model.create_user(
             "local@example.com",
@@ -769,12 +774,12 @@ class TestLocalLogin:
         assert "loopback" in resp.json()["detail"].lower()
 
     async def test_admits_loopback_real_client_via_nginx(
-        self, client, db, monkeypatch
+        self, client, app, db, monkeypatch
     ):
         """The benign mirror: peer loopback (nginx), X-Real-IP loopback (the
         operator's browser) -> admit. (ASGI test client peer is itself
         loopback, satisfying the trust gate that honors X-Real-IP.)"""
-        monkeypatch.setenv("KLANGK_AUTH_MODES", "none")
+        monkeypatch.setattr(app.state.oidc, "auth_modes", lambda: "none")
         monkeypatch.setenv("KLANGK_DEFAULT_USER", "local@example.com")
         await model.create_user(
             "local@example.com",
@@ -1594,7 +1599,7 @@ class TestWorkspaceRoutes:
         assert resp.status_code == 404
 
     async def test_delete_workspace_with_container(
-        self, client, user, registry
+        self, client, app, user, registry
     ):
         headers = await _auth_headers(client)
         create_resp = await client.post(
@@ -1626,7 +1631,7 @@ class TestWorkspaceRoutes:
         mock_rm.assert_awaited_once_with("fake-container-id")
 
     async def test_delete_workspace_cleans_up_groups(
-        self, client, user, registry
+        self, client, app, user, registry
     ):
         headers = await _auth_headers(client)
         create_resp = await client.post(
@@ -1679,7 +1684,7 @@ class TestWorkspaceRoutes:
         mock_notify.assert_called_once_with(user["id"])
 
     async def test_delete_notifies_deleter_and_owner(
-        self, client, user, registry, sockets
+        self, client, app, user, registry, sockets
     ):
         headers = await _auth_headers(client)
         create_resp = await client.post(
@@ -1861,7 +1866,7 @@ class TestWorkspaceRoutes:
         assert match[0]["service_command"] == "pi"
 
     async def test_update_workspace_propagates_to_live_state(
-        self, client, user, registry
+        self, client, app, user, registry
     ):
         # Editing setup_state/health_check on a workspace whose
         # container is live updates the cached ContainerState so the
@@ -1933,7 +1938,7 @@ class TestWorkspaceRoutes:
         assert resp.status_code == 404
 
     async def test_update_workspace_race_delete(
-        self, client, user, monkeypatch
+        self, client, app, user, monkeypatch
     ):
         """Workspace deleted between get and update returns 404."""
         headers = await _auth_headers(client)
@@ -2182,7 +2187,7 @@ class TestWorkspaceSharingRoutes:
         assert isinstance(resp.json(), list)
 
     async def test_list_shared_bare_path_not_capped_at_default(
-        self, client, user
+        self, client, app, user
     ):
         """Shared bare-list path returns more than the default of 10 (#1266).
 
@@ -2302,7 +2307,7 @@ class TestWorkspaceSharingRoutes:
         assert resp.json()[0]["email"] == "other@example.com"
 
     async def test_add_member_notifies_owner_and_target(
-        self, client, user, sockets
+        self, client, app, user, sockets
     ):
         headers = await _auth_headers(client)
         other = await self._create_other_user()
@@ -2323,7 +2328,7 @@ class TestWorkspaceSharingRoutes:
         assert notified == {user["id"], other["id"]}
 
     async def test_remove_member_notifies_owner_and_removed(
-        self, client, user, sockets
+        self, client, app, user, sockets
     ):
         headers = await _auth_headers(client)
         other = await self._create_other_user()
@@ -2348,7 +2353,7 @@ class TestWorkspaceSharingRoutes:
         assert notified == {user["id"], other["id"]}
 
     async def test_add_to_role_notifies_owner_and_target(
-        self, client, user, sockets
+        self, client, app, user, sockets
     ):
         headers = await _auth_headers(client)
         other = await self._create_other_user()
@@ -2369,7 +2374,7 @@ class TestWorkspaceSharingRoutes:
         assert notified == {user["id"], other["id"]}
 
     async def test_remove_from_role_notifies_owner_and_member(
-        self, client, user, sockets
+        self, client, app, user, sockets
     ):
         headers = await _auth_headers(client)
         other = await self._create_other_user()
@@ -2395,7 +2400,7 @@ class TestWorkspaceSharingRoutes:
         assert notified == {user["id"], other["id"]}
 
     async def test_change_role_notifies_owner_and_target(
-        self, client, user, sockets
+        self, client, app, user, sockets
     ):
         headers = await _auth_headers(client)
         other = await self._create_other_user()
@@ -2419,7 +2424,7 @@ class TestWorkspaceSharingRoutes:
         assert notified == {user["id"], other["id"]}
 
     async def test_change_role_allows_system_agent_removal(
-        self, client, user, db
+        self, client, app, user, db
     ):
         # role=None is removal-from-all-roles — harmless cleanup, so the
         # guard (which only fires on a grant) must let it through.
@@ -2608,7 +2613,7 @@ class TestWorkspaceACL:
         assert resp.status_code == 403
 
     async def test_get_workspace_acl_with_group(
-        self, client, admin_user, user
+        self, client, app, admin_user, user
     ):
         """ACL endpoint resolves group names."""
         headers = await _auth_headers(client)
@@ -3011,7 +3016,7 @@ class TestChangeWorkspaceRole:
         assert "Role group" in resp.json()["detail"]
 
     async def test_change_role_skips_missing_groups_on_remove(
-        self, client, user
+        self, client, app, user
     ):
         headers = await _auth_headers(client)
         resp = await client.post(
@@ -3639,7 +3644,7 @@ class TestBrowserBridge:
         assert "expired" in resp.json()["detail"].lower()
 
     async def test_browser_id_routes_to_correct_tab(
-        self, client, user, registry, sockets
+        self, client, app, user, registry, sockets
     ):
         """Browser ID routes to the specific browser tab."""
         mock_sock = MagicMock()
@@ -3669,7 +3674,7 @@ class TestBrowserBridge:
             registry.revoke_workspace_browsers("ws-conn")
 
     async def test_browser_not_subscribed_returns_502(
-        self, client, user, registry, sockets
+        self, client, app, user, registry, sockets
     ):
         """Returns 502 when target not in browser_subscribers."""
         mock_sock = MagicMock()
@@ -3707,7 +3712,7 @@ class TestBrowserBridge:
             registry.revoke_workspace_browsers("ws-nosess")
 
     async def test_dispatch_error_returns_502(
-        self, client, user, registry, sockets
+        self, client, app, user, registry, sockets
     ):
         mock_sock = MagicMock()
         registry.register_browser("bid-err", "ws-err", mock_sock)
@@ -3733,7 +3738,7 @@ class TestBrowserBridge:
             registry.revoke_workspace_browsers("ws-err")
 
     async def test_stream_endpoint_relays_ndjson(
-        self, client, user, registry, sockets
+        self, client, app, user, registry, sockets
     ):
         """The streaming endpoint relays the generator's NDJSON to the caller."""
         mock_sock = MagicMock()
@@ -4346,7 +4351,7 @@ class TestFileRoutes:
             self._cleanup(ws_id)
 
     async def test_download_file_strips_quotes_from_filename(
-        self, client, user
+        self, client, app, user
     ):
         headers = await _auth_headers(client)
         ws_id = await self._create_workspace(client, headers)
@@ -4734,7 +4739,7 @@ class TestAdminEndpoints:
         assert body["total"] >= 2
 
     async def test_list_users_default_page_size_is_10(
-        self, client, admin_user
+        self, client, app, admin_user
     ):
         headers = await self._admin_headers(client)
         # Create 12 users so the default page is full but not exhaustive.
@@ -4749,7 +4754,7 @@ class TestAdminEndpoints:
         assert len(body["users"]) == 10
 
     async def test_list_users_pagination_across_pages(
-        self, client, admin_user
+        self, client, app, admin_user
     ):
         headers = await self._admin_headers(client)
         for i in range(5):
@@ -4824,7 +4829,7 @@ class TestAdminEndpoints:
         assert body["total"] == 1
 
     async def test_list_users_invalid_sort_falls_back_to_created(
-        self, client, admin_user
+        self, client, app, admin_user
     ):
         headers = await self._admin_headers(client)
         # An unknown sort column must not 500 (falls back to created_at).
@@ -4884,7 +4889,7 @@ class TestAdminEndpoints:
         assert "Password" in resp.json()["detail"]
 
     async def test_admin_create_user_send_verification_email(
-        self, client, admin_user
+        self, client, app, admin_user
     ):
         headers = await self._admin_headers(client)
         with patch("klangk_backend.api.admin.emailsvc") as mock_email:
@@ -4910,7 +4915,7 @@ class TestAdminEndpoints:
         assert user["handle"] == "verify"  # derived, not NULL
 
     async def test_admin_create_user_no_password_no_verify(
-        self, client, admin_user
+        self, client, app, admin_user
     ):
         headers = await self._admin_headers(client)
         resp = await client.post(
@@ -4983,7 +4988,7 @@ class TestAdminEndpoints:
         assert "system agent" in resp.json()["detail"]
 
     async def test_delete_user_cascades_workspaces(
-        self, client, admin_user, user, registry
+        self, client, app, admin_user, user, registry
     ):
         """Deleting a user cascades to their ws_mod."""
         headers = await self._admin_headers(client)
@@ -5091,7 +5096,7 @@ class TestAdminEndpoints:
         assert resp.status_code == 404
 
     async def test_update_agent_password_rejected(
-        self, client, admin_user, db
+        self, client, app, admin_user, db
     ):
         # Seed the agent user so it exists in the DB
         from klangk_backend.main import seed_agent_user
@@ -5166,7 +5171,7 @@ class TestGroupEndpoints:
         assert body["total"] >= 1
 
     async def test_list_groups_default_page_size_is_10(
-        self, client, admin_user
+        self, client, app, admin_user
     ):
         headers = await self._admin_headers(client)
         for i in range(12):
@@ -5180,7 +5185,7 @@ class TestGroupEndpoints:
         assert len(body["groups"]) == 10
 
     async def test_list_groups_pagination_across_pages(
-        self, client, admin_user
+        self, client, app, admin_user
     ):
         headers = await self._admin_headers(client)
         for i in range(5):
@@ -5248,7 +5253,7 @@ class TestGroupEndpoints:
         assert body["total"] == 1
 
     async def test_list_groups_invalid_sort_falls_back_to_name(
-        self, client, admin_user
+        self, client, app, admin_user
     ):
         headers = await self._admin_headers(client)
         # An unknown sort column must not 500 (falls back to name).
@@ -5503,7 +5508,7 @@ class TestACLEndpoints:
         assert "terminal" in perms
 
     async def test_my_permissions_for_resource_no_access(
-        self, client, admin_user, user
+        self, client, app, admin_user, user
     ):
         """User without specific ACE only gets inherited permissions."""
         headers = await _auth_headers(client)
@@ -5600,7 +5605,7 @@ class TestAdminResourceACL:
         assert resp.status_code == 403
 
     async def test_root_acl_rejects_removing_authenticated_view(
-        self, client, admin_user
+        self, client, app, admin_user
     ):
         headers = await self._admin_headers(client)
         # Try to save root ACL without Authenticated view
@@ -5620,7 +5625,7 @@ class TestAdminResourceACL:
         assert "locking out" in resp.json()["detail"]
 
     async def test_root_acl_accepts_wildcard_authenticated(
-        self, client, admin_user
+        self, client, app, admin_user
     ):
         headers = await self._admin_headers(client)
         # Authenticated with * should be accepted
@@ -5645,7 +5650,7 @@ class TestAdminResourceACL:
         assert resp.status_code == 200
 
     async def test_admin_acl_rejects_removing_all_group_access(
-        self, client, admin_user
+        self, client, app, admin_user
     ):
         headers = await self._admin_headers(client)
         # Try to save /admin ACL with no group Allow
@@ -6285,7 +6290,7 @@ class TestWorkspaceExportImport:
         mock_notify.assert_called_once_with(user["id"])
 
     async def test_import_runs_tar_off_event_loop(
-        self, client, admin_user, user
+        self, client, app, admin_user, user
     ):
         """Import runs tar subprocesses off the event loop (regression #1261).
 
@@ -6335,7 +6340,7 @@ class TestWorkspaceExportImport:
         assert all(t != loop_thread for t in seen)
 
     async def test_export_runs_size_estimate_off_event_loop(
-        self, client, admin_user, user
+        self, client, app, admin_user, user
     ):
         """Export's ``du`` size-estimate runs off the event loop (#1261)."""
         import subprocess
@@ -6553,7 +6558,7 @@ class TestWorkspaceExportImport:
         assert (home / "test.txt").exists()
 
     async def test_export_streams_valid_tarball(
-        self, client, admin_user, user
+        self, client, app, admin_user, user
     ):
         """Export streams a valid .tar.gz with size estimate header."""
         headers = await self._user_headers(client)
@@ -6624,7 +6629,7 @@ class TestWorkspaceExportImport:
             assert any("big.bin" in n for n in tar.getnames())
 
     async def test_export_du_failure_falls_back(
-        self, client, admin_user, user, monkeypatch
+        self, client, app, admin_user, user, monkeypatch
     ):
         """If du fails, estimated size defaults to minimum."""
         headers = await self._user_headers(client)
@@ -6678,7 +6683,7 @@ class TestWorkspaceExportImport:
         assert resp.headers["x-estimated-size"] == "1"
 
     async def test_import_upload_error_cleans_tempfile(
-        self, client, user, monkeypatch
+        self, client, app, user, monkeypatch
     ):
         """If the upload write fails, the temp file is cleaned up."""
         import klangk_backend.api.workspaces as api_mod
@@ -6719,7 +6724,7 @@ class TestWorkspaceExportImport:
         assert not os.path.exists(created_tmp[0])
 
     async def test_export_preserves_all_symlinks(
-        self, client, admin_user, user
+        self, client, app, admin_user, user
     ):
         """All symlinks are preserved in export (stored as links, not content)."""
         headers = await self._user_headers(client)
@@ -6925,7 +6930,7 @@ class TestWorkspaceExportImport:
         assert "PATH" not in env
 
     async def test_import_cleanup_on_extraction_failure(
-        self, client, user, monkeypatch
+        self, client, app, user, monkeypatch
     ):
         """If tar extraction fails, the workspace is cleaned up."""
         import json
@@ -7000,7 +7005,7 @@ class TestWorkspaceExportImport:
         assert "corrupt" in resp.json()["detail"].lower()
 
     async def test_import_timeout_cleans_up_workspace(
-        self, client, user, monkeypatch
+        self, client, app, user, monkeypatch
     ):
         """If tar extraction times out after workspace creation, cleanup occurs."""
         import json
@@ -7139,7 +7144,7 @@ class TestInvitations:
         mock_send.assert_called_once()
 
     async def test_send_invitation_disabled(
-        self, client, admin_user, monkeypatch
+        self, client, app, admin_user, monkeypatch
     ):
         headers = await self._admin_headers(client)
         monkeypatch.setattr(auth, "invitations_enabled", lambda: False)
@@ -7152,7 +7157,7 @@ class TestInvitations:
         assert "disabled" in resp.json()["detail"]
 
     async def test_send_invitation_existing_user(
-        self, client, admin_user, user
+        self, client, app, admin_user, user
     ):
         headers = await self._admin_headers(client)
         resp = await client.post(
@@ -7241,7 +7246,7 @@ class TestInvitations:
         assert body["pending_count"] >= 2
 
     async def test_list_invitations_default_page_size_is_10(
-        self, client, admin_user
+        self, client, app, admin_user
     ):
         headers = await self._admin_headers(client)
         with patch.object(
@@ -7264,7 +7269,7 @@ class TestInvitations:
         assert len(body["invitations"]) == 10
 
     async def test_list_invitations_pagination_across_pages(
-        self, client, admin_user
+        self, client, app, admin_user
     ):
         headers = await self._admin_headers(client)
         with patch.object(
@@ -7325,7 +7330,7 @@ class TestInvitations:
         assert emails[0] == "alpha@example.com"
 
     async def test_list_invitations_sort_by_invited_by(
-        self, client, admin_user
+        self, client, app, admin_user
     ):
         # Two invitations from two different inviters. Sorting by
         # ``invited_by`` must track the inviter's email (the value the UI
@@ -7357,7 +7362,7 @@ class TestInvitations:
         assert ours[0]["email"] == "alpha@example.com"
 
     async def test_list_invitations_sort_desc_reverses(
-        self, client, admin_user
+        self, client, app, admin_user
     ):
         headers = await self._admin_headers(client)
         with patch.object(
@@ -7416,7 +7421,7 @@ class TestInvitations:
         assert body["pending_count"] >= 2
 
     async def test_list_invitations_invalid_sort_falls_back_to_created(
-        self, client, admin_user
+        self, client, app, admin_user
     ):
         headers = await self._admin_headers(client)
         # An unknown sort column must not 500 (falls back to created_at).
@@ -7602,7 +7607,7 @@ class TestInvitations:
         assert "Password" in resp.json()["detail"]
 
     async def test_accept_invite_works_when_registration_disabled(
-        self, client, admin_user, monkeypatch
+        self, client, app, admin_user, monkeypatch
     ):
         headers = await self._admin_headers(client)
         with patch.object(
@@ -7630,7 +7635,7 @@ class TestInvitations:
         assert resp.json()["status"] == "accepted"
 
     async def test_accept_invite_email_already_registered(
-        self, client, admin_user, user
+        self, client, app, admin_user, user
     ):
         headers = await self._admin_headers(client)
         with patch.object(
@@ -7658,7 +7663,7 @@ class TestInvitations:
         assert resp.status_code == 400
         assert "already exists" in resp.json()["detail"]
 
-    async def test_accept_invite_wrong_purpose_token(self, client, db):
+    async def test_accept_invite_wrong_purpose_token(self, client, app, db):
         # Use a verification token (wrong purpose)
         token = auth.create_verification_token("fake-user-id")
         resp = await client.post(
@@ -7673,7 +7678,7 @@ class TestInvitations:
         assert "invitations_enabled" in resp.json()
 
     async def test_config_advertises_allow_autostart(
-        self, client, monkeypatch
+        self, client, app, monkeypatch
     ):
         # Default: flag unset -> not allowed, so the UI hides its checkbox.
         monkeypatch.delenv("KLANGK_ALLOW_AUTOSTART", raising=False)
@@ -7691,8 +7696,10 @@ class TestInvitations:
 
 
 class TestOIDCConfig:
-    async def test_config_includes_oidc_fields(self, client, monkeypatch):
-        monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
+    async def test_config_includes_oidc_fields(self, client, app, monkeypatch):
+        # Default (no auth mode set) is ``none`` (#1374). Patch the OIDC
+        # instance rather than the env (#1450).
+        monkeypatch.setattr(app.state.oidc, "auth_modes", lambda: "none")
         resp = await client.get("/api/v1/config")
         assert resp.status_code == 200
         data = resp.json()
@@ -7702,13 +7709,13 @@ class TestOIDCConfig:
         # Production default (no OIDC, mode unset) is now ``none`` (#1374).
         assert data["auth_modes"] == "none"
 
-    async def test_config_with_providers(self, client, monkeypatch):
+    async def test_config_with_providers(self, client, app, monkeypatch):
         monkeypatch.setattr(
-            api.oidc,
+            app.state.oidc,
             "list_providers",
             lambda: [{"id": "test", "display_name": "Test"}],
         )
-        monkeypatch.setattr(api.oidc, "auth_modes", lambda *args: "both")
+        monkeypatch.setattr(app.state.oidc, "auth_modes", lambda *args: "both")
         resp = await client.get("/api/v1/config")
         data = resp.json()
         assert len(data["oidc_providers"]) == 1
@@ -7717,10 +7724,10 @@ class TestOIDCConfig:
 
 class TestOIDCAuthModeGuards:
     async def test_login_blocked_when_oidc_only(
-        self, client, monkeypatch, user
+        self, client, app, monkeypatch, user
     ):
         monkeypatch.setattr(
-            api.oidc, "password_login_allowed", lambda *args: False
+            app.state.oidc, "password_login_allowed", lambda *args: False
         )
         resp = await client.post(
             "/api/v1/auth/login",
@@ -7730,10 +7737,10 @@ class TestOIDCAuthModeGuards:
         assert "disabled" in resp.json()["detail"]
 
     async def test_register_blocked_when_oidc_only(
-        self, client, monkeypatch, db
+        self, client, app, monkeypatch, db
     ):
         monkeypatch.setattr(
-            api.oidc, "password_login_allowed", lambda *args: False
+            app.state.oidc, "password_login_allowed", lambda *args: False
         )
         resp = await client.post(
             "/api/v1/auth/register",
@@ -7741,9 +7748,11 @@ class TestOIDCAuthModeGuards:
         )
         assert resp.status_code == 403
 
-    async def test_login_allowed_when_both(self, client, monkeypatch, user):
+    async def test_login_allowed_when_both(
+        self, client, app, monkeypatch, user
+    ):
         monkeypatch.setattr(
-            api.oidc, "password_login_allowed", lambda *args: True
+            app.state.oidc, "password_login_allowed", lambda *args: True
         )
         resp = await client.post(
             "/api/v1/auth/login",
@@ -7753,20 +7762,22 @@ class TestOIDCAuthModeGuards:
 
 
 class TestOIDCLogin:
-    async def test_oidc_login_not_enabled(self, client, monkeypatch):
+    async def test_oidc_login_not_enabled(self, client, app, monkeypatch):
         monkeypatch.setattr(
-            api.oidc, "oidc_login_allowed", lambda *args: False
+            app.state.oidc, "oidc_login_allowed", lambda *args: False
         )
         resp = await client.get("/api/v1/auth/oidc/test/login")
         assert resp.status_code == 404
 
-    async def test_unknown_provider(self, client, monkeypatch):
-        monkeypatch.setattr(api.oidc, "oidc_login_allowed", lambda *args: True)
-        monkeypatch.setattr(api.oidc, "get_provider", lambda _: None)
+    async def test_unknown_provider(self, client, app, monkeypatch):
+        monkeypatch.setattr(
+            app.state.oidc, "oidc_login_allowed", lambda *args: True
+        )
+        monkeypatch.setattr(app.state.oidc, "get_provider", lambda _: None)
         resp = await client.get("/api/v1/auth/oidc/nope/login")
         assert resp.status_code == 404
 
-    async def test_invalid_cli_redirect(self, client, monkeypatch):
+    async def test_invalid_cli_redirect(self, client, app, monkeypatch):
         provider = api.oidc.OIDCProvider(
             id="test",
             display_name="Test",
@@ -7774,8 +7785,10 @@ class TestOIDCLogin:
             client_id="klangk",
             client_secret="s",
         )
-        monkeypatch.setattr(api.oidc, "oidc_login_allowed", lambda *args: True)
-        monkeypatch.setattr(api.oidc, "get_provider", lambda _: provider)
+        monkeypatch.setattr(
+            app.state.oidc, "oidc_login_allowed", lambda *args: True
+        )
+        monkeypatch.setattr(app.state.oidc, "get_provider", lambda _: provider)
         resp = await client.get(
             "/api/v1/auth/oidc/test/login",
             params={"cli_redirect": "https://evil.com/steal"},
@@ -7783,7 +7796,7 @@ class TestOIDCLogin:
         assert resp.status_code == 400
         assert "localhost" in resp.json()["detail"]
 
-    async def test_oidc_login_redirects(self, client, monkeypatch):
+    async def test_oidc_login_redirects(self, client, app, monkeypatch):
         provider = api.oidc.OIDCProvider(
             id="test",
             display_name="Test",
@@ -7791,10 +7804,12 @@ class TestOIDCLogin:
             client_id="klangk",
             client_secret="s",
         )
-        monkeypatch.setattr(api.oidc, "oidc_login_allowed", lambda *args: True)
-        monkeypatch.setattr(api.oidc, "get_provider", lambda _: provider)
         monkeypatch.setattr(
-            api.oidc,
+            app.state.oidc, "oidc_login_allowed", lambda *args: True
+        )
+        monkeypatch.setattr(app.state.oidc, "get_provider", lambda _: provider)
+        monkeypatch.setattr(
+            app.state.oidc,
             "build_auth_url",
             AsyncMock(return_value="https://idp.example.com/auth?foo=bar"),
         )
@@ -7809,7 +7824,7 @@ class TestOIDCLogin:
 
 
 class TestOIDCCallback:
-    async def _setup_callback(self, client, monkeypatch, db, claims=None):
+    async def _setup_callback(self, client, app, monkeypatch, db, claims=None):
         """Set up mocks for a successful OIDC callback test."""
         import json as json_mod
 
@@ -7820,9 +7835,9 @@ class TestOIDCCallback:
             client_id="klangk",
             client_secret="s",
         )
-        monkeypatch.setattr(api.oidc, "get_provider", lambda _: provider)
+        monkeypatch.setattr(app.state.oidc, "get_provider", lambda _: provider)
         monkeypatch.setattr(
-            api.oidc,
+            app.state.oidc,
             "exchange_code",
             AsyncMock(
                 return_value={
@@ -7839,7 +7854,7 @@ class TestOIDCCallback:
         if claims:
             default_claims.update(claims)
         monkeypatch.setattr(
-            api.oidc,
+            app.state.oidc,
             "validate_id_token",
             AsyncMock(return_value=default_claims),
         )
@@ -7854,8 +7869,10 @@ class TestOIDCCallback:
         )
         return provider, cookie_data
 
-    async def test_callback_creates_user(self, client, monkeypatch, db):
-        _, cookie_data = await self._setup_callback(client, monkeypatch, db)
+    async def test_callback_creates_user(self, client, app, monkeypatch, db):
+        _, cookie_data = await self._setup_callback(
+            client, app, monkeypatch, db
+        )
         client.cookies.set("oidc_test", cookie_data)
         resp = await client.get(
             "/api/v1/auth/oidc/test/callback",
@@ -7875,7 +7892,7 @@ class TestOIDCCallback:
         assert user["password_hash"] is None
 
     async def test_callback_syncs_groups_via_hook(
-        self, client, monkeypatch, db
+        self, client, app, monkeypatch, db
     ):
         """OIDC callback calls the group mapping hook and syncs memberships."""
 
@@ -7884,11 +7901,12 @@ class TestOIDCCallback:
                 return {"admin", "power-users"}
             return {"users"}
 
-        monkeypatch.setattr(api.oidc, "_login_hook", test_hook)
-        monkeypatch.setattr(api.oidc, "_login_hook_is_async", False)
+        monkeypatch.setattr(app.state.oidc, "login_hook", test_hook)
+        monkeypatch.setattr(app.state.oidc, "login_hook_is_async", False)
 
         _, cookie_data = await self._setup_callback(
             client,
+            app,
             monkeypatch,
             db,
             claims={
@@ -7916,10 +7934,11 @@ class TestOIDCCallback:
         assert len(sync_ids) == 2
 
     async def test_callback_links_existing_user(
-        self, client, monkeypatch, db, user
+        self, client, app, monkeypatch, db, user
     ):
         _, cookie_data = await self._setup_callback(
             client,
+            app,
             monkeypatch,
             db,
             claims={"sub": "new-sub", "email": "testuser@example.com"},
@@ -7937,8 +7956,10 @@ class TestOIDCCallback:
         assert linked is not None
         assert linked["id"] == user["id"]
 
-    async def test_callback_state_mismatch(self, client, monkeypatch, db):
-        _, cookie_data = await self._setup_callback(client, monkeypatch, db)
+    async def test_callback_state_mismatch(self, client, app, monkeypatch, db):
+        _, cookie_data = await self._setup_callback(
+            client, app, monkeypatch, db
+        )
         client.cookies.set("oidc_test", cookie_data)
         resp = await client.get(
             "/api/v1/auth/oidc/test/callback",
@@ -7947,8 +7968,8 @@ class TestOIDCCallback:
         assert resp.status_code == 400
         assert "State mismatch" in resp.json()["detail"]
 
-    async def test_callback_missing_cookie(self, client, monkeypatch, db):
-        await self._setup_callback(client, monkeypatch, db)
+    async def test_callback_missing_cookie(self, client, app, monkeypatch, db):
+        await self._setup_callback(client, app, monkeypatch, db)
         resp = await client.get(
             "/api/v1/auth/oidc/test/callback",
             params={"code": "code", "state": "test-state"},
@@ -7956,7 +7977,7 @@ class TestOIDCCallback:
         assert resp.status_code == 400
         assert "cookie" in resp.json()["detail"].lower()
 
-    async def test_callback_idp_error(self, client, monkeypatch, db):
+    async def test_callback_idp_error(self, client, app, monkeypatch, db):
         provider = api.oidc.OIDCProvider(
             id="test",
             display_name="Test",
@@ -7964,7 +7985,7 @@ class TestOIDCCallback:
             client_id="klangk",
             client_secret="s",
         )
-        monkeypatch.setattr(api.oidc, "get_provider", lambda _: provider)
+        monkeypatch.setattr(app.state.oidc, "get_provider", lambda _: provider)
         resp = await client.get(
             "/api/v1/auth/oidc/test/callback",
             params={"error": "access_denied"},
@@ -7972,7 +7993,7 @@ class TestOIDCCallback:
         assert resp.status_code == 400
         assert resp.json()["detail"] == "Login failed"
 
-    async def test_callback_cli_redirect(self, client, monkeypatch, db):
+    async def test_callback_cli_redirect(self, client, app, monkeypatch, db):
         import json as json_mod
 
         provider = api.oidc.OIDCProvider(
@@ -7982,14 +8003,14 @@ class TestOIDCCallback:
             client_id="klangk",
             client_secret="s",
         )
-        monkeypatch.setattr(api.oidc, "get_provider", lambda _: provider)
+        monkeypatch.setattr(app.state.oidc, "get_provider", lambda _: provider)
         monkeypatch.setattr(
-            api.oidc,
+            app.state.oidc,
             "exchange_code",
             AsyncMock(return_value={"id_token": "idt", "access_token": "at"}),
         )
         monkeypatch.setattr(
-            api.oidc,
+            app.state.oidc,
             "validate_id_token",
             AsyncMock(
                 return_value={
@@ -8019,7 +8040,7 @@ class TestOIDCCallback:
         )
 
     async def test_callback_tampered_cli_redirect_falls_back(
-        self, client, monkeypatch, db
+        self, client, app, monkeypatch, db
     ):
         """A tampered (non-localhost) cli_redirect in the unsigned state
         cookie must NOT receive the token — fall back to the web flow.
@@ -8036,14 +8057,14 @@ class TestOIDCCallback:
             client_id="klangk",
             client_secret="s",
         )
-        monkeypatch.setattr(api.oidc, "get_provider", lambda _: provider)
+        monkeypatch.setattr(app.state.oidc, "get_provider", lambda _: provider)
         monkeypatch.setattr(
-            api.oidc,
+            app.state.oidc,
             "exchange_code",
             AsyncMock(return_value={"id_token": "idt", "access_token": "at"}),
         )
         monkeypatch.setattr(
-            api.oidc,
+            app.state.oidc,
             "validate_id_token",
             AsyncMock(
                 return_value={
@@ -8077,7 +8098,7 @@ class TestOIDCCallback:
         assert "token=" in location
 
     async def test_callback_token_exchange_failure(
-        self, client, monkeypatch, db
+        self, client, app, monkeypatch, db
     ):
         import json as json_mod
 
@@ -8088,13 +8109,13 @@ class TestOIDCCallback:
             client_id="klangk",
             client_secret="s",
         )
-        monkeypatch.setattr(api.oidc, "get_provider", lambda _: provider)
+        monkeypatch.setattr(app.state.oidc, "get_provider", lambda _: provider)
         mock_request = httpx.Request("POST", "https://idp/token")
         mock_response = httpx.Response(
             400, text="bad request", request=mock_request
         )
         monkeypatch.setattr(
-            api.oidc,
+            app.state.oidc,
             "exchange_code",
             AsyncMock(
                 side_effect=httpx.HTTPStatusError(
@@ -8117,7 +8138,7 @@ class TestOIDCCallback:
         )
         assert resp.status_code == 502
 
-    async def test_callback_no_id_token(self, client, monkeypatch, db):
+    async def test_callback_no_id_token(self, client, app, monkeypatch, db):
         import json as json_mod
 
         provider = api.oidc.OIDCProvider(
@@ -8127,9 +8148,9 @@ class TestOIDCCallback:
             client_id="klangk",
             client_secret="s",
         )
-        monkeypatch.setattr(api.oidc, "get_provider", lambda _: provider)
+        monkeypatch.setattr(app.state.oidc, "get_provider", lambda _: provider)
         monkeypatch.setattr(
-            api.oidc,
+            app.state.oidc,
             "exchange_code",
             AsyncMock(return_value={"access_token": "at"}),
         )
@@ -8149,7 +8170,9 @@ class TestOIDCCallback:
         assert resp.status_code == 502
         assert "No ID token" in resp.json()["detail"]
 
-    async def test_callback_invalid_id_token(self, client, monkeypatch, db):
+    async def test_callback_invalid_id_token(
+        self, client, app, monkeypatch, db
+    ):
         import json as json_mod
 
         provider = api.oidc.OIDCProvider(
@@ -8159,14 +8182,14 @@ class TestOIDCCallback:
             client_id="klangk",
             client_secret="s",
         )
-        monkeypatch.setattr(api.oidc, "get_provider", lambda _: provider)
+        monkeypatch.setattr(app.state.oidc, "get_provider", lambda _: provider)
         monkeypatch.setattr(
-            api.oidc,
+            app.state.oidc,
             "exchange_code",
             AsyncMock(return_value={"id_token": "bad", "access_token": "at"}),
         )
         monkeypatch.setattr(
-            api.oidc,
+            app.state.oidc,
             "validate_id_token",
             AsyncMock(side_effect=Exception("bad token")),
         )
@@ -8186,7 +8209,7 @@ class TestOIDCCallback:
         assert resp.status_code == 502
         assert "validation failed" in resp.json()["detail"]
 
-    async def test_callback_missing_claims(self, client, monkeypatch, db):
+    async def test_callback_missing_claims(self, client, app, monkeypatch, db):
         import json as json_mod
 
         provider = api.oidc.OIDCProvider(
@@ -8196,14 +8219,14 @@ class TestOIDCCallback:
             client_id="klangk",
             client_secret="s",
         )
-        monkeypatch.setattr(api.oidc, "get_provider", lambda _: provider)
+        monkeypatch.setattr(app.state.oidc, "get_provider", lambda _: provider)
         monkeypatch.setattr(
-            api.oidc,
+            app.state.oidc,
             "exchange_code",
             AsyncMock(return_value={"id_token": "t", "access_token": "at"}),
         )
         monkeypatch.setattr(
-            api.oidc,
+            app.state.oidc,
             "validate_id_token",
             AsyncMock(return_value={"sub": "s"}),  # no email
         )
@@ -8223,16 +8246,19 @@ class TestOIDCCallback:
         assert resp.status_code == 502
         assert "missing" in resp.json()["detail"].lower()
 
-    async def test_callback_login_hook_rejects(self, client, monkeypatch, db):
+    async def test_callback_login_hook_rejects(
+        self, client, app, monkeypatch, db
+    ):
         """A login validation hook can reject an OIDC login."""
 
         def reject_hook(provider, claims, email, tokens):
             raise ValueError("Denied by hook")
 
-        monkeypatch.setattr(oidc, "_login_hook", reject_hook)
-        monkeypatch.setattr(oidc, "_login_hook_is_async", False)
+        monkeypatch.setattr(app.state.oidc, "login_hook", reject_hook)
+        monkeypatch.setattr(app.state.oidc, "login_hook_is_async", False)
         _, cookie_data = await self._setup_callback(
             client,
+            app,
             monkeypatch,
             db,
         )
@@ -8247,11 +8273,12 @@ class TestOIDCCallback:
         assert await model.get_user_by_email("oidcuser@example.com") is None
 
     async def test_callback_rejects_unverified_email_by_default(
-        self, client, monkeypatch, db
+        self, client, app, monkeypatch, db
     ):
         """Unverified email is rejected when trust-email is false (default)."""
         _, cookie_data = await self._setup_callback(
             client,
+            app,
             monkeypatch,
             db,
             claims={"email_verified": False},
@@ -8267,18 +8294,19 @@ class TestOIDCCallback:
         assert await model.get_user_by_email("oidcuser@example.com") is None
 
     async def test_callback_rejects_missing_email_verified(
-        self, client, monkeypatch, db
+        self, client, app, monkeypatch, db
     ):
         """Missing email_verified claim is rejected (same as False)."""
         _, cookie_data = await self._setup_callback(
             client,
+            app,
             monkeypatch,
             db,
             claims={"sub": "no-ev-sub", "email": "noev@example.com"},
         )
         # Override claims to omit email_verified entirely
         monkeypatch.setattr(
-            api.oidc,
+            app.state.oidc,
             "validate_id_token",
             AsyncMock(
                 return_value={
@@ -8296,11 +8324,12 @@ class TestOIDCCallback:
         assert resp.status_code == 403
 
     async def test_callback_trust_email_allows_unverified(
-        self, client, monkeypatch, db
+        self, client, app, monkeypatch, db
     ):
         """With trust-email: true, unverified emails are accepted."""
         provider, cookie_data = await self._setup_callback(
             client,
+            app,
             monkeypatch,
             db,
             claims={"email_verified": False},
@@ -8317,10 +8346,12 @@ class TestOIDCCallback:
             await model.get_user_by_email("oidcuser@example.com") is not None
         )
 
-    async def test_callback_returning_user(self, client, monkeypatch, db):
+    async def test_callback_returning_user(self, client, app, monkeypatch, db):
         """A user who already has the OIDC identity linked logs in without
         JIT provisioning or email lookup."""
-        _, cookie_data = await self._setup_callback(client, monkeypatch, db)
+        _, cookie_data = await self._setup_callback(
+            client, app, monkeypatch, db
+        )
         # First callback — creates the user via JIT provisioning.
         client.cookies.set("oidc_test", cookie_data)
         resp = await client.get(
@@ -8333,7 +8364,9 @@ class TestOIDCCallback:
         assert user is not None
 
         # Second callback — returning user, found by external ID.
-        _, cookie_data2 = await self._setup_callback(client, monkeypatch, db)
+        _, cookie_data2 = await self._setup_callback(
+            client, app, monkeypatch, db
+        )
         client.cookies.set("oidc_test", cookie_data2)
         resp2 = await client.get(
             "/api/v1/auth/oidc/test/callback",
@@ -8343,15 +8376,19 @@ class TestOIDCCallback:
         assert resp2.status_code == 302
         assert "token=" in resp2.headers["location"]
 
-    async def test_callback_unknown_provider(self, client, monkeypatch, db):
-        monkeypatch.setattr(api.oidc, "get_provider", lambda _: None)
+    async def test_callback_unknown_provider(
+        self, client, app, monkeypatch, db
+    ):
+        monkeypatch.setattr(app.state.oidc, "get_provider", lambda _: None)
         resp = await client.get(
             "/api/v1/auth/oidc/nope/callback",
             params={"code": "code", "state": "s"},
         )
         assert resp.status_code == 404
 
-    async def test_callback_invalid_cookie_json(self, client, monkeypatch, db):
+    async def test_callback_invalid_cookie_json(
+        self, client, app, monkeypatch, db
+    ):
         provider = api.oidc.OIDCProvider(
             id="test",
             display_name="Test",
@@ -8359,7 +8396,7 @@ class TestOIDCCallback:
             client_id="klangk",
             client_secret="s",
         )
-        monkeypatch.setattr(api.oidc, "get_provider", lambda _: provider)
+        monkeypatch.setattr(app.state.oidc, "get_provider", lambda _: provider)
         client.cookies.set("oidc_test", "not-json")
         resp = await client.get(
             "/api/v1/auth/oidc/test/callback",
@@ -8368,7 +8405,7 @@ class TestOIDCCallback:
         assert resp.status_code == 400
 
     async def test_callback_non_dict_cookie_json(
-        self, client, monkeypatch, db
+        self, client, app, monkeypatch, db
     ):
         """Non-dict JSON in the state cookie returns 400, not 500 (#1334)."""
         provider = api.oidc.OIDCProvider(
@@ -8378,7 +8415,7 @@ class TestOIDCCallback:
             client_id="klangk",
             client_secret="s",
         )
-        monkeypatch.setattr(api.oidc, "get_provider", lambda _: provider)
+        monkeypatch.setattr(app.state.oidc, "get_provider", lambda _: provider)
         client.cookies.set("oidc_test", "[1, 2, 3]")
         resp = await client.get(
             "/api/v1/auth/oidc/test/callback",
@@ -8390,7 +8427,7 @@ class TestOIDCCallback:
 class TestOIDCCallbackAgentGuard:
     """OIDC callback must never mint a session as the system agent (#1225)."""
 
-    async def _setup_callback(self, client, monkeypatch, db, claims=None):
+    async def _setup_callback(self, client, app, monkeypatch, db, claims=None):
         import json as json_mod
 
         provider = api.oidc.OIDCProvider(
@@ -8400,9 +8437,9 @@ class TestOIDCCallbackAgentGuard:
             client_id="klangk",
             client_secret="s",
         )
-        monkeypatch.setattr(api.oidc, "get_provider", lambda _: provider)
+        monkeypatch.setattr(app.state.oidc, "get_provider", lambda _: provider)
         monkeypatch.setattr(
-            api.oidc,
+            app.state.oidc,
             "exchange_code",
             AsyncMock(
                 return_value={
@@ -8419,7 +8456,7 @@ class TestOIDCCallbackAgentGuard:
         if claims:
             default_claims.update(claims)
         monkeypatch.setattr(
-            api.oidc,
+            app.state.oidc,
             "validate_id_token",
             AsyncMock(return_value=default_claims),
         )
@@ -8434,10 +8471,12 @@ class TestOIDCCallbackAgentGuard:
         return provider, cookie_data
 
     async def test_oidc_rejects_agent_email(
-        self, client, monkeypatch, db, agent_user
+        self, client, app, monkeypatch, db, agent_user
     ):
         """OIDC login with the agent's email is rejected with 403."""
-        _, cookie_data = await self._setup_callback(client, monkeypatch, db)
+        _, cookie_data = await self._setup_callback(
+            client, app, monkeypatch, db
+        )
         client.cookies.set("oidc_test", cookie_data)
         resp = await client.get(
             "/api/v1/auth/oidc/test/callback",
@@ -8447,7 +8486,7 @@ class TestOIDCCallbackAgentGuard:
         assert "system agent" in resp.json()["detail"]
 
     async def test_oidc_rejects_agent_by_external_id(
-        self, client, monkeypatch, db, agent_user
+        self, client, app, monkeypatch, db, agent_user
     ):
         """OIDC login resolving the agent by external_id is rejected."""
         # The DB trigger blocks linking OIDC identity to the agent, so
@@ -8458,7 +8497,9 @@ class TestOIDCCallbackAgentGuard:
             "get_user_by_external_id",
             AsyncMock(return_value=agent),
         )
-        _, cookie_data = await self._setup_callback(client, monkeypatch, db)
+        _, cookie_data = await self._setup_callback(
+            client, app, monkeypatch, db
+        )
         client.cookies.set("oidc_test", cookie_data)
         resp = await client.get(
             "/api/v1/auth/oidc/test/callback",
@@ -8469,7 +8510,7 @@ class TestOIDCCallbackAgentGuard:
 
 
 class TestOIDCLogout:
-    async def test_logout_returns_oidc_logout_url(self, client, db):
+    async def test_logout_returns_oidc_logout_url(self, client, app, db):
         """OIDC user with logout_redirect gets IdP logout URL in response."""
         # Create OIDC user
         user = await model.create_user(
@@ -8491,9 +8532,11 @@ class TestOIDCLogout:
             logout_redirect=True,
         )
         with (
-            patch.object(api.oidc, "get_provider", return_value=provider),
             patch.object(
-                api.oidc,
+                app.state.oidc, "get_provider", return_value=provider
+            ),
+            patch.object(
+                app.state.oidc,
                 "build_logout_url",
                 AsyncMock(return_value="https://idp.example.com/logout?x=1"),
             ),
@@ -8505,7 +8548,7 @@ class TestOIDCLogout:
             == "https://idp.example.com/logout?x=1"
         )
 
-    async def test_logout_no_redirect_for_local_user(self, client, user):
+    async def test_logout_no_redirect_for_local_user(self, client, app, user):
         """Local user gets no oidc_logout_url."""
         login_resp = await client.post(
             "/api/v1/auth/login",
@@ -8518,7 +8561,7 @@ class TestOIDCLogout:
         assert resp.status_code == 200
         assert "oidc_logout_url" not in resp.json()
 
-    async def test_logout_no_redirect_when_disabled(self, client, db):
+    async def test_logout_no_redirect_when_disabled(self, client, app, db):
         """OIDC user with logout_redirect=false gets no URL."""
         user = await model.create_user(
             "oidc-nologout@example.com",
@@ -8538,7 +8581,9 @@ class TestOIDCLogout:
             client_secret="s",
             logout_redirect=False,
         )
-        with patch.object(api.oidc, "get_provider", return_value=provider):
+        with patch.object(
+            app.state.oidc, "get_provider", return_value=provider
+        ):
             resp = await client.post("/api/v1/auth/logout", headers=headers)
         assert resp.status_code == 200
         assert "oidc_logout_url" not in resp.json()
@@ -8561,7 +8606,7 @@ class TestHandleEndpoints:
         assert updated["handle"] == "newhandle"
 
     async def test_change_handle_refreshes_presence(
-        self, client, user, sockets
+        self, client, app, user, sockets
     ):
         headers = await _auth_headers(client)
         with patch.object(
@@ -8661,7 +8706,7 @@ class TestHandleEndpoints:
         assert updated["handle"] == "admin-set-handle"
 
     async def test_admin_change_handle_refreshes_presence(
-        self, client, admin_user, user, sockets
+        self, client, app, admin_user, user, sockets
     ):
         admin_resp = await client.post(
             "/api/v1/auth/login",
@@ -8686,7 +8731,7 @@ class TestHandleEndpoints:
         )
 
     async def test_admin_change_user_handle_invalid(
-        self, client, admin_user, user
+        self, client, app, admin_user, user
     ):
         admin_resp = await client.post(
             "/api/v1/auth/login",

--- a/src/backend/tests/test_main.py
+++ b/src/backend/tests/test_main.py
@@ -13,7 +13,7 @@ from fastapi import FastAPI
 from httpx import AsyncClient, ASGITransport
 from sqlalchemy.exc import IntegrityError as SAIntegrityError
 
-from klangk_backend import main, model
+from klangk_backend import main, model, oidc
 from klangk_backend.container import ContainerRegistry
 from klangk_backend.settings import KlangkSettings
 from klangk_backend.wshandler.session import WebSocketState
@@ -93,64 +93,101 @@ class TestSeedDefaultUser:
 # --- no-auth bind safety gate (#1374) ---
 
 
+def _bind_safety_app_state(auth_mode=None):
+    """Build a minimal app_state whose oidc reads the given auth mode (#1450).
+
+    Pass the mode explicitly — the bind-safety tests exercise different
+    modes (password / none), and OIDC now reads ``settings.auth_modes`` at
+    construction instead of re-reading the env per call.
+    """
+    env = {"KLANGK_AUTH_MODES": auth_mode} if auth_mode else {}
+    settings = KlangkSettings(env=env)
+    app_state = types.SimpleNamespace(settings=settings)
+    app_state.oidc = oidc.OIDC(app_state)
+    return app_state
+
+
 class TestNoAuthBindSafety:
     """enforce_no_auth_bind_safety() — refuse none mode on a non-loopback
     bind unless explicitly overridden."""
 
     def test_noop_when_not_none_mode(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_AUTH_MODES", "password")
         monkeypatch.setenv("KLANGK_LISTEN", "0.0.0.0")
         # Returns None, raises nothing.
-        assert main.enforce_no_auth_bind_safety() is None
+        assert (
+            main.enforce_no_auth_bind_safety(
+                _bind_safety_app_state(auth_mode="password")
+            )
+            is None
+        )
 
     def test_allows_loopback_ipv4(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_AUTH_MODES", "none")
         monkeypatch.setenv("KLANGK_LISTEN", "127.0.0.1")
-        assert main.enforce_no_auth_bind_safety() is None
+        assert (
+            main.enforce_no_auth_bind_safety(
+                _bind_safety_app_state(auth_mode="none")
+            )
+            is None
+        )
 
     def test_allows_loopback_ipv6_and_localhost(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_AUTH_MODES", "none")
         for host in ("::1", "localhost"):
             monkeypatch.setenv("KLANGK_LISTEN", host)
-            assert main.enforce_no_auth_bind_safety() is None
+            assert (
+                main.enforce_no_auth_bind_safety(
+                    _bind_safety_app_state(auth_mode="none")
+                )
+                is None
+            )
 
     def test_allows_full_loopback_range(self, monkeypatch):
         """The whole 127.0.0.0/8 range is loopback (RFC 990), not just
         127.0.0.1 — ``127.0.0.2`` is a valid loopback bind and must be
         admitted (the original exact-match allowlist wrongly refused it)."""
-        monkeypatch.setenv("KLANGK_AUTH_MODES", "none")
         for host in ("127.0.0.2", "127.255.255.254"):
             monkeypatch.setenv("KLANGK_LISTEN", host)
-            assert main.enforce_no_auth_bind_safety() is None
+            assert (
+                main.enforce_no_auth_bind_safety(
+                    _bind_safety_app_state(auth_mode="none")
+                )
+                is None
+            )
 
     def test_allows_loopback_default_when_listen_unset(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_AUTH_MODES", "none")
         monkeypatch.delenv("KLANGK_LISTEN", raising=False)
         # KLANGK_LISTEN defaults to 127.0.0.1 (#1375).
-        assert main.enforce_no_auth_bind_safety() is None
+        assert (
+            main.enforce_no_auth_bind_safety(
+                _bind_safety_app_state(auth_mode="none")
+            )
+            is None
+        )
 
     def test_refuses_ipv6_wildcard(self, monkeypatch):
         """``::`` binds every interface (incl. IPv6) and is NOT loopback —
         must be refused even though it isn't ``0.0.0.0``."""
-        monkeypatch.setenv("KLANGK_AUTH_MODES", "none")
         monkeypatch.setenv("KLANGK_LISTEN", "::")
         with pytest.raises(SystemExit) as exc_info:
-            main.enforce_no_auth_bind_safety()
+            main.enforce_no_auth_bind_safety(
+                _bind_safety_app_state(auth_mode="none")
+            )
         assert "::" in str(exc_info.value)
 
     def test_refuses_non_loopback_hostname(self, monkeypatch):
         """A bare hostname (other than ``localhost``) is not an IP literal and
         not a recognized loopback name — fail-closed (refuse)."""
-        monkeypatch.setenv("KLANGK_AUTH_MODES", "none")
         monkeypatch.setenv("KLANGK_LISTEN", "myhost")
         with pytest.raises(SystemExit):
-            main.enforce_no_auth_bind_safety()
+            main.enforce_no_auth_bind_safety(
+                _bind_safety_app_state(auth_mode="none")
+            )
 
     def test_refuses_non_loopback_bind(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_AUTH_MODES", "none")
         monkeypatch.setenv("KLANGK_LISTEN", "0.0.0.0")
         with pytest.raises(SystemExit) as exc_info:
-            main.enforce_no_auth_bind_safety()
+            main.enforce_no_auth_bind_safety(
+                _bind_safety_app_state(auth_mode="none")
+            )
         msg = str(exc_info.value)
         assert "KLANGK_AUTH_MODES=none" in msg
         assert "loopback" in msg
@@ -159,18 +196,26 @@ class TestNoAuthBindSafety:
 
     def test_allows_socket_path(self, monkeypatch):
         """A UDS path is safe — same-uid trust boundary (#1399)."""
-        monkeypatch.setenv("KLANGK_AUTH_MODES", "none")
         monkeypatch.setenv("KLANGK_LISTEN", "/tmp/klangk.sock")
-        assert main.enforce_no_auth_bind_safety() is None
+        assert (
+            main.enforce_no_auth_bind_safety(
+                _bind_safety_app_state(auth_mode="none")
+            )
+            is None
+        )
 
     def test_override_flag_allows_non_loopback(self, monkeypatch, caplog):
-        monkeypatch.setenv("KLANGK_AUTH_MODES", "none")
         monkeypatch.setenv("KLANGK_LISTEN", "0.0.0.0")
         monkeypatch.setenv("KLANGK_ALLOW_INSECURE_NO_AUTH", "1")
         import logging
 
         with caplog.at_level(logging.WARNING):
-            assert main.enforce_no_auth_bind_safety() is None
+            assert (
+                main.enforce_no_auth_bind_safety(
+                    _bind_safety_app_state(auth_mode="none")
+                )
+                is None
+            )
         assert "non-loopback bind" in caplog.text
 
 
@@ -318,6 +363,7 @@ class TestLifespan:
         app.state.sockets = app_state.sockets
         app.state.settings = app_state.settings
         app.state.nginx_watchdog = main.NginxWatchdog(KlangkSettings(env={}))
+        app.state.oidc = oidc.OIDC(app.state)
         registry = app_state.container_registry
         with (
             patch.object(
@@ -360,6 +406,7 @@ class TestLifespan:
         app.state.sockets = app_state.sockets
         app.state.settings = app_state.settings
         app.state.nginx_watchdog = main.NginxWatchdog(KlangkSettings(env={}))
+        app.state.oidc = oidc.OIDC(app.state)
         registry = app_state.container_registry
         with (
             patch.object(
@@ -577,6 +624,7 @@ class TestStartupShutdownRestart:
         app.state.sockets = app_state.sockets
         app.state.settings = app_state.settings
         app.state.nginx_watchdog = main.NginxWatchdog(KlangkSettings(env={}))
+        app.state.oidc = oidc.OIDC(app.state)
         registry = app_state.container_registry
         loop = asyncio.get_running_loop()
         with (

--- a/src/backend/tests/test_mode_switching.py
+++ b/src/backend/tests/test_mode_switching.py
@@ -6,24 +6,28 @@ steps, then flipping the mode) and asserts the behaviour the
 *Auth Modes* guide promises a real operator. They exist precisely to keep
 the docs honest — if a documented flow stops working, these tests fail.
 
-Mode is read live from the environment on every request
-(``oidc.auth_modes(settings)``), so "restart with a different mode" is simulated by
-re-seeding (the real lifespan step that touches identity) against the *same*
-persistent test database, then changing ``KLANGK_AUTH_MODES`` and continuing
-to hit the same API.
+The auth mode is read from ``app.state.oidc.auth_modes()`` (#1450), which
+derives it from ``settings.auth_modes`` frozen at OIDC construction.  A
+mode switch is therefore simulated by rebuilding the OIDC instance (a
+"restart") after changing ``KLANGK_AUTH_MODES``.
 """
 
 import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
-from klangk_backend import api, auth, main, model
+from klangk_backend import api, auth, main, model, oidc as oidc_mod
+from klangk_backend.settings import KlangkSettings
 from klangk_backend.main import register_exception_handlers
 from klangk_backend.util import API_PREFIX
 
 DEFAULT_EMAIL = "admin@example.com"
 SEEDED_PASSWORD = "seeded-pw"
 NEW_PASSWORD = "rotated-by-admin"
+
+# Stashed by the ``mode_server`` fixture so ``_none`` / ``_password`` can
+# rebuild the OIDC instance after a mode flip (simulates a restart).
+_current_app = None
 
 
 @pytest.fixture
@@ -35,6 +39,7 @@ async def mode_server(db, monkeypatch):
     Returns ``(client, default_user)`` where ``default_user`` is the DB row
     for the seeded default user (so tests know its ``id`` / ``email``).
     """
+    global _current_app
     monkeypatch.setenv("KLANGK_DEFAULT_USER", DEFAULT_EMAIL)
     monkeypatch.setenv("KLANGK_DEFAULT_PASSWORD", SEEDED_PASSWORD)
     # Seed exactly as the lifespan does at startup.
@@ -43,23 +48,39 @@ async def mode_server(db, monkeypatch):
     assert default_user is not None, "seed_default_user must create the user"
 
     app = FastAPI()
+    app.state.settings = KlangkSettings(env={"KLANGK_AUTH_MODES": "none"})
+    app.state.oidc = oidc_mod.OIDC(app.state)
     app.include_router(api.root_router)
     app.include_router(api.router, prefix=API_PREFIX)
     register_exception_handlers(app)
+    _current_app = app
 
     transport = ASGITransport(app=app)
     async with AsyncClient(
         transport=transport, base_url="http://test"
     ) as client:
         yield client, default_user
+    _current_app = None
+
+
+def _set_mode(mode: str):
+    """Rebuild ``app.state.oidc`` with a new auth mode (#1450).
+
+    OIDC reads ``settings.auth_modes`` at construction; after a mode
+    change the instance must be rebuilt so the new mode takes effect
+    (same as a real server restart).
+    """
+    app = _current_app
+    app.state.settings = KlangkSettings(env={"KLANGK_AUTH_MODES": mode})
+    app.state.oidc = oidc_mod.OIDC(app.state)
 
 
 def _none(monkeypatch):
-    monkeypatch.setenv("KLANGK_AUTH_MODES", "none")
+    _set_mode("none")
 
 
 def _password(monkeypatch):
-    monkeypatch.setenv("KLANGK_AUTH_MODES", "password")
+    _set_mode("password")
 
 
 # ---------------------------------------------------------------------------

--- a/src/backend/tests/test_oidc.py
+++ b/src/backend/tests/test_oidc.py
@@ -2,7 +2,8 @@
 
 import os
 import time
-from unittest.mock import AsyncMock, patch
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import yaml
 
@@ -18,16 +19,14 @@ def _settings() -> KlangkSettings:
     return KlangkSettings(os.environ)
 
 
-@pytest.fixture(autouse=True)
-def clean_oidc_state(monkeypatch):
-    """Reset OIDC module state between tests."""
-    monkeypatch.delenv("KLANGK_OIDC_CONFIG", raising=False)
-    monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
-    oidc._providers.clear()
-    oidc.clear_caches()
-    yield
-    oidc._providers.clear()
-    oidc.clear_caches()
+def _oidc(settings: KlangkSettings | None = None) -> oidc.OIDC:
+    """Build a fresh OIDC instance from the live (monkeypatched) env.
+
+    Each call constructs a new instance so test state (providers, caches,
+    login-hook) never leaks between tests (#1450).
+    """
+    app_state = types.SimpleNamespace(settings=settings or _settings())
+    return oidc.OIDC(app_state)
 
 
 def _provider(**overrides):
@@ -52,12 +51,12 @@ class TestGet:
 class TestLoadConfig:
     def test_no_config(self, monkeypatch):
         monkeypatch.delenv("KLANGK_OIDC_CONFIG", raising=False)
-        assert oidc.load_config() == []
+        assert _oidc().load_config() == []
 
     def test_missing_file(self, monkeypatch, tmp_path):
         monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(tmp_path / "nope.json"))
         with pytest.raises(ConfigurationError, match="absolute path"):
-            oidc.load_config()
+            _oidc().load_config()
 
     def test_valid_config(self, monkeypatch, tmp_path):
         cfg = tmp_path / "oidc.yaml"
@@ -75,7 +74,7 @@ class TestLoadConfig:
             )
         )
         monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(cfg))
-        providers = oidc.load_config()
+        providers = _oidc().load_config()
         assert len(providers) == 1
         assert providers[0].id == "test"
         assert providers[0].issuer == "https://idp.example.com"
@@ -99,7 +98,7 @@ class TestLoadConfig:
             )
         )
         monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(cfg))
-        providers = oidc.load_config()
+        providers = _oidc().load_config()
         assert providers[0].client_secret == "file-secret"
 
     def test_ca_cert(self, monkeypatch, tmp_path):
@@ -119,7 +118,7 @@ class TestLoadConfig:
             )
         )
         monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(cfg))
-        providers = oidc.load_config()
+        providers = _oidc().load_config()
         assert providers[0].ca_cert == "/etc/pki/dod-ca.pem"
 
     def test_token_validation_pem(self, monkeypatch, tmp_path):
@@ -140,7 +139,7 @@ class TestLoadConfig:
             )
         )
         monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(cfg))
-        providers = oidc.load_config()
+        providers = _oidc().load_config()
         assert providers[0].token_validation_pem == pem
 
     def test_ca_cert_relative_resolved(self, monkeypatch, tmp_path):
@@ -160,7 +159,7 @@ class TestLoadConfig:
             )
         )
         monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(cfg))
-        providers = oidc.load_config()
+        providers = _oidc().load_config()
         expected = str(tmp_path / "certs" / "ca.pem")
         assert providers[0].ca_cert == expected
 
@@ -180,7 +179,7 @@ class TestLoadConfig:
             )
         )
         monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(cfg))
-        providers = oidc.load_config()
+        providers = _oidc().load_config()
         assert providers[0].ca_cert is None
 
     def test_trust_email(self, monkeypatch, tmp_path):
@@ -200,7 +199,7 @@ class TestLoadConfig:
             )
         )
         monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(cfg))
-        providers = oidc.load_config()
+        providers = _oidc().load_config()
         assert providers[0].trust_email is True
 
     def test_trust_email_defaults_false(self, monkeypatch, tmp_path):
@@ -219,7 +218,7 @@ class TestLoadConfig:
             )
         )
         monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(cfg))
-        providers = oidc.load_config()
+        providers = _oidc().load_config()
         assert providers[0].trust_email is False
 
     def test_multiple_providers(self, monkeypatch, tmp_path):
@@ -245,7 +244,7 @@ class TestLoadConfig:
             )
         )
         monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(cfg))
-        providers = oidc.load_config()
+        providers = _oidc().load_config()
         assert len(providers) == 2
         assert providers[0].id == "a"
         assert providers[1].id == "b"
@@ -270,7 +269,7 @@ class TestLoadConfig:
             )
         )
         monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(cfg))
-        providers = oidc.load_config()
+        providers = _oidc().load_config()
         assert len(providers) == 1
         assert providers[0].display_name == "Legacy"
         assert providers[0].client_id == "klangk"
@@ -293,14 +292,9 @@ class TestInlineProviders:
             "    client-id: klangk\n"
             '    client-secret: "inline-secret"\n'
         )
-        from klangk_backend.settings import KlangkSettings
-
-        monkeypatch.setattr(
-            oidc,
-            "get_settings",
-            lambda: KlangkSettings(env={}, config_file=str(cfg)),
-        )
-        providers = oidc.load_config()
+        monkeypatch.delenv("KLANGK_OIDC_CONFIG", raising=False)
+        settings = KlangkSettings(env=os.environ, config_file=str(cfg))
+        providers = _oidc(settings).load_config()
         assert len(providers) == 1
         assert providers[0].id == "inline"
         assert providers[0].display_name == "Inline IdP"
@@ -310,7 +304,6 @@ class TestInlineProviders:
     def test_external_file_overrides_inline(self, monkeypatch, tmp_path):
         """When both inline and external are configured, external wins
         (env var override, consistent with env > file precedence)."""
-        # External file via env var
         ext = tmp_path / "oidc.yaml"
         ext.write_text(
             yaml.dump(
@@ -327,7 +320,6 @@ class TestInlineProviders:
         )
         monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(ext))
 
-        # Inline in config file
         cfg = tmp_path / "config.yaml"
         cfg.write_text(
             "oidc_providers:\n"
@@ -337,14 +329,8 @@ class TestInlineProviders:
             "    client-id: klangk\n"
             '    client-secret: "inline"\n'
         )
-        from klangk_backend.settings import KlangkSettings
-
-        monkeypatch.setattr(
-            oidc,
-            "get_settings",
-            lambda: KlangkSettings(env={}, config_file=str(cfg)),
-        )
-        providers = oidc.load_config()
+        settings = KlangkSettings(env=os.environ, config_file=str(cfg))
+        providers = _oidc(settings).load_config()
         assert len(providers) == 1
         assert providers[0].id == "external"
 
@@ -361,14 +347,9 @@ class TestInlineProviders:
             "    client-id: klangk\n"
             f'    client-secret: "file:{secret}"\n'
         )
-        from klangk_backend.settings import KlangkSettings
-
-        monkeypatch.setattr(
-            oidc,
-            "get_settings",
-            lambda: KlangkSettings(env={}, config_file=str(cfg)),
-        )
-        providers = oidc.load_config()
+        monkeypatch.delenv("KLANGK_OIDC_CONFIG", raising=False)
+        settings = KlangkSettings(env=os.environ, config_file=str(cfg))
+        providers = _oidc(settings).load_config()
         assert providers[0].client_secret == "resolved-secret"
 
     def test_inline_multiple_providers(self, tmp_path, monkeypatch):
@@ -386,14 +367,9 @@ class TestInlineProviders:
             "    client-id: klangk\n"
             '    client-secret: "sb"\n'
         )
-        from klangk_backend.settings import KlangkSettings
-
-        monkeypatch.setattr(
-            oidc,
-            "get_settings",
-            lambda: KlangkSettings(env={}, config_file=str(cfg)),
-        )
-        providers = oidc.load_config()
+        monkeypatch.delenv("KLANGK_OIDC_CONFIG", raising=False)
+        settings = KlangkSettings(env=os.environ, config_file=str(cfg))
+        providers = _oidc(settings).load_config()
         assert len(providers) == 2
         assert providers[0].id == "a"
         assert providers[1].id == "b"
@@ -417,7 +393,7 @@ class TestInlineProviders:
             )
         )
         monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(ext))
-        providers = oidc.load_config()
+        providers = _oidc().load_config()
         assert len(providers) == 1
         assert providers[0].id == "external"
 
@@ -439,16 +415,18 @@ class TestProviderRegistry:
             )
         )
         monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(cfg))
-        oidc.init_providers()
-        assert oidc.is_enabled()
-        assert oidc.get_provider("test") is not None
-        assert oidc.get_provider("nope") is None
-        providers = oidc.list_providers()
+        o = _oidc()
+        o.init_providers()
+        assert o.is_enabled()
+        assert o.get_provider("test") is not None
+        assert o.get_provider("nope") is None
+        providers = o.list_providers()
         assert providers == [{"id": "test", "display_name": "Test"}]
 
     def test_not_enabled_when_empty(self):
-        assert not oidc.is_enabled()
-        assert oidc.list_providers() == []
+        o = _oidc()
+        assert not o.is_enabled()
+        assert o.list_providers() == []
 
     def test_init_raises_when_oidc_required_but_no_providers(
         self, monkeypatch
@@ -456,7 +434,7 @@ class TestProviderRegistry:
         monkeypatch.delenv("KLANGK_OIDC_CONFIG", raising=False)
         monkeypatch.setenv("KLANGK_AUTH_MODES", "oidc")
         with pytest.raises(ConfigurationError, match="no OIDC providers"):
-            oidc.init_providers()
+            _oidc().init_providers()
 
     def test_init_raises_when_both_required_but_no_providers(
         self, monkeypatch
@@ -464,88 +442,88 @@ class TestProviderRegistry:
         monkeypatch.delenv("KLANGK_OIDC_CONFIG", raising=False)
         monkeypatch.setenv("KLANGK_AUTH_MODES", "both")
         with pytest.raises(ConfigurationError, match="no OIDC providers"):
-            oidc.init_providers()
+            _oidc().init_providers()
 
     def test_init_ok_when_password_only(self, monkeypatch):
         monkeypatch.delenv("KLANGK_OIDC_CONFIG", raising=False)
         monkeypatch.setenv("KLANGK_AUTH_MODES", "password")
-        oidc.init_providers()
-        assert not oidc.is_enabled()
+        o = _oidc()
+        o.init_providers()
+        assert not o.is_enabled()
 
 
 class TestAuthModes:
     def test_default_none_when_no_oidc(self, monkeypatch):
-        # Production default (no OIDC, mode unset) is now ``none`` — a fresh
-        # klangk boots in no-login single-user local-dev mode (#1374).
         monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
-        assert oidc.auth_modes(_settings()) == "none"
-        assert not oidc.password_login_allowed(_settings())
-        assert oidc.local_login_allowed(_settings())
+        o = _oidc()
+        assert o.auth_modes() == "none"
+        assert not o.password_login_allowed()
+        assert o.local_login_allowed()
 
     def test_default_none_when_oidc_enabled(self, monkeypatch):
-        # #1419: OIDC settings no longer change auth_mode. An unset
-        # KLANGK_AUTH_MODES resolves to "none" even when an OIDC provider
-        # is configured — OIDC is opt-in via an explicit
-        # KLANGK_AUTH_MODES=oidc (or "both"). (Earlier versions promoted
-        # the unset default to "both" here; that rule was removed.)
         monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
-        oidc._providers.append(_provider())
-        assert oidc.auth_modes(_settings()) == "none"
-        assert oidc.local_login_allowed(_settings())
-        assert not oidc.password_login_allowed(_settings())
-        assert not oidc.oidc_login_allowed(_settings())
+        o = _oidc()
+        o.providers.append(_provider())
+        assert o.auth_modes() == "none"
+        assert o.local_login_allowed()
+        assert not o.password_login_allowed()
+        assert not o.oidc_login_allowed()
 
     def test_oidc_only(self, monkeypatch):
         monkeypatch.setenv("KLANGK_AUTH_MODES", "oidc")
-        oidc._providers.append(_provider())
-        assert oidc.auth_modes(_settings()) == "oidc"
-        assert not oidc.password_login_allowed(_settings())
-        assert oidc.oidc_login_allowed(_settings())
+        o = _oidc()
+        o.providers.append(_provider())
+        assert o.auth_modes() == "oidc"
+        assert not o.password_login_allowed()
+        assert o.oidc_login_allowed()
 
     def test_password_only(self, monkeypatch):
         monkeypatch.setenv("KLANGK_AUTH_MODES", "password")
-        oidc._providers.append(_provider())
-        assert oidc.auth_modes(_settings()) == "password"
-        assert oidc.password_login_allowed(_settings())
-        assert not oidc.oidc_login_allowed(_settings())
+        o = _oidc()
+        o.providers.append(_provider())
+        assert o.auth_modes() == "password"
+        assert o.password_login_allowed()
+        assert not o.oidc_login_allowed()
 
     def test_none_mode(self, monkeypatch):
         monkeypatch.setenv("KLANGK_AUTH_MODES", "none")
-        assert oidc.auth_modes(_settings()) == "none"
-        assert not oidc.password_login_allowed(_settings())
-        assert not oidc.oidc_login_allowed(_settings())
-        assert oidc.local_login_allowed(_settings())
+        o = _oidc()
+        assert o.auth_modes() == "none"
+        assert not o.password_login_allowed()
+        assert not o.oidc_login_allowed()
+        assert o.local_login_allowed()
 
     def test_none_mode_ignores_oidc_config(self, monkeypatch):
-        # OIDC config may be present but is irrelevant in none mode.
-        oidc._providers.append(_provider())
+        o = _oidc()
+        o.providers.append(_provider())
         monkeypatch.setenv("KLANGK_AUTH_MODES", "none")
-        assert oidc.auth_modes(_settings()) == "none"
-        assert oidc.local_login_allowed(_settings())
+        # Rebuild so settings reflects the mode change
+        o = _oidc()
+        o.providers.append(_provider())
+        assert o.auth_modes() == "none"
+        assert o.local_login_allowed()
 
     def test_local_login_false_in_other_modes(self, monkeypatch):
         for mode in ("password", "oidc", "both"):
             monkeypatch.setenv("KLANGK_AUTH_MODES", mode)
-            assert not oidc.local_login_allowed(_settings())
+            o = _oidc()
+            assert not o.local_login_allowed()
 
     # --- AUTH_MODES unset defaults to ``none`` (no amalgamated setting) ---
-    # #1422 removed KLANGK_PRESET/KLANGK_UI_MODE — AUTH_MODES is the sole
-    # authority on auth, and its unset default is ``none`` unconditionally
-    # (OIDC settings don't promote it, per #1419; no preset defaults it).
 
     def test_unset_defaults_to_none(self, monkeypatch):
         monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
-        assert oidc.auth_modes(_settings()) == "none"
-        assert oidc.local_login_allowed(_settings())
-        assert not oidc.password_login_allowed(_settings())
+        o = _oidc()
+        assert o.auth_modes() == "none"
+        assert o.local_login_allowed()
+        assert not o.password_login_allowed()
 
     def test_unset_stays_none_with_oidc_configured(self, monkeypatch):
-        # OIDC presence never flips the mode (#1419) — operator must set
-        # KLANGK_AUTH_MODES=oidc/both explicitly.
         monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
-        assert oidc.auth_modes(_settings()) == "none"
-        oidc._providers.append(_provider())
-        assert oidc.auth_modes(_settings()) == "none"
+        o = _oidc()
+        assert o.auth_modes() == "none"
+        o.providers.append(_provider())
+        assert o.auth_modes() == "none"
 
 
 class TestClientKwargs:
@@ -587,7 +565,6 @@ def _mock_httpx_client(get_response=None, post_response=None):
         client.get.return_value = get_response
     if post_response:
         client.post.return_value = post_response
-    # httpx.AsyncClient.__aenter__ returns self
     client.__aenter__ = AsyncMock(return_value=client)
     client.__aexit__ = AsyncMock(return_value=False)
     return client
@@ -595,8 +572,6 @@ def _mock_httpx_client(get_response=None, post_response=None):
 
 def _mock_response(data):
     """Create a mock httpx response with sync .json() and .raise_for_status()."""
-    from unittest.mock import MagicMock
-
     resp = MagicMock()
     resp.json.return_value = data
     resp.raise_for_status = MagicMock()
@@ -614,12 +589,13 @@ class TestDiscovery:
         mock_resp = _mock_response(disc_data)
         client_instance = _mock_httpx_client(get_response=mock_resp)
 
+        o = _oidc()
         with patch("httpx.AsyncClient", return_value=client_instance):
-            result1 = await oidc.discover(provider)
+            result1 = await o.discover(provider)
             assert result1 == disc_data
 
             # Second call should use cache
-            result2 = await oidc.discover(provider)
+            result2 = await o.discover(provider)
             assert result2 == disc_data
             # Only one HTTP call
             assert client_instance.get.call_count == 1
@@ -630,26 +606,28 @@ class TestDiscovery:
         mock_resp = _mock_response(disc_data)
         client_instance = _mock_httpx_client(get_response=mock_resp)
 
+        o = _oidc()
         with patch("httpx.AsyncClient", return_value=client_instance):
-            await oidc.discover(provider)
+            await o.discover(provider)
             # Expire the cache
-            oidc._discovery_cache[provider.id].fetched_at = (
+            o.discovery_cache[provider.id].fetched_at = (
                 time.time() - oidc._DISCOVERY_TTL - 1
             )
-            await oidc.discover(provider)
+            await o.discover(provider)
             assert client_instance.get.call_count == 2
 
 
 class TestBuildAuthUrl:
     async def test_build_auth_url(self):
         provider = _provider()
-        oidc._discovery_cache[provider.id] = oidc.CachedDiscovery(
+        o = _oidc()
+        o.discovery_cache[provider.id] = oidc.CachedDiscovery(
             data={
                 "authorization_endpoint": "https://idp.example.com/auth",
             },
             fetched_at=time.time(),
         )
-        url = await oidc.build_auth_url(
+        url = await o.build_auth_url(
             provider,
             "https://klangk.example.com/callback",
             "state123",
@@ -665,7 +643,8 @@ class TestBuildAuthUrl:
 class TestExchangeCode:
     async def test_exchange_code(self):
         provider = _provider()
-        oidc._discovery_cache[provider.id] = oidc.CachedDiscovery(
+        o = _oidc()
+        o.discovery_cache[provider.id] = oidc.CachedDiscovery(
             data={"token_endpoint": "https://idp.example.com/token"},
             fetched_at=time.time(),
         )
@@ -674,7 +653,7 @@ class TestExchangeCode:
         client_instance = _mock_httpx_client(post_response=mock_resp)
 
         with patch("httpx.AsyncClient", return_value=client_instance):
-            result = await oidc.exchange_code(
+            result = await o.exchange_code(
                 provider, "code123", "https://cb", "verifier"
             )
             assert result == token_resp
@@ -687,8 +666,8 @@ class TestExchangeCode:
 class TestGetJWKS:
     async def test_get_jwks_caches(self):
         provider = _provider()
-        # Pre-populate discovery cache
-        oidc._discovery_cache[provider.id] = oidc.CachedDiscovery(
+        o = _oidc()
+        o.discovery_cache[provider.id] = oidc.CachedDiscovery(
             data={"jwks_uri": "https://idp.example.com/jwks"},
             fetched_at=time.time(),
         )
@@ -697,15 +676,16 @@ class TestGetJWKS:
         client_instance = _mock_httpx_client(get_response=mock_resp)
 
         with patch("httpx.AsyncClient", return_value=client_instance):
-            result1 = await oidc.get_jwks(provider)
+            result1 = await o.get_jwks(provider)
             assert result1 == jwks_data
-            result2 = await oidc.get_jwks(provider)
+            result2 = await o.get_jwks(provider)
             assert result2 == jwks_data
             assert client_instance.get.call_count == 1
 
     async def test_get_jwks_cache_expires(self):
         provider = _provider()
-        oidc._discovery_cache[provider.id] = oidc.CachedDiscovery(
+        o = _oidc()
+        o.discovery_cache[provider.id] = oidc.CachedDiscovery(
             data={"jwks_uri": "https://idp.example.com/jwks"},
             fetched_at=time.time(),
         )
@@ -714,23 +694,22 @@ class TestGetJWKS:
         client_instance = _mock_httpx_client(get_response=mock_resp)
 
         with patch("httpx.AsyncClient", return_value=client_instance):
-            await oidc.get_jwks(provider)
-            oidc._jwks_cache[provider.id].fetched_at = (
+            await o.get_jwks(provider)
+            o.jwks_cache[provider.id].fetched_at = (
                 time.time() - oidc._JWKS_TTL - 1
             )
-            await oidc.get_jwks(provider)
+            await o.get_jwks(provider)
             assert client_instance.get.call_count == 2
 
 
 class TestValidateIdToken:
     async def test_validate_id_token_with_jwks(self):
-        from unittest.mock import MagicMock
-
         provider = _provider()
         claims = {"sub": "user1", "email": "user@example.com"}
+        o = _oidc()
         with (
             patch.object(
-                oidc, "get_jwks", AsyncMock(return_value={"keys": []})
+                o, "get_jwks", AsyncMock(return_value={"keys": []})
             ) as mock_jwks,
             patch.object(
                 oidc.jose_jwt,
@@ -738,7 +717,7 @@ class TestValidateIdToken:
                 MagicMock(return_value=claims),
             ) as mock_decode,
         ):
-            result = await oidc.validate_id_token(
+            result = await o.validate_id_token(
                 provider, "fake-token", access_token="fake-at"
             )
             assert result == claims
@@ -753,20 +732,19 @@ class TestValidateIdToken:
             )
 
     async def test_validate_id_token_with_static_pem(self):
-        from unittest.mock import MagicMock
-
         pem = "-----BEGIN PUBLIC KEY-----\nMIIBI...\n-----END PUBLIC KEY-----"
         provider = _provider(token_validation_pem=pem)
         claims = {"sub": "user1", "email": "user@example.com"}
+        o = _oidc()
         with (
-            patch.object(oidc, "get_jwks", AsyncMock()) as mock_jwks,
+            patch.object(o, "get_jwks", AsyncMock()) as mock_jwks,
             patch.object(
                 oidc.jose_jwt,
                 "decode",
                 MagicMock(return_value=claims),
             ) as mock_decode,
         ):
-            result = await oidc.validate_id_token(provider, "fake-token")
+            result = await o.validate_id_token(provider, "fake-token")
             assert result == claims
             mock_jwks.assert_not_awaited()
             mock_decode.assert_called_once_with(
@@ -782,27 +760,31 @@ class TestValidateIdToken:
 class TestBuildLogoutUrl:
     async def test_disabled(self):
         provider = _provider(logout_redirect=False)
-        result = await oidc.build_logout_url(provider, "https://klangk/login")
+        result = await _oidc().build_logout_url(
+            provider, "https://klangk/login"
+        )
         assert result is None
 
     async def test_no_end_session_endpoint(self):
         provider = _provider(logout_redirect=True)
-        oidc._discovery_cache[provider.id] = oidc.CachedDiscovery(
+        o = _oidc()
+        o.discovery_cache[provider.id] = oidc.CachedDiscovery(
             data={"authorization_endpoint": "https://idp/auth"},
             fetched_at=time.time(),
         )
-        result = await oidc.build_logout_url(provider, "https://klangk/login")
+        result = await o.build_logout_url(provider, "https://klangk/login")
         assert result is None
 
     async def test_builds_url(self):
         provider = _provider(logout_redirect=True)
-        oidc._discovery_cache[provider.id] = oidc.CachedDiscovery(
+        o = _oidc()
+        o.discovery_cache[provider.id] = oidc.CachedDiscovery(
             data={
                 "end_session_endpoint": "https://idp.example.com/logout",
             },
             fetched_at=time.time(),
         )
-        result = await oidc.build_logout_url(
+        result = await o.build_logout_url(
             provider, "https://klangk.example.com/#/login"
         )
         assert result is not None
@@ -831,8 +813,9 @@ class TestParseHookValue:
 class TestLoadLoginHook:
     def test_no_hook_when_not_set(self, monkeypatch):
         monkeypatch.delenv("KLANGK_OIDC_LOGIN_HOOK", raising=False)
-        oidc.load_login_hook()
-        assert oidc._login_hook is None
+        o = _oidc()
+        o.load_login_hook()
+        assert o.login_hook is None
 
     def test_hook_loaded_from_file(self, monkeypatch, tmp_path):
         hook_file = tmp_path / "myhook.py"
@@ -841,9 +824,10 @@ class TestLoadLoginHook:
             "    return {'testers'}\n"
         )
         monkeypatch.setenv("KLANGK_OIDC_LOGIN_HOOK", str(hook_file))
-        oidc.load_login_hook()
-        assert oidc._login_hook is not None
-        assert oidc._login_hook(None, {}, "", {}) == {"testers"}
+        o = _oidc()
+        o.load_login_hook()
+        assert o.login_hook is not None
+        assert o.login_hook(None, {}, "", {}) == {"testers"}
 
     def test_hook_loaded_with_custom_func_name(self, monkeypatch, tmp_path):
         hook_file = tmp_path / "myhook.py"
@@ -852,9 +836,10 @@ class TestLoadLoginHook:
             "    return {'admins'}\n"
         )
         monkeypatch.setenv("KLANGK_OIDC_LOGIN_HOOK", f"{hook_file}:check")
-        oidc.load_login_hook()
-        assert oidc._login_hook is not None
-        assert oidc._login_hook(None, {}, "", {}) == {"admins"}
+        o = _oidc()
+        o.load_login_hook()
+        assert o.login_hook is not None
+        assert o.login_hook(None, {}, "", {}) == {"admins"}
 
     def test_async_hook_detected(self, monkeypatch, tmp_path):
         hook_file = tmp_path / "myhook.py"
@@ -863,13 +848,14 @@ class TestLoadLoginHook:
             "    return None\n"
         )
         monkeypatch.setenv("KLANGK_OIDC_LOGIN_HOOK", str(hook_file))
-        oidc.load_login_hook()
-        assert oidc._login_hook_is_async is True
+        o = _oidc()
+        o.load_login_hook()
+        assert o.login_hook_is_async is True
 
     def test_file_not_found(self, monkeypatch):
         monkeypatch.setenv("KLANGK_OIDC_LOGIN_HOOK", "/nonexistent/hook.py")
         with pytest.raises(ConfigurationError, match="file not found"):
-            oidc.load_login_hook()
+            _oidc().load_login_hook()
 
     def test_func_not_found(self, monkeypatch, tmp_path):
         hook_file = tmp_path / "myhook.py"
@@ -878,7 +864,7 @@ class TestLoadLoginHook:
         with pytest.raises(
             ConfigurationError, match="not found or not callable"
         ):
-            oidc.load_login_hook()
+            _oidc().load_login_hook()
 
     def test_not_callable(self, monkeypatch, tmp_path):
         hook_file = tmp_path / "myhook.py"
@@ -887,67 +873,64 @@ class TestLoadLoginHook:
         with pytest.raises(
             ConfigurationError, match="not found or not callable"
         ):
-            oidc.load_login_hook()
+            _oidc().load_login_hook()
 
 
 class TestCallLoginHook:
     async def test_no_hook_returns_none(self):
-        oidc._login_hook = None
-        result = await oidc.call_login_hook(
-            _provider(), {}, "x@example.com", {}
-        )
+        o = _oidc()
+        result = await o.call_login_hook(_provider(), {}, "x@example.com", {})
         assert result is None
 
     async def test_hook_returns_groups(self):
         def hook(provider, claims, email, tokens):
             return {"admin", "devs"}
 
-        oidc._login_hook = hook
-        oidc._login_hook_is_async = False
-        result = await oidc.call_login_hook(
-            _provider(), {}, "x@example.com", {}
-        )
+        o = _oidc()
+        o.login_hook = hook
+        o.login_hook_is_async = False
+        result = await o.call_login_hook(_provider(), {}, "x@example.com", {})
         assert result == {"admin", "devs"}
 
     async def test_hook_returns_none(self):
         def hook(provider, claims, email, tokens):
             return None
 
-        oidc._login_hook = hook
-        oidc._login_hook_is_async = False
-        result = await oidc.call_login_hook(
-            _provider(), {}, "x@example.com", {}
-        )
+        o = _oidc()
+        o.login_hook = hook
+        o.login_hook_is_async = False
+        result = await o.call_login_hook(_provider(), {}, "x@example.com", {})
         assert result is None
 
     async def test_async_hook_returns_groups(self):
         async def hook(provider, claims, email, tokens):
             return {"editors"}
 
-        oidc._login_hook = hook
-        oidc._login_hook_is_async = True
-        result = await oidc.call_login_hook(
-            _provider(), {}, "x@example.com", {}
-        )
+        o = _oidc()
+        o.login_hook = hook
+        o.login_hook_is_async = True
+        result = await o.call_login_hook(_provider(), {}, "x@example.com", {})
         assert result == {"editors"}
 
     async def test_hook_raises_rejects_login(self):
         def hook(provider, claims, email, tokens):
             raise ValueError("denied")
 
-        oidc._login_hook = hook
-        oidc._login_hook_is_async = False
+        o = _oidc()
+        o.login_hook = hook
+        o.login_hook_is_async = False
         with pytest.raises(ValueError, match="denied"):
-            await oidc.call_login_hook(_provider(), {}, "x@example.com", {})
+            await o.call_login_hook(_provider(), {}, "x@example.com", {})
 
     async def test_async_hook_raises_rejects_login(self):
         async def hook(provider, claims, email, tokens):
             raise ValueError("async denied")
 
-        oidc._login_hook = hook
-        oidc._login_hook_is_async = True
+        o = _oidc()
+        o.login_hook = hook
+        o.login_hook_is_async = True
         with pytest.raises(ValueError, match="async denied"):
-            await oidc.call_login_hook(_provider(), {}, "x@example.com", {})
+            await o.call_login_hook(_provider(), {}, "x@example.com", {})
 
 
 class TestSyncOidcGroups:


### PR DESCRIPTION
Closes #1450. Part of #1426 (composition-root refactor), Slice 3.

## What

`oidc.py` had three module-level mutable globals (`_providers`, `_discovery_cache`, `_jwks_cache`) plus `_login_hook`/`_login_hook_is_async`, and three functions that reached config two different ways — `get_settings()` (the global accessor) and `resolve_env_value`. All of it is OIDC-owned state and config.

Promoted to an `OIDC` class on `app.state.oidc`, matching the uniform constructor pattern (`Terminal` #1480, `NginxWatchdog` #1463, etc.): `__init__` takes only `app_state`, derives `self.settings`. The provider list, caches, and hook state are instance attrs (no under-prefix: `self.providers`, `self.discovery_cache`, `self.jwks_cache`, `self.login_hook`).

## Changes

**Production:**
- **`oidc.py`** — `OIDC` class owns `load_config`, `init_providers`, `get_provider`, `list_providers`, `is_enabled`, `auth_modes`, `password`/`local`/`oidc_login_allowed`, `discover`, `get_jwks`, `build_auth_url`, `exchange_code`, `validate_id_token`, `build_logout_url`, `load_login_hook`, `call_login_hook`. Config reads from `self.settings.oidc_config` / `.oidc_login_hook` / `.oidc_providers` (typed settings, not `resolve_env_value` / `get_settings`). Pure helpers (`get`, `_parse_providers`, `_parse_hook_value`, `generate_pkce`, `client_kwargs`, `sync_oidc_groups`) stay module-level. `clear_caches` removed (each test gets a fresh instance).
- **`main.py`** — `app.state.oidc = OIDC(app.state)` in `build_app`; lifespan calls `app.state.oidc.init_providers()` / `.load_login_hook()`; `enforce_no_auth_bind_safety(app_state)` reads `app_state.oidc.auth_modes()`.
- **API routes** reach oidc via `request.app.state.oidc` (no `get_settings`). `_exchange_and_validate_token` takes `oidc_inst`.
- Dropped unused `get_settings` imports from API modules.

**Tests:** fresh `OIDC` instances per test (no module-global state); `monkeypatch` on `app.state.oidc` methods instead of patching the module; explicit env in `KlangkSettings` (no `os.environ` reads). 100% coverage maintained.

## Verification

All three suites green locally:
- Backend unit: **2373 passed, 100% coverage**
- Backend e2e: **95 passed**
- CLI e2e: **62 passed, 1 skipped**
