### PR TITLE
fix(e2e): use playwright's default browser when PLAYWRIGHT_BROWSERS_PATH unset

### DIFF
--- a/src/frontend/e2e-tests/playwright.config.ts
+++ b/src/frontend/e2e-tests/playwright.config.ts
@@ -8,9 +8,19 @@ const BROWSERS = process.env.PLAYWRIGHT_BROWSERS_PATH || "";
 
 const chromiumUse = {
   launchOptions: {
+    // In devenv/NixOS, PLAYWRIGHT_BROWSERS_PATH points at the nix-bundled
+    // browsers and we pin the exact nix build (chromium-1223) — @playwright/test
+    // 1.59.1's default revision differs, so the pin is required there (#1193).
+    // When PLAYWRIGHT_BROWSERS_PATH is UNSET (e.g. the dist-smoke, which
+    // `npx playwright install`s its own browser on a stock runner), fall back
+    // to undefined so Playwright uses its default (the just-installed) browser
+    // instead of a non-existent /chromium-1223/... path. CHROME_PATH overrides
+    // both for local runs.
     executablePath:
       process.env.CHROME_PATH ||
-      `${BROWSERS}/chromium-1223/chrome-linux64/chrome`,
+      (BROWSERS
+        ? `${BROWSERS}/chromium-1223/chrome-linux64/chrome`
+        : undefined),
     args: ["--enable-unsafe-swiftshader"],
   },
 };
@@ -22,7 +32,8 @@ const firefoxUse = {
     // runs (e.g. macOS, where the binary is firefox/Nightly.app/...), mirroring
     // CHROME_PATH above.
     executablePath:
-      process.env.FIREFOX_PATH || `${BROWSERS}/firefox-1522/firefox/firefox`,
+      process.env.FIREFOX_PATH ||
+      (BROWSERS ? `${BROWSERS}/firefox-1522/firefox/firefox` : undefined),
     // Allow navigator.clipboard read/write in automation without a prompt, so
     // the paste e2e can seed the clipboard. (The fix's own read path uses the
     // native `paste` event and needs no permission.)
@@ -43,7 +54,8 @@ const webkitUse = {
     // npm-version-derived revision. WEBKIT_PATH mirrors CHROME/FIREFOX_PATH
     // for local overrides. See #1193.
     executablePath:
-      process.env.WEBKIT_PATH || `${BROWSERS}/webkit-2287/pw_run.sh`,
+      process.env.WEBKIT_PATH ||
+      (BROWSERS ? `${BROWSERS}/webkit-2287/pw_run.sh` : undefined),
   },
 };
 


### PR DESCRIPTION
Unblocks the dist-smoke (the Playwright failure surfaced after #1709/#1721
finally got klangkd booting on the dist-smoke's caddy 2.6.2).

## Root cause

`playwright.config.ts` **unconditionally** built the chromium `executablePath`
as `` `${BROWSERS}/chromium-1223/chrome-linux64/chrome` ``. The `chromium-1223`
pin is the **nix-bundled** build (devenv/NixOS pins it because
`@playwright/test` 1.59.1's default revision differs — `#1193`, see the webkit
comment in the file).

In the **dist-smoke** (stock Ubuntu runner, no nix) `PLAYWRIGHT_BROWSERS_PATH`
is unset, so `BROWSERS` is `""` and the path collapsed to
`/chromium-1223/chrome-linux64/chrome` — which doesn't exist. The dist-smoke's
`npx playwright install` had fetched a **different** revision
(`chromium-1217`, the one 1.59.1 actually wants) to the default
`~/.cache/ms-playwright/`, so Playwright couldn't find a browser:

```
Error: browserType.launch: Failed to launch chromium because executable
doesn't exist at /chromium-1223/chrome-linux64/chrome
```

This was always broken in the dist-smoke — it was just hidden behind the
caddy failure until #1709 was fully fixed.

## Fix

Only use the pinned nix path when `PLAYWRIGHT_BROWSERS_PATH` (or the `*_PATH`
override) is set; otherwise leave `executablePath` **`undefined`** so Playwright
uses its default (the browser `npx playwright install` just fetched). Applied
to chromium, firefox, and webkit blocks.

```ts
executablePath:
  process.env.CHROME_PATH ||
  (BROWSERS ? `${BROWSERS}/chromium-1223/chrome-linux64/chrome` : undefined),
```

Per the project's NixOS-support intent, the nix-pinned path stays in effect
where `PLAYWRIGHT_BROWSERS_PATH` is set; nothing is set in the dist-smoke
itself (no env-var change there).

## Verification

`executablePath` resolves correctly:
- `PLAYWRIGHT_BROWSERS_PATH` **unset** (dist-smoke) → `undefined` → Playwright
  default → the `chromium-1217` it installed.
- `PLAYWRIGHT_BROWSERS_PATH` **set** (devenv: `/nix/store/.../playwright-browsers`)
  → pinned `chromium-1223` path — **unchanged** (no regression for the CI
  e2e suite).
- `CHROME_PATH` (local override) → that path.

Config still parses (`npx playwright test --list --project=dist-smoke` lists
the spec after `npm ci`). The dist-smoke run itself (workflow_dispatch) is the
final confirmation.

## Notes
- No changelog entry — this is test/CI infra (no user-visible behavior
  change), per the changelog rules.
