### PR TITLE
Promote auth.py to Auth(app_state); kill import-time + call-time env reads (#1501)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -79,6 +79,18 @@ operators or integrators to act when upgrading.
   call time. The module globals `_REJECT_PROXY`, `_TRUSTED_PROXY_CIDRS`, and
   `_UDS_MODE` are gone. `klangkd` arms UDS trust via
   `app.state.util.set_uds_mode(True)` after `build_app` (#1503, #1426).
+- **Auth config is instance-owned on `Auth(app_state)`:** `auth.py` no longer
+  reads config at import time. The module globals (`SECRET_KEY`,
+  `ALGORITHM`, `TOKEN_EXPIRE_HOURS`, `MIN_PASSWORD_LENGTH`, `LOGIN_LOCKOUT_*`,
+  `INVITE_TOKEN_EXPIRE_HOURS`, `WORKSPACE_TOKEN_EXPIRE_HOURS`) and the
+  call-time `resolve_env_value` reads are gone; each is an instance attr or
+  method reading `self.settings`. Token create/decode, register/login/
+  refresh/logout, `registration_enabled`/`invitations_enabled`, and
+  `require_secure_jwt_secret` are methods on `Auth`, reached via
+  `app.state.auth.*`. Pure helpers (password hashing, email validation, the
+  lockout predicate) and the FastAPI dependency callables stay module-level.
+  `_INSECURE_DEFAULT_SECRET` consolidated into `settings.INSECURE_DEFAULT_SECRET`
+  (#1501, #1426).
 
 ### Removed
 

--- a/src/backend/klangk_backend/api/__init__.py
+++ b/src/backend/klangk_backend/api/__init__.py
@@ -54,7 +54,7 @@ from ._common import get_app_state_dep
 # name to the logic module after the submodule imports (see below) so the
 # instance endpoints reference klangk_backend.auth, not the route module.
 from .. import auth as _auth_logic
-from ..util import resolve_env_bool, resolve_env_value
+from ..util import resolve_env_value
 
 # Route submodules, aliased because their names collide with the logic
 # modules imported above (api/auth.py vs klangk_backend.auth, etc.) and we
@@ -158,9 +158,12 @@ if resolve_env_value("KLANGK_TEST_MODE"):  # pragma: no cover
         return {"idle_timeout_seconds": seconds}
 
     @router.get("/test/workspace-token/{workspace_id}")
-    async def get_workspace_token(workspace_id: str):
+    async def get_workspace_token(
+        workspace_id: str,
+        app_state=Depends(get_app_state_dep),
+    ):
         """Return a workspace JWT for testing (test only)."""
-        return {"token": auth.create_workspace_token(workspace_id)}
+        return {"token": app_state.auth.create_workspace_token(workspace_id)}
 
     @router.get("/test/browsers/{workspace_id}")
     async def get_browsers(
@@ -204,8 +207,8 @@ SUPPORT_EMAIL = resolve_env_value("KLANGK_SUPPORT_EMAIL") or ""
 @router.get("/config")
 async def get_config(app_state=Depends(get_app_state_dep)):
     config = {
-        "registration_enabled": auth.registration_enabled(),
-        "invitations_enabled": auth.invitations_enabled(),
+        "registration_enabled": app_state.auth.registration_enabled(),
+        "invitations_enabled": app_state.auth.invitations_enabled(),
         # White-label product name (KLANGK_PRODUCT_NAME). Surfaced so the
         # frontend can rename the product (tab title, app-bar logo) without
         # a rebuild; defaults to "Klangk" for back-compat (#1149).
@@ -218,14 +221,17 @@ async def get_config(app_state=Depends(get_app_state_dep)):
         # Whether per-workspace auto-start (start the container on server
         # boot) is permitted. The web UI gates its "Auto start" checkbox on
         # this so users can't toggle a setting the server will reject (#1115).
-        "allow_autostart": resolve_env_bool("KLANGK_ALLOW_AUTOSTART"),
+        "allow_autostart": (app_state.settings.allow_autostart or "")
+        .strip()
+        .lower()
+        in ("1", "true", "yes"),
         # Surfaced so the UI can validate password length inline (matches
         # the rule enforced server-side by auth.validate_password_length).
-        "min_password_length": auth.MIN_PASSWORD_LENGTH,
+        "min_password_length": app_state.auth.min_password_length,
         # Deployer logo override (KLANGK_LOGO_URL). Empty when unset, in
         # which case the frontend renders the default KlangkLogo widget.
         # Supports file:/cmd: resolution like other secrets. See #1152.
-        "logo_url": resolve_env_value("KLANGK_LOGO_URL") or "",
+        "logo_url": app_state.settings.logo_url or "",
         # Configurable legal & support links (#1177). Plain env values (no
         # file:/cmd: resolution -- they are public, shown pre-auth). Empty
         # string when unset; the frontend hides whatever isn't configured.

--- a/src/backend/klangk_backend/api/_common.py
+++ b/src/backend/klangk_backend/api/_common.py
@@ -57,8 +57,8 @@ async def require_workspace_token(request: Request) -> str:
     if not authorization.startswith("Bearer "):
         raise HTTPException(status_code=401, detail="Missing workspace token")
     token = authorization[7:]
-    result = auth.decode_workspace_token(token)
-    if result is auth.WORKSPACE_TOKEN_EXPIRED:
+    result = request.app.state.auth.decode_workspace_token(token)
+    if result is auth.Auth.WORKSPACE_TOKEN_EXPIRED:
         raise HTTPException(status_code=401, detail="Workspace token expired")
     if result is None:
         raise HTTPException(status_code=401, detail="Invalid workspace token")

--- a/src/backend/klangk_backend/api/admin.py
+++ b/src/backend/klangk_backend/api/admin.py
@@ -49,7 +49,7 @@ async def send_invitation(
     app_state=Depends(get_app_state_dep),
 ):
     """Send an invitation email (admin only)."""
-    if not auth.invitations_enabled():
+    if not app_state.auth.invitations_enabled():
         raise HTTPException(status_code=403, detail="Invitations are disabled")
 
     auth.validate_email(req.email)
@@ -68,7 +68,7 @@ async def send_invitation(
         )
 
     invitation = await model.create_invitation(req.email, admin["id"])
-    token = auth.create_invitation_token(invitation["id"], req.email)
+    token = app_state.auth.create_invitation_token(invitation["id"], req.email)
 
     hostname, proto, base_path = request.app.state.util.derive_hosting_info(
         request.headers, request.client.host if request.client else None
@@ -143,7 +143,9 @@ async def resend_invitation(
             detail="Invitation not found or not pending",
         )
 
-    token = auth.create_invitation_token(invitation["id"], invitation["email"])
+    token = app_state.auth.create_invitation_token(
+        invitation["id"], invitation["email"]
+    )
     hostname, proto, base_path = request.app.state.util.derive_hosting_info(
         request.headers, request.client.host if request.client else None
     )
@@ -213,7 +215,7 @@ async def admin_create_user(
                 request.client.host if request.client else None,
             )
         )
-        verification_token = auth.create_verification_token(user_id)
+        verification_token = app_state.auth.create_verification_token(user_id)
         verification_url = (
             f"{proto}://{hostname}{base_path}"
             f"/#/verify?token={verification_token}"
@@ -242,7 +244,7 @@ async def admin_create_user(
             status_code=400,
             detail="Password is required when not sending verification email",
         )
-    auth.validate_password_length(req.password)
+    app_state.auth.validate_password_length(req.password)
     password_hash = auth.hash_password(req.password)
     user = await model.create_user(req.email, password_hash, verified=True)
     return {"id": user["id"], "email": user["email"], "status": "created"}
@@ -310,7 +312,7 @@ async def update_user(
     if req.email is not None:
         await model.update_email(user_id, req.email)
     if req.password is not None:
-        auth.validate_password_length(req.password)
+        app_state.auth.validate_password_length(req.password)
         password_hash = auth.hash_password(req.password)
         await model.update_password(user_id, password_hash)
     if req.handle is not None:

--- a/src/backend/klangk_backend/api/auth.py
+++ b/src/backend/klangk_backend/api/auth.py
@@ -21,7 +21,6 @@ from .. import (
     wshandler,
 )
 from ._common import get_app_state_dep
-from ..util import resolve_env_value
 from ._common import (
     send_email,
 )
@@ -43,8 +42,8 @@ async def verify_workspace_token(request: Request):
             headers={"X-Token-Error": "missing"},
         )
     token = authorization[7:]
-    result = auth.decode_workspace_token(token)
-    if result is auth.WORKSPACE_TOKEN_EXPIRED:
+    result = request.app.state.auth.decode_workspace_token(token)
+    if result is auth.Auth.WORKSPACE_TOKEN_EXPIRED:
         return JSONResponse(
             status_code=401,
             content={"detail": "Workspace token expired"},
@@ -70,9 +69,9 @@ async def register(
             status_code=403,
             detail="Password registration is disabled",
         )
-    if resolve_env_value("KLANGK_TEST_MODE"):
+    if request.app.state.settings.test_mode:
         # Test mode: auto-verify so E2E tests get immediate access
-        result = await auth.register(req, verified=True)
+        result = await request.app.state.auth.register(req, verified=True)
         return result
 
     logger.info("Registering user: %s", req.email)
@@ -80,7 +79,7 @@ async def register(
     existing = await model.get_user_by_email(req.email)
     if existing is not None:
         raise HTTPException(status_code=400, detail="Registration failed")
-    auth.validate_password_length(req.password)
+    request.app.state.auth.validate_password_length(req.password)
 
     password_hash = auth.hash_password(req.password)
     user_id = str(uuid.uuid4())
@@ -94,7 +93,9 @@ async def register(
         proto,
         base_path,
     )
-    verification_token = auth.create_verification_token(user_id)
+    verification_token = request.app.state.auth.create_verification_token(
+        user_id
+    )
     verification_url = (
         f"{proto}://{hostname}{base_path}/#/verify?token={verification_token}"
     )
@@ -125,9 +126,9 @@ async def register(
 
 
 @router.get("/auth/verify")
-async def verify_email(token: str):
+async def verify_email(token: str, request: Request):
     """Verify a user's email via the token from the verification link."""
-    user_id = auth.decode_verification_token(token)
+    user_id = request.app.state.auth.decode_verification_token(token)
     if user_id is None:
         raise HTTPException(
             status_code=400, detail="Invalid or expired verification token"
@@ -136,7 +137,7 @@ async def verify_email(token: str):
     if not updated:
         raise HTTPException(status_code=404, detail="User not found")
     user = await model.get_user_by_id(user_id)
-    access_token = auth.create_token(user_id, user["email"])
+    access_token = request.app.state.auth.create_token(user_id, user["email"])
     return {"status": "verified", "access_token": access_token}
 
 
@@ -194,7 +195,9 @@ async def resend_verification(
     hostname, proto, base_path = request.app.state.util.derive_hosting_info(
         request.headers, request.client.host if request.client else None
     )
-    verification_token = auth.create_verification_token(user["id"])
+    verification_token = request.app.state.auth.create_verification_token(
+        user["id"]
+    )
     verification_url = (
         f"{proto}://{hostname}{base_path}/#/verify?token={verification_token}"
     )
@@ -206,7 +209,7 @@ async def resend_verification(
     return {"status": "sent"}
 
 
-class ForgotPasswordRequest(auth.BaseModel):
+class ForgotPasswordRequest(BaseModel):
     email: str
 
 
@@ -240,7 +243,9 @@ async def forgot_password(
     hostname, proto, base_path = request.app.state.util.derive_hosting_info(
         request.headers, request.client.host if request.client else None
     )
-    reset_token = auth.create_password_reset_token(user["id"])
+    reset_token = request.app.state.auth.create_password_reset_token(
+        user["id"]
+    )
     reset_url = (
         f"{proto}://{hostname}{base_path}/#/reset-password?token={reset_token}"
     )
@@ -252,20 +257,20 @@ async def forgot_password(
     return {"status": "sent"}
 
 
-class ResetPasswordRequest(auth.BaseModel):
+class ResetPasswordRequest(BaseModel):
     token: str
     password: str
 
 
 @router.post("/auth/reset-password")
-async def reset_password(req: ResetPasswordRequest):
+async def reset_password(req: ResetPasswordRequest, request: Request):
     """Reset password using a token from the reset email."""
-    user_id = auth.decode_password_reset_token(req.token)
+    user_id = request.app.state.auth.decode_password_reset_token(req.token)
     if user_id is None:
         raise HTTPException(
             status_code=400, detail="Invalid or expired reset token"
         )
-    auth.validate_password_length(req.password)
+    request.app.state.auth.validate_password_length(req.password)
     if user_id == model.AGENT_USER_ID:
         raise HTTPException(
             status_code=400,
@@ -277,7 +282,7 @@ async def reset_password(req: ResetPasswordRequest):
     user = await model.get_user_by_id(user_id)
     if user is None:  # pragma: no cover
         raise HTTPException(status_code=404, detail="User not found")
-    token = auth.create_token(user_id, user["email"])
+    token = request.app.state.auth.create_token(user_id, user["email"])
     return {"status": "reset", "access_token": token}
 
 
@@ -290,10 +295,10 @@ async def login(
         raise HTTPException(
             status_code=403, detail="Password login is disabled"
         )
-    return await auth.login(req)
+    return await request.app.state.auth.login(req)
 
 
-class LocalLoginResponse(auth.BaseModel):
+class LocalLoginResponse(BaseModel):
     access_token: str
     token_type: str = "bearer"
     email: str
@@ -330,7 +335,7 @@ async def local_login(request: Request):
             status_code=403,
             detail="Local login requires a loopback client",
         )
-    email = resolve_env_value("KLANGK_DEFAULT_USER", "admin@example.com")
+    email = request.app.state.settings.default_user
     user = await model.get_user_by_email(email)
     if user is None:
         # seed_default_user() runs in the lifespan before the app serves
@@ -339,7 +344,7 @@ async def local_login(request: Request):
             status_code=500,
             detail="Default user is not seeded",
         )
-    token = auth.create_token(user["id"], user["email"])
+    token = request.app.state.auth.create_token(user["id"], user["email"])
     return LocalLoginResponse(access_token=token, email=user["email"])
 
 
@@ -350,10 +355,10 @@ async def refresh_token(request: Request):
     if not authorization.startswith("Bearer "):
         raise HTTPException(status_code=401, detail="Not authenticated")
     token = authorization[7:]
-    return await auth.refresh_token(token)
+    return await request.app.state.auth.refresh_token(token)
 
 
-class ChangePasswordRequest(auth.BaseModel):
+class ChangePasswordRequest(BaseModel):
     current_password: str
     new_password: str
 
@@ -361,6 +366,7 @@ class ChangePasswordRequest(auth.BaseModel):
 @router.post("/auth/change-password")
 async def change_password(
     req: ChangePasswordRequest,
+    request: Request,
     user: dict = Depends(auth.get_current_user),
 ):
     """Change password. Requires current password."""
@@ -378,13 +384,13 @@ async def change_password(
         raise HTTPException(
             status_code=401, detail="Current password is incorrect"
         )
-    auth.validate_password_length(req.new_password)
+    request.app.state.auth.validate_password_length(req.new_password)
     password_hash = auth.hash_password(req.new_password)
     await model.update_password(user["id"], password_hash)
     return {"status": "updated"}
 
 
-class ChangeEmailRequest(auth.BaseModel):
+class ChangeEmailRequest(BaseModel):
     email: str
     password: str
 
@@ -424,7 +430,7 @@ async def change_email(
     hostname, proto, base_path = request.app.state.util.derive_hosting_info(
         request.headers, request.client.host if request.client else None
     )
-    token = auth.create_verification_token(user["id"])
+    token = request.app.state.auth.create_verification_token(user["id"])
     url = f"{proto}://{hostname}{base_path}/#/verify?token={token}"
     await send_email(
         app_state.email.send_verification_email(req.email, url),
@@ -434,7 +440,7 @@ async def change_email(
     return {"status": "updated", "needs_verification": True}
 
 
-class ChangeHandleRequest(auth.BaseModel):
+class ChangeHandleRequest(BaseModel):
     handle: str
     password: str
 
@@ -491,7 +497,7 @@ async def logout(
     # Blocklist the token so it can't be reused after logout
     authorization = request.headers.get("authorization", "")
     if authorization.startswith("Bearer "):
-        await auth.logout(authorization[7:])
+        await request.app.state.auth.logout(authorization[7:])
 
     # If the user logged in via OIDC and the provider has logout_redirect
     # enabled, return the IdP logout URL so the frontend can redirect.
@@ -524,9 +530,9 @@ class AcceptInviteRequest(BaseModel):
 
 
 @router.post("/auth/accept-invite")
-async def accept_invite(req: AcceptInviteRequest):
+async def accept_invite(req: AcceptInviteRequest, request: Request):
     """Accept an invitation and create a verified account."""
-    result = auth.decode_invitation_token(req.token)
+    result = request.app.state.auth.decode_invitation_token(req.token)
     if result is None:
         raise HTTPException(
             status_code=400, detail="Invalid or expired invitation token"
@@ -539,7 +545,7 @@ async def accept_invite(req: AcceptInviteRequest):
             status_code=400, detail="Invitation is no longer valid"
         )
 
-    auth.validate_password_length(req.password)
+    request.app.state.auth.validate_password_length(req.password)
 
     existing = await model.get_user_by_email(email)
     if existing is not None:
@@ -551,5 +557,7 @@ async def accept_invite(req: AcceptInviteRequest):
     user = await model.create_user(email, password_hash, verified=True)
     await model.mark_invitation_accepted(invitation_id)
 
-    access_token = auth.create_token(user["id"], user["email"])
+    access_token = request.app.state.auth.create_token(
+        user["id"], user["email"]
+    )
     return {"status": "accepted", "access_token": access_token}

--- a/src/backend/klangk_backend/api/oidc_auth.py
+++ b/src/backend/klangk_backend/api/oidc_auth.py
@@ -280,7 +280,7 @@ async def oidc_callback(
     if hook_groups is not None:
         await oidc.sync_oidc_groups(user["id"], hook_groups)
 
-    access_token = auth.create_token(user["id"], email)
+    access_token = request.app.state.auth.create_token(user["id"], email)
     return _build_redirect_response(
         request, provider_id, access_token, cookie_data
     )

--- a/src/backend/klangk_backend/auth.py
+++ b/src/backend/klangk_backend/auth.py
@@ -1,28 +1,40 @@
+"""Authentication: password hashing, JWT tokens, login/register/refresh.
+
+Stateful/config-reading auth lives on :class:`Auth`, an ``app.state``-owned
+instance constructed once in :func:`build_app` (#1501, #1426). Every config
+value is read from ``self.settings`` at call time — no module-level globals,
+no import-time ``get_settings()``. Pure helpers (password hashing, email
+validation, the lockout predicate, the Pydantic models) and the FastAPI
+dependency callables (``get_current_user`` etc.) stay module-level.
+"""
+
 import logging
 import re
 import uuid
 from datetime import datetime, timedelta, timezone
 
 import bcrypt
-from fastapi import Depends, HTTPException
-from sqlalchemy.exc import IntegrityError as SAIntegrityError
+from fastapi import Depends, HTTPException, Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from jose import ExpiredSignatureError, JWTError, jwt
 from pydantic import BaseModel
+from sqlalchemy.exc import IntegrityError as SAIntegrityError
 
 from . import model
 from .exceptions import ConfigurationError
-from .util import resolve_env_value
+from .settings import INSECURE_DEFAULT_SECRET
 
 logger = logging.getLogger(__name__)
 
-# --- Rate limiting constants ---
-LOGIN_LOCKOUT_WINDOW = int(
-    resolve_env_value("KLANGK_LOGIN_LOCKOUT_WINDOW", "300")
-)
-LOGIN_LOCKOUT_DURATION = int(
-    resolve_env_value("KLANGK_LOGIN_LOCKOUT_DURATION", "900")
-)
+# Maximum password length bcrypt will accept (its 72-byte limit).
+MAX_PASSWORD_BYTES = 72
+
+security = HTTPBearer(auto_error=False)
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers (no config) — module-level
+# ---------------------------------------------------------------------------
 
 
 def is_locked_out(
@@ -47,98 +59,6 @@ def is_locked_out(
             f"Too many failed attempts. Try again in {remaining // 60} minutes.",
         )
     return False, None
-
-
-def should_lockout(attempt_info: dict | None) -> bool:
-    """Return True if the attempt count exceeds the threshold."""
-    if attempt_info is None:
-        return False
-    return (
-        attempt_info.get("attempt_count", 0) >= LOGIN_LOCKOUT_FAILURES
-    )  # pragma: no cover
-
-
-def window_elapsed(attempt_info: dict | None) -> bool:
-    """Return True if the first failure in *attempt_info* predates the
-    sliding lockout window.
-
-    Used to decide whether ``record_failed_login`` should reset the
-    count (old failures stop counting) rather than increment.  ``None``
-    info, a missing/unparseable ``first_attempt_at`` → not elapsed.
-    """
-    if attempt_info is None:
-        return False
-    first = attempt_info.get("first_attempt_at")
-    if not first:
-        return False
-    try:
-        first_dt = datetime.fromisoformat(first)
-    except (TypeError, ValueError):
-        return False
-    return (
-        datetime.now(timezone.utc) - first_dt
-    ).total_seconds() > LOGIN_LOCKOUT_WINDOW
-
-
-_INSECURE_DEFAULT_SECRET = "klangk-dev-secret-change-in-production"
-SECRET_KEY = resolve_env_value("KLANGK_JWT_SECRET", _INSECURE_DEFAULT_SECRET)
-ALGORITHM = "HS256"
-TOKEN_EXPIRE_HOURS = float(
-    resolve_env_value("KLANGK_ACCESS_TOKEN_HOURS", "24")
-)
-
-
-def jwt_secret_is_secure() -> bool:
-    """True if a non-empty, non-default JWT signing secret is configured."""
-    return bool(SECRET_KEY) and SECRET_KEY != _INSECURE_DEFAULT_SECRET
-
-
-def require_secure_jwt_secret() -> None:
-    """Warn or fail at startup if the JWT secret is insecure.
-
-    With the unset/default secret, anyone can forge tokens for any user.
-    When KLANGK_PREVENT_INSECURE_JWT_SECRET is truthy, startup fails.
-    Otherwise a warning is logged.
-    """
-    if jwt_secret_is_secure():
-        return
-    prevent = (
-        resolve_env_value("KLANGK_PREVENT_INSECURE_JWT_SECRET", "") or ""
-    ).lower()
-    if prevent in ("1", "true", "yes"):
-        raise ConfigurationError(
-            "KLANGK_JWT_SECRET is unset or the insecure default. Set a "
-            "strong secret or remove KLANGK_PREVENT_INSECURE_JWT_SECRET."
-        )
-    logger.warning(
-        "KLANGK_JWT_SECRET is unset or the insecure default. Set "
-        "KLANGK_PREVENT_INSECURE_JWT_SECRET=1 in production."
-    )
-
-
-MIN_PASSWORD_LENGTH = int(resolve_env_value("KLANGK_MIN_PASSWORD_LENGTH", "8"))
-MAX_PASSWORD_BYTES = 72  # bcrypt limit
-
-# Default of 5 enables brute-force protection out of the box. Set to 0
-# to disable (not recommended — see #938).
-LOGIN_LOCKOUT_FAILURES = int(
-    resolve_env_value("KLANGK_LOGIN_LOCKOUT_FAILURES", "5")
-)
-
-security = HTTPBearer(auto_error=False)
-
-
-def validate_password_length(password: str) -> None:
-    if len(password) < MIN_PASSWORD_LENGTH:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Password must be at least {MIN_PASSWORD_LENGTH} characters",
-        )
-    if len(password.encode()) > MAX_PASSWORD_BYTES:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Password must not exceed {MAX_PASSWORD_BYTES} bytes",
-        )
 
 
 def hash_password(password: str) -> str:
@@ -173,25 +93,6 @@ class TokenResponse(BaseModel):
     token_type: str = "bearer"
 
 
-def create_token(user_id: str, email: str) -> str:
-    jti = str(uuid.uuid4())
-    expire = datetime.now(timezone.utc) + timedelta(hours=TOKEN_EXPIRE_HOURS)
-    payload = {
-        "sub": user_id,
-        "email": email,
-        "jti": jti,
-        "exp": expire,
-    }
-    return jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM)
-
-
-def decode_token(token: str, *, allow_expired: bool = False) -> dict:
-    options = {"verify_exp": False} if allow_expired else {}
-    return jwt.decode(
-        token, SECRET_KEY, algorithms=[ALGORITHM], options=options
-    )
-
-
 class RegisterResult(BaseModel):
     user_id: str
     email: str
@@ -209,266 +110,439 @@ def validate_email(email: str) -> None:
         )
 
 
-def registration_enabled() -> bool:
-    """Check if public registration is enabled."""
-    val = resolve_env_value("KLANGK_DISABLE_REGISTRATION", "")
-    return val.lower() not in ("1", "true", "yes")
+# ---------------------------------------------------------------------------
+# Auth instance — config-reading, app.state-owned (#1501, #1426)
+# ---------------------------------------------------------------------------
 
 
-def invitations_enabled() -> bool:
-    """Check if admin invitations are enabled."""
-    val = resolve_env_value("KLANGK_DISABLE_INVITES", "")
-    return val.lower() not in ("1", "true", "yes")
+class Auth:
+    """Owns every auth config value and JWT operation.
 
-
-async def register(
-    req: RegisterRequest, verified: bool = False
-) -> RegisterResult:
-    if not registration_enabled():
-        raise HTTPException(status_code=403, detail="Registration is disabled")
-    existing = await model.get_user_by_email(req.email)
-    if existing is not None:
-        raise HTTPException(status_code=400, detail="Registration failed")
-    validate_email(req.email)
-    validate_password_length(req.password)
-
-    password_hash = hash_password(req.password)
-    # The duplicate-email pre-check above is not atomic with the
-    # INSERT, so two concurrent registrations can both pass it and
-    # one hits the UNIQUE constraint. Catch that and return the same
-    # opaque error as the pre-check (avoids user enumeration and an
-    # unhandled HTTP 500).
-    try:
-        user = await model.create_user(
-            req.email, password_hash, verified=verified
-        )
-    except SAIntegrityError:
-        raise HTTPException(status_code=400, detail="Registration failed")
-    token = None
-    if verified:
-        token = create_token(user["id"], user["email"])
-    return RegisterResult(
-        user_id=user["id"], email=user["email"], access_token=token
-    )
-
-
-async def login(req: LoginRequest) -> TokenResponse:
-    # Check if locked out before doing any expensive work
-    if LOGIN_LOCKOUT_FAILURES > 0:
-        attempt_info = await model.get_login_attempt_info(req.email)
-        is_locked, msg = is_locked_out(attempt_info)
-        if is_locked:
-            raise HTTPException(status_code=429, detail=msg)
-
-    user = await model.get_user_by_email(req.email)
-    # OIDC-only users have no password hash; treat that as invalid
-    # credentials rather than letting verify_password crash on None.
-    if (
-        user is None
-        or not user.get("password_hash")
-        or not verify_password(req.password, user["password_hash"])
-    ):
-        if LOGIN_LOCKOUT_FAILURES > 0:
-            # Reuse the attempt_info fetched up front for the lockout
-            # check to decide whether the sliding window has elapsed —
-            # if so, reset the count instead of incrementing, so old
-            # failures stop counting toward the threshold.
-            reset = window_elapsed(attempt_info)
-            await model.record_failed_login(req.email, reset=reset)
-            # Check if this attempt triggered a lockout
-            updated_info = await model.get_login_attempt_info(req.email)
-            if should_lockout(updated_info):
-                locked_until = datetime.now(timezone.utc) + timedelta(
-                    seconds=LOGIN_LOCKOUT_DURATION
-                )
-                await model.set_login_lockout(
-                    req.email, locked_until.isoformat()
-                )
-                raise HTTPException(
-                    status_code=429,
-                    detail=f"Too many failed attempts. Locked out for {LOGIN_LOCKOUT_DURATION // 60} minutes.",
-                )
-        raise HTTPException(status_code=401, detail="Invalid credentials")
-    if not user.get("verified"):
-        raise HTTPException(
-            status_code=403, detail="Account not verified. Check your email."
-        )
-
-    if LOGIN_LOCKOUT_FAILURES > 0:
-        await model.clear_login_attempts(req.email)
-    token = create_token(user["id"], user["email"])
-    return TokenResponse(access_token=token)
-
-
-async def refresh_token(token: str) -> TokenResponse:
-    """Exchange a valid access token for a new one.
-
-    The old token's JTI is blocklisted with the new token cached
-    alongside it, making the endpoint idempotent: repeated calls
-    with the same old token return the same new token.
+    Constructed once in :func:`build_app` and stored on ``app.state.auth``.
+    Reads ``self.settings`` at construction for the resolved config (all
+    ``file:``/``cmd:`` values already resolved, #1461) and at call time for
+    the toggle-style fields. Token create/decode close over ``self.secret``
+    / ``self.algorithm`` so every caller agrees on one key.
     """
-    jti = None
-    try:
-        payload = decode_token(token)
-        user_id = payload.get("sub")
-        email = payload.get("email")
-        jti = payload.get("jti")
-        exp = payload.get("exp")
-        if not all([user_id, email, jti, exp]):  # pragma: no cover
-            raise HTTPException(status_code=401, detail="Invalid token")
 
-        if await model.is_token_blocklisted(jti):
-            # Already refreshed — return the cached replacement
-            cached = await model.get_refreshed_token(jti)
-            if cached is not None:
-                return TokenResponse(access_token=cached)
+    # Email-verification / password-reset token lifetimes are fixed
+    # policy (not env-driven). Reached as instance attrs so every token
+    # lifetime reads uniformly: auth.<kind>_expire_hours.
+
+    # Sentinels returned by the decode helpers.
+    TOKEN_EXPIRED = "TOKEN_EXPIRED"
+    WORKSPACE_TOKEN_EXPIRED = "WORKSPACE_TOKEN_EXPIRED"
+
+    def __init__(self, app_state):
+        self.app_state = app_state
+        self.settings = app_state.settings
+        s = self.settings
+        self.secret = s.jwt_secret
+        self.algorithm = "HS256"
+        self.token_expire_hours = float(s.access_token_hours)
+        self.min_password_length = int(s.min_password_length)
+        self.login_lockout_failures = int(s.login_lockout_failures)
+        self.login_lockout_duration = int(s.login_lockout_duration)
+        self.login_lockout_window = int(s.login_lockout_window)
+        self.invite_token_expire_hours = int(s.invite_expire_hours)
+        self.workspace_token_expire_hours = float(s.workspace_token_hours)
+        # Fixed-policy token lifetimes (not env-driven).
+        self.verify_token_expire_hours = 72
+        self.reset_token_expire_hours = 1
+
+    # --- secret / startup guard ---
+
+    def jwt_secret_is_secure(self) -> bool:
+        """True if a non-empty, non-default JWT signing secret is configured."""
+        return bool(self.secret) and self.secret != INSECURE_DEFAULT_SECRET
+
+    def require_secure_jwt_secret(self) -> None:
+        """Warn or fail at startup if the JWT secret is insecure.
+
+        With the unset/default secret, anyone can forge tokens for any user.
+        When ``prevent_insecure_jwt_secret`` is truthy, startup fails.
+        Otherwise a warning is logged.
+        """
+        if self.jwt_secret_is_secure():
+            return
+        prevent = (self.settings.prevent_insecure_jwt_secret or "").lower()
+        if prevent in ("1", "true", "yes"):
+            raise ConfigurationError(
+                "KLANGK_JWT_SECRET is unset or the insecure default. Set a "
+                "strong secret or remove KLANGK_PREVENT_INSECURE_JWT_SECRET."
+            )
+        logger.warning(
+            "KLANGK_JWT_SECRET is unset or the insecure default. Set "
+            "KLANGK_PREVENT_INSECURE_JWT_SECRET=1 in production."
+        )
+
+    # --- toggles ---
+
+    def registration_enabled(self) -> bool:
+        """Check if public registration is enabled."""
+        val = self.settings.disable_registration or ""
+        return val.lower() not in ("1", "true", "yes")
+
+    def invitations_enabled(self) -> bool:
+        """Check if admin invitations are enabled."""
+        val = self.settings.disable_invites or ""
+        return val.lower() not in ("1", "true", "yes")
+
+    def validate_password_length(self, password: str) -> None:
+        if len(password) < self.min_password_length:
             raise HTTPException(
-                status_code=401, detail="Token has been revoked"
+                status_code=400,
+                detail=f"Password must be at least {self.min_password_length} characters",
+            )
+        if len(password.encode()) > MAX_PASSWORD_BYTES:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Password must not exceed {MAX_PASSWORD_BYTES} bytes",
             )
 
-        user = await model.get_user_by_id(user_id)
-        if user is None:
-            raise HTTPException(status_code=401, detail="User not found")
+    # --- lockout predicates (read lockout config) ---
 
-        new_token = create_token(user_id, email)
-        expires_at = datetime.fromtimestamp(exp, tz=timezone.utc).isoformat()
-        await model.blocklist_token(jti, expires_at, new_token=new_token)
-        return TokenResponse(access_token=new_token)
+    def should_lockout(self, attempt_info: dict | None) -> bool:
+        """Return True if the attempt count exceeds the threshold."""
+        if attempt_info is None:
+            return False
+        return (
+            attempt_info.get("attempt_count", 0) >= self.login_lockout_failures
+        )
 
-    except ExpiredSignatureError:
-        # Token expired — check if it was previously refreshed
-        payload = decode_token(token, allow_expired=True)
-        jti = payload.get("jti")
-        if jti:
-            cached = await model.get_refreshed_token(jti)
-            if cached is not None:
-                return TokenResponse(access_token=cached)
-        raise HTTPException(status_code=401, detail="Token expired")
-    except JWTError:  # pragma: no cover
-        raise HTTPException(status_code=401, detail="Invalid token")
+    def window_elapsed(self, attempt_info: dict | None) -> bool:
+        """Return True if the first failure in *attempt_info* predates the
+        sliding lockout window.
 
+        Used to decide whether ``record_failed_login`` should reset the
+        count (old failures stop counting) rather than increment.  ``None``
+        info, a missing/unparseable ``first_attempt_at`` → not elapsed.
+        """
+        if attempt_info is None:
+            return False
+        first = attempt_info.get("first_attempt_at")
+        if not first:
+            return False
+        try:
+            first_dt = datetime.fromisoformat(first)
+        except (TypeError, ValueError):
+            return False
+        return (
+            datetime.now(timezone.utc) - first_dt
+        ).total_seconds() > self.login_lockout_window
 
-VERIFY_TOKEN_EXPIRE_HOURS = 72
-RESET_TOKEN_EXPIRE_HOURS = 1
-INVITE_TOKEN_EXPIRE_HOURS = int(
-    resolve_env_value("KLANGK_INVITE_EXPIRE_HOURS", "72")
-)
+    # --- access tokens ---
 
+    def create_token(self, user_id: str, email: str) -> str:
+        jti = str(uuid.uuid4())
+        expire = datetime.now(timezone.utc) + timedelta(
+            hours=self.token_expire_hours
+        )
+        payload = {
+            "sub": user_id,
+            "email": email,
+            "jti": jti,
+            "exp": expire,
+        }
+        return jwt.encode(payload, self.secret, algorithm=self.algorithm)
 
-def create_verification_token(user_id: str) -> str:
-    """Create a JWT token for email verification."""
-    expire = datetime.now(timezone.utc) + timedelta(
-        hours=VERIFY_TOKEN_EXPIRE_HOURS
-    )
-    payload = {"sub": user_id, "purpose": "verify", "exp": expire}
-    return jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM)
+    def decode_token(self, token: str, *, allow_expired: bool = False) -> dict:
+        options = {"verify_exp": False} if allow_expired else {}
+        return jwt.decode(
+            token,
+            self.secret,
+            algorithms=[self.algorithm],
+            options=options,
+        )
 
+    # --- email-verification tokens ---
 
-def decode_verification_token(token: str) -> str | None:
-    """Decode a verification token. Returns user_id or None if invalid."""
-    try:
-        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
-        if payload.get("purpose") != "verify":
+    def create_verification_token(self, user_id: str) -> str:
+        """Create a JWT token for email verification."""
+        expire = datetime.now(timezone.utc) + timedelta(
+            hours=self.verify_token_expire_hours
+        )
+        payload = {"sub": user_id, "purpose": "verify", "exp": expire}
+        return jwt.encode(payload, self.secret, algorithm=self.algorithm)
+
+    def decode_verification_token(self, token: str) -> str | None:
+        """Decode a verification token. Returns user_id or None if invalid."""
+        try:
+            payload = jwt.decode(
+                token, self.secret, algorithms=[self.algorithm]
+            )
+            if payload.get("purpose") != "verify":
+                return None
+            return payload.get("sub")
+        except JWTError:
             return None
-        return payload.get("sub")
-    except JWTError:
-        return None
 
+    # --- password-reset tokens ---
 
-def create_password_reset_token(user_id: str) -> str:
-    """Create a JWT token for password reset."""
-    expire = datetime.now(timezone.utc) + timedelta(
-        hours=RESET_TOKEN_EXPIRE_HOURS
-    )
-    payload = {"sub": user_id, "purpose": "reset", "exp": expire}
-    return jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM)
+    def create_password_reset_token(self, user_id: str) -> str:
+        """Create a JWT token for password reset."""
+        expire = datetime.now(timezone.utc) + timedelta(
+            hours=self.reset_token_expire_hours
+        )
+        payload = {"sub": user_id, "purpose": "reset", "exp": expire}
+        return jwt.encode(payload, self.secret, algorithm=self.algorithm)
 
-
-def decode_password_reset_token(token: str) -> str | None:
-    """Decode a password reset token. Returns user_id or None."""
-    try:
-        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
-        if payload.get("purpose") != "reset":
+    def decode_password_reset_token(self, token: str) -> str | None:
+        """Decode a password reset token. Returns user_id or None."""
+        try:
+            payload = jwt.decode(
+                token, self.secret, algorithms=[self.algorithm]
+            )
+            if payload.get("purpose") != "reset":
+                return None
+            return payload.get("sub")
+        except JWTError:
             return None
-        return payload.get("sub")
-    except JWTError:
-        return None
 
+    # --- invitation tokens ---
 
-def create_invitation_token(invitation_id: str, email: str) -> str:
-    """Create a JWT token for an invitation."""
-    expire = datetime.now(timezone.utc) + timedelta(
-        hours=INVITE_TOKEN_EXPIRE_HOURS
-    )
-    payload = {
-        "sub": invitation_id,
-        "email": email,
-        "purpose": "invite",
-        "exp": expire,
-    }
-    return jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM)
+    def create_invitation_token(self, invitation_id: str, email: str) -> str:
+        """Create a JWT token for an invitation."""
+        expire = datetime.now(timezone.utc) + timedelta(
+            hours=self.invite_token_expire_hours
+        )
+        payload = {
+            "sub": invitation_id,
+            "email": email,
+            "purpose": "invite",
+            "exp": expire,
+        }
+        return jwt.encode(payload, self.secret, algorithm=self.algorithm)
 
-
-def decode_invitation_token(token: str) -> tuple[str, str] | None:
-    """Decode an invitation token. Returns (invitation_id, email) or None."""
-    try:
-        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
-        if payload.get("purpose") != "invite":
+    def decode_invitation_token(self, token: str) -> tuple[str, str] | None:
+        """Decode an invitation token. Returns (invitation_id, email) or None."""
+        try:
+            payload = jwt.decode(
+                token, self.secret, algorithms=[self.algorithm]
+            )
+            if payload.get("purpose") != "invite":
+                return None
+            inv_id = payload.get("sub")
+            email = payload.get("email")
+            if not inv_id or not email:
+                return None
+            return (inv_id, email)
+        except JWTError:
             return None
-        inv_id = payload.get("sub")
-        email = payload.get("email")
-        if not inv_id or not email:
+
+    # --- workspace tokens ---
+
+    def create_workspace_token(self, workspace_id: str) -> str:
+        """Create a JWT token identifying a workspace for container→host auth."""
+        expire = datetime.now(timezone.utc) + timedelta(
+            hours=self.workspace_token_expire_hours
+        )
+        payload = {"sub": workspace_id, "purpose": "workspace", "exp": expire}
+        return jwt.encode(payload, self.secret, algorithm=self.algorithm)
+
+    def decode_workspace_token(self, token: str) -> str | None:
+        """Decode a workspace token.
+
+        Returns:
+            str workspace_id on success.
+            WORKSPACE_TOKEN_EXPIRED if the token is expired.
+            None for all other failures.
+        """
+        try:
+            payload = jwt.decode(
+                token, self.secret, algorithms=[self.algorithm]
+            )
+            if payload.get("purpose") != "workspace":
+                return None
+            return payload.get("sub")
+        except ExpiredSignatureError:
+            return self.WORKSPACE_TOKEN_EXPIRED
+        except JWTError:
             return None
-        return (inv_id, email)
-    except JWTError:
-        return None
 
+    # --- registration / login flows ---
 
-WORKSPACE_TOKEN_EXPIRE_HOURS = float(
-    resolve_env_value("KLANGK_WORKSPACE_TOKEN_HOURS", "24")
-)
+    async def register(
+        self, req: RegisterRequest, verified: bool = False
+    ) -> RegisterResult:
+        if not self.registration_enabled():
+            raise HTTPException(
+                status_code=403, detail="Registration is disabled"
+            )
+        existing = await model.get_user_by_email(req.email)
+        if existing is not None:
+            raise HTTPException(status_code=400, detail="Registration failed")
+        validate_email(req.email)
+        self.validate_password_length(req.password)
 
+        password_hash = hash_password(req.password)
+        # The duplicate-email pre-check above is not atomic with the
+        # INSERT, so two concurrent registrations can both pass it and
+        # one hits the UNIQUE constraint. Catch that and return the same
+        # opaque error as the pre-check (avoids user enumeration and an
+        # unhandled HTTP 500).
+        try:
+            user = await model.create_user(
+                req.email, password_hash, verified=verified
+            )
+        except SAIntegrityError:
+            raise HTTPException(status_code=400, detail="Registration failed")
+        token = None
+        if verified:
+            token = self.create_token(user["id"], user["email"])
+        return RegisterResult(
+            user_id=user["id"], email=user["email"], access_token=token
+        )
 
-def create_workspace_token(workspace_id: str) -> str:
-    """Create a JWT token identifying a workspace for container→host auth."""
-    expire = datetime.now(timezone.utc) + timedelta(
-        hours=WORKSPACE_TOKEN_EXPIRE_HOURS
-    )
-    payload = {"sub": workspace_id, "purpose": "workspace", "exp": expire}
-    return jwt.encode(payload, SECRET_KEY, algorithm=ALGORITHM)
+    async def login(self, req: LoginRequest) -> TokenResponse:
+        # Check if locked out before doing any expensive work
+        if self.login_lockout_failures > 0:
+            attempt_info = await model.get_login_attempt_info(req.email)
+            is_locked, msg = is_locked_out(attempt_info)
+            if is_locked:
+                raise HTTPException(status_code=429, detail=msg)
 
+        user = await model.get_user_by_email(req.email)
+        # OIDC-only users have no password hash; treat that as invalid
+        # credentials rather than letting verify_password crash on None.
+        if (
+            user is None
+            or not user.get("password_hash")
+            or not verify_password(req.password, user["password_hash"])
+        ):
+            if self.login_lockout_failures > 0:
+                # Reuse the attempt_info fetched up front for the lockout
+                # check to decide whether the sliding window has elapsed —
+                # if so, reset the count instead of incrementing, so old
+                # failures stop counting toward the threshold.
+                reset = self.window_elapsed(attempt_info)
+                await model.record_failed_login(req.email, reset=reset)
+                # Check if this attempt triggered a lockout
+                updated_info = await model.get_login_attempt_info(req.email)
+                if self.should_lockout(updated_info):
+                    locked_until = datetime.now(timezone.utc) + timedelta(
+                        seconds=self.login_lockout_duration
+                    )
+                    await model.set_login_lockout(
+                        req.email, locked_until.isoformat()
+                    )
+                    raise HTTPException(
+                        status_code=429,
+                        detail=f"Too many failed attempts. Locked out for {self.login_lockout_duration // 60} minutes.",
+                    )
+            raise HTTPException(status_code=401, detail="Invalid credentials")
+        if not user.get("verified"):
+            raise HTTPException(
+                status_code=403,
+                detail="Account not verified. Check your email.",
+            )
 
-# Sentinel returned by decode_workspace_token when the JWT is expired.
-WORKSPACE_TOKEN_EXPIRED = "WORKSPACE_TOKEN_EXPIRED"
+        if self.login_lockout_failures > 0:
+            await model.clear_login_attempts(req.email)
+        token = self.create_token(user["id"], user["email"])
+        return TokenResponse(access_token=token)
 
+    async def refresh_token(self, token: str) -> TokenResponse:
+        """Exchange a valid access token for a new one.
 
-def decode_workspace_token(token: str) -> str | None:
-    """Decode a workspace token.
+        The old token's JTI is blocklisted with the new token cached
+        alongside it, making the endpoint idempotent: repeated calls
+        with the same old token return the same new token.
+        """
+        jti = None
+        try:
+            payload = self.decode_token(token)
+            user_id = payload.get("sub")
+            email = payload.get("email")
+            jti = payload.get("jti")
+            exp = payload.get("exp")
+            if not all([user_id, email, jti, exp]):  # pragma: no cover
+                raise HTTPException(status_code=401, detail="Invalid token")
 
-    Returns:
-        str workspace_id on success.
-        WORKSPACE_TOKEN_EXPIRED if the token is expired.
-        None for all other failures.
-    """
-    try:
-        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
-        if payload.get("purpose") != "workspace":
+            if await model.is_token_blocklisted(jti):
+                # Already refreshed — return the cached replacement
+                cached = await model.get_refreshed_token(jti)
+                if cached is not None:
+                    return TokenResponse(access_token=cached)
+                raise HTTPException(
+                    status_code=401, detail="Token has been revoked"
+                )
+
+            user = await model.get_user_by_id(user_id)
+            if user is None:
+                raise HTTPException(status_code=401, detail="User not found")
+
+            new_token = self.create_token(user_id, email)
+            expires_at = datetime.fromtimestamp(
+                exp, tz=timezone.utc
+            ).isoformat()
+            await model.blocklist_token(jti, expires_at, new_token=new_token)
+            return TokenResponse(access_token=new_token)
+
+        except ExpiredSignatureError:
+            # Token expired — check if it was previously refreshed
+            payload = self.decode_token(token, allow_expired=True)
+            jti = payload.get("jti")
+            if jti:
+                cached = await model.get_refreshed_token(jti)
+                if cached is not None:
+                    return TokenResponse(access_token=cached)
+            raise HTTPException(status_code=401, detail="Token expired")
+        except JWTError:  # pragma: no cover
+            raise HTTPException(status_code=401, detail="Invalid token")
+
+    async def get_user_from_token(self, token: str) -> dict | str | None:
+        """Validate a token string (used for WebSocket auth).
+
+        Returns:
+            dict: the user record on success.
+            TOKEN_EXPIRED: if the token signature is valid but expired.
+            None: for all other failures (malformed, revoked, missing user).
+        """
+        try:
+            payload = self.decode_token(token)
+            user_id = payload.get("sub")
+            jti = payload.get("jti")
+            if user_id is None or jti is None:
+                return None
+            if await model.is_token_blocklisted(jti):
+                return None
+            return await model.get_user_by_id(user_id)
+        except ExpiredSignatureError:
+            return self.TOKEN_EXPIRED
+        except JWTError:
             return None
-        return payload.get("sub")
-    except ExpiredSignatureError:
-        return WORKSPACE_TOKEN_EXPIRED
-    except JWTError:
-        return None
+
+    async def logout(self, token: str) -> None:
+        """Blocklist the token's JTI."""
+        try:
+            payload = self.decode_token(token)
+            jti = payload.get("jti")
+            exp = payload.get("exp")
+            if jti and exp:
+                expires_at = datetime.fromtimestamp(
+                    exp, tz=timezone.utc
+                ).isoformat()
+                await model.blocklist_token(jti, expires_at)
+        except JWTError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# FastAPI dependency callables — module-level, reach app.state.auth
+# ---------------------------------------------------------------------------
 
 
 async def get_current_user(
+    request: Request,
     credentials: HTTPAuthorizationCredentials | None = Depends(security),
 ) -> dict:
+    auth = request.app.state.auth
     if credentials is None:
         raise HTTPException(status_code=401, detail="Not authenticated")
 
     try:
-        payload = decode_token(credentials.credentials)
+        payload = auth.decode_token(credentials.credentials)
         user_id = payload.get("sub")
         jti = payload.get("jti")
         if user_id is None or jti is None:
@@ -488,13 +562,15 @@ async def get_current_user(
 
 
 async def get_current_user_optional(
+    request: Request,
     credentials: HTTPAuthorizationCredentials | None = Depends(security),
 ) -> dict | None:
     """Like get_current_user but returns None instead of raising 401."""
     if credentials is None:
         return None
+    auth = request.app.state.auth
     try:
-        payload = decode_token(credentials.credentials)
+        payload = auth.decode_token(credentials.credentials)
         user_id = payload.get("sub")
         jti = payload.get("jti")
         if user_id is None or jti is None:
@@ -504,45 +580,3 @@ async def get_current_user_optional(
         return await model.get_user_by_id(user_id)
     except JWTError:
         return None
-
-
-# Sentinel returned by get_user_from_token when the JWT is expired.
-TOKEN_EXPIRED = "TOKEN_EXPIRED"
-
-
-async def get_user_from_token(token: str) -> dict | str | None:
-    """Validate a token string (used for WebSocket auth).
-
-    Returns:
-        dict: the user record on success.
-        TOKEN_EXPIRED: if the token signature is valid but expired.
-        None: for all other failures (malformed, revoked, missing user).
-    """
-    try:
-        payload = decode_token(token)
-        user_id = payload.get("sub")
-        jti = payload.get("jti")
-        if user_id is None or jti is None:
-            return None
-        if await model.is_token_blocklisted(jti):
-            return None
-        return await model.get_user_by_id(user_id)
-    except ExpiredSignatureError:
-        return TOKEN_EXPIRED
-    except JWTError:
-        return None
-
-
-async def logout(token: str) -> None:
-    """Blocklist the token's JTI."""
-    try:
-        payload = decode_token(token)
-        jti = payload.get("jti")
-        exp = payload.get("exp")
-        if jti and exp:
-            expires_at = datetime.fromtimestamp(
-                exp, tz=timezone.utc
-            ).isoformat()
-            await model.blocklist_token(jti, expires_at)
-    except JWTError:
-        pass

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -5,7 +5,7 @@ import logging
 import os
 import time
 
-from . import auth, bringup, model, podman
+from . import bringup, model, podman
 from .podman import PodmanError
 
 logger = logging.getLogger(__name__)
@@ -1308,7 +1308,9 @@ class ContainerRegistry:
 
         # Write the workspace token so container processes can
         # authenticate without an env-var restart.
-        workspace_token = auth.create_workspace_token(workspace_id)
+        workspace_token = self.app_state.auth.create_workspace_token(
+            workspace_id
+        )
         await self.app_state.terminal.set_workspace_token(cid, workspace_token)
 
         # Block until the entrypoint's one-time setup is done. ``podman

--- a/src/backend/klangk_backend/emailsvc.py
+++ b/src/backend/klangk_backend/emailsvc.py
@@ -16,7 +16,6 @@ from jinja2 import (
     select_autoescape,
 )
 
-from . import auth
 from .exceptions import SendmailError
 
 logger = logging.getLogger(__name__)
@@ -269,7 +268,7 @@ class EmailService:
         rendered = self.render_email(
             "verify",
             link=verification_url,
-            expiry_hours=auth.VERIFY_TOKEN_EXPIRE_HOURS,
+            expiry_hours=self.app_state.auth.verify_token_expire_hours,
         )
         await self._send(self.build_multipart(to, rendered))
         logger.info("Verification email sent to %s", to)
@@ -279,7 +278,7 @@ class EmailService:
         rendered = self.render_email(
             "reset",
             link=reset_url,
-            expiry_hours=auth.RESET_TOKEN_EXPIRE_HOURS,
+            expiry_hours=self.app_state.auth.reset_token_expire_hours,
         )
         await self._send(self.build_multipart(to, rendered))
         logger.info("Password reset email sent to %s", to)
@@ -291,7 +290,7 @@ class EmailService:
         rendered = self.render_email(
             "invite",
             link=invite_url,
-            expiry_hours=auth.INVITE_TOKEN_EXPIRE_HOURS,
+            expiry_hours=self.app_state.auth.invite_token_expire_hours,
             invited_by=invited_by_email,
         )
         await self._send(self.build_multipart(to, rendered))

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -574,7 +574,7 @@ async def lifespan(app: FastAPI):
     # and therefore before trust is applied.
     setup_logfire(app)
 
-    auth.require_secure_jwt_secret()
+    app.state.auth.require_secure_jwt_secret()
     app.state.plugins.load()
     app.state.oidc.init_providers()
     enforce_no_auth_bind_safety(app.state)
@@ -718,6 +718,11 @@ def build_app(settings: KlangkSettings) -> FastAPI:
     """
     app = FastAPI(title="Klangk", lifespan=lifespan)
     app.state.settings = settings
+    # #1501: Auth(app_state) owns every auth config value and JWT
+    # operation (previously module-level globals + import-time
+    # resolve_env_value reads in auth.py). Reads self.settings at
+    # construction/call time.
+    app.state.auth = auth.Auth(app.state)
     # Slice 2 (#1449): the container registry is an owned instance, not a
     # module global. The lifespan reads app.state.container_registry.
     app.state.container_registry = container.ContainerRegistry(app.state)

--- a/src/backend/klangk_backend/settings.py
+++ b/src/backend/klangk_backend/settings.py
@@ -163,8 +163,11 @@ def _resolve_indirection(value: str | None, key: str = "") -> str | None:
 # KlangkSettings model
 # ---------------------------------------------------------------------------
 
-# The insecure default JWT secret — matches the constant in auth.py.
-_INSECURE_DEFAULT_SECRET = "change-this-to-a-random-secret"
+# The insecure default JWT secret. Single source of truth — auth.py's
+# Auth.jwt_secret_is_secure() compares against this (#1501).
+INSECURE_DEFAULT_SECRET = "change-this-to-a-random-secret"
+# Back-compat alias (was the private name).
+_INSECURE_DEFAULT_SECRET = INSECURE_DEFAULT_SECRET
 
 
 # --- Env-source override for injectable env dicts (#1426 Slice 1) ---

--- a/src/backend/klangk_backend/wshandler/connection.py
+++ b/src/backend/klangk_backend/wshandler/connection.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta, timezone
 
 
 from .. import acl as _acl
-from .. import auth, container, model
+from .. import container, model
 from ..terminal import TerminalSession
 from ..podman import ExecSession
 from .constants import (
@@ -338,7 +338,7 @@ class Connection:
             workspace_id, app_state=self.app_state
         )
         token_expiry = datetime.now(timezone.utc) + timedelta(
-            hours=auth.WORKSPACE_TOKEN_EXPIRE_HOURS
+            hours=self.app_state.auth.workspace_token_expire_hours
         )
         await session.add_subscriber(
             self.sock, container_id, token_expiry=token_expiry

--- a/src/backend/klangk_backend/wshandler/dispatch.py
+++ b/src/backend/klangk_backend/wshandler/dispatch.py
@@ -75,8 +75,8 @@ async def handle_websocket(websocket: WebSocket, app_state) -> None:
         await websocket.close(code=4001, reason="Missing token")
         return
 
-    result = await auth.get_user_from_token(token)
-    if result is auth.TOKEN_EXPIRED:
+    result = await app_state.auth.get_user_from_token(token)
+    if result is auth.Auth.TOKEN_EXPIRED:
         await websocket.close(code=4002, reason="Token expired")
         return
     if result is None:

--- a/src/backend/klangk_backend/wshandler/session.py
+++ b/src/backend/klangk_backend/wshandler/session.py
@@ -10,7 +10,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
-from .. import auth, model
+from .. import model
 from .safe_websocket import SafeWebSocket, WS_ERRORS, broadcast_to_set
 from .constants import (
     agent_conversations,
@@ -178,7 +178,7 @@ class WorkspaceSession:
                 return  # pragma: no cover
 
             # Renew at 80% of the token lifetime.
-            lifetime = auth.WORKSPACE_TOKEN_EXPIRE_HOURS * 3600
+            lifetime = self.app_state.auth.workspace_token_expire_hours * 3600
             delay = lifetime * 0.8
             try:
                 await asyncio.sleep(delay)
@@ -190,13 +190,17 @@ class WorkspaceSession:
                 return  # pragma: no cover
 
             try:
-                new_token = auth.create_workspace_token(self.workspace_id)
+                new_token = self.app_state.auth.create_workspace_token(
+                    self.workspace_id
+                )
                 await self.app_state.terminal.set_workspace_token(
                     container_id, new_token
                 )
                 self.workspace_token_expiry = datetime.now(
                     timezone.utc
-                ) + timedelta(hours=auth.WORKSPACE_TOKEN_EXPIRE_HOURS)
+                ) + timedelta(
+                    hours=self.app_state.auth.workspace_token_expire_hours
+                )
                 logger.info(
                     "Renewed workspace token for %s",
                     self.workspace_id,

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -12,6 +12,14 @@ os.environ.setdefault("COVERAGE_CORE", "sysmon")
 # in the env before any such import runs during collection. The autouse
 # `temp_data_dir` fixture overrides these with per-test tmp dirs once tests
 # start. util.py no longer triggers this (#1503), but auth.py does.
+# state_dir / data_dir are required (no defaults, #1461). Several modules
+# still read config at import time via resolve_env_value (-> get_settings()):
+# api/__init__.py (LOGIN_BANNER, PRODUCT_NAME, legal/support URLs),
+# api/_common.py (FILE_UPLOAD_SIZE_MAX), wshandler/constants.py (WS_DEBUG).
+# Set temp dirs in the env before any such import runs during collection.
+# The autouse `temp_data_dir` fixture overrides these with per-test tmp
+# dirs once tests start. auth.py no longer triggers this (#1501); util.py
+# no longer triggers this (#1503).
 os.environ.setdefault(
     "KLANGK_STATE_DIR", tempfile.mkdtemp(prefix="klangk-collect-state-")
 )
@@ -212,6 +220,7 @@ def app_state(temp_data_dir):
     import types
 
     from klangk_backend.settings import KlangkSettings
+    from klangk_backend.auth import Auth
     from klangk_backend.container import ContainerRegistry
     from klangk_backend.emailsvc import EmailService
     from klangk_backend.util import Util
@@ -219,6 +228,7 @@ def app_state(temp_data_dir):
 
     settings = KlangkSettings(os.environ)
     state = types.SimpleNamespace(settings=settings)
+    state.auth = Auth(state)
     registry = ContainerRegistry(state)
     state.container_registry = registry
     registry.app_state = state

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -15,7 +15,7 @@ from httpx import AsyncClient, ASGITransport
 from klangk_backend import (
     agent,
     api,
-    auth,
+    auth as auth_mod,
     model,
     podman,
     workspaces as ws_mod,
@@ -27,6 +27,18 @@ from klangk_backend import oidc as oidc_mod
 from klangk_backend import plugins as plugins_mod
 from _helpers import make_settings
 from klangk_backend.wshandler.session import WebSocketState
+import types
+
+
+def _auth():
+    """A standalone Auth for token forging (same default secret as the
+    app fixture, so tokens round-trip through app.state.auth.decode_*)."""
+    return auth_mod.Auth(types.SimpleNamespace(settings=make_settings({})))
+
+
+# Aliases for the raw-JWT test that builds a token by hand.
+_SECRET = make_settings({}).jwt_secret
+_ALGORITHM = "HS256"
 
 # Mock Podman instance wired onto app.state.podman by the app fixture;
 # files/volume-API tests patch its methods via patch.object (#1468).
@@ -64,6 +76,8 @@ async def app(db, temp_data_dir):
     app.state.agents.get_workspace_session = sockets.get_session
     app.state.email = emailsvc_mod.EmailService(app.state)
     app.state.util = util_mod.Util(app.state)
+
+    app.state.auth = auth_mod.Auth(app.state)
 
     app.include_router(api.root_router)
     app.include_router(api.router, prefix=API_PREFIX)
@@ -107,7 +121,7 @@ async def _oidc_user_headers(email="oidc@example.com"):
     authenticated endpoints that must not 500 on a NULL hash (#890).
     """
     user = await model.create_user(email, None, verified=True, provider="oidc")
-    token = auth.create_token(user["id"], user["email"])
+    token = _auth().create_token(user["id"], user["email"])
     return {"Authorization": f"Bearer {token}"}
 
 
@@ -130,7 +144,7 @@ class TestEmpty:
 
 class TestVerifyWorkspaceToken:
     async def test_valid_workspace_token(self, client):
-        token = auth.create_workspace_token("ws-123")
+        token = _auth().create_workspace_token("ws-123")
         resp = await client.get(
             "/api/v1/auth/verify-workspace-token",
             headers={"Authorization": f"Bearer {token}"},
@@ -150,7 +164,7 @@ class TestVerifyWorkspaceToken:
         assert resp.status_code == 401
 
     async def test_user_jwt_rejected(self, client):
-        user_token = auth.create_token("user-1", "u@test.com")
+        user_token = _auth().create_token("user-1", "u@test.com")
         resp = await client.get(
             "/api/v1/auth/verify-workspace-token",
             headers={"Authorization": f"Bearer {user_token}"},
@@ -164,7 +178,7 @@ class TestVerifyWorkspaceToken:
 
         expired = datetime.now(timezone.utc) - timedelta(hours=1)
         payload = {"sub": "ws-123", "purpose": "workspace", "exp": expired}
-        token = jwt.encode(payload, auth.SECRET_KEY, algorithm=auth.ALGORITHM)
+        token = jwt.encode(payload, _SECRET, algorithm=_ALGORITHM)
         resp = await client.get(
             "/api/v1/auth/verify-workspace-token",
             headers={"Authorization": f"Bearer {token}"},
@@ -184,7 +198,7 @@ class TestVerifyWorkspaceToken:
 class TestWorkspaceChat:
     async def test_post_agent_message(self, client, user):
         workspace = await model.create_workspace(user["id"], "chat-ws")
-        token = auth.create_workspace_token(workspace["id"])
+        token = _auth().create_workspace_token(workspace["id"])
         resp = await client.post(
             "/api/v1/workspaces/post-chat-message",
             headers={"Authorization": f"Bearer {token}"},
@@ -198,7 +212,7 @@ class TestWorkspaceChat:
 
     async def test_broadcasts_to_websocket(self, client, user, sockets):
         workspace = await model.create_workspace(user["id"], "bcast-ws")
-        token = auth.create_workspace_token(workspace["id"])
+        token = _auth().create_workspace_token(workspace["id"])
         session = sockets.get_or_create_session(workspace["id"])
         mock_sock = MagicMock()
         session.subscribers.add(mock_sock)
@@ -231,7 +245,7 @@ class TestWorkspaceChat:
         assert resp.status_code == 401
 
     async def test_workspace_not_found(self, client):
-        token = auth.create_workspace_token("nonexistent-ws")
+        token = _auth().create_workspace_token("nonexistent-ws")
         resp = await client.post(
             "/api/v1/workspaces/post-chat-message",
             headers={"Authorization": f"Bearer {token}"},
@@ -241,7 +255,7 @@ class TestWorkspaceChat:
 
     async def test_empty_message_rejected(self, client, user):
         workspace = await model.create_workspace(user["id"], "empty-ws")
-        token = auth.create_workspace_token(workspace["id"])
+        token = _auth().create_workspace_token(workspace["id"])
         resp = await client.post(
             "/api/v1/workspaces/post-chat-message",
             headers={"Authorization": f"Bearer {token}"},
@@ -391,7 +405,7 @@ class TestConfig:
         resp = await client.get("/api/v1/config")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["min_password_length"] == auth.MIN_PASSWORD_LENGTH
+        assert data["min_password_length"] == _auth().min_password_length
 
     async def test_get_config_logo_url_defaults_empty(
         self, client, app, monkeypatch
@@ -402,8 +416,12 @@ class TestConfig:
         assert resp.status_code == 200
         assert resp.json()["logo_url"] == ""
 
-    async def test_get_config_logo_url_reflects_env(self, client, monkeypatch):
-        monkeypatch.setenv("KLANGK_LOGO_URL", "https://example.com/l.png")
+    async def test_get_config_logo_url_reflects_env(
+        self, client, app, monkeypatch
+    ):
+        monkeypatch.setattr(
+            app.state.settings, "logo_url", "https://example.com/l.png"
+        )
         resp = await client.get("/api/v1/config")
         assert resp.status_code == 200
         assert resp.json()["logo_url"] == "https://example.com/l.png"
@@ -460,10 +478,13 @@ class TestConfig:
     async def test_get_config_logo_url_resolves_file_secret(
         self, client, app, tmp_path, monkeypatch
     ):
-        # file:/cmd: resolution works like other secrets (#1152).
-        secret = tmp_path / "logo_url"
-        secret.write_text("https://from.secret/l.png")
-        monkeypatch.setenv("KLANGK_LOGO_URL", f"file:{secret}")
+        # file:/cmd: resolution happens at settings construction (#1461);
+        # the field holds the resolved value, which /config surfaces as-is.
+        monkeypatch.setattr(
+            app.state.settings,
+            "logo_url",
+            "https://from.secret/l.png",
+        )
         resp = await client.get("/api/v1/config")
         assert resp.json()["logo_url"] == "https://from.secret/l.png"
 
@@ -532,9 +553,9 @@ class TestAuthRoutes:
         assert user is not None
         assert user["handle"] == "handleme"  # derived, not NULL
 
-    async def test_register_test_mode(self, client, db, monkeypatch):
+    async def test_register_test_mode(self, client, app, db, monkeypatch):
         """In test mode, unauthenticated registration is allowed and auto-verified."""
-        monkeypatch.setenv("KLANGK_TEST_MODE", "1")
+        monkeypatch.setattr(app.state.settings, "test_mode", "1")
         resp = await client.post(
             "/api/v1/auth/register",
             json={"email": "new@example.com", "password": "newpass1"},
@@ -603,15 +624,13 @@ class TestAuthRoutes:
 
     async def test_verify_email(self, client, db):
         """Verify endpoint marks user as verified."""
-        from klangk_backend import auth as auth_mod
-
         import bcrypt
 
         password_hash = bcrypt.hashpw(b"pass", bcrypt.gensalt()).decode()
         user = await model.create_user(
             "unverified@example.com", password_hash, verified=False
         )
-        token = auth_mod.create_verification_token(user["id"])
+        token = _auth().create_verification_token(user["id"])
         resp = await client.get(f"/api/v1/auth/verify?token={token}")
         assert resp.status_code == 200
         assert resp.json()["status"] == "verified"
@@ -627,9 +646,7 @@ class TestAuthRoutes:
         assert resp.status_code == 400
 
     async def test_verify_nonexistent_user(self, client, db):
-        from klangk_backend import auth as auth_mod
-
-        token = auth_mod.create_verification_token("nonexistent-id")
+        token = _auth().create_verification_token("nonexistent-id")
         resp = await client.get(f"/api/v1/auth/verify?token={token}")
         assert resp.status_code == 404
 
@@ -691,10 +708,12 @@ class TestLocalLogin:
         self, client, app, db, monkeypatch
     ):
         monkeypatch.setattr(app.state.oidc, "auth_modes", lambda: "none")
-        monkeypatch.setenv("KLANGK_DEFAULT_USER", "local@example.com")
+        monkeypatch.setattr(
+            app.state.settings, "default_user", "local@example.com"
+        )
         await model.create_user(
             "local@example.com",
-            auth.hash_password("unused"),
+            auth_mod.hash_password("unused"),
             verified=True,
         )
         resp = await client.post("/api/v1/auth/local")
@@ -704,17 +723,19 @@ class TestLocalLogin:
         assert data["token_type"] == "bearer"
         token = data["access_token"]
         # The token flows through the normal JWT gate unchanged.
-        claims = auth.decode_token(token)
+        claims = _auth().decode_token(token)
         assert claims["email"] == "local@example.com"
 
     async def test_token_authorizes_requests(
         self, client, app, db, monkeypatch
     ):
         monkeypatch.setattr(app.state.oidc, "auth_modes", lambda: "none")
-        monkeypatch.setenv("KLANGK_DEFAULT_USER", "local@example.com")
+        monkeypatch.setattr(
+            app.state.settings, "default_user", "local@example.com"
+        )
         await model.create_user(
             "local@example.com",
-            auth.hash_password("unused"),
+            auth_mod.hash_password("unused"),
             verified=True,
         )
         token = (await client.post("/api/v1/auth/local")).json()[
@@ -748,16 +769,20 @@ class TestLocalLogin:
         # app skips — so if it were somehow bypassed at runtime the endpoint
         # surfaces a 500 rather than minting a token for a ghost user.
         monkeypatch.setattr(app.state.oidc, "auth_modes", lambda: "none")
-        monkeypatch.setenv("KLANGK_DEFAULT_USER", "ghost@example.com")
+        monkeypatch.setattr(
+            app.state.settings, "default_user", "ghost@example.com"
+        )
         resp = await client.post("/api/v1/auth/local")
         assert resp.status_code == 500
 
     async def test_no_body_required(self, client, app, db, monkeypatch):
         monkeypatch.setattr(app.state.oidc, "auth_modes", lambda: "none")
-        monkeypatch.setenv("KLANGK_DEFAULT_USER", "local@example.com")
+        monkeypatch.setattr(
+            app.state.settings, "default_user", "local@example.com"
+        )
         await model.create_user(
             "local@example.com",
-            auth.hash_password("unused"),
+            auth_mod.hash_password("unused"),
             verified=True,
         )
         # Simple POST (no JSON body, no custom header) — the loopback bind +
@@ -778,10 +803,12 @@ class TestLocalLogin:
         """Front-proxy bypass: peer is loopback (nginx) but X-Real-IP is the
         real client (a workspace container) -> backend refuses independently."""
         monkeypatch.setattr(app.state.oidc, "auth_modes", lambda: "none")
-        monkeypatch.setenv("KLANGK_DEFAULT_USER", "local@example.com")
+        monkeypatch.setattr(
+            app.state.settings, "default_user", "local@example.com"
+        )
         await model.create_user(
             "local@example.com",
-            auth.hash_password("unused"),
+            auth_mod.hash_password("unused"),
             verified=True,
         )
         resp = await client.post(
@@ -798,10 +825,12 @@ class TestLocalLogin:
         operator's browser) -> admit. (ASGI test client peer is itself
         loopback, satisfying the trust gate that honors X-Real-IP.)"""
         monkeypatch.setattr(app.state.oidc, "auth_modes", lambda: "none")
-        monkeypatch.setenv("KLANGK_DEFAULT_USER", "local@example.com")
+        monkeypatch.setattr(
+            app.state.settings, "default_user", "local@example.com"
+        )
         await model.create_user(
             "local@example.com",
-            auth.hash_password("unused"),
+            auth_mod.hash_password("unused"),
             verified=True,
         )
         resp = await client.post(
@@ -813,7 +842,7 @@ class TestLocalLogin:
 
 class TestResendVerification:
     async def _create_unverified_user(self):
-        password_hash = auth.hash_password("testpass")
+        password_hash = auth_mod.hash_password("testpass")
         await model.create_user(
             "unverified@example.com", password_hash, verified=False
         )
@@ -976,7 +1005,7 @@ class TestResendVerification:
 
 class TestForgotPassword:
     async def _create_user(self):
-        password_hash = auth.hash_password("oldpass")
+        password_hash = auth_mod.hash_password("oldpass")
         return await model.create_user(
             "forgot@example.com", password_hash, verified=True
         )
@@ -1056,14 +1085,14 @@ class TestForgotPassword:
 
 class TestResetPassword:
     async def _create_user(self):
-        password_hash = auth.hash_password("oldpass")
+        password_hash = auth_mod.hash_password("oldpass")
         return await model.create_user(
             "reset@example.com", password_hash, verified=True
         )
 
     async def test_reset_success(self, client, db):
         user = await self._create_user()
-        token = auth.create_password_reset_token(user["id"])
+        token = _auth().create_password_reset_token(user["id"])
         resp = await client.post(
             "/api/v1/auth/reset-password",
             json={"token": token, "password": "newpass1"},
@@ -1091,7 +1120,7 @@ class TestResetPassword:
 
     async def test_reset_short_password(self, client, db):
         user = await self._create_user()
-        token = auth.create_password_reset_token(user["id"])
+        token = _auth().create_password_reset_token(user["id"])
         resp = await client.post(
             "/api/v1/auth/reset-password",
             json={"token": token, "password": "ab"},
@@ -1100,7 +1129,7 @@ class TestResetPassword:
         assert "8 characters" in resp.json()["detail"]
 
     async def test_reset_agent_user_rejected(self, client, db):
-        token = auth.create_password_reset_token(model.AGENT_USER_ID)
+        token = _auth().create_password_reset_token(model.AGENT_USER_ID)
         resp = await client.post(
             "/api/v1/auth/reset-password",
             json={"token": token, "password": "newpass1"},
@@ -1224,7 +1253,7 @@ class TestChangeEmail:
 
     async def test_change_email_already_taken(self, client, user, db):
         # Create another user
-        password_hash = auth.hash_password("other")
+        password_hash = auth_mod.hash_password("other")
         await model.create_user(
             "other@example.com", password_hash, verified=True
         )
@@ -2172,7 +2201,7 @@ class TestWorkspaceRoutes:
 
 class TestWorkspaceSharingRoutes:
     async def _create_other_user(self):
-        password_hash = auth.hash_password("otherpass")
+        password_hash = auth_mod.hash_password("otherpass")
         return await model.create_user(
             "other@example.com", password_hash, verified=True
         )
@@ -3159,7 +3188,7 @@ class TestTransferOwnership:
         ws_id = resp.json()["id"]
 
         other = await model.create_user("xfer-other@test.com", "pass")
-        other_token = auth.create_token(other["id"], other["email"])
+        other_token = _auth().create_token(other["id"], other["email"])
         other_headers = {"Authorization": f"Bearer {other_token}"}
 
         await model.create_user("xfer-target2@test.com", "pass")
@@ -3216,7 +3245,7 @@ class TestTransferOwnership:
         assert resp.status_code == 200
 
         # New owner should be in the owners role group
-        target_token = auth.create_token(target["id"], target["email"])
+        target_token = _auth().create_token(target["id"], target["email"])
         target_headers = {"Authorization": f"Bearer {target_token}"}
         resp = await client.get(
             f"/api/v1/workspaces/{ws_id}/roles",
@@ -3640,7 +3669,7 @@ class TestUserSearch:
 
 class TestBrowserBridge:
     def _ws_token_headers(self, workspace_id="ws-test"):
-        token = auth.create_workspace_token(workspace_id)
+        token = _auth().create_workspace_token(workspace_id)
         return {"Authorization": f"Bearer {token}"}
 
     async def test_missing_token_returns_401(self, client, user):
@@ -3659,11 +3688,11 @@ class TestBrowserBridge:
         assert resp.status_code == 403
         assert "Unknown browser ID" in resp.json()["detail"]
 
-    async def test_expired_token_returns_401(self, client, user):
+    async def test_expired_token_returns_401(self, client, app, user):
         with patch.object(
-            auth,
+            app.state.auth,
             "decode_workspace_token",
-            return_value=auth.WORKSPACE_TOKEN_EXPIRED,
+            return_value=auth_mod.Auth.WORKSPACE_TOKEN_EXPIRED,
         ):
             resp = await client.post(
                 "/api/v1/browser-delegate",
@@ -4730,8 +4759,8 @@ class TestGroups:
 
     async def test_jwt_has_no_roles(self, user):
         """JWT tokens no longer include roles."""
-        token = auth.create_token(user["id"], "testuser@example.com")
-        payload = auth.decode_token(token)
+        token = _auth().create_token(user["id"], "testuser@example.com")
+        payload = _auth().decode_token(token)
         assert "roles" not in payload
 
     async def test_login_jwt_has_no_roles(self, client, user):
@@ -4741,7 +4770,7 @@ class TestGroups:
         )
         assert resp.status_code == 200
         token = resp.json()["access_token"]
-        payload = auth.decode_token(token)
+        payload = _auth().decode_token(token)
         assert "roles" not in payload
 
 
@@ -7206,7 +7235,9 @@ class TestInvitations:
         self, client, app, admin_user, monkeypatch
     ):
         headers = await self._admin_headers(client)
-        monkeypatch.setattr(auth, "invitations_enabled", lambda: False)
+        monkeypatch.setattr(
+            app.state.auth, "invitations_enabled", lambda: False
+        )
         resp = await client.post(
             "/api/v1/admin/invitations",
             headers=headers,
@@ -7589,7 +7620,7 @@ class TestInvitations:
                 json={"email": "accept@example.com"},
             )
         inv_id = create_resp.json()["id"]
-        token = auth.create_invitation_token(inv_id, "accept@example.com")
+        token = _auth().create_invitation_token(inv_id, "accept@example.com")
 
         resp = await client.post(
             "/api/v1/auth/accept-invite",
@@ -7628,7 +7659,7 @@ class TestInvitations:
                 json={"email": "double@example.com"},
             )
         inv_id = create_resp.json()["id"]
-        token = auth.create_invitation_token(inv_id, "double@example.com")
+        token = _auth().create_invitation_token(inv_id, "double@example.com")
 
         # Accept once
         await client.post(
@@ -7656,7 +7687,7 @@ class TestInvitations:
                 json={"email": "short@example.com"},
             )
         inv_id = create_resp.json()["id"]
-        token = auth.create_invitation_token(inv_id, "short@example.com")
+        token = _auth().create_invitation_token(inv_id, "short@example.com")
 
         resp = await client.post(
             "/api/v1/auth/accept-invite",
@@ -7680,10 +7711,12 @@ class TestInvitations:
                 json={"email": "noreg@example.com"},
             )
         inv_id = create_resp.json()["id"]
-        token = auth.create_invitation_token(inv_id, "noreg@example.com")
+        token = _auth().create_invitation_token(inv_id, "noreg@example.com")
 
         # Disable registration
-        monkeypatch.setattr(auth, "registration_enabled", lambda: False)
+        monkeypatch.setattr(
+            app.state.auth, "registration_enabled", lambda: False
+        )
 
         # Accept-invite should still work
         resp = await client.post(
@@ -7708,11 +7741,11 @@ class TestInvitations:
                 json={"email": "race@example.com"},
             )
         inv_id = create_resp.json()["id"]
-        token = auth.create_invitation_token(inv_id, "race@example.com")
+        token = _auth().create_invitation_token(inv_id, "race@example.com")
 
         # Simulate race: create user with that email before accepting
         await model.create_user(
-            "race@example.com", auth.hash_password("pass"), verified=True
+            "race@example.com", auth_mod.hash_password("pass"), verified=True
         )
 
         resp = await client.post(
@@ -7724,7 +7757,7 @@ class TestInvitations:
 
     async def test_accept_invite_wrong_purpose_token(self, client, db):
         # Use a verification token (wrong purpose)
-        token = auth.create_verification_token("fake-user-id")
+        token = _auth().create_verification_token("fake-user-id")
         resp = await client.post(
             "/api/v1/auth/accept-invite",
             json={"token": token, "password": "newpassword"},
@@ -7740,13 +7773,13 @@ class TestInvitations:
         self, client, app, monkeypatch
     ):
         # Default: flag unset -> not allowed, so the UI hides its checkbox.
-        monkeypatch.delenv("KLANGK_ALLOW_AUTOSTART", raising=False)
+        monkeypatch.setattr(app.state.settings, "allow_autostart", None)
         resp = await client.get("/api/v1/config")
         assert resp.status_code == 200
         assert resp.json()["allow_autostart"] is False
 
         # Flag set -> advertised as true so the UI may show the checkbox.
-        monkeypatch.setenv("KLANGK_ALLOW_AUTOSTART", "1")
+        monkeypatch.setattr(app.state.settings, "allow_autostart", "1")
         resp = await client.get("/api/v1/config")
         assert resp.json()["allow_autostart"] is True
 
@@ -8579,7 +8612,7 @@ class TestOIDCLogout:
             provider="test",
             external_id="logout-sub",
         )
-        token = auth.create_token(user["id"], user["email"])
+        token = _auth().create_token(user["id"], user["email"])
         headers = {"Authorization": f"Bearer {token}"}
 
         provider = api.oidc.OIDCProvider(
@@ -8629,7 +8662,7 @@ class TestOIDCLogout:
             provider="test",
             external_id="nologout-sub",
         )
-        token = auth.create_token(user["id"], user["email"])
+        token = _auth().create_token(user["id"], user["email"])
         headers = {"Authorization": f"Bearer {token}"}
 
         provider = api.oidc.OIDCProvider(

--- a/src/backend/tests/test_auth.py
+++ b/src/backend/tests/test_auth.py
@@ -11,6 +11,24 @@ from jose import jwt
 from klangk_backend import auth, model
 from klangk_backend.exceptions import ConfigurationError
 from sqlalchemy.exc import IntegrityError as SAIntegrityError
+import types as _types
+
+from _helpers import make_settings
+from klangk_backend.auth import Auth
+
+
+def _auth(env=None):
+    """Build an Auth instance from explicit env (no os.environ)."""
+    return Auth(_types.SimpleNamespace(settings=make_settings(env)))
+
+
+def _req(auth=None):
+    """A request-like with app.state.auth for the FastAPI dep callables."""
+    if auth is None:
+        auth = _auth()
+    return _types.SimpleNamespace(
+        app=_types.SimpleNamespace(state=_types.SimpleNamespace(auth=auth))
+    )
 
 
 class TestPasswordHashing:
@@ -45,70 +63,47 @@ class TestPasswordHashing:
 class TestSecurityDefaults:
     """Lock in the hardened auth defaults introduced in #938.
 
-    These module-level constants are evaluated at import time from env
-    vars, so to assert the *production* defaults we spawn a subprocess
-    with the policy env vars stripped — independent of whatever the
-    test process (or a developer's shell) has set. A regression that
+    Auth reads settings at construction (#1501), so the production
+    defaults are asserted directly — no subprocess dance needed (that
+    was a workaround for the import-time globals). A regression that
     weakens either default fails here.
     """
 
     def test_hardened_defaults_when_env_unset(self):
-        import subprocess
-        import sys
-
-        code = (
-            "import os\n"
-            "for k in ('KLANGK_MIN_PASSWORD_LENGTH',"
-            " 'KLANGK_LOGIN_LOCKOUT_FAILURES'):\n"
-            "    os.environ.pop(k, None)\n"
-            "from klangk_backend import auth\n"
-            "print(auth.MIN_PASSWORD_LENGTH,"
-            " auth.LOGIN_LOCKOUT_FAILURES)\n"
-        )
-        env = {
-            k: v
-            for k, v in os.environ.items()
-            if k
-            not in (
-                "KLANGK_MIN_PASSWORD_LENGTH",
-                "KLANGK_LOGIN_LOCKOUT_FAILURES",
-            )
-        }
-        out = subprocess.check_output(
-            [sys.executable, "-c", code], env=env, text=True
-        ).strip()
-        # MIN_PASSWORD_LENGTH=8, LOGIN_LOCKOUT_FAILURES=5 (both on by
+        a = _auth()  # unset policy env -> production defaults
+        # min_password_length=8, login_lockout_failures=5 (both on by
         # default — brute-force protection and a sane password floor).
-        assert out == "8 5"
+        assert a.min_password_length == 8
+        assert a.login_lockout_failures == 5
 
 
 class TestValidatePasswordLength:
     def test_rejects_short_password(self):
         with pytest.raises(HTTPException) as exc_info:
-            auth.validate_password_length("")
+            _auth().validate_password_length("")
         assert exc_info.value.status_code == 400
         assert "at least" in exc_info.value.detail
 
     def test_rejects_over_72_bytes(self):
         with pytest.raises(HTTPException) as exc_info:
-            auth.validate_password_length("a" * 73)
+            _auth().validate_password_length("a" * 73)
         assert exc_info.value.status_code == 400
         assert "72 bytes" in exc_info.value.detail
 
     def test_rejects_multibyte_over_72_bytes(self):
         pw = "\u00e9" * 37  # 2 bytes each = 74 bytes
         with pytest.raises(HTTPException) as exc_info:
-            auth.validate_password_length(pw)
+            _auth().validate_password_length(pw)
         assert exc_info.value.status_code == 400
 
     def test_accepts_valid_password(self):
-        auth.validate_password_length("goodpass")
+        _auth().validate_password_length("goodpass")
 
 
 class TestJWT:
     def test_create_and_decode_token(self):
-        token = auth.create_token("user-123", "alice@example.com")
-        payload = auth.decode_token(token)
+        token = _auth().create_token("user-123", "alice@example.com")
+        payload = _auth().decode_token(token)
         assert payload["sub"] == "user-123"
         assert payload["email"] == "alice@example.com"
         assert "jti" in payload
@@ -118,14 +113,14 @@ class TestJWT:
         from jose import JWTError
 
         with pytest.raises(JWTError):
-            auth.decode_token("garbage.token.value")
+            _auth().decode_token("garbage.token.value")
 
 
 class TestRegister:
-    async def test_register_disabled(self, db, monkeypatch):
-        monkeypatch.setenv("KLANGK_DISABLE_REGISTRATION", "true")
+    async def test_register_disabled(self, db):
+        a = _auth({"KLANGK_DISABLE_REGISTRATION": "true"})
         with pytest.raises(HTTPException) as exc_info:
-            await auth.register(
+            await a.register(
                 auth.RegisterRequest(
                     email="blocked@example.com", password="pass1234"
                 )
@@ -133,7 +128,7 @@ class TestRegister:
         assert exc_info.value.status_code == 403
 
     async def test_register_success(self, db):
-        result = await auth.register(
+        result = await _auth().register(
             auth.RegisterRequest(email="new@example.com", password="pass1234")
         )
         assert result.user_id
@@ -141,7 +136,7 @@ class TestRegister:
         assert result.access_token is None  # unverified, no token
 
     async def test_register_verified(self, db):
-        result = await auth.register(
+        result = await _auth().register(
             auth.RegisterRequest(
                 email="verified@example.com", password="pass1234"
             ),
@@ -151,11 +146,11 @@ class TestRegister:
         assert result.email == "verified@example.com"
 
     async def test_register_duplicate_email(self, db):
-        await auth.register(
+        await _auth().register(
             auth.RegisterRequest(email="dup@example.com", password="pass1234")
         )
         with pytest.raises(HTTPException) as exc_info:
-            await auth.register(
+            await _auth().register(
                 auth.RegisterRequest(
                     email="dup@example.com", password="pass5678"
                 )
@@ -173,7 +168,7 @@ class TestRegister:
             ),
         ):
             with pytest.raises(HTTPException) as exc_info:
-                await auth.register(
+                await _auth().register(
                     auth.RegisterRequest(
                         email="race@example.com", password="pass1234"
                     )
@@ -183,38 +178,37 @@ class TestRegister:
 
     async def test_register_invalid_email(self, db):
         with pytest.raises(HTTPException) as exc_info:
-            await auth.register(
+            await _auth().register(
                 auth.RegisterRequest(email="not-an-email", password="pass1234")
             )
         assert exc_info.value.status_code == 400
 
     async def test_register_short_password(self, db):
         with pytest.raises(HTTPException) as exc_info:
-            await auth.register(
+            await _auth().register(
                 auth.RegisterRequest(email="valid@example.com", password="abc")
             )
         assert exc_info.value.status_code == 400
 
-    async def test_register_password_length_configurable(
-        self, db, monkeypatch
-    ):
-        """MIN_PASSWORD_LENGTH can be overridden via env var."""
-        monkeypatch.setattr(auth, "MIN_PASSWORD_LENGTH", 8)
+    async def test_register_password_length_configurable(self, db):
+        """min_password_length is read from settings at construction."""
+        # A non-default floor (10): 9 chars fails, 10 succeeds.
+        a = _auth({"KLANGK_MIN_PASSWORD_LENGTH": "10"})
         with pytest.raises(HTTPException) as exc_info:
-            await auth.register(
+            await a.register(
                 auth.RegisterRequest(
-                    email="valid@example.com", password="1234567"
+                    email="valid@example.com", password="123456789"
                 )
             )
         assert exc_info.value.status_code == 400
         assert (
-            "8" in exc_info.value.detail
+            "10" in exc_info.value.detail
         )  # error message includes the length
 
-        # 8 chars should succeed
-        result = await auth.register(
+        # 10 chars should succeed
+        result = await a.register(
             auth.RegisterRequest(
-                email="valid@example.com", password="12345678"
+                email="valid2@example.com", password="1234567890"
             )
         )
         assert result.user_id
@@ -222,7 +216,7 @@ class TestRegister:
 
 class TestLogin:
     async def test_login_success(self, user):
-        result = await auth.login(
+        result = await _auth().login(
             auth.LoginRequest(
                 email="testuser@example.com", password="testpass"
             )
@@ -232,7 +226,7 @@ class TestLogin:
 
     async def test_login_wrong_password(self, user):
         with pytest.raises(HTTPException) as exc_info:
-            await auth.login(
+            await _auth().login(
                 auth.LoginRequest(
                     email="testuser@example.com", password="wrong"
                 )
@@ -246,7 +240,7 @@ class TestLogin:
             "oidc@example.com", None, verified=True, provider="oidc"
         )
         with pytest.raises(HTTPException) as exc_info:
-            await auth.login(
+            await _auth().login(
                 auth.LoginRequest(
                     email="oidc@example.com", password="anything"
                 )
@@ -262,7 +256,7 @@ class TestLogin:
             "unverified@example.com", password_hash, verified=False
         )
         with pytest.raises(HTTPException) as exc_info:
-            await auth.login(
+            await _auth().login(
                 auth.LoginRequest(
                     email="unverified@example.com", password="testpass"
                 )
@@ -272,7 +266,7 @@ class TestLogin:
 
     async def test_login_nonexistent_user(self, db):
         with pytest.raises(HTTPException) as exc_info:
-            await auth.login(
+            await _auth().login(
                 auth.LoginRequest(email="noone@example.com", password="pass")
             )
         assert exc_info.value.status_code == 401
@@ -310,32 +304,32 @@ class TestLoginRateLimit:
 
     async def test_login_wrong_password_records_attempt(self, user):
         """Wrong password increments attempt count."""
-        for i in range(auth.LOGIN_LOCKOUT_FAILURES - 1):
+        for i in range(_auth().login_lockout_failures - 1):
             with pytest.raises(HTTPException) as exc_info:
-                await auth.login(
+                await _auth().login(
                     auth.LoginRequest(
                         email="testuser@example.com", password="wrong"
                     )
                 )
             assert exc_info.value.status_code == 401
         info = await model.get_login_attempt_info("testuser@example.com")
-        assert info["attempt_count"] == auth.LOGIN_LOCKOUT_FAILURES - 1
+        assert info["attempt_count"] == _auth().login_lockout_failures - 1
 
     async def test_login_lockout_after_max_attempts(self, user):
         """Locked out after LOGIN_LOCKOUT_FAILURES failed attempts."""
-        for i in range(auth.LOGIN_LOCKOUT_FAILURES):
+        for i in range(_auth().login_lockout_failures):
             with pytest.raises(HTTPException) as exc_info:
-                await auth.login(
+                await _auth().login(
                     auth.LoginRequest(
                         email="testuser@example.com", password="wrong"
                     )
                 )
-            if i < auth.LOGIN_LOCKOUT_FAILURES - 1:
+            if i < _auth().login_lockout_failures - 1:
                 assert exc_info.value.status_code == 401
             else:
                 assert exc_info.value.status_code == 429
         with pytest.raises(HTTPException) as exc_info:
-            await auth.login(
+            await _auth().login(
                 auth.LoginRequest(
                     email="testuser@example.com", password="wrong"
                 )
@@ -357,13 +351,13 @@ class TestLoginRateLimit:
                 " VALUES (?, ?, ?)",
                 (
                     "testuser@example.com",
-                    auth.LOGIN_LOCKOUT_FAILURES - 1,
+                    _auth().login_lockout_failures - 1,
                     old,
                 ),
             )
         # A wrong password now: window elapsed -> reset, not lock.
         with pytest.raises(HTTPException) as exc_info:
-            await auth.login(
+            await _auth().login(
                 auth.LoginRequest(
                     email="testuser@example.com", password="wrong"
                 )
@@ -374,17 +368,19 @@ class TestLoginRateLimit:
 
     def test_window_elapsed_policy(self):
         """window_elapsed decides whether the sliding window has passed."""
-        assert auth.window_elapsed(None) is False
-        assert auth.window_elapsed({"first_attempt_at": None}) is False
+        assert _auth().window_elapsed(None) is False
+        assert _auth().window_elapsed({"first_attempt_at": None}) is False
         # Unparseable timestamp is treated as not-elapsed (safe default).
-        assert auth.window_elapsed({"first_attempt_at": "not-a-date"}) is False
+        assert (
+            _auth().window_elapsed({"first_attempt_at": "not-a-date"}) is False
+        )
         old = (
             datetime.now(timezone.utc)
-            - timedelta(seconds=auth.LOGIN_LOCKOUT_WINDOW + 1)
+            - timedelta(seconds=_auth().login_lockout_window + 1)
         ).isoformat()
-        assert auth.window_elapsed({"first_attempt_at": old}) is True
+        assert _auth().window_elapsed({"first_attempt_at": old}) is True
         recent = datetime.now(timezone.utc).isoformat()
-        assert auth.window_elapsed({"first_attempt_at": recent}) is False
+        assert _auth().window_elapsed({"first_attempt_at": recent}) is False
 
     async def test_login_lockout_message_shows_remaining_time(self, user):
         """Lockout message includes remaining minutes."""
@@ -394,7 +390,7 @@ class TestLoginRateLimit:
             "testuser@example.com", locked_until.isoformat()
         )
         with pytest.raises(HTTPException) as exc_info:
-            await auth.login(
+            await _auth().login(
                 auth.LoginRequest(
                     email="testuser@example.com", password="wrong"
                 )
@@ -409,7 +405,7 @@ class TestLoginRateLimit:
         await model.set_login_lockout(
             "testuser@example.com", expired_until.isoformat()
         )
-        result = await auth.login(
+        result = await _auth().login(
             auth.LoginRequest(
                 email="testuser@example.com", password="testpass"
             )
@@ -424,7 +420,7 @@ class TestLoginRateLimit:
             "testuser@example.com", locked_until.isoformat()
         )
         with pytest.raises(HTTPException) as exc_info:
-            await auth.login(
+            await _auth().login(
                 auth.LoginRequest(
                     email="testuser@example.com", password="testpass"
                 )
@@ -433,14 +429,14 @@ class TestLoginRateLimit:
 
     async def test_should_lockout_helper(self, db):
         """should_lockout returns True at threshold, False below/above."""
-        assert auth.should_lockout({"attempt_count": 4}) is False
-        assert auth.should_lockout({"attempt_count": 5}) is True
-        assert auth.should_lockout(None) is False
+        assert _auth().should_lockout({"attempt_count": 4}) is False
+        assert _auth().should_lockout({"attempt_count": 5}) is True
+        assert _auth().should_lockout(None) is False
 
     async def test_should_lockout_respects_configured_threshold(self, db):
         """should_lockout uses LOGIN_LOCKOUT_FAILURES as the threshold."""
-        assert auth.should_lockout({"attempt_count": 5}) is True
-        assert auth.should_lockout({"attempt_count": 4}) is False
+        assert _auth().should_lockout({"attempt_count": 5}) is True
+        assert _auth().should_lockout({"attempt_count": 4}) is False
 
     async def test_is_locked_out_helper(self, db):
         """is_locked_out returns True/msg when locked_until is in the future."""
@@ -458,12 +454,12 @@ class TestLoginRateLimit:
         assert auth.is_locked_out(no_lock) == (False, None)
         assert auth.is_locked_out(None) == (False, None)
 
-    async def test_login_lockout_disabled_when_zero(self, db, monkeypatch):
-        """With LOGIN_LOCKOUT_FAILURES=0, no rate limiting occurs."""
-        monkeypatch.setattr(auth, "LOGIN_LOCKOUT_FAILURES", 0)
+    async def test_login_lockout_disabled_when_zero(self, db):
+        """With login_lockout_failures=0, no rate limiting occurs."""
+        a = _auth({"KLANGK_LOGIN_LOCKOUT_FAILURES": "0"})
         for _ in range(20):
             with pytest.raises(HTTPException) as exc_info:
-                await auth.login(
+                await a.login(
                     auth.LoginRequest(
                         email="testuser@example.com", password="wrong"
                     )
@@ -472,14 +468,14 @@ class TestLoginRateLimit:
 
     async def test_login_nonexistent_user_also_rate_limited(self, db):
         """Nonexistent users are also rate-limited to prevent enumeration."""
-        for i in range(auth.LOGIN_LOCKOUT_FAILURES):
+        for i in range(_auth().login_lockout_failures):
             with pytest.raises(HTTPException) as exc_info:
-                await auth.login(
+                await _auth().login(
                     auth.LoginRequest(
                         email="nobody@example.com", password="wrong"
                     )
                 )
-            if i < auth.LOGIN_LOCKOUT_FAILURES - 1:
+            if i < _auth().login_lockout_failures - 1:
                 assert exc_info.value.status_code == 401
             else:
                 assert exc_info.value.status_code == 429
@@ -488,7 +484,7 @@ class TestLoginRateLimit:
         """Successful login clears failed attempt counts."""
         await model.record_failed_login("testuser@example.com")
         await model.record_failed_login("testuser@example.com")
-        result = await auth.login(
+        result = await _auth().login(
             auth.LoginRequest(
                 email="testuser@example.com", password="testpass"
             )
@@ -500,17 +496,17 @@ class TestLoginRateLimit:
 
 class TestVerification:
     def test_create_and_decode_verification_token(self):
-        token = auth.create_verification_token("user-123")
-        user_id = auth.decode_verification_token(token)
+        token = _auth().create_verification_token("user-123")
+        user_id = _auth().decode_verification_token(token)
         assert user_id == "user-123"
 
     def test_decode_invalid_token(self):
-        assert auth.decode_verification_token("garbage") is None
+        assert _auth().decode_verification_token("garbage") is None
 
     def test_decode_wrong_purpose(self):
         # A regular auth token should not pass as a verification token
-        token = auth.create_token("user-123", "test")
-        assert auth.decode_verification_token(token) is None
+        token = _auth().create_token("user-123", "test")
+        assert _auth().decode_verification_token(token) is None
 
     async def test_verify_user(self, db):
         import bcrypt
@@ -532,97 +528,97 @@ class TestVerification:
 
 class TestPasswordReset:
     def test_create_and_decode_reset_token(self):
-        token = auth.create_password_reset_token("user-456")
-        assert auth.decode_password_reset_token(token) == "user-456"
+        token = _auth().create_password_reset_token("user-456")
+        assert _auth().decode_password_reset_token(token) == "user-456"
 
     def test_decode_invalid_token(self):
-        assert auth.decode_password_reset_token("garbage") is None
+        assert _auth().decode_password_reset_token("garbage") is None
 
     def test_reset_and_verify_tokens_not_interchangeable(self):
-        reset = auth.create_password_reset_token("user-456")
-        verify = auth.create_verification_token("user-456")
-        assert auth.decode_verification_token(reset) is None
-        assert auth.decode_password_reset_token(verify) is None
+        reset = _auth().create_password_reset_token("user-456")
+        verify = _auth().create_verification_token("user-456")
+        assert _auth().decode_verification_token(reset) is None
+        assert _auth().decode_password_reset_token(verify) is None
 
 
 class TestWorkspaceToken:
     def test_create_and_decode_workspace_token(self):
-        token = auth.create_workspace_token("ws-123")
-        assert auth.decode_workspace_token(token) == "ws-123"
+        token = _auth().create_workspace_token("ws-123")
+        assert _auth().decode_workspace_token(token) == "ws-123"
 
     def test_decode_invalid_token(self):
-        assert auth.decode_workspace_token("garbage") is None
+        assert _auth().decode_workspace_token("garbage") is None
 
     def test_user_token_rejected(self):
-        user_token = auth.create_token("user-1", "u@test.com")
-        assert auth.decode_workspace_token(user_token) is None
+        user_token = _auth().create_token("user-1", "u@test.com")
+        assert _auth().decode_workspace_token(user_token) is None
 
     def test_verify_token_rejected(self):
-        verify_token = auth.create_verification_token("user-1")
-        assert auth.decode_workspace_token(verify_token) is None
+        verify_token = _auth().create_verification_token("user-1")
+        assert _auth().decode_workspace_token(verify_token) is None
 
     def test_workspace_token_rejected_by_other_decoders(self):
-        ws_token = auth.create_workspace_token("ws-123")
-        assert auth.decode_verification_token(ws_token) is None
-        assert auth.decode_password_reset_token(ws_token) is None
+        ws_token = _auth().create_workspace_token("ws-123")
+        assert _auth().decode_verification_token(ws_token) is None
+        assert _auth().decode_password_reset_token(ws_token) is None
 
 
 class TestTokenValidation:
     async def test_get_user_from_valid_token(self, user):
-        token = auth.create_token(user["id"], user["email"])
-        result = await auth.get_user_from_token(token)
+        token = _auth().create_token(user["id"], user["email"])
+        result = await _auth().get_user_from_token(token)
         assert result is not None
         assert result["id"] == user["id"]
 
     async def test_get_user_from_invalid_token(self, db):
-        result = await auth.get_user_from_token("invalid.token.here")
+        result = await _auth().get_user_from_token("invalid.token.here")
         assert result is None
 
     async def test_blocklisted_token_rejected(self, user):
-        token = auth.create_token(user["id"], user["email"])
+        token = _auth().create_token(user["id"], user["email"])
         # Token should work before blocklisting
-        assert await auth.get_user_from_token(token) is not None
+        assert await _auth().get_user_from_token(token) is not None
         # Blocklist it
-        await auth.logout(token)
+        await _auth().logout(token)
         # Now it should fail
-        assert await auth.get_user_from_token(token) is None
+        assert await _auth().get_user_from_token(token) is None
 
     async def test_get_user_from_token_missing_sub(self, db):
         """Token with no 'sub' claim returns None."""
         token = jwt.encode(
             {"email": "x", "jti": "j1", "exp": 9999999999},
-            auth.SECRET_KEY,
-            algorithm=auth.ALGORITHM,
+            _auth().secret,
+            algorithm=_auth().algorithm,
         )
-        assert await auth.get_user_from_token(token) is None
+        assert await _auth().get_user_from_token(token) is None
 
     async def test_get_user_from_token_missing_jti(self, db):
         """Token with no 'jti' claim returns None."""
         token = jwt.encode(
             {"sub": "uid", "email": "x", "exp": 9999999999},
-            auth.SECRET_KEY,
-            algorithm=auth.ALGORITHM,
+            _auth().secret,
+            algorithm=_auth().algorithm,
         )
-        assert await auth.get_user_from_token(token) is None
+        assert await _auth().get_user_from_token(token) is None
 
     async def test_get_user_from_token_deleted_user(self, user):
         """Token for a user that no longer exists returns None."""
-        token = auth.create_token("nonexistent-id", "ghost@example.com")
-        assert await auth.get_user_from_token(token) is None
+        token = _auth().create_token("nonexistent-id", "ghost@example.com")
+        assert await _auth().get_user_from_token(token) is None
 
 
 class TestGetCurrentUser:
     async def test_valid_credentials(self, user):
-        token = auth.create_token(user["id"], user["email"])
+        token = _auth().create_token(user["id"], user["email"])
         creds = HTTPAuthorizationCredentials(
             scheme="Bearer", credentials=token
         )
-        result = await auth.get_current_user(creds)
+        result = await auth.get_current_user(_req(), creds)
         assert result["id"] == user["id"]
 
     async def test_no_credentials(self, db):
         with pytest.raises(HTTPException) as exc_info:
-            await auth.get_current_user(None)
+            await auth.get_current_user(_req(), None)
         assert exc_info.value.status_code == 401
 
     async def test_invalid_token(self, db):
@@ -630,106 +626,106 @@ class TestGetCurrentUser:
             scheme="Bearer", credentials="bad.token.here"
         )
         with pytest.raises(HTTPException) as exc_info:
-            await auth.get_current_user(creds)
+            await auth.get_current_user(_req(), creds)
         assert exc_info.value.status_code == 401
 
     async def test_missing_sub_in_token(self, db):
         token = jwt.encode(
             {"email": "x", "jti": "j1", "exp": 9999999999},
-            auth.SECRET_KEY,
-            algorithm=auth.ALGORITHM,
+            _auth().secret,
+            algorithm=_auth().algorithm,
         )
         creds = HTTPAuthorizationCredentials(
             scheme="Bearer", credentials=token
         )
         with pytest.raises(HTTPException) as exc_info:
-            await auth.get_current_user(creds)
+            await auth.get_current_user(_req(), creds)
         assert exc_info.value.status_code == 401
 
     async def test_blocklisted_token(self, user):
-        token = auth.create_token(user["id"], user["email"])
-        await auth.logout(token)
+        token = _auth().create_token(user["id"], user["email"])
+        await _auth().logout(token)
         creds = HTTPAuthorizationCredentials(
             scheme="Bearer", credentials=token
         )
         with pytest.raises(HTTPException) as exc_info:
-            await auth.get_current_user(creds)
+            await auth.get_current_user(_req(), creds)
         assert exc_info.value.status_code == 401
 
     async def test_deleted_user(self, user):
-        token = auth.create_token("nonexistent-id", "ghost@example.com")
+        token = _auth().create_token("nonexistent-id", "ghost@example.com")
         creds = HTTPAuthorizationCredentials(
             scheme="Bearer", credentials=token
         )
         with pytest.raises(HTTPException) as exc_info:
-            await auth.get_current_user(creds)
+            await auth.get_current_user(_req(), creds)
         assert exc_info.value.status_code == 401
 
 
 class TestGetCurrentUserOptional:
     async def test_valid_credentials(self, user):
-        token = auth.create_token(user["id"], user["email"])
+        token = _auth().create_token(user["id"], user["email"])
         creds = HTTPAuthorizationCredentials(
             scheme="Bearer", credentials=token
         )
-        result = await auth.get_current_user_optional(creds)
+        result = await auth.get_current_user_optional(_req(), creds)
         assert result is not None
         assert result["id"] == user["id"]
 
     async def test_no_credentials(self, db):
-        result = await auth.get_current_user_optional(None)
+        result = await auth.get_current_user_optional(_req(), None)
         assert result is None
 
     async def test_invalid_token(self, db):
         creds = HTTPAuthorizationCredentials(
             scheme="Bearer", credentials="bad.token"
         )
-        result = await auth.get_current_user_optional(creds)
+        result = await auth.get_current_user_optional(_req(), creds)
         assert result is None
 
     async def test_missing_sub(self, db):
         token = jwt.encode(
             {"email": "x", "jti": "j1", "exp": 9999999999},
-            auth.SECRET_KEY,
-            algorithm=auth.ALGORITHM,
+            _auth().secret,
+            algorithm=_auth().algorithm,
         )
         creds = HTTPAuthorizationCredentials(
             scheme="Bearer", credentials=token
         )
-        result = await auth.get_current_user_optional(creds)
+        result = await auth.get_current_user_optional(_req(), creds)
         assert result is None
 
     async def test_blocklisted_token(self, user):
-        token = auth.create_token(user["id"], user["email"])
-        await auth.logout(token)
+        token = _auth().create_token(user["id"], user["email"])
+        await _auth().logout(token)
         creds = HTTPAuthorizationCredentials(
             scheme="Bearer", credentials=token
         )
-        result = await auth.get_current_user_optional(creds)
+        result = await auth.get_current_user_optional(_req(), creds)
         assert result is None
 
     async def test_deleted_user(self, user):
-        token = auth.create_token("nonexistent-id", "ghost@example.com")
+        token = _auth().create_token("nonexistent-id", "ghost@example.com")
         creds = HTTPAuthorizationCredentials(
             scheme="Bearer", credentials=token
         )
-        result = await auth.get_current_user_optional(creds)
+        result = await auth.get_current_user_optional(_req(), creds)
         assert result is None
 
 
 class TestLogout:
     async def test_logout_invalid_token(self, db):
         """Logout with garbage token should not raise."""
-        await auth.logout("not.a.valid.token")
+        await _auth().logout("not.a.valid.token")
 
     async def test_logout_token_without_jti(self, db):
         """Logout with token missing jti should not raise."""
         token = jwt.encode(
             {"sub": "uid", "exp": 9999999999},
-            auth.SECRET_KEY,
-            algorithm=auth.ALGORITHM,
+            _auth().secret,
+            algorithm=_auth().algorithm,
         )
-        await auth.logout(token)
+        await _auth().logout(token)
 
 
 class TestRefreshToken:
@@ -739,11 +735,11 @@ class TestRefreshToken:
             "a@b.com", auth.hash_password("pw"), verified=True
         )
         user = await model.get_user_by_email("a@b.com")
-        token = auth.create_token(user["id"], user["email"])
-        result = await auth.refresh_token(token)
+        token = _auth().create_token(user["id"], user["email"])
+        result = await _auth().refresh_token(token)
         assert result.access_token != token
         # Old JTI should be blocklisted
-        old_payload = auth.decode_token(token, allow_expired=True)
+        old_payload = _auth().decode_token(token, allow_expired=True)
         assert await model.is_token_blocklisted(old_payload["jti"])
 
     async def test_refresh_idempotent(self, db):
@@ -752,9 +748,9 @@ class TestRefreshToken:
             "a@b.com", auth.hash_password("pw"), verified=True
         )
         user = await model.get_user_by_email("a@b.com")
-        token = auth.create_token(user["id"], user["email"])
-        result1 = await auth.refresh_token(token)
-        result2 = await auth.refresh_token(token)
+        token = _auth().create_token(user["id"], user["email"])
+        result1 = await _auth().refresh_token(token)
+        result2 = await _auth().refresh_token(token)
         assert result1.access_token == result2.access_token
 
     async def test_refresh_expired_token_returns_401(self, db):
@@ -770,11 +766,11 @@ class TestRefreshToken:
                 "jti": "expired-jti",
                 "exp": datetime.now(timezone.utc) - timedelta(hours=1),
             },
-            auth.SECRET_KEY,
-            algorithm=auth.ALGORITHM,
+            _auth().secret,
+            algorithm=_auth().algorithm,
         )
         with pytest.raises(HTTPException) as exc_info:
-            await auth.refresh_token(expired)
+            await _auth().refresh_token(expired)
         assert exc_info.value.status_code == 401
 
     async def test_refresh_expired_token_with_prior_refresh(self, db):
@@ -797,10 +793,10 @@ class TestRefreshToken:
                 "jti": "old-jti",
                 "exp": datetime.now(timezone.utc) - timedelta(seconds=1),
             },
-            auth.SECRET_KEY,
-            algorithm=auth.ALGORITHM,
+            _auth().secret,
+            algorithm=_auth().algorithm,
         )
-        result = await auth.refresh_token(expired)
+        result = await _auth().refresh_token(expired)
         assert result.access_token == "cached-new-token"
 
     async def test_refresh_expired_returns_cached_regardless_of_blocklist_expiry(
@@ -826,17 +822,17 @@ class TestRefreshToken:
                 "jti": "old-jti",
                 "exp": datetime.now(timezone.utc) - timedelta(hours=2),
             },
-            auth.SECRET_KEY,
-            algorithm=auth.ALGORITHM,
+            _auth().secret,
+            algorithm=_auth().algorithm,
         )
-        result = await auth.refresh_token(expired)
+        result = await _auth().refresh_token(expired)
         assert result.access_token == "cached-replacement"
 
     async def test_refresh_deleted_user_returns_401(self, db):
         """Refreshing a token for a deleted user returns 401."""
-        token = auth.create_token("nonexistent-user", "gone@example.com")
+        token = _auth().create_token("nonexistent-user", "gone@example.com")
         with pytest.raises(HTTPException) as exc_info:
-            await auth.refresh_token(token)
+            await _auth().refresh_token(token)
         assert exc_info.value.status_code == 401
 
     async def test_refresh_revoked_token_returns_401(self, db):
@@ -845,83 +841,88 @@ class TestRefreshToken:
             "a@b.com", auth.hash_password("pw"), verified=True
         )
         user = await model.get_user_by_email("a@b.com")
-        token = auth.create_token(user["id"], user["email"])
-        await auth.logout(token)
+        token = _auth().create_token(user["id"], user["email"])
+        await _auth().logout(token)
         with pytest.raises(HTTPException) as exc_info:
-            await auth.refresh_token(token)
+            await _auth().refresh_token(token)
         assert exc_info.value.status_code == 401
 
-    def test_configurable_token_expire_hours(self, monkeypatch):
-        """TOKEN_EXPIRE_HOURS reads from KLANGK_ACCESS_TOKEN_HOURS."""
-        monkeypatch.setenv("KLANGK_ACCESS_TOKEN_HOURS", "48")
-        # Re-evaluate the module-level constant
-        result = int(auth.resolve_env_value("KLANGK_ACCESS_TOKEN_HOURS", "24"))
-        assert result == 48
+    def test_configurable_token_expire_hours(self):
+        """token_expire_hours reads from settings at construction."""
+        a = _auth({"KLANGK_ACCESS_TOKEN_HOURS": "48"})
+        assert a.token_expire_hours == 48.0
 
 
 class TestInvitationTokens:
     def test_roundtrip(self):
-        token = auth.create_invitation_token("inv-123", "user@example.com")
-        result = auth.decode_invitation_token(token)
+        token = _auth().create_invitation_token("inv-123", "user@example.com")
+        result = _auth().decode_invitation_token(token)
         assert result == ("inv-123", "user@example.com")
 
     def test_wrong_purpose_rejected(self):
-        token = auth.create_verification_token("uid")
-        assert auth.decode_invitation_token(token) is None
+        token = _auth().create_verification_token("uid")
+        assert _auth().decode_invitation_token(token) is None
 
     def test_invalid_token_returns_none(self):
-        assert auth.decode_invitation_token("garbage") is None
+        assert _auth().decode_invitation_token("garbage") is None
 
     def test_missing_email_returns_none(self):
         token = jwt.encode(
             {"sub": "inv-1", "purpose": "invite", "exp": 9999999999},
-            auth.SECRET_KEY,
-            algorithm=auth.ALGORITHM,
+            _auth().secret,
+            algorithm=_auth().algorithm,
         )
-        assert auth.decode_invitation_token(token) is None
+        assert _auth().decode_invitation_token(token) is None
 
     def test_missing_sub_returns_none(self):
         token = jwt.encode(
             {"email": "x@y.com", "purpose": "invite", "exp": 9999999999},
-            auth.SECRET_KEY,
-            algorithm=auth.ALGORITHM,
+            _auth().secret,
+            algorithm=_auth().algorithm,
         )
-        assert auth.decode_invitation_token(token) is None
+        assert _auth().decode_invitation_token(token) is None
 
 
 class TestInvitationsEnabled:
     def test_enabled_by_default(self):
-        assert auth.invitations_enabled() is True
+        assert _auth().invitations_enabled() is True
 
-    def test_disabled(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_DISABLE_INVITES", "true")
-        assert auth.invitations_enabled() is False
+    def test_disabled(self):
+        a = _auth({"KLANGK_DISABLE_INVITES": "true"})
+        assert a.invitations_enabled() is False
 
 
 class TestRequireSecureJwtSecret:
-    def test_secure_secret_passes(self, monkeypatch):
-        monkeypatch.setattr(auth, "SECRET_KEY", "a-real-strong-secret")
-        assert auth.jwt_secret_is_secure() is True
-        auth.require_secure_jwt_secret()  # no raise
+    def test_secure_secret_passes(self):
+        a = _auth({"KLANGK_JWT_SECRET": "a-real-strong-secret"})
+        assert a.jwt_secret_is_secure() is True
+        a.require_secure_jwt_secret()  # no raise
 
-    def test_default_secret_is_insecure(self, monkeypatch):
-        monkeypatch.setattr(auth, "SECRET_KEY", auth._INSECURE_DEFAULT_SECRET)
-        assert auth.jwt_secret_is_secure() is False
+    def test_default_secret_is_insecure(self):
+        a = _auth()  # unset -> INSECURE_DEFAULT_SECRET
+        assert a.jwt_secret_is_secure() is False
 
-    def test_default_secret_warns(self, monkeypatch):
-        monkeypatch.setattr(auth, "SECRET_KEY", auth._INSECURE_DEFAULT_SECRET)
-        monkeypatch.delenv("KLANGK_PREVENT_INSECURE_JWT_SECRET", raising=False)
-        auth.require_secure_jwt_secret()  # warns but does not raise
+    def test_default_secret_warns(self, caplog):
+        a = _auth()
+        import logging
 
-    def test_default_secret_blocks_with_prevent(self, monkeypatch):
-        monkeypatch.setattr(auth, "SECRET_KEY", auth._INSECURE_DEFAULT_SECRET)
-        monkeypatch.setenv("KLANGK_PREVENT_INSECURE_JWT_SECRET", "1")
+        with caplog.at_level(logging.WARNING, logger="klangk_backend.auth"):
+            a.require_secure_jwt_secret()  # warns but does not raise
+
+    def test_default_secret_blocks_with_prevent(self):
+        a = _auth({"KLANGK_PREVENT_INSECURE_JWT_SECRET": "1"})
         with pytest.raises(ConfigurationError, match="KLANGK_JWT_SECRET"):
-            auth.require_secure_jwt_secret()
+            a.require_secure_jwt_secret()
 
-    def test_empty_secret_blocks_with_prevent(self, monkeypatch):
-        monkeypatch.setattr(auth, "SECRET_KEY", "")
-        monkeypatch.setenv("KLANGK_PREVENT_INSECURE_JWT_SECRET", "1")
-        assert auth.jwt_secret_is_secure() is False
+    def test_empty_secret_blocks_with_prevent(self):
+        # jwt_secret unset falls back to the insecure default; an explicit
+        # empty string is also insecure and blocked when prevent is set.
+        a = _auth(
+            {
+                "KLANGK_JWT_SECRET": "",
+                "KLANGK_PREVENT_INSECURE_JWT_SECRET": "1",
+            }
+        )
+        assert a.jwt_secret_is_secure() is False
         with pytest.raises(ConfigurationError):
-            auth.require_secure_jwt_secret()
+            a.require_secure_jwt_secret()

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -10,7 +10,14 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from klangk_backend import bringup, container, model, podman, util as util_mod
+from klangk_backend import (
+    auth as auth_mod,
+    bringup,
+    container,
+    model,
+    podman,
+    util as util_mod,
+)
 from _helpers import make_settings
 
 
@@ -49,6 +56,8 @@ def _make_app_state(registry=None, sockets=None):
     app_state.workspaces = Workspaces(app_state)
     # #1503: container.py reaches derive_hosting_info via app_state.util.
     app_state.util = util_mod.Util(app_state)
+
+    app_state.auth = auth_mod.Auth(app_state)
     return app_state
 
 
@@ -727,8 +736,6 @@ class TestStartContainer:
 
     async def test_workspace_token_written_to_container(self, workspace):
         """Workspace token is written to the container via set_workspace_token."""
-        from klangk_backend import auth
-
         with (
             patch_podman(self.registry),
             patch.object(
@@ -744,7 +751,7 @@ class TestStartContainer:
         cid, token = mock_set.call_args.args
         assert cid == "new-cid"
         assert cid == "new-cid"
-        decoded_ws = auth.decode_workspace_token(token)
+        decoded_ws = self.registry.app_state.auth.decode_workspace_token(token)
         assert decoded_ws == workspace["id"]
 
     async def test_pull_policy_default_never(self, workspace):

--- a/src/backend/tests/test_emailsvc.py
+++ b/src/backend/tests/test_emailsvc.py
@@ -13,8 +13,11 @@ from klangk_backend.exceptions import SendmailError
 
 def _email_service(env: dict) -> EmailService:
     """Build an EmailService from explicit env (never touches the process env)."""
+    from klangk_backend.auth import Auth
+
     settings = make_settings(env)
     app_state = types.SimpleNamespace(settings=settings)
+    app_state.auth = Auth(app_state)
     return EmailService(app_state)
 
 

--- a/src/backend/tests/test_main.py
+++ b/src/backend/tests/test_main.py
@@ -15,6 +15,7 @@ from sqlalchemy.exc import IntegrityError as SAIntegrityError
 
 from klangk_backend import (
     agent as agent_mod,
+    auth as auth_mod,
     emailsvc as emailsvc_mod,
     util as util_mod,
     main,
@@ -53,6 +54,8 @@ def _make_app_state(settings=None):
     app_state.agents = agent_mod.Agents(app_state)
     app_state.email = emailsvc_mod.EmailService(app_state)
     app_state.util = util_mod.Util(app_state)
+
+    app_state.auth = auth_mod.Auth(app_state)
     return app_state
 
 
@@ -386,6 +389,8 @@ class TestLifespan:
         app.state.agents = agent_mod.Agents(app.state)
         app.state.email = emailsvc_mod.EmailService(app.state)
         app.state.util = util_mod.Util(app.state)
+
+        app.state.auth = auth_mod.Auth(app.state)
         registry = app_state.container_registry
         with (
             patch.object(
@@ -434,6 +439,8 @@ class TestLifespan:
         app.state.agents = agent_mod.Agents(app.state)
         app.state.email = emailsvc_mod.EmailService(app.state)
         app.state.util = util_mod.Util(app.state)
+
+        app.state.auth = auth_mod.Auth(app.state)
         registry = app_state.container_registry
         with (
             patch.object(
@@ -659,6 +666,8 @@ class TestStartupShutdownRestart:
         app.state.agents = agent_mod.Agents(app.state)
         app.state.email = emailsvc_mod.EmailService(app.state)
         app.state.util = util_mod.Util(app.state)
+
+        app.state.auth = auth_mod.Auth(app.state)
         registry = app_state.container_registry
         loop = asyncio.get_running_loop()
         with (
@@ -699,6 +708,8 @@ class TestSetupStaticFiles:
         _settings = make_settings({})
         test_app.state.settings = _settings
         test_app.state.util = util_mod.Util(test_app.state)
+
+        test_app.state.auth = auth_mod.Auth(test_app.state)
         main.setup_static_files(test_app, tmp_path)
 
         transport = ASGITransport(app=test_app)
@@ -716,6 +727,8 @@ class TestSetupStaticFiles:
         _settings = make_settings({})
         test_app.state.settings = _settings
         test_app.state.util = util_mod.Util(test_app.state)
+
+        test_app.state.auth = auth_mod.Auth(test_app.state)
         main.setup_static_files(test_app, tmp_path)
 
         transport = ASGITransport(app=test_app)
@@ -737,6 +750,8 @@ class TestSetupStaticFiles:
         _settings = make_settings({})
         test_app.state.settings = _settings
         test_app.state.util = util_mod.Util(test_app.state)
+
+        test_app.state.auth = auth_mod.Auth(test_app.state)
         main.setup_static_files(test_app, tmp_path)
 
         transport = ASGITransport(app=test_app)
@@ -756,6 +771,8 @@ class TestSetupStaticFiles:
         _settings = make_settings({})
         test_app.state.settings = _settings
         test_app.state.util = util_mod.Util(test_app.state)
+
+        test_app.state.auth = auth_mod.Auth(test_app.state)
         main.setup_static_files(test_app, tmp_path)
 
         transport = ASGITransport(app=test_app)
@@ -776,6 +793,8 @@ class TestSetupStaticFiles:
         _settings = make_settings({})
         test_app.state.settings = _settings
         test_app.state.util = util_mod.Util(test_app.state)
+
+        test_app.state.auth = auth_mod.Auth(test_app.state)
         main.setup_static_files(test_app, tmp_path)
 
         transport = ASGITransport(app=test_app)
@@ -799,6 +818,8 @@ class TestSetupStaticFiles:
         _settings = make_settings({"KLANGK_CUSTOMIZE_DIR": str(custom)})
         test_app.state.settings = _settings
         test_app.state.util = util_mod.Util(test_app.state)
+
+        test_app.state.auth = auth_mod.Auth(test_app.state)
         main.setup_static_files(test_app, tmp_path)
 
         branding_route = [
@@ -816,6 +837,8 @@ class TestSetupStaticFiles:
         _settings = make_settings({})
         test_app.state.settings = _settings
         test_app.state.util = util_mod.Util(test_app.state)
+
+        test_app.state.auth = auth_mod.Auth(test_app.state)
         main.setup_static_files(test_app, tmp_path)
 
         branding_route = [
@@ -830,6 +853,8 @@ class TestSetupStaticFiles:
         _settings = make_settings({})
         test_app.state.settings = _settings
         test_app.state.util = util_mod.Util(test_app.state)
+
+        test_app.state.auth = auth_mod.Auth(test_app.state)
         main.setup_static_files(test_app, tmp_path)
         transport = ASGITransport(app=test_app)
         async with AsyncClient(
@@ -849,6 +874,8 @@ class TestSetupStaticFiles:
         _settings = make_settings({})
         test_app.state.settings = _settings
         test_app.state.util = util_mod.Util(test_app.state)
+
+        test_app.state.auth = auth_mod.Auth(test_app.state)
         main.setup_static_files(test_app, tmp_path)
         transport = ASGITransport(app=test_app)
         async with AsyncClient(

--- a/src/backend/tests/test_mode_switching.py
+++ b/src/backend/tests/test_mode_switching.py
@@ -18,7 +18,7 @@ from httpx import ASGITransport, AsyncClient
 
 from klangk_backend import (
     api,
-    auth,
+    auth as auth_mod,
     emailsvc as emailsvc_mod,
     util as util_mod,
     main,
@@ -29,6 +29,13 @@ from klangk_backend import (
 from _helpers import make_settings
 from klangk_backend.main import register_exception_handlers
 from klangk_backend.util import API_PREFIX
+import types
+
+
+def _auth():
+    """Standalone Auth for token forging (default secret matches the app)."""
+    return auth_mod.Auth(types.SimpleNamespace(settings=make_settings({})))
+
 
 DEFAULT_EMAIL = "admin@example.com"
 SEEDED_PASSWORD = "seeded-pw"
@@ -62,6 +69,8 @@ async def mode_server(db, monkeypatch):
     app.state.plugins = plugins_mod.Plugins(app.state)
     app.state.email = emailsvc_mod.EmailService(app.state)
     app.state.util = util_mod.Util(app.state)
+
+    app.state.auth = auth_mod.Auth(app.state)
     app.include_router(api.root_router)
     app.include_router(api.router, prefix=API_PREFIX)
     register_exception_handlers(app)
@@ -348,7 +357,7 @@ class TestChangePasswordReality:
             "oidc-only@example.com", None, verified=True
         )
         # Mint a token for that user so the request authenticates.
-        oidc_token = auth.create_token(oidc_user["id"], oidc_user["email"])
+        oidc_token = _auth().create_token(oidc_user["id"], oidc_user["email"])
 
         resp = await client.post(
             "/api/v1/auth/change-password",

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -17,6 +17,7 @@ from fastapi import WebSocketDisconnect
 
 from klangk_backend import (
     agent as agent_mod,
+    auth as auth_mod,
     emailsvc as emailsvc_mod,
     util as util_mod,
     model,
@@ -100,7 +101,15 @@ def _make_app_state(registry=None, sockets=None):
     app_state.agents = agent_mod.Agents(app_state)
     app_state.email = emailsvc_mod.EmailService(app_state)
     app_state.util = util_mod.Util(app_state)
+
+    app_state.auth = auth_mod.Auth(app_state)
     return app_state
+
+
+def _auth():
+    """A standalone Auth for token forging (same default secret as the
+    app fixture, so tokens round-trip through app.state.auth.decode_*)."""
+    return auth_mod.Auth(types.SimpleNamespace(settings=make_settings({})))
 
 
 def _mock_sock(headers=None, query_params=None):
@@ -1919,11 +1928,10 @@ class TestHandleWebsocketDispatch:
     """Test all command dispatch branches through the main handler."""
 
     async def _run_commands(self, user, commands, app_state=None):
-        from klangk_backend import auth as auth_mod
 
         if app_state is None:
             app_state = _make_app_state()
-        token = auth_mod.create_token(user["id"], user["email"])
+        token = _auth().create_token(user["id"], user["email"])
         websocket = _mock_raw_sock(query_params={"token": token})
         msgs = [json.dumps(c) for c in commands] + [WebSocketDisconnect()]
         websocket.receive_text = AsyncMock(side_effect=msgs)
@@ -1998,9 +2006,8 @@ class TestHandleWebsocketDispatch:
         """Container should NOT be killed on disconnect — idle timeout handles it."""
         app_state = _make_app_state()
         registry = app_state.container_registry
-        from klangk_backend import auth as auth_mod
 
-        token = auth_mod.create_token(user["id"], user["email"])
+        token = _auth().create_token(user["id"], user["email"])
         websocket = _mock_raw_sock(query_params={"token": token})
 
         workspace = await app_state.workspaces.create_workspace(
@@ -2071,8 +2078,6 @@ class TestHandleWebsocket:
 
         from jose import jwt
 
-        from klangk_backend import auth as auth_mod
-
         expired = datetime.now(timezone.utc) - timedelta(hours=1)
         payload = {
             "sub": user["id"],
@@ -2081,7 +2086,7 @@ class TestHandleWebsocket:
             "exp": expired,
         }
         token = jwt.encode(
-            payload, auth_mod.SECRET_KEY, algorithm=auth_mod.ALGORITHM
+            payload, _auth().secret, algorithm=_auth().algorithm
         )
         websocket = _mock_raw_sock(query_params={"token": token})
         await handle_websocket(websocket, app_state)
@@ -2091,9 +2096,8 @@ class TestHandleWebsocket:
 
     async def test_valid_token_then_disconnect(self, user):
         app_state = _make_app_state()
-        from klangk_backend import auth as auth_mod
 
-        token = auth_mod.create_token(user["id"], user["email"])
+        token = _auth().create_token(user["id"], user["email"])
         websocket = _mock_raw_sock(query_params={"token": token})
         websocket.receive_text = AsyncMock(side_effect=WebSocketDisconnect())
 
@@ -2103,9 +2107,8 @@ class TestHandleWebsocket:
 
     async def test_unexpected_exception_logged(self, user):
         app_state = _make_app_state()
-        from klangk_backend import auth as auth_mod
 
-        token = auth_mod.create_token(user["id"], user["email"])
+        token = _auth().create_token(user["id"], user["email"])
         websocket = _mock_raw_sock(query_params={"token": token})
         websocket.receive_text = AsyncMock(
             side_effect=ValueError("unexpected")
@@ -2117,9 +2120,8 @@ class TestHandleWebsocket:
 
     async def test_runtime_error_treated_as_disconnect(self, user, app_state):
         app_state = _make_app_state()
-        from klangk_backend import auth as auth_mod
 
-        token = auth_mod.create_token(user["id"], user["email"])
+        token = _auth().create_token(user["id"], user["email"])
         websocket = _mock_raw_sock(query_params={"token": token})
         websocket.receive_text = AsyncMock(
             side_effect=RuntimeError(
@@ -2133,9 +2135,8 @@ class TestHandleWebsocket:
 
     async def test_invalid_json(self, user, app_state):
         app_state = _make_app_state()
-        from klangk_backend import auth as auth_mod
 
-        token = auth_mod.create_token(user["id"], user["email"])
+        token = _auth().create_token(user["id"], user["email"])
         websocket = _mock_raw_sock(query_params={"token": token})
         websocket.receive_text = AsyncMock(
             side_effect=["not json", WebSocketDisconnect()]
@@ -2148,9 +2149,8 @@ class TestHandleWebsocket:
 
     async def test_unknown_command(self, user, app_state):
         app_state = _make_app_state()
-        from klangk_backend import auth as auth_mod
 
-        token = auth_mod.create_token(user["id"], user["email"])
+        token = _auth().create_token(user["id"], user["email"])
         websocket = _mock_raw_sock(query_params={"token": token})
         websocket.receive_text = AsyncMock(
             side_effect=[
@@ -2168,9 +2168,8 @@ class TestHandleWebsocket:
         app_state = _make_app_state()
         sockets = app_state.sockets
         registry = app_state.container_registry
-        from klangk_backend import auth as auth_mod
 
-        token = auth_mod.create_token(user["id"], user["email"])
+        token = _auth().create_token(user["id"], user["email"])
         websocket = _mock_raw_sock(query_params={"token": token})
         workspace = await _create_workspace_with_acl(
             app_state, user["id"], "ui-ready-ws"
@@ -2227,9 +2226,8 @@ class TestHandleWebsocket:
 
     async def test_ui_ready_no_pending(self, user):
         app_state = _make_app_state()
-        from klangk_backend import auth as auth_mod
 
-        token = auth_mod.create_token(user["id"], user["email"])
+        token = _auth().create_token(user["id"], user["email"])
         websocket = _mock_raw_sock(query_params={"token": token})
         websocket.receive_text = AsyncMock(
             side_effect=[
@@ -2253,9 +2251,8 @@ class TestHandleWebsocket:
     async def test_general_exception_logged(self, user):
         app_state = _make_app_state()
         sockets = app_state.sockets
-        from klangk_backend import auth as auth_mod
 
-        token = auth_mod.create_token(user["id"], user["email"])
+        token = _auth().create_token(user["id"], user["email"])
         websocket = _mock_raw_sock(query_params={"token": token})
         websocket.receive_text = AsyncMock(
             side_effect=RuntimeError("unexpected")
@@ -3441,9 +3438,8 @@ class TestSshAgentForwarder:
 class TestExecDispatch:
     async def test_dispatch_exec_start(self, user):
         app_state = _make_app_state()
-        from klangk_backend import auth as auth_mod
 
-        token = auth_mod.create_token(user["id"], user["email"])
+        token = _auth().create_token(user["id"], user["email"])
         websocket = _mock_raw_sock(query_params={"token": token})
         websocket.receive_text = AsyncMock(
             side_effect=[
@@ -3459,9 +3455,8 @@ class TestExecDispatch:
 
     async def test_dispatch_exec_input(self, user):
         app_state = _make_app_state()
-        from klangk_backend import auth as auth_mod
 
-        token = auth_mod.create_token(user["id"], user["email"])
+        token = _auth().create_token(user["id"], user["email"])
         websocket = _mock_raw_sock(query_params={"token": token})
         websocket.receive_text = AsyncMock(
             side_effect=[
@@ -3477,9 +3472,8 @@ class TestExecDispatch:
 
     async def test_dispatch_exec_stop(self, user):
         app_state = _make_app_state()
-        from klangk_backend import auth as auth_mod
 
-        token = auth_mod.create_token(user["id"], user["email"])
+        token = _auth().create_token(user["id"], user["email"])
         websocket = _mock_raw_sock(query_params={"token": token})
         websocket.receive_text = AsyncMock(
             side_effect=[
@@ -3495,9 +3489,8 @@ class TestExecDispatch:
 
     async def test_dispatch_exec_close_stdin(self, user):
         app_state = _make_app_state()
-        from klangk_backend import auth as auth_mod
 
-        token = auth_mod.create_token(user["id"], user["email"])
+        token = _auth().create_token(user["id"], user["email"])
         websocket = _mock_raw_sock(query_params={"token": token})
         websocket.receive_text = AsyncMock(
             side_effect=[
@@ -3513,9 +3506,8 @@ class TestExecDispatch:
 
     async def test_dispatch_heartbeat(self, user):
         app_state = _make_app_state()
-        from klangk_backend import auth as auth_mod
 
-        token = auth_mod.create_token(user["id"], user["email"])
+        token = _auth().create_token(user["id"], user["email"])
         websocket = _mock_raw_sock(query_params={"token": token})
         websocket.receive_text = AsyncMock(
             side_effect=[
@@ -3531,9 +3523,8 @@ class TestExecDispatch:
 
     async def test_dispatch_chat_send(self, user):
         app_state = _make_app_state()
-        from klangk_backend import auth as auth_mod
 
-        token = auth_mod.create_token(user["id"], user["email"])
+        token = _auth().create_token(user["id"], user["email"])
         websocket = _mock_raw_sock(query_params={"token": token})
         websocket.receive_text = AsyncMock(
             side_effect=[
@@ -3549,9 +3540,8 @@ class TestExecDispatch:
 
     async def test_dispatch_chat_delete(self, user):
         app_state = _make_app_state()
-        from klangk_backend import auth as auth_mod
 
-        token = auth_mod.create_token(user["id"], user["email"])
+        token = _auth().create_token(user["id"], user["email"])
         websocket = _mock_raw_sock(query_params={"token": token})
         websocket.receive_text = AsyncMock(
             side_effect=[
@@ -3569,9 +3559,8 @@ class TestExecDispatch:
 class TestChatLoadMoreDispatch:
     async def test_dispatch_chat_load_more(self, user):
         app_state = _make_app_state()
-        from klangk_backend import auth as auth_mod
 
-        token = auth_mod.create_token(user["id"], user["email"])
+        token = _auth().create_token(user["id"], user["email"])
         websocket = _mock_raw_sock(query_params={"token": token})
         websocket.receive_text = AsyncMock(
             side_effect=[
@@ -3613,9 +3602,8 @@ class TestBrowserBridge:
     async def test_dispatch_browser_response(self, user):
         app_state = _make_app_state()
         sockets = app_state.sockets
-        from klangk_backend import auth as auth_mod
 
-        token = auth_mod.create_token(user["id"], user["email"])
+        token = _auth().create_token(user["id"], user["email"])
         websocket = _mock_raw_sock(query_params={"token": token})
         websocket.receive_text = AsyncMock(
             side_effect=[
@@ -4634,10 +4622,9 @@ class TestCleanupSubscriberRace:
 class TestWsDebugLogging:
     async def test_recv_logged_when_debug(self, user, monkeypatch):
         app_state = _make_app_state()
-        from klangk_backend import auth as auth_mod
 
         monkeypatch.setattr(wshandler, "WS_DEBUG", True)
-        token = auth_mod.create_token(user["id"], user["email"])
+        token = _auth().create_token(user["id"], user["email"])
         websocket = _mock_raw_sock(query_params={"token": token})
         websocket.receive_text = AsyncMock(
             side_effect=[
@@ -5336,9 +5323,8 @@ class TestHandleShutdownContainer:
 
     async def test_shutdown_dispatch(self, user):
         app_state = _make_app_state()
-        from klangk_backend import auth as auth_mod
 
-        token = auth_mod.create_token(user["id"], user["email"])
+        token = _auth().create_token(user["id"], user["email"])
         websocket = _mock_raw_sock(query_params={"token": token})
         websocket.receive_text = AsyncMock(
             side_effect=[
@@ -8277,9 +8263,8 @@ class TestSendQueueBehavior:
     async def test_slow_client_closes_connection(self, user):
         """When the send queue is full, handle_websocket drops the client."""
         app_state = _make_app_state()
-        from klangk_backend import auth as auth_mod
 
-        token = auth_mod.create_token(user["id"], user["email"])
+        token = _auth().create_token(user["id"], user["email"])
         websocket = _mock_raw_sock(query_params={"token": token})
 
         # Make the raw websocket.send_json block forever so the queue fills up
@@ -9664,9 +9649,8 @@ class TestDispatchBrowserRequestStreamTo:
     async def test_loop_dispatches_browser_chunk(self, user, app_state):
         app_state = _make_app_state()
         sockets = app_state.sockets
-        from klangk_backend import auth as auth_mod
 
-        token = auth_mod.create_token(user["id"], user["email"])
+        token = _auth().create_token(user["id"], user["email"])
         websocket = _mock_raw_sock(query_params={"token": token})
         websocket.receive_text = AsyncMock(
             side_effect=[
@@ -9760,9 +9744,7 @@ class TestTokenRenewal:
         try:
             with (
                 patch.object(
-                    wshandler.auth,
-                    "WORKSPACE_TOKEN_EXPIRE_HOURS",
-                    0.0001,
+                    app_state.auth, "workspace_token_expire_hours", 0.0001
                 ),
                 patch.object(
                     _mock_term,
@@ -9782,7 +9764,7 @@ class TestTokenRenewal:
             assert mock_set.call_count >= 1
             cid, token = mock_set.call_args.args
             assert cid == "test-cid"
-            decoded = wshandler.auth.decode_workspace_token(token)
+            decoded = _auth().decode_workspace_token(token)
             assert decoded == workspace["id"]
         finally:
             sockets.sessions.pop(workspace["id"], None)
@@ -9814,9 +9796,7 @@ class TestTokenRenewal:
 
             with (
                 patch.object(
-                    wshandler.auth,
-                    "WORKSPACE_TOKEN_EXPIRE_HOURS",
-                    0.0001,
+                    app_state.auth, "workspace_token_expire_hours", 0.0001
                 ),
                 patch.object(
                     _mock_term,
@@ -9857,9 +9837,7 @@ class TestTokenRenewal:
         try:
             with (
                 patch.object(
-                    wshandler.auth,
-                    "WORKSPACE_TOKEN_EXPIRE_HOURS",
-                    0.0001,
+                    app_state.auth, "workspace_token_expire_hours", 0.0001
                 ),
                 patch.object(
                     _mock_term,
@@ -9929,9 +9907,8 @@ class TestTokenRenewal:
 class TestSSHAgentDispatch:
     async def test_dispatch_ssh_agent_start(self, user):
         app_state = _make_app_state()
-        from klangk_backend import auth as auth_mod
 
-        token = auth_mod.create_token(user["id"], user["email"])
+        token = _auth().create_token(user["id"], user["email"])
         websocket = _mock_raw_sock(query_params={"token": token})
         websocket.receive_text = AsyncMock(
             side_effect=[
@@ -9947,9 +9924,8 @@ class TestSSHAgentDispatch:
 
     async def test_dispatch_ssh_agent_data(self, user):
         app_state = _make_app_state()
-        from klangk_backend import auth as auth_mod
 
-        token = auth_mod.create_token(user["id"], user["email"])
+        token = _auth().create_token(user["id"], user["email"])
         websocket = _mock_raw_sock(query_params={"token": token})
         websocket.receive_text = AsyncMock(
             side_effect=[
@@ -9965,9 +9941,8 @@ class TestSSHAgentDispatch:
 
     async def test_dispatch_ssh_agent_stop(self, user):
         app_state = _make_app_state()
-        from klangk_backend import auth as auth_mod
 
-        token = auth_mod.create_token(user["id"], user["email"])
+        token = _auth().create_token(user["id"], user["email"])
         websocket = _mock_raw_sock(query_params={"token": token})
         websocket.receive_text = AsyncMock(
             side_effect=[
@@ -9983,9 +9958,8 @@ class TestSSHAgentDispatch:
 
     async def test_dispatch_share_window(self, user):
         app_state = _make_app_state()
-        from klangk_backend import auth as auth_mod
 
-        token = auth_mod.create_token(user["id"], user["email"])
+        token = _auth().create_token(user["id"], user["email"])
         websocket = _mock_raw_sock(query_params={"token": token})
         websocket.receive_text = AsyncMock(
             side_effect=[
@@ -10001,9 +9975,8 @@ class TestSSHAgentDispatch:
 
     async def test_dispatch_unshare_window(self, user):
         app_state = _make_app_state()
-        from klangk_backend import auth as auth_mod
 
-        token = auth_mod.create_token(user["id"], user["email"])
+        token = _auth().create_token(user["id"], user["email"])
         websocket = _mock_raw_sock(query_params={"token": token})
         websocket.receive_text = AsyncMock(
             side_effect=[
@@ -10019,9 +9992,8 @@ class TestSSHAgentDispatch:
 
     async def test_dispatch_create_shared_terminal(self, user):
         app_state = _make_app_state()
-        from klangk_backend import auth as auth_mod
 
-        token = auth_mod.create_token(user["id"], user["email"])
+        token = _auth().create_token(user["id"], user["email"])
         websocket = _mock_raw_sock(query_params={"token": token})
         websocket.receive_text = AsyncMock(
             side_effect=[
@@ -10037,9 +10009,8 @@ class TestSSHAgentDispatch:
 
     async def test_dispatch_join_shared_terminal(self, user):
         app_state = _make_app_state()
-        from klangk_backend import auth as auth_mod
 
-        token = auth_mod.create_token(user["id"], user["email"])
+        token = _auth().create_token(user["id"], user["email"])
         websocket = _mock_raw_sock(query_params={"token": token})
         websocket.receive_text = AsyncMock(
             side_effect=[
@@ -10061,9 +10032,8 @@ class TestSSHAgentDispatch:
 
     async def test_dispatch_delete_shared_terminal(self, user):
         app_state = _make_app_state()
-        from klangk_backend import auth as auth_mod
 
-        token = auth_mod.create_token(user["id"], user["email"])
+        token = _auth().create_token(user["id"], user["email"])
         websocket = _mock_raw_sock(query_params={"token": token})
         websocket.receive_text = AsyncMock(
             side_effect=[
@@ -10081,9 +10051,8 @@ class TestSSHAgentDispatch:
 
     async def test_dispatch_list_shared_terminals(self, user, app_state):
         app_state = _make_app_state()
-        from klangk_backend import auth as auth_mod
 
-        token = auth_mod.create_token(user["id"], user["email"])
+        token = _auth().create_token(user["id"], user["email"])
         websocket = _mock_raw_sock(query_params={"token": token})
         websocket.receive_text = AsyncMock(
             side_effect=[
@@ -10101,9 +10070,8 @@ class TestSSHAgentDispatch:
 
     async def test_dispatch_chat_agent_abort(self, user, app_state):
         app_state = _make_app_state()
-        from klangk_backend import auth as auth_mod
 
-        token = auth_mod.create_token(user["id"], user["email"])
+        token = _auth().create_token(user["id"], user["email"])
         websocket = _mock_raw_sock(query_params={"token": token})
         websocket.receive_text = AsyncMock(
             side_effect=[
@@ -10446,7 +10414,7 @@ class TestTokenRenewalFailureLogged:
         ) + timedelta(seconds=0.05)
         with (
             patch.object(
-                wshandler.auth, "WORKSPACE_TOKEN_EXPIRE_HOURS", 0.0001
+                app_state.auth, "workspace_token_expire_hours", 0.0001
             ),
             patch.object(
                 _mock_term,


### PR DESCRIPTION
Closes #1501. Part of #1426 (composition-root refactor).

## What

`auth.py` read config two ways — both at import/use time, not from the frozen `KlangkSettings`:

1. **Import-time module globals**: `LOGIN_LOCKOUT_WINDOW`, `LOGIN_LOCKOUT_DURATION`, `SECRET_KEY`, `ALGORITHM`, `TOKEN_EXPIRE_HOURS`, `MIN_PASSWORD_LENGTH`, `LOGIN_LOCKOUT_FAILURES`, `INVITE_TOKEN_EXPIRE_HOURS`, `WORKSPACE_TOKEN_EXPIRE_HOURS` — all built via `resolve_env_value("KLANGK_...")` at first import (the #1426 anti-pattern). `test_auth.py` had a subprocess dance to test overrides because the globals didn't respond to in-process settings rebuilds.
2. **Call-time `resolve_env_value` reads**: `require_secure_jwt_secret`, `registration_enabled`, `invitations_enabled`, the `KLANGK_PREVENT_INSECURE_JWT_SECRET` / `KLANGK_TEST_MODE` / `KLANGK_DEFAULT_USER` reads in routes.

Both are gone. All config-reading auth lives on `Auth(app_state)`, reading `self.settings` at construction/call time — matching `Terminal` (#1480), `EmailService` (#1483), `Workspaces` (#1484), `Util` (#1503).

## Changes

### `auth.py` — new `Auth(app_state)` class
- **Instance attrs** (computed in `__init__` from `self.settings`): `secret`, `algorithm`, `token_expire_hours`, `min_password_length`, `login_lockout_failures`, `login_lockout_duration`, `login_lockout_window`, `invite_token_expire_hours`, `workspace_token_expire_hours`, plus fixed-policy `verify_token_expire_hours` (72) and `reset_token_expire_hours` (1).
- **Methods**: `jwt_secret_is_secure`, `require_secure_jwt_secret`, `registration_enabled`, `invitations_enabled`, `validate_password_length`, `should_lockout`, `window_elapsed`, `create_token`/`decode_token`, the `create_*_token`/`decode_*_token` family, `register`/`login`/`refresh_token`/`logout`/`get_user_from_token`.
- **Sentinels** `TOKEN_EXPIRED` / `WORKSPACE_TOKEN_EXPIRED` stay class constants (`Auth.TOKEN_EXPIRED`).
- **Pure helpers stay module-level**: `hash_password`, `verify_password`, `validate_email`, `is_locked_out`, `MAX_PASSWORD_BYTES`, the Pydantic models (`RegisterRequest`, `LoginRequest`, `TokenResponse`, `RegisterResult`).
- **FastAPI deps stay module-level**: `get_current_user`, `get_current_user_optional` — they now take `request` first and reach `request.app.state.auth`.
- **`_INSECURE_DEFAULT_SECRET` consolidated** into `settings.INSECURE_DEFAULT_SECRET` (single source of truth; the duplicate in `auth.py` is gone).

### `settings.py`
- `_INSECURE_DEFAULT_SECRET` → public `INSECURE_DEFAULT_SECRET` (private alias kept for back-comat).

### `main.py`
- `app.state.auth = Auth(app.state)` wired in `build_app` (right after `app.state.settings`).
- Lifespan: `app.state.auth.require_secure_jwt_secret()`.

### Consumers updated (all reach `*.auth.*`)
- `api/auth.py` — token methods via `request.app.state.auth.*`; toggles via `request.app.state.settings.*` (`test_mode`, `default_user`); removed call-time `resolve_env_value` for `KLANGK_TEST_MODE`/`KLANGK_DEFAULT_USER`.
- `api/admin.py` — `app_state.auth.*`.
- `api/__init__.py` — `/config` (`registration_enabled`, `invitations_enabled`, `min_password_length`), `/test/workspace-token`.
- `api/_common.py` — `require_workspace_token`.
- `api/oidc_auth.py` — callback `create_token`.
- `container.py` — `create_workspace_token`.
- `emailsvc.py` — token-lifetime expiry text (`verify`/`reset`/`invite_token_expire_hours`).
- `wshandler/dispatch.py` — `get_user_from_token` / `TOKEN_EXPIRED`.
- `wshandler/session.py`, `wshandler/connection.py` — `workspace_token_expire_hours`, `create_workspace_token`.

### Tests
- `test_auth.py`: subprocess dance (line 65) **removed** — builds `Auth(make_settings(env))` directly. `monkeypatch.setattr(auth, "GLOBAL", ...)` replaced with `Auth(make_settings({env}))`. ~200 `auth.X` → `_auth().X` / `auth_mod.X` (pure helpers).
- `test_api.py`: token forging via a `_auth()` helper (default secret matches the app, so tokens round-trip). `monkeypatch.setenv("KLANGK_TEST_MODE"/"KLANGK_DEFAULT_USER")` → `monkeypatch.setattr(app.state.settings, ...)`. `monkeypatch.setattr(auth, ...)` → `monkeypatch.setattr(app.state.auth, ...)`.
- `test_container.py`, `test_emailsvc.py`, `test_mode_switching.py`, `test_wshandler.py`: `.auth` wired onto every test `app_state`; token forging via `_auth()` helpers.
- `conftest.py`: `app_state` fixture wires `state.auth = Auth(state)`.

### Acceptance criteria (from #1501)
- [x] `auth.py` exposes `Auth(app_state)`; config-reading functions and import-time globals become methods/instance attrs reading `self.settings`.
- [x] No `resolve_env_value`/`os.environ` in `auth.py`.
- [x] Instance wired onto `app.state.auth` in `build_app`; all consumers reach it via `app_state.auth.*` / `app.state.auth.*`.
- [x] `test_auth.py` subprocess dance replaced by constructing `Auth(app_state)` with `KlangkSettings(env={...})` directly.
- [x] Full backend suite green with `-n auto` and coverage at 100% (2396 passed).

## Notes

- The conftest collection-time env workaround (`os.environ.setdefault(KLANGK_STATE_DIR/DATA_DIR)`) is **kept** — `api/__init__.py` (LOGIN_BANNER, PRODUCT_NAME, legal/support URLs), `api/_common.py` (FILE_UPLOAD_SIZE_MAX), and `wshandler/constants.py` (WS_DEBUG) still read config at import time. Those are tracked by #1512 (move `main.py`/`api` globals to owned classes). auth.py and util.py no longer trigger it.
- `get_settings()` survives for the remaining import-time readers above; it dies when #1512 lands.
