### PR TITLE
ci: rename backend test job test-python -> test-backend (stale branch-protection context)

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test-python:
+  test-backend:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## Summary

The Python test job in `.github/workflows/backend-tests.yml` was renamed `test-backend` → `test-python` by `caecb21f` (#1606, the klangkd/klangkc wheel rename), but **branch protection on `main` was never updated** — it still requires a status context named `test-backend`. So every PR since that merge shows `test-backend` stuck at "Waiting for status to be reported" indefinitely, even though the real Python suite (now check name `test-python`) runs and passes.

This renames the job back to `test-backend` so the emitted check name matches what branch protection expects.

| workflow | job id → check name | required context | match |
| --- | --- | --- | --- |
| `frontend-tests.yml` | `test-frontend` | `test-frontend` | ✓ |
| `backend-tests.yml` | `test-python` → **`test-backend`** | `test-backend` | ✓ (after) |
| `backend-e2e-tests.yml` | `test-backend-e2e` | `test-backend-e2e` | ✓ |
| `frontend-e2e-tests.yml` | `test-frontend-e2e` | `test-frontend-e2e` | ✓ |

## Why rename the job, not update branch protection

- Matches the filename (`backend-tests.yml`) and the `test-frontend` sibling convention.
- No internal references to the old `test-python` job id exist (no `needs:`, no outputs) — verified with `grep -rn test-python .github/`.
- The alternative (flip the required context to `test-python` via the protection API) is a one-line config change too, but leaves the check name inconsistent with its file and siblings.

## Test plan

CI on this PR will emit a check named `test-backend`; once it's green, the merge box on this PR (and every other open PR) should satisfy the `test-backend` required context instead of waiting forever.

## Context

Spotted while diagnosing PR #1635's CI, where `test-backend` showed "expected / Waiting for status to be reported" while `test-python` had passed.
