### PR TITLE
Hoist ssl_trust.py functions into SSLTrust(app_state) (#1567)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -100,6 +100,20 @@ operators or integrators to act when upgrading.
 
 ### Changed
 
+- **`SSLTrust(app_state)` class (#1567).** The two settings-dependent
+  functions in `ssl_trust.py` — the cert-dir resolver and the
+  backend-process trust applier — are now methods on an
+  `app.state.ssl_trust = SSLTrust(app.state)` instance
+  (`ssl_cert_dir()` / `apply_backend_ssl_trust()`), reading the deployer
+  config through `self.settings` instead of threading `settings` through
+  every call. The four pure path/bundle helpers (`iter_cert_files`,
+  `ssl_env_vars`, `system_ca_bundle`, `write_merged_bundle`) and the
+  module constants (`SSL_MOUNT_DEST`, `SSL_BUNDLE_DEST`, `SSL_CERT_EXTS`,
+  `SSL_TRUST_VARS`) stay module-level. `main.py` (lifespan) and
+  `container.py` (`ContainerRegistry`) now reach the resolver via
+  `self.app_state.ssl_trust`. No trust-merge logic or bundle-format
+  change — purely how callers reach the functions.
+
 - **`Lifecycle(app_state)` class** — the app-level lifecycle functions in
   `klangk_backend/main.py` (DB seeding of the default user / agent user /
   default ACLs, plus `startup` / `runtime_shutdown` / `process_shutdown` /

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -14,7 +14,6 @@ logger = logging.getLogger(__name__)
 # --- Runtime SSL/CA certificate injection (#1181) -------------------------
 from .ssl_trust import (  # noqa: E402
     SSL_MOUNT_DEST as _SSL_MOUNT_DEST,
-    ssl_cert_dir,
     ssl_env_vars,
 )
 
@@ -1460,7 +1459,7 @@ class ContainerRegistry:
         # Resolve the agent home at this async seam (``_build_env`` is
         # sync) so every exec process inherits KLANGK_AGENT_HOME (#1157).
         agent_home = f"/home/{await self.app_state.model.users.agent_handle()}"
-        ssl_dir = ssl_cert_dir(self.settings)
+        ssl_dir = self.app_state.ssl_trust.ssl_cert_dir()
         if ssl_dir:
             logger.info(
                 "Runtime SSL trust enabled: mounting %s at %s",

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -415,7 +415,7 @@ async def lifespan(app: FastAPI):
     # Make the backend process itself trust deployer-supplied CAs (#1181)
     # before any outbound TLS happens (OIDC discovery, SMTP relay, LLM-proxy
     # upstream). No-op when KLANGK_SSL_CERT_DIR is unset or empty of certs.
-    ssl_trust.apply_backend_ssl_trust(app.state.settings)
+    app.state.ssl_trust.apply_backend_ssl_trust()
 
     # Configure Logfire *after* SSL trust is applied. logfire.configure()
     # probes the Logfire API at configuration time, so it must run once the
@@ -572,6 +572,10 @@ def build_app(settings: KlangkSettings) -> FastAPI:
     # operation (previously module-level globals + import-time
     # resolve_env_value reads in auth.py). Reads self.settings at
     # construction/call time.
+    # #1567: SSLTrust(app_state) owns the settings-dependent trust surface
+    # (cert-dir resolver + backend-process trust applier). The 4 pure
+    # path/bundle helpers stay module-level in ssl_trust.py.
+    app.state.ssl_trust = ssl_trust.SSLTrust(app.state)
     app.state.auth = auth.Auth(app.state)
     # #1468: Podman(settings) owns the resolved binary path + the ~20 CLI
     # wrappers. Constructed before the registry/terminal so they reach it

--- a/src/backend/klangk_backend/ssl_trust.py
+++ b/src/backend/klangk_backend/ssl_trust.py
@@ -8,7 +8,7 @@ and both trust scopes consume them at runtime:
   at :data:`SSL_BUNDLE_DEST`, the in-container bundle the entrypoint builds
   from the mounted certs plus the container's system bundle.
 
-* **Backend process** — :func:`apply_backend_ssl_trust` builds a host-side
+* **Backend process** — :meth:`SSLTrust.apply_backend_ssl_trust` builds a host-side
   bundle and sets the trust vars in :data:`os.environ` so the backend's own
   outbound TLS (OIDC IdP, SMTP relay, LLM-proxy upstream) honors the private
   CAs.  Called once at startup (:func:`klangk_backend.main.lifespan`).
@@ -66,34 +66,11 @@ def iter_cert_files(ssl_dir: str):
             yield os.path.join(ssl_dir, name)
 
 
-def ssl_cert_dir(settings) -> str | None:
-    """Return the deployer SSL cert dir if it should be trusted, else ``None``.
-
-    Resolves ``KLANGK_SSL_CERT_DIR`` first (deprecated, backwards-compat);
-    falls back to ``<KLANGK_CUSTOMIZE_DIR>/certs`` (#1360).  Returns the
-    absolute path when the directory exists and contains at least one
-    ``.pem``/``.crt`` file; ``None`` otherwise (unset, missing, or empty
-    of certs).  Never raises — a misconfigured path simply disables
-    runtime trust.
-    """
-    raw = settings.ssl_cert_dir
-    if not raw:
-        customize = settings.customize_dir
-        candidate = os.path.join(customize, "certs")
-        if os.path.isdir(candidate):
-            raw = candidate
-    if not raw:
-        return None
-    path = os.path.realpath(raw)
-    if not os.path.isdir(path):
-        return None
-    return path if any(True for _ in iter_cert_files(path)) else None
-
-
 def ssl_env_vars(ssl_dir: str | None) -> list[str]:
     """Container env vars pointing toolchains at the in-container bundle.
 
-    Empty unless a trustable cert dir is configured (see :func:`ssl_cert_dir`).
+    Empty unless a trustable cert dir is configured
+    (see :meth:`SSLTrust.ssl_cert_dir`).
     The bundle itself is built by the container entrypoint at startup from the
     mounted certs plus the container's system bundle.
     """
@@ -160,48 +137,88 @@ def write_merged_bundle(bundle_path: str, ssl_dir: str) -> bool:
     return written > 0 and os.path.getsize(bundle_path) > 0
 
 
-def apply_backend_ssl_trust(settings) -> str | None:
-    """Make the backend process trust the deployer's custom CAs.
+class SSLTrust:
+    """Owns the settings-dependent SSL trust surface (#1567).
 
-    Builds a merged bundle (system + custom) under ``<data_dir>/ssl`` and sets
-    :data:`SSL_TRUST_VARS` in :data:`os.environ`, so the backend's outbound TLS
-    (OIDC discovery, SMTP relay, LLM-proxy upstream) honors the private CAs.
-    Idempotent and safe to call at startup; a no-op when no cert dir is
-    configured.  Refuses to apply trust when the system bundle can't be found
-    *and* no cert was written (would risk losing public-internet trust).
-
-    Returns the bundle path, or ``None`` if trust was not applied.
+    The 2 functions that read ``settings`` — the cert-dir resolver and the
+    backend-process trust applier — live here as methods (``ssl_cert_dir`` /
+    ``apply_backend_ssl_trust``), reaching the deployer config through
+    ``self.settings`` rather than threading it through every call. The 4 pure
+    path/bundle helpers and the module constants stay module-level: they take
+    explicit paths or none at all and read no settings.
     """
-    ssl_dir = ssl_cert_dir(settings)
-    if not ssl_dir:
-        return None
-    state_dir = settings.state_dir
-    bundle_dir = os.path.join(state_dir, "ssl")
-    try:
-        os.makedirs(bundle_dir, exist_ok=True)
-    except OSError as exc:
-        logger.error("Cannot create SSL bundle dir %s: %s", bundle_dir, exc)
-        return None
-    bundle_path = os.path.join(bundle_dir, "ca-bundle.crt")
-    if not write_merged_bundle(bundle_path, ssl_dir):
-        logger.warning(
-            "SSL bundle %s is empty (no system bundle and no custom certs); "
-            "not applying backend trust",
+
+    def __init__(self, app_state):
+        self.app_state = app_state
+        self.settings = app_state.settings
+
+    def ssl_cert_dir(self) -> str | None:
+        """Return the deployer SSL cert dir if it should be trusted, else ``None``.
+
+        Resolves ``KLANGK_SSL_CERT_DIR`` first (deprecated, backwards-compat);
+        falls back to ``<KLANGK_CUSTOMIZE_DIR>/certs`` (#1360).  Returns the
+        absolute path when the directory exists and contains at least one
+        ``.pem``/``.crt`` file; ``None`` otherwise (unset, missing, or empty
+        of certs).  Never raises — a misconfigured path simply disables
+        runtime trust.
+        """
+        raw = self.settings.ssl_cert_dir
+        if not raw:
+            customize = self.settings.customize_dir
+            candidate = os.path.join(customize, "certs")
+            if os.path.isdir(candidate):
+                raw = candidate
+        if not raw:
+            return None
+        path = os.path.realpath(raw)
+        if not os.path.isdir(path):
+            return None
+        return path if any(True for _ in iter_cert_files(path)) else None
+
+    def apply_backend_ssl_trust(self) -> str | None:
+        """Make the backend process trust the deployer's custom CAs.
+
+        Builds a merged bundle (system + custom) under ``<data_dir>/ssl`` and sets
+        :data:`SSL_TRUST_VARS` in :data:`os.environ`, so the backend's outbound TLS
+        (OIDC discovery, SMTP relay, LLM-proxy upstream) honors the private CAs.
+        Idempotent and safe to call at startup; a no-op when no cert dir is
+        configured.  Refuses to apply trust when the system bundle can't be found
+        *and* no cert was written (would risk losing public-internet trust).
+
+        Returns the bundle path, or ``None`` if trust was not applied.
+        """
+        ssl_dir = self.ssl_cert_dir()
+        if not ssl_dir:
+            return None
+        state_dir = self.settings.state_dir
+        bundle_dir = os.path.join(state_dir, "ssl")
+        try:
+            os.makedirs(bundle_dir, exist_ok=True)
+        except OSError as exc:
+            logger.error(
+                "Cannot create SSL bundle dir %s: %s", bundle_dir, exc
+            )
+            return None
+        bundle_path = os.path.join(bundle_dir, "ca-bundle.crt")
+        if not write_merged_bundle(bundle_path, ssl_dir):
+            logger.warning(
+                "SSL bundle %s is empty (no system bundle and no custom certs); "
+                "not applying backend trust",
+                bundle_path,
+            )
+            return None
+        if not system_ca_bundle(self_bundle=bundle_path):
+            logger.warning(
+                "Applying backend SSL trust without a system bundle: the trust "
+                "vars replace the default store, so public-internet TLS endpoints "
+                "may fail. Provide a system CA bundle or unset KLANGK_SSL_CERT_DIR."
+            )
+        for name in SSL_TRUST_VARS:
+            os.environ[name] = bundle_path
+        logger.info(
+            "Backend SSL trust applied: %s -> %d env var(s) (custom certs from %s)",
             bundle_path,
+            len(SSL_TRUST_VARS),
+            ssl_dir,
         )
-        return None
-    if not system_ca_bundle(self_bundle=bundle_path):
-        logger.warning(
-            "Applying backend SSL trust without a system bundle: the trust "
-            "vars replace the default store, so public-internet TLS endpoints "
-            "may fail. Provide a system CA bundle or unset KLANGK_SSL_CERT_DIR."
-        )
-    for name in SSL_TRUST_VARS:
-        os.environ[name] = bundle_path
-    logger.info(
-        "Backend SSL trust applied: %s -> %d env var(s) (custom certs from %s)",
-        bundle_path,
-        len(SSL_TRUST_VARS),
-        ssl_dir,
-    )
-    return bundle_path
+        return bundle_path

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -16,6 +16,7 @@ from klangk_backend import (
     files as files_mod,
     model,
     podman,
+    ssl_trust,
     util as util_mod,
 )
 from _helpers import make_settings
@@ -51,6 +52,9 @@ def _make_app_state(registry=None, sockets=None):
     app_state.files = files_mod.Files(app_state)
     # #1503: container.py reaches derive_hosting_info via app_state.util.
     app_state.util = util_mod.Util(app_state)
+    # #1567: ContainerRegistry reaches the cert-dir resolver via
+    # app_state.ssl_trust (the settings-dependent SSL trust surface).
+    app_state.ssl_trust = ssl_trust.SSLTrust(app_state)
 
     app_state.auth = auth_mod.Auth(app_state)
     # #1572: ContainerRegistry reaches app_state.model.ports; Auth reaches
@@ -113,33 +117,33 @@ class TestSslCertDir:
     """Runtime SSL/CA certificate injection (#1181): ssl_cert_dir() resolver."""
 
     def test_unset_returns_none(self):
-        assert container.ssl_cert_dir(make_settings({})) is None
+        assert self._trust(make_settings({})).ssl_cert_dir() is None
 
     def test_missing_dir_returns_none(self, tmp_path):
         gone = tmp_path / "does-not-exist"
         s = make_settings({"KLANGK_SSL_CERT_DIR": str(gone)})
-        assert container.ssl_cert_dir(s) is None
+        assert self._trust(s).ssl_cert_dir() is None
 
     def test_empty_dir_returns_none(self, tmp_path):
         # Dir exists but contains no .pem/.crt.
         (tmp_path / "readme.txt").write_text("no certs here")
         s = make_settings({"KLANGK_SSL_CERT_DIR": str(tmp_path)})
-        assert container.ssl_cert_dir(s) is None
+        assert self._trust(s).ssl_cert_dir() is None
 
     def test_dir_with_pem_returns_path(self, tmp_path):
         (tmp_path / "ca.pem").write_text("-----BEGIN CERTIFICATE-----")
         s = make_settings({"KLANGK_SSL_CERT_DIR": str(tmp_path)})
-        assert container.ssl_cert_dir(s) == str(tmp_path.resolve())
+        assert self._trust(s).ssl_cert_dir() == str(tmp_path.resolve())
 
     def test_dir_with_crt_returns_path(self, tmp_path):
         (tmp_path / "my-ca.crt").write_text("-----BEGIN CERTIFICATE-----")
         s = make_settings({"KLANGK_SSL_CERT_DIR": str(tmp_path)})
-        assert container.ssl_cert_dir(s) == str(tmp_path.resolve())
+        assert self._trust(s).ssl_cert_dir() == str(tmp_path.resolve())
 
     def test_extension_case_insensitive(self, tmp_path):
         (tmp_path / "CA.PEM").write_text("-----BEGIN CERTIFICATE-----")
         s = make_settings({"KLANGK_SSL_CERT_DIR": str(tmp_path)})
-        assert container.ssl_cert_dir(s) == str(tmp_path.resolve())
+        assert self._trust(s).ssl_cert_dir() == str(tmp_path.resolve())
 
     def test_ssl_env_vars_empty_without_dir(self):
         assert container.ssl_env_vars(None) == []
@@ -152,6 +156,11 @@ class TestSslCertDir:
             "CURL_CA_BUNDLE=/tmp/klangk/ca-bundle.crt",
             "NODE_EXTRA_CA_CERTS=/tmp/klangk/ca-bundle.crt",
         ]
+
+    @staticmethod
+    def _trust(s) -> ssl_trust.SSLTrust:
+        """SSLTrust owning the given settings (#1567)."""
+        return ssl_trust.SSLTrust(types.SimpleNamespace(settings=s))
 
 
 class TestImagePullPolicy:
@@ -902,18 +911,18 @@ class TestStartContainer:
         assert not any(e.startswith("SSL_CERT_FILE=") for e in env)
 
     async def test_no_ssl_trust_when_dir_has_no_certs(
-        self, workspace, tmp_path
+        self, workspace, tmp_path, monkeypatch
     ):
         """A cert dir with no .pem/.crt is not mounted (#1181)."""
         ssl_dir = tmp_path / "ssl"
         ssl_dir.mkdir()
         (ssl_dir / "notes.txt").write_text("not a cert")
-        # Point the registry's settings at the empty cert dir so ssl_cert_dir()
-        # actually evaluates it (previously this was an inert setenv against
-        # os.environ that the registry — built from make_settings({}) — never
-        # saw; the test passed for the wrong reason).
-        self.registry.settings = make_settings(
-            {"KLANGK_SSL_CERT_DIR": str(ssl_dir)}
+        # Point the registry's SSLTrust at the empty cert dir so ssl_cert_dir()
+        # actually evaluates it (previously this reassigned registry.settings,
+        # which the resolver now reaches only via app_state.ssl_trust; patch the
+        # settings field the SSLTrust instance reads instead).
+        monkeypatch.setattr(
+            self.registry.app_state.settings, "ssl_cert_dir", str(ssl_dir)
         )
         with patch_podman(self.registry) as p:
             await self.registry.start_container(

--- a/src/backend/tests/test_main.py
+++ b/src/backend/tests/test_main.py
@@ -19,6 +19,7 @@ from klangk_backend import (
     emailsvc as emailsvc_mod,
     files as files_mod,
     nginx as nginx_mod,
+    ssl_trust as ssl_trust_mod,
     util as util_mod,
     main,
     model,
@@ -64,6 +65,8 @@ def _make_app_state(settings=None):
     app_state.agents = agent_mod.Agents(app_state)
     app_state.email = emailsvc_mod.EmailService(app_state)
     app_state.util = util_mod.Util(app_state)
+    # #1567: the lifespan calls app.state.ssl_trust.apply_backend_ssl_trust().
+    app_state.ssl_trust = ssl_trust_mod.SSLTrust(app_state)
 
     app_state.auth = auth_mod.Auth(app_state)
     # #1571: Lifecycle(app_state) owns startup/shutdown/restart + seeding.
@@ -428,6 +431,7 @@ class TestLifespan:
         app.state.container_registry = app_state.container_registry
         app.state.sockets = app_state.sockets
         app.state.settings = app_state.settings
+        app.state.ssl_trust = app_state.ssl_trust
         app.state.db = app_state.db
         app.state.model = app_state.model
         app.state.nginx_watchdog = nginx_mod.NginxWatchdog(app.state)
@@ -475,6 +479,7 @@ class TestLifespan:
         app.state.container_registry = app_state.container_registry
         app.state.sockets = app_state.sockets
         app.state.settings = app_state.settings
+        app.state.ssl_trust = app_state.ssl_trust
         app.state.db = app_state.db
         app.state.model = app_state.model
         app.state.nginx_watchdog = nginx_mod.NginxWatchdog(app.state)
@@ -517,6 +522,7 @@ class TestLifespan:
         app = FastAPI()
         app_state = _make_app_state()
         app.state.settings = app_state.settings
+        app.state.ssl_trust = app_state.ssl_trust
         app.state.util = util_mod.Util(app.state)
         # The lifespan binds app.state.db into the ContextVar before the
         # pid-file refuse check (#1520); point it at the conftest-bound DB.
@@ -685,6 +691,7 @@ class TestStartupShutdownRestart:
         app.state.container_registry = app_state.container_registry
         app.state.sockets = app_state.sockets
         app.state.settings = app_state.settings
+        app.state.ssl_trust = app_state.ssl_trust
         app.state.db = app_state.db
         app.state.model = app_state.model
         app.state.nginx_watchdog = nginx_mod.NginxWatchdog(app.state)

--- a/src/backend/tests/test_ssl_trust.py
+++ b/src/backend/tests/test_ssl_trust.py
@@ -1,7 +1,7 @@
 """Tests for runtime SSL/CA certificate trust (#1181).
 
-Covers the shared resolver (:func:`ssl_trust.ssl_cert_dir`), the
-backend-process trust path (:func:`ssl_trust.apply_backend_ssl_trust`),
+Covers the shared resolver (:meth:`ssl_trust.SSLTrust.ssl_cert_dir`), the
+backend-process trust path (:meth:`ssl_trust.SSLTrust.apply_backend_ssl_trust`),
 and the merged-bundle semantics (system + custom) that keep
 public-internet TLS working.
 """
@@ -23,6 +23,14 @@ def _settings(env: dict):
     return make_settings(env)
 
 
+def _trust(s) -> ssl_trust.SSLTrust:
+    """Build an SSLTrust owning the given settings (#1567).
+
+    SSLTrust only reads ``app_state.settings``, so a bare namespace is enough.
+    """
+    return ssl_trust.SSLTrust(types.SimpleNamespace(settings=s))
+
+
 @pytest.fixture(autouse=True)
 def _restore_trust_env(monkeypatch):
     """Snapshot/restore the trust env vars around each test.
@@ -42,22 +50,22 @@ def _restore_trust_env(monkeypatch):
 
 class TestSslCertDir:
     def test_unset_returns_none(self):
-        assert ssl_trust.ssl_cert_dir(_settings({})) is None
+        assert _trust(_settings({})).ssl_cert_dir() is None
 
     def test_missing_dir_returns_none(self, tmp_path):
         s = _settings({"KLANGK_SSL_CERT_DIR": str(tmp_path / "nope")})
-        assert ssl_trust.ssl_cert_dir(s) is None
+        assert _trust(s).ssl_cert_dir() is None
 
     def test_empty_dir_returns_none(self, tmp_path):
         (tmp_path / "readme.txt").write_text("no certs")
         s = _settings({"KLANGK_SSL_CERT_DIR": str(tmp_path)})
-        assert ssl_trust.ssl_cert_dir(s) is None
+        assert _trust(s).ssl_cert_dir() is None
 
     def test_pem_and_crt_detected(self, tmp_path):
         (tmp_path / "a.pem").write_text("CERTA")
         (tmp_path / "b.CRT").write_text("CERTB")
         s = _settings({"KLANGK_SSL_CERT_DIR": str(tmp_path)})
-        assert ssl_trust.ssl_cert_dir(s) == str(tmp_path.resolve())
+        assert _trust(s).ssl_cert_dir() == str(tmp_path.resolve())
 
     def test_falls_back_to_customize_dir_certs(self, tmp_path):
         # When KLANGK_SSL_CERT_DIR is unset but <customize_dir>/certs
@@ -67,7 +75,7 @@ class TestSslCertDir:
         certs.mkdir(parents=True)
         (certs / "ca.pem").write_text("CERT")
         s = _settings({"KLANGK_CUSTOMIZE_DIR": str(custom)})
-        assert ssl_trust.ssl_cert_dir(s) == str(certs.resolve())
+        assert _trust(s).ssl_cert_dir() == str(certs.resolve())
 
     def test_customize_dir_certs_ignored_when_empty(self, tmp_path):
         # An empty certs/ subdir is treated the same as missing.
@@ -75,7 +83,7 @@ class TestSslCertDir:
         certs = custom / "certs"
         certs.mkdir(parents=True)
         s = _settings({"KLANGK_CUSTOMIZE_DIR": str(custom)})
-        assert ssl_trust.ssl_cert_dir(s) is None
+        assert _trust(s).ssl_cert_dir() is None
 
 
 class TestSslEnvVars:
@@ -94,13 +102,13 @@ class TestSslEnvVars:
 
 class TestApplyBackendSslTrust:
     def test_noop_when_unset(self):
-        assert ssl_trust.apply_backend_ssl_trust(_settings({})) is None
+        assert _trust(_settings({})).apply_backend_ssl_trust() is None
         for k in ssl_trust.SSL_TRUST_VARS:
             assert k not in os.environ
 
     def test_noop_when_dir_has_no_certs(self, tmp_path):
         s = _settings({"KLANGK_SSL_CERT_DIR": str(tmp_path)})
-        assert ssl_trust.apply_backend_ssl_trust(s) is None
+        assert _trust(s).apply_backend_ssl_trust() is None
         for k in ssl_trust.SSL_TRUST_VARS:
             assert k not in os.environ
 
@@ -122,7 +130,7 @@ class TestApplyBackendSslTrust:
             }
         )
 
-        bundle = ssl_trust.apply_backend_ssl_trust(s)
+        bundle = _trust(s).apply_backend_ssl_trust()
 
         assert bundle is not None
         assert os.path.isfile(bundle)
@@ -152,7 +160,7 @@ class TestApplyBackendSslTrust:
             }
         )
 
-        ssl_trust.apply_backend_ssl_trust(s)
+        _trust(s).apply_backend_ssl_trust()
 
         bundle = os.environ["SSL_CERT_FILE"]
         contents = Path(bundle).read_text()
@@ -182,12 +190,13 @@ class TestApplyBackendSslTrust:
             }
         )
 
-        ssl_trust.apply_backend_ssl_trust(s)
+        trust = _trust(s)
+        trust.apply_backend_ssl_trust()
         first = os.environ["SSL_CERT_FILE"]
         size_after_first = os.path.getsize(first)
         contents_after_first = Path(first).read_text()
 
-        ssl_trust.apply_backend_ssl_trust(s)
+        trust.apply_backend_ssl_trust()
         second = os.environ["SSL_CERT_FILE"]
         assert second == first
         assert os.path.getsize(second) == size_after_first
@@ -211,7 +220,7 @@ class TestApplyBackendSslTrust:
         )
 
         with caplog.at_level(logging.WARNING):
-            ssl_trust.apply_backend_ssl_trust(s)
+            _trust(s).apply_backend_ssl_trust()
         # Still applied (custom certs present), but warned about system loss.
         assert os.environ["SSL_CERT_FILE"]
         assert any("system bundle" in r.message for r in caplog.records)
@@ -334,14 +343,14 @@ class TestInternalsAndErrorBranches:
             lambda *a, **k: (_ for _ in ()).throw(OSError("nope")),
         )
         assert (
-            ssl_trust.apply_backend_ssl_trust(
+            _trust(
                 _settings(
                     {
                         "KLANGK_SSL_CERT_DIR": str(cert_dir),
                         "KLANGK_DATA_DIR": str(tmp_path / "data"),
                     }
                 )
-            )
+            ).apply_backend_ssl_trust()
             is None
         )
 
@@ -356,14 +365,14 @@ class TestInternalsAndErrorBranches:
         )
         with caplog.at_level(logging.WARNING):
             assert (
-                ssl_trust.apply_backend_ssl_trust(
+                _trust(
                     _settings(
                         {
                             "KLANGK_SSL_CERT_DIR": str(cert_dir),
                             "KLANGK_DATA_DIR": str(tmp_path / "data"),
                         }
                     )
-                )
+                ).apply_backend_ssl_trust()
                 is None
             )
         assert any("empty" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

Folds the two settings-dependent functions in `ssl_trust.py` into an `SSLTrust(app_state)` class, matching the `X(app_state)` ownership pattern every sibling subsystem uses. Closes #1567.

## Changes

- **`ssl_trust.py`** — new `SSLTrust(app_state)` class. The 2 settings-dependent functions become methods that read `self.settings` (dropping the `settings` parameter):
  - `ssl_cert_dir(settings)` → `ssl_cert_dir(self)`
  - `apply_backend_ssl_trust(settings)` → `apply_backend_ssl_trust(self)`
- The **4 pure helpers stay module-level** (`iter_cert_files`, `ssl_env_vars`, `system_ca_bundle`, `write_merged_bundle`) — they take explicit paths and read no settings, so monkeypatching `ssl_trust.system_ca_bundle` / `ssl_trust.iter_cert_files` still works.
- The **module constants stay module-level** (`SSL_MOUNT_DEST`, `SSL_BUNDLE_DEST`, `SSL_CERT_EXTS`, `SSL_TRUST_VARS`).
- **`main.py`** — wired `app.state.ssl_trust = ssl_trust.SSLTrust(app.state)` in `build_app`; the lifespan now calls `app.state.ssl_trust.apply_backend_ssl_trust()`.
- **`container.py`** — `ContainerRegistry` (which has `self.app_state`) now reaches the resolver via `self.app_state.ssl_trust.ssl_cert_dir()`; `ssl_cert_dir` dropped from the import (`ssl_env_vars` + `SSL_MOUNT_DEST` still imported — they're module-level).
- **Tests** — `test_ssl_trust.py` builds `SSLTrust` via a `_trust(settings)` helper (a bare namespace is enough, since the class only reads `app_state.settings`); `test_container.py`'s `TestSslCertDir` converted to the class, `_make_app_state` wires `app_state.ssl_trust`, and `test_no_ssl_trust_when_dir_has_no_certs` patches the `settings.ssl_cert_dir` field the `SSLTrust` instance reads (instead of reassigning `registry.settings`, which the resolver no longer reaches). `test_main.py`'s `_make_app_state` and the 4 lifespan blocks wire/copy `app.state.ssl_trust`.
- Changelog entry under `## [Unreleased]` → `### Changed`.

No trust-merge logic, bundle format, or env-var change — purely how callers reach the functions.

## Verification

- Backend (`-n auto`): **2428 passed, 100%**.
- CLI: **486 passed, 100%**.
- Rebased onto latest `main` (resolved a `container.py` conflict with #1573's `agent_handle` conversion and a `docs/changes.md` conflict with #1571's `Lifecycle` entry — kept both); both suites re-run green post-rebase.

## Acceptance criteria

- [x] `SSLTrust(app_state)` class; `ssl_cert_dir` / `apply_backend_ssl_trust` are methods using `self.settings` (no `settings` parameter).
- [x] The 4 pure helpers remain module-level.
- [x] Module constants remain module-level.
- [x] `app.state.ssl_trust` wired in `build_app`; test fixtures construct it.
- [x] `main.py` lifespan + `container.py` call sites updated.
- [x] Backend + CLI green at 100%.
- [x] Changelog entry added.
