### PR TITLE
Fix NginxWatchdog leaking worker processes on unclean shutdown (#1533)

### DIFF
--- a/src/backend/e2e-tests/test_nginx_lifecycle_e2e.py
+++ b/src/backend/e2e-tests/test_nginx_lifecycle_e2e.py
@@ -1,13 +1,16 @@
-"""End-to-end test: nginx dies when klangkd dies (#1439).
+"""End-to-end test: nginx dies when klangkd dies (#1439, #1533).
 
-klangkd spawns nginx as a child. Before #1439, nginx ran in its own
-session (``start_new_session=True``), so a hard kill of klangkd orphaned
-it. After #1439, nginx runs in klangkd's process group and dies with it.
+klangkd spawns nginx in its own session (``setsid`` via ``preexec_fn``)
+with ``PR_SET_PDEATHSIG(SIGTERM)`` so the kernel auto-signals nginx when
+klangkd exits. ``stop()`` uses ``os.killpg`` for clean shutdown. The
+combination ensures nginx (master + workers) dies with klangkd under
+SIGTERM, SIGINT, and SIGKILL.
 
 Run with: devenv shell -- test-backend-e2e test_nginx_lifecycle_e2e.py
 """
 
 import os
+import signal
 import subprocess
 import tempfile
 import time
@@ -82,32 +85,58 @@ def _start_klangkd():
     return proc, nginx_port
 
 
+def _wait_for_port_closed(port, timeout=10):
+    """Wait until nothing is listening on localhost:port."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if not _port_listening(port):
+            return True
+        time.sleep(0.3)
+    return False
+
+
+def _signal_test(sig):
+    """Start klangkd + nginx, send *sig*, assert nginx port closes."""
+    proc, nginx_port = _start_klangkd()
+    try:
+        ok = _wait_for_nginx(nginx_port)
+        if not ok:
+            proc.kill()
+            out, _ = proc.communicate(timeout=5)
+            pytest.fail(
+                f"klangkd did not start:\n"
+                f"{out.decode(errors='replace')[:2000]}"
+            )
+
+        assert _port_listening(nginx_port), "nginx not serving"
+
+        os.kill(proc.pid, sig)
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+
+        assert _wait_for_port_closed(nginx_port), (
+            f"nginx port still listening after {signal.Signals(sig).name}"
+        )
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait()
+
+
 class TestNginxDiesWithKlangkd:
-    """nginx must not outlive klangkd (#1439)."""
+    """nginx must not outlive klangkd (#1439, #1533)."""
 
     def test_nginx_stops_on_sigterm(self):
         """Graceful shutdown (SIGTERM) stops nginx."""
-        proc, nginx_port = _start_klangkd()
-        try:
-            ok = _wait_for_nginx(nginx_port)
-            if not ok:
-                proc.kill()
-                out, _ = proc.communicate(timeout=5)
-                pytest.fail(
-                    f"klangkd did not start:\n"
-                    f"{out.decode(errors='replace')[:2000]}"
-                )
+        _signal_test(signal.SIGTERM)
 
-            assert _port_listening(nginx_port), "nginx not serving"
+    def test_nginx_stops_on_sigint(self):
+        """Keyboard interrupt (SIGINT) stops nginx."""
+        _signal_test(signal.SIGINT)
 
-            proc.terminate()
-            proc.wait(timeout=10)
-            time.sleep(1)
-
-            assert not _port_listening(nginx_port), (
-                "nginx port still listening after SIGTERM"
-            )
-        finally:
-            if proc.poll() is None:
-                proc.kill()
-                proc.wait()
+    def test_nginx_stops_on_sigkill(self):
+        """Hard kill (SIGKILL) — PR_SET_PDEATHSIG fires, nginx exits."""
+        _signal_test(signal.SIGKILL)

--- a/src/backend/klangk_backend/nginx.py
+++ b/src/backend/klangk_backend/nginx.py
@@ -25,11 +25,15 @@ settings.
 from __future__ import annotations
 
 import asyncio
+import ctypes
+import ctypes.util
 import ipaddress
 import logging
 import os
+import signal
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 from .settings import (
@@ -576,6 +580,31 @@ http {{
         return "/usr/sbin/nginx"
 
 
+_PR_SET_PDEATHSIG = 1
+_HAS_PDEATHSIG = sys.platform == "linux"
+if _HAS_PDEATHSIG:
+    _libc = ctypes.CDLL(
+        ctypes.util.find_library("c") or "libc.so.6", use_errno=True
+    )
+
+
+def _nginx_preexec() -> None:  # pragma: no cover  – runs in forked child
+    """New session (for killpg) + auto-SIGTERM when parent dies (#1533).
+
+    ``os.setsid()`` puts nginx in its own process group so ``stop()`` can
+    ``os.killpg`` the entire tree on clean shutdown.
+
+    On Linux, ``prctl(PR_SET_PDEATHSIG, SIGTERM)`` asks the kernel to send
+    SIGTERM to the nginx master if klangkd dies without calling ``stop()``
+    (e.g. SIGKILL).  nginx handles SIGTERM by forwarding SIGQUIT to its
+    workers, so the whole tree exits.  macOS has no equivalent; on unclean
+    shutdown, orphaned nginx processes must be cleaned up externally.
+    """
+    os.setsid()
+    if _HAS_PDEATHSIG:
+        _libc.prctl(_PR_SET_PDEATHSIG, signal.SIGTERM)
+
+
 class NginxWatchdog:
     """Owns the nginx child process and its supervision task (#1463).
 
@@ -599,8 +628,9 @@ class NginxWatchdog:
         """Spawn nginx and respawn it on unexpected exit (with backoff).
 
         Exits cleanly when ``_stopping`` is set (a cooperative shutdown).
-        nginx runs in klangkd's process group (no ``start_new_session``) so
-        it is killed automatically when klangkd is terminated (#1439).
+        ``_nginx_preexec`` puts nginx in its own session (for ``os.killpg``
+        on clean shutdown) and sets ``PR_SET_PDEATHSIG(SIGTERM)`` so the
+        kernel auto-signals nginx if klangkd dies uncleanly (#1533).
         """
         backoff = 1.0
         while not self._stopping:
@@ -612,6 +642,7 @@ class NginxWatchdog:
                 conf_path,
                 stdout=None,
                 stderr=None,
+                preexec_fn=_nginx_preexec,
             )
             logger.info(
                 "nginx started (pid %d) with %s", self._proc.pid, conf_path
@@ -659,17 +690,27 @@ class NginxWatchdog:
         self._task = asyncio.create_task(self._watch(bin_path, conf_path))
 
     async def stop(self) -> None:
-        """Stop nginx and cancel the watchdog (cooperative: waits for exit)."""
+        """Stop nginx and cancel the watchdog (cooperative: waits for exit).
+
+        Kills the entire process group (master + workers) so no orphaned
+        workers linger after shutdown (#1533).
+        """
         self._stopping = True
         proc = self._proc
         # The proc-kill branch is only reached when nginx was spawned (UDS
         # mode); covered via TestStopWatchdog + the e2e ACL teardown.
         if proc is not None and proc.returncode is None:
-            proc.terminate()
+            try:
+                os.killpg(proc.pid, signal.SIGTERM)
+            except (ProcessLookupError, PermissionError):
+                proc.terminate()
             try:
                 await asyncio.wait_for(proc.wait(), timeout=5)
             except asyncio.TimeoutError:
-                proc.kill()
+                try:
+                    os.killpg(proc.pid, signal.SIGKILL)
+                except (ProcessLookupError, PermissionError):
+                    proc.kill()
         self._proc = None
         task = self._task
         # Same: only when a watchdog task was created (UDS mode).

--- a/src/backend/tests/test_nginx.py
+++ b/src/backend/tests/test_nginx.py
@@ -6,6 +6,7 @@ real nginx — the runtime ACL enforcement is covered by the e2e suite
 """
 
 import asyncio
+from unittest.mock import Mock
 
 import pytest
 
@@ -544,12 +545,43 @@ class TestStopWatchdog:
         assert wd._stopping is True
 
     @pytest.mark.asyncio
-    async def test_stops_terminates_running_proc(self):
-        """A still-running nginx proc is terminated, then awaited."""
+    async def test_stops_terminates_running_proc(self, monkeypatch):
+        """A still-running nginx proc is killed via os.killpg (SIGTERM)."""
+        import signal
 
-        terminated = []
+        killpg_calls = []
+        monkeypatch.setattr(
+            "os.killpg", lambda pgid, sig: killpg_calls.append((pgid, sig))
+        )
 
         class FakeProc:
+            pid = 12345
+            returncode = None
+
+            def terminate(self):
+                pass  # pragma: no cover
+
+            def kill(self):
+                pass  # pragma: no cover
+
+            async def wait(self):
+                return 0
+
+        wd = _wd(make_settings({}))
+        wd._proc = FakeProc()
+        await wd.stop()
+        assert killpg_calls == [(12345, signal.SIGTERM)]
+        assert wd._proc is None
+
+    @pytest.mark.asyncio
+    async def test_stops_falls_back_to_terminate(self, monkeypatch):
+        """Falls back to proc.terminate() when killpg raises."""
+
+        terminated = []
+        monkeypatch.setattr("os.killpg", Mock(side_effect=ProcessLookupError))
+
+        class FakeProc:
+            pid = 12345
             returncode = None
 
             def terminate(self):
@@ -584,16 +616,71 @@ class TestStopWatchdog:
 
     @pytest.mark.asyncio
     async def test_stops_kills_on_timeout(self, monkeypatch):
-        """If the proc doesn't exit within the timeout, kill() follows."""
-        import klangk_backend.main as main
+        """If the proc doesn't exit within the timeout, SIGKILL via killpg."""
+        import signal
+
+        import klangk_backend.nginx as nginx_mod
 
         actions = []
 
+        def fake_killpg(pgid, sig):
+            actions.append(("killpg", sig))
+
+        monkeypatch.setattr("os.killpg", fake_killpg)
+
         class HungProc:
+            pid = 99999
             returncode = None
 
             def terminate(self):
-                actions.append("terminate")
+                actions.append("terminate")  # pragma: no cover
+
+            def kill(self):
+                actions.append("kill")  # pragma: no cover
+
+            async def wait(self):
+                await asyncio.sleep(100)
+                return 0
+
+        async def _fake_wait_for(coro, timeout):
+            coro.close()
+            raise asyncio.TimeoutError()
+
+        monkeypatch.setattr(nginx_mod.asyncio, "wait_for", _fake_wait_for)
+        wd = _wd(make_settings({}))
+        wd._proc = HungProc()
+        await wd.stop()
+        assert actions == [
+            ("killpg", signal.SIGTERM),
+            ("killpg", signal.SIGKILL),
+        ]
+        assert wd._proc is None
+
+    @pytest.mark.asyncio
+    async def test_stops_kills_fallback_on_timeout(self, monkeypatch):
+        """Falls back to proc.kill() when killpg SIGKILL raises."""
+        import signal
+
+        import klangk_backend.nginx as nginx_mod
+
+        actions = []
+        call_count = [0]
+
+        def fake_killpg(pgid, sig):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                actions.append(("killpg", sig))
+            else:
+                raise ProcessLookupError
+
+        monkeypatch.setattr("os.killpg", fake_killpg)
+
+        class HungProc:
+            pid = 99999
+            returncode = None
+
+            def terminate(self):
+                actions.append("terminate")  # pragma: no cover
 
             def kill(self):
                 actions.append("kill")
@@ -606,9 +693,9 @@ class TestStopWatchdog:
             coro.close()
             raise asyncio.TimeoutError()
 
-        monkeypatch.setattr(main.asyncio, "wait_for", _fake_wait_for)
+        monkeypatch.setattr(nginx_mod.asyncio, "wait_for", _fake_wait_for)
         wd = _wd(make_settings({}))
         wd._proc = HungProc()
         await wd.stop()
-        assert actions == ["terminate", "kill"]
+        assert actions == [("killpg", signal.SIGTERM), "kill"]
         assert wd._proc is None


### PR DESCRIPTION
## Summary

- Adds `preexec_fn` to nginx spawn that calls `os.setsid()` (own process group) + `prctl(PR_SET_PDEATHSIG, SIGTERM)` (kernel auto-kills nginx when klangkd dies)
- `stop()` uses `os.killpg(pid, SIGTERM)` to kill the entire process group (master + workers), falling back to `proc.terminate()` if the group is gone
- Timeout escalation uses `os.killpg(pid, SIGKILL)` with fallback to `proc.kill()`
- `PR_SET_PDEATHSIG` is Linux-only; gated by `sys.platform == "linux"`. On macOS, only the `killpg` clean-shutdown path applies

### How it works

| Scenario | Mechanism |
|---|---|
| Clean shutdown (SIGTERM/SIGINT to klangkd) | `stop()` → `os.killpg(SIGTERM)` kills master + workers |
| Unclean shutdown (SIGKILL to klangkd) | Kernel delivers `SIGTERM` to nginx master via `PR_SET_PDEATHSIG`; nginx master forwards `SIGQUIT` to workers |

## Test plan

- [x] 2381 unit tests pass, 100% coverage
- [x] 97 e2e tests pass
- [x] `test_nginx_stops_on_sigterm` — nginx port closes after SIGTERM
- [x] `test_nginx_stops_on_sigint` — nginx port closes after SIGINT
- [x] `test_nginx_stops_on_sigkill` — nginx port closes after SIGKILL (PR_SET_PDEATHSIG)
- [x] Unit tests for killpg, fallback to terminate, timeout escalation

Closes #1533
