### PR TITLE
Per-workspace network egress filtering via OCI hooks (#1365)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,13 +2,13 @@
 
 Project-specific guidance for coding agents working in this repo.
 
-## Prefix most commands with `devenv --quiet -O dotenv.enable:bool false shell --`
+## Prefix most commands with `devenv --quiet shell --`
 
 Klangk uses [devenv](https://devenv.sh) (Nix-based) for its dev environment. **Every command that touches the project toolchain must be run through the devenv shell**, including git. The toolchain — Python venv, Node, Dart/Flutter, podman, pre-commit hooks, etc. — only exists inside the shell.
 
 ```bash
-devenv --quiet -O dotenv.enable:bool false shell -- git commit -m "..."
-devenv --quiet -O dotenv.enable:bool false shell -- pytest
+devenv --quiet -- git commit -m "..."
+devenv --quiet -- pytest
 ```
 
 The flags: `--quiet` suppresses noisy devenv output; `-O dotenv.enable:bool false` prevents devenv from loading `.env` (which can interfere with test environments that set their own env vars via monkeypatch). `shell --` launches an ephemeral shell with the full environment, runs the command, and exits — this is the pattern agents should use for one-off commands. (`devenv shell` with no `--` drops into an interactive shell; not useful for non-interactive agents.) This applies to **all** commands: builds, tests, lint, `git`, `podman`, `flutter`, `gh`.

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -63,16 +63,19 @@ operators or integrators to act when upgrading.
 - **Per-workspace network egress filtering via OCI hooks (#1365).**
   Workspaces may now declare an `allowed_domains` allow-list (`host` or
   `host:port` specs) to restrict outbound network to specific destinations.
-  When the deployer sets `KLANGKD_NETFILTER_HOOKS_DIR`, the backend injects
-  an OCI `createContainer` hook that installs a default-deny iptables
-  ruleset in the workspace's network namespace (allowing loopback, DNS, the
-  backend gateway, and the listed destinations) before the container
-  process starts — no proxy, no TLS interception, no microVM. Workspaces
-  without `allowed_domains` keep unrestricted networking exactly as before;
-  if a workspace declares a list but netfilter isn't enabled, it starts
-  unrestricted with a loud operator warning (fail-open). Configurable via
-  the workspace Settings panel or the `allowed_domains` field on the
-  workspace create/update API. See
+  Netfilter is armed by default: the backend injects an OCI `createContainer`
+  hook (materialized into `<state_dir>/oci-hooks` at startup) that installs a
+  default-deny iptables ruleset in the workspace's network namespace
+  (allowing loopback, DNS, the backend gateway, and the listed destinations)
+  before the container process starts — no proxy, no TLS interception, no
+  microVM. The hooks dir defaults to `<state_dir>/oci-hooks`; override
+  `KLANGKD_NETFILTER_HOOKS_DIR` for a split runtime, or disable entirely with
+  `KLANGKD_NETFILTER_ENABLED=false` (#1774). Workspaces without
+  `allowed_domains` keep unrestricted networking exactly as before; if a
+  workspace declares a list but netfilter isn't armed, it starts unrestricted
+  with a loud warning surfaced to the user who set it (fail-open, #1769).
+  Configurable via the workspace Settings panel or the `allowed_domains`
+  field on the workspace create/update API. See
   [Egress Filtering](https://klangk.dev/features/egress-filtering).
 
 - **The `features_config:` block now accepts the stripped, lowercased key form

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -60,6 +60,21 @@ operators or integrators to act when upgrading.
   reported rather than silently emptying the list. Selecting a terminal is wired for a future `klangk shell`
   step. The workspace-list page is now titled "Klangk: Workspaces".
 
+- **Per-workspace network egress filtering via OCI hooks (#1365).**
+  Workspaces may now declare an `allowed_domains` allow-list (`host` or
+  `host:port` specs) to restrict outbound network to specific destinations.
+  When the deployer sets `KLANGKD_NETFILTER_HOOKS_DIR`, the backend injects
+  an OCI `createContainer` hook that installs a default-deny iptables
+  ruleset in the workspace's network namespace (allowing loopback, DNS, the
+  backend gateway, and the listed destinations) before the container
+  process starts — no proxy, no TLS interception, no microVM. Workspaces
+  without `allowed_domains` keep unrestricted networking exactly as before;
+  if a workspace declares a list but netfilter isn't enabled, it starts
+  unrestricted with a loud operator warning (fail-open). Configurable via
+  the workspace Settings panel or the `allowed_domains` field on the
+  workspace create/update API. See
+  [Egress Filtering](https://klangk.dev/features/egress-filtering).
+
 - **The `features_config:` block now accepts the stripped, lowercased key form
   (`soliplex_url`) in addition to the full declared name
   (`KLANGKWS_FEATURE_SOLIPLEX_URL`) (#1737).** The short form matches the key the

--- a/docs/features/egress-filtering.md
+++ b/docs/features/egress-filtering.md
@@ -24,8 +24,10 @@ starts.
    ruleset in the container's network namespace (via `nsenter` on the init
    pid).
 4. The default `OUTPUT` policy is `DROP`; loopback, established
-   connections, DNS (udp/tcp 53), the backend gateway
-   (`host.containers.internal`), and the resolved allowed destinations are
+   connections, **DNS to the container's configured resolvers only**
+   (read from its `/etc/resolv.conf`, not a blanket `udp/tcp 53` allow),
+   the backend gateway (`host.containers.internal`, resolved from the
+   container's `/etc/hosts`), and the resolved allowed destinations are
    `ACCEPT`ed. Everything else is dropped.
 
 The hook runs **before** the container process starts, so the ruleset is in
@@ -73,8 +75,11 @@ curl -X PUT https://klangkd/api/v1/workspaces/<id> \
 - `host:port` allows a single TCP port.
 - Each entry is validated server-side; malformed entries are rejected with
   HTTP 400.
-- An empty list (or `null`) means **unrestricted** — the workspace is never
-  filtered.
+- An empty list (or `null`) **inherits the deploy-wide default**
+  (`KLANGKD_NETFILTER_DEFAULT_DOMAINS`); if no default is configured, the
+  workspace is **unrestricted**. There is currently no per-workspace opt-out
+  into truly-unrestricted egress when a deploy default is set — clear the
+  default server-side to permit unrestricted workspaces.
 
 A restart of the workspace container applies the change to a running
 workspace (the ruleset is set at create time).
@@ -97,6 +102,13 @@ unusable, but the warning makes the gap visible.
   Mitigation: allow a port without pinning a host, or allow a CIDR
   range (a possible future enhancement; the initial implementation is
   `host`/`host:port` only).
+- **DNS is pinned to resolvers, not blocked entirely.** Outbound `:53` is
+  accepted only to the nameservers in the container's `/etc/resolv.conf`,
+  so a workspace cannot talk to an arbitrary host on port 53. This does
+  **not** prevent DNS tunneling through those permitted resolvers to
+  attacker-controlled domains (data can still be encoded in DNS queries).
+  Treat the filter as an egress allow-list, not a complete anti-exfiltration
+  guarantee against DNS-based channels.
 - **Port granularity.** The initial implementation supports `host` and
   `host:port`. CIDR ranges and port-only rules may follow.
 - **`macOS` hosts.** The `createContainer` hook runs inside the

--- a/docs/features/egress-filtering.md
+++ b/docs/features/egress-filtering.md
@@ -83,7 +83,7 @@ curl -X PUT https://klangkd/api/v1/workspaces/<id> \
 ```
 
 - `host` allows all ports to that host.
-- `host:port` allows a single TCP port.
+- `host:port` allows a single TCP port (port must be 1–65535).
 - Each entry is validated server-side; malformed entries are rejected with
   HTTP 400.
 - An empty list (or `null`) **inherits the deploy-wide default**

--- a/docs/features/egress-filtering.md
+++ b/docs/features/egress-filtering.md
@@ -37,20 +37,23 @@ by the runtime before the container entrypoint executes.
 
 ## Enabling it (operator)
 
+Netfilter is **armed by default**. At startup klangkd materializes the hook
+script (`klangk-netfilter.sh`) and its config (`klangk-netfilter.json`)
+into a hooks directory and registers the OCI `createContainer` hook — no
+configuration is required for the common case.
+
 1. Ensure `iptables`, `getent`, and `nsenter` are available where the OCI
    runtime executes (the host, or the Docker-in-Docker outer container —
    _not_ the workspace image). The documented DinD deployment already has
    `CAP_SYS_ADMIN` + `seccomp=unconfined`, which provides the necessary
    privileges.
-2. Set `KLANGKD_NETFILTER_HOOKS_DIR` to a directory the OCI runtime can
-   read. At startup klangkd writes the hook script (`klangk-netfilter.sh`)
-   and its config (`klangk-netfilter.json`) into that directory, so it just
-   needs to exist (or be creatable). The path must be resolvable where the
-   runtime executes — for the DinD / bare-Linux deployments this is any
-   host path; for `podman machine` on macOS it must be inside the CoreOS VM
-   (install into the VM or bake into a custom machine image), since
-   `podman machine` does not bind-mount arbitrary host paths the way Docker
-   Desktop does.
+2. The hooks dir defaults to `<state_dir>/oci-hooks`
+   (`KLANGKD_STATE_DIR`/`oci-hooks`). Override
+   `KLANGKD_NETFILTER_HOOKS_DIR` only when the OCI runtime can't see
+   `state_dir` — a split runtime, a DinD outer container, or a
+   `podman machine` CoreOS VM (where it must be inside the VM, since
+   `podman machine` does not bind-mount arbitrary host paths the way
+   Docker Desktop does):
 
    ```bash
    export KLANGKD_NETFILTER_HOOKS_DIR=/var/lib/klangk/netfilter-hooks
@@ -58,6 +61,13 @@ by the runtime before the container entrypoint executes.
 
 3. Restart klangkd. The log shows
    `Netfilter egress filtering enabled: OCI hooks installed in <dir>`.
+
+To **disable** netfilter entirely (e.g. an environment without
+`iptables`/`nsenter`, or where the hook can't be granted `CAP_NET_ADMIN`),
+set `KLANGKD_NETFILTER_ENABLED=false` (or YAML `netfilter_enabled: false`).
+When disabled, `enabled()` reports false, `--hooks-dir` is never passed,
+and workspaces with `allowed_domains` fail open with a loud warning
+(#1769). (#1774)
 
 ## Configuring a workspace
 
@@ -87,13 +97,16 @@ workspace (the ruleset is set at create time).
 
 ## Fail-open behavior
 
-If a workspace declares `allowed_domains` but netfilter is **not** enabled
-on the server (`KLANGKD_NETFILTER_HOOKS_DIR` unset or unwritable), the
-workspace starts **unrestricted** and the server logs a loud warning. The
+If a workspace declares `allowed_domains` but netfilter is **not armed**
+on the server — disabled via `KLANGKD_NETFILTER_ENABLED=false`, the hooks
+dir unwritable, or the hook not installed/current (#1771) — the workspace
+starts **unrestricted** and the server logs a loud warning. The
 `allowed_domains` value is still persisted, so it takes effect the moment
-the operator enables netfilter. This is deliberate: a misconfigured deploy
-degrades to the unrestricted baseline rather than making workspaces
-unusable, but the warning makes the gap visible.
+netfilter is armed. The workspace's Settings panel and list row also badge
+the gap (#1769), so the user who set the list sees it — not just operator
+logs. This is deliberate: a misconfigured deploy degrades to the
+unrestricted baseline rather than making workspaces unusable, but the
+warning makes the gap visible.
 
 ## Caveats
 

--- a/docs/features/egress-filtering.md
+++ b/docs/features/egress-filtering.md
@@ -109,6 +109,16 @@ unusable, but the warning makes the gap visible.
   attacker-controlled domains (data can still be encoded in DNS queries).
   Treat the filter as an egress allow-list, not a complete anti-exfiltration
   guarantee against DNS-based channels.
+- **Ruleset immutability depends on the runtime capability set.** The
+  hook installs the iptables rules before the container entrypoint starts,
+  and a filtered workspace also has `NET_ADMIN` dropped explicitly
+  (`--cap-drop NET_ADMIN`). `NET_ADMIN` is already absent from podman's
+  default capability set, so this is a no-op under defaults and defense
+  in depth against an operator override. It is **not** a hard guarantee:
+  running the workspace `--privileged`, adding `--cap-add NET_ADMIN`, or a
+  permissive seccomp profile hands the entrypoint `iptables -F OUTPUT`,
+  which flushes the ruleset and lets it exfiltrate freely. Do not run
+  filtered workspaces privileged or grant `NET_ADMIN`.
 - **Port granularity.** The initial implementation supports `host` and
   `host:port`. CIDR ranges and port-only rules may follow.
 - **`macOS` hosts.** The `createContainer` hook runs inside the

--- a/docs/features/egress-filtering.md
+++ b/docs/features/egress-filtering.md
@@ -1,0 +1,117 @@
+# Per-workspace network egress filtering
+
+Klangk can restrict which external hosts a workspace container may reach,
+so a deployment running AI agents or untrusted code isn't an open
+exfiltration vector. The filter is **opt-in** per workspace _and_ per
+deploy: a workspace with no `allowed_domains` keeps unrestricted outbound
+networking exactly as before.
+
+The mechanism uses OCI `createContainer` hooks — there is no proxy, no TLS
+interception, and no microVM. Each workspace that declares an allow-list
+gets iptables rules injected into its network namespace before its process
+starts.
+
+## How it works
+
+1. A workspace carries an `allowed_domains` list (`host` or `host:port`
+   specs).
+2. On container start, if the deploy has enabled netfilter, the backend
+   passes `--annotation klangk.netfilter.rules=<host:port,...>` and
+   `--hooks-dir <dir>` to `podman create`.
+3. The OCI hook (`klangk-netfilter.sh`, materialized by the backend into the
+   hooks dir) fires at `createContainer` time, reads the annotation from the
+   container state, resolves each host to IPs, and installs an iptables
+   ruleset in the container's network namespace (via `nsenter` on the init
+   pid).
+4. The default `OUTPUT` policy is `DROP`; loopback, established
+   connections, DNS (udp/tcp 53), the backend gateway
+   (`host.containers.internal`), and the resolved allowed destinations are
+   `ACCEPT`ed. Everything else is dropped.
+
+The hook runs **before** the container process starts, so the ruleset is in
+place and immutable before any user code runs — `CAP_NET_ADMIN` is dropped
+by the runtime before the container entrypoint executes.
+
+## Enabling it (operator)
+
+1. Ensure `iptables`, `getent`, and `nsenter` are available where the OCI
+   runtime executes (the host, or the Docker-in-Docker outer container —
+   _not_ the workspace image). The documented DinD deployment already has
+   `CAP_SYS_ADMIN` + `seccomp=unconfined`, which provides the necessary
+   privileges.
+2. Set `KLANGKD_NETFILTER_HOOKS_DIR` to a directory the OCI runtime can
+   read. At startup klangkd writes the hook script (`klangk-netfilter.sh`)
+   and its config (`klangk-netfilter.json`) into that directory, so it just
+   needs to exist (or be creatable). The path must be resolvable where the
+   runtime executes — for the DinD / bare-Linux deployments this is any
+   host path; for `podman machine` on macOS it must be inside the CoreOS VM
+   (install into the VM or bake into a custom machine image), since
+   `podman machine` does not bind-mount arbitrary host paths the way Docker
+   Desktop does.
+
+   ```bash
+   export KLANGKD_NETFILTER_HOOKS_DIR=/var/lib/klangk/netfilter-hooks
+   ```
+
+3. Restart klangkd. The log shows
+   `Netfilter egress filtering enabled: OCI hooks installed in <dir>`.
+
+## Configuring a workspace
+
+Set `allowed_domains` via the workspace **Settings** panel (an
+"Allowed Domains" list editor under Mounts / Environment Variables) or the
+API:
+
+```bash
+curl -X PUT https://klangkd/api/v1/workspaces/<id> \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"allowed_domains": ["github.com:443", "pypi.org", "registry.npmjs.org"]}'
+```
+
+- `host` allows all ports to that host.
+- `host:port` allows a single TCP port.
+- Each entry is validated server-side; malformed entries are rejected with
+  HTTP 400.
+- An empty list (or `null`) means **unrestricted** — the workspace is never
+  filtered.
+
+A restart of the workspace container applies the change to a running
+workspace (the ruleset is set at create time).
+
+## Fail-open behavior
+
+If a workspace declares `allowed_domains` but netfilter is **not** enabled
+on the server (`KLANGKD_NETFILTER_HOOKS_DIR` unset or unwritable), the
+workspace starts **unrestricted** and the server logs a loud warning. The
+`allowed_domains` value is still persisted, so it takes effect the moment
+the operator enables netfilter. This is deliberate: a misconfigured deploy
+degrades to the unrestricted baseline rather than making workspaces
+unusable, but the warning makes the gap visible.
+
+## Caveats
+
+- **DNS resolution at creation time.** iptables matches IPs, so hostnames
+  are resolved when the container is created. If a service rotates IPs
+  (common with CDNs), access may break until the workspace is restarted.
+  Mitigation: allow a port without pinning a host, or allow a CIDR
+  range (a possible future enhancement; the initial implementation is
+  `host`/`host:port` only).
+- **Port granularity.** The initial implementation supports `host` and
+  `host:port`. CIDR ranges and port-only rules may follow.
+- **`macOS` hosts.** The `createContainer` hook runs inside the
+  container's Linux network namespace, never the macOS (XNU) kernel, so
+  `iptables` availability is not host-dependent. For the DinD deployment
+  there is no macOS-specific concern. For a native-on-mac deployment
+  driving `podman machine`, ensure the `--hooks-dir` path and
+  `klangk-netfilter.sh` are resolvable from inside the CoreOS VM.
+
+## References
+
+- [Podman maintainer discussion on OCI hooks for iptables][podman-disc]
+- [Working OCI hooks + iptables implementation][jerabaul29]
+- [OCI runtime spec — hooks][oci-hooks]
+
+[podman-disc]: https://github.com/containers/podman/discussions/27099
+[jerabaul29]: https://github.com/jerabaul29/2025_podman_iptable_rules
+[oci-hooks]: https://github.com/opencontainers/runtime-spec/blob/main/config.md#posix-platform-hooks

--- a/docs/features/egress-filtering.md
+++ b/docs/features/egress-filtering.md
@@ -17,7 +17,8 @@ starts.
    specs).
 2. On container start, if the deploy has enabled netfilter, the backend
    passes `--annotation klangk.netfilter.rules=<host:port,...>` and
-   `--hooks-dir <dir>` to `podman create`.
+   `--hooks-dir <dir>` to `podman create` (see the caveat below on
+   `--hooks-dir` overriding default hook dirs).
 3. The OCI hook (`klangk-netfilter.sh`, materialized by the backend into the
    hooks dir) fires at `createContainer` time, reads the annotation from the
    container state, resolves each host to IPs, and installs an iptables
@@ -119,6 +120,19 @@ unusable, but the warning makes the gap visible.
   permissive seccomp profile hands the entrypoint `iptables -F OUTPUT`,
   which flushes the ruleset and lets it exfiltrate freely. Do not run
   filtered workspaces privileged or grant `NET_ADMIN`.
+- **`--hooks-dir` overrides podman's default hook dirs.** Podman's
+  `--hooks-dir` flag _replaces_ (does not append to) the default OCI hook
+  search paths, so passing only klangk's hooks dir for a filtered
+  workspace would silently disable every _other_ `createContainer` hook
+  an operator relies on (monitoring, secrets injection, GPU, corporate
+  integrations). To avoid that, a filtered container passes klangk's hooks
+  dir **and** the two standard default dirs
+  (`/usr/share/containers/oci/hooks.d`, `/etc/containers/oci/hooks.d`),
+  preserving operator hooks. Podman tolerates a dir that doesn't exist (it
+  simply finds no hooks there). Limitation: a _non-standard_ hooks dir
+  configured only via `containers.conf` is still clobbered by an explicit
+  `--hooks-dir`; unrestricted workspaces are unaffected (the flag isn't
+  passed). See #1770.
 - **Port granularity.** The initial implementation supports `host` and
   `host:port`. CIDR ranges and port-only rules may follow.
 - **`macOS` hosts.** The `createContainer` hook runs inside the

--- a/klangkd.yaml.example
+++ b/klangkd.yaml.example
@@ -34,6 +34,11 @@ data_dir: "cmd:echo $DEVENV_STATE/klangk/data"
 # --- Container / workspace ---
 image_name: klangk-workspace
 
+# --- Per-workspace egress filtering (#1365) ---
+# Set to a directory the OCI runtime can read to enable opt-in per-workspace
+# allowed_domains enforcement. Unset (default) = unrestricted egress.
+# netfilter_hooks_dir: /var/lib/klangk/netfilter-hooks
+
 # --- Uncomment to enable OIDC ---
 # auth_modes: both
 # oidc_providers:

--- a/src/frontend/lib/auth/auth_service.dart
+++ b/src/frontend/lib/auth/auth_service.dart
@@ -25,6 +25,12 @@ class AuthService extends ChangeNotifier {
   int _minPasswordLength = 8;
   String _instanceId = 'default';
   bool _allowAutostart = false;
+  // #1365: deploy-wide netfilter default allow-list + whether the feature
+  // is armed. Surfaced via /api/v1/config so the create-workspace UI can
+  // pre-fill its allowed-domains editor from the default (a workspace
+  // overrides, not unions) and gate the editor on netfilter_enabled.
+  List<String> _netfilterDefaultDomains = const [];
+  bool _netfilterEnabled = false;
   Timer? _permissionTimer;
   Timer? _refreshTimer;
 
@@ -55,6 +61,17 @@ class AuthService extends ChangeNotifier {
   /// on this — setting auto_start on a server that rejects it would
   /// 400 (#1115).
   bool get allowAutostart => _allowAutostart;
+
+  /// #1365: the deploy-wide netfilter default allow-list
+  /// (KLANGKD_NETFILTER_DEFAULT_DOMAINS). The create-workspace dialog
+  /// pre-fills its editor from this; a workspace's own list overrides
+  /// (replaces) it.
+  List<String> get netfilterDefaultDomains => _netfilterDefaultDomains;
+
+  /// #1365: whether netfilter is armed on the server (hooks dir configured).
+  /// The UI shows the allowed-domains editor only when the deploy can
+  /// actually enforce it.
+  bool get netfilterEnabled => _netfilterEnabled;
 
   /// Decode the JWT payload.
   Map<String, dynamic>? get _payload {
@@ -114,6 +131,10 @@ class AuthService extends ChangeNotifier {
             (data['login_banner_every_visit'] as bool?) ?? false;
         _instanceId = (data['instance_id'] as String?) ?? 'default';
         _allowAutostart = (data['allow_autostart'] as bool?) ?? false;
+        _netfilterDefaultDomains =
+            (data['netfilter_default_domains'] as List?)?.cast<String>() ??
+                const [];
+        _netfilterEnabled = (data['netfilter_enabled'] as bool?) ?? false;
         _minPasswordLength =
             (data['min_password_length'] as num?)?.toInt() ?? 8;
         // White-label values — mirrored into the Branding helper so widgets

--- a/src/frontend/lib/auth/auth_service.dart
+++ b/src/frontend/lib/auth/auth_service.dart
@@ -116,13 +116,21 @@ class AuthService extends ChangeNotifier {
     _loadToken();
   }
 
-  Future<void> _loadToken() async {
-    final prefs = await SharedPreferences.getInstance();
-    _token = prefs.getString(_tokenKey);
-
+  /// Fetch `/api/v1/config` and apply the result. Sends the persisted
+  /// token when available so the server returns authenticated-only fields
+  /// (notably the netfilter deploy allow-list + armed status, #1365) — the
+  /// pre-auth payload omits them. Called at startup and after a fresh
+  /// login (so a just-authenticated user picks up the fields without an
+  /// app restart).
+  Future<void> _loadConfig() async {
     try {
       final client = testAuthHttpClientOverride ?? http.Client();
-      final resp = await client.get(Uri.parse('$_baseUrl/api/v1/config'));
+      final resp = await client.get(
+        Uri.parse('$_baseUrl/api/v1/config'),
+        headers: {
+          if (_token != null) 'Authorization': 'Bearer $_token',
+        },
+      );
       if (resp.statusCode == 200) {
         final data = jsonDecode(resp.body);
         _bannerTitle = (data['login_banner_title'] as String?) ?? '';
@@ -147,6 +155,13 @@ class AuthService extends ChangeNotifier {
       // coverage:ignore-start
       debugPrint('[AuthService] load config failed: $e');
     } // coverage:ignore-end
+  }
+
+  Future<void> _loadToken() async {
+    final prefs = await SharedPreferences.getInstance();
+    _token = prefs.getString(_tokenKey);
+
+    await _loadConfig();
 
     if (_bannerText.isNotEmpty) {
       if (_loginBannerEveryVisit) {
@@ -224,6 +239,10 @@ class AuthService extends ChangeNotifier {
     _token = token;
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString(_tokenKey, token);
+    // Re-fetch config now that we have a token, so authenticated-only
+    // fields (e.g. the netfilter deploy allow-list, #1365) are picked up
+    // without an app restart.
+    await _loadConfig();
     await _fetchPermissions();
     _scheduleTokenRefresh();
     notifyListeners();

--- a/src/frontend/lib/workspace/create_workspace_dialog.dart
+++ b/src/frontend/lib/workspace/create_workspace_dialog.dart
@@ -19,12 +19,20 @@ class CreateWorkspaceDialog extends StatefulWidget {
   /// from AuthService.allowAutostart (server's KLANGKD_ALLOW_AUTOSTART).
   final bool allowAutostart;
 
+  /// #1365: deploy-wide netfilter default allow-list, surfaced via
+  /// /api/v1/config (KLANGKD_NETFILTER_DEFAULT_DOMAINS). The editor is
+  /// pre-filled with this so a new workspace inherits the deployer's floor;
+  /// the creator's edits replace it (stored as the workspace's own
+  /// allowed_domains). Empty when netfilter is unset/disabled on the server.
+  final List<String> defaultAllowedDomains;
+
   const CreateWorkspaceDialog({
     super.key,
     required this.auth,
     required this.defaultImage,
     required this.allowedImages,
     this.allowAutostart = false,
+    this.defaultAllowedDomains = const [],
   });
 
   @override
@@ -57,6 +65,10 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
   void initState() {
     super.initState();
     _selectedImage = widget.defaultImage;
+    // #1365: pre-fill the editor with the deploy-wide default so a new
+    // workspace inherits it; the creator's edits replace (not merge with)
+    // the default and are submitted as the workspace's allowed_domains.
+    _allowedDomains.addAll(widget.defaultAllowedDomains);
   }
 
   @override

--- a/src/frontend/lib/workspace/create_workspace_dialog.dart
+++ b/src/frontend/lib/workspace/create_workspace_dialog.dart
@@ -37,13 +37,16 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
   final _healthCheckController = TextEditingController();
   final _mountController = TextEditingController();
   final _envController = TextEditingController();
+  final _allowedDomainsController = TextEditingController();
   late String _selectedImage;
   final _mounts = <String>[];
   final _envVars = <String, String>{};
+  final _allowedDomains = <String>[];
   bool _autoStart = false;
   String? _errorMessage;
   String? _mountError;
   String? _envError;
+  String? _allowedDomainsError;
 
   final _labelStyle = TextStyle(
     color: KColors.textPrimary,
@@ -63,6 +66,7 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
     _healthCheckController.dispose();
     _mountController.dispose();
     _envController.dispose();
+    _allowedDomainsController.dispose();
     super.dispose();
   }
 
@@ -98,6 +102,22 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
     });
   }
 
+  void _tryAddAllowedDomain() {
+    final v = _allowedDomainsController.text.trim();
+    if (v.isEmpty) return;
+    final spec = RegExp(
+        r'^\[[0-9A-Fa-f:.]+\](:[0-9]{1,5})?$|^[A-Za-z0-9][A-Za-z0-9.\-]*(:[0-9]{1,5})?$');
+    if (v.contains(' ') || v.contains('/') || !spec.hasMatch(v)) {
+      setState(() => _allowedDomainsError = 'Expected host or host:port');
+      return;
+    }
+    setState(() {
+      if (!_allowedDomains.contains(v)) _allowedDomains.add(v);
+      _allowedDomainsController.clear();
+      _allowedDomainsError = null;
+    });
+  }
+
   static String? _validateEnvEntry(String input) {
     if (!input.contains('=')) return 'Expected KEY=VALUE format';
     final key = input.substring(0, input.indexOf('='));
@@ -119,6 +139,9 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
     if (_mounts.isNotEmpty) body['mounts'] = List<String>.from(_mounts);
     if (_envVars.isNotEmpty) {
       body['env'] = Map<String, String>.from(_envVars);
+    }
+    if (_allowedDomains.isNotEmpty) {
+      body['allowed_domains'] = List<String>.from(_allowedDomains);
     }
     if (widget.allowAutostart && _autoStart) {
       body['auto_start'] = true;
@@ -181,6 +204,7 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
               ),
               ..._buildMountsEditor(),
               ..._buildEnvVarsEditor(),
+              ..._buildAllowedDomainsEditor(),
               const SizedBox(height: 16),
               TextField(
                 controller: _cmdController,
@@ -382,6 +406,74 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
           ),
           const SizedBox(width: 8),
           IconButton(icon: const Icon(Icons.add), onPressed: _tryAddEnv),
+        ],
+      ),
+    ];
+  }
+
+  List<Widget> _buildAllowedDomainsEditor() {
+    return [
+      const SizedBox(height: 16),
+      Text('Allowed Domains', style: _labelStyle),
+      const SizedBox(height: 8),
+      ..._allowedDomains.asMap().entries.map(
+            (e) => Padding(
+              padding: const EdgeInsets.only(bottom: 4),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: SelectableText(
+                      e.value,
+                      style: const TextStyle(fontSize: 13),
+                    ),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.copy, size: 16),
+                    tooltip: 'Copy',
+                    onPressed: () =>
+                        Clipboard.setData(ClipboardData(text: e.value)),
+                    padding: EdgeInsets.zero,
+                    constraints: const BoxConstraints(),
+                  ),
+                  const SizedBox(width: 4),
+                  IconButton(
+                    icon: const Icon(Icons.close, size: 18),
+                    onPressed: () =>
+                        setState(() => _allowedDomains.removeAt(e.key)),
+                    padding: EdgeInsets.zero,
+                    constraints: const BoxConstraints(),
+                  ),
+                ],
+              ),
+            ),
+          ),
+      if (_allowedDomainsError != null) ...[
+        Text(
+          _allowedDomainsError!,
+          style: TextStyle(
+            color: Theme.of(context).colorScheme.error,
+            fontSize: 12,
+          ),
+        ),
+        const SizedBox(height: 4),
+      ],
+      Row(
+        children: [
+          Expanded(
+            child: TextField(
+              controller: _allowedDomainsController,
+              decoration: const InputDecoration(
+                hintText: 'github.com:443',
+                isDense: true,
+                border: OutlineInputBorder(),
+              ),
+              style: const TextStyle(fontSize: 13),
+              onSubmitted: (_) => _tryAddAllowedDomain(),
+            ),
+          ),
+          const SizedBox(width: 8),
+          IconButton(
+              icon: const Icon(Icons.add), onPressed: _tryAddAllowedDomain),
         ],
       ),
     ];

--- a/src/frontend/lib/workspace/create_workspace_dialog.dart
+++ b/src/frontend/lib/workspace/create_workspace_dialog.dart
@@ -3,7 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import '../auth/auth_service.dart';
 import '../theme/colors.dart';
-import 'workspace_list_page.dart' show validateMountSpec;
+import 'workspace_list_page.dart'
+    show validateMountSpec, validateAllowedDomainSpec;
 
 /// Dialog for creating a new workspace. Fields, top to bottom:
 /// Name, Mounts, Environment Variables, Service shell command, Health
@@ -26,6 +27,11 @@ class CreateWorkspaceDialog extends StatefulWidget {
   /// allowed_domains). Empty when netfilter is unset/disabled on the server.
   final List<String> defaultAllowedDomains;
 
+  /// #1365: whether netfilter is armed on the server. When false, the
+  /// allowed-domains editor shows a "not enforced" notice so the creator
+  /// knows the list won't take effect until an operator enables netfilter.
+  final bool netfilterEnabled;
+
   const CreateWorkspaceDialog({
     super.key,
     required this.auth,
@@ -33,6 +39,7 @@ class CreateWorkspaceDialog extends StatefulWidget {
     required this.allowedImages,
     this.allowAutostart = false,
     this.defaultAllowedDomains = const [],
+    this.netfilterEnabled = false,
   });
 
   @override
@@ -117,10 +124,9 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
   void _tryAddAllowedDomain() {
     final v = _allowedDomainsController.text.trim();
     if (v.isEmpty) return;
-    final spec = RegExp(
-        r'^\[[0-9A-Fa-f:.]+\](:[0-9]{1,5})?$|^[A-Za-z0-9][A-Za-z0-9.\-]*(:[0-9]{1,5})?$');
-    if (v.contains(' ') || v.contains('/') || !spec.hasMatch(v)) {
-      setState(() => _allowedDomainsError = 'Expected host or host:port');
+    final err = validateAllowedDomainSpec(v);
+    if (err != null) {
+      setState(() => _allowedDomainsError = err);
       return;
     }
     setState(() {
@@ -488,6 +494,30 @@ class _CreateWorkspaceDialogState extends State<CreateWorkspaceDialog> {
               icon: const Icon(Icons.add), onPressed: _tryAddAllowedDomain),
         ],
       ),
+      if (_allowedDomains.isNotEmpty && !widget.netfilterEnabled) ...[
+        const SizedBox(height: 8),
+        Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          decoration: BoxDecoration(
+            color: Colors.amber.withValues(alpha: 0.12),
+            borderRadius: BorderRadius.circular(4),
+          ),
+          child: const Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(Icons.warning_amber, size: 18),
+              SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  'Egress filtering is not active on this server — the '
+                  'allowed-domains list will NOT be enforced until an '
+                  'operator enables netfilter.',
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
     ];
   }
 }

--- a/src/frontend/lib/workspace/workspace_list_page.dart
+++ b/src/frontend/lib/workspace/workspace_list_page.dart
@@ -352,6 +352,7 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
         defaultImage: defaultImage,
         allowedImages: allowedImages,
         allowAutostart: _auth.allowAutostart,
+        defaultAllowedDomains: _auth.netfilterDefaultDomains,
       ),
     );
 

--- a/src/frontend/lib/workspace/workspace_list_page.dart
+++ b/src/frontend/lib/workspace/workspace_list_page.dart
@@ -566,6 +566,20 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
                                       e.value['created_at'] as String?,
                                     ),
                                   ),
+                                  if (_hasUnenforcedEgress(e.value)) ...[
+                                    const SizedBox(width: 8),
+                                    Tooltip(
+                                      message: 'Allowed-domains set but '
+                                          'egress filtering is not '
+                                          'enforced (netfilter disabled '
+                                          'on server)',
+                                      child: Icon(
+                                        Icons.warning_amber,
+                                        size: 16,
+                                        color: Colors.orange,
+                                      ),
+                                    ),
+                                  ],
                                   if (wsMembers.isNotEmpty) ...[
                                     const SizedBox(width: 8),
                                     ...wsMembers.map((m) {
@@ -627,6 +641,16 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
         ],
       ),
     );
+  }
+
+  /// #1769: true when this workspace declares allowed_domains but the
+  /// deploy has netfilter disabled, so the allow-list is NOT enforced
+  /// (deliberate fail-open). Used to badge such workspaces in the list —
+  /// the gap is otherwise visible only in operator logs.
+  bool _hasUnenforcedEgress(Map<String, dynamic> ws) {
+    if (_auth.netfilterEnabled) return false;
+    final domains = ws['allowed_domains'] as List?;
+    return domains != null && domains.isNotEmpty;
   }
 
   Widget _buildTabBody(_Section section) {

--- a/src/frontend/lib/workspace/workspace_list_page.dart
+++ b/src/frontend/lib/workspace/workspace_list_page.dart
@@ -44,6 +44,24 @@ String? validateMountSpec(String spec) {
   return null;
 }
 
+/// Client-side validation for a ``host`` or ``host:port`` allowed-domain
+/// spec. Returns an error string on failure, ``null`` on success. The server
+/// validates definitively; this catches typos at the boundary.
+String? validateAllowedDomainSpec(String spec) {
+  if (spec.contains(' ') || spec.contains('/')) {
+    return 'Expected host or host:port';
+  }
+  final re = RegExp(
+      r'^\[[0-9A-Fa-f:.]+\](:[0-9]{1,5})?$|^[A-Za-z0-9][A-Za-z0-9.\-]*(:[0-9]{1,5})?$');
+  if (!re.hasMatch(spec)) return 'Expected host or host:port';
+  // Reject ports > 65535 (the regex allows up to 5 digits).
+  final portMatch = RegExp(r':(\d{1,5})$').firstMatch(spec);
+  if (portMatch != null && int.parse(portMatch.group(1)!) > 65535) {
+    return 'Port must be 1–65535';
+  }
+  return null;
+}
+
 class WorkspaceListPage extends StatefulWidget {
   const WorkspaceListPage({super.key}); // coverage:ignore-line
 
@@ -353,6 +371,7 @@ class _WorkspaceListPageState extends State<WorkspaceListPage> {
         allowedImages: allowedImages,
         allowAutostart: _auth.allowAutostart,
         defaultAllowedDomains: _auth.netfilterDefaultDomains,
+        netfilterEnabled: _auth.netfilterEnabled,
       ),
     );
 

--- a/src/frontend/lib/workspace/workspace_settings_panel.dart
+++ b/src/frontend/lib/workspace/workspace_settings_panel.dart
@@ -177,12 +177,15 @@ class _SettingsFormState extends State<_SettingsForm> {
   late TextEditingController _healthCheckCtrl;
   final _mountCtrl = TextEditingController();
   final _envCtrl = TextEditingController();
+  final _allowedDomainsCtrl = TextEditingController();
   late String _selectedImage;
   late List<String> _mounts;
   late Map<String, String> _envVars;
+  late List<String> _allowedDomains;
   bool _autoStart = false;
   String? _mountError;
   String? _envError;
+  String? _allowedDomainsError;
   bool _saving = false;
   bool _exporting = false;
 
@@ -209,6 +212,10 @@ class _SettingsFormState extends State<_SettingsForm> {
     _envVars = Map<String, String>.from(
       (widget.workspace['env'] as Map?)?.cast<String, String>() ??
           <String, String>{},
+    );
+    _allowedDomains = List<String>.from(
+      (widget.workspace['allowed_domains'] as List?)?.cast<String>() ??
+          <String>[],
     );
     _autoStart = (widget.workspace['auto_start'] as bool?) ?? false;
   }
@@ -252,6 +259,13 @@ class _SettingsFormState extends State<_SettingsForm> {
             <String, String>{},
       );
     }
+    if (old.workspace['allowed_domains'] !=
+        widget.workspace['allowed_domains']) {
+      _allowedDomains = List<String>.from(
+        (widget.workspace['allowed_domains'] as List?)?.cast<String>() ??
+            <String>[],
+      );
+    }
   }
 
   @override
@@ -261,6 +275,7 @@ class _SettingsFormState extends State<_SettingsForm> {
     _healthCheckCtrl.dispose();
     _mountCtrl.dispose();
     _envCtrl.dispose();
+    _allowedDomainsCtrl.dispose();
     super.dispose();
   }
 
@@ -276,6 +291,7 @@ class _SettingsFormState extends State<_SettingsForm> {
           : _healthCheckCtrl.text.trim(),
       'mounts': _mounts.isNotEmpty ? _mounts : null,
       'env': _envVars.isNotEmpty ? _envVars : null,
+      'allowed_domains': _allowedDomains.isNotEmpty ? _allowedDomains : null,
       if (widget.allowAutostart) 'auto_start': _autoStart,
     });
     if (mounted) setState(() => _saving = false);
@@ -312,6 +328,24 @@ class _SettingsFormState extends State<_SettingsForm> {
       _envVars[key] = value;
       _envCtrl.clear();
       _envError = null;
+    });
+  }
+
+  void _tryAddAllowedDomain() {
+    final v = _allowedDomainsCtrl.text.trim();
+    if (v.isEmpty) return;
+    // Lightweight client-side check (the server validates definitively):
+    // a spec is a host with an optional :port, no spaces or slashes.
+    final spec = RegExp(
+        r'^\[[0-9A-Fa-f:.]+\](:[0-9]{1,5})?$|^[A-Za-z0-9][A-Za-z0-9.\-]*(:[0-9]{1,5})?$');
+    if (v.contains(' ') || v.contains('/') || !spec.hasMatch(v)) {
+      setState(() => _allowedDomainsError = 'Expected host or host:port');
+      return;
+    }
+    setState(() {
+      if (!_allowedDomains.contains(v)) _allowedDomains.add(v);
+      _allowedDomainsCtrl.clear();
+      _allowedDomainsError = null;
     });
   }
 
@@ -417,6 +451,8 @@ class _SettingsFormState extends State<_SettingsForm> {
         _buildMountsEditor(labelStyle),
         const SizedBox(height: 16),
         _buildEnvVarsEditor(labelStyle),
+        const SizedBox(height: 16),
+        _buildAllowedDomainsEditor(labelStyle),
         const SizedBox(height: 16),
         TextField(
           controller: _cmdCtrl,
@@ -529,6 +565,40 @@ class _SettingsFormState extends State<_SettingsForm> {
               onRemove: () => setState(() => _envVars.remove(e.value.key)),
             ),
           ),
+    );
+  }
+
+  Widget _buildAllowedDomainsEditor(TextStyle labelStyle) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _buildEditableList(
+          label: 'Allowed Domains',
+          labelStyle: labelStyle,
+          hint: 'github.com:443',
+          controller: _allowedDomainsCtrl,
+          error: _allowedDomainsError,
+          onAdd: _tryAddAllowedDomain,
+          items: _allowedDomains.asMap().entries.map(
+                (e) => _buildEditableListItem(
+                  text: e.value,
+                  onCopy: e.value,
+                  onRemove: () =>
+                      setState(() => _allowedDomains.removeAt(e.key)),
+                ),
+              ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          'Restricts outbound network to these hosts (host or host:port). '
+          'Requires KLANGKD_NETFILTER_HOOKS_DIR on the server; empty '
+          'means unrestricted.',
+          style: TextStyle(
+            color: KColors.textSecondary,
+            fontSize: 12,
+          ),
+        ),
+      ],
     );
   }
 

--- a/src/frontend/lib/workspace/workspace_settings_panel.dart
+++ b/src/frontend/lib/workspace/workspace_settings_panel.dart
@@ -162,6 +162,8 @@ class WorkspaceSettingsPanelState extends State<WorkspaceSettingsPanel> {
           context.select<AuthService, bool>((a) => a.allowAutostart),
       saveMessage: _saveMessage,
       pendingEgressRestart: _pendingEgressRestart,
+      netfilterEnabled:
+          context.select<AuthService, bool>((a) => a.netfilterEnabled),
       onSave: _saveSettings,
     );
   }
@@ -187,6 +189,7 @@ class _SettingsForm extends StatefulWidget {
   final bool allowAutostart;
   final String? saveMessage;
   final bool pendingEgressRestart;
+  final bool netfilterEnabled;
   final Future<void> Function(Map<String, dynamic>) onSave;
 
   const _SettingsForm({
@@ -197,6 +200,7 @@ class _SettingsForm extends StatefulWidget {
     required this.allowAutostart,
     required this.saveMessage,
     required this.pendingEgressRestart,
+    required this.netfilterEnabled,
     required this.onSave,
   });
 
@@ -663,7 +667,42 @@ class _SettingsFormState extends State<_SettingsForm> {
             fontSize: 12,
           ),
         ),
+        if (_allowedDomains.isNotEmpty && !widget.netfilterEnabled) ...[
+          const SizedBox(height: 8),
+          _buildEgressNotEnforcedNotice(),
+        ],
       ],
+    );
+  }
+
+  /// #1769: this workspace declares allowed_domains but the deploy has
+  /// netfilter disabled (KLANGKD_NETFILTER_HOOKS_DIR unset/unwritable),
+  /// so the allow-list is NOT being enforced — the container starts with
+  /// unrestricted egress (deliberate fail-open). Surface the gap to the
+  /// user who set the list (the party at risk); the server only logs the
+  /// warning to operator logs otherwise.
+  Widget _buildEgressNotEnforcedNotice() {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: KColors.accentAmber.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Icon(Icons.warning_amber, size: 18),
+          const SizedBox(width: 8),
+          const Expanded(
+            child: Text(
+              'Egress filtering is not active on this server — the '
+              'allowed-domains list above is NOT being enforced. This '
+              'workspace will start with unrestricted outbound network '
+              'until an operator sets KLANGKD_NETFILTER_HOOKS_DIR.',
+            ),
+          ),
+        ],
+      ),
     );
   }
 

--- a/src/frontend/lib/workspace/workspace_settings_panel.dart
+++ b/src/frontend/lib/workspace/workspace_settings_panel.dart
@@ -8,6 +8,7 @@ import '../theme/colors.dart';
 import '../utils/web_helpers_stub.dart'
     if (dart.library.js_interop) '../utils/web_helpers_web.dart';
 import '../ws/ws_client.dart';
+import 'workspace_list_page.dart' show validateAllowedDomainSpec;
 
 /// Workspace settings panel: config editing only.
 /// Used as a tab in the IDE layout.
@@ -371,12 +372,9 @@ class _SettingsFormState extends State<_SettingsForm> {
   void _tryAddAllowedDomain() {
     final v = _allowedDomainsCtrl.text.trim();
     if (v.isEmpty) return;
-    // Lightweight client-side check (the server validates definitively):
-    // a spec is a host with an optional :port, no spaces or slashes.
-    final spec = RegExp(
-        r'^\[[0-9A-Fa-f:.]+\](:[0-9]{1,5})?$|^[A-Za-z0-9][A-Za-z0-9.\-]*(:[0-9]{1,5})?$');
-    if (v.contains(' ') || v.contains('/') || !spec.hasMatch(v)) {
-      setState(() => _allowedDomainsError = 'Expected host or host:port');
+    final err = validateAllowedDomainSpec(v);
+    if (err != null) {
+      setState(() => _allowedDomainsError = err);
       return;
     }
     setState(() {
@@ -676,11 +674,10 @@ class _SettingsFormState extends State<_SettingsForm> {
   }
 
   /// #1769: this workspace declares allowed_domains but the deploy has
-  /// netfilter disabled (KLANGKD_NETFILTER_HOOKS_DIR unset/unwritable),
-  /// so the allow-list is NOT being enforced — the container starts with
-  /// unrestricted egress (deliberate fail-open). Surface the gap to the
-  /// user who set the list (the party at risk); the server only logs the
-  /// warning to operator logs otherwise.
+  /// netfilter disabled, so the allow-list is NOT being enforced — the
+  /// container starts with unrestricted egress (deliberate fail-open).
+  /// Surface the gap to the user who set the list (the party at risk);
+  /// the server only logs the warning to operator logs otherwise.
   Widget _buildEgressNotEnforcedNotice() {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
@@ -688,12 +685,12 @@ class _SettingsFormState extends State<_SettingsForm> {
         color: KColors.accentAmber.withValues(alpha: 0.12),
         borderRadius: BorderRadius.circular(4),
       ),
-      child: Row(
+      child: const Row(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Icon(Icons.warning_amber, size: 18),
-          const SizedBox(width: 8),
-          const Expanded(
+          Icon(Icons.warning_amber, size: 18),
+          SizedBox(width: 8),
+          Expanded(
             child: Text(
               'Egress filtering is not active on this server — the '
               'allowed-domains list above is NOT being enforced. This '

--- a/src/frontend/lib/workspace/workspace_settings_panel.dart
+++ b/src/frontend/lib/workspace/workspace_settings_panel.dart
@@ -660,7 +660,7 @@ class _SettingsFormState extends State<_SettingsForm> {
         const SizedBox(height: 4),
         Text(
           'Restricts outbound network to these hosts (host or host:port). '
-          'Requires KLANGKD_NETFILTER_HOOKS_DIR on the server; empty '
+          'Requires netfilter to be enabled on the server; empty '
           'means unrestricted.',
           style: TextStyle(
             color: KColors.textSecondary,
@@ -698,7 +698,7 @@ class _SettingsFormState extends State<_SettingsForm> {
               'Egress filtering is not active on this server — the '
               'allowed-domains list above is NOT being enforced. This '
               'workspace will start with unrestricted outbound network '
-              'until an operator sets KLANGKD_NETFILTER_HOOKS_DIR.',
+              'until an operator enables netfilter on the server.',
             ),
           ),
         ],

--- a/src/frontend/lib/workspace/workspace_settings_panel.dart
+++ b/src/frontend/lib/workspace/workspace_settings_panel.dart
@@ -28,6 +28,11 @@ class WorkspaceSettingsPanelState extends State<WorkspaceSettingsPanel> {
   String? _error;
   String? _saveMessage;
   Timer? _saveMessageTimer;
+  // #1365: set when a successful save changed allowed_domains on a
+  // workspace whose container is running — the egress filter is baked at
+  // container create time, so the new ruleset won't take effect until the
+  // container is restarted. Surfaced as a notice under the save message.
+  bool _pendingEgressRestart = false;
 
   @override
   void initState() {
@@ -111,7 +116,20 @@ class WorkspaceSettingsPanelState extends State<WorkspaceSettingsPanel> {
     );
     if (!mounted) return;
     if (resp.statusCode == 200) {
-      setState(() => _saveMessage = 'Settings saved');
+      // #1365: the egress filter is applied at container create time (the
+      // OCI hook runs at createContainer), so a change to allowed_domains
+      // only takes effect on the next (re)start. Detect the change before
+      // _loadData() reassigns _workspace, and only nag when a container is
+      // actually running (a stopped workspace picks the new rules up on
+      // its next start — no action needed).
+      final prevDomains = _workspace?['allowed_domains'];
+      final egressChanged =
+          !_domainListsEqual(prevDomains, fields['allowed_domains']);
+      final running = (_workspace?['running'] as bool?) ?? false;
+      setState(() {
+        _saveMessage = 'Settings saved';
+        _pendingEgressRestart = egressChanged && running;
+      });
       _loadData();
       _saveMessageTimer?.cancel();
       _saveMessageTimer = Timer(const Duration(seconds: 2), () {
@@ -143,9 +161,22 @@ class WorkspaceSettingsPanelState extends State<WorkspaceSettingsPanel> {
       allowAutostart:
           context.select<AuthService, bool>((a) => a.allowAutostart),
       saveMessage: _saveMessage,
+      pendingEgressRestart: _pendingEgressRestart,
       onSave: _saveSettings,
     );
   }
+}
+
+/// Compare two allowed_domains values (each a ``List?`` of ``String``) for
+/// order-independent equality, so the restart notice fires only on a real
+/// change — not a harmless reorder or the null/empty equivalence (#1365).
+bool _domainListsEqual(Object? a, Object? b) {
+  final la = (a is List ? a.cast<String>() : const <String>[]);
+  final lb = (b is List ? b.cast<String>() : const <String>[]);
+  if (la.length != lb.length) return false;
+  // Order-independent: the server de-dupes + may reorder on round-trip, so
+  // compare as sets to avoid a spurious "changed" on a save that didn't.
+  return <String>{...la}.difference(<String>{...lb}).isEmpty;
 }
 
 class _SettingsForm extends StatefulWidget {
@@ -155,6 +186,7 @@ class _SettingsForm extends StatefulWidget {
   final String defaultImage;
   final bool allowAutostart;
   final String? saveMessage;
+  final bool pendingEgressRestart;
   final Future<void> Function(Map<String, dynamic>) onSave;
 
   const _SettingsForm({
@@ -164,6 +196,7 @@ class _SettingsForm extends StatefulWidget {
     required this.defaultImage,
     required this.allowAutostart,
     required this.saveMessage,
+    required this.pendingEgressRestart,
     required this.onSave,
   });
 
@@ -366,6 +399,10 @@ class _SettingsFormState extends State<_SettingsForm> {
             children: [
               if (widget.saveMessage != null) ...[
                 _buildSaveMessage(),
+                if (widget.pendingEgressRestart) ...[
+                  const SizedBox(height: 8),
+                  _buildEgressRestartNotice(),
+                ],
                 const SizedBox(height: 16),
               ],
               _buildConfigCard(labelStyle),
@@ -392,6 +429,34 @@ class _SettingsFormState extends State<_SettingsForm> {
         borderRadius: BorderRadius.circular(4),
       ),
       child: Text(widget.saveMessage!),
+    );
+  }
+
+  /// #1365: the egress filter is baked into the container at create time
+  /// (the OCI createContainer hook installs the iptables ruleset before the
+  /// entrypoint runs), so a saved allowed_domains change has no effect on a
+  /// running container until it's restarted. Shown under the save message
+  /// only when the change landed and a container is live.
+  Widget _buildEgressRestartNotice() {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: KColors.accentAmber.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Icon(Icons.restart_alt, size: 18),
+          const SizedBox(width: 8),
+          const Expanded(
+            child: Text(
+              'Restart the workspace container to apply the new egress '
+              'filter — the ruleset is set at container create time.',
+            ),
+          ),
+        ],
+      ),
     );
   }
 

--- a/src/frontend/test/auth_service_test.dart
+++ b/src/frontend/test/auth_service_test.dart
@@ -89,6 +89,8 @@ void main() {
       bool loginBannerEveryVisit = false,
       int? minPasswordLength,
       String? productName,
+      List<String>? netfilterDefaultDomains,
+      bool? netfilterEnabled,
     }) {
       return MockClient((request) async {
         if (request.url.path.contains('/api/v1/config')) {
@@ -102,6 +104,10 @@ void main() {
               if (minPasswordLength != null)
                 'min_password_length': minPasswordLength,
               if (productName != null) 'product_name': productName,
+              if (netfilterDefaultDomains != null)
+                'netfilter_default_domains': netfilterDefaultDomains,
+              if (netfilterEnabled != null)
+                'netfilter_enabled': netfilterEnabled,
             }),
             200,
           );
@@ -146,6 +152,26 @@ void main() {
       final service2 = AuthService();
       await Future.delayed(Duration.zero);
       expect(service2.allowAutostart, isTrue);
+    });
+
+    test('loads netfilter default domains + enabled from /api/config',
+        () async {
+      // #1365: defaults (absent fields) → empty / disabled.
+      testAuthHttpClientOverride = _bannerClient();
+      final service = AuthService();
+      await Future.delayed(Duration.zero);
+      expect(service.netfilterDefaultDomains, isEmpty);
+      expect(service.netfilterEnabled, isFalse);
+
+      // Advertised values are surfaced verbatim.
+      testAuthHttpClientOverride = _bannerClient(
+        netfilterDefaultDomains: ['github.com:443', 'pypi.org'],
+        netfilterEnabled: true,
+      );
+      final service2 = AuthService();
+      await Future.delayed(Duration.zero);
+      expect(service2.netfilterDefaultDomains, ['github.com:443', 'pypi.org']);
+      expect(service2.netfilterEnabled, isTrue);
     });
 
     test('loads min_password_length from /api/config', () async {

--- a/src/frontend/test/create_workspace_dialog_test.dart
+++ b/src/frontend/test/create_workspace_dialog_test.dart
@@ -63,6 +63,7 @@ void main() {
     String defaultImage = 'klangk-pi',
     List<String>? allowedImages,
     bool allowAutostart = false,
+    List<String> defaultAllowedDomains = const [],
   }) {
     final a = auth ?? AuthService();
     return MaterialApp(
@@ -78,6 +79,7 @@ void main() {
                   defaultImage: defaultImage,
                   allowedImages: allowedImages ?? [defaultImage, 'klangk-full'],
                   allowAutostart: allowAutostart,
+                  defaultAllowedDomains: defaultAllowedDomains,
                 ),
               );
             });
@@ -425,6 +427,90 @@ void main() {
       await tester.pump();
 
       expect(postedBody!['allowed_domains'], ['github.com:443']);
+    });
+
+    testWidgets('pre-fills allowed domains from the deploy default',
+        (tester) async {
+      // #1365: the editor inherits KLANGKD_NETFILTER_DEFAULT_DOMAINS so a
+      // new workspace starts from the deployer's floor. The creator's
+      // edits replace (not merge with) the default.
+      Map<String, dynamic>? postedBody;
+      testAuthHttpClientOverride = mockClient((request) async {
+        if (request.method == 'POST') {
+          postedBody = jsonDecode(request.body) as Map<String, dynamic>;
+          return http.Response(
+            jsonEncode({'id': 'ws-1', 'name': 'x', 'created_at': ''}),
+            200,
+          );
+        }
+        return http.Response('Not found', 404);
+      });
+      await tester.pumpWidget(buildDialog(
+        defaultAllowedDomains: ['github.com:443', 'pypi.org'],
+      ));
+      await tester.pump(); // post-frame callback
+      await tester.pump(); // dialog renders
+
+      // Both defaults render as chips (SelectableText, not the input's
+      // hintText which also carries 'github.com:443').
+      expect(
+        find.byWidgetPredicate(
+          (w) => w is SelectableText && (w.data ?? '') == 'github.com:443',
+        ),
+        findsOneWidget,
+      );
+      expect(find.text('pypi.org'), findsOneWidget);
+
+      // Submitting without edits sends the inherited default as the
+      // workspace's own allowed_domains.
+      await tester.enterText(_nameField(), 'Inherited');
+      await tester.tap(find.text('Create'));
+      await tester.pump();
+      await tester.pump();
+
+      expect(postedBody!['allowed_domains'], ['github.com:443', 'pypi.org']);
+    });
+
+    testWidgets('creator edits replace the inherited default', (tester) async {
+      // Removing a chip and adding a new one produces exactly the edited
+      // set — the default is not unioned back in.
+      Map<String, dynamic>? postedBody;
+      testAuthHttpClientOverride = mockClient((request) async {
+        if (request.method == 'POST') {
+          postedBody = jsonDecode(request.body) as Map<String, dynamic>;
+          return http.Response(
+            jsonEncode({'id': 'ws-1', 'name': 'x', 'created_at': ''}),
+            200,
+          );
+        }
+        return http.Response('Not found', 404);
+      });
+      await tester.pumpWidget(buildDialog(
+        defaultAllowedDomains: ['github.com:443', 'pypi.org'],
+      ));
+      await tester.pump();
+      await tester.pump();
+
+      // Remove pypi.org (the second chip's close button).
+      await tester.tap(find.byIcon(Icons.close).at(1));
+      await tester.pump();
+      expect(find.text('pypi.org'), findsNothing);
+
+      // Add a new domain.
+      final input = find.widgetWithText(TextField, 'github.com:443');
+      await tester.ensureVisible(input);
+      await tester.enterText(input, 'added.io');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pump();
+
+      await tester.enterText(_nameField(), 'Edited');
+      await tester.tap(find.text('Create'));
+      await tester.pump();
+      await tester.pump();
+
+      // The default's pypi.org is gone; the added domain is present; the
+      // unedited default entry survives. Pure override, no merge.
+      expect(postedBody!['allowed_domains'], ['github.com:443', 'added.io']);
     });
 
     testWidgets('rejects an invalid allowed domain spec', (tester) async {

--- a/src/frontend/test/create_workspace_dialog_test.dart
+++ b/src/frontend/test/create_workspace_dialog_test.dart
@@ -427,6 +427,75 @@ void main() {
       expect(postedBody!['allowed_domains'], ['github.com:443']);
     });
 
+    testWidgets('rejects an invalid allowed domain spec', (tester) async {
+      testAuthHttpClientOverride = mockClient(
+        (_) async => http.Response('Not found', 404),
+      );
+      await tester.pumpWidget(buildDialog());
+      await tester.pump(); // post-frame callback
+      await tester.pump(); // dialog renders
+
+      final input = find.widgetWithText(TextField, 'github.com:443');
+      await tester.ensureVisible(input);
+      await tester.enterText(input, 'bad spec');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pump();
+
+      expect(find.text('Expected host or host:port'), findsOneWidget);
+      // The bad spec did not become a list item.
+      expect(
+        find.byWidgetPredicate(
+          (w) => w is SelectableText && (w.data ?? '') == 'bad spec',
+        ),
+        findsNothing,
+      );
+    });
+
+    testWidgets('removes an allowed domain via its close button',
+        (tester) async {
+      testAuthHttpClientOverride = mockClient(
+        (_) async => http.Response('Not found', 404),
+      );
+      await tester.pumpWidget(buildDialog());
+      await tester.pump(); // post-frame callback
+      await tester.pump(); // dialog renders
+
+      final input = find.widgetWithText(TextField, 'github.com:443');
+      await tester.ensureVisible(input);
+      await tester.enterText(input, 'example.com:443');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pump();
+      expect(find.text('example.com:443'), findsOneWidget);
+
+      // The only close icon on screen is this chip's remove button
+      // (no mounts/env chips were added).
+      await tester.tap(find.byIcon(Icons.close));
+      await tester.pump();
+      expect(find.text('example.com:443'), findsNothing);
+    });
+
+    testWidgets('copies an allowed domain via its copy button', (tester) async {
+      testAuthHttpClientOverride = mockClient(
+        (_) async => http.Response('Not found', 404),
+      );
+      await tester.pumpWidget(buildDialog());
+      await tester.pump(); // post-frame callback
+      await tester.pump(); // dialog renders
+
+      final input = find.widgetWithText(TextField, 'github.com:443');
+      await tester.ensureVisible(input);
+      await tester.enterText(input, 'example.com:443');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pump();
+
+      // The only copy icon on screen is this chip's copy button.
+      await tester.tap(find.byIcon(Icons.copy));
+      await tester.pump();
+      // Tapping copy fired the chip's onPressed (Clipboard.setData) —
+      // the chip is otherwise unchanged.
+      expect(find.text('example.com:443'), findsOneWidget);
+    });
+
     testWidgets('clears mount error on successful add', (tester) async {
       testAuthHttpClientOverride = mockClient(
         (_) async => http.Response('Not found', 404),

--- a/src/frontend/test/create_workspace_dialog_test.dart
+++ b/src/frontend/test/create_workspace_dialog_test.dart
@@ -64,6 +64,7 @@ void main() {
     List<String>? allowedImages,
     bool allowAutostart = false,
     List<String> defaultAllowedDomains = const [],
+    bool netfilterEnabled = false,
   }) {
     final a = auth ?? AuthService();
     return MaterialApp(
@@ -80,6 +81,7 @@ void main() {
                   allowedImages: allowedImages ?? [defaultImage, 'klangk-full'],
                   allowAutostart: allowAutostart,
                   defaultAllowedDomains: defaultAllowedDomains,
+                  netfilterEnabled: netfilterEnabled,
                 ),
               );
             });
@@ -580,6 +582,53 @@ void main() {
       // Tapping copy fired the chip's onPressed (Clipboard.setData) —
       // the chip is otherwise unchanged.
       expect(find.text('example.com:443'), findsOneWidget);
+    });
+
+    testWidgets('rejects port > 65535', (tester) async {
+      testAuthHttpClientOverride = mockClient(
+        (_) async => http.Response('Not found', 404),
+      );
+      await tester.pumpWidget(buildDialog());
+      await tester.pump();
+      await tester.pump();
+
+      final input = find.widgetWithText(TextField, 'github.com:443');
+      await tester.ensureVisible(input);
+      await tester.enterText(input, 'a.com:99999');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pump();
+
+      expect(find.textContaining('65535'), findsOneWidget);
+    });
+
+    testWidgets('shows not-enforced notice when netfilter disabled',
+        (tester) async {
+      testAuthHttpClientOverride = mockClient(
+        (_) async => http.Response('Not found', 404),
+      );
+      await tester.pumpWidget(buildDialog(
+        defaultAllowedDomains: ['github.com:443'],
+        netfilterEnabled: false,
+      ));
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.textContaining('NOT be enforced'), findsOneWidget);
+    });
+
+    testWidgets('hides not-enforced notice when netfilter enabled',
+        (tester) async {
+      testAuthHttpClientOverride = mockClient(
+        (_) async => http.Response('Not found', 404),
+      );
+      await tester.pumpWidget(buildDialog(
+        defaultAllowedDomains: ['github.com:443'],
+        netfilterEnabled: true,
+      ));
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.textContaining('NOT be enforced'), findsNothing);
     });
 
     testWidgets('clears mount error on successful add', (tester) async {

--- a/src/frontend/test/create_workspace_dialog_test.dart
+++ b/src/frontend/test/create_workspace_dialog_test.dart
@@ -100,7 +100,7 @@ void main() {
       expect(find.text('New Workspace'), findsOneWidget);
       expect(find.text('Cancel'), findsOneWidget);
       expect(find.text('Create'), findsOneWidget);
-      expect(find.byType(TextField), findsNWidgets(5));
+      expect(find.byType(TextField), findsNWidgets(6));
       expect(find.byType(DropdownButtonFormField<String>), findsOneWidget);
     });
 
@@ -393,6 +393,38 @@ void main() {
       await tester.pump();
 
       expect(postedBody!.containsKey('image'), isFalse);
+      // allowed_domains is omitted entirely when none are added.
+      expect(postedBody!.containsKey('allowed_domains'), isFalse);
+    });
+
+    testWidgets('includes allowed domains in body', (tester) async {
+      Map<String, dynamic>? postedBody;
+      testAuthHttpClientOverride = mockClient((request) async {
+        if (request.method == 'POST') {
+          postedBody = jsonDecode(request.body) as Map<String, dynamic>;
+          return http.Response(
+            jsonEncode({'id': 'ws-1', 'name': 'x', 'created_at': ''}),
+            200,
+          );
+        }
+        return http.Response('Not found', 404);
+      });
+      await tester.pumpWidget(buildDialog());
+      await tester.pump(); // post-frame callback
+      await tester.pump(); // dialog renders
+
+      final input = find.widgetWithText(TextField, 'github.com:443');
+      await tester.ensureVisible(input);
+      await tester.enterText(input, 'github.com:443');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pump();
+
+      await tester.enterText(_nameField(), 'Filtered');
+      await tester.tap(find.text('Create'));
+      await tester.pump();
+      await tester.pump();
+
+      expect(postedBody!['allowed_domains'], ['github.com:443']);
     });
 
     testWidgets('clears mount error on successful add', (tester) async {

--- a/src/frontend/test/workspace_list_page_test.dart
+++ b/src/frontend/test/workspace_list_page_test.dart
@@ -1062,7 +1062,7 @@ void main() {
       expect(
           find.descendant(
               of: find.byType(AlertDialog), matching: find.byType(TextField)),
-          findsNWidgets(5));
+          findsNWidgets(6));
       expect(find.byType(DropdownButtonFormField<String>), findsOneWidget);
     });
 

--- a/src/frontend/test/workspace_list_page_test.dart
+++ b/src/frontend/test/workspace_list_page_test.dart
@@ -107,11 +107,16 @@ void main() {
     Future<http.Response> Function(http.Request) handler, {
     Map<String, List<String>>? permissions,
     List<Map<String, dynamic>>? groups,
+    bool netfilterEnabled = false,
   }) {
     return MockClient((request) async {
       if (request.url.path.contains('/api/v1/config')) {
         return http.Response(
-          jsonEncode({'login_banner_title': '', 'login_banner': ''}),
+          jsonEncode({
+            'login_banner_title': '',
+            'login_banner': '',
+            'netfilter_enabled': netfilterEnabled,
+          }),
           200,
         );
       }
@@ -359,6 +364,88 @@ void main() {
       // First letters of email addresses
       expect(find.text('A'), findsOneWidget);
       expect(find.text('B'), findsOneWidget);
+    });
+
+    // #1769: a workspace carrying allowed_domains while the deploy has
+    // netfilter disabled starts unrestricted (fail-open); badge it so the
+    // user who set the list sees the gap, not just operator logs.
+    group('egress not-enforced badge (#1769)', () {
+      testWidgets('badges a workspace with allowed_domains when netfilter off',
+          (tester) async {
+        testAuthHttpClientOverride = withPermissions((request) async {
+          if (request.url.path == '/api/v1/workspaces') {
+            return http.Response(
+              jsonEncode(_envelope([
+                {
+                  'id': 'ws-1',
+                  'name': 'Filtered',
+                  'container_id': null,
+                  'created_at': '2026-01-15 14:30:00',
+                  'allowed_domains': ['github.com:443'],
+                },
+              ])),
+              200,
+            );
+          }
+          return http.Response('Not found', 404);
+        });
+        await tester.pumpWidget(buildPage());
+        await tester.pumpAndSettle();
+
+        expect(find.byIcon(Icons.warning_amber), findsOneWidget);
+      });
+
+      testWidgets('no badge when netfilter is enabled (allow-list enforced)',
+          (tester) async {
+        testAuthHttpClientOverride = withPermissions(
+          (request) async {
+            if (request.url.path == '/api/v1/workspaces') {
+              return http.Response(
+                jsonEncode(_envelope([
+                  {
+                    'id': 'ws-1',
+                    'name': 'Filtered',
+                    'container_id': null,
+                    'created_at': '2026-01-15 14:30:00',
+                    'allowed_domains': ['github.com:443'],
+                  },
+                ])),
+                200,
+              );
+            }
+            return http.Response('Not found', 404);
+          },
+          netfilterEnabled: true,
+        );
+        await tester.pumpWidget(buildPage());
+        await tester.pumpAndSettle();
+
+        expect(find.byIcon(Icons.warning_amber), findsNothing);
+      });
+
+      testWidgets('no badge when a workspace has no allowed_domains',
+          (tester) async {
+        testAuthHttpClientOverride = withPermissions((request) async {
+          if (request.url.path == '/api/v1/workspaces') {
+            return http.Response(
+              jsonEncode(_envelope([
+                {
+                  'id': 'ws-1',
+                  'name': 'Plain',
+                  'container_id': null,
+                  'created_at': '2026-01-15 14:30:00',
+                },
+              ])),
+              200,
+            );
+          }
+          return http.Response('Not found', 404);
+        });
+        await tester.pumpWidget(buildPage());
+        await tester.pumpAndSettle();
+
+        expect(find.byIcon(Icons.warning_amber), findsNothing);
+      });
     });
 
     testWidgets('shows shared workspaces section', (tester) async {

--- a/src/frontend/test/workspace_settings_panel_test.dart
+++ b/src/frontend/test/workspace_settings_panel_test.dart
@@ -70,10 +70,17 @@ http.Client _client({
   int transferStatus = 200,
   Map<String, dynamic>? transferResponse,
   List<Map<String, dynamic>>? searchResults,
+  bool netfilterEnabled = false,
 }) {
   final ws = (workspace ?? _workspace);
   return MockClient((request) async {
     final p = request.url.path;
+    if (p == '/api/v1/config') {
+      return http.Response(
+        jsonEncode({'netfilter_enabled': netfilterEnabled}),
+        200,
+      );
+    }
     if (p == '/api/v1/workspaces') {
       return http.Response(jsonEncode([ws]), 200);
     }
@@ -405,6 +412,60 @@ void main() {
       await tester.pump(const Duration(seconds: 2));
       await tester.pumpAndSettle();
     });
+  });
+
+  // #1769: a workspace that declares allowed_domains while the deploy has
+  // netfilter disabled starts unrestricted (fail-open). The gap must be
+  // surfaced to the user who set the list, not just operator logs.
+  group('egress not-enforced notice (#1769)', () {
+    testWidgets(
+      'shows the notice when allowed_domains are set and netfilter is off',
+      (tester) async {
+        testAuthHttpClientOverride = _client(
+          workspace: {
+            ..._workspace,
+            'allowed_domains': <String>['example.com:443'],
+          },
+        );
+        await tester.pumpWidget(_buildPanel());
+        await tester.pumpAndSettle();
+
+        expect(
+          find.textContaining('NOT being enforced'),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgets(
+      'hides the notice when netfilter is enabled (allow-list enforced)',
+      (tester) async {
+        testAuthHttpClientOverride = _client(
+          workspace: {
+            ..._workspace,
+            'allowed_domains': <String>['example.com:443'],
+          },
+          netfilterEnabled: true,
+        );
+        await tester.pumpWidget(_buildPanel());
+        await tester.pumpAndSettle();
+
+        expect(find.textContaining('NOT being enforced'), findsNothing);
+      },
+    );
+
+    testWidgets(
+      'hides the notice when no allowed_domains are set (unrestricted by '
+      'design)',
+      (tester) async {
+        // Default workspace has no allowed_domains; nothing to enforce.
+        testAuthHttpClientOverride = _client();
+        await tester.pumpWidget(_buildPanel());
+        await tester.pumpAndSettle();
+
+        expect(find.textContaining('NOT being enforced'), findsNothing);
+      },
+    );
   });
 
   group('save', () {

--- a/src/frontend/test/workspace_settings_panel_test.dart
+++ b/src/frontend/test/workspace_settings_panel_test.dart
@@ -498,6 +498,88 @@ void main() {
       // Drain the 2s auto-clear timer (see save-success test).
       await tester.pumpAndSettle();
     });
+
+    testWidgets(
+        'allowed_domains change on a running container shows restart notice',
+        (tester) async {
+      // #1365: the egress filter is baked at container create time, so a
+      // saved change only takes effect after a restart. The notice appears
+      // only when a container is running AND allowed_domains changed.
+      // Mounts/env emptied so the only close icon is the domain chip's.
+      testAuthHttpClientOverride = _client(workspace: {
+        ..._workspace,
+        'mounts': <String>[],
+        'env': <String, String>{},
+        'allowed_domains': <String>['old.example:443'],
+        'running': true,
+      });
+      await tester.pumpWidget(_buildPanel());
+      await tester.pumpAndSettle();
+
+      // Remove the existing domain so the save differs from the loaded ws.
+      await tester.tap(find.byIcon(Icons.close).first);
+      await tester.pump();
+
+      await _scrollToAndTap(tester, find.text('Save'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text('Settings saved'), findsOneWidget);
+      expect(find.textContaining('Restart the workspace container'),
+          findsOneWidget);
+      await tester.pump(const Duration(seconds: 2));
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('no restart notice when allowed_domains unchanged on save',
+        (tester) async {
+      // Saving without touching the filter must not nag.
+      testAuthHttpClientOverride = _client(workspace: {
+        ..._workspace,
+        'allowed_domains': <String>['stable.example:443'],
+        'running': true,
+      });
+      await tester.pumpWidget(_buildPanel());
+      await tester.pumpAndSettle();
+
+      await _scrollToAndTap(tester, find.text('Save'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text('Settings saved'), findsOneWidget);
+      expect(
+          find.textContaining('Restart the workspace container'), findsNothing);
+      await tester.pump(const Duration(seconds: 2));
+      await tester.pumpAndSettle();
+    });
+
+    testWidgets('no restart notice when container is not running',
+        (tester) async {
+      // A stopped workspace picks the new rules up on next start — no
+      // action needed, so no notice even though allowed_domains changed.
+      testAuthHttpClientOverride = _client(workspace: {
+        ..._workspace,
+        'mounts': <String>[],
+        'env': <String, String>{},
+        'allowed_domains': <String>['old.example:443'],
+        'running': false,
+      });
+      await tester.pumpWidget(_buildPanel());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byIcon(Icons.close).first);
+      await tester.pump();
+
+      await _scrollToAndTap(tester, find.text('Save'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.text('Settings saved'), findsOneWidget);
+      expect(
+          find.textContaining('Restart the workspace container'), findsNothing);
+      await tester.pump(const Duration(seconds: 2));
+      await tester.pumpAndSettle();
+    });
   });
 
   group('auto start', () {

--- a/src/frontend/test/workspace_settings_panel_test.dart
+++ b/src/frontend/test/workspace_settings_panel_test.dart
@@ -330,6 +330,81 @@ void main() {
         findsNothing,
       );
     });
+
+    testWidgets('removes an allowed domain via its close button',
+        (tester) async {
+      // Mounts/env empty so the only close icon on screen belongs to the
+      // allowed-domains chip.
+      testAuthHttpClientOverride = _client(workspace: {
+        ..._workspace,
+        'mounts': <String>[],
+        'env': <String, String>{},
+        'allowed_domains': <String>['example.com:443'],
+      });
+      await tester.pumpWidget(_buildPanel());
+      await tester.pumpAndSettle();
+
+      expect(find.text('example.com:443'), findsOneWidget);
+      await tester.tap(find.byIcon(Icons.close));
+      await tester.pump();
+
+      expect(find.text('example.com:443'), findsNothing);
+    });
+
+    testWidgets('reload after save re-reads allowed_domains from server',
+        (tester) async {
+      // A successful save calls _loadData(), which re-fetches the workspace
+      // and rebuilds the form with a fresh map. didUpdateWidget must
+      // re-read allowed_domains (#1365) so the editor tracks server state
+      // instead of holding a stale local copy. The PUT drops the server's
+      // allowed_domains entirely so the null-coalescing fallback in the
+      // refresh path is also exercised.
+      List<String>? domains = ['example.com:443'];
+      testAuthHttpClientOverride = MockClient((request) async {
+        final p = request.url.path;
+        if (p == '/api/v1/workspaces') {
+          final ws = <String, dynamic>{..._workspace};
+          if (domains != null)
+            ws['allowed_domains'] = List<String>.from(domains!);
+          return http.Response(jsonEncode([ws]), 200);
+        }
+        if (p == '/api/v1/workspaces/shared') {
+          return http.Response(jsonEncode([]), 200);
+        }
+        if (p == '/api/v1/images') {
+          return http.Response(
+            jsonEncode({
+              'default': 'klangk-pi',
+              'allowed': ['klangk-pi', 'other:latest'],
+            }),
+            200,
+          );
+        }
+        if (p == '/api/v1/workspaces/$_wsId' && request.method == 'PUT') {
+          domains = null;
+          return http.Response(jsonEncode({'status': 'updated'}), 200);
+        }
+        return http.Response('not found', 404);
+      });
+      await tester.pumpWidget(_buildPanel());
+      await tester.pumpAndSettle();
+      expect(find.text('example.com:443'), findsOneWidget);
+
+      await _scrollToAndTap(tester, find.text('Save'));
+      await tester.pump();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      // After the post-save reload the server no longer carries
+      // allowed_domains, so didUpdateWidget refreshed _allowedDomains to
+      // empty (the null-coalescing fallback) and the chip is gone.
+      expect(find.text('example.com:443'), findsNothing);
+
+      // Advance past the 2s save-message auto-clear timer so no timer is
+      // pending at dispose (flutter_test fails on pending timers).
+      await tester.pump(const Duration(seconds: 2));
+      await tester.pumpAndSettle();
+    });
   });
 
   group('save', () {

--- a/src/frontend/test/workspace_settings_panel_test.dart
+++ b/src/frontend/test/workspace_settings_panel_test.dart
@@ -23,6 +23,9 @@ Finder _mountInput() => find.byWidgetPredicate(
 Finder _envInput() => find.byWidgetPredicate(
       (w) => w is TextField && w.decoration?.hintText == 'KEY=VALUE',
     );
+Finder _allowedDomainsInput() => find.byWidgetPredicate(
+      (w) => w is TextField && w.decoration?.hintText == 'github.com:443',
+    );
 
 /// A WsClient whose sendShutdownContainer we can observe, for the danger-zone
 /// confirm dialog test.
@@ -296,6 +299,36 @@ void main() {
       await tester.pump();
 
       expect(find.text('FOO=bar'), findsNothing);
+    });
+  });
+
+  group('allowed domains editor', () {
+    testWidgets('adds a valid host:port', (tester) async {
+      await tester.pumpWidget(_buildPanel());
+      await tester.pumpAndSettle();
+
+      await tester.enterText(_allowedDomainsInput(), 'example.com:443');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pump();
+
+      expect(find.text('example.com:443'), findsOneWidget);
+    });
+
+    testWidgets('rejects a spec with whitespace', (tester) async {
+      await tester.pumpWidget(_buildPanel());
+      await tester.pumpAndSettle();
+
+      await tester.enterText(_allowedDomainsInput(), 'bad spec');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pump();
+
+      expect(find.text('Expected host or host:port'), findsOneWidget);
+      expect(
+        find.byWidgetPredicate(
+          (w) => w is SelectableText && (w.data ?? '') == 'bad spec',
+        ),
+        findsNothing,
+      );
     });
   });
 

--- a/src/klangk/klangk/api/__init__.py
+++ b/src/klangk/klangk/api/__init__.py
@@ -184,7 +184,10 @@ if os.environ.get("KLANGKD_TEST_MODE"):  # pragma: no cover
 
 
 @router.get("/config")
-async def get_config(app=Depends(get_app_dep)):
+async def get_config(
+    app=Depends(get_app_dep),
+    user: dict | None = Depends(auth.get_current_user_optional),
+):
     s = app.state.settings
     config = {
         "registration_enabled": app.state.auth.registration_enabled(),
@@ -218,15 +221,20 @@ async def get_config(app=Depends(get_app_dep)):
         "aup_url": s.aup_url,
         "support_url": s.support_url,
         "support_email": s.support_email,
-        # #1365: deploy-wide netfilter allow-list + whether the feature is
-        # armed. The create-workspace UI pre-fills its allowed-domains
-        # editor from this default so a new workspace inherits the
-        # deployer's floor; the creator's edits replace it (stored on the
-        # workspace). netfilter_enabled lets the UI show the editor only
-        # when the deploy can actually enforce it.
-        "netfilter_default_domains": app.state.netfilter.default_domains(),
-        "netfilter_enabled": app.state.netfilter.enabled(),
     }
+    # #1365: deploy-wide netfilter allow-list + whether the feature is
+    # armed. These advertise the deploy's egress perimeter, so they are
+    # exposed only to authenticated callers — NOT on the pre-auth /config
+    # payload that feeds the login page (otherwise an anonymous caller
+    # learns which hosts this deploy permits and whether the filter is on).
+    # The create-workspace UI reads them post-login (the frontend sends the
+    # persisted token on its /config fetch and re-fetches after login). See
+    # #1769 re: per-workspace enforcement visibility.
+    if user is not None:
+        config["netfilter_default_domains"] = (
+            app.state.netfilter.default_domains()
+        )
+        config["netfilter_enabled"] = app.state.netfilter.enabled()
     config.update(app.state.features.frontend_config())
     # KLANGKD_FEATURES_ENABLE: the deploy's chosen active-feature list,
     # forwarded verbatim so the frontend can resolve the active set against

--- a/src/klangk/klangk/api/__init__.py
+++ b/src/klangk/klangk/api/__init__.py
@@ -218,6 +218,14 @@ async def get_config(app=Depends(get_app_dep)):
         "aup_url": s.aup_url,
         "support_url": s.support_url,
         "support_email": s.support_email,
+        # #1365: deploy-wide netfilter allow-list + whether the feature is
+        # armed. The create-workspace UI pre-fills its allowed-domains
+        # editor from this default so a new workspace inherits the
+        # deployer's floor; the creator's edits replace it (stored on the
+        # workspace). netfilter_enabled lets the UI show the editor only
+        # when the deploy can actually enforce it.
+        "netfilter_default_domains": app.state.netfilter.default_domains(),
+        "netfilter_enabled": app.state.netfilter.enabled(),
     }
     config.update(app.state.features.frontend_config())
     # KLANGKD_FEATURES_ENABLE: the deploy's chosen active-feature list,

--- a/src/klangk/klangk/api/workspaces.py
+++ b/src/klangk/klangk/api/workspaces.py
@@ -81,12 +81,11 @@ def _validate_allowed_domains(
         domains = netfilter_mod.parse_allowed_domains(values)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
-    if app.state.netfilter.hooks_dir() is None:
+    if not app.state.netfilter.enabled():
         logger.warning(
-            "Workspace configured allowed_domains=%s but netfilter is "
-            "disabled (KLANGKD_NETFILTER_HOOKS_DIR unset); the value is "
-            "persisted but egress will be UNRESTRICTED until netfilter is "
-            "enabled (#1365).",
+            "Workspace configured allowed_domains=%s but netfilter is not "
+            "armed on this server; the value is persisted but egress will "
+            "be UNRESTRICTED until netfilter is enabled (#1365, #1774).",
             domains,
         )
     return domains

--- a/src/klangk/klangk/api/workspaces.py
+++ b/src/klangk/klangk/api/workspaces.py
@@ -28,6 +28,7 @@ from sqlalchemy.exc import IntegrityError as SAIntegrityError
 from .. import (
     acl,
     auth,
+    netfilter as netfilter_mod,
     wshandler,
 )
 from ._common import get_app_dep
@@ -60,6 +61,35 @@ router = APIRouter()
 # safety ceiling, not a hard contract -- a user with more workspaces
 # than this should use explicit pagination.
 BARE_LIST_LIMIT = 500
+
+
+def _validate_allowed_domains(
+    values: list[str] | None, app
+) -> list[str] | None:
+    """Validate + normalize a workspace's ``allowed_domains`` list.
+
+    Returns the validated list (de-duplicated, ordered), or ``None`` when
+    no list was supplied (unrestricted egress). Raises an HTTP 400 with a
+    precise message on any malformed ``host[:port]`` entry. Only warns —
+    never rejects — when the deployer has not enabled netfilter: the value
+    is still persisted so it takes effect the moment the operator sets
+    ``KLANGKD_NETFILTER_HOOKS_DIR`` (#1365).
+    """
+    if not values:
+        return None
+    try:
+        domains = netfilter_mod.parse_allowed_domains(values)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if app.state.netfilter.hooks_dir() is None:
+        logger.warning(
+            "Workspace configured allowed_domains=%s but netfilter is "
+            "disabled (KLANGKD_NETFILTER_HOOKS_DIR unset); the value is "
+            "persisted but egress will be UNRESTRICTED until netfilter is "
+            "enabled (#1365).",
+            domains,
+        )
+    return domains
 
 
 def _annotate_running(items: list[dict], container_registry) -> list[dict]:
@@ -162,6 +192,7 @@ class CreateWorkspaceRequest(BaseModel):
     env: dict[str, str] | None = None
     setup_state: Literal["pending", "complete", "failed"] | None = None
     health_check: str | None = None
+    allowed_domains: list[str] | None = None
 
 
 @router.post("/workspaces")
@@ -189,6 +220,7 @@ async def create_workspace(
         mount_err = app.state.container_registry.validate_mounts(body.mounts)
         if mount_err:
             raise HTTPException(status_code=400, detail=mount_err)
+    allowed_domains = _validate_allowed_domains(body.allowed_domains, app)
     try:
         ws = await app.state.workspaces.create_workspace(
             user["id"],
@@ -200,6 +232,7 @@ async def create_workspace(
             env=body.env,
             setup_state=body.setup_state or "complete",
             health_check=body.health_check,
+            allowed_domains=allowed_domains,
         )
     except SAIntegrityError:
         raise HTTPException(
@@ -238,6 +271,7 @@ class UpdateWorkspaceRequest(BaseModel):
     env: dict[str, str] | None = None
     setup_state: Literal["pending", "complete", "failed"] | None = None
     health_check: str | None = None
+    allowed_domains: list[str] | None = None
 
 
 @router.put("/workspaces/{workspace_id}")
@@ -267,6 +301,10 @@ async def update_workspace(
         )
         if mount_err:
             raise HTTPException(status_code=400, detail=mount_err)
+    if "allowed_domains" in fields:
+        fields["allowed_domains"] = _validate_allowed_domains(
+            fields["allowed_domains"], app
+        )
     if not fields:
         raise HTTPException(status_code=400, detail="No fields to update")
     workspace = await app.state.model.workspaces.get_workspace(workspace_id)
@@ -320,6 +358,7 @@ async def duplicate_workspace(
             mounts=source.get("mounts"),
             env=source.get("env"),
             health_check=source.get("health_check"),
+            allowed_domains=source.get("allowed_domains"),
         )
     except SAIntegrityError:
         raise HTTPException(
@@ -674,6 +713,7 @@ async def _extract_archive_metadata(
         "mounts": mounts,
         "env": env,
         "health_check": metadata.get("health_check"),
+        "allowed_domains": metadata.get("allowed_domains"),
     }
 
 
@@ -732,6 +772,9 @@ async def import_workspace(
     ws = None
     try:
         meta = await _extract_archive_metadata(archive_path, name, app)
+        allowed_domains = _validate_allowed_domains(
+            meta.get("allowed_domains"), app
+        )
 
         try:
             ws = await app.state.workspaces.create_workspace(
@@ -743,6 +786,7 @@ async def import_workspace(
                 mounts=meta["mounts"],
                 env=meta["env"],
                 health_check=meta["health_check"],
+                allowed_domains=allowed_domains,
             )
         except SAIntegrityError:
             raise HTTPException(

--- a/src/klangk/klangk/container.py
+++ b/src/klangk/klangk/container.py
@@ -1040,16 +1040,16 @@ class ContainerRegistry:
 
     def _egress_filter(
         self, allowed_domains: list[str] | None
-    ) -> tuple[dict[str, str] | None, str | None]:
-        """Build ``(annotations, hooks_dir)`` for per-workspace egress (#1365).
+    ) -> tuple[dict[str, str] | None, str | None, list[str] | None]:
+        """Build ``(annotations, hooks_dir, cap_drop)`` for egress (#1365).
 
-        ``(None, None)`` when unrestricted (no domains, or netfilter
+        ``(None, None, None)`` when unrestricted (no domains, or netfilter
         disabled). Delegates to ``app.state.netfilter``; defensive for
         test app-states that may not wire it.
         """
         nf = getattr(self.app.state, "netfilter", None)
         if nf is None:
-            return None, None
+            return None, None, None
         return nf.create_kwargs(allowed_domains)
 
     async def start_container(
@@ -1577,11 +1577,14 @@ class ContainerRegistry:
         # Per-workspace egress filtering (#1365): add the OCI annotation
         # + --hooks-dir only when the workspace declares allowed_domains
         # AND netfilter is enabled, so unrestricted workspaces keep
-        # podman's default hooks-dir behavior (no behavior change).
-        annotations, hooks_dir = self._egress_filter(allowed_domains)
+        # podman's default hooks-dir behavior (no behavior change). The
+        # filtered container also drops NET_ADMIN (#1773) so the entrypoint
+        # can't flush the ruleset.
+        annotations, hooks_dir, cap_drop = self._egress_filter(allowed_domains)
         if annotations is not None:
             create_kwargs["annotations"] = annotations
             create_kwargs["hooks_dir"] = hooks_dir
+            create_kwargs["cap_drop"] = cap_drop
 
         logger.info(
             "workspace-open: build env vars, volumes, and "

--- a/src/klangk/klangk/container.py
+++ b/src/klangk/klangk/container.py
@@ -1040,8 +1040,8 @@ class ContainerRegistry:
 
     def _egress_filter(
         self, allowed_domains: list[str] | None
-    ) -> tuple[dict[str, str] | None, str | None, list[str] | None]:
-        """Build ``(annotations, hooks_dir, cap_drop)`` for egress (#1365).
+    ) -> tuple[dict[str, str] | None, list[str] | None, list[str] | None]:
+        """Build ``(annotations, hooks_dirs, cap_drop)`` for egress (#1365).
 
         ``(None, None, None)`` when unrestricted (no domains, or netfilter
         disabled). Delegates to ``app.state.netfilter``; defensive for
@@ -1578,12 +1578,17 @@ class ContainerRegistry:
         # + --hooks-dir only when the workspace declares allowed_domains
         # AND netfilter is enabled, so unrestricted workspaces keep
         # podman's default hooks-dir behavior (no behavior change). The
-        # filtered container also drops NET_ADMIN (#1773) so the entrypoint
-        # can't flush the ruleset.
-        annotations, hooks_dir, cap_drop = self._egress_filter(allowed_domains)
+        # klangk hooks dir is passed alongside the standard default hook
+        # dirs (#1770 — --hooks-dir overrides, not appends, so the
+        # standard dirs are repeated to keep operator createContainer
+        # hooks running). The filtered container also drops NET_ADMIN
+        # (#1773) so the entrypoint can't flush the ruleset.
+        annotations, hooks_dirs, cap_drop = self._egress_filter(
+            allowed_domains
+        )
         if annotations is not None:
             create_kwargs["annotations"] = annotations
-            create_kwargs["hooks_dir"] = hooks_dir
+            create_kwargs["hooks_dir"] = hooks_dirs
             create_kwargs["cap_drop"] = cap_drop
 
         logger.info(

--- a/src/klangk/klangk/container.py
+++ b/src/klangk/klangk/container.py
@@ -1038,6 +1038,20 @@ class ContainerRegistry:
             setup_state=setup_state,
         )
 
+    def _egress_filter(
+        self, allowed_domains: list[str] | None
+    ) -> tuple[dict[str, str] | None, str | None]:
+        """Build ``(annotations, hooks_dir)`` for per-workspace egress (#1365).
+
+        ``(None, None)`` when unrestricted (no domains, or netfilter
+        disabled). Delegates to ``app.state.netfilter``; defensive for
+        test app-states that may not wire it.
+        """
+        nf = getattr(self.app.state, "netfilter", None)
+        if nf is None:
+            return None, None
+        return nf.create_kwargs(allowed_domains)
+
     async def start_container(
         self,
         workspace_id: str,
@@ -1056,6 +1070,7 @@ class ContainerRegistry:
         health_check: str | None = None,
         setup_state: str | None = None,
         service_command: str | None = None,
+        allowed_domains: list[str] | None = None,
     ) -> tuple[str, str]:
         """Start (or restart) a Pi container for a workspace.
 
@@ -1083,6 +1098,7 @@ class ContainerRegistry:
                 health_check=health_check,
                 setup_state=setup_state,
                 service_command=service_command,
+                allowed_domains=allowed_domains,
             )
 
     async def _handle_existing_container(
@@ -1463,6 +1479,7 @@ class ContainerRegistry:
         health_check: str | None = None,
         setup_state: str | None = None,
         service_command: str | None = None,
+        allowed_domains: list[str] | None = None,
     ) -> tuple[str, str]:
         """Inner implementation of start_container (called under lock)."""
         t_start = time.monotonic()
@@ -1556,6 +1573,15 @@ class ContainerRegistry:
             userns=self.app.state.settings.userns,
             pull=self.image_pull_policy(),
         )
+
+        # Per-workspace egress filtering (#1365): add the OCI annotation
+        # + --hooks-dir only when the workspace declares allowed_domains
+        # AND netfilter is enabled, so unrestricted workspaces keep
+        # podman's default hooks-dir behavior (no behavior change).
+        annotations, hooks_dir = self._egress_filter(allowed_domains)
+        if annotations is not None:
+            create_kwargs["annotations"] = annotations
+            create_kwargs["hooks_dir"] = hooks_dir
 
         logger.info(
             "workspace-open: build env vars, volumes, and "

--- a/src/klangk/klangk/main.py
+++ b/src/klangk/klangk/main.py
@@ -27,6 +27,7 @@ from . import (
     oidc,
     features,
     podman,
+    netfilter,
     ssl_trust,
     terminal,
     util as util_mod,
@@ -353,6 +354,11 @@ class Lifecycle:
         SIGHUP restart path.
         """
         state = self.app.state
+        # #1365: materialize the OCI egress-filter hook into the configured
+        # hooks dir (no-op when netfilter is disabled). Best-effort — a
+        # failure logs and leaves the feature disabled rather than blocking
+        # startup.
+        state.netfilter.install_hooks()
         registry = state.container_registry
         await registry.prewarm_podman()
         await registry.reap_instance_containers()
@@ -460,6 +466,7 @@ class Lifecycle:
         # Every app.state subsystem that implements reconfigure().
         subsystems = [
             "ssl_trust",
+            "netfilter",
             "auth",
             "podman",
             "sockets",
@@ -861,6 +868,10 @@ def build_app(settings: KlangkSettings) -> FastAPI:
     # (cert-dir resolver + backend-process trust applier). The 4 pure
     # path/bundle helpers stay module-level in ssl_trust.py.
     app.state.ssl_trust = ssl_trust.SSLTrust(app)
+    # #1365: NetFilter(app_state) owns the per-workspace egress-filter
+    # OCI hook install dir + annotation builder (opt-in via
+    # KLANGKD_NETFILTER_HOOKS_DIR). Reaches config through self.settings.
+    app.state.netfilter = netfilter.NetFilter(app)
     app.state.auth = auth.Auth(app)
     # #1468: Podman(settings) owns the resolved binary path + the ~20 CLI
     # wrappers. Constructed before the registry/terminal so they reach it

--- a/src/klangk/klangk/model/schema.py
+++ b/src/klangk/klangk/model/schema.py
@@ -145,6 +145,9 @@ async def init_db(db) -> None:
                 health_check TEXT,
                 mounts TEXT,  -- JSON array of host:container mount specs
                 env TEXT,  -- JSON dict of custom environment variables
+                -- comma-joined host[:port] specs; NULL = unrestricted
+                -- egress (see KLANGKD_NETFILTER_HOOKS_DIR, #1365)
+                allowed_domains TEXT,
                 created_at TEXT NOT NULL DEFAULT (datetime('now')),
                 UNIQUE(user_id, name),
                 -- (C) the system agent must never own a workspace.
@@ -191,6 +194,13 @@ async def init_db(db) -> None:
             await db.execute("ALTER TABLE workspaces ADD COLUMN mounts TEXT")
         if "env" not in ws_cols:
             await db.execute("ALTER TABLE workspaces ADD COLUMN env TEXT")
+        # Migration: add allowed_domains column (#1365). NULL by default
+        # so existing workspaces keep unrestricted outbound networking;
+        # the filter is opt-in per workspace AND per deploy.
+        if "allowed_domains" not in ws_cols:
+            await db.execute(
+                "ALTER TABLE workspaces ADD COLUMN allowed_domains TEXT"
+            )
         await db.execute("""
             CREATE TABLE IF NOT EXISTS port_allocations (
                 port INTEGER PRIMARY KEY,

--- a/src/klangk/klangk/model/workspaces.py
+++ b/src/klangk/klangk/model/workspaces.py
@@ -100,6 +100,7 @@ class WorkspacesModel:
         env: dict[str, str] | None,
         setup_state: str,
         health_check: str | None,
+        allowed_domains: list[str] | None = None,
     ) -> dict:
         """INSERT a workspace row on ``db`` and return the new workspace dict.
 
@@ -110,11 +111,15 @@ class WorkspacesModel:
         created_at = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
         mounts_json = json.dumps(mounts) if mounts else None
         env_json = json.dumps(env) if env else None
+        allowed_domains_json = (
+            json.dumps(allowed_domains) if allowed_domains else None
+        )
         await db.execute(
             "INSERT INTO workspaces"
             " (id, user_id, name, image, service_command, auto_start,"
-            " setup_state, health_check, mounts, env, created_at)"
-            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            " setup_state, health_check, mounts, env, allowed_domains,"
+            " created_at)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 workspace_id,
                 user_id,
@@ -126,6 +131,7 @@ class WorkspacesModel:
                 health_check,
                 mounts_json,
                 env_json,
+                allowed_domains_json,
                 created_at,
             ),
         )
@@ -140,6 +146,7 @@ class WorkspacesModel:
             "health_check": health_check,
             "mounts": mounts,
             "env": env,
+            "allowed_domains": allowed_domains,
             "num_ports": DEFAULT_PORTS_PER_WORKSPACE,
             "created_at": created_at,
         }
@@ -219,6 +226,7 @@ class WorkspacesModel:
         env: dict[str, str] | None = None,
         setup_state: str = SETUP_STATE_COMPLETE,
         health_check: str | None = None,
+        allowed_domains: list[str] | None = None,
     ) -> dict:
         """Create a workspace row AND seed its owner ACE + role groups.
 
@@ -250,6 +258,7 @@ class WorkspacesModel:
                 env=env,
                 setup_state=setup_state,
                 health_check=health_check,
+                allowed_domains=allowed_domains,
             )
             await self._seed_workspace_acl(db, ws, user_id)
             return ws
@@ -265,6 +274,7 @@ class WorkspacesModel:
         env: dict[str, str] | None = None,
         setup_state: str = SETUP_STATE_COMPLETE,
         health_check: str | None = None,
+        allowed_domains: list[str] | None = None,
     ) -> dict:
         """Insert a workspace row only (no ACL seeding).
 
@@ -287,6 +297,7 @@ class WorkspacesModel:
                 env=env,
                 setup_state=setup_state,
                 health_check=health_check,
+                allowed_domains=allowed_domains,
             )
 
     async def list_workspaces(
@@ -317,7 +328,7 @@ class WorkspacesModel:
             cursor = await db.execute(
                 "SELECT id, name, container_id, image, service_command,"
                 " auto_start, setup_state, health_check, mounts, env,"
-                " created_at"
+                " allowed_domains, created_at"
                 " FROM workspaces"
                 f" {where} {order_by} LIMIT ? OFFSET ?",
                 tuple(params),
@@ -337,6 +348,9 @@ class WorkspacesModel:
                     if row["mounts"]
                     else None,
                     "env": json.loads(row["env"]) if row["env"] else None,
+                    "allowed_domains": json.loads(row["allowed_domains"])
+                    if row["allowed_domains"]
+                    else None,
                     "created_at": row["created_at"],
                 }
                 for row in rows
@@ -381,7 +395,8 @@ class WorkspacesModel:
             cursor = await db.execute(
                 "SELECT DISTINCT w.id, w.name, w.container_id, w.image,"
                 " w.service_command, w.auto_start, w.setup_state,"
-                " w.health_check, w.mounts, w.env, w.created_at,"
+                " w.health_check, w.mounts, w.env, w.allowed_domains,"
+                " w.created_at,"
                 " u.email AS owner_email"
                 " FROM workspaces w"
                 " JOIN acl_entries ae ON ae.resource = '/workspaces/' || w.id"
@@ -418,6 +433,9 @@ class WorkspacesModel:
                     if row["mounts"]
                     else None,
                     "env": json.loads(row["env"]) if row["env"] else None,
+                    "allowed_domains": json.loads(row["allowed_domains"])
+                    if row["allowed_domains"]
+                    else None,
                     "created_at": row["created_at"],
                     "owner_email": row["owner_email"],
                 }
@@ -444,7 +462,7 @@ class WorkspacesModel:
                 cursor = await db.execute(
                     "SELECT id, user_id, name, container_id, num_ports, image,"
                     " service_command, auto_start, setup_state, health_check,"
-                    " mounts, env"
+                    " mounts, env, allowed_domains"
                     " FROM workspaces WHERE id = ? AND user_id = ?",
                     (workspace_id, user_id),
                 )
@@ -452,7 +470,7 @@ class WorkspacesModel:
                 cursor = await db.execute(
                     "SELECT id, user_id, name, container_id, num_ports, image,"
                     " service_command, auto_start, setup_state, health_check,"
-                    " mounts, env"
+                    " mounts, env, allowed_domains"
                     " FROM workspaces WHERE id = ?",
                     (workspace_id,),
                 )
@@ -472,13 +490,17 @@ class WorkspacesModel:
                 "health_check": row["health_check"],
                 "mounts": json.loads(row["mounts"]) if row["mounts"] else None,
                 "env": json.loads(row["env"]) if row["env"] else None,
+                "allowed_domains": json.loads(row["allowed_domains"])
+                if row["allowed_domains"]
+                else None,
             }
 
     async def get_workspace_by_id(self, workspace_id: str) -> dict | None:
         """Get a workspace by ID without access control (for admin use)."""
         row = await self.app.state.db.fetchone(
             "SELECT id, user_id, name, container_id, num_ports, image,"
-            " service_command, setup_state, health_check, mounts, env"
+            " service_command, setup_state, health_check, mounts, env,"
+            " allowed_domains"
             " FROM workspaces WHERE id = ?",
             (workspace_id,),
         )
@@ -496,6 +518,9 @@ class WorkspacesModel:
             "health_check": row["health_check"],
             "mounts": json.loads(row["mounts"]) if row["mounts"] else None,
             "env": json.loads(row["env"]) if row["env"] else None,
+            "allowed_domains": json.loads(row["allowed_domains"])
+            if row["allowed_domains"]
+            else None,
         }
 
     async def get_workspace_members(self, workspace_id: str) -> list[dict]:
@@ -599,6 +624,7 @@ class WorkspacesModel:
             "health_check",
             "mounts",
             "env",
+            "allowed_domains",
         }
         to_set = {}
         for k, v in fields.items():
@@ -608,7 +634,7 @@ class WorkspacesModel:
                 if v not in SETUP_STATES:
                     raise ValueError(f"Invalid setup_state: {v!r}")
                 to_set[k] = v
-            elif k in ("mounts", "env"):
+            elif k in ("mounts", "env", "allowed_domains"):
                 to_set[k] = json.dumps(v) if v is not None else None
             elif k == "auto_start":
                 to_set[k] = 1 if v else 0
@@ -728,7 +754,7 @@ class WorkspacesModel:
             cursor = await db.execute(
                 "SELECT id, user_id, name, container_id, num_ports, image,"
                 " service_command, auto_start, setup_state, health_check,"
-                " mounts, env"
+                " mounts, env, allowed_domains"
                 " FROM workspaces WHERE auto_start = 1",
             )
             rows = await cursor.fetchall()
@@ -748,6 +774,9 @@ class WorkspacesModel:
                     if row["mounts"]
                     else None,
                     "env": json.loads(row["env"]) if row["env"] else None,
+                    "allowed_domains": json.loads(row["allowed_domains"])
+                    if row["allowed_domains"]
+                    else None,
                 }
                 for row in rows
             ]

--- a/src/klangk/klangk/netfilter.py
+++ b/src/klangk/klangk/netfilter.py
@@ -236,6 +236,20 @@ class NetFilter:
     def _raw_hooks_dir(self) -> str | None:
         return self.app.state.settings.netfilter_hooks_dir
 
+    def default_domains(self) -> list[str]:
+        """The deploy-wide default allow-list (#1365), already validated +
+        de-duped at settings construction (a bad spec aborts boot).
+
+        A workspace with no ``allowed_domains`` of its own inherits this.
+        Returns a copy so callers can't mutate the cached settings list.
+        """
+        raw = self.app.state.settings.netfilter_default_domains
+        return list(raw) if raw else []
+
+    def enabled(self) -> bool:
+        """Whether netfilter is armed on this deploy (hooks dir configured)."""
+        return self.hooks_dir() is not None
+
     def hooks_dir(self) -> str | None:
         """Return the configured hooks dir (validated to exist), else ``None``.
 
@@ -297,26 +311,33 @@ class NetFilter:
     ) -> tuple[dict[str, str] | None, str | None]:
         """Build ``(annotations, hooks_dir)`` for a workspace's container.
 
-        ``(None, None)`` when the workspace is unrestricted: no
-        ``allowed_domains`` (unrestricted by config), or netfilter is
-        disabled (the deployer did not configure a hooks dir). When
-        ``allowed_domains`` is set but netfilter is disabled, a loud
-        warning is logged — the workspace starts unrestricted and the
-        operator must enable netfilter to enforce the policy.
+        Resolution (#1365): a workspace's non-empty ``allowed_domains``
+        **overrides** the deploy-wide default; otherwise the default applies.
+        ``(None, None)`` — unrestricted — only when both are empty, or when
+        netfilter is disabled (no hooks dir). When an effective list exists
+        but netfilter is disabled, a loud warning is logged: the container
+        starts unrestricted and the operator must enable netfilter to
+        enforce the policy.
         """
-        if not allowed_domains:
+        # Workspace overrides the deploy default; empty/None inherits it.
+        domains = (
+            list(allowed_domains)
+            if allowed_domains
+            else self.default_domains()
+        )
+        if not domains:
             return None, None
         path = self.hooks_dir()
         if path is None:
             logger.warning(
-                "Workspace declares allowed_domains=%s but netfilter is "
+                "Effective allowed_domains=%s but netfilter is "
                 "disabled (KLANGKD_NETFILTER_HOOKS_DIR is unset or "
                 "unwritable); the workspace will start with UNRESTRICTED "
                 "egress. Configure KLANGKD_NETFILTER_HOOKS_DIR and ensure "
                 "iptables is available where the OCI runtime executes to "
                 "enforce the filter (#1365).",
-                allowed_domains,
+                domains,
             )
             return None, None
-        annotation = {ANNOTATION_KEY: render_rules_annotation(allowed_domains)}
+        annotation = {ANNOTATION_KEY: render_rules_annotation(domains)}
         return annotation, path

--- a/src/klangk/klangk/netfilter.py
+++ b/src/klangk/klangk/netfilter.py
@@ -103,7 +103,22 @@ def _valid_domain_spec(spec: str) -> bool:
         return False
     if "/" in spec:
         return False
-    return bool(_DOMAIN_RE.match(spec) or _DOMAIN_BRACKET_RE.match(spec))
+    if not (_DOMAIN_RE.match(spec) or _DOMAIN_BRACKET_RE.match(spec)):
+        return False
+    # The regex accepts up to 5 digits; additionally reject ports > 65535.
+    if ":" in spec:
+        # For bracketed IPv6 ([::1]:port), the port follows ']:'.
+        # For host:port, the port follows the last ':'.
+        if spec.startswith("["):
+            idx = spec.rfind("]:")
+            port_str = (
+                spec[idx + 2 :] if idx >= 0 and idx + 2 < len(spec) else None
+            )
+        else:
+            port_str = spec.rsplit(":", 1)[1]
+        if port_str and port_str.isdigit() and int(port_str) > 65535:
+            return False
+    return True
 
 
 def parse_allowed_domains(values: list[str]) -> list[str]:

--- a/src/klangk/klangk/netfilter.py
+++ b/src/klangk/klangk/netfilter.py
@@ -63,6 +63,21 @@ HOOK_SCRIPT_NAME = "klangk-netfilter.sh"
 # permissive seccomp profile. See issue #1773.
 DROPPED_CAPABILITIES = ("NET_ADMIN",)
 
+# The OCI hook search paths podman uses by default. ``--hooks-dir`` on the
+# ``podman create`` command line *overrides* these (it does not append), so
+# passing only klangk's hooks dir for a filtered workspace would silently
+# disable every *other* createContainer hook an operator relies on
+# (monitoring, secrets injection, GPU, corporate integrations). To keep
+# them running, a filtered container passes klangk's dir AND these two
+# standard default dirs (podman tolerates dirs that don't exist — it just
+# finds no hooks in them). A non-standard hooks dir configured only via
+# ``containers.conf`` is still clobbered by an explicit ``--hooks-dir``
+# (documented limitation). See issue #1770.
+STANDARD_HOOK_DIRS = (
+    "/usr/share/containers/oci/hooks.d",
+    "/etc/containers/oci/hooks.d",
+)
+
 # A hostname or IP (v4/v6), optionally bracketed for v6, with an optional
 # trailing ``:port``. Deliberately permissive on the host grammar — the
 # hook does the real DNS resolution; this just rejects gross mistakes
@@ -389,8 +404,8 @@ class NetFilter:
 
     def create_kwargs(
         self, allowed_domains: list[str] | None
-    ) -> tuple[dict[str, str] | None, str | None, list[str] | None]:
-        """Build ``(annotations, hooks_dir, cap_drop)`` for a container.
+    ) -> tuple[dict[str, str] | None, list[str] | None, list[str] | None]:
+        """Build ``(annotations, hooks_dirs, cap_drop)`` for a container.
 
         Resolution (#1365): a workspace's non-empty ``allowed_domains``
         **overrides** the deploy-wide default; otherwise the default applies.
@@ -399,6 +414,12 @@ class NetFilter:
         exists but netfilter is disabled, a loud warning is logged: the
         container starts unrestricted and the operator must enable netfilter
         to enforce the policy.
+
+        ``hooks_dirs`` is klangk's hooks dir followed by
+        :data:`STANDARD_HOOK_DIRS`: ``--hooks-dir`` overrides (does not
+        append) podman's default hook search paths, so the standard dirs are
+        repeated explicitly to keep operator createContainer hooks running
+        for a filtered workspace (#1770).
 
         ``cap_drop`` is :data:`DROPPED_CAPABILITIES` (``NET_ADMIN``) for a
         filtered container, so the entrypoint cannot flush the iptables
@@ -424,4 +445,8 @@ class NetFilter:
             )
             return None, None, None
         annotation = {ANNOTATION_KEY: render_rules_annotation(domains)}
-        return annotation, path, list(DROPPED_CAPABILITIES)
+        return (
+            annotation,
+            [path, *STANDARD_HOOK_DIRS],
+            list(DROPPED_CAPABILITIES),
+        )

--- a/src/klangk/klangk/netfilter.py
+++ b/src/klangk/klangk/netfilter.py
@@ -170,14 +170,40 @@ resolve() {
     getent ahosts "$1" 2>/dev/null | awk '{print $1}' | sort -u
 }
 
-# Print one ACCEPT rule per resolved IP for a host[:port] spec.
+# Print one ACCEPT rule per resolved IP for a host[:port] spec. Handles
+# bracketed IPv6 literals ([::1], [2001:db8::1]:443) — the brackets are
+# stripped and the optional ]:port suffix parsed — as well as plain
+# hostnames/IPv4 with an optional :port. A non-numeric port is skipped
+# defensively (the API validator rejects these, but the hook never trusts
+# the annotation blindly).
 accept_rules() {
     _spec=$1
-    _host=${_spec%%:*}
+    _host=
     _port=
     case "$_spec" in
-        *:*) _port=${_spec##*:} ;;
+        "["*"]"*)
+            # [ipv6] or [ipv6]:port — drop the brackets + parse the port.
+            _host=${_spec%%]*}        # "[ipv6"  (strip ](:port) suffix)
+            _host=${_host#?}          # "ipv6"   (strip leading [)
+            case "$_spec" in
+                *"]:"*) _port=${_spec##*:} ;;
+            esac
+            ;;
+        *)
+            # hostname / IPv4, optional :port.
+            _host=${_spec%%:*}
+            case "$_spec" in
+                *:*) _port=${_spec##*:} ;;
+            esac
+            ;;
     esac
+    [ -n "$_host" ] || return 0
+    # Defensive: skip a non-numeric port rather than emit a bad rule.
+    if [ -n "$_port" ]; then
+        case "$_port" in
+            *[!0-9]*) return 0 ;;
+        esac
+    fi
     for _ip in $(resolve "$_host"); do
         if [ -n "$_port" ]; then
             printf '%s\n' "-d $_ip -p tcp --dport $_port -j ACCEPT"
@@ -187,31 +213,69 @@ accept_rules() {
     done
 }
 
-# Default-deny egress; allow loopback, established, and DNS first so the
-# container can still resolve hostnames at runtime.
+# Default-deny egress; allow loopback + established first.
 ipt -P OUTPUT DROP
 ipt -A OUTPUT -o lo -j ACCEPT
 ipt -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
-ipt -A OUTPUT -p udp --dport 53 -j ACCEPT
-ipt -A OUTPUT -p tcp --dport 53 -j ACCEPT
 
-# Always allow the backend gateway (LLM proxy, browser delegate, chat
-# bridge) — host.containers.internal is added by --add-host.
-for _ip in $(resolve host.containers.internal); do
-    ipt -A OUTPUT -d "$_ip" -j ACCEPT
-done
+# DNS: allow :53 ONLY to the container's configured resolvers (read from
+# its /etc/resolv.conf via /proc/$pid/root — the OCI runtime has set up the
+# container's mount namespace by createContainer time), not to any
+# destination. A blanket :53 ACCEPT is an exfil / DNS-tunneling channel that
+# defeats an anti-exfiltration filter. KLANGK_NETFILTER_RESOLV overrides the
+# path (for tests); if the file is absent/unreadable DNS is blocked and the
+# gap is logged (#1365).
+_resolv=${KLANGK_NETFILTER_RESOLV:-/proc/$pid/root/etc/resolv.conf}
+if [ -r "$_resolv" ]; then
+    while read -r _kw _ns _rest; do
+        [ "$_kw" = "nameserver" ] || continue
+        [ -n "$_ns" ] || continue
+        ipt -A OUTPUT -p udp --dport 53 -d "$_ns" -j ACCEPT
+        ipt -A OUTPUT -p tcp --dport 53 -d "$_ns" -j ACCEPT
+    done < "$_resolv"
+else
+    echo "klangk-netfilter: cannot read $_resolv; DNS will be blocked" >&2
+fi
 
-# Per-workspace allowed destinations.
+# Backend gateway (LLM proxy, browser delegate, chat bridge). The backend
+# adds host.containers.internal:host-gateway to the container, so resolve it
+# from the CONTAINER's /etc/hosts — the host netns this hook runs in does not
+# know the name (it is a podman-injected container-side alias), and resolving
+# it via the host's getent silently yields no IP, leaving the workspace cut
+# off from its own backend. KLANGK_NETFILTER_HOSTS overrides the path (tests).
+_hosts=${KLANGK_NETFILTER_HOSTS:-/proc/$pid/root/etc/hosts}
+if [ -r "$_hosts" ]; then
+    while read -r _gip _grest; do
+        # Skip comment/blank lines.
+        case "$_gip" in \#*|"") continue ;; esac
+        case " $_grest " in
+            *" host.containers.internal "*)
+                [ -n "$_gip" ] && ipt -A OUTPUT -d "$_gip" -j ACCEPT
+                ;;
+        esac
+    done < "$_hosts"
+fi
+
+# Per-workspace allowed destinations. Split the comma-separated rules under
+# IFS=',', then RESTORE IFS before the loop body so that (a) accept_rules'
+# command substitutions split getent's newline-separated output into IPs,
+# and (b) the unquoted $_rule below word-splits into separate iptables argv
+# entries. Without the restore, every ACCEPT rule collapsed into one blob
+# argument that iptables rejected, and multi-IP hosts collapsed into one
+# garbage IP — silently, since ipt()'s failures are only logged (#1365).
 _save_ifs=$IFS
 IFS=','
-for _spec in $rules; do
+set -- $rules
+IFS=$_save_ifs
+for _spec in "$@"; do
     [ -n "$_spec" ] || continue
     accept_rules "$_spec" | while IFS= read -r _rule; do
         [ -n "$_rule" ] || continue
+        # $_rule is intentionally unquoted: each line is a series of
+        # iptables flags that must word-split into separate arguments.
         ipt -A OUTPUT $_rule
     done
 done
-IFS=$_save_ifs
 
 exit 0
 """

--- a/src/klangk/klangk/netfilter.py
+++ b/src/klangk/klangk/netfilter.py
@@ -12,8 +12,14 @@ so the bundled OCI hook fires at ``createContainer`` time, resolves each
 host to IPs, and installs iptables rules inside the container's network
 namespace that allow only loopback, DNS, the backend gateway, and the
 listed destinations — default-dropping everything else. The hook runs
-before the container process starts, so the ruleset is in place and
-immutable before any user code runs (CAP_NET_ADMIN is dropped afterwards).
+before the container process starts, so the ruleset is in place before
+any user code runs; a filtered container also gets
+:data:`DROPPED_CAPABILITIES` (``NET_ADMIN``) dropped so the entrypoint
+cannot flush the ruleset. The ruleset is immutable **only under the
+runtime's default capability set** — granting ``NET_ADMIN`` (e.g.
+``--cap-add NET_ADMIN``), running ``--privileged``, or a permissive
+seccomp profile lets the entrypoint ``iptables -F OUTPUT`` and exfiltrate
+freely. See issue #1773.
 
 **Backward compatible / fail-open:** a workspace without ``allowed_domains``
 gets no annotation, no ``--hooks-dir``, and unrestricted networking exactly
@@ -47,6 +53,15 @@ ANNOTATION_KEY = "klangk.netfilter.rules"
 # Filenames written into the configured hooks dir.
 HOOK_JSON_NAME = "klangk-netfilter.json"
 HOOK_SCRIPT_NAME = "klangk-netfilter.sh"
+
+# Linux capabilities explicitly dropped from a *filtered* workspace's
+# container. ``NET_ADMIN`` lets a process flush/replace the iptables
+# ruleset the hook installed, defeating the filter. It is already absent
+# from podman's default capability set, so dropping it explicitly is a
+# no-op under defaults and defense-in-depth against an operator who grants
+# it (``--cap-add NET_ADMIN``), runs the deploy ``--privileged``, or uses a
+# permissive seccomp profile. See issue #1773.
+DROPPED_CAPABILITIES = ("NET_ADMIN",)
 
 # A hostname or IP (v4/v6), optionally bracketed for v6, with an optional
 # trailing ``:port``. Deliberately permissive on the host grammar — the
@@ -139,8 +154,10 @@ HOOK_SCRIPT = r"""#!/bin/sh
 # nsenter on the init pid from the OCI state) that allow only loopback,
 # DNS, the backend gateway, and the listed destinations — default-dropping
 # everything else. Runs before the container process starts, so the
-# ruleset is immutable before any user code runs (CAP_NET_ADMIN is dropped
-# afterwards). See issue #1365.
+# ruleset is in place before any user code runs. It is immutable only if
+# the runtime does not grant NET_ADMIN (filtered containers also get
+# NET_ADMIN dropped, but --privileged / --cap-add NET_ADMIN / a permissive
+# seccomp profile defeat the filter). See issues #1365 and #1773.
 set -u
 
 state=$(cat)
@@ -372,17 +389,20 @@ class NetFilter:
 
     def create_kwargs(
         self, allowed_domains: list[str] | None
-    ) -> tuple[dict[str, str] | None, str | None]:
-        """Build ``(annotations, hooks_dir)`` for a workspace's container.
+    ) -> tuple[dict[str, str] | None, str | None, list[str] | None]:
+        """Build ``(annotations, hooks_dir, cap_drop)`` for a container.
 
         Resolution (#1365): a workspace's non-empty ``allowed_domains``
         **overrides** the deploy-wide default; otherwise the default applies.
-        ``(None, None)`` — unrestricted — only when both are empty, or when
-        netfilter is disabled (no hooks dir). When an effective list exists
-        but netfilter is disabled, a loud warning is logged: the container
-        starts unrestricted and the operator must enable netfilter to
-        enforce the policy.
-        """
+        ``(None, None, None)`` — unrestricted — only when both are empty, or
+        when netfilter is disabled (no hooks dir). When an effective list
+        exists but netfilter is disabled, a loud warning is logged: the
+        container starts unrestricted and the operator must enable netfilter
+        to enforce the policy.
+
+        ``cap_drop`` is :data:`DROPPED_CAPABILITIES` (``NET_ADMIN``) for a
+        filtered container, so the entrypoint cannot flush the iptables
+        ruleset (#1773)."""
         # Workspace overrides the deploy default; empty/None inherits it.
         domains = (
             list(allowed_domains)
@@ -390,7 +410,7 @@ class NetFilter:
             else self.default_domains()
         )
         if not domains:
-            return None, None
+            return None, None, None
         path = self.hooks_dir()
         if path is None:
             logger.warning(
@@ -402,6 +422,6 @@ class NetFilter:
                 "enforce the filter (#1365).",
                 domains,
             )
-            return None, None
+            return None, None, None
         annotation = {ANNOTATION_KEY: render_rules_annotation(domains)}
-        return annotation, path
+        return annotation, path, list(DROPPED_CAPABILITIES)

--- a/src/klangk/klangk/netfilter.py
+++ b/src/klangk/klangk/netfilter.py
@@ -343,8 +343,17 @@ class NetFilter:
         return list(raw) if raw else []
 
     def enabled(self) -> bool:
-        """Whether netfilter is armed on this deploy (hooks dir configured)."""
-        return self.hooks_dir() is not None
+        """Whether netfilter is armed on this deploy.
+
+        Armed = the hooks dir is configured AND the OCI hook script + JSON
+        are installed and current. A configured-but-not-installed dir (a
+        partial ``install_hooks()`` failure, or a stale hook from an old
+        klangk version) is NOT armed — callers fail open with a loud
+        warning rather than appearing filtered while running unrestricted
+        (#1771).
+        """
+        path = self.hooks_dir()
+        return path is not None and self._hook_files_current(path)
 
     def hooks_dir(self) -> str | None:
         """Return the configured hooks dir (validated to exist), else ``None``.
@@ -368,6 +377,29 @@ class NetFilter:
             )
             return None
         return path
+
+    def _hook_files_current(self, path: str) -> bool:
+        """True iff the hook script + JSON in *path* are present and match
+        the in-tree content.
+
+        Detects a partial ``install_hooks()`` (one file written, the other
+        not), a missing hook, and a stale hook left over from an old klangk
+        version. Stateless — the filesystem is the source of truth, so this
+        survives restarts and doesn't depend on ``install_hooks()`` having
+        run in this process (#1771).
+        """
+        script_path = os.path.join(path, HOOK_SCRIPT_NAME)
+        json_path = os.path.join(path, HOOK_JSON_NAME)
+        try:
+            with open(script_path) as f:
+                if f.read() != HOOK_SCRIPT:
+                    return False
+            with open(json_path) as f:
+                if f.read() != render_hook_json(script_path):
+                    return False
+        except OSError:
+            return False
+        return True
 
     def install_hooks(self) -> str | None:
         """Materialize the hook script + JSON into the hooks dir.
@@ -442,6 +474,23 @@ class NetFilter:
                 "iptables is available where the OCI runtime executes to "
                 "enforce the filter (#1365).",
                 domains,
+            )
+            return None, None, None
+        if not self._hook_files_current(path):
+            # Configured but the OCI hook isn't installed / current: a
+            # partial install_hooks() failure or a stale hook from an old
+            # version. Do NOT hand podman this dir — the runtime would run
+            # no hook and the workspace would appear filtered while running
+            # unrestricted. Fail open with a loud warning instead (#1771).
+            logger.warning(
+                "KLANGKD_NETFILTER_HOOKS_DIR=%s is configured but the OCI "
+                "hook is not installed or is stale (%s / %s missing or out "
+                "of date); the workspace will start with UNRESTRICTED "
+                "egress. Restart the server (install_hooks() runs at "
+                "startup) or confirm the dir is writable (#1771).",
+                path,
+                HOOK_SCRIPT_NAME,
+                HOOK_JSON_NAME,
             )
             return None, None, None
         annotation = {ANNOTATION_KEY: render_rules_annotation(domains)}

--- a/src/klangk/klangk/netfilter.py
+++ b/src/klangk/klangk/netfilter.py
@@ -54,6 +54,11 @@ ANNOTATION_KEY = "klangk.netfilter.rules"
 HOOK_JSON_NAME = "klangk-netfilter.json"
 HOOK_SCRIPT_NAME = "klangk-netfilter.sh"
 
+# Subdir under ``state_dir`` used for the hooks dir when the operator
+# doesn't set ``KLANGKD_NETFILTER_HOOKS_DIR`` explicitly — so netfilter is
+# armed out of the box without a second env var (#1774).
+DEFAULT_HOOKS_SUBDIR = "oci-hooks"
+
 # Linux capabilities explicitly dropped from a *filtered* workspace's
 # container. ``NET_ADMIN`` lets a process flush/replace the iptables
 # ruleset the hook installed, defeating the filter. It is already absent
@@ -330,7 +335,19 @@ class NetFilter:
 
     @property
     def _raw_hooks_dir(self) -> str | None:
-        return self.app.state.settings.netfilter_hooks_dir
+        # #1774: netfilter_enabled is the master switch; when False the
+        # feature is fully off (no dir, no install, enabled() False).
+        if not self.app.state.settings.netfilter_enabled:
+            return None
+        raw = self.app.state.settings.netfilter_hooks_dir
+        if raw:
+            return raw
+        # Default to a state_dir subdir so netfilter is armed out of the
+        # box without a second env var (#1774). state_dir is always resolved
+        # at construction (_require_dirs fails fast otherwise, #1461).
+        return os.path.join(
+            self.app.state.settings.state_dir, DEFAULT_HOOKS_SUBDIR
+        )
 
     def default_domains(self) -> list[str]:
         """The deploy-wide default allow-list (#1365), already validated +
@@ -356,11 +373,15 @@ class NetFilter:
         return path is not None and self._hook_files_current(path)
 
     def hooks_dir(self) -> str | None:
-        """Return the configured hooks dir (validated to exist), else ``None``.
+        """Return the effective hooks dir (validated to exist), else ``None``.
 
-        ``None`` (unset, or pointing somewhere that doesn't exist / can't be
-        created) means netfilter is disabled: workspaces start unrestricted
-        regardless of their ``allowed_domains``.
+        With netfilter enabled (the default), an unset ``netfilter_hooks_dir``
+        resolves to ``<state_dir>/oci-hooks`` (#1774). ``None`` — netfilter
+        disabled via the master switch, the dir unset with no ``state_dir``,
+        or pointing somewhere that can't be created — means workspaces start
+        unrestricted regardless of their ``allowed_domains``. This is the
+        *configured* dir; :meth:`enabled` additionally requires the hook to
+        be installed + current (#1771).
         """
         raw = self._raw_hooks_dir
         if not raw:

--- a/src/klangk/klangk/netfilter.py
+++ b/src/klangk/klangk/netfilter.py
@@ -1,0 +1,322 @@
+"""Per-workspace network egress filtering via OCI ``createContainer`` hooks.
+
+A workspace may declare ``allowed_domains`` (a list of ``host`` or
+``host:port`` specs). When the deployer has enabled netfilter
+(``KLANGKD_NETFILTER_HOOKS_DIR``), a workspace with allowed_domains has:
+
+* the OCI annotation ``klangk.netfilter.rules`` set to the resolved spec
+  list, and
+* ``--hooks-dir`` pointed at the directory this module populates,
+
+so the bundled OCI hook fires at ``createContainer`` time, resolves each
+host to IPs, and installs iptables rules inside the container's network
+namespace that allow only loopback, DNS, the backend gateway, and the
+listed destinations — default-dropping everything else. The hook runs
+before the container process starts, so the ruleset is in place and
+immutable before any user code runs (CAP_NET_ADMIN is dropped afterwards).
+
+**Backward compatible / fail-open:** a workspace without ``allowed_domains``
+gets no annotation, no ``--hooks-dir``, and unrestricted networking exactly
+as before. If a workspace *does* declare ``allowed_domains`` but netfilter
+is not enabled (no hooks dir configured), the workspace starts
+**unrestricted** and the server logs a loud warning — the deployer must
+satisfy the deployment requirements (iptables available where the OCI
+runtime executes) before the filter is enforced. See issue #1365.
+
+This module owns the settings-dependent surface (the hooks-dir resolver and
+the annotation builder); the pure validators/renderers are module-level so
+they are unit-testable without an app. The :class:`NetFilter` state object
+is constructed once in :func:`build_app` and stored on
+``app.state.netfilter``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+
+logger = logging.getLogger(__name__)
+
+# OCI annotation carrying the comma-separated ``host[:port]`` spec list.
+# The hook JSON's ``annotations`` filter gates firing on this key's
+# presence, so a workspace without it is never filtered.
+ANNOTATION_KEY = "klangk.netfilter.rules"
+
+# Filenames written into the configured hooks dir.
+HOOK_JSON_NAME = "klangk-netfilter.json"
+HOOK_SCRIPT_NAME = "klangk-netfilter.sh"
+
+# A hostname or IP (v4/v6), optionally bracketed for v6, with an optional
+# trailing ``:port``. Deliberately permissive on the host grammar — the
+# hook does the real DNS resolution; this just rejects gross mistakes
+# (empty specs, whitespace, non-numeric ports, stray slashes) so a typo in
+# the API is rejected at the boundary rather than failing silently inside
+# the container netns.
+_DOMAIN_RE = re.compile(
+    r"^[A-Za-z0-9](?:[A-Za-z0-9.\-]*[A-Za-z0-9])?"  # hostname / IPv4
+    r"(?::[0-9]{1,5})?$"  # optional :port
+)
+_DOMAIN_BRACKET_RE = re.compile(
+    r"^\[[0-9A-Fa-f:.]+\](?::[0-9]{1,5})?$"  # [ipv6](:port)?
+)
+
+
+def _valid_domain_spec(spec: str) -> bool:
+    if not spec or any(ch.isspace() for ch in spec):
+        return False
+    if "/" in spec:
+        return False
+    return bool(_DOMAIN_RE.match(spec) or _DOMAIN_BRACKET_RE.match(spec))
+
+
+def parse_allowed_domains(values: list[str]) -> list[str]:
+    """Validate + normalize a list of ``host[:port]`` specs.
+
+    Strips whitespace, drops empties, and de-duplicates while preserving
+    first-seen order. Raises :class:`ValueError` listing every invalid
+    spec so the API surfaces a precise error instead of a silent skip.
+    """
+    out: list[str] = []
+    seen: set[str] = set()
+    invalid: list[str] = []
+    for raw in values:
+        spec = raw.strip()
+        if not spec:
+            continue
+        if not _valid_domain_spec(spec):
+            invalid.append(raw)
+            continue
+        if spec not in seen:
+            seen.add(spec)
+            out.append(spec)
+    if invalid:
+        raise ValueError(
+            "Invalid allowed_domains entry/entries: "
+            + ", ".join(repr(s) for s in invalid)
+        )
+    return out
+
+
+def render_rules_annotation(domains: list[str]) -> str:
+    """Render the comma-separated annotation value from validated domains."""
+    return ",".join(domains)
+
+
+def render_hook_json(script_path: str) -> str:
+    """Render the OCI hook JSON pointing at the absolute ``script_path``.
+
+    The ``annotations`` map gates the hook to fire **only** for containers
+    that carry :data:`ANNOTATION_KEY` — a workspace without the annotation
+    (no allowed_domains) never triggers the hook, so it stays unrestricted.
+    """
+    return json.dumps(
+        {
+            "version": "1.0.0",
+            "hook": {"path": os.path.abspath(script_path)},
+            "when": {"always": 1},
+            "stages": ["createContainer"],
+            "annotations": {ANNOTATION_KEY: ".*"},
+        },
+        indent=2,
+    )
+
+
+# The OCI hook script. POSIX sh (no bashisms): it may run under a minimal
+# /bin/sh in the runtime namespace. Reads the container state JSON from
+# stdin, resolves the annotation's hosts to IPs, and installs a
+# default-deny egress ruleset in the container netns via nsenter. Kept as
+# the single source of truth so :func:`NetFilter.install_hooks` can
+# materialize it at runtime without a packaging/data-file dependency.
+HOOK_SCRIPT = r"""#!/bin/sh
+# klangk OCI createContainer hook — per-workspace egress filtering.
+#
+# Fires only for containers that carry the `klangk.netfilter.rules`
+# annotation (the hook JSON's `annotations` filter gates this). Reads the
+# host[:port] specs from that annotation, resolves each host to IPs, and
+# installs iptables rules in the container's network namespace (via
+# nsenter on the init pid from the OCI state) that allow only loopback,
+# DNS, the backend gateway, and the listed destinations — default-dropping
+# everything else. Runs before the container process starts, so the
+# ruleset is immutable before any user code runs (CAP_NET_ADMIN is dropped
+# afterwards). See issue #1365.
+set -u
+
+state=$(cat)
+
+# Extract the annotation value + the init pid with sed (no jq dependency).
+rules=$(printf '%s' "$state" \
+    | sed -n 's/.*"klangk.netfilter.rules"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+pid=$(printf '%s' "$state" \
+    | sed -n 's/.*"pid"[[:space:]]*:[[:space:]]*\([0-9][0-9]*\).*/\1/p')
+
+# Nothing to filter without a rules annotation or an init pid.
+[ -n "$rules" ] || exit 0
+[ -n "$pid" ] || exit 0
+[ -e "/proc/$pid/ns/net" ] || exit 0
+
+# iptables inside the container's network namespace. Failures are logged
+# to stderr (captured by the OCI runtime) but do not abort the hook — the
+# default-DROP policy below is the fail-closed posture for a misconfigured
+# deploy, and a partial ruleset is still better than none.
+ipt() {
+    nsenter --net="/proc/$pid/ns/net" iptables "$@" || \
+        echo "klangk-netfilter: iptables $* failed" >&2
+}
+
+# Resolve a hostname to unique A/AAAA IPs, one per line.
+resolve() {
+    getent ahosts "$1" 2>/dev/null | awk '{print $1}' | sort -u
+}
+
+# Print one ACCEPT rule per resolved IP for a host[:port] spec.
+accept_rules() {
+    _spec=$1
+    _host=${_spec%%:*}
+    _port=
+    case "$_spec" in
+        *:*) _port=${_spec##*:} ;;
+    esac
+    for _ip in $(resolve "$_host"); do
+        if [ -n "$_port" ]; then
+            printf '%s\n' "-d $_ip -p tcp --dport $_port -j ACCEPT"
+        else
+            printf '%s\n' "-d $_ip -j ACCEPT"
+        fi
+    done
+}
+
+# Default-deny egress; allow loopback, established, and DNS first so the
+# container can still resolve hostnames at runtime.
+ipt -P OUTPUT DROP
+ipt -A OUTPUT -o lo -j ACCEPT
+ipt -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+ipt -A OUTPUT -p udp --dport 53 -j ACCEPT
+ipt -A OUTPUT -p tcp --dport 53 -j ACCEPT
+
+# Always allow the backend gateway (LLM proxy, browser delegate, chat
+# bridge) — host.containers.internal is added by --add-host.
+for _ip in $(resolve host.containers.internal); do
+    ipt -A OUTPUT -d "$_ip" -j ACCEPT
+done
+
+# Per-workspace allowed destinations.
+_save_ifs=$IFS
+IFS=','
+for _spec in $rules; do
+    [ -n "$_spec" ] || continue
+    accept_rules "$_spec" | while IFS= read -r _rule; do
+        [ -n "$_rule" ] || continue
+        ipt -A OUTPUT $_rule
+    done
+done
+IFS=$_save_ifs
+
+exit 0
+"""
+
+
+class NetFilter:
+    """Owns the settings-dependent netfilter surface (#1365).
+
+    The hooks-dir resolver and the annotation/``--hooks-dir`` builder live
+    here as methods reaching config through ``self.app.state.settings``;
+    the pure validators/renderers stay module-level. Constructed once in
+    :func:`build_app` on ``app.state.netfilter``.
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    def reconfigure(self, app) -> None:
+        self.app = app
+
+    @property
+    def _raw_hooks_dir(self) -> str | None:
+        return self.app.state.settings.netfilter_hooks_dir
+
+    def hooks_dir(self) -> str | None:
+        """Return the configured hooks dir (validated to exist), else ``None``.
+
+        ``None`` (unset, or pointing somewhere that doesn't exist / can't be
+        created) means netfilter is disabled: workspaces start unrestricted
+        regardless of their ``allowed_domains``.
+        """
+        raw = self._raw_hooks_dir
+        if not raw:
+            return None
+        path = os.path.realpath(raw)
+        try:
+            os.makedirs(path, exist_ok=True)
+        except OSError as exc:
+            logger.error(
+                "KLANGKD_NETFILTER_HOOKS_DIR=%s cannot be created (%s); "
+                "per-workspace egress filtering is disabled",
+                raw,
+                exc,
+            )
+            return None
+        return path
+
+    def install_hooks(self) -> str | None:
+        """Materialize the hook script + JSON into the hooks dir.
+
+        Idempotent: re-writes both files on every call (so a package
+        upgrade ships the new script). Returns the dir, or ``None`` when
+        netfilter is disabled. Failures are logged and the feature is left
+        disabled rather than crashing startup.
+        """
+        path = self.hooks_dir()
+        if path is None:
+            return None
+        script_path = os.path.join(path, HOOK_SCRIPT_NAME)
+        json_path = os.path.join(path, HOOK_JSON_NAME)
+        try:
+            with open(script_path, "w") as f:
+                f.write(HOOK_SCRIPT)
+            os.chmod(script_path, 0o755)
+            with open(json_path, "w") as f:
+                f.write(render_hook_json(script_path))
+        except OSError as exc:
+            logger.error(
+                "Could not install netfilter hooks into %s: %s "
+                "(per-workspace egress filtering is disabled)",
+                path,
+                exc,
+            )
+            return None
+        logger.info(
+            "Netfilter egress filtering enabled: OCI hooks installed in %s",
+            path,
+        )
+        return path
+
+    def create_kwargs(
+        self, allowed_domains: list[str] | None
+    ) -> tuple[dict[str, str] | None, str | None]:
+        """Build ``(annotations, hooks_dir)`` for a workspace's container.
+
+        ``(None, None)`` when the workspace is unrestricted: no
+        ``allowed_domains`` (unrestricted by config), or netfilter is
+        disabled (the deployer did not configure a hooks dir). When
+        ``allowed_domains`` is set but netfilter is disabled, a loud
+        warning is logged — the workspace starts unrestricted and the
+        operator must enable netfilter to enforce the policy.
+        """
+        if not allowed_domains:
+            return None, None
+        path = self.hooks_dir()
+        if path is None:
+            logger.warning(
+                "Workspace declares allowed_domains=%s but netfilter is "
+                "disabled (KLANGKD_NETFILTER_HOOKS_DIR is unset or "
+                "unwritable); the workspace will start with UNRESTRICTED "
+                "egress. Configure KLANGKD_NETFILTER_HOOKS_DIR and ensure "
+                "iptables is available where the OCI runtime executes to "
+                "enforce the filter (#1365).",
+                allowed_domains,
+            )
+            return None, None
+        annotation = {ANNOTATION_KEY: render_rules_annotation(allowed_domains)}
+        return annotation, path

--- a/src/klangk/klangk/podman.py
+++ b/src/klangk/klangk/podman.py
@@ -264,7 +264,7 @@ class Podman:
         dns: list[str] | None = None,
         env: list[str] | None = None,
         annotations: dict[str, str] | None = None,
-        hooks_dir: str | None = None,
+        hooks_dir: list[str] | None = None,
         init: bool = False,
         interactive: bool = False,
         pull: str = "never",
@@ -278,17 +278,20 @@ class Podman:
         ``replace=True`` removes an existing container with the same name.
         ``annotations``/``hooks_dir`` carry per-workspace OCI hooks (e.g.
         the netfilter egress filter, #1365): each annotation becomes a
-        ``--annotation key=value`` flag, and ``hooks_dir`` becomes
-        ``--hooks-dir`` (passed only when set so unrestricted workspaces
-        keep podman's default hooks-dir behavior). ``cap_drop`` becomes one
+        ``--annotation key=value`` flag, and each ``hooks_dir`` entry becomes
+        a ``--hooks-dir`` flag. ``--hooks-dir`` overrides (does not append)
+        podman's default hook search paths, so a filtered container passes
+        the klangk dir *and* the standard default dirs to keep operator
+        createContainer hooks running (#1770); unrestricted workspaces omit
+        the flag entirely (no behavior change). ``cap_drop`` becomes one
         ``--cap-drop`` flag each (used to drop ``NET_ADMIN`` on filtered
         workspaces, #1773).
         """
         args = ["create", f"--pull={pull}", "--name", name]
         if replace:
             args.append("--replace")
-        if hooks_dir:
-            args += ["--hooks-dir", hooks_dir]
+        for d in hooks_dir or []:
+            args += ["--hooks-dir", d]
         if init:
             args.append("--init")
         if interactive:

--- a/src/klangk/klangk/podman.py
+++ b/src/klangk/klangk/podman.py
@@ -270,6 +270,7 @@ class Podman:
         pull: str = "never",
         replace: bool = True,
         userns: str | None = None,
+        cap_drop: list[str] | None = None,
     ) -> str:
         """Create a container and return its id.
 
@@ -279,7 +280,9 @@ class Podman:
         the netfilter egress filter, #1365): each annotation becomes a
         ``--annotation key=value`` flag, and ``hooks_dir`` becomes
         ``--hooks-dir`` (passed only when set so unrestricted workspaces
-        keep podman's default hooks-dir behavior).
+        keep podman's default hooks-dir behavior). ``cap_drop`` becomes one
+        ``--cap-drop`` flag each (used to drop ``NET_ADMIN`` on filtered
+        workspaces, #1773).
         """
         args = ["create", f"--pull={pull}", "--name", name]
         if replace:
@@ -292,6 +295,8 @@ class Podman:
             args.append("-i")
         if userns:
             args += ["--userns", userns]
+        for cap in cap_drop or []:
+            args += ["--cap-drop", cap]
         for key, value in (labels or {}).items():
             args += ["--label", f"{key}={value}"]
         for key, value in (annotations or {}).items():

--- a/src/klangk/klangk/podman.py
+++ b/src/klangk/klangk/podman.py
@@ -263,6 +263,8 @@ class Podman:
         add_hosts: list[str] | None = None,
         dns: list[str] | None = None,
         env: list[str] | None = None,
+        annotations: dict[str, str] | None = None,
+        hooks_dir: str | None = None,
         init: bool = False,
         interactive: bool = False,
         pull: str = "never",
@@ -273,10 +275,17 @@ class Podman:
 
         ``publish`` is a list of ``(host_port, container_port)`` pairs.
         ``replace=True`` removes an existing container with the same name.
+        ``annotations``/``hooks_dir`` carry per-workspace OCI hooks (e.g.
+        the netfilter egress filter, #1365): each annotation becomes a
+        ``--annotation key=value`` flag, and ``hooks_dir`` becomes
+        ``--hooks-dir`` (passed only when set so unrestricted workspaces
+        keep podman's default hooks-dir behavior).
         """
         args = ["create", f"--pull={pull}", "--name", name]
         if replace:
             args.append("--replace")
+        if hooks_dir:
+            args += ["--hooks-dir", hooks_dir]
         if init:
             args.append("--init")
         if interactive:
@@ -285,6 +294,8 @@ class Podman:
             args += ["--userns", userns]
         for key, value in (labels or {}).items():
             args += ["--label", f"{key}={value}"]
+        for key, value in (annotations or {}).items():
+            args += ["--annotation", f"{key}={value}"]
         for bind in binds or []:
             args += ["-v", bind]
         for path, opts in (tmpfs or {}).items():

--- a/src/klangk/klangk/settings.py
+++ b/src/klangk/klangk/settings.py
@@ -624,13 +624,25 @@ class KlangkSettings(BaseSettings):
     health_check_startup_grace: str | None = None
     health_check_timeout: str | None = None
     hosted_ports_per_workspace: str = "5"
+    # netfilter_enabled: master on/off switch for per-workspace egress
+    # filtering (#1774). Defaults to True — netfilter is armed out of the
+    # box (the OCI hook is materialized into a state_dir subdir at startup;
+    # see NetFilter). Set False to disable the feature entirely (e.g. in an
+    # environment without iptables/nsenter, or where the hook can't be
+    # granted CAP_NET_ADMIN): enabled() reports false, create_kwargs() never
+    # passes --hooks-dir, and workspaces with allowed_domains fail open
+    # with a loud warning (#1769). This is the operator *intent*; the
+    # /api/v1/config field of the same name is the resolved *armed status*
+    # (intent AND hook installed, #1771).
+    netfilter_enabled: bool = True
     # netfilter_hooks_dir: directory where the per-workspace egress-filter
     # OCI hook (klangk-netfilter.{json,sh}) is materialized at startup.
-    # Unset (default) disables per-workspace egress filtering — workspaces
-    # have unrestricted outbound networking. Set it to enable opt-in
-    # per-workspace allowed_domains enforcement (#1365). The path must be
-    # resolvable where the OCI runtime executes (the host or DinD outer
-    # container; for podman-machine it must be inside the CoreOS VM).
+    # When netfilter_enabled is True (the default) and this is unset, it
+    # defaults to <state_dir>/oci-hooks — so filtering works out of the box
+    # without a second env var (#1774). Set it explicitly only when the OCI
+    # runtime can't see state_dir (a split runtime / DinD outer container /
+    # podman-machine CoreOS VM). The path must be resolvable where the OCI
+    # runtime executes.
     netfilter_hooks_dir: str | None = None
     # netfilter_default_domains: a deploy-wide allow-list applied to every
     # workspace that doesn't declare its own (#1365). A workspace with a

--- a/src/klangk/klangk/settings.py
+++ b/src/klangk/klangk/settings.py
@@ -46,6 +46,10 @@ from pydantic_settings import (
     YamlConfigSettingsSource,
 )
 from pydantic import PrivateAttr, field_validator, model_validator
+
+# netfilter.py is pure-stdlib (no settings import), so this top-level import
+# is cycle-safe. Used by the netfilter_default_domains field validator below.
+from klangk.netfilter import parse_allowed_domains
 from pydantic_settings.sources.providers.env import parse_env_vars
 
 logger = logging.getLogger(__name__)
@@ -628,6 +632,16 @@ class KlangkSettings(BaseSettings):
     # resolvable where the OCI runtime executes (the host or DinD outer
     # container; for podman-machine it must be inside the CoreOS VM).
     netfilter_hooks_dir: str | None = None
+    # netfilter_default_domains: a deploy-wide allow-list applied to every
+    # workspace that doesn't declare its own (#1365). A workspace with a
+    # non-empty allowed_domains *overrides* (replaces) this default; a
+    # workspace with none inherits it. Unset (default) preserves the
+    # original per-workspace-only behavior (empty = unrestricted).
+    #
+    # Accepts either a comma-separated string (env var) or a real list
+    # (YAML config file), normalized + validated at construction by
+    # _coerce_netfilter_default_domains so a typo fails fast at boot.
+    netfilter_default_domains: list[str] | None = None
     test_mode: str | None = None
     version_file: str | None = None
 
@@ -988,6 +1002,36 @@ class KlangkSettings(BaseSettings):
                 "→ defaults to 'none')."
             )
         return v
+
+    @field_validator("netfilter_default_domains", mode="before")
+    @classmethod
+    def _coerce_netfilter_default_domains(cls, v):
+        """Accept either a comma-separated string (env var) or a real list
+        (YAML config file), then validate + de-dupe via
+        :func:`klangk.netfilter.parse_allowed_domains` (#1365).
+
+        Env vars deliver a single string (``a.com,b.com``); the YAML source
+        delivers a native list. Both are normalized to a validated, de-duped
+        ``list[str]`` of ``host[:port]`` specs. ``None`` / empty → ``None``
+        (no deploy default; workspaces unrestricted unless they declare their
+        own). An invalid spec aborts boot — a typo in the deploy-wide floor
+        should fail loudly, not silently degrade the security posture.
+        """
+        if v is None:
+            return None
+        if isinstance(v, str):
+            parts = [s.strip() for s in v.split(",")]
+            items = [p for p in parts if p]
+        elif isinstance(v, list):
+            items = [str(s).strip() for s in v if str(s).strip()]
+        else:
+            raise ValueError(
+                "KLANGKD_NETFILTER_DEFAULT_DOMAINS must be a list or a "
+                f"comma-separated string, got {type(v).__name__}"
+            )
+        if not items:
+            return None
+        return parse_allowed_domains(items)
 
     @model_validator(mode="after")
     def _warn_on_deprecated_proxy_engine(self) -> "KlangkSettings":

--- a/src/klangk/klangk/settings.py
+++ b/src/klangk/klangk/settings.py
@@ -640,7 +640,8 @@ class KlangkSettings(BaseSettings):
     #
     # Accepts either a comma-separated string (env var) or a real list
     # (YAML config file), normalized + validated at construction by
-    # _coerce_netfilter_default_domains so a typo fails fast at boot.
+    # _coerce_netfilter_default_domains. A malformed value warns and falls
+    # back to None (no default) rather than aborting the server (#1772).
     netfilter_default_domains: list[str] | None = None
     test_mode: str | None = None
     version_file: str | None = None
@@ -1014,8 +1015,16 @@ class KlangkSettings(BaseSettings):
         delivers a native list. Both are normalized to a validated, de-duped
         ``list[str]`` of ``host[:port]`` specs. ``None`` / empty → ``None``
         (no deploy default; workspaces unrestricted unless they declare their
-        own). An invalid spec aborts boot — a typo in the deploy-wide floor
-        should fail loudly, not silently degrade the security posture.
+        own).
+
+        A malformed value (a bad ``host[:port]`` spec, or a non-list/
+        non-string type) does NOT abort the server — it logs a loud warning
+        and falls back to ``None`` (no deploy default applied), so a typo in
+        the deploy-wide default can't take down a running server or kill a
+        SIGHUP reload (#1772). This matches the warn+fallback posture of
+        peer settings (e.g. ``image_pull_policy``) and netfilter's
+        fail-open-with-visibility design — a misconfigured deploy degrades
+        to unrestricted + a visible warning rather than refusing to run.
         """
         if v is None:
             return None
@@ -1025,13 +1034,27 @@ class KlangkSettings(BaseSettings):
         elif isinstance(v, list):
             items = [str(s).strip() for s in v if str(s).strip()]
         else:
-            raise ValueError(
-                "KLANGKD_NETFILTER_DEFAULT_DOMAINS must be a list or a "
-                f"comma-separated string, got {type(v).__name__}"
+            logger.warning(
+                "KLANGKD_NETFILTER_DEFAULT_DOMAINS=%r must be a list or a "
+                "comma-separated string (got %s); ignoring the deploy-wide "
+                "default (no default applied).",
+                v,
+                type(v).__name__,
             )
+            return None
         if not items:
             return None
-        return parse_allowed_domains(items)
+        try:
+            return parse_allowed_domains(items)
+        except ValueError as exc:
+            logger.warning(
+                "KLANGKD_NETFILTER_DEFAULT_DOMAINS=%r has an invalid spec "
+                "(%s); ignoring the deploy-wide default (no default "
+                "applied). Fix the value and reload to restore it.",
+                v,
+                exc,
+            )
+            return None
 
     @model_validator(mode="after")
     def _warn_on_deprecated_proxy_engine(self) -> "KlangkSettings":

--- a/src/klangk/klangk/settings.py
+++ b/src/klangk/klangk/settings.py
@@ -620,6 +620,14 @@ class KlangkSettings(BaseSettings):
     health_check_startup_grace: str | None = None
     health_check_timeout: str | None = None
     hosted_ports_per_workspace: str = "5"
+    # netfilter_hooks_dir: directory where the per-workspace egress-filter
+    # OCI hook (klangk-netfilter.{json,sh}) is materialized at startup.
+    # Unset (default) disables per-workspace egress filtering — workspaces
+    # have unrestricted outbound networking. Set it to enable opt-in
+    # per-workspace allowed_domains enforcement (#1365). The path must be
+    # resolvable where the OCI runtime executes (the host or DinD outer
+    # container; for podman-machine it must be inside the CoreOS VM).
+    netfilter_hooks_dir: str | None = None
     test_mode: str | None = None
     version_file: str | None = None
 

--- a/src/klangk/klangk/workspaces.py
+++ b/src/klangk/klangk/workspaces.py
@@ -202,6 +202,7 @@ class Workspaces:
             "mounts": ws.get("mounts"),
             "env": ws.get("env"),
             "health_check": ws.get("health_check"),
+            "allowed_domains": ws.get("allowed_domains"),
             "num_ports": ws.get("num_ports", 5),
         }
 
@@ -367,6 +368,7 @@ class Workspaces:
         env: dict[str, str] | None = None,
         setup_state: str | None = None,
         health_check: str | None = None,
+        allowed_domains: list[str] | None = None,
     ) -> dict:
         workspace = (
             await self.app.state.model.workspaces.create_workspace_with_acl(
@@ -379,6 +381,7 @@ class Workspaces:
                 env=env,
                 setup_state=setup_state or model.SETUP_STATE_COMPLETE,
                 health_check=health_check,
+                allowed_domains=allowed_domains,
             )
         )
         home = self.home_path(workspace["id"])
@@ -510,6 +513,7 @@ class Workspaces:
             health_check=ws.get("health_check"),
             setup_state=ws.get("setup_state"),
             service_command=ws.get("service_command"),
+            allowed_domains=ws.get("allowed_domains"),
         )
         return cid, status
 

--- a/src/klangk/klangk/wshandler/connection.py
+++ b/src/klangk/klangk/wshandler/connection.py
@@ -326,6 +326,7 @@ class Connection:
             health_check=workspace.get("health_check"),
             setup_state=workspace.get("setup_state"),
             service_command=workspace.get("service_command"),
+            allowed_domains=workspace.get("allowed_domains"),
         )
         self.container_status = container_status
         self.workspace_id = workspace_id

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -416,6 +416,18 @@ class TestConfig:
         assert "login_banner" in data
         assert "instance_id" in data
 
+    async def test_get_config_exposes_netfilter_default_domains(
+        self, client, app
+    ):
+        # #1365: the create-workspace UI pre-fills its allowed-domains editor
+        # from the deploy-wide default (which a workspace overrides, not
+        # unions). netfilter_enabled gates showing the editor at all.
+        app.state.settings.netfilter_default_domains = ["github.com:443"]
+        resp = await client.get("/api/v1/config")
+        assert resp.json()["netfilter_default_domains"] == ["github.com:443"]
+        # hooks dir unset in the test fixture → disabled.
+        assert resp.json()["netfilter_enabled"] is False
+
     async def test_get_config_includes_features(
         self, client, app, tmp_path, monkeypatch
     ):

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -416,14 +416,29 @@ class TestConfig:
         assert "login_banner" in data
         assert "instance_id" in data
 
-    async def test_get_config_exposes_netfilter_default_domains(
+    async def test_get_config_omits_netfilter_fields_when_unauthenticated(
         self, client, app
+    ):
+        # #1365: the deploy allow-list + armed-status advertise the egress
+        # perimeter, so they must NOT appear on the pre-auth /config payload
+        # (which feeds the login page). Anonymous callers learn neither.
+        app.state.settings.netfilter_default_domains = ["github.com:443"]
+        resp = await client.get("/api/v1/config")
+        data = resp.json()
+        assert "netfilter_default_domains" not in data
+        assert "netfilter_enabled" not in data
+
+    async def test_get_config_exposes_netfilter_default_domains(
+        self, client, app, user
     ):
         # #1365: the create-workspace UI pre-fills its allowed-domains editor
         # from the deploy-wide default (which a workspace overrides, not
-        # unions). netfilter_enabled gates showing the editor at all.
+        # unions). netfilter_enabled gates showing the editor at all. Both
+        # are returned only to authenticated callers (the UI sends the token
+        # on its /config fetch and re-fetches after login).
         app.state.settings.netfilter_default_domains = ["github.com:443"]
-        resp = await client.get("/api/v1/config")
+        headers = await _auth_headers(client)
+        resp = await client.get("/api/v1/config", headers=headers)
         assert resp.json()["netfilter_default_domains"] == ["github.com:443"]
         # hooks dir unset in the test fixture → disabled.
         assert resp.json()["netfilter_enabled"] is False

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -24,6 +24,7 @@ from klangk import (
 from klangk.container import ContainerRegistry
 from klangk import emailsvc as emailsvc_mod
 from klangk import util as util_mod
+from klangk import netfilter as netfilter_mod
 from klangk import oidc as oidc_mod
 from klangk import features as features_mod
 from _helpers import make_settings
@@ -79,6 +80,9 @@ async def app(db, temp_data_dir):
     app.state.agents = agent.Agents(app)
     app.state.email = emailsvc_mod.EmailService(app)
     app.state.util = util_mod.Util(app)
+    # #1365: create/update workspace validation reaches the netfilter
+    # hooks-dir resolver.
+    app.state.netfilter = netfilter_mod.NetFilter(app)
 
     app.state.auth = auth_mod.Auth(app)
     # #1572: wire DB + Model so converted domains (tokens,
@@ -1669,6 +1673,44 @@ class TestWorkspaceRoutes:
         assert resp.status_code == 400
         assert "Invalid mount" in resp.json()["detail"]
 
+    async def test_create_with_allowed_domains_persists(
+        self, client, app, user, caplog
+    ):
+        # netfilter is disabled by default in the test app, so the value
+        # is persisted (fail-open) with a loud warning (#1365).
+        headers = await _auth_headers(client)
+        with caplog.at_level("WARNING"):
+            resp = await client.post(
+                "/api/v1/workspaces",
+                headers=headers,
+                json={
+                    "name": "filtered",
+                    "allowed_domains": [
+                        "github.com:443",
+                        "github.com:443",
+                        "pypi.org",
+                    ],
+                },
+            )
+        assert resp.status_code == 200
+        assert resp.json()["allowed_domains"] == [
+            "github.com:443",
+            "pypi.org",
+        ]
+        assert any("UNRESTRICTED" in r.message for r in caplog.records)
+
+    async def test_create_with_invalid_allowed_domains_rejected(
+        self, client, user
+    ):
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            headers=headers,
+            json={"name": "bad", "allowed_domains": ["bad spec"]},
+        )
+        assert resp.status_code == 400
+        assert "Invalid allowed_domains" in resp.json()["detail"]
+
     async def test_create_auto_start_rejected_without_env(self, client, user):
         headers = await _auth_headers(client)
         with patch.dict(os.environ, {}, clear=False):
@@ -2065,6 +2107,24 @@ class TestWorkspaceRoutes:
         match = [w for w in resp.json() if w["id"] == ws_id]
         assert match[0]["name"] == "renamed"
         assert match[0]["service_command"] == "pi"
+
+    async def test_update_workspace_allowed_domains(self, client, user):
+        headers = await _auth_headers(client)
+        resp = await client.post(
+            "/api/v1/workspaces",
+            json={"name": "dom-ws"},
+            headers=headers,
+        )
+        ws_id = resp.json()["id"]
+        resp = await client.put(
+            f"/api/v1/workspaces/{ws_id}",
+            json={"allowed_domains": ["github.com:443"]},
+            headers=headers,
+        )
+        assert resp.status_code == 200
+        resp = await client.get("/api/v1/workspaces", headers=headers)
+        match = [w for w in resp.json() if w["id"] == ws_id]
+        assert match[0]["allowed_domains"] == ["github.com:443"]
 
     async def test_update_workspace_propagates_to_live_state(
         self, client, app, user, registry
@@ -6335,6 +6395,7 @@ class TestWorkspaceMetadata:
             "mounts": ["/data:/data"],
             "env": {"FOO": "bar"},
             "health_check": None,
+            "allowed_domains": None,
             "num_ports": 3,
         }
 

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -56,6 +56,11 @@ def _make_app_state(registry=None, sockets=None):
     # #1567: ContainerRegistry reaches the cert-dir resolver via
     # app_state.state.ssl_trust (the settings-dependent SSL trust surface).
     app_state.state.ssl_trust = ssl_trust.SSLTrust(app_state)
+    # #1365: ContainerRegistry reaches the egress-filter builder via
+    # app_state.state.netfilter (the settings-dependent netfilter surface).
+    from klangk import netfilter as netfilter_mod
+
+    app_state.state.netfilter = netfilter_mod.NetFilter(app_state)
 
     app_state.state.auth = auth_mod.Auth(app_state)
     # #1572: ContainerRegistry reaches app_state.state.model.ports; Auth reaches
@@ -564,6 +569,60 @@ class TestStartContainer:
         assert status == "created"
         p.start_container.assert_awaited_once_with("new-cid")
         assert workspace["id"] in self.registry.states
+
+    async def test_egress_filter_no_domains_is_noop(self, workspace):
+        # No allowed_domains -> no annotation or hooks-dir; the container
+        # keeps podman's default hooks-dir behavior (unrestricted). #1365
+        with patch_podman(self.registry) as p:
+            await self.registry.start_container(
+                workspace["id"], "/tmp/ws", "/tmp/home"
+            )
+        kwargs = p.create_container.call_args.kwargs
+        assert "annotations" not in kwargs
+        assert "hooks_dir" not in kwargs
+
+    async def test_egress_filter_disabled_fail_opens(self, workspace, caplog):
+        # allowed_domains set but netfilter disabled (no hooks dir) ->
+        # unrestricted with a loud warning (fail open). #1365
+        with patch_podman(self.registry), caplog.at_level("WARNING"):
+            await self.registry.start_container(
+                workspace["id"],
+                "/tmp/ws",
+                "/tmp/home",
+                allowed_domains=["github.com:443"],
+            )
+        assert any("UNRESTRICTED" in r.message for r in caplog.records)
+
+    async def test_egress_filter_enabled_passes_annotation_and_hooks_dir(
+        self, workspace, tmp_path, monkeypatch
+    ):
+        monkeypatch.setattr(
+            self.registry.app.state.settings,
+            "netfilter_hooks_dir",
+            str(tmp_path / "hooks"),
+        )
+        with patch_podman(self.registry) as p:
+            await self.registry.start_container(
+                workspace["id"],
+                "/tmp/ws",
+                "/tmp/home",
+                allowed_domains=["github.com:443", "pypi.org"],
+            )
+        kwargs = p.create_container.call_args.kwargs
+        assert kwargs["annotations"] == {
+            "klangk.netfilter.rules": "github.com:443,pypi.org"
+        }
+        assert kwargs["hooks_dir"] == str((tmp_path / "hooks").resolve())
+
+    def test_egress_filter_missing_netfilter_state_is_noop(self):
+        # Defensive: an app-state without a netfilter subsystem (some
+        # partial test builders) is treated as unrestricted rather than
+        # raising. #1365
+        app_state = types.SimpleNamespace(
+            state=types.SimpleNamespace(settings=make_settings({}))
+        )
+        reg = container.ContainerRegistry(app_state)
+        assert reg._egress_filter(["github.com"]) == (None, None)
 
     async def test_sudo_disabled_by_default(self, workspace):
         with patch_podman(self.registry) as p:

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -613,7 +613,11 @@ class TestStartContainer:
         assert kwargs["annotations"] == {
             "klangk.netfilter.rules": "github.com:443,pypi.org"
         }
-        assert kwargs["hooks_dir"] == str((tmp_path / "hooks").resolve())
+        assert kwargs["hooks_dir"] == [
+            str((tmp_path / "hooks").resolve()),
+            "/usr/share/containers/oci/hooks.d",
+            "/etc/containers/oci/hooks.d",
+        ]
         assert kwargs["cap_drop"] == ["NET_ADMIN"]
 
     def test_egress_filter_missing_netfilter_state_is_noop(self):

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -602,6 +602,9 @@ class TestStartContainer:
             "netfilter_hooks_dir",
             str(tmp_path / "hooks"),
         )
+        # #1771: create_kwargs only trusts a dir whose hook is actually
+        # installed, so arm it before starting the container.
+        self.registry.app.state.netfilter.install_hooks()
         with patch_podman(self.registry) as p:
             await self.registry.start_container(
                 workspace["id"],

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -580,6 +580,7 @@ class TestStartContainer:
         kwargs = p.create_container.call_args.kwargs
         assert "annotations" not in kwargs
         assert "hooks_dir" not in kwargs
+        assert "cap_drop" not in kwargs
 
     async def test_egress_filter_disabled_fail_opens(self, workspace, caplog):
         # allowed_domains set but netfilter disabled (no hooks dir) ->
@@ -613,6 +614,7 @@ class TestStartContainer:
             "klangk.netfilter.rules": "github.com:443,pypi.org"
         }
         assert kwargs["hooks_dir"] == str((tmp_path / "hooks").resolve())
+        assert kwargs["cap_drop"] == ["NET_ADMIN"]
 
     def test_egress_filter_missing_netfilter_state_is_noop(self):
         # Defensive: an app-state without a netfilter subsystem (some
@@ -622,7 +624,7 @@ class TestStartContainer:
             state=types.SimpleNamespace(settings=make_settings({}))
         )
         reg = container.ContainerRegistry(app_state)
-        assert reg._egress_filter(["github.com"]) == (None, None)
+        assert reg._egress_filter(["github.com"]) == (None, None, None)
 
     async def test_sudo_disabled_by_default(self, workspace):
         with patch_podman(self.registry) as p:

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -70,6 +70,10 @@ def _make_app_state(settings=None):
     app_state.state.util = util_mod.Util(app_state)
     # #1567: the lifespan calls app.state.ssl_trust.apply_backend_ssl_trust().
     app_state.state.ssl_trust = ssl_trust_mod.SSLTrust(app_state)
+    # #1365: the lifespan calls app.state.netfilter.install_hooks().
+    from klangk.netfilter import NetFilter
+
+    app_state.state.netfilter = NetFilter(app_state)
     app_state.state.auth = auth_mod.Auth(app_state)
     app_state.state.proxy_watchdog = proxy_mod.ProxyWatchdog(app_state)
     from klangk.terminal import Terminal

--- a/src/klangk/klangkd-tests/tests/test_model_workspaces.py
+++ b/src/klangk/klangkd-tests/tests/test_model_workspaces.py
@@ -175,6 +175,56 @@ async def test_update_workspace_fields(ws, user):
     )
 
 
+async def test_allowed_domains_roundtrip(ws, user):
+    # Create persists the list; get/get_by_id/list all surface it.
+    ws_row = await ws.create_workspace_with_acl(
+        user["id"],
+        "filtered",
+        allowed_domains=["github.com:443", "pypi.org"],
+    )
+    assert ws_row["allowed_domains"] == ["github.com:443", "pypi.org"]
+    got = await ws.get_workspace(ws_row["id"], user["id"])
+    assert got["allowed_domains"] == ["github.com:443", "pypi.org"]
+    by_id = await ws.get_workspace_by_id(ws_row["id"])
+    assert by_id["allowed_domains"] == ["github.com:443", "pypi.org"]
+    listing = await ws.list_workspaces(user["id"])
+    assert listing["items"][0]["allowed_domains"] == [
+        "github.com:443",
+        "pypi.org",
+    ]
+
+
+async def test_allowed_domains_default_none(ws, user):
+    # No allowed_domains -> NULL -> unrestricted (surfaces as None).
+    ws_row = await ws.create_workspace(user["id"], "open")
+    assert ws_row["allowed_domains"] is None
+    got = await ws.get_workspace(ws_row["id"], user["id"])
+    assert got["allowed_domains"] is None
+
+
+async def test_allowed_domains_updateable(ws, user):
+    ws_row = await ws.create_workspace(user["id"], "editable")
+    assert (
+        await ws.update_workspace(
+            ws_row["id"],
+            user["id"],
+            allowed_domains=["github.com"],
+        )
+        is True
+    )
+    got = await ws.get_workspace(ws_row["id"], user["id"])
+    assert got["allowed_domains"] == ["github.com"]
+    # Clearing by passing None restores unrestricted.
+    assert (
+        await ws.update_workspace(
+            ws_row["id"], user["id"], allowed_domains=None
+        )
+        is True
+    )
+    got = await ws.get_workspace(ws_row["id"], user["id"])
+    assert got["allowed_domains"] is None
+
+
 async def test_transfer_workspace(ws, app_state, user):
     new_owner = await app_state.state.model.users.create_user("new@x.com", "h")
     ws_row = await ws.create_workspace_with_acl(user["id"], "transfer-me")

--- a/src/klangk/klangkd-tests/tests/test_netfilter.py
+++ b/src/klangk/klangkd-tests/tests/test_netfilter.py
@@ -11,10 +11,12 @@ from klangk import netfilter as nf
 from _helpers import make_settings
 
 
-def _app(hooks_dir=None, tmp_path=None):
+def _app(hooks_dir=None, default_domains=None, tmp_path=None):
     settings = make_settings({})
     if hooks_dir is not None:
         settings.netfilter_hooks_dir = hooks_dir
+    if default_domains is not None:
+        settings.netfilter_default_domains = default_domains
     return types.SimpleNamespace(
         state=types.SimpleNamespace(settings=settings)
     )
@@ -186,3 +188,65 @@ class TestNetFilterCreateKwargs:
         )
         assert ann == {nf.ANNOTATION_KEY: "github.com:443,pypi.org"}
         assert hooks == os.path.realpath(path)
+
+    def test_workspace_overrides_deploy_default(self, tmp_path):
+        # A non-empty workspace list replaces the default (no merge).
+        path = str(tmp_path / "hooks")
+        ann, _ = nf.NetFilter(
+            _app(hooks_dir=path, default_domains=["default.com", "a.io"])
+        ).create_kwargs(["ws.com:443"])
+        assert ann == {nf.ANNOTATION_KEY: "ws.com:443"}
+
+    def test_empty_workspace_inherits_deploy_default(self, tmp_path):
+        path = str(tmp_path / "hooks")
+        ann, hooks = nf.NetFilter(
+            _app(hooks_dir=path, default_domains=["default.com", "a.io"])
+        ).create_kwargs(None)
+        assert ann == {nf.ANNOTATION_KEY: "default.com,a.io"}
+        assert hooks == os.path.realpath(path)
+
+        # Same for an explicit empty list (None and [] both inherit).
+        ann2, _ = nf.NetFilter(
+            _app(hooks_dir=path, default_domains=["default.com", "a.io"])
+        ).create_kwargs([])
+        assert ann2 == {nf.ANNOTATION_KEY: "default.com,a.io"}
+
+    def test_default_present_but_netfilter_disabled_warns(self, caplog):
+        app = _app(default_domains=["default.com"])  # no hooks dir
+        with caplog.at_level("WARNING"):
+            result = nf.NetFilter(app).create_kwargs(None)
+        assert result == (None, None)
+        assert any("UNRESTRICTED" in r.message for r in caplog.records)
+
+
+class TestNetFilterDefaultDomains:
+    def test_unset_returns_empty(self):
+        assert nf.NetFilter(_app()).default_domains() == []
+
+    def test_returns_settings_list(self):
+        # The field is already validated + de-duped at construction; this
+        # just surfaces it (and returns a copy so callers can't mutate it).
+        nf_obj = nf.NetFilter(_app(default_domains=["b.io", "a.com:443"]))
+        assert nf_obj.default_domains() == ["b.io", "a.com:443"]
+        # Mutating the returned list does not leak into settings.
+        got = nf_obj.default_domains()
+        got.append("evil.io")
+        assert nf_obj.default_domains() == ["b.io", "a.com:443"]
+
+    def test_reflects_reloaded_settings(self):
+        # reconfigure() points at a new app/state; the next read sees the
+        # new settings (no stale cache).
+        nf_obj = nf.NetFilter(_app(default_domains=["a.com"]))
+        assert nf_obj.default_domains() == ["a.com"]
+        nf_obj.reconfigure(_app(default_domains=["b.com"]))
+        assert nf_obj.default_domains() == ["b.com"]
+
+
+class TestNetFilterEnabled:
+    def test_disabled_when_hooks_dir_unset(self):
+        assert nf.NetFilter(_app()).enabled() is False
+
+    def test_enabled_when_hooks_dir_set(self, tmp_path):
+        assert (
+            nf.NetFilter(_app(hooks_dir=str(tmp_path / "h"))).enabled() is True
+        )

--- a/src/klangk/klangkd-tests/tests/test_netfilter.py
+++ b/src/klangk/klangkd-tests/tests/test_netfilter.py
@@ -48,6 +48,7 @@ class TestParseAllowedDomains:
             "10.0.0.1",
             "10.0.0.1:53",
             "sub.domain.example.com:8080",
+            "a.com:65535",  # max valid port
             "[::1]",
             "[2001:db8::1]:443",
         ],
@@ -61,6 +62,8 @@ class TestParseAllowedDomains:
             "bad spec",  # whitespace
             "a.com:abc",  # non-numeric port
             "a.com:123456",  # port too long (>5 digits)
+            "a.com:99999",  # port > 65535
+            "[::1]:70000",  # bracketed IPv6, port > 65535
             "/etc/passwd",  # slash
             "-leading",  # leading hyphen rejected by host grammar
             "a.com/path",

--- a/src/klangk/klangkd-tests/tests/test_netfilter.py
+++ b/src/klangk/klangkd-tests/tests/test_netfilter.py
@@ -170,45 +170,49 @@ class TestNetFilterInstallHooks:
 
 
 class TestNetFilterCreateKwargs:
-    def test_no_domains_returns_none_pair(self):
-        assert nf.NetFilter(_app()).create_kwargs(None) == (None, None)
-        assert nf.NetFilter(_app()).create_kwargs([]) == (None, None)
+    def test_no_domains_returns_none_triplet(self):
+        assert nf.NetFilter(_app()).create_kwargs(None) == (None, None, None)
+        assert nf.NetFilter(_app()).create_kwargs([]) == (None, None, None)
 
     def test_domains_without_hooks_dir_warns_and_fail_opens(self, caplog):
         app = _app()  # netfilter disabled
         with caplog.at_level("WARNING"):
             result = nf.NetFilter(app).create_kwargs(["github.com:443"])
-        assert result == (None, None)
+        assert result == (None, None, None)
         assert any("UNRESTRICTED" in r.message for r in caplog.records)
 
-    def test_domains_with_hooks_dir_returns_annotation_and_path(
+    def test_domains_with_hooks_dir_returns_annotation_path_and_cap_drop(
         self, tmp_path
     ):
         path = str(tmp_path / "hooks")
-        ann, hooks = nf.NetFilter(_app(hooks_dir=path)).create_kwargs(
-            ["github.com:443", "pypi.org"]
-        )
+        ann, hooks, cap_drop = nf.NetFilter(
+            _app(hooks_dir=path)
+        ).create_kwargs(["github.com:443", "pypi.org"])
         assert ann == {nf.ANNOTATION_KEY: "github.com:443,pypi.org"}
         assert hooks == os.path.realpath(path)
+        # A filtered container drops NET_ADMIN so the entrypoint can't
+        # flush the ruleset (#1773).
+        assert cap_drop == ["NET_ADMIN"]
 
     def test_workspace_overrides_deploy_default(self, tmp_path):
         # A non-empty workspace list replaces the default (no merge).
         path = str(tmp_path / "hooks")
-        ann, _ = nf.NetFilter(
+        ann, _, cap_drop = nf.NetFilter(
             _app(hooks_dir=path, default_domains=["default.com", "a.io"])
         ).create_kwargs(["ws.com:443"])
         assert ann == {nf.ANNOTATION_KEY: "ws.com:443"}
+        assert cap_drop == ["NET_ADMIN"]
 
     def test_empty_workspace_inherits_deploy_default(self, tmp_path):
         path = str(tmp_path / "hooks")
-        ann, hooks = nf.NetFilter(
+        ann, hooks, _ = nf.NetFilter(
             _app(hooks_dir=path, default_domains=["default.com", "a.io"])
         ).create_kwargs(None)
         assert ann == {nf.ANNOTATION_KEY: "default.com,a.io"}
         assert hooks == os.path.realpath(path)
 
         # Same for an explicit empty list (None and [] both inherit).
-        ann2, _ = nf.NetFilter(
+        ann2, _, _ = nf.NetFilter(
             _app(hooks_dir=path, default_domains=["default.com", "a.io"])
         ).create_kwargs([])
         assert ann2 == {nf.ANNOTATION_KEY: "default.com,a.io"}
@@ -217,7 +221,7 @@ class TestNetFilterCreateKwargs:
         app = _app(default_domains=["default.com"])  # no hooks dir
         with caplog.at_level("WARNING"):
             result = nf.NetFilter(app).create_kwargs(None)
-        assert result == (None, None)
+        assert result == (None, None, None)
         assert any("UNRESTRICTED" in r.message for r in caplog.records)
 
 

--- a/src/klangk/klangkd-tests/tests/test_netfilter.py
+++ b/src/klangk/klangkd-tests/tests/test_netfilter.py
@@ -189,7 +189,10 @@ class TestNetFilterCreateKwargs:
             _app(hooks_dir=path)
         ).create_kwargs(["github.com:443", "pypi.org"])
         assert ann == {nf.ANNOTATION_KEY: "github.com:443,pypi.org"}
-        assert hooks == os.path.realpath(path)
+        # #1770: the klangk hooks dir is followed by the standard default
+        # hook dirs so --hooks-dir doesn't silently disable operator
+        # createContainer hooks.
+        assert hooks == [os.path.realpath(path), *nf.STANDARD_HOOK_DIRS]
         # A filtered container drops NET_ADMIN so the entrypoint can't
         # flush the ruleset (#1773).
         assert cap_drop == ["NET_ADMIN"]
@@ -209,7 +212,7 @@ class TestNetFilterCreateKwargs:
             _app(hooks_dir=path, default_domains=["default.com", "a.io"])
         ).create_kwargs(None)
         assert ann == {nf.ANNOTATION_KEY: "default.com,a.io"}
-        assert hooks == os.path.realpath(path)
+        assert hooks == [os.path.realpath(path), *nf.STANDARD_HOOK_DIRS]
 
         # Same for an explicit empty list (None and [] both inherit).
         ann2, _, _ = nf.NetFilter(

--- a/src/klangk/klangkd-tests/tests/test_netfilter.py
+++ b/src/klangk/klangkd-tests/tests/test_netfilter.py
@@ -2,7 +2,9 @@
 
 import json
 import os
+import shutil
 import stat
+import subprocess
 import types
 
 import pytest
@@ -250,3 +252,337 @@ class TestNetFilterEnabled:
         assert (
             nf.NetFilter(_app(hooks_dir=str(tmp_path / "h"))).enabled() is True
         )
+
+
+# --- the OCI hook script, actually executed ---
+#
+# The hook's iptables ruleset IS the security enforcement, and a string-only
+# assertion ("klangk.netfilter.rules" in f.read()) lets every argv-splitting
+# and IPv6-parsing bug ship undetected (#1365 review: B1/B2 both escaped
+# because HOOK_SCRIPT had zero executable coverage). These tests run it for
+# real against synthetic OCI state with shimmed nsenter/iptables/getent.
+
+
+def _state(rules, *, with_pid=True):
+    """Build synthetic OCI container state JSON for the hook.
+
+    ``rules`` is the ``klangk.netfilter.rules`` annotation value, or ``None``
+    to omit the annotation (early-exit path). ``with_pid=False`` omits ``pid``
+    (the other early-exit path). Otherwise ``pid`` is the running process's
+    id so the hook's ``[ -e /proc/$pid/ns/net ]`` guard passes — the nsenter
+    shim ignores the path anyway.
+    """
+    s = {}
+    if with_pid:
+        s["pid"] = os.getpid()
+    if rules is not None:
+        s["annotations"] = {nf.ANNOTATION_KEY: rules}
+    return json.dumps(s)
+
+
+def _run_hook(tmp_path, state, getent_map=None, resolv=None, hosts=None):
+    """Execute ``nf.HOOK_SCRIPT`` against ``state``; return recorded iptables
+    invocations (each a ``list[str]`` of argv).
+
+    ``nsenter``/``iptables``/``getent`` are shimmed on a prepended PATH dir
+    so the hook runs without root or a real netns. ``getent_map`` maps a host
+    to its resolved IPs (newline-separated via the shim); a host absent from
+    the map resolves to itself (deterministic, and enough to test argv).
+    ``resolv``/``hosts`` are the contents of the container's
+    /etc/resolv.conf and /etc/hosts the hook reads (via env-var path
+    overrides); both default to empty so per-destination assertions stay
+    clean — the dedicated DNS/gateway tests pass content.
+    """
+    getent_map = getent_map or {}
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    record = tmp_path / "iptables.log"
+    map_file = tmp_path / "getent.map"
+    resolv_file = tmp_path / "resolv.conf"
+    hosts_file = tmp_path / "hosts"
+
+    map_file.write_text(
+        "\n".join(f"{h}|{','.join(ips)}" for h, ips in getent_map.items())
+        + "\n"
+    )
+    resolv_file.write_text(resolv or "")
+    hosts_file.write_text(hosts or "")
+    # getent ahosts <host> shim: resolve from the | map, else echo the host.
+    (bin_dir / "getent").write_text(
+        "#!/bin/sh\n"
+        f'map="{map_file}"\n'
+        'host="$2"\n'
+        'if [ -f "$map" ]; then\n'
+        '  while IFS="|" read -r h ips; do\n'
+        '    if [ "$h" = "$host" ]; then\n'
+        '      printf "%s\\n" "$ips" | tr "," "\\n"\n'
+        "      exit 0\n"
+        "    fi\n"
+        '  done < "$map"\n'
+        "fi\n"
+        'printf "%s\\n" "$host"\n'
+    )
+    (bin_dir / "getent").chmod(0o755)
+    # nsenter shim: drop the --net flag + the "iptables" token, then re-exec
+    # the iptables shim with the remaining args (the real netns is irrelevant
+    # to what we're asserting, which is the argv the hook builds).
+    (bin_dir / "nsenter").write_text(
+        "#!/bin/sh\n"
+        "shift  # --net=/proc/.../ns/net\n"
+        'shift  # "iptables"\n'
+        'exec iptables "$@"\n'
+    )
+    (bin_dir / "nsenter").chmod(0o755)
+    # iptables shim: record argv, one arg per line, blank line between calls.
+    (bin_dir / "iptables").write_text(
+        "#!/bin/sh\n"
+        f'rec="{record}"\n'
+        'for a in "$@"; do\n'
+        '  printf "%s\\n" "$a" >>"$rec"\n'
+        "done\n"
+        'printf "\\n" >>"$rec"\n'
+        "exit 0\n"
+    )
+    (bin_dir / "iptables").chmod(0o755)
+
+    hook = bin_dir / "klangk-netfilter.sh"
+    hook.write_text(nf.HOOK_SCRIPT)
+    hook.chmod(0o755)
+
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}:{env['PATH']}"
+    # Point the hook at our temp resolv.conf/hosts instead of /proc/$pid/root.
+    env["KLANGK_NETFILTER_RESOLV"] = str(resolv_file)
+    env["KLANGK_NETFILTER_HOSTS"] = str(hosts_file)
+    sh = shutil.which("sh") or "/bin/sh"
+    proc = subprocess.run(
+        [sh, str(hook)],
+        input=state,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert proc.returncode == 0, (
+        f"hook exited {proc.returncode}\nstderr:\n{proc.stderr}"
+    )
+    if not record.exists():
+        return []
+    calls = []
+    for block in record.read_text().split("\n\n"):
+        args = block.split("\n")
+        if args == [""]:
+            continue
+        calls.append(args)
+    return calls
+
+
+def _accept_rules(calls):
+    """The per-destination ACCEPT invocations: [-A, OUTPUT, -d, <ip>, ...]."""
+    return [c for c in calls if c[:3] == ["-A", "OUTPUT", "-d"]]
+
+
+class TestHookScriptExecutable:
+    def test_host_port_emits_split_argv(self, tmp_path):
+        # B1 regression: the ACCEPT rule must reach iptables as separate
+        # argv entries (-d <ip> -p tcp --dport <port> -j ACCEPT), not one
+        # blob. The IFS=',' bug collapsed the whole rule into a single
+        # rejected argument.
+        calls = _run_hook(
+            tmp_path,
+            _state("github.com:443"),
+            getent_map={"github.com": ["140.82.112.4"]},
+        )
+        assert _accept_rules(calls) == [
+            [
+                "-A",
+                "OUTPUT",
+                "-d",
+                "140.82.112.4",
+                "-p",
+                "tcp",
+                "--dport",
+                "443",
+                "-j",
+                "ACCEPT",
+            ],
+        ]
+
+    def test_default_drop_policy_set(self, tmp_path):
+        # The fail-closed posture: OUTPUT policy is DROP before any ACCEPT.
+        calls = _run_hook(
+            tmp_path,
+            _state("a.example"),
+            getent_map={"a.example": ["1.2.3.4"]},
+        )
+        assert ["-P", "OUTPUT", "DROP"] in calls
+
+    def test_multi_ip_host_emits_one_rule_per_ip(self, tmp_path):
+        # B1 compounding bug: under IFS=',' getent's newline-separated output
+        # collapsed into one garbage IP. Each resolved IP must get its own
+        # correctly-split ACCEPT rule.
+        calls = _run_hook(
+            tmp_path,
+            _state("multi.example:443"),
+            getent_map={"multi.example": ["1.1.1.1", "2.2.2.2"]},
+        )
+        assert _accept_rules(calls) == [
+            [
+                "-A",
+                "OUTPUT",
+                "-d",
+                "1.1.1.1",
+                "-p",
+                "tcp",
+                "--dport",
+                "443",
+                "-j",
+                "ACCEPT",
+            ],
+            [
+                "-A",
+                "OUTPUT",
+                "-d",
+                "2.2.2.2",
+                "-p",
+                "tcp",
+                "--dport",
+                "443",
+                "-j",
+                "ACCEPT",
+            ],
+        ]
+
+    def test_bracketed_ipv6_with_port(self, tmp_path):
+        # B2 regression: [2001:db8::1]:443 is blessed by the API validator
+        # but the hook's ':' suffix-splitting mangled it (_host="[2001").
+        # Brackets must be stripped and the port parsed.
+        calls = _run_hook(
+            tmp_path,
+            _state("[2001:db8::1]:443"),
+            getent_map={"2001:db8::1": ["2001:db8::1"]},
+        )
+        assert _accept_rules(calls) == [
+            [
+                "-A",
+                "OUTPUT",
+                "-d",
+                "2001:db8::1",
+                "-p",
+                "tcp",
+                "--dport",
+                "443",
+                "-j",
+                "ACCEPT",
+            ],
+        ]
+
+    def test_bracketed_ipv6_without_port(self, tmp_path):
+        # B2: [::1] (no port) — brackets stripped, no --dport emitted.
+        calls = _run_hook(
+            tmp_path,
+            _state("[::1]"),
+            getent_map={"::1": ["::1"]},
+        )
+        assert _accept_rules(calls) == [
+            ["-A", "OUTPUT", "-d", "::1", "-j", "ACCEPT"],
+        ]
+
+    def test_multiple_specs_all_applied_in_order(self, tmp_path):
+        # The whole CSV is split and each spec yields its rules.
+        calls = _run_hook(
+            tmp_path,
+            _state("github.com:443,pypi.org,[::1]"),
+            getent_map={
+                "github.com": ["140.82.112.4"],
+                "pypi.org": ["151.101.0.0"],
+            },
+        )
+        dests = [c[3] for c in _accept_rules(calls)]
+        assert dests == ["140.82.112.4", "151.101.0.0", "::1"]
+
+    def test_host_without_port_allows_all_ports(self, tmp_path):
+        calls = _run_hook(
+            tmp_path,
+            _state("pypi.org"),
+            getent_map={"pypi.org": ["151.101.0.0"]},
+        )
+        assert _accept_rules(calls) == [
+            ["-A", "OUTPUT", "-d", "151.101.0.0", "-j", "ACCEPT"],
+        ]
+
+    def test_no_annotation_is_noop(self, tmp_path):
+        # No rules annotation → the hook exits before touching iptables.
+        assert _run_hook(tmp_path, _state(None)) == []
+
+    def test_no_pid_is_noop(self, tmp_path):
+        # No init pid → same early exit (no netns to install into).
+        assert _run_hook(tmp_path, _state("a.com:443", with_pid=False)) == []
+
+    # --- I1: DNS must be pinned to the container's resolvers, not blanket ---
+
+    def test_dns_allowed_only_to_resolv_nameservers(self, tmp_path):
+        # I1 regression: :53 used to be ACCEPTed to ANY destination (an
+        # exfil / DNS-tunneling channel). Now it's allowed only to the
+        # nameservers in the container's /etc/resolv.conf.
+        calls = _run_hook(
+            tmp_path,
+            _state("github.com:443"),
+            getent_map={"github.com": ["140.82.112.4"]},
+            resolv="nameserver 1.1.1.1\nnameserver 8.8.8.8\n",
+        )
+        dns = [c for c in calls if "--dport" in c and "53" in c and "-p" in c]
+        # One udp + one tcp rule per nameserver, each pinned to that IP.
+        for ns in ("1.1.1.1", "8.8.8.8"):
+            for proto in ("udp", "tcp"):
+                assert [
+                    "-A",
+                    "OUTPUT",
+                    "-p",
+                    proto,
+                    "--dport",
+                    "53",
+                    "-d",
+                    ns,
+                    "-j",
+                    "ACCEPT",
+                ] in dns
+        # No blanket :53 rule (one without a -d destination) survives.
+        assert not any("-d" not in c for c in dns)
+
+    def test_no_dns_allow_when_no_resolvers(self, tmp_path):
+        # With no nameservers configured, DNS is fully blocked (fail-closed),
+        # never falling back to the old blanket :53 ACCEPT.
+        calls = _run_hook(
+            tmp_path,
+            _state("github.com:443"),
+            getent_map={"github.com": ["140.82.112.4"]},
+            resolv="",  # no nameservers
+        )
+        assert not any("--dport" in c and "53" in c for c in calls)
+
+    # --- I7: gateway resolved from the container's /etc/hosts, not getent ---
+
+    def test_gateway_allowed_from_hosts_file(self, tmp_path):
+        # I7 regression: host.containers.internal used to be resolved via the
+        # host netns getent (where the name doesn't exist) → no gateway rule →
+        # the workspace couldn't reach its LLM proxy / browser delegate / chat
+        # bridge. Now it's read from the container's /etc/hosts.
+        calls = _run_hook(
+            tmp_path,
+            _state("github.com:443"),
+            getent_map={"github.com": ["140.82.112.4"]},
+            hosts=("127.0.0.1 localhost\n10.0.2.2 host.containers.internal\n"),
+        )
+        assert ["-A", "OUTPUT", "-d", "10.0.2.2", "-j", "ACCEPT"] in calls
+
+    def test_gateway_absent_when_not_in_hosts(self, tmp_path):
+        # No host.containers.internal entry → no gateway rule. Confirms the
+        # hook doesn't fall back to a host-netns getent (which would either
+        # silently produce nothing or resolve the wrong IP).
+        calls = _run_hook(
+            tmp_path,
+            _state("github.com:443"),
+            getent_map={"github.com": ["140.82.112.4"]},
+            hosts="127.0.0.1 localhost\n",
+        )
+        assert not any("-d" in c and "10.0.2.2" in c for c in calls)

--- a/src/klangk/klangkd-tests/tests/test_netfilter.py
+++ b/src/klangk/klangkd-tests/tests/test_netfilter.py
@@ -185,9 +185,11 @@ class TestNetFilterCreateKwargs:
         self, tmp_path
     ):
         path = str(tmp_path / "hooks")
-        ann, hooks, cap_drop = nf.NetFilter(
-            _app(hooks_dir=path)
-        ).create_kwargs(["github.com:443", "pypi.org"])
+        nf_obj = nf.NetFilter(_app(hooks_dir=path))
+        nf_obj.install_hooks()  # arm the hook so create_kwargs trusts the dir
+        ann, hooks, cap_drop = nf_obj.create_kwargs(
+            ["github.com:443", "pypi.org"]
+        )
         assert ann == {nf.ANNOTATION_KEY: "github.com:443,pypi.org"}
         # #1770: the klangk hooks dir is followed by the standard default
         # hook dirs so --hooks-dir doesn't silently disable operator
@@ -200,24 +202,26 @@ class TestNetFilterCreateKwargs:
     def test_workspace_overrides_deploy_default(self, tmp_path):
         # A non-empty workspace list replaces the default (no merge).
         path = str(tmp_path / "hooks")
-        ann, _, cap_drop = nf.NetFilter(
+        nf_obj = nf.NetFilter(
             _app(hooks_dir=path, default_domains=["default.com", "a.io"])
-        ).create_kwargs(["ws.com:443"])
+        )
+        nf_obj.install_hooks()
+        ann, _, cap_drop = nf_obj.create_kwargs(["ws.com:443"])
         assert ann == {nf.ANNOTATION_KEY: "ws.com:443"}
         assert cap_drop == ["NET_ADMIN"]
 
     def test_empty_workspace_inherits_deploy_default(self, tmp_path):
         path = str(tmp_path / "hooks")
-        ann, hooks, _ = nf.NetFilter(
+        nf_obj = nf.NetFilter(
             _app(hooks_dir=path, default_domains=["default.com", "a.io"])
-        ).create_kwargs(None)
+        )
+        nf_obj.install_hooks()
+        ann, hooks, _ = nf_obj.create_kwargs(None)
         assert ann == {nf.ANNOTATION_KEY: "default.com,a.io"}
         assert hooks == [os.path.realpath(path), *nf.STANDARD_HOOK_DIRS]
 
         # Same for an explicit empty list (None and [] both inherit).
-        ann2, _, _ = nf.NetFilter(
-            _app(hooks_dir=path, default_domains=["default.com", "a.io"])
-        ).create_kwargs([])
+        ann2, _, _ = nf_obj.create_kwargs([])
         assert ann2 == {nf.ANNOTATION_KEY: "default.com,a.io"}
 
     def test_default_present_but_netfilter_disabled_warns(self, caplog):
@@ -226,6 +230,36 @@ class TestNetFilterCreateKwargs:
             result = nf.NetFilter(app).create_kwargs(None)
         assert result == (None, None, None)
         assert any("UNRESTRICTED" in r.message for r in caplog.records)
+
+    def test_configured_but_not_installed_fail_opens(self, tmp_path, caplog):
+        # #1771: the hooks dir exists but the hook files were never written
+        # (partial install_hooks failure). create_kwargs must NOT hand
+        # podman the dir; it fails open with a distinct loud warning.
+        path = str(tmp_path / "hooks")
+        nf_obj = nf.NetFilter(_app(hooks_dir=path))
+        # hooks_dir() makedirs the dir, but no hook files are installed.
+        with caplog.at_level("WARNING"):
+            result = nf_obj.create_kwargs(["github.com:443"])
+        assert result == (None, None, None)
+        assert any(
+            "not installed or is stale" in r.message for r in caplog.records
+        )
+
+    @pytest.mark.parametrize("fname", [nf.HOOK_SCRIPT_NAME, nf.HOOK_JSON_NAME])
+    def test_stale_hook_files_fail_opens(self, tmp_path, caplog, fname):
+        # #1771: either hook file stale (old version) — script OR json — the
+        # content mismatch must be detected and treated as not-armed.
+        path = str(tmp_path / "hooks")
+        nf_obj = nf.NetFilter(_app(hooks_dir=path))
+        nf_obj.install_hooks()
+        with open(os.path.join(path, fname), "w") as f:
+            f.write("# stale old hook\n")
+        with caplog.at_level("WARNING"):
+            result = nf_obj.create_kwargs(["github.com:443"])
+        assert result == (None, None, None)
+        assert any(
+            "not installed or is stale" in r.message for r in caplog.records
+        )
 
 
 class TestNetFilterDefaultDomains:
@@ -255,10 +289,28 @@ class TestNetFilterEnabled:
     def test_disabled_when_hooks_dir_unset(self):
         assert nf.NetFilter(_app()).enabled() is False
 
-    def test_enabled_when_hooks_dir_set(self, tmp_path):
+    def test_enabled_when_installed(self, tmp_path):
+        # #1771: armed requires the hook to be installed, not just the dir
+        # configured.
+        nf_obj = nf.NetFilter(_app(hooks_dir=str(tmp_path / "h")))
+        nf_obj.install_hooks()
+        assert nf_obj.enabled() is True
+
+    def test_not_enabled_when_configured_but_not_installed(self, tmp_path):
+        # The dir exists but no hook files -> not armed (#1771).
         assert (
-            nf.NetFilter(_app(hooks_dir=str(tmp_path / "h"))).enabled() is True
+            nf.NetFilter(_app(hooks_dir=str(tmp_path / "h"))).enabled()
+            is False
         )
+
+    def test_not_enabled_when_hook_files_stale(self, tmp_path):
+        # Files present but content is stale -> not armed (#1771).
+        path = str(tmp_path / "h")
+        nf_obj = nf.NetFilter(_app(hooks_dir=path))
+        nf_obj.install_hooks()
+        with open(os.path.join(path, nf.HOOK_SCRIPT_NAME), "w") as f:
+            f.write("# stale\n")
+        assert nf_obj.enabled() is False
 
 
 # --- the OCI hook script, actually executed ---

--- a/src/klangk/klangkd-tests/tests/test_netfilter.py
+++ b/src/klangk/klangkd-tests/tests/test_netfilter.py
@@ -1,0 +1,188 @@
+"""Tests for the per-workspace netfilter egress-filter surface (#1365)."""
+
+import json
+import os
+import stat
+import types
+
+import pytest
+
+from klangk import netfilter as nf
+from _helpers import make_settings
+
+
+def _app(hooks_dir=None, tmp_path=None):
+    settings = make_settings({})
+    if hooks_dir is not None:
+        settings.netfilter_hooks_dir = hooks_dir
+    return types.SimpleNamespace(
+        state=types.SimpleNamespace(settings=settings)
+    )
+
+
+# --- pure validators / renderers ---
+
+
+class TestParseAllowedDomains:
+    def test_strips_and_dedupes_preserving_order(self):
+        assert nf.parse_allowed_domains(
+            ["github.com:443", " github.com:443 ", "pypi.org"]
+        ) == ["github.com:443", "pypi.org"]
+
+    def test_drops_empties(self):
+        assert nf.parse_allowed_domains(["", "  ", "a.com"]) == ["a.com"]
+
+    @pytest.mark.parametrize(
+        "spec",
+        [
+            "github.com",
+            "github.com:443",
+            "pypi.org:80",
+            "10.0.0.1",
+            "10.0.0.1:53",
+            "sub.domain.example.com:8080",
+            "[::1]",
+            "[2001:db8::1]:443",
+        ],
+    )
+    def test_valid_specs(self, spec):
+        assert nf.parse_allowed_domains([spec]) == [spec]
+
+    @pytest.mark.parametrize(
+        "spec",
+        [
+            "bad spec",  # whitespace
+            "a.com:abc",  # non-numeric port
+            "a.com:123456",  # port too long (>5 digits)
+            "/etc/passwd",  # slash
+            "-leading",  # leading hyphen rejected by host grammar
+            "a.com/path",
+        ],
+    )
+    def test_invalid_specs_rejected(self, spec):
+        with pytest.raises(ValueError):
+            nf.parse_allowed_domains([spec])
+
+    def test_error_lists_every_invalid_entry(self):
+        with pytest.raises(ValueError) as exc:
+            nf.parse_allowed_domains(["good.com", "bad spec", "also bad"])
+        msg = str(exc.value)
+        assert "bad spec" in msg
+        assert "also bad" in msg
+        assert "good.com" not in msg.split("Invalid")[1]
+
+
+class TestRenderRulesAnnotation:
+    def test_comma_joined(self):
+        assert (
+            nf.render_rules_annotation(["github.com:443", "pypi.org"])
+            == "github.com:443,pypi.org"
+        )
+
+    def test_single(self):
+        assert nf.render_rules_annotation(["a.com"]) == "a.com"
+
+
+class TestRenderHookJson:
+    def test_points_at_absolute_script_and_gates_on_annotation(self, tmp_path):
+        script = str(tmp_path / "klangk-netfilter.sh")
+        data = json.loads(nf.render_hook_json(script))
+        assert data["hook"]["path"] == os.path.abspath(script)
+        assert data["stages"] == ["createContainer"]
+        # The annotations gate makes the hook fire ONLY for containers
+        # that carry the annotation — an unrestricted workspace is never
+        # filtered.
+        assert nf.ANNOTATION_KEY in data["annotations"]
+
+
+# --- NetFilter state object ---
+
+
+class TestNetFilterHooksDir:
+    def test_unset_returns_none(self):
+        assert nf.NetFilter(_app()).hooks_dir() is None
+
+    def test_creates_missing_dir(self, tmp_path):
+        path = str(tmp_path / "nested" / "hooks")
+        assert nf.NetFilter(
+            _app(hooks_dir=path)
+        ).hooks_dir() == os.path.realpath(path)
+        assert os.path.isdir(path)
+
+    def test_unwritable_returns_none(self, tmp_path, monkeypatch):
+        path = str(tmp_path / "hooks")
+        settings = make_settings({})
+        settings.netfilter_hooks_dir = path
+
+        def boom(*a, **kw):
+            raise OSError("nope")
+
+        monkeypatch.setattr(os, "makedirs", boom)
+        app = types.SimpleNamespace(
+            state=types.SimpleNamespace(settings=settings)
+        )
+        assert nf.NetFilter(app).hooks_dir() is None
+
+
+class TestNetFilterInstallHooks:
+    def test_disabled_is_noop(self):
+        assert nf.NetFilter(_app()).install_hooks() is None
+
+    def test_writes_script_and_json(self, tmp_path):
+        path = str(tmp_path / "hooks")
+        installed = nf.NetFilter(_app(hooks_dir=path)).install_hooks()
+        assert installed == os.path.realpath(path)
+        script = os.path.join(path, nf.HOOK_SCRIPT_NAME)
+        jsonf = os.path.join(path, nf.HOOK_JSON_NAME)
+        assert os.path.isfile(script)
+        # Executable so the OCI runtime can invoke it.
+        mode = stat.S_IMODE(os.lstat(script).st_mode)
+        assert mode & 0o111
+        with open(script) as f:
+            assert "klangk.netfilter.rules" in f.read()
+        with open(jsonf) as f:
+            data = json.load(f)
+        assert data["hook"]["path"] == os.path.abspath(script)
+
+    def test_idempotent(self, tmp_path):
+        path = str(tmp_path / "hooks")
+        nf_obj = nf.NetFilter(_app(hooks_dir=path))
+        nf_obj.install_hooks()
+        # Second call re-writes without error.
+        assert nf_obj.install_hooks() == os.path.realpath(path)
+
+    def test_write_failure_returns_none(self, tmp_path, monkeypatch):
+        path = str(tmp_path / "hooks")
+        nf_obj = nf.NetFilter(_app(hooks_dir=path))
+        original_open = open
+
+        def flaky_open(p, *a, **kw):
+            if str(p).endswith(nf.HOOK_SCRIPT_NAME):
+                raise OSError("disk full")
+            return original_open(p, *a, **kw)
+
+        monkeypatch.setattr("builtins.open", flaky_open)
+        assert nf_obj.install_hooks() is None
+
+
+class TestNetFilterCreateKwargs:
+    def test_no_domains_returns_none_pair(self):
+        assert nf.NetFilter(_app()).create_kwargs(None) == (None, None)
+        assert nf.NetFilter(_app()).create_kwargs([]) == (None, None)
+
+    def test_domains_without_hooks_dir_warns_and_fail_opens(self, caplog):
+        app = _app()  # netfilter disabled
+        with caplog.at_level("WARNING"):
+            result = nf.NetFilter(app).create_kwargs(["github.com:443"])
+        assert result == (None, None)
+        assert any("UNRESTRICTED" in r.message for r in caplog.records)
+
+    def test_domains_with_hooks_dir_returns_annotation_and_path(
+        self, tmp_path
+    ):
+        path = str(tmp_path / "hooks")
+        ann, hooks = nf.NetFilter(_app(hooks_dir=path)).create_kwargs(
+            ["github.com:443", "pypi.org"]
+        )
+        assert ann == {nf.ANNOTATION_KEY: "github.com:443,pypi.org"}
+        assert hooks == os.path.realpath(path)

--- a/src/klangk/klangkd-tests/tests/test_netfilter.py
+++ b/src/klangk/klangkd-tests/tests/test_netfilter.py
@@ -13,8 +13,11 @@ from klangk import netfilter as nf
 from _helpers import make_settings
 
 
-def _app(hooks_dir=None, default_domains=None, tmp_path=None):
+def _app(hooks_dir=None, default_domains=None, enabled=True, tmp_path=None):
     settings = make_settings({})
+    # #1774: netfilter_enabled defaults True (the production default); pass
+    # enabled=False to exercise the master-switch-off path.
+    settings.netfilter_enabled = enabled
     if hooks_dir is not None:
         settings.netfilter_hooks_dir = hooks_dir
     if default_domains is not None:
@@ -103,8 +106,18 @@ class TestRenderHookJson:
 
 
 class TestNetFilterHooksDir:
-    def test_unset_returns_none(self):
-        assert nf.NetFilter(_app()).hooks_dir() is None
+    def test_disabled_via_setting_returns_none(self):
+        # #1774: netfilter_enabled=False fully disables — no hooks dir.
+        assert nf.NetFilter(_app(enabled=False)).hooks_dir() is None
+
+    def test_unset_hooks_dir_defaults_to_state_dir_subdir(self):
+        # #1774: with netfilter enabled (the default) and no explicit hooks
+        # dir, it resolves to <state_dir>/oci-hooks.
+        app = _app()
+        state_dir = app.state.settings.state_dir
+        assert nf.NetFilter(app).hooks_dir() == os.path.realpath(
+            os.path.join(state_dir, nf.DEFAULT_HOOKS_SUBDIR)
+        )
 
     def test_creates_missing_dir(self, tmp_path):
         path = str(tmp_path / "nested" / "hooks")
@@ -130,7 +143,8 @@ class TestNetFilterHooksDir:
 
 class TestNetFilterInstallHooks:
     def test_disabled_is_noop(self):
-        assert nf.NetFilter(_app()).install_hooks() is None
+        # #1774: netfilter_enabled=False -> install_hooks is a noop.
+        assert nf.NetFilter(_app(enabled=False)).install_hooks() is None
 
     def test_writes_script_and_json(self, tmp_path):
         path = str(tmp_path / "hooks")
@@ -174,8 +188,9 @@ class TestNetFilterCreateKwargs:
         assert nf.NetFilter(_app()).create_kwargs(None) == (None, None, None)
         assert nf.NetFilter(_app()).create_kwargs([]) == (None, None, None)
 
-    def test_domains_without_hooks_dir_warns_and_fail_opens(self, caplog):
-        app = _app()  # netfilter disabled
+    def test_domains_disabled_via_setting_warns_and_fail_opens(self, caplog):
+        # #1774: netfilter_enabled=False -> fail open with a loud warning.
+        app = _app(enabled=False)
         with caplog.at_level("WARNING"):
             result = nf.NetFilter(app).create_kwargs(["github.com:443"])
         assert result == (None, None, None)
@@ -225,7 +240,7 @@ class TestNetFilterCreateKwargs:
         assert ann2 == {nf.ANNOTATION_KEY: "default.com,a.io"}
 
     def test_default_present_but_netfilter_disabled_warns(self, caplog):
-        app = _app(default_domains=["default.com"])  # no hooks dir
+        app = _app(default_domains=["default.com"], enabled=False)
         with caplog.at_level("WARNING"):
             result = nf.NetFilter(app).create_kwargs(None)
         assert result == (None, None, None)
@@ -286,8 +301,9 @@ class TestNetFilterDefaultDomains:
 
 
 class TestNetFilterEnabled:
-    def test_disabled_when_hooks_dir_unset(self):
-        assert nf.NetFilter(_app()).enabled() is False
+    def test_disabled_when_netfilter_enabled_false(self):
+        # #1774: the master switch off -> not armed.
+        assert nf.NetFilter(_app(enabled=False)).enabled() is False
 
     def test_enabled_when_installed(self, tmp_path):
         # #1771: armed requires the hook to be installed, not just the dir

--- a/src/klangk/klangkd-tests/tests/test_podman.py
+++ b/src/klangk/klangkd-tests/tests/test_podman.py
@@ -260,6 +260,37 @@ class TestCreateContainer:
         assert "--pull=missing" in args
         assert "--pull=never" not in args
 
+    async def test_annotations_emitted(self):
+        with patch(EXEC, _exec(("id\n", "", 0))) as m:
+            await _p.create_container(
+                "n",
+                "img",
+                annotations={"klangk.netfilter.rules": "github.com:443"},
+                replace=False,
+            )
+        args = _args(m)
+        assert [
+            "--annotation",
+            "klangk.netfilter.rules=github.com:443",
+        ] == args[args.index("--annotation") : args.index("--annotation") + 2]
+
+    async def test_hooks_dir_emitted(self):
+        with patch(EXEC, _exec(("id\n", "", 0))) as m:
+            await _p.create_container(
+                "n", "img", hooks_dir="/etc/klangk/hooks", replace=False
+            )
+        args = _args(m)
+        assert ["--hooks-dir", "/etc/klangk/hooks"] == args[
+            args.index("--hooks-dir") : args.index("--hooks-dir") + 2
+        ]
+
+    async def test_no_hooks_dir_or_annotation_by_default(self):
+        with patch(EXEC, _exec(("id\n", "", 0))) as m:
+            await _p.create_container("n", "img", replace=False)
+        args = _args(m)
+        assert "--hooks-dir" not in args
+        assert "--annotation" not in args
+
 
 class TestStartContainer:
     async def test_start(self):

--- a/src/klangk/klangkd-tests/tests/test_podman.py
+++ b/src/klangk/klangkd-tests/tests/test_podman.py
@@ -290,6 +290,17 @@ class TestCreateContainer:
         args = _args(m)
         assert "--hooks-dir" not in args
         assert "--annotation" not in args
+        assert "--cap-drop" not in args
+
+    async def test_cap_drop_emitted(self):
+        with patch(EXEC, _exec(("id\n", "", 0))) as m:
+            await _p.create_container(
+                "n", "img", cap_drop=["NET_ADMIN"], replace=False
+            )
+        args = _args(m)
+        assert ["--cap-drop", "NET_ADMIN"] == args[
+            args.index("--cap-drop") : args.index("--cap-drop") + 2
+        ]
 
 
 class TestStartContainer:

--- a/src/klangk/klangkd-tests/tests/test_podman.py
+++ b/src/klangk/klangkd-tests/tests/test_podman.py
@@ -277,12 +277,33 @@ class TestCreateContainer:
     async def test_hooks_dir_emitted(self):
         with patch(EXEC, _exec(("id\n", "", 0))) as m:
             await _p.create_container(
-                "n", "img", hooks_dir="/etc/klangk/hooks", replace=False
+                "n", "img", hooks_dir=["/etc/klangk/hooks"], replace=False
             )
         args = _args(m)
         assert ["--hooks-dir", "/etc/klangk/hooks"] == args[
             args.index("--hooks-dir") : args.index("--hooks-dir") + 2
         ]
+
+    async def test_multiple_hooks_dirs_each_emit_a_flag(self):
+        # #1770: --hooks-dir overrides (does not append) podman's default
+        # hook search paths, so a filtered container passes the klangk dir
+        # AND the standard default dirs — one --hooks-dir flag each, in
+        # order, so operator createContainer hooks keep running.
+        dirs = [
+            "/etc/klangk/hooks",
+            "/usr/share/containers/oci/hooks.d",
+            "/etc/containers/oci/hooks.d",
+        ]
+        with patch(EXEC, _exec(("id\n", "", 0))) as m:
+            await _p.create_container(
+                "n", "img", hooks_dir=dirs, replace=False
+            )
+        args = _args(m)
+        assert args.count("--hooks-dir") == 3
+        emitted = [
+            args[i + 1] for i, a in enumerate(args) if a == "--hooks-dir"
+        ]
+        assert emitted == dirs
 
     async def test_no_hooks_dir_or_annotation_by_default(self):
         with patch(EXEC, _exec(("id\n", "", 0))) as m:

--- a/src/klangk/klangkd-tests/tests/test_settings.py
+++ b/src/klangk/klangkd-tests/tests/test_settings.py
@@ -151,6 +151,42 @@ class TestConfigFile:
         s = make_settings({}, config_file="none")
         assert s.egress_port == "8995"  # built-in default
 
+    def test_netfilter_default_domains_from_env_comma_string(self):
+        """Env delivers a comma-separated string; coerced to a validated,
+        de-duped list (#1365)."""
+        s = make_settings(
+            {"KLANGKD_NETFILTER_DEFAULT_DOMAINS": "b.io, a.com:443 ,b.io"}
+        )
+        assert s.netfilter_default_domains == ["b.io", "a.com:443"]
+
+    def test_netfilter_default_domains_from_yaml_list(self, tmp_path):
+        """YAML delivers a native list (#1365)."""
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(
+            "netfilter_default_domains:\n  - github.com:443\n  - pypi.org\n"
+        )
+        s = make_settings({}, config_file=str(cfg))
+        assert s.netfilter_default_domains == ["github.com:443", "pypi.org"]
+
+    def test_netfilter_default_domains_empty_is_none(self):
+        """Empty / unset → None (no deploy default; workspaces unrestricted)."""
+        assert make_settings({}).netfilter_default_domains is None
+        assert (
+            make_settings(
+                {"KLANGKD_NETFILTER_DEFAULT_DOMAINS": "  , "}
+            ).netfilter_default_domains
+            is None
+        )
+
+    def test_netfilter_default_domains_invalid_aborts_boot(self):
+        """A bad spec fails fast at construction, not silently at use."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            make_settings(
+                {"KLANGKD_NETFILTER_DEFAULT_DOMAINS": "good.com,bad spec"}
+            )
+
     def test_file_cmd_resolution_from_yaml(self, tmp_path):
         """file:/cmd: values in YAML resolve at construction (#1461)."""
         secret = tmp_path / "jwt.txt"

--- a/src/klangk/klangkd-tests/tests/test_settings.py
+++ b/src/klangk/klangkd-tests/tests/test_settings.py
@@ -187,6 +187,18 @@ class TestConfigFile:
                 {"KLANGKD_NETFILTER_DEFAULT_DOMAINS": "good.com,bad spec"}
             )
 
+    def test_netfilter_default_domains_wrong_type_aborts_boot(self, tmp_path):
+        """A non-list/non-string value (e.g. a bare int from a malformed
+        YAML block) is rejected at construction, not silently coerced."""
+        from pydantic import ValidationError
+
+        # YAML delivering a scalar int directly (a typo'd block like
+        # `netfilter_default_domains: 42` instead of a list).
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("netfilter_default_domains: 42\n")
+        with pytest.raises(ValidationError):
+            make_settings({}, config_file=str(cfg))
+
     def test_file_cmd_resolution_from_yaml(self, tmp_path):
         """file:/cmd: values in YAML resolve at construction (#1461)."""
         secret = tmp_path / "jwt.txt"

--- a/src/klangk/klangkd-tests/tests/test_settings.py
+++ b/src/klangk/klangkd-tests/tests/test_settings.py
@@ -178,26 +178,33 @@ class TestConfigFile:
             is None
         )
 
-    def test_netfilter_default_domains_invalid_aborts_boot(self):
-        """A bad spec fails fast at construction, not silently at use."""
-        from pydantic import ValidationError
-
-        with pytest.raises(ValidationError):
-            make_settings(
+    def test_netfilter_default_domains_invalid_warns_and_empties(self, caplog):
+        """#1772: a bad spec no longer aborts boot — it warns and falls back
+        to None (no deploy default), so a typo can't take the server down."""
+        with caplog.at_level("WARNING"):
+            s = make_settings(
                 {"KLANGKD_NETFILTER_DEFAULT_DOMAINS": "good.com,bad spec"}
             )
+        assert s.netfilter_default_domains is None
+        assert any("invalid spec" in r.message for r in caplog.records)
 
-    def test_netfilter_default_domains_wrong_type_aborts_boot(self, tmp_path):
-        """A non-list/non-string value (e.g. a bare int from a malformed
-        YAML block) is rejected at construction, not silently coerced."""
-        from pydantic import ValidationError
-
+    def test_netfilter_default_domains_wrong_type_warns_and_empties(
+        self, tmp_path, caplog
+    ):
+        """#1772: a non-list/non-string value (e.g. a bare int from a
+        malformed YAML block) warns and falls back to None rather than
+        aborting construction."""
         # YAML delivering a scalar int directly (a typo'd block like
         # `netfilter_default_domains: 42` instead of a list).
         cfg = tmp_path / "config.yaml"
         cfg.write_text("netfilter_default_domains: 42\n")
-        with pytest.raises(ValidationError):
-            make_settings({}, config_file=str(cfg))
+        with caplog.at_level("WARNING"):
+            s = make_settings({}, config_file=str(cfg))
+        assert s.netfilter_default_domains is None
+        assert any(
+            "must be a list or a comma-separated string" in r.message
+            for r in caplog.records
+        )
 
     def test_file_cmd_resolution_from_yaml(self, tmp_path):
         """file:/cmd: values in YAML resolve at construction (#1461)."""

--- a/src/klangk/klangkd-tests/tests/test_settings.py
+++ b/src/klangk/klangkd-tests/tests/test_settings.py
@@ -206,6 +206,14 @@ class TestConfigFile:
             for r in caplog.records
         )
 
+    def test_netfilter_enabled_defaults_true(self):
+        # #1774: netfilter is armed out of the box.
+        assert make_settings({}).netfilter_enabled is True
+
+    def test_netfilter_enabled_env_override(self):
+        s = make_settings({"KLANGKD_NETFILTER_ENABLED": "false"})
+        assert s.netfilter_enabled is False
+
     def test_file_cmd_resolution_from_yaml(self, tmp_path):
         """file:/cmd: values in YAML resolve at construction (#1461)."""
         secret = tmp_path / "jwt.txt"

--- a/zensical.toml
+++ b/zensical.toml
@@ -25,6 +25,7 @@ nav = [
     { "Service Command" = "features/service-command.md" },
     { "Auto-Start" = "features/auto-start.md" },
     { "Health Check" = "features/health-check.md" },
+    { "Egress Filtering" = "features/egress-filtering.md" },
     { "Sandbox" = "features/sandbox.md" },
     { "Chat" = "features/chat.md" },
     { "File Viewer" = "features/file-viewer.md" },


### PR DESCRIPTION
## Summary

Closes #1365. Adds opt-in per-workspace network egress filtering so a deployment running AI agents or untrusted code can restrict which external hosts a workspace container may reach — without a proxy, TLS interception, or microVM.

The mechanism is an OCI `createContainer` hook: for a workspace that declares an `allowed_domains` allow-list (and a deploy that has enabled netfilter), the backend passes `--annotation klangk.netfilter.rules=<host:port,...>` plus `--hooks-dir`, and a bundled POSIX-sh hook fires before the container process starts. The hook resolves each host to IPs and installs a default-deny iptables ruleset in the container's network namespace (via `nsenter` on the init pid): loopback, established connections, DNS (udp/tcp 53), the backend gateway (`host.containers.internal`), and the listed destinations are accepted; everything else is dropped. `CAP_NET_ADMIN` is dropped by the runtime before the entrypoint runs, so the ruleset is immutable.

## What changed

- **`netfilter.py`** (new) — `NetFilter` state object owning the hooks-dir resolver, annotation builder, and runtime materialization of `klangk-netfilter.{sh,json}` into the configured dir at startup. The hook script is embedded as a single source-of-truth constant (so there's no packaging/data-file dependency or drift between a repo copy and what's installed).
- **`podman.create_container`** — gained `annotations` and `hooks_dir` params.
- **`container.start_container`** — threads `allowed_domains` into `create_kwargs` (annotation + `--hooks-dir` added **only** when set, so unrestricted workspaces keep podman's default hooks-dir behavior).
- **`wshandler/connection.py`** — passes `allowed_domains` on the terminal-open path so a created-but-not-autostarted workspace is filtered on first connect, not only when eagerly started.
- **`model/schema` + `model/workspaces`** — `allowed_domains TEXT` column + migration; persisted/retrieved across every CRUD/list/shared/admin path.
- **`api/workspaces`** — `allowed_domains` on create/update/duplicate/import with server-side validation (`_validate_allowed_domains`).
- **`settings.py`** — `KLANGKD_NETFILTER_HOOKS_DIR` (opt-in, default unset = unrestricted).
- **`main.py`** — wires `app.state.netfilter`, installs hooks at startup, reconfigures on SIGHUP.
- **Frontend** — "Allowed Domains" list editors in both the workspace **Settings** panel and the **Create** dialog.
- **Docs** — `docs/features/egress-filtering.md`, changelog entry, `klangkd.yaml.example`, nav entry.

## Backward compatibility / fail-open

- A workspace **without** `allowed_domains` keeps unrestricted networking exactly as before — no annotation, no `--hooks-dir`, no behavior change.
- If a workspace **declares** a list but the deploy hasn't set `KLANGKD_NETFILTER_HOOKS_DIR`, the workspace starts **unrestricted** and the server logs a loud operator warning. The value is still persisted so it takes effect the moment netfilter is enabled. (Fail-open is only at the "deployer didn't enable the feature" layer — the hook itself fails **closed**, default `OUTPUT DROP`, once enabled.)

## Design notes

- **Runtime-generated hooks vs. repo `hooks/` files.** The issue's rough plan listed `hooks/*.json` + `hooks/*.sh` as repo files; this generates them at startup from constants in `netfilter.py` instead — single source of truth, no packaging drift, fully unit-testable. The exact script content is visible in `HOOK_SCRIPT`.
- **Hook is POSIX sh** (no bashisms), parses OCI state via `sed` (no `jq`), resolves hosts via `getent`. Failures are logged to stderr (captured by the runtime) but don't abort the hook — the default-DROP policy is the fail-closed posture.

## Caveats (documented in the feature doc)

- Hostnames are resolved at create time (iptables matches IPs), so CDN IP rotation can break access until restart — the documented mitigation is to allow a port without pinning a host.
- Port-level granularity only (`host`/`host:port`); CIDR ranges may follow.
- macOS / `podman machine`: the `--hooks-dir` path must resolve inside the CoreOS VM.

## Test coverage

Python 3362 passed @ 100%; frontend 908 passed. New tests cover the netfilter module (validators, renderers, hook install, create-kwargs fail-open/enabled), podman `create_container` flags, the container egress wiring (no-domains / disabled-fail-open / enabled), model persistence round-trip + update/clear, and API create/update validation (including the disabled-deploy warning path).
