### PR TITLE
fix(1691): default builds skip soliplex (CI unblock for ag-ui LFS gap)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -657,6 +657,23 @@ set-password <email>` (set a known password for the default user — whose
 
 ### Fixed
 
+- **Default builds skip the soliplex remote plugin (CI unblock, #1691).**
+  Every PR triggering `klangk:flutter-build` was failing during
+  `flutter pub get`: the soliplex plugin (#1683) pulls `soliplex_client` /
+  `soliplex_agent` from `soliplex/frontend.git`, one of which depends on the
+  **git** source of `ag_ui` (`ag-ui-protocol/ag-ui`) — and that repo has an
+  LFS-tracked fixture (`apps/dojo/e2e/fixtures/test-image.png`) whose object
+  went missing on the remote, breaking every clone's smudge filter.
+  Workaround: `scripts/flutterbuildweb.sh` and
+  `scripts/build-workspace-image.sh` now default to `update_plugins.py
+--local-only`, which skips git-sourced plugins (records them in
+  `plugins.lock` with `sha: 'skipped'`). Soliplex is dormant by default
+  anyway (not in `DEFAULT_FEATURES`), so a default build produces a
+  pre-#1683-equivalent bundle with no ag-ui LFS dependency. Release /
+  single-client builds that need soliplex compiled in opt in with
+  `KLANGK_BUILD_INCLUDE_REMOTE=1`. Proper fix is upstream (consume the
+  hosted `ag_ui` from pub.dev instead of the git repo) — tracked in #1691.
+
 - **`pip install klangk` no longer warns `typer 0.27.0 does not provide the
 extra 'all'`** (#1679). The declaration was `typer[all]>=0.12.0`, but the
   `all` extra was removed from typer (its constituents `rich`, `shellingham`,

--- a/docs/features/plugins.md
+++ b/docs/features/plugins.md
@@ -133,6 +133,16 @@ harmless on a non-Soliplex install — but they do appear in the tool list.
 Workspace-side gating (filtering extensions per `KLANGK_FEATURES_ENABLE`
 at container entrypoint) is a follow-up, not part of #1664.
 
+**Build-time note (#1691):** soliplex is a remote (`git:`) plugin, and its
+transitive `ag_ui` dep is currently pulled from a git repo with an
+upstream LFS-object gap that breaks every default build. To keep CI green,
+the build scripts (`scripts/flutterbuildweb.sh`,
+`scripts/build-workspace-image.sh`) skip git-sourced plugins by default
+(`update_plugins.py --local-only`). A bare `pip install klangk` therefore
+ships **without soliplex compiled in** until the upstream LFS issue is
+fixed; set `KLANGK_BUILD_INCLUDE_REMOTE=1` at build time to fetch soliplex
+(and other remote plugins) into the bundle.
+
 ## Additional plugins
 
 These plugins ship with klangk but are **not** included in the default

--- a/scripts/build-workspace-image.sh
+++ b/scripts/build-workspace-image.sh
@@ -41,9 +41,20 @@ fi
 # Materialize plugins into a build-owned tempdir (#1660): the declaration
 # is checked in at plugins.yaml; the payload (symlinked trees + plugins.lock)
 # is ephemeral. Cleaned up on exit.
+#
+# Remote (git-sourced) plugins are skipped by default — set
+# KLANGK_BUILD_INCLUDE_REMOTE=1 to fetch them. The only remote plugin today
+# is soliplex, whose transitive ag_ui git dep has an upstream LFS-object gap
+# (#1691) that breaks every CI build. Skipping soliplex drops the workspace
+# image back to the pre-#1683 local set. Release/single-client builds that
+# need soliplex's extension.ts bundled set KLANGK_BUILD_INCLUDE_REMOTE=1.
 PAYLOAD_DIR="$(mktemp -d "${TMPDIR:-/tmp}/klangk-plugins-XXXXXX")"
 trap 'rm -rf "$PAYLOAD_DIR"' EXIT
-python3 scripts/update_plugins.py --payload-dir "$PAYLOAD_DIR"
+UPDATE_FLAGS=(--payload-dir "$PAYLOAD_DIR")
+if [ "${KLANGK_BUILD_INCLUDE_REMOTE:-0}" != "1" ]; then
+  UPDATE_FLAGS+=(--local-only)
+fi
+python3 scripts/update_plugins.py "${UPDATE_FLAGS[@]}"
 
 # Stage full plugin directories outside the source tree
 STAGING="$PAYLOAD_DIR/.docker"

--- a/scripts/flutterbuildweb.sh
+++ b/scripts/flutterbuildweb.sh
@@ -15,7 +15,19 @@ trap 'rm -rf "$PAYLOAD_DIR"' EXIT
 
 # Fetch/symlink plugins into the payload dir, then generate the Dart
 # aggregator + features.json from those trees.
-python3 scripts/update_plugins.py --payload-dir "$PAYLOAD_DIR"
+#
+# Remote (git-sourced) plugins are skipped by default — set
+# KLANGK_BUILD_INCLUDE_REMOTE=1 to fetch them. Today the only remote plugin
+# is soliplex, whose transitive ag_ui git dep has an upstream LFS-object
+# gap (#1691) that breaks every CI build. Skipping remote plugins drops the
+# build back to the pre-#1683 local set (soliplex is dormant by default
+# anyway, so CI builds don't need it). Release/single-client builds that
+# need soliplex compiled in set KLANGK_BUILD_INCLUDE_REMOTE=1.
+UPDATE_FLAGS=(--payload-dir "$PAYLOAD_DIR")
+if [ "${KLANGK_BUILD_INCLUDE_REMOTE:-0}" != "1" ]; then
+  UPDATE_FLAGS+=(--local-only)
+fi
+python3 scripts/update_plugins.py "${UPDATE_FLAGS[@]}"
 python3 scripts/import_dart_plugins.py --payload-dir "$PAYLOAD_DIR"
 
 # flterm is forked (github.com/runyaga/flterm) to build on the nix Flutter

--- a/scripts/tests/test_build_script_remote_guard.py
+++ b/scripts/tests/test_build_script_remote_guard.py
@@ -1,0 +1,78 @@
+"""Tests for the build scripts' remote-plugin env-var guard (#1691).
+
+The build scripts (``scripts/flutterbuildweb.sh``,
+``scripts/build-workspace-image.sh``) wrap ``update_plugins.py`` and default
+to ``--local-only`` — skipping git-sourced plugins — unless
+``KLANGK_BUILD_INCLUDE_REMOTE=1`` is set. This is the workaround for the
+upstream ag-ui LFS-object gap that broke every CI build: the only remote
+plugin today is soliplex (whose transitive ``ag_ui`` git dep has a missing
+LFS object on the remote), and soliplex is dormant by default anyway, so
+CI builds don't need it compiled in.
+
+These are contract tests — they grep the scripts for the guard so a future
+edit that removes it (without intending to) is loud. The actual skip
+behavior is covered by ``test_update_plugins.py::TestLocalOnlyFlag``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+# Make sure the scripts directory is importable.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+_SCRIPTS_DIR = Path(__file__).resolve().parents[1]
+_BUILD_SCRIPTS = [
+    _SCRIPTS_DIR / "flutterbuildweb.sh",
+    _SCRIPTS_DIR / "build-workspace-image.sh",
+]
+
+
+def test_build_scripts_check_env_var():
+    """Every build script that calls update_plugins.py gates remote plugins
+    behind KLANGK_BUILD_INCLUDE_REMOTE=1 (#1691).
+
+    Without this guard, a default CI build clones every git-sourced plugin
+    (today: soliplex), and any upstream-LFS gap takes the whole build down.
+    """
+    for script in _BUILD_SCRIPTS:
+        text = script.read_text()
+        assert "update_plugins.py" in text, (
+            f"{script.name} no longer calls update_plugins.py — "
+            f"guard test is stale, investigate"
+        )
+        assert "KLANGK_BUILD_INCLUDE_REMOTE" in text, (
+            f"{script.name} calls update_plugins.py without the "
+            f"KLANGK_BUILD_INCLUDE_REMOTE guard — a default CI build will "
+            f"clone remote plugins (incl. soliplex) and re-break #1691"
+        )
+        assert "--local-only" in text, (
+            f"{script.name} references the env var but doesn't pass "
+            f"--local-only to update_plugins.py"
+        )
+
+
+def test_build_scripts_default_to_local_only():
+    """The default (env var unset) must skip remote plugins.
+
+    The guard's polarity matters: the *default* must be the safe one (skip
+    remote), with the opt-in (include remote) being the explicit override.
+    A future edit that flips the polarity (e.g. defaulting to fetching
+    remote plugins, with an env var to skip) would re-break #1691.
+    """
+    for script in _BUILD_SCRIPTS:
+        text = script.read_text()
+        # The conditional adds --local-only UNLESS the env var is "1".
+        # Match the pattern: if [ "${KLANGK_BUILD_INCLUDE_REMOTE:-0}" != "1" ]
+        # (the :-0 default makes unset → "0" → != "1" → true → add --local-only).
+        assert "KLANGK_BUILD_INCLUDE_REMOTE:-0" in text, (
+            f"{script.name} doesn't default KLANGK_BUILD_INCLUDE_REMOTE to '0' "
+            f"— the polarity may be flipped, making remote-fetch the default "
+            f"(re-breaks #1691)"
+        )
+        assert '!= "1"' in text, (
+            f"{script.name} doesn't compare against '1' — polarity may be "
+            f"flipped (re-breaks #1691)"
+        )


### PR DESCRIPTION
<!-- issue: https://github.com/mcdonc/klangk/issues/1691 -->

# Default builds skip soliplex — CI unblock for the ag-ui LFS gap

Closes #1691 (workaround; proper fix stays tracked there). Every PR triggering `klangk:flutter-build` was failing because soliplex (#1683) transitively pulls `ag_ui` from the `ag-ui-protocol/ag-ui` git repo, which has an LFS-tracked fixture (`apps/dojo/e2e/fixtures/test-image.png`) whose object went missing on the remote — breaking every clone's smudge filter and aborting `flutter pub get`.

## Workaround

`scripts/flutterbuildweb.sh` and `scripts/build-workspace-image.sh` now default to `update_plugins.py --local-only`, which skips git-sourced plugins (records them in `plugins.lock` with `sha: 'skipped'`). The only git-sourced plugin today is soliplex, and it's dormant by default anyway (not in `DEFAULT_FEATURES`), so a default build produces a pre-#1683-equivalent bundle: 4 Dart features + 7 defaults, no soliplex, no ag-ui LFS dependency.

Release / single-client builds that need soliplex compiled in opt in with:

```bash
KLANGK_BUILD_INCLUDE_REMOTE=1
```

which drops the `--local-only` flag and fetches soliplex (and any future remote plugins) normally.

## Why this shape

- **Reuses existing machinery** — `--local-only` was added in #1664 for the scripts test suite; this just promotes it to the default for real builds. No new fetcher logic.
- **Preserves the #1683 design** — soliplex stays declared in `plugins.yaml` as a `git:` entry; nothing is reverted. The opt-in is at the build-driver layer, not the declaration layer, so flipping back to "always fetch" when upstream is fixed is a one-line default change.
- **Safe-by-default polarity** — remote fetch is the explicit opt-in, local-only is the default. A future edit that flips the polarity re-breaks #1691; the new `test_build_script_remote_guard.py` contract test catches that.

## Files

| File | Change |
| --- | --- |
| `scripts/flutterbuildweb.sh` | Wrap `update_plugins.py` call with `KLANGK_BUILD_INCLUDE_REMOTE` guard; default to `--local-only`. |
| `scripts/build-workspace-image.sh` | Same guard. |
| `scripts/tests/test_build_script_remote_guard.py` | New (2 tests): contract tests that grep the build scripts for the guard + verify polarity. |
| `docs/features/plugins.md` | New "Build-time note (#1691)" under the dormant section. |
| `docs/changes.md` | Fixed entry under [Unreleased]. |

## Verification

End-to-end (manual, in the worktree):

```bash
$ devenv shell -- bash scripts/flutterbuildweb.sh
# ...
Changed 130 dependencies!                              # pub get succeeded
Compiling lib/main.dart for the Web...    77.2s        # build succeeded
Regenerated feature manifest .../features.json

$ python3 -c "import json; m=json.load(open('src/frontend/build/web/features.json')); print(sorted(f['name'] for f in m['features']))"
['beep', 'boingball', 'celebrate', 'git-credential']   # 4 local, no soliplex
```

- **3203 tests pass** (3173 klangk + 30 scripts), **100% coverage** on the `klangk` package.
- All pre-commit hooks green (shellcheck, shfmt, prettier, markdownlint, ruff).

## Proper fix (out of scope, tracked in #1691)

Get soliplex upstream to consume the hosted `ag_ui` from pub.dev instead of the `ag-ui-protocol/ag-ui` git repo. Once that lands and the pinned ref in `plugins.yaml` is bumped, the build scripts can drop the `--local-only` default and soliplex ships compiled-in as #1683 intended. The vendoring follow-up (#1686) would also eliminate the transitive `soliplex_*` git deps entirely.

## Acceptance criteria (from #1691)

- [x] A PR with no Flutter-source changes can pass `klangk:flutter-build` without depending on the health of `ag-ui-protocol/ag-ui`'s LFS server. (Verified end-to-end: `flutterbuildweb.sh` now succeeds.)
- [x] The chosen fix is documented (changelog entry under `### Fixed`, note in `docs/features/plugins.md`).
