### PR TITLE
Delete main:app shim; seal composition root; E2E launches runtestserver.py (#1454)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -63,6 +63,14 @@ operators or integrators to act when upgrading.
 
 ### Changed
 
+- **The `main:app` ASGI shim is gone (#1454).** `main.py` no longer exposes
+  an `app` attribute or a lazy `__getattr__` — the composition root is sealed.
+  `klangkd` is the only production entry point (constructs the app explicitly
+  via `build_app(settings)` and passes the object to uvicorn). The E2E suites
+  launch `e2e-tests/runtestserver.py` (a test-only launcher that builds the
+  app and passes the object to uvicorn) instead of the `klangk_backend.main:app`
+  string import — no `module:app` string import anywhere.
+
 - **`resolve_env_value` / `resolve_env_bool` / `get_settings` retired
   (#1518):** the transitional config-reading shims are deleted. Every
   call-time caller now reads `app_state.settings.<field>` directly: `main.py`

--- a/src/backend/e2e-tests/runtestserver.py
+++ b/src/backend/e2e-tests/runtestserver.py
@@ -1,0 +1,44 @@
+"""E2E test server launcher (NOT for production).
+
+Builds the app explicitly (``build_app(KlangkSettings(os.environ))``) and passes
+the object to uvicorn — no ``module:app`` string import. The composition root
+is sealed (#1454); this is the test-only TCP entry point the E2E suites use
+instead of bare ``uvicorn klangk_backend.main:app``.
+
+Reads config from env vars (the E2E harness sets them before spawning this
+process). Accepts the uvicorn bind options the suites need as CLI args.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+import uvicorn
+
+from klangk_backend.main import build_app
+from klangk_backend.settings import KlangkSettings
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="E2E test server")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, required=True)
+    parser.add_argument("--ws-max-size", type=int, default=16777216)
+    parser.add_argument("--ws-ping-interval", type=int, default=20)
+    parser.add_argument("--ws-ping-timeout", type=int, default=20)
+    args = parser.parse_args()
+
+    app = build_app(KlangkSettings(os.environ))
+    uvicorn.run(
+        app,
+        host=args.host,
+        port=args.port,
+        ws_max_size=args.ws_max_size,
+        ws_ping_interval=args.ws_ping_interval,
+        ws_ping_timeout=args.ws_ping_timeout,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/backend/e2e-tests/test_agent_home_e2e.py
+++ b/src/backend/e2e-tests/test_agent_home_e2e.py
@@ -79,8 +79,8 @@ def server():
     }
     proc = subprocess.Popen(
         [
-            "uvicorn",
-            "klangk_backend.main:app",
+            "python3",
+            os.path.join(os.path.dirname(__file__), "runtestserver.py"),
             "--host",
             "0.0.0.0",
             "--port",

--- a/src/backend/e2e-tests/test_api_e2e.py
+++ b/src/backend/e2e-tests/test_api_e2e.py
@@ -66,8 +66,8 @@ def _start_server(data_dir, port):
     }
     proc = subprocess.Popen(
         [
-            "uvicorn",
-            "klangk_backend.main:app",
+            "python3",
+            os.path.join(os.path.dirname(__file__), "runtestserver.py"),
             "--host",
             "0.0.0.0",
             "--port",
@@ -1065,8 +1065,8 @@ class TestAutoStartWithServiceCommand:
         }
         proc = subprocess.Popen(
             [
-                "uvicorn",
-                "klangk_backend.main:app",
+                "python3",
+                os.path.join(os.path.dirname(__file__), "runtestserver.py"),
                 "--host",
                 "0.0.0.0",
                 "--port",

--- a/src/backend/e2e-tests/test_event_fanout.py
+++ b/src/backend/e2e-tests/test_event_fanout.py
@@ -57,8 +57,8 @@ def server():
     }
     proc = subprocess.Popen(
         [
-            "uvicorn",
-            "klangk_backend.main:app",
+            "python3",
+            os.path.join(os.path.dirname(__file__), "runtestserver.py"),
             "--host",
             "0.0.0.0",
             "--port",

--- a/src/backend/e2e-tests/test_health_check_e2e.py
+++ b/src/backend/e2e-tests/test_health_check_e2e.py
@@ -56,8 +56,8 @@ def server():
     }
     proc = subprocess.Popen(
         [
-            "uvicorn",
-            "klangk_backend.main:app",
+            "python3",
+            os.path.join(os.path.dirname(__file__), "runtestserver.py"),
             "--host",
             "0.0.0.0",
             "--port",

--- a/src/backend/e2e-tests/test_nginx_acl_e2e.py
+++ b/src/backend/e2e-tests/test_nginx_acl_e2e.py
@@ -27,14 +27,14 @@ def _render_conf(env_overrides, tmpdir=None):
     """Render nginx.conf via the Python renderer (#1396) with controlled env.
 
     Replaces the old ``_run_nginx_sh`` (which ran ``scripts/nginx.sh`` and
-    killed it after config generation). Sets KLANGK_* env vars, invalidates
-    the live env (read by render_config via get_settings), renders via :func:`klangk_backend.nginx.render_config`,
-    then restores the env. Returns the conf text.
+    killed it after config generation). Renders via :func:`klangk_backend.nginx.render_config`
+    from an explicit settings dict built from ``env_overrides`` — no
+    ``os.environ`` mutation. Returns the conf text.
 
     Keys the renderer consults but that aren't in ``env_overrides`` are
-    explicitly *cleared* (not left at whatever a prior test set) so each test
-    starts from a known-clean state — without this, ``test_no_llm_block_*``
-    would see a ``KLANGK_LLM_BASE_URL`` leaked from ``test_llm_block_*``.
+    absent from the dict (unset) so each test starts from a known-clean
+    state — without this, ``test_no_llm_block_*`` would see a
+    ``KLANGK_LLM_BASE_URL`` leaked from ``test_llm_block_*``.
     """
     env = {
         "KLANGK_NGINX_PORT": "19999",
@@ -42,44 +42,13 @@ def _render_conf(env_overrides, tmpdir=None):
         "KLANGK_STATE_DIR": str(tmpdir or "/tmp/klangk-e2e-state"),
         **env_overrides,
     }
-    # Every renderer-relevant key: absent in env_overrides => cleared for this
-    # render (restored to its prior value afterwards).
-    renderer_keys = {
-        "KLANGK_NGINX_PORT",
-        "KLANGK_DATA_DIR",
-        "KLANGK_STATE_DIR",
-        "KLANGK_CONTAINER_SUBNETS",
-        "KLANGK_LLM_BASE_URL",
-        "KLANGK_LLM_API_KEY",
-        "KLANGK_HOSTED_PORTS_PER_WORKSPACE",
-        "KLANGK_TRUST_OUTER_PROXY",
-        "KLANGK_FILE_UPLOAD_SIZE_MAX",
-        "KLANGK_DNS_SERVERS",
-        "KLANGK_NGINX_BIN",
-    }
-    old_env = {}
-    for k in renderer_keys:
-        old_env[k] = os.environ.get(k)
-        if k in env and env[k] is not None:
-            os.environ[k] = env[k]
-        else:
-            # Explicitly clear so an absent key means "not set" for this
-            # render, regardless of what a prior test left behind.
-            os.environ.pop(k, None)
-    try:
-        from klangk_backend.nginx import NginxRenderer, tcp_upstream
-        from klangk_backend.settings import KlangkSettings
-        import types
+    from klangk_backend.nginx import NginxRenderer, tcp_upstream
+    from klangk_backend.settings import KlangkSettings
+    import types
 
-        return NginxRenderer(
-            types.SimpleNamespace(settings=KlangkSettings(os.environ))
-        ).render_config(tcp_upstream("127.0.0.1", "19998"))
-    finally:
-        for k, old in old_env.items():
-            if old is None:
-                os.environ.pop(k, None)
-            else:
-                os.environ[k] = old
+    return NginxRenderer(
+        types.SimpleNamespace(settings=KlangkSettings(env))
+    ).render_config(tcp_upstream("127.0.0.1", "19998"))
 
 
 def _write_and_launch_nginx(conf_text, nginx_port, tmpdir):
@@ -423,8 +392,8 @@ class TestNginxAclEnforcement:
         }
         backend_proc = subprocess.Popen(
             [
-                "uvicorn",
-                "klangk_backend.main:app",
+                "python3",
+                os.path.join(os.path.dirname(__file__), "runtestserver.py"),
                 "--host",
                 "0.0.0.0",
                 "--port",
@@ -455,25 +424,24 @@ class TestNginxAclEnforcement:
             raise RuntimeError("Backend did not start")
 
         # Start nginx via the Python renderer (#1396): render the conf
-        # from these env vars, then launch nginx directly with -c.
+        # from an explicit settings dict, then launch nginx directly with -c.
         from klangk_backend.nginx import NginxRenderer, tcp_upstream
         from klangk_backend.settings import KlangkSettings
         import types
 
-        for k, v in {
+        nginx_env = {
             "KLANGK_NGINX_PORT": nginx_port,
             "KLANGK_CONTAINER_SUBNETS": "192.0.2.0/24",
             "KLANGK_LLM_BASE_URL": f"http://127.0.0.1:{backend_port}",
             "KLANGK_LLM_API_KEY": "fake-key",
             "KLANGK_DATA_DIR": data_dir,
             "KLANGK_STATE_DIR": state_dir,
-        }.items():
-            os.environ[k] = v
+        }
         nginx_state = os.path.join(tmpdir, "nginx")
         os.makedirs(nginx_state, exist_ok=True)
         conf_path = os.path.join(nginx_state, "nginx.conf")
         NginxRenderer(
-            types.SimpleNamespace(settings=KlangkSettings(os.environ))
+            types.SimpleNamespace(settings=KlangkSettings(nginx_env))
         ).write_config(tcp_upstream("127.0.0.1", backend_port), conf_path)
         nginx_proc = subprocess.Popen(
             ["nginx", "-e", "stderr", "-c", conf_path],
@@ -601,8 +569,8 @@ class TestNginxDenyByDefault:
         }
         backend_proc = subprocess.Popen(
             [
-                "uvicorn",
-                "klangk_backend.main:app",
+                "python3",
+                os.path.join(os.path.dirname(__file__), "runtestserver.py"),
                 "--host",
                 "127.0.0.1",
                 "--port",
@@ -639,18 +607,17 @@ class TestNginxDenyByDefault:
         from klangk_backend.settings import KlangkSettings
         import types
 
-        for k, v in {
+        nginx_env = {
             "KLANGK_NGINX_PORT": nginx_port,
             "KLANGK_CONTAINER_SUBNETS": host_ip,
             "KLANGK_DATA_DIR": data_dir,
             "KLANGK_STATE_DIR": state_dir,
-        }.items():
-            os.environ[k] = v
+        }
         nginx_state = os.path.join(tmpdir, "nginx")
         os.makedirs(nginx_state, exist_ok=True)
         conf_path = os.path.join(nginx_state, "nginx.conf")
         NginxRenderer(
-            types.SimpleNamespace(settings=KlangkSettings(os.environ))
+            types.SimpleNamespace(settings=KlangkSettings(nginx_env))
         ).write_config(tcp_upstream("127.0.0.1", backend_port), conf_path)
         nginx_proc = subprocess.Popen(
             ["nginx", "-e", "stderr", "-c", conf_path],
@@ -772,8 +739,8 @@ class TestNginxAuthLocalAcl:
         }
         backend_proc = subprocess.Popen(
             [
-                "uvicorn",
-                "klangk_backend.main:app",
+                "python3",
+                os.path.join(os.path.dirname(__file__), "runtestserver.py"),
                 "--host",
                 "127.0.0.1",
                 "--port",
@@ -809,14 +776,16 @@ class TestNginxAuthLocalAcl:
         from klangk_backend.settings import KlangkSettings
         import types
 
-        os.environ["KLANGK_NGINX_PORT"] = nginx_port
-        os.environ["KLANGK_DATA_DIR"] = data_dir
-        os.environ["KLANGK_STATE_DIR"] = state_dir
+        nginx_env = {
+            "KLANGK_NGINX_PORT": nginx_port,
+            "KLANGK_DATA_DIR": data_dir,
+            "KLANGK_STATE_DIR": state_dir,
+        }
         nginx_state = os.path.join(tmpdir, "nginx")
         os.makedirs(nginx_state, exist_ok=True)
         conf_path = os.path.join(nginx_state, "nginx.conf")
         NginxRenderer(
-            types.SimpleNamespace(settings=KlangkSettings(os.environ))
+            types.SimpleNamespace(settings=KlangkSettings(nginx_env))
         ).write_config(tcp_upstream("127.0.0.1", backend_port), conf_path)
         nginx_proc = subprocess.Popen(
             ["nginx", "-e", "stderr", "-c", conf_path],

--- a/src/backend/e2e-tests/test_per_user_home.py
+++ b/src/backend/e2e-tests/test_per_user_home.py
@@ -48,8 +48,8 @@ def server():
     }
     proc = subprocess.Popen(
         [
-            "uvicorn",
-            "klangk_backend.main:app",
+            "python3",
+            os.path.join(os.path.dirname(__file__), "runtestserver.py"),
             "--host",
             "0.0.0.0",
             "--port",

--- a/src/backend/e2e-tests/test_service_command_shared_e2e.py
+++ b/src/backend/e2e-tests/test_service_command_shared_e2e.py
@@ -62,8 +62,8 @@ def server():
     }
     proc = subprocess.Popen(
         [
-            "uvicorn",
-            "klangk_backend.main:app",
+            "python3",
+            os.path.join(os.path.dirname(__file__), "runtestserver.py"),
             "--host",
             "0.0.0.0",
             "--port",

--- a/src/backend/e2e-tests/test_sighup_restart_e2e.py
+++ b/src/backend/e2e-tests/test_sighup_restart_e2e.py
@@ -64,8 +64,8 @@ def server():
     }
     proc = subprocess.Popen(
         [
-            "uvicorn",
-            "klangk_backend.main:app",
+            "python3",
+            os.path.join(os.path.dirname(__file__), "runtestserver.py"),
             "--host",
             "0.0.0.0",
             "--port",

--- a/src/backend/klangk_backend/klangkd.py
+++ b/src/backend/klangk_backend/klangkd.py
@@ -104,10 +104,10 @@ def main(  # pragma: no cover
     except FileNotFoundError:
         pass
     Path(uds_path).parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-    # Construct the app explicitly and pass the object to uvicorn (not the
-    # "klangk_backend.main:app" string import). This avoids the module-level
+    # Construct the app explicitly and pass the object to uvicorn (not a
+    # ``module:app`` string import). This avoids the module-level
     # ``app = build_app()`` global — there's one ``build_app(settings)`` call,
-    # one registry, wired correctly (#1464).
+    # one registry, wired correctly (#1464, #1454).
     from klangk_backend.main import build_app  # noqa: allow-deferred-import
 
     asgi_app = build_app(settings)

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -689,15 +689,8 @@ from .api._common import get_app_state_dep  # noqa: F401, E402
 
 
 # --- ASGI app ---
-# No module-level ``app = build_app(...)``: that eagerly constructed a
-# ``ContainerRegistry`` at import time, separate from the one klangkd / the
-# lifespan use — two registries, and the health loop ran on the wrong one
-# (#1464). Instead, klangkd constructs the app explicitly (build_app(settings))
-# and passes the object to uvicorn. The lazy ``__getattr__`` below covers the
-# ``uvicorn klangk_backend.main:app`` string-import path used by E2E tests.
-
-
-def __getattr__(name):
-    if name == "app":
-        return build_app(KlangkSettings(os.environ))
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+# No module-level ``app = build_app(...)`` and no ``__getattr__`` shim: the
+# composition root is sealed (#1454). ``klangkd`` constructs the app
+# explicitly (``build_app(settings)``) and passes the object to uvicorn. The
+# E2E suites launch ``e2e-tests/runtestserver.py``, which builds the app and
+# passes the object to uvicorn — no ``module:app`` string import anywhere.

--- a/src/backend/tests/test_main.py
+++ b/src/backend/tests/test_main.py
@@ -1087,9 +1087,30 @@ class TestBuildApp:
         app = main.build_app(make_settings({}))
         assert model.AgentPrincipalError in app.exception_handlers
 
-    def test_module_app_is_built(self):
-        """The module-level ``app`` shim is a real FastAPI app."""
-        assert isinstance(main.app, FastAPI)
+    def test_no_module_level_app_attribute(self):
+        """main.py no longer exposes an ``app`` attribute (#1454).
+
+        The composition root is sealed: ``klangkd`` builds the app explicitly.
+        E2E suites launch ``e2e-tests/runtestserver.py`` (which builds the
+        app and passes the object to uvicorn) instead of a string import.
+        """
+        assert not hasattr(main, "app")
+
+    def test_runtestserver_builds_app(self):
+        """The E2E launcher script builds a real FastAPI app."""
+        import runpy
+        from pathlib import Path
+
+        script = (
+            Path(__file__).resolve().parent.parent
+            / "e2e-tests"
+            / "runtestserver.py"
+        )
+        # Don't execute __main__ (that would call uvicorn.run); just verify
+        # the module imports and exposes build_app correctly.
+        ns = runpy.run_path(str(script), run_name="not_main")
+        app = ns["build_app"](ns["KlangkSettings"](os.environ))
+        assert isinstance(app, FastAPI)
 
 
 class TestGetAppStateDep:

--- a/src/cli/e2e-tests/test_cli_e2e.py
+++ b/src/cli/e2e-tests/test_cli_e2e.py
@@ -63,8 +63,15 @@ def _start_server(data_dir, port, extra_env=None):
     log_file = open(log_path, "w")  # noqa: SIM115
     proc = subprocess.Popen(
         [
-            "uvicorn",
-            "klangk_backend.main:app",
+            "python3",
+            os.path.join(
+                os.path.dirname(__file__),
+                "..",
+                "..",
+                "backend",
+                "e2e-tests",
+                "runtestserver.py",
+            ),
             "--host",
             "0.0.0.0",
             "--port",

--- a/src/cli/e2e-tests/test_monitor_e2e.py
+++ b/src/cli/e2e-tests/test_monitor_e2e.py
@@ -72,8 +72,15 @@ def _start_server(data_dir, port, health_interval="2"):
     log_file = open(log_path, "w")  # noqa: SIM115
     proc = subprocess.Popen(
         [
-            "uvicorn",
-            "klangk_backend.main:app",
+            "python3",
+            os.path.join(
+                os.path.dirname(__file__),
+                "..",
+                "..",
+                "backend",
+                "e2e-tests",
+                "runtestserver.py",
+            ),
             "--host",
             "0.0.0.0",
             "--port",

--- a/src/cli/e2e-tests/test_terminal_windows_e2e.py
+++ b/src/cli/e2e-tests/test_terminal_windows_e2e.py
@@ -62,8 +62,15 @@ def _start_server(data_dir):
     log_file = open(log_path, "w")  # noqa: SIM115
     proc = subprocess.Popen(
         [
-            "uvicorn",
-            "klangk_backend.main:app",
+            "python3",
+            os.path.join(
+                os.path.dirname(__file__),
+                "..",
+                "..",
+                "backend",
+                "e2e-tests",
+                "runtestserver.py",
+            ),
             "--host",
             "0.0.0.0",
             "--port",

--- a/src/frontend/e2e-tests/e2e/klangk.spec.ts
+++ b/src/frontend/e2e-tests/e2e/klangk.spec.ts
@@ -577,9 +577,9 @@ test.describe("Klangk E2E", () => {
         const backendPort = process.env.KLANGK_E2E_PORT || "18997";
         const dataDir = process.env.KLANGK_E2E_DATA_DIR || "/tmp/klangk-e2e";
         const backendProcess = spawnProc(
-          "uvicorn",
+          "python3",
           [
-            "klangk_backend.main:app",
+            "e2e-tests/runtestserver.py",
             "--host",
             "0.0.0.0",
             "--port",

--- a/src/frontend/e2e-tests/global-setup.ts
+++ b/src/frontend/e2e-tests/global-setup.ts
@@ -133,8 +133,8 @@ async function globalSetup() {
 
   // Start uvicorn directly with E2E overrides as env vars.
   const backendProcess = spawn(
-    "uvicorn",
-    ["klangk_backend.main:app", "--host", "0.0.0.0", "--port", backendPort],
+    "python3",
+    ["e2e-tests/runtestserver.py", "--host", "0.0.0.0", "--port", backendPort],
     {
       cwd: join(projectRoot, "src", "backend"),
       detached: true,


### PR DESCRIPTION
Closes #1454. Final slice of #1426 (composition-root refactor).

## What

The `main:app` ASGI shim is gone. `main.py` no longer exposes an `app` attribute or a lazy `__getattr__` — the composition root is sealed.

- **Production:** `klangkd` is the only entry point. It constructs the app explicitly (`build_app(settings)`) and passes the object to uvicorn — already done in prior slices, unchanged here.
- **E2E tests:** launch `e2e-tests/runtestserver.py` (a test-only launcher) instead of bare `uvicorn klangk_backend.main:app`. The script builds the app explicitly and passes the object to uvicorn — no `module:app` string import anywhere.

### `runtestserver.py`
A minimal argparse script in `src/backend/e2e-tests/`:
- Builds `build_app(KlangkSettings(os.environ))` — reads config from env (the E2E harness sets env vars before spawning).
- Accepts `--host`, `--port`, `--ws-max-size`, `--ws-ping-interval`, `--ws-ping-timeout` (the uvicorn options the suites passed via CLI flags).
- Runs `uvicorn.run(app, ...)` with the object.

### E2E launch sites converted (13 files, 3 languages)
All `subprocess.Popen(["uvicorn", "klangk_backend.main:app", ...])` → `subprocess.Popen(["python3", "runtestserver.py", ...])`:
- Backend e2e (8 files): `test_api_e2e`, `test_nginx_acl_e2e`, `test_sighup_restart_e2e`, `test_per_user_home`, `test_event_fanout`, `test_health_check_e2e`, `test_agent_home_e2e`, `test_service_command_shared_e2e`
- CLI e2e (3 files): `test_cli_e2e`, `test_monitor_e2e`, `test_terminal_windows_e2e`
- Frontend e2e (2 files): `global-setup.ts`, `e2e/klangk.spec.ts`

### Deleted
- `main.py` `__getattr__("app")` shim + the 6-line comment block explaining it.
- `test_main.py::test_module_app_is_built` (asserted the deleted `main.app`).

### Added
- `test_main.py::test_no_module_level_app_attribute` — asserts `main` has no `app` attr.
- `test_main.py::test_runtestserver_builds_app` — asserts the launcher script builds a real FastAPI app.

## Acceptance
- [x] No `module:app` string import anywhere (`grep -rn "main:app\|_test_server:app" src/` → empty).
- [x] `main.py` has no `app` attribute (unit test asserts `not hasattr(main, "app")`).
- [x] `get_settings()` already deleted (done in #1518).
- [x] 100% coverage; full backend suite green with `-n auto` (2379 passed).
- [x] E2E suites launch `runtestserver.py` (builds app explicitly, passes object to uvicorn).

## Note
The e2e suites can't use `klangkd` directly — it always binds a UDS (production posture), while the tests need TCP. `runtestserver.py` is the test-only TCP equivalent that mirrors klangkd's explicit-construction pattern.

This is the **final slice of #1426**. The composition root is sealed: every app instance is built by `build_app(settings)` with explicit settings threading, no import-time or attribute-access-time construction.
