### PR TITLE
fix(1611): mask caddy.service so klangkd's child can bind admin port

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,9 +101,22 @@ jobs:
         # chromium`, which resolves the correct package names per-OS. Hand-
         # maintaining the lib list broke on the Ubuntu 24.04 t64 transition
         # (libasound2 → libasound2t64, libatk1.0-0 → libatk1.0-0t64, …).
+        #
+        # MASK caddy.service: the Debian/Ubuntu caddy package ships a systemd
+        # unit that autostarts on install and binds the default admin port
+        # 127.0.0.1:2019. klangkd owns its own caddy child process
+        # (CADDY_ADMIN=unix//<sock>), but caddy's initial config-load still
+        # tries to bind 2019 before applying the new admin address — so the
+        # system service sitting on 2019 makes every klangkd-managed caddy
+        # fail to start ("bind: address already in use"). Mask the unit so
+        # the apt-installed caddy is just a binary on PATH, which is what
+        # klangkd's contract expects.
         run: |
           sudo apt-get update
           sudo apt-get install -y caddy curl python3 python3-venv
+          sudo systemctl stop caddy.service 2>/dev/null || true
+          sudo systemctl disable caddy.service 2>/dev/null || true
+          sudo systemctl mask caddy.service
 
       - name: Download wheel artifact
         uses: actions/download-artifact@v7


### PR DESCRIPTION
Follow-up to #1707 / #1611. The dist-smoke-test job's second `workflow_dispatch` run failed: klangkd's caddy child crashed on every restart attempt with:

```
Error: loading initial config: loading new config: starting caddy administration endpoint: listen tcp 127.0.0.1:2019: bind: address already in use
```

Failed run: https://github.com/mcdonc/klangk/actions/runs/29846484392/job/88689613725

## Root cause

The Debian/Ubuntu `caddy` package ships a systemd unit that autostarts on install. `apt-get install caddy` created `/etc/systemd/system/multi-user.target.wants/caddy.service` and started caddy binding `127.0.0.1:2019` (the caddy default admin port).

klangkd correctly bootstraps its own child with `CADDY_ADMIN=unix//<sock>` (`caddy.py:726`), but caddy's **initial** config-load still tries to bind 2019 before applying the new admin address — so the system service sitting on 2019 makes every klangkd-managed caddy fail to start. The whole point of the smoke gate is testing that klangkd works; having a coexisting `caddy.service` defeats that.

## Fix

Stop, disable, and mask `caddy.service` after the apt install:

```yaml
sudo systemctl stop caddy.service 2>/dev/null || true
sudo systemctl disable caddy.service 2>/dev/null || true
sudo systemctl mask caddy.service
```

The apt-installed caddy becomes just a binary on PATH, which is what klangkd's contract expects — it owns its own child process. This mirrors how the production host container does it (caddy runs as a klangkd-supervised child, not as an independent service).

One workflow file changed, 13 insertions. Topology unchanged.
