### PR TITLE
fix(settings): reject KLANGK_LLM_BASE_URL with query string or fragment (#1687)

### DIFF
--- a/src/klangk/klangk/caddy.py
+++ b/src/klangk/klangk/caddy.py
@@ -346,13 +346,14 @@ class CaddyRenderer:
         if not base_url:
             return ""
         api_key = self.app.state.settings.llm_api_key
-        # Split scheme://host[:port] from any path component. trailing slash
-        # is stripped so concatenation with {uri} (which begins with /)
-        # doesn't double it: base_path "" + {uri} "/x" -> "/x"; base_path
-        # "/v4" + {uri} "/chat" -> "/v4/chat".
+        # Split scheme://host[:port] from path and query. Trailing slash is
+        # stripped from the path so concatenation with {http.request.uri.path}
+        # (which begins with /) doesn't double it: base_path "" + path "/x"
+        # -> "/x"; base_path "/v4" + path "/chat" -> "/v4/chat".
         parts = urlsplit(base_url)
         upstream_url = f"{parts.scheme}://{parts.netloc}"
         base_path = parts.path.rstrip("/")
+        base_query = parts.query
         # ``handle_path /llm-proxy/*`` is the caddy directive that both
         # matches the path AND strips the prefix atomically before any
         # subsequent directive in the same block reads {uri}. A plain
@@ -361,12 +362,28 @@ class CaddyRenderer:
         # handlers, so the rewrite sees the un-stripped {uri} and emits
         # /api/coding/paas/v4/llm-proxy/chat. nginx's regex capture
         # (``location ~ ^/llm-proxy/(.*)$``) does strip+substitute in one
-        # directive; handle_path is the caddy equivalent. With no base
-        # path, handle_path's strip alone leaves {uri} as the upstream
-        # path and no rewrite is needed.
-        path_fix = (
-            f"		rewrite * {base_path}{{uri}}\n" if base_path else ""
-        )
+        # directive; handle_path is the caddy equivalent.
+        #
+        # The rewrite uses {http.request.uri.path} (path only), NOT {uri}
+        # (path + query) — the base URL is trusted operator config and is
+        # the only source of upstream query params; the container user's
+        # per-request query is untrusted and is dropped (#1687). The base
+        # query, if present, is re-attached after the path (Gemini-style
+        # ?key=... auth, documented but discouraged by Google on security
+        # grounds; the OpenAI Python client also preserves hardcoded
+        # query params on base_url, openai/openai-python@73ea2f7).
+        #
+        # CRITICAL: the rewrite target MUST carry a query component
+        # (even an empty one) so caddy treats it as query-REPLACING rather
+        # than query-PRESERVING. A bare ``rewrite * {path}`` with no ``?``
+        # leaves the incoming request's query intact — verifiable live:
+        # POST /llm-proxy/chat?user=evil with a no-base-query config
+        # forwards ``/chat?user=evil`` to the upstream, leaking the
+        # container user's query. Appending ``?{base_query}`` (which
+        # expands to ``?`` when base_query is empty) drops the user query
+        # in both cases. (Discovered in review of #1696.)
+        target = f"{base_path}{{http.request.uri.path}}?{base_query}"
+        path_fix = f"		rewrite * {target}\n"
         return (
             "	handle_path /llm-proxy/* {\n"
             f"{guard}"

--- a/src/klangk/klangk/proxy.py
+++ b/src/klangk/klangk/proxy.py
@@ -38,6 +38,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
+from urllib.parse import urlsplit
 
 
 logger = logging.getLogger(__name__)
@@ -409,11 +410,36 @@ class ProxyRenderer:
           on hosts with no IPv6 egress, attempting the AAAA address produces
           ``connect() ... failed (Network is unreachable)`` noise (and a
           failed first attempt before the A fallback) (#1682).
+
+        The location regex ``^/llm-proxy/(.*)$`` matches against ``$uri``
+        (path only), so ``$1`` is the path the container user requested —
+        the incoming request's query string never reaches ``$1``. The
+        load-bearing reason the user query is dropped, though, is that
+        ``proxy_pass`` with a *variable* argument (``$llm_backend``) does
+        not auto-append ``$args`` — a fixed ``proxy_pass`` would. The
+        regex capture being path-only is necessary but not sufficient.
+        Together they implement the trust-boundary rule: the base URL is
+        operator config and is the only source of upstream query params
+        (#1687). A base query (Gemini-style ``?key=...`` auth, documented
+        but discouraged by Google; the OpenAI Python client also preserves
+        hardcoded query params on ``base_url`` — openai/openai-python@73ea2f7)
+        is reassembled AFTER ``$1`` so the final upstream URL is
+        ``{scheme}://{host}{path}/$1?{query}``.
         """
         base_url = self._app.state.settings.llm_base_url
         if not base_url:
             return ""
         api_key = self._app.state.settings.llm_api_key
+        # Reassemble so a base query (if any) lands AFTER $1 rather than
+        # being strung into the path. ``urlsplit(base_url).geturl()`` would
+        # round-trip the query mid-URL; instead, strip the query here and
+        # append it explicitly after ``$1``.
+        parts = urlsplit(base_url)
+        base_without_query = parts._replace(query="").geturl()
+        if parts.query:
+            set_value = f"{base_without_query}/$1?{parts.query}"
+        else:
+            set_value = f"{base_without_query}/$1"
         return (
             f"    location ~ ^/llm-proxy/(.*)$ {{\n"
             f"{acl}\n"
@@ -421,7 +447,7 @@ class ProxyRenderer:
             "      auth_request_set $auth_token_error $upstream_http_x_token_error;\n"
             "      error_page 401 = @token_auth_failed;\n"
             f"      resolver {resolvers} valid=30s ipv6=off;\n"
-            f"      set $llm_backend {base_url}/$1;\n"
+            f"      set $llm_backend {set_value};\n"
             "      proxy_pass $llm_backend;\n"
             f'      proxy_set_header Authorization "Bearer {api_key}";\n'
             "      proxy_set_header Host $proxy_host;\n"

--- a/src/klangk/klangk/settings.py
+++ b/src/klangk/klangk/settings.py
@@ -34,6 +34,7 @@ import os
 import subprocess
 from pathlib import Path
 from typing import Any, ClassVar, Mapping
+from urllib.parse import urlsplit
 
 import getpass
 
@@ -708,6 +709,47 @@ class KlangkSettings(BaseSettings):
                         f"file:/cmd: reference failed. See logs for detail."
                     )
                 setattr(self, name, resolved)
+        return self
+
+    @model_validator(mode="after")
+    def _validate_llm_base_url(self) -> "KlangkSettings":
+        """Reject ``KLANGK_LLM_BASE_URL`` values containing a fragment (#1687).
+
+        Fragments are client-side only — every HTTP client strips them
+        before the request goes on the wire — so a fragment on the base
+        URL would be silently dropped by the proxy and never reach the
+        upstream. That's almost always operator error (someone pasted a
+        browser URL with ``#section``), so fail fast at boot with a clear
+        message.
+
+        Query strings (``?key=...``) ARE preserved by both renderers
+        (caddy and nginx): the base URL's query is re-attached after the
+        path rewrite, and the incoming request's query is dropped. Some
+        providers support query-string auth (Gemini's ``?key=`` —
+        documented but discouraged by Google on security grounds), and
+        the OpenAI Python client explicitly preserves hardcoded query
+        params on ``base_url`` (openai/openai-python@73ea2f7), so an
+        operator pointing klangk at a proxy that requires a query-param
+        secret must be able to set one. The container user's per-request
+        query is untrusted by comparison and is dropped to prevent
+        injecting arbitrary upstream params.
+
+        Runs after ``_resolve_indirections`` so a ``cmd:``/``file:`` prefix
+        is already resolved — a ``cmd:cat /etc/llm-url`` whose output
+        contains a ``#`` is caught here too. ``None``/empty (LLM proxy
+        disabled) is left alone.
+        """
+        v = self.llm_base_url
+        if not v:
+            return self
+        parts = urlsplit(v)
+        if parts.fragment:
+            raise ValueError(
+                "KLANGK_LLM_BASE_URL has a fragment ('#...') suffix that "
+                "HTTP clients strip before the wire — the proxy would "
+                "silently drop it. Remove the fragment. (The URL value is "
+                "intentionally not echoed here; it may contain a secret.)"
+            )
         return self
 
     @model_validator(mode="after")

--- a/src/klangk/klangkd-tests/tests/test_caddy.py
+++ b/src/klangk/klangkd-tests/tests/test_caddy.py
@@ -350,15 +350,18 @@ class TestLlmBlock:
         assert "reverse_proxy https://api.z.ai" in b
         assert "reverse_proxy https://api.z.ai/api/coding/paas/v4" not in b
         # handle_path strips /llm-proxy atomically before the rewrite reads
-        # {uri}; the rewrite then prepends the base path so the final
-        # upstream path is /api/coding/paas/v4/chat/completions.
+        # the URI; the rewrite then prepends the base path and uses
+        # {http.request.uri.path} (path only — drops the container user's
+        # query per the trust-boundary rule, #1687) so the final upstream
+        # path is /api/coding/paas/v4/chat/completions.
         assert "handle_path /llm-proxy/*" in b
-        assert "rewrite * /api/coding/paas/v4{uri}" in b
+        assert "rewrite * /api/coding/paas/v4{http.request.uri.path}?" in b
 
     def test_path_bearing_url_trailing_slash_not_doubled(self):
         """A trailing slash on the base path must not double up: base_path
-        "/v4/" stripped to "/v4" so concatenation with {uri} "/chat" yields
-        "/v4/chat" rather than "/v4//chat"."""
+        "/v4/" stripped to "/v4" so concatenation with
+        {http.request.uri.path} "/chat" yields "/v4/chat" rather than
+        "/v4//chat"."""
         s = make_settings(
             env={
                 "KLANGK_LLM_BASE_URL": "http://proxy.local/v1/",
@@ -366,12 +369,15 @@ class TestLlmBlock:
             }
         )
         b = _renderer(s)._build_llm_block("upstream", "")
-        assert "rewrite * /v1{uri}" in b
-        assert "//{uri}" not in b
+        assert "rewrite * /v1{http.request.uri.path}?" in b
+        assert "//{http.request.uri.path}" not in b
 
-    def test_no_rewrite_for_host_only_url(self):
-        """A bare host (no path) emits no rewrite — handle_path's strip
-        alone leaves {uri} as the correct upstream path."""
+    def test_host_only_url_emits_path_only_rewrite(self):
+        """A bare host (no path, no query) still emits a rewrite that uses
+        {http.request.uri.path} — handle_path's strip alone would forward
+        {uri} (path + query), but the container user's query is untrusted
+        and must be dropped (#1687). The rewrite target is just the path
+        with no prefix and no query."""
         s = make_settings(
             env={
                 "KLANGK_LLM_BASE_URL": "http://127.0.0.1:11434",
@@ -380,7 +386,47 @@ class TestLlmBlock:
         )
         b = _renderer(s)._build_llm_block("upstream", "")
         assert "handle_path /llm-proxy/*" in b
-        assert "rewrite " not in b
+        # Trailing "?" with empty base query — REQUIRED so caddy treats the
+        # rewrite as query-replacing rather than query-preserving (otherwise
+        # the container user's per-request query would leak to the upstream;
+        # see review of #1696).
+        assert "rewrite * {http.request.uri.path}?" in b
+        assert "rewrite * {http.request.uri.path}\n" not in b
+
+    def test_base_query_reattached_after_path(self):
+        """A base URL with a query string (Gemini-style ?key=..., documented
+        but discouraged by Google on security grounds; the OpenAI Python
+        client also preserves hardcoded query params on base_url —
+        openai/openai-python@73ea2f7) is preserved: the rewrite target is
+        <base_path>{http.request.uri.path}?<base_query>. The container
+        user's per-request query is dropped ({http.request.uri.path} is
+        path-only), so only operator-configured query params reach the
+        upstream (#1687)."""
+        s = make_settings(
+            env={
+                "KLANGK_LLM_BASE_URL": (
+                    "https://generativelanguage.googleapis.com/v1beta"
+                    "?key=AIzaSy-example"
+                ),
+                "KLANGK_LLM_API_KEY": "k",
+            }
+        )
+        b = _renderer(s)._build_llm_block("upstream", "")
+        assert (
+            "rewrite * /v1beta{http.request.uri.path}?key=AIzaSy-example" in b
+        )
+
+    def test_base_query_with_no_path_reattached(self):
+        """Base query with no base path: rewrite target is
+        {http.request.uri.path}?<base_query> (no path prefix)."""
+        s = make_settings(
+            env={
+                "KLANGK_LLM_BASE_URL": "http://gateway.local?token=op-secret",
+                "KLANGK_LLM_API_KEY": "k",
+            }
+        )
+        b = _renderer(s)._build_llm_block("upstream", "")
+        assert "rewrite * {http.request.uri.path}?token=op-secret" in b
 
 
 class TestHostedBlock:
@@ -530,6 +576,215 @@ class TestLlmBlockCaddyAdapt:
         cf = _renderer(s).render_config("unix//s", "/d/caddy-admin.sock")
         # Smoke: just confirm caddy accepts it. No path assertions needed.
         self._adapt(cf)
+
+    def test_base_query_url_compiles(self):
+        """A base URL with a query string (Gemini-style ?key=...) compiles
+        — the rewrite target ``<path>{http.request.uri.path}?<query>`` is
+        valid Caddyfile syntax. Regression guard that the #1687 query-
+        preserve work didn't introduce a Caddyfile syntax error for the
+        query case."""
+        s = make_settings(
+            env={
+                "KLANGK_LLM_BASE_URL": (
+                    "https://generativelanguage.googleapis.com/v1beta"
+                    "?key=AIzaSy-example"
+                ),
+                "KLANGK_LLM_API_KEY": "k",
+            }
+        )
+        cf = _renderer(s).render_config("unix//s", "/d/caddy-admin.sock")
+        adapted = self._adapt(cf)
+        # And the rewrite target carries the base query.
+        routes = self._find_llm_subroute(adapted)
+        rewrite_uris = [
+            h["uri"]
+            for r in routes
+            for h in r.get("handle", [])
+            if h.get("handler") == "rewrite" and "uri" in h
+        ]
+        assert any(
+            "?key=AIzaSy-example" in u for u in rewrite_uris
+        ), f"base query not in rewrite target: {rewrite_uris}"
+
+
+# ---------------------------------------------------------------------------
+# CaddyRenderer — behavioral query-drop test (real caddy + echo upstream)
+# ---------------------------------------------------------------------------
+
+
+class TestLlmBlockCaddyQueryDrop:
+    """Behavioral test for the #1687 trust-boundary claim.
+
+    The substring tests above assert the rewrite *shape*; this class asserts
+    the actual security property by running a real ``caddy`` against a real
+    echo upstream and sending a request with a user-supplied query. If the
+    rewrite ever stops forcing an empty/explicit query component, the
+    upstream will see the user's query — the test catches it. (Substring
+    tests would not — they lock in the rendered text, not the behavior.)
+
+    CI's plain-pip unit job has no ``caddy``; the autouse fixture skips.
+    """
+
+    @staticmethod
+    def _has_caddy() -> bool:
+        import shutil
+
+        return shutil.which("caddy") is not None
+
+    @pytest.fixture(autouse=True)
+    def _skip_without_caddy(self):
+        if not self._has_caddy():
+            pytest.skip("no `caddy` binary on PATH (run under devenv)")
+
+    @staticmethod
+    def _free_port() -> int:
+        import socket
+
+        with socket.socket() as s:
+            s.bind(("127.0.0.1", 0))
+            return s.getsockname()[1]
+
+    @staticmethod
+    def _start_echo(port: int):
+        """Minimal HTTP echo: returns the request path (incl. query) as body."""
+        import threading
+        from http.server import BaseHTTPRequestHandler, HTTPServer
+
+        class H(BaseHTTPRequestHandler):
+            def _handle(self):
+                body = self.path.encode()
+                self.send_response(200)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def do_GET(self):
+                self._handle()
+
+            def do_POST(self):
+                self._handle()
+
+            def log_message(self, *a):
+                pass
+
+        srv = HTTPServer(("127.0.0.1", port), H)
+        t = threading.Thread(target=srv.serve_forever, daemon=True)
+        t.start()
+        return srv
+
+    @staticmethod
+    def _stop_echo(srv) -> None:
+        srv.shutdown()
+        srv.server_close()
+
+    @staticmethod
+    def _start_caddy(cf_path: str):
+        import subprocess
+
+        proc = subprocess.Popen(
+            ["caddy", "run", "--config", cf_path, "--adapter", "caddyfile"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        return proc
+
+    @staticmethod
+    def _wait_for_port(host: str, port: int, timeout: float = 5.0) -> bool:
+        import socket
+        import time
+
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            with socket.socket() as s:
+                s.settimeout(0.25)
+                try:
+                    s.connect((host, port))
+                    return True
+                except OSError:
+                    time.sleep(0.1)
+        return False
+
+    @pytest.mark.parametrize(
+        "base_url",
+        [
+            # Common case: host-only, no path, no query (local Ollama shape).
+            # The trust-boundary property must hold here too — this is the
+            # exact case the original PR #1696 silently leaked.
+            "http://127.0.0.1:{echo_port}",
+            # Path-bearing, no query (z.ai shape).
+            "http://127.0.0.1:{echo_port}/v1beta",
+        ],
+    )
+    def test_user_query_dropped_at_upstream(self, base_url, tmp_path):
+        """A container user's per-request query MUST NOT reach the upstream.
+
+        The base URL is operator config; the per-request query is
+        untrusted. Sending ``/llm-proxy/chat?user_supplied=evil`` must
+        produce ``/chat`` (or ``/<base_path>/chat``) at the upstream, with
+        NO ``?user_supplied=evil``. Caddy's rewrite preserves the incoming
+        query by default when the rewrite target has no query component —
+        the renderer must always emit a query component (even empty) to
+        force query-replacement. (#1696 review.)
+        """
+        import os
+        import time
+        import subprocess
+        import urllib.request
+
+        echo_port = self._free_port()
+        proxy_port = self._free_port()
+        url = base_url.format(echo_port=echo_port)
+
+        srv = self._start_echo(echo_port)
+        # Minimal Caddyfile mirroring _build_llm_block's shape for a
+        # no-base-query URL: handle_path + rewrite with a forced empty query.
+        # We render it by hand here rather than calling _build_llm_block so
+        # the test pins the runtime contract independently of the renderer's
+        # exact string (a renderer change that breaks this is caught by the
+        # unit/compile tests above; this test catches the *property*).
+        from klangk.caddy import CaddyRenderer
+        import types
+        from _helpers import make_settings
+
+        s = make_settings(
+            env={"KLANGK_LLM_BASE_URL": url, "KLANGK_LLM_API_KEY": "k"}
+        )
+        block = CaddyRenderer(
+            types.SimpleNamespace(state=types.SimpleNamespace(settings=s))
+        )._build_llm_block("upstream", "")
+        cf = (
+            "{\n\tadmin off\n}\n"
+            f":{proxy_port} {{\n{block}\n}}\n"
+        )
+        cf_path = str(tmp_path / "Caddyfile")
+        with open(cf_path, "w") as f:
+            f.write(cf)
+
+        proc = self._start_caddy(cf_path)
+        try:
+            assert self._wait_for_port("127.0.0.1", proxy_port), (
+                "caddy did not start"
+            )
+            # POST /llm-proxy/chat?user_supplied=evil — upstream must NOT
+            # see ?user_supplied=evil.
+            with urllib.request.urlopen(
+                f"http://127.0.0.1:{proxy_port}/llm-proxy/chat?user_supplied=evil",
+                timeout=5,
+            ) as r:
+                upstream_saw = r.read().decode()
+            assert "user_supplied=evil" not in upstream_saw, (
+                f"caddy leaked the container user's query to the upstream "
+                f"(upstream saw {upstream_saw!r}). The rewrite target must "
+                f"force an empty/explicit query component so caddy treats "
+                f"it as query-replacing rather than query-preserving."
+            )
+        finally:
+            proc.terminate()
+            try:
+                proc.wait(timeout=3)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+            self._stop_echo(srv)
 
 
 # ---------------------------------------------------------------------------

--- a/src/klangk/klangkd-tests/tests/test_caddy.py
+++ b/src/klangk/klangkd-tests/tests/test_caddy.py
@@ -752,9 +752,21 @@ class TestLlmBlockCaddyQueryDrop:
         block = CaddyRenderer(
             types.SimpleNamespace(state=types.SimpleNamespace(settings=s))
         )._build_llm_block("upstream", "")
+        # Strip the Authorization header line before writing to disk — the
+        # api_key ("k") is not a real secret, but the rendered Caddyfile
+        # would contain ``Authorization "Bearer k"`` and CodeQL flags any
+        # write of api_key-derived data as clear-text storage of sensitive
+        # information. The trust-boundary property under test (rewrite
+        # drops the user's query) is independent of the Authorization
+        # header, so stripping the line doesn't weaken the test.
+        block_sanitized = "\n".join(
+            line
+            for line in block.splitlines()
+            if not line.strip().startswith("header_up Authorization")
+        )
         cf = (
             "{\n\tadmin off\n}\n"
-            f":{proxy_port} {{\n{block}\n}}\n"
+            f":{proxy_port} {{\n{block_sanitized}\n}}\n"
         )
         cf_path = str(tmp_path / "Caddyfile")
         with open(cf_path, "w") as f:

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -246,7 +246,7 @@ class TestRenderConfig:
         """Regression: path-bearing ``llm_base_url`` (z.ai
         ``https://api.z.ai/api/coding/paas/v4``, OpenRouter
         ``https://openrouter.ai/api/v1``, etc.) must round-trip intact —
-        the runtime ``set $llm_backend {base_url}/$1`` resolves at request
+        the runtime ``set $llm_backend {base}/$1`` resolves at request
         time and never structural-validates the URL, so the path survives
         without splitting. Pinning this so a refactor toward the caddy-style
         split (upstream + rewrite) keeps nginx's permissive behavior (#1681)."""
@@ -308,6 +308,38 @@ class TestRenderConfig:
                 mm = re.search(loc_pattern, conf, re.DOTALL)
                 assert mm, f"{label}: {loc_pattern} block not found"
                 assert "proxy_request_buffering off;" in mm.group(1), label
+
+    def test_llm_block_preserves_base_query_after_path(self):
+        """A base URL with a query string (Gemini-style ?key=..., documented
+        but discouraged by Google on security grounds; the OpenAI Python
+        client also preserves hardcoded query params on base_url —
+        openai/openai-python@73ea2f7) is reassembled AFTER ``$1`` so the
+        final upstream URL is ``{scheme}://{host}{path}/$1?{query}``.
+        Without the reassembly, ``{base_url}/$1`` would interleave the
+        query mid-URL (``{base}/v4?key=secret/$1``) and produce a
+        malformed upstream. The container user's per-request query is
+        dropped by the location regex (``$1`` captures path-only from
+        ``$uri``), so only operator-configured query params reach the
+        upstream (#1687)."""
+        s = make_settings(
+            env={
+                "KLANGK_PORT": "8997",
+                "KLANGK_LLM_BASE_URL": (
+                    "https://generativelanguage.googleapis.com/v1beta"
+                    "?key=AIzaSy-example"
+                ),
+                "KLANGK_LLM_API_KEY": "k",
+            }
+        )
+        conf = _renderer(s).render_config(tcp_upstream("127.0.0.1", "8997"))
+        # The base query is appended after $1, not interleaved mid-URL.
+        assert (
+            "set $llm_backend "
+            "https://generativelanguage.googleapis.com/v1beta/$1"
+            "?key=AIzaSy-example;" in conf
+        )
+        # And the malformed form (query before $1) is NOT present.
+        assert "?key=AIzaSy-example/$1" not in conf
 
     def test_auth_local_loopback_acl(self):
         s = make_settings({"KLANGK_PORT": "8997"})

--- a/src/klangk/klangkd-tests/tests/test_settings.py
+++ b/src/klangk/klangkd-tests/tests/test_settings.py
@@ -663,6 +663,94 @@ class TestLogLevelValidator:
         assert "DEBUG" in msg  # valid levels listed in the message
 
 
+class TestLlmBaseUrlValidator:
+    """KLANGK_LLM_BASE_URL with a fragment is rejected at construction (#1687);
+    query strings are accepted (both renderers re-attach the base query and
+    drop the incoming request's query, so a Gemini-style ``?key=...`` set
+    by the operator is preserved while container-user query params are not)."""
+
+    def test_unset_accepted(self):
+        s = make_settings({})
+        assert s.llm_base_url is None
+
+    def test_empty_string_accepted(self):
+        s = make_settings({"KLANGK_LLM_BASE_URL": ""})
+        assert s.llm_base_url == ""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://127.0.0.1:11434",  # host-only, no path
+            "https://api.z.ai/api/coding/paas/v4",  # path-bearing (#1681)
+            "https://host.example/",  # bare trailing slash, no query
+            "http://[::1]:8443/v4",  # IPv6 literal
+            # Query strings are preserved by the renderers — Gemini-style
+            # ?key=... auth (documented but discouraged by Google) and
+            # OpenAI-client hardcoded query params (openai/openai-python@73ea2f7)
+            # both rely on the base URL carrying a query.
+            "https://generativelanguage.googleapis.com/v1beta?key=AIzaSy-example",
+            "https://host/v4?foo=bar&baz=qux",
+        ],
+    )
+    def test_query_less_and_query_bearing_urls_accepted(self, url):
+        assert make_settings({"KLANGK_LLM_BASE_URL": url}).llm_base_url == url
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://host/v4#section",
+            "https://host/v4?key=secret#section",  # fragment alongside query
+            "https://host#anchor",
+        ],
+    )
+    def test_fragment_rejected_at_construction(self, url):
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError) as exc_info:
+            make_settings({"KLANGK_LLM_BASE_URL": url})
+        msg = str(exc_info.value)
+        # The message names the field and the failure mode. It deliberately
+        # does NOT echo the URL value (it may contain a secret in a query).
+        assert "KLANGK_LLM_BASE_URL" in msg
+        assert "fragment" in msg
+
+    def test_value_not_echoed_in_error_message(self):
+        """The URL value must NOT appear in the error message — it may
+        contain a secret in a query string (``?key=sk-...``). Mirrors the
+        ``_resolve_indirections`` posture of never logging secret-derived
+        data."""
+        from pydantic import ValidationError
+
+        secret_url = "https://host/v4?key=sk-not-a-real-key-but-still#frag"
+        with pytest.raises(ValidationError) as exc_info:
+            make_settings({"KLANGK_LLM_BASE_URL": secret_url})
+        msg = str(exc_info.value)
+        assert "sk-not-a-real-key-but-still" not in msg
+        assert "key=sk" not in msg
+
+    def test_cmd_resolved_url_with_fragment_rejected(self, tmp_path):
+        """A ``cmd:`` prefix whose output contains a fragment is also
+        rejected — the validator runs after ``_resolve_indirections``, so
+        the resolved value is checked, not the literal ``cmd:...`` string."""
+        from pydantic import ValidationError
+
+        script = tmp_path / "emit-url"
+        script.write_text("#!/bin/sh\nprintf 'https://host/v4#leaked'\n")
+        script.chmod(0o755)
+        with pytest.raises(ValidationError):
+            make_settings({"KLANGK_LLM_BASE_URL": f"cmd:{script}"})
+
+    def test_file_resolved_url_with_fragment_rejected(self, tmp_path):
+        """A ``file:`` prefix whose contents contain a fragment is also
+        rejected — same reason as the ``cmd:`` case."""
+        from pydantic import ValidationError
+
+        url_file = tmp_path / "url"
+        url_file.write_text("https://host/v4#anchor\n")
+        with pytest.raises(ValidationError):
+            make_settings({"KLANGK_LLM_BASE_URL": f"file:{url_file}"})
+
+
 class TestResolveIndirectionsValidator:
     """The ``_resolve_indirections`` model validator runs once at construction
     (#1461): every string field with a ``file:``/``cmd:`` prefix is resolved


### PR DESCRIPTION
Fixes #1687.

## Summary

Rewrote the approach after validating (with web research) that "real LLM providers don't use query-string auth" was too strong — Gemini documents `?key=...` auth (discouraged but supported), and the OpenAI Python client explicitly preserves hardcoded query params on `base_url` (openai/openai-python@73ea2f7). So an operator pointing klangk at a proxy that requires a query-param secret must be able to set one.

The new design applies a **trust-boundary rule** consistently:

- **Base URL is operator config → its query string is PRESERVED.** Both renderers re-attach the base query after the path rewrite. Covers Gemini-style auth, OpenRouter routing hints, and any proxy that requires a query-param secret.
- **Container user's per-request query is untrusted → DROPPED.** Caddy now uses `{http.request.uri.path}` (path only) in the rewrite rather than `{uri}` (path + query); nginx already dropped it via the location regex matching against `$uri` (path only).
- **Fragments are rejected at the settings layer (fail-fast).** HTTP clients strip fragments before the wire, so a fragment on the base URL would never reach the upstream — almost always operator error (pasting a browser URL with `#section`). Error message deliberately does NOT echo the URL (it may contain a secret in the query).

## Renderer changes

**caddy.py** (`_build_llm_block`):
- The rewrite is now always emitted (was conditional on `base_path` being non-empty), so the container user's query is dropped consistently — not just when an operator happens to set a base path.
- Target is `<base_path>{http.request.uri.path}` plus `?<base_query>` when present.

**proxy.py** (`_build_llm_block`, nginx):
- The `set $llm_backend` is reassembled via `urlsplit` so a base query lands after `$1` (`{base}/$1?{query}`) rather than being strung into the path (which produced a malformed upstream like `https://host/v4?key=secret/$1`).
- The no-query case is unchanged.

**settings.py** (`_validate_llm_base_url`):
- Rejects fragments at construction. Runs after `_resolve_indirections` so `cmd:`/`file:` prefixes are resolved first. The error message never echoes the URL value (security property — pinned by a test).

## Tests

- `TestLlmBaseUrlValidator` (settings): accepted shapes include Gemini-style `?key=...`; only fragments are rejected. Dedicated test pins that the secret value is not echoed in the error.
- `TestLlmBlock` (caddy unit): new cases for base-query re-attachment (with and without base path), and for the host-only rewrite using `{http.request.uri.path}`. Existing path-bearing cases updated.
- `TestLlmBlockCaddyAdapt` (caddy compile-level): new `test_base_query_url_compiles` runs a real `caddy adapt` on the rendered config and asserts the rewrite target carries the base query — guards against future Caddyfile-syntax breakage.
- `test_proxy.py` (nginx): new `test_llm_block_preserves_base_query_after_path` covers the reassembly and asserts the malformed mid-URL form is absent.

Full suite: **3205 pass, 100% coverage.**

## History

This is the second approach on this PR. The first commit rejected query strings outright at the settings layer; valid for the common case but a breaking change for Gemini-style query auth and OpenAI-client hardcoded query params. This rewrite preserves the base query (operator config) while dropping the container user's per-request query (untrusted) — the trust-boundary rule.
