### PR TITLE
fix(proxy): make nginx access_log systemd-safe under systemctl start (#1550)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -772,6 +772,25 @@ set-password <email>` (set a known password for the default user — whose
 
 ### Fixed
 
+- **The nginx proxy engine stays up under a plain `systemctl start` with no
+  operator log workaround (#1550).** nginx's `access_log` directive has no
+  `stdout` keyword, so it always `open(2)`s its destination by path; under
+  systemd fd 1 is a Unix socket to journald (`ls /proc/<pid>/fd/1` →
+  `socket:[N]`) that can't be re-opened, so the legacy `access_log
+/dev/stdout;` failed with `ENXIO` and nginx exited at config parse.
+  `ProxyRenderer` now probes fd 1: when it's reopenable (devenv, interactive,
+  pipe-to-file, containers without journald) it keeps `access_log
+/dev/stdout;`; when it's a socket (systemd journal) it emits `access_log
+syslog:server=unix:/dev/log;` — the converged journald route that works on
+  NixOS, Ubuntu 24.04+, and every other systemd host, since `/dev/log` is
+  created and serviced by the core `systemd-journald-dev-log.socket` unit (no
+  rsyslog needed), so access logs land in the journal next to klangkd's own.
+  A `state_dir` file is the last-resort fallback for the rare
+  socket-stdout-but-no-`/dev/log` case. `error_log stderr;` is unchanged
+  (nginx special-cases the bare `stderr` token to inherited fd 2). This
+  makes a default `StandardOutput=journal` unit work, retiring the
+  `StandardOutput=append:...` workaround from #1546.
+
 - **The Caddy proxy engine's child coexists with any other Caddy on the host
   and binds its admin UDS from the first moment, on any Caddy version
   (#1709).** Two version-robustness bugs were fixed. (1) The watchdog spawned
@@ -783,10 +802,10 @@ set-password <email>` (set a known password for the default user — whose
   crash-looped polling a UDS that never appeared — failing on any host that
   also runs Caddy (a system `caddy.service`, a sibling reverse proxy, another
   klangkd). The spawn now passes a minimal initial Caddyfile (`{ admin
-  unix//<sock> }`) via `--config`; the `admin` global option has been honored
+unix//<sock> }`) via `--config`; the `admin` global option has been honored
   since Caddy v2.0. (2) The admin address no longer carries a `|0600` mode
   suffix — that syntax is only honored on Caddy >= 2.8 and on older Caddy is
-  folded into the socket *path* (creating `caddy-admin.sock|0600` instead of
+  folded into the socket _path_ (creating `caddy-admin.sock|0600` instead of
   `caddy-admin.sock`), which broke the admin poll on the older system Caddy
   the dist-smoke gate installs. The owner-only mode (#1559) is now enforced
   by the watchdog via `os.chmod` after the bind (version-independent). (3)

--- a/src/klangk/klangk/proxy.py
+++ b/src/klangk/klangk/proxy.py
@@ -35,6 +35,7 @@ import logging
 import os
 import signal
 import shutil
+import stat
 import subprocess
 import sys
 from pathlib import Path
@@ -110,6 +111,33 @@ def detect_host_ipv4s() -> list[str]:
             ip = token.split("/")[0]
             addrs.append(ip)
     return addrs
+
+
+def stdout_is_reopenable() -> bool:
+    """True if nginx can re-``open()`` ``/dev/stdout`` by path here (#1550).
+
+    nginx's ``access_log`` directive has no ``stdout`` keyword: it always
+    ``open(2)``s its destination by path, and ``/dev/stdout`` resolves to
+    ``/proc/self/fd/1``. That re-open succeeds when fd 1 is a regular file,
+    pipe, or PTY (devenv, interactive, pipe-to-file), but fails with
+    ``ENXIO`` when fd 1 is a Unix socket — which is exactly what systemd
+    gives every service: stdout is a socket to journald
+    (``ls /proc/<pid>/fd/1`` → ``socket:[N]``); a socket can be written but
+    not re-opened by path, so nginx exits at config parse.
+
+    ``error_log stderr;`` is unaffected — nginx special-cases the bare
+    ``stderr`` token to write straight to inherited fd 2 and never re-opens
+    it — so only ``access_log`` needs this check.
+
+    We mirror nginx's view by ``fstat(2)``-ing our own fd 1: klangkd's nginx
+    child inherits this exact fd, so its reopenability matches ours.
+    """
+    try:
+        st = os.fstat(1)
+    except OSError:
+        # fd 1 unusable — assume reopenable to preserve legacy behavior.
+        return True
+    return not stat.S_ISSOCK(st.st_mode)
 
 
 # Fallback subnets when auto-detection yields nothing (mirrors nginx.sh):
@@ -330,6 +358,39 @@ class ProxyRenderer:
             bytes_ = 524288000
         mb = max(1, bytes_ // 1048576)
         return f"{mb}m"
+
+    def access_log_dest(self) -> str:
+        """The ``access_log`` directive line, systemd-safe (#1550).
+
+        nginx always ``open(2)``s the ``access_log`` path; ``/dev/stdout``
+        re-opens our inherited fd 1, which under systemd is a journald
+        socket that can't be re-opened → ``ENXIO`` → nginx exits at config
+        parse. Pick a destination openable *here*:
+
+        - fd 1 reopenable (devenv / interactive / pipe-to-file — the
+          non-journald case): ``access_log /dev/stdout;`` (legacy behavior;
+          access logs ride klangkd's stdout).
+        - fd 1 a socket (systemd journal): ``access_log
+          syslog:server=unix:/dev/log;`` — the converged journald route on
+          every systemd host. ``/dev/log`` is created and serviced by the
+          core ``systemd-journald-dev-log.socket`` unit (not rsyslog), so it
+          is present and journald-native on NixOS, Ubuntu 24.04+, RHEL,
+          Debian, Arch, … without any extra daemon, and access logs land in
+          the journal next to klangkd's own logs (``journalctl`` / ``--grep``
+          on the host). The final ``state_dir`` file branch only fires in the
+          rare socket-stdout-but-no-``/dev/log`` case (e.g. a non-systemd
+          container whose stdout was wired to a socket).
+
+        ``error_log stderr;`` is emitted unchanged by both renderers — nginx
+        special-cases the bare ``stderr`` token to inherited fd 2 and never
+        re-opens it, so it is systemd-safe already.
+        """
+        if stdout_is_reopenable():
+            return "access_log /dev/stdout;"
+        if os.path.exists("/dev/log"):
+            return "access_log syslog:server=unix:/dev/log;"
+        state_dir = self._app.state.settings.state_dir
+        return f"access_log {state_dir}/nginx-access.log;"
 
     # -- Section builders --------------------------------------------------
 
@@ -610,6 +671,7 @@ class ProxyRenderer:
         client_max_body_size = self.compute_client_max_body_size()
         resolvers = self.detect_dns_resolvers()
         acl, _ = self.compute_container_acls()
+        access_log = self.access_log_dest()
         egress_locations = self._egress_locations(upstream, acl, resolvers)
         realip = self._realip_block()
         return f"""daemon off;
@@ -617,7 +679,7 @@ pid /tmp/nginx.pid;
 error_log stderr;
 events {{ worker_connections 1024; }}
 http {{
-  access_log /dev/stdout;
+  {access_log}
   client_body_temp_path /tmp/nginx_client_body;
   proxy_temp_path /tmp/nginx_proxy;
   fastcgi_temp_path /tmp/nginx_fastcgi;
@@ -654,6 +716,7 @@ http {{
         client_max_body_size = self.compute_client_max_body_size()
         resolvers = self.detect_dns_resolvers()
         acl, deny = self.compute_container_acls()
+        access_log = self.access_log_dest()
 
         hosted_block = self._build_hosted_block()
         egress_locations = self._egress_locations(upstream, acl, resolvers)
@@ -689,7 +752,7 @@ pid /tmp/nginx.pid;
 error_log stderr;
 events {{ worker_connections 1024; }}
 http {{
-  access_log /dev/stdout;
+  {access_log}
   client_body_temp_path /tmp/nginx_client_body;
   proxy_temp_path /tmp/nginx_proxy;
   fastcgi_temp_path /tmp/nginx_fastcgi;

--- a/src/klangk/klangkd-tests/tests/test_proxy.py
+++ b/src/klangk/klangkd-tests/tests/test_proxy.py
@@ -6,7 +6,9 @@ is covered by the e2e suite (``test_proxy_acl_e2e.py``).
 """
 
 import asyncio
+import os
 import re
+import socket
 from unittest.mock import Mock
 
 import pytest
@@ -16,6 +18,7 @@ import types
 from klangk.proxy import (
     ProxyRenderer,
     detect_host_ipv4s,
+    stdout_is_reopenable,
     tcp_upstream,
     uds_upstream,
 )
@@ -63,6 +66,124 @@ class TestClientMaxBodySize:
     def test_garbage_falls_back(self):
         s = make_settings({"KLANGK_FILE_UPLOAD_SIZE_MAX": "not-a-number"})
         assert _renderer(s).compute_client_max_body_size() == "500m"
+
+
+class TestStdoutIsReopenable:
+    """The fd-1-type probe behind the #1550 ``access_log`` destination.
+
+    nginx ``open(2)``s ``/dev/stdout`` → ``/proc/self/fd/1``; that fails with
+    ``ENXIO`` only when fd 1 is a socket (systemd journald). We mirror nginx's
+    view by ``fstat``-ing our own fd 1 (klangkd's nginx child inherits it).
+    """
+
+    @staticmethod
+    def _probe_with_fd1(fd) -> bool:
+        """Run ``stdout_is_reopenable()`` with *fd* dup2'd onto fd 1."""
+        saved = os.dup(1)
+        try:
+            os.dup2(fd, 1)
+            return stdout_is_reopenable()
+        finally:
+            os.dup2(saved, 1)
+            os.close(saved)
+
+    def test_pipe_is_reopenable(self):
+        # devenv / interactive / pipe-to-file / pytest capture.
+        r, w = os.pipe()
+        try:
+            assert self._probe_with_fd1(w) is True
+        finally:
+            os.close(r)
+            os.close(w)
+
+    def test_regular_file_is_reopenable(self, tmp_path):
+        f = tmp_path / "log"
+        f.write_text("")
+        with open(f, "w") as fh:
+            assert self._probe_with_fd1(fh.fileno()) is True
+
+    def test_socket_is_not_reopenable(self):
+        # The systemd-journald case: fd 1 is an AF_UNIX socket.
+        a, b = socket.socketpair()
+        try:
+            assert self._probe_with_fd1(a.fileno()) is False
+        finally:
+            a.close()
+            b.close()
+
+    def test_fstat_failure_assumes_reopenable(self, monkeypatch):
+        # If fd 1 can't be fstat'd (e.g. closed), assume reopenable so we
+        # preserve legacy behavior rather than guessing socket.
+        def _boom(_fd):
+            raise OSError("bad fd")
+
+        monkeypatch.setattr("klangk.proxy.os.fstat", _boom)
+        assert stdout_is_reopenable() is True
+
+
+class TestAccessLogDest:
+    """``access_log`` destination picked for systemd-safety (#1550).
+
+    The converged systemd answer is ``syslog:server=unix:/dev/log``: it works
+    on NixOS and Ubuntu 24.04+ alike because ``/dev/log`` is created and
+    serviced by the core ``systemd-journald-dev-log.socket`` unit (not
+    rsyslog). ``/dev/stdout`` is kept only where fd 1 is reopenable.
+    """
+
+    def test_reopenable_stdout_keeps_dev_stdout(self, monkeypatch):
+        # devenv / interactive / pipe: fd 1 reopenable → legacy behavior.
+        monkeypatch.setattr("klangk.proxy.stdout_is_reopenable", lambda: True)
+        s = make_settings({})
+        assert _renderer(s).access_log_dest() == "access_log /dev/stdout;"
+
+    def test_systemd_journal_uses_syslog_dev_log(self, monkeypatch):
+        # fd 1 is a journald socket; /dev/log present → converged syslog route.
+        monkeypatch.setattr("klangk.proxy.stdout_is_reopenable", lambda: False)
+        monkeypatch.setattr("os.path.exists", lambda p: p == "/dev/log")
+        s = make_settings({})
+        assert _renderer(s).access_log_dest() == (
+            "access_log syslog:server=unix:/dev/log;"
+        )
+
+    def test_socket_stdout_no_dev_log_falls_back_to_state_dir_file(
+        self, monkeypatch, tmp_path
+    ):
+        # Rare case: fd 1 a socket but no /dev/log (e.g. a non-systemd
+        # container whose stdout was wired to a socket). Must still produce
+        # an openable destination or nginx fails config parse.
+        monkeypatch.setattr("klangk.proxy.stdout_is_reopenable", lambda: False)
+        monkeypatch.setattr("os.path.exists", lambda p: False)
+        s = make_settings({"KLANGK_STATE_DIR": str(tmp_path)})
+        assert _renderer(s).access_log_dest() == (
+            f"access_log {tmp_path}/nginx-access.log;"
+        )
+
+    def test_default_env_keeps_dev_stdout_in_rendered_config(self):
+        # Under pytest fd 1 is a pipe → reopenable → legacy /dev/stdout is
+        # preserved (no regression for dev / e2e / pipe-to-file).
+        s = make_settings({})  # port unset ⇒ headless
+        conf = _renderer(s).render_config(tcp_upstream("127.0.0.1", "8997"))
+        assert "access_log /dev/stdout;" in conf
+        assert "error_log stderr;" in conf
+
+    def test_systemd_choice_lands_in_headless_config(self, monkeypatch):
+        monkeypatch.setattr("klangk.proxy.stdout_is_reopenable", lambda: False)
+        monkeypatch.setattr("os.path.exists", lambda p: p == "/dev/log")
+        s = make_settings({})  # port unset ⇒ headless
+        conf = _renderer(s).render_config(tcp_upstream("127.0.0.1", "8997"))
+        assert "access_log syslog:server=unix:/dev/log;" in conf
+        assert "/dev/stdout" not in conf
+        # error_log stderr is unchanged (nginx special-cases the stderr
+        # token to inherited fd 2; always systemd-safe).
+        assert "error_log stderr;" in conf
+
+    def test_systemd_choice_lands_in_full_config(self, monkeypatch):
+        monkeypatch.setattr("klangk.proxy.stdout_is_reopenable", lambda: False)
+        monkeypatch.setattr("os.path.exists", lambda p: p == "/dev/log")
+        s = make_settings({"KLANGK_PORT": "8997"})  # port set ⇒ full/browser
+        conf = _renderer(s).render_config(tcp_upstream("127.0.0.1", "8997"))
+        assert "access_log syslog:server=unix:/dev/log;" in conf
+        assert "/dev/stdout" not in conf
 
 
 class TestContainerAcls:


### PR DESCRIPTION
## Summary

Makes the (deprecated) nginx proxy engine stay up under a plain `systemctl start klangk` with the default `StandardOutput=journal`, with no operator log-config workaround. Closes #1550. Retires the `StandardOutput=append:...` workaround from #1546.

## Problem (#1550)

nginx's `access_log` directive has no `stdout` keyword, so it always `open(2)`s its destination by path. The legacy `access_log /dev/stdout;` resolves `/dev/stdout` → `/proc/self/fd/1`; under systemd fd 1 is a **Unix socket to journald** (`ls /proc/<pid>/fd/1` → `socket:[N]`) that can't be re-opened by path → `ENXIO` → nginx exits at config parse → watchdog respawns forever. This blocks every production-style deploy that runs `klangkd` as the systemd unit.

`error_log stderr;` is **not** affected — nginx special-cases the bare `stderr` token to write straight to inherited fd 2 and never re-opens it. So only `access_log` needs fixing.

## Fix

`ProxyRenderer` now probes fd 1 and picks an `access_log` destination that's openable *here*:

| fd 1 type | Destination | Where it applies |
|---|---|---|
| reopenable (pipe / PTY / regular file) | `access_log /dev/stdout;` (legacy) | devenv, interactive, pipe-to-file, containers without journald |
| **socket (systemd journal)** | **`access_log syslog:server=unix:/dev/log;`** | **NixOS, Ubuntu 24.04+, every systemd host** |
| socket but no `/dev/log` (rare) | `access_log <state_dir>/nginx-access.log;` | non-systemd container whose stdout was wired to a socket |

The probe is `os.fstat(1)` + `stat.S_ISSOCK` — klangkd's nginx child inherits this exact fd, so its reopenability matches ours. Wired into both `_render_headless_config` and `_render_full_config`. `error_log stderr;` unchanged.

## Why this converges on NixOS *and* Ubuntu 24.04+

`/dev/log` is created and serviced by **`systemd-journald-dev-log.socket`** — a core systemd unit, **not** an rsyslog thing. So it's present and journald-native on **every** systemd-based host (NixOS, Ubuntu 24.04+, RHEL, Debian, Arch) with no extra daemon, and access logs land in the journal next to klangkd's own (`journalctl`, `--grep`). nginx's maintainer (Valentin Bartenev) confirms `access_log` will never grow a `stdout` keyword (perf concerns), so syslog-to-`/dev/log` is the canonical route — it's what NixOS's own nginx module uses by default. Sources: [nginx ngx_http_log_module](https://nginx.org/en/docs/http/ngx_http_log_module.html), [nginx mailing list](https://mailman.nginx.org/pipermail/nginx/2016-February/049899.html), [blog.yuuta.moe](https://blog.yuuta.moe/2024/10/26/nginx-access-log-stderr/), [NixOS discourse](https://discourse.nixos.org/t/nginx-logging-to-journald/2005).

This matters because the Caddy engine is now the default (`#1634`), but **nginx is the deprecated fallback we may revert to** — and it needs to be systemd-clean so a Caddy-regression rollback doesn't reintroduce the footgun.

## Testing

- 10 new unit tests in `test_proxy.py`: `TestStdoutIsReopenable` (pipe / regular-file / socket / fstat-failure) and `TestAccessLogDest` (all three destination branches × headless + full rendered configs, plus the default-env `/dev/stdout` no-regression case).
- `test_proxy.py`: 75/75 green; `proxy.py` at 100% coverage on the new lines.
- Full Python suite (`-n auto`): 3272 passed. The only failures are pre-existing `TestChatFollowUp::*` flakes (timing-window tests using `asyncio.sleep(100)`/`3600`) — they pass in isolation, fail non-deterministically under xdist load, and are wholly outside this diff (chat path, not proxy).
- Pre-commit: markdownlint / prettier / ruff / trufflehog all pass. (Prettier also normalized one pre-existing MD049 asterisk-emphasis violation in the adjacent Caddy changelog entry — collateral from the file already being non-conformant.)

## Acceptance criteria (#1550)

- [x] A plain `systemctl start klangk` (default `StandardOutput=journal`) comes up with nginx serving — no `append:` workaround.
- [x] nginx access/error logs land in the journal under systemd (`syslog:server=unix:/dev/log`; `error_log stderr` already worked).
- [x] Backend unit + e2e suites stay green (renderer change is fd-1-keyed; under pytest fd 1 is a pipe → legacy `/dev/stdout` path unchanged → no e2e regression).
- [ ] #1546's `StandardOutput=append:...` workaround removed from `keithmoon.nix` — that's a host-config file outside this repo; tracked separately.

