### PR TITLE
fix(e2e): keep egress port distinct from ingress port

### DIFF
--- a/src/klangk/klangkd-tests/e2e-tests/_e2e_server.py
+++ b/src/klangk/klangkd-tests/e2e-tests/_e2e_server.py
@@ -188,7 +188,15 @@ def start_server(
         if tcp_port is None:
             tcp_port = str(free_port())
             overrides["KLANGK_PORT"] = tcp_port
-        overrides.setdefault("KLANGK_EGRESS_PORT", str(free_port()))
+        # Two independent free_port() draws can return the same port on a
+        # busy runner (the OS reuses the just-released ephemeral port).
+        # KLANGK_EGRESS_PORT must differ from KLANGK_PORT or the settings
+        # validator rejects it and klangkd exits early — redraw until
+        # distinct so the proxy's two listeners never collide.
+        egress_port = str(free_port())
+        while egress_port == tcp_port:
+            egress_port = str(free_port())
+        overrides.setdefault("KLANGK_EGRESS_PORT", egress_port)
         uds_path = None
         url = f"http://localhost:{tcp_port}"
 


### PR DESCRIPTION
## Summary

Fixes a flaky E2E harness bug that surfaced as a CI failure on an unrelated PR (#1735, the read-only terminal whitelist). Cherry-picked out of that PR so the security fix stays focused.

## Problem

The shared `_e2e_server.start_server` (used by both the backend and CLI E2E suites) drew `KLANGK_PORT` and `KLANGK_EGRESS_PORT` via two independent `free_port()` calls. Each call binds `127.0.0.1:0`, releases, and returns the number — so on a busy CI runner the OS can hand the second draw the **same ephemeral port** it just freed from the first.

When the two collide, `KlangkSettings` rejects it (`KLANGK_EGRESS_PORT must differ from KLANGK_PORT ... the proxy cannot bind two server blocks to the same port`), `klangkd` exits early, and every E2E test in the run errors out:

```
ValidationError: KLANGK_EGRESS_PORT ('33245') must differ from KLANGK_PORT ('33245')
RuntimeError: klangkd exited early
============ 52 passed, 1 skipped, 10 errors in 161.03s ============
```

Observed on PR #1735's `test-cli-e2e` job (both draws returned `33245`).

## Fix

Redraw the egress port until it differs from the ingress port, so the proxy's two listeners never collide:

```python
egress_port = str(free_port())
while egress_port == tcp_port:
    egress_port = str(free_port())
overrides.setdefault("KLANGK_EGRESS_PORT", egress_port)
```

The `free_port()` TOCTOU window with other processes still exists (documented in the helper), but this closes the self-inflicted collision where the harness hands the server two identical ports.

## Scope

Test-harness only (`_e2e_server.py`); not under the `--cov=klangk` coverage gate. No user-visible change, so no changelog entry. Backend + CLI unit suites: `3316 passed`, 100% coverage.
