### PR TITLE
Drop typer[all] extra to squash pip warning (#1679)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -632,6 +632,13 @@ set-password <email>` (set a known password for the default user — whose
 
 ### Fixed
 
+- **`pip install klangk` no longer warns `typer 0.27.0 does not provide the
+extra 'all'`** (#1679). The declaration was `typer[all]>=0.12.0`, but the
+  `all` extra was removed from typer (its constituents `rich`, `shellingham`,
+  `colorama` are now unconditional typer runtime deps — `colorama` only on
+  Windows). Changed to `typer>=0.12.0`; the deps `[all]` used to pull in are
+  still installed transitively, so no functionality is lost.
+
 - **The browser-listener container-source deny no longer false-positives
   behind a trusted proxy co-located on klangk's host** (#1546). The
   `location /` deny (#1376) was an inline `deny <ip>; allow all;` list,

--- a/src/klangk/pyproject.toml
+++ b/src/klangk/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.12"
 dependencies = [
     "fastapi>=0.115.0",
     "pydantic-settings>=2.5.0",
-    "typer[all]>=0.12.0",
+    "typer>=0.12.0",
     "uvicorn[standard]>=0.32.0",
     "websockets>=14.0",
     "aiosqlite>=0.20.0",

--- a/uv.lock
+++ b/uv.lock
@@ -691,7 +691,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0" },
     { name = "starlette", specifier = ">=1.3.1" },
-    { name = "typer", extras = ["all"], specifier = ">=0.12.0" },
+    { name = "typer", specifier = ">=0.12.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
     { name = "websockets", specifier = ">=14.0" },
 ]


### PR DESCRIPTION
Closes #1679.

## Summary

`pip install klangk` (and any `pip install` resolving klangk's deps) warned:

```
WARNING: typer 0.27.0 does not provide the extra 'all'
```

The `all` extra was removed from typer — its constituents (`rich`, `shellingham`, `colorama`) are now unconditional typer runtime deps (`colorama` only on Windows). Declaring `typer[all]` is silently ignored by modern typer, and pip warns about it on every fresh install.

## Change

```diff
- "typer[all]>=0.12.0",
+ "typer>=0.12.0",
```

(`src/klangk/pyproject.toml:12`)

`uv.lock` updated automatically to drop `extras = ["all"]` from klangk's typer requirement. Added a `### Fixed` entry to `docs/changes.md`.

## Verification

Reproduced the warning first, then confirmed the fix:

| | `typer[all]>=0.12.0` | `typer>=0.12.0` |
| --- | --- | --- |
| pip warning | `WARNING: typer 0.27.0 does not provide the extra 'all'` | (none) |
| `rich` installed | ✅ | ✅ |
| `shellingham` installed | ✅ | ✅ |
| `annotated-doc` installed | ✅ | ✅ |
| `colorama` installed | ✅ | ❌ (correctly — typer declares `colorama; platform_system == "Windows"`, Linux doesn't need it) |

So dropping `[all]` loses nothing on Linux/macOS, and Windows still gets `colorama` via typer's own platform-guarded dep.

Test suite: **3173 passed, 100% coverage** (CI invocation: `python -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -n auto`).
