### PR TITLE
refactor(backend): move OS socket probes from model/ports.py to util.py

### DIFF
--- a/src/backend/klangk_backend/model/ports.py
+++ b/src/backend/klangk_backend/model/ports.py
@@ -1,9 +1,36 @@
-"""TCP port allocation tracking and free-port discovery."""
+"""TCP port allocation tracking.
+
+OS-level socket probes (``port_in_use``, ``free_port``, ``scan_free_ports``)
+live in :mod:`klangk_backend.util` now (#1547); they are re-imported below so
+the historical ``model.ports.*`` / ``model.*`` import paths keep working.
+"""
 
 import asyncio
-import socket
 
+from ..util import (  # moved to util (#1547); re-exported via __all__
+    MAX_PORT,
+    free_port,
+    port_in_use,
+    scan_free_ports,
+)
 from .db import transaction
+
+
+__all__ = [
+    # OS-level socket probes — moved to klangk_backend.util (#1547);
+    # re-exported here so the historical model.ports.* / model.* import
+    # paths keep working.
+    "MAX_PORT",
+    "port_in_use",
+    "free_port",
+    "scan_free_ports",
+    # DB-backed allocation tracking (this module's primary purpose).
+    "add_port_allocations",
+    "find_and_allocate_ports",
+    "remove_port_allocations",
+    "get_workspace_ports",
+    "get_all_allocated_ports",
+]
 
 
 async def add_port_allocations(workspace_id: str, ports: list[int]) -> None:
@@ -14,69 +41,6 @@ async def add_port_allocations(workspace_id: str, ports: list[int]) -> None:
                 "INSERT INTO port_allocations (port, workspace_id) VALUES (?, ?)",
                 (port, workspace_id),
             )
-
-
-# Highest valid TCP port.  find_and_allocate_ports will not scan past
-# this, so an exhausted range fails fast instead of looping forever.
-MAX_PORT = 65535
-
-
-def port_in_use(port: int) -> bool:
-    """Check if a port is bound at the OS level."""
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        try:
-            s.bind(("0.0.0.0", port))
-            return False
-        except OSError:
-            return True
-
-
-def free_port() -> int:
-    """Return a free TCP port on loopback for ephemeral use.
-
-    Binds ``127.0.0.1:0`` so the OS assigns an ephemeral port, then
-    releases it and returns the number. Used by the E2E harnesses to
-    pick the server port (and to seed ``KLANGK_PORT_RANGE_START``)
-    instead of a hardcoded value, so concurrent runs — xdist workers,
-    or several suites on one machine — don't collide (#1393). This
-    generalizes the ``_find_free_port`` helper first introduced in
-    ``test_nginx_acl_e2e.py``.
-
-    The port is released before this returns, so there is an inherent
-    TOCTOU window before the caller rebinds it (e.g. uvicorn at server
-    startup, or a workspace container binding a hosted-app port). For
-    the workspace-port range the allocator's own :func:`port_in_use`
-    check (run inside :func:`scan_free_ports`) is the backstop: it skips
-    any port a concurrent run grabbed in the meantime.
-    """
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        # Loopback (not INADDR_ANY "") for ephemeral pickup — same
-        # free-port behavior, matches the test_nginx_acl_e2e pattern.
-        s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
-
-
-def scan_free_ports(start: int, count: int, used: set[int]) -> list[int]:
-    """Find ``count`` free ports at or after ``start``.
-
-    Skips ports already in ``used`` (DB-allocated) and ports reported as
-    bound by the OS.  This is synchronous because it performs blocking
-    ``socket.bind()`` checks; ``find_and_allocate_ports`` runs it in an
-    executor so the event loop is not stalled.  Raises ``ValueError`` if
-    fewer than ``count`` free ports are available before ``MAX_PORT``.
-    """
-    ports: list[int] = []
-    port = start
-    while len(ports) < count:
-        if port > MAX_PORT:
-            raise ValueError(
-                f"Could not allocate {count} free ports starting at "
-                f"{start}: exhausted at {MAX_PORT}"
-            )
-        if port not in used and not port_in_use(port):
-            ports.append(port)
-        port += 1
-    return ports
 
 
 async def find_and_allocate_ports(

--- a/src/backend/klangk_backend/util.py
+++ b/src/backend/klangk_backend/util.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import ipaddress
 import logging
+import socket
 import subprocess
 from typing import TypeVar
 
@@ -111,6 +112,84 @@ def sanitize_disposition_name(name: str) -> str:
     (double quotes, backslashes, path separators).
     """
     return name.replace("/", "_").replace("\\", "_").replace('"', "")
+
+
+# --- OS-level TCP port discovery (moved from model/ports.py, #1547) -----
+# These are pure socket probes — they never touch the DB, so they live in
+# util (next to the loopback / network-trust helpers) rather than in the
+# ``model`` persistence layer. ``model.ports`` re-exports them for back-compat.
+
+# Highest valid TCP port.  scan_free_ports will not scan past this, so an
+# exhausted range fails fast instead of looping forever.
+MAX_PORT = 65535
+
+
+def port_in_use(port: int) -> bool:
+    """Check if a port is bound at the OS level.
+
+    Binds ``0.0.0.0`` (all interfaces) deliberately: workspace host ports
+    are published by podman with no host IP, i.e. on ``0.0.0.0`` (see
+    ``podman.create``'s ``-p host:container``), so the probe must detect a
+    bind on *any* interface to predict a publish collision. Binding the
+    probe to loopback would miss ports held only on an external interface
+    and let the allocator hand out a port podman then fails to bind. This
+    is why CodeQL's ``py/bind-socket-all-network-interfaces`` (alert #155)
+    is a false positive here.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        try:
+            s.bind(("0.0.0.0", port))
+            return False
+        except OSError:
+            return True
+
+
+def free_port() -> int:
+    """Return a free TCP port on loopback for ephemeral use.
+
+    Binds ``127.0.0.1:0`` so the OS assigns an ephemeral port, then
+    releases it and returns the number. Used by the E2E harnesses to
+    pick the server port (and to seed ``KLANGK_PORT_RANGE_START``)
+    instead of a hardcoded value, so concurrent runs — xdist workers,
+    or several suites on one machine — don't collide (#1393). This
+    generalizes the ``_find_free_port`` helper first introduced in
+    ``test_nginx_acl_e2e.py``.
+
+    The port is released before this returns, so there is an inherent
+    TOCTOU window before the caller rebinds it (e.g. uvicorn at server
+    startup, or a workspace container binding a hosted-app port). For
+    the workspace-port range the allocator's own :func:`port_in_use`
+    check (run inside :func:`scan_free_ports`) is the backstop: it skips
+    any port a concurrent run grabbed in the meantime.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        # Loopback (not INADDR_ANY "") for ephemeral pickup — same
+        # free-port behavior, matches the test_nginx_acl_e2e pattern.
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def scan_free_ports(start: int, count: int, used: set[int]) -> list[int]:
+    """Find ``count`` free ports at or after ``start``.
+
+    Skips ports already in ``used`` (DB-allocated) and ports reported as
+    bound by the OS.  This is synchronous because it performs blocking
+    ``socket.bind()`` checks; ``model.find_and_allocate_ports`` runs it in
+    an executor so the event loop is not stalled.  Raises ``ValueError`` if
+    fewer than ``count`` free ports are available before ``MAX_PORT``.
+    """
+    ports: list[int] = []
+    port = start
+    while len(ports) < count:
+        if port > MAX_PORT:
+            raise ValueError(
+                f"Could not allocate {count} free ports starting at "
+                f"{start}: exhausted at {MAX_PORT}"
+            )
+        if port not in used and not port_in_use(port):
+            ports.append(port)
+        port += 1
+    return ports
 
 
 # Loopback addresses used by ``Util.client_is_loopback`` (the none-mode

--- a/src/backend/tests/test_model.py
+++ b/src/backend/tests/test_model.py
@@ -7,7 +7,7 @@ import aiosqlite
 import pytest
 import sqlalchemy.exc
 
-from klangk_backend import model
+from klangk_backend import model, util
 
 
 class TestMigration:
@@ -759,28 +759,6 @@ class TestPortAllocations:
         ports = await model.get_workspace_ports(workspace["id"])
         assert ports == [9000, 9001, 9002]
 
-    def test_free_port_returns_bindable_ephemeral_port(self):
-        """free_port hands back a port nothing else holds (#1393)."""
-        p = model.free_port()
-        assert isinstance(p, int)
-        assert 0 < p <= model.MAX_PORT
-        # The port must actually be bindable right now (the E2E harnesses
-        # rely on this to seed KLANGK_PORT / KLANGK_PORT_RANGE_START).
-        assert model.port_in_use(p) is False
-
-    def test_free_port_is_distinct_across_calls(self):
-        """Two calls don't hand back the same port while held (#1393)."""
-        import socket
-
-        a = model.free_port()
-        held = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        held.bind(("127.0.0.1", a))
-        try:
-            b = model.free_port()
-            assert b != a, "free_port reused a port that is currently bound"
-        finally:
-            held.close()
-
     async def test_get_all_allocated_ports(self, workspace):
         await model.add_port_allocations(workspace["id"], [9000, 9001])
         all_ports = await model.get_all_allocated_ports()
@@ -815,7 +793,7 @@ class TestPortAllocations:
         assert all_ports == set()
 
     async def test_find_and_allocate_ports(self, workspace, monkeypatch):
-        monkeypatch.setattr(model.ports, "port_in_use", lambda p: False)
+        monkeypatch.setattr(util, "port_in_use", lambda p: False)
         ports = await model.find_and_allocate_ports(workspace["id"], 3, 9000)
         assert ports == [9000, 9001, 9002]
         stored = await model.get_workspace_ports(workspace["id"])
@@ -824,7 +802,7 @@ class TestPortAllocations:
     async def test_find_and_allocate_skips_used(
         self, workspace, user, monkeypatch
     ):
-        monkeypatch.setattr(model.ports, "port_in_use", lambda p: False)
+        monkeypatch.setattr(util, "port_in_use", lambda p: False)
         await model.add_port_allocations(workspace["id"], [9000, 9002])
         ws2 = await model.create_workspace(user["id"], "ws2")
         ports = await model.find_and_allocate_ports(ws2["id"], 3, 9000)
@@ -833,9 +811,7 @@ class TestPortAllocations:
     async def test_find_and_allocate_skips_os_bound_ports(
         self, workspace, monkeypatch
     ):
-        monkeypatch.setattr(
-            model.ports, "port_in_use", lambda p: p in {9001, 9003}
-        )
+        monkeypatch.setattr(util, "port_in_use", lambda p: p in {9001, 9003})
         ports = await model.find_and_allocate_ports(workspace["id"], 3, 9000)
         assert ports == [9000, 9002, 9004]
 
@@ -845,7 +821,7 @@ class TestPortAllocations:
         """Exhausting the port range fails fast instead of looping forever."""
         # Every port at/after start is treated as in-use; asking for any
         # ports from a start of MAX_PORT guarantees immediate exhaustion.
-        monkeypatch.setattr(model.ports, "port_in_use", lambda p: True)
+        monkeypatch.setattr(util, "port_in_use", lambda p: True)
         with pytest.raises(ValueError):
             await model.find_and_allocate_ports(
                 workspace["id"], 1, model.MAX_PORT
@@ -857,9 +833,7 @@ class TestPortAllocations:
         """The scan never exceeds MAX_PORT and raises if it can't fulfil."""
         # Only the last two ports are free; requesting two succeeds, three raises.
         free = {model.MAX_PORT - 1, model.MAX_PORT}
-        monkeypatch.setattr(
-            model.ports, "port_in_use", lambda p: p not in free
-        )
+        monkeypatch.setattr(util, "port_in_use", lambda p: p not in free)
         ports = await model.find_and_allocate_ports(
             workspace["id"], 2, model.MAX_PORT - 1
         )
@@ -869,18 +843,6 @@ class TestPortAllocations:
             await model.find_and_allocate_ports(
                 ws2["id"], 3, model.MAX_PORT - 1
             )
-
-
-class TestPortInUse:
-    def test_free_port(self):
-        assert model.port_in_use(59123) is False
-
-    def test_bound_port(self):
-        import socket
-
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            s.bind(("0.0.0.0", 59124))
-            assert model.port_in_use(59124) is True
 
 
 class TestServiceCommand:

--- a/src/backend/tests/test_util.py
+++ b/src/backend/tests/test_util.py
@@ -2,7 +2,10 @@
 
 from klangk_backend.settings import resolve_dynamic_config
 from klangk_backend.util import (
+    MAX_PORT,
     Util,
+    free_port,
+    port_in_use,
     read_file_value,
     run_cmd_value,
     resolve_file_value,
@@ -588,3 +591,42 @@ class TestClientIsLoopback:
         assert u.connection_peer_is_trusted(None) is False
         u.set_uds_mode(True)
         assert u.connection_peer_is_trusted(None) is True
+
+
+# --- OS-level port discovery (moved from test_model.py, #1547) ---
+# port_in_use / free_port are pure socket probes that live in util now;
+# they have no DB dependency, so their direct tests belong here.
+
+
+class TestPortDiscovery:
+    def test_port_in_use_false_for_free_port(self):
+        assert port_in_use(59123) is False
+
+    def test_port_in_use_true_for_bound_port(self):
+        import socket
+
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("0.0.0.0", 59124))
+            assert port_in_use(59124) is True
+
+    def test_free_port_returns_bindable_ephemeral_port(self):
+        """free_port hands back a port nothing else holds (#1393)."""
+        p = free_port()
+        assert isinstance(p, int)
+        assert 0 < p <= MAX_PORT
+        # The port must actually be bindable right now (the E2E harnesses
+        # rely on this to seed KLANGK_PORT / KLANGK_PORT_RANGE_START).
+        assert port_in_use(p) is False
+
+    def test_free_port_is_distinct_across_calls(self):
+        """Two calls don't hand back the same port while held (#1393)."""
+        import socket
+
+        a = free_port()
+        held = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        held.bind(("127.0.0.1", a))
+        try:
+            b = free_port()
+            assert b != a, "free_port reused a port that is currently bound"
+        finally:
+            held.close()


### PR DESCRIPTION
# Move OS socket probes out of model/ports.py into util.py

Closes #1547.

## What

`port_in_use`, `free_port`, `scan_free_ports`, and `MAX_PORT` are pure
OS-level socket probes — they never touch the database — yet they lived in
`klangk_backend/model/ports.py` next to the `port_allocations` table queries,
breaking the layering of the `model` package (one DB-backed module per table).
This PR moves them to `klangk_backend/util.py`, which already owns the
loopback / network-trust helpers they sit next to (`LOOPBACK_ADDRS`,
`client_is_loopback`, `trusted_proxy_cidrs`).

`model/ports.py` keeps the DB-backed functions plus `find_and_allocate_ports`
(the composer that bridges model ↔ util) and **re-imports** the moved symbols
via `__all__`, so every historical import path still works unchanged.

## Why

`model/` is the persistence layer — `users.py`, `workspaces.py`, `tokens.py`,
`invitations.py`, `login_attempts.py`, …, one DB module per table, all
queries/transactions. `port_in_use`/`free_port`/`scan_free_ports` are the only
functions in the package that never touch the DB; they're `socket.bind()`
probes. They break the layering. `util.py` is already the home for OS-level
network reasoning, so they belong there.

This also documents *why* `port_in_use` binds `0.0.0.0` deliberately (see
below), which is the rationale for dismissing CodeQL alert #155.

## Change breakdown

| File | Change |
|------|--------|
| `klangk_backend/util.py` | + `socket` import; + port-discovery section (`MAX_PORT`, `port_in_use`, `free_port`, `scan_free_ports`) moved verbatim, with an expanded `port_in_use` docstring |
| `klangk_backend/model/ports.py` | trimmed to DB-backed fns + `find_and_allocate_ports`; re-imports the 4 moved symbols and declares them in `__all__` |
| `tests/test_model.py` | 5 `monkeypatch.setattr(model.ports, …)` → `util` (where `scan_free_ports` now resolves `port_in_use`); `TestPortInUse` + the two `free_port` tests removed |
| `tests/test_util.py` | + `TestPortDiscovery` with the relocated port-probe tests |

No behavior change — pure move/refactor. The moved function bodies are
byte-identical; only `port_in_use`'s docstring grew (documenting the
deliberate `0.0.0.0` bind).

## Back-compat

All existing import paths keep working (the re-import + `__all__` make
`model.ports.port_in_use is util.port_in_use`):

- `from klangk_backend import model; model.port_in_use(...)` / `model.free_port()`
- `from klangk_backend.model.ports import port_in_use`
- `from klangk_backend.model import free_port` — used by **20+ e2e files**
  across `src/backend/e2e-tests`, `src/cli/e2e-tests`, and `sandboxes/tests`,
  none of which needed to change.

## CodeQL alert #155 — false positive, dismissed in this PR

`port_in_use` binds `0.0.0.0`, which trips CodeQL's
`py/bind-socket-all-network-interfaces`. It's a deliberate false positive:
workspace host ports are published by podman with **no host IP** (i.e. on
`0.0.0.0`, via `podman.create`'s `-p host:container`), so the probe *must*
detect a bind on any interface to predict a publish collision. Binding the
probe to loopback would miss ports held only on an external interface and
let the allocator hand out a port podman then fails to bind. The rationale
is now in the docstring; the alert is dismissed as false positive with the
same reasoning.

## Verification

- `python -m pytest src/backend/tests -v -n auto` → **2392 passed, 100% coverage**
  (`util.py` 149/149, `model/ports.py` 53/53). Run with `-n auto` as CI does.
- `ruff check` + `ruff format --check` clean on all four changed files.
- Back-compat import smoke: `model.ports.port_in_use is util.port_in_use` ✓.
