### PR TITLE
fix(nginx): key container-source deny on the pre-realip peer (#1546)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -397,6 +397,26 @@ set-password <email>` (set a known password for the default user — whose
   `KLANGK_PORT`/`KLANGK_LISTEN` are retained for tests that launch uvicorn
   over TCP directly but are unused under `klangkd`.
 
+### Fixed
+
+- **The browser-listener container-source deny no longer false-positives
+  behind a trusted proxy co-located on klangk's host** (#1546). The
+  `location /` deny (#1376) was an inline `deny <ip>; allow all;` list,
+  which nginx evaluates against `$remote_addr`. After #1560's realip
+  directives rewrite `$remote_addr` to the `X-Forwarded-For` client, a
+  trusted outer proxy running on the same host as klangk (whose forwarded
+  real client is a host interface IP, e.g. a `10.100.0.0/24` bridge) made
+  every proxied browser request land on a denied host IP → 403 for the whole
+  UI/API. The deny is now a `geo $realip_remote_addr $container_source { … }`
+  block + `if ($container_source) { return 403; }` on the catch-all, keyed on
+  the _immediate_ TCP peer (`$realip_remote_addr`, pre-realip) instead of the
+  rewritten real client. So: a container connecting directly via pasta NAT is
+  still denied (brute-force cap intact); a request through a trusted proxy is
+  let through (its peer is the proxy, not a container source) while
+  `X-Real-IP`/`X-Forwarded-For` still carry the real client to the backend.
+  An upstream proxy on the same host now works out of the box — no
+  `KLANGK_CONTAINER_SUBNETS` escape hatch needed.
+
 ### Security
 
 - **nginx now denies container source IPs by default on the catch-all

--- a/src/backend/e2e-tests/test_nginx_acl_e2e.py
+++ b/src/backend/e2e-tests/test_nginx_acl_e2e.py
@@ -249,7 +249,8 @@ class TestNginxAclConfig:
     # remembering its Depends(auth).
 
     def test_catch_all_denies_container_subnets(self, tmp_path):
-        """Catch-all `location /` denies the explicit container subnets."""
+        """Catch-all `location /` denies the explicit container subnets — via
+        the http-scope geo block, keyed on the pre-realip peer (#1546)."""
         conf = _render_conf(
             {
                 "KLANGK_CONTAINER_SUBNETS": "10.89.0.0/24,172.30.0.0/16",
@@ -257,39 +258,37 @@ class TestNginxAclConfig:
             },
             str(tmp_path),
         )
-        catch_all = re.search(r"location / \{(.*?)\}", conf, re.DOTALL).group(
-            1
-        )
-        assert "deny 10.89.0.0/24;" in catch_all
-        assert "deny 172.30.0.0/16;" in catch_all
-        assert "allow all;" in catch_all
+        # The container-source set lives in the geo block (http scope),
+        # not as inline `deny` lines on location / anymore.
+        assert "geo $realip_remote_addr $container_source {" in conf
+        assert "10.89.0.0/24 1;" in conf
+        assert "172.30.0.0/16 1;" in conf
+        # The catch-all guard references the geo's variable. The guard
+        # line is unique in the config, so assert on the whole conf.
+        assert "if ($container_source) { return 403; }" in conf
 
     def test_catch_all_never_denies_loopback(self, tmp_path):
-        """Loopback is never denied on the catch-all even when it appears in
+        """Loopback is never flagged by the geo even when it appears in
         KLANGK_CONTAINER_SUBNETS — local browsers connect via loopback and
         must reach the full UI/API."""
         conf = _render_conf(
             {"KLANGK_CONTAINER_SUBNETS": "127.0.0.1,10.89.0.0/24"},
             str(tmp_path),
         )
-        catch_all = re.search(r"location / \{(.*?)\}", conf, re.DOTALL).group(
-            1
-        )
-        assert "deny 10.89.0.0/24;" in catch_all
-        assert "deny 127.0.0.1;" not in catch_all
-        assert "allow all;" in catch_all
+        assert "10.89.0.0/24 1;" in conf
+        assert "127.0.0.1 1;" not in conf
+        assert "default 0;" in conf
 
     def test_catch_all_deny_present_when_containers_configured(self, tmp_path):
-        """The deny-by-default ACL is always present on the catch-all whenever
-        container subnets are configured — there is no way to opt out of it."""
+        """The container-source guard is always present on the catch-all
+        whenever non-loopback container subnets are configured — there is
+        no way to opt out of the brute-force cap (#1376)."""
         conf = _render_conf(
             {"KLANGK_CONTAINER_SUBNETS": "10.89.0.0/24"}, str(tmp_path)
         )
-        catch_all = re.search(r"location / \{(.*?)\}", conf, re.DOTALL).group(
-            1
-        )
-        assert "deny 10.89.0.0/24;" in catch_all
-        assert "allow all;" in catch_all
+        assert "geo $realip_remote_addr $container_source {" in conf
+        assert "10.89.0.0/24 1;" in conf
+        assert "if ($container_source) { return 403; }" in conf
 
 
 class TestNginxHostedBlock:
@@ -590,8 +589,10 @@ class TestNginxDenyByDefault:
             raise RuntimeError("Backend did not start")
 
         # Start nginx via the Python renderer (#1396) with the host IP as
-        # the (sole) container source IP. CONTAINER_DENY on the catch-all
-        # then denies exactly that IP.
+        # the (sole) container source IP. The browser catch-all's container
+        # guard (geo on $realip_remote_addr) then denies a *direct* request
+        # from exactly that IP — while a trusted-proxy request whose XFF is
+        # that IP still passes (the peer is the proxy, not a container source).
         from klangk_backend.nginx import NginxRenderer, tcp_upstream
         from klangk_backend.settings import KlangkSettings
         import types
@@ -654,6 +655,22 @@ class TestNginxDenyByDefault:
             timeout=5,
         )
         assert r.status_code == 403
+
+    def test_proxied_request_with_container_xff_is_allowed(self, stack):
+        """A request whose *immediate* peer is trusted (loopback) but whose
+        ``X-Forwarded-For`` is a container-source IP must reach the backend
+        (NOT 403). This is the #1546 fix: the container guard keys on the
+        pre-realip peer (``$realip_remote_addr``), not the realip-rewritten
+        ``$remote_addr`` — so a trusted proxy forwarding a host/container IP
+        as the real client is not denied. Without the fix this would 403.
+        """
+        r = httpx.get(
+            f"http://127.0.0.1:{stack['browser_port']}/api/v1/users",
+            headers={"X-Forwarded-For": stack["host_ip"]},
+            timeout=5,
+        )
+        # Reached the backend (not nginx-denied): 401 unauth is fine.
+        assert r.status_code != 403
 
     def test_api_allowed_from_loopback(self, stack):
         """From loopback, the same /api/v1 path reaches the backend (not 403) —

--- a/src/backend/klangk_backend/nginx.py
+++ b/src/backend/klangk_backend/nginx.py
@@ -207,58 +207,113 @@ class NginxRenderer:
             pass
         return " ".join(servers) or "8.8.8.8"
 
-    def compute_container_acls(self) -> tuple[str, str]:
-        """Build the CONTAINER_ACL (allowlist) and CONTAINER_DENY (blocklist) text.
+    def _container_source_entries(self) -> tuple[list[str], list[str]]:
+        """Resolve the container source IP/CIDR set → ``(acl_entries, deny_entries)``.
 
-        Returns ``(acl_block, deny_block)`` where each is the indented
-        ``allow``/``deny`` directives (no leading/trailing newline). Two
-        complementary ACLs from one source set (#1376):
+        - ``acl_entries``: every source, loopback included — drives the egress
+          CONTAINER_ACL allowlist (containers connect from these IPs).
+        - ``deny_entries``: non-loopback sources only — drives the browser
+          catch-all guard. Loopback is excluded so a local browser keeps full
+          UI/API access.
 
-        - CONTAINER_ACL: allowlist on the three container endpoints
-          (llm-proxy, browser-delegate, post-chat-message). Allows the container
-          source IPs, denies everyone else.
-        - CONTAINER_DENY: blocklist on the catch-all ``location /``. Denies the
-          container source IPs so a container reaches ONLY those three endpoints,
-          not the whole /api/v1/* tree. Loopback is ALWAYS excluded (local
-          browsers need the full UI/API).
-
-        With an explicit ``KLANGK_CONTAINER_SUBNETS`` override, 127.0.0.1 is NOT
-        implicitly added to CONTAINER_ACL (the operator's list is used verbatim).
+        Source: explicit ``KLANGK_CONTAINER_SUBNETS`` if set (used verbatim,
+        127.0.0.1 NOT implicitly added), else auto-detected host IPv4s, else
+        the RFC1918 fallback.
         """
         explicit = self._settings.container_subnets
         if explicit:
-            subnets = [
+            entries = [
                 s.strip() for s in str(explicit).split(",") if s.strip()
             ]
-            acl_lines = [f"      allow {s};" for s in subnets]
-            deny_lines = [
-                f"      deny {s};" for s in subnets if not _is_loopback(s)
-            ]
-            if not deny_lines:
+            deny_entries = [s for s in entries if not _is_loopback(s)]
+            if not deny_entries:
                 logger.warning(
                     "container source set has no non-loopback entries — "
                     "catch-all location / denies nothing (deny-by-default inactive)"
                 )
-        else:
-            addrs = detect_host_ipv4s()
-            if addrs:
-                acl_lines = [f"      allow {a};" for a in addrs]
-                deny_lines = [
-                    f"      deny {a};" for a in addrs if not _is_loopback(a)
-                ]
-            else:
-                logger.warning(
-                    "container subnet detection failed, using fallback RFC1918 ranges"
-                )
-                acl_lines = [
-                    f"      allow {s};" for s in _FALLBACK_ACL_SUBNETS
-                ]
-                deny_lines = [
-                    f"      deny {s};" for s in _FALLBACK_DENY_SUBNETS
-                ]
-        acl = "\n".join(acl_lines) + "\n      deny all;"
-        deny = "\n".join(deny_lines) + "\n      allow all;"
-        return acl, deny
+            return entries, deny_entries
+        addrs = detect_host_ipv4s()
+        if addrs:
+            return addrs, [a for a in addrs if not _is_loopback(a)]
+        logger.warning(
+            "container subnet detection failed, using fallback RFC1918 ranges"
+        )
+        return list(_FALLBACK_ACL_SUBNETS), list(_FALLBACK_DENY_SUBNETS)
+
+    def compute_container_acls(self) -> tuple[str, str]:
+        """Build the CONTAINER_ACL (egress allowlist) and browser deny guard.
+
+        Returns ``(acl, deny_guard)``:
+
+        - ``acl``: ``allow <src>;`` lines + ``deny all;`` for the three
+          container-egress locations (llm-proxy, browser-delegate,
+          post-chat-message). Keyed on nginx's ``$remote_addr`` — fine because
+          egress is reached *directly* by containers (pasta NAT), with no proxy
+          in front to rewrite it.
+        - ``deny_guard``: an ``if ($container_source) { return 403; }`` line
+          for the browser catch-all ``location /``. ``$container_source`` is a
+          flag set by :meth:`compute_container_geo`.
+        """
+        acl_entries, _deny_entries = self._container_source_entries()
+        acl = "\n".join(f"      allow {e};" for e in acl_entries)
+        acl = acl + "\n      deny all;"
+        deny_guard = "      if ($container_source) { return 403; }\n"
+        return acl, deny_guard
+
+    def compute_container_geo(self) -> str:
+        """The ``geo`` block that flags container-source peers (http scope).
+
+        Plain-English version of what this does and why:
+
+        **What.** Builds a lookup table: for each incoming request, nginx takes
+        the address the connection came from and sets ``$container_source`` to
+        ``1`` if that address is a workspace-container source, ``0`` otherwise.
+        The browser catch-all ``location /`` then does
+        ``if ($container_source) { return 403; }`` — a container trying to
+        reach the browser UI is refused, everyone else gets through. This is
+        the brute-force cap from #1376 (a container can hammer only its own
+        token-gated egress endpoints, not ``/api/v1/auth/login`` etc.).
+
+        **Why ``$realip_remote_addr`` and not ``$remote_addr``.**
+        ``$remote_addr`` is the *effective* client: #1560's realip directives
+        rewrite it to the real browser IP (from ``X-Forwarded-For``) whenever
+        the immediate peer is a trusted proxy. Keying the guard on that would
+        mean: when a trusted proxy forwards a request whose real client is one
+        of klangk's own host interface IPs (e.g. a proxy co-located on the same
+        host, #1546), nginx rewrites ``$remote_addr`` to that host IP, the guard
+        matches a container source, and every proxied browser request returns
+        403. ``$realip_remote_addr`` is the address the realip module *started
+        with* — the actual TCP peer, before any rewrite. So:
+
+          * request through a trusted proxy → peer is the *proxy's* IP (not a
+            container source) → allowed, and ``$remote_addr`` still carries the
+            real client for the backend's IP-trust checks;
+          * container connecting directly (pasta NAT) → peer is a host IP that
+            *is* a container source → denied (brute-force cap intact);
+          * LAN browser connecting directly → peer is its LAN IP → allowed.
+
+        This needs the realip module compiled into nginx (it provides the
+        ``$realip_remote_addr`` variable) — already required by #1560's
+        ``set_real_ip_from`` directives. When proxy-header trust is off
+        (``KLANGK_REJECT_PROXY_HEADERS``), no realip directives fire,
+        ``$remote_addr`` is never rewritten, and ``$realip_remote_addr`` simply
+        equals it — correct either way.
+
+        Loopback is never listed (it maps to the ``default 0`` → allowed), so
+        local browsers are unaffected. With no non-loopback container sources
+        at all, the block still declares the variable (default 0) so the
+        ``location /`` guard references a defined variable.
+        """
+        _acl_entries, deny_entries = self._container_source_entries()
+        body = (
+            "\n".join(f"    {e} 1;" for e in deny_entries)
+            if deny_entries
+            else ""
+        )
+        body = f"    default 0;\n{body}" if body else "    default 0;"
+        return (
+            f"  geo $realip_remote_addr $container_source {{\n{body}\n  }}\n"
+        )
 
     def compute_client_max_body_size(self) -> str:
         """Derive nginx ``client_max_body_size`` from ``KLANGK_FILE_UPLOAD_SIZE_MAX``.
@@ -544,6 +599,11 @@ http {{
         hosted_block = self._build_hosted_block()
         egress_locations = self._egress_locations(upstream, acl, resolvers)
         realip = self._realip_block()
+        # The container-source flag used by the browser catch-all's
+        # ``if ($container_source) { return 403; }`` guard (the deny value
+        # above). http-scope ``geo`` keyed on the pre-realip peer — see
+        # compute_container_geo().
+        geo = self.compute_container_geo()
         trust = self._trust_outer_proxy()
         if trust:
             forwarded_headers = (
@@ -591,7 +651,7 @@ http {{
 
   client_max_body_size {client_max_body_size};
 {realip}
-  # --- Container-egress listener (container → backend via host.containers.internal) ---
+{geo}  # --- Container-egress listener (container → backend via host.containers.internal) ---
   server {{
     listen {egress_listen}:{egress_port};
 {egress_locations}  }}

--- a/src/backend/klangk_backend/nginx.py
+++ b/src/backend/klangk_backend/nginx.py
@@ -550,7 +550,7 @@ class NginxRenderer:
         egress_listen = self._settings.egress_listen
         client_max_body_size = self.compute_client_max_body_size()
         resolvers = self.detect_dns_resolvers()
-        acl, _deny = self.compute_container_acls()
+        acl, _ = self.compute_container_acls()
         egress_locations = self._egress_locations(upstream, acl, resolvers)
         realip = self._realip_block()
         return f"""daemon off;

--- a/src/backend/tests/test_nginx.py
+++ b/src/backend/tests/test_nginx.py
@@ -6,6 +6,7 @@ real nginx — the runtime ACL enforcement is covered by the e2e suite
 """
 
 import asyncio
+import re
 from unittest.mock import Mock
 
 import pytest
@@ -71,23 +72,14 @@ class TestContainerAcls:
         assert "deny all;" in acl
         # 127.0.0.1 NOT implicitly added on explicit override.
         assert "allow 127.0.0.1;" not in acl
-        # Deny block denies the non-loopback subnets.
-        assert "deny 10.89.0.0/24;" in deny
-        assert "allow all;" in deny
-
-    def test_loopback_excluded_from_deny(self):
-        s = make_settings(
-            env={"KLANGK_CONTAINER_SUBNETS": "127.0.0.1,10.89.0.0/24"}
-        )
-        _, deny = _renderer(s).compute_container_acls()
-        assert "deny 10.89.0.0/24;" in deny
-        assert "deny 127.0.0.1;" not in deny
-        assert "allow all;" in deny
+        # The browser catch-all guard now references the geo flag
+        # ($container_source), keyed on the pre-realip peer — see
+        # TestContainerGeo for the source-set assertions.
+        assert "if ($container_source) { return 403; }" in deny
 
     def test_all_loopback_warns(self, caplog):
         s = make_settings({"KLANGK_CONTAINER_SUBNETS": "127.0.0.1"})
-        _, deny = _renderer(s).compute_container_acls()
-        assert "allow all;" in deny
+        _renderer(s)._container_source_entries()
         assert "no non-loopback" in caplog.text
 
     def test_auto_detect_or_fallback(self):
@@ -96,7 +88,79 @@ class TestContainerAcls:
         acl, deny = _renderer(s).compute_container_acls()
         # Must produce *something* (host IPs or fallback).
         assert "deny all;" in acl
-        assert "allow all;" in deny
+        assert "if ($container_source)" in deny
+
+
+class TestContainerGeo:
+    """The http-scope ``geo`` block that flags container-source peers (#1376,
+    #1546).
+
+    The browser catch-all ``location /`` denies requests whose *immediate*
+    TCP peer is a container source (pasta NAT) — capping brute-force surface
+    — but must NOT deny requests that only *look* like a container source
+    after #1560's realip rewrite (a trusted proxy co-located on the host,
+    whose forwarded real client is a host IP). So the geo is keyed on
+    ``$realip_remote_addr`` (the pre-realip peer), never ``$remote_addr``.
+    """
+
+    def test_explicit_subnets_listed_loopback_excluded(self):
+        s = make_settings(
+            env={"KLANGK_CONTAINER_SUBNETS": "10.89.0.0/24,172.30.0.0/16"}
+        )
+        geo = _renderer(s).compute_container_geo()
+        assert "geo $realip_remote_addr $container_source {" in geo
+        assert "10.89.0.0/24 1;" in geo
+        assert "172.30.0.0/16 1;" in geo
+        assert "default 0;" in geo
+
+    def test_loopback_never_flagged(self):
+        """Loopback maps to default 0 (allowed) even when listed in the set —
+        local browsers keep full UI/API access."""
+        s = make_settings(
+            env={"KLANGK_CONTAINER_SUBNETS": "127.0.0.1,10.89.0.0/24"}
+        )
+        geo = _renderer(s).compute_container_geo()
+        assert "10.89.0.0/24 1;" in geo
+        assert "127.0.0.1 1;" not in geo
+
+    def test_empty_or_all_loopback_still_emits_block(self):
+        """Even with no non-loopback sources, the ``$container_source`` variable
+        is declared (default 0) so the ``location /`` guard references a
+        defined variable."""
+        s = make_settings({"KLANGK_CONTAINER_SUBNETS": "127.0.0.1"})
+        geo = _renderer(s).compute_container_geo()
+        assert "geo $realip_remote_addr $container_source {" in geo
+        assert "default 0;" in geo
+        # No source lines beyond the default.
+        assert geo.count(" 1;") == 0
+
+    def test_uses_realip_remote_addr_not_remote_addr(self):
+        """Regression guard (#1546): the geo must key on the *immediate* peer
+        (``$realip_remote_addr``), not the realip-rewritten real client
+        (``$remote_addr``) — otherwise a co-located trusted proxy whose real
+        client is a host IP is denied on every browser request."""
+        s = make_settings(env={"KLANGK_CONTAINER_SUBNETS": "10.89.0.0/24"})
+        geo = _renderer(s).compute_container_geo()
+        assert "$realip_remote_addr" in geo
+        assert "$remote_addr $container_source" not in geo
+
+    def test_geo_emitted_in_full_config_at_http_scope(self):
+        s = make_settings(
+            {
+                "KLANGK_PORT": "8997",
+                "KLANGK_EGRESS_PORT": "8995",
+                "KLANGK_CONTAINER_SUBNETS": "10.89.0.0/24",
+            }
+        )
+        conf = _renderer(s).render_config(tcp_upstream("127.0.0.1", "8997"))
+        # geo block present, before the first server block (http scope).
+        geo_pos = conf.index("geo $realip_remote_addr $container_source")
+        first_server = conf.index("server {")
+        assert geo_pos < first_server
+        # The catch-all guard references the geo's variable.
+        catch_all = re.search(r"location / \{(.*?)\n    \}", conf, re.DOTALL)
+        assert catch_all, "location / not found"
+        assert "if ($container_source) { return 403; }" in catch_all.group(1)
 
 
 class TestDnsResolvers:
@@ -502,11 +566,14 @@ class TestContainerAclFallback:
 
         s = make_settings({})
         monkeypatch.setattr(nginx_mod, "detect_host_ipv4s", lambda: [])
-        acl, deny = _renderer(s).compute_container_acls()
+        acl, _deny = _renderer(s).compute_container_acls()
         assert "allow 172.16.0.0/12;" in acl
         assert "allow 10.0.0.0/8;" in acl
-        assert "deny 172.16.0.0/12;" in deny
-        assert "allow all;" in deny
+        # The fallback non-loopback ranges land in the geo block (the
+        # container-source flag), not as inline `deny` lines anymore.
+        geo = _renderer(s).compute_container_geo()
+        assert "172.16.0.0/12 1;" in geo
+        assert "10.0.0.0/8 1;" in geo
 
 
 class TestWriteConfig:

--- a/src/backend/tests/test_nginx.py
+++ b/src/backend/tests/test_nginx.py
@@ -566,7 +566,7 @@ class TestContainerAclFallback:
 
         s = make_settings({})
         monkeypatch.setattr(nginx_mod, "detect_host_ipv4s", lambda: [])
-        acl, _deny = _renderer(s).compute_container_acls()
+        acl, _ = _renderer(s).compute_container_acls()
         assert "allow 172.16.0.0/12;" in acl
         assert "allow 10.0.0.0/8;" in acl
         # The fallback non-loopback ranges land in the geo block (the


### PR DESCRIPTION
## Summary

Fixes the proxied-browser 403 found while validating #1546 (Caddy reverse proxy in a NixOS declarative container, co-located on klangk's host). After #1560's realip directives, every browser-path request through the proxy returned 403 and never reached the backend.

### Root cause

The browser catch-all `location /` deny (#1376 — the brute-force cap that stops a workspace container hammering `/api/v1/auth/login`) was an inline `deny <ip>; allow all;` list, which nginx evaluates against `$remote_addr`. #1560's `set_real_ip_from` rewrites `$remote_addr` to the `X-Forwarded-For` client whenever the immediate peer is a trusted proxy. A proxy co-located on klangk's host sees the browser on a host interface IP (e.g. the `10.100.0.0/24` container bridge) and forwards that as XFF → nginx rewrites `$remote_addr` to that host IP → it's in the deny list → 403 for the whole UI/API.

### Fix

Key the deny on the **immediate TCP peer** (pre-realip), not the rewritten real client. Replaced the inline `deny` list with:

```nginx
geo $realip_remote_addr $container_source {
    default 0;
    10.89.0.0/24 1;     # the non-loopback container-source set
    ...
}
...
location / {
    if ($container_source) { return 403; }
    proxy_pass ...;
}
```

`$realip_remote_addr` is the address the realip module *started with* — the real TCP peer, before its rewrite. Behavior matrix:

| request | immediate peer | `$remote_addr` (realip) | verdict |
|---|---|---|---|
| direct container via pasta NAT | host IP (a container source) | unchanged | **deny** (cap intact) |
| browser through trusted proxy | proxy IP (not a source) | real client | **allow** |
| loopback browser | 127.0.0.1 (never listed) | unchanged | allow |

So real-IP passthrough keeps working and the brute-force cap is preserved — a container connecting directly is still denied, only proxied traffic is let through. An upstream proxy on the same host now works out of the box; no `KLANGK_CONTAINER_SUBNETS` escape hatch needed.

The egress `CONTAINER_ACL` is unchanged (stays keyed on `$remote_addr` with `allow`/`deny`) — egress is reached *directly* by containers via pasta NAT, with no proxy in front to rewrite `$remote_addr`.

The `geo` block carries a plain-English comment explaining the `$realip_remote_addr`-vs-`$remote_addr` choice and all three request shapes.

### Validation

- New `TestContainerGeo` unit class (5 tests, incl. a regression guard that the geo uses `$realip_remote_addr`, not `$remote_addr`).
- Updated `TestContainerAcls` / `TestContainerAclFallback` for the new `(acl, deny_guard)` contract.
- The three `test_catch_all_*` e2e config tests rewritten for the geo block.
- New runtime e2e `test_proxied_request_with_container_xff_is_allowed`: a request whose immediate peer is trusted (loopback) but whose `X-Forwarded-For` is a container-source IP reaches the backend (not 403). This is the direct regression test for the bug.
- Existing `test_api_denied_from_container_ip` still passes — the brute-force cap is intact.
- Backend unit: **2403 passed, 100% coverage**. Nginx e2e: **30 passed**.
- End-to-end on the live #1546 deployment (keithmoon): `/api/v1/auth/me` via Caddy now returns **401** (reaches the backend) instead of 403; the access log shows `$remote_addr = 10.100.0.1` (real client, via realip) — exactly what #1546 wanted.

### Carries a decision for #1559 (nginx → Caddy swap)

This establishes the load-bearing rule for the Caddy migration: the container-source deny must use Caddy's **`remote_ip`** matcher (the connected TCP peer, ignores `trusted_proxies`) — **not `client_ip`** (the XFF-stripped real client, which considers `trusted_proxies`). Using `client_ip` would reintroduce this exact 403. Documented in a comment on #1559 with a Phase 2 parity-test acceptance criterion.

## Related

- #1546 — the deployment that surfaced it (validates the fix end-to-end).
- #1560 — the realip directives whose rewrite exposed the collision.
- #1376 — the original brute-force deny (preserved, just re-keyed).
- #1549 — the "behind a proxy" docs chapter (the gotcha I documented there is now superseded by this fix).
- #1559 — the Caddy swap, carrying the `remote_ip`-not-`client_ip` decision.

## Changelog

`docs/changes.md` `### Fixed` entry added under `[Unreleased]`.
