### PR TITLE
Use server-configured min password length in change form (#1350)

### DIFF
--- a/src/frontend/lib/auth/settings_page.dart
+++ b/src/frontend/lib/auth/settings_page.dart
@@ -242,7 +242,12 @@ class _PasswordSectionState extends State<_PasswordSection> {
             obscureText: _obscureNew,
             validator: (v) {
               if (v == null || v.isEmpty) return 'Required';
-              if (v.length < 8) return 'Min 8 characters';
+              // Read the server-configured minimum (KLANGK_MIN_PASSWORD_LENGTH,
+              // surfaced by AuthService from /api/v1/config) instead of
+              // hardcoding 8 — otherwise the client passes a password the
+              // server rejects when the deploy raised the floor (#1350).
+              final min = context.read<AuthService>().minPasswordLength;
+              if (v.length < min) return 'Min $min characters';
               return null;
             },
           ),


### PR DESCRIPTION
Closes #1350.

## Summary

The password-change form validator in `src/frontend/lib/auth/settings_page.dart` hardcoded `v.length < 8` instead of reading the server-configured minimum. On a deploy that raised the floor (e.g. `KLANGK_MIN_PASSWORD_LENGTH=12`), the client-side check passed but the server rejected — confusing UX.

## Change

One-line behavior fix — read the value the client already had:

```dart
// Before
if (v.length < 8) return 'Min 8 characters';

// After
final min = context.read<AuthService>().minPasswordLength;
if (v.length < min) return 'Min $min characters';
```

`AuthService.minPasswordLength` (`src/frontend/lib/auth/auth_service.dart:50`) is sourced from `KLANGK_MIN_PASSWORD_LENGTH` via `/api/v1/config` (parsed at `auth_service.dart:117-118` as `(data['min_password_length'] as num?)?.toInt() ?? 8`, so it falls back to 8 on older backends that omit the field). The admin users page already uses the same getter (`admin_users_page.dart:134, 314`) — this brings the password-change form to parity.

`min` is `int` (getter is `int get minPasswordLength`), so `v.length < min` is `int < int`.

## Verification

```
cd src/frontend && flutter analyze lib/auth/settings_page.dart   # No issues found
cd src/frontend && flutter test                                   # 905 passed
```

Rebased onto latest `main`; branch is up-to-date.
