### PR TITLE
Rename klangkc CLI script to klangk (#1615)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,7 +91,7 @@ not process-compose. Consequences when debugging a managed stack:
 
 ## CLI subpackage isolation (`klangk.cli`)
 
-Code in `src/klangk/klangk/cli/` (the `klangkc` client) must **not** import
+Code in `src/klangk/klangk/cli/` (the `klangk` client) must **not** import
 anything from the rest of the `klangk` package — only stdlib, third-party
 deps, and sibling modules within `cli/` itself (`from .config import ...`,
 `from .transport import ...`). The CLI is a standalone client that ships in

--- a/devenv.nix
+++ b/devenv.nix
@@ -271,7 +271,7 @@ in
       -v -n auto --no-cov "$@"
   '';
 
-  # CLI E2E tests: start real server, run klangkc commands.
+  # CLI E2E tests: start real server, run klangk commands.
   # Ports are free-allocated (#1393), so xdist is no longer forcibly
   # disabled. The suite runs serially by default (no -n) because the
   # tests spawn real podman containers and within-suite parallelism is

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -29,7 +29,7 @@ $KLANGK_DATA_DIR/workspaces/<user-id>/home/<workspace-id>/
 
 ## Components
 
-- **Package** (`src/klangk/`): one Python distribution shipping two top-level packages — the `klangkd` server (FastAPI, single-port: API, WebSocket, frontend static files) and the `klangkc` client (`klangkc` command, typer-based, talks to the server over HTTP + WebSocket for terminal access to containers). One `pip install klangk` yields both binaries (#1606).
+- **Package** (`src/klangk/`): one Python distribution shipping two top-level packages — the `klangkd` server (FastAPI, single-port: API, WebSocket, frontend static files) and the `klangk` client (`klangk` command, typer-based, talks to the server over HTTP + WebSocket for terminal access to containers). One `pip install klangk` yields both binaries (#1606).
 - **Frontend** (`src/frontend/`): Flutter Web — chat (markdown rendering, syntax-highlighted code blocks, @mentions, message types, pagination, history recall), file viewer, debug panel, workspace presence
 - **Containers** (`src/containers/`): Custom Dockerfile for Pi agent containers with Python3, Node.js, build-essential, SQLite, vim, emacs, network tools, Pi extensions (built and run via podman)
 

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -105,7 +105,7 @@ operators or integrators to act when upgrading.
   `<KLANGK_STATE_DIR>/plugins` when unset; an explicit value always wins
   (#1461, #1506). `klangkd` no longer mutates `os.environ` to inject a
   `state_dir` default; the field enforces its own requirement (#1459).
-- **CLI transport resolver:** `klangkc --server` now accepts a Unix socket
+- **CLI transport resolver:** `klangk --server` now accepts a Unix socket
   path (e.g. `/tmp/klangk.sock`) in addition to `http(s)://` URLs. All HTTP
   and WebSocket connections route through a single transport resolver that
   picks UDS or TCP based on the server spec (#1399).
@@ -118,7 +118,7 @@ operators or integrators to act when upgrading.
   bind without `KLANGK_ALLOW_INSECURE_NO_AUTH` — socket file permissions
   (0700 parent dir) provide the same trust boundary as loopback (#1399).
 - **Direct UDS login:** `client_is_loopback` treats direct UDS connections
-  (no nginx proxy) as loopback, so `klangkc login /path/to/sock` works in
+  (no nginx proxy) as loopback, so `klangk login /path/to/sock` works in
   no-auth mode (#1399).
 - **Per-test timeout for the Python test suites** — both backend and CLI
   suites now run with `pytest-timeout` (`--timeout=60`). A hanging test
@@ -135,6 +135,13 @@ operators or integrators to act when upgrading.
   set (#1558).
 
 ### Changed
+
+- **CLI command renamed `klangkc` → `klangk` (#1615).** One `pip install
+klangk` now yields `klangk` (client) and `klangkd` (server), matching the
+  unified distribution name. The `klangkc` entrypoint is removed; the Typer
+  app name, all help/error text, docs, demo scripts, and backend comment
+  references are updated to the new name. The Python module (`klangk.cli`)
+  and the `klangkc-tests` test directory are unchanged.
 
 - **`frontend_dir` default moved in-package (#1600).** The default changed
   from the repo-relative `src/frontend/build/web` (which only worked under an
@@ -276,25 +283,25 @@ operators or integrators to act when upgrading.
   nginx per-location `allow 127.0.0.1/::1; deny all` ACL keep `/auth/local`
   unreachable from workspace containers, and the server refuses to start in
   `none` mode on a non-loopback bind unless `KLANGK_ALLOW_INSECURE_NO_AUTH=1`
-  is set. The CLI (`klangkc`) auto-logs in on first command run with no prior
-  `klangkc login`; the server's auth mode is probed live (not cached) so a
+  is set. The CLI (`klangk`) auto-logs in on first command run with no prior
+  `klangk login`; the server's auth mode is probed live (not cached) so a
   mode switch takes effect immediately. See [Auth Modes](features/auth-modes.md)
   for the full mode-switching guide.
-- **`klangkc admin` command group** (#1374): site-wide administration now
+- **`klangk admin` command group** (#1374): site-wide administration now
   has a dedicated CLI surface — `admin users ls`, `admin users
 set-password <email>` (set a known password for the default user — whose
   password is random unless `KLANGK_DEFAULT_PASSWORD` was set — before
   flipping `none` -> `password`), and `admin invitations send/ls`. The
   top-level `invite`/`invitations` commands moved under `admin invitations`.
-- **`klangkc status`** now reports your user id and admin status (derived
+- **`klangk status`** now reports your user id and admin status (derived
   from `/my-permissions`).
 
 ### Breaking
 
-- **One `klangk` distribution ships the renamed server package `klangkd` and the folded-in client `klangkc` (#1606).** The backend package is renamed `klangk_backend` → `klangkd` and the standalone `klangkc` distribution is retired — the client is promoted to a sibling top-level package under the same source root. One `pip install klangk` yields both `klangkd` (server) and `klangkc` (client); the entrypoint command names are unchanged. The distribution name (`klangk`) is distinct from the import packages (`klangkd` / `klangkc`), like `python-dateutil` → `dateutil`.
+- **One `klangk` distribution ships the renamed server package `klangkd` and the folded-in client `klangk` (#1606).** The backend package is renamed `klangk_backend` → `klangkd` and the standalone `klangkc` distribution is retired — the client is promoted to a sibling top-level package under the same source root. One `pip install klangk` yields both `klangkd` (server) and `klangk` (client); the entrypoint command names are unchanged. The distribution name (`klangk`) is distinct from the import packages (`klangkd` / `klangk`), like `python-dateutil` → `dateutil`.
   - **Integrators** who `import klangk_backend` (e.g. OIDC login hooks) must update to `import klangkd`.
   - **The `klangkc` PyPI distribution is retired** in favor of `klangk`; the `cli-v*` tag line and `cli-publish.yml` workflow are removed. Both binaries release together off the single `v*` tag line.
-  - **Test layout**: tests are split into per-package suites — `src/klangk/klangkd-tests/{tests,e2e-tests}` (server) and `src/klangk/klangkc-tests/{tests,e2e-tests}` (client) — as hyphenated siblings of the package dirs so they don't ship in the wheel. Both unit suites share one `--cov=klangkd --cov=klangkc` 100% gate (run together via `test-backend`).
+  - **Test layout**: tests are split into per-package suites — `src/klangk/klangkd-tests/{tests,e2e-tests}` (server) and `src/klangk/klangkc-tests/{tests,e2e-tests}` (client) — as hyphenated siblings of the package dirs so they don't ship in the wheel. Both unit suites share one `--cov=klangkd --cov=klangk` 100% gate (run together via `test-backend`).
 
 - **The listen/port settings model is restructured** (#1542):
   - `KLANGK_NGINX_PORT` → rename to `KLANGK_EGRESS_PORT` (deprecated alias
@@ -351,10 +358,10 @@ set-password <email>` (set a known password for the default user — whose
   bypassing nginx — must set `KLANGK_LISTEN=0.0.0.0` to restore the old
   behavior. Applies to both the devenv dev server and the host container.
   (#1375)
-- **`klangkc invite` moved under the `admin` group** (#1374). The top-level
-  `klangkc invite <email>` command is gone, with no backward-compat alias.
-  Use `klangkc admin invitations send <email>` (and list with
-  `klangkc admin invitations ls`). Site-wide administration — users and
+- **`klangk invite` moved under the `admin` group** (#1374). The top-level
+  `klangk invite <email>` command is gone, with no backward-compat alias.
+  Use `klangk admin invitations send <email>` (and list with
+  `klangk admin invitations ls`). Site-wide administration — users and
   invitations — now has a dedicated `admin` CLI surface matching the
   `terminal`/`volumes` noun-subgroup convention.
 - **`klangkd` binds a UDS; `scripts/nginx.sh` retired** (#1396). uvicorn now

--- a/docs/deployment/signals.md
+++ b/docs/deployment/signals.md
@@ -45,7 +45,7 @@ nginx/Postgres convention):
    automatically by the live CORS middleware; `KLANGK_FRONTEND_DIR` is
    remounted if it changed (#1610).
 3. **Close every WebSocket client** with close code `1012` ("service
-   restarted"). Both the web UI and `klangkc monitor` reconnect
+   restarted"). Both the web UI and `klangk monitor` reconnect
    automatically with backoff and rebuild their state on reconnect.
 4. Tear down chat-agent subprocesses and cancel in-flight agent runs.
 5. **Stop and remove all workspace containers** and cancel the

--- a/docs/development/ci.md
+++ b/docs/development/ci.md
@@ -17,7 +17,7 @@ triggering.
 
 Unit tests (Python, frontend) run with `pip install` or `flutter test`
 and do not require devenv. The Python suite covers both the `klangkd`
-(server) and `klangkc` (client) packages from one `pip install -e src/klangk`;
+(server) and `klangk` (client) packages from one `pip install -e src/klangk`;
 E2E tests use `devenv shell` with the full environment (podman, workspace
 image, nginx).
 
@@ -36,8 +36,8 @@ image, nginx).
 
 ## Release and publishing
 
-| Workflow                | File              | Trigger           | Description                       |
-| ----------------------- | ----------------- | ----------------- | --------------------------------- |
-| **Release**             | `release.yml`     | Manual            | Build and publish host container  |
-| **Publish CLI to PyPI** | `cli-publish.yml` | Push `cli-v*` tag | Build and publish klangkc to PyPI |
-| **Deploy Docs**         | `docs.yml`        | Manual            | Deploy docs to GitHub Pages       |
+| Workflow                | File              | Trigger           | Description                      |
+| ----------------------- | ----------------- | ----------------- | -------------------------------- |
+| **Release**             | `release.yml`     | Manual            | Build and publish host container |
+| **Publish CLI to PyPI** | `cli-publish.yml` | Push `cli-v*` tag | Build and publish klangk to PyPI |
+| **Deploy Docs**         | `docs.yml`        | Manual            | Deploy docs to GitHub Pages      |

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -15,7 +15,7 @@ test-frontend
 # Backend E2E tests (starts real server + podman containers)
 test-backend-e2e
 
-# CLI E2E tests (starts real server, runs klangkc commands)
+# CLI E2E tests (starts real server, runs klangk commands)
 test-cli-e2e
 
 # Frontend E2E tests (Playwright, needs flutter build + podman build)

--- a/docs/features/auth-modes.md
+++ b/docs/features/auth-modes.md
@@ -59,10 +59,10 @@ required from the caller:
 
 - The **frontend** calls `POST /api/v1/auth/local` on load and stores the
   token, skipping the login form entirely.
-- The **CLI** (`klangkc`) probes the server's auth mode on each
+- The **CLI** (`klangk`) probes the server's auth mode on each
   command (via `GET /config`) and auto-calls `/auth/local` when it's `none`,
-  so no `klangkc login` is ever needed — the first command after registering
-  the server with `klangkc login <server>` just works (and re-registration
+  so no `klangk login` is ever needed — the first command after registering
+  the server with `klangk login <server>` just works (and re-registration
   isn't: a saved token that 401s triggers the same auto-login fallback).
 - **Workspace terminals** (WebSocket) flow the token through the existing
   `?token=` path unchanged.
@@ -147,23 +147,23 @@ admin token:
 ```bash
 # 1. Still in none mode — you're auto-logged-in as the admin default user.
 #    Give that user a real password via the admin endpoint:
-klangkc admin users set-password admin@example.com
+klangk admin users set-password admin@example.com
 
 # 2. (Optional) invite teammates while you're still admin-with-token:
-klangkc admin invitations send teammate@example.com
+klangk admin invitations send teammate@example.com
 
 # 3. Flip the mode and restart the substrate:
 #    (set KLANGK_AUTH_MODES=password in your substrate env, then restart)
 
 # 4. Log in for real — you and your invitees now use the login form / CLI:
-klangkc login
+klangk login
 ```
 
-`klangkc admin users set-password` resolves the email to a user id and
+`klangk admin users set-password` resolves the email to a user id and
 `PATCH`es the password (admin-gated). Run it **while still in `none` mode**,
 when you're holding the free admin token — after the flip, the old free token
 still authorizes until it expires, but it's simplest to do the password set
-first. Confirm you're the admin with `klangkc status` (it reports
+first. Confirm you're the admin with `klangk status` (it reports
 `admin: yes`).
 
 ### `password` / `oidc` / `both` -> `none` (dropping back to solo)

--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -53,7 +53,7 @@ Users are created automatically on their first SSO login — no
 separate registration step. If a user already has an email/password
 account with the same address, it is linked to their SSO identity.
 
-The CLI (`klangkc login`) supports OIDC too: it opens a browser for
+The CLI (`klangk login`) supports OIDC too: it opens a browser for
 the SSO flow and receives the token via a temporary localhost callback.
 
 See [OIDC Configuration](../reference/oidc.md) for setup instructions.

--- a/docs/features/auto-start.md
+++ b/docs/features/auto-start.md
@@ -33,13 +33,13 @@ Enable auto-start from the workspace **Settings** tab.
 
 ```bash
 # Enable during creation
-klangkc create my-service --auto-start
+klangk create my-service --auto-start
 
 # Enable on an existing workspace
-klangkc edit my-service --auto-start
+klangk edit my-service --auto-start
 
 # Disable
-klangkc edit my-service --no-auto-start
+klangk edit my-service --no-auto-start
 ```
 
 ### Sandbox config
@@ -62,7 +62,7 @@ workspace's `service-cmd` terminal window — so the service is already
 running by the time any user connects. Auto-started containers are
 pinned alive (they do not idle out between connections).
 
-Users connect later with `klangkc shell` and see the service output in
+Users connect later with `klangk shell` and see the service output in
 the `service-cmd` tab. They can open another tab for a shell alongside
 the running service.
 
@@ -84,7 +84,7 @@ This gives you:
 1. Server starts → container starts → `openclaw gateway` runs
 2. Health check confirms the gateway is responding — see
    [Health Check](health-check.md)
-3. User runs `klangkc shell my-service` → sees gateway output
-4. User runs `klangkc shell my-service shell` → gets a bash prompt
+3. User runs `klangk shell my-service` → sees gateway output
+4. User runs `klangk shell my-service shell` → gets a bash prompt
    in a separate tmux window
 5. Ctrl+C in the gateway window stops it; up-arrow + Enter restarts

--- a/docs/features/export-import.md
+++ b/docs/features/export-import.md
@@ -7,11 +7,11 @@ Workspaces can be exported as `.tar.gz` archives and imported to create new work
 
 ## Export
 
-Export is admin-only. `klangkc export <workspace>` downloads the archive via `GET /api/v1/workspaces/{id}/export`. The tarball is built on the server using a temp file to avoid memory pressure on large workspaces.
+Export is admin-only. `klangk export <workspace>` downloads the archive via `GET /api/v1/workspaces/{id}/export`. The tarball is built on the server using a temp file to avoid memory pressure on large workspaces.
 
 ## Import
 
-`klangkc import <archive>` uploads the archive via `POST /api/v1/workspaces/import`. The server streams the upload to a temp file, extracts metadata, creates the workspace, and extracts the home directory. Invalid images or mounts from the archive are silently dropped. Use `--name` to override the workspace name from the archive.
+`klangk import <archive>` uploads the archive via `POST /api/v1/workspaces/import`. The server streams the upload to a temp file, extracts metadata, creates the workspace, and extracts the home directory. Invalid images or mounts from the archive are silently dropped. Use `--name` to override the workspace name from the archive.
 
 > **Same-instance only:** Archives include the exporting instance's unique ID. Import rejects archives that are missing an instance ID or whose instance ID does not match the importing server. This prevents foreign workspace imports from planting home directory symlinks that reference user IDs that don't exist on the destination instance.
 

--- a/docs/features/health-check.md
+++ b/docs/features/health-check.md
@@ -49,7 +49,7 @@ For each workspace with a health check configured:
    client that connects to an _already_-unhealthy workspace also
    receives a one-time **snapshot** of every health-checked
    workspace's current status immediately on connect -- so a pure-WS
-   consumer like `klangkc monitor` sees steady-state failures right
+   consumer like `klangk monitor` sees steady-state failures right
    away instead of being blind until the next transition (#1175).
    Each `service_health` frame also carries three additive fields:
    `running` (`false` on the terminal **container-death** frame, so a
@@ -152,12 +152,12 @@ miss:
   when healthy), plus the time of the last check (`health_checked_at`).
 - **Server logs** — on each transition to unhealthy, the check's output is
   logged at `INFO` (steady-state unhealthy polls log it at `DEBUG`).
-- **`klangkc monitor`** — stream events and optionally **run a command**
+- **`klangk monitor`** — stream events and optionally **run a command**
   when something changes. This is the automation hook.
 
-### Reacting to failures automatically with `klangkc monitor`
+### Reacting to failures automatically with `klangk monitor`
 
-`klangkc monitor` connects to the server and receives the same events
+`klangk monitor` connects to the server and receives the same events
 the web UI does — health transitions, container starts/stops, workspace
 changes — and can run a command for each one. The event JSON is piped
 to the command's stdin, and details are exposed as environment
@@ -175,21 +175,21 @@ variables. For `service_health` events those are:
 Fire a desktop notification when a service goes unhealthy:
 
 ```bash
-klangkc monitor --type service_health -- \
+klangk monitor --type service_health -- \
   sh -c '[ "$KLANGK_HEALTHY" = false ] && notify-send "klangk" "$KLANGK_HEALTH_MESSAGE"'
 ```
 
 Page yourself (or a Slack webhook) on any health change:
 
 ```bash
-klangkc monitor --type service_health --workspace $WS_ID -- \
+klangk monitor --type service_health --workspace $WS_ID -- \
   sh -c 'curl -s -d "klangk health: $KLANGK_HEALTHY" https://hooks.example.com/alerts'
 ```
 
 Just watch the stream (pipe to `jq`):
 
 ```bash
-klangkc monitor --type service_health | jq .
+klangk monitor --type service_health | jq .
 ```
 
 Because the stream is deltas-only, silence normally means "nothing
@@ -205,7 +205,7 @@ filters it out — drop the filter to observe it.
 exponential backoff — and refreshes its login token on auth failures,
 so it survives server restarts and token expiry as a long-running
 daemon. Bound it with `--max-reconnects N`, or disable reconnect with
-`--no-reconnect`. See `klangkc monitor --help`.
+`--no-reconnect`. See `klangk monitor --help`.
 
 ## Setting the health check
 
@@ -218,13 +218,13 @@ the workspace **Settings** tab.
 
 ```bash
 # Set during creation
-klangkc create my-service --health-check 'curl -sf http://localhost:8080/health'
+klangk create my-service --health-check 'curl -sf http://localhost:8080/health'
 
 # Change it later
-klangkc edit my-service --health-check 'pgrep -f "openclaw gateway"'
+klangk edit my-service --health-check 'pgrep -f "openclaw gateway"'
 
 # Clear it
-klangkc edit my-service --health-check ''
+klangk edit my-service --health-check ''
 ```
 
 ### Sandbox config

--- a/docs/features/invitations.md
+++ b/docs/features/invitations.md
@@ -16,7 +16,7 @@ secure link that expires after 72 hours.
 You can also invite users from the CLI:
 
 ```text
-klangkc admin invitations send user@example.com
+klangk admin invitations send user@example.com
 ```
 
 ## Invitation States
@@ -49,6 +49,6 @@ in and can start using workspaces.
 ## CLI Commands
 
 ```text
-klangkc admin invitations send <email>   # Send an invitation
-klangkc admin invitations ls             # List all invitations
+klangk admin invitations send <email>   # Send an invitation
+klangk admin invitations ls             # List all invitations
 ```

--- a/docs/features/sandbox.md
+++ b/docs/features/sandbox.md
@@ -2,23 +2,23 @@
 
 # Sandbox
 
-`klangkc sandbox` creates a workspace using a project-level config
+`klangk sandbox` creates a workspace using a project-level config
 file. It reads `.klangk-sandbox.yaml`, creates the workspace with the
 configured image, mounts, and volumes, copies files, and runs the
-setup script. Use `klangkc shell` afterwards to connect.
+setup script. Use `klangk shell` afterwards to connect.
 
-`klangkc sandbox` is a quality-of-life feature of the
-[`klangkc` CLI](../reference/cli.md) that combines several of
+`klangk sandbox` is a quality-of-life feature of the
+[`klangk` CLI](../reference/cli.md) that combines several of
 Klangk's individual features — workspace creation, bind mounts,
 file copying, and command execution — into a single step driven by
 a config file. Everything it does can be done manually with
-`klangkc create`, `klangkc exec`, and `klangkc shell`, but the
+`klangk create`, `klangk exec`, and `klangk shell`, but the
 sandbox command makes it easy to check a `.klangk-sandbox.yaml` into
 your repo so you or your teammates can spin up an identical sandboxed
 environment with one command.
 
 This feature is most useful when run with the Klangk server on your own
-machine. It requires the `klangkc` client program. It is not a feature of the
+machine. It requires the `klangk` client program. It is not a feature of the
 web UI.
 
 > **Sandboxes vs. plugins.** Sandboxes are a _runtime_ feature: they
@@ -43,15 +43,15 @@ sandbox:
 Then run:
 
 ```bash
-klangkc sandbox myworkspace
-klangkc shell myworkspace
+klangk sandbox myworkspace
+klangk shell myworkspace
 ```
 
 The first command creates a workspace named `myworkspace`, mounts the
 sandbox root into the container at `~/myproj`, and runs any setup
 script. The second command connects you to an interactive shell.
 
-Run `klangkc sandbox myworkspace` again on an existing workspace and
+Run `klangk sandbox myworkspace` again on an existing workspace and
 it will error — pass `--force` to re-apply the config and re-run
 setup.
 
@@ -178,7 +178,7 @@ mounts:
 ```
 
 Then in your `~/.profile` (so the service command — running as the
-agent — and `klangkc exec` see the variables too; see
+agent — and `klangk exec` see the variables too; see
 [The Shell](the-shell.md#startup-files)) or setup script:
 
 ```bash
@@ -191,7 +191,7 @@ next shell session without recreating the workspace.
 ## Command reference
 
 ```text
-klangkc sandbox WORKSPACE [PATH] [--force]
+klangk sandbox WORKSPACE [PATH] [--force]
 ```
 
 | Argument/Flag | Default | Description                                                             |
@@ -210,7 +210,7 @@ klangkc sandbox WORKSPACE [PATH] [--force]
 3. Mount the sandbox root at `mount-at`
 4. Copy files listed in `copy` into the container home
 5. Run the `setup` script inside the container (if configured)
-6. Print a message to run `klangkc shell` to connect
+6. Print a message to run `klangk shell` to connect
 
 **Subsequent runs** (workspace already exists):
 
@@ -219,16 +219,16 @@ klangkc sandbox WORKSPACE [PATH] [--force]
 
 ### Connecting after sandbox
 
-After `klangkc sandbox` completes, connect with:
+After `klangk sandbox` completes, connect with:
 
 ```bash
-klangkc shell myworkspace
+klangk shell myworkspace
 ```
 
 To forward your SSH agent into the container:
 
 ```bash
-klangkc shell myworkspace -A
+klangk shell myworkspace -A
 ```
 
 If the workspace has a `service-command` configured (e.g.
@@ -239,15 +239,15 @@ above). To get an interactive shell alongside it, connect to a
 named terminal window:
 
 ```bash
-klangkc shell myworkspace dev
+klangk shell myworkspace dev
 ```
 
 This creates a new terminal window called `dev` where you can
 work interactively while the service command continues running in
 the first window.
 
-The copy and setup steps only run during `klangkc sandbox`. On
-`klangkc shell`, the command connects directly to the existing
+The copy and setup steps only run during `klangk sandbox`. On
+`klangk shell`, the command connects directly to the existing
 workspace. This means:
 
 - **Mounts** are always current (they're live links to host paths).
@@ -340,11 +340,11 @@ If the setup script is interrupted (Ctrl+C, network failure, etc.),
 the workspace is left in an inconsistent state. To recover:
 
 - **If your script is idempotent:** re-run with `--force`:
-  `klangkc sandbox myws --force`
+  `klangk sandbox myws --force`
 - **If not:** restart the container and try again:
-  `klangkc restart myws && klangkc sandbox myws --force`.
+  `klangk restart myws && klangk sandbox myws --force`.
   Or delete the workspace entirely and start over:
-  `klangkc rm myws && klangkc sandbox myws`.
+  `klangk rm myws && klangk sandbox myws`.
 
 ### Tips
 
@@ -448,8 +448,8 @@ Usage:
 
 ```bash
 cd ~/projects/klangk
-klangkc sandbox myproj
-klangkc shell myproj -A
+klangk sandbox myproj
+klangk shell myproj -A
 # First sandbox: creates workspace, mounts everything, installs nix
 # shell: connects with SSH agent forwarding
 # Subsequent sandbox calls: error unless --force

--- a/docs/features/service-command.md
+++ b/docs/features/service-command.md
@@ -49,18 +49,18 @@ later in the workspace **Settings** tab.
 
 ### CLI
 
-`klangkc create` accepts `--command`/`-c` to set the service command at
-creation time. On an existing workspace, use `klangkc edit`:
+`klangk create` accepts `--command`/`-c` to set the service command at
+creation time. On an existing workspace, use `klangk edit`:
 
 ```bash
 # Set it when creating the workspace
-klangkc create my-workspace --command 'npm run dev'
+klangk create my-workspace --command 'npm run dev'
 
 # Set or change it on an existing workspace
-klangkc edit my-workspace --command 'npm run dev'
+klangk edit my-workspace --command 'npm run dev'
 
 # Clear it
-klangkc edit my-workspace --command ''
+klangk edit my-workspace --command ''
 ```
 
 ### Sandbox config
@@ -75,7 +75,7 @@ workspace:
 ## When does the command run?
 
 The service command runs whenever a **fresh container** is created
-for the workspace — at workspace creation, on `klangkc restart`, at
+for the workspace — at workspace creation, on `klangk restart`, at
 server boot (for [auto-start](#auto-start-workspaces) workspaces), or
 on the first connection that starts the container. It does **not**
 re-run on reconnect; if you disconnect and reconnect, you pick up the
@@ -87,7 +87,7 @@ running, or you may be at a bash prompt if it exited).
 If the workspace has [auto-start](workspaces.md#auto-start) enabled,
 the container also starts when the Klangk server starts (boot), so
 the service is already running before any user connects. When you
-later run `klangkc shell`, you walk up to the service already
+later run `klangk shell`, you walk up to the service already
 running in the `service-cmd` tab. Visitors who open the workspace see
 it as a shared terminal without any action from the owner.
 

--- a/docs/features/ssh-agent-forwarding.md
+++ b/docs/features/ssh-agent-forwarding.md
@@ -1,6 +1,6 @@
 # SSH Agent Forwarding
 
-When connecting via `klangkc shell -A`, your local SSH agent is
+When connecting via `klangk shell -A`, your local SSH agent is
 forwarded into the workspace container. This lets you use
 `git push git@github.com:...`, `ssh`, and other SSH-based tools
 inside the container using your local SSH keys — without copying any
@@ -9,7 +9,7 @@ private keys.
 ## How it works
 
 When `--forward-agent` (`-A`) is enabled (via CLI flag or config
-file), `klangkc shell` checks for a local `SSH_AUTH_SOCK` and sets
+file), `klangk shell` checks for a local `SSH_AUTH_SOCK` and sets
 up a relay over the existing WebSocket tunnel:
 
 1. A Unix socket is created inside the container at a well-known path
@@ -29,7 +29,7 @@ Pass `-A` (or `--forward-agent`) to enable forwarding:
 ssh-add -l
 
 # Connect with agent forwarding
-klangkc shell -A my-workspace
+klangk shell -A my-workspace
 
 # Inside the container:
 ssh-add -l                          # shows your forwarded keys
@@ -68,7 +68,7 @@ config file documentation.
 
 - A running SSH agent on your local machine (`SSH_AUTH_SOCK` must
   be set and point to a valid socket)
-- The `klangkc shell` CLI (agent forwarding is not available from
+- The `klangk shell` CLI (agent forwarding is not available from
   the web frontend)
 
 ## Limitations
@@ -77,7 +77,7 @@ config file documentation.
   connection at a time. This works for typical usage (single `git
 push`, `ssh` commands) but may not work correctly with parallel
   SSH operations like `git clone --recurse-submodules -j4`.
-- **Web frontend**: Agent forwarding is only available via `klangkc
+- **Web frontend**: Agent forwarding is only available via `klangk
 shell`, not from the browser-based terminal.
 
 ## Session persistence
@@ -93,7 +93,7 @@ same path, so existing shells continue to work.
 - Check that `SSH_AUTH_SOCK` is set: `echo $SSH_AUTH_SOCK`
 - If empty, either `-A` was not passed or your local agent wasn't
   running when you connected. Exit the shell, ensure `ssh-agent` is
-  running locally, and reconnect with `klangkc shell -A`.
+  running locally, and reconnect with `klangk shell -A`.
 
 ### Agent forwarding doesn't work after reconnecting
 
@@ -105,7 +105,7 @@ same path, so existing shells continue to work.
 
 Set `KLANGKC_DEBUG_SSH_AGENT=1` to enable verbose logging of the SSH
 agent relay. On the backend, messages go to the server log. On the
-CLI, messages are written to `~/.klangkc-ssh-agent.log` (to avoid
+CLI, messages are written to `~/.klangk-ssh-agent.log` (to avoid
 corrupting the terminal display).
 
 ```bash
@@ -114,9 +114,9 @@ KLANGKC_DEBUG_SSH_AGENT=1
 
 # CLI side
 export KLANGKC_DEBUG_SSH_AGENT=1
-klangkc shell -A my-workspace
+klangk shell -A my-workspace
 # In another terminal:
-tail -f ~/.klangkc-ssh-agent.log
+tail -f ~/.klangk-ssh-agent.log
 ```
 
 Log messages are prefixed with `[ssh-agent]` and show data flow

--- a/docs/features/terminal.md
+++ b/docs/features/terminal.md
@@ -56,7 +56,7 @@ container. It starts on demand when you click the Terminal tab.
 - If the container stops (idle timeout or crash), an overlay appears
   with a restart button. The terminal auto-reconnects after restart.
 
-### Exiting a `klangkc shell` session
+### Exiting a `klangk shell` session
 
 Typing `exit` or pressing **Ctrl+D** does **not** disconnect you from
 the container. Klangk's tmux is configured with `remain-on-exit`, which
@@ -64,7 +64,7 @@ keeps the pane alive and immediately respawns a new shell. This is
 intentional — it prevents you from accidentally losing your terminal
 session.
 
-To actually disconnect from a `klangkc shell` session, use the SSH-style
+To actually disconnect from a `klangk shell` session, use the SSH-style
 escape sequence: press **Enter**, then **~**, then **.** (period). This
 cleanly disconnects the CLI client without affecting the tmux session
 inside the container.

--- a/docs/features/the-shell.md
+++ b/docs/features/the-shell.md
@@ -5,7 +5,7 @@ set up the environment before your personal `~/.bashrc` runs:
 
 - `/etc/profile.d/klangk-*.sh` — environment exports (`PATH=/opt/klangk/bin`,
   `EDITOR`) sourced by **every login shell**, interactive or not. This is
-  why one-shot commands like `klangkc exec` (`bash -lc`) still find
+  why one-shot commands like `klangk exec` (`bash -lc`) still find
   `pi` and the `klangk-*` helpers. (The workspace health check is the
   exception — it runs as a non-login `bash -c` and sources nothing; see
   [Health Check](health-check.md).)
@@ -71,7 +71,7 @@ same startup files (see [Startup files](#startup-files) below):
 
 - Edit `~/.profile` for **environment exports** (PATH additions,
   `OPENCLAW_HOME`, tool-manager setup like nvm/asdf) that login-shell
-  commands — interactive terminals, the service command, and `klangkc
+  commands — interactive terminals, the service command, and `klangk
 exec` — must see. (The health check is deliberately _not_ a profile
   consumer; see [Health Check](health-check.md).)
 - Edit `~/.bashrc` for **interactive niceties** (aliases, prompt
@@ -86,7 +86,7 @@ All changes persist across container restarts.
 Klangk runs in-container commands in a few different ways, and each
 sources a different set of startup files. Getting this right matters:
 an environment export buried below `~/.bashrc`'s interactivity guard is
-invisible to `klangkc exec`, so a one-shot command run there can fail
+invisible to `klangk exec`, so a one-shot command run there can fail
 to find a tool even though an interactive terminal finds it fine.
 
 The one deliberate exception is the **health check**: it runs as a
@@ -96,13 +96,13 @@ See [Health Check](health-check.md).
 
 ### Convention
 
-| File                                        | Purpose                                                                                                          | Sourced by                                                                            |
-| ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| `/etc/profile.d/klangk-*.sh`                | system-wide defaults (klangk `PATH`, `EDITOR`)                                                                   | every login shell                                                                     |
-| `~/.profile`                                | **per-user environment exports** (PATH additions, tool homes, nvm/asdf) — anything login-shell commands must see | login shells: interactive terminals, the service command, `klangkc exec` (`bash -lc`) |
-| `~/.bashrc` (below the interactivity guard) | interactive niceties (aliases, prompt)                                                                           | interactive non-login bash shells; also chained from `~/.profile` for login shells    |
+| File                                        | Purpose                                                                                                          | Sourced by                                                                           |
+| ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `/etc/profile.d/klangk-*.sh`                | system-wide defaults (klangk `PATH`, `EDITOR`)                                                                   | every login shell                                                                    |
+| `~/.profile`                                | **per-user environment exports** (PATH additions, tool homes, nvm/asdf) — anything login-shell commands must see | login shells: interactive terminals, the service command, `klangk exec` (`bash -lc`) |
+| `~/.bashrc` (below the interactivity guard) | interactive niceties (aliases, prompt)                                                                           | interactive non-login bash shells; also chained from `~/.profile` for login shells   |
 
-**Rule of thumb:** if a login-shell command (`klangkc exec`, a setup
+**Rule of thumb:** if a login-shell command (`klangk exec`, a setup
 script, the service command) needs it, it goes in `~/.profile`. If it
 only matters when you're at a prompt, it goes in `~/.bashrc`. The
 health check is not a `~/.profile` consumer — see
@@ -115,12 +115,12 @@ health check is not a `~/.profile` consumer — see
 | Interactive terminal                         | `tmux new-session` (login shell) or `bash -l` | yes                                                                                        |
 | `service_command` (the `service-cmd` window) | login shell (tmux window 0)                   | yes                                                                                        |
 | Workspace health check                       | `bash -c` (a **non-login** shell)             | no — the probe is deterministic; uses absolute paths (see [Health Check](health-check.md)) |
-| `klangkc exec` (default)                     | `bash -lc` (a login shell)                    | yes                                                                                        |
-| `klangkc exec --raw` / `klangkc sync`        | raw command (no shell)                        | no — programmatic transports (rsync) must not source startup files                         |
+| `klangk exec` (default)                      | `bash -lc` (a login shell)                    | yes                                                                                        |
+| `klangk exec --raw` / `klangk sync`          | raw command (no shell)                        | no — programmatic transports (rsync) must not source startup files                         |
 
 This is why workspace setup scripts (`sandboxes/*/setup.sh`) persist
 their env exports to `~/.profile` rather than `~/.bashrc`: the exports
-must be visible to the service command and `klangkc exec`, both of
+must be visible to the service command and `klangk exec`, both of
 which are login shells that source `~/.profile`. `~/.bashrc`'s
 interactivity guard (`case $- in *i*) ;; *) return`) hides its body
 from those non-interactive login shells. The health check is the

--- a/docs/features/workspaces.md
+++ b/docs/features/workspaces.md
@@ -48,8 +48,8 @@ Toggle auto-start from the workspace **Settings** tab, or via the
 CLI:
 
 ```bash
-klangkc edit my-project --auto-start
-klangkc edit my-project --no-auto-start
+klangk edit my-project --auto-start
+klangk edit my-project --no-auto-start
 ```
 
 When the server starts, it starts containers for all auto-start
@@ -76,10 +76,10 @@ Workspace owners can share access with other users or groups from the
 **Sharing** tab, or from the CLI:
 
 ```bash
-klangkc share my-project user@example.com                # share (coder role)
-klangkc share my-project user@example.com --role=owner   # share with role
-klangkc unshare my-project user@example.com              # remove access
-klangkc members my-project                               # list members
+klangk share my-project user@example.com                # share (coder role)
+klangk share my-project user@example.com --role=owner   # share with role
+klangk unshare my-project user@example.com              # remove access
+klangk members my-project                               # list members
 ```
 
 Shared users connect to the same container and see the workspace in

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -98,7 +98,7 @@ instructions.
 
 Out of the box (the default `none` auth mode) there is **nothing to log in
 with** — open <http://localhost:8995> and you're already in, as the default
-user (`KLANGK_DEFAULT_USER`). The CLI likewise needs no `klangkc login`.
+user (`KLANGK_DEFAULT_USER`). The CLI likewise needs no `klangk login`.
 
 If you switched to a real auth mode (`password`, `oidc`, or `both` — e.g. the
 Docker examples above set `KLANGK_AUTH_MODES=password`), log in with the

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,7 @@ real time.
 Terminals run inside [tmux](features/the-shell.md) for session
 persistence and window management. Access them from the web UI or
 connect from your local terminal with
-[`klangkc shell`](reference/cli.md).
+[`klangk shell`](reference/cli.md).
 
 ### Administration
 

--- a/docs/reference/acl.md
+++ b/docs/reference/acl.md
@@ -76,7 +76,7 @@ When a workspace is created, the owner gets a `(Allow, user:{id}, *)` ACE on `/w
 
 **API**: `GET /api/v1/my-permissions` returns your effective permissions on all static resources. Add `?resource=/workspaces/{id}` to check a specific resource.
 
-**CLI**: `klangkc ls --shared` shows workspaces shared with you.
+**CLI**: `klangk ls --shared` shows workspaces shared with you.
 
 ## Troubleshooting: "Why can't I access this workspace?"
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2,28 +2,28 @@
 
 # CLI
 
-`klangkc` is the command-line client for Klangk. It lets you manage
+`klangk` is the command-line client for Klangk. It lets you manage
 workspaces, connect to container shells, sync files, and administer
 users from your terminal without needing the web UI. It also
 supports [sandboxing projects](../features/sandbox.md) from a config
 file and [SSH agent forwarding](../features/ssh-agent-forwarding.md)
 for using your local SSH keys inside containers.
 
-[![klangkc --help](../assets/cli-help.png)](../assets/cli-help.png)
+[![klangk --help](../assets/cli-help.png)](../assets/cli-help.png)
 
 ## Installation
 
-Install `klangkc` from PyPI:
+Install `klangk` from PyPI:
 
 ```bash
-pip install klangkc
+pip install klangk
 ```
 
 Requires Python 3.12+.
 
 ## Configuration
 
-`klangkc` uses two files in `~/.config/klangk/`:
+`klangk` uses two files in `~/.config/klangk/`:
 
 - **`cli.yaml`** — user-edited settings. The CLI never writes to this
   file. Define server aliases, default users, and per-server overrides
@@ -60,11 +60,11 @@ servers:
 ```
 
 You do not need to create `cli.yaml` manually. On your first
-`klangkc login`, the CLI creates one automatically using the
+`klangk login`, the CLI creates one automatically using the
 hostname as the alias and the login user as the default:
 
 ```bash
-klangkc login http://myhost:8995 admin@example.com
+klangk login http://myhost:8995 admin@example.com
 # Creates ~/.config/klangk/cli.yaml with:
 #   servers:
 #     myhost:
@@ -77,12 +77,12 @@ freely after the initial creation.
 
 #### Settings
 
-| Setting         | Scope            | Default  | Description                                        |
-| --------------- | ---------------- | -------- | -------------------------------------------------- |
-| `forward-agent` | global or server | `false`  | Forward local SSH agent into containers            |
-| `ws-max-size`   | global or server | 16777216 | Maximum WebSocket message size in bytes            |
-| `user`          | server only      |          | Default user (email or handle) for `klangkc login` |
-| `url`           | server only      |          | Server URL (required for each server entry)        |
+| Setting         | Scope            | Default  | Description                                       |
+| --------------- | ---------------- | -------- | ------------------------------------------------- |
+| `forward-agent` | global or server | `false`  | Forward local SSH agent into containers           |
+| `ws-max-size`   | global or server | 16777216 | Maximum WebSocket message size in bytes           |
+| `user`          | server only      |          | Default user (email or handle) for `klangk login` |
+| `url`           | server only      |          | Server URL (required for each server entry)       |
 
 Per-server settings override global settings. CLI flags override both.
 
@@ -102,17 +102,17 @@ http://localhost:8995:
       token: eyJ...
 ```
 
-Multiple users can be cached per server. `klangkc login` switches
+Multiple users can be cached per server. `klangk login` switches
 the active user and reuses a cached token if it is still valid.
 
 ### No-auth (single-user) servers
 
 If the server runs with `KLANGK_AUTH_MODES=none` (no-login local-dev mode),
-login requires **no password** — `klangkc login` calls `/api/v1/auth/local`
+login requires **no password** — `klangk login` calls `/api/v1/auth/local`
 and stores the freely-issued token. See [Auth Modes](../features/auth-modes.md).
 
-In `none` mode you don't even need to run `klangkc login` for each command:
-register the server once with `klangkc login <server>`, and thereafter every
+In `none` mode you don't even need to run `klangk login` for each command:
+register the server once with `klangk login <server>`, and thereafter every
 protected command auto-logs in (the `require_auth` gate probes the server mode
 and calls `/auth/local`). Against a `password`/`oidc`/`both` server the normal
 "Not logged in" error still fires.
@@ -122,9 +122,9 @@ and calls `/auth/local`). Against a `password`/`oidc`/`both` server the normal
 Commands need a server to talk to. The active server is determined by:
 
 1. **`--server` flag** (highest priority) — pass on any command:
-   `klangkc --server=prod ls`
+   `klangk --server=prod ls`
 2. **`active-server` in state.yaml** — set automatically by
-   `klangkc login`
+   `klangk login`
 3. **Error** — if neither is available, the CLI exits with an error
    message
 
@@ -135,80 +135,80 @@ or a raw URL. It does not change `state.yaml`.
 
 ```bash
 # Authentication
-klangkc login local                          # login to "local" alias (uses default user from config)
-klangkc login http://localhost:8995          # login with a raw URL (prompts for user)
-klangkc login prod chris@example.com         # login as a specific user
-klangkc logout                               # logout from active server
-klangkc logout prod                          # logout from a specific server
-klangkc status                               # show active server and user
+klangk login local                          # login to "local" alias (uses default user from config)
+klangk login http://localhost:8995          # login with a raw URL (prompts for user)
+klangk login prod chris@example.com         # login as a specific user
+klangk logout                               # logout from active server
+klangk logout prod                          # logout from a specific server
+klangk status                               # show active server and user
 
 # Non-interactive login (for scripts)
-klangkc login prod admin --password-file /path/to/pwfile
-echo "secret" | klangkc login prod admin --password-file -
+klangk login prod admin --password-file /path/to/pwfile
+echo "secret" | klangk login prod admin --password-file -
 
 # Working with a non-default server
-klangkc --server=prod ls                     # list workspaces on prod
-klangkc --server=prod shell my-project       # connect to shell on prod
+klangk --server=prod ls                     # list workspaces on prod
+klangk --server=prod shell my-project       # connect to shell on prod
 
 # Workspaces
-klangkc ls                               # list workspaces (first page)
-klangkc ls --shared                      # include workspaces shared with you
-klangkc ls --limit 50                    # list up to 50 per section
-klangkc ls --all                         # page through every workspace
-klangkc ls --sort name --order asc       # sort by name, ascending
-klangkc ls --filter gamma                # substring filter on name
-klangkc create my-project                # create a workspace
-klangkc create my-project --auto-start   # create with auto-start on server boot
-klangkc create my-project --mount ~/src:/home/klangk/work/src          # with bind mount
-klangkc create my-project --mount nix-store:/nix           # with named volume
-klangkc create my-project --env FOO=bar                      # with env vars
-klangkc create my-project --health-check 'curl -sf http://localhost:8080/health'  # with a service health check
-klangkc create my-project --command 'npm run dev'  # with a service command
-klangkc create my-project -c 'npm run dev'         # short form of --command
-klangkc edit my-project                  # interactive edit (name, image, command, health check, mounts, env)
-klangkc edit my-project --auto-start     # enable auto-start on server boot
-klangkc edit my-project --no-auto-start  # disable auto-start
-klangkc edit my-project --env FOO=bar    # set env var via flag
-klangkc dup my-project my-copy           # duplicate a workspace
-klangkc shell my-project                 # drop into bash inside the container
-klangkc shell my-project debug           # attach to the "debug" terminal window (created if it doesn't exist)
-klangkc sandbox myws                     # create workspace from .klangk-sandbox.yaml
-klangkc sandbox myws ~/projects/myapp    # specify sandbox root explicitly
-klangkc sandbox myws --force             # re-apply config and re-run setup on existing workspace
-klangkc exec my-project ls /home/klangk/work         # run a command in the container (login shell: sources ~/.profile)
-klangkc exec --raw my-project rsync --server ...      # raw argv, no shell (for transports like rsync)
-klangkc monitor                                        # stream all server events as JSON
-klangkc monitor --type service_health | jq .           # pretty-print health transitions
-klangkc monitor --type service_health -- sh -c '[ "$KLANGK_HEALTHY" = false ] && notify-send "klangk" "$KLANGK_HEALTH_MESSAGE"'  # alert with the failure reason
-klangkc sync ~/src my-project:/home/klangk/work      # sync files to/from the container
-klangkc rm my-project                # delete a workspace
-klangkc restart my-project           # restart the container for a workspace (owner only)
-klangkc export my-project            # export workspace to my-project.tar.gz (admin only)
-klangkc export my-project -o bak.tar.gz  # export to specific file
-klangkc import bak.tar.gz            # import workspace from archive
-klangkc import bak.tar.gz --name new-name  # import with a different name
+klangk ls                               # list workspaces (first page)
+klangk ls --shared                      # include workspaces shared with you
+klangk ls --limit 50                    # list up to 50 per section
+klangk ls --all                         # page through every workspace
+klangk ls --sort name --order asc       # sort by name, ascending
+klangk ls --filter gamma                # substring filter on name
+klangk create my-project                # create a workspace
+klangk create my-project --auto-start   # create with auto-start on server boot
+klangk create my-project --mount ~/src:/home/klangk/work/src          # with bind mount
+klangk create my-project --mount nix-store:/nix           # with named volume
+klangk create my-project --env FOO=bar                      # with env vars
+klangk create my-project --health-check 'curl -sf http://localhost:8080/health'  # with a service health check
+klangk create my-project --command 'npm run dev'  # with a service command
+klangk create my-project -c 'npm run dev'         # short form of --command
+klangk edit my-project                  # interactive edit (name, image, command, health check, mounts, env)
+klangk edit my-project --auto-start     # enable auto-start on server boot
+klangk edit my-project --no-auto-start  # disable auto-start
+klangk edit my-project --env FOO=bar    # set env var via flag
+klangk dup my-project my-copy           # duplicate a workspace
+klangk shell my-project                 # drop into bash inside the container
+klangk shell my-project debug           # attach to the "debug" terminal window (created if it doesn't exist)
+klangk sandbox myws                     # create workspace from .klangk-sandbox.yaml
+klangk sandbox myws ~/projects/myapp    # specify sandbox root explicitly
+klangk sandbox myws --force             # re-apply config and re-run setup on existing workspace
+klangk exec my-project ls /home/klangk/work         # run a command in the container (login shell: sources ~/.profile)
+klangk exec --raw my-project rsync --server ...      # raw argv, no shell (for transports like rsync)
+klangk monitor                                        # stream all server events as JSON
+klangk monitor --type service_health | jq .           # pretty-print health transitions
+klangk monitor --type service_health -- sh -c '[ "$KLANGK_HEALTHY" = false ] && notify-send "klangk" "$KLANGK_HEALTH_MESSAGE"'  # alert with the failure reason
+klangk sync ~/src my-project:/home/klangk/work      # sync files to/from the container
+klangk rm my-project                # delete a workspace
+klangk restart my-project           # restart the container for a workspace (owner only)
+klangk export my-project            # export workspace to my-project.tar.gz (admin only)
+klangk export my-project -o bak.tar.gz  # export to specific file
+klangk import bak.tar.gz            # import workspace from archive
+klangk import bak.tar.gz --name new-name  # import with a different name
 
 # Sharing
-klangkc members my-project           # list workspace members by role
-klangkc share my-project user@x.com  # share workspace (default: coder role)
-klangkc share my-project user@x.com --role=spectator  # share with specific role
-klangkc unshare my-project user@x.com # remove a user from all roles
-klangkc terminal ls my-project       # list all terminals (own + shared)
-klangkc terminal share my-project bash        # share a terminal with workspace members
-klangkc terminal unshare my-project bash      # stop sharing a terminal
+klangk members my-project           # list workspace members by role
+klangk share my-project user@x.com  # share workspace (default: coder role)
+klangk share my-project user@x.com --role=spectator  # share with specific role
+klangk unshare my-project user@x.com # remove a user from all roles
+klangk terminal ls my-project       # list all terminals (own + shared)
+klangk terminal share my-project bash        # share a terminal with workspace members
+klangk terminal unshare my-project bash      # stop sharing a terminal
 
 # Admin
-klangkc admin users ls                    # list all user accounts (admin only)
-klangkc admin users set-password user@example.com   # set/reset a password (admin only)
-klangkc admin invitations send user@example.com     # send an invitation email (admin only)
-klangkc admin invitations ls                       # list all invitations (admin only)
-klangkc images                       # list available container images
-klangkc volumes ls                   # list your podman volumes
-klangkc volumes create nix-store     # create a named volume (owned by you)
-klangkc volumes rm nix-store         # delete a volume (must be yours)
+klangk admin users ls                    # list all user accounts (admin only)
+klangk admin users set-password user@example.com   # set/reset a password (admin only)
+klangk admin invitations send user@example.com     # send an invitation email (admin only)
+klangk admin invitations ls                       # list all invitations (admin only)
+klangk images                       # list available container images
+klangk volumes ls                   # list your podman volumes
+klangk volumes create nix-store     # create a named volume (owned by you)
+klangk volumes rm nix-store         # delete a volume (must be yours)
 ```
 
-`klangkc status` shows the active server, your user id/email, and whether
+`klangk status` shows the active server, your user id/email, and whether
 you hold site-wide admin privileges (derived from the server's
 `/my-permissions` — the same source the web UI uses).
 
@@ -216,7 +216,7 @@ The CLI connects to the running Klangk backend over HTTP + WebSocket — it work
 
 ## Exiting the shell
 
-To disconnect from `klangkc shell`, use the SSH-style escape sequence:
+To disconnect from `klangk shell`, use the SSH-style escape sequence:
 **Enter**, **~**, **.** (three keystrokes in sequence).
 
 1. Press **Enter** to make sure you're at the beginning of a new line.
@@ -238,12 +238,12 @@ tildes freely in commands and text without triggering the escape.
 
 ## Named terminal windows
 
-`klangkc shell` accepts an optional terminal name argument to connect to
+`klangk shell` accepts an optional terminal name argument to connect to
 a specific terminal window inside the workspace:
 
 ```bash
-klangkc shell my-project build    # attach to the "build" window
-klangkc shell my-project logs     # attach to the "logs" window
+klangk shell my-project build    # attach to the "build" window
+klangk shell my-project logs     # attach to the "logs" window
 ```
 
 If the named window doesn't exist, it is created automatically. This
@@ -251,15 +251,15 @@ lets you open multiple named terminals from the CLI without using the web
 UI. The new window also appears as a tab in the web UI for anyone
 viewing the workspace.
 
-Without a terminal name, `klangkc shell` connects to the currently
+Without a terminal name, `klangk shell` connects to the currently
 active window.
 
 ## Terminal behavior differences
 
-`klangkc shell` provides the same tmux-based terminal as the web frontend, but clipboard behavior differs:
+`klangk shell` provides the same tmux-based terminal as the web frontend, but clipboard behavior differs:
 
 - **Web frontend**: Text selections auto-copy to the system clipboard via the browser bridge. Mouse wheel scrolls through scrollback. No extra setup needed.
-- **CLI (`klangkc shell`)**: Text selections auto-copy to the system clipboard via [OSC 52](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-Operating-System-Commands), which requires your terminal emulator to support it. Mouse wheel scrollback works. Native text selection (viewport-only) is available via **Shift+drag**.
+- **CLI (`klangk shell`)**: Text selections auto-copy to the system clipboard via [OSC 52](https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-Operating-System-Commands), which requires your terminal emulator to support it. Mouse wheel scrollback works. Native text selection (viewport-only) is available via **Shift+drag**.
 
 ### OSC 52 terminal support
 
@@ -280,4 +280,4 @@ The following terminal emulators support OSC 52 clipboard integration (auto-copy
 | MATE Terminal    | No             |
 | Terminator       | No             |
 
-If your terminal does not support OSC 52, tmux selections will still be captured in the tmux paste buffer but will not automatically appear on your system clipboard. Consider switching to a terminal emulator that supports OSC 52 for the best `klangkc shell` experience.
+If your terminal does not support OSC 52, tmux selections will still be captured in the tmux paste buffer but will not automatically appear on your system clipboard. Consider switching to a terminal emulator that supports OSC 52 for the best `klangk shell` experience.

--- a/docs/reference/oidc.md
+++ b/docs/reference/oidc.md
@@ -105,7 +105,7 @@ This is configured per provider, so a deployment with multiple IdPs can trust so
 ## How It Works
 
 - **Web**: Login page shows one button per provider. Clicking redirects to the IdP via Authorization Code flow with PKCE. After authentication, the IdP redirects back to Klangk which exchanges the code for tokens, validates the ID token, and issues a Klangk JWT.
-- **CLI**: `klangkc login` detects OIDC from the server config, opens a browser for authentication, and receives the token via a temporary localhost callback server.
+- **CLI**: `klangk login` detects OIDC from the server config, opens a browser for authentication, and receives the token via a temporary localhost callback server.
 - **Login hook**: A Python script (`KLANGK_OIDC_LOGIN_HOOK`) can handle login validation and group mapping. See [OIDC Login Hook](#oidc-login-hook) below.
 - **User provisioning**: On first OIDC login, a user is created automatically (verified, no password). If a local user with the same email already exists, the OIDC identity is linked to it.
 - **OIDC users** cannot use forgot-password, change-password, or change-email.

--- a/docs/sandboxes/hermes.md
+++ b/docs/sandboxes/hermes.md
@@ -18,7 +18,7 @@ still reports healthy.
 
 ```bash
 cd sandboxes/hermes
-klangkc sandbox hermes
+klangk sandbox hermes
 ```
 
 First run fetches and runs the upstream Hermes installer, writes a config

--- a/docs/sandboxes/openclaw.md
+++ b/docs/sandboxes/openclaw.md
@@ -18,7 +18,7 @@ container auto-starts with the server.
 
 ```bash
 cd sandboxes/openclaw
-klangkc sandbox openclaw
+klangk sandbox openclaw
 ```
 
 First run installs Node.js 24 (via nvm), openclaw, writes a config

--- a/plugins/git-credential/README.md
+++ b/plugins/git-credential/README.md
@@ -28,7 +28,7 @@ Git invokes the helper with one of three operations:
 - **`erase`** — git reports that credentials were rejected. The helper
   forwards to the bridge so the browser plugin can clear its cache.
 
-If no browser is connected (e.g. `klangkc shell` without a browser),
+If no browser is connected (e.g. `klangk shell` without a browser),
 the helper exits non-zero and git falls through to its next configured
 credential helper or prompts interactively.
 

--- a/sandboxes/devenv-sandbox/README.md
+++ b/sandboxes/devenv-sandbox/README.md
@@ -9,7 +9,7 @@ No sudo required — uses single-user nix (no daemon).
 
 ```bash
 cd sandboxes/devenv-sandbox
-klangkc sandbox -A
+klangk sandbox -A
 ```
 
 First run installs nix, devenv, and cachix into the container. The

--- a/sandboxes/tests/hermes/test_hermes_setup_e2e.py
+++ b/sandboxes/tests/hermes/test_hermes_setup_e2e.py
@@ -2,7 +2,7 @@
 
 Covers two invariants (#1109):
 
-- **Installs as a sandbox.** ``klangkc sandbox hermes`` fetches and runs the
+- **Installs as a sandbox.** ``klangk sandbox hermes`` fetches and runs the
   upstream Hermes installer at runtime (per-workspace, as the non-root
   ``klangk`` user), writes ``~/.profile`` exports + the llm-proxy config, and
   lands the ``hermes`` binary.
@@ -28,7 +28,7 @@ in the root/FHS branch, which a non-root sandbox never takes).
 
 This reads files directly from the host (the per-user home and the ``/hermes``
 mount both live under the server data dir / the sandbox dir). It deliberately
-avoids ``klangkc exec`` for the profile check: exec runs a raw command with
+avoids ``klangk exec`` for the profile check: exec runs a raw command with
 no login shell (#1041), so it would not source ``~/.profile`` and would give
 a false negative.
 
@@ -305,7 +305,7 @@ class TestHermesSetup:
         env = {**os.environ, "HOME": str(config_dir)}
         os.makedirs(config_dir / ".config" / "klangk", exist_ok=True)
         _run(
-            ["klangkc", "login", base_url, EMAIL, "--password-file", "-"],
+            ["klangk", "login", base_url, EMAIL, "--password-file", "-"],
             input=PASSWORD + "\n",
             env=env,
         )
@@ -390,7 +390,7 @@ class TestHermesSetup:
 
         This is the #1109 end-to-end validation. The whole chain must work:
 
-        1. ``klangkc sandbox hermes`` creates the workspace carrying
+        1. ``klangk sandbox hermes`` creates the workspace carrying
            ``service_command``, ``health_check``, and ``auto_start`` from
            the sandbox config.
         2. ``setup.sh`` writes ``~/.profile`` exports up front, fetches +
@@ -408,7 +408,7 @@ class TestHermesSetup:
            status endpoint reports ``healthy``.
         """
         sandbox_proc = subprocess.Popen(
-            ["klangkc", "sandbox", WS, SANDBOX_DIR],
+            ["klangk", "sandbox", WS, SANDBOX_DIR],
             env=self._env,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
@@ -417,7 +417,7 @@ class TestHermesSetup:
         try:
             rc = sandbox_proc.wait(timeout=SETUP_TIMEOUT)
             out = sandbox_proc.stdout.read() or ""
-            assert rc == 0, "klangkc sandbox (hermes install) failed:\n" + out
+            assert rc == 0, "klangk sandbox (hermes install) failed:\n" + out
 
             ws_id = self._await_container()
 

--- a/sandboxes/tests/openclaw/test_openclaw_setup_e2e.py
+++ b/sandboxes/tests/openclaw/test_openclaw_setup_e2e.py
@@ -346,7 +346,7 @@ class TestOpenclawSetupProfileExports:
         env = {**os.environ, "HOME": str(config_dir)}
         os.makedirs(config_dir / ".config" / "klangk", exist_ok=True)
         _run(
-            ["klangkc", "login", base_url, EMAIL, "--password-file", "-"],
+            ["klangk", "login", base_url, EMAIL, "--password-file", "-"],
             input=PASSWORD + "\n",
             env=env,
         )
@@ -406,7 +406,7 @@ class TestOpenclawSetupProfileExports:
         # Run the sandbox in the background; it blocks on the sentinel
         # right after writing the consolidated ~/.profile exports.
         sandbox_proc = subprocess.Popen(
-            ["klangkc", "sandbox", WS, SANDBOX_DIR],
+            ["klangk", "sandbox", WS, SANDBOX_DIR],
             env=env,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
@@ -434,7 +434,7 @@ class TestOpenclawSetupProfileExports:
             # Release setup.sh and let the real openclaw install finish.
             os.remove(SENTINEL)
             assert sandbox_proc.wait(timeout=SETUP_TIMEOUT) == 0, (
-                "klangkc sandbox failed:\n" + (sandbox_proc.stdout.read() or "")
+                "klangk sandbox failed:\n" + (sandbox_proc.stdout.read() or "")
             )
 
             # The real install ran: the openclaw binary lands on the
@@ -454,7 +454,7 @@ class TestOpenclawSetupProfileExports:
             else:
                 out, _ = self._capture_sandbox(sandbox_proc)
                 if out:
-                    print(f"--- klangkc sandbox output ---\n{out}")
+                    print(f"--- klangk sandbox output ---\n{out}")
 
     def test_second_workspace_reuses_install_but_writes_own_profile(self):
         """A second workspace at the same /openclaw mount SKIPS the install
@@ -490,7 +490,7 @@ class TestOpenclawSetupProfileExports:
         # No sentinel: WS2's setup runs to completion. The install is
         # skipped (openclaw already on the mount), so this is fast.
         sandbox_proc = subprocess.Popen(
-            ["klangkc", "sandbox", WS2, SANDBOX_DIR],
+            ["klangk", "sandbox", WS2, SANDBOX_DIR],
             env=self._env,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
@@ -499,7 +499,7 @@ class TestOpenclawSetupProfileExports:
         try:
             rc = sandbox_proc.wait(timeout=SETUP_TIMEOUT)
             out = sandbox_proc.stdout.read() or ""
-            assert rc == 0, f"klangkc sandbox (WS2) failed:\n{out}"
+            assert rc == 0, f"klangk sandbox (WS2) failed:\n{out}"
 
             # The install was genuinely skipped -- proving we're on the
             # skip path, not a vacuous pass where a regression re-ran
@@ -541,7 +541,7 @@ class TestOpenclawSetupProfileExports:
         This is the #1089 end-to-end validation. The whole chain must
         work for the status to flip to healthy:
 
-        1. ``klangkc sandbox`` creates the workspace carrying
+        1. ``klangk sandbox`` creates the workspace carrying
            ``health_check`` from the sandbox config.
         2. setup completes -> ``setup_state == complete`` (the monitor
            skips checks until then).
@@ -573,7 +573,7 @@ class TestOpenclawSetupProfileExports:
         # WS3 reuses the populated mount, so its setup SKIPS the install
         # (fast) -- the point here is the health-check path, not install.
         sandbox_proc = subprocess.Popen(
-            ["klangkc", "sandbox", WS3, SANDBOX_DIR],
+            ["klangk", "sandbox", WS3, SANDBOX_DIR],
             env=self._env,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
@@ -582,7 +582,7 @@ class TestOpenclawSetupProfileExports:
         try:
             rc = sandbox_proc.wait(timeout=SETUP_TIMEOUT)
             out = sandbox_proc.stdout.read() or ""
-            assert rc == 0, f"klangkc sandbox (WS3) failed:\n{out}"
+            assert rc == 0, f"klangk sandbox (WS3) failed:\n{out}"
             # The install was genuinely skipped, proving the fast path.
             assert "openclaw already installed, skipping." in out, (
                 "expected setup to SKIP the install (mount already "

--- a/src/containers/workspace/Dockerfile
+++ b/src/containers/workspace/Dockerfile
@@ -63,7 +63,7 @@ RUN chmod +x /opt/klangk/entrypoint.sh \
       /opt/klangk/bin/klangk-set-workspace-token \
       /opt/klangk/bin/klangk-workspace-token
 # System-wide environment exports for ALL login shells (interactive AND
-# non-interactive, e.g. `klangkc exec`'s `bash -lc`). /etc/profile sources
+# non-interactive, e.g. `klangk exec`'s `bash -lc`). /etc/profile sources
 # these unconditionally via run-parts. See issue #1093 for why env must live
 # here rather than in /etc/bash.bashrc (which non-interactive shells skip).
 # (The workspace health check is an exception: it runs a non-login `bash -c`

--- a/src/containers/workspace/bash.bashrc
+++ b/src/containers/workspace/bash.bashrc
@@ -4,7 +4,7 @@
 #
 # NOTE: environment exports (PATH=/opt/klangk/bin, EDITOR) live in
 # /etc/profile.d/klangk-*.sh so that non-interactive login shells (bash -lc
-# — e.g. `klangkc exec`) see them too. This file is only sourced
+# — e.g. `klangk exec`) see them too. This file is only sourced
 # for interactive shells, so anything placed here is invisible to one-shot
 # non-interactive commands. See issue #1093. (The workspace health check is
 # the exception: it runs a non-login `bash -c` and sources nothing — see

--- a/src/containers/workspace/klangk-copy-to-clipboard.py
+++ b/src/containers/workspace/klangk-copy-to-clipboard.py
@@ -8,7 +8,7 @@ Two strategies, tried in order:
 
 1. **Bridge** (web frontend): POST clipboard_write to the browser-delegate
    bridge endpoint, which tells the Flutter app to call Clipboard.setData.
-2. **OSC 52** (klangkc shell / any terminal): emit the OSC 52 escape
+2. **OSC 52** (klangk shell / any terminal): emit the OSC 52 escape
    sequence so the outer terminal emulator copies to the system clipboard.
    Supported by iTerm2, Windows Terminal, kitty, alacritty, foot, etc.
 """
@@ -113,7 +113,7 @@ def main():
 
     browser_id = _get_browser_id()
 
-    # "klangkshell" sentinel means we're in klangkc shell (CLI), not a
+    # "klangkshell" sentinel means we're in klangk shell (CLI), not a
     # browser — skip the bridge and go straight to OSC 52.
     if browser_id == "klangkshell":
         _osc52(text)

--- a/src/containers/workspace/profile.d/klangk-editor.sh
+++ b/src/containers/workspace/profile.d/klangk-editor.sh
@@ -2,7 +2,7 @@
 # Default editor for git commit messages, crontab -e, etc.
 #
 # In /etc/profile.d (not /etc/bash.bashrc) so that non-interactive login
-# shells — e.g. `klangkc exec` running `git commit` — see EDITOR too.
+# shells — e.g. `klangk exec` running `git commit` — see EDITOR too.
 # /etc/bash.bashrc only loads for interactive shells, which would hide
 # this from one-shot commands. See issue #1093.
 # (The workspace health check is NOT a consumer of this: it runs a

--- a/src/containers/workspace/profile.d/klangk-path.sh
+++ b/src/containers/workspace/profile.d/klangk-path.sh
@@ -6,7 +6,7 @@
 # clobbering the /opt/klangk/bin prefix that the Dockerfile ENV sets. This
 # snippet re-prepends it so EVERY login shell finds pi and the
 # klangk-* helpers — including non-interactive login shells (`bash -lc`),
-# which is what `klangkc exec` uses.
+# which is what `klangk exec` uses.
 # /etc/bash.bashrc was the wrong home because it is only sourced for
 # interactive shells; a non-interactive login shell never saw the export.
 #

--- a/src/containers/workspace/tmux.conf
+++ b/src/containers/workspace/tmux.conf
@@ -22,7 +22,7 @@ set -gs terminal-features 'xterm*:extkeys'
 # convention). See #384 for full research on why this is unavoidable.
 #
 # Selections auto-copy to the browser's system clipboard via the bridge
-# (klangk-copy-to-clipboard). In klangkc shell (CLI), Shift+drag gives
+# (klangk-copy-to-clipboard). In klangk shell (CLI), Shift+drag gives
 # native terminal selection (viewport-only); plain drag uses tmux
 # selection (cross-viewport, routed to clipboard via bridge).
 set -g mouse on

--- a/src/frontend/e2e-tests/demo/1505-reconciliation.md
+++ b/src/frontend/e2e-tests/demo/1505-reconciliation.md
@@ -113,7 +113,7 @@ single-quoted because `.demo-env` is `source`d by bash: unquoted
 
 ### 10. KLANGK_ALLOW_AUTOSTART=1 in .demo-env (run-demo-backend.sh)
 
-Scene 3 (`klangkc sandbox`) creates a workspace with `auto_start: true` from the
+Scene 3 (`klangk sandbox`) creates a workspace with `auto_start: true` from the
 sandbox config. The server rejects this with 400 unless `KLANGK_ALLOW_AUTOSTART=1`
 is set. Added to the managed `.demo-env` block and the idempotency guard.
 

--- a/src/frontend/e2e-tests/demo/README.md
+++ b/src/frontend/e2e-tests/demo/README.md
@@ -1,6 +1,6 @@
 # Klangk Intro Video — demo scene scripts
 
-Scripts that drive the klangk web UI **and** the `klangkc` CLI through each scene
+Scripts that drive the klangk web UI **and** the `klangk` CLI through each scene
 of the intro video (`videoscript.md`), recording video you can voice over and cut
 together in DaVinci Resolve. This is **not** part of the CI test suite — it's a
 recording harness, separate from `../e2e/` (the real Playwright config explicitly
@@ -12,8 +12,8 @@ recorders:
 - **Web-UI scenes** (5, 6, 6b, 7, 8, 9, 10) — driven by **Playwright**
   against the Flutter web app (`record-demo.sh` wraps the Xvfb + ffmpeg
   capture). See "Running a web-UI scene" below.
-- **CLI scenes** (2, 3, 4) — host-terminal work (`klangkc shell`, `git clone`,
-  `klangkc sandbox`) that Playwright can't drive. Driven by **`record-terminal.sh`**
+- **CLI scenes** (2, 3, 4) — host-terminal work (`klangk shell`, `git clone`,
+  `klangk sandbox`) that Playwright can't drive. Driven by **`record-terminal.sh`**
   - `cli_demo.py` (Xvfb + xterm + tmux + ffmpeg). See "CLI terminal scenes"
     below.
 
@@ -187,8 +187,8 @@ that recording, and trim dead air in DaVinci (or narrate over it).
 
 ## CLI terminal scenes (`record-terminal.sh` + `cli_demo.py`)
 
-The CLI scenes (2, 3, 4) drive a real terminal — `klangkc login`, `klangkc
-create`, `klangkc shell`, `klangkc sandbox`, `git clone`, `klangkc monitor` —
+The CLI scenes (2, 3, 4) drive a real terminal — `klangk login`, `klangk
+create`, `klangk shell`, `klangk sandbox`, `git clone`, `klangk monitor` —
 which Playwright can't touch. The recorder scripts a terminal and captures it as
 a **true 1080p** `.mp4` with no manual recording.
 
@@ -204,7 +204,7 @@ same insight the web-UI harness (`record-demo.sh`) uses to beat Playwright's
    session.
 3. **tmux** — owns the pty. xterm _displays_ the session; the driver _writes_
    to it (`send-keys`) and reads it (`capture-pane`). It's also the persistence
-   layer (`klangkc shell` is tmux-backed, so this matches the real UX).
+   layer (`klangk shell` is tmux-backed, so this matches the real UX).
 4. **ffmpeg** (`x11grab`) — captures the whole Xvfb display into a true
    full-resolution `.mp4`.
 

--- a/src/frontend/e2e-tests/demo/cli_demo.py
+++ b/src/frontend/e2e-tests/demo/cli_demo.py
@@ -26,7 +26,7 @@ Scenes
 
     The built-in ``demo`` scene needs **no klangk server** — it's a
     self-contained smoke test so the recorder is verifiable anywhere. The
-    ``scene_2`` / ``scene_3`` / ``scene_4`` stubs drive the real ``klangkc``
+    ``scene_2`` / ``scene_3`` / ``scene_4`` stubs drive the real ``klangk``
     CLI and require a live server (see ``README.md``).
 """
 
@@ -185,7 +185,7 @@ class Term:
         prompt, steady cursor — see ``record-terminal.sh``), so it looks
         identical to the first pane and becomes the active pane. ``-v`` stacks
         the panes (horizontal divider) so each gets the full terminal width —
-        important for scene 3b's long ``klangkc monitor | jq .`` JSON lines.
+        important for scene 3b's long ``klangk monitor | jq .`` JSON lines.
         The split is a tmux control call, so it never appears as typed text in
         the recording.
         """
@@ -226,7 +226,7 @@ class Term:
 
         Unlike :meth:`_send` (which is literal), this is interpreted by
         tmux as a key name so modifiers like Ctrl work. Used for
-        interrupts (Ctrl+C on a long-running ``klangkc monitor``).
+        interrupts (Ctrl+C on a long-running ``klangk monitor``).
         """
         subprocess.run(["tmux", "send-keys", "-t", self.session, key], check=True)
 
@@ -286,7 +286,7 @@ def scene_demo(t: Term) -> None:
 def _row_healthy(pane: str, name: str = "openclaw") -> bool:
     """True if the ``name`` workspace row shows ``healthy`` in the pane.
 
-    Used while ``watch klangkc ls`` refreshes the Status column live: Rich
+    Used while ``watch klangk ls`` refreshes the Status column live: Rich
     strips color under the non-TTY watch capture, so the status reads as plain
     text. A per-line check for both the workspace name and ``healthy`` is
     reliable (the table header says "Status", not "healthy").
@@ -351,7 +351,7 @@ def scene_2(t: Term) -> None:
     The hero user is ``admin@example.com`` (created once via the admin API).
     This scene creates the ``demo`` workspace, which is KEPT for continuity —
     the browser scenes later operate on the same workspace. Requires a live
-    klangk server reachable by ``klangkc`` (see README).
+    klangk server reachable by ``klangk`` (see README).
     """
     # The CLI transport is the UDS (uvicorn's socket, direct). record-cli.sh
     # sets KLANGK_DEMO_SERVER to the socket path; this default matches for
@@ -374,9 +374,9 @@ def scene_2(t: Term) -> None:
     t.pause(5)
 
     # --- login --------------------------------------------------------
-    # No narration is printed — the voiceover covers it. klangkc login prompts
+    # No narration is printed — the voiceover covers it. klangk login prompts
     # for a password (masked, no echo).
-    t.type(f"klangkc login {server} {admin}", per_char=0.03)
+    t.type(f"klangk login {server} {admin}", per_char=0.03)
     t.enter()
     t.expect("Password", timeout=15)
     t.type(password, per_char=0.06)  # masked: no echo, but type at demo speed
@@ -385,14 +385,14 @@ def scene_2(t: Term) -> None:
     t.pause(HOLD)
 
     # --- create -------------------------------------------------------
-    t.type("klangkc create demo", per_char=0.03)
+    t.type("klangk create demo", per_char=0.03)
     t.enter()
     t.expect("Created workspace", timeout=30)
     t.pause(HOLD)
 
     # --- FIRST shell: drop into the container (plain) ----------------
     # Demonstrate the container experience, then reconnect with -A to clone.
-    t.type("klangkc shell demo", per_char=0.03)
+    t.type("klangk shell demo", per_char=0.03)
     t.enter()
     t.expect("Escape: Enter", timeout=15)  # the "~." hint line
     _wait_remote(t, timeout=20)
@@ -409,7 +409,7 @@ def scene_2(t: Term) -> None:
     _disconnect_ssh(t, hold=HOLD)
 
     # --- SECOND shell: re-enter with agent forwarding (-A) -------------
-    t.type("klangkc shell demo -A", per_char=0.03)
+    t.type("klangk shell demo -A", per_char=0.03)
     t.enter()
     t.expect("Escape: Enter", timeout=15)
     _wait_remote(t, timeout=20)
@@ -465,7 +465,7 @@ def scene_2(t: Term) -> None:
     # Connect to a NAMED window ("terminal2") — a separate terminal in the
     # same workspace (created if absent), not the active one. Shows that one
     # workspace can have several CLI terminals open at once.
-    t.type("klangkc shell demo terminal2", per_char=0.03)
+    t.type("klangk shell demo terminal2", per_char=0.03)
     t.enter()
     t.expect("Escape: Enter", timeout=15)
     _wait_remote(t, timeout=20)
@@ -489,11 +489,11 @@ def scene_2(t: Term) -> None:
     _disconnect_ssh(t, hold=HOLD)
 
     # --- list workspaces from the host ---------------------------------
-    # klangkc ls is a quick API call; `demo` (and any seeded workspaces) show.
+    # klangk ls is a quick API call; `demo` (and any seeded workspaces) show.
     # No `expect` here: any plausible marker ("demo", the "Name" header) would
-    # false-match scrollback (e.g. the earlier `klangkc shell demo` line), so
+    # false-match scrollback (e.g. the earlier `klangk shell demo` line), so
     # a fixed pause is safer for this final beat.
-    t.type("klangkc ls", per_char=0.03)
+    t.type("klangk ls", per_char=0.03)
     t.enter()
     t.pause(3)
     t.pause(HOLD)
@@ -501,7 +501,7 @@ def scene_2(t: Term) -> None:
 
 
 def scene_3(t: Term) -> None:
-    """klangkc sandbox: one config, one command (~1.5 min).
+    """klangk sandbox: one config, one command (~1.5 min).
 
     The sandbox-concept scene — **CLI only** (no browser). Shows that a
     checked-in config file plus one command reproduces a full dev
@@ -534,13 +534,13 @@ def scene_3(t: Term) -> None:
     # step 2 — create the workspace from the sandbox config. Mounts
     # everything, runs setup (fast: pre-warmed + /openclaw is a mount),
     # starts the container.
-    t.type("klangkc sandbox openclaw sandboxes/openclaw", per_char=0.03)
+    t.type("klangk sandbox openclaw sandboxes/openclaw", per_char=0.03)
     t.enter()
     t.expect("Setup complete", timeout=360)
     t.pause(HOLD)
 
     # step 3 — connect, show the project mounted inside, then disconnect.
-    t.type("klangkc shell openclaw", per_char=0.03)
+    t.type("klangk shell openclaw", per_char=0.03)
     t.enter()
     t.expect("Escape: Enter", timeout=15)  # the "~." hint line
     _wait_remote(t, timeout=20)
@@ -572,7 +572,7 @@ def scene_3b(t: Term) -> None:
     (``clanker:service-cmd``) in the bottom pane to see the gateway's logs,
     then watch live ``service_health`` events in the top pane. Ctrl+C the
     gateway to trigger an ``unhealthy`` event, then recover via
-    ``klangkc restart openclaw`` (the service command re-fires on the fresh
+    ``klangk restart openclaw`` (the service command re-fires on the fresh
     container -- #1244/#1246). Narrate over the whole arc.
 
     Carries the same preconditions as Scene 3 (live server, autostart on,
@@ -593,10 +593,10 @@ def scene_3b(t: Term) -> None:
     # ``workspace:`` lines while you say this.)
     t.pause(HOLD)
 
-    # step 2 — klangkc ls: the Status column shows openclaw as healthy
+    # step 2 — klangk ls: the Status column shows openclaw as healthy
     # (green). Narrate: the service command is running and its health
     # check is passing — everything the CLI knows, right here.
-    t.type("klangkc ls", per_char=0.03)
+    t.type("klangk ls", per_char=0.03)
     t.enter()
     t.pause(3)  # let the table land
     t.pause(HOLD)
@@ -608,7 +608,7 @@ def scene_3b(t: Term) -> None:
     top = t.pane_id()
     bottom = t.split()
     t.pause(HOLD)
-    t.type("klangkc shell openclaw clanker:service-cmd", per_char=0.03)
+    t.type("klangk shell openclaw clanker:service-cmd", per_char=0.03)
     t.enter()
     t.expect("Escape: Enter", timeout=20)  # the "~." hint = joined
     t.pause(HOLD)  # let the gateway logs stream
@@ -618,7 +618,7 @@ def scene_3b(t: Term) -> None:
     # Narrate: exit 0 = healthy; you can wire a command (-- sh -c '...')
     # to fire on change (e.g. a Slack alert). jq pretty-prints the JSON.
     t.select_pane(top)
-    t.type("klangkc monitor --type service_health | jq .", per_char=0.03)
+    t.type("klangk monitor --type service_health | jq .", per_char=0.03)
     t.enter()
     t.expect("service_health", timeout=30)
     t.pause(HOLD)
@@ -648,27 +648,27 @@ def scene_3b(t: Term) -> None:
     t.select_pane(top)  # focus survives, but be explicit
     t.pause(HOLD)
 
-    # step 7 — recovery via `klangkc restart openclaw` (#1244/#1246).
+    # step 7 — recovery via `klangk restart openclaw` (#1244/#1246).
     # Restarting the workspace stops + removes the container, then creates a
     # fresh one -- and the service command RE-FIRES on every fresh container
     # create (the #1244/#1246 fix), so the gateway comes back on its own.
     # Watch the Status column live: stopped -> starting -> healthy. ``watch``
-    # does the repeated refresh for us -- no re-typing klangkc ls. Ctrl+C once
+    # does the repeated refresh for us -- no re-typing klangk ls. Ctrl+C once
     # the openclaw row reads healthy again. (This window is trimmed in edit.)
     # Per-workspace restart (not a full-server SIGHUP), so the `demo` workspace
     # and the rest of the recording are untouched -- scene 3b no longer has to
     # be recorded last.
     t.run("clear")
-    t.type("klangkc restart openclaw", per_char=0.03)
+    t.type("klangk restart openclaw", per_char=0.03)
     t.enter()
     # restart blocks until the fresh container is created (stop+remove+start
     # is one synchronous request). Wait for its COMPLETION line -- NOT
     # "host $", which is already in the pane as the echoed command's prompt
-    # prefix ("host $ klangkc restart openclaw") and would match instantly,
+    # prefix ("host $ klangk restart openclaw") and would match instantly,
     # typing watch into the still-running restart.
     t.expect("Restarted workspace openclaw", timeout=60)
     t.pause(1)
-    t.type("watch -n 3 klangkc ls", per_char=0.03)
+    t.type("watch -n 3 klangk ls", per_char=0.03)
     t.enter()
     t.pause(4)  # let the first watch frame land
     deadline = time.monotonic() + 180
@@ -692,9 +692,9 @@ def scene_4(t: Term) -> None:
     """openclaw service sandbox (~1.5 min). Requires a live server."""
     _intro(t, "A long-lived service: openclaw")
     t.run("cd sandboxes/openclaw", expect="$")
-    t.run("klangkc sandbox openclaw", expect="$", timeout=180)
+    t.run("klangk sandbox openclaw", expect="$", timeout=180)
     t.pause(1.0)
-    t.run("klangkc monitor --type service_health | jq .", expect="$", timeout=20)
+    t.run("klangk monitor --type service_health | jq .", expect="$", timeout=20)
     t.pause(1.0)
 
 

--- a/src/frontend/e2e-tests/demo/collab-choreography.ts
+++ b/src/frontend/e2e-tests/demo/collab-choreography.ts
@@ -49,7 +49,7 @@ import {
   connectWs,
   getMeId,
   captureContainerPane,
-  klangkcExec,
+  klangkExec,
   type DemoWs,
 } from "./demo-helpers";
 
@@ -404,7 +404,7 @@ export async function resetCollabState(ctx: CollabCtx): Promise<void> {
   // window directly, bypassing the grouped-session / WS routing that causes
   // desync.
   try {
-    klangkcExec(
+    klangkExec(
       ctx.workspaceName,
       `tmux send-keys -t ${ctx.ownerUserId}:${ctx.scratchWindowName} C-l`,
     );
@@ -701,11 +701,11 @@ async function performSidechannel(ctx: CollabCtx, beat: Beat): Promise<void> {
     // Owner sidechannel (teammate perspective): terminal_input via the WS
     // routes to the grouped session's active window, which defaults to 0
     // (bash) after terminal_start.  Bypass the WS entirely and send keys
-    // directly to the correct tmux window via klangkc exec so the input
+    // directly to the correct tmux window via klangk exec so the input
     // lands in scratch (not pi in bash).
     if (beat.actor === "owner" && ctx.perspective === "teammate") {
       const escaped = beat.text.replace(/'/g, "'\\''");
-      klangkcExec(
+      klangkExec(
         ctx.workspaceName,
         `tmux send-keys -t ${ctx.ownerUserId}:${ctx.scratchWindowName} '${escaped}' Enter`,
       );
@@ -781,13 +781,13 @@ async function waitForPaneTextShallow(
   // The shared terminal's window name is ctx.scratchWindowName in the owner's
   // tmux session (ownerUserId). captureContainerPane takes (workspace, session,
   // window, lines) where window is an int index — but our window is named, not
-  // necessarily index 2. Use the bash helper directly via klangkcExec through
+  // necessarily index 2. Use the bash helper directly via klangkExec through
   // the owner WS? Simpler: capture by session+window-name using tmux's name
   // form. We approximate by capturing the owner session across a few windows.
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     try {
-      // Try the named window directly via klangkcExec (captureContainerPane
+      // Try the named window directly via klangkExec (captureContainerPane
       // only takes an int window; replicate its tmux call with a window name).
       // eslint-disable-next-line @typescript-eslint/no-require-imports
       const { execFileSync } = require("node:child_process") as {
@@ -795,7 +795,7 @@ async function waitForPaneTextShallow(
       };
       const server = process.env.KLANGK_TEST_URL || "http://localhost:8996";
       const pane = execFileSync(
-        "klangkc",
+        "klangk",
         [
           "--server",
           server,

--- a/src/frontend/e2e-tests/demo/demo-helpers.ts
+++ b/src/frontend/e2e-tests/demo/demo-helpers.ts
@@ -58,7 +58,7 @@ export const DEMO_HERO_EMAIL = DEMO_ADMIN_EMAIL;
 export const DEMO_HERO_PASSWORD = DEMO_ADMIN_PASSWORD;
 
 /** The single shared workspace every web-UI scene accumulates into. Created
- *  on-camera by CLI Scene 2 (`klangkc create demo`) and carried forward: the
+ *  on-camera by CLI Scene 2 (`klangk create demo`) and carried forward: the
  *  web-UI scenes operate this SAME workspace so clanker's app.py (Sc 5)
  *  survives into the Files tab (Sc 6), the collaboration (Sc 7), etc. */
 export const SHARED_WORKSPACE = "demo";
@@ -717,7 +717,7 @@ export function terminalTabCenterPx(tabIndex: number): number {
  *  `existingTabs` = how many tabs are already open BEFORE this click (the
  *  "+" sits right after the last one). A fresh single-terminal workspace
  *  passes 1 ("+" at fracX ≈ 0.145); the hero `demo` workspace passes 2
- *  because scene 2's `klangkc shell demo terminal2` left a second window
+ *  because scene 2's `klangk shell demo terminal2` left a second window
  *  that shows up as a tab ("+" at fracX ≈ 0.272). */
 export const addTerminalTab = (page: Page, existingTabs = 1) => {
   const { width, height } = vp(page);
@@ -755,7 +755,7 @@ export async function waitForTerminal(
 // Container tmux introspection (side channel for live-agent scenes).
 // ---------------------------------------------------------------------------
 // The container's shell IS a tmux session (named <user-id>), so a side
-// `klangkc exec` can read the VERY SAME pane the browser Terminal tab renders.
+// `klangk exec` can read the VERY SAME pane the browser Terminal tab renders.
 // Live-agent scenes (5b) use this to detect pi's completion deterministically
 // (e.g. "Successfully installed", the hosted URL, or an idle status line)
 // WITHOUT on-screen OCR or fixed timeouts -- the browser types the prompts
@@ -764,15 +764,15 @@ export async function waitForTerminal(
 
 import { execFileSync } from "node:child_process";
 
-/** Run `klangkc exec <workspace> bash -lc <cmd>` and return stdout. Points at
+/** Run `klangk exec <workspace> bash -lc <cmd>` and return stdout. Points at
  *  the demo server (KLANGK_DEMO_SERVER / KLANGK_TEST_URL). Throws on non-zero
  *  exit so callers fail fast. */
-export function klangkcExec(
+export function klangkExec(
   workspace: string,
   cmd: string,
   extraEnv: Record<string, string> = {},
 ): string {
-  // klangkcExec uses the UDS (same login token as the CLI scenes) rather than
+  // klangkExec uses the UDS (same login token as the CLI scenes) rather than
   // the TCP URL, so browser-scene prep doesn't need a separate TCP login.
   const stateDir = process.env.KLANGK_DEMO_STATE_DIR || "/tmp/klangk-demo";
   const server =
@@ -780,7 +780,7 @@ export function klangkcExec(
     process.env.KLANGK_DEMO_SERVER ||
     `${stateDir}/klangk.sock`;
   return execFileSync(
-    "klangkc",
+    "klangk",
     ["--server", server, "exec", workspace, "bash", "-lc", cmd],
     {
       env: { ...process.env, ...extraEnv },
@@ -799,7 +799,7 @@ export function captureContainerPane(
   window = 0,
   lines = 12,
 ): string {
-  return klangkcExec(
+  return klangkExec(
     workspace,
     `tmux capture-pane -t ${session}:${window} -p -S -${lines}`,
   );
@@ -813,7 +813,7 @@ export function sendContainerKey(
   key: string,
   window = 0,
 ): void {
-  klangkcExec(workspace, `tmux send-keys -t ${session}:${window} ${key}`);
+  klangkExec(workspace, `tmux send-keys -t ${session}:${window} ${key}`);
 }
 
 /** Wait until the container pane contains `needle` (substring or RegExp),

--- a/src/frontend/e2e-tests/demo/record-cli.sh
+++ b/src/frontend/e2e-tests/demo/record-cli.sh
@@ -9,7 +9,7 @@
 #   record-cli.sh 3b     record Scene 3b only
 #   record-cli.sh all    record 2 → 3 → 3b in sequence
 #
-# State flow (the recording shell shares $HOME, so klangkc login state and the
+# State flow (the recording shell shares $HOME, so klangk login state and the
 # container layer persist between takes):
 #   Scene 2  prep: seed --reset (full repave → only potemkin remain) + logout
 #                 → records an on-camera login + create
@@ -59,7 +59,7 @@ SCENE="${1:-}"
 # Filter devenv shell's progress noise so only real output shows.
 quiet() { grep -vE "Validating|^•|Configuring|cachix|Evaluating|Loading|Running|✓ Running tasks|warning: Substituter|Using config|^✓ " || true; }
 
-kc() { devenv shell -- klangkc "$@" 2>&1 | quiet; }
+kc() { devenv shell -- klangk "$@" 2>&1 | quiet; }
 
 # Ensure the dedicated demo backend is up (start it if not). Idempotent.
 ensure_backend() {
@@ -83,7 +83,7 @@ current_user() {
 
 # Ensure we're logged in as $HERO WITHOUT tearing down containers.
 #
-# IMPORTANT: `klangkc logout` makes the backend stop the logging-out user's
+# IMPORTANT: `klangk logout` makes the backend stop the logging-out user's
 # containers (api/auth.logout -> session.logout_user -> stop_and_remove).
 # So a naive "logout then login" here would kill the openclaw container that
 # Scene 3 created and that Scene 3b must inherit ALREADY healthy (to show
@@ -99,7 +99,7 @@ ensure_logged_in() {
   fi
   echo "  [prep] login as $HERO (was: ${cur:-logged out})"
   [ -n "$cur" ] && kc logout "$SERVER" >/dev/null 2>&1 || true
-  printf "%s" "$PASS" | devenv shell -- klangkc login --password-file - "$SERVER" "$HERO" 2>&1 | quiet | tail -1
+  printf "%s" "$PASS" | devenv shell -- klangk login --password-file - "$SERVER" "$HERO" 2>&1 | quiet | tail -1
 }
 
 rm_ws() {

--- a/src/frontend/e2e-tests/demo/record-terminal.sh
+++ b/src/frontend/e2e-tests/demo/record-terminal.sh
@@ -134,9 +134,9 @@ echo "  Xvfb up (pid $XVFB_PID)"
 # --- 2. tmux session (shared rc-file shell) + xterm ----------------------
 # Every pane — the session shell AND any `split-window` the driver creates —
 # runs `bash --rcfile` against one generated file, so they share an identical
-# setup: the klangk venv on PATH (so `klangkc` resolves), the clean `host $ `
+# setup: the klangk venv on PATH (so `klangk` resolves), the clean `host $ `
 # prompt (NOT devenv shell, so no powerline/starship banner to hide), the
-# forwarded SSH agent socket (so `klangkc shell -A` works), and a steady
+# forwarded SSH agent socket (so `klangk shell -A` works), and a steady
 # non-blinking cursor. Writing it once — instead of typing the exports into
 # the session via send-keys — keeps startup reliable and lets split panes
 # inherit the same environment with no extra typing on camera.

--- a/src/frontend/e2e-tests/demo/run-demo-backend.sh
+++ b/src/frontend/e2e-tests/demo/run-demo-backend.sh
@@ -12,7 +12,7 @@
 #
 #   backend (uvicorn):     127.0.0.1:$KLANGK_PORT  (.demo-env -> 8998; TCP because
 #                                                  KLANGK_LISTEN=127.0.0.1)
-#   nginx (klangkc target)::$KLANGK_EGRESS_PORT     (.demo-env -> 8996)
+#   nginx (klangk target)::$KLANGK_EGRESS_PORT     (.demo-env -> 8996)
 #   instance id:           "video"   (unique pid file + container labels)
 #
 # KLANGK_LISTEN=127.0.0.1 is load-bearing: post-#1400 the default listen is

--- a/src/frontend/e2e-tests/demo/scenes/scene-05b-pi-debug.ts
+++ b/src/frontend/e2e-tests/demo/scenes/scene-05b-pi-debug.ts
@@ -3,7 +3,7 @@
  *
  * CONTINUITY: still in the hero's `demo` workspace (from Sc 2/4/5), Terminal
  * tab. A BROWSER scene (Playwright drives the web Terminal tab; this is NOT a
- * klangkc-shell CLI scene — scenes 2/3/3b are the shell scenes, 4/5/5b are
+ * klangk-shell CLI scene — scenes 2/3/3b are the shell scenes, 4/5/5b are
  * browser).
  *
  * THREE terminal tabs are already open from Sc 2 + Sc 4 (left → right):
@@ -25,7 +25,7 @@
  *
  * The browser types every prompt/command visibly for the camera, but the scene
  * does NOT use fixed timeouts for pi's LIVE turns: the container's shell IS a
- * tmux session (named <user-id>), so a side `klangkc exec` reads the bash pane
+ * tmux session (named <user-id>), so a side `klangk exec` reads the bash pane
  * (window 0) — the VERY same pane the browser renders. waitForPaneText /
  * waitForPiIdle detect pi's completion deterministically. The scratch/terminal2
  * beats are deterministic shell commands (instant output), so they use fixed
@@ -55,7 +55,7 @@ import {
   getMeId,
   openWorkspaceDemo,
   waitForTerminal,
-  klangkcExec,
+  klangkExec,
   waitForPaneText,
   waitForPiIdle,
   getWorkspaceStatus,
@@ -99,7 +99,7 @@ test("pi debug", async ({ page, context, request }) => {
   // port (the stale flask app), never the cleanup shell itself — a pkill/pgrep
   // on "app.py" or "python" self-matches this very command line and exits 137
   // (SIGKILL). Each stage || true; the trailing echo fixes exit 0.
-  klangkcExec(
+  klangkExec(
     ws.name,
     "fuser -k 8000/tcp 2>/dev/null || true; " +
       "cd ~ && rm -f app.py requirements.txt && rm -rf .venv; " +
@@ -184,7 +184,7 @@ test("pi debug", async ({ page, context, request }) => {
   // virtualenv — terminal2's bare `python3 app.py` uses system python). This
   // guarantees terminal2's on-camera run serves on 8000 regardless of what pi
   // did. Invisible to the recording.
-  klangkcExec(
+  klangkExec(
     ws.name,
     "fuser -k 8000/tcp 2>/dev/null || true; " +
       "pip install flask >/dev/null 2>&1 || true; echo ready",

--- a/src/frontend/e2e-tests/demo/scenes/scene-08-plugins.ts
+++ b/src/frontend/e2e-tests/demo/scenes/scene-08-plugins.ts
@@ -14,7 +14,7 @@
  * /opt/klangk/pi-agent/extensions/boingball.ts), so there's no image-rebuild
  * prep — it's available in any workspace, instantly, with no setup script.
  * That zero-startup-cost, baked-at-build-time property is the whole point of
- * the scene's VO (vs the klangkc sandbox setup scripts from Sc 3).
+ * the scene's VO (vs the klangk sandbox setup scripts from Sc 3).
  *
  * How the animation works: pi calls the `boing` tool (registered by the
  * boingball extension). The tool POSTs `{action:"boing", browser_id}` to the

--- a/src/frontend/e2e-tests/demo/seed-demo-pdf.ts
+++ b/src/frontend/e2e-tests/demo/seed-demo-pdf.ts
@@ -2,7 +2,7 @@
  * Seed the Pyramid PDF into the hero's `demo` workspace home.
  *
  * Run this RIGHT AFTER the demo container is created (Scene 2's
- * `klangkc create demo`), so the file is present for Scene 6 (File Browser) to
+ * `klangk create demo`), so the file is present for Scene 6 (File Browser) to
  * browse. Idempotent — a re-run just overwrites. Called by record-cli.sh after
  * the CLI pass; also safe to run standalone for a browser-only continuation:
  *
@@ -11,7 +11,7 @@
  *
  * Standalone (no Playwright): uses node's global fetch + child_process. Logs
  * in as the hero, finds `demo`, resolves the container's $HOME off-camera via
- * `klangkc exec`, and uploads the PDF via the files/upload API (which needs the
+ * `klangk exec`, and uploads the PDF via the files/upload API (which needs the
  * container running).
  */
 import { readFileSync } from "node:fs";
@@ -48,10 +48,10 @@ async function findWorkspace(token: string): Promise<string> {
 }
 
 function containerHome(name: string): string {
-  // klangkc exec resolves the hero's per-user home symlink off-camera.
+  // klangk exec resolves the hero's per-user home symlink off-camera.
   const server = DEMO_URL;
   return execFileSync(
-    "klangkc",
+    "klangk",
     ["--server", server, "exec", name, "bash", "-lc", "echo -n $HOME"],
     { encoding: "utf-8" },
   ).trim();

--- a/src/frontend/e2e-tests/demo/videoscript.md
+++ b/src/frontend/e2e-tests/demo/videoscript.md
@@ -12,16 +12,16 @@ One continuous story across a single evolving workspace, **`demo`**, created
 on camera in Scene 2 and kept alive through every scene after. State
 accumulates shot to shot:
 
-| Workspace  | Born in                                    | Owner               | Role in the video                                                                                                                                                                                                                                                   |
-| ---------- | ------------------------------------------ | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`demo`** | Scene 2 (`klangkc create demo`, on camera) | `admin@example.com` | **Hero.** Kept alive through every scene after. Accumulates: cloned klangk repo + Pi session (Sc 2) → clanker's Flask app `app.py`/`requirements.txt` (Sc 5) → debugged, running app (Sc 5b) → browsed files + Pyramid PDF (Sc 6) → shared with the team (Sc 7/7b). |
-| `openclaw` | Scene 3 (`klangkc sandbox openclaw`)       | `admin@example.com` | Self-contained sandbox + service feature demo. Stays in the list (green health icon); its Service tab + hosted app are shown in Sc 3b/4.                                                                                                                            |
-| Potemkin   | Pre-seeded (see Accounts below)            | various             | Decorative — fill every account's list so it looks lived-in. Never opened on camera.                                                                                                                                                                                |
+| Workspace  | Born in                                   | Owner               | Role in the video                                                                                                                                                                                                                                                   |
+| ---------- | ----------------------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`demo`** | Scene 2 (`klangk create demo`, on camera) | `admin@example.com` | **Hero.** Kept alive through every scene after. Accumulates: cloned klangk repo + Pi session (Sc 2) → clanker's Flask app `app.py`/`requirements.txt` (Sc 5) → debugged, running app (Sc 5b) → browsed files + Pyramid PDF (Sc 6) → shared with the team (Sc 7/7b). |
+| `openclaw` | Scene 3 (`klangk sandbox openclaw`)       | `admin@example.com` | Self-contained sandbox + service feature demo. Stays in the list (green health icon); its Service tab + hosted app are shown in Sc 3b/4.                                                                                                                            |
+| Potemkin   | Pre-seeded (see Accounts below)           | various             | Decorative — fill every account's list so it looks lived-in. Never opened on camera.                                                                                                                                                                                |
 
 **Rules:**
 
 - Whenever a scene says "open a workspace", it means **open the `demo` workspace**.
-- **Do not `klangkc rm demo` during the run** — it must survive into the next
+- **Do not `klangk rm demo` during the run** — it must survive into the next
   scene. `rm` is mentioned verbally in Sc 2 as the eventual cleanup, not
   executed on `demo`.
 - Record the browser arc (Sc 4→5→5b→6→7→7b) **in order**, against the same live
@@ -40,7 +40,7 @@ accumulates shot to shot:
       Sc 3/3b service scene).
 - [ ] **Real LLM key configured** for the proxy. The clanker chat scene AND the
       openclaw scene both depend on the LLM proxy actually working. Test it.
-- [ ] `jq` installed locally (for the `klangkc monitor | jq .` beat).
+- [ ] `jq` installed locally (for the `klangk monitor | jq .` beat).
 - [ ] For Sc 3b's unhealthy beat: `KLANGK_HEALTH_CHECK_INTERVAL=10` set (snappier
       flip on camera; product default is 30s). Needs a **full** backend restart
       (not SIGHUP) — set it off camera, before recording.
@@ -99,9 +99,9 @@ script firing synthetic events.
 
 > Recording a fresh install live is the #1 way to waste a take.
 
-- [ ] **openclaw sandbox:** run `klangkc sandbox openclaw` once off-camera so the
+- [ ] **openclaw sandbox:** run `klangk sandbox openclaw` once off-camera so the
       nvm + Node 24 + openclaw download is done. On-camera, keep the workspace
-      and `klangkc restart openclaw` (fast — install guards fire because
+      and `klangk restart openclaw` (fast — install guards fire because
       `/openclaw` is a mount).
 - [ ] **A repo to clone** in the CLI scene: `git@github.com:mcdonc/klangk.git`.
       Verify `ssh-add -l` shows your key so `-A` works.
@@ -119,14 +119,14 @@ script firing synthetic events.
 - [ ] **CLI scenes** are driven by `cli_demo.py` (xterm+tmux+ffmpeg via
       `record-terminal.sh`). Cursor must not blink (`xterm cursorBlink:false` +
       `PROMPT_COMMAND='printf "\033[2 q"'`). Plain `host $` host prompt; venv on
-      PATH for `klangkc`. ≥5s pauses between commands (`KLANGK_DEMO_HOLD`,
+      PATH for `klangk`. ≥5s pauses between commands (`KLANGK_DEMO_HOLD`,
       default 5).
 
 ### Master reset (between full re-runs)
 
 ```bash
-klangkc rm demo            # hero workspace — wipes the accumulated state
-klangkc rm openclaw        # only if you want a truly fresh sandbox/service scene
+klangk rm demo            # hero workspace — wipes the accumulated state
+klangk rm openclaw        # only if you want a truly fresh sandbox/service scene
 # then re-run Sc 2, 3 to rebuild demo/openclaw on camera
 ```
 
@@ -171,25 +171,25 @@ I'll start by showing a solo workflow from the command line, then move to the we
 
 ## Scene 2 — The CLI — Creating Your First Workspace (2 minutes)
 
-_[Screen: local terminal, klangkc already installed]_
+_[Screen: local terminal, klangk already installed]_
 
-The CLI is called `klangkc`. You install it with pip and point it at your Klangk server. Let me log in.
+The CLI is called `klangk`. You install it with pip and point it at your Klangk server. Let me log in.
 
-_[Type: klangkc login admin@example.com]_
+_[Type: klangk login admin@example.com]_
 
 Now let me create a workspace.
 
-_[Type: klangkc create demo]_
+_[Type: klangk create demo]_
 
 That's it — a fresh Linux container with Python, Node, git, and build tools is now running. Let me drop into it.
 
-_[Type: klangkc shell demo]_
+_[Type: klangk shell demo]_
 
 This is an SSH-like connection into an Ubuntu container. I'm in a real bash shell on Linux, regardless of what my local machine is. Under the hood this is backed by tmux, so if I disconnect and reconnect, everything is exactly where I left it — same scrollback, same running processes.
 
 Let me do something useful. I'll clone a repo.
 
-_[Type: klangkc shell demo -A]_
+_[Type: klangk shell demo -A]_
 
 The `-A` flag forwards my local SSH agent into the container, so I can use my GitHub SSH keys without copying any private keys into the container.
 
@@ -211,7 +211,7 @@ _[Type: hostname — shows the container ID. Then: echo "$(hostname)" > ~/contai
 
 Now let me split my screen and connect again, this time to a named window.
 
-_[Split the terminal into two horizontally split panes. In the new (bottom) pane, type: klangkc shell demo terminal2]_
+_[Split the terminal into two horizontally split panes. In the new (bottom) pane, type: klangk shell demo terminal2]_
 
 Now I've got two terminals open to the same workspace, on top of each other. The second one connected to a separate, named window — "terminal2". And here's the proof that it's the same container:
 
@@ -221,16 +221,16 @@ Same hostname — because both terminals share one container. Each connection is
 
 _[Disconnect the second pane with ~. , then the first]_
 
-The container keeps running. Back at my host prompt, I can see all my workspaces with `klangkc ls` — there's `demo`, the one we just made.
+The container keeps running. Back at my host prompt, I can see all my workspaces with `klangk ls` — there's `demo`, the one we just made.
 
-_[Type: klangkc ls]_
+_[Type: klangk ls]_
 
-And when I'm eventually done with a workspace, `klangkc rm` tears it down and cleans up its files. But I'm going to keep this one around — we'll come back to it from the browser in a minute.
+And when I'm eventually done with a workspace, `klangk rm` tears it down and cleans up its files. But I'm going to keep this one around — we'll come back to it from the browser in a minute.
 
-> **Production —** _on screen:_ local terminal, `klangkc` installed, clean
+> **Production —** _on screen:_ local terminal, `klangk` installed, clean
 > prompt. _pre-roll:_ confirm `ssh-add -l` lists your key; repo is
 > `git@github.com:mcdonc/klangk.git`; have `pi` functional in a workspace (test
-> the prompt once off-camera). _reset:_ `klangkc rm demo && klangkc create demo`
+> the prompt once off-camera). _reset:_ `klangk rm demo && klangk create demo`
 > — but only for a full arc re-run, since `demo` must survive into Sc 4–7.
 > _gotchas:_ the `pi` interaction is **live/nondeterministic** — one long take,
 > leave dead air, narrate over later; `-A` must actually work (test first); the
@@ -238,31 +238,31 @@ And when I'm eventually done with a workspace, `klangkc rm` tears it down and cl
 > split-pane beat connects to a **named** window (`logs`) via a tmux control call
 > (it never appears as typed text).
 
-## Scene 3 — klangkc sandbox — One Command to Rule Them All (~1.5 minutes)
+## Scene 3 — klangk sandbox — One Command to Rule Them All (~1.5 minutes)
 
 _[Screen: local terminal, in a project directory]_
 
-Creating workspaces manually is fine, but the real power for solo developers is `klangkc sandbox`. You check a config file into your repo, and then one command sets up everything.
+Creating workspaces manually is fine, but the real power for solo developers is `klangk sandbox`. You check a config file into your repo, and then one command sets up everything.
 
 We have a sandbox config for `openclaw` in our repository.
 
 _[Type: cat sandboxes/openclaw/.klangk-sandbox.yaml — point at the mount-at and setup lines]_
 
-Here's what a sandbox config looks like — it mounts the project at a fixed path inside the container and runs a setup script to get it ready. When I run `klangkc sandbox openclaw`, it creates the workspace, mounts everything, and starts the container.
+Here's what a sandbox config looks like — it mounts the project at a fixed path inside the container and runs a setup script to get it ready. When I run `klangk sandbox openclaw`, it creates the workspace, mounts everything, and starts the container.
 
-_[Type: klangkc sandbox openclaw sandboxes/openclaw]_
+_[Type: klangk sandbox openclaw sandboxes/openclaw]_
 
 The idea is that you commit this config file to your repo. Any teammate — or future you on a different machine — runs the same command and gets the exact same environment. It's like a Dockerfile for your dev environment, but the container lifecycle is managed for you.
 
-You can connect to the workspace with `klangkc shell`.
+You can connect to the workspace with `klangk shell`.
 
-_[Type: klangkc shell openclaw]_
+_[Type: klangk shell openclaw]_
 
 > **Production —** _on screen:_ local terminal at the klangk repo root. _pre-roll:_
 > openclaw **pre-warmed** (Node install done off-camera); `jq` installed; LLM proxy
-> working (so the gateway comes up healthy, not red); confirm `klangkc ls` shows a
+> working (so the gateway comes up healthy, not red); confirm `klangk ls` shows a
 > **Status** column (post-#1207). _reset:_ keep the openclaw workspace and
-> `klangkc restart openclaw` (re-installs are slow); only `rm && sandbox` for a
+> `klangk restart openclaw` (re-installs are slow); only `rm && sandbox` for a
 > truly fresh take. _gotchas:_ **never record the first-run install live**;
 > CLI-only — the hosted app is Scene 4.
 
@@ -274,19 +274,19 @@ But a workspace can also run a **long-lived service**: a dev server, a database,
 
 _[Scroll back to the three lines under `workspace:` — service-command, auto-start: true, health-check]_
 
-When I ran `klangkc sandbox openclaw`, the setup installed Node and openclaw, wrote a config that points at the Klangk LLM proxy, and started the gateway automatically. That's the **service command** at work — a per-workspace singleton: it runs once in its own session and is shared with everyone you give access to. And I can see that straight from the command line:
+When I ran `klangk sandbox openclaw`, the setup installed Node and openclaw, wrote a config that points at the Klangk LLM proxy, and started the gateway automatically. That's the **service command** at work — a per-workspace singleton: it runs once in its own session and is shared with everyone you give access to. And I can see that straight from the command line:
 
-_[Type: klangkc ls — the Status column shows openclaw as healthy, in green]_
+_[Type: klangk ls — the Status column shows openclaw as healthy, in green]_
 
 The Status column shows `openclaw` as **healthy** — the service command is running and its health check is passing. Everything the CLI knows about the workspace, you see right here.
 
 I can even attach to the service command itself — here's the gateway running live.
 
-_[Split the terminal horizontally. In the new pane: klangkc shell openclaw clanker:service-cmd — joins the service command's session; gateway logs stream]_
+_[Split the terminal horizontally. In the new pane: klangk shell openclaw clanker:service-cmd — joins the service command's session; gateway logs stream]_
 
-Now here's what turns this from "a process I left running" into an actual service. First, **health checks**. A running container only proves the container is alive — it says nothing about the process inside it. So Klangk runs my health-check command inside the container every ten seconds: exit zero means healthy, anything else is unhealthy — and that status is the very thing lighting up the Status column. Because it's all surfaced as events, I can watch it live from the command line with `klangkc monitor`:
+Now here's what turns this from "a process I left running" into an actual service. First, **health checks**. A running container only proves the container is alive — it says nothing about the process inside it. So Klangk runs my health-check command inside the container every ten seconds: exit zero means healthy, anything else is unhealthy — and that status is the very thing lighting up the Status column. Because it's all surfaced as events, I can watch it live from the command line with `klangk monitor`:
 
-_[In the top pane: klangkc monitor --type service_health | jq . — a healthy frame arrives immediately on connect]_
+_[In the top pane: klangk monitor --type service_health | jq . — a healthy frame arrives immediately on connect]_
 
 There — healthy. And I can even run a command on a change, like firing a Slack alert when the service goes down. So what happens when the service actually breaks?
 
@@ -300,7 +300,7 @@ _[Ctrl+C the monitor; close the bottom pane; back to a single terminal]_
 
 Second, **auto-start and recovery**. I've got `KLANGK_ALLOW_AUTOSTART` enabled on the server, so if the server reboots, openclaw's container boots on its own and the gateway is running _before anyone connects_. And the same thing happens any time the container is recreated — the service command re-fires on every fresh container create. So I can show you right now with a per-workspace restart, without taking the whole server down:
 
-_[Host terminal: klangkc restart openclaw — a per-workspace restart. Then: watch -n 3 klangkc ls — openclaw's Status goes starting → healthy again as the service command re-fires on the fresh container]_
+_[Host terminal: klangk restart openclaw — a per-workspace restart. Then: watch -n 3 klangk ls — openclaw's Status goes starting → healthy again as the service command re-fires on the fresh container]_
 
 The gateway here is also exposed as a **hosted app** — once we switch to the browser I can click straight through to openclaw's own web UI, proxied through Klangk's single port. No separate port to open, no extra auth to wire up. We'll see that in a moment.
 
@@ -311,14 +311,14 @@ So the same sandbox idea — one config file, one command — scales from "my de
 > `jq` + LLM proxy working); **`KLANGK_HEALTH_CHECK_INTERVAL=10`** set (snappier
 > unhealthy flip; product default 30s; needs a **full** backend restart, off
 > camera). _mechanic (the unhealthy beat):_ two-pane split (horizontal
-> divider) — bottom pane `klangkc shell openclaw clanker:service-cmd` (joins the
-> service command; gateway logs stream), top pane `klangkc monitor --type
+> divider) — bottom pane `klangk shell openclaw clanker:service-cmd` (joins the
+> service command; gateway logs stream), top pane `klangk monitor --type
 service_health | jq .` (shows a healthy frame immediately via
 > snapshot-on-connect). Ctrl+C the **bottom** pane kills the gateway; the
 > **top** pane emits `"healthy": false` within ≤ interval (the next health
 > check). Then Ctrl+C the monitor, kill the bottom pane, and recover with
-> `klangkc restart openclaw` (the service command re-fires on the fresh
-> container — #1244/#1246). _reset:_ to re-run, `klangkc restart openclaw`
+> `klangk restart openclaw` (the service command re-fires on the fresh
+> container — #1244/#1246). _reset:_ to re-run, `klangk restart openclaw`
 > again to get back to healthy before re-breaking.
 > _gotchas:_ the unhealthy flip is silent dead air (≤10s at interval=10) — trim in
 > edit; the gateway binds a port, so **localhost only**; per-workspace restart
@@ -347,11 +347,11 @@ There — openclaw's own web UI, proxied through Klangk's single port. No separa
 
 _[Return to the workspace list, click the demo workspace card on the "Owned by Me" tab]_
 
-This is a continuation of exactly what we were doing. The terminal here is the same tmux session I had from `klangkc shell` — the repo I cloned and the Pi session I ran from the command line are all still here. That's the whole point: the CLI and the web UI are two windows into the same container.
+This is a continuation of exactly what we were doing. The terminal here is the same tmux session I had from `klangk shell` — the repo I cloned and the Pi session I ran from the command line are all still here. That's the whole point: the CLI and the web UI are two windows into the same container.
 
 _[Click the "+" next to the terminal tab bar to open a new tab, then double-click the tab name and rename it "scratch"]_
 
-I can create multiple interactive terminal tabs, rename them, close them. And these aren't trapped in the browser — any tab I create here can be connected to from the CLI too, with `klangkc shell`. The web UI and the CLI are just two ways into the same sessions.
+I can create multiple interactive terminal tabs, rename them, close them. And these aren't trapped in the browser — any tab I create here can be connected to from the CLI too, with `klangk shell`. The web UI and the CLI are just two ways into the same sessions.
 
 But the web UI has features beyond the terminal — files, chat, and collaboration. Let me show those.
 
@@ -414,7 +414,7 @@ One thing worth being clear about: clanker is a **chat agent**, not a coding-age
 > doing exactly that. Treat it like the live `pi` beats in Scenes 2 and 6 — one
 > long take, leave dead air while Pi works, narrate over later.
 >
-> Note that the pi session files are in ~/.pi within the container and those contain the conversation with Pi. While you're recording the session you can also use "podman exec" or "klangkc exec" and tmux to capture the conversation and respond interactively.
+> Note that the pi session files are in ~/.pi within the container and those contain the conversation with Pi. While you're recording the session you can also use "podman exec" or "klangk exec" and tmux to capture the conversation and respond interactively.
 
 _[Screen: same workspace, Terminal tab]_
 
@@ -648,7 +648,7 @@ For example, the "boingball" plugin lets Pi trigger a bouncing ball amimation. T
 
 Plugins are declared in a YAML file and fetched automatically.
 
-How do plugins differ from the `klangkc sandbox` setup scripts we saw earlier? They're both ways to customize a workspace, but they make a different trade-off.
+How do plugins differ from the `klangk sandbox` setup scripts we saw earlier? They're both ways to customize a workspace, but they make a different trade-off.
 
 The downside of plugins is that they require Klangk itself to be recompiled to pick them up — you can't just add one on the fly. But the payoff is that there's **no startup cost**: a plugin is baked into the image at build time, so every workspace that uses that image is ready to go instantly, with no setup script to run on first creation. The feature is available to all workspaces instantly.
 
@@ -671,7 +671,7 @@ The admin panel lets you manage users and groups, send email invitations, and co
 
 ## Scene 10 — Closing (30 seconds)
 
-So that's some of Klangk. For solo developers: sandboxed containers you manage from the CLI, one-command project setup with `klangkc sandbox`, SSH agent forwarding so your keys just work, and workspaces that can run always-on services with auto-start and health checks. For teams: shared workspaces, pair programming through shared terminals, real-time chat with an AI agent, and role-based access control. All self-hosted, all open source.
+So that's some of Klangk. For solo developers: sandboxed containers you manage from the CLI, one-command project setup with `klangk sandbox`, SSH agent forwarding so your keys just work, and workspaces that can run always-on services with auto-start and health checks. For teams: shared workspaces, pair programming through shared terminals, real-time chat with an AI agent, and role-based access control. All self-hosted, all open source.
 
 Most containers auto-stop after an idle timeout to save resources, but your files persist. You can get started with a single Docker command or clone the repo and use devenv for development.
 

--- a/src/frontend/e2e-tests/e2e/token-expiry.spec.ts
+++ b/src/frontend/e2e-tests/e2e/token-expiry.spec.ts
@@ -52,7 +52,7 @@ test.describe("Token expiry", () => {
     expect(tokenError).toBe("invalid");
   });
 
-  test("klangkc shell with expired token shows session expired", async ({
+  test("klangk shell with expired token shows session expired", async ({
     request,
   }) => {
     // Register a user and create a workspace so the shell has a target
@@ -86,9 +86,9 @@ test.describe("Token expiry", () => {
       `active-server: "${API_BASE}"\n"${API_BASE}":\n  active-user: "${email}"\n  users:\n    "${email}":\n      token: ${expiredToken}\n`,
     );
 
-    // Run klangkc shell — it should fail with a clear error
+    // Run klangk shell — it should fail with a clear error
     try {
-      execSync(`klangkc shell "${workspace.name}"`, {
+      execSync(`klangk shell "${workspace.name}"`, {
         env: cleanEnv({ HOME: tmpHome }),
         encoding: "utf-8",
         timeout: 15_000,
@@ -98,7 +98,7 @@ test.describe("Token expiry", () => {
     } catch (e: any) {
       const output = (e.stderr || "") + (e.stdout || "");
       expect(output).toContain("Session expired");
-      expect(output).toContain("klangkc login");
+      expect(output).toContain("klangk login");
     }
 
     // Cleanup

--- a/src/klangk/klangk/cli/README.md
+++ b/src/klangk/klangk/cli/README.md
@@ -1,4 +1,4 @@
-# klangkc
+# klangk
 
 CLI client for [Klangk](https://github.com/mcdonc/klangk), a multi-user
 containerized development environment.
@@ -6,7 +6,7 @@ containerized development environment.
 ## Installation
 
 ```bash
-pip install klangkc
+pip install klangk
 ```
 
 Requires Python 3.12+.
@@ -14,10 +14,10 @@ Requires Python 3.12+.
 ## Quick start
 
 ```bash
-klangkc login admin@example.com        # authenticate
-klangkc ls                             # list workspaces
-klangkc create my-project              # create a workspace
-klangkc shell my-project               # drop into a shell
+klangk login admin@example.com        # authenticate
+klangk ls                             # list workspaces
+klangk create my-project              # create a workspace
+klangk shell my-project               # drop into a shell
 ```
 
 ## Features

--- a/src/klangk/klangk/cli/client.py
+++ b/src/klangk/klangk/cli/client.py
@@ -196,7 +196,7 @@ def decode_token_claims(token: str) -> dict:
 
     The CLI already trusts the token it holds (it came from a successful
     login), so signature verification adds nothing for read-only local
-    use like reading the ``sub`` (user id) claim in ``klangkc status``.
+    use like reading the ``sub`` (user id) claim in ``klangk status``.
     Returns ``{}`` on any decode failure.
     """
     try:
@@ -299,7 +299,7 @@ class KlangkClient:
     def check_auth(self, resp: httpx.Response) -> None:
         """Raise AuthError if the server returned 401."""
         if resp.status_code == 401:
-            raise AuthError("Session expired — run `klangkc login`")
+            raise AuthError("Session expired — run `klangk login`")
 
     @staticmethod
     def _raise_for_status(resp: httpx.Response) -> None:
@@ -782,7 +782,7 @@ async def ws_shell(
         local_agent_sock = os.environ.get("SSH_AUTH_SOCK")
         _debug_agent = os.environ.get("KLANGKC_DEBUG_SSH_AGENT", "")
         if _debug_agent:  # pragma: no cover
-            _agent_log = os.path.expanduser("~/.klangkc-ssh-agent.log")
+            _agent_log = os.path.expanduser("~/.klangk-ssh-agent.log")
             _fh = logging.FileHandler(_agent_log, mode="w")
             _fh.setFormatter(logging.Formatter("%(asctime)s %(message)s"))
             logger.addHandler(_fh)
@@ -1249,12 +1249,12 @@ class TerminalSession(_ShellSession):
                         )
                     else:
                         self.stdout.write(
-                            "\r\nSession expired. Run `klangkc login`"
+                            "\r\nSession expired. Run `klangk login`"
                             " to re-authenticate.\r\n"
                         )
                 elif _code in (4001, 4002):
                     self.stdout.write(
-                        "\r\nSession expired. Run `klangkc login` to"
+                        "\r\nSession expired. Run `klangk login` to"
                         " re-authenticate.\r\n"
                     )
                 else:
@@ -1489,7 +1489,7 @@ async def exec_on_ws(
     Returns the remote process exit code.  ``login`` defaults to False
     (raw argv) -- this is the low-level primitive used by setup/file-copy
     paths that already build their own ``sh -c`` command; the
-    interactive ``klangkc exec`` entrypoint (ws_exec) overrides it to
+    interactive ``klangk exec`` entrypoint (ws_exec) overrides it to
     True. See #1041.
     """
     session = ExecSession(
@@ -1515,7 +1515,7 @@ async def ws_exec(
 
     Returns the remote process exit code.  Defaults to ``login=True``
     (run as a bash login shell so ~/.profile is sourced, like a
-    terminal -- #1041); ``klangkc exec --raw`` and the rsync transport
+    terminal -- #1041); ``klangk exec --raw`` and the rsync transport
     pass False for raw argv.
     """
     async with ws_connect(server_spec, token=token, max_size=max_size) as ws:

--- a/src/klangk/klangk/cli/main.py
+++ b/src/klangk/klangk/cli/main.py
@@ -63,7 +63,7 @@ from .sandbox import (
 )
 
 app = typer.Typer(
-    name="klangkc",
+    name="klangk",
     help="Klangk Client",
     rich_markup_mode="rich",
 )
@@ -108,7 +108,7 @@ def server_url() -> str:
         return active
     _err.print(
         "[red]No server configured[/red] — run"
-        " [bold]klangkc login <server>[/bold] first,"
+        " [bold]klangk login <server>[/bold] first,"
         " or pass [bold]--server[/bold]."
     )
     raise typer.Exit(code=1)
@@ -130,7 +130,7 @@ def require_auth() -> None:
 
     In ``none`` (no-auth) mode the server freely issues a token for the
     seeded default user, so any command auto-logs in on first run rather
-    than demanding a prior ``klangkc login`` (#1374). The server's mode is
+    than demanding a prior ``klangk login`` (#1374). The server's mode is
     probed live (not cached) so a mode switch takes effect immediately:
     flipping none->password after a command auto-logged in still leaves
     that token valid until it expires, but a *fresh* command with no
@@ -143,7 +143,7 @@ def require_auth() -> None:
     if _maybe_none_login(state, url):
         return
     _err.print(
-        "[red]Not logged in[/red] — run [bold]klangkc login[/bold] first."
+        "[red]Not logged in[/red] — run [bold]klangk login[/bold] first."
     )
     raise typer.Exit(code=1)
 
@@ -417,7 +417,7 @@ def list_workspaces(
 def create(
     name: str = typer.Argument(..., help="Workspace name"),
     image: str | None = typer.Option(
-        None, "--image", help="Container image to use (see `klangkc images`)"
+        None, "--image", help="Container image to use (see `klangk images`)"
     ),
     auto_start: bool = typer.Option(
         False,
@@ -436,7 +436,7 @@ def create(
         None,
         "--command",
         "-c",
-        help="Service shell command (see `klangkc edit --command`).",
+        help="Service shell command (see `klangk edit --command`).",
     ),
     mount: list[str] | None = typer.Option(
         None,
@@ -949,7 +949,7 @@ def shell(
     token = _state().get_token(server_url())
     if not token:  # pragma: no cover
         _err.print(
-            "[red]Not logged in[/red] — run [bold]klangkc login[/bold] first."
+            "[red]Not logged in[/red] — run [bold]klangk login[/bold] first."
         )  # pragma: no cover
         raise typer.Exit(code=1)  # pragma: no cover
 
@@ -965,7 +965,7 @@ def shell(
     else:
         workspaces = client.list_workspaces(all_pages=True)
         if not workspaces:
-            typer.echo("No workspaces found — create one with klangkc create.")
+            typer.echo("No workspaces found — create one with klangk create.")
             raise typer.Exit(code=1)
         if len(workspaces) == 1:
             ws = workspaces[0]
@@ -1004,7 +1004,7 @@ def shell(
         drain_stdin()
         if e.response.status_code in (4001, 4002):
             _err.print(
-                "[red]Session expired. Run `klangkc login`"
+                "[red]Session expired. Run `klangk login`"
                 " to re-authenticate.[/red]"
             )
         else:
@@ -1199,7 +1199,7 @@ def monitor(
         None,
         help=(
             "Optional command to run for each event. Pass it after '--' "
-            "so its own flags aren't parsed by klangkc."
+            "so its own flags aren't parsed by klangk."
         ),
     ),
     event_type: list[str] = typer.Option(
@@ -1267,19 +1267,19 @@ def monitor(
 
     \b
     Examples:
-      klangkc monitor                                # stream all events
-      klangkc monitor --type service_health | jq .   # pretty health events
-      klangkc monitor --type service_health -- sh -c \
+      klangk monitor                                # stream all events
+      klangk monitor --type service_health | jq .   # pretty health events
+      klangk monitor --type service_health -- sh -c \
         '[ "$KLANGK_HEALTHY" = false ] && notify-send "Service unhealthy"'
-      klangkc monitor --type service_health -- sh -c \
+      klangk monitor --type service_health -- sh -c \
         '[ "$KLANGK_RUNNING" = false ] && echo "container stopped"'
-      klangkc monitor --workspace <id> --type service_health
+      klangk monitor --workspace <id> --type service_health
     """
     require_auth()
     surl = server_url()
     token = _state().get_token(surl)
     if not token:  # pragma: no cover  # require_auth already guards this
-        _err.print("[red]Not logged in. Run `klangkc login` first.[/red]")
+        _err.print("[red]Not logged in. Run `klangk login` first.[/red]")
         raise typer.Exit(code=1)
     effective_max = 0 if no_reconnect else max_reconnects
     try:
@@ -1399,12 +1399,12 @@ def sandbox(
 
     Creates the workspace with the configured image, mounts, and
     volumes, copies files, and runs the setup script.  Use
-    ``klangkc shell`` afterwards to connect.
+    ``klangk shell`` afterwards to connect.
     """
     token = _state().get_token(server_url())
     if not token:  # pragma: no cover
         _err.print(
-            "[red]Not logged in[/red] — run [bold]klangkc login[/bold] first."
+            "[red]Not logged in[/red] — run [bold]klangk login[/bold] first."
         )
         raise typer.Exit(code=1)
 
@@ -1474,7 +1474,7 @@ def sandbox(
             if e.response.status_code in (4001, 4002):
                 _err.print(
                     "[red]Session expired.[/red] Run"
-                    " [bold]klangkc login[/bold] to re-authenticate."
+                    " [bold]klangk login[/bold] to re-authenticate."
                 )
                 raise typer.Exit(code=1) from None
             raise
@@ -1483,7 +1483,7 @@ def sandbox(
             raise typer.Exit(code=1) from None
 
     _err.print(
-        f"[green]Done.[/green] Run [bold]klangkc shell"
+        f"[green]Done.[/green] Run [bold]klangk shell"
         f" {workspace}[/bold] to connect."
     )
 
@@ -1895,17 +1895,17 @@ def exec_cmd(
     it sources ``~/.profile`` and sees the same environment an
     interactive terminal does -- PATH additions, tool homes
     (OPENCLAW_HOME, nvm/asdf), etc. (#1041). Pass ``--raw`` to run raw
-    argv with no shell (used by ``klangkc sync``'s rsync transport).
+    argv with no shell (used by ``klangk sync``'s rsync transport).
 
     Also usable as an rsync transport:
-    rsync -avz -e "klangkc exec --raw" src/ ws:/dest/
+    rsync -avz -e "klangk exec --raw" src/ ws:/dest/
     """
     require_auth()
 
     command = ctx.args
     # With allow_extra_args + allow_interspersed_args=False, Click does
     # NOT consume the ``--`` end-of-options separator -- it lands in
-    # ctx.args verbatim (verified), so ``klangkc exec ws -- echo hi``
+    # ctx.args verbatim (verified), so ``klangk exec ws -- echo hi``
     # would try to run ``--`` as a command. Strip a single leading
     # ``--`` so the conventional separator works. A ``--`` elsewhere is
     # left alone (it is then a real command argument).
@@ -1960,17 +1960,17 @@ def sync(
 
     Examples:
 
-        klangkc sync ~/project my-workspace:/work/project
+        klangk sync ~/project my-workspace:/work/project
 
-        klangkc sync my-workspace:/work/output ~/output
+        klangk sync my-workspace:/work/output ~/output
 
-        klangkc sync ~/src ws:/work/src --delete --exclude .git
+        klangk sync ~/src ws:/work/src --delete --exclude .git
     """
     require_auth()
 
-    klangkc_bin = shutil.which("klangkc")
-    if not klangkc_bin:  # pragma: no cover
-        _err.print("[red]Cannot find klangkc in PATH[/red]")
+    klangk_bin = shutil.which("klangk")
+    if not klangk_bin:  # pragma: no cover
+        _err.print("[red]Cannot find klangk in PATH[/red]")
         raise typer.Exit(code=1)
 
     rsync_bin = shutil.which("rsync")
@@ -1987,7 +1987,7 @@ def sync(
         # shell): rsync's binary protocol must not be corrupted by a
         # ~/.profile that prints to stdout, and rsync shell-quotes its
         # argv so a non-login round-trips cleanly. See #1041.
-        f"{klangkc_bin} exec --raw",
+        f"{klangk_bin} exec --raw",
         *ctx.args,
         src,
         dest,

--- a/src/klangk/klangk/cli/sandbox.py
+++ b/src/klangk/klangk/cli/sandbox.py
@@ -1,4 +1,4 @@
-"""Sandbox config loading and path resolution for ``klangkc sandbox``."""
+"""Sandbox config loading and path resolution for ``klangk sandbox``."""
 
 from __future__ import annotations
 

--- a/src/klangk/klangk/container.py
+++ b/src/klangk/klangk/container.py
@@ -1581,7 +1581,7 @@ class ContainerRegistry:
 
         # Fresh create: provision the agent home and fire the service
         # command (#1244). This is the single choke point -- every
-        # start path (boot autostart, create, connect, klangkc restart)
+        # start path (boot autostart, create, connect, klangk restart)
         # routes through start_container, so the bring-up runs once per
         # fresh container regardless of caller. ensure_service_session
         # is idempotent, and setup_state gates the create-time deferral

--- a/src/klangk/klangk/podman.py
+++ b/src/klangk/klangk/podman.py
@@ -555,15 +555,15 @@ class ExecSession:
 
         By default *command* is passed to ``podman exec`` as raw argv
         (no shell) -- the right thing for programmatic transports like
-        ``klangkc sync``'s rsync, which must NOT source startup files: a
+        ``klangk sync``'s rsync, which must NOT source startup files: a
         ``~/.profile`` that prints to stdout would corrupt the binary
         rsync stream (the classic ssh/scp footgun), and rsync's argv is
         shell-quoted precisely so a non-login round-trips cleanly.
 
         When *login* is set the command runs under a **login shell** that
         sources ``~/.profile`` -- matching what an interactive terminal
-        sees, and what ``klangkc exec`` needs by default (#1041): a user
-        typing ``klangkc exec ws openclaw --version`` expects the
+        sees, and what ``klangk exec`` needs by default (#1041): a user
+        typing ``klangk exec ws openclaw --version`` expects the
         nvm-installed binary on PATH. The login shell is run as
         ``bash -lc 'exec "$@"'`` with the command as its argv -- the
         standard wrapper-script idiom that gets BOTH a login shell

--- a/src/klangk/klangk/wshandler/controllers.py
+++ b/src/klangk/klangk/wshandler/controllers.py
@@ -247,7 +247,7 @@ class ExecController:
         # `login` (default raw) selects whether the command runs as a
         # bash login shell (sources ~/.profile, like a terminal) or as
         # raw argv (no shell, for programmatic transports like rsync).
-        # klangkc exec sends login=true; klangkc exec --raw and the
+        # klangk exec sends login=true; klangk exec --raw and the
         # rsync transport send login=false. See #1041.
         login = bool(msg.get("login", False))
         session = ExecSession(

--- a/src/klangk/klangk/wshandler/dispatch.py
+++ b/src/klangk/klangk/wshandler/dispatch.py
@@ -90,7 +90,7 @@ async def handle_websocket(websocket: WebSocket, app) -> None:
     conn = Connection(safe_ws, user, app)
     app.state.sockets.connections[safe_ws] = conn
     # Replay current health of every health-checked workspace so a
-    # pure-WS consumer (e.g. ``klangkc monitor``) sees steady-state
+    # pure-WS consumer (e.g. ``klangk monitor``) sees steady-state
     # status immediately instead of being blind until the next
     # transition (#1175 item 1).
     app.state.sockets.send_service_health_snapshot(safe_ws)

--- a/src/klangk/klangkc-tests/e2e-tests/test_cli_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_cli_e2e.py
@@ -194,7 +194,7 @@ def _ensure_login(cli_config):
     """
     _run(
         [
-            "klangkc",
+            "klangk",
             "login",
             cli_config["server_url"],
             "test@example.com",
@@ -210,7 +210,7 @@ class TestLogin:
     def test_login_with_email_arg(self, server, cli_config):
         result = _run(
             [
-                "klangkc",
+                "klangk",
                 "login",
                 server["url"],
                 "test@example.com",
@@ -231,7 +231,7 @@ class TestLogin:
     def test_login_reuses_token(self, server, cli_config):
         result = _run(
             [
-                "klangkc",
+                "klangk",
                 "login",
                 server["url"],
                 "test@example.com",
@@ -246,7 +246,7 @@ class TestLogin:
 
     def test_status_shows_logged_in(self, cli_config):
         result = _run(
-            ["klangkc", "status", "--plain"],
+            ["klangk", "status", "--plain"],
             env=cli_config["env"],
         )
         assert result.returncode == 0
@@ -257,7 +257,7 @@ class TestLogin:
 class TestWorkspaceCRUD:
     def test_create_workspace(self, cli_config):
         result = _run(
-            ["klangkc", "create", "e2e-crud"],
+            ["klangk", "create", "e2e-crud"],
             env=cli_config["env"],
         )
         assert result.returncode == 0
@@ -265,7 +265,7 @@ class TestWorkspaceCRUD:
 
     def test_list_workspaces(self, cli_config):
         result = _run(
-            ["klangkc", "ls", "--plain"],
+            ["klangk", "ls", "--plain"],
             env=cli_config["env"],
         )
         assert result.returncode == 0
@@ -273,21 +273,21 @@ class TestWorkspaceCRUD:
 
     def test_create_duplicate_fails(self, cli_config):
         result = _run(
-            ["klangkc", "create", "e2e-crud"],
+            ["klangk", "create", "e2e-crud"],
             env=cli_config["env"],
         )
         assert result.returncode != 0
 
     def test_delete_nonexistent_fails(self, cli_config):
         result = _run(
-            ["klangkc", "rm", "nonexistent-ws"],
+            ["klangk", "rm", "nonexistent-ws"],
             env=cli_config["env"],
         )
         assert result.returncode != 0
 
     def test_delete_workspace(self, cli_config):
         result = _run(
-            ["klangkc", "rm", "e2e-crud"],
+            ["klangk", "rm", "e2e-crud"],
             env=cli_config["env"],
         )
         assert result.returncode == 0
@@ -295,7 +295,7 @@ class TestWorkspaceCRUD:
 
     def test_list_after_delete(self, cli_config):
         result = _run(
-            ["klangkc", "ls", "--plain"],
+            ["klangk", "ls", "--plain"],
             env=cli_config["env"],
         )
         assert "e2e-crud" not in result.stdout
@@ -307,7 +307,7 @@ class TestDuplicate:
         env = cli_config["env"]
         _run(
             [
-                "klangkc",
+                "klangk",
                 "login",
                 cli_config["server_url"],
                 "test@example.com",
@@ -322,12 +322,12 @@ class TestDuplicate:
         env = cli_config["env"]
         TestDuplicate._login(cli_config)
         _run(
-            ["klangkc", "create", "e2e-dup-src", "--env", "FOO=bar"],
+            ["klangk", "create", "e2e-dup-src", "--env", "FOO=bar"],
             env=env,
         )
         try:
             result = _run(
-                ["klangkc", "dup", "e2e-dup-src", "e2e-dup-copy"],
+                ["klangk", "dup", "e2e-dup-src", "e2e-dup-copy"],
                 env=env,
             )
             assert result.returncode == 0
@@ -335,20 +335,20 @@ class TestDuplicate:
 
             # Verify copy appears in list
             result = _run(
-                ["klangkc", "ls", "--plain"],
+                ["klangk", "ls", "--plain"],
                 env=env,
             )
             assert "e2e-dup-src" in result.stdout
             assert "e2e-dup-copy" in result.stdout
         finally:
-            _run(["klangkc", "rm", "e2e-dup-copy"], env=env)
-            _run(["klangkc", "rm", "e2e-dup-src"], env=env)
+            _run(["klangk", "rm", "e2e-dup-copy"], env=env)
+            _run(["klangk", "rm", "e2e-dup-src"], env=env)
 
     def test_dup_nonexistent(self, cli_config):
         env = cli_config["env"]
         TestDuplicate._login(cli_config)
         result = _run(
-            ["klangkc", "dup", "no-such-ws", "copy"],
+            ["klangk", "dup", "no-such-ws", "copy"],
             env=env,
         )
         assert result.returncode != 0
@@ -358,13 +358,13 @@ class TestExec:
     @pytest.fixture(autouse=True, scope="class")
     @staticmethod
     def workspace(cli_config):
-        _run(["klangkc", "create", "e2e-exec"], env=cli_config["env"])
+        _run(["klangk", "create", "e2e-exec"], env=cli_config["env"])
         yield
-        _run(["klangkc", "rm", "e2e-exec"], env=cli_config["env"])
+        _run(["klangk", "rm", "e2e-exec"], env=cli_config["env"])
 
     def test_exec_echo(self, cli_config):
         result = _run(
-            ["klangkc", "exec", "e2e-exec", "echo", "hello from exec"],
+            ["klangk", "exec", "e2e-exec", "echo", "hello from exec"],
             env=cli_config["env"],
             timeout=120,
         )
@@ -373,7 +373,7 @@ class TestExec:
 
     def test_exec_piped_stdin(self, cli_config):
         result = _run(
-            ["klangkc", "exec", "e2e-exec", "cat"],
+            ["klangk", "exec", "e2e-exec", "cat"],
             input="piped data\n",
             env=cli_config["env"],
             timeout=120,
@@ -383,7 +383,7 @@ class TestExec:
 
     def test_exec_exit_code(self, cli_config):
         result = _run(
-            ["klangkc", "exec", "e2e-exec", "false"],
+            ["klangk", "exec", "e2e-exec", "false"],
             env=cli_config["env"],
             timeout=120,
         )
@@ -393,7 +393,7 @@ class TestExec:
         """Smoke test: run `yes` briefly to exercise bounded queue back-pressure."""
         result = _run(
             [
-                "klangkc",
+                "klangk",
                 "exec",
                 "e2e-exec",
                 "bash",
@@ -413,9 +413,9 @@ class TestSync:
     @pytest.fixture(autouse=True, scope="class")
     @staticmethod
     def workspace(cli_config):
-        _run(["klangkc", "create", "e2e-sync"], env=cli_config["env"])
+        _run(["klangk", "create", "e2e-sync"], env=cli_config["env"])
         yield
-        _run(["klangkc", "rm", "e2e-sync"], env=cli_config["env"])
+        _run(["klangk", "rm", "e2e-sync"], env=cli_config["env"])
 
     def test_sync_to_container(self, cli_config, tmp_path):
         # Create local files
@@ -426,7 +426,7 @@ class TestSync:
 
         result = _run(
             [
-                "klangkc",
+                "klangk",
                 "sync",
                 str(src) + "/",
                 "e2e-sync:/home/work/synced/",
@@ -439,7 +439,7 @@ class TestSync:
         # Verify files arrived
         verify = _run(
             [
-                "klangkc",
+                "klangk",
                 "exec",
                 "e2e-sync",
                 "cat",
@@ -455,7 +455,7 @@ class TestSync:
         # Create a file in the container
         _run(
             [
-                "klangkc",
+                "klangk",
                 "exec",
                 "e2e-sync",
                 "bash",
@@ -471,7 +471,7 @@ class TestSync:
 
         result = _run(
             [
-                "klangkc",
+                "klangk",
                 "sync",
                 "e2e-sync:/home/work/remote-file.txt",
                 str(dest) + "/",
@@ -489,9 +489,9 @@ class TestSyncLarge:
     @pytest.fixture(autouse=True, scope="class")
     @staticmethod
     def workspace(cli_config):
-        _run(["klangkc", "create", "e2e-sync-large"], env=cli_config["env"])
+        _run(["klangk", "create", "e2e-sync-large"], env=cli_config["env"])
         yield
-        _run(["klangkc", "rm", "e2e-sync-large"], env=cli_config["env"])
+        _run(["klangk", "rm", "e2e-sync-large"], env=cli_config["env"])
 
     def _make_large_tree(self, root, rng, target_bytes=10 * 1024 * 1024):
         """Create a directory tree with ~target_bytes of data."""
@@ -530,7 +530,7 @@ class TestSyncLarge:
         # Sync to container
         result = _run(
             [
-                "klangkc",
+                "klangk",
                 "sync",
                 str(src) + "/",
                 "e2e-sync-large:/home/work/large-upload/",
@@ -543,7 +543,7 @@ class TestSyncLarge:
         # Verify file count in container
         verify = _run(
             [
-                "klangkc",
+                "klangk",
                 "exec",
                 "e2e-sync-large",
                 "bash",
@@ -559,7 +559,7 @@ class TestSyncLarge:
         # Verify total size in container
         verify = _run(
             [
-                "klangkc",
+                "klangk",
                 "exec",
                 "e2e-sync-large",
                 "bash",
@@ -577,7 +577,7 @@ class TestSyncLarge:
         for rel, expected_hash in list(src_hashes.items())[:3]:
             verify = _run(
                 [
-                    "klangkc",
+                    "klangk",
                     "exec",
                     "e2e-sync-large",
                     "sha256sum",
@@ -597,7 +597,7 @@ class TestSyncLarge:
         # Create large data in the container
         _run(
             [
-                "klangkc",
+                "klangk",
                 "exec",
                 "e2e-sync-large",
                 "bash",
@@ -614,7 +614,7 @@ class TestSyncLarge:
         # Verify size in container (~10.5 MB)
         verify = _run(
             [
-                "klangkc",
+                "klangk",
                 "exec",
                 "e2e-sync-large",
                 "bash",
@@ -630,7 +630,7 @@ class TestSyncLarge:
         # Get hashes in container
         verify = _run(
             [
-                "klangkc",
+                "klangk",
                 "exec",
                 "e2e-sync-large",
                 "bash",
@@ -655,7 +655,7 @@ class TestSyncLarge:
 
         result = _run(
             [
-                "klangkc",
+                "klangk",
                 "sync",
                 "e2e-sync-large:/home/work/large-download/",
                 str(dest) + "/",
@@ -679,7 +679,7 @@ class TestServiceCommand:
         env = cli_config["env"]
         _run(
             [
-                "klangkc",
+                "klangk",
                 "login",
                 cli_config["server_url"],
                 "test@example.com",
@@ -694,11 +694,11 @@ class TestServiceCommand:
         """service_command is stored in the workspace via the API."""
         env = cli_config["env"]
         TestServiceCommand._login(cli_config)
-        _run(["klangkc", "create", "e2e-defcmd"], env=env)
+        _run(["klangk", "create", "e2e-defcmd"], env=env)
         try:
             # Set command
             result = _run(
-                ["klangkc", "edit", "e2e-defcmd", "--command", "echo hello"],
+                ["klangk", "edit", "e2e-defcmd", "--command", "echo hello"],
                 env=env,
             )
             assert result.returncode == 0
@@ -706,12 +706,12 @@ class TestServiceCommand:
 
             # Clear
             result = _run(
-                ["klangkc", "edit", "e2e-defcmd", "--command", ""], env=env
+                ["klangk", "edit", "e2e-defcmd", "--command", ""], env=env
             )
             assert result.returncode == 0
             assert "Updated" in result.stdout
         finally:
-            _run(["klangkc", "rm", "e2e-defcmd"], env=env)
+            _run(["klangk", "rm", "e2e-defcmd"], env=env)
 
 
 class TestAutoStart:
@@ -732,7 +732,7 @@ class TestAutoStart:
         klangk_config_dir.mkdir(parents=True)
         _run(
             [
-                "klangkc",
+                "klangk",
                 "login",
                 base_url,
                 "test@example.com",
@@ -751,39 +751,39 @@ class TestAutoStart:
         env = self._env
         try:
             result = _run(
-                ["klangkc", "create", "e2e-autostart", "--auto-start"],
+                ["klangk", "create", "e2e-autostart", "--auto-start"],
                 env=env,
             )
             assert result.returncode == 0
             assert "e2e-autostart" in result.stdout
         finally:
-            _run(["klangkc", "rm", "e2e-autostart"], env=env)
+            _run(["klangk", "rm", "e2e-autostart"], env=env)
 
     def test_edit_auto_start_on_off(self):
         env = self._env
-        _run(["klangkc", "create", "e2e-autostart2"], env=env)
+        _run(["klangk", "create", "e2e-autostart2"], env=env)
         try:
             result = _run(
-                ["klangkc", "edit", "e2e-autostart2", "--auto-start"],
+                ["klangk", "edit", "e2e-autostart2", "--auto-start"],
                 env=env,
             )
             assert result.returncode == 0
             assert "Updated" in result.stdout
 
             result = _run(
-                ["klangkc", "edit", "e2e-autostart2", "--no-auto-start"],
+                ["klangk", "edit", "e2e-autostart2", "--no-auto-start"],
                 env=env,
             )
             assert result.returncode == 0
             assert "Updated" in result.stdout
         finally:
-            _run(["klangkc", "rm", "e2e-autostart2"], env=env)
+            _run(["klangk", "rm", "e2e-autostart2"], env=env)
 
     def test_create_auto_start_rejected_without_env(self, cli_config):
         """auto_start=True is rejected when KLANGK_ALLOW_AUTOSTART is unset."""
         env = cli_config["env"]
         result = _run(
-            ["klangkc", "create", "e2e-autostart-no", "--auto-start"],
+            ["klangk", "create", "e2e-autostart-no", "--auto-start"],
             env=env,
         )
         assert result.returncode != 0
@@ -791,17 +791,17 @@ class TestAutoStart:
 
 
 def _poll_exec(env, workspace, shell_cmd, expect, timeout=30, interval=1.0):
-    """Run ``klangkc exec`` repeatedly until *expect* appears in stdout.
+    """Run ``klangk exec`` repeatedly until *expect* appears in stdout.
 
     The service command runs asynchronously in a tmux window, so its
-    effect isn't visible the instant ``klangkc sandbox`` returns.  This
+    effect isn't visible the instant ``klangk sandbox`` returns.  This
     polls until it is (or fails loudly on timeout).
     """
     deadline = time.monotonic() + timeout
     last = ""
     while time.monotonic() < deadline:
         r = _run(
-            ["klangkc", "exec", workspace, "bash", "-c", shell_cmd],
+            ["klangk", "exec", workspace, "bash", "-c", shell_cmd],
             env=env,
             timeout=30,
         )
@@ -811,7 +811,7 @@ def _poll_exec(env, workspace, shell_cmd, expect, timeout=30, interval=1.0):
         time.sleep(interval)
     raise AssertionError(
         f"timed out after {timeout}s waiting for {expect!r} from"
-        f" `klangkc exec {workspace} {shell_cmd}`; last stdout:"
+        f" `klangk exec {workspace} {shell_cmd}`; last stdout:"
         f" {last!r}"
     )
 
@@ -821,7 +821,7 @@ class TestSandboxAutoStartServiceCommand:
 
     This is the path PR #1032 guarantees: when a workspace is created
     with ``auto_start`` the service command is *not* run eagerly at
-    container start (the software isn't installed yet).  ``klangkc
+    container start (the software isn't installed yet).  ``klangk
     sandbox`` runs ``setup.sh`` (which installs the command), then sends
     ``terminal_start``, which launches the command in a dedicated tmux
     window.  We verify the command actually ran *and* that it only
@@ -850,7 +850,7 @@ class TestSandboxAutoStartServiceCommand:
         klangk_config_dir.mkdir(parents=True)
         _run(
             [
-                "klangkc",
+                "klangk",
                 "login",
                 base_url,
                 "test@example.com",
@@ -907,7 +907,7 @@ class TestSandboxAutoStartServiceCommand:
             # (sleep 5 + install), then sends terminal_start so the
             # service command runs in the persistent service-cmd window.
             result = _run(
-                ["klangkc", "sandbox", self.WS, str(sandbox_root)],
+                ["klangk", "sandbox", self.WS, str(sandbox_root)],
                 env=env,
                 timeout=120,
             )
@@ -925,7 +925,7 @@ class TestSandboxAutoStartServiceCommand:
             # (2) setup.sh did install /tmp/myapp -- proving setup ran
             # and therefore myapp did NOT exist at eager-start time.
             installed = _run(
-                ["klangkc", "exec", self.WS, "test", "-x", "/tmp/myapp"],
+                ["klangk", "exec", self.WS, "test", "-x", "/tmp/myapp"],
                 env=env,
                 timeout=30,
             )
@@ -940,7 +940,7 @@ class TestSandboxAutoStartServiceCommand:
             # setup_state), so service-cmd-when is written after setup-done.
             ordering = _run(
                 [
-                    "klangkc",
+                    "klangk",
                     "exec",
                     self.WS,
                     "bash",
@@ -956,7 +956,7 @@ class TestSandboxAutoStartServiceCommand:
                 f"{ordering.stdout!r}"
             )
         finally:
-            _run(["klangkc", "rm", self.WS], env=env, timeout=60)
+            _run(["klangk", "rm", self.WS], env=env, timeout=60)
 
 
 class TestMounts:
@@ -965,7 +965,7 @@ class TestMounts:
         env = cli_config["env"]
         _run(
             [
-                "klangkc",
+                "klangk",
                 "login",
                 cli_config["server_url"],
                 "test@example.com",
@@ -982,7 +982,7 @@ class TestMounts:
         try:
             result = _run(
                 [
-                    "klangkc",
+                    "klangk",
                     "create",
                     "e2e-mount",
                     "--mount",
@@ -993,16 +993,16 @@ class TestMounts:
             assert result.returncode == 0
             assert "e2e-mount" in result.stdout
         finally:
-            _run(["klangkc", "rm", "e2e-mount"], env=env)
+            _run(["klangk", "rm", "e2e-mount"], env=env)
 
     def test_edit_with_mount_flags(self, cli_config):
         env = cli_config["env"]
         TestMounts._login(cli_config)
-        _run(["klangkc", "create", "e2e-mount-edit"], env=env)
+        _run(["klangk", "create", "e2e-mount-edit"], env=env)
         try:
             result = _run(
                 [
-                    "klangkc",
+                    "klangk",
                     "edit",
                     "e2e-mount-edit",
                     "--mount",
@@ -1015,25 +1015,25 @@ class TestMounts:
             assert result.returncode == 0
             assert "Updated" in result.stdout
         finally:
-            _run(["klangkc", "rm", "e2e-mount-edit"], env=env)
+            _run(["klangk", "rm", "e2e-mount-edit"], env=env)
 
     def test_edit_interactive_add_mount(self, cli_config):
         env = cli_config["env"]
         TestMounts._login(cli_config)
-        _run(["klangkc", "create", "e2e-mount-int"], env=env)
+        _run(["klangk", "create", "e2e-mount-int"], env=env)
         try:
             # Interactive: keep name, keep image, keep command,
             # add mount "/tmp:/mnt/test", skip add, skip remove,
             # skip add env
             result = _run(
-                ["klangkc", "edit", "e2e-mount-int"],
+                ["klangk", "edit", "e2e-mount-int"],
                 input="\n\n\n/tmp:/mnt/test\n\n\n\n",
                 env=env,
             )
             assert result.returncode == 0
             assert "Updated" in result.stdout
         finally:
-            _run(["klangkc", "rm", "e2e-mount-int"], env=env)
+            _run(["klangk", "rm", "e2e-mount-int"], env=env)
 
 
 class TestEnvVars:
@@ -1042,7 +1042,7 @@ class TestEnvVars:
         env = cli_config["env"]
         _run(
             [
-                "klangkc",
+                "klangk",
                 "login",
                 cli_config["server_url"],
                 "test@example.com",
@@ -1059,7 +1059,7 @@ class TestEnvVars:
         try:
             result = _run(
                 [
-                    "klangkc",
+                    "klangk",
                     "create",
                     "e2e-env",
                     "--env",
@@ -1072,16 +1072,16 @@ class TestEnvVars:
             assert result.returncode == 0
             assert "e2e-env" in result.stdout
         finally:
-            _run(["klangkc", "rm", "e2e-env"], env=env)
+            _run(["klangk", "rm", "e2e-env"], env=env)
 
     def test_edit_with_env_flag(self, cli_config):
         env = cli_config["env"]
         TestEnvVars._login(cli_config)
-        _run(["klangkc", "create", "e2e-env-edit"], env=env)
+        _run(["klangk", "create", "e2e-env-edit"], env=env)
         try:
             result = _run(
                 [
-                    "klangkc",
+                    "klangk",
                     "edit",
                     "e2e-env-edit",
                     "--env",
@@ -1092,7 +1092,7 @@ class TestEnvVars:
             assert result.returncode == 0
             assert "Updated" in result.stdout
         finally:
-            _run(["klangkc", "rm", "e2e-env-edit"], env=env)
+            _run(["klangk", "rm", "e2e-env-edit"], env=env)
 
 
 class TestVolumes:
@@ -1101,7 +1101,7 @@ class TestVolumes:
         env = cli_config["env"]
         _run(
             [
-                "klangkc",
+                "klangk",
                 "login",
                 cli_config["server_url"],
                 "test@example.com",
@@ -1117,38 +1117,38 @@ class TestVolumes:
         TestVolumes._login(cli_config)
 
         # Create
-        result = _run(["klangkc", "volumes", "create", "e2e-vol"], env=env)
+        result = _run(["klangk", "volumes", "create", "e2e-vol"], env=env)
         assert result.returncode == 0
         assert "Created" in result.stdout
 
         # List
-        result = _run(["klangkc", "volumes", "ls", "--plain"], env=env)
+        result = _run(["klangk", "volumes", "ls", "--plain"], env=env)
         assert result.returncode == 0
         assert "e2e-vol" in result.stdout
 
         # Create duplicate fails
-        result = _run(["klangkc", "volumes", "create", "e2e-vol"], env=env)
+        result = _run(["klangk", "volumes", "create", "e2e-vol"], env=env)
         assert result.returncode != 0
 
         # Remove
-        result = _run(["klangkc", "volumes", "rm", "e2e-vol"], env=env)
+        result = _run(["klangk", "volumes", "rm", "e2e-vol"], env=env)
         assert result.returncode == 0
         assert "Deleted" in result.stdout
 
         # List after delete
-        result = _run(["klangkc", "volumes", "ls", "--plain"], env=env)
+        result = _run(["klangk", "volumes", "ls", "--plain"], env=env)
         assert "e2e-vol" not in result.stdout
 
     def test_volumes_rm_nonexistent(self, cli_config):
         env = cli_config["env"]
         TestVolumes._login(cli_config)
-        result = _run(["klangkc", "volumes", "rm", "no-such-vol"], env=env)
+        result = _run(["klangk", "volumes", "rm", "no-such-vol"], env=env)
         assert result.returncode != 0
 
     def test_volumes_empty_list(self, cli_config):
         env = cli_config["env"]
         TestVolumes._login(cli_config)
-        result = _run(["klangkc", "volumes", "ls"], env=env)
+        result = _run(["klangk", "volumes", "ls"], env=env)
         assert result.returncode == 0
         # May show "No volumes." or an empty table
 
@@ -1163,7 +1163,7 @@ class TestAuthError:
         klangk_config.mkdir(parents=True)
         env = clean_env(HOME=str(config_dir))
         result = _run(
-            ["klangkc", "ls"],
+            ["klangk", "ls"],
             env=env,
         )
         assert result.returncode != 0
@@ -1174,14 +1174,14 @@ class TestAuthError:
 class TestLogout:
     def test_logout(self, cli_config):
         result = _run(
-            ["klangkc", "logout"],
+            ["klangk", "logout"],
             env=cli_config["env"],
         )
         assert result.returncode == 0
 
     def test_status_after_logout(self, cli_config):
         result = _run(
-            ["klangkc", "status", "--plain"],
+            ["klangk", "status", "--plain"],
             env=cli_config["env"],
         )
         assert "not_logged_in" in result.stdout
@@ -1194,7 +1194,7 @@ class TestExportSymlinks:
         """Ensure logged in for this test class."""
         _run(
             [
-                "klangkc",
+                "klangk",
                 "login",
                 cli_config["server_url"],
                 "test@example.com",
@@ -1233,7 +1233,7 @@ class TestExportSymlinks:
         """All symlinks are preserved (stored as links, not content)."""
         env = cli_config["env"]
 
-        result = _run(["klangkc", "create", "e2e-symlink"], env=env)
+        result = _run(["klangk", "create", "e2e-symlink"], env=env)
         assert result.returncode == 0
 
         try:
@@ -1250,7 +1250,7 @@ class TestExportSymlinks:
 
             archive = tmp_path / "symlink-test.tar.gz"
             result = _run(
-                ["klangkc", "export", "e2e-symlink", "-o", str(archive)],
+                ["klangk", "export", "e2e-symlink", "-o", str(archive)],
                 env=env,
                 timeout=120,
             )
@@ -1270,7 +1270,7 @@ class TestExportSymlinks:
                 assert len(ext) == 1
                 assert ext[0].issym()
         finally:
-            _run(["klangkc", "rm", "e2e-symlink"], env=env)
+            _run(["klangk", "rm", "e2e-symlink"], env=env)
 
 
 class TestExportImport:
@@ -1280,7 +1280,7 @@ class TestExportImport:
         """Ensure logged in for this test class."""
         _run(
             [
-                "klangkc",
+                "klangk",
                 "login",
                 cli_config["server_url"],
                 "test@example.com",
@@ -1303,7 +1303,7 @@ class TestExportImport:
         # Create a workspace with metadata
         result = _run(
             [
-                "klangkc",
+                "klangk",
                 "create",
                 "export-test",
                 "--env",
@@ -1316,7 +1316,7 @@ class TestExportImport:
         # Export (workspace has no container started yet — just metadata)
         archive = tmp_path / "export-test.tar.gz"
         result = _run(
-            ["klangkc", "export", "export-test", "-o", str(archive)],
+            ["klangk", "export", "export-test", "-o", str(archive)],
             env=env,
             timeout=120,
         )
@@ -1337,7 +1337,7 @@ class TestExportImport:
 
         # Delete the original (not needed for import, but keeps things tidy)
         try:
-            _run(["klangkc", "rm", "export-test"], env=env)
+            _run(["klangk", "rm", "export-test"], env=env)
         except subprocess.TimeoutExpired:
             logger.warning(
                 "Timeout removing export-test, deferring to teardown"
@@ -1346,7 +1346,7 @@ class TestExportImport:
         # Import with a new name
         result = _run(
             [
-                "klangkc",
+                "klangk",
                 "import",
                 str(archive),
                 "--name",
@@ -1358,7 +1358,7 @@ class TestExportImport:
         assert result.returncode == 0, result.stderr or result.stdout
 
         # Verify the imported workspace exists
-        result = _run(["klangkc", "ls", "--plain"], env=env)
+        result = _run(["klangk", "ls", "--plain"], env=env)
         assert "export-restored" in result.stdout
 
     def test_export_import_round_trip_with_symlinks(
@@ -1367,7 +1367,7 @@ class TestExportImport:
         """Symlinks survive an export→import round-trip intact."""
         env = cli_config["env"]
 
-        result = _run(["klangkc", "create", "export-symlink"], env=env)
+        result = _run(["klangk", "create", "export-symlink"], env=env)
         assert result.returncode == 0
 
         try:
@@ -1406,7 +1406,7 @@ class TestExportImport:
             # Export
             archive = tmp_path / "symlink-roundtrip.tar.gz"
             result = _run(
-                ["klangkc", "export", "export-symlink", "-o", str(archive)],
+                ["klangk", "export", "export-symlink", "-o", str(archive)],
                 env=env,
                 timeout=120,
             )
@@ -1436,7 +1436,7 @@ class TestExportImport:
 
             # Delete original (not required for import — uses a different name)
             try:
-                _run(["klangkc", "rm", "export-symlink"], env=env)
+                _run(["klangk", "rm", "export-symlink"], env=env)
             except subprocess.TimeoutExpired:
                 logger.warning(
                     "Timeout removing export-symlink, deferring to teardown"
@@ -1444,7 +1444,7 @@ class TestExportImport:
 
             result = _run(
                 [
-                    "klangkc",
+                    "klangk",
                     "import",
                     str(archive),
                     "--name",
@@ -1488,14 +1488,14 @@ class TestExportImport:
             )
 
             try:
-                _run(["klangkc", "rm", "export-symlink-imported"], env=env)
+                _run(["klangk", "rm", "export-symlink-imported"], env=env)
             except subprocess.TimeoutExpired:
                 logger.warning(
                     "Timeout removing export-symlink-imported, deferring to teardown"
                 )
         finally:
             try:
-                _run(["klangkc", "rm", "export-symlink"], env=env)
+                _run(["klangk", "rm", "export-symlink"], env=env)
             except subprocess.TimeoutExpired:
                 logger.warning(
                     "Timeout removing export-symlink in finally, deferring to teardown"
@@ -1520,7 +1520,7 @@ class TestAllowedMountRoots:
         klangk_config_dir.mkdir(parents=True)
         _run(
             [
-                "klangkc",
+                "klangk",
                 "login",
                 base_url,
                 "test@example.com",
@@ -1540,7 +1540,7 @@ class TestAllowedMountRoots:
         try:
             result = _run(
                 [
-                    "klangkc",
+                    "klangk",
                     "create",
                     "e2e-mount-ok",
                     "--mount",
@@ -1551,13 +1551,13 @@ class TestAllowedMountRoots:
             assert result.returncode == 0
             assert "e2e-mount-ok" in result.stdout
         finally:
-            _run(["klangkc", "rm", "e2e-mount-ok"], env=env)
+            _run(["klangk", "rm", "e2e-mount-ok"], env=env)
 
     def test_denied_mount_fails(self):
         env = self._env
         result = _run(
             [
-                "klangkc",
+                "klangk",
                 "create",
                 "e2e-mount-denied",
                 "--mount",
@@ -1602,7 +1602,7 @@ class TestVolumeUserIsolation:
             (config_dir / ".config" / "klangk").mkdir(parents=True)
             _run(
                 [
-                    "klangkc",
+                    "klangk",
                     "login",
                     base_url,
                     email,
@@ -1625,7 +1625,7 @@ class TestVolumeUserIsolation:
         # User A creates workspace with a named volume
         _run(
             [
-                "klangkc",
+                "klangk",
                 "create",
                 "ws-a",
                 "--mount",
@@ -1636,7 +1636,7 @@ class TestVolumeUserIsolation:
         try:
             # User A execs to trigger container start (creates the volume)
             result = _run(
-                ["klangkc", "exec", "ws-a", "echo", "ok"],
+                ["klangk", "exec", "ws-a", "echo", "ok"],
                 env=env_a,
                 timeout=120,
             )
@@ -1645,7 +1645,7 @@ class TestVolumeUserIsolation:
             # User B creates workspace with the same volume
             _run(
                 [
-                    "klangkc",
+                    "klangk",
                     "create",
                     "ws-b",
                     "--mount",
@@ -1656,15 +1656,15 @@ class TestVolumeUserIsolation:
             try:
                 # User B execs — should fail because the volume belongs to A
                 result = _run(
-                    ["klangkc", "exec", "ws-b", "echo", "stolen"],
+                    ["klangk", "exec", "ws-b", "echo", "stolen"],
                     env=env_b,
                     timeout=120,
                 )
                 assert result.returncode != 0
             finally:
-                _run(["klangkc", "rm", "ws-b"], env=env_b)
+                _run(["klangk", "rm", "ws-b"], env=env_b)
         finally:
-            _run(["klangkc", "rm", "ws-a"], env=env_a)
+            _run(["klangk", "rm", "ws-a"], env=env_a)
             subprocess.run(
                 ["podman", "volume", "rm", "shared-vol"],
                 capture_output=True,
@@ -1676,30 +1676,30 @@ class TestVolumeUserIsolation:
         env_b = self._env_b
 
         # User A creates a volume
-        result = _run(["klangkc", "volumes", "create", "vol-a"], env=env_a)
+        result = _run(["klangk", "volumes", "create", "vol-a"], env=env_a)
         assert result.returncode == 0
         try:
             # User B creates a volume
-            result = _run(["klangkc", "volumes", "create", "vol-b"], env=env_b)
+            result = _run(["klangk", "volumes", "create", "vol-b"], env=env_b)
             assert result.returncode == 0
             try:
                 # User A should see vol-a but not vol-b
                 result = _run(
-                    ["klangkc", "volumes", "ls", "--plain"], env=env_a
+                    ["klangk", "volumes", "ls", "--plain"], env=env_a
                 )
                 assert "vol-a" in result.stdout
                 assert "vol-b" not in result.stdout
 
                 # User B should see vol-b but not vol-a
                 result = _run(
-                    ["klangkc", "volumes", "ls", "--plain"], env=env_b
+                    ["klangk", "volumes", "ls", "--plain"], env=env_b
                 )
                 assert "vol-b" in result.stdout
                 assert "vol-a" not in result.stdout
             finally:
-                _run(["klangkc", "volumes", "rm", "vol-b"], env=env_b)
+                _run(["klangk", "volumes", "rm", "vol-b"], env=env_b)
         finally:
-            _run(["klangkc", "volumes", "rm", "vol-a"], env=env_a)
+            _run(["klangk", "volumes", "rm", "vol-a"], env=env_a)
 
     def test_volumes_rm_other_user_rejected(self):
         """A user cannot delete another user's volume."""
@@ -1708,17 +1708,17 @@ class TestVolumeUserIsolation:
 
         # User A creates a volume
         result = _run(
-            ["klangkc", "volumes", "create", "vol-private"], env=env_a
+            ["klangk", "volumes", "create", "vol-private"], env=env_a
         )
         assert result.returncode == 0
         try:
             # User B tries to delete it — should fail
             result = _run(
-                ["klangkc", "volumes", "rm", "vol-private"], env=env_b
+                ["klangk", "volumes", "rm", "vol-private"], env=env_b
             )
             assert result.returncode != 0
         finally:
-            _run(["klangkc", "volumes", "rm", "vol-private"], env=env_a)
+            _run(["klangk", "volumes", "rm", "vol-private"], env=env_a)
 
 
 class TestTerminalSharing:
@@ -1738,7 +1738,7 @@ class TestTerminalSharing:
         (config_dir / ".config" / "klangk").mkdir(parents=True)
         _run(
             [
-                "klangkc",
+                "klangk",
                 "login",
                 base_url,
                 "test@example.com",
@@ -1748,21 +1748,21 @@ class TestTerminalSharing:
             input="testpass\n",
             env=env,
         )
-        _run(["klangkc", "create", "e2e-share"], env=env)
+        _run(["klangk", "create", "e2e-share"], env=env)
         # Start container so terminal commands work
         _run(
-            ["klangkc", "exec", "e2e-share", "true"],
+            ["klangk", "exec", "e2e-share", "true"],
             env=env,
             timeout=120,
         )
         request.cls._env = env
         yield
-        _run(["klangkc", "rm", "e2e-share"], env=env)
+        _run(["klangk", "rm", "e2e-share"], env=env)
         _stop_server(proc, data_dir)
 
     def test_terminals_lists_windows(self):
         result = _run(
-            ["klangkc", "terminal", "ls", "e2e-share"],
+            ["klangk", "terminal", "ls", "e2e-share"],
             env=self._env,
             timeout=120,
         )
@@ -1772,7 +1772,7 @@ class TestTerminalSharing:
         env = self._env
         # First discover the window name via `klangk terminals`
         list_result = _run(
-            ["klangkc", "terminal", "ls", "e2e-share"],
+            ["klangk", "terminal", "ls", "e2e-share"],
             env=env,
             timeout=120,
         )
@@ -1792,7 +1792,7 @@ class TestTerminalSharing:
         )
 
         result = _run(
-            ["klangkc", "terminal", "share", "e2e-share", terminal_name],
+            ["klangk", "terminal", "share", "e2e-share", terminal_name],
             env=env,
             timeout=120,
         )
@@ -1800,7 +1800,7 @@ class TestTerminalSharing:
         assert "shared" in result.stderr.lower()
 
         result = _run(
-            ["klangkc", "terminal", "unshare", "e2e-share", terminal_name],
+            ["klangk", "terminal", "unshare", "e2e-share", terminal_name],
             env=env,
             timeout=120,
         )
@@ -1809,7 +1809,7 @@ class TestTerminalSharing:
 
     def test_share_nonexistent_terminal(self):
         result = _run(
-            ["klangkc", "terminal", "share", "e2e-share", "nonexistent"],
+            ["klangk", "terminal", "share", "e2e-share", "nonexistent"],
             env=self._env,
             timeout=120,
         )
@@ -1829,11 +1829,11 @@ class TestContainerReplace:
         stopped container so the next exec succeeds.
         """
         env = cli_config["env"]
-        _run(["klangkc", "create", "e2e-replace"], env=env)
+        _run(["klangk", "create", "e2e-replace"], env=env)
         try:
             # Start the container via exec
             result = _run(
-                ["klangkc", "exec", "e2e-replace", "echo", "first"],
+                ["klangk", "exec", "e2e-replace", "echo", "first"],
                 env=env,
                 timeout=120,
             )
@@ -1864,18 +1864,18 @@ class TestContainerReplace:
 
             # Exec again — --replace should create a fresh container
             result = _run(
-                ["klangkc", "exec", "e2e-replace", "echo", "second"],
+                ["klangk", "exec", "e2e-replace", "echo", "second"],
                 env=env,
                 timeout=120,
             )
             assert result.returncode == 0
             assert "second" in result.stdout
         finally:
-            _run(["klangkc", "rm", "e2e-replace"], env=env)
+            _run(["klangk", "rm", "e2e-replace"], env=env)
 
 
 class TestWorkspaceSharing:
-    """Test klangkc share/unshare/members commands."""
+    """Test klangk share/unshare/members commands."""
 
     @pytest.fixture(scope="class", autouse=True)
     @staticmethod
@@ -1898,7 +1898,7 @@ class TestWorkspaceSharing:
         (config_dir / ".config" / "klangk").mkdir(parents=True)
         _run(
             [
-                "klangkc",
+                "klangk",
                 "login",
                 base_url,
                 "test@example.com",
@@ -1908,7 +1908,7 @@ class TestWorkspaceSharing:
             input="testpass\n",
             env=env,
         )
-        _run(["klangkc", "create", "e2e-ws-share"], env=env)
+        _run(["klangk", "create", "e2e-ws-share"], env=env)
         request.cls._env = env
 
     @pytest.fixture(autouse=True)
@@ -1920,7 +1920,7 @@ class TestWorkspaceSharing:
 
         # Share workspace with second user
         result = _run(
-            ["klangkc", "share", "e2e-ws-share", "share-user@example.com"],
+            ["klangk", "share", "e2e-ws-share", "share-user@example.com"],
             env=env,
         )
         assert result.returncode == 0
@@ -1928,7 +1928,7 @@ class TestWorkspaceSharing:
 
         # List members — should include the shared user
         result = _run(
-            ["klangkc", "members", "e2e-ws-share"],
+            ["klangk", "members", "e2e-ws-share"],
             env=env,
         )
         assert result.returncode == 0
@@ -1937,7 +1937,7 @@ class TestWorkspaceSharing:
         # Unshare
         result = _run(
             [
-                "klangkc",
+                "klangk",
                 "unshare",
                 "e2e-ws-share",
                 "share-user@example.com",
@@ -1948,7 +1948,7 @@ class TestWorkspaceSharing:
 
         # Shared user should be gone (owner may still appear)
         result = _run(
-            ["klangkc", "members", "e2e-ws-share"],
+            ["klangk", "members", "e2e-ws-share"],
             env=env,
         )
         assert result.returncode == 0
@@ -1960,7 +1960,7 @@ class TestWorkspaceSharing:
         # Share as spectator
         result = _run(
             [
-                "klangkc",
+                "klangk",
                 "share",
                 "e2e-ws-share",
                 "share-user@example.com",
@@ -1973,7 +1973,7 @@ class TestWorkspaceSharing:
 
         # Members should show spectator role
         result = _run(
-            ["klangkc", "members", "e2e-ws-share"],
+            ["klangk", "members", "e2e-ws-share"],
             env=env,
         )
         assert result.returncode == 0
@@ -1982,7 +1982,7 @@ class TestWorkspaceSharing:
         # Change role to collaborator
         result = _run(
             [
-                "klangkc",
+                "klangk",
                 "share",
                 "e2e-ws-share",
                 "share-user@example.com",
@@ -1995,7 +1995,7 @@ class TestWorkspaceSharing:
 
         # Members should now show collaborator
         result = _run(
-            ["klangkc", "members", "e2e-ws-share"],
+            ["klangk", "members", "e2e-ws-share"],
             env=env,
         )
         assert result.returncode == 0
@@ -2005,7 +2005,7 @@ class TestWorkspaceSharing:
         # Cleanup
         _run(
             [
-                "klangkc",
+                "klangk",
                 "unshare",
                 "e2e-ws-share",
                 "share-user@example.com",
@@ -2069,7 +2069,7 @@ class TestTokenRefresh:
     def _login(self, cli_config):
         result = _run(
             [
-                "klangkc",
+                "klangk",
                 "login",
                 cli_config["server_url"],
                 "test@example.com",
@@ -2085,7 +2085,7 @@ class TestTokenRefresh:
     def test_proactive_refresh_on_http(
         self, short_token_server, short_token_cli_config
     ):
-        """After token nears expiry, klangkc ls should refresh transparently."""
+        """After token nears expiry, klangk ls should refresh transparently."""
         self._login(short_token_cli_config)
         original_token = _read_state_token(
             Path(short_token_cli_config["env"]["HOME"]),
@@ -2099,7 +2099,7 @@ class TestTokenRefresh:
         # within the refresh window from the moment it's issued.
         # A simple ls should trigger proactive refresh.
         result = _run(
-            ["klangkc", "ls"],
+            ["klangk", "ls"],
             env=short_token_cli_config["env"],
         )
         assert result.returncode == 0, result.stderr
@@ -2125,7 +2125,7 @@ class TestTokenRefresh:
         time.sleep(9)
 
         result = _run(
-            ["klangkc", "ls"],
+            ["klangk", "ls"],
             env=short_token_cli_config["env"],
         )
         # The proactive refresh should have gotten a new token before
@@ -2159,7 +2159,7 @@ class TestTokenRefresh:
         )
         # The short lifetime means proactive refresh fires immediately
         result = _run(
-            ["klangkc", "ls"],
+            ["klangk", "ls"],
             env=short_token_cli_config["env"],
         )
         assert result.returncode == 0, result.stderr

--- a/src/klangk/klangkc-tests/e2e-tests/test_monitor_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_monitor_e2e.py
@@ -1,7 +1,7 @@
 """End-to-end test for ``klangk monitor`` health-event detection (#1174).
 
 The monitor command (added in #1015) previously had only stub-based unit
-tests (``src/klangk/klangk-tests/tests/test_cli.py`` exercises ``monitor_connection`` /
+tests (``src/klangk/klangkc-tests/tests/test_cli.py`` exercises ``monitor_connection`` /
 ``monitor_run`` against a fake WebSocket).  This module launches the real
 ``klangk monitor`` as a subprocess against a live server driving real
 health-check transitions, and asserts it receives both the unhealthy and

--- a/src/klangk/klangkc-tests/e2e-tests/test_monitor_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_monitor_e2e.py
@@ -1,9 +1,9 @@
-"""End-to-end test for ``klangkc monitor`` health-event detection (#1174).
+"""End-to-end test for ``klangk monitor`` health-event detection (#1174).
 
 The monitor command (added in #1015) previously had only stub-based unit
-tests (``src/klangk/klangkc-tests/tests/test_cli.py`` exercises ``monitor_connection`` /
+tests (``src/klangk/klangk-tests/tests/test_cli.py`` exercises ``monitor_connection`` /
 ``monitor_run`` against a fake WebSocket).  This module launches the real
-``klangkc monitor`` as a subprocess against a live server driving real
+``klangk monitor`` as a subprocess against a live server driving real
 health-check transitions, and asserts it receives both the unhealthy and
 healthy ``service_health`` events as a workspace's check flips down and back
 up.
@@ -188,7 +188,7 @@ def auth(server):
 
 @pytest.fixture(scope="module")
 def cli_env(server, tmp_path_factory):
-    """An isolated HOME with ``klangkc`` logged into the test server.
+    """An isolated HOME with ``klangk`` logged into the test server.
 
     The monitor reads its server URL + token from the CLI config under
     ``~/.config/klangk/cli.yaml``, so a separate HOME (with a fresh login)
@@ -198,7 +198,7 @@ def cli_env(server, tmp_path_factory):
     env = clean_env(HOME=str(config_dir))
     result = subprocess.run(
         [
-            "klangkc",
+            "klangk",
             "login",
             server["url"],
             "test@example.com",
@@ -212,7 +212,7 @@ def cli_env(server, tmp_path_factory):
         timeout=30,
     )
     assert result.returncode == 0, (
-        f"klangkc login failed: {result.stdout=}\n{result.stderr=}"
+        f"klangk login failed: {result.stdout=}\n{result.stderr=}"
     )
     return env
 
@@ -348,7 +348,7 @@ class TestMonitorDetectsHealthFlips:
     async def test_monitor_sees_unhealthy_then_healthy(
         self, server, auth, cli_env
     ):
-        """``klangkc monitor`` prints the down->up service_health pair (#1174)."""
+        """``klangk monitor`` prints the down->up service_health pair (#1174)."""
         workspace_id = _create_workspace(server, auth)
         try:
             # Hold the container alive so the health loop polls it.
@@ -369,7 +369,7 @@ class TestMonitorDetectsHealthFlips:
                 # discarded (the reconnect/status banners go there) so its
                 # OS buffer can't deadlock the process.
                 proc = await asyncio.create_subprocess_exec(
-                    "klangkc",
+                    "klangk",
                     "monitor",
                     "--type",
                     "service_health",

--- a/src/klangk/klangkc-tests/e2e-tests/test_terminal_windows_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_terminal_windows_e2e.py
@@ -1,10 +1,10 @@
 """E2E tests for terminal window independence across CLI and web sessions.
 
 Constraints tested:
-1. Within a given web tab or klangkc shell, the displayed window never
+1. Within a given web tab or klangk shell, the displayed window never
    changes unless the user explicitly switches.
-2. klangkc shell ws = visiting the default terminal (window 0).
-3. klangkc shell ws NAME = creating/attaching to a named window.
+2. klangk shell ws = visiting the default terminal (window 0).
+3. klangk shell ws NAME = creating/attaching to a named window.
 4. Web and CLI viewing the same named window see the same tmux window.
 5. Terminal window mutations (create, close, rename) are broadcast to
    all connections for the same user.
@@ -156,7 +156,7 @@ def _stop_server(proc, data_dir):
 def _login(base_url, env):
     _run(
         [
-            "klangkc",
+            "klangk",
             "login",
             base_url,
             "test@example.com",
@@ -182,7 +182,7 @@ def _cli_check_window(ws_name, env, timeout=25):
     script = f"""
 set timeout {timeout}
 log_user 0
-spawn klangkc shell {ws_name}
+spawn klangk shell {ws_name}
 expect {{
     -re {{\\$ }} {{}}
     timeout {{ puts "TIMEOUT"; exit 1 }}
@@ -214,9 +214,9 @@ wait
 def _cli_hold_and_check(ws_name, window_name, hold_seconds, env):
     """Start CLI shell, check window before and after a hold period."""
     if window_name:
-        cmd = f"klangkc shell {ws_name} {window_name}"
+        cmd = f"klangk shell {ws_name} {window_name}"
     else:
-        cmd = f"klangkc shell {ws_name}"
+        cmd = f"klangk shell {ws_name}"
     script = f"""
 set timeout 30
 log_user 0
@@ -408,8 +408,8 @@ class TestTerminalWindows:
     @pytest.fixture(autouse=True)
     def _fresh_workspace(self):
         """Create a fresh workspace for each test."""
-        _run(["klangkc", "rm", WS_NAME], env=self._env)
-        result = _run(["klangkc", "create", WS_NAME], env=self._env)
+        _run(["klangk", "rm", WS_NAME], env=self._env)
+        result = _run(["klangk", "create", WS_NAME], env=self._env)
         assert result.returncode == 0, result.stderr
         # Resolve full ID via API
         r = httpx.get(
@@ -424,12 +424,12 @@ class TestTerminalWindows:
         assert self._ws_id, f"Workspace {WS_NAME} not found after create"
         # Warm up container
         _run(
-            ["klangkc", "exec", WS_NAME, "true"],
+            ["klangk", "exec", WS_NAME, "true"],
             env=self._env,
             timeout=120,
         )
         yield
-        _run(["klangkc", "rm", WS_NAME], env=self._env)
+        _run(["klangk", "rm", WS_NAME], env=self._env)
 
     def test_web_tab_switch_doesnt_move_cli(self):
         """Clicking a different tab in web UI doesn't change CLI window."""
@@ -465,11 +465,11 @@ class TestTerminalWindows:
         asyncio.run(_test())
 
     def test_named_cli_doesnt_move_default_cli(self):
-        """Opening klangkc shell ws NAME doesn't move default CLI."""
+        """Opening klangk shell ws NAME doesn't move default CLI."""
         script = f"""
 set timeout 30
 log_user 0
-spawn klangkc shell {WS_NAME}
+spawn klangk shell {WS_NAME}
 set s1 $spawn_id
 expect -re {{\\$ }}
 sleep 3
@@ -477,7 +477,7 @@ send "echo B1S; tmux display-message -p '#I:#W'; echo B1E\\r"
 expect -re {{B1S\\r?\\n(\\d+:\\S+)\\r?\\nB1E}}
 set b1 $expect_out(1,string)
 
-spawn klangkc shell {WS_NAME} named1
+spawn klangk shell {WS_NAME} named1
 set s2 $spawn_id
 expect -re {{\\$ }}
 sleep 3
@@ -665,7 +665,7 @@ puts "AFTER=$a1"
             script = f"""
 set timeout 25
 log_user 0
-spawn klangkc shell {WS_NAME} shared
+spawn klangk shell {WS_NAME} shared
 expect {{
     -re {{\\$ }} {{}}
     timeout {{ puts "TIMEOUT"; exit 1 }}
@@ -700,7 +700,7 @@ wait
         asyncio.run(_test())
 
     def test_cli_default_is_window_zero(self):
-        """klangkc shell ws (no arg) lands on window 0."""
+        """klangk shell ws (no arg) lands on window 0."""
         window = _cli_check_window(WS_NAME, self._env)
         assert window.startswith("0:"), f"Expected 0:*, got {window}"
 

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -1,4 +1,4 @@
-"""Tests for the klangkc CLI."""
+"""Tests for the klangk CLI."""
 
 import asyncio
 import json
@@ -1562,7 +1562,7 @@ class TestRequireAuthNoneMode:
         )
         monkeypatch.setattr(main, "_state_cache", None)
         # Server is already registered (active_server set) — mirroring the
-        # scoped behavior where `klangkc login <server>` registers it once.
+        # scoped behavior where `klangk login <server>` registers it once.
         state = CLIState()
         state.active_server = "http://localhost:8995"
         state.save()
@@ -2604,9 +2604,9 @@ class TestMisc:
         monkeypatch.setattr("klangk.cli.auth.fetch_config", lambda _: {})
 
     def test_auth_error_message(self):
-        err = AuthError("Session expired — run `klangkc login`")
+        err = AuthError("Session expired — run `klangk login`")
         assert "Session expired" in str(err)
-        assert "klangkc login" in str(err)
+        assert "klangk login" in str(err)
 
     def test_workspace_dataclass_fields(self):
         ws = Workspace(id="x", name="y", created_at="z")
@@ -3153,7 +3153,7 @@ class TestExecSessionRunClosedWs:
 
 
 class _FakeMonitorConn:
-    """Async-iterator WS stub for ``klangkc monitor``."""
+    """Async-iterator WS stub for ``klangk monitor``."""
 
     def __init__(self, messages: list[str]):
         self._messages = list(messages)

--- a/src/klangk/klangkc-tests/tests/test_cli_integration.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_integration.py
@@ -926,7 +926,7 @@ class TestStdoutLoopAuthClose:
 
         output = "".join(captured)
         assert "Session expired" in output
-        assert "klangkc login" in output
+        assert "klangk login" in output
 
 
 class TestStdinTerminalResponseFilter:

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -2386,7 +2386,7 @@ class TestMainCLI:
         """With allow_extra_args + allow_interspersed_args=False, Click
         does NOT consume the ``--`` end-of-options separator -- it lands
         in ctx.args verbatim. exec_cmd strips a single leading ``--`` so
-        the conventional ``klangkc exec ws -- echo hi`` works instead of
+        the conventional ``klangk exec ws -- echo hi`` works instead of
         trying to run ``--`` as a command.
         """
         from klangk.cli import main
@@ -2456,13 +2456,13 @@ class TestMainCLI:
         # #1041: sync uses ``exec --raw`` as the rsync transport so the
         # remote command runs raw (no login shell) -- a ~/.profile that
         # prints would otherwise corrupt the binary rsync stream.
-        assert "klangkc exec --raw" in " ".join(cmd)
+        assert "klangk exec --raw" in " ".join(cmd)
 
     def test_sync_no_rsync(self, logged_in_cfg):
         from klangk.cli import main
 
         def which_no_rsync(name):
-            return "/usr/bin/klangkc" if name == "klangkc" else None
+            return "/usr/bin/klangk" if name == "klangk" else None
 
         ctx = MagicMock()
         ctx.args = []
@@ -3110,7 +3110,7 @@ class TestSandboxCommand:
         call_kwargs = client.create_workspace.call_args
         assert call_kwargs[0][0] == "myws"
         assert "Creating workspace" in result.output
-        assert "klangkc shell" in result.output
+        assert "klangk shell" in result.output
 
     def test_existing_workspace_errors_without_force(
         self, logged_in_cfg, tmp_path

--- a/src/klangk/klangkc-tests/tests/test_sandbox.py
+++ b/src/klangk/klangkc-tests/tests/test_sandbox.py
@@ -1,4 +1,4 @@
-"""Tests for klangkc sandbox config loading and path resolution."""
+"""Tests for klangk sandbox config loading and path resolution."""
 
 import pytest
 import yaml

--- a/src/klangk/klangkd-tests/e2e-tests/_e2e_env.py
+++ b/src/klangk/klangkd-tests/e2e-tests/_e2e_env.py
@@ -1,7 +1,7 @@
 """Shared hermetic env helper for E2E test suites (#1526).
 
 Every E2E suite that launches a subprocess (``runtestserver.py``, ``klangkd``,
-or ``klangkc``) must build the child's env from :func:`clean_env`, **not**
+or ``klangk``) must build the child's env from :func:`clean_env`, **not**
 ``{**os.environ, ...}``. A stray ``KLANGK_*`` var in the CI runner's env
 (or one leaked by a prior test) silently becomes the child's config and can
 change test results — ``clean_env`` strips all config-affecting prefixes so

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -2665,7 +2665,7 @@ class TestExecController:
     async def test_start_login_true_threads_through(self, app_state):
         """#1041: ``login: True`` in the message reaches ExecSession.start
         so the command runs as a bash login shell (sources ~/.profile).
-        This is the klangkc exec default."""
+        This is the klangk exec default."""
         app_state = _make_app_state()
         registry = app_state.state.container_registry
         ctrl, _, _ = self._controller(app_state=app_state)

--- a/src/klangk/pyproject.toml
+++ b/src/klangk/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "klangk"
 dynamic = ["version"]
-description = "Klangk: multi-user Pi coding agent — server (klangkd) and client (klangkc)"
+description = "Klangk: multi-user Pi coding agent — server (klangkd) and client (klangk)"
 requires-python = ">=3.12"
 # One unified wheel ships a single top-level package (klangk) with the CLI
 # folded in as klangk.cli.  One ``pip install klangk`` yields both the
-# ``klangkd`` server and ``klangkc`` client binaries (#1606).
+# ``klangkd`` server and ``klangk`` client binaries (#1606).
 dependencies = [
     "fastapi>=0.115.0",
     "pydantic-settings>=2.5.0",
@@ -35,7 +35,7 @@ dependencies = [
 # User-facing command names are unchanged — they're entrypoint names,
 # distinct from the package names. One ``pip install klangk`` yields both.
 klangkd = "klangk.launcher:app"
-klangkc = "klangk.cli.main:main"
+klangk = "klangk.cli.main:main"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"


### PR DESCRIPTION
## Summary

Renames the CLI entrypoint from `klangkc` to **`klangk`** — so one `pip install klangk` yields `klangk` (client) and `klangkd` (server). Closes #1615.

## Changes

- **Entrypoint** (`src/klangk/pyproject.toml`): `klangkc = "klangk.cli.main:main"` → `klangk = "klangk.cli.main:main"`.
- **Typer app name** (`cli/main.py:66`): `name="klangkc"` → `name="klangk"` (so `--help` / usage strings show the right binary).
- **Bulk sweep** (~60 files, ~400 occurrences): every user-facing reference to the `klangkc` command — help text, error messages, examples in CLI sources, docs (`cli.md`, feature docs, architecture, getting-started), demo recording scripts, backend comments, container profile scripts, and test assertions — updated to `klangk`.
- **`docs/changes.md`**: new `### Changed` entry; historical `klangkc` PyPI distribution references preserved (they name the retired distribution, not the command).

## Non-goals (per the issue)

- The Python module `klangk.cli` is unchanged.
- The `klangkc-tests` test directory name is unchanged (its *contents* were swept — command strings in assertions/examples).
- `klangkd` (server script) is unchanged.

## Verification

- Backend + CLI combined (`-n auto`): **3023 passed, 100%**.
- Rebased onto latest `main` (clean); re-verified post-rebase.
