### PR TITLE
Promote nginx.py renderer to NginxRenderer(app_state); NginxWatchdog(app_state) (#1469)

### DIFF
--- a/src/backend/e2e-tests/test_nginx_acl_e2e.py
+++ b/src/backend/e2e-tests/test_nginx_acl_e2e.py
@@ -63,12 +63,13 @@ def _render_conf(env_overrides, tmpdir=None):
             # render, regardless of what a prior test left behind.
             os.environ.pop(k, None)
     try:
-        from klangk_backend.nginx import render_config, tcp_upstream
+        from klangk_backend.nginx import NginxRenderer, tcp_upstream
         from klangk_backend.settings import get_settings
+        import types
 
-        return render_config(
-            tcp_upstream("127.0.0.1", "19998"), get_settings()
-        )
+        return NginxRenderer(
+            types.SimpleNamespace(settings=get_settings())
+        ).render_config(tcp_upstream("127.0.0.1", "19998"))
     finally:
         for k, old in old_env.items():
             if old is None:
@@ -448,8 +449,9 @@ class TestNginxAclEnforcement:
 
         # Start nginx via the Python renderer (#1396): render the conf
         # from these env vars, then launch nginx directly with -c.
-        from klangk_backend.nginx import write_config, tcp_upstream
+        from klangk_backend.nginx import NginxRenderer, tcp_upstream
         from klangk_backend.settings import get_settings
+        import types
 
         for k, v in {
             "KLANGK_NGINX_PORT": nginx_port,
@@ -461,9 +463,9 @@ class TestNginxAclEnforcement:
         nginx_state = os.path.join(tmpdir, "nginx")
         os.makedirs(nginx_state, exist_ok=True)
         conf_path = os.path.join(nginx_state, "nginx.conf")
-        write_config(
-            tcp_upstream("127.0.0.1", backend_port), conf_path, get_settings()
-        )
+        NginxRenderer(
+            types.SimpleNamespace(settings=get_settings())
+        ).write_config(tcp_upstream("127.0.0.1", backend_port), conf_path)
         nginx_proc = subprocess.Popen(
             ["nginx", "-e", "stderr", "-c", conf_path],
             stdout=subprocess.PIPE,
@@ -621,8 +623,9 @@ class TestNginxDenyByDefault:
         # Start nginx via the Python renderer (#1396) with the host IP as
         # the (sole) container source IP. CONTAINER_DENY on the catch-all
         # then denies exactly that IP.
-        from klangk_backend.nginx import write_config, tcp_upstream
+        from klangk_backend.nginx import NginxRenderer, tcp_upstream
         from klangk_backend.settings import get_settings
+        import types
 
         for k, v in {
             "KLANGK_NGINX_PORT": nginx_port,
@@ -632,9 +635,9 @@ class TestNginxDenyByDefault:
         nginx_state = os.path.join(tmpdir, "nginx")
         os.makedirs(nginx_state, exist_ok=True)
         conf_path = os.path.join(nginx_state, "nginx.conf")
-        write_config(
-            tcp_upstream("127.0.0.1", backend_port), conf_path, get_settings()
-        )
+        NginxRenderer(
+            types.SimpleNamespace(settings=get_settings())
+        ).write_config(tcp_upstream("127.0.0.1", backend_port), conf_path)
         nginx_proc = subprocess.Popen(
             ["nginx", "-e", "stderr", "-c", conf_path],
             stdout=subprocess.PIPE,
@@ -785,16 +788,17 @@ class TestNginxAuthLocalAcl:
         # nginx via the Python renderer (#1396) with no container subnets —
         # the /auth/local block is always generated with its fixed loopback
         # allowlist.
-        from klangk_backend.nginx import write_config, tcp_upstream
+        from klangk_backend.nginx import NginxRenderer, tcp_upstream
         from klangk_backend.settings import get_settings
+        import types
 
         os.environ["KLANGK_NGINX_PORT"] = nginx_port
         nginx_state = os.path.join(tmpdir, "nginx")
         os.makedirs(nginx_state, exist_ok=True)
         conf_path = os.path.join(nginx_state, "nginx.conf")
-        write_config(
-            tcp_upstream("127.0.0.1", backend_port), conf_path, get_settings()
-        )
+        NginxRenderer(
+            types.SimpleNamespace(settings=get_settings())
+        ).write_config(tcp_upstream("127.0.0.1", backend_port), conf_path)
         nginx_proc = subprocess.Popen(
             ["nginx", "-e", "stderr", "-c", conf_path],
             stdout=subprocess.PIPE,

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -404,14 +404,16 @@ async def process_shutdown() -> None:
 class NginxWatchdog:
     """Owns the nginx child process and its supervision task (#1463).
 
-    Constructed with ``settings`` (needed to render nginx.conf via the
-    renderer, which takes settings as of Slice 2a). Stored on
-    ``app.state.nginx_watchdog``; the lifespan calls ``.start()`` /
-    ``.stop()``.
+    Constructed with ``app_state`` (``self._settings = app_state.settings``)
+    and owns a :class:`~klangk_backend.nginx.NginxRenderer` instance for
+    config rendering (#1469). Stored on ``app.state.nginx_watchdog``; the
+    lifespan calls ``.start()`` / ``.stop()``.
     """
 
-    def __init__(self, settings: KlangkSettings) -> None:
-        self._settings = settings
+    def __init__(self, app_state) -> None:
+        self._app_state = app_state
+        self._settings: KlangkSettings = app_state.settings
+        self._renderer = nginx_mod.NginxRenderer(app_state)
         self._proc: asyncio.subprocess.Process | None = None
         self._task: asyncio.Task | None = None
         self._stopping = False
@@ -464,9 +466,9 @@ class NginxWatchdog:
         )
         uds_path = os.path.join(state_dir, "klangk.sock")
         conf_path = os.path.join(state_dir, "nginx.conf")
-        bin_path = nginx_mod.find_nginx_bin(self._settings)
-        nginx_mod.write_config(
-            nginx_mod.uds_upstream(uds_path), conf_path, self._settings
+        bin_path = self._renderer.find_nginx_bin()
+        self._renderer.write_config(
+            nginx_mod.uds_upstream(uds_path), conf_path
         )
         return bin_path, conf_path
 
@@ -744,7 +746,7 @@ def build_app(settings: KlangkSettings) -> FastAPI:
     app.state.container_registry = container.ContainerRegistry(app.state)
     # Slice 2b (#1463): nginx watchdog is an owned instance with start/stop
     # lifecycle methods called by the lifespan.
-    app.state.nginx_watchdog = NginxWatchdog(settings)
+    app.state.nginx_watchdog = NginxWatchdog(app.state)
     # Slice 2c (#1475): the WebSocketState is an owned instance wired onto
     # app.state.sockets. The registry and agent module reach it through
     # explicit references — no module-level singleton.

--- a/src/backend/klangk_backend/nginx.py
+++ b/src/backend/klangk_backend/nginx.py
@@ -13,6 +13,13 @@ parameter so it serves both the production UDS bind
 (:func:`tcp_upstream`) — only the ``proxy_pass`` base differs.
 
 See #1392 (design record) and #1396 (this chunk).
+
+The settings-driven rendering logic lives on :class:`NginxRenderer`, an
+owned instance constructed with ``app_state`` (``self._settings =
+app_state.settings``) per the composition-root refactor (#1426, #1469).
+Pure helpers (upstream constructors, host-IP auto-detection, the minimal-
+template auth-location formatter) stay module-level — they don't read
+settings.
 """
 
 from __future__ import annotations
@@ -51,7 +58,7 @@ def _is_loopback(addr: str) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# Upstream constructors
+# Upstream constructors (pure — no settings)
 # ---------------------------------------------------------------------------
 
 
@@ -101,44 +108,6 @@ def detect_host_ipv4s() -> list[str]:
     return addrs
 
 
-def detect_dns_resolvers(settings: KlangkSettings) -> str:
-    """Space-separated nameservers for nginx's ``resolver`` directive.
-
-    From ``KLANGK_DNS_SERVERS`` (comma→space) if set, else parsed from
-    ``/etc/resolv.conf`` (IPv6 bracketed for nginx), else ``8.8.8.8``.
-    """
-    raw = resolve_indirection(settings.dns_servers)
-    if raw:
-        servers = []
-        for token in str(raw).split(","):
-            token = token.strip()
-            if not token:
-                continue
-            if ":" in token and not token.startswith("["):
-                servers.append(f"[{token}]")
-            else:
-                servers.append(token)
-        return " ".join(servers) or "8.8.8.8"
-    # Parse /etc/resolv.conf.
-    servers: list[str] = []
-    try:
-        for line in Path("/etc/resolv.conf").read_text().splitlines():
-            parts = line.split()
-            if len(parts) >= 2 and parts[0] == "nameserver":
-                addr = parts[1]
-                if ":" in addr:
-                    servers.append(f"[{addr}]")
-                else:
-                    servers.append(addr)
-    except OSError:
-        pass
-    return " ".join(servers) or "8.8.8.8"
-
-
-# ---------------------------------------------------------------------------
-# Container ACL / DENY computation
-# ---------------------------------------------------------------------------
-
 # Fallback subnets when auto-detection yields nothing (mirrors nginx.sh):
 # 172.16/12 + 10/8 (common container ranges), explicitly NOT 192.168/16
 # (most common LAN range — allowing it would expose the LLM proxy to peers).
@@ -146,187 +115,9 @@ _FALLBACK_ACL_SUBNETS = ["172.16.0.0/12", "10.0.0.0/8", "127.0.0.1"]
 _FALLBACK_DENY_SUBNETS = ["172.16.0.0/12", "10.0.0.0/8"]
 
 
-def compute_container_acls(settings: KlangkSettings) -> tuple[str, str]:
-    """Build the CONTAINER_ACL (allowlist) and CONTAINER_DENY (blocklist) text.
-
-    Returns ``(acl_block, deny_block)`` where each is the indented
-    ``allow``/``deny`` directives (no leading/trailing newline). Two
-    complementary ACLs from one source set (#1376):
-
-    - CONTAINER_ACL: allowlist on the three container endpoints
-      (llm-proxy, browser-delegate, post-chat-message). Allows the container
-      source IPs, denies everyone else.
-    - CONTAINER_DENY: blocklist on the catch-all ``location /``. Denies the
-      container source IPs so a container reaches ONLY those three endpoints,
-      not the whole /api/v1/* tree. Loopback is ALWAYS excluded (local
-      browsers need the full UI/API).
-
-    With an explicit ``KLANGK_CONTAINER_SUBNETS`` override, 127.0.0.1 is NOT
-    implicitly added to CONTAINER_ACL (the operator's list is used verbatim).
-    """
-    explicit = resolve_indirection(settings.container_subnets)
-    if explicit:
-        subnets = [s.strip() for s in str(explicit).split(",") if s.strip()]
-        acl_lines = [f"      allow {s};" for s in subnets]
-        deny_lines = [
-            f"      deny {s};" for s in subnets if not _is_loopback(s)
-        ]
-        if not deny_lines:
-            logger.warning(
-                "container source set has no non-loopback entries — "
-                "catch-all location / denies nothing (deny-by-default inactive)"
-            )
-    else:
-        addrs = detect_host_ipv4s()
-        if addrs:
-            acl_lines = [f"      allow {a};" for a in addrs]
-            deny_lines = [
-                f"      deny {a};" for a in addrs if not _is_loopback(a)
-            ]
-        else:
-            logger.warning(
-                "container subnet detection failed, using fallback RFC1918 ranges"
-            )
-            acl_lines = [f"      allow {s};" for s in _FALLBACK_ACL_SUBNETS]
-            deny_lines = [f"      deny {s};" for s in _FALLBACK_DENY_SUBNETS]
-    acl = "\n".join(acl_lines) + "\n      deny all;"
-    deny = "\n".join(deny_lines) + "\n      allow all;"
-    return acl, deny
-
-
 # ---------------------------------------------------------------------------
-# client_max_body_size
+# Minimal-template auth-location formatter (pure — no settings)
 # ---------------------------------------------------------------------------
-
-
-def compute_client_max_body_size(settings: KlangkSettings) -> str:
-    """Derive nginx ``client_max_body_size`` from ``KLANGK_FILE_UPLOAD_SIZE_MAX``.
-
-    The setting is in bytes (default 500 MB); nginx wants ``Nm``. Minimum 1m.
-    """
-    raw = resolve_indirection(settings.file_upload_size_max) or "524288000"
-    try:
-        bytes_ = int(str(raw))
-    except (TypeError, ValueError):
-        bytes_ = 524288000
-    mb = max(1, bytes_ // 1048576)
-    return f"{mb}m"
-
-
-# ---------------------------------------------------------------------------
-# Section builders
-# ---------------------------------------------------------------------------
-
-
-def _build_hosted_block(settings: KlangkSettings) -> str:
-    """The /hosted/ proxy locations (or a 404 block when disabled).
-
-    Disabled entirely when ``KLANGK_HOSTED_PORTS_PER_WORKSPACE`` is exactly 0
-    — mirrors the backend's ``ports_per_workspace_cap()`` (#1237).
-    """
-    raw = resolve_indirection(settings.hosted_ports_per_workspace) or "5"
-    if str(raw).strip() == "0":
-        return (
-            "    # Hosted-app serving is disabled "
-            "(KLANGK_HOSTED_PORTS_PER_WORKSPACE=0).\n"
-            "    location ^~ /hosted/ {\n"
-            "      return 404;\n"
-            "    }\n"
-        )
-    return (
-        "    # A hosted URL without a trailing slash (e.g. .../9001) can't match the\n"
-        "    # proxy location below. Redirect to the canonical trailing-slash form so\n"
-        "    # relative asset paths resolve.\n"
-        "    location ~ ^/hosted/[^/]+/(?<hosted_port>\\d+)$ {\n"
-        "      if ($hosted_is_ws = 0) {\n"
-        "        return 308 $uri/$is_args$args;\n"
-        "      }\n"
-        "      # WebSocket clients cannot follow a 308; proxy instead.\n"
-        "      proxy_pass http://127.0.0.1:$hosted_port/$is_args$args;\n"
-        "      proxy_set_header Host $http_host;\n"
-        "      proxy_set_header X-Real-IP $remote_addr;\n"
-        "      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n"
-        "      proxy_set_header X-Forwarded-Proto $scheme;\n"
-        "      proxy_http_version 1.1;\n"
-        "      proxy_set_header Upgrade $http_upgrade;\n"
-        "      proxy_set_header Connection $connection_upgrade;\n"
-        "    }\n"
-        "\n"
-        "    # Hosted app proxy: extract port from URL and proxy to container.\n"
-        "    location ~ ^/hosted/[^/]+/(\\d+)/(.*)$ {\n"
-        "      proxy_pass http://127.0.0.1:$1/$2$is_args$args;\n"
-        "      proxy_set_header Host $http_host;\n"
-        "      proxy_set_header X-Real-IP $remote_addr;\n"
-        "      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n"
-        "      proxy_set_header X-Forwarded-Proto $scheme;\n"
-        "      proxy_http_version 1.1;\n"
-        "      proxy_set_header Upgrade $http_upgrade;\n"
-        "      proxy_set_header Connection $connection_upgrade;\n"
-        "    }\n"
-    )
-
-
-def _build_llm_block(
-    acl: str, resolvers: str, settings: KlangkSettings
-) -> str:
-    """The /llm-proxy/ location, only when ``KLANGK_LLM_BASE_URL`` is set.
-
-    Containers hit this instead of the real endpoint, so they never see the
-    API key. Uses an nginx variable so the upstream resolves at request time
-    (avoids crash on unresolvable hosts). ``file:``/``cmd:`` prefixes on the
-    URL and key are resolved here (Python's resolver, not the retired
-    ``klangk-resolve-value`` console script).
-    """
-    base_url = resolve_indirection(settings.llm_base_url)
-    if not base_url:
-        return ""
-    api_key = resolve_indirection(settings.llm_api_key) or ""
-    return (
-        f"    location ~ ^/llm-proxy/(.*)$ {{\n"
-        f"{acl}\n"
-        "      auth_request /api/v1/auth/verify-workspace-token;\n"
-        "      auth_request_set $auth_token_error $upstream_http_x_token_error;\n"
-        "      error_page 401 = @token_auth_failed;\n"
-        f"      resolver {resolvers} valid=30s;\n"
-        f"      set $llm_backend {base_url}/$1;\n"
-        "      proxy_pass $llm_backend;\n"
-        f'      proxy_set_header Authorization "Bearer {api_key}";\n'
-        "      proxy_set_header Host $proxy_host;\n"
-        "      proxy_ssl_server_name on;\n"
-        "      proxy_http_version 1.1;\n"
-        '      proxy_set_header Connection "";\n'
-        "      proxy_buffering off;\n"
-        "      proxy_cache off;\n"
-        "      chunked_transfer_encoding on;\n"
-        "    }\n"
-    )
-
-
-def _trust_outer_proxy(settings: KlangkSettings) -> bool:
-    raw = resolve_indirection(settings.trust_outer_proxy) or ""
-    return str(raw).strip().lower() in ("1", "true", "yes")
-
-
-# ---------------------------------------------------------------------------
-# Main renderer
-# ---------------------------------------------------------------------------
-
-
-def render_config(upstream: str, settings: KlangkSettings) -> str:
-    """Render ``nginx.conf`` as a string.
-
-    Template selection keys off ``KLANGK_LISTEN``'s shape only (#1398): a
-    socket path ⇒ the minimal (headless) template; TCP ⇒ the full (browser)
-    template. The AUTH value does not participate in template selection —
-    only the bind does. ``upstream`` is the ``proxy_pass`` base
-    (:func:`uds_upstream` for the production socket bind, :func:`tcp_upstream`
-    for tests). All other values come from the merged settings
-    (env > config file > defaults) plus the host-IP / DNS auto-detection
-    probes.
-    """
-    if listen_is_socket(resolve_indirection(settings.listen)):
-        return _render_minimal_config(upstream, settings)
-    return _render_full_config(upstream, settings)
 
 
 def _minimal_auth_locations(upstream: str) -> str:
@@ -358,31 +149,261 @@ def _minimal_auth_locations(upstream: str) -> str:
     )
 
 
-def _render_minimal_config(upstream: str, settings: KlangkSettings) -> str:
-    """Render the minimal (headless) ``nginx.conf`` — socket bind only (#1398).
+# ---------------------------------------------------------------------------
+# Renderer (settings-driven — owned instance, #1469)
+# ---------------------------------------------------------------------------
 
-    Emitted when ``KLANGK_LISTEN`` is a socket path: a browser can't reach a
-    UDS and uvicorn exposes no browser-facing TCP, so no browser UI is
-    serviceable. The only served surface is the container-egress
-    ``/llm-proxy`` location (with its workspace-token ``auth_request`` gate +
-    CONTAINER_ACL) on the single container-egress listener. No ``location /``,
-    no ``/api/v1/*``, no static UI, no ``/auth/local`` — the attack surface is
-    two channels (operator→UDS, container→llm-proxy) and nothing else.
 
-    The ``auth_request`` subrequest target + JSON 401 page are emitted only
-    when an ``/llm-proxy`` location exists to gate on them (i.e. when
-    ``KLANGK_LLM_BASE_URL`` is set); with no LLM configured the server block
-    serves nothing.
+class NginxRenderer:
+    """Settings-driven ``nginx.conf`` renderer (#1396, #1469).
+
+    Constructed with ``app_state`` (``self._settings = app_state.settings``)
+    per the composition-root pattern. The renderer is a pure function of the
+    merged config (settings + env probes); it does not touch podman.
+    ``NginxWatchdog`` owns an instance and calls :meth:`render_config` /
+    :meth:`find_nginx_bin` / :meth:`write_config` from its ``_prepare`` step.
     """
-    nginx_port = resolve_indirection(settings.nginx_port) or "8995"
-    client_max_body_size = compute_client_max_body_size(settings)
-    resolvers = detect_dns_resolvers(settings)
-    acl, _deny = compute_container_acls(settings)
-    llm_block = _build_llm_block(acl, resolvers, settings)
-    # The auth_request infrastructure is only reachable via the /llm-proxy
-    # location's auth_request; omit it entirely when there's no LLM proxy.
-    auth_locations = _minimal_auth_locations(upstream) if llm_block else ""
-    return f"""daemon off;
+
+    def __init__(self, app_state) -> None:
+        self._app_state = app_state
+        self._settings: KlangkSettings = app_state.settings
+
+    # -- DNS / ACL / size computation --------------------------------------
+
+    def detect_dns_resolvers(self) -> str:
+        """Space-separated nameservers for nginx's ``resolver`` directive.
+
+        From ``KLANGK_DNS_SERVERS`` (comma→space) if set, else parsed from
+        ``/etc/resolv.conf`` (IPv6 bracketed for nginx), else ``8.8.8.8``.
+        """
+        raw = resolve_indirection(self._settings.dns_servers)
+        if raw:
+            servers = []
+            for token in str(raw).split(","):
+                token = token.strip()
+                if not token:
+                    continue
+                if ":" in token and not token.startswith("["):
+                    servers.append(f"[{token}]")
+                else:
+                    servers.append(token)
+            return " ".join(servers) or "8.8.8.8"
+        # Parse /etc/resolv.conf.
+        servers: list[str] = []
+        try:
+            for line in Path("/etc/resolv.conf").read_text().splitlines():
+                parts = line.split()
+                if len(parts) >= 2 and parts[0] == "nameserver":
+                    addr = parts[1]
+                    if ":" in addr:
+                        servers.append(f"[{addr}]")
+                    else:
+                        servers.append(addr)
+        except OSError:
+            pass
+        return " ".join(servers) or "8.8.8.8"
+
+    def compute_container_acls(self) -> tuple[str, str]:
+        """Build the CONTAINER_ACL (allowlist) and CONTAINER_DENY (blocklist) text.
+
+        Returns ``(acl_block, deny_block)`` where each is the indented
+        ``allow``/``deny`` directives (no leading/trailing newline). Two
+        complementary ACLs from one source set (#1376):
+
+        - CONTAINER_ACL: allowlist on the three container endpoints
+          (llm-proxy, browser-delegate, post-chat-message). Allows the container
+          source IPs, denies everyone else.
+        - CONTAINER_DENY: blocklist on the catch-all ``location /``. Denies the
+          container source IPs so a container reaches ONLY those three endpoints,
+          not the whole /api/v1/* tree. Loopback is ALWAYS excluded (local
+          browsers need the full UI/API).
+
+        With an explicit ``KLANGK_CONTAINER_SUBNETS`` override, 127.0.0.1 is NOT
+        implicitly added to CONTAINER_ACL (the operator's list is used verbatim).
+        """
+        explicit = resolve_indirection(self._settings.container_subnets)
+        if explicit:
+            subnets = [
+                s.strip() for s in str(explicit).split(",") if s.strip()
+            ]
+            acl_lines = [f"      allow {s};" for s in subnets]
+            deny_lines = [
+                f"      deny {s};" for s in subnets if not _is_loopback(s)
+            ]
+            if not deny_lines:
+                logger.warning(
+                    "container source set has no non-loopback entries — "
+                    "catch-all location / denies nothing (deny-by-default inactive)"
+                )
+        else:
+            addrs = detect_host_ipv4s()
+            if addrs:
+                acl_lines = [f"      allow {a};" for a in addrs]
+                deny_lines = [
+                    f"      deny {a};" for a in addrs if not _is_loopback(a)
+                ]
+            else:
+                logger.warning(
+                    "container subnet detection failed, using fallback RFC1918 ranges"
+                )
+                acl_lines = [
+                    f"      allow {s};" for s in _FALLBACK_ACL_SUBNETS
+                ]
+                deny_lines = [
+                    f"      deny {s};" for s in _FALLBACK_DENY_SUBNETS
+                ]
+        acl = "\n".join(acl_lines) + "\n      deny all;"
+        deny = "\n".join(deny_lines) + "\n      allow all;"
+        return acl, deny
+
+    def compute_client_max_body_size(self) -> str:
+        """Derive nginx ``client_max_body_size`` from ``KLANGK_FILE_UPLOAD_SIZE_MAX``.
+
+        The setting is in bytes (default 500 MB); nginx wants ``Nm``. Minimum 1m.
+        """
+        raw = (
+            resolve_indirection(self._settings.file_upload_size_max)
+            or "524288000"
+        )
+        try:
+            bytes_ = int(str(raw))
+        except (TypeError, ValueError):
+            bytes_ = 524288000
+        mb = max(1, bytes_ // 1048576)
+        return f"{mb}m"
+
+    # -- Section builders --------------------------------------------------
+
+    def _build_hosted_block(self) -> str:
+        """The /hosted/ proxy locations (or a 404 block when disabled).
+
+        Disabled entirely when ``KLANGK_HOSTED_PORTS_PER_WORKSPACE`` is exactly 0
+        — mirrors the backend's ``ports_per_workspace_cap()`` (#1237).
+        """
+        raw = (
+            resolve_indirection(self._settings.hosted_ports_per_workspace)
+            or "5"
+        )
+        if str(raw).strip() == "0":
+            return (
+                "    # Hosted-app serving is disabled "
+                "(KLANGK_HOSTED_PORTS_PER_WORKSPACE=0).\n"
+                "    location ^~ /hosted/ {\n"
+                "      return 404;\n"
+                "    }\n"
+            )
+        return (
+            "    # A hosted URL without a trailing slash (e.g. .../9001) can't match the\n"
+            "    # proxy location below. Redirect to the canonical trailing-slash form so\n"
+            "    # relative asset paths resolve.\n"
+            "    location ~ ^/hosted/[^/]+/(?<hosted_port>\\d+)$ {\n"
+            "      if ($hosted_is_ws = 0) {\n"
+            "        return 308 $uri/$is_args$args;\n"
+            "      }\n"
+            "      # WebSocket clients cannot follow a 308; proxy instead.\n"
+            "      proxy_pass http://127.0.0.1:$hosted_port/$is_args$args;\n"
+            "      proxy_set_header Host $http_host;\n"
+            "      proxy_set_header X-Real-IP $remote_addr;\n"
+            "      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n"
+            "      proxy_set_header X-Forwarded-Proto $scheme;\n"
+            "      proxy_http_version 1.1;\n"
+            "      proxy_set_header Upgrade $http_upgrade;\n"
+            "      proxy_set_header Connection $connection_upgrade;\n"
+            "    }\n"
+            "\n"
+            "    # Hosted app proxy: extract port from URL and proxy to container.\n"
+            "    location ~ ^/hosted/[^/]+/(\\d+)/(.*)$ {\n"
+            "      proxy_pass http://127.0.0.1:$1/$2$is_args$args;\n"
+            "      proxy_set_header Host $http_host;\n"
+            "      proxy_set_header X-Real-IP $remote_addr;\n"
+            "      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n"
+            "      proxy_set_header X-Forwarded-Proto $scheme;\n"
+            "      proxy_http_version 1.1;\n"
+            "      proxy_set_header Upgrade $http_upgrade;\n"
+            "      proxy_set_header Connection $connection_upgrade;\n"
+            "    }\n"
+        )
+
+    def _build_llm_block(self, acl: str, resolvers: str) -> str:
+        """The /llm-proxy/ location, only when ``KLANGK_LLM_BASE_URL`` is set.
+
+        Containers hit this instead of the real endpoint, so they never see the
+        API key. Uses an nginx variable so the upstream resolves at request time
+        (avoids crash on unresolvable hosts). ``file:``/``cmd:`` prefixes on the
+        URL and key are resolved here (Python's resolver, not the retired
+        ``klangk-resolve-value`` console script).
+        """
+        base_url = resolve_indirection(self._settings.llm_base_url)
+        if not base_url:
+            return ""
+        api_key = resolve_indirection(self._settings.llm_api_key) or ""
+        return (
+            f"    location ~ ^/llm-proxy/(.*)$ {{\n"
+            f"{acl}\n"
+            "      auth_request /api/v1/auth/verify-workspace-token;\n"
+            "      auth_request_set $auth_token_error $upstream_http_x_token_error;\n"
+            "      error_page 401 = @token_auth_failed;\n"
+            f"      resolver {resolvers} valid=30s;\n"
+            f"      set $llm_backend {base_url}/$1;\n"
+            "      proxy_pass $llm_backend;\n"
+            f'      proxy_set_header Authorization "Bearer {api_key}";\n'
+            "      proxy_set_header Host $proxy_host;\n"
+            "      proxy_ssl_server_name on;\n"
+            "      proxy_http_version 1.1;\n"
+            '      proxy_set_header Connection "";\n'
+            "      proxy_buffering off;\n"
+            "      proxy_cache off;\n"
+            "      chunked_transfer_encoding on;\n"
+            "    }\n"
+        )
+
+    def _trust_outer_proxy(self) -> bool:
+        raw = resolve_indirection(self._settings.trust_outer_proxy) or ""
+        return str(raw).strip().lower() in ("1", "true", "yes")
+
+    # -- Main renderer -----------------------------------------------------
+
+    def render_config(self, upstream: str) -> str:
+        """Render ``nginx.conf`` as a string.
+
+        Template selection keys off ``KLANGK_LISTEN``'s shape only (#1398): a
+        socket path ⇒ the minimal (headless) template; TCP ⇒ the full (browser)
+        template. The AUTH value does not participate in template selection —
+        only the bind does. ``upstream`` is the ``proxy_pass`` base
+        (:func:`uds_upstream` for the production socket bind, :func:`tcp_upstream`
+        for tests). All other values come from the merged settings
+        (env > config file > defaults) plus the host-IP / DNS auto-detection
+        probes.
+        """
+        if listen_is_socket(resolve_indirection(self._settings.listen)):
+            return self._render_minimal_config(upstream)
+        return self._render_full_config(upstream)
+
+    def _render_minimal_config(self, upstream: str) -> str:
+        """Render the minimal (headless) ``nginx.conf`` — socket bind only (#1398).
+
+        Emitted when ``KLANGK_LISTEN`` is a socket path: a browser can't reach a
+        UDS and uvicorn exposes no browser-facing TCP, so no browser UI is
+        serviceable. The only served surface is the container-egress
+        ``/llm-proxy`` location (with its workspace-token ``auth_request`` gate +
+        CONTAINER_ACL) on the single container-egress listener. No ``location /``,
+        no ``/api/v1/*``, no static UI, no ``/auth/local`` — the attack surface is
+        two channels (operator→UDS, container→llm-proxy) and nothing else.
+
+        The ``auth_request`` subrequest target + JSON 401 page are emitted only
+        when an ``/llm-proxy`` location exists to gate on them (i.e. when
+        ``KLANGK_LLM_BASE_URL`` is set); with no LLM configured the server block
+        serves nothing.
+        """
+        nginx_port = resolve_indirection(self._settings.nginx_port) or "8995"
+        client_max_body_size = self.compute_client_max_body_size()
+        resolvers = self.detect_dns_resolvers()
+        acl, _deny = self.compute_container_acls()
+        llm_block = self._build_llm_block(acl, resolvers)
+        # The auth_request infrastructure is only reachable via the /llm-proxy
+        # location's auth_request; omit it entirely when there's no LLM proxy.
+        auth_locations = _minimal_auth_locations(upstream) if llm_block else ""
+        return f"""daemon off;
 pid /tmp/nginx.pid;
 error_log stderr;
 events {{ worker_connections 1024; }}
@@ -402,44 +423,43 @@ http {{
 }}
 """
 
+    def _render_full_config(self, upstream: str) -> str:
+        """Render the full (browser) ``nginx.conf`` — TCP bind (#1396, #1398).
 
-def _render_full_config(upstream: str, settings: KlangkSettings) -> str:
-    """Render the full (browser) ``nginx.conf`` — TCP bind (#1396, #1398).
+        Emitted when ``KLANGK_LISTEN`` is TCP: the browser UI + every API path +
+        static files + the no-auth ``/auth/local`` handout are all serviceable.
+        This is the template the renderer shipped before #1398's socket/minimal
+        branch; it is kept verbatim so the TCP path is a strict regression guard.
+        """
+        nginx_port = resolve_indirection(self._settings.nginx_port) or "8995"
+        client_max_body_size = self.compute_client_max_body_size()
+        resolvers = self.detect_dns_resolvers()
+        acl, deny = self.compute_container_acls()
 
-    Emitted when ``KLANGK_LISTEN`` is TCP: the browser UI + every API path +
-    static files + the no-auth ``/auth/local`` handout are all serviceable.
-    This is the template the renderer shipped before #1398's socket/minimal
-    branch; it is kept verbatim so the TCP path is a strict regression guard.
-    """
-    nginx_port = resolve_indirection(settings.nginx_port) or "8995"
-    client_max_body_size = compute_client_max_body_size(settings)
-    resolvers = detect_dns_resolvers(settings)
-    acl, deny = compute_container_acls(settings)
+        hosted_block = self._build_hosted_block()
+        llm_block = self._build_llm_block(acl, resolvers)
+        trust = self._trust_outer_proxy()
+        if trust:
+            forwarded_headers = (
+                "      proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;\n"
+                "      proxy_set_header X-Forwarded-Host $http_x_forwarded_host;\n"
+                "      proxy_set_header X-Forwarded-Prefix $http_x_forwarded_prefix;\n"
+            )
+        else:
+            forwarded_headers = (
+                "      proxy_set_header X-Forwarded-Proto $scheme;\n"
+                "      proxy_set_header X-Forwarded-Host $http_host;\n"
+            )
 
-    hosted_block = _build_hosted_block(settings)
-    llm_block = _build_llm_block(acl, resolvers, settings)
-    trust = _trust_outer_proxy(settings)
-    if trust:
-        forwarded_headers = (
-            "      proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;\n"
-            "      proxy_set_header X-Forwarded-Host $http_x_forwarded_host;\n"
-            "      proxy_set_header X-Forwarded-Prefix $http_x_forwarded_prefix;\n"
+        # The three proxy-header lines every proxied location shares.
+        common_headers = (
+            "      proxy_set_header Host $http_host;\n"
+            "      proxy_set_header X-Real-IP $remote_addr;\n"
+            "      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n"
+            "      proxy_http_version 1.1;\n"
         )
-    else:
-        forwarded_headers = (
-            "      proxy_set_header X-Forwarded-Proto $scheme;\n"
-            "      proxy_set_header X-Forwarded-Host $http_host;\n"
-        )
 
-    # The three proxy-header lines every proxied location shares.
-    common_headers = (
-        "      proxy_set_header Host $http_host;\n"
-        "      proxy_set_header X-Real-IP $remote_addr;\n"
-        "      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n"
-        "      proxy_http_version 1.1;\n"
-    )
-
-    conf = f"""daemon off;
+        conf = f"""daemon off;
 pid /tmp/nginx.pid;
 error_log stderr;
 events {{ worker_connections 1024; }}
@@ -525,40 +545,38 @@ http {{
   }}
 }}
 """
-    return conf
+        return conf
 
+    # -- I/O + binary location --------------------------------------------
 
-def write_config(
-    upstream: str, conf_path: str | Path, settings: KlangkSettings
-) -> str:
-    """Render the config and write it to ``conf_path`` (returns the text).
+    def write_config(self, upstream: str, conf_path: str | Path) -> str:
+        """Render the config and write it to ``conf_path`` (returns the text).
 
-    Written mode ``0600`` because the rendered config may embed secrets
-    (notably the LLM API key, which nginx needs in the ``/llm-proxy/`` block
-    to set the ``Authorization`` header — there is no way to proxy that
-    header without nginx knowing it). The file lives under the same
-    same-uid-only ``state_dir`` as the UDS, so the restrictive mode matches
-    the existing trust boundary.
-    """
-    text = render_config(upstream, settings)
-    path = Path(conf_path)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    # The LLM API key is necessarily in this config (nginx adds the
-    # Authorization header on the proxied upstream); 0600 keeps it private
-    # to the klangk user. lgtm[py/clear-text-storage-of-sensitive-data]
-    # — the storage is intentional and unavoidable for nginx-based proxying.
-    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-    with os.fdopen(fd, "w") as f:
-        f.write(text)
-    return text
+        Written mode ``0600`` because the rendered config may embed secrets
+        (notably the LLM API key, which nginx needs in the ``/llm-proxy/`` block
+        to set the ``Authorization`` header — there is no way to proxy that
+        header without nginx knowing it). The file lives under the same
+        same-uid-only ``state_dir`` as the UDS, so the restrictive mode matches
+        the existing trust boundary.
+        """
+        text = self.render_config(upstream)
+        path = Path(conf_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # The LLM API key is necessarily in this config (nginx adds the
+        # Authorization header on the proxied upstream); 0600 keeps it private
+        # to the klangk user. lgtm[py/clear-text-storage-of-sensitive-data]
+        # — the storage is intentional and unavoidable for nginx-based proxying.
+        fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w") as f:
+            f.write(text)
+        return text
 
-
-def find_nginx_bin(settings: KlangkSettings) -> str:
-    """Locate the nginx binary: KLANGK_NGINX_BIN > PATH > /usr/sbin/nginx."""
-    configured = resolve_indirection(settings.nginx_bin)
-    if configured:
-        return str(configured)
-    found = shutil.which("nginx")
-    if found:
-        return found
-    return "/usr/sbin/nginx"
+    def find_nginx_bin(self) -> str:
+        """Locate the nginx binary: KLANGK_NGINX_BIN > PATH > /usr/sbin/nginx."""
+        configured = resolve_indirection(self._settings.nginx_bin)
+        if configured:
+            return str(configured)
+        found = shutil.which("nginx")
+        if found:
+            return found
+        return "/usr/sbin/nginx"

--- a/src/backend/tests/test_main.py
+++ b/src/backend/tests/test_main.py
@@ -377,7 +377,7 @@ class TestLifespan:
         app.state.container_registry = app_state.container_registry
         app.state.sockets = app_state.sockets
         app.state.settings = app_state.settings
-        app.state.nginx_watchdog = main.NginxWatchdog(KlangkSettings(env={}))
+        app.state.nginx_watchdog = main.NginxWatchdog(app.state)
         app.state.oidc = oidc.OIDC(app.state)
         app.state.plugins = plugins.Plugins(app.state)
         app.state.workspaces = workspaces.Workspaces(app.state)
@@ -424,7 +424,7 @@ class TestLifespan:
         app.state.container_registry = app_state.container_registry
         app.state.sockets = app_state.sockets
         app.state.settings = app_state.settings
-        app.state.nginx_watchdog = main.NginxWatchdog(KlangkSettings(env={}))
+        app.state.nginx_watchdog = main.NginxWatchdog(app.state)
         app.state.oidc = oidc.OIDC(app.state)
         app.state.plugins = plugins.Plugins(app.state)
         app.state.workspaces = workspaces.Workspaces(app.state)
@@ -554,7 +554,7 @@ class TestStartupShutdownRestart:
     async def test_restart_runtime_runs_shutdown_then_startup(self):
         main._restart_lock = None  # force fresh lock creation
         app_state = _make_app_state()
-        wd = main.NginxWatchdog(KlangkSettings(env={}))
+        wd = main.NginxWatchdog(app_state)
         with (
             patch(
                 "klangk_backend.main.runtime_shutdown", new_callable=AsyncMock
@@ -577,7 +577,7 @@ class TestStartupShutdownRestart:
         main._restart_lock = asyncio.Lock()
         existing = main._restart_lock
         app_state = _make_app_state()
-        wd = main.NginxWatchdog(KlangkSettings(env={}))
+        wd = main.NginxWatchdog(app_state)
         with (
             patch(
                 "klangk_backend.main.runtime_shutdown", new_callable=AsyncMock
@@ -602,7 +602,7 @@ class TestStartupShutdownRestart:
             order.append("up")
 
         app_state = _make_app_state()
-        wd = main.NginxWatchdog(KlangkSettings(env={}))
+        wd = main.NginxWatchdog(app_state)
         with (
             patch(
                 "klangk_backend.main.runtime_shutdown",
@@ -627,7 +627,7 @@ class TestStartupShutdownRestart:
     async def test_on_sighup_schedules_restart(self):
         """on_sighup creates a task that runs restart_runtime."""
         app_state = _make_app_state()
-        wd = main.NginxWatchdog(KlangkSettings(env={}))
+        wd = main.NginxWatchdog(app_state)
         with patch(
             "klangk_backend.main.restart_runtime", new_callable=AsyncMock
         ) as mock_restart:
@@ -648,7 +648,7 @@ class TestStartupShutdownRestart:
         app.state.container_registry = app_state.container_registry
         app.state.sockets = app_state.sockets
         app.state.settings = app_state.settings
-        app.state.nginx_watchdog = main.NginxWatchdog(KlangkSettings(env={}))
+        app.state.nginx_watchdog = main.NginxWatchdog(app.state)
         app.state.oidc = oidc.OIDC(app.state)
         app.state.plugins = plugins.Plugins(app.state)
         app.state.workspaces = workspaces.Workspaces(app.state)

--- a/src/backend/tests/test_nginx.py
+++ b/src/backend/tests/test_nginx.py
@@ -9,17 +9,27 @@ import asyncio
 
 import pytest
 
+import types
+
 from klangk_backend.nginx import (
-    compute_client_max_body_size,
-    compute_container_acls,
-    detect_dns_resolvers,
+    NginxRenderer,
     detect_host_ipv4s,
-    find_nginx_bin,
-    render_config,
     tcp_upstream,
     uds_upstream,
 )
 from klangk_backend.settings import KlangkSettings
+
+
+def _renderer(settings):
+    """Wrap settings in a minimal app_state and build a NginxRenderer (#1469)."""
+    return NginxRenderer(types.SimpleNamespace(settings=settings))
+
+
+def _wd(settings):
+    """Build a NginxWatchdog from settings (wrapped in a minimal app_state)."""
+    from klangk_backend.main import NginxWatchdog
+
+    return NginxWatchdog(types.SimpleNamespace(settings=settings))
 
 
 class TestUpstreams:
@@ -33,19 +43,19 @@ class TestUpstreams:
 class TestClientMaxBodySize:
     def test_default_500mb(self):
         s = KlangkSettings(env={})
-        assert compute_client_max_body_size(s) == "500m"
+        assert _renderer(s).compute_client_max_body_size() == "500m"
 
     def test_custom(self):
         s = KlangkSettings(env={"KLANGK_FILE_UPLOAD_SIZE_MAX": "10485760"})
-        assert compute_client_max_body_size(s) == "10m"
+        assert _renderer(s).compute_client_max_body_size() == "10m"
 
     def test_minimum_1m(self):
         s = KlangkSettings(env={"KLANGK_FILE_UPLOAD_SIZE_MAX": "100"})
-        assert compute_client_max_body_size(s) == "1m"
+        assert _renderer(s).compute_client_max_body_size() == "1m"
 
     def test_garbage_falls_back(self):
         s = KlangkSettings(env={"KLANGK_FILE_UPLOAD_SIZE_MAX": "not-a-number"})
-        assert compute_client_max_body_size(s) == "500m"
+        assert _renderer(s).compute_client_max_body_size() == "500m"
 
 
 class TestContainerAcls:
@@ -53,7 +63,7 @@ class TestContainerAcls:
         s = KlangkSettings(
             env={"KLANGK_CONTAINER_SUBNETS": "10.89.0.0/24,172.30.0.0/16"}
         )
-        acl, deny = compute_container_acls(s)
+        acl, deny = _renderer(s).compute_container_acls()
         assert "allow 10.89.0.0/24;" in acl
         assert "allow 172.30.0.0/16;" in acl
         assert "deny all;" in acl
@@ -67,21 +77,21 @@ class TestContainerAcls:
         s = KlangkSettings(
             env={"KLANGK_CONTAINER_SUBNETS": "127.0.0.1,10.89.0.0/24"}
         )
-        _, deny = compute_container_acls(s)
+        _, deny = _renderer(s).compute_container_acls()
         assert "deny 10.89.0.0/24;" in deny
         assert "deny 127.0.0.1;" not in deny
         assert "allow all;" in deny
 
     def test_all_loopback_warns(self, caplog):
         s = KlangkSettings(env={"KLANGK_CONTAINER_SUBNETS": "127.0.0.1"})
-        _, deny = compute_container_acls(s)
+        _, deny = _renderer(s).compute_container_acls()
         assert "allow all;" in deny
         assert "no non-loopback" in caplog.text
 
     def test_auto_detect_or_fallback(self):
         """Without explicit subnets: either host IPs or fallback RFC1918."""
         s = KlangkSettings(env={})
-        acl, deny = compute_container_acls(s)
+        acl, deny = _renderer(s).compute_container_acls()
         # Must produce *something* (host IPs or fallback).
         assert "deny all;" in acl
         assert "allow all;" in deny
@@ -90,31 +100,31 @@ class TestContainerAcls:
 class TestDnsResolvers:
     def test_explicit_servers(self):
         s = KlangkSettings(env={"KLANGK_DNS_SERVERS": "1.2.3.4,5.6.7.8"})
-        result = detect_dns_resolvers(s)
+        result = _renderer(s).detect_dns_resolvers()
         assert "1.2.3.4" in result
         assert "5.6.7.8" in result
 
     def test_ipv6_bracketed(self):
         s = KlangkSettings(env={"KLANGK_DNS_SERVERS": "::1"})
-        assert "[::1]" in detect_dns_resolvers(s)
+        assert "[::1]" in _renderer(s).detect_dns_resolvers()
 
     def test_empty_tokens_skipped(self):
         """Trailing commas / empty entries in KLANGK_DNS_SERVERS are skipped."""
         s = KlangkSettings(env={"KLANGK_DNS_SERVERS": "1.2.3.4,,5.6.7.8,"})
-        result = detect_dns_resolvers(s)
+        result = _renderer(s).detect_dns_resolvers()
         assert "1.2.3.4" in result
         assert "5.6.7.8" in result
 
     def test_fallback(self):
         s = KlangkSettings(env={})
-        result = detect_dns_resolvers(s)
+        result = _renderer(s).detect_dns_resolvers()
         assert len(result) > 0  # from resolv.conf or 8.8.8.8
 
 
 class TestRenderConfig:
     def test_basic_structure(self):
         s = KlangkSettings(env={"KLANGK_NGINX_PORT": "8995"})
-        conf = render_config(tcp_upstream("127.0.0.1", "8997"), s)
+        conf = _renderer(s).render_config(tcp_upstream("127.0.0.1", "8997"))
         assert "daemon off;" in conf
         assert "listen 8995;" in conf
         assert "proxy_pass http://127.0.0.1:8997" in conf
@@ -125,19 +135,19 @@ class TestRenderConfig:
 
     def test_uds_upstream_in_conf(self):
         s = KlangkSettings(env={"KLANGK_NGINX_PORT": "8995"})
-        conf = render_config(uds_upstream("/tmp/klangk.sock"), s)
+        conf = _renderer(s).render_config(uds_upstream("/tmp/klangk.sock"))
         assert "proxy_pass http://unix:/tmp/klangk.sock:" in conf
 
     def test_no_llm_block_without_url(self):
         s = KlangkSettings(env={})
-        conf = render_config(tcp_upstream("127.0.0.1", "8997"), s)
+        conf = _renderer(s).render_config(tcp_upstream("127.0.0.1", "8997"))
         assert "llm-proxy" not in conf
 
     def test_llm_block_with_url(self):
         s = KlangkSettings(
             env={"KLANGK_LLM_BASE_URL": "http://127.0.0.1:11434"}
         )
-        conf = render_config(tcp_upstream("127.0.0.1", "8997"), s)
+        conf = _renderer(s).render_config(tcp_upstream("127.0.0.1", "8997"))
         assert "llm-proxy" in conf
 
     def test_llm_api_key_resolved(self):
@@ -147,13 +157,13 @@ class TestRenderConfig:
                 "KLANGK_LLM_API_KEY": "cmd:printf %s resolved-key",
             }
         )
-        conf = render_config(tcp_upstream("127.0.0.1", "8997"), s)
+        conf = _renderer(s).render_config(tcp_upstream("127.0.0.1", "8997"))
         assert 'Authorization "Bearer resolved-key"' in conf
         assert "cmd:" not in conf
 
     def test_auth_local_loopback_acl(self):
         s = KlangkSettings(env={})
-        conf = render_config(tcp_upstream("127.0.0.1", "8997"), s)
+        conf = _renderer(s).render_config(tcp_upstream("127.0.0.1", "8997"))
         # Find the auth/local block.
         import re
 
@@ -168,25 +178,25 @@ class TestRenderConfig:
 
     def test_hosted_disabled(self):
         s = KlangkSettings(env={"KLANGK_HOSTED_PORTS_PER_WORKSPACE": "0"})
-        conf = render_config(tcp_upstream("127.0.0.1", "8997"), s)
+        conf = _renderer(s).render_config(tcp_upstream("127.0.0.1", "8997"))
         assert "location ^~ /hosted/ {" in conf
         assert "return 404;" in conf
 
     def test_hosted_enabled_default(self):
         s = KlangkSettings(env={})
-        conf = render_config(tcp_upstream("127.0.0.1", "8997"), s)
+        conf = _renderer(s).render_config(tcp_upstream("127.0.0.1", "8997"))
         assert "location ~ ^/hosted/[^/]+/(?<hosted_port>" in conf
 
     def test_trust_outer_proxy(self):
         s = KlangkSettings(env={"KLANGK_TRUST_OUTER_PROXY": "1"})
-        conf = render_config(tcp_upstream("127.0.0.1", "8997"), s)
+        conf = _renderer(s).render_config(tcp_upstream("127.0.0.1", "8997"))
         # When trusting outer proxy, X-Forwarded-* come from client headers.
         assert "http_x_forwarded_proto" in conf
         assert "http_x_forwarded_host" in conf
 
     def test_no_trust_outer_proxy(self):
         s = KlangkSettings(env={})
-        conf = render_config(tcp_upstream("127.0.0.1", "8997"), s)
+        conf = _renderer(s).render_config(tcp_upstream("127.0.0.1", "8997"))
         # Default: X-Forwarded-* derived from trusted values.
         assert "proxy_set_header X-Forwarded-Proto $scheme;" in conf
         assert "proxy_set_header X-Forwarded-Host $http_host;" in conf
@@ -201,7 +211,7 @@ class TestRenderConfig:
                 "KLANGK_LLM_API_KEY": f"file:{secret}",
             }
         )
-        conf = render_config(tcp_upstream("127.0.0.1", "8997"), s)
+        conf = _renderer(s).render_config(tcp_upstream("127.0.0.1", "8997"))
         assert 'Authorization "Bearer file-based-key"' in conf
 
 
@@ -223,7 +233,7 @@ class TestMinimalTemplate:
                 "KLANGK_NGINX_PORT": "8995",
             }
         )
-        conf = render_config(uds_upstream("/tmp/klangk.sock"), s)
+        conf = _renderer(s).render_config(uds_upstream("/tmp/klangk.sock"))
         # /llm-proxy container-egress location is present, token-gated.
         assert "location ~ ^/llm-proxy/" in conf
         assert "auth_request /api/v1/auth/verify-workspace-token;" in conf
@@ -247,7 +257,7 @@ class TestMinimalTemplate:
                 "KLANGK_NGINX_PORT": "8995",
             }
         )
-        conf = render_config(uds_upstream("/tmp/klangk.sock"), s)
+        conf = _renderer(s).render_config(uds_upstream("/tmp/klangk.sock"))
         assert "location ~ ^/llm-proxy/" not in conf
         assert "verify-workspace-token" not in conf
         assert "@token_auth_failed" not in conf
@@ -265,7 +275,7 @@ class TestMinimalTemplate:
                 "KLANGK_NGINX_PORT": "8995",
             }
         )
-        conf = render_config(uds_upstream("/tmp/klangk.sock"), s)
+        conf = _renderer(s).render_config(uds_upstream("/tmp/klangk.sock"))
         # Exactly one listen directive — the container-egress nginx_port.
         assert conf.count("\n    listen ") == 1
         assert "listen 8995;" in conf
@@ -277,7 +287,7 @@ class TestMinimalTemplate:
         s = KlangkSettings(
             env={"KLANGK_LISTEN": "127.0.0.1", "KLANGK_NGINX_PORT": "8995"}
         )
-        conf = render_config(tcp_upstream("127.0.0.1", "8997"), s)
+        conf = _renderer(s).render_config(tcp_upstream("127.0.0.1", "8997"))
         assert "location / {" in conf
         assert "/api/v1/browser-delegate" in conf
         assert "/api/v1/auth/local" in conf
@@ -295,7 +305,9 @@ class TestMinimalTemplate:
                     "KLANGK_NGINX_PORT": "8995",
                 }
             )
-            minimal = render_config(uds_upstream("/tmp/klangk.sock"), s_sock)
+            minimal = _renderer(s_sock).render_config(
+                uds_upstream("/tmp/klangk.sock")
+            )
             assert "location / {" not in minimal
             assert "location ~ ^/llm-proxy/" in minimal
 
@@ -306,18 +318,20 @@ class TestMinimalTemplate:
                     "KLANGK_NGINX_PORT": "8995",
                 }
             )
-            full = render_config(tcp_upstream("127.0.0.1", "8997"), s_tcp)
+            full = _renderer(s_tcp).render_config(
+                tcp_upstream("127.0.0.1", "8997")
+            )
             assert "location / {" in full
 
 
 class TestFindNginxBin:
     def test_configured(self):
         s = KlangkSettings(env={"KLANGK_NGINX_BIN": "/custom/nginx"})
-        assert find_nginx_bin(s) == "/custom/nginx"
+        assert _renderer(s).find_nginx_bin() == "/custom/nginx"
 
     def test_fallback_to_which(self):
         s = KlangkSettings(env={})
-        result = find_nginx_bin(s)
+        result = _renderer(s).find_nginx_bin()
         # Either found on PATH or falls back to /usr/sbin/nginx.
         assert len(result) > 0
 
@@ -327,7 +341,7 @@ class TestFindNginxBin:
 
         s = KlangkSettings(env={})
         monkeypatch.setattr(nginx_mod.shutil, "which", lambda _: None)
-        assert find_nginx_bin(s) == "/usr/sbin/nginx"
+        assert _renderer(s).find_nginx_bin() == "/usr/sbin/nginx"
 
 
 class TestDetectHostIPv4s:
@@ -354,7 +368,7 @@ class TestDnsResolversFromResolvConf:
             "read_text",
             lambda self: content,
         )
-        result = detect_dns_resolvers(s)
+        result = _renderer(s).detect_dns_resolvers()
         assert "1.1.1.1" in result
         assert "[::1]" in result
 
@@ -368,7 +382,7 @@ class TestDnsResolversFromResolvConf:
             raise OSError("no resolv.conf")
 
         monkeypatch.setattr(nginx_mod.Path, "read_text", _raise)
-        assert detect_dns_resolvers(s) == "8.8.8.8"
+        assert _renderer(s).detect_dns_resolvers() == "8.8.8.8"
 
 
 class TestContainerAclFallback:
@@ -378,7 +392,7 @@ class TestContainerAclFallback:
 
         s = KlangkSettings(env={})
         monkeypatch.setattr(nginx_mod, "detect_host_ipv4s", lambda: [])
-        acl, deny = compute_container_acls(s)
+        acl, deny = _renderer(s).compute_container_acls()
         assert "allow 172.16.0.0/12;" in acl
         assert "allow 10.0.0.0/8;" in acl
         assert "deny 172.16.0.0/12;" in deny
@@ -388,11 +402,10 @@ class TestContainerAclFallback:
 class TestWriteConfig:
     def test_writes_file(self, tmp_path):
         s = KlangkSettings(env={"KLANGK_NGINX_PORT": "8995"})
+        r = _renderer(s)
         conf_path = tmp_path / "nginx.conf"
-        text = render_config(tcp_upstream("127.0.0.1", "8997"), s)
-        from klangk_backend.nginx import write_config
-
-        written = write_config(tcp_upstream("127.0.0.1", "8997"), conf_path, s)
+        text = r.render_config(tcp_upstream("127.0.0.1", "8997"))
+        written = r.write_config(tcp_upstream("127.0.0.1", "8997"), conf_path)
         assert conf_path.read_text() == text
         assert written == text
 
@@ -435,10 +448,9 @@ class TestWatchdogGate:
     @pytest.mark.asyncio
     async def test_start_noop_when_disabled(self, monkeypatch):
         """No-op when the test-only _KLANGK_DISABLE_NGINX is set."""
-        from klangk_backend.main import NginxWatchdog
 
         monkeypatch.setenv("_KLANGK_DISABLE_NGINX", "1")
-        wd = NginxWatchdog(KlangkSettings(env={}))
+        wd = _wd(KlangkSettings(env={}))
         await wd.start()
         assert wd._task is None
 
@@ -462,7 +474,8 @@ class TestWatchdogGate:
         )
         monkeypatch.delenv("_KLANGK_DISABLE_NGINX", raising=False)
         monkeypatch.setattr(
-            "klangk_backend.nginx.find_nginx_bin", lambda *a: "/fake/nginx"
+            "klangk_backend.nginx.NginxRenderer.find_nginx_bin",
+            lambda self: "/fake/nginx",
         )
 
         spawned = {}
@@ -472,7 +485,7 @@ class TestWatchdogGate:
             spawned["conf"] = conf_path
 
         monkeypatch.setattr(NginxWatchdog, "_watch", _fake_watch)
-        wd = NginxWatchdog(s)
+        wd = _wd(s)
         await wd.start()
         try:
             assert wd._task is not None
@@ -491,7 +504,6 @@ class TestPrepareNginx:
     """NginxWatchdog._prepare() renders nginx.conf with UDS upstream (#1400)."""
 
     def test_renders_config_and_returns_paths(self, monkeypatch, tmp_path):
-        from klangk_backend.main import NginxWatchdog
 
         s = KlangkSettings(
             env={
@@ -501,9 +513,10 @@ class TestPrepareNginx:
             }
         )
         monkeypatch.setattr(
-            "klangk_backend.nginx.find_nginx_bin", lambda *a: "/fake/nginx"
+            "klangk_backend.nginx.NginxRenderer.find_nginx_bin",
+            lambda self: "/fake/nginx",
         )
-        wd = NginxWatchdog(s)
+        wd = _wd(s)
         bin_path, conf_path = wd._prepare()
         assert bin_path == "/fake/nginx"
         assert conf_path == str(tmp_path / "nginx.conf")
@@ -519,9 +532,8 @@ class TestStopWatchdog:
     @pytest.mark.asyncio
     async def test_stops_no_proc_no_task(self):
         """Nothing spawned: just clears state (the no-op path)."""
-        from klangk_backend.main import NginxWatchdog
 
-        wd = NginxWatchdog(KlangkSettings(env={}))
+        wd = _wd(KlangkSettings(env={}))
         await wd.stop()
         assert wd._proc is None
         assert wd._task is None
@@ -530,7 +542,6 @@ class TestStopWatchdog:
     @pytest.mark.asyncio
     async def test_stops_terminates_running_proc(self):
         """A still-running nginx proc is terminated, then awaited."""
-        from klangk_backend.main import NginxWatchdog
 
         terminated = []
 
@@ -546,7 +557,7 @@ class TestStopWatchdog:
             async def wait(self):
                 return 0
 
-        wd = NginxWatchdog(KlangkSettings(env={}))
+        wd = _wd(KlangkSettings(env={}))
         wd._proc = FakeProc()
         await wd.stop()
         assert terminated == [True]
@@ -555,7 +566,6 @@ class TestStopWatchdog:
     @pytest.mark.asyncio
     async def test_stops_cancels_task(self):
         """A watchdog task is cancelled and awaited. Covers the task branch."""
-        from klangk_backend.main import NginxWatchdog
 
         async def _long_running():
             try:
@@ -563,7 +573,7 @@ class TestStopWatchdog:
             except asyncio.CancelledError:
                 raise
 
-        wd = NginxWatchdog(KlangkSettings(env={}))
+        wd = _wd(KlangkSettings(env={}))
         wd._task = asyncio.create_task(_long_running())
         await wd.stop()
         assert wd._task is None
@@ -572,7 +582,6 @@ class TestStopWatchdog:
     async def test_stops_kills_on_timeout(self, monkeypatch):
         """If the proc doesn't exit within the timeout, kill() follows."""
         import klangk_backend.main as main
-        from klangk_backend.main import NginxWatchdog
 
         actions = []
 
@@ -594,7 +603,7 @@ class TestStopWatchdog:
             raise asyncio.TimeoutError()
 
         monkeypatch.setattr(main.asyncio, "wait_for", _fake_wait_for)
-        wd = NginxWatchdog(KlangkSettings(env={}))
+        wd = _wd(KlangkSettings(env={}))
         wd._proc = HungProc()
         await wd.stop()
         assert actions == ["terminate", "kill"]

--- a/src/frontend/e2e-tests/global-setup.ts
+++ b/src/frontend/e2e-tests/global-setup.ts
@@ -99,8 +99,10 @@ async function globalSetup() {
       KLANGK_PORT: backendPort,
     };
     execSync(
-      `python -c "from klangk_backend.nginx import write_config, tcp_upstream; ` +
-        `write_config(tcp_upstream('127.0.0.1', '${backendPort}'), '${confPath}')"`,
+      `python -c "from klangk_backend.nginx import NginxRenderer, tcp_upstream; ` +
+        `from klangk_backend.settings import get_settings; import types; ` +
+        `NginxRenderer(types.SimpleNamespace(settings=get_settings()))` +
+        `.write_config(tcp_upstream('127.0.0.1', '${backendPort}'), '${confPath}')"`,
       {
         cwd: join(projectRoot, "src", "backend"),
         env: renderEnv,


### PR DESCRIPTION
Part of #1426 (composition-root refactor). Closes #1469.

## What

Moves the 11 settings-driven module-level functions in `nginx.py` onto a
**`NginxRenderer(app_state)`** class, and converts **`NginxWatchdog`** from
`NginxWatchdog(settings)` to **`NginxWatchdog(app_state)`**. The watchdog
owns a `NginxRenderer` instance and delegates rendering to it.

This matches the uniform `X(app_state)` composition-root pattern:
`OIDC(app_state)` #1450, `Plugins(app_state)` #1451, `NginxWatchdog(app_state)`
#1463, `Terminal(app_state)` #1480, `Workspaces(app_state)` #1484,
`Agents(app_state)` #1486, `ContainerRegistry(app_state)` #1487,
`EmailService(app_state)` #1483. (`DB(settings)` #1452 is the deliberate
exception.)

## Design decision: subobject, not merge

The issue offered two options: (1) a standalone `NginxRenderer(app_state)`
subobject composed by `NginxWatchdog`, or (2) folding the renderer methods
directly onto `NginxWatchdog`. I chose **option 1 (subobject)** because:

- **Matches the composition pattern** — `ContainerRegistry` composes
  `PortAllocator`/`BrowserRouter`/`IdleMonitor`/`HealthMonitor` rather than
  merging them; `NginxWatchdog` composing `NginxRenderer` is the same shape.
- **Separation of concerns** — rendering (pure config templating, ~500 lines)
  vs supervision (spawn/respawn/stop) are different responsibilities; merging
  would bloat `NginxWatchdog` to ~700 lines doing two things.
- **Test ergonomics** — rendering tests construct `NginxRenderer(app_state)`
  directly without needing to build a watchdog; supervision tests construct
  `NginxWatchdog(app_state)` which creates its own renderer internally.
- **File layout preserved** — rendering stays in `nginx.py`, supervision stays
  in `main.py`; no 500-line move between files.

## Changes

### `nginx.py`

- **`NginxRenderer(app_state)`** class with `self._settings = app_state.settings`.
  The 11 settings-taking functions become methods (drop the `settings` param,
  use `self._settings`):
  `render_config`, `write_config`, `find_nginx_bin`, `detect_dns_resolvers`,
  `compute_container_acls`, `compute_client_max_body_size`,
  `_build_hosted_block`, `_build_llm_block`, `_trust_outer_proxy`,
  `_render_minimal_config`, `_render_full_config`.
- **Pure helpers stay module-level** (don't read settings): `tcp_upstream`,
  `uds_upstream`, `detect_host_ipv4s`, `_minimal_auth_locations`,
  `_is_loopback`, and the constants `_LOOPBACK_NETS`, `_FALLBACK_*_SUBNETS`.
- No `settings=None` fallbacks / `get_settings()` in the renderer — all callers
  pass `app_state` (or construct a renderer from `get_settings()` in e2e).

### `main.py`

- `NginxWatchdog.__init__(self, app_state)` — stores `self._settings =
  app_state.settings` and `self._renderer = NginxRenderer(app_state)`.
- `_prepare` calls `self._renderer.find_nginx_bin()` and
  `self._renderer.write_config(...)` instead of `nginx_mod.find_nginx_bin(self._settings)`.
- `build_app`: `NginxWatchdog(app.state)` (was `NginxWatchdog(settings)`).

### Callers migrated

| file | change |
| --- | --- |
| `test_nginx.py` | renderer tests use `_renderer(s)` helper; watchdog tests use `_wd(s)` helper; monkeypatch target → `NginxRenderer.find_nginx_bin` |
| `test_main.py` | 7 `NginxWatchdog(settings)` → `NginxWatchdog(app.state)` / `NginxWatchdog(app_state)` |
| `test_nginx_acl_e2e.py` | 4 `render_config`/`write_config` calls → `NginxRenderer(SimpleNamespace(settings=get_settings())).method()` |
| `frontend/e2e-tests/global-setup.ts` | Python one-liner → `NginxRenderer(...).write_config(...)` (also fixes pre-existing 2-arg call that was missing settings) |

## Test results

- **2380 backend tests pass, 100% coverage** (`nginx.py`: 147 stmts, 0 missed).
- E2E callers (`test_nginx_acl_e2e.py`, `global-setup.ts`) migrated; verified
  by CI's "E2E: Backend Tests" and "E2E: Frontend Tests" jobs.
