### PR TITLE
fix: flaky frontend coverage gate on workspace_settings_panel.dart (#1626)

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -26,6 +26,7 @@ jobs:
               - 'src/frontend/test/**'
               - 'src/frontend/pubspec.yaml'
               - 'plugins/**/klangk/**'
+              - 'scripts/lcov-report.py'
               - '.github/workflows/frontend-tests.yml'
 
       - uses: subosito/flutter-action@v2

--- a/scripts/lcov-report.py
+++ b/scripts/lcov-report.py
@@ -13,11 +13,16 @@ def main():
         return
 
     files = {}
+    uncovered_lines: dict[str, list[int]] = {}
     current = None
     for line in lines:
         line = line.strip()
         if line.startswith("SF:"):
             current = line[3:]
+        elif line.startswith("DA:"):
+            parts = line[3:].split(",")
+            if len(parts) >= 2 and parts[1] == "0":
+                uncovered_lines.setdefault(current, []).append(int(parts[0]))
         elif line.startswith("LH:"):
             files.setdefault(current, {})["hit"] = int(line[3:])
         elif line.startswith("LF:"):
@@ -52,7 +57,11 @@ def main():
         for f, d in missing:
             short = f.replace("lib/", "")
             hit, total = d.get("hit", 0), d.get("total", 0)
-            print(f"  {short}: {total - hit} lines uncovered")
+            line_nums = uncovered_lines.get(f, [])
+            if line_nums:
+                print(f"  {short}: {total - hit} lines uncovered: {line_nums}")
+            else:
+                print(f"  {short}: {total - hit} lines uncovered")
         print(
             f"\nFAIL Required test coverage of {required}% "
             f"not reached. Total coverage: {pct:.2f}%"

--- a/src/frontend/lib/workspace/workspace_settings_panel.dart
+++ b/src/frontend/lib/workspace/workspace_settings_panel.dart
@@ -27,11 +27,18 @@ class WorkspaceSettingsPanelState extends State<WorkspaceSettingsPanel> {
   bool _loading = true;
   String? _error;
   String? _saveMessage;
+  Timer? _saveMessageTimer;
 
   @override
   void initState() {
     super.initState();
     _loadData();
+  }
+
+  @override
+  void dispose() {
+    _saveMessageTimer?.cancel();
+    super.dispose();
   }
 
   Future<void> _loadData() async {
@@ -106,7 +113,8 @@ class WorkspaceSettingsPanelState extends State<WorkspaceSettingsPanel> {
     if (resp.statusCode == 200) {
       setState(() => _saveMessage = 'Settings saved');
       _loadData();
-      Future.delayed(const Duration(seconds: 2), () {
+      _saveMessageTimer?.cancel();
+      _saveMessageTimer = Timer(const Duration(seconds: 2), () {
         if (mounted) setState(() => _saveMessage = null);
       });
     } else {

--- a/src/frontend/test/workspace_settings_panel_test.dart
+++ b/src/frontend/test/workspace_settings_panel_test.dart
@@ -118,7 +118,10 @@ Widget _buildPanel({WsClient? wsClient}) => MultiProvider(
         ChangeNotifierProvider(create: (_) => AuthService()),
         ChangeNotifierProvider.value(value: wsClient ?? WsClient()),
       ],
-      child: const MaterialApp(
+      // Non-const so that the Dart VM's coverage instrumentation observes
+      // the constructor call at runtime.  Const constructors are evaluated
+      // at compile time and invisible to coverage (dart-lang/sdk#38934).
+      child: MaterialApp(
         home: Scaffold(body: WorkspaceSettingsPanel(workspaceId: _wsId)),
       ),
     );


### PR DESCRIPTION
## Summary
- Remove `const` from the test's `WorkspaceSettingsPanel` instantiation so the constructor is called at runtime and observed by the Dart VM's coverage collector (dart-lang/sdk#38934, dart-lang/sdk#56644)
- Store the save-message `Timer` and cancel it in `dispose()` to prevent setState-after-dispose
- Print uncovered line numbers in `lcov-report.py` for future diagnosis
- Add `scripts/lcov-report.py` to the frontend CI path filter

## Root cause
The Dart VM evaluates `const` constructors at compile time, making them invisible to runtime coverage instrumentation. Combined with lazy compilation non-determinism, this caused a random line to appear uncovered on CI, defeating `coverage:ignore` pragmas since the uncovered line shifted between code versions.

## Test plan
- [x] All 905 frontend tests pass locally
- [x] Coverage reports 100% locally
- [ ] CI `test-frontend` job passes on this PR

Closes #1626