### PR TITLE
Promote workspaces.py to a Workspaces(app_state) class (#1484)

### DIFF
--- a/src/backend/klangk_backend/agent.py
+++ b/src/backend/klangk_backend/agent.py
@@ -11,7 +11,7 @@ import logging
 import re
 import time
 
-from . import model, util, workspaces
+from . import model, util
 from .podman import subprocess_env
 
 _THINK_RE = re.compile(r"<think>.*?</think>\s*", re.DOTALL)
@@ -69,7 +69,7 @@ def is_disabled() -> bool:
 
 
 async def ensure_agent_home(
-    workspace_id: str, container_id: str, podman=None
+    workspace_id: str, container_id: str, app_state=None
 ) -> str:
     """Eagerly provision the agent's home directory with Pi config.
 
@@ -90,15 +90,15 @@ async def ensure_agent_home(
         raise AgentSetupError(
             f"Workspace {workspace_id} not found in database"
         )
-    workspace_home = workspaces.home_path(workspace_id)
+    workspace_home = app_state.workspaces.home_path(workspace_id)
 
     agent_handle = await model.agent_handle()
-    container_home, created = await workspaces.ensure_home_symlink(
+    container_home, created = await app_state.workspaces.ensure_home_symlink(
         workspace_home, agent_handle, model.AGENT_USER_ID
     )
     if created:
-        await workspaces.populate_home_skel(
-            container_id, model.AGENT_USER_ID, podman
+        await app_state.workspaces.populate_home_skel(
+            container_id, model.AGENT_USER_ID
         )
 
     # Run klangk-setup-pi to populate ~/.pi/agent/ with models.json,
@@ -106,7 +106,7 @@ async def ensure_agent_home(
     # personal preferences — --force deletes settings.json first so
     # it picks up the current KLANGK_LLM_MODEL env var.
     proc = await asyncio.create_subprocess_exec(
-        podman.bin,
+        app_state.podman.bin,
         "exec",
         "-u",
         "klangk",
@@ -197,7 +197,7 @@ class AgentSession:
             handle = await model.agent_handle()
             return f"/home/{handle}"
         container_home = await ensure_agent_home(
-            self.workspace_id, container_id, self.app_state.podman
+            self.workspace_id, container_id, self.app_state
         )
         self._home_ready = True
         return container_home

--- a/src/backend/klangk_backend/api/admin.py
+++ b/src/backend/klangk_backend/api/admin.py
@@ -18,7 +18,6 @@ from .. import (
     emailsvc,
     model,
     wshandler,
-    workspaces,
 )
 from ._common import get_app_state_dep
 from ..model import (
@@ -249,6 +248,7 @@ async def list_user_workspaces(
     limit: int | None = Query(None, ge=1, le=200),
     offset: int | None = Query(None, ge=0),
     admin: dict = Depends(acl.has_permission("admin")),
+    app_state=Depends(get_app_state_dep),
 ):
     """List workspaces owned by a user (admin only).
 
@@ -259,7 +259,7 @@ async def list_user_workspaces(
     user = await model.get_user_by_id(user_id)
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
-    return await workspaces.list_workspaces(
+    return await app_state.workspaces.list_workspaces(
         user_id, limit=limit or 100, offset=offset or 0
     )
 
@@ -278,7 +278,7 @@ async def delete_user(
     # Stop all containers for this user before deleting
     await app_state.container_registry.stop_user_containers(user_id)
     # Archive workspace data before deletion
-    await workspaces.archive_user_data(user_id, user["email"])
+    await app_state.workspaces.archive_user_data(user_id, user["email"])
     deleted = await model.delete_user(user_id)
     if not deleted:  # pragma: no cover — race between get and delete
         raise HTTPException(status_code=404, detail="User not found")

--- a/src/backend/klangk_backend/api/workspaces.py
+++ b/src/backend/klangk_backend/api/workspaces.py
@@ -31,7 +31,6 @@ from .. import (
     container,
     model,
     wshandler,
-    workspaces,
 )
 from ._common import get_app_state_dep
 from ..model import (
@@ -114,7 +113,7 @@ async def list_workspaces(
     (name substring) apply in both shapes.
     """
     bare = limit is None and offset is None
-    result = await workspaces.list_workspaces(
+    result = await app_state.workspaces.list_workspaces(
         user["id"],
         limit=BARE_LIST_LIMIT if bare else limit,
         offset=offset or 0,
@@ -192,7 +191,7 @@ async def create_workspace(
         if mount_err:
             raise HTTPException(status_code=400, detail=mount_err)
     try:
-        ws = await workspaces.create_workspace(
+        ws = await app_state.workspaces.create_workspace(
             user["id"],
             body.name,
             image=body.image,
@@ -202,7 +201,6 @@ async def create_workspace(
             env=body.env,
             setup_state=body.setup_state or "complete",
             health_check=body.health_check,
-            app_state=app_state,
         )
     except SAIntegrityError:
         raise HTTPException(
@@ -219,7 +217,7 @@ async def create_workspace(
     # so workspaces whose setup.sh hasn't run yet defer until complete.
     if body.auto_start:
         try:
-            await workspaces.start_workspace(ws, app_state)
+            await app_state.workspaces.start_workspace(ws)
         except Exception:
             logger.warning(
                 "Eager start failed for workspace %s",
@@ -313,7 +311,7 @@ async def duplicate_workspace(
     if source is None:  # pragma: no cover — race after ACL check
         raise HTTPException(status_code=404, detail="Workspace not found")
     try:
-        ws = await workspaces.create_workspace(
+        ws = await app_state.workspaces.create_workspace(
             user["id"],
             body.name,
             image=source.get("image"),
@@ -322,7 +320,6 @@ async def duplicate_workspace(
             mounts=source.get("mounts"),
             env=source.get("env"),
             health_check=source.get("health_check"),
-            app_state=app_state,
         )
     except SAIntegrityError:
         raise HTTPException(
@@ -362,7 +359,7 @@ async def delete_workspace(
         await app_state.container_registry.stop_and_remove_container(cid)
     await wshandler.reset_workspace_state(app_state.sockets, workspace_id)
 
-    deleted = await workspaces.delete_workspace(
+    deleted = await app_state.workspaces.delete_workspace(
         workspace_id, workspace["user_id"]
     )
     if not deleted:  # pragma: no cover — race between get and delete
@@ -406,7 +403,7 @@ async def restart_workspace(
     await wshandler.reset_workspace_state(app_state.sockets, workspace_id)
     # Start a fresh container; the service command fires via the
     # create choke point in start_container.
-    await workspaces.start_workspace(workspace, app_state)
+    await app_state.workspaces.start_workspace(workspace)
     return {"status": "restarted"}
 
 
@@ -478,6 +475,7 @@ async def workspace_status(
 async def export_workspace(
     workspace_id: str,
     admin: dict = Depends(acl.has_permission("admin", admin_resource)),
+    app_state=Depends(get_app_state_dep),
 ):
     """Export a workspace as a .tar.gz archive (admin only).
 
@@ -491,10 +489,10 @@ async def export_workspace(
     if workspace is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
 
-    home_dir = workspaces.home_path(workspace_id)
+    home_dir = app_state.workspaces.home_path(workspace_id)
     ws_name = workspace["name"]
 
-    metadata = workspaces.workspace_metadata(workspace)
+    metadata = app_state.workspaces.workspace_metadata(workspace)
 
     # Estimate uncompressed size for client progress display.
     estimated_size = 0
@@ -525,7 +523,9 @@ async def export_workspace(
             with open(meta_file, "w") as f:
                 json.dump(metadata, f, indent=2)
 
-            tar_args = workspaces.build_export_tar_args("-", tmpdir, home_dir)
+            tar_args = app_state.workspaces.build_export_tar_args(
+                "-", tmpdir, home_dir
+            )
 
             proc = await asyncio.create_subprocess_exec(
                 *tar_args,
@@ -661,10 +661,10 @@ async def _extract_archive_metadata(
 
 
 async def _extract_home_directory(
-    archive_path: str, user_id: int, ws_id: int
+    archive_path: str, user_id: int, ws_id: int, app_state
 ) -> None:
     """Extract the ``home/`` tree from *archive_path* into the workspace home."""
-    home_dir = workspaces.home_path(ws_id)
+    home_dir = app_state.workspaces.home_path(ws_id)
     home_dir.mkdir(parents=True, exist_ok=True)
     check = await asyncio.to_thread(
         subprocess.run,
@@ -715,7 +715,7 @@ async def import_workspace(
         meta = await _extract_archive_metadata(archive_path, name)
 
         try:
-            ws = await workspaces.create_workspace(
+            ws = await app_state.workspaces.create_workspace(
                 user["id"],
                 meta["name"],
                 image=meta["image"],
@@ -724,7 +724,6 @@ async def import_workspace(
                 mounts=meta["mounts"],
                 env=meta["env"],
                 health_check=meta["health_check"],
-                app_state=app_state,
             )
         except SAIntegrityError:
             raise HTTPException(
@@ -733,16 +732,18 @@ async def import_workspace(
             )
 
         try:
-            await _extract_home_directory(archive_path, user["id"], ws["id"])
+            await _extract_home_directory(
+                archive_path, user["id"], ws["id"], app_state
+            )
         except HTTPException:
-            await workspaces.delete_workspace(ws["id"], user["id"])
+            await app_state.workspaces.delete_workspace(ws["id"], user["id"])
             raise
 
     except HTTPException:
         raise
     except (json.JSONDecodeError, subprocess.TimeoutExpired):
         if ws:
-            await workspaces.delete_workspace(ws["id"], user["id"])
+            await app_state.workspaces.delete_workspace(ws["id"], user["id"])
         raise HTTPException(
             status_code=400, detail="Invalid or corrupt archive"
         )

--- a/src/backend/klangk_backend/bringup.py
+++ b/src/backend/klangk_backend/bringup.py
@@ -31,7 +31,7 @@ async def bringup(
     Idempotent via :func:`terminal.ensure_service_session`.
     """
     agent_home = await agent.ensure_agent_home(
-        workspace_id, container_id, app_state.podman
+        workspace_id, container_id, app_state
     )
     if not service_command:
         return

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -598,10 +598,9 @@ class HealthMonitor:
         # Resolve the owner's container home the same way
         # start_workspace does, so the check runs in the right
         # HOME rather than as root in /.
-        from . import workspaces as _wm  # noqa: allow-deferred-import
-
-        ws_home = _wm.home_path(state.workspace_id)
-        user_home, _created = await _wm.ensure_home_symlink(
+        ws = self._registry.app_state.workspaces
+        ws_home = ws.home_path(state.workspace_id)
+        user_home, _created = await ws.ensure_home_symlink(
             ws_home, handle, owner_id
         )
         cid_short = state.container_id[:12]

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -363,7 +363,7 @@ async def startup(app_state) -> None:
     await registry.adopt_orphaned_containers()
     registry.start_cleanup_loop()
     registry.start_health_loop()
-    n = await workspaces.auto_start_workspaces(app_state)
+    n = await app_state.workspaces.auto_start_workspaces()
     if n:  # pragma: no cover
         logger.info("Auto-started %d workspace(s)", n)
 
@@ -769,6 +769,10 @@ def build_app(settings: KlangkSettings) -> FastAPI:
     # settings, not frozen at import), declarations, and resolved values
     # (previously module globals).
     app.state.plugins = plugins.Plugins(app.state)
+    # #1484: Workspaces(app_state) owns the workspace root (computed from
+    # settings.data_dir at construction, not frozen at import) + CRUD/path
+    # helpers.
+    app.state.workspaces = workspaces.Workspaces(app.state)
     # #1452: DB(settings) owns the engine cache + data dir (computed from
     # settings, not frozen at import). Set as the module-level default so
     # the model/ free functions (transaction/fetchone/get_db) reach it.

--- a/src/backend/klangk_backend/workspaces.py
+++ b/src/backend/klangk_backend/workspaces.py
@@ -10,14 +10,8 @@ from pathlib import Path
 
 from . import container, model
 from .model.instance import get_instance_id
-from .util import resolve_env_bool, resolve_env_value
 
 logger = logging.getLogger(__name__)
-
-data_dir = Path(
-    resolve_env_value("KLANGK_DATA_DIR", str(Path.home() / ".klangk" / "data"))
-)
-WORKSPACES_ROOT = data_dir / "workspaces"
 
 # Characters allowed in sanitized filenames (alphanumeric, dash,
 # underscore, dot, @).  Everything else is replaced with underscore.
@@ -27,14 +21,6 @@ _SAFE_FILENAME_RE = re.compile(r"[^a-zA-Z0-9._@-]")
 def sanitize_filename(name: str) -> str:
     """Replace unsafe characters in a filename component."""
     return _SAFE_FILENAME_RE.sub("_", name)
-
-
-def safe_path(*segments: str) -> Path:
-    """Build a path under WORKSPACES_ROOT, raising ValueError on traversal."""
-    path = WORKSPACES_ROOT.joinpath(*segments)
-    if not path.resolve().is_relative_to(WORKSPACES_ROOT.resolve()):
-        raise ValueError(f"Path traversal blocked: {'/'.join(segments)}")
-    return path
 
 
 def rmtree(path: Path | str, label: str = "") -> None:
@@ -55,275 +41,6 @@ def rmtree(path: Path | str, label: str = "") -> None:
 async def _async_rmtree(path: Path | str, label: str = "") -> None:
     """Remove a directory tree in a thread, logging errors."""
     await asyncio.to_thread(rmtree, path, label)
-
-
-def workspace_metadata(ws: dict) -> dict:
-    """Extract export metadata from a workspace dict.
-
-    Includes the instance ID so that imports can verify the archive
-    came from the same Klangk instance.
-    """
-    return {
-        "name": ws["name"],
-        "instance_id": get_instance_id(),
-        "image": ws.get("image"),
-        "service_command": ws.get("service_command"),
-        "auto_start": ws.get("auto_start", False),
-        "mounts": ws.get("mounts"),
-        "env": ws.get("env"),
-        "health_check": ws.get("health_check"),
-        "num_ports": ws.get("num_ports", 5),
-    }
-
-
-def build_export_tar_args(
-    output: str,
-    tmpdir: str,
-    home_dir: Path | None,
-) -> list[str]:
-    """Build GNU tar arguments for workspace export.
-
-    GNU tar stores symlinks as symlinks (not contents), so external
-    symlinks (e.g., -> /usr/bin/python3) are harmless in the archive —
-    they resolve correctly inside the container. No symlink filtering.
-
-    Args:
-        output: tar output path, or "-" for stdout.
-        tmpdir: directory containing workspace.json.
-        home_dir: workspace home directory, or None if it doesn't exist.
-    """
-    args = [
-        "tar",
-        "-czf",
-        output,
-        "-C",
-        tmpdir,
-        "workspace.json",
-    ]
-    if home_dir is not None and home_dir.exists():
-        ws_dir_name = home_dir.name
-        escaped = re.escape(ws_dir_name)
-        args.extend(
-            [
-                f"--transform=s/^{escaped}/home/",
-                "-C",
-                str(home_dir.parent),
-                ws_dir_name,
-            ]
-        )
-    return args
-
-
-async def build_workspace_archive(
-    metadata: dict, home_dir: Path, archive_path: Path
-) -> bool:
-    """Build a .tar.gz archive in the export/import format.
-
-    The archive contains workspace.json (metadata) and home/ (the home
-    directory tree).  Symlinks are stored as symlinks (not dereferenced).
-    Both home_dir and archive_path must resolve under WORKSPACES_ROOT.
-    Returns True on success, False on failure.
-    """
-    # Validate that paths stay within the data directory.
-    for label, p in [("home_dir", home_dir), ("archive_path", archive_path)]:
-        if p.exists() or p.parent.exists():
-            resolved = (p if p.exists() else p.parent).resolve()
-            if not resolved.is_relative_to(WORKSPACES_ROOT.resolve()):
-                logger.error("Path validation failed for %s: %s", label, p)
-                return False
-
-    tmpdir = tempfile.mkdtemp()
-    try:
-        meta_file = Path(tmpdir) / "workspace.json"
-        meta_file.write_text(json.dumps(metadata, indent=2))
-
-        tar_args = build_export_tar_args(str(archive_path), tmpdir, home_dir)
-
-        proc = await asyncio.create_subprocess_exec(
-            *tar_args,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-        )
-        _, stderr = await asyncio.wait_for(proc.communicate(), timeout=300)
-
-        if proc.returncode != 0:
-            logger.error(
-                "tar failed for %s: %s",
-                archive_path.name,
-                stderr.decode("utf-8", errors="replace"),
-            )
-            return False
-        return True
-    except (asyncio.TimeoutError, OSError) as e:
-        logger.error("Failed to build archive %s: %s", archive_path.name, e)
-        return False
-    finally:
-        await _async_rmtree(tmpdir, "build_workspace_archive tmpdir")
-
-
-async def archive_user_data(user_id: str, email: str) -> list[Path]:
-    """Archive each workspace to a .tar.gz in the export/import format.
-
-    Creates one archive per workspace containing workspace.json (metadata)
-    and home/ (the workspace home directory).  These archives can be
-    re-imported via ``POST /workspaces/import``.
-
-    Returns the list of created archive paths (may be empty).
-    After successful archival each workspace's data directory is removed.
-    """
-    safe_email = sanitize_filename(email)
-
-    # Page through every workspace (list_workspaces paginates).
-    archives: list[Path] = []
-    archived_ws_ids: list[str] = []
-    offset = 0
-    while True:
-        page = await model.list_workspaces(user_id, offset=offset)
-        user_workspaces = page["items"]
-        if not user_workspaces:
-            break
-        for ws in user_workspaces:
-            ws_name = sanitize_filename(ws["name"])
-            archive_name = f"{user_id}-{safe_email}-{ws_name}.tar.gz"
-            try:
-                archive_path = safe_path(
-                    archive_name
-                )  # lgtm[py/path-injection]
-            except ValueError:
-                logger.error(
-                    "Archive path traversal blocked for workspace %s",
-                    ws["name"],
-                )
-                continue
-            home_dir = home_path(ws["id"])
-            metadata = workspace_metadata(ws)
-            if await build_workspace_archive(metadata, home_dir, archive_path):
-                # lgtm[py/clear-text-logging-sensitive-data]
-                logger.info(
-                    "Archived workspace %s to %s", ws["name"], archive_path
-                )
-                archives.append(archive_path)
-                archived_ws_ids.append(ws["id"])
-        if not page["has_more"]:
-            break
-        offset = page["next_offset"]
-
-    # Remove each archived workspace's data directory.
-    for ws_id in archived_ws_ids:
-        ws_dir = safe_path(ws_id)
-        if ws_dir.exists():
-            await _async_rmtree(ws_dir, f"workspace data {ws_id}")
-    return archives
-
-
-def workspace_path(workspace_id: str) -> Path:
-    """Build path to /WORKSPACES_ROOT/{workspace_id}/home/work"""
-    return home_path(workspace_id) / "work"
-
-
-def home_path(workspace_id: str) -> Path:
-    """Build path to /WORKSPACES_ROOT/{workspace_id}/home"""
-    return safe_path(workspace_id, "home")
-
-
-def config_path(workspace_id: str) -> Path:
-    """Build path to /WORKSPACES_ROOT/{workspace_id}/config"""
-    return safe_path(workspace_id, "config")
-
-
-def get_config_host_path(workspace_id: str) -> Path:
-    path = config_path(workspace_id)
-    path.mkdir(parents=True, exist_ok=True)
-    return path
-
-
-async def create_workspace(
-    user_id: str,
-    name: str,
-    image: str | None = None,
-    service_command: str | None = None,
-    auto_start: bool = False,
-    mounts: list[str] | None = None,
-    env: dict[str, str] | None = None,
-    setup_state: str | None = None,
-    health_check: str | None = None,
-    app_state=None,
-) -> dict:
-    workspace = await model.create_workspace_with_acl(
-        user_id,
-        name,
-        image=image,
-        service_command=service_command,
-        auto_start=auto_start,
-        mounts=mounts,
-        env=env,
-        setup_state=setup_state or model.SETUP_STATE_COMPLETE,
-        health_check=health_check,
-    )
-    home = home_path(workspace["id"])
-    home.mkdir(parents=True, exist_ok=True)
-    work = workspace_path(workspace["id"])
-    work.mkdir(parents=True, exist_ok=True)
-    users_dir = home / ".users"
-    users_dir.mkdir(exist_ok=True)
-    terminals_dir = home / ".terminals"
-    terminals_dir.mkdir(exist_ok=True)
-    # Allocate ports at creation time so ranges are sequential
-    if app_state is not None:
-        try:
-            await app_state.container_registry.allocate_ports(
-                workspace["id"], workspace["num_ports"]
-            )
-        except Exception:
-            # Clean up the DB record and directories on port allocation failure
-            await model.delete_workspace(workspace["id"], user_id)
-            await _async_rmtree(home, f"workspace {workspace['id']} rollback")
-            raise
-    return workspace
-
-
-async def list_workspaces(
-    user_id: str,
-    limit: int = 10,
-    offset: int = 0,
-    sort: str = "created",
-    order: str = "desc",
-    q: str | None = None,
-) -> dict:
-    return await model.list_workspaces(user_id, limit, offset, sort, order, q)
-
-
-async def get_workspace(
-    workspace_id: str, user_id: str | None = None
-) -> dict | None:
-    return await model.get_workspace(workspace_id, user_id)
-
-
-async def delete_workspace(workspace_id: str, user_id: str) -> bool:
-    workspace = await model.get_workspace(workspace_id, user_id)
-    if workspace is None:
-        return False
-
-    deleted = await model.delete_workspace(workspace_id, user_id)
-    if deleted:
-        ws_dir = safe_path(workspace_id)
-        await _async_rmtree(ws_dir, f"workspace {workspace_id}")
-    return deleted
-
-
-def get_workspace_host_path(workspace_id: str) -> Path:
-    path = workspace_path(workspace_id)
-    path.mkdir(parents=True, exist_ok=True)
-    return path
-
-
-def get_home_host_path(workspace_id: str) -> Path:
-    path = home_path(workspace_id)
-    path.mkdir(parents=True, exist_ok=True)
-    return path
-
-
-# --- Handle management ---
 
 
 def _ensure_home_symlink_sync(
@@ -376,31 +93,6 @@ def _ensure_home_symlink_sync(
     return f"/home/{handle}", created
 
 
-async def ensure_home_symlink(
-    workspace_home: Path,
-    handle: str,
-    user_id: str,
-) -> tuple[str, bool]:
-    """Ensure the ``/home/{handle} -> .users/{user_id}`` symlink exists.
-
-    Creates the ``.users/{user_id}`` directory and symlink if missing.
-    If the symlink exists and already points to the right target, no-op.
-    If the handle changed (old symlink for this user_id exists), removes
-    the old one and creates the new one.
-
-    The blocking filesystem work runs in a worker thread via
-    ``asyncio.to_thread`` so connect / container-start paths do not
-    stall the event loop on disk latency (#1262).
-
-    Returns ``(container_home_path, created)`` where *created* is True
-    when a new user directory was created (caller should populate it
-    with skeleton files).
-    """
-    return await asyncio.to_thread(
-        _ensure_home_symlink_sync, workspace_home, handle, user_id
-    )
-
-
 async def populate_home_skel(
     container_id: str,
     user_id: str,
@@ -431,78 +123,411 @@ async def populate_home_skel(
         )
 
 
-async def start_workspace(ws: dict, app_state) -> tuple[str, str]:
-    """Start a container for a workspace immediately.
+class Workspaces:
+    """Workspace filesystem paths, CRUD, and lifecycle.
 
-    Thin wrapper around ``app_state.container_registry.start_container``
-    that unpacks the workspace dict. The agent home provisioning and the
-    service command firing happen at the single create choke point
-    inside ``start_container`` (see ``bringup.bringup``, #1244), so
-    they no longer live here.
-
-    ``idle_timeout`` is left at its default; only
-    ``auto_start_workspaces`` (the boot path) pins it to 0.
-
-    Returns ``(container_id, status)``.
+    Constructed once in :func:`build_app` and stored on
+    ``app.state.workspaces`` (#1484). The workspace root (``WORKSPACES_ROOT``)
+    and ``data_dir`` are computed at construction from settings — no
+    import-time env read (the frozen-at-import hazard).
     """
-    owner_id = ws["user_id"]
-    workspace_id = ws["id"]
-    host_path = str(get_workspace_host_path(workspace_id))
-    h_path = str(get_home_host_path(workspace_id))
-    cfg_path = str(get_config_host_path(workspace_id))
-    cid, status = await app_state.container_registry.start_container(
-        workspace_id,
-        host_path,
-        h_path,
-        ws.get("container_id"),
-        num_ports=ws.get("num_ports", container.DEFAULT_PORTS_PER_WORKSPACE),
-        image=ws.get("image"),
-        config_path=cfg_path,
-        extra_mounts=ws.get("mounts"),
-        extra_env=ws.get("env"),
-        user_id=owner_id,
-        health_check=ws.get("health_check"),
-        setup_state=ws.get("setup_state"),
-        service_command=ws.get("service_command"),
-    )
-    return cid, status
 
+    def __init__(self, app_state=None):
+        self.app_state = app_state
+        self.settings = app_state.settings
+        raw = self.settings.data_dir or str(Path.home() / ".klangk" / "data")
+        self.data_dir = Path(raw)
+        self.root = self.data_dir / "workspaces"
 
-async def auto_start_workspaces(app_state) -> int:
-    """Start containers for all workspaces with auto_start enabled.
+    # --- export/import helpers ---
 
-    Skipped entirely if ``KLANGK_ALLOW_AUTOSTART`` is not set.
-    Returns the number of containers started.
-    """
-    if not resolve_env_bool("KLANGK_ALLOW_AUTOSTART"):
-        return 0
+    def build_export_tar_args(
+        self,
+        output: str,
+        tmpdir: str,
+        home_dir: Path | None,
+    ) -> list[str]:
+        """Build GNU tar arguments for workspace export.
 
-    ws_list = await model.list_auto_start_workspaces()
-    started = 0
-    for i, ws in enumerate(ws_list):
-        if i > 0:
-            await asyncio.sleep(random.uniform(0.5, 2.0))
+        GNU tar stores symlinks as symlinks (not contents), so external
+        symlinks (e.g., -> /usr/bin/python3) are harmless in the archive —
+        they resolve correctly inside the container. No symlink filtering.
+
+        Args:
+            output: tar output path, or "-" for stdout.
+            tmpdir: directory containing workspace.json.
+            home_dir: workspace home directory, or None if it doesn't exist.
+        """
+        args = [
+            "tar",
+            "-czf",
+            output,
+            "-C",
+            tmpdir,
+            "workspace.json",
+        ]
+        if home_dir is not None and home_dir.exists():
+            ws_dir_name = home_dir.name
+            escaped = re.escape(ws_dir_name)
+            args.extend(
+                [
+                    f"--transform=s/^{escaped}/home/",
+                    "-C",
+                    str(home_dir.parent),
+                    ws_dir_name,
+                ]
+            )
+        return args
+
+    def workspace_metadata(self, ws: dict) -> dict:
+        """Extract export metadata from a workspace dict.
+
+        Includes the instance ID so that imports can verify the archive
+        came from the same Klangk instance.
+        """
+        return {
+            "name": ws["name"],
+            "instance_id": get_instance_id(),
+            "image": ws.get("image"),
+            "service_command": ws.get("service_command"),
+            "auto_start": ws.get("auto_start", False),
+            "mounts": ws.get("mounts"),
+            "env": ws.get("env"),
+            "health_check": ws.get("health_check"),
+            "num_ports": ws.get("num_ports", 5),
+        }
+
+    # --- path helpers (close over root) ---
+
+    def safe_path(self, *segments: str) -> Path:
+        """Build a path under the workspace root, raising ValueError on traversal."""
+        path = self.root.joinpath(*segments)
+        if not path.resolve().is_relative_to(self.root.resolve()):
+            raise ValueError(f"Path traversal blocked: {'/'.join(segments)}")
+        return path
+
+    def workspace_path(self, workspace_id: str) -> Path:
+        """Build path to /{root}/{workspace_id}/home/work"""
+        return self.home_path(workspace_id) / "work"
+
+    def home_path(self, workspace_id: str) -> Path:
+        """Build path to /{root}/{workspace_id}/home"""
+        return self.safe_path(workspace_id, "home")
+
+    def config_path(self, workspace_id: str) -> Path:
+        """Build path to /{root}/{workspace_id}/config"""
+        return self.safe_path(workspace_id, "config")
+
+    def get_config_host_path(self, workspace_id: str) -> Path:
+        path = self.config_path(workspace_id)
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def get_workspace_host_path(self, workspace_id: str) -> Path:
+        path = self.workspace_path(workspace_id)
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    def get_home_host_path(self, workspace_id: str) -> Path:
+        path = self.home_path(workspace_id)
+        path.mkdir(parents=True, exist_ok=True)
+        return path
+
+    # --- archive ---
+
+    async def build_workspace_archive(
+        self, metadata: dict, home_dir: Path, archive_path: Path
+    ) -> bool:
+        """Build a .tar.gz archive in the export/import format.
+
+        The archive contains workspace.json (metadata) and home/ (the home
+        directory tree).  Symlinks are stored as symlinks (not dereferenced).
+        Both home_dir and archive_path must resolve under the workspace root.
+        Returns True on success, False on failure.
+        """
+        # Validate that paths stay within the data directory.
+        for label, p in [
+            ("home_dir", home_dir),
+            ("archive_path", archive_path),
+        ]:
+            if p.exists() or p.parent.exists():
+                resolved = (p if p.exists() else p.parent).resolve()
+                if not resolved.is_relative_to(self.root.resolve()):
+                    logger.error("Path validation failed for %s: %s", label, p)
+                    return False
+
+        tmpdir = tempfile.mkdtemp()
         try:
-            cid, status = await start_workspace(ws, app_state)
-            # Auto-started containers are boot services: pin them alive
-            # so they do not idle out between user connections. Only the
-            # boot path does this -- create/restart use the default idle
-            # timeout (#1244).
-            state = app_state.container_registry.states.get(ws["id"])
-            if state:
-                state.idle_timeout = 0
-            logger.info(
-                "Auto-started workspace %s (%s): %s",
-                ws["name"],
-                cid[:12],
-                status,
+            meta_file = Path(tmpdir) / "workspace.json"
+            meta_file.write_text(json.dumps(metadata, indent=2))
+
+            tar_args = self.build_export_tar_args(
+                str(archive_path), tmpdir, home_dir
             )
-            started += 1
+
+            proc = await asyncio.create_subprocess_exec(
+                *tar_args,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            _, stderr = await asyncio.wait_for(proc.communicate(), timeout=300)
+
+            if proc.returncode != 0:
+                logger.error(
+                    "tar failed for %s: %s",
+                    archive_path.name,
+                    stderr.decode("utf-8", errors="replace"),
+                )
+                return False
+            return True
+        except (asyncio.TimeoutError, OSError) as e:
+            logger.error(
+                "Failed to build archive %s: %s", archive_path.name, e
+            )
+            return False
+        finally:
+            await _async_rmtree(tmpdir, "build_workspace_archive tmpdir")
+
+    async def archive_user_data(self, user_id: str, email: str) -> list[Path]:
+        """Archive each workspace to a .tar.gz in the export/import format.
+
+        Creates one archive per workspace containing workspace.json (metadata)
+        and home/ (the workspace home directory).  These archives can be
+        re-imported via ``POST /workspaces/import``.
+
+        Returns the list of created archive paths (may be empty).
+        After successful archival each workspace's data directory is removed.
+        """
+        safe_email = sanitize_filename(email)
+
+        # Page through every workspace (list_workspaces paginates).
+        archives: list[Path] = []
+        archived_ws_ids: list[str] = []
+        offset = 0
+        while True:
+            page = await model.list_workspaces(user_id, offset=offset)
+            user_workspaces = page["items"]
+            if not user_workspaces:
+                break
+            for ws in user_workspaces:
+                ws_name = sanitize_filename(ws["name"])
+                archive_name = f"{user_id}-{safe_email}-{ws_name}.tar.gz"
+                try:
+                    archive_path = self.safe_path(
+                        archive_name
+                    )  # lgtm[py/path-injection]
+                except ValueError:
+                    logger.error(
+                        "Archive path traversal blocked for workspace %s",
+                        ws["name"],
+                    )
+                    continue
+                home_dir = self.home_path(ws["id"])
+                metadata = self.workspace_metadata(ws)
+                if await self.build_workspace_archive(
+                    metadata, home_dir, archive_path
+                ):
+                    # lgtm[py/clear-text-logging-sensitive-data]
+                    logger.info(
+                        "Archived workspace %s to %s", ws["name"], archive_path
+                    )
+                    archives.append(archive_path)
+                    archived_ws_ids.append(ws["id"])
+            if not page["has_more"]:
+                break
+            offset = page["next_offset"]
+
+        # Remove each archived workspace's data directory.
+        for ws_id in archived_ws_ids:
+            ws_dir = self.safe_path(ws_id)
+            if ws_dir.exists():
+                await _async_rmtree(ws_dir, f"workspace data {ws_id}")
+        return archives
+
+    # --- CRUD ---
+
+    async def create_workspace(
+        self,
+        user_id: str,
+        name: str,
+        image: str | None = None,
+        service_command: str | None = None,
+        auto_start: bool = False,
+        mounts: list[str] | None = None,
+        env: dict[str, str] | None = None,
+        setup_state: str | None = None,
+        health_check: str | None = None,
+    ) -> dict:
+        workspace = await model.create_workspace_with_acl(
+            user_id,
+            name,
+            image=image,
+            service_command=service_command,
+            auto_start=auto_start,
+            mounts=mounts,
+            env=env,
+            setup_state=setup_state or model.SETUP_STATE_COMPLETE,
+            health_check=health_check,
+        )
+        home = self.home_path(workspace["id"])
+        home.mkdir(parents=True, exist_ok=True)
+        work = self.workspace_path(workspace["id"])
+        work.mkdir(parents=True, exist_ok=True)
+        users_dir = home / ".users"
+        users_dir.mkdir(exist_ok=True)
+        terminals_dir = home / ".terminals"
+        terminals_dir.mkdir(exist_ok=True)
+        # Allocate ports at creation time so ranges are sequential
+        try:
+            await self.app_state.container_registry.allocate_ports(
+                workspace["id"], workspace["num_ports"]
+            )
         except Exception:
-            logger.warning(
-                "Failed to auto-start workspace %s (%s)",
-                ws["name"],
-                ws["id"],
-                exc_info=True,
-            )
-    return started
+            # Clean up the DB record and directories on port allocation failure
+            await model.delete_workspace(workspace["id"], user_id)
+            await _async_rmtree(home, f"workspace {workspace['id']} rollback")
+            raise
+        return workspace
+
+    async def list_workspaces(
+        self,
+        user_id: str,
+        limit: int = 10,
+        offset: int = 0,
+        sort: str = "created",
+        order: str = "desc",
+        q: str | None = None,
+    ) -> dict:
+        return await model.list_workspaces(
+            user_id, limit, offset, sort, order, q
+        )
+
+    async def get_workspace(
+        self, workspace_id: str, user_id: str | None = None
+    ) -> dict | None:
+        return await model.get_workspace(workspace_id, user_id)
+
+    async def delete_workspace(self, workspace_id: str, user_id: str) -> bool:
+        workspace = await model.get_workspace(workspace_id, user_id)
+        if workspace is None:
+            return False
+
+        deleted = await model.delete_workspace(workspace_id, user_id)
+        if deleted:
+            ws_dir = self.safe_path(workspace_id)
+            await _async_rmtree(ws_dir, f"workspace {workspace_id}")
+        return deleted
+
+    # --- home symlink ---
+
+    async def ensure_home_symlink(
+        self,
+        workspace_home: Path,
+        handle: str,
+        user_id: str,
+    ) -> tuple[str, bool]:
+        """Ensure the ``/home/{handle} -> .users/{user_id}`` symlink exists.
+
+        Creates the ``.users/{user_id}`` directory and symlink if missing.
+        If the symlink exists and already points to the right target, no-op.
+        If the handle changed (old symlink for this user_id exists), removes
+        the old one and creates the new one.
+
+        The blocking filesystem work runs in a worker thread via
+        ``asyncio.to_thread`` so connect / container-start paths do not
+        stall the event loop on disk latency (#1262).
+
+        Returns ``(container_home_path, created)`` where *created* is True
+        when a new user directory was created (caller should populate it
+        with skeleton files).
+        """
+        return await asyncio.to_thread(
+            _ensure_home_symlink_sync, workspace_home, handle, user_id
+        )
+
+    async def populate_home_skel(
+        self,
+        container_id: str,
+        user_id: str,
+    ) -> None:
+        """Copy /etc/skel into a new user's home directory inside the container."""
+        await populate_home_skel(container_id, user_id, self.app_state.podman)
+
+    # --- lifecycle ---
+
+    async def start_workspace(self, ws: dict) -> tuple[str, str]:
+        """Start a container for a workspace immediately.
+
+        Thin wrapper around ``self.app_state.container_registry.start_container``
+        that unpacks the workspace dict. The agent home provisioning and the
+        service command firing happen at the single create choke point
+        inside ``start_container`` (see ``bringup.bringup``, #1244), so
+        they no longer live here.
+
+        ``idle_timeout`` is left at its default; only
+        ``auto_start_workspaces`` (the boot path) pins it to 0.
+
+        Returns ``(container_id, status)``.
+        """
+        owner_id = ws["user_id"]
+        workspace_id = ws["id"]
+        host_path = str(self.get_workspace_host_path(workspace_id))
+        h_path = str(self.get_home_host_path(workspace_id))
+        cfg_path = str(self.get_config_host_path(workspace_id))
+        cid, status = await self.app_state.container_registry.start_container(
+            workspace_id,
+            host_path,
+            h_path,
+            ws.get("container_id"),
+            num_ports=ws.get(
+                "num_ports", container.DEFAULT_PORTS_PER_WORKSPACE
+            ),
+            image=ws.get("image"),
+            config_path=cfg_path,
+            extra_mounts=ws.get("mounts"),
+            extra_env=ws.get("env"),
+            user_id=owner_id,
+            health_check=ws.get("health_check"),
+            setup_state=ws.get("setup_state"),
+            service_command=ws.get("service_command"),
+        )
+        return cid, status
+
+    async def auto_start_workspaces(self) -> int:
+        """Start containers for all workspaces with auto_start enabled.
+
+        Skipped entirely if ``KLANGK_ALLOW_AUTOSTART`` is not set.
+        Returns the number of containers started.
+        """
+        if not self.settings.allow_autostart:
+            return 0
+
+        ws_list = await model.list_auto_start_workspaces()
+        started = 0
+        for i, ws in enumerate(ws_list):
+            if i > 0:
+                await asyncio.sleep(random.uniform(0.5, 2.0))
+            try:
+                cid, status = await self.start_workspace(ws)
+                # Auto-started containers are boot services: pin them alive
+                # so they do not idle out between user connections. Only the
+                # boot path does this -- create/restart use the default idle
+                # timeout (#1244).
+                state = self.app_state.container_registry.states.get(ws["id"])
+                if state:
+                    state.idle_timeout = 0
+                logger.info(
+                    "Auto-started workspace %s (%s): %s",
+                    ws["name"],
+                    cid[:12],
+                    status,
+                )
+                started += 1
+            except Exception:
+                logger.warning(
+                    "Failed to auto-start workspace %s (%s)",
+                    ws["name"],
+                    ws["id"],
+                    exc_info=True,
+                )
+        return started

--- a/src/backend/klangk_backend/wshandler/connection.py
+++ b/src/backend/klangk_backend/wshandler/connection.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta, timezone
 
 
 from .. import acl as _acl
-from .. import agent, auth, container, model, workspaces
+from .. import agent, auth, container, model
 from ..terminal import TerminalSession
 from ..podman import ExecSession
 from ..util import derive_hosting_info
@@ -279,19 +279,25 @@ class Connection:
         self, workspace_id: str, workspace: dict
     ) -> None:
         """Start/restart container for a workspace."""
-        host_path = str(workspaces.get_workspace_host_path(workspace_id))
-        home_path = str(workspaces.get_home_host_path(workspace_id))
-        cfg_path = str(workspaces.get_config_host_path(workspace_id))
+        host_path = str(
+            self.app_state.workspaces.get_workspace_host_path(workspace_id)
+        )
+        home_path = str(
+            self.app_state.workspaces.get_home_host_path(workspace_id)
+        )
+        cfg_path = str(
+            self.app_state.workspaces.get_config_host_path(workspace_id)
+        )
 
         # Ensure the per-user home symlink exists BEFORE starting the
         # container, because mounts under /home/{handle}/ need the
         # symlink in place so podman doesn't auto-create a real dir.
         handle = await model.get_user_handle(self.user["id"])
-        workspace_home = workspaces.home_path(workspace_id)
+        workspace_home = self.app_state.workspaces.home_path(workspace_id)
         (
             self._user_home,
             self._home_created,
-        ) = await workspaces.ensure_home_symlink(
+        ) = await self.app_state.workspaces.ensure_home_symlink(
             workspace_home, handle, self.user["id"]
         )
 
@@ -363,8 +369,8 @@ class Connection:
         # Populate skeleton if this is a new user home (symlink was
         # created above, before container start).
         if self._home_created:
-            await workspaces.populate_home_skel(
-                container_id, self.user["id"], self.app_state.podman
+            await self.app_state.workspaces.populate_home_skel(
+                container_id, self.user["id"]
             )
 
         logger.info("Container ready for workspace %s", workspace_id)
@@ -420,7 +426,7 @@ class Connection:
         ):
             send_error(self.sock, "Permission denied")
             return
-        workspace = await workspaces.get_workspace(workspace_id)
+        workspace = await self.app_state.workspaces.get_workspace(workspace_id)
         if workspace is None:
             send_error(self.sock, "Workspace not found")
             return
@@ -528,7 +534,7 @@ class Connection:
             logger.warning("Cleanup error during restart: %s", e)
 
         if workspace is None:
-            workspace = await workspaces.get_workspace(
+            workspace = await self.app_state.workspaces.get_workspace(
                 workspace_id, user["id"]
             )
         if workspace is None:
@@ -867,15 +873,19 @@ class Connection:
             # Update the per-workspace symlink.
             workspace = self.workspace
             if workspace:
-                workspace_home = workspaces.home_path(self.workspace_id)
-                container_home, created = await workspaces.ensure_home_symlink(
+                workspace_home = self.app_state.workspaces.home_path(
+                    self.workspace_id
+                )
+                (
+                    container_home,
+                    created,
+                ) = await self.app_state.workspaces.ensure_home_symlink(
                     workspace_home, handle, self.user["id"]
                 )
                 if created and self.container_id:
-                    await workspaces.populate_home_skel(
+                    await self.app_state.workspaces.populate_home_skel(
                         self.container_id,
                         self.user["id"],
-                        self.app_state.podman,
                     )
                 self._user_home = container_home
             self.sock.send_json(

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -66,12 +66,9 @@ def temp_data_dir(tmp_path, monkeypatch):
     # to rebind — construct a fresh DB from settings).
     import klangk_backend.model as us
     import klangk_backend.model.db as us_core
-    import klangk_backend.workspaces as wm
     from klangk_backend.settings import KlangkSettings
 
     us_core.set_db(us_core.DB(KlangkSettings(os.environ)))
-    wm.data_dir = tmp_path
-    wm.WORKSPACES_ROOT = tmp_path / "workspaces"
     # Clear agent caches so each test starts fresh.
     us.clear_agent_cache()
     # Set a deterministic instance ID for tests that don't use the db
@@ -186,6 +183,32 @@ async def admin_user(admin_group):
     )
     await us.add_user_to_group(user["id"], admin_group["id"])
     return user
+
+
+@pytest.fixture
+def app_state(temp_data_dir):
+    """Build a minimal app_state with owned instances wired (#1484).
+
+    Shared across all test files — each test file that needs app_state
+    requests it rather than defining its own. Built fresh per test from
+    the temp_data_dir's settings so every owned instance points at the
+    per-test tmp dir.
+    """
+    import types
+
+    from klangk_backend.settings import KlangkSettings
+    from klangk_backend.container import ContainerRegistry
+    from klangk_backend.workspaces import Workspaces
+
+    settings = KlangkSettings(os.environ)
+    registry = ContainerRegistry(settings)
+    state = types.SimpleNamespace(
+        container_registry=registry,
+        settings=settings,
+    )
+    registry.app_state = state
+    state.workspaces = Workspaces(state)
+    return state
 
 
 @pytest.fixture

--- a/src/backend/tests/test_agent.py
+++ b/src/backend/tests/test_agent.py
@@ -10,6 +10,7 @@ from klangk_backend.agent import (
     AgentError,
     AgentProcessDied,
     AgentSession,
+    AgentSetupError,
     any_running,
     ensure_agent_home,
     get_session,
@@ -71,9 +72,11 @@ def _make_app_state(cid="cid"):
     mock_registry = MagicMock()
     mock_registry.get_state.return_value = _FakeContainerState(cid)
     mock_pod = MagicMock()
-    return types.SimpleNamespace(
+    app_state = types.SimpleNamespace(
         container_registry=mock_registry, podman=mock_pod
     )
+    app_state.workspaces = MagicMock()
+    return app_state
 
 
 def _make_session(workspace_id="ws-id"):
@@ -836,15 +839,8 @@ class TestGetSession:
 
 
 class TestEnsureAgentHome:
-    """Direct tests for the eager-provisioning function (#1157).
-
-    Called from start_workspace at container bring-up (every exec
-    process inherits $KLANGK_AGENT_HOME) and again from chat-start, which
-    caches the result per AgentSession (see TestEnsureHome).
-    """
-
     async def test_provisions_home_and_runs_setup(self, tmp_path):
-        from klangk_backend import model, workspaces
+        from klangk_backend import model
 
         fake_ws = {"user_id": "owner1"}
         fake_home = tmp_path / "home"
@@ -853,32 +849,31 @@ class TestEnsureAgentHome:
         mock_proc.communicate = AsyncMock(return_value=(b"", b""))
         mock_proc.returncode = 0
 
+        ws = MagicMock()
+        ws.home_path.return_value = fake_home
+        ws.ensure_home_symlink = AsyncMock(
+            return_value=("/home/clanker", True)
+        )
+        ws.populate_home_skel = AsyncMock()
+        app_state = MagicMock()
+        app_state.workspaces = ws
+        app_state.podman = _mock_pod
+
         with (
             patch.object(model, "get_workspace_by_id", return_value=fake_ws),
-            patch.object(workspaces, "home_path", return_value=fake_home),
-            patch.object(
-                workspaces,
-                "ensure_home_symlink",
-                new_callable=AsyncMock,
-                return_value=("/home/clanker", True),
-            ) as mock_symlink,
-            patch.object(
-                workspaces, "populate_home_skel", new_callable=AsyncMock
-            ) as mock_skel,
             patch(
                 "asyncio.create_subprocess_exec",
                 return_value=mock_proc,
             ) as mock_exec,
         ):
-            result = await ensure_agent_home("ws1", "cid", _mock_pod)
+            result = await ensure_agent_home("ws1", "cid", app_state)
 
         assert result == "/home/clanker"
-        mock_symlink.assert_called_once()
+        ws.ensure_home_symlink.assert_awaited_once()
         # Skeleton files only on first creation (created=True).
-        mock_skel.assert_awaited_once_with(
+        ws.populate_home_skel.assert_awaited_once_with(
             "cid",
             "00000000-0000-0000-0000-000000000001",
-            _mock_pod,
         )
         # klangk-setup-pi --force re-writes Pi config each time.  It's
         # invoked by its full install path (bare-name resolution isn't
@@ -895,7 +890,7 @@ class TestEnsureAgentHome:
         the lazy chat-start path retries on first mention (#1162).
         The return value (container home) is unaffected by the rc.
         """
-        from klangk_backend import agent, model, workspaces
+        from klangk_backend import agent, model
 
         fake_home = tmp_path / "home"
         fake_home.mkdir()
@@ -905,71 +900,73 @@ class TestEnsureAgentHome:
         )
         mock_proc.returncode = 127  # script missing / crashed
 
+        ws = MagicMock()
+        ws.home_path.return_value = fake_home
+        ws.ensure_home_symlink = AsyncMock(
+            return_value=("/home/clanker", True)
+        )
+        ws.populate_home_skel = AsyncMock()
+        app_state = MagicMock()
+        app_state.workspaces = ws
+        app_state.podman = _mock_pod
+
         with (
             patch.object(
                 model, "get_workspace_by_id", return_value={"user_id": "o"}
-            ),
-            patch.object(workspaces, "home_path", return_value=fake_home),
-            patch.object(
-                workspaces,
-                "ensure_home_symlink",
-                new_callable=AsyncMock,
-                return_value=("/home/clanker", True),
-            ),
-            patch.object(
-                workspaces, "populate_home_skel", new_callable=AsyncMock
             ),
             patch("asyncio.create_subprocess_exec", return_value=mock_proc),
         ):
             # Must NOT raise -- provisioning is best-effort.
-            result = await agent.ensure_agent_home("ws1", "cid", _mock_pod)
+            result = await agent.ensure_agent_home("ws1", "cid", app_state)
 
         assert result == "/home/clanker"
 
     async def test_skips_skel_when_home_already_exists(self, tmp_path):
-        from klangk_backend import model, workspaces
+        from klangk_backend import model
 
-        # created=False -> home dir already existed, no skel needed.
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+
+        ws = MagicMock()
+        ws.home_path.return_value = fake_home
+        # created=False means the user dir already exists -> no skel
+        ws.ensure_home_symlink = AsyncMock(
+            return_value=("/home/clanker", False)
+        )
+        ws.populate_home_skel = AsyncMock()
+        app_state = MagicMock()
+        app_state.workspaces = ws
+        app_state.podman = _mock_pod
+
         with (
             patch.object(
                 model, "get_workspace_by_id", return_value={"user_id": "o"}
             ),
-            patch.object(workspaces, "home_path", return_value=tmp_path),
-            patch.object(
-                workspaces,
-                "ensure_home_symlink",
-                new_callable=AsyncMock,
-                return_value=("/home/clanker", False),
-            ),
-            patch.object(
-                workspaces, "populate_home_skel", new_callable=AsyncMock
-            ) as mock_skel,
-            patch(
-                "asyncio.create_subprocess_exec",
-                return_value=AsyncMock(
-                    communicate=AsyncMock(return_value=(b"", b""))
-                ),
-            ),
         ):
-            result = await ensure_agent_home("ws1", "cid", _mock_pod)
+            result = await ensure_agent_home("ws1", "cid", app_state)
 
         assert result == "/home/clanker"
-        mock_skel.assert_not_awaited()
+        # created=False -> skel should NOT be called
+        ws.populate_home_skel.assert_not_awaited()
 
-    async def test_raises_when_workspace_missing(self):
+    async def test_workspace_not_found_raises(self):
         from klangk_backend import model
-        from klangk_backend.agent import AgentSetupError
+
+        ws = MagicMock()
+        app_state = MagicMock()
+        app_state.workspaces = ws
+        app_state.podman = _mock_pod
 
         with patch.object(model, "get_workspace_by_id", return_value=None):
-            with pytest.raises(AgentSetupError, match="not found in database"):
-                await ensure_agent_home("ws-gone", "cid", _mock_pod)
+            with pytest.raises(AgentSetupError, match="not found"):
+                await ensure_agent_home("ws-gone", "cid", app_state)
 
 
 class TestEnsureHome:
     async def test_ensure_home_creates_dir_and_runs_login_shell(
         self, tmp_path
     ):
-        from klangk_backend import model, workspaces
+        from klangk_backend import model
 
         session = AgentSession("ws1", app_state=_make_app_state())
 
@@ -981,28 +978,20 @@ class TestEnsureHome:
         mock_proc.communicate = AsyncMock(return_value=(b"", b""))
         mock_proc.returncode = 0
 
+        ws = MagicMock()
+        ws.home_path.return_value = fake_home
+        ws.ensure_home_symlink = AsyncMock(
+            return_value=("/home/clanker", True)
+        )
+        ws.populate_home_skel = AsyncMock()
+        session.app_state.workspaces = ws
+
         with (
             patch.object(
                 model,
                 "get_workspace_by_id",
                 return_value=fake_ws,
             ),
-            patch.object(
-                workspaces,
-                "home_path",
-                return_value=fake_home,
-            ),
-            patch.object(
-                workspaces,
-                "ensure_home_symlink",
-                new_callable=AsyncMock,
-                return_value=("/home/clanker", True),
-            ) as mock_symlink,
-            patch.object(
-                workspaces,
-                "populate_home_skel",
-                new_callable=AsyncMock,
-            ) as mock_skel,
             patch(
                 "asyncio.create_subprocess_exec",
                 return_value=mock_proc,
@@ -1012,11 +1001,10 @@ class TestEnsureHome:
 
         assert result == "/home/clanker"
         assert session._home_ready is True
-        mock_symlink.assert_called_once()
-        mock_skel.assert_awaited_once_with(
+        ws.ensure_home_symlink.assert_awaited_once()
+        ws.populate_home_skel.assert_awaited_once_with(
             "cid",
             "00000000-0000-0000-0000-000000000001",
-            session.app_state.podman,
         )
 
     async def test_ensure_home_cached(self):

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -34,13 +34,19 @@ _mock_pod = MagicMock()
 
 
 @pytest.fixture
-async def app(db):
+async def app(db, temp_data_dir):
     """Create a minimal FastAPI app with just the API router."""
     app = FastAPI()
     from klangk_backend.util import API_PREFIX
     from klangk_backend.main import register_exception_handlers
 
-    settings = KlangkSettings(env={"KLANGK_AUTH_MODES": "password"})
+    settings = KlangkSettings(
+        env={
+            "KLANGK_AUTH_MODES": "password",
+            "KLANGK_DATA_DIR": str(temp_data_dir),
+            "KLANGK_CUSTOMIZE_DIR": str(temp_data_dir / "customize"),
+        }
+    )
     registry = ContainerRegistry(settings)
     sockets = WebSocketState()
     app.state.settings = settings
@@ -53,6 +59,7 @@ async def app(db):
     registry.podman = _mock_pod
     app.state.oidc = oidc_mod.OIDC(app.state)
     app.state.plugins = plugins_mod.Plugins(app.state)
+    app.state.workspaces = ws_mod.Workspaces(app.state)
     agent.get_workspace_session = sockets.get_session
 
     app.include_router(api.root_router)
@@ -1507,12 +1514,13 @@ class TestWorkspaceRoutes:
         assert resp.status_code == 400
         assert "Auto-start is not enabled" in resp.json()["detail"]
 
-    async def test_create_auto_start_allowed_with_env(self, client, user):
+    async def test_create_auto_start_allowed_with_env(self, client, app, user):
         headers = await _auth_headers(client)
         with (
             patch.dict(os.environ, {"KLANGK_ALLOW_AUTOSTART": "1"}),
-            patch(
-                "klangk_backend.workspaces.start_workspace",
+            patch.object(
+                app.state.workspaces,
+                "start_workspace",
                 new_callable=AsyncMock,
             ) as mock_start,
         ):
@@ -1525,12 +1533,15 @@ class TestWorkspaceRoutes:
         assert resp.json()["auto_start"] is True
         mock_start.assert_awaited_once()
 
-    async def test_create_auto_start_eager_failure_logged(self, client, user):
+    async def test_create_auto_start_eager_failure_logged(
+        self, client, app, user
+    ):
         headers = await _auth_headers(client)
         with (
             patch.dict(os.environ, {"KLANGK_ALLOW_AUTOSTART": "1"}),
-            patch(
-                "klangk_backend.workspaces.start_workspace",
+            patch.object(
+                app.state.workspaces,
+                "start_workspace",
                 new_callable=AsyncMock,
                 side_effect=RuntimeError("podman broke"),
             ),
@@ -1721,7 +1732,7 @@ class TestWorkspaceRoutes:
         # Deleter is the owner here, so exactly one notify call for them.
         mock_notify.assert_called_once_with(user["id"])
 
-    async def test_restart_workspace(self, client, user, registry):
+    async def test_restart_workspace(self, client, app, user, registry):
         headers = await _auth_headers(client)
         create_resp = await client.post(
             "/api/v1/workspaces", headers=headers, json={"name": "restart-me"}
@@ -1737,8 +1748,9 @@ class TestWorkspaceRoutes:
                 "stop_and_remove_container",
                 new_callable=AsyncMock,
             ) as mock_stop,
-            patch(
-                "klangk_backend.workspaces.start_workspace",
+            patch.object(
+                app.state.workspaces,
+                "start_workspace",
                 new_callable=AsyncMock,
             ) as mock_start,
         ):
@@ -4950,7 +4962,7 @@ class TestAdminEndpoints:
         )
         assert resp.status_code == 403
 
-    async def test_delete_user(self, client, admin_user, user, registry):
+    async def test_delete_user(self, client, app, admin_user, user, registry):
         headers = await self._admin_headers(client)
         with (
             patch.object(
@@ -4958,7 +4970,11 @@ class TestAdminEndpoints:
                 "stop_user_containers",
                 new_callable=AsyncMock,
             ),
-            patch.object(ws_mod, "archive_user_data", new_callable=AsyncMock),
+            patch.object(
+                app.state.workspaces,
+                "archive_user_data",
+                new_callable=AsyncMock,
+            ),
         ):
             resp = await client.delete(
                 f"/api/v1/admin/users/{user['id']}", headers=headers
@@ -5606,7 +5622,7 @@ class TestAdminResourceACL:
         )
         assert resp.status_code == 200
 
-    async def test_get_resource_acl_requires_admin(self, client, user):
+    async def test_get_resource_acl_requires_admin(self, client, app, user):
         headers = await _auth_headers(client)
         resp = await client.get(
             "/api/v1/admin/acl/resource?resource=/workspaces", headers=headers
@@ -5680,13 +5696,13 @@ class TestAdminResourceACL:
 
 
 class TestSafePath:
-    def test_valid_path(self, temp_data_dir):
-        path = ws_mod.safe_path("user1", "home", "ws1")
-        assert path == ws_mod.WORKSPACES_ROOT / "user1" / "home" / "ws1"
+    def test_valid_path(self, temp_data_dir, app):
+        path = app.state.workspaces.safe_path("user1", "home", "ws1")
+        assert path == app.state.workspaces.root / "user1" / "home" / "ws1"
 
-    def test_traversal_raises(self, temp_data_dir):
+    def test_traversal_raises(self, temp_data_dir, app):
         with pytest.raises(ValueError, match="Path traversal blocked"):
-            ws_mod.safe_path("..", "..", "etc", "passwd")
+            app.state.workspaces.safe_path("..", "..", "etc", "passwd")
 
 
 class TestSanitizeFilename:
@@ -5705,14 +5721,14 @@ class TestSanitizeFilename:
 
 
 class TestRmtree:
-    def test_removes_directory(self, temp_data_dir):
+    def test_removes_directory(self, temp_data_dir, app):
         d = temp_data_dir / "workspaces" / "toremove"
         d.mkdir(parents=True)
         (d / "file.txt").write_text("data")
         ws_mod.rmtree(d, "test")
         assert not d.exists()
 
-    def test_logs_errors(self, temp_data_dir, caplog):
+    def test_logs_errors(self, temp_data_dir, caplog, app):
         """Logs warnings on individual file removal failures."""
         d = temp_data_dir / "workspaces" / "failremove"
         d.mkdir(parents=True)
@@ -5730,12 +5746,12 @@ class TestRmtree:
 
 
 class TestBuildWorkspaceArchive:
-    async def test_builds_importable_archive(self, temp_data_dir):
+    async def test_builds_importable_archive(self, temp_data_dir, app):
         """Archive contains workspace.json and home/ directory."""
         import json
         import subprocess
 
-        ws_root = ws_mod.WORKSPACES_ROOT
+        ws_root = app.state.workspaces.root
         ws_root.mkdir(parents=True, exist_ok=True)
         home_dir = ws_root / "user1" / "home" / "ws1"
         home_dir.mkdir(parents=True)
@@ -5744,7 +5760,7 @@ class TestBuildWorkspaceArchive:
         metadata = {"name": "myws", "image": None, "num_ports": 5}
         archive_path = ws_root / "test.tar.gz"
 
-        result = await ws_mod.build_workspace_archive(
+        result = await app.state.workspaces.build_workspace_archive(
             metadata, home_dir, archive_path
         )
         assert result is True
@@ -5769,25 +5785,25 @@ class TestBuildWorkspaceArchive:
         meta = json.loads(meta_out.stdout)
         assert meta["name"] == "myws"
 
-    async def test_builds_archive_without_home(self, temp_data_dir):
+    async def test_builds_archive_without_home(self, temp_data_dir, app):
         """Archive works when home directory doesn't exist."""
-        ws_root = ws_mod.WORKSPACES_ROOT
+        ws_root = app.state.workspaces.root
         ws_root.mkdir(parents=True, exist_ok=True)
         home_dir = ws_root / "nonexistent"
         metadata = {"name": "empty"}
         archive_path = ws_root / "empty.tar.gz"
 
-        result = await ws_mod.build_workspace_archive(
+        result = await app.state.workspaces.build_workspace_archive(
             metadata, home_dir, archive_path
         )
         assert result is True
         assert archive_path.exists()
 
-    async def test_excludes_external_symlinks(self, temp_data_dir):
+    async def test_excludes_external_symlinks(self, temp_data_dir, app):
         """Symlinks pointing outside home_dir are excluded."""
         import subprocess
 
-        ws_root = ws_mod.WORKSPACES_ROOT
+        ws_root = app.state.workspaces.root
         ws_root.mkdir(parents=True, exist_ok=True)
         home_dir = ws_root / "user1" / "home" / "ws1"
         home_dir.mkdir(parents=True)
@@ -5798,7 +5814,7 @@ class TestBuildWorkspaceArchive:
         metadata = {"name": "test"}
         archive_path = ws_root / "symtest.tar.gz"
 
-        result = await ws_mod.build_workspace_archive(
+        result = await app.state.workspaces.build_workspace_archive(
             metadata, home_dir, archive_path
         )
         assert result is True
@@ -5814,9 +5830,9 @@ class TestBuildWorkspaceArchive:
         assert any("external_link" in m for m in members)
         assert any("relative_link" in m for m in members)
 
-    async def test_tar_failure_returns_false(self, temp_data_dir):
+    async def test_tar_failure_returns_false(self, temp_data_dir, app):
         """Returns False when tar exits non-zero."""
-        ws_root = ws_mod.WORKSPACES_ROOT
+        ws_root = app.state.workspaces.root
         ws_root.mkdir(parents=True, exist_ok=True)
         home_dir = ws_root / "home"
         home_dir.mkdir()
@@ -5828,14 +5844,14 @@ class TestBuildWorkspaceArchive:
         mock_proc.returncode = 1
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
-            result = await ws_mod.build_workspace_archive(
+            result = await app.state.workspaces.build_workspace_archive(
                 metadata, home_dir, archive_path
             )
         assert result is False
 
-    async def test_oserror_returns_false(self, temp_data_dir):
+    async def test_oserror_returns_false(self, temp_data_dir, app):
         """Returns False when tar cannot be started."""
-        ws_root = ws_mod.WORKSPACES_ROOT
+        ws_root = app.state.workspaces.root
         ws_root.mkdir(parents=True, exist_ok=True)
         home_dir = ws_root / "home"
         metadata = {"name": "fail"}
@@ -5844,25 +5860,36 @@ class TestBuildWorkspaceArchive:
         with patch(
             "asyncio.create_subprocess_exec", side_effect=OSError("no tar")
         ):
-            result = await ws_mod.build_workspace_archive(
+            result = await app.state.workspaces.build_workspace_archive(
                 metadata, home_dir, archive_path
             )
         assert result is False
 
-    async def test_path_outside_workspaces_root_rejected(self, temp_data_dir):
+    async def test_path_outside_workspaces_root_rejected(
+        self, temp_data_dir, app
+    ):
         """Returns False if paths are outside WORKSPACES_ROOT."""
         home_dir = temp_data_dir / "outside"
         home_dir.mkdir(parents=True)
         metadata = {"name": "bad"}
         archive_path = temp_data_dir / "bad.tar.gz"
 
-        result = await ws_mod.build_workspace_archive(
+        result = await app.state.workspaces.build_workspace_archive(
             metadata, home_dir, archive_path
         )
         assert result is False
 
 
 class TestWorkspaceMetadata:
+    def _ws(self):
+        """Build a Workspaces instance for testing (#1484)."""
+        from klangk_backend.settings import KlangkSettings
+        import types as types_mod
+
+        return ws_mod.Workspaces(
+            types_mod.SimpleNamespace(settings=KlangkSettings(env={}))
+        )
+
     def test_extracts_metadata(self):
         from klangk_backend.model.instance import get_instance_id
 
@@ -5875,7 +5902,7 @@ class TestWorkspaceMetadata:
             "env": {"FOO": "bar"},
             "num_ports": 3,
         }
-        meta = ws_mod.workspace_metadata(ws)
+        meta = self._ws().workspace_metadata(ws)
         assert meta == {
             "name": "myws",
             "instance_id": get_instance_id(),
@@ -5889,29 +5916,33 @@ class TestWorkspaceMetadata:
         }
 
     def test_defaults_num_ports(self):
-        meta = ws_mod.workspace_metadata({"name": "x"})
+        meta = self._ws().workspace_metadata({"name": "x"})
         assert meta["num_ports"] == 5
 
     def test_includes_instance_id(self):
         from klangk_backend.model.instance import get_instance_id
 
-        meta = ws_mod.workspace_metadata({"name": "x"})
+        meta = self._ws().workspace_metadata({"name": "x"})
         assert meta["instance_id"] == get_instance_id()
 
 
 class TestArchiveUserData:
-    async def test_archive_creates_importable_tarballs(self, user, workspace):
+    async def test_archive_creates_importable_tarballs(
+        self, user, workspace, app
+    ):
         """Creates one .tar.gz per workspace in export format."""
         import json
         import subprocess
 
         # Put a file in the workspace home directory
-        home_dir = ws_mod.home_path(workspace["id"])
+        home_dir = app.state.workspaces.home_path(workspace["id"])
         home_dir.mkdir(parents=True, exist_ok=True)
         (home_dir / "hello.txt").write_text("test content")
 
-        ws_dir = ws_mod.WORKSPACES_ROOT / workspace["id"]
-        result = await ws_mod.archive_user_data(user["id"], user["email"])
+        ws_dir = app.state.workspaces.root / workspace["id"]
+        result = await app.state.workspaces.archive_user_data(
+            user["id"], user["email"]
+        )
         assert len(result) == 1
         archive = result[0]
         assert archive.exists()
@@ -5937,46 +5968,56 @@ class TestArchiveUserData:
         members = listing.stdout.strip().split("\n")
         assert any(m.startswith("home/") or m == "home" for m in members)
 
-    async def test_archive_multiple_workspaces(self, user):
+    async def test_archive_multiple_workspaces(self, user, app):
         """Creates separate archives for each workspace."""
         ws1 = await model.create_workspace(user["id"], "ws-one")
         ws2 = await model.create_workspace(user["id"], "ws-two")
 
         for ws in [ws1, ws2]:
-            home = ws_mod.home_path(ws["id"])
+            home = app.state.workspaces.home_path(ws["id"])
             home.mkdir(parents=True, exist_ok=True)
             (home / "file.txt").write_text("data")
 
-        result = await ws_mod.archive_user_data(user["id"], user["email"])
+        result = await app.state.workspaces.archive_user_data(
+            user["id"], user["email"]
+        )
         assert len(result) == 2
         names = {a.name for a in result}
         assert any("ws-one" in n for n in names)
         assert any("ws-two" in n for n in names)
 
-    async def test_archive_paginates_more_than_one_page(self, user):
+    async def test_archive_paginates_more_than_one_page(self, user, app):
         """Archival pages through every workspace when there are >10."""
         for i in range(12):
             ws = await model.create_workspace(user["id"], f"ws-{i:02d}")
-            home = ws_mod.home_path(ws["id"])
+            home = app.state.workspaces.home_path(ws["id"])
             home.mkdir(parents=True, exist_ok=True)
             (home / "file.txt").write_text("data")
 
-        result = await ws_mod.archive_user_data(user["id"], user["email"])
+        result = await app.state.workspaces.archive_user_data(
+            user["id"], user["email"]
+        )
         assert len(result) == 12
 
-    async def test_archive_no_data_dir(self, user):
+    async def test_archive_no_data_dir(self, user, app):
         """Returns empty list if user has no data directory."""
-        result = await ws_mod.archive_user_data(user["id"], user["email"])
+        result = await app.state.workspaces.archive_user_data(
+            user["id"], user["email"]
+        )
         assert result == []
 
-    async def test_archive_no_workspaces(self, user):
+    async def test_archive_no_workspaces(self, user, app):
         """Returns empty list if user has no workspaces."""
-        result = await ws_mod.archive_user_data(user["id"], user["email"])
+        result = await app.state.workspaces.archive_user_data(
+            user["id"], user["email"]
+        )
         assert result == []
 
-    async def test_archive_tar_failure_skips_workspace(self, user, workspace):
+    async def test_archive_tar_failure_skips_workspace(
+        self, user, workspace, app
+    ):
         """Skips workspaces where tar fails, doesn't remove workspace dir."""
-        home_dir = ws_mod.home_path(workspace["id"])
+        home_dir = app.state.workspaces.home_path(workspace["id"])
         home_dir.mkdir(parents=True, exist_ok=True)
 
         mock_proc = AsyncMock()
@@ -5984,34 +6025,36 @@ class TestArchiveUserData:
         mock_proc.returncode = 1
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
-            result = await ws_mod.archive_user_data(user["id"], user["email"])
+            result = await app.state.workspaces.archive_user_data(
+                user["id"], user["email"]
+            )
         assert result == []
         # Workspace dir not removed since no archives were created
-        ws_dir = ws_mod.WORKSPACES_ROOT / workspace["id"]
+        ws_dir = app.state.workspaces.root / workspace["id"]
         assert ws_dir.exists()
 
-    async def test_archive_sanitizes_email(self, user, workspace):
+    async def test_archive_sanitizes_email(self, user, workspace, app):
         """Email with path separators is sanitized in archive filename."""
-        home_dir = ws_mod.home_path(workspace["id"])
+        home_dir = app.state.workspaces.home_path(workspace["id"])
         home_dir.mkdir(parents=True, exist_ok=True)
 
-        result = await ws_mod.archive_user_data(
+        result = await app.state.workspaces.archive_user_data(
             user["id"], "user/../../etc/passwd"
         )
         assert len(result) == 1
         archive = result[0]
         assert archive.resolve().is_relative_to(
-            ws_mod.WORKSPACES_ROOT.resolve()
+            app.state.workspaces.root.resolve()
         )
         # Slashes are replaced with underscores
         assert "/" not in archive.name
         assert "\\" not in archive.name
 
-    async def test_archive_path_traversal_blocked(self, user, workspace):
+    async def test_archive_path_traversal_blocked(self, user, workspace, app):
         """Skips workspace if archive path would escape WORKSPACES_ROOT."""
         from pathlib import PosixPath
 
-        home_dir = ws_mod.home_path(workspace["id"])
+        home_dir = app.state.workspaces.home_path(workspace["id"])
         home_dir.mkdir(parents=True, exist_ok=True)
 
         orig_is_relative_to = PosixPath.is_relative_to
@@ -6022,7 +6065,9 @@ class TestArchiveUserData:
             return orig_is_relative_to(self, other)
 
         with patch.object(PosixPath, "is_relative_to", fake_is_relative_to):
-            result = await ws_mod.archive_user_data(user["id"], user["email"])
+            result = await app.state.workspaces.archive_user_data(
+                user["id"], user["email"]
+            )
         assert result == []
 
 
@@ -6052,7 +6097,7 @@ class TestWorkspaceExportImport:
         d.update(overrides)
         return d
 
-    async def test_export_workspace(self, client, admin_user, user):
+    async def test_export_workspace(self, client, admin_user, user, app):
         # Create a workspace as regular user
         headers = await self._user_headers(client)
         resp = await client.post(
@@ -6062,9 +6107,8 @@ class TestWorkspaceExportImport:
         ws = resp.json()
 
         # Write a file into the workspace home dir
-        import klangk_backend.workspaces as ws_mod
 
-        home = ws_mod.home_path(ws["id"])
+        home = app.state.workspaces.home_path(ws["id"])
         home.mkdir(parents=True, exist_ok=True)
         (home / "work").mkdir(exist_ok=True)
         (home / "work" / "hello.txt").write_text("hello world")
@@ -6094,7 +6138,7 @@ class TestWorkspaceExportImport:
             assert metadata["name"] == "export-test"
             assert "instance_id" in metadata
 
-    async def test_export_requires_admin(self, client, user):
+    async def test_export_requires_admin(self, client, user, app):
         headers = await self._user_headers(client)
         resp = await client.post(
             "/api/v1/workspaces", headers=headers, json={"name": "no-export"}
@@ -6107,14 +6151,14 @@ class TestWorkspaceExportImport:
         )
         assert resp.status_code == 403
 
-    async def test_export_not_found(self, client, admin_user):
+    async def test_export_not_found(self, client, admin_user, app):
         headers = await self._admin_headers(client)
         resp = await client.get(
             "/api/v1/workspaces/nonexistent-id/export", headers=headers
         )
         assert resp.status_code == 404
 
-    async def test_import_workspace(self, client, admin_user, user):
+    async def test_import_workspace(self, client, admin_user, user, app):
         # Create and export a workspace
         headers = await self._user_headers(client)
         resp = await client.post(
@@ -6128,9 +6172,7 @@ class TestWorkspaceExportImport:
         )
         ws = resp.json()
 
-        import klangk_backend.workspaces as ws_mod
-
-        home = ws_mod.home_path(ws["id"])
+        home = app.state.workspaces.home_path(ws["id"])
         home.mkdir(parents=True, exist_ok=True)
         (home / "work").mkdir(exist_ok=True)
         (home / "work" / "data.txt").write_text("test data")
@@ -6159,7 +6201,7 @@ class TestWorkspaceExportImport:
         assert imported["name"] == "imported-ws"
 
         # Verify the home dir was extracted
-        new_home = ws_mod.home_path(imported["id"])
+        new_home = app.state.workspaces.home_path(imported["id"])
         assert (new_home / "work" / "data.txt").exists()
         assert (new_home / "work" / "data.txt").read_text() == "test data"
 
@@ -6364,7 +6406,7 @@ class TestWorkspaceExportImport:
         assert resp.status_code == 200
         ws = resp.json()
 
-        home = ws_mod.home_path(ws["id"])
+        home = app.state.workspaces.home_path(ws["id"])
         home.mkdir(parents=True, exist_ok=True)
         (home / "f.txt").write_text("x")
 
@@ -6498,7 +6540,7 @@ class TestWorkspaceExportImport:
         assert resp.status_code == 200
         assert resp.json()["name"] == "img-fallback"
 
-    async def test_import_invalid_mounts_dropped(self, client, user):
+    async def test_import_invalid_mounts_dropped(self, client, app, user):
         """Archive with invalid mounts drops them silently."""
         import io
         import json
@@ -6525,7 +6567,7 @@ class TestWorkspaceExportImport:
         assert resp.status_code == 200
         assert resp.json()["name"] == "mount-drop"
 
-    async def test_import_home_root_member_skipped(self, client, user):
+    async def test_import_home_root_member_skipped(self, client, user, app):
         """The bare 'home/' directory entry is skipped during extraction."""
         import io
         import json
@@ -6560,10 +6602,8 @@ class TestWorkspaceExportImport:
         )
         assert resp.status_code == 200
 
-        import klangk_backend.workspaces as ws_mod
-
         ws = resp.json()
-        home = ws_mod.home_path(ws["id"])
+        home = app.state.workspaces.home_path(ws["id"])
         assert (home / "test.txt").exists()
 
     async def test_export_streams_valid_tarball(
@@ -6576,9 +6616,7 @@ class TestWorkspaceExportImport:
         )
         ws = resp.json()
 
-        import klangk_backend.workspaces as ws_mod
-
-        home = ws_mod.home_path(ws["id"])
+        home = app.state.workspaces.home_path(ws["id"])
         home.mkdir(parents=True, exist_ok=True)
         (home / "work").mkdir(exist_ok=True)
         (home / "work" / "file.txt").write_text("streamed content")
@@ -6601,7 +6639,9 @@ class TestWorkspaceExportImport:
             assert "workspace.json" in names
             assert any("file.txt" in n for n in names)
 
-    async def test_export_large_file_chunks(self, client, admin_user, user):
+    async def test_export_large_file_chunks(
+        self, client, admin_user, user, app
+    ):
         """Export with large files triggers the write buffer flush path."""
         headers = await self._user_headers(client)
         resp = await client.post(
@@ -6611,9 +6651,7 @@ class TestWorkspaceExportImport:
         )
         ws = resp.json()
 
-        import klangk_backend.workspaces as ws_mod
-
-        home = ws_mod.home_path(ws["id"])
+        home = app.state.workspaces.home_path(ws["id"])
         home.mkdir(parents=True, exist_ok=True)
         (home / "work").mkdir(exist_ok=True)
         # Write a large file with random data (incompressible, so gzip
@@ -6647,9 +6685,7 @@ class TestWorkspaceExportImport:
         )
         ws = resp.json()
 
-        import klangk_backend.workspaces as ws_mod
-
-        home = ws_mod.home_path(ws["id"])
+        home = app.state.workspaces.home_path(ws["id"])
         home.mkdir(parents=True, exist_ok=True)
         (home / "work").mkdir(exist_ok=True)
         (home / "work" / "f.txt").write_text("data")
@@ -6673,7 +6709,7 @@ class TestWorkspaceExportImport:
         # Falls back to 0 * 0.4 = 0, clamped to 1
         assert resp.headers["x-estimated-size"] == "1"
 
-    async def test_export_empty_workspace(self, client, admin_user, user):
+    async def test_export_empty_workspace(self, client, app, admin_user, user):
         """Export of workspace with no home dir still works."""
         headers = await self._user_headers(client)
         resp = await client.post(
@@ -6744,9 +6780,7 @@ class TestWorkspaceExportImport:
         )
         ws = resp.json()
 
-        import klangk_backend.workspaces as ws_mod
-
-        home = ws_mod.home_path(ws["id"])
+        home = app.state.workspaces.home_path(ws["id"])
         home.mkdir(parents=True, exist_ok=True)
         (home / "work").mkdir(exist_ok=True)
         (home / "work" / "real.txt").write_text("real file")
@@ -6773,7 +6807,9 @@ class TestWorkspaceExportImport:
             assert ext[0].issym()
             assert ext[0].linkname == "/etc/passwd"
 
-    async def test_export_import_deep_nesting(self, client, admin_user, user):
+    async def test_export_import_deep_nesting(
+        self, client, admin_user, user, app
+    ):
         """Export and import a workspace with deep directory nesting."""
         import random
         import tarfile
@@ -6784,9 +6820,7 @@ class TestWorkspaceExportImport:
         )
         ws = resp.json()
 
-        import klangk_backend.workspaces as ws_mod
-
-        home = ws_mod.home_path(ws["id"])
+        home = app.state.workspaces.home_path(ws["id"])
         home.mkdir(parents=True, exist_ok=True)
 
         # Create a deep directory structure with files at various depths
@@ -6858,7 +6892,7 @@ class TestWorkspaceExportImport:
         assert imported["name"] == "deep-imported"
 
         # Verify all files survived
-        imported_home = ws_mod.home_path(imported["id"])
+        imported_home = app.state.workspaces.home_path(imported["id"])
         for rel, content in expected_files.items():
             file_path = imported_home / rel
             assert file_path.exists(), f"Missing after import: {rel}"

--- a/src/backend/tests/test_bringup.py
+++ b/src/backend/tests/test_bringup.py
@@ -35,7 +35,7 @@ class TestBringup:
                 setup_state="complete",
                 app_state=_app_state,
             )
-        mock_home.assert_awaited_once_with("ws-id", "cid", _app_state.podman)
+        mock_home.assert_awaited_once_with("ws-id", "cid", _app_state)
         _app_state.terminal.ensure_service_session.assert_awaited_once_with(
             "cid",
             "/home/clanker",
@@ -53,7 +53,7 @@ class TestBringup:
             await bringup.bringup(
                 "ws-id", "cid", None, "complete", app_state=_app_state
             )
-        mock_home.assert_awaited_once_with("ws-id", "cid", _app_state.podman)
+        mock_home.assert_awaited_once_with("ws-id", "cid", _app_state)
         _app_state.terminal.ensure_service_session.assert_not_awaited()
 
     async def test_skips_service_command_when_empty(self):

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -44,6 +44,9 @@ def _make_app_state(registry=None, sockets=None):
 
     app_state.terminal = Terminal(app_state)
     app_state.plugins = plugins_mod.Plugins(app_state)
+    from klangk_backend.workspaces import Workspaces
+
+    app_state.workspaces = Workspaces(app_state)
     return app_state
 
 
@@ -2439,9 +2442,14 @@ class TestHealthMonitorRunOne:
             patch.object(
                 model, "get_user_handle", AsyncMock(return_value="owner")
             ),
-            patch("klangk_backend.workspaces.home_path", return_value="/h/p"),
-            patch(
-                "klangk_backend.workspaces.ensure_home_symlink",
+            patch.object(
+                monitor._registry.app_state.workspaces,
+                "home_path",
+                return_value="/h/p",
+            ),
+            patch.object(
+                monitor._registry.app_state.workspaces,
+                "ensure_home_symlink",
                 new_callable=AsyncMock,
                 return_value=("/home/klangk", False),
             ),
@@ -2477,9 +2485,14 @@ class TestHealthMonitorRunOne:
             patch.object(
                 model, "get_user_handle", AsyncMock(return_value="owner")
             ),
-            patch("klangk_backend.workspaces.home_path", return_value="/h/p"),
-            patch(
-                "klangk_backend.workspaces.ensure_home_symlink",
+            patch.object(
+                monitor._registry.app_state.workspaces,
+                "home_path",
+                return_value="/h/p",
+            ),
+            patch.object(
+                monitor._registry.app_state.workspaces,
+                "ensure_home_symlink",
                 new_callable=AsyncMock,
                 return_value=("/home/klangk", False),
             ),
@@ -2502,9 +2515,14 @@ class TestHealthMonitorRunOne:
             patch.object(
                 model, "get_user_handle", AsyncMock(return_value="owner")
             ),
-            patch("klangk_backend.workspaces.home_path", return_value="/h/p"),
-            patch(
-                "klangk_backend.workspaces.ensure_home_symlink",
+            patch.object(
+                monitor._registry.app_state.workspaces,
+                "home_path",
+                return_value="/h/p",
+            ),
+            patch.object(
+                monitor._registry.app_state.workspaces,
+                "ensure_home_symlink",
                 new_callable=AsyncMock,
                 return_value=("/home/klangk", False),
             ),
@@ -2527,9 +2545,14 @@ class TestHealthMonitorRunOne:
             patch.object(
                 model, "get_user_handle", AsyncMock(return_value="owner")
             ),
-            patch("klangk_backend.workspaces.home_path", return_value="/h/p"),
-            patch(
-                "klangk_backend.workspaces.ensure_home_symlink",
+            patch.object(
+                monitor._registry.app_state.workspaces,
+                "home_path",
+                return_value="/h/p",
+            ),
+            patch.object(
+                monitor._registry.app_state.workspaces,
+                "ensure_home_symlink",
                 new_callable=AsyncMock,
                 return_value=("/home/klangk", False),
             ),
@@ -2562,9 +2585,14 @@ class TestHealthMonitorRunOne:
             patch.object(
                 model, "get_user_handle", AsyncMock(return_value="owner")
             ),
-            patch("klangk_backend.workspaces.home_path", return_value="/h/p"),
-            patch(
-                "klangk_backend.workspaces.ensure_home_symlink",
+            patch.object(
+                monitor._registry.app_state.workspaces,
+                "home_path",
+                return_value="/h/p",
+            ),
+            patch.object(
+                monitor._registry.app_state.workspaces,
+                "ensure_home_symlink",
                 new_callable=AsyncMock,
                 return_value=("/home/klangk", False),
             ),

--- a/src/backend/tests/test_main.py
+++ b/src/backend/tests/test_main.py
@@ -13,7 +13,7 @@ from fastapi import FastAPI
 from httpx import AsyncClient, ASGITransport
 from sqlalchemy.exc import IntegrityError as SAIntegrityError
 
-from klangk_backend import main, model, oidc, plugins
+from klangk_backend import main, model, oidc, plugins, workspaces
 from klangk_backend.container import ContainerRegistry
 from klangk_backend.settings import KlangkSettings
 from klangk_backend.wshandler.session import WebSocketState
@@ -38,6 +38,9 @@ def _make_app_state(settings=None):
 
     registry.podman = Podman(settings)
     app_state.podman = registry.podman
+    app_state.oidc = oidc.OIDC(app_state)
+    app_state.plugins = plugins.Plugins(app_state)
+    app_state.workspaces = workspaces.Workspaces(app_state)
     return app_state
 
 
@@ -105,6 +108,7 @@ def _bind_safety_app_state(auth_mode=None):
     app_state = types.SimpleNamespace(settings=settings)
     app_state.oidc = oidc.OIDC(app_state)
     app_state.plugins = plugins.Plugins(app_state)
+    app_state.workspaces = workspaces.Workspaces(app_state)
     return app_state
 
 
@@ -366,6 +370,7 @@ class TestLifespan:
         app.state.nginx_watchdog = main.NginxWatchdog(KlangkSettings(env={}))
         app.state.oidc = oidc.OIDC(app.state)
         app.state.plugins = plugins.Plugins(app.state)
+        app.state.workspaces = workspaces.Workspaces(app.state)
         registry = app_state.container_registry
         with (
             patch.object(
@@ -410,6 +415,7 @@ class TestLifespan:
         app.state.nginx_watchdog = main.NginxWatchdog(KlangkSettings(env={}))
         app.state.oidc = oidc.OIDC(app.state)
         app.state.plugins = plugins.Plugins(app.state)
+        app.state.workspaces = workspaces.Workspaces(app.state)
         registry = app_state.container_registry
         with (
             patch.object(
@@ -479,8 +485,9 @@ class TestStartupShutdownRestart:
             ) as mock_adopt,
             patch.object(registry, "start_cleanup_loop") as mock_cleanup,
             patch.object(registry, "start_health_loop") as mock_health,
-            patch(
-                "klangk_backend.main.workspaces.auto_start_workspaces",
+            patch.object(
+                workspaces.Workspaces,
+                "auto_start_workspaces",
                 new_callable=AsyncMock,
                 return_value=0,
             ) as mock_autostart,
@@ -629,6 +636,7 @@ class TestStartupShutdownRestart:
         app.state.nginx_watchdog = main.NginxWatchdog(KlangkSettings(env={}))
         app.state.oidc = oidc.OIDC(app.state)
         app.state.plugins = plugins.Plugins(app.state)
+        app.state.workspaces = workspaces.Workspaces(app.state)
         registry = app_state.container_registry
         loop = asyncio.get_running_loop()
         with (

--- a/src/backend/tests/test_workspaces.py
+++ b/src/backend/tests/test_workspaces.py
@@ -1,43 +1,25 @@
 """Tests for workspaces: workspace lifecycle, directory management, port allocation."""
 
 import os
-import types
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from klangk_backend import workspaces as ws_mod, container
-from klangk_backend.container import ContainerRegistry
-from klangk_backend.settings import KlangkSettings
-
-
-@pytest.fixture
-def app_state():
-    """Build a minimal app_state with a real ContainerRegistry."""
-    settings = KlangkSettings(env={})
-    registry = ContainerRegistry(settings)
-    state = types.SimpleNamespace(
-        container_registry=registry,
-        settings=settings,
-    )
-    registry.app_state = state
-    return state
 
 
 class TestCreateWorkspace:
     async def test_creates_workspace_and_dirs(self, user, app_state):
-        ws = await ws_mod.create_workspace(
-            user["id"], "my-ws", app_state=app_state
-        )
+        ws = await app_state.workspaces.create_workspace(user["id"], "my-ws")
         assert ws["name"] == "my-ws"
         assert ws["user_id"] == user["id"]
         assert "id" in ws
 
-        data_path = ws_mod.workspace_path(ws["id"])
+        data_path = app_state.workspaces.workspace_path(ws["id"])
         assert data_path.exists()
         assert data_path.is_dir()
 
-        home_dir = ws_mod.home_path(ws["id"])
+        home_dir = app_state.workspaces.home_path(ws["id"])
         assert home_dir.exists()
         assert home_dir.is_dir()
 
@@ -46,22 +28,16 @@ class TestCreateWorkspace:
         assert users_dir.is_dir()
 
     async def test_allocates_ports(self, user, app_state):
-        ws = await ws_mod.create_workspace(
-            user["id"], "ported", app_state=app_state
-        )
+        ws = await app_state.workspaces.create_workspace(user["id"], "ported")
         registry = app_state.container_registry
         ports = await registry.get_workspace_ports(ws["id"])
         assert len(ports) == ws["num_ports"]
         assert all(p >= container.PORT_RANGE_START for p in ports)
 
     async def test_duplicate_name_fails(self, user, app_state):
-        await ws_mod.create_workspace(
-            user["id"], "unique", app_state=app_state
-        )
+        await app_state.workspaces.create_workspace(user["id"], "unique")
         with pytest.raises(Exception):
-            await ws_mod.create_workspace(
-                user["id"], "unique", app_state=app_state
-            )
+            await app_state.workspaces.create_workspace(user["id"], "unique")
 
     async def test_invalid_setup_state_rejected(self, user, app_state):
         """Invalid setup_state raises ValueError (#1033)."""
@@ -69,11 +45,10 @@ class TestCreateWorkspace:
 
         # Service layer (goes through create_workspace_with_acl).
         with pytest.raises(ValueError, match="Invalid setup_state"):
-            await ws_mod.create_workspace(
+            await app_state.workspaces.create_workspace(
                 user["id"],
                 "bad-state",
                 setup_state="bogus",
-                app_state=app_state,
             )
         # Row-only model primitive validates the same way.
         with pytest.raises(ValueError, match="Invalid setup_state"):
@@ -83,8 +58,8 @@ class TestCreateWorkspace:
 
     async def test_setup_state_defaults_to_complete(self, user, app_state):
         """Workspaces without a setup command default to 'complete'."""
-        ws = await ws_mod.create_workspace(
-            user["id"], "default-state", app_state=app_state
+        ws = await app_state.workspaces.create_workspace(
+            user["id"], "default-state"
         )
         assert ws["setup_state"] == "complete"
 
@@ -98,18 +73,14 @@ class TestCreateWorkspace:
             side_effect=RuntimeError("port exhaustion"),
         ):
             with pytest.raises(RuntimeError, match="port exhaustion"):
-                await ws_mod.create_workspace(
-                    user["id"], "boom", app_state=app_state
-                )
+                await app_state.workspaces.create_workspace(user["id"], "boom")
 
         # DB record should have been cleaned up
-        result = await ws_mod.list_workspaces(user["id"])
+        result = await app_state.workspaces.list_workspaces(user["id"])
         assert all(ws["name"] != "boom" for ws in result["items"])
 
         # Name should be reusable (proves full cleanup)
-        ws = await ws_mod.create_workspace(
-            user["id"], "boom", app_state=app_state
-        )
+        ws = await app_state.workspaces.create_workspace(user["id"], "boom")
         assert ws["name"] == "boom"
 
 
@@ -117,9 +88,7 @@ async def test_update_workspace_invalid_setup_state_rejected(user, app_state):
     """update_workspace rejects an invalid setup_state (#1033)."""
     from klangk_backend.model import update_workspace
 
-    ws = await ws_mod.create_workspace(
-        user["id"], "upd-state", app_state=app_state
-    )
+    ws = await app_state.workspaces.create_workspace(user["id"], "upd-state")
     with pytest.raises(ValueError, match="Invalid setup_state"):
         await update_workspace(ws["id"], ws["user_id"], setup_state="bogus")
 
@@ -128,8 +97,8 @@ async def test_update_workspace_sets_setup_state(user, app_state):
     """update_workspace can transition setup_state (#1033)."""
     from klangk_backend.model import get_workspace, update_workspace
 
-    ws = await ws_mod.create_workspace(
-        user["id"], "upd-ok", setup_state="pending", app_state=app_state
+    ws = await app_state.workspaces.create_workspace(
+        user["id"], "upd-ok", setup_state="pending"
     )
     assert ws["setup_state"] == "pending"
     await update_workspace(ws["id"], ws["user_id"], setup_state="complete")
@@ -206,8 +175,8 @@ async def test_create_workspace_with_acl_rollback_on_seeding_failure(user):
 
 
 class TestListWorkspaces:
-    async def test_list_empty(self, user):
-        result = await ws_mod.list_workspaces(user["id"])
+    async def test_list_empty(self, user, app_state):
+        result = await app_state.workspaces.list_workspaces(user["id"])
         assert result == {
             "items": [],
             "has_more": False,
@@ -215,9 +184,9 @@ class TestListWorkspaces:
         }
 
     async def test_list_multiple(self, user, app_state):
-        await ws_mod.create_workspace(user["id"], "ws-a", app_state=app_state)
-        await ws_mod.create_workspace(user["id"], "ws-b", app_state=app_state)
-        result = await ws_mod.list_workspaces(user["id"])
+        await app_state.workspaces.create_workspace(user["id"], "ws-a")
+        await app_state.workspaces.create_workspace(user["id"], "ws-b")
+        result = await app_state.workspaces.list_workspaces(user["id"])
         names = [ws["name"] for ws in result["items"]]
         assert "ws-a" in names
         assert "ws-b" in names
@@ -226,101 +195,106 @@ class TestListWorkspaces:
 
 class TestGetWorkspace:
     async def test_get_existing(self, user, app_state):
-        ws = await ws_mod.create_workspace(
-            user["id"], "findme", app_state=app_state
-        )
-        found = await ws_mod.get_workspace(ws["id"], user["id"])
+        ws = await app_state.workspaces.create_workspace(user["id"], "findme")
+        found = await app_state.workspaces.get_workspace(ws["id"], user["id"])
         assert found is not None
         assert found["name"] == "findme"
 
-    async def test_get_nonexistent(self, user):
-        found = await ws_mod.get_workspace("fake-id", user["id"])
+    async def test_get_nonexistent(self, user, app_state):
+        found = await app_state.workspaces.get_workspace("fake-id", user["id"])
         assert found is None
 
     async def test_get_wrong_user(self, user, app_state):
-        ws = await ws_mod.create_workspace(
-            user["id"], "mine", app_state=app_state
+        ws = await app_state.workspaces.create_workspace(user["id"], "mine")
+        found = await app_state.workspaces.get_workspace(
+            ws["id"], "other-user"
         )
-        found = await ws_mod.get_workspace(ws["id"], "other-user")
         assert found is None
 
 
 class TestDeleteWorkspace:
     async def test_delete_removes_db_and_dirs(self, user, app_state):
-        ws = await ws_mod.create_workspace(
-            user["id"], "doomed", app_state=app_state
-        )
-        data_path = ws_mod.workspace_path(ws["id"])
-        home_dir = ws_mod.home_path(ws["id"])
+        ws = await app_state.workspaces.create_workspace(user["id"], "doomed")
+        data_path = app_state.workspaces.workspace_path(ws["id"])
+        home_dir = app_state.workspaces.home_path(ws["id"])
         (data_path / "file.txt").write_text("hello")
         (home_dir / ".bashrc").write_text("# custom")
 
-        deleted = await ws_mod.delete_workspace(ws["id"], user["id"])
+        deleted = await app_state.workspaces.delete_workspace(
+            ws["id"], user["id"]
+        )
         assert deleted is True
-        assert await ws_mod.get_workspace(ws["id"], user["id"]) is None
+        assert (
+            await app_state.workspaces.get_workspace(ws["id"], user["id"])
+            is None
+        )
         assert not data_path.exists()
         assert not home_dir.exists()
 
-    async def test_delete_nonexistent(self, user):
-        deleted = await ws_mod.delete_workspace("fake-id", user["id"])
+    async def test_delete_nonexistent(self, user, app_state):
+        deleted = await app_state.workspaces.delete_workspace(
+            "fake-id", user["id"]
+        )
         assert deleted is False
 
     async def test_delete_cascades_ports(self, user, app_state):
-        ws = await ws_mod.create_workspace(
-            user["id"], "ported", app_state=app_state
-        )
+        ws = await app_state.workspaces.create_workspace(user["id"], "ported")
         registry = app_state.container_registry
         ports_before = await registry.get_workspace_ports(ws["id"])
         assert len(ports_before) > 0
 
-        await ws_mod.delete_workspace(ws["id"], user["id"])
+        await app_state.workspaces.delete_workspace(ws["id"], user["id"])
         ports_after = await registry.get_workspace_ports(ws["id"])
         assert ports_after == []
 
     async def test_delete_missing_dirs_ok(self, user, app_state):
-        ws = await ws_mod.create_workspace(
-            user["id"], "no-dirs", app_state=app_state
-        )
-        home_dir = ws_mod.home_path(ws["id"])
+        ws = await app_state.workspaces.create_workspace(user["id"], "no-dirs")
+        home_dir = app_state.workspaces.home_path(ws["id"])
         import shutil
 
         shutil.rmtree(home_dir)
 
-        deleted = await ws_mod.delete_workspace(ws["id"], user["id"])
+        deleted = await app_state.workspaces.delete_workspace(
+            ws["id"], user["id"]
+        )
         assert deleted is True
 
 
 class TestHostPaths:
-    def test_workspace_host_path_creates_dir(self, user, temp_data_dir):
-        path = ws_mod.get_workspace_host_path("ws-1")
+    def test_workspace_host_path_creates_dir(
+        self, user, temp_data_dir, app_state
+    ):
+        path = app_state.workspaces.get_workspace_host_path("ws-1")
         assert path.exists()
         assert path.is_dir()
 
-    def test_home_host_path_creates_dir(self, user, temp_data_dir):
-        path = ws_mod.get_home_host_path("ws-1")
+    def test_home_host_path_creates_dir(self, user, temp_data_dir, app_state):
+        path = app_state.workspaces.get_home_host_path("ws-1")
         assert path.exists()
         assert path.is_dir()
 
-    def test_workspace_host_path_idempotent(self, user, temp_data_dir):
-        path1 = ws_mod.get_workspace_host_path("ws-1")
-        path2 = ws_mod.get_workspace_host_path("ws-1")
+    def test_workspace_host_path_idempotent(
+        self, user, temp_data_dir, app_state
+    ):
+        path1 = app_state.workspaces.get_workspace_host_path("ws-1")
+        path2 = app_state.workspaces.get_workspace_host_path("ws-1")
         assert path1 == path2
 
-    def test_paths_are_under_data_dir(self, user, temp_data_dir):
-        path = ws_mod.get_workspace_host_path("ws-1")
+    def test_paths_are_under_data_dir(self, user, temp_data_dir, app_state):
+        path = app_state.workspaces.get_workspace_host_path("ws-1")
         assert str(path).startswith(str(temp_data_dir))
 
-        home = ws_mod.get_home_host_path("ws-1")
+        home = app_state.workspaces.get_home_host_path("ws-1")
         assert str(home).startswith(str(temp_data_dir))
 
 
 class TestEnsureHomeSymlink:
     async def test_creates_symlink(self, user, app_state):
-        ws = await ws_mod.create_workspace(
-            user["id"], "symlink-ws", app_state=app_state
+        ws = await app_state.workspaces.create_workspace(
+            user["id"], "symlink-ws"
         )
-        home = ws_mod.home_path(ws["id"])
-        result, created = await ws_mod.ensure_home_symlink(
+        home = app_state.workspaces.home_path(ws["id"])
+        result, created = await app_state.workspaces.ensure_home_symlink(
             home, "alice", "uid-1"
         )
         assert result == "/home/alice"
@@ -331,24 +305,24 @@ class TestEnsureHomeSymlink:
         assert (home / ".users" / "uid-1").is_dir()
 
     async def test_idempotent(self, user, app_state):
-        ws = await ws_mod.create_workspace(
-            user["id"], "symlink-ws2", app_state=app_state
+        ws = await app_state.workspaces.create_workspace(
+            user["id"], "symlink-ws2"
         )
-        home = ws_mod.home_path(ws["id"])
-        await ws_mod.ensure_home_symlink(home, "bob", "uid-1")
-        result, created = await ws_mod.ensure_home_symlink(
+        home = app_state.workspaces.home_path(ws["id"])
+        await app_state.workspaces.ensure_home_symlink(home, "bob", "uid-1")
+        result, created = await app_state.workspaces.ensure_home_symlink(
             home, "bob", "uid-1"
         )
         assert result == "/home/bob"
         assert created is False
 
     async def test_rename_removes_old_symlink(self, user, app_state):
-        ws = await ws_mod.create_workspace(
-            user["id"], "symlink-ws3", app_state=app_state
+        ws = await app_state.workspaces.create_workspace(
+            user["id"], "symlink-ws3"
         )
-        home = ws_mod.home_path(ws["id"])
-        await ws_mod.ensure_home_symlink(home, "alice", "uid-1")
-        result, created = await ws_mod.ensure_home_symlink(
+        home = app_state.workspaces.home_path(ws["id"])
+        await app_state.workspaces.ensure_home_symlink(home, "alice", "uid-1")
+        result, created = await app_state.workspaces.ensure_home_symlink(
             home, "alicia", "uid-1"
         )
         assert result == "/home/alicia"
@@ -361,10 +335,10 @@ class TestEnsureHomeSymlink:
 
         The old user's files should be adopted into the new user dir.
         """
-        ws = await ws_mod.create_workspace(
-            user["id"], "symlink-ws4", app_state=app_state
+        ws = await app_state.workspaces.create_workspace(
+            user["id"], "symlink-ws4"
         )
-        home = ws_mod.home_path(ws["id"])
+        home = app_state.workspaces.home_path(ws["id"])
         # Simulate imported workspace: symlink for old user ID with files.
         (home / ".users").mkdir(parents=True, exist_ok=True)
         old_dir = home / ".users" / "old-uid"
@@ -373,7 +347,7 @@ class TestEnsureHomeSymlink:
         (old_dir / ".profile").write_text("# old profile")
         (home / "admin").symlink_to(".users/old-uid")
         # New user connects — different user ID, same handle.
-        result, created = await ws_mod.ensure_home_symlink(
+        result, created = await app_state.workspaces.ensure_home_symlink(
             home, "admin", "new-uid"
         )
         assert result == "/home/admin"
@@ -419,22 +393,19 @@ class TestPopulateHomeSkel:
 
 class TestAutoStartWorkspaces:
     async def test_returns_zero_when_env_not_set(self, user, app_state):
-        with patch.dict(os.environ, {}, clear=False):
-            os.environ.pop("KLANGK_ALLOW_AUTOSTART", None)
-            result = await ws_mod.auto_start_workspaces(app_state)
+        # allow_autostart unset -> skip entirely
+        result = await app_state.workspaces.auto_start_workspaces()
         assert result == 0
 
     async def test_starts_auto_start_workspaces(self, user, app_state):
         registry = app_state.container_registry
-        ws1 = await ws_mod.create_workspace(
-            user["id"], "auto-ws1", auto_start=True, app_state=app_state
+        ws1 = await app_state.workspaces.create_workspace(
+            user["id"], "auto-ws1", auto_start=True
         )
-        ws2 = await ws_mod.create_workspace(
-            user["id"], "auto-ws2", auto_start=True, app_state=app_state
+        ws2 = await app_state.workspaces.create_workspace(
+            user["id"], "auto-ws2", auto_start=True
         )
-        await ws_mod.create_workspace(
-            user["id"], "normal-ws", app_state=app_state
-        )
+        await app_state.workspaces.create_workspace(user["id"], "normal-ws")
 
         # Pre-populate states so idle_timeout can be set.
         from klangk_backend.container import ContainerState
@@ -442,7 +413,7 @@ class TestAutoStartWorkspaces:
         registry.states[ws1["id"]] = ContainerState(ws1["id"], "cid-1")
         registry.states[ws2["id"]] = ContainerState(ws2["id"], "cid-2")
         try:
-            with patch.dict(os.environ, {"KLANGK_ALLOW_AUTOSTART": "1"}):
+            with patch.object(app_state.settings, "allow_autostart", "1"):
                 with patch.object(
                     registry,
                     "start_container",
@@ -453,7 +424,9 @@ class TestAutoStartWorkspaces:
                         "klangk_backend.workspaces.asyncio.sleep",
                         new_callable=AsyncMock,
                     ) as mock_sleep:
-                        result = await ws_mod.auto_start_workspaces(app_state)
+                        result = (
+                            await app_state.workspaces.auto_start_workspaces()
+                        )
             assert result == 2
             assert mock_start.await_count == 2
             mock_sleep.assert_awaited_once()
@@ -465,17 +438,17 @@ class TestAutoStartWorkspaces:
 
     async def test_handles_start_failure_gracefully(self, user, app_state):
         registry = app_state.container_registry
-        await ws_mod.create_workspace(
-            user["id"], "fail-ws", auto_start=True, app_state=app_state
+        await app_state.workspaces.create_workspace(
+            user["id"], "fail-ws", auto_start=True
         )
-        with patch.dict(os.environ, {"KLANGK_ALLOW_AUTOSTART": "1"}):
+        with patch.object(app_state.settings, "allow_autostart", "1"):
             with patch.object(
                 registry,
                 "start_container",
                 new_callable=AsyncMock,
                 side_effect=RuntimeError("container failed"),
             ):
-                result = await ws_mod.auto_start_workspaces(app_state)
+                result = await app_state.workspaces.auto_start_workspaces()
         assert result == 0
 
 
@@ -491,12 +464,11 @@ class TestStartWorkspace:
 
     async def test_unpacks_dict_and_starts_container(self, user, app_state):
         registry = app_state.container_registry
-        ws = await ws_mod.create_workspace(
+        ws = await app_state.workspaces.create_workspace(
             user["id"],
             "start-ws",
             auto_start=True,
             service_command="openclaw gateway",
-            app_state=app_state,
         )
         try:
             with patch.object(
@@ -505,7 +477,7 @@ class TestStartWorkspace:
                 new_callable=AsyncMock,
                 return_value=("cid-x", "created"),
             ) as mock_start:
-                cid, status = await ws_mod.start_workspace(ws, app_state)
+                cid, status = await app_state.workspaces.start_workspace(ws)
             assert cid == "cid-x"
             assert status == "created"
             mock_start.assert_awaited_once()
@@ -520,11 +492,10 @@ class TestStartWorkspace:
     async def test_does_not_pin_idle_timeout(self, user, app_state):
         """Only the boot path (auto_start_workspaces) pins idle_timeout."""
         registry = app_state.container_registry
-        ws = await ws_mod.create_workspace(
+        ws = await app_state.workspaces.create_workspace(
             user["id"],
             "start-ws-no-idle",
             auto_start=True,
-            app_state=app_state,
         )
         from klangk_backend.container import ContainerState
 
@@ -539,7 +510,7 @@ class TestStartWorkspace:
                 new_callable=AsyncMock,
                 return_value=("cid-y", "created"),
             ):
-                await ws_mod.start_workspace(ws, app_state)
+                await app_state.workspaces.start_workspace(ws)
             assert registry.states[ws["id"]].idle_timeout == default_timeout
         finally:
             registry.states.pop(ws["id"], None)

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -106,6 +106,7 @@ def _make_app_state(registry=None, sockets=None):
     # #1480: shared mock Terminal wired onto app_state. Tests patch
     # its methods via patch.object(_mock_term, ...).
     app_state.terminal = _mock_term
+    app_state.workspaces = ws_mod.Workspaces(app_state)
     return app_state
 
 
@@ -219,14 +220,14 @@ async def _conn_in_workspace(
         sockets.sessions.pop(workspace_id, None)
 
 
-async def _create_workspace_with_acl(user_id, name, **kwargs):
+async def _create_workspace_with_acl(app_state, user_id, name, **kwargs):
     """Create a workspace whose owner has full access.
 
     The service-layer ``create_workspace`` now seeds the owner ACE and role
     groups atomically (see model.create_workspace_with_acl, #128), so this
     is a thin alias kept for call-site readability.
     """
-    return await ws_mod.create_workspace(user_id, name, **kwargs)
+    return await app_state.workspaces.create_workspace(user_id, name, **kwargs)
 
 
 # --- SafeWebSocket ---
@@ -1868,10 +1869,11 @@ class TestHandleTerminalStart:
 
 
 class TestHandleSetHandle:
-    async def test_set_handle_success(self, user, temp_data_dir):
-        from klangk_backend import workspaces
+    async def test_set_handle_success(self, user, temp_data_dir, app_state):
 
-        ws = await workspaces.create_workspace(user["id"], "handle-test")
+        ws = await app_state.workspaces.create_workspace(
+            user["id"], "handle-test"
+        )
         sock = _mock_sock()
         conn = _base_conn(
             user={"id": user["id"], "email": user["email"]}, ws=sock
@@ -1896,7 +1898,7 @@ class TestHandleSetHandle:
         )
         assert conn._user_home == "/home/alice"
 
-    async def test_set_handle_conflict(self, user, temp_data_dir):
+    async def test_set_handle_conflict(self, user, temp_data_dir, app_state):
         # Create another user that already has handle "alice"
         other = await model.create_user(
             "alice@example.com", "hash", verified=True
@@ -1920,13 +1922,15 @@ class TestHandleSetHandle:
         sent = sock.send_json.call_args_list
         assert any(call.args[0].get("type") == "error" for call in sent)
 
-    async def test_handle_auto_created_on_connect(self, user):
+    async def test_handle_auto_created_on_connect(self, user, app_state):
         app_state = _make_app_state()
         sockets = app_state.sockets
         registry = app_state.container_registry
         sock = _mock_sock(headers={"host": "localhost:8997"})
         conn = _base_conn(user=user, ws=sock, app_state=app_state)
-        workspace = await ws_mod.create_workspace(user["id"], "auto-handle")
+        workspace = await app_state.workspaces.create_workspace(
+            user["id"], "auto-handle"
+        )
 
         async def fake_start(*a, **kw):
             registry.track_activity("cid-ah", workspace["id"])
@@ -1949,10 +1953,13 @@ class TestHandleSetHandle:
         sockets.sessions.pop(workspace["id"], None)
         registry.states.pop(workspace["id"], None)
 
-    async def test_handle_resolved_on_start(self, user, temp_data_dir):
-        from klangk_backend import workspaces
+    async def test_handle_resolved_on_start(
+        self, user, temp_data_dir, app_state
+    ):
 
-        ws = await workspaces.create_workspace(user["id"], "handle-test4")
+        ws = await app_state.workspaces.create_workspace(
+            user["id"], "handle-test4"
+        )
         sock = _mock_sock()
         conn = _base_conn(
             user={"id": user["id"], "email": user["email"]}, ws=sock
@@ -2136,17 +2143,19 @@ class TestHandleWorkspaceConnect:
         await conn.handle_workspace_connect({})
         assert "Missing" in sock.send_json.call_args[0][0]["message"]
 
-    async def test_workspace_not_found(self, user):
+    async def test_workspace_not_found(self, user, app_state):
         sock = _mock_sock()
         conn = _base_conn(user=user, ws=sock)
         await conn.handle_workspace_connect({"workspaceId": "fake"})
         assert "Permission denied" in sock.send_json.call_args[0][0]["message"]
 
-    async def test_connect_success(self, user, agent_user):
+    async def test_connect_success(self, user, agent_user, app_state):
         app_state = _make_app_state()
         registry = app_state.container_registry
         sock = _mock_sock()
-        workspace = await _create_workspace_with_acl(user["id"], "test-ws")
+        workspace = await _create_workspace_with_acl(
+            app_state, user["id"], "test-ws"
+        )
         conn = _base_conn(user=user, ws=sock, app_state=app_state)
 
         async def fake_start(wid, workspace):
@@ -2177,12 +2186,14 @@ class TestHandleWorkspaceConnect:
         # Integer timeout (default 30m) should show as "30m" not "30.0m"
         assert "30m" in conn.pending_status_msg
 
-    async def test_connect_sends_service_command(self, user, agent_user):
+    async def test_connect_sends_service_command(
+        self, user, agent_user, app_state
+    ):
         app_state = _make_app_state()
         registry = app_state.container_registry
         sock = _mock_sock()
         workspace = await _create_workspace_with_acl(
-            user["id"], "cmd-ws", service_command="pi"
+            app_state, user["id"], "cmd-ws", service_command="pi"
         )
         conn = _base_conn(user=user, ws=sock, app_state=app_state)
 
@@ -2209,16 +2220,18 @@ class TestHandleWorkspaceConnect:
         ready = [c for c in calls if c.get("type") == "container_ready"]
         assert ready[0]["serviceCommand"] == "pi"
 
-    async def test_connect_denied_no_acl(self, user):
+    async def test_connect_denied_no_acl(self, user, app_state):
         """User without ACL entry gets 'Permission denied'."""
         sock = _mock_sock()
-        workspace = await ws_mod.create_workspace(user["id"], "no-acl-ws")
+        workspace = await app_state.workspaces.create_workspace(
+            user["id"], "no-acl-ws"
+        )
         conn = _base_conn(user={"id": "other-user", "email": "x"}, ws=sock)
         await conn.handle_workspace_connect({"workspaceId": workspace["id"]})
         calls = [c[0][0] for c in sock.send_json.call_args_list]
         assert any("Permission denied" in str(c) for c in calls)
 
-    async def test_connect_race_deleted(self, user):
+    async def test_connect_race_deleted(self, user, app_state):
         """ACL passes but workspace deleted before lookup."""
         from klangk_backend import model
 
@@ -2237,10 +2250,14 @@ class TestHandleWorkspaceConnect:
         calls = [c[0][0] for c in sock.send_json.call_args_list]
         assert any("Workspace not found" in str(c) for c in calls)
 
-    async def test_connect_container_start_valueerror(self, user, agent_user):
+    async def test_connect_container_start_valueerror(
+        self, user, agent_user, app_state
+    ):
         """ValueError from start_container is sent as an error, not a crash."""
         sock = _mock_sock()
-        workspace = await _create_workspace_with_acl(user["id"], "bad-mount")
+        workspace = await _create_workspace_with_acl(
+            app_state, user["id"], "bad-mount"
+        )
         conn = _base_conn(user=user, ws=sock)
 
         with patch.object(
@@ -2282,13 +2299,15 @@ class TestHandleWorkspaceDisconnect:
 
 
 class TestStartWorkspaceContainer:
-    async def test_new_session(self, user):
+    async def test_new_session(self, user, app_state):
         app_state = _make_app_state()
         sockets = app_state.sockets
         registry = app_state.container_registry
         sock = _mock_sock(headers={"host": "localhost:8997"})
         conn = _base_conn(user=user, ws=sock, app_state=app_state)
-        workspace = await ws_mod.create_workspace(user["id"], "start-ws")
+        workspace = await app_state.workspaces.create_workspace(
+            user["id"], "start-ws"
+        )
 
         async def fake_start(*a, **kw):
             registry.track_activity("cid-1", workspace["id"])
@@ -2315,13 +2334,15 @@ class TestStartWorkspaceContainer:
         sockets.sessions.pop(workspace["id"], None)
         registry.states.pop(workspace["id"], None)
 
-    async def test_resolves_existing_handle(self, user):
+    async def test_resolves_existing_handle(self, user, app_state):
         app_state = _make_app_state()
         sockets = app_state.sockets
         registry = app_state.container_registry
         sock = _mock_sock(headers={"host": "localhost:8997"})
         conn = _base_conn(user=user, ws=sock, app_state=app_state)
-        workspace = await ws_mod.create_workspace(user["id"], "handle-ws")
+        workspace = await app_state.workspaces.create_workspace(
+            user["id"], "handle-ws"
+        )
         # Set a custom handle in the DB
         await model.set_user_handle(user["id"], "chris")
 
@@ -2344,13 +2365,15 @@ class TestStartWorkspaceContainer:
         sockets.sessions.pop(workspace["id"], None)
         registry.states.pop(workspace["id"], None)
 
-    async def test_idle_callback_ws_error(self, user):
+    async def test_idle_callback_ws_error(self, user, app_state):
         app_state = _make_app_state()
         sockets = app_state.sockets
         registry = app_state.container_registry
         sock = _mock_sock(headers={"host": "localhost:8997"})
         conn = _base_conn(user=user, ws=sock, app_state=app_state)
-        workspace = await ws_mod.create_workspace(user["id"], "idle-ws")
+        workspace = await app_state.workspaces.create_workspace(
+            user["id"], "idle-ws"
+        )
 
         async def fake_start(*a, **kw):
             registry.track_activity("cid-3", workspace["id"])
@@ -2375,14 +2398,16 @@ class TestStartWorkspaceContainer:
         sockets.sessions.pop(workspace["id"], None)
         registry.states.pop(workspace["id"], None)
 
-    async def test_clears_pending_status_msg(self, user):
+    async def test_clears_pending_status_msg(self, user, app_state):
         app_state = _make_app_state()
         sockets = app_state.sockets
         registry = app_state.container_registry
         sock = _mock_sock(headers={"host": "localhost:8997"})
         conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.pending_status_msg = "stale message from prior connect"
-        workspace = await ws_mod.create_workspace(user["id"], "pending-ws")
+        workspace = await app_state.workspaces.create_workspace(
+            user["id"], "pending-ws"
+        )
 
         async def fake_start(*a, **kw):
             registry.track_activity("cid-p", workspace["id"])
@@ -2438,11 +2463,11 @@ class TestHandleWebsocketDispatch:
         )
         websocket.accept.assert_awaited_once()
 
-    async def test_dispatch_terminal_stop(self, user):
+    async def test_dispatch_terminal_stop(self, user, app_state):
         websocket = await self._run_commands(user, [{"cmd": "terminal_stop"}])
         websocket.accept.assert_awaited_once()
 
-    async def test_dispatch_terminal_window_commands(self, user):
+    async def test_dispatch_terminal_window_commands(self, user, app_state):
         for cmd in (
             "terminal_new_window",
             "terminal_select_window",
@@ -2453,40 +2478,40 @@ class TestHandleWebsocketDispatch:
             websocket = await self._run_commands(user, [{"cmd": cmd}])
             websocket.accept.assert_awaited_once()
 
-    async def test_dispatch_restart_container(self, user):
+    async def test_dispatch_restart_container(self, user, app_state):
         websocket = await self._run_commands(
             user, [{"cmd": "restart_container"}]
         )
         calls = [c[0][0] for c in websocket.send_json.call_args_list]
         assert any("Not connected" in str(c) for c in calls)
 
-    async def test_dispatch_workspace_connect(self, user):
+    async def test_dispatch_workspace_connect(self, user, app_state):
         websocket = await self._run_commands(
             user, [{"cmd": "workspace_connect"}]
         )
         calls = [c[0][0] for c in websocket.send_json.call_args_list]
         assert any("Missing" in str(c) for c in calls)
 
-    async def test_dispatch_set_handle(self, user):
+    async def test_dispatch_set_handle(self, user, app_state):
         websocket = await self._run_commands(
             user, [{"cmd": "set_handle", "handle": "alice"}]
         )
         calls = [c[0][0] for c in websocket.send_json.call_args_list]
         assert any("Not connected" in str(c) for c in calls)
 
-    async def test_dispatch_workspace_disconnect(self, user):
+    async def test_dispatch_workspace_disconnect(self, user, app_state):
         websocket = await self._run_commands(
             user, [{"cmd": "workspace_disconnect"}]
         )
         websocket.accept.assert_awaited_once()
 
-    async def test_dispatch_browser_reattach(self, user):
+    async def test_dispatch_browser_reattach(self, user, app_state):
         websocket = await self._run_commands(
             user, [{"cmd": "browser_reattach", "browser_id": "bid-x"}]
         )
         websocket.accept.assert_awaited_once()
 
-    async def test_container_survives_disconnect(self, user):
+    async def test_container_survives_disconnect(self, user, app_state):
         """Container should NOT be killed on disconnect — idle timeout handles it."""
         app_state = _make_app_state()
         registry = app_state.container_registry
@@ -2495,7 +2520,9 @@ class TestHandleWebsocketDispatch:
         token = auth_mod.create_token(user["id"], user["email"])
         websocket = _mock_raw_sock(query_params={"token": token})
 
-        workspace = await ws_mod.create_workspace(user["id"], "stop-ws")
+        workspace = await app_state.workspaces.create_workspace(
+            user["id"], "stop-ws"
+        )
         websocket.receive_text = AsyncMock(
             side_effect=[
                 json.dumps(
@@ -2605,7 +2632,7 @@ class TestHandleWebsocket:
 
         websocket.accept.assert_awaited_once()
 
-    async def test_runtime_error_treated_as_disconnect(self, user):
+    async def test_runtime_error_treated_as_disconnect(self, user, app_state):
         app_state = _make_app_state()
         from klangk_backend import auth as auth_mod
 
@@ -2621,7 +2648,7 @@ class TestHandleWebsocket:
 
         websocket.accept.assert_awaited_once()
 
-    async def test_invalid_json(self, user):
+    async def test_invalid_json(self, user, app_state):
         app_state = _make_app_state()
         from klangk_backend import auth as auth_mod
 
@@ -2636,7 +2663,7 @@ class TestHandleWebsocket:
         calls = [c[0][0] for c in websocket.send_json.call_args_list]
         assert any("Invalid JSON" in str(c) for c in calls)
 
-    async def test_unknown_command(self, user):
+    async def test_unknown_command(self, user, app_state):
         app_state = _make_app_state()
         from klangk_backend import auth as auth_mod
 
@@ -2654,7 +2681,7 @@ class TestHandleWebsocket:
         calls = [c[0][0] for c in websocket.send_json.call_args_list]
         assert any("Unknown command" in str(c) for c in calls)
 
-    async def test_ui_ready_with_pending(self, user):
+    async def test_ui_ready_with_pending(self, user, app_state):
         app_state = _make_app_state()
         sockets = app_state.sockets
         registry = app_state.container_registry
@@ -2662,7 +2689,9 @@ class TestHandleWebsocket:
 
         token = auth_mod.create_token(user["id"], user["email"])
         websocket = _mock_raw_sock(query_params={"token": token})
-        workspace = await _create_workspace_with_acl(user["id"], "ui-ready-ws")
+        workspace = await _create_workspace_with_acl(
+            app_state, user["id"], "ui-ready-ws"
+        )
 
         async def fake_start(self_arg, wid, ws_obj):
             self_arg.container_id = "cid"
@@ -5245,14 +5274,18 @@ class TestHandleRestartContainer:
         mock_cleanup.assert_not_called()
         mock_start.assert_not_called()
 
-    async def test_restart_deny_leaves_other_connections_untouched(self, user):
+    async def test_restart_deny_leaves_other_connections_untouched(
+        self, user, app_state
+    ):
         """A spectator's denied restart must not change other users'
         container_id or otherwise disrupt their session (issue #873)."""
         app_state = _make_app_state()
         sockets = app_state.sockets
         sock1 = _mock_sock(headers={"host": "localhost:8997"})
         sock2 = _mock_sock()
-        ws = await _create_workspace_with_acl(user["id"], "restart-deny")
+        ws = await _create_workspace_with_acl(
+            app_state, user["id"], "restart-deny"
+        )
         conn1 = _base_conn(user=user, ws=sock1, app_state=app_state)
         conn2 = _base_conn(user=user, ws=sock2, app_state=app_state)
         conn1.workspace_id = ws["id"]
@@ -5283,11 +5316,13 @@ class TestHandleRestartContainer:
             sockets.connections.pop(sock2, None)
             sockets.sessions.pop(ws["id"], None)
 
-    async def test_restart_success(self, user):
+    async def test_restart_success(self, user, app_state):
         app_state = _make_app_state()
         registry = app_state.container_registry
         sock = _mock_sock(headers={"host": "localhost:8997"})
-        workspace = await _create_workspace_with_acl(user["id"], "restart-ws")
+        workspace = await _create_workspace_with_acl(
+            app_state, user["id"], "restart-ws"
+        )
         conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.workspace_id = workspace["id"]
         conn.container_id = "cid-old"
@@ -5349,7 +5384,7 @@ class TestHandleRestartContainer:
 
         with (
             patch.object(
-                ws_mod,
+                app_state.workspaces,
                 "get_workspace",
                 return_value=None,
             ),
@@ -5364,13 +5399,15 @@ class TestHandleRestartContainer:
         calls = [c[0][0] for c in sock.send_json.call_args_list]
         assert any("not found" in str(c) for c in calls)
 
-    async def test_restart_fractional_timeout(self, user, monkeypatch):
+    async def test_restart_fractional_timeout(
+        self, user, monkeypatch, app_state
+    ):
         app_state = _make_app_state()
         registry = app_state.container_registry
         monkeypatch.setattr(container, "IDLE_TIMEOUT_SECONDS", 90)
         sock = _mock_sock(headers={"host": "localhost:8997"})
         workspace = await _create_workspace_with_acl(
-            user["id"], "restart-frac"
+            app_state, user["id"], "restart-frac"
         )
         conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.workspace_id = workspace["id"]
@@ -5412,11 +5449,13 @@ class TestHandleRestartContainer:
         assert len(ready) == 1
         assert "1.5m" in ready[0]["event"]["value"]["reason"]
 
-    async def test_restart_cleanup_error(self, user):
+    async def test_restart_cleanup_error(self, user, app_state):
         app_state = _make_app_state()
         registry = app_state.container_registry
         sock = _mock_sock(headers={"host": "localhost:8997"})
-        workspace = await _create_workspace_with_acl(user["id"], "restart-err")
+        workspace = await _create_workspace_with_acl(
+            app_state, user["id"], "restart-err"
+        )
         conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.workspace_id = workspace["id"]
         conn.container_id = "cid-err"
@@ -5459,12 +5498,12 @@ class TestHandleRestartContainer:
         ]
         assert len(ready) == 1
 
-    async def test_restart_cleanup_ws_disconnect(self, user):
+    async def test_restart_cleanup_ws_disconnect(self, user, app_state):
         app_state = _make_app_state()
         registry = app_state.container_registry
         sock = _mock_sock(headers={"host": "localhost:8997"})
         workspace = await _create_workspace_with_acl(
-            user["id"], "restart-disc"
+            app_state, user["id"], "restart-disc"
         )
         conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.workspace_id = workspace["id"]
@@ -5508,13 +5547,17 @@ class TestHandleRestartContainer:
         ]
         assert len(ready) == 1
 
-    async def test_restart_updates_other_connections_container_id(self, user):
+    async def test_restart_updates_other_connections_container_id(
+        self, user, app_state
+    ):
         app_state = _make_app_state()
         sockets = app_state.sockets
         registry = app_state.container_registry
         sock1 = _mock_sock(headers={"host": "localhost:8997"})
         sock2 = _mock_sock()
-        workspace = await _create_workspace_with_acl(user["id"], "restart-cid")
+        workspace = await _create_workspace_with_acl(
+            app_state, user["id"], "restart-cid"
+        )
         conn1 = _base_conn(user=user, ws=sock1, app_state=app_state)
         conn2 = _base_conn(user=user, ws=sock2, app_state=app_state)
         conn1.workspace_id = workspace["id"]
@@ -5597,7 +5640,9 @@ class TestHandleShutdownContainer:
             for m in sent
         )
 
-    async def test_shutdown_deny_does_not_clear_other_connections(self, user):
+    async def test_shutdown_deny_does_not_clear_other_connections(
+        self, user, app_state
+    ):
         """A spectator's denied shutdown must not clear other users'
         container_id (which would disrupt their session) — issue #873."""
         app_state = _make_app_state()
@@ -5605,7 +5650,9 @@ class TestHandleShutdownContainer:
         registry = app_state.container_registry
         sock1 = _mock_sock()
         sock2 = _mock_sock()
-        ws = await _create_workspace_with_acl(user["id"], "shutdown-deny")
+        ws = await _create_workspace_with_acl(
+            app_state, user["id"], "shutdown-deny"
+        )
         conn1 = _base_conn(user=user, ws=sock1, app_state=app_state)
         conn2 = _base_conn(user=user, ws=sock2, app_state=app_state)
         conn1.workspace_id = ws["id"]
@@ -5647,14 +5694,16 @@ class TestHandleShutdownContainer:
             for m in sent
         )
 
-    async def test_shutdown_broadcasts_stopped(self, user):
+    async def test_shutdown_broadcasts_stopped(self, user, app_state):
         app_state = _make_app_state()
         sockets = app_state.sockets
         registry = app_state.container_registry
         sock1 = _mock_sock()
         sock2 = _mock_sock()
         conn = _base_conn(user=user, ws=sock1, app_state=app_state)
-        ws = await _create_workspace_with_acl(user["id"], "shutdown-ws")
+        ws = await _create_workspace_with_acl(
+            app_state, user["id"], "shutdown-ws"
+        )
         conn.workspace_id = ws["id"]
         conn.container_id = "cid"
 
@@ -5683,14 +5732,16 @@ class TestHandleShutdownContainer:
 
         sockets.sessions.pop(ws["id"], None)
 
-    async def test_shutdown_stops_agent_session(self, user):
+    async def test_shutdown_stops_agent_session(self, user, app_state):
         """handle_shutdown_container stops the agent RPC subprocess."""
         app_state = _make_app_state()
         sockets = app_state.sockets
         registry = app_state.container_registry
         sock = _mock_sock()
         conn = _base_conn(user=user, ws=sock, app_state=app_state)
-        ws = await _create_workspace_with_acl(user["id"], "shutdown-agent")
+        ws = await _create_workspace_with_acl(
+            app_state, user["id"], "shutdown-agent"
+        )
         conn.workspace_id = ws["id"]
         conn.container_id = "cid"
 
@@ -5719,7 +5770,9 @@ class TestHandleShutdownContainer:
             registry.on_workspace_killed = old_cb
             sockets.sessions.pop(ws["id"], None)
 
-    async def test_shutdown_clears_other_connections_container_id(self, user):
+    async def test_shutdown_clears_other_connections_container_id(
+        self, user, app_state
+    ):
         app_state = _make_app_state()
         sockets = app_state.sockets
         registry = app_state.container_registry
@@ -5727,7 +5780,9 @@ class TestHandleShutdownContainer:
         sock2 = _mock_sock()
         conn1 = _base_conn(user=user, ws=sock1, app_state=app_state)
         conn2 = _base_conn(user=user, ws=sock2, app_state=app_state)
-        ws = await _create_workspace_with_acl(user["id"], "shutdown-cid")
+        ws = await _create_workspace_with_acl(
+            app_state, user["id"], "shutdown-cid"
+        )
         conn1.workspace_id = ws["id"]
         conn1.container_id = "old-cid"
         conn2.workspace_id = ws["id"]
@@ -5752,13 +5807,15 @@ class TestHandleShutdownContainer:
         sockets.connections.pop(sock2, None)
         sockets.sessions.pop(ws["id"], None)
 
-    async def test_shutdown_handles_stop_error(self, user):
+    async def test_shutdown_handles_stop_error(self, user, app_state):
         app_state = _make_app_state()
         sockets = app_state.sockets
         registry = app_state.container_registry
         sock = _mock_sock()
         conn = _base_conn(user=user, ws=sock, app_state=app_state)
-        ws = await _create_workspace_with_acl(user["id"], "shutdown-err")
+        ws = await _create_workspace_with_acl(
+            app_state, user["id"], "shutdown-err"
+        )
         conn.workspace_id = ws["id"]
         conn.container_id = "cid"
 
@@ -7789,7 +7846,7 @@ class TestShareWindowHandlers:
         calls = [c[0][0] for c in sock.send_json.call_args_list]
         assert any("Permission" in c.get("message", "") for c in calls)
 
-    async def test_create_shared_terminal_empty_name(self, user):
+    async def test_create_shared_terminal_empty_name(self, user, app_state):
         sock = _mock_sock()
         conn = _base_conn(user=user, ws=sock)
         conn.container_id = "cid"
@@ -7800,7 +7857,7 @@ class TestShareWindowHandlers:
         calls = [c[0][0] for c in sock.send_json.call_args_list]
         assert any("Name" in c.get("message", "") for c in calls)
 
-    async def test_create_shared_terminal_error(self, user):
+    async def test_create_shared_terminal_error(self, user, app_state):
         sock = _mock_sock()
         conn = _base_conn(user=user, ws=sock)
         conn.container_id = "cid"
@@ -7822,7 +7879,9 @@ class TestShareWindowHandlers:
         conn = _base_conn()
         await conn.handle_list_shared_terminals()
 
-    async def test_list_shared_terminals_permission_denied(self, user):
+    async def test_list_shared_terminals_permission_denied(
+        self, user, app_state
+    ):
         sock = _mock_sock()
         conn = _base_conn(user=user, ws=sock)
         conn.workspace_id = "ws-1"
@@ -7831,7 +7890,7 @@ class TestShareWindowHandlers:
         calls = [c[0][0] for c in sock.send_json.call_args_list]
         assert any("Permission" in c.get("message", "") for c in calls)
 
-    async def test_list_shared_terminals_no_session(self, user):
+    async def test_list_shared_terminals_no_session(self, user, app_state):
         sock = _mock_sock()
         conn = _base_conn(user=user, ws=sock)
         conn.workspace_id = "no-session"
@@ -7841,10 +7900,10 @@ class TestShareWindowHandlers:
         shared = [c for c in calls if c.get("type") == "shared_terminals"]
         assert shared[0]["terminals"] == []
 
-    async def test_has_perm_checks_acl(self, user, temp_data_dir):
+    async def test_has_perm_checks_acl(self, user, temp_data_dir, app_state):
         sock = _mock_sock()
         conn = _base_conn(user=user, ws=sock)
-        ws = await _create_workspace_with_acl(user["id"], "perm-ws")
+        ws = await _create_workspace_with_acl(app_state, user["id"], "perm-ws")
         conn.workspace_id = ws["id"]
         assert await conn._has_perm("view")
 
@@ -8145,7 +8204,7 @@ class TestSharedTerminalController:
         await ctrl.create_shared_terminal({"name": "x"})
         assert "Permission" in sock.send_json.call_args[0][0]["message"]
 
-    async def test_create_shared_terminal_empty_name(self, user):
+    async def test_create_shared_terminal_empty_name(self, user, app_state):
         ctrl, sock, _ = self._controller(user=user)
         await ctrl.create_shared_terminal({"name": "  "})
         assert "Name" in sock.send_json.call_args[0][0]["message"]
@@ -8589,7 +8648,7 @@ class TestFindWindow:
         finally:
             sockets.sessions.pop("ws-find", None)
 
-    async def test_shared_true_rejects_unshared_window(self, user):
+    async def test_shared_true_rejects_unshared_window(self, user, app_state):
         """A present-but-unshared window is treated as not found."""
         app_state = _make_app_state()
         sockets = app_state.sockets
@@ -8609,7 +8668,7 @@ class TestFindWindow:
         finally:
             sockets.sessions.pop("ws-find", None)
 
-    async def test_custom_error_message(self, user):
+    async def test_custom_error_message(self, user, app_state):
         app_state = _make_app_state()
         sockets = app_state.sockets
         sock, conn, session = self._setup(user, [], app_state=app_state)
@@ -8638,7 +8697,9 @@ class TestFractionalTimeout:
         registry = app_state.container_registry
         monkeypatch.setattr(container, "IDLE_TIMEOUT_SECONDS", 90)
         sock = _mock_sock()
-        workspace = await _create_workspace_with_acl(user["id"], "frac-ws")
+        workspace = await _create_workspace_with_acl(
+            app_state, user["id"], "frac-ws"
+        )
         conn = _base_conn(user=user, ws=sock, app_state=app_state)
 
         async def fake_start(wid, workspace):
@@ -9416,12 +9477,14 @@ class TestChatSend:
             wshandler.agent_tasks.clear()
             wshandler.agent_conversations.pop(workspace["id"], None)
 
-    async def test_chat_history_on_connect(self, user, agent_user):
+    async def test_chat_history_on_connect(self, user, agent_user, app_state):
         app_state = _make_app_state()
         registry = app_state.container_registry
         from klangk_backend import model
 
-        workspace = await _create_workspace_with_acl(user["id"], "chat-ws")
+        workspace = await _create_workspace_with_acl(
+            app_state, user["id"], "chat-ws"
+        )
         await model.add_chat_message(
             workspace["id"], "uid-other", "someone@test.com", "old message"
         )
@@ -9454,7 +9517,7 @@ class TestChatSend:
         assert len(history[0]["messages"]) == 1
         assert history[0]["messages"][0]["message"] == "old message"
 
-    async def test_chat_load_more(self, workspace, user):
+    async def test_chat_load_more(self, workspace, user, app_state):
         from klangk_backend import model
 
         msgs = []
@@ -9482,7 +9545,9 @@ class TestChatSend:
         await conn.handle_chat_load_more({"before_id": "x"})
         sock.send_json.assert_not_called()
 
-    async def test_chat_load_more_no_before_id(self, workspace, user):
+    async def test_chat_load_more_no_before_id(
+        self, workspace, user, app_state
+    ):
         sock = _mock_sock()
         conn = _base_conn(user=user, ws=sock)
         conn.workspace_id = workspace["id"]
@@ -9491,12 +9556,14 @@ class TestChatSend:
 
 
 class TestPresence:
-    async def test_presence_list_on_connect(self, user, agent_user):
+    async def test_presence_list_on_connect(self, user, agent_user, app_state):
         """Joining user receives presence_list with current users."""
         app_state = _make_app_state()
         sockets = app_state.sockets
         registry = app_state.container_registry
-        workspace = await _create_workspace_with_acl(user["id"], "pres-ws")
+        workspace = await _create_workspace_with_acl(
+            app_state, user["id"], "pres-ws"
+        )
 
         sock = _mock_sock()
         conn = _base_conn(user=user, ws=sock, app_state=app_state)
@@ -9540,7 +9607,7 @@ class TestPresence:
         from klangk_backend import model
 
         workspace = await _create_workspace_with_acl(
-            user["id"], "pres-join-ws"
+            app_state, user["id"], "pres-join-ws"
         )
 
         # First user connects
@@ -9610,13 +9677,15 @@ class TestPresence:
             sockets.connections.pop(sock1, None)
             sockets.connections.pop(sock2, None)
 
-    async def test_presence_leave_broadcast(self, user):
+    async def test_presence_leave_broadcast(self, user, app_state):
         """Remaining subscribers receive presence_leave after debounce."""
         app_state = _make_app_state()
         sockets = app_state.sockets
         from klangk_backend import model
 
-        workspace = await _create_workspace_with_acl(user["id"], "pres-lv-ws")
+        workspace = await _create_workspace_with_acl(
+            app_state, user["id"], "pres-lv-ws"
+        )
 
         sock1 = _mock_sock()
         sock2 = _mock_sock()
@@ -9670,7 +9739,7 @@ class TestPresence:
         from klangk_backend import model
 
         workspace = await _create_workspace_with_acl(
-            user["id"], "pres-debounce-ws"
+            app_state, user["id"], "pres-debounce-ws"
         )
 
         sock1 = _mock_sock()  # observer
@@ -9763,13 +9832,15 @@ class TestPresence:
             sockets.connections.pop(sock2, None)
             sockets.connections.pop(sock3, None)
 
-    async def test_presence_leave_multi_tab(self, user):
+    async def test_presence_leave_multi_tab(self, user, app_state):
         """No presence_leave if user has another connection in workspace."""
         app_state = _make_app_state()
         sockets = app_state.sockets
         from klangk_backend import model
 
-        workspace = await _create_workspace_with_acl(user["id"], "pres-mt-ws")
+        workspace = await _create_workspace_with_acl(
+            app_state, user["id"], "pres-mt-ws"
+        )
 
         sock1 = _mock_sock()
         sock2 = _mock_sock()
@@ -9811,11 +9882,13 @@ class TestPresence:
 
 
 class TestRefreshUserHandle:
-    async def test_refresh_updates_connections_and_broadcasts(self, user):
+    async def test_refresh_updates_connections_and_broadcasts(
+        self, user, app_state
+    ):
         app_state = _make_app_state()
         sockets = app_state.sockets
         workspace = await _create_workspace_with_acl(
-            user["id"], "handle-refresh-ws"
+            app_state, user["id"], "handle-refresh-ws"
         )
         sock = _mock_sock()
         conn = _base_conn(user=user, ws=sock, app_state=app_state)
@@ -9851,12 +9924,14 @@ class TestRefreshUserHandle:
 
 
 class TestChatDelete:
-    async def test_chat_delete_broadcasts_update(self, user):
+    async def test_chat_delete_broadcasts_update(self, user, app_state):
         app_state = _make_app_state()
         sockets = app_state.sockets
         from klangk_backend import model
 
-        workspace = await ws_mod.create_workspace(user["id"], "chat-del-ws")
+        workspace = await app_state.workspaces.create_workspace(
+            user["id"], "chat-del-ws"
+        )
         sock = _mock_sock()
         conn = _base_conn(user=user, ws=sock, app_state=app_state)
         conn.workspace_id = workspace["id"]
@@ -9880,10 +9955,12 @@ class TestChatDelete:
 
         sockets.sessions.pop(workspace["id"], None)
 
-    async def test_chat_delete_wrong_user_ignored(self, user):
+    async def test_chat_delete_wrong_user_ignored(self, user, app_state):
         from klangk_backend import model
 
-        workspace = await ws_mod.create_workspace(user["id"], "chat-del-ws2")
+        workspace = await app_state.workspaces.create_workspace(
+            user["id"], "chat-del-ws2"
+        )
         sock = _mock_sock()
         conn = _base_conn(ws=sock)
         conn.workspace_id = workspace["id"]
@@ -10081,7 +10158,7 @@ class TestDispatchBrowserRequestStreamTo:
         finally:
             sockets.sessions.pop("ws-stream-to", None)
 
-    async def test_loop_dispatches_browser_chunk(self, user):
+    async def test_loop_dispatches_browser_chunk(self, user, app_state):
         app_state = _make_app_state()
         sockets = app_state.sockets
         from klangk_backend import auth as auth_mod
@@ -10104,10 +10181,13 @@ class TestDispatchBrowserRequestStreamTo:
 
 
 class TestUiReadySharedTerminals:
-    async def test_ui_ready_sends_shared_terminals(self, user, temp_data_dir):
-        from klangk_backend import workspaces
+    async def test_ui_ready_sends_shared_terminals(
+        self, user, temp_data_dir, app_state
+    ):
 
-        ws = await workspaces.create_workspace(user["id"], "ui-shared")
+        ws = await app_state.workspaces.create_workspace(
+            user["id"], "ui-shared"
+        )
         async with _conn_in_workspace(
             {"id": user["id"], "email": user["email"]},
             ws["id"],
@@ -10127,12 +10207,15 @@ class TestUiReadySharedTerminals:
                 for m in sent
             )
 
-    async def test_ui_ready_sends_container_ready(self, user, temp_data_dir):
+    async def test_ui_ready_sends_container_ready(
+        self, user, temp_data_dir, app_state
+    ):
         app_state = _make_app_state()
         sockets = app_state.sockets
-        from klangk_backend import workspaces
 
-        ws = await workspaces.create_workspace(user["id"], "ui-ready-cr")
+        ws = await app_state.workspaces.create_workspace(
+            user["id"], "ui-ready-cr"
+        )
         sock = _mock_sock()
         conn = _base_conn(
             user={"id": user["id"], "email": user["email"]},
@@ -10161,11 +10244,13 @@ class TestUiReadySharedTerminals:
 
 
 class TestTokenRenewal:
-    async def test_renewal_creates_new_token(self, user):
+    async def test_renewal_creates_new_token(self, user, app_state):
         """Token renewal loop creates a new token and pushes it."""
         app_state = _make_app_state()
         sockets = app_state.sockets
-        workspace = await _create_workspace_with_acl(user["id"], "renew-ws")
+        workspace = await _create_workspace_with_acl(
+            app_state, user["id"], "renew-ws"
+        )
         session = sockets.get_or_create_session(workspace["id"], app_state)
         session.container_id = "test-cid"
 
@@ -10199,11 +10284,13 @@ class TestTokenRenewal:
         finally:
             sockets.sessions.pop(workspace["id"], None)
 
-    async def test_renewal_retries_on_failure(self, user):
+    async def test_renewal_retries_on_failure(self, user, app_state):
         """Token renewal retries after failure."""
         app_state = _make_app_state()
         sockets = app_state.sockets
-        workspace = await _create_workspace_with_acl(user["id"], "retry-ws")
+        workspace = await _create_workspace_with_acl(
+            app_state, user["id"], "retry-ws"
+        )
         session = sockets.get_or_create_session(workspace["id"], app_state)
         session.container_id = "test-cid"
 
@@ -10249,7 +10336,7 @@ class TestTokenRenewal:
         finally:
             sockets.sessions.pop(workspace["id"], None)
 
-    async def test_reset_cancels_token_renewal_task(self, user):
+    async def test_reset_cancels_token_renewal_task(self, user, app_state):
         """reset() cancels the token renewal task (issue #871).
 
         Without cancellation the renewal loop keeps running after a
@@ -10258,7 +10345,9 @@ class TestTokenRenewal:
         """
         app_state = _make_app_state()
         sockets = app_state.sockets
-        workspace = await _create_workspace_with_acl(user["id"], "leak-ws")
+        workspace = await _create_workspace_with_acl(
+            app_state, user["id"], "leak-ws"
+        )
         session = sockets.get_or_create_session(workspace["id"], app_state)
         session.container_id = "test-cid"
 
@@ -10293,12 +10382,16 @@ class TestTokenRenewal:
         finally:
             sockets.sessions.pop(workspace["id"], None)
 
-    async def test_concurrent_add_subscriber_no_duplicate_renewal(self, user):
+    async def test_concurrent_add_subscriber_no_duplicate_renewal(
+        self, user, app_state
+    ):
         """Two concurrent add_subscriber calls must not create duplicate
         renewal tasks (#1299)."""
         app_state = _make_app_state()
         sockets = app_state.sockets
-        workspace = await _create_workspace_with_acl(user["id"], "race-ws")
+        workspace = await _create_workspace_with_acl(
+            app_state, user["id"], "race-ws"
+        )
         session = sockets.get_or_create_session(workspace["id"], app_state)
 
         try:
@@ -10483,7 +10576,7 @@ class TestSSHAgentDispatch:
             await handle_websocket(websocket, app_state)
         mock.assert_awaited_once()
 
-    async def test_dispatch_list_shared_terminals(self, user):
+    async def test_dispatch_list_shared_terminals(self, user, app_state):
         app_state = _make_app_state()
         from klangk_backend import auth as auth_mod
 
@@ -10503,7 +10596,7 @@ class TestSSHAgentDispatch:
             await handle_websocket(websocket, app_state)
         mock.assert_awaited_once()
 
-    async def test_dispatch_chat_agent_abort(self, user):
+    async def test_dispatch_chat_agent_abort(self, user, app_state):
         app_state = _make_app_state()
         from klangk_backend import auth as auth_mod
 
@@ -10523,12 +10616,16 @@ class TestSSHAgentDispatch:
 
 
 class TestStartAgentIfNeeded:
-    async def test_starts_agent_and_broadcasts_presence(self, user, db):
+    async def test_starts_agent_and_broadcasts_presence(
+        self, user, db, app_state
+    ):
         app_state = _make_app_state()
         sockets = app_state.sockets
         sock = _mock_sock()
         conn = _base_conn(user=user, ws=sock, app_state=app_state)
-        workspace = await ws_mod.create_workspace(user["id"], "agent-ws")
+        workspace = await app_state.workspaces.create_workspace(
+            user["id"], "agent-ws"
+        )
         conn.workspace_id = workspace["id"]
 
         session = sockets.get_or_create_session(workspace["id"], app_state)
@@ -10548,7 +10645,7 @@ class TestStartAgentIfNeeded:
             await session.remove_subscriber(sock)
             sockets.sessions.pop(workspace["id"], None)
 
-    async def test_start_agent_logs_on_failure(self, user, db):
+    async def test_start_agent_logs_on_failure(self, user, db, app_state):
         sock = _mock_sock()
         conn = _base_conn(user=user, ws=sock)
         conn.workspace_id = "ws-fail"
@@ -10562,10 +10659,12 @@ class TestStartAgentIfNeeded:
 
 
 class TestHandleChatAgentAbort:
-    async def test_cancels_running_task(self, user, db):
+    async def test_cancels_running_task(self, user, db, app_state):
         sock = _mock_sock()
         conn = _base_conn(user=user, ws=sock)
-        workspace = await ws_mod.create_workspace(user["id"], "abort-ws")
+        workspace = await app_state.workspaces.create_workspace(
+            user["id"], "abort-ws"
+        )
         conn.workspace_id = workspace["id"]
 
         async def slow():
@@ -10588,16 +10687,18 @@ class TestHandleChatAgentAbort:
                 except asyncio.CancelledError:
                     pass
 
-    async def test_abort_no_workspace(self, user, db):
+    async def test_abort_no_workspace(self, user, db, app_state):
         sock = _mock_sock()
         conn = _base_conn(user=user, ws=sock)
         conn.workspace_id = None
         await conn.handle_chat_agent_abort()
 
-    async def test_abort_no_task(self, user, db):
+    async def test_abort_no_task(self, user, db, app_state):
         sock = _mock_sock()
         conn = _base_conn(user=user, ws=sock)
-        workspace = await ws_mod.create_workspace(user["id"], "abort-none")
+        workspace = await app_state.workspaces.create_workspace(
+            user["id"], "abort-none"
+        )
         conn.workspace_id = workspace["id"]
         wshandler.agent_tasks.pop(workspace["id"], None)
         await conn.handle_chat_agent_abort()
@@ -10635,8 +10736,12 @@ class TestHandleChatAgentAbort:
 
 
 class TestPresenceIncludesAgent:
-    async def test_agent_in_presence_when_running(self, user, agent_user):
-        workspace = await ws_mod.create_workspace(user["id"], "pres-ws")
+    async def test_agent_in_presence_when_running(
+        self, user, agent_user, app_state
+    ):
+        workspace = await app_state.workspaces.create_workspace(
+            user["id"], "pres-ws"
+        )
         async with _conn_in_workspace(user, workspace["id"]) as (
             sock,
             conn,
@@ -10654,11 +10759,13 @@ class TestPresenceIncludesAgent:
             assert model.AGENT_USER_ID in ids
 
     async def test_agent_not_in_presence_when_running_in_other_workspace(
-        self, user, agent_user
+        self, user, agent_user, app_state
     ):
         """Agent running in a different workspace must not appear in this
         workspace's presence list (regression for #870)."""
-        workspace = await ws_mod.create_workspace(user["id"], "pres-ws")
+        workspace = await app_state.workspaces.create_workspace(
+            user["id"], "pres-ws"
+        )
         async with _conn_in_workspace(user, workspace["id"]) as (
             sock,
             conn,


### PR DESCRIPTION
Closes #1484. Part of #1426 (composition-root refactor).

## What

`workspaces.py` had `data_dir`/`WORKSPACES_ROOT` frozen at import time from `resolve_env_value`, plus `allow_autostart` read per-call from env. All workspace path/archive/CRUD functions were module-level, closing over the frozen globals.

Promoted to a `Workspaces` class on `app.state.workspaces`. The root (`self.root`, was `WORKSPACES_ROOT`) and `data_dir` are computed at construction from `settings.data_dir` — no import-time env read (the frozen-at-import hazard).

## Changes

**Production:**
- **`workspaces.py`** — `Workspaces` class owns `safe_path`, `home_path`, `workspace_path`, `config_path`, `get_*_host_path`, `build_workspace_archive`, `archive_user_data`, `create`/`delete`/`list`/`get_workspace`, `ensure_home_symlink`, `populate_home_skel`, `start_workspace`, `auto_start_workspaces`, `workspace_metadata`, `build_export_tar_args`. `allow_autostart` read from `self.settings`. Pure helpers (`sanitize_filename`, `rmtree`, `_ensure_home_symlink_sync`, `populate_home_skel` delegate) stay module-level.
- **`agent.py`** — `ensure_agent_home` takes `app_state` (not `podman`); reaches workspaces via `app_state.workspaces`. `populate_home_skel` no longer takes `podman` (reaches it via `self.app_state.podman`).
- **`bringup.py`** — passes `app_state` to `ensure_agent_home`.
- **`main.py`** — `app.state.workspaces = Workspaces(app.state)`; `startup` reads `app_state.workspaces.auto_start_workspaces()`.
- **`api/workspaces.py`** — all `workspaces.X` → `app_state.workspaces.X`; `_extract_home_directory` takes `app_state`. Export route gains `app_state` dep.
- **`api/admin.py`** — `list_user_workspaces`/`delete_user` use `app_state.workspaces`.
- **`wshandler/connection.py`** — `workspaces.X` → `self.app_state.workspaces.X`.
- **`container.py`** — health monitor reaches `app_state.workspaces` via registry back-ref.

**Tests:** conftest `app_state` fixture (shared across all test files) wires `Workspaces`; `test_api` app fixture includes `KLANGK_DATA_DIR`; test fixtures build fresh instances. 100% coverage maintained.

## Verification

All three suites green locally:
- Backend unit: **2376 passed, 100% coverage**
- Backend e2e: **95 passed**
- CLI e2e: **62 passed, 1 skipped**
