### PR TITLE
klangkd reaps its own instance's leftover containers at startup; drop devenv kill-containers (#1554)

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -131,15 +131,6 @@ in
       after = [ "klangk:update-plugins" ];
       showOutput = true;
     };
-    "klangk:kill-containers" = {
-      exec = ''
-        if [ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ]; then
-          podman ps -a --filter "label=klangk.instance=$(klangk-instance-id)" -q \
-            | xargs -r podman rm -f
-        fi
-      '';
-      after = [ "klangk:uv-sync" ];
-    };
     "klangk:kill-port-holders" = {
       exec = ''
         if [ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ]; then
@@ -181,7 +172,6 @@ in
       after = [
         "klangk:flutter-build"
         "klangk:build-workspace-image"
-        "klangk:kill-containers"
         "klangk:kill-port-holders"
       ];
     };
@@ -243,12 +233,6 @@ in
         | python3 "$DEVENV_ROOT/scripts/trivy-report-nofix.py" -
     fi
     exec python3 "$DEVENV_ROOT/scripts/trivy-report-nofix.py" "$@"'';
-
-  scripts.kill-containers.exec = ''
-    podman ps -a \
-      --filter "label=klangk.instance=$(klangk-instance-id)" \
-      -q | xargs -r podman rm -f
-  '';
 
   scripts.update-plugins.exec = ''
     cd $DEVENV_ROOT

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -236,6 +236,19 @@ operators or integrators to act when upgrading.
 
 ### Removed
 
+- **devenv `klangk:kill-containers` task and `scripts.kill-containers`:**
+  klangkd now reaps its own instance's leftover containers at startup
+  (in `reap_instance_containers`, immediately after `prewarm_podman`),
+  removing the need for devenv to shell out to `klangk-instance-id` +
+  `podman rm -f` before the backend process starts. The kill now happens
+  in every deployment shape (systemd, host-container, bare `klangkd`),
+  not just under devenv (#1554).
+- **`adopt_orphaned_containers` → `reap_instance_containers`:** the old
+  method was effectively a startup reap already (the in-memory registry is
+  empty at startup, so every leftover was "untracked" and removed). Renamed
+  to reflect what it actually does and dropped the dead tracked-skip branch;
+  added the in-container guard (skip when klangkd itself runs in a
+  container) (#1554).
 - **`scripts/run-host-container.sh`:** retired; the `env | grep '^KLANGK_'`
   env-passthrough mechanism is replaced by mounting a config file (#1417).
 - **Headless single-user profile: nginx minimal template on a socket bind**

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -1630,33 +1630,46 @@ class ContainerRegistry:
                 "Podman pre-warm failed (%.3fs): %s", time.monotonic() - t0, e
             )
 
-    # --- Orphan adoption ---
+    # --- Startup reap ---
 
-    async def adopt_orphaned_containers(self) -> None:
+    async def reap_instance_containers(self) -> None:
+        """Remove every container labelled with this instance's ID.
+
+        Runs early in :func:`startup`, before any workspace is tracked, so
+        every leftover container from a crashed/killed previous run is
+        reaped unconditionally -- there is nothing to "adopt" because the
+        in-memory registry starts empty.  ``auto_start_workspaces`` then
+        recreates the ones that should be running.
+
+        Skipped when klangkd itself runs inside a container (developing
+        klangk-in-klangk): killing the instance's containers would tear
+        down our own host.
+        """
+        if os.path.exists("/.dockerenv") or os.path.exists(
+            "/run/.containerenv"
+        ):
+            logger.info(
+                "Running inside container, skipping startup container reap"
+            )
+            return
         try:
             containers = await self.app_state.podman.list_containers(
                 f"klangk.instance={model.get_instance_id()}"
             )
-            for c in containers:
-                cid = c.get("Id") or c.get("ID", "")
-                if cid not in self._cid_to_wsid:
-                    logger.info(
-                        "Removing orphaned container %s on startup",
-                        cid[:12],
-                    )
-                    try:
-                        await self.app_state.podman.remove_container(cid)
-                    except podman.PodmanError as e:
-                        logger.warning(
-                            "Failed to remove orphaned container %s: %s",
-                            cid[:12],
-                            e,
-                        )
-        except (
-            podman.PodmanError,
-            OSError,
-        ) as e:
-            logger.warning("Error scanning for orphaned containers: %s", e)
+        except (podman.PodmanError, OSError) as e:
+            logger.warning("Error scanning for leftover containers: %s", e)
+            return
+        for c in containers:
+            cid = c.get("Id") or c.get("ID", "")
+            if not cid:
+                continue
+            logger.info("Reaping leftover container %s on startup", cid[:12])
+            try:
+                await self.app_state.podman.remove_container(cid)
+            except podman.PodmanError as e:
+                logger.warning(
+                    "Failed to reap leftover container %s: %s", cid[:12], e
+                )
 
     # --- Shutdown ---
 

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -348,8 +348,9 @@ def remove_pid_file() -> None:
 async def startup(app_state) -> None:
     """Container-side startup (self-healing on re-run).
 
-    Warms podman, adopts/reaps leftover containers, launches the idle
-    and health background loops, and auto-starts workspaces.  Every
+    Warms podman, reaps leftover containers from a previous run, launches
+    the idle and health background loops, and auto-starts workspaces.
+    Every
     step is idempotent -- ``init_db`` uses ``CREATE TABLE IF NOT
     EXISTS``, the loop starters are gated on ``task is None``, and
     ``auto_start`` re-creates stopped containers -- so re-running this
@@ -357,7 +358,7 @@ async def startup(app_state) -> None:
     """
     registry = app_state.container_registry
     await registry.prewarm_podman()
-    await registry.adopt_orphaned_containers()
+    await registry.reap_instance_containers()
     registry.start_cleanup_loop()
     registry.start_health_loop()
     n = await app_state.workspaces.auto_start_workspaces()

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -2296,7 +2296,7 @@ class TestPrewarmPodman:
         # Should not raise
 
 
-class TestAdoptOrphanedContainers:
+class TestReapInstanceContainers:
     def setup_method(self):
         app_state = _make_app_state()
         self.registry = app_state.container_registry
@@ -2314,12 +2314,12 @@ class TestAdoptOrphanedContainers:
             ),
             remove_container=AsyncMock(),
         ) as mocks:
-            await self.registry.adopt_orphaned_containers()
-        # Orphaned containers are removed, not adopted.
+            await self.registry.reap_instance_containers()
+        # Leftover containers are removed at startup.
         assert "ws-orphan" not in self.registry.states
         mocks.remove_container.assert_awaited_once_with("orphan-123")
 
-    async def test_removes_orphan_without_labels(self):
+    async def test_removes_container_without_labels(self):
         with patch_podman(
             self.registry,
             list_containers=AsyncMock(
@@ -2327,21 +2327,22 @@ class TestAdoptOrphanedContainers:
             ),
             remove_container=AsyncMock(),
         ) as mocks:
-            await self.registry.adopt_orphaned_containers()
+            await self.registry.reap_instance_containers()
         assert "unknown" not in self.registry.states
         mocks.remove_container.assert_awaited_once_with("orphan-x")
 
-    async def test_skips_already_tracked(self):
+    async def test_removes_even_when_tracked(self):
+        """At startup the registry is empty, so every leftover is reaped --
+        including one whose ID happens to match a tracked container (which
+        cannot happen at real startup, but the reap is unconditional)."""
         self.registry.track_activity("tracked-456", "ws-tracked")
         with patch_podman(
             self.registry,
             list_containers=AsyncMock(return_value=[{"Id": "tracked-456"}]),
             remove_container=AsyncMock(),
         ) as mocks:
-            await self.registry.adopt_orphaned_containers()
-        # Already tracked → not removed.
-        assert self.registry.states["ws-tracked"].container_id == "tracked-456"
-        mocks.remove_container.assert_not_awaited()
+            await self.registry.reap_instance_containers()
+        mocks.remove_container.assert_awaited_once_with("tracked-456")
 
     async def test_podman_error_handled(self):
         with patch_podman(
@@ -2350,7 +2351,7 @@ class TestAdoptOrphanedContainers:
                 side_effect=podman.PodmanError(500, "fail")
             ),
         ):
-            await self.registry.adopt_orphaned_containers()
+            await self.registry.reap_instance_containers()
         # Should not raise
 
     async def test_remove_podman_error_handled(self):
@@ -2369,10 +2370,36 @@ class TestAdoptOrphanedContainers:
                 side_effect=podman.PodmanError(500, "remove failed")
             ),
         ) as mocks:
-            await self.registry.adopt_orphaned_containers()
+            await self.registry.reap_instance_containers()
         mocks.remove_container.assert_awaited_once_with("orphan-bad")
-        # Container was not adopted — just skipped after failed removal.
+        # Container was not adopted -- just skipped after failed removal.
         assert "ws-bad" not in self.registry.states
+
+    async def test_skipped_inside_container(self):
+        """The reap is a no-op when klangkd runs inside a container."""
+        with patch_podman(
+            self.registry,
+            list_containers=AsyncMock(),
+            remove_container=AsyncMock(),
+        ) as mocks:
+            with patch(
+                "os.path.exists", side_effect=lambda p: p == "/.dockerenv"
+            ):
+                await self.registry.reap_instance_containers()
+        mocks.list_containers.assert_not_awaited()
+        mocks.remove_container.assert_not_awaited()
+
+    async def test_skips_empty_id(self):
+        """A container dict with no Id/ID is skipped, not passed to remove."""
+        with patch_podman(
+            self.registry,
+            list_containers=AsyncMock(
+                return_value=[{"Id": "good-1"}, {"Labels": None}]
+            ),
+            remove_container=AsyncMock(),
+        ) as mocks:
+            await self.registry.reap_instance_containers()
+        mocks.remove_container.assert_awaited_once_with("good-1")
 
 
 class TestBrowserRegistry:

--- a/src/backend/tests/test_main.py
+++ b/src/backend/tests/test_main.py
@@ -422,7 +422,7 @@ class TestLifespan:
         with (
             patch.object(
                 registry,
-                "adopt_orphaned_containers",
+                "reap_instance_containers",
                 new_callable=AsyncMock,
             ) as mock_adopt,
             patch.object(registry, "start_cleanup_loop") as mock_start,
@@ -467,7 +467,7 @@ class TestLifespan:
         with (
             patch.object(
                 registry,
-                "adopt_orphaned_containers",
+                "reap_instance_containers",
                 new_callable=AsyncMock,
             ),
             patch.object(registry, "start_cleanup_loop"),
@@ -528,7 +528,7 @@ class TestStartupShutdownRestart:
             ) as mock_prewarm,
             patch.object(
                 registry,
-                "adopt_orphaned_containers",
+                "reap_instance_containers",
                 new_callable=AsyncMock,
             ) as mock_adopt,
             patch.object(registry, "start_cleanup_loop") as mock_cleanup,
@@ -697,7 +697,7 @@ class TestStartupShutdownRestart:
             ) as mock_remove,
             patch.object(
                 registry,
-                "adopt_orphaned_containers",
+                "reap_instance_containers",
                 new_callable=AsyncMock,
             ),
             patch.object(registry, "start_cleanup_loop"),


### PR DESCRIPTION
# klangkd reaps its own instance's leftover containers at startup

Closes #1554.

## What changed

klangkd now kills every container labelled with its instance ID early in `startup()` — via a new `reap_instance_containers()` method, called right after `prewarm_podman()` and before the cleanup/health loops. This replaces the devenv `klangk:kill-containers` task (and `scripts.kill-containers`), which shelled out to `klangk-instance-id` + `podman rm -f` from a separate process before the backend started.

### `adopt_orphaned_containers` → `reap_instance_containers`

The old method was already a startup reap in disguise: at startup the in-memory registry (`_cid_to_wsid`) is empty, so the "skip tracked" check was vacuously true and every leftover was removed. Renamed to reflect what it actually does, and dropped the dead tracked-skip branch. Added the in-container guard (`/.dockerenv` / `/run/.containerenv`) that `shutdown()` already had, so klangk-in-klangk development doesn't kill the host.

### devenv.nix

Removed:
- The `klangk:kill-containers` task.
- The `scripts.kill-containers` script.
- The backend process's `after = [ ... "klangk:kill-containers" ]` dependency.

## Why

1. **Correctness under `--config <file>`**: the devenv task's `$(klangk-instance-id)` call resolves the DB from a separate process that can't see the config file, so under `--config <file>` it can resolve a different instance ID than klangkd uses (#1551). klangkd knows its own instance ID in-process — no external lookup, no divergence.
2. **Every deployment shape gets the kill**: systemd, host-container, and bare `klangkd` deployments never had devenv running pre-start, so a crashed previous klangkd left orphaned containers that the new one "adopted" (inheriting stale state). Now the kill is intrinsic to klangkd's startup.
3. **Pairs with #1553**: removes one `klangk-instance-id` consumer (the devenv task), shrinking the external-DB-access surface that #1553 is eliminating.

## Testing

- 2394 backend unit tests pass, 100% coverage maintained.
- `TestReapInstanceContainers` covers: removes leftover containers, removes containers without labels, removes even when tracked (unconditional reap), podman list-error handled, per-container remove-error handled, **new**: skipped inside container, skips empty container ID.
- `test_main.py` startup tests updated to mock `reap_instance_containers`.
