### PR TITLE
fix(e2e): read KLANGKWS_AGENT_HOME in agent-home e2e test

### DIFF
--- a/src/klangk/klangkd-tests/e2e-tests/test_agent_home_e2e.py
+++ b/src/klangk/klangkd-tests/e2e-tests/test_agent_home_e2e.py
@@ -3,7 +3,7 @@
 #1157 shipped two container-bringup behaviors that the unit suite can
 only *mock*:
 
-1. ``KLANGKD_AGENT_HOME=/home/<agent_handle>`` is baked into the
+1. ``KLANGKWS_AGENT_HOME=/home/<agent_handle>`` is baked into the
    container env at creation (``_build_env``), so **every** exec
    process inside the container inherits it.  The unit test only proves
    ``_build_env`` emits the string; here we prove podman actually
@@ -230,7 +230,7 @@ async def exec_command(ws, command):
 class TestAgentHomeE2E:
     @pytest.mark.asyncio
     async def test_agent_home_env_present_in_exec(self, server, auth):
-        """KLANGKD_AGENT_HOME is baked at container start and inherited by
+        """KLANGKWS_AGENT_HOME is baked at container start and inherited by
         every exec process (#1157).  The WS exec path spawns a process
         inside the container via the server's exec machinery (the same
         path terminals use) -- it does *not* pass the var per-call, so
@@ -243,11 +243,11 @@ class TestAgentHomeE2E:
             try:
                 output = await exec_command(
                     ws,
-                    ["bash", "-c", 'echo "$KLANGKD_AGENT_HOME"'],
+                    ["bash", "-c", 'echo "$KLANGKWS_AGENT_HOME"'],
                 )
                 # Exact value: the default agent handle's home.
                 assert output.strip() == AGENT_HOME, (
-                    f"expected KLANGKD_AGENT_HOME={AGENT_HOME!r}, "
+                    f"expected KLANGKWS_AGENT_HOME={AGENT_HOME!r}, "
                     f"got {output!r}"
                 )
             finally:


### PR DESCRIPTION
## Summary

Fixes the `E2E: Backend Tests` failure introduced by #1740 (the `KLANGK_` prefix split).

The rename correctly changed the **injection** point in `container.py`:

```python
env_vars.append(f"KLANGKWS_AGENT_HOME={agent_home}")
```

(`KLANGKWS_*` is right — per the rename's own rule, a var injected into a container is `KLANGKWS_*` at the injection point; `src/containers/workspace/agent-context.md` reads `KLANGKWS_AGENT_HOME`.)

But it **mis-renamed the e2e test's in-container read** to `KLANGKD_AGENT_HOME` (the server-settings prefix). The container never receives that var, so the assertion always saw an empty string:

```
FAILED test_agent_home_e2e.py::TestAgentHomeE2E::test_agent_home_env_present_in_exec
AssertionError: expected KLANGKD_AGENT_HOME='/home/clanker', got '\n'
```

## Fix

Point the test's `echo`, docstrings, and assert message at `KLANGKWS_AGENT_HOME` — the var `_build_env` actually emits. The server-fixture env vars (`KLANGKD_JWT_SECRET`, etc.) are unchanged (correct: those are server settings, not injected).

## Why a separate PR

This is blocking #1741 and #1653's backend-e2e jobs (both fail identically) but is unrelated to either PR's changes — it's fallout from #1740 that landed on `main`. Splitting it out lets the fix reach `main` independently and unblock the dependent PRs without them carrying an unrelated change.

Test-only; no changelog entry (no user-visible change).
