### PR TITLE
Hoist files.py functions into a Files(app_state) class (#1566)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -100,6 +100,15 @@ operators or integrators to act when upgrading.
 
 ### Changed
 
+- **`Files(app_state)` class** — the eight stateful file operations in
+  `klangk_backend/files.py` (list/read/write/delete/rename/stat/stream)
+  are now methods on a `Files(app_state)` class wired as
+  `app.state.files`, instead of free functions that took `podman` as a
+  trailing argument. `api/files.py` calls them as
+  `app_state.files.*(...)`; the class owns the `podman` reference the
+  same way `Workspaces`/`Terminal` do. The pure `validate_path` helper
+  stays module-level. No behavior change for API consumers (#1566).
+
 - **`bringup.py` folded into `ContainerRegistry`** — the container
   bring-up hook (provision the agent home, fire the service command) is
   now `ContainerRegistry._bringup`, called inline from `start_container`

--- a/src/backend/klangk_backend/api/files.py
+++ b/src/backend/klangk_backend/api/files.py
@@ -17,7 +17,6 @@ from pydantic import BaseModel
 
 from .. import (
     acl,
-    files,
 )
 from ._common import get_app_state_dep
 from ..util import (
@@ -50,7 +49,7 @@ async def list_files(
 ):
     cid = _require_container(workspace_id, app_state.container_registry)
     try:
-        return await files.list_files(cid, path, podman=app_state.podman)
+        return await app_state.files.list_files(cid, path)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
 
@@ -64,7 +63,7 @@ async def read_file(
 ):
     cid = _require_container(workspace_id, app_state.container_registry)
     try:
-        content = await files.read_file(cid, path, app_state.podman)
+        content = await app_state.files.read_file(cid, path)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     if content is None:
@@ -83,7 +82,7 @@ async def delete_file(
 ):
     cid = _require_container(workspace_id, app_state.container_registry)
     try:
-        deleted = await files.delete_path(cid, path, app_state.podman)
+        deleted = await app_state.files.delete_path(cid, path)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     except FileNotFoundError:
@@ -107,8 +106,8 @@ async def rename_file(
 ):
     cid = _require_container(workspace_id, app_state.container_registry)
     try:
-        renamed = await files.rename_path(
-            cid, body.old_path, body.new_path, app_state.podman
+        renamed = await app_state.files.rename_path(
+            cid, body.old_path, body.new_path
         )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
@@ -132,7 +131,7 @@ async def download_file(
 ):
     cid = _require_container(workspace_id, app_state.container_registry)
     try:
-        info = await files.stat_path(cid, path, app_state.podman)
+        info = await app_state.files.stat_path(cid, path)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     if info is None:
@@ -140,14 +139,14 @@ async def download_file(
     name = sanitize_disposition_name(posixpath.basename(path) or "download")
     if not info["is_dir"]:
         return StreamingResponse(
-            files.stream_file(cid, path, app_state.podman),
+            app_state.files.stream_file(cid, path),
             media_type="application/octet-stream",
             headers={
                 "Content-Disposition": f'attachment; filename="{name}"',
             },
         )
     return StreamingResponse(
-        files.stream_dir_tar(cid, path, app_state.podman),
+        app_state.files.stream_dir_tar(cid, path),
         media_type="application/gzip",
         headers={
             "Content-Disposition": f'attachment; filename="{name}.tar.gz"',
@@ -182,8 +181,8 @@ async def upload_file(
         buf.write(chunk)
 
     try:
-        saved_path = await files.write_file(
-            cid, filename, buf.getvalue(), app_state.podman
+        saved_path = await app_state.files.write_file(
+            cid, filename, buf.getvalue()
         )
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))

--- a/src/backend/klangk_backend/files.py
+++ b/src/backend/klangk_backend/files.py
@@ -1,9 +1,17 @@
 """File operations inside workspace containers via ``podman exec``.
 
-All path-accepting functions validate that paths are absolute and
+All path-accepting methods validate that paths are absolute and
 normalized.  Operations run as the ``klangk`` user inside the container
 so OS-level permissions apply.  The container boundary is the primary
 sandbox; ``validate_path`` provides defense-in-depth.
+
+The stateful operations live on the :class:`Files` class, constructed
+once in :func:`klangk_backend.main.build_app` and stored on
+``app.state.files`` (#1566) — the same ``X(app_state)`` pattern every
+other owned subsystem uses (``Workspaces``, ``Terminal``, ...). The
+class owns the ``podman`` reference instead of threading it through
+every call. ``validate_path`` is a pure path-normalization helper with
+no podman/settings dependency, so it stays module-level.
 """
 
 import posixpath
@@ -41,218 +49,224 @@ def validate_path(path: str) -> str:
     return normalized
 
 
-async def list_files(
-    container_id: str, path: str = "/", *, podman
-) -> list[dict]:
-    """List files and directories at the given path inside the container."""
-    path = validate_path(path)
-    rc, out, _err = await podman.exec_container(
-        container_id,
-        [
-            "find",
-            "-L",
-            path,
-            "-maxdepth",
-            "1",
-            "-mindepth",
-            "1",
-            "-printf",
-            r"%f\t%Y\t%s\t%T@\t%C@\n",
-        ],
-        user=EXEC_USER,
-    )
-    if rc != 0:
-        return []
-    entries = []
-    for line in out.strip().splitlines():
-        parts = line.split("\t")
-        if len(parts) != 5:
-            continue
-        name, ftype, size_str, mtime_str, ctime_str = parts
-        is_dir = ftype == "d"
-        entry_path = (
-            path.rstrip("/") + "/" + name if path != "/" else "/" + name
+class Files:
+    """File operations inside workspace containers via ``podman exec``.
+
+    Constructed once in :func:`klangk_backend.main.build_app` and stored
+    on ``app.state.files`` (#1566). The class owns the ``podman``
+    reference (previously threaded through every call as a trailing
+    argument), the same way ``Workspaces`` / ``Terminal`` own theirs.
+    """
+
+    def __init__(self, app_state):
+        self.app_state = app_state
+        self.podman = app_state.podman
+
+    async def list_files(
+        self, container_id: str, path: str = "/"
+    ) -> list[dict]:
+        """List files and directories at the given path inside the container."""
+        path = validate_path(path)
+        rc, out, _err = await self.podman.exec_container(
+            container_id,
+            [
+                "find",
+                "-L",
+                path,
+                "-maxdepth",
+                "1",
+                "-mindepth",
+                "1",
+                "-printf",
+                r"%f\t%Y\t%s\t%T@\t%C@\n",
+            ],
+            user=EXEC_USER,
         )
-        try:
-            size = int(size_str) if not is_dir else None
-        except ValueError:
-            size = None
-        try:
-            mtime = float(mtime_str)
-        except ValueError:
-            mtime = 0.0
-        try:
-            ctime = float(ctime_str)
-        except ValueError:
-            ctime = 0.0
-        entries.append(
-            {
-                "name": name,
-                "path": entry_path,
-                "is_dir": is_dir,
-                "size": size,
-                "mtime": mtime,
-                "ctime": ctime,
-            }
+        if rc != 0:
+            return []
+        entries = []
+        for line in out.strip().splitlines():
+            parts = line.split("\t")
+            if len(parts) != 5:
+                continue
+            name, ftype, size_str, mtime_str, ctime_str = parts
+            is_dir = ftype == "d"
+            entry_path = (
+                path.rstrip("/") + "/" + name if path != "/" else "/" + name
+            )
+            try:
+                size = int(size_str) if not is_dir else None
+            except ValueError:
+                size = None
+            try:
+                mtime = float(mtime_str)
+            except ValueError:
+                mtime = 0.0
+            try:
+                ctime = float(ctime_str)
+            except ValueError:
+                ctime = 0.0
+            entries.append(
+                {
+                    "name": name,
+                    "path": entry_path,
+                    "is_dir": is_dir,
+                    "size": size,
+                    "mtime": mtime,
+                    "ctime": ctime,
+                }
+            )
+        entries.sort(key=lambda e: e["name"])
+        return entries
+
+    async def stat_path(self, container_id: str, path: str) -> dict | None:
+        """Stat a single path.  Returns ``{"is_dir": bool, "size": int}``
+        or ``None`` if the path does not exist."""
+        path = validate_path(path)
+        rc, out, _err = await self.podman.exec_container(
+            container_id,
+            ["stat", "-L", "--format", "%F\t%s", "--", path],
+            user=EXEC_USER,
         )
-    entries.sort(key=lambda e: e["name"])
-    return entries
+        if rc != 0:
+            return None
+        parts = out.strip().split("\t")
+        if len(parts) != 2:
+            return None
+        ftype, size_str = parts
+        is_dir = "directory" in ftype
+        try:
+            size = int(size_str)
+        except ValueError:
+            size = 0
+        return {"is_dir": is_dir, "size": size}
 
+    async def read_file(self, container_id: str, path: str) -> str | None:
+        """Read file contents as text.  Returns None if missing or > 1 MB."""
+        path = validate_path(path)
+        info = await self.stat_path(container_id, path)
+        if info is None or info["is_dir"]:
+            return None
+        if info["size"] > 1_000_000:
+            return None
+        rc, out, _err = await self.podman.exec_container(
+            container_id,
+            ["cat", "--", path],
+            user=EXEC_USER,
+        )
+        if rc != 0:
+            return None
+        return out
 
-async def stat_path(container_id: str, path: str, podman) -> dict | None:
-    """Stat a single path.  Returns ``{"is_dir": bool, "size": int}``
-    or ``None`` if the path does not exist."""
-    path = validate_path(path)
-    rc, out, _err = await podman.exec_container(
-        container_id,
-        ["stat", "-L", "--format", "%F\t%s", "--", path],
-        user=EXEC_USER,
-    )
-    if rc != 0:
-        return None
-    parts = out.strip().split("\t")
-    if len(parts) != 2:
-        return None
-    ftype, size_str = parts
-    is_dir = "directory" in ftype
-    try:
-        size = int(size_str)
-    except ValueError:
-        size = 0
-    return {"is_dir": is_dir, "size": size}
+    def stream_file(
+        self, container_id: str, path: str
+    ) -> AsyncGenerator[bytes, None]:
+        """Stream file contents as raw bytes for download."""
+        path = validate_path(path)
+        return self.podman.exec_container_stream(
+            container_id,
+            ["cat", "--", path],
+            user=EXEC_USER,
+        )
 
+    def stream_dir_tar(
+        self, container_id: str, path: str
+    ) -> AsyncGenerator[bytes, None]:
+        """Stream a directory as a tar.gz archive for download."""
+        path = validate_path(path)
+        # Use sh -c with readlink to resolve symlinks before tar -C,
+        # because tar -C does not follow symlinks on all implementations.
+        return self.podman.exec_container_stream(
+            container_id,
+            [
+                "sh",
+                "-c",
+                'dir="$(readlink -f "$1")" && tar -czf - -C "$dir" .',
+                "sh",
+                path,
+            ],
+            user=EXEC_USER,
+        )
 
-async def read_file(container_id: str, path: str, podman) -> str | None:
-    """Read file contents as text.  Returns None if missing or > 1 MB."""
-    path = validate_path(path)
-    info = await stat_path(container_id, path, podman)
-    if info is None or info["is_dir"]:
-        return None
-    if info["size"] > 1_000_000:
-        return None
-    rc, out, _err = await podman.exec_container(
-        container_id,
-        ["cat", "--", path],
-        user=EXEC_USER,
-    )
-    if rc != 0:
-        return None
-    return out
+    async def delete_path(self, container_id: str, path: str) -> str:
+        """Delete a file or directory.  Returns the path deleted."""
+        path = validate_path(path)
+        # Check existence first
+        rc, _out, _err = await self.podman.exec_container(
+            container_id,
+            ["test", "-e", path],
+            user=EXEC_USER,
+        )
+        if rc != 0:
+            raise FileNotFoundError("Path not found")
+        rc, _out, err = await self.podman.exec_container(
+            container_id,
+            ["rm", "-rf", "--", path],
+            user=EXEC_USER,
+        )
+        if rc != 0:
+            raise OSError(f"Delete failed: {err.strip()}")
+        return path
 
+    async def rename_path(
+        self, container_id: str, old_path: str, new_path: str
+    ) -> str:
+        """Rename/move a file or directory.  Returns the new path."""
+        old_path = validate_path(old_path)
+        new_path = validate_path(new_path)
+        # Check source exists
+        rc, _out, _err = await self.podman.exec_container(
+            container_id,
+            ["test", "-e", old_path],
+            user=EXEC_USER,
+        )
+        if rc != 0:
+            raise FileNotFoundError("Source path not found")
+        # Check dest does not exist
+        rc, _out, _err = await self.podman.exec_container(
+            container_id,
+            ["test", "-e", new_path],
+            user=EXEC_USER,
+        )
+        if rc == 0:
+            raise FileExistsError("Destination already exists")
+        # Create parent directory
+        parent = posixpath.dirname(new_path)
+        await self.podman.exec_container(
+            container_id,
+            ["mkdir", "-p", "--", parent],
+            user=EXEC_USER,
+        )
+        # Move
+        rc, _out, err = await self.podman.exec_container(
+            container_id,
+            ["mv", "--", old_path, new_path],
+            user=EXEC_USER,
+        )
+        if rc != 0:
+            raise OSError(f"Rename failed: {err.strip()}")
+        return new_path
 
-def stream_file(
-    container_id: str, path: str, podman
-) -> AsyncGenerator[bytes, None]:
-    """Stream file contents as raw bytes for download."""
-    path = validate_path(path)
-    return podman.exec_container_stream(
-        container_id,
-        ["cat", "--", path],
-        user=EXEC_USER,
-    )
-
-
-def stream_dir_tar(
-    container_id: str, path: str, podman
-) -> AsyncGenerator[bytes, None]:
-    """Stream a directory as a tar.gz archive for download."""
-    path = validate_path(path)
-    # Use sh -c with readlink to resolve symlinks before tar -C,
-    # because tar -C does not follow symlinks on all implementations.
-    return podman.exec_container_stream(
-        container_id,
-        [
-            "sh",
-            "-c",
-            'dir="$(readlink -f "$1")" && tar -czf - -C "$dir" .',
-            "sh",
-            path,
-        ],
-        user=EXEC_USER,
-    )
-
-
-async def delete_path(container_id: str, path: str, podman) -> str:
-    """Delete a file or directory.  Returns the path deleted."""
-    path = validate_path(path)
-    # Check existence first
-    rc, _out, _err = await podman.exec_container(
-        container_id,
-        ["test", "-e", path],
-        user=EXEC_USER,
-    )
-    if rc != 0:
-        raise FileNotFoundError("Path not found")
-    rc, _out, err = await podman.exec_container(
-        container_id,
-        ["rm", "-rf", "--", path],
-        user=EXEC_USER,
-    )
-    if rc != 0:
-        raise OSError(f"Delete failed: {err.strip()}")
-    return path
-
-
-async def rename_path(
-    container_id: str, old_path: str, new_path: str, podman
-) -> str:
-    """Rename/move a file or directory.  Returns the new path."""
-    old_path = validate_path(old_path)
-    new_path = validate_path(new_path)
-    # Check source exists
-    rc, _out, _err = await podman.exec_container(
-        container_id,
-        ["test", "-e", old_path],
-        user=EXEC_USER,
-    )
-    if rc != 0:
-        raise FileNotFoundError("Source path not found")
-    # Check dest does not exist
-    rc, _out, _err = await podman.exec_container(
-        container_id,
-        ["test", "-e", new_path],
-        user=EXEC_USER,
-    )
-    if rc == 0:
-        raise FileExistsError("Destination already exists")
-    # Create parent directory
-    parent = posixpath.dirname(new_path)
-    await podman.exec_container(
-        container_id,
-        ["mkdir", "-p", "--", parent],
-        user=EXEC_USER,
-    )
-    # Move
-    rc, _out, err = await podman.exec_container(
-        container_id,
-        ["mv", "--", old_path, new_path],
-        user=EXEC_USER,
-    )
-    if rc != 0:
-        raise OSError(f"Rename failed: {err.strip()}")
-    return new_path
-
-
-async def write_file(
-    container_id: str, path: str, content: bytes, podman
-) -> str:
-    """Write file contents.  Returns the path written."""
-    path = validate_path(path)
-    # mkdir -p + cat > file in one sh invocation.
-    # Path is passed as $1 (positional arg), never interpolated into the
-    # command string, so shell metacharacters in the path are harmless.
-    rc, _out, err = await podman.exec_container(
-        container_id,
-        [
-            "sh",
-            "-c",
-            'mkdir -p "$(dirname "$1")" && cat > "$1"',
-            "sh",
-            path,
-        ],
-        user=EXEC_USER,
-        stdin_data=content,
-    )
-    if rc != 0:
-        raise OSError(f"Write failed: {err.strip()}")
-    return path
+    async def write_file(
+        self, container_id: str, path: str, content: bytes
+    ) -> str:
+        """Write file contents.  Returns the path written."""
+        path = validate_path(path)
+        # mkdir -p + cat > file in one sh invocation.
+        # Path is passed as $1 (positional arg), never interpolated into the
+        # command string, so shell metacharacters in the path are harmless.
+        rc, _out, err = await self.podman.exec_container(
+            container_id,
+            [
+                "sh",
+                "-c",
+                'mkdir -p "$(dirname "$1")" && cat > "$1"',
+                "sh",
+                path,
+            ],
+            user=EXEC_USER,
+            stdin_data=content,
+        )
+        if rc != 0:
+            raise OSError(f"Write failed: {err.strip()}")
+        return path

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -21,6 +21,7 @@ from . import (
     auth,
     container,
     emailsvc,
+    files,
     model,
     nginx as nginx_mod,
     oidc,
@@ -579,6 +580,11 @@ def build_app(settings: KlangkSettings) -> FastAPI:
     # settings.data_dir at construction, not frozen at import) + CRUD/path
     # helpers.
     app.state.workspaces = workspaces.Workspaces(app.state)
+    # #1566: Files(app_state) owns the podman-exec file operations
+    # (list/read/write/delete/rename/stream), previously free functions
+    # in files.py that threaded podman through every call. The class owns
+    # the podman reference, the same way Workspaces/Terminal do.
+    app.state.files = files.Files(app.state)
     # #1452: DB(settings) owns the engine cache + data dir (computed from
     # settings, not frozen at import). Bound as the active DB for the
     # lifespan's context in the lifespan itself (#1520: no module-global

--- a/src/backend/tests/test_agent.py
+++ b/src/backend/tests/test_agent.py
@@ -7,6 +7,7 @@ import pytest
 from unittest.mock import AsyncMock, patch, MagicMock
 
 from _helpers import make_settings
+from klangk_backend import files as files_mod
 from klangk_backend.agent import (
     AgentError,
     AgentProcessDied,
@@ -65,6 +66,7 @@ def _make_app_state(cid="cid"):
         podman=mock_pod,
     )
     app_state.workspaces = MagicMock()
+    app_state.files = files_mod.Files(app_state)
     app_state.sockets = MagicMock()
     return app_state
 

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -16,6 +16,7 @@ from klangk_backend import (
     agent,
     api,
     auth as auth_mod,
+    files as files_mod,
     model,
     podman,
     workspaces as ws_mod,
@@ -72,6 +73,7 @@ async def app(db, temp_data_dir):
     app.state.oidc = oidc_mod.OIDC(app.state)
     app.state.plugins = plugins_mod.Plugins(app.state)
     app.state.workspaces = ws_mod.Workspaces(app.state)
+    app.state.files = files_mod.Files(app.state)
     app.state.agents = agent.Agents(app.state)
     app.state.email = emailsvc_mod.EmailService(app.state)
     app.state.util = util_mod.Util(app.state)
@@ -4317,7 +4319,7 @@ class TestFileRoutes:
         ws_id = await self._create_workspace(client, headers)
         try:
             with patch(
-                "klangk_backend.files.delete_path",
+                "klangk_backend.files.Files.delete_path",
                 new_callable=AsyncMock,
                 side_effect=OSError("Permission denied"),
             ):
@@ -4404,7 +4406,7 @@ class TestFileRoutes:
         ws_id = await self._create_workspace(client, headers)
         try:
             with patch(
-                "klangk_backend.files.rename_path",
+                "klangk_backend.files.Files.rename_path",
                 new_callable=AsyncMock,
                 side_effect=OSError("Permission denied"),
             ):

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -13,6 +13,7 @@ import pytest
 from klangk_backend import (
     auth as auth_mod,
     container,
+    files as files_mod,
     model,
     podman,
     util as util_mod,
@@ -47,6 +48,7 @@ def _make_app_state(registry=None, sockets=None):
     from klangk_backend.workspaces import Workspaces
 
     app_state.workspaces = Workspaces(app_state)
+    app_state.files = files_mod.Files(app_state)
     # #1503: container.py reaches derive_hosting_info via app_state.util.
     app_state.util = util_mod.Util(app_state)
 

--- a/src/backend/tests/test_files.py
+++ b/src/backend/tests/test_files.py
@@ -1,5 +1,6 @@
 """Tests for files: exec-based list, read, write, delete, rename, path validation."""
 
+import types
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -11,6 +12,16 @@ _mock_pod = MagicMock()
 CID = "test-container-123"
 EXEC = "exec_container"
 EXEC_STREAM = "exec_container_stream"
+
+
+@pytest.fixture
+def files_inst():
+    """A ``Files`` instance whose ``podman`` is the shared mock.
+
+    Per-test ``patch.object(_mock_pod, ...)`` patches apply because the
+    instance holds the same object reference (``self.podman = _mock_pod``).
+    """
+    return files.Files(types.SimpleNamespace(podman=_mock_pod))
 
 
 class TestValidatePath:
@@ -77,7 +88,7 @@ class TestValidatePath:
 
 
 class TestListFiles:
-    async def test_list_files(self):
+    async def test_list_files(self, files_inst):
         find_output = (
             "a.txt\tf\t100\t1700000000.0\t1700000001.0\n"
             "subdir\td\t4096\t1700000002.0\t1700000003.0\n"
@@ -88,9 +99,7 @@ class TestListFiles:
             new_callable=AsyncMock,
             return_value=(0, find_output, ""),
         ) as mock:
-            entries = await files.list_files(
-                CID, "/home/work", podman=_mock_pod
-            )
+            entries = await files_inst.list_files(CID, "/home/work")
 
         mock.assert_called_once()
         assert mock.call_args.kwargs["user"] == "klangk"
@@ -107,7 +116,7 @@ class TestListFiles:
         assert entries[1]["is_dir"] is True
         assert entries[1]["size"] is None
 
-    async def test_list_root(self):
+    async def test_list_root(self, files_inst):
         find_output = "home\td\t4096\t1700000000.0\t1700000000.0\n"
         with patch.object(
             _mock_pod,
@@ -115,34 +124,30 @@ class TestListFiles:
             new_callable=AsyncMock,
             return_value=(0, find_output, ""),
         ):
-            entries = await files.list_files(CID, "/", podman=_mock_pod)
+            entries = await files_inst.list_files(CID, "/")
 
         assert entries[0]["path"] == "/home"
 
-    async def test_list_empty_dir(self):
+    async def test_list_empty_dir(self, files_inst):
         with patch.object(
             _mock_pod, EXEC, new_callable=AsyncMock, return_value=(0, "", "")
         ):
-            entries = await files.list_files(
-                CID, "/home/work", podman=_mock_pod
-            )
+            entries = await files_inst.list_files(CID, "/home/work")
 
         assert entries == []
 
-    async def test_list_nonexistent_dir(self):
+    async def test_list_nonexistent_dir(self, files_inst):
         with patch.object(
             _mock_pod,
             EXEC,
             new_callable=AsyncMock,
             return_value=(1, "", "No such file"),
         ):
-            entries = await files.list_files(
-                CID, "/no/such/dir", podman=_mock_pod
-            )
+            entries = await files_inst.list_files(CID, "/no/such/dir")
 
         assert entries == []
 
-    async def test_list_sorted(self):
+    async def test_list_sorted(self, files_inst):
         find_output = (
             "c.txt\tf\t1\t0.0\t0.0\n"
             "a.txt\tf\t1\t0.0\t0.0\n"
@@ -154,15 +159,15 @@ class TestListFiles:
             new_callable=AsyncMock,
             return_value=(0, find_output, ""),
         ):
-            entries = await files.list_files(CID, "/home", podman=_mock_pod)
+            entries = await files_inst.list_files(CID, "/home")
 
         assert [e["name"] for e in entries] == ["a.txt", "b.txt", "c.txt"]
 
-    async def test_list_rejects_relative_path(self):
+    async def test_list_rejects_relative_path(self, files_inst):
         with pytest.raises(ValueError, match="absolute"):
-            await files.list_files(CID, "work", podman=_mock_pod)
+            await files_inst.list_files(CID, "work")
 
-    async def test_list_symlink_to_dir(self):
+    async def test_list_symlink_to_dir(self, files_inst):
         """Symlinks to directories show as is_dir=True (find -printf %Y)."""
         find_output = "link\td\t4096\t0.0\t0.0\n"
         with patch.object(
@@ -171,10 +176,10 @@ class TestListFiles:
             new_callable=AsyncMock,
             return_value=(0, find_output, ""),
         ):
-            entries = await files.list_files(CID, "/home", podman=_mock_pod)
+            entries = await files_inst.list_files(CID, "/home")
         assert entries[0]["is_dir"] is True
 
-    async def test_list_symlink_to_file(self):
+    async def test_list_symlink_to_file(self, files_inst):
         """Symlinks to files show as is_dir=False (find -printf %Y returns f)."""
         find_output = "link\tf\t100\t0.0\t0.0\n"
         with patch.object(
@@ -183,10 +188,10 @@ class TestListFiles:
             new_callable=AsyncMock,
             return_value=(0, find_output, ""),
         ):
-            entries = await files.list_files(CID, "/home", podman=_mock_pod)
+            entries = await files_inst.list_files(CID, "/home")
         assert entries[0]["is_dir"] is False
 
-    async def test_list_broken_symlink(self):
+    async def test_list_broken_symlink(self, files_inst):
         """Broken symlinks (find -printf %Y returns N) show as is_dir=False."""
         find_output = "broken\tN\t0\t0.0\t0.0\n"
         with patch.object(
@@ -195,10 +200,10 @@ class TestListFiles:
             new_callable=AsyncMock,
             return_value=(0, find_output, ""),
         ):
-            entries = await files.list_files(CID, "/home", podman=_mock_pod)
+            entries = await files_inst.list_files(CID, "/home")
         assert entries[0]["is_dir"] is False
 
-    async def test_list_skips_malformed_lines(self):
+    async def test_list_skips_malformed_lines(self, files_inst):
         find_output = "good.txt\tf\t10\t0.0\t0.0\nbadline\n"
         with patch.object(
             _mock_pod,
@@ -206,11 +211,11 @@ class TestListFiles:
             new_callable=AsyncMock,
             return_value=(0, find_output, ""),
         ):
-            entries = await files.list_files(CID, "/home", podman=_mock_pod)
+            entries = await files_inst.list_files(CID, "/home")
         assert len(entries) == 1
         assert entries[0]["name"] == "good.txt"
 
-    async def test_list_handles_bad_size(self):
+    async def test_list_handles_bad_size(self, files_inst):
         find_output = "f.txt\tf\tnotanumber\t0.0\t0.0\n"
         with patch.object(
             _mock_pod,
@@ -218,10 +223,10 @@ class TestListFiles:
             new_callable=AsyncMock,
             return_value=(0, find_output, ""),
         ):
-            entries = await files.list_files(CID, "/home", podman=_mock_pod)
+            entries = await files_inst.list_files(CID, "/home")
         assert entries[0]["size"] is None
 
-    async def test_list_handles_bad_mtime(self):
+    async def test_list_handles_bad_mtime(self, files_inst):
         find_output = "f.txt\tf\t10\tbad\t0.0\n"
         with patch.object(
             _mock_pod,
@@ -229,10 +234,10 @@ class TestListFiles:
             new_callable=AsyncMock,
             return_value=(0, find_output, ""),
         ):
-            entries = await files.list_files(CID, "/home", podman=_mock_pod)
+            entries = await files_inst.list_files(CID, "/home")
         assert entries[0]["mtime"] == 0.0
 
-    async def test_list_handles_bad_ctime(self):
+    async def test_list_handles_bad_ctime(self, files_inst):
         find_output = "f.txt\tf\t10\t0.0\tbad\n"
         with patch.object(
             _mock_pod,
@@ -240,142 +245,134 @@ class TestListFiles:
             new_callable=AsyncMock,
             return_value=(0, find_output, ""),
         ):
-            entries = await files.list_files(CID, "/home", podman=_mock_pod)
+            entries = await files_inst.list_files(CID, "/home")
         assert entries[0]["ctime"] == 0.0
 
-    async def test_list_default_path_is_root(self):
+    async def test_list_default_path_is_root(self, files_inst):
         with patch.object(
             _mock_pod, EXEC, new_callable=AsyncMock, return_value=(0, "", "")
         ) as mock:
-            await files.list_files(CID, podman=_mock_pod)
+            await files_inst.list_files(CID)
 
         cmd = mock.call_args[0][1]
         assert cmd[2] == "/"
 
 
 class TestStatPath:
-    async def test_stat_file(self):
+    async def test_stat_file(self, files_inst):
         with patch.object(
             _mock_pod,
             EXEC,
             new_callable=AsyncMock,
             return_value=(0, "regular file\t12345", ""),
         ):
-            info = await files.stat_path(
-                CID, "/home/work/f.txt", podman=_mock_pod
-            )
+            info = await files_inst.stat_path(CID, "/home/work/f.txt")
 
         assert info == {"is_dir": False, "size": 12345}
 
-    async def test_stat_directory(self):
+    async def test_stat_directory(self, files_inst):
         with patch.object(
             _mock_pod,
             EXEC,
             new_callable=AsyncMock,
             return_value=(0, "directory\t4096", ""),
         ):
-            info = await files.stat_path(CID, "/home/work", podman=_mock_pod)
+            info = await files_inst.stat_path(CID, "/home/work")
 
         assert info == {"is_dir": True, "size": 4096}
 
-    async def test_stat_malformed_output(self):
+    async def test_stat_malformed_output(self, files_inst):
         with patch.object(
             _mock_pod,
             EXEC,
             new_callable=AsyncMock,
             return_value=(0, "garbage", ""),
         ):
-            info = await files.stat_path(CID, "/home", podman=_mock_pod)
+            info = await files_inst.stat_path(CID, "/home")
         assert info is None
 
-    async def test_stat_bad_size(self):
+    async def test_stat_bad_size(self, files_inst):
         with patch.object(
             _mock_pod,
             EXEC,
             new_callable=AsyncMock,
             return_value=(0, "regular file\tnotanumber", ""),
         ):
-            info = await files.stat_path(CID, "/f.txt", podman=_mock_pod)
+            info = await files_inst.stat_path(CID, "/f.txt")
         assert info == {"is_dir": False, "size": 0}
 
-    async def test_stat_nonexistent(self):
+    async def test_stat_nonexistent(self, files_inst):
         with patch.object(
             _mock_pod,
             EXEC,
             new_callable=AsyncMock,
             return_value=(1, "", "No such file"),
         ):
-            info = await files.stat_path(CID, "/nope", podman=_mock_pod)
+            info = await files_inst.stat_path(CID, "/nope")
 
         assert info is None
 
 
 class TestReadFile:
-    async def test_read_file(self):
+    async def test_read_file(self, files_inst):
         with patch.object(_mock_pod, EXEC, new_callable=AsyncMock) as mock:
             mock.side_effect = [
                 (0, "regular file\t100", ""),  # stat
                 (0, "hello world", ""),  # cat
             ]
-            content = await files.read_file(
-                CID, "/home/work/hello.txt", podman=_mock_pod
-            )
+            content = await files_inst.read_file(CID, "/home/work/hello.txt")
 
         assert content == "hello world"
         # cat should use -- separator
         cat_cmd = mock.call_args_list[1][0][1]
         assert "--" in cat_cmd
 
-    async def test_read_nonexistent(self):
+    async def test_read_nonexistent(self, files_inst):
         with patch.object(
             _mock_pod,
             EXEC,
             new_callable=AsyncMock,
             return_value=(1, "", "No such file"),
         ):
-            content = await files.read_file(CID, "/nope.txt", podman=_mock_pod)
+            content = await files_inst.read_file(CID, "/nope.txt")
 
         assert content is None
 
-    async def test_read_too_large(self):
+    async def test_read_too_large(self, files_inst):
         with patch.object(
             _mock_pod,
             EXEC,
             new_callable=AsyncMock,
             return_value=(0, "regular file\t2000000", ""),
         ):
-            content = await files.read_file(CID, "/big.bin", podman=_mock_pod)
+            content = await files_inst.read_file(CID, "/big.bin")
 
         assert content is None
 
-    async def test_read_directory_returns_none(self):
+    async def test_read_directory_returns_none(self, files_inst):
         with patch.object(
             _mock_pod,
             EXEC,
             new_callable=AsyncMock,
             return_value=(0, "directory\t4096", ""),
         ):
-            content = await files.read_file(
-                CID, "/home/work", podman=_mock_pod
-            )
+            content = await files_inst.read_file(CID, "/home/work")
 
         assert content is None
 
-    async def test_read_cat_fails(self):
+    async def test_read_cat_fails(self, files_inst):
         with patch.object(_mock_pod, EXEC, new_callable=AsyncMock) as mock:
             mock.side_effect = [
                 (0, "regular file\t100", ""),  # stat ok
                 (1, "", "Permission denied"),  # cat fails
             ]
-            content = await files.read_file(
-                CID, "/home/noperm.txt", podman=_mock_pod
-            )
+            content = await files_inst.read_file(CID, "/home/noperm.txt")
 
         assert content is None
 
 
 class TestStreamFile:
-    async def test_stream_file(self):
+    async def test_stream_file(self, files_inst):
         async def fake_stream(*a, **kw):
             yield b"chunk1"
             yield b"chunk2"
@@ -384,8 +381,8 @@ class TestStreamFile:
             _mock_pod, EXEC_STREAM, side_effect=fake_stream
         ) as mock:
             chunks = []
-            async for chunk in files.stream_file(
-                CID, "/home/work/image.png", podman=_mock_pod
+            async for chunk in files_inst.stream_file(
+                CID, "/home/work/image.png"
             ):
                 chunks.append(chunk)
 
@@ -396,16 +393,14 @@ class TestStreamFile:
         assert "--" in cmd
         assert mock.call_args.kwargs["user"] == "klangk"
 
-    async def test_stream_file_rejects_relative(self):
+    async def test_stream_file_rejects_relative(self, files_inst):
         with pytest.raises(ValueError, match="absolute"):
-            async for _ in files.stream_file(
-                CID, "relative.txt", podman=_mock_pod
-            ):
+            async for _ in files_inst.stream_file(CID, "relative.txt"):
                 pass  # pragma: no cover
 
 
 class TestStreamDirTar:
-    async def test_stream_dir_tar(self):
+    async def test_stream_dir_tar(self, files_inst):
         async def fake_stream(*a, **kw):
             yield b"\x1f\x8b"
             yield b"tardata"
@@ -414,8 +409,8 @@ class TestStreamDirTar:
             _mock_pod, EXEC_STREAM, side_effect=fake_stream
         ) as mock:
             chunks = []
-            async for chunk in files.stream_dir_tar(
-                CID, "/home/work/mydir", podman=_mock_pod
+            async for chunk in files_inst.stream_dir_tar(
+                CID, "/home/work/mydir"
             ):
                 chunks.append(chunk)
 
@@ -425,49 +420,45 @@ class TestStreamDirTar:
         assert "tar" in cmd[2]  # tar is in the sh -c script
         assert mock.call_args.kwargs["user"] == "klangk"
 
-    async def test_stream_dir_tar_rejects_relative(self):
+    async def test_stream_dir_tar_rejects_relative(self, files_inst):
         with pytest.raises(ValueError, match="absolute"):
-            async for _ in files.stream_dir_tar(CID, "nope", podman=_mock_pod):
+            async for _ in files_inst.stream_dir_tar(CID, "nope"):
                 pass  # pragma: no cover
 
 
 class TestDeletePath:
-    async def test_delete_file(self):
+    async def test_delete_file(self, files_inst):
         with patch.object(_mock_pod, EXEC, new_callable=AsyncMock) as mock:
             mock.side_effect = [
                 (0, "", ""),  # test -e
                 (0, "", ""),  # rm -rf
             ]
-            result = await files.delete_path(
-                CID, "/home/work/doomed.txt", podman=_mock_pod
-            )
+            result = await files_inst.delete_path(CID, "/home/work/doomed.txt")
 
         assert result == "/home/work/doomed.txt"
         rm_cmd = mock.call_args_list[1][0][1]
         assert "--" in rm_cmd
         assert mock.call_args_list[1].kwargs["user"] == "klangk"
 
-    async def test_delete_nonexistent(self):
+    async def test_delete_nonexistent(self, files_inst):
         with patch.object(
             _mock_pod, EXEC, new_callable=AsyncMock, return_value=(1, "", "")
         ):
             with pytest.raises(FileNotFoundError):
-                await files.delete_path(CID, "/nope.txt", podman=_mock_pod)
+                await files_inst.delete_path(CID, "/nope.txt")
 
-    async def test_delete_rm_fails(self):
+    async def test_delete_rm_fails(self, files_inst):
         with patch.object(_mock_pod, EXEC, new_callable=AsyncMock) as mock:
             mock.side_effect = [
                 (0, "", ""),  # test -e ok
                 (1, "", "Permission denied"),  # rm fails
             ]
             with pytest.raises(OSError, match="Permission denied"):
-                await files.delete_path(
-                    CID, "/usr/bin/important", podman=_mock_pod
-                )
+                await files_inst.delete_path(CID, "/usr/bin/important")
 
 
 class TestRenamePath:
-    async def test_rename(self):
+    async def test_rename(self, files_inst):
         with patch.object(_mock_pod, EXEC, new_callable=AsyncMock) as mock:
             mock.side_effect = [
                 (0, "", ""),  # test -e old
@@ -475,38 +466,33 @@ class TestRenamePath:
                 (0, "", ""),  # mkdir -p
                 (0, "", ""),  # mv
             ]
-            result = await files.rename_path(
+            result = await files_inst.rename_path(
                 CID,
                 "/home/work/old.txt",
                 "/home/work/new.txt",
-                podman=_mock_pod,
             )
 
         assert result == "/home/work/new.txt"
         mv_cmd = mock.call_args_list[3][0][1]
         assert "--" in mv_cmd
 
-    async def test_rename_source_missing(self):
+    async def test_rename_source_missing(self, files_inst):
         with patch.object(
             _mock_pod, EXEC, new_callable=AsyncMock, return_value=(1, "", "")
         ):
             with pytest.raises(FileNotFoundError):
-                await files.rename_path(
-                    CID, "/nope.txt", "/new.txt", podman=_mock_pod
-                )
+                await files_inst.rename_path(CID, "/nope.txt", "/new.txt")
 
-    async def test_rename_dest_exists(self):
+    async def test_rename_dest_exists(self, files_inst):
         with patch.object(_mock_pod, EXEC, new_callable=AsyncMock) as mock:
             mock.side_effect = [
                 (0, "", ""),  # test -e old — exists
                 (0, "", ""),  # test -e new — also exists
             ]
             with pytest.raises(FileExistsError):
-                await files.rename_path(
-                    CID, "/old.txt", "/existing.txt", podman=_mock_pod
-                )
+                await files_inst.rename_path(CID, "/old.txt", "/existing.txt")
 
-    async def test_rename_mv_fails(self):
+    async def test_rename_mv_fails(self, files_inst):
         with patch.object(_mock_pod, EXEC, new_callable=AsyncMock) as mock:
             mock.side_effect = [
                 (0, "", ""),  # test -e old
@@ -515,18 +501,16 @@ class TestRenamePath:
                 (1, "", "Cross-device link"),  # mv fails
             ]
             with pytest.raises(OSError, match="Cross-device"):
-                await files.rename_path(
-                    CID, "/old.txt", "/mnt/new.txt", podman=_mock_pod
-                )
+                await files_inst.rename_path(CID, "/old.txt", "/mnt/new.txt")
 
 
 class TestWriteFile:
-    async def test_write(self):
+    async def test_write(self, files_inst):
         with patch.object(
             _mock_pod, EXEC, new_callable=AsyncMock, return_value=(0, "", "")
         ) as mock:
-            result = await files.write_file(
-                CID, "/home/work/out.txt", b"data", podman=_mock_pod
+            result = await files_inst.write_file(
+                CID, "/home/work/out.txt", b"data"
             )
 
         assert result == "/home/work/out.txt"
@@ -539,7 +523,7 @@ class TestWriteFile:
         assert "/home/work/out.txt" not in cmd[2]  # not in the script
         assert cmd[-1] == "/home/work/out.txt"  # passed as positional arg
 
-    async def test_write_fails(self):
+    async def test_write_fails(self, files_inst):
         with patch.object(
             _mock_pod,
             EXEC,
@@ -547,51 +531,45 @@ class TestWriteFile:
             return_value=(1, "", "Read-only"),
         ):
             with pytest.raises(OSError, match="Read-only"):
-                await files.write_file(
-                    CID, "/usr/bin/evil", b"bad", podman=_mock_pod
-                )
+                await files_inst.write_file(CID, "/usr/bin/evil", b"bad")
 
-    async def test_write_rejects_relative_path(self):
+    async def test_write_rejects_relative_path(self, files_inst):
         with pytest.raises(ValueError, match="absolute"):
-            await files.write_file(
-                CID, "relative.txt", b"data", podman=_mock_pod
-            )
+            await files_inst.write_file(CID, "relative.txt", b"data")
 
-    async def test_write_rejects_null_byte(self):
+    async def test_write_rejects_null_byte(self, files_inst):
         with pytest.raises(ValueError, match="Null byte"):
-            await files.write_file(
-                CID, "/home/\x00evil", b"data", podman=_mock_pod
-            )
+            await files_inst.write_file(CID, "/home/\x00evil", b"data")
 
 
 class TestExecUser:
     """All operations must run as the klangk user."""
 
-    async def test_list_runs_as_klangk(self):
+    async def test_list_runs_as_klangk(self, files_inst):
         with patch.object(
             _mock_pod, EXEC, new_callable=AsyncMock, return_value=(0, "", "")
         ) as mock:
-            await files.list_files(CID, "/", podman=_mock_pod)
+            await files_inst.list_files(CID, "/")
         assert mock.call_args.kwargs["user"] == "klangk"
 
-    async def test_read_runs_as_klangk(self):
+    async def test_read_runs_as_klangk(self, files_inst):
         with patch.object(_mock_pod, EXEC, new_callable=AsyncMock) as mock:
             mock.side_effect = [
                 (0, "regular file\t10", ""),
                 (0, "content", ""),
             ]
-            await files.read_file(CID, "/f.txt", podman=_mock_pod)
+            await files_inst.read_file(CID, "/f.txt")
         for call in mock.call_args_list:
             assert call.kwargs["user"] == "klangk"
 
-    async def test_delete_runs_as_klangk(self):
+    async def test_delete_runs_as_klangk(self, files_inst):
         with patch.object(_mock_pod, EXEC, new_callable=AsyncMock) as mock:
             mock.side_effect = [(0, "", ""), (0, "", "")]
-            await files.delete_path(CID, "/f.txt", podman=_mock_pod)
+            await files_inst.delete_path(CID, "/f.txt")
         for call in mock.call_args_list:
             assert call.kwargs["user"] == "klangk"
 
-    async def test_rename_runs_as_klangk(self):
+    async def test_rename_runs_as_klangk(self, files_inst):
         with patch.object(_mock_pod, EXEC, new_callable=AsyncMock) as mock:
             mock.side_effect = [
                 (0, "", ""),
@@ -599,35 +577,35 @@ class TestExecUser:
                 (0, "", ""),
                 (0, "", ""),
             ]
-            await files.rename_path(CID, "/a.txt", "/b.txt", podman=_mock_pod)
+            await files_inst.rename_path(CID, "/a.txt", "/b.txt")
         for call in mock.call_args_list:
             assert call.kwargs["user"] == "klangk"
 
-    async def test_write_runs_as_klangk(self):
+    async def test_write_runs_as_klangk(self, files_inst):
         with patch.object(
             _mock_pod, EXEC, new_callable=AsyncMock, return_value=(0, "", "")
         ) as mock:
-            await files.write_file(CID, "/f.txt", b"x", podman=_mock_pod)
+            await files_inst.write_file(CID, "/f.txt", b"x")
         assert mock.call_args.kwargs["user"] == "klangk"
 
-    async def test_stream_file_runs_as_klangk(self):
+    async def test_stream_file_runs_as_klangk(self, files_inst):
         async def fake_stream(*a, **kw):
             yield b"x"
 
         with patch.object(
             _mock_pod, EXEC_STREAM, side_effect=fake_stream
         ) as mock:
-            async for _ in files.stream_file(CID, "/f.bin", podman=_mock_pod):
+            async for _ in files_inst.stream_file(CID, "/f.bin"):
                 pass
         assert mock.call_args.kwargs["user"] == "klangk"
 
-    async def test_stream_dir_tar_runs_as_klangk(self):
+    async def test_stream_dir_tar_runs_as_klangk(self, files_inst):
         async def fake_stream(*a, **kw):
             yield b"x"
 
         with patch.object(
             _mock_pod, EXEC_STREAM, side_effect=fake_stream
         ) as mock:
-            async for _ in files.stream_dir_tar(CID, "/dir", podman=_mock_pod):
+            async for _ in files_inst.stream_dir_tar(CID, "/dir"):
                 pass
         assert mock.call_args.kwargs["user"] == "klangk"

--- a/src/backend/tests/test_main.py
+++ b/src/backend/tests/test_main.py
@@ -17,6 +17,7 @@ from klangk_backend import (
     agent as agent_mod,
     auth as auth_mod,
     emailsvc as emailsvc_mod,
+    files as files_mod,
     nginx as nginx_mod,
     util as util_mod,
     main,
@@ -50,6 +51,7 @@ def _make_app_state(settings=None):
     app_state.oidc = oidc.OIDC(app_state)
     app_state.plugins = plugins.Plugins(app_state)
     app_state.workspaces = workspaces.Workspaces(app_state)
+    app_state.files = files_mod.Files(app_state)
     # #1520: the lifespan binds app.state.db as the active DB for its context;
     # mirror build_app so lifespan-driven tests have it.
     from klangk_backend.model import db as db_mod

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -19,6 +19,7 @@ from klangk_backend import (
     agent as agent_mod,
     auth as auth_mod,
     emailsvc as emailsvc_mod,
+    files as files_mod,
     util as util_mod,
     model,
     wshandler,
@@ -99,6 +100,7 @@ def _make_app_state(registry=None, sockets=None):
     # its methods via patch.object(_mock_term, ...).
     app_state.terminal = _mock_term
     app_state.workspaces = ws_mod.Workspaces(app_state)
+    app_state.files = files_mod.Files(app_state)
     app_state.agents = agent_mod.Agents(app_state)
     app_state.email = emailsvc_mod.EmailService(app_state)
     app_state.util = util_mod.Util(app_state)


### PR DESCRIPTION
## Summary

Fixes #1566.

Folds the eight stateful functions in `klangk_backend/files.py` into a `Files(app_state)` class wired as `app.state.files`, the same `X(app_state)` pattern every other owned subsystem (`Workspaces`, `Terminal`, `Agents`, …) already uses. The class owns the `podman` reference instead of threading it through every call.

## Changes

- **`files.py`** — new `Files(app_state)` class; the 8 podman-taking free functions become methods reading `self.podman` (no `podman` parameter). `read_file` internally calls `self.stat_path(...)`. `validate_path` stays module-level (pure path normalization, no deps).
- **`api/files.py`** — sole consumer; call sites now `app_state.files.*(...)`. Dropped the now-unused `files` module import.
- **`main.py` / `build_app`** — wires `app.state.files = files.Files(app.state)` alongside the other owned instances.
- **Test fixtures** — `_make_app_state` in `test_wshandler` / `test_container` / `test_main` / `test_agent`, and the `app` fixture in `test_api`, construct `Files(app_state)` (skipped in the minimal `_bind_safety_app_state`, which has no `podman` and doesn't touch files).
- **`test_files.py`** — exercises the class via a `files_inst` fixture (backed by the shared `_mock_pod`, so per-test `patch.object(_mock_pod, ...)` patches still apply). `TestValidatePath` unchanged.
- **`test_api.py`** — the two oserror patches retargeted `klangk_backend.files.delete_path` / `rename_path` → `klangk_backend.files.Files.delete_path` / `rename_path`.

No behavior change — pure refactor of how callers reach the functions.

## Verification

- `test_files.py`: 61/61 pass.
- Full backend suite: **2408 passed, 100% coverage** (`-n auto`, as CI runs it).
- CLI suite: 486 passed, 100% coverage.

## Changelog

Added a `### Changed` entry under `## [Unreleased]` (per the issue).

## Checklist

- [x] `Files(app_state)` class; 8 podman-taking functions are methods using `self.podman` (no `podman` param)
- [x] `validate_path` remains module-level
- [x] `app.state.files` wired in `build_app`; `_make_app_state` / `app` fixtures construct it
- [x] `api/files.py` uses `app_state.files.*`
- [x] No other module imports the free functions (they were `api/files.py` only — verified by grep)
- [x] Backend (`-n auto`) and CLI suites green at 100% coverage
- [x] Changelog entry under `## [Unreleased]` → `### Changed`
