### PR TITLE
Remove in-container guards from container cleanup (reap + shutdown) (#1556)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -236,6 +236,16 @@ operators or integrators to act when upgrading.
 
 ### Removed
 
+- **In-container guards on container cleanup:** the
+  `/.dockerenv` / `/run/.containerenv` early-return checks in
+  `reap_instance_containers()` and `shutdown()` are gone. Both operations are
+  scoped by the `klangk.instance` label filter, which already excludes any
+  container this klangkd didn't create (unrelated host containers, or
+  containers created by an outer klangkd with a different instance ID), so
+  the guards protected against an impossible case. A side effect was that
+  8 container-cleanup logic tests failed whenever pytest ran inside a
+  container (distrobox, CI-in-docker, klangk-in-klangk); the suite is now
+  portable across host environments with no test-side patching (#1556).
 - **devenv `klangk:kill-containers` task and `scripts.kill-containers`:**
   klangkd now reaps its own instance's leftover containers at startup
   (in `reap_instance_containers`, immediately after `prewarm_podman`),

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -1641,17 +1641,12 @@ class ContainerRegistry:
         in-memory registry starts empty.  ``auto_start_workspaces`` then
         recreates the ones that should be running.
 
-        Skipped when klangkd itself runs inside a container (developing
-        klangk-in-klangk): killing the instance's containers would tear
-        down our own host.
+        Safe even when klangkd itself runs inside a container: the
+        ``klangk.instance`` label filter scopes removal to containers
+        *this instance* created, so an unrelated host container (or a
+        container created by an outer klangkd with a different instance
+        ID) is never touched (#1556).
         """
-        if os.path.exists("/.dockerenv") or os.path.exists(
-            "/run/.containerenv"
-        ):
-            logger.info(
-                "Running inside container, skipping startup container reap"
-            )
-            return
         try:
             containers = await self.app_state.podman.list_containers(
                 f"klangk.instance={model.get_instance_id()}"
@@ -1688,13 +1683,6 @@ class ContainerRegistry:
             except asyncio.CancelledError:
                 pass
             self.health.health_task = None
-        # Skip container cleanup when running inside a container
-        # (developing klangk in klangk -- don't kill our own container).
-        if os.path.exists("/.dockerenv") or os.path.exists(
-            "/run/.containerenv"
-        ):
-            logger.info("Running inside container, skipping container cleanup")
-            return
         tracked_ids = set(self._cid_to_wsid.keys())
         tasks = [self.stop_and_remove_container(cid) for cid in tracked_ids]
         try:

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -1962,14 +1962,6 @@ class TestShutdown:
         app_state = _make_app_state()
         self.registry = app_state.container_registry
 
-    async def test_shutdown_skips_in_container(self):
-        """When running inside a container, shutdown skips cleanup."""
-        self.registry.track_activity("cid", "ws")
-        with patch("os.path.exists", return_value=True):
-            await self.registry.shutdown()
-        # Container should still be tracked (not cleaned up)
-        assert "ws" in self.registry.states
-
     async def test_shutdown_stops_tracked(self):
         # list_containers returns the tracked cid; it should be skipped in
         # the orphan loop (already tracked) but still removed via tracking.
@@ -2374,20 +2366,6 @@ class TestReapInstanceContainers:
         mocks.remove_container.assert_awaited_once_with("orphan-bad")
         # Container was not adopted -- just skipped after failed removal.
         assert "ws-bad" not in self.registry.states
-
-    async def test_skipped_inside_container(self):
-        """The reap is a no-op when klangkd runs inside a container."""
-        with patch_podman(
-            self.registry,
-            list_containers=AsyncMock(),
-            remove_container=AsyncMock(),
-        ) as mocks:
-            with patch(
-                "os.path.exists", side_effect=lambda p: p == "/.dockerenv"
-            ):
-                await self.registry.reap_instance_containers()
-        mocks.list_containers.assert_not_awaited()
-        mocks.remove_container.assert_not_awaited()
 
     async def test_skips_empty_id(self):
         """A container dict with no Id/ID is skipped, not passed to remove."""


### PR DESCRIPTION
# Remove the in-container guards from container cleanup

Closes #1556.

## What changed

Deleted the `/.dockerenv` / `/run/.containerenv` early-return guards from both `reap_instance_containers()` and `shutdown()` in `src/backend/klangk_backend/container.py`.

## Why

The guards protected against a threat the `klangk.instance` label filter already prevents. Both operations are scoped to containers matching `klangk.instance={get_instance_id()}`, and every container klangkd creates is stamped with that label at creation time. So:

- An **unrelated host container** (distrobox, dev container) has no `klangk.instance` label → invisible to the filter → never touched, guard or no guard.
- A **klangk workspace container** ("klangk-in-klangk") was created by an *outer* klangkd → labeled with the *outer* instance ID. The inner klangkd's filter uses the *inner* instance ID (its own DB). Different IDs → the host doesn't match → never touched.

The only scenario the guards actually caught is inner and outer sharing the same DB/instance ID (mounting the outer's `data_dir` into the inner) — contrived, and a container check is the wrong tool there anyway (it'd also block legitimate same-instance nested setups).

## Side benefit: portable test suite

The guards coupled 8 container-cleanup logic tests to the host environment. They passed on bare metal and failed inside any container (distrobox, CI-in-docker, klangk-in-klangk) because the real `/run/.containerenv` tripped the guard before the cleanup path ran:

```
FAILED TestReapInstanceContainers::test_removes_orphaned_containers
FAILED TestReapInstanceContainers::test_removes_container_without_labels
FAILED TestReapInstanceContainers::test_removes_even_when_tracked
FAILED TestReapInstanceContainers::test_remove_podman_error_handled
FAILED TestReapInstanceContainers::test_skips_empty_id
FAILED TestShutdown::test_shutdown_stops_tracked
FAILED TestShutdown::test_shutdown_stops_orphans
FAILED TestShutdown::test_shutdown_orphan_remove_error
```

With the guards gone, the suite passes identically on bare metal and inside a container — no test-side patching needed.

## Tests

- Deleted the two guard-only tests (`test_skipped_inside_container`, `test_shutdown_skips_in_container`) — they existed solely to exercise the removed guards. The no-skip path is already covered by the logic tests above.
- **Host:** 2392 passed, 100% coverage.
- **Inside distrobox container:** 2392 passed (same count, zero failures) — the 8 formerly-failing tests now pass unmodified.

## Verification method

The distrobox container from #1556's investigation was kept around specifically to validate this fix. The full backend suite runs clean inside it with `KLANGK_*`/`DEVENV_*` env vars deliberately unset and Nix scrubbed from PATH — proving the suite no longer depends on the host environment.
