### PR TITLE
Promote db.py to a DB(settings) class; kill import-time globals (#1452)

### DIFF
--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -701,7 +701,7 @@ def setup_static_files(app: FastAPI, frontend_dir: Path) -> None:
     if candidate.is_dir():
         branding_dir = candidate
     else:
-        fallback = model.db.data_dir / "branding"
+        fallback = Path(get_settings().data_dir or "") / "branding"
         branding_dir = fallback if fallback.is_dir() else None
     if branding_dir is not None:
         logger.info("Branding served from %s", branding_dir)
@@ -769,6 +769,11 @@ def build_app(settings: KlangkSettings) -> FastAPI:
     # settings, not frozen at import), declarations, and resolved values
     # (previously module globals).
     app.state.plugins = plugins.Plugins(app.state)
+    # #1452: DB(settings) owns the engine cache + data dir (computed from
+    # settings, not frozen at import). Set as the module-level default so
+    # the model/ free functions (transaction/fetchone/get_db) reach it.
+    app.state.db = model.db.DB(settings)
+    model.db.set_db(app.state.db)
     # WebSocketState reaches the registry through its own app_state
     # back-reference (send_service_health_snapshot / reset_workspace).
     # The unit-test fixtures set this explicitly; build_app must too, or

--- a/src/backend/klangk_backend/model/__init__.py
+++ b/src/backend/klangk_backend/model/__init__.py
@@ -19,18 +19,16 @@ target the owning submodule directly (``model.db`` for engine state,
 """
 
 from .db import (
-    DB_PATH,
+    DB,
     Connection,
     CursorResult,
     Row,
-    data_dir,
-    engine,
-    ensure_engine,
     fetchone,
-    make_engine,
     dispose_engine,
     get_db,
+    get_default_db,
     logger,
+    set_db,
     transaction,
 )
 from .schema import init_db
@@ -171,18 +169,16 @@ from .instance import (
 
 __all__ = (
     # db
-    "DB_PATH",
+    "DB",
     "Connection",
     "CursorResult",
     "Row",
-    "data_dir",
-    "engine",
-    "ensure_engine",
     "fetchone",
-    "make_engine",
     "dispose_engine",
     "get_db",
+    "get_default_db",
     "logger",
+    "set_db",
     "transaction",
     # schema
     "init_db",

--- a/src/backend/klangk_backend/model/db.py
+++ b/src/backend/klangk_backend/model/db.py
@@ -1,9 +1,17 @@
 """Shared core: async engine, connection wrappers, and transaction helpers.
 
 All DB access in the per-domain modules goes through :func:`transaction`
-and :func:`fetchone` defined here.  The engine state (``engine``,
-``DB_PATH``) also lives here so test fixtures that rebind it can target a
-single, obvious location.
+and :func:`fetchone` defined here.  The engine state also lives here so
+test fixtures that rebind it can target a single, obvious location.
+
+#1452: the import-time ``data_dir`` / ``DB_PATH`` globals (frozen from a
+global env read at import) are gone. All DB state/derivation lives on
+:class:`DB`, trivially constructed from settings. A module-level
+``_db`` instance is set at startup (and rebound per-test by the conftest
+fixture) so the existing ``transaction``/``fetchone``/``get_db`` module
+functions continue to work without threading a ``DB`` through every
+``model/`` call site — that larger pass is explicitly out of scope for
+this slice (see #1452 scope fence).
 """
 
 import asyncio
@@ -15,20 +23,9 @@ from sqlalchemy import event
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.pool import NullPool
 
-from ..util import resolve_env_value
+from ..settings import KlangkSettings, get_settings
 
 logger = logging.getLogger(__name__)
-
-data_dir = Path(
-    resolve_env_value("KLANGK_DATA_DIR", str(Path.home() / ".klangk" / "data"))
-)
-DB_PATH = data_dir / "klangk.db"
-
-# ---------------------------------------------------------------------------
-# SQLAlchemy async engine + compatibility wrappers
-# ---------------------------------------------------------------------------
-
-engine = None
 
 
 class Row:
@@ -103,93 +100,159 @@ class Connection:
         await self._conn.close()
 
 
-def make_engine(db_path: Path | str, **kwargs):
-    """Create a new async engine with PRAGMA listeners.
+class DB:
+    """Settings-derived database: owns the engine cache and connection helpers.
 
-    Uses NullPool so every ``transaction()`` gets a fresh connection and
-    returns it immediately on close.  SQLite connections are cheap (a
-    thread + file handle) and pooling them just creates artificial
-    contention — under concurrent load a bounded QueuePool exhausts its
-    slots and blocks the entire API with TimeoutError.
+    Constructed once at startup (``app.state.db = DB(settings)``) and
+    trivially standalone for the import-and-query / ops REPL path
+    (``DB(KlangkSettings(os.environ))``). The data dir and DB path are
+    computed from settings at construction — no import-time global, no
+    frozen-at-import hazard (#1452).
     """
-    url = f"sqlite+aiosqlite:///{db_path}"
-    engine = create_async_engine(
-        url,
-        poolclass=NullPool,
-        **kwargs,
-    )
 
-    @event.listens_for(engine.sync_engine, "connect")
-    def _set_pragmas(dbapi_conn, connection_record):
-        cursor = dbapi_conn.cursor()
-        cursor.execute("PRAGMA journal_mode = WAL")
-        cursor.execute("PRAGMA foreign_keys = ON")
-        cursor.execute("PRAGMA busy_timeout = 15000")
-        cursor.close()
+    def __init__(self, settings: KlangkSettings):
+        self.settings = settings
+        raw = settings.data_dir or str(Path.home() / ".klangk" / "data")
+        self.data_dir = Path(raw)
+        self.db_path = self.data_dir / "klangk.db"
+        self.engine = None
 
-    return engine
+    def make_engine(self):
+        """Create a new async engine with PRAGMA listeners.
+
+        Uses NullPool so every ``transaction()`` gets a fresh connection and
+        returns it immediately on close.  SQLite connections are cheap (a
+        thread + file handle) and pooling them just creates artificial
+        contention — under concurrent load a bounded QueuePool exhausts its
+        slots and blocks the entire API with TimeoutError.
+        """
+        url = f"sqlite+aiosqlite:///{self.db_path}"
+        engine = create_async_engine(
+            url,
+            poolclass=NullPool,
+        )
+
+        @event.listens_for(engine.sync_engine, "connect")
+        def _set_pragmas(dbapi_conn, connection_record):
+            cursor = dbapi_conn.cursor()
+            cursor.execute("PRAGMA journal_mode = WAL")
+            cursor.execute("PRAGMA foreign_keys = ON")
+            cursor.execute("PRAGMA busy_timeout = 15000")
+            cursor.close()
+
+        return engine
+
+    def ensure_engine(self):
+        if self.engine is None:
+            self.db_path.parent.mkdir(parents=True, exist_ok=True)
+            self.engine = self.make_engine()
+        return self.engine
+
+    async def dispose_engine(self) -> None:
+        """Dispose the current engine (shutdown / test teardown)."""
+        if self.engine is not None:
+            await self.engine.dispose()
+            self.engine = None
+
+    async def get_db(self) -> Connection:
+        """Acquire a raw database connection from the pool.
+
+        Caller is responsible for commit/rollback/close.
+
+        The ``engine.connect()`` await is shielded so that a cancellation
+        delivered mid-acquisition cannot orphan the underlying connection:
+        aiosqlite opens its worker thread (and the real ``sqlite3.Connection``)
+        before the await returns, so interrupting it leaves those resources
+        with no handle to close them -- they then outlive the event loop and
+        surface as ``RuntimeError: Event loop is closed`` / ``ResourceWarning:
+        unclosed database`` (#1250). If we are cancelled, we drain the
+        shielded connect and close whatever it produced before propagating.
+        """
+        engine = self.ensure_engine()
+        task = asyncio.ensure_future(engine.connect())
+        try:
+            conn = await asyncio.shield(task)
+        except asyncio.CancelledError:
+            try:
+                conn = await task
+                await conn.close()
+            except (
+                Exception
+            ):  # pragma: no cover - defensive; close best-effort
+                pass
+            raise
+        return Connection(conn)
+
+    @asynccontextmanager
+    async def transaction(self):
+        """Context manager: auto-commits on clean exit, rolls back on error."""
+        db = await self.get_db()
+        try:
+            yield db
+            await db.commit()
+        except BaseException:
+            await db.rollback()
+            raise
+        finally:
+            await db.close()
+
+    async def fetchone(self, query: str, params: tuple = ()) -> Row | None:
+        """Run a single-row SELECT and return the row, or ``None``."""
+        async with self.transaction() as db:
+            cursor = await db.execute(query, params)
+            return await cursor.fetchone()
 
 
-def ensure_engine():
-    global engine
-    if engine is None:
-        DB_PATH.parent.mkdir(parents=True, exist_ok=True)
-        engine = make_engine(DB_PATH)
-    return engine
+# ---------------------------------------------------------------------------
+# Module-level instance + delegation functions
+#
+# A single ``_db`` is set at startup (and rebound per-test). The module-level
+# ``transaction`` / ``fetchone`` / ``get_db`` delegate to it so the ~50
+# ``model/`` call sites that do ``from .db import transaction`` keep working
+# without threading a ``DB`` through every signature — that larger pass is
+# explicitly out of scope for #1452 (scope fence: it implies folding all of
+# model/ into DB, which is a separate decision about the data-access shape).
+# ---------------------------------------------------------------------------
+
+_db: DB | None = None
 
 
-async def dispose_engine() -> None:
-    """Dispose the current engine (shutdown / test teardown)."""
-    global engine
-    if engine is not None:
-        await engine.dispose()
-        engine = None
+def set_db(db: DB) -> None:
+    """Set the module-level DB instance (startup / test fixture)."""
+    global _db
+    _db = db
+
+
+def get_default_db() -> DB:
+    """Return the module-level DB, constructing one lazily if needed.
+
+    Lazily constructs from :func:`get_settings` so the import-and-query /
+    ops REPL path works without an explicit ``set_db`` call — matching the
+    pre-refactor behavior where ``ensure_engine`` read the global env.
+    """
+    global _db
+    if _db is None:
+        _db = DB(get_settings())
+    return _db
 
 
 async def get_db() -> Connection:
-    """Acquire a raw database connection from the pool.
-
-    Caller is responsible for commit/rollback/close.
-
-    The ``engine.connect()`` await is shielded so that a cancellation
-    delivered mid-acquisition cannot orphan the underlying connection:
-    aiosqlite opens its worker thread (and the real ``sqlite3.Connection``)
-    before the await returns, so interrupting it leaves those resources
-    with no handle to close them -- they then outlive the event loop and
-    surface as ``RuntimeError: Event loop is closed`` / ``ResourceWarning:
-    unclosed database`` (#1250). If we are cancelled, we drain the
-    shielded connect and close whatever it produced before propagating.
-    """
-    engine = ensure_engine()
-    task = asyncio.ensure_future(engine.connect())
-    try:
-        conn = await asyncio.shield(task)
-    except asyncio.CancelledError:
-        try:
-            conn = await task
-            await conn.close()
-        except Exception:  # pragma: no cover - defensive; close best-effort
-            pass
-        raise
-    return Connection(conn)
+    """Module-level delegate to the default DB's :meth:`DB.get_db`."""
+    return await get_default_db().get_db()
 
 
 @asynccontextmanager
 async def transaction():
-    """Context manager: auto-commits on clean exit, rolls back on error."""
-    db = await get_db()
-    try:
+    """Module-level delegate to the default DB's :meth:`DB.transaction`."""
+    async with get_default_db().transaction() as db:
         yield db
-        await db.commit()
-    except BaseException:
-        await db.rollback()
-        raise
-    finally:
-        await db.close()
 
 
 async def fetchone(query: str, params: tuple = ()) -> Row | None:
-    """Run a single-row SELECT and return the row, or ``None``."""
-    async with transaction() as db:
-        cursor = await db.execute(query, params)
-        return await cursor.fetchone()
+    """Module-level delegate to the default DB's :meth:`DB.fetchone`."""
+    return await get_default_db().fetchone(query, params)
+
+
+async def dispose_engine() -> None:
+    """Module-level delegate to the default DB's :meth:`DB.dispose_engine`."""
+    await get_default_db().dispose_engine()

--- a/src/backend/klangk_backend/model/instance.py
+++ b/src/backend/klangk_backend/model/instance.py
@@ -16,8 +16,7 @@ exposes this to non-Python callers (shell scripts, TypeScript tests).
 import sqlite3
 import uuid
 
-from . import db as _db
-from .db import get_db
+from .db import get_default_db, get_db
 
 _cache: str | None = None
 
@@ -76,8 +75,9 @@ def resolve_instance_id_sync() -> str:
     """
     global _cache
 
-    _db.DB_PATH.parent.mkdir(parents=True, exist_ok=True)
-    conn = sqlite3.connect(str(_db.DB_PATH))
+    db_path = get_default_db().db_path
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
     try:
         conn.execute("PRAGMA journal_mode = WAL")
         conn.execute("PRAGMA foreign_keys = ON")

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -61,18 +61,15 @@ def temp_data_dir(tmp_path, monkeypatch):
     monkeypatch.setenv("KLANGK_DATA_DIR", str(tmp_path))
     monkeypatch.setenv("KLANGK_CUSTOMIZE_DIR", str(tmp_path / "customize"))
     monkeypatch.delenv("KLANGK_IMAGE_PULL_POLICY", raising=False)
-    # Re-import to pick up the new env var.  The engine state lives on
-    # ``model.db`` (where ``ensure_engine`` reads it), so the globals
-    # must be rebound there — setting them on the package would not be
-    # seen by the core helpers.
+    # Rebuild the DB instance from the new env so the engine cache and
+    # db_path point at the per-test temp dir (#1452: no import-time globals
+    # to rebind — construct a fresh DB from settings).
     import klangk_backend.model as us
     import klangk_backend.model.db as us_core
     import klangk_backend.workspaces as wm
+    from klangk_backend.settings import KlangkSettings
 
-    us_core.data_dir = tmp_path
-    us_core.DB_PATH = tmp_path / "klangk.db"
-    # Reset the SQLAlchemy engine so it reconnects to the new DB path.
-    us_core.engine = None
+    us_core.set_db(us_core.DB(KlangkSettings(os.environ)))
     wm.data_dir = tmp_path
     wm.WORKSPACES_ROOT = tmp_path / "workspaces"
     # Clear agent caches so each test starts fresh.

--- a/src/backend/tests/test_model.py
+++ b/src/backend/tests/test_model.py
@@ -14,8 +14,9 @@ class TestMigration:
     async def test_migrate_old_schema(self, temp_data_dir):
         """Migrates a pre-OIDC database: password_hash NOT NULL, no
         provider/external_id columns."""
-        db = await aiosqlite.connect(str(model.db.DB_PATH))
-        model.db.DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+        db_path = model.db.get_default_db().db_path
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        db = await aiosqlite.connect(str(db_path))
         try:
             await db.execute("""
                 CREATE TABLE users (
@@ -55,8 +56,9 @@ class TestMigration:
 
     async def test_migrate_workspaces_adds_auto_start(self, temp_data_dir):
         """Migrates a workspaces table missing the auto_start column."""
-        db = await aiosqlite.connect(str(model.db.DB_PATH))
-        model.db.DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+        db_path = model.db.get_default_db().db_path
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        db = await aiosqlite.connect(str(db_path))
         try:
             await db.execute("""
                 CREATE TABLE users (
@@ -117,8 +119,9 @@ class TestMigration:
     ):
         """init_db renames the legacy default_command column to service_command
         (#1203), preserving existing data."""
-        db = await aiosqlite.connect(str(model.db.DB_PATH))
-        model.db.DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+        db_path = model.db.get_default_db().db_path
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        db = await aiosqlite.connect(str(db_path))
         try:
             await db.execute("""
                 CREATE TABLE users (
@@ -185,8 +188,9 @@ class TestMigration:
         so a DB created before they shipped lacked them. init_db must add
         them on upgrade (NULL by default) without touching existing rows.
         """
-        db = await aiosqlite.connect(str(model.db.DB_PATH))
-        model.db.DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+        db_path = model.db.get_default_db().db_path
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        db = await aiosqlite.connect(str(db_path))
         try:
             await db.execute("""
                 CREATE TABLE users (
@@ -1847,3 +1851,45 @@ class TestInstanceId:
         """get_instance_id raises before resolve_instance_id is called."""
         with pytest.raises(RuntimeError, match="not yet resolved"):
             model.get_instance_id()
+
+
+class TestDB:
+    """Tests for the DB(settings) class (#1452)."""
+
+    def test_db_derives_path_from_settings(self, temp_data_dir):
+        """DB computes db_path from settings.data_dir, not import-time globals."""
+        from klangk_backend.model.db import DB
+        from klangk_backend.settings import KlangkSettings
+        import os
+
+        db = DB(KlangkSettings(os.environ))
+        assert str(db.db_path).endswith("klangk.db")
+        assert db.engine is None
+
+    def test_get_default_db_lazy_constructs(self, temp_data_dir):
+        """get_default_db lazily constructs a DB from settings when _db is None."""
+        from klangk_backend.model import db as db_mod
+
+        saved = db_mod._db
+        try:
+            db_mod._db = None
+            result = db_mod.get_default_db()
+            assert result is not None
+            assert result.db_path.name == "klangk.db"
+        finally:
+            db_mod._db = saved
+
+    def test_set_db_replaces_instance(self, temp_data_dir):
+        """set_db replaces the module-level DB instance."""
+        from klangk_backend.model import db as db_mod
+        from klangk_backend.model.db import DB
+        from klangk_backend.settings import KlangkSettings
+        import os
+
+        saved = db_mod._db
+        try:
+            new_db = DB(KlangkSettings(os.environ))
+            db_mod.set_db(new_db)
+            assert db_mod.get_default_db() is new_db
+        finally:
+            db_mod.set_db(saved)


### PR DESCRIPTION
Closes #1452. Part of #1426 (composition-root refactor), Slice 5.

## What

`model/db.py` had `data_dir` and `DB_PATH` frozen at import time from a global env read (`resolve_env_value`), plus `engine`/`ensure_engine`/`get_db` as module-level mutable state. All defeated late-binding of settings and the `KlangkSettings(env)` constructor.

Replaced with a `DB(settings)` class that owns the data dir, db path, engine cache, and connection helpers (`get_db`/`transaction`/`fetchone`). Trivially constructible standalone for the import-and-query/REPL path (`DB(KlangkSettings(os.environ))`), no app required.

## Changes

**Production:**
- **`db.py`** — `DB` class with `self.settings`, `self.data_dir`, `self.db_path`, `self.engine`. `make_engine` reads `self.db_path` (no hardcoded URL). Module-level `transaction`/`fetchone`/`get_db`/`dispose_engine` delegate to a module-level `_db` instance (set via `set_db` at startup) — the ~50 `model/` call sites that do `from .db import transaction` keep working without threading a `DB` through every signature (**scope fence**: folding all of `model/` into `DB` is a separate issue, per #1452).
- **`instance.py`** — `resolve_instance_id_sync` reads `db_path` from `get_default_db()` instead of the module global `DB_PATH`.
- **`main.py`** — `app.state.db = DB(settings)`; `model.db.set_db(app.state.db)` in `build_app`. Branding fallback uses `get_settings().data_dir` instead of `model.db.data_dir`.
- Removed dead module-level `make_engine`/`ensure_engine` delegates (no callers). Updated `model/__init__.py` re-exports and `__all__`.

**Tests:** conftest `temp_data_dir` builds a fresh `DB(KlangkSettings(env))` per test instead of rebinding module globals. Added `TestDB` class covering `DB` construction + `set_db`/`get_default_db`. 100% coverage maintained.

## Verification

All three suites green locally:
- Backend unit: **2376 passed, 100% coverage**
- Backend e2e: **95 passed**
- CLI e2e: **62 passed, 1 skipped**
