### PR TITLE
Fix flaky chat agent-mention tests under -n auto (#1581)

### DIFF
--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -174,6 +174,23 @@ async def _empty_async_generator():
         yield
 
 
+async def _await_agent_run(workspace_id: str) -> None:
+    """Wait for a workspace's in-flight agent run to finish.
+
+    ``handle_chat_send`` schedules ``handle_agent_mention`` as a
+    fire-and-forget ``asyncio.create_task`` and returns immediately, so a
+    test can't observe the run's side effects (the ``send_prompt`` call,
+    the broadcasts) until that task has executed.  Awaiting the registered
+    task directly — instead of ``asyncio.sleep`` — removes the wall-clock
+    race that made the agent-mention tests flaky under ``-n auto``, where
+    CPU contention from sibling xdist workers let the 0.1s sleep elapse
+    before the task reached ``send_prompt`` (#1581).
+    """
+    task = _ws_constants.agent_tasks.get(workspace_id)
+    if task is not None:
+        await task
+
+
 def _base_conn(user=None, ws=None, app_state=None):
     if ws is None:
         ws = _mock_sock()
@@ -8744,7 +8761,7 @@ class TestChatSend:
                 await conn.handle_chat_send(
                     {"message": "@clanker what time is it?"}
                 )
-                await asyncio.sleep(0.1)
+                await _await_agent_run(workspace["id"])
             # Prompt was sent with the user's question
             mock_session.send_prompt.assert_awaited_once()
             calls = [c[0][0] for c in sock.send_json.call_args_list]
@@ -8796,7 +8813,7 @@ class TestChatSend:
                 return_value=mock_session,
             ):
                 await conn.handle_chat_send({"message": "@clanker"})
-                await asyncio.sleep(0.1)
+                await _await_agent_run(workspace["id"])
             calls = [c[0][0] for c in sock.send_json.call_args_list]
             agent_msgs = [
                 c
@@ -8827,7 +8844,7 @@ class TestChatSend:
                 side_effect=RuntimeError("boom"),
             ):
                 await conn.handle_chat_send({"message": "@clanker help"})
-                await asyncio.sleep(0.1)
+                await _await_agent_run(workspace["id"])
             calls = [c[0][0] for c in sock.send_json.call_args_list]
             agent_msgs = [
                 c
@@ -8867,7 +8884,7 @@ class TestChatSend:
                 return_value=mock_session,
             ):
                 await conn.handle_chat_send({"message": "@clanker hello"})
-                await asyncio.sleep(0.1)
+                await _await_agent_run(workspace["id"])
             calls = [c[0][0] for c in sock.send_json.call_args_list]
             sys_msgs = [
                 c


### PR DESCRIPTION
## Summary

Fixes #1581.

`TestChatSend::test_chat_send_agent_mention` failed intermittently under `pytest -n auto` with `Expected send_prompt to have been awaited once. Awaited 0 times.`, but always passed in isolation.

## Root cause

`handle_chat_send` schedules `handle_agent_mention` as a **fire-and-forget** `asyncio.create_task` and returns immediately. The agent-mention tests then did `await asyncio.sleep(0.1)` and asserted on the background run's side effects (`send_prompt` awaited, the `agent_thinking` / `chat_message` broadcasts).

Under `-n auto`, CPU contention from sibling xdist workers let the 0.1s of wall-clock elapse before the background task reached `send_prompt`. That task isn't free — before `send_prompt` it `await`s `model.agent_handle()`, `model.get_chat_messages(...)`, `model.agent_email()`, and `agents.get_session(...)` (several DB round-trips). On a loaded worker those weren't all done inside 0.1s, so the assertion ran first → `Awaited 0 times`.

The issue's "cross-worker state leak" hypothesis was a red herring: xdist workers are separate processes, each workspace fixture gets a fresh UUID (so `agent_conversations` keys never collide between tests), and there's no shared mock. It's purely the `sleep` racing a real background task.

## Fix

Replace the `asyncio.sleep(0.1)` with a **deterministic await of the registered agent task** — the same `await <task>` pattern already used in this file (`await conn._ssh_agent_task`). Added a small helper:

```python
async def _await_agent_run(workspace_id: str) -> None:
    task = _ws_constants.agent_tasks.get(workspace_id)
    if task is not None:
        await task
```

`handle_chat_send` registers the task in `_ws_constants.agent_tasks[workspace_id]`; the helper grabs it right after `handle_chat_send` returns (before the loop runs it) and awaits it to completion, so all side effects are observable at assertion time. `handle_agent_mention` swallows its own exceptions internally (error / process-died paths broadcast and return), so `await task` never raises out for the error-path tests.

Applied to all four agent-mention tests that assert on the run's effects (`test_chat_send_agent_mention`, `_empty_prompt`, `_error`, `_process_died`) — they shared the identical race. Left `test_chat_send_no_agent_mention` on a sleep since it's a **negative** assertion (no task to await; the sleep window is where a stray run would show up).

## Verification

- `TestChatSend` class: 15/15 pass.
- **10 consecutive full-suite `-n auto` runs: 0 failures** (acceptance criterion: ≥10 green).
- Full backend suite: 2397 passed, 100% coverage.
- CLI suite: 486 passed, 100% coverage.

Test-only fix → no changelog entry (per the issue).
