### PR TITLE
feat(1689): drop @demigodmode/pi-web-agent from workspace image

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -429,6 +429,14 @@ klangk` now yields `klangk` (client) and `klangkd` (server), matching the
 
 ### Removed
 
+- **The `@demigodmode/pi-web-agent` Pi extension is no longer installed
+  in the workspace image (#1689).** The workspace Dockerfile previously ran
+  `pi install npm:@demigodmode/pi-web-agent@1.5.0` alongside the global
+  `@earendil-works/pi-coding-agent` install; that step is gone, and the
+  extension is no longer listed among the pre-installed Pi extensions in
+  the docs. `@earendil-works/pi-coding-agent` is unchanged. Users who want
+  the web-agent UI can still `pi install` it at runtime.
+
 - **`instance_metadata` DB table / DB-stored instance ID:** the instance
   ID is now a single line of text in `<data_dir>/instance-id`, not a row in
   SQLite. The file lives in `data_dir` (next to `klangk.db`) because it

--- a/docs/features/ai-coding-harnesses.md
+++ b/docs/features/ai-coding-harnesses.md
@@ -68,7 +68,6 @@ follow-up conversations and interjections.
 
 The workspace image ships with several Pi extensions pre-installed:
 
-- **pi-web-agent** — web-based agent UI
 - **llm-proxy-models** — dynamically fetches available models from the
   LLM proxy
 - **minimax-thinking-tags** — strips `<think>` tags from models that

--- a/src/containers/workspace/Dockerfile
+++ b/src/containers/workspace/Dockerfile
@@ -1,12 +1,10 @@
 ARG WORKSPACE_BASE_IMAGE=ghcr.io/mcdonc/klangk/klangk-workspace-base:2026.07.03-7a5caf9
 FROM $WORKSPACE_BASE_IMAGE
 
-# Install Pi coding agent and npm-based extensions globally.
-# This layer is expensive (~30s) and rarely changes, so it goes first.
-# Records packages in settings.json for Pi to discover at runtime.
+# Install Pi coding agent globally. This layer is expensive (~30s) and
+# rarely changes, so it goes first.
 RUN npm install -g @earendil-works/pi-coding-agent@0.79.9 \
-    && mkdir -p /opt/klangk/pi-agent/extensions /opt/klangk/pi-agent/skills \
-    && PI_CODING_AGENT_DIR=/opt/klangk/pi-agent pi install npm:@demigodmode/pi-web-agent@1.5.0
+    && mkdir -p /opt/klangk/pi-agent/extensions /opt/klangk/pi-agent/skills
 
 # Copy full plugin repos and symlink discoverable pieces into central dirs.
 # Extensions get <plugin>.ts, skills get <plugin>-<skill>/, prompts get

--- a/src/containers/workspace/klangk-setup-pi.py
+++ b/src/containers/workspace/klangk-setup-pi.py
@@ -53,7 +53,16 @@ def write_settings():
     if settings_path.exists():
         return  # don't overwrite user's settings
 
-    image_settings = json.loads((IMAGE_DIR / "settings.json").read_text())
+    # The image's settings.json is emitted by ``pi install`` at build time
+    # (Pi records installed extensions there as a side effect of installing
+    # any npm extension). An image with no pre-installed npm extensions has
+    # no settings.json — start from an empty dict and write the standard
+    # keys below so the agent home is still fully provisioned.
+    image_settings_path = IMAGE_DIR / "settings.json"
+    if image_settings_path.is_file():
+        image_settings = json.loads(image_settings_path.read_text())
+    else:
+        image_settings = {}
     model = os.environ.get("KLANGK_LLM_MODEL", "")
     image_settings["defaultProvider"] = "llm-proxy"
     image_settings["defaultModel"] = model

--- a/src/klangk/klangkd-tests/tests/test_setup_pi.py
+++ b/src/klangk/klangkd-tests/tests/test_setup_pi.py
@@ -70,6 +70,38 @@ class TestWriteSettings:
 
         assert json.loads((agent / "settings.json").read_text()) == existing
 
+    def test_provisions_when_image_has_no_settings(
+        self, tmp_path, monkeypatch
+    ):
+        # An image with no pre-installed npm extensions has no settings.json
+        # in IMAGE_DIR (the file is a side effect of `pi install`). The
+        # setup script must still provision a working settings.json rather
+        # than crash (#1689).
+        home = tmp_path / "home" / "testuser"
+        home.mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setenv("KLANGK_LLM_MODEL", "test-model")
+
+        image_dir = tmp_path / "opt" / "klangk" / "pi-agent"
+        for d in ("extensions", "skills", "prompts", "npm"):
+            (image_dir / d).mkdir(parents=True)
+        # NOTE: deliberately no image_dir / settings.json.
+        monkeypatch.setattr(sc, "IMAGE_DIR", image_dir)
+        monkeypatch.setattr(sc, "ERROR_LOG", tmp_path / "errors.log")
+
+        agent = home / ".pi" / "agent"
+        agent.mkdir(parents=True)
+
+        sc.write_settings()  # must not raise
+
+        settings = json.loads((agent / "settings.json").read_text())
+        assert settings["defaultProvider"] == "llm-proxy"
+        assert settings["defaultModel"] == "test-model"
+        assert settings["defaultThinkingLevel"] == "off"
+        assert settings["extensions"] == [str(image_dir / "extensions")]
+        assert settings["skills"] == [str(image_dir / "skills")]
+        assert settings["prompts"] == [str(image_dir / "prompts")]
+
 
 class TestEnsureSettingsKeys:
     def test_backfills_missing_keys(self, fake_home):


### PR DESCRIPTION
## Summary

Stop installing/configuring `@demigodmode/pi-web-agent` in the workspace
image. The `@earendil-works/pi-coding-agent` install is unchanged — only
the `pi-web-agent` extension is dropped.

Closes #1689.

## Changes

- **`src/containers/workspace/Dockerfile`** — removed the
  `PI_CODING_AGENT_DIR=/opt/klangk/pi-agent pi install npm:@demigodmode/pi-web-agent@1.5.0`
  clause from the Pi install `RUN`. `npm install -g @earendil-works/pi-coding-agent@…`
  and the `mkdir -p /opt/klangk/pi-agent/{extensions,skills}` are unchanged.
- **`docs/features/ai-coding-harnesses.md`** — dropped the `pi-web-agent`
  bullet from the "Pi extensions" list.
- **`docs/changes.md`** — added a `### Removed` entry under `[Unreleased]`.

## Checklist

- [x] `rg "pi-web-agent"` returns nothing under `src/` and `docs/`.
- [x] `@earendil-works/pi-coding-agent` install is unchanged.
- [x] No tests reference the touched files.
