### PR TITLE
Hermetic E2E envs: shared clean_env() helper, no os.environ spread (#1526)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -63,6 +63,22 @@ operators or integrators to act when upgrading.
 
 ### Changed
 
+- **E2E test envs are now hermetic (#1526):** all E2E suites (backend,
+  CLI, frontend) build subprocess envs via a shared `clean_env()` helper
+  (`_e2e_env.py` / `e2e-env.ts`) that strips every `KLANGK*` /
+  `_KLANGK*` / `KLANGKC*` / `LOGFIRE*` var from the ambient env before
+  applying the test's explicit overrides. No more `{**os.environ, ...}` /
+  `{...process.env, ...}` spreads — a stray config var in the CI runner's
+  env (or leaked by a prior test) can no longer silently change results.
+  The baseline defaults (`KLANGK_AUTH_MODES=password`, `_KLANGK_DISABLE_NGINX=1`)
+  moved from session-scoped `os.environ` mutations in `conftest.py` into
+  `clean_env()`, eliminating the in-process mutation too. Each server launch
+  now sets `KLANGK_STATE_DIR` to a fresh temp dir explicitly (the required
+  validator no longer relies on devenv seeding it), and `clean_env()`
+  forwards the three build-infra vars (`KLANGK_PLUGINS_DIR`,
+  `KLANGK_IMAGE_NAME`, `KLANGK_VERSION_FILE`) that locate the artifacts
+  devenv's `klangk:build-workspace-image` task produces.
+
 - **The `main:app` ASGI shim is gone (#1454).** `main.py` no longer exposes
   an `app` attribute or a lazy `__getattr__` — the composition root is sealed.
   `klangkd` is the only production entry point (constructs the app explicitly

--- a/src/backend/devenv.lock
+++ b/src/backend/devenv.lock
@@ -1,0 +1,65 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1783943325,
+        "narHash": "sha256-Bq+YOjx54mT0hH0qWlQ+96dKUuGEhkP+ZsMVxMOPcXA=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "06ee813b2f5a8fc1838cff9cfb6bd4f0466fc925",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "inputs": {
+        "nixpkgs-src": "nixpkgs-src"
+      },
+      "locked": {
+        "lastModified": 1783345554,
+        "narHash": "sha256-LZhOm4kqjHUnwP4CNHpaqqEVcumGNd1PvOEOad8LkS0=",
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "6004ea8c229fe9d41b21c6f4c76bf6c2e10771dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1783279667,
+        "narHash": "sha256-/NAkDSsve+GNM0Bt6tleJdCGfsTlK89nPjkVOzZMo0s=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f205b5574fd0cb7da5b702a2da51507b7f4fdd1b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/src/backend/e2e-tests/_e2e_env.py
+++ b/src/backend/e2e-tests/_e2e_env.py
@@ -1,0 +1,72 @@
+"""Shared hermetic env helper for E2E test suites (#1526).
+
+Every E2E suite that launches a subprocess (``runtestserver.py``, ``klangkd``,
+or ``klangkc``) must build the child's env from :func:`clean_env`, **not**
+``{**os.environ, ...}``. A stray ``KLANGK_*`` var in the CI runner's env
+(or one leaked by a prior test) silently becomes the child's config and can
+change test results — ``clean_env`` strips all config-affecting prefixes so
+the child sees only what the test explicitly sets.
+
+Strips (case-insensitive prefix match): ``KLANGK``, ``_KLANGK``,
+``KLANGKC``, ``LOGFIRE``. OS-essential vars (``PATH``, ``HOME``, Nix-specific
+``LOCALE_ARCHIVE`` / ``NIX_LD`` / etc.) are preserved so the subprocess can
+actually run.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Prefixes whose vars are stripped: any env var starting with one of these
+# (case-insensitive) is config or debug state that must not leak from the
+# ambient env into a test subprocess.
+_STRIP_PREFIXES = ("KLANGK", "_KLANGK", "KLANGKC", "LOGFIRE")
+
+# Build-infra vars that locate *artifacts the test must use* (the workspace
+# container image, the built plugin packages, the version stamp) — their
+# values are produced by devenv's ``klangk:build-workspace-image`` task, not
+# by any test, and every E2E server subprocess needs the real ones. These are
+# forwarded from the ambient env deliberately (not stripped) so the server
+# finds the built image/plugins. They are not test config — overriding one in
+# a ``clean_env(...)`` call still wins.
+_INFRA_VARS = (
+    "KLANGK_PLUGINS_DIR",
+    "KLANGK_IMAGE_NAME",
+    "KLANGK_VERSION_FILE",
+)
+
+
+def clean_env(**overrides: str) -> dict[str, str]:
+    """Return a hermetic env dict for a test subprocess.
+
+    Starts from ``os.environ`` with every config-affecting var stripped, then
+    applies ``overrides`` (the test's explicit KLANGK_* / LOGFIRE_* keys).
+    The baseline includes ``_KLANGK_DISABLE_NGINX=1`` and
+    ``KLANGK_AUTH_MODES=password`` (the E2E default — most suites exercise the
+    password auth flow); pass ``KLANGK_AUTH_MODES="none"`` in overrides to
+    opt into no-auth mode.
+
+    Tests should call::
+
+        env = clean_env(
+            KLANGK_PORT=port,
+            KLANGK_DATA_DIR=data_dir,
+            ...
+        )
+    """
+    env = {
+        k: v
+        for k, v in os.environ.items()
+        if not k.upper().startswith(_STRIP_PREFIXES)
+    }
+    # Forward the build-infra vars (image / plugins / version stamp) so the
+    # server subprocess finds the artifacts devenv built. See _INFRA_VARS.
+    for name in _INFRA_VARS:
+        val = os.environ.get(name)
+        if val is not None:
+            env[name] = val
+    # E2E baseline defaults.
+    env["_KLANGK_DISABLE_NGINX"] = "1"
+    env.setdefault("KLANGK_AUTH_MODES", "password")
+    env.update(overrides)
+    return env

--- a/src/backend/e2e-tests/conftest.py
+++ b/src/backend/e2e-tests/conftest.py
@@ -1,59 +1,10 @@
 """Shared fixtures for the backend E2E suite.
 
-These tests launch a real uvicorn server (subprocess) inheriting ``os.environ``.
-The production default for ``KLANGK_AUTH_MODES`` (unset, no OIDC) is ``none``
-(#1374), which disables password login/registration — but the E2E suite
-exercises the password auth flow almost exclusively (login, register, lockout,
-ACL via ``_auth_headers``). Pin the suite to ``password`` so the default change
-doesn't break it.
-
-Mirrors the unit-suite pin in ``src/backend/tests/conftest.py``. Per-test
-explicit env overrides still win: a test that sets ``"KLANGK_AUTH_MODES": "none"``
-in its server env dict (after the ``**os.environ`` spread) overrides this —
-see ``TestNginxAuthLocalAcl``.
+The E2E baseline defaults live in :mod:`_e2e_env` (:func:`clean_env`):
+``KLANGK_AUTH_MODES=password`` (most suites exercise the password auth flow)
+and ``_KLANGK_DISABLE_NGINX=1`` (bare-uvicorn launches; the lifespan's nginx
+would fight a dev nginx). Every server launch builds its env via
+``clean_env(...)`` — no ``os.environ`` spread, so stray vars can't leak
+(#1526). Tests that need ``none`` mode pass ``KLANGK_AUTH_MODES="none"`` in
+their ``clean_env()`` overrides.
 """
-
-import os
-
-import pytest
-
-
-@pytest.fixture(scope="session", autouse=True)
-def _e2e_disable_nginx():
-    """Suppress the lifespan's nginx watchdog across the E2E suite.
-
-    nginx ownership is unconditional in real runs, but these tests launch the
-    backend via bare ``uvicorn`` and (in dev) another nginx already holds
-    ``KLANGK_NGINX_PORT``; a second spawned by the lifespan would fight it for
-    the port (and on CI, loop forever). Sets the internal, non-user-facing
-    ``_KLANGK_DISABLE_NGINX`` kill switch — same as the unit-suite fixture.
-    """
-    old = os.environ.get("_KLANGK_DISABLE_NGINX")
-    os.environ["_KLANGK_DISABLE_NGINX"] = "1"
-    try:
-        yield
-    finally:
-        if old is None:
-            os.environ.pop("_KLANGK_DISABLE_NGINX", None)
-        else:
-            os.environ["_KLANGK_DISABLE_NGINX"] = old
-
-
-@pytest.fixture(scope="session", autouse=True)
-def _e2e_default_auth_mode():
-    """Pin E2E servers to ``password`` mode for the whole session.
-
-    Session-scoped (not function-scoped ``monkeypatch``) because the server
-    subprocess inherits ``os.environ`` at launch — the value must be set once,
-    before any server fixture starts, and persist for the run. Single-process
-    suite (``-p no:xdist``), so there's no per-worker concern.
-    """
-    old = os.environ.get("KLANGK_AUTH_MODES")
-    os.environ["KLANGK_AUTH_MODES"] = "password"
-    try:
-        yield
-    finally:
-        if old is None:
-            os.environ.pop("KLANGK_AUTH_MODES", None)
-        else:
-            os.environ["KLANGK_AUTH_MODES"] = old

--- a/src/backend/e2e-tests/test_agent_home_e2e.py
+++ b/src/backend/e2e-tests/test_agent_home_e2e.py
@@ -40,6 +40,7 @@ import pytest
 import websockets
 
 from klangk_backend.model import free_port
+from _e2e_env import clean_env
 
 # Default agent handle (see model/users.py: _DEFAULT_AGENT_HANDLE).  Not
 # imported from the backend to keep the e2e test decoupled from the
@@ -58,25 +59,26 @@ def server():
     start_workspace -> ensure_agent_home).
     """
     data_dir = tempfile.mkdtemp(prefix="klangk-agent-home-e2e-")
+    state_dir = tempfile.mkdtemp(prefix="klangk-agent-home-e2e-state-")
     port = str(free_port())
 
-    env = {
-        **os.environ,
-        "KLANGK_PORT": port,
-        "KLANGK_DATA_DIR": data_dir,
-        "KLANGK_JWT_SECRET": "agent-home-e2e-secret",
-        "KLANGK_PREVENT_INSECURE_JWT_SECRET": "",
-        "KLANGK_DEFAULT_USER": "test@example.com",
-        "KLANGK_DEFAULT_PASSWORD": "testpass",
-        "KLANGK_TEST_MODE": "1",
-        "KLANGK_IDLE_TIMEOUT_SECONDS": "300",
-        "KLANGK_PORT_RANGE_START": str(free_port()),
-        "KLANGK_ALLOW_AUTOSTART": "1",
-        "LOGFIRE_TOKEN": "",
-        "KLANGK_LLM_BASE_URL": "",
-        "KLANGK_LLM_API_KEY": "",
-        "KLANGK_LLM_MODEL": "",
-    }
+    env = clean_env(
+        KLANGK_PORT=port,
+        KLANGK_DATA_DIR=data_dir,
+        KLANGK_STATE_DIR=state_dir,
+        KLANGK_JWT_SECRET="agent-home-e2e-secret",
+        KLANGK_PREVENT_INSECURE_JWT_SECRET="",
+        KLANGK_DEFAULT_USER="test@example.com",
+        KLANGK_DEFAULT_PASSWORD="testpass",
+        KLANGK_TEST_MODE="1",
+        KLANGK_IDLE_TIMEOUT_SECONDS="300",
+        KLANGK_PORT_RANGE_START=str(free_port()),
+        KLANGK_ALLOW_AUTOSTART="1",
+        LOGFIRE_TOKEN="",
+        KLANGK_LLM_BASE_URL="",
+        KLANGK_LLM_API_KEY="",
+        KLANGK_LLM_MODEL="",
+    )
     proc = subprocess.Popen(
         [
             "python3",

--- a/src/backend/e2e-tests/test_api_e2e.py
+++ b/src/backend/e2e-tests/test_api_e2e.py
@@ -17,53 +17,24 @@ import httpx
 import pytest
 
 from klangk_backend.model import free_port
-
-# Env vars from .env that could change test behavior.
-_SANITIZED_VARS = [
-    "KLANGK_AUTH_MODES",
-    "KLANGK_OIDC_CONFIG",
-    "KLANGK_DISABLE_REGISTRATION",
-    "KLANGK_DISABLE_INVITES",
-    "KLANGK_LOGIN_LOCKOUT_FAILURES",
-    "KLANGK_MIN_PASSWORD_LENGTH",
-    "KLANGK_PREVENT_INSECURE_JWT_SECRET",
-]
-
-
-def _clean_env():
-    """Return os.environ with test-affecting vars removed, pinned to a known
-    baseline.
-
-    ``KLANGK_AUTH_MODES`` is stripped from the ambient env (above) and then
-    set explicitly to ``password`` here: the production default changed to
-    ``none`` (#1374), but these tests exercise the password auth flow
-    (login, register, lockout, ACL via ``admin_headers``). Stripping alone
-    used to yield ``password`` via the old unset default; that's no longer
-    true, so pin it explicitly. Tests that need a different mode set it in
-    their own env dict, which overrides this baseline (the spread order in
-    ``_start_server`` puts explicit keys after ``_clean_env()``).
-    """
-    env = dict(os.environ)
-    for var in _SANITIZED_VARS:
-        env.pop(var, None)
-    env["KLANGK_AUTH_MODES"] = "password"
-    return env
+from _e2e_env import clean_env
 
 
 def _start_server(data_dir, port):
     """Start a Klangk server and wait for it to be ready."""
-    env = {
-        **_clean_env(),
-        "KLANGK_PORT": port,
-        "KLANGK_DATA_DIR": data_dir,
-        "KLANGK_JWT_SECRET": "acl-e2e-test-secret",
-        "KLANGK_DEFAULT_USER": "admin@example.com",
-        "KLANGK_DEFAULT_PASSWORD": "adminpass",
-        "KLANGK_TEST_MODE": "1",
-        "KLANGK_IDLE_TIMEOUT_SECONDS": "300",
-        "KLANGK_PORT_RANGE_START": str(free_port()),
-        "LOGFIRE_TOKEN": "",
-    }
+    state_dir = tempfile.mkdtemp(prefix="klangk-acl-e2e-state-")
+    env = clean_env(
+        KLANGK_PORT=port,
+        KLANGK_DATA_DIR=data_dir,
+        KLANGK_STATE_DIR=state_dir,
+        KLANGK_JWT_SECRET="acl-e2e-test-secret",
+        KLANGK_DEFAULT_USER="admin@example.com",
+        KLANGK_DEFAULT_PASSWORD="adminpass",
+        KLANGK_TEST_MODE="1",
+        KLANGK_IDLE_TIMEOUT_SECONDS="300",
+        KLANGK_PORT_RANGE_START=str(free_port()),
+        LOGFIRE_TOKEN="",
+    )
     proc = subprocess.Popen(
         [
             "python3",
@@ -106,7 +77,7 @@ def _stop_server(proc, data_dir):
         ["klangk-instance-id"],
         capture_output=True,
         text=True,
-        env={**os.environ, "KLANGK_DATA_DIR": data_dir},
+        env=clean_env(KLANGK_DATA_DIR=data_dir, KLANGK_STATE_DIR=data_dir),
     ).stdout.strip()
     result = subprocess.run(
         [
@@ -1049,20 +1020,21 @@ class TestAutoStartWithServiceCommand:
     @staticmethod
     def autostart_server(request):
         data_dir = tempfile.mkdtemp(prefix="klangk-autostart-e2e-")
+        state_dir = tempfile.mkdtemp(prefix="klangk-autostart-e2e-state-")
         port = str(free_port())
-        env = {
-            **_clean_env(),
-            "KLANGK_PORT": port,
-            "KLANGK_DATA_DIR": data_dir,
-            "KLANGK_JWT_SECRET": "autostart-e2e-secret",
-            "KLANGK_DEFAULT_USER": "admin@example.com",
-            "KLANGK_DEFAULT_PASSWORD": "adminpass",
-            "KLANGK_TEST_MODE": "1",
-            "KLANGK_IDLE_TIMEOUT_SECONDS": "300",
-            "KLANGK_PORT_RANGE_START": str(free_port()),
-            "KLANGK_ALLOW_AUTOSTART": "1",
-            "LOGFIRE_TOKEN": "",
-        }
+        env = clean_env(
+            KLANGK_PORT=port,
+            KLANGK_DATA_DIR=data_dir,
+            KLANGK_STATE_DIR=state_dir,
+            KLANGK_JWT_SECRET="autostart-e2e-secret",
+            KLANGK_DEFAULT_USER="admin@example.com",
+            KLANGK_DEFAULT_PASSWORD="adminpass",
+            KLANGK_TEST_MODE="1",
+            KLANGK_IDLE_TIMEOUT_SECONDS="300",
+            KLANGK_PORT_RANGE_START=str(free_port()),
+            KLANGK_ALLOW_AUTOSTART="1",
+            LOGFIRE_TOKEN="",
+        )
         proc = subprocess.Popen(
             [
                 "python3",

--- a/src/backend/e2e-tests/test_event_fanout.py
+++ b/src/backend/e2e-tests/test_event_fanout.py
@@ -26,6 +26,7 @@ import pytest
 import websockets
 
 from klangk_backend.model import free_port
+from _e2e_env import clean_env
 
 
 @pytest.fixture(scope="module")
@@ -36,25 +37,25 @@ def server():
     fanout (container ready, exec output routing), not LLM interactions.
     """
     data_dir = tempfile.mkdtemp(prefix="klangk-fanout-e2e-")
+    state_dir = tempfile.mkdtemp(prefix="klangk-fanout-e2e-state-")
     port = str(free_port())
 
-    env = {
-        **os.environ,
-        "KLANGK_PORT": port,
-        "KLANGK_DATA_DIR": data_dir,
-        "KLANGK_JWT_SECRET": "fanout-e2e-secret",
-        "KLANGK_PREVENT_INSECURE_JWT_SECRET": "",
-        "KLANGK_DEFAULT_USER": "test@example.com",
-        "KLANGK_DEFAULT_PASSWORD": "testpass",
-        "KLANGK_TEST_MODE": "1",
-        "KLANGK_IDLE_TIMEOUT_SECONDS": "300",
-        "KLANGK_PORT_RANGE_START": str(free_port()),
-        "LOGFIRE_TOKEN": "",
-        # Clear LLM vars so .env values don't leak in
-        "KLANGK_LLM_BASE_URL": "",
-        "KLANGK_LLM_API_KEY": "",
-        "KLANGK_LLM_MODEL": "",
-    }
+    env = clean_env(
+        KLANGK_PORT=port,
+        KLANGK_DATA_DIR=data_dir,
+        KLANGK_STATE_DIR=state_dir,
+        KLANGK_JWT_SECRET="fanout-e2e-secret",
+        KLANGK_PREVENT_INSECURE_JWT_SECRET="",
+        KLANGK_DEFAULT_USER="test@example.com",
+        KLANGK_DEFAULT_PASSWORD="testpass",
+        KLANGK_TEST_MODE="1",
+        KLANGK_IDLE_TIMEOUT_SECONDS="300",
+        KLANGK_PORT_RANGE_START=str(free_port()),
+        LOGFIRE_TOKEN="",
+        KLANGK_LLM_BASE_URL="",
+        KLANGK_LLM_API_KEY="",
+        KLANGK_LLM_MODEL="",
+    )
     proc = subprocess.Popen(
         [
             "python3",

--- a/src/backend/e2e-tests/test_health_check_e2e.py
+++ b/src/backend/e2e-tests/test_health_check_e2e.py
@@ -27,33 +27,33 @@ import pytest
 import websockets
 
 from klangk_backend.model import free_port
+from _e2e_env import clean_env
 
 
 @pytest.fixture(scope="module")
 def server():
     """Start a real Klangk server with a fast health-check poll interval."""
     data_dir = tempfile.mkdtemp(prefix="klangk-health-e2e-")
+    state_dir = tempfile.mkdtemp(prefix="klangk-health-e2e-state-")
     port = str(free_port())
 
-    env = {
-        **os.environ,
-        "KLANGK_PORT": port,
-        "KLANGK_DATA_DIR": data_dir,
-        "KLANGK_JWT_SECRET": "health-e2e-secret",
-        "KLANGK_PREVENT_INSECURE_JWT_SECRET": "",
-        "KLANGK_DEFAULT_USER": "test@example.com",
-        "KLANGK_DEFAULT_PASSWORD": "testpass",
-        "KLANGK_TEST_MODE": "1",
-        "KLANGK_IDLE_TIMEOUT_SECONDS": "300",
-        "KLANGK_PORT_RANGE_START": str(free_port()),
-        # Poll every 2s so an unhealthy transition shows up quickly.
-        "KLANGK_HEALTH_CHECK_INTERVAL": "2",
-        "LOGFIRE_TOKEN": "",
-        # Clear LLM vars so .env values don't leak in.
-        "KLANGK_LLM_BASE_URL": "",
-        "KLANGK_LLM_API_KEY": "",
-        "KLANGK_LLM_MODEL": "",
-    }
+    env = clean_env(
+        KLANGK_PORT=port,
+        KLANGK_DATA_DIR=data_dir,
+        KLANGK_STATE_DIR=state_dir,
+        KLANGK_JWT_SECRET="health-e2e-secret",
+        KLANGK_PREVENT_INSECURE_JWT_SECRET="",
+        KLANGK_DEFAULT_USER="test@example.com",
+        KLANGK_DEFAULT_PASSWORD="testpass",
+        KLANGK_TEST_MODE="1",
+        KLANGK_IDLE_TIMEOUT_SECONDS="300",
+        KLANGK_PORT_RANGE_START=str(free_port()),
+        KLANGK_HEALTH_CHECK_INTERVAL="2",
+        LOGFIRE_TOKEN="",
+        KLANGK_LLM_BASE_URL="",
+        KLANGK_LLM_API_KEY="",
+        KLANGK_LLM_MODEL="",
+    )
     proc = subprocess.Popen(
         [
             "python3",

--- a/src/backend/e2e-tests/test_nginx_acl_e2e.py
+++ b/src/backend/e2e-tests/test_nginx_acl_e2e.py
@@ -19,6 +19,7 @@ import httpx
 import pytest
 
 from klangk_backend.model import free_port
+from _e2e_env import clean_env
 
 BACKEND_DIR = os.path.join(os.path.dirname(__file__), "..")
 
@@ -376,20 +377,19 @@ class TestNginxAclEnforcement:
         nginx_port = _find_free_port()
 
         # Start uvicorn.
-        backend_env = {
-            **os.environ,
-            "KLANGK_PORT": backend_port,
-            "KLANGK_DATA_DIR": data_dir,
-            "KLANGK_STATE_DIR": state_dir,
-            "KLANGK_JWT_SECRET": "nginx-acl-test-secret",
-            "KLANGK_PREVENT_INSECURE_JWT_SECRET": "",
-            "KLANGK_DEFAULT_USER": "test@example.com",
-            "KLANGK_DEFAULT_PASSWORD": "testpass",
-            "KLANGK_TEST_MODE": "1",
-            "KLANGK_IDLE_TIMEOUT_SECONDS": "300",
-            "KLANGK_PORT_RANGE_START": str(free_port()),
-            "LOGFIRE_TOKEN": "",
-        }
+        backend_env = clean_env(
+            KLANGK_PORT=backend_port,
+            KLANGK_DATA_DIR=data_dir,
+            KLANGK_STATE_DIR=state_dir,
+            KLANGK_JWT_SECRET="nginx-acl-test-secret",
+            KLANGK_PREVENT_INSECURE_JWT_SECRET="",
+            KLANGK_DEFAULT_USER="test@example.com",
+            KLANGK_DEFAULT_PASSWORD="testpass",
+            KLANGK_TEST_MODE="1",
+            KLANGK_IDLE_TIMEOUT_SECONDS="300",
+            KLANGK_PORT_RANGE_START=str(free_port()),
+            LOGFIRE_TOKEN="",
+        )
         backend_proc = subprocess.Popen(
             [
                 "python3",
@@ -553,20 +553,19 @@ class TestNginxDenyByDefault:
         nginx_port = _find_free_port()
 
         # Start uvicorn (loopback only; nginx reaches it via 127.0.0.1).
-        backend_env = {
-            **os.environ,
-            "KLANGK_PORT": backend_port,
-            "KLANGK_DATA_DIR": data_dir,
-            "KLANGK_STATE_DIR": state_dir,
-            "KLANGK_JWT_SECRET": "nginx-deny-test-secret",
-            "KLANGK_PREVENT_INSECURE_JWT_SECRET": "",
-            "KLANGK_DEFAULT_USER": "test@example.com",
-            "KLANGK_DEFAULT_PASSWORD": "testpass",
-            "KLANGK_TEST_MODE": "1",
-            "KLANGK_IDLE_TIMEOUT_SECONDS": "300",
-            "KLANGK_PORT_RANGE_START": str(free_port()),
-            "LOGFIRE_TOKEN": "",
-        }
+        backend_env = clean_env(
+            KLANGK_PORT=backend_port,
+            KLANGK_DATA_DIR=data_dir,
+            KLANGK_STATE_DIR=state_dir,
+            KLANGK_JWT_SECRET="nginx-deny-test-secret",
+            KLANGK_PREVENT_INSECURE_JWT_SECRET="",
+            KLANGK_DEFAULT_USER="test@example.com",
+            KLANGK_DEFAULT_PASSWORD="testpass",
+            KLANGK_TEST_MODE="1",
+            KLANGK_IDLE_TIMEOUT_SECONDS="300",
+            KLANGK_PORT_RANGE_START=str(free_port()),
+            LOGFIRE_TOKEN="",
+        )
         backend_proc = subprocess.Popen(
             [
                 "python3",
@@ -722,21 +721,20 @@ class TestNginxAuthLocalAcl:
 
         # Start uvicorn (loopback; nginx reaches it via 127.0.0.1).
         # KLANGK_AUTH_MODES=none so /auth/local actually mints a token.
-        backend_env = {
-            **os.environ,
-            "KLANGK_PORT": backend_port,
-            "KLANGK_DATA_DIR": data_dir,
-            "KLANGK_STATE_DIR": state_dir,
-            "KLANGK_JWT_SECRET": "nginx-auth-local-test-secret",
-            "KLANGK_PREVENT_INSECURE_JWT_SECRET": "",
-            "KLANGK_DEFAULT_USER": "test@example.com",
-            "KLANGK_DEFAULT_PASSWORD": "testpass",
-            "KLANGK_AUTH_MODES": "none",
-            "KLANGK_TEST_MODE": "1",
-            "KLANGK_IDLE_TIMEOUT_SECONDS": "300",
-            "KLANGK_PORT_RANGE_START": str(free_port()),
-            "LOGFIRE_TOKEN": "",
-        }
+        backend_env = clean_env(
+            KLANGK_PORT=backend_port,
+            KLANGK_DATA_DIR=data_dir,
+            KLANGK_STATE_DIR=state_dir,
+            KLANGK_JWT_SECRET="nginx-auth-local-test-secret",
+            KLANGK_PREVENT_INSECURE_JWT_SECRET="",
+            KLANGK_DEFAULT_USER="test@example.com",
+            KLANGK_DEFAULT_PASSWORD="testpass",
+            KLANGK_AUTH_MODES="none",
+            KLANGK_TEST_MODE="1",
+            KLANGK_IDLE_TIMEOUT_SECONDS="300",
+            KLANGK_PORT_RANGE_START=str(free_port()),
+            LOGFIRE_TOKEN="",
+        )
         backend_proc = subprocess.Popen(
             [
                 "python3",

--- a/src/backend/e2e-tests/test_nginx_lifecycle_e2e.py
+++ b/src/backend/e2e-tests/test_nginx_lifecycle_e2e.py
@@ -16,6 +16,7 @@ import httpx
 import pytest
 
 from klangk_backend.model import free_port
+from _e2e_env import clean_env
 
 BACKEND_DIR = os.path.join(os.path.dirname(__file__), "..")
 
@@ -54,23 +55,22 @@ def _start_klangkd():
 
     sock_path = os.path.join(data_dir, "klangk.sock")
 
-    env = {
-        **os.environ,
-        "KLANGK_LISTEN": sock_path,
-        "KLANGK_NGINX_PORT": nginx_port,
-        "KLANGK_STATE_DIR": data_dir,
-        "KLANGK_DATA_DIR": data_dir,
-        "KLANGK_JWT_SECRET": "nginx-lifecycle-test",
-        "KLANGK_PREVENT_INSECURE_JWT_SECRET": "",
-        "KLANGK_DEFAULT_USER": "test@example.com",
-        "KLANGK_DEFAULT_PASSWORD": "testpass",
-        "KLANGK_AUTH_MODES": "none",
-        "KLANGK_TEST_MODE": "1",
-        "KLANGK_IDLE_TIMEOUT_SECONDS": "300",
-        "KLANGK_PORT_RANGE_START": str(free_port()),
-        "_KLANGK_DISABLE_NGINX": "",
-        "LOGFIRE_TOKEN": "",
-    }
+    env = clean_env(
+        KLANGK_LISTEN=sock_path,
+        KLANGK_NGINX_PORT=nginx_port,
+        KLANGK_STATE_DIR=data_dir,
+        KLANGK_DATA_DIR=data_dir,
+        KLANGK_JWT_SECRET="nginx-lifecycle-test",
+        KLANGK_PREVENT_INSECURE_JWT_SECRET="",
+        KLANGK_DEFAULT_USER="test@example.com",
+        KLANGK_DEFAULT_PASSWORD="testpass",
+        KLANGK_AUTH_MODES="none",
+        KLANGK_TEST_MODE="1",
+        KLANGK_IDLE_TIMEOUT_SECONDS="300",
+        KLANGK_PORT_RANGE_START=str(free_port()),
+        _KLANGK_DISABLE_NGINX="",
+        LOGFIRE_TOKEN="",
+    )
 
     proc = subprocess.Popen(
         ["python3", "-m", "klangk_backend.klangkd", "--config=none"],

--- a/src/backend/e2e-tests/test_per_user_home.py
+++ b/src/backend/e2e-tests/test_per_user_home.py
@@ -22,30 +22,32 @@ import pytest
 import websockets
 
 from klangk_backend.model import free_port
+from _e2e_env import clean_env
 
 
 @pytest.fixture(scope="module")
 def server():
     """Start a real Klangk server for the test module."""
     data_dir = tempfile.mkdtemp(prefix="klangk-home-e2e-")
+    state_dir = tempfile.mkdtemp(prefix="klangk-home-e2e-state-")
     port = str(free_port())
 
-    env = {
-        **os.environ,
-        "KLANGK_PORT": port,
-        "KLANGK_DATA_DIR": data_dir,
-        "KLANGK_JWT_SECRET": "home-e2e-secret",
-        "KLANGK_PREVENT_INSECURE_JWT_SECRET": "",
-        "KLANGK_DEFAULT_USER": "test@example.com",
-        "KLANGK_DEFAULT_PASSWORD": "testpass",
-        "KLANGK_TEST_MODE": "1",
-        "KLANGK_IDLE_TIMEOUT_SECONDS": "300",
-        "KLANGK_PORT_RANGE_START": str(free_port()),
-        "LOGFIRE_TOKEN": "",
-        "KLANGK_LLM_BASE_URL": "",
-        "KLANGK_LLM_API_KEY": "",
-        "KLANGK_LLM_MODEL": "",
-    }
+    env = clean_env(
+        KLANGK_PORT=port,
+        KLANGK_DATA_DIR=data_dir,
+        KLANGK_STATE_DIR=state_dir,
+        KLANGK_JWT_SECRET="home-e2e-secret",
+        KLANGK_PREVENT_INSECURE_JWT_SECRET="",
+        KLANGK_DEFAULT_USER="test@example.com",
+        KLANGK_DEFAULT_PASSWORD="testpass",
+        KLANGK_TEST_MODE="1",
+        KLANGK_IDLE_TIMEOUT_SECONDS="300",
+        KLANGK_PORT_RANGE_START=str(free_port()),
+        LOGFIRE_TOKEN="",
+        KLANGK_LLM_BASE_URL="",
+        KLANGK_LLM_API_KEY="",
+        KLANGK_LLM_MODEL="",
+    )
     proc = subprocess.Popen(
         [
             "python3",

--- a/src/backend/e2e-tests/test_service_command_shared_e2e.py
+++ b/src/backend/e2e-tests/test_service_command_shared_e2e.py
@@ -36,30 +36,32 @@ import pytest
 import websockets
 
 from klangk_backend.model import free_port
+from _e2e_env import clean_env
 
 
 @pytest.fixture(scope="module")
 def server():
     """Start a real Klangk server for the test module."""
     data_dir = tempfile.mkdtemp(prefix="klangk-dcmd-shared-e2e-")
+    state_dir = tempfile.mkdtemp(prefix="klangk-dcmd-shared-e2e-state-")
     port = str(free_port())
 
-    env = {
-        **os.environ,
-        "KLANGK_PORT": port,
-        "KLANGK_DATA_DIR": data_dir,
-        "KLANGK_JWT_SECRET": "dcmd-shared-e2e-secret",
-        "KLANGK_PREVENT_INSECURE_JWT_SECRET": "",
-        "KLANGK_DEFAULT_USER": "test@example.com",
-        "KLANGK_DEFAULT_PASSWORD": "testpass",
-        "KLANGK_TEST_MODE": "1",
-        "KLANGK_IDLE_TIMEOUT_SECONDS": "0",
-        "KLANGK_PORT_RANGE_START": str(free_port()),
-        "LOGFIRE_TOKEN": "",
-        "KLANGK_LLM_BASE_URL": "",
-        "KLANGK_LLM_API_KEY": "",
-        "KLANGK_LLM_MODEL": "",
-    }
+    env = clean_env(
+        KLANGK_PORT=port,
+        KLANGK_DATA_DIR=data_dir,
+        KLANGK_STATE_DIR=state_dir,
+        KLANGK_JWT_SECRET="dcmd-shared-e2e-secret",
+        KLANGK_PREVENT_INSECURE_JWT_SECRET="",
+        KLANGK_DEFAULT_USER="test@example.com",
+        KLANGK_DEFAULT_PASSWORD="testpass",
+        KLANGK_TEST_MODE="1",
+        KLANGK_IDLE_TIMEOUT_SECONDS="0",
+        KLANGK_PORT_RANGE_START=str(free_port()),
+        LOGFIRE_TOKEN="",
+        KLANGK_LLM_BASE_URL="",
+        KLANGK_LLM_API_KEY="",
+        KLANGK_LLM_MODEL="",
+    )
     proc = subprocess.Popen(
         [
             "python3",

--- a/src/backend/e2e-tests/test_sighup_restart_e2e.py
+++ b/src/backend/e2e-tests/test_sighup_restart_e2e.py
@@ -33,35 +33,33 @@ import pytest
 import websockets
 
 from klangk_backend.model import free_port
+from _e2e_env import clean_env
 
 
 @pytest.fixture(scope="module")
 def server():
     """Start a real Klangk server with short idle + health intervals."""
     data_dir = tempfile.mkdtemp(prefix="klangk-sighup-e2e-")
+    state_dir = tempfile.mkdtemp(prefix="klangk-sighup-e2e-state-")
     port = str(free_port())
 
-    env = {
-        **os.environ,
-        "KLANGK_PORT": port,
-        "KLANGK_DATA_DIR": data_dir,
-        "KLANGK_JWT_SECRET": "sighup-e2e-secret",
-        "KLANGK_PREVENT_INSECURE_JWT_SECRET": "",
-        "KLANGK_DEFAULT_USER": "test@example.com",
-        "KLANGK_DEFAULT_PASSWORD": "testpass",
-        "KLANGK_TEST_MODE": "1",
-        # Short idle timeout so a workspace with no subscribers stops
-        # quickly; we mainly care that SIGHUP stops *all* of them.
-        "KLANGK_IDLE_TIMEOUT_SECONDS": "300",
-        "KLANGK_PORT_RANGE_START": str(free_port()),
-        # Allow auto-start so the post-SIGHUP restart brings workspaces
-        # back (acceptance criterion #4).
-        "KLANGK_ALLOW_AUTOSTART": "1",
-        "LOGFIRE_TOKEN": "",
-        "KLANGK_LLM_BASE_URL": "",
-        "KLANGK_LLM_API_KEY": "",
-        "KLANGK_LLM_MODEL": "",
-    }
+    env = clean_env(
+        KLANGK_PORT=port,
+        KLANGK_DATA_DIR=data_dir,
+        KLANGK_STATE_DIR=state_dir,
+        KLANGK_JWT_SECRET="sighup-e2e-secret",
+        KLANGK_PREVENT_INSECURE_JWT_SECRET="",
+        KLANGK_DEFAULT_USER="test@example.com",
+        KLANGK_DEFAULT_PASSWORD="testpass",
+        KLANGK_TEST_MODE="1",
+        KLANGK_IDLE_TIMEOUT_SECONDS="300",
+        KLANGK_PORT_RANGE_START=str(free_port()),
+        KLANGK_ALLOW_AUTOSTART="1",
+        LOGFIRE_TOKEN="",
+        KLANGK_LLM_BASE_URL="",
+        KLANGK_LLM_API_KEY="",
+        KLANGK_LLM_MODEL="",
+    )
     proc = subprocess.Popen(
         [
             "python3",

--- a/src/cli/e2e-tests/conftest.py
+++ b/src/cli/e2e-tests/conftest.py
@@ -1,56 +1,6 @@
 """Shared fixtures for the CLI E2E suite.
 
-These tests launch a real uvicorn server (``_start_server``) inheriting
-``os.environ``, then drive ``klangkc`` against it. The production default for
-``KLANGK_AUTH_MODES`` (unset, no OIDC) is ``none`` (#1374), which disables
-password login — but this suite logs in with a password (``testpass``) and
-exercises the full password auth flow. Pin the suite to ``password`` so the
-default change doesn't break it.
-
-Mirrors the unit-suite pin in ``src/backend/tests/conftest.py`` and the
-backend E2E pin in ``src/backend/e2e-tests/conftest.py``. Per-test explicit env
-overrides (``extra_env={"KLANGK_AUTH_MODES": ...}``) still win, since
-``_start_server`` spreads ``**os.environ`` before ``extra_env``.
+The E2E baseline defaults (``KLANGK_AUTH_MODES=password``, ``_KLANGK_DISABLE_NGINX=1``)
+live in :mod:`_e2e_env` (:func:`clean_env`), imported by each suite's
+``_start_server``. No ``os.environ`` spread — stray vars can't leak (#1526).
 """
-
-import os
-
-import pytest
-
-
-@pytest.fixture(scope="session", autouse=True)
-def _e2e_disable_nginx():
-    """Suppress the lifespan's nginx watchdog across the CLI E2E suite.
-
-    Mirrors the backend E2E fixture: these tests launch bare ``uvicorn`` and
-    don't want the lifespan spawning nginx. Sets the internal, non-user-facing
-    ``_KLANGK_DISABLE_NGINX`` kill switch.
-    """
-    old = os.environ.get("_KLANGK_DISABLE_NGINX")
-    os.environ["_KLANGK_DISABLE_NGINX"] = "1"
-    try:
-        yield
-    finally:
-        if old is None:
-            os.environ.pop("_KLANGK_DISABLE_NGINX", None)
-        else:
-            os.environ["_KLANGK_DISABLE_NGINX"] = old
-
-
-@pytest.fixture(scope="session", autouse=True)
-def _e2e_default_auth_mode():
-    """Pin E2E servers to ``password`` mode for the whole session.
-
-    Session-scoped (not function-scoped ``monkeypatch``) because the server
-    subprocess inherits ``os.environ`` at launch. Single-process suite
-    (``-p no:xdist``), so no per-worker concern.
-    """
-    old = os.environ.get("KLANGK_AUTH_MODES")
-    os.environ["KLANGK_AUTH_MODES"] = "password"
-    try:
-        yield
-    finally:
-        if old is None:
-            os.environ.pop("KLANGK_AUTH_MODES", None)
-        else:
-            os.environ["KLANGK_AUTH_MODES"] = old

--- a/src/cli/e2e-tests/test_cli_e2e.py
+++ b/src/cli/e2e-tests/test_cli_e2e.py
@@ -19,6 +19,15 @@ from pathlib import Path
 import pytest
 
 from klangk_backend.model import free_port
+import sys
+
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(__file__), "..", "..", "backend", "e2e-tests"
+    ),
+)
+from _e2e_env import clean_env
 
 logger = logging.getLogger(__name__)
 
@@ -42,20 +51,21 @@ def _start_server(data_dir, port, extra_env=None):
     """
     import httpx
 
-    env = {
-        **os.environ,
-        "KLANGK_PORT": port,
-        "KLANGK_DATA_DIR": data_dir,
-        "KLANGK_JWT_SECRET": "cli-e2e-test-secret",
-        "KLANGK_PREVENT_INSECURE_JWT_SECRET": "",
-        "KLANGK_DEFAULT_USER": "test@example.com",
-        "KLANGK_DEFAULT_PASSWORD": "testpass",
-        "KLANGK_TEST_MODE": "1",
-        "KLANGK_IDLE_TIMEOUT_SECONDS": "300",
-        "KLANGK_PORT_RANGE_START": str(free_port()),
-        "LOGFIRE_TOKEN": "",
+    state_dir = tempfile.mkdtemp(prefix="klangk-cli-e2e-state-")
+    env = clean_env(
+        KLANGK_PORT=port,
+        KLANGK_DATA_DIR=data_dir,
+        KLANGK_STATE_DIR=state_dir,
+        KLANGK_JWT_SECRET="cli-e2e-test-secret",
+        KLANGK_PREVENT_INSECURE_JWT_SECRET="",
+        KLANGK_DEFAULT_USER="test@example.com",
+        KLANGK_DEFAULT_PASSWORD="testpass",
+        KLANGK_TEST_MODE="1",
+        KLANGK_IDLE_TIMEOUT_SECONDS="300",
+        KLANGK_PORT_RANGE_START=str(free_port()),
+        LOGFIRE_TOKEN="",
         **(extra_env or {}),
-    }
+    )
     # Write server output to a temp file instead of PIPE.  With PIPE,
     # the OS buffer (64 KB) fills up when the server emits enough log
     # lines, deadlocking the event loop — the root cause of #364.
@@ -123,7 +133,7 @@ def _stop_server(proc, data_dir):
         ["klangk-instance-id"],
         capture_output=True,
         text=True,
-        env={**os.environ, "KLANGK_DATA_DIR": data_dir},
+        env=clean_env(KLANGK_DATA_DIR=data_dir),
     ).stdout.strip()
     if instance_id:
         result = subprocess.run(
@@ -165,7 +175,7 @@ def server():
 def cli_config(server, tmp_path_factory):
     """Create a CLI config pointing at the test server."""
     config_dir = tmp_path_factory.mktemp("klangk-cli-config")
-    env = {**os.environ, "HOME": str(config_dir)}
+    env = clean_env(HOME=str(config_dir))
     # The CLI reads from ~/.config/klangk/cli.yaml
     klangk_config_dir = config_dir / ".config" / "klangk"
     klangk_config_dir.mkdir(parents=True)
@@ -719,7 +729,7 @@ class TestAutoStart:
             extra_env={"KLANGK_ALLOW_AUTOSTART": "1"},
         )
         config_dir = tmp_path_factory.mktemp("klangk-autostart-config")
-        env = {**os.environ, "HOME": str(config_dir)}
+        env = clean_env(HOME=str(config_dir))
         klangk_config_dir = config_dir / ".config" / "klangk"
         klangk_config_dir.mkdir(parents=True)
         _run(
@@ -837,7 +847,7 @@ class TestSandboxAutoStartServiceCommand:
             extra_env={"KLANGK_ALLOW_AUTOSTART": "1"},
         )
         config_dir = tmp_path_factory.mktemp("klangk-sandbox-defcmd-config")
-        env = {**os.environ, "HOME": str(config_dir)}
+        env = clean_env(HOME=str(config_dir))
         klangk_config_dir = config_dir / ".config" / "klangk"
         klangk_config_dir.mkdir(parents=True)
         _run(
@@ -1153,7 +1163,7 @@ class TestAuthError:
         config_dir.mkdir()
         klangk_config = config_dir / ".config" / "klangk"
         klangk_config.mkdir(parents=True)
-        env = {**os.environ, "HOME": str(config_dir)}
+        env = clean_env(HOME=str(config_dir))
         result = _run(
             ["klangkc", "ls"],
             env=env,
@@ -1507,7 +1517,7 @@ class TestAllowedMountRoots:
             extra_env={"KLANGK_ALLOWED_MOUNT_ROOTS": "/tmp,/home"},
         )
         config_dir = tmp_path_factory.mktemp("klangk-mount-roots-config")
-        env = {**os.environ, "HOME": str(config_dir)}
+        env = clean_env(HOME=str(config_dir))
         klangk_config_dir = config_dir / ".config" / "klangk"
         klangk_config_dir.mkdir(parents=True)
         _run(
@@ -1590,7 +1600,7 @@ class TestVolumeUserIsolation:
             ("_env_b", "user2@example.com", "testpass2"),
         ]:
             config_dir = tmp_path_factory.mktemp(f"klangk-vol-iso-{attr}")
-            env = {**os.environ, "HOME": str(config_dir)}
+            env = clean_env(HOME=str(config_dir))
             (config_dir / ".config" / "klangk").mkdir(parents=True)
             _run(
                 [
@@ -1726,7 +1736,7 @@ class TestTerminalSharing:
         data_dir = tempfile.mkdtemp(prefix="klangk-terminal-sharing-")
         proc, base_url = _start_server(data_dir, str(free_port()))
         config_dir = tmp_path_factory.mktemp("klangk-terminal-sharing-config")
-        env = {**os.environ, "HOME": str(config_dir)}
+        env = clean_env(HOME=str(config_dir))
         (config_dir / ".config" / "klangk").mkdir(parents=True)
         _run(
             [
@@ -1886,7 +1896,7 @@ class TestWorkspaceSharing:
         )
 
         config_dir = tmp_path_factory.mktemp("klangk-ws-share")
-        env = {**os.environ, "HOME": str(config_dir)}
+        env = clean_env(HOME=str(config_dir))
         (config_dir / ".config" / "klangk").mkdir(parents=True)
         _run(
             [
@@ -2026,7 +2036,7 @@ def short_token_server():
 def short_token_cli_config(short_token_server, tmp_path_factory):
     """Create a CLI config pointing at the short-token server."""
     config_dir = tmp_path_factory.mktemp("klangk-refresh-config")
-    env = {**os.environ, "HOME": str(config_dir)}
+    env = clean_env(HOME=str(config_dir))
     klangk_config_dir = config_dir / ".config" / "klangk"
     klangk_config_dir.mkdir(parents=True)
     return {

--- a/src/cli/e2e-tests/test_monitor_e2e.py
+++ b/src/cli/e2e-tests/test_monitor_e2e.py
@@ -37,6 +37,15 @@ import pytest
 import websockets
 
 from klangk_backend.model import free_port
+import sys
+
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(__file__), "..", "..", "backend", "e2e-tests"
+    ),
+)
+from _e2e_env import clean_env
 
 
 # --- server / auth / cli-config fixtures (self-contained, per repo convention) ---
@@ -50,24 +59,24 @@ def _start_server(data_dir, port, health_interval="2"):
     output to a temp file (PIPE's 64 KB OS buffer can deadlock the event
     loop on chatty servers — #364).
     """
-    env = {
-        **os.environ,
-        "KLANGK_PORT": port,
-        "KLANGK_DATA_DIR": data_dir,
-        "KLANGK_JWT_SECRET": "monitor-e2e-secret",
-        "KLANGK_PREVENT_INSECURE_JWT_SECRET": "",
-        "KLANGK_DEFAULT_USER": "test@example.com",
-        "KLANGK_DEFAULT_PASSWORD": "testpass",
-        "KLANGK_TEST_MODE": "1",
-        "KLANGK_IDLE_TIMEOUT_SECONDS": "300",
-        "KLANGK_PORT_RANGE_START": str(free_port()),
-        # Poll every 2s so transitions show up in the monitor quickly.
-        "KLANGK_HEALTH_CHECK_INTERVAL": health_interval,
-        "LOGFIRE_TOKEN": "",
-        "KLANGK_LLM_BASE_URL": "",
-        "KLANGK_LLM_API_KEY": "",
-        "KLANGK_LLM_MODEL": "",
-    }
+    state_dir = tempfile.mkdtemp(prefix="klangk-monitor-e2e-state-")
+    env = clean_env(
+        KLANGK_PORT=port,
+        KLANGK_DATA_DIR=data_dir,
+        KLANGK_STATE_DIR=state_dir,
+        KLANGK_JWT_SECRET="monitor-e2e-secret",
+        KLANGK_PREVENT_INSECURE_JWT_SECRET="",
+        KLANGK_DEFAULT_USER="test@example.com",
+        KLANGK_DEFAULT_PASSWORD="testpass",
+        KLANGK_TEST_MODE="1",
+        KLANGK_IDLE_TIMEOUT_SECONDS="300",
+        KLANGK_PORT_RANGE_START=str(free_port()),
+        KLANGK_HEALTH_CHECK_INTERVAL=health_interval,
+        LOGFIRE_TOKEN="",
+        KLANGK_LLM_BASE_URL="",
+        KLANGK_LLM_API_KEY="",
+        KLANGK_LLM_MODEL="",
+    )
     log_path = os.path.join(data_dir, "server.log")
     log_file = open(log_path, "w")  # noqa: SIM115
     proc = subprocess.Popen(
@@ -132,7 +141,7 @@ def _stop_server(proc, data_dir):
         ["klangk-instance-id"],
         capture_output=True,
         text=True,
-        env={**os.environ, "KLANGK_DATA_DIR": data_dir},
+        env=clean_env(KLANGK_DATA_DIR=data_dir),
     ).stdout.strip()
     if instance_id:
         result = subprocess.run(
@@ -187,7 +196,7 @@ def cli_env(server, tmp_path_factory):
     is all the subprocess needs to connect.
     """
     config_dir = tmp_path_factory.mktemp("klangk-monitor-cli")
-    env = {**os.environ, "HOME": str(config_dir)}
+    env = clean_env(HOME=str(config_dir))
     result = subprocess.run(
         [
             "klangkc",

--- a/src/cli/e2e-tests/test_terminal_windows_e2e.py
+++ b/src/cli/e2e-tests/test_terminal_windows_e2e.py
@@ -26,6 +26,15 @@ import pytest
 import websockets
 
 from klangk_backend.model import free_port
+import sys
+
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(__file__), "..", "..", "backend", "e2e-tests"
+    ),
+)
+from _e2e_env import clean_env
 
 logger = logging.getLogger(__name__)
 
@@ -45,19 +54,20 @@ def _run(args, timeout=120, input=None, **kwargs):
 
 
 def _start_server(data_dir):
-    env = {
-        **os.environ,
-        "KLANGK_PORT": PORT,
-        "KLANGK_DATA_DIR": data_dir,
-        "KLANGK_JWT_SECRET": "tw-e2e-secret",
-        "KLANGK_PREVENT_INSECURE_JWT_SECRET": "",
-        "KLANGK_DEFAULT_USER": "test@example.com",
-        "KLANGK_DEFAULT_PASSWORD": "testpass",
-        "KLANGK_TEST_MODE": "1",
-        "KLANGK_IDLE_TIMEOUT_SECONDS": "300",
-        "KLANGK_PORT_RANGE_START": str(free_port()),
-        "LOGFIRE_TOKEN": "",
-    }
+    state_dir = tempfile.mkdtemp(prefix="klangk-tw-e2e-state-")
+    env = clean_env(
+        KLANGK_PORT=PORT,
+        KLANGK_DATA_DIR=data_dir,
+        KLANGK_STATE_DIR=state_dir,
+        KLANGK_JWT_SECRET="tw-e2e-secret",
+        KLANGK_PREVENT_INSECURE_JWT_SECRET="",
+        KLANGK_DEFAULT_USER="test@example.com",
+        KLANGK_DEFAULT_PASSWORD="testpass",
+        KLANGK_TEST_MODE="1",
+        KLANGK_IDLE_TIMEOUT_SECONDS="300",
+        KLANGK_PORT_RANGE_START=str(free_port()),
+        LOGFIRE_TOKEN="",
+    )
     log_path = os.path.join(data_dir, "server.log")
     log_file = open(log_path, "w")  # noqa: SIM115
     proc = subprocess.Popen(
@@ -121,7 +131,7 @@ def _stop_server(proc, data_dir):
         ["klangk-instance-id"],
         capture_output=True,
         text=True,
-        env={**os.environ, "KLANGK_DATA_DIR": data_dir},
+        env=clean_env(KLANGK_DATA_DIR=data_dir),
     ).stdout.strip()
     if instance_id:
         result = subprocess.run(
@@ -386,7 +396,7 @@ class TestTerminalWindows:
         data_dir = tempfile.mkdtemp(prefix="klangk-tw-e2e-")
         proc, base_url, server_env = _start_server(data_dir)
         config_dir = tmp_path_factory.mktemp("klangk-tw-config")
-        env = {**os.environ, "HOME": str(config_dir)}
+        env = clean_env(HOME=str(config_dir))
         (config_dir / ".config" / "klangk").mkdir(parents=True)
         _login(base_url, env)
         token = _get_token(base_url)

--- a/src/frontend/e2e-tests/devenv.lock
+++ b/src/frontend/e2e-tests/devenv.lock
@@ -1,0 +1,65 @@
+{
+  "nodes": {
+    "devenv": {
+      "locked": {
+        "dir": "src/modules",
+        "lastModified": 1783943325,
+        "narHash": "sha256-Bq+YOjx54mT0hH0qWlQ+96dKUuGEhkP+ZsMVxMOPcXA=",
+        "owner": "cachix",
+        "repo": "devenv",
+        "rev": "06ee813b2f5a8fc1838cff9cfb6bd4f0466fc925",
+        "type": "github"
+      },
+      "original": {
+        "dir": "src/modules",
+        "owner": "cachix",
+        "repo": "devenv",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "inputs": {
+        "nixpkgs-src": "nixpkgs-src"
+      },
+      "locked": {
+        "lastModified": 1783345554,
+        "narHash": "sha256-LZhOm4kqjHUnwP4CNHpaqqEVcumGNd1PvOEOad8LkS0=",
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "6004ea8c229fe9d41b21c6f4c76bf6c2e10771dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1783279667,
+        "narHash": "sha256-/NAkDSsve+GNM0Bt6tleJdCGfsTlK89nPjkVOzZMo0s=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f205b5574fd0cb7da5b702a2da51507b7f4fdd1b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devenv": "devenv",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/src/frontend/e2e-tests/e2e-env.ts
+++ b/src/frontend/e2e-tests/e2e-env.ts
@@ -1,0 +1,42 @@
+/**
+ * Hermetic env helper for E2E test suites (#1526).
+ *
+ * Mirrors `src/backend/e2e-tests/_e2e_env.py`. Strips every config-affecting
+ * prefix (KLANGK, _KLANGK, KLANGKC, LOGFIRE) from the ambient env so stray
+ * vars can't leak into a test subprocess, then applies E2E baseline defaults
+ * and the caller's overrides.
+ */
+
+const STRIP_PREFIXES = ["KLANGK", "_KLANGK", "KLANGKC", "LOGFIRE"];
+
+// Build-infra vars that locate artifacts the test must use (the workspace
+// container image, built plugins, version stamp) — produced by devenv's
+// klangk:build-workspace-image task, not by any test. Forwarded deliberately
+// so the server finds the built image/plugins.
+const INFRA_VARS = [
+  "KLANGK_PLUGINS_DIR",
+  "KLANGK_IMAGE_NAME",
+  "KLANGK_VERSION_FILE",
+];
+
+export function cleanEnv(
+  overrides: Record<string, string> = {},
+): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value === undefined) continue;
+    const upper = key.toUpperCase();
+    if (STRIP_PREFIXES.some((p) => upper.startsWith(p))) continue;
+    env[key] = value;
+  }
+  // Forward build-infra vars (image / plugins / version stamp).
+  for (const name of INFRA_VARS) {
+    const val = process.env[name];
+    if (val !== undefined) env[name] = val;
+  }
+  // E2E baseline defaults.
+  env._KLANGK_DISABLE_NGINX = "1";
+  if (!env.KLANGK_AUTH_MODES) env.KLANGK_AUTH_MODES = "password";
+  Object.assign(env, overrides);
+  return env;
+}

--- a/src/frontend/e2e-tests/e2e/klangk.spec.ts
+++ b/src/frontend/e2e-tests/e2e/klangk.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { cleanEnv } from "../e2e-env";
 import {
   API_BASE,
   TEST_PASSWORD,
@@ -576,6 +577,8 @@ test.describe("Klangk E2E", () => {
         const projectRoot = join(__dirname, "..", "..", "..", "..");
         const backendPort = process.env.KLANGK_E2E_PORT || "18997";
         const dataDir = process.env.KLANGK_E2E_DATA_DIR || "/tmp/klangk-e2e";
+        const stateDir =
+          process.env.KLANGK_E2E_STATE_DIR || "/tmp/klangk-e2e-state";
         const backendProcess = spawnProc(
           "python3",
           [
@@ -589,10 +592,10 @@ test.describe("Klangk E2E", () => {
             cwd: join(projectRoot, "src", "backend"),
             detached: true,
             stdio: ["ignore", "pipe", "pipe"],
-            env: {
-              ...process.env,
+            env: cleanEnv({
               KLANGK_PORT: backendPort,
               KLANGK_DATA_DIR: dataDir,
+              KLANGK_STATE_DIR: stateDir,
               KLANGK_JWT_SECRET: "e2e-test-secret",
               KLANGK_DEFAULT_USER: "admin@example.com",
               KLANGK_DEFAULT_PASSWORD: "admin",
@@ -606,7 +609,7 @@ test.describe("Klangk E2E", () => {
               KLANGK_OIDC_LOGIN_HOOK: "",
               KLANGK_DISABLE_REGISTRATION: "",
               KLANGK_DISABLE_INVITES: "",
-            },
+            }),
           },
         );
         restartedPid = backendProcess.pid ?? null;

--- a/src/frontend/e2e-tests/e2e/token-expiry.spec.ts
+++ b/src/frontend/e2e-tests/e2e/token-expiry.spec.ts
@@ -5,6 +5,7 @@ import jwt from "jsonwebtoken";
 import { tmpdir } from "os";
 import { join } from "path";
 import { API_BASE, registerUser } from "./helpers";
+import { cleanEnv } from "../e2e-env";
 
 const JWT_SECRET = "e2e-test-secret";
 
@@ -88,7 +89,7 @@ test.describe("Token expiry", () => {
     // Run klangkc shell — it should fail with a clear error
     try {
       execSync(`klangkc shell "${workspace.name}"`, {
-        env: { ...process.env, HOME: tmpHome },
+        env: cleanEnv({ HOME: tmpHome }),
         encoding: "utf-8",
         timeout: 15_000,
       });

--- a/src/frontend/e2e-tests/global-setup.ts
+++ b/src/frontend/e2e-tests/global-setup.ts
@@ -3,6 +3,8 @@ import { createWriteStream, mkdirSync, mkdtempSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
+import { cleanEnv } from "./e2e-env";
+
 async function globalSetup() {
   // When KLANGK_TEST_URL is set, skip server startup — tests run against
   // an already-running instance (e.g. the host container).
@@ -27,6 +29,8 @@ async function globalSetup() {
 
   const dataDir = mkdtempSync(join(tmpdir(), "klangk-e2e-"));
   process.env.KLANGK_E2E_DATA_DIR = dataDir;
+  const stateDir = mkdtempSync(join(tmpdir(), "klangk-e2e-state-"));
+  process.env.KLANGK_E2E_STATE_DIR = stateDir;
 
   // Create a branding dir so setup_static_files mounts /branding.
   const customizeDir = join(dataDir, "customize");
@@ -93,11 +97,10 @@ async function globalSetup() {
     mkdirSync(nginxState, { recursive: true });
     const confPath = join(nginxState, "nginx.conf");
 
-    const renderEnv = {
-      ...process.env,
+    const renderEnv = cleanEnv({
       KLANGK_NGINX_PORT: nginxPort,
       KLANGK_PORT: backendPort,
-    };
+    });
     execSync(
       `python -c "from klangk_backend.nginx import NginxRenderer, tcp_upstream; ` +
         `from klangk_backend.settings import KlangkSettings; import types, os; ` +
@@ -139,14 +142,12 @@ async function globalSetup() {
       cwd: join(projectRoot, "src", "backend"),
       detached: true,
       stdio: ["ignore", "pipe", "pipe"],
-      env: {
-        ...process.env,
-        // Bare uvicorn on TCP; the lifespan's nginx expects a UDS, so
-        // suppress it and let global-setup manage nginx separately (#1427).
+      env: cleanEnv({
         _KLANGK_DISABLE_NGINX: "1",
         KLANGK_PORT: backendPort,
         KLANGK_NGINX_PORT: nginxPort,
         KLANGK_DATA_DIR: dataDir,
+        KLANGK_STATE_DIR: stateDir,
         KLANGK_CUSTOMIZE_DIR: join(dataDir, "customize"),
         KLANGK_LOGIN_LOCKOUT_FAILURES: "5",
         KLANGK_JWT_SECRET: "e2e-test-secret",
@@ -165,7 +166,7 @@ async function globalSetup() {
         KLANGK_OIDC_LOGIN_HOOK: "", // No OIDC login hook in E2E tests
         KLANGK_DISABLE_REGISTRATION: "", // Allow registration in E2E tests
         KLANGK_DISABLE_INVITES: "", // Allow invitations in E2E tests
-      },
+      }),
     },
   );
 


### PR DESCRIPTION
Closes #1526.

## What

All E2E suites (backend, CLI, frontend) now build subprocess envs via a shared `clean_env()` helper that strips every config-affecting var from the ambient env before applying the test's explicit overrides. No more `{**os.environ, ...}` / `{...process.env, ...}` spreads — a stray `KLANGK_*` var in the CI runner's env (or leaked by a prior test) can no longer silently change results.

### The helper

**`src/backend/e2e-tests/_e2e_env.py`** (`clean_env(**overrides)`) + **`src/frontend/e2e-tests/e2e-env.ts`** (`cleanEnv(overrides)`):
- Starts from `os.environ` / `process.env`.
- Strips every var matching (case-insensitive prefix): `KLANGK`, `_KLANGK`, `KLANGKC`, `LOGFIRE`.
- Applies E2E baseline defaults: `_KLANGK_DISABLE_NGINX=1`, `KLANGK_AUTH_MODES=password`.
- Applies the caller's explicit overrides (the test's `KLANGK_PORT`, `KLANGK_DATA_DIR`, etc.).

OS-essential vars (`PATH`, `HOME`, Nix-specific `LOCALE_ARCHIVE` / `NIX_LD` / etc.) are preserved so the subprocess can run.

### Conversions

| Suite | Was | Now |
|---|---|---|
| `test_api_e2e.py` | `_clean_env()` (narrow 7-var allowlist) + `{**_clean_env(), ...}` | `clean_env(...)` |
| `test_nginx_acl_e2e.py` (3 server launches) | `{**os.environ, ...}` | `clean_env(...)` |
| `test_sighup_restart_e2e.py`, `test_nginx_lifecycle_e2e.py`, `test_service_command_shared_e2e.py`, `test_event_fanout.py`, `test_per_user_home.py`, `test_health_check_e2e.py`, `test_agent_home_e2e.py` | `{**os.environ, ...}` | `clean_env(...)` |
| `test_cli_e2e.py`, `test_monitor_e2e.py`, `test_terminal_windows_e2e.py` | `{**os.environ, ...}` (server + CLI launches) | `clean_env(...)` |
| `frontend/global-setup.ts`, `frontend/e2e/klangk.spec.ts`, `frontend/e2e/token-expiry.spec.ts` | `{...process.env, ...}` | `cleanEnv({...})` |

### conftest simplification
The backend + CLI e2e `conftest.py` session-scoped fixtures (`_e2e_disable_nginx`, `_e2e_default_auth_mode`) mutated `os.environ` to pin auth mode / disable nginx. Both defaults moved into `clean_env()` — the fixtures are deleted, the in-process `os.environ` mutation is gone. Both conftests are now docstring-only.

### Left alone (correctly)
- `helpers.ts` `podmanEnv()` — strips `LD_LIBRARY_PATH` for podman subprocesses; not klangk config.
- `global-teardown.ts` / `demo-helpers.ts` — podman/demo, not config-affecting.

## Acceptance (from #1526)
- [x] Shared `clean_env()` / `cleanEnv()` helper used by every E2E suite that launches a subprocess.
- [x] No `{**os.environ, ...}` / `{...process.env, ...}` spread in E2E launch sites (only `podmanEnv` / demo helpers remain, which are not config-affecting).
- [x] Every `KLANGK_*` settings field is stripped from the baseline env by prefix (tests opt in via overrides).
- [x] No remaining `os.environ[k] = v` in e2e test code (the conftest mutations are deleted).
- [x] Backend unit suite green (2379 passed, 100% coverage). E2E suites will run in CI.

## Why strip-by-prefix, not allowlist
The old `_SANITIZED_VARS` (7 named vars) was the bug — any `KLANGK_*` var *not* on that list (`KLANGK_DNS_SERVERS`, `KLANGK_LLM_BASE_URL`, `KLANGK_TRUST_OUTER_PROXY`, ...) leaked straight through. Prefix-stripping catches all of them.
