### PR TITLE
ci: enforce deferred-imports check in backend-tests (#1695)

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -53,6 +53,19 @@ jobs:
         # gate here (scripts/ isn't part of the klangk package).
         run: python -m pytest scripts/tests/ -v
 
+      - name: deferred-imports check
+        if: steps.filter.outputs.python == 'true'
+        # CI enforcement of the local pre-commit `deferred-imports` hook
+        # (scripts/check_deferred_imports.py). The hook scans the whole
+        # klangk package from any staged .py file, so a single deferred
+        # import landing on main blocks every subsequent .py touch locally
+        # (contributors end up at --no-verify, #1695). CI never ran the
+        # hook, so the breakage was invisible and accumulated. This step
+        # runs the same checker directly — pure stdlib, no deps — so a
+        # regression fails CI instead of silently shipping. Stdlib import,
+        # the checker prints `file:line: deferred import: ...` to stderr.
+        run: python3 scripts/check_deferred_imports.py src/klangk/klangk src/klangk/klangk/cli
+
       - name: Skip notice
         if: steps.filter.outputs.python != 'true'
         run: echo "No Python package changes — skipping tests"


### PR DESCRIPTION
## Summary

The local `deferred-imports` pre-commit hook (`scripts/check_deferred_imports.py`)
was failing on `main` because of a function-scope import in `caddy.py`
(introduced in #1681). #1694 hoisted that specific import, so the hook now
passes repo-wide — but the deeper problem the issue raises is that **CI never
ran the hook**, so the breakage was invisible and accumulated silently on
`main` (contributors hitting it had to use `--no-verify`, e.g. #1693).

Closes #1695.

## Change

Add a CI step to `backend-tests.yml` that runs
`python3 scripts/check_deferred_imports.py src/klangk/klangk src/klangk/klangk/cli`
— the same checker, same package set, as the local pre-commit hook. Reuses the
job's existing `setup-python` + paths-filter gate, so it runs only when Python
sources change and needs no extra deps (the checker is stdlib-only).

On a regression, the checker prints `file:line: deferred import: ...` to
stderr and exits non-zero, failing the job — instead of silently shipping to
`main` and blocking every subsequent local `.py` commit.

## Verification

- `pre-commit run deferred-imports --all-files` → Passed on this branch.
- `python3 scripts/check_deferred_imports.py src/klangk/klangk src/klangk/klangk/cli` → exit 0.
- Workflow YAML parses; actionlint + yamllint clean (pre-commit passed on commit).
- The checker's enforcement is proven: it's what flagged `caddy.py:344` before #1694 hoisted it.

## Notes

No changelog entry — CI workflow change with no user-visible product effect.
