### PR TITLE
fix(nginx): emit realip directives so $remote_addr is the real client IP (#1558)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -88,6 +88,15 @@ operators or integrators to act when upgrading.
   suites now run with `pytest-timeout` (`--timeout=60`). A hanging test
   fails after 60s instead of burning the whole job budget. New
   `pytest-timeout` dev dependency (#1513).
+- **klangk nginx now rewrites `$remote_addr` to the real client IP** via the
+  realip module (`set_real_ip_from <each KLANGK_TRUSTED_PROXY_CIDRS entry>` +
+  `real_ip_header X-Forwarded-For` + `real_ip_recursive on`). Without this,
+  `proxy_set_header X-Real-IP $remote_addr` clobbered the real client IP the
+  outer proxy forwarded with the proxy's own IP, so the backend's
+  `client_is_loopback` / `derive_hosting_info` resolved the proxy IP, not the
+  browser's — a regression from stable/1.0 where the customer proxy hit
+  uvicorn directly. Suppressed entirely when `KLANGK_REJECT_PROXY_HEADERS` is
+  set (#1558).
 
 ### Changed
 

--- a/src/backend/klangk_backend/nginx.py
+++ b/src/backend/klangk_backend/nginx.py
@@ -355,6 +355,62 @@ class NginxRenderer:
             "    }\n"
         )
 
+    def _reject_proxy_headers(self) -> bool:
+        """True if KLANGK_REJECT_PROXY_HEADERS is set (hard trust-off)."""
+        raw = self._settings.reject_proxy_headers
+        return bool(raw and str(raw).strip().lower() in ("1", "true", "yes"))
+
+    def _realip_block(self) -> str:
+        """Emit nginx realip directives so ``$remote_addr`` is the real client.
+
+        Without the realip module ``$remote_addr`` is always the immediate
+        peer (the outer reverse proxy), and ``proxy_set_header X-Real-IP
+        $remote_addr`` clobbers the real client IP the proxy forwarded — so
+        the backend's ``client_is_loopback`` / ``derive_hosting_info`` resolve
+        the proxy's IP, not the browser's (#1558, regression from
+        stable/1.0 where the customer proxy hit uvicorn directly). With
+        these directives nginx rewrites ``$remote_addr`` from
+        ``X-Forwarded-For``, but **only when the immediate peer is in the
+        trusted set** (``set_real_ip_from``): a direct, non-proxy connection
+        cannot spoof XFF.
+
+        Reuses ``KLANGK_TRUSTED_PROXY_CIDRS`` — the same trust set the
+        Python ``peer_trusted()`` / ``client_is_loopback()`` helpers consult
+        — so nginx and the backend agree on which peers are trusted.
+        Suppressed entirely when ``KLANGK_REJECT_PROXY_HEADERS`` is set (hard
+        trust-off), preserving the fail-closed posture.
+        """
+        if self._reject_proxy_headers():
+            return ""
+        raw = self._settings.trusted_proxy_cidrs
+        entries: list[str] = []
+        for token in (raw or "").split(","):
+            token = token.strip()
+            if not token:
+                continue
+            # Validate so an invalid entry doesn't crash nginx at start
+            # (mirrors util.trusted_proxy_cidrs()'s skip-and-log).
+            try:
+                ipaddress.ip_address(token)
+            except ValueError:
+                try:
+                    ipaddress.ip_network(token, strict=False)
+                except ValueError:
+                    logger.warning(
+                        "Ignoring an invalid KLANGK_TRUSTED_PROXY_CIDRS "
+                        "entry in nginx realip block"
+                    )
+                    continue
+            entries.append(token)
+        if not entries:
+            entries = ["127.0.0.1", "::1"]
+        lines = "\n".join(f"  set_real_ip_from {e};" for e in entries)
+        return (
+            f"{lines}\n"
+            "  real_ip_header X-Forwarded-For;\n"
+            "  real_ip_recursive on;\n"
+        )
+
     def _trust_outer_proxy(self) -> bool:
         raw = self._settings.trust_outer_proxy
         return str(raw).strip().lower() in ("1", "true", "yes")
@@ -441,6 +497,7 @@ class NginxRenderer:
         resolvers = self.detect_dns_resolvers()
         acl, _deny = self.compute_container_acls()
         egress_locations = self._egress_locations(upstream, acl, resolvers)
+        realip = self._realip_block()
         return f"""daemon off;
 pid /tmp/nginx.pid;
 error_log stderr;
@@ -454,7 +511,7 @@ http {{
   scgi_temp_path /tmp/nginx_scgi;
 
   client_max_body_size {client_max_body_size};
-
+{realip}
   server {{
     listen {egress_listen}:{egress_port};
 {egress_locations}  }}
@@ -486,6 +543,7 @@ http {{
 
         hosted_block = self._build_hosted_block()
         egress_locations = self._egress_locations(upstream, acl, resolvers)
+        realip = self._realip_block()
         trust = self._trust_outer_proxy()
         if trust:
             forwarded_headers = (
@@ -532,7 +590,7 @@ http {{
   }}
 
   client_max_body_size {client_max_body_size};
-
+{realip}
   # --- Container-egress listener (container → backend via host.containers.internal) ---
   server {{
     listen {egress_listen}:{egress_port};

--- a/src/backend/tests/test_nginx.py
+++ b/src/backend/tests/test_nginx.py
@@ -221,6 +221,77 @@ class TestRenderConfig:
         assert "proxy_set_header X-Forwarded-Proto $scheme;" in conf
         assert "proxy_set_header X-Forwarded-Host $http_host;" in conf
 
+
+class TestRealipBlock:
+    """The realip module directives so ``$remote_addr`` is the real client (#1558)."""
+
+    def test_default_loopback_trust(self):
+        s = make_settings({"KLANGK_PORT": "8997"})
+        conf = _renderer(s).render_config(tcp_upstream("127.0.0.1", "8997"))
+        assert "set_real_ip_from 127.0.0.1;" in conf
+        assert "set_real_ip_from ::1;" in conf
+        assert "real_ip_header X-Forwarded-For;" in conf
+        assert "real_ip_recursive on;" in conf
+
+    def test_custom_cidrs(self):
+        s = make_settings(
+            {
+                "KLANGK_PORT": "8997",
+                "KLANGK_TRUSTED_PROXY_CIDRS": "10.100.0.0/24,127.0.0.1",
+            }
+        )
+        conf = _renderer(s).render_config(tcp_upstream("127.0.0.1", "8997"))
+        assert "set_real_ip_from 10.100.0.0/24;" in conf
+        assert "set_real_ip_from 127.0.0.1;" in conf
+
+    def test_suppressed_when_reject_proxy_headers(self):
+        s = make_settings(
+            {"KLANGK_PORT": "8997", "KLANGK_REJECT_PROXY_HEADERS": "1"}
+        )
+        conf = _renderer(s).render_config(tcp_upstream("127.0.0.1", "8997"))
+        assert "set_real_ip_from" not in conf
+        assert "real_ip_header" not in conf
+
+    def test_present_in_headless(self):
+        s = make_settings(env={"KLANGK_EGRESS_PORT": "8995"})
+        conf = _renderer(s).render_config(uds_upstream("/tmp/klangk.sock"))
+        assert "set_real_ip_from 127.0.0.1;" in conf
+        assert "real_ip_header X-Forwarded-For;" in conf
+
+    def test_invalid_entries_skipped(self):
+        s = make_settings(
+            {
+                "KLANGK_PORT": "8997",
+                "KLANGK_TRUSTED_PROXY_CIDRS": "127.0.0.1,not-a-cidr,10.0.0.0/8",
+            }
+        )
+        conf = _renderer(s).render_config(tcp_upstream("127.0.0.1", "8997"))
+        assert "set_real_ip_from 127.0.0.1;" in conf
+        assert "set_real_ip_from 10.0.0.0/8;" in conf
+        assert "not-a-cidr" not in conf
+
+    def test_empty_and_all_invalid_falls_back_to_loopback(self):
+        """Empty tokens are skipped; if every entry is invalid, loopback is used."""
+        s = make_settings(
+            {
+                "KLANGK_PORT": "8997",
+                "KLANGK_TRUSTED_PROXY_CIDRS": ",not-valid,",
+            }
+        )
+        conf = _renderer(s).render_config(tcp_upstream("127.0.0.1", "8997"))
+        assert "set_real_ip_from 127.0.0.1;" in conf
+        assert "set_real_ip_from ::1;" in conf
+        assert "not-valid" not in conf
+
+    def test_block_at_http_scope(self):
+        """The realip directives sit at ``http {}`` scope, outside any server block."""
+        s = make_settings({"KLANGK_PORT": "8997"})
+        conf = _renderer(s).render_config(tcp_upstream("127.0.0.1", "8997"))
+        # set_real_ip_from must appear before the first 'server {' block.
+        realip_pos = conf.index("set_real_ip_from")
+        first_server = conf.index("server {")
+        assert realip_pos < first_server
+
     def test_file_cmd_resolution_from_yaml(self, tmp_path):
         """file:/cmd: values resolve in the renderer."""
         secret = tmp_path / "llm.key"


### PR DESCRIPTION
# Emit nginx realip directives so $remote_addr is the real client IP

Closes #1558.

## Problem

klangk's nginx does `proxy_set_header X-Real-IP $remote_addr;` on every proxied location, but without the realip module `$remote_addr` is always the **immediate peer** (the outer reverse proxy). This clobbers the real client IP the proxy forwarded, so the backend's `client_is_loopback` / `derive_hosting_info` resolve the **proxy's IP**, not the browser's.

This is a regression from `stable/1.0`, where the customer's outer proxy hit uvicorn directly (`--no-proxy-headers`) — the forwarded headers reached the backend intact. On `main` the settings restructure (#1542) put klangk's nginx in the browser path (uvicorn is now UDS-only), introducing the clobber.

Verified empirically in the #1546 deployment:

```
$ curl -X POST -H "X-Real-IP: 8.8.8.8" -H "X-Forwarded-For: 8.8.8.8" \
    http://127.0.0.1:28997/api/v1/auth/local
[200]   # ← spoofed X-Real-IP discarded; backend sees 127.0.0.1
```

## Fix

Emit the standard nginx realip block at `http {}` scope, derived from the trust set klangk already knows about:

```nginx
set_real_ip_from <each KLANGK_TRUSTED_PROXY_CIDRS entry>;
real_ip_header   X-Forwarded-For;
real_ip_recursive on;
```

Now `$remote_addr` is rewritten from `X-Forwarded-For` **only when the immediate peer is in the trusted set** — so:
- A connection from a trusted proxy → `$remote_addr` = real client IP → `X-Real-IP $remote_addr` forwards it correctly.
- A direct (non-proxy) connection → peer not in `set_real_ip_from` → `$remote_addr` stays as the direct client → **XFF spoofing impossible**.

`KLANGK_TRUSTED_PROXY_CIDRS` (default `127.0.0.1,::1`) already expresses the exact trust boundary, so no new config is needed. It now does double duty: nginx `$remote_addr` rewrite + Python `peer_trusted()` header trust — both use the same set.

Suppressed entirely when `KLANGK_REJECT_PROXY_HEADERS` is set (hard trust-off), preserving the fail-closed posture.

## Verification

- `nginx -t` passes on the rendered config (realip module is compiled into the standard nginx build).
- Full backend suite: 2399 passed, 100% coverage.
- New `TestRealipBlock` class: 7 tests covering default loopback trust, custom CIDRs, reject-proxy-headers suppression, headless template, invalid-entry skipping, all-invalid fallback, and http-scope placement.
