### PR TITLE
feat(acl): hoist klangk_backend/acl.py FastAPI layer into ACL(app_state) (#1577)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -205,6 +205,25 @@ operators or integrators to act when upgrading.
   behavior change — same DB, same queries; this is the fourth slice of
   #1563.
 
+- **`ACL(app_state)` class for the FastAPI permission layer (#1577).**
+  The top-level `klangk_backend/acl.py` (the resource-tree walk +
+  `Depends` permission dependency, **not** `model/acl.py`) is now an
+  `app.state.acl = ACL(app.state)` instance. The three DB-touching
+  functions (`get_principals`, `check_permission`,
+  `permissions_for_resources`) become methods reaching
+  `self.app_state.model.{users,acl}`. The `has_permission(perm,
+resource_fn)` dependency factory stays module-level (it's built at
+  route-definition time and can't close over an instance); its closure
+  resolves `request.app.state.acl` per request, exactly like
+  `auth.get_current_user` resolving `request.app.state.auth` — so all
+  ~50 `Depends(acl.has_permission(...))` call sites are unchanged. The
+  two direct callers (`api/__init__.py` `/my-permissions`, the WebSocket
+  connection layer) now go through `app_state.acl.*`. The pure helpers
+  (`ace_matches_principals`, `resource_ancestors`,
+  `check_permission_inmemory`, `request_to_resource`) and the
+  module-level free-function backstops stay until #1578. No behavior
+  change — this is the sixth slice of #1563.
+
 - **`Model(app_state)` composition root introduced (#1572).** A new
   `app.state.model = Model(app.state)` (wired in `build_app` after
   `app.state.db`) composes the per-domain data-access sub-objects.

--- a/src/backend/klangk_backend/acl.py
+++ b/src/backend/klangk_backend/acl.py
@@ -184,18 +184,128 @@ def has_permission(permission: str, resource_fn=None):
 
     resource_fn: optional async callable(request, user) -> resource_path.
     If not provided, the resource is derived from the request URL path.
+
+    The permission check runs on the request's ``ACL(app_state)`` instance
+    (``request.app.state.acl``) — the same shape as ``auth.get_current_user``
+    resolving ``request.app.state.auth``. The dependency is built at route
+    definition time, so the instance is resolved per-request rather than
+    closed over (#1577).
     """
 
     async def check(
         request: Request, user: dict = Depends(auth.get_current_user)
     ) -> dict:
+        acl = request.app.state.acl
         if resource_fn:
             resource = await resource_fn(request, user)
         else:
             resource = request_to_resource(request)
-        principals = await get_principals(user["id"])
-        if not await check_permission(resource, principals, permission):
+        principals = await acl.get_principals(user["id"])
+        if not await acl.check_permission(resource, principals, permission):
             raise HTTPException(status_code=403, detail="Permission denied")
         return user
 
     return check
+
+
+# ---------------------------------------------------------------------------
+# ACL(app_state): the app_state-owned permission layer.
+#
+# This is the one genuinely new class the #1563 hoist forces (#1577): the
+# FastAPI permission layer in this module reaches the model layer's DB
+# delegates (``model.get_user_group_ids``, ``model.get_acl_entries_map``),
+# so once those become ``Model(app_state)`` methods the layer needs
+# ``app_state`` too. ``ACL(app_state)`` is wired in ``build_app`` as
+# ``app.state.acl = ACL(app_state)`` alongside the other owned instances.
+#
+# The DB-touching entry points (``get_principals``, ``check_permission``,
+# ``permissions_for_resources``) become methods reaching
+# ``self.app_state.model.{users,acl}``. The FastAPI dependency factory
+# ``has_permission`` stays module-level (it's built at route-definition
+# time and can't close over an instance); its closure resolves
+# ``request.app.state.acl`` per request, exactly like
+# ``auth.get_current_user`` resolving ``request.app.state.auth``.
+#
+# The module-level free-function backstops above stay until #1578
+# dissolves the ``_current_db`` ContextVar; they're still used by the test
+# suite (``test_acl.py`` calls ``get_principals`` / ``check_permission``
+# directly). The pure helpers (``ace_matches_principals``, ``resource_ancestors``,
+# ``check_permission_inmemory``, ``request_to_resource``) are stateless and
+# stay module-level — the methods below reuse them.
+# ---------------------------------------------------------------------------
+
+
+class ACL:
+    """FastAPI permission layer, resolved through ``app_state.model.*``.
+
+    Constructed once at startup (``app.state.acl = ACL(app_state)``) and
+    reached per-request via ``request.app.state.acl`` (by the
+    ``has_permission`` dependency factory) or directly as ``app_state.acl``
+    (by handlers / the WebSocket connection layer). Reaches the DB through
+    ``self.app_state.model`` — the single owned ``Model`` instance.
+    """
+
+    def __init__(self, app_state):
+        self.app_state = app_state
+
+    async def get_principals(self, user_id: str) -> dict:
+        """Build principal info for the given user."""
+        group_ids = await self.app_state.model.users.get_user_group_ids(
+            user_id
+        )
+        return {
+            "user_id": user_id,
+            "group_ids": group_ids,
+            "authenticated": True,
+        }
+
+    async def check_permission(
+        self,
+        resource_path: str,
+        principals: dict,
+        permission: str,
+    ) -> bool:
+        """Walk from resource_path up to root, checking ACEs.
+
+        Returns True if an Allow ACE matches, False if a Deny ACE matches
+        or no match is found (default deny). Fetches the ACEs for every
+        ancestor of ``resource_path`` in a single query and evaluates them
+        in memory via :func:`check_permission_inmemory`. Nothing is
+        retained across requests.
+        """
+        entries = await self.app_state.model.acl.get_acl_entries_map(
+            resource_ancestors(resource_path)
+        )
+        return check_permission_inmemory(
+            resource_path, principals, permission, entries
+        )
+
+    async def permissions_for_resources(
+        self,
+        resources: list[str],
+        principals: dict,
+        permissions: list[str],
+    ) -> dict[str, list[str]]:
+        """Effective permissions for each resource, preload-then-evaluate.
+
+        Fetches ACL entries for the union of every resource's ancestor
+        paths in a single query, then checks each (resource, permission)
+        pair in memory. Only resources with at least one granted
+        permission appear in the result.
+        """
+        ancestor_paths: list[str] = []
+        for res in resources:
+            ancestor_paths.extend(resource_ancestors(res))
+        entries = await self.app_state.model.acl.get_acl_entries_map(
+            ancestor_paths
+        )
+        result: dict[str, list[str]] = {}
+        for res in resources:
+            perms = [
+                p
+                for p in permissions
+                if check_permission_inmemory(res, principals, p, entries)
+            ]
+            if perms:
+                result[res] = perms
+        return result

--- a/src/backend/klangk_backend/api/__init__.py
+++ b/src/backend/klangk_backend/api/__init__.py
@@ -38,7 +38,6 @@ from fastapi.responses import PlainTextResponse
 from pydantic import BaseModel
 
 from .. import (
-    acl,
     container,
     emailsvc,
     oidc,
@@ -269,10 +268,10 @@ async def my_permissions(
     specific resource path (e.g., ``/workspaces/{id}``). Otherwise
     returns permissions for all static resources.
     """
-    principals = await acl.get_principals(user["id"])
+    principals = await request.app.state.acl.get_principals(user["id"])
     groups = await request.app.state.model.users.get_user_groups(user["id"])
     if resource is not None:
-        permissions = await acl.permissions_for_resources(
+        permissions = await request.app.state.acl.permissions_for_resources(
             [resource], principals, ALL_PERMISSIONS
         )
         perms = permissions.get(resource, [])
@@ -284,7 +283,7 @@ async def my_permissions(
         }
     # Batch all static resources into a single ACL query instead of
     # awaiting check_permission() per resource/permission pair.
-    permissions = await acl.permissions_for_resources(
+    permissions = await request.app.state.acl.permissions_for_resources(
         STATIC_RESOURCES, principals, ALL_PERMISSIONS
     )
     return {

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -17,6 +17,7 @@ from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 from . import (
+    acl,
     agent,
     auth,
     container,
@@ -626,6 +627,12 @@ def build_app(settings: KlangkSettings) -> FastAPI:
     # domains still go through the _current_db ContextVar backstop.
     app.state.model = model.Model(app.state)
     app.state.agents = agent.Agents(app.state)
+    # #1577: ACL(app_state) owns the FastAPI permission layer — the
+    # resource-tree walk / principal resolution that the ``has_permission``
+    # dependency (resolved per-request from ``request.app.state.acl``) and
+    # the WebSocket connection layer delegate to. Reached through
+    # ``self.app_state.model.{users,acl}``, so wired after ``app.state.model``.
+    app.state.acl = acl.ACL(app.state)
     # #1483: EmailService(app_state) owns SMTP/sendmail transport + the
     # Jinja template env (previously module-level functions reading
     # resolve_env_value at call time).

--- a/src/backend/klangk_backend/wshandler/__init__.py
+++ b/src/backend/klangk_backend/wshandler/__init__.py
@@ -16,7 +16,6 @@ those submodules so existing call sites keep working unchanged, e.g.::
 # Re-export sibling modules so that existing patch targets like
 # ``klangk_backend.wshandler.auth`` and ``wshandler.model`` keep
 # working — the old monolith imported them at module level.
-from .. import acl as _acl  # noqa: F401
 from .. import auth as auth  # noqa: F401
 from .. import container as container  # noqa: F401
 from .. import model as model  # noqa: F401

--- a/src/backend/klangk_backend/wshandler/connection.py
+++ b/src/backend/klangk_backend/wshandler/connection.py
@@ -6,7 +6,6 @@ import time
 from datetime import datetime, timedelta, timezone
 
 
-from .. import acl as _acl
 from .. import container, model
 from ..terminal import TerminalSession
 from ..podman import ExecSession
@@ -423,8 +422,8 @@ class Connection:
             send_error(self.sock, "Missing workspaceId")
             return
 
-        principals = await _acl.get_principals(self.user["id"])
-        if not await _acl.check_permission(
+        principals = await self.app_state.acl.get_principals(self.user["id"])
+        if not await self.app_state.acl.check_permission(
             f"/workspaces/{workspace_id}", principals, "terminal"
         ):
             send_error(self.sock, "Permission denied")
@@ -639,8 +638,8 @@ class Connection:
         """Check if the connected user has a workspace permission."""
         if not self.workspace_id:
             return False
-        principals = await _acl.get_principals(self.user["id"])
-        return await _acl.check_permission(
+        principals = await self.app_state.acl.get_principals(self.user["id"])
+        return await self.app_state.acl.check_permission(
             f"/workspaces/{self.workspace_id}", principals, perm
         )
 

--- a/src/backend/tests/_helpers.py
+++ b/src/backend/tests/_helpers.py
@@ -32,13 +32,16 @@ def make_settings(
 
 
 def wire_db_and_model(state) -> None:
-    """Attach ``db`` + ``model`` to a test ``app_state`` namespace (#1572).
+    """Attach ``db`` + ``model`` + ``acl`` to a test ``app_state`` namespace.
 
     App code reaches the converted domains (tokens, login_attempts,
     invitations, ports) via ``app_state.model.<domain>.<method>``, which
-    resolves ``self.app_state.db``. Every test that builds an ``app_state``
-    namespace and constructs an owned instance that touches those domains
-    (``Auth``, ``ContainerRegistry``, …) must wire both.
+    resolves ``self.app_state.db``. The FastAPI permission layer
+    (``ACL(app_state)``, #1577) reaches ``app_state.model.{users,acl}``, so
+    any test that builds an ``app_state`` namespace and exercises a request
+    / WebSocket path must wire ``acl`` too. Every test that builds an
+    ``app_state`` namespace and constructs an owned instance that touches
+    those domains (``Auth``, ``ContainerRegistry``, …) must wire all three.
 
     Reuses the ContextVar-bound DB when one exists (the autouse
     ``temp_data_dir`` fixture binds it and runs ``init_db`` against it), so
@@ -49,6 +52,7 @@ def wire_db_and_model(state) -> None:
     """
     from klangk_backend.model import Model
     from klangk_backend.model.db import DB, get_current_db
+    from klangk_backend.acl import ACL
 
     if getattr(state, "db", None) is None:
         try:
@@ -57,3 +61,5 @@ def wire_db_and_model(state) -> None:
             state.db = DB(state.settings)
     if getattr(state, "model", None) is None:
         state.model = Model(state)
+    if getattr(state, "acl", None) is None:
+        state.acl = ACL(state)

--- a/src/backend/tests/test_acl_app_state.py
+++ b/src/backend/tests/test_acl_app_state.py
@@ -1,0 +1,201 @@
+"""Direct coverage for ``ACL(app_state)`` — the FastAPI permission layer (#1577).
+
+Exercises the three DB-touching methods on ``app_state.acl``
+(``get_principals``, ``check_permission``, ``permissions_for_resources``),
+which reach the model layer through ``self.app_state.model.{users,acl}`` —
+and the ``has_permission`` dependency factory, whose closure resolves
+``request.app.state.acl`` per request. Mirrors the #1572–#1575
+``test_model_*`` pattern: ``app_state`` (db + model + acl wired via the
+ContextVar DB) with the schema initialized.
+"""
+
+import pytest
+
+from klangk_backend import acl
+from klangk_backend.model import (
+    ACTION_ALLOW,
+    ACTION_DENY,
+    PRINCIPAL_GROUP,
+    PRINCIPAL_SYSTEM,
+    PRINCIPAL_USER,
+    SYSTEM_AUTHENTICATED,
+)
+
+
+@pytest.fixture
+async def ac(app_state, db):
+    """``app_state.acl`` with the schema initialized."""
+    return app_state.acl
+
+
+async def test_get_principals(ac, user):
+    from klangk_backend import model
+
+    group = await model.create_group("g")
+    await model.add_user_to_group(user["id"], group["id"])
+    principals = await ac.get_principals(user["id"])
+    assert principals == {
+        "user_id": user["id"],
+        "group_ids": [group["id"]],
+        "authenticated": True,
+    }
+
+
+async def test_check_permission_allow_and_deny(ac, user):
+    from klangk_backend import model
+
+    # Allow on exact resource via user principal.
+    await model.add_acl_entry(
+        "/ws-allow",
+        0,
+        ACTION_ALLOW,
+        "view",
+        PRINCIPAL_USER,
+        user_id=user["id"],
+    )
+    principals = await ac.get_principals(user["id"])
+    assert await ac.check_permission("/ws-allow", principals, "view") is True
+    # Wrong permission -> not granted (default deny).
+    assert await ac.check_permission("/ws-allow", principals, "edit") is False
+
+    # Deny wins over a deeper allow (first-match-wins on the walked path).
+    await model.add_acl_entry(
+        "/ws-deny",
+        0,
+        ACTION_DENY,
+        "view",
+        PRINCIPAL_SYSTEM,
+        system_principal=SYSTEM_AUTHENTICATED,
+    )
+    assert await ac.check_permission("/ws-deny", principals, "view") is False
+
+
+async def test_check_permission_walks_to_parent(ac, user):
+    from klangk_backend import model
+
+    # Allow at the parent; a child resource inherits it via the walk.
+    await model.add_acl_entry(
+        "/parent",
+        0,
+        ACTION_ALLOW,
+        "view",
+        PRINCIPAL_USER,
+        user_id=user["id"],
+    )
+    principals = await ac.get_principals(user["id"])
+    assert (
+        await ac.check_permission("/parent/child", principals, "view") is True
+    )
+    # No matching ancestor -> default deny.
+    assert await ac.check_permission("/unrelated", principals, "view") is False
+
+
+async def test_permissions_for_resources(ac, user):
+    from klangk_backend import model
+
+    await model.add_acl_entry(
+        "/r1",
+        0,
+        ACTION_ALLOW,
+        "view",
+        PRINCIPAL_USER,
+        user_id=user["id"],
+    )
+    await model.add_acl_entry(
+        "/r2",
+        0,
+        ACTION_ALLOW,
+        "*",
+        PRINCIPAL_USER,
+        user_id=user["id"],
+    )
+    principals = await ac.get_principals(user["id"])
+    result = await ac.permissions_for_resources(
+        ["/r1", "/r2", "/r3"], principals, ["view", "edit"]
+    )
+    # /r1 grants only view; /r2 grants both (wildcard); /r3 grants nothing.
+    assert result == {"/r1": ["view"], "/r2": ["view", "edit"]}
+    # Empty resource list -> empty result (no query needed).
+    assert await ac.permissions_for_resources([], principals, ["view"]) == {}
+
+
+async def test_permissions_for_resources_via_group(ac, user):
+    from klangk_backend import model
+
+    group = await model.create_group("editors")
+    await model.add_user_to_group(user["id"], group["id"])
+    await model.add_acl_entry(
+        "/grp-res",
+        0,
+        ACTION_ALLOW,
+        "terminal",
+        PRINCIPAL_GROUP,
+        group_id=group["id"],
+    )
+    principals = await ac.get_principals(user["id"])
+    result = await ac.permissions_for_resources(
+        ["/grp-res"], principals, ["terminal", "files"]
+    )
+    assert result == {"/grp-res": ["terminal"]}
+
+
+async def test_has_permission_allows(ac, user):
+    """The dependency factory resolves request.app.state.acl and returns
+    the user when the permission check passes."""
+    import types
+
+    from unittest.mock import AsyncMock
+
+    # Fake a request whose app.state.acl.check_permission returns True.
+    fake_app = types.SimpleNamespace(state=types.SimpleNamespace(acl=ac))
+    ac.check_permission = AsyncMock(return_value=True)
+    ac.get_principals = AsyncMock(
+        return_value={
+            "user_id": user["id"],
+            "group_ids": [],
+            "authenticated": True,
+        }
+    )
+    request = types.SimpleNamespace(
+        app=fake_app, url=types.SimpleNamespace(path="/api/v1/workspaces/ws-1")
+    )
+    dep = acl.has_permission("terminal")
+    result = await dep(request, user)
+    assert result is user
+    ac.check_permission.assert_awaited_once()
+    # The resource was derived from the request URL path.
+    _res, _principals, _perm = ac.check_permission.call_args.args
+    assert _res == "/workspaces/ws-1"
+    assert _perm == "terminal"
+
+
+async def test_has_permission_denies_via_resource_fn(ac, user):
+    """When denied, the dependency raises 403; a resource_fn overrides the
+    path-derived resource."""
+    import types
+
+    from unittest.mock import AsyncMock
+
+    from fastapi import HTTPException
+
+    fake_app = types.SimpleNamespace(state=types.SimpleNamespace(acl=ac))
+    ac.check_permission = AsyncMock(return_value=False)
+    ac.get_principals = AsyncMock(
+        return_value={
+            "user_id": user["id"],
+            "group_ids": [],
+            "authenticated": True,
+        }
+    )
+    request = types.SimpleNamespace(app=fake_app)
+
+    async def _resource_fn(req, u):
+        return "/custom-resource"
+
+    dep = acl.has_permission("share", _resource_fn)
+    with pytest.raises(HTTPException) as exc:
+        await dep(request, user)
+    assert exc.value.status_code == 403
+    _res, _principals, _perm = ac.check_permission.call_args.args
+    assert _res == "/custom-resource"
+    assert _perm == "share"

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -17,6 +17,7 @@ from fastapi import WebSocketDisconnect
 
 from klangk_backend import (
     agent as agent_mod,
+    acl as acl_mod,
     auth as auth_mod,
     emailsvc as emailsvc_mod,
     files as files_mod,
@@ -6461,8 +6462,10 @@ class TestShareWindowHandlers:
         ]
         await session.add_subscriber(sock, "cid")
         try:
-            with patch(
-                "klangk_backend.acl.check_permission", return_value=True
+            with patch.object(
+                acl_mod.ACL,
+                "check_permission",
+                new=AsyncMock(return_value=True),
             ):
                 await conn.handle_share_window({"window_id": "@1"})
             assert session.terminal_windows[user["id"]][1]["shared"] is True
@@ -6480,7 +6483,9 @@ class TestShareWindowHandlers:
         conn.workspace_id = "ws-1"
         conn.container_id = "cid"
         conn._user_home = "/home/admin"
-        with patch("klangk_backend.acl.check_permission", return_value=False):
+        with patch.object(
+            acl_mod.ACL, "check_permission", new=AsyncMock(return_value=False)
+        ):
             await conn.handle_share_window({"window_id": "@0"})
         calls = [c[0][0] for c in sock.send_json.call_args_list]
         assert any("Permission" in c.get("message", "") for c in calls)
@@ -6500,8 +6505,10 @@ class TestShareWindowHandlers:
         await session.add_subscriber(sock, "cid")
         try:
             with (
-                patch(
-                    "klangk_backend.acl.check_permission", return_value=True
+                patch.object(
+                    acl_mod.ACL,
+                    "check_permission",
+                    new=AsyncMock(return_value=True),
                 ),
                 patch.object(_mock_term, "kill_joiner_sessions") as mock_kill,
             ):
@@ -6524,8 +6531,10 @@ class TestShareWindowHandlers:
                 {"name": "1", "index": 0, "id": "@0", "shared": False},
                 {"name": "build", "index": 1, "id": "@1", "shared": True},
             ]
-            with patch(
-                "klangk_backend.acl.check_permission", return_value=True
+            with patch.object(
+                acl_mod.ACL,
+                "check_permission",
+                new=AsyncMock(return_value=True),
             ):
                 await conn.handle_list_shared_terminals()
             calls = [c[0][0] for c in sock.send_json.call_args_list]
@@ -6571,8 +6580,10 @@ class TestShareWindowHandlers:
         sockets.connections[owner_sock] = owner_conn
         sockets.connections[viewer_sock] = viewer_conn
         try:
-            with patch(
-                "klangk_backend.acl.check_permission", return_value=True
+            with patch.object(
+                acl_mod.ACL,
+                "check_permission",
+                new=AsyncMock(return_value=True),
             ):
                 await owner_conn.handle_list_shared_terminals()
             calls = [c[0][0] for c in owner_sock.send_json.call_args_list]
@@ -6608,8 +6619,10 @@ class TestShareWindowHandlers:
                 {"name": "1", "index": 0, "id": "@0", "shared": False}
             ]
             with (
-                patch(
-                    "klangk_backend.acl.check_permission", return_value=True
+                patch.object(
+                    acl_mod.ACL,
+                    "check_permission",
+                    new=AsyncMock(return_value=True),
                 ),
                 patch.object(
                     _mock_term,
@@ -6645,7 +6658,9 @@ class TestShareWindowHandlers:
         conn.container_id = "cid"
         conn._user_home = "/home/admin"
         conn.workspace_id = "ws-1"
-        with patch("klangk_backend.acl.check_permission", return_value=True):
+        with patch.object(
+            acl_mod.ACL, "check_permission", new=AsyncMock(return_value=True)
+        ):
             await conn.handle_share_window({})
         calls = [c[0][0] for c in sock.send_json.call_args_list]
         assert any("id" in c.get("message", "").lower() for c in calls)
@@ -6663,8 +6678,10 @@ class TestShareWindowHandlers:
             {"name": "1", "index": 0, "id": "@0", "shared": False}
         ]
         try:
-            with patch(
-                "klangk_backend.acl.check_permission", return_value=True
+            with patch.object(
+                acl_mod.ACL,
+                "check_permission",
+                new=AsyncMock(return_value=True),
             ):
                 await conn.handle_share_window({"window_id": "@99"})
             calls = [c[0][0] for c in sock.send_json.call_args_list]
@@ -6680,7 +6697,9 @@ class TestShareWindowHandlers:
         conn.container_id = "cid"
         conn._user_home = "/home/admin"
         conn.workspace_id = "no-session-ws"
-        with patch("klangk_backend.acl.check_permission", return_value=True):
+        with patch.object(
+            acl_mod.ACL, "check_permission", new=AsyncMock(return_value=True)
+        ):
             await conn.handle_share_window({"window_id": "@0"})
         # No error — early return
 
@@ -6693,7 +6712,9 @@ class TestShareWindowHandlers:
         conn = _base_conn(user=user, ws=sock)
         conn.container_id = "cid"
         conn._user_home = "/home/admin"
-        with patch("klangk_backend.acl.check_permission", return_value=False):
+        with patch.object(
+            acl_mod.ACL, "check_permission", new=AsyncMock(return_value=False)
+        ):
             await conn.handle_unshare_window({"window_id": "@0"})
         calls = [c[0][0] for c in sock.send_json.call_args_list]
         assert any("Permission" in c.get("message", "") for c in calls)
@@ -6704,7 +6725,9 @@ class TestShareWindowHandlers:
         conn.container_id = "cid"
         conn._user_home = "/home/admin"
         conn.workspace_id = "ws-1"
-        with patch("klangk_backend.acl.check_permission", return_value=True):
+        with patch.object(
+            acl_mod.ACL, "check_permission", new=AsyncMock(return_value=True)
+        ):
             await conn.handle_unshare_window({})
         calls = [c[0][0] for c in sock.send_json.call_args_list]
         assert any("id" in c.get("message", "").lower() for c in calls)
@@ -6722,8 +6745,10 @@ class TestShareWindowHandlers:
             {"name": "1", "index": 0, "id": "@0", "shared": True}
         ]
         try:
-            with patch(
-                "klangk_backend.acl.check_permission", return_value=True
+            with patch.object(
+                acl_mod.ACL,
+                "check_permission",
+                new=AsyncMock(return_value=True),
             ):
                 await conn.handle_unshare_window({"window_id": "@99"})
             calls = [c[0][0] for c in sock.send_json.call_args_list]
@@ -6739,7 +6764,9 @@ class TestShareWindowHandlers:
         conn.container_id = "cid"
         conn._user_home = "/home/admin"
         conn.workspace_id = "no-session-ws"
-        with patch("klangk_backend.acl.check_permission", return_value=True):
+        with patch.object(
+            acl_mod.ACL, "check_permission", new=AsyncMock(return_value=True)
+        ):
             await conn.handle_unshare_window({"window_id": "@0"})
 
     async def test_unshare_kill_error_handled(self, user):
@@ -6757,8 +6784,10 @@ class TestShareWindowHandlers:
         await session.add_subscriber(sock, "cid")
         try:
             with (
-                patch(
-                    "klangk_backend.acl.check_permission", return_value=True
+                patch.object(
+                    acl_mod.ACL,
+                    "check_permission",
+                    new=AsyncMock(return_value=True),
                 ),
                 patch.object(
                     _mock_term,
@@ -6790,8 +6819,10 @@ class TestShareWindowHandlers:
         registry.track_activity("cid", "ws-1")
         try:
             with (
-                patch(
-                    "klangk_backend.acl.check_permission", return_value=True
+                patch.object(
+                    acl_mod.ACL,
+                    "check_permission",
+                    new=AsyncMock(return_value=True),
                 ),
                 patch.object(_ws_controllers, "TerminalSession") as MockTS,
                 patch.object(_mock_term, "select_window"),
@@ -6846,8 +6877,10 @@ class TestShareWindowHandlers:
         registry.track_activity("cid", "ws-1")
         try:
             with (
-                patch(
-                    "klangk_backend.acl.check_permission", return_value=True
+                patch.object(
+                    acl_mod.ACL,
+                    "check_permission",
+                    new=AsyncMock(return_value=True),
                 ),
                 patch.object(_ws_controllers, "TerminalSession") as MockTS,
                 patch.object(_mock_term, "select_window"),
@@ -6894,7 +6927,9 @@ class TestShareWindowHandlers:
         conn = _base_conn(user=user, ws=sock)
         conn.container_id = "cid"
         conn._user_home = "/home/x"
-        with patch("klangk_backend.acl.check_permission", return_value=False):
+        with patch.object(
+            acl_mod.ACL, "check_permission", new=AsyncMock(return_value=False)
+        ):
             await conn.handle_join_shared_terminal(
                 {"user_id": "x", "window_id": "@99"}
             )
@@ -6907,7 +6942,9 @@ class TestShareWindowHandlers:
         conn.container_id = "cid"
         conn._user_home = "/home/x"
         conn.workspace_id = "ws-1"
-        with patch("klangk_backend.acl.check_permission", return_value=True):
+        with patch.object(
+            acl_mod.ACL, "check_permission", new=AsyncMock(return_value=True)
+        ):
             await conn.handle_join_shared_terminal({})
         calls = [c[0][0] for c in sock.send_json.call_args_list]
         assert any("required" in c.get("message", "").lower() for c in calls)
@@ -6937,8 +6974,10 @@ class TestShareWindowHandlers:
 
         try:
             with (
-                patch(
-                    "klangk_backend.acl.check_permission", return_value=True
+                patch.object(
+                    acl_mod.ACL,
+                    "check_permission",
+                    new=AsyncMock(return_value=True),
                 ),
                 patch.object(_ws_controllers, "TerminalSession") as MockTS,
                 patch.object(
@@ -6987,8 +7026,10 @@ class TestShareWindowHandlers:
 
         try:
             with (
-                patch(
-                    "klangk_backend.acl.check_permission", return_value=True
+                patch.object(
+                    acl_mod.ACL,
+                    "check_permission",
+                    new=AsyncMock(return_value=True),
                 ),
                 patch.object(_ws_controllers, "TerminalSession") as MockTS,
                 patch.object(
@@ -7050,8 +7091,10 @@ class TestShareWindowHandlers:
 
         try:
             with (
-                patch(
-                    "klangk_backend.acl.check_permission", return_value=True
+                patch.object(
+                    acl_mod.ACL,
+                    "check_permission",
+                    new=AsyncMock(return_value=True),
                 ),
                 patch.object(_ws_controllers, "TerminalSession") as MockTS,
                 patch.object(
@@ -7100,8 +7143,10 @@ class TestShareWindowHandlers:
         ]
         try:
             with (
-                patch(
-                    "klangk_backend.acl.check_permission", return_value=True
+                patch.object(
+                    acl_mod.ACL,
+                    "check_permission",
+                    new=AsyncMock(return_value=True),
                 ),
                 patch.object(_ws_controllers, "TerminalSession") as MockTS,
             ):
@@ -7128,7 +7173,9 @@ class TestShareWindowHandlers:
         conn.container_id = "cid"
         conn._user_home = "/home/x"
         conn.workspace_id = "no-session"
-        with patch("klangk_backend.acl.check_permission", return_value=True):
+        with patch.object(
+            acl_mod.ACL, "check_permission", new=AsyncMock(return_value=True)
+        ):
             await conn.handle_join_shared_terminal(
                 {"user_id": "x", "window_id": "@99"}
             )
@@ -7144,8 +7191,10 @@ class TestShareWindowHandlers:
         conn.workspace_id = "ws-1"
         sockets.get_or_create_session("ws-1", app_state)
         try:
-            with patch(
-                "klangk_backend.acl.check_permission", return_value=True
+            with patch.object(
+                acl_mod.ACL,
+                "check_permission",
+                new=AsyncMock(return_value=True),
             ):
                 await conn.handle_join_shared_terminal(
                     {"user_id": "nobody", "window_id": "@99"}
@@ -7166,8 +7215,10 @@ class TestShareWindowHandlers:
                 {"name": "build", "index": 1, "id": "@1", "shared": True},
             ]
             with (
-                patch(
-                    "klangk_backend.acl.check_permission", return_value=True
+                patch.object(
+                    acl_mod.ACL,
+                    "check_permission",
+                    new=AsyncMock(return_value=True),
                 ),
                 patch.object(_mock_term, "kill_joiner_sessions"),
                 patch.object(_mock_term, "close_window", return_value=[]),
@@ -7189,7 +7240,9 @@ class TestShareWindowHandlers:
         sock = _mock_sock()
         conn = _base_conn(user=user, ws=sock)
         conn.container_id = "cid"
-        with patch("klangk_backend.acl.check_permission", return_value=False):
+        with patch.object(
+            acl_mod.ACL, "check_permission", new=AsyncMock(return_value=False)
+        ):
             await conn.handle_delete_shared_terminal(
                 {"user_id": "x", "window_id": "@99"}
             )
@@ -7201,7 +7254,9 @@ class TestShareWindowHandlers:
         conn = _base_conn(user=user, ws=sock)
         conn.container_id = "cid"
         conn.workspace_id = "ws-1"
-        with patch("klangk_backend.acl.check_permission", return_value=True):
+        with patch.object(
+            acl_mod.ACL, "check_permission", new=AsyncMock(return_value=True)
+        ):
             await conn.handle_delete_shared_terminal({})
         calls = [c[0][0] for c in sock.send_json.call_args_list]
         assert any("required" in c.get("message", "").lower() for c in calls)
@@ -7215,8 +7270,10 @@ class TestShareWindowHandlers:
         conn.workspace_id = "ws-1"
         sockets.get_or_create_session("ws-1", app_state)
         try:
-            with patch(
-                "klangk_backend.acl.check_permission", return_value=True
+            with patch.object(
+                acl_mod.ACL,
+                "check_permission",
+                new=AsyncMock(return_value=True),
             ):
                 await conn.handle_delete_shared_terminal(
                     {"user_id": user["id"], "window_id": "@99"}
@@ -7250,8 +7307,10 @@ class TestShareWindowHandlers:
             {"name": "build", "index": 0, "id": "@0", "shared": True},
         ]
         try:
-            with patch(
-                "klangk_backend.acl.check_permission", return_value=True
+            with patch.object(
+                acl_mod.ACL,
+                "check_permission",
+                new=AsyncMock(return_value=True),
             ):
                 await conn.handle_delete_shared_terminal(
                     {"user_id": other["id"], "window_id": "@0"}
@@ -7285,8 +7344,10 @@ class TestShareWindowHandlers:
                 {"name": "build", "index": 0, "id": "@0", "shared": True},
             ]
             with (
-                patch(
-                    "klangk_backend.acl.check_permission", return_value=True
+                patch.object(
+                    acl_mod.ACL,
+                    "check_permission",
+                    new=AsyncMock(return_value=True),
                 ),
                 patch.object(_mock_term, "kill_joiner_sessions"),
                 patch.object(_mock_term, "close_window", return_value=[]),
@@ -7309,8 +7370,10 @@ class TestShareWindowHandlers:
         ]
         try:
             with (
-                patch(
-                    "klangk_backend.acl.check_permission", return_value=True
+                patch.object(
+                    acl_mod.ACL,
+                    "check_permission",
+                    new=AsyncMock(return_value=True),
                 ),
                 patch.object(
                     _mock_term,
@@ -7333,7 +7396,11 @@ class TestShareWindowHandlers:
         conn._user_home = "/home/admin"
         conn.workspace_id = "no-session"
         with (
-            patch("klangk_backend.acl.check_permission", return_value=True),
+            patch.object(
+                acl_mod.ACL,
+                "check_permission",
+                new=AsyncMock(return_value=True),
+            ),
             patch.object(_mock_term, "new_window", return_value=[]),
         ):
             await conn.handle_create_shared_terminal({"name": "dev"})
@@ -7344,7 +7411,9 @@ class TestShareWindowHandlers:
         conn = _base_conn(user=user, ws=sock)
         conn.container_id = "cid"
         conn.workspace_id = "no-session"
-        with patch("klangk_backend.acl.check_permission", return_value=True):
+        with patch.object(
+            acl_mod.ACL, "check_permission", new=AsyncMock(return_value=True)
+        ):
             await conn.handle_delete_shared_terminal(
                 {"user_id": user["id"], "window_id": "@99"}
             )
@@ -7359,7 +7428,9 @@ class TestShareWindowHandlers:
         conn = _base_conn(user=user, ws=sock)
         conn.container_id = "cid"
         conn._user_home = "/home/admin"
-        with patch("klangk_backend.acl.check_permission", return_value=False):
+        with patch.object(
+            acl_mod.ACL, "check_permission", new=AsyncMock(return_value=False)
+        ):
             await conn.handle_create_shared_terminal({"name": "x"})
         calls = [c[0][0] for c in sock.send_json.call_args_list]
         assert any("Permission" in c.get("message", "") for c in calls)
@@ -7370,7 +7441,9 @@ class TestShareWindowHandlers:
         conn.container_id = "cid"
         conn._user_home = "/home/admin"
         conn.workspace_id = "ws-1"
-        with patch("klangk_backend.acl.check_permission", return_value=True):
+        with patch.object(
+            acl_mod.ACL, "check_permission", new=AsyncMock(return_value=True)
+        ):
             await conn.handle_create_shared_terminal({"name": ""})
         calls = [c[0][0] for c in sock.send_json.call_args_list]
         assert any("Name" in c.get("message", "") for c in calls)
@@ -7382,7 +7455,11 @@ class TestShareWindowHandlers:
         conn._user_home = "/home/admin"
         conn.workspace_id = "ws-1"
         with (
-            patch("klangk_backend.acl.check_permission", return_value=True),
+            patch.object(
+                acl_mod.ACL,
+                "check_permission",
+                new=AsyncMock(return_value=True),
+            ),
             patch.object(
                 _mock_term,
                 "new_window",
@@ -7403,7 +7480,9 @@ class TestShareWindowHandlers:
         sock = _mock_sock()
         conn = _base_conn(user=user, ws=sock)
         conn.workspace_id = "ws-1"
-        with patch("klangk_backend.acl.check_permission", return_value=False):
+        with patch.object(
+            acl_mod.ACL, "check_permission", new=AsyncMock(return_value=False)
+        ):
             await conn.handle_list_shared_terminals()
         calls = [c[0][0] for c in sock.send_json.call_args_list]
         assert any("Permission" in c.get("message", "") for c in calls)
@@ -7412,7 +7491,9 @@ class TestShareWindowHandlers:
         sock = _mock_sock()
         conn = _base_conn(user=user, ws=sock)
         conn.workspace_id = "no-session"
-        with patch("klangk_backend.acl.check_permission", return_value=True):
+        with patch.object(
+            acl_mod.ACL, "check_permission", new=AsyncMock(return_value=True)
+        ):
             await conn.handle_list_shared_terminals()
         calls = [c[0][0] for c in sock.send_json.call_args_list]
         shared = [c for c in calls if c.get("type") == "shared_terminals"]


### PR DESCRIPTION
## Summary

Hoists the top-level `klangk_backend/acl.py` — the resource-tree walk + `Depends` permission dependency (**not** `model/acl.py`) — into `ACL(app_state)`. This is split 6/7 of #1563 and *the one genuinely new class* the refactor forces: every other slice moved a `model/` domain onto `Model(app_state)`, but the FastAPI permission layer lived outside `model/` and reached the DB through it.

## What changed

**New `ACL(app_state)` class** in `klangk_backend/acl.py`, wired as `app.state.acl = ACL(app.state)` in `build_app` (after `app.state.model`, which it depends on):
- The three DB-touching functions — `get_principals`, `check_permission`, `permissions_for_resources` — become methods reaching `self.app_state.model.{users,acl}` (resolving group IDs via `model.users`, ACE maps via `model.acl`).
- The pure helpers (`ace_matches_principals`, `resource_ancestors`, `check_permission_inmemory`, `request_to_resource`) stay module-level — the methods reuse them.

**`has_permission(perm, resource_fn)` stays module-level.** It's a FastAPI dependency *factory* built at route-definition time, so it can't close over an instance. Its closure now resolves `request.app.state.acl` per request — exactly the pattern `auth.get_current_user` already uses to resolve `request.app.state.auth`. **Consequence: all ~50 `Depends(acl.has_permission(...))` call sites across `api/admin.py`, `api/workspaces.py`, `api/files.py` are unchanged.**

**Two direct callers converted:**
- `api/__init__.py` (`/my-permissions`) → `request.app.state.acl.*`
- `wshandler/connection.py` (the `_has_perm` / terminal-permission check) → `self.app_state.acl.*`

The module-level free-function backstops stay until #1578 (used by `test_acl.py`'s direct calls); the dead `_acl` re-export in `wshandler/__init__.py` and the unused import in `connection.py` were removed.

## Tests

- **`test_acl_app_state.py`** (new) — direct coverage of every `ACL(app_state)` method (`get_principals`, `check_permission` allow/deny/walk/default-deny, `permissions_for_resources` including group-principal + empty-list paths) and the `has_permission` factory (allow path with URL-derived resource, deny path with a `resource_fn` override raising 403).
- **`test_wshandler.py`** — retargeted the 38 `patch("klangk_backend.acl.check_permission", ...)` sites to `patch.object(acl_mod.ACL, "check_permission", ...)` (class-level, since the test fixtures use varying `conn`/`owner_conn`/`viewer_conn` variable names and some build a controller rather than a conn). `_helpers.wire_db_and_model` now wires `state.acl = ACL(state)` so every test `app_state` namespace has it.

Backend suite green at 100% coverage (2469 passed, `-n auto`); CLI suite unchanged (486 passed, 100%).

## Notes

- No behavior change — same ACL walk, same queries; purely how the layer reaches the DB.
- Rebases cleanly onto #1576 (`ChatModel`, landed during this work) — the only overlap was `wshandler/connection.py` (different lines; auto-merged).
- With this, the request path reaches `app_state.model.*` everywhere except the module-level backstops reserved for #1578 (the final ContextVar dissolution + #1551 fix).
- Closes #1577.
