### PR TITLE
feat(1645): first-run config generation — no admin/password unless the deploy mode needs one

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -27,6 +27,24 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **First-run config generation: a bare `klangkd` boots with no config
+  file (#1645).** When `klangkd` is invoked with no `--config` and no
+  `klangkd.yaml` exists at the resolved path (`$KLANGK_CONFIG_DIR/klangkd.yaml`,
+  default `~/.config/klangk/klangkd.yaml`), a near-empty template is generated
+  pointing at the solo docs (#1629) with commented examples for the mode
+  transitions. No admin identity or password is emitted — the admin row is
+  seeded at runtime: `default_user` defaults to `<unixuser>@example.com`
+  (derived from `getpass.getuser()`), with `password_hash=None` in `none`/`oidc`
+  mode (the row is load-bearing for `/auth/local` token minting but no
+  endpoint checks the hash). `password`/`both` mode requires
+  `KLANGK_DEFAULT_PASSWORD` (fail-fast if unset — auto-generate-and-print was
+  removed as a lockout footgun for detached deployments). Combined with the
+  wheel publish (#1656), `pip install klangkd && klangkd` yields a usable
+  solo instance with no config file and no password. The `--config` default
+  changed from `/etc/klangkd.yaml` to the XDG config dir — the host container
+  and devenv both pass `--config=none` explicitly, so existing deployments are
+  unaffected. Existing `klangkd.yaml` files are never overwritten.
+
 - **The `klangk` wheel is now published to PyPI on tag push (#1656).**
   `release.yml` gains a parallel `build-wheel` job that builds the frontend
   (default plugin set from the checked-in `plugins.yaml`) and produces the

--- a/docs/features/auth-modes.md
+++ b/docs/features/auth-modes.md
@@ -48,6 +48,46 @@ OIDC, or combined login.
 > redeploying to preserve your intended auth posture. See
 > [Switching modes](#switching-modes).
 
+## Seeding behavior across modes
+
+On every boot, the lifespan seeds a default admin row **only when the admin
+group is empty** (first boot, or after every admin has been deleted —
+[#1622](https://github.com/mcdonc/klangk/issues/1622)). What gets seeded depends
+on `auth_modes` and (for password modes) whether `KLANGK_DEFAULT_PASSWORD`
+is staged. The two tables below are the acceptance matrix for this behavior
+([#1645](https://github.com/mcdonc/klangk/issues/1645)).
+
+### Table A — first boot (fresh DB, admin group empty)
+
+| `auth_modes`   | bind                                                     | `default_password` | behavior                                                                                                                   |
+| -------------- | -------------------------------------------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| `none` (unset) | UDS (no `KLANGK_PORT`)                                   | n/a                | Seed admin row, `password_hash=None`. No password minted, nothing printed. `/auth/local` works (loopback-token).           |
+| `none` (unset) | TCP loopback (`KLANGK_PORT` + `KLANGK_LISTEN=127.0.0.1`) | n/a                | Same as UDS row. `/auth/local` works from loopback.                                                                        |
+| `none` (unset) | TCP non-loopback (`KLANGK_LISTEN=0.0.0.0`)               | n/a                | **Fail-fast:** `none` mode refuses a non-loopback bind.                                                                    |
+| `oidc`         | any                                                      | n/a                | Seed admin row, `password_hash=None`. The seeded row exists for `/auth/local` and as a recovery identity.                  |
+| `password`     | any                                                      | set                | Seed admin row with `default_password`'s value (hashed). No print.                                                         |
+| `password`     | any                                                      | unset              | **Fail-fast:** `auth_modes=password requires KLANGK_DEFAULT_PASSWORD (set it in klangkd.yaml or the env)`. Refuse to boot. |
+| `both`         | any                                                      | set                | Seed admin row with `default_password`'s value (hashed). No print.                                                         |
+| `both`         | any                                                      | unset              | **Fail-fast:** same as `password`.                                                                                         |
+
+The admin identity (`default_user`) defaults to `<unixuser>@example.com`,
+derived from the invoking Unix user. Explicit `KLANGK_DEFAULT_USER` (env or
+`klangkd.yaml`) always wins.
+
+### Table B — subsequent starts (admin group non-empty)
+
+The [#1622](https://github.com/mcdonc/klangk/issues/1622) gate short-circuits
+seeding once any admin exists — so `default_user` / `default_password` /
+`auth_modes` changes after first boot have **no effect on the seeded row**.
+Subsequent starts don't re-seed, re-password, or re-email. Changing the admin
+after first boot is done via the in-app UI or `klangk admin users *`.
+
+| `auth_modes` (now) | `default_password` (now) | first-boot admin row state                                                   | behavior on restart                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| ------------------ | ------------------------ | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| any                | any                      | admin row exists with a real hash (was `password`/`both` at first boot)      | Seed skipped. Existing admin's email/password unchanged. Login uses the existing credentials.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| any                | any                      | admin row exists with `password_hash=None` (was `none`/`oidc` at first boot) | Seed skipped. Existing admin row untouched — `password_hash` stays `None`. If `auth_modes` is now `password`/`both`, **boot fails fast** with "requires at least one admin with a password" — the Table B lockout guard fires before the server serves traffic, so the operator can't get into an unrecoverable state. Recovery: flip back to `none` mode (the null hash is fine there), use `/auth/local` to get an admin token, run `klangk admin users set-password` to set a real hash, then flip back to `password`/`both`. Or re-empty the admin group + reseed with `KLANGK_DEFAULT_PASSWORD` staged. |
+| any                | set                      | admin group emptied between boots                                            | Reseed from current `default_user`/`default_password` (delete-resurrection, #1622). Gating per Table A applies to this re-seed.                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+
 ## No-auth mode (`none`)
 
 `none` is the foundation for a no-friction single-user dev/test loop —
@@ -138,10 +178,9 @@ so the new mode takes effect the moment the server restarts.
 
 This is the common upgrade path: you've been running solo in `none` mode and
 now want real logins (for yourself and/or teammates). One thing to sort out
-first: **the password for the default user.** The seeded admin user always
-has a password — either `KLANGK_DEFAULT_PASSWORD` if you set it, or a random
-one the server printed to stderr at first boot. If you didn't capture that
-random password, set a known one now while you're still holding the free
+first: **the password for the default user.** In `none` mode the seeded
+admin has no password (`password_hash=None` — nothing checks it). Before
+flipping to `password`/`both`, set one while you're still holding the free
 admin token:
 
 ```bash

--- a/docs/reference/klangkd-config.md
+++ b/docs/reference/klangkd-config.md
@@ -14,15 +14,15 @@ This means an operator can set the bulk of a deployment's config in the YAML fil
 
 ## `--config` flag
 
-`klangkd` requires a config file by default. There are three modes:
+`klangkd` resolves its config file in three modes:
 
-| Invocation                              | Behavior                                                        |
-| --------------------------------------- | --------------------------------------------------------------- |
-| `klangkd`                               | Requires `/etc/klangkd.yaml` to exist. Missing → startup error. |
-| `klangkd --config /path/to/config.yaml` | Uses the specified file. Missing → startup error.               |
-| `klangkd --config=none`                 | No config file — env vars and built-in defaults only.           |
+| Invocation                              | Behavior                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `klangkd`                               | Resolves `$KLANGK_CONFIG_DIR/klangkd.yaml` (default `~/.config/klangk/klangkd.yaml`). If the file is missing it is **generated** as a near-empty template pointing at the docs ([#1645](https://github.com/mcdonc/klangk/issues/1645)). No admin identity or password is emitted — the admin row is seeded at runtime: `default_user` defaults to `<unixuser>@example.com`, with `password_hash=None` in `none`/`oidc` mode (no password needed) and `KLANGK_DEFAULT_PASSWORD` required in `password`/`both` mode (fail-fast if unset). |
+| `klangkd --config /path/to/config.yaml` | Uses the specified file. Missing → startup error. Explicit paths are never auto-generated.                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `klangkd --config=none`                 | No config file — env vars and built-in defaults only.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 
-There is no silent fallback. The only way to run without a config file is `--config=none`.
+A bare `klangkd` is the pip/uv first-run path: install the wheel, run `klangkd`, log in with the printed credentials. System deployments that manage config out-of-band typically use `--config=none` (the host container's `supervisord.conf` does this) or `--config=<explicit-path>` (a deployment pipeline writes the file before starting `klangkd`).
 
 ## Key mapping
 
@@ -254,29 +254,29 @@ port: "8997"
 
 ### Container / workspace
 
-| Key                          | Default                              | Env var                                   |
-| ---------------------------- | ------------------------------------ | ----------------------------------------- |
-| `data_dir`                   | `<state_dir>/data`                   | `KLANGK_DATA_DIR`                         |
-| `state_dir`                  | `$XDG_STATE_HOME/klangk`             | `KLANGK_STATE_DIR`                        |
-| `config_dir`                 | `$XDG_CONFIG_HOME/klangk`            | `KLANGK_CONFIG_DIR`                       |
-| `customize_dir`              | `<config_dir>/custom`                | `KLANGK_CUSTOMIZE_DIR`                    |
-| `features_enable`            | _(unset → manifest `defaults`)_      | `KLANGK_FEATURES_ENABLE`                  |
-| `image_name`                 | `klangk-workspace`                   | `KLANGK_IMAGE_NAME`                       |
-| `image_pull_policy`          | `never`                              | `KLANGK_IMAGE_PULL_POLICY`                |
-| `allowed_images`             |                                      | `KLANGK_ALLOWED_IMAGES`                   |
-| `allowed_mount_roots`        |                                      | `KLANGK_ALLOWED_MOUNT_ROOTS`              |
-| `allow_autostart`            |                                      | `KLANGK_ALLOW_AUTOSTART`                  |
-| `allow_sudo`                 |                                      | `KLANGK_ALLOW_SUDO`                       |
-| `container_subnets`          | _(auto-derived)_                     | `KLANGK_CONTAINER_SUBNETS`                |
-| `userns`                     |                                      | `KLANGK_USERNS`                           |
-| `podman_bin`                 | `podman`                             | `KLANGK_PODMAN_BIN`                       |
-| `disable_tmux`               |                                      | `KLANGK_DISABLE_TMUX`                     |
-| `health_check_interval`      |                                      | `KLANGK_HEALTH_CHECK_INTERVAL`            |
-| `health_check_startup_grace` |                                      | `KLANGK_HEALTH_CHECK_STARTUP_GRACE`       |
-| `health_check_timeout`       |                                      | `KLANGK_HEALTH_CHECK_TIMEOUT`             |
-| `hosted_ports_per_workspace` | `5`                                  | `KLANGK_HOSTED_PORTS_PER_WORKSPACE`       |
-| `test_mode`                  |                                      | `KLANGK_TEST_MODE`                        |
-| `version_file`               |                                      | `KLANGK_VERSION_FILE`                     |
+| Key                          | Default                         | Env var                             |
+| ---------------------------- | ------------------------------- | ----------------------------------- |
+| `data_dir`                   | `<state_dir>/data`              | `KLANGK_DATA_DIR`                   |
+| `state_dir`                  | `$XDG_STATE_HOME/klangk`        | `KLANGK_STATE_DIR`                  |
+| `config_dir`                 | `$XDG_CONFIG_HOME/klangk`       | `KLANGK_CONFIG_DIR`                 |
+| `customize_dir`              | `<config_dir>/custom`           | `KLANGK_CUSTOMIZE_DIR`              |
+| `features_enable`            | _(unset → manifest `defaults`)_ | `KLANGK_FEATURES_ENABLE`            |
+| `image_name`                 | `klangk-workspace`              | `KLANGK_IMAGE_NAME`                 |
+| `image_pull_policy`          | `never`                         | `KLANGK_IMAGE_PULL_POLICY`          |
+| `allowed_images`             |                                 | `KLANGK_ALLOWED_IMAGES`             |
+| `allowed_mount_roots`        |                                 | `KLANGK_ALLOWED_MOUNT_ROOTS`        |
+| `allow_autostart`            |                                 | `KLANGK_ALLOW_AUTOSTART`            |
+| `allow_sudo`                 |                                 | `KLANGK_ALLOW_SUDO`                 |
+| `container_subnets`          | _(auto-derived)_                | `KLANGK_CONTAINER_SUBNETS`          |
+| `userns`                     |                                 | `KLANGK_USERNS`                     |
+| `podman_bin`                 | `podman`                        | `KLANGK_PODMAN_BIN`                 |
+| `disable_tmux`               |                                 | `KLANGK_DISABLE_TMUX`               |
+| `health_check_interval`      |                                 | `KLANGK_HEALTH_CHECK_INTERVAL`      |
+| `health_check_startup_grace` |                                 | `KLANGK_HEALTH_CHECK_STARTUP_GRACE` |
+| `health_check_timeout`       |                                 | `KLANGK_HEALTH_CHECK_TIMEOUT`       |
+| `hosted_ports_per_workspace` | `5`                             | `KLANGK_HOSTED_PORTS_PER_WORKSPACE` |
+| `test_mode`                  |                                 | `KLANGK_TEST_MODE`                  |
+| `version_file`               |                                 | `KLANGK_VERSION_FILE`               |
 
 ### LLM
 

--- a/src/klangk/klangk/first_run.py
+++ b/src/klangk/klangk/first_run.py
@@ -1,0 +1,128 @@
+"""First-run config generation so a bare ``klangkd`` boots (#1645 / #1607).
+
+When ``klangkd`` is invoked with no ``--config`` and the resolved config file
+doesn't exist, this generates a default ``klangkd.yaml`` at that path: a
+near-empty template pointing at the solo docs (#1629) with commented examples
+for the state transitions (enabling the browser, switching to multiuser).
+
+No ``default_user`` or ``default_password`` is emitted — the admin identity
+is derived from the invoking Unix user at runtime (settings default), and a
+password is only needed (and fail-fast required) when the operator explicitly
+switches to ``auth_modes: password`` / ``both``. The generated file's purpose
+is discoverability (``this is where your config lives``) + a quick-reference
+for the mode transitions, not carrying any seeded identity.
+
+The resolved config-file path lives under ``KLANGK_CONFIG_DIR`` (default
+``$XDG_CONFIG_HOME/klangk``, #1649). ``KLANGK_CONFIG_DIR`` is read from the
+env **before** any ``KlangkSettings`` construction — it can't come from
+``klangkd.yaml`` because ``klangkd.yaml`` is what we're locating (the
+bootstrap rule from #1649).
+
+Constraints:
+
+- **Never overwrite an existing file** — generation is gated on the file's
+  absence (the caller checks; the ``open("x")`` mode also refuses a race).
+- **Never emit a ``config_dir:`` key** — it would be ignored with a warning
+  per #1649 (``klangkd.yaml`` can't relocate the config tree it lives in).
+- **No plugin seeding** — the runtime reads a shipped manifest (#1655) and
+  the wheel bakes the default set's UIs (#1656); no runtime declaration
+  needed.
+- **#1622 admin-seeding gate unchanged** — ``seed_default_user`` still
+  refuses to re-seed once an admin exists.
+
+Cross-platform note (#1607): the XDG fallback applies on macOS too — we
+deliberately do not switch to ``~/Library/Application Support``.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from pathlib import Path
+
+from klangk.settings import _XDG_SUBDIR, _xdg_config_home
+
+# The filename inside ``config_dir``. Renamed from ``klangkd.conf`` in #1654.
+_CONFIG_FILENAME = "klangkd.yaml"
+
+
+def default_config_path() -> str:
+    """Return the config-file path a bare ``klangkd`` resolves to.
+
+    ``$KLANGK_CONFIG_DIR/klangkd.yaml`` when the env var is set (the
+    operator's explicit override), else ``$XDG_CONFIG_HOME/klangk/klangkd.yaml``
+    (XDG fallback to ``~/.config`` — Linux *and* macOS, per #1607).
+
+    Resolved purely from the env (no ``KlangkSettings`` construction) per
+    #1649's bootstrap rule: ``klangkd.yaml`` can't relocate the config tree
+    it lives in, so the config-tree root has to be computable before we
+    locate the file.
+    """
+    config_dir = os.environ.get("KLANGK_CONFIG_DIR") or os.path.join(
+        _xdg_config_home(), _XDG_SUBDIR
+    )
+    return os.path.join(config_dir, _CONFIG_FILENAME)
+
+
+def _render_config() -> str:
+    """Render the generated ``klangkd.yaml`` body.
+
+    Intentionally a near-empty template — the admin identity is derived at
+    runtime from the Unix user (settings default), and a password is only
+    required when the operator switches to password mode. The file carries
+    discoverability + commented examples for the mode transitions, nothing
+    more. Settings not listed here use the in-code defaults.
+    """
+    timestamp = datetime.now().astimezone().strftime("%Y-%m-%d %H:%M:%S %Z")
+    return f"""# klangkd configuration — generated on first run ({timestamp}).
+#
+# This file was auto-created because no klangkd.yaml was found at its
+# expected location (${{KLANGK_CONFIG_DIR:-$XDG_CONFIG_HOME/klangk}}/klangkd.yaml,
+# overridable via KLANGK_CONFIG_DIR). Edit it to customize your deployment.
+#
+# By default klangkd runs in solo mode: headless (UDS, no browser listener),
+# auth_modes=none (loopback trust, no password). The admin identity is
+# derived from your Unix user. See the docs for what to do next:
+#   https://mcdonc.github.io/klangk/         (full docs index)
+#   https://mcdonc.github.io/klangk/features/auth-modes/  (auth modes +
+#                                              the first-run seeding tables)
+#
+# --- Uncomment to change modes, then restart klangkd ---
+#
+# port: "8997"             # browser/UI port (loopback by default; enables
+#                          # the web UI at http://localhost:8997)
+# listen: "127.0.0.1"      # browser interface address (rendered when port
+#                          # is set; must be loopback unless you override)
+# auth_modes: password     # password | oidc | both | none (default: none)
+#                          # password/both require default_password (below)
+# default_user: admin@example.com   # override the derived Unix-user identity
+# default_password: "..."  # required when auth_modes is password/both
+# jwt_secret: change-me    # default is an insecure placeholder; mint a real
+#                          # secret for any non-local deployment
+#
+# Full settings reference:
+#   https://mcdonc.github.io/klangk/reference/klangkd-config/
+"""
+
+
+def generate_default_config(path: str) -> None:
+    """Write a default ``klangkd.yaml`` template at *path*.
+
+    The file is a near-empty template (see :func:`_render_config`): no admin
+    identity or password is emitted. The admin row is seeded at runtime
+    (derived from the Unix user; null password in ``none``/``oidc`` mode,
+    or ``KLANGK_DEFAULT_PASSWORD`` in ``password``/``both`` mode — fail-fast
+    if unset). See ``main.seed_default_user``.
+
+    The parent directory is created (0700) if missing. **Does not overwrite**
+    — ``open("x")`` mode fails loudly if the file appeared between the
+    caller's existence check and now (a concurrent ``klangkd``). We do NOT
+    silently clobber: an existing file is the operator's config.
+
+    Does not emit ``config_dir:`` / ``state_dir:`` / ``data_dir:`` keys
+    (#1649 — they would be ignored with a warning).
+    """
+    body = _render_config()
+    Path(path).parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    with open(path, "x", encoding="utf-8") as f:
+        f.write(body)

--- a/src/klangk/klangk/launcher.py
+++ b/src/klangk/klangk/launcher.py
@@ -1,4 +1,4 @@
-"""``klangkd`` — the klangk server launcher (#1395, #1396).
+"""``klangkd`` — the klangk server launcher (#1395, #1396, #1645).
 
 Loads config (from a YAML file + env vars + built-in defaults, per the
 precedence rules in :mod:`klangk.settings`), binds uvicorn (to a
@@ -7,18 +7,27 @@ otherwise), and owns the proxy child (currently nginx) that fronts it.
 
 Usage::
 
-    klangkd                          # requires /etc/klangkd.yaml
+    klangkd                          # resolves <KLANGK_CONFIG_DIR>/klangkd.yaml;
+    #                                # generates it on first run (#1645)
     klangkd --config /path/to/cfg.yaml
     klangkd --config=none            # env-vars-only (the sole opt-out)
 
 Config-file resolution (three states, no implicit escape):
 
-1. Bare ``klangkd`` → requires ``/etc/klangkd.yaml``; missing → error.
+1. Bare ``klangkd`` → resolves ``$KLANGK_CONFIG_DIR/klangkd.yaml`` (default
+   ``~/.config/klangk/klangkd.yaml``, #1649). If the file is missing it is
+   **generated** as a near-empty template pointing at the docs (#1645) —
+   no admin identity or password is emitted. The admin row is seeded at
+   runtime: ``default_user`` defaults to ``<unixuser>@example.com`` with
+   ``password_hash=None`` in ``none``/``oidc`` mode (no password needed);
+   ``password``/``both`` mode requires ``KLANGK_DEFAULT_PASSWORD`` (fail-fast
+   if unset).
 2. ``--config=<path>`` → that path required to exist; missing → error.
+   Explicit paths are never auto-generated.
 3. ``--config=none`` → run from env vars + built-in defaults (no file).
 
-See #1392 (the design record), #1395 (config + launcher), and #1396 (UDS +
-proxy ownership) for the full rationale.
+See #1392 (the design record), #1395 (config + launcher), #1396 (UDS +
+proxy ownership), and #1645 (first-run generation) for the full rationale.
 """
 
 from __future__ import annotations
@@ -35,11 +44,8 @@ import uvicorn
 # exists). ``build_app``'s ``configure(settings)`` later overrides the
 # level from ``KLANGK_LOG_LEVEL`` (#1467).
 from klangk import logger  # noqa: F401
+from klangk import first_run
 from klangk.settings import KlangkSettings
-
-# The default config-file location — a deployed klangkd finds its config here
-# with no args.  See #1395.
-DEFAULT_CONFIG_PATH = "/etc/klangkd.yaml"
 
 app = typer.Typer(
     add_completion=False,
@@ -48,13 +54,39 @@ app = typer.Typer(
 )
 
 
-def _resolve_config_path(config: str) -> str:
+def _resolve_config_path(config: str | None) -> str:
     """Resolve the ``--config`` value into a path or the 'none' sentinel.
 
-    Returns the path string (which the caller has verified exists), or
-    ``"none"`` for the explicit opt-out.  Raises ``typer.BadParameter`` (which
-    Typer surfaces as a clean CLI error) on a missing required file.
+    Three cases, no implicit escape (#1392 / #1645):
+
+    - ``None`` (bare ``klangkd``, no ``--config``) → resolve the default path
+      at ``<KLANGK_CONFIG_DIR>/klangkd.yaml`` (default
+      ``~/.config/klangk/klangkd.yaml``). **Generate on first run** if the
+      file doesn't exist (#1645): writes a near-empty template pointing at
+      the docs. No admin identity or password is emitted — the admin row
+      is seeded at runtime (``default_user`` defaults to
+      ``<unixuser>@example.com``; null hash in ``none``/``oidc`` mode,
+      ``KLANGK_DEFAULT_PASSWORD`` required in ``password``/``both``).
+    - ``"none"`` → explicit env-only opt-out (no config file).
+    - ``"<path>"`` → that path, required to exist. Missing → ``BadParameter``.
+      Explicit paths are never auto-generated — generation only fires for
+      the implicit default.
+
+    Returns the resolved path string or ``"none"``.  Raises
+    ``typer.BadParameter`` (which Typer surfaces as a clean CLI error) on a
+    missing explicitly-required file.
     """
+    if config is None:
+        path = first_run.default_config_path()
+        if not os.path.isfile(path):
+            try:
+                first_run.generate_default_config(path)
+            except FileExistsError:
+                # Race: another klangkd (e.g. a systemd restart overlap)
+                # generated the file between our isfile check and the open.
+                # Treat it as "the file is there now" and proceed.
+                pass
+        return path
     if config == "none":
         return "none"
     path = Path(config)
@@ -68,13 +100,16 @@ def _resolve_config_path(config: str) -> str:
 
 @app.command()
 def main(  # pragma: no cover
-    config: str = typer.Option(
-        DEFAULT_CONFIG_PATH,
+    config: str | None = typer.Option(
+        None,
         "--config",
         "-c",
         help=(
-            "Path to a YAML config file (default: /etc/klangkd.yaml). "
-            "Use 'none' to run from env vars only (no config file)."
+            "Path to a YAML config file. Bare ``klangkd`` (no --config) "
+            "resolves ``$KLANGK_CONFIG_DIR/klangkd.yaml`` "
+            "(default ``~/.config/klangk/klangkd.yaml``) and generates it "
+            "on first run (#1645). Use 'none' to run from env vars only "
+            "(no config file)."
         ),
     ),
 ) -> None:

--- a/src/klangk/klangk/main.py
+++ b/src/klangk/klangk/main.py
@@ -4,9 +4,7 @@ import asyncio
 import ipaddress
 import logging
 import os
-import secrets
 import signal
-import sys
 from contextlib import asynccontextmanager
 from pathlib import Path
 
@@ -49,9 +47,6 @@ from .model import (
 )
 from .model import AGENT_USER_ID
 from .wshandler import handle_websocket
-
-_GREEN = "\033[32m"
-_RESET = "\033[0m"
 
 logger = logging.getLogger(__name__)
 
@@ -183,20 +178,21 @@ class Lifecycle:
 
     async def seed_default_user(self) -> None:
         """Seed the default admin user exactly once, gated on admin-group
-        emptiness (#1622).
+        emptiness (#1622) and the deploy's auth mode (#1645).
 
-        Creates the admin from ``KLANGK_DEFAULT_USER`` / ``KLANGK_DEFAULT_PASSWORD``
-        **only when the ``admin`` group has no members** (first boot on a fresh
-        install, or after every admin has been deleted). Once at least one admin
-        exists, this method **never** creates, renames, re-emails, or
-        re-passwords a user: ``KLANGK_DEFAULT_*`` is ignored, so editing it in
-        ``klangkd.yaml`` and restarting cannot mint a new admin (the
-        config-mints-admin security hole) or clobber the existing admin's
-        identity (lockout). Changing the admin after the first boot is done
-        via the normal in-app / ``klangkc admin`` paths.
+        Password handling depends on ``auth_modes``:
 
-        If ``KLANGK_DEFAULT_PASSWORD`` is set, use it; otherwise generate a
-        random password and print it to stderr (only on the seeding boot).
+        - ``none`` / ``oidc`` → seed with ``password_hash=None``. The row is
+          load-bearing for ``/auth/local`` (token minting, #1374) but no
+          endpoint validates the hash — a password would be noise.
+        - ``password`` / ``both`` → seed with ``KLANGK_DEFAULT_PASSWORD``.
+          **Fail-fast if unset** — auto-generating + printing to stderr was
+          a footgun for detached deployments (the password was lost to a
+          log nobody reads, causing lockout).
+
+        In all modes: once the admin group has ≥1 member, this method is a
+        no-op (#1622 — editing ``KLANGK_DEFAULT_*`` and restarting cannot
+        mint a new admin or clobber the existing one).
         """
         settings = self.app.state.settings
         admin_group_id = await self.ensure_admin_group()
@@ -211,36 +207,97 @@ class Lifecycle:
             admin_group_id
         )
         if members:
+            await self._enforce_password_mode_has_hashed_admin(members)
             return
 
         email = settings.default_user
-        password = settings.default_password
-        generated = password is None
-        if generated:
-            password = secrets.token_urlsafe(16)
-        password_hash = bcrypt.hashpw(
-            password.encode(), bcrypt.gensalt()
-        ).decode()
+        # Read auth_modes inline rather than via self.app.state.oidc.auth_modes()
+        # so the test helper (which builds a minimal namespace without an OIDC
+        # instance) can exercise seeding. Equivalent for valid inputs: the
+        # settings field validator rejects typos at construction, so by here
+        # auth_modes is None or one of the valid modes. None defaults to "none"
+        # (the same default oidc.auth_modes() applies).
+        auth_modes = settings.auth_modes or "none"
+
+        if auth_modes in ("password", "both"):
+            # Password mode: require a staged password. Fail-fast if unset —
+            # auto-generation was removed to prevent lockout on detached
+            # deployments (#1645).
+            password = settings.default_password
+            if password is None:
+                raise RuntimeError(
+                    f"auth_modes={auth_modes} requires KLANGK_DEFAULT_PASSWORD "
+                    "(set it in klangkd.yaml or the env). Refusing to boot "
+                    "without a known admin password."
+                )
+            password_hash = bcrypt.hashpw(
+                password.encode(), bcrypt.gensalt()
+            ).decode()
+        else:
+            # none / oidc: seed with null password. The row exists for
+            # /auth/local token minting; no endpoint checks the hash.
+            password_hash = None
+
         user = await self.app.state.model.users.create_user(
             email, password_hash, verified=True
         )
         await self.app.state.model.users.add_user_to_group(
             user["id"], admin_group_id
         )
-        if generated:
+        if password_hash is not None:
             logger.info(
-                "Created default admin user '%s' (password printed to stderr)",
-                email,
-            )
-            # Print password to stderr only — keep it out of structured
-            # logs where it could be shipped to a log aggregator.
-            print(
-                f"{_GREEN}Default admin password for"
-                f" '{email}': {password}{_RESET}",
-                file=sys.stderr,
+                "Created default admin user '%s' in admin group", email
             )
         else:
-            logger.info("Created default user '%s' in admin group", email)
+            logger.info(
+                "Created default admin user '%s' (no password — auth_modes=%s)",
+                email,
+                auth_modes,
+            )
+
+    async def _enforce_password_mode_has_hashed_admin(
+        self, admin_members: list[dict]
+    ) -> None:
+        """Refuse to boot in password/both mode if no admin can log in.
+
+        The Table B lockout guard (#1645 review): if the admin row was seeded
+        in none/oidc mode (``password_hash=None``) and the operator then flips
+        to password/both, password login would 401 for every admin (``auth.py``
+        treats a null hash as invalid credentials) and ``/auth/local`` is
+        disabled outside none mode — so there is no path to an admin token.
+        Rather than let the operator discover this at the login screen, refuse
+        to boot with a clear error naming the recovery path.
+
+        The check is: in password/both mode, at least one admin must have a
+        non-null ``password_hash``. If none do, raise ``RuntimeError``.
+
+        Recovery (documented in ``docs/features/auth-modes.md`` Table B):
+        flip back to ``none`` mode, use ``/auth/local`` to get a free admin
+        token, run ``klangk admin users set-password`` to set a real hash,
+        then flip back to password/both. Or re-empty the admin group +
+        reseed with ``KLANGK_DEFAULT_PASSWORD`` staged.
+        """
+        auth_modes = self.app.state.settings.auth_modes or "none"
+        if auth_modes not in ("password", "both"):
+            return
+        # get_group_members doesn't carry password_hash; fetch per member.
+        # The admin group is small (typically 1-3 members) so the N queries
+        # are cheap; a single JOIN would require a new model method for this
+        # one call site, which isn't worth it.
+        for member in admin_members:
+            user = await self.app.state.model.users.get_user_by_email(
+                member["email"]
+            )
+            if user and user.get("password_hash"):
+                return  # At least one admin can log in — fine.
+        raise RuntimeError(
+            f"auth_modes={auth_modes} requires at least one admin with a "
+            "password, but every admin has no password hash (seeded in "
+            "none/oidc mode). Recovery: boot in none mode, run "
+            "`klangk admin users set-password <email>` via /auth/local trust, "
+            "then flip back to password/both. Or delete the admin row and "
+            "reseed with KLANGK_DEFAULT_PASSWORD staged."
+        )
 
     async def seed_agent_user(self) -> None:
         """Ensure the chat agent user exists in the DB.

--- a/src/klangk/klangk/settings.py
+++ b/src/klangk/klangk/settings.py
@@ -35,6 +35,8 @@ import subprocess
 from pathlib import Path
 from typing import Any, ClassVar, Mapping
 
+import getpass
+
 from pydantic_settings import (
     BaseSettings,
     EnvSettingsSource,
@@ -86,6 +88,24 @@ def _xdg_state_home() -> str:
     return os.environ.get("XDG_STATE_HOME") or os.path.expanduser(
         "~/.local/state"
     )
+
+
+def _safe_getuser() -> str:
+    """Return the invoking Unix user, with a fallback for uid-less envs.
+
+    Used for the dynamic ``default_user`` default (#1645): a bare ``klangkd``
+    seeds ``<unixuser>@example.com`` so the solo user's identity is derived
+    from who's actually running it. In containers / CI where the uid has no
+    passwd entry, ``getpass.getuser()`` raises — fall back to ``"user"`` so
+    construction doesn't crash (the identity is cosmetic in ``none`` mode).
+    """
+    try:
+        return getpass.getuser()
+    except OSError:
+        # In containers/CI where the uid has no passwd entry, getpass.getuser()
+        # raises OSError. Fall back to "user" so construction doesn't crash
+        # (the identity is cosmetic in none mode).
+        return "user"
 
 
 # Re-exported for backward compat — callers that ``from ..util import ...``
@@ -411,7 +431,7 @@ class KlangkSettings(BaseSettings):
     auth_modes: str | None = None
     jwt_secret: str | None = _INSECURE_DEFAULT_SECRET
     prevent_insecure_jwt_secret: str = ""
-    default_user: str = "admin@example.com"
+    default_user: str | None = None
     default_password: str | None = None
     access_token_hours: str | None = "24"
     workspace_token_hours: str | None = "24"
@@ -743,6 +763,13 @@ class KlangkSettings(BaseSettings):
         # config_dir, not state_dir (#1644/#1649).
         if not self.customize_dir:
             self.customize_dir = os.path.join(self.config_dir, "custom")
+        # default_user: the admin identity for first-boot seeding. Derived
+        # from the invoking Unix user (<user>@example.com) so a bare
+        # ``klangkd`` seeds the operator's own identity (#1645). Explicit
+        # KLANGK_DEFAULT_USER (env/config) always wins — unaffected for
+        # intentional deployments that stage a specific admin email.
+        if not self.default_user:
+            self.default_user = f"{_safe_getuser()}@example.com"
         return self
 
     @model_validator(mode="after")

--- a/src/klangk/klangkd-tests/tests/test_first_run.py
+++ b/src/klangk/klangkd-tests/tests/test_first_run.py
@@ -1,0 +1,194 @@
+"""Tests for first-run config generation (#1645 / #1607).
+
+Bare ``klangkd`` (no ``--config``) resolves ``<KLANGK_CONFIG_DIR>/klangkd.yaml``
+(default ``~/.config/klangk/klangkd.yaml``) and generates a near-empty template
+on first run. No admin identity or password is emitted — the admin row is
+seeded at runtime (derived from the Unix user; null password in ``none``/``oidc``
+mode, or ``KLANGK_DEFAULT_PASSWORD`` in ``password``/``both`` mode — fail-fast
+if unset). See ``test_main.py::TestSeedDefaultUserAuthModeGating`` for the
+seeding behavior.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from klangk import first_run
+
+
+class TestDefaultConfigPath:
+    """default_config_path() — the path bare ``klangkd`` resolves to."""
+
+    def test_uses_klangk_config_dir_env_when_set(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("KLANGK_CONFIG_DIR", str(tmp_path))
+        assert first_run.default_config_path() == str(
+            tmp_path / "klangkd.yaml"
+        )
+
+    def test_falls_back_to_xdg_config_home(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("KLANGK_CONFIG_DIR", raising=False)
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        assert first_run.default_config_path() == str(
+            tmp_path / "klangk" / "klangkd.yaml"
+        )
+
+    def test_falls_back_to_home_when_xdg_unset(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("KLANGK_CONFIG_DIR", raising=False)
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        assert first_run.default_config_path() == str(
+            tmp_path / ".config" / "klangk" / "klangkd.yaml"
+        )
+
+    def test_klangk_config_dir_wins_over_xdg(self, tmp_path, monkeypatch):
+        explicit = tmp_path / "explicit"
+        xdg = tmp_path / "xdg"
+        monkeypatch.setenv("KLANGK_CONFIG_DIR", str(explicit))
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+        assert first_run.default_config_path() == str(
+            explicit / "klangkd.yaml"
+        )
+
+
+class TestGenerateDefaultConfig:
+    """generate_default_config() — writes the template + nothing else."""
+
+    def test_writes_file_at_path(self, tmp_path):
+        path = str(tmp_path / "klangkd.yaml")
+        first_run.generate_default_config(path)
+        assert os.path.isfile(path)
+
+    def test_creates_parent_dir_if_missing(self, tmp_path):
+        path = str(tmp_path / "nested" / "deeper" / "klangkd.yaml")
+        first_run.generate_default_config(path)
+        assert os.path.isfile(path)
+
+    def test_does_not_emit_default_user_or_password(self, tmp_path):
+        # The generated template carries no admin identity or password —
+        # those are derived at runtime (#1645). The admin row is seeded by
+        # seed_default_user (null hash in none/oidc, fail-fast in password/both).
+        path = str(tmp_path / "klangkd.yaml")
+        first_run.generate_default_config(path)
+        body = Path(path).read_text()
+        # The keys appear only as commented examples, not active config.
+        for line in body.splitlines():
+            stripped = line.strip()
+            if stripped.startswith("default_user:") or stripped.startswith(
+                "default_password:"
+            ):
+                pytest.fail(
+                    f"Generated file has an active (uncommented) "
+                    f"admin-identity key: {stripped}"
+                )
+
+    def test_does_not_emit_config_dir_or_state_dir_keys(self, tmp_path):
+        path = str(tmp_path / "klangkd.yaml")
+        first_run.generate_default_config(path)
+        body = Path(path).read_text()
+        for line in body.splitlines():
+            stripped = line.strip()
+            for key in ("config_dir:", "state_dir:", "data_dir:"):
+                if stripped.startswith(key):
+                    pytest.fail(
+                        f"Generated file has an active path key: {stripped}"
+                    )
+
+    def test_does_not_overwrite_existing_file(self, tmp_path):
+        path = str(tmp_path / "klangkd.yaml")
+        Path(path).write_text("product_name: operator-edited\n")
+        with pytest.raises(FileExistsError):
+            first_run.generate_default_config(path)
+        assert "operator-edited" in Path(path).read_text()
+
+    def test_generated_file_loads_via_klangk_settings(
+        self, tmp_path, monkeypatch
+    ):
+        # The generated template must be parseable by KlangkSettings (that's
+        # what klangkd does immediately after generation).
+        path = str(tmp_path / "klangkd.yaml")
+        first_run.generate_default_config(path)
+        from klangk.settings import KlangkSettings
+
+        monkeypatch.setenv("KLANGK_STATE_DIR", str(tmp_path / "state"))
+        s = KlangkSettings(os.environ, config_file=path)
+        # No active keys → everything is defaults. default_user is the
+        # dynamic Unix-user default.
+        import getpass
+
+        assert s.default_user == f"{getpass.getuser()}@example.com"
+
+    def test_template_mentions_solo_docs(self, tmp_path):
+        # The file's purpose is discoverability — it points at the docs.
+        path = str(tmp_path / "klangkd.yaml")
+        first_run.generate_default_config(path)
+        body = Path(path).read_text()
+        assert "mcdonc.github.io/klangk" in body
+
+
+class TestLauncherIntegration:
+    """launcher._resolve_config_path(None) wires first-run generation in."""
+
+    def test_none_generates_when_missing(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("KLANGK_CONFIG_DIR", str(tmp_path))
+        from klangk.launcher import _resolve_config_path
+
+        path = tmp_path / "klangkd.yaml"
+        assert not path.is_file()
+        resolved = _resolve_config_path(None)
+        assert resolved == str(path)
+        assert path.is_file()
+
+    def test_none_does_not_regenerate_when_present(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("KLANGK_CONFIG_DIR", str(tmp_path))
+        path = tmp_path / "klangkd.yaml"
+        path.write_text("product_name: already-here\n")
+        from klangk.launcher import _resolve_config_path
+
+        resolved = _resolve_config_path(None)
+        assert resolved == str(path)
+        assert "already-here" in path.read_text()
+
+    def test_none_handles_fileexists_race(self, tmp_path, monkeypatch):
+        # If another klangkd generates the file between our isfile check and
+        # open("x"), generate_default_config raises FileExistsError. The
+        # launcher must treat that as "the file is there now" and proceed,
+        # not crash (a systemd restart overlap shouldn't take down the boot).
+        monkeypatch.setenv("KLANGK_CONFIG_DIR", str(tmp_path))
+        # Simulate the race: generate_default_config raises FileExistsError
+        # (another process created the file between our isfile check and the
+        # open("x") inside the generator).
+        from klangk import first_run as first_run_mod
+
+        def _raise_fileexists(path):
+            raise FileExistsError(path)
+
+        monkeypatch.setattr(
+            first_run_mod, "generate_default_config", _raise_fileexists
+        )
+        from klangk.launcher import _resolve_config_path
+
+        resolved = _resolve_config_path(None)
+        assert resolved == str(tmp_path / "klangkd.yaml")
+
+    def test_explicit_missing_path_still_errors(self, tmp_path):
+        import typer
+
+        from klangk.launcher import _resolve_config_path
+
+        with pytest.raises(typer.BadParameter):
+            _resolve_config_path(str(tmp_path / "does-not-exist.yaml"))
+
+    def test_none_sentinel_still_works(self):
+        from klangk.launcher import _resolve_config_path
+
+        assert _resolve_config_path("none") == "none"
+
+    def test_explicit_existing_path_still_works(self, tmp_path):
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("product_name: test\n")
+        from klangk.launcher import _resolve_config_path
+
+        assert _resolve_config_path(str(cfg)) == str(cfg)

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -35,8 +35,9 @@ from klangk.wshandler.session import WebSocketState
 def _make_app_state(settings=None):
     """Build a minimal mock app for tests."""
     if settings is None:
-        # Pin a default password so the lifespan's seed_default_user does
-        # not generate (and print) one to stderr on every boot (#1493).
+        # Pin a default password so tests that exercise the full lifespan
+        # (where seed_default_user runs) don't fail-fast in password mode.
+        # In none mode (the default) the password is ignored (null hash).
         settings = make_settings({"KLANGK_DEFAULT_PASSWORD": "test"})
     # Two-phase: shell first so owned instances can take app at
     # construction (#1426).
@@ -125,18 +126,16 @@ class TestSeedDefaultUser:
         user = await app_state.state.model.users.get_user_by_email("seed-test")
         assert user is not None
 
-    async def test_generates_password_when_not_set(
-        self, db, capsys, app_state
-    ):
+    async def test_seeds_null_password_in_none_mode(self, db, app_state):
+        # Default mode (none): seed with null password_hash. The row exists
+        # for /auth/local token minting but no endpoint checks the hash (#1645).
         await _lifecycle(
-            make_settings({"KLANGK_DEFAULT_USER": "gen-test"})
+            make_settings({"KLANGK_DEFAULT_USER": "none-test"})
         ).seed_default_user()
-        # Swallow the incidental generated-password print to stderr
-        # (asserted explicitly by test_generated_password_printed_to_stderr).
-        capsys.readouterr()
-        user = await app_state.state.model.users.get_user_by_email("gen-test")
+        user = await app_state.state.model.users.get_user_by_email("none-test")
         assert user is not None
-        # User exists and is in the admin group
+        assert user["password_hash"] is None
+        # User is in the admin group
         admin_group = await app_state.state.model.users.get_group_by_name(
             "admin"
         )
@@ -146,21 +145,154 @@ class TestSeedDefaultUser:
         )
         assert admin_group["id"] in group_ids
 
-    async def test_generated_password_printed_to_stderr(
-        self, db, caplog, capsys
-    ):
-        import logging
 
-        with caplog.at_level(logging.INFO):
+class TestSeedDefaultUserAuthModeGating:
+    """#1645 Table A: password handling depends on auth_modes.
+
+    none / oidc → null password_hash (row is for /auth/local token minting).
+    password / both → require KLANGK_DEFAULT_PASSWORD or fail-fast.
+    """
+
+    async def test_none_mode_seeds_null_password(self, db, app_state):
+        await _lifecycle(
+            make_settings({"KLANGK_DEFAULT_USER": "u-none"})
+        ).seed_default_user()
+        user = await app_state.state.model.users.get_user_by_email("u-none")
+        assert user["password_hash"] is None
+
+    async def test_oidc_mode_seeds_null_password(self, db, app_state):
+        await _lifecycle(
+            make_settings(
+                {
+                    "KLANGK_AUTH_MODES": "oidc",
+                    "KLANGK_DEFAULT_USER": "u-oidc",
+                }
+            )
+        ).seed_default_user()
+        user = await app_state.state.model.users.get_user_by_email("u-oidc")
+        assert user["password_hash"] is None
+
+    async def test_password_mode_uses_default_password(self, db, app_state):
+        await _lifecycle(
+            make_settings(
+                {
+                    "KLANGK_AUTH_MODES": "password",
+                    "KLANGK_DEFAULT_USER": "u-pw",
+                    "KLANGK_DEFAULT_PASSWORD": "real-pass",
+                }
+            )
+        ).seed_default_user()
+        user = await app_state.state.model.users.get_user_by_email("u-pw")
+        assert user["password_hash"] is not None
+        import bcrypt
+
+        assert bcrypt.checkpw(b"real-pass", user["password_hash"].encode())
+
+    async def test_password_mode_fails_fast_without_default_password(
+        self, db, app_state
+    ):
+        with pytest.raises(RuntimeError, match="KLANGK_DEFAULT_PASSWORD"):
             await _lifecycle(
-                make_settings({"KLANGK_DEFAULT_USER": "log-test"})
+                make_settings(
+                    {
+                        "KLANGK_AUTH_MODES": "password",
+                        "KLANGK_DEFAULT_USER": "u-nopw",
+                    }
+                )
             ).seed_default_user()
-        # Password must NOT appear in log output (security)
-        assert "password printed to stderr" in caplog.text
-        assert "log-test" in caplog.text
-        # Password appears on stderr only
-        captured = capsys.readouterr()
-        assert "Default admin password for" in captured.err
+
+    async def test_both_mode_uses_default_password(self, db, app_state):
+        await _lifecycle(
+            make_settings(
+                {
+                    "KLANGK_AUTH_MODES": "both",
+                    "KLANGK_DEFAULT_USER": "u-both",
+                    "KLANGK_DEFAULT_PASSWORD": "both-pass",
+                }
+            )
+        ).seed_default_user()
+        user = await app_state.state.model.users.get_user_by_email("u-both")
+        assert user["password_hash"] is not None
+
+    async def test_both_mode_fails_fast_without_default_password(
+        self, db, app_state
+    ):
+        with pytest.raises(RuntimeError, match="KLANGK_DEFAULT_PASSWORD"):
+            await _lifecycle(
+                make_settings(
+                    {
+                        "KLANGK_AUTH_MODES": "both",
+                        "KLANGK_DEFAULT_USER": "u-both-nopw",
+                    }
+                )
+            ).seed_default_user()
+
+    async def test_table_b_guard_blocks_password_boot_when_admin_has_null_hash(
+        self, db, app_state
+    ):
+        """Table B lockout guard (#1645 review): booting in password mode with
+        a null-hash admin (seeded in none/oidc) is refused before the server
+        serves traffic. Without this guard the operator would discover the
+        lockout at the login screen with no recovery path (/auth/local is
+        disabled outside none mode)."""
+        # Seed in none mode → admin row with password_hash=None.
+        await _lifecycle(
+            make_settings({"KLANGK_DEFAULT_USER": "u-nullhash@example.com"})
+        ).seed_default_user()
+        admin = await app_state.state.model.users.get_user_by_email(
+            "u-nullhash@example.com"
+        )
+        assert admin["password_hash"] is None
+
+        # Subsequent boot in password mode (admin group non-empty → seeding
+        # skipped, but the guard fires on the existing members).
+        with pytest.raises(RuntimeError, match="admin with a password"):
+            await _lifecycle(
+                make_settings(
+                    {
+                        "KLANGK_AUTH_MODES": "password",
+                        "KLANGK_DEFAULT_USER": "u-nullhash@example.com",
+                    }
+                )
+            ).seed_default_user()
+
+    async def test_table_b_guard_passes_when_admin_has_hash(
+        self, db, app_state
+    ):
+        """Mirror of the lockout guard: a password-mode boot where the admin
+        DOES have a hash proceeds normally (seed skipped, no error)."""
+        # Seed in password mode → admin row with real hash.
+        await _lifecycle(
+            make_settings(
+                {
+                    "KLANGK_AUTH_MODES": "password",
+                    "KLANGK_DEFAULT_USER": "u-hashed@example.com",
+                    "KLANGK_DEFAULT_PASSWORD": "real-pass",
+                }
+            )
+        ).seed_default_user()
+
+        # Subsequent boot in password mode (same admin, same hash) — no raise.
+        await _lifecycle(
+            make_settings(
+                {
+                    "KLANGK_AUTH_MODES": "password",
+                    "KLANGK_DEFAULT_USER": "u-hashed@example.com",
+                    "KLANGK_DEFAULT_PASSWORD": "real-pass",
+                }
+            )
+        ).seed_default_user()
+
+    async def test_table_b_guard_noop_in_none_mode(self, db, app_state):
+        """The guard doesn't fire in none mode even with a null-hash admin —
+        none mode never validates passwords."""
+        await _lifecycle(
+            make_settings({"KLANGK_DEFAULT_USER": "u-none@example.com"})
+        ).seed_default_user()
+        # Second boot, still none mode — no raise.
+        await _lifecycle(
+            make_settings({"KLANGK_DEFAULT_USER": "u-none@example.com"})
+        ).seed_default_user()
 
 
 class TestSeedDefaultUserGating:
@@ -222,6 +354,7 @@ class TestSeedDefaultUserGating:
         await _lifecycle(
             make_settings(
                 {
+                    "KLANGK_AUTH_MODES": "password",
                     "KLANGK_DEFAULT_USER": "keep@example.com",
                     "KLANGK_DEFAULT_PASSWORD": "original-pass",
                 }
@@ -237,6 +370,7 @@ class TestSeedDefaultUserGating:
         await _lifecycle(
             make_settings(
                 {
+                    "KLANGK_AUTH_MODES": "password",
                     "KLANGK_DEFAULT_USER": "changed@example.com",
                     "KLANGK_DEFAULT_PASSWORD": "changed-pass",
                 }
@@ -261,6 +395,7 @@ class TestSeedDefaultUserGating:
         await _lifecycle(
             make_settings(
                 {
+                    "KLANGK_AUTH_MODES": "password",
                     "KLANGK_DEFAULT_USER": "resurrect@example.com",
                     "KLANGK_DEFAULT_PASSWORD": "resurrect-pass",
                 }
@@ -287,6 +422,7 @@ class TestSeedDefaultUserGating:
         await _lifecycle(
             make_settings(
                 {
+                    "KLANGK_AUTH_MODES": "password",
                     "KLANGK_DEFAULT_USER": "resurrect@example.com",
                     "KLANGK_DEFAULT_PASSWORD": "resurrect-pass",
                 }
@@ -319,6 +455,7 @@ class TestSeedDefaultUserGating:
         await _lifecycle(
             make_settings(
                 {
+                    "KLANGK_AUTH_MODES": "password",
                     "KLANGK_DEFAULT_USER": "fresh@example.com",
                     "KLANGK_DEFAULT_PASSWORD": "fresh-pass",
                 }

--- a/src/klangk/klangkd-tests/tests/test_mode_switching.py
+++ b/src/klangk/klangkd-tests/tests/test_mode_switching.py
@@ -72,9 +72,14 @@ async def mode_server(db, monkeypatch, app_state):
     for the seeded default user (so tests know its ``id`` / ``email``).
     """
     global _current_app
-    # Seed exactly as the lifespan does at startup.
+    # Seed the admin row. Seeded in password mode (with a real hash) rather
+    # than none mode so the password-login paths exercised by TestPasswordToNone
+    # have a real credential to validate against. (Real lifespan seeding would
+    # pick none/password based on auth_modes; the fixture pins password-mode
+    # seeding + then starts the server in none mode for the upgrade tests.)
     await _lifecycle(
         {
+            "KLANGK_AUTH_MODES": "password",
             "KLANGK_DEFAULT_USER": DEFAULT_EMAIL,
             "KLANGK_DEFAULT_PASSWORD": SEEDED_PASSWORD,
         }
@@ -85,7 +90,9 @@ async def mode_server(db, monkeypatch, app_state):
     assert default_user is not None, "seed_default_user must create the user"
 
     app = FastAPI()
-    app.state.settings = make_settings({"KLANGK_AUTH_MODES": "none"})
+    app.state.settings = make_settings(
+        {"KLANGK_AUTH_MODES": "none", "KLANGK_DEFAULT_USER": DEFAULT_EMAIL}
+    )
     app.state.oidc = oidc_mod.OIDC(app)
     app.state.plugins = plugins_mod.Plugins(app)
     app.state.email = emailsvc_mod.EmailService(app)
@@ -118,7 +125,9 @@ def _set_mode(mode: str):
     (same as a real server restart).
     """
     app = _current_app
-    app.state.settings = make_settings({"KLANGK_AUTH_MODES": mode})
+    app.state.settings = make_settings(
+        {"KLANGK_AUTH_MODES": mode, "KLANGK_DEFAULT_USER": DEFAULT_EMAIL}
+    )
     app.state.oidc = oidc_mod.OIDC(app)
 
 

--- a/src/klangk/klangkd-tests/tests/test_settings.py
+++ b/src/klangk/klangkd-tests/tests/test_settings.py
@@ -518,10 +518,27 @@ class TestEnvConstructor:
         assert s.egress_port != "9999"
 
     def test_empty_env_dict_uses_defaults(self):
+        import getpass
+
         s = make_settings({})
         assert s.auth_modes is None
-        assert s.default_user == "admin@example.com"
+        # default_user is derived from the invoking Unix user (#1645).
+        assert s.default_user == f"{getpass.getuser()}@example.com"
         assert s.min_password_length == "8"
+
+    def test_default_user_falls_back_when_getuser_fails(self, monkeypatch):
+        # In containers/CI where the uid has no passwd entry, getpass.getuser()
+        # raises OSError (since Python 3.13; earlier versions raised KeyError
+        # / ImportError, but the wrapper normalizes now) — the default must
+        # fall back to "user" so construction doesn't crash (#1645).
+        import getpass as getpass_mod
+
+        def _raise():
+            raise OSError("No username set in the environment")
+
+        monkeypatch.setattr(getpass_mod, "getuser", _raise)
+        s = make_settings({})
+        assert s.default_user == "user@example.com"
 
     def test_env_for_sources_reset_after_construction(self):
         # The class-var bridge is cleaned up after construction so it doesn't


### PR DESCRIPTION
<!-- issue: https://github.com/mcdonc/klangk/issues/1645 -->

# First-run config generation — no admin/password unless the deploy mode needs one

Closes #1645. A bare `klangkd` (no `--config`, no `klangkd.yaml`) now boots to "solo state": UDS bind, `auth_modes=none` default, auto-seeded admin row with `password_hash=None`. No password is minted or printed — the admin identity is derived from the invoking Unix user at runtime. A password only enters the picture when the operator explicitly switches to `auth_modes=password`/`both`, at which point `KLANGK_DEFAULT_PASSWORD` is **required** (fail-fast if unset). Combined with the wheel publish (#1656, merged), `pip install klangkd && klangkd` yields a usable solo instance with no config file and no password.

Full acceptance is the two tables in [`docs/features/auth-modes.md`](https://github.com/mcdonc/klangk/blob/issue-1645-first-run-config-ge/docs/features/auth-modes.md) ("Seeding behavior across modes"): Table A (first boot — per `auth_modes` × `bind` × `default_password`) and Table B (subsequent starts — what happens when the operator changes modes after first boot).

## What's new

**`src/klangk/klangk/first_run.py`** (new) — two functions:

- `default_config_path()` — resolves `<KLANGK_CONFIG_DIR>/klangkd.yaml` (default `~/.config/klangk/klangkd.yaml`). Pure env read, no `KlangkSettings` construction (the #1649 bootstrap rule).
- `generate_default_config(path)` — writes a **near-empty template** pointing at the docs + commented examples for the mode transitions. `open("x")` refuses to clobber; parent dir created 0700. **No admin identity or password emitted** — those are runtime-derived.

**`src/klangk/klangk/launcher.py`** — `DEFAULT_CONFIG_PATH` (`/etc/klangkd.yaml`) removed. The `--config` default is now `None`, which `_resolve_config_path` resolves via `first_run.default_config_path()` + `generate_default_config()` if the file is missing. Explicit `--config=<path>` is unchanged (required to exist; never auto-generated). `--config=none` is unchanged.

| Invocation | Behavior |
| --- | --- |
| `klangkd` | Resolves `$KLANGK_CONFIG_DIR/klangkd.yaml` (default `~/.config/klangk/klangkd.yaml`); generates a near-empty template on first run if missing. Admin row seeded at runtime (null hash in `none`/`oidc`; `KLANGK_DEFAULT_PASSWORD` required in `password`/`both`). |
| `klangkd --config /path/to/config.yaml` | Uses the specified file. Missing → startup error. **Never auto-generated.** |
| `klangkd --config=none` | No config file — env vars and built-in defaults only. |

**`src/klangk/klangk/settings.py`** — `default_user` field default changed from `"admin@example.com"` to `None`, filled by the `_require_dirs` validator with `<getpass.getuser()>@example.com` (the invoking Unix user). `_safe_getuser()` wraps `getpass.getuser()` with an `except OSError: return "user"` fallback for uid-less containers. Explicit `KLANGK_DEFAULT_USER` (env/config) always wins.

**`src/klangk/klangk/main.py`** — `seed_default_user` reworked:

- **`none` / `oidc` mode** → seed admin row with `password_hash=None`. The row is load-bearing for `/auth/local` token minting but no endpoint checks the hash.
- **`password` / `both` mode** → seed with `KLANGK_DEFAULT_PASSWORD`; **fail-fast `RuntimeError` if unset** (auto-generate-and-print removed as a lockout footgun for detached deployments).
- **Table B lockout guard** (`_enforce_password_mode_has_hashed_admin`) — on subsequent boots (admin group non-empty), if `auth_modes` is `password`/`both` and **every** admin has `password_hash=None` (seeded in `none`/`oidc` then flipped), refuse to boot. The error names the recovery path. Closes the documented-but-unrecoverable lockout the review flagged.

## Constraints honored

- **Never overwrite an existing file** — `open(path, "x")` fails loudly; the launcher's `isfile` check + `FileExistsError` handler covers the systemd-restart race.
- **Never auto-migrate** existing config — operators do that manually.
- **No `config_dir:` / `state_dir:` / `data_dir:` keys emitted** — would be ignored with a warning per #1649.
- **#1622 admin-seeding gate unchanged** — seeding still only fires when the admin group is empty.
- **macOS** — XDG fallback applies as-is (no `~/Library/Application Support` special-case, per #1607).
- **Plugin seeding dropped from scope** (per #1645's #1651 recovery note) — the runtime reads the shipped manifest (#1655); the wheel bakes the default set's UIs (#1656).

## Adversarial review fixes

A fresh-eyes review (z.ai/glm-4.6, thinking=high) returned REQUEST CHANGES — all 4 blocking findings addressed:

1. **Table B lockout guard** (described above) — the documented recovery path was incomplete; the guard prevents the unrecoverable state from being reached at all.
2. **Broken doc links** in `first_run.py` — the #1629 solo/multiuser tracks aren't merged; replaced with stable docs URLs.
3. **Narrowed `except Exception` → `except OSError`** in `_safe_getuser` (Python 3.13's `getuser()` wraps all failures in `OSError`).
4. **`FileExistsError` race** in launcher handled (two concurrent `klangkd`s don't race).

Plus 2 important findings (Table B test coverage, misleading fixture comment in `test_mode_switching.py`).

## Design notes

- **Why a near-empty template, not "every default emitted verbatim"?** The in-code defaults are already correct; a verbose file overrides future default changes in code and is noise that obscures what varies per install (nothing, in `none` mode — the admin identity is runtime-derived). The template carries discoverability + mode-transition examples, nothing more.
- **Why dynamic `default_user`?** The solo user's identity is cosmetic (the token carries the email but they never receive mail at it); deriving it from `getpass.getuser()` ties the seeded identity to whoever is actually running it. Intentional deployments override via `default_user` (config/env) — unchanged.
- **Why fail-fast on missing `default_password` in `password`/`both`?** Auto-generate-and-print was a footgun: a detached deployment (container, systemd) would lose the password to a log nobody reads, causing lockout. `password`/`both` is always an explicit operator choice, so an unset password is unambiguously an error worth refusing.
- **The `--config` default change** (`/etc/klangkd.yaml` → XDG) is a no-op for existing deployments: the host container's `supervisord.conf` passes `--config=none` explicitly, devenv's backend passes `--config=klangkd.yaml` explicitly, and nothing in-tree used `/etc/klangkd.yaml` (it was a system-deployment placeholder).

## Verification

- 3174 klangk tests pass (+27 from the first-run suite + Table A/B gating tests + Table B guard tests), **100% coverage** on `klangk`, `-n auto`.
- All pre-commit hooks green.
- Smoke-tested locally: bare `klangkd` boots, generates the near-empty template at `~/.config/klangk/klangkd.yaml`, seeds the admin row with `password_hash=None`, `/auth/local` mints a token.
