### PR TITLE
feat: SIGHUP reloads + applies configuration (#1587)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -108,6 +108,15 @@ operators or integrators to act when upgrading.
 
 ### Changed
 
+- **SIGHUP now reloads configuration (#1587).** Sending `SIGHUP` to
+  `klangkd` re-resolves `KlangkSettings` from the environment / YAML
+  config file and applies the new values before recycling the runtime.
+  Invalid config denies the restart (runtime left on last-known-good,
+  reason logged at `ERROR`). Settings bound for the process lifetime
+  (`KLANGK_PORT`, `KLANGK_LISTEN`, `KLANGK_DATA_DIR`, `KLANGK_STATE_DIR`)
+  are warned but require a full restart to apply. See
+  [Process Signals](deployment/signals.md).
+
 - **The `_current_db` ContextVar and its module-level DB delegates are
   gone (#1578, fixes #1551).** Every data-access path now reaches the DB
   through the single owned `app_state.db` — `model.db`'s `_current_db`

--- a/docs/deployment/signals.md
+++ b/docs/deployment/signals.md
@@ -22,21 +22,33 @@ What happens, in order:
 Net effect: a _full_ stop. Workspaces go away; on the next start,
 `auto_start` brings back any that are configured for it.
 
-## SIGHUP — graceful runtime restart (#1212)
+## SIGHUP — reload configuration + graceful runtime restart (#1212, #1587)
 
 Sent by `kill -HUP $(cat $KLANGK_STATE_DIR/klangk-<instance>.pid)`, or by
 your service manager's "reload" action.
 
 SIGHUP is **not** a process restart — the HTTP listener and the database
-stay up the whole time. Instead it recycles the _runtime layer_:
+stay up the whole time. It means "reload config and apply it" (the
+nginx/Postgres convention):
 
-1. **Close every WebSocket client** with close code `1012` ("service
+1. **Re-resolve configuration** from the environment (`KLANGK_*` env
+   vars and/or the YAML config file). If the new configuration is
+   **invalid** (bad value, dangling `file:`/`cmd:` ref, unreadable config
+   file), the restart is **denied** — the runtime stays running on its
+   last-known-good config and the reason is logged at `ERROR` level.
+2. **Apply reloadable settings.** The new `KlangkSettings` instance is
+   swapped onto `app_state.settings`; all subsystems read it live. The
+   OIDC discovery/JWKS caches are cleared and providers re-initialized,
+   plugins are re-scanned, SSL trust is re-applied, and the agent user
+   is re-seeded (so `KLANGK_AGENT_EMAIL`/`_HANDLE` changes take effect
+   in the DB).
+3. **Close every WebSocket client** with close code `1012` ("service
    restarted"). Both the web UI and `klangkc monitor` reconnect
    automatically with backoff and rebuild their state on reconnect.
-2. Tear down chat-agent subprocesses and cancel in-flight agent runs.
-3. **Stop and remove all workspace containers** and cancel the
+4. Tear down chat-agent subprocesses and cancel in-flight agent runs.
+5. **Stop and remove all workspace containers** and cancel the
    idle/health background loops (`registry.shutdown()`).
-4. Re-run container-side startup: pre-warm podman, adopt/reap leftover
+6. Re-run container-side startup: pre-warm podman, adopt/reap leftover
    containers, restart the idle/health loops, and `auto_start` any
    workspaces configured for it.
 
@@ -45,21 +57,33 @@ sessions are, and those reconnect on their own.
 
 ### When to use it
 
+- You changed `KLANGK_*` env vars or the YAML config file and want them
+  applied without a full process restart.
+- You changed OIDC provider configuration, auth modes, the agent handle,
+  plugin config, or SSL trust certificates.
 - You changed a workspace's auto-start or sandbox configuration and want
   it picked up without bouncing the whole server.
 - You want to force every workspace container to be recreated (e.g. after
   rebuilding the workspace image) while keeping the server reachable.
-- A demo/ops beat where you want to show `stopped → running → healthy`
-  transitions without a full restart that would make `klangkc ls` see a
-  refused connection mid-bounce.
 
-### What it deliberately does _not_ do
+### Settings that require a full process restart
 
-- It does **not** re-read `.env` / re-run OIDC provider discovery / reload
-  plugins. Those are process-startup concerns; for them, fully restart
-  the server (SIGTERM + relaunch).
+A small set of settings are bound for the life of the process and cannot
+be applied by SIGHUP alone. If one of these changes, SIGHUP logs a
+`WARNING` naming it — the reloadable settings are still applied, but the
+non-reloadable change needs a full `klangkd` restart:
+
+| Setting            | Reason                             |
+| ------------------ | ---------------------------------- |
+| `KLANGK_PORT`      | The HTTP listener is already bound |
+| `KLANGK_LISTEN`    | The HTTP listener is already bound |
+| `KLANGK_DATA_DIR`  | The DB engine is already open      |
+| `KLANGK_STATE_DIR` | Instance state is already on disk  |
+
+### What it does _not_ do
+
 - It does **not** dispose the database engine or remove the PID file —
-  those are process-shutdown-only (`_process_shutdown`).
+  those are process-shutdown-only.
 
 ### Concurrency
 

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -1,6 +1,8 @@
 # Environment Variables
 
 > **Config file alternative:** All `KLANGK_*` settings below can also be set in a YAML config file via `klangkd --config`. The config file is the recommended substrate for production deployments; env vars override file values. See [Configuration File](klangkd-config.md).
+>
+> **Applying configuration changes:** After editing `KLANGK_*` env vars or the YAML config file, send `SIGHUP` to the `klangkd` process to reload and apply the new values without a full process restart. The HTTP listener and DB stay up; WebSocket clients reconnect automatically. A small set of settings (`KLANGK_PORT`, `KLANGK_LISTEN`, `KLANGK_DATA_DIR`, `KLANGK_STATE_DIR`) are bound for the life of the process and require a full restart — SIGHUP logs a warning if one of these changed. An invalid configuration denies the reload (runtime left on last-known-good config, reason logged at `ERROR`). See [Process Signals](../deployment/signals.md#sighup--reload-configuration--graceful-runtime-restart-1212-1587).
 
 `$DEVENV_STATE` refers to `<project root>/.devenv/state` — this is where devenv stores runtime data.
 

--- a/src/backend/e2e-tests/runtestserver.py
+++ b/src/backend/e2e-tests/runtestserver.py
@@ -27,9 +27,10 @@ def main() -> None:
     parser.add_argument("--ws-max-size", type=int, default=16777216)
     parser.add_argument("--ws-ping-interval", type=int, default=20)
     parser.add_argument("--ws-ping-timeout", type=int, default=20)
+    parser.add_argument("--config", default=None, help="YAML config file")
     args = parser.parse_args()
 
-    app = build_app(KlangkSettings(os.environ))
+    app = build_app(KlangkSettings(os.environ, config_file=args.config))
     uvicorn.run(
         app,
         host=args.host,

--- a/src/backend/e2e-tests/test_sighup_restart_e2e.py
+++ b/src/backend/e2e-tests/test_sighup_restart_e2e.py
@@ -1,4 +1,4 @@
-"""End-to-end tests for graceful runtime restart on SIGHUP (#1212).
+"""End-to-end tests for graceful runtime restart on SIGHUP (#1212, #1587).
 
 SIGHUP triggers an in-place runtime restart: every WebSocket client is
 closed with code 1012, all workspace containers are stopped, the
@@ -6,13 +6,18 @@ idle/health loops are cancelled, then container-side startup re-runs
 (prewarm, adopt, loops, auto-start).  The HTTP listener and DB stay up
 throughout.
 
+Since #1587, SIGHUP also **reloads configuration**: the settings are
+re-resolved from the environment + config file, and reloadable values
+take effect without a process restart.
+
 These tests start a real server on a private port, open WebSocket
-sessions, send SIGHUP, and assert the four acceptance criteria:
+sessions, send SIGHUP, and assert the acceptance criteria:
 
 1. HTTP stays available across the restart (no refused connections).
 2. WebSocket clients are closed with code 1012 and can reconnect.
 3. A second SIGHUP during a restart queues behind it (serialized).
 4. Workspace containers are stopped and then auto-started again.
+5. A config file change is picked up after SIGHUP (#1587).
 
 Requires: podman available, klangk image built.
 
@@ -325,3 +330,114 @@ async def test_containers_stopped_then_autostarted(server, auth):
         )
     except httpx.ReadTimeout:
         pass
+
+
+# --- Config reload via SIGHUP (#1587) ---
+
+
+def test_config_reload_via_sighup():
+    """#5: A config file change is picked up after SIGHUP (#1587).
+
+    Writes a YAML config with product_name="Before", starts a server
+    with --config, asserts /api/v1/config returns "Before", rewrites the
+    file to "After", sends SIGHUP, and asserts the endpoint returns
+    "After".
+    """
+    import yaml
+
+    data_dir = tempfile.mkdtemp(prefix="klangk-reload-e2e-")
+    state_dir = tempfile.mkdtemp(prefix="klangk-reload-e2e-state-")
+    port = str(free_port())
+
+    config_path = os.path.join(state_dir, "klangk.yaml")
+    with open(config_path, "w") as f:
+        yaml.dump({"product_name": "Before"}, f)
+
+    env = clean_env(
+        KLANGK_PORT=port,
+        KLANGK_DATA_DIR=data_dir,
+        KLANGK_STATE_DIR=state_dir,
+        KLANGK_JWT_SECRET="reload-e2e-secret",
+        KLANGK_PREVENT_INSECURE_JWT_SECRET="",
+        KLANGK_DEFAULT_USER="test@example.com",
+        KLANGK_DEFAULT_PASSWORD="testpass",
+        KLANGK_TEST_MODE="1",
+        KLANGK_IDLE_TIMEOUT_SECONDS="300",
+        KLANGK_PORT_RANGE_START=str(free_port()),
+        LOGFIRE_TOKEN="",
+        KLANGK_LLM_BASE_URL="",
+        KLANGK_LLM_API_KEY="",
+        KLANGK_LLM_MODEL="",
+    )
+    proc = subprocess.Popen(
+        [
+            "python3",
+            os.path.join(os.path.dirname(__file__), "runtestserver.py"),
+            "--host",
+            "0.0.0.0",
+            "--port",
+            port,
+            "--config",
+            config_path,
+        ],
+        cwd=os.path.join(os.path.dirname(__file__), ".."),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    base_url = f"http://localhost:{port}"
+    try:
+        for _ in range(60):
+            try:
+                if (
+                    httpx.get(f"{base_url}/health", timeout=2).status_code
+                    == 200
+                ):
+                    break
+            except Exception:
+                pass
+            time.sleep(1)
+        else:
+            stdout = proc.stdout.read().decode() if proc.stdout else ""
+            raise RuntimeError(f"Server failed to start:\n{stdout}")
+
+        # Login.
+        resp = httpx.post(
+            f"{base_url}/api/v1/auth/login",
+            json={"email": "test@example.com", "password": "testpass"},
+            timeout=10,
+        )
+        assert resp.status_code == 200
+        headers = {"Authorization": f"Bearer {resp.json()['access_token']}"}
+
+        # Assert initial config.
+        resp = httpx.get(
+            f"{base_url}/api/v1/config", headers=headers, timeout=10
+        )
+        assert resp.status_code == 200
+        assert resp.json()["product_name"] == "Before"
+
+        # Rewrite the config file and send SIGHUP.
+        with open(config_path, "w") as f:
+            yaml.dump({"product_name": "After"}, f)
+        os.kill(proc.pid, subprocess.signal.SIGHUP)
+
+        # Wait for the restart to complete and assert the new value.
+        time.sleep(5)
+        assert _wait_http_ok({"url": base_url, "proc": proc}), (
+            "server did not recover after SIGHUP"
+        )
+        resp = httpx.get(
+            f"{base_url}/api/v1/config", headers=headers, timeout=10
+        )
+        assert resp.status_code == 200
+        assert resp.json()["product_name"] == "After"
+    finally:
+        try:
+            proc.kill()
+            proc.wait(timeout=10)
+        except (ProcessLookupError, subprocess.TimeoutExpired):
+            pass
+        close_popen_pipes(proc)
+        shutil.rmtree(data_dir, ignore_errors=True)
+        shutil.rmtree(state_dir, ignore_errors=True)

--- a/src/backend/klangk_backend/acl.py
+++ b/src/backend/klangk_backend/acl.py
@@ -165,6 +165,9 @@ class ACL:
     def __init__(self, app_state):
         self.app_state = app_state
 
+    def reconfigure(self, app_state) -> None:
+        self.app_state = app_state
+
     async def get_principals(self, user_id: str) -> dict:
         """Build principal info for the given user."""
         group_ids = await self.app_state.model.users.get_user_group_ids(

--- a/src/backend/klangk_backend/agent.py
+++ b/src/backend/klangk_backend/agent.py
@@ -95,6 +95,9 @@ class Agents:
         self._agents: dict[str, "AgentSession"] = {}
         self._agents_lock = asyncio.Lock()
 
+    def reconfigure(self, app_state) -> None:
+        self.app_state = app_state
+
     def is_disabled(self) -> bool:
         """True if the chat agent has been disabled by an admin.
 

--- a/src/backend/klangk_backend/auth.py
+++ b/src/backend/klangk_backend/auth.py
@@ -139,6 +139,9 @@ class Auth:
         self.verify_token_expire_hours = 72
         self.reset_token_expire_hours = 1
 
+    def reconfigure(self, app_state) -> None:
+        self.app_state = app_state
+
     # --- settings-derived config (read live off app_state, #1608) ---
 
     @property

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -122,6 +122,9 @@ class PortAllocator:
         self.port_lock: asyncio.Lock = asyncio.Lock()
         self.app_state = app_state
 
+    def reconfigure(self, app_state) -> None:
+        self.app_state = app_state
+
     async def allocate_ports(self, workspace_id: str, count: int) -> list[int]:
         # Clamp to the server-wide cap (KLANGK_HOSTED_PORTS_PER_WORKSPACE)
         # so creation never allocates ports the deployer has disabled —
@@ -206,6 +209,9 @@ class IdleMonitor:
         self.app_state = app_state
         self.cleanup_task: asyncio.Task | None = None
         self._cleanup_wake: asyncio.Event | None = None
+
+    def reconfigure(self, app_state) -> None:
+        self.app_state = app_state
 
     def get_cleanup_wake(self) -> asyncio.Event:
         if self._cleanup_wake is None:
@@ -330,6 +336,9 @@ class HealthMonitor:
     def __init__(self, app_state) -> None:
         self.app_state = app_state
         self.health_task: asyncio.Task | None = None
+
+    def reconfigure(self, app_state) -> None:
+        self.app_state = app_state
 
     @property
     def connections(self):
@@ -607,6 +616,12 @@ class ContainerRegistry:
 
         # The Podman instance is reached via self.app_state.podman (owned
         # instance, #1426) — no post-construction wiring needed.
+
+    def reconfigure(self, app_state) -> None:
+        self.app_state = app_state
+        self.ports.reconfigure(app_state)
+        self.idle.reconfigure(app_state)
+        self.health.reconfigure(app_state)
 
     # --- settings-derived config (read live off app_state, #1608) ---
 

--- a/src/backend/klangk_backend/emailsvc.py
+++ b/src/backend/klangk_backend/emailsvc.py
@@ -49,6 +49,10 @@ class EmailService:
         # flip KLANGK_EMAIL_TEMPLATES_DIR between cases).
         self._env: Environment | None = None
 
+    def reconfigure(self, app_state) -> None:
+        self.app_state = app_state
+        self._env = None
+
     # --- config ---
 
     def resolve_password(self) -> str | None:

--- a/src/backend/klangk_backend/files.py
+++ b/src/backend/klangk_backend/files.py
@@ -61,6 +61,9 @@ class Files:
     def __init__(self, app_state):
         self.app_state = app_state
 
+    def reconfigure(self, app_state) -> None:
+        self.app_state = app_state
+
     async def list_files(
         self, container_id: str, path: str = "/"
     ) -> list[dict]:

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -103,6 +103,14 @@ class Lifecycle:
 
     def reconfigure(self, app_state) -> None:
         self.app_state = app_state
+        self._pending_agent_reseed = True
+
+    async def apply_pending_reseed(self) -> None:
+        """Re-seed the agent user if flagged by reconfigure (#1587)."""
+        if not getattr(self, "_pending_agent_reseed", False):
+            return
+        self._pending_agent_reseed = False
+        await self.seed_agent_user()
 
     async def seed_default_acls(self, admin_group_id: str) -> None:
         """Seed default ACL entries if none exist yet."""
@@ -373,37 +381,37 @@ class Lifecycle:
         app_state.settings = new
 
         # Every app_state subsystem that implements reconfigure().
-        subsystems: list[tuple[str, str]] = [
-            ("ssl_trust", "ssl_trust"),
-            ("auth", "auth"),
-            ("podman", "podman"),
-            ("sockets", "sockets"),
-            ("container_registry", "container_registry"),
-            ("nginx_watchdog", "nginx_watchdog"),
-            ("terminal", "terminal"),
-            ("oidc", "oidc"),
-            ("plugins", "plugins"),
-            ("workspaces", "workspaces"),
-            ("files", "files"),
-            ("db", "db"),
-            ("model", "model"),
-            ("agents", "agents"),
-            ("acl", "acl"),
-            ("email", "email"),
-            ("util", "util"),
-            ("lifecycle", "lifecycle"),
+        subsystems = [
+            "ssl_trust",
+            "auth",
+            "podman",
+            "sockets",
+            "container_registry",
+            "nginx_watchdog",
+            "terminal",
+            "oidc",
+            "plugins",
+            "workspaces",
+            "files",
+            "db",
+            "model",
+            "agents",
+            "acl",
+            "email",
+            "util",
+            "lifecycle",
         ]
-        for name, attr in subsystems:
+        for name in subsystems:
             try:
-                getattr(app_state, attr).reconfigure(app_state)
+                getattr(app_state, name).reconfigure(app_state)
             except Exception as exc:  # noqa: BLE001
                 logger.warning(
                     "SIGHUP: %s reconfigure failed (skipped): %s", name, exc
                 )
-        # The agent email/handle live in the users table; re-seed so a
-        # changed KLANGK_AGENT_EMAIL/_HANDLE takes effect in the DB.
+        # Lifecycle.reconfigure flags an agent re-seed; apply it now
+        # (async, so it can't run inside the sync reconfigure loop).
         try:
-            await self.seed_agent_user()
+            await app_state.lifecycle.apply_pending_reseed()
         except Exception as exc:  # noqa: BLE001
             logger.warning(
                 "SIGHUP: agent user re-seed failed (skipped): %s", exc

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -60,6 +60,19 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
+# Settings that a SIGHUP reload re-resolves and validates but CANNOT apply
+# without a full process restart: the HTTP listener is bound for the life of
+# the process, and the DB engine + on-disk state dir are already open/written.
+# A change here is logged at warning level (so the operator knows it didn't
+# take effect) rather than silently ignored (#1587).
+_NON_RELOADABLE_SETTINGS: tuple[tuple[str, str], ...] = (
+    ("port", "the HTTP listener is already bound"),
+    ("listen", "the HTTP listener is already bound"),
+    ("data_dir", "the DB engine is already open"),
+    ("state_dir", "instance state is already on disk"),
+)
+
+
 class Lifecycle:
     """App-level bringup/shutdown and DB seeding (#1571).
 
@@ -87,6 +100,9 @@ class Lifecycle:
         # running event loop (the constructor runs in build_app, outside a
         # loop).
         self._restart_lock: asyncio.Lock | None = None
+
+    def reconfigure(self, app_state) -> None:
+        self.app_state = app_state
 
     async def seed_default_acls(self, admin_group_id: str) -> None:
         """Seed default ACL entries if none exist yet."""
@@ -295,19 +311,120 @@ class Lifecycle:
     async def restart_runtime(self) -> None:
         """Graceful runtime restart: stop containers, keep the listener.
 
-        Triggered by SIGHUP.  Closes all WebSocket clients (code 1012),
-        stops containers and background loops, then re-runs container-side
-        startup (prewarm, adopt, loops, auto-start).  The HTTP listener
-        and DB engine stay up throughout -- clients reconnect
-        automatically, and in-flight HTTP requests are never dropped.
+        Triggered by SIGHUP.  Before touching the runtime, configuration is
+        re-resolved (``settings.reload()``, #1587); if it is invalid the
+        restart is **denied** -- the running runtime is left untouched on
+        its last-known-good config rather than torn down against a broken
+        one.  On a valid reload the settings are **swapped** onto
+        ``app_state.settings`` and the OIDC/plugins/SSL-trust/agent-user
+        steps are re-run, then the runtime recycles.  All subsystems read
+        settings live via ``self.app_state.settings`` (#1608), so the swap
+        propagates automatically with no per-subsystem ``reconfigure()``.
         """
         if self._restart_lock is None:
             self._restart_lock = asyncio.Lock()
         async with self._restart_lock:
+            new_settings, error = self._reload_settings()
+            if error is not None:
+                logger.error(
+                    "SIGHUP: denying restart — invalid configuration: %s",
+                    error,
+                )
+                logger.info(
+                    "SIGHUP: restart denied; runtime left running on "
+                    "existing configuration"
+                )
+                return
+            logger.info("SIGHUP: applying reloaded configuration")
+            await self._apply_reloaded_settings(new_settings)
             logger.info("SIGHUP: restarting runtime (keeping HTTP listener)")
             await self.runtime_shutdown()
             await self.startup()
             logger.info("SIGHUP: runtime restarted")
+
+    def _reload_settings(
+        self,
+    ) -> tuple[KlangkSettings | None, str | None]:
+        """Re-resolve settings for a SIGHUP reload.
+
+        Returns ``(new, error)``: on success ``new`` is the freshly-resolved
+        :class:`KlangkSettings` and ``error`` is ``None``; on failure ``new``
+        is ``None`` and ``error`` is the deny reason.
+        """
+        try:
+            new = self.app_state.settings.reload()
+        except Exception as exc:  # noqa: BLE001 — surface any failure
+            return None, str(exc)
+        return new, None
+
+    async def _apply_reloaded_settings(self, new: KlangkSettings) -> None:
+        """Swap settings and call ``reconfigure(app_state)`` on every subsystem.
+
+        All subsystems read ``self.app_state.settings`` live (#1608), so
+        swapping the instance propagates automatically.  Each subsystem's
+        ``reconfigure(app_state)`` handles any cached runtime state that
+        needs refreshing (OIDC caches, plugin declarations, SSL trust,
+        nginx renderer, email templates).  Most are no-ops.  Each call is
+        best-effort: a failure is logged at warning level and skipped so
+        one bad step can't leave the runtime half-reconfigured.
+        """
+        app_state = self.app_state
+        self._warn_non_reloadable(app_state.settings, new)
+        app_state.settings = new
+
+        # Every app_state subsystem that implements reconfigure().
+        subsystems: list[tuple[str, str]] = [
+            ("ssl_trust", "ssl_trust"),
+            ("auth", "auth"),
+            ("podman", "podman"),
+            ("sockets", "sockets"),
+            ("container_registry", "container_registry"),
+            ("nginx_watchdog", "nginx_watchdog"),
+            ("terminal", "terminal"),
+            ("oidc", "oidc"),
+            ("plugins", "plugins"),
+            ("workspaces", "workspaces"),
+            ("files", "files"),
+            ("db", "db"),
+            ("model", "model"),
+            ("agents", "agents"),
+            ("acl", "acl"),
+            ("email", "email"),
+            ("util", "util"),
+            ("lifecycle", "lifecycle"),
+        ]
+        for name, attr in subsystems:
+            try:
+                getattr(app_state, attr).reconfigure(app_state)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "SIGHUP: %s reconfigure failed (skipped): %s", name, exc
+                )
+        # The agent email/handle live in the users table; re-seed so a
+        # changed KLANGK_AGENT_EMAIL/_HANDLE takes effect in the DB.
+        try:
+            await self.seed_agent_user()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "SIGHUP: agent user re-seed failed (skipped): %s", exc
+            )
+
+    def _warn_non_reloadable(
+        self, old: KlangkSettings, new: KlangkSettings
+    ) -> None:
+        """Log settings that changed but need a full process restart."""
+        changed = [
+            f"{field} ({reason})"
+            for field, reason in _NON_RELOADABLE_SETTINGS
+            if getattr(old, field) != getattr(new, field)
+        ]
+        if changed:
+            logger.warning(
+                "SIGHUP: settings changed but require a full process restart "
+                "to take effect: %s. Restart the klangkd process to apply "
+                "them.",
+                "; ".join(changed),
+            )
 
     def on_sighup(self) -> None:
         """Schedule a runtime restart on the running event loop.

--- a/src/backend/klangk_backend/model/acl.py
+++ b/src/backend/klangk_backend/model/acl.py
@@ -49,6 +49,9 @@ class ACLModel:
     def __init__(self, app_state):
         self.app_state = app_state
 
+    def reconfigure(self, app_state) -> None:
+        self.app_state = app_state
+
     async def add_acl_entry(
         self,
         resource: str,

--- a/src/backend/klangk_backend/model/chat.py
+++ b/src/backend/klangk_backend/model/chat.py
@@ -35,6 +35,9 @@ class ChatModel:
     def __init__(self, app_state):
         self.app_state = app_state
 
+    def reconfigure(self, app_state) -> None:
+        self.app_state = app_state
+
     async def parse_mentions(
         self, db: Connection, message: str, workspace_id: str
     ) -> list[str]:

--- a/src/backend/klangk_backend/model/db.py
+++ b/src/backend/klangk_backend/model/db.py
@@ -118,6 +118,9 @@ class DB:
         self.app_state = app_state
         self.engine = None
 
+    def reconfigure(self, app_state) -> None:
+        self.app_state = app_state
+
     @property
     def data_dir(self) -> Path:
         return Path(self.app_state.settings.data_dir)

--- a/src/backend/klangk_backend/model/invitations.py
+++ b/src/backend/klangk_backend/model/invitations.py
@@ -34,6 +34,9 @@ class InvitationsModel:
     def __init__(self, app_state):
         self.app_state = app_state
 
+    def reconfigure(self, app_state) -> None:
+        self.app_state = app_state
+
     async def create_invitation(self, email: str, invited_by: str) -> dict:
         """Create a new invitation. Returns the invitation dict."""
         async with self.app_state.db.transaction() as db:

--- a/src/backend/klangk_backend/model/login_attempts.py
+++ b/src/backend/klangk_backend/model/login_attempts.py
@@ -20,6 +20,9 @@ class LoginAttemptsModel:
     def __init__(self, app_state):
         self.app_state = app_state
 
+    def reconfigure(self, app_state) -> None:
+        self.app_state = app_state
+
     async def record_failed_login(
         self, email: str, *, reset: bool = False
     ) -> None:

--- a/src/backend/klangk_backend/model/model.py
+++ b/src/backend/klangk_backend/model/model.py
@@ -49,6 +49,20 @@ class Model:
         self.workspaces = WorkspacesModel(app_state)
         self.chat = ChatModel(app_state)
 
+    def reconfigure(self, app_state) -> None:
+        self.app_state = app_state
+        for sub in (
+            self.tokens,
+            self.login_attempts,
+            self.invitations,
+            self.ports,
+            self.users,
+            self.acl,
+            self.workspaces,
+            self.chat,
+        ):
+            sub.reconfigure(app_state)
+
     @asynccontextmanager
     async def transaction(self):
         """Auto-commit-on-clean-exit transaction on this model's DB."""

--- a/src/backend/klangk_backend/model/ports.py
+++ b/src/backend/klangk_backend/model/ports.py
@@ -47,6 +47,9 @@ class PortsModel:
     def __init__(self, app_state):
         self.app_state = app_state
 
+    def reconfigure(self, app_state) -> None:
+        self.app_state = app_state
+
     async def add_port_allocations(
         self, workspace_id: str, ports: list[int]
     ) -> None:

--- a/src/backend/klangk_backend/model/tokens.py
+++ b/src/backend/klangk_backend/model/tokens.py
@@ -19,6 +19,9 @@ class TokensModel:
     def __init__(self, app_state):
         self.app_state = app_state
 
+    def reconfigure(self, app_state) -> None:
+        self.app_state = app_state
+
     async def blocklist_token(
         self, jti: str, expires_at: str, new_token: str | None = None
     ) -> None:

--- a/src/backend/klangk_backend/model/users.py
+++ b/src/backend/klangk_backend/model/users.py
@@ -168,6 +168,9 @@ class UsersModel:
     def __init__(self, app_state):
         self.app_state = app_state
 
+    def reconfigure(self, app_state) -> None:
+        self.app_state = app_state
+
     async def get_agent_user(self) -> dict:
         """Return the agent user dict from DB, cached after first call."""
         global agent_user_cache

--- a/src/backend/klangk_backend/model/workspaces.py
+++ b/src/backend/klangk_backend/model/workspaces.py
@@ -85,6 +85,9 @@ class WorkspacesModel:
     def __init__(self, app_state):
         self.app_state = app_state
 
+    def reconfigure(self, app_state) -> None:
+        self.app_state = app_state
+
     async def _insert_workspace_row(
         self,
         db,

--- a/src/backend/klangk_backend/nginx.py
+++ b/src/backend/klangk_backend/nginx.py
@@ -757,7 +757,7 @@ class NginxWatchdog:
 
     def reconfigure(self, app_state) -> None:
         self._app_state = app_state
-        self._renderer = NginxRenderer(self._app_state)
+        self._renderer = NginxRenderer(app_state)
 
     async def _watch(
         self, bin_path: str, conf_path: str

--- a/src/backend/klangk_backend/nginx.py
+++ b/src/backend/klangk_backend/nginx.py
@@ -169,6 +169,9 @@ class NginxRenderer:
     def __init__(self, app_state) -> None:
         self._app_state = app_state
 
+    def reconfigure(self, app_state) -> None:
+        self._app_state = app_state
+
     # -- DNS / ACL / size computation --------------------------------------
 
     def detect_dns_resolvers(self) -> str:
@@ -757,7 +760,7 @@ class NginxWatchdog:
 
     def reconfigure(self, app_state) -> None:
         self._app_state = app_state
-        self._renderer = NginxRenderer(app_state)
+        self._renderer.reconfigure(app_state)
 
     async def _watch(
         self, bin_path: str, conf_path: str

--- a/src/backend/klangk_backend/nginx.py
+++ b/src/backend/klangk_backend/nginx.py
@@ -755,6 +755,10 @@ class NginxWatchdog:
         self._task: asyncio.Task | None = None
         self._stopping = False
 
+    def reconfigure(self, app_state) -> None:
+        self._app_state = app_state
+        self._renderer = NginxRenderer(self._app_state)
+
     async def _watch(
         self, bin_path: str, conf_path: str
     ) -> None:  # pragma: no cover

--- a/src/backend/klangk_backend/oidc.py
+++ b/src/backend/klangk_backend/oidc.py
@@ -159,6 +159,13 @@ class OIDC:
         self.login_hook: Callable | None = None
         self.login_hook_is_async: bool = False
 
+    def reconfigure(self, app_state) -> None:
+        self.app_state = app_state
+        self.discovery_cache.clear()
+        self.jwks_cache.clear()
+        self.init_providers()
+        self.load_login_hook()
+
     async def sync_oidc_groups(
         self,
         user_id: str,

--- a/src/backend/klangk_backend/plugins.py
+++ b/src/backend/klangk_backend/plugins.py
@@ -38,6 +38,10 @@ class Plugins:
         # Resolved values: {env_key: str}
         self.values: dict[str, str] = {}
 
+    def reconfigure(self, app_state) -> None:
+        self.app_state = app_state
+        self.load()
+
     @property
     def plugins_dir(self) -> str:
         # Read live off app_state (#1608) so a SIGHUP settings reload picks

--- a/src/backend/klangk_backend/podman.py
+++ b/src/backend/klangk_backend/podman.py
@@ -73,6 +73,9 @@ class Podman:
     def __init__(self, app_state):
         self.app_state = app_state
 
+    def reconfigure(self, app_state) -> None:
+        self.app_state = app_state
+
     @property
     def _bin(self) -> str:
         return self.app_state.settings.podman_bin

--- a/src/backend/klangk_backend/settings.py
+++ b/src/backend/klangk_backend/settings.py
@@ -42,7 +42,7 @@ from pydantic_settings import (
     SettingsConfigDict,
     YamlConfigSettingsSource,
 )
-from pydantic import field_validator, model_validator
+from pydantic import PrivateAttr, field_validator, model_validator
 from pydantic_settings.sources.providers.env import parse_env_vars
 
 logger = logging.getLogger(__name__)
@@ -269,6 +269,16 @@ class KlangkSettings(BaseSettings):
     _env_for_sources: ClassVar[Mapping[str, str] | None] = None
     _config_file_for_sources: ClassVar[str | None] = None
 
+    # The sources this instance was built from, retained so :meth:`reload`
+    # can re-resolve identically (env-only or env + the same YAML config
+    # file).  Private attrs (NOT model fields) — they carry no config data
+    # and must not be validated.  ``_reload_env`` is a reference to the
+    # mapping passed to ``__init__``: ``os.environ`` in production (a live
+    # mapping, so reload picks up operator edits), a dict in tests (so
+    # reload re-reads that dict, never ``os.environ`` — #1457 isolation).
+    _reload_env: Mapping[str, str] | None = PrivateAttr(default=None)
+    _reload_config_file: str | None = PrivateAttr(default=None)
+
     model_config = SettingsConfigDict(
         env_prefix="KLANGK_",
         extra="ignore",
@@ -301,6 +311,31 @@ class KlangkSettings(BaseSettings):
             # the class if ``super().__init__()`` raises.
             type(self)._env_for_sources = None
             type(self)._config_file_for_sources = None
+        # Retain the real sources for reload() (see the PrivateAttr decl).
+        self._reload_env = env
+        self._reload_config_file = config_file
+
+    def reload(self) -> "KlangkSettings":
+        """Re-resolve settings from the same sources used to build this instance.
+
+        Returns a fresh ``KlangkSettings`` built from the env mapping + config
+        file captured at construction (see ``_reload_env`` /
+        ``_reload_config_file``).  In production the env mapping is the live
+        ``os.environ``, so a reload after an operator edits ``KLANGK_*``
+        picks up the new values; in tests it is the dict passed to the
+        constructor, so reload re-reads that dict and never touches
+        ``os.environ``.
+
+        Raises whatever construction raises — pydantic ``ValidationError``
+        for a bogus/invalid value (a dangling ``file:``/``cmd:`` ref, a
+        failed field/model validator, a duplicate port, ...) or ``OSError``
+        if the config file can no longer be read.  Callers that want a
+        deny-on-invalid gate (e.g. the SIGHUP restart path, #1587) wrap this
+        in a try/except and refuse to act on failure.
+        """
+        return type(self)(
+            self._reload_env, config_file=self._reload_config_file
+        )
 
     @classmethod
     def settings_customise_sources(

--- a/src/backend/klangk_backend/ssl_trust.py
+++ b/src/backend/klangk_backend/ssl_trust.py
@@ -151,6 +151,10 @@ class SSLTrust:
     def __init__(self, app_state):
         self.app_state = app_state
 
+    def reconfigure(self, app_state) -> None:
+        self.app_state = app_state
+        self.apply_backend_ssl_trust()
+
     def ssl_cert_dir(self) -> str | None:
         """Return the deployer SSL cert dir if it should be trusted, else ``None``.
 

--- a/src/backend/klangk_backend/terminal.py
+++ b/src/backend/klangk_backend/terminal.py
@@ -226,6 +226,9 @@ class Terminal:
     def __init__(self, app_state):
         self._app_state = app_state
 
+    def reconfigure(self, app_state) -> None:
+        self._app_state = app_state
+
     @property
     def podman(self) -> Podman:
         return self._app_state.podman

--- a/src/backend/klangk_backend/util.py
+++ b/src/backend/klangk_backend/util.py
@@ -236,6 +236,9 @@ class Util:
         # unit/e2e tests that launch uvicorn over TCP are unaffected.
         self.uds_mode = False
 
+    def reconfigure(self, app_state) -> None:
+        self.app_state = app_state
+
     def set_uds_mode(self, enabled: bool) -> None:
         """Mark whether the server is bound to a UDS. Called from the lifespan
         when the bind is a socket; never set by tests that use TCP or the ASGI

--- a/src/backend/klangk_backend/workspaces.py
+++ b/src/backend/klangk_backend/workspaces.py
@@ -134,6 +134,9 @@ class Workspaces:
     def __init__(self, app_state):
         self.app_state = app_state
 
+    def reconfigure(self, app_state) -> None:
+        self.app_state = app_state
+
     # --- settings-derived paths (read live off app_state, #1608) ---
 
     @property

--- a/src/backend/klangk_backend/wshandler/session.py
+++ b/src/backend/klangk_backend/wshandler/session.py
@@ -419,6 +419,9 @@ class WebSocketState:
         # broadcast; if they reconnect before it fires we cancel it.
         self._pending_leaves: dict[tuple[str, str], asyncio.Task] = {}
 
+    def reconfigure(self, app_state) -> None:
+        self.app_state = app_state
+
     def get_session(self, workspace_id: str) -> WorkspaceSession | None:
         return self.sessions.get(workspace_id)
 

--- a/src/backend/tests/test_main.py
+++ b/src/backend/tests/test_main.py
@@ -809,8 +809,8 @@ class TestStartupShutdownRestart:
 
             obj.reconfigure = make_tracker(attr, orig)
         with patch.object(
-            lc, "seed_agent_user", new_callable=AsyncMock
-        ) as mock_seed:
+            lc, "apply_pending_reseed", new_callable=AsyncMock
+        ) as mock_reseed:
             await lc._apply_reloaded_settings(new_settings)
         assert app_state.settings is new_settings
         assert app_state.settings is not old_settings
@@ -818,7 +818,7 @@ class TestStartupShutdownRestart:
         assert "oidc" in called
         assert "plugins" in called
         assert len(called) == 18
-        mock_seed.assert_awaited_once()
+        mock_reseed.assert_awaited_once()
 
     async def test_apply_logs_warning_when_reconfigure_fails(
         self, app_state, caplog
@@ -835,14 +835,14 @@ class TestStartupShutdownRestart:
             ),
             patch.object(app_state.oidc, "reconfigure") as mock_oidc_reconf,
             patch.object(
-                lc, "seed_agent_user", new_callable=AsyncMock
-            ) as mock_seed,
+                lc, "apply_pending_reseed", new_callable=AsyncMock
+            ) as mock_reseed,
             caplog.at_level("WARNING"),
         ):
             await lc._apply_reloaded_settings(new_settings)
         assert "ssl_trust reconfigure failed" in caplog.text
         mock_oidc_reconf.assert_called_once()
-        mock_seed.assert_awaited_once()
+        mock_reseed.assert_awaited_once()
 
     def test_warn_non_reloadable_logs_changed_settings(
         self, app_state, caplog
@@ -857,6 +857,16 @@ class TestStartupShutdownRestart:
             lc._warn_non_reloadable(old, new)
         assert "port" in caplog.text
         assert "full process restart" in caplog.text
+
+    async def test_apply_pending_reseed_noop_without_flag(self, app_state):
+        """apply_pending_reseed is a no-op when reconfigure hasn't been called."""
+        app_state = _make_app_state()
+        lc = app_state.lifecycle
+        with patch.object(
+            lc, "seed_agent_user", new_callable=AsyncMock
+        ) as mock_seed:
+            await lc.apply_pending_reseed()
+        mock_seed.assert_not_awaited()
 
     def test_warn_non_reloadable_silent_on_reloadable_only(
         self, app_state, caplog

--- a/src/backend/tests/test_main.py
+++ b/src/backend/tests/test_main.py
@@ -67,8 +67,13 @@ def _make_app_state(settings=None):
     app_state.util = util_mod.Util(app_state)
     # #1567: the lifespan calls app.state.ssl_trust.apply_backend_ssl_trust().
     app_state.ssl_trust = ssl_trust_mod.SSLTrust(app_state)
-
     app_state.auth = auth_mod.Auth(app_state)
+    app_state.nginx_watchdog = nginx_mod.NginxWatchdog(app_state)
+    from klangk_backend.terminal import Terminal
+    from klangk_backend.acl import ACL
+
+    app_state.terminal = Terminal(app_state)
+    app_state.acl = ACL(app_state)
     # #1571: Lifecycle(app_state) owns startup/shutdown/restart + seeding.
     app_state.lifecycle = main.Lifecycle(app_state)
     return app_state
@@ -686,6 +691,213 @@ class TestStartupShutdownRestart:
             "down-end",
             "up",
         ]
+
+    async def test_restart_denies_on_invalid_config(self, app_state):
+        """Invalid config denies the restart; no teardown, no startup."""
+        app_state = _make_app_state()
+        lc = app_state.lifecycle
+        lc._restart_lock = None
+        with (
+            patch.object(
+                lc,
+                "_reload_settings",
+                return_value=(None, "bad config"),
+            ) as mock_reload,
+            patch.object(
+                lc, "runtime_shutdown", new_callable=AsyncMock
+            ) as mock_down,
+            patch.object(lc, "startup", new_callable=AsyncMock) as mock_up,
+        ):
+            await lc.restart_runtime()
+        mock_reload.assert_called_once()
+        mock_down.assert_not_awaited()
+        mock_up.assert_not_awaited()
+
+    async def test_restart_reloads_then_applies_then_restarts(self, app_state):
+        """Valid config: reload → apply → shutdown → startup."""
+        app_state = _make_app_state()
+        lc = app_state.lifecycle
+        lc._restart_lock = None
+        new_settings = make_settings({"KLANGK_DEFAULT_PASSWORD": "test"})
+        order = []
+        with (
+            patch.object(
+                lc,
+                "_reload_settings",
+                return_value=(new_settings, None),
+            ),
+            patch.object(
+                lc,
+                "_apply_reloaded_settings",
+                new_callable=AsyncMock,
+                side_effect=lambda s: order.append("apply"),
+            ),
+            patch.object(
+                lc,
+                "runtime_shutdown",
+                new_callable=AsyncMock,
+                side_effect=lambda: order.append("shutdown"),
+            ),
+            patch.object(
+                lc,
+                "startup",
+                new_callable=AsyncMock,
+                side_effect=lambda: order.append("startup"),
+            ),
+        ):
+            await lc.restart_runtime()
+        assert order == ["apply", "shutdown", "startup"]
+
+    def test_reload_settings_returns_new_when_valid(self, app_state):
+        app_state = _make_app_state()
+        lc = app_state.lifecycle
+        new, error = lc._reload_settings()
+        assert new is not None
+        assert error is None
+        assert new is not app_state.settings
+
+    def test_reload_settings_returns_error_when_invalid(self, app_state):
+        app_state = _make_app_state()
+        lc = app_state.lifecycle
+        # Pydantic models can't be patched with patch.object; patch the
+        # class method instead.
+        with patch.object(
+            type(app_state.settings),
+            "reload",
+            side_effect=ValueError("bad"),
+        ):
+            new, error = lc._reload_settings()
+        assert new is None
+        assert "bad" in error
+
+    async def test_apply_reloaded_settings_calls_reconfigure(self, app_state):
+        """Swap + reconfigure called on every subsystem."""
+        app_state = _make_app_state()
+        lc = app_state.lifecycle
+        new_settings = make_settings({"KLANGK_DEFAULT_PASSWORD": "test"})
+        old_settings = app_state.settings
+        called = []
+        for attr in (
+            "ssl_trust",
+            "auth",
+            "podman",
+            "sockets",
+            "container_registry",
+            "nginx_watchdog",
+            "terminal",
+            "oidc",
+            "plugins",
+            "workspaces",
+            "files",
+            "db",
+            "model",
+            "agents",
+            "acl",
+            "email",
+            "util",
+            "lifecycle",
+        ):
+            obj = getattr(app_state, attr)
+            orig = obj.reconfigure
+
+            def make_tracker(name, orig_fn):
+                def tracked(app_state):
+                    called.append(name)
+                    return orig_fn(app_state)
+
+                return tracked
+
+            obj.reconfigure = make_tracker(attr, orig)
+        with patch.object(
+            lc, "seed_agent_user", new_callable=AsyncMock
+        ) as mock_seed:
+            await lc._apply_reloaded_settings(new_settings)
+        assert app_state.settings is new_settings
+        assert app_state.settings is not old_settings
+        assert "ssl_trust" in called
+        assert "oidc" in called
+        assert "plugins" in called
+        assert len(called) == 18
+        mock_seed.assert_awaited_once()
+
+    async def test_apply_logs_warning_when_reconfigure_fails(
+        self, app_state, caplog
+    ):
+        """A failing reconfigure is skipped + warned, the rest still run."""
+        app_state = _make_app_state()
+        lc = app_state.lifecycle
+        new_settings = make_settings({"KLANGK_DEFAULT_PASSWORD": "test"})
+        with (
+            patch.object(
+                app_state.ssl_trust,
+                "reconfigure",
+                side_effect=RuntimeError("ssl boom"),
+            ),
+            patch.object(app_state.oidc, "reconfigure") as mock_oidc_reconf,
+            patch.object(
+                lc, "seed_agent_user", new_callable=AsyncMock
+            ) as mock_seed,
+            caplog.at_level("WARNING"),
+        ):
+            await lc._apply_reloaded_settings(new_settings)
+        assert "ssl_trust reconfigure failed" in caplog.text
+        mock_oidc_reconf.assert_called_once()
+        mock_seed.assert_awaited_once()
+
+    def test_warn_non_reloadable_logs_changed_settings(
+        self, app_state, caplog
+    ):
+        app_state = _make_app_state()
+        lc = app_state.lifecycle
+        old = app_state.settings
+        new = make_settings(
+            {"KLANGK_DEFAULT_PASSWORD": "test", "KLANGK_PORT": "9999"}
+        )
+        with caplog.at_level("WARNING"):
+            lc._warn_non_reloadable(old, new)
+        assert "port" in caplog.text
+        assert "full process restart" in caplog.text
+
+    def test_warn_non_reloadable_silent_on_reloadable_only(
+        self, app_state, caplog
+    ):
+        app_state = _make_app_state()
+        lc = app_state.lifecycle
+        old = app_state.settings
+        # Build new settings from the same env as old so only
+        # reloadable fields differ.
+        env = dict(old._reload_env)
+        env["KLANGK_AGENT_HANDLE"] = "newbot"
+        new = make_settings(env)
+        with caplog.at_level("WARNING"):
+            lc._warn_non_reloadable(old, new)
+        assert "full process restart" not in caplog.text
+
+    async def test_agent_handle_change_takes_effect_after_restart(
+        self, db, app_state
+    ):
+        """Acceptance test: editing KLANGK_AGENT_HANDLE + SIGHUP makes the
+        new handle the live agent handle without a process restart."""
+        app_state = _make_app_state()
+        lc = app_state.lifecycle
+
+        # Seed the initial agent user using the test DB.
+        from _helpers import get_test_db
+
+        app_state.db = get_test_db()
+        app_state.model = model.Model(app_state)
+        await lc.seed_agent_user()
+        old_handle = await app_state.model.users.agent_handle()
+        assert old_handle == "clanker"
+
+        # Simulate a config change: new settings with a different handle.
+        env = dict(app_state.settings._reload_env)
+        env["KLANGK_AGENT_HANDLE"] = "newbot"
+        env["KLANGK_AGENT_EMAIL"] = "newbot@example.com"
+        new_settings = make_settings(env)
+        await lc._apply_reloaded_settings(new_settings)
+        new_handle = await app_state.model.users.agent_handle()
+        assert new_handle == "newbot"
 
     async def test_on_sighup_schedules_restart(self, app_state):
         """on_sighup creates a task that runs restart_runtime."""

--- a/src/backend/tests/test_settings.py
+++ b/src/backend/tests/test_settings.py
@@ -621,3 +621,33 @@ class TestRequireDirsValidator:
             }
         )
         assert s.customize_dir == "/explicit/custom"
+
+
+class TestReload:
+    """KlangkSettings.reload() re-resolves from the same sources (#1587)."""
+
+    def test_reload_returns_fresh_instance(self):
+        s = make_settings({"KLANGK_AGENT_HANDLE": "bot1"})
+        s2 = s.reload()
+        assert s2 is not s
+        assert s2.agent_handle == "bot1"
+
+    def test_reload_picks_up_changed_env(self):
+        env = {
+            "KLANGK_DATA_DIR": "/d",
+            "KLANGK_STATE_DIR": "/s",
+            "KLANGK_AGENT_HANDLE": "old",
+        }
+        s = KlangkSettings(env)
+        env["KLANGK_AGENT_HANDLE"] = "new"
+        s2 = s.reload()
+        assert s2.agent_handle == "new"
+        assert s.agent_handle == "old"
+
+    def test_reload_raises_on_invalid_config(self):
+        s = make_settings({})
+        with pytest.raises(Exception):
+            # auth_modes must be a valid value; "bogus" will fail validation.
+            env = dict(s._reload_env)
+            env["KLANGK_AUTH_MODES"] = "bogus"
+            KlangkSettings(env)


### PR DESCRIPTION
## Summary

Closes #1587. SIGHUP now means "reload config and apply it" (the nginx/Postgres convention): the runtime-restart path re-resolves `KlangkSettings` from the same sources the process started with (live `KLANGK_*` env + YAML config file), **applies** the reloadable values to the owned subsystems, then recycles the runtime — keeping the HTTP listener and DB up.

Built on #1608 (all state objects read `self.app_state.settings` live), so a settings swap propagates automatically with no per-subsystem cache refresh.

## What changed

### Settings reload
- **`KlangkSettings.reload()`** — re-resolve from the construction sources (`_reload_env` / `_reload_config_file` `PrivateAttr`s). Production: live `os.environ`; tests: the dict.
- **`Lifecycle._reload_settings()`** — wraps `reload()`, returns `(new, error)`.
- **`restart_runtime()`** calls it **before any teardown**; on error it logs at `ERROR` and returns (no shutdown/startup).

### `reconfigure(app_state)` interface
Every state object implements `reconfigure(app_state)`. Most are no-ops (settings are read live per #1608). The ones that do real work:

| Subsystem | What `reconfigure` does |
|---|---|
| `OIDC` | Clears discovery/JWKS caches, re-inits providers, reloads login hook |
| `Plugins` | Re-scans plugin declarations + values |
| `SSLTrust` | Re-applies backend SSL trust |
| `NginxWatchdog` | Rebuilds the `NginxRenderer` for the next config render |
| `EmailService` | Resets the cached Jinja template environment |
| `ContainerRegistry` | Propagates to PortAllocator, IdleMonitor, HealthMonitor |
| `Model` | Propagates to all 8 sub-models |

### Non-reloadable warnings
Settings bound for the process lifetime are warned but not denied: `port`, `listen`, `data_dir`, `state_dir`.

### Docs
- `docs/deployment/signals.md` — rewritten with reload behavior, reloadable/non-reloadable split, invalid-config deny.
- `docs/reference/environment.md` — "Applying configuration changes" note.
- `docs/changes.md` — changelog entry.

## Tests (backend, 100% coverage)

- `test_restart_denies_on_invalid_config` — deny path: no apply, no teardown.
- `test_restart_reloads_then_applies_then_restarts` — ordering is `[apply, shutdown, startup]`.
- `test_reload_settings_returns_new_when_valid` / `_returns_error_when_invalid`.
- `test_apply_reloaded_settings_calls_reconfigure` — all 18 subsystems' `reconfigure()` called.
- `test_apply_logs_warning_when_reconfigure_fails` — failing step skipped + warned, rest still run.
- `test_warn_non_reloadable_logs_changed_settings` / `_silent_on_reloadable_only`.
- `test_agent_handle_change_takes_effect_after_restart` — **acceptance test**: editing `KLANGK_AGENT_HANDLE` + apply makes the new handle live.
- `TestReload` in test_settings.py — `reload()` returns fresh instance, picks up changed env, raises on invalid.

## Test plan

- [x] Backend tests pass (`-n auto`, 2484 tests, 100% coverage)
- [ ] CLI E2E tests on CI
- [ ] Frontend E2E tests on CI