### PR TITLE
feat(settings): accept kebab-case config keys everywhere

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -27,6 +27,13 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **Config-file keys accept `snake_case` _and_ `kebab-case`:** every
+  `klangkd` config-file key may now be written in either form (`jwt_secret`
+  or `jwt-secret`, `nginx_port` or `nginx-port`, etc.) and resolves to the
+  same setting. Generalizes the dual-form lookup the OIDC provider dicts
+  already had to the whole config file; `snake_case` remains the
+  preferred/documented form (#1538).
+
 - **Construction-time `file:`/`cmd:` resolution:** `KlangkSettings` now
   resolves all `file:`/`cmd:`-prefixed field values once, at construction.
   A dangling reference (e.g. `file:/nonexistent`) fails fast at boot with

--- a/docs/reference/klangkd-config.md
+++ b/docs/reference/klangkd-config.md
@@ -34,6 +34,10 @@ Config-file keys map directly to `KLANGK_*` environment variable names with the 
 | `KLANGK_NGINX_PORT` | `nginx_port`    |
 | `KLANGK_AUTH_MODES` | `auth_modes`    |
 
+### `snake_case` or `kebab-case`
+
+Every config-file key accepts **either** `snake_case` or `kebab-case` — `jwt_secret` and `jwt-secret` resolve to the same setting, as do `nginx_port` / `nginx-port`, `auth_modes` / `auth-modes`, and so on ([#1538](https://github.com/mcdonc/klangk/issues/1538)). This matches the dual-form lookup the OIDC provider dicts already had and is forgiving of either style, but **`snake_case` is the preferred/documented form** — all examples in this chapter (and the field names they map to) use `snake_case`.
+
 ## `file:` and `cmd:` resolution
 
 Any value — whether from the config file or an env var — can use `file:` or `cmd:` prefixes to resolve secrets at **construction time** (not per-call at use time):

--- a/src/backend/klangk_backend/settings.py
+++ b/src/backend/klangk_backend/settings.py
@@ -33,7 +33,7 @@ import logging
 import os
 import subprocess
 from pathlib import Path
-from typing import ClassVar, Mapping
+from typing import Any, ClassVar, Mapping
 
 from pydantic_settings import (
     BaseSettings,
@@ -212,6 +212,34 @@ class _EnvDictSource(EnvSettingsSource):
         )
 
 
+class _KebabYamlConfigSettingsSource(YamlConfigSettingsSource):
+    """YAML config source that accepts kebab-case *and* snake_case keys.
+
+    The config file is documented in snake_case (matching the field names),
+    but klangk's wider config-file style is kebab-case (e.g. the CLI's
+    ``cli.yaml`` and the OIDC provider dicts).  pydantic-settings matches
+    config keys against snake_case field names only, so a bare
+    ``YamlConfigSettingsSource`` silently ignores hyphenated keys.  This
+    subclass normalizes top-level hyphenated keys (``nginx-port`` →
+    ``nginx_port``) so an operator may write **either** form for any key
+    (#1538); snake_case keys pass through unchanged.
+
+    Only **top-level** keys are normalized.  Nested mappings (the dicts inside
+    ``oidc_providers``) are left as-is — their dual-form lookup is already
+    handled by :func:`klangk_backend.oidc.get`, which checks kebab then snake.
+    """
+
+    def _read_file(self, file_path: Path) -> dict[str, Any]:
+        data = super()._read_file(file_path)
+        # Normalize only top-level keys: ``-`` → ``_`` so either form maps to
+        # the same snake_case field.  Nested values (e.g. oidc_providers
+        # dicts) are preserved verbatim.
+        return {
+            (key.replace("-", "_") if isinstance(key, str) else key): value
+            for key, value in data.items()
+        }
+
+
 class KlangkSettings(BaseSettings):
     """Typed configuration for all ``KLANGK_*`` environment variables.
 
@@ -305,7 +333,7 @@ class KlangkSettings(BaseSettings):
         path = cls._config_file_for_sources
         if path is not None and path != "none":
             sources.append(
-                YamlConfigSettingsSource(settings_cls, yaml_file=path)
+                _KebabYamlConfigSettingsSource(settings_cls, yaml_file=path)
             )
         # init_settings (kwargs passed to the constructor) wins over everything.
         sources.append(init_settings)

--- a/src/backend/tests/test_settings.py
+++ b/src/backend/tests/test_settings.py
@@ -160,6 +160,89 @@ class TestConfigFile:
 
 
 # ---------------------------------------------------------------------------
+# Dual-form keys: kebab-case *and* snake_case (config-file style, #1538)
+# ---------------------------------------------------------------------------
+
+
+class TestDualFormKeys:
+    """Every config-file key may be written in either snake_case or
+    kebab-case and resolve to the same field (#1538). snake_case remains the
+    documented/preferred form; kebab-case is accepted for backwards compat
+    and consistency with the wider config-file style (e.g. cli.yaml, OIDC
+    provider dicts). Top-level keys are normalized by
+    ``_KebabYamlConfigSettingsSource``; nested OIDC provider dicts are
+    handled separately by :func:`klangk_backend.oidc.get`."""
+
+    def test_kebab_case_key_loads(self, tmp_path):
+        """A hyphenated top-level key maps to its snake_case field."""
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text('nginx-port: "9999"\n')
+        s = make_settings({}, config_file=str(cfg))
+        assert s.nginx_port == "9999"
+
+    def test_snake_case_key_loads(self, tmp_path):
+        """snake_case (the documented form) still loads unchanged."""
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text('nginx_port: "7777"\n')
+        s = make_settings({}, config_file=str(cfg))
+        assert s.nginx_port == "7777"
+
+    def test_kebab_and_snake_resolve_same_field(self, tmp_path):
+        """Both forms populate the same field (not two different ones)."""
+        cfg_kebab = tmp_path / "kebab.yaml"
+        cfg_kebab.write_text('brand-color: "#111111"\n')
+        cfg_snake = tmp_path / "snake.yaml"
+        cfg_snake.write_text('brand_color: "#222222"\n')
+        s_kebab = make_settings({}, config_file=str(cfg_kebab))
+        s_snake = make_settings({}, config_file=str(cfg_snake))
+        assert s_kebab.brand_color == "#111111"
+        assert s_snake.brand_color == "#222222"
+
+    def test_multi_word_kebab_keys(self, tmp_path):
+        """Several multi-word keys accept kebab-case in one file."""
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(
+            'product-name: "Kebab"\n'
+            'trusted-proxy-cidrs: "10.0.0.0/8"\n'
+            'login-lockout-window: "600"\n'
+        )
+        s = make_settings({}, config_file=str(cfg))
+        assert s.product_name == "Kebab"
+        assert s.trusted_proxy_cidrs == "10.0.0.0/8"
+        assert s.login_lockout_window == "600"
+
+    def test_kebab_required_dir(self, tmp_path):
+        """state-dir (kebab) satisfies the required-dir validator."""
+        cfg = tmp_path / "config.yaml"
+        state = tmp_path / "state"
+        state.mkdir()
+        cfg.write_text(f'state-dir: "{state}"\n')
+        # Direct construction: env has no STATE_DIR, so the kebab key in the
+        # config file is the sole source (make_settings would inject one).
+        s = KlangkSettings(
+            env={"KLANGK_DATA_DIR": str(tmp_path / "data")},
+            config_file=str(cfg),
+        )
+        assert s.state_dir == str(state)
+
+    def test_nested_oidc_providers_not_normalized(self, tmp_path):
+        """Nested dicts (oidc_providers entries) are left verbatim — their
+        dual-form lookup is handled by oidc.get(), not the YAML source."""
+
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(
+            "oidc_providers:\n"
+            "  - id: cac\n"
+            "    client-id: klangk\n"
+            "    client-secret: sekret\n"
+        )
+        s = make_settings({}, config_file=str(cfg))
+        assert s.oidc_providers == [
+            {"id": "cac", "client-id": "klangk", "client-secret": "sekret"}
+        ]
+
+
+# ---------------------------------------------------------------------------
 # classify_listen / listen_is_socket (polymorphic KLANGK_LISTEN, #1422)
 # ---------------------------------------------------------------------------
 # KLANGK_LISTEN is polymorphic: a socket path or a TCP host (no port —


### PR DESCRIPTION
## Summary

Every `klangkd` config-file key now resolves in **either `snake_case` or `kebab-case`** — `jwt_secret` and `jwt-secret`, `nginx_port` and `nginx-port`, `auth_modes` and `auth-modes`, etc. — and populate the same setting. This closes #1538.

Previously only the OIDC provider dicts accepted both forms (via the `get()` helper); every other config key was read by pydantic-settings, which matches against snake_case field names only and silently ignored hyphenated keys.

`snake_case` remains the **preferred/documented** form; `kebab-case` is accepted for backwards compat and consistency with the wider config-file style. All examples in `docs/reference/klangkd-config.md` stay `snake_case`.

## How

`_KebabYamlConfigSettingsSource` — a `YamlConfigSettingsSource` subclass that normalizes **top-level** hyphenated keys (`-` → `_`) before pydantic matches them to field names. snake_case keys pass through unchanged. Nested mappings (the dicts inside `oidc_providers`) are left verbatim — their dual-form lookup is already handled by `klangk_backend.oidc.get`, which checks kebab then snake. Wired into `KlangkSettings.settings_customise_sources` in place of the bare `YamlConfigSettingsSource`.

## Changes

- `src/backend/klangk_backend/settings.py` — new `_KebabYamlConfigSettingsSource`; used by `settings_customise_sources`.
- `src/backend/tests/test_settings.py` — `TestDualFormKeys` covering kebab/snake resolution, multi-word keys, a kebab `state-dir` satisfying the required-dir validator, and that nested OIDC provider dicts are not normalized.
- `docs/reference/klangkd-config.md` — short note under "Key mapping" stating either form is accepted, snake_case preferred.
- `docs/changes.md` — changelog entry under `[Unreleased] / Added`.

## Tests

Full backend suite green with `-n auto` (the way CI runs it): **2387 passed, 100% coverage**, `settings.py` at 100%.

Closes #1538.
