### PR TITLE
fix(wshandler): whitelist read-only terminal input (#1716)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -884,6 +884,20 @@ extra 'all'`** (#1679). The declaration was `typer[all]>=0.12.0`, but the
 
 ### Security
 
+- **Read-only ("spectate") terminal input is now a strict whitelist of
+  the protocol responses tmux needs to initialize, instead of "any ESC
+  byte" (#1716).** The old gate let a read-only joiner pass any string
+  beginning with `ESC`, so a spectator could inject arbitrary CSI/DCS/OSC
+  sequences into the shared terminal — including **OSC 52 clipboard
+  read/write**, which can exfiltrate or overwrite the owner's clipboard in
+  terminals that support it. Only the terminal-protocol responses tmux's
+  attach handshake needs now pass: DA1/DA2/DA3 device-attribute responses,
+  the DSR cursor-position report, OSC 10/11/12/4 color reports, XTVERSION,
+  and XTGETTCAP; user typing and every other escape sequence (title sets,
+  size queries, DCS/tmux passthrough) is dropped. The size guard also now
+  runs before the whitelist check, so an oversized read-only message is
+  rejected without scanning it.
+
 - **Bumped `pyasn1` 0.6.3 → 0.6.4 to fix CVE-2026-59886 / GHSA-hm4w-wwcw-mr6r
   (#1730, dependabot #4 / #3).** "Uncontrolled resource consumption when
   converting decoded REAL values" — a denial-of-service via crafted ASN.1

--- a/src/klangk/klangk/wshandler/controllers.py
+++ b/src/klangk/klangk/wshandler/controllers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import logging
+import re
 import time
 from typing import TYPE_CHECKING
 
@@ -27,6 +28,86 @@ if TYPE_CHECKING:
     from .session import WorkspaceSession  # noqa: allow-deferred-import
 
 logger = logging.getLogger(__name__)
+
+# Read-only ("spectate") terminal-input whitelist (issue #1716).
+#
+# A read-only joiner may only send the terminal-protocol RESPONSES that
+# tmux needs to complete client initialization: it queries the joining
+# terminal for its capabilities/colors and expects replies.  Anything
+# else — user typing AND arbitrary escape sequences such as OSC 52
+# clipboard read/write, title sets, size reports, or DCS passthrough —
+# is dropped.  The previous gate ("starts with ESC") let any ESC byte
+# through, so a spectator could inject OSC 52 and exfiltrate the
+# owner's clipboard.
+#
+# The whitelist mirrors what the terminal emulators on the read-only
+# path (xterm.js via container_terminal.dart and flterm via
+# ghostty_terminal.dart) actually reply with during tmux's attach
+# handshake: device attributes (DA1/DA2/DA3), cursor-position report,
+# color reports (OSC 10/11/12 default fg/bg/cursor + OSC 4 palette),
+# XTVERSION, and XTGETTCAP.  Each of these reply types is matched with
+# a tight, bounded pattern; OSC 52 (clipboard) and every other OSC/
+# CSI/DCS sequence fall through to the drop.
+#
+# Atomicity assumption: each terminal_input WebSocket message contains
+# one or more WHOLE responses, never a fragment of one.  This holds
+# because the frontend forwards each onOutput/onData callback as a
+# single terminal_input (ws_client.sendTerminalInput) and VT parsers
+# emit a generated response as a complete byte string in one callback.
+# The match below is a fullmatch — a mid-response split across two
+# messages would be dropped.  If a future terminal library ever
+# fragments responses, the fix is a per-connection reassembly buffer
+# here, not loosening the gate.
+#
+# ST (string terminator) is ESC '\\' or BEL ('\x07').
+_ST = r"(?:\x1b\\|\x07)"
+# DA1/DA2/DA3 responses: CSI [?>=] <params> c
+_READ_ONLY_DA = r"\x1b\[[?>=][\d;]*c"
+# DSR cursor-position report: CSI <row> ; <col> R
+_READ_ONLY_DSR_CURSOR = r"\x1b\[\d+;\d+R"
+# OSC color reports (default fg/bg/cursor via 10/11/12, palette via 4;<n>).
+# The value may be an X11 `rgb:R/G/B` (1-4 hex/channel), an xterm-style
+# `#rrggbb`/`#rrrrggggbbbb`, or an intensity `rgbi:r/g/b`.
+_READ_ONLY_COLOR_VALUE = (
+    r"rgb:[0-9A-Fa-f]{1,4}/[0-9A-Fa-f]{1,4}/[0-9A-Fa-f]{1,4}"
+    r"|#[0-9A-Fa-f]{6}(?:[0-9A-Fa-f]{6})?"
+    r"|rgbi:\d+(?:\.\d+)?/\d+(?:\.\d+)?/\d+(?:\.\d+)?"
+)
+_READ_ONLY_OSC_COLOR = (
+    r"\x1b\](?:4;\d+|10|11|12);(?:" + _READ_ONLY_COLOR_VALUE + r")" + _ST
+)
+# XTVERSION response: DCS > | <name SP version> ST (printable payload
+# only — no nested escape possible since ESC is excluded).
+_READ_ONLY_XTVERSION = r"\x1bP>\|[\x20-\x7e]*" + _ST
+# XTGETTCAP response: DCS (0|1) + r <hex>=<hex>(;<hex>=<hex>)* ST.
+# 1+r is success, 0+r is failure; payload is hex + '=' + ';'.
+_READ_ONLY_XTGETTCAP = r"\x1bP[01]\+r[0-9A-Fa-f=;]*" + _ST
+_READ_ONLY_INPUT = re.compile(
+    r"(?:"
+    + r"|".join(
+        (
+            _READ_ONLY_DA,
+            _READ_ONLY_DSR_CURSOR,
+            _READ_ONLY_OSC_COLOR,
+            _READ_ONLY_XTVERSION,
+            _READ_ONLY_XTGETTCAP,
+        )
+    )
+    + r")+"
+)
+
+
+def _is_allowed_read_only_input(data: str) -> bool:
+    """True only for the terminal-protocol responses a read-only client
+    may legitimately send during tmux initialization.
+
+    Strict whitelist (issue #1716): user input and arbitrary escape
+    sequences — notably OSC 52 clipboard read/write — are rejected.
+    The whole payload must be one or more whitelisted responses; any
+    extra byte (typed text, a different OSC/CSI/DCS) fails the match
+    and the message is dropped.
+    """
+    return _READ_ONLY_INPUT.fullmatch(data) is not None
 
 
 class SshAgentForwarder:
@@ -617,16 +698,17 @@ class TerminalController:
             logger.warning("terminal_input: no session or not alive")
             return
         data = msg.get("data", "")
-        if session.read_only:
-            # Allow terminal protocol responses (DA queries, color
-            # reports) through so tmux can complete initialization.
-            # Block user-typed input.
-            if not data.startswith("\x1b"):
-                return
         if len(data) > MAX_INPUT_SIZE:
             logger.warning(
                 "terminal_input too large (%d bytes), dropping", len(data)
             )
+            return
+        if session.read_only and not _is_allowed_read_only_input(data):
+            # Read-only spectators may only send the terminal-protocol
+            # responses tmux needs to complete initialization (DA,
+            # color, cursor-position, XTVERSION, XTGETTCAP reports).
+            # User typing and arbitrary escape sequences — notably OSC
+            # 52 clipboard read/write — are dropped (#1716).
             return
         self._conn.app.state.container_registry.record_activity(
             self._conn.container_id

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -496,6 +496,82 @@ class TestSendError:
 # --- handle_steer ---
 
 
+class TestReadOnlyInputWhitelist:
+    """Direct coverage for the read-only terminal-input whitelist (#1716).
+
+    Only terminal-protocol RESPONSES tmux needs to initialize may pass;
+    user typing and arbitrary escape sequences (notably OSC 52) are
+    dropped.
+    """
+
+    @pytest.mark.parametrize(
+        "data",
+        [
+            # DA1/DA2/DA3 device-attribute responses.
+            "\x1b[?6c",
+            "\x1b[?1;2c",
+            "\x1b[?64;1;2;4;6;9;15;16;17;18;21;22c",
+            "\x1b[>41;0;33c",
+            "\x1b[=123c",
+            # DSR cursor-position report.
+            "\x1b[1;1R",
+            "\x1b[24;80R",
+            # OSC color reports (palette + default fg/bg/cursor),
+            # terminated by either BEL or ESC '\'.
+            "\x1b]11;rgb:0000/0000/0000\x07",
+            "\x1b]10;rgb:aaaa/bbbb/cccc\x1b\\",
+            "\x1b]12;rgb:ff/ff/ff\x07",
+            "\x1b]4;0;rgb:00/00/00\x1b\\",
+            # OSC color value forms beyond rgb: (#rrggbb / rgbi:).
+            "\x1b]11;#ff00ff\x07",
+            "\x1b]11;#aabbccddeeff\x1b\\",
+            "\x1b]11;rgbi:255/0/255\x07",
+            "\x1b]11;rgbi:0.5/0.0/1.0\x07",
+            # XTVERSION response: DCS > | <name SP version> ST.
+            "\x1bP>|xterm.js 5.5.0\x1b\\",
+            "\x1bP>|tmux 3.4\x07",
+            # XTGETTCAP response: DCS (0|1) + r <hex>=<hex> ST.
+            "\x1bP1+r5443=787465726d\x1b\\",
+            "\x1bP0+r\x1b\\",  # capability-not-found failure reply
+            # Multiple responses batched in one message.
+            "\x1b[?6c\x1b]11;rgb:0000/0000/0000\x07",
+            "\x1b[?6c\x1bP>|xterm.js 5.5.0\x1b\\",
+        ],
+    )
+    def test_allows_init_responses(self, data):
+        assert _ws_controllers._is_allowed_read_only_input(data)
+
+    @pytest.mark.parametrize(
+        "data",
+        [
+            # User typing.
+            "ls",
+            "",
+            # OSC 52 clipboard read/write — the headline threat.
+            "\x1b]52;c;Zm9v\x07",  # write
+            "\x1b]52;c;?\x07",  # read
+            # Other OSC: title set, color reset.
+            "\x1b]0;title\x07",
+            "\x1b]104\x07",
+            # CSI queries / commands (not responses).
+            "\x1b[18t",  # report terminal size
+            "\x1b[19t",
+            "\x1b[6n",  # DSR cursor query
+            "\x1b[2J",  # clear screen
+            "\x1b[H",  # cursor home
+            "\x1b[c",  # bare DA query
+            # DCS passthrough (arbitrary tmux commands).
+            "\x1bPtmux;evil\x1b\\",
+            # Smuggling: text or OSC 52 around a valid response.
+            "ls\x1b[?6c",
+            "\x1b[?6cls",
+            "\x1b[?6c\x1b]52;c;Zm9v\x07",
+        ],
+    )
+    def test_blocks_everything_else(self, data):
+        assert not _ws_controllers._is_allowed_read_only_input(data)
+
+
 class TestHandleTerminalInput:
     async def test_writes_data(self, app_state):
         app_state = _make_app_state()
@@ -550,6 +626,25 @@ class TestHandleTerminalInput:
         # DA response: ESC [ ? 6 c
         await conn.handle_terminal_input({"data": "\x1b[?6c"})
         t.write.assert_awaited_once_with("\x1b[?6c")
+        registry.states.pop("ws", None)
+
+    async def test_read_only_blocks_osc52_clipboard(self, app_state):
+        """OSC 52 clipboard read/write is dropped for spectators (#1716)."""
+        app_state = _make_app_state()
+        registry = app_state.state.container_registry
+        t = _mock_terminal()
+        t.read_only = True
+        conn = _base_conn(app_state=app_state)
+        conn.terminal_session = t
+        conn.container_id = "cid"
+        registry.track_activity("cid", "ws")
+
+        for data in (
+            "\x1b]52;c;Zm9v\x07",  # clipboard write
+            "\x1b]52;c;?\x07",  # clipboard read
+        ):
+            await conn.handle_terminal_input({"data": data})
+        t.write.assert_not_awaited()
         registry.states.pop("ws", None)
 
     async def test_oversized_input_dropped(self, app_state):
@@ -5636,7 +5731,8 @@ class TestTerminalController:
         await ctrl.input({"data": "ls"})
         session.write.assert_not_awaited()
 
-    async def test_input_read_only_allows_escape_sequences(self, app_state):
+    async def test_input_read_only_allows_da_response(self, app_state):
+        """DA1/DA2/DA3 device-attribute responses pass (#1716)."""
         app_state = _make_app_state()
         registry = app_state.state.container_registry
         ctrl, _, _ = self._controller(app_state=app_state)
@@ -5645,8 +5741,83 @@ class TestTerminalController:
         session.read_only = True
         ctrl.session = session
         with patch.object(registry, "record_activity"):
-            await ctrl.input({"data": "\x1b[6n"})
-        session.write.assert_awaited_once_with("\x1b[6n")
+            await ctrl.input({"data": "\x1b[?1;2c"})
+        session.write.assert_awaited_once_with("\x1b[?1;2c")
+
+    async def test_input_read_only_allows_color_report(self):
+        """OSC 10/11/12/4 color reports pass; ST may be BEL or ESC \\\
+        (#1716)."""
+        ctrl, _, _ = self._controller()
+        session = AsyncMock()
+        session.is_alive = True
+        session.read_only = True
+        ctrl.session = session
+        for data in (
+            "\x1b]11;rgb:0000/0000/0000\x07",
+            "\x1b]10;rgb:aaaa/bbbb/cccc\x1b\\",
+            "\x1b]4;0;rgb:ff/00/00\x07",
+            # Color value forms beyond rgb: (#rrggbb / rgbi:).
+            "\x1b]11;#ff00ff\x07",
+            "\x1b]11;#aabbccddeeff\x1b\\",
+            "\x1b]11;rgbi:255/0/255\x07",
+        ):
+            session.write.reset_mock()
+            await ctrl.input({"data": data})
+            session.write.assert_awaited_once_with(data)
+
+    async def test_input_read_only_allows_dcs_capability_reports(self):
+        """XTVERSION and XTGETTCAP responses pass (#1716)."""
+        ctrl, _, _ = self._controller()
+        session = AsyncMock()
+        session.is_alive = True
+        session.read_only = True
+        ctrl.session = session
+        for data in (
+            "\x1bP>|xterm.js 5.5.0\x1b\\",  # XTVERSION
+            "\x1bP>|tmux 3.4\x07",
+            "\x1bP1+r5443=787465726d\x1b\\",  # XTGETTCAP success
+            "\x1bP0+r\x1b\\",  # XTGETTCAP not-found
+        ):
+            session.write.reset_mock()
+            await ctrl.input({"data": data})
+            session.write.assert_awaited_once_with(data)
+
+    async def test_input_read_only_blocks_osc52_clipboard(self):
+        """OSC 52 clipboard read/write is dropped for spectators (#1716)."""
+        ctrl, _, _ = self._controller()
+        session = AsyncMock()
+        session.is_alive = True
+        session.read_only = True
+        ctrl.session = session
+        for data in (
+            "\x1b]52;c;Zm9v\x07",  # clipboard write (base64 "foo")
+            "\x1b]52;c;?\x07",  # clipboard read
+        ):
+            session.write.reset_mock()
+            await ctrl.input({"data": data})
+            session.write.assert_not_awaited()
+
+    async def test_input_read_only_blocks_arbitrary_escapes(self):
+        """Title sets, size reports, clear, DSR query, DCS passthrough
+        are all dropped (#1716)."""
+        ctrl, _, _ = self._controller()
+        session = AsyncMock()
+        session.is_alive = True
+        session.read_only = True
+        ctrl.session = session
+        for data in (
+            "\x1b]0;title\x07",  # OSC 0 title set
+            "\x1b[18t",  # report terminal size
+            "\x1b[2J",  # clear screen
+            "\x1b[6n",  # DSR cursor query (not a response)
+            "\x1bPtmux;evil\x1b\\",  # DCS tmux passthrough
+            "\x1b[c",  # bare DA query
+            "ls\x1b[?6c",  # text smuggled before a valid response
+            "\x1b[?6c\x1b]52;c;Zm9v\x07",  # OSC 52 chained after DA
+        ):
+            session.write.reset_mock()
+            await ctrl.input({"data": data})
+            session.write.assert_not_awaited()
 
     async def test_input_oversized_dropped(self):
         ctrl, _, _ = self._controller()
@@ -5655,6 +5826,24 @@ class TestTerminalController:
         session.read_only = False
         ctrl.session = session
         await ctrl.input({"data": "x" * (_ws_constants.MAX_INPUT_SIZE + 1)})
+        session.write.assert_not_awaited()
+
+    async def test_input_oversized_read_only_dropped_before_regex(self):
+        """Oversized read-only input hits the size guard before the
+        whitelist regex (#1716) — the cheap O(1) check protects the
+        linear scan, restoring the prior cost profile."""
+        ctrl, _, _ = self._controller()
+        session = AsyncMock()
+        session.is_alive = True
+        session.read_only = True
+        ctrl.session = session
+        big = "\x1b[?6c" + "x" * (_ws_constants.MAX_INPUT_SIZE + 1)
+        with patch(
+            "klangk.wshandler.controllers._is_allowed_read_only_input"
+        ) as allow:
+            await ctrl.input({"data": big})
+        # Size guard returned early, so the whitelist was never consulted.
+        allow.assert_not_called()
         session.write.assert_not_awaited()
 
     async def test_input_writes_and_records_activity(self, app_state):


### PR DESCRIPTION
## Summary

Fixes #1716.

Read-only ("spectate") terminal enforcement let through **any** input that began with an ESC byte, not just the terminal-protocol replies (DA queries, color reports) the code intended to allow. A read-only joiner could therefore inject arbitrary CSI/DCS/**OSC** sequences into the shared terminal — including **OSC 52 clipboard read/write**, which can exfiltrate or overwrite the owner's clipboard in terminals that support it (tmux forwards OSC 52 by default in many configs).

The previous gate at `TerminalController.input`:

```python
if session.read_only:
    if not data.startswith("\x1b"):
        return
```

accepted any string beginning with `ESC`, so a spectator could send `\x1b]52;c;?\x07` to read the owner's clipboard, `\x1b]52;c;<base64>\x07` to overwrite it, plus title sets (`\x1b]0;…`), size queries (`\x1b[18t`), and DCS/tmux passthrough (`\x1bP…\x1b\\`).

## Fix

Replaced the "starts with ESC" gate with a strict whitelist regex (`_READ_ONLY_INPUT`) + `_is_allowed_read_only_input()`. A read-only payload must be **one or more** of the exact protocol responses tmux needs to complete client initialization:

- **DA1 / DA2 / DA3** device-attribute responses — `ESC [ ?|>|= <params> c`
- **DSR cursor-position report** — `ESC [ <row> ; <col> R`
- **OSC color reports** — `OSC (10|11|12|4;<n>) ; rgb:<hex>/<hex>/<hex> ST` (ST = `ESC\` or BEL)

The match is a **fullmatch**, so any extra byte fails the whole message — smuggling text before a valid response (`ls\x1b[?6c`) or chaining OSC 52 after a valid DA (`\x1b[?6c\x1b]52;c;…`) is rejected. Multiple legitimate responses batched in one message (`\x1b[?6c\x1b]11;rgb:…\x07`) still pass.

## Tests

- New parametrized `TestReadOnlyInputWhitelist` (24 cases) directly exercising `_is_allowed_read_only_input` — allow-list (DA1/DA2/DA3, DSR cursor, OSC color reports with both ST forms, multiple batched) and block-list (user typing, OSC 52 read/write, title set, `OSC 104`, size queries, DSR query, clear, cursor home, bare DA query, DCS passthrough, and three smuggling cases).
- New Connection-level `test_read_only_blocks_osc52_clipboard`.
- Updated `TestTerminalController.test_input_read_only_allows_escape_sequences` (which previously asserted the DSR *query* `\x1b[6n` passed) to `test_input_read_only_allows_da_response` using a real DA1 response, plus new controller tests for color reports passing and arbitrary escapes / OSC 52 / smuggling being dropped.

Full suite: `3305 passed`, 100% coverage.

## Changelog

Added a **Security** entry under `[Unreleased]`.

## Security impact

Closes the OSC 52 clipboard exfiltration / overwrite vector and the broader class of "spectator can inject arbitrary escape sequences the owner's terminal may interpret" in a terminal the code claimed was read-only.
