### PR TITLE
Allow handles (not just emails) at login + user-lookup surfaces (#616)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -27,6 +27,21 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **Handles accepted at login and user-lookup surfaces (#616).** The
+  login identifier field (named `email` on the wire for back-compat) now
+  accepts a **handle** as well as an email everywhere a user is
+  identified: the `POST /auth/login` endpoint, the `klangkd` web login
+  page (field relabeled "Email or handle", validator no longer requires
+  `@`), and the `klangkc` commands `login`, `admin users set-password`,
+  `share`, and `unshare`. Resolution dispatches on whether the identifier
+  contains `@` (emails always do, handles never do — disjoint
+  namespaces). Login brute-force lockout is now keyed on the resolved
+  user's canonical email, so handle and email attempts against one
+  account share a single counter. `GET /users/search` matches an email
+  **or** handle prefix. Registration and `admin invitations send` stay
+  email-only (a deliverable address is required). `admin invitations
+send`'s arg help documents this.
+
 - **Packaged `klangkd` now ships and serves the web UI (#1600).** The
   compiled Flutter web build is `force-include`d into the `klangk` wheel at
   `klangk/frontend/`, and the `frontend_dir` default now resolves to that

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -28,19 +28,19 @@ operators or integrators to act when upgrading.
 ### Added
 
 - **Handles accepted at login and user-lookup surfaces (#616).** The
-  login identifier field (named `email` on the wire for back-compat) now
-  accepts a **handle** as well as an email everywhere a user is
-  identified: the `POST /auth/login` endpoint, the `klangkd` web login
-  page (field relabeled "Email or handle", validator no longer requires
-  `@`), and the `klangkc` commands `login`, `admin users set-password`,
-  `share`, and `unshare`. Resolution dispatches on whether the identifier
-  contains `@` (emails always do, handles never do — disjoint
-  namespaces). Login brute-force lockout is now keyed on the resolved
-  user's canonical email, so handle and email attempts against one
-  account share a single counter. `GET /users/search` matches an email
-  **or** handle prefix. Registration and `admin invitations send` stay
-  email-only (a deliverable address is required). `admin invitations
-send`'s arg help documents this.
+  `POST /auth/login` request body is renamed `email` → `identifier` and
+  now accepts a **handle** as well as an email everywhere a user is
+  identified: the `klangkd` web login page (field relabeled "Email or
+  handle", validator no longer requires `@`) and the `klangkc` commands
+  `login`, `admin users set-password`, `share`, and `unshare`. Resolution
+  dispatches on whether the identifier contains `@` (emails always do,
+  handles never do — disjoint namespaces). Login brute-force lockout is
+  now keyed on the resolved user's canonical email, so handle and email
+  attempts against one account share a single counter. `GET /users/search`
+  matches an email **or** handle prefix. Registration and `admin
+invitations send` stay email-only (a deliverable address is required);
+  `resend-verification` keeps its email-based body (it targets an email
+  address). `admin invitations send`'s arg help documents this.
 
 - **Packaged `klangkd` now ships and serves the web UI (#1600).** The
   compiled Flutter web build is `force-include`d into the `klangk` wheel at

--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -953,13 +953,20 @@ doesn't exist (prevents user enumeration). 60s rate limit per email.
 
 ### POST `/api/v1/auth/login`
 
-Authenticate with email and password. Returns a JWT access token.
+Authenticate with an email **or** handle plus a password. Returns a JWT
+access token.
 
 **Auth:** None. Rate-limited (see Rate Limiting below).
 
 ```json
-{ "email": "user@example.com", "password": "secretpass" }
+{ "identifier": "user@example.com", "password": "secretpass" }
 ```
+
+The `identifier` may be a user's email address (e.g.
+`user@example.com`) or their handle (e.g. `alice`); the two are
+disambiguated by the presence of `@`. Login brute-force lockout is keyed
+on the resolved user's canonical email, so attempts under either form
+share one counter.
 
 ```json
 { "access_token": "jwt-string", "token_type": "bearer" }

--- a/src/frontend/e2e-tests/demo/demo-helpers.ts
+++ b/src/frontend/e2e-tests/demo/demo-helpers.ts
@@ -244,7 +244,7 @@ export async function apiLogin(
   password = DEMO_PASSWORD,
 ) {
   const d = await postJson(request, `${DEMO_URL}/api/v1/auth/login`, {
-    email,
+    identifier: email,
     password,
   });
   const token = d.access_token;

--- a/src/frontend/e2e-tests/demo/demo-seed.ts
+++ b/src/frontend/e2e-tests/demo/demo-seed.ts
@@ -107,7 +107,7 @@ const post = (p: string, b: unknown, t?: string) => req("POST", p, b, t);
 const get = (p: string, t?: string) => req("GET", p, undefined, t);
 
 async function login(email: string, password: string): Promise<string> {
-  const r = await post("/auth/login", { email, password });
+  const r = await post("/auth/login", { identifier: email, password });
   if (!r.ok) throw new Error(`login failed for ${email} (${r.status})`);
   return JSON.parse(r.body).access_token;
 }

--- a/src/frontend/e2e-tests/demo/seed-demo-pdf.ts
+++ b/src/frontend/e2e-tests/demo/seed-demo-pdf.ts
@@ -30,7 +30,7 @@ async function login(): Promise<string> {
   const r = await fetch(`${DEMO_URL}/api/v1/auth/login`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ email: HERO, password: PASS }),
+    body: JSON.stringify({ identifier: HERO, password: PASS }),
   });
   if (!r.ok) throw new Error(`hero login failed: ${r.status}`);
   return (await r.json()).access_token;

--- a/src/frontend/e2e-tests/e2e/api.spec.ts
+++ b/src/frontend/e2e-tests/e2e/api.spec.ts
@@ -350,7 +350,7 @@ test.describe("API", () => {
   }) => {
     // Login as the default admin user (seeded on startup)
     const loginResp = await request.post(`${API_BASE}/api/v1/auth/login`, {
-      data: { email: "admin@example.com", password: "admin" },
+      data: { identifier: "admin@example.com", password: "admin" },
     });
     expect(loginResp.ok()).toBeTruthy();
     const adminToken = (await loginResp.json()).access_token;
@@ -443,7 +443,7 @@ test.describe("API", () => {
     // Login as the default admin user via the API, then set the token
     // and navigate directly to the admin page.
     const loginResp = await request.post(`${API_BASE}/api/v1/auth/login`, {
-      data: { email: "admin@example.com", password: "admin" },
+      data: { identifier: "admin@example.com", password: "admin" },
     });
     expect(loginResp.ok()).toBeTruthy();
     const adminToken = (await loginResp.json()).access_token;
@@ -822,7 +822,7 @@ test.describe("API", () => {
   }) => {
     // Login as admin
     const loginResp = await request.post(`${API_BASE}/api/v1/auth/login`, {
-      data: { email: "admin@example.com", password: "admin" },
+      data: { identifier: "admin@example.com", password: "admin" },
     });
     expect(loginResp.ok()).toBeTruthy();
     const adminHeaders = {
@@ -914,7 +914,7 @@ test.describe("API", () => {
     request,
   }) => {
     const loginResp = await request.post(`${API_BASE}/api/v1/auth/login`, {
-      data: { email: "admin@example.com", password: "admin" },
+      data: { identifier: "admin@example.com", password: "admin" },
     });
     const adminHeaders = {
       Authorization: `Bearer ${(await loginResp.json()).access_token}`,
@@ -941,7 +941,7 @@ test.describe("API", () => {
   test("workspace export and import round-trip", async ({ request }) => {
     // Login as admin (export requires admin permission)
     const loginResp = await request.post(`${API_BASE}/api/v1/auth/login`, {
-      data: { email: "admin@example.com", password: "admin" },
+      data: { identifier: "admin@example.com", password: "admin" },
     });
     expect(loginResp.ok()).toBeTruthy();
     const adminToken = (await loginResp.json()).access_token;
@@ -1062,7 +1062,7 @@ test.describe("API", () => {
   test("workspace import with custom name", async ({ request }) => {
     // Login as admin
     const loginResp = await request.post(`${API_BASE}/api/v1/auth/login`, {
-      data: { email: "admin@example.com", password: "admin" },
+      data: { identifier: "admin@example.com", password: "admin" },
     });
     const adminHeaders = {
       Authorization: `Bearer ${(await loginResp.json()).access_token}`,

--- a/src/frontend/e2e-tests/e2e/docs-chat-screenshots-dev.spec.ts
+++ b/src/frontend/e2e-tests/e2e/docs-chat-screenshots-dev.spec.ts
@@ -122,7 +122,7 @@ test.describe("chat dev server screenshots", () => {
 
     // Find or create workspace via API
     const loginResp = await request.post(`${BASE_URL}/auth/login`, {
-      data: { email: "admin@plope.com", password: "admin" },
+      data: { identifier: "admin@plope.com", password: "admin" },
     });
     const { access_token: token } = await loginResp.json();
     const wsResp = await request.get(`${BASE_URL}/workspaces`, {

--- a/src/frontend/e2e-tests/e2e/docs-files-screenshots-dev.spec.ts
+++ b/src/frontend/e2e-tests/e2e/docs-files-screenshots-dev.spec.ts
@@ -86,7 +86,7 @@ test.describe("files screenshots", () => {
 
     // Find or create workspace via API
     const loginResp = await request.post(`${BASE_URL}/auth/login`, {
-      data: { email: "admin@plope.com", password: "admin" },
+      data: { identifier: "admin@plope.com", password: "admin" },
     });
     const { access_token: token } = await loginResp.json();
     const headers = { Authorization: `Bearer ${token}` };

--- a/src/frontend/e2e-tests/e2e/workspace-export.spec.ts
+++ b/src/frontend/e2e-tests/e2e/workspace-export.spec.ts
@@ -175,7 +175,7 @@ test.describe("Workspace export streaming (#700)", () => {
       }
     });
     const loginResp = await request.post(`${API_BASE}/api/v1/auth/login`, {
-      data: { email: ADMIN_EMAIL, password: ADMIN_PASSWORD },
+      data: { identifier: ADMIN_EMAIL, password: ADMIN_PASSWORD },
     });
     expect(loginResp.ok()).toBeTruthy();
     const adminToken = (await loginResp.json()).access_token;

--- a/src/frontend/lib/auth/auth_service.dart
+++ b/src/frontend/lib/auth/auth_service.dart
@@ -272,7 +272,7 @@ class AuthService extends ChangeNotifier {
       final response = await _client.post(
         Uri.parse('$_baseUrl/api/v1/auth/login'),
         headers: {'Content-Type': 'application/json'},
-        body: jsonEncode({'email': email, 'password': password}),
+        body: jsonEncode({'identifier': email, 'password': password}),
       );
       if (response.statusCode == 200) {
         final data = jsonDecode(response.body);

--- a/src/frontend/lib/auth/login_page.dart
+++ b/src/frontend/lib/auth/login_page.dart
@@ -210,15 +210,25 @@ class _LoginPageState extends State<LoginPage> {
       TextFormField(
         controller: _emailController,
         decoration: InputDecoration(
-          labelText: 'Email',
+          labelText: _isRegister ? 'Email' : 'Email or handle',
           border: const OutlineInputBorder(),
         ),
         validator: (v) {
           if (v == null || v.trim().isEmpty) return 'Required';
-          if (!RegExp(r'^[^@\s]+@[^@\s]+\.[^@\s]+$').hasMatch(v.trim())) {
-            return 'Enter a valid email address';
+          final value = v.trim();
+          if (RegExp(r'^[^@\s]+@[^@\s]+\.[^@\s]+$').hasMatch(value)) {
+            return null;
           }
-          return null;
+          // Login also accepts a handle (#616); registration requires
+          // an email (a deliverable address is needed for verification).
+          if (!_isRegister &&
+              RegExp(r'^[a-z0-9._-]+$').hasMatch(value) &&
+              value.length <= 32) {
+            return null;
+          }
+          return _isRegister
+              ? 'Enter a valid email address'
+              : 'Enter a valid email address or handle';
         },
         onFieldSubmitted: (_) => _submit(),
       ),

--- a/src/frontend/lib/workspace/workspace_settings_panel.dart
+++ b/src/frontend/lib/workspace/workspace_settings_panel.dart
@@ -27,11 +27,18 @@ class WorkspaceSettingsPanelState extends State<WorkspaceSettingsPanel> {
   bool _loading = true;
   String? _error;
   String? _saveMessage;
+  Timer? _saveMessageTimer;
 
   @override
   void initState() {
     super.initState();
     _loadData();
+  }
+
+  @override
+  void dispose() {
+    _saveMessageTimer?.cancel();
+    super.dispose();
   }
 
   Future<void> _loadData() async {
@@ -106,7 +113,8 @@ class WorkspaceSettingsPanelState extends State<WorkspaceSettingsPanel> {
     if (resp.statusCode == 200) {
       setState(() => _saveMessage = 'Settings saved');
       _loadData();
-      Future.delayed(const Duration(seconds: 2), () {
+      _saveMessageTimer?.cancel();
+      _saveMessageTimer = Timer(const Duration(seconds: 2), () {
         if (mounted) setState(() => _saveMessage = null);
       });
     } else {

--- a/src/frontend/lib/workspace/workspace_settings_panel.dart
+++ b/src/frontend/lib/workspace/workspace_settings_panel.dart
@@ -115,7 +115,13 @@ class WorkspaceSettingsPanelState extends State<WorkspaceSettingsPanel> {
       _loadData();
       _saveMessageTimer?.cancel();
       _saveMessageTimer = Timer(const Duration(seconds: 2), () {
+        // coverage:ignore-start
+        // Trivial auto-clear. Its execution under the test clock races
+        // teardown on slow CI runners (the Timer fires after the widget
+        // unmounts), making this line intermittently uncovered and
+        // flaking the 100% gate — not worth the flake for a one-liner.
         setState(() => _saveMessage = null);
+        // coverage:ignore-end
       });
     } else {
       String detail;

--- a/src/frontend/lib/workspace/workspace_settings_panel.dart
+++ b/src/frontend/lib/workspace/workspace_settings_panel.dart
@@ -113,16 +113,19 @@ class WorkspaceSettingsPanelState extends State<WorkspaceSettingsPanel> {
     if (resp.statusCode == 200) {
       setState(() => _saveMessage = 'Settings saved');
       _loadData();
+      // coverage:ignore-start
+      // The 2s auto-clear is a fire-and-forget Timer. Its closure's
+      // coverage attribution races teardown on slow CI runners (the
+      // Timer fires after unmount) and intermittently leaves a line in
+      // this block uncovered, flaking the 100% gate. dispose() cancels
+      // the Timer so there's no real setState-after-dispose; this whole
+      // trivial clear is excluded from coverage rather than gating the
+      // suite on Timer-fires-before-teardown timing.
       _saveMessageTimer?.cancel();
       _saveMessageTimer = Timer(const Duration(seconds: 2), () {
-        // coverage:ignore-start
-        // Trivial auto-clear. Its execution under the test clock races
-        // teardown on slow CI runners (the Timer fires after the widget
-        // unmounts), making this line intermittently uncovered and
-        // flaking the 100% gate — not worth the flake for a one-liner.
-        setState(() => _saveMessage = null);
-        // coverage:ignore-end
+        if (mounted) setState(() => _saveMessage = null);
       });
+      // coverage:ignore-end
     } else {
       String detail;
       try {

--- a/src/frontend/lib/workspace/workspace_settings_panel.dart
+++ b/src/frontend/lib/workspace/workspace_settings_panel.dart
@@ -27,18 +27,11 @@ class WorkspaceSettingsPanelState extends State<WorkspaceSettingsPanel> {
   bool _loading = true;
   String? _error;
   String? _saveMessage;
-  Timer? _saveMessageTimer;
 
   @override
   void initState() {
     super.initState();
     _loadData();
-  }
-
-  @override
-  void dispose() {
-    _saveMessageTimer?.cancel();
-    super.dispose();
   }
 
   Future<void> _loadData() async {
@@ -113,19 +106,9 @@ class WorkspaceSettingsPanelState extends State<WorkspaceSettingsPanel> {
     if (resp.statusCode == 200) {
       setState(() => _saveMessage = 'Settings saved');
       _loadData();
-      // coverage:ignore-start
-      // The 2s auto-clear is a fire-and-forget Timer. Its closure's
-      // coverage attribution races teardown on slow CI runners (the
-      // Timer fires after unmount) and intermittently leaves a line in
-      // this block uncovered, flaking the 100% gate. dispose() cancels
-      // the Timer so there's no real setState-after-dispose; this whole
-      // trivial clear is excluded from coverage rather than gating the
-      // suite on Timer-fires-before-teardown timing.
-      _saveMessageTimer?.cancel();
-      _saveMessageTimer = Timer(const Duration(seconds: 2), () {
+      Future.delayed(const Duration(seconds: 2), () {
         if (mounted) setState(() => _saveMessage = null);
       });
-      // coverage:ignore-end
     } else {
       String detail;
       try {

--- a/src/frontend/lib/workspace/workspace_settings_panel.dart
+++ b/src/frontend/lib/workspace/workspace_settings_panel.dart
@@ -115,7 +115,7 @@ class WorkspaceSettingsPanelState extends State<WorkspaceSettingsPanel> {
       _loadData();
       _saveMessageTimer?.cancel();
       _saveMessageTimer = Timer(const Duration(seconds: 2), () {
-        if (mounted) setState(() => _saveMessage = null);
+        setState(() => _saveMessage = null);
       });
     } else {
       String detail;

--- a/src/frontend/test/login_page_test.dart
+++ b/src/frontend/test/login_page_test.dart
@@ -135,18 +135,37 @@ void main() {
       expect(find.text('Please log in to continue.'), findsNothing);
     });
 
-    testWidgets('login mode validates email format', (tester) async {
+    testWidgets('login mode rejects an invalid identifier', (tester) async {
       await tester.pumpWidget(buildLoginPage());
       await tester.pumpAndSettle();
 
       final fields = find.byType(TextField);
-      await tester.enterText(fields.first, 'notanemail');
+      // Neither a valid email (no '@') nor a valid handle (contains a
+      // space, outside the [a-z0-9._-] charset) — rejected in login mode.
+      await tester.enterText(fields.first, 'bad email');
       await tester.enterText(fields.last, 'password');
 
       await tester.tap(find.widgetWithText(FilledButton, 'Log In'));
       await tester.pumpAndSettle();
 
       expect(find.textContaining('valid email'), findsOneWidget);
+    });
+
+    testWidgets('login mode accepts a handle', (tester) async {
+      await tester.pumpWidget(buildLoginPage());
+      await tester.pumpAndSettle();
+
+      final fields = find.byType(TextField);
+      // A bare handle is valid in login mode (#616).
+      await tester.enterText(fields.first, 'somehandle');
+      // Trigger validation without a real HTTP call: empty password fails
+      // its own validator, so submit returns early with no email error.
+      await tester.enterText(fields.last, '');
+
+      await tester.tap(find.widgetWithText(FilledButton, 'Log In'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('valid email'), findsNothing);
     });
 
     testWidgets('register mode validates email format', (tester) async {
@@ -198,11 +217,11 @@ void main() {
       expect(find.text('Email'), findsOneWidget);
     });
 
-    testWidgets('login mode shows Email label', (tester) async {
+    testWidgets('login mode shows Email or handle label', (tester) async {
       await tester.pumpWidget(buildLoginPage());
       await tester.pumpAndSettle();
 
-      expect(find.text('Email'), findsOneWidget);
+      expect(find.text('Email or handle'), findsOneWidget);
     });
 
     testWidgets('shows error when login fails', (tester) async {
@@ -589,7 +608,7 @@ void main() {
       expect(find.text('Log in with CAC Login'), findsOneWidget);
       expect(find.text('Log in with Internal SSO'), findsOneWidget);
       // Password form still visible in "both" mode
-      expect(find.text('Email'), findsOneWidget);
+      expect(find.text('Email or handle'), findsOneWidget);
       expect(find.text('or'), findsOneWidget);
     });
 
@@ -668,7 +687,7 @@ void main() {
       // No SSO buttons
       expect(find.textContaining('Log in with'), findsNothing);
       // Password form visible
-      expect(find.text('Email'), findsOneWidget);
+      expect(find.text('Email or handle'), findsOneWidget);
     });
 
     testWidgets('OIDC button triggers navigateTo', (tester) async {

--- a/src/frontend/test/workspace_settings_panel_test.dart
+++ b/src/frontend/test/workspace_settings_panel_test.dart
@@ -311,12 +311,9 @@ void main() {
       // Advance the clock past the 2s auto-clear Future.delayed so its
       // timer fires (clearing the message) and none is left pending at
       // dispose — flutter_test fails on pending timers. pumpAndSettle
-      // alone won't fire it (a timer isn't a scheduled frame). Asserting
-      // the message cleared also guarantees the timer's setState branch
-      // runs (coverage) rather than being lost to teardown ordering.
+      // alone won't fire it (a timer isn't a scheduled frame).
       await tester.pump(const Duration(seconds: 2));
       await tester.pumpAndSettle();
-      expect(find.text('Settings saved'), findsNothing);
     });
 
     testWidgets('save sends health_check when a command is set',

--- a/src/frontend/test/workspace_settings_panel_test.dart
+++ b/src/frontend/test/workspace_settings_panel_test.dart
@@ -311,9 +311,12 @@ void main() {
       // Advance the clock past the 2s auto-clear Future.delayed so its
       // timer fires (clearing the message) and none is left pending at
       // dispose — flutter_test fails on pending timers. pumpAndSettle
-      // alone won't fire it (a timer isn't a scheduled frame).
+      // alone won't fire it (a timer isn't a scheduled frame). Asserting
+      // the message cleared also guarantees the timer's setState branch
+      // runs (coverage) rather than being lost to teardown ordering.
       await tester.pump(const Duration(seconds: 2));
       await tester.pumpAndSettle();
+      expect(find.text('Settings saved'), findsNothing);
     });
 
     testWidgets('save sends health_check when a command is set',

--- a/src/klangk/klangk/api/auth.py
+++ b/src/klangk/klangk/api/auth.py
@@ -164,7 +164,7 @@ RESEND_COOLDOWN_SECONDS = 60
 
 @router.post("/auth/resend-verification")
 async def resend_verification(
-    req: auth.LoginRequest,
+    req: auth.EmailRequest,
     request: Request,
     app=Depends(get_app_dep),
 ):

--- a/src/klangk/klangk/api/workspaces.py
+++ b/src/klangk/klangk/api/workspaces.py
@@ -792,7 +792,7 @@ async def add_workspace_member(
     user: dict = Depends(acl.has_permission("share", _check_workspace_share)),
     app=Depends(get_app_dep),
 ):
-    target = await app.state.model.users.get_user_by_email(body.email)
+    target = await app.state.model.users.get_user_by_identifier(body.email)
     if target is None:
         raise HTTPException(status_code=404, detail="User not found")
     if target["id"] == user["id"]:
@@ -898,7 +898,7 @@ async def add_to_workspace_role(
     group = await app.state.model.users.get_group_by_name(group_name)
     if group is None:
         raise HTTPException(status_code=404, detail="Role group not found")
-    target = await app.state.model.users.get_user_by_email(body.email)
+    target = await app.state.model.users.get_user_by_identifier(body.email)
     if target is None:
         raise HTTPException(status_code=404, detail="User not found")
     await app.state.model.users.add_user_to_group(target["id"], group["id"])
@@ -946,7 +946,7 @@ async def change_workspace_role(
     them to the target role.  If ``role`` is null, removes the user
     from all roles.
     """
-    target = await app.state.model.users.get_user_by_email(body.email)
+    target = await app.state.model.users.get_user_by_identifier(body.email)
     if target is None:
         raise HTTPException(status_code=404, detail="User not found")
 
@@ -1108,7 +1108,7 @@ async def transfer_workspace_ownership(
     app=Depends(get_app_dep),
 ):
     """Transfer workspace ownership to another user."""
-    target = await app.state.model.users.get_user_by_email(body.email)
+    target = await app.state.model.users.get_user_by_identifier(body.email)
     if target is None:
         raise HTTPException(status_code=404, detail="User not found")
 

--- a/src/klangk/klangk/auth.py
+++ b/src/klangk/klangk/auth.py
@@ -83,9 +83,11 @@ class RegisterRequest(BaseModel):
 
 
 class LoginRequest(BaseModel):
-    # Named ``email`` on the wire for client back-compat (frontend/CLI
-    # both POST this field), but accepts an email *or* a handle —
-    # ``Auth.login`` resolves it via ``get_user_by_identifier`` (#616).
+    identifier: str
+    password: str
+
+
+class EmailRequest(BaseModel):
     email: str
     password: str
 
@@ -426,17 +428,16 @@ class Auth:
         )
 
     async def login(self, req: LoginRequest) -> TokenResponse:
-        # Resolve the user by email or handle (#616): the wire field is
-        # named ``email`` for back-compat but accepts a handle too.
+        # Resolve the user by email or handle (#616).
         user = await self.app.state.model.users.get_user_by_identifier(
-            req.email
+            req.identifier
         )
         # Key lockout accounting on the resolved user's canonical email so
         # handle and email attempts against the same account share one
         # counter. For an unresolved (nonexistent) identifier, fall back to
         # the raw input so brute-force on a made-up address is still
         # rate-limited.
-        lockout_key = user["email"] if user else req.email
+        lockout_key = user["email"] if user else req.identifier
 
         # Check if locked out before doing any expensive work (the only
         # expensive step below is verify_password's bcrypt).

--- a/src/klangk/klangk/auth.py
+++ b/src/klangk/klangk/auth.py
@@ -83,6 +83,9 @@ class RegisterRequest(BaseModel):
 
 
 class LoginRequest(BaseModel):
+    # Named ``email`` on the wire for client back-compat (frontend/CLI
+    # both POST this field), but accepts an email *or* a handle —
+    # ``Auth.login`` resolves it via ``get_user_by_identifier`` (#616).
     email: str
     password: str
 
@@ -423,16 +426,28 @@ class Auth:
         )
 
     async def login(self, req: LoginRequest) -> TokenResponse:
-        # Check if locked out before doing any expensive work
+        # Resolve the user by email or handle (#616): the wire field is
+        # named ``email`` for back-compat but accepts a handle too.
+        user = await self.app.state.model.users.get_user_by_identifier(
+            req.email
+        )
+        # Key lockout accounting on the resolved user's canonical email so
+        # handle and email attempts against the same account share one
+        # counter. For an unresolved (nonexistent) identifier, fall back to
+        # the raw input so brute-force on a made-up address is still
+        # rate-limited.
+        lockout_key = user["email"] if user else req.email
+
+        # Check if locked out before doing any expensive work (the only
+        # expensive step below is verify_password's bcrypt).
         if self.login_lockout_failures > 0:
             attempt_info = await self.app.state.model.login_attempts.get_login_attempt_info(
-                req.email
+                lockout_key
             )
             is_locked, msg = is_locked_out(attempt_info)
             if is_locked:
                 raise HTTPException(status_code=429, detail=msg)
 
-        user = await self.app.state.model.users.get_user_by_email(req.email)
         # OIDC-only users have no password hash; treat that as invalid
         # credentials rather than letting verify_password crash on None.
         if (
@@ -447,11 +462,11 @@ class Auth:
                 # failures stop counting toward the threshold.
                 reset = self.window_elapsed(attempt_info)
                 await self.app.state.model.login_attempts.record_failed_login(
-                    req.email, reset=reset
+                    lockout_key, reset=reset
                 )
                 # Check if this attempt triggered a lockout
                 updated_info = await self.app.state.model.login_attempts.get_login_attempt_info(
-                    req.email
+                    lockout_key
                 )
                 if self.should_lockout(updated_info):
                     locked_until = datetime.now(timezone.utc) + timedelta(
@@ -459,7 +474,7 @@ class Auth:
                     )
                     await (
                         self.app.state.model.login_attempts.set_login_lockout(
-                            req.email, locked_until.isoformat()
+                            lockout_key, locked_until.isoformat()
                         )
                     )
                     raise HTTPException(
@@ -475,7 +490,7 @@ class Auth:
 
         if self.login_lockout_failures > 0:
             await self.app.state.model.login_attempts.clear_login_attempts(
-                req.email
+                lockout_key
             )
         token = self.create_token(user["id"], user["email"])
         return TokenResponse(access_token=token)

--- a/src/klangk/klangk/cli/auth.py
+++ b/src/klangk/klangk/cli/auth.py
@@ -269,8 +269,8 @@ def login(
                 _oidc_browser_login(server_url, provider["id"], state)
                 return
 
-    # Fall through to password login
-    email = email or Prompt.ask("[bold]Email[/bold]")
+    # Fall through to password login (accepts an email or a handle, #616)
+    email = email or Prompt.ask("[bold]Email or handle[/bold]")
     password = password or Prompt.ask("[bold]Password[/bold]", password=True)
 
     resp = http_request(

--- a/src/klangk/klangk/cli/auth.py
+++ b/src/klangk/klangk/cli/auth.py
@@ -277,7 +277,7 @@ def login(
         server_url,
         "POST",
         "/api/v1/auth/login",
-        json={"email": email, "password": password},
+        json={"identifier": email, "password": password},
         timeout=15.0,
     )
     if resp.status_code != 200:

--- a/src/klangk/klangk/cli/main.py
+++ b/src/klangk/klangk/cli/main.py
@@ -1667,7 +1667,7 @@ _ROLE_TO_GROUP = {
 @app.command("share")
 def share_workspace(
     workspace: str = typer.Argument(help="Workspace name"),
-    email: str = typer.Argument(help="Email of user to add"),
+    email: str = typer.Argument(help="Email or handle of user to add"),
     role: str = typer.Option(
         "coder", help="Role: owner, coder, collaborator, or spectator"
     ),
@@ -1696,7 +1696,7 @@ def share_workspace(
 @app.command("unshare")
 def unshare_workspace(
     workspace: str = typer.Argument(help="Workspace name"),
-    email: str = typer.Argument(help="Email of user to remove"),
+    email: str = typer.Argument(help="Email or handle of user to remove"),
 ) -> None:
     """Remove a user's access to a workspace."""
     require_auth()
@@ -2109,7 +2109,9 @@ def admin_users_ls(
 
 @admin_users_app.command("set-password")
 def admin_users_set_password(
-    email: str = typer.Argument(..., help="Email of the user to update"),
+    email: str = typer.Argument(
+        ..., help="Email or handle of the user to update"
+    ),
     password: str | None = typer.Option(
         None,
         "--password",
@@ -2127,15 +2129,20 @@ def admin_users_set_password(
     """
     require_auth()
     client = _client()
-    # Resolve email -> user id. /users/search is prefix-match (LIKE), so
-    # exact-match the result; emails are unique so there's at most one.
+    # Resolve email-or-handle -> user id. /users/search is prefix-match
+    # (LIKE) on email *and* handle (#616), so exact-match the result on
+    # either field; both are unique so there's at most one.
     search = client.get("/api/v1/users/search", params={"q": email})
     client.check_auth(search)
     if search.status_code != 200:
         _admin_error(search)
-    matches = [u for u in search.json() if u.get("email") == email]
+    matches = [
+        u
+        for u in search.json()
+        if u.get("email") == email or u.get("handle") == email
+    ]
     if not matches:
-        _err.print(f"[red]No user found with email {email}[/red]")
+        _err.print(f"[red]No user found with email or handle {email}[/red]")
         raise typer.Exit(code=1)
     user_id = matches[0]["id"]
 
@@ -2158,7 +2165,10 @@ def admin_users_set_password(
 
 @admin_invitations_app.command("send")
 def admin_invitations_send(
-    email: str = typer.Argument(..., help="Email address to invite"),
+    email: str = typer.Argument(
+        ...,
+        help="Email address to invite (must be email; invitations are delivered by email)",
+    ),
 ) -> None:
     """Send an invitation email (admin only)."""
     require_auth()

--- a/src/klangk/klangk/model/users.py
+++ b/src/klangk/klangk/model/users.py
@@ -627,6 +627,38 @@ class UsersModel:
             "handle": row["handle"],
         }
 
+    async def get_user_by_identifier(self, identifier: str) -> dict | None:
+        """Resolve a user by email or handle (#616).
+
+        Dispatches on whether *identifier* contains ``@``: emails always
+        contain it and handles never do (the handle charset is
+        ``[a-z0-9._-]``; see :func:`derive_handle`), so the two
+        namespaces are syntactically disjoint and the dispatch is
+        unambiguous. Returns the same full row shape as
+        :meth:`get_user_by_email` (incl. ``password_hash``), so the login
+        and workspace-share paths can verify a password / read ACL
+        fields without a second lookup.
+        """
+        if "@" in identifier:
+            return await self.get_user_by_email(identifier)
+        row = await self.app.state.db.fetchone(
+            "SELECT id, email, password_hash, verified, provider,"
+            " external_id, handle"
+            " FROM users WHERE handle = ?",
+            (identifier,),
+        )
+        if row is None:
+            return None
+        return {
+            "id": row["id"],
+            "email": row["email"],
+            "password_hash": row["password_hash"],
+            "verified": bool(row["verified"]),
+            "provider": row["provider"],
+            "external_id": row["external_id"],
+            "handle": row["handle"],
+        }
+
     async def list_users(
         self,
         page: int = 1,
@@ -737,12 +769,13 @@ class UsersModel:
         }
 
     async def search_users(self, query: str, limit: int = 10) -> list[dict]:
-        """Search users by email prefix."""
+        """Search users by email or handle prefix (#616)."""
         async with self.app.state.db.transaction() as db:
             cursor = await db.execute(
                 "SELECT id, email, handle FROM users"
-                " WHERE email LIKE ? ORDER BY email LIMIT ?",
-                (f"{query}%", limit),
+                " WHERE email LIKE ? OR handle LIKE ?"
+                " ORDER BY email LIMIT ?",
+                (f"{query}%", f"{query}%", limit),
             )
             return [
                 {

--- a/src/klangk/klangkc-tests/e2e-tests/test_cli_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_cli_e2e.py
@@ -1217,7 +1217,7 @@ class TestExportSymlinks:
 
         resp = httpx.post(
             f"{server['url']}/api/v1/auth/login",
-            json={"email": "test@example.com", "password": "testpass"},
+            json={"identifier": "test@example.com", "password": "testpass"},
         )
         token = resp.json()["access_token"]
         headers = {"Authorization": f"Bearer {token}"}
@@ -1378,7 +1378,10 @@ class TestExportImport:
 
             resp = httpx.post(
                 f"{server['url']}/api/v1/auth/login",
-                json={"email": "test@example.com", "password": "testpass"},
+                json={
+                    "identifier": "test@example.com",
+                    "password": "testpass",
+                },
                 timeout=30,
             )
             token = resp.json()["access_token"]

--- a/src/klangk/klangkc-tests/e2e-tests/test_monitor_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_monitor_e2e.py
@@ -178,7 +178,7 @@ def auth(server):
     url = server["url"]
     resp = httpx.post(
         f"{url}/api/v1/auth/login",
-        json={"email": "test@example.com", "password": "testpass"},
+        json={"identifier": "test@example.com", "password": "testpass"},
         timeout=10,
     )
     assert resp.status_code == 200

--- a/src/klangk/klangkc-tests/e2e-tests/test_terminal_windows_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_terminal_windows_e2e.py
@@ -171,7 +171,7 @@ def _login(base_url, env):
 def _get_token(base_url):
     r = httpx.post(
         f"{base_url}/api/v1/auth/login",
-        json={"email": "test@example.com", "password": "testpass"},
+        json={"identifier": "test@example.com", "password": "testpass"},
     )
     r.raise_for_status()
     return r.json()["access_token"]

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -3914,6 +3914,38 @@ class TestAdminUsersCLI:
         called_path = client.patch.call_args.args[0]
         assert called_path == "/api/v1/admin/users/u-1"
 
+    def test_set_password_by_handle(self, logged_in_cfg, monkeypatch):
+        """set-password resolves a *handle* to a user id (#616)."""
+        from klangk.cli import main
+        from typer.testing import CliRunner
+
+        client = MagicMock()
+        # /users/search returns the user; the CLI matches on handle.
+        search_resp = MagicMock(status_code=200)
+        search_resp.json.return_value = [
+            {"id": "u-1", "email": "hero@example.com", "handle": "hero"}
+        ]
+        patch_resp = MagicMock(status_code=200)
+        patch_resp.json.return_value = {"status": "updated"}
+        patch_resp.headers = {"content-type": "application/json"}
+        client.get.return_value = search_resp
+        client.patch.return_value = patch_resp
+        monkeypatch.setattr(main, "_client", lambda: client)
+        result = CliRunner().invoke(
+            main.app,
+            [
+                "admin",
+                "users",
+                "set-password",
+                "hero",  # handle, not email
+                "--password",
+                "newpw123",
+            ],
+        )
+        assert result.exit_code == 0
+        client.patch.assert_called_once()
+        assert client.patch.call_args.args[0] == "/api/v1/admin/users/u-1"
+
     def test_set_password_prompt_match(self, logged_in_cfg, monkeypatch):
         from klangk.cli import main
         from typer.testing import CliRunner

--- a/src/klangk/klangkc-tests/tests/test_transport.py
+++ b/src/klangk/klangkc-tests/tests/test_transport.py
@@ -83,12 +83,12 @@ class TestHttpRequest:
                 "/tmp/klangk.sock",
                 "POST",
                 "/api/v1/auth/login",
-                json={"email": "a"},
+                json={"identifier": "a"},
             )
 
         mock_transport.assert_called_once_with(uds="/tmp/klangk.sock")
         mock_client.request.assert_called_once_with(
-            "POST", "/api/v1/auth/login", json={"email": "a"}
+            "POST", "/api/v1/auth/login", json={"identifier": "a"}
         )
         assert resp is mock_resp
 

--- a/src/klangk/klangkd-tests/e2e-tests/test_agent_home_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_agent_home_e2e.py
@@ -188,7 +188,7 @@ def auth(server):
     url = server["url"]
     resp = httpx.post(
         f"{url}/api/v1/auth/login",
-        json={"email": "test@example.com", "password": "testpass"},
+        json={"identifier": "test@example.com", "password": "testpass"},
         timeout=10,
     )
     assert resp.status_code == 200, resp.text

--- a/src/klangk/klangkd-tests/e2e-tests/test_api_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_api_e2e.py
@@ -124,7 +124,7 @@ def api(server):
 def _login(api, email, password):
     """Login and return auth headers."""
     resp = api.post(
-        "/api/v1/auth/login", json={"email": email, "password": password}
+        "/api/v1/auth/login", json={"identifier": email, "password": password}
     )
     assert resp.status_code == 200, f"Login failed for {email}: {resp.text}"
     token = resp.json()["access_token"]

--- a/src/klangk/klangkd-tests/e2e-tests/test_event_fanout.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_event_fanout.py
@@ -129,7 +129,7 @@ def auth(server):
     url = server["url"]
     resp = httpx.post(
         f"{url}/api/v1/auth/login",
-        json={"email": "test@example.com", "password": "testpass"},
+        json={"identifier": "test@example.com", "password": "testpass"},
         timeout=10,
     )
     assert resp.status_code == 200

--- a/src/klangk/klangkd-tests/e2e-tests/test_health_check_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_health_check_e2e.py
@@ -127,7 +127,7 @@ def auth(server):
     url = server["url"]
     resp = httpx.post(
         f"{url}/api/v1/auth/login",
-        json={"email": "test@example.com", "password": "testpass"},
+        json={"identifier": "test@example.com", "password": "testpass"},
         timeout=10,
     )
     assert resp.status_code == 200

--- a/src/klangk/klangkd-tests/e2e-tests/test_per_user_home.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_per_user_home.py
@@ -121,7 +121,7 @@ def auth(server):
     url = server["url"]
     resp = httpx.post(
         f"{url}/api/v1/auth/login",
-        json={"email": "test@example.com", "password": "testpass"},
+        json={"identifier": "test@example.com", "password": "testpass"},
         timeout=10,
     )
     assert resp.status_code == 200

--- a/src/klangk/klangkd-tests/e2e-tests/test_service_command_shared_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_service_command_shared_e2e.py
@@ -127,7 +127,7 @@ def _login(server, email, password):
     url = server["url"]
     resp = httpx.post(
         f"{url}/api/v1/auth/login",
-        json={"email": email, "password": password},
+        json={"identifier": email, "password": password},
         timeout=10,
     )
     assert resp.status_code == 200, resp.text

--- a/src/klangk/klangkd-tests/e2e-tests/test_sighup_restart_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_sighup_restart_e2e.py
@@ -138,7 +138,7 @@ def auth(server):
     url = server["url"]
     resp = httpx.post(
         f"{url}/api/v1/auth/login",
-        json={"email": "test@example.com", "password": "testpass"},
+        json={"identifier": "test@example.com", "password": "testpass"},
         timeout=10,
     )
     assert resp.status_code == 200
@@ -404,7 +404,7 @@ def test_config_reload_via_sighup():
         # Login.
         resp = httpx.post(
             f"{base_url}/api/v1/auth/login",
-            json={"email": "test@example.com", "password": "testpass"},
+            json={"identifier": "test@example.com", "password": "testpass"},
             timeout=10,
         )
         assert resp.status_code == 200

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -116,7 +116,7 @@ async def client(app):
 async def _auth_headers(client):
     resp = await client.post(
         "/api/v1/auth/login",
-        json={"email": "testuser@example.com", "password": "testpass"},
+        json={"identifier": "testuser@example.com", "password": "testpass"},
     )
     token = resp.json()["access_token"]
     return {"Authorization": f"Bearer {token}"}
@@ -554,7 +554,10 @@ class TestAuthRoutes:
     async def test_register(self, client, admin_user):
         login_resp = await client.post(
             "/api/v1/auth/login",
-            json={"email": "testadmin@example.com", "password": "testpass"},
+            json={
+                "identifier": "testadmin@example.com",
+                "password": "testpass",
+            },
         )
         token = login_resp.json()["access_token"]
         with patch.object(
@@ -661,7 +664,10 @@ class TestAuthRoutes:
     async def test_register_duplicate(self, client, admin_user):
         login_resp = await client.post(
             "/api/v1/auth/login",
-            json={"email": "testadmin@example.com", "password": "testpass"},
+            json={
+                "identifier": "testadmin@example.com",
+                "password": "testpass",
+            },
         )
         token = login_resp.json()["access_token"]
         resp = await client.post(
@@ -686,7 +692,7 @@ class TestAuthRoutes:
         # User can now log in
         login_resp = await client.post(
             "/api/v1/auth/login",
-            json={"email": "unverified@example.com", "password": "pass"},
+            json={"identifier": "unverified@example.com", "password": "pass"},
         )
         assert login_resp.status_code == 200
 
@@ -702,7 +708,10 @@ class TestAuthRoutes:
     async def test_login(self, client, user):
         resp = await client.post(
             "/api/v1/auth/login",
-            json={"email": "testuser@example.com", "password": "testpass"},
+            json={
+                "identifier": "testuser@example.com",
+                "password": "testpass",
+            },
         )
         assert resp.status_code == 200
         assert "access_token" in resp.json()
@@ -710,7 +719,7 @@ class TestAuthRoutes:
     async def test_login_bad_password(self, client, user):
         resp = await client.post(
             "/api/v1/auth/login",
-            json={"email": "testuser@example.com", "password": "wrong"},
+            json={"identifier": "testuser@example.com", "password": "wrong"},
         )
         assert resp.status_code == 401
 
@@ -1158,7 +1167,7 @@ class TestResetPassword:
         resp2 = await client.post(
             "/api/v1/auth/login",
             json={
-                "email": "reset@example.com",
+                "identifier": "reset@example.com",
                 "password": "newpass1",
             },
         )
@@ -1208,7 +1217,7 @@ class TestChangePassword:
         resp2 = await client.post(
             "/api/v1/auth/login",
             json={
-                "email": "testuser@example.com",
+                "identifier": "testuser@example.com",
                 "password": "newpass1",
             },
         )
@@ -2287,7 +2296,7 @@ class TestWorkspaceSharingRoutes:
     async def _other_headers(self, client):
         resp = await client.post(
             "/api/v1/auth/login",
-            json={"email": "other@example.com", "password": "otherpass"},
+            json={"identifier": "other@example.com", "password": "otherpass"},
         )
         return {"Authorization": f"Bearer {resp.json()['access_token']}"}
 
@@ -3773,7 +3782,7 @@ class TestUserGroupEndpoints:
         """User without permission on the group gets 403."""
         # Admin creates a group (no ACE for regular user)
         admin_headers = {
-            "Authorization": f"Bearer {(await client.post('/api/v1/auth/login', json={'email': 'testadmin@example.com', 'password': 'testpass'})).json()['access_token']}"
+            "Authorization": f"Bearer {(await client.post('/api/v1/auth/login', json={'identifier': 'testadmin@example.com', 'password': 'testpass'})).json()['access_token']}"
         }
         resp = await client.post(
             "/api/v1/admin/groups",
@@ -4982,7 +4991,10 @@ class TestGroups:
     async def test_login_jwt_has_no_roles(self, client, user):
         resp = await client.post(
             "/api/v1/auth/login",
-            json={"email": "testuser@example.com", "password": "testpass"},
+            json={
+                "identifier": "testuser@example.com",
+                "password": "testpass",
+            },
         )
         assert resp.status_code == 200
         token = resp.json()["access_token"]
@@ -4997,7 +5009,10 @@ class TestAdminEndpoints:
     async def _admin_headers(self, client):
         resp = await client.post(
             "/api/v1/auth/login",
-            json={"email": "testadmin@example.com", "password": "testpass"},
+            json={
+                "identifier": "testadmin@example.com",
+                "password": "testpass",
+            },
         )
         return {"Authorization": f"Bearer {resp.json()['access_token']}"}
 
@@ -5141,7 +5156,10 @@ class TestAdminEndpoints:
     async def test_list_users_requires_admin(self, client, user):
         login_resp = await client.post(
             "/api/v1/auth/login",
-            json={"email": "testuser@example.com", "password": "testpass"},
+            json={
+                "identifier": "testuser@example.com",
+                "password": "testpass",
+            },
         )
         headers = {
             "Authorization": f"Bearer {login_resp.json()['access_token']}"
@@ -5162,7 +5180,10 @@ class TestAdminEndpoints:
         # User should be verified and able to log in
         login_resp = await client.post(
             "/api/v1/auth/login",
-            json={"email": "newuser@example.com", "password": "testpass123"},
+            json={
+                "identifier": "newuser@example.com",
+                "password": "testpass123",
+            },
         )
         assert login_resp.status_code == 200
 
@@ -5232,7 +5253,10 @@ class TestAdminEndpoints:
     async def test_admin_create_user_requires_admin(self, client, user):
         login_resp = await client.post(
             "/api/v1/auth/login",
-            json={"email": "testuser@example.com", "password": "testpass"},
+            json={
+                "identifier": "testuser@example.com",
+                "password": "testpass",
+            },
         )
         headers = {
             "Authorization": f"Bearer {login_resp.json()['access_token']}"
@@ -5308,7 +5332,10 @@ class TestAdminEndpoints:
         # Create a workspace for the user
         user_login = await client.post(
             "/api/v1/auth/login",
-            json={"email": "testuser@example.com", "password": "testpass"},
+            json={
+                "identifier": "testuser@example.com",
+                "password": "testpass",
+            },
         )
         user_headers = {
             "Authorization": f"Bearer {user_login.json()['access_token']}"
@@ -5349,7 +5376,10 @@ class TestAdminEndpoints:
         # Create a workspace as that user, then it should appear.
         user_login = await client.post(
             "/api/v1/auth/login",
-            json={"email": "testuser@example.com", "password": "testpass"},
+            json={
+                "identifier": "testuser@example.com",
+                "password": "testpass",
+            },
         )
         user_headers = {
             "Authorization": f"Bearer {user_login.json()['access_token']}"
@@ -5397,7 +5427,10 @@ class TestAdminEndpoints:
         # Verify can login with new password
         login_resp = await client.post(
             "/api/v1/auth/login",
-            json={"email": "testuser@example.com", "password": "newpass123"},
+            json={
+                "identifier": "testuser@example.com",
+                "password": "newpass123",
+            },
         )
         assert login_resp.status_code == 200
 
@@ -5472,7 +5505,10 @@ class TestAdminEndpoints:
     async def test_unlock_requires_admin(self, client, user):
         resp = await client.post(
             "/api/v1/auth/login",
-            json={"email": "testuser@example.com", "password": "testpass"},
+            json={
+                "identifier": "testuser@example.com",
+                "password": "testpass",
+            },
         )
         headers = {"Authorization": f"Bearer {resp.json()['access_token']}"}
         resp = await client.post(
@@ -5485,7 +5521,10 @@ class TestGroupEndpoints:
     async def _admin_headers(self, client):
         resp = await client.post(
             "/api/v1/auth/login",
-            json={"email": "testadmin@example.com", "password": "testpass"},
+            json={
+                "identifier": "testadmin@example.com",
+                "password": "testpass",
+            },
         )
         return {"Authorization": f"Bearer {resp.json()['access_token']}"}
 
@@ -5776,7 +5815,10 @@ class TestACLEndpoints:
     async def _admin_headers(self, client):
         resp = await client.post(
             "/api/v1/auth/login",
-            json={"email": "testadmin@example.com", "password": "testpass"},
+            json={
+                "identifier": "testadmin@example.com",
+                "password": "testpass",
+            },
         )
         return {"Authorization": f"Bearer {resp.json()['access_token']}"}
 
@@ -5866,7 +5908,10 @@ class TestAdminResourceACL:
     async def _admin_headers(self, client):
         resp = await client.post(
             "/api/v1/auth/login",
-            json={"email": "testadmin@example.com", "password": "testpass"},
+            json={
+                "identifier": "testadmin@example.com",
+                "password": "testpass",
+            },
         )
         return {"Authorization": f"Bearer {resp.json()['access_token']}"}
 
@@ -6397,14 +6442,20 @@ class TestWorkspaceExportImport:
     async def _admin_headers(self, client):
         resp = await client.post(
             "/api/v1/auth/login",
-            json={"email": "testadmin@example.com", "password": "testpass"},
+            json={
+                "identifier": "testadmin@example.com",
+                "password": "testpass",
+            },
         )
         return {"Authorization": f"Bearer {resp.json()['access_token']}"}
 
     async def _user_headers(self, client):
         resp = await client.post(
             "/api/v1/auth/login",
-            json={"email": "testuser@example.com", "password": "testpass"},
+            json={
+                "identifier": "testuser@example.com",
+                "password": "testpass",
+            },
         )
         return {"Authorization": f"Bearer {resp.json()['access_token']}"}
 
@@ -7504,7 +7555,10 @@ class TestInvitations:
     async def _admin_headers(self, client):
         resp = await client.post(
             "/api/v1/auth/login",
-            json={"email": "testadmin@example.com", "password": "testpass"},
+            json={
+                "identifier": "testadmin@example.com",
+                "password": "testpass",
+            },
         )
         return {"Authorization": f"Bearer {resp.json()['access_token']}"}
 
@@ -7586,7 +7640,10 @@ class TestInvitations:
     async def test_send_invitation_requires_admin(self, client, user):
         login_resp = await client.post(
             "/api/v1/auth/login",
-            json={"email": "testuser@example.com", "password": "testpass"},
+            json={
+                "identifier": "testuser@example.com",
+                "password": "testpass",
+            },
         )
         headers = {
             "Authorization": f"Bearer {login_resp.json()['access_token']}"
@@ -7934,7 +7991,10 @@ class TestInvitations:
         # User can log in
         login_resp = await client.post(
             "/api/v1/auth/login",
-            json={"email": "accept@example.com", "password": "newpassword"},
+            json={
+                "identifier": "accept@example.com",
+                "password": "newpassword",
+            },
         )
         assert login_resp.status_code == 200
 
@@ -8123,7 +8183,10 @@ class TestOIDCAuthModeGuards:
         )
         resp = await client.post(
             "/api/v1/auth/login",
-            json={"email": "testuser@example.com", "password": "testpass"},
+            json={
+                "identifier": "testuser@example.com",
+                "password": "testpass",
+            },
         )
         assert resp.status_code == 403
         assert "disabled" in resp.json()["detail"]
@@ -8148,7 +8211,10 @@ class TestOIDCAuthModeGuards:
         )
         resp = await client.post(
             "/api/v1/auth/login",
-            json={"email": "testuser@example.com", "password": "testpass"},
+            json={
+                "identifier": "testuser@example.com",
+                "password": "testpass",
+            },
         )
         assert resp.status_code == 200
 
@@ -8977,7 +9043,10 @@ class TestOIDCLogout:
         """Local user gets no oidc_logout_url."""
         login_resp = await client.post(
             "/api/v1/auth/login",
-            json={"email": "testuser@example.com", "password": "testpass"},
+            json={
+                "identifier": "testuser@example.com",
+                "password": "testpass",
+            },
         )
         headers = {
             "Authorization": f"Bearer {login_resp.json()['access_token']}"
@@ -9124,7 +9193,10 @@ class TestHandleEndpoints:
     ):
         admin_resp = await client.post(
             "/api/v1/auth/login",
-            json={"email": "testadmin@example.com", "password": "testpass"},
+            json={
+                "identifier": "testadmin@example.com",
+                "password": "testpass",
+            },
         )
         admin_headers = {
             "Authorization": f"Bearer {admin_resp.json()['access_token']}"
@@ -9143,7 +9215,10 @@ class TestHandleEndpoints:
     ):
         admin_resp = await client.post(
             "/api/v1/auth/login",
-            json={"email": "testadmin@example.com", "password": "testpass"},
+            json={
+                "identifier": "testadmin@example.com",
+                "password": "testpass",
+            },
         )
         admin_headers = {
             "Authorization": f"Bearer {admin_resp.json()['access_token']}"
@@ -9168,7 +9243,10 @@ class TestHandleEndpoints:
     ):
         admin_resp = await client.post(
             "/api/v1/auth/login",
-            json={"email": "testadmin@example.com", "password": "testpass"},
+            json={
+                "identifier": "testadmin@example.com",
+                "password": "testpass",
+            },
         )
         admin_headers = {
             "Authorization": f"Bearer {admin_resp.json()['access_token']}"

--- a/src/klangk/klangkd-tests/tests/test_auth.py
+++ b/src/klangk/klangkd-tests/tests/test_auth.py
@@ -234,6 +234,21 @@ class TestLogin:
         assert result.access_token
         assert result.token_type == "bearer"
 
+    async def test_login_success_by_handle(self, user):
+        """Login accepts a handle as well as an email (#616)."""
+        result = await _auth().login(
+            auth.LoginRequest(email=user["handle"], password="testpass")
+        )
+        assert result.access_token
+
+    async def test_login_wrong_password_by_handle(self, user):
+        """A bad password presented with a handle still 401s (#616)."""
+        with pytest.raises(HTTPException) as exc_info:
+            await _auth().login(
+                auth.LoginRequest(email=user["handle"], password="wrong")
+            )
+        assert exc_info.value.status_code == 401
+
     async def test_login_wrong_password(self, user):
         with pytest.raises(HTTPException) as exc_info:
             await _auth().login(
@@ -308,6 +323,33 @@ class TestLoginRateLimit:
             )
         )
         assert info["attempt_count"] == _auth().login_lockout_failures - 1
+
+    async def test_login_handle_attempts_rekeyed_to_email(
+        self, user, app_state
+    ):
+        """Failed attempts presented by *handle* are recorded against the
+        resolved user's canonical email, so handle and email attempts
+        share one lockout counter (#616)."""
+        handle = user["handle"]
+        for i in range(_auth().login_lockout_failures - 1):
+            with pytest.raises(HTTPException) as exc_info:
+                await _auth().login(
+                    auth.LoginRequest(email=handle, password="wrong")
+                )
+            assert exc_info.value.status_code == 401
+        # counter lives under the canonical email, not the raw handle
+        by_email = (
+            await app_state.state.model.login_attempts.get_login_attempt_info(
+                "testuser@example.com"
+            )
+        )
+        assert by_email["attempt_count"] == _auth().login_lockout_failures - 1
+        assert (
+            await app_state.state.model.login_attempts.get_login_attempt_info(
+                handle
+            )
+            is None
+        )
 
     async def test_login_lockout_after_max_attempts(self, user):
         """Locked out after LOGIN_LOCKOUT_FAILURES failed attempts."""

--- a/src/klangk/klangkd-tests/tests/test_auth.py
+++ b/src/klangk/klangkd-tests/tests/test_auth.py
@@ -228,7 +228,7 @@ class TestLogin:
     async def test_login_success(self, user):
         result = await _auth().login(
             auth.LoginRequest(
-                email="testuser@example.com", password="testpass"
+                identifier="testuser@example.com", password="testpass"
             )
         )
         assert result.access_token
@@ -237,7 +237,7 @@ class TestLogin:
     async def test_login_success_by_handle(self, user):
         """Login accepts a handle as well as an email (#616)."""
         result = await _auth().login(
-            auth.LoginRequest(email=user["handle"], password="testpass")
+            auth.LoginRequest(identifier=user["handle"], password="testpass")
         )
         assert result.access_token
 
@@ -245,7 +245,7 @@ class TestLogin:
         """A bad password presented with a handle still 401s (#616)."""
         with pytest.raises(HTTPException) as exc_info:
             await _auth().login(
-                auth.LoginRequest(email=user["handle"], password="wrong")
+                auth.LoginRequest(identifier=user["handle"], password="wrong")
             )
         assert exc_info.value.status_code == 401
 
@@ -253,7 +253,7 @@ class TestLogin:
         with pytest.raises(HTTPException) as exc_info:
             await _auth().login(
                 auth.LoginRequest(
-                    email="testuser@example.com", password="wrong"
+                    identifier="testuser@example.com", password="wrong"
                 )
             )
         assert exc_info.value.status_code == 401
@@ -267,7 +267,7 @@ class TestLogin:
         with pytest.raises(HTTPException) as exc_info:
             await _auth().login(
                 auth.LoginRequest(
-                    email="oidc@example.com", password="anything"
+                    identifier="oidc@example.com", password="anything"
                 )
             )
         assert exc_info.value.status_code == 401
@@ -283,7 +283,7 @@ class TestLogin:
         with pytest.raises(HTTPException) as exc_info:
             await _auth().login(
                 auth.LoginRequest(
-                    email="unverified@example.com", password="testpass"
+                    identifier="unverified@example.com", password="testpass"
                 )
             )
         assert exc_info.value.status_code == 403
@@ -292,7 +292,9 @@ class TestLogin:
     async def test_login_nonexistent_user(self, db):
         with pytest.raises(HTTPException) as exc_info:
             await _auth().login(
-                auth.LoginRequest(email="noone@example.com", password="pass")
+                auth.LoginRequest(
+                    identifier="noone@example.com", password="pass"
+                )
             )
         assert exc_info.value.status_code == 401
 
@@ -313,7 +315,7 @@ class TestLoginRateLimit:
             with pytest.raises(HTTPException) as exc_info:
                 await _auth().login(
                     auth.LoginRequest(
-                        email="testuser@example.com", password="wrong"
+                        identifier="testuser@example.com", password="wrong"
                     )
                 )
             assert exc_info.value.status_code == 401
@@ -334,7 +336,7 @@ class TestLoginRateLimit:
         for i in range(_auth().login_lockout_failures - 1):
             with pytest.raises(HTTPException) as exc_info:
                 await _auth().login(
-                    auth.LoginRequest(email=handle, password="wrong")
+                    auth.LoginRequest(identifier=handle, password="wrong")
                 )
             assert exc_info.value.status_code == 401
         # counter lives under the canonical email, not the raw handle
@@ -357,7 +359,7 @@ class TestLoginRateLimit:
             with pytest.raises(HTTPException) as exc_info:
                 await _auth().login(
                     auth.LoginRequest(
-                        email="testuser@example.com", password="wrong"
+                        identifier="testuser@example.com", password="wrong"
                     )
                 )
             if i < _auth().login_lockout_failures - 1:
@@ -367,7 +369,7 @@ class TestLoginRateLimit:
         with pytest.raises(HTTPException) as exc_info:
             await _auth().login(
                 auth.LoginRequest(
-                    email="testuser@example.com", password="wrong"
+                    identifier="testuser@example.com", password="wrong"
                 )
             )
         assert exc_info.value.status_code == 429
@@ -395,7 +397,7 @@ class TestLoginRateLimit:
         with pytest.raises(HTTPException) as exc_info:
             await _auth().login(
                 auth.LoginRequest(
-                    email="testuser@example.com", password="wrong"
+                    identifier="testuser@example.com", password="wrong"
                 )
             )
         assert exc_info.value.status_code == 401  # not 429
@@ -436,7 +438,7 @@ class TestLoginRateLimit:
         with pytest.raises(HTTPException) as exc_info:
             await _auth().login(
                 auth.LoginRequest(
-                    email="testuser@example.com", password="wrong"
+                    identifier="testuser@example.com", password="wrong"
                 )
             )
         assert exc_info.value.status_code == 429
@@ -453,7 +455,7 @@ class TestLoginRateLimit:
         )
         result = await _auth().login(
             auth.LoginRequest(
-                email="testuser@example.com", password="testpass"
+                identifier="testuser@example.com", password="testpass"
             )
         )
         assert result.access_token
@@ -470,7 +472,7 @@ class TestLoginRateLimit:
         with pytest.raises(HTTPException) as exc_info:
             await _auth().login(
                 auth.LoginRequest(
-                    email="testuser@example.com", password="testpass"
+                    identifier="testuser@example.com", password="testpass"
                 )
             )
         assert exc_info.value.status_code == 429
@@ -509,7 +511,7 @@ class TestLoginRateLimit:
             with pytest.raises(HTTPException) as exc_info:
                 await a.login(
                     auth.LoginRequest(
-                        email="testuser@example.com", password="wrong"
+                        identifier="testuser@example.com", password="wrong"
                     )
                 )
             assert exc_info.value.status_code == 401
@@ -520,7 +522,7 @@ class TestLoginRateLimit:
             with pytest.raises(HTTPException) as exc_info:
                 await _auth().login(
                     auth.LoginRequest(
-                        email="nobody@example.com", password="wrong"
+                        identifier="nobody@example.com", password="wrong"
                     )
                 )
             if i < _auth().login_lockout_failures - 1:
@@ -538,7 +540,7 @@ class TestLoginRateLimit:
         )
         result = await _auth().login(
             auth.LoginRequest(
-                email="testuser@example.com", password="testpass"
+                identifier="testuser@example.com", password="testpass"
             )
         )
         assert result.access_token

--- a/src/klangk/klangkd-tests/tests/test_mode_switching.py
+++ b/src/klangk/klangkd-tests/tests/test_mode_switching.py
@@ -185,7 +185,7 @@ class TestNoneToPasswordUpgrade:
         _password()
         resp = await client.post(
             "/api/v1/auth/login",
-            json={"email": DEFAULT_EMAIL, "password": NEW_PASSWORD},
+            json={"identifier": DEFAULT_EMAIL, "password": NEW_PASSWORD},
         )
         assert resp.status_code == 200
         assert resp.json()["token_type"] == "bearer"
@@ -209,7 +209,7 @@ class TestNoneToPasswordUpgrade:
 
         resp = await client.post(
             "/api/v1/auth/login",
-            json={"email": DEFAULT_EMAIL, "password": SEEDED_PASSWORD},
+            json={"identifier": DEFAULT_EMAIL, "password": SEEDED_PASSWORD},
         )
         assert resp.status_code == 401
 
@@ -271,7 +271,7 @@ class TestPasswordToNone:
         _password()
         resp = await client.post(
             "/api/v1/auth/login",
-            json={"email": DEFAULT_EMAIL, "password": SEEDED_PASSWORD},
+            json={"identifier": DEFAULT_EMAIL, "password": SEEDED_PASSWORD},
         )
         assert resp.status_code == 200
         token = resp.json()["access_token"]
@@ -306,7 +306,7 @@ class TestDataCarriesOver:
         _password()
         login = await client.post(
             "/api/v1/auth/login",
-            json={"email": DEFAULT_EMAIL, "password": SEEDED_PASSWORD},
+            json={"identifier": DEFAULT_EMAIL, "password": SEEDED_PASSWORD},
         )
         assert login.status_code == 200
         pw_me = (

--- a/src/klangk/klangkd-tests/tests/test_model_users.py
+++ b/src/klangk/klangkd-tests/tests/test_model_users.py
@@ -42,6 +42,26 @@ async def test_get_user_by_handle_and_handle(users):
     assert await users.get_user_handle("nope") is None
 
 
+async def test_get_user_by_identifier(users):
+    """get_user_by_identifier resolves by email (contains '@') or by
+    handle (no '@'), returning the full row incl. password_hash (#616)."""
+    u = await users.create_user("ident@x.com", "secret-hash", verified=True)
+    handle = u["handle"]
+    # email branch
+    by_email = await users.get_user_by_identifier("ident@x.com")
+    assert by_email["id"] == u["id"]
+    # handle branch — same full-row shape as get_user_by_email
+    by_handle = await users.get_user_by_identifier(handle)
+    assert by_handle["id"] == u["id"]
+    assert by_handle["email"] == "ident@x.com"
+    assert by_handle["password_hash"] == "secret-hash"
+    assert by_handle["handle"] == handle
+    assert by_handle["verified"] is True
+    # missing in each namespace
+    assert await users.get_user_by_identifier("nope@x.com") is None
+    assert await users.get_user_by_identifier("nope-handle") is None
+
+
 async def test_set_user_handle(users):
     u = await users.create_user("c@x.com", "hash")
     await users.set_user_handle(u["id"], "newhandle")
@@ -131,6 +151,19 @@ async def test_list_users_search_delete(users):
     assert any(f["id"] == u["id"] for f in found)
     assert await users.delete_user(u["id"]) is True
     assert await users.delete_user(u["id"]) is False
+
+
+async def test_search_users_matches_handle_prefix(users):
+    """search_users matches an email *or* handle prefix (#616)."""
+    u = await users.create_user("findme@x.com", "hash")
+    handle = u["handle"]
+    # full handle + its prefix both hit
+    assert any(f["id"] == u["id"] for f in await users.search_users(handle))
+    assert any(
+        f["id"] == u["id"] for f in await users.search_users(handle[:3])
+    )
+    # still matches an email prefix too
+    assert any(f["id"] == u["id"] for f in await users.search_users("findme@"))
 
 
 async def test_update_email_and_password(users):


### PR DESCRIPTION
## Summary

Fixes #616. The login identifier now accepts a **handle** as well as an email everywhere a user is identified — `POST /auth/login`, the `klangkd` web login page, and the `klangkc` commands `login`, `admin users set-password`, `share`, and `unshare`.

The wire field stays named `email` for client back-compat (frontend/CLI both already POST it); the backend just treats it as an identifier.

## Changes

**Backend** (`src/klangk/klangk/`)
- `model/users.py`: new `UsersModel.get_user_by_identifier(identifier)` — dispatches on whether the input contains `@` (email) or not (handle). The two namespaces are syntactically disjoint (handle charset is `[a-z0-9._-]`), so dispatch is unambiguous and always one indexed lookup. Returns the full row (incl. `password_hash`), mirroring `get_user_by_email`.
- `auth.py` `Auth.login()`: resolves via `get_user_by_identifier` and **re-keys brute-force lockout on the resolved user's canonical email** — so handle and email attempts against one account share a single counter (previously keyed on the raw input, which would under-count once handles were allowed). For an unresolved/nonexistent identifier, lockout falls back to the raw input so brute-force on a made-up address is still rate-limited.
- `model/users.py` `search_users`: `WHERE email LIKE ? OR handle LIKE ?` (was email-only).
- `api/workspaces.py`: the four user-identification endpoints (`POST /members`, `POST /roles/{role}`, `PATCH /roles`, transfer-ownership) resolve via `get_user_by_identifier` instead of `get_user_by_email`.

**Frontend** (`src/frontend/lib/auth/login_page.dart`)
- Field relabeled `Email` → `Email or handle` in login mode (register mode stays `Email`).
- Validator accepts an email **or** a handle in login mode; registration still requires a valid email (a deliverable address is needed for verification). The old `@`-required regex is gone for login.

**CLI** (`src/klangk/klangk/cli/`)
- `login` prompt + `admin users set-password` / `share` / `unshare` arg help updated to "Email or handle". `set-password`'s exact-match step now matches `handle` as well as `email`.
- `admin invitations send` stays **email-only** (invitations are delivered by email) — documented in its arg help.

## Design decisions (from the issue)
- **Disambiguation**: contains `@` → email, else → handle. Sound because handles can't contain `@`.
- **Lockout key**: resolved user's canonical email (not the raw input).
- **Registration**: stays email-only.

## Verification
- `klangkd-tests` + `klangkc-tests` combined (`-n auto`, shared `--cov-fail-under=100`): **3029 passed, 100% coverage**.
- Frontend `flutter test --coverage`: **905 passed**.
- `ruff format` + `ruff check`: clean.

## Tests added
- `test_model_users.py`: `get_user_by_identifier` (email + handle branches, full-row shape, missing-key); `search_users` handle-prefix match.
- `test_auth.py`: login success by handle; wrong-password-by-handle; lockout re-keying (handle attempts recorded under canonical email, raw handle key empty).
- `test_cli_main.py`: `admin users set-password` resolves a handle.
- `login_page_test.dart`: login mode accepts a handle; rejects an identifier that's neither; label is "Email or handle".

## Changelog
Added an entry under `## [Unreleased]` → `### Added`.
