### PR TITLE
Move container.py settings globals onto ContainerRegistry(app_state) (#1487)

### DIFF
--- a/src/backend/klangk_backend/agent.py
+++ b/src/backend/klangk_backend/agent.py
@@ -69,7 +69,7 @@ def is_disabled() -> bool:
 
 
 async def ensure_agent_home(
-    workspace_id: str, container_id: str, app_state=None
+    workspace_id: str, container_id: str, app_state
 ) -> str:
     """Eagerly provision the agent's home directory with Pi config.
 

--- a/src/backend/klangk_backend/api/__init__.py
+++ b/src/backend/klangk_backend/api/__init__.py
@@ -133,7 +133,9 @@ if resolve_env_value("KLANGK_TEST_MODE"):  # pragma: no cover
                     workspace_id
                 )
             }
-        return {"idle_timeout_seconds": container.IDLE_TIMEOUT_SECONDS}
+        return {
+            "idle_timeout_seconds": app_state.container_registry.idle_timeout_seconds
+        }
 
     class SetIdleTimeoutRequest(BaseModel):
         seconds: int
@@ -152,8 +154,7 @@ if resolve_env_value("KLANGK_TEST_MODE"):  # pragma: no cover
                 workspace_id, seconds
             )
         else:
-            container.IDLE_TIMEOUT_SECONDS = seconds
-            container.CHECK_INTERVAL_SECONDS = max(10, min(60, seconds // 3))
+            app_state.container_registry.set_idle_timeout(seconds)
         return {"idle_timeout_seconds": seconds}
 
     @router.get("/test/workspace-token/{workspace_id}")

--- a/src/backend/klangk_backend/api/files.py
+++ b/src/backend/klangk_backend/api/files.py
@@ -51,7 +51,7 @@ async def list_files(
 ):
     cid = _require_container(workspace_id, app_state.container_registry)
     try:
-        return await files.list_files(cid, path, app_state.podman)
+        return await files.list_files(cid, path, podman=app_state.podman)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 

--- a/src/backend/klangk_backend/api/images.py
+++ b/src/backend/klangk_backend/api/images.py
@@ -11,7 +11,6 @@ from pydantic import BaseModel
 
 from .. import (
     auth,
-    container,
     model,
 )
 from ..podman import PodmanError as PodmanError
@@ -23,10 +22,13 @@ router = APIRouter()
 
 
 @router.get("/images")
-async def list_images(_user: dict = Depends(auth.get_current_user)):
+async def list_images(
+    _user: dict = Depends(auth.get_current_user),
+    app_state=Depends(get_app_state_dep),
+):
     return {
-        "default": container.IMAGE_NAME,
-        "allowed": sorted(container.ALLOWED_IMAGES),
+        "default": app_state.container_registry.image_name,
+        "allowed": sorted(app_state.container_registry.allowed_images),
     }
 
 

--- a/src/backend/klangk_backend/api/workspaces.py
+++ b/src/backend/klangk_backend/api/workspaces.py
@@ -28,7 +28,6 @@ from sqlalchemy.exc import IntegrityError as SAIntegrityError
 from .. import (
     acl,
     auth,
-    container,
     model,
     wshandler,
 )
@@ -180,14 +179,17 @@ async def create_workspace(
             detail="Auto-start is not enabled on this server"
             " (set KLANGK_ALLOW_AUTOSTART=1)",
         )
-    if body.image and body.image not in container.ALLOWED_IMAGES:
+    if (
+        body.image
+        and body.image not in app_state.container_registry.allowed_images
+    ):
         raise HTTPException(
             status_code=400,
             detail=f"Image {body.image!r} is not allowed. "
-            f"Allowed: {sorted(container.ALLOWED_IMAGES)}",
+            f"Allowed: {sorted(app_state.container_registry.allowed_images)}",
         )
     if body.mounts:
-        mount_err = container.validate_mounts(body.mounts)
+        mount_err = app_state.container_registry.validate_mounts(body.mounts)
         if mount_err:
             raise HTTPException(status_code=400, detail=mount_err)
     try:
@@ -257,14 +259,16 @@ async def update_workspace(
             " (set KLANGK_ALLOW_AUTOSTART=1)",
         )
     if "image" in fields and fields["image"] is not None:
-        if fields["image"] not in container.ALLOWED_IMAGES:
+        if fields["image"] not in app_state.container_registry.allowed_images:
             raise HTTPException(
                 status_code=400,
                 detail=f"Image {fields['image']!r} is not allowed. "
-                f"Allowed: {sorted(container.ALLOWED_IMAGES)}",
+                f"Allowed: {sorted(app_state.container_registry.allowed_images)}",
             )
     if "mounts" in fields and fields["mounts"]:
-        mount_err = container.validate_mounts(fields["mounts"])
+        mount_err = app_state.container_registry.validate_mounts(
+            fields["mounts"]
+        )
         if mount_err:
             raise HTTPException(status_code=400, detail=mount_err)
     if not fields:
@@ -586,7 +590,7 @@ async def _stream_upload_to_tempfile(file: UploadFile) -> str:
 
 
 async def _extract_archive_metadata(
-    archive_path: str, name: str | None
+    archive_path: str, name: str | None, app_state
 ) -> dict:
     """Read workspace.json from the archive and return sanitized metadata."""
     result = await asyncio.to_thread(
@@ -616,11 +620,11 @@ async def _extract_archive_metadata(
         )
 
     image = metadata.get("image")
-    if image and image not in container.ALLOWED_IMAGES:
+    if image and image not in app_state.container_registry.allowed_images:
         image = None
 
     mounts = metadata.get("mounts")
-    if mounts and container.validate_mounts(mounts):
+    if mounts and app_state.container_registry.validate_mounts(mounts):
         mounts = None
 
     # Validate provenance: reject archives without instance_id or from a
@@ -712,7 +716,7 @@ async def import_workspace(
     archive_path = await _stream_upload_to_tempfile(file)
     ws = None
     try:
-        meta = await _extract_archive_metadata(archive_path, name)
+        meta = await _extract_archive_metadata(archive_path, name, app_state)
 
         try:
             ws = await app_state.workspaces.create_workspace(

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -7,52 +7,28 @@ import time
 
 from . import auth, bringup, model, podman, util
 from .podman import PodmanError
-from .settings import KlangkSettings
 
 logger = logging.getLogger(__name__)
 
 
-def container_dns_config() -> list[str]:
-    """Return DNS server list from KLANGK_DNS_SERVERS env var.
-
-    Set KLANGK_DNS_SERVERS to a comma-separated list of DNS server IPs
-    (e.g., "100.100.100.100,8.8.8.8" for Tailscale MagicDNS + Google).
-    Returns an empty list if not configured.
-    """
-    raw = util.resolve_env_value("KLANGK_DNS_SERVERS", "")
-    return [s.strip() for s in raw.split(",") if s.strip()]
+# --- Runtime SSL/CA certificate injection (#1181) -------------------------
+from .ssl_trust import (  # noqa: E402
+    SSL_MOUNT_DEST as _SSL_MOUNT_DEST,
+    ssl_cert_dir,
+    ssl_env_vars,
+)
 
 
-IMAGE_NAME = util.resolve_env_value("KLANGK_IMAGE_NAME", "klangk-workspace")
+# ---------------------------------------------------------------------------
+# Pure module-level constants (no settings reads — #1487 carve-out)
+# ---------------------------------------------------------------------------
 
-TERMINAL_BANNER = util.resolve_env_value("KLANGK_TERMINAL_BANNER", "")
+CONTAINER_PORT_START = 8000
+DEFAULT_PORTS_PER_WORKSPACE = 5
 
-_allowed_images_env = util.resolve_env_value("KLANGK_ALLOWED_IMAGES", "")
-ALLOWED_IMAGES: set[str] = {
-    img.strip() for img in _allowed_images_env.split(",") if img.strip()
-}
-ALLOWED_IMAGES.add(IMAGE_NAME)  # default image is always allowed
+HEALTH_MESSAGE_MAX_BYTES = 512
 
 _VALID_PULL_POLICIES = {"never", "missing", "always", "newer"}
-
-
-def image_pull_policy() -> str:
-    """Resolve the workspace-image pull policy from the environment.
-
-    Default ``never`` keeps airgapped behavior (image must already exist
-    locally).  Set ``KLANGK_IMAGE_PULL_POLICY=missing`` to pull from a
-    registry when the image isn't present.
-    """
-    policy = util.resolve_env_value("KLANGK_IMAGE_PULL_POLICY", "never")
-    if policy not in _VALID_PULL_POLICIES:
-        logger.warning(
-            "Invalid KLANGK_IMAGE_PULL_POLICY=%r (valid: %s); using 'never'.",
-            policy,
-            ", ".join(sorted(_VALID_PULL_POLICIES)),
-        )
-        return "never"
-    return policy
-
 
 _VALID_MOUNT_OPTIONS = {
     "ro",
@@ -64,16 +40,6 @@ _VALID_MOUNT_OPTIONS = {
     "cached",
     "delegated",
 }
-
-
-_allowed_mount_roots_env = util.resolve_env_value(
-    "KLANGK_ALLOWED_MOUNT_ROOTS", ""
-)
-ALLOWED_MOUNT_ROOTS: list[str] = [
-    os.path.realpath(p.strip())
-    for p in _allowed_mount_roots_env.split(",")
-    if p.strip()
-]
 
 _PROTECTED_PATHS = [
     "/var/run/docker.sock",
@@ -87,176 +53,13 @@ def _is_named_volume(source: str) -> bool:
     return "/" not in source and not source.startswith(".")
 
 
-def _is_protected(source: str) -> bool:
-    """True if source is a protected host path that must never be mounted.
-
-    Uses ``os.path.realpath`` to resolve symlinks — a symlink pointing
-    to a protected path (e.g. Docker socket) is still blocked.
-    """
-    resolved = os.path.realpath(source)
-    data_dir = os.path.realpath(
-        util.resolve_env_value(
-            "KLANGK_DATA_DIR", os.path.expanduser("~/.klangk/data")
-        )
-        or os.path.expanduser("~/.klangk/data")
-    )
-    for blocked in [*_PROTECTED_PATHS, data_dir]:
-        blocked = os.path.realpath(blocked)
-        if resolved == blocked or resolved.startswith(blocked + "/"):
-            return True
-    return False
-
-
-def validate_mount_spec(spec: str) -> str | None:
-    """Validate a container mount spec string.
-
-    Returns None if valid, or an error message string if invalid.
-    Valid forms: source:dest or source:dest:options
-    The container path (dest) must be absolute.
-    """
-    parts = spec.split(":")
-    if len(parts) < 2 or len(parts) > 3:
-        return f"Invalid mount {spec!r}: expected source:dest or source:dest:options"
-    source, dest = parts[0], parts[1]
-    if not source:
-        return f"Invalid mount {spec!r}: source is empty"
-    if not dest.startswith("/"):
-        return f"Invalid mount {spec!r}: container path must be absolute (start with /)"
-    if len(parts) == 3:
-        options = parts[2]
-        for opt in options.split(","):
-            if opt and opt not in _VALID_MOUNT_OPTIONS:
-                return f"Invalid mount {spec!r}: unknown option {opt!r}"
-    if not _is_named_volume(source):
-        if _is_protected(source):
-            return f"Invalid mount {spec!r}: source is a protected host path"
-        if ALLOWED_MOUNT_ROOTS:
-            resolved = os.path.realpath(source)
-            if not any(
-                resolved == root or resolved.startswith(root + "/")
-                for root in ALLOWED_MOUNT_ROOTS
-            ):
-                allowed = ", ".join(ALLOWED_MOUNT_ROOTS)
-                return (
-                    f"Invalid mount {spec!r}: bind mount source must be "
-                    f"under an allowed root ({allowed})"
-                )
-    return None
-
-
-def validate_mounts(mounts: list[str]) -> str | None:
-    """Validate a list of mount specs. Returns first error or None."""
-    for spec in mounts:
-        error = validate_mount_spec(spec)
-        if error:
-            return error
-    return None
-
-
-def parse_idle_timeout() -> tuple[int, int]:
-    default = 30 * 60
-    env_val = util.resolve_env_value("KLANGK_IDLE_TIMEOUT_SECONDS")
-    if env_val is not None:
-        try:
-            timeout = int(env_val)
-        except ValueError:
-            logger.warning(
-                "KLANGK_IDLE_TIMEOUT_SECONDS=%r is not a valid integer, "
-                "using default %d",
-                env_val,
-                default,
-            )
-            timeout = default
-    else:
-        timeout = default
-    interval = max(10, min(60, timeout // 3))
-    return timeout, interval
-
-
-IDLE_TIMEOUT_SECONDS, CHECK_INTERVAL_SECONDS = parse_idle_timeout()
-
-
-# --- Runtime SSL/CA certificate injection (#1181) -------------------------
-# The detection (ssl_cert_dir), container env vars (ssl_env_vars) and the
-# in-container mount/bundle paths live in :mod:`ssl_trust`, which also owns
-# the backend-process trust path.  See that module for the full design.
-from .ssl_trust import (  # noqa: E402
-    SSL_MOUNT_DEST as _SSL_MOUNT_DEST,
-    ssl_cert_dir,
-    ssl_env_vars,
-)
-
-PORT_RANGE_START = int(
-    util.resolve_env_value("KLANGK_PORT_RANGE_START") or "9000"
-)
-CONTAINER_PORT_START = 8000
-DEFAULT_PORTS_PER_WORKSPACE = 5
-
-
-def ports_per_workspace_cap() -> int:
-    """Server-wide ceiling on hosted-app ports per workspace.
-
-    ``KLANGK_HOSTED_PORTS_PER_WORKSPACE`` (default
-    ``DEFAULT_PORTS_PER_WORKSPACE``, currently 5). ``0`` disables
-    hosted-app serving entirely: no ports are allocated, no hosting env
-    is injected into containers, and the ``/hosted/`` nginx locations
-    return 404. Per-workspace values (#1238) are clamped *down* to this
-    cap; they may never exceed it.
-
-    Resolved live (not cached at import) so changing the env and
-    restarting containers takes effect on the next reconcile without a
-    backend restart.
-    """
-    raw = util.resolve_env_value("KLANGK_HOSTED_PORTS_PER_WORKSPACE") or str(
-        DEFAULT_PORTS_PER_WORKSPACE
-    )
-    try:
-        return max(0, int(raw))
-    except ValueError:
-        logger.warning(
-            "KLANGK_HOSTED_PORTS_PER_WORKSPACE=%r is not an int; "
-            "using default %d",
-            raw,
-            DEFAULT_PORTS_PER_WORKSPACE,
-        )
-        return DEFAULT_PORTS_PER_WORKSPACE
-
-
-# Health-check polling interval (seconds) for HealthMonitor.  See #1015.
-HEALTH_CHECK_INTERVAL_SECONDS = int(
-    util.resolve_env_value("KLANGK_HEALTH_CHECK_INTERVAL") or "30"
-)
-# Per-invocation timeout for a single `podman exec` health check.
-HEALTH_CHECK_TIMEOUT_SECONDS = float(
-    util.resolve_env_value("KLANGK_HEALTH_CHECK_TIMEOUT") or "10"
-)
-# Startup grace period (seconds).  After a service begins starting,
-# failing health checks do NOT count as unhealthy until this much time
-# has elapsed -- mirroring Docker's HEALTHCHECK `--start-period`.  The
-# service command (a dev server, AI gateway, daemon) needs time to boot
-# after it's launched; without a grace window the very first poll fires
-# while it's still coming up and false-flags the workspace unhealthy
-# (e.g. "Gateway not yet ready to accept connections").  A *healthy*
-# result is still recorded immediately, so a fast-booting service shows
-# up as healthy as soon as it actually responds.  The window is anchored
-# to when the service command fires (see ``mark_service_started``) and
-# falls back to when the container state was first tracked, so
-# health-checked workspaces with no service command also get a grace.
-HEALTH_CHECK_STARTUP_GRACE_SECONDS = float(
-    util.resolve_env_value("KLANGK_HEALTH_CHECK_STARTUP_GRACE") or "30"
-)
-# Maximum bytes of check output retained as the failure reason (#1088).
-# A bounded tail keeps a verbose check from growing memory unbounded
-# across many workspaces while still capturing *why* it failed.
-HEALTH_MESSAGE_MAX_BYTES = 512
-
-
 class ContainerState:
     """Per-workspace container lifecycle state."""
 
-    def __init__(self, workspace_id: str, container_id: str):
+    def __init__(self, workspace_id: str, container_id: str, registry):
         self.workspace_id = workspace_id
         self.container_id = container_id
+        self.registry = registry
         self.last_activity = time.time()
         self.idle_timeout: int | None = None
         self.idle_callbacks: list = []
@@ -306,7 +109,7 @@ class ContainerState:
     def get_idle_timeout(self) -> int:
         if self.idle_timeout is not None:
             return self.idle_timeout
-        return IDLE_TIMEOUT_SECONDS
+        return self.registry.idle_timeout_seconds
 
 
 class PortAllocator:
@@ -316,18 +119,19 @@ class PortAllocator:
     port tracking.  Extracted from ``ContainerRegistry`` (issue #972).
     """
 
-    def __init__(self) -> None:
+    def __init__(self, registry) -> None:
         self.port_lock: asyncio.Lock = asyncio.Lock()
+        self.registry = registry
 
     async def allocate_ports(self, workspace_id: str, count: int) -> list[int]:
         # Clamp to the server-wide cap (KLANGK_HOSTED_PORTS_PER_WORKSPACE)
         # so creation never allocates ports the deployer has disabled —
         # otherwise a cap of 0 would still leave orphan allocations
         # until the container's first start reconcile (#1237).
-        count = min(count, ports_per_workspace_cap())
+        count = min(count, self.registry.ports_per_workspace_cap())
         async with self.port_lock:
             return await model.find_and_allocate_ports(
-                workspace_id, count, PORT_RANGE_START
+                workspace_id, count, self.registry.port_range_start
             )
 
     async def get_workspace_ports(self, workspace_id: str) -> list[int]:
@@ -394,7 +198,7 @@ class IdleMonitor:
     """
 
     def __init__(self, registry: "ContainerRegistry") -> None:
-        self._registry = registry
+        self.registry = registry
         self.cleanup_task: asyncio.Task | None = None
         self._cleanup_wake: asyncio.Event | None = None
 
@@ -404,40 +208,40 @@ class IdleMonitor:
         return self._cleanup_wake
 
     def on_idle_stop(self, workspace_id: str, callback) -> None:
-        state = self._registry.states.get(workspace_id)
+        state = self.registry.states.get(workspace_id)
         if state:
             state.idle_callbacks.append(callback)
 
     def remove_idle_callback(self, workspace_id: str, callback) -> None:
-        state = self._registry.states.get(workspace_id)
+        state = self.registry.states.get(workspace_id)
         if state and callback in state.idle_callbacks:
             state.idle_callbacks.remove(callback)
 
     def set_workspace_idle_timeout(
         self, workspace_id: str, seconds: int
     ) -> None:
-        state = self._registry.states.get(workspace_id)
+        state = self.registry.states.get(workspace_id)
         if state:
             state.idle_timeout = seconds
             self.get_cleanup_wake().set()
 
     def get_workspace_idle_timeout(self, workspace_id: str) -> int:
-        state = self._registry.states.get(workspace_id)
+        state = self.registry.states.get(workspace_id)
         if state:
             return state.get_idle_timeout()
-        return IDLE_TIMEOUT_SECONDS
+        return self.registry.idle_timeout_seconds
 
     async def cleanup_idle_containers(self) -> None:
         while True:
             timeouts = [
                 s.idle_timeout
-                for s in self._registry.states.values()
+                for s in self.registry.states.values()
                 if s.idle_timeout is not None
             ]
             if timeouts:
                 interval = max(2, min(timeouts) // 2)
             else:
-                interval = CHECK_INTERVAL_SECONDS
+                interval = self.registry.check_interval_seconds
             wake = self.get_cleanup_wake()
             wake.clear()
             try:
@@ -446,7 +250,7 @@ class IdleMonitor:
                 pass
             now = time.time()
             to_stop = []
-            for ws_id, state in list(self._registry.states.items()):
+            for ws_id, state in list(self.registry.states.items()):
                 timeout = state.get_idle_timeout()
                 idle_secs = now - state.last_activity
                 logger.debug(
@@ -464,22 +268,22 @@ class IdleMonitor:
                     cid,
                     wid,
                 )
-                state = self._registry.states.get(wid)
+                state = self.registry.states.get(wid)
                 if state:
                     for cb in list(state.idle_callbacks):
                         try:
                             await cb(wid)
                         except Exception as e:
                             logger.error("Idle callback error: %s", e)
-                await self._registry.notify_workspace_killed(wid)
-                await self._registry.stop_and_remove_container(cid)
+                await self.registry.notify_workspace_killed(wid)
+                await self.registry.stop_and_remove_container(cid)
 
     def start_cleanup_loop(self) -> None:
         logger.info(
             "Instance: %s, idle timeout: %ds, check interval: %ds",
             model.get_instance_id(),
-            IDLE_TIMEOUT_SECONDS,
-            CHECK_INTERVAL_SECONDS,
+            self.registry.idle_timeout_seconds,
+            self.registry.check_interval_seconds,
         )
         if self.cleanup_task is None:
             self.cleanup_task = asyncio.create_task(
@@ -517,18 +321,18 @@ class HealthMonitor:
     """
 
     def __init__(self, registry: "ContainerRegistry") -> None:
-        self._registry = registry
+        self.registry = registry
         self.health_task: asyncio.Task | None = None
 
     @property
-    def _connections(self):
+    def connections(self):
         """The WebSocketState instance the monitor broadcasts through (#1464).
 
         Reached via the registry's ``sockets`` attribute, set by
         ``build_app()`` in production. No lazy import — the registry owns
         the reference.
         """
-        return self._registry.sockets
+        return self.registry.sockets
 
     def _setup_complete(self, state: ContainerState) -> bool:
         """True if health checks may run for this workspace.
@@ -553,7 +357,7 @@ class HealthMonitor:
         """
         return (
             time.time() - state.service_started_at
-            < HEALTH_CHECK_STARTUP_GRACE_SECONDS
+            < self.registry.health_check_startup_grace
         )
 
     async def _run_one(self, state: ContainerState) -> tuple[str, str]:
@@ -598,7 +402,7 @@ class HealthMonitor:
         # Resolve the owner's container home the same way
         # start_workspace does, so the check runs in the right
         # HOME rather than as root in /.
-        ws = self._registry.app_state.workspaces
+        ws = self.registry.app_state.workspaces
         ws_home = ws.home_path(state.workspace_id)
         user_home, _created = await ws.ensure_home_symlink(
             ws_home, handle, owner_id
@@ -611,7 +415,7 @@ class HealthMonitor:
             state.health_check,
         )
         try:
-            rc, out, err = await self._registry.podman.exec_container(
+            rc, out, err = await self.registry.podman.exec_container(
                 state.container_id,
                 # bash -c (NON-login): sources nothing, so the probe is
                 # deterministic and insulated from the user's interactive
@@ -622,7 +426,7 @@ class HealthMonitor:
                 ["bash", "-c", state.health_check],
                 user="klangk",
                 extra_env={"HOME": user_home},
-                timeout=HEALTH_CHECK_TIMEOUT_SECONDS,
+                timeout=self.registry.health_check_timeout,
             )
         except (podman.PodmanError, asyncio.TimeoutError, OSError) as e:
             return "unhealthy", f"{type(e).__name__}: {e}"
@@ -691,7 +495,7 @@ class HealthMonitor:
         consumer can detect a missed transition.
         """
         state.health_seq += 1
-        self._connections.notify_service_health(
+        self.connections.notify_service_health(
             state.workspace_id,
             healthy=status == "healthy",
             message=message,
@@ -715,7 +519,7 @@ class HealthMonitor:
         stream is a single source of truth.
         """
         state.health_seq += 1
-        self._connections.notify_service_health(
+        self.connections.notify_service_health(
             state.workspace_id,
             healthy=False,
             message=None,
@@ -733,8 +537,8 @@ class HealthMonitor:
         loop being alive -- if the loop stalls, the heartbeats stop.
         """
         while True:
-            await asyncio.sleep(HEALTH_CHECK_INTERVAL_SECONDS)
-            for state in list(self._registry.states.values()):
+            await asyncio.sleep(self.registry.health_check_interval)
+            for state in list(self.registry.states.values()):
                 if not state.health_check:
                     continue
                 if not self._setup_complete(state):
@@ -751,7 +555,7 @@ class HealthMonitor:
 
     def _send_heartbeats(self) -> None:
         """Fan health heartbeats to opt-in connections."""
-        self._connections.send_health_heartbeats()
+        self.connections.send_health_heartbeats()
 
     def start_health_loop(self) -> None:
         if self.health_task is None:
@@ -772,39 +576,174 @@ class ContainerRegistry:
     threading.
     """
 
-    def __init__(self, settings: "KlangkSettings | None" = None):
-        self.settings = settings
+    def __init__(self, app_state):
+        self.app_state = app_state
+        self.settings = app_state.settings
+
+        # --- settings-derived attrs (computed once, #1487) ---
+        s = self.settings
+        self.image_name: str = s.image_name or "klangk-workspace"
+        self.terminal_banner: str = s.terminal_banner or ""
+        self.allowed_images: set[str] = set()
+        if s.allowed_images:
+            self.allowed_images = {
+                img.strip()
+                for img in s.allowed_images.split(",")
+                if img.strip()
+            }
+        self.allowed_images.add(self.image_name)
+        self.allowed_mount_roots: list[str] = []
+        if s.allowed_mount_roots:
+            self.allowed_mount_roots = [
+                os.path.realpath(p.strip())
+                for p in s.allowed_mount_roots.split(",")
+                if p.strip()
+            ]
+        self.port_range_start: int = int(s.port_range_start or "9000")
+        self.idle_timeout_seconds, self.check_interval_seconds = (
+            self._parse_idle_timeout()
+        )
+        self.health_check_interval: float = float(
+            s.health_check_interval or "30"
+        )
+        self.health_check_timeout: float = float(
+            s.health_check_timeout or "10"
+        )
+        self.health_check_startup_grace: float = float(
+            s.health_check_startup_grace or "30"
+        )
+
         self.states: dict[str, ContainerState] = {}
-        # Reverse lookup: container_id -> workspace_id
         self._cid_to_wsid: dict[str, str] = {}
-        # Per-workspace locks to serialize container creation.
         self._workspace_locks: dict[str, asyncio.Lock] = {}
-        # Per-container locks serializing the service-command fire
-        # sequence (window-exists -> new-window -> send-keys) so the boot
-        # path and the per-connection path can't both create a duplicate
-        # ``service-cmd`` tmux window (#1188). Owned here, not in
-        # terminal.py — terminal reaches it via app_state (#1478).
         self._service_session_locks: dict[str, asyncio.Lock] = {}
         self.on_workspace_killed = None
         self.on_container_status_changed = None
 
         # Collaborators
-        self.ports = PortAllocator()
+        self.ports = PortAllocator(self)
         self.browsers = BrowserRouter()
         self.idle = IdleMonitor(self)
         self.health = HealthMonitor(self)
 
-        # Back-reference to ``app.state`` (set by ``build_app()`` after
-        # construction). Used to pass ``app_state`` to ``bringup.bringup``
-        # and other callees that need explicit dependency threading.
-        self.app_state = None
-
         # The WebSocketState instance (set by build_app after construction,
-        # #1464). The HealthMonitor reaches it via self._registry.sockets.
+        # #1464). The HealthMonitor reaches it via self.registry.sockets.
         self.sockets = None
         # The Podman instance (set by build_app after construction, #1468).
         # Internal callers reach the CLI wrappers via self.podman.X.
         self.podman = None
+
+    # --- settings-derived methods (were module functions, #1487) ---
+
+    def container_dns_config(self) -> list[str]:
+        """Return DNS server list from settings.dns_servers."""
+        raw = self.settings.dns_servers or ""
+        return [d.strip() for d in raw.split(",") if d.strip()]
+
+    def image_pull_policy(self) -> str:
+        """Resolve the workspace-image pull policy from settings."""
+        policy = self.settings.image_pull_policy or "never"
+        if policy not in _VALID_PULL_POLICIES:
+            logger.warning(
+                "Invalid KLANGK_IMAGE_PULL_POLICY=%r (valid: %s); using 'never'.",
+                policy,
+                ", ".join(sorted(_VALID_PULL_POLICIES)),
+            )
+            return "never"
+        return policy
+
+    def _is_protected(self, source: str) -> bool:
+        """True if source is a protected host path that must never be mounted."""
+        resolved = os.path.realpath(source)
+        data_dir = os.path.realpath(
+            self.settings.data_dir or os.path.expanduser("~/.klangk/data")
+        )
+        for blocked in [*_PROTECTED_PATHS, data_dir]:
+            blocked = os.path.realpath(blocked)
+            if resolved == blocked or resolved.startswith(blocked + "/"):
+                return True
+        return False
+
+    def validate_mount_spec(self, spec: str) -> str | None:
+        """Validate a container mount spec string."""
+        parts = spec.split(":")
+        if len(parts) < 2 or len(parts) > 3:
+            return f"Invalid mount {spec!r}: expected source:dest or source:dest:options"
+        source, dest = parts[0], parts[1]
+        if not source:
+            return f"Invalid mount {spec!r}: source is empty"
+        if not dest.startswith("/"):
+            return f"Invalid mount {spec!r}: container path must be absolute (start with /)"
+        if len(parts) == 3:
+            options = parts[2]
+            for opt in options.split(","):
+                if opt and opt not in _VALID_MOUNT_OPTIONS:
+                    return f"Invalid mount {spec!r}: unknown option {opt!r}"
+        if not _is_named_volume(source):
+            if self._is_protected(source):
+                return (
+                    f"Invalid mount {spec!r}: source is a protected host path"
+                )
+            if self.allowed_mount_roots:
+                resolved = os.path.realpath(source)
+                if not any(
+                    resolved == root or resolved.startswith(root + "/")
+                    for root in self.allowed_mount_roots
+                ):
+                    allowed = ", ".join(self.allowed_mount_roots)
+                    return (
+                        f"Invalid mount {spec!r}: bind mount source must be "
+                        f"under an allowed root ({allowed})"
+                    )
+        return None
+
+    def validate_mounts(self, mounts: list[str]) -> str | None:
+        """Validate a list of mount specs. Returns first error or None."""
+        for spec in mounts:
+            error = self.validate_mount_spec(spec)
+            if error:
+                return error
+        return None
+
+    def _parse_idle_timeout(self) -> tuple[int, int]:
+        default = 30 * 60
+        env_val = self.settings.idle_timeout_seconds
+        if env_val is not None:
+            try:
+                timeout = int(env_val)
+            except ValueError:
+                logger.warning(
+                    "KLANGK_IDLE_TIMEOUT_SECONDS=%r is not a valid integer, "
+                    "using default %d",
+                    env_val,
+                    default,
+                )
+                timeout = default
+        else:
+            timeout = default
+        interval = max(10, min(60, timeout // 3))
+        return timeout, interval
+
+    def ports_per_workspace_cap(self) -> int:
+        """Server-wide ceiling on hosted-app ports per workspace."""
+        raw = self.settings.hosted_ports_per_workspace or str(
+            DEFAULT_PORTS_PER_WORKSPACE
+        )
+        try:
+            return max(0, int(raw))
+        except ValueError:
+            logger.warning(
+                "KLANGK_HOSTED_PORTS_PER_WORKSPACE=%r is not an int; "
+                "using default %d",
+                raw,
+                DEFAULT_PORTS_PER_WORKSPACE,
+            )
+            return DEFAULT_PORTS_PER_WORKSPACE
+
+    def set_idle_timeout(self, seconds: int) -> None:
+        """Set the global idle timeout (replaces api mutating module globals)."""
+        self.idle_timeout_seconds = seconds
+        self.check_interval_seconds = max(10, min(60, seconds // 3))
 
     # --- Service-session locks (#1188, #1478) ---
     # The per-container firing-lock dict lives here on the registry. It used
@@ -878,7 +817,7 @@ class ContainerRegistry:
         state = self.states.get(workspace_id)
         was_new = state is None
         if was_new:
-            state = ContainerState(workspace_id, container_id)
+            state = ContainerState(workspace_id, container_id, self)
             self.states[workspace_id] = state
         else:
             # Remove old reverse mapping if container changed
@@ -1148,14 +1087,14 @@ class ContainerRegistry:
         releases all of its allocations; the returned empty list then
         suppresses the hosting env in :meth:`_build_env` (#1237).
         """
-        num_ports = min(num_ports, ports_per_workspace_cap())
+        num_ports = min(num_ports, self.ports_per_workspace_cap())
         async with self.port_lock:
             host_ports = await model.get_workspace_ports(workspace_id)
             if len(host_ports) < num_ports:
                 new_ports = await model.find_and_allocate_ports(
                     workspace_id,
                     num_ports - len(host_ports),
-                    PORT_RANGE_START,
+                    self.port_range_start,
                 )
                 host_ports.extend(new_ports)
             elif len(host_ports) > num_ports:
@@ -1203,9 +1142,9 @@ class ContainerRegistry:
             if hosting_base_path is None:
                 hosting_base_path = b
         env_vars: list[str] = []
-        nginx_port = util.resolve_env_value("KLANGK_NGINX_PORT", "8995")
+        nginx_port = self.settings.nginx_port or "8995"
         proxy_url = f"http://host.containers.internal:{nginx_port}/llm-proxy"
-        llm_model = util.resolve_env_value("KLANGK_LLM_MODEL", "")
+        llm_model = self.settings.llm_model or ""
         env_vars.append(f"KLANGK_LLM_PROXY_URL={proxy_url}")
         if llm_model:
             env_vars.append(f"KLANGK_LLM_MODEL={llm_model}")
@@ -1235,8 +1174,8 @@ class ContainerRegistry:
         env_vars.append(
             f"KLANGK_BRIDGE_URL=http://host.containers.internal:{nginx_port}"
         )
-        if TERMINAL_BANNER:
-            env_vars.append(f"KLANGK_TERMINAL_BANNER={TERMINAL_BANNER}")
+        if self.terminal_banner:
+            env_vars.append(f"KLANGK_TERMINAL_BANNER={self.terminal_banner}")
 
         # Runtime SSL/CA trust (#1181): point OpenSSL/Python/curl/Node
         # at the bundle the entrypoint builds from the mounted certs.
@@ -1257,7 +1196,7 @@ class ContainerRegistry:
     async def _ensure_volumes(
         extra_mounts: list[str] | None,
         user_id: str | None,
-        podman=None,
+        podman,
     ) -> None:
         """Create named volumes and validate bind-mount sources."""
         if not extra_mounts:
@@ -1390,7 +1329,7 @@ class ContainerRegistry:
         cid: str,
         container_name: str,
         publish: list[tuple[int, int]],
-        podman=None,
+        podman,
     ) -> None:
         """Remove stale containers holding conflicting ports."""
         logger.warning(
@@ -1452,11 +1391,11 @@ class ContainerRegistry:
     ) -> tuple[str, str]:
         """Inner implementation of start_container (called under lock)."""
         t_start = time.monotonic()
-        resolved_image = image or IMAGE_NAME
-        if resolved_image not in ALLOWED_IMAGES:
+        resolved_image = image or self.image_name
+        if resolved_image not in self.allowed_images:
             raise ValueError(
                 f"Image {resolved_image!r} is not in the allowed "
-                f"list: {sorted(ALLOWED_IMAGES)}"
+                f"list: {sorted(self.allowed_images)}"
             )
 
         # Reuse a running container or remove a stopped one.
@@ -1513,7 +1452,11 @@ class ContainerRegistry:
         ]
         iid = model.get_instance_id()
         container_name = f"klangk-{iid}-{workspace_id[:12]}"
-        allow_sudo = util.resolve_env_bool("KLANGK_ALLOW_SUDO")
+        allow_sudo = (self.settings.allow_sudo or "").strip().lower() in (
+            "1",
+            "true",
+            "yes",
+        )
 
         create_kwargs = dict(
             labels={
@@ -1529,14 +1472,12 @@ class ContainerRegistry:
             },
             publish=publish,
             add_hosts=["host.containers.internal:host-gateway"],
-            dns=container_dns_config() or None,
+            dns=self.container_dns_config() or None,
             env=env_vars,
             init=True,
             interactive=True,
-            userns=util.resolve_env_value(
-                "KLANGK_USERNS", "keep-id:uid=1000,gid=1000"
-            ),
-            pull=image_pull_policy(),
+            userns=self.settings.userns or "keep-id:uid=1000,gid=1000",
+            pull=self.image_pull_policy(),
         )
 
         logger.info(
@@ -1681,11 +1622,9 @@ class ContainerRegistry:
         try:
             cid = await self.podman.create_container(
                 "klangk-prewarm",
-                IMAGE_NAME,
+                self.image_name,
                 pull="never",
-                userns=util.resolve_env_value(
-                    "KLANGK_USERNS", "keep-id:uid=1000,gid=1000"
-                ),
+                userns=self.settings.userns or "keep-id:uid=1000,gid=1000",
             )
             await self.podman.remove_container(cid)
             logger.info("Podman pre-warmed in %.3fs", time.monotonic() - t0)

--- a/src/backend/klangk_backend/files.py
+++ b/src/backend/klangk_backend/files.py
@@ -42,7 +42,7 @@ def validate_path(path: str) -> str:
 
 
 async def list_files(
-    container_id: str, path: str = "/", podman=None
+    container_id: str, path: str = "/", *, podman
 ) -> list[dict]:
     """List files and directories at the given path inside the container."""
     path = validate_path(path)
@@ -99,7 +99,7 @@ async def list_files(
     return entries
 
 
-async def stat_path(container_id: str, path: str, podman=None) -> dict | None:
+async def stat_path(container_id: str, path: str, podman) -> dict | None:
     """Stat a single path.  Returns ``{"is_dir": bool, "size": int}``
     or ``None`` if the path does not exist."""
     path = validate_path(path)
@@ -122,7 +122,7 @@ async def stat_path(container_id: str, path: str, podman=None) -> dict | None:
     return {"is_dir": is_dir, "size": size}
 
 
-async def read_file(container_id: str, path: str, podman=None) -> str | None:
+async def read_file(container_id: str, path: str, podman) -> str | None:
     """Read file contents as text.  Returns None if missing or > 1 MB."""
     path = validate_path(path)
     info = await stat_path(container_id, path, podman)
@@ -141,7 +141,7 @@ async def read_file(container_id: str, path: str, podman=None) -> str | None:
 
 
 def stream_file(
-    container_id: str, path: str, podman=None
+    container_id: str, path: str, podman
 ) -> AsyncGenerator[bytes, None]:
     """Stream file contents as raw bytes for download."""
     path = validate_path(path)
@@ -153,7 +153,7 @@ def stream_file(
 
 
 def stream_dir_tar(
-    container_id: str, path: str, podman=None
+    container_id: str, path: str, podman
 ) -> AsyncGenerator[bytes, None]:
     """Stream a directory as a tar.gz archive for download."""
     path = validate_path(path)
@@ -172,7 +172,7 @@ def stream_dir_tar(
     )
 
 
-async def delete_path(container_id: str, path: str, podman=None) -> str:
+async def delete_path(container_id: str, path: str, podman) -> str:
     """Delete a file or directory.  Returns the path deleted."""
     path = validate_path(path)
     # Check existence first
@@ -194,7 +194,7 @@ async def delete_path(container_id: str, path: str, podman=None) -> str:
 
 
 async def rename_path(
-    container_id: str, old_path: str, new_path: str, podman=None
+    container_id: str, old_path: str, new_path: str, podman
 ) -> str:
     """Rename/move a file or directory.  Returns the new path."""
     old_path = validate_path(old_path)
@@ -234,7 +234,7 @@ async def rename_path(
 
 
 async def write_file(
-    container_id: str, path: str, content: bytes, podman=None
+    container_id: str, path: str, content: bytes, podman
 ) -> str:
     """Write file contents.  Returns the path written."""
     path = validate_path(path)

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -155,7 +155,7 @@ def _is_loopback_bind(host: str) -> bool:
         return False
 
 
-def enforce_no_auth_bind_safety(app_state=None) -> None:
+def enforce_no_auth_bind_safety(app_state) -> None:
     """Refuse to start in ``none`` auth mode unless the bind is loopback.
 
     ``KLANGK_AUTH_MODES=none`` freely issues a token for the seeded default
@@ -740,7 +740,7 @@ def build_app(settings: KlangkSettings) -> FastAPI:
     app.state.settings = settings
     # Slice 2 (#1449): the container registry is an owned instance, not a
     # module global. The lifespan reads app.state.container_registry.
-    app.state.container_registry = container.ContainerRegistry(settings)
+    app.state.container_registry = container.ContainerRegistry(app.state)
     # Slice 2b (#1463): nginx watchdog is an owned instance with start/stop
     # lifecycle methods called by the lifespan.
     app.state.nginx_watchdog = NginxWatchdog(settings)

--- a/src/backend/klangk_backend/oidc.py
+++ b/src/backend/klangk_backend/oidc.py
@@ -174,7 +174,7 @@ class OIDC:
     don't leak across test runs (previously module globals).
     """
 
-    def __init__(self, app_state=None):
+    def __init__(self, app_state):
         self.app_state = app_state
         self.settings = app_state.settings
         self.providers: list[OIDCProvider] = []

--- a/src/backend/klangk_backend/plugins.py
+++ b/src/backend/klangk_backend/plugins.py
@@ -31,7 +31,7 @@ class Plugins:
     load time (honoring ``file:``/``cmd:`` prefixes for plugin secrets).
     """
 
-    def __init__(self, app_state=None):
+    def __init__(self, app_state):
         self.app_state = app_state
         self.settings = app_state.settings
         self.plugins_dir = self.settings.plugins_dir or os.path.join(

--- a/src/backend/klangk_backend/terminal.py
+++ b/src/backend/klangk_backend/terminal.py
@@ -223,7 +223,7 @@ class Terminal:
     single ``app_state`` reference rather than three separate ctor args.
     """
 
-    def __init__(self, app_state=None):
+    def __init__(self, app_state):
         self._app_state = app_state
 
     @property

--- a/src/backend/klangk_backend/workspaces.py
+++ b/src/backend/klangk_backend/workspaces.py
@@ -132,7 +132,7 @@ class Workspaces:
     import-time env read (the frozen-at-import hazard).
     """
 
-    def __init__(self, app_state=None):
+    def __init__(self, app_state):
         self.app_state = app_state
         self.settings = app_state.settings
         raw = self.settings.data_dir or str(Path.home() / ".klangk" / "data")

--- a/src/backend/klangk_backend/wshandler/connection.py
+++ b/src/backend/klangk_backend/wshandler/connection.py
@@ -464,7 +464,9 @@ class Connection:
             f"{container_name}{ports_str}",
             "created": f"Created new container {container_name}{ports_str}",
         }.get(status, "Container ready")
-        status_msg += format_idle_timeout(container.IDLE_TIMEOUT_SECONDS)
+        status_msg += format_idle_timeout(
+            self.app_state.container_registry.idle_timeout_seconds
+        )
 
         self.sock.send_json(
             {
@@ -557,7 +559,9 @@ class Connection:
         container_name, ports_str = format_container_info(workspace_id, ports)
         status_msg = f"Container restarted {container_name}{ports_str}"
 
-        timeout_mins = container.IDLE_TIMEOUT_SECONDS / 60
+        timeout_mins = (
+            self.app_state.container_registry.idle_timeout_seconds / 60
+        )
         if timeout_mins == int(timeout_mins):
             status_msg += f" — idle timeout: {int(timeout_mins)}m"
         else:

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -201,11 +201,9 @@ def app_state(temp_data_dir):
     from klangk_backend.workspaces import Workspaces
 
     settings = KlangkSettings(os.environ)
-    registry = ContainerRegistry(settings)
-    state = types.SimpleNamespace(
-        container_registry=registry,
-        settings=settings,
-    )
+    state = types.SimpleNamespace(settings=settings)
+    registry = ContainerRegistry(state)
+    state.container_registry = registry
     registry.app_state = state
     state.workspaces = Workspaces(state)
     return state

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -16,7 +16,6 @@ from klangk_backend import (
     agent,
     api,
     auth,
-    container,
     model,
     podman,
     workspaces as ws_mod,
@@ -47,9 +46,9 @@ async def app(db, temp_data_dir):
             "KLANGK_CUSTOMIZE_DIR": str(temp_data_dir / "customize"),
         }
     )
-    registry = ContainerRegistry(settings)
-    sockets = WebSocketState()
     app.state.settings = settings
+    registry = ContainerRegistry(app.state)
+    sockets = WebSocketState()
     app.state.container_registry = registry
     app.state.sockets = sockets
     registry.sockets = sockets
@@ -1784,7 +1783,7 @@ class TestWorkspaceRoutes:
         )
         assert resp.status_code == 404
 
-    async def test_workspace_status_running(self, client, user, registry):
+    async def test_workspace_status_running(self, client, user, registry, app):
         headers = await _auth_headers(client)
         create_resp = await client.post(
             "/api/v1/workspaces",
@@ -1806,7 +1805,10 @@ class TestWorkspaceRoutes:
         assert data["container_id"] == "cid-status"
         assert data["health"] is None  # placeholder
         assert isinstance(data["idle_seconds"], (int, float))
-        assert data["idle_timeout"] == api.container.IDLE_TIMEOUT_SECONDS
+        assert (
+            data["idle_timeout"]
+            == app.state.container_registry.idle_timeout_seconds
+        )
         assert isinstance(data["ports"], list)
 
         # Clean up registry state.
@@ -4599,14 +4601,16 @@ class TestFileRoutes:
 class TestSetIdleTimeout:
     async def test_set_idle_timeout_global(self, db, app, registry):
         """Setting global idle timeout changes the module-level variable."""
-        original_timeout = container.IDLE_TIMEOUT_SECONDS
+        original_timeout = app.state.container_registry.idle_timeout_seconds
         try:
-            container.IDLE_TIMEOUT_SECONDS = 42
-            assert container.IDLE_TIMEOUT_SECONDS == 42
+            app.state.container_registry.idle_timeout_seconds = 42
+            assert app.state.container_registry.idle_timeout_seconds == 42
             # Per-workspace lookup falls back to global
             assert registry.get_workspace_idle_timeout("any") == 42
         finally:
-            container.IDLE_TIMEOUT_SECONDS = original_timeout
+            app.state.container_registry.idle_timeout_seconds = (
+                original_timeout
+            )
 
     async def test_endpoint_missing_without_test_mode(self, client):
         """Without KLANGK_TEST_MODE, the endpoints should not exist."""
@@ -4619,12 +4623,15 @@ class TestSetIdleTimeout:
 
     async def test_set_idle_timeout_per_workspace(self, db, app, registry):
         """Per-workspace idle timeout should not affect global."""
-        original_timeout = container.IDLE_TIMEOUT_SECONDS
+        original_timeout = app.state.container_registry.idle_timeout_seconds
         try:
             registry.track_activity("cid-test", "ws-test")
             registry.set_workspace_idle_timeout("ws-test", 5)
             assert registry.get_workspace_idle_timeout("ws-test") == 5
-            assert container.IDLE_TIMEOUT_SECONDS == original_timeout
+            assert (
+                app.state.container_registry.idle_timeout_seconds
+                == original_timeout
+            )
             # Unknown workspace returns global default
             assert (
                 registry.get_workspace_idle_timeout("ws-other")
@@ -4646,8 +4653,8 @@ class TestSetIdleTimeout:
             assert state.idle_timeout == 6
             # Global CHECK_INTERVAL_SECONDS should be unchanged
             assert (
-                container.CHECK_INTERVAL_SECONDS
-                == container.parse_idle_timeout()[1]
+                app.state.container_registry.check_interval_seconds
+                == app.state.container_registry._parse_idle_timeout()[1]
             )
         finally:
             registry.states.pop("ws-fast", None)
@@ -5622,7 +5629,7 @@ class TestAdminResourceACL:
         )
         assert resp.status_code == 200
 
-    async def test_get_resource_acl_requires_admin(self, client, app, user):
+    async def test_get_resource_acl_requires_admin(self, client, user):
         headers = await _auth_headers(client)
         resp = await client.get(
             "/api/v1/admin/acl/resource?resource=/workspaces", headers=headers
@@ -5721,14 +5728,14 @@ class TestSanitizeFilename:
 
 
 class TestRmtree:
-    def test_removes_directory(self, temp_data_dir, app):
+    def test_removes_directory(self, temp_data_dir):
         d = temp_data_dir / "workspaces" / "toremove"
         d.mkdir(parents=True)
         (d / "file.txt").write_text("data")
         ws_mod.rmtree(d, "test")
         assert not d.exists()
 
-    def test_logs_errors(self, temp_data_dir, caplog, app):
+    def test_logs_errors(self, temp_data_dir, caplog):
         """Logs warnings on individual file removal failures."""
         d = temp_data_dir / "workspaces" / "failremove"
         d.mkdir(parents=True)
@@ -6138,7 +6145,7 @@ class TestWorkspaceExportImport:
             assert metadata["name"] == "export-test"
             assert "instance_id" in metadata
 
-    async def test_export_requires_admin(self, client, user, app):
+    async def test_export_requires_admin(self, client, user):
         headers = await self._user_headers(client)
         resp = await client.post(
             "/api/v1/workspaces", headers=headers, json={"name": "no-export"}
@@ -6151,7 +6158,7 @@ class TestWorkspaceExportImport:
         )
         assert resp.status_code == 403
 
-    async def test_export_not_found(self, client, admin_user, app):
+    async def test_export_not_found(self, client, admin_user):
         headers = await self._admin_headers(client)
         resp = await client.get(
             "/api/v1/workspaces/nonexistent-id/export", headers=headers
@@ -6540,7 +6547,7 @@ class TestWorkspaceExportImport:
         assert resp.status_code == 200
         assert resp.json()["name"] == "img-fallback"
 
-    async def test_import_invalid_mounts_dropped(self, client, app, user):
+    async def test_import_invalid_mounts_dropped(self, client, user):
         """Archive with invalid mounts drops them silently."""
         import io
         import json
@@ -6709,7 +6716,7 @@ class TestWorkspaceExportImport:
         # Falls back to 0 * 0.4 = 0, clamped to 1
         assert resp.headers["x-estimated-size"] == "1"
 
-    async def test_export_empty_workspace(self, client, app, admin_user, user):
+    async def test_export_empty_workspace(self, client, admin_user, user):
         """Export of workspace with no home dir still works."""
         headers = await self._user_headers(client)
         resp = await client.post(
@@ -7706,7 +7713,7 @@ class TestInvitations:
         assert resp.status_code == 400
         assert "already exists" in resp.json()["detail"]
 
-    async def test_accept_invite_wrong_purpose_token(self, client, app, db):
+    async def test_accept_invite_wrong_purpose_token(self, client, db):
         # Use a verification token (wrong purpose)
         token = auth.create_verification_token("fake-user-id")
         resp = await client.post(
@@ -8591,7 +8598,7 @@ class TestOIDCLogout:
             == "https://idp.example.com/logout?x=1"
         )
 
-    async def test_logout_no_redirect_for_local_user(self, client, app, user):
+    async def test_logout_no_redirect_for_local_user(self, client, user):
         """Local user gets no oidc_logout_url."""
         login_resp = await client.post(
             "/api/v1/auth/login",

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -19,16 +19,16 @@ def _make_app_state(registry=None, sockets=None):
     from klangk_backend.wshandler.session import WebSocketState
 
     settings = KlangkSettings(env={})
-    if registry is None:
-        registry = container.ContainerRegistry(settings)
     if sockets is None:
         sockets = WebSocketState()
 
     app_state = types.SimpleNamespace(
-        container_registry=registry,
         sockets=sockets,
         settings=settings,
     )
+    if registry is None:
+        registry = container.ContainerRegistry(app_state)
+    app_state.container_registry = registry
     registry.sockets = sockets
     registry.app_state = app_state
     sockets.app_state = app_state
@@ -65,34 +65,37 @@ def _stub_bringup(monkeypatch):
 
 
 class TestParseIdleTimeout:
-    def test_default_values(self, monkeypatch):
-        monkeypatch.delenv("KLANGK_IDLE_TIMEOUT_SECONDS", raising=False)
-        timeout, interval = container.parse_idle_timeout()
-        assert timeout == 30 * 60
-        assert interval == max(10, min(60, timeout // 3))
+    def _registry(self, env):
+        import types as types_mod
+        from klangk_backend.settings import KlangkSettings
 
-    def test_custom_value(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_IDLE_TIMEOUT_SECONDS", "120")
-        timeout, interval = container.parse_idle_timeout()
-        assert timeout == 120
-        assert interval == max(10, min(60, 120 // 3))
+        settings = KlangkSettings(env=env)
+        app_state = types_mod.SimpleNamespace(settings=settings)
+        return container.ContainerRegistry(app_state)
 
-    def test_invalid_value_uses_default(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_IDLE_TIMEOUT_SECONDS", "not_a_number")
-        timeout, interval = container.parse_idle_timeout()
-        assert timeout == 30 * 60
+    def test_default_values(self):
+        reg = self._registry({})
+        assert reg.idle_timeout_seconds == 30 * 60
+        assert reg.check_interval_seconds == max(10, min(60, 30 * 60 // 3))
 
-    def test_small_value_clamps_interval(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_IDLE_TIMEOUT_SECONDS", "15")
-        timeout, interval = container.parse_idle_timeout()
-        assert timeout == 15
-        assert interval == 10  # clamped to min 10
+    def test_custom_value(self):
+        reg = self._registry({"KLANGK_IDLE_TIMEOUT_SECONDS": "120"})
+        assert reg.idle_timeout_seconds == 120
+        assert reg.check_interval_seconds == max(10, min(60, 120 // 3))
 
-    def test_large_value_clamps_interval(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_IDLE_TIMEOUT_SECONDS", "3600")
-        timeout, interval = container.parse_idle_timeout()
-        assert timeout == 3600
-        assert interval == 60  # clamped to max 60
+    def test_invalid_value_uses_default(self):
+        reg = self._registry({"KLANGK_IDLE_TIMEOUT_SECONDS": "not_a_number"})
+        assert reg.idle_timeout_seconds == 30 * 60
+
+    def test_small_value_clamps_interval(self):
+        reg = self._registry({"KLANGK_IDLE_TIMEOUT_SECONDS": "15"})
+        assert reg.idle_timeout_seconds == 15
+        assert reg.check_interval_seconds == 10  # clamped to min 10
+
+    def test_large_value_clamps_interval(self):
+        reg = self._registry({"KLANGK_IDLE_TIMEOUT_SECONDS": "3600"})
+        assert reg.idle_timeout_seconds == 3600
+        assert reg.check_interval_seconds == 60  # clamped to max 60
 
 
 class TestSslCertDir:
@@ -142,18 +145,34 @@ class TestSslCertDir:
 
 
 class TestImagePullPolicy:
-    def test_default_is_never(self, monkeypatch):
-        monkeypatch.delenv("KLANGK_IMAGE_PULL_POLICY", raising=False)
-        assert container.image_pull_policy() == "never"
+    def setup_method(self):
+        app_state = _make_app_state()
+        self.registry = app_state.container_registry
 
-    def test_valid_override(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_IMAGE_PULL_POLICY", "missing")
-        assert container.image_pull_policy() == "missing"
+    def test_default_is_never(self):
+        assert self.registry.image_pull_policy() == "never"
 
-    def test_invalid_falls_back_to_never(self, monkeypatch, caplog):
-        monkeypatch.setenv("KLANGK_IMAGE_PULL_POLICY", "sometimes")
+    def test_valid_override(self):
+        # Rebuild registry with env override
+        import types as types_mod
+        from klangk_backend.settings import KlangkSettings
+
+        settings = KlangkSettings(env={"KLANGK_IMAGE_PULL_POLICY": "missing"})
+        app_state = types_mod.SimpleNamespace(settings=settings)
+        reg = container.ContainerRegistry(app_state)
+        assert reg.image_pull_policy() == "missing"
+
+    def test_invalid_falls_back_to_never(self, caplog):
+        import types as types_mod
+        from klangk_backend.settings import KlangkSettings
+
+        settings = KlangkSettings(
+            env={"KLANGK_IMAGE_PULL_POLICY": "sometimes"}
+        )
+        app_state = types_mod.SimpleNamespace(settings=settings)
+        reg = container.ContainerRegistry(app_state)
         with caplog.at_level("WARNING"):
-            assert container.image_pull_policy() == "never"
+            assert reg.image_pull_policy() == "never"
         assert "Invalid KLANGK_IMAGE_PULL_POLICY" in caplog.text
 
 
@@ -307,22 +326,26 @@ class TestIdleCallbacks:
 
 
 class TestPortAllocation:
+    def setup_method(self):
+        app_state = _make_app_state()
+        self.registry = app_state.container_registry
+
     async def test_allocate_ports(self, workspace):
         ports = await model.find_and_allocate_ports(
-            workspace["id"], 3, container.PORT_RANGE_START
+            workspace["id"], 3, self.registry.port_range_start
         )
         assert len(ports) == 3
-        assert all(p >= container.PORT_RANGE_START for p in ports)
+        assert all(p >= self.registry.port_range_start for p in ports)
 
     async def test_allocate_ports_avoids_used(self, workspace, user):
         # Allocate some ports for workspace 1
         ports1 = await model.find_and_allocate_ports(
-            workspace["id"], 3, container.PORT_RANGE_START
+            workspace["id"], 3, self.registry.port_range_start
         )
         # Create second workspace and allocate
         ws2 = await model.create_workspace(user["id"], "ws2")
         ports2 = await model.find_and_allocate_ports(
-            ws2["id"], 3, container.PORT_RANGE_START
+            ws2["id"], 3, self.registry.port_range_start
         )
         # No overlap
         assert set(ports1).isdisjoint(set(ports2))
@@ -331,7 +354,7 @@ class TestPortAllocation:
         app_state = _make_app_state()
         registry = app_state.container_registry
         allocated = await model.find_and_allocate_ports(
-            workspace["id"], 2, container.PORT_RANGE_START
+            workspace["id"], 2, self.registry.port_range_start
         )
         retrieved = await registry.get_workspace_ports(workspace["id"])
         assert retrieved == sorted(allocated)
@@ -344,29 +367,42 @@ class TestPortAllocation:
 
 
 class TestDnsConfig:
-    def test_no_env_returns_empty(self, monkeypatch):
-        monkeypatch.delenv("KLANGK_DNS_SERVERS", raising=False)
-        assert container.container_dns_config() == []
+    def _registry(self, env):
+        import types as types_mod
+        from klangk_backend.settings import KlangkSettings
 
-    def test_single_server(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_DNS_SERVERS", "100.100.100.100")
-        assert container.container_dns_config() == ["100.100.100.100"]
+        settings = KlangkSettings(env=env)
+        app_state = types_mod.SimpleNamespace(settings=settings)
+        return container.ContainerRegistry(app_state)
 
-    def test_multiple_servers(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_DNS_SERVERS", "100.100.100.100, 8.8.8.8")
-        assert container.container_dns_config() == [
-            "100.100.100.100",
-            "8.8.8.8",
-        ]
+    def test_no_env_returns_empty(self):
+        assert self._registry({}).container_dns_config() == []
 
-    def test_empty_string(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_DNS_SERVERS", "")
-        assert container.container_dns_config() == []
+    def test_single_server(self):
+        assert self._registry(
+            {"KLANGK_DNS_SERVERS": "100.100.100.100"}
+        ).container_dns_config() == ["100.100.100.100"]
+
+    def test_multiple_servers(self):
+        result = self._registry(
+            {"KLANGK_DNS_SERVERS": "100.100.100.100, 8.8.8.8"}
+        ).container_dns_config()
+        assert result == ["100.100.100.100", "8.8.8.8"]
+
+    def test_empty_string(self):
+        assert (
+            self._registry({"KLANGK_DNS_SERVERS": ""}).container_dns_config()
+            == []
+        )
 
 
 class TestConstants:
+    def setup_method(self):
+        app_state = _make_app_state()
+        self.registry = app_state.container_registry
+
     def test_port_range_start(self):
-        assert container.PORT_RANGE_START == 9000
+        assert self.registry.port_range_start == 9000
 
     def test_container_port_start(self):
         assert container.CONTAINER_PORT_START == 8000
@@ -378,25 +414,48 @@ class TestConstants:
 class TestPortsPerWorkspaceCap:
     """KLANGK_HOSTED_PORTS_PER_WORKSPACE resolver (#1237)."""
 
-    def test_default_when_unset(self, monkeypatch):
-        monkeypatch.delenv("KLANGK_HOSTED_PORTS_PER_WORKSPACE", raising=False)
-        assert container.ports_per_workspace_cap() == 5
+    def setup_method(self):
+        app_state = _make_app_state()
+        self.registry = app_state.container_registry
 
-    def test_override(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_HOSTED_PORTS_PER_WORKSPACE", "3")
-        assert container.ports_per_workspace_cap() == 3
+    def _registry(self, env):
+        import types as types_mod
+        from klangk_backend.settings import KlangkSettings
 
-    def test_zero_disables(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_HOSTED_PORTS_PER_WORKSPACE", "0")
-        assert container.ports_per_workspace_cap() == 0
+        settings = KlangkSettings(env=env)
+        app_state = types_mod.SimpleNamespace(settings=settings)
+        return container.ContainerRegistry(app_state)
+
+    def test_default_when_unset(self):
+        assert self._registry({}).ports_per_workspace_cap() == 5
+
+    def test_override(self):
+        assert (
+            self._registry(
+                {"KLANGK_HOSTED_PORTS_PER_WORKSPACE": "3"}
+            ).ports_per_workspace_cap()
+            == 3
+        )
+
+    def test_zero_disables(self):
+        assert (
+            self._registry(
+                {"KLANGK_HOSTED_PORTS_PER_WORKSPACE": "0"}
+            ).ports_per_workspace_cap()
+            == 0
+        )
 
     def test_garbage_falls_back_to_default(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_HOSTED_PORTS_PER_WORKSPACE", "abc")
-        assert container.ports_per_workspace_cap() == 5
+        monkeypatch.setattr(
+            self.registry.settings, "hosted_ports_per_workspace", "abc"
+        )
+        assert self.registry.ports_per_workspace_cap() == 5
 
     def test_negative_clamped_to_zero(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_HOSTED_PORTS_PER_WORKSPACE", "-2")
-        assert container.ports_per_workspace_cap() == 0
+        monkeypatch.setattr(
+            self.registry.settings, "hosted_ports_per_workspace", "-2"
+        )
+        assert self.registry.ports_per_workspace_cap() == 0
 
 
 # --- Container lifecycle tests (mocked) ---
@@ -483,7 +542,7 @@ class TestStartContainer:
         assert "!ALL" in str(call.args[1])
 
     async def test_sudo_enabled(self, workspace, monkeypatch):
-        monkeypatch.setenv("KLANGK_ALLOW_SUDO", "true")
+        monkeypatch.setattr(self.registry.settings, "allow_sudo", "true")
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
@@ -493,7 +552,7 @@ class TestStartContainer:
         assert "NOPASSWD:ALL" in str(call.args[1])
 
     async def test_sudo_disabled(self, workspace, monkeypatch):
-        monkeypatch.setenv("KLANGK_ALLOW_SUDO", "0")
+        monkeypatch.setattr(self.registry.settings, "allow_sudo", "0")
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
@@ -501,7 +560,7 @@ class TestStartContainer:
         assert "!ALL" in str(_sudo_call(p).args[1])
 
     async def test_sudo_disabled_false(self, workspace, monkeypatch):
-        monkeypatch.setenv("KLANGK_ALLOW_SUDO", "false")
+        monkeypatch.setattr(self.registry.settings, "allow_sudo", "false")
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
@@ -510,7 +569,7 @@ class TestStartContainer:
 
     async def test_sudo_toggled_off_to_on(self, workspace, monkeypatch):
         """Start with sudo disabled, restart with sudo enabled."""
-        monkeypatch.setenv("KLANGK_ALLOW_SUDO", "false")
+        monkeypatch.setattr(self.registry.settings, "allow_sudo", "false")
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
@@ -520,7 +579,7 @@ class TestStartContainer:
         # "Restart" — remove container state so start_container creates a new one
         self.registry.states.clear()
         await model.update_workspace_container(workspace["id"], None)
-        monkeypatch.setenv("KLANGK_ALLOW_SUDO", "true")
+        monkeypatch.setattr(self.registry.settings, "allow_sudo", "true")
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
@@ -529,7 +588,7 @@ class TestStartContainer:
 
     async def test_sudo_toggled_on_to_off(self, workspace, monkeypatch):
         """Start with sudo enabled, restart with sudo disabled."""
-        monkeypatch.setenv("KLANGK_ALLOW_SUDO", "true")
+        monkeypatch.setattr(self.registry.settings, "allow_sudo", "true")
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
@@ -538,7 +597,7 @@ class TestStartContainer:
 
         self.registry.states.clear()
         await model.update_workspace_container(workspace["id"], None)
-        monkeypatch.setenv("KLANGK_ALLOW_SUDO", "false")
+        monkeypatch.setattr(self.registry.settings, "allow_sudo", "false")
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
@@ -642,8 +701,8 @@ class TestStartContainer:
 
     async def test_llm_proxy_env_vars(self, workspace, monkeypatch):
         """Container gets proxy URL, not real API keys."""
-        monkeypatch.setenv("KLANGK_LLM_MODEL", "gemma4:31b")
-        monkeypatch.setenv("KLANGK_NGINX_PORT", "8995")
+        monkeypatch.setattr(self.registry.settings, "llm_model", "gemma4:31b")
+        monkeypatch.setattr(self.registry.settings, "nginx_port", "8995")
 
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
@@ -701,7 +760,9 @@ class TestStartContainer:
         assert p.create_container.call_args.kwargs["pull"] == "never"
 
     async def test_pull_policy_from_env(self, workspace, monkeypatch):
-        monkeypatch.setenv("KLANGK_IMAGE_PULL_POLICY", "missing")
+        monkeypatch.setattr(
+            self.registry.settings, "image_pull_policy", "missing"
+        )
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
@@ -798,7 +859,7 @@ class TestStartContainer:
 
     async def test_terminal_banner_custom(self, workspace, monkeypatch):
         """Deployer can set a terminal banner via env var."""
-        monkeypatch.setattr(container, "TERMINAL_BANNER", "Custom warning")
+        monkeypatch.setattr(self.registry, "terminal_banner", "Custom warning")
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"],
@@ -880,7 +941,7 @@ class TestStartContainer:
     async def test_excess_ports_trimmed(self, workspace):
         # Pre-allocate more ports than needed
         await model.find_and_allocate_ports(
-            workspace["id"], 5, container.PORT_RANGE_START
+            workspace["id"], 5, self.registry.port_range_start
         )
         with patch_podman(self.registry):
             await self.registry.start_container(
@@ -894,7 +955,9 @@ class TestStartContainer:
 
     async def test_cap_clamps_allocation_down(self, workspace, monkeypatch):
         """KLANGK_HOSTED_PORTS_PER_WORKSPACE clamps num_ports down (#1237)."""
-        monkeypatch.setenv("KLANGK_HOSTED_PORTS_PER_WORKSPACE", "3")
+        monkeypatch.setattr(
+            self.registry.settings, "hosted_ports_per_workspace", "3"
+        )
         with patch_podman(self.registry):
             await self.registry.start_container(
                 workspace["id"],
@@ -909,9 +972,11 @@ class TestStartContainer:
         self, workspace, monkeypatch
     ):
         """cap=0 trims an existing workspace's allocations on next start."""
-        monkeypatch.setenv("KLANGK_HOSTED_PORTS_PER_WORKSPACE", "0")
+        monkeypatch.setattr(
+            self.registry.settings, "hosted_ports_per_workspace", "0"
+        )
         await model.find_and_allocate_ports(
-            workspace["id"], 5, container.PORT_RANGE_START
+            workspace["id"], 5, self.registry.port_range_start
         )
         with patch_podman(self.registry):
             await self.registry.start_container(
@@ -925,7 +990,9 @@ class TestStartContainer:
 
     async def test_cap_zero_omits_hosting_env(self, workspace, monkeypatch):
         """cap=0 suppresses KLANGK_PORT_MAPPINGS / KLANGK_HOSTING_* (#1237)."""
-        monkeypatch.setenv("KLANGK_HOSTED_PORTS_PER_WORKSPACE", "0")
+        monkeypatch.setattr(
+            self.registry.settings, "hosted_ports_per_workspace", "0"
+        )
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"],
@@ -950,7 +1017,9 @@ class TestStartContainer:
         so a cap of 0 must keep port_allocations empty from the start —
         not just trim on the container's first start.
         """
-        monkeypatch.setenv("KLANGK_HOSTED_PORTS_PER_WORKSPACE", "0")
+        monkeypatch.setattr(
+            self.registry.settings, "hosted_ports_per_workspace", "0"
+        )
         await self.registry.allocate_ports(workspace["id"], 5)
         assert await self.registry.get_workspace_ports(workspace["id"]) == []
 
@@ -981,7 +1050,7 @@ class TestStartContainer:
                 "/tmp/home",
             )
         args, kwargs = p.create_container.call_args
-        assert args[1] == container.IMAGE_NAME
+        assert args[1] == self.registry.image_name
         assert kwargs["labels"]["klangk.managed"] == "true"
         assert kwargs["labels"]["klangk.workspace-id"] == workspace["id"]
         assert kwargs["init"] is True
@@ -1037,7 +1106,7 @@ class TestStartContainerPortConflict:
     async def test_port_conflict_removes_stale_and_retries(self, workspace):
         # Pre-allocate ports so we know exactly which ones the workspace gets.
         allocated = await model.find_and_allocate_ports(
-            workspace["id"], 5, container.PORT_RANGE_START
+            workspace["id"], 5, self.registry.port_range_start
         )
         conflict_port = allocated[0]
 
@@ -1078,7 +1147,7 @@ class TestStartContainerPortConflict:
 
     async def test_port_conflict_skips_own_container(self, workspace):
         allocated = await model.find_and_allocate_ports(
-            workspace["id"], 5, container.PORT_RANGE_START
+            workspace["id"], 5, self.registry.port_range_start
         )
         conflict_port = allocated[0]
 
@@ -1142,7 +1211,7 @@ class TestStartContainerPortConflict:
     async def test_port_conflict_stale_vanished(self, workspace):
         """Stale container gone by the time we inspect it."""
         await model.find_and_allocate_ports(
-            workspace["id"], 5, container.PORT_RANGE_START
+            workspace["id"], 5, self.registry.port_range_start
         )
         start_calls = []
 
@@ -1170,7 +1239,7 @@ class TestStartContainerPortConflict:
     async def test_port_conflict_bad_port_bindings(self, workspace):
         """Malformed HostPort values don't crash the retry."""
         await model.find_and_allocate_ports(
-            workspace["id"], 5, container.PORT_RANGE_START
+            workspace["id"], 5, self.registry.port_range_start
         )
         start_calls = []
 
@@ -1204,7 +1273,7 @@ class TestStartContainerPortConflict:
     async def test_port_conflict_remove_error_logged(self, workspace):
         """Error removing stale container is logged, not raised."""
         allocated = await model.find_and_allocate_ports(
-            workspace["id"], 5, container.PORT_RANGE_START
+            workspace["id"], 5, self.registry.port_range_start
         )
         conflict_port = allocated[0]
         start_calls = []
@@ -1253,123 +1322,142 @@ class TestStartContainerPortConflict:
 
 
 class TestValidateMountSpec:
+    def setup_method(self):
+        app_state = _make_app_state()
+        self.registry = app_state.container_registry
+
     def test_valid_bind_mount(self):
-        assert container.validate_mount_spec("/host:/container") is None
+        assert self.registry.validate_mount_spec("/host:/container") is None
 
     def test_valid_volume_mount(self):
-        assert container.validate_mount_spec("vol-name:/data") is None
+        assert self.registry.validate_mount_spec("vol-name:/data") is None
 
     def test_valid_with_options(self):
-        assert container.validate_mount_spec("/host:/container:ro") is None
+        assert self.registry.validate_mount_spec("/host:/container:ro") is None
 
     def test_valid_with_multiple_options(self):
         assert (
-            container.validate_mount_spec("/host:/container:ro,nocopy") is None
+            self.registry.validate_mount_spec("/host:/container:ro,nocopy")
+            is None
         )
 
     def test_no_colon(self):
-        err = container.validate_mount_spec("nocolon")
+        err = self.registry.validate_mount_spec("nocolon")
         assert err is not None
         assert "expected" in err.lower()
 
     def test_too_many_colons(self):
-        err = container.validate_mount_spec("a:b:c:d")
+        err = self.registry.validate_mount_spec("a:b:c:d")
         assert err is not None
 
     def test_empty_source(self):
-        err = container.validate_mount_spec(":/container")
+        err = self.registry.validate_mount_spec(":/container")
         assert err is not None
         assert "source is empty" in err.lower()
 
     def test_relative_container_path(self):
-        err = container.validate_mount_spec("/host:relative")
+        err = self.registry.validate_mount_spec("/host:relative")
         assert err is not None
         assert "absolute" in err.lower()
 
     def test_unknown_option(self):
-        err = container.validate_mount_spec("/host:/container:bogus")
+        err = self.registry.validate_mount_spec("/host:/container:bogus")
         assert err is not None
         assert "unknown option" in err.lower()
 
     def test_validate_mounts_list(self):
-        assert container.validate_mounts(["/a:/b", "vol:/c"]) is None
+        assert self.registry.validate_mounts(["/a:/b", "vol:/c"]) is None
 
     def test_validate_mounts_list_with_error(self):
-        err = container.validate_mounts(["/a:/b", "bad"])
+        err = self.registry.validate_mounts(["/a:/b", "bad"])
         assert err is not None
 
 
 class TestAllowedMountRoots:
+    def setup_method(self):
+        app_state = _make_app_state()
+        self.registry = app_state.container_registry
+
     def test_bind_mount_allowed(self, monkeypatch):
         monkeypatch.setattr(
-            container, "ALLOWED_MOUNT_ROOTS", ["/home", "/data"]
+            self.registry, "allowed_mount_roots", ["/home", "/data"]
         )
-        assert container.validate_mount_spec("/home/user/src:/work") is None
+        assert (
+            self.registry.validate_mount_spec("/home/user/src:/work") is None
+        )
 
     def test_bind_mount_exact_root(self, monkeypatch):
-        monkeypatch.setattr(container, "ALLOWED_MOUNT_ROOTS", ["/home"])
-        assert container.validate_mount_spec("/home:/work") is None
+        monkeypatch.setattr(self.registry, "allowed_mount_roots", ["/home"])
+        assert self.registry.validate_mount_spec("/home:/work") is None
 
     def test_bind_mount_denied(self, monkeypatch):
         monkeypatch.setattr(
-            container, "ALLOWED_MOUNT_ROOTS", ["/home", "/data"]
+            self.registry, "allowed_mount_roots", ["/home", "/data"]
         )
-        err = container.validate_mount_spec("/etc/passwd:/etc/passwd:ro")
+        err = self.registry.validate_mount_spec("/etc/passwd:/etc/passwd:ro")
         assert err is not None
         assert "allowed root" in err.lower()
 
     def test_bind_mount_traversal_denied(self, monkeypatch):
-        monkeypatch.setattr(container, "ALLOWED_MOUNT_ROOTS", ["/home"])
-        err = container.validate_mount_spec("/home/../etc:/work")
+        monkeypatch.setattr(self.registry, "allowed_mount_roots", ["/home"])
+        err = self.registry.validate_mount_spec("/home/../etc:/work")
         assert err is not None
         assert "allowed root" in err.lower()
 
     def test_named_volume_always_allowed(self, monkeypatch):
-        monkeypatch.setattr(container, "ALLOWED_MOUNT_ROOTS", ["/home"])
-        assert container.validate_mount_spec("my-volume:/data") is None
+        monkeypatch.setattr(self.registry, "allowed_mount_roots", ["/home"])
+        assert self.registry.validate_mount_spec("my-volume:/data") is None
 
     def test_no_restriction_when_empty(self, monkeypatch):
-        monkeypatch.setattr(container, "ALLOWED_MOUNT_ROOTS", [])
-        assert container.validate_mount_spec("/etc/shadow:/secrets") is None
+        monkeypatch.setattr(self.registry, "allowed_mount_roots", [])
+        assert (
+            self.registry.validate_mount_spec("/etc/shadow:/secrets") is None
+        )
 
     def test_multiple_roots(self, monkeypatch):
         monkeypatch.setattr(
-            container, "ALLOWED_MOUNT_ROOTS", ["/home", "/data", "/opt"]
+            self.registry, "allowed_mount_roots", ["/home", "/data", "/opt"]
         )
-        assert container.validate_mount_spec("/data/files:/work") is None
-        assert container.validate_mount_spec("/opt/app:/app") is None
-        err = container.validate_mount_spec("/var/log:/logs")
+        assert self.registry.validate_mount_spec("/data/files:/work") is None
+        assert self.registry.validate_mount_spec("/opt/app:/app") is None
+        err = self.registry.validate_mount_spec("/var/log:/logs")
         assert err is not None
 
 
 class TestProtectedPaths:
+    def setup_method(self):
+        app_state = _make_app_state()
+        self.registry = app_state.container_registry
+
     def test_docker_socket_blocked(self, monkeypatch):
-        monkeypatch.setattr(container, "ALLOWED_MOUNT_ROOTS", ["/"])
-        err = container.validate_mount_spec(
+        monkeypatch.setattr(self.registry, "allowed_mount_roots", ["/"])
+        err = self.registry.validate_mount_spec(
             "/var/run/docker.sock:/var/run/docker.sock"
         )
         assert err is not None
         assert "protected" in err.lower()
 
     def test_podman_socket_blocked(self, monkeypatch):
-        monkeypatch.setattr(container, "ALLOWED_MOUNT_ROOTS", ["/"])
-        err = container.validate_mount_spec(
+        monkeypatch.setattr(self.registry, "allowed_mount_roots", ["/"])
+        err = self.registry.validate_mount_spec(
             "/run/podman/podman.sock:/run/podman/podman.sock"
         )
         assert err is not None
         assert "protected" in err.lower()
 
     def test_data_dir_blocked(self, monkeypatch):
-        monkeypatch.setattr(container, "ALLOWED_MOUNT_ROOTS", ["/"])
-        monkeypatch.setenv("KLANGK_DATA_DIR", "/srv/klangk/data")
-        err = container.validate_mount_spec(
+        monkeypatch.setattr(self.registry, "allowed_mount_roots", ["/"])
+        monkeypatch.setattr(
+            self.registry.settings, "data_dir", "/srv/klangk/data"
+        )
+        err = self.registry.validate_mount_spec(
             "/srv/klangk/data/workspaces:/loot"
         )
         assert err is not None
         assert "protected" in err.lower()
 
     def test_protected_blocked_even_without_allowlist(self):
-        err = container.validate_mount_spec(
+        err = self.registry.validate_mount_spec(
             "/var/run/docker.sock:/var/run/docker.sock"
         )
         assert err is not None
@@ -1379,7 +1467,7 @@ class TestProtectedPaths:
         """Symlinks to protected paths are resolved and blocked."""
         link = tmp_path / "sneaky-sock"
         link.symlink_to("/var/run/docker.sock")
-        err = container.validate_mount_spec(f"{link}:/mnt/sock")
+        err = self.registry.validate_mount_spec(f"{link}:/mnt/sock")
         assert err is not None
         assert "protected" in err.lower()
 
@@ -1399,11 +1487,11 @@ class TestProtectedPaths:
             link.symlink_to(str(target))
 
             monkeypatch.setattr(
-                container,
-                "ALLOWED_MOUNT_ROOTS",
+                self.registry,
+                "allowed_mount_roots",
                 [str(allowed)],
             )
-            err = container.validate_mount_spec(f"{link}:/mnt/data")
+            err = self.registry.validate_mount_spec(f"{link}:/mnt/data")
             assert err is None
 
     def test_symlink_outside_allowed_root_blocked(self, monkeypatch):
@@ -1420,11 +1508,11 @@ class TestProtectedPaths:
             link.symlink_to(str(outside))
 
             monkeypatch.setattr(
-                container,
-                "ALLOWED_MOUNT_ROOTS",
+                self.registry,
+                "allowed_mount_roots",
                 [str(allowed)],
             )
-            err = container.validate_mount_spec(f"{link}:/mnt/data")
+            err = self.registry.validate_mount_spec(f"{link}:/mnt/data")
             assert err is not None
             assert "allowed root" in err.lower()
 
@@ -1978,7 +2066,7 @@ class TestCleanupIdleContainers:
         # Set activity far in the past
         self.registry.track_activity("cid", "ws-1")
         self.registry.states["ws-1"].last_activity = (
-            time.time() - container.IDLE_TIMEOUT_SECONDS - 100
+            time.time() - self.registry.idle_timeout_seconds - 100
         )
 
         with patch_podman(self.registry) as p:
@@ -1998,7 +2086,7 @@ class TestCleanupIdleContainers:
     async def test_idle_calls_workspace_killed_callback(self):
         self.registry.track_activity("cid", "ws-killed")
         self.registry.states["ws-killed"].last_activity = (
-            time.time() - container.IDLE_TIMEOUT_SECONDS - 100
+            time.time() - self.registry.idle_timeout_seconds - 100
         )
 
         killed_cb = AsyncMock()
@@ -2022,7 +2110,7 @@ class TestCleanupIdleContainers:
     async def test_idle_workspace_killed_callback_error(self):
         self.registry.track_activity("cid", "ws-err")
         self.registry.states["ws-err"].last_activity = (
-            time.time() - container.IDLE_TIMEOUT_SECONDS - 100
+            time.time() - self.registry.idle_timeout_seconds - 100
         )
 
         killed_cb = AsyncMock(side_effect=RuntimeError("boom"))
@@ -2063,7 +2151,7 @@ class TestCleanupIdleContainers:
     async def test_idle_callback_invoked(self):
         self.registry.track_activity("cid", "ws-1")
         self.registry.states["ws-1"].last_activity = (
-            time.time() - container.IDLE_TIMEOUT_SECONDS - 100
+            time.time() - self.registry.idle_timeout_seconds - 100
         )
 
         callback_called = []
@@ -2088,7 +2176,7 @@ class TestCleanupIdleContainers:
     async def test_idle_callback_error_handled(self):
         self.registry.track_activity("cid", "ws-1")
         self.registry.states["ws-1"].last_activity = (
-            time.time() - container.IDLE_TIMEOUT_SECONDS - 100
+            time.time() - self.registry.idle_timeout_seconds - 100
         )
 
         async def bad_callback(ws_id):
@@ -2397,7 +2485,7 @@ def _health_registry(ws_state=None):
 
     Constructs a fresh registry via ``_make_app_state`` and wires its
     ``sockets`` to the given WebSocketState (or a fresh one by default).
-    HealthMonitor reaches sockets via ``self._registry.sockets``.
+    HealthMonitor reaches sockets via ``self.registry.sockets``.
     """
     app_state = _make_app_state(sockets=ws_state)
     return app_state.container_registry
@@ -2412,13 +2500,16 @@ def _health_state(
     setup_state="complete",
     health_status=None,
     in_startup_grace=False,
+    registry=None,
 ):
     """Build a ContainerState wired up for health checks.
 
     *in_startup_grace* defaults to False so the core healthy/unhealthy
     tests exercise post-grace behavior; the startup-grace tests opt in.
     """
-    st = container.ContainerState(workspace_id, container_id)
+    if registry is None:
+        registry = _health_registry()
+    st = container.ContainerState(workspace_id, container_id, registry)
     st.health_check = health_check
     st.owner_id = owner_id
     st.setup_state = setup_state
@@ -2429,6 +2520,10 @@ def _health_state(
 
 
 class TestHealthMonitorRunOne:
+    def setup_method(self):
+        app_state = _make_app_state()
+        self.registry = app_state.container_registry
+
     """_run_one: rc 0 → healthy, non-zero/error → unhealthy (with reason)."""
 
     async def test_exit_zero_is_healthy(self):
@@ -2436,19 +2531,17 @@ class TestHealthMonitorRunOne:
         st = _health_state()
         exec_mock = AsyncMock(return_value=(0, "", ""))
         with (
-            patch.object(
-                monitor._registry.podman, "exec_container", exec_mock
-            ),
+            patch.object(monitor.registry.podman, "exec_container", exec_mock),
             patch.object(
                 model, "get_user_handle", AsyncMock(return_value="owner")
             ),
             patch.object(
-                monitor._registry.app_state.workspaces,
+                monitor.registry.app_state.workspaces,
                 "home_path",
                 return_value="/h/p",
             ),
             patch.object(
-                monitor._registry.app_state.workspaces,
+                monitor.registry.app_state.workspaces,
                 "ensure_home_symlink",
                 new_callable=AsyncMock,
                 return_value=("/home/klangk", False),
@@ -2461,7 +2554,7 @@ class TestHealthMonitorRunOne:
         assert call.args[0] == "cid1234567890"
         assert call.kwargs["user"] == "klangk"
         assert call.kwargs["extra_env"] == {"HOME": "/home/klangk"}
-        assert call.kwargs["timeout"] == container.HEALTH_CHECK_TIMEOUT_SECONDS
+        assert call.kwargs["timeout"] == self.registry.health_check_timeout
         # The health check runs as a NON-login bash shell (bash -c) on
         # purpose: it sources nothing, so the probe is deterministic and
         # decoupled from the user's interactive ~/.profile / ~/.bashrc.
@@ -2478,7 +2571,7 @@ class TestHealthMonitorRunOne:
         st = _health_state()
         with (
             patch.object(
-                monitor._registry.podman,
+                monitor.registry.podman,
                 "exec_container",
                 AsyncMock(return_value=(1, "", "curl: connection refused")),
             ),
@@ -2486,12 +2579,12 @@ class TestHealthMonitorRunOne:
                 model, "get_user_handle", AsyncMock(return_value="owner")
             ),
             patch.object(
-                monitor._registry.app_state.workspaces,
+                monitor.registry.app_state.workspaces,
                 "home_path",
                 return_value="/h/p",
             ),
             patch.object(
-                monitor._registry.app_state.workspaces,
+                monitor.registry.app_state.workspaces,
                 "ensure_home_symlink",
                 new_callable=AsyncMock,
                 return_value=("/home/klangk", False),
@@ -2508,7 +2601,7 @@ class TestHealthMonitorRunOne:
         st = _health_state()
         with (
             patch.object(
-                monitor._registry.podman,
+                monitor.registry.podman,
                 "exec_container",
                 AsyncMock(return_value=(2, "all good on stdout", "")),
             ),
@@ -2516,12 +2609,12 @@ class TestHealthMonitorRunOne:
                 model, "get_user_handle", AsyncMock(return_value="owner")
             ),
             patch.object(
-                monitor._registry.app_state.workspaces,
+                monitor.registry.app_state.workspaces,
                 "home_path",
                 return_value="/h/p",
             ),
             patch.object(
-                monitor._registry.app_state.workspaces,
+                monitor.registry.app_state.workspaces,
                 "ensure_home_symlink",
                 new_callable=AsyncMock,
                 return_value=("/home/klangk", False),
@@ -2538,7 +2631,7 @@ class TestHealthMonitorRunOne:
         st = _health_state()
         with (
             patch.object(
-                monitor._registry.podman,
+                monitor.registry.podman,
                 "exec_container",
                 AsyncMock(return_value=(127, "", "")),
             ),
@@ -2546,12 +2639,12 @@ class TestHealthMonitorRunOne:
                 model, "get_user_handle", AsyncMock(return_value="owner")
             ),
             patch.object(
-                monitor._registry.app_state.workspaces,
+                monitor.registry.app_state.workspaces,
                 "home_path",
                 return_value="/h/p",
             ),
             patch.object(
-                monitor._registry.app_state.workspaces,
+                monitor.registry.app_state.workspaces,
                 "ensure_home_symlink",
                 new_callable=AsyncMock,
                 return_value=("/home/klangk", False),
@@ -2578,7 +2671,7 @@ class TestHealthMonitorRunOne:
         st = _health_state()
         with (
             patch.object(
-                monitor._registry.podman,
+                monitor.registry.podman,
                 "exec_container",
                 AsyncMock(side_effect=podman.PodmanError(500, "boom")),
             ),
@@ -2586,12 +2679,12 @@ class TestHealthMonitorRunOne:
                 model, "get_user_handle", AsyncMock(return_value="owner")
             ),
             patch.object(
-                monitor._registry.app_state.workspaces,
+                monitor.registry.app_state.workspaces,
                 "home_path",
                 return_value="/h/p",
             ),
             patch.object(
-                monitor._registry.app_state.workspaces,
+                monitor.registry.app_state.workspaces,
                 "ensure_home_symlink",
                 new_callable=AsyncMock,
                 return_value=("/home/klangk", False),
@@ -2606,7 +2699,7 @@ class TestHealthMonitorRunOne:
         monitor = _health_registry().health
         st = _health_state(owner_id=None)
         with patch.object(
-            monitor._registry.podman, "exec_container"
+            monitor.registry.podman, "exec_container"
         ) as exec_mock:
             status, message = await monitor._run_one(st)
         assert status == "unhealthy"
@@ -2622,7 +2715,7 @@ class TestHealthMonitorRunOne:
                 model, "get_user_handle", AsyncMock(return_value=None)
             ),
             patch.object(
-                monitor._registry.podman, "exec_container"
+                monitor.registry.podman, "exec_container"
             ) as exec_mock,
         ):
             status, message = await monitor._run_one(st)
@@ -2858,6 +2951,10 @@ class TestHealthMonitorStartupGrace:
 
 
 class TestHealthMonitorLoopSkips:
+    def setup_method(self):
+        app_state = _make_app_state()
+        self.registry = app_state.container_registry
+
     """run_health_loop skips setup-incomplete and checkless workspaces."""
 
     async def test_skips_setup_incomplete(self):
@@ -2870,7 +2967,7 @@ class TestHealthMonitorLoopSkips:
                 patch.object(
                     monitor, "_check_workspace", AsyncMock()
                 ) as check,
-                patch.object(container, "HEALTH_CHECK_INTERVAL_SECONDS", 0.01),
+                patch.object(reg, "health_check_interval", 0.01),
             ):
                 task = asyncio.create_task(monitor.run_health_loop())
                 await asyncio.sleep(0.05)
@@ -2893,7 +2990,7 @@ class TestHealthMonitorLoopSkips:
                 patch.object(
                     monitor, "_check_workspace", AsyncMock()
                 ) as check,
-                patch.object(container, "HEALTH_CHECK_INTERVAL_SECONDS", 0.01),
+                patch.object(reg, "health_check_interval", 0.01),
             ):
                 task = asyncio.create_task(monitor.run_health_loop())
                 await asyncio.sleep(0.05)
@@ -2916,7 +3013,7 @@ class TestHealthMonitorLoopSkips:
                 patch.object(
                     monitor, "_check_workspace", AsyncMock()
                 ) as check,
-                patch.object(container, "HEALTH_CHECK_INTERVAL_SECONDS", 0.01),
+                patch.object(reg, "health_check_interval", 0.01),
             ):
                 task = asyncio.create_task(monitor.run_health_loop())
                 await asyncio.sleep(0.05)
@@ -3067,7 +3164,9 @@ class TestHealthMonitorDeath:
         )
         reg.states[st.workspace_id] = st
         reg._cid_to_wsid[st.container_id] = st.workspace_id
-        st.last_activity = time.time() - container.IDLE_TIMEOUT_SECONDS - 100
+        st.last_activity = (
+            time.time() - self.registry.idle_timeout_seconds - 100
+        )
 
         try:
             reg.sockets.connections[sock] = SimpleNamespace(
@@ -3097,6 +3196,10 @@ class TestHealthMonitorDeath:
 
 
 class TestHealthLoopHeartbeat:
+    def setup_method(self):
+        app_state = _make_app_state()
+        self.registry = app_state.container_registry
+
     """run_health_loop ticks a heartbeat each sweep (#1175 item 3b).
 
     Emitting from the loop (not a standalone task) ties heartbeat
@@ -3113,7 +3216,7 @@ class TestHealthLoopHeartbeat:
             )
             with (
                 patch.object(monitor, "_check_workspace", AsyncMock()),
-                patch.object(container, "HEALTH_CHECK_INTERVAL_SECONDS", 0.01),
+                patch.object(reg, "health_check_interval", 0.01),
             ):
                 task = asyncio.create_task(monitor.run_health_loop())
                 await asyncio.sleep(0.05)
@@ -3197,21 +3300,58 @@ class TestRegistryServiceSessionLocks:
         assert reg.prune_service_session_locks({"a", "b"}) == 0
 
     def test_registry_takes_settings(self):
-        """ContainerRegistry.__init__ accepts settings (#1426)."""
+        """ContainerRegistry.__init__ accepts app_state (#1426, #1487)."""
         from klangk_backend.settings import KlangkSettings
+        import types as types_mod
 
-        reg = container.ContainerRegistry(KlangkSettings(env={}))
+        settings = KlangkSettings(env={})
+        app_state = types_mod.SimpleNamespace(settings=settings)
+        reg = container.ContainerRegistry(app_state)
         assert reg.settings is not None
+        assert reg.app_state is app_state
 
 
 class TestRegistryConnections:
+    def setup_method(self):
+        app_state = _make_app_state()
+        self.registry = app_state.container_registry
+
     """HealthMonitor reaches WebSocketState via the registry, not a module global (#1464)."""
 
     def test_connections_property_reads_from_registry(self):
-        """The _connections property returns self._registry.sockets."""
+        """The connections property returns self.registry.sockets."""
         from klangk_backend.wshandler.session import WebSocketState
 
         ws_state = WebSocketState()
         app_state = _make_app_state(sockets=ws_state)
         reg = app_state.container_registry
-        assert reg.health._connections is ws_state
+        assert reg.health.connections is ws_state
+
+
+class TestRegistrySettingsDerived:
+    """Settings-derived attrs on ContainerRegistry (#1487)."""
+
+    def _registry(self, env):
+        import types as types_mod
+        from klangk_backend.settings import KlangkSettings
+
+        settings = KlangkSettings(env=env)
+        app_state = types_mod.SimpleNamespace(settings=settings)
+        return container.ContainerRegistry(app_state)
+
+    def test_allowed_images_from_settings(self):
+        reg = self._registry({"KLANGK_ALLOWED_IMAGES": "foo,bar"})
+        assert "foo" in reg.allowed_images
+        assert "bar" in reg.allowed_images
+        assert reg.image_name in reg.allowed_images  # default always allowed
+
+    def test_allowed_mount_roots_from_settings(self):
+        reg = self._registry({"KLANGK_ALLOWED_MOUNT_ROOTS": "/home,/data"})
+        assert any(r.endswith("/home") for r in reg.allowed_mount_roots)
+        assert any(r.endswith("/data") for r in reg.allowed_mount_roots)
+
+    def test_set_idle_timeout(self):
+        reg = self._registry({})
+        reg.set_idle_timeout(120)
+        assert reg.idle_timeout_seconds == 120
+        assert reg.check_interval_seconds == max(10, min(60, 120 // 3))

--- a/src/backend/tests/test_main.py
+++ b/src/backend/tests/test_main.py
@@ -23,13 +23,13 @@ def _make_app_state(settings=None):
     """Build a minimal app_state for tests."""
     if settings is None:
         settings = KlangkSettings(env={})
-    registry = ContainerRegistry(settings)
     sockets = WebSocketState()
     app_state = types.SimpleNamespace(
-        container_registry=registry,
         sockets=sockets,
         settings=settings,
     )
+    registry = ContainerRegistry(app_state)
+    app_state.container_registry = registry
     registry.sockets = sockets
     registry.app_state = app_state
     sockets.app_state = app_state

--- a/src/backend/tests/test_workspaces.py
+++ b/src/backend/tests/test_workspaces.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from klangk_backend import workspaces as ws_mod, container
+from klangk_backend import workspaces as ws_mod
 
 
 class TestCreateWorkspace:
@@ -32,7 +32,9 @@ class TestCreateWorkspace:
         registry = app_state.container_registry
         ports = await registry.get_workspace_ports(ws["id"])
         assert len(ports) == ws["num_ports"]
-        assert all(p >= container.PORT_RANGE_START for p in ports)
+        assert all(
+            p >= app_state.container_registry.port_range_start for p in ports
+        )
 
     async def test_duplicate_name_fails(self, user, app_state):
         await app_state.workspaces.create_workspace(user["id"], "unique")
@@ -410,8 +412,12 @@ class TestAutoStartWorkspaces:
         # Pre-populate states so idle_timeout can be set.
         from klangk_backend.container import ContainerState
 
-        registry.states[ws1["id"]] = ContainerState(ws1["id"], "cid-1")
-        registry.states[ws2["id"]] = ContainerState(ws2["id"], "cid-2")
+        registry.states[ws1["id"]] = ContainerState(
+            ws1["id"], "cid-1", registry
+        )
+        registry.states[ws2["id"]] = ContainerState(
+            ws2["id"], "cid-2", registry
+        )
         try:
             with patch.object(app_state.settings, "allow_autostart", "1"):
                 with patch.object(
@@ -501,8 +507,10 @@ class TestStartWorkspace:
 
         # Registry default idle timeout is non-zero; start_workspace
         # must not clobber it.
-        default_timeout = ContainerState(ws["id"], "cid-y").idle_timeout
-        registry.states[ws["id"]] = ContainerState(ws["id"], "cid-y")
+        default_timeout = ContainerState(
+            ws["id"], "cid-y", registry
+        ).idle_timeout
+        registry.states[ws["id"]] = ContainerState(ws["id"], "cid-y", registry)
         try:
             with patch.object(
                 registry,

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -88,16 +88,16 @@ def _make_app_state(registry=None, sockets=None):
     from klangk_backend.container import ContainerRegistry
 
     settings = KlangkSettings(env={})
-    if registry is None:
-        registry = ContainerRegistry(settings)
     if sockets is None:
         sockets = WebSocketState()
 
     app_state = types.SimpleNamespace(
-        container_registry=registry,
         sockets=sockets,
         settings=settings,
     )
+    if registry is None:
+        registry = ContainerRegistry(app_state)
+    app_state.container_registry = registry
     registry.sockets = sockets
     registry.app_state = app_state
     sockets.app_state = app_state
@@ -4703,8 +4703,10 @@ class TestServiceHealthSnapshot:
     """send_service_health_snapshot replays current health to one socket
     on connect, closing the steady-state-unhealthy hole (#1175 item 1)."""
 
-    def _state(self, ws_id, *, health_check, health_status, message=None):
-        cs = container.ContainerState(ws_id, f"cid-{ws_id}")
+    def _state(
+        self, ws_id, *, registry, health_check, health_status, message=None
+    ):
+        cs = container.ContainerState(ws_id, f"cid-{ws_id}", registry)
         cs.health_check = health_check
         cs.health_status = health_status
         cs.health_message = message
@@ -4721,11 +4723,13 @@ class TestServiceHealthSnapshot:
             registry.states.clear()
             registry.states["ws-healthy"] = self._state(
                 "ws-healthy",
+                registry=registry,
                 health_check="true",
                 health_status="healthy",
             )
             registry.states["ws-sick"] = self._state(
                 "ws-sick",
+                registry=registry,
                 health_check="curl localhost",
                 health_status="unhealthy",
                 message="conn refused",
@@ -4733,12 +4737,14 @@ class TestServiceHealthSnapshot:
             # health check configured but never polled yet
             registry.states["ws-unchecked"] = self._state(
                 "ws-unchecked",
+                registry=registry,
                 health_check="true",
                 health_status=None,
             )
             # no health check at all (plain dev workspace)
             registry.states["ws-nocheck"] = self._state(
                 "ws-nocheck",
+                registry=registry,
                 health_check=None,
                 health_status=None,
             )
@@ -4770,6 +4776,7 @@ class TestServiceHealthSnapshot:
             registry.states.clear()
             registry.states["ws-1"] = self._state(
                 "ws-1",
+                registry=registry,
                 health_check="true",
                 health_status="healthy",
             )
@@ -4793,11 +4800,13 @@ class TestServiceHealthSnapshot:
             registry.states.clear()
             registry.states["ws-1"] = self._state(
                 "ws-1",
+                registry=registry,
                 health_check="true",
                 health_status="healthy",
             )
             registry.states["ws-2"] = self._state(
                 "ws-2",
+                registry=registry,
                 health_check="true",
                 health_status="unhealthy",
             )
@@ -4904,8 +4913,8 @@ class TestNotifyServiceHealthForwarding:
 class TestServiceHealthSnapshotFields:
     """send_service_health_snapshot carries running/seq/checked_at."""
 
-    def _state(self, ws_id, *, checked_at=None, seq=0):
-        cs = container.ContainerState(ws_id, f"cid-{ws_id}")
+    def _state(self, ws_id, *, registry, checked_at=None, seq=0):
+        cs = container.ContainerState(ws_id, f"cid-{ws_id}", registry)
         cs.health_check = "true"
         cs.health_status = "unhealthy"
         cs.health_message = "down"
@@ -4922,7 +4931,7 @@ class TestServiceHealthSnapshotFields:
         try:
             registry.states.clear()
             registry.states["ws-1"] = self._state(
-                "ws-1", checked_at=1_700_000_000.0, seq=5
+                "ws-1", registry=registry, checked_at=1_700_000_000.0, seq=5
             )
             sockets.send_service_health_snapshot(sock)
         finally:
@@ -5404,7 +5413,9 @@ class TestHandleRestartContainer:
     ):
         app_state = _make_app_state()
         registry = app_state.container_registry
-        monkeypatch.setattr(container, "IDLE_TIMEOUT_SECONDS", 90)
+        monkeypatch.setattr(
+            app_state.container_registry, "idle_timeout_seconds", 90
+        )
         sock = _mock_sock(headers={"host": "localhost:8997"})
         workspace = await _create_workspace_with_acl(
             app_state, user["id"], "restart-frac"
@@ -8695,7 +8706,9 @@ class TestFractionalTimeout:
     ):
         app_state = _make_app_state()
         registry = app_state.container_registry
-        monkeypatch.setattr(container, "IDLE_TIMEOUT_SECONDS", 90)
+        monkeypatch.setattr(
+            app_state.container_registry, "idle_timeout_seconds", 90
+        )
         sock = _mock_sock()
         workspace = await _create_workspace_with_acl(
             app_state, user["id"], "frac-ws"


### PR DESCRIPTION
## Summary

- Converts `ContainerRegistry` constructor from `ContainerRegistry(settings)` to `ContainerRegistry(app_state)`, matching the uniform `X(app_state)` family
- Moves all settings-derived import-time-frozen globals (`IMAGE_NAME`, `TERMINAL_BANNER`, `ALLOWED_IMAGES`, `ALLOWED_MOUNT_ROOTS`, `IDLE_TIMEOUT_SECONDS`, `CHECK_INTERVAL_SECONDS`, `PORT_RANGE_START`, `HEALTH_CHECK_*`) onto the registry as instance attrs computed in `__init__`
- Converts call-time module functions (`container_dns_config`, `image_pull_policy`, `_is_protected`, `validate_mount_spec`, `validate_mounts`, `parse_idle_timeout`, `ports_per_workspace_cap`) to registry methods
- Replaces in-method `resolve_env_value`/`resolve_env_bool` reads with `self._settings.*`
- Fixes the runtime-mutation hazard: `api/__init__.py` no longer mutates module globals for idle timeout — uses `set_idle_timeout()` method instead
- Migrates all call sites (`api/images.py`, `api/workspaces.py`, `api/__init__.py`, `wshandler/connection.py`)
- Updates all tests to work against registry instances rather than module globals

### Parameter cleanup

- Makes `app_state` required (drops `=None` default) on `ContainerRegistry`, `Plugins`, `Workspaces`, `Terminal`, and `OIDC` — all callers always pass it
- Makes `registry` required on `ContainerState` and `PortAllocator`
- Makes `podman` required on `_ensure_volumes`, `_resolve_port_conflict`, and all `files.py` functions
- Makes `app_state` required on `enforce_no_auth_bind_safety` and `ensure_agent_home`
- Removes `None`-guard workaround logic that was dead code (e.g. `if self.settings`, `if s and s.image_name`)
- Removes 16 unused `app` fixture params from test methods (already pulled in transitively via `client`)

### Pure-constant carve-out (stays module-level)

`CONTAINER_PORT_START`, `DEFAULT_PORTS_PER_WORKSPACE`, `HEALTH_MESSAGE_MAX_BYTES`, `_VALID_PULL_POLICIES`, `_VALID_MOUNT_OPTIONS`, `_PROTECTED_PATHS`, `unhealthy_message()`, `_is_named_volume()` — these do not read settings and remain as module-level constants/functions.

## Test plan

- [x] Full backend suite passes (2379 tests)
- [x] 100% coverage maintained
- [x] `rg "resolve_env_value|resolve_env_bool" container.py` is empty

Closes #1487
