### PR TITLE
Kill last import-time get_settings() callers; drop conftest env workaround (#1516)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -63,6 +63,19 @@ operators or integrators to act when upgrading.
 
 ### Changed
 
+- **Last import-time config reads removed from the API and wshandler
+  packages (#1516):** `api/__init__.py`, `api/_common.py`, and
+  `wshandler/constants.py` no longer read config at module import time.
+  The `/config` endpoint (`product_name`, `login_banner`, legal/support
+  URLs, `logo_url`, `allow_autostart`) and `/version` read the frozen
+  `app_state.settings` directly. The `FILE_UPLOAD_SIZE_MAX` module constant
+  is gone — `files.py`/`workspaces.py` read
+  `app_state.settings.file_upload_size_max`. `KLANGKWS_DEBUG` and
+  `KLANGK_TEST_MODE` (plain flags, not secrets) read `os.environ` directly
+  with no `file:`/`cmd:` resolution. The test collection-time
+  `KLANGK_STATE_DIR`/`KLANGK_DATA_DIR` env workaround in `conftest.py` is
+  removed — test collection no longer needs env pre-set.
+
 - **`resolve_env_value` (KLANGK path) no longer re-resolves `file:`/`cmd:`**
   — the field is already resolved at construction. The function survives for
   plugins' dynamic keys (non-`KLANGK_`, discovered from `package.json`) and

--- a/src/backend/klangk_backend/api/__init__.py
+++ b/src/backend/klangk_backend/api/__init__.py
@@ -45,7 +45,7 @@ from .. import (
     oidc,
     wshandler,
 )
-from ._common import get_app_state_dep
+from ._common import autostart_allowed, get_app_state_dep
 
 # Imported under an alias: the ``from . import auth as _auth_routes`` line
 # below pulls in the api/auth.py *submodule*, and the import machinery writes
@@ -54,7 +54,6 @@ from ._common import get_app_state_dep
 # name to the logic module after the submodule imports (see below) so the
 # instance endpoints reference klangk_backend.auth, not the route module.
 from .. import auth as _auth_logic
-from ..util import resolve_env_value
 
 # Route submodules, aliased because their names collide with the logic
 # modules imported above (api/auth.py vs klangk_backend.auth, etc.) and we
@@ -103,7 +102,7 @@ async def empty():
 @router.get("/version")
 async def version(app_state=Depends(get_app_state_dep)):
     """Return build version info, plus loaded plugin metadata."""
-    if version_file := resolve_env_value("KLANGK_VERSION_FILE", ""):
+    if version_file := app_state.settings.version_file:
         if os.path.isfile(version_file):
             with open(version_file) as f:
                 info = json.load(f)
@@ -119,7 +118,7 @@ async def version(app_state=Depends(get_app_state_dep)):
 
 # --- Test/debug endpoints (only when KLANGK_TEST_MODE is set) ---
 
-if resolve_env_value("KLANGK_TEST_MODE"):  # pragma: no cover
+if os.environ.get("KLANGK_TEST_MODE"):  # pragma: no cover
 
     @router.get("/test/idle-timeout")
     async def get_idle_timeout(
@@ -186,60 +185,40 @@ if resolve_env_value("KLANGK_TEST_MODE"):  # pragma: no cover
         return browsers
 
 
-LOGIN_BANNER_TITLE = resolve_env_value("KLANGK_LOGIN_BANNER_TITLE", "")
-LOGIN_BANNER = resolve_env_value("KLANGK_LOGIN_BANNER", "")
-PRODUCT_NAME = resolve_env_value("KLANGK_PRODUCT_NAME", "Klangk") or "Klangk"
-
-# Configurable legal & support links (#1177). These are PUBLIC URLs shown
-# to unauthenticated users on the login/registration screens, in the app
-# chrome, and in email footers -- so they deliberately use plain env values
-# and do NOT go through resolve_env_value() (no file:/cmd: secret
-# resolution). A deployer pointing these at sensitive internal resources
-# would be exposing them to the world. Empty string when unset, matching the
-# logo_url convention the frontend already falls back from.
-TERMS_URL = resolve_env_value("KLANGK_TERMS_URL") or ""
-PRIVACY_URL = resolve_env_value("KLANGK_PRIVACY_URL") or ""
-AUP_URL = resolve_env_value("KLANGK_AUP_URL") or ""
-SUPPORT_URL = resolve_env_value("KLANGK_SUPPORT_URL") or ""
-SUPPORT_EMAIL = resolve_env_value("KLANGK_SUPPORT_EMAIL") or ""
-
-
 @router.get("/config")
 async def get_config(app_state=Depends(get_app_state_dep)):
+    s = app_state.settings
     config = {
         "registration_enabled": app_state.auth.registration_enabled(),
         "invitations_enabled": app_state.auth.invitations_enabled(),
         # White-label product name (KLANGK_PRODUCT_NAME). Surfaced so the
         # frontend can rename the product (tab title, app-bar logo) without
         # a rebuild; defaults to "Klangk" for back-compat (#1149).
-        "product_name": PRODUCT_NAME,
-        "login_banner_title": LOGIN_BANNER_TITLE,
-        "login_banner": LOGIN_BANNER,
+        "product_name": s.product_name,
+        "login_banner_title": s.login_banner_title,
+        "login_banner": s.login_banner,
         "oidc_providers": app_state.oidc.list_providers(),
         "auth_modes": app_state.oidc.auth_modes(),
         "instance_id": model.get_instance_id(),
         # Whether per-workspace auto-start (start the container on server
         # boot) is permitted. The web UI gates its "Auto start" checkbox on
         # this so users can't toggle a setting the server will reject (#1115).
-        "allow_autostart": (app_state.settings.allow_autostart or "")
-        .strip()
-        .lower()
-        in ("1", "true", "yes"),
+        "allow_autostart": autostart_allowed(app_state),
         # Surfaced so the UI can validate password length inline (matches
         # the rule enforced server-side by auth.validate_password_length).
         "min_password_length": app_state.auth.min_password_length,
         # Deployer logo override (KLANGK_LOGO_URL). Empty when unset, in
         # which case the frontend renders the default KlangkLogo widget.
         # Supports file:/cmd: resolution like other secrets. See #1152.
-        "logo_url": app_state.settings.logo_url or "",
+        "logo_url": s.logo_url,
         # Configurable legal & support links (#1177). Plain env values (no
         # file:/cmd: resolution -- they are public, shown pre-auth). Empty
         # string when unset; the frontend hides whatever isn't configured.
-        "terms_url": TERMS_URL,
-        "privacy_url": PRIVACY_URL,
-        "aup_url": AUP_URL,
-        "support_url": SUPPORT_URL,
-        "support_email": SUPPORT_EMAIL,
+        "terms_url": s.terms_url,
+        "privacy_url": s.privacy_url,
+        "aup_url": s.aup_url,
+        "support_url": s.support_url,
+        "support_email": s.support_email,
     }
     config.update(app_state.plugins.frontend_config())
     return config

--- a/src/backend/klangk_backend/api/_common.py
+++ b/src/backend/klangk_backend/api/_common.py
@@ -13,15 +13,8 @@ from fastapi import HTTPException, Request
 from pydantic import BaseModel
 
 from .. import auth
-from ..util import resolve_env_value
 
 logger = logging.getLogger(__name__)
-
-# Maximum upload size for file uploads and workspace imports (bytes).
-# Default 500 MB; override via KLANGK_FILE_UPLOAD_SIZE_MAX (in bytes).
-FILE_UPLOAD_SIZE_MAX = int(
-    resolve_env_value("KLANGK_FILE_UPLOAD_SIZE_MAX", str(500 * 1024 * 1024))
-)
 
 
 async def send_email(coro, recipient: str, kind: str = "email") -> None:
@@ -73,6 +66,19 @@ def get_app_state_dep(request: Request):
     reaching for module-level globals (#1426, #1475).
     """
     return request.app.state
+
+
+def autostart_allowed(app_state) -> bool:
+    """Whether per-workspace auto-start is permitted (KLANGK_ALLOW_AUTOSTART).
+
+    Read off the frozen ``app_state.settings`` rather than re-resolving the
+    env at call time (#1516).
+    """
+    return (app_state.settings.allow_autostart or "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+    )
 
 
 class WorkspaceAclEntry(BaseModel):

--- a/src/backend/klangk_backend/api/browser_delegate.py
+++ b/src/backend/klangk_backend/api/browser_delegate.py
@@ -12,9 +12,6 @@ from fastapi.responses import (
 )
 from pydantic import BaseModel
 
-from .. import (
-    wshandler,
-)
 from ._common import get_app_state_dep
 from ._common import (
     require_workspace_token,
@@ -109,7 +106,7 @@ async def browser_delegate_stream(
     )
     return StreamingResponse(
         session.dispatch_browser_request_stream_to(
-            target_sock, payload, wshandler.bridge_idle_timeout()
+            target_sock, payload, app_state.util.bridge_idle_timeout()
         ),
         media_type="application/x-ndjson",
     )

--- a/src/backend/klangk_backend/api/files.py
+++ b/src/backend/klangk_backend/api/files.py
@@ -24,7 +24,6 @@ from ..util import (
     sanitize_disposition_name,
 )
 from ._common import (
-    FILE_UPLOAD_SIZE_MAX,
     workspace_resource,
 )
 
@@ -170,7 +169,7 @@ async def upload_file(
     if not filename:  # pragma: no cover
         raise HTTPException(status_code=400, detail="No filename provided")
 
-    max_upload = FILE_UPLOAD_SIZE_MAX
+    max_upload = int(app_state.settings.file_upload_size_max)
     buf = io.BytesIO()
     total = 0
     while chunk := await file.read(1024 * 1024):

--- a/src/backend/klangk_backend/api/workspaces.py
+++ b/src/backend/klangk_backend/api/workspaces.py
@@ -39,13 +39,12 @@ from ..model import (
 )
 from ..model.instance import get_instance_id
 from ..util import (
-    resolve_env_bool,
     sanitize_disposition_name,
 )
 from ._common import (
-    FILE_UPLOAD_SIZE_MAX,
     WorkspaceAclEntry,
     admin_resource,
+    autostart_allowed,
     workspace_resource,
 )
 
@@ -173,7 +172,7 @@ async def create_workspace(
     user: dict = Depends(auth.get_current_user),
     app_state=Depends(get_app_state_dep),
 ):
-    if body.auto_start and not resolve_env_bool("KLANGK_ALLOW_AUTOSTART"):
+    if body.auto_start and not autostart_allowed(app_state):
         raise HTTPException(
             status_code=400,
             detail="Auto-start is not enabled on this server"
@@ -250,9 +249,7 @@ async def update_workspace(
     app_state=Depends(get_app_state_dep),
 ):
     fields = body.model_dump(exclude_unset=True)
-    if fields.get("auto_start") and not resolve_env_bool(
-        "KLANGK_ALLOW_AUTOSTART"
-    ):
+    if fields.get("auto_start") and not autostart_allowed(app_state):
         raise HTTPException(
             status_code=400,
             detail="Auto-start is not enabled on this server"
@@ -564,13 +561,12 @@ async def export_workspace(
     )
 
 
-async def _stream_upload_to_tempfile(file: UploadFile) -> str:
+async def _stream_upload_to_tempfile(file: UploadFile, max_upload: int) -> str:
     """Stream *file* to a temp file, enforcing the upload size limit.
 
     Returns the path to the temp file.  Caller is responsible for
     deleting it.
     """
-    max_upload = FILE_UPLOAD_SIZE_MAX
     tmp = tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False)
     total = 0
     try:
@@ -713,7 +709,9 @@ async def import_workspace(
     Creates a new workspace with metadata from workspace.json and
     extracts the home directory from the archive.
     """
-    archive_path = await _stream_upload_to_tempfile(file)
+    archive_path = await _stream_upload_to_tempfile(
+        file, int(app_state.settings.file_upload_size_max)
+    )
     ws = None
     try:
         meta = await _extract_archive_metadata(archive_path, name, app_state)

--- a/src/backend/klangk_backend/emailsvc.py
+++ b/src/backend/klangk_backend/emailsvc.py
@@ -155,17 +155,17 @@ class EmailService:
         s = self.settings
         return {
             "product_name": self.product_name(),
-            "logo_url": s.logo_url or "",
-            "brand_color": s.brand_color or "#E65100",
+            "logo_url": s.logo_url,
+            "brand_color": s.brand_color,
             # Configurable legal & support links (#1177). Plain env values,
             # shown in the email footer to all recipients. Mirrors what
             # /config exposes to the frontend; the base template renders
             # whatever is set.
-            "terms_url": s.terms_url or "",
-            "privacy_url": s.privacy_url or "",
-            "aup_url": s.aup_url or "",
-            "support_url": s.support_url or "",
-            "support_email": s.support_email or "",
+            "terms_url": s.terms_url,
+            "privacy_url": s.privacy_url,
+            "aup_url": s.aup_url,
+            "support_url": s.support_url,
+            "support_email": s.support_email,
         }
 
     def _customize_dir(self) -> str:

--- a/src/backend/klangk_backend/settings.py
+++ b/src/backend/klangk_backend/settings.py
@@ -416,19 +416,19 @@ class KlangkSettings(BaseSettings):
     email_templates_dir: str | None = None
 
     # --- Legal / support links ---
-    terms_url: str | None = None
-    privacy_url: str | None = None
-    aup_url: str | None = None
-    support_url: str | None = None
-    support_email: str | None = None
+    terms_url: str = ""
+    privacy_url: str = ""
+    aup_url: str = ""
+    support_url: str = ""
+    support_email: str = ""
 
     # --- Branding / UI ---
-    product_name: str | None = "Klangk"
-    logo_url: str | None = None
-    brand_color: str | None = "#E65100"
-    login_banner: str | None = None
-    login_banner_title: str | None = None
-    terminal_banner: str | None = None
+    product_name: str = "Klangk"
+    logo_url: str = ""
+    brand_color: str = "#E65100"
+    login_banner: str = ""
+    login_banner_title: str = ""
+    terminal_banner: str = ""
 
     # --- Agent ---
     agent_email: str | None = "clanker@example.com"

--- a/src/backend/klangk_backend/util.py
+++ b/src/backend/klangk_backend/util.py
@@ -353,6 +353,19 @@ class Util:
         hostname, proto, _ = self.derive_hosting_info(None, None)
         return [f"{proto}://{hostname}"]
 
+    def bridge_idle_timeout(self) -> float:
+        """Max seconds between streamed browser chunks before giving up.
+
+        Bounds the gap between chunks (not the total query duration), so a
+        long-but-progressing stream never times out. Override with
+        KLANGK_BRIDGE_TIMEOUT_SECONDS (the settings field is parsed here).
+        """
+        raw = self.settings.bridge_timeout_seconds
+        try:
+            return float(raw) if raw else 30.0
+        except (TypeError, ValueError):
+            return 30.0
+
 
 class BoundedOutputQueue(asyncio.Queue[T | None]):
     """Bounded asyncio.Queue with non-blocking sentinel support.

--- a/src/backend/klangk_backend/wshandler/__init__.py
+++ b/src/backend/klangk_backend/wshandler/__init__.py
@@ -33,7 +33,6 @@ from .constants import (
     cancel_agent_task as cancel_agent_task,
     drop_agent_task_if_current as drop_agent_task_if_current,
     log_ws_msg as log_ws_msg,
-    bridge_idle_timeout as bridge_idle_timeout,
     clear_agent_mention_state as clear_agent_mention_state,
 )
 from .safe_websocket import (

--- a/src/backend/klangk_backend/wshandler/constants.py
+++ b/src/backend/klangk_backend/wshandler/constants.py
@@ -9,12 +9,13 @@ dependencies between sibling modules are placed here.
 import asyncio
 import json
 import logging
-
-from ..util import resolve_env_value
+import os
 
 logger = logging.getLogger(__name__)
 
-WS_DEBUG = bool(resolve_env_value("KLANGKWS_DEBUG"))
+# Plain debug flag (not a KlangkSettings field): read straight from the
+# environment, no file:/cmd: resolution (#1516).
+WS_DEBUG = bool(os.environ.get("KLANGKWS_DEBUG"))
 
 # Max size for terminal/exec input data (base64-decoded bytes).
 # Matches uvicorn's --ws-max-size (16 MB) so the app-level cap isn't
@@ -23,20 +24,6 @@ MAX_INPUT_SIZE = 16777216
 
 # Max outbound messages before we declare the client too slow and close.
 SEND_QUEUE_SIZE = 256
-
-
-def bridge_idle_timeout() -> float:
-    """Max seconds between streamed browser chunks before giving up.
-
-    Bounds the gap between chunks (not the total query duration), so a
-    long-but-progressing stream never times out.  Override with
-    KLANGK_BRIDGE_TIMEOUT_SECONDS.
-    """
-    raw = resolve_env_value("KLANGK_BRIDGE_TIMEOUT_SECONDS")
-    try:
-        return float(raw) if raw else 30.0
-    except ValueError:
-        return 30.0
 
 
 # ---------------------------------------------------------------------------

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -1,31 +1,10 @@
 """Shared fixtures for backend unit tests."""
 
 import os
-import tempfile
 
 # Must be set before coverage.py initialises in each xdist worker so that
 # code executed inside SQLAlchemy's greenlet context is tracked.
 os.environ.setdefault("COVERAGE_CORE", "sysmon")
-
-# state_dir / data_dir are required (no defaults, #1461). auth.py still reads
-# config at import time (#1501 — Auth promotion not yet done); set temp dirs
-# in the env before any such import runs during collection. The autouse
-# `temp_data_dir` fixture overrides these with per-test tmp dirs once tests
-# start. util.py no longer triggers this (#1503), but auth.py does.
-# state_dir / data_dir are required (no defaults, #1461). Several modules
-# still read config at import time via resolve_env_value (-> get_settings()):
-# api/__init__.py (LOGIN_BANNER, PRODUCT_NAME, legal/support URLs),
-# api/_common.py (FILE_UPLOAD_SIZE_MAX), wshandler/constants.py (WS_DEBUG).
-# Set temp dirs in the env before any such import runs during collection.
-# The autouse `temp_data_dir` fixture overrides these with per-test tmp
-# dirs once tests start. auth.py no longer triggers this (#1501); util.py
-# no longer triggers this (#1503).
-os.environ.setdefault(
-    "KLANGK_STATE_DIR", tempfile.mkdtemp(prefix="klangk-collect-state-")
-)
-os.environ.setdefault(
-    "KLANGK_DATA_DIR", tempfile.mkdtemp(prefix="klangk-collect-data-")
-)
 
 import bcrypt
 

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -265,14 +265,16 @@ class TestWorkspaceChat:
 
 
 class TestVersion:
-    async def test_version_from_file(self, client, tmp_path, monkeypatch):
+    async def test_version_from_file(self, client, app, tmp_path, monkeypatch):
         version_file = tmp_path / "version.json"
         version_file.write_text(
             '{"version": "2026.01.01+abc1234",'
             ' "commit": "abc1234",'
             ' "built_at": "2026-01-01T00:00:00Z"}'
         )
-        monkeypatch.setenv("KLANGK_VERSION_FILE", str(version_file))
+        monkeypatch.setattr(
+            app.state.settings, "version_file", str(version_file)
+        )
         resp = await client.get("/api/v1/version")
         assert resp.status_code == 200
         data = resp.json()
@@ -281,8 +283,8 @@ class TestVersion:
         assert data["built_at"] == "2026-01-01T00:00:00Z"
         assert "plugins" in data
 
-    async def test_version_no_file(self, client, monkeypatch):
-        monkeypatch.delenv("KLANGK_VERSION_FILE", raising=False)
+    async def test_version_no_file(self, client, app, monkeypatch):
+        monkeypatch.setattr(app.state.settings, "version_file", None)
         resp = await client.get("/api/v1/version")
         assert resp.status_code == 200
         data = resp.json()
@@ -294,7 +296,7 @@ class TestVersion:
     async def test_version_includes_plugins(
         self, client, app, tmp_path, monkeypatch
     ):
-        monkeypatch.delenv("KLANGK_VERSION_FILE", raising=False)
+        monkeypatch.setattr(app.state.settings, "version_file", None)
         plugin_dir = tmp_path / "plugins" / "myplugin"
         plugin_dir.mkdir(parents=True)
         (plugin_dir / "package.json").write_text(
@@ -332,7 +334,9 @@ class TestVersion:
             ' "commit": "abc1234",'
             ' "built_at": "2026-01-01T00:00:00Z"}'
         )
-        monkeypatch.setenv("KLANGK_VERSION_FILE", str(version_file))
+        monkeypatch.setattr(
+            app.state.settings, "version_file", str(version_file)
+        )
         resp = await client.get("/api/v1/version")
         assert resp.status_code == 200
         data = resp.json()
@@ -350,7 +354,9 @@ class TestVersion:
             ' "commit": "abc1234",'
             ' "built_at": "2026-01-01T00:00:00Z"}'
         )
-        monkeypatch.setenv("KLANGK_VERSION_FILE", str(version_file))
+        monkeypatch.setattr(
+            app.state.settings, "version_file", str(version_file)
+        )
         resp = await client.get("/api/v1/version")
         assert resp.status_code == 200
         data = resp.json()
@@ -390,9 +396,11 @@ class TestConfig:
         data = resp.json()
         assert data["my_plugin_var"] == "test-value"
 
-    async def test_get_config_banner_fields(self, client, monkeypatch):
-        monkeypatch.setattr(api, "LOGIN_BANNER_TITLE", "Notice")
-        monkeypatch.setattr(api, "LOGIN_BANNER", "You must accept terms.")
+    async def test_get_config_banner_fields(self, client, app, monkeypatch):
+        monkeypatch.setattr(app.state.settings, "login_banner_title", "Notice")
+        monkeypatch.setattr(
+            app.state.settings, "login_banner", "You must accept terms."
+        )
         resp = await client.get("/api/v1/config")
         assert resp.status_code == 200
         data = resp.json()
@@ -444,15 +452,25 @@ class TestConfig:
     async def test_get_config_legal_links_reflect_env(
         self, client, app, monkeypatch
     ):
-        # Each link is surfaced verbatim from its module constant (resolved
-        # from env at import time, like PRODUCT_NAME / LOGIN_BANNER).
-        monkeypatch.setattr(api, "TERMS_URL", "https://corp.example.com/terms")
+        # Each link is surfaced verbatim from its settings field (frozen at
+        # construction, like product_name / login_banner).
         monkeypatch.setattr(
-            api, "PRIVACY_URL", "https://corp.example.com/privacy"
+            app.state.settings, "terms_url", "https://corp.example.com/terms"
         )
-        monkeypatch.setattr(api, "AUP_URL", "https://corp.example.com/aup")
-        monkeypatch.setattr(api, "SUPPORT_URL", "https://help.example.com")
-        monkeypatch.setattr(api, "SUPPORT_EMAIL", "help@example.com")
+        monkeypatch.setattr(
+            app.state.settings,
+            "privacy_url",
+            "https://corp.example.com/privacy",
+        )
+        monkeypatch.setattr(
+            app.state.settings, "aup_url", "https://corp.example.com/aup"
+        )
+        monkeypatch.setattr(
+            app.state.settings, "support_url", "https://help.example.com"
+        )
+        monkeypatch.setattr(
+            app.state.settings, "support_email", "help@example.com"
+        )
         resp = await client.get("/api/v1/config")
         assert resp.status_code == 200
         data = resp.json()
@@ -468,9 +486,10 @@ class TestConfig:
         # Legal/support links are PUBLIC URLs shown to unauthenticated
         # users, so they must NOT get file:/cmd: secret resolution -- a
         # deployer pointing them at a file: path would be exposing secret
-        # resolution to the world. The raw value is surfaced verbatim
-        # (were it resolved, file:///etc/shadow would yield empty/None).
-        monkeypatch.setattr(api, "TERMS_URL", "file:///etc/shadow")
+        # resolution to the world. The settings field is surfaced verbatim.
+        monkeypatch.setattr(
+            app.state.settings, "terms_url", "file:///etc/shadow"
+        )
         resp = await client.get("/api/v1/config")
         assert resp.status_code == 200
         assert resp.json()["terms_url"] == "file:///etc/shadow"
@@ -496,8 +515,10 @@ class TestConfig:
         data = resp.json()
         assert data["product_name"] == "Klangk"
 
-    async def test_get_config_reflects_product_name(self, client, monkeypatch):
-        monkeypatch.setattr(api, "PRODUCT_NAME", "Acme Labs")
+    async def test_get_config_reflects_product_name(
+        self, client, app, monkeypatch
+    ):
+        monkeypatch.setattr(app.state.settings, "product_name", "Acme Labs")
         resp = await client.get("/api/v1/config")
         assert resp.status_code == 200
         data = resp.json()
@@ -1552,7 +1573,7 @@ class TestWorkspaceRoutes:
     async def test_create_auto_start_allowed_with_env(self, client, app, user):
         headers = await _auth_headers(client)
         with (
-            patch.dict(os.environ, {"KLANGK_ALLOW_AUTOSTART": "1"}),
+            patch.object(app.state.settings, "allow_autostart", "1"),
             patch.object(
                 app.state.workspaces,
                 "start_workspace",
@@ -1573,7 +1594,7 @@ class TestWorkspaceRoutes:
     ):
         headers = await _auth_headers(client)
         with (
-            patch.dict(os.environ, {"KLANGK_ALLOW_AUTOSTART": "1"}),
+            patch.object(app.state.settings, "allow_autostart", "1"),
             patch.object(
                 app.state.workspaces,
                 "start_workspace",
@@ -4167,16 +4188,20 @@ class TestFileRoutes:
         finally:
             self._cleanup(ws_id)
 
-    async def test_upload_exceeds_size_limit(self, client, user):
+    async def test_upload_exceeds_size_limit(
+        self, client, user, app, monkeypatch
+    ):
         headers = await _auth_headers(client)
         ws_id = await self._create_workspace(client, headers)
         try:
-            with patch.object(api.files, "FILE_UPLOAD_SIZE_MAX", 10):
-                resp = await client.post(
-                    f"/api/v1/workspaces/{ws_id}/files/upload?path=/home/work/big.txt",
-                    headers=headers,
-                    files={"file": ("big.txt", b"x" * 100, "text/plain")},
-                )
+            monkeypatch.setattr(
+                app.state.settings, "file_upload_size_max", "10"
+            )
+            resp = await client.post(
+                f"/api/v1/workspaces/{ws_id}/files/upload?path=/home/work/big.txt",
+                headers=headers,
+                files={"file": ("big.txt", b"x" * 100, "text/plain")},
+            )
             assert resp.status_code == 413
             assert "limit" in resp.json()["detail"].lower()
         finally:
@@ -6957,11 +6982,9 @@ class TestWorkspaceExportImport:
             assert link_path.is_symlink(), f"Not a symlink: {link_path}"
             assert os.readlink(str(link_path)) == "file0.txt"
 
-    async def test_import_size_limit(self, client, user, monkeypatch):
+    async def test_import_size_limit(self, client, user, app, monkeypatch):
         """Upload exceeding size limit is rejected."""
-        import klangk_backend.api.workspaces as api_mod
-
-        monkeypatch.setattr(api_mod, "FILE_UPLOAD_SIZE_MAX", 100)
+        monkeypatch.setattr(app.state.settings, "file_upload_size_max", "100")
 
         headers = await self._user_headers(client)
         resp = await client.post(

--- a/src/backend/tests/test_api_package.py
+++ b/src/backend/tests/test_api_package.py
@@ -267,18 +267,28 @@ class TestSubmoduleStructure:
         from klangk_backend.api import _common
 
         for name in (
-            "FILE_UPLOAD_SIZE_MAX",
             "send_email",
             "workspace_resource",
             "admin_resource",
             "require_workspace_token",
             "WorkspaceAclEntry",
+            "autostart_allowed",
         ):
             assert hasattr(_common, name), f"_common missing {name}"
 
-    def test_file_upload_size_max_is_shared_object(self):
-        """workspaces and files must see the same upload-size cap."""
-        from klangk_backend.api import _common, files, workspaces
+    def test_no_duplicate_module_globals(self):
+        """No module-level config reads survive in the api package (#1516)."""
+        from klangk_backend.api import _common, __init__ as api_init
 
-        assert workspaces.FILE_UPLOAD_SIZE_MAX is _common.FILE_UPLOAD_SIZE_MAX
-        assert files.FILE_UPLOAD_SIZE_MAX is _common.FILE_UPLOAD_SIZE_MAX
+        assert not hasattr(_common, "FILE_UPLOAD_SIZE_MAX")
+        for name in (
+            "LOGIN_BANNER_TITLE",
+            "LOGIN_BANNER",
+            "PRODUCT_NAME",
+            "TERMS_URL",
+            "PRIVACY_URL",
+            "AUP_URL",
+            "SUPPORT_URL",
+            "SUPPORT_EMAIL",
+        ):
+            assert not hasattr(api_init, name), f"api still defines {name}"

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -52,6 +52,12 @@ from klangk_backend.wshandler import (
 )
 
 
+def _util(env=None):
+    """Build a Util instance from explicit env."""
+    settings = make_settings(env)
+    return util_mod.Util(types.SimpleNamespace(settings=settings))
+
+
 _mock_pod = MagicMock()
 _mock_pod.exec_container = AsyncMock(return_value=(0, "", ""))
 
@@ -9475,17 +9481,24 @@ class TestChatDelete:
 
 
 class TestBridgeIdleTimeout:
-    def test_default(self, monkeypatch):
-        monkeypatch.delenv("KLANGK_BRIDGE_TIMEOUT_SECONDS", raising=False)
-        assert wshandler.bridge_idle_timeout() == 30.0
+    def test_default(self):
+        assert _util().bridge_idle_timeout() == 30.0
 
-    def test_env_override(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_BRIDGE_TIMEOUT_SECONDS", "45")
-        assert wshandler.bridge_idle_timeout() == 45.0
+    def test_env_override(self):
+        assert (
+            _util(
+                {"KLANGK_BRIDGE_TIMEOUT_SECONDS": "45"}
+            ).bridge_idle_timeout()
+            == 45.0
+        )
 
-    def test_invalid_env_falls_back(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_BRIDGE_TIMEOUT_SECONDS", "nope")
-        assert wshandler.bridge_idle_timeout() == 30.0
+    def test_invalid_env_falls_back(self):
+        assert (
+            _util(
+                {"KLANGK_BRIDGE_TIMEOUT_SECONDS": "nope"}
+            ).bridge_idle_timeout()
+            == 30.0
+        )
 
 
 class TestHandleBrowserChunk:


### PR DESCRIPTION
Closes #1516. Part of #1426 (composition-root refactor).

## What

After #1501 (Auth) and #1503 (Util), the **only** remaining import-time config reads — the ones forcing the `os.environ.setdefault(KLANGK_STATE_DIR/DATA_DIR)` collection-time workaround in `src/backend/tests/conftest.py` — were module-level `resolve_env_value(...)` / `get_settings()` calls in three modules. Every one of those calls constructs a **fresh** `KlangkSettings(os.environ)` at first import (the #1426 anti-pattern), which fails `ValidationError` on the missing required `state_dir`/`data_dir` unless the env is pre-seeded.

All three are gone. Test collection no longer needs env pre-set.

## Changes

### `api/__init__.py`
- **Deleted module globals**: `LOGIN_BANNER_TITLE`, `LOGIN_BANNER`, `PRODUCT_NAME`, `TERMS_URL`, `PRIVACY_URL`, `AUP_URL`, `SUPPORT_URL`, `SUPPORT_EMAIL`.
- **`get_config`** reads the frozen `app_state.settings` directly (`product_name`, `login_banner*`, legal/support URLs, `logo_url`).
- **`allow_autostart`** + the `create_workspace`/`update_workspace` checks now share one helper, `autostart_allowed(app_state)` (in `_common.py`), reading `app_state.settings.allow_autostart`.
- **`/version`** reads `app_state.settings.version_file` (was call-time `resolve_env_value`).
- **`KLANGK_TEST_MODE`** route-registration gate → `os.environ.get` (plain flag, not a secret, no `file:`/`cmd:` resolution).
- Dropped the `resolve_env_value` import.

### `api/_common.py`
- **Deleted `FILE_UPLOAD_SIZE_MAX`** module constant.
- Added `autostart_allowed(app_state)` (shared by `get_config`, `create_workspace`, `update_workspace`).

### `api/files.py`, `api/workspaces.py`
- Read `int(app_state.settings.file_upload_size_max)` at call time instead of the module constant.
- `_stream_upload_to_tempfile` takes `max_upload` as a param; `import_workspace` passes it.
- Dropped `FILE_UPLOAD_SIZE_MAX` / `resolve_env_bool` imports.

### `wshandler/constants.py`
- `WS_DEBUG` → `os.environ.get("KLANGKWS_DEBUG")` (plain debug flag, not a `KlangkSettings` field).
- `bridge_idle_timeout()` → `os.environ.get("KLANGK_BRIDGE_TIMEOUT_SECONDS")` (plain scalar, no secret).
- Dropped the `resolve_env_value` import.

### `tests/conftest.py`
- **Removed the collection-time `os.environ.setdefault(KLANGK_STATE_DIR/DATA_DIR)` workaround** + the multi-iteration comment. Test collection no longer needs env pre-set — verified by `--collect-only` (2396 collected) with no env seeded.

### Tests
- `test_api.py`: `monkeypatch.setattr(api, "<GLOBAL>", ...)` → `monkeypatch.setattr(app.state.settings, "<field>", ...)` for banner/product/legal/logo/version/autostart/upload-size tests. `patch.dict(os.environ, {"KLANGK_ALLOW_AUTOSTART": ...})` → `patch.object(app.state.settings, "allow_autostart", ...)`.
- `test_api_package.py`: replaced the obsolete `test_file_upload_size_max_is_shared_object` with `test_no_duplicate_module_globals` (asserts no module-level config reads survive).

## Acceptance (from #1516)

- [x] **No module-level `resolve_env_value`/`resolve_env_bool`/`get_settings()` in `klangk_backend/`** — verified by AST scan (no top-level `Assign`/`If` whose value calls them).
- [x] **Conftest collection-time env workaround removed** — `--collect-only` collects 2396 with no env seeded.
- [x] 100% coverage; full backend suite green with `-n auto` (2396 passed, 29s, no hang).

## Out of scope (noted, not blocking)

`get_settings()` and the `resolve_env_value`/`resolve_env_bool` re-exports from `util.py` **survive** — they still have legitimate **call-time** (not import-time) consumers that don't block collection:
- `main.py` CLI/seed functions (`KLANGK_LISTEN`, default user, `LOGFIRE_*`) and the lazy `main:app` shim (#1454 territory).
- `ssl_trust.py`, `agent.py`, `model/db.py` (`ensure_engine` fallback).
- `plugins.py` dynamic non-`KLANGK_` keys (the permanent legitimate path).

These retire as each consuming module is threaded an explicit `settings`/`app_state` — a separate slice. The import-time triggers that forced the conftest workaround are fully eliminated here.
