### PR TITLE
Promote plugins.py to a Plugins(app_state) instance (#1451)

### DIFF
--- a/src/backend/klangk_backend/api/__init__.py
+++ b/src/backend/klangk_backend/api/__init__.py
@@ -43,7 +43,6 @@ from .. import (
     emailsvc,
     model,
     oidc,
-    plugins,
     wshandler,
 )
 from ._common import get_app_state_dep
@@ -102,19 +101,19 @@ async def empty():
 
 
 @router.get("/version")
-async def version():
+async def version(app_state=Depends(get_app_state_dep)):
     """Return build version info, plus loaded plugin metadata."""
     if version_file := resolve_env_value("KLANGK_VERSION_FILE", ""):
         if os.path.isfile(version_file):
             with open(version_file) as f:
                 info = json.load(f)
-            info["plugins"] = plugins.plugin_list()
+            info["plugins"] = app_state.plugins.plugin_list()
             return info
     return {
         "version": "dev",
         "commit": "unknown",
         "built_at": None,
-        "plugins": plugins.plugin_list(),
+        "plugins": app_state.plugins.plugin_list(),
     }
 
 
@@ -235,7 +234,7 @@ async def get_config(app_state=Depends(get_app_state_dep)):
         "support_url": SUPPORT_URL,
         "support_email": SUPPORT_EMAIL,
     }
-    config.update(plugins.frontend_config())
+    config.update(app_state.plugins.frontend_config())
     return config
 
 

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -5,7 +5,7 @@ import logging
 import os
 import time
 
-from . import auth, bringup, model, plugins, podman, util
+from . import auth, bringup, model, podman, util
 from .podman import PodmanError
 from .settings import KlangkSettings
 
@@ -1245,7 +1245,7 @@ class ContainerRegistry:
         # ever needed. Emitted only when a trustable cert dir is present.
         env_vars.extend(ssl_env_vars(ssl_dir))
 
-        for k, v in plugins.container_env().items():
+        for k, v in self.app_state.plugins.container_env().items():
             env_vars.append(f"{k}={v}")
 
         if extra_env:

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -576,7 +576,7 @@ async def lifespan(app: FastAPI):
     setup_logfire(app)
 
     auth.require_secure_jwt_secret()
-    plugins.load()
+    app.state.plugins.load()
     app.state.oidc.init_providers()
     enforce_no_auth_bind_safety(app.state)
     app.state.oidc.load_login_hook()
@@ -765,6 +765,10 @@ def build_app(settings: KlangkSettings) -> FastAPI:
     # caches, and login-hook state (previously module globals). Reaches
     # config through self.settings.
     app.state.oidc = oidc.OIDC(app.state)
+    # #1451: Plugins(app_state) owns the plugins dir (computed from
+    # settings, not frozen at import), declarations, and resolved values
+    # (previously module globals).
+    app.state.plugins = plugins.Plugins(app.state)
     # WebSocketState reaches the registry through its own app_state
     # back-reference (send_service_health_snapshot / reset_workspace).
     # The unit-test fixtures set this explicitly; build_app must too, or

--- a/src/backend/klangk_backend/plugins.py
+++ b/src/backend/klangk_backend/plugins.py
@@ -9,117 +9,131 @@ import json
 import logging
 import os
 
-from .util import resolve_env_value
+from .settings import resolve_env_value
 
 logger = logging.getLogger(__name__)
 
-_PLUGINS_DIR = resolve_env_value("KLANGK_PLUGINS_DIR") or os.path.join(
-    os.path.expanduser("~"), ".klangk", "plugins"
-)
-
 VALID_SCOPES = {"container", "frontend", "both"}
 
-# Loaded at startup: {env_key: {plugin, description, default, scope}}
-_declarations: dict[str, dict] = {}
 
-# Resolved values: {env_key: str}
-_values: dict[str, str] = {}
+class Plugins:
+    """Plugin config scanner: loads declared keys and resolved values.
 
+    Constructed once in :func:`build_app` and stored on
+    ``app.state.plugins`` (#1451). The plugins dir is computed at
+    construction from ``self.settings.plugins_dir`` — no import-time env
+    read (#1450's frozen-at-import hazard). Declarations and values are
+    instance attrs (no mutable module globals).
 
-def load() -> None:
-    """Scan plugin package.json files and resolve config values from env."""
-    global _declarations, _values  # noqa: PLW0603
-    _declarations = {}
-    _values = {}
-
-    if not os.path.isdir(_PLUGINS_DIR):
-        return
-
-    for name in sorted(os.listdir(_PLUGINS_DIR)):
-        pkg_json = os.path.join(_PLUGINS_DIR, name, "package.json")
-        if not os.path.isfile(pkg_json):
-            continue
-
-        try:
-            with open(pkg_json) as f:
-                manifest = json.load(f)
-        except (json.JSONDecodeError, ValueError, OSError):
-            continue
-
-        config = manifest.get("klangk", {}).get("config", {})
-        if not isinstance(config, dict):
-            continue
-
-        for key, spec in config.items():
-            if not isinstance(spec, dict):
-                continue
-            scope = spec.get("scope", "container")
-            if scope not in VALID_SCOPES:
-                scope = "container"
-            _declarations[key] = {
-                "plugin": name,
-                "description": spec.get("description", ""),
-                "default": spec.get("default", ""),
-                "scope": scope,
-            }
-
-    for key, spec in _declarations.items():
-        default = spec.get("default", "")
-        # resolve_env_value (not raw os.environ) so plugin-declared keys
-        # also honor the file:/cmd: prefixes — plugin config may itself be
-        # a secret (e.g. an API token declared by a plugin).
-        _values[key] = resolve_env_value(key, default) or ""
-
-    if _declarations:
-        logger.info(
-            "Loaded %d plugin config key(s): %s",
-            len(_declarations),
-            ", ".join(sorted(_declarations)),
-        )
-
-
-def plugin_list() -> list[dict[str, str]]:
-    """Return metadata for each loaded plugin (name, version, description)."""
-    if not os.path.isdir(_PLUGINS_DIR):
-        return []
-    plugins = []
-    for name in sorted(os.listdir(_PLUGINS_DIR)):
-        pkg_json = os.path.join(_PLUGINS_DIR, name, "package.json")
-        if not os.path.isfile(pkg_json):
-            continue
-        try:
-            with open(pkg_json) as f:
-                manifest = json.load(f)
-        except (json.JSONDecodeError, ValueError, OSError):
-            continue
-        plugins.append(
-            {
-                "name": name,
-                "version": manifest.get("version", ""),
-                "description": manifest.get("description", ""),
-            }
-        )
-    return plugins
-
-
-def container_env() -> dict[str, str]:
-    """Return env vars to inject into workspace containers."""
-    result = {}
-    for key, spec in _declarations.items():
-        scope = spec.get("scope", "container")
-        if scope in ("container", "both"):
-            result[key] = _values.get(key, "")
-    return result
-
-
-def frontend_config() -> dict[str, str]:
-    """Return config entries for the GET /api/config response.
-
-    Keys are lowercased for JSON convention (e.g. SOLIPLEX_URL → soliplex_url).
+    Plugin-declared config keys (discovered at ``load()`` time from
+    ``package.json``) are dynamic — they're not settings fields — so
+    their values are still resolved via :func:`resolve_env_value` at
+    load time (honoring ``file:``/``cmd:`` prefixes for plugin secrets).
     """
-    result = {}
-    for key, spec in _declarations.items():
-        scope = spec.get("scope", "container")
-        if scope in ("frontend", "both"):
-            result[key.lower()] = _values.get(key, "")
-    return result
+
+    def __init__(self, app_state=None):
+        self.app_state = app_state
+        self.settings = app_state.settings
+        self.plugins_dir = self.settings.plugins_dir or os.path.join(
+            os.path.expanduser("~"), ".klangk", "plugins"
+        )
+        # Loaded at startup: {env_key: {plugin, description, default, scope}}
+        self.declarations: dict[str, dict] = {}
+        # Resolved values: {env_key: str}
+        self.values: dict[str, str] = {}
+
+    def load(self) -> None:
+        """Scan plugin package.json files and resolve config values."""
+        self.declarations = {}
+        self.values = {}
+
+        if not os.path.isdir(self.plugins_dir):
+            return
+
+        for name in sorted(os.listdir(self.plugins_dir)):
+            pkg_json = os.path.join(self.plugins_dir, name, "package.json")
+            if not os.path.isfile(pkg_json):
+                continue
+
+            try:
+                with open(pkg_json) as f:
+                    manifest = json.load(f)
+            except (json.JSONDecodeError, ValueError, OSError):
+                continue
+
+            config = manifest.get("klangk", {}).get("config", {})
+            if not isinstance(config, dict):
+                continue
+
+            for key, spec in config.items():
+                if not isinstance(spec, dict):
+                    continue
+                scope = spec.get("scope", "container")
+                if scope not in VALID_SCOPES:
+                    scope = "container"
+                self.declarations[key] = {
+                    "plugin": name,
+                    "description": spec.get("description", ""),
+                    "default": spec.get("default", ""),
+                    "scope": scope,
+                }
+
+        for key, spec in self.declarations.items():
+            default = spec.get("default", "")
+            # resolve_env_value (not raw os.environ) so plugin-declared keys
+            # also honor the file:/cmd: prefixes — plugin config may itself be
+            # a secret (e.g. an API token declared by a plugin). These keys
+            # are dynamic (discovered from package.json), not settings fields,
+            # so they can't be migrated to typed settings.
+            self.values[key] = resolve_env_value(key, default) or ""
+
+        if self.declarations:
+            logger.info(
+                "Loaded %d plugin config key(s): %s",
+                len(self.declarations),
+                ", ".join(sorted(self.declarations)),
+            )
+
+    def plugin_list(self) -> list[dict[str, str]]:
+        """Return metadata for each loaded plugin (name, version, description)."""
+        if not os.path.isdir(self.plugins_dir):
+            return []
+        plugins = []
+        for name in sorted(os.listdir(self.plugins_dir)):
+            pkg_json = os.path.join(self.plugins_dir, name, "package.json")
+            if not os.path.isfile(pkg_json):
+                continue
+            try:
+                with open(pkg_json) as f:
+                    manifest = json.load(f)
+            except (json.JSONDecodeError, ValueError, OSError):
+                continue
+            plugins.append(
+                {
+                    "name": name,
+                    "version": manifest.get("version", ""),
+                    "description": manifest.get("description", ""),
+                }
+            )
+        return plugins
+
+    def container_env(self) -> dict[str, str]:
+        """Return env vars to inject into workspace containers."""
+        result = {}
+        for key, spec in self.declarations.items():
+            scope = spec.get("scope", "container")
+            if scope in ("container", "both"):
+                result[key] = self.values.get(key, "")
+        return result
+
+    def frontend_config(self) -> dict[str, str]:
+        """Return config entries for the GET /api/config response.
+
+        Keys are lowercased for JSON convention (e.g. SOLIPLEX_URL → soliplex_url).
+        """
+        result = {}
+        for key, spec in self.declarations.items():
+            scope = spec.get("scope", "container")
+            if scope in ("frontend", "both"):
+                result[key.lower()] = self.values.get(key, "")
+        return result

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -18,13 +18,13 @@ from klangk_backend import (
     auth,
     container,
     model,
-    plugins,
     podman,
     workspaces as ws_mod,
     wshandler,
 )
 from klangk_backend.container import ContainerRegistry
 from klangk_backend import oidc as oidc_mod
+from klangk_backend import plugins as plugins_mod
 from klangk_backend.settings import KlangkSettings
 from klangk_backend.wshandler.session import WebSocketState
 
@@ -52,6 +52,7 @@ async def app(db):
     app.state.podman = _mock_pod
     registry.podman = _mock_pod
     app.state.oidc = oidc_mod.OIDC(app.state)
+    app.state.plugins = plugins_mod.Plugins(app.state)
     agent.get_workspace_session = sockets.get_session
 
     app.include_router(api.root_router)
@@ -276,8 +277,16 @@ class TestVersion:
             '{"name": "myplugin", "version": "1.2.3",'
             ' "description": "A test plugin"}'
         )
-        monkeypatch.setattr(
-            "klangk_backend.plugins._PLUGINS_DIR", str(tmp_path / "plugins")
+        # Rebuild the Plugins instance pointing at the tmp plugin dir
+        from klangk_backend.settings import KlangkSettings
+        import types as types_mod
+
+        app.state.plugins = app.state.plugins.__class__(
+            types_mod.SimpleNamespace(
+                settings=KlangkSettings(
+                    env={"KLANGK_PLUGINS_DIR": str(tmp_path / "plugins")}
+                )
+            )
         )
         resp = await client.get("/api/v1/version")
         assert resp.status_code == 200
@@ -337,10 +346,10 @@ class TestConfig:
         assert "login_banner" in data
         assert "instance_id" in data
 
-    async def test_get_config_includes_plugins(self, client, monkeypatch):
+    async def test_get_config_includes_plugins(self, client, app, monkeypatch):
         monkeypatch.setattr(
-            plugins,
-            "_declarations",
+            app.state.plugins,
+            "declarations",
             {
                 "MY_PLUGIN_VAR": {
                     "plugin": "test",
@@ -351,7 +360,7 @@ class TestConfig:
             },
         )
         monkeypatch.setattr(
-            plugins, "_values", {"MY_PLUGIN_VAR": "test-value"}
+            app.state.plugins, "values", {"MY_PLUGIN_VAR": "test-value"}
         )
         resp = await client.get("/api/v1/config")
         assert resp.status_code == 200

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from klangk_backend import bringup, container, model, plugins, podman
+from klangk_backend import bringup, container, model, podman
 
 
 def _make_app_state(registry=None, sockets=None):
@@ -40,8 +40,10 @@ def _make_app_state(registry=None, sockets=None):
         app_state.podman = registry.podman
     # #1480: container.py reaches set_workspace_token via app_state.terminal.
     from klangk_backend.terminal import Terminal
+    from klangk_backend import plugins as plugins_mod
 
     app_state.terminal = Terminal(app_state)
+    app_state.plugins = plugins_mod.Plugins(app_state)
     return app_state
 
 
@@ -997,8 +999,8 @@ class TestStartContainer:
 
     async def test_plugins_env_injected(self, workspace, monkeypatch):
         monkeypatch.setattr(
-            plugins,
-            "_declarations",
+            self.registry.app_state.plugins,
+            "declarations",
             {
                 "PLUGIN_VAR": {
                     "plugin": "test",
@@ -1008,7 +1010,11 @@ class TestStartContainer:
                 }
             },
         )
-        monkeypatch.setattr(plugins, "_values", {"PLUGIN_VAR": "plugin-val"})
+        monkeypatch.setattr(
+            self.registry.app_state.plugins,
+            "values",
+            {"PLUGIN_VAR": "plugin-val"},
+        )
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"

--- a/src/backend/tests/test_main.py
+++ b/src/backend/tests/test_main.py
@@ -13,7 +13,7 @@ from fastapi import FastAPI
 from httpx import AsyncClient, ASGITransport
 from sqlalchemy.exc import IntegrityError as SAIntegrityError
 
-from klangk_backend import main, model, oidc
+from klangk_backend import main, model, oidc, plugins
 from klangk_backend.container import ContainerRegistry
 from klangk_backend.settings import KlangkSettings
 from klangk_backend.wshandler.session import WebSocketState
@@ -104,6 +104,7 @@ def _bind_safety_app_state(auth_mode=None):
     settings = KlangkSettings(env=env)
     app_state = types.SimpleNamespace(settings=settings)
     app_state.oidc = oidc.OIDC(app_state)
+    app_state.plugins = plugins.Plugins(app_state)
     return app_state
 
 
@@ -364,6 +365,7 @@ class TestLifespan:
         app.state.settings = app_state.settings
         app.state.nginx_watchdog = main.NginxWatchdog(KlangkSettings(env={}))
         app.state.oidc = oidc.OIDC(app.state)
+        app.state.plugins = plugins.Plugins(app.state)
         registry = app_state.container_registry
         with (
             patch.object(
@@ -407,6 +409,7 @@ class TestLifespan:
         app.state.settings = app_state.settings
         app.state.nginx_watchdog = main.NginxWatchdog(KlangkSettings(env={}))
         app.state.oidc = oidc.OIDC(app.state)
+        app.state.plugins = plugins.Plugins(app.state)
         registry = app_state.container_registry
         with (
             patch.object(
@@ -625,6 +628,7 @@ class TestStartupShutdownRestart:
         app.state.settings = app_state.settings
         app.state.nginx_watchdog = main.NginxWatchdog(KlangkSettings(env={}))
         app.state.oidc = oidc.OIDC(app.state)
+        app.state.plugins = plugins.Plugins(app.state)
         registry = app_state.container_registry
         loop = asyncio.get_running_loop()
         with (

--- a/src/backend/tests/test_mode_switching.py
+++ b/src/backend/tests/test_mode_switching.py
@@ -16,7 +16,14 @@ import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
-from klangk_backend import api, auth, main, model, oidc as oidc_mod
+from klangk_backend import (
+    api,
+    auth,
+    main,
+    model,
+    oidc as oidc_mod,
+    plugins as plugins_mod,
+)
 from klangk_backend.settings import KlangkSettings
 from klangk_backend.main import register_exception_handlers
 from klangk_backend.util import API_PREFIX
@@ -50,6 +57,7 @@ async def mode_server(db, monkeypatch):
     app = FastAPI()
     app.state.settings = KlangkSettings(env={"KLANGK_AUTH_MODES": "none"})
     app.state.oidc = oidc_mod.OIDC(app.state)
+    app.state.plugins = plugins_mod.Plugins(app.state)
     app.include_router(api.root_router)
     app.include_router(api.router, prefix=API_PREFIX)
     register_exception_handlers(app)

--- a/src/backend/tests/test_plugins.py
+++ b/src/backend/tests/test_plugins.py
@@ -1,8 +1,10 @@
 """Tests for plugins module."""
 
 import json
+import types
 
 from klangk_backend import plugins
+from klangk_backend.settings import KlangkSettings
 
 
 def _make_plugin(tmp_path, name, config):
@@ -14,27 +16,33 @@ def _make_plugin(tmp_path, name, config):
     )
 
 
+def _plugins(plugins_dir):
+    """Build a fresh Plugins instance pointing at *plugins_dir* (#1451)."""
+    app_state = types.SimpleNamespace(
+        settings=KlangkSettings(env={"KLANGK_PLUGINS_DIR": str(plugins_dir)})
+    )
+    return plugins.Plugins(app_state)
+
+
 class TestPluginConfig:
     def test_load_no_dir(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(
-            plugins, "_PLUGINS_DIR", str(tmp_path / "nonexistent")
-        )
-        plugins.load()
-        assert plugins.container_env() == {}
-        assert plugins.frontend_config() == {}
+        p = _plugins(tmp_path / "nonexistent")
+        p.load()
+        assert p.container_env() == {}
+        assert p.frontend_config() == {}
 
     def test_load_empty_dir(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(plugins, "_PLUGINS_DIR", str(tmp_path))
-        plugins.load()
-        assert plugins.container_env() == {}
-        assert plugins.frontend_config() == {}
+        p = _plugins(tmp_path)
+        p.load()
+        assert p.container_env() == {}
+        assert p.frontend_config() == {}
 
     def test_load_dir_without_package_json(self, tmp_path, monkeypatch):
         (tmp_path / "no-manifest").mkdir()
-        monkeypatch.setattr(plugins, "_PLUGINS_DIR", str(tmp_path))
-        plugins.load()
-        assert plugins.container_env() == {}
-        assert plugins.frontend_config() == {}
+        p = _plugins(tmp_path)
+        p.load()
+        assert p.container_env() == {}
+        assert p.frontend_config() == {}
 
     def test_load_plugin_without_config(self, tmp_path, monkeypatch):
         plugin_dir = tmp_path / "no-config"
@@ -42,10 +50,10 @@ class TestPluginConfig:
         (plugin_dir / "package.json").write_text(
             json.dumps({"name": "@klangk/no-config"})
         )
-        monkeypatch.setattr(plugins, "_PLUGINS_DIR", str(tmp_path))
-        plugins.load()
-        assert plugins.container_env() == {}
-        assert plugins.frontend_config() == {}
+        p = _plugins(tmp_path)
+        p.load()
+        assert p.container_env() == {}
+        assert p.frontend_config() == {}
 
     def test_load_container_scope(self, tmp_path, monkeypatch):
         _make_plugin(
@@ -59,11 +67,11 @@ class TestPluginConfig:
                 }
             },
         )
-        monkeypatch.setattr(plugins, "_PLUGINS_DIR", str(tmp_path))
+        p = _plugins(tmp_path)
         monkeypatch.delenv("MY_API_KEY", raising=False)
-        plugins.load()
-        assert plugins.container_env() == {"MY_API_KEY": "default-val"}
-        assert plugins.frontend_config() == {}
+        p.load()
+        assert p.container_env() == {"MY_API_KEY": "default-val"}
+        assert p.frontend_config() == {}
 
     def test_load_frontend_scope(self, tmp_path, monkeypatch):
         _make_plugin(
@@ -77,11 +85,11 @@ class TestPluginConfig:
                 }
             },
         )
-        monkeypatch.setattr(plugins, "_PLUGINS_DIR", str(tmp_path))
+        p = _plugins(tmp_path)
         monkeypatch.setenv("MY_CLIENT_ID", "real-id")
-        plugins.load()
-        assert plugins.container_env() == {}
-        assert plugins.frontend_config() == {"my_client_id": "real-id"}
+        p.load()
+        assert p.container_env() == {}
+        assert p.frontend_config() == {"my_client_id": "real-id"}
 
     def test_load_both_scope(self, tmp_path, monkeypatch):
         _make_plugin(
@@ -95,11 +103,11 @@ class TestPluginConfig:
                 }
             },
         )
-        monkeypatch.setattr(plugins, "_PLUGINS_DIR", str(tmp_path))
+        p = _plugins(tmp_path)
         monkeypatch.setenv("SHARED_URL", "http://real")
-        plugins.load()
-        assert plugins.container_env() == {"SHARED_URL": "http://real"}
-        assert plugins.frontend_config() == {"shared_url": "http://real"}
+        p.load()
+        assert p.container_env() == {"SHARED_URL": "http://real"}
+        assert p.frontend_config() == {"shared_url": "http://real"}
 
     def test_env_overrides_default(self, tmp_path, monkeypatch):
         _make_plugin(
@@ -113,19 +121,19 @@ class TestPluginConfig:
                 }
             },
         )
-        monkeypatch.setattr(plugins, "_PLUGINS_DIR", str(tmp_path))
+        p = _plugins(tmp_path)
         monkeypatch.setenv("MY_VAR", "from-env")
-        plugins.load()
-        assert plugins.container_env() == {"MY_VAR": "from-env"}
+        p.load()
+        assert p.container_env() == {"MY_VAR": "from-env"}
 
     def test_load_invalid_json(self, tmp_path, monkeypatch):
         plugin_dir = tmp_path / "bad"
         plugin_dir.mkdir()
         (plugin_dir / "package.json").write_text("not json")
-        monkeypatch.setattr(plugins, "_PLUGINS_DIR", str(tmp_path))
-        plugins.load()
-        assert plugins.container_env() == {}
-        assert plugins.frontend_config() == {}
+        p = _plugins(tmp_path)
+        p.load()
+        assert p.container_env() == {}
+        assert p.frontend_config() == {}
 
     def test_multiple_plugins(self, tmp_path, monkeypatch):
         _make_plugin(
@@ -155,16 +163,16 @@ class TestPluginConfig:
                 },
             },
         )
-        monkeypatch.setattr(plugins, "_PLUGINS_DIR", str(tmp_path))
+        p = _plugins(tmp_path)
         monkeypatch.delenv("A_KEY", raising=False)
         monkeypatch.setenv("B_KEY", "b-val")
         monkeypatch.setenv("C_KEY", "c-val")
-        plugins.load()
-        assert plugins.container_env() == {
+        p.load()
+        assert p.container_env() == {
             "A_KEY": "a-default",
             "C_KEY": "c-val",
         }
-        assert plugins.frontend_config() == {
+        assert p.frontend_config() == {
             "b_key": "b-val",
             "c_key": "c-val",
         }
@@ -175,9 +183,9 @@ class TestPluginConfig:
         (plugin_dir / "package.json").write_text(
             json.dumps({"name": "@klangk/bad", "klangk": {"config": "nope"}})
         )
-        monkeypatch.setattr(plugins, "_PLUGINS_DIR", str(tmp_path))
-        plugins.load()
-        assert plugins.container_env() == {}
+        p = _plugins(tmp_path)
+        p.load()
+        assert p.container_env() == {}
 
     def test_non_dict_spec_ignored(self, tmp_path, monkeypatch):
         plugin_dir = tmp_path / "bad-spec"
@@ -190,9 +198,9 @@ class TestPluginConfig:
                 }
             )
         )
-        monkeypatch.setattr(plugins, "_PLUGINS_DIR", str(tmp_path))
-        plugins.load()
-        assert plugins.container_env() == {}
+        p = _plugins(tmp_path)
+        p.load()
+        assert p.container_env() == {}
 
     def test_invalid_scope_defaults_to_container(self, tmp_path, monkeypatch):
         _make_plugin(
@@ -206,25 +214,23 @@ class TestPluginConfig:
                 }
             },
         )
-        monkeypatch.setattr(plugins, "_PLUGINS_DIR", str(tmp_path))
+        p = _plugins(tmp_path)
         monkeypatch.delenv("X_KEY", raising=False)
-        plugins.load()
-        assert plugins.container_env() == {"X_KEY": "val"}
-        assert plugins.frontend_config() == {}
+        p.load()
+        assert p.container_env() == {"X_KEY": "val"}
+        assert p.frontend_config() == {}
 
 
 class TestPluginList:
-    def test_no_dir(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(
-            plugins, "_PLUGINS_DIR", str(tmp_path / "nonexistent")
-        )
-        assert plugins.plugin_list() == []
+    def test_no_dir(self, tmp_path):
+        p = _plugins(tmp_path / "nonexistent")
+        assert p.plugin_list() == []
 
-    def test_empty_dir(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(plugins, "_PLUGINS_DIR", str(tmp_path))
-        assert plugins.plugin_list() == []
+    def test_empty_dir(self, tmp_path):
+        p = _plugins(tmp_path)
+        assert p.plugin_list() == []
 
-    def test_returns_metadata(self, tmp_path, monkeypatch):
+    def test_returns_metadata(self, tmp_path):
         plugin_dir = tmp_path / "my-plugin"
         plugin_dir.mkdir()
         (plugin_dir / "package.json").write_text(
@@ -236,8 +242,8 @@ class TestPluginList:
                 }
             )
         )
-        monkeypatch.setattr(plugins, "_PLUGINS_DIR", str(tmp_path))
-        result = plugins.plugin_list()
+        p = _plugins(tmp_path)
+        result = p.plugin_list()
         assert len(result) == 1
         assert result[0] == {
             "name": "my-plugin",
@@ -245,35 +251,35 @@ class TestPluginList:
             "description": "A plugin",
         }
 
-    def test_skips_invalid_json(self, tmp_path, monkeypatch):
+    def test_skips_invalid_json(self, tmp_path):
         plugin_dir = tmp_path / "bad"
         plugin_dir.mkdir()
         (plugin_dir / "package.json").write_text("not json")
-        monkeypatch.setattr(plugins, "_PLUGINS_DIR", str(tmp_path))
-        assert plugins.plugin_list() == []
+        p = _plugins(tmp_path)
+        assert p.plugin_list() == []
 
-    def test_missing_fields_default_empty(self, tmp_path, monkeypatch):
+    def test_missing_fields_default_empty(self, tmp_path):
         plugin_dir = tmp_path / "minimal"
         plugin_dir.mkdir()
         (plugin_dir / "package.json").write_text(json.dumps({"name": "m"}))
-        monkeypatch.setattr(plugins, "_PLUGINS_DIR", str(tmp_path))
-        result = plugins.plugin_list()
+        p = _plugins(tmp_path)
+        result = p.plugin_list()
         assert result[0] == {
             "name": "minimal",
             "version": "",
             "description": "",
         }
 
-    def test_skips_dir_without_package_json(self, tmp_path, monkeypatch):
+    def test_skips_dir_without_package_json(self, tmp_path):
         (tmp_path / "no-manifest").mkdir()
-        monkeypatch.setattr(plugins, "_PLUGINS_DIR", str(tmp_path))
-        assert plugins.plugin_list() == []
+        p = _plugins(tmp_path)
+        assert p.plugin_list() == []
 
-    def test_sorted_by_name(self, tmp_path, monkeypatch):
+    def test_sorted_by_name(self, tmp_path):
         for name in ["zeta", "alpha", "mid"]:
             d = tmp_path / name
             d.mkdir()
             (d / "package.json").write_text(json.dumps({"name": name}))
-        monkeypatch.setattr(plugins, "_PLUGINS_DIR", str(tmp_path))
-        names = [p["name"] for p in plugins.plugin_list()]
+        p = _plugins(tmp_path)
+        names = [pl["name"] for pl in p.plugin_list()]
         assert names == ["alpha", "mid", "zeta"]


### PR DESCRIPTION
Closes #1451. Part of #1426 (composition-root refactor), Slice 4.

> **Based on #1450** (OIDC refactor) — retarget to `main` after that merges.

## What

`plugins.py` had `_PLUGINS_DIR` (frozen at import time via `resolve_env_value`) and `_declarations`/`_values` (mutable module globals). Promoted to a `Plugins` class on `app.state.plugins`, matching the uniform constructor pattern (`OIDC` #1450, `Terminal` #1480, etc.): `__init__` takes only `app_state`, derives `self.settings`. Instance attrs use no under-prefix (`self.plugins_dir`, `self.declarations`, `self.values`).

## Changes

**Production:**
- **`plugins.py`** — `Plugins` class owns `load`, `plugin_list`, `container_env`, `frontend_config`. `plugins_dir` computed at construction from `self.settings.plugins_dir` (no import-time env read — the frozen-at-import hazard). Plugin-declared config keys are dynamic (discovered from `package.json` at `load()` time, not settings fields), so their values still resolve via `resolve_env_value(key, default)` in the load loop — the only remaining env read, kept intentionally.
- **`main.py`** — `app.state.plugins = Plugins(app.state)` in `build_app`; lifespan calls `app.state.plugins.load()`.
- **`container.py`** — `self.app_state.plugins.container_env()` (via registry back-ref). Dropped unused `plugins` import.
- **API routes** — `version()` and `get_config()` reach plugins via `app_state.plugins` (the `version` route now takes `app_state` dep). Dropped unused `plugins` import.

**Tests:** fresh `Plugins` instances per test (no module-global state); explicit env in `KlangkSettings` for `plugins_dir` (no `os.environ` reads). 100% coverage maintained.

## Verification

- Backend unit: **2373 passed, 100% coverage**
- `ruff check` + `ruff format` clean
