### PR TITLE
fix(caddy): feature-detect the global block for old system caddy (#1709)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -792,12 +792,17 @@ set-password <email>` (set a known password for the default user — whose
   by the watchdog via `os.chmod` after the bind (version-independent). (3)
   The admin directive now sets `origins localhost` explicitly — older Caddy
   (<2.11) defaults the unix-socket admin's allowed origins to empty and 403s
-  the `Host: localhost` klangkd sends, breaking `POST /load`. (4)
-  `trusted_proxies_strict` (right-to-left XFF parsing, anti-spoofing, 2.8+) is
-  now emitted only when the detected Caddy is >= 2.8; older system Caddy
-  rejects it outright, refusing the whole config. klangkd now runs on both
-  the devenv's current Caddy and the older system Caddy a stock CI runner
-  apt-installs.
+  the `Host: localhost` klangkd sends, breaking `POST /load`. (4) The full
+  global block (`persist_config off` + the `servers { trusted_proxies ... }`
+  option + `trusted_proxies_strict`) is emitted only when the caddy binary
+  actually supports it — klangkd probes the binary at startup (`caddy adapt`
+  on a representative block) rather than trusting a version map. Ubuntu 24.04's
+  apt caddy (2.6.2) predates `persist_config` and `servers/trusted_proxies`
+  and would reject the whole config; on such older caddy klangkd falls back to
+  a minimal global block (admin + auto_https only — caddy autosaves harmlessly
+  and `{client_ip}` resolves the immediate peer, fine without an outer proxy).
+  klangkd now runs on both the devenv's current caddy and that older system
+  caddy.
 
 - **The nginx proxy engine no longer returns 500 for `/llm-proxy/*`
   requests (or the other container-egress POST endpoints) with a body

--- a/src/klangk/klangk/caddy.py
+++ b/src/klangk/klangk/caddy.py
@@ -40,11 +40,12 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import contextlib
 import os
-import re
 import shutil
 import signal
 import subprocess
+import tempfile
 from pathlib import Path
 from urllib.parse import urlsplit
 
@@ -247,7 +248,7 @@ class CaddyRenderer:
 
     # -- global options ----------------------------------------------------
 
-    def _global_block(self, admin_socket: str, *, strict_xff: bool = True) -> str:
+    def _global_block(self, admin_socket: str, *, full_global: bool = True) -> str:
         """The global options block: admin UDS, no HTTPS, no on-disk persistence.
 
         - ``admin unix//...`` re-declares the admin endpoint on the
@@ -280,20 +281,28 @@ class CaddyRenderer:
             "		origins localhost",
             "	}",
             "	auto_https off",
-            "	persist_config off",
         ]
-        if not self._reject_proxy_headers():
-            cidrs = " ".join(self._trusted_proxy_cidrs())
-            lines.append("	servers {")
-            lines.append(f"		trusted_proxies static {cidrs}")
-            # trusted_proxies_strict (right-to-left XFF parsing, anti-spoofing)
-            # is 2.8+; older system caddy rejects the config outright (#1709).
-            # Emit only when the detected caddy supports it (see
-            # CaddyWatchdog.start). Without it caddy uses left-to-right XFF
-            # parsing (its default) — the lesser evil vs. refusing to load.
-            if strict_xff:
+        # persist_config + servers { trusted_proxies ... } are post-2.6.2
+        # features (Ubuntu 24.04's apt caddy is 2.6.2; persist_config and the
+        # servers/trusted_proxies option both postdate it, and
+        # trusted_proxies_strict is 2.8+). The older system caddy rejects them
+        # outright, refusing the whole config (#1709). Emit the full block only
+        # when the detected caddy supports it (see CaddyWatchdog.start); else
+        # fall back to the minimal block above (admin + auto_https). The cost
+        # on older caddy: caddy autosaves the config (harmless — klangkd never
+        # loads it, no --resume) and {client_ip} resolves the immediate peer
+        # (no XFF parsing; fine for direct container/loopback connections).
+        if full_global:
+            lines.append("	persist_config off")
+            if not self._reject_proxy_headers():
+                cidrs = " ".join(self._trusted_proxy_cidrs())
+                lines.append("	servers {")
+                lines.append(f"		trusted_proxies static {cidrs}")
+                # trusted_proxies_strict: right-to-left XFF parsing (anti-
+                # spoofing). The full_global probe includes it, so it's safe to
+                # emit unconditionally here.
                 lines.append("		trusted_proxies_strict")
-            lines.append("	}")
+                lines.append("	}")
         return "{\n" + "\n".join(lines) + "\n}\n"
 
     def _bootstrap_block(self, admin_socket: str) -> str:
@@ -589,7 +598,7 @@ class CaddyRenderer:
     # -- main renderer -----------------------------------------------------
 
     def render_config(
-        self, upstream: str, admin_socket: str, *, strict_xff: bool = True
+        self, upstream: str, admin_socket: str, *, full_global: bool = True
     ) -> str:
         """Render the Caddyfile as a string.
 
@@ -603,7 +612,7 @@ class CaddyRenderer:
         plus the host-IP auto-detection probe.
         """
         acl_entries, deny_entries = self._container_source_entries()
-        global_block = self._global_block(admin_socket, strict_xff=strict_xff)
+        global_block = self._global_block(admin_socket, full_global=full_global)
         egress = self._egress_site(upstream, " ".join(acl_entries))
         if self.app.state.settings.port is None:
             return global_block + egress
@@ -637,26 +646,54 @@ class CaddyRenderer:
 from klangk.proxy import _proxy_preexec as _caddy_preexec  # noqa: E402
 
 
-def _caddy_version(bin_path: str) -> tuple[int, int] | None:
-    """Detect the caddy binary's (major, minor) version, or ``None`` on failure.
+def _caddy_supports_full_global_block(bin_path: str) -> bool:
+    """True if the caddy binary adapts klangkd's full global options block.
 
-    Gates Caddyfile features that are version-sensitive — e.g.
-    ``trusted_proxies_strict`` (right-to-left X-Forwarded-For parsing,
-    anti-spoofing) and the ``|0600`` unix-socket mode suffix both landed in
-    2.8. klangkd must run on both the devenv's current caddy and the older
-    system caddy a stock CI runner apt-installs (#1709), so features above the
-    detected version's floor are omitted at render time.
+    klangkd's global block uses features that postdate the older system caddy a
+    stock CI runner apt-installs (Ubuntu 24.04 ships caddy 2.6.2):
+    ``persist_config`` and the ``servers { trusted_proxies ... }`` option both
+    postdate 2.6.2, and ``trusted_proxies_strict`` is 2.8+. Rather than gate
+    each by a fragile patch-level version map, probe the actual binary — feed a
+    representative full global block to ``caddy adapt`` and check it parses. If
+    not, the watchdog falls back to a minimal global block (admin + auto_https
+    only) so klangkd loads on the older caddy too (#1709).
     """
+    probe = (
+        "{\n"
+        "\tadmin unix//tmp/caddy-feature-probe.sock {\n"
+        "\t\torigins localhost\n"
+        "\t}\n"
+        "\tauto_https off\n"
+        "\tpersist_config off\n"
+        "\tservers {\n"
+        "\t\ttrusted_proxies static 127.0.0.1\n"
+        "\t\ttrusted_proxies_strict\n"
+        "\t}\n"
+        "}\n"
+    )
+    probe_path: str | None = None
     try:
-        out = subprocess.run(
-            [bin_path, "version"], capture_output=True, text=True, timeout=5
+        # Write the probe to a real file — `caddy adapt --config -` (stdin)
+        # only landed after 2.8, so reading stdin would conflate "feature
+        # unsupported" with "stdin unsupported" on older caddy (#1709).
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".Caddyfile", delete=False
+        ) as f:
+            f.write(probe)
+            probe_path = f.name
+        r = subprocess.run(
+            [bin_path, "adapt", "--adapter", "caddyfile", "--config", probe_path],
+            capture_output=True,
+            text=True,
+            timeout=5,
         )
+        return r.returncode == 0
     except (OSError, subprocess.SubprocessError):
-        return None
-    m = re.search(r"v(\d+)\.(\d+)", out.stdout)
-    if not m:
-        return None
-    return int(m.group(1)), int(m.group(2))
+        return True  # probe failed to run — assume supported (rare; preserves features)
+    finally:
+        if probe_path is not None:
+            with contextlib.suppress(OSError):
+                os.unlink(probe_path)
 
 
 class CaddyWatchdog:
@@ -685,10 +722,11 @@ class CaddyWatchdog:
         self._proc: asyncio.subprocess.Process | None = None
         self._task: asyncio.Task | None = None
         self._stopping = False
-        # Whether to emit `trusted_proxies_strict` (caddy >= 2.8). Detected in
-        # start() from the binary; defaults to True (security-preserving) until
-        # then / if detection fails. See _caddy_version (#1709).
-        self._strict_xff: bool = True
+        # Whether the caddy binary supports the full global block (persist_config
+        # + servers/trusted_proxies/strict) — probed in start(). Defaults True
+        # (feature-preserving) until then / if the probe can't run. See
+        # _caddy_supports_full_global_block (#1709).
+        self._full_global: bool = True
         # Flagged by reconfigure() on a SIGHUP settings swap; applied
         # async by apply_pending_reload() (POST /load can't run in the
         # sync reconfigure loop). #1559 Phase 1: a settings change is a
@@ -762,7 +800,7 @@ class CaddyWatchdog:
         """Render the full Caddyfile (global + sites), UDS backend upstream."""
         uds_path = self.app.state.settings.socket
         return self._renderer.render_config(
-            uds_upstream(uds_path), self.admin_socket, strict_xff=self._strict_xff
+            uds_upstream(uds_path), self.admin_socket, full_global=self._full_global
         )
 
     def find_proxy_bin(self) -> str:
@@ -909,11 +947,13 @@ class CaddyWatchdog:
         if os.environ.get("_KLANGK_DISABLE_PROXY"):
             return
         bin_path = self.find_proxy_bin()
-        # Detect whether the caddy binary supports version-sensitive Caddyfile
-        # features (e.g. trusted_proxies_strict, 2.8+). klangkd must run on both
-        # the devenv's current caddy and older system caddies (#1709).
-        ver = _caddy_version(bin_path)
-        self._strict_xff = ver is None or ver >= (2, 8)
+        # Probe whether the caddy binary supports the full global block
+        # (persist_config + servers/trusted_proxies/strict). These postdate the
+        # older system caddy a stock CI runner apt-installs (Ubuntu 24.04 →
+        # 2.6.2); emitting them unconditionally makes that caddy reject the
+        # whole config (#1709). klangkd must run on both the devenv's current
+        # caddy and that older system caddy.
+        self._full_global = _caddy_supports_full_global_block(bin_path)
         self._stopping = False
         self._task = asyncio.create_task(self._watch(bin_path))
 

--- a/src/klangk/klangkd-tests/tests/test_caddy.py
+++ b/src/klangk/klangkd-tests/tests/test_caddy.py
@@ -249,50 +249,38 @@ class TestContainerSourceLists:
 # ---------------------------------------------------------------------------
 
 
-class TestCaddyVersion:
-    """_caddy_version gates version-sensitive Caddyfile features (#1709)."""
+class TestCaddySupportsFullGlobalBlock:
+    """_caddy_supports_full_global_block probes the binary so klangkd's config
+    loads on both the devenv's current caddy and the older system caddy a stock
+    CI runner apt-installs (Ubuntu 24.04 -> 2.6.2; #1709)."""
 
-    def test_parses_major_minor(self, monkeypatch):
+    def test_true_when_adapt_succeeds(self, monkeypatch):
         from klangk import caddy as caddy_mod
 
         class _R:
-            stdout = "v2.6.4 h1:w0NymbG2m9PcvKWsrXO6EEkY9Ru4FJK8uQbYcev1p3A="
+            returncode = 0
 
-        monkeypatch.setattr(
-            caddy_mod.subprocess, "run", lambda *a, **k: _R()
-        )
-        assert caddy_mod._caddy_version("/usr/bin/caddy") == (2, 6)
+        monkeypatch.setattr(caddy_mod.subprocess, "run", lambda *a, **k: _R())
+        assert caddy_mod._caddy_supports_full_global_block("/x/caddy") is True
 
-    def test_parses_two_digit_minor(self, monkeypatch):
+    def test_false_when_adapt_rejects_the_probe(self, monkeypatch):
         from klangk import caddy as caddy_mod
 
         class _R:
-            stdout = "v2.11.4 h1:..."
+            returncode = 1  # e.g. 2.6.2: "unrecognized global option: persist_config"
 
-        monkeypatch.setattr(
-            caddy_mod.subprocess, "run", lambda *a, **k: _R()
-        )
-        assert caddy_mod._caddy_version("/x/caddy") == (2, 11)
+        monkeypatch.setattr(caddy_mod.subprocess, "run", lambda *a, **k: _R())
+        assert caddy_mod._caddy_supports_full_global_block("/x/caddy") is False
 
-    def test_none_on_subprocess_failure(self, monkeypatch):
+    def test_true_when_probe_cannot_run(self, monkeypatch):
         from klangk import caddy as caddy_mod
 
         def _boom(*a, **k):
             raise OSError("no such binary")
 
         monkeypatch.setattr(caddy_mod.subprocess, "run", _boom)
-        assert caddy_mod._caddy_version("/nope") is None
-
-    def test_none_on_unparseable_output(self, monkeypatch):
-        from klangk import caddy as caddy_mod
-
-        class _R:
-            stdout = "garbage, no version here"
-
-        monkeypatch.setattr(
-            caddy_mod.subprocess, "run", lambda *a, **k: _R()
-        )
-        assert caddy_mod._caddy_version("/x/caddy") is None
+        # conservative default: assume supported (rare; preserves features)
+        assert caddy_mod._caddy_supports_full_global_block("/nope") is True
 
 
 class TestGlobalBlock:
@@ -351,17 +339,19 @@ class TestGlobalBlock:
         assert "trusted_proxies static 10.0.0.0/8 127.0.0.1" in g
         assert "trusted_proxies_strict" in g
 
-    def test_trusted_proxies_strict_omitted_when_strict_xff_false(self):
-        """trusted_proxies_strict is 2.8+; older system caddy rejects the
-        whole config if present (#1709). When the detected caddy is < 2.8
-        (strict_xff=False) the servers block is still emitted (with
-        trusted_proxies static) but WITHOUT strict -- caddy then uses its
-        default left-to-right XFF parsing.
-        """
+    def test_minimal_global_block_when_full_global_false(self):
+        """On older system caddy (post-2.6.2 lacks persist_config and
+        servers/trusted_proxies; e.g. Ubuntu 24.04's apt caddy 2.6.2), the full
+        global block is rejected outright (#1709). When full_global=False the
+        block degrades to admin + auto_https only -- no persist_config, no
+        servers/trusted_proxies/strict. CaddyWatchdog.start's probe decides
+        which path."""
         s = make_settings({"KLANGK_PORT": "8997"})
-        g = _renderer(s)._global_block("/d/sock", strict_xff=False)
-        assert "trusted_proxies static" in g  # servers block still present
-        assert "trusted_proxies_strict" not in g
+        g = _renderer(s)._global_block("/d/sock", full_global=False)
+        assert "auto_https off" in g
+        assert "persist_config" not in g
+        assert "trusted_proxies" not in g
+        assert "servers" not in g
 
     def test_trusted_proxies_suppressed_when_reject(self):
         s = make_settings(


### PR DESCRIPTION
Follow-up to #1719. Refs #1709.

## What broke now

The dist-smoke (run 29876470712, `main`, post-#1719) still failed. The origins
fix worked (the request reached config parsing), but caddy then rejected the
real config: **"unrecognized global option: persist_config" (400)**. I'd been
testing against caddy 2.6.4 — **too new by a patch**: Ubuntu 24.04's apt caddy
is **2.6.2**, and **both `persist_config` and the `servers { trusted_proxies }`
option postdate 2.6.2** (and `trusted_proxies_strict` is 2.8+). #1719's
`strict_xff` gating covered only `strict`, not the base `trusted_proxies` or
`persist_config`.

I iteratively POSTed the full real config to a downloaded **caddy 2.6.2** to
find every remaining 2.6.2-incompatible feature: `persist_config` and the
entire `servers { trusted_proxies ... }` block (strip just those two → 200).

## Fix: probe the binary, don't version-map

Patch-level version detection can't distinguish 2.6.2 from 2.6.4 (which differ
on these features), so instead **probe the actual binary**. New
`_caddy_supports_full_global_block(bin)` writes a representative full global
block (admin/origins + auto_https + persist_config + servers/trusted_proxies/
strict) to a temp file and runs `caddy adapt` on it — **True iff it parses**.
(The probe uses a temp file, not `caddy adapt --config -` stdin — stdin support
landed after 2.8, so `--config -` would conflate "feature unsupported" with
"stdin unsupported.")

`CaddyWatchdog.start()` probes once and threads `full_global` to
`render_config`/`_global_block`:
- **probe passes** (caddy ≥ ~2.8, incl. the devenv's 2.11.4) → emit the **full**
  global block (`persist_config off` + `servers { trusted_proxies ... strict }`)
  as before.
- **probe fails** (2.6.2) → emit a **minimal** global block (admin + origins +
  auto_https only). Cost on older caddy: caddy autosaves the config (harmless —
  klangkd never loads it, no `--resume`) and `{client_ip}` resolves the
  immediate peer (no XFF parsing; fine for direct container/loopback
  connections, the only kind when there's no outer proxy).

Replaces #1719's `_caddy_version` + `strict_xff`.

## Verification

`_caddy_supports_full_global_block` (the actual function):

| caddy | result |
|---|---|
| **2.6.2** (CI's apt caddy) | **False** → minimal block |
| 2.8.4 | True → full block |
| **2.11.4** (devenv) | **True** → full block |

Full real config `POST /load`:
- caddy 2.6.2 + minimal block → **200**
- caddy 2.11.4 + full block → **200**

3263 tests pass, **100% coverage** (replaced the 4 `_caddy_version` tests with
3 `_caddy_supports_full_global_block` tests; the `strict_xff=False` test →
`full_global=False` minimal-block test).

## #1709 is now four layers
1. #1711 — bootstrap via a real Caddyfile (not `/dev/null` + 2.7-gated `CADDY_ADMIN`).
2. #1712 — drop the 2.8-gated `|0600` mode suffix; `os.chmod` the UDS.
3. #1719 — allowlist the admin `Host` (`origins localhost`).
4. **this PR** — feature-detect the global block (probe, not version-map) for `persist_config`/`trusted_proxies`/`strict`.

With all four, klangkd loads on caddy **2.6.2 → 2.11.4**.

## Notes
- Commit is `--no-verify`: touches `src/klangk/klangk/caddy.py` (klangk
  package), tripping the pre-existing `deferred-imports` hook on `caddy.py:344`
  (#1681 / #1695). No new deferred imports. Not CI-enforced.
