### PR TITLE
chore(e2e): drop unused adm-zip (CVE-2026-39244, dependabot #2)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -505,3 +505,12 @@ set-password <email>` (set a known password for the default user — whose
   nginx with 403. Loopback (local browsers) and other IPs (remote browsers)
   are unaffected. The three container endpoints keep their existing allowlist +
   workspace-token `auth_request`.
+
+- **Removed unused `adm-zip` devDependency from the frontend e2e-test
+  package (#2).** `adm-zip` and `@types/adm-zip` were declared in
+  `src/frontend/e2e-tests/package.json` but never imported anywhere in the
+  tree; dropping them eliminates the vulnerable `0.5.x` line
+  (CVE-2026-39244 / GHSA-xcpc-8h2w-3j85 — crafted ZIP triggers a 4 GB
+  memory allocation) flagged by Dependabot. `npm audit` now reports 0
+  vulnerabilities; Playwright still compiles all 202 tests. No production
+  code depended on the package.

--- a/src/frontend/e2e-tests/package-lock.json
+++ b/src/frontend/e2e-tests/package-lock.json
@@ -7,10 +7,8 @@
       "name": "klangk-e2e-tests",
       "devDependencies": {
         "@playwright/test": "1.59.1",
-        "@types/adm-zip": "^0.5.8",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/ws": "^8.18.1",
-        "adm-zip": "^0.5.17",
         "jsonwebtoken": "^9.0.3",
         "ws": "^8.18.2"
       }
@@ -29,16 +27,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@types/adm-zip": {
-      "version": "0.5.8",
-      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.8.tgz",
-      "integrity": "sha512-RVVH7QvZYbN+ihqZ4kX/dMiowf6o+Jk1fNwiSdx0NahBJLU787zkULhGhJM8mf/obmLGmgdMM0bXsQTmyfbR7Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/jsonwebtoken": {
@@ -77,16 +65,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0"
       }
     },
     "node_modules/buffer-equal-constant-time": {

--- a/src/frontend/e2e-tests/package.json
+++ b/src/frontend/e2e-tests/package.json
@@ -8,10 +8,8 @@
   },
   "devDependencies": {
     "@playwright/test": "1.59.1",
-    "@types/adm-zip": "^0.5.8",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/ws": "^8.18.1",
-    "adm-zip": "^0.5.17",
     "jsonwebtoken": "^9.0.3",
     "ws": "^8.18.2"
   }


### PR DESCRIPTION
## Summary

Resolves Dependabot alert **#2** — [`adm-zip` < 0.6.0 (CVE-2026-39244 / GHSA-xcpc-8h2w-3j85)](https://github.com/mcdonc/klangk/security/dependabot/2): a crafted ZIP file triggers a ~4 GB memory allocation.

## What was wrong

`adm-zip@0.5.17` and `@types/adm-zip` were declared as `devDependencies` in `src/frontend/e2e-tests/package.json` but **never imported anywhere** in the tree:

```
$ rg -n "adm-zip|AdmZip" --glob '!**/package-lock.json'
./src/frontend/e2e-tests/package.json:11:    "@types/adm-zip": "^0.5.8",
./src/frontend/e2e-tests/package.json:14:    "adm-zip": "^0.5.17",
```

Dead weight that dragged in a CVE.

## Fix

Removed both packages from `package.json` and regenerated `package-lock.json`. This drops the vulnerable `0.5.x` line entirely (rather than bumping across the `0.5`→`0.6` major boundary) since nothing consumes the library.

## Verification

- `npm install` → `removed 3 packages`, **`found 0 vulnerabilities`**.
- `npx playwright test --list` → all **202 tests** in 28 files compile and list cleanly (Playwright is the TS entry point; `tsc` is not a direct dep).
- `markdownlint` / `prettier` / `trufflehog` pre-commit hooks pass.
- Changelog entry added under `[Unreleased]` → `### Security`.

## Files

- `src/frontend/e2e-tests/package.json` — removed `adm-zip`, `@types/adm-zip`.
- `src/frontend/e2e-tests/package-lock.json` — regenerated (3 packages removed).
- `docs/changes.md` — `### Security` entry.

Merging this PR will auto-resolve alert #2 (Dependabot dismisses alerts once the patched state reaches the default branch).

Refs: https://github.com/mcdonc/klangk/security/dependabot/2
