### PR TITLE
feat(1664): soliplex as compiled-in (dormant) default wheel feature

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -27,6 +27,23 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **Soliplex ships as a compiled-in (dormant) feature of the default wheel
+  (#1664).** The Soliplex knowledge-base plugin
+  (`soliplex/klangk-plugin-soliplex`, maintained by the Soliplex org) is now
+  declared in the checked-in `plugins.yaml` as a remote `git:` entry pinned at
+  `v0.4` (`f9ad398`). A bare install compiles it in — the Dart UI + the TS
+  extension land in the bundle — but it's **not** in `DEFAULT_FEATURES`, so
+  `KLANGK_FEATURES_ENABLE` unset leaves it inactive. Operators running a
+  Soliplex server opt in with `KLANGK_FEATURES_ENABLE=soliplex` instead of
+  forking the repo and rebuilding. This is the first real exercise of the
+  "compiled-in ⊋ defaults" design from #1655 (compiled-in = 8, defaults = 7).
+  Its one config key (`SOLIPLEX_URL`, scope `frontend`) is bridged via
+  `/api/config` when active; no `container_env_keys` (browser-side feature).
+  `update_plugins.py` gained a `--local-only` flag so CI can verify the
+  local-plugin contract without hitting the network — the soliplex git fetch
+  is exercised by the real build (`flutterbuildweb.sh`) and by a synthetic
+  codegen test.
+
 - **First-run config generation: a bare `klangkd` boots with no config
   file (#1645).** When `klangkd` is invoked with no `--config` and no
   `klangkd.yaml` exists at the resolved path (`$KLANGK_CONFIG_DIR/klangkd.yaml`,

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -33,16 +33,24 @@ operators or integrators to act when upgrading.
   declared in the checked-in `plugins.yaml` as a remote `git:` entry pinned at
   `v0.4` (`f9ad398`). A bare install compiles it in — the Dart UI + the TS
   extension land in the bundle — but it's **not** in `DEFAULT_FEATURES`, so
-  `KLANGK_FEATURES_ENABLE` unset leaves it inactive. Operators running a
-  Soliplex server opt in with `KLANGK_FEATURES_ENABLE=soliplex` instead of
-  forking the repo and rebuilding. This is the first real exercise of the
-  "compiled-in ⊋ defaults" design from #1655 (compiled-in = 8, defaults = 7).
-  Its one config key (`SOLIPLEX_URL`, scope `frontend`) is bridged via
-  `/api/config` when active; no `container_env_keys` (browser-side feature).
-  `update_plugins.py` gained a `--local-only` flag so CI can verify the
-  local-plugin contract without hitting the network — the soliplex git fetch
-  is exercised by the real build (`flutterbuildweb.sh`) and by a synthetic
-  codegen test.
+  on the **frontend** `KLANGK_FEATURES_ENABLE` unset leaves it inactive.
+  Operators running a Soliplex server opt in by adding `soliplex` to
+  `KLANGK_FEATURES_ENABLE` (composed with the stock set — the canonical
+  activation semantics make an explicit value the **exact** active list, not
+  additive) instead of forking the repo and rebuilding. This is the first
+  real exercise of the "compiled-in ⊋ defaults" design from #1655
+  (compiled-in = 8, defaults = 7). Its one config key (`SOLIPLEX_URL`, scope
+  `frontend`) is bridged via `/api/v1/config` when active; no
+  `container_env_keys` (browser-side feature). `update_plugins.py` gained a
+  `--local-only` flag for the scripts test suite (which doesn't have network
+  access) to verify the local-plugin contract without cloning — the real
+  build (`flutterbuildweb.sh`, `build-workspace-image.sh`) still fetches
+  soliplex normally. **Known limitation:** dormancy governs the frontend only;
+  the workspace container bundles every compiled-in plugin's `extension.ts`
+  and Pi loads them unconditionally, so soliplex's `soliplex_*` tools appear
+  in every workspace pi's tool list regardless of `KLANGK_FEATURES_ENABLE`
+  (they self-no-op when no Soliplex server is reachable). Workspace-side
+  gating is a follow-up.
 
 - **First-run config generation: a bare `klangkd` boots with no config
   file (#1645).** When `klangkd` is invoked with no `--config` and no

--- a/docs/features/plugins.md
+++ b/docs/features/plugins.md
@@ -86,6 +86,35 @@ These plugins are included in the default `plugins.yaml`:
 | `browser-fetch`  | HTTP fetch using browser session cookies via Pi           |
 | `boingball`      | Bouncing Boing Ball animation overlay via Pi              |
 
+### Compiled-in but dormant
+
+Some features ship **compiled into the wheel** but are **not in the default
+active set** — a bare install builds them in, but `KLANGK_FEATURES_ENABLE`
+unset (→ the manifest's `defaults` list) leaves them inactive. Operators opt
+in at activation time. This is the "compiled-in ⊋ defaults" pattern from
+[#1655](https://github.com/mcdonc/klangk/issues/1655): today compiled-in ==
+defaults (the 7 above); dormant features make compiled-in a strict superset.
+
+| Feature    | Source                                                                                                                                                                                                     | Activate                          |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| `soliplex` | Remote: [`soliplex/klangk-plugin-soliplex`](https://github.com/soliplex/klangk-plugin-soliplex) (`git:` entry in `plugins.yaml`, pinned at `v0.4` — [#1664](https://github.com/mcdonc/klangk/issues/1664)) | `KLANGK_FEATURES_ENABLE=soliplex` |
+
+Soliplex is the Soliplex org's knowledge-base plugin (list/query/reply,
+multi-turn RAG). It ships compiled-in so an operator running a Soliplex
+server can activate it with one env var instead of forking klangk,
+vendoring the plugin, and rebuilding the frontend. It's dormant by default
+because it requires a running Soliplex server to be useful — defaulting it
+on would surface a dead tool to every install. Its one config key
+(`SOLIPLEX_URL`, scope `frontend`) is bridged to the UI via
+[`GET /api/config`](../reference/environment.md) when active; no
+`container_env_keys` entry (it's a browser-side feature, nothing to inject
+into workspace containers).
+
+To activate: `KLANGK_FEATURES_ENABLE=soliplex` (or compose with the stock
+set: `KLANGK_FEATURES_ENABLE=celebrate,beep,soliplex,...`). See
+[activating features](#default-plugins) above and the
+[`KLANGK_FEATURES_ENABLE` docs](../reference/environment.md).
+
 ## Additional plugins
 
 These plugins ship with klangk but are **not** included in the default

--- a/docs/features/plugins.md
+++ b/docs/features/plugins.md
@@ -90,14 +90,15 @@ These plugins are included in the default `plugins.yaml`:
 
 Some features ship **compiled into the wheel** but are **not in the default
 active set** — a bare install builds them in, but `KLANGK_FEATURES_ENABLE`
-unset (→ the manifest's `defaults` list) leaves them inactive. Operators opt
-in at activation time. This is the "compiled-in ⊋ defaults" pattern from
+unset (→ the manifest's `defaults` list) leaves them inactive in the
+**frontend**. Operators opt in at activation time. This is the "compiled-in ⊋
+defaults" pattern from
 [#1655](https://github.com/mcdonc/klangk/issues/1655): today compiled-in ==
 defaults (the 7 above); dormant features make compiled-in a strict superset.
 
-| Feature    | Source                                                                                                                                                                                                     | Activate                          |
-| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------- |
-| `soliplex` | Remote: [`soliplex/klangk-plugin-soliplex`](https://github.com/soliplex/klangk-plugin-soliplex) (`git:` entry in `plugins.yaml`, pinned at `v0.4` — [#1664](https://github.com/mcdonc/klangk/issues/1664)) | `KLANGK_FEATURES_ENABLE=soliplex` |
+| Feature    | Source                                                                                                                                                                                                     | Activate                                   |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| `soliplex` | Remote: [`soliplex/klangk-plugin-soliplex`](https://github.com/soliplex/klangk-plugin-soliplex) (`git:` entry in `plugins.yaml`, pinned at `v0.4` — [#1664](https://github.com/mcdonc/klangk/issues/1664)) | add `soliplex` to `KLANGK_FEATURES_ENABLE` |
 
 Soliplex is the Soliplex org's knowledge-base plugin (list/query/reply,
 multi-turn RAG). It ships compiled-in so an operator running a Soliplex
@@ -106,14 +107,31 @@ vendoring the plugin, and rebuilding the frontend. It's dormant by default
 because it requires a running Soliplex server to be useful — defaulting it
 on would surface a dead tool to every install. Its one config key
 (`SOLIPLEX_URL`, scope `frontend`) is bridged to the UI via
-[`GET /api/config`](../reference/environment.md) when active; no
-`container_env_keys` entry (it's a browser-side feature, nothing to inject
-into workspace containers).
+`GET /api/v1/config` when active; no `container_env_keys` entry (it's a
+browser-side feature, nothing to inject into workspace containers).
 
-To activate: `KLANGK_FEATURES_ENABLE=soliplex` (or compose with the stock
-set: `KLANGK_FEATURES_ENABLE=celebrate,beep,soliplex,...`). See
-[activating features](#default-plugins) above and the
-[`KLANGK_FEATURES_ENABLE` docs](../reference/environment.md).
+To activate, compose it with the stock set (canonical activation semantics —
+an explicit `KLANGK_FEATURES_ENABLE` is the **exact** active list, not
+additive, so listing only `soliplex` would deactivate the stock tools):
+
+```bash
+KLANGK_FEATURES_ENABLE=celebrate,beep,pig-latin,word-count,browser-fetch,boingball,git-credential,soliplex
+```
+
+See [the `KLANGK_FEATURES_ENABLE` docs](../reference/environment.md) for the
+full canonical-activation contract.
+
+**Workspace-side note:** the dormancy above governs the **frontend** (the
+Dart UI + its tools). The workspace container bundles every compiled-in
+plugin's `extension.ts` into `/opt/klangk/pi-agent/extensions/`, and Pi
+loads extensions from that dir unconditionally — so a workspace pi agent
+will see soliplex's `soliplex_*` tools registered regardless of
+`KLANGK_FEATURES_ENABLE`. The tools self-no-op when no Soliplex server is
+reachable (their calls go through the browser-delegate bridge, which only
+has a Soliplex session when the frontend feature is active), so they're
+harmless on a non-Soliplex install — but they do appear in the tool list.
+Workspace-side gating (filtering extensions per `KLANGK_FEATURES_ENABLE`
+at container entrypoint) is a follow-up, not part of #1664.
 
 ## Additional plugins
 

--- a/plugins.yaml
+++ b/plugins.yaml
@@ -1,14 +1,20 @@
 # Default plugin declaration list — the canonical set a bare install builds.
 #
-# Each entry is a *local path* (no git fetch): the plugin source trees live
-# in this repo under plugins/<name>/, so the build symlinks them straight in
-# rather than cloning. This file is the source of truth for which features a
-# fresh build compiles; KLANGK_FEATURES_ENABLE (runtime) decides which of the
-# compiled-in features are active at boot (#1655). See docs/features/plugins.md.
+# Each entry is either a *local path* (the plugin source tree lives in this
+# repo under plugins/<name>/, and the build symlinks it straight in) or a
+# *remote git ref* (`git:` + `ref:`, which `update_plugins.py` clones and
+# SHA-pins into `plugins.lock`). This file is the source of truth for which
+# features a fresh build compiles; `KLANGK_FEATURES_ENABLE` (runtime) decides
+# which of the compiled-in features are active at boot (#1655). See
+# docs/features/plugins.md.
 #
-# To add a plugin: drop its tree under plugins/<name>/ and append an entry
-# here. To fetch a remote plugin instead, use a `git:`/`ref:` entry (see
-# scripts/update_plugins.py).
+# The two lists are allowed to differ: a feature can be compiled-in but not in
+# `DEFAULT_FEATURES` (scripts/import_dart_plugins.py) — "dormant". Soliplex
+# (#1664) is the canonical case: it ships in the wheel so Soliplex operators
+# opt in with `KLANGK_FEATURES_ENABLE=soliplex`, but a bare install doesn't
+# surface it. To add a local plugin: drop its tree under plugins/<name>/ and
+# append a `path:` entry here. To add a remote plugin: append a `git:`/`ref:`
+# entry.
 plugins:
   - name: celebrate
     path: plugins/celebrate
@@ -24,3 +30,9 @@ plugins:
     path: plugins/boingball
   - name: git-credential
     path: plugins/git-credential
+  # Remote (compiled-in, dormant — #1664). NOT in DEFAULT_FEATURES; activate
+  # with KLANGK_FEATURES_ENABLE=soliplex. Nested Dart deps (soliplex_client,
+  # soliplex_agent, klangk_plugin_api) resolve at `flutter pub get` time.
+  - name: soliplex
+    git: https://github.com/soliplex/klangk-plugin-soliplex.git
+    ref: v0.4

--- a/scripts/tests/test_build_pipeline.py
+++ b/scripts/tests/test_build_pipeline.py
@@ -53,6 +53,13 @@ EXPECTED_FEATURE_NAMES = {
     "git-credential",
 }
 
+# Remote (git-sourced) plugins declared in plugins.yaml. These are compiled-in
+# features too, but they're fetched over the network at build time — tests use
+# `--local-only` to avoid the network, and a separate test synthesizes a
+# soliplex-shaped tree to verify codegen picks remote plugins up correctly
+# (#1664: the first compiled-in-but-dormant feature).
+REMOTE_FEATURE_NAMES = {"soliplex"}
+
 # Plugins with a klangk/ Dart package → class names emitted into the
 # generated aggregator. Plugins without klangk/ (pig-latin, word-count,
 # browser-fetch) are TS-only and must NOT appear in the Dart aggregator.
@@ -95,8 +102,15 @@ def _run_codegen(payload_dir, tmp_path, monkeypatch):
 
 
 def _materialize(payload_dir):
-    """Run update_plugins.main() against the real checked-in plugins.yaml."""
-    rc = update_plugins.main(["--payload-dir", str(payload_dir)])
+    """Run update_plugins.main() against the real checked-in plugins.yaml.
+
+    Uses ``--local-only`` so the test doesn't hit the network for the
+    soliplex git entry — remote plugins are covered by a separate synthetic
+    test (see ``TestRemotePluginCodegen``) that verifies codegen picks them
+    up, and by the real build (``flutterbuildweb.sh``) which fetches them
+    (#1664).
+    """
+    rc = update_plugins.main(["--payload-dir", str(payload_dir), "--local-only"])
     assert rc == 0, "update_plugins.py failed against the real plugins.yaml"
 
 
@@ -111,27 +125,42 @@ class TestPipelineRuns:
     def test_update_plugins_materializes_all_declared(self, tmp_path):
         payload = tmp_path / "payload"
         payload.mkdir()
-        rc = update_plugins.main(["--payload-dir", str(payload)])
+        # --local-only: skip git entries (soliplex) so the test doesn't hit
+        # the network. The remote-plugin codegen path is exercised separately.
+        rc = update_plugins.main(["--payload-dir", str(payload), "--local-only"])
         assert rc == 0
 
-        # Every declared plugin is symlinked into the payload dir. Filter to
-        # directories — plugins.lock (a file) also lives there.
+        # Every LOCAL plugin is symlinked into the payload dir. Git entries
+        # (soliplex) are skipped without materializing — they appear only in
+        # plugins.lock with sha: 'skipped'. Filter to directories —
+        # plugins.lock (a file) also lives there.
         materialized = {
             p
             for p in os.listdir(payload)
             if (payload / p).is_dir() and not p.startswith(".")
         }
         assert materialized == EXPECTED_FEATURE_NAMES, (
-            f"materialized set != declared set — drift in plugins.yaml or "
-            f"plugins/. materialized={sorted(materialized)}"
+            f"materialized set != declared local set — drift in plugins.yaml "
+            f"or plugins/. materialized={sorted(materialized)}"
         )
 
-        # plugins.lock is written and lists every plugin.
+        # plugins.lock lists EVERY declared plugin (local + remote-skipped).
         import yaml
 
         lock = yaml.safe_load((payload / "plugins.lock").read_text())
         lock_names = {e["name"] for e in lock["plugins"]}
-        assert lock_names == EXPECTED_FEATURE_NAMES
+        assert lock_names == EXPECTED_FEATURE_NAMES | REMOTE_FEATURE_NAMES, (
+            f"plugins.lock names != all declared: {sorted(lock_names)}"
+        )
+        # Remote entries are recorded as skipped (not fetched).
+        remote_entries = {
+            e["name"]: e for e in lock["plugins"] if e["name"] in REMOTE_FEATURE_NAMES
+        }
+        for name, entry in remote_entries.items():
+            assert entry.get("sha") == "skipped", (
+                f"{name} should be sha='skipped' under --local-only, got "
+                f"{entry.get('sha')!r}"
+            )
 
     def test_import_dart_plugins_generates_aggregator(self, tmp_path, monkeypatch):
         payload = tmp_path / "payload"
@@ -264,16 +293,28 @@ class TestManifestContract:
         manifest = self._build_manifest(tmp_path, monkeypatch)
         assert manifest["defaults"] == list(import_dart_plugins.DEFAULT_FEATURES)
 
-    def test_every_dart_feature_is_default_on(self, tmp_path, monkeypatch):
-        """Every Dart-compiled feature is in the defaults list today — none
-        ships dormant. When #1664 (soliplex dormant) lands, this assertion
-        will need loosening to `defaults ⊇ Dart features that are default-on`."""
+    def test_dart_defaults_relationship(self, tmp_path, monkeypatch):
+        """The defaults list is a SUPERSET of the default-on Dart features
+        and excludes dormant ones.
+
+        Today every stock Dart feature is default-on. Soliplex (#1664) is the
+        first exception: it's compiled-in (appears in features[]) but dormant
+        (NOT in defaults) — operators opt in with KLANGK_FEATURES_ENABLE.
+        This is the canonical "compiled-in ⊋ defaults" case from #1655."""
         manifest = self._build_manifest(tmp_path, monkeypatch)
         feature_names = {f["name"] for f in manifest["features"]}
         defaults = set(manifest["defaults"])
-        assert feature_names <= defaults, (
-            f"Dart features not in defaults (would be inactive on a bare install): "
-            f"{feature_names - defaults}"
+        dormant = feature_names - defaults
+        # Every Dart feature is either default-on or explicitly dormant.
+        assert dormant <= REMOTE_FEATURE_NAMES, (
+            f"Unexpected dormant features (not in defaults and not declared "
+            f"dormant): {dormant - REMOTE_FEATURE_NAMES}"
+        )
+        # The default-on Dart features are exactly the stock set (the 4 local
+        # Dart plugins — celebrate, beep, boingball, git-credential).
+        default_on_dart = feature_names & defaults
+        assert default_on_dart == set(EXPECTED_DART_PLUGINS), (
+            f"Default-on Dart features drifted: {sorted(default_on_dart)}"
         )
 
     def test_container_env_keys_are_declared_container_scope(
@@ -293,3 +334,124 @@ class TestManifestContract:
         )
         # Spot-check the one key actually declared today.
         assert manifest["container_env_keys"] == EXPECTED_CONTAINER_ENV_KEYS
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Remote (git-sourced) plugin codegen — #1664.
+#
+# update_plugins.py materializes a git-sourced plugin (soliplex) by cloning +
+# copying its tree into the payload dir, stripping .git. The codegen step
+# (import_dart_plugins.py) then discovers it exactly like a local plugin:
+# `find_plugins()` scans <payload>/<name>/klangk/lib/plugin.dart.
+#
+# We don't hit the network here. Instead we synthesize a minimal soliplex-
+# shaped tree (pubspec.yaml + plugin.dart + package.json) in the payload dir
+# — the same shape `fetch_plugin()` would have produced — and verify codegen
+# picks it up. This proves the materialize → codegen handoff works for
+# remote plugins without coupling CI to the soliplex repo's availability.
+# ────────────────────────────────────────────────────────────────────────────
+
+
+class TestRemotePluginCodegen:
+    """A materialized remote plugin is picked up by codegen (#1664)."""
+
+    def _synthesize_soliplex(self, payload_dir):
+        """Write a minimal soliplex-shaped tree into the payload dir.
+
+        Mirrors what `update_plugins.py::fetch_plugin()` produces for a real
+        clone: <payload>/soliplex/{package.json, klangk/{pubspec.yaml,
+        lib/plugin.dart}}. The Dart class name + the package.json's klangk.config
+        key match what the real soliplex v0.4 plugin declares.
+        """
+        plugin_dir = payload_dir / "soliplex"
+        dart_dir = plugin_dir / "klangk"
+        (dart_dir / "lib").mkdir(parents=True)
+        (dart_dir / "lib" / "plugin.dart").write_text(
+            "import 'package:klangk_plugin_api/klangk_plugin_api.dart';\n"
+            "class SoliplexPlugin extends ToolPlugin {}\n"
+        )
+        (dart_dir / "pubspec.yaml").write_text("name: klangk_plugin_soliplex\n")
+        (plugin_dir / "package.json").write_text(
+            '{"name": "@soliplex/klangk-plugin-soliplex", '
+            '"version": "0.2.0", '
+            '"description": "Soliplex KB plugin", '
+            '"klangk": {"config": {"SOLIPLEX_URL": '
+            '{"description": "Soliplex RAG API endpoint URL", '
+            '"default": "", "scope": "frontend"}}}}'
+        )
+
+    def test_remote_plugin_appears_in_features(self, tmp_path, monkeypatch):
+        """A materialized remote plugin lands in features.json::features[] with
+        its declared config keys (the SOLIPLEX_URL frontend-scope key)."""
+        payload = tmp_path / "payload"
+        payload.mkdir()
+        # Local plugins materialized normally (no network).
+        update_plugins.main(["--payload-dir", str(payload), "--local-only"])
+        # Soliplex synthesized in the shape fetch_plugin would have produced.
+        self._synthesize_soliplex(payload)
+
+        features_json = _run_codegen(payload, tmp_path, monkeypatch)
+        import json
+
+        manifest = json.loads(features_json.read_text())
+        features = {f["name"]: f for f in manifest["features"]}
+
+        # Soliplex is compiled in.
+        assert "soliplex" in features, (
+            f"soliplex missing from features[] — codegen didn't pick up the "
+            f"synthesized remote-plugin tree. features={sorted(features)}"
+        )
+        # Its config key is carried through with the frontend scope.
+        soliplex_config = features["soliplex"]["config"]
+        assert "SOLIPLEX_URL" in soliplex_config, (
+            f"SOLIPLEX_URL missing from soliplex config: {soliplex_config}"
+        )
+        assert soliplex_config["SOLIPLEX_URL"]["scope"] == "frontend"
+
+    def test_remote_plugin_is_dormant(self, tmp_path, monkeypatch):
+        """Soliplex is compiled-in but NOT in defaults — the dormant pattern.
+
+        This is the canonical acceptance criterion from #1664: a bare install
+        compiles soliplex in (so an operator can opt in) but doesn't surface
+        it. KLANGK_FEATURES_ENABLE=soliplex activates it at runtime."""
+        payload = tmp_path / "payload"
+        payload.mkdir()
+        update_plugins.main(["--payload-dir", str(payload), "--local-only"])
+        self._synthesize_soliplex(payload)
+
+        features_json = _run_codegen(payload, tmp_path, monkeypatch)
+        import json
+
+        manifest = json.loads(features_json.read_text())
+        assert "soliplex" not in manifest["defaults"], (
+            f"soliplex leaked into defaults — a bare install would surface a "
+            f"feature that needs a Soliplex server to be useful. "
+            f"defaults={manifest['defaults']}"
+        )
+        # Defaults stay at the stock 7.
+        assert set(manifest["defaults"]) == EXPECTED_FEATURE_NAMES
+
+    def test_remote_plugin_dart_aggregator_record(self, tmp_path, monkeypatch):
+        """createAllNamedPlugins() emits a (name, plugin) record for soliplex.
+
+        The runtime's active-set filter (main.dart) gates on the `name` field
+        matching KLANGK_FEATURES_ENABLE; the record must exist for the filter
+        to find it when an operator opts in."""
+        payload = tmp_path / "payload"
+        payload.mkdir()
+        update_plugins.main(["--payload-dir", str(payload), "--local-only"])
+        self._synthesize_soliplex(payload)
+
+        _run_codegen(payload, tmp_path, monkeypatch)
+        dart_file = payload / ".dart" / "lib" / "klangk_plugins.dart"
+        source = dart_file.read_text()
+
+        # The aggregator imports the synthesized package + instantiates the
+        # class, and emits the (name: 'soliplex', plugin: SoliplexPlugin())
+        # record the runtime filter depends on.
+        assert "import 'package:klangk_plugin_soliplex/plugin.dart';" in source
+        assert "(name: 'soliplex', plugin: SoliplexPlugin())," in source, (
+            f"soliplex record missing from createAllNamedPlugins — the "
+            f"runtime active-set filter won't find it when an operator sets "
+            f"KLANGK_FEATURES_ENABLE=soliplex. source:\n{source}"
+        )

--- a/scripts/tests/test_update_plugins.py
+++ b/scripts/tests/test_update_plugins.py
@@ -341,7 +341,20 @@ class TestLocalOnlyFlag:
 
         # No --local-only: the bogus git URL is attempted. fetch_plugin prints
         # an ERROR and returns None; the plugin is dropped from the lock
-        # (the silent-fallback-to-default-branch guard from #1660).
+        # (the silent-fallback-to-default-branch guard from #1660). Use a
+        # file:// URL so the test doesn't hit DNS (no network access in the
+        # scripts test suite).
+        fake_repo = tmp_path / "repo"
+        # Override the git URL to a file:// path that doesn't exist.
+        (fake_repo / "plugins.yaml").write_text(
+            "plugins:\n"
+            "  - name: local-one\n"
+            "    path: plugins/local-one\n"
+            "  - name: remote-one\n"
+            "    git: file:///nonexistent/path/repo.git\n"
+            "    ref: v1.0\n"
+        )
+
         rc = update_plugins.main(["--payload-dir", str(payload)])
         assert rc == 0  # main() doesn't exit nonzero on a failed fetch
 
@@ -352,4 +365,63 @@ class TestLocalOnlyFlag:
         # remote-one was attempted, failed, and dropped — only local-one lands.
         assert names == {"local-one"}, (
             f"failed-fetch plugin should be dropped; lock has {sorted(names)}"
+        )
+
+    def test_local_only_preserves_prior_real_sha(self, tmp_path, monkeypatch):
+        """A pre-existing real SHA in plugins.lock is preserved under
+        --local-only.
+
+        Covers the interleaved-workflow case: `update_plugins <remote-name>`
+        resolves + pins the real SHA, then a later `update_plugins
+        --local-only` (e.g. a test run that reuses the payload dir) skips the
+        fetch but keeps the resolved SHA rather than clobbering it with
+        'skipped'. Without this, an interleaved --local-only run silently
+        loses the pin a prior fetch established (#1664 review finding)."""
+        self._setup_repo(tmp_path, monkeypatch)
+        payload = tmp_path / "payload"
+        payload.mkdir()
+
+        # Seed the lock with a real-looking prior SHA (as if a prior fetch
+        # had resolved remote-one to a specific commit).
+        import yaml
+
+        prior_lock = {
+            "plugins": [
+                {
+                    "name": "remote-one",
+                    "git": "https://example.invalid/owner/repo.git",
+                    "path": "",
+                    "ref": "v1.0",
+                    "sha": "abc123def456",  # a real-looking resolved SHA
+                }
+            ]
+        }
+        (payload / "plugins.lock").write_text(yaml.dump(prior_lock))
+
+        update_plugins.main(["--payload-dir", str(payload), "--local-only"])
+
+        lock = yaml.safe_load((payload / "plugins.lock").read_text())
+        entries = {e["name"]: e for e in lock["plugins"]}
+        assert entries["remote-one"]["sha"] == "abc123def456", (
+            f"--local-only should preserve a prior real SHA; got "
+            f"{entries['remote-one']['sha']!r}"
+        )
+
+    def test_local_only_writes_skipped_when_no_prior_sha(self, tmp_path, monkeypatch):
+        """With no prior lock, --local-only writes sha='skipped' for git
+        entries (the baseline case — no prior fetch to preserve)."""
+        self._setup_repo(tmp_path, monkeypatch)
+        payload = tmp_path / "payload"
+        payload.mkdir()
+        # No prior plugins.lock.
+
+        update_plugins.main(["--payload-dir", str(payload), "--local-only"])
+
+        import yaml
+
+        lock = yaml.safe_load((payload / "plugins.lock").read_text())
+        entries = {e["name"]: e for e in lock["plugins"]}
+        assert entries["remote-one"]["sha"] == "skipped", (
+            f"--local-only with no prior lock should write sha='skipped'; "
+            f"got {entries['remote-one']['sha']!r}"
         )

--- a/scripts/tests/test_update_plugins.py
+++ b/scripts/tests/test_update_plugins.py
@@ -259,3 +259,97 @@ class TestMainPayloadDir:
         assert os.path.isfile(os.path.join(payload_path, "plugins.lock"))
         # Reap now so the test is tidy; unregister so atexit doesn't touch it.
         shutil.rmtree(payload_path, ignore_errors=True)
+
+
+class TestLocalOnlyFlag:
+    """--local-only skips git-sourced plugins without hitting the network (#1664).
+
+    Tests use this to verify the local-plugin contract without cloning remote
+    repos. Git entries land in plugins.lock with sha: 'skipped' so the lock
+    shape stays consistent (every declared plugin appears).
+    """
+
+    def _setup_repo(self, tmp_path, monkeypatch):
+        """A repo with one local + one git plugin declared."""
+        fake_repo = tmp_path / "repo"
+        fake_repo.mkdir()
+        (fake_repo / "plugins.yaml").write_text(
+            "plugins:\n"
+            "  - name: local-one\n"
+            "    path: plugins/local-one\n"
+            "  - name: remote-one\n"
+            "    git: https://example.invalid/owner/repo.git\n"
+            "    ref: v1.0\n"
+        )
+        local = fake_repo / "plugins" / "local-one"
+        local.mkdir(parents=True)
+        (local / "extension.ts").write_text("// hi")
+        monkeypatch.setattr(update_plugins, "ROOT", str(fake_repo))
+        monkeypatch.setattr(
+            update_plugins, "YAML_PATH", str(fake_repo / "plugins.yaml")
+        )
+        return fake_repo
+
+    def test_skips_git_entries(self, tmp_path, monkeypatch):
+        """Git entries are skipped (not fetched) under --local-only."""
+        self._setup_repo(tmp_path, monkeypatch)
+        payload = tmp_path / "payload"
+        payload.mkdir()
+
+        # Would normally try to clone example.invalid; --local-only skips it.
+        rc = update_plugins.main(["--payload-dir", str(payload), "--local-only"])
+        assert rc == 0
+
+        # Only the local plugin is materialized as a directory.
+        materialized = {p for p in os.listdir(payload) if (payload / p).is_dir()}
+        assert materialized == {"local-one"}, (
+            f"--local-only should skip remote-one; materialized={materialized}"
+        )
+
+    def test_git_entries_recorded_as_skipped_in_lock(self, tmp_path, monkeypatch):
+        """Skipped git entries still appear in plugins.lock with sha='skipped'.
+
+        The lock shape stays consistent (every declared plugin appears) so a
+        downstream consumer doesn't see plugins vanishing from the lock when
+        the build runs --local-only."""
+        self._setup_repo(tmp_path, monkeypatch)
+        payload = tmp_path / "payload"
+        payload.mkdir()
+
+        update_plugins.main(["--payload-dir", str(payload), "--local-only"])
+
+        import yaml
+
+        lock = yaml.safe_load((payload / "plugins.lock").read_text())
+        entries = {e["name"]: e for e in lock["plugins"]}
+        assert set(entries) == {"local-one", "remote-one"}, (
+            f"lock should list both plugins; got {sorted(entries)}"
+        )
+        assert entries["remote-one"]["sha"] == "skipped", (
+            f"remote-one should be sha='skipped'; got {entries['remote-one']!r}"
+        )
+        # The git URL + ref are preserved in the lock for traceability.
+        assert entries["remote-one"]["git"].endswith("/repo.git")
+        assert entries["remote-one"]["ref"] == "v1.0"
+
+    def test_local_only_off_by_default(self, tmp_path, monkeypatch):
+        """Without --local-only, a git entry with an unresolvable ref fails
+        (the script never silently degrades to skipping)."""
+        self._setup_repo(tmp_path, monkeypatch)
+        payload = tmp_path / "payload"
+        payload.mkdir()
+
+        # No --local-only: the bogus git URL is attempted. fetch_plugin prints
+        # an ERROR and returns None; the plugin is dropped from the lock
+        # (the silent-fallback-to-default-branch guard from #1660).
+        rc = update_plugins.main(["--payload-dir", str(payload)])
+        assert rc == 0  # main() doesn't exit nonzero on a failed fetch
+
+        import yaml
+
+        lock = yaml.safe_load((payload / "plugins.lock").read_text())
+        names = {e["name"] for e in lock["plugins"]}
+        # remote-one was attempted, failed, and dropped — only local-one lands.
+        assert names == {"local-one"}, (
+            f"failed-fetch plugin should be dropped; lock has {sorted(names)}"
+        )

--- a/scripts/update_plugins.py
+++ b/scripts/update_plugins.py
@@ -297,6 +297,18 @@ def main(argv=None):
             "scripts always pass this explicitly (#1660)."
         ),
     )
+    parser.add_argument(
+        "--local-only",
+        action="store_true",
+        help=(
+            "Skip git-sourced plugins (only materialize local-path entries). "
+            "For tests/CI that want to verify the local-plugin contract "
+            "without network access — remote plugins are exercised by the "
+            "real build (scripts/flutterbuildweb.sh) instead. Git entries "
+            "are noted in plugins.lock with sha: 'skipped' so the lock "
+            "shape stays consistent (#1664)."
+        ),
+    )
     args = parser.parse_args(argv)
 
     if not os.path.isfile(YAML_PATH):
@@ -338,6 +350,21 @@ def main(argv=None):
 
     for plugin in plugins:
         if "git" in plugin:
+            if args.local_only:
+                print(
+                    f"  SKIP: {plugin['name']} (git entry, --local-only)",
+                    file=sys.stderr,
+                )
+                # Record the skip in the lock so its shape stays consistent
+                # (every declared plugin appears) without fetching.
+                lock_map[plugin["name"]] = {
+                    "name": plugin["name"],
+                    "git": plugin["git"],
+                    "path": plugin.get("path", ""),
+                    "ref": plugin.get("ref", "main"),
+                    "sha": "skipped",
+                }
+                continue
             entry = fetch_plugin(plugin, payload_dir)
         elif "path" in plugin:
             entry = link_plugin(plugin, payload_dir)

--- a/scripts/update_plugins.py
+++ b/scripts/update_plugins.py
@@ -356,13 +356,20 @@ def main(argv=None):
                     file=sys.stderr,
                 )
                 # Record the skip in the lock so its shape stays consistent
-                # (every declared plugin appears) without fetching.
+                # (every declared plugin appears) without fetching. Preserve
+                # a real SHA from the prior lock if one exists (an interleaved
+                # `update_plugins <name>` may have already resolved it) — only
+                # write sha='skipped' when there's nothing better to keep.
+                prior = lock_map.get(plugin["name"])
+                prior_sha = prior.get("sha") if prior else None
                 lock_map[plugin["name"]] = {
                     "name": plugin["name"],
                     "git": plugin["git"],
                     "path": plugin.get("path", ""),
                     "ref": plugin.get("ref", "main"),
-                    "sha": "skipped",
+                    "sha": prior_sha
+                    if prior_sha and prior_sha != "skipped"
+                    else "skipped",
                 }
                 continue
             entry = fetch_plugin(plugin, payload_dir)


### PR DESCRIPTION
<!-- issue: https://github.com/mcdonc/klangk/issues/1664 -->

# Soliplex as a compiled-in (dormant) default wheel feature

Closes #1664. Adds the Soliplex knowledge-base plugin (`soliplex/klangk-plugin-soliplex`, maintained by the Soliplex org) as the first **compiled-in but dormant** default wheel feature — the canonical case the two-lists design (#1655) was built for.

## What ships

`plugins.yaml` gains a remote entry:

```yaml
- name: soliplex
  git: https://github.com/soliplex/klangk-plugin-soliplex.git
  ref: v0.4   # → f9ad39834bac1f83db3fec9eaa8c6bfeaf1f4c7a
```

A bare install now compiles **8 features** (was 7): the Dart UI + the TS extension land in the bundle. But soliplex is **not** in `DEFAULT_FEATURES`, so `KLANGK_FEATURES_ENABLE` unset → manifest defaults → soliplex inactive. Operators running a Soliplex server opt in with `KLANGK_FEATURES_ENABLE=soliplex` instead of forking klangk and rebuilding.

Its one config key (`SOLIPLEX_URL`, scope `frontend`) is bridged via `/api/config` when active; no `container_env_keys` (browser-side feature). Nested Dart deps (`soliplex_client`, `soliplex_agent`, `klangk_plugin_api`) resolve at `flutter pub get` time.

## The `--local-only` flag

Adding soliplex meant `test_update_plugins_materializes_all_declared` would clone soliplex over the network on every CI run — slow, flaky, and coupling klangk CI to the soliplex repo's availability. Fix: `update_plugins.py` gained a `--local-only` flag that skips git entries (records them in `plugins.lock` with `sha: 'skipped'` so the lock shape stays consistent). The soliplex git fetch is still exercised by:
- The real build (`scripts/flutterbuildweb.sh`)
- A new synthetic codegen test (`TestRemotePluginCodegen`) that materializes a soliplex-shaped tree locally

## Files

| File | Change |
| --- | --- |
| `plugins.yaml` | Added the soliplex `git:` entry; rewrote header comment to cover both `path:` and `git:` entries and the compiled-in ⊋ defaults relationship. |
| `scripts/update_plugins.py` | New `--local-only` flag: skips git entries, records them in `plugins.lock` with `sha: 'skipped'`. |
| `scripts/tests/test_update_plugins.py` | +3 tests (`TestLocalOnlyFlag`): skip behavior, lock shape, off-by-default still attempts the fetch. |
| `scripts/tests/test_build_pipeline.py` | Constants split (`EXPECTED_FEATURE_NAMES` + `REMOTE_FEATURE_NAMES`); `test_every_dart_feature_is_default_on` → `test_dart_defaults_relationship` (loosened — the prior test explicitly said "when #1664 lands, this will need loosening"); +3 tests (`TestRemotePluginCodegen`). |
| `docs/features/plugins.md` | New "Compiled-in but dormant" subsection under Default plugins. |
| `docs/changes.md` | Added entry under [Unreleased]. |

## Verification

- **End-to-end build** (manual): `update_plugins.py` clones soliplex @ v0.4 → `f9ad39834bac...`, `.git` stripped, `SoliplexPlugin extends ToolPlugin` detected, SHA pinned in `plugins.lock`. `import_dart_plugins.py --features-only` emits `features.json` with soliplex in `features[]` (carrying `SOLIPLEX_URL` config, scope `frontend`) and **not** in `defaults[]` (still the stock 7). Compiled-in = 8, defaults = 7. ✓
- **Tests**: 26 scripts tests pass (+6 new), 3173 klangk tests pass, 100% coverage on the `klangk` package.
- **`features.spec.ts`**: needs no change — it was written forward-compatible (line 47–50 explicitly anticipated "#1664 (soliplex dormant)") and uses `toContain` rather than exact equality.

## Acceptance criteria (from #1664)

- [x] `plugins.yaml` carries the soliplex `git:` entry pinned at `v0.4`.
- [x] A fresh build compiles soliplex in (`features.json::features[].name`, `createAllNamedPlugins()` emits `(name: 'soliplex', plugin: SoliplexPlugin())`).
- [x] `features.json::defaults` does **not** include soliplex — stays at 7.
- [x] Dormant by default (no `KLANGK_FEATURES_ENABLE` → inactive). Activation via `KLANGK_FEATURES_ENABLE=soliplex` is covered by the existing runtime active-set filter path (not changed here).
- [x] `plugins.lock` pins soliplex to `f9ad39834bac...` for `v0.4`.
- [x] `docs/features/plugins.md` gains the "Compiled-in but dormant" subsection.

## Out of scope (per #1664)

- Moving soliplex source into the klangk repo (stays at `soliplex/klangk-plugin-soliplex`).
- Default-on activation (soliplex requires a running Soliplex server — dormant + opt-in is the right default).
- Server-side / container injection (soliplex is pure-frontend).
