### PR TITLE
Hoist model/acl.py into ACLModel(app_state) (#1574)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -100,6 +100,20 @@ operators or integrators to act when upgrading.
 
 ### Changed
 
+- **`ACLModel(app_state)`** — the ACL data-access functions in
+  `model/acl.py` (`add_acl_entry`, `get_acl_entries`, `get_acl_entries_map`,
+  `get_acl_entries_resolved`, `replace_acl_entries`,
+  `delete_acl_entries_for_resource`, `get_acl_entries_by_principal_user`,
+  `get_acl_entries_by_principal_group`, `get_acl_tree_summary`) are now
+  methods on an `ACLModel(app_state)` class reached via
+  `app_state.model.acl`, instead of module-level free functions. The API
+  routes (`api/admin.py`, `api/workspaces.py`) and `main.py`'s ACL seed now
+  call `app_state.model.acl.*`. The principal/action constants
+  (`ACTION_ALLOW`, `PRINCIPAL_*`, `SYSTEM_*`) and the pure `row_to_acl_entry`
+  helper stay module-level; the free-function backstops stay until #1578
+  (the separate `klangk_backend/acl.py` FastAPI permission layer still
+  reaches `model.get_acl_entries_map` through them). No behavior change (#1574).
+
 - **`SSLTrust(app_state)` class (#1567).** The two settings-dependent
   functions in `ssl_trust.py` — the cert-dir resolver and the
   backend-process trust applier — are now methods on an

--- a/src/backend/klangk_backend/api/admin.py
+++ b/src/backend/klangk_backend/api/admin.py
@@ -15,7 +15,6 @@ from pydantic import BaseModel
 from .. import (
     acl,
     auth,
-    model,
     wshandler,
 )
 from ._common import get_app_state_dep
@@ -411,7 +410,7 @@ async def user_create_group(
         )
     group = await app_state.model.users.create_group(req.name, req.description)
     # Grant creator full access via ACL
-    await model.add_acl_entry(
+    await app_state.model.acl.add_acl_entry(
         f"/groups/{group['id']}",
         0,
         ACTION_ALLOW,
@@ -452,7 +451,9 @@ async def user_delete_group(
     if group is None:
         raise HTTPException(status_code=404, detail="Group not found")
     await app_state.model.users.delete_group(group_id)
-    await model.delete_acl_entries_for_resource(f"/groups/{group_id}")
+    await app_state.model.acl.delete_acl_entries_for_resource(
+        f"/groups/{group_id}"
+    )
     return {"status": "deleted"}
 
 
@@ -625,33 +626,39 @@ async def remove_group_member(
 @router.get("/admin/acl/tree")
 async def get_acl_tree(
     admin: dict = Depends(acl.has_permission("admin")),
+    app_state=Depends(get_app_state_dep),
 ):
-    return await model.get_acl_tree_summary()
+    return await app_state.model.acl.get_acl_tree_summary()
 
 
 @router.get("/admin/acl/by-principal/user/{user_id}")
 async def get_acl_by_user(
     user_id: str,
     admin: dict = Depends(acl.has_permission("admin")),
+    app_state=Depends(get_app_state_dep),
 ):
-    return await model.get_acl_entries_by_principal_user(user_id)
+    return await app_state.model.acl.get_acl_entries_by_principal_user(user_id)
 
 
 @router.get("/admin/acl/by-principal/group/{group_id}")
 async def get_acl_by_group(
     group_id: str,
     admin: dict = Depends(acl.has_permission("admin")),
+    app_state=Depends(get_app_state_dep),
 ):
-    return await model.get_acl_entries_by_principal_group(group_id)
+    return await app_state.model.acl.get_acl_entries_by_principal_group(
+        group_id
+    )
 
 
 @router.get("/admin/acl/resource")
 async def get_resource_acl(
     resource: str,
     admin: dict = Depends(acl.has_permission("admin", admin_resource)),
+    app_state=Depends(get_app_state_dep),
 ):
     """Get resolved ACL entries for any resource (admin only)."""
-    return await model.get_acl_entries_resolved(resource)
+    return await app_state.model.acl.get_acl_entries_resolved(resource)
 
 
 @router.put("/admin/acl/resource")
@@ -659,6 +666,7 @@ async def replace_resource_acl(
     resource: str,
     entries: list[WorkspaceAclEntry],
     admin: dict = Depends(acl.has_permission("admin", admin_resource)),
+    app_state=Depends(get_app_state_dep),
 ):
     """Replace ACL entries for any resource (admin only)."""
     # Validate: root ACL must keep Authenticated view access
@@ -704,8 +712,8 @@ async def replace_resource_acl(
         }
         for i, e in enumerate(entries)
     ]
-    await model.replace_acl_entries(resource, acl_entries)
-    return await model.get_acl_entries_resolved(resource)
+    await app_state.model.acl.replace_acl_entries(resource, acl_entries)
+    return await app_state.model.acl.get_acl_entries_resolved(resource)
 
 
 STATIC_RESOURCES = [

--- a/src/backend/klangk_backend/api/workspaces.py
+++ b/src/backend/klangk_backend/api/workspaces.py
@@ -366,7 +366,9 @@ async def delete_workspace(
     if not deleted:  # pragma: no cover — race between get and delete
         raise HTTPException(status_code=404, detail="Workspace not found")
     # Clean up ACL entries for this workspace
-    await model.delete_acl_entries_for_resource(f"/workspaces/{workspace_id}")
+    await app_state.model.acl.delete_acl_entries_for_resource(
+        f"/workspaces/{workspace_id}"
+    )
     # Notify the deleter, the owner, and any shared members so their
     # workspace list refreshes (members were fetched above, before the
     # resource's ACL entries were removed).
@@ -794,10 +796,10 @@ async def add_workspace_member(
     # Add ACL entries granting the target user view+terminal+files+chat
     # on this workspace, packed at the next available positions.
     resource = f"/workspaces/{workspace_id}"
-    existing = await model.get_acl_entries(resource)
+    existing = await app_state.model.acl.get_acl_entries(resource)
     next_pos = max((e["position"] for e in existing), default=-1) + 1
     for perm in ("view", "terminal", "files", "chat"):
-        await model.add_acl_entry(
+        await app_state.model.acl.add_acl_entry(
             resource,
             next_pos,
             ACTION_ALLOW,
@@ -824,7 +826,7 @@ async def remove_workspace_member(
 ):
     # Remove all ACL entries for this user on this workspace
     resource = f"/workspaces/{workspace_id}"
-    entries = await model.get_acl_entries(resource)
+    entries = await app_state.model.acl.get_acl_entries(resource)
     remaining = [
         e
         for e in entries
@@ -835,7 +837,7 @@ async def remove_workspace_member(
     # Rewrite entries with new positions
     for i, entry in enumerate(remaining):
         entry["position"] = i
-    await model.replace_acl_entries(resource, remaining)
+    await app_state.model.acl.replace_acl_entries(resource, remaining)
     app_state.sockets.notify_user_workspaces_changed(user["id"])
     app_state.sockets.notify_user_workspaces_changed(member_id)
     return {"status": "removed"}
@@ -976,10 +978,11 @@ async def change_workspace_role(
 async def get_workspace_groups(
     workspace_id: str,
     user: dict = Depends(acl.has_permission("share", _check_workspace_share)),
+    app_state=Depends(get_app_state_dep),
 ):
     """Get groups with access to this workspace via ACL."""
     resource = f"/workspaces/{workspace_id}"
-    entries = await model.get_acl_entries_resolved(resource)
+    entries = await app_state.model.acl.get_acl_entries_resolved(resource)
     seen = set()
     groups = []
     for e in entries:
@@ -1007,10 +1010,10 @@ async def add_workspace_group(
     if group is None:
         raise HTTPException(status_code=404, detail="Group not found")
     resource = f"/workspaces/{workspace_id}"
-    existing = await model.get_acl_entries(resource)
+    existing = await app_state.model.acl.get_acl_entries(resource)
     max_pos = max((e["position"] for e in existing), default=-1)
     for i, perm in enumerate(["view", "terminal", "files", "chat"]):
-        await model.add_acl_entry(
+        await app_state.model.acl.add_acl_entry(
             resource,
             max_pos + 1 + i,
             ACTION_ALLOW,
@@ -1026,10 +1029,11 @@ async def remove_workspace_group(
     workspace_id: str,
     group_id: str,
     user: dict = Depends(acl.has_permission("share", _check_workspace_share)),
+    app_state=Depends(get_app_state_dep),
 ):
     """Remove all ACL entries for a group on this workspace."""
     resource = f"/workspaces/{workspace_id}"
-    entries = await model.get_acl_entries(resource)
+    entries = await app_state.model.acl.get_acl_entries(resource)
     remaining = [
         e
         for e in entries
@@ -1040,7 +1044,7 @@ async def remove_workspace_group(
     ]
     for i, entry in enumerate(remaining):
         entry["position"] = i
-    await model.replace_acl_entries(resource, remaining)
+    await app_state.model.acl.replace_acl_entries(resource, remaining)
     return {"status": "removed"}
 
 
@@ -1051,10 +1055,11 @@ async def remove_workspace_group(
 async def get_workspace_acl(
     workspace_id: str,
     user: dict = Depends(acl.has_permission("share", _check_workspace_share)),
+    app_state=Depends(get_app_state_dep),
 ):
     """Get resolved ACL entries for a workspace."""
     resource = f"/workspaces/{workspace_id}"
-    return await model.get_acl_entries_resolved(resource)
+    return await app_state.model.acl.get_acl_entries_resolved(resource)
 
 
 @router.put("/workspaces/{workspace_id}/acl")
@@ -1062,6 +1067,7 @@ async def replace_workspace_acl(
     workspace_id: str,
     entries: list[WorkspaceAclEntry],
     user: dict = Depends(acl.has_permission("share", _check_workspace_share)),
+    app_state=Depends(get_app_state_dep),
 ):
     """Replace all ACL entries for a workspace."""
     resource = f"/workspaces/{workspace_id}"
@@ -1077,8 +1083,8 @@ async def replace_workspace_acl(
         }
         for i, e in enumerate(entries)
     ]
-    await model.replace_acl_entries(resource, acl_entries)
-    return await model.get_acl_entries_resolved(resource)
+    await app_state.model.acl.replace_acl_entries(resource, acl_entries)
+    return await app_state.model.acl.get_acl_entries_resolved(resource)
 
 
 # --- Ownership transfer ---

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -89,11 +89,11 @@ class Lifecycle:
 
     async def seed_default_acls(self, admin_group_id: str) -> None:
         """Seed default ACL entries if none exist yet."""
-        existing = await model.get_acl_tree_summary()
+        existing = await self.app_state.model.acl.get_acl_tree_summary()
         if existing:
             return
         # /: Authenticated users can view, deny everyone else
-        await model.add_acl_entry(
+        await self.app_state.model.acl.add_acl_entry(
             "/",
             0,
             ACTION_ALLOW,
@@ -101,7 +101,7 @@ class Lifecycle:
             PRINCIPAL_SYSTEM,
             system_principal=SYSTEM_AUTHENTICATED,
         )
-        await model.add_acl_entry(
+        await self.app_state.model.acl.add_acl_entry(
             "/",
             1,
             ACTION_DENY,
@@ -110,7 +110,7 @@ class Lifecycle:
             system_principal=SYSTEM_EVERYONE,
         )
         # /workspaces: Authenticated users can create
-        await model.add_acl_entry(
+        await self.app_state.model.acl.add_acl_entry(
             "/workspaces",
             0,
             ACTION_ALLOW,
@@ -119,7 +119,7 @@ class Lifecycle:
             system_principal=SYSTEM_AUTHENTICATED,
         )
         # /groups: Authenticated users can create groups
-        await model.add_acl_entry(
+        await self.app_state.model.acl.add_acl_entry(
             "/groups",
             0,
             ACTION_ALLOW,
@@ -128,7 +128,7 @@ class Lifecycle:
             system_principal=SYSTEM_AUTHENTICATED,
         )
         # /admin: admin group gets full access, deny everyone else
-        await model.add_acl_entry(
+        await self.app_state.model.acl.add_acl_entry(
             "/admin",
             0,
             ACTION_ALLOW,
@@ -136,7 +136,7 @@ class Lifecycle:
             PRINCIPAL_GROUP,
             group_id=admin_group_id,
         )
-        await model.add_acl_entry(
+        await self.app_state.model.acl.add_acl_entry(
             "/admin",
             1,
             ACTION_DENY,

--- a/src/backend/klangk_backend/model/__init__.py
+++ b/src/backend/klangk_backend/model/__init__.py
@@ -77,6 +77,7 @@ from .users import (
     verify_user,
 )
 from .acl import (
+    ACLModel,
     ACTION_ALLOW,
     ACTION_DENY,
     PRINCIPAL_GROUP,
@@ -220,6 +221,7 @@ __all__ = (
     "validate_handle",
     "verify_user",
     # acl
+    "ACLModel",
     "ACTION_ALLOW",
     "ACTION_DENY",
     "PRINCIPAL_GROUP",

--- a/src/backend/klangk_backend/model/acl.py
+++ b/src/backend/klangk_backend/model/acl.py
@@ -1,4 +1,13 @@
-"""ACL entries (access-control list rows) and principal/action constants."""
+"""ACL entries (access-control list rows) and principal/action constants.
+
+``ACLModel`` is the ``app_state``-owned form, reached via
+``app_state.model.acl`` (#1563 / #1574). The module-level free functions
+are the pre-existing ``_current_db`` ContextVar delegates, kept as the
+backstop until #1578 dissolves the ContextVar. The principal/action
+constants and the pure ``row_to_acl_entry`` helper stay module-level —
+they are imported as literal values by ``chat.py``, ``workspaces.py``,
+and ``schema.py``.
+"""
 
 from .db import transaction
 from .users import AGENT_USER_ID, AgentPrincipalError
@@ -13,6 +22,258 @@ PRINCIPAL_GROUP = 2
 
 SYSTEM_EVERYONE = 0
 SYSTEM_AUTHENTICATED = 1
+
+
+def row_to_acl_entry(row) -> dict:
+    """Map an acl_entries row to the dict shape callers expect."""
+    return {
+        "id": row["id"],
+        "resource": row["resource"],
+        "position": row["position"],
+        "action": row["action"],
+        "principal_type": row["principal_type"],
+        "user_id": row["user_id"],
+        "group_id": row["group_id"],
+        "system_principal": row["system_principal"],
+        "permission": row["permission"],
+    }
+
+
+class ACLModel:
+    """ACL data access, through ``app_state.db``.
+
+    Reached via ``app_state.model.acl``. Reaches the DB through
+    ``self.app_state.db`` (the single DB instance for the whole app).
+    The method bodies mirror the module-level free functions below
+    (backstop); the constants and the pure ``row_to_acl_entry`` helper
+    stay module-level.
+    """
+
+    def __init__(self, app_state):
+        self.app_state = app_state
+
+    async def add_acl_entry(
+        self,
+        resource: str,
+        position: int,
+        action: int,
+        permission: str,
+        principal_type: int,
+        user_id: str | None = None,
+        group_id: str | None = None,
+        system_principal: int | None = None,
+    ) -> int:
+        """Add an ACL entry. Returns the entry ID.
+
+        Raises ``AgentPrincipalError`` if the entry would make the system
+        agent a user principal.
+        """
+        if user_id == AGENT_USER_ID:
+            raise AgentPrincipalError(
+                "The system agent cannot hold ACL entries"
+                " (global fixed UUID — granting it cross-workspace"
+                " blast radius)."
+            )
+        async with self.app_state.db.transaction() as db:
+            cursor = await db.execute(
+                "INSERT INTO acl_entries"
+                " (resource, position, action, principal_type,"
+                "  user_id, group_id, system_principal, permission)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    resource,
+                    position,
+                    action,
+                    principal_type,
+                    user_id,
+                    group_id,
+                    system_principal,
+                    permission,
+                ),
+            )
+            return cursor.lastrowid
+
+    async def get_acl_entries(self, resource: str) -> list[dict]:
+        """Get ACL entries for a resource, ordered by position."""
+        async with self.app_state.db.transaction() as db:
+            cursor = await db.execute(
+                "SELECT id, resource, position, action, principal_type,"
+                " user_id, group_id, system_principal, permission"
+                " FROM acl_entries WHERE resource = ?"
+                " ORDER BY position",
+                (resource,),
+            )
+            return [row_to_acl_entry(row) for row in await cursor.fetchall()]
+
+    async def get_acl_entries_map(
+        self,
+        resources: list[str],
+    ) -> dict[str, list[dict]]:
+        """Fetch ACL entries for many resources in a single query.
+
+        Returns a ``{resource: [entries]}`` map (entries ordered by position).
+        Resources with no entries are present as empty lists. This exists so
+        callers that check many resources/permissions (e.g. ``my_permissions``)
+        don't open one DB connection per resource — see ``acl.check_permission``
+        which previously caused ~300 sequential connection-per-query reads.
+        """
+        resources = list(dict.fromkeys(resources))  # de-dup, keep order
+        result: dict[str, list[dict]] = {r: [] for r in resources}
+        if not resources:
+            return result
+        placeholders = ",".join("?" for _ in resources)
+        async with self.app_state.db.transaction() as db:
+            cursor = await db.execute(
+                "SELECT id, resource, position, action, principal_type,"
+                " user_id, group_id, system_principal, permission"
+                " FROM acl_entries WHERE resource IN"
+                f" ({placeholders}) ORDER BY position",
+                tuple(resources),
+            )
+            for row in await cursor.fetchall():
+                result.setdefault(row["resource"], []).append(
+                    row_to_acl_entry(row)
+                )
+        return result
+
+    async def get_acl_entries_resolved(self, resource: str) -> list[dict]:
+        """Get ACL entries with resolved principal names."""
+        async with self.app_state.db.transaction() as db:
+            cursor = await db.execute(
+                "SELECT ae.id, ae.resource, ae.position, ae.action,"
+                " ae.principal_type, ae.user_id, ae.group_id,"
+                " ae.system_principal, ae.permission,"
+                " u.email AS user_email, g.name AS group_name"
+                " FROM acl_entries ae"
+                " LEFT JOIN users u ON ae.user_id = u.id"
+                " LEFT JOIN groups g ON ae.group_id = g.id"
+                " WHERE ae.resource = ?"
+                " ORDER BY ae.position",
+                (resource,),
+            )
+            results = []
+            for row in await cursor.fetchall():
+                entry = {
+                    "id": row["id"],
+                    "resource": row["resource"],
+                    "position": row["position"],
+                    "action": row["action"],
+                    "principal_type": row["principal_type"],
+                    "permission": row["permission"],
+                }
+                pt = row["principal_type"]
+                if pt == PRINCIPAL_SYSTEM:
+                    sp = row["system_principal"]
+                    entry["principal"] = (
+                        "Everyone"
+                        if sp == SYSTEM_EVERYONE
+                        else "Authenticated"
+                    )
+                    entry["system_principal"] = sp
+                elif pt == PRINCIPAL_USER:
+                    entry["principal"] = row["user_email"] or row["user_id"]
+                    entry["user_id"] = row["user_id"]
+                elif pt == PRINCIPAL_GROUP:
+                    entry["principal"] = row["group_name"] or row["group_id"]
+                    entry["group_id"] = row["group_id"]
+                results.append(entry)
+            return results
+
+    async def replace_acl_entries(
+        self, resource: str, entries: list[dict]
+    ) -> None:
+        """Replace all ACL entries for a resource.
+
+        Raises ``AgentPrincipalError`` if any entry would make the system
+        agent a user principal. This is the second writer into
+        ``acl_entries`` (a raw INSERT, fed request-body ``user_id`` by the
+        PUT-acl endpoints) and must be guarded alongside
+        :meth:`add_acl_entry` so neither writer can make the agent a
+        principal.
+        """
+        for entry in entries:
+            if (
+                entry.get("principal_type") == PRINCIPAL_USER
+                and entry.get("user_id") == AGENT_USER_ID
+            ):
+                raise AgentPrincipalError(
+                    "The system agent cannot hold ACL entries"
+                    " (global fixed UUID — granting it cross-workspace"
+                    " blast radius)."
+                )
+        async with self.app_state.db.transaction() as db:
+            await db.execute(
+                "DELETE FROM acl_entries WHERE resource = ?", (resource,)
+            )
+            for entry in entries:
+                await db.execute(
+                    "INSERT INTO acl_entries"
+                    " (resource, position, action, principal_type,"
+                    "  user_id, group_id, system_principal, permission)"
+                    " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        resource,
+                        entry["position"],
+                        entry["action"],
+                        entry["principal_type"],
+                        entry.get("user_id"),
+                        entry.get("group_id"),
+                        entry.get("system_principal"),
+                        entry["permission"],
+                    ),
+                )
+
+    async def delete_acl_entries_for_resource(self, resource: str) -> int:
+        """Delete all ACL entries for a resource. Returns count deleted."""
+        async with self.app_state.db.transaction() as db:
+            cursor = await db.execute(
+                "DELETE FROM acl_entries WHERE resource = ?", (resource,)
+            )
+            return cursor.rowcount
+
+    async def get_acl_entries_by_principal_user(
+        self, user_id: str
+    ) -> list[dict]:
+        """Get all ACL entries referencing a specific user."""
+        async with self.app_state.db.transaction() as db:
+            cursor = await db.execute(
+                "SELECT id, resource, position, action, principal_type,"
+                " user_id, group_id, system_principal, permission"
+                " FROM acl_entries WHERE principal_type = ? AND user_id = ?"
+                " ORDER BY resource, position",
+                (PRINCIPAL_USER, user_id),
+            )
+            return [dict(row) for row in await cursor.fetchall()]
+
+    async def get_acl_entries_by_principal_group(
+        self, group_id: str
+    ) -> list[dict]:
+        """Get all ACL entries referencing a specific group."""
+        async with self.app_state.db.transaction() as db:
+            cursor = await db.execute(
+                "SELECT id, resource, position, action, principal_type,"
+                " user_id, group_id, system_principal, permission"
+                " FROM acl_entries WHERE principal_type = ? AND group_id = ?"
+                " ORDER BY resource, position",
+                (PRINCIPAL_GROUP, group_id),
+            )
+            return [dict(row) for row in await cursor.fetchall()]
+
+    async def get_acl_tree_summary(self) -> list[dict]:
+        """Get all distinct resources with their ACE counts."""
+        async with self.app_state.db.transaction() as db:
+            cursor = await db.execute(
+                "SELECT resource, COUNT(*) as ace_count"
+                " FROM acl_entries GROUP BY resource"
+                " ORDER BY resource"
+            )
+            return [
+                {"resource": row["resource"], "ace_count": row["ace_count"]}
+                for row in await cursor.fetchall()
+            ]
+
+
+# --- ContextVar-backed free functions (backstop; removed in #1578) ---
 
 
 async def add_acl_entry(
@@ -54,21 +315,6 @@ async def add_acl_entry(
             ),
         )
         return cursor.lastrowid
-
-
-def row_to_acl_entry(row) -> dict:
-    """Map an acl_entries row to the dict shape callers expect."""
-    return {
-        "id": row["id"],
-        "resource": row["resource"],
-        "position": row["position"],
-        "action": row["action"],
-        "principal_type": row["principal_type"],
-        "user_id": row["user_id"],
-        "group_id": row["group_id"],
-        "system_principal": row["system_principal"],
-        "permission": row["permission"],
-    }
 
 
 async def get_acl_entries(resource: str) -> list[dict]:

--- a/src/backend/klangk_backend/model/model.py
+++ b/src/backend/klangk_backend/model/model.py
@@ -9,15 +9,16 @@ seed) uses the same resolved value — the one ``app.state.db`` the app was
 built with (#1563, #1551).
 
 Foundation (#1572): only the four standalone domains are composed here
-(``tokens``, ``login_attempts``, ``invitations``, ``ports``). ``users`` is
-added in #1573; the remaining domains (``acl``, ``workspaces``, ``chat``)
-are added in their own issues; until then they're still reached via the
-module-level free functions + the ``_current_db`` ContextVar backstop in
-``model/db.py``.
+(``tokens``, ``login_attempts``, ``invitations``, ``ports``). ``users``
+(#1573) and ``acl`` (#1574) are added; the remaining domains
+(``workspaces``, ``chat``) are added in their own issues; until then
+they're still reached via the module-level free functions + the
+``_current_db`` ContextVar backstop in ``model/db.py``.
 """
 
 from contextlib import asynccontextmanager
 
+from .acl import ACLModel
 from .ports import PortsModel
 from .tokens import TokensModel
 from .login_attempts import LoginAttemptsModel
@@ -42,6 +43,7 @@ class Model:
         self.invitations = InvitationsModel(app_state)
         self.ports = PortsModel(app_state)
         self.users = UsersModel(app_state)
+        self.acl = ACLModel(app_state)
 
     @asynccontextmanager
     async def transaction(self):

--- a/src/backend/tests/test_main.py
+++ b/src/backend/tests/test_main.py
@@ -75,13 +75,19 @@ def _make_app_state(settings=None):
 
 
 def _lifecycle(settings):
-    """A ``Lifecycle`` whose app_state carries just ``settings``.
+    """A ``Lifecycle`` whose app_state can reach ``model.acl``.
 
-    The seed methods read only ``self.app_state.settings`` (DB access goes
-    through the model/ ContextVar backstop bound by the ``db`` fixture),
-    so a bare namespace is enough for the seed-focused tests below.
+    The seed methods read ``self.app_state.settings`` and reach the DB via
+    ``self.app_state.model.acl.*`` (ACL seeding) and the model/ ContextVar
+    backstop (everything else), so the namespace needs ``db`` + ``model``
+    wired (#1574). ``wire_db_and_model`` reuses the ContextVar-bound DB the
+    ``db`` fixture set up.
     """
-    return main.Lifecycle(types.SimpleNamespace(settings=settings))
+    from _helpers import wire_db_and_model
+
+    state = types.SimpleNamespace(settings=settings)
+    wire_db_and_model(state)
+    return main.Lifecycle(state)
 
 
 # --- Seed default user ---

--- a/src/backend/tests/test_mode_switching.py
+++ b/src/backend/tests/test_mode_switching.py
@@ -41,6 +41,15 @@ def _auth():
     return auth_mod.Auth(state)
 
 
+def _lifecycle(env):
+    """A ``Lifecycle`` whose app_state can reach ``model.acl`` (#1574)."""
+    from _helpers import wire_db_and_model
+
+    state = types.SimpleNamespace(settings=make_settings(env))
+    wire_db_and_model(state)
+    return main.Lifecycle(state)
+
+
 DEFAULT_EMAIL = "admin@example.com"
 SEEDED_PASSWORD = "seeded-pw"
 NEW_PASSWORD = "rotated-by-admin"
@@ -61,15 +70,11 @@ async def mode_server(db, monkeypatch):
     """
     global _current_app
     # Seed exactly as the lifespan does at startup.
-    await main.Lifecycle(
-        types.SimpleNamespace(
-            settings=make_settings(
-                {
-                    "KLANGK_DEFAULT_USER": DEFAULT_EMAIL,
-                    "KLANGK_DEFAULT_PASSWORD": SEEDED_PASSWORD,
-                }
-            )
-        )
+    await _lifecycle(
+        {
+            "KLANGK_DEFAULT_USER": DEFAULT_EMAIL,
+            "KLANGK_DEFAULT_PASSWORD": SEEDED_PASSWORD,
+        }
     ).seed_default_user()
     default_user = await model.get_user_by_email(DEFAULT_EMAIL)
     assert default_user is not None, "seed_default_user must create the user"
@@ -399,29 +404,21 @@ class TestRestartIdempotency:
         must not duplicate the user or drop its admin membership."""
         client, user = mode_server
         _none()
-        await main.Lifecycle(
-            types.SimpleNamespace(
-                settings=make_settings(
-                    {
-                        "KLANGK_AUTH_MODES": "none",
-                        "KLANGK_DEFAULT_USER": DEFAULT_EMAIL,
-                        "KLANGK_DEFAULT_PASSWORD": SEEDED_PASSWORD,
-                    }
-                )
-            )
+        await _lifecycle(
+            {
+                "KLANGK_AUTH_MODES": "none",
+                "KLANGK_DEFAULT_USER": DEFAULT_EMAIL,
+                "KLANGK_DEFAULT_PASSWORD": SEEDED_PASSWORD,
+            }
         ).seed_default_user()  # simulate restart in none mode
 
         _password()
-        await main.Lifecycle(
-            types.SimpleNamespace(
-                settings=make_settings(
-                    {
-                        "KLANGK_AUTH_MODES": "password",
-                        "KLANGK_DEFAULT_USER": DEFAULT_EMAIL,
-                        "KLANGK_DEFAULT_PASSWORD": SEEDED_PASSWORD,
-                    }
-                )
-            )
+        await _lifecycle(
+            {
+                "KLANGK_AUTH_MODES": "password",
+                "KLANGK_DEFAULT_USER": DEFAULT_EMAIL,
+                "KLANGK_DEFAULT_PASSWORD": SEEDED_PASSWORD,
+            }
         ).seed_default_user()  # simulate restart in password mode
 
         again = await model.get_user_by_email(DEFAULT_EMAIL)

--- a/src/backend/tests/test_model.py
+++ b/src/backend/tests/test_model.py
@@ -1824,3 +1824,75 @@ class TestUsersBackstopBranches:
         await model.update_password(user["id"], "newhash")
         fetched = await model.get_user_by_email(user["email"])
         assert fetched["password_hash"] == "newhash"
+
+
+class TestAclBackstopBranches:
+    """Cover backstop branches not reached by app code (#1574).
+
+    The API routes and the seed now reach ACL via ``app_state.model.acl.*``
+    (the class methods, covered in ``test_model_app_state.py``); these
+    free-function backstops are kept until #1578 (``klangk_backend/acl.py``
+    still uses ``get_acl_entries_map``), so the ones that lost their app-code
+    callers are exercised directly here.
+    """
+
+    async def test_resolved_delete_by_principal_and_tree(self, db, user):
+        group = await model.create_group("bs-group")
+        await model.add_acl_entry(
+            "/bs-res",
+            0,
+            model.ACTION_ALLOW,
+            "view",
+            model.PRINCIPAL_USER,
+            user_id=user["id"],
+        )
+        await model.add_acl_entry(
+            "/bs-res",
+            1,
+            model.ACTION_ALLOW,
+            "view",
+            model.PRINCIPAL_GROUP,
+            group_id=group["id"],
+        )
+        await model.add_acl_entry(
+            "/bs-res",
+            2,
+            model.ACTION_ALLOW,
+            "view",
+            model.PRINCIPAL_SYSTEM,
+            system_principal=model.SYSTEM_EVERYONE,
+        )
+        # resolved view names the principal (user / group / system paths)
+        resolved = await model.get_acl_entries_resolved("/bs-res")
+        assert len(resolved) == 3
+        assert any(r.get("principal") == "Everyone" for r in resolved)
+        # by-principal lookups
+        assert (
+            len(await model.get_acl_entries_by_principal_user(user["id"])) == 1
+        )
+        assert (
+            len(await model.get_acl_entries_by_principal_group(group["id"]))
+            == 1
+        )
+        # tree summary lists the resource
+        tree = await model.get_acl_tree_summary()
+        assert any(row["resource"] == "/bs-res" for row in tree)
+        # replace with a fresh non-empty entry set (covers the INSERT loop)
+        await model.replace_acl_entries(
+            "/bs-res",
+            [
+                {
+                    "position": 0,
+                    "action": model.ACTION_DENY,
+                    "principal_type": model.PRINCIPAL_SYSTEM,
+                    "system_principal": model.SYSTEM_AUTHENTICATED,
+                    "permission": "*",
+                    "user_id": None,
+                    "group_id": None,
+                }
+            ],
+        )
+        after = await model.get_acl_entries("/bs-res")
+        assert len(after) == 1
+        # delete returns the count
+        assert await model.delete_acl_entries_for_resource("/bs-res") == 1

--- a/src/backend/tests/test_model_app_state.py
+++ b/src/backend/tests/test_model_app_state.py
@@ -158,3 +158,143 @@ class TestPortsModel:
         assert 9000 not in await p.get_workspace_ports(ws_id)
         all_ports = await p.get_all_allocated_ports()
         assert 9001 in all_ports
+
+
+class TestACLModel:
+    """Direct coverage for the ``ACLModel`` class methods (#1574).
+
+    The method bodies mirror the module-level free functions (backstop);
+    both copies are kept until #1578, so both need coverage. The backstop
+    is covered indirectly by ``klangk_backend/acl.py`` (still on the
+    ContextVar path) and directly in ``test_model.py``; this class covers
+    the class methods through ``app_state.model.acl`` — the surface the
+    API routes and the seed now use.
+    """
+
+    async def test_add_get_replace_delete_resolved(
+        self, app_state_with_schema, user
+    ):
+        a = app_state_with_schema.model.acl
+        resource = "/workspaces/acl-cls"
+        eid = await a.add_acl_entry(
+            resource,
+            0,
+            model.ACTION_ALLOW,
+            "view",
+            model.PRINCIPAL_USER,
+            user_id=user["id"],
+        )
+        assert isinstance(eid, int)
+        entries = await a.get_acl_entries(resource)
+        assert len(entries) == 1 and entries[0]["id"] == eid
+
+        # get_acl_entries_map (class method — no production caller yet;
+        # ``acl.py`` still uses the backstop).
+        amap = await a.get_acl_entries_map([resource, "/none/here"])
+        assert len(amap[resource]) == 1
+        assert amap["/none/here"] == []
+        assert await a.get_acl_entries_map([]) == {}
+
+        # resolved view carries the user email as the principal name
+        resolved = await a.get_acl_entries_resolved(resource)
+        assert resolved[0]["principal"] == user["email"]
+
+        # replace (with a system-everyone deny) then read back
+        await a.replace_acl_entries(
+            resource,
+            [
+                {
+                    "position": 0,
+                    "action": model.ACTION_DENY,
+                    "principal_type": model.PRINCIPAL_SYSTEM,
+                    "system_principal": model.SYSTEM_EVERYONE,
+                    "permission": "*",
+                    "user_id": None,
+                    "group_id": None,
+                }
+            ],
+        )
+        after = await a.get_acl_entries(resource)
+        assert len(after) == 1
+        assert after[0]["action"] == model.ACTION_DENY
+
+        # delete returns the count, then the resource is empty
+        deleted = await a.delete_acl_entries_for_resource(resource)
+        assert deleted == 1
+        assert await a.get_acl_entries(resource) == []
+
+    async def test_by_principal_user_and_group(
+        self, app_state_with_schema, user
+    ):
+        a = app_state_with_schema.model.acl
+        group = await model.create_group("acl-group")
+        await a.add_acl_entry(
+            "/by-princ",
+            0,
+            model.ACTION_ALLOW,
+            "view",
+            model.PRINCIPAL_USER,
+            user_id=user["id"],
+        )
+        await a.add_acl_entry(
+            "/by-princ",
+            1,
+            model.ACTION_ALLOW,
+            "view",
+            model.PRINCIPAL_GROUP,
+            group_id=group["id"],
+        )
+        by_user = await a.get_acl_entries_by_principal_user(user["id"])
+        assert len(by_user) == 1
+        by_group = await a.get_acl_entries_by_principal_group(group["id"])
+        assert len(by_group) == 1
+
+    async def test_tree_summary(self, app_state_with_schema, user):
+        a = app_state_with_schema.model.acl
+        await a.add_acl_entry(
+            "/tree/one",
+            0,
+            model.ACTION_ALLOW,
+            "view",
+            model.PRINCIPAL_SYSTEM,
+            system_principal=model.SYSTEM_EVERYONE,
+        )
+        tree = await a.get_acl_tree_summary()
+        resources = {row["resource"] for row in tree}
+        assert "/tree/one" in resources
+
+    async def test_add_rejects_agent_principal(self, app_state_with_schema):
+        from klangk_backend.model import AgentPrincipalError
+
+        a = app_state_with_schema.model.acl
+        with pytest.raises(AgentPrincipalError):
+            await a.add_acl_entry(
+                "/agent-guard",
+                0,
+                model.ACTION_ALLOW,
+                "view",
+                model.PRINCIPAL_USER,
+                user_id=model.AGENT_USER_ID,
+            )
+
+    async def test_replace_rejects_agent_principal(
+        self, app_state_with_schema
+    ):
+        from klangk_backend.model import AgentPrincipalError
+
+        a = app_state_with_schema.model.acl
+        with pytest.raises(AgentPrincipalError):
+            await a.replace_acl_entries(
+                "/agent-guard",
+                [
+                    {
+                        "position": 0,
+                        "action": model.ACTION_ALLOW,
+                        "principal_type": model.PRINCIPAL_USER,
+                        "user_id": model.AGENT_USER_ID,
+                        "group_id": None,
+                        "system_principal": None,
+                        "permission": "view",
+                    }
+                ],
+            )


### PR DESCRIPTION
## Summary

Fixes #1574 (split 3/7 of #1563).

Converts the ACL **model layer** (`model/acl.py` — data access for `acl_entries`) to `ACLModel(app_state)`, reached via `app_state.model.acl`. This is purely the data-access layer; the separate `klangk_backend/acl.py` FastAPI permission dependency is its own follow-up (it still reaches `model.get_acl_entries_map` through the backstop).

## Changes

- **`model/acl.py` → `ACLModel(app_state)`**: the 9 DB-bound functions (`add_acl_entry`, `get_acl_entries`, `get_acl_entries_map`, `get_acl_entries_resolved`, `replace_acl_entries`, `delete_acl_entries_for_resource`, `get_acl_entries_by_principal_user`, `get_acl_entries_by_principal_group`, `get_acl_tree_summary`) become methods reading `self.app_state.db`.
- **Constants + `row_to_acl_entry` stay module-level** — `ACTION_ALLOW`/`ACTION_DENY`, `PRINCIPAL_SYSTEM`/`PRINCIPAL_USER`/`PRINCIPAL_GROUP`, `SYSTEM_EVERYONE`/`SYSTEM_AUTHENTICATED`, and the pure `row_to_acl_entry` helper. `chat.py` / `workspaces.py` / `schema.py` import them unchanged.
- **`Model.__init__`** wires `self.acl = ACLModel(app_state)`; `model/__init__.py` re-exports `ACLModel`.
- **Call sites converted** (~28): `api/admin.py` (8), `api/workspaces.py` (13), and `main.py`'s `seed_default_acls` (7) now call `app_state.model.acl.*`. The 8 route handlers that lacked an `app_state` dependency now take `app_state=Depends(get_app_state_dep)`.
- **Backstop retained**: the module-level free functions stay (kept until #1578 dissolves the ContextVar), since `klangk_backend/acl.py` still reaches `model.get_acl_entries_map` through them. Matches the `ports`/`tokens`/`users` pattern.

## Test changes

- `test_model_app_state.py::TestACLModel` — covers all 9 class methods + both agent-principal guards.
- `test_model.py::TestAclBackstopBranches` — covers the orphaned backstop free functions (the ones that lost their app-code callers).
- `test_main.py` `_lifecycle` and `test_mode_switching.py` `_lifecycle` helpers now wire `db` + `model` via `wire_db_and_model`, so `seed_default_acls` (which now reaches `app_state.model.acl`) resolves.

## Verification

- New tests pass (176 in `test_model*`).
- Full backend suite: **2434 passed, 100% coverage** (`-n auto`).
- CLI suite: 486 passed, 100% coverage.
- `model/acl.py` at 100%.

## Changelog

Added a `### Changed` entry under `## [Unreleased]` (per the issue).

## Checklist

- [x] `model/acl.py` is `ACLModel(app_state)`; constants + `row_to_acl_entry` stay module-level
- [x] All ACL model call sites use `app_state.model.acl.<method>`
- [x] `chat.py` / `workspaces.py` / `schema.py` still import the ACL constants unchanged
- [x] Backend (`-n auto`) and CLI suites green at 100% coverage
- [x] Changelog entry under `## [Unreleased]` → `### Changed`
