### PR TITLE
release(1656): publish the klangk wheel to PyPI on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,3 +76,64 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Build + publish the klangk wheel to PyPI via trusted publishing (OIDC,
+  # no API token — same shape as the deleted cli-publish.yml pre-#1606).
+  # Runs in parallel with the image build — the wheel doesn't need
+  # podman/docker, and pip/uv users (the #1607 / #1645 first-run audience)
+  # get an installable artifact via `pip install klangk==<tag>`. The
+  # distribution name is ``klangk`` (one unified wheel ships the klangkd
+  # server + klangk CLI, #1606); the tag is ``vX.Y.Z``; hatch-vcs derives
+  # the version from it.
+  #
+  # Trusted-publishing prereq (PyPI side, one-time): the `klangk` PyPI
+  # project must have a trusted publisher configured for this repo +
+  # workflow + environment (mcdonc/klangk, .github/workflows/release.yml,
+  # environment name: pypi). With that in place PyPI validates the OIDC
+  # token from GitHub Actions and publishes with no secret on our side.
+  build-wheel:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: pypi # PyPI trusted publisher binds to this environment name
+    permissions:
+      id-token: write # OIDC attestation — the only permission trusted publishing needs
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # hatch-vcs needs full history to derive the version
+
+      - uses: ./.github/actions/devenv-setup
+        with:
+          # Build the frontend with the default plugin set (checked-in
+          # plugins.yaml, #1660) so the wheel's klangk/frontend/ carries
+          # the compiled UI + features.json. The hatch build hook
+          # (hatch_build_frontend.py) force-includes it and *requires* it
+          # for non-editable wheel builds (#1600).
+          build-tasks: klangk:flutter-build
+
+      - name: Build wheel
+        run: |
+          . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+          # scripts/build_wheel.sh installs python-build transiently (uv-sync
+          # at shell entry would wipe it; the script installs + builds in one
+          # process). Requires the frontend artifact from klangk:flutter-build
+          # above — the hatch build hook force-includes it and requires it for
+          # non-editable wheel builds (#1600).
+          devenv shell -- bash scripts/build_wheel.sh
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: klangk-wheel
+          path: src/klangk/dist/*.whl
+          retention-days: 30
+
+      - name: Publish to PyPI
+        # Trusted publishing (OIDC) — no API token. pypa/gh-action-pypi-publish
+        # negotiates an OIDC token from GitHub Actions and presents it to
+        # PyPI, which validates it against the trusted-publisher config on
+        # the `klangk` project (environment: pypi, workflow: release.yml).
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: src/klangk/dist
+          skip-existing: true # idempotent on re-runs of the same tag

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -27,6 +27,19 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **The `klangk` wheel is now published to PyPI on tag push (#1656).**
+  `release.yml` gains a parallel `build-wheel` job that builds the frontend
+  (default plugin set from the checked-in `plugins.yaml`) and produces the
+  wheel via `scripts/build_wheel.sh`, then publishes it via **trusted
+  publishing (OIDC)** — `pypa/gh-action-pypi-publish@release/v1` with
+  `permissions.id-token: write` and `environment: pypi`, no API token secret
+  (same shape as the deleted `cli-publish.yml` pre-#1606). `pip install
+klangk==<tag>` now yields a working `klangkd` with the UI served from the
+  in-wheel `klangk/frontend/`. This is the release artifact the pip/uv
+  first-run UX (#1607 / #1645) was designed for. Requires a one-time
+  trusted-publisher config on the `klangk` PyPI project bound to this repo /
+  workflow / environment.
+
 - **Build-pipeline integration tests for the plugin build path (#1666).**
   `scripts/tests/test_build_pipeline.py` runs the real
   `update_plugins.py` + `import_dart_plugins.py` against the checked-in

--- a/docs/development/releasing.md
+++ b/docs/development/releasing.md
@@ -7,7 +7,56 @@ devenv shell -- git tag v0.1.0
 devenv shell -- git push origin v0.1.0
 ```
 
-This builds the host image (including workspace and Flutter web), pushes both `klangk-host` and `klangk-workspace` to GHCR tagged with the version (e.g. `v0.1.0`), and creates a GitHub Release. The release body is GitHub's auto-generated notes (PR list + compare link) **with that version's section from [the changelog](../changes.md) prepended**, when one exists. No `:latest` tag is pushed — all images are referenced by explicit version. For patch releases, increment the patch version: `v0.1.1`.
+The workflow runs two jobs in parallel:
+
+- **`build-and-release`** — builds the host image (including workspace and
+  Flutter web), pushes both `klangk-host` and `klangk-workspace` to GHCR
+  tagged with the version (e.g. `v0.1.0`), and creates a GitHub Release. The
+  release body is GitHub's auto-generated notes (PR list + compare link)
+  **with that version's section from [the changelog](../changes.md)
+  prepended**, when one exists. No `:latest` tag is pushed — all images are
+  referenced by explicit version.
+- **`build-wheel`** — builds the `klangk` wheel (with the default-plugin-set
+  frontend baked in) and publishes it to PyPI, so `pip install klangk==<tag>`
+  yields a working `klangkd` with the UI served from the in-wheel
+  `klangk/frontend/` (#1656).
+
+For patch releases, increment the patch version: `v0.1.1`.
+
+## PyPI publishing
+
+The `build-wheel` job publishes via **trusted publishing (OIDC)** — no API
+token. `pypa/gh-action-pypi-publish@release/v1` negotiates an OIDC token
+from GitHub Actions and presents it to PyPI, which validates it against the
+trusted-publisher config on the `klangk` PyPI project.
+
+**One-time setup (PyPI side):** the `klangk` PyPI project must have a
+trusted publisher configured for:
+
+- PyPI project: `klangk` (the distribution name, #1606)
+- GitHub repo: `mcdonc/klangk`
+- Workflow filename: `.github/workflows/release.yml`
+- Environment name: `pypi` (the job's `environment:`)
+
+With that in place, no secret is needed on the GitHub side — the publish is
+authenticated purely via OIDC attestation. `skip-existing: true` makes the
+upload idempotent on re-runs of the same tag (PyPI refuses re-upload of the
+same filename).
+
+The wheel is built by `scripts/build_wheel.sh`, which installs
+`python-build` transiently (it's not a declared dependency of the runtime
+venv) and runs `python3 -m build --wheel` from `src/klangk/`. The hatch
+build hook (`src/klangk/hatch_build_frontend.py`) force-includes the Flutter
+web build at `klangk/frontend/` and **requires** it for non-editable wheel
+builds — so the `build-wheel` job runs `klangk:flutter-build` first (which
+runs `flutterbuildweb.sh` against the checked-in `plugins.yaml`, #1660).
+
+To build a wheel locally for testing (after running `flutterbuildweb.sh`):
+
+```bash
+devenv shell -- bash scripts/build_wheel.sh
+# produces src/klangk/dist/klangk-<version>-py3-none-any.whl
+```
 
 ## Gardening the changelog before a tag
 
@@ -15,4 +64,4 @@ This builds the host image (including workspace and Flutter web), pushes both `k
 
 ## CI
 
-The `release.yml` workflow builds and pushes the host image to GHCR, triggered by pushing a version tag matching `v[0-9]*`. The `image-workspace.yml` workflow builds and pushes the workspace image independently on push to `main` (when workspace container files change).
+The `release.yml` workflow builds and pushes the host image to GHCR + the wheel to PyPI, triggered by pushing a version tag matching `v[0-9]*`. The `image-workspace.yml` workflow builds and pushes the workspace image independently on push to `main` (when workspace container files change).

--- a/scripts/build_wheel.sh
+++ b/scripts/build_wheel.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Build the klangk release wheel (#1656).
+#
+# Run AFTER scripts/flutterbuildweb.sh has produced src/frontend/build/web/
+# (the hatch build hook force-includes it into the wheel at klangk/frontend/,
+# and *requires* it for non-editable wheel builds — #1600). release.yml runs
+# this as the "Build wheel" step with klangk:flutter-build as the devenv
+# build-task, which runs flutterbuildweb.sh first.
+#
+# The ``build`` package isn't a declared dependency of the klangk venv (the
+# venv is the app's runtime, not a build env). uv-sync runs at devenv shell
+# entry and would wipe a transiently-installed build on the next shell, so
+# this script installs it and builds in the same shell invocation.
+#
+# Usage: devenv shell -- bash scripts/build_wheel.sh
+#   (or directly, inside a devenv shell)
+# Produces: src/klangk/dist/klangk-<version>-py3-none-any.whl
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Install the PEP 517 build frontend transiently. uv-sync has already run by
+# the time we're inside the shell; this install persists for this process.
+uv pip install build
+
+# Build the wheel from src/klangk (where pyproject.toml + the build hook live).
+cd "$REPO_ROOT/src/klangk"
+python3 -m build --wheel
+
+# Report what we produced.
+echo "=== built wheels ==="
+ls -lh dist/*.whl


### PR DESCRIPTION
<!-- issue: https://github.com/mcdonc/klangk/issues/1656 -->

# Publish the `klangk` wheel to PyPI on tag push (trusted publishing)

Closes #1656. `release.yml` gains a parallel `build-wheel` job that builds the wheel (with the default-plugin-set frontend baked in) and publishes it to PyPI via **trusted publishing (OIDC) — no API token**, matching the shape of the deleted `cli-publish.yml` (per the issue's history comment). `pip install klangk==<tag>` now yields a working `klangkd` with the UI served from the in-wheel `klangk/frontend/` — the release artifact the pip/uv first-run UX (#1607 / #1645) was designed for.

## What's new

**`build-wheel` job in `release.yml`** (runs in parallel with the existing `build-and-release` image+GHCR job — the wheel doesn't need podman/docker):

1. `devenv-setup` with `build-tasks: klangk:flutter-build` — runs `flutterbuildweb.sh` against the checked-in `plugins.yaml` (the default plugin set, post-#1660)
2. `scripts/build_wheel.sh` — installs `python-build` transiently (uv-sync at devenv shell entry would wipe it; install + build share one process) and runs `python3 -m build --wheel` from `src/klangk/`
3. Uploads the wheel as a CI artifact (for inspection / manual retrieval)
4. `pypa/gh-action-pypi-publish@release/v1` — trusted publishing (OIDC)

The hatch build hook (`hatch_build_frontend.py`) force-includes the Flutter web build at `klangk/frontend/` and **requires** it for non-editable wheel builds (#1600) — so the frontend-build prerequisite is enforced.

**`scripts/build_wheel.sh`** — new, runnable locally for manual release testing.

**`docs/development/releasing.md`** — documents the `build-wheel` job, the trusted-publishing model + PyPI-side setup, and how to build a wheel locally.

## Trusted publishing — no secret on our side

| | |
| --- | --- |
| `environment:` | `pypi` (PyPI's trusted-publisher config binds to this) |
| `permissions:` | `id-token: write` (the only perm OIDC attestation needs) |
| Publish action | `pypa/gh-action-pypi-publish@release/v1` |
| Secret | **none** — the action negotiates an OIDC token from GitHub Actions and presents it to PyPI, which validates it against the trusted-publisher config on the `klangk` project |

This mirrors the deleted `cli-publish.yml` (per the issue's history comment): no `PYPI_API_TOKEN`, no `TWINE_PASSWORD`. The publish is authenticated purely via OIDC attestation gated by the PyPI-side trusted-publisher config.

**One-time setup (PyPI side, documented in `releasing.md`):** the `klangk` PyPI project must have a trusted publisher configured for:

- PyPI project: `klangk` (the distribution name, #1606)
- GitHub repo: `mcdonc/klangk`
- Workflow filename: `.github/workflows/release.yml`
- Environment name: `pypi`

## Smoke-tested locally

- `flutterbuildweb.sh` + `scripts/build_wheel.sh` produces `klangk-<version>-py3-none-any.whl` (~27MB)
- Verified the wheel contains `klangk/frontend/index.html`, `klangk/frontend/features.json`, `klangk/frontend/main.dart.js` (51 frontend files total)
- `actionlint`, `shellcheck`, `yamllint`, `prettier`, `markdownlint` all clean

## Design notes

- **Parallel, not serial.** The wheel job runs alongside the image build — flutter builds twice (~2 min each, on separate runners) but the wheel publish doesn't wait for the full image build + push (~10+ min). Worth the redundancy for the parallelism.
- **`fetch-depth: 0`** on checkout so hatch-vcs can derive the version from the full git history (the tag → version mapping needs the tag to be reachable).
- **`skip-existing: true`** on the publish action makes the upload idempotent on re-runs of the same tag (PyPI refuses re-upload of the same filename; this makes it a no-op instead of a failure).
- **Tag scheme.** Kept unified — `v[0-9]*` triggers both the image release and the PyPI publish in one tag push. The old `cli-v*` decoupling (deleted with `cli-publish.yml` in #1606) isn't reintroduced; #1606 unified the distributions, so one tag suffices.

## CI caveat

This PR's CI run won't exercise the new `build-wheel` job — it only triggers on `v*` tag pushes. The job was smoke-tested locally (wheel builds clean, contains the expected artifacts). First real exercise is the next tagged release.
