### PR TITLE
security: bump pyasn1 0.6.3 → 0.6.4 for CVE-2026-59886 (#1730)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -884,6 +884,15 @@ extra 'all'`** (#1679). The declaration was `typer[all]>=0.12.0`, but the
 
 ### Security
 
+- **Bumped `pyasn1` 0.6.3 → 0.6.4 to fix CVE-2026-59886 / GHSA-hm4w-wwcw-mr6r
+  (#1730, dependabot #4 / #3).** "Uncontrolled resource consumption when
+  converting decoded REAL values" — a denial-of-service via crafted ASN.1
+  REAL values. `pyasn1` is reached at runtime through `python-jose` and
+  `rsa`, both on the JWT/OIDC auth path (`auth.py`, `oidc.py`), i.e. an
+  attacker-reachable surface. It is a purely transitive dependency with no
+  direct pin in `pyproject.toml`, so the lock bump alone closes both
+  dependabot alerts with no code change.
+
 - **Admin seeding is first-boot-only: config can no longer mint or
   reset admins once an admin exists (#1622).** Previously
   `seed_default_user` ran on every boot and created a fresh admin from

--- a/uv.lock
+++ b/uv.lock
@@ -976,11 +976,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Bumps the locked `pyasn1` 0.6.3 → **0.6.4** to fix **CVE-2026-59886 / GHSA-hm4w-wwcw-mr6r** (high) — "uncontrolled resource consumption when converting decoded REAL values". Closes #1730 and the two dependabot alerts [#3](https://github.com/mcdonc/klangk/security/dependabot/3) / [#4](https://github.com/mcdonc/klangk/security/dependabot/4).

## Why this matters (not just a tick-box)

`pyasn1` is **reachable at runtime via the auth path**: it's pulled transitively by `python-jose` and `rsa`, and `python-jose` is imported in `auth.py` / `oidc.py` (JWT + OIDC token validation). The CVE is a DoS via crafted ASN.1 REAL values, so an attacker submitting a crafted JWT/cert that the auth path processes could trigger it. Severity: high.

## What changed

- `uv.lock`: `pyasn1` 0.6.3 → 0.6.4 (minimal diff — 3 lines: the version + new sdist/wheel hashes). Nothing else moved.
- `docs/changes.md`: `### Security` entry under `## [Unreleased]`.

`pyasn1` is purely transitive (no pin in `pyproject.toml`; `python-jose` and `rsa` impose no version constraint), so `uv lock --upgrade-package pyasn1` resolved to 0.6.4 with **no code change** — exactly as scoped in #1730.

## Verification

- Full Python suite (as CI runs it): **3273 passed, 100% coverage** (`-n auto`). The `auth`/`oidc` tests are the relevant smoke for the pyasn1-reachable path and pass with 0.6.4.
- Pre-commit clean (check-toml / markdownlint / prettier / trufflehog all pass).

## Acceptance criteria (#1730)

- [x] `uv.lock` resolves `pyasn1` to 0.6.4 with no chain of upstream bumps.
- [x] Full Python suite green (3273 passed, 100% coverage).
- [ ] Dependabot alerts **#3 and #4** auto-close once this reaches the default branch (GitHub does this automatically when the patched version lands).
- [x] Changelog `### Security` entry referencing CVE-2026-59886.

## Out of scope (flagged in #1730)

The repo has **no `.github/dependabot.yml`**, which is why no auto upgrade PR was opened for this alert. Adding one (ecosystem `uv` on `/`, weekly) is a worthwhile separate follow-up so future advisories land as reviewable PRs instead of silent alerts.

