### PR TITLE
Hoist main.py lifecycle/seed functions into a Lifecycle(app_state) class (#1571)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -100,6 +100,19 @@ operators or integrators to act when upgrading.
 
 ### Changed
 
+- **`Lifecycle(app_state)` class** — the app-level lifecycle functions in
+  `klangk_backend/main.py` (DB seeding of the default user / agent user /
+  default ACLs, plus `startup` / `runtime_shutdown` / `process_shutdown` /
+  `restart_runtime` / `on_sighup`) are now methods on a `Lifecycle(app_state)`
+  class wired as `app.state.lifecycle`, instead of module-level free
+  functions with `app_state` threaded in. The lifespan and the SIGHUP
+  restart path call its methods; the per-process restart lock that
+  serialized SIGHUP restarts moved from a module global to a per-instance
+  attribute. Pure helpers with no `app_state` dependency
+  (`_is_loopback_bind`, `enforce_no_auth_bind_safety`, `setup_logfire`,
+  `register_exception_handlers`) stay module-level. No behavior change
+  (#1571).
+
 - **`Files(app_state)` class** — the eight stateful file operations in
   `klangk_backend/files.py` (list/read/write/delete/rename/stat/stream)
   are now methods on a `Files(app_state)` class wired as

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -59,73 +59,260 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
-async def seed_default_acls(admin_group_id: str) -> None:
-    """Seed default ACL entries if none exist yet."""
-    existing = await model.get_acl_tree_summary()
-    if existing:
-        return
-    # /: Authenticated users can view, deny everyone else
-    await model.add_acl_entry(
-        "/",
-        0,
-        ACTION_ALLOW,
-        "view",
-        PRINCIPAL_SYSTEM,
-        system_principal=SYSTEM_AUTHENTICATED,
-    )
-    await model.add_acl_entry(
-        "/",
-        1,
-        ACTION_DENY,
-        "*",
-        PRINCIPAL_SYSTEM,
-        system_principal=SYSTEM_EVERYONE,
-    )
-    # /workspaces: Authenticated users can create
-    await model.add_acl_entry(
-        "/workspaces",
-        0,
-        ACTION_ALLOW,
-        "create",
-        PRINCIPAL_SYSTEM,
-        system_principal=SYSTEM_AUTHENTICATED,
-    )
-    # /groups: Authenticated users can create groups
-    await model.add_acl_entry(
-        "/groups",
-        0,
-        ACTION_ALLOW,
-        "create",
-        PRINCIPAL_SYSTEM,
-        system_principal=SYSTEM_AUTHENTICATED,
-    )
-    # /admin: admin group gets full access, deny everyone else
-    await model.add_acl_entry(
-        "/admin",
-        0,
-        ACTION_ALLOW,
-        "*",
-        PRINCIPAL_GROUP,
-        group_id=admin_group_id,
-    )
-    await model.add_acl_entry(
-        "/admin",
-        1,
-        ACTION_DENY,
-        "*",
-        PRINCIPAL_SYSTEM,
-        system_principal=SYSTEM_EVERYONE,
-    )
-    logger.info("Seeded default ACL entries")
+class Lifecycle:
+    """App-level bringup/shutdown and DB seeding (#1571).
 
+    Owns the startup/shutdown/restart sequence plus the default-user,
+    agent-user, and ACL seeding that runs at lifespan start. Constructed
+    once in :func:`build_app` and stored on ``app.state.lifecycle``, the
+    same ``X(app_state)`` pattern every other owned subsystem uses
+    (``Auth``, ``Workspaces``, ``ContainerRegistry``, ...). The lifespan
+    and the SIGHUP restart path call its methods rather than module-level
+    free functions; concurrent SIGHUP signals serialize on a per-instance
+    lock so a second signal arriving mid-restart queues behind the first
+    instead of racing.
 
-async def ensure_admin_group() -> str:
-    """Ensure the 'admin' group exists. Returns the group ID."""
-    group = await model.get_group_by_name("admin")
-    if group is None:
-        group = await model.create_group("admin", description="Administrators")
-        logger.info("Created admin group: %s", group["id"])
-    return group["id"]
+    Pure helpers with no ``app_state`` dependency
+    (:func:`_is_loopback_bind`, :func:`enforce_no_auth_bind_safety`,
+    :func:`setup_logfire`, :func:`register_exception_handlers`) stay
+    module-level.
+    """
+
+    def __init__(self, app_state):
+        self.app_state = app_state
+        # Serializes concurrent SIGHUP-triggered restarts so a second
+        # signal arriving mid-restart queues behind the first instead of
+        # racing. Lazily created on first restart so the lock binds to the
+        # running event loop (the constructor runs in build_app, outside a
+        # loop).
+        self._restart_lock: asyncio.Lock | None = None
+
+    async def seed_default_acls(self, admin_group_id: str) -> None:
+        """Seed default ACL entries if none exist yet."""
+        existing = await model.get_acl_tree_summary()
+        if existing:
+            return
+        # /: Authenticated users can view, deny everyone else
+        await model.add_acl_entry(
+            "/",
+            0,
+            ACTION_ALLOW,
+            "view",
+            PRINCIPAL_SYSTEM,
+            system_principal=SYSTEM_AUTHENTICATED,
+        )
+        await model.add_acl_entry(
+            "/",
+            1,
+            ACTION_DENY,
+            "*",
+            PRINCIPAL_SYSTEM,
+            system_principal=SYSTEM_EVERYONE,
+        )
+        # /workspaces: Authenticated users can create
+        await model.add_acl_entry(
+            "/workspaces",
+            0,
+            ACTION_ALLOW,
+            "create",
+            PRINCIPAL_SYSTEM,
+            system_principal=SYSTEM_AUTHENTICATED,
+        )
+        # /groups: Authenticated users can create groups
+        await model.add_acl_entry(
+            "/groups",
+            0,
+            ACTION_ALLOW,
+            "create",
+            PRINCIPAL_SYSTEM,
+            system_principal=SYSTEM_AUTHENTICATED,
+        )
+        # /admin: admin group gets full access, deny everyone else
+        await model.add_acl_entry(
+            "/admin",
+            0,
+            ACTION_ALLOW,
+            "*",
+            PRINCIPAL_GROUP,
+            group_id=admin_group_id,
+        )
+        await model.add_acl_entry(
+            "/admin",
+            1,
+            ACTION_DENY,
+            "*",
+            PRINCIPAL_SYSTEM,
+            system_principal=SYSTEM_EVERYONE,
+        )
+        logger.info("Seeded default ACL entries")
+
+    async def ensure_admin_group(self) -> str:
+        """Ensure the 'admin' group exists. Returns the group ID."""
+        group = await model.get_group_by_name("admin")
+        if group is None:
+            group = await model.create_group(
+                "admin", description="Administrators"
+            )
+            logger.info("Created admin group: %s", group["id"])
+        return group["id"]
+
+    async def seed_default_user(self) -> None:
+        """Create default user if it doesn't exist.
+
+        If KLANGK_DEFAULT_PASSWORD is set, use it. Otherwise generate a
+        random password and print it to the console (only on first
+        creation).
+        """
+        settings = self.app_state.settings
+        admin_group_id = await self.ensure_admin_group()
+        await self.seed_default_acls(admin_group_id)
+
+        email = settings.default_user
+        password = settings.default_password
+        existing = await model.get_user_by_email(email)
+        if existing is None:
+            generated = password is None
+            if generated:
+                password = secrets.token_urlsafe(16)
+            password_hash = bcrypt.hashpw(
+                password.encode(), bcrypt.gensalt()
+            ).decode()
+            user = await model.create_user(email, password_hash, verified=True)
+            await model.add_user_to_group(user["id"], admin_group_id)
+            if generated:
+                logger.info(
+                    "Created default admin user '%s'"
+                    " (password printed to stderr)",
+                    email,
+                )
+                # Print password to stderr only — keep it out of structured
+                # logs where it could be shipped to a log aggregator.
+                print(
+                    f"{_GREEN}Default admin password for"
+                    f" '{email}': {password}{_RESET}",
+                    file=sys.stderr,
+                )
+            else:
+                logger.info("Created default user '%s' in admin group", email)
+        else:
+            # Ensure existing default user is in admin group
+            await model.add_user_to_group(existing["id"], admin_group_id)
+
+    async def seed_agent_user(self) -> None:
+        """Ensure the chat agent user exists in the DB.
+
+        Reads email/handle from env vars (with defaults) and upserts the
+        agent row.  This is the ONLY place the env vars are consulted.
+
+        Refuses to seed the agent with a handle already owned by another
+        user.  A colliding agent handle is destructive:
+        ``ensure_home_symlink`` would later migrate that user's home files
+        into the agent's tree via its workspace-import adoption branch.
+        The ``users.handle`` UNIQUE constraint is the structural backstop,
+        but we fail loudly here with an actionable message instead of
+        letting a bare ``IntegrityError`` abort startup mid-sequence.
+        See #1137.
+        """
+        settings = self.app_state.settings
+        email = settings.agent_email
+        handle = settings.agent_handle
+        async with model.transaction() as db:
+            # Pre-check: refuse a handle already claimed by a non-agent user.
+            # Runs in the same transaction as the upsert so there is no
+            # check-then-act window.
+            cursor = await db.execute(
+                "SELECT id FROM users WHERE handle = ? AND id != ?",
+                (handle, AGENT_USER_ID),
+            )
+            if await cursor.fetchone() is not None:
+                raise RuntimeError(
+                    f"Cannot seed chat agent: handle {handle!r} is already"
+                    " used by another user. Set KLANGK_AGENT_HANDLE to a"
+                    " unique value."
+                )
+            await db.execute(
+                "INSERT INTO users (id, email, password_hash, verified,"
+                " provider, handle)"
+                " VALUES (?, ?, NULL, 1, 'system', ?)"
+                " ON CONFLICT(id) DO UPDATE SET email = ?, handle = ?",
+                (AGENT_USER_ID, email, handle, email, handle),
+            )
+        model.clear_agent_cache()
+        logger.info("Seeded agent user '%s' (%s)", handle, email)
+
+    async def startup(self) -> None:
+        """Container-side startup (self-healing on re-run).
+
+        Warms podman, reaps leftover containers from a previous run,
+        launches the idle and health background loops, and auto-starts
+        workspaces. Every step is idempotent -- ``init_db`` uses
+        ``CREATE TABLE IF NOT EXISTS``, the loop starters are gated on
+        ``task is None``, and ``auto_start`` re-creates stopped containers
+        -- so re-running this after ``runtime_shutdown`` is exactly the
+        SIGHUP restart path.
+        """
+        app_state = self.app_state
+        registry = app_state.container_registry
+        await registry.prewarm_podman()
+        await registry.reap_instance_containers()
+        registry.start_cleanup_loop()
+        registry.start_health_loop()
+        n = await app_state.workspaces.auto_start_workspaces()
+        if n:  # pragma: no cover
+            logger.info("Auto-started %d workspace(s)", n)
+
+    async def runtime_shutdown(self) -> None:
+        """Stop the runtime, keeping the HTTP listener and DB alive.
+
+        Drops every WebSocket client (code 1012 = "reconnect"), tears down
+        agent subprocesses and in-flight agent runs, then stops all
+        containers and cancels the idle/health loops.  Used by both the
+        normal process-shutdown path and the SIGHUP restart path -- the
+        difference is only whether ``startup()`` runs again afterwards.
+        """
+        app_state = self.app_state
+        await wshandler.disconnect_all_websockets(app_state.sockets)
+        await app_state.agents.stop_all_sessions()
+        wshandler.clear_agent_mention_state()
+        await app_state.container_registry.shutdown()
+
+    async def process_shutdown(self) -> None:
+        """Full process teardown (run once, at the very end)."""
+        # instance_id() resolves from the file if startup didn't get there;
+        # if there's genuinely no PID file (startup crashed early)
+        # remove_pid_file no-ops on the missing file.
+        app_state = self.app_state
+        app_state.util.remove_pid_file()
+        await app_state.db.dispose_engine()
+
+    async def restart_runtime(self) -> None:
+        """Graceful runtime restart: stop containers, keep the listener.
+
+        Triggered by SIGHUP.  Closes all WebSocket clients (code 1012),
+        stops containers and background loops, then re-runs container-side
+        startup (prewarm, adopt, loops, auto-start).  The HTTP listener
+        and DB engine stay up throughout -- clients reconnect
+        automatically, and in-flight HTTP requests are never dropped.
+        """
+        if self._restart_lock is None:
+            self._restart_lock = asyncio.Lock()
+        async with self._restart_lock:
+            logger.info("SIGHUP: restarting runtime (keeping HTTP listener)")
+            await self.runtime_shutdown()
+            await self.startup()
+            logger.info("SIGHUP: runtime restarted")
+
+    def on_sighup(self) -> None:
+        """Schedule a runtime restart on the running event loop.
+
+        Signal callbacks can't be async, so this just creates a task.  The
+        restart itself is serialized by ``_restart_lock``.
+        """
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:  # pragma: no cover - no loop during shutdown
+            return
+        loop.create_task(self.restart_runtime())
 
 
 # Addresses that are safe for no-auth single-user (``none``) mode: only the
@@ -192,132 +379,6 @@ def enforce_no_auth_bind_safety(app_state) -> None:
     )
 
 
-async def seed_default_user(settings) -> None:
-    """Create default user if it doesn't exist.
-
-    If KLANGK_DEFAULT_PASSWORD is set, use it. Otherwise generate a random
-    password and print it to the console (only on first creation).
-    """
-    admin_group_id = await ensure_admin_group()
-    await seed_default_acls(admin_group_id)
-
-    email = settings.default_user
-    password = settings.default_password
-    existing = await model.get_user_by_email(email)
-    if existing is None:
-        generated = password is None
-        if generated:
-            password = secrets.token_urlsafe(16)
-        password_hash = bcrypt.hashpw(
-            password.encode(), bcrypt.gensalt()
-        ).decode()
-        user = await model.create_user(email, password_hash, verified=True)
-        await model.add_user_to_group(user["id"], admin_group_id)
-        if generated:
-            logger.info(
-                "Created default admin user '%s' (password printed to stderr)",
-                email,
-            )
-            # Print password to stderr only — keep it out of structured
-            # logs where it could be shipped to a log aggregator.
-            print(
-                f"{_GREEN}Default admin password for"
-                f" '{email}': {password}{_RESET}",
-                file=sys.stderr,
-            )
-        else:
-            logger.info("Created default user '%s' in admin group", email)
-    else:
-        # Ensure existing default user is in admin group
-        await model.add_user_to_group(existing["id"], admin_group_id)
-
-
-async def seed_agent_user(settings) -> None:
-    """Ensure the chat agent user exists in the DB.
-
-    Reads email/handle from env vars (with defaults) and upserts the
-    agent row.  This is the ONLY place the env vars are consulted.
-
-    Refuses to seed the agent with a handle already owned by another user.
-    A colliding agent handle is destructive: ``ensure_home_symlink`` would
-    later migrate that user's home files into the agent's tree via its
-    workspace-import adoption branch.  The ``users.handle`` UNIQUE
-    constraint is the structural backstop, but we fail loudly here with an
-    actionable message instead of letting a bare ``IntegrityError`` abort
-    startup mid-sequence.  See #1137.
-    """
-    email = settings.agent_email
-    handle = settings.agent_handle
-    async with model.transaction() as db:
-        # Pre-check: refuse a handle already claimed by a non-agent user.
-        # Runs in the same transaction as the upsert so there is no
-        # check-then-act window.
-        cursor = await db.execute(
-            "SELECT id FROM users WHERE handle = ? AND id != ?",
-            (handle, AGENT_USER_ID),
-        )
-        if await cursor.fetchone() is not None:
-            raise RuntimeError(
-                f"Cannot seed chat agent: handle {handle!r} is already used"
-                " by another user. Set KLANGK_AGENT_HANDLE to a"
-                " unique value."
-            )
-        await db.execute(
-            "INSERT INTO users (id, email, password_hash, verified,"
-            " provider, handle)"
-            " VALUES (?, ?, NULL, 1, 'system', ?)"
-            " ON CONFLICT(id) DO UPDATE SET email = ?, handle = ?",
-            (AGENT_USER_ID, email, handle, email, handle),
-        )
-    model.clear_agent_cache()
-    logger.info("Seeded agent user '%s' (%s)", handle, email)
-
-
-async def startup(app_state) -> None:
-    """Container-side startup (self-healing on re-run).
-
-    Warms podman, reaps leftover containers from a previous run, launches
-    the idle and health background loops, and auto-starts workspaces.
-    Every
-    step is idempotent -- ``init_db`` uses ``CREATE TABLE IF NOT
-    EXISTS``, the loop starters are gated on ``task is None``, and
-    ``auto_start`` re-creates stopped containers -- so re-running this
-    after ``runtime_shutdown`` is exactly the SIGHUP restart path.
-    """
-    registry = app_state.container_registry
-    await registry.prewarm_podman()
-    await registry.reap_instance_containers()
-    registry.start_cleanup_loop()
-    registry.start_health_loop()
-    n = await app_state.workspaces.auto_start_workspaces()
-    if n:  # pragma: no cover
-        logger.info("Auto-started %d workspace(s)", n)
-
-
-async def runtime_shutdown(app_state) -> None:
-    """Stop the runtime, keeping the HTTP listener and DB alive.
-
-    Drops every WebSocket client (code 1012 = "reconnect"), tears down
-    agent subprocesses and in-flight agent runs, then stops all
-    containers and cancels the idle/health loops.  Used by both the
-    normal process-shutdown path and the SIGHUP restart path -- the
-    difference is only whether ``startup()`` runs again afterwards.
-    """
-    await wshandler.disconnect_all_websockets(app_state.sockets)
-    await app_state.agents.stop_all_sessions()
-    wshandler.clear_agent_mention_state()
-    await app_state.container_registry.shutdown()
-
-
-async def process_shutdown(app_state) -> None:
-    """Full process teardown (run once, at the very end)."""
-    # instance_id() resolves from the file if startup didn't get there; if
-    # there's genuinely no PID file (startup crashed early) remove_pid_file
-    # no-ops on the missing file.
-    app_state.util.remove_pid_file()
-    await app_state.db.dispose_engine()
-
-
 # ---------------------------------------------------------------------------
 # nginx child-process ownership (#1396, #1463)
 # ---------------------------------------------------------------------------
@@ -327,42 +388,6 @@ async def process_shutdown(app_state) -> None:
 # backoff + clean SIGTERM to the process group on shutdown). No external
 # supervisor library — bespoke, matching uvicorn's own precedent. devenv /
 # supervisord remain only the outer restart layer for uvicorn (klangkd).
-
-# Serializes concurrent SIGHUP-triggered restarts so a second signal
-# arriving mid-restart queues behind the first instead of racing.
-_restart_lock: asyncio.Lock | None = None
-
-
-async def restart_runtime(app_state, nginx_watchdog) -> None:
-    """Graceful runtime restart: stop containers, keep the listener.
-
-    Triggered by SIGHUP.  Closes all WebSocket clients (code 1012),
-    stops containers and background loops, then re-runs container-side
-    startup (prewarm, adopt, loops, auto-start).  The HTTP listener
-    and DB engine stay up throughout -- clients reconnect
-    automatically, and in-flight HTTP requests are never dropped.
-    """
-    global _restart_lock
-    if _restart_lock is None:
-        _restart_lock = asyncio.Lock()
-    async with _restart_lock:
-        logger.info("SIGHUP: restarting runtime (keeping HTTP listener)")
-        await runtime_shutdown(app_state)
-        await startup(app_state)
-        logger.info("SIGHUP: runtime restarted")
-
-
-def on_sighup(app_state, nginx_watchdog) -> None:
-    """Schedule a runtime restart on the running event loop.
-
-    Signal callbacks can't be async, so this just creates a task.  The
-    restart itself is serialized by ``_restart_lock``.
-    """
-    try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:  # pragma: no cover - no loop during shutdown
-        return
-    loop.create_task(restart_runtime(app_state, nginx_watchdog))
 
 
 @asynccontextmanager
@@ -405,8 +430,8 @@ async def lifespan(app: FastAPI):
     app.state.oidc.init_providers()
     enforce_no_auth_bind_safety(app.state)
     app.state.oidc.load_login_hook()
-    await seed_default_user(app.state.settings)
-    await seed_agent_user(app.state.settings)
+    await app.state.lifecycle.seed_default_user()
+    await app.state.lifecycle.seed_agent_user()
     registry = app.state.container_registry
 
     async def _on_workspace_killed(ws_id):
@@ -416,7 +441,7 @@ async def lifespan(app: FastAPI):
     registry.set_on_container_status_changed(
         app.state.sockets.notify_container_status
     )
-    await startup(app.state)
+    await app.state.lifecycle.startup()
     # Start nginx (only when bound to a UDS — klangkd; no-op for TCP tests).
     # Rendered + owned by Python (#1396); replaces scripts/nginx.sh.
     await app.state.nginx_watchdog.start()
@@ -429,17 +454,15 @@ async def lifespan(app: FastAPI):
     loop = asyncio.get_running_loop()
     loop.add_signal_handler(
         signal.SIGHUP,
-        on_sighup,
-        app.state,
-        app.state.nginx_watchdog,
+        app.state.lifecycle.on_sighup,
     )
     try:
         yield
     finally:
         loop.remove_signal_handler(signal.SIGHUP)
         await app.state.nginx_watchdog.stop()
-        await runtime_shutdown(app.state)
-        await process_shutdown(app.state)
+        await app.state.lifecycle.runtime_shutdown()
+        await app.state.lifecycle.process_shutdown()
         model.db.reset_current_db(_db_token)
         logger.info("Klangk backend stopped")
 
@@ -607,6 +630,11 @@ def build_app(settings: KlangkSettings) -> FastAPI:
     # hosting-info derivation, and customize-dir resolver (previously
     # module-level functions + import-time globals in util.py).
     app.state.util = util_mod.Util(app.state)
+    # #1571: Lifecycle(app_state) owns the startup/shutdown/restart
+    # sequence and the default-user / agent-user / ACL seeding that runs
+    # at lifespan start (previously module-level free functions in this
+    # module). The lifespan and the SIGHUP restart path call its methods.
+    app.state.lifecycle = Lifecycle(app.state)
 
     app.add_middleware(
         CORSMiddleware,

--- a/src/backend/klangk_backend/wshandler/helpers.py
+++ b/src/backend/klangk_backend/wshandler/helpers.py
@@ -107,7 +107,8 @@ async def reset_workspace_state(
 async def disconnect_all_websockets(sockets: WebSocketState) -> None:
     """Drop every WebSocket connection and clear all session state.
 
-    Used by the SIGHUP runtime-restart path (see ``main.runtime_shutdown``).
+    Used by the SIGHUP runtime-restart path (see
+    ``main.Lifecycle.runtime_shutdown``).
     Connected clients are closed with code 1012 so they reconnect and
     rebuild state against the freshly-started containers.
     """

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -2512,9 +2512,11 @@ class TestWorkspaceSharingRoutes:
     ):
         # role=None is removal-from-all-roles — harmless cleanup, so the
         # guard (which only fires on a grant) must let it through.
-        from klangk_backend.main import seed_agent_user
+        from klangk_backend.main import Lifecycle
 
-        await seed_agent_user(make_settings({}))
+        await Lifecycle(
+            types.SimpleNamespace(settings=make_settings({}))
+        ).seed_agent_user()
         agent = await model.get_user_by_id(model.AGENT_USER_ID)
         headers = await _auth_headers(client)
         resp = await client.post(
@@ -2564,9 +2566,11 @@ class TestWorkspaceSharingRoutes:
         # handler translates AgentPrincipalError to HTTP 400. This is the
         # one HTTP-level grant test kept to prove the wiring; the choke
         # points themselves are unit-tested in test_model.py.
-        from klangk_backend.main import seed_agent_user
+        from klangk_backend.main import Lifecycle
 
-        await seed_agent_user(make_settings({}))
+        await Lifecycle(
+            types.SimpleNamespace(settings=make_settings({}))
+        ).seed_agent_user()
         agent = await model.get_user_by_id(model.AGENT_USER_ID)
         headers = await _auth_headers(client)
         resp = await client.post(
@@ -3225,9 +3229,11 @@ class TestTransferOwnership:
         assert resp.status_code == 403
 
     async def test_transfer_to_agent_rejected(self, client, user):
-        from klangk_backend.main import seed_agent_user
+        from klangk_backend.main import Lifecycle
 
-        await seed_agent_user(make_settings({}))
+        await Lifecycle(
+            types.SimpleNamespace(settings=make_settings({}))
+        ).seed_agent_user()
         agent = await model.get_user_by_id(model.AGENT_USER_ID)
 
         headers = await _auth_headers(client)
@@ -5092,9 +5098,11 @@ class TestAdminEndpoints:
         assert resp.status_code == 404
 
     async def test_delete_agent_user_rejected(self, client, admin_user, db):
-        from klangk_backend.main import seed_agent_user
+        from klangk_backend.main import Lifecycle
 
-        await seed_agent_user(make_settings({}))
+        await Lifecycle(
+            types.SimpleNamespace(settings=make_settings({}))
+        ).seed_agent_user()
         headers = await self._admin_headers(client)
         resp = await client.delete(
             f"/api/v1/admin/users/{model.AGENT_USER_ID}", headers=headers
@@ -5214,9 +5222,11 @@ class TestAdminEndpoints:
         self, client, app, admin_user, db
     ):
         # Seed the agent user so it exists in the DB
-        from klangk_backend.main import seed_agent_user
+        from klangk_backend.main import Lifecycle
 
-        await seed_agent_user(make_settings({}))
+        await Lifecycle(
+            types.SimpleNamespace(settings=make_settings({}))
+        ).seed_agent_user()
         headers = await self._admin_headers(client)
         resp = await client.patch(
             f"/api/v1/admin/users/{model.AGENT_USER_ID}",

--- a/src/backend/tests/test_main.py
+++ b/src/backend/tests/test_main.py
@@ -66,7 +66,19 @@ def _make_app_state(settings=None):
     app_state.util = util_mod.Util(app_state)
 
     app_state.auth = auth_mod.Auth(app_state)
+    # #1571: Lifecycle(app_state) owns startup/shutdown/restart + seeding.
+    app_state.lifecycle = main.Lifecycle(app_state)
     return app_state
+
+
+def _lifecycle(settings):
+    """A ``Lifecycle`` whose app_state carries just ``settings``.
+
+    The seed methods read only ``self.app_state.settings`` (DB access goes
+    through the model/ ContextVar backstop bound by the ``db`` fixture),
+    so a bare namespace is enough for the seed-focused tests below.
+    """
+    return main.Lifecycle(types.SimpleNamespace(settings=settings))
 
 
 # --- Seed default user ---
@@ -74,14 +86,14 @@ def _make_app_state(settings=None):
 
 class TestSeedDefaultUser:
     async def test_creates_user_when_missing(self, db):
-        await main.seed_default_user(
+        await _lifecycle(
             make_settings(
                 {
                     "KLANGK_DEFAULT_USER": "seed-test",
                     "KLANGK_DEFAULT_PASSWORD": "seed-pass",
                 }
             )
-        )
+        ).seed_default_user()
         user = await model.get_user_by_email("seed-test")
         assert user is not None
 
@@ -92,16 +104,16 @@ class TestSeedDefaultUser:
                 "KLANGK_DEFAULT_PASSWORD": "seed-pass",
             }
         )
-        await main.seed_default_user(s)
+        await _lifecycle(s).seed_default_user()
         # Call again — should not raise
-        await main.seed_default_user(s)
+        await _lifecycle(s).seed_default_user()
         user = await model.get_user_by_email("seed-test")
         assert user is not None
 
     async def test_generates_password_when_not_set(self, db, capsys):
-        await main.seed_default_user(
+        await _lifecycle(
             make_settings({"KLANGK_DEFAULT_USER": "gen-test"})
-        )
+        ).seed_default_user()
         # Swallow the incidental generated-password print to stderr
         # (asserted explicitly by test_generated_password_printed_to_stderr).
         capsys.readouterr()
@@ -119,9 +131,9 @@ class TestSeedDefaultUser:
         import logging
 
         with caplog.at_level(logging.INFO):
-            await main.seed_default_user(
+            await _lifecycle(
                 make_settings({"KLANGK_DEFAULT_USER": "log-test"})
-            )
+            ).seed_default_user()
         # Password must NOT appear in log output (security)
         assert "password printed to stderr" in caplog.text
         assert "log-test" in caplog.text
@@ -274,36 +286,36 @@ class TestNoAuthBindSafety:
 
 class TestSeedAgentUser:
     async def test_creates_agent_user(self, db):
-        await main.seed_agent_user(make_settings({}))
+        await _lifecycle(make_settings({})).seed_agent_user()
         user = await model.get_user_by_id(model.AGENT_USER_ID)
         assert user is not None
         assert user["email"] == "clanker@example.com"
         assert user["handle"] == "clanker"
 
     async def test_custom_env_vars(self, db):
-        await main.seed_agent_user(
+        await _lifecycle(
             make_settings(
                 {
                     "KLANGK_AGENT_EMAIL": "bot@test.com",
                     "KLANGK_AGENT_HANDLE": "TestBot",
                 }
             )
-        )
+        ).seed_agent_user()
         user = await model.get_user_by_id(model.AGENT_USER_ID)
         assert user is not None
         assert user["email"] == "bot@test.com"
         assert user["handle"] == "TestBot"
 
     async def test_upserts_existing(self, db):
-        await main.seed_agent_user(make_settings({}))
-        await main.seed_agent_user(
+        await _lifecycle(make_settings({})).seed_agent_user()
+        await _lifecycle(
             make_settings(
                 {
                     "KLANGK_AGENT_EMAIL": "new@test.com",
                     "KLANGK_AGENT_HANDLE": "NewBot",
                 }
             )
-        )
+        ).seed_agent_user()
         user = await model.get_user_by_id(model.AGENT_USER_ID)
         assert user["email"] == "new@test.com"
         assert user["handle"] == "NewBot"
@@ -311,7 +323,7 @@ class TestSeedAgentUser:
     async def test_clears_cache(self, db):
         # Prime cache with fallback
         await model.get_agent_user()
-        await main.seed_agent_user(make_settings({}))
+        await _lifecycle(make_settings({})).seed_agent_user()
         # Cache should now reflect DB values
         agent = await model.get_agent_user()
         assert agent["email"] == "clanker@example.com"
@@ -347,9 +359,9 @@ class TestSeedAgentUser:
         )
         assert human["handle"] == "alice"
         with pytest.raises(RuntimeError, match="alice"):
-            await main.seed_agent_user(
+            await _lifecycle(
                 make_settings({"KLANGK_AGENT_HANDLE": "alice"})
-            )
+            ).seed_agent_user()
         # Human user is untouched.
         refreshed = await model.get_user_by_id(human["id"])
         assert refreshed["handle"] == "alice"
@@ -358,14 +370,16 @@ class TestSeedAgentUser:
 
     async def test_seed_rename_to_human_handle_refuses(self, db):
         """Re-seeding the agent onto a human's handle fails, leaves agent as-is."""
-        await main.seed_agent_user(make_settings({}))  # agent handle = clanker
+        await _lifecycle(
+            make_settings({})
+        ).seed_agent_user()  # agent handle = clanker
         human = await model.create_user(
             "alice@example.com", "hash", verified=True
         )
         with pytest.raises(RuntimeError, match="already used by another user"):
-            await main.seed_agent_user(
+            await _lifecycle(
                 make_settings({"KLANGK_AGENT_HANDLE": "alice"})
-            )
+            ).seed_agent_user()
         # Agent keeps its original handle; human untouched.
         agent = await model.get_user_by_id(model.AGENT_USER_ID)
         assert agent["handle"] == "clanker"
@@ -393,9 +407,9 @@ class TestSeedAgentUser:
         (home / "alice").symlink_to(f".users/{human['id']}")
 
         with pytest.raises(RuntimeError):
-            await main.seed_agent_user(
+            await _lifecycle(
                 make_settings({"KLANGK_AGENT_HANDLE": "alice"})
-            )
+            ).seed_agent_user()
 
         # Human's files are exactly where they were — nothing migrated.
         assert (human_dir / "secret.txt").read_text() == "alice's secrets"
@@ -425,6 +439,7 @@ class TestLifespan:
         app.state.util = util_mod.Util(app.state)
 
         app.state.auth = auth_mod.Auth(app.state)
+        app.state.lifecycle = app_state.lifecycle
         registry = app_state.container_registry
         with (
             patch.object(
@@ -471,6 +486,7 @@ class TestLifespan:
         app.state.util = util_mod.Util(app.state)
 
         app.state.auth = auth_mod.Auth(app.state)
+        app.state.lifecycle = app_state.lifecycle
         registry = app_state.container_registry
         with (
             patch.object(
@@ -517,17 +533,6 @@ class TestLifespan:
 
 
 class TestStartupShutdownRestart:
-    @pytest.fixture(autouse=True)
-    def _reset_restart_lock(self):
-        # ``main._restart_lock`` is a module-global lazily created on first
-        # use. Without a reset, lock state leaks across tests, making them
-        # order-dependent (and breaking some tests in isolation or under
-        # pytest-randomly's shuffle). Reset to the pre-first-use floor before
-        # every test in this class so each one is self-contained (#1242).
-        main._restart_lock = None
-        yield
-        main._restart_lock = None
-
     async def test_startup_calls_container_sequence(self):
         app_state = _make_app_state()
         registry = app_state.container_registry
@@ -551,7 +556,7 @@ class TestStartupShutdownRestart:
                 return_value=0,
             ) as mock_autostart,
         ):
-            await main.startup(app_state)
+            await app_state.lifecycle.startup()
         mock_prewarm.assert_awaited_once()
         mock_adopt.assert_awaited_once()
         mock_cleanup.assert_called_once()
@@ -578,7 +583,7 @@ class TestStartupShutdownRestart:
                 registry, "shutdown", new_callable=AsyncMock
             ) as mock_shutdown,
         ):
-            await main.runtime_shutdown(app_state)
+            await app_state.lifecycle.runtime_shutdown()
         mock_disc.assert_awaited_once()
         mock_stop_agents.assert_awaited_once()
         mock_clear.assert_called_once()
@@ -590,72 +595,65 @@ class TestStartupShutdownRestart:
         with (
             patch.object(util_mod.Util, "remove_pid_file") as mock_remove,
         ):
-            await main.process_shutdown(app_state)
+            await app_state.lifecycle.process_shutdown()
         mock_remove.assert_called_once()
         app_state.db.dispose_engine.assert_awaited_once()
 
     async def test_restart_runtime_runs_shutdown_then_startup(self):
-        main._restart_lock = None  # force fresh lock creation
         app_state = _make_app_state()
-        wd = nginx_mod.NginxWatchdog(app_state)
+        lc = app_state.lifecycle
+        lc._restart_lock = None  # force fresh lock creation
         with (
-            patch(
-                "klangk_backend.main.runtime_shutdown", new_callable=AsyncMock
+            patch.object(
+                lc, "runtime_shutdown", new_callable=AsyncMock
             ) as mock_down,
-            patch(
-                "klangk_backend.main.startup", new_callable=AsyncMock
-            ) as mock_up,
+            patch.object(lc, "startup", new_callable=AsyncMock) as mock_up,
         ):
-            await main.restart_runtime(app_state, wd)
-        mock_down.assert_awaited_once_with(app_state)
-        mock_up.assert_awaited_once_with(app_state)
+            await lc.restart_runtime()
+        mock_down.assert_awaited_once()
+        mock_up.assert_awaited_once()
         # Lock was created and is now held-free.
-        assert main._restart_lock is not None
+        assert lc._restart_lock is not None
 
     async def test_restart_runtime_reuses_existing_lock(self):
         # Seed a lock explicitly; ``restart_runtime`` must reuse it rather
-        # than create a new one. (Previously this relied on a prior test's
-        # side effect of populating the module-global, which made it
-        # order-dependent and broken in isolation — #1242.)
-        main._restart_lock = asyncio.Lock()
-        existing = main._restart_lock
+        # than create a new one. The lock is now per-instance (#1571), so a
+        # fresh Lifecycle starts at the pre-first-use floor without a
+        # cross-test reset fixture.
         app_state = _make_app_state()
-        wd = nginx_mod.NginxWatchdog(app_state)
+        lc = app_state.lifecycle
+        lc._restart_lock = asyncio.Lock()
+        existing = lc._restart_lock
         with (
-            patch(
-                "klangk_backend.main.runtime_shutdown", new_callable=AsyncMock
-            ),
-            patch("klangk_backend.main.startup", new_callable=AsyncMock),
+            patch.object(lc, "runtime_shutdown", new_callable=AsyncMock),
+            patch.object(lc, "startup", new_callable=AsyncMock),
         ):
-            await main.restart_runtime(app_state, wd)
+            await lc.restart_runtime()
         # Same lock object reused, not replaced.
-        assert main._restart_lock is existing
+        assert lc._restart_lock is existing
 
     async def test_restart_lock_serializes_concurrent_calls(self):
         """Two restarts kicked off together run strictly one-after-another."""
-        main._restart_lock = None
+        app_state = _make_app_state()
+        lc = app_state.lifecycle
+        lc._restart_lock = None
         order = []
 
-        async def fake_shutdown(app_state):
+        async def fake_shutdown():
             order.append("down-start")
             await asyncio.sleep(0.01)
             order.append("down-end")
 
-        async def fake_startup(app_state):
+        async def fake_startup():
             order.append("up")
 
-        app_state = _make_app_state()
-        wd = nginx_mod.NginxWatchdog(app_state)
         with (
-            patch(
-                "klangk_backend.main.runtime_shutdown",
-                side_effect=fake_shutdown,
-            ),
-            patch("klangk_backend.main.startup", side_effect=fake_startup),
+            patch.object(lc, "runtime_shutdown", side_effect=fake_shutdown),
+            patch.object(lc, "startup", side_effect=fake_startup),
         ):
             await asyncio.gather(
-                main.restart_runtime(app_state, wd),
-                main.restart_runtime(app_state, wd),
+                lc.restart_runtime(),
+                lc.restart_runtime(),
             )
         # Two complete down-start...down-end...up cycles, never interleaved.
         assert order == [
@@ -670,15 +668,15 @@ class TestStartupShutdownRestart:
     async def test_on_sighup_schedules_restart(self):
         """on_sighup creates a task that runs restart_runtime."""
         app_state = _make_app_state()
-        wd = nginx_mod.NginxWatchdog(app_state)
-        with patch(
-            "klangk_backend.main.restart_runtime", new_callable=AsyncMock
+        lc = app_state.lifecycle
+        with patch.object(
+            lc, "restart_runtime", new_callable=AsyncMock
         ) as mock_restart:
-            main.on_sighup(app_state, wd)
+            lc.on_sighup()
             # Let the scheduled task run.
             await asyncio.sleep(0)
             await asyncio.sleep(0)
-        mock_restart.assert_awaited_once_with(app_state, wd)
+        mock_restart.assert_awaited_once()
 
     async def test_lifespan_registers_sighup_handler(self, db):
         """The lifespan installs (and removes) a SIGHUP handler."""
@@ -698,6 +696,7 @@ class TestStartupShutdownRestart:
         app.state.util = util_mod.Util(app.state)
 
         app.state.auth = auth_mod.Auth(app.state)
+        app.state.lifecycle = app_state.lifecycle
         registry = app_state.container_registry
         loop = asyncio.get_running_loop()
         with (

--- a/src/backend/tests/test_mode_switching.py
+++ b/src/backend/tests/test_mode_switching.py
@@ -53,7 +53,7 @@ _current_app = None
 @pytest.fixture
 async def mode_server(db, monkeypatch):
     """Boot a real-router server whose default admin user is seeded the way
-    the real lifespan seeds it (``main.seed_default_user``), then flip modes
+    the real lifespan seeds it (``main.Lifecycle.seed_default_user``), then flip modes
     by changing ``KLANGK_AUTH_MODES`` between requests.
 
     Returns ``(client, default_user)`` where ``default_user`` is the DB row
@@ -61,14 +61,16 @@ async def mode_server(db, monkeypatch):
     """
     global _current_app
     # Seed exactly as the lifespan does at startup.
-    await main.seed_default_user(
-        make_settings(
-            {
-                "KLANGK_DEFAULT_USER": DEFAULT_EMAIL,
-                "KLANGK_DEFAULT_PASSWORD": SEEDED_PASSWORD,
-            }
+    await main.Lifecycle(
+        types.SimpleNamespace(
+            settings=make_settings(
+                {
+                    "KLANGK_DEFAULT_USER": DEFAULT_EMAIL,
+                    "KLANGK_DEFAULT_PASSWORD": SEEDED_PASSWORD,
+                }
+            )
         )
-    )
+    ).seed_default_user()
     default_user = await model.get_user_by_email(DEFAULT_EMAIL)
     assert default_user is not None, "seed_default_user must create the user"
 
@@ -397,26 +399,30 @@ class TestRestartIdempotency:
         must not duplicate the user or drop its admin membership."""
         client, user = mode_server
         _none()
-        await main.seed_default_user(
-            make_settings(
-                {
-                    "KLANGK_AUTH_MODES": "none",
-                    "KLANGK_DEFAULT_USER": DEFAULT_EMAIL,
-                    "KLANGK_DEFAULT_PASSWORD": SEEDED_PASSWORD,
-                }
+        await main.Lifecycle(
+            types.SimpleNamespace(
+                settings=make_settings(
+                    {
+                        "KLANGK_AUTH_MODES": "none",
+                        "KLANGK_DEFAULT_USER": DEFAULT_EMAIL,
+                        "KLANGK_DEFAULT_PASSWORD": SEEDED_PASSWORD,
+                    }
+                )
             )
-        )  # simulate restart in none mode
+        ).seed_default_user()  # simulate restart in none mode
 
         _password()
-        await main.seed_default_user(
-            make_settings(
-                {
-                    "KLANGK_AUTH_MODES": "password",
-                    "KLANGK_DEFAULT_USER": DEFAULT_EMAIL,
-                    "KLANGK_DEFAULT_PASSWORD": SEEDED_PASSWORD,
-                }
+        await main.Lifecycle(
+            types.SimpleNamespace(
+                settings=make_settings(
+                    {
+                        "KLANGK_AUTH_MODES": "password",
+                        "KLANGK_DEFAULT_USER": DEFAULT_EMAIL,
+                        "KLANGK_DEFAULT_PASSWORD": SEEDED_PASSWORD,
+                    }
+                )
             )
-        )  # simulate restart in password mode
+        ).seed_default_user()  # simulate restart in password mode
 
         again = await model.get_user_by_email(DEFAULT_EMAIL)
         assert again["id"] == user["id"]


### PR DESCRIPTION
## Summary

Fixes #1571.

Hoists `main.py`'s app-level lifecycle/seed free functions into a `Lifecycle(app_state)` class wired as `app.state.lifecycle` — the same `X(app_state)` pattern every other owned subsystem (`Auth`, `Workspaces`, `ContainerRegistry`, …) already uses. This was the last cluster of free functions in `main.py` reaching `app_state`.

## What moved into `Lifecycle(app_state)`

The 9 functions are now methods:
- `seed_default_acls`, `ensure_admin_group`, `seed_default_user`, `seed_agent_user`
- `startup`, `runtime_shutdown`, `process_shutdown`
- `restart_runtime`, `on_sighup`

`build_app` wires `app.state.lifecycle = Lifecycle(app.state)`. The lifespan and the SIGHUP restart path call its methods (`app.state.lifecycle.startup()`, `.runtime_shutdown()`, `.on_sighup()`, …).

## What stayed module-level

Pure helpers with no `app_state` dependency, per the issue: `_is_loopback_bind`, `enforce_no_auth_bind_safety`, `setup_logfire`, `register_exception_handlers`, `setup_static_files`, `lifespan`, `build_app`.

## Notable details

- The SIGHUP restart-serialization lock moved from a **module global** (`_restart_lock`) to a **per-instance attribute** (`self._restart_lock`), still lazily created on first restart. This made the `_reset_restart_lock` autouse fixture in `TestStartupShutdownRestart` unnecessary — each test's fresh `Lifecycle` starts at the pre-first-use floor — so it's removed (the cross-test leakage it guarded against is structurally gone).
- `restart_runtime` / `on_sighup` **drop the unused `nginx_watchdog` parameter** (it was threaded but never read).

## Test changes

- `_make_app_state` wires `Lifecycle`; a `_lifecycle(settings)` helper wraps a bare settings namespace for the seed-focused tests.
- `TestSeedDefaultUser` / `TestSeedAgentUser` call `_lifecycle(s).seed_default_user()` / `.seed_agent_user()`.
- `TestStartupShutdownRestart` calls `app_state.lifecycle.*` and patches methods on the instance (`patch.object(lc, "startup", …)`); the lock assertions target `lc._restart_lock`.
- Lifespan tests set `app.state.lifecycle`.
- `test_api.py` (5 sites) and `test_mode_switching.py` (3 sites) seed via `main.Lifecycle(types.SimpleNamespace(settings=…)).seed_agent_user()` / `.seed_default_user()`.

## Verification

- `test_main.py` + `test_mode_switching.py`: 76 passed.
- Full backend suite: **2408 passed, 100% coverage** (`-n auto`).
- CLI suite: 486 passed, 100% coverage.

## Changelog

Added a `### Changed` entry under `## [Unreleased]` (per the issue).

## Checklist

- [x] `Lifecycle(app_state)` owning the seed + startup + shutdown functions
- [x] `build_app` wires `app.state.lifecycle = Lifecycle(app.state)`
- [x] The lifespan and SIGHUP path call methods, not free functions
- [x] Backend (`-n auto`) and CLI suites green at 100% coverage
- [x] Changelog entry under `## [Unreleased]` → `### Changed`
