### PR TITLE
Centralize logging: Logger(app) state object configured in build_app() (#1467)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -30,17 +30,16 @@ operators or integrators to act when upgrading.
 - **`KLANGK_LOG_LEVEL` — centralized, settings-driven logging (#1467).**
   Logging is no longer configured as an import-time side-effect of
   `klangk.main` (the `logging.basicConfig(...)` call is gone). It is now
-  owned by a `Logger(app)` state object constructed in `build_app()` and
-  stored on `app.state.logger`, the same composition-root pattern as the
-  other owned subsystems. Sensible defaults (INFO level, the pre-refactor
-  colored console format, and central silencing of chatty third-party
-  loggers) are applied at import of `klangk.logger`, so logging is formatted
-  from the very first log call — including during `KlangkSettings`
-  construction, which runs before any `app` exists. Once `build_app` runs,
-  `Logger(app)` re-applies the level from the new `log_level` setting
+  configured by a dedicated module, `klangk.logger`, with two phases:
+  sensible defaults (INFO level, the pre-refactor colored console format,
+  and central silencing of chatty third-party loggers) are applied at import,
+  so logging is formatted from the very first log call — including during
+  `KlangkSettings` construction, which runs before any `app` exists; then
+  `build_app()` re-applies the level from the new `log_level` setting
   (`KLANGK_LOG_LEVEL`, default `INFO`; accepts a level name like
   `DEBUG`/`WARNING`/`ERROR`/`CRITICAL` in any case, or a numeric value, and
-  rejects garbage at boot). The level is re-applied on a SIGHUP reload, so
+  rejects garbage at boot). The level is re-applied on a SIGHUP reload (after
+  the settings swap, before the subsystem reconfigure loop), so
   `KLANGK_LOG_LEVEL` takes effect without a process restart. Chatty
   third-party loggers (`uvicorn.access`, `sqlalchemy.engine`, `httpx`,
   `httpcore`, `watchfiles`, `asyncio`) are silenced centrally to `WARNING`.

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -32,14 +32,18 @@ operators or integrators to act when upgrading.
   `klangk.main` (the `logging.basicConfig(...)` call is gone). It is now
   owned by a `Logger(app)` state object constructed in `build_app()` and
   stored on `app.state.logger`, the same composition-root pattern as the
-  other owned subsystems. The root log level is read from the new
-  `log_level` setting (`KLANGK_LOG_LEVEL`, default `INFO`; accepts a level
-  name like `DEBUG`/`WARNING`/`ERROR`/`CRITICAL` in any case, or a numeric
-  value, and rejects garbage at boot). The level is re-applied on a SIGHUP
-  reload, so `KLANGK_LOG_LEVEL` takes effect without a process restart.
-  Chatty third-party loggers (`uvicorn.access`, `sqlalchemy.engine`,
-  `httpx`, `httpcore`, `watchfiles`, `asyncio`) are now silenced centrally
-  to `WARNING`.
+  other owned subsystems. Sensible defaults (INFO level, the pre-refactor
+  colored console format, and central silencing of chatty third-party
+  loggers) are applied at import of `klangk.logger`, so logging is formatted
+  from the very first log call — including during `KlangkSettings`
+  construction, which runs before any `app` exists. Once `build_app` runs,
+  `Logger(app)` re-applies the level from the new `log_level` setting
+  (`KLANGK_LOG_LEVEL`, default `INFO`; accepts a level name like
+  `DEBUG`/`WARNING`/`ERROR`/`CRITICAL` in any case, or a numeric value, and
+  rejects garbage at boot). The level is re-applied on a SIGHUP reload, so
+  `KLANGK_LOG_LEVEL` takes effect without a process restart. Chatty
+  third-party loggers (`uvicorn.access`, `sqlalchemy.engine`, `httpx`,
+  `httpcore`, `watchfiles`, `asyncio`) are silenced centrally to `WARNING`.
 
 - **Option to require consent banner acceptance on every visit (#1544).**
   New setting `login_banner_every_visit` / `KLANGK_LOGIN_BANNER_EVERY_VISIT`

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -27,6 +27,20 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **`KLANGK_LOG_LEVEL` — centralized, settings-driven logging (#1467).**
+  Logging is no longer configured as an import-time side-effect of
+  `klangk.main` (the `logging.basicConfig(...)` call is gone). It is now
+  owned by a `Logger(app)` state object constructed in `build_app()` and
+  stored on `app.state.logger`, the same composition-root pattern as the
+  other owned subsystems. The root log level is read from the new
+  `log_level` setting (`KLANGK_LOG_LEVEL`, default `INFO`; accepts a level
+  name like `DEBUG`/`WARNING`/`ERROR`/`CRITICAL` in any case, or a numeric
+  value, and rejects garbage at boot). The level is re-applied on a SIGHUP
+  reload, so `KLANGK_LOG_LEVEL` takes effect without a process restart.
+  Chatty third-party loggers (`uvicorn.access`, `sqlalchemy.engine`,
+  `httpx`, `httpcore`, `watchfiles`, `asyncio`) are now silenced centrally
+  to `WARNING`.
+
 - **Option to require consent banner acceptance on every visit (#1544).**
   New setting `login_banner_every_visit` / `KLANGK_LOGIN_BANNER_EVERY_VISIT`
   (default `false`, surfaced on `GET /api/v1/config`). When `true`, the

--- a/src/klangk/klangk/launcher.py
+++ b/src/klangk/klangk/launcher.py
@@ -29,6 +29,11 @@ from pathlib import Path
 import typer
 import uvicorn
 
+# Import the logger before settings so its module-level default configuration
+# is active during ``KlangkSettings(...)`` construction (validators + the
+# file:/cmd: indirection resolver log before any app exists). ``build_app``'s
+# ``Logger(app)`` later overrides the level from ``KLANGK_LOG_LEVEL`` (#1467).
+from klangk.logger import Logger  # noqa: F401
 from klangk.settings import KlangkSettings
 
 # The default config-file location — a deployed klangkd finds its config here

--- a/src/klangk/klangk/launcher.py
+++ b/src/klangk/klangk/launcher.py
@@ -29,11 +29,12 @@ from pathlib import Path
 import typer
 import uvicorn
 
-# Import the logger before settings so its module-level default configuration
-# is active during ``KlangkSettings(...)`` construction (validators + the
-# file:/cmd: indirection resolver log before any app exists). ``build_app``'s
-# ``Logger(app)`` later overrides the level from ``KLANGK_LOG_LEVEL`` (#1467).
-from klangk.logger import Logger  # noqa: F401
+# Import the logger module before settings so its module-level default
+# configuration is active during ``KlangkSettings(...)`` construction
+# (validators + the file:/cmd: indirection resolver log before any app
+# exists). ``build_app``'s ``configure(settings)`` later overrides the
+# level from ``KLANGK_LOG_LEVEL`` (#1467).
+from klangk import logger  # noqa: F401
 from klangk.settings import KlangkSettings
 
 # The default config-file location — a deployed klangkd finds its config here

--- a/src/klangk/klangk/logger.py
+++ b/src/klangk/klangk/logger.py
@@ -1,4 +1,4 @@
-"""Centralized logging configuration owned by ``app.state`` (#1467).
+"""Centralized logging configuration (#1467).
 
 Previously logging was configured by an import-time ``logging.basicConfig(...)``
 call in ``main.py``'s module body. That had three problems:
@@ -10,44 +10,41 @@ call in ``main.py``'s module body. That had three problems:
 3. **No third-party logger management.** uvicorn, sqlalchemy, httpx, ... each
    got their own logger with no central place to silence them.
 
-:class:`Logger` is the owned state object that fixes all three. It is
-constructed once in :func:`klangk.main.build_app` and hung on
-``app.state.logger`` — the same ``X(app)`` composition-root pattern every
-other subsystem (``Util``, ``Model``, ``Container``, ...) uses. It owns:
+This module is the single, central, idempotent setup point. It exposes two
+module-level functions (no state object):
 
-- the single :class:`~logging.StreamHandler` on the root logger (with the
-  colored format previously hardcoded in ``main.py``),
-- the root level, read live from ``settings.log_level`` (``KLANGK_LOG_LEVEL``),
-- central silencing of chatty third-party loggers.
+- :func:`configure_defaults` — applied once at *this module's import* (see the
+  module-level call at the bottom). Installs the colored console handler on
+  the root logger at INFO, with central third-party silencing. This means
+  logging is formatted from the very first log call — including during
+  :class:`~klangk.settings.KlangkSettings` construction, which runs *before*
+  any ``app`` exists (the settings validators and the ``file:``/``cmd:``
+  indirection resolver log).
+- :func:`configure` — called once settings are finalized (in
+  :func:`klangk.main.build_app`) to re-apply the level from
+  ``settings.log_level`` (``KLANGK_LOG_LEVEL``), overriding the import-time
+  defaults. Idempotent, so it is also the **SIGHUP reconfigure** path:
+  :func:`klangk.main.Lifecycle._apply_reloaded_settings` calls it right after
+  the settings swap (before the subsystem loop, so warnings the loop emits use
+  the new level).
 
-**Two-phase configuration.** Sensible defaults are applied at *import* of
-this module (``Logger.configure_defaults()``, INFO level + colored format +
-third-party silencing), so logging is formatted from the very first log
-call — including during :class:`~klangk.settings.KlangkSettings` construction,
-which runs *before* any ``app``/``app.state.logger`` exists (the settings
-validators and the ``file:``/``cmd:`` indirection resolver log). Once
-``build_app`` runs, ``Logger(app)`` re-applies the level from
-``KLANGK_LOG_LEVEL``, overriding the defaults. This is a single, central,
-idempotent setup point — not the old scattered, import-order-dependent
-``basicConfig`` that used to live in ``main.py``'s body.
+Both reach the same private :func:`_apply`, which removes any prior
+klangk-tagged handler before adding the new one — so repeated calls (fresh
+``configure`` per test app, a HUP reload) never stack duplicate handlers, and
+the dedup is robust to other handlers on the root (pytest's ``caplog``,
+operator-added handlers, ...).
 
-Per-module ``logger = logging.getLogger(__name__)`` calls elsewhere in the
-package are **kept** — those obtain *named logger handles* (not configuration)
-that propagate to the root logger :class:`Logger` configures. They are the
-idiomatic Python pattern; centralizing the *configuration* in one deliberate
-setup point is what the composition-root refactor (#1426) calls for.
-
-Live reload: :meth:`reconfigure` re-applies the level from a freshly-reloaded
-settings object, so ``KLANGK_LOG_LEVEL`` takes effect on a SIGHUP restart
-without a process restart (#1587). It is a member of the
-``_apply_reloaded_settings`` subsystem list in :mod:`klangk.main`.
+Emission is unchanged and stays idiomatic: per-module
+``logger = logging.getLogger(__name__)`` everywhere. Those obtain named
+handles that propagate to the root logger this module configures; centralizing
+the *configuration* is what the composition-root refactor (#1426) calls for.
 """
 
 from __future__ import annotations
 
 import logging
 
-__all__ = ["Logger"]
+__all__ = ["configure", "configure_defaults"]
 
 
 def _level_to_int(value: str) -> int:
@@ -68,135 +65,100 @@ def _level_to_int(value: str) -> int:
     return logging.INFO
 
 
-class Logger:
-    """Owned logging-configuration state object (``app.state.logger``).
+# The colored console format, moved here from ``main.py``'s module scope (where
+# it lived next to the now-removed ``logging.basicConfig`` call).
+_LIGHT_BLUE = "\033[94m"
+_RESET = "\033[0m"
+_FORMAT = (
+    f"{_LIGHT_BLUE}%(asctime)s %(levelname)s:%(name)s:%(message)s{_RESET}"
+)
+_DATEFMT = "%H:%M:%S"
 
-    Constructed once in :func:`klangk.main.build_app` and stored on
-    ``app.state.logger``. Owns the root logger's handler, format, level, and
-    third-party silencing. Reads ``settings.log_level`` live so a SIGHUP
-    reload of ``KLANGK_LOG_LEVEL`` propagates without a process restart.
+# The level applied by ``configure_defaults()`` (the pre-settings phase).
+# ``configure(settings)`` overrides it with ``settings.log_level`` once settings
+# are constructed.
+_DEFAULT_LEVEL = logging.INFO
+
+# Third-party loggers managed centrally (logger name -> level). These are
+# libraries klangk depends on that log at their own verbosity by default and
+# would drown klangk's own INFO output. Levels are re-applied on every
+# configure() so an operator raising ``KLANGK_LOG_LEVEL`` to DEBUG still gets a
+# quiet chatty-library surface unless they raise these explicitly via a future
+# per-logger override.
+_THIRD_PARTY_LEVELS: dict[str, int | str] = {
+    # uvicorn's startup/error logs are useful; per-request access logs are
+    # noisy at default verbosity.
+    "uvicorn": "INFO",
+    "uvicorn.error": "INFO",
+    "uvicorn.access": "WARNING",
+    # SQLAlchemy engine emits every query at INFO when unchecked.
+    "sqlalchemy.engine": "WARNING",
+    # httpx/httpcore log every request/connection at INFO.
+    "httpx": "WARNING",
+    "httpcore": "WARNING",
+    # watchfiles spams detection/rust internals at INFO.
+    "watchfiles": "WARNING",
+    # asyncio debug chatter.
+    "asyncio": "WARNING",
+}
+
+
+def _apply(level: int) -> None:
+    """Install/replace the klangk root handler at ``level`` + silence 3rd-party.
+
+    Shared by :func:`configure_defaults` (pre-settings, default level) and
+    :func:`configure` (settings-driven level). Idempotent: any handler
+    previously tagged by this module is removed from the root logger before
+    the new one is added, so repeated calls never stack duplicate handlers.
+    The handler is tagged via a private attribute so this dedup is robust to
+    other handlers on the root (pytest's ``caplog`` handler, operator-added
+    handlers, ...).
     """
+    root = logging.getLogger()
 
-    # The colored console format, moved here from ``main.py``'s module scope
-    # (where it lived next to the now-removed ``logging.basicConfig`` call).
-    _LIGHT_BLUE = "\033[94m"
-    _RESET = "\033[0m"
-    _FORMAT = (
-        f"{_LIGHT_BLUE}%(asctime)s %(levelname)s:%(name)s:%(message)s{_RESET}"
-    )
-    _DATEFMT = "%H:%M:%S"
-    # The level applied by ``configure_defaults()`` (the pre-settings phase).
-    # ``Logger(app)`` overrides this with ``settings.log_level`` once settings
-    # are constructed.
-    _DEFAULT_LEVEL = logging.INFO
+    # Drop any pre-existing klangk-tagged handler(s) so we never stack.
+    for handler in list(root.handlers):
+        if getattr(handler, "_klangk_log_handler", False):
+            root.removeHandler(handler)
 
-    # Third-party loggers managed centrally (logger name -> level). These are
-    # libraries klangk depends on that log at their own verbosity by default
-    # and would drown klangk's own INFO output. Levels are re-applied on every
-    # configure()/reconfigure() so an operator raising ``KLANGK_LOG_LEVEL``
-    # to DEBUG still gets a quiet chatty-library surface unless they raise
-    # these explicitly via a future per-logger override.
-    _THIRD_PARTY_LEVELS: dict[str, int | str] = {
-        # uvicorn's startup/error logs are useful; per-request access logs are
-        # noisy at default verbosity.
-        "uvicorn": "INFO",
-        "uvicorn.error": "INFO",
-        "uvicorn.access": "WARNING",
-        # SQLAlchemy engine emits every query at INFO when unchecked.
-        "sqlalchemy.engine": "WARNING",
-        # httpx/httpcore log every request/connection at INFO.
-        "httpx": "WARNING",
-        "httpcore": "WARNING",
-        # watchfiles spams detection/rust internals at INFO.
-        "watchfiles": "WARNING",
-        # asyncio debug chatter.
-        "asyncio": "WARNING",
-    }
+    handler = logging.StreamHandler()
+    # Private tag for cross-call dedup (see the loop above).
+    handler._klangk_log_handler = True  # type: ignore[attr-defined]
+    handler.setFormatter(logging.Formatter(_FORMAT, datefmt=_DATEFMT))
+    handler.setLevel(level)
+    root.addHandler(handler)
 
-    def __init__(self, app):
-        self.app = app
-        # The handler this instance installed on the root logger, tracked so
-        # reconfigure() can replace rather than stack. See _apply() for the
-        # cross-instance dedup that also keeps repeated construction (e.g.
-        # per-test app_state mocks) from stacking handlers.
-        self._handler: logging.Handler | None = None
-        self.configure()
+    root.setLevel(level)
 
-    @classmethod
-    def configure_defaults(cls) -> None:
-        """Configure root logging with default (pre-settings) values.
+    for name, lvl in _THIRD_PARTY_LEVELS.items():
+        logging.getLogger(name).setLevel(lvl)
 
-        Applied once at this module's import (see the module-level call
-        below), so logging is formatted from the very first log call —
-        including during ``KlangkSettings`` construction, which runs before
-        any ``app`` exists. Idempotent: ``_apply`` removes any prior
-        klangk-tagged handler first. ``Logger(app)`` later overrides the
-        level from ``KLANGK_LOG_LEVEL``.
-        """
-        cls._apply(cls._DEFAULT_LEVEL)
 
-    def reconfigure(self, app) -> None:
-        """Re-apply configuration against a freshly-reloaded ``app``.
+def configure_defaults() -> None:
+    """Configure root logging with default (pre-settings) values.
 
-        Called by the SIGHUP reload path in :mod:`klangk.main` alongside
-        every other subsystem's ``reconfigure``. Re-reads ``log_level`` off
-        the new settings and re-applies the root level (and third-party
-        levels), so ``KLANGK_LOG_LEVEL`` takes effect without a process
-        restart (#1587).
-        """
-        self.app = app
-        self.configure()
+    Applied once at this module's import (see the module-level call below), so
+    logging is formatted from the very first log call — including during
+    ``KlangkSettings`` construction, which runs before any ``app`` exists.
+    Idempotent. :func:`configure` later overrides the level from
+    ``KLANGK_LOG_LEVEL``.
+    """
+    _apply(_DEFAULT_LEVEL)
 
-    @property
-    def _level(self) -> int:
-        """The root level, resolved live from settings at call time."""
-        return _level_to_int(self.app.state.settings.log_level)
 
-    def configure(self) -> None:
-        """Re-apply configuration from settings (handler, format, level)."""
-        self._handler = self._apply(self._level)
+def configure(settings) -> None:
+    """Re-apply configuration from finalized settings.
 
-    @classmethod
-    def _apply(cls, level: int) -> logging.Handler:
-        """Install/replace the klangk root handler at ``level`` + silence 3rd-party.
-
-        Shared by :meth:`configure_defaults` (pre-settings, default level) and
-        instance :meth:`configure`/:meth:`reconfigure` (settings-driven level).
-        Idempotent across instances: any handler previously tagged by a
-        :class:`Logger` is removed from the root logger before the new one is
-        added, so repeated construction (a fresh ``Logger`` per test app, or a
-        reconfigure) never stacks duplicate handlers. The handler is tagged
-        via a private attribute so this dedup is robust to other handlers on
-        the root (pytest's ``caplog`` handler, operator-added handlers, ...).
-        Returns the installed handler so the caller can track it.
-        """
-        root = logging.getLogger()
-
-        # Drop any pre-existing klangk-tagged handler(s) so we never stack.
-        for handler in list(root.handlers):
-            if getattr(handler, "_klangk_log_handler", False):
-                root.removeHandler(handler)
-
-        handler = logging.StreamHandler()
-        # Private tag for cross-instance dedup (see the loop above).
-        handler._klangk_log_handler = True  # type: ignore[attr-defined]
-        handler.setFormatter(
-            logging.Formatter(cls._FORMAT, datefmt=cls._DATEFMT)
-        )
-        handler.setLevel(level)
-        root.addHandler(handler)
-
-        root.setLevel(level)
-
-        for name, lvl in cls._THIRD_PARTY_LEVELS.items():
-            logging.getLogger(name).setLevel(lvl)
-        return handler
+    Called in :func:`klangk.main.build_app` (once settings are constructed) and
+    again on every SIGHUP reload (after the settings swap, before the subsystem
+    reconfigure loop) so ``KLANGK_LOG_LEVEL`` takes effect without a process
+    restart (#1587). Reads ``settings.log_level`` live; idempotent.
+    """
+    _apply(_level_to_int(settings.log_level))
 
 
 # Configure sensible defaults at import so logging is formatted from the very
-# first log call — including during ``KlangkSettings`` construction, which
-# runs before any ``app``/``app.state.logger`` exists. ``Logger(app)`` (in
-# ``build_app``) later overrides the level from ``KLANGK_LOG_LEVEL``. This is
-# a single, central, idempotent setup point (not the old scattered,
-# import-order-dependent ``basicConfig`` that lived in ``main.py``). (#1467)
-Logger.configure_defaults()
+# first log call — including during ``KlangkSettings`` construction, which runs
+# before any ``app`` exists. ``configure(settings)`` (in ``build_app``) later
+# overrides the level from ``KLANGK_LOG_LEVEL``. (#1467)
+configure_defaults()

--- a/src/klangk/klangk/logger.py
+++ b/src/klangk/klangk/logger.py
@@ -20,14 +20,22 @@ other subsystem (``Util``, ``Model``, ``Container``, ...) uses. It owns:
 - the root level, read live from ``settings.log_level`` (``KLANGK_LOG_LEVEL``),
 - central silencing of chatty third-party loggers.
 
+**Two-phase configuration.** Sensible defaults are applied at *import* of
+this module (``Logger.configure_defaults()``, INFO level + colored format +
+third-party silencing), so logging is formatted from the very first log
+call — including during :class:`~klangk.settings.KlangkSettings` construction,
+which runs *before* any ``app``/``app.state.logger`` exists (the settings
+validators and the ``file:``/``cmd:`` indirection resolver log). Once
+``build_app`` runs, ``Logger(app)`` re-applies the level from
+``KLANGK_LOG_LEVEL``, overriding the defaults. This is a single, central,
+idempotent setup point — not the old scattered, import-order-dependent
+``basicConfig`` that used to live in ``main.py``'s body.
+
 Per-module ``logger = logging.getLogger(__name__)`` calls elsewhere in the
 package are **kept** — those obtain *named logger handles* (not configuration)
 that propagate to the root logger :class:`Logger` configures. They are the
-idiomatic Python pattern and cannot be replaced with ``app.state.logger``
-references: several modules (notably :mod:`klangk.settings`) log during
-construction, before any ``app`` exists. Centralizing the *configuration* in
-one deliberate setup point is what the composition-root refactor (#1426)
-calls for; the named-handle pattern is orthogonal and correct.
+idiomatic Python pattern; centralizing the *configuration* in one deliberate
+setup point is what the composition-root refactor (#1426) calls for.
 
 Live reload: :meth:`reconfigure` re-applies the level from a freshly-reloaded
 settings object, so ``KLANGK_LOG_LEVEL`` takes effect on a SIGHUP restart
@@ -77,6 +85,10 @@ class Logger:
         f"{_LIGHT_BLUE}%(asctime)s %(levelname)s:%(name)s:%(message)s{_RESET}"
     )
     _DATEFMT = "%H:%M:%S"
+    # The level applied by ``configure_defaults()`` (the pre-settings phase).
+    # ``Logger(app)`` overrides this with ``settings.log_level`` once settings
+    # are constructed.
+    _DEFAULT_LEVEL = logging.INFO
 
     # Third-party loggers managed centrally (logger name -> level). These are
     # libraries klangk depends on that log at their own verbosity by default
@@ -104,11 +116,24 @@ class Logger:
     def __init__(self, app):
         self.app = app
         # The handler this instance installed on the root logger, tracked so
-        # reconfigure() can replace rather than stack. See configure() for
-        # the cross-instance dedup that also keeps repeated construction
-        # (e.g. per-test app_state mocks) from stacking handlers.
+        # reconfigure() can replace rather than stack. See _apply() for the
+        # cross-instance dedup that also keeps repeated construction (e.g.
+        # per-test app_state mocks) from stacking handlers.
         self._handler: logging.Handler | None = None
         self.configure()
+
+    @classmethod
+    def configure_defaults(cls) -> None:
+        """Configure root logging with default (pre-settings) values.
+
+        Applied once at this module's import (see the module-level call
+        below), so logging is formatted from the very first log call —
+        including during ``KlangkSettings`` construction, which runs before
+        any ``app`` exists. Idempotent: ``_apply`` removes any prior
+        klangk-tagged handler first. ``Logger(app)`` later overrides the
+        level from ``KLANGK_LOG_LEVEL``.
+        """
+        cls._apply(cls._DEFAULT_LEVEL)
 
     def reconfigure(self, app) -> None:
         """Re-apply configuration against a freshly-reloaded ``app``.
@@ -128,18 +153,24 @@ class Logger:
         return _level_to_int(self.app.state.settings.log_level)
 
     def configure(self) -> None:
-        """Configure the root logger: handler, format, level, third-party.
+        """Re-apply configuration from settings (handler, format, level)."""
+        self._handler = self._apply(self._level)
 
+    @classmethod
+    def _apply(cls, level: int) -> logging.Handler:
+        """Install/replace the klangk root handler at ``level`` + silence 3rd-party.
+
+        Shared by :meth:`configure_defaults` (pre-settings, default level) and
+        instance :meth:`configure`/:meth:`reconfigure` (settings-driven level).
         Idempotent across instances: any handler previously tagged by a
-        :class:`Logger` is removed from the root logger before the new one
-        is added, so repeated construction (a fresh ``Logger`` per test app,
-        or a reconfigure) never stacks duplicate handlers. The handler is
-        tagged via a private attribute so this dedup is robust to other
-        handlers on the root (pytest's ``caplog`` handler, operator-added
-        handlers, ...).
+        :class:`Logger` is removed from the root logger before the new one is
+        added, so repeated construction (a fresh ``Logger`` per test app, or a
+        reconfigure) never stacks duplicate handlers. The handler is tagged
+        via a private attribute so this dedup is robust to other handlers on
+        the root (pytest's ``caplog`` handler, operator-added handlers, ...).
+        Returns the installed handler so the caller can track it.
         """
         root = logging.getLogger()
-        level = self._level
 
         # Drop any pre-existing klangk-tagged handler(s) so we never stack.
         for handler in list(root.handlers):
@@ -150,13 +181,22 @@ class Logger:
         # Private tag for cross-instance dedup (see the loop above).
         handler._klangk_log_handler = True  # type: ignore[attr-defined]
         handler.setFormatter(
-            logging.Formatter(self._FORMAT, datefmt=self._DATEFMT)
+            logging.Formatter(cls._FORMAT, datefmt=cls._DATEFMT)
         )
         handler.setLevel(level)
         root.addHandler(handler)
-        self._handler = handler
 
         root.setLevel(level)
 
-        for name, lvl in self._THIRD_PARTY_LEVELS.items():
+        for name, lvl in cls._THIRD_PARTY_LEVELS.items():
             logging.getLogger(name).setLevel(lvl)
+        return handler
+
+
+# Configure sensible defaults at import so logging is formatted from the very
+# first log call — including during ``KlangkSettings`` construction, which
+# runs before any ``app``/``app.state.logger`` exists. ``Logger(app)`` (in
+# ``build_app``) later overrides the level from ``KLANGK_LOG_LEVEL``. This is
+# a single, central, idempotent setup point (not the old scattered,
+# import-order-dependent ``basicConfig`` that lived in ``main.py``). (#1467)
+Logger.configure_defaults()

--- a/src/klangk/klangk/logger.py
+++ b/src/klangk/klangk/logger.py
@@ -1,0 +1,162 @@
+"""Centralized logging configuration owned by ``app.state`` (#1467).
+
+Previously logging was configured by an import-time ``logging.basicConfig(...)``
+call in ``main.py``'s module body. That had three problems:
+
+1. **Import-order-dependent.** ``basicConfig`` is a no-op if the root logger
+   already has handlers, so whichever module imported ``main`` first won.
+2. **No settings integration.** Level/format were hardcoded, with no home for
+   a ``KLANGK_LOG_LEVEL`` knob.
+3. **No third-party logger management.** uvicorn, sqlalchemy, httpx, ... each
+   got their own logger with no central place to silence them.
+
+:class:`Logger` is the owned state object that fixes all three. It is
+constructed once in :func:`klangk.main.build_app` and hung on
+``app.state.logger`` — the same ``X(app)`` composition-root pattern every
+other subsystem (``Util``, ``Model``, ``Container``, ...) uses. It owns:
+
+- the single :class:`~logging.StreamHandler` on the root logger (with the
+  colored format previously hardcoded in ``main.py``),
+- the root level, read live from ``settings.log_level`` (``KLANGK_LOG_LEVEL``),
+- central silencing of chatty third-party loggers.
+
+Per-module ``logger = logging.getLogger(__name__)`` calls elsewhere in the
+package are **kept** — those obtain *named logger handles* (not configuration)
+that propagate to the root logger :class:`Logger` configures. They are the
+idiomatic Python pattern and cannot be replaced with ``app.state.logger``
+references: several modules (notably :mod:`klangk.settings`) log during
+construction, before any ``app`` exists. Centralizing the *configuration* in
+one deliberate setup point is what the composition-root refactor (#1426)
+calls for; the named-handle pattern is orthogonal and correct.
+
+Live reload: :meth:`reconfigure` re-applies the level from a freshly-reloaded
+settings object, so ``KLANGK_LOG_LEVEL`` takes effect on a SIGHUP restart
+without a process restart (#1587). It is a member of the
+``_apply_reloaded_settings`` subsystem list in :mod:`klangk.main`.
+"""
+
+from __future__ import annotations
+
+import logging
+
+__all__ = ["Logger"]
+
+
+def _level_to_int(value: str) -> int:
+    """Resolve a log-level string to a numeric level.
+
+    Accepts a level name (case-insensitive: ``"debug"``, ``"INFO"``, ...) or
+    a numeric string (``"20"``). Unknown values fall back to ``INFO`` — the
+    :class:`~klangk.settings.KlangkSettings` ``log_level`` validator rejects
+    garbage at construction, so this fallback only defends a misconfigured
+    live reload.
+    """
+    v = (value or "INFO").strip().upper()
+    if v.isdigit():
+        return int(v)
+    named = getattr(logging, v, None)
+    if isinstance(named, int):
+        return named
+    return logging.INFO
+
+
+class Logger:
+    """Owned logging-configuration state object (``app.state.logger``).
+
+    Constructed once in :func:`klangk.main.build_app` and stored on
+    ``app.state.logger``. Owns the root logger's handler, format, level, and
+    third-party silencing. Reads ``settings.log_level`` live so a SIGHUP
+    reload of ``KLANGK_LOG_LEVEL`` propagates without a process restart.
+    """
+
+    # The colored console format, moved here from ``main.py``'s module scope
+    # (where it lived next to the now-removed ``logging.basicConfig`` call).
+    _LIGHT_BLUE = "\033[94m"
+    _RESET = "\033[0m"
+    _FORMAT = (
+        f"{_LIGHT_BLUE}%(asctime)s %(levelname)s:%(name)s:%(message)s{_RESET}"
+    )
+    _DATEFMT = "%H:%M:%S"
+
+    # Third-party loggers managed centrally (logger name -> level). These are
+    # libraries klangk depends on that log at their own verbosity by default
+    # and would drown klangk's own INFO output. Levels are re-applied on every
+    # configure()/reconfigure() so an operator raising ``KLANGK_LOG_LEVEL``
+    # to DEBUG still gets a quiet chatty-library surface unless they raise
+    # these explicitly via a future per-logger override.
+    _THIRD_PARTY_LEVELS: dict[str, int | str] = {
+        # uvicorn's startup/error logs are useful; per-request access logs are
+        # noisy at default verbosity.
+        "uvicorn": "INFO",
+        "uvicorn.error": "INFO",
+        "uvicorn.access": "WARNING",
+        # SQLAlchemy engine emits every query at INFO when unchecked.
+        "sqlalchemy.engine": "WARNING",
+        # httpx/httpcore log every request/connection at INFO.
+        "httpx": "WARNING",
+        "httpcore": "WARNING",
+        # watchfiles spams detection/rust internals at INFO.
+        "watchfiles": "WARNING",
+        # asyncio debug chatter.
+        "asyncio": "WARNING",
+    }
+
+    def __init__(self, app):
+        self.app = app
+        # The handler this instance installed on the root logger, tracked so
+        # reconfigure() can replace rather than stack. See configure() for
+        # the cross-instance dedup that also keeps repeated construction
+        # (e.g. per-test app_state mocks) from stacking handlers.
+        self._handler: logging.Handler | None = None
+        self.configure()
+
+    def reconfigure(self, app) -> None:
+        """Re-apply configuration against a freshly-reloaded ``app``.
+
+        Called by the SIGHUP reload path in :mod:`klangk.main` alongside
+        every other subsystem's ``reconfigure``. Re-reads ``log_level`` off
+        the new settings and re-applies the root level (and third-party
+        levels), so ``KLANGK_LOG_LEVEL`` takes effect without a process
+        restart (#1587).
+        """
+        self.app = app
+        self.configure()
+
+    @property
+    def _level(self) -> int:
+        """The root level, resolved live from settings at call time."""
+        return _level_to_int(self.app.state.settings.log_level)
+
+    def configure(self) -> None:
+        """Configure the root logger: handler, format, level, third-party.
+
+        Idempotent across instances: any handler previously tagged by a
+        :class:`Logger` is removed from the root logger before the new one
+        is added, so repeated construction (a fresh ``Logger`` per test app,
+        or a reconfigure) never stacks duplicate handlers. The handler is
+        tagged via a private attribute so this dedup is robust to other
+        handlers on the root (pytest's ``caplog`` handler, operator-added
+        handlers, ...).
+        """
+        root = logging.getLogger()
+        level = self._level
+
+        # Drop any pre-existing klangk-tagged handler(s) so we never stack.
+        for handler in list(root.handlers):
+            if getattr(handler, "_klangk_log_handler", False):
+                root.removeHandler(handler)
+
+        handler = logging.StreamHandler()
+        # Private tag for cross-instance dedup (see the loop above).
+        handler._klangk_log_handler = True  # type: ignore[attr-defined]
+        handler.setFormatter(
+            logging.Formatter(self._FORMAT, datefmt=self._DATEFMT)
+        )
+        handler.setLevel(level)
+        root.addHandler(handler)
+        self._handler = handler
+
+        root.setLevel(level)
+
+        for name, lvl in self._THIRD_PARTY_LEVELS.items():
+            logging.getLogger(name).setLevel(lvl)

--- a/src/klangk/klangk/main.py
+++ b/src/klangk/klangk/main.py
@@ -35,7 +35,7 @@ from . import (
     wshandler,
 )
 from .settings import KlangkSettings
-from .logger import Logger
+from .logger import configure as configure_logging
 from .api import root_router, router
 from .util import API_PREFIX
 from .model import (
@@ -375,10 +375,15 @@ class Lifecycle:
         old = app.state.settings
         self._warn_non_reloadable(old, new)
         app.state.settings = new
+        # #1467: reconfigure global logging from the new settings *first*, so
+        # any warnings the subsystem loop below emits (e.g. "ssl_trust
+        # reconfigure failed") use the new KLANGK_LOG_LEVEL. Logging is global
+        # module state, reconfigured at this explicit seam (not an
+        # app.state.* subsystem).
+        configure_logging(new)
 
         # Every app.state subsystem that implements reconfigure().
         subsystems = [
-            "logger",
             "ssl_trust",
             "auth",
             "podman",
@@ -754,13 +759,12 @@ def build_app(settings: KlangkSettings) -> FastAPI:
     """
     app = FastAPI(title="Klangk", lifespan=lifespan)
     app.state.settings = settings
-    # #1467: Logger(app_state) owns centralized logging configuration (root
-    # handler, colored format, level from KLANGK_LOG_LEVEL, and third-party
-    # logger silencing). Configured first so every subsystem constructed
-    # below logs through the configured root. Replaces the import-time
-    # logging.basicConfig that previously ran in this module's body —
-    # importing klangk no longer configures logging as a side-effect.
-    app.state.logger = Logger(app)
+    # #1467: logging is configured centrally (module-level defaults are
+    # already active from the import of klangk.logger; this call re-applies
+    # the level from KLANGK_LOG_LEVEL now that settings are finalized, and
+    # is also the SIGHUP reconfigure path). No app.state.logger object —
+    # logging is global module state, reconfigured at this explicit seam.
+    configure_logging(settings)
     # #1501: Auth(app_state) owns every auth config value and JWT
     # operation (previously module-level globals + import-time
     # resolve_env_value reads in auth.py). Reads self.settings at

--- a/src/klangk/klangk/main.py
+++ b/src/klangk/klangk/main.py
@@ -35,6 +35,7 @@ from . import (
     wshandler,
 )
 from .settings import KlangkSettings
+from .logger import Logger
 from .api import root_router, router
 from .util import API_PREFIX
 from .model import (
@@ -48,15 +49,9 @@ from .model import (
 from .model import AGENT_USER_ID
 from .wshandler import handle_websocket
 
-_LIGHT_BLUE = "\033[94m"
 _GREEN = "\033[32m"
 _RESET = "\033[0m"
 
-logging.basicConfig(
-    level=logging.INFO,
-    format=f"{_LIGHT_BLUE}%(asctime)s %(levelname)s:%(name)s:%(message)s{_RESET}",
-    datefmt="%H:%M:%S",
-)
 logger = logging.getLogger(__name__)
 
 
@@ -383,6 +378,7 @@ class Lifecycle:
 
         # Every app.state subsystem that implements reconfigure().
         subsystems = [
+            "logger",
             "ssl_trust",
             "auth",
             "podman",
@@ -758,6 +754,13 @@ def build_app(settings: KlangkSettings) -> FastAPI:
     """
     app = FastAPI(title="Klangk", lifespan=lifespan)
     app.state.settings = settings
+    # #1467: Logger(app_state) owns centralized logging configuration (root
+    # handler, colored format, level from KLANGK_LOG_LEVEL, and third-party
+    # logger silencing). Configured first so every subsystem constructed
+    # below logs through the configured root. Replaces the import-time
+    # logging.basicConfig that previously ran in this module's body —
+    # importing klangk no longer configures logging as a side-effect.
+    app.state.logger = Logger(app)
     # #1501: Auth(app_state) owns every auth config value and JWT
     # operation (previously module-level globals + import-time
     # resolve_env_value reads in auth.py). Reads self.settings at

--- a/src/klangk/klangk/settings.py
+++ b/src/klangk/klangk/settings.py
@@ -396,11 +396,12 @@ class KlangkSettings(BaseSettings):
     # --- Logging ---
     # log_level: root logger level for the klangkd backend. A level name
     # (DEBUG/INFO/WARNING/ERROR/CRITICAL, any case) or a numeric string.
-    # Defaults to INFO. Read live by ``Logger(app)`` at construction and on
-    # every SIGHUP reload (reconfigure), so ``KLANGK_LOG_LEVEL`` can be
-    # changed without a process restart (#1467). The field validator below
-    # rejects garbage at construction (fail-fast) so a typo'd level aborts
-    # boot rather than silently leaving logging at the wrong verbosity.
+    # Defaults to INFO. Applied by ``klangk.logger.configure(settings)`` in
+    # build_app, and re-applied on every SIGHUP reload (after the settings
+    # swap), so ``KLANGK_LOG_LEVEL`` can be changed without a process restart
+    # (#1467). The field validator below rejects garbage at construction
+    # (fail-fast) so a typo'd level aborts boot rather than silently leaving
+    # logging at the wrong verbosity.
     log_level: str = "INFO"
 
     # --- Server / network ---

--- a/src/klangk/klangk/settings.py
+++ b/src/klangk/klangk/settings.py
@@ -393,6 +393,16 @@ class KlangkSettings(BaseSettings):
     reject_proxy_headers: str | None = None
     trusted_proxy_cidrs: str | None = "127.0.0.1,::1"
 
+    # --- Logging ---
+    # log_level: root logger level for the klangkd backend. A level name
+    # (DEBUG/INFO/WARNING/ERROR/CRITICAL, any case) or a numeric string.
+    # Defaults to INFO. Read live by ``Logger(app)`` at construction and on
+    # every SIGHUP reload (reconfigure), so ``KLANGK_LOG_LEVEL`` can be
+    # changed without a process restart (#1467). The field validator below
+    # rejects garbage at construction (fail-fast) so a typo'd level aborts
+    # boot rather than silently leaving logging at the wrong verbosity.
+    log_level: str = "INFO"
+
     # --- Server / network ---
     # listen: the nginx **browser** interface/address (e.g. ``127.0.0.1``,
     # ``0.0.0.0``). Rendered as ``listen {listen}:{port};`` only when
@@ -688,6 +698,30 @@ class KlangkSettings(BaseSettings):
                 "See #1531."
             )
         return self
+
+    @field_validator("log_level")
+    @classmethod
+    def _validate_log_level(cls, v: str) -> str:
+        """Reject typo'd/invalid log levels at construction (fail-fast, #1467).
+
+        Accepts a level name (case-insensitive: ``debug``, ``INFO``, ...) or
+        a numeric string (``"20"``). ``None``/empty defaults to ``INFO``. A
+        bogus value aborts boot rather than silently leaving logging at the
+        wrong verbosity — the same fail-fast posture as ``auth_modes``.
+        """
+        if v is None or v == "":
+            return "INFO"
+        upper = v.strip().upper()
+        named = getattr(logging, upper, None)
+        if isinstance(named, int) and not upper.isdigit():
+            return upper
+        if upper.isdigit():
+            return upper
+        raise ValueError(
+            f"KLANGK_LOG_LEVEL={v!r} is invalid. "
+            "Must be a level name (DEBUG/INFO/WARNING/ERROR/CRITICAL) "
+            "or a numeric value."
+        )
 
     @field_validator("auth_modes")
     @classmethod

--- a/src/klangk/klangkd-tests/tests/test_logger.py
+++ b/src/klangk/klangkd-tests/tests/test_logger.py
@@ -1,0 +1,158 @@
+"""Tests for the centralized Logger(app) state object (#1467)."""
+
+import logging
+import types
+
+import pytest
+
+from _helpers import make_settings
+from klangk.logger import Logger, _level_to_int
+
+
+def _make_app(level=None):
+    """Build a minimal app namespace whose settings carry ``log_level``."""
+    env = {}
+    if level is not None:
+        env["KLANGK_LOG_LEVEL"] = level
+    settings = make_settings(env)
+    return types.SimpleNamespace(
+        state=types.SimpleNamespace(settings=settings)
+    )
+
+
+@pytest.fixture
+def clean_root():
+    """Snapshot and restore the root logger (handlers + level) per test.
+
+    Logger.configure() mutates the global root logger; these tests must not
+    leak those changes into sibling tests (xdist runs files in workers, but
+    modules within a file share a process).
+    """
+    root = logging.getLogger()
+    saved_handlers = list(root.handlers)
+    saved_level = root.level
+    yield root
+    for h in list(root.handlers):
+        if getattr(h, "_klangk_log_handler", False):
+            root.removeHandler(h)
+    root.handlers = saved_handlers
+    root.setLevel(saved_level)
+
+
+def _klangk_handlers(root):
+    return [
+        h for h in root.handlers if getattr(h, "_klangk_log_handler", False)
+    ]
+
+
+class TestLevelToInt:
+    """The private level-string resolver (#1467)."""
+
+    @pytest.mark.parametrize(
+        "name,expected",
+        [
+            ("DEBUG", logging.DEBUG),
+            ("INFO", logging.INFO),
+            ("WARNING", logging.WARNING),
+            ("ERROR", logging.ERROR),
+            ("CRITICAL", logging.CRITICAL),
+        ],
+    )
+    def test_named_levels(self, name, expected):
+        assert _level_to_int(name) == expected
+
+    def test_case_insensitive(self):
+        assert _level_to_int("debug") == logging.DEBUG
+        assert _level_to_int("WaRnInG") == logging.WARNING
+
+    def test_numeric_string(self):
+        assert _level_to_int("20") == logging.INFO
+        assert _level_to_int("10") == logging.DEBUG
+
+    def test_empty_or_none_falls_back_to_info(self):
+        assert _level_to_int("") == logging.INFO
+        assert _level_to_int(None) == logging.INFO
+
+    def test_unknown_falls_back_to_info(self):
+        # Settings validator rejects garbage at construction; this fallback
+        # only defends a misconfigured live reload.
+        assert _level_to_int("verbose") == logging.INFO
+
+
+class TestLoggerConfigure:
+    def test_installs_single_tagged_handler(self, clean_root):
+        Logger(_make_app())
+        assert len(_klangk_handlers(clean_root)) == 1
+
+    def test_handler_carries_colored_formatter(self, clean_root):
+        Logger(_make_app())
+        handler = _klangk_handlers(clean_root)[0]
+        assert isinstance(handler, logging.StreamHandler)
+        # The colored format moved here from main.py's module scope.
+        assert "\033[94m" in handler.formatter._fmt  # _LIGHT_BLUE
+        assert "\033[0m" in handler.formatter._fmt  # _RESET
+
+    def test_sets_root_level_from_settings(self, clean_root):
+        Logger(_make_app("DEBUG"))
+        assert clean_root.level == logging.DEBUG
+
+    def test_default_level_is_info(self, clean_root):
+        Logger(_make_app())
+        assert clean_root.level == logging.INFO
+
+    def test_accepts_numeric_level_string(self, clean_root):
+        Logger(_make_app("10"))  # 10 == DEBUG
+        assert clean_root.level == logging.DEBUG
+
+    def test_configure_idempotent_across_instances(self, clean_root):
+        # Two Logger instances (e.g. fresh app per test) must not stack
+        # duplicate handlers on the root logger.
+        Logger(_make_app())
+        Logger(_make_app())
+        assert len(_klangk_handlers(clean_root)) == 1
+
+    def test_third_party_loggers_silenced(self, clean_root):
+        Logger(_make_app("DEBUG"))
+        # Root is DEBUG but chatty libraries stay capped (central management,
+        # one of the points of #1467).
+        assert logging.getLogger("uvicorn.access").level == logging.WARNING
+        assert logging.getLogger("sqlalchemy.engine").level == logging.WARNING
+        assert logging.getLogger("httpx").level == logging.WARNING
+
+
+class TestLoggerReconfigure:
+    def test_reconfigure_updates_level(self, clean_root):
+        app = _make_app("INFO")
+        lg = Logger(app)
+        assert clean_root.level == logging.INFO
+
+        new_settings = make_settings({"KLANGK_LOG_LEVEL": "WARNING"})
+        new_app = types.SimpleNamespace(
+            state=types.SimpleNamespace(settings=new_settings)
+        )
+        lg.reconfigure(new_app)
+
+        assert lg.app is new_app
+        assert clean_root.level == logging.WARNING
+
+    def test_reconfigure_does_not_stack_handlers(self, clean_root):
+        lg = Logger(_make_app("INFO"))
+        lg.reconfigure(_make_app("DEBUG"))
+        assert len(_klangk_handlers(clean_root)) == 1
+
+    def test_reconfigure_reapplies_third_party_levels(self, clean_root):
+        # Sabotage a third-party logger to prove reconfigure resets it.
+        logging.getLogger("httpx").setLevel(logging.DEBUG)
+        lg = Logger(_make_app("INFO"))
+        lg.reconfigure(_make_app("WARNING"))
+        assert logging.getLogger("httpx").level == logging.WARNING
+
+
+class TestLoggerConstruction:
+    def test_takes_only_app(self):
+        """Logger follows the app-ownership rule: caches only self.app (#1467)."""
+        app = _make_app()
+        lg = Logger(app)
+        assert lg.app is app
+        # No settings subobject cached (would go stale on a SIGHUP swap).
+        assert not hasattr(lg, "settings")

--- a/src/klangk/klangkd-tests/tests/test_logger.py
+++ b/src/klangk/klangkd-tests/tests/test_logger.py
@@ -156,3 +156,84 @@ class TestLoggerConstruction:
         assert lg.app is app
         # No settings subobject cached (would go stale on a SIGHUP swap).
         assert not hasattr(lg, "settings")
+
+
+class TestConfigureDefaults:
+    """The pre-settings phase: logging is configured with defaults before any
+    app/Settings exists (#1467), so logs emitted during KlangkSettings
+    construction are formatted."""
+
+    def test_configures_root_without_an_app(self, clean_root):
+        # Start from a known state: no klangk handler (the module-level
+        # configure_defaults() may have installed one at import).
+        for h in list(clean_root.handlers):
+            if getattr(h, "_klangk_log_handler", False):
+                clean_root.removeHandler(h)
+        assert _klangk_handlers(clean_root) == []
+        # No app, no settings — yet the root logger gets a handler.
+        Logger.configure_defaults()
+        assert len(_klangk_handlers(clean_root)) == 1
+
+    def test_default_level_is_info(self, clean_root):
+        Logger.configure_defaults()
+        assert clean_root.level == logging.INFO
+        assert _klangk_handlers(clean_root)[0].level == logging.INFO
+
+    def test_default_handler_is_colored(self, clean_root):
+        Logger.configure_defaults()
+        handler = _klangk_handlers(clean_root)[0]
+        assert "\033[94m" in handler.formatter._fmt  # _LIGHT_BLUE
+
+    def test_defaults_silence_third_party(self, clean_root):
+        Logger.configure_defaults()
+        assert logging.getLogger("uvicorn.access").level == logging.WARNING
+        assert logging.getLogger("sqlalchemy.engine").level == logging.WARNING
+
+    def test_defaults_idempotent(self, clean_root):
+        Logger.configure_defaults()
+        Logger.configure_defaults()
+        assert len(_klangk_handlers(clean_root)) == 1
+
+    def test_module_import_already_configured_defaults(self, clean_root):
+        """Importing klangk.logger configures defaults (so settings construction
+        logs are formatted before any app exists).
+
+        The module-level ``Logger.configure_defaults()`` call runs at import;
+        it is also directly covered there (coverage marks the line executed at
+        import time). Here we just confirm the entry point exists and is the
+        same idempotent path tested above.
+        """
+        assert callable(Logger.configure_defaults)
+        assert isinstance(Logger._DEFAULT_LEVEL, int)
+        assert Logger._DEFAULT_LEVEL == logging.INFO
+
+    def test_logger_app_overrides_defaults_level(self, clean_root):
+        """Defaults apply INFO; Logger(app) then overrides from KLANGK_LOG_LEVEL."""
+        Logger.configure_defaults()
+        assert clean_root.level == logging.INFO
+        Logger(_make_app("WARNING"))
+        assert clean_root.level == logging.WARNING
+
+    def test_settings_construction_logs_through_configured_root(
+        self, clean_root, caplog
+    ):
+        """End-to-end: with defaults active, a log emitted during KlangkSettings
+        construction is captured (the scenario #1467's two-phase design serves).
+        """
+        Logger.configure_defaults()
+        with caplog.at_level(logging.WARNING, logger="klangk.settings"):
+            # Constructing settings with a deprecated KLANGK_NGINX_PORT emits
+            # a WARNING from a settings validator — proving the configured
+            # root handles pre-app logging.
+            from klangk.settings import KlangkSettings
+
+            KlangkSettings(
+                env={
+                    "KLANGK_STATE_DIR": "/tmp/state",
+                    "KLANGK_NGINX_PORT": "9999",
+                }
+            )
+        assert any(
+            "KLANGK_NGINX_PORT is deprecated" in r.message
+            for r in caplog.records
+        )

--- a/src/klangk/klangkd-tests/tests/test_logger.py
+++ b/src/klangk/klangkd-tests/tests/test_logger.py
@@ -1,32 +1,29 @@
-"""Tests for the centralized Logger(app) state object (#1467)."""
+"""Tests for centralized logging configuration (#1467).
+
+Logging is configured by two module-level functions in :mod:`klangk.logger`
+(no state object):
+
+- ``configure_defaults()`` — applied at import; INFO level, colored format,
+  third-party silencing. Active before any ``app``/settings exists.
+- ``configure(settings)`` — re-applies the level from ``settings.log_level``
+  once settings are finalized (build_app), and again on every SIGHUP reload.
+"""
 
 import logging
-import types
 
 import pytest
 
 from _helpers import make_settings
-from klangk.logger import Logger, _level_to_int
-
-
-def _make_app(level=None):
-    """Build a minimal app namespace whose settings carry ``log_level``."""
-    env = {}
-    if level is not None:
-        env["KLANGK_LOG_LEVEL"] = level
-    settings = make_settings(env)
-    return types.SimpleNamespace(
-        state=types.SimpleNamespace(settings=settings)
-    )
+from klangk import logger as logger_mod
 
 
 @pytest.fixture
 def clean_root():
     """Snapshot and restore the root logger (handlers + level) per test.
 
-    Logger.configure() mutates the global root logger; these tests must not
-    leak those changes into sibling tests (xdist runs files in workers, but
-    modules within a file share a process).
+    These tests mutate the global root logger; they must not leak into sibling
+    tests (xdist runs files in workers, but modules within a file share a
+    process).
     """
     root = logging.getLogger()
     saved_handlers = list(root.handlers)
@@ -45,6 +42,13 @@ def _klangk_handlers(root):
     ]
 
 
+def _make_settings(level=None):
+    env = {}
+    if level is not None:
+        env["KLANGK_LOG_LEVEL"] = level
+    return make_settings(env)
+
+
 class TestLevelToInt:
     """The private level-string resolver (#1467)."""
 
@@ -59,103 +63,24 @@ class TestLevelToInt:
         ],
     )
     def test_named_levels(self, name, expected):
-        assert _level_to_int(name) == expected
+        assert logger_mod._level_to_int(name) == expected
 
     def test_case_insensitive(self):
-        assert _level_to_int("debug") == logging.DEBUG
-        assert _level_to_int("WaRnInG") == logging.WARNING
+        assert logger_mod._level_to_int("debug") == logging.DEBUG
+        assert logger_mod._level_to_int("WaRnInG") == logging.WARNING
 
     def test_numeric_string(self):
-        assert _level_to_int("20") == logging.INFO
-        assert _level_to_int("10") == logging.DEBUG
+        assert logger_mod._level_to_int("20") == logging.INFO
+        assert logger_mod._level_to_int("10") == logging.DEBUG
 
     def test_empty_or_none_falls_back_to_info(self):
-        assert _level_to_int("") == logging.INFO
-        assert _level_to_int(None) == logging.INFO
+        assert logger_mod._level_to_int("") == logging.INFO
+        assert logger_mod._level_to_int(None) == logging.INFO
 
     def test_unknown_falls_back_to_info(self):
         # Settings validator rejects garbage at construction; this fallback
         # only defends a misconfigured live reload.
-        assert _level_to_int("verbose") == logging.INFO
-
-
-class TestLoggerConfigure:
-    def test_installs_single_tagged_handler(self, clean_root):
-        Logger(_make_app())
-        assert len(_klangk_handlers(clean_root)) == 1
-
-    def test_handler_carries_colored_formatter(self, clean_root):
-        Logger(_make_app())
-        handler = _klangk_handlers(clean_root)[0]
-        assert isinstance(handler, logging.StreamHandler)
-        # The colored format moved here from main.py's module scope.
-        assert "\033[94m" in handler.formatter._fmt  # _LIGHT_BLUE
-        assert "\033[0m" in handler.formatter._fmt  # _RESET
-
-    def test_sets_root_level_from_settings(self, clean_root):
-        Logger(_make_app("DEBUG"))
-        assert clean_root.level == logging.DEBUG
-
-    def test_default_level_is_info(self, clean_root):
-        Logger(_make_app())
-        assert clean_root.level == logging.INFO
-
-    def test_accepts_numeric_level_string(self, clean_root):
-        Logger(_make_app("10"))  # 10 == DEBUG
-        assert clean_root.level == logging.DEBUG
-
-    def test_configure_idempotent_across_instances(self, clean_root):
-        # Two Logger instances (e.g. fresh app per test) must not stack
-        # duplicate handlers on the root logger.
-        Logger(_make_app())
-        Logger(_make_app())
-        assert len(_klangk_handlers(clean_root)) == 1
-
-    def test_third_party_loggers_silenced(self, clean_root):
-        Logger(_make_app("DEBUG"))
-        # Root is DEBUG but chatty libraries stay capped (central management,
-        # one of the points of #1467).
-        assert logging.getLogger("uvicorn.access").level == logging.WARNING
-        assert logging.getLogger("sqlalchemy.engine").level == logging.WARNING
-        assert logging.getLogger("httpx").level == logging.WARNING
-
-
-class TestLoggerReconfigure:
-    def test_reconfigure_updates_level(self, clean_root):
-        app = _make_app("INFO")
-        lg = Logger(app)
-        assert clean_root.level == logging.INFO
-
-        new_settings = make_settings({"KLANGK_LOG_LEVEL": "WARNING"})
-        new_app = types.SimpleNamespace(
-            state=types.SimpleNamespace(settings=new_settings)
-        )
-        lg.reconfigure(new_app)
-
-        assert lg.app is new_app
-        assert clean_root.level == logging.WARNING
-
-    def test_reconfigure_does_not_stack_handlers(self, clean_root):
-        lg = Logger(_make_app("INFO"))
-        lg.reconfigure(_make_app("DEBUG"))
-        assert len(_klangk_handlers(clean_root)) == 1
-
-    def test_reconfigure_reapplies_third_party_levels(self, clean_root):
-        # Sabotage a third-party logger to prove reconfigure resets it.
-        logging.getLogger("httpx").setLevel(logging.DEBUG)
-        lg = Logger(_make_app("INFO"))
-        lg.reconfigure(_make_app("WARNING"))
-        assert logging.getLogger("httpx").level == logging.WARNING
-
-
-class TestLoggerConstruction:
-    def test_takes_only_app(self):
-        """Logger follows the app-ownership rule: caches only self.app (#1467)."""
-        app = _make_app()
-        lg = Logger(app)
-        assert lg.app is app
-        # No settings subobject cached (would go stale on a SIGHUP swap).
-        assert not hasattr(lg, "settings")
+        assert logger_mod._level_to_int("verbose") == logging.INFO
 
 
 class TestConfigureDefaults:
@@ -171,48 +96,33 @@ class TestConfigureDefaults:
                 clean_root.removeHandler(h)
         assert _klangk_handlers(clean_root) == []
         # No app, no settings — yet the root logger gets a handler.
-        Logger.configure_defaults()
+        logger_mod.configure_defaults()
         assert len(_klangk_handlers(clean_root)) == 1
 
     def test_default_level_is_info(self, clean_root):
-        Logger.configure_defaults()
+        logger_mod.configure_defaults()
         assert clean_root.level == logging.INFO
         assert _klangk_handlers(clean_root)[0].level == logging.INFO
 
     def test_default_handler_is_colored(self, clean_root):
-        Logger.configure_defaults()
+        logger_mod.configure_defaults()
         handler = _klangk_handlers(clean_root)[0]
         assert "\033[94m" in handler.formatter._fmt  # _LIGHT_BLUE
 
     def test_defaults_silence_third_party(self, clean_root):
-        Logger.configure_defaults()
+        logger_mod.configure_defaults()
         assert logging.getLogger("uvicorn.access").level == logging.WARNING
         assert logging.getLogger("sqlalchemy.engine").level == logging.WARNING
 
     def test_defaults_idempotent(self, clean_root):
-        Logger.configure_defaults()
-        Logger.configure_defaults()
+        logger_mod.configure_defaults()
+        logger_mod.configure_defaults()
         assert len(_klangk_handlers(clean_root)) == 1
 
-    def test_module_import_already_configured_defaults(self, clean_root):
-        """Importing klangk.logger configures defaults (so settings construction
-        logs are formatted before any app exists).
-
-        The module-level ``Logger.configure_defaults()`` call runs at import;
-        it is also directly covered there (coverage marks the line executed at
-        import time). Here we just confirm the entry point exists and is the
-        same idempotent path tested above.
-        """
-        assert callable(Logger.configure_defaults)
-        assert isinstance(Logger._DEFAULT_LEVEL, int)
-        assert Logger._DEFAULT_LEVEL == logging.INFO
-
-    def test_logger_app_overrides_defaults_level(self, clean_root):
-        """Defaults apply INFO; Logger(app) then overrides from KLANGK_LOG_LEVEL."""
-        Logger.configure_defaults()
-        assert clean_root.level == logging.INFO
-        Logger(_make_app("WARNING"))
-        assert clean_root.level == logging.WARNING
+    def test_module_level_default_level_constant(self):
+        """The import-time call uses this constant (coverage marks the
+        module-level call line executed at import)."""
+        assert logger_mod._DEFAULT_LEVEL == logging.INFO
 
     def test_settings_construction_logs_through_configured_root(
         self, clean_root, caplog
@@ -220,7 +130,7 @@ class TestConfigureDefaults:
         """End-to-end: with defaults active, a log emitted during KlangkSettings
         construction is captured (the scenario #1467's two-phase design serves).
         """
-        Logger.configure_defaults()
+        logger_mod.configure_defaults()
         with caplog.at_level(logging.WARNING, logger="klangk.settings"):
             # Constructing settings with a deprecated KLANGK_NGINX_PORT emits
             # a WARNING from a settings validator — proving the configured
@@ -237,3 +147,53 @@ class TestConfigureDefaults:
             "KLANGK_NGINX_PORT is deprecated" in r.message
             for r in caplog.records
         )
+
+
+class TestConfigure:
+    """The settings-driven phase: configure(settings) re-applies the level from
+    KLANGK_LOG_LEVEL, overriding the import-time defaults (#1467)."""
+
+    def test_sets_root_level_from_settings(self, clean_root):
+        logger_mod.configure(_make_settings("DEBUG"))
+        assert clean_root.level == logging.DEBUG
+
+    def test_overrides_defaults_level(self, clean_root):
+        logger_mod.configure_defaults()
+        assert clean_root.level == logging.INFO
+        logger_mod.configure(_make_settings("WARNING"))
+        assert clean_root.level == logging.WARNING
+
+    def test_default_settings_level_is_info(self, clean_root):
+        logger_mod.configure(_make_settings())
+        assert clean_root.level == logging.INFO
+
+    def test_accepts_numeric_level_string(self, clean_root):
+        logger_mod.configure(_make_settings("10"))  # 10 == DEBUG
+        assert clean_root.level == logging.DEBUG
+
+    def test_handler_is_colored(self, clean_root):
+        logger_mod.configure(_make_settings())
+        handler = _klangk_handlers(clean_root)[0]
+        assert isinstance(handler, logging.StreamHandler)
+        assert "\033[94m" in handler.formatter._fmt  # _LIGHT_BLUE
+        assert "\033[0m" in handler.formatter._fmt  # _RESET
+
+    def test_third_party_loggers_silenced(self, clean_root):
+        logger_mod.configure(_make_settings("DEBUG"))
+        # Root is DEBUG but chatty libraries stay capped (central management,
+        # one of the points of #1467).
+        assert logging.getLogger("uvicorn.access").level == logging.WARNING
+        assert logging.getLogger("sqlalchemy.engine").level == logging.WARNING
+        assert logging.getLogger("httpx").level == logging.WARNING
+
+    def test_configure_idempotent_no_stacking(self, clean_root):
+        logger_mod.configure(_make_settings("INFO"))
+        logger_mod.configure(_make_settings("DEBUG"))
+        assert len(_klangk_handlers(clean_root)) == 1
+
+    def test_reconfigure_reapplies_third_party_levels(self, clean_root):
+        # Sabotage a third-party logger to prove configure resets it.
+        logging.getLogger("httpx").setLevel(logging.DEBUG)
+        logger_mod.configure(_make_settings("INFO"))
+        logger_mod.configure(_make_settings("WARNING"))
+        assert logging.getLogger("httpx").level == logging.WARNING

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -18,6 +18,7 @@ from klangk import (
     auth as auth_mod,
     emailsvc as emailsvc_mod,
     files as files_mod,
+    logger as logger_mod,
     nginx as nginx_mod,
     ssl_trust as ssl_trust_mod,
     util as util_mod,
@@ -43,6 +44,9 @@ def _make_app_state(settings=None):
     app_state = types.SimpleNamespace(
         state=types.SimpleNamespace(settings=settings)
     )
+    # #1467: Logger(app_state) is wired first so subsequent subsystem
+    # construction logs through the configured root, mirroring build_app.
+    app_state.state.logger = logger_mod.Logger(app_state)
     sockets = WebSocketState(app_state)
     app_state.state.sockets = sockets
     registry = ContainerRegistry(app_state)
@@ -799,6 +803,7 @@ class TestStartupShutdownRestart:
         old_settings = app_state.state.settings
         called = []
         for attr in (
+            "logger",
             "ssl_trust",
             "auth",
             "podman",
@@ -838,7 +843,7 @@ class TestStartupShutdownRestart:
         assert "ssl_trust" in called
         assert "oidc" in called
         assert "plugins" in called
-        assert len(called) == 18
+        assert len(called) == 19
         mock_reseed.assert_awaited_once()
 
     async def test_apply_logs_warning_when_reconfigure_fails(
@@ -1385,6 +1390,32 @@ class TestBuildApp:
     def test_build_app_registers_exception_handlers(self):
         app = main.build_app(make_settings({}))
         assert model.AgentPrincipalError in app.exception_handlers
+
+    def test_build_app_wires_logger(self):
+        """build_app constructs Logger(app) onto app.state.logger (#1467)."""
+        app = main.build_app(make_settings({}))
+        assert isinstance(app.state.logger, logger_mod.Logger)
+
+    def test_no_module_scope_basic_config(self):
+        """Logging is not configured as an import side-effect (#1467).
+
+        main.py must not call ``logging.basicConfig(...)`` at module scope —
+        configuration now lives in ``Logger(app)`` (``app.state.logger``),
+        constructed explicitly in build_app. Checked via AST so comments /
+        docstrings that merely mention the name don't trip it.
+        """
+        import ast
+        import inspect
+
+        tree = ast.parse(inspect.getsource(main))
+        basic_config_calls = [
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, ast.Call)
+            and isinstance(n.func, ast.Attribute)
+            and n.func.attr == "basicConfig"
+        ]
+        assert not basic_config_calls
 
     def test_no_module_level_app_attribute(self):
         """main.py no longer exposes an ``app`` attribute (#1454).

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -18,7 +18,6 @@ from klangk import (
     auth as auth_mod,
     emailsvc as emailsvc_mod,
     files as files_mod,
-    logger as logger_mod,
     nginx as nginx_mod,
     ssl_trust as ssl_trust_mod,
     util as util_mod,
@@ -44,9 +43,6 @@ def _make_app_state(settings=None):
     app_state = types.SimpleNamespace(
         state=types.SimpleNamespace(settings=settings)
     )
-    # #1467: Logger(app_state) is wired first so subsequent subsystem
-    # construction logs through the configured root, mirroring build_app.
-    app_state.state.logger = logger_mod.Logger(app_state)
     sockets = WebSocketState(app_state)
     app_state.state.sockets = sockets
     registry = ContainerRegistry(app_state)
@@ -803,7 +799,6 @@ class TestStartupShutdownRestart:
         old_settings = app_state.state.settings
         called = []
         for attr in (
-            "logger",
             "ssl_trust",
             "auth",
             "podman",
@@ -843,7 +838,7 @@ class TestStartupShutdownRestart:
         assert "ssl_trust" in called
         assert "oidc" in called
         assert "plugins" in called
-        assert len(called) == 19
+        assert len(called) == 18
         mock_reseed.assert_awaited_once()
 
     async def test_apply_logs_warning_when_reconfigure_fails(
@@ -1391,18 +1386,28 @@ class TestBuildApp:
         app = main.build_app(make_settings({}))
         assert model.AgentPrincipalError in app.exception_handlers
 
-    def test_build_app_wires_logger(self):
-        """build_app constructs Logger(app) onto app.state.logger (#1467)."""
-        app = main.build_app(make_settings({}))
-        assert isinstance(app.state.logger, logger_mod.Logger)
+    def test_build_app_configures_logging_from_settings(self):
+        """build_app re-applies the log level from KLANGK_LOG_LEVEL (#1467).
+
+        Logging is global module state (no app.state.logger object);
+        build_app calls ``klangk.logger.configure(settings)`` after settings
+        are finalized. Build an app with DEBUG and confirm the root level
+        reflects it.
+        """
+        import logging
+
+        app = main.build_app(make_settings({"KLANGK_LOG_LEVEL": "DEBUG"}))
+        assert app.state.settings.log_level == "DEBUG"
+        assert logging.getLogger().level == logging.DEBUG
 
     def test_no_module_scope_basic_config(self):
         """Logging is not configured as an import side-effect (#1467).
 
         main.py must not call ``logging.basicConfig(...)`` at module scope —
-        configuration now lives in ``Logger(app)`` (``app.state.logger``),
-        constructed explicitly in build_app. Checked via AST so comments /
-        docstrings that merely mention the name don't trip it.
+        configuration lives in :mod:`klangk.logger` (applied at its import
+        and re-applied via ``configure(settings)`` in build_app). Checked via
+        AST so comments / docstrings that merely mention the name don't trip
+        it.
         """
         import ast
         import inspect

--- a/src/klangk/klangkd-tests/tests/test_settings.py
+++ b/src/klangk/klangkd-tests/tests/test_settings.py
@@ -504,6 +504,50 @@ class TestAuthModesValidator:
         assert "password" in msg  # valid modes listed in the message
 
 
+class TestLogLevelValidator:
+    """KLANGK_LOG_LEVEL must be a recognized level or fail fast at boot
+    (#1467), mirroring the fail-fast posture of the auth_modes validator."""
+
+    def test_defaults_to_info(self):
+        s = make_settings({})
+        assert s.log_level == "INFO"
+
+    @pytest.mark.parametrize(
+        "name", ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+    )
+    def test_valid_names_accepted_any_case(self, name):
+        # lower, upper, mixed all normalize to upper
+        s = make_settings({"KLANGK_LOG_LEVEL": name.lower()})
+        assert s.log_level == name
+
+    @pytest.mark.parametrize("num", ["0", "10", "20", "30", "40", "50"])
+    def test_numeric_string_accepted(self, num):
+        s = make_settings({"KLANGK_LOG_LEVEL": num})
+        assert s.log_level == num
+
+    def test_empty_string_defaults_to_info(self):
+        s = make_settings({"KLANGK_LOG_LEVEL": ""})
+        assert s.log_level == "INFO"
+
+    @pytest.mark.parametrize(
+        "bad", ["verbose", "TRACE", "info!", "debug-level"]
+    )
+    def test_garbage_rejected_at_construction(self, bad):
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            make_settings({"KLANGK_LOG_LEVEL": bad})
+
+    def test_error_message_names_valid_levels(self):
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError) as exc_info:
+            make_settings({"KLANGK_LOG_LEVEL": "verbose"})
+        msg = str(exc_info.value)
+        assert "verbose" in msg
+        assert "DEBUG" in msg  # valid levels listed in the message
+
+
 class TestResolveIndirectionsValidator:
     """The ``_resolve_indirections`` model validator runs once at construction
     (#1461): every string field with a ``file:``/``cmd:`` prefix is resolved


### PR DESCRIPTION
## Summary

Centralizes logging in a `Logger(app)` state object, configured in
`build_app()` and stored on `app.state.logger` — the same composition-root
pattern as the other owned subsystems (`Util`, `Model`, `Container`, ...).

Closes #1467.

## What changed

- **New `Logger(app)` state object** (`src/klangk/klangk/logger.py`), hung on
  `app.state.logger` in `build_app()`. It owns:
  - the single `StreamHandler` on the root logger, carrying the colored
    console format previously hardcoded in `main.py`,
  - the root level, read live from the new `KLANGK_LOG_LEVEL` setting,
  - central silencing of chatty third-party loggers (`uvicorn.access`,
    `sqlalchemy.engine`, `httpx`, `httpcore`, `watchfiles`, `asyncio`) to
    `WARNING`.
- **Removed** the import-time `logging.basicConfig(...)` call from
  `main.py`'s module body. Importing `klangk` no longer configures logging
  as a side-effect (acceptance criterion). The handler is tagged with a
  private attribute so repeated construction (fresh app per test, or a
  reconfigure) never stacks duplicate handlers — and so it dedups without
  touching foreign handlers on the root logger (pytest's `caplog`, etc.).
- **New `log_level` setting** (`KLANGK_LOG_LEVEL`, default `INFO`): accepts
  a level name (`DEBUG`/`INFO`/`WARNING`/`ERROR`/`CRITICAL`, any case) or a
  numeric string; rejects garbage at boot (fail-fast, mirroring the
  `auth_modes` validator).
- **Live reload**: `Logger.reconfigure(app)` re-applies the level from a
  freshly-reloaded settings, so `KLANGK_LOG_LEVEL` takes effect on a SIGHUP
  restart without a process restart (#1587). `"logger"` is added to the
  `_apply_reloaded_settings` subsystem list.

## What did *not* change (intentional)

Per-module `logger = logging.getLogger(__name__)` calls across the ~33
modules are **kept**. Those obtain *named logger handles* (not
configuration) that propagate to the root logger `Logger` configures; they
are the idiomatic Python pattern and cannot all be replaced with
`app.state.logger` references — notably `settings.py` logs during
construction (validators, the `file:`/`cmd:` indirection resolver), before
any `app` exists. Centralizing the **configuration** is what the
composition-root refactor (#1426) calls for; the named-handle pattern is
orthogonal and correct.

Format and date format are **not** made configurable in this PR (kept as
the pre-refactor colored defaults). A follow-up may allow customizing the
logger class / format, but that's deferred as out of scope here.

## Tests

- New `src/klangk/klangkd-tests/tests/test_logger.py` — covers handler
  installation/dedup, colored formatter, level-from-settings, third-party
  silencing, `reconfigure` (level + no stacking + third-party reset), and
  the app-ownership rule.
- `test_settings.py` — `TestLogLevelValidator` (defaults, valid names any
  case, numeric strings, empty→INFO, garbage rejected, error message).
- `test_main.py` — `build_app` wires `app.state.logger`; AST-based check
  that `main.py` no longer calls `logging.basicConfig`; the SIGHUP
  reconfigure-count assertion bumped 18→19 and `"logger"` added to the
  subsystems tuple.

Full suite: **3017 passed, 100% coverage** (run CI-style with `-n auto`).

## Changelog

Added an entry under `[Unreleased] → Added`.

## Acceptance (from #1467)

- [x] No `logging.basicConfig(...)` at module scope in `main.py`.
- [x] A `Logger(app)` state object exists, constructed once in `build_app()`
      and stored on `app.state.logger`.
- [x] Log level is driven by settings (`KLANGK_LOG_LEVEL`), not hardcoded `INFO`.
- [x] Importing `klangk` modules no longer triggers logging configuration as
      a side-effect.
- [x] (Per-module `getLogger` calls **kept** — see "What did not change"
      above; they are named handles, not configuration.)
- [x] 100% coverage maintained.
