### PR TITLE
fix(packaging): move pytest toolchain into a test extra

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -38,7 +38,7 @@ jobs:
         if: steps.filter.outputs.python == 'true'
         # One unified distribution (src/klangk) ships the klangk package
         # (server + CLI). The two unit suites share one --cov gate (#1606).
-        run: pip install -e src/klangk/
+        run: pip install -e 'src/klangk/[test]'
 
       - name: Run tests
         if: steps.filter.outputs.python == 'true'

--- a/devenv.nix
+++ b/devenv.nix
@@ -109,7 +109,12 @@ in
     "klangk:uv-sync" = {
       exec = ''
         cd "$DEVENV_ROOT"
-        uv sync -p "$UV_PYTHON"
+        # --extra test: pull the pytest toolchain (klangk[test]) so the
+        # venv runs the suite. Without it, uv sync installs only the
+        # runtime deps (pytest* live in the ``test`` optional-dependency
+        # extra, #1673) and `devenv test` / `pytest` blow up with
+        # ModuleNotFoundError.
+        uv sync --extra test -p "$UV_PYTHON"
       '';
       after = [ "devenv:python:virtualenv" ];
       before = [ "devenv:enterShell" ];

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -239,6 +239,18 @@ invitations send` stay email-only (a deliverable address is required);
 
 ### Changed
 
+- **The pytest toolchain is now an optional `test` extra, not a runtime
+  dependency (#1673).** `src/klangk/pyproject.toml` moves `pytest`,
+  `pytest-asyncio`, `pytest-cov`, `pytest-xdist`, and `pytest-timeout` out
+  of `dependencies` into `[project.optional-dependencies] test`. A plain
+  `pip install klangk` (or `pip install klangk==<tag>` from PyPI) no longer
+  pulls in pytest + its transitive deps (pluggy, iniconfig, packaging,
+  coverage, execnet — ~a dozen packages / several MB with no runtime role).
+  Dev and CI installs opt in explicitly: `pip install klangk[test]`, or
+  `uv sync --extra test` (the path the devenv shell and `backend-tests.yml`
+  now use). **Integrator action:** if you install `klangk` into an env where
+  you also run the test suite, add the `[test]` extra.
+
 - **`KLANGK_PLUGINS_DIR` is gone from every layer (#1660).** The plugin
   declaration list is now the checked-in `plugins.yaml` at the repo root
   (the build-time source of truth, analogue of a committed `package.json` /

--- a/src/klangk/pyproject.toml
+++ b/src/klangk/pyproject.toml
@@ -24,6 +24,15 @@ dependencies = [
     "logfire[fastapi]>=3.0.0",
     "pyyaml>=6.0",
     "httpx>=0.28.0",
+]
+
+# Test toolchain — opt in via `pip install klangk[test]` or
+# `uv sync --extra test`. Kept out of the runtime ``dependencies`` so a
+# production ``pip install klangk`` doesn't pull pytest + its transitive
+# deps (pluggy, iniconfig, packaging, coverage, execnet, ~a dozen pkgs)
+# that have no role at runtime (#1673).
+[project.optional-dependencies]
+test = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.24.0",
     "pytest-cov>=6.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -651,11 +651,6 @@ dependencies = [
     { name = "jinja2" },
     { name = "logfire", extra = ["fastapi"] },
     { name = "pydantic-settings" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
-    { name = "pytest-timeout" },
-    { name = "pytest-xdist" },
     { name = "python-jose", extra = ["cryptography"] },
     { name = "python-multipart" },
     { name = "pyyaml" },
@@ -664,6 +659,15 @@ dependencies = [
     { name = "typer" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "websockets" },
+]
+
+[package.optional-dependencies]
+test = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
 ]
 
 [package.metadata]
@@ -677,11 +681,11 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1" },
     { name = "logfire", extras = ["fastapi"], specifier = ">=3.0.0" },
     { name = "pydantic-settings", specifier = ">=2.5.0" },
-    { name = "pytest", specifier = ">=8.0.0" },
-    { name = "pytest-asyncio", specifier = ">=0.24.0" },
-    { name = "pytest-cov", specifier = ">=6.0.0" },
-    { name = "pytest-timeout", specifier = ">=2.3.0" },
-    { name = "pytest-xdist", specifier = ">=3.0.0" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.24.0" },
+    { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=6.0.0" },
+    { name = "pytest-timeout", marker = "extra == 'test'", specifier = ">=2.3.0" },
+    { name = "pytest-xdist", marker = "extra == 'test'", specifier = ">=3.0.0" },
     { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3.0" },
     { name = "python-multipart", specifier = ">=0.0.30" },
     { name = "pyyaml", specifier = ">=6.0" },
@@ -691,6 +695,7 @@ requires-dist = [
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
     { name = "websockets", specifier = ">=14.0" },
 ]
+provides-extras = ["test"]
 
 [[package]]
 name = "logfire"


### PR DESCRIPTION
## Summary

`src/klangk/pyproject.toml` listed the entire pytest toolchain as hard runtime `dependencies`, so a production `pip install klangk` (or `pip install klangk==<tag>` from PyPI) pulled in pytest, pytest-asyncio, pytest-cov, pytest-xdist, pytest-timeout, plus their transitive deps (pluggy, iniconfig, packaging, coverage, execnet) — roughly a dozen packages and several MB with no role at runtime.

## Changes

- **`src/klangk/pyproject.toml`** — move the five `pytest*` deps out of `dependencies` into a new `[project.optional-dependencies] test` block.
- **`devenv.nix`** (`klangk:uv-sync` task) — `uv sync -p "$UV_PYTHON"` → `uv sync --extra test -p "$UV_PYTHON"` so the devenv shell keeps the test toolchain installed.
- **`.github/workflows/backend-tests.yml`** — `pip install -e src/klangk/` → `pip install -e 'src/klangk/[test]'` so CI still gets pytest.
- **`docs/changes.md`** — `### Changed` entry under `[Unreleased]` noting the integrator action (add `[test]` extra when installing into an env where the suite is run).
- **`uv.lock`** — regenerated.

## Verification

- Plain `uv sync` no longer installs pytest (and uninstalls the pytest* packages if previously present):
  ```
  === uv sync (no extra) — pytest should be ABSENT ===
   - pytest-timeout==2.4.0
   - pytest-xdist==3.8.0
      import pytest
  ModuleNotFoundError: No module named 'pytest'
  ```
- `uv sync --extra test` reinstates them:
  ```
  === uv sync --extra test — pytest should be PRESENT ===
   + pytest-timeout==2.4.0
   + pytest-xdist==3.8.0
  pytest 9.1.1
  ```
- Full Python suite passes at the 100% coverage gate (run the way CI does):
  ```
  devenv --quiet -O dotenv.enable:bool false shell -- \
    python -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -v -n auto
  ...
  Required test coverage of 100% reached. Total coverage: 100.00%
  ============================ 3148 passed in 32.50s =============================
  ```

`release.yml`'s wheel-build job needs no change — it runs `python -m build` (via `scripts/build_wheel.sh`) and never installs the package for testing, so it doesn't need the `[test]` extra.

Closes #1673.
