### PR TITLE
refactor(model): migrate users callers to app_state.model.users; inline db-threaded shims (#1596)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -100,6 +100,20 @@ operators or integrators to act when upgrading.
 
 ### Changed
 
+- **Production callers of the users data-access layer now reach it via
+  `app_state.model.users.*` (#1596).** The seeding path (`Lifecycle`:
+  `ensure_admin_group` / `seed_default_user`), the OIDC JIT-provisioning
+  path (`api/oidc_auth._find_or_create_user`), and the in-place handle
+  helpers on `UsersModel` no longer go through the module-level
+  `model.<fn>(...)` free functions — they call `self.app_state.model.users`
+  / `request.app.state.model.users` directly. The three `db`-threaded
+  methods (`unique_handle`, `generate_handle`, `backfill_handles`) are
+  inlined over their free-function shims (real bodies on the methods,
+  keeping the explicit `db` connection for atomicity/migration). No
+  behavior change. The module-level free functions + re-exports remain
+  as the test/ContextVar backstop and are removed when `#1578` dissolves
+  the `_current_db` ContextVar; `schema.py`'s migration path still imports
+  them, so deletion is sequenced there.
 - **`WorkspacesModel` shim layer removed (#1597).** The workspace
   data-access free functions in `model/workspaces.py`
   (`create_workspace`, `create_workspace_with_acl`, `list_workspaces`,

--- a/src/backend/klangk_backend/api/oidc_auth.py
+++ b/src/backend/klangk_backend/api/oidc_auth.py
@@ -165,13 +165,14 @@ async def _exchange_and_validate_token(oidc_inst, provider, code, cookie_data):
     return claims, tokens
 
 
-async def _find_or_create_user(provider_id, sub, email):
+async def _find_or_create_user(app_state, provider_id, sub, email):
     """Locate an existing user by OIDC identity or create one via JIT provisioning.
 
     Raises ``HTTPException(403)`` if the resolved user is the system agent —
     OIDC must never mint a session as the agent (#1225).
     """
-    user = await model.get_user_by_external_id(provider_id, sub)
+    users = app_state.model.users
+    user = await users.get_user_by_external_id(provider_id, sub)
     if user is not None:
         if user["id"] == model.AGENT_USER_ID:
             raise HTTPException(
@@ -180,17 +181,17 @@ async def _find_or_create_user(provider_id, sub, email):
             )
         return user
 
-    existing = await model.get_user_by_email(email)
+    existing = await users.get_user_by_email(email)
     if existing is not None:
         if existing["id"] == model.AGENT_USER_ID:
             raise HTTPException(
                 status_code=403,
                 detail="Cannot log in as the system agent",
             )
-        await model.link_oidc_identity(existing["id"], provider_id, sub)
+        await users.link_oidc_identity(existing["id"], provider_id, sub)
         return existing
 
-    return await model.create_user(
+    return await users.create_user(
         email=email,
         password_hash=None,
         verified=True,
@@ -275,7 +276,9 @@ async def oidc_callback(
             detail="Login denied by server policy",
         ) from None
 
-    user = await _find_or_create_user(provider_id, claims["sub"], email)
+    user = await _find_or_create_user(
+        request.app.state, provider_id, claims["sub"], email
+    )
 
     if hook_groups is not None:
         await oidc.sync_oidc_groups(user["id"], hook_groups)

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -149,9 +149,9 @@ class Lifecycle:
 
     async def ensure_admin_group(self) -> str:
         """Ensure the 'admin' group exists. Returns the group ID."""
-        group = await model.get_group_by_name("admin")
+        group = await self.app_state.model.users.get_group_by_name("admin")
         if group is None:
-            group = await model.create_group(
+            group = await self.app_state.model.users.create_group(
                 "admin", description="Administrators"
             )
             logger.info("Created admin group: %s", group["id"])
@@ -170,7 +170,7 @@ class Lifecycle:
 
         email = settings.default_user
         password = settings.default_password
-        existing = await model.get_user_by_email(email)
+        existing = await self.app_state.model.users.get_user_by_email(email)
         if existing is None:
             generated = password is None
             if generated:
@@ -178,8 +178,12 @@ class Lifecycle:
             password_hash = bcrypt.hashpw(
                 password.encode(), bcrypt.gensalt()
             ).decode()
-            user = await model.create_user(email, password_hash, verified=True)
-            await model.add_user_to_group(user["id"], admin_group_id)
+            user = await self.app_state.model.users.create_user(
+                email, password_hash, verified=True
+            )
+            await self.app_state.model.users.add_user_to_group(
+                user["id"], admin_group_id
+            )
             if generated:
                 logger.info(
                     "Created default admin user '%s'"
@@ -197,7 +201,9 @@ class Lifecycle:
                 logger.info("Created default user '%s' in admin group", email)
         else:
             # Ensure existing default user is in admin group
-            await model.add_user_to_group(existing["id"], admin_group_id)
+            await self.app_state.model.users.add_user_to_group(
+                existing["id"], admin_group_id
+            )
 
     async def seed_agent_user(self) -> None:
         """Ensure the chat agent user exists in the DB.

--- a/src/backend/klangk_backend/model/users.py
+++ b/src/backend/klangk_backend/model/users.py
@@ -685,16 +685,64 @@ class UsersModel:
             raise ValueError(f"'{handle}' is reserved for the workspace agent")
 
     async def unique_handle(self, db, base: str) -> str:
-        """Return *base* if available, else append -2, -3, … until unique."""
-        return await unique_handle(db, base)
+        """Return *base* if available, else append -2, -3, … until unique.
+
+        The live agent handle is always treated as taken (#1160) — even if
+        the agent row hasn't been seeded yet — so a derived handle never
+        collides with ``/home/<agent_handle>``.
+
+        Resolves the agent handle on the *passed* connection (not via the
+        cached :meth:`agent_handle`, which opens a fresh connection): this
+        runs during DB migration where the ``handle`` column's schema change
+        is uncommitted on *db* but invisible to a new connection.
+        """
+        cursor = await db.execute(
+            "SELECT handle FROM users WHERE id = ?", (AGENT_USER_ID,)
+        )
+        row = await cursor.fetchone()
+        agent = row[0] if row and row[0] else _DEFAULT_AGENT_HANDLE
+        # Try base, then base-2, base-3, …; skip the agent handle each time.
+        candidate = base
+        i = 1
+        while i < 10000:
+            if candidate != agent:
+                cursor = await db.execute(
+                    "SELECT 1 FROM users WHERE handle = ?", (candidate,)
+                )
+                if await cursor.fetchone() is None:
+                    return candidate
+            i += 1
+            candidate = f"{base}-{i}"
+            if len(candidate) > MAX_HANDLE_LEN:
+                candidate = f"{base[: MAX_HANDLE_LEN - len(str(i)) - 1]}-{i}"
+        return hash_fallback_handle(base)
 
     async def generate_handle(self, db, email: str) -> str:
-        """Return a unique handle derived from *email* on connection *db*."""
-        return await generate_handle(db, email)
+        """Return a unique handle derived from *email* on connection *db*.
+
+        This is the single shared handle generator. Every codepath that
+        creates a user — :meth:`create_user`, the email-verification
+        register route, the admin invite route, and :meth:`backfill_handles`
+        — must go through here so handle derivation and uniqueness stay in
+        sync (regression: #1256, where the email-verification routes did a
+        raw ``INSERT`` with no handle and got ``NULL``).
+        """
+        return await self.unique_handle(db, derive_handle(email))
 
     async def backfill_handles(self, db) -> None:
         """Assign handles to any users that don't have one yet."""
-        await backfill_handles(db)
+        cursor = await db.execute(
+            "SELECT id, email FROM users WHERE handle IS NULL"
+        )
+        rows = await cursor.fetchall()
+        for row in rows:
+            handle = await self.generate_handle(db, row["email"])
+            await db.execute(
+                "UPDATE users SET handle = ? WHERE id = ?",
+                (handle, row["id"]),
+            )
+        if rows:
+            await db.commit()
 
     async def create_user(
         self,

--- a/src/backend/tests/test_api.py
+++ b/src/backend/tests/test_api.py
@@ -8667,7 +8667,7 @@ class TestOIDCCallbackAgentGuard:
         # mock get_user_by_external_id to simulate a pre-linked agent.
         agent = await model.get_user_by_id(model.AGENT_USER_ID)
         monkeypatch.setattr(
-            model,
+            app.state.model.users,
             "get_user_by_external_id",
             AsyncMock(return_value=agent),
         )

--- a/src/backend/tests/test_model_users.py
+++ b/src/backend/tests/test_model_users.py
@@ -202,3 +202,34 @@ async def test_backfill_handles_method(users):
         await users.backfill_handles(db)
     fetched = await users.get_user_by_id("bf-id")
     assert fetched["handle"] is not None
+
+
+async def test_unique_handle_truncates_long_suffix(users):
+    """A base near MAX_HANDLE_LEN gets its numeric suffix truncated."""
+    from klangk_backend.model import MAX_HANDLE_LEN
+
+    long = "a" * MAX_HANDLE_LEN
+    async with users.app_state.db.transaction() as db:
+        await db.execute(
+            "INSERT INTO users (id, email, password_hash, verified, handle)"
+            " VALUES (?, ?, ?, 0, ?)",
+            ("long-id", "long@x.com", "h", long),
+        )
+        result = await users.unique_handle(db, long)
+    assert len(result) <= MAX_HANDLE_LEN
+    assert result.endswith("-2")
+
+
+async def test_unique_handle_falls_back_to_hash(users):
+    """When every numeric suffix collides, fall back to a hashed handle."""
+    from unittest.mock import AsyncMock
+
+    mock_cursor = AsyncMock()
+    mock_cursor.fetchone = AsyncMock(return_value=(1,))
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(return_value=mock_cursor)
+
+    result = await users.unique_handle(mock_db, "taken")
+    # hash_fallback_handle: "<base>-<sha256[:8]>"
+    assert "-" in result
+    assert len(result.rsplit("-", 1)[1]) == 8


### PR DESCRIPTION
## Summary

Part of #1596. Migrates the **production** callers of the users data-access layer off the module-level `model.<fn>(...)` free functions onto the `app_state`-owned method path, and inlines the three `db`-threaded `UsersModel` shims over their free functions.

This is the cleanly-separable slice of #1596. The free-function **deletion** + test migration is structurally #1578 (see *Scope* below) — it can't be done here without rewriting the shared `_current_db` ContextVar test backstop (which `model/workspaces.py`, owned by #1597, also depends on) and touching workspaces-adjacent test files.

## What changed

**Production callers migrated to `app_state.model.users.*`:**
- `Lifecycle` seed path (`main.py`): `ensure_admin_group` / `seed_default_user` now call `self.app_state.model.users.{get_group_by_name, create_group, get_user_by_email, create_user, add_user_to_group}` instead of `model.<fn>`.
- OIDC JIT provisioning (`api/oidc_auth.py`): `_find_or_create_user` gains an `app_state` param and reaches `app_state.model.users.{get_user_by_external_id, get_user_by_email, link_oidc_identity, create_user}`; the callback route passes `request.app.state`.
- `oidc.py`: the now-unused `from . import model` import is dropped (its only uses were the migrated users calls; `sync_oidc_groups` is a *module-level free function* bare-tested via the ContextVar, so it stays on `model.*` until #1578).

**Inlined the three `db`-threaded `UsersModel` shims** (`unique_handle`, `generate_handle`, `backfill_handles`) over their free functions: real bodies on the methods, no more `return await <freefn>(...)` forwarding. The explicit `db` connection param is kept — the atomicity/migration constraints in their docstrings are load-bearing (uniqueness check + insert on the same connection; `backfill_handles` runs inside a schema migration where the `handle` column change is uncommitted on `db`).

**`clear_agent_cache` stays on the module path** — it clears a module global (no DB access), is out of scope for the app_state migration, and the bare-`SimpleNamespace(settings=...)` seed tests rely on it not requiring `app_state.model`.

## Scope — why the free functions aren't deleted here

The issue's acceptance criteria ask for the module-level free functions to be deleted. That turns out to be structurally #1578's work, not separable now:

- The **test suite is built on the `_current_db` ContextVar backstop** (`conftest.py`'s `temp_data_dir` binds it; ~290 `model.<fn>(...)` call sites across 14 test files read it, including `test_api.py`'s 110). Rewriting `conftest.py`'s ContextVar fixtures is literally #1578's acceptance criterion ("no `set_current_db` in `conftest.py`").
- **`model/workspaces.py` imports `get_user_group_ids`** from `users.py` — and `workspaces.py` is owned by #1597, explicitly out of bounds for this PR. So that free function can't be deleted until #1597 migrates its caller.
- `schema.py`'s migration path calls `backfill_handles(db)` with no `app_state` in scope.

So: the free functions + `model/__init__.py` re-exports remain as the test/ContextVar backstop, and are removed when #1578 dissolves the ContextVar. This PR does everything cleanly separable now (production migration + shim inlining) and shrinks #1578's eventual surface.

## Tests (backend, 100% coverage, 2471 passed)

- `test_unique_handle_truncates_long_suffix`, `test_unique_handle_falls_back_to_hash` — new method-path coverage mirroring the free-function tests in `test_model.py` (the inlined method bodies now own the truncation/hash-fallback paths).
- Fixed the OIDC agent-rejection test's patch target: `model.get_user_by_external_id` → `app.state.model.users.get_user_by_external_id` (the code now calls the method).

## Changelog

`docs/changes.md` → `## [Unreleased]` → `### Changed` entry added.

## Related

- #1596 — this issue (partial; closes when #1578 deletes the backstop).
- #1597 — the analogous `workspaces.py` migration (in progress, not touched here).
- #1578 — dissolves the `_current_db` ContextVar and removes the remaining free-function backstop.
