### PR TITLE
Fix flaky TestTokenRenewal token-expiry race (#1564)

### DIFF
--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -9749,19 +9749,33 @@ class TestTokenRenewal:
         session.container_id = "test-cid"
 
         try:
+            # Drive the renewal loop on a fast clock (so the first renewal
+            # fires well within the test's wait) while giving the minted
+            # token a wide (1h) lifetime. Decoupling trigger timing from
+            # token lifetime avoids the wall-clock race that made this
+            # test flaky on slow CI runners (#1564): the renewed token
+            # used to be minted with a ~0.36s lifetime (expire_hours=
+            # 0.0001) and was already expired by the time the decode
+            # assertion ran on a loaded runner.
+            original_sleep = asyncio.sleep
+
+            async def fast_sleep(delay, *a, **kw):
+                await original_sleep(min(delay, 0.01))
+
             with (
                 patch.object(
-                    app_state.auth, "workspace_token_expire_hours", 0.0001
+                    app_state.auth, "workspace_token_expire_hours", 1.0
                 ),
                 patch.object(
                     _mock_term,
                     "set_workspace_token",
                     new_callable=AsyncMock,
                 ) as mock_set,
+                patch("asyncio.sleep", side_effect=fast_sleep),
             ):
                 expiry = datetime.now(timezone.utc) + timedelta(seconds=0.1)
                 session.start_token_renewal(expiry)
-                await asyncio.sleep(0.5)
+                await original_sleep(0.5)
                 session._token_renewal_task.cancel()
                 try:
                     await session._token_renewal_task


### PR DESCRIPTION
## Summary

Fixes #1564.

`TestTokenRenewal::test_renewal_creates_new_token` was intermittently failing on GitHub Actions runners — the freshly-minted workspace token decoded as `WORKSPACE_TOKEN_EXPIRED` instead of the workspace ID.

## Root cause

The renewal loop was driven with `workspace_token_expire_hours=0.0001`, which bakes an `exp` claim of ~0.36s into the minted token (`auth.create_workspace_token` sets `exp = now + expire_hours`). The renewal *trigger delay* and the *token lifetime* were coupled to the same value. On a loaded runner, the wall-clock gap between mint (inside the loop) and the `decode_workspace_token` assertion (after the `with` block) exceeded 0.36s, so the token was already expired → `ExpiredSignatureError` → `WORKSPACE_TOKEN_EXPIRED`.

## Fix

Decouple the renewal trigger timing from the token lifetime, mirroring the existing `test_renewal_retries_on_failure` pattern:

- Give the minted token a wide (1h) expiry (`workspace_token_expire_hours=1.0`) so it cannot expire before the decode assertion.
- Speed the renewal loop's sleep via a patched `asyncio.sleep` (`fast_sleep`) so the renewal still fires well within the test's wait, despite the now-large `delay = lifetime * 0.8`.

The test asserts on what actually matters (the renewal loop creates a new token and pushes it), and no longer races real-time token expiry. The renewal's *trigger* is decoupled from any near-zero lifetime.

## Verification

- `TestTokenRenewal` class passes (4 tests).
- Stress-run: 50/50 consecutive runs pass.
- Full backend suite: 2405 passed, 100% coverage (`-n auto`, as CI runs it).

No changelog entry — test-only flake with no user-visible impact (per the issue).

## Checklist

- [x] Backend tests pass (`python -m pytest src/backend/tests -v -n auto`)
- [x] No coverage regression (100%)
