### PR TITLE
fix(build): print absolute wheel path in build_wheel.sh

### DIFF
--- a/scripts/build_wheel.sh
+++ b/scripts/build_wheel.sh
@@ -27,6 +27,11 @@ uv pip install build
 cd "$REPO_ROOT/src/klangk"
 python3 -m build --wheel
 
-# Report what we produced.
+# Report what we produced. The script cd'd into src/klangk before building,
+# so dist/ is relative to that dir, not the caller's CWD — print absolute
+# paths so the wheel can be located from anywhere.
 echo "=== built wheels ==="
 ls -lh dist/*.whl
+for whl in dist/*.whl; do
+  echo "$(cd "$(dirname "$whl")" && pwd)/$(basename "$whl")"
+done


### PR DESCRIPTION
## Summary

`scripts/build_wheel.sh` builds the wheel into `src/klangk/dist/` (it `cd`s into `src/klangk` before running `python3 -m build`), but only prints a path relative to that directory. From the caller's CWD the wheel appears missing:

```
❯ scripts/build_wheel.sh
...
Successfully built klangk-1.0.5.dev127+gc34f8c47-py3-none-any.whl
=== built wheels ===
-rw-r--r-- 1 chrism users 27M Jul 19 00:31 dist/klangk-1.0.5.dev127+gc34f8c47-py3-none-any.whl
❯ ls dist
ls: cannot access 'dist': No such file or directory
```

The wheel actually landed at `src/klangk/dist/klangk-...whl`.

## Changes

After the existing `ls -lh dist/*.whl` line, echo each built wheel's absolute path:

```sh
for whl in dist/*.whl; do
  echo "$(cd "$(dirname "$whl")" && pwd)/$(basename "$whl")"
done
```

Closes #1671.
