### PR TITLE
Rename klangkd.conf → klangkd.yaml in code + docs (#1652)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -479,7 +479,7 @@ set-password <email>` (set a known password for the default user — whose
   `seed_default_user` ran on every boot and created a fresh admin from
   `KLANGK_DEFAULT_USER` / `KLANGK_DEFAULT_PASSWORD` whenever the configured
   email didn't match an existing user — so anyone able to edit
-  `klangkd.conf` (or set the `KLANGK_DEFAULT_*` env vars) could mint or
+  `klangkd.yaml` (or set the `KLANGK_DEFAULT_*` env vars) could mint or
   reset an admin account by editing those values and restarting, bypassing
   all auth and admin-invite flows. Seeding is now gated on **`admin`-group
   emptiness**: an admin is created from `KLANGK_DEFAULT_*` only when the
@@ -489,7 +489,7 @@ set-password <email>` (set a known password for the default user — whose
   also prevents lockout: editing `KLANGK_DEFAULT_USER` and restarting can
   no longer clobber the already-seeded admin's identity. To change the
   admin after first boot, use the normal in-app / `klangkc admin` paths.
-  Deployers should still treat `klangkd.conf` as sensitive (first-boot
+  Deployers should still treat `klangkd.yaml` as sensitive (first-boot
   password, LLM keys, JWT secret), but it is no longer a standing
   admin-minting credential.
 

--- a/docs/reference/environment.md
+++ b/docs/reference/environment.md
@@ -6,7 +6,7 @@
 
 `$DEVENV_STATE` refers to `<project root>/.devenv/state` — this is where devenv stores runtime data.
 
-For local development, settings live in `klangkd.conf` (gitignored; copy from `klangkd.conf.example`). Environment variables override config-file values.
+For local development, settings live in `klangkd.yaml` (gitignored; copy from `klangkd.yaml.example`). Environment variables override config-file values.
 
 **`file:` prefix:** Any env var can be prefixed with `file:` to read the value from a file (e.g. `KLANGK_JWT_SECRET=file:/run/secrets/jwt`). The file contents are stripped of leading/trailing whitespace. This works with secret management tools like agenix/sops that write decrypted secrets to files. If the file cannot be read, construction **fails** with a `ValidationError` — see [#1461](https://github.com/mcdonc/klangk/issues/1461) (fail-fast at boot, not silently at use time).
 

--- a/docs/reference/klangkd-config.md
+++ b/docs/reference/klangkd-config.md
@@ -18,7 +18,7 @@ This means an operator can set the bulk of a deployment's config in the YAML fil
 
 | Invocation                              | Behavior                                                        |
 | --------------------------------------- | --------------------------------------------------------------- |
-| `klangkd`                               | Requires `/etc/klangkd.conf` to exist. Missing → startup error. |
+| `klangkd`                               | Requires `/etc/klangkd.yaml` to exist. Missing → startup error. |
 | `klangkd --config /path/to/config.yaml` | Uses the specified file. Missing → startup error.               |
 | `klangkd --config=none`                 | No config file — env vars and built-in defaults only.           |
 
@@ -81,7 +81,7 @@ If `KLANGK_OIDC_CONFIG` is also set (as an env var), the separate file wins — 
 A production-ready config file covering all common settings:
 
 ```yaml
-# /etc/klangkd.conf
+# /etc/klangkd.yaml
 
 # --- Auth / identity ---
 auth_modes: both

--- a/docs/reference/oidc.md
+++ b/docs/reference/oidc.md
@@ -11,7 +11,7 @@ OIDC providers can be configured in two ways: **inline** in the `klangkd` config
 Add an `oidc_providers` section to your `klangkd` config file:
 
 ```yaml
-# /etc/klangkd.conf
+# /etc/klangkd.yaml
 auth_modes: both
 
 oidc_providers:

--- a/src/klangk/klangk/launcher.py
+++ b/src/klangk/klangk/launcher.py
@@ -7,13 +7,13 @@ otherwise), and owns the proxy child (currently nginx) that fronts it.
 
 Usage::
 
-    klangkd                          # requires /etc/klangkd.conf
+    klangkd                          # requires /etc/klangkd.yaml
     klangkd --config /path/to/cfg.yaml
     klangkd --config=none            # env-vars-only (the sole opt-out)
 
 Config-file resolution (three states, no implicit escape):
 
-1. Bare ``klangkd`` → requires ``/etc/klangkd.conf``; missing → error.
+1. Bare ``klangkd`` → requires ``/etc/klangkd.yaml``; missing → error.
 2. ``--config=<path>`` → that path required to exist; missing → error.
 3. ``--config=none`` → run from env vars + built-in defaults (no file).
 
@@ -39,7 +39,7 @@ from klangk.settings import KlangkSettings
 
 # The default config-file location — a deployed klangkd finds its config here
 # with no args.  See #1395.
-DEFAULT_CONFIG_PATH = "/etc/klangkd.conf"
+DEFAULT_CONFIG_PATH = "/etc/klangkd.yaml"
 
 app = typer.Typer(
     add_completion=False,
@@ -73,7 +73,7 @@ def main(  # pragma: no cover
         "--config",
         "-c",
         help=(
-            "Path to a YAML config file (default: /etc/klangkd.conf). "
+            "Path to a YAML config file (default: /etc/klangkd.yaml). "
             "Use 'none' to run from env vars only (no config file)."
         ),
     ),

--- a/src/klangk/klangk/main.py
+++ b/src/klangk/klangk/main.py
@@ -190,7 +190,7 @@ class Lifecycle:
         install, or after every admin has been deleted). Once at least one admin
         exists, this method **never** creates, renames, re-emails, or
         re-passwords a user: ``KLANGK_DEFAULT_*`` is ignored, so editing it in
-        ``klangkd.conf`` and restarting cannot mint a new admin (the
+        ``klangkd.yaml`` and restarting cannot mint a new admin (the
         config-mints-admin security hole) or clobber the existing admin's
         identity (lockout). Changing the admin after the first boot is done
         via the normal in-app / ``klangkc admin`` paths.


### PR DESCRIPTION
## Summary

Resolves #1652. Renames every `klangkd.conf` reference to `klangkd.yaml` in code and docs.

## What & why

The server's config file is YAML, and the repo template is already named `klangkd.yaml.example` — but the code still called it `/etc/klangkd.conf`:

- `launcher.py:42` — `DEFAULT_CONFIG_PATH = "/etc/klangkd.conf"`
- `launcher.py:10, 16, 76` — module docstring + `--config` help text
- `main.py:193` — comment
- `docs/reference/environment.md`, `klangkd-config.md`, `oidc.md` — reference docs
- `docs/changes.md` — two mentions in the unreleased #1622 entry

A `.conf` name for a YAML file (and one that disagrees with the actual on-disk template) was just legacy. Standardized on `klangkd.yaml` everywhere.

## Compatibility

None needed. **No release has shipped a config file at all yet**, so this is a clean rename — no `/etc/klangkd.conf` legacy path to honor, no fallback, no deprecation window. (Same reasoning as the issue.)

No changelog entry of its own, for the same reason: nothing operator-facing has shipped, so there's nothing to announce.

## Verification

- `rg klangkd.conf` across the tree returns nothing (worktree clean of the old name).
- All four changed `.md` files pass `markdownlint` (the repo's local `.markdownlint.yaml` disables MD013/MD024-siblings).
- Full Python suite: **3130 passed, 100% coverage** (`pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -n auto`).
- pre-commit hooks pass (markdownlint, prettier, ruff, trufflehog).

## Files

- `src/klangk/klangk/launcher.py` — `DEFAULT_CONFIG_PATH` + docstring + `--config` help.
- `src/klangk/klangk/main.py` — one comment.
- `docs/reference/environment.md`, `docs/reference/klangkd-config.md`, `docs/reference/oidc.md` — reference docs.
- `docs/changes.md` — two `klangkd.conf` mentions in the unreleased #1622 section.

Refs: #1652
