### PR TITLE
Lift settings field defaults into KlangkSettings; kill consumer or-fallbacks (#1514)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -63,6 +63,19 @@ operators or integrators to act when upgrading.
 
 ### Changed
 
+- **Settings field defaults lifted into `KlangkSettings` (#1514):** the
+  `str | None = None` fields whose consumers applied a fixed `or "default"`
+  fallback at read time are now non-optional `str` with the default baked in:
+  `dns_servers`, `llm_model`, `llm_api_key`, `userns`
+  (`keep-id:uid=1000,gid=1000`), `disable_registration`, `disable_invites`,
+  `prevent_insecure_jwt_secret`, `trust_outer_proxy`, `disable_tmux`,
+  `allow_sudo`, `allow_autostart`, `hosted_ports_per_workspace`,
+  `email_templates_dir`, `smtp_reply_to`. The scattered `or ""` /
+  `or "keep-id:..."` fallbacks in `auth.py`, `container.py`, `nginx.py`,
+  `terminal.py`, `emailsvc.py`, and `api/_common.py` are gone; consumers
+  read `self.settings.<field>` directly. (The product-name / legal-link /
+  branding fields were already lifted in #1516/#1517.)
+
 - **Last import-time config reads removed from the API and wshandler
   packages (#1516):** `api/__init__.py`, `api/_common.py`, and
   `wshandler/constants.py` no longer read config at module import time.

--- a/src/backend/klangk_backend/api/_common.py
+++ b/src/backend/klangk_backend/api/_common.py
@@ -74,7 +74,7 @@ def autostart_allowed(app_state) -> bool:
     Read off the frozen ``app_state.settings`` rather than re-resolving the
     env at call time (#1516).
     """
-    return (app_state.settings.allow_autostart or "").strip().lower() in (
+    return app_state.settings.allow_autostart.strip().lower() in (
         "1",
         "true",
         "yes",

--- a/src/backend/klangk_backend/auth.py
+++ b/src/backend/klangk_backend/auth.py
@@ -165,7 +165,7 @@ class Auth:
         """
         if self.jwt_secret_is_secure():
             return
-        prevent = (self.settings.prevent_insecure_jwt_secret or "").lower()
+        prevent = self.settings.prevent_insecure_jwt_secret.lower()
         if prevent in ("1", "true", "yes"):
             raise ConfigurationError(
                 "KLANGK_JWT_SECRET is unset or the insecure default. Set a "
@@ -180,12 +180,12 @@ class Auth:
 
     def registration_enabled(self) -> bool:
         """Check if public registration is enabled."""
-        val = self.settings.disable_registration or ""
+        val = self.settings.disable_registration
         return val.lower() not in ("1", "true", "yes")
 
     def invitations_enabled(self) -> bool:
         """Check if admin invitations are enabled."""
-        val = self.settings.disable_invites or ""
+        val = self.settings.disable_invites
         return val.lower() not in ("1", "true", "yes")
 
     def validate_password_length(self, password: str) -> None:

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -637,7 +637,7 @@ class ContainerRegistry:
 
     def container_dns_config(self) -> list[str]:
         """Return DNS server list from settings.dns_servers."""
-        raw = self.settings.dns_servers or ""
+        raw = self.settings.dns_servers
         return [d.strip() for d in raw.split(",") if d.strip()]
 
     def image_pull_policy(self) -> str:
@@ -724,9 +724,7 @@ class ContainerRegistry:
 
     def ports_per_workspace_cap(self) -> int:
         """Server-wide ceiling on hosted-app ports per workspace."""
-        raw = self.settings.hosted_ports_per_workspace or str(
-            DEFAULT_PORTS_PER_WORKSPACE
-        )
+        raw = self.settings.hosted_ports_per_workspace
         try:
             return max(0, int(raw))
         except ValueError:
@@ -1142,7 +1140,7 @@ class ContainerRegistry:
         env_vars: list[str] = []
         nginx_port = self.settings.nginx_port
         proxy_url = f"http://host.containers.internal:{nginx_port}/llm-proxy"
-        llm_model = self.settings.llm_model or ""
+        llm_model = self.settings.llm_model
         env_vars.append(f"KLANGK_LLM_PROXY_URL={proxy_url}")
         if llm_model:
             env_vars.append(f"KLANGK_LLM_MODEL={llm_model}")
@@ -1452,7 +1450,7 @@ class ContainerRegistry:
         ]
         iid = model.get_instance_id()
         container_name = f"klangk-{iid}-{workspace_id[:12]}"
-        allow_sudo = (self.settings.allow_sudo or "").strip().lower() in (
+        allow_sudo = self.settings.allow_sudo.strip().lower() in (
             "1",
             "true",
             "yes",
@@ -1476,7 +1474,7 @@ class ContainerRegistry:
             env=env_vars,
             init=True,
             interactive=True,
-            userns=self.settings.userns or "keep-id:uid=1000,gid=1000",
+            userns=self.settings.userns,
             pull=self.image_pull_policy(),
         )
 
@@ -1624,7 +1622,7 @@ class ContainerRegistry:
                 "klangk-prewarm",
                 self.image_name,
                 pull="never",
-                userns=self.settings.userns or "keep-id:uid=1000,gid=1000",
+                userns=self.settings.userns,
             )
             await self.podman.remove_container(cid)
             logger.info("Podman pre-warmed in %.3fs", time.monotonic() - t0)

--- a/src/backend/klangk_backend/emailsvc.py
+++ b/src/backend/klangk_backend/emailsvc.py
@@ -183,7 +183,7 @@ class EmailService:
         """
         if self._env is None:
             loaders = []
-            user_dir = self.settings.email_templates_dir or ""
+            user_dir = self.settings.email_templates_dir
             if not user_dir:
                 candidate = Path(self._customize_dir()) / "email-templates"
                 if candidate.is_dir():

--- a/src/backend/klangk_backend/nginx.py
+++ b/src/backend/klangk_backend/nginx.py
@@ -329,7 +329,7 @@ class NginxRenderer:
         base_url = self._settings.llm_base_url
         if not base_url:
             return ""
-        api_key = self._settings.llm_api_key or ""
+        api_key = self._settings.llm_api_key
         return (
             f"    location ~ ^/llm-proxy/(.*)$ {{\n"
             f"{acl}\n"
@@ -351,7 +351,7 @@ class NginxRenderer:
         )
 
     def _trust_outer_proxy(self) -> bool:
-        raw = self._settings.trust_outer_proxy or ""
+        raw = self._settings.trust_outer_proxy
         return str(raw).strip().lower() in ("1", "true", "yes")
 
     # -- Main renderer -----------------------------------------------------

--- a/src/backend/klangk_backend/settings.py
+++ b/src/backend/klangk_backend/settings.py
@@ -304,7 +304,7 @@ class KlangkSettings(BaseSettings):
     # --- Auth / identity ---
     auth_modes: str | None = None
     jwt_secret: str | None = _INSECURE_DEFAULT_SECRET
-    prevent_insecure_jwt_secret: str | None = None
+    prevent_insecure_jwt_secret: str = ""
     default_user: str | None = "admin@example.com"
     default_password: str | None = None
     access_token_hours: str | None = "24"
@@ -313,8 +313,8 @@ class KlangkSettings(BaseSettings):
     login_lockout_failures: str | None = "5"
     login_lockout_duration: str | None = "900"
     login_lockout_window: str | None = "300"
-    disable_registration: str | None = None
-    disable_invites: str | None = None
+    disable_registration: str = ""
+    disable_invites: str = ""
     invite_expire_hours: str | None = "72"
     allow_insecure_no_auth: str | None = None
     reject_proxy_headers: str | None = None
@@ -347,13 +347,13 @@ class KlangkSettings(BaseSettings):
     # trust_outer_proxy: opt-in to surviving an outer trusted proxy's
     # X-Forwarded-* in nginx's catch-all (see #1396 renderer). Mirrors the
     # KLANGK_TRUST_OUTER_PROXY env var the old nginx.sh read.
-    trust_outer_proxy: str | None = None
+    trust_outer_proxy: str = ""
     # ws_msg_size_max: max WebSocket message size (bytes), passed to uvicorn.
     # Default 16 MiB; klangkd reads it through the typed config (config file +
     # file:/cmd: resolution), not raw env.
     ws_msg_size_max: str | None = "16777216"
     cors_origins: str | None = None
-    dns_servers: str | None = None
+    dns_servers: str = ""
     hosting_hostname: str | None = None
     hosting_proto: str | None = None
     hosting_base_path: str | None = None
@@ -377,16 +377,16 @@ class KlangkSettings(BaseSettings):
     image_pull_policy: str | None = "never"
     allowed_images: str | None = None
     allowed_mount_roots: str | None = None
-    allow_autostart: str | None = None
-    allow_sudo: str | None = None
+    allow_autostart: str = ""
+    allow_sudo: str = ""
     container_subnets: str | None = None
-    userns: str | None = None
+    userns: str = "keep-id:uid=1000,gid=1000"
     podman_bin: str | None = "podman"
-    disable_tmux: str | None = None
+    disable_tmux: str = ""
     health_check_interval: str | None = None
     health_check_startup_grace: str | None = None
     health_check_timeout: str | None = None
-    hosted_ports_per_workspace: str | None = "5"
+    hosted_ports_per_workspace: str = "5"
     test_mode: str | None = None
     version_file: str | None = None
 
@@ -396,8 +396,8 @@ class KlangkSettings(BaseSettings):
     # not read by the backend itself. Kept here so the renderer reads it
     # through the same typed config path as everything else (#1396).
     llm_base_url: str | None = None
-    llm_api_key: str | None = None
-    llm_model: str | None = None
+    llm_api_key: str = ""
+    llm_model: str = ""
 
     # --- OIDC ---
     oidc_config: str | None = None
@@ -410,10 +410,10 @@ class KlangkSettings(BaseSettings):
     smtp_user: str | None = None
     smtp_password: str | None = None
     smtp_from: str | None = None
-    smtp_reply_to: str | None = None
+    smtp_reply_to: str = ""
     smtp_use_tls: str | None = "true"
     sendmail_path: str | None = "sendmail"
-    email_templates_dir: str | None = None
+    email_templates_dir: str = ""
 
     # --- Legal / support links ---
     terms_url: str = ""

--- a/src/backend/klangk_backend/terminal.py
+++ b/src/backend/klangk_backend/terminal.py
@@ -243,7 +243,7 @@ class Terminal:
         affects the default per-user terminal; shared/joined terminals are
         built on tmux session groups and always use tmux regardless.
         """
-        val = (self._app_state.settings.disable_tmux or "").lower()
+        val = self._app_state.settings.disable_tmux.lower()
         return val not in ("1", "true", "yes")
 
     # --- tmux session / window queries ---

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -7796,7 +7796,7 @@ class TestInvitations:
         self, client, app, monkeypatch
     ):
         # Default: flag unset -> not allowed, so the UI hides its checkbox.
-        monkeypatch.setattr(app.state.settings, "allow_autostart", None)
+        monkeypatch.setattr(app.state.settings, "allow_autostart", "")
         resp = await client.get("/api/v1/config")
         assert resp.status_code == 200
         assert resp.json()["allow_autostart"] is False

--- a/src/backend/tests/test_terminal.py
+++ b/src/backend/tests/test_terminal.py
@@ -43,7 +43,7 @@ _mock_registry.mark_service_started = MagicMock()
 # in per-class setup_method / patch.object auto-restore); only the
 # settings-bearing wrapper + Terminal are recreated.
 _mock_settings = MagicMock()
-_mock_settings.disable_tmux = None
+_mock_settings.disable_tmux = ""
 _app_state = types.SimpleNamespace(
     podman=_mock_pod,
     container_registry=_mock_registry,
@@ -63,7 +63,7 @@ def _fresh_terminal():
     """
     global _mock_settings, _app_state, _terminal
     _mock_settings = MagicMock()
-    _mock_settings.disable_tmux = None
+    _mock_settings.disable_tmux = ""
     _app_state = types.SimpleNamespace(
         podman=_mock_pod,
         container_registry=_mock_registry,
@@ -995,7 +995,7 @@ class TestBuildShellCommandJoinSession:
 
 class TestTerminalTmuxEnabled:
     def test_default_enabled(self):
-        _mock_settings.disable_tmux = None
+        _mock_settings.disable_tmux = ""
         assert _terminal.tmux_enabled() is True
 
     @pytest.mark.parametrize("val", ["1", "true", "TRUE", "yes", "Yes"])


### PR DESCRIPTION
Closes #1514. Part of #1426 (composition-root refactor).

## What

Several consumers applied a fixed `field or "default"` / `(field or "").strip()` fallback at read time, where the fallback was a constant — not runtime-conditional. Those defaults belong in the field declaration, not scattered across call sites. This lifts them into `KlangkSettings` and drops the consumer wraps.

## Changes

### `settings.py` — fields promoted to non-optional `str` with baked defaults

| Field | Was | Now |
|---|---|---|
| `prevent_insecure_jwt_secret` | `str \| None = None` | `str = ""` |
| `disable_registration` | `str \| None = None` | `str = ""` |
| `disable_invites` | `str \| None = None` | `str = ""` |
| `trust_outer_proxy` | `str \| None = None` | `str = ""` |
| `dns_servers` | `str \| None = None` | `str = ""` |
| `allow_autostart` | `str \| None = None` | `str = ""` |
| `allow_sudo` | `str \| None = None` | `str = ""` |
| `userns` | `str \| None = None` | `str = "keep-id:uid=1000,gid=1000"` |
| `disable_tmux` | `str \| None = None` | `str = ""` |
| `hosted_ports_per_workspace` | `str \| None = "5"` | `str = "5"` |
| `llm_api_key` | `str \| None = None` | `str = ""` |
| `llm_model` | `str \| None = None` | `str = ""` |
| `smtp_reply_to` | `str \| None = None` | `str = ""` |
| `email_templates_dir` | `str \| None = None` | `str = ""` |

### Consumer wraps dropped
- `auth.py` — `prevent_insecure_jwt_secret`, `disable_registration`, `disable_invites` `or ""` → direct read.
- `container.py` — `dns_servers`, `hosted_ports_per_workspace` (the `or str(DEFAULT_PORTS_PER_WORKSPACE)` was dead — field already defaulted to `"5"`), `llm_model`, `allow_sudo`, `userns` (×2) `or X` → direct read.
- `nginx.py` — `llm_api_key`, `trust_outer_proxy` `or ""` → direct read.
- `terminal.py` — `(disable_tmux or "").lower()` → `.lower()`.
- `emailsvc.py` — `email_templates_dir or ""` → direct read.
- `api/_common.py` — `(allow_autostart or "").strip()` → `.strip()`.

### Left alone (genuinely not fixed-default)
- `smtp_reply_to or None` in `emailsvc.reply_to()` — None-coalescing (empty → "no Reply-To header"), not a default; stays.
- `email_templates_dir` derive-from-`customize_dir` logic in `emailsvc._build_env()` — depends on filesystem existence (`candidate.is_dir()`), not config; stays (only the `or ""` wrap dropped).

## Acceptance (from #1514)
- [x] No `self.settings.<field> or <const>` / `getattr(settings, ...)` / `if ... is not None else` patterns where the fallback is a fixed config default — verified by `rg "settings\.\w+ or " src/backend/klangk_backend/` returning no fixed-default hits.
- [x] Each lifted default is a field-declaration default in `settings.py`.
- [x] 100% coverage; full backend suite green with `-n auto` (2396 passed).

## Tests
- `test_terminal.py`: mock `_mock_settings.disable_tmux` `None` → `""` (field is now `str`).
- `test_api.py`: `test_config_advertises_allow_autostart` patches `allow_autostart` to `""` (was `None`).
