### PR TITLE
refactor: state objects must not cache subobjects of app_state (#1608)

### DIFF
--- a/src/backend/klangk_backend/agent.py
+++ b/src/backend/klangk_backend/agent.py
@@ -92,7 +92,6 @@ class Agents:
 
     def __init__(self, app_state) -> None:
         self.app_state = app_state
-        self.settings = app_state.settings
         self._agents: dict[str, "AgentSession"] = {}
         self._agents_lock = asyncio.Lock()
 
@@ -103,7 +102,7 @@ class Agents:
         see ``AgentSession.ensure_started``, which consults this before
         creating the process.
         """
-        return self.settings.agent_disabled.strip().lower() in (
+        return self.app_state.settings.agent_disabled.strip().lower() in (
             "1",
             "true",
             "yes",

--- a/src/backend/klangk_backend/auth.py
+++ b/src/backend/klangk_backend/auth.py
@@ -134,20 +134,44 @@ class Auth:
 
     def __init__(self, app_state):
         self.app_state = app_state
-        self.settings = app_state.settings
-        s = self.settings
-        self.secret = s.jwt_secret
         self.algorithm = "HS256"
-        self.token_expire_hours = float(s.access_token_hours)
-        self.min_password_length = int(s.min_password_length)
-        self.login_lockout_failures = int(s.login_lockout_failures)
-        self.login_lockout_duration = int(s.login_lockout_duration)
-        self.login_lockout_window = int(s.login_lockout_window)
-        self.invite_token_expire_hours = int(s.invite_expire_hours)
-        self.workspace_token_expire_hours = float(s.workspace_token_hours)
         # Fixed-policy token lifetimes (not env-driven).
         self.verify_token_expire_hours = 72
         self.reset_token_expire_hours = 1
+
+    # --- settings-derived config (read live off app_state, #1608) ---
+
+    @property
+    def secret(self) -> str:
+        return self.app_state.settings.jwt_secret
+
+    @property
+    def token_expire_hours(self) -> float:
+        return float(self.app_state.settings.access_token_hours)
+
+    @property
+    def min_password_length(self) -> int:
+        return int(self.app_state.settings.min_password_length)
+
+    @property
+    def login_lockout_failures(self) -> int:
+        return int(self.app_state.settings.login_lockout_failures)
+
+    @property
+    def login_lockout_duration(self) -> int:
+        return int(self.app_state.settings.login_lockout_duration)
+
+    @property
+    def login_lockout_window(self) -> int:
+        return int(self.app_state.settings.login_lockout_window)
+
+    @property
+    def invite_token_expire_hours(self) -> int:
+        return int(self.app_state.settings.invite_expire_hours)
+
+    @property
+    def workspace_token_expire_hours(self) -> float:
+        return float(self.app_state.settings.workspace_token_hours)
 
     # --- secret / startup guard ---
 
@@ -164,7 +188,7 @@ class Auth:
         """
         if self.jwt_secret_is_secure():
             return
-        prevent = self.settings.prevent_insecure_jwt_secret.lower()
+        prevent = self.app_state.settings.prevent_insecure_jwt_secret.lower()
         if prevent in ("1", "true", "yes"):
             raise ConfigurationError(
                 "KLANGK_JWT_SECRET is unset or the insecure default. Set a "
@@ -179,12 +203,12 @@ class Auth:
 
     def registration_enabled(self) -> bool:
         """Check if public registration is enabled."""
-        val = self.settings.disable_registration
+        val = self.app_state.settings.disable_registration
         return val.lower() not in ("1", "true", "yes")
 
     def invitations_enabled(self) -> bool:
         """Check if admin invitations are enabled."""
-        val = self.settings.disable_invites
+        val = self.app_state.settings.disable_invites
         return val.lower() not in ("1", "true", "yes")
 
     def validate_password_length(self, password: str) -> None:

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -580,39 +580,11 @@ class ContainerRegistry:
 
     def __init__(self, app_state):
         self.app_state = app_state
-        self.settings = app_state.settings
 
-        # --- settings-derived attrs (computed once, #1487) ---
-        s = self.settings
-        self.image_name: str = s.image_name or "klangk-workspace"
-        self.terminal_banner: str = s.terminal_banner or ""
-        self.allowed_images: set[str] = set()
-        if s.allowed_images:
-            self.allowed_images = {
-                img.strip()
-                for img in s.allowed_images.split(",")
-                if img.strip()
-            }
-        self.allowed_images.add(self.image_name)
-        self.allowed_mount_roots: list[str] = []
-        if s.allowed_mount_roots:
-            self.allowed_mount_roots = [
-                os.path.realpath(p.strip())
-                for p in s.allowed_mount_roots.split(",")
-                if p.strip()
-            ]
-        self.port_range_start: int = int(s.port_range_start or "9000")
+        # Runtime-mutable state (initialized from settings but overridable
+        # at runtime via set_idle_timeout — NOT a live settings read).
         self.idle_timeout_seconds, self.check_interval_seconds = (
             self._parse_idle_timeout()
-        )
-        self.health_check_interval: float = float(
-            s.health_check_interval or "30"
-        )
-        self.health_check_timeout: float = float(
-            s.health_check_timeout or "10"
-        )
-        self.health_check_startup_grace: float = float(
-            s.health_check_startup_grace or "30"
         )
 
         self.states: dict[str, ContainerState] = {}
@@ -631,16 +603,62 @@ class ContainerRegistry:
         # The Podman instance is reached via self.app_state.podman (owned
         # instance, #1426) — no post-construction wiring needed.
 
+    # --- settings-derived config (read live off app_state, #1608) ---
+
+    @property
+    def image_name(self) -> str:
+        return self.app_state.settings.image_name or "klangk-workspace"
+
+    @property
+    def terminal_banner(self) -> str:
+        return self.app_state.settings.terminal_banner or ""
+
+    @property
+    def allowed_images(self) -> set[str]:
+        imgs: set[str] = set()
+        raw = self.app_state.settings.allowed_images
+        if raw:
+            imgs = {i.strip() for i in raw.split(",") if i.strip()}
+        imgs.add(self.image_name)
+        return imgs
+
+    @property
+    def allowed_mount_roots(self) -> list[str]:
+        raw = self.app_state.settings.allowed_mount_roots
+        if not raw:
+            return []
+        return [
+            os.path.realpath(p.strip()) for p in raw.split(",") if p.strip()
+        ]
+
+    @property
+    def port_range_start(self) -> int:
+        return int(self.app_state.settings.port_range_start or "9000")
+
+    @property
+    def health_check_interval(self) -> float:
+        return float(self.app_state.settings.health_check_interval or "30")
+
+    @property
+    def health_check_timeout(self) -> float:
+        return float(self.app_state.settings.health_check_timeout or "10")
+
+    @property
+    def health_check_startup_grace(self) -> float:
+        return float(
+            self.app_state.settings.health_check_startup_grace or "30"
+        )
+
     # --- settings-derived methods (were module functions, #1487) ---
 
     def container_dns_config(self) -> list[str]:
         """Return DNS server list from settings.dns_servers."""
-        raw = self.settings.dns_servers
+        raw = self.app_state.settings.dns_servers
         return [d.strip() for d in raw.split(",") if d.strip()]
 
     def image_pull_policy(self) -> str:
         """Resolve the workspace-image pull policy from settings."""
-        policy = self.settings.image_pull_policy
+        policy = self.app_state.settings.image_pull_policy
         if policy not in _VALID_PULL_POLICIES:
             logger.warning(
                 "Invalid KLANGK_IMAGE_PULL_POLICY=%r (valid: %s); using 'never'.",
@@ -653,7 +671,7 @@ class ContainerRegistry:
     def _is_protected(self, source: str) -> bool:
         """True if source is a protected host path that must never be mounted."""
         resolved = os.path.realpath(source)
-        data_dir = os.path.realpath(self.settings.data_dir)
+        data_dir = os.path.realpath(self.app_state.settings.data_dir)
         for blocked in [*_PROTECTED_PATHS, data_dir]:
             blocked = os.path.realpath(blocked)
             if resolved == blocked or resolved.startswith(blocked + "/"):
@@ -703,7 +721,7 @@ class ContainerRegistry:
 
     def _parse_idle_timeout(self) -> tuple[int, int]:
         default = 30 * 60
-        env_val = self.settings.idle_timeout_seconds
+        env_val = self.app_state.settings.idle_timeout_seconds
         if env_val is not None:
             try:
                 timeout = int(env_val)
@@ -722,7 +740,7 @@ class ContainerRegistry:
 
     def ports_per_workspace_cap(self) -> int:
         """Server-wide ceiling on hosted-app ports per workspace."""
-        raw = self.settings.hosted_ports_per_workspace
+        raw = self.app_state.settings.hosted_ports_per_workspace
         try:
             return max(0, int(raw))
         except ValueError:
@@ -1175,9 +1193,9 @@ class ContainerRegistry:
             if hosting_base_path is None:
                 hosting_base_path = b
         env_vars: list[str] = []
-        egress_port = self.settings.egress_port
+        egress_port = self.app_state.settings.egress_port
         proxy_url = f"http://host.containers.internal:{egress_port}/llm-proxy"
-        llm_model = self.settings.llm_model
+        llm_model = self.app_state.settings.llm_model
         env_vars.append(f"KLANGK_LLM_PROXY_URL={proxy_url}")
         if llm_model:
             env_vars.append(f"KLANGK_LLM_MODEL={llm_model}")
@@ -1491,7 +1509,7 @@ class ContainerRegistry:
         ]
         iid = self.app_state.util.instance_id()
         container_name = f"klangk-{iid}-{workspace_id[:12]}"
-        allow_sudo = self.settings.allow_sudo.strip().lower() in (
+        allow_sudo = self.app_state.settings.allow_sudo.strip().lower() in (
             "1",
             "true",
             "yes",
@@ -1515,7 +1533,7 @@ class ContainerRegistry:
             env=env_vars,
             init=True,
             interactive=True,
-            userns=self.settings.userns,
+            userns=self.app_state.settings.userns,
             pull=self.image_pull_policy(),
         )
 
@@ -1661,7 +1679,7 @@ class ContainerRegistry:
                 "klangk-prewarm",
                 self.image_name,
                 pull="never",
-                userns=self.settings.userns,
+                userns=self.app_state.settings.userns,
             )
             await self.app_state.podman.remove_container(cid)
             logger.info("Podman pre-warmed in %.3fs", time.monotonic() - t0)

--- a/src/backend/klangk_backend/container.py
+++ b/src/backend/klangk_backend/container.py
@@ -55,10 +55,10 @@ def _is_named_volume(source: str) -> bool:
 class ContainerState:
     """Per-workspace container lifecycle state."""
 
-    def __init__(self, workspace_id: str, container_id: str, registry):
+    def __init__(self, workspace_id: str, container_id: str, app_state):
         self.workspace_id = workspace_id
         self.container_id = container_id
-        self.registry = registry
+        self.app_state = app_state
         self.last_activity = time.time()
         self.idle_timeout: int | None = None
         self.idle_callbacks: list = []
@@ -108,7 +108,7 @@ class ContainerState:
     def get_idle_timeout(self) -> int:
         if self.idle_timeout is not None:
             return self.idle_timeout
-        return self.registry.idle_timeout_seconds
+        return self.app_state.container_registry.idle_timeout_seconds
 
 
 class PortAllocator:
@@ -118,23 +118,27 @@ class PortAllocator:
     port tracking.  Extracted from ``ContainerRegistry`` (issue #972).
     """
 
-    def __init__(self, registry) -> None:
+    def __init__(self, app_state) -> None:
         self.port_lock: asyncio.Lock = asyncio.Lock()
-        self.registry = registry
+        self.app_state = app_state
 
     async def allocate_ports(self, workspace_id: str, count: int) -> list[int]:
         # Clamp to the server-wide cap (KLANGK_HOSTED_PORTS_PER_WORKSPACE)
         # so creation never allocates ports the deployer has disabled —
         # otherwise a cap of 0 would still leave orphan allocations
         # until the container's first start reconcile (#1237).
-        count = min(count, self.registry.ports_per_workspace_cap())
+        count = min(
+            count, self.app_state.container_registry.ports_per_workspace_cap()
+        )
         async with self.port_lock:
-            return await self.registry.app_state.model.ports.find_and_allocate_ports(
-                workspace_id, count, self.registry.port_range_start
+            return await self.app_state.model.ports.find_and_allocate_ports(
+                workspace_id,
+                count,
+                self.app_state.container_registry.port_range_start,
             )
 
     async def get_workspace_ports(self, workspace_id: str) -> list[int]:
-        return await self.registry.app_state.model.ports.get_workspace_ports(
+        return await self.app_state.model.ports.get_workspace_ports(
             workspace_id
         )
 
@@ -198,8 +202,8 @@ class IdleMonitor:
     Extracted from ``ContainerRegistry`` (issue #972).
     """
 
-    def __init__(self, registry: "ContainerRegistry") -> None:
-        self.registry = registry
+    def __init__(self, app_state) -> None:
+        self.app_state = app_state
         self.cleanup_task: asyncio.Task | None = None
         self._cleanup_wake: asyncio.Event | None = None
 
@@ -209,40 +213,41 @@ class IdleMonitor:
         return self._cleanup_wake
 
     def on_idle_stop(self, workspace_id: str, callback) -> None:
-        state = self.registry.states.get(workspace_id)
+        state = self.app_state.container_registry.states.get(workspace_id)
         if state:
             state.idle_callbacks.append(callback)
 
     def remove_idle_callback(self, workspace_id: str, callback) -> None:
-        state = self.registry.states.get(workspace_id)
+        state = self.app_state.container_registry.states.get(workspace_id)
         if state and callback in state.idle_callbacks:
             state.idle_callbacks.remove(callback)
 
     def set_workspace_idle_timeout(
         self, workspace_id: str, seconds: int
     ) -> None:
-        state = self.registry.states.get(workspace_id)
+        state = self.app_state.container_registry.states.get(workspace_id)
         if state:
             state.idle_timeout = seconds
             self.get_cleanup_wake().set()
 
     def get_workspace_idle_timeout(self, workspace_id: str) -> int:
-        state = self.registry.states.get(workspace_id)
+        state = self.app_state.container_registry.states.get(workspace_id)
         if state:
             return state.get_idle_timeout()
-        return self.registry.idle_timeout_seconds
+        return self.app_state.container_registry.idle_timeout_seconds
 
     async def cleanup_idle_containers(self) -> None:
+        registry = self.app_state.container_registry
         while True:
             timeouts = [
                 s.idle_timeout
-                for s in self.registry.states.values()
+                for s in registry.states.values()
                 if s.idle_timeout is not None
             ]
             if timeouts:
                 interval = max(2, min(timeouts) // 2)
             else:
-                interval = self.registry.check_interval_seconds
+                interval = registry.check_interval_seconds
             wake = self.get_cleanup_wake()
             wake.clear()
             try:
@@ -251,7 +256,7 @@ class IdleMonitor:
                 pass
             now = time.time()
             to_stop = []
-            for ws_id, state in list(self.registry.states.items()):
+            for ws_id, state in list(registry.states.items()):
                 timeout = state.get_idle_timeout()
                 idle_secs = now - state.last_activity
                 logger.debug(
@@ -269,22 +274,23 @@ class IdleMonitor:
                     cid,
                     wid,
                 )
-                state = self.registry.states.get(wid)
+                state = registry.states.get(wid)
                 if state:
                     for cb in list(state.idle_callbacks):
                         try:
                             await cb(wid)
                         except Exception as e:
                             logger.error("Idle callback error: %s", e)
-                await self.registry.notify_workspace_killed(wid)
-                await self.registry.stop_and_remove_container(cid)
+                await registry.notify_workspace_killed(wid)
+                await registry.stop_and_remove_container(cid)
 
     def start_cleanup_loop(self) -> None:
+        registry = self.app_state.container_registry
         logger.info(
             "Instance: %s, idle timeout: %ds, check interval: %ds",
-            self.registry.app_state.util.instance_id(),
-            self.registry.idle_timeout_seconds,
-            self.registry.check_interval_seconds,
+            self.app_state.util.instance_id(),
+            registry.idle_timeout_seconds,
+            registry.check_interval_seconds,
         )
         if self.cleanup_task is None:
             self.cleanup_task = asyncio.create_task(
@@ -321,8 +327,8 @@ class HealthMonitor:
     container-side WS agent here).
     """
 
-    def __init__(self, registry: "ContainerRegistry") -> None:
-        self.registry = registry
+    def __init__(self, app_state) -> None:
+        self.app_state = app_state
         self.health_task: asyncio.Task | None = None
 
     @property
@@ -332,7 +338,7 @@ class HealthMonitor:
         Reached via ``app_state.sockets`` (owned instance, #1426) — no
         post-construction wiring needed.
         """
-        return self.registry.app_state.sockets
+        return self.app_state.sockets
 
     def _setup_complete(self, state: ContainerState) -> bool:
         """True if health checks may run for this workspace.
@@ -357,7 +363,7 @@ class HealthMonitor:
         """
         return (
             time.time() - state.service_started_at
-            < self.registry.health_check_startup_grace
+            < self.app_state.container_registry.health_check_startup_grace
         )
 
     async def _run_one(self, state: ContainerState) -> tuple[str, str]:
@@ -396,15 +402,13 @@ class HealthMonitor:
         owner_id = state.owner_id
         if owner_id is None:
             return "unhealthy", "no owner recorded for workspace"
-        handle = await self.registry.app_state.model.users.get_user_handle(
-            owner_id
-        )
+        handle = await self.app_state.model.users.get_user_handle(owner_id)
         if not handle:
             return "unhealthy", f"owner {owner_id} has no handle"
         # Resolve the owner's container home the same way
         # start_workspace does, so the check runs in the right
         # HOME rather than as root in /.
-        ws = self.registry.app_state.workspaces
+        ws = self.app_state.workspaces
         ws_home = ws.home_path(state.workspace_id)
         user_home, _created = await ws.ensure_home_symlink(
             ws_home, handle, owner_id
@@ -417,7 +421,7 @@ class HealthMonitor:
             state.health_check,
         )
         try:
-            rc, out, err = await self.registry.app_state.podman.exec_container(
+            rc, out, err = await self.app_state.podman.exec_container(
                 state.container_id,
                 # bash -c (NON-login): sources nothing, so the probe is
                 # deterministic and insulated from the user's interactive
@@ -428,7 +432,7 @@ class HealthMonitor:
                 ["bash", "-c", state.health_check],
                 user="klangk",
                 extra_env={"HOME": user_home},
-                timeout=self.registry.health_check_timeout,
+                timeout=self.app_state.container_registry.health_check_timeout,
             )
         except (podman.PodmanError, asyncio.TimeoutError, OSError) as e:
             return "unhealthy", f"{type(e).__name__}: {e}"
@@ -539,8 +543,9 @@ class HealthMonitor:
         loop being alive -- if the loop stalls, the heartbeats stop.
         """
         while True:
-            await asyncio.sleep(self.registry.health_check_interval)
-            for state in list(self.registry.states.values()):
+            registry = self.app_state.container_registry
+            await asyncio.sleep(registry.health_check_interval)
+            for state in list(registry.states.values()):
                 if not state.health_check:
                     continue
                 if not self._setup_complete(state):
@@ -595,10 +600,10 @@ class ContainerRegistry:
         self.on_container_status_changed = None
 
         # Collaborators
-        self.ports = PortAllocator(self)
+        self.ports = PortAllocator(app_state)
         self.browsers = BrowserRouter()
-        self.idle = IdleMonitor(self)
-        self.health = HealthMonitor(self)
+        self.idle = IdleMonitor(app_state)
+        self.health = HealthMonitor(app_state)
 
         # The Podman instance is reached via self.app_state.podman (owned
         # instance, #1426) — no post-construction wiring needed.
@@ -829,7 +834,7 @@ class ContainerRegistry:
         state = self.states.get(workspace_id)
         was_new = state is None
         if was_new:
-            state = ContainerState(workspace_id, container_id, self)
+            state = ContainerState(workspace_id, container_id, self.app_state)
             self.states[workspace_id] = state
         else:
             # Remove old reverse mapping if container changed

--- a/src/backend/klangk_backend/emailsvc.py
+++ b/src/backend/klangk_backend/emailsvc.py
@@ -44,7 +44,6 @@ class EmailService:
 
     def __init__(self, app_state) -> None:
         self.app_state = app_state
-        self.settings = app_state.settings
         # Per-instance cached Jinja environment. Built lazily on first
         # render; reset via reset_template_env() (mainly for tests that
         # flip KLANGK_EMAIL_TEMPLATES_DIR between cases).
@@ -56,29 +55,30 @@ class EmailService:
         """Resolve KLANGK_SMTP_PASSWORD.
 
         ``file:``/``cmd:`` prefixes are dereferenced at construction by
-        ``KlangkSettings`` (#1461), so ``self.settings.smtp_password`` is
+        ``KlangkSettings`` (#1461), so ``self.app_state.settings.smtp_password`` is
         already the resolved value (or ``None`` when unset).
         """
-        return self.settings.smtp_password
+        return self.app_state.settings.smtp_password
 
     def product_name(self) -> str:
         """Configured product name (KLANGK_PRODUCT_NAME), default 'Klangk'."""
-        return self.settings.product_name
+        return self.app_state.settings.product_name
 
     def smtp_config(self) -> dict:
         """Read SMTP configuration from settings at call time."""
         return {
-            "host": self.settings.smtp_host,
-            "port": int(self.settings.smtp_port),
-            "user": self.settings.smtp_user,
+            "host": self.app_state.settings.smtp_host,
+            "port": int(self.app_state.settings.smtp_port),
+            "user": self.app_state.settings.smtp_user,
             "password": self.resolve_password(),
-            "from_addr": self.settings.smtp_from,
-            "use_tls": self.settings.smtp_use_tls.lower() in ("true", "1"),
+            "from_addr": self.app_state.settings.smtp_from,
+            "use_tls": self.app_state.settings.smtp_use_tls.lower()
+            in ("true", "1"),
         }
 
     def use_smtp(self) -> bool:
         """Return True if SMTP is configured, False to use sendmail."""
-        return bool(self.settings.smtp_host)
+        return bool(self.app_state.settings.smtp_host)
 
     def reply_to(self) -> str | None:
         """Configured Reply-To address (KLANGK_SMTP_REPLY_TO), or None.
@@ -87,7 +87,7 @@ class EmailService:
         distinct from the envelope From. None -> no header (today's
         behavior). See #1165 / #261.
         """
-        return self.settings.smtp_reply_to or None
+        return self.app_state.settings.smtp_reply_to or None
 
     def _set_headers(self, msg: EmailMessage) -> None:
         """Apply optional headers shared by every outgoing message."""
@@ -119,7 +119,7 @@ class EmailService:
         logger.info("Email sent via SMTP to %s", msg["To"])
 
     async def send_via_sendmail(self, msg: EmailMessage) -> None:
-        sendmail = self.settings.sendmail_path
+        sendmail = self.app_state.settings.sendmail_path
         logger.info("Using sendmail at: %s", sendmail)
         resolved = shutil.which(sendmail)
         logger.info("Resolved sendmail path: %s", resolved)
@@ -152,7 +152,7 @@ class EmailService:
 
         Mirrors what /config exposes to the frontend (see api.get_config).
         """
-        s = self.settings
+        s = self.app_state.settings
         return {
             "product_name": self.product_name(),
             "logo_url": s.logo_url,
@@ -170,7 +170,7 @@ class EmailService:
 
     def _customize_dir(self) -> str:
         """Root customization directory (defaults to ``<state_dir>/custom``)."""
-        return self.settings.customize_dir
+        return self.app_state.settings.customize_dir
 
     def _template_env(self) -> Environment:
         """Build (and cache) the Jinja environment.
@@ -183,7 +183,7 @@ class EmailService:
         """
         if self._env is None:
             loaders = []
-            user_dir = self.settings.email_templates_dir
+            user_dir = self.app_state.settings.email_templates_dir
             if not user_dir:
                 candidate = Path(self._customize_dir()) / "email-templates"
                 if candidate.is_dir():

--- a/src/backend/klangk_backend/files.py
+++ b/src/backend/klangk_backend/files.py
@@ -60,14 +60,13 @@ class Files:
 
     def __init__(self, app_state):
         self.app_state = app_state
-        self.podman = app_state.podman
 
     async def list_files(
         self, container_id: str, path: str = "/"
     ) -> list[dict]:
         """List files and directories at the given path inside the container."""
         path = validate_path(path)
-        rc, out, _err = await self.podman.exec_container(
+        rc, out, _err = await self.app_state.podman.exec_container(
             container_id,
             [
                 "find",
@@ -123,7 +122,7 @@ class Files:
         """Stat a single path.  Returns ``{"is_dir": bool, "size": int}``
         or ``None`` if the path does not exist."""
         path = validate_path(path)
-        rc, out, _err = await self.podman.exec_container(
+        rc, out, _err = await self.app_state.podman.exec_container(
             container_id,
             ["stat", "-L", "--format", "%F\t%s", "--", path],
             user=EXEC_USER,
@@ -149,7 +148,7 @@ class Files:
             return None
         if info["size"] > 1_000_000:
             return None
-        rc, out, _err = await self.podman.exec_container(
+        rc, out, _err = await self.app_state.podman.exec_container(
             container_id,
             ["cat", "--", path],
             user=EXEC_USER,
@@ -163,7 +162,7 @@ class Files:
     ) -> AsyncGenerator[bytes, None]:
         """Stream file contents as raw bytes for download."""
         path = validate_path(path)
-        return self.podman.exec_container_stream(
+        return self.app_state.podman.exec_container_stream(
             container_id,
             ["cat", "--", path],
             user=EXEC_USER,
@@ -176,7 +175,7 @@ class Files:
         path = validate_path(path)
         # Use sh -c with readlink to resolve symlinks before tar -C,
         # because tar -C does not follow symlinks on all implementations.
-        return self.podman.exec_container_stream(
+        return self.app_state.podman.exec_container_stream(
             container_id,
             [
                 "sh",
@@ -192,14 +191,14 @@ class Files:
         """Delete a file or directory.  Returns the path deleted."""
         path = validate_path(path)
         # Check existence first
-        rc, _out, _err = await self.podman.exec_container(
+        rc, _out, _err = await self.app_state.podman.exec_container(
             container_id,
             ["test", "-e", path],
             user=EXEC_USER,
         )
         if rc != 0:
             raise FileNotFoundError("Path not found")
-        rc, _out, err = await self.podman.exec_container(
+        rc, _out, err = await self.app_state.podman.exec_container(
             container_id,
             ["rm", "-rf", "--", path],
             user=EXEC_USER,
@@ -215,7 +214,7 @@ class Files:
         old_path = validate_path(old_path)
         new_path = validate_path(new_path)
         # Check source exists
-        rc, _out, _err = await self.podman.exec_container(
+        rc, _out, _err = await self.app_state.podman.exec_container(
             container_id,
             ["test", "-e", old_path],
             user=EXEC_USER,
@@ -223,7 +222,7 @@ class Files:
         if rc != 0:
             raise FileNotFoundError("Source path not found")
         # Check dest does not exist
-        rc, _out, _err = await self.podman.exec_container(
+        rc, _out, _err = await self.app_state.podman.exec_container(
             container_id,
             ["test", "-e", new_path],
             user=EXEC_USER,
@@ -232,13 +231,13 @@ class Files:
             raise FileExistsError("Destination already exists")
         # Create parent directory
         parent = posixpath.dirname(new_path)
-        await self.podman.exec_container(
+        await self.app_state.podman.exec_container(
             container_id,
             ["mkdir", "-p", "--", parent],
             user=EXEC_USER,
         )
         # Move
-        rc, _out, err = await self.podman.exec_container(
+        rc, _out, err = await self.app_state.podman.exec_container(
             container_id,
             ["mv", "--", old_path, new_path],
             user=EXEC_USER,
@@ -255,7 +254,7 @@ class Files:
         # mkdir -p + cat > file in one sh invocation.
         # Path is passed as $1 (positional arg), never interpolated into the
         # command string, so shell metacharacters in the path are harmless.
-        rc, _out, err = await self.podman.exec_container(
+        rc, _out, err = await self.app_state.podman.exec_container(
             container_id,
             [
                 "sh",

--- a/src/backend/klangk_backend/main.py
+++ b/src/backend/klangk_backend/main.py
@@ -585,7 +585,7 @@ def build_app(settings: KlangkSettings) -> FastAPI:
     # #1468: Podman(settings) owns the resolved binary path + the ~20 CLI
     # wrappers. Constructed before the registry/terminal so they reach it
     # via self.app_state.podman (#1426).
-    app.state.podman = podman.Podman(settings)
+    app.state.podman = podman.Podman(app.state)
     # Slice 2c (#1475): the WebSocketState is an owned instance wired onto
     # app.state.sockets. Constructed before the registry so it reaches it
     # via self.app_state.sockets — no module-level singleton.
@@ -621,7 +621,7 @@ def build_app(settings: KlangkSettings) -> FastAPI:
     # settings, not frozen at import). Bound as the active DB for the
     # lifespan's context in the lifespan itself (#1520: no module-global
     # backstop — the model/ free functions reach it via a ContextVar).
-    app.state.db = model.db.DB(settings)
+    app.state.db = model.db.DB(app.state)
     # #1563 / #1572: Model(app_state) composes the per-domain data-access
     # sub-objects (tokens, login_attempts, invitations, ports here; users,
     # acl, workspaces, chat arrive in follow-up issues). Each reaches the

--- a/src/backend/klangk_backend/model/db.py
+++ b/src/backend/klangk_backend/model/db.py
@@ -28,7 +28,6 @@ from sqlalchemy import event
 from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.pool import NullPool
 
-from ..settings import KlangkSettings
 
 logger = logging.getLogger(__name__)
 
@@ -115,12 +114,17 @@ class DB:
     frozen-at-import hazard (#1452).
     """
 
-    def __init__(self, settings: KlangkSettings):
-        self.settings = settings
-        raw = settings.data_dir
-        self.data_dir = Path(raw)
-        self.db_path = self.data_dir / "klangk.db"
+    def __init__(self, app_state):
+        self.app_state = app_state
         self.engine = None
+
+    @property
+    def data_dir(self) -> Path:
+        return Path(self.app_state.settings.data_dir)
+
+    @property
+    def db_path(self) -> Path:
+        return self.data_dir / "klangk.db"
 
     def make_engine(self):
         """Create a new async engine with PRAGMA listeners.

--- a/src/backend/klangk_backend/nginx.py
+++ b/src/backend/klangk_backend/nginx.py
@@ -15,8 +15,9 @@ parameter so it serves both the production UDS bind
 See #1392 (design record) and #1396 (this chunk).
 
 The settings-driven rendering logic lives on :class:`NginxRenderer`, an
-owned instance constructed with ``app_state`` (``self._settings =
-app_state.settings``) per the composition-root refactor (#1426, #1469).
+owned instance constructed with ``app_state`` per the composition-root
+refactor (#1426, #1469).  Settings are read live via
+``self.app_state.settings`` (#1608).
 Pure helpers (upstream constructors, host-IP auto-detection, the minimal-
 template auth-location formatter) stay module-level — they don't read
 settings.
@@ -158,8 +159,8 @@ def _egress_auth_locations(upstream: str) -> str:
 class NginxRenderer:
     """Settings-driven ``nginx.conf`` renderer (#1396, #1469).
 
-    Constructed with ``app_state`` (``self._settings = app_state.settings``)
-    per the composition-root pattern. The renderer is a pure function of the
+    Constructed with ``app_state`` per the composition-root pattern; settings
+    are read live via ``self.app_state.settings`` (#1608). The renderer is a pure function of the
     merged config (settings + env probes); it does not touch podman.
     ``NginxWatchdog`` owns an instance and calls :meth:`render_config` /
     :meth:`find_nginx_bin` / :meth:`write_config` from its ``_prepare`` step.
@@ -740,8 +741,9 @@ def _nginx_preexec() -> None:  # pragma: no cover  – runs in forked child
 class NginxWatchdog:
     """Owns the nginx child process and its supervision task (#1463).
 
-    Constructed with ``app_state`` (``self._settings = app_state.settings``)
-    and owns a :class:`NginxRenderer` instance for config rendering (#1469).
+    Constructed with ``app_state`` and owns a :class:`NginxRenderer` instance
+    for config rendering (#1469). Settings are read live via
+    ``self.app_state.settings`` (#1608).
     Stored on ``app.state.nginx_watchdog``; the lifespan calls
     ``.start()`` / ``.stop()``.
     """

--- a/src/backend/klangk_backend/nginx.py
+++ b/src/backend/klangk_backend/nginx.py
@@ -36,9 +36,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-from .settings import (
-    KlangkSettings,
-)
 
 logger = logging.getLogger(__name__)
 
@@ -170,7 +167,6 @@ class NginxRenderer:
 
     def __init__(self, app_state) -> None:
         self._app_state = app_state
-        self._settings: KlangkSettings = app_state.settings
 
     # -- DNS / ACL / size computation --------------------------------------
 
@@ -180,7 +176,7 @@ class NginxRenderer:
         From ``KLANGK_DNS_SERVERS`` (comma→space) if set, else parsed from
         ``/etc/resolv.conf`` (IPv6 bracketed for nginx), else ``8.8.8.8``.
         """
-        raw = self._settings.dns_servers
+        raw = self._app_state.settings.dns_servers
         if raw:
             servers = []
             for token in str(raw).split(","):
@@ -220,7 +216,7 @@ class NginxRenderer:
         127.0.0.1 NOT implicitly added), else auto-detected host IPv4s, else
         the RFC1918 fallback.
         """
-        explicit = self._settings.container_subnets
+        explicit = self._app_state.settings.container_subnets
         if explicit:
             entries = [
                 s.strip() for s in str(explicit).split(",") if s.strip()
@@ -320,7 +316,7 @@ class NginxRenderer:
 
         The setting is in bytes (default 500 MB); nginx wants ``Nm``. Minimum 1m.
         """
-        raw = self._settings.file_upload_size_max
+        raw = self._app_state.settings.file_upload_size_max
         try:
             bytes_ = int(str(raw))
         except (TypeError, ValueError):
@@ -336,7 +332,7 @@ class NginxRenderer:
         Disabled entirely when ``KLANGK_HOSTED_PORTS_PER_WORKSPACE`` is exactly 0
         — mirrors the backend's ``ports_per_workspace_cap()`` (#1237).
         """
-        raw = self._settings.hosted_ports_per_workspace
+        raw = self._app_state.settings.hosted_ports_per_workspace
         if str(raw).strip() == "0":
             return (
                 "    # Hosted-app serving is disabled "
@@ -386,10 +382,10 @@ class NginxRenderer:
         URL and key are resolved here (Python's resolver, not the retired
         ``klangk-resolve-value`` console script).
         """
-        base_url = self._settings.llm_base_url
+        base_url = self._app_state.settings.llm_base_url
         if not base_url:
             return ""
-        api_key = self._settings.llm_api_key
+        api_key = self._app_state.settings.llm_api_key
         return (
             f"    location ~ ^/llm-proxy/(.*)$ {{\n"
             f"{acl}\n"
@@ -412,7 +408,7 @@ class NginxRenderer:
 
     def _reject_proxy_headers(self) -> bool:
         """True if KLANGK_REJECT_PROXY_HEADERS is set (hard trust-off)."""
-        raw = self._settings.reject_proxy_headers
+        raw = self._app_state.settings.reject_proxy_headers
         return bool(raw and str(raw).strip().lower() in ("1", "true", "yes"))
 
     def _realip_block(self) -> str:
@@ -437,7 +433,7 @@ class NginxRenderer:
         """
         if self._reject_proxy_headers():
             return ""
-        raw = self._settings.trusted_proxy_cidrs
+        raw = self._app_state.settings.trusted_proxy_cidrs
         entries: list[str] = []
         for token in (raw or "").split(","):
             token = token.strip()
@@ -467,7 +463,7 @@ class NginxRenderer:
         )
 
     def _trust_outer_proxy(self) -> bool:
-        raw = self._settings.trust_outer_proxy
+        raw = self._app_state.settings.trust_outer_proxy
         return str(raw).strip().lower() in ("1", "true", "yes")
 
     # -- Main renderer -----------------------------------------------------
@@ -484,7 +480,7 @@ class NginxRenderer:
         settings (env > config file > defaults) plus the host-IP / DNS
         auto-detection probes.
         """
-        if self._settings.port is None:
+        if self._app_state.settings.port is None:
             return self._render_headless_config(upstream)
         return self._render_full_config(upstream)
 
@@ -546,8 +542,8 @@ class NginxRenderer:
         only served surface is container egress (plus same-uid UDS access to
         the backend, which bypasses nginx entirely).
         """
-        egress_port = self._settings.egress_port
-        egress_listen = self._settings.egress_listen
+        egress_port = self._app_state.settings.egress_port
+        egress_listen = self._app_state.settings.egress_listen
         client_max_body_size = self.compute_client_max_body_size()
         resolvers = self.detect_dns_resolvers()
         acl, _ = self.compute_container_acls()
@@ -588,10 +584,10 @@ http {{
         no ``auth_request`` infra (it has no token-gated locations); all of
         that lives in the egress block.
         """
-        listen_addr = self._settings.listen
-        port = self._settings.port
-        egress_port = self._settings.egress_port
-        egress_listen = self._settings.egress_listen
+        listen_addr = self._app_state.settings.listen
+        port = self._app_state.settings.port
+        egress_port = self._app_state.settings.egress_port
+        egress_listen = self._app_state.settings.egress_listen
         client_max_body_size = self.compute_client_max_body_size()
         resolvers = self.detect_dns_resolvers()
         acl, deny = self.compute_container_acls()
@@ -707,7 +703,7 @@ http {{
 
     def find_nginx_bin(self) -> str:
         """Locate the nginx binary: KLANGK_NGINX_BIN > PATH > /usr/sbin/nginx."""
-        configured = self._settings.nginx_bin
+        configured = self._app_state.settings.nginx_bin
         if configured:
             return str(configured)
         found = shutil.which("nginx")
@@ -752,7 +748,6 @@ class NginxWatchdog:
 
     def __init__(self, app_state) -> None:
         self._app_state = app_state
-        self._settings: KlangkSettings = app_state.settings
         self._renderer = NginxRenderer(app_state)
         self._proc: asyncio.subprocess.Process | None = None
         self._task: asyncio.Task | None = None
@@ -802,8 +797,10 @@ class NginxWatchdog:
         selects headless (unset) vs full (set) templates and the nginx listen
         directives; the upstream is always the UDS.
         """
-        uds_path = self._settings.socket
-        conf_path = os.path.join(self._settings.state_dir, "nginx.conf")
+        uds_path = self._app_state.settings.socket
+        conf_path = os.path.join(
+            self._app_state.settings.state_dir, "nginx.conf"
+        )
         bin_path = self._renderer.find_nginx_bin()
         self._renderer.write_config(uds_upstream(uds_path), conf_path)
         return bin_path, conf_path

--- a/src/backend/klangk_backend/oidc.py
+++ b/src/backend/klangk_backend/oidc.py
@@ -153,7 +153,6 @@ class OIDC:
 
     def __init__(self, app_state):
         self.app_state = app_state
-        self.settings = app_state.settings
         self.providers: list[OIDCProvider] = []
         self.discovery_cache: dict[str, CachedDiscovery] = {}
         self.jwks_cache: dict[str, _CachedJWKS] = {}
@@ -190,19 +189,19 @@ class OIDC:
 
         Sources (checked in order, first non-empty wins):
 
-        1. **External file** — ``KLANGK_OIDC_CONFIG`` (``self.settings.oidc_config``)
+        1. **External file** — ``KLANGK_OIDC_CONFIG`` (``self.app_state.settings.oidc_config``)
            pointing at a separate YAML file.  This is an env-var override, so it
            wins over the config file (consistent with the global precedence rule:
            env > file > defaults).
         2. **Inline** — ``oidc_providers:`` list in the klangkd config file
-          (``self.settings.oidc_providers``).
+          (``self.app_state.settings.oidc_providers``).
 
         Returns an empty list if neither is configured.  Raises
         :class:`~klangk_backend.exceptions.ConfigurationError` if the external
         file path is set but doesn't exist.
         """
         # 1. External file via KLANGK_OIDC_CONFIG (env override wins)
-        config_path = self.settings.oidc_config
+        config_path = self.app_state.settings.oidc_config
         if config_path:
             if not os.path.isfile(config_path):
                 raise ConfigurationError(
@@ -215,8 +214,8 @@ class OIDC:
             return _parse_providers(raw, config_dir=config_dir)
 
         # 2. Inline providers from the config file
-        if self.settings.oidc_providers:
-            return _parse_providers(self.settings.oidc_providers)
+        if self.app_state.settings.oidc_providers:
+            return _parse_providers(self.app_state.settings.oidc_providers)
 
         return []
 
@@ -274,11 +273,11 @@ class OIDC:
         that used to default it). The deployment shape is derived from this
         knob plus ``KLANGK_LISTEN``.
 
-        Reads ``self.settings.auth_modes`` (resolved once at construction) —
+        Reads ``self.app_state.settings.auth_modes`` (resolved once at construction) —
         part of the composition-root refactor (#1426): the mode is not re-read
         from the environment at call time.
         """
-        val = self.settings.auth_modes
+        val = self.app_state.settings.auth_modes
         if val in ("oidc", "password", "both", "none"):
             return val
         return "none"
@@ -449,7 +448,7 @@ class OIDC:
 
         If not set, all OIDC logins are accepted with no group sync.
         """
-        raw = self.settings.oidc_login_hook
+        raw = self.app_state.settings.oidc_login_hook
         if not raw:
             self.login_hook = None
             self.login_hook_is_async = False

--- a/src/backend/klangk_backend/plugins.py
+++ b/src/backend/klangk_backend/plugins.py
@@ -33,12 +33,16 @@ class Plugins:
 
     def __init__(self, app_state):
         self.app_state = app_state
-        self.settings = app_state.settings
-        self.plugins_dir = self.settings.plugins_dir
         # Loaded at startup: {env_key: {plugin, description, default, scope}}
         self.declarations: dict[str, dict] = {}
         # Resolved values: {env_key: str}
         self.values: dict[str, str] = {}
+
+    @property
+    def plugins_dir(self) -> str:
+        # Read live off app_state (#1608) so a SIGHUP settings reload picks
+        # up a changed KLANGK_PLUGINS_DIR / KLANGK_CUSTOMIZE_DIR.
+        return self.app_state.settings.plugins_dir
 
     def load(self) -> None:
         """Scan plugin package.json files and resolve config values."""

--- a/src/backend/klangk_backend/podman.py
+++ b/src/backend/klangk_backend/podman.py
@@ -24,7 +24,6 @@ import tempfile
 import time
 from collections.abc import AsyncGenerator
 
-from .settings import KlangkSettings
 from .util import BoundedOutputQueue
 
 logger = logging.getLogger(__name__)
@@ -71,9 +70,12 @@ class Podman:
     per-call ``get_settings()`` reacharound.
     """
 
-    def __init__(self, settings: KlangkSettings):
-        self._settings = settings
-        self._bin = settings.podman_bin
+    def __init__(self, app_state):
+        self.app_state = app_state
+
+    @property
+    def _bin(self) -> str:
+        return self.app_state.settings.podman_bin
 
     @property
     def bin(self) -> str:

--- a/src/backend/klangk_backend/ssl_trust.py
+++ b/src/backend/klangk_backend/ssl_trust.py
@@ -150,7 +150,6 @@ class SSLTrust:
 
     def __init__(self, app_state):
         self.app_state = app_state
-        self.settings = app_state.settings
 
     def ssl_cert_dir(self) -> str | None:
         """Return the deployer SSL cert dir if it should be trusted, else ``None``.
@@ -162,9 +161,9 @@ class SSLTrust:
         of certs).  Never raises — a misconfigured path simply disables
         runtime trust.
         """
-        raw = self.settings.ssl_cert_dir
+        raw = self.app_state.settings.ssl_cert_dir
         if not raw:
-            customize = self.settings.customize_dir
+            customize = self.app_state.settings.customize_dir
             candidate = os.path.join(customize, "certs")
             if os.path.isdir(candidate):
                 raw = candidate
@@ -190,7 +189,7 @@ class SSLTrust:
         ssl_dir = self.ssl_cert_dir()
         if not ssl_dir:
             return None
-        state_dir = self.settings.state_dir
+        state_dir = self.app_state.settings.state_dir
         bundle_dir = os.path.join(state_dir, "ssl")
         try:
             os.makedirs(bundle_dir, exist_ok=True)

--- a/src/backend/klangk_backend/util.py
+++ b/src/backend/klangk_backend/util.py
@@ -222,7 +222,6 @@ class Util:
 
     def __init__(self, app_state):
         self.app_state = app_state
-        self.settings = app_state.settings
         # Instance identity: resolved once at startup by resolve_instance_id()
         # and cached here — no module global (#1553).
         self._instance_id: str | None = None
@@ -249,7 +248,7 @@ class Util:
 
         Defaults to ``<state_dir>/custom`` (derived in ``_require_dirs``).
         """
-        return self.settings.customize_dir
+        return self.app_state.settings.customize_dir
 
     # --- Instance identity ------------------------------------------------
 
@@ -262,7 +261,9 @@ class Util:
         Resolves ``data_dir`` from ``self.settings``. Does **not** open the
         SQLite DB — only the path is computed.
         """
-        return Path(self.settings.data_dir) / self.INSTANCE_ID_FILENAME
+        return (
+            Path(self.app_state.settings.data_dir) / self.INSTANCE_ID_FILENAME
+        )
 
     def resolve_instance_id(self) -> str:
         """Read the instance ID from ``<data_dir>/instance-id``, creating it if absent.
@@ -327,7 +328,8 @@ class Util:
         user don't collide on one PID file.
         """
         return (
-            Path(self.settings.state_dir) / f"klangk-{self.instance_id()}.pid"
+            Path(self.app_state.settings.state_dir)
+            / f"klangk-{self.instance_id()}.pid"
         )
 
     def check_pid_file(self) -> int | None:
@@ -393,7 +395,7 @@ class Util:
 
     def reject_proxy_headers(self) -> bool:
         """True if KLANGK_REJECT_PROXY_HEADERS is set (hard trust-off)."""
-        raw = self.settings.reject_proxy_headers
+        raw = self.app_state.settings.reject_proxy_headers
         return bool(raw and raw.strip().lower() in ("1", "true", "yes"))
 
     def trusted_proxy_cidrs(self) -> set[ipaddress._BaseAddress]:
@@ -403,7 +405,7 @@ class Util:
         at construction (#1461). Invalid entries are logged and skipped; if
         none are valid, defaults to loopback.
         """
-        raw = self.settings.trusted_proxy_cidrs
+        raw = self.app_state.settings.trusted_proxy_cidrs
         trusted: set[ipaddress._BaseAddress] = set()
         for token in (raw or "").split(","):
             token = token.strip()
@@ -508,9 +510,9 @@ class Util:
         headers the request branches are skipped and the env vars are the
         sole source, falling back to bare ``localhost`` / ``http`` / ``""``.
         """
-        hostname = self.settings.hosting_hostname
-        proto = self.settings.hosting_proto
-        base_path = self.settings.hosting_base_path
+        hostname = self.app_state.settings.hosting_hostname
+        proto = self.app_state.settings.hosting_proto
+        base_path = self.app_state.settings.hosting_base_path
         trust = (
             (not self.reject_proxy_headers())
             and self.connection_peer_is_trusted(client_host)
@@ -549,7 +551,7 @@ class Util:
         wiring, not the browser origin). Origins carry no path, so
         KLANGK_HOSTING_BASE_PATH is ignored here.
         """
-        explicit = self.settings.cors_origins
+        explicit = self.app_state.settings.cors_origins
         if explicit:
             return [o.strip() for o in explicit.split(",") if o.strip()]
         hostname, proto, _ = self.derive_hosting_info(None, None)
@@ -562,7 +564,7 @@ class Util:
         long-but-progressing stream never times out. Override with
         KLANGK_BRIDGE_TIMEOUT_SECONDS (the settings field is parsed here).
         """
-        raw = self.settings.bridge_timeout_seconds
+        raw = self.app_state.settings.bridge_timeout_seconds
         try:
             return float(raw) if raw else 30.0
         except (TypeError, ValueError):

--- a/src/backend/klangk_backend/workspaces.py
+++ b/src/backend/klangk_backend/workspaces.py
@@ -133,10 +133,16 @@ class Workspaces:
 
     def __init__(self, app_state):
         self.app_state = app_state
-        self.settings = app_state.settings
-        raw = self.settings.data_dir
-        self.data_dir = Path(raw)
-        self.root = self.data_dir / "workspaces"
+
+    # --- settings-derived paths (read live off app_state, #1608) ---
+
+    @property
+    def data_dir(self) -> Path:
+        return Path(self.app_state.settings.data_dir)
+
+    @property
+    def root(self) -> Path:
+        return self.data_dir / "workspaces"
 
     # --- export/import helpers ---
 
@@ -510,7 +516,7 @@ class Workspaces:
         Skipped entirely if ``KLANGK_ALLOW_AUTOSTART`` is not set.
         Returns the number of containers started.
         """
-        if not self.settings.allow_autostart:
+        if not self.app_state.settings.allow_autostart:
             return 0
 
         ws_list = (

--- a/src/backend/tests/_helpers.py
+++ b/src/backend/tests/_helpers.py
@@ -85,7 +85,7 @@ def wire_db_and_model(state) -> None:
         try:
             state.db = get_test_db()
         except LookupError:
-            state.db = DB(state.settings)
+            state.db = DB(state)
     if getattr(state, "model", None) is None:
         state.model = Model(state)
     if getattr(state, "acl", None) is None:

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -6,6 +6,8 @@ import os
 # code executed inside SQLAlchemy's greenlet context is tracked.
 os.environ.setdefault("COVERAGE_CORE", "sysmon")
 
+import types
+
 import bcrypt
 
 import pytest
@@ -58,7 +60,7 @@ def temp_data_dir(tmp_path, monkeypatch):
     from klangk_backend.model.db import DB
     from _helpers import set_test_db, reset_test_db
 
-    set_test_db(DB(KlangkSettings(os.environ)))
+    set_test_db(DB(types.SimpleNamespace(settings=KlangkSettings(os.environ))))
     # Clear agent caches so each test starts fresh.
     from klangk_backend.model import clear_agent_cache
 

--- a/src/backend/tests/test_agent.py
+++ b/src/backend/tests/test_agent.py
@@ -140,25 +140,25 @@ class TestAgentDisabled:
 
     async def test_is_disabled_true_when_set(self):
         agents = _make_agents()
-        agents.settings.agent_disabled = "1"
+        agents.app_state.settings.agent_disabled = "1"
         assert agents.is_disabled() is True
 
     async def test_is_disabled_truthy_variants(self):
         agents = _make_agents()
         for val in ("1", "true", "YES", "True"):
-            agents.settings.agent_disabled = val
+            agents.app_state.settings.agent_disabled = val
             assert agents.is_disabled() is True, val
 
     async def test_is_disabled_falsy_variants(self):
         agents = _make_agents()
         for val in ("0", "false", "no", ""):
-            agents.settings.agent_disabled = val
+            agents.app_state.settings.agent_disabled = val
             assert agents.is_disabled() is False, val
 
     async def test_ensure_started_refuses_when_disabled(self):
         """The subprocess is never spawned when disabled."""
         session = _make_session("ws-disabled")
-        session.agents.settings.agent_disabled = "1"
+        session.agents.app_state.settings.agent_disabled = "1"
         with patch("asyncio.create_subprocess_exec") as mock_spawn:
             with pytest.raises(AgentError, match="disabled"):
                 await session.ensure_started()
@@ -167,7 +167,7 @@ class TestAgentDisabled:
     async def test_send_prompt_raises_when_disabled(self):
         """send_prompt surfaces the disabled state, never spawns."""
         session = _make_session("ws-disabled")
-        session.agents.settings.agent_disabled = "1"
+        session.agents.app_state.settings.agent_disabled = "1"
         with patch("asyncio.create_subprocess_exec") as mock_spawn:
             with pytest.raises(AgentError, match="disabled"):
                 await session.send_prompt("hello")

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -463,13 +463,17 @@ class TestPortsPerWorkspaceCap:
 
     def test_garbage_falls_back_to_default(self, monkeypatch):
         monkeypatch.setattr(
-            self.registry.settings, "hosted_ports_per_workspace", "abc"
+            self.registry.app_state.settings,
+            "hosted_ports_per_workspace",
+            "abc",
         )
         assert self.registry.ports_per_workspace_cap() == 5
 
     def test_negative_clamped_to_zero(self, monkeypatch):
         monkeypatch.setattr(
-            self.registry.settings, "hosted_ports_per_workspace", "-2"
+            self.registry.app_state.settings,
+            "hosted_ports_per_workspace",
+            "-2",
         )
         assert self.registry.ports_per_workspace_cap() == 0
 
@@ -557,7 +561,9 @@ class TestStartContainer:
         assert "!ALL" in str(call.args[1])
 
     async def test_sudo_enabled(self, workspace, monkeypatch):
-        monkeypatch.setattr(self.registry.settings, "allow_sudo", "true")
+        monkeypatch.setattr(
+            self.registry.app_state.settings, "allow_sudo", "true"
+        )
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
@@ -567,7 +573,9 @@ class TestStartContainer:
         assert "NOPASSWD:ALL" in str(call.args[1])
 
     async def test_sudo_disabled(self, workspace, monkeypatch):
-        monkeypatch.setattr(self.registry.settings, "allow_sudo", "0")
+        monkeypatch.setattr(
+            self.registry.app_state.settings, "allow_sudo", "0"
+        )
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
@@ -575,7 +583,9 @@ class TestStartContainer:
         assert "!ALL" in str(_sudo_call(p).args[1])
 
     async def test_sudo_disabled_false(self, workspace, monkeypatch):
-        monkeypatch.setattr(self.registry.settings, "allow_sudo", "false")
+        monkeypatch.setattr(
+            self.registry.app_state.settings, "allow_sudo", "false"
+        )
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
@@ -586,7 +596,9 @@ class TestStartContainer:
         self, workspace, monkeypatch, app_state
     ):
         """Start with sudo disabled, restart with sudo enabled."""
-        monkeypatch.setattr(self.registry.settings, "allow_sudo", "false")
+        monkeypatch.setattr(
+            self.registry.app_state.settings, "allow_sudo", "false"
+        )
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
@@ -598,7 +610,9 @@ class TestStartContainer:
         await app_state.model.workspaces.update_workspace_container(
             workspace["id"], None
         )
-        monkeypatch.setattr(self.registry.settings, "allow_sudo", "true")
+        monkeypatch.setattr(
+            self.registry.app_state.settings, "allow_sudo", "true"
+        )
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
@@ -609,7 +623,9 @@ class TestStartContainer:
         self, workspace, monkeypatch, app_state
     ):
         """Start with sudo enabled, restart with sudo disabled."""
-        monkeypatch.setattr(self.registry.settings, "allow_sudo", "true")
+        monkeypatch.setattr(
+            self.registry.app_state.settings, "allow_sudo", "true"
+        )
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
@@ -620,7 +636,9 @@ class TestStartContainer:
         await app_state.model.workspaces.update_workspace_container(
             workspace["id"], None
         )
-        monkeypatch.setattr(self.registry.settings, "allow_sudo", "false")
+        monkeypatch.setattr(
+            self.registry.app_state.settings, "allow_sudo", "false"
+        )
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"], "/tmp/ws", "/tmp/home"
@@ -732,8 +750,12 @@ class TestStartContainer:
 
     async def test_llm_proxy_env_vars(self, workspace, monkeypatch):
         """Container gets proxy URL, not real API keys."""
-        monkeypatch.setattr(self.registry.settings, "llm_model", "gemma4:31b")
-        monkeypatch.setattr(self.registry.settings, "egress_port", "8995")
+        monkeypatch.setattr(
+            self.registry.app_state.settings, "llm_model", "gemma4:31b"
+        )
+        monkeypatch.setattr(
+            self.registry.app_state.settings, "egress_port", "8995"
+        )
 
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
@@ -792,7 +814,7 @@ class TestStartContainer:
 
     async def test_pull_policy_from_env(self, workspace, monkeypatch):
         monkeypatch.setattr(
-            self.registry.settings, "image_pull_policy", "missing"
+            self.registry.app_state.settings, "image_pull_policy", "missing"
         )
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
@@ -884,7 +906,11 @@ class TestStartContainer:
 
     async def test_terminal_banner_custom(self, workspace, monkeypatch):
         """Deployer can set a terminal banner via env var."""
-        monkeypatch.setattr(self.registry, "terminal_banner", "Custom warning")
+        monkeypatch.setattr(
+            self.registry.app_state.settings,
+            "terminal_banner",
+            "Custom warning",
+        )
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"],
@@ -939,7 +965,7 @@ class TestStartContainer:
         ssl_dir.mkdir()
         (ssl_dir / "notes.txt").write_text("not a cert")
         # Point the registry's SSLTrust at the empty cert dir so ssl_cert_dir()
-        # actually evaluates it (previously this reassigned registry.settings,
+        # actually evaluates it (previously this reassigned registry.app_state.settings,
         # which the resolver now reaches only via app_state.ssl_trust; patch the
         # settings field the SSLTrust instance reads instead).
         monkeypatch.setattr(
@@ -986,7 +1012,7 @@ class TestStartContainer:
     async def test_cap_clamps_allocation_down(self, workspace, monkeypatch):
         """KLANGK_HOSTED_PORTS_PER_WORKSPACE clamps num_ports down (#1237)."""
         monkeypatch.setattr(
-            self.registry.settings, "hosted_ports_per_workspace", "3"
+            self.registry.app_state.settings, "hosted_ports_per_workspace", "3"
         )
         with patch_podman(self.registry):
             await self.registry.start_container(
@@ -1003,7 +1029,7 @@ class TestStartContainer:
     ):
         """cap=0 trims an existing workspace's allocations on next start."""
         monkeypatch.setattr(
-            self.registry.settings, "hosted_ports_per_workspace", "0"
+            self.registry.app_state.settings, "hosted_ports_per_workspace", "0"
         )
         await app_state.model.ports.find_and_allocate_ports(
             workspace["id"], 5, self.registry.port_range_start
@@ -1021,7 +1047,7 @@ class TestStartContainer:
     async def test_cap_zero_omits_hosting_env(self, workspace, monkeypatch):
         """cap=0 suppresses KLANGK_PORT_MAPPINGS / KLANGK_HOSTING_* (#1237)."""
         monkeypatch.setattr(
-            self.registry.settings, "hosted_ports_per_workspace", "0"
+            self.registry.app_state.settings, "hosted_ports_per_workspace", "0"
         )
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
@@ -1048,7 +1074,7 @@ class TestStartContainer:
         not just trim on the container's first start.
         """
         monkeypatch.setattr(
-            self.registry.settings, "hosted_ports_per_workspace", "0"
+            self.registry.app_state.settings, "hosted_ports_per_workspace", "0"
         )
         await self.registry.allocate_ports(workspace["id"], 5)
         assert await self.registry.get_workspace_ports(workspace["id"]) == []
@@ -1415,43 +1441,57 @@ class TestAllowedMountRoots:
 
     def test_bind_mount_allowed(self, monkeypatch):
         monkeypatch.setattr(
-            self.registry, "allowed_mount_roots", ["/home", "/data"]
+            self.registry.app_state.settings,
+            "allowed_mount_roots",
+            "/home,/data",
         )
         assert (
             self.registry.validate_mount_spec("/home/user/src:/work") is None
         )
 
     def test_bind_mount_exact_root(self, monkeypatch):
-        monkeypatch.setattr(self.registry, "allowed_mount_roots", ["/home"])
+        monkeypatch.setattr(
+            self.registry.app_state.settings, "allowed_mount_roots", "/home"
+        )
         assert self.registry.validate_mount_spec("/home:/work") is None
 
     def test_bind_mount_denied(self, monkeypatch):
         monkeypatch.setattr(
-            self.registry, "allowed_mount_roots", ["/home", "/data"]
+            self.registry.app_state.settings,
+            "allowed_mount_roots",
+            "/home,/data",
         )
         err = self.registry.validate_mount_spec("/etc/passwd:/etc/passwd:ro")
         assert err is not None
         assert "allowed root" in err.lower()
 
     def test_bind_mount_traversal_denied(self, monkeypatch):
-        monkeypatch.setattr(self.registry, "allowed_mount_roots", ["/home"])
+        monkeypatch.setattr(
+            self.registry.app_state.settings, "allowed_mount_roots", "/home"
+        )
         err = self.registry.validate_mount_spec("/home/../etc:/work")
         assert err is not None
         assert "allowed root" in err.lower()
 
     def test_named_volume_always_allowed(self, monkeypatch):
-        monkeypatch.setattr(self.registry, "allowed_mount_roots", ["/home"])
+        monkeypatch.setattr(
+            self.registry.app_state.settings, "allowed_mount_roots", "/home"
+        )
         assert self.registry.validate_mount_spec("my-volume:/data") is None
 
     def test_no_restriction_when_empty(self, monkeypatch):
-        monkeypatch.setattr(self.registry, "allowed_mount_roots", [])
+        monkeypatch.setattr(
+            self.registry.app_state.settings, "allowed_mount_roots", ""
+        )
         assert (
             self.registry.validate_mount_spec("/etc/shadow:/secrets") is None
         )
 
     def test_multiple_roots(self, monkeypatch):
         monkeypatch.setattr(
-            self.registry, "allowed_mount_roots", ["/home", "/data", "/opt"]
+            self.registry.app_state.settings,
+            "allowed_mount_roots",
+            "/home,/data,/opt",
         )
         assert self.registry.validate_mount_spec("/data/files:/work") is None
         assert self.registry.validate_mount_spec("/opt/app:/app") is None
@@ -1465,7 +1505,9 @@ class TestProtectedPaths:
         self.registry = app_state.container_registry
 
     def test_docker_socket_blocked(self, monkeypatch):
-        monkeypatch.setattr(self.registry, "allowed_mount_roots", ["/"])
+        monkeypatch.setattr(
+            self.registry.app_state.settings, "allowed_mount_roots", "/"
+        )
         err = self.registry.validate_mount_spec(
             "/var/run/docker.sock:/var/run/docker.sock"
         )
@@ -1473,7 +1515,9 @@ class TestProtectedPaths:
         assert "protected" in err.lower()
 
     def test_podman_socket_blocked(self, monkeypatch):
-        monkeypatch.setattr(self.registry, "allowed_mount_roots", ["/"])
+        monkeypatch.setattr(
+            self.registry.app_state.settings, "allowed_mount_roots", "/"
+        )
         err = self.registry.validate_mount_spec(
             "/run/podman/podman.sock:/run/podman/podman.sock"
         )
@@ -1481,9 +1525,11 @@ class TestProtectedPaths:
         assert "protected" in err.lower()
 
     def test_data_dir_blocked(self, monkeypatch):
-        monkeypatch.setattr(self.registry, "allowed_mount_roots", ["/"])
         monkeypatch.setattr(
-            self.registry.settings, "data_dir", "/srv/klangk/data"
+            self.registry.app_state.settings, "allowed_mount_roots", "/"
+        )
+        monkeypatch.setattr(
+            self.registry.app_state.settings, "data_dir", "/srv/klangk/data"
         )
         err = self.registry.validate_mount_spec(
             "/srv/klangk/data/workspaces:/loot"
@@ -1522,9 +1568,9 @@ class TestProtectedPaths:
             link.symlink_to(str(target))
 
             monkeypatch.setattr(
-                self.registry,
+                self.registry.app_state.settings,
                 "allowed_mount_roots",
-                [str(allowed)],
+                str(allowed),
             )
             err = self.registry.validate_mount_spec(f"{link}:/mnt/data")
             assert err is None
@@ -1543,9 +1589,9 @@ class TestProtectedPaths:
             link.symlink_to(str(outside))
 
             monkeypatch.setattr(
-                self.registry,
+                self.registry.app_state.settings,
                 "allowed_mount_roots",
-                [str(allowed)],
+                str(allowed),
             )
             err = self.registry.validate_mount_spec(f"{link}:/mnt/data")
             assert err is not None
@@ -3034,7 +3080,9 @@ class TestHealthMonitorLoopSkips:
                 patch.object(
                     monitor, "_check_workspace", AsyncMock()
                 ) as check,
-                patch.object(reg, "health_check_interval", 0.01),
+                patch.object(
+                    reg.app_state.settings, "health_check_interval", "0.01"
+                ),
             ):
                 task = asyncio.create_task(monitor.run_health_loop())
                 await asyncio.sleep(0.05)
@@ -3057,7 +3105,9 @@ class TestHealthMonitorLoopSkips:
                 patch.object(
                     monitor, "_check_workspace", AsyncMock()
                 ) as check,
-                patch.object(reg, "health_check_interval", 0.01),
+                patch.object(
+                    reg.app_state.settings, "health_check_interval", "0.01"
+                ),
             ):
                 task = asyncio.create_task(monitor.run_health_loop())
                 await asyncio.sleep(0.05)
@@ -3080,7 +3130,9 @@ class TestHealthMonitorLoopSkips:
                 patch.object(
                     monitor, "_check_workspace", AsyncMock()
                 ) as check,
-                patch.object(reg, "health_check_interval", 0.01),
+                patch.object(
+                    reg.app_state.settings, "health_check_interval", "0.01"
+                ),
             ):
                 task = asyncio.create_task(monitor.run_health_loop())
                 await asyncio.sleep(0.05)
@@ -3287,7 +3339,9 @@ class TestHealthLoopHeartbeat:
             )
             with (
                 patch.object(monitor, "_check_workspace", AsyncMock()),
-                patch.object(reg, "health_check_interval", 0.01),
+                patch.object(
+                    reg.app_state.settings, "health_check_interval", "0.01"
+                ),
             ):
                 task = asyncio.create_task(monitor.run_health_loop())
                 await asyncio.sleep(0.05)
@@ -3377,7 +3431,7 @@ class TestRegistryServiceSessionLocks:
         settings = make_settings({})
         app_state = types_mod.SimpleNamespace(settings=settings)
         reg = container.ContainerRegistry(app_state)
-        assert reg.settings is not None
+        assert reg.app_state.settings is not None
         assert reg.app_state is app_state
 
 

--- a/src/backend/tests/test_container.py
+++ b/src/backend/tests/test_container.py
@@ -27,11 +27,11 @@ def _make_app_state(registry=None, sockets=None):
     from klangk_backend.wshandler.session import WebSocketState
 
     settings = make_settings({})
-    podman_inst = Podman(settings)
     # Two-phase: build the namespace shell first so the owned instances
     # (sockets, registry, terminal, plugins) can take app_state at
     # construction and reach collaborators via self.app_state (#1426).
     app_state = types.SimpleNamespace(settings=settings)
+    podman_inst = Podman(app_state)
     app_state.podman = podman_inst
     if sockets is None:
         sockets = WebSocketState(app_state)
@@ -2582,7 +2582,7 @@ def _health_registry(ws_state=None):
 
     Constructs a fresh registry via ``_make_app_state`` and wires its
     ``sockets`` to the given WebSocketState (or a fresh one by default).
-    HealthMonitor reaches sockets via ``self.registry.app_state.sockets``.
+    HealthMonitor reaches sockets via ``self.app_state.sockets``.
     """
     app_state = _make_app_state(sockets=ws_state)
     return app_state.container_registry
@@ -2597,16 +2597,16 @@ def _health_state(
     setup_state="complete",
     health_status=None,
     in_startup_grace=False,
-    registry=None,
+    app_state=None,
 ):
     """Build a ContainerState wired up for health checks.
 
     *in_startup_grace* defaults to False so the core healthy/unhealthy
     tests exercise post-grace behavior; the startup-grace tests opt in.
     """
-    if registry is None:
-        registry = _health_registry()
-    st = container.ContainerState(workspace_id, container_id, registry)
+    if app_state is None:
+        app_state = _health_registry().app_state
+    st = container.ContainerState(workspace_id, container_id, app_state)
     st.health_check = health_check
     st.owner_id = owner_id
     st.setup_state = setup_state
@@ -2629,20 +2629,20 @@ class TestHealthMonitorRunOne:
         exec_mock = AsyncMock(return_value=(0, "", ""))
         with (
             patch.object(
-                monitor.registry.app_state.podman, "exec_container", exec_mock
+                monitor.app_state.podman, "exec_container", exec_mock
             ),
             patch.object(
-                monitor.registry.app_state.model.users,
+                monitor.app_state.model.users,
                 "get_user_handle",
                 AsyncMock(return_value="owner"),
             ),
             patch.object(
-                monitor.registry.app_state.workspaces,
+                monitor.app_state.workspaces,
                 "home_path",
                 return_value="/h/p",
             ),
             patch.object(
-                monitor.registry.app_state.workspaces,
+                monitor.app_state.workspaces,
                 "ensure_home_symlink",
                 new_callable=AsyncMock,
                 return_value=("/home/klangk", False),
@@ -2674,22 +2674,22 @@ class TestHealthMonitorRunOne:
         st = _health_state()
         with (
             patch.object(
-                monitor.registry.app_state.podman,
+                monitor.app_state.podman,
                 "exec_container",
                 AsyncMock(return_value=(1, "", "curl: connection refused")),
             ),
             patch.object(
-                monitor.registry.app_state.model.users,
+                monitor.app_state.model.users,
                 "get_user_handle",
                 AsyncMock(return_value="owner"),
             ),
             patch.object(
-                monitor.registry.app_state.workspaces,
+                monitor.app_state.workspaces,
                 "home_path",
                 return_value="/h/p",
             ),
             patch.object(
-                monitor.registry.app_state.workspaces,
+                monitor.app_state.workspaces,
                 "ensure_home_symlink",
                 new_callable=AsyncMock,
                 return_value=("/home/klangk", False),
@@ -2706,22 +2706,22 @@ class TestHealthMonitorRunOne:
         st = _health_state()
         with (
             patch.object(
-                monitor.registry.app_state.podman,
+                monitor.app_state.podman,
                 "exec_container",
                 AsyncMock(return_value=(2, "all good on stdout", "")),
             ),
             patch.object(
-                monitor.registry.app_state.model.users,
+                monitor.app_state.model.users,
                 "get_user_handle",
                 AsyncMock(return_value="owner"),
             ),
             patch.object(
-                monitor.registry.app_state.workspaces,
+                monitor.app_state.workspaces,
                 "home_path",
                 return_value="/h/p",
             ),
             patch.object(
-                monitor.registry.app_state.workspaces,
+                monitor.app_state.workspaces,
                 "ensure_home_symlink",
                 new_callable=AsyncMock,
                 return_value=("/home/klangk", False),
@@ -2738,22 +2738,22 @@ class TestHealthMonitorRunOne:
         st = _health_state()
         with (
             patch.object(
-                monitor.registry.app_state.podman,
+                monitor.app_state.podman,
                 "exec_container",
                 AsyncMock(return_value=(127, "", "")),
             ),
             patch.object(
-                monitor.registry.app_state.model.users,
+                monitor.app_state.model.users,
                 "get_user_handle",
                 AsyncMock(return_value="owner"),
             ),
             patch.object(
-                monitor.registry.app_state.workspaces,
+                monitor.app_state.workspaces,
                 "home_path",
                 return_value="/h/p",
             ),
             patch.object(
-                monitor.registry.app_state.workspaces,
+                monitor.app_state.workspaces,
                 "ensure_home_symlink",
                 new_callable=AsyncMock,
                 return_value=("/home/klangk", False),
@@ -2780,22 +2780,22 @@ class TestHealthMonitorRunOne:
         st = _health_state()
         with (
             patch.object(
-                monitor.registry.app_state.podman,
+                monitor.app_state.podman,
                 "exec_container",
                 AsyncMock(side_effect=podman.PodmanError(500, "boom")),
             ),
             patch.object(
-                monitor.registry.app_state.model.users,
+                monitor.app_state.model.users,
                 "get_user_handle",
                 AsyncMock(return_value="owner"),
             ),
             patch.object(
-                monitor.registry.app_state.workspaces,
+                monitor.app_state.workspaces,
                 "home_path",
                 return_value="/h/p",
             ),
             patch.object(
-                monitor.registry.app_state.workspaces,
+                monitor.app_state.workspaces,
                 "ensure_home_symlink",
                 new_callable=AsyncMock,
                 return_value=("/home/klangk", False),
@@ -2810,7 +2810,7 @@ class TestHealthMonitorRunOne:
         monitor = _health_registry().health
         st = _health_state(owner_id=None)
         with patch.object(
-            monitor.registry.app_state.podman, "exec_container"
+            monitor.app_state.podman, "exec_container"
         ) as exec_mock:
             status, message = await monitor._run_one(st)
         assert status == "unhealthy"
@@ -2823,12 +2823,12 @@ class TestHealthMonitorRunOne:
         st = _health_state(owner_id="uid-owner")
         with (
             patch.object(
-                monitor.registry.app_state.model.users,
+                monitor.app_state.model.users,
                 "get_user_handle",
                 AsyncMock(return_value=None),
             ),
             patch.object(
-                monitor.registry.app_state.podman, "exec_container"
+                monitor.app_state.podman, "exec_container"
             ) as exec_mock,
         ):
             status, message = await monitor._run_one(st)

--- a/src/backend/tests/test_main.py
+++ b/src/backend/tests/test_main.py
@@ -48,7 +48,7 @@ def _make_app_state(settings=None):
     # #1468: container.py / agent.py reach the CLI wrappers via self.podman.
     from klangk_backend.podman import Podman
 
-    app_state.podman = Podman(settings)
+    app_state.podman = Podman(app_state)
     app_state.oidc = oidc.OIDC(app_state)
     app_state.plugins = plugins.Plugins(app_state)
     app_state.workspaces = workspaces.Workspaces(app_state)
@@ -57,7 +57,7 @@ def _make_app_state(settings=None):
     # mirror build_app so lifespan-driven tests have it.
     from klangk_backend.model import db as db_mod
 
-    app_state.db = db_mod.DB(settings)
+    app_state.db = db_mod.DB(app_state)
     # #1572: Model(app_state) composing the converted domains.
     from klangk_backend.model import Model
 

--- a/src/backend/tests/test_model.py
+++ b/src/backend/tests/test_model.py
@@ -1,6 +1,7 @@
 """Tests for model: users, workspaces, messages, port allocations."""
 
 import asyncio
+import types
 import uuid
 
 import aiosqlite
@@ -2154,7 +2155,7 @@ class TestDB:
         from klangk_backend.settings import KlangkSettings
         import os
 
-        db = DB(KlangkSettings(os.environ))
+        db = DB(types.SimpleNamespace(settings=KlangkSettings(os.environ)))
         assert str(db.db_path).endswith("klangk.db")
         assert db.engine is None
 

--- a/src/backend/tests/test_model_app_state.py
+++ b/src/backend/tests/test_model_app_state.py
@@ -381,7 +381,7 @@ class TestNoConfigDivergenceRegression:
             }
         )
         state = types.SimpleNamespace(settings=settings)
-        state.db = DB(settings)
+        state.db = DB(state)
         state.model = Model(state)
 
         # The owned DB resolves to the configured path, not the ambient one.

--- a/src/backend/tests/test_podman.py
+++ b/src/backend/tests/test_podman.py
@@ -5,13 +5,14 @@ import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+import types
 
 from klangk_backend import podman
 from _helpers import make_settings
 
 # Instance whose methods the tests exercise (#1468: the ~20 free
 # functions became Podman methods; classify/PodmanError stay module-level).
-_p = podman.Podman(make_settings({}))
+_p = podman.Podman(types.SimpleNamespace(settings=make_settings({})))
 
 EXEC = "klangk_backend.podman.asyncio.create_subprocess_exec"
 

--- a/src/backend/tests/test_podman_exec.py
+++ b/src/backend/tests/test_podman_exec.py
@@ -4,12 +4,13 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+import types
 
 
 from klangk_backend.podman import ExecSession, Podman
 from _helpers import make_settings
 
-_podman = Podman(make_settings({}))
+_podman = Podman(types.SimpleNamespace(settings=make_settings({})))
 
 
 def _mock_proc(stdout_data=b"", returncode=None):

--- a/src/backend/tests/test_wshandler.py
+++ b/src/backend/tests/test_wshandler.py
@@ -9958,7 +9958,7 @@ class TestTokenRenewal:
 
             with (
                 patch.object(
-                    app_state.auth, "workspace_token_expire_hours", 1.0
+                    app_state.settings, "workspace_token_hours", "1.0"
                 ),
                 patch.object(
                     _mock_term,
@@ -10011,7 +10011,7 @@ class TestTokenRenewal:
 
             with (
                 patch.object(
-                    app_state.auth, "workspace_token_expire_hours", 0.0001
+                    app_state.settings, "workspace_token_hours", "0.0001"
                 ),
                 patch.object(
                     _mock_term,
@@ -10052,7 +10052,7 @@ class TestTokenRenewal:
         try:
             with (
                 patch.object(
-                    app_state.auth, "workspace_token_expire_hours", 0.0001
+                    app_state.settings, "workspace_token_hours", "0.0001"
                 ),
                 patch.object(
                     _mock_term,
@@ -10635,7 +10635,7 @@ class TestTokenRenewalFailureLogged:
         ) + timedelta(seconds=0.05)
         with (
             patch.object(
-                app_state.auth, "workspace_token_expire_hours", 0.0001
+                app_state.settings, "workspace_token_hours", "0.0001"
             ),
             patch.object(
                 _mock_term,


### PR DESCRIPTION
## Summary

- Remove all cached `app_state` subobjects (`self.settings`, `self.podman`, `self.db`) across 11 modules — every state object now reads `self.app_state.settings.<field>` live
- Convert `Podman(settings)` → `Podman(app_state)` and `DB(settings)` → `DB(app_state)` with derived attrs (`_bin`, `data_dir`, `db_path`) as live properties
- Convert container collaborators (`PortAllocator`, `IdleMonitor`, `HealthMonitor`, `ContainerState`) from taking `registry` to taking `app_state`, reaching the registry via `self.app_state.container_registry`
- Replace all frozen settings-derived attributes materialized at construction with live `self.app_state.settings.<field>` reads

## Test plan

- [x] Backend tests pass (`-n auto`, 2472 tests, 100% coverage)
- [ ] E2E tests on CI

Closes #1608