### PR TITLE
test(1666): frontend e2e — built feature artifacts visible through /api/config

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -36,7 +36,11 @@ operators or integrators to act when upgrading.
   manifest contract (shape, scopes, `defaults` / `container_env_keys`
   invariants), and the 7-on-disk / 4-Dart asymmetry is locked. The suite
   runs in `test-backend` CI (broadened path-filter to include `scripts/`,
-  `plugins/`, `plugins.yaml`).
+  `plugins/`, `plugins.yaml`). A frontend e2e spec
+  (`src/frontend/e2e-tests/e2e/features.spec.ts`) also asserts the built
+  `features.json` is served at `/features.json` and `/api/v1/config`
+  surfaces the frontend-scope keys — proving the build → serve → API chain
+  end-to-end against a real booted `klangkd`.
 
 - **Feature manifest (`features.json`) + per-deploy activation
   (`KLANGK_FEATURES_ENABLE`) (#1655).** The build emits a single

--- a/src/frontend/e2e-tests/e2e/features.spec.ts
+++ b/src/frontend/e2e-tests/e2e/features.spec.ts
@@ -1,0 +1,103 @@
+// Feature-artifact e2e — what the frontend actually sees at boot (#1666).
+//
+// After `klangk:flutter-build` emits features.json next to index.html and
+// klangkd serves the frontend dir at /, the browser (at boot) fetches two
+// artifacts: the sibling features.json (per-feature metadata + the
+// default-on set) and /api/v1/config (the deploy's active-feature knob +
+// the frontend-scope config values). This spec asserts both are served and
+// carry the expected feature set — proving the build → serve → API chain
+// is intact end-to-end.
+//
+// Runs in the chromium-api project (API/sibling-file fetches, no browser
+// rendering). The full "does the UI render the feature" path is heavier
+// (features surface as Pi extensions / app-bar actions inside a workspace)
+// and lives elsewhere; this is the artifact-visibility gate.
+//
+// Keep EXPECTED_FEATURES in sync with scripts/tests/test_build_pipeline.py
+// and the checked-in plugins.yaml.
+
+import { test, expect } from "@playwright/test";
+import { API_BASE } from "./helpers";
+
+// The four plugins with a klangk/ Dart package — the set that appears in
+// features.json's features[] list (TS-only plugins are absent from the
+// manifest; they're baked into the workspace image and always-on, #1655).
+const EXPECTED_FEATURES = ["celebrate", "beep", "boingball", "git-credential"];
+
+test.describe("feature artifacts visible to the frontend", () => {
+  test("features.json is served at /features.json with the expected set", async ({
+    request,
+  }) => {
+    const resp = await request.get(`${API_BASE}/features.json`);
+    expect(
+      resp.ok(),
+      "features.json must be served as a frontend sibling",
+    ).toBeTruthy();
+    const manifest = await resp.json();
+
+    // Top-level shape — the runtime Plugins._read_manifest() contract.
+    expect(manifest).toHaveProperty("features");
+    expect(manifest).toHaveProperty("defaults");
+    expect(manifest).toHaveProperty("container_env_keys");
+
+    const featureNames = (manifest.features as Array<{ name: string }>).map(
+      (f) => f.name,
+    );
+    // Every expected Dart feature is in the served manifest. (We don't assert
+    // exact equality — a future PR may add a dormant compiled-in feature like
+    // soliplex (#1664) without breaking this test. The build-pipeline unit
+    // test locks the exact set; this asserts the subset the frontend cares
+    // about is present after the real build + serve.)
+    for (const name of EXPECTED_FEATURES) {
+      expect(featureNames, `features.json missing ${name}`).toContain(name);
+    }
+
+    // defaults is a list of strings (the frontend reads it as the default-on
+    // set when KLANGK_FEATURES_ENABLE is unset).
+    expect(Array.isArray(manifest.defaults)).toBeTruthy();
+    for (const d of manifest.defaults as unknown[]) {
+      expect(typeof d).toBe("string");
+    }
+  });
+
+  test("/api/v1/config surfaces frontend-scope keys from the manifest", async ({
+    request,
+  }) => {
+    // /api/v1/config is public (the login page fetches it pre-auth for
+    // oidc_providers / login_banner), so no auth needed.
+    const resp = await request.get(`${API_BASE}/api/v1/config`);
+    expect(resp.ok()).toBeTruthy();
+    const config = await resp.json();
+
+    // boingball declares KLANGK_BOING_SPEED with scope: frontend — the server
+    // lowercases the key (KLANGK_ prefix included) and resolves the value.
+    // The key's *presence* is what matters: it proves the server read
+    // features.json and bridged the frontend-scope config block through to
+    // /api/config. The plugin reads exactly this lowercased name
+    // (plugins/boingball/klangk/lib/plugin.dart), so a drift here breaks
+    // the runtime contract between server and plugin.
+    expect(
+      config,
+      "klangk_boing_speed missing — server didn't bridge boingball's frontend config",
+    ).toHaveProperty("klangk_boing_speed");
+
+    // git-credential's KLANGK_GITHUB_OAUTH_CLIENT_ID has scope: container, so
+    // it must NOT appear in /api/config (frontend-scope only). Guards against
+    // a scope-classification regression leaking container env into the
+    // browser. Lowercased form — the server lowercases all config keys.
+    expect(config).not.toHaveProperty("klangk_github_oauth_client_id");
+  });
+
+  test("/api/v1/config omits features_enable when KLANGK_FEATURES_ENABLE unset", async ({
+    request,
+  }) => {
+    // The e2e server is launched without KLANGK_FEATURES_ENABLE, so the
+    // frontend must fall back to the manifest's defaults list. Asserting the
+    // key is absent (not just falsy) locks the canonical-semantics contract
+    // from #1655: unset → frontend uses defaults; set → exactly that list.
+    const resp = await request.get(`${API_BASE}/api/v1/config`);
+    expect(resp.ok()).toBeTruthy();
+    const config = await resp.json();
+    expect(config).not.toHaveProperty("features_enable");
+  });
+});

--- a/src/frontend/e2e-tests/playwright.config.ts
+++ b/src/frontend/e2e-tests/playwright.config.ts
@@ -74,7 +74,12 @@ export default defineConfig({
     {
       // API-only and simple-UI tests — no cross-browser behavior, run once.
       name: "chromium-api",
-      testMatch: ["api.spec.ts", "branding.spec.ts", "token-expiry.spec.ts"],
+      testMatch: [
+        "api.spec.ts",
+        "branding.spec.ts",
+        "features.spec.ts",
+        "token-expiry.spec.ts",
+      ],
       use: chromiumUse,
     },
     {


### PR DESCRIPTION
<!-- issue: https://github.com/mcdonc/klangk/issues/1666 -->

# Frontend e2e — built feature artifacts visible through /api/config

Closes #1666 (layer 3 done right). Adds the "through the frontend" gate that the build-pipeline emission tests (#1667, merged) couldn't provide: boots real `klangkd` against the real built frontend and asserts the artifacts the browser depends on at boot are served and carry the expected feature set.

## Why this isn't a Dart unit test

I first tried layer 3 as a `flutter test` of `createAllNamedPlugins()` — it doesn't work. The plugins unconditionally `import 'dart:js_interop'` (beep plays Web Audio, boingball runs JS via `window.eval`), so they're **web-only** code. `flutter test` runs on the VM and can't compile them (`Error: 'JSString' isn't a type`). The only thing that compile-tests them is `flutter build web` itself, which already runs in `test-frontend-e2e` CI. So the real gap isn't "does the aggregator compile" (the build already proves that) — it's "does the built artifact reach the running system's API, and does the frontend's boot contract hold." That's an e2e test.

## What's new

**`src/frontend/e2e-tests/e2e/features.spec.ts`** — 3 tests, `chromium-api` project (same shape as `api.spec.ts` / `branding.spec.ts`: API/sibling-file fetches, no browser rendering).

- `GET /features.json` serves the sibling manifest with the 4 expected Dart features (`celebrate`, `beep`, `boingball`, `git-credential`) + a well-formed `defaults` list. Proves the build emitted the manifest and klangkd serves it as a static sibling of `index.html`.
- `GET /api/v1/config` surfaces frontend-scope config keys (`klangk_boing_speed`) and does **not** leak container-scope keys (`klangk_github_oauth_client_id`). Proves the server read `features.json` and bridged the right scope through to the API.
- `/api/v1/config` omits `features_enable` when `KLANGK_FEATURES_ENABLE` is unset — locks the canonical-semantics contract from #1655 (unset → frontend falls back to manifest defaults).

`playwright.config.ts`: adds `features.spec.ts` to the `chromium-api` project's `testMatch`.

## No key-naming change

This PR is test-only — `frontend_config()` continues to lowercase each key wholesale (`KLANGK_BOING_SPEED` → `klangk_boing_speed`), matching what the boingball plugin reads (`data['klangk_boing_speed']`). Earlier drafts of this PR tried stripping the `KLANGK_` prefix (`boing_speed`) and verbatim passthrough (`KLANGK_BOING_SPEED`); both were reverted in favor of leaving the existing lowercase-whole behavior untouched.

## Verification

- 3168 unit tests pass (3148 klangk + 20 scripts), 100% coverage on `klangk`, `-n auto`.
- 3 e2e tests pass against a real booted `klangkd` + real built frontend (`flutterbuildweb.sh` → `features.json`).
- All pre-commit hooks green (ruff, prettier, markdownlint, dart format, yamllint, actionlint, trufflehog).
