### PR TITLE
Convert agent.py to Agents(app_state) instance (#1486)

### DIFF
--- a/src/backend/klangk_backend/agent.py
+++ b/src/backend/klangk_backend/agent.py
@@ -3,6 +3,12 @@
 Manages a long-lived ``pi --mode rpc`` subprocess per workspace
 container, sending prompts and collecting responses via JSONL over
 stdin/stdout of a ``podman exec`` session.
+
+#1486: the module-level ``_agents`` dict, ``_agents_lock``, and
+``get_workspace_session`` callback have been promoted to an
+``Agents(app_state)`` instance on ``app.state.agents``, following
+the same pattern as ``ContainerRegistry``, ``OIDC``, ``Plugins``,
+etc.
 """
 
 import asyncio
@@ -48,111 +54,263 @@ class AgentSetupError(AgentError):
     """Raised when the agent's home directory cannot be set up."""
 
 
-# Registry of active agent sessions keyed by workspace ID.
-_agents: dict[str, "AgentSession"] = {}
-_agents_lock = asyncio.Lock()
+def ephemeral_system_message(
+    workspace_id: str,
+    agent_email: str,
+    agent_handle: str,
+    text: str,
+) -> dict:
+    """Build a transient agent presence system message for live broadcast.
 
-# Callback to get a workspace session for broadcasting.
-# Set by wshandler at import time to break the circular dependency.
-get_workspace_session = None
-
-
-def is_disabled() -> bool:
-    """True if the chat agent has been disabled by an admin.
-
-    When disabled, the ``pi --mode rpc`` subprocess is never spawned —
-    see ``ensure_started``, which consults this before creating the
-    process.  Resolved at call time so tests can toggle it via
-    ``monkeypatch.setenv``.
+    Mirrors the shape returned by [model.add_chat_message] so the frontend
+    renders it the same as a persisted system message, but is never written
+    to chat history — agent presence transitions (disconnect/reconnect) are
+    driven by container lifecycle (idle-stop, restart, crash) and would
+    otherwise pollute history with stale, unbalanced "has disconnected"
+    entries.  ``id`` is a synthetic prefix so the frontend can dedupe;
+    ``created_at`` is empty (the frontend tolerates that).
     """
-    return util.resolve_env_bool("KLANGK_AGENT_DISABLED")
+    return {
+        "id": f"ephemeral-agent-{workspace_id}-{int(time.monotonic() * 1000)}",
+        "workspace_id": workspace_id,
+        "user_id": model.AGENT_USER_ID,
+        "user_email": agent_email,
+        "user_handle": agent_handle,
+        "message": text,
+        "message_type": model.MSG_SYSTEM,
+        "created_at": "",
+        "mentions": [],
+    }
 
 
-async def ensure_agent_home(
-    workspace_id: str, container_id: str, app_state
-) -> str:
-    """Eagerly provision the agent's home directory with Pi config.
+class Agents:
+    """Registry of active agent sessions, owned by ``app.state.agents``.
 
-    Creates ``/home/.users/{AGENT_USER_ID}`` on the host bind-mount and
-    populates it via ``klangk-setup-pi`` (the same path real users
-    take).  Returns the container path, e.g. ``/home/clanker``.
-
-    Idempotent: ``ensure_home_symlink`` is a no-op when the symlink
-    already exists (skeleton files only on first creation), and
-    ``klangk-setup-pi --force`` re-writes Pi config to pick up env-var
-    changes.  Called eagerly at container bring-up (so
-    ``$KLANGK_AGENT_HOME`` points at a populated directory for every
-    process) and again from chat-start, which caches the result per
-    ``AgentSession``.
+    Replaces the former module-level ``_agents`` dict, ``_agents_lock``,
+    and ``get_workspace_session`` callback (#1486).
     """
-    ws = await model.get_workspace_by_id(workspace_id)
-    if not ws:
-        raise AgentSetupError(
-            f"Workspace {workspace_id} not found in database"
-        )
-    workspace_home = app_state.workspaces.home_path(workspace_id)
 
-    agent_handle = await model.agent_handle()
-    container_home, created = await app_state.workspaces.ensure_home_symlink(
-        workspace_home, agent_handle, model.AGENT_USER_ID
-    )
-    if created:
-        await app_state.workspaces.populate_home_skel(
-            container_id, model.AGENT_USER_ID
+    def __init__(self, app_state) -> None:
+        self.app_state = app_state
+        self._agents: dict[str, "AgentSession"] = {}
+        self._agents_lock = asyncio.Lock()
+        self.get_workspace_session = None
+
+    def is_disabled(self) -> bool:
+        """True if the chat agent has been disabled by an admin.
+
+        When disabled, the ``pi --mode rpc`` subprocess is never spawned —
+        see ``AgentSession.ensure_started``, which consults this before
+        creating the process.  Resolved at call time so tests can toggle
+        it via ``monkeypatch.setenv``.
+        """
+        return util.resolve_env_bool("KLANGK_AGENT_DISABLED")
+
+    async def ensure_agent_home(
+        self, workspace_id: str, container_id: str
+    ) -> str:
+        """Eagerly provision the agent's home directory with Pi config.
+
+        Creates ``/home/.users/{AGENT_USER_ID}`` on the host bind-mount and
+        populates it via ``klangk-setup-pi`` (the same path real users
+        take).  Returns the container path, e.g. ``/home/clanker``.
+
+        Idempotent: ``ensure_home_symlink`` is a no-op when the symlink
+        already exists (skeleton files only on first creation), and
+        ``klangk-setup-pi --force`` re-writes Pi config to pick up env-var
+        changes.  Called eagerly at container bring-up (so
+        ``$KLANGK_AGENT_HOME`` points at a populated directory for every
+        process) and again from chat-start, which caches the result per
+        ``AgentSession``.
+        """
+        ws = await model.get_workspace_by_id(workspace_id)
+        if not ws:
+            raise AgentSetupError(
+                f"Workspace {workspace_id} not found in database"
+            )
+        workspace_home = self.app_state.workspaces.home_path(workspace_id)
+
+        agent_handle = await model.agent_handle()
+        (
+            container_home,
+            created,
+        ) = await self.app_state.workspaces.ensure_home_symlink(
+            workspace_home, agent_handle, model.AGENT_USER_ID
+        )
+        if created:
+            await self.app_state.workspaces.populate_home_skel(
+                container_id, model.AGENT_USER_ID
+            )
+
+        # Run klangk-setup-pi to populate ~/.pi/agent/ with models.json,
+        # settings.json, etc.  Unlike real users, the agent has no
+        # personal preferences — --force deletes settings.json first so
+        # it picks up the current KLANGK_LLM_MODEL env var.
+        proc = await asyncio.create_subprocess_exec(
+            self.app_state.podman.bin,
+            "exec",
+            "-u",
+            "klangk",
+            "-e",
+            f"HOME={container_home}",
+            container_id,
+            "/opt/klangk/bin/klangk-setup-pi",
+            "--force",
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=subprocess_env(),
+        )
+        stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
+        if proc.returncode != 0:
+            logger.warning(
+                "klangk-setup-pi exited %s for container %s; agent home at "
+                "%s may be incomplete (chat will retry on first mention):\n"
+                "stdout: %s\nstderr: %s",
+                proc.returncode,
+                container_id,
+                container_home,
+                stdout.decode(errors="replace") if stdout else "",
+                stderr.decode(errors="replace") if stderr else "",
+            )
+        else:
+            logger.info(
+                "Agent home ready at %s for container %s",
+                container_home,
+                container_id,
+            )
+        return container_home
+
+    async def get_session(self, workspace_id: str) -> "AgentSession":
+        """Get or create an AgentSession for the given workspace.
+
+        The session resolves the current container ID from the container
+        registry on each startup, so it automatically picks up container
+        restarts without needing to be told the new ID.
+
+        Serialized with ``stop_session`` via ``_agents_lock`` so that a new
+        session is never installed for a container that ``stop_session`` has
+        already torn down (#1298).
+        """
+        async with self._agents_lock:
+            session = self._agents.get(workspace_id)
+            if session is None:
+                session = AgentSession(workspace_id, agents=self)
+                self._agents[workspace_id] = session
+            return session
+
+    def is_running(self, workspace_id: str) -> bool:
+        """Return True if an agent subprocess is alive for this workspace."""
+        session = self._agents.get(workspace_id)
+        if session is None:
+            return False
+        return session._proc is not None and session._proc.returncode is None
+
+    def any_running(self) -> bool:
+        """Return True if any agent subprocess is alive."""
+        return any(
+            s._proc is not None and s._proc.returncode is None
+            for s in self._agents.values()
         )
 
-    # Run klangk-setup-pi to populate ~/.pi/agent/ with models.json,
-    # settings.json, etc.  Unlike real users, the agent has no
-    # personal preferences — --force deletes settings.json first so
-    # it picks up the current KLANGK_LLM_MODEL env var.
-    proc = await asyncio.create_subprocess_exec(
-        app_state.podman.bin,
-        "exec",
-        "-u",
-        "klangk",
-        "-e",
-        f"HOME={container_home}",
-        container_id,
-        "/opt/klangk/bin/klangk-setup-pi",
-        "--force",
-        stdin=asyncio.subprocess.DEVNULL,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        env=subprocess_env(),
-    )
-    stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
-    # Check the return code but do NOT fail the container bring-up over a
-    # provisioning hiccup: the workspace stays usable, and the lazy
-    # chat-start path (AgentSession._ensure_home) will retry on first
-    # mention.  Surface the failure loudly, though, so it's not silently
-    # swallowed (a previous silent-unconditional "ready" log hid a
-    # missing ~/.pi/agent entirely). #1162
-    if proc.returncode != 0:
-        logger.warning(
-            "klangk-setup-pi exited %s for container %s; agent home at "
-            "%s may be incomplete (chat will retry on first mention):\n"
-            "stdout: %s\nstderr: %s",
-            proc.returncode,
-            container_id,
-            container_home,
-            stdout.decode(errors="replace") if stdout else "",
-            stderr.decode(errors="replace") if stderr else "",
+    async def stop_session(self, workspace_id: str) -> None:
+        """Stop and remove the agent session for a workspace.
+
+        Serialized with ``get_session`` via ``_agents_lock`` so that a
+        concurrent ``get_session`` cannot install a new session for a
+        container that is being torn down (#1298).
+        """
+        async with self._agents_lock:
+            session = self._agents.pop(workspace_id, None)
+            if session:
+                await session.stop()
+
+    async def stop_all_sessions(self) -> None:
+        """Stop and remove every active agent session.
+
+        Used by the SIGHUP runtime-restart path: each agent session is a
+        Pi RPC subprocess attached to a container that is about to be
+        stopped, so they must be torn down before the containers go.
+        """
+        for ws_id in list(self._agents.keys()):
+            await self.stop_session(ws_id)
+
+    async def broadcast_agent_disconnect(self, workspace_id: str) -> None:
+        """Broadcast a disconnect system message when the agent process dies.
+
+        Ephemeral only — sent to currently-connected subscribers, never
+        written to chat history.
+        """
+        if not workspace_id:
+            return
+        if await model.get_workspace_by_id(workspace_id) is None:
+            return
+        agent_handle = await model.agent_handle()
+        agent_email = await model.agent_email()
+        sys_msg = ephemeral_system_message(
+            workspace_id,
+            agent_email,
+            agent_handle,
+            f"{agent_handle} has disconnected",
         )
-    else:
-        logger.info(
-            "Agent home ready at %s for container %s",
-            container_home,
-            container_id,
+        session = (
+            self.get_workspace_session(workspace_id)
+            if self.get_workspace_session
+            else None
         )
-    return container_home
+        if session:
+            session.broadcast({"type": "agent_thinking", "thinking": False})
+            session.broadcast({"type": "chat_message", **sys_msg})
+            session.broadcast(
+                {
+                    "type": "presence_leave",
+                    "user_id": model.AGENT_USER_ID,
+                    "user_email": agent_email,
+                    "user_handle": agent_handle,
+                }
+            )
+
+    async def broadcast_agent_reconnect(self, workspace_id: str) -> None:
+        """Broadcast a reconnect system message after auto-restart.
+
+        Ephemeral only — see ``broadcast_agent_disconnect``.
+        """
+        if not workspace_id:
+            return
+        if await model.get_workspace_by_id(workspace_id) is None:
+            return
+        agent_handle = await model.agent_handle()
+        agent_email = await model.agent_email()
+        sys_msg = ephemeral_system_message(
+            workspace_id,
+            agent_email,
+            agent_handle,
+            f"{agent_handle} has reconnected",
+        )
+        session = (
+            self.get_workspace_session(workspace_id)
+            if self.get_workspace_session
+            else None
+        )
+        if session:
+            session.broadcast({"type": "chat_message", **sys_msg})
+            session.broadcast(
+                {
+                    "type": "presence_join",
+                    "user_id": model.AGENT_USER_ID,
+                    "user_email": agent_email,
+                    "user_handle": agent_handle,
+                }
+            )
 
 
 class AgentSession:
     """Wraps a ``pi --mode rpc`` subprocess inside a container."""
 
-    def __init__(self, workspace_id: str, app_state=None) -> None:
+    def __init__(self, workspace_id: str, agents: Agents) -> None:
         self.workspace_id = workspace_id
-        self.app_state = app_state
+        self.agents = agents
+        self.app_state = agents.app_state
         self._proc: asyncio.subprocess.Process | None = None
         # Serializes prompt round-trips so two concurrent prompts can't
         # interleave their stdin writes / stdout reads on one subprocess.
@@ -189,15 +347,15 @@ class AgentSession:
     async def _ensure_home(self, container_id: str) -> str:
         """Ensure the agent has a home directory with Pi config (cached).
 
-        Thin per-instance cache over :func:`ensure_agent_home`.  The
+        Thin per-instance cache over ``Agents.ensure_agent_home``.  The
         actual provisioning — and the eager bring-up call site — live
         there.  Returns the container path, e.g. ``/home/clanker``.
         """
         if self._home_ready:
             handle = await model.agent_handle()
             return f"/home/{handle}"
-        container_home = await ensure_agent_home(
-            self.workspace_id, container_id, self.app_state
+        container_home = await self.agents.ensure_agent_home(
+            self.workspace_id, container_id
         )
         self._home_ready = True
         return container_home
@@ -205,7 +363,7 @@ class AgentSession:
     async def ensure_started(self) -> asyncio.subprocess.Process:
         if self._proc is not None and self._proc.returncode is None:
             return self._proc
-        if is_disabled():
+        if self.agents.is_disabled():
             # Admin kill switch: refuse to spawn the subprocess.  This is
             # the single place the env var is enforced — if it's set, the
             # agent never runs for any workspace.
@@ -297,7 +455,7 @@ class AgentSession:
             f": {stderr_text}" if stderr_text else "",
         )
 
-        await broadcast_agent_disconnect(self.workspace_id)
+        await self.agents.broadcast_agent_disconnect(self.workspace_id)
         # Auto-restart after a brief delay to avoid tight loops
         self._restart_attempts += 1
         if self._restart_attempts > 2:
@@ -322,7 +480,7 @@ class AgentSession:
             return
         try:
             await self.ensure_started()
-            await broadcast_agent_reconnect(self.workspace_id)
+            await self.agents.broadcast_agent_reconnect(self.workspace_id)
         except Exception:
             logger.exception(
                 "Failed to auto-restart agent for workspace %s",
@@ -557,163 +715,3 @@ class AgentSession:
             except ProcessLookupError:  # pragma: no cover
                 pass
         self._proc = None
-
-
-async def get_session(workspace_id: str, app_state=None) -> AgentSession:
-    """Get or create an AgentSession for the given workspace.
-
-    The session resolves the current container ID from the container
-    registry on each startup, so it automatically picks up container
-    restarts without needing to be told the new ID.
-
-    Serialized with ``stop_session`` via ``_agents_lock`` so that a new
-    session is never installed for a container that ``stop_session`` has
-    already torn down (#1298).
-    """
-    async with _agents_lock:
-        session = _agents.get(workspace_id)
-        if session is None:
-            session = AgentSession(workspace_id, app_state=app_state)
-            _agents[workspace_id] = session
-        return session
-
-
-def is_running(workspace_id: str) -> bool:
-    """Return True if an agent subprocess is alive for this workspace."""
-    session = _agents.get(workspace_id)
-    if session is None:
-        return False
-    return session._proc is not None and session._proc.returncode is None
-
-
-def any_running() -> bool:
-    """Return True if any agent subprocess is alive."""
-    return any(
-        s._proc is not None and s._proc.returncode is None
-        for s in _agents.values()
-    )
-
-
-async def stop_session(workspace_id: str) -> None:
-    """Stop and remove the agent session for a workspace.
-
-    Serialized with ``get_session`` via ``_agents_lock`` so that a
-    concurrent ``get_session`` cannot install a new session for a
-    container that is being torn down (#1298).
-    """
-    async with _agents_lock:
-        session = _agents.pop(workspace_id, None)
-        if session:
-            await session.stop()
-
-
-async def stop_all_sessions() -> None:
-    """Stop and remove every active agent session.
-
-    Used by the SIGHUP runtime-restart path: each agent session is a
-    Pi RPC subprocess attached to a container that is about to be
-    stopped, so they must be torn down before the containers go.
-    """
-    for ws_id in list(_agents.keys()):
-        await stop_session(ws_id)
-
-
-def ephemeral_system_message(
-    workspace_id: str,
-    agent_email: str,
-    agent_handle: str,
-    text: str,
-) -> dict:
-    """Build a transient agent presence system message for live broadcast.
-
-    Mirrors the shape returned by [model.add_chat_message] so the frontend
-    renders it the same as a persisted system message, but is never written
-    to chat history — agent presence transitions (disconnect/reconnect) are
-    driven by container lifecycle (idle-stop, restart, crash) and would
-    otherwise pollute history with stale, unbalanced "has disconnected"
-    entries.  ``id`` is a synthetic prefix so the frontend can dedupe;
-    ``created_at`` is empty (the frontend tolerates that).
-    """
-    return {
-        "id": f"ephemeral-agent-{workspace_id}-{int(time.monotonic() * 1000)}",
-        "workspace_id": workspace_id,
-        "user_id": model.AGENT_USER_ID,
-        "user_email": agent_email,
-        "user_handle": agent_handle,
-        "message": text,
-        "message_type": model.MSG_SYSTEM,
-        "created_at": "",
-        "mentions": [],
-    }
-
-
-async def broadcast_agent_disconnect(workspace_id: str) -> None:
-    """Broadcast a disconnect system message when the agent process dies.
-
-    Ephemeral only — sent to currently-connected subscribers, never written
-    to chat history.  The agent subprocess lives inside the workspace
-    container, so it dies on every container idle-stop / restart; persisting
-    "has disconnected" made those lifecycle events linger in chat history
-    and surface as a stale leading message on the next visit, with no
-    symmetric persisted "has connected" to balance them.
-    """
-    if not workspace_id:
-        return
-    # Workspace may have been deleted — skip if gone.
-    if await model.get_workspace_by_id(workspace_id) is None:
-        return
-    agent_handle = await model.agent_handle()
-    agent_email = await model.agent_email()
-    sys_msg = ephemeral_system_message(
-        workspace_id,
-        agent_email,
-        agent_handle,
-        f"{agent_handle} has disconnected",
-    )
-    session = (
-        get_workspace_session(workspace_id) if get_workspace_session else None
-    )
-    if session:
-        session.broadcast({"type": "agent_thinking", "thinking": False})
-        session.broadcast({"type": "chat_message", **sys_msg})
-        session.broadcast(
-            {
-                "type": "presence_leave",
-                "user_id": model.AGENT_USER_ID,
-                "user_email": agent_email,
-                "user_handle": agent_handle,
-            }
-        )
-
-
-async def broadcast_agent_reconnect(workspace_id: str) -> None:
-    """Broadcast a reconnect system message after auto-restart.
-
-    Ephemeral only — see [broadcast_agent_disconnect].
-    """
-    if not workspace_id:
-        return
-    # Workspace may have been deleted — skip if gone.
-    if await model.get_workspace_by_id(workspace_id) is None:
-        return
-    agent_handle = await model.agent_handle()
-    agent_email = await model.agent_email()
-    sys_msg = ephemeral_system_message(
-        workspace_id,
-        agent_email,
-        agent_handle,
-        f"{agent_handle} has reconnected",
-    )
-    session = (
-        get_workspace_session(workspace_id) if get_workspace_session else None
-    )
-    if session:
-        session.broadcast({"type": "chat_message", **sys_msg})
-        session.broadcast(
-            {
-                "type": "presence_join",
-                "user_id": model.AGENT_USER_ID,
-                "user_email": agent_email,
-                "user_handle": agent_handle,
-            }
-        )

--- a/src/backend/klangk_backend/bringup.py
+++ b/src/backend/klangk_backend/bringup.py
@@ -2,9 +2,9 @@
 
 This is the single choke point reached after
 ``ContainerRegistry.start_container`` creates a *fresh* container
-(status ``"created"``). ``container`` cannot import ``agent``
-directly (``agent`` already imports ``container``), so the bring-up
-step lives here to keep that boundary clean.
+(status ``"created"``).  Agent home provisioning and the service
+command are reached via ``app_state.agents`` and
+``app_state.terminal`` respectively.
 
 ``ensure_service_session`` is idempotent (per-container lock +
 window-exists check), so calling this on every fresh create is safe:
@@ -14,8 +14,6 @@ workspaces whose ``setup.sh`` has not run yet is handled by gating on
 ``"pending"`` at create, and the fire lands later once setup
 completes and the WS connect path runs.
 """
-
-from . import agent
 
 
 async def bringup(
@@ -30,8 +28,8 @@ async def bringup(
     Called at the single choke point: every freshly-created container.
     Idempotent via :func:`terminal.ensure_service_session`.
     """
-    agent_home = await agent.ensure_agent_home(
-        workspace_id, container_id, app_state
+    agent_home = await app_state.agents.ensure_agent_home(
+        workspace_id, container_id
     )
     if not service_command:
         return

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -378,7 +378,7 @@ async def runtime_shutdown(app_state) -> None:
     difference is only whether ``startup()`` runs again afterwards.
     """
     await wshandler.disconnect_all_websockets(app_state.sockets)
-    await agent.stop_all_sessions()
+    await app_state.agents.stop_all_sessions()
     wshandler.clear_agent_mention_state()
     await app_state.container_registry.shutdown()
 
@@ -783,7 +783,10 @@ def build_app(settings: KlangkSettings) -> FastAPI:
     # The unit-test fixtures set this explicitly; build_app must too, or
     # every WS connect crashes on the health snapshot (#1475).
     sockets.app_state = app.state
-    agent.get_workspace_session = sockets.get_session
+    # #1486: Agents(app_state) owns the per-workspace Pi RPC sessions
+    # (previously module globals _agents/_agents_lock/get_workspace_session).
+    app.state.agents = agent.Agents(app.state)
+    app.state.agents.get_workspace_session = sockets.get_session
 
     app.add_middleware(
         CORSMiddleware,

--- a/src/backend/klangk_backend/wshandler/__init__.py
+++ b/src/backend/klangk_backend/wshandler/__init__.py
@@ -17,7 +17,6 @@ those submodules so existing call sites keep working unchanged, e.g.::
 # ``klangk_backend.wshandler.auth`` and ``wshandler.model`` keep
 # working — the old monolith imported them at module level.
 from .. import acl as _acl  # noqa: F401
-from .. import agent as agent  # noqa: F401
 from .. import auth as auth  # noqa: F401
 from .. import container as container  # noqa: F401
 from .. import model as model  # noqa: F401

--- a/src/backend/klangk_backend/wshandler/agent_mention.py
+++ b/src/backend/klangk_backend/wshandler/agent_mention.py
@@ -4,7 +4,8 @@ import asyncio
 import logging
 import re
 
-from .. import agent, model
+from ..agent import AgentProcessDied, ephemeral_system_message
+from .. import model
 from .constants import (
     agent_conversations as agent_conversations,
     agent_tasks as agent_tasks,
@@ -156,16 +157,16 @@ async def handle_agent_mention(
         )
 
     try:
-        pi = await agent.get_session(workspace_id)
+        pi = await sockets.app_state.agents.get_session(workspace_id)
         response_text = await pi.send_prompt(prompt)
     except asyncio.CancelledError:  # pragma: no cover
         response_text = "Stopped."
-    except agent.AgentProcessDied:
+    except AgentProcessDied:
         logger.warning("Agent process died for workspace %s", workspace_id)
         # Broadcast an ephemeral (non-persisted) system message — agent
         # presence transitions are container-lifecycle events and must
         # not linger in chat history (no symmetric persisted "connected").
-        sys_msg = agent.ephemeral_system_message(
+        sys_msg = ephemeral_system_message(
             workspace_id,
             agent_email,
             agent_handle,

--- a/src/backend/klangk_backend/wshandler/connection.py
+++ b/src/backend/klangk_backend/wshandler/connection.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta, timezone
 
 
 from .. import acl as _acl
-from .. import agent, auth, container, model
+from .. import auth, container, model
 from ..terminal import TerminalSession
 from ..podman import ExecSession
 from ..util import derive_hosting_info
@@ -608,7 +608,7 @@ class Connection:
             logger.warning("Error stopping container: %s", e)
 
         # Stop the Pi RPC subprocess now that its container is gone.
-        await agent.stop_session(workspace_id)
+        await self.app_state.agents.stop_session(workspace_id)
 
         # Notify subscribers AFTER the container is fully stopped, so
         # reconnecting clients don't find a half-dead container.
@@ -823,8 +823,8 @@ class Connection:
     async def _start_agent_if_needed(self) -> None:
         """Start the Pi RPC agent so it shows in presence."""
         try:
-            session = await agent.get_session(
-                self.workspace_id, app_state=self.app_state
+            session = await self.app_state.agents.get_session(
+                self.workspace_id
             )
             await session.ensure_started()
             # Broadcast updated presence now that agent is alive

--- a/src/backend/klangk_backend/wshandler/helpers.py
+++ b/src/backend/klangk_backend/wshandler/helpers.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from .. import agent, model
+from .. import model
 from .safe_websocket import SafeWebSocket
 from .constants import log_ws_msg
 from .session import WebSocketState
@@ -32,7 +32,7 @@ async def get_presence_list(
             )
     # Include agent only if its RPC process is alive in this workspace.
 
-    if agent.is_running(workspace_id):
+    if sockets.app_state.agents.is_running(workspace_id):
         agent_user = await model.get_agent_user()
         users.append(
             {

--- a/src/backend/klangk_backend/wshandler/session.py
+++ b/src/backend/klangk_backend/wshandler/session.py
@@ -10,7 +10,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
-from .. import agent, auth, model
+from .. import auth, model
 from .safe_websocket import SafeWebSocket, WS_ERRORS, broadcast_to_set
 from .constants import (
     agent_conversations,
@@ -583,7 +583,7 @@ class WebSocketState:
         agent_conversations.pop(workspace_id, None)
         cancel_agent_task(workspace_id)
         # Stop the Pi RPC subprocess so it doesn't outlive the container.
-        await agent.stop_session(workspace_id)
+        await self.app_state.agents.stop_session(workspace_id)
 
     def notify_container_status(
         self, workspace_id: str, running: bool

--- a/src/backend/tests/test_agent.py
+++ b/src/backend/tests/test_agent.py
@@ -11,14 +11,7 @@ from klangk_backend.agent import (
     AgentProcessDied,
     AgentSession,
     AgentSetupError,
-    any_running,
-    ensure_agent_home,
-    get_session,
-    is_disabled,
-    is_running,
-    stop_all_sessions,
-    stop_session,
-    _agents,
+    Agents,
 )
 
 # Mock Podman instance for ensure_agent_home tests (#1468).
@@ -32,18 +25,11 @@ class _FakeContainerState:
 
 
 @pytest.fixture(autouse=True)
-def _clear_agents():
-    _agents.clear()
-    yield
-    _agents.clear()
-
-
-@pytest.fixture(autouse=True)
 def _mock_container_registry():
     """Provide a default container registry state for all agent tests.
 
     Agent code accesses ``self.app_state.container_registry.get_state()``.
-    The ``_make_session`` helper wires a fake app_state with a mock
+    The ``_make_agents`` helper wires a fake app_state with a mock
     registry whose ``get_state`` returns a ``_FakeContainerState``.
     This fixture is kept as a no-op for structural compatibility.
     """
@@ -79,10 +65,18 @@ def _make_app_state(cid="cid"):
     return app_state
 
 
+def _make_agents(cid="cid"):
+    """Create an Agents instance with a fake app_state."""
+    app_state = _make_app_state(cid)
+    agents = Agents(app_state)
+    app_state.agents = agents
+    return agents
+
+
 def _make_session(workspace_id="ws-id"):
     """Create an AgentSession with home setup already done."""
-    app_state = _make_app_state()
-    s = AgentSession(workspace_id, app_state=app_state)
+    agents = _make_agents()
+    s = AgentSession(workspace_id, agents=agents)
     s._home_ready = True
     s._last_container_id = "cid"
     return s
@@ -124,21 +118,25 @@ class TestAgentDisabled:
 
     async def test_is_disabled_defaults_false(self, monkeypatch):
         monkeypatch.delenv("KLANGK_AGENT_DISABLED", raising=False)
-        assert is_disabled() is False
+        agents = _make_agents()
+        assert agents.is_disabled() is False
 
     async def test_is_disabled_true_when_set(self, monkeypatch):
         monkeypatch.setenv("KLANGK_AGENT_DISABLED", "1")
-        assert is_disabled() is True
+        agents = _make_agents()
+        assert agents.is_disabled() is True
 
     async def test_is_disabled_truthy_variants(self, monkeypatch):
+        agents = _make_agents()
         for val in ("1", "true", "YES", "True"):
             monkeypatch.setenv("KLANGK_AGENT_DISABLED", val)
-            assert is_disabled() is True, val
+            assert agents.is_disabled() is True, val
 
     async def test_is_disabled_falsy_variants(self, monkeypatch):
+        agents = _make_agents()
         for val in ("0", "false", "no", ""):
             monkeypatch.setenv("KLANGK_AGENT_DISABLED", val)
-            assert is_disabled() is False, val
+            assert agents.is_disabled() is False, val
 
     async def test_ensure_started_refuses_when_disabled(self, monkeypatch):
         """The subprocess is never spawned when disabled."""
@@ -618,8 +616,11 @@ class TestAgentSession:
         not permanently give up (the bug from #895)."""
         from klangk_backend import model
 
-        session = _make_session("ws-recover")
-        _agents["ws-recover"] = session
+        agents = _make_agents()
+        session = AgentSession("ws-recover", agents=agents)
+        session._home_ready = True
+        session._last_container_id = "cid"
+        agents._agents["ws-recover"] = session
         # Simulate 3 prior deaths: counter near the limit (one more death
         # would brick the agent without the reset).
         session._restart_attempts = 2
@@ -637,16 +638,14 @@ class TestAgentSession:
         mock_proc.stderr.feed_eof()
         session._proc = mock_proc
 
+        agents.get_workspace_session = MagicMock(return_value=MagicMock())
+
         with (
             patch.object(
                 model,
                 "add_chat_message",
                 new_callable=AsyncMock,
                 return_value={"id": "m1", "message": "msg"},
-            ),
-            patch(
-                "klangk_backend.agent.get_workspace_session",
-                return_value=MagicMock(),
             ),
             patch.object(
                 session,
@@ -785,22 +784,22 @@ class TestAgentSession:
 
 class TestGetSession:
     async def test_creates_new_session(self):
-        app_state = _make_app_state()
-        session = await get_session("ws-1", app_state=app_state)
+        agents = _make_agents()
+        session = await agents.get_session("ws-1")
         assert session.workspace_id == "ws-1"
-        assert "ws-1" in _agents
+        assert "ws-1" in agents._agents
 
     async def test_reuses_existing_session(self):
-        app_state = _make_app_state()
-        s1 = await get_session("ws-1", app_state=app_state)
-        s2 = await get_session("ws-1", app_state=app_state)
+        agents = _make_agents()
+        s1 = await agents.get_session("ws-1")
+        s2 = await agents.get_session("ws-1")
         assert s1 is s2
 
     async def test_get_session_blocked_during_stop(self):
         """get_session must not install a session while stop_session is
         tearing one down for the same workspace (#1298)."""
-        app_state = _make_app_state()
-        session = await get_session("ws-race", app_state=app_state)
+        agents = _make_agents()
+        session = await agents.get_session("ws-race")
         session._proc = AsyncMock()
         session._proc.returncode = None
         session._proc.kill = MagicMock()
@@ -819,7 +818,7 @@ class TestGetSession:
         session.stop = slow_stop  # type: ignore[assignment]
 
         async def do_get():
-            s = await get_session("ws-race", app_state=app_state)
+            s = await agents.get_session("ws-race")
             order.append("get_done")
             return s
 
@@ -827,7 +826,7 @@ class TestGetSession:
         # would see the workspace missing from _agents (already popped) and
         # install a brand-new session before stop finishes.
         _, new_session = await asyncio.gather(
-            stop_session("ws-race"),
+            agents.stop_session("ws-race"),
             do_get(),
         )
 
@@ -835,7 +834,7 @@ class TestGetSession:
         assert order == ["stop_begin", "stop_end", "get_done"]
         # The returned session is a fresh one (not the stopped one).
         assert new_session is not session
-        assert "ws-race" in _agents
+        assert "ws-race" in agents._agents
 
 
 class TestEnsureAgentHome:
@@ -855,9 +854,10 @@ class TestEnsureAgentHome:
             return_value=("/home/clanker", True)
         )
         ws.populate_home_skel = AsyncMock()
-        app_state = MagicMock()
-        app_state.workspaces = ws
-        app_state.podman = _mock_pod
+
+        agents = _make_agents()
+        agents.app_state.workspaces = ws
+        agents.app_state.podman = _mock_pod
 
         with (
             patch.object(model, "get_workspace_by_id", return_value=fake_ws),
@@ -866,7 +866,7 @@ class TestEnsureAgentHome:
                 return_value=mock_proc,
             ) as mock_exec,
         ):
-            result = await ensure_agent_home("ws1", "cid", app_state)
+            result = await agents.ensure_agent_home("ws1", "cid")
 
         assert result == "/home/clanker"
         ws.ensure_home_symlink.assert_awaited_once()
@@ -875,10 +875,6 @@ class TestEnsureAgentHome:
             "cid",
             "00000000-0000-0000-0000-000000000001",
         )
-        # klangk-setup-pi --force re-writes Pi config each time.  It's
-        # invoked by its full install path (bare-name resolution isn't
-        # reliable across podman/OCI runtimes) -- matching the existing
-        # klangk-setup-home pattern.
         argv = mock_exec.call_args.args
         assert "/opt/klangk/bin/klangk-setup-pi" in argv
         assert "--force" in argv
@@ -890,7 +886,7 @@ class TestEnsureAgentHome:
         the lazy chat-start path retries on first mention (#1162).
         The return value (container home) is unaffected by the rc.
         """
-        from klangk_backend import agent, model
+        from klangk_backend import model
 
         fake_home = tmp_path / "home"
         fake_home.mkdir()
@@ -906,9 +902,10 @@ class TestEnsureAgentHome:
             return_value=("/home/clanker", True)
         )
         ws.populate_home_skel = AsyncMock()
-        app_state = MagicMock()
-        app_state.workspaces = ws
-        app_state.podman = _mock_pod
+
+        agents = _make_agents()
+        agents.app_state.workspaces = ws
+        agents.app_state.podman = _mock_pod
 
         with (
             patch.object(
@@ -917,7 +914,7 @@ class TestEnsureAgentHome:
             patch("asyncio.create_subprocess_exec", return_value=mock_proc),
         ):
             # Must NOT raise -- provisioning is best-effort.
-            result = await agent.ensure_agent_home("ws1", "cid", app_state)
+            result = await agents.ensure_agent_home("ws1", "cid")
 
         assert result == "/home/clanker"
 
@@ -934,16 +931,17 @@ class TestEnsureAgentHome:
             return_value=("/home/clanker", False)
         )
         ws.populate_home_skel = AsyncMock()
-        app_state = MagicMock()
-        app_state.workspaces = ws
-        app_state.podman = _mock_pod
+
+        agents = _make_agents()
+        agents.app_state.workspaces = ws
+        agents.app_state.podman = _mock_pod
 
         with (
             patch.object(
                 model, "get_workspace_by_id", return_value={"user_id": "o"}
             ),
         ):
-            result = await ensure_agent_home("ws1", "cid", app_state)
+            result = await agents.ensure_agent_home("ws1", "cid")
 
         assert result == "/home/clanker"
         # created=False -> skel should NOT be called
@@ -952,14 +950,12 @@ class TestEnsureAgentHome:
     async def test_workspace_not_found_raises(self):
         from klangk_backend import model
 
-        ws = MagicMock()
-        app_state = MagicMock()
-        app_state.workspaces = ws
-        app_state.podman = _mock_pod
+        agents = _make_agents()
+        agents.app_state.podman = _mock_pod
 
         with patch.object(model, "get_workspace_by_id", return_value=None):
             with pytest.raises(AgentSetupError, match="not found"):
-                await ensure_agent_home("ws-gone", "cid", app_state)
+                await agents.ensure_agent_home("ws-gone", "cid")
 
 
 class TestEnsureHome:
@@ -968,7 +964,8 @@ class TestEnsureHome:
     ):
         from klangk_backend import model
 
-        session = AgentSession("ws1", app_state=_make_app_state())
+        agents = _make_agents()
+        session = AgentSession("ws1", agents=agents)
 
         fake_ws = {"user_id": "owner1"}
         fake_home = tmp_path / "home"
@@ -1008,7 +1005,8 @@ class TestEnsureHome:
         )
 
     async def test_ensure_home_cached(self):
-        session = AgentSession("ws-id", app_state=_make_app_state())
+        agents = _make_agents()
+        session = AgentSession("ws-id", agents=agents)
         session._home_ready = True
         result = await session._ensure_home("cid")
         assert result == "/home/clanker"
@@ -1017,7 +1015,8 @@ class TestEnsureHome:
         from klangk_backend import model
         from klangk_backend.agent import AgentSetupError
 
-        session = AgentSession("ws-gone", app_state=_make_app_state())
+        agents = _make_agents()
+        session = AgentSession("ws-gone", agents=agents)
 
         with patch.object(model, "get_workspace_by_id", return_value=None):
             with pytest.raises(AgentSetupError, match="not found in database"):
@@ -1026,78 +1025,88 @@ class TestEnsureHome:
 
 class TestStopSession:
     async def test_stop_existing(self):
-        session = await get_session("ws-1", app_state=_make_app_state())
+        agents = _make_agents()
+        session = await agents.get_session("ws-1")
         session._proc = AsyncMock()
         session._proc.returncode = None
         session._proc.kill = MagicMock()
         session._proc.wait = AsyncMock()
 
-        await stop_session("ws-1")
-        assert "ws-1" not in _agents
+        await agents.stop_session("ws-1")
+        assert "ws-1" not in agents._agents
 
     async def test_stop_nonexistent(self):
-        await stop_session("no-such-ws")  # should not raise
+        agents = _make_agents()
+        await agents.stop_session("no-such-ws")  # should not raise
 
 
 class TestStopAllSessions:
     async def test_stops_every_session(self):
-        app_state = _make_app_state()
+        agents = _make_agents()
         for ws_id in ("ws-a", "ws-b"):
-            session = await get_session(ws_id, app_state=app_state)
+            session = await agents.get_session(ws_id)
             session._proc = AsyncMock()
             session._proc.returncode = None
             session._proc.kill = MagicMock()
             session._proc.wait = AsyncMock()
 
-        assert len(_agents) == 2
-        await stop_all_sessions()
-        assert _agents == {}
+        assert len(agents._agents) == 2
+        await agents.stop_all_sessions()
+        assert agents._agents == {}
 
     async def test_empty_is_noop(self):
-        await stop_all_sessions()
-        assert _agents == {}
+        agents = _make_agents()
+        await agents.stop_all_sessions()
+        assert agents._agents == {}
 
 
 class TestIsRunning:
     def test_no_session(self):
-        assert not is_running("ws-id")
+        agents = _make_agents()
+        assert not agents.is_running("ws-id")
 
     def test_no_proc(self):
-        _agents["ws-id"] = _make_session()
-        assert not is_running("ws-id")
+        agents = _make_agents()
+        agents._agents["ws-id"] = _make_session()
+        assert not agents.is_running("ws-id")
 
     def test_proc_alive(self):
+        agents = _make_agents()
         s = _make_session()
         s._proc = MagicMock()
         s._proc.returncode = None
-        _agents["ws-id"] = s
-        assert is_running("ws-id")
+        agents._agents["ws-id"] = s
+        assert agents.is_running("ws-id")
 
     def test_proc_dead(self):
+        agents = _make_agents()
         s = _make_session()
         s._proc = MagicMock()
         s._proc.returncode = 1
-        _agents["ws-id"] = s
-        assert not is_running("ws-id")
+        agents._agents["ws-id"] = s
+        assert not agents.is_running("ws-id")
 
 
 class TestAnyRunning:
     def test_empty(self):
-        assert not any_running()
+        agents = _make_agents()
+        assert not agents.any_running()
 
     def test_one_alive(self):
+        agents = _make_agents()
         s = _make_session()
         s._proc = MagicMock()
         s._proc.returncode = None
-        _agents["ws-id"] = s
-        assert any_running()
+        agents._agents["ws-id"] = s
+        assert agents.any_running()
 
     def test_all_dead(self):
+        agents = _make_agents()
         s = _make_session()
         s._proc = MagicMock()
         s._proc.returncode = 0
-        _agents["ws-id"] = s
-        assert not any_running()
+        agents._agents["ws-id"] = s
+        assert not agents.any_running()
 
 
 class TestSpawnSerialization:
@@ -1156,7 +1165,10 @@ class TestSpawnSerialization:
 class TestMonitorProcess:
     async def test_monitor_broadcasts_on_death(self):
         from klangk_backend import model
-        from klangk_backend.agent import broadcast_agent_disconnect
+
+        agents = _make_agents()
+        mock_session = MagicMock()
+        agents.get_workspace_session = MagicMock(return_value=mock_session)
 
         with (
             patch.object(
@@ -1170,14 +1182,8 @@ class TestMonitorProcess:
                 "add_chat_message",
                 new_callable=AsyncMock,
             ) as mock_chat,
-            patch(
-                "klangk_backend.agent.get_workspace_session"
-            ) as mock_get_session,
         ):
-            mock_session = MagicMock()
-            mock_get_session.return_value = mock_session
-
-            await broadcast_agent_disconnect("ws-mon")
+            await agents.broadcast_agent_disconnect("ws-mon")
 
             # Presence transitions must NOT be persisted to chat history
             # (they'd linger as stale "has disconnected" on the next visit).
@@ -1191,16 +1197,14 @@ class TestMonitorProcess:
             assert chat_broadcast["message_type"] == model.MSG_SYSTEM
 
     async def test_broadcast_no_workspace(self):
-        from klangk_backend.agent import broadcast_agent_disconnect
-
+        agents = _make_agents()
         # Should not raise when workspace_id is empty
-        await broadcast_agent_disconnect("")
+        await agents.broadcast_agent_disconnect("")
 
     async def test_broadcast_disconnect_deleted_workspace(self):
-        from klangk_backend.agent import broadcast_agent_disconnect
-
+        agents = _make_agents()
         # Should not raise when workspace has been deleted
-        await broadcast_agent_disconnect("deleted-ws-id")
+        await agents.broadcast_agent_disconnect("deleted-ws-id")
 
     async def test_stop_cancels_monitor(self):
         session = _make_session()
@@ -1220,8 +1224,11 @@ class TestMonitorProcess:
     async def test_monitor_auto_restarts(self):
         from klangk_backend import model
 
-        session = _make_session("ws-restart")
-        _agents["ws-restart"] = session
+        agents = _make_agents()
+        session = AgentSession("ws-restart", agents=agents)
+        session._home_ready = True
+        session._last_container_id = "cid"
+        agents._agents["ws-restart"] = session
 
         mock_proc = AsyncMock()
         mock_proc.returncode = 1
@@ -1230,16 +1237,14 @@ class TestMonitorProcess:
         mock_proc.stderr.feed_eof()
         session._proc = mock_proc
 
+        agents.get_workspace_session = MagicMock(return_value=MagicMock())
+
         with (
             patch.object(
                 model,
                 "add_chat_message",
                 new_callable=AsyncMock,
                 return_value={"id": "m1", "message": "msg"},
-            ),
-            patch(
-                "klangk_backend.agent.get_workspace_session",
-                return_value=MagicMock(),
             ),
             patch.object(
                 session,
@@ -1258,8 +1263,11 @@ class TestMonitorProcess:
     async def test_monitor_gives_up_after_max_retries(self):
         from klangk_backend import model
 
-        session = _make_session("ws-giveup")
-        _agents["ws-giveup"] = session
+        agents = _make_agents()
+        session = AgentSession("ws-giveup", agents=agents)
+        session._home_ready = True
+        session._last_container_id = "cid"
+        agents._agents["ws-giveup"] = session
         session._restart_attempts = 2  # already at limit
 
         mock_proc = AsyncMock()
@@ -1269,16 +1277,14 @@ class TestMonitorProcess:
         mock_proc.stderr.feed_eof()
         session._proc = mock_proc
 
+        agents.get_workspace_session = MagicMock(return_value=MagicMock())
+
         with (
             patch.object(
                 model,
                 "add_chat_message",
                 new_callable=AsyncMock,
                 return_value={"id": "m1", "message": "msg"},
-            ),
-            patch(
-                "klangk_backend.agent.get_workspace_session",
-                return_value=MagicMock(),
             ),
             patch.object(
                 session,
@@ -1316,8 +1322,11 @@ class TestMonitorProcess:
         from klangk_backend import model
         import logging
 
-        session = _make_session("ws-stderr")
-        _agents["ws-stderr"] = session
+        agents = _make_agents()
+        session = AgentSession("ws-stderr", agents=agents)
+        session._home_ready = True
+        session._last_container_id = "cid"
+        agents._agents["ws-stderr"] = session
         session._restart_attempts = 2  # will give up
 
         mock_proc = AsyncMock()
@@ -1328,16 +1337,14 @@ class TestMonitorProcess:
         mock_proc.stderr.feed_eof()
         session._proc = mock_proc
 
+        agents.get_workspace_session = MagicMock(return_value=MagicMock())
+
         with (
             patch.object(
                 model,
                 "add_chat_message",
                 new_callable=AsyncMock,
                 return_value={"id": "m1", "message": "msg"},
-            ),
-            patch(
-                "klangk_backend.agent.get_workspace_session",
-                return_value=MagicMock(),
             ),
             caplog.at_level(logging.WARNING, logger="klangk_backend.agent"),
         ):
@@ -1351,8 +1358,11 @@ class TestMonitorProcess:
         """Monitor handles stderr read errors gracefully."""
         from klangk_backend import model
 
-        session = _make_session("ws-stderr-err")
-        _agents["ws-stderr-err"] = session
+        agents = _make_agents()
+        session = AgentSession("ws-stderr-err", agents=agents)
+        session._home_ready = True
+        session._last_container_id = "cid"
+        agents._agents["ws-stderr-err"] = session
         session._restart_attempts = 2
 
         mock_proc = AsyncMock()
@@ -1362,16 +1372,14 @@ class TestMonitorProcess:
         mock_proc.stderr.read = AsyncMock(side_effect=OSError("broken pipe"))
         session._proc = mock_proc
 
+        agents.get_workspace_session = MagicMock(return_value=MagicMock())
+
         with (
             patch.object(
                 model,
                 "add_chat_message",
                 new_callable=AsyncMock,
                 return_value={"id": "m1", "message": "msg"},
-            ),
-            patch(
-                "klangk_backend.agent.get_workspace_session",
-                return_value=MagicMock(),
             ),
         ):
             await session._monitor_process(mock_proc)
@@ -1380,8 +1388,11 @@ class TestMonitorProcess:
     async def test_monitor_restart_failure_logged(self):
         from klangk_backend import model
 
-        session = _make_session("ws-fail")
-        _agents["ws-fail"] = session
+        agents = _make_agents()
+        session = AgentSession("ws-fail", agents=agents)
+        session._home_ready = True
+        session._last_container_id = "cid"
+        agents._agents["ws-fail"] = session
 
         mock_proc = AsyncMock()
         mock_proc.returncode = 1
@@ -1390,16 +1401,14 @@ class TestMonitorProcess:
         mock_proc.stderr.feed_eof()
         session._proc = mock_proc
 
+        agents.get_workspace_session = MagicMock(return_value=MagicMock())
+
         with (
             patch.object(
                 model,
                 "add_chat_message",
                 new_callable=AsyncMock,
                 return_value={"id": "m1", "message": "msg"},
-            ),
-            patch(
-                "klangk_backend.agent.get_workspace_session",
-                return_value=MagicMock(),
             ),
             patch.object(
                 session,
@@ -1416,7 +1425,10 @@ class TestMonitorProcess:
 
     async def test_broadcast_reconnect(self):
         from klangk_backend import model
-        from klangk_backend.agent import broadcast_agent_reconnect
+
+        agents = _make_agents()
+        mock_session = MagicMock()
+        agents.get_workspace_session = MagicMock(return_value=mock_session)
 
         with (
             patch.object(
@@ -1430,14 +1442,8 @@ class TestMonitorProcess:
                 "add_chat_message",
                 new_callable=AsyncMock,
             ) as mock_chat,
-            patch(
-                "klangk_backend.agent.get_workspace_session"
-            ) as mock_get_session,
         ):
-            mock_session = MagicMock()
-            mock_get_session.return_value = mock_session
-
-            await broadcast_agent_reconnect("ws-rc")
+            await agents.broadcast_agent_reconnect("ws-rc")
 
             # Reconnect is ephemeral too — never persisted.
             mock_chat.assert_not_awaited()
@@ -1448,23 +1454,24 @@ class TestMonitorProcess:
             assert chat_broadcast["message_type"] == model.MSG_SYSTEM
 
     async def test_broadcast_reconnect_no_workspace(self):
-        from klangk_backend.agent import broadcast_agent_reconnect
-
-        await broadcast_agent_reconnect("")
+        agents = _make_agents()
+        await agents.broadcast_agent_reconnect("")
 
     async def test_broadcast_reconnect_deleted_workspace(self):
-        from klangk_backend.agent import broadcast_agent_reconnect
-
+        agents = _make_agents()
         # Should not raise when workspace has been deleted
-        await broadcast_agent_reconnect("deleted-ws-id")
+        await agents.broadcast_agent_reconnect("deleted-ws-id")
 
     async def test_monitor_skips_restart_if_container_gone(self, caplog):
         """Monitor does not restart when the container has been removed."""
         from klangk_backend import model
         import logging
 
-        session = _make_session("ws-gone")
-        _agents["ws-gone"] = session
+        agents = _make_agents()
+        session = AgentSession("ws-gone", agents=agents)
+        session._home_ready = True
+        session._last_container_id = "cid"
+        agents._agents["ws-gone"] = session
 
         mock_proc = AsyncMock()
         mock_proc.returncode = 1
@@ -1473,16 +1480,14 @@ class TestMonitorProcess:
         mock_proc.stderr.feed_eof()
         session._proc = mock_proc
 
+        agents.get_workspace_session = MagicMock(return_value=MagicMock())
+
         with (
             patch.object(
                 model,
                 "add_chat_message",
                 new_callable=AsyncMock,
                 return_value={"id": "m1", "message": "msg"},
-            ),
-            patch(
-                "klangk_backend.agent.get_workspace_session",
-                return_value=MagicMock(),
             ),
             patch.object(
                 session.app_state.container_registry,
@@ -1507,8 +1512,11 @@ class TestMonitorProcess:
     async def test_monitor_skips_restart_if_already_restarted(self):
         from klangk_backend import model
 
-        session = _make_session("ws-skip")
-        _agents["ws-skip"] = session
+        agents = _make_agents()
+        session = AgentSession("ws-skip", agents=agents)
+        session._home_ready = True
+        session._last_container_id = "cid"
+        agents._agents["ws-skip"] = session
 
         dead_proc = AsyncMock()
         dead_proc.returncode = 1
@@ -1521,16 +1529,14 @@ class TestMonitorProcess:
             # Simulate something else restarting the proc during sleep
             session._proc = AsyncMock()
 
+        agents.get_workspace_session = MagicMock(return_value=MagicMock())
+
         with (
             patch.object(
                 model,
                 "add_chat_message",
                 new_callable=AsyncMock,
                 return_value={"id": "m1", "message": "msg"},
-            ),
-            patch(
-                "klangk_backend.agent.get_workspace_session",
-                return_value=MagicMock(),
             ),
             patch(
                 "klangk_backend.agent.asyncio.sleep",

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -19,7 +19,6 @@ from klangk_backend import (
     model,
     podman,
     workspaces as ws_mod,
-    wshandler,
 )
 from klangk_backend.container import ContainerRegistry
 from klangk_backend import oidc as oidc_mod
@@ -59,7 +58,8 @@ async def app(db, temp_data_dir):
     app.state.oidc = oidc_mod.OIDC(app.state)
     app.state.plugins = plugins_mod.Plugins(app.state)
     app.state.workspaces = ws_mod.Workspaces(app.state)
-    agent.get_workspace_session = sockets.get_session
+    app.state.agents = agent.Agents(app.state)
+    app.state.agents.get_workspace_session = sockets.get_session
 
     app.include_router(api.root_router)
     app.include_router(api.router, prefix=API_PREFIX)
@@ -1637,7 +1637,7 @@ class TestWorkspaceRoutes:
                 new_callable=AsyncMock,
             ) as mock_rm,
             patch.object(
-                wshandler.agent,
+                app.state.agents,
                 "stop_session",
                 new_callable=AsyncMock,
             ) as mock_stop_agent,

--- a/src/backend/tests/test_bringup.py
+++ b/src/backend/tests/test_bringup.py
@@ -2,40 +2,42 @@
 
 ``bringup`` runs inside ``start_container`` for every fresh container.
 It provisions the agent home and fires the service command. The
-underlying primitives (``agent.ensure_agent_home``,
+underlying primitives (``Agents.ensure_agent_home``,
 ``Terminal.ensure_service_session``) have their own coverage; these
 tests pin the orchestration: that both are called in the right order
 with the right args, and that the service-command half is skipped when
 no command is configured.
 """
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 from klangk_backend import bringup
+from klangk_backend.agent import Agents
 
 _app_state = MagicMock()
 _app_state.terminal.ensure_service_session = AsyncMock()
+_app_state.agents = MagicMock(spec=Agents)
+_app_state.agents.ensure_agent_home = AsyncMock(return_value="/home/clanker")
 
 
 class TestBringup:
     def setup_method(self):
         _app_state.terminal.ensure_service_session.reset_mock()
+        _app_state.agents.ensure_agent_home.reset_mock()
+        _app_state.agents.ensure_agent_home.return_value = "/home/clanker"
 
     async def test_provisions_home_and_fires_service_command(self):
         """A configured service command fires after the home is ready."""
-        with patch(
-            "klangk_backend.bringup.agent.ensure_agent_home",
-            new_callable=AsyncMock,
-            return_value="/home/clanker",
-        ) as mock_home:
-            await bringup.bringup(
-                "ws-id",
-                "cid",
-                "openclaw gateway",
-                setup_state="complete",
-                app_state=_app_state,
-            )
-        mock_home.assert_awaited_once_with("ws-id", "cid", _app_state)
+        await bringup.bringup(
+            "ws-id",
+            "cid",
+            "openclaw gateway",
+            setup_state="complete",
+            app_state=_app_state,
+        )
+        _app_state.agents.ensure_agent_home.assert_awaited_once_with(
+            "ws-id", "cid"
+        )
         _app_state.terminal.ensure_service_session.assert_awaited_once_with(
             "cid",
             "/home/clanker",
@@ -45,27 +47,19 @@ class TestBringup:
 
     async def test_skips_service_command_when_none(self):
         """No service_command -> only the agent home is provisioned."""
-        with patch(
-            "klangk_backend.bringup.agent.ensure_agent_home",
-            new_callable=AsyncMock,
-            return_value="/home/clanker",
-        ) as mock_home:
-            await bringup.bringup(
-                "ws-id", "cid", None, "complete", app_state=_app_state
-            )
-        mock_home.assert_awaited_once_with("ws-id", "cid", _app_state)
+        await bringup.bringup(
+            "ws-id", "cid", None, "complete", app_state=_app_state
+        )
+        _app_state.agents.ensure_agent_home.assert_awaited_once_with(
+            "ws-id", "cid"
+        )
         _app_state.terminal.ensure_service_session.assert_not_awaited()
 
     async def test_skips_service_command_when_empty(self):
         """An empty service_command string is treated as 'none'."""
-        with patch(
-            "klangk_backend.bringup.agent.ensure_agent_home",
-            new_callable=AsyncMock,
-            return_value="/home/clanker",
-        ):
-            await bringup.bringup(
-                "ws-id", "cid", "", "complete", app_state=_app_state
-            )
+        await bringup.bringup(
+            "ws-id", "cid", "", "complete", app_state=_app_state
+        )
         _app_state.terminal.ensure_service_session.assert_not_awaited()
 
     async def test_threads_setup_state_through_predicate(self):
@@ -75,18 +69,13 @@ class TestBringup:
         gating happens inside it via should_fire_service_command), so the
         orchestrator's job is just to pass the value through unchanged.
         """
-        with patch(
-            "klangk_backend.bringup.agent.ensure_agent_home",
-            new_callable=AsyncMock,
-            return_value="/home/clanker",
-        ):
-            await bringup.bringup(
-                "ws-id",
-                "cid",
-                "openclaw gateway",
-                setup_state="pending",
-                app_state=_app_state,
-            )
+        await bringup.bringup(
+            "ws-id",
+            "cid",
+            "openclaw gateway",
+            setup_state="pending",
+            app_state=_app_state,
+        )
         _app_state.terminal.ensure_service_session.assert_awaited_once_with(
             "cid",
             "/home/clanker",
@@ -96,18 +85,13 @@ class TestBringup:
 
     async def test_threads_none_setup_state(self):
         """A None setup_state (caller omitted it) is passed through."""
-        with patch(
-            "klangk_backend.bringup.agent.ensure_agent_home",
-            new_callable=AsyncMock,
-            return_value="/home/clanker",
-        ):
-            await bringup.bringup(
-                "ws-id",
-                "cid",
-                "openclaw gateway",
-                None,
-                app_state=_app_state,
-            )
+        await bringup.bringup(
+            "ws-id",
+            "cid",
+            "openclaw gateway",
+            None,
+            app_state=_app_state,
+        )
         _app_state.terminal.ensure_service_session.assert_awaited_once_with(
             "cid",
             "/home/clanker",

--- a/src/backend/tests/test_main.py
+++ b/src/backend/tests/test_main.py
@@ -13,7 +13,14 @@ from fastapi import FastAPI
 from httpx import AsyncClient, ASGITransport
 from sqlalchemy.exc import IntegrityError as SAIntegrityError
 
-from klangk_backend import main, model, oidc, plugins, workspaces
+from klangk_backend import (
+    agent as agent_mod,
+    main,
+    model,
+    oidc,
+    plugins,
+    workspaces,
+)
 from klangk_backend.container import ContainerRegistry
 from klangk_backend.settings import KlangkSettings
 from klangk_backend.wshandler.session import WebSocketState
@@ -41,6 +48,7 @@ def _make_app_state(settings=None):
     app_state.oidc = oidc.OIDC(app_state)
     app_state.plugins = plugins.Plugins(app_state)
     app_state.workspaces = workspaces.Workspaces(app_state)
+    app_state.agents = agent_mod.Agents(app_state)
     return app_state
 
 
@@ -371,6 +379,7 @@ class TestLifespan:
         app.state.oidc = oidc.OIDC(app.state)
         app.state.plugins = plugins.Plugins(app.state)
         app.state.workspaces = workspaces.Workspaces(app.state)
+        app.state.agents = agent_mod.Agents(app.state)
         registry = app_state.container_registry
         with (
             patch.object(
@@ -416,6 +425,7 @@ class TestLifespan:
         app.state.oidc = oidc.OIDC(app.state)
         app.state.plugins = plugins.Plugins(app.state)
         app.state.workspaces = workspaces.Workspaces(app.state)
+        app.state.agents = agent_mod.Agents(app.state)
         registry = app_state.container_registry
         with (
             patch.object(
@@ -507,8 +517,9 @@ class TestStartupShutdownRestart:
                 "klangk_backend.main.wshandler.disconnect_all_websockets",
                 new_callable=AsyncMock,
             ) as mock_disc,
-            patch(
-                "klangk_backend.main.agent.stop_all_sessions",
+            patch.object(
+                app_state.agents,
+                "stop_all_sessions",
                 new_callable=AsyncMock,
             ) as mock_stop_agents,
             patch(
@@ -637,6 +648,7 @@ class TestStartupShutdownRestart:
         app.state.oidc = oidc.OIDC(app.state)
         app.state.plugins = plugins.Plugins(app.state)
         app.state.workspaces = workspaces.Workspaces(app.state)
+        app.state.agents = agent_mod.Agents(app.state)
         registry = app_state.container_registry
         loop = asyncio.get_running_loop()
         with (

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -16,6 +16,7 @@ from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
 from fastapi import WebSocketDisconnect
 
 from klangk_backend import (
+    agent as agent_mod,
     model,
     wshandler,
     container,
@@ -107,6 +108,7 @@ def _make_app_state(registry=None, sockets=None):
     # its methods via patch.object(_mock_term, ...).
     app_state.terminal = _mock_term
     app_state.workspaces = ws_mod.Workspaces(app_state)
+    app_state.agents = agent_mod.Agents(app_state)
     return app_state
 
 
@@ -4493,8 +4495,8 @@ class TestResetWorkspaceState:
         app_state = _make_app_state()
         sockets = app_state.sockets
         ws_id = "ws-agent-stop"
-        with patch(
-            "klangk_backend.agent.stop_session", new_callable=AsyncMock
+        with patch.object(
+            app_state.agents, "stop_session", new_callable=AsyncMock
         ) as mock_stop:
             await reset_workspace_state(sockets, ws_id)
             mock_stop.assert_awaited_once_with(ws_id)
@@ -5770,8 +5772,9 @@ class TestHandleShutdownContainer:
                     "stop_and_remove_container",
                     new_callable=AsyncMock,
                 ),
-                patch(
-                    "klangk_backend.agent.stop_session",
+                patch.object(
+                    app_state.agents,
+                    "stop_session",
                     new_callable=AsyncMock,
                 ) as mock_stop,
             ):
@@ -8982,8 +8985,9 @@ class TestChatFollowUp:
                 "time": time.monotonic(),
                 "interjected": False,
             }
-            with patch(
-                "klangk_backend.agent.get_session",
+            with patch.object(
+                app_state.agents,
+                "get_session",
                 return_value=mock_session,
             ):
                 await conn.handle_chat_send({"message": "what about now?"})
@@ -9023,8 +9027,9 @@ class TestChatFollowUp:
                 "time": time.monotonic(),
                 "interjected": True,
             }
-            with patch(
-                "klangk_backend.agent.get_session",
+            with patch.object(
+                app_state.agents,
+                "get_session",
                 return_value=mock_session,
             ):
                 await conn.handle_chat_send({"message": "still here?"})
@@ -9265,8 +9270,9 @@ class TestChatSend:
         session = sockets.get_or_create_session(workspace["id"], app_state)
         await session.add_subscriber(sock, "cid")
         try:
-            with patch(
-                "klangk_backend.agent.get_session",
+            with patch.object(
+                app_state.agents,
+                "get_session",
                 return_value=mock_session,
             ):
                 await conn.handle_chat_send(
@@ -9318,8 +9324,9 @@ class TestChatSend:
         session = sockets.get_or_create_session(workspace["id"], app_state)
         await session.add_subscriber(sock, "cid")
         try:
-            with patch(
-                "klangk_backend.agent.get_session",
+            with patch.object(
+                app_state.agents,
+                "get_session",
                 return_value=mock_session,
             ):
                 await conn.handle_chat_send({"message": "@clanker"})
@@ -9348,8 +9355,9 @@ class TestChatSend:
         session = sockets.get_or_create_session(workspace["id"], app_state)
         await session.add_subscriber(sock, "cid")
         try:
-            with patch(
-                "klangk_backend.agent.get_session",
+            with patch.object(
+                app_state.agents,
+                "get_session",
                 side_effect=RuntimeError("boom"),
             ):
                 await conn.handle_chat_send({"message": "@clanker help"})
@@ -9387,8 +9395,9 @@ class TestChatSend:
         session = sockets.get_or_create_session(workspace["id"], app_state)
         await session.add_subscriber(sock, "cid")
         try:
-            with patch(
-                "klangk_backend.agent.get_session",
+            with patch.object(
+                app_state.agents,
+                "get_session",
                 return_value=mock_session,
             ):
                 await conn.handle_chat_send({"message": "@clanker hello"})
@@ -10648,8 +10657,9 @@ class TestStartAgentIfNeeded:
         mock_agent_session.ensure_started = AsyncMock()
 
         try:
-            with patch(
-                "klangk_backend.agent.get_session",
+            with patch.object(
+                app_state.agents,
+                "get_session",
                 return_value=mock_agent_session,
             ):
                 await conn._start_agent_if_needed()
@@ -10663,8 +10673,9 @@ class TestStartAgentIfNeeded:
         conn = _base_conn(user=user, ws=sock)
         conn.workspace_id = "ws-fail"
 
-        with patch(
-            "klangk_backend.agent.get_session",
+        with patch.object(
+            conn.app_state.agents,
+            "get_session",
             side_effect=RuntimeError("nope"),
         ):
             # Should not raise
@@ -10761,8 +10772,9 @@ class TestPresenceIncludesAgent:
             session,
             app_state,
         ):
-            with patch(
-                "klangk_backend.agent.is_running",
+            with patch.object(
+                app_state.agents,
+                "is_running",
                 side_effect=lambda ws_id: ws_id == workspace["id"],
             ):
                 users = await get_presence_list(
@@ -10785,8 +10797,9 @@ class TestPresenceIncludesAgent:
             session,
             app_state,
         ):
-            with patch(
-                "klangk_backend.agent.is_running",
+            with patch.object(
+                app_state.agents,
+                "is_running",
                 side_effect=lambda ws_id: ws_id == "other-workspace",
             ):
                 users = await get_presence_list(
@@ -10847,8 +10860,9 @@ class TestAgentMentionOtherMsgsContext:
         await session.add_subscriber(sock, "cid")
 
         try:
-            with patch(
-                "klangk_backend.agent.get_session",
+            with patch.object(
+                app_state.agents,
+                "get_session",
                 return_value=mock_session,
             ):
                 await handle_agent_mention(
@@ -10912,8 +10926,9 @@ class TestAgentMentionAskerIdentity:
         await session.add_subscriber(sock, "cid")
 
         try:
-            with patch(
-                "klangk_backend.agent.get_session",
+            with patch.object(
+                app_state.agents,
+                "get_session",
                 return_value=mock_session,
             ):
                 await handle_agent_mention(


### PR DESCRIPTION
## Summary

- Promote module-level `_agents` dict, `_agents_lock`, and `get_workspace_session` callback into an `Agents(app_state)` class on `app.state.agents`
- `AgentSession` now takes an `Agents` back-reference instead of relying on module globals for `is_disabled` checks and broadcast calls
- `ensure_agent_home`, `get_session`, `stop_session`, `stop_all_sessions`, `is_running`, `any_running`, `broadcast_agent_disconnect`, `broadcast_agent_reconnect` are now instance methods on `Agents`
- All callers updated: `main.py`, `bringup.py`, `wshandler/connection.py`, `wshandler/session.py`, `wshandler/helpers.py`, `wshandler/agent_mention.py`
- `bringup.py` no longer imports `agent` directly — reaches it via `app_state.agents`
- `wshandler/__init__.py` drops the `agent` module re-export

## Test plan

- [x] All 2379 backend tests pass
- [x] 100% coverage maintained
- [x] Pre-commit hooks pass (ruff, deferred-imports, etc.)

Closes #1486
