### PR TITLE
Model(app_state) foundation + tokens/login_attempts/invitations/ports (#1572)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -109,6 +109,21 @@ operators or integrators to act when upgrading.
   last "free function that takes `app_state`" pattern outside `model/`
   is gone (#1568).
 
+- **`Model(app_state)` composition root introduced (#1572).** A new
+  `app.state.model = Model(app.state)` (wired in `build_app` after
+  `app.state.db`) composes the per-domain data-access sub-objects.
+  Four standalone domains land first — `tokens`, `login_attempts`,
+  `invitations`, `ports` — as `TokensModel` / `LoginAttemptsModel` /
+  `InvitationsModel` / `PortsModel` (`app_state.model.tokens.X(...)`
+  etc.), each resolving the DB through `self.app_state.db` (the single
+  app-wide instance). App code for these domains now goes through
+  `app_state.model.<domain>.<method>`; the larger domains (`users`,
+  `acl`, `workspaces`, `chat`) still use the module-level free functions
+  via the `_current_db` ContextVar backstop until their follow-up issues.
+  No behavior change — same DB, same queries; this is the foundation slice
+  of #1563 and closes the #1551 divergence class for the four converted
+  domains.
+
 - **PID-file helpers moved onto `Util`** (`app.state.util`). The
   `pid_file_path` / `check_pid_file` / `write_pid_file` / `remove_pid_file`
   functions are now methods of the same `Util` that owns the instance ID —

--- a/src/backend/klangk_backend/api/admin.py
+++ b/src/backend/klangk_backend/api/admin.py
@@ -60,14 +60,20 @@ async def send_invitation(
             status_code=400, detail="A user with this email already exists"
         )
 
-    pending = await model.get_pending_invitation_by_email(req.email)
+    pending = (
+        await app_state.model.invitations.get_pending_invitation_by_email(
+            req.email
+        )
+    )
     if pending is not None:
         raise HTTPException(
             status_code=400,
             detail="A pending invitation already exists for this email",
         )
 
-    invitation = await model.create_invitation(req.email, admin["id"])
+    invitation = await app_state.model.invitations.create_invitation(
+        req.email, admin["id"]
+    )
     token = app_state.auth.create_invitation_token(invitation["id"], req.email)
 
     hostname, proto, base_path = request.app.state.util.derive_hosting_info(
@@ -100,6 +106,7 @@ async def list_invitations(
     order: str = "desc",
     q: str | None = None,
     admin: dict = Depends(acl.has_permission("admin")),
+    app_state=Depends(get_app_state_dep),
 ):
     """List invitations (admin only), server-side paginated/sorted/filtered.
 
@@ -108,7 +115,7 @@ async def list_invitations(
     of ``email`` | ``invited_by`` | ``created``, ``order`` is ``asc`` |
     ``desc``, and ``q`` is a substring filter on the invitee email.
     """
-    return await model.list_invitations(
+    return await app_state.model.invitations.list_invitations(
         page=page, page_size=page_size, sort=sort, order=order, q=q
     )
 
@@ -117,9 +124,12 @@ async def list_invitations(
 async def revoke_invitation(
     invitation_id: str,
     admin: dict = Depends(acl.has_permission("admin")),
+    app_state=Depends(get_app_state_dep),
 ):
     """Revoke a pending invitation (admin only)."""
-    revoked = await model.revoke_invitation(invitation_id)
+    revoked = await app_state.model.invitations.revoke_invitation(
+        invitation_id
+    )
     if not revoked:
         raise HTTPException(
             status_code=404,
@@ -136,7 +146,9 @@ async def resend_invitation(
     app_state=Depends(get_app_state_dep),
 ):
     """Resend an invitation email (admin only)."""
-    invitation = await model.get_invitation(invitation_id)
+    invitation = await app_state.model.invitations.get_invitation(
+        invitation_id
+    )
     if invitation is None or invitation["status"] != "pending":
         raise HTTPException(
             status_code=404,
@@ -221,7 +233,7 @@ async def admin_create_user(
             f"/#/verify?token={verification_token}"
         )
 
-        async with model.transaction() as db:
+        async with app_state.model.transaction() as db:
             await model.insert_unverified_user(
                 db, user_id, req.email, password_hash
             )
@@ -328,13 +340,15 @@ async def update_user(
 
 @router.post("/admin/users/{user_id}/unlockout")
 async def unlock_user(
-    user_id: str, admin: dict = Depends(acl.has_permission("admin"))
+    user_id: str,
+    admin: dict = Depends(acl.has_permission("admin")),
+    app_state=Depends(get_app_state_dep),
 ):
     """Reset a user's login lockout so they can log in immediately."""
     user = await model.get_user_by_id(user_id)
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
-    await model.clear_login_attempts(user["email"])
+    await app_state.model.login_attempts.clear_login_attempts(user["email"])
     return {"status": "unlocked"}
 
 

--- a/src/backend/klangk_backend/api/auth.py
+++ b/src/backend/klangk_backend/api/auth.py
@@ -108,7 +108,7 @@ async def register(
 
     # Insert user and send email in a transaction — if the email fails,
     # the user insert is rolled back so they can try again.
-    async with model.transaction() as db:
+    async with app_state.model.transaction() as db:
         await model.insert_unverified_user(
             db, user_id, req.email, password_hash
         )
@@ -421,7 +421,7 @@ async def change_email(
         raise HTTPException(status_code=400, detail="Email already in use")
     await model.update_email(user["id"], req.email)
     # Mark as unverified and send verification email
-    async with model.transaction() as db:
+    async with app_state.model.transaction() as db:
         await db.execute(
             "UPDATE users SET verified = 0 WHERE id = ?",
             (user["id"],),
@@ -539,7 +539,9 @@ async def accept_invite(req: AcceptInviteRequest, request: Request):
         )
     invitation_id, email = result
 
-    invitation = await model.get_invitation(invitation_id)
+    invitation = await request.app.state.model.invitations.get_invitation(
+        invitation_id
+    )
     if invitation is None or invitation["status"] != "pending":
         raise HTTPException(
             status_code=400, detail="Invitation is no longer valid"
@@ -555,7 +557,9 @@ async def accept_invite(req: AcceptInviteRequest, request: Request):
 
     password_hash = auth.hash_password(req.password)
     user = await model.create_user(email, password_hash, verified=True)
-    await model.mark_invitation_accepted(invitation_id)
+    await request.app.state.model.invitations.mark_invitation_accepted(
+        invitation_id
+    )
 
     access_token = request.app.state.auth.create_token(
         user["id"], user["email"]

--- a/src/backend/klangk_backend/auth.py
+++ b/src/backend/klangk_backend/auth.py
@@ -397,7 +397,9 @@ class Auth:
     async def login(self, req: LoginRequest) -> TokenResponse:
         # Check if locked out before doing any expensive work
         if self.login_lockout_failures > 0:
-            attempt_info = await model.get_login_attempt_info(req.email)
+            attempt_info = await self.app_state.model.login_attempts.get_login_attempt_info(
+                req.email
+            )
             is_locked, msg = is_locked_out(attempt_info)
             if is_locked:
                 raise HTTPException(status_code=429, detail=msg)
@@ -416,15 +418,21 @@ class Auth:
                 # if so, reset the count instead of incrementing, so old
                 # failures stop counting toward the threshold.
                 reset = self.window_elapsed(attempt_info)
-                await model.record_failed_login(req.email, reset=reset)
+                await self.app_state.model.login_attempts.record_failed_login(
+                    req.email, reset=reset
+                )
                 # Check if this attempt triggered a lockout
-                updated_info = await model.get_login_attempt_info(req.email)
+                updated_info = await self.app_state.model.login_attempts.get_login_attempt_info(
+                    req.email
+                )
                 if self.should_lockout(updated_info):
                     locked_until = datetime.now(timezone.utc) + timedelta(
                         seconds=self.login_lockout_duration
                     )
-                    await model.set_login_lockout(
-                        req.email, locked_until.isoformat()
+                    await (
+                        self.app_state.model.login_attempts.set_login_lockout(
+                            req.email, locked_until.isoformat()
+                        )
                     )
                     raise HTTPException(
                         status_code=429,
@@ -438,7 +446,9 @@ class Auth:
             )
 
         if self.login_lockout_failures > 0:
-            await model.clear_login_attempts(req.email)
+            await self.app_state.model.login_attempts.clear_login_attempts(
+                req.email
+            )
         token = self.create_token(user["id"], user["email"])
         return TokenResponse(access_token=token)
 
@@ -459,9 +469,11 @@ class Auth:
             if not all([user_id, email, jti, exp]):  # pragma: no cover
                 raise HTTPException(status_code=401, detail="Invalid token")
 
-            if await model.is_token_blocklisted(jti):
+            if await self.app_state.model.tokens.is_token_blocklisted(jti):
                 # Already refreshed — return the cached replacement
-                cached = await model.get_refreshed_token(jti)
+                cached = await self.app_state.model.tokens.get_refreshed_token(
+                    jti
+                )
                 if cached is not None:
                     return TokenResponse(access_token=cached)
                 raise HTTPException(
@@ -476,7 +488,9 @@ class Auth:
             expires_at = datetime.fromtimestamp(
                 exp, tz=timezone.utc
             ).isoformat()
-            await model.blocklist_token(jti, expires_at, new_token=new_token)
+            await self.app_state.model.tokens.blocklist_token(
+                jti, expires_at, new_token=new_token
+            )
             return TokenResponse(access_token=new_token)
 
         except ExpiredSignatureError:
@@ -484,7 +498,9 @@ class Auth:
             payload = self.decode_token(token, allow_expired=True)
             jti = payload.get("jti")
             if jti:
-                cached = await model.get_refreshed_token(jti)
+                cached = await self.app_state.model.tokens.get_refreshed_token(
+                    jti
+                )
                 if cached is not None:
                     return TokenResponse(access_token=cached)
             raise HTTPException(status_code=401, detail="Token expired")
@@ -505,7 +521,7 @@ class Auth:
             jti = payload.get("jti")
             if user_id is None or jti is None:
                 return None
-            if await model.is_token_blocklisted(jti):
+            if await self.app_state.model.tokens.is_token_blocklisted(jti):
                 return None
             return await model.get_user_by_id(user_id)
         except ExpiredSignatureError:
@@ -523,7 +539,9 @@ class Auth:
                 expires_at = datetime.fromtimestamp(
                     exp, tz=timezone.utc
                 ).isoformat()
-                await model.blocklist_token(jti, expires_at)
+                await self.app_state.model.tokens.blocklist_token(
+                    jti, expires_at
+                )
         except JWTError:
             pass
 
@@ -548,7 +566,7 @@ async def get_current_user(
         if user_id is None or jti is None:
             raise HTTPException(status_code=401, detail="Invalid token")
 
-        if await model.is_token_blocklisted(jti):
+        if await request.app.state.model.tokens.is_token_blocklisted(jti):
             raise HTTPException(
                 status_code=401, detail="Token has been revoked"
             )
@@ -575,7 +593,7 @@ async def get_current_user_optional(
         jti = payload.get("jti")
         if user_id is None or jti is None:
             return None
-        if await model.is_token_blocklisted(jti):
+        if await request.app.state.model.tokens.is_token_blocklisted(jti):
             return None
         return await model.get_user_by_id(user_id)
     except JWTError:

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -130,12 +130,14 @@ class PortAllocator:
         # until the container's first start reconcile (#1237).
         count = min(count, self.registry.ports_per_workspace_cap())
         async with self.port_lock:
-            return await model.find_and_allocate_ports(
+            return await self.registry.app_state.model.ports.find_and_allocate_ports(
                 workspace_id, count, self.registry.port_range_start
             )
 
     async def get_workspace_ports(self, workspace_id: str) -> list[int]:
-        return await model.get_workspace_ports(workspace_id)
+        return await self.registry.app_state.model.ports.get_workspace_ports(
+            workspace_id
+        )
 
 
 class BrowserRouter:
@@ -1113,17 +1115,23 @@ class ContainerRegistry:
         """
         num_ports = min(num_ports, self.ports_per_workspace_cap())
         async with self.port_lock:
-            host_ports = await model.get_workspace_ports(workspace_id)
+            host_ports = await self.app_state.model.ports.get_workspace_ports(
+                workspace_id
+            )
             if len(host_ports) < num_ports:
-                new_ports = await model.find_and_allocate_ports(
-                    workspace_id,
-                    num_ports - len(host_ports),
-                    self.port_range_start,
+                new_ports = (
+                    await self.app_state.model.ports.find_and_allocate_ports(
+                        workspace_id,
+                        num_ports - len(host_ports),
+                        self.port_range_start,
+                    )
                 )
                 host_ports.extend(new_ports)
             elif len(host_ports) > num_ports:
                 excess = host_ports[num_ports:]
-                await model.remove_port_allocations(workspace_id, excess)
+                await self.app_state.model.ports.remove_port_allocations(
+                    workspace_id, excess
+                )
                 host_ports = host_ports[:num_ports]
         return host_ports
 

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -584,6 +584,14 @@ def build_app(settings: KlangkSettings) -> FastAPI:
     # lifespan's context in the lifespan itself (#1520: no module-global
     # backstop — the model/ free functions reach it via a ContextVar).
     app.state.db = model.db.DB(settings)
+    # #1563 / #1572: Model(app_state) composes the per-domain data-access
+    # sub-objects (tokens, login_attempts, invitations, ports here; users,
+    # acl, workspaces, chat arrive in follow-up issues). Each reaches the
+    # DB via self.app_state.db — the single instance wired just above — so
+    # every code path resolves the same DB (the #1551 divergence class is
+    # structurally impossible for these domains). The not-yet-converted
+    # domains still go through the _current_db ContextVar backstop.
+    app.state.model = model.Model(app.state)
     app.state.agents = agent.Agents(app.state)
     # #1483: EmailService(app_state) owns SMTP/sendmail transport + the
     # Jinja template env (previously module-level functions reading

--- a/src/backend/klangk_backend/model/__init__.py
+++ b/src/backend/klangk_backend/model/__init__.py
@@ -32,6 +32,7 @@ from .db import (
     transaction,
 )
 from .schema import init_db
+from .model import Model
 from .users import (
     AGENT_USER_ID,
     AgentPrincipalError,
@@ -177,6 +178,8 @@ __all__ = (
     "transaction",
     # schema
     "init_db",
+    # composition root
+    "Model",
     # users
     "AGENT_USER_ID",
     "AgentPrincipalError",

--- a/src/backend/klangk_backend/model/invitations.py
+++ b/src/backend/klangk_backend/model/invitations.py
@@ -1,9 +1,183 @@
-"""User invitations (beta/access-request lifecycle)."""
+"""User invitations (beta/access-request lifecycle).
+
+:class:`InvitationsModel` is the ``app_state``-owned form reached via
+``app_state.model.invitations`` (#1563 / #1572). The module-level free
+functions are the pre-existing ``_current_db`` ContextVar delegates, kept
+as the backstop until #1578 dissolves the ContextVar.
+``ADMIN_INVITATION_SORT_COLUMNS`` is a pure constant (module-level).
+"""
 
 import uuid
 from datetime import datetime, timezone
 
 from .db import fetchone, transaction
+
+# Whitelisted sort columns for the admin invitations list. Values are the
+# SQL expressions to ORDER BY; the ``invited_by`` key sorts by the inviter's
+# email (the joined ``users.email``), which is the value the UI displays.
+ADMIN_INVITATION_SORT_COLUMNS = {
+    "email": "i.email",
+    "invited_by": "u.email",
+    "created": "i.created_at",
+}
+
+
+class InvitationsModel:
+    """Invitation lifecycle, resolved through ``app_state.db``.
+
+    Reached via ``app_state.model.invitations``. Reaches the DB through
+    ``self.app_state.db`` (the single DB instance for the whole app). The
+    method bodies mirror the module-level free functions below (backstop);
+    the duplication is temporary and removed in #1578 when the free
+    functions are deleted.
+    """
+
+    def __init__(self, app_state):
+        self.app_state = app_state
+
+    async def create_invitation(self, email: str, invited_by: str) -> dict:
+        """Create a new invitation. Returns the invitation dict."""
+        async with self.app_state.db.transaction() as db:
+            invitation_id = str(uuid.uuid4())
+            await db.execute(
+                "INSERT INTO invitations (id, email, invited_by) VALUES (?, ?, ?)",
+                (invitation_id, email, invited_by),
+            )
+            cursor = await db.execute(
+                "SELECT created_at FROM invitations WHERE id = ?",
+                (invitation_id,),
+            )
+            row = await cursor.fetchone()
+            return {
+                "id": invitation_id,
+                "email": email,
+                "invited_by": invited_by,
+                "status": "pending",
+                "created_at": row["created_at"],
+            }
+
+    async def get_invitation(self, invitation_id: str) -> dict | None:
+        """Get an invitation by ID."""
+        row = await self.app_state.db.fetchone(
+            "SELECT id, email, invited_by, status, created_at, accepted_at"
+            " FROM invitations WHERE id = ?",
+            (invitation_id,),
+        )
+        if row is None:
+            return None
+        return {
+            "id": row["id"],
+            "email": row["email"],
+            "invited_by": row["invited_by"],
+            "status": row["status"],
+            "created_at": row["created_at"],
+            "accepted_at": row["accepted_at"],
+        }
+
+    async def get_pending_invitation_by_email(self, email: str) -> dict | None:
+        """Get a pending invitation for the given email."""
+        row = await self.app_state.db.fetchone(
+            "SELECT id, email, invited_by, status, created_at, accepted_at"
+            " FROM invitations WHERE email = ? AND status = 'pending'",
+            (email,),
+        )
+        if row is None:
+            return None
+        return {
+            "id": row["id"],
+            "email": row["email"],
+            "invited_by": row["invited_by"],
+            "status": row["status"],
+            "created_at": row["created_at"],
+            "accepted_at": row["accepted_at"],
+        }
+
+    async def list_invitations(
+        self,
+        page: int = 1,
+        page_size: int = 10,
+        sort: str = "created",
+        order: str = "desc",
+        q: str | None = None,
+    ) -> dict:
+        """List invitations with server-side pagination, sorting, and filtering."""
+        sort_col = ADMIN_INVITATION_SORT_COLUMNS.get(sort, "i.created_at")
+        direction = "DESC" if order.lower() == "desc" else "ASC"
+        page = max(1, page)
+        page_size = max(1, min(page_size, 200))
+        offset = (page - 1) * page_size
+
+        async with self.app_state.db.transaction() as db:
+            where_clause = ""
+            params: list = []
+            if q:
+                where_clause = " WHERE i.email LIKE ?"
+                params.append(f"%{q}%")
+
+            count_cursor = await db.execute(
+                f"SELECT COUNT(*) AS c FROM invitations i{where_clause}",
+                params,
+            )
+            total = (await count_cursor.fetchone())["c"]
+
+            pending_cursor = await db.execute(
+                "SELECT COUNT(*) AS c FROM invitations WHERE status = 'pending'"
+            )
+            pending_count = (await pending_cursor.fetchone())["c"]
+
+            cursor = await db.execute(
+                "SELECT i.id, i.email, i.invited_by, i.status,"
+                " i.created_at, i.accepted_at, u.email AS invited_by_email"
+                " FROM invitations i"
+                " JOIN users u ON i.invited_by = u.id"
+                f"{where_clause}"
+                f" ORDER BY {sort_col} {direction}, i.id"
+                " LIMIT ? OFFSET ?",
+                (*params, page_size, offset),
+            )
+            invitations = [
+                {
+                    "id": row["id"],
+                    "email": row["email"],
+                    "invited_by": row["invited_by"],
+                    "invited_by_email": row["invited_by_email"],
+                    "status": row["status"],
+                    "created_at": row["created_at"],
+                    "accepted_at": row["accepted_at"],
+                }
+                for row in await cursor.fetchall()
+            ]
+            return {
+                "invitations": invitations,
+                "page": page,
+                "page_size": page_size,
+                "total": total,
+                "pending_count": pending_count,
+            }
+
+    async def mark_invitation_accepted(self, invitation_id: str) -> bool:
+        """Mark an invitation as accepted. Returns True if updated."""
+        async with self.app_state.db.transaction() as db:
+            now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
+            cursor = await db.execute(
+                "UPDATE invitations SET status = 'accepted', accepted_at = ?"
+                " WHERE id = ? AND status = 'pending'",
+                (now, invitation_id),
+            )
+            return cursor.rowcount > 0
+
+    async def revoke_invitation(self, invitation_id: str) -> bool:
+        """Revoke a pending invitation. Returns True if updated."""
+        async with self.app_state.db.transaction() as db:
+            cursor = await db.execute(
+                "UPDATE invitations SET status = 'revoked'"
+                " WHERE id = ? AND status = 'pending'",
+                (invitation_id,),
+            )
+            return cursor.rowcount > 0
+
+
+# --- ContextVar-backed free functions (backstop; removed in #1578) ---
 
 
 async def create_invitation(email: str, invited_by: str) -> dict:

--- a/src/backend/klangk_backend/model/login_attempts.py
+++ b/src/backend/klangk_backend/model/login_attempts.py
@@ -1,11 +1,89 @@
 """Login-attempt tracking for brute-force protection.
 
 Storage only; the sliding-window *decision* lives in ``auth.py``.
+:class:`LoginAttemptsModel` is the ``app_state``-owned form reached via
+``app_state.model.login_attempts`` (#1563 / #1572). The module-level free
+functions are the pre-existing ``_current_db`` ContextVar delegates, kept
+as the backstop until #1578 dissolves the ContextVar.
 """
 
 from datetime import datetime, timezone
 
-from .db import fetchone, transaction
+
+class LoginAttemptsModel:
+    """Login-attempt storage, resolved through ``app_state.db``.
+
+    Reached via ``app_state.model.login_attempts``. Reaches the DB through
+    ``self.app_state.db`` (the single DB instance for the whole app).
+    """
+
+    def __init__(self, app_state):
+        self.app_state = app_state
+
+    async def record_failed_login(
+        self, email: str, *, reset: bool = False
+    ) -> None:
+        """Record a failed login attempt for an email.
+
+        Storage only; the sliding-window *decision* lives in ``auth.py``.
+        """
+        async with self.app_state.db.transaction() as db:
+            now_iso = datetime.now(timezone.utc).isoformat()
+            if reset:
+                await db.execute(
+                    """INSERT INTO login_attempts
+                       (email, attempt_count, first_attempt_at)
+                       VALUES (?, 1, ?)
+                       ON CONFLICT(email) DO UPDATE SET
+                       attempt_count = 1,
+                       first_attempt_at = excluded.first_attempt_at,
+                       locked_until = NULL""",
+                    (email, now_iso),
+                )
+            else:
+                await db.execute(
+                    """INSERT INTO login_attempts (email, attempt_count, first_attempt_at)
+                       VALUES (?, 1, ?) ON CONFLICT(email) DO UPDATE SET
+                       attempt_count = attempt_count + 1""",
+                    (email, now_iso),
+                )
+
+    async def get_login_attempt_info(
+        self, email: str
+    ) -> dict[str, int | str | None] | None:
+        """Return login attempt info for an email, or None if no attempts tracked."""
+        row = await self.app_state.db.fetchone(
+            "SELECT attempt_count, first_attempt_at, locked_until"
+            " FROM login_attempts WHERE email = ?",
+            (email,),
+        )
+        if row is None:
+            return None
+        return {
+            "attempt_count": row["attempt_count"],
+            "first_attempt_at": row["first_attempt_at"],
+            "locked_until": row["locked_until"],
+        }
+
+    async def set_login_lockout(self, email: str, locked_until: str) -> None:
+        """Set the lockout time for an email after too many failed attempts."""
+        async with self.app_state.db.transaction() as db:
+            await db.execute(
+                "UPDATE login_attempts SET locked_until = ? WHERE email = ?",
+                (locked_until, email),
+            )
+
+    async def clear_login_attempts(self, email: str) -> None:
+        """Clear all login attempts for an email (on successful login)."""
+        async with self.app_state.db.transaction() as db:
+            await db.execute(
+                "DELETE FROM login_attempts WHERE email = ?", (email,)
+            )
+
+
+# --- ContextVar-backed free functions (backstop; removed in #1578) ---
+
+from .db import fetchone, transaction  # noqa: E402
 
 
 async def record_failed_login(email: str, *, reset: bool = False) -> None:

--- a/src/backend/klangk_backend/model/model.py
+++ b/src/backend/klangk_backend/model/model.py
@@ -1,0 +1,65 @@
+"""The ``Model(app_state)`` composition root for the data-access layer.
+
+Composes the per-domain sub-objects so call sites reach data access through
+a single owned instance — ``app_state.model.tokens.blocklist_token(...)`` —
+exactly like every other ``X(app_state)`` subsystem. Each sub-object takes
+``app_state`` and keeps it (reaching the DB via ``self.app_state.db``), so
+every code path that opens the DB (lifespan, request handlers, startup
+seed) uses the same resolved value — the one ``app.state.db`` the app was
+built with (#1563, #1551).
+
+Foundation (#1572): only the four standalone domains are composed here
+(``tokens``, ``login_attempts``, ``invitations``, ``ports``). The larger
+domains (``users``, ``acl``, ``workspaces``, ``chat``) are added in their
+own issues; until then they're still reached via the module-level free
+functions + the ``_current_db`` ContextVar backstop in ``model/db.py``.
+"""
+
+from contextlib import asynccontextmanager
+
+from .ports import PortsModel
+from .tokens import TokensModel
+from .login_attempts import LoginAttemptsModel
+from .invitations import InvitationsModel
+from .schema import init_db
+
+
+class Model:
+    """Owned data-access root: composes per-domain sub-objects.
+
+    Constructed once at startup (``app.state.model = Model(app_state)``).
+    Each sub-object takes ``app_state`` and reaches ``self.app_state.db``,
+    so there is a single DB instance for the whole app — no implicit
+    cross-task state (#1563).
+    """
+
+    def __init__(self, app_state):
+        self.app_state = app_state
+        self.tokens = TokensModel(app_state)
+        self.login_attempts = LoginAttemptsModel(app_state)
+        self.invitations = InvitationsModel(app_state)
+        self.ports = PortsModel(app_state)
+
+    @asynccontextmanager
+    async def transaction(self):
+        """Auto-commit-on-clean-exit transaction on this model's DB."""
+        async with self.app_state.db.transaction() as db:
+            yield db
+
+    async def fetchone(self, query: str, params: tuple = ()):
+        """Run a single-row SELECT and return the row, or ``None``."""
+        return await self.app_state.db.fetchone(query, params)
+
+    async def get_db(self):
+        """Acquire a raw connection. Caller commits/rolls back/closes."""
+        return await self.app_state.db.get_db()
+
+    async def init_db(self):
+        """Create/migrate the schema.
+
+        Reached through the active ContextVar DB until #1578 dissolves it;
+        ``Model`` itself holds no schema logic — the per-domain sub-objects
+        are added incrementally and the ContextVar backstop serves the
+        not-yet-converted ones.
+        """
+        await init_db()

--- a/src/backend/klangk_backend/model/ports.py
+++ b/src/backend/klangk_backend/model/ports.py
@@ -3,6 +3,11 @@
 OS-level socket probes (``port_in_use``, ``free_port``, ``scan_free_ports``)
 live in :mod:`klangk_backend.util` now (#1547); they are re-imported below so
 the historical ``model.ports.*`` / ``model.*`` import paths keep working.
+
+:class:`PortsModel` is the ``app_state``-owned form (DB-backed allocation)
+reached via ``app_state.model.ports`` (#1563 / #1572). The module-level free
+functions are the pre-existing ``_current_db`` ContextVar delegates, kept as
+the backstop until #1578 dissolves the ContextVar.
 """
 
 import asyncio
@@ -13,7 +18,6 @@ from ..util import (  # moved to util (#1547); re-exported via __all__
     port_in_use,
     scan_free_ports,
 )
-from .db import transaction
 
 
 __all__ = [
@@ -25,12 +29,93 @@ __all__ = [
     "free_port",
     "scan_free_ports",
     # DB-backed allocation tracking (this module's primary purpose).
+    "PortsModel",
     "add_port_allocations",
     "find_and_allocate_ports",
     "remove_port_allocations",
     "get_workspace_ports",
     "get_all_allocated_ports",
 ]
+
+
+class PortsModel:
+    """DB-backed port-allocation tracking, through ``app_state.db``.
+
+    Reached via ``app_state.model.ports``. Reaches the DB through
+    ``self.app_state.db`` (the single DB instance for the whole app). The
+    OS-level socket probes (``port_in_use`` etc.) stay in ``util`` — only
+    the DB-backed allocation tracking lives here.
+    """
+
+    def __init__(self, app_state):
+        self.app_state = app_state
+
+    async def add_port_allocations(
+        self, workspace_id: str, ports: list[int]
+    ) -> None:
+        """Allocate ports to a workspace. Raises IntegrityError on conflict."""
+        async with self.app_state.db.transaction() as db:
+            for port in ports:
+                await db.execute(
+                    "INSERT INTO port_allocations (port, workspace_id) VALUES (?, ?)",
+                    (port, workspace_id),
+                )
+
+    async def find_and_allocate_ports(
+        self, workspace_id: str, count: int, start: int
+    ) -> list[int]:
+        """Atomically find free ports and allocate them in a single transaction."""
+        async with self.app_state.db.transaction() as db:
+            cursor = await db.execute("SELECT port FROM port_allocations")
+            rows = await cursor.fetchall()
+            used = {row["port"] for row in rows}
+
+            # The socket.bind() probe inside scan_free_ports blocks, so run
+            # the scan in the default executor to avoid stalling the loop.
+            loop = asyncio.get_running_loop()
+            ports = await loop.run_in_executor(
+                None, scan_free_ports, start, count, used
+            )
+
+            for p in ports:
+                await db.execute(
+                    "INSERT INTO port_allocations (port, workspace_id) VALUES (?, ?)",
+                    (p, workspace_id),
+                )
+            return ports
+
+    async def remove_port_allocations(
+        self, workspace_id: str, ports: list[int]
+    ) -> None:
+        """Remove specific port allocations from a workspace."""
+        async with self.app_state.db.transaction() as db:
+            for port in ports:
+                await db.execute(
+                    "DELETE FROM port_allocations WHERE port = ? AND workspace_id = ?",
+                    (port, workspace_id),
+                )
+
+    async def get_workspace_ports(self, workspace_id: str) -> list[int]:
+        """Return all allocated ports for a workspace, sorted."""
+        async with self.app_state.db.transaction() as db:
+            cursor = await db.execute(
+                "SELECT port FROM port_allocations WHERE workspace_id = ? ORDER BY port",
+                (workspace_id,),
+            )
+            rows = await cursor.fetchall()
+            return [row["port"] for row in rows]
+
+    async def get_all_allocated_ports(self) -> set[int]:
+        """Return all allocated port numbers across all workspaces."""
+        async with self.app_state.db.transaction() as db:
+            cursor = await db.execute("SELECT port FROM port_allocations")
+            rows = await cursor.fetchall()
+            return {row["port"] for row in rows}
+
+
+# --- ContextVar-backed free functions (backstop; removed in #1578) ---
+
+from .db import transaction  # noqa: E402
 
 
 async def add_port_allocations(workspace_id: str, ports: list[int]) -> None:

--- a/src/backend/klangk_backend/model/tokens.py
+++ b/src/backend/klangk_backend/model/tokens.py
@@ -1,6 +1,58 @@
-"""JWT token blocklist (revocation + refreshed-token handoff)."""
+"""JWT token blocklist (revocation + refreshed-token handoff).
 
-from .db import fetchone, transaction
+:class:`TokensModel` is the ``app_state``-owned form reached via
+``app_state.model.tokens`` (#1563 / #1572). The module-level free functions
+are the pre-existing ``_current_db`` ContextVar delegates, kept as the
+backstop until #1578 dissolves the ContextVar — not-yet-converted callers
+and tests keep working unchanged.
+"""
+
+
+class TokensModel:
+    """Token-blocklist operations, resolved through ``app_state.db``.
+
+    Constructed by :class:`~klangk_backend.model.model.Model` and reached
+    via ``app_state.model.tokens``. Reaches the DB through
+    ``self.app_state.db`` (the single DB instance for the whole app).
+    """
+
+    def __init__(self, app_state):
+        self.app_state = app_state
+
+    async def blocklist_token(
+        self, jti: str, expires_at: str, new_token: str | None = None
+    ) -> None:
+        async with self.app_state.db.transaction() as db:
+            await db.execute(
+                "INSERT OR IGNORE INTO token_blocklist"
+                " (jti, expires_at, new_token) VALUES (?, ?, ?)",
+                (jti, expires_at, new_token),
+            )
+
+    async def is_token_blocklisted(self, jti: str) -> bool:
+        row = await self.app_state.db.fetchone(
+            "SELECT 1 FROM token_blocklist WHERE jti = ?",
+            (jti,),
+        )
+        return row is not None
+
+    async def get_refreshed_token(self, jti: str) -> str | None:
+        """Return the replacement token for a refreshed JTI.
+
+        The returned token is a full JWT whose own ``exp`` claim governs
+        its validity — no additional expiry check is needed here.
+        """
+        row = await self.app_state.db.fetchone(
+            "SELECT new_token FROM token_blocklist"
+            " WHERE jti = ? AND new_token IS NOT NULL",
+            (jti,),
+        )
+        return row[0] if row else None
+
+
+# --- ContextVar-backed free functions (backstop; removed in #1578) ---
+
+from .db import fetchone, transaction  # noqa: E402
 
 
 async def blocklist_token(

--- a/src/backend/tests/_helpers.py
+++ b/src/backend/tests/_helpers.py
@@ -29,3 +29,31 @@ def make_settings(
     )
     env.setdefault("KLANGK_DATA_DIR", tempfile.mkdtemp(prefix="klangk-data-"))
     return KlangkSettings(env=env, config_file=config_file)
+
+
+def wire_db_and_model(state) -> None:
+    """Attach ``db`` + ``model`` to a test ``app_state`` namespace (#1572).
+
+    App code reaches the converted domains (tokens, login_attempts,
+    invitations, ports) via ``app_state.model.<domain>.<method>``, which
+    resolves ``self.app_state.db``. Every test that builds an ``app_state``
+    namespace and constructs an owned instance that touches those domains
+    (``Auth``, ``ContainerRegistry``, …) must wire both.
+
+    Reuses the ContextVar-bound DB when one exists (the autouse
+    ``temp_data_dir`` fixture binds it and runs ``init_db`` against it), so
+    ``app_state.db`` is the *same* schema-bearing instance the rest of the
+    test reaches via the backstop — not a fresh DB on a different temp path
+    (which would hit "no such table"). Idempotent: skips re-wiring when
+    already present.
+    """
+    from klangk_backend.model import Model
+    from klangk_backend.model.db import DB, get_current_db
+
+    if getattr(state, "db", None) is None:
+        try:
+            state.db = get_current_db()
+        except LookupError:
+            state.db = DB(state.settings)
+    if getattr(state, "model", None) is None:
+        state.model = Model(state)

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -200,6 +200,13 @@ def app_state(temp_data_dir):
     state.workspaces = Workspaces(state)
     state.email = EmailService(state)
     state.util = Util(state)
+    # #1572: wire DB + Model(app_state) so converted domains (tokens,
+    # login_attempts, invitations, ports) reached via app_state.model.*
+    # resolve the per-test DB (the same one the ContextVar backstop binds
+    # for the not-yet-converted domains).
+    from _helpers import wire_db_and_model
+
+    wire_db_and_model(state)
     # Resolve the instance ID into the per-test util (writes
     # <data_dir>/instance-id), so consumers of app_state.util.instance_id()
     # get a real value without each test calling resolve explicitly.

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -33,7 +33,11 @@ import types
 def _auth():
     """A standalone Auth for token forging (same default secret as the
     app fixture, so tokens round-trip through app.state.auth.decode_*)."""
-    return auth_mod.Auth(types.SimpleNamespace(settings=make_settings({})))
+    from _helpers import wire_db_and_model
+
+    state = types.SimpleNamespace(settings=make_settings({}))
+    wire_db_and_model(state)
+    return auth_mod.Auth(state)
 
 
 # Aliases for the raw-JWT test that builds a token by hand.
@@ -73,6 +77,12 @@ async def app(db, temp_data_dir):
     app.state.util = util_mod.Util(app.state)
 
     app.state.auth = auth_mod.Auth(app.state)
+    # #1572: wire DB + Model(app_state) so converted domains (tokens,
+    # login_attempts, invitations, ports) reached via app_state.model.*
+    # resolve the same per-test DB the ContextVar backstop binds.
+    from _helpers import wire_db_and_model
+
+    wire_db_and_model(app.state)
 
     app.include_router(api.root_router)
     app.include_router(api.router, prefix=API_PREFIX)

--- a/src/backend/tests/test_auth.py
+++ b/src/backend/tests/test_auth.py
@@ -18,15 +18,24 @@ from klangk_backend.auth import Auth
 
 def _auth(env=None):
     """Build an Auth instance from explicit env (no os.environ)."""
-    return Auth(_types.SimpleNamespace(settings=make_settings(env)))
+    from _helpers import wire_db_and_model
+
+    state = _types.SimpleNamespace(settings=make_settings(env))
+    wire_db_and_model(state)
+    return Auth(state)
 
 
 def _req(auth=None):
-    """A request-like with app.state.auth for the FastAPI dep callables."""
+    """A request-like whose ``app.state`` is the auth's app_state.
+
+    Exposes ``app.state.auth`` (the FastAPI dep reads it) plus the
+    ``model``/``db`` the dep callables reach (#1572).
+    """
     if auth is None:
         auth = _auth()
+    auth.app_state.auth = auth
     return _types.SimpleNamespace(
-        app=_types.SimpleNamespace(state=_types.SimpleNamespace(auth=auth))
+        app=_types.SimpleNamespace(state=auth.app_state)
     )
 
 

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -51,6 +51,12 @@ def _make_app_state(registry=None, sockets=None):
     app_state.util = util_mod.Util(app_state)
 
     app_state.auth = auth_mod.Auth(app_state)
+    # #1572: ContainerRegistry reaches app_state.model.ports; Auth reaches
+    # app_state.model.{tokens,login_attempts}. Wire db + model onto the
+    # namespace (the ContextVar backstop binds the same DB for the rest).
+    from _helpers import wire_db_and_model
+
+    wire_db_and_model(app_state)
     return app_state
 
 

--- a/src/backend/tests/test_main.py
+++ b/src/backend/tests/test_main.py
@@ -55,6 +55,10 @@ def _make_app_state(settings=None):
     from klangk_backend.model import db as db_mod
 
     app_state.db = db_mod.DB(settings)
+    # #1572: Model(app_state) composing the converted domains.
+    from klangk_backend.model import Model
+
+    app_state.model = Model(app_state)
     app_state.agents = agent_mod.Agents(app_state)
     app_state.email = emailsvc_mod.EmailService(app_state)
     app_state.util = util_mod.Util(app_state)
@@ -409,6 +413,7 @@ class TestLifespan:
         app.state.sockets = app_state.sockets
         app.state.settings = app_state.settings
         app.state.db = app_state.db
+        app.state.model = app_state.model
         app.state.nginx_watchdog = nginx_mod.NginxWatchdog(app.state)
         app.state.oidc = oidc.OIDC(app.state)
         app.state.plugins = plugins.Plugins(app.state)
@@ -454,6 +459,7 @@ class TestLifespan:
         app.state.sockets = app_state.sockets
         app.state.settings = app_state.settings
         app.state.db = app_state.db
+        app.state.model = app_state.model
         app.state.nginx_watchdog = nginx_mod.NginxWatchdog(app.state)
         app.state.oidc = oidc.OIDC(app.state)
         app.state.plugins = plugins.Plugins(app.state)
@@ -680,6 +686,7 @@ class TestStartupShutdownRestart:
         app.state.sockets = app_state.sockets
         app.state.settings = app_state.settings
         app.state.db = app_state.db
+        app.state.model = app_state.model
         app.state.nginx_watchdog = nginx_mod.NginxWatchdog(app.state)
         app.state.oidc = oidc.OIDC(app.state)
         app.state.plugins = plugins.Plugins(app.state)

--- a/src/backend/tests/test_mode_switching.py
+++ b/src/backend/tests/test_mode_switching.py
@@ -34,7 +34,11 @@ import types
 
 def _auth():
     """Standalone Auth for token forging (default secret matches the app)."""
-    return auth_mod.Auth(types.SimpleNamespace(settings=make_settings({})))
+    from _helpers import wire_db_and_model
+
+    state = types.SimpleNamespace(settings=make_settings({}))
+    wire_db_and_model(state)
+    return auth_mod.Auth(state)
 
 
 DEFAULT_EMAIL = "admin@example.com"
@@ -76,6 +80,11 @@ async def mode_server(db, monkeypatch):
     app.state.util = util_mod.Util(app.state)
 
     app.state.auth = auth_mod.Auth(app.state)
+    # #1572: Auth (login/refresh/logout) reaches app.state.model.{tokens,
+    # login_attempts}; wire db + model onto the app state.
+    from _helpers import wire_db_and_model
+
+    wire_db_and_model(app.state)
     app.include_router(api.root_router)
     app.include_router(api.router, prefix=API_PREFIX)
     register_exception_handlers(app)

--- a/src/backend/tests/test_model_app_state.py
+++ b/src/backend/tests/test_model_app_state.py
@@ -1,0 +1,160 @@
+"""Direct coverage for the ``Model(app_state)`` composition root (#1572).
+
+The per-domain ``*Model`` classes (tokens, login_attempts, invitations, ports)
+and the ``Model`` transaction/init helpers are exercised here through
+``app_state.model`` — the same surface app code is migrating to. The
+module-level free-function backstops that lost their app-code callers (they
+moved to the class methods) are covered here too.
+"""
+
+import pytest
+
+from klangk_backend import model
+
+
+@pytest.fixture
+async def app_state_with_schema(app_state, db):
+    """app_state (db + model wired) with the schema initialized."""
+    return app_state
+
+
+class TestModelRoot:
+    """The Model composition root's own helpers (transaction/fetchone/get_db/init_db)."""
+
+    async def test_init_db_creates_schema(self, app_state, temp_data_dir):
+        # init_db via the Model method against the app_state DB.
+        await app_state.model.init_db()
+        async with app_state.model.transaction() as db:
+            cursor = await db.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+            tables = {r[0] for r in await cursor.fetchall()}
+        assert "users" in tables
+        assert "port_allocations" in tables
+
+    async def test_transaction_commits_and_rolls_back(
+        self, app_state_with_schema
+    ):
+        m = app_state_with_schema.model
+        async with m.transaction() as db:
+            await db.execute(
+                "INSERT INTO token_blocklist (jti, expires_at) VALUES (?, ?)",
+                ("root-jti", "2099-01-01"),
+            )
+        # committed: visible via fetchone
+        row = await m.fetchone(
+            "SELECT jti FROM token_blocklist WHERE jti = ?", ("root-jti",)
+        )
+        assert row is not None and row["jti"] == "root-jti"
+
+        # rollback path: an exception inside the block discards the write
+        with pytest.raises(RuntimeError):
+            async with m.transaction() as db:
+                await db.execute(
+                    "INSERT INTO token_blocklist (jti, expires_at)"
+                    " VALUES (?, ?)",
+                    ("rolled-jti", "2099-01-01"),
+                )
+                raise RuntimeError("boom")
+        row = await m.fetchone(
+            "SELECT jti FROM token_blocklist WHERE jti = ?", ("rolled-jti",)
+        )
+        assert row is None
+
+    async def test_get_db_returns_raw_connection(self, app_state_with_schema):
+        db = await app_state_with_schema.model.get_db()
+        try:
+            await db.execute(
+                "INSERT INTO token_blocklist (jti, expires_at) VALUES (?, ?)",
+                ("raw-jti", "2099-01-01"),
+            )
+            await db.commit()
+        finally:
+            await db.close()
+
+
+class TestTokensModel:
+    async def test_blocklist_and_check_and_refresh(
+        self, app_state_with_schema
+    ):
+        t = app_state_with_schema.model.tokens
+        assert await t.is_token_blocklisted("nope") is False
+        await t.blocklist_token("jti-1", "2099-01-01", new_token="new-jwt")
+        assert await t.is_token_blocklisted("jti-1") is True
+        assert await t.get_refreshed_token("jti-1") == "new-jwt"
+        assert await t.get_refreshed_token("none") is None
+
+    async def test_free_function_backstop(self, app_state_with_schema):
+        # The ContextVar-backed free function still works (backstop, #1578).
+        await model.blocklist_token("ff-jti", "2099-01-01", new_token="ff-new")
+        assert await model.get_refreshed_token("ff-jti") == "ff-new"
+        assert await model.is_token_blocklisted("ff-jti") is True
+
+
+class TestLoginAttemptsModel:
+    async def test_record_and_lock_and_clear(self, app_state_with_schema):
+        la = app_state_with_schema.model.login_attempts
+        await la.record_failed_login("a@b.com")
+        info = await la.get_login_attempt_info("a@b.com")
+        assert info["attempt_count"] == 1
+        await la.record_failed_login("a@b.com")
+        assert (await la.get_login_attempt_info("a@b.com"))[
+            "attempt_count"
+        ] == 2
+        await la.set_login_lockout("a@b.com", "2099-01-01")
+        assert (await la.get_login_attempt_info("a@b.com"))[
+            "locked_until"
+        ] == "2099-01-01"
+        await la.clear_login_attempts("a@b.com")
+        assert await la.get_login_attempt_info("a@b.com") is None
+
+    async def test_record_reset_clears_lockout(self, app_state_with_schema):
+        la = app_state_with_schema.model.login_attempts
+        await la.set_login_lockout("r@b.com", "2099-01-01")
+        await la.record_failed_login("r@b.com", reset=True)
+        info = await la.get_login_attempt_info("r@b.com")
+        assert info["attempt_count"] == 1
+        assert info["locked_until"] is None
+
+
+class TestInvitationsModel:
+    async def test_create_get_list_revoke(self, app_state_with_schema, user):
+        inv = app_state_with_schema.model.invitations
+        created = await inv.create_invitation("x@y.com", user["id"])
+        got = await inv.get_invitation(created["id"])
+        assert got["email"] == "x@y.com"
+        assert await inv.get_invitation("missing") is None
+        assert await inv.get_pending_invitation_by_email("x@y.com") is not None
+        listed = await inv.list_invitations(q="x@y")
+        assert listed["total"] == 1
+        assert listed["pending_count"] == 1
+        assert await inv.revoke_invitation(created["id"]) is True
+        assert await inv.revoke_invitation(created["id"]) is False
+
+    async def test_mark_accepted(self, app_state_with_schema, user):
+        inv = app_state_with_schema.model.invitations
+        created = await inv.create_invitation("z@y.com", user["id"])
+        assert await inv.mark_invitation_accepted(created["id"]) is True
+        assert await inv.mark_invitation_accepted(created["id"]) is False
+
+    async def test_free_function_backstop_list_with_q(
+        self, app_state_with_schema, user
+    ):
+        await model.create_invitation("q@y.com", user["id"])
+        listed = await model.list_invitations(q="q@y")
+        assert listed["total"] == 1
+
+
+class TestPortsModel:
+    async def test_add_find_remove_get(self, app_state_with_schema, workspace):
+        p = app_state_with_schema.model.ports
+        ws_id = workspace["id"]
+        await p.add_port_allocations(ws_id, [9000, 9001])
+        assert await p.get_workspace_ports(ws_id) == [9000, 9001]
+        # find_and_allocate skips already-allocated 9000/9001
+        new = await p.find_and_allocate_ports(ws_id, 1, 9000)
+        assert 9000 not in new and 9001 not in new
+        await p.remove_port_allocations(ws_id, [9000])
+        assert 9000 not in await p.get_workspace_ports(ws_id)
+        all_ports = await p.get_all_allocated_ports()
+        assert 9001 in all_ports

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -104,13 +104,22 @@ def _make_app_state(registry=None, sockets=None):
     app_state.util = util_mod.Util(app_state)
 
     app_state.auth = auth_mod.Auth(app_state)
+    # #1572: ContainerRegistry reaches app_state.model.ports; Auth reaches
+    # app_state.model.{tokens,login_attempts}.
+    from _helpers import wire_db_and_model
+
+    wire_db_and_model(app_state)
     return app_state
 
 
 def _auth():
     """A standalone Auth for token forging (same default secret as the
     app fixture, so tokens round-trip through app.state.auth.decode_*)."""
-    return auth_mod.Auth(types.SimpleNamespace(settings=make_settings({})))
+    from _helpers import wire_db_and_model
+
+    state = types.SimpleNamespace(settings=make_settings({}))
+    wire_db_and_model(state)
+    return auth_mod.Auth(state)
 
 
 def _mock_sock(headers=None, query_params=None):


### PR DESCRIPTION
## Summary

Foundation slice of #1563: introduces the `Model(app_state)` composition root and converts the four standalone data-access domains (`tokens`, `login_attempts`, `invitations`, `ports`) to `*Model(app_state)` classes. Closes #1572.

## Changes

- **`model/model.py`** (new) — `Model(app_state)` composing `TokensModel` / `LoginAttemptsModel` / `InvitationsModel` / `PortsModel`, plus `transaction()` / `fetchone()` / `get_db()` / `init_db()` methods. Each sub-object keeps `self.app_state` and resolves the DB via `self.app_state.db` (the single app-wide instance — closes the #1551 divergence class for these domains).
- **4 domain modules** — added the `*Model(app_state)` classes alongside the existing module-level free functions, which are kept verbatim as the `_current_db` ContextVar backstop (removed in #1578).
- **`build_app`** wires `app.state.model = Model(app.state)` after `app.state.db`.
- **App call sites converted** to `app_state.model.<domain>.<method>`: `auth.py` (tokens, login_attempts), `container.py` (ports — `PortAllocator` via `self.registry.app_state.model.ports`), `api/admin.py` + `api/auth.py` (invitations, txn delegates, login_attempts).
- **Tests** — `_helpers.wire_db_and_model()` reuses the ContextVar-bound DB (schema-bearing) to attach `db`+`model` onto every test `app_state`; applied to the test app/app_state builders in `conftest`, `test_api`, `test_auth`, `test_container`, `test_main`, `test_mode_switching`, `test_wshandler`. New `test_model_app_state.py` covers the `Model`/`*Model` surface directly.
- Changelog entry under `## [Unreleased]` → `### Changed`.

## Backstop (per #1572)

The `_current_db` ContextVar + module-level free-function delegates in `model/db.py` are **unchanged** — `users`, `acl`, `workspaces`, `chat` still go through them. The 4 converted domains stop using the ContextVar in app code (they reach `self.app_state.db`), but the free-function shims stay so not-yet-converted callers and tests keep working. Dissolved in #1578.

## Acceptance criteria (#1572)

- [x] `model/model.py` defines `Model(app_state)` composing the 4 `*Model` sub-objects + transaction/init helpers; `build_app` wires `app.state.model`.
- [x] `tokens`/`login_attempts`/`invitations`/`ports` are `*Model` classes; all app call sites use `app_state.model.<domain>.<method>`.
- [x] The `model.transaction()`/`get_db()`/`init_db()` delegate call sites route through `app_state.model.*`.
- [x] ContextVar + remaining free-function delegates (`users.*`, `acl.*`, `workspaces.*`, `chat.*`) unchanged and working.
- [x] Backend (`-n auto`) green at 100% — 2408 passed.
- [x] CLI green at 100% — 486 passed.
- [x] Changelog entry under `## [Unreleased]` → `### Changed`.

## Notes

- Hit a `deferred-imports` pre-commit hook — moved `Model`'s `from .schema import init_db` to module top (no cycle; `schema` imports only `db`/`acl`/`users`).
- Surfaced a pre-existing flaky test (`test_chat_send_agent_mention` under `-n auto`) — filed **#1581**, not caused by this change.

Parent: #1563. Next slices: #1573 (UsersModel), #1574 (ACLModel), #1575 (WorkspacesModel), #1576 (ChatModel), #1577 (ACL app_state dep), #1578 (final ContextVar dissolution + #1551 fix).
