### PR TITLE
Promote emailsvc.py to EmailService(app_state) (#1483)

### DIFF
--- a/src/backend/klangk_backend/api/admin.py
+++ b/src/backend/klangk_backend/api/admin.py
@@ -15,7 +15,6 @@ from pydantic import BaseModel
 from .. import (
     acl,
     auth,
-    emailsvc,
     model,
     wshandler,
 )
@@ -50,6 +49,7 @@ async def send_invitation(
     req: SendInviteRequest,
     request: Request,
     admin: dict = Depends(acl.has_permission("admin")),
+    app_state=Depends(get_app_state_dep),
 ):
     """Send an invitation email (admin only)."""
     if not auth.invitations_enabled():
@@ -81,7 +81,9 @@ async def send_invitation(
     )
 
     await send_email(
-        emailsvc.send_invitation_email(req.email, invite_url, admin["email"]),
+        app_state.email.send_invitation_email(
+            req.email, invite_url, admin["email"]
+        ),
         req.email,
         "invitation email",
     )
@@ -134,6 +136,7 @@ async def resend_invitation(
     invitation_id: str,
     request: Request,
     admin: dict = Depends(acl.has_permission("admin")),
+    app_state=Depends(get_app_state_dep),
 ):
     """Resend an invitation email (admin only)."""
     invitation = await model.get_invitation(invitation_id)
@@ -152,7 +155,7 @@ async def resend_invitation(
     )
 
     await send_email(
-        emailsvc.send_invitation_email(
+        app_state.email.send_invitation_email(
             invitation["email"], invite_url, admin["email"]
         ),
         invitation["email"],
@@ -187,6 +190,7 @@ async def admin_create_user(
     req: AdminCreateUserRequest,
     request: Request,
     admin: dict = Depends(acl.has_permission("admin")),
+    app_state=Depends(get_app_state_dep),
 ):
     """Create a user (admin only).
 
@@ -220,7 +224,9 @@ async def admin_create_user(
                 db, user_id, req.email, password_hash
             )
             await send_email(
-                emailsvc.send_verification_email(req.email, verification_url),
+                app_state.email.send_verification_email(
+                    req.email, verification_url
+                ),
                 req.email,
                 "verification email",
             )

--- a/src/backend/klangk_backend/api/auth.py
+++ b/src/backend/klangk_backend/api/auth.py
@@ -17,7 +17,6 @@ from pydantic import BaseModel
 
 from .. import (
     auth,
-    emailsvc,
     model,
     wshandler,
 )
@@ -68,6 +67,7 @@ async def verify_workspace_token(request: Request):
 async def register(
     req: auth.RegisterRequest,
     request: Request,
+    app_state=Depends(get_app_state_dep),
 ):
     if not request.app.state.oidc.password_login_allowed():
         raise HTTPException(
@@ -117,7 +117,9 @@ async def register(
         )
         logger.info("User inserted (uncommitted): %s", req.email)
         await send_email(
-            emailsvc.send_verification_email(req.email, verification_url),
+            app_state.email.send_verification_email(
+                req.email, verification_url
+            ),
             req.email,
             "verification email",
         )
@@ -167,6 +169,7 @@ RESEND_COOLDOWN_SECONDS = 60
 async def resend_verification(
     req: auth.LoginRequest,
     request: Request,
+    app_state=Depends(get_app_state_dep),
 ):
     """Resend verification email. Requires email+password to prevent abuse."""
     user = await model.get_user_by_email(req.email)
@@ -200,7 +203,7 @@ async def resend_verification(
         f"{proto}://{hostname}{base_path}/#/verify?token={verification_token}"
     )
     await send_email(
-        emailsvc.send_verification_email(req.email, verification_url),
+        app_state.email.send_verification_email(req.email, verification_url),
         req.email,
         "verification email",
     )
@@ -216,7 +219,11 @@ RESET_COOLDOWN_SECONDS = 60
 
 
 @router.post("/auth/forgot-password")
-async def forgot_password(req: ForgotPasswordRequest, request: Request):
+async def forgot_password(
+    req: ForgotPasswordRequest,
+    request: Request,
+    app_state=Depends(get_app_state_dep),
+):
     """Send a password reset email if the account exists."""
     user = await model.get_user_by_email(req.email)
     if user is None:
@@ -242,7 +249,7 @@ async def forgot_password(req: ForgotPasswordRequest, request: Request):
         f"{proto}://{hostname}{base_path}/#/reset-password?token={reset_token}"
     )
     await send_email(
-        emailsvc.send_password_reset_email(req.email, reset_url),
+        app_state.email.send_password_reset_email(req.email, reset_url),
         req.email,
         "password reset email",
     )
@@ -391,6 +398,7 @@ async def change_email(
     req: ChangeEmailRequest,
     request: Request,
     user: dict = Depends(auth.get_current_user),
+    app_state=Depends(get_app_state_dep),
 ):
     """Change email. Requires password. Marks account as unverified."""
     stored = await model.get_user_by_email(user["email"])
@@ -423,7 +431,7 @@ async def change_email(
     token = auth.create_verification_token(user["id"])
     url = f"{proto}://{hostname}{base_path}/#/verify?token={token}"
     await send_email(
-        emailsvc.send_verification_email(req.email, url),
+        app_state.email.send_verification_email(req.email, url),
         req.email,
         "verification email",
     )

--- a/src/backend/klangk_backend/emailsvc.py
+++ b/src/backend/klangk_backend/emailsvc.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+import os
 import shutil
 from dataclasses import dataclass
 from email.message import EmailMessage
@@ -18,181 +19,13 @@ from jinja2 import (
 
 from . import auth
 from .exceptions import SendmailError
-from .util import customize_dir, resolve_env_value
+from .settings import resolve_indirection
 
 logger = logging.getLogger(__name__)
 
 # Supported email events. Each maps to a directory under
 # email_templates/ holding subject.txt, body.txt, body.html. See #1165.
 EMAIL_EVENTS = ("verify", "reset", "invite")
-
-# Cached Jinja environment. Built lazily on first render; reset via
-# reset_template_env() (mainly for tests that flip
-# KLANGK_EMAIL_TEMPLATES_DIR between cases).
-_env: Environment | None = None
-
-
-def resolve_password() -> str | None:
-    """Resolve KLANGK_SMTP_PASSWORD via resolve_env_value."""
-    return resolve_env_value("KLANGK_SMTP_PASSWORD")
-
-
-def product_name() -> str:
-    """Configured product name (KLANGK_PRODUCT_NAME), default 'Klangk'.
-
-    Used to white-label emails so deployments can rename the product
-    without editing source. Resolved at call time via resolve_env_value so
-    file:/cmd: prefixes work and value changes take effect per send.
-    """
-    return resolve_env_value("KLANGK_PRODUCT_NAME", "Klangk") or "Klangk"
-
-
-def smtp_config() -> dict:
-    """Read SMTP configuration from environment at call time."""
-    return {
-        "host": resolve_env_value("KLANGK_SMTP_HOST"),
-        "port": int(resolve_env_value("KLANGK_SMTP_PORT", "587")),
-        "user": resolve_env_value("KLANGK_SMTP_USER"),
-        "password": resolve_password(),
-        "from_addr": resolve_env_value("KLANGK_SMTP_FROM"),
-        "use_tls": resolve_env_value("KLANGK_SMTP_USE_TLS", "true").lower()
-        in ("true", "1"),
-    }
-
-
-def use_smtp() -> bool:
-    """Return True if SMTP is configured, False to use sendmail."""
-    return bool(resolve_env_value("KLANGK_SMTP_HOST"))
-
-
-def reply_to() -> str | None:
-    """Configured Reply-To address (KLANGK_SMTP_REPLY_TO), or None.
-
-    Compliance/deliverability knob: orgs want a monitored reply address
-    distinct from the envelope From. None -> no header (today's behavior).
-    See #1165 / #261.
-    """
-    return resolve_env_value("KLANGK_SMTP_REPLY_TO", "") or None
-
-
-def _set_headers(msg: EmailMessage) -> None:
-    """Apply optional headers shared by every outgoing message."""
-    rt = reply_to()
-    if rt:
-        msg["Reply-To"] = rt
-
-
-async def send_via_smtp(msg: EmailMessage) -> None:
-    cfg = smtp_config()
-    logger.debug(
-        "SMTP config: host=%s port=%s user=%s tls=%s",
-        cfg["host"],
-        cfg["port"],
-        cfg["user"],
-        cfg["use_tls"],
-    )
-    kwargs: dict = {
-        "hostname": cfg["host"],
-        "port": cfg["port"],
-    }
-    if cfg["use_tls"]:
-        kwargs["start_tls"] = True
-    if cfg["user"] and cfg["password"]:
-        kwargs["username"] = cfg["user"]
-        kwargs["password"] = cfg["password"]
-    await aiosmtplib.send(msg, **kwargs)
-    logger.info("Email sent via SMTP to %s", msg["To"])
-
-
-async def send_via_sendmail(msg: EmailMessage) -> None:
-    sendmail = resolve_env_value("KLANGK_SENDMAIL_PATH", "sendmail")
-    logger.info("Using sendmail at: %s", sendmail)
-    resolved = shutil.which(sendmail)
-    logger.info("Resolved sendmail path: %s", resolved)
-    proc = await asyncio.create_subprocess_exec(
-        sendmail,
-        "-t",
-        stdin=asyncio.subprocess.PIPE,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-    )
-    stdout, stderr = await proc.communicate(msg.as_bytes())
-    if proc.returncode != 0:
-        raise SendmailError(
-            f"sendmail ({sendmail}) exited with code {proc.returncode}: {stderr.decode()}"
-        )
-    logger.info("Email sent via sendmail to %s", msg["To"])
-
-
-def reset_template_env() -> None:
-    """Drop the cached Jinja environment.
-
-    For tests that change KLANGK_EMAIL_TEMPLATES_DIR between cases, since
-    the environment is built once and cached.
-    """
-    global _env
-    _env = None
-
-
-def _brand_ctx() -> dict:
-    """Global branding variables surfaced to every email template.
-
-    Resolved at call time so file:/cmd: prefixes work and value changes
-    take effect without a restart. Mirrors what /config exposes to the
-    frontend (see api.get_config).
-    """
-    return {
-        "product_name": product_name(),
-        "logo_url": resolve_env_value("KLANGK_LOGO_URL", "") or "",
-        "brand_color": resolve_env_value("KLANGK_BRAND_COLOR", "#E65100")
-        or "#E65100",
-        # Configurable legal & support links (#1177). Plain env values, no
-        # file:/cmd: resolution -- they are public and shown in the email
-        # footer to all recipients. Mirrors what /config exposes to the
-        # frontend; the base template renders whatever is set.
-        "terms_url": resolve_env_value("KLANGK_TERMS_URL") or "",
-        "privacy_url": resolve_env_value("KLANGK_PRIVACY_URL") or "",
-        "aup_url": resolve_env_value("KLANGK_AUP_URL") or "",
-        "support_url": resolve_env_value("KLANGK_SUPPORT_URL") or "",
-        "support_email": resolve_env_value("KLANGK_SUPPORT_EMAIL") or "",
-    }
-
-
-def _template_env() -> Environment:
-    """Build (and cache) the Jinja environment.
-
-    Uses a ChoiceLoader: a deployer directory (KLANGK_EMAIL_TEMPLATES_DIR)
-    is tried first so it shadows the built-ins on a per-file basis; the
-    built-in package templates (email_templates/) are the fallback. Both
-    {% extends %} and {% include %} resolve through the same chain, so
-    overriding just base.html re-brands every email at once. See #1165.
-    """
-    global _env
-    if _env is None:
-        loaders = []
-        user_dir = resolve_env_value("KLANGK_EMAIL_TEMPLATES_DIR", "")
-        if not user_dir:
-            candidate = Path(customize_dir()) / "email-templates"
-            if candidate.is_dir():
-                user_dir = str(candidate)
-        if user_dir:
-            path = Path(user_dir)
-            if path.is_dir():
-                logger.info("Email templates loaded from %s", path)
-                loaders.append(FileSystemLoader(str(path)))
-        loaders.append(PackageLoader("klangk_backend", "email_templates"))
-        _env = Environment(
-            loader=ChoiceLoader(loaders),
-            # autoescape by extension: .html/.xml are escaped (closes the
-            # template-authoring XSS gap str.format leaves open); .txt is
-            # NOT (so <{{ link }}> stays literal). NOTE: a .html.j2 suffix
-            # would NOT match and silently disable escaping -- keep .html.
-            autoescape=select_autoescape(["html", "xml"]),
-            trim_blocks=True,
-            lstrip_blocks=True,
-            auto_reload=False,
-        )
-    return _env
 
 
 @dataclass(frozen=True)
@@ -204,93 +37,275 @@ class EmailRender:
     html: str
 
 
-def render_email(
-    event: str,
-    *,
-    link: str,
-    expiry_hours: int | float,
-    invited_by: str = "",
-) -> EmailRender:
-    """Render subject/text/html for an auth email event.
+class EmailService:
+    """Owned email subsystem wired onto ``app.state.email`` (#1483).
 
-    ``event`` is one of EMAIL_EVENTS (verify / reset / invite). ``link`` is
-    the per-email callback URL; ``expiry_hours`` is the real token TTL
-    (fixing the prior drift where bodies hardcoded "72 hours"/"1 hour"
-    regardless of config); ``invited_by`` is the inviter's email (invite
-    only). Branding globals come from _brand_ctx().
-
-    The subject receives only branding vars -- never the link/token -- so
-    tokens can't leak into mail-server subject logs.
+    Replaces the flat module-level functions that read config at call
+    time. Config is read from ``self.settings`` (``KlangkSettings``);
+    every env var the module touches has a matching typed field.
     """
-    if event not in EMAIL_EVENTS:
-        raise ValueError(f"unknown email event: {event!r}")
-    env = _template_env()
-    ctx = {
-        **_brand_ctx(),
-        "link": link,
-        "expiry_hours": int(expiry_hours),
-        "invited_by": invited_by,
-    }
-    subject = env.get_template(f"{event}/subject.txt").render(**ctx).strip()
-    text = env.get_template(f"{event}/body.txt").render(**ctx)
-    html = env.get_template(f"{event}/body.html").render(**ctx)
-    return EmailRender(subject=subject, text=text, html=html)
 
+    def __init__(self, app_state) -> None:
+        self.app_state = app_state
+        self.settings = app_state.settings
+        # Per-instance cached Jinja environment. Built lazily on first
+        # render; reset via reset_template_env() (mainly for tests that
+        # flip KLANGK_EMAIL_TEMPLATES_DIR between cases).
+        self._env: Environment | None = None
 
-def build_multipart(to: str, rendered: EmailRender) -> EmailMessage:
-    """Assemble a multipart/alternative (text + HTML) message."""
-    cfg = smtp_config()
-    msg = EmailMessage()
-    msg["Subject"] = rendered.subject
-    msg["From"] = cfg["from_addr"] or cfg["user"] or "noreply@localhost"
-    msg["To"] = to
-    msg.set_content(rendered.text)
-    msg.add_alternative(rendered.html, subtype="html")
-    _set_headers(msg)
-    return msg
+    # --- config ---
 
+    def resolve_password(self) -> str | None:
+        """Resolve KLANGK_SMTP_PASSWORD.
 
-async def _send(msg: EmailMessage) -> None:
-    """Deliver via SMTP (if configured) or local sendmail."""
-    if use_smtp():
-        await send_via_smtp(msg)
-    else:
-        await send_via_sendmail(msg)
+        ``file:``/``cmd:`` prefixes are dereferenced here at call time.
+        Remove this indirection (read ``self.settings.smtp_password``
+        directly) once #1461 moves resolution into KlangkSettings at
+        construction.
+        """
+        return resolve_indirection(
+            self.settings.smtp_password, "KLANGK_SMTP_PASSWORD"
+        )
 
+    def product_name(self) -> str:
+        """Configured product name (KLANGK_PRODUCT_NAME), default 'Klangk'."""
+        return self.settings.product_name or "Klangk"
 
-async def send_verification_email(to: str, verification_url: str) -> None:
-    """Send a verification email with the given callback URL."""
-    rendered = render_email(
-        "verify",
-        link=verification_url,
-        expiry_hours=auth.VERIFY_TOKEN_EXPIRE_HOURS,
-    )
-    await _send(build_multipart(to, rendered))
-    logger.info("Verification email sent to %s", to)
+    def smtp_config(self) -> dict:
+        """Read SMTP configuration from settings at call time."""
+        return {
+            "host": self.settings.smtp_host,
+            "port": int(self.settings.smtp_port or "587"),
+            "user": self.settings.smtp_user,
+            "password": self.resolve_password(),
+            "from_addr": self.settings.smtp_from,
+            "use_tls": (self.settings.smtp_use_tls or "true").lower()
+            in ("true", "1"),
+        }
 
+    def use_smtp(self) -> bool:
+        """Return True if SMTP is configured, False to use sendmail."""
+        return bool(self.settings.smtp_host)
 
-async def send_password_reset_email(to: str, reset_url: str) -> None:
-    """Send a password reset email with the given callback URL."""
-    rendered = render_email(
-        "reset",
-        link=reset_url,
-        expiry_hours=auth.RESET_TOKEN_EXPIRE_HOURS,
-    )
-    await _send(build_multipart(to, rendered))
-    logger.info("Password reset email sent to %s", to)
+    def reply_to(self) -> str | None:
+        """Configured Reply-To address (KLANGK_SMTP_REPLY_TO), or None.
 
+        Compliance/deliverability knob: orgs want a monitored reply address
+        distinct from the envelope From. None -> no header (today's
+        behavior). See #1165 / #261.
+        """
+        return self.settings.smtp_reply_to or None
 
-async def send_invitation_email(
-    to: str, invite_url: str, invited_by_email: str
-) -> None:
-    """Send an invitation email with the given registration URL."""
-    rendered = render_email(
-        "invite",
-        link=invite_url,
-        expiry_hours=auth.INVITE_TOKEN_EXPIRE_HOURS,
-        invited_by=invited_by_email,
-    )
-    await _send(build_multipart(to, rendered))
-    logger.info(
-        "Invitation email sent to %s (invited by %s)", to, invited_by_email
-    )
+    def _set_headers(self, msg: EmailMessage) -> None:
+        """Apply optional headers shared by every outgoing message."""
+        rt = self.reply_to()
+        if rt:
+            msg["Reply-To"] = rt
+
+    # --- transport ---
+
+    async def send_via_smtp(self, msg: EmailMessage) -> None:
+        cfg = self.smtp_config()
+        logger.debug(
+            "SMTP config: host=%s port=%s user=%s tls=%s",
+            cfg["host"],
+            cfg["port"],
+            cfg["user"],
+            cfg["use_tls"],
+        )
+        kwargs: dict = {
+            "hostname": cfg["host"],
+            "port": cfg["port"],
+        }
+        if cfg["use_tls"]:
+            kwargs["start_tls"] = True
+        if cfg["user"] and cfg["password"]:
+            kwargs["username"] = cfg["user"]
+            kwargs["password"] = cfg["password"]
+        await aiosmtplib.send(msg, **kwargs)
+        logger.info("Email sent via SMTP to %s", msg["To"])
+
+    async def send_via_sendmail(self, msg: EmailMessage) -> None:
+        sendmail = self.settings.sendmail_path or "sendmail"
+        logger.info("Using sendmail at: %s", sendmail)
+        resolved = shutil.which(sendmail)
+        logger.info("Resolved sendmail path: %s", resolved)
+        proc = await asyncio.create_subprocess_exec(
+            sendmail,
+            "-t",
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await proc.communicate(msg.as_bytes())
+        if proc.returncode != 0:
+            raise SendmailError(
+                f"sendmail ({sendmail}) exited with code {proc.returncode}: {stderr.decode()}"
+            )
+        logger.info("Email sent via sendmail to %s", msg["To"])
+
+    # --- templating ---
+
+    def reset_template_env(self) -> None:
+        """Drop the cached Jinja environment.
+
+        For tests that change KLANGK_EMAIL_TEMPLATES_DIR between cases,
+        since the environment is built once and cached.
+        """
+        self._env = None
+
+    def _brand_ctx(self) -> dict:
+        """Global branding variables surfaced to every email template.
+
+        Mirrors what /config exposes to the frontend (see api.get_config).
+        """
+        s = self.settings
+        return {
+            "product_name": self.product_name(),
+            "logo_url": s.logo_url or "",
+            "brand_color": s.brand_color or "#E65100",
+            # Configurable legal & support links (#1177). Plain env values,
+            # shown in the email footer to all recipients. Mirrors what
+            # /config exposes to the frontend; the base template renders
+            # whatever is set.
+            "terms_url": s.terms_url or "",
+            "privacy_url": s.privacy_url or "",
+            "aup_url": s.aup_url or "",
+            "support_url": s.support_url or "",
+            "support_email": s.support_email or "",
+        }
+
+    def _customize_dir(self) -> str:
+        """Return the root customization directory.
+
+        Resolves ``KLANGK_CUSTOMIZE_DIR`` (default ``~/.klangk/custom``).
+        """
+        return self.settings.customize_dir or str(
+            os.path.join(os.path.expanduser("~"), ".klangk", "custom")
+        )
+
+    def _template_env(self) -> Environment:
+        """Build (and cache) the Jinja environment.
+
+        Uses a ChoiceLoader: a deployer directory (KLANGK_EMAIL_TEMPLATES_DIR)
+        is tried first so it shadows the built-ins on a per-file basis; the
+        built-in package templates (email_templates/) are the fallback. Both
+        {% extends %} and {% include %} resolve through the same chain, so
+        overriding just base.html re-brands every email at once. See #1165.
+        """
+        if self._env is None:
+            loaders = []
+            user_dir = self.settings.email_templates_dir or ""
+            if not user_dir:
+                candidate = Path(self._customize_dir()) / "email-templates"
+                if candidate.is_dir():
+                    user_dir = str(candidate)
+            if user_dir:
+                path = Path(user_dir)
+                if path.is_dir():
+                    logger.info("Email templates loaded from %s", path)
+                    loaders.append(FileSystemLoader(str(path)))
+            loaders.append(PackageLoader("klangk_backend", "email_templates"))
+            self._env = Environment(
+                loader=ChoiceLoader(loaders),
+                # autoescape by extension: .html/.xml are escaped (closes the
+                # template-authoring XSS gap str.format leaves open); .txt is
+                # NOT (so <{{ link }}> stays literal). NOTE: a .html.j2 suffix
+                # would NOT match and silently disable escaping -- keep .html.
+                autoescape=select_autoescape(["html", "xml"]),
+                trim_blocks=True,
+                lstrip_blocks=True,
+                auto_reload=False,
+            )
+        return self._env
+
+    def render_email(
+        self,
+        event: str,
+        *,
+        link: str,
+        expiry_hours: int | float,
+        invited_by: str = "",
+    ) -> EmailRender:
+        """Render subject/text/html for an auth email event.
+
+        ``event`` is one of EMAIL_EVENTS (verify / reset / invite). ``link`` is
+        the per-email callback URL; ``expiry_hours`` is the real token TTL
+        (fixing the prior drift where bodies hardcoded "72 hours"/"1 hour"
+        regardless of config); ``invited_by`` is the inviter's email (invite
+        only). Branding globals come from _brand_ctx().
+
+        The subject receives only branding vars -- never the link/token -- so
+        tokens can't leak into mail-server subject logs.
+        """
+        if event not in EMAIL_EVENTS:
+            raise ValueError(f"unknown email event: {event!r}")
+        env = self._template_env()
+        ctx = {
+            **self._brand_ctx(),
+            "link": link,
+            "expiry_hours": int(expiry_hours),
+            "invited_by": invited_by,
+        }
+        subject = (
+            env.get_template(f"{event}/subject.txt").render(**ctx).strip()
+        )
+        text = env.get_template(f"{event}/body.txt").render(**ctx)
+        html = env.get_template(f"{event}/body.html").render(**ctx)
+        return EmailRender(subject=subject, text=text, html=html)
+
+    def build_multipart(self, to: str, rendered: EmailRender) -> EmailMessage:
+        """Assemble a multipart/alternative (text + HTML) message."""
+        cfg = self.smtp_config()
+        msg = EmailMessage()
+        msg["Subject"] = rendered.subject
+        msg["From"] = cfg["from_addr"] or cfg["user"] or "noreply@localhost"
+        msg["To"] = to
+        msg.set_content(rendered.text)
+        msg.add_alternative(rendered.html, subtype="html")
+        self._set_headers(msg)
+        return msg
+
+    async def _send(self, msg: EmailMessage) -> None:
+        """Deliver via SMTP (if configured) or local sendmail."""
+        if self.use_smtp():
+            await self.send_via_smtp(msg)
+        else:
+            await self.send_via_sendmail(msg)
+
+    async def send_verification_email(
+        self, to: str, verification_url: str
+    ) -> None:
+        """Send a verification email with the given callback URL."""
+        rendered = self.render_email(
+            "verify",
+            link=verification_url,
+            expiry_hours=auth.VERIFY_TOKEN_EXPIRE_HOURS,
+        )
+        await self._send(self.build_multipart(to, rendered))
+        logger.info("Verification email sent to %s", to)
+
+    async def send_password_reset_email(self, to: str, reset_url: str) -> None:
+        """Send a password reset email with the given callback URL."""
+        rendered = self.render_email(
+            "reset",
+            link=reset_url,
+            expiry_hours=auth.RESET_TOKEN_EXPIRE_HOURS,
+        )
+        await self._send(self.build_multipart(to, rendered))
+        logger.info("Password reset email sent to %s", to)
+
+    async def send_invitation_email(
+        self, to: str, invite_url: str, invited_by_email: str
+    ) -> None:
+        """Send an invitation email with the given registration URL."""
+        rendered = self.render_email(
+            "invite",
+            link=invite_url,
+            expiry_hours=auth.INVITE_TOKEN_EXPIRE_HOURS,
+            invited_by=invited_by_email,
+        )
+        await self._send(self.build_multipart(to, rendered))
+        logger.info(
+            "Invitation email sent to %s (invited by %s)", to, invited_by_email
+        )

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -20,6 +20,7 @@ from . import (
     agent,
     auth,
     container,
+    emailsvc,
     model,
     nginx as nginx_mod,
     oidc,
@@ -787,6 +788,10 @@ def build_app(settings: KlangkSettings) -> FastAPI:
     # (previously module globals _agents/_agents_lock/get_workspace_session).
     app.state.agents = agent.Agents(app.state)
     app.state.agents.get_workspace_session = sockets.get_session
+    # #1483: EmailService(app_state) owns SMTP/sendmail transport + the
+    # Jinja template env (previously module-level functions reading
+    # resolve_env_value at call time).
+    app.state.email = emailsvc.EmailService(app.state)
 
     app.add_middleware(
         CORSMiddleware,

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -198,6 +198,7 @@ def app_state(temp_data_dir):
 
     from klangk_backend.settings import KlangkSettings
     from klangk_backend.container import ContainerRegistry
+    from klangk_backend.emailsvc import EmailService
     from klangk_backend.workspaces import Workspaces
 
     settings = KlangkSettings(os.environ)
@@ -206,6 +207,7 @@ def app_state(temp_data_dir):
     state.container_registry = registry
     registry.app_state = state
     state.workspaces = Workspaces(state)
+    state.email = EmailService(state)
     return state
 
 

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -21,6 +21,7 @@ from klangk_backend import (
     workspaces as ws_mod,
 )
 from klangk_backend.container import ContainerRegistry
+from klangk_backend import emailsvc as emailsvc_mod
 from klangk_backend import oidc as oidc_mod
 from klangk_backend import plugins as plugins_mod
 from klangk_backend.settings import KlangkSettings
@@ -60,6 +61,7 @@ async def app(db, temp_data_dir):
     app.state.workspaces = ws_mod.Workspaces(app.state)
     app.state.agents = agent.Agents(app.state)
     app.state.agents.get_workspace_session = sockets.get_session
+    app.state.email = emailsvc_mod.EmailService(app.state)
 
     app.include_router(api.root_router)
     app.include_router(api.router, prefix=API_PREFIX)
@@ -491,7 +493,7 @@ class TestAuthRoutes:
         )
         token = login_resp.json()["access_token"]
         with patch.object(
-            api.emailsvc,
+            emailsvc_mod.EmailService,
             "send_verification_email",
             new_callable=AsyncMock,
         ):
@@ -513,7 +515,7 @@ class TestAuthRoutes:
         ``ensure_home_symlink`` failed on first workspace connect.
         """
         with patch.object(
-            api.emailsvc,
+            emailsvc_mod.EmailService,
             "send_verification_email",
             new_callable=AsyncMock,
         ):
@@ -542,7 +544,7 @@ class TestAuthRoutes:
     async def test_register_unauthenticated(self, client, db):
         """Registration is open — no auth required (verification gates access)."""
         with patch.object(
-            api.emailsvc,
+            emailsvc_mod.EmailService,
             "send_verification_email",
             new_callable=AsyncMock,
         ):
@@ -556,7 +558,7 @@ class TestAuthRoutes:
     async def test_register_email_send_failure_rolls_back(self, client, db):
         """If verification email fails, user creation is rolled back."""
         with patch.object(
-            api.emailsvc,
+            emailsvc_mod.EmailService,
             "send_verification_email",
             new_callable=AsyncMock,
             side_effect=RuntimeError("sendmail not found"),
@@ -844,7 +846,7 @@ class TestResendVerification:
     async def test_resend_success(self, client, db):
         await self._create_unverified_user()
         with patch.object(
-            api.emailsvc,
+            emailsvc_mod.EmailService,
             "send_verification_email",
             new_callable=AsyncMock,
         ) as mock_send:
@@ -908,7 +910,7 @@ class TestResendVerification:
         api.resend_timestamps.pop("unverified@example.com", None)
         await self._create_unverified_user()
         with patch.object(
-            api.emailsvc,
+            emailsvc_mod.EmailService,
             "send_verification_email",
             new_callable=AsyncMock,
         ):
@@ -935,7 +937,9 @@ class TestResendVerification:
         api.resend_timestamps.clear()
         await self._create_unverified_user()
         with patch.object(
-            api.emailsvc, "send_verification_email", new_callable=AsyncMock
+            emailsvc_mod.EmailService,
+            "send_verification_email",
+            new_callable=AsyncMock,
         ):
             resp1 = await client.post(
                 "/api/v1/auth/resend-verification",
@@ -979,7 +983,7 @@ class TestForgotPassword:
     async def test_forgot_sends_email(self, client, db):
         await self._create_user()
         with patch.object(
-            api.emailsvc,
+            emailsvc_mod.EmailService,
             "send_password_reset_email",
             new_callable=AsyncMock,
         ) as mock_send:
@@ -1003,7 +1007,7 @@ class TestForgotPassword:
     async def test_forgot_rate_limited(self, client, db):
         await self._create_user()
         with patch.object(
-            api.emailsvc,
+            emailsvc_mod.EmailService,
             "send_password_reset_email",
             new_callable=AsyncMock,
         ):
@@ -1022,7 +1026,9 @@ class TestForgotPassword:
         api.reset_timestamps.clear()
         await self._create_user()
         with patch.object(
-            api.emailsvc, "send_password_reset_email", new_callable=AsyncMock
+            emailsvc_mod.EmailService,
+            "send_password_reset_email",
+            new_callable=AsyncMock,
         ):
             resp1 = await client.post(
                 "/api/v1/auth/forgot-password",
@@ -1181,7 +1187,7 @@ class TestChangeEmail:
     async def test_change_email_success(self, client, user):
         headers = await _auth_headers(client)
         with patch.object(
-            api.emailsvc,
+            emailsvc_mod.EmailService,
             "send_verification_email",
             new_callable=AsyncMock,
         ) as mock_send:
@@ -4920,8 +4926,11 @@ class TestAdminEndpoints:
         self, client, app, admin_user
     ):
         headers = await self._admin_headers(client)
-        with patch("klangk_backend.api.admin.emailsvc") as mock_email:
-            mock_email.send_verification_email = AsyncMock()
+        with patch.object(
+            emailsvc_mod.EmailService,
+            "send_verification_email",
+            new_callable=AsyncMock,
+        ) as mock_email:
             resp = await client.post(
                 "/api/v1/admin/users",
                 headers=headers,
@@ -4934,7 +4943,7 @@ class TestAdminEndpoints:
         data = resp.json()
         assert data["email"] == "verify@example.com"
         assert data["status"] == "pending_verification"
-        mock_email.send_verification_email.assert_called_once()
+        mock_email.assert_called_once()
         # User should exist but not be verified, with a derived handle
         # (regression: #1256 — this branch used to INSERT without a handle).
         user = await model.get_user_by_email("verify@example.com")
@@ -7177,7 +7186,7 @@ class TestInvitations:
     async def test_send_invitation(self, client, admin_user):
         headers = await self._admin_headers(client)
         with patch.object(
-            api.emailsvc,
+            emailsvc_mod.EmailService,
             "send_invitation_email",
             new_callable=AsyncMock,
         ) as mock_send:
@@ -7221,7 +7230,7 @@ class TestInvitations:
     async def test_send_invitation_duplicate_pending(self, client, admin_user):
         headers = await self._admin_headers(client)
         with patch.object(
-            api.emailsvc,
+            emailsvc_mod.EmailService,
             "send_invitation_email",
             new_callable=AsyncMock,
         ):
@@ -7265,7 +7274,7 @@ class TestInvitations:
     async def test_list_invitations(self, client, admin_user):
         headers = await self._admin_headers(client)
         with patch.object(
-            api.emailsvc,
+            emailsvc_mod.EmailService,
             "send_invitation_email",
             new_callable=AsyncMock,
         ):
@@ -7300,7 +7309,7 @@ class TestInvitations:
     ):
         headers = await self._admin_headers(client)
         with patch.object(
-            api.emailsvc,
+            emailsvc_mod.EmailService,
             "send_invitation_email",
             new_callable=AsyncMock,
         ):
@@ -7323,7 +7332,7 @@ class TestInvitations:
     ):
         headers = await self._admin_headers(client)
         with patch.object(
-            api.emailsvc,
+            emailsvc_mod.EmailService,
             "send_invitation_email",
             new_callable=AsyncMock,
         ):
@@ -7357,7 +7366,7 @@ class TestInvitations:
     async def test_list_invitations_sort_by_email(self, client, admin_user):
         headers = await self._admin_headers(client)
         with patch.object(
-            api.emailsvc,
+            emailsvc_mod.EmailService,
             "send_invitation_email",
             new_callable=AsyncMock,
         ):
@@ -7416,7 +7425,7 @@ class TestInvitations:
     ):
         headers = await self._admin_headers(client)
         with patch.object(
-            api.emailsvc,
+            emailsvc_mod.EmailService,
             "send_invitation_email",
             new_callable=AsyncMock,
         ):
@@ -7445,7 +7454,7 @@ class TestInvitations:
     async def test_list_invitations_filter_by_email(self, client, admin_user):
         headers = await self._admin_headers(client)
         with patch.object(
-            api.emailsvc,
+            emailsvc_mod.EmailService,
             "send_invitation_email",
             new_callable=AsyncMock,
         ):
@@ -7485,7 +7494,7 @@ class TestInvitations:
     async def test_revoke_invitation(self, client, admin_user):
         headers = await self._admin_headers(client)
         with patch.object(
-            api.emailsvc,
+            emailsvc_mod.EmailService,
             "send_invitation_email",
             new_callable=AsyncMock,
         ):
@@ -7517,7 +7526,7 @@ class TestInvitations:
     async def test_resend_invitation(self, client, admin_user):
         headers = await self._admin_headers(client)
         with patch.object(
-            api.emailsvc,
+            emailsvc_mod.EmailService,
             "send_invitation_email",
             new_callable=AsyncMock,
         ):
@@ -7528,7 +7537,7 @@ class TestInvitations:
             )
         inv_id = create_resp.json()["id"]
         with patch.object(
-            api.emailsvc,
+            emailsvc_mod.EmailService,
             "send_invitation_email",
             new_callable=AsyncMock,
         ) as mock_resend:
@@ -7549,7 +7558,7 @@ class TestInvitations:
     async def test_resend_revoked(self, client, admin_user):
         headers = await self._admin_headers(client)
         with patch.object(
-            api.emailsvc,
+            emailsvc_mod.EmailService,
             "send_invitation_email",
             new_callable=AsyncMock,
         ):
@@ -7570,7 +7579,7 @@ class TestInvitations:
     async def test_accept_invite(self, client, admin_user):
         headers = await self._admin_headers(client)
         with patch.object(
-            api.emailsvc,
+            emailsvc_mod.EmailService,
             "send_invitation_email",
             new_callable=AsyncMock,
         ):
@@ -7609,7 +7618,7 @@ class TestInvitations:
     async def test_accept_invite_already_accepted(self, client, admin_user):
         headers = await self._admin_headers(client)
         with patch.object(
-            api.emailsvc,
+            emailsvc_mod.EmailService,
             "send_invitation_email",
             new_callable=AsyncMock,
         ):
@@ -7637,7 +7646,7 @@ class TestInvitations:
     async def test_accept_invite_short_password(self, client, admin_user):
         headers = await self._admin_headers(client)
         with patch.object(
-            api.emailsvc,
+            emailsvc_mod.EmailService,
             "send_invitation_email",
             new_callable=AsyncMock,
         ):
@@ -7661,7 +7670,7 @@ class TestInvitations:
     ):
         headers = await self._admin_headers(client)
         with patch.object(
-            api.emailsvc,
+            emailsvc_mod.EmailService,
             "send_invitation_email",
             new_callable=AsyncMock,
         ):
@@ -7689,7 +7698,7 @@ class TestInvitations:
     ):
         headers = await self._admin_headers(client)
         with patch.object(
-            api.emailsvc,
+            emailsvc_mod.EmailService,
             "send_invitation_email",
             new_callable=AsyncMock,
         ):

--- a/src/backend/tests/test_emailsvc.py
+++ b/src/backend/tests/test_emailsvc.py
@@ -1,53 +1,64 @@
-"""Tests for emailsvc: SMTP and sendmail sending."""
+"""Tests for EmailService: SMTP and sendmail sending (#1483)."""
 
+import types
 from email.message import EmailMessage
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from klangk_backend import emailsvc
+from klangk_backend.emailsvc import EmailService
 from klangk_backend.exceptions import SendmailError
+from klangk_backend.settings import KlangkSettings
 
 
-# The Jinja environment is built once and cached at module level, so a
+def _email_service(env: dict) -> EmailService:
+    """Build an EmailService from explicit env (never touches the process env)."""
+    settings = KlangkSettings(env=env)
+    app_state = types.SimpleNamespace(settings=settings)
+    return EmailService(app_state)
+
+
+# The Jinja environment is built once and cached per instance, so a
 # KLANGK_EMAIL_TEMPLATES_DIR set in one test would leak into the next.
-# Rebuild it fresh for every case (env-var state itself is handled by
-# monkeypatch). See #1165.
+# Rebuild the service fresh for every case (env-var state itself is
+# handled by rebuilding with a new env dict). See #1165.
 @pytest.fixture(autouse=True)
-def _reset_email_template_env():
-    emailsvc.reset_template_env()
+def _fresh_email_service():
+    # Each test builds its own EmailService via _email_service(); this
+    # fixture exists purely as an explicit per-test isolation marker.
     yield
-    emailsvc.reset_template_env()
 
 
 class TestResolvePassword:
-    def test_plain_password(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_SMTP_PASSWORD", "secret123")
-        assert emailsvc.resolve_password() == "secret123"
+    def test_plain_password(self):
+        svc = _email_service({"KLANGK_SMTP_PASSWORD": "secret123"})
+        assert svc.resolve_password() == "secret123"
 
-    def test_file_prefix_reads_file(self, monkeypatch, tmp_path):
+    def test_file_prefix_reads_file(self, tmp_path):
         pw_file = tmp_path / "smtp_pass"
         pw_file.write_text("file-secret\n")
-        monkeypatch.setenv("KLANGK_SMTP_PASSWORD", f"file:{pw_file}")
-        assert emailsvc.resolve_password() == "file-secret"
+        svc = _email_service({"KLANGK_SMTP_PASSWORD": f"file:{pw_file}"})
+        assert svc.resolve_password() == "file-secret"
 
-    def test_file_missing_returns_none(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_SMTP_PASSWORD", "file:/nonexistent/file")
-        assert emailsvc.resolve_password() is None
+    def test_file_missing_returns_none(self):
+        svc = _email_service(
+            {"KLANGK_SMTP_PASSWORD": "file:/nonexistent/file"}
+        )
+        assert svc.resolve_password() is None
 
-    def test_no_password(self, monkeypatch):
-        monkeypatch.delenv("KLANGK_SMTP_PASSWORD", raising=False)
-        assert emailsvc.resolve_password() is None
+    def test_no_password(self):
+        svc = _email_service({})
+        assert svc.resolve_password() is None
 
 
 class TestUseSmtp:
-    def test_uses_smtp_when_host_set(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_SMTP_HOST", "mail.example.com")
-        assert emailsvc.use_smtp() is True
+    def test_uses_smtp_when_host_set(self):
+        svc = _email_service({"KLANGK_SMTP_HOST": "mail.example.com"})
+        assert svc.use_smtp() is True
 
-    def test_uses_sendmail_when_no_host(self, monkeypatch):
-        monkeypatch.delenv("KLANGK_SMTP_HOST", raising=False)
-        assert emailsvc.use_smtp() is False
+    def test_uses_sendmail_when_no_host(self):
+        svc = _email_service({})
+        assert svc.use_smtp() is False
 
 
 def _plain_msg(to="to@example.com", subject="Hi", body="Body"):
@@ -61,16 +72,21 @@ def _plain_msg(to="to@example.com", subject="Hi", body="Body"):
 
 
 class TestSendViaSmtp:
-    async def test_calls_aiosmtplib_send(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_SMTP_HOST", "smtp.example.com")
-        monkeypatch.setenv("KLANGK_SMTP_PORT", "587")
-        monkeypatch.setenv("KLANGK_SMTP_USER", "user")
-        monkeypatch.setenv("KLANGK_SMTP_PASSWORD", "pass")
-        monkeypatch.setenv("KLANGK_SMTP_USE_TLS", "true")
+    async def test_calls_aiosmtplib_send(self):
+        svc = _email_service(
+            {
+                "KLANGK_SMTP_HOST": "smtp.example.com",
+                "KLANGK_SMTP_PORT": "587",
+                "KLANGK_SMTP_USER": "user",
+                "KLANGK_SMTP_PASSWORD": "pass",
+                "KLANGK_SMTP_USE_TLS": "true",
+            }
+        )
+        import klangk_backend.emailsvc as emailsvc_mod
 
         mock_send = AsyncMock()
-        with patch.object(emailsvc.aiosmtplib, "send", mock_send):
-            await emailsvc.send_via_smtp(_plain_msg())
+        with patch.object(emailsvc_mod.aiosmtplib, "send", mock_send):
+            await svc.send_via_smtp(_plain_msg())
 
         mock_send.assert_awaited_once()
         kwargs = mock_send.call_args[1]
@@ -80,16 +96,19 @@ class TestSendViaSmtp:
         assert kwargs["password"] == "pass"
         assert kwargs["start_tls"] is True
 
-    async def test_no_auth_when_no_credentials(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_SMTP_HOST", "smtp.example.com")
-        monkeypatch.setenv("KLANGK_SMTP_PORT", "25")
-        monkeypatch.delenv("KLANGK_SMTP_USER", raising=False)
-        monkeypatch.delenv("KLANGK_SMTP_PASSWORD", raising=False)
-        monkeypatch.setenv("KLANGK_SMTP_USE_TLS", "false")
-
+    async def test_no_auth_when_no_credentials(self):
+        svc = _email_service(
+            {
+                "KLANGK_SMTP_HOST": "smtp.example.com",
+                "KLANGK_SMTP_PORT": "25",
+                "KLANGK_SMTP_USE_TLS": "false",
+            }
+        )
         mock_send = AsyncMock()
-        with patch.object(emailsvc.aiosmtplib, "send", mock_send):
-            await emailsvc.send_via_smtp(_plain_msg())
+        import klangk_backend.emailsvc as emailsvc_mod
+
+        with patch.object(emailsvc_mod.aiosmtplib, "send", mock_send):
+            await svc.send_via_smtp(_plain_msg())
 
         kwargs = mock_send.call_args[1]
         assert "username" not in kwargs
@@ -99,6 +118,7 @@ class TestSendViaSmtp:
 
 class TestSendViaSendmail:
     async def test_calls_sendmail_subprocess(self):
+        svc = _email_service({})
         mock_proc = AsyncMock()
         mock_proc.communicate.return_value = (b"", b"")
         mock_proc.returncode = 0
@@ -106,14 +126,14 @@ class TestSendViaSendmail:
         with patch(
             "asyncio.create_subprocess_exec", return_value=mock_proc
         ) as mock_exec:
-            await emailsvc.send_via_sendmail(_plain_msg())
+            await svc.send_via_sendmail(_plain_msg())
 
         mock_exec.assert_awaited_once()
         assert mock_exec.call_args[0][0] == "sendmail"
 
-    async def test_custom_sendmail_path(self, monkeypatch):
-        monkeypatch.setenv(
-            "KLANGK_SENDMAIL_PATH", "/run/current-system/sw/bin/sendmail"
+    async def test_custom_sendmail_path(self):
+        svc = _email_service(
+            {"KLANGK_SENDMAIL_PATH": "/run/current-system/sw/bin/sendmail"}
         )
         mock_proc = AsyncMock()
         mock_proc.communicate.return_value = (b"", b"")
@@ -122,28 +142,29 @@ class TestSendViaSendmail:
         with patch(
             "asyncio.create_subprocess_exec", return_value=mock_proc
         ) as mock_exec:
-            await emailsvc.send_via_sendmail(_plain_msg())
+            await svc.send_via_sendmail(_plain_msg())
 
         assert (
             mock_exec.call_args[0][0] == "/run/current-system/sw/bin/sendmail"
         )
 
     async def test_raises_on_sendmail_failure(self):
+        svc = _email_service({})
         mock_proc = AsyncMock()
         mock_proc.communicate.return_value = (b"", b"sendmail error")
         mock_proc.returncode = 1
 
         with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
             with pytest.raises(SendmailError, match="exited with code 1"):
-                await emailsvc.send_via_sendmail(_plain_msg())
+                await svc.send_via_sendmail(_plain_msg())
 
 
 class TestSendVerificationEmail:
-    async def test_sends_verification_email(self, monkeypatch):
-        monkeypatch.delenv("KLANGK_SMTP_HOST", raising=False)
+    async def test_sends_verification_email(self):
+        svc = _email_service({})
         mock_sendmail = AsyncMock()
-        with patch.object(emailsvc, "send_via_sendmail", mock_sendmail):
-            await emailsvc.send_verification_email(
+        with patch.object(svc, "send_via_sendmail", mock_sendmail):
+            await svc.send_verification_email(
                 "user@example.com",
                 "https://klangk.example.com/#/verify?token=abc123",
             )
@@ -165,24 +186,27 @@ class TestSendVerificationEmail:
         assert "Verify my account" in html_part
         assert "Klangk" in html_part
 
-    async def test_sends_via_smtp_when_configured(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_SMTP_HOST", "smtp.example.com")
-        monkeypatch.setenv("KLANGK_SMTP_USER", "user")
-        monkeypatch.setenv("KLANGK_SMTP_PASSWORD", "pass")
+    async def test_sends_via_smtp_when_configured(self):
+        svc = _email_service(
+            {
+                "KLANGK_SMTP_HOST": "smtp.example.com",
+                "KLANGK_SMTP_USER": "user",
+                "KLANGK_SMTP_PASSWORD": "pass",
+            }
+        )
         mock_smtp = AsyncMock()
-        with patch.object(emailsvc, "send_via_smtp", mock_smtp):
-            await emailsvc.send_verification_email(
+        with patch.object(svc, "send_via_smtp", mock_smtp):
+            await svc.send_verification_email(
                 "user@example.com",
                 "https://klangk.example.com/#/verify?token=abc",
             )
         mock_smtp.assert_awaited_once()
 
-    async def test_uses_configured_product_name(self, monkeypatch):
-        monkeypatch.delenv("KLANGK_SMTP_HOST", raising=False)
-        monkeypatch.setenv("KLANGK_PRODUCT_NAME", "Acme Labs")
+    async def test_uses_configured_product_name(self):
+        svc = _email_service({"KLANGK_PRODUCT_NAME": "Acme Labs"})
         mock_sendmail = AsyncMock()
-        with patch.object(emailsvc, "send_via_sendmail", mock_sendmail):
-            await emailsvc.send_verification_email(
+        with patch.object(svc, "send_via_sendmail", mock_sendmail):
+            await svc.send_verification_email(
                 "user@example.com",
                 "https://klangk.example.com/#/verify?token=abc",
             )
@@ -196,11 +220,11 @@ class TestSendVerificationEmail:
 
 
 class TestSendPasswordResetEmail:
-    async def test_sends_reset_email(self, monkeypatch):
-        monkeypatch.delenv("KLANGK_SMTP_HOST", raising=False)
+    async def test_sends_reset_email(self):
+        svc = _email_service({})
         mock_sendmail = AsyncMock()
-        with patch.object(emailsvc, "send_via_sendmail", mock_sendmail):
-            await emailsvc.send_password_reset_email(
+        with patch.object(svc, "send_via_sendmail", mock_sendmail):
+            await svc.send_password_reset_email(
                 "user@example.com",
                 "https://klangk.example.com/#/reset-password?token=xyz",
             )
@@ -217,13 +241,17 @@ class TestSendPasswordResetEmail:
         assert 'href="https://klangk.example.com/#/reset-password' in html_part
         assert "Reset my password" in html_part
 
-    async def test_sends_via_smtp_when_configured(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_SMTP_HOST", "smtp.example.com")
-        monkeypatch.setenv("KLANGK_SMTP_USER", "user")
-        monkeypatch.setenv("KLANGK_SMTP_PASSWORD", "pass")
+    async def test_sends_via_smtp_when_configured(self):
+        svc = _email_service(
+            {
+                "KLANGK_SMTP_HOST": "smtp.example.com",
+                "KLANGK_SMTP_USER": "user",
+                "KLANGK_SMTP_PASSWORD": "pass",
+            }
+        )
         mock_smtp = AsyncMock()
-        with patch.object(emailsvc, "send_via_smtp", mock_smtp):
-            await emailsvc.send_password_reset_email(
+        with patch.object(svc, "send_via_smtp", mock_smtp):
+            await svc.send_password_reset_email(
                 "user@example.com",
                 "https://klangk.example.com/#/reset-password?token=xyz",
             )
@@ -231,11 +259,11 @@ class TestSendPasswordResetEmail:
 
 
 class TestSendInvitationEmail:
-    async def test_sends_invitation_email(self, monkeypatch):
-        monkeypatch.delenv("KLANGK_SMTP_HOST", raising=False)
+    async def test_sends_invitation_email(self):
+        svc = _email_service({})
         mock_sendmail = AsyncMock()
-        with patch.object(emailsvc, "send_via_sendmail", mock_sendmail):
-            await emailsvc.send_invitation_email(
+        with patch.object(svc, "send_via_sendmail", mock_sendmail):
+            await svc.send_invitation_email(
                 "invited@example.com",
                 "https://klangk.example.com/#/accept-invite?token=abc123",
                 "admin@example.com",
@@ -255,28 +283,32 @@ class TestSendInvitationEmail:
         assert "admin@example.com" in html_part
         assert "Accept invitation" in html_part
 
-    async def test_sends_via_smtp_when_configured(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_SMTP_HOST", "smtp.example.com")
-        monkeypatch.setenv("KLANGK_SMTP_USER", "user")
-        monkeypatch.setenv("KLANGK_SMTP_PASSWORD", "pass")
+    async def test_sends_via_smtp_when_configured(self):
+        svc = _email_service(
+            {
+                "KLANGK_SMTP_HOST": "smtp.example.com",
+                "KLANGK_SMTP_USER": "user",
+                "KLANGK_SMTP_PASSWORD": "pass",
+            }
+        )
         mock_smtp = AsyncMock()
-        with patch.object(emailsvc, "send_via_smtp", mock_smtp):
-            await emailsvc.send_invitation_email(
+        with patch.object(svc, "send_via_smtp", mock_smtp):
+            await svc.send_invitation_email(
                 "invited@example.com",
                 "https://klangk.example.com/#/accept-invite?token=abc",
                 "admin@example.com",
             )
         mock_smtp.assert_awaited_once()
 
-    async def test_invited_by_email_html_escaped(self, monkeypatch):
+    async def test_invited_by_email_html_escaped(self):
         # A crafted inviter email with HTML/marker characters must be
         # escaped in the HTML body so it cannot inject markup or script.
         # See https://github.com/mcdonc/klangk/issues/878
-        monkeypatch.delenv("KLANGK_SMTP_HOST", raising=False)
+        svc = _email_service({})
         mock_sendmail = AsyncMock()
         crafted = 'admin"><img/src=x onerror=alert(1)>@example.com'
-        with patch.object(emailsvc, "send_via_sendmail", mock_sendmail):
-            await emailsvc.send_invitation_email(
+        with patch.object(svc, "send_via_sendmail", mock_sendmail):
+            await svc.send_invitation_email(
                 "invited@example.com",
                 "https://klangk.example.com/#/accept-invite?token=abc",
                 crafted,
@@ -300,106 +332,105 @@ class TestSendInvitationEmail:
 
 class TestRenderEmail:
     def test_verify_event_renders_all_three_parts(self):
-        r = emailsvc.render_email(
-            "verify", link="https://x/v?t=1", expiry_hours=72
-        )
+        svc = _email_service({})
+        r = svc.render_email("verify", link="https://x/v?t=1", expiry_hours=72)
         assert r.subject == "Verify your Klangk account"
         assert "https://x/v?t=1" in r.text
         assert "expires in 72 hours" in r.text
         assert 'href="https://x/v?t=1"' in r.html
 
     def test_unknown_event_raises(self):
+        svc = _email_service({})
         # Guards against a typo in a caller wiring up a new event.
         with pytest.raises(ValueError, match="unknown email event"):
-            emailsvc.render_email("bogus", link="https://x", expiry_hours=1)
+            svc.render_email("bogus", link="https://x", expiry_hours=1)
 
     def test_expiry_hours_interpolated_not_hardcoded(self):
         # Proves the drift fix (#1165): a non-default TTL is reflected
         # in BOTH text and html, instead of the old hardcoded "72 hours".
-        r = emailsvc.render_email("verify", link="https://x", expiry_hours=48)
+        svc = _email_service({})
+        r = svc.render_email("verify", link="https://x", expiry_hours=48)
         assert "expires in 48 hours" in r.text
         assert "expires in 48 hours" in r.html
 
     def test_singular_hour_when_expiry_is_one(self):
-        r = emailsvc.render_email("reset", link="https://x", expiry_hours=1)
+        svc = _email_service({})
+        r = svc.render_email("reset", link="https://x", expiry_hours=1)
         assert "expires in 1 hour." in r.text
         assert "1 hours" not in r.text
 
-    def test_brand_color_in_badge(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_BRAND_COLOR", "#abcdef")
-        r = emailsvc.render_email("verify", link="https://x", expiry_hours=72)
+    def test_brand_color_in_badge(self):
+        svc = _email_service({"KLANGK_BRAND_COLOR": "#abcdef"})
+        r = svc.render_email("verify", link="https://x", expiry_hours=72)
         assert "#abcdef" in r.html
 
-    def test_logo_url_replaces_badge(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_LOGO_URL", "https://logo/test.png")
-        r = emailsvc.render_email("verify", link="https://x", expiry_hours=72)
+    def test_logo_url_replaces_badge(self):
+        svc = _email_service({"KLANGK_LOGO_URL": "https://logo/test.png"})
+        r = svc.render_email("verify", link="https://x", expiry_hours=72)
         assert '<img src="https://logo/test.png"' in r.html
         # The paw badge is hidden when a logo override is set.
         assert "&#128062;" not in r.html
 
-    def test_product_name_flows_through(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_PRODUCT_NAME", "Acme Labs")
-        r = emailsvc.render_email("verify", link="https://x", expiry_hours=72)
+    def test_product_name_flows_through(self):
+        svc = _email_service({"KLANGK_PRODUCT_NAME": "Acme Labs"})
+        r = svc.render_email("verify", link="https://x", expiry_hours=72)
         assert r.subject == "Verify your Acme Labs account"
         assert "Acme Labs" in r.html
         assert "Klangk" not in r.html
 
-    def test_legal_links_in_footer_when_set(self, monkeypatch):
+    def test_legal_links_in_footer_when_set(self):
         # The legal footer renders only the configured links, joined.
-        monkeypatch.setenv("KLANGK_TERMS_URL", "https://corp/t")
-        monkeypatch.setenv("KLANGK_PRIVACY_URL", "https://corp/p")
-        monkeypatch.setenv("KLANGK_AUP_URL", "https://corp/a")
-        r = emailsvc.render_email("verify", link="https://x", expiry_hours=72)
+        svc = _email_service(
+            {
+                "KLANGK_TERMS_URL": "https://corp/t",
+                "KLANGK_PRIVACY_URL": "https://corp/p",
+                "KLANGK_AUP_URL": "https://corp/a",
+            }
+        )
+        r = svc.render_email("verify", link="https://x", expiry_hours=72)
         assert 'href="https://corp/t">Terms' in r.html
         assert 'href="https://corp/p">Privacy' in r.html
         assert 'href="https://corp/a">Acceptable Use' in r.html
         # Joined by a middot separator, not run together.
         assert "Terms</a> &middot; <a" in r.html
 
-    def test_support_link_and_email_in_footer(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_SUPPORT_URL", "https://help")
-        monkeypatch.setenv("KLANGK_SUPPORT_EMAIL", "help@corp")
-        r = emailsvc.render_email("verify", link="https://x", expiry_hours=72)
+    def test_support_link_and_email_in_footer(self):
+        svc = _email_service(
+            {
+                "KLANGK_SUPPORT_URL": "https://help",
+                "KLANGK_SUPPORT_EMAIL": "help@corp",
+            }
+        )
+        r = svc.render_email("verify", link="https://x", expiry_hours=72)
         assert 'href="https://help">Support' in r.html
         assert 'href="mailto:help@corp">help@corp' in r.html
 
-    def test_no_legal_footer_when_none_set(self, monkeypatch):
+    def test_no_legal_footer_when_none_set(self):
         # When no legal/support vars are set, the footer block is hidden.
-        for k in (
-            "KLANGK_TERMS_URL",
-            "KLANGK_PRIVACY_URL",
-            "KLANGK_AUP_URL",
-            "KLANGK_SUPPORT_URL",
-            "KLANGK_SUPPORT_EMAIL",
-        ):
-            monkeypatch.delenv(k, raising=False)
-        r = emailsvc.render_email("verify", link="https://x", expiry_hours=72)
+        svc = _email_service({})
+        r = svc.render_email("verify", link="https://x", expiry_hours=72)
         assert ">Terms<" not in r.html
         assert ">Privacy<" not in r.html
         assert "mailto:" not in r.html
 
 
 class TestTemplateOverlay:
-    def test_user_dir_shadows_builtin_per_file(self, tmp_path, monkeypatch):
+    def test_user_dir_shadows_builtin_per_file(self, tmp_path):
         # A deployer dir with only an overriding subject shadows that one
         # file; everything else falls through to the built-ins.
         d = tmp_path / "templates"
         (d / "verify").mkdir(parents=True)
         (d / "verify" / "subject.txt").write_text("CUSTOM VERIFY SUBJECT\n")
-        monkeypatch.setenv("KLANGK_EMAIL_TEMPLATES_DIR", str(d))
-        r = emailsvc.render_email(
-            "verify", link="https://x/v?t=1", expiry_hours=72
-        )
+        svc = _email_service({"KLANGK_EMAIL_TEMPLATES_DIR": str(d)})
+        r = svc.render_email("verify", link="https://x/v?t=1", expiry_hours=72)
         assert r.subject == "CUSTOM VERIFY SUBJECT"
         # The body was NOT overridden -> built-in still used.
         assert "verify your email address" in r.text
         # A different event (not overridden) keeps its built-in subject.
-        rr = emailsvc.render_email(
-            "reset", link="https://x/r?t=1", expiry_hours=1
-        )
+        rr = svc.render_email("reset", link="https://x/r?t=1", expiry_hours=1)
         assert rr.subject == "Reset your Klangk password"
 
-    def test_overriding_base_rebrands_all_events(self, tmp_path, monkeypatch):
+    def test_overriding_base_rebrands_all_events(self, tmp_path):
         # Editing base.html alone re-brands every email, because each
         # child does {% extends "base.html" %} and the ChoiceLoader
         # resolves the override first.
@@ -409,39 +440,37 @@ class TestTemplateOverlay:
             "<div>BRANDED {{ product_name }}</div>"
             "{% block content %}{% endblock %}"
         )
-        monkeypatch.setenv("KLANGK_EMAIL_TEMPLATES_DIR", str(d))
-        rv = emailsvc.render_email("verify", link="https://x", expiry_hours=72)
-        ri = emailsvc.render_email(
+        svc = _email_service({"KLANGK_EMAIL_TEMPLATES_DIR": str(d)})
+        rv = svc.render_email("verify", link="https://x", expiry_hours=72)
+        ri = svc.render_email(
             "invite", link="https://x", expiry_hours=72, invited_by="a@b.com"
         )
         assert "BRANDED Klangk" in rv.html
         assert "BRANDED Klangk" in ri.html
 
-    def test_nonexistent_user_dir_is_ignored(self, tmp_path, monkeypatch):
+    def test_nonexistent_user_dir_is_ignored(self, tmp_path):
         # A bad path doesn't crash; built-ins are used.
-        monkeypatch.setenv(
-            "KLANGK_EMAIL_TEMPLATES_DIR", str(tmp_path / "does-not-exist")
+        svc = _email_service(
+            {"KLANGK_EMAIL_TEMPLATES_DIR": str(tmp_path / "does-not-exist")}
         )
-        r = emailsvc.render_email("verify", link="https://x", expiry_hours=72)
+        r = svc.render_email("verify", link="https://x", expiry_hours=72)
         assert r.subject == "Verify your Klangk account"
 
-    def test_customize_dir_email_templates_fallback(
-        self, tmp_path, monkeypatch
-    ):
+    def test_customize_dir_email_templates_fallback(self, tmp_path):
         # When KLANGK_EMAIL_TEMPLATES_DIR is unset but
         # <customize_dir>/email-templates exists, it is used.  See #1360.
-        monkeypatch.delenv("KLANGK_EMAIL_TEMPLATES_DIR", raising=False)
         custom = tmp_path / "cust"
         tdir = custom / "email-templates"
         (tdir / "verify").mkdir(parents=True)
         (tdir / "verify" / "subject.txt").write_text("CUSTOM SUBJECT\n")
-        monkeypatch.setenv("KLANGK_CUSTOMIZE_DIR", str(custom))
-        r = emailsvc.render_email("verify", link="https://x", expiry_hours=72)
+        svc = _email_service({"KLANGK_CUSTOMIZE_DIR": str(custom)})
+        r = svc.render_email("verify", link="https://x", expiry_hours=72)
         assert r.subject == "CUSTOM SUBJECT"
 
-    def test_html_autoescape_on_html_off_text(self, monkeypatch):
+    def test_html_autoescape_on_html_off_text(self):
         # .html is autoescaped (closes the str.format XSS gap); .txt is not.
-        r = emailsvc.render_email(
+        svc = _email_service({})
+        r = svc.render_email(
             "invite",
             link="https://x",
             expiry_hours=72,
@@ -453,26 +482,38 @@ class TestTemplateOverlay:
 
 
 class TestReplyTo:
-    def test_reply_to_none_when_unset(self, monkeypatch):
-        monkeypatch.delenv("KLANGK_SMTP_REPLY_TO", raising=False)
-        assert emailsvc.reply_to() is None
+    def test_reply_to_none_when_unset(self):
+        svc = _email_service({})
+        assert svc.reply_to() is None
 
-    def test_reply_to_resolved_when_set(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_SMTP_REPLY_TO", "support@example.com")
-        assert emailsvc.reply_to() == "support@example.com"
+    def test_reply_to_resolved_when_set(self):
+        svc = _email_service({"KLANGK_SMTP_REPLY_TO": "support@example.com"})
+        assert svc.reply_to() == "support@example.com"
 
-    async def test_multipart_carries_reply_to(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_SMTP_REPLY_TO", "support@example.com")
-        rendered = emailsvc.render_email(
+    async def test_multipart_carries_reply_to(self):
+        svc = _email_service({"KLANGK_SMTP_REPLY_TO": "support@example.com"})
+        rendered = svc.render_email(
             "verify", link="https://x", expiry_hours=72
         )
-        msg = emailsvc.build_multipart("to@e.com", rendered)
+        msg = svc.build_multipart("to@e.com", rendered)
         assert msg["Reply-To"] == "support@example.com"
 
-    def test_multipart_no_reply_to_when_unset(self, monkeypatch):
-        monkeypatch.delenv("KLANGK_SMTP_REPLY_TO", raising=False)
-        rendered = emailsvc.render_email(
+    def test_multipart_no_reply_to_when_unset(self):
+        svc = _email_service({})
+        rendered = svc.render_email(
             "verify", link="https://x", expiry_hours=72
         )
-        msg = emailsvc.build_multipart("to@e.com", rendered)
+        msg = svc.build_multipart("to@e.com", rendered)
         assert msg["Reply-To"] is None
+
+
+class TestTemplateEnvReset:
+    """reset_template_env drops the cached Jinja env (#1483)."""
+
+    def test_reset_clears_cache(self):
+        svc = _email_service({})
+        # Trigger a build.
+        svc.render_email("verify", link="https://x", expiry_hours=72)
+        assert svc._env is not None
+        svc.reset_template_env()
+        assert svc._env is None

--- a/src/backend/tests/test_main.py
+++ b/src/backend/tests/test_main.py
@@ -15,6 +15,7 @@ from sqlalchemy.exc import IntegrityError as SAIntegrityError
 
 from klangk_backend import (
     agent as agent_mod,
+    emailsvc as emailsvc_mod,
     main,
     model,
     oidc,
@@ -49,6 +50,7 @@ def _make_app_state(settings=None):
     app_state.plugins = plugins.Plugins(app_state)
     app_state.workspaces = workspaces.Workspaces(app_state)
     app_state.agents = agent_mod.Agents(app_state)
+    app_state.email = emailsvc_mod.EmailService(app_state)
     return app_state
 
 
@@ -380,6 +382,7 @@ class TestLifespan:
         app.state.plugins = plugins.Plugins(app.state)
         app.state.workspaces = workspaces.Workspaces(app.state)
         app.state.agents = agent_mod.Agents(app.state)
+        app.state.email = emailsvc_mod.EmailService(app.state)
         registry = app_state.container_registry
         with (
             patch.object(
@@ -426,6 +429,7 @@ class TestLifespan:
         app.state.plugins = plugins.Plugins(app.state)
         app.state.workspaces = workspaces.Workspaces(app.state)
         app.state.agents = agent_mod.Agents(app.state)
+        app.state.email = emailsvc_mod.EmailService(app.state)
         registry = app_state.container_registry
         with (
             patch.object(
@@ -649,6 +653,7 @@ class TestStartupShutdownRestart:
         app.state.plugins = plugins.Plugins(app.state)
         app.state.workspaces = workspaces.Workspaces(app.state)
         app.state.agents = agent_mod.Agents(app.state)
+        app.state.email = emailsvc_mod.EmailService(app.state)
         registry = app_state.container_registry
         loop = asyncio.get_running_loop()
         with (

--- a/src/backend/tests/test_mode_switching.py
+++ b/src/backend/tests/test_mode_switching.py
@@ -19,6 +19,7 @@ from httpx import ASGITransport, AsyncClient
 from klangk_backend import (
     api,
     auth,
+    emailsvc as emailsvc_mod,
     main,
     model,
     oidc as oidc_mod,
@@ -58,6 +59,7 @@ async def mode_server(db, monkeypatch):
     app.state.settings = KlangkSettings(env={"KLANGK_AUTH_MODES": "none"})
     app.state.oidc = oidc_mod.OIDC(app.state)
     app.state.plugins = plugins_mod.Plugins(app.state)
+    app.state.email = emailsvc_mod.EmailService(app.state)
     app.include_router(api.root_router)
     app.include_router(api.router, prefix=API_PREFIX)
     register_exception_handlers(app)

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -17,6 +17,7 @@ from fastapi import WebSocketDisconnect
 
 from klangk_backend import (
     agent as agent_mod,
+    emailsvc as emailsvc_mod,
     model,
     wshandler,
     container,
@@ -109,6 +110,7 @@ def _make_app_state(registry=None, sockets=None):
     app_state.terminal = _mock_term
     app_state.workspaces = ws_mod.Workspaces(app_state)
     app_state.agents = agent_mod.Agents(app_state)
+    app_state.email = emailsvc_mod.EmailService(app_state)
     return app_state
 
 


### PR DESCRIPTION
Closes #1483. Part of #1426 (composition-root refactor).

## What

`emailsvc.py` was a flat collection of module-level functions (`smtp_config`, `use_smtp`, `reply_to`, `product_name`, `_brand_ctx`, `render_email`, `build_multipart`, `_send`, `send_via_smtp`, `send_via_sendmail`, the three `send_*_email` entry points) that read config via `resolve_env_value("KLANGK_...")` at call time, plus a module-global cached Jinja env (`_env`) and `reset_template_env()`.

Promoted to `EmailService(app_state)` — an owned instance wired onto `app.state.email`. Config is read from `self.settings` (`KlangkSettings`); every env var the module touches has a matching typed field. The Jinja env is per-instance (`self._env`), with `reset_template_env()` kept for tests that flip the templates dir.

## Changes

**Production:**
- **`emailsvc.py`** — `EmailService(app_state)` with `self.app_state`/`self.settings` (no under-prefix). All functions become methods. The cached Jinja env (`_env`) becomes per-instance. `resolve_password()` still applies `resolve_indirection` for `file:`/`cmd:` prefixes on `smtp_password` (one-line wrap, commented to remove when #1461 lands). No `resolve_env_value`/`os.environ` in the module.
- **`main.py`** — `app.state.email = emailsvc.EmailService(app.state)` in `build_app`; `emailsvc` added to the module import block.
- **`api/admin.py`** — 3 routes (`send_invitation`, `resend_invitation`, `admin_create_user`) get `app_state=Depends(get_app_state_dep)`; `emailsvc.send_*` → `app_state.email.send_*`. `emailsvc` import removed.
- **`api/auth.py`** — 4 routes (`register`, `resend_verification`, `forgot_password`, `change_email`) get `app_state=Depends(get_app_state_dep)`; `emailsvc.send_*` → `app_state.email.send_*`. `emailsvc` import removed.

**Tests:**
- `test_emailsvc.py` rewritten — `_email_service(env: dict)` helper builds `EmailService` from explicit env (no `os.environ`); tests toggle config via settings, patch methods via `patch.object(svc, ...)`. The `_fresh_email_service` autouse fixture marks per-test isolation.
- `test_api.py`, `test_main.py`, `test_wshandler.py`, `test_mode_switching.py` app fixtures wire `app.state.email = EmailService(app.state)`; email mocks updated from `patch.object(api.emailsvc, ...)` → `patch.object(emailsvc_mod.EmailService, ...)` (class-level, no `app` needed).
- `conftest.py` shared `app_state` fixture wires `state.email`.

## Verification

- Backend unit: **2380 passed, 100% coverage**
- `ruff check` + `ruff format` clean
