### PR TITLE
feat(model): WorkspacesModel(app_state) + convert workspaces call sites (#1575)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -176,6 +176,23 @@ operators or integrators to act when upgrading.
   dead code. No behavior change — same DB, same queries; this is the
   second slice of #1563.
 
+- **`WorkspacesModel(app_state)` added as the workspaces domain
+  (#1575).** The workspaces data-access surface (workspace CRUD, ACL-
+  seeded creation, members, shared-workspace listings, ownership
+  transfer, container/port tracking) is now
+  `app_state.model.workspaces.<method>` (`create_workspace_with_acl`,
+  `create_workspace`, `list_workspaces`, `list_shared_workspaces`,
+  `get_workspace`, `get_workspace_by_id`, `get_workspace_members`,
+  `delete_workspace`, `update_workspace`, `transfer_workspace`, …),
+  reaching the DB through `self.app_state.db`. The ~28 request-path
+  call sites across `workspaces.py`, `agent.py`, `container.py`,
+  `api/workspaces.py`, `api/chat.py`, and `wshandler/controllers.py`
+  now go through it (`get_workspace_members` gained a
+  `Depends(get_app_state_dep)`). The module-level free-function
+  backstops stay for the test suite until #1578 dissolves them. No
+  behavior change — same DB, same queries; this is the fourth slice of
+  #1563.
+
 - **`Model(app_state)` composition root introduced (#1572).** A new
   `app.state.model = Model(app.state)` (wired in `build_app` after
   `app.state.db`) composes the per-domain data-access sub-objects.

--- a/src/backend/klangk_backend/agent.py
+++ b/src/backend/klangk_backend/agent.py
@@ -126,7 +126,9 @@ class Agents:
         process) and again from chat-start, which caches the result per
         ``AgentSession``.
         """
-        ws = await model.get_workspace_by_id(workspace_id)
+        ws = await self.app_state.model.workspaces.get_workspace_by_id(
+            workspace_id
+        )
         if not ws:
             raise AgentSetupError(
                 f"Workspace {workspace_id} not found in database"
@@ -246,7 +248,12 @@ class Agents:
         """
         if not workspace_id:
             return
-        if await model.get_workspace_by_id(workspace_id) is None:
+        if (
+            await self.app_state.model.workspaces.get_workspace_by_id(
+                workspace_id
+            )
+            is None
+        ):
             return
         agent_handle = await self.app_state.model.users.agent_handle()
         agent_email = await self.app_state.model.users.agent_email()
@@ -276,7 +283,12 @@ class Agents:
         """
         if not workspace_id:
             return
-        if await model.get_workspace_by_id(workspace_id) is None:
+        if (
+            await self.app_state.model.workspaces.get_workspace_by_id(
+                workspace_id
+            )
+            is None
+        ):
             return
         agent_handle = await self.app_state.model.users.agent_handle()
         agent_email = await self.app_state.model.users.agent_email()

--- a/src/backend/klangk_backend/api/chat.py
+++ b/src/backend/klangk_backend/api/chat.py
@@ -37,7 +37,9 @@ async def workspace_chat(
     The message is stored as MSG_AGENT and broadcast to all connected
     WebSocket subscribers in the workspace.
     """
-    workspace = await model.get_workspace_by_id(workspace_id)
+    workspace = await app_state.model.workspaces.get_workspace_by_id(
+        workspace_id
+    )
     if workspace is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
 

--- a/src/backend/klangk_backend/api/workspaces.py
+++ b/src/backend/klangk_backend/api/workspaces.py
@@ -140,7 +140,7 @@ async def list_shared_workspaces(
     With pagination params returns an envelope (see ``list_workspaces``).
     """
     bare = limit is None and offset is None
-    result = await model.list_shared_workspaces(
+    result = await app_state.model.workspaces.list_shared_workspaces(
         user["id"],
         limit=BARE_LIST_LIMIT if bare else limit,
         offset=offset or 0,
@@ -270,10 +270,10 @@ async def update_workspace(
             raise HTTPException(status_code=400, detail=mount_err)
     if not fields:
         raise HTTPException(status_code=400, detail="No fields to update")
-    workspace = await model.get_workspace(workspace_id)
+    workspace = await app_state.model.workspaces.get_workspace(workspace_id)
     if workspace is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
-    updated = await model.update_workspace(
+    updated = await app_state.model.workspaces.update_workspace(
         workspace_id, workspace["user_id"], **fields
     )
     if not updated:
@@ -308,7 +308,7 @@ async def duplicate_workspace(
     user: dict = Depends(acl.has_permission("create", workspace_resource)),
     app_state=Depends(get_app_state_dep),
 ):
-    source = await model.get_workspace(workspace_id)
+    source = await app_state.model.workspaces.get_workspace(workspace_id)
     if source is None:  # pragma: no cover — race after ACL check
         raise HTTPException(status_code=404, detail="Workspace not found")
     try:
@@ -336,13 +336,15 @@ async def delete_workspace(
     user: dict = Depends(acl.has_permission("delete", workspace_resource)),
     app_state=Depends(get_app_state_dep),
 ):
-    workspace = await model.get_workspace(workspace_id)
+    workspace = await app_state.model.workspaces.get_workspace(workspace_id)
     if workspace is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
 
     # Capture shared members before we tear down ACL entries, so we can
     # notify them (and the owner/deleter) that the workspace is gone.
-    members = await model.get_workspace_members(workspace_id)
+    members = await app_state.model.workspaces.get_workspace_members(
+        workspace_id
+    )
 
     # Prefer the live container_id from the registry (tracks the currently
     # running container) over the DB value (may be stale if the container
@@ -392,7 +394,7 @@ async def restart_workspace(
     command re-fires at the create choke point, so a service workspace
     recovers to healthy.
     """
-    workspace = await model.get_workspace(workspace_id)
+    workspace = await app_state.model.workspaces.get_workspace(workspace_id)
     if workspace is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
     live_state = app_state.container_registry.get_state(workspace_id)
@@ -421,7 +423,7 @@ async def workspace_status(
     Returns running state, container health, idle timeout info,
     and allocated ports.
     """
-    workspace = await model.get_workspace(workspace_id)
+    workspace = await app_state.model.workspaces.get_workspace(workspace_id)
     if workspace is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
 
@@ -485,10 +487,14 @@ async def export_workspace(
     The archive contains workspace.json (metadata) and the home
     directory tree under home/.
     """
-    workspace = await model.get_workspace(workspace_id, admin["id"])
+    workspace = await app_state.model.workspaces.get_workspace(
+        workspace_id, admin["id"]
+    )
     if workspace is None:
         # Admin may not own the workspace — look it up without access check.
-        workspace = await model.get_workspace_by_id(workspace_id)
+        workspace = await app_state.model.workspaces.get_workspace_by_id(
+            workspace_id
+        )
     if workspace is None:
         raise HTTPException(status_code=404, detail="Workspace not found")
 
@@ -771,8 +777,9 @@ async def _check_workspace_share(request: Request, user: dict) -> str:
 async def get_workspace_members(
     workspace_id: str,
     user: dict = Depends(acl.has_permission("share", _check_workspace_share)),
+    app_state=Depends(get_app_state_dep),
 ):
-    return await model.get_workspace_members(workspace_id)
+    return await app_state.model.workspaces.get_workspace_members(workspace_id)
 
 
 class AddMemberRequest(BaseModel):
@@ -1107,7 +1114,9 @@ async def transfer_workspace_ownership(
         raise HTTPException(status_code=404, detail="User not found")
 
     try:
-        ws = await model.transfer_workspace(workspace_id, target["id"])
+        ws = await app_state.model.workspaces.transfer_workspace(
+            workspace_id, target["id"]
+        )
     except ValueError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -5,7 +5,7 @@ import logging
 import os
 import time
 
-from . import model, podman
+from . import podman
 from .podman import PodmanError
 
 logger = logging.getLogger(__name__)
@@ -1307,7 +1307,9 @@ class ContainerRegistry:
             "workspace-open: create container image (podman create): %.3fs",
             time.monotonic() - t_create,
         )
-        await model.update_workspace_container(workspace_id, cid)
+        await self.app_state.model.workspaces.update_workspace_container(
+            workspace_id, cid
+        )
         self.track_activity(
             cid,
             workspace_id,
@@ -1634,7 +1636,9 @@ class ContainerRegistry:
 
     async def stop_user_containers(self, user_id: str) -> None:
         """Stop all containers for a user (called on logout)."""
-        workspaces = await model.get_user_workspaces_with_containers(user_id)
+        workspaces = await self.app_state.model.workspaces.get_user_workspaces_with_containers(
+            user_id
+        )
         for ws in workspaces:
             if ws["container_id"]:
                 await self.notify_workspace_killed(ws["id"])

--- a/src/backend/klangk_backend/model/model.py
+++ b/src/backend/klangk_backend/model/model.py
@@ -10,8 +10,8 @@ built with (#1563, #1551).
 
 Foundation (#1572): only the four standalone domains are composed here
 (``tokens``, ``login_attempts``, ``invitations``, ``ports``). ``users``
-(#1573) and ``acl`` (#1574) are added; the remaining domains
-(``workspaces``, ``chat``) are added in their own issues; until then
+(#1573), ``acl`` (#1574), and ``workspaces`` (#1575) are added; the
+remaining domains (``chat``) are added in their own issues; until then
 they're still reached via the module-level free functions + the
 ``_current_db`` ContextVar backstop in ``model/db.py``.
 """
@@ -24,6 +24,7 @@ from .tokens import TokensModel
 from .login_attempts import LoginAttemptsModel
 from .invitations import InvitationsModel
 from .users import UsersModel
+from .workspaces import WorkspacesModel
 from .schema import init_db
 
 
@@ -44,6 +45,7 @@ class Model:
         self.ports = PortsModel(app_state)
         self.users = UsersModel(app_state)
         self.acl = ACLModel(app_state)
+        self.workspaces = WorkspacesModel(app_state)
 
     @asynccontextmanager
     async def transaction(self):

--- a/src/backend/klangk_backend/model/workspaces.py
+++ b/src/backend/klangk_backend/model/workspaces.py
@@ -716,3 +716,567 @@ async def list_auto_start_workspaces() -> list[dict]:
             }
             for row in rows
         ]
+
+
+# ---------------------------------------------------------------------------
+# WorkspacesModel: the app_state-owned form, reached via
+# ``app_state.model.workspaces``.
+#
+# Mirrors the per-domain sub-objects introduced in the foundation (#1572):
+# methods reach the DB through ``self.app_state.db`` (the single app-wide
+# instance). The module-level free functions above stay as the
+# ``_current_db`` ContextVar backstop until #1578 dissolves them — they're
+# still used by the test suite (~200 sites) and a couple of app_state-less
+# callers (``list_shared_workspaces``'s backstop chains through the users
+# backstop ``get_user_group_ids``).
+#
+# Cross-domain: the only non-workspaces model call inside this domain is
+# ``get_user_group_ids`` (users), resolved in the shared-workspace listing
+# via ``self.app_state.model.users``. ACL primitives consumed here are the
+# module-level constants (``ACTION_ALLOW`` / ``PRINCIPAL_*``), which #1574
+# moves onto ``ACLModel`` but which stay importable here as names regardless.
+#
+# The private ``db``-param helpers (``_insert_workspace_row`` /
+# ``_seed_workspace_acl``) stay module-level: they take a caller-supplied
+# connection so they can run inside a larger transaction (the atomic
+# create-with-ACL path), and the methods below delegate to them — same
+# shape as UsersModel's ``unique_handle`` / ``generate_handle`` delegates.
+# ---------------------------------------------------------------------------
+
+
+class WorkspacesModel:
+    """Workspace CRUD/members/listings, resolved through ``app_state.db``.
+
+    Constructed by :class:`~klangk_backend.model.model.Model` and reached
+    via ``app_state.model.workspaces``. Reaches the DB through
+    ``self.app_state.db`` (the single DB instance for the whole app).
+    """
+
+    def __init__(self, app_state):
+        self.app_state = app_state
+
+    async def create_workspace_with_acl(
+        self,
+        user_id: str,
+        name: str,
+        image: str | None = None,
+        service_command: str | None = None,
+        auto_start: bool = False,
+        mounts: list[str] | None = None,
+        env: dict[str, str] | None = None,
+        setup_state: str = SETUP_STATE_COMPLETE,
+        health_check: str | None = None,
+    ) -> dict:
+        """Create a workspace row AND seed its owner ACE + role groups.
+
+        The row insert and the ACL/group seeding run in a **single
+        transaction**, so any failure rolls the whole thing back — no
+        orphaned row, ACEs, or role groups (#128).
+        """
+        if user_id == AGENT_USER_ID:
+            raise AgentPrincipalError(
+                "The system agent cannot own a workspace (seeding it a"
+                " wildcard owner ACE + owners-group membership makes its"
+                " UUID a privileged principal) — system agent"
+            )
+        if setup_state not in SETUP_STATES:
+            raise ValueError(f"Invalid setup_state: {setup_state!r}")
+        async with self.app_state.db.transaction() as db:
+            ws = await _insert_workspace_row(
+                db,
+                user_id,
+                name,
+                image=image,
+                service_command=service_command,
+                auto_start=auto_start,
+                mounts=mounts,
+                env=env,
+                setup_state=setup_state,
+                health_check=health_check,
+            )
+            await _seed_workspace_acl(db, ws, user_id)
+            return ws
+
+    async def create_workspace(
+        self,
+        user_id: str,
+        name: str,
+        image: str | None = None,
+        service_command: str | None = None,
+        auto_start: bool = False,
+        mounts: list[str] | None = None,
+        env: dict[str, str] | None = None,
+        setup_state: str = SETUP_STATE_COMPLETE,
+        health_check: str | None = None,
+    ) -> dict:
+        """Insert a workspace row only (no ACL seeding).
+
+        Prefer :meth:`create_workspace_with_acl` for normal workspace
+        creation — it seeds the owner ACE and role groups atomically and is
+        what the service layer uses. This row-only primitive is kept for
+        callers that manage ACLs separately.
+        """
+        if setup_state not in SETUP_STATES:
+            raise ValueError(f"Invalid setup_state: {setup_state!r}")
+        async with self.app_state.db.transaction() as db:
+            return await _insert_workspace_row(
+                db,
+                user_id,
+                name,
+                image=image,
+                service_command=service_command,
+                auto_start=auto_start,
+                mounts=mounts,
+                env=env,
+                setup_state=setup_state,
+                health_check=health_check,
+            )
+
+    async def list_workspaces(
+        self,
+        user_id: str,
+        limit: int = 10,
+        offset: int = 0,
+        sort: str = "created",
+        order: str = "desc",
+        q: str | None = None,
+    ) -> dict:
+        """List a page of workspaces owned by ``user_id``.
+
+        Returns a pagination envelope:
+        ``{"items": [...], "has_more": bool, "next_offset": int | None}``.
+        """
+        order_by = sort_order_clause(sort, order)
+        where = "WHERE user_id = ?"
+        params: list = [user_id]
+        if q:
+            where += " AND name LIKE '%' || ? || '%'"
+            params.append(q)
+        params.extend([limit + 1, offset])
+        async with self.app_state.db.transaction() as db:
+            cursor = await db.execute(
+                "SELECT id, name, container_id, image, service_command,"
+                " auto_start, setup_state, health_check, mounts, env,"
+                " created_at"
+                " FROM workspaces"
+                f" {where} {order_by} LIMIT ? OFFSET ?",
+                tuple(params),
+            )
+            rows = await cursor.fetchall()
+            items = [
+                {
+                    "id": row["id"],
+                    "name": row["name"],
+                    "container_id": row["container_id"],
+                    "image": row["image"],
+                    "service_command": row["service_command"],
+                    "auto_start": bool(row["auto_start"]),
+                    "setup_state": row["setup_state"],
+                    "health_check": row["health_check"],
+                    "mounts": json.loads(row["mounts"])
+                    if row["mounts"]
+                    else None,
+                    "env": json.loads(row["env"]) if row["env"] else None,
+                    "created_at": row["created_at"],
+                }
+                for row in rows
+            ]
+            has_more = len(items) > limit
+            items = items[:limit]
+            return {
+                "items": items,
+                "has_more": has_more,
+                "next_offset": offset + limit if has_more else None,
+            }
+
+    async def list_shared_workspaces(
+        self,
+        user_id: str,
+        limit: int = 10,
+        offset: int = 0,
+        sort: str = "created",
+        order: str = "desc",
+        q: str | None = None,
+    ) -> dict:
+        """List a page of workspaces shared with (not owned by) this user.
+
+        Access is granted through either a direct user-level ACE or a
+        group-level ACE on ``/workspaces/{id}``.
+        """
+        order_by = sort_order_clause(sort, order, prefix="w")
+        name_filter = " AND w.name LIKE '%' || ? || '%'" if q else ""
+        async with self.app_state.db.transaction() as db:
+            group_ids = await self.app_state.model.users.get_user_group_ids(
+                user_id
+            )
+            group_placeholders = ",".join("?" for _ in group_ids)
+            group_clause = (
+                f" OR (ae.principal_type = {PRINCIPAL_GROUP}"
+                f" AND ae.group_id IN ({group_placeholders}))"
+                if group_ids
+                else ""
+            )
+            cursor = await db.execute(
+                "SELECT DISTINCT w.id, w.name, w.container_id, w.image,"
+                " w.service_command, w.auto_start, w.setup_state,"
+                " w.health_check, w.mounts, w.env, w.created_at,"
+                " u.email AS owner_email"
+                " FROM workspaces w"
+                " JOIN acl_entries ae ON ae.resource = '/workspaces/' || w.id"
+                " JOIN users u ON w.user_id = u.id"
+                " WHERE ae.action = ? AND w.user_id != ?"
+                "   AND ("
+                f"    (ae.principal_type = {PRINCIPAL_USER} AND ae.user_id = ?)"
+                f"    {group_clause}"
+                "   )"
+                f"{name_filter}"
+                f" {order_by} LIMIT ? OFFSET ?",
+                (
+                    ACTION_ALLOW,
+                    user_id,
+                    user_id,
+                    *group_ids,
+                    *([q] if q else []),
+                    limit + 1,
+                    offset,
+                ),
+            )
+            rows = await cursor.fetchall()
+            items = [
+                {
+                    "id": row["id"],
+                    "name": row["name"],
+                    "container_id": row["container_id"],
+                    "image": row["image"],
+                    "service_command": row["service_command"],
+                    "auto_start": bool(row["auto_start"]),
+                    "setup_state": row["setup_state"],
+                    "health_check": row["health_check"],
+                    "mounts": json.loads(row["mounts"])
+                    if row["mounts"]
+                    else None,
+                    "env": json.loads(row["env"]) if row["env"] else None,
+                    "created_at": row["created_at"],
+                    "owner_email": row["owner_email"],
+                }
+                for row in rows
+            ]
+            has_more = len(items) > limit
+            items = items[:limit]
+            return {
+                "items": items,
+                "has_more": has_more,
+                "next_offset": offset + limit if has_more else None,
+            }
+
+    async def get_workspace(
+        self, workspace_id: str, user_id: str | None = None
+    ) -> dict | None:
+        """Get a workspace by ID.
+
+        If user_id is provided, restricts to workspaces owned by that user.
+        """
+        async with self.app_state.db.transaction() as db:
+            if user_id is not None:
+                cursor = await db.execute(
+                    "SELECT id, user_id, name, container_id, num_ports, image,"
+                    " service_command, auto_start, setup_state, health_check,"
+                    " mounts, env"
+                    " FROM workspaces WHERE id = ? AND user_id = ?",
+                    (workspace_id, user_id),
+                )
+            else:
+                cursor = await db.execute(
+                    "SELECT id, user_id, name, container_id, num_ports, image,"
+                    " service_command, auto_start, setup_state, health_check,"
+                    " mounts, env"
+                    " FROM workspaces WHERE id = ?",
+                    (workspace_id,),
+                )
+            row = await cursor.fetchone()
+            if row is None:
+                return None
+            return {
+                "id": row["id"],
+                "user_id": row["user_id"],
+                "name": row["name"],
+                "container_id": row["container_id"],
+                "num_ports": row["num_ports"],
+                "image": row["image"],
+                "service_command": row["service_command"],
+                "auto_start": bool(row["auto_start"]),
+                "setup_state": row["setup_state"],
+                "health_check": row["health_check"],
+                "mounts": json.loads(row["mounts"]) if row["mounts"] else None,
+                "env": json.loads(row["env"]) if row["env"] else None,
+            }
+
+    async def get_workspace_by_id(self, workspace_id: str) -> dict | None:
+        """Get a workspace by ID without access control (for admin use)."""
+        row = await self.app_state.db.fetchone(
+            "SELECT id, user_id, name, container_id, num_ports, image,"
+            " service_command, setup_state, health_check, mounts, env"
+            " FROM workspaces WHERE id = ?",
+            (workspace_id,),
+        )
+        if row is None:
+            return None
+        return {
+            "id": row["id"],
+            "user_id": row["user_id"],
+            "name": row["name"],
+            "container_id": row["container_id"],
+            "num_ports": row["num_ports"],
+            "image": row["image"],
+            "service_command": row["service_command"],
+            "setup_state": row["setup_state"],
+            "health_check": row["health_check"],
+            "mounts": json.loads(row["mounts"]) if row["mounts"] else None,
+            "env": json.loads(row["env"]) if row["env"] else None,
+        }
+
+    async def get_workspace_members(self, workspace_id: str) -> list[dict]:
+        """Get users who have been granted access to a workspace via ACL."""
+        async with self.app_state.db.transaction() as db:
+            cursor = await db.execute(
+                "SELECT DISTINCT u.id, u.email, u.handle FROM users u"
+                " JOIN acl_entries ae ON ae.user_id = u.id"
+                " JOIN workspaces w ON w.id = ?"
+                " WHERE ae.resource = ? AND ae.principal_type = ?"
+                "   AND ae.action = ? AND u.id != w.user_id"
+                " ORDER BY u.email",
+                (
+                    workspace_id,
+                    f"/workspaces/{workspace_id}",
+                    PRINCIPAL_USER,
+                    ACTION_ALLOW,
+                ),
+            )
+            return [
+                {
+                    "id": row["id"],
+                    "email": row["email"],
+                    "handle": row["handle"],
+                }
+                for row in await cursor.fetchall()
+            ]
+
+    async def delete_workspace(self, workspace_id: str, user_id: str) -> bool:
+        async with self.app_state.db.transaction() as db:
+            cursor = await db.execute(
+                "DELETE FROM workspaces WHERE id = ? AND user_id = ?",
+                (workspace_id, user_id),
+            )
+            if cursor.rowcount == 0:
+                return False
+            # Clean up ACL entries for this workspace
+            resource = f"/workspaces/{workspace_id}"
+            await db.execute(
+                "DELETE FROM acl_entries WHERE resource = ?", (resource,)
+            )
+            # Clean up per-workspace role groups and their memberships
+            role_suffixes = ["owners", "coders", "collaborators", "spectators"]
+            for suffix in role_suffixes:
+                group_name = f"{suffix}-{workspace_id}"
+                cursor_g = await db.execute(
+                    "SELECT id FROM groups WHERE name = ?", (group_name,)
+                )
+                row = await cursor_g.fetchone()
+                if row:
+                    group_id = row["id"]
+                    await db.execute(
+                        "DELETE FROM user_groups WHERE group_id = ?",
+                        (group_id,),
+                    )
+                    await db.execute(
+                        "DELETE FROM acl_entries WHERE group_id = ?",
+                        (group_id,),
+                    )
+                    await db.execute(
+                        "DELETE FROM groups WHERE id = ?", (group_id,)
+                    )
+            # Clean up port allocations
+            await db.execute(
+                "DELETE FROM port_allocations WHERE workspace_id = ?",
+                (workspace_id,),
+            )
+            # Clean up chat messages
+            await db.execute(
+                "DELETE FROM chat_messages WHERE workspace_id = ?",
+                (workspace_id,),
+            )
+            return True
+
+    async def update_workspace_container(
+        self, workspace_id: str, container_id: str | None
+    ) -> None:
+        async with self.app_state.db.transaction() as db:
+            await db.execute(
+                "UPDATE workspaces SET container_id = ? WHERE id = ?",
+                (container_id, workspace_id),
+            )
+
+    async def update_workspace(
+        self,
+        workspace_id: str,
+        user_id: str,
+        **fields: str | None,
+    ) -> bool:
+        """Update workspace fields. Only provided fields are changed."""
+        allowed = {
+            "name",
+            "image",
+            "service_command",
+            "auto_start",
+            "setup_state",
+            "health_check",
+            "mounts",
+            "env",
+        }
+        to_set = {}
+        for k, v in fields.items():
+            if k not in allowed:
+                continue
+            if k == "setup_state":
+                if v not in SETUP_STATES:
+                    raise ValueError(f"Invalid setup_state: {v!r}")
+                to_set[k] = v
+            elif k in ("mounts", "env"):
+                to_set[k] = json.dumps(v) if v is not None else None
+            elif k == "auto_start":
+                to_set[k] = 1 if v else 0
+            else:
+                to_set[k] = v
+        if not to_set:
+            return False
+        set_clause = ", ".join(f"{k} = ?" for k in to_set)
+        values = list(to_set.values()) + [workspace_id, user_id]
+        async with self.app_state.db.transaction() as db:
+            cursor = await db.execute(
+                f"UPDATE workspaces SET {set_clause}"  # noqa: S608
+                " WHERE id = ? AND user_id = ?",
+                values,
+            )
+            return cursor.rowcount > 0
+
+    async def transfer_workspace(
+        self,
+        workspace_id: str,
+        new_owner_id: str,
+    ) -> dict | None:
+        """Transfer workspace ownership to a different user.
+
+        Updates the workspace ``user_id``, the owner ACE (position 0), and
+        the ``owners`` role group membership atomically.  Returns the
+        updated workspace dict, or ``None`` if the workspace does not exist.
+        """
+        if new_owner_id == AGENT_USER_ID:
+            raise AgentPrincipalError(
+                "Cannot transfer a workspace to the system agent"
+            )
+
+        async with self.app_state.db.transaction() as db:
+            cursor = await db.execute(
+                "SELECT id, user_id, name FROM workspaces WHERE id = ?",
+                (workspace_id,),
+            )
+            row = await cursor.fetchone()
+            if row is None:
+                return None
+
+            old_owner_id = row["user_id"]
+            ws_name = row["name"]
+
+            if old_owner_id == new_owner_id:
+                raise ValueError("Target user is already the owner")
+
+            # Check UNIQUE(user_id, name) won't be violated.
+            dup = await db.execute(
+                "SELECT 1 FROM workspaces"
+                " WHERE user_id = ? AND name = ? AND id != ?",
+                (new_owner_id, ws_name, workspace_id),
+            )
+            if await dup.fetchone():
+                raise ValueError(
+                    f"Target user already owns a workspace named {ws_name!r}"
+                )
+
+            # 1. Update workspace owner.
+            await db.execute(
+                "UPDATE workspaces SET user_id = ? WHERE id = ?",
+                (new_owner_id, workspace_id),
+            )
+
+            # 2. Update the owner ACE (position 0) to point at the new owner.
+            resource = f"/workspaces/{workspace_id}"
+            await db.execute(
+                "UPDATE acl_entries SET user_id = ?"
+                " WHERE resource = ? AND position = 0"
+                " AND principal_type = ?",
+                (new_owner_id, resource, PRINCIPAL_USER),
+            )
+
+            # 3. Swap owners-group membership: remove old owner, add new.
+            owners_group_name = f"owners-{workspace_id}"
+            g_cursor = await db.execute(
+                "SELECT id FROM groups WHERE name = ?",
+                (owners_group_name,),
+            )
+            g_row = await g_cursor.fetchone()
+            if g_row:
+                group_id = g_row["id"]
+                await db.execute(
+                    "DELETE FROM user_groups WHERE user_id = ? AND group_id = ?",
+                    (old_owner_id, group_id),
+                )
+                await db.execute(
+                    "INSERT OR IGNORE INTO user_groups"
+                    " (user_id, group_id, source) VALUES (?, ?, ?)",
+                    (new_owner_id, group_id, "manual"),
+                )
+
+        return await self.get_workspace_by_id(workspace_id)
+
+    async def get_user_workspaces_with_containers(
+        self, user_id: str
+    ) -> list[dict]:
+        async with self.app_state.db.transaction() as db:
+            cursor = await db.execute(
+                "SELECT id, container_id FROM workspaces WHERE user_id = ? AND container_id IS NOT NULL",
+                (user_id,),
+            )
+            rows = await cursor.fetchall()
+            return [
+                {"id": row["id"], "container_id": row["container_id"]}
+                for row in rows
+            ]
+
+    async def list_auto_start_workspaces(self) -> list[dict]:
+        """List all workspaces with auto_start enabled."""
+        async with self.app_state.db.transaction() as db:
+            cursor = await db.execute(
+                "SELECT id, user_id, name, container_id, num_ports, image,"
+                " service_command, auto_start, setup_state, health_check,"
+                " mounts, env"
+                " FROM workspaces WHERE auto_start = 1",
+            )
+            rows = await cursor.fetchall()
+            return [
+                {
+                    "id": row["id"],
+                    "user_id": row["user_id"],
+                    "name": row["name"],
+                    "container_id": row["container_id"],
+                    "num_ports": row["num_ports"],
+                    "image": row["image"],
+                    "service_command": row["service_command"],
+                    "auto_start": True,
+                    "setup_state": row["setup_state"],
+                    "health_check": row["health_check"],
+                    "mounts": json.loads(row["mounts"])
+                    if row["mounts"]
+                    else None,
+                    "env": json.loads(row["env"]) if row["env"] else None,
+                }
+                for row in rows
+            ]

--- a/src/backend/klangk_backend/workspaces.py
+++ b/src/backend/klangk_backend/workspaces.py
@@ -304,7 +304,9 @@ class Workspaces:
         archived_ws_ids: list[str] = []
         offset = 0
         while True:
-            page = await model.list_workspaces(user_id, offset=offset)
+            page = await self.app_state.model.workspaces.list_workspaces(
+                user_id, offset=offset
+            )
             user_workspaces = page["items"]
             if not user_workspaces:
                 break
@@ -357,16 +359,18 @@ class Workspaces:
         setup_state: str | None = None,
         health_check: str | None = None,
     ) -> dict:
-        workspace = await model.create_workspace_with_acl(
-            user_id,
-            name,
-            image=image,
-            service_command=service_command,
-            auto_start=auto_start,
-            mounts=mounts,
-            env=env,
-            setup_state=setup_state or model.SETUP_STATE_COMPLETE,
-            health_check=health_check,
+        workspace = (
+            await self.app_state.model.workspaces.create_workspace_with_acl(
+                user_id,
+                name,
+                image=image,
+                service_command=service_command,
+                auto_start=auto_start,
+                mounts=mounts,
+                env=env,
+                setup_state=setup_state or model.SETUP_STATE_COMPLETE,
+                health_check=health_check,
+            )
         )
         home = self.home_path(workspace["id"])
         home.mkdir(parents=True, exist_ok=True)
@@ -383,7 +387,9 @@ class Workspaces:
             )
         except Exception:
             # Clean up the DB record and directories on port allocation failure
-            await model.delete_workspace(workspace["id"], user_id)
+            await self.app_state.model.workspaces.delete_workspace(
+                workspace["id"], user_id
+            )
             await _async_rmtree(home, f"workspace {workspace['id']} rollback")
             raise
         return workspace
@@ -397,21 +403,27 @@ class Workspaces:
         order: str = "desc",
         q: str | None = None,
     ) -> dict:
-        return await model.list_workspaces(
+        return await self.app_state.model.workspaces.list_workspaces(
             user_id, limit, offset, sort, order, q
         )
 
     async def get_workspace(
         self, workspace_id: str, user_id: str | None = None
     ) -> dict | None:
-        return await model.get_workspace(workspace_id, user_id)
+        return await self.app_state.model.workspaces.get_workspace(
+            workspace_id, user_id
+        )
 
     async def delete_workspace(self, workspace_id: str, user_id: str) -> bool:
-        workspace = await model.get_workspace(workspace_id, user_id)
+        workspace = await self.app_state.model.workspaces.get_workspace(
+            workspace_id, user_id
+        )
         if workspace is None:
             return False
 
-        deleted = await model.delete_workspace(workspace_id, user_id)
+        deleted = await self.app_state.model.workspaces.delete_workspace(
+            workspace_id, user_id
+        )
         if deleted:
             ws_dir = self.safe_path(workspace_id)
             await _async_rmtree(ws_dir, f"workspace {workspace_id}")
@@ -501,7 +513,9 @@ class Workspaces:
         if not self.settings.allow_autostart:
             return 0
 
-        ws_list = await model.list_auto_start_workspaces()
+        ws_list = (
+            await self.app_state.model.workspaces.list_auto_start_workspaces()
+        )
         started = 0
         for i, ws in enumerate(ws_list):
             if i > 0:

--- a/src/backend/klangk_backend/wshandler/controllers.py
+++ b/src/backend/klangk_backend/wshandler/controllers.py
@@ -420,7 +420,9 @@ class TerminalController:
         rather than silently disabling service commands.
         """
         try:
-            ws = await model.get_workspace(self._conn.workspace_id)
+            ws = await self._conn.app_state.model.workspaces.get_workspace(
+                self._conn.workspace_id
+            )
         except Exception:
             return "complete"
         if ws is None:
@@ -1356,7 +1358,7 @@ class SharedTerminalController:
         # not be trusted blindly, otherwise any collaborator with the
         # share-terminals permission could close other users' windows.
         if owner_user_id != self._conn.user["id"]:
-            workspace = await model.get_workspace_by_id(
+            workspace = await self._conn.app_state.model.workspaces.get_workspace_by_id(
                 self._conn.workspace_id
             )
             if (

--- a/src/backend/tests/test_agent.py
+++ b/src/backend/tests/test_agent.py
@@ -74,6 +74,10 @@ def _make_app_state(cid="cid"):
     app_state.model.users.agent_email = AsyncMock(
         return_value="clanker@example.com"
     )
+    # #1575: agent.py reaches app_state.model.workspaces.get_workspace_by_id.
+    app_state.model.workspaces.get_workspace_by_id = AsyncMock(
+        return_value=None
+    )
     return app_state
 
 
@@ -852,8 +856,6 @@ class TestGetSession:
 
 class TestEnsureAgentHome:
     async def test_provisions_home_and_runs_setup(self, tmp_path):
-        from klangk_backend import model
-
         fake_ws = {"user_id": "owner1"}
         fake_home = tmp_path / "home"
         fake_home.mkdir()
@@ -873,7 +875,11 @@ class TestEnsureAgentHome:
         agents.app_state.podman = _mock_pod
 
         with (
-            patch.object(model, "get_workspace_by_id", return_value=fake_ws),
+            patch.object(
+                agents.app_state.model.workspaces,
+                "get_workspace_by_id",
+                return_value=fake_ws,
+            ),
             patch(
                 "asyncio.create_subprocess_exec",
                 return_value=mock_proc,
@@ -899,7 +905,6 @@ class TestEnsureAgentHome:
         the lazy chat-start path retries on first mention (#1162).
         The return value (container home) is unaffected by the rc.
         """
-        from klangk_backend import model
 
         fake_home = tmp_path / "home"
         fake_home.mkdir()
@@ -922,7 +927,9 @@ class TestEnsureAgentHome:
 
         with (
             patch.object(
-                model, "get_workspace_by_id", return_value={"user_id": "o"}
+                agents.app_state.model.workspaces,
+                "get_workspace_by_id",
+                return_value={"user_id": "o"},
             ),
             patch("asyncio.create_subprocess_exec", return_value=mock_proc),
         ):
@@ -932,8 +939,6 @@ class TestEnsureAgentHome:
         assert result == "/home/clanker"
 
     async def test_skips_skel_when_home_already_exists(self, tmp_path):
-        from klangk_backend import model
-
         fake_home = tmp_path / "home"
         fake_home.mkdir()
 
@@ -951,7 +956,9 @@ class TestEnsureAgentHome:
 
         with (
             patch.object(
-                model, "get_workspace_by_id", return_value={"user_id": "o"}
+                agents.app_state.model.workspaces,
+                "get_workspace_by_id",
+                return_value={"user_id": "o"},
             ),
         ):
             result = await agents.ensure_agent_home("ws1", "cid")
@@ -961,12 +968,14 @@ class TestEnsureAgentHome:
         ws.populate_home_skel.assert_not_awaited()
 
     async def test_workspace_not_found_raises(self):
-        from klangk_backend import model
-
         agents = _make_agents()
         agents.app_state.podman = _mock_pod
 
-        with patch.object(model, "get_workspace_by_id", return_value=None):
+        with patch.object(
+            agents.app_state.model.workspaces,
+            "get_workspace_by_id",
+            return_value=None,
+        ):
             with pytest.raises(AgentSetupError, match="not found"):
                 await agents.ensure_agent_home("ws-gone", "cid")
 
@@ -975,8 +984,6 @@ class TestEnsureHome:
     async def test_ensure_home_creates_dir_and_runs_login_shell(
         self, tmp_path
     ):
-        from klangk_backend import model
-
         agents = _make_agents()
         session = AgentSession("ws1", agents=agents)
 
@@ -998,7 +1005,7 @@ class TestEnsureHome:
 
         with (
             patch.object(
-                model,
+                agents.app_state.model.workspaces,
                 "get_workspace_by_id",
                 return_value=fake_ws,
             ),
@@ -1025,13 +1032,16 @@ class TestEnsureHome:
         assert result == "/home/clanker"
 
     async def test_ensure_home_workspace_not_in_db(self):
-        from klangk_backend import model
         from klangk_backend.agent import AgentSetupError
 
         agents = _make_agents()
         session = AgentSession("ws-gone", agents=agents)
 
-        with patch.object(model, "get_workspace_by_id", return_value=None):
+        with patch.object(
+            agents.app_state.model.workspaces,
+            "get_workspace_by_id",
+            return_value=None,
+        ):
             with pytest.raises(AgentSetupError, match="not found in database"):
                 await session._ensure_home("cid")
 
@@ -1187,7 +1197,7 @@ class TestMonitorProcess:
 
         with (
             patch.object(
-                model,
+                agents.app_state.model.workspaces,
                 "get_workspace_by_id",
                 new_callable=AsyncMock,
                 return_value={"id": "ws-mon"},
@@ -1459,7 +1469,7 @@ class TestMonitorProcess:
 
         with (
             patch.object(
-                model,
+                agents.app_state.model.workspaces,
                 "get_workspace_by_id",
                 new_callable=AsyncMock,
                 return_value={"id": "ws-rc"},

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -2030,13 +2030,14 @@ class TestWorkspaceRoutes:
             "/api/v1/workspaces", headers=headers, json={"name": "race-ws"}
         )
         ws_id = resp.json()["id"]
-        original_update = model.update_workspace
+        ws_model = app.state.model.workspaces
+        original_update = ws_model.update_workspace
 
         async def _delete_then_update(workspace_id, user_id, **fields):
-            await model.delete_workspace(workspace_id, user_id)
+            await ws_model.delete_workspace(workspace_id, user_id)
             return await original_update(workspace_id, user_id, **fields)
 
-        monkeypatch.setattr(model, "update_workspace", _delete_then_update)
+        monkeypatch.setattr(ws_model, "update_workspace", _delete_then_update)
         resp = await client.put(
             f"/api/v1/workspaces/{ws_id}",
             json={"service_command": "pi"},

--- a/src/backend/tests/test_model.py
+++ b/src/backend/tests/test_model.py
@@ -1896,3 +1896,70 @@ class TestAclBackstopBranches:
         assert len(after) == 1
         # delete returns the count
         assert await model.delete_acl_entries_for_resource("/bs-res") == 1
+
+
+class TestWorkspacesBackstopBranches:
+    """Cover free-function branches not reached by app code (now on the
+    WorkspacesModel methods) — get_workspace_by_id, transfer_workspace,
+    the invalid-setup_state guard, the list q-filter, and the
+    role-group teardown in delete_workspace (#1575)."""
+
+    async def test_get_workspace_by_id_found_and_missing(self, user):
+        ws = await model.create_workspace(user["id"], "lookup")
+        found = await model.get_workspace_by_id(ws["id"])
+        assert found["name"] == "lookup"
+        assert await model.get_workspace_by_id("nope") is None
+
+    async def test_list_workspaces_with_query(self, user):
+        await model.create_workspace(user["id"], "alpha")
+        await model.create_workspace(user["id"], "beta")
+        result = await model.list_workspaces(user["id"], q="alp")
+        assert [w["name"] for w in result["items"]] == ["alpha"]
+
+    async def test_create_workspace_with_acl_invalid_setup_state(self, user):
+        with pytest.raises(ValueError):
+            await model.create_workspace_with_acl(
+                user["id"], "bad", setup_state="bogus"
+            )
+
+    async def test_delete_workspace_tears_down_role_groups(self, user):
+        ws = await model.create_workspace_with_acl(user["id"], "seeded")
+        # The four role groups exist before delete.
+        async with model.transaction() as db:
+            cur = await db.execute(
+                "SELECT name FROM groups WHERE name LIKE ?",
+                (f"%-{ws['id']}",),
+            )
+            assert len(await cur.fetchall()) == 4
+        assert await model.delete_workspace(ws["id"], user["id"]) is True
+        # Role groups + memberships + ACEs gone after delete.
+        async with model.transaction() as db:
+            cur = await db.execute(
+                "SELECT name FROM groups WHERE name LIKE ?",
+                (f"%-{ws['id']}",),
+            )
+            assert await cur.fetchall() == []
+
+    async def test_transfer_workspace_moves_ownership(self, user):
+        other = await model.create_user("newowner@x.com", "h")
+        ws = await model.create_workspace_with_acl(user["id"], "xfer")
+        transferred = await model.transfer_workspace(ws["id"], other["id"])
+        assert transferred["user_id"] == other["id"]
+        # Owner ACE (position 0) now points at the new owner.
+        entries = await model.get_acl_entries(f"/workspaces/{ws['id']}")
+        owner_ace = next(
+            e for e in entries if e["position"] == 0 and e["permission"] == "*"
+        )
+        assert owner_ace["user_id"] == other["id"]
+
+    async def test_transfer_workspace_guards(self, user):
+        other = await model.create_user("newowner2@x.com", "h")
+        ws = await model.create_workspace_with_acl(user["id"], "xfer-guard")
+        with pytest.raises(model.AgentPrincipalError):
+            await model.transfer_workspace(ws["id"], model.AGENT_USER_ID)
+        with pytest.raises(ValueError, match="already the owner"):
+            await model.transfer_workspace(ws["id"], user["id"])
+        await model.create_workspace_with_acl(other["id"], "xfer-guard")
+        with pytest.raises(ValueError, match="already owns"):
+            await model.transfer_workspace(ws["id"], other["id"])
+        assert await model.transfer_workspace("missing", other["id"]) is None

--- a/src/backend/tests/test_model_workspaces.py
+++ b/src/backend/tests/test_model_workspaces.py
@@ -1,0 +1,225 @@
+"""Direct coverage for ``WorkspacesModel(app_state)`` (#1575).
+
+Exercises every method on ``app_state.model.workspaces`` — the
+app_state-owned form app code migrated to — including the cross-domain
+shared-workspace listing (which reaches ``app_state.model.users``) and
+the agent-principal / setup-state guards. Mirrors the #1573
+``test_model_users.py`` pattern: ``app_state`` (db + model wired via the
+ContextVar DB) with the schema initialized.
+"""
+
+import pytest
+
+from klangk_backend.model.workspaces import (
+    SETUP_STATE_COMPLETE,
+    SETUP_STATE_PENDING,
+)
+from klangk_backend.model.users import AGENT_USER_ID, AgentPrincipalError
+
+
+@pytest.fixture
+async def ws(app_state, db):
+    """``app_state.model.workspaces`` with the schema initialized."""
+    return app_state.model.workspaces
+
+
+async def test_create_workspace_with_acl_and_get(ws, user):
+    ws_row = await ws.create_workspace_with_acl(
+        user["id"], "owned", setup_state=SETUP_STATE_COMPLETE
+    )
+    assert ws_row["user_id"] == user["id"]
+    assert ws_row["num_ports"] is not None
+    # Seeded owner ACE + role groups are visible via the members/acl path.
+    by_id = await ws.get_workspace_by_id(ws_row["id"])
+    assert by_id["name"] == "owned"
+    assert await ws.get_workspace_by_id("missing") is None
+
+
+async def test_create_workspace_row_only(ws, user):
+    ws_row = await ws.create_workspace(user["id"], "row-only")
+    assert ws_row["name"] == "row-only"
+    got = await ws.get_workspace(ws_row["id"], user["id"])
+    assert got["id"] == ws_row["id"]
+
+
+async def test_create_workspace_with_acl_rejects_agent(ws):
+    with pytest.raises(AgentPrincipalError):
+        await ws.create_workspace_with_acl(AGENT_USER_ID, "agent-owned")
+
+
+async def test_create_invalid_setup_state(ws, user):
+    with pytest.raises(ValueError):
+        await ws.create_workspace_with_acl(
+            user["id"], "bad", setup_state="bogus"
+        )
+    with pytest.raises(ValueError):
+        await ws.create_workspace(user["id"], "bad", setup_state="bogus")
+
+
+async def test_list_workspaces_with_query(ws, user):
+    await ws.create_workspace(user["id"], "alpha")
+    await ws.create_workspace(user["id"], "beta")
+    filtered = await ws.list_workspaces(user["id"], q="alp")
+    assert [w["name"] for w in filtered["items"]] == ["alpha"]
+    all_items = await ws.list_workspaces(user["id"])
+    assert {w["name"] for w in all_items["items"]} == {"alpha", "beta"}
+
+
+async def test_list_shared_workspaces(ws, app_state, user):
+    other = await app_state.model.users.create_user("other@x.com", "h")
+    ws_row = await ws.create_workspace_with_acl(other["id"], "shared-ws")
+    # Grant ``user`` a direct user-level Allow ACE on the workspace.
+    from klangk_backend import model as _m
+
+    await _m.add_acl_entry(
+        f"/workspaces/{ws_row['id']}",
+        100,
+        _m.ACTION_ALLOW,
+        "terminal",
+        _m.PRINCIPAL_USER,
+        user_id=user["id"],
+    )
+    shared = await ws.list_shared_workspaces(user["id"])
+    assert any(w["id"] == ws_row["id"] for w in shared["items"])
+    assert shared["items"][0]["owner_email"] == "other@x.com"
+    # q-filter narrows by name.
+    filtered = await ws.list_shared_workspaces(user["id"], q="shared")
+    assert [w["name"] for w in filtered["items"]] == ["shared-ws"]
+    # Nothing shared with ``other``.
+    assert (await ws.list_shared_workspaces(other["id"]))["items"] == []
+
+
+async def test_get_workspace_access_control(ws, user):
+    ws_row = await ws.create_workspace(user["id"], "mine")
+    assert await ws.get_workspace(ws_row["id"], user["id"]) is not None
+    # Wrong user -> not found.
+    assert await ws.get_workspace(ws_row["id"], "someone-else") is None
+    assert await ws.get_workspace("missing", user["id"]) is None
+    # No user_id -> no access check.
+    assert (await ws.get_workspace(ws_row["id"]))["id"] == ws_row["id"]
+
+
+async def test_get_workspace_members(ws, app_state, user):
+    other = await app_state.model.users.create_user("member@x.com", "h")
+    ws_row = await ws.create_workspace_with_acl(user["id"], "members-ws")
+    from klangk_backend import model as _m
+
+    await _m.add_acl_entry(
+        f"/workspaces/{ws_row['id']}",
+        100,
+        _m.ACTION_ALLOW,
+        "terminal",
+        _m.PRINCIPAL_USER,
+        user_id=other["id"],
+    )
+    members = await ws.get_workspace_members(ws_row["id"])
+    assert [m["id"] for m in members] == [other["id"]]
+    # Owner is excluded from the member list.
+    assert all(m["id"] != user["id"] for m in members)
+
+
+async def test_delete_workspace_with_role_groups(ws, user):
+    ws_row = await ws.create_workspace_with_acl(user["id"], "to-delete")
+    # Seeded role groups exist; delete must tear them down.
+    assert await ws.delete_workspace(ws_row["id"], user["id"]) is True
+    assert await ws.get_workspace_by_id(ws_row["id"]) is None
+    # Second delete (gone) -> False.
+    assert await ws.delete_workspace(ws_row["id"], user["id"]) is False
+    # Wrong owner -> False.
+    ws2 = await ws.create_workspace(user["id"], "another")
+    assert await ws.delete_workspace(ws2["id"], "wrong-owner") is False
+
+
+async def test_update_workspace_container(ws, user):
+    ws_row = await ws.create_workspace(user["id"], "container-ws")
+    await ws.update_workspace_container(ws_row["id"], "cid-1")
+    assert (await ws.get_workspace_by_id(ws_row["id"]))[
+        "container_id"
+    ] == "cid-1"
+    await ws.update_workspace_container(ws_row["id"], None)
+    assert (await ws.get_workspace_by_id(ws_row["id"]))["container_id"] is None
+
+
+async def test_update_workspace_fields(ws, user):
+    ws_row = await ws.create_workspace(user["id"], "updatable")
+    assert (
+        await ws.update_workspace(
+            ws_row["id"],
+            user["id"],
+            name="renamed",
+            setup_state=SETUP_STATE_PENDING,
+            auto_start=True,
+            mounts=["/m"],
+            env={"K": "v"},
+        )
+        is True
+    )
+    got = await ws.get_workspace(ws_row["id"])
+    assert got["name"] == "renamed"
+    assert got["setup_state"] == SETUP_STATE_PENDING
+    assert got["auto_start"] is True
+    assert got["mounts"] == ["/m"]
+    assert got["env"] == {"K": "v"}
+    # Unknown fields are ignored; no-op update returns False.
+    assert (
+        await ws.update_workspace(ws_row["id"], user["id"], bogus="x") is False
+    )
+    # Invalid setup_state raises.
+    with pytest.raises(ValueError):
+        await ws.update_workspace(
+            ws_row["id"], user["id"], setup_state="bogus"
+        )
+    # Wrong owner -> False.
+    assert (
+        await ws.update_workspace(ws_row["id"], "wrong", name="nope") is False
+    )
+
+
+async def test_transfer_workspace(ws, app_state, user):
+    new_owner = await app_state.model.users.create_user("new@x.com", "h")
+    ws_row = await ws.create_workspace_with_acl(user["id"], "transfer-me")
+    transferred = await ws.transfer_workspace(ws_row["id"], new_owner["id"])
+    assert transferred["user_id"] == new_owner["id"]
+    # Owner ACE + owners-group membership moved to the new owner.
+    from klangk_backend import model as _m
+
+    entries = await _m.get_acl_entries(f"/workspaces/{ws_row['id']}")
+    owner_ace = next(
+        e for e in entries if e["position"] == 0 and e["permission"] == "*"
+    )
+    assert owner_ace["user_id"] == new_owner["id"]
+
+
+async def test_transfer_workspace_guards(ws, app_state, user):
+    new_owner = await app_state.model.users.create_user("new2@x.com", "h")
+    ws_row = await ws.create_workspace_with_acl(user["id"], "guard-me")
+    # Agent principal cannot receive a workspace.
+    with pytest.raises(AgentPrincipalError):
+        await ws.transfer_workspace(ws_row["id"], AGENT_USER_ID)
+    # Already the owner.
+    with pytest.raises(ValueError, match="already the owner"):
+        await ws.transfer_workspace(ws_row["id"], user["id"])
+    # Duplicate name in target owner's set.
+    await ws.create_workspace_with_acl(new_owner["id"], "guard-me")
+    with pytest.raises(ValueError, match="already owns"):
+        await ws.transfer_workspace(ws_row["id"], new_owner["id"])
+    # Nonexistent workspace -> None.
+    assert await ws.transfer_workspace("missing", new_owner["id"]) is None
+
+
+async def test_get_user_workspaces_with_containers(ws, user):
+    assert await ws.get_user_workspaces_with_containers(user["id"]) == []
+    ws_row = await ws.create_workspace(user["id"], "with-container")
+    await ws.update_workspace_container(ws_row["id"], "cid-x")
+    result = await ws.get_user_workspaces_with_containers(user["id"])
+    assert [w["container_id"] for w in result] == ["cid-x"]
+
+
+async def test_list_auto_start_workspaces(ws, user):
+    await ws.create_workspace(user["id"], "manual")
+    # auto_start lives on the container/image config; set it via update.
+    auto = await ws.create_workspace(user["id"], "auto")
+    await ws.update_workspace(auto["id"], user["id"], auto_start=True)
+    started = await ws.list_auto_start_workspaces()
+    assert [w["name"] for w in started] == ["auto"]
+    assert started[0]["auto_start"] is True

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -750,8 +750,9 @@ class TestHandleTerminalStart:
                 ],
             ),
             patch.object(_mock_term, "attach_browser", new_callable=AsyncMock),
-            patch(
-                "klangk_backend.wshandler.controllers.model.get_workspace",
+            patch.object(
+                app_state.model.workspaces,
+                "get_workspace",
                 new=AsyncMock(return_value={"setup_state": "complete"}),
             ),
             patch.object(
@@ -1156,8 +1157,9 @@ class TestHandleTerminalStart:
                 "klangk_backend.wshandler.controllers.TerminalSession", MockTS
             ),
             patch.object(_mock_term, "attach_browser", new_callable=AsyncMock),
-            patch(
-                "klangk_backend.wshandler.controllers.model.get_workspace",
+            patch.object(
+                app_state.model.workspaces,
+                "get_workspace",
                 new=AsyncMock(return_value={"setup_state": "complete"}),
             ),
             patch.object(
@@ -5679,9 +5681,9 @@ class TestTerminalController:
 
     async def test_setup_state_db_error_defaults_to_complete(self):
         """If the setup_state lookup raises, default to 'complete'."""
-        ctrl, _, _ = self._controller()
+        ctrl, _, conn = self._controller()
         with patch.object(
-            _ws_controllers.model,
+            conn.app_state.model.workspaces,
             "get_workspace",
             new_callable=AsyncMock,
             side_effect=RuntimeError("db down"),
@@ -5691,9 +5693,9 @@ class TestTerminalController:
 
     async def test_setup_state_workspace_missing_defaults_to_complete(self):
         """If get_workspace returns None, default to 'complete'."""
-        ctrl, _, _ = self._controller()
+        ctrl, _, conn = self._controller()
         with patch.object(
-            _ws_controllers.model,
+            conn.app_state.model.workspaces,
             "get_workspace",
             new_callable=AsyncMock,
             return_value=None,
@@ -5703,9 +5705,9 @@ class TestTerminalController:
 
     async def test_setup_state_returns_workspace_value(self):
         """Returns the workspace's actual setup_state when present (#1033)."""
-        ctrl, _, _ = self._controller()
+        ctrl, _, conn = self._controller()
         with patch.object(
-            _ws_controllers.model,
+            conn.app_state.model.workspaces,
             "get_workspace",
             new_callable=AsyncMock,
             return_value={"setup_state": "pending"},
@@ -6269,8 +6271,9 @@ class TestTerminalController:
         ctrl, _, conn = self._controller()
         conn._service_command = "./run.sh"
         with (
-            patch(
-                "klangk_backend.wshandler.controllers.model.get_workspace",
+            patch.object(
+                conn.app_state.model.workspaces,
+                "get_workspace",
                 new=AsyncMock(return_value={"setup_state": "complete"}),
             ),
             patch.object(
@@ -7792,9 +7795,11 @@ class TestSharedTerminalController:
     async def test_delete_shared_terminal_other_user_denied(
         self, user, temp_data_dir
     ):
-        ctrl, sock, _ = self._controller(user=user)
-        with patch(
-            "klangk_backend.model.get_workspace_by_id", new=AsyncMock()
+        ctrl, sock, conn = self._controller(user=user)
+        with patch.object(
+            conn.app_state.model.workspaces,
+            "get_workspace_by_id",
+            new=AsyncMock(),
         ) as gw:
             gw.return_value = {"user_id": "someone-else"}
             await ctrl.delete_shared_terminal(
@@ -7837,8 +7842,9 @@ class TestSharedTerminalController:
             # model.get_workspace_by_id to authorize; return a workspace
             # owned by the current user so the delete is permitted.
             with (
-                patch(
-                    "klangk_backend.model.get_workspace_by_id",
+                patch.object(
+                    app_state.model.workspaces,
+                    "get_workspace_by_id",
                     new=AsyncMock(return_value={"user_id": user["id"]}),
                 ),
                 patch.object(_mock_term, "kill_joiner_sessions") as kill,


### PR DESCRIPTION
## Summary

Hoists the **workspaces** domain into `WorkspacesModel(app_state)` — split 4/7 of #1563. All 13 DB-bound workspace functions become methods on `app_state.model.workspaces` (reaching `self.app_state.db`), and the ~28 request-path call sites move to the composed path.

This mirrors the pattern established in #1572 (foundation) and #1573 (UsersModel): the module-level free functions stay as a `_current_db` ContextVar backstop until #1578 dissolves them, so the test suite and not-yet-converted callers keep working.

## What changed

**New `WorkspacesModel`** in `model/workspaces.py`:
- All 13 DB-bound functions (`create_workspace_with_acl`, `create_workspace`, `list_workspaces`, `list_shared_workspaces`, `get_workspace`, `get_workspace_by_id`, `get_workspace_members`, `delete_workspace`, `update_workspace_container`, `update_workspace`, `transfer_workspace`, `get_user_workspaces_with_containers`, `list_auto_start_workspaces`) become methods using `self.app_state.db`.
- The cross-domain call in `list_shared_workspaces` (which resolves the user's group IDs) now goes through `self.app_state.model.users.get_user_group_ids` instead of the module-level `get_user_group_ids`.
- Pure helpers (`sort_order_clause`, `SORT_COLUMNS`) and the `db`-param helpers (`_insert_workspace_row`, `_seed_workspace_acl`) stay module-level — the latter take a caller-supplied connection so they can run inside the atomic create-with-ACL transaction.

**`model/model.py`** — `self.workspaces = WorkspacesModel(app_state)` added to the `Model` composition root.

**28 call-site conversions** across 6 files (`workspaces.py`, `agent.py`, `container.py`, `api/workspaces.py`, `api/chat.py`, `wshandler/controllers.py`): `model.<ws-fn>(...)` → `app_state.model.workspaces.<ws-fn>(...)`. The `get_workspace_members` endpoint gained a `Depends(get_app_state_dep)`; `container.py` dropped its now-dead `model` import.

## Tests

- **`test_model_workspaces.py`** (new) — direct coverage of every `WorkspacesModel` method, including the cross-domain shared-workspace listing, the agent-principal / setup-state guards, and role-group teardown.
- **`TestWorkspacesBackstopBranches`** in `test_model.py` — covers free-function branches that lost their app-code callers (`get_workspace_by_id`, `transfer_workspace` + guards, invalid-`setup_state`, `list_workspaces` q-filter, role-group teardown in `delete_workspace`).
- Retargeted stale mocks in `test_agent.py` / `test_wshandler.py` / `test_api.py` that patched the module-level `model.<ws-fn>` to patch `app_state.model.workspaces.<ws-fn>` instead (the controller/agent code now reads from the instance, not the module).

Backend suite green at 100% coverage (2455 passed, `-n auto`); CLI suite unchanged (486 passed, 100%).

## Notes

- No behavior change — same DB, same queries; this is purely about *how* code reaches the DB.
- Rebases cleanly onto #1574 (`ACLModel`, which landed during this work) — the only overlap was `model/model.py` (both add sub-objects to `Model.__init__`) and `test_model.py` (both append a backstop-branches test class).
- Closes #1575. The ContextVar backstop stays in place for #1578 to dissolve.
