### PR TITLE
fix(e2e): generous per-test timeout for backend E2E suite (#1591)

### DIFF
--- a/src/backend/e2e-tests/conftest.py
+++ b/src/backend/e2e-tests/conftest.py
@@ -7,4 +7,40 @@ would fight a dev nginx). Every server launch builds its env via
 ``clean_env(...)`` — no ``os.environ`` spread, so stray vars can't leak
 (#1526). Tests that need ``none`` mode pass ``KLANGK_AUTH_MODES="none"`` in
 their ``clean_env()`` overrides.
+
+Per-test timeout
+----------------
+The repo-wide ``--timeout=60`` (set in ``src/backend/pyproject.toml`` addopts,
+#1513) is sized for the *unit* suites. E2E tests spin up real podman
+containers: bringup (``container_ready``) plus teardown (the workspace DELETE
+that stops+removes the container) can legitimately exceed 60s on a loaded
+runner, and the 60s cap races the teardown ``finally`` inside the test body
+(the cap covers the whole call phase, body included). pytest-timeout then
+kills the process mid-cleanup — surfacing as a spurious "Timeout (>60.0s)"
+on a test whose assertion already passed (#1591).
+
+``pytest_collection_modifyitems`` stamps a generous per-test timeout on every
+E2E test that doesn't set its own, so container-spinning tests get headroom
+without each author having to remember ``@pytest.mark.timeout(...)``. A
+per-test ``timeout`` marker overrides the global ``--timeout`` (pytest-timeout
+resolves the closest marker first).
 """
+
+import pytest
+
+# Real containers need real time: bringup + exec + teardown (stop+rm the
+# podman container via the workspace DELETE) can run well past the unit
+# suite's 60s cap on a loaded GitHub-hosted runner. 300s leaves ample
+# headroom while still bounding a genuinely-hung test.
+_E2E_TIMEOUT_SECONDS = 300
+
+
+def pytest_collection_modifyitems(config, items):
+    """Give every E2E test a generous per-test timeout (#1591).
+
+    Only stamps tests without an explicit ``timeout`` marker, so a test
+    that deliberately pins a tighter/looser budget keeps it.
+    """
+    for item in items:
+        if item.get_closest_marker("timeout") is None:
+            item.add_marker(pytest.mark.timeout(_E2E_TIMEOUT_SECONDS))


### PR DESCRIPTION
## Summary

Fixes #1591.

The repo-wide `--timeout=60` (set in `src/backend/pyproject.toml` `addopts`, #1513) is sized for the **unit** suites, but it also applies to the backend E2E suite (the `test-backend-e2e` task only overrides coverage with `--no-cov`, not the timeout). E2E tests spin up real podman containers: bringup (`container_ready`) plus teardown (the workspace DELETE that stops+removes the container) legitimately exceeds 60s on a loaded GitHub-hosted runner, and the 60s cap races the teardown `finally` inside the test body — the cap covers the whole call phase, body included. pytest-timeout then kills the process mid-cleanup, surfacing as a spurious `Timeout (>60.0s)` on a test whose assertion already passed.

## Changes

`src/backend/e2e-tests/conftest.py` gains a `pytest_collection_modifyitems` hook that stamps a **300s** per-test timeout on every E2E test that doesn't set its own:

```python
def pytest_collection_modifyitems(config, items):
    for item in items:
        if item.get_closest_marker("timeout") is None:
            item.add_marker(pytest.mark.timeout(300))
```

A per-test `timeout` marker overrides the global `--timeout` (pytest-timeout resolves the closest marker first — confirmed in `pytest_timeout._get_item_settings`), so container-spinning tests get headroom **without** each author having to remember `@pytest.mark.timeout(...)`. Tests that deliberately pin a tighter/looser budget keep it (the `is None` guard skips already-marked items).

This travels with the tests — works via the devenv task, direct `pytest`, or CI — and future-proofs new container-spinning E2E tests against the same flake.

## Verification

- Throwaway probe confirmed: an unmarked E2E test gets `timeout(300)`, and an explicit `@pytest.mark.timeout(10)` is preserved (not clobbered). Probe deleted after.
- Backend E2E suite collects cleanly (98 tests, conftest imports without error).
- Unit suites unchanged: **2455 passed, 100% coverage** (`-n auto`).

## Notes

- No changelog entry — test-infra fix with no user-visible effect, consistent with prior flaky-test fixes (#1570, #1583).
- The E2E suite itself isn't run locally (needs podman + built workspace image; a human-facing workflow). The fix is verified structurally (marker logic + collection + unit green); CI will exercise the real container paths.
