### PR TITLE
Tests: construct KlangkSettings(env={...}) directly, stop monkeypatching os.environ (#1457)

### DIFF
--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -12,6 +12,8 @@ import pytest
 
 from klangk_backend.settings import KlangkSettings
 
+from _helpers import make_settings
+
 # Use fast bcrypt rounds (4 instead of default 12) for all tests.
 _original_gensalt = bcrypt.gensalt
 
@@ -37,24 +39,6 @@ def _disable_nginx(monkeypatch):
     Sets the internal, non-user-facing ``_KLANGK_DISABLE_NGINX`` kill switch.
     """
     monkeypatch.setenv("_KLANGK_DISABLE_NGINX", "1")
-
-
-@pytest.fixture(autouse=True)
-def _default_auth_mode(monkeypatch):
-    """Pin the test suite to ``password`` mode.
-
-    The production default for ``KLANGK_AUTH_MODES`` (when unset and no OIDC
-    is configured) is ``none`` — see ``oidc.auth_modes``. Most backend tests
-    exercise the authenticated API via ``_auth_headers`` (HTTP login), which
-    the ``password`` gate admits; pinning the suite here keeps that working
-    regardless of how the production default evolves, so a default change
-    doesn't silently flip ~190 login-flow tests.
-
-    Tests that care about a *specific* mode set it themselves (their
-    ``setenv``/``delenv`` overrides this). ``delenv`` is the way to opt into
-    the real production default within a test.
-    """
-    monkeypatch.setenv("KLANGK_AUTH_MODES", "password")
 
 
 @pytest.fixture(autouse=True)
@@ -200,14 +184,20 @@ def app_state(temp_data_dir):
     """
     import types
 
-    from klangk_backend.settings import KlangkSettings
     from klangk_backend.auth import Auth
     from klangk_backend.container import ContainerRegistry
     from klangk_backend.emailsvc import EmailService
     from klangk_backend.util import Util
     from klangk_backend.workspaces import Workspaces
 
-    settings = KlangkSettings(os.environ)
+    settings = make_settings(
+        {
+            "KLANGK_AUTH_MODES": "password",
+            "KLANGK_DATA_DIR": str(temp_data_dir),
+            "KLANGK_STATE_DIR": str(temp_data_dir / "state"),
+            "KLANGK_CUSTOMIZE_DIR": str(temp_data_dir / "customize"),
+        }
+    )
     state = types.SimpleNamespace(settings=settings)
     state.auth = Auth(state)
     registry = ContainerRegistry(state)

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -410,11 +410,8 @@ class TestConfig:
         data = resp.json()
         assert data["min_password_length"] == _auth().min_password_length
 
-    async def test_get_config_logo_url_defaults_empty(
-        self, client, app, monkeypatch
-    ):
+    async def test_get_config_logo_url_defaults_empty(self, client, app):
         # No KLANGK_LOGO_URL set -> empty string (UI renders default widget).
-        monkeypatch.delenv("KLANGK_LOGO_URL", raising=False)
         resp = await client.get("/api/v1/config")
         assert resp.status_code == 200
         assert resp.json()["logo_url"] == ""
@@ -2505,7 +2502,7 @@ class TestWorkspaceSharingRoutes:
         # guard (which only fires on a grant) must let it through.
         from klangk_backend.main import seed_agent_user
 
-        await seed_agent_user(make_settings(os.environ))
+        await seed_agent_user(make_settings({}))
         agent = await model.get_user_by_id(model.AGENT_USER_ID)
         headers = await _auth_headers(client)
         resp = await client.post(
@@ -2557,7 +2554,7 @@ class TestWorkspaceSharingRoutes:
         # points themselves are unit-tested in test_model.py.
         from klangk_backend.main import seed_agent_user
 
-        await seed_agent_user(make_settings(os.environ))
+        await seed_agent_user(make_settings({}))
         agent = await model.get_user_by_id(model.AGENT_USER_ID)
         headers = await _auth_headers(client)
         resp = await client.post(
@@ -3218,7 +3215,7 @@ class TestTransferOwnership:
     async def test_transfer_to_agent_rejected(self, client, user):
         from klangk_backend.main import seed_agent_user
 
-        await seed_agent_user(make_settings(os.environ))
+        await seed_agent_user(make_settings({}))
         agent = await model.get_user_by_id(model.AGENT_USER_ID)
 
         headers = await _auth_headers(client)
@@ -5070,7 +5067,7 @@ class TestAdminEndpoints:
     async def test_delete_agent_user_rejected(self, client, admin_user, db):
         from klangk_backend.main import seed_agent_user
 
-        await seed_agent_user(make_settings(os.environ))
+        await seed_agent_user(make_settings({}))
         headers = await self._admin_headers(client)
         resp = await client.delete(
             f"/api/v1/admin/users/{model.AGENT_USER_ID}", headers=headers
@@ -5192,7 +5189,7 @@ class TestAdminEndpoints:
         # Seed the agent user so it exists in the DB
         from klangk_backend.main import seed_agent_user
 
-        await seed_agent_user(make_settings(os.environ))
+        await seed_agent_user(make_settings({}))
         headers = await self._admin_headers(client)
         resp = await client.patch(
             f"/api/v1/admin/users/{model.AGENT_USER_ID}",

--- a/src/backend/tests/test_auth.py
+++ b/src/backend/tests/test_auth.py
@@ -1,6 +1,5 @@
 """Tests for auth module: password hashing, JWT tokens, login/register."""
 
-import os
 import pytest
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
@@ -275,32 +274,12 @@ class TestLogin:
 class TestLoginRateLimit:
     """Tests for login brute-force protection.
 
-    The default LOGIN_LOCKOUT_FAILURES is 5 (enabled); these tests pin
-    it explicitly to 5 and reload the auth module so they exercise the
-    lockout machinery deterministically regardless of the default.
+    The default LOGIN_LOCKOUT_FAILURES is 5 (enabled); ``_auth()`` builds
+    ``Auth(make_settings({}))`` which picks up that default, so these tests
+    exercise the lockout machinery deterministically (#1515: auth reads
+    from settings at construction, not module globals — the old reload
+    dance is obsolete).
     """
-
-    def setup_method(self):
-        self._prev = os.environ.get("KLANGK_LOGIN_LOCKOUT_FAILURES")
-        os.environ["KLANGK_LOGIN_LOCKOUT_FAILURES"] = "5"
-        import importlib
-        import klangk_backend.auth as a
-
-        importlib.reload(a)
-        globals()["auth"] = a
-        globals()["model"] = a.model
-
-    def teardown_method(self):
-        if self._prev is None:
-            os.environ.pop("KLANGK_LOGIN_LOCKOUT_FAILURES", None)
-        else:
-            os.environ["KLANGK_LOGIN_LOCKOUT_FAILURES"] = self._prev
-        import importlib
-        import klangk_backend.auth as a
-
-        importlib.reload(a)
-        globals()["auth"] = a
-        globals()["model"] = a.model
 
     async def test_login_wrong_password_records_attempt(self, user):
         """Wrong password increments attempt count."""

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -528,8 +528,7 @@ class TestStartContainer:
         p.start_container.assert_awaited_once_with("new-cid")
         assert workspace["id"] in self.registry.states
 
-    async def test_sudo_disabled_by_default(self, workspace, monkeypatch):
-        monkeypatch.delenv("KLANGK_ALLOW_SUDO", raising=False)
+    async def test_sudo_disabled_by_default(self, workspace):
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
@@ -813,9 +812,7 @@ class TestStartContainer:
         assert "KLANGK_HOSTING_PROTO=https" in env
         assert "KLANGK_HOSTING_BASE_PATH=/klangk" in env
 
-    async def test_hosting_env_vars_default_is_bare_localhost(
-        self, workspace, monkeypatch
-    ):
+    async def test_hosting_env_vars_default_is_bare_localhost(self, workspace):
         """Omitted hosting_* resolves to bare localhost (#1240).
 
         This is the path ``eager_start_workspace`` takes (autostart /
@@ -826,10 +823,6 @@ class TestStartContainer:
         Now the choke point resolves it, and no port is synthesized from
         ``KLANGK_NGINX_PORT`` (the port must live in HOSTING_HOSTNAME).
         """
-        monkeypatch.delenv("KLANGK_HOSTING_HOSTNAME", raising=False)
-        monkeypatch.delenv("KLANGK_HOSTING_PROTO", raising=False)
-        monkeypatch.delenv("KLANGK_HOSTING_BASE_PATH", raising=False)
-        monkeypatch.setenv("KLANGK_NGINX_PORT", "8996")
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"],
@@ -888,11 +881,8 @@ class TestStartContainer:
         assert "CURL_CA_BUNDLE=/tmp/klangk/ca-bundle.crt" in env
         assert "NODE_EXTRA_CA_CERTS=/tmp/klangk/ca-bundle.crt" in env
 
-    async def test_no_ssl_trust_when_cert_dir_unset(
-        self, workspace, monkeypatch
-    ):
+    async def test_no_ssl_trust_when_cert_dir_unset(self, workspace):
         """Without KLANGK_SSL_CERT_DIR there is no mount and no trust env."""
-        monkeypatch.delenv("KLANGK_SSL_CERT_DIR", raising=False)
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"],
@@ -905,13 +895,19 @@ class TestStartContainer:
         assert not any(e.startswith("SSL_CERT_FILE=") for e in env)
 
     async def test_no_ssl_trust_when_dir_has_no_certs(
-        self, workspace, monkeypatch, tmp_path
+        self, workspace, tmp_path
     ):
         """A cert dir with no .pem/.crt is not mounted (#1181)."""
         ssl_dir = tmp_path / "ssl"
         ssl_dir.mkdir()
         (ssl_dir / "notes.txt").write_text("not a cert")
-        monkeypatch.setenv("KLANGK_SSL_CERT_DIR", str(ssl_dir))
+        # Point the registry's settings at the empty cert dir so ssl_cert_dir()
+        # actually evaluates it (previously this was an inert setenv against
+        # os.environ that the registry — built from make_settings({}) — never
+        # saw; the test passed for the wrong reason).
+        self.registry.settings = make_settings(
+            {"KLANGK_SSL_CERT_DIR": str(ssl_dir)}
+        )
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"],
@@ -1020,11 +1016,8 @@ class TestStartContainer:
         await self.registry.allocate_ports(workspace["id"], 5)
         assert await self.registry.get_workspace_ports(workspace["id"]) == []
 
-    async def test_hosting_env_present_when_enabled(
-        self, workspace, monkeypatch
-    ):
+    async def test_hosting_env_present_when_enabled(self, workspace):
         """Sanity: with the default cap, hosting env is injected as before."""
-        monkeypatch.delenv("KLANGK_HOSTED_PORTS_PER_WORKSPACE", raising=False)
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"],

--- a/src/backend/tests/test_main.py
+++ b/src/backend/tests/test_main.py
@@ -65,26 +65,35 @@ def _make_app_state(settings=None):
 
 
 class TestSeedDefaultUser:
-    async def test_creates_user_when_missing(self, db, monkeypatch):
-        monkeypatch.setenv("KLANGK_DEFAULT_USER", "seed-test")
-        monkeypatch.setenv("KLANGK_DEFAULT_PASSWORD", "seed-pass")
-        await main.seed_default_user(make_settings(os.environ))
+    async def test_creates_user_when_missing(self, db):
+        await main.seed_default_user(
+            make_settings(
+                {
+                    "KLANGK_DEFAULT_USER": "seed-test",
+                    "KLANGK_DEFAULT_PASSWORD": "seed-pass",
+                }
+            )
+        )
         user = await model.get_user_by_email("seed-test")
         assert user is not None
 
-    async def test_skips_existing_user(self, db, monkeypatch):
-        monkeypatch.setenv("KLANGK_DEFAULT_USER", "seed-test")
-        monkeypatch.setenv("KLANGK_DEFAULT_PASSWORD", "seed-pass")
-        await main.seed_default_user(make_settings(os.environ))
+    async def test_skips_existing_user(self, db):
+        s = make_settings(
+            {
+                "KLANGK_DEFAULT_USER": "seed-test",
+                "KLANGK_DEFAULT_PASSWORD": "seed-pass",
+            }
+        )
+        await main.seed_default_user(s)
         # Call again — should not raise
-        await main.seed_default_user(make_settings(os.environ))
+        await main.seed_default_user(s)
         user = await model.get_user_by_email("seed-test")
         assert user is not None
 
-    async def test_generates_password_when_not_set(self, db, monkeypatch):
-        monkeypatch.setenv("KLANGK_DEFAULT_USER", "gen-test")
-        monkeypatch.delenv("KLANGK_DEFAULT_PASSWORD", raising=False)
-        await main.seed_default_user(make_settings(os.environ))
+    async def test_generates_password_when_not_set(self, db):
+        await main.seed_default_user(
+            make_settings({"KLANGK_DEFAULT_USER": "gen-test"})
+        )
         user = await model.get_user_by_email("gen-test")
         assert user is not None
         # User exists and is in the admin group
@@ -94,14 +103,14 @@ class TestSeedDefaultUser:
         assert admin_group["id"] in group_ids
 
     async def test_generated_password_printed_to_stderr(
-        self, db, monkeypatch, caplog, capsys
+        self, db, caplog, capsys
     ):
-        monkeypatch.setenv("KLANGK_DEFAULT_USER", "log-test")
-        monkeypatch.delenv("KLANGK_DEFAULT_PASSWORD", raising=False)
         import logging
 
         with caplog.at_level(logging.INFO):
-            await main.seed_default_user(make_settings(os.environ))
+            await main.seed_default_user(
+                make_settings({"KLANGK_DEFAULT_USER": "log-test"})
+            )
         # Password must NOT appear in log output (security)
         assert "password printed to stderr" in caplog.text
         assert "log-test" in caplog.text
@@ -246,26 +255,36 @@ class TestNoAuthBindSafety:
 
 class TestSeedAgentUser:
     async def test_creates_agent_user(self, db):
-        await main.seed_agent_user(make_settings(os.environ))
+        await main.seed_agent_user(make_settings({}))
         user = await model.get_user_by_id(model.AGENT_USER_ID)
         assert user is not None
         assert user["email"] == "clanker@example.com"
         assert user["handle"] == "clanker"
 
-    async def test_custom_env_vars(self, db, monkeypatch):
-        monkeypatch.setenv("KLANGK_AGENT_EMAIL", "bot@test.com")
-        monkeypatch.setenv("KLANGK_AGENT_HANDLE", "TestBot")
-        await main.seed_agent_user(make_settings(os.environ))
+    async def test_custom_env_vars(self, db):
+        await main.seed_agent_user(
+            make_settings(
+                {
+                    "KLANGK_AGENT_EMAIL": "bot@test.com",
+                    "KLANGK_AGENT_HANDLE": "TestBot",
+                }
+            )
+        )
         user = await model.get_user_by_id(model.AGENT_USER_ID)
         assert user is not None
         assert user["email"] == "bot@test.com"
         assert user["handle"] == "TestBot"
 
-    async def test_upserts_existing(self, db, monkeypatch):
-        await main.seed_agent_user(make_settings(os.environ))
-        monkeypatch.setenv("KLANGK_AGENT_EMAIL", "new@test.com")
-        monkeypatch.setenv("KLANGK_AGENT_HANDLE", "NewBot")
-        await main.seed_agent_user(make_settings(os.environ))
+    async def test_upserts_existing(self, db):
+        await main.seed_agent_user(make_settings({}))
+        await main.seed_agent_user(
+            make_settings(
+                {
+                    "KLANGK_AGENT_EMAIL": "new@test.com",
+                    "KLANGK_AGENT_HANDLE": "NewBot",
+                }
+            )
+        )
         user = await model.get_user_by_id(model.AGENT_USER_ID)
         assert user["email"] == "new@test.com"
         assert user["handle"] == "NewBot"
@@ -273,7 +292,7 @@ class TestSeedAgentUser:
     async def test_clears_cache(self, db):
         # Prime cache with fallback
         await model.get_agent_user()
-        await main.seed_agent_user(make_settings(os.environ))
+        await main.seed_agent_user(make_settings({}))
         # Cache should now reflect DB values
         agent = await model.get_agent_user()
         assert agent["email"] == "clanker@example.com"
@@ -297,9 +316,7 @@ class TestSeedAgentUser:
         # The underlying driver-level cause is the sqlite UNIQUE violation.
         assert isinstance(exc_info.value.orig, sqlite3.IntegrityError)
 
-    async def test_seed_refuses_handle_collision_with_human(
-        self, db, monkeypatch
-    ):
+    async def test_seed_refuses_handle_collision_with_human(self, db):
         """Seeding the agent with a live user's handle fails cleanly.
 
         The destructive path is ensure_home_symlink migrating that user's
@@ -310,35 +327,33 @@ class TestSeedAgentUser:
             "alice@example.com", "hash", verified=True
         )
         assert human["handle"] == "alice"
-        monkeypatch.setenv("KLANGK_AGENT_HANDLE", "alice")
         with pytest.raises(RuntimeError, match="alice"):
-            await main.seed_agent_user(make_settings(os.environ))
+            await main.seed_agent_user(
+                make_settings({"KLANGK_AGENT_HANDLE": "alice"})
+            )
         # Human user is untouched.
         refreshed = await model.get_user_by_id(human["id"])
         assert refreshed["handle"] == "alice"
         # Agent was not created with the colliding handle.
         assert await model.get_user_by_id(model.AGENT_USER_ID) is None
 
-    async def test_seed_rename_to_human_handle_refuses(self, db, monkeypatch):
+    async def test_seed_rename_to_human_handle_refuses(self, db):
         """Re-seeding the agent onto a human's handle fails, leaves agent as-is."""
-        await main.seed_agent_user(
-            make_settings(os.environ)
-        )  # agent handle = clanker
+        await main.seed_agent_user(make_settings({}))  # agent handle = clanker
         human = await model.create_user(
             "alice@example.com", "hash", verified=True
         )
-        monkeypatch.setenv("KLANGK_AGENT_HANDLE", "alice")
         with pytest.raises(RuntimeError, match="already used by another user"):
-            await main.seed_agent_user(make_settings(os.environ))
+            await main.seed_agent_user(
+                make_settings({"KLANGK_AGENT_HANDLE": "alice"})
+            )
         # Agent keeps its original handle; human untouched.
         agent = await model.get_user_by_id(model.AGENT_USER_ID)
         assert agent["handle"] == "clanker"
         refreshed = await model.get_user_by_id(human["id"])
         assert refreshed["handle"] == "alice"
 
-    async def test_collision_leaves_human_files_untouched(
-        self, db, monkeypatch, tmp_path
-    ):
+    async def test_collision_leaves_human_files_untouched(self, db, tmp_path):
         """A handle collision never reaches ensure_home_symlink's adoption.
 
         Builds the on-disk layout that the destructive branch would migrate
@@ -358,9 +373,10 @@ class TestSeedAgentUser:
         (human_dir / "secret.txt").write_text("alice's secrets")
         (home / "alice").symlink_to(f".users/{human['id']}")
 
-        monkeypatch.setenv("KLANGK_AGENT_HANDLE", "alice")
         with pytest.raises(RuntimeError):
-            await main.seed_agent_user(make_settings(os.environ))
+            await main.seed_agent_user(
+                make_settings({"KLANGK_AGENT_HANDLE": "alice"})
+            )
 
         # Human's files are exactly where they were — nothing migrated.
         assert (human_dir / "secret.txt").read_text() == "alice's secrets"
@@ -373,14 +389,7 @@ class TestSeedAgentUser:
 
 
 class TestLifespan:
-    async def test_lifespan_starts_and_stops(self, db, monkeypatch):
-        monkeypatch.delenv("KLANGK_OIDC_CONFIG", raising=False)
-        monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
-        # Default mode is now ``none``; pin the bind loopback so the
-        # no-auth safety gate admits startup deterministically (the real
-        # out-of-box boot path).
-        monkeypatch.setenv("KLANGK_LISTEN", "127.0.0.1")
-        monkeypatch.delenv("KLANGK_PREVENT_INSECURE_JWT_SECRET", raising=False)
+    async def test_lifespan_starts_and_stops(self, db):
         app = FastAPI()
         app_state = _make_app_state()
         app.state.container_registry = app_state.container_registry
@@ -423,15 +432,9 @@ class TestLifespan:
             mock_shutdown.assert_awaited_once()
             mock_remove.assert_called_once()
 
-    async def test_lifespan_workspace_killed_resets_state(
-        self, db, monkeypatch
-    ):
+    async def test_lifespan_workspace_killed_resets_state(self, db):
         """The workspace-killed callback threads app.state into
         reset_workspace_state (sockets, workspace_id) — #1475."""
-        monkeypatch.delenv("KLANGK_OIDC_CONFIG", raising=False)
-        monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
-        monkeypatch.setenv("KLANGK_LISTEN", "127.0.0.1")
-        monkeypatch.delenv("KLANGK_PREVENT_INSECURE_JWT_SECRET", raising=False)
         app = FastAPI()
         app_state = _make_app_state()
         app.state.container_registry = app_state.container_registry
@@ -471,11 +474,7 @@ class TestLifespan:
                 await registry.on_workspace_killed("ws-killed")
         mock_reset.assert_awaited_once_with(app.state.sockets, "ws-killed")
 
-    async def test_lifespan_refuses_if_pid_alive(self, db, monkeypatch):
-        monkeypatch.delenv("KLANGK_OIDC_CONFIG", raising=False)
-        monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
-        monkeypatch.setenv("KLANGK_LISTEN", "127.0.0.1")
-        monkeypatch.delenv("KLANGK_PREVENT_INSECURE_JWT_SECRET", raising=False)
+    async def test_lifespan_refuses_if_pid_alive(self, db):
         from klangk_backend.model import db as db_mod
 
         app = FastAPI()
@@ -657,12 +656,8 @@ class TestStartupShutdownRestart:
             await asyncio.sleep(0)
         mock_restart.assert_awaited_once_with(app_state, wd)
 
-    async def test_lifespan_registers_sighup_handler(self, db, monkeypatch):
+    async def test_lifespan_registers_sighup_handler(self, db):
         """The lifespan installs (and removes) a SIGHUP handler."""
-        monkeypatch.delenv("KLANGK_OIDC_CONFIG", raising=False)
-        monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
-        monkeypatch.setenv("KLANGK_LISTEN", "127.0.0.1")
-        monkeypatch.delenv("KLANGK_PREVENT_INSECURE_JWT_SECRET", raising=False)
         app = FastAPI()
         app_state = _make_app_state()
         app.state.container_registry = app_state.container_registry
@@ -822,7 +817,6 @@ class TestSetupStaticFiles:
         custom = tmp_path / "cust"
         branding = custom / "branding"
         branding.mkdir(parents=True)
-        monkeypatch.setenv("KLANGK_CUSTOMIZE_DIR", str(custom))
 
         test_app = FastAPI()
         _settings = make_settings({"KLANGK_CUSTOMIZE_DIR": str(custom)})

--- a/src/backend/tests/test_mode_switching.py
+++ b/src/backend/tests/test_mode_switching.py
@@ -12,8 +12,6 @@ mode switch is therefore simulated by rebuilding the OIDC instance (a
 "restart") after changing ``KLANGK_AUTH_MODES``.
 """
 
-import os
-
 import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
@@ -58,10 +56,15 @@ async def mode_server(db, monkeypatch):
     for the seeded default user (so tests know its ``id`` / ``email``).
     """
     global _current_app
-    monkeypatch.setenv("KLANGK_DEFAULT_USER", DEFAULT_EMAIL)
-    monkeypatch.setenv("KLANGK_DEFAULT_PASSWORD", SEEDED_PASSWORD)
     # Seed exactly as the lifespan does at startup.
-    await main.seed_default_user(make_settings(os.environ))
+    await main.seed_default_user(
+        make_settings(
+            {
+                "KLANGK_DEFAULT_USER": DEFAULT_EMAIL,
+                "KLANGK_DEFAULT_PASSWORD": SEEDED_PASSWORD,
+            }
+        )
+    )
     default_user = await model.get_user_by_email(DEFAULT_EMAIL)
     assert default_user is not None, "seed_default_user must create the user"
 
@@ -98,11 +101,11 @@ def _set_mode(mode: str):
     app.state.oidc = oidc_mod.OIDC(app.state)
 
 
-def _none(monkeypatch):
+def _none():
     _set_mode("none")
 
 
-def _password(monkeypatch):
+def _password():
     _set_mode("password")
 
 
@@ -121,7 +124,7 @@ class TestNoneToPasswordUpgrade:
         with a new password — succeeds because the seeded default user is an
         admin."""
         client, user = mode_server
-        _none(monkeypatch)
+        _none()
 
         token = (await client.post("/api/v1/auth/local")).json()[
             "access_token"
@@ -148,7 +151,7 @@ class TestNoneToPasswordUpgrade:
         """Step 3-4: flip to password mode, then login with the password the
         admin just set works — the documented end state."""
         client, user = mode_server
-        _none(monkeypatch)
+        _none()
         token = (await client.post("/api/v1/auth/local")).json()[
             "access_token"
         ]
@@ -158,7 +161,7 @@ class TestNoneToPasswordUpgrade:
             json={"password": NEW_PASSWORD},
         )
 
-        _password(monkeypatch)
+        _password()
         resp = await client.post(
             "/api/v1/auth/login",
             json={"email": DEFAULT_EMAIL, "password": NEW_PASSWORD},
@@ -172,7 +175,7 @@ class TestNoneToPasswordUpgrade:
         """``admin users set-password`` replaces the hash, so whatever password
         the default user had before (the seeded one) no longer works."""
         client, user = mode_server
-        _none(monkeypatch)
+        _none()
         token = (await client.post("/api/v1/auth/local")).json()[
             "access_token"
         ]
@@ -181,7 +184,7 @@ class TestNoneToPasswordUpgrade:
             headers={"Authorization": f"Bearer {token}"},
             json={"password": NEW_PASSWORD},
         )
-        _password(monkeypatch)
+        _password()
 
         resp = await client.post(
             "/api/v1/auth/login",
@@ -194,7 +197,7 @@ class TestNoneToPasswordUpgrade:
     ):
         """Once real login is on, the free-token endpoint is gone (403)."""
         client, _ = mode_server
-        _password(monkeypatch)
+        _password()
         resp = await client.post("/api/v1/auth/local")
         assert resp.status_code == 403
 
@@ -205,7 +208,7 @@ class TestNoneToPasswordUpgrade:
         mode switch is not a global logout (docs: 'tokens in flight keep
         working until they expire')."""
         client, _ = mode_server
-        _none(monkeypatch)
+        _none()
         token = (await client.post("/api/v1/auth/local")).json()[
             "access_token"
         ]
@@ -214,7 +217,7 @@ class TestNoneToPasswordUpgrade:
             await client.get("/api/v1/auth/me", headers=h)
         ).status_code == 200
 
-        _password(monkeypatch)
+        _password()
         # Same token, new mode — still valid.
         resp = await client.get("/api/v1/auth/me", headers=h)
         assert resp.status_code == 200
@@ -231,10 +234,10 @@ class TestPasswordToNone:
     ):
         """Reversing the switch re-enables the no-auth endpoint."""
         client, _ = mode_server
-        _password(monkeypatch)
+        _password()
         assert (await client.post("/api/v1/auth/local")).status_code == 403
 
-        _none(monkeypatch)
+        _none()
         resp = await client.post("/api/v1/auth/local")
         assert resp.status_code == 200
         assert resp.json()["email"] == DEFAULT_EMAIL
@@ -244,7 +247,7 @@ class TestPasswordToNone:
     ):
         """Token-in-flight claim, reverse direction."""
         client, _ = mode_server
-        _password(monkeypatch)
+        _password()
         resp = await client.post(
             "/api/v1/auth/login",
             json={"email": DEFAULT_EMAIL, "password": SEEDED_PASSWORD},
@@ -253,7 +256,7 @@ class TestPasswordToNone:
         token = resp.json()["access_token"]
         h = {"Authorization": f"Bearer {token}"}
 
-        _none(monkeypatch)
+        _none()
         assert (
             await client.get("/api/v1/auth/me", headers=h)
         ).status_code == 200
@@ -271,7 +274,7 @@ class TestDataCarriesOver:
         """The operator is the same DB user before and after the switch (same
         id, same email, still admin)."""
         client, user = mode_server
-        _none(monkeypatch)
+        _none()
         free = (await client.post("/api/v1/auth/local")).json()["access_token"]
         none_me = (
             await client.get(
@@ -279,7 +282,7 @@ class TestDataCarriesOver:
             )
         ).json()
 
-        _password(monkeypatch)
+        _password()
         login = await client.post(
             "/api/v1/auth/login",
             json={"email": DEFAULT_EMAIL, "password": SEEDED_PASSWORD},
@@ -303,10 +306,10 @@ class TestDataCarriesOver:
         """A workspace created in none mode is still owned by the default user
         after flipping to password mode — modes change auth, not data."""
         client, user = mode_server
-        _none(monkeypatch)
+        _none()
         ws = await model.create_workspace(user["id"], "persists-across-switch")
 
-        _password(monkeypatch)
+        _password()
         # Re-resolve the workspace straight from the DB the restart would see.
         rows = (await model.list_workspaces(user["id"]))["items"]
         names = [r["name"] for r in rows]
@@ -330,7 +333,7 @@ class TestChangePasswordReality:
         """Self-service ``/auth/change-password`` works on the seeded default
         user because it has a real password hash."""
         client, _ = mode_server
-        _none(monkeypatch)
+        _none()
         token = (await client.post("/api/v1/auth/local")).json()[
             "access_token"
         ]
@@ -352,7 +355,7 @@ class TestChangePasswordReality:
         self-service change-password — that 403 path exists, it just does not
         apply to the seeded default user."""
         client, _ = mode_server
-        _none(monkeypatch)
+        _none()
 
         # A user with no password hash (an OIDC-only style account).
         oidc_user = await model.create_user(
@@ -384,21 +387,33 @@ class TestRestartIdempotency:
         """Re-running the lifespan seed (a restart with a new mode, same DB)
         must not duplicate the user or drop its admin membership."""
         client, user = mode_server
-        _none(monkeypatch)
+        _none()
         await main.seed_default_user(
-            make_settings(os.environ)
+            make_settings(
+                {
+                    "KLANGK_AUTH_MODES": "none",
+                    "KLANGK_DEFAULT_USER": DEFAULT_EMAIL,
+                    "KLANGK_DEFAULT_PASSWORD": SEEDED_PASSWORD,
+                }
+            )
         )  # simulate restart in none mode
 
-        _password(monkeypatch)
+        _password()
         await main.seed_default_user(
-            make_settings(os.environ)
+            make_settings(
+                {
+                    "KLANGK_AUTH_MODES": "password",
+                    "KLANGK_DEFAULT_USER": DEFAULT_EMAIL,
+                    "KLANGK_DEFAULT_PASSWORD": SEEDED_PASSWORD,
+                }
+            )
         )  # simulate restart in password mode
 
         again = await model.get_user_by_email(DEFAULT_EMAIL)
         assert again["id"] == user["id"]
         # Still admin (membership re-asserted, not lost) — ask the canonical
         # /my-permissions source the CLI and frontend both use.
-        _none(monkeypatch)
+        _none()
         token = (await client.post("/api/v1/auth/local")).json()[
             "access_token"
         ]

--- a/src/backend/tests/test_oidc.py
+++ b/src/backend/tests/test_oidc.py
@@ -1,6 +1,5 @@
 """Tests for OIDC client module."""
 
-import os
 import time
 import types
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -15,18 +14,16 @@ from _helpers import make_settings
 from klangk_backend.settings import KlangkSettings
 
 
-def _settings() -> KlangkSettings:
-    """Build settings from the live (monkeypatched) environment."""
-    return KlangkSettings(os.environ)
-
-
 def _oidc(settings: KlangkSettings | None = None) -> oidc.OIDC:
-    """Build a fresh OIDC instance from the live (monkeypatched) env.
+    """Build a fresh OIDC instance from explicit settings.
 
     Each call constructs a new instance so test state (providers, caches,
-    login-hook) never leaks between tests (#1450).
+    login-hook) never leaks between tests (#1450). Defaults to a plain
+    ``make_settings({})`` (auth_modes is the production default ``none``);
+    tests pass explicit settings to vary a field (#1457: construct
+    directly, never via os.environ).
     """
-    app_state = types.SimpleNamespace(settings=settings or _settings())
+    app_state = types.SimpleNamespace(settings=settings or make_settings({}))
     return oidc.OIDC(app_state)
 
 
@@ -50,16 +47,18 @@ class TestGet:
 
 
 class TestLoadConfig:
-    def test_no_config(self, monkeypatch):
-        monkeypatch.delenv("KLANGK_OIDC_CONFIG", raising=False)
+    def test_no_config(self):
         assert _oidc().load_config() == []
 
-    def test_missing_file(self, monkeypatch, tmp_path):
-        monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(tmp_path / "nope.json"))
+    def test_missing_file(self, tmp_path):
         with pytest.raises(ConfigurationError, match="absolute path"):
-            _oidc().load_config()
+            _oidc(
+                make_settings(
+                    {"KLANGK_OIDC_CONFIG": str(tmp_path / "nope.json")}
+                )
+            ).load_config()
 
-    def test_valid_config(self, monkeypatch, tmp_path):
+    def test_valid_config(self, tmp_path):
         cfg = tmp_path / "oidc.yaml"
         cfg.write_text(
             yaml.dump(
@@ -74,14 +73,15 @@ class TestLoadConfig:
                 ]
             )
         )
-        monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(cfg))
-        providers = _oidc().load_config()
+        providers = _oidc(
+            make_settings({"KLANGK_OIDC_CONFIG": str(cfg)})
+        ).load_config()
         assert len(providers) == 1
         assert providers[0].id == "test"
         assert providers[0].issuer == "https://idp.example.com"
         assert providers[0].client_secret == "s3cret"
 
-    def test_file_secret(self, monkeypatch, tmp_path):
+    def test_file_secret(self, tmp_path):
         secret_file = tmp_path / "secret"
         secret_file.write_text("file-secret\n")
         cfg = tmp_path / "oidc.yaml"
@@ -98,11 +98,12 @@ class TestLoadConfig:
                 ]
             )
         )
-        monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(cfg))
-        providers = _oidc().load_config()
+        providers = _oidc(
+            make_settings({"KLANGK_OIDC_CONFIG": str(cfg)})
+        ).load_config()
         assert providers[0].client_secret == "file-secret"
 
-    def test_ca_cert(self, monkeypatch, tmp_path):
+    def test_ca_cert(self, tmp_path):
         cfg = tmp_path / "oidc.yaml"
         cfg.write_text(
             yaml.dump(
@@ -118,11 +119,12 @@ class TestLoadConfig:
                 ]
             )
         )
-        monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(cfg))
-        providers = _oidc().load_config()
+        providers = _oidc(
+            make_settings({"KLANGK_OIDC_CONFIG": str(cfg)})
+        ).load_config()
         assert providers[0].ca_cert == "/etc/pki/dod-ca.pem"
 
-    def test_token_validation_pem(self, monkeypatch, tmp_path):
+    def test_token_validation_pem(self, tmp_path):
         pem = "-----BEGIN PUBLIC KEY-----\nMIIBI...\n-----END PUBLIC KEY-----"
         cfg = tmp_path / "oidc.yaml"
         cfg.write_text(
@@ -139,11 +141,12 @@ class TestLoadConfig:
                 ]
             )
         )
-        monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(cfg))
-        providers = _oidc().load_config()
+        providers = _oidc(
+            make_settings({"KLANGK_OIDC_CONFIG": str(cfg)})
+        ).load_config()
         assert providers[0].token_validation_pem == pem
 
-    def test_ca_cert_relative_resolved(self, monkeypatch, tmp_path):
+    def test_ca_cert_relative_resolved(self, tmp_path):
         cfg = tmp_path / "oidc.yaml"
         cfg.write_text(
             yaml.dump(
@@ -159,12 +162,13 @@ class TestLoadConfig:
                 ]
             )
         )
-        monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(cfg))
-        providers = _oidc().load_config()
+        providers = _oidc(
+            make_settings({"KLANGK_OIDC_CONFIG": str(cfg)})
+        ).load_config()
         expected = str(tmp_path / "certs" / "ca.pem")
         assert providers[0].ca_cert == expected
 
-    def test_ca_cert_default_none(self, monkeypatch, tmp_path):
+    def test_ca_cert_default_none(self, tmp_path):
         cfg = tmp_path / "oidc.yaml"
         cfg.write_text(
             yaml.dump(
@@ -179,11 +183,12 @@ class TestLoadConfig:
                 ]
             )
         )
-        monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(cfg))
-        providers = _oidc().load_config()
+        providers = _oidc(
+            make_settings({"KLANGK_OIDC_CONFIG": str(cfg)})
+        ).load_config()
         assert providers[0].ca_cert is None
 
-    def test_trust_email(self, monkeypatch, tmp_path):
+    def test_trust_email(self, tmp_path):
         cfg = tmp_path / "oidc.yaml"
         cfg.write_text(
             yaml.dump(
@@ -199,11 +204,12 @@ class TestLoadConfig:
                 ]
             )
         )
-        monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(cfg))
-        providers = _oidc().load_config()
+        providers = _oidc(
+            make_settings({"KLANGK_OIDC_CONFIG": str(cfg)})
+        ).load_config()
         assert providers[0].trust_email is True
 
-    def test_trust_email_defaults_false(self, monkeypatch, tmp_path):
+    def test_trust_email_defaults_false(self, tmp_path):
         cfg = tmp_path / "oidc.yaml"
         cfg.write_text(
             yaml.dump(
@@ -218,11 +224,12 @@ class TestLoadConfig:
                 ]
             )
         )
-        monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(cfg))
-        providers = _oidc().load_config()
+        providers = _oidc(
+            make_settings({"KLANGK_OIDC_CONFIG": str(cfg)})
+        ).load_config()
         assert providers[0].trust_email is False
 
-    def test_multiple_providers(self, monkeypatch, tmp_path):
+    def test_multiple_providers(self, tmp_path):
         cfg = tmp_path / "oidc.yaml"
         cfg.write_text(
             yaml.dump(
@@ -244,13 +251,14 @@ class TestLoadConfig:
                 ]
             )
         )
-        monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(cfg))
-        providers = _oidc().load_config()
+        providers = _oidc(
+            make_settings({"KLANGK_OIDC_CONFIG": str(cfg)})
+        ).load_config()
         assert len(providers) == 2
         assert providers[0].id == "a"
         assert providers[1].id == "b"
 
-    def test_snake_case_fallback(self, monkeypatch, tmp_path):
+    def test_snake_case_fallback(self, tmp_path):
         """Legacy snake_case keys still work for backwards compat."""
         cfg = tmp_path / "oidc.yaml"
         cfg.write_text(
@@ -269,8 +277,9 @@ class TestLoadConfig:
                 ]
             )
         )
-        monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(cfg))
-        providers = _oidc().load_config()
+        providers = _oidc(
+            make_settings({"KLANGK_OIDC_CONFIG": str(cfg)})
+        ).load_config()
         assert len(providers) == 1
         assert providers[0].display_name == "Legacy"
         assert providers[0].client_id == "klangk"
@@ -283,7 +292,7 @@ class TestLoadConfig:
 class TestInlineProviders:
     """OIDC providers specified inline in the klangkd config file (#1395)."""
 
-    def test_inline_providers_loaded(self, tmp_path, monkeypatch):
+    def test_inline_providers_loaded(self, tmp_path):
         cfg = tmp_path / "config.yaml"
         cfg.write_text(
             "oidc_providers:\n"
@@ -293,8 +302,7 @@ class TestInlineProviders:
             "    client-id: klangk\n"
             '    client-secret: "inline-secret"\n'
         )
-        monkeypatch.delenv("KLANGK_OIDC_CONFIG", raising=False)
-        settings = make_settings(os.environ, config_file=str(cfg))
+        settings = make_settings({}, config_file=str(cfg))
         providers = _oidc(settings).load_config()
         assert len(providers) == 1
         assert providers[0].id == "inline"
@@ -302,7 +310,7 @@ class TestInlineProviders:
         assert providers[0].client_secret == "inline-secret"
         assert providers[0].issuer == "https://idp.example.com"
 
-    def test_external_file_overrides_inline(self, monkeypatch, tmp_path):
+    def test_external_file_overrides_inline(self, tmp_path):
         """When both inline and external are configured, external wins
         (env var override, consistent with env > file precedence)."""
         ext = tmp_path / "oidc.yaml"
@@ -319,8 +327,6 @@ class TestInlineProviders:
                 ]
             )
         )
-        monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(ext))
-
         cfg = tmp_path / "config.yaml"
         cfg.write_text(
             "oidc_providers:\n"
@@ -330,12 +336,14 @@ class TestInlineProviders:
             "    client-id: klangk\n"
             '    client-secret: "inline"\n'
         )
-        settings = make_settings(os.environ, config_file=str(cfg))
+        settings = make_settings(
+            {"KLANGK_OIDC_CONFIG": str(ext)}, config_file=str(cfg)
+        )
         providers = _oidc(settings).load_config()
         assert len(providers) == 1
         assert providers[0].id == "external"
 
-    def test_inline_file_secret_resolution(self, tmp_path, monkeypatch):
+    def test_inline_file_secret_resolution(self, tmp_path):
         """file: prefix in inline provider secrets resolves correctly."""
         secret = tmp_path / "secret.txt"
         secret.write_text("resolved-secret\n")
@@ -348,12 +356,11 @@ class TestInlineProviders:
             "    client-id: klangk\n"
             f'    client-secret: "file:{secret}"\n'
         )
-        monkeypatch.delenv("KLANGK_OIDC_CONFIG", raising=False)
-        settings = make_settings(os.environ, config_file=str(cfg))
+        settings = make_settings({}, config_file=str(cfg))
         providers = _oidc(settings).load_config()
         assert providers[0].client_secret == "resolved-secret"
 
-    def test_inline_multiple_providers(self, tmp_path, monkeypatch):
+    def test_inline_multiple_providers(self, tmp_path):
         cfg = tmp_path / "config.yaml"
         cfg.write_text(
             "oidc_providers:\n"
@@ -368,16 +375,13 @@ class TestInlineProviders:
             "    client-id: klangk\n"
             '    client-secret: "sb"\n'
         )
-        monkeypatch.delenv("KLANGK_OIDC_CONFIG", raising=False)
-        settings = make_settings(os.environ, config_file=str(cfg))
+        settings = make_settings({}, config_file=str(cfg))
         providers = _oidc(settings).load_config()
         assert len(providers) == 2
         assert providers[0].id == "a"
         assert providers[1].id == "b"
 
-    def test_falls_back_to_external_when_no_inline(
-        self, monkeypatch, tmp_path
-    ):
+    def test_falls_back_to_external_when_no_inline(self, tmp_path):
         """With no inline providers, external file is used."""
         ext = tmp_path / "oidc.yaml"
         ext.write_text(
@@ -393,14 +397,15 @@ class TestInlineProviders:
                 ]
             )
         )
-        monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(ext))
-        providers = _oidc().load_config()
+        providers = _oidc(
+            make_settings({"KLANGK_OIDC_CONFIG": str(ext)})
+        ).load_config()
         assert len(providers) == 1
         assert providers[0].id == "external"
 
 
 class TestProviderRegistry:
-    def test_init_and_lookup(self, monkeypatch, tmp_path):
+    def test_init_and_lookup(self, tmp_path):
         cfg = tmp_path / "oidc.yaml"
         cfg.write_text(
             yaml.dump(
@@ -415,8 +420,7 @@ class TestProviderRegistry:
                 ]
             )
         )
-        monkeypatch.setenv("KLANGK_OIDC_CONFIG", str(cfg))
-        o = _oidc()
+        o = _oidc(make_settings({"KLANGK_OIDC_CONFIG": str(cfg)}))
         o.init_providers()
         assert o.is_enabled()
         assert o.get_provider("test") is not None
@@ -429,40 +433,32 @@ class TestProviderRegistry:
         assert not o.is_enabled()
         assert o.list_providers() == []
 
-    def test_init_raises_when_oidc_required_but_no_providers(
-        self, monkeypatch
-    ):
-        monkeypatch.delenv("KLANGK_OIDC_CONFIG", raising=False)
-        monkeypatch.setenv("KLANGK_AUTH_MODES", "oidc")
+    def test_init_raises_when_oidc_required_but_no_providers(self):
         with pytest.raises(ConfigurationError, match="no OIDC providers"):
-            _oidc().init_providers()
+            _oidc(
+                make_settings({"KLANGK_AUTH_MODES": "oidc"})
+            ).init_providers()
 
-    def test_init_raises_when_both_required_but_no_providers(
-        self, monkeypatch
-    ):
-        monkeypatch.delenv("KLANGK_OIDC_CONFIG", raising=False)
-        monkeypatch.setenv("KLANGK_AUTH_MODES", "both")
+    def test_init_raises_when_both_required_but_no_providers(self):
         with pytest.raises(ConfigurationError, match="no OIDC providers"):
-            _oidc().init_providers()
+            _oidc(
+                make_settings({"KLANGK_AUTH_MODES": "both"})
+            ).init_providers()
 
-    def test_init_ok_when_password_only(self, monkeypatch):
-        monkeypatch.delenv("KLANGK_OIDC_CONFIG", raising=False)
-        monkeypatch.setenv("KLANGK_AUTH_MODES", "password")
-        o = _oidc()
+    def test_init_ok_when_password_only(self):
+        o = _oidc(make_settings({"KLANGK_AUTH_MODES": "password"}))
         o.init_providers()
         assert not o.is_enabled()
 
 
 class TestAuthModes:
-    def test_default_none_when_no_oidc(self, monkeypatch):
-        monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
+    def test_default_none_when_no_oidc(self):
         o = _oidc()
         assert o.auth_modes() == "none"
         assert not o.password_login_allowed()
         assert o.local_login_allowed()
 
-    def test_default_none_when_oidc_enabled(self, monkeypatch):
-        monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
+    def test_default_none_when_oidc_enabled(self):
         o = _oidc()
         o.providers.append(_provider())
         assert o.auth_modes() == "none"
@@ -470,57 +466,47 @@ class TestAuthModes:
         assert not o.password_login_allowed()
         assert not o.oidc_login_allowed()
 
-    def test_oidc_only(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_AUTH_MODES", "oidc")
-        o = _oidc()
+    def test_oidc_only(self):
+        o = _oidc(make_settings({"KLANGK_AUTH_MODES": "oidc"}))
         o.providers.append(_provider())
         assert o.auth_modes() == "oidc"
         assert not o.password_login_allowed()
         assert o.oidc_login_allowed()
 
-    def test_password_only(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_AUTH_MODES", "password")
-        o = _oidc()
+    def test_password_only(self):
+        o = _oidc(make_settings({"KLANGK_AUTH_MODES": "password"}))
         o.providers.append(_provider())
         assert o.auth_modes() == "password"
         assert o.password_login_allowed()
         assert not o.oidc_login_allowed()
 
-    def test_none_mode(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_AUTH_MODES", "none")
-        o = _oidc()
+    def test_none_mode(self):
+        o = _oidc(make_settings({"KLANGK_AUTH_MODES": "none"}))
         assert o.auth_modes() == "none"
         assert not o.password_login_allowed()
         assert not o.oidc_login_allowed()
         assert o.local_login_allowed()
 
-    def test_none_mode_ignores_oidc_config(self, monkeypatch):
-        o = _oidc()
-        o.providers.append(_provider())
-        monkeypatch.setenv("KLANGK_AUTH_MODES", "none")
-        # Rebuild so settings reflects the mode change
-        o = _oidc()
+    def test_none_mode_ignores_oidc_config(self):
+        o = _oidc(make_settings({"KLANGK_AUTH_MODES": "none"}))
         o.providers.append(_provider())
         assert o.auth_modes() == "none"
         assert o.local_login_allowed()
 
-    def test_local_login_false_in_other_modes(self, monkeypatch):
+    def test_local_login_false_in_other_modes(self):
         for mode in ("password", "oidc", "both"):
-            monkeypatch.setenv("KLANGK_AUTH_MODES", mode)
-            o = _oidc()
+            o = _oidc(make_settings({"KLANGK_AUTH_MODES": mode}))
             assert not o.local_login_allowed()
 
     # --- AUTH_MODES unset defaults to ``none`` (no amalgamated setting) ---
 
-    def test_unset_defaults_to_none(self, monkeypatch):
-        monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
+    def test_unset_defaults_to_none(self):
         o = _oidc()
         assert o.auth_modes() == "none"
         assert o.local_login_allowed()
         assert not o.password_login_allowed()
 
-    def test_unset_stays_none_with_oidc_configured(self, monkeypatch):
-        monkeypatch.delenv("KLANGK_AUTH_MODES", raising=False)
+    def test_unset_stays_none_with_oidc_configured(self):
         o = _oidc()
         assert o.auth_modes() == "none"
         o.providers.append(_provider())
@@ -812,69 +798,74 @@ class TestParseHookValue:
 
 
 class TestLoadLoginHook:
-    def test_no_hook_when_not_set(self, monkeypatch):
-        monkeypatch.delenv("KLANGK_OIDC_LOGIN_HOOK", raising=False)
+    def test_no_hook_when_not_set(self):
         o = _oidc()
         o.load_login_hook()
         assert o.login_hook is None
 
-    def test_hook_loaded_from_file(self, monkeypatch, tmp_path):
+    def test_hook_loaded_from_file(self, tmp_path):
         hook_file = tmp_path / "myhook.py"
         hook_file.write_text(
             "def on_login(provider, claims, email, tokens):\n"
             "    return {'testers'}\n"
         )
-        monkeypatch.setenv("KLANGK_OIDC_LOGIN_HOOK", str(hook_file))
-        o = _oidc()
+        o = _oidc(make_settings({"KLANGK_OIDC_LOGIN_HOOK": str(hook_file)}))
         o.load_login_hook()
         assert o.login_hook is not None
         assert o.login_hook(None, {}, "", {}) == {"testers"}
 
-    def test_hook_loaded_with_custom_func_name(self, monkeypatch, tmp_path):
+    def test_hook_loaded_with_custom_func_name(self, tmp_path):
         hook_file = tmp_path / "myhook.py"
         hook_file.write_text(
             "def check(provider, claims, email, tokens):\n"
             "    return {'admins'}\n"
         )
-        monkeypatch.setenv("KLANGK_OIDC_LOGIN_HOOK", f"{hook_file}:check")
-        o = _oidc()
+        o = _oidc(
+            make_settings({"KLANGK_OIDC_LOGIN_HOOK": f"{hook_file}:check"})
+        )
         o.load_login_hook()
         assert o.login_hook is not None
         assert o.login_hook(None, {}, "", {}) == {"admins"}
 
-    def test_async_hook_detected(self, monkeypatch, tmp_path):
+    def test_async_hook_detected(self, tmp_path):
         hook_file = tmp_path / "myhook.py"
         hook_file.write_text(
             "async def on_login(provider, claims, email, tokens):\n"
             "    return None\n"
         )
-        monkeypatch.setenv("KLANGK_OIDC_LOGIN_HOOK", str(hook_file))
-        o = _oidc()
+        o = _oidc(make_settings({"KLANGK_OIDC_LOGIN_HOOK": str(hook_file)}))
         o.load_login_hook()
         assert o.login_hook_is_async is True
 
-    def test_file_not_found(self, monkeypatch):
-        monkeypatch.setenv("KLANGK_OIDC_LOGIN_HOOK", "/nonexistent/hook.py")
+    def test_file_not_found(self):
         with pytest.raises(ConfigurationError, match="file not found"):
-            _oidc().load_login_hook()
+            _oidc(
+                make_settings(
+                    {"KLANGK_OIDC_LOGIN_HOOK": "/nonexistent/hook.py"}
+                )
+            ).load_login_hook()
 
-    def test_func_not_found(self, monkeypatch, tmp_path):
+    def test_func_not_found(self, tmp_path):
         hook_file = tmp_path / "myhook.py"
         hook_file.write_text("x = 1\n")
-        monkeypatch.setenv("KLANGK_OIDC_LOGIN_HOOK", f"{hook_file}:missing")
         with pytest.raises(
             ConfigurationError, match="not found or not callable"
         ):
-            _oidc().load_login_hook()
+            _oidc(
+                make_settings(
+                    {"KLANGK_OIDC_LOGIN_HOOK": f"{hook_file}:missing"}
+                )
+            ).load_login_hook()
 
-    def test_not_callable(self, monkeypatch, tmp_path):
+    def test_not_callable(self, tmp_path):
         hook_file = tmp_path / "myhook.py"
         hook_file.write_text("on_login = 42\n")
-        monkeypatch.setenv("KLANGK_OIDC_LOGIN_HOOK", str(hook_file))
         with pytest.raises(
             ConfigurationError, match="not found or not callable"
         ):
-            _oidc().load_login_hook()
+            _oidc(
+                make_settings({"KLANGK_OIDC_LOGIN_HOOK": str(hook_file)})
+            ).load_login_hook()
 
 
 class TestCallLoginHook:

--- a/src/backend/tests/test_ssl_trust.py
+++ b/src/backend/tests/test_ssl_trust.py
@@ -108,7 +108,6 @@ class TestApplyBackendSslTrust:
         cert_dir = tmp_path / "ssl"
         cert_dir.mkdir()
         (cert_dir / "corp-ca.pem").write_text("FAKE-CORP-CA\n")
-        monkeypatch.setenv("KLANGK_SSL_CERT_DIR", str(cert_dir))
         monkeypatch.setattr(
             ssl_trust,
             "system_ca_bundle",
@@ -140,7 +139,6 @@ class TestApplyBackendSslTrust:
         cert_dir = tmp_path / "ssl"
         cert_dir.mkdir()
         (cert_dir / "corp-ca.crt").write_text("CORP\n")
-        monkeypatch.setenv("KLANGK_SSL_CERT_DIR", str(cert_dir))
         monkeypatch.setattr(
             ssl_trust,
             "system_ca_bundle",
@@ -171,7 +169,6 @@ class TestApplyBackendSslTrust:
         cert_dir = tmp_path / "ssl"
         cert_dir.mkdir()
         (cert_dir / "corp-ca.pem").write_text("CORP\n")
-        monkeypatch.setenv("KLANGK_SSL_CERT_DIR", str(cert_dir))
         monkeypatch.setattr(
             ssl_trust,
             "system_ca_bundle",
@@ -205,7 +202,6 @@ class TestApplyBackendSslTrust:
         cert_dir = tmp_path / "ssl"
         cert_dir.mkdir()
         (cert_dir / "corp-ca.pem").write_text("CORP\n")
-        monkeypatch.setenv("KLANGK_SSL_CERT_DIR", str(cert_dir))
         monkeypatch.setattr(ssl_trust, "system_ca_bundle", lambda **kw: None)
         s = _settings(
             {
@@ -332,8 +328,6 @@ class TestInternalsAndErrorBranches:
         cert_dir = tmp_path / "ssl"
         cert_dir.mkdir()
         (cert_dir / "c.pem").write_text("C")
-        monkeypatch.setenv("KLANGK_SSL_CERT_DIR", str(cert_dir))
-        monkeypatch.setenv("KLANGK_DATA_DIR", str(tmp_path / "data"))
         monkeypatch.setattr(
             ssl_trust.os,
             "makedirs",
@@ -354,8 +348,6 @@ class TestInternalsAndErrorBranches:
     def test_apply_warns_on_empty_bundle(self, monkeypatch, tmp_path, caplog):
         cert_dir = tmp_path / "ssl"
         cert_dir.mkdir()
-        monkeypatch.setenv("KLANGK_SSL_CERT_DIR", str(cert_dir))
-        monkeypatch.setenv("KLANGK_DATA_DIR", str(tmp_path / "data"))
         monkeypatch.setattr(
             ssl_trust, "system_ca_bundle", lambda self_bundle=None: None
         )


### PR DESCRIPTION
Closes #1457.

## What

Replaced the `monkeypatch.setenv`/`delenv`/`os.environ[...]` reacharound for configuring `KlangkSettings` fields with explicit `make_settings(env={...})` construction across **8 test files** (−94 settings-mutation call sites). Tests now say what they configure:

```python
# Before (opaque reacharound via process env):
monkeypatch.setenv("KLANGK_AUTH_MODES", "oidc")
settings = _settings()  # reads os.environ

# After (explicit):
settings = make_settings({"KLANGK_AUTH_MODES": "oidc"})
```

## Files converted

| File | Sites | Pattern |
|---|---:|---|
| `test_oidc.py` | 40 | `_oidc()` helper now takes explicit settings; removed `_settings()` os.environ reader |
| `test_main.py` | 32 | Seed/lifespan tests — `make_settings(os.environ)` → `make_settings({...})`; lifespan monkeypatches were inert dead code (registry built from `make_settings({})`) |
| `test_mode_switching.py` | ~15 | `mode_server` fixture + `_none()`/`_password()` helpers — explicit settings dicts |
| `test_container.py` | 8 | Registry tests — inert `delenv` removed; `KLANGK_SSL_CERT_DIR` test **fixed** (was silently broken: setenv was inert against a `make_settings({})` registry) |
| `test_auth.py` | 2 | Deleted the `importlib.reload` + `os.environ` lockout dance (obsolete since #1515 — Auth reads from settings at construction) |
| `test_api.py` | 6 | `seed_agent_user(make_settings({}))`; removed inert `LOGO_URL` delenv |
| `test_ssl_trust.py` | 8 | Removed redundant `setenv` (every test already built explicit `_settings({...})`) |
| `conftest.py` | 1 | Deleted the autouse `_default_auth_mode` fixture (`KLANGK_AUTH_MODES=password`); `app_state` fixture now builds explicit `make_settings({...})` |

## Bug found & fixed

`test_container.py::test_no_ssl_trust_when_dir_has_no_certs` was silently broken: it did `monkeypatch.setenv("KLANGK_SSL_CERT_DIR", str(ssl_dir))` but the registry was built from `make_settings({})` (which doesn't read `os.environ`), so the cert dir was never seen — the test passed for the wrong reason ("no cert dir" rather than "cert dir with no certs"). Now patches `self.registry.settings` directly so `ssl_cert_dir()` actually evaluates the empty dir.

## Remaining `KLANGK_*` monkeypatch sites (all legitimate)

These are **not** `KlangkSettings` field configuration and are correctly left as-is:

- **`_KLANGK_DISABLE_NGINX`** (`conftest.py`, `test_nginx.py`) — plain debug flag, read via `os.environ.get` directly (per AGENTS.md), not a settings field.
- **`test_setup_pi.py`** (10 sites) — `klangk-setup-pi.py` is a standalone container script that reads `KLANGK_LLM_MODEL`/`KLANGK_LLM_PROXY_URL` via `os.environ.get` directly, not through `KlangkSettings`.
- **`test_terminal.py`** (2 sites) — tests that the terminal **strips** sensitive env vars from the child process; must set them in `os.environ` to test the stripping.
- **`test_settings.py`** (1 site) — tests that `make_settings({})` **ignores** `os.environ` (the isolation property itself).
- **`conftest.py` `temp_data_dir`** (4 sites) — per-test temp-dir infrastructure (`KLANGK_DATA_DIR`/`STATE_DIR`/`CUSTOMIZE_DIR`) consumed by the DB construction inside the fixture; the "code not yet migrated" case the issue hedges.

## Acceptance

- [x] No `monkeypatch.setenv`/`delenv`/`os.environ[...]` in `src/backend/tests/` used to configure `KlangkSettings` **fields** (auth_modes, oidc_config, agent_email, default_user, ssl_cert_dir, etc.) — all gone.
- [x] The `password,oidc` invalid value — already fixed during #1455 (verified: `test_template_keys_off_listen_not_auth` uses `"both"` via `make_settings(env={...})`).
- [x] Backend suite: 2379 passed, 100% coverage, `-n auto`.
