### PR TITLE
fix(caddy): drop --environ startup env spew

### DIFF
--- a/src/klangk/klangk/caddy.py
+++ b/src/klangk/klangk/caddy.py
@@ -42,6 +42,7 @@ import logging
 import os
 import shutil
 import signal
+from urllib.parse import urlsplit
 
 import httpx
 
@@ -341,8 +342,6 @@ class CaddyRenderer:
         placeholder substitution in the header context isn't reliable enough
         to override what it would auto-set. See review of #1681.
         """
-        from urllib.parse import urlsplit
-
         base_url = self.app.state.settings.llm_base_url
         if not base_url:
             return ""
@@ -733,7 +732,6 @@ class CaddyWatchdog:
             self._proc = await asyncio.create_subprocess_exec(
                 bin_path,
                 "run",
-                "--environ",
                 # Pin the initial config to /dev/null so an accidental
                 # Caddyfile in CWD can't override the "no on-disk source of
                 # truth" guarantee — the real config arrives via POST /load.


### PR DESCRIPTION
## Summary

`devenv processes up` (and any `KLANGK_PROXY_ENGINE=caddy` deploy) opened
with a screenful of environment variables because the Caddy watchdog
launched `caddy run --environ` — caddy's `--environ` flag prints every
environment variable (including unexported nix-shell internals like
`_DEVENV_DIFF`, `configureFlags=`, `name=devenv-shell-env`) to stdout
before starting.

## Changes

- **`src/klangk/klangk/caddy.py`** — drop `--environ` from the
  `caddy run` invocation. Debug-only flag; caddy still receives its
  environment via the subprocess `env=`, it just no longer prints it.
- **`src/klangk/klangk/caddy.py`** — also hoist
  `from urllib.parse import urlsplit` out of `CaddyRenderer._llm_proxy_*`
  into module scope. It landed deferred in #1681 (cbd24cbe), which makes
  `caddy.py` trip the repo's `deferred-imports` pre-commit hook for every
  subsequent touch of the file (I hit it trying to land just the one-line
  `--environ` removal). stdlib import, no circular risk.

## Verification

- 3180 Python tests pass, 100% coverage.
- `check_deferred_imports.py src/klangk/klangk/caddy.py` clean (was
  failing on the deferred `urlsplit`).
