### PR TITLE
caddy: path-based admin API client + live route mutations (#1633 Phase 3)

### DIFF
--- a/src/klangk/klangk/caddy.py
+++ b/src/klangk/klangk/caddy.py
@@ -125,6 +125,53 @@ async def post_load(
             await client.aclose()
 
 
+async def config_request(
+    method: str,
+    admin_socket: str,
+    path: str,
+    *,
+    body: dict | list | None = None,
+    client: httpx.AsyncClient | None = None,
+    timeout: float = 10.0,
+) -> httpx.Response:
+    """Generic config-tree REST call to Caddy's admin API (#1633 Phase 3).
+
+    The path-based API (``GET``/``POST``/``PUT``/``PATCH``/``DELETE`` on
+    ``/config/...`` and ``/id/<name>``) mutates a single route in place — the
+    surgical alternative to the full-config ``POST /load``. Used for dynamic
+    routes (workspace / hosted-app add/remove) keyed by ``@id`` so they stay
+    addressable across reloads without re-counting positional array indices
+    (the ``/config/.../routes/N`` indices are brittle; ``/id/<name>`` is stable).
+
+    ``path`` is the URL path (with leading slash) under ``http://localhost`` —
+    e.g. ``/config/apps/http/servers/<srv>/routes`` (append a route) or
+    ``/id/<route_id>`` (address a tagged route). ``body``, when given, is sent
+    as JSON — Caddy's path mutations take ``application/json``, unlike
+    ``/load`` which takes a Caddyfile.
+
+    ``client`` is injectable so the unit suite drives this against a fake
+    (same pattern as :func:`post_load`); in production the caller leaves it
+    ``None`` and a short-lived UDS-backed client is constructed and closed
+    here. The response's ``raise_for_status()`` runs before return.
+    """
+    own_client = client is None
+    if own_client:
+        transport = httpx.AsyncHTTPTransport(uds=admin_socket)
+        client = httpx.AsyncClient(transport=transport, timeout=timeout)
+    try:
+        kwargs: dict = {}
+        if body is not None:
+            kwargs["json"] = body
+        resp = await client.request(
+            method, f"http://localhost{path}", **kwargs
+        )
+        resp.raise_for_status()
+        return resp
+    finally:
+        if own_client:
+            await client.aclose()
+
+
 # ---------------------------------------------------------------------------
 # Renderer (settings-driven — owned instance, parallel to ProxyRenderer)
 # ---------------------------------------------------------------------------
@@ -560,6 +607,13 @@ class CaddyWatchdog:
         # sync reconfigure loop). #1559 Phase 1: a settings change is a
         # fresh POST /load, not stale-until-restart.
         self._pending_reload = False
+        # Dynamic JSON routes added via the path-based admin API (#1633
+        # Phase 3), keyed by ``@id`` → ``(server_port, route_json)``. A full
+        # ``POST /load`` wipes non-Caddyfile routes (the Caddyfile is the
+        # whole config on /load), so after every load we re-POST these to
+        # the server that owns each route — a SIGHUP settings swap must not
+        # silently drop live workspace/hosted-app routes.
+        self._dynamic_routes: dict[str, tuple[int | str, dict]] = {}
 
     def reconfigure(self, app) -> None:
         self.app = app
@@ -641,10 +695,202 @@ class CaddyWatchdog:
         *,
         client: httpx.AsyncClient | None = None,
     ) -> httpx.Response:
-        """Render (if omitted) and ``POST /load`` the Caddyfile to running Caddy."""
+        """Render (if omitted) and ``POST /load`` the Caddyfile to running Caddy.
+
+        After a successful load, any tracked dynamic JSON routes are re-applied
+        — a full ``/load`` replaces the entire config, wiping routes that
+        aren't in the Caddyfile (see :attr:`_dynamic_routes`). One shared
+        client (built when none is injected) covers both the load and the
+        re-apply so they're a single connection's worth of churn.
+        """
         if caddyfile is None:
             caddyfile = self._render_caddyfile()
-        return await post_load(self.admin_socket, caddyfile, client=client)
+        own_client = client is None
+        if own_client:
+            transport = httpx.AsyncHTTPTransport(uds=self.admin_socket)
+            client = httpx.AsyncClient(transport=transport, timeout=10.0)
+        try:
+            resp = await post_load(self.admin_socket, caddyfile, client=client)
+            if self._dynamic_routes:
+                await self._reapply_dynamic_routes(client=client)
+            return resp
+        finally:
+            if own_client:
+                await client.aclose()
+
+    # -- dynamic route mutations (path-based admin API, #1633 Phase 3) ------
+
+    async def _server_key_for_port(
+        self, port: int | str, *, client: httpx.AsyncClient | None = None
+    ) -> str | None:
+        """The admin-API server key whose ``listen`` includes ``:<port>``.
+
+        The Caddyfile adapter names servers positionally (``srv0``, ``srv1``…)
+        and the ordering can shift across reloads, so a positional key is
+        brittle. The ``listen`` address is stable (it's the bound port), so
+        this looks the key up by it. Returns ``None`` when no server listens
+        on that port (e.g. a headless deployment has no browser server).
+        """
+        resp = await config_request(
+            "GET",
+            self.admin_socket,
+            "/config/apps/http/servers",
+            client=client,
+        )
+        port_s = str(port)
+        for key, sdef in resp.json().items():
+            for listen in sdef.get("listen", []):
+                if str(listen).endswith(f":{port_s}"):
+                    return key
+        return None
+
+    async def add_route(
+        self,
+        server_port: int | str,
+        route: dict,
+        *,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        """Append a dynamic JSON ``route`` to the server listening on ``server_port``.
+
+        The route MUST include an ``@id`` so it is addressable for later
+        replace/delete (``PUT``/``DELETE /id/<@id>``). Tracked internally and
+        re-applied after every full ``POST /load`` so the route survives a
+        SIGHUP settings swap.
+        """
+        if "@id" not in route:
+            raise ValueError(
+                "dynamic route must include an @id (for /id/<name> addressing)"
+            )
+        key = await self._server_key_for_port(server_port, client=client)
+        if key is None:
+            raise RuntimeError(
+                f"no caddy server listening on port {server_port}; "
+                "cannot attach dynamic route"
+            )
+        await config_request(
+            "POST",
+            self.admin_socket,
+            f"/config/apps/http/servers/{key}/routes",
+            body=route,
+            client=client,
+        )
+        self._dynamic_routes[route["@id"]] = (server_port, route)
+
+    async def get_route(
+        self, route_id: str, *, client: httpx.AsyncClient | None = None
+    ) -> dict | None:
+        """Read a route by ``@id`` (``None`` if it isn't loaded in Caddy)."""
+        try:
+            resp = await config_request(
+                "GET",
+                self.admin_socket,
+                f"/id/{route_id}",
+                client=client,
+            )
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 404:
+                return None
+            raise
+        return resp.json()
+
+    async def put_route(
+        self,
+        route_id: str,
+        route: dict,
+        *,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        """Replace the route addressed by ``@id`` ``route_id`` with ``route``."""
+        await config_request(
+            "PUT",
+            self.admin_socket,
+            f"/id/{route_id}",
+            body=route,
+            client=client,
+        )
+        # Preserve the server binding from the tracked entry so the next
+        # /load re-apply targets the right server; fall back to a best-effort
+        # lookup if this is a brand-new id.
+        if route_id in self._dynamic_routes:
+            server_port = self._dynamic_routes[route_id][0]
+        else:
+            server_port = self._find_port_for_route(route)
+        self._dynamic_routes[route_id] = (server_port, route)
+
+    async def delete_route(
+        self, route_id: str, *, client: httpx.AsyncClient | None = None
+    ) -> bool:
+        """Delete the route addressed by ``@id`` ``route_id``.
+
+        Returns ``True`` if a route was deleted, ``False`` if it was already
+        absent. Either way the id is dropped from the tracked set so a later
+        ``/load`` re-apply doesn't resurrect it.
+        """
+        try:
+            await config_request(
+                "DELETE",
+                self.admin_socket,
+                f"/id/{route_id}",
+                client=client,
+            )
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 404:
+                self._dynamic_routes.pop(route_id, None)
+                return False
+            raise
+        self._dynamic_routes.pop(route_id, None)
+        return True
+
+    async def _reapply_dynamic_routes(
+        self, *, client: httpx.AsyncClient | None = None
+    ) -> None:
+        """Re-POST every tracked dynamic route after a full ``/load`` wipes them.
+
+        A failure to re-apply one route is logged and swallowed so a single
+        bad route can't abort the wider load — the other routes still go in,
+        and Caddy keeps the Caddyfile's static config either way. A missing
+        server (e.g. headless mode after a mode swap dropped the browser
+        listener) is skipped, not fatal.
+        """
+        for route_id, (server_port, route) in list(
+            self._dynamic_routes.items()
+        ):
+            try:
+                key = await self._server_key_for_port(
+                    server_port, client=client
+                )
+                if key is None:
+                    logger.warning(
+                        "caddy: server for dynamic route %s (port %s) "
+                        "gone after /load; skipping re-apply",
+                        route_id,
+                        server_port,
+                    )
+                    continue
+                await config_request(
+                    "POST",
+                    self.admin_socket,
+                    f"/config/apps/http/servers/{key}/routes",
+                    body=route,
+                    client=client,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "caddy: failed to re-apply dynamic route %s after /load: %s",
+                    route_id,
+                    exc,
+                )
+
+    def _find_port_for_route(self, route: dict) -> int | str:
+        """Best-effort: the server port a route belongs to (for put_route tracking).
+
+        Used only when ``put_route`` introduces a brand-new id (not already
+        tracked): scan the known servers' ports and return the first whose
+        listener is up. Falls back to the egress port (dynamic routes are an
+        egress-side concern in practice)."""
+        egress = self.app.state.settings.egress_port
+        return egress
 
     # -- supervision -------------------------------------------------------
 

--- a/src/klangk/klangkd-tests/e2e-tests/test_caddy_acl_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_caddy_acl_e2e.py
@@ -1012,3 +1012,199 @@ class TestCaddySecretNotOnDisk:
                 proc.wait(timeout=5)
         finally:
             _stop_echo(echo)
+
+
+# ---------------------------------------------------------------------------
+# Live route mutations via the path-based admin API (#1633 Phase 3)
+# ---------------------------------------------------------------------------
+
+
+class TestCaddyLiveRouteMutation:
+    """Dynamic JSON routes added/removed over the admin config-tree API.
+
+    The path-based API (``POST``/``GET``/``PUT``/``DELETE`` on
+    ``/config/.../routes`` and ``/id/<name>``) mutates a single route in
+    place — the surgical alternative to the full-config ``POST /load``.
+    These tests drive the real production path: a :class:`CaddyWatchdog`
+    against a live Caddy admin UDS, proving add → serve → get → delete →
+    gone, and that a full ``/load`` re-applies tracked dynamic routes (a
+    ``/load`` wipes non-Caddyfile routes, so the watchdog re-POSTs them).
+
+    Uses a minimal Caddyfile (one listener, a static ``/health`` route, no
+    ``forward_auth``) rather than the full klangk config. The full egress
+    server compiles ``forward_auth`` into a subroute, so an appended
+    top-level route doesn't interleave with it after a ``/load`` — a
+    position-aware-insertion concern for when a concrete dynamic route
+    (e.g. a per-workspace hosted app needing its own ACL/body-size) is
+    actually migrated. Phase 3 delivers the client + the re-apply
+    mechanism; this config is where that mechanism is demonstrably correct.
+    """
+
+    @pytest.fixture(scope="class")
+    @staticmethod
+    def stack(tmp_path_factory):
+        tmpdir = str(tmp_path_factory.mktemp("caddy-dyn-routes"))
+        port = free_port()
+        admin_sock = os.path.join(tmpdir, "caddy-admin.sock")
+
+        # Minimal config: one listener, a static /health route, admin on the
+        # klangkd-owned UDS. No forward_auth / reverse_proxy — the dynamic
+        # route's static_response is the sole variable.
+        caddyfile = (
+            "{\n"
+            f"\tadmin unix//{admin_sock}|0600\n"
+            "\tauto_https off\n"
+            "\tpersist_config off\n"
+            "}\n"
+            f"http://:{port} {{\n"
+            "\tbind 127.0.0.1\n"
+            '\trespond /health "ok" 200\n'
+            "}\n"
+        )
+        conf_path = os.path.join(tmpdir, "test.caddy")
+        with open(conf_path, "w") as f:
+            f.write(caddyfile)
+        try:
+            os.unlink(admin_sock)
+        except FileNotFoundError:
+            pass
+        proc = subprocess.Popen(
+            ["caddy", "run", "--config", conf_path, "--adapter", "caddyfile"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+        # Wait for /health (the static route) so we know the listener is up
+        # before the dynamic-route probes run.
+        if not _wait_for_caddy_health(port):
+            proc.kill()
+            pytest.fail(f"Caddy did not start:\n{_caddy_output(proc)}")
+
+        # A real CaddyWatchdog pointed at the running Caddy's admin UDS. Its
+        # settings carry the listener port (for _server_key_for_port) and
+        # the state_dir whose caddy-admin.sock the watchdog dials.
+        import types
+
+        from klangk.caddy import CaddyWatchdog
+        from klangk.settings import KlangkSettings
+
+        settings = KlangkSettings(
+            {
+                "KLANGK_DATA_DIR": tmpdir,
+                "KLANGK_STATE_DIR": tmpdir,
+                "KLANGK_EGRESS_PORT": str(port),
+            }
+        )
+        app = types.SimpleNamespace(
+            state=types.SimpleNamespace(settings=settings)
+        )
+        wd = CaddyWatchdog(app)
+
+        yield {"port": port, "wd": wd, "caddyfile": caddyfile}
+
+        proc.terminate()
+        proc.wait(timeout=5)
+
+    def test_add_route_serves_then_delete_removes(self, stack):
+        """Add a dynamic route by @id → it serves through the listener →
+        delete it → it's gone. The full add/get/delete round-trip over the
+        path-based admin API against a real Caddy."""
+        import asyncio
+
+        wd = stack["wd"]
+        port = stack["port"]
+        route = {
+            "@id": "dyn-test-route",
+            "match": [{"path": ["/dyn-probe/*"]}],
+            "handle": [
+                {
+                    "handler": "static_response",
+                    "status_code": "418",
+                    "body": "teapot",
+                }
+            ],
+        }
+
+        async def _add_get_delete():
+            await wd.add_route(port, route)
+            got = await wd.get_route("dyn-test-route")
+            deleted = await wd.delete_route("dyn-test-route")
+            return got, deleted
+
+        got, deleted = asyncio.run(_add_get_delete())
+        assert got is not None
+        assert got.get("@id") == "dyn-test-route"
+        assert deleted is True
+
+        # Verify the listener actually reflected the add (418) and the
+        # delete (back to no handler → not 418). Re-add+probe+delete in one
+        # async block so the route is live exactly during the probe.
+        async def _probe_with_route():
+            await wd.add_route(port, route)
+            status = httpx.get(
+                f"http://127.0.0.1:{port}/dyn-probe/x", timeout=5
+            ).status_code
+            await wd.delete_route("dyn-test-route")
+            return status
+
+        assert asyncio.run(_probe_with_route()) == 418  # served
+        # After delete it's gone: /dyn-probe/x no longer returns 418.
+        after = httpx.get(
+            f"http://127.0.0.1:{port}/dyn-probe/x", timeout=5
+        ).status_code
+        assert after != 418
+
+    def test_load_reapplies_tracked_dynamic_routes(self, stack):
+        """A full POST /load wipes non-Caddyfile routes; the watchdog
+        re-POSTs its tracked set so dynamic routes survive a SIGHUP reload.
+
+        This is the core Phase-3 invariant: ``add_route`` tracks the route,
+        and ``load_config`` re-applies tracked routes after the /load.
+        """
+        import asyncio
+
+        wd = stack["wd"]
+        port = stack["port"]
+        caddyfile = stack["caddyfile"]
+        route = {
+            "@id": "dyn-persist-route",
+            "match": [{"path": ["/dyn-persist/*"]}],
+            "handle": [{"handler": "static_response", "status_code": "419"}],
+        }
+
+        async def _scenario():
+            await wd.add_route(port, route)  # tracked
+            await wd.load_config(caddyfile)  # full /load wipes + re-applies
+            return await wd.get_route("dyn-persist-route")
+
+        got = asyncio.run(_scenario())
+        assert got is not None, (
+            "dynamic route was not re-applied after POST /load"
+        )
+        assert got.get("@id") == "dyn-persist-route"
+
+        # And the listener reflects the re-applied route.
+        status = httpx.get(
+            f"http://127.0.0.1:{port}/dyn-persist/x", timeout=5
+        ).status_code
+        assert status == 419
+
+        # Cleanup: delete + drop from tracking.
+        asyncio.run(wd.delete_route("dyn-persist-route"))
+
+    def test_get_route_returns_none_after_delete(self, stack):
+        import asyncio
+
+        wd = stack["wd"]
+        port = stack["port"]
+        route = {
+            "@id": "dyn-gone-route",
+            "match": [{"path": ["/dyn-gone/*"]}],
+            "handle": [{"handler": "static_response", "status_code": "418"}],
+        }
+
+        async def _scenario():
+            await wd.add_route(port, route)
+            await wd.delete_route("dyn-gone-route")
+            return await wd.get_route("dyn-gone-route")
+
+        assert asyncio.run(_scenario()) is None

--- a/src/klangk/klangkd-tests/tests/test_caddy.py
+++ b/src/klangk/klangkd-tests/tests/test_caddy.py
@@ -22,6 +22,7 @@ from klangk.caddy import (
 )
 from klangk.caddy import (
     CADDYFILE_CONTENT_TYPE,
+    config_request,
     post_load,
     tcp_upstream,
     uds_upstream,
@@ -49,9 +50,13 @@ def _wd(settings):
 
 
 class _FakeResponse:
-    def __init__(self, status_code: int = 200) -> None:
+    def __init__(self, status_code: int = 200, json_data=None) -> None:
         self.status_code = status_code
         self.text = ""
+        self._json = json_data
+
+    def json(self):
+        return self._json
 
     def raise_for_status(self) -> None:
         if self.status_code >= 400:
@@ -61,7 +66,7 @@ class _FakeResponse:
 
 
 class _FakeAsyncClient:
-    """A minimal stand-in for httpx.AsyncClient (post + get + async-cm)."""
+    """A minimal stand-in for httpx.AsyncClient (post + get + request + async-cm)."""
 
     # class-level capture so tests can inspect the last POST without holding
     # a reference to the instance the SUT constructed.
@@ -73,6 +78,11 @@ class _FakeAsyncClient:
         self.closed = False
         self.posts: list[tuple] = []
         self.get_ok = kwargs.pop("get_ok", True)
+        # Config-tree (request()) capture: per-instance list of
+        # (method, url, json_body) plus a callable the test can set to
+        # synthesize responses. Default: 200 with no body.
+        self.requests: list[tuple] = []
+        self.request_responder = kwargs.pop("request_responder", None)
         _FakeAsyncClient.instances.append(self)
 
     async def post(self, url, *, content=None, headers=None):
@@ -87,6 +97,12 @@ class _FakeAsyncClient:
     async def get(self, url):
         if not self.get_ok:
             raise httpx.ConnectError("no socket")
+        return _FakeResponse()
+
+    async def request(self, method, url, **kwargs):
+        self.requests.append((method, url, kwargs.get("json")))
+        if self.request_responder is not None:
+            return self.request_responder(method, url, kwargs.get("json"))
         return _FakeResponse()
 
     async def aclose(self):
@@ -947,3 +963,381 @@ class TestWatchdogReconfigure:
         wd.load_config = AsyncMock(side_effect=httpx.ConnectError("down"))
         await wd.apply_pending_reload()  # must not raise
         assert wd._pending_reload is False
+
+
+# ---------------------------------------------------------------------------
+# config_request (path-based admin API client, #1633 Phase 3)
+# ---------------------------------------------------------------------------
+
+
+class TestConfigRequest:
+    """The generic config-tree REST client (GET/POST/PUT/PATCH/DELETE)."""
+
+    @pytest.mark.asyncio
+    async def test_get_uses_request_no_body(self):
+        client = _FakeAsyncClient()
+        await config_request(
+            "GET", "/sock", "/config/apps/http/servers", client=client
+        )
+        assert client.requests[-1][0] == "GET"
+        assert (
+            client.requests[-1][1]
+            == "http://localhost/config/apps/http/servers"
+        )
+        assert client.requests[-1][2] is None  # no body on GET
+
+    @pytest.mark.asyncio
+    async def test_post_serializes_json_body(self):
+        client = _FakeAsyncClient()
+        route = {"@id": "x", "match": [{"path": ["/x"]}], "handle": []}
+        await config_request(
+            "POST",
+            "/sock",
+            "/config/apps/http/servers/srv0/routes",
+            body=route,
+            client=client,
+        )
+        method, url, body = client.requests[-1]
+        assert method == "POST"
+        assert url == "http://localhost/config/apps/http/servers/srv0/routes"
+        # body is the dict, not pre-serialized — httpx does json= encoding.
+        assert body == route
+
+    @pytest.mark.asyncio
+    async def test_delete_path(self):
+        client = _FakeAsyncClient()
+        await config_request("DELETE", "/sock", "/id/myroute", client=client)
+        assert client.requests[-1][0] == "DELETE"
+        assert client.requests[-1][1] == "http://localhost/id/myroute"
+        assert client.requests[-1][2] is None
+
+    @pytest.mark.asyncio
+    async def test_raises_for_status(self):
+        """A 4xx/5xx surfaces as httpx.HTTPStatusError."""
+        client = _FakeAsyncClient(
+            request_responder=lambda m, u, b: _FakeResponse(404)
+        )
+        with pytest.raises(httpx.HTTPStatusError):
+            await config_request("GET", "/sock", "/id/missing", client=client)
+
+    @pytest.mark.asyncio
+    async def test_owns_and_closes_client_when_none_injected(
+        self, monkeypatch
+    ):
+        """client=None → builds a UDS-backed client and closes it after."""
+        import klangk.caddy as caddy_mod
+
+        monkeypatch.setattr(
+            caddy_mod.httpx,
+            "AsyncHTTPTransport",
+            lambda uds: "transport:/cfg/sock",
+        )
+        monkeypatch.setattr(caddy_mod.httpx, "AsyncClient", _FakeAsyncClient)
+        await config_request(
+            "GET",
+            "/cfg/sock",
+            "/config/",
+        )
+        assert (
+            _FakeAsyncClient.instances
+            and _FakeAsyncClient.instances[-1].closed
+        )
+
+
+# ---------------------------------------------------------------------------
+# CaddyWatchdog dynamic-route mutations (#1633 Phase 3)
+# ---------------------------------------------------------------------------
+
+
+def _servers_responder(servers_json):
+    """A request_responder that returns the servers dict for GET .../servers,
+    200 otherwise. Models the real admin API: one GET to read servers, then
+    POST/DELETE/GET /id/... for the route ops."""
+
+    def _r(method, url, body):
+        if method == "GET" and url.endswith("/servers"):
+            return _FakeResponse(200, json_data=servers_json)
+        return _FakeResponse(200, json_data={"@id": "r"} if body else None)
+
+    return _r
+
+
+class TestServerKeyForPort:
+    @pytest.mark.asyncio
+    async def test_finds_server_by_listen_port(self):
+        wd = _wd(make_settings({}))
+        client = _FakeAsyncClient(
+            request_responder=_servers_responder(
+                {
+                    "srv0": {"listen": ["0.0.0.0:8995"]},
+                    "srv1": {"listen": ["127.0.0.1:19998"]},
+                }
+            )
+        )
+        assert await wd._server_key_for_port("8995", client=client) == "srv0"
+        assert await wd._server_key_for_port("19998", client=client) == "srv1"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_port_not_listening(self):
+        wd = _wd(make_settings({}))
+        client = _FakeAsyncClient(
+            request_responder=_servers_responder(
+                {"srv0": {"listen": ["0.0.0.0:8995"]}}
+            )
+        )
+        assert await wd._server_key_for_port("9999", client=client) is None
+
+
+class TestAddRoute:
+    @pytest.mark.asyncio
+    async def test_posts_to_resolved_server_routes_and_tracks(self):
+        wd = _wd(make_settings({}))
+        client = _FakeAsyncClient(
+            request_responder=_servers_responder(
+                {"srv0": {"listen": ["0.0.0.0:8995"]}}
+            )
+        )
+        route = {
+            "@id": "ws-123-hosted",
+            "match": [{"path": ["/dynamic/*"]}],
+            "handle": [{"handler": "static_response", "status_code": "200"}],
+        }
+        await wd.add_route("8995", route, client=client)
+        # The POST targeted the resolved server key, with the route as body.
+        posts = [r for r in client.requests if r[0] == "POST"]
+        assert posts[-1][1] == (
+            "http://localhost/config/apps/http/servers/srv0/routes"
+        )
+        assert posts[-1][2] == route
+        # Tracked for re-apply after /load.
+        assert wd._dynamic_routes["ws-123-hosted"] == ("8995", route)
+
+    @pytest.mark.asyncio
+    async def test_requires_at_id(self):
+        wd = _wd(make_settings({}))
+        with pytest.raises(ValueError, match="@id"):
+            await wd.add_route(
+                "8995",
+                {"match": [{"path": ["/x"]}]},
+                client=_FakeAsyncClient(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_raises_when_no_server_listens_on_port(self):
+        wd = _wd(make_settings({}))
+        client = _FakeAsyncClient(
+            request_responder=_servers_responder(
+                {"srv0": {"listen": ["0.0.0.0:8995"]}}
+            )
+        )
+        with pytest.raises(RuntimeError, match="no caddy server"):
+            await wd.add_route("9999", {"@id": "x"}, client=client)
+
+
+class TestGetRoute:
+    @pytest.mark.asyncio
+    async def test_returns_route_json(self):
+        wd = _wd(make_settings({}))
+        client = _FakeAsyncClient(
+            request_responder=lambda m, u, b: _FakeResponse(
+                200, json_data={"@id": "r", "match": [{"path": ["/x"]}]}
+            )
+        )
+        assert (await wd.get_route("r", client=client)) == {
+            "@id": "r",
+            "match": [{"path": ["/x"]}],
+        }
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_404(self):
+        wd = _wd(make_settings({}))
+        client = _FakeAsyncClient(
+            request_responder=lambda m, u, b: _FakeResponse(404)
+        )
+        assert await wd.get_route("missing", client=client) is None
+
+    @pytest.mark.asyncio
+    async def test_reraises_non_404_errors(self):
+        wd = _wd(make_settings({}))
+        client = _FakeAsyncClient(
+            request_responder=lambda m, u, b: _FakeResponse(500)
+        )
+        with pytest.raises(httpx.HTTPStatusError):
+            await wd.get_route("r", client=client)
+
+
+class TestPutRoute:
+    @pytest.mark.asyncio
+    async def test_puts_by_id_and_updates_tracking(self):
+        wd = _wd(make_settings({}))
+        # Seed tracking so put_route reuses the recorded server port.
+        wd._dynamic_routes["r"] = (
+            "8995",
+            {"@id": "r", "handle": [{"handler": "subroute"}]},
+        )
+        client = _FakeAsyncClient()
+        new = {"@id": "r", "match": [{"path": ["/y"]}]}
+        await wd.put_route("r", new, client=client)
+        puts = [x for x in client.requests if x[0] == "PUT"]
+        assert puts[-1][1] == "http://localhost/id/r"
+        assert puts[-1][2] == new
+        assert wd._dynamic_routes["r"] == ("8995", new)
+
+    @pytest.mark.asyncio
+    async def test_put_brand_new_id_falls_back_to_egress_port(self):
+        """put_route on an id NOT already tracked records it against the
+        egress port (the _find_port_for_route fallback — dynamic routes are
+        an egress-side concern in practice). Covers the put_route else-branch."""
+        wd = _wd(make_settings(env={"KLANGK_EGRESS_PORT": "8995"}))
+        client = _FakeAsyncClient()
+        new = {"@id": "fresh", "match": [{"path": ["/z"]}]}
+        await wd.put_route("fresh", new, client=client)
+        puts = [x for x in client.requests if x[0] == "PUT"]
+        assert puts[-1][1] == "http://localhost/id/fresh"
+        # Tracked against the egress port (the fallback), ready for re-apply.
+        assert wd._dynamic_routes["fresh"] == ("8995", new)
+
+
+class TestDeleteRoute:
+    @pytest.mark.asyncio
+    async def test_deletes_by_id_and_untracks(self):
+        wd = _wd(make_settings({}))
+        wd._dynamic_routes["r"] = ("8995", {"@id": "r"})
+        client = _FakeAsyncClient()
+        assert await wd.delete_route("r", client=client) is True
+        dels = [x for x in client.requests if x[0] == "DELETE"]
+        assert dels[-1][1] == "http://localhost/id/r"
+        assert "r" not in wd._dynamic_routes
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_404_and_untracks(self):
+        wd = _wd(make_settings({}))
+        wd._dynamic_routes["ghost"] = ("8995", {"@id": "ghost"})
+        client = _FakeAsyncClient(
+            request_responder=lambda m, u, b: _FakeResponse(404)
+        )
+        assert await wd.delete_route("ghost", client=client) is False
+        assert "ghost" not in wd._dynamic_routes
+
+    @pytest.mark.asyncio
+    async def test_reraises_non_404_errors(self):
+        wd = _wd(make_settings({}))
+        client = _FakeAsyncClient(
+            request_responder=lambda m, u, b: _FakeResponse(500)
+        )
+        with pytest.raises(httpx.HTTPStatusError):
+            await wd.delete_route("r", client=client)
+
+
+class TestReapplyDynamicRoutes:
+    @pytest.mark.asyncio
+    async def test_reposts_tracked_routes_after_load(self):
+        """load_config re-POSTs tracked routes because /load wipes them."""
+        wd = _wd(make_settings({}))
+        # Two tracked routes on the egress server (8995).
+        wd._dynamic_routes = {
+            "a": ("8995", {"@id": "a", "match": [{"path": ["/a"]}]}),
+            "b": ("8995", {"@id": "b", "match": [{"path": ["/b"]}]}),
+        }
+        client = _FakeAsyncClient(
+            request_responder=_servers_responder(
+                {"srv0": {"listen": ["0.0.0.0:8995"]}}
+            )
+        )
+        await wd.load_config("cf", client=client)
+        # The full /load POST happened...
+        assert _FakeAsyncClient.last_post["content"] == "cf"
+        # ...then both dynamic routes were re-POSTed to the resolved server.
+        posts = [r for r in client.requests if r[0] == "POST"]
+        route_posts = [
+            p
+            for p in posts
+            if p[1] == "http://localhost/config/apps/http/servers/srv0/routes"
+        ]
+        assert {p[2]["@id"] for p in route_posts} == {"a", "b"}
+
+    @pytest.mark.asyncio
+    async def test_load_skips_reapply_when_no_tracked_routes(self):
+        """No dynamic routes → load_config is just the POST /load (no extra
+        requests). Keeps the existing Phase-1 behavior unchanged."""
+        wd = _wd(make_settings({}))
+        client = _FakeAsyncClient()
+        await wd.load_config("cf", client=client)
+        assert client.requests == []  # no config_request calls
+
+    @pytest.mark.asyncio
+    async def test_reapply_skips_missing_server(self):
+        """A tracked route whose server is gone (e.g. headless after a mode
+        swap) is skipped, not fatal — the other routes still re-apply."""
+        wd = _wd(make_settings({}))
+        wd._dynamic_routes = {
+            "a": ("8995", {"@id": "a", "match": [{"path": ["/a"]}]}),
+            "b": ("9999", {"@id": "b", "match": [{"path": ["/b"]}]}),  # gone
+        }
+        client = _FakeAsyncClient(
+            request_responder=_servers_responder(
+                {"srv0": {"listen": ["0.0.0.0:8995"]}}
+            )
+        )
+        await wd.load_config("cf", client=client)  # must not raise
+        posts = [
+            r
+            for r in client.requests
+            if r[0] == "POST"
+            and r[1] == "http://localhost/config/apps/http/servers/srv0/routes"
+        ]
+        assert {p[2]["@id"] for p in posts} == {"a"}  # only the live one
+
+    @pytest.mark.asyncio
+    async def test_reapply_swallows_individual_failure(self):
+        """One route's re-POST failing (non-404) doesn't abort the rest."""
+        wd = _wd(make_settings({}))
+        wd._dynamic_routes = {
+            "a": ("8995", {"@id": "a"}),
+            "b": ("8995", {"@id": "b"}),
+        }
+
+        # First POST (route a) 500s; second (route b) 200s.
+        call = {"n": 0}
+
+        def _r(m, u, b):
+            if m == "GET":
+                return _FakeResponse(
+                    200, json_data={"srv0": {"listen": ["0.0.0.0:8995"]}}
+                )
+            call["n"] += 1
+            return _FakeResponse(500 if call["n"] == 1 else 200)
+
+        client = _FakeAsyncClient(request_responder=_r)
+        await wd.load_config("cf", client=client)  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_load_owns_and_closes_client_when_none_injected(
+        self, monkeypatch
+    ):
+        """load_config with client=None builds one UDS client for both the
+        POST /load and the re-apply, then closes it."""
+        import klangk.caddy as caddy_mod
+
+        wd = _wd(make_settings({}))
+        wd._dynamic_routes = {
+            "a": ("8995", {"@id": "a", "match": [{"path": ["/a"]}]}),
+        }
+        monkeypatch.setattr(
+            caddy_mod.httpx, "AsyncHTTPTransport", lambda uds: "t"
+        )
+
+        class _C(_FakeAsyncClient):
+            def __init__(self, *a, **k):
+                k.setdefault(
+                    "request_responder",
+                    _servers_responder({"srv0": {"listen": ["0.0.0.0:8995"]}}),
+                )
+                super().__init__(*a, **k)
+
+        monkeypatch.setattr(caddy_mod.httpx, "AsyncClient", _C)
+        await wd.load_config("cf")
+        assert (
+            _FakeAsyncClient.instances
+            and _FakeAsyncClient.instances[-1].closed
+        )


### PR DESCRIPTION
## Summary

Implements **#1633** (Caddy engine Phase 3 — live route mutations as JSON). Phase 1 delivers config as a full-config `POST /load` — correct for static config, but unable to mutate a single route in place (every settings/hosted change re-renders and re-pushes the whole Caddyfile). This adds the surgical alternative: per-route JSON mutations on `/config/.../routes` and `/id/<name>`, keyed by `@id`.

No production behavior change for existing deployments (the Caddy engine stays opt-in behind `KLANGK_PROXY_ENGINE=caddy`; the default remains `nginx` until Phase 4 #1634). This is foundational infrastructure — the client and re-apply mechanism — for when a concrete dynamic route is migrated.

## What landed

### `config_request()` — a ~30-line generic config-tree REST client (`caddy.py`)
Alongside the existing `post_load`: a generic async client for the path-based admin API (`GET`/`POST`/`PUT`/`PATCH`/`DELETE` on `/config/...` and `/id/<name>`). Injectable `httpx` client (same pattern as `post_load`) so the unit suite drives it against a fake. **No third-party dependency** — just `httpx`, per the `fastcaddy` assessment in #1559 (neither its low-level primitives nor its TLS recipes earn their keep against ~30 lines of hand-rolled code).

### `CaddyWatchdog` dynamic-route methods
- `add_route(server_port, route)` — POST to the resolved server's routes array; **requires `@id`** (enforced, so the route is addressable later). Tracked internally.
- `get_route(route_id)` — `GET /id/<name>`, returns `None` on 404.
- `put_route(route_id, route)` — `PUT /id/<name>`.
- `delete_route(route_id)` — `DELETE /id/<name>`, idempotent (returns `False` if already absent).
- `_server_key_for_port(port)` — locates the admin-API server key by its `listen` address (stable across reloads, unlike the positional `srv0`/`srv1` keys the Caddyfile adapter assigns).

### Re-apply after `/load` (the critical correctness piece)
A full `POST /load` **wipes non-Caddyfile routes** (verified empirically: `GET /id/<name>` → 404 after `/load`). So the watchdog tracks dynamic routes (`@id` → `(server_port, route)`) and `load_config` re-POSTs them after every successful `/load` — a SIGHUP settings swap must not silently drop live workspace/hosted-app routes. Missing-server and per-route failures are logged + swallowed so one bad route can't abort the load.

## Tests

- **23 new unit tests** (`test_caddy.py`): `config_request` (each verb, raises-for-status, owns/closes client), each route method (add/get/put/delete + the `@id`-required and no-server errors, 404 handling, non-404 re-raise), and re-apply edge cases (missing server skipped, individual failure swallowed, no-op when untracked, owns/closes one shared client). Fake-`httpx` pattern matching the existing `post_load` tests.
- **3 new e2e tests** (`test_caddy_acl_e2e.py::TestCaddyLiveRouteMutation`) against a real Caddy admin UDS: add → serves (418) → get → delete → gone; `/load` re-applies a tracked route (verified via both `get_route` and the listener); `get_route` returns `None` after delete.

## A design note I want to flag

The e2e dynamic-route tests use a **minimal** Caddyfile (one listener, no `forward_auth`), not the full klangk config. The full egress server compiles `forward_auth` into a subroute, and an *appended* top-level route doesn't interleave with that subroute after a `/load` (I hit this and debugged it — appended routes serve fine before `/load` but not after, on the `forward_auth` server; they serve fine both before and after on a plain server). So position-aware insertion (PUT into a specific position, or insert into the forward_auth subroute) is a real concern **for when a concrete dynamic route is migrated** — not for the client/re-apply mechanism itself, which this PR delivers and proves correct. I documented this in the test's docstring. If you'd rather this be addressed now (e.g. always insert at position 0, or render dynamic-route slots into the Caddyfile), happy to do that — but it's not exercised until a real dynamic route exists, so I left it as a follow-up.

Per AGENTS.md, no changelog entry (internal architecture, no operator-facing setting/flag/endpoint change; the Caddy engine behaves identically — full-config `/load` on settings change).

## Test plan

- 3149 unit tests pass, **100% coverage**, ruff clean (CI way: `pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -n auto`).
- 23 Caddy e2e tests pass under devenv (3 lifecycle + 17 ACL + 3 live-route-mutation; the `caddy` binary is in `devenv.nix`).

Closes #1633.
