### PR TITLE
Seed default admin exactly once, gated on admin-group emptiness (#1622)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -391,6 +391,25 @@ set-password <email>` (set a known password for the default user — whose
 
 ### Security
 
+- **Admin seeding is first-boot-only: config can no longer mint or
+  reset admins once an admin exists (#1622).** Previously
+  `seed_default_user` ran on every boot and created a fresh admin from
+  `KLANGK_DEFAULT_USER` / `KLANGK_DEFAULT_PASSWORD` whenever the configured
+  email didn't match an existing user — so anyone able to edit
+  `klangkd.conf` (or set the `KLANGK_DEFAULT_*` env vars) could mint or
+  reset an admin account by editing those values and restarting, bypassing
+  all auth and admin-invite flows. Seeding is now gated on **`admin`-group
+  emptiness**: an admin is created from `KLANGK_DEFAULT_*` only when the
+  `admin` group has no members (first boot, or after every admin has been
+  deleted); once at least one admin exists, startup never creates, renames,
+  re-emails, or re-passwords a user regardless of `KLANGK_DEFAULT_*`. This
+  also prevents lockout: editing `KLANGK_DEFAULT_USER` and restarting can
+  no longer clobber the already-seeded admin's identity. To change the
+  admin after first boot, use the normal in-app / `klangkc admin` paths.
+  Deployers should still treat `klangkd.conf` as sensitive (first-boot
+  password, LLM keys, JWT secret), but it is no longer a standing
+  admin-minting credential.
+
 - **nginx now denies container source IPs by default on the catch-all
   `location /`** (#1376). Previously the catch-all was open to container
   source IPs (the host's own IP via pasta NAT), so safety relied on every

--- a/docs/features/auth-modes.md
+++ b/docs/features/auth-modes.md
@@ -191,6 +191,7 @@ OIDC identity on their **first SSO login**, keyed on the identity's `sub` and
 email. If the default user's seeded email doesn't match a real SSO account,
 that first SSO login creates a _new_ user row and the default user's solo-mode
 data stays under the old email. To avoid orphaning data, set
-`KLANGK_DEFAULT_USER` to your SSO email **before** the first seed, or assign
+`KLANGK_DEFAULT_USER` to your SSO email **before the first boot** (it's
+read only on first seed — editing it later has no effect, #1622), or assign
 the default user's workspaces to the SSO identity via the admin API after
 linking.

--- a/src/klangk/klangk/main.py
+++ b/src/klangk/klangk/main.py
@@ -177,52 +177,65 @@ class Lifecycle:
         return group["id"]
 
     async def seed_default_user(self) -> None:
-        """Create default user if it doesn't exist.
+        """Seed the default admin user exactly once, gated on admin-group
+        emptiness (#1622).
 
-        If KLANGK_DEFAULT_PASSWORD is set, use it. Otherwise generate a
-        random password and print it to the console (only on first
-        creation).
+        Creates the admin from ``KLANGK_DEFAULT_USER`` / ``KLANGK_DEFAULT_PASSWORD``
+        **only when the ``admin`` group has no members** (first boot on a fresh
+        install, or after every admin has been deleted). Once at least one admin
+        exists, this method **never** creates, renames, re-emails, or
+        re-passwords a user: ``KLANGK_DEFAULT_*`` is ignored, so editing it in
+        ``klangkd.conf`` and restarting cannot mint a new admin (the
+        config-mints-admin security hole) or clobber the existing admin's
+        identity (lockout). Changing the admin after the first boot is done
+        via the normal in-app / ``klangkc admin`` paths.
+
+        If ``KLANGK_DEFAULT_PASSWORD`` is set, use it; otherwise generate a
+        random password and print it to stderr (only on the seeding boot).
         """
         settings = self.app.state.settings
         admin_group_id = await self.ensure_admin_group()
         await self.seed_default_acls(admin_group_id)
 
+        # Once an admin exists, startup must not touch users (#1622). The
+        # gate is group membership, not a row id: "admin" is a group, and a
+        # deployer can promote more than one admin, so keying on a fixed
+        # seeded-admin id would be the wrong concept. Emptying the admin
+        # group + restart re-seeds (delete-resurrection at the group level).
+        members = await self.app.state.model.users.get_group_members(
+            admin_group_id
+        )
+        if members:
+            return
+
         email = settings.default_user
         password = settings.default_password
-        existing = await self.app.state.model.users.get_user_by_email(email)
-        if existing is None:
-            generated = password is None
-            if generated:
-                password = secrets.token_urlsafe(16)
-            password_hash = bcrypt.hashpw(
-                password.encode(), bcrypt.gensalt()
-            ).decode()
-            user = await self.app.state.model.users.create_user(
-                email, password_hash, verified=True
+        generated = password is None
+        if generated:
+            password = secrets.token_urlsafe(16)
+        password_hash = bcrypt.hashpw(
+            password.encode(), bcrypt.gensalt()
+        ).decode()
+        user = await self.app.state.model.users.create_user(
+            email, password_hash, verified=True
+        )
+        await self.app.state.model.users.add_user_to_group(
+            user["id"], admin_group_id
+        )
+        if generated:
+            logger.info(
+                "Created default admin user '%s' (password printed to stderr)",
+                email,
             )
-            await self.app.state.model.users.add_user_to_group(
-                user["id"], admin_group_id
+            # Print password to stderr only — keep it out of structured
+            # logs where it could be shipped to a log aggregator.
+            print(
+                f"{_GREEN}Default admin password for"
+                f" '{email}': {password}{_RESET}",
+                file=sys.stderr,
             )
-            if generated:
-                logger.info(
-                    "Created default admin user '%s'"
-                    " (password printed to stderr)",
-                    email,
-                )
-                # Print password to stderr only — keep it out of structured
-                # logs where it could be shipped to a log aggregator.
-                print(
-                    f"{_GREEN}Default admin password for"
-                    f" '{email}': {password}{_RESET}",
-                    file=sys.stderr,
-                )
-            else:
-                logger.info("Created default user '%s' in admin group", email)
         else:
-            # Ensure existing default user is in admin group
-            await self.app.state.model.users.add_user_to_group(
-                existing["id"], admin_group_id
-            )
+            logger.info("Created default user '%s' in admin group", email)
 
     async def seed_agent_user(self) -> None:
         """Ensure the chat agent user exists in the DB.

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -163,6 +163,183 @@ class TestSeedDefaultUser:
         assert "Default admin password for" in captured.err
 
 
+class TestSeedDefaultUserGating:
+    """#1622: seed exactly once, gated on admin-group emptiness.
+
+    Once the ``admin`` group has ≥1 member, ``seed_default_user`` must not
+    create a new admin or modify any existing user, no matter what
+    ``KLANGK_DEFAULT_*`` says — closes the config-mints-admin hole and
+    prevents lockout.
+    """
+
+    async def test_does_not_create_when_admin_group_has_member(
+        self, db, app_state
+    ):
+        """Legacy/post-first-boot install: an admin already exists → seed is
+        a no-op on users, regardless of KLANGK_DEFAULT_USER."""
+        # Seed once to populate the admin group.
+        await _lifecycle(
+            make_settings(
+                {
+                    "KLANGK_DEFAULT_USER": "first@example.com",
+                    "KLANGK_DEFAULT_PASSWORD": "first-pass",
+                }
+            )
+        ).seed_default_user()
+        original = await app_state.state.model.users.get_user_by_email(
+            "first@example.com"
+        )
+        assert original is not None
+
+        # Now change KLANGK_DEFAULT_USER and re-seed → must NOT create a
+        # second admin from the new config.
+        await _lifecycle(
+            make_settings(
+                {
+                    "KLANGK_DEFAULT_USER": "second@example.com",
+                    "KLANGK_DEFAULT_PASSWORD": "second-pass",
+                }
+            )
+        ).seed_default_user()
+        assert (
+            await app_state.state.model.users.get_user_by_email(
+                "second@example.com"
+            )
+            is None
+        )
+        # Original admin untouched.
+        assert (
+            await app_state.state.model.users.get_user_by_email(
+                "first@example.com"
+            )
+        )["id"] == original["id"]
+
+    async def test_does_not_modify_existing_admin_when_config_changes(
+        self, db, app_state
+    ):
+        """Changing KLANGK_DEFAULT_* after first boot cannot clobber the
+        existing admin's email/password (no lockout)."""
+        await _lifecycle(
+            make_settings(
+                {
+                    "KLANGK_DEFAULT_USER": "keep@example.com",
+                    "KLANGK_DEFAULT_PASSWORD": "original-pass",
+                }
+            )
+        ).seed_default_user()
+        admin = await app_state.state.model.users.get_user_by_email(
+            "keep@example.com"
+        )
+        assert admin is not None
+        original_hash = admin["password_hash"]
+
+        # Re-seed with a different email/password in config.
+        await _lifecycle(
+            make_settings(
+                {
+                    "KLANGK_DEFAULT_USER": "changed@example.com",
+                    "KLANGK_DEFAULT_PASSWORD": "changed-pass",
+                }
+            )
+        ).seed_default_user()
+
+        admin_after = await app_state.state.model.users.get_user_by_email(
+            "keep@example.com"
+        )
+        assert admin_after is not None
+        # Email, id, and password hash all unchanged.
+        assert admin_after["id"] == admin["id"]
+        assert admin_after["email"] == "keep@example.com"
+        assert admin_after["password_hash"] == original_hash
+
+    async def test_reseeds_after_admin_group_emptied(self, db, app_state):
+        """Delete-resurrection at the group level: deleting the admin user
+        account (which cascades their group membership) + restart re-seeds
+        from KLANGK_DEFAULT_* (the gate is group membership, not a tombstone).
+        The operator "reset to seeded config" flow is deleting the admin
+        account, not demoting it."""
+        await _lifecycle(
+            make_settings(
+                {
+                    "KLANGK_DEFAULT_USER": "resurrect@example.com",
+                    "KLANGK_DEFAULT_PASSWORD": "resurrect-pass",
+                }
+            )
+        ).seed_default_user()
+        admin = await app_state.state.model.users.get_user_by_email(
+            "resurrect@example.com"
+        )
+        admin_group = await app_state.state.model.users.get_group_by_name(
+            "admin"
+        )
+        assert admin is not None and admin_group is not None
+
+        # Delete the admin user account → CASCADE empties the admin group
+        # → next seed re-creates from config (the email is gone too, so no
+        # UNIQUE collision).
+        await app_state.state.model.users.delete_user(admin["id"])
+        assert (
+            await app_state.state.model.users.get_group_members(
+                admin_group["id"]
+            )
+            == []
+        )
+        await _lifecycle(
+            make_settings(
+                {
+                    "KLANGK_DEFAULT_USER": "resurrect@example.com",
+                    "KLANGK_DEFAULT_PASSWORD": "resurrect-pass",
+                }
+            )
+        ).seed_default_user()
+
+        # A member is back in the admin group.
+        members = await app_state.state.model.users.get_group_members(
+            admin_group["id"]
+        )
+        assert len(members) == 1
+
+    async def test_seed_creates_admin_on_truly_fresh_db(self, db, app_state):
+        """Fresh install (empty admin group) → seed creates, mirroring
+        pre-#1622 first-boot behavior."""
+        admin_group = await app_state.state.model.users.get_group_by_name(
+            "admin"
+        )
+        # admin group may not exist yet; ensure it then assert empty.
+        if admin_group is None:
+            admin_group = await app_state.state.model.users.create_group(
+                "admin", description="Administrators"
+            )
+        assert (
+            await app_state.state.model.users.get_group_members(
+                admin_group["id"]
+            )
+            == []
+        )
+        await _lifecycle(
+            make_settings(
+                {
+                    "KLANGK_DEFAULT_USER": "fresh@example.com",
+                    "KLANGK_DEFAULT_PASSWORD": "fresh-pass",
+                }
+            )
+        ).seed_default_user()
+        assert (
+            await app_state.state.model.users.get_user_by_email(
+                "fresh@example.com"
+            )
+            is not None
+        )
+        assert (
+            len(
+                await app_state.state.model.users.get_group_members(
+                    admin_group["id"]
+                )
+            )
+            == 1
+        )
+
+
 # --- no-auth bind safety gate (#1374) ---
 
 


### PR DESCRIPTION
## Summary

Seeds the default admin user **exactly once**, gated on **admin-group emptiness**. Once an admin exists, startup never creates, renames, re-emails, or re-passwords a user — no matter what `Klangk.conf` / the `KLANGK_DEFAULT_*` env vars say. `KLANGK_DEFAULT_USER` / `KLANGK_DEFAULT_PASSWORD` become first-boot-only (where "first boot" = the boot on which the `admin` group is empty).

Closes #1622.

## What changed

`seed_default_user` (`main.py:184`) previously ran on every boot and **created a fresh admin** from `KLANGK_DEFAULT_*` whenever the configured email didn't match an existing user. It now gates user creation on **`admin`-group emptiness**:

- **`admin` group empty → seed once:** create the admin from `KLANGK_DEFAULT_*` (random id, same as today). This is the **only** time `KLANGK_DEFAULT_*` is read.
- **`admin` group has ≥1 member → do nothing** to users: no second admin, no modification of the existing admin's email/handle/password, `KLANGK_DEFAULT_*` ignored.

The other boot steps it owns stay idempotent and unchanged (`ensure_admin_group`, `seed_default_acls`).

## Why

1. **Closes the config-mints-admin security hole.** Previously, anyone with write access to `klangkd.conf` (or the `KLANGK_DEFAULT_*` env) could mint or reset an admin at boot, bypassing all auth and admin-invite flows. The config file was implicitly root-equivalent. Now `KLANGK_DEFAULT_*`'s privileged power is confined to the window before an admin exists.
2. **Prevents lockout.** Editing `KLANGK_DEFAULT_USER` and restarting can no longer clobber the already-seeded admin's identity.

## Delete-resurrection (resolved for free)

At the group level — no tombstone needed. Deleting the admin user account (`delete_user`, which cascades the membership via `ON DELETE CASCADE`) + restart → empty group → re-seeds from `KLANGK_DEFAULT_*`. Keep ≥1 admin → nothing. Identical on fresh and legacy installs.

## What this does *not* do (by design)

- **No fixed/known admin user id.** The earlier draft of #1622 proposed a `DEFAULT_USER_ID` mirroring `AGENT_USER_ID`; it was dropped because the admin is a **group** membership (not a singleton like the agent), so a famous id on one row conflates "the seed identity" with "admin identity" and only ever attaches to fresh installs anyway. See the "Why no fixed id" section in #1622.
- **No data migration.** The gate is satisfiable on every existing install: legacy installs already have an admin member → the gate is closed on the first post-upgrade boot → they just stop being subject to config-driven minting. No PK rewrite, no FK chase, no `adopt` command.

## Tests

- New `TestSeedDefaultUserGating` in `test_main.py` covers:
  - does not create a second admin when the `admin` group has a member (config change ignored)
  - does not modify the existing admin's email/id/password-hash when `KLANGK_DEFAULT_*` changes (no lockout)
  - delete-resurrection: deleting the admin user + re-seed repopulates the group
  - fresh-DB seeding still works (empty group → create + add to admin group)
- The existing `TestSeedDefaultUser` tests (create-when-missing, skip-on-existing, generated-password, stderr-print) remain green — they're consistent with the gated behavior on a fresh DB.

## Docs

- `docs/features/auth-modes.md`: the "seeded default user" bullet and the OIDC caveat now call out that `KLANGK_DEFAULT_*` is read only on first seed (editing later has no effect).
- `docs/changes.md`: new `### Security` entry.

## Acceptance (from #1622)

- [x] `seed_default_user` gates user creation on `admin`-group emptiness.
- [x] On a non-empty `admin` group, does not read `KLANGK_DEFAULT_*` or modify any existing user (verified by test).
- [x] First-boot seed still uses `KLANGK_DEFAULT_*` + random id, adds to `admin` group.
- [x] Non-seeded user creation unchanged (random ids).
- [x] Delete-resurrection decided (row-existence at group level) + implemented + documented.
- [x] Existing seed tests updated; **100% coverage** (3027 passed, CI-style with `-n auto`).
- [x] Documentation updated (auth-modes.md + changelog).
- [x] Changelog entry (security posture change).
