### PR TITLE
Squash all warnings across all test suites (#1493)

### DIFF
--- a/src/backend/e2e-tests/_e2e_env.py
+++ b/src/backend/e2e-tests/_e2e_env.py
@@ -16,6 +16,27 @@ actually run.
 from __future__ import annotations
 
 import os
+from subprocess import Popen
+
+
+def close_popen_pipes(proc: Popen) -> None:
+    """Close a Popen's captured stdout/stderr pipes.
+
+    E2E server fixtures capture the child's combined output on a
+    ``stdout=PIPE`` pipe to surface its log on failure. The
+    ``_io.BufferedReader`` that backs ``proc.stdout`` is *not* closed by
+    ``proc.kill()/wait()``; leaving it open leaks an fd until GC, which
+    surfaces as ``ResourceWarning: unclosed file`` in the suite's
+    warnings summary (#1493). Call this at the end of every fixture's
+    teardown after the log has been drained.
+    """
+    for stream in (proc.stdout, proc.stderr):
+        if stream is not None:
+            try:
+                stream.close()
+            except Exception:
+                pass
+
 
 # Prefixes whose vars are stripped: any env var starting with one of these
 # (case-insensitive) is config or debug state that must not leak from the

--- a/src/backend/e2e-tests/test_agent_home_e2e.py
+++ b/src/backend/e2e-tests/test_agent_home_e2e.py
@@ -40,7 +40,7 @@ import pytest
 import websockets
 
 from klangk_backend.model import free_port
-from _e2e_env import clean_env
+from _e2e_env import clean_env, close_popen_pipes
 
 # Default agent handle (see model/users.py: _DEFAULT_AGENT_HANDLE).  Not
 # imported from the backend to keep the e2e test decoupled from the
@@ -133,6 +133,7 @@ def server():
             sys.stderr.write(
                 f"\n=== agent-home-e2e server log ===\n{server_log}\n===\n"
             )
+    close_popen_pipes(proc)
     _rm_containers(instance_id)
     shutil.rmtree(data_dir, ignore_errors=True)
 

--- a/src/backend/e2e-tests/test_api_e2e.py
+++ b/src/backend/e2e-tests/test_api_e2e.py
@@ -17,7 +17,7 @@ import httpx
 import pytest
 
 from klangk_backend.model import free_port
-from _e2e_env import clean_env
+from _e2e_env import clean_env, close_popen_pipes
 
 
 def _start_server(data_dir, port):
@@ -73,6 +73,7 @@ def _stop_server(proc, data_dir):
         proc.wait(timeout=5)
     except (ProcessLookupError, subprocess.TimeoutExpired):
         pass
+    close_popen_pipes(proc)
     instance_id = subprocess.run(
         ["klangk-instance-id"],
         capture_output=True,

--- a/src/backend/e2e-tests/test_event_fanout.py
+++ b/src/backend/e2e-tests/test_event_fanout.py
@@ -26,7 +26,7 @@ import pytest
 import websockets
 
 from klangk_backend.model import free_port
-from _e2e_env import clean_env
+from _e2e_env import clean_env, close_popen_pipes
 
 
 @pytest.fixture(scope="module")
@@ -102,6 +102,7 @@ def server():
             sys.stderr.write(
                 f"\n=== Fanout server log ===\n{server_log}\n===\n"
             )
+    close_popen_pipes(proc)
     result = subprocess.run(
         [
             "podman",

--- a/src/backend/e2e-tests/test_health_check_e2e.py
+++ b/src/backend/e2e-tests/test_health_check_e2e.py
@@ -27,7 +27,7 @@ import pytest
 import websockets
 
 from klangk_backend.model import free_port
-from _e2e_env import clean_env
+from _e2e_env import clean_env, close_popen_pipes
 
 
 @pytest.fixture(scope="module")
@@ -100,6 +100,7 @@ def server():
             sys.stderr.write(
                 f"\n=== Health e2e server log ===\n{server_log}\n===\n"
             )
+    close_popen_pipes(proc)
     result = subprocess.run(
         [
             "podman",

--- a/src/backend/e2e-tests/test_nginx_acl_e2e.py
+++ b/src/backend/e2e-tests/test_nginx_acl_e2e.py
@@ -19,7 +19,7 @@ import httpx
 import pytest
 
 from klangk_backend.model import free_port
-from _e2e_env import clean_env
+from _e2e_env import clean_env, close_popen_pipes
 
 BACKEND_DIR = os.path.join(os.path.dirname(__file__), "..")
 
@@ -475,6 +475,8 @@ class TestNginxAclEnforcement:
         nginx_proc.wait(timeout=5)
         backend_proc.kill()
         backend_proc.wait(timeout=5)
+        close_popen_pipes(nginx_proc)
+        close_popen_pipes(backend_proc)
 
     def test_regular_endpoint_allowed(self, nginx_stack):
         """Regular endpoints (/) are not ACL-gated and should work."""
@@ -647,6 +649,8 @@ class TestNginxDenyByDefault:
         nginx_proc.wait(timeout=5)
         backend_proc.kill()
         backend_proc.wait(timeout=5)
+        close_popen_pipes(nginx_proc)
+        close_popen_pipes(backend_proc)
 
     def test_api_denied_from_container_ip(self, stack):
         """From the container source IP, a non-container /api/v1 path is

--- a/src/backend/e2e-tests/test_nginx_lifecycle_e2e.py
+++ b/src/backend/e2e-tests/test_nginx_lifecycle_e2e.py
@@ -19,7 +19,7 @@ import httpx
 import pytest
 
 from klangk_backend.model import free_port
-from _e2e_env import clean_env
+from _e2e_env import clean_env, close_popen_pipes
 
 BACKEND_DIR = os.path.join(os.path.dirname(__file__), "..")
 
@@ -124,6 +124,7 @@ def _signal_test(sig):
         if proc.poll() is None:
             proc.kill()
             proc.wait()
+        close_popen_pipes(proc)
 
 
 class TestNginxDiesWithKlangkd:

--- a/src/backend/e2e-tests/test_per_user_home.py
+++ b/src/backend/e2e-tests/test_per_user_home.py
@@ -22,7 +22,7 @@ import pytest
 import websockets
 
 from klangk_backend.model import free_port
-from _e2e_env import clean_env
+from _e2e_env import clean_env, close_popen_pipes
 
 
 @pytest.fixture(scope="module")
@@ -94,6 +94,7 @@ def server():
             sys.stderr.write(
                 f"\n=== Home E2E server log ===\n{server_log}\n===\n"
             )
+    close_popen_pipes(proc)
     result = subprocess.run(
         [
             "podman",

--- a/src/backend/e2e-tests/test_service_command_shared_e2e.py
+++ b/src/backend/e2e-tests/test_service_command_shared_e2e.py
@@ -36,7 +36,7 @@ import pytest
 import websockets
 
 from klangk_backend.model import free_port
-from _e2e_env import clean_env
+from _e2e_env import clean_env, close_popen_pipes
 
 
 @pytest.fixture(scope="module")
@@ -102,6 +102,7 @@ def server():
             sys.stderr.write(
                 f"\n=== dcmd-shared server log ===\n{server_log}\n===\n"
             )
+    close_popen_pipes(proc)
     result = subprocess.run(
         [
             "podman",

--- a/src/backend/e2e-tests/test_sighup_restart_e2e.py
+++ b/src/backend/e2e-tests/test_sighup_restart_e2e.py
@@ -33,7 +33,7 @@ import pytest
 import websockets
 
 from klangk_backend.model import free_port
-from _e2e_env import clean_env
+from _e2e_env import clean_env, close_popen_pipes
 
 
 @pytest.fixture(scope="module")
@@ -106,6 +106,7 @@ def server():
             sys.stderr.write(
                 f"\n=== SIGHUP e2e server log ===\n{server_log}\n===\n"
             )
+    close_popen_pipes(proc)
     result = subprocess.run(
         [
             "podman",
@@ -208,12 +209,15 @@ async def test_websocket_closed_with_1012_and_reconnects(server, auth):
 
         # The server closes every client with code 1012 ("service
         # restarted").  websockets raises ConnectionClosed on a
-        # server-initiated close; the code is on the exception.
+        # server-initiated close; the code is on the received close
+        # frame.  ``ConnectionClosed.code`` is deprecated in websockets
+        # >=13.1 (``rcvd`` is the received Close frame; None only if the
+        # peer hung up without a close frame, which can't carry 1012).
         closed = None
         try:
             await asyncio.wait_for(ws.recv(), timeout=60)
         except websockets.ConnectionClosed as exc:
-            closed = exc.code
+            closed = exc.rcvd.code if exc.rcvd is not None else None
         assert closed == 1012, f"expected close 1012, got {closed}"
     finally:
         await ws.close()

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -36,6 +36,15 @@ klangkd = "klangk_backend.klangkd:app"
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 addopts = "--capture=no --cov=klangk_backend --cov-report=term-missing --no-cov-on-fail --cov-fail-under=100 --timeout=60"
+# Treat new warnings as errors so they can't re-accumulate (#1493). The
+# two ignores are pre-existing mock-induced GC artifacts (MagicMock stubs
+# whose coroutine objects are collected in a later test) -- not real bugs
+# -- and are mirrored in the repo-root pyproject for the combined run.
+filterwarnings = [
+    "error",
+    "ignore::pytest.PytestUnraisableExceptionWarning",
+    "ignore:coroutine .* was never awaited:RuntimeWarning",
+]
 
 [tool.ruff]
 line-length = 79

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -3156,15 +3156,17 @@ class TestHealthMonitorDeath:
         )
         reg.states[st.workspace_id] = st
         reg._cid_to_wsid[st.container_id] = st.workspace_id
-        st.last_activity = (
-            time.time() - self.registry.idle_timeout_seconds - 100
-        )
+        st.last_activity = time.time() - reg.idle_timeout_seconds - 100
 
         try:
             reg.app_state.sockets.connections[sock] = SimpleNamespace(
                 user={"id": "u1", "email": "a@x"}
             )
-            with patch_podman(self.registry):
+            # Patch the registry that actually runs the cleanup loop
+            # (``reg``), not ``self.registry`` -- otherwise the real
+            # ``podman remove_container`` fires on a fake container id
+            # and its subprocess transport leaks (#1493).
+            with patch_podman(reg):
                 task = asyncio.create_task(reg.cleanup_idle_containers())
                 await asyncio.sleep(0.05)
                 reg.get_cleanup_wake().set()

--- a/src/backend/tests/test_main.py
+++ b/src/backend/tests/test_main.py
@@ -33,7 +33,9 @@ from klangk_backend.wshandler.session import WebSocketState
 def _make_app_state(settings=None):
     """Build a minimal app_state for tests."""
     if settings is None:
-        settings = make_settings({})
+        # Pin a default password so the lifespan's seed_default_user does
+        # not generate (and print) one to stderr on every boot (#1493).
+        settings = make_settings({"KLANGK_DEFAULT_PASSWORD": "test"})
     # Two-phase: shell first so owned instances can take app_state at
     # construction (#1426).
     app_state = types.SimpleNamespace(settings=settings)
@@ -90,10 +92,13 @@ class TestSeedDefaultUser:
         user = await model.get_user_by_email("seed-test")
         assert user is not None
 
-    async def test_generates_password_when_not_set(self, db):
+    async def test_generates_password_when_not_set(self, db, capsys):
         await main.seed_default_user(
             make_settings({"KLANGK_DEFAULT_USER": "gen-test"})
         )
+        # Swallow the incidental generated-password print to stderr
+        # (asserted explicitly by test_generated_password_printed_to_stderr).
+        capsys.readouterr()
         user = await model.get_user_by_email("gen-test")
         assert user is not None
         # User exists and is in the admin group

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -166,7 +166,7 @@ def _mock_terminal(alive=True):
     return t
 
 
-def _empty_async_generator():
+async def _empty_async_generator():
     """An async generator that yields nothing — the safe default for
     ``session.output`` on a bare ``AsyncMock()`` session (see
     ``_mock_terminal`` for why)."""
@@ -5864,7 +5864,7 @@ class TestTerminalController:
         app_state = _make_app_state()
         registry = app_state.container_registry
         ctrl, _, _ = self._controller(app_state=app_state)
-        session = AsyncMock()
+        session = _mock_terminal()
         ctrl.session = session
         with patch.object(registry, "record_activity") as rec:
             result = await ctrl.activate_session(session, 80, 24)

--- a/src/frontend/test/auth_service_test.dart
+++ b/src/frontend/test/auth_service_test.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
@@ -168,7 +167,7 @@ void main() {
     test('product_name is applied to Branding from /api/config', () async {
       testAuthHttpClientOverride = _bannerClient(productName: 'Acme Labs');
 
-      final service = AuthService();
+      AuthService();
       await Future.delayed(Duration.zero);
 
       expect(Branding.name, 'Acme Labs');
@@ -179,7 +178,7 @@ void main() {
       Branding.name = 'Stale';
       testAuthHttpClientOverride = _bannerClient();
 
-      final service = AuthService();
+      AuthService();
       await Future.delayed(Duration.zero);
 
       expect(Branding.name, 'Klangk');

--- a/src/frontend/test/ghostty_terminal_test.dart
+++ b/src/frontend/test/ghostty_terminal_test.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:flterm/flterm.dart';
-import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/src/frontend/test/login_page_test.dart
+++ b/src/frontend/test/login_page_test.dart
@@ -312,9 +312,7 @@ void main() {
         (tester) async {
       tester.view.physicalSize = const Size(1200, 2400);
       addTearDown(() => tester.view.resetPhysicalSize());
-      int callCount = 0;
       testAuthHttpClientOverride = MockClient((request) async {
-        callCount++;
         if (request.url.path.contains('login')) {
           return http.Response(
             jsonEncode({'detail': 'Account not verified'}),

--- a/src/frontend/test/workspace_settings_panel_test.dart
+++ b/src/frontend/test/workspace_settings_panel_test.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/material.dart';


### PR DESCRIPTION
## Summary

Squashes the warnings each test suite was emitting on a green run (#1493). A green suite that spews warnings is not green — these fix the warnings at the source rather than suppressing them, and add a `filterwarnings = ["error", ...]` gate to the backend suite so they can't silently re-accumulate.

## Backend unit suite (`src/backend/tests`)

Now passes clean under `-W error` with 100% coverage (verified stable across multiple runs). Three real warning sources fixed at the root:

- **`ResourceWarning: unclosed subprocess transport`** — `test_container.py::TestHealthMonitorDeath::test_idle_cleanup_emits_death_frame` called `patch_podman(self.registry)` but ran the cleanup loop on a *different* registry (`reg`), so the real `podman remove_container` fired on a fake container id and its subprocess transport leaked. Now patches `reg` (the registry actually used).
- **`Task exception was never retrieved` (`TypeError: 'async for' requires __aiter__, got generator`)** — `_empty_async_generator()` was declared as a plain `def` with `yield` (a *sync* generator, despite its name/docstring). Every `forward_output` task iterating it died with a `TypeError` that surfaced as an unretrieved task exception. Made it `async def`. Also switched `test_activate_session_wires_forward_task` from a bare `AsyncMock()` session (whose `output()` returns a coroutine, not an async iterable) to `_mock_terminal()`.
- **`Default admin password for ...` stderr spam** — `_make_app_state()` now pins `KLANGK_DEFAULT_PASSWORD` so the three lifespan-driven tests don't generate/print one on every boot; `test_generates_password_when_not_set` swallows its incidental print via `capsys` (the real print behavior is still asserted by its sibling `test_generated_password_printed_to_stderr`).

**Optional gate** — added a curated `filterwarnings = ["error", ...]` to `src/backend/pyproject.toml` (with the two documented mock-artifact ignores mirrored from the root config) so new warnings fail the build instead of re-accumulating.

## Backend e2e suite (`src/backend/e2e-tests`)

- **`DeprecationWarning: ConnectionClosed.code is deprecated`** (the one called out in the issue) — `test_sighup_restart_e2e.py` now uses `exc.rcvd.code` (deprecated in websockets ≥13.1).
- **`ResourceWarning: unclosed file <_io.BufferedReader>`** — every e2e server fixture used `Popen(stdout=PIPE)` but never closed `proc.stdout`. Added a shared `close_popen_pipes()` helper in `_e2e_env.py` and called it in all 10 fixture teardowns (sighup, agent_home, api, event_fanout, health_check, nginx_acl ×2 stacks, nginx_lifecycle, per_user_home, service_command_shared). Verified the sighup suite is now warning-free.

## Frontend (`src/frontend`)

`flutter analyze` went from **7 issues → 1** (the remaining `PLACEHOLDER` path warning is intentional — replaced by `import_plugins.py` and overridden by `pubspec_overrides.yaml`). Fixed: 2 unused imports, 3 unused local variables, 1 unnecessary import across 4 test files. All 902 `flutter test`s pass.

## CLI unit suite (`src/cli/tests`)

Already clean on default runs — the existing curated `filterwarnings` suppresses the two documented mock-induced GC artifacts (`PytestUnraisableExceptionWarning`, `coroutine .* was never awaited`). Left as-is; the `-W error` path is blocked by a racy `ws_shell` coroutine artifact that the existing ignores already cover on normal runs, and forcing it would risk CI flakiness for no real coverage gain.

## Verification

| Suite | Result |
| --- | --- |
| Backend unit (`-W error`, with coverage) | 2381 passed, 100% coverage, 0 warnings |
| Backend e2e (sighup) | 4 passed, 0 pytest warnings (was 1 DeprecationWarning + 1 ResourceWarning) |
| CLI unit (default, with coverage) | 486 passed, 100% coverage, 0 warnings |
| Frontend `flutter test` | 902 passed |
| Frontend `flutter analyze` | 1 issue (intentional `PLACEHOLDER`) |

Closes #1493.
