### PR TITLE
docs(reference): document the GET /api/v1/auth/me endpoint

### DIFF
--- a/docs/reference/api-endpoints.md
+++ b/docs/reference/api-endpoints.md
@@ -256,7 +256,10 @@ No request body.
 
 ### GET `/api/v1/auth/me`
 
-Get the current authenticated user's profile.
+Get the current authenticated user's profile: their `id`, `email`, and
+display `handle`. This resolves the bearer token's identity into a stable
+user record; the frontend calls it to read the current user's identity
+(e.g. the Settings page populates its handle field from the response).
 
 **Auth:** JWT required.
 
@@ -265,6 +268,11 @@ No request body.
 ```json
 { "id": "uuid", "email": "user@example.com", "handle": "myhandle" }
 ```
+
+The response carries identity fields only — it does **not** include
+roles, groups, or per-resource permissions. For those, call
+`GET /api/v1/my-permissions`, which returns the user's groups and their
+effective permissions across resources.
 
 ---
 


### PR DESCRIPTION
## Summary

The `GET /api/v1/auth/me` endpoint (`get_me()` in `api/auth.py`) had only a
minimal one-line entry in `docs/reference/api-endpoints.md` (added by the
`#720` rewrite). This expands it so the endpoint is properly documented.

Closes #1507.

## What changed

Enriched the `/api/v1/auth/me` entry in `docs/reference/api-endpoints.md`:

- States exactly which fields it returns — `id`, `email`, `handle`.
- Notes its frontend consumer (the Settings page reads the current handle from it).
- Clarifies that the response carries **identity fields only** — it does **not**
  include roles, groups, or per-resource permissions, and points to
  `GET /api/v1/my-permissions` for those.

The last point corrects the issue's "id, email, handle, roles, etc." expectation:
the underlying query is `SELECT id, email, handle FROM users`, and the frontend
fetches groups/permissions separately from `/my-permissions` on app load.

Docs-only change. Verified `zensical build` (as CI runs it) succeeds and the
`api-endpoints` page renders; no new broken anchors introduced (the `/my-permissions`
reference is plain text, not a link).
