### PR TITLE
fix(1611): delegate Playwright browser-dep install to npx (Ubuntu 24.04 t64)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,19 +91,19 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Install caddy + Playwright deps via apt
+      - name: Install caddy + Python via apt
         # Stock Ubuntu packages — no devenv, no nix. Caddy is klangkd's
         # default proxy engine child (KLANGK_PROXY_BIN overrides if needed,
         # but the default shutil.which("caddy") → /usr/bin/caddy path is
-        # exactly what apt installs). The Playwright libs are what
-        # `npx playwright install-deps` would install; we install them
-        # directly so the spec run doesn't need to.
+        # exactly what apt installs). The Playwright browser runtime libs
+        # (libnss3, libgbm1, libasound2t64, …) are NOT installed here —
+        # scripts/dist-smoke-test.sh runs `npx playwright install --with-deps
+        # chromium`, which resolves the correct package names per-OS. Hand-
+        # maintaining the lib list broke on the Ubuntu 24.04 t64 transition
+        # (libasound2 → libasound2t64, libatk1.0-0 → libatk1.0-0t64, …).
         run: |
           sudo apt-get update
-          sudo apt-get install -y caddy curl python3 python3-venv \
-            libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libcups2 \
-            libdrm2 libxkbcommon0 libxcomposite1 libxdamage1 libxfixes3 \
-            libxrandr2 libgbm1 libpango-1.0-0 libcairo2 libasound2
+          sudo apt-get install -y caddy curl python3 python3-venv
 
       - name: Download wheel artifact
         uses: actions/download-artifact@v7


### PR DESCRIPTION
Follow-up to #1705 / #1611. The dist-smoke-test job failed its first real `workflow_dispatch` run on the `apt-get install` step: `Package 'libasound2' has no installation candidate`.

## Root cause

Ubuntu 24.04's [t64 transition](https://wiki.ubuntu.com/Time64Migration) renamed several runtime libraries with no Compatibility-Symlink — `libasound2` is now a virtual package provided by `libasound2t64`, and `libatk1.0-0` / `libatk-bridge2.0-0` / `libcups2` / `libglib2.0-0` got the same `-t64` suffix. The hand-maintained apt list in the workflow used the pre-t64 names, so apt refused.

Failed run: https://github.com/mcdonc/klangk/actions/runs/29845509929/job/88686361663

## Fix

Stop hand-maintaining the Playwright browser-dep list. The workflow installs only `caddy curl python3 python3-venv`; the Playwright runtime libs are installed by `npx playwright install --with-deps chromium` (which `scripts/dist-smoke-test.sh` already runs). Playwright's install-deps list tracks per-OS package renames automatically, so the t64 transition (and any future rename) is handled upstream.

Diff: one workflow file, eight lines changed. Topology unchanged (`build-wheel → dist-smoke-test → publish-and-release`, manual dispatch still gated).
