### PR TITLE
TUI foundation: bare `klangk` launches an interactive textual app (#1746)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -27,6 +27,14 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **Bare `klangk` (no subcommand) launches an interactive textual TUI on a
+  real terminal (#1746).** The TUI is the foundation of the terminal client:
+  in-TUI login (local/password, with no-auth auto-login and OIDC hand-off to
+  `klangk login`), live server switching including adding a new alias, and a
+  live workspace/container status feed over the existing WebSocket. Subcommands
+  are unchanged; in non-interactive contexts (pipes, CI) bare `klangk` still
+  prints help. `textual` is now a runtime dependency.
+
 - **The `features_config:` block now accepts the stripped, lowercased key form
   (`soliplex_url`) in addition to the full declared name
   (`KLANGKWS_FEATURE_SOLIPLEX_URL`) (#1737).** The short form matches the key the

--- a/src/klangk/klangk/cli/config.py
+++ b/src/klangk/klangk/cli/config.py
@@ -55,6 +55,47 @@ _STATE_PATH = _xdg_state_home() / _CLI_SUBDIR / "klangk-state.yaml"
 _DEFAULT_WS_MAX_SIZE = 2**24  # 16 MB
 
 
+# Server-side XDG subdir + socket filename, mirrored from
+# ``settings.py`` (``_XDG_SUBDIR = "klangkd"``; socket =
+# ``<state_dir>/klangk.sock``) so the CLI can locate a co-located
+# ``klangkd``'s default UDS without importing from the server package
+# (``klangk.cli`` isolation rule). Named constants make the mirroring
+# grep-able if the server renames either.
+_SERVER_XDG_SUBDIR = "klangkd"
+_SOCKET_NAME = "klangk.sock"
+
+
+def default_server_uds_path() -> str:
+    """Return the UDS path a co-located ``klangkd`` binds by default.
+
+    Mirrors the server's derivation so a single-host ``klangkd`` +
+    ``klangk`` works with no ``klangk login`` step (#1676). Resolution
+    order, matching the server:
+
+    1. ``KLANGK_SOCKET`` — if an explicit *plain absolute* path (not a
+       ``file:``/``cmd:`` indirection, which the server resolves by
+       running a cmd / reading a file and the CLI can't reproduce), the
+       server binds exactly there, so return it directly.
+    2. ``KLANGK_STATE_DIR/klangk.sock`` when ``KLANGK_STATE_DIR`` is set.
+    3. ``$XDG_STATE_HOME/klangkd/klangk.sock`` (→ ~/.local/state/klangkd/…).
+
+    Replicated in ``klangk.cli`` — not imported from the server — because
+    the CLI runs in a different environment (``klangk.cli`` isolation
+    rule). The ``file:``/``cmd:`` ``KLANGK_SOCKET`` indirection case is
+    not reproduced; operators who relocate the socket that way still need
+    a one-time ``klangk login``.
+    """
+    explicit = os.environ.get("KLANGK_SOCKET")
+    if explicit and explicit.startswith("/"):
+        # An absolute value is a plain path the server binds verbatim;
+        # file:/cmd: indirections don't start with "/" and fall through.
+        return explicit
+    state_dir = os.environ.get("KLANGK_STATE_DIR")
+    if not state_dir:
+        state_dir = os.path.join(str(_xdg_state_home()), _SERVER_XDG_SUBDIR)
+    return os.path.join(state_dir, _SOCKET_NAME)
+
+
 @dataclass
 class ServerEntry:
     """A named server in klangk.yaml."""

--- a/src/klangk/klangk/cli/config.py
+++ b/src/klangk/klangk/cli/config.py
@@ -203,6 +203,24 @@ def add_server_to_config(
     _CONFIG_PATH.write_text(yaml.dump(data, default_flow_style=False))
 
 
+def remove_server_from_config(alias: str) -> bool:
+    """Remove a named server entry from klangk.yaml.
+
+    Returns True if the alias was present and removed, False otherwise.
+    The counterpart to ``add_server_to_config`` (TUI delete-server flow).
+    """
+    if not _CONFIG_PATH.exists():
+        return False
+    data = yaml.safe_load(_CONFIG_PATH.read_text()) or {}
+    servers = data.get("servers") or {}
+    if alias not in servers:
+        return False
+    del servers[alias]
+    data["servers"] = servers
+    _CONFIG_PATH.write_text(yaml.dump(data, default_flow_style=False))
+    return True
+
+
 @dataclass
 class UserEntry:
     """Per-user credentials within a server in klangk-state.yaml."""

--- a/src/klangk/klangk/cli/config.py
+++ b/src/klangk/klangk/cli/config.py
@@ -137,6 +137,31 @@ def seed_config(server_url: str, user: str | None = None) -> None:
     _CONFIG_PATH.write_text(yaml.dump(data, default_flow_style=False))
 
 
+def add_server_to_config(
+    alias: str, server_url: str, user: str | None = None
+) -> None:
+    """Add (or replace) a named server entry in klangk.yaml.
+
+    Unlike ``seed_config`` (one-shot, only when the file is absent), this
+    merges into an existing user config so the TUI can add a server alias
+    interactively without clobbering the rest of the file. klangk.yaml
+    remains user-owned; this is the one managed write, used only by the
+    TUI's add-server flow.
+    """
+    _CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    if _CONFIG_PATH.exists():
+        data = yaml.safe_load(_CONFIG_PATH.read_text()) or {}
+    else:
+        data = {}
+    servers = data.get("servers") or {}
+    entry: dict = {"url": server_url}
+    if user:
+        entry["user"] = user
+    servers[alias] = entry
+    data["servers"] = servers
+    _CONFIG_PATH.write_text(yaml.dump(data, default_flow_style=False))
+
+
 @dataclass
 class UserEntry:
     """Per-user credentials within a server in klangk-state.yaml."""

--- a/src/klangk/klangk/cli/main.py
+++ b/src/klangk/klangk/cli/main.py
@@ -52,7 +52,12 @@ from .client import (
     reset_terminal,
     _server_mode_is_none,
 )
-from .config import CLIConfig, CLIState, seed_config, _xdg_state_home
+from .config import (
+    CLIConfig,
+    CLIState,
+    default_server_uds_path,
+    seed_config,
+)
 from .mount import validate_mount_spec
 from .transport import ws_connect
 from .sandbox import (
@@ -92,15 +97,6 @@ def _state() -> CLIState:
 
 
 _server_override: str | None = None
-
-# Server-side XDG subdir + socket filename, mirrored from
-# ``settings.py`` (``_XDG_SUBDIR = "klangkd"``; socket =
-# ``<state_dir>/klangk.sock``) so the CLI can locate a co-located
-# ``klangkd``'s default UDS without importing from the server package
-# (``klangk.cli`` isolation rule). Named constants make the mirroring
-# grep-able if the server renames either.
-_SERVER_XDG_SUBDIR = "klangkd"
-_SOCKET_NAME = "klangk.sock"
 
 
 @app.callback()
@@ -143,39 +139,6 @@ def _maybe_launch_tui(ctx: typer.Context) -> None:
         raise typer.Exit(code=1)
 
 
-def _default_server_uds_path() -> str:
-    """Return the UDS path a co-located ``klangkd`` binds by default.
-
-    Mirrors the server's derivation so a single-host ``klangkd`` +
-    ``klangk`` works with no ``klangk login`` step (#1676). Resolution
-    order, matching the server:
-
-    1. ``KLANGK_SOCKET`` — if an explicit *plain absolute* path (not a
-       ``file:``/``cmd:`` indirection, which the server resolves by
-       running a cmd / reading a file and the CLI can't reproduce), the
-       server binds exactly there, so return it directly. This covers the
-       natural way to relocate a socket (``KLANGK_SOCKET=/run/klangk.sock``).
-    2. ``KLANGK_STATE_DIR/klangk.sock`` when ``KLANGK_STATE_DIR`` is set.
-    3. ``$XDG_STATE_HOME/klangkd/klangk.sock`` (→ ``~/.local/state/klangkd/…``).
-
-    Replicated in ``klangk.cli`` — not imported — because the CLI runs in
-    a different environment than the server (``klangk.cli`` isolation
-    rule) and reuses ``config._xdg_state_home`` for the XDG fallback so
-    the two derivations can't drift. The ``file:``/``cmd:``
-    ``KLANGK_SOCKET`` indirection case is not reproduced; operators who
-    relocate the socket that way still need a one-time ``klangk login``.
-    """
-    explicit = os.environ.get("KLANGK_SOCKET")
-    if explicit and explicit.startswith("/"):
-        # An absolute value is a plain path the server binds verbatim;
-        # file:/cmd: indirections don't start with "/" and fall through.
-        return explicit
-    state_dir = os.environ.get("KLANGK_STATE_DIR")
-    if not state_dir:
-        state_dir = os.path.join(str(_xdg_state_home()), _SERVER_XDG_SUBDIR)
-    return os.path.join(state_dir, _SOCKET_NAME)
-
-
 def server_url() -> str:
     if _server_override is not None:
         return _server_override
@@ -190,7 +153,7 @@ def server_url() -> str:
     # passes, and the unreachable connect is then surfaced by
     # ``require_auth`` as a clear "Cannot connect to klangkd" message
     # rather than a misleading "Not logged in".
-    default_uds = _default_server_uds_path()
+    default_uds = default_server_uds_path()
     if Path(default_uds).exists():
         return default_uds
     _err.print(

--- a/src/klangk/klangk/cli/main.py
+++ b/src/klangk/klangk/cli/main.py
@@ -67,6 +67,10 @@ app = typer.Typer(
     name="klangk",
     help="Klangk Client",
     rich_markup_mode="rich",
+    # Run the callback even with no subcommand so bare `klangk` can launch
+    # the interactive TUI (see _maybe_launch_tui). `--help`/`--version` are
+    # still handled by click before the callback runs, so they keep precedence.
+    invoke_without_command=True,
 )
 
 _cfg_cache: CLIConfig | None = None
@@ -101,6 +105,7 @@ _SOCKET_NAME = "klangk.sock"
 
 @app.callback()
 def app_callback(
+    ctx: typer.Context,
     server: str | None = typer.Option(
         None, "--server", help="Server alias or URL"
     ),
@@ -108,6 +113,34 @@ def app_callback(
     global _server_override
     if server is not None:
         _server_override = _cfg().resolve_server(server)
+    if ctx.invoked_subcommand is None:
+        _maybe_launch_tui(ctx)
+
+
+def _is_interactive() -> bool:
+    """True when stdin and stdout are both real terminals."""
+    return sys.stdin.isatty() and sys.stdout.isatty()
+
+
+def _maybe_launch_tui(ctx: typer.Context) -> None:
+    """Launch the interactive TUI for a bare ``klangk`` invocation.
+
+    Only on a real terminal: in non-TTY contexts (pipes, CI, typer's
+    ``CliRunner``) the historic "print help" behavior is preserved so the
+    command stays scriptable and the CLI test suite isn't surprised by a
+    TUI it can't drive. The TUI is imported lazily so the textual dep
+    never loads on plain subcommand paths (``klangk ls`` etc.).
+    """
+    if not _is_interactive():
+        typer.echo(ctx.get_help())
+        raise typer.Exit(code=0)
+    from .tui import run_tui  # noqa: allow-deferred-import
+
+    try:
+        run_tui(server_url=_server_override)
+    except Exception as exc:  # surface TUI crashes, don't swallow them
+        _err.print(f"[red]TUI error:[/red] {exc}")
+        raise typer.Exit(code=1)
 
 
 def _default_server_uds_path() -> str:

--- a/src/klangk/klangk/cli/transport.py
+++ b/src/klangk/klangk/cli/transport.py
@@ -66,6 +66,21 @@ def resolve_transport(server_spec: str) -> ServerTransport:
     )
 
 
+def is_valid_server_spec(server_spec: str) -> bool:
+    """True if *server_spec* is a usable server location.
+
+    Mirrors ``resolve_transport``: an ``http(s)://`` URL (TCP) or an
+    absolute path (UDS). Anything else — a bare name or relative path — is
+    not usable and would raise from ``resolve_transport`` at request time,
+    so callers should reject it up front (e.g. the TUI server picker).
+    """
+    try:
+        resolve_transport(server_spec)
+    except ValueError:
+        return False
+    return True
+
+
 # ---------------------------------------------------------------------------
 # HTTP helper
 # ---------------------------------------------------------------------------

--- a/src/klangk/klangk/cli/tui/__init__.py
+++ b/src/klangk/klangk/cli/tui/__init__.py
@@ -1,0 +1,18 @@
+"""Interactive TUI for the klangk client (textual).
+
+Launched by bare ``klangk`` on an interactive terminal (see
+``klangk.cli.main._maybe_launch_tui``). Stays within ``klangk.cli``
+(isolation rule): only stdlib, third-party deps, and sibling ``cli``
+modules.
+"""
+
+from .app import KlangkApp, run_tui
+from .state import LoginError, ServerInfo, TuiState
+
+__all__ = [
+    "KlangkApp",
+    "LoginError",
+    "ServerInfo",
+    "TuiState",
+    "run_tui",
+]

--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -57,9 +57,12 @@ class KlangkApp(App):
         border-left: none;
         border-right: none;
     }
-    /* Give the server picker a visible box so its width matches the fields. */
+    /* Give the server picker a visible top/bottom rule (no side borders) so
+    its width matches the fields without inset side bars. */
     OptionList {
         border: tall $border-blurred;
+        border-left: none;
+        border-right: none;
     }
     """
 

--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -26,18 +26,22 @@ class KlangkApp(App):
         align: center top;
     }
     #login_box {
-        width: 64;
+        width: 96;
         max-width: 90%;
         padding: 1 2;
     }
     #switch_box, #add_box {
-        width: 70;
+        width: 104;
         max-width: 90%;
         padding: 1 2;
     }
     #main {
         padding: 1 2;
         width: 1fr;
+    }
+    /* Right-align button rows with the input fields above them. */
+    .actions {
+        align-horizontal: right;
     }
     """
 

--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -28,20 +28,26 @@ class KlangkApp(App):
     #login_box {
         width: 96;
         max-width: 90%;
-        padding: 1 2;
+        padding: 2 2;
     }
     #switch_box, #add_box {
         width: 104;
         max-width: 90%;
-        padding: 1 2;
+        padding: 2 2;
     }
     #main {
         padding: 1 2;
         width: 1fr;
     }
-    /* Right-align button rows with the input fields above them. */
+    /* A little air under the server status line, before the picker. */
+    #server_line {
+        margin-bottom: 1;
+    }
+    /* Right-align button rows; don't let them expand vertically (avoids a
+    large gap below the button before the next field). */
     .actions {
         align-horizontal: right;
+        height: auto;
     }
     """
 

--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -49,13 +49,17 @@ class KlangkApp(App):
         align-horizontal: right;
         height: auto;
     }
-    /* Underline-style entry fields: keep only the bottom border so each
-    field is one row shorter (text sitting on an underline). */
+    /* Underline-style entry fields: invisible top border + no side borders,
+    keeping the default height so the text stays vertically centered on the
+    middle row, with only the bottom border showing as an underline. */
     Input, Input:focus {
-        height: 2;
-        border-top: none;
+        border-top: blank;
         border-left: none;
         border-right: none;
+    }
+    /* Give the server picker a visible box so its width matches the fields. */
+    OptionList {
+        border: tall $border-blurred;
     }
     """
 

--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -54,6 +54,7 @@ class KlangkApp(App):
         self.live_extra = ""
 
     def on_mount(self) -> None:
+        self.title = "Klangk"
         if self.tui_state.is_authenticated():
             self.push_screen(MainScreen())
         else:

--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -1,0 +1,106 @@
+"""The klangk textual TUI app and entry point."""
+
+from __future__ import annotations
+
+from textual.app import App
+
+from .screens import (
+    AddServerScreen,
+    LoginScreen,
+    MainScreen,
+    ServerSwitchScreen,
+)
+from .state import LoginError, TuiState
+
+
+class KlangkApp(App):
+    """Interactive TUI over the existing klangk client."""
+
+    CSS = """
+    .title {
+        text-style: bold;
+        color: $primary;
+        padding: 1 0;
+    }
+    Screen {
+        align: center top;
+    }
+    #login_box {
+        width: 64;
+        max-width: 90%;
+        padding: 1 2;
+    }
+    #switch_box, #add_box {
+        width: 70;
+        max-width: 90%;
+        padding: 1 2;
+    }
+    #main {
+        padding: 1 2;
+        width: 1fr;
+    }
+    """
+
+    BINDINGS = [("q", "quit", "Quit")]
+
+    def __init__(self, state: TuiState) -> None:
+        super().__init__()
+        self.tui_state = state
+        # Latest live-status annotation shown in the status bar.
+        self.live_extra = ""
+
+    def on_mount(self) -> None:
+        if self.tui_state.is_authenticated():
+            self.push_screen(MainScreen())
+            return
+        # No-auth servers log in for free (#1374); do it before pushing any
+        # screen so we land directly on the main shell instead of flashing a
+        # login screen whose on_mount would have to push mid-mount.
+        if self.tui_state.auth_mode() == "none":
+            try:
+                self.tui_state.login_none()
+            except LoginError:
+                pass
+            if self.tui_state.is_authenticated():
+                self.push_screen(MainScreen())
+                return
+        self.push_screen(LoginScreen())
+
+    # --- navigation hooks used by screens ---
+
+    def login_succeeded(self) -> None:
+        self.pop_screen()  # LoginScreen
+        self.push_screen(MainScreen())
+
+    def do_logout(self) -> None:
+        self.tui_state.logout()
+        self.pop_screen()  # MainScreen
+        self.live_extra = ""
+        self.push_screen(LoginScreen())
+
+    def server_changed(self) -> None:
+        """Pop back to the MainScreen and refresh it after a server change."""
+        while self.screen_stack and not isinstance(
+            self.screen_stack[-1], MainScreen
+        ):
+            self.pop_screen()
+        top = self.screen_stack[-1] if self.screen_stack else None
+        if isinstance(top, MainScreen):
+            top.refresh_view()
+
+
+def run_tui(server_url: str | None = None) -> None:
+    """Launch the interactive TUI (called only in an interactive terminal)."""
+    KlangkApp(TuiState(server_url)).run()
+
+
+# Re-export for convenience / tests.
+__all__ = [
+    "AddServerScreen",
+    "KlangkApp",
+    "LoginScreen",
+    "MainScreen",
+    "ServerSwitchScreen",
+    "TuiState",
+    "run_tui",
+]

--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -28,7 +28,7 @@ class KlangkApp(App):
     #login_box {
         width: 96;
         max-width: 90%;
-        padding: 2 2;
+        padding: 0 2;
     }
     #switch_box, #add_box {
         width: 104;

--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -64,6 +64,12 @@ class KlangkApp(App):
         border-left: none;
         border-right: none;
     }
+    /* Compact buttons: drop the min-width so they hug their labels instead
+    of padding out to a fixed width. */
+    Button {
+        min-width: 0;
+        padding: 0 1;
+    }
     """
 
     BINDINGS = [("q", "quit", "Quit")]

--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -10,7 +10,7 @@ from .screens import (
     MainScreen,
     ServerSwitchScreen,
 )
-from .state import LoginError, TuiState
+from .state import TuiState
 
 
 class KlangkApp(App):
@@ -52,19 +52,8 @@ class KlangkApp(App):
     def on_mount(self) -> None:
         if self.tui_state.is_authenticated():
             self.push_screen(MainScreen())
-            return
-        # No-auth servers log in for free (#1374); do it before pushing any
-        # screen so we land directly on the main shell instead of flashing a
-        # login screen whose on_mount would have to push mid-mount.
-        if self.tui_state.auth_mode() == "none":
-            try:
-                self.tui_state.login_none()
-            except LoginError:
-                pass
-            if self.tui_state.is_authenticated():
-                self.push_screen(MainScreen())
-                return
-        self.push_screen(LoginScreen())
+        else:
+            self.push_screen(LoginScreen())
 
     # --- navigation hooks used by screens ---
 

--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -49,6 +49,14 @@ class KlangkApp(App):
         align-horizontal: right;
         height: auto;
     }
+    /* Underline-style entry fields: keep only the bottom border so each
+    field is one row shorter (text sitting on an underline). */
+    Input, Input:focus {
+        height: 2;
+        border-top: none;
+        border-left: none;
+        border-right: none;
+    }
     """
 
     BINDINGS = [("q", "quit", "Quit")]

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -76,11 +76,15 @@ class LoginScreen(Screen):
         ol = self.query_one("#server_options", OptionList)
         ol.clear_options()
         current = self.app.tui_state.current_url()
-        for s in self.app.tui_state.known_servers():
+        known = self.app.tui_state.known_servers()
+        known_urls = {s.url for s in known}
+        for s in known:
             mark = "*" if s.url == current else " "
             ol.add_option(Option(f"{mark} {s.alias}  ({s.url})", id=s.url))
         uds = self.app.tui_state.default_uds()
-        if uds and uds != current:
+        # Only offer the auto-detected default UDS if no alias already covers
+        # it (otherwise it would duplicate the persisted alias row).
+        if uds and uds != current and uds not in known_urls:
             ol.add_option(Option(f"  Local klangkd (UDS)  ({uds})", id=uds))
 
     @staticmethod
@@ -101,12 +105,9 @@ class LoginScreen(Screen):
         if raw in cfg.servers:
             # Known alias — switch to its URL.
             self.app.tui_state.switch_server(cfg.servers[raw].url)
-        elif raw.startswith("/"):
-            # A socket path (e.g. the auto-detected UDS): use it without
-            # persisting a throwaway alias.
-            self.app.tui_state.switch_server(raw)
         else:
-            # A new URL — save it as an alias so it appears next time.
+            # A new server (URL or UDS path) — save it as an alias so it can
+            # be re-selected later.
             self.app.tui_state.add_server(self._derive_alias(raw), raw)
         self.query_one("#server_input", Input).value = ""
         self._set_message("")

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -1,0 +1,286 @@
+"""Screens for the klangk TUI: login, main shell, server switch/add.
+
+Navigation between screens is driven by methods on ``KlangkApp``
+(``login_succeeded`` / ``do_logout`` / ``server_changed``); screens stay
+free of cross-screen coupling and reach state through ``self.app.tui_state``.
+"""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.screen import Screen
+from textual.widgets import (
+    Button,
+    Footer,
+    Header,
+    Input,
+    OptionList,
+    Static,
+)
+from textual.widgets.option_list import Option
+
+from .state import LoginError
+from .widgets import Sidebar, StatusBar
+from .ws import listen_for_status
+
+
+class LoginScreen(Screen):
+    """Credential screen that adapts to the server's auth mode.
+
+    ``none`` → auto no-auth login; ``oidc`` → SSO hand-off (browser);
+    ``password``/``both`` → email/handle + password form; ``unreachable``
+    → diagnostic message. The password form and SSO button are
+    ``disabled`` (not hidden) for non-applicable modes so the screen
+    stays simple to render and test.
+    """
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=False)
+        yield Vertical(
+            Static("klangk", classes="title"),
+            Static("", id="notice"),
+            Input(placeholder="Email or handle", id="identifier"),
+            Input(placeholder="Password", id="password", password=True),
+            Button("Log in", id="login", variant="primary"),
+            Button("Log in via browser (SSO)", id="oidc"),
+            Static("", id="message"),
+            id="login_box",
+        )
+        yield Footer()
+
+    def on_mount(self) -> None:
+        state = self.app.tui_state
+        mode = state.auth_mode()
+        notice = self.query_one("#notice", Static)
+        if mode == "none":
+            # Reached only if the app-level no-auth auto-login failed.
+            notice.update("No-auth login failed — check the server.")
+            self._disable_form()
+            return
+        if mode == "unreachable":
+            notice.update(
+                "Cannot reach the server. Check the URL or that klangkd"
+                " is running."
+            )
+            self._disable_form()
+            return
+        if mode == "oidc":
+            notice.update(
+                "This server uses single sign-on. Click 'Log in via browser'."
+            )
+            self._disable_form()
+            return
+        # password / both
+        notice.update("Enter your credentials.")
+        self.query_one("#oidc", Button).disabled = True
+
+    def _disable_form(self) -> None:
+        self.query_one("#identifier", Input).disabled = True
+        self.query_one("#password", Input).disabled = True
+        self.query_one("#login", Button).disabled = True
+
+    def _set_message(self, text: str, *, error: bool = False) -> None:
+        rendered = f"[red]{text}[/red]" if error else text
+        self.query_one("#message", Static).update(rendered)
+
+    # --- login arms ---
+
+    def _attempt_password(self) -> None:
+        identifier = self.query_one("#identifier", Input).value.strip()
+        password = self.query_one("#password", Input).value
+        if not identifier or not password:
+            self._set_message(
+                "Email/handle and password are required.", error=True
+            )
+            return
+        try:
+            self.app.tui_state.login_password(identifier, password)
+        except LoginError as exc:
+            self._set_message(f"Login failed: {exc}", error=True)
+            return
+        self.app.login_succeeded()
+
+    def _attempt_oidc(self) -> None:
+        providers = self.app.tui_state.oidc_providers()
+        if not providers:
+            self._set_message("No SSO provider configured.", error=True)
+            return
+        provider_id = providers[0]["id"]
+        try:
+            self.app.tui_state.oidc_login(provider_id)
+        except LoginError as exc:
+            self._set_message(f"SSO failed: {exc}", error=True)
+            return
+        if self.app.tui_state.is_authenticated():
+            self.app.login_succeeded()
+        else:
+            self._set_message("SSO did not complete.")
+
+    # --- event handlers ---
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "login":
+            self._attempt_password()
+        elif event.button.id == "oidc":
+            self._attempt_oidc()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        if event.input.id in ("identifier", "password"):
+            self._attempt_password()
+
+
+class MainScreen(Screen):
+    """The app shell: sidebar + content + status bar, with a live WS feed."""
+
+    BINDINGS = [
+        ("s", "switch_server", "Switch server"),
+        ("a", "add_server", "Add server"),
+        ("l", "logout", "Logout"),
+    ]
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=False)
+        yield Horizontal(
+            Sidebar(id="sidebar"),
+            Vertical(
+                Static("klangk", classes="title"),
+                Static("", id="content"),
+                id="main",
+            ),
+        )
+        yield StatusBar(id="status")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self.refresh_view()
+        if self.app.tui_state.is_authenticated():
+            self.app.run_worker(self._status_loop, name="status-ws")
+
+    def action_switch_server(self) -> None:
+        self.app.push_screen(ServerSwitchScreen())
+
+    def action_add_server(self) -> None:
+        self.app.push_screen(AddServerScreen())
+
+    def action_logout(self) -> None:
+        self.app.do_logout()
+
+    def refresh_view(self) -> None:
+        state = self.app.tui_state
+        self.query_one("#sidebar", Sidebar).set_items(
+            [
+                "klangk",
+                "",
+                "[s] switch server",
+                "[a] add server",
+                "[l] logout",
+                "[q] quit",
+            ]
+        )
+        server = state.current_url()
+        user = state.email() or "(unknown)"
+        self.query_one("#status", StatusBar).set_state(
+            server=server, user=user, extra=self.app.live_extra
+        )
+        body = (
+            f"Server: {server or '(none)'}\n"
+            f"User: {user}\n\n"
+            "Live workspace/container status is streaming. "
+            "Workspace screens arrive in later issues (#1747+)."
+        )
+        self.query_one("#content", Static).update(body)
+
+    async def _status_loop(self) -> None:
+        state = self.app.tui_state
+        url = state.current_url()
+        token = state.token()
+        if not url or not token:
+            return
+        try:
+            await listen_for_status(url, token, on_event=self._on_status_event)
+        except Exception:
+            # Best-effort: the TUI stays usable if the status stream dies.
+            self.app.live_extra = "status: disconnected"
+            self.refresh_view()
+
+    def _on_status_event(self, event: dict) -> None:
+        etype = event.get("type", "event")
+        self.app.live_extra = f"live: {etype}"
+        self.refresh_view()
+
+
+class ServerSwitchScreen(Screen):
+    """Pick a known server alias to switch to."""
+
+    BINDINGS = [("escape", "app.pop_screen", "Back")]
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=False)
+        yield Vertical(
+            Static("Switch server", classes="title"),
+            Static("", id="switch_msg"),
+            OptionList(id="server_options"),
+            id="switch_box",
+        )
+        yield Footer()
+
+    def on_mount(self) -> None:
+        servers = self.app.tui_state.known_servers()
+        if not servers:
+            self.query_one("#switch_msg", Static).update(
+                "No servers configured. Use 'a' to add one."
+            )
+            return
+        current = self.app.tui_state.current_url()
+        ol = self.query_one("#server_options", OptionList)
+        for s in servers:
+            mark = "*" if s.url == current else " "
+            ol.add_option(Option(f"{mark} {s.alias}  ({s.url})", id=s.url))
+
+    def on_option_list_option_selected(
+        self, event: OptionList.OptionSelected
+    ) -> None:
+        url = event.option.id
+        if url:
+            self.app.tui_state.switch_server(url)
+        self.app.server_changed()
+
+
+class AddServerScreen(Screen):
+    """Add a new server alias and switch to it."""
+
+    BINDINGS = [("escape", "app.pop_screen", "Back")]
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=False)
+        yield Vertical(
+            Static("Add server", classes="title"),
+            Input(placeholder="Alias (e.g. prod)", id="alias"),
+            Input(
+                placeholder="URL (https://host or /path/to.sock)",
+                id="url",
+            ),
+            Button("Add and switch", id="add", variant="primary"),
+            Static("", id="add_msg"),
+            id="add_box",
+        )
+        yield Footer()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "add":
+            self._add()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        if event.input.id in ("alias", "url"):
+            self._add()
+
+    def _add(self) -> None:
+        alias = self.query_one("#alias", Input).value.strip()
+        url = self.query_one("#url", Input).value.strip()
+        msg = self.query_one("#add_msg", Static)
+        if not alias or not url:
+            msg.update("[red]Alias and URL are required.[/red]")
+            return
+        self.app.tui_state.add_server(alias, url)
+        self.app.server_changed()

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -38,6 +38,8 @@ class LoginScreen(Screen):
     password form; ``unreachable`` → diagnostic.
     """
 
+    BINDINGS = [("d", "delete_server", "Delete server")]
+
     def compose(self) -> ComposeResult:
         yield Header(show_clock=False)
         yield Vertical(
@@ -48,12 +50,18 @@ class LoginScreen(Screen):
                 placeholder=("Server URL or alias (e.g. https://host, prod)"),
                 id="server_input",
             ),
-            Button("Use server", id="use_server"),
+            Horizontal(
+                Button("Use server", id="use_server"),
+                classes="actions",
+            ),
             Static("", id="notice"),
             Input(placeholder="Email or handle", id="identifier"),
             Input(placeholder="Password", id="password", password=True),
-            Button("Log in", id="login", variant="primary"),
-            Button("Log in via browser (SSO)", id="oidc"),
+            Horizontal(
+                Button("Log in", id="login", variant="primary"),
+                Button("Log in via browser (SSO)", id="oidc"),
+                classes="actions",
+            ),
             Static("", id="message"),
             id="login_box",
         )
@@ -64,11 +72,14 @@ class LoginScreen(Screen):
         if self.app.tui_state.current_url() is not None:
             self._setup_auth()
         else:
-            self.query_one("#server_line", Static).update(
-                "No server selected. Pick one above or enter a URL,"
-                " then press 'Use server'."
-            )
-            self._disable_credentials()
+            self._show_no_server()
+
+    def _show_no_server(self) -> None:
+        self.query_one("#server_line", Static).update(
+            "No server selected. Pick one above or enter a URL,"
+            " then press 'Use server'."
+        )
+        self._disable_credentials()
 
     # --- server picker ---
 
@@ -113,6 +124,23 @@ class LoginScreen(Screen):
         self._set_message("")
         self._populate_servers()
         self._setup_auth()
+
+    def action_delete_server(self) -> None:
+        ol = self.query_one("#server_options", OptionList)
+        idx = ol.highlighted
+        if idx is None:
+            self._set_message("Select a server to delete.", error=True)
+            return
+        url = ol.get_option_at_index(idx).id
+        if self.app.tui_state.delete_server(url):
+            self._set_message("Server deleted.")
+        else:
+            self._set_message("Not a saved alias.", error=True)
+        self._populate_servers()
+        if self.app.tui_state.current_url() is None:
+            self._show_no_server()
+        else:
+            self._setup_auth()
 
     # --- auth-mode setup ---
 
@@ -316,7 +344,10 @@ class MainScreen(Screen):
 class ServerSwitchScreen(Screen):
     """Pick a known server alias to switch to."""
 
-    BINDINGS = [("escape", "app.pop_screen", "Back")]
+    BINDINGS = [
+        ("escape", "app.pop_screen", "Back"),
+        ("d", "delete_server", "Delete"),
+    ]
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=False)
@@ -329,17 +360,30 @@ class ServerSwitchScreen(Screen):
         yield Footer()
 
     def on_mount(self) -> None:
-        servers = self.app.tui_state.known_servers()
-        if not servers:
-            self.query_one("#switch_msg", Static).update(
-                "No servers configured. Use 'a' to add one."
-            )
-            return
-        current = self.app.tui_state.current_url()
+        self._populate()
+
+    def _populate(self) -> None:
         ol = self.query_one("#server_options", OptionList)
+        ol.clear_options()
+        servers = self.app.tui_state.known_servers()
+        msg = self.query_one("#switch_msg", Static)
+        if not servers:
+            msg.update("No servers configured. Use 'a' to add one.")
+            return
+        msg.update("")
+        current = self.app.tui_state.current_url()
         for s in servers:
             mark = "*" if s.url == current else " "
             ol.add_option(Option(f"{mark} {s.alias}  ({s.url})", id=s.url))
+
+    def action_delete_server(self) -> None:
+        ol = self.query_one("#server_options", OptionList)
+        idx = ol.highlighted
+        if idx is None:
+            return
+        url = ol.get_option_at_index(idx).id
+        self.app.tui_state.delete_server(url)
+        self._populate()
 
     def on_option_list_option_selected(
         self, event: OptionList.OptionSelected

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -23,6 +23,7 @@ from textual.widgets import (
 from textual.widgets.option_list import Option
 
 from .state import LoginError
+from ..transport import is_valid_server_spec
 from .widgets import Sidebar, StatusBar
 from .ws import listen_for_status
 
@@ -35,14 +36,14 @@ class ConfirmScreen(ModalScreen[bool]):
     ConfirmScreen > Vertical {
         width: 64;
         max-width: 90%;
-        padding: 1 2;
+        height: auto;
+        padding: 0 2;
         border: round $primary;
         background: $panel;
     }
     ConfirmScreen Horizontal {
         align-horizontal: right;
         height: auto;
-        padding-top: 1;
     }
     """
 
@@ -86,7 +87,7 @@ class LoginScreen(Screen):
                 id="server_input",
             ),
             Horizontal(
-                Button("Add server", id="use_server"),
+                Button("Use server", id="use_server"),
                 classes="actions",
             ),
             Static("", id="notice"),
@@ -112,7 +113,7 @@ class LoginScreen(Screen):
     def _show_no_server(self) -> None:
         self.query_one("#server_line", Static).update(
             "No server selected. Pick one above or enter a URL,"
-            " then press 'Add server'."
+            " then press 'Use server'."
         )
         self._disable_credentials()
 
@@ -151,10 +152,17 @@ class LoginScreen(Screen):
         if raw in cfg.servers:
             # Known alias — switch to its URL.
             self.app.tui_state.switch_server(cfg.servers[raw].url)
-        else:
+        elif is_valid_server_spec(raw):
             # A new server (URL or UDS path) — save it as an alias so it can
             # be re-selected later.
             self.app.tui_state.add_server(self._derive_alias(raw), raw)
+        else:
+            self._set_message(
+                "Enter a server URL (https://host), a socket path"
+                " (/...), or a known alias.",
+                error=True,
+            )
+            return
         self.query_one("#server_input", Input).value = ""
         self._set_message("")
         self._populate_servers()
@@ -478,6 +486,12 @@ class AddServerScreen(Screen):
         msg = self.query_one("#add_msg", Static)
         if not alias or not url:
             msg.update("[red]Alias and URL are required.[/red]")
+            return
+        if not is_valid_server_spec(url):
+            msg.update(
+                "[red]URL must be http(s)://host or an absolute socket"
+                " path (/...).[/red]"
+            )
             return
         self.app.tui_state.add_server(alias, url)
         self.app.server_changed()

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -86,7 +86,7 @@ class LoginScreen(Screen):
                 id="server_input",
             ),
             Horizontal(
-                Button("Use server", id="use_server"),
+                Button("Add server", id="use_server"),
                 classes="actions",
             ),
             Static("", id="notice"),
@@ -112,7 +112,7 @@ class LoginScreen(Screen):
     def _show_no_server(self) -> None:
         self.query_one("#server_line", Static).update(
             "No server selected. Pick one above or enter a URL,"
-            " then press 'Use server'."
+            " then press 'Add server'."
         )
         self._disable_credentials()
 

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -94,9 +94,6 @@ class LoginScreen(Screen):
             Input(placeholder="Password", id="password", password=True),
             Horizontal(
                 Button("Log in via browser (SSO)", id="oidc"),
-                classes="actions",
-            ),
-            Horizontal(
                 Button("Log in", id="login", variant="primary"),
                 classes="actions",
             ),

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -7,6 +7,8 @@ free of cross-screen coupling and reach state through ``self.app.tui_state``.
 
 from __future__ import annotations
 
+from urllib.parse import urlparse
+
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
 from textual.screen import Screen
@@ -26,19 +28,27 @@ from .ws import listen_for_status
 
 
 class LoginScreen(Screen):
-    """Credential screen that adapts to the server's auth mode.
+    """Credential screen that also picks the server to log into.
 
-    ``none`` → auto no-auth login; ``oidc`` → SSO hand-off (browser);
-    ``password``/``both`` → email/handle + password form; ``unreachable``
-    → diagnostic message. The password form and SSO button are
-    ``disabled`` (not hidden) for non-applicable modes so the screen
-    stays simple to render and test.
+    A fresh user with no server configured can pick a known alias, select
+    the co-located default UDS, or type a URL (which is saved as a new
+    alias) — then authenticate. Once a server is active the screen
+    adapts to its auth mode: ``none`` → auto no-auth login; ``oidc`` →
+    SSO hand-off (browser); ``password``/``both`` → email/handle +
+    password form; ``unreachable`` → diagnostic.
     """
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=False)
         yield Vertical(
             Static("klangk", classes="title"),
+            Static("", id="server_line"),
+            OptionList(id="server_options"),
+            Input(
+                placeholder=("Server URL or alias (e.g. https://host, prod)"),
+                id="server_input",
+            ),
+            Button("Use server", id="use_server"),
             Static("", id="notice"),
             Input(placeholder="Email or handle", id="identifier"),
             Input(placeholder="Password", id="password", password=True),
@@ -50,18 +60,78 @@ class LoginScreen(Screen):
         yield Footer()
 
     def on_mount(self) -> None:
+        self._populate_servers()
+        if self.app.tui_state.current_url() is not None:
+            self._setup_auth()
+        else:
+            self.query_one("#server_line", Static).update(
+                "No server selected. Pick one above or enter a URL,"
+                " then press 'Use server'."
+            )
+            self._disable_credentials()
+
+    # --- server picker ---
+
+    def _populate_servers(self) -> None:
+        ol = self.query_one("#server_options", OptionList)
+        ol.clear_options()
+        current = self.app.tui_state.current_url()
+        for s in self.app.tui_state.known_servers():
+            mark = "*" if s.url == current else " "
+            ol.add_option(Option(f"{mark} {s.alias}  ({s.url})", id=s.url))
+        uds = self.app.tui_state.default_uds()
+        if uds and uds != current:
+            ol.add_option(Option(f"  Local klangkd (UDS)  ({uds})", id=uds))
+
+    @staticmethod
+    def _derive_alias(raw: str) -> str:
+        if "://" in raw:
+            host = urlparse(raw).hostname
+            if host:
+                return host
+        name = raw.rstrip("/").split("/")[-1]
+        return name or "server"
+
+    def _choose_server(self, raw: str | None) -> None:
+        raw = (raw or "").strip()
+        if not raw:
+            self._set_message("Enter a server URL or alias.", error=True)
+            return
+        cfg = self.app.tui_state.cfg()
+        if raw in cfg.servers:
+            # Known alias — switch to its URL.
+            self.app.tui_state.switch_server(cfg.servers[raw].url)
+        elif raw.startswith("/"):
+            # A socket path (e.g. the auto-detected UDS): use it without
+            # persisting a throwaway alias.
+            self.app.tui_state.switch_server(raw)
+        else:
+            # A new URL — save it as an alias so it appears next time.
+            self.app.tui_state.add_server(self._derive_alias(raw), raw)
+        self.query_one("#server_input", Input).value = ""
+        self._set_message("")
+        self._populate_servers()
+        self._setup_auth()
+
+    # --- auth-mode setup ---
+
+    def _setup_auth(self) -> None:
         state = self.app.tui_state
         mode = state.auth_mode()
+        self.query_one("#server_line", Static).update(
+            f"Server: {state.current_url()}"
+        )
+        self._enable_credentials()
         notice = self.query_one("#notice", Static)
         if mode == "none":
-            # Reached only if the app-level no-auth auto-login failed.
-            notice.update("No-auth login failed — check the server.")
-            self._disable_form()
+            notice.update("No-auth server — logging in…")
+            # Defer the (possibly screen-pushing) login so we don't push
+            # during this screen's own mount.
+            self.call_after_refresh(self._attempt_none)
             return
         if mode == "unreachable":
             notice.update(
-                "Cannot reach the server. Check the URL or that klangkd"
-                " is running."
+                "Cannot reach the server. Pick another or check klangkd."
             )
             self._disable_form()
             return
@@ -75,7 +145,22 @@ class LoginScreen(Screen):
         notice.update("Enter your credentials.")
         self.query_one("#oidc", Button).disabled = True
 
+    def _disable_credentials(self) -> None:
+        # No server chosen: disable the whole credential area.
+        self.query_one("#identifier", Input).disabled = True
+        self.query_one("#password", Input).disabled = True
+        self.query_one("#login", Button).disabled = True
+        self.query_one("#oidc", Button).disabled = True
+
+    def _enable_credentials(self) -> None:
+        self.query_one("#identifier", Input).disabled = False
+        self.query_one("#password", Input).disabled = False
+        self.query_one("#login", Button).disabled = False
+        self.query_one("#oidc", Button).disabled = False
+
     def _disable_form(self) -> None:
+        # Server set but not password-authable (oidc/unreachable): disable
+        # the password form, leave the SSO button usable.
         self.query_one("#identifier", Input).disabled = True
         self.query_one("#password", Input).disabled = True
         self.query_one("#login", Button).disabled = True
@@ -85,6 +170,14 @@ class LoginScreen(Screen):
         self.query_one("#message", Static).update(rendered)
 
     # --- login arms ---
+
+    def _attempt_none(self) -> None:
+        try:
+            self.app.tui_state.login_none()
+        except LoginError as exc:
+            self._set_message(f"No-auth login failed: {exc}", error=True)
+            return
+        self.app.login_succeeded()
 
     def _attempt_password(self) -> None:
         identifier = self.query_one("#identifier", Input).value.strip()
@@ -119,14 +212,23 @@ class LoginScreen(Screen):
 
     # --- event handlers ---
 
+    def on_option_list_option_selected(
+        self, event: OptionList.OptionSelected
+    ) -> None:
+        self._choose_server(event.option.id)
+
     def on_button_pressed(self, event: Button.Pressed) -> None:
-        if event.button.id == "login":
+        if event.button.id == "use_server":
+            self._choose_server(self.query_one("#server_input", Input).value)
+        elif event.button.id == "login":
             self._attempt_password()
         elif event.button.id == "oidc":
             self._attempt_oidc()
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
-        if event.input.id in ("identifier", "password"):
+        if event.input.id == "server_input":
+            self._choose_server(event.input.value)
+        elif event.input.id in ("identifier", "password"):
             self._attempt_password()
 
 

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -11,7 +11,7 @@ from urllib.parse import urlparse
 
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
-from textual.screen import Screen
+from textual.screen import ModalScreen, Screen
 from textual.widgets import (
     Button,
     Footer,
@@ -25,6 +25,42 @@ from textual.widgets.option_list import Option
 from .state import LoginError
 from .widgets import Sidebar, StatusBar
 from .ws import listen_for_status
+
+
+class ConfirmScreen(ModalScreen[bool]):
+    """A yes/no confirmation dialog. Dismisses with True on confirm."""
+
+    DEFAULT_CSS = """
+    ConfirmScreen { align: center middle; }
+    ConfirmScreen > Vertical {
+        width: 64;
+        max-width: 90%;
+        padding: 1 2;
+        border: round $primary;
+        background: $panel;
+    }
+    ConfirmScreen Horizontal {
+        align-horizontal: right;
+        height: auto;
+        padding-top: 1;
+    }
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__()
+        self.message = message
+
+    def compose(self) -> ComposeResult:
+        yield Vertical(
+            Static(self.message),
+            Horizontal(
+                Button("Cancel", id="no"),
+                Button("Delete", id="yes", variant="error"),
+            ),
+        )
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        self.dismiss(event.button.id == "yes")
 
 
 class LoginScreen(Screen):
@@ -43,7 +79,6 @@ class LoginScreen(Screen):
     def compose(self) -> ComposeResult:
         yield Header(show_clock=False)
         yield Vertical(
-            Static("klangk", classes="title"),
             Static("", id="server_line"),
             OptionList(id="server_options"),
             Input(
@@ -58,8 +93,11 @@ class LoginScreen(Screen):
             Input(placeholder="Email or handle", id="identifier"),
             Input(placeholder="Password", id="password", password=True),
             Horizontal(
-                Button("Log in", id="login", variant="primary"),
                 Button("Log in via browser (SSO)", id="oidc"),
+                classes="actions",
+            ),
+            Horizontal(
+                Button("Log in", id="login", variant="primary"),
                 classes="actions",
             ),
             Static("", id="message"),
@@ -132,15 +170,23 @@ class LoginScreen(Screen):
             self._set_message("Select a server to delete.", error=True)
             return
         url = ol.get_option_at_index(idx).id
-        if self.app.tui_state.delete_server(url):
-            self._set_message("Server deleted.")
-        else:
-            self._set_message("Not a saved alias.", error=True)
-        self._populate_servers()
-        if self.app.tui_state.current_url() is None:
-            self._show_no_server()
-        else:
-            self._setup_auth()
+
+        def _on_confirm(confirmed: bool) -> None:
+            if not confirmed:
+                return
+            if self.app.tui_state.delete_server(url):
+                self._set_message("Server deleted.")
+            else:
+                self._set_message("Not a saved alias.", error=True)
+            self._populate_servers()
+            if self.app.tui_state.current_url() is None:
+                self._show_no_server()
+            else:
+                self._setup_auth()
+
+        self.app.push_screen(
+            ConfirmScreen(f"Delete server {url}?"), _on_confirm
+        )
 
     # --- auth-mode setup ---
 
@@ -275,7 +321,6 @@ class MainScreen(Screen):
         yield Horizontal(
             Sidebar(id="sidebar"),
             Vertical(
-                Static("klangk", classes="title"),
                 Static("", id="content"),
                 id="main",
             ),
@@ -382,8 +427,16 @@ class ServerSwitchScreen(Screen):
         if idx is None:
             return
         url = ol.get_option_at_index(idx).id
-        self.app.tui_state.delete_server(url)
-        self._populate()
+
+        def _on_confirm(confirmed: bool) -> None:
+            if not confirmed:
+                return
+            self.app.tui_state.delete_server(url)
+            self._populate()
+
+        self.app.push_screen(
+            ConfirmScreen(f"Delete server {url}?"), _on_confirm
+        )
 
     def on_option_list_option_selected(
         self, event: OptionList.OptionSelected

--- a/src/klangk/klangk/cli/tui/state.py
+++ b/src/klangk/klangk/cli/tui/state.py
@@ -11,6 +11,7 @@ deps, and sibling ``cli`` modules.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 
 import httpx
 
@@ -25,6 +26,7 @@ from ..config import (
     CLIConfig,
     CLIState,
     add_server_to_config,
+    default_server_uds_path,
 )
 from ..transport import http_request
 
@@ -64,7 +66,21 @@ class TuiState:
     def current_url(self) -> str | None:
         if self._server_override is not None:
             return self._server_override
-        return self.state().active_server
+        active = self.state().active_server
+        if active is not None:
+            return active
+        # Single-host convenience (#1676): a co-located klangkd's default
+        # UDS is usable with no `klangk login` step, so a fresh user can log
+        # in straight from the TUI.
+        uds = default_server_uds_path()
+        if Path(uds).exists():
+            return uds
+        return None
+
+    def default_uds(self) -> str | None:
+        """The co-located klangkd default UDS, if its socket exists."""
+        uds = default_server_uds_path()
+        return uds if Path(uds).exists() else None
 
     def known_servers(self) -> list[ServerInfo]:
         return [

--- a/src/klangk/klangk/cli/tui/state.py
+++ b/src/klangk/klangk/cli/tui/state.py
@@ -1,0 +1,190 @@
+"""Live state bridge for the klangk TUI.
+
+Reads ``CLIConfig`` / ``CLIState`` fresh on every access (no stale
+snapshots), mirroring the server-side ``app``-ownership discipline so a
+server switch or an external ``klangk login`` is reflected immediately.
+
+Stays within ``klangk.cli`` (isolation rule): only stdlib, third-party
+deps, and sibling ``cli`` modules.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import httpx
+
+from ..auth import (
+    _UNREACHABLE,
+    _oidc_browser_login,
+    fetch_config,
+    local_login,
+)
+from ..client import KlangkClient
+from ..config import (
+    CLIConfig,
+    CLIState,
+    add_server_to_config,
+)
+from ..transport import http_request
+
+
+class LoginError(Exception):
+    """Raised when an in-TUI login attempt fails."""
+
+
+@dataclass(frozen=True)
+class ServerInfo:
+    """A known server alias + URL from klangk.yaml."""
+
+    alias: str
+    url: str
+
+
+class TuiState:
+    """Live bridge to CLIConfig / CLIState / KlangkClient.
+
+    Config and state are re-loaded on every call rather than cached at
+    construction, so the TUI never acts on a stale snapshot after a
+    server switch, an external login, or a token refresh.
+    """
+
+    def __init__(self, server_url: str | None = None) -> None:
+        # ``--server`` override; otherwise the active server from state.
+        self._server_override = server_url
+
+    # --- fresh config / state each call ---
+
+    def cfg(self) -> CLIConfig:
+        return CLIConfig.load()
+
+    def state(self) -> CLIState:
+        return CLIState.load()
+
+    def current_url(self) -> str | None:
+        if self._server_override is not None:
+            return self._server_override
+        return self.state().active_server
+
+    def known_servers(self) -> list[ServerInfo]:
+        return [
+            ServerInfo(alias=alias, url=entry.url)
+            for alias, entry in self.cfg().servers.items()
+        ]
+
+    def token(self) -> str | None:
+        url = self.current_url()
+        if url is None:
+            return None
+        return self.state().get_token(url)
+
+    def email(self) -> str | None:
+        url = self.current_url()
+        if url is None:
+            return None
+        return self.state().get_email(url)
+
+    def is_authenticated(self) -> bool:
+        return self.token() is not None
+
+    def client(self) -> KlangkClient:
+        return KlangkClient(self.current_url(), self.token())
+
+    # --- auth mode (probed live via /config) ---
+
+    def auth_mode(self) -> str:
+        """``none`` / ``password`` / ``oidc`` / ``both`` / ``unreachable``."""
+        url = self.current_url()
+        if url is None:
+            return "password"
+        config = fetch_config(url)
+        if config == _UNREACHABLE:
+            return "unreachable"
+        if not isinstance(config, dict):
+            return "password"
+        return config.get("auth_modes", "password")
+
+    def oidc_providers(self) -> list[dict]:
+        url = self.current_url()
+        if url is None:
+            return []
+        config = fetch_config(url)
+        if not isinstance(config, dict):
+            return []
+        return list(config.get("oidc_providers") or [])
+
+    # --- login arms ---
+
+    def login_password(self, identifier: str, password: str) -> str:
+        url = self.current_url()
+        if url is None:
+            raise LoginError("No server configured")
+        try:
+            resp = http_request(
+                url,
+                "POST",
+                "/api/v1/auth/login",
+                json={"identifier": identifier, "password": password},
+                timeout=15.0,
+            )
+        except httpx.HTTPError as exc:
+            raise LoginError(f"could not reach server: {exc}") from None
+        if resp.status_code != 200:
+            detail = f"HTTP {resp.status_code}"
+            try:
+                detail = resp.json().get("detail", detail)
+            except Exception:
+                pass
+            raise LoginError(detail)
+        token = resp.json().get("access_token")
+        if not token:
+            raise LoginError("server returned no access token")
+        state = self.state()
+        state.set_credentials(url, identifier, token)
+        state.save()
+        return identifier
+
+    def login_none(self) -> str:
+        url = self.current_url()
+        if url is None:
+            raise LoginError("No server configured")
+        try:
+            email, token = local_login(url)
+        except SystemExit as exc:
+            raise LoginError("no-auth login failed") from exc
+        state = self.state()
+        state.set_credentials(url, email, token)
+        state.save()
+        return email
+
+    def oidc_login(self, provider_id: str) -> None:
+        """Delegate to the existing browser-based OIDC flow."""
+        url = self.current_url()
+        if url is None:
+            raise LoginError("No server configured")
+        try:
+            _oidc_browser_login(url, provider_id, self.state())
+        except SystemExit as exc:
+            raise LoginError("OIDC login failed") from exc
+
+    def logout(self) -> None:
+        url = self.current_url()
+        state = self.state()
+        if url is not None:
+            state.clear_credentials(url)
+            state.save()
+
+    # --- server switching / adding ---
+
+    def switch_server(self, url: str) -> None:
+        state = self.state()
+        state.active_server = url
+        state.save()
+
+    def add_server(
+        self, alias: str, url: str, user: str | None = None
+    ) -> None:
+        add_server_to_config(alias, url, user)
+        state = self.state()
+        state.active_server = url
+        state.save()

--- a/src/klangk/klangk/cli/tui/state.py
+++ b/src/klangk/klangk/cli/tui/state.py
@@ -27,6 +27,7 @@ from ..config import (
     CLIState,
     add_server_to_config,
     default_server_uds_path,
+    remove_server_from_config,
 )
 from ..transport import http_request
 
@@ -204,3 +205,22 @@ class TuiState:
         state = self.state()
         state.active_server = url
         state.save()
+
+    def delete_server(self, url: str) -> bool:
+        """Delete the alias pointing at *url*.
+
+        Returns True if an alias was removed. If it was the active server,
+        the active pointer is cleared (so ``current_url`` falls back to the
+        default UDS or None) rather than left dangling.
+        """
+        cfg = self.cfg()
+        aliases = [a for a, e in cfg.servers.items() if e.url == url]
+        if not aliases:
+            return False
+        for a in aliases:
+            remove_server_from_config(a)
+        state = self.state()
+        if state.active_server == url:
+            state.active_server = None
+            state.save()
+        return True

--- a/src/klangk/klangk/cli/tui/widgets.py
+++ b/src/klangk/klangk/cli/tui/widgets.py
@@ -1,0 +1,51 @@
+"""StatusBar and Sidebar widgets for the klangk TUI."""
+
+from __future__ import annotations
+
+from textual.widgets import Static
+
+
+class StatusBar(Static):
+    """One-line bottom bar: current server, user, and live-state flag."""
+
+    DEFAULT_CSS = """
+    StatusBar {
+        dock: bottom;
+        height: 1;
+        background: $boost;
+        color: $text-muted;
+        padding: 0 1;
+    }
+    """
+
+    def set_state(
+        self,
+        *,
+        server: str | None,
+        user: str | None,
+        extra: str = "",
+    ) -> None:
+        text = (
+            f"server: {server or '(none)'}"
+            f"   |   user: {user or '(not logged in)'}"
+        )
+        if extra:
+            text += f"   |   {extra}"
+        self.update(text)
+
+
+class Sidebar(Static):
+    """Left navigation pane (keybinding-driven for the foundation)."""
+
+    DEFAULT_CSS = """
+    Sidebar {
+        dock: left;
+        width: 24;
+        padding: 1 2;
+        background: $panel;
+        border-right: solid $primary-background;
+    }
+    """
+
+    def set_items(self, items: list[str]) -> None:
+        self.update("\n".join(items))

--- a/src/klangk/klangk/cli/tui/ws.py
+++ b/src/klangk/klangk/cli/tui/ws.py
@@ -1,0 +1,39 @@
+"""WebSocket status listener for the klangk TUI.
+
+Connects to the server's ``/ws`` and forwards the same broadcast events
+the web UI and ``klangk monitor`` consume (``workspaces_changed``,
+``container_status``, ``service_health``) to a callback, so the TUI's
+status reflects live workspace/container state. Reconnection is the
+caller's concern — the ``monitor`` command owns the battle-tested
+reconnect loop; this is the lean listener the TUI runs as a worker.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+
+from ..transport import ws_connect
+
+
+async def listen_for_status(
+    server_url: str,
+    token: str,
+    on_event: Callable[[dict], object],
+    *,
+    max_size: int | None = None,
+) -> None:
+    """Connect to ``/ws`` and call ``on_event(event)`` for each broadcast.
+
+    Non-JSON and non-object frames are skipped (the server occasionally
+    sends control/ack frames).
+    """
+    async with ws_connect(server_url, token=token, max_size=max_size) as ws:
+        async for raw in ws:
+            try:
+                event = json.loads(raw)
+            except (TypeError, ValueError):
+                continue
+            if not isinstance(event, dict):
+                continue
+            on_event(event)

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -317,36 +317,38 @@ class TestMainCLI:
 
     def test_default_server_uds_path_derivation(self, monkeypatch):
         """Unit-test the path derivation independent of existence."""
-        from klangk.cli import main
+        from klangk.cli import config
 
         monkeypatch.delenv("KLANGK_STATE_DIR", raising=False)
         monkeypatch.setenv("XDG_STATE_HOME", "/custom/xdg")
         assert (
-            main._default_server_uds_path()
+            config.default_server_uds_path()
             == "/custom/xdg/klangkd/klangk.sock"
         )
 
         monkeypatch.setenv("XDG_STATE_HOME", "/custom/xdg")
         monkeypatch.setenv("KLANGK_STATE_DIR", "/explicit/state")
-        assert main._default_server_uds_path() == "/explicit/state/klangk.sock"
+        assert (
+            config.default_server_uds_path() == "/explicit/state/klangk.sock"
+        )
 
         monkeypatch.delenv("KLANGK_STATE_DIR", raising=False)
         monkeypatch.delenv("XDG_STATE_HOME", raising=False)
         # Unset fallback → ~/.local/state (expanduser under HOME).
-        assert main._default_server_uds_path().endswith(
+        assert config.default_server_uds_path().endswith(
             ".local/state/klangkd/klangk.sock"
         )
 
         # An explicit plain absolute KLANGK_SOCKET is honored verbatim —
         # the server binds exactly there and skips the state_dir default.
         monkeypatch.setenv("KLANGK_SOCKET", "/run/klangk.sock")
-        assert main._default_server_uds_path() == "/run/klangk.sock"
+        assert config.default_server_uds_path() == "/run/klangk.sock"
 
         # file:/cmd: indirections can't be resolved client-side and must
         # fall through to the state_dir-derived default.
         for indirect in ("file:/etc/klangk/socket", "cmd:cat /etc/socket"):
             monkeypatch.setenv("KLANGK_SOCKET", indirect)
-            assert main._default_server_uds_path().endswith(
+            assert config.default_server_uds_path().endswith(
                 ".local/state/klangkd/klangk.sock"
             )
         monkeypatch.delenv("KLANGK_SOCKET", raising=False)

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import types
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -472,7 +473,10 @@ class TestMainCLI:
         )
         CLIState().save()
 
-        main.app_callback(server="prod")
+        main.app_callback(
+            types.SimpleNamespace(invoked_subcommand="status"),
+            server="prod",
+        )
         assert main._server_override == "http://prod:8995"
 
     def test_list_workspaces_empty(self, logged_in_cfg, monkeypatch):

--- a/src/klangk/klangkc-tests/tests/test_transport.py
+++ b/src/klangk/klangkc-tests/tests/test_transport.py
@@ -8,9 +8,22 @@ from klangk.cli.transport import (
     ServerTransport,
     http_request,
     http_stream,
+    is_valid_server_spec,
     resolve_transport,
     ws_connect,
 )
+
+
+class TestIsValidServerSpec:
+    def test_valid_specs(self):
+        assert is_valid_server_spec("https://host:8995")
+        assert is_valid_server_spec("http://host")
+        assert is_valid_server_spec("/run/klangk.sock")
+
+    def test_invalid_specs(self):
+        assert not is_valid_server_spec("sdfsdf")
+        assert not is_valid_server_spec("relative/path")
+        assert not is_valid_server_spec("host:8995")  # no scheme
 
 
 class TestResolveTransport:

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -18,6 +18,7 @@ from klangk.cli.config import (
     CLIState,
     ServerEntry,
     add_server_to_config,
+    remove_server_from_config,
 )
 from klangk.cli.tui import screens as scr
 from klangk.cli.tui import state as tui_state_mod
@@ -111,6 +112,20 @@ def test_add_server_merges_existing(redirect_xdg):
     loaded = CLIConfig.load()
     assert set(loaded.servers) == {"a", "b"}
     assert loaded.servers["a"].url == "https://a.example"
+
+
+def test_remove_server_from_config(redirect_xdg):
+    add_server_to_config("a", "https://a.example")
+    add_server_to_config("b", "https://b.example")
+    assert remove_server_from_config("a") is True
+    assert set(CLIConfig.load().servers) == {"b"}
+    # removing an absent alias is a no-op (False)
+    assert remove_server_from_config("zzz") is False
+
+
+def test_remove_server_no_config_file(monkeypatch, tmp_path):
+    monkeypatch.setattr(cfgmod, "_CONFIG_PATH", tmp_path / "nope.yaml")
+    assert remove_server_from_config("a") is False
 
 
 # ---------------------------------------------------------------------------
@@ -305,6 +320,21 @@ def test_logout_switch_add(redirect_xdg):
     loaded = CLIConfig.load()
     assert loaded.servers["c"].url == "https://c.example"
     assert loaded.servers["c"].user == "u"
+
+
+def test_delete_server(redirect_xdg):
+    add_server_to_config("a", "https://a.example")
+    add_server_to_config("b", "https://b.example")
+    TuiState().switch_server("https://a.example")  # make 'a' active
+    assert TuiState().state().active_server == "https://a.example"
+
+    # delete by url -> alias gone, active pointer cleared
+    assert TuiState().delete_server("https://a.example") is True
+    assert set(CLIConfig.load().servers) == {"b"}
+    assert TuiState().state().active_server is None
+
+    # not found
+    assert TuiState().delete_server("https://nope.example") is False
 
 
 # ---------------------------------------------------------------------------
@@ -856,6 +886,117 @@ async def test_populate_servers_dedups_default_udsk(monkeypatch):
         ol = app.screen.query_one("#server_options", OptionList)
         # only the persisted alias row; no separate "Local klangkd (UDS)" row
         assert len(ol._options) == 1
+
+
+async def test_login_delete_server(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    cfg = CLIConfig()
+    cfg.servers = {"prod": ServerEntry(url="https://prod.example")}
+    deleted = {}
+    st = _st(
+        current_url=lambda: "https://prod.example",
+        known_servers=lambda: [
+            tui_state_mod.ServerInfo("prod", "https://prod.example")
+        ],
+        default_uds=lambda: None,
+        cfg=lambda: cfg,
+        auth_mode=lambda: "password",
+        email=lambda: None,
+        token=lambda: None,
+        is_authenticated=lambda: False,
+        delete_server=lambda url: deleted.__setitem__("u", url) or True,
+    )
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        login = app.screen
+        ol = login.query_one("#server_options", OptionList)
+        # nothing highlighted -> prompt to select
+        ol.highlighted = None
+        login.action_delete_server()
+        await pilot.pause()
+        assert "Select a server" in str(login.query_one("#message").render())
+        # highlight + delete -> delete_server called, success message
+        ol.highlighted = 0
+        login.action_delete_server()
+        await pilot.pause()
+        assert deleted.get("u") == "https://prod.example"
+        assert "Server deleted" in str(login.query_one("#message").render())
+        # delete returns False -> "Not a saved alias"
+        st.delete_server = lambda url: False
+        ol.highlighted = 0
+        login.action_delete_server()
+        await pilot.pause()
+        assert "Not a saved alias" in str(login.query_one("#message").render())
+
+
+async def test_login_delete_clears_to_no_server(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    st = _st(
+        current_url=lambda: "https://prod.example",
+        known_servers=lambda: [
+            tui_state_mod.ServerInfo("prod", "https://prod.example")
+        ],
+        default_uds=lambda: None,
+        cfg=lambda: CLIConfig(),
+        auth_mode=lambda: "password",
+        email=lambda: None,
+        token=lambda: None,
+        is_authenticated=lambda: False,
+    )
+
+    def fake_delete(url):
+        st.current_url = lambda: None
+        st.known_servers = lambda: []
+        return True
+
+    st.delete_server = fake_delete
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        login = app.screen
+        ol = login.query_one("#server_options", OptionList)
+        ol.highlighted = 0
+        login.action_delete_server()
+        await pilot.pause()
+        # current_url now None -> no-server state
+        assert "No server selected" in str(
+            login.query_one("#server_line").render()
+        )
+
+
+async def test_switch_screen_delete_server(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    deleted = {}
+    st = _authed_state(
+        known_servers=lambda: [
+            tui_state_mod.ServerInfo("prod", "https://prod.example")
+        ],
+        delete_server=lambda url: deleted.__setitem__("u", url),
+    )
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(ServerSwitchScreen())
+        await pilot.pause()
+        switch = app.screen
+        ol = switch.query_one("#server_options", OptionList)
+        # nothing highlighted -> no-op
+        ol.highlighted = None
+        switch.action_delete_server()
+        await pilot.pause()
+        assert "u" not in deleted
+        # highlight + delete
+        ol.highlighted = 0
+        switch.action_delete_server()
+        await pilot.pause()
+        assert deleted.get("u") == "https://prod.example"
 
 
 # ---------------------------------------------------------------------------

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -853,7 +853,7 @@ async def test_login_server_picker(monkeypatch):
         await pilot.pause()
         assert calls.get("add") == ("other.sock", "/var/run/other.sock")
 
-        # "Add server" button also dispatches
+        # "Use server" button also dispatches
         srv_input.value = "prod"
         login.on_button_pressed(FakeBtnPress("use_server"))
         await pilot.pause()
@@ -887,6 +887,59 @@ async def test_populate_servers_dedups_default_udsk(monkeypatch):
         ol = app.screen.query_one("#server_options", OptionList)
         # only the persisted alias row; no separate "Local klangkd (UDS)" row
         assert len(ol._options) == 1
+
+
+async def test_login_choose_invalid_server(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    added = {}
+    st = _st(
+        current_url=lambda: None,
+        known_servers=lambda: [],
+        default_uds=lambda: None,
+        cfg=lambda: CLIConfig(),
+        auth_mode=lambda: "password",
+        email=lambda: None,
+        token=lambda: None,
+        is_authenticated=lambda: False,
+        add_server=lambda alias, url, user=None: added.__setitem__(
+            "a", (alias, url)
+        ),
+    )
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        login = app.screen
+        login._choose_server("sdfsdf")
+        await pilot.pause()
+        # not persisted, and a sensible message is shown
+        assert added.get("a") is None
+        assert "URL" in str(login.query_one("#message").render())
+
+
+async def test_add_server_rejects_invalid_url(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    added = {}
+    st = _authed_state(
+        add_server=lambda alias, url, user=None: added.__setitem__(
+            "a", (alias, url)
+        )
+    )
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(AddServerScreen())
+        await pilot.pause()
+        s = app.screen
+        s.query_one("#alias", Input).value = "x"
+        s.query_one("#url", Input).value = "sdfsdf"
+        s._add()
+        await pilot.pause()
+        assert added.get("a") is None
+        assert "http" in str(s.query_one("#add_msg").render()).lower()
 
 
 async def test_confirm_screen(monkeypatch):

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -1,0 +1,938 @@
+"""Tests for the klangk TUI foundation (issue #1746).
+
+Covers the textual app shell, login/server-switch flows, the live state
+bridge, the WebSocket status listener, the bare-``klangk`` launch wiring,
+and the ``add_server_to_config`` helper — under the 100% coverage gate.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from textual.widgets import Input
+
+from klangk.cli import config as cfgmod
+from klangk.cli import tui as tui_pkg
+from klangk.cli.config import CLIConfig, CLIState, add_server_to_config
+from klangk.cli.tui import screens as scr
+from klangk.cli.tui import state as tui_state_mod
+from klangk.cli.tui import ws as ws_mod
+from klangk.cli.tui.app import KlangkApp, run_tui
+from klangk.cli.tui.screens import (
+    AddServerScreen,
+    LoginScreen,
+    MainScreen,
+    ServerSwitchScreen,
+)
+from klangk.cli.tui.state import LoginError, TuiState
+from klangk.cli.tui.ws import listen_for_status
+
+
+# ---------------------------------------------------------------------------
+# fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def redirect_xdg(monkeypatch, tmp_path):
+    """Point CLI config/state files at tmp_path (never the user's real ones)."""
+    cpath = tmp_path / "klangk.yaml"
+    spath = tmp_path / "klangk-state.yaml"
+    monkeypatch.setattr(cfgmod, "_CONFIG_PATH", cpath)
+    monkeypatch.setattr(cfgmod, "_STATE_PATH", spath)
+    return cpath, spath
+
+
+class FakeResp:
+    def __init__(self, status_code=200, payload=None):
+        self.status_code = status_code
+        self._payload = payload if payload is not None else {}
+
+    def json(self):
+        return self._payload
+
+
+class FakeOptionSelected:
+    """Stand-in for OptionList.OptionSelected carrying an option id."""
+
+    def __init__(self, option_id):
+        self.option = type("Opt", (), {"id": option_id})()
+
+
+class FakeBtnPress:
+    """Stand-in for Button.Pressed carrying a button id."""
+
+    def __init__(self, button_id):
+        self.button = type("B", (), {"id": button_id})()
+
+
+def _st(**methods):
+    """A TuiState with the given methods overridden (for Pilot tests)."""
+    st = TuiState()
+    for k, v in methods.items():
+        setattr(st, k, v)
+    return st
+
+
+def _authed_state(**extra):
+    base = dict(
+        is_authenticated=lambda: True,
+        current_url=lambda: "https://x.example",
+        email=lambda: "me@x.example",
+        token=lambda: "tok",
+        known_servers=lambda: [],
+    )
+    base.update(extra)
+    return _st(**base)
+
+
+# ---------------------------------------------------------------------------
+# config.add_server_to_config
+# ---------------------------------------------------------------------------
+
+
+def test_add_server_creates_file(redirect_xdg):
+    cpath, _ = redirect_xdg
+    assert not cpath.exists()
+    add_server_to_config("prod", "https://prod.example", user="me@x")
+    loaded = CLIConfig.load()
+    assert loaded.servers["prod"].url == "https://prod.example"
+    assert loaded.servers["prod"].user == "me@x"
+
+
+def test_add_server_merges_existing(redirect_xdg):
+    add_server_to_config("a", "https://a.example")
+    add_server_to_config("b", "https://b.example")
+    loaded = CLIConfig.load()
+    assert set(loaded.servers) == {"a", "b"}
+    assert loaded.servers["a"].url == "https://a.example"
+
+
+# ---------------------------------------------------------------------------
+# TuiState
+# ---------------------------------------------------------------------------
+
+
+def test_current_url_override_wins(redirect_xdg):
+    st = CLIState()
+    st.active_server = "https://active.example"
+    st.save()
+    assert TuiState().current_url() == "https://active.example"
+    assert TuiState("https://override").current_url() == "https://override"
+
+
+def test_current_url_none_when_unconfigured(redirect_xdg):
+    t = TuiState()
+    assert t.current_url() is None
+    assert t.token() is None
+    assert t.email() is None
+    assert t.is_authenticated() is False
+
+
+def test_known_servers_roundtrip(redirect_xdg):
+    add_server_to_config("alpha", "https://a.example")
+    add_server_to_config("beta", "https://b.example")
+    servers = TuiState().known_servers()
+    assert {s.alias for s in servers} == {"alpha", "beta"}
+    assert all(isinstance(s.url, str) for s in servers)
+
+
+def test_token_email_client_from_state(redirect_xdg):
+    st = CLIState()
+    st.set_credentials("https://x.example", "me@x", "tok")
+    st.save()
+    t = TuiState()
+    assert t.current_url() == "https://x.example"
+    assert t.token() == "tok"
+    assert t.email() == "me@x"
+    assert t.is_authenticated() is True
+    c = t.client()
+    assert c.server_url == "https://x.example"
+    assert c.token == "tok"
+
+
+def test_auth_mode_variants(monkeypatch, redirect_xdg):
+    t = TuiState("https://x.example")
+    monkeypatch.setattr(
+        tui_state_mod, "fetch_config", lambda url: tui_state_mod._UNREACHABLE
+    )
+    assert t.auth_mode() == "unreachable"
+
+    monkeypatch.setattr(tui_state_mod, "fetch_config", lambda url: None)
+    assert t.auth_mode() == "password"
+
+    monkeypatch.setattr(
+        tui_state_mod, "fetch_config", lambda url: {"auth_modes": "oidc"}
+    )
+    assert t.auth_mode() == "oidc"
+
+    # No server configured -> safe default.
+    assert TuiState().auth_mode() == "password"
+
+
+def test_oidc_providers(monkeypatch, redirect_xdg):
+    monkeypatch.setattr(
+        tui_state_mod,
+        "fetch_config",
+        lambda url: {"oidc_providers": [{"id": "google"}]},
+    )
+    assert TuiState("https://x.example").oidc_providers() == [{"id": "google"}]
+    monkeypatch.setattr(tui_state_mod, "fetch_config", lambda url: None)
+    assert TuiState("https://x.example").oidc_providers() == []
+    assert TuiState().oidc_providers() == []
+
+
+def test_login_password_success(monkeypatch, redirect_xdg):
+    captured = {}
+
+    def fake_http(url, method, path, **kwargs):
+        captured["sent"] = kwargs["json"]
+        return FakeResp(200, {"access_token": "abc"})
+
+    monkeypatch.setattr(tui_state_mod, "http_request", fake_http)
+    email = TuiState("https://x.example").login_password("me@x", "pw")
+    assert email == "me@x"
+    assert captured["sent"] == {"identifier": "me@x", "password": "pw"}
+    assert TuiState().token() == "abc"
+
+
+def test_login_password_failures(monkeypatch, redirect_xdg):
+    t = TuiState("https://x.example")
+
+    with pytest.raises(LoginError):
+        TuiState().login_password("a", "b")
+
+    def boom(url, method, path, **kwargs):
+        raise httpx.ConnectError("nope")
+
+    monkeypatch.setattr(tui_state_mod, "http_request", boom)
+    with pytest.raises(LoginError):
+        t.login_password("a", "b")
+
+    monkeypatch.setattr(
+        tui_state_mod,
+        "http_request",
+        lambda *a, **k: FakeResp(401, {"detail": "bad creds"}),
+    )
+    with pytest.raises(LoginError, match="bad creds"):
+        t.login_password("a", "b")
+
+    class BadJson(FakeResp):
+        def json(self):
+            raise ValueError("no json")
+
+    monkeypatch.setattr(
+        tui_state_mod, "http_request", lambda *a, **k: BadJson(500)
+    )
+    with pytest.raises(LoginError, match="HTTP 500"):
+        t.login_password("a", "b")
+
+    monkeypatch.setattr(
+        tui_state_mod, "http_request", lambda *a, **k: FakeResp(200, {})
+    )
+    with pytest.raises(LoginError, match="no access token"):
+        t.login_password("a", "b")
+
+
+def test_login_none(monkeypatch, redirect_xdg):
+    # no server (empty state) -> LoginError
+    with pytest.raises(LoginError):
+        TuiState().login_none()
+
+    monkeypatch.setattr(
+        tui_state_mod, "local_login", lambda url: ("local", "tok")
+    )
+    assert TuiState("https://x.example").login_none() == "local"
+    assert TuiState("https://x.example").token() == "tok"
+
+    def die(url):
+        raise SystemExit(1)
+
+    monkeypatch.setattr(tui_state_mod, "local_login", die)
+    with pytest.raises(LoginError):
+        TuiState("https://x.example").login_none()
+
+
+def test_oidc_login(monkeypatch, redirect_xdg):
+    # no server (empty state) -> LoginError
+    with pytest.raises(LoginError):
+        TuiState().oidc_login("google")
+
+    seen = {}
+
+    def fake_oidc(url, provider_id, state):
+        seen["args"] = (url, provider_id)
+        state.set_credentials(url, "oidc@x", "otok")
+        state.save()
+
+    monkeypatch.setattr(tui_state_mod, "_oidc_browser_login", fake_oidc)
+    TuiState("https://x.example").oidc_login("google")
+    assert seen["args"] == ("https://x.example", "google")
+
+    def die(*a):
+        raise SystemExit(1)
+
+    monkeypatch.setattr(tui_state_mod, "_oidc_browser_login", die)
+    with pytest.raises(LoginError):
+        TuiState("https://x.example").oidc_login("google")
+
+
+def test_logout_switch_add(redirect_xdg):
+    st = CLIState()
+    st.set_credentials("https://x.example", "me@x", "tok")
+    st.save()
+    t = TuiState()
+    assert t.is_authenticated()
+
+    t.logout()
+    assert TuiState().token() is None
+
+    # logout with no server is a no-op
+    TuiState().logout()
+
+    add_server_to_config("a", "https://a.example")
+    add_server_to_config("b", "https://b.example")
+    TuiState().switch_server("https://b.example")
+    assert TuiState().current_url() == "https://b.example"
+
+    TuiState().add_server("c", "https://c.example", user="u")
+    assert TuiState().current_url() == "https://c.example"
+    loaded = CLIConfig.load()
+    assert loaded.servers["c"].url == "https://c.example"
+    assert loaded.servers["c"].user == "u"
+
+
+# ---------------------------------------------------------------------------
+# ws.listen_for_status
+# ---------------------------------------------------------------------------
+
+
+class FakeWS:
+    def __init__(self, frames):
+        self._frames = list(frames)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._frames:
+            raise StopAsyncIteration
+        return self._frames.pop(0)
+
+
+class FakeCM:
+    def __init__(self, ws):
+        self._ws = ws
+
+    async def __aenter__(self):
+        return self._ws
+
+    async def __aexit__(self, *a):
+        return False
+
+
+async def test_listen_for_status_filters_and_forwards(monkeypatch):
+    collected = []
+    frames = [
+        '{"type": "workspaces_changed"}',
+        "not-json",
+        "123",  # valid JSON but not a dict
+        '{"type": "service_health"}',
+    ]
+    monkeypatch.setattr(
+        ws_mod, "ws_connect", lambda *a, **k: FakeCM(FakeWS(frames))
+    )
+    await listen_for_status("/sock", "tok", on_event=collected.append)
+    assert collected == [
+        {"type": "workspaces_changed"},
+        {"type": "service_health"},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Pilot tests: app + screens
+# ---------------------------------------------------------------------------
+
+
+async def test_app_opens_login_when_unauthenticated():
+    st = _st(
+        is_authenticated=lambda: False,
+        auth_mode=lambda: "password",
+        current_url=lambda: "https://x.example",
+        email=lambda: None,
+        token=lambda: None,
+    )
+    app = KlangkApp(st)
+    async with app.run_test():
+        assert isinstance(app.screen, LoginScreen)
+
+
+async def test_app_none_mode_auto_logs_in():
+    flag = {"ok": False}
+
+    def fake_none():
+        flag["ok"] = True
+        st.is_authenticated = lambda: True
+        return "local"
+
+    st = _st(
+        auth_mode=lambda: "none",
+        is_authenticated=lambda: False,
+        login_none=fake_none,
+        current_url=lambda: "/sock",
+        email=lambda: "local",
+        token=lambda: "tok",
+        known_servers=lambda: [],
+    )
+    app = KlangkApp(st)
+    async with app.run_test():
+        assert isinstance(app.screen, MainScreen)
+    assert flag["ok"] is True
+
+
+async def test_app_none_mode_failure_falls_back_to_login():
+    def boom():
+        raise LoginError("nope")
+
+    st = _st(
+        auth_mode=lambda: "none",
+        is_authenticated=lambda: False,
+        login_none=boom,
+        current_url=lambda: "/sock",
+        email=lambda: None,
+        token=lambda: None,
+    )
+    app = KlangkApp(st)
+    async with app.run_test():
+        assert isinstance(app.screen, LoginScreen)
+
+
+async def test_main_screen_renders_status(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    app = KlangkApp(_authed_state())
+    async with app.run_test():
+        screen = app.screen
+        assert isinstance(screen, MainScreen)
+        bar = screen.query_one("#status")
+        assert "https://x.example" in str(bar.render())
+        assert "me@x.example" in str(bar.render())
+
+
+async def test_main_screen_status_event_updates_live_extra(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    app = KlangkApp(_authed_state())
+    async with app.run_test() as pilot:
+        screen = app.screen
+        screen._on_status_event({"type": "service_health"})
+        await pilot.pause()
+        assert app.live_extra == "live: service_health"
+        assert "live: service_health" in str(
+            screen.query_one("#status").render()
+        )
+
+
+async def test_status_loop_no_token_returns_early(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    app = KlangkApp(_authed_state(token=lambda: None))
+    async with app.run_test():
+        await app.screen._status_loop()  # no token -> early return
+
+
+async def test_status_loop_handles_disconnect(monkeypatch):
+    async def boom(*a, **k):
+        raise RuntimeError("ws died")
+
+    monkeypatch.setattr(scr, "listen_for_status", boom)
+    app = KlangkApp(_authed_state())
+    async with app.run_test() as pilot:
+        await app.screen._status_loop()
+        await pilot.pause()
+        assert app.live_extra == "status: disconnected"
+
+
+async def test_login_password_flow_success(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+
+    def fake_login(identifier, password):
+        st.is_authenticated = lambda: True
+        st.email = lambda: identifier
+        st.token = lambda: "tok"
+        return identifier
+
+    st = _st(
+        is_authenticated=lambda: False,
+        auth_mode=lambda: "password",
+        current_url=lambda: "https://x.example",
+        email=lambda: None,
+        token=lambda: None,
+        known_servers=lambda: [],
+        login_password=fake_login,
+    )
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        login = app.screen
+        login.query_one("#identifier", Input).value = "me@x"
+        login.query_one("#password", Input).value = "pw"
+        login._attempt_password()
+        await pilot.pause()
+        assert isinstance(app.screen, MainScreen)
+
+
+async def test_login_password_flow_empty_and_fail():
+    st = _st(
+        is_authenticated=lambda: False,
+        auth_mode=lambda: "password",
+        current_url=lambda: "https://x.example",
+        email=lambda: None,
+        token=lambda: None,
+    )
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        login = app.screen
+        login._attempt_password()  # empty fields
+        await pilot.pause()
+        assert "required" in str(login.query_one("#message").render())
+
+        st.login_password = lambda a, b: (_ for _ in ()).throw(
+            LoginError("bad creds")
+        )
+        login.query_one("#identifier", Input).value = "me@x"
+        login.query_one("#password", Input).value = "pw"
+        login._attempt_password()
+        await pilot.pause()
+        assert "bad creds" in str(login.query_one("#message").render())
+        assert isinstance(app.screen, LoginScreen)
+
+
+async def test_login_input_submitted_triggers_password(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+
+    def fake_login(identifier, password):
+        st.is_authenticated = lambda: True
+        st.email = lambda: identifier
+        st.token = lambda: "tok"
+        return identifier
+
+    st = _st(
+        is_authenticated=lambda: False,
+        auth_mode=lambda: "password",
+        current_url=lambda: "https://x.example",
+        email=lambda: None,
+        token=lambda: None,
+        known_servers=lambda: [],
+        login_password=fake_login,
+    )
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        login = app.screen
+        ident = login.query_one("#identifier", Input)
+        ident.value = "me@x"
+        login.query_one("#password", Input).value = "pw"
+        login.on_input_submitted(Input.Submitted(ident, ident.value))
+        await pilot.pause()
+        assert isinstance(app.screen, MainScreen)
+
+
+async def test_login_oidc_flow(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+
+    # success
+    def fake_oidc(provider_id):
+        st.is_authenticated = lambda: True
+        st.token = lambda: "otok"
+        st.email = lambda: "oidc@x"
+
+    st = _st(
+        is_authenticated=lambda: False,
+        auth_mode=lambda: "oidc",
+        current_url=lambda: "https://x.example",
+        email=lambda: None,
+        token=lambda: None,
+        oidc_providers=lambda: [{"id": "google"}],
+        oidc_login=fake_oidc,
+    )
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.screen._attempt_oidc()
+        await pilot.pause()
+        assert isinstance(app.screen, MainScreen)
+
+    # no providers -> message
+    st2 = _st(
+        is_authenticated=lambda: False,
+        auth_mode=lambda: "oidc",
+        current_url=lambda: "https://x.example",
+        email=lambda: None,
+        token=lambda: None,
+        oidc_providers=lambda: [],
+    )
+    app2 = KlangkApp(st2)
+    async with app2.run_test() as pilot:
+        app2.screen._attempt_oidc()
+        await pilot.pause()
+        assert "SSO provider" in str(
+            app2.screen.query_one("#message").render()
+        )
+
+    # failure -> message
+    st3 = _st(
+        is_authenticated=lambda: False,
+        auth_mode=lambda: "oidc",
+        current_url=lambda: "https://x.example",
+        email=lambda: None,
+        token=lambda: None,
+        oidc_providers=lambda: [{"id": "google"}],
+        oidc_login=lambda pid: (_ for _ in ()).throw(LoginError("nope")),
+    )
+    app3 = KlangkApp(st3)
+    async with app3.run_test() as pilot:
+        app3.screen._attempt_oidc()
+        await pilot.pause()
+        assert "SSO failed" in str(app3.screen.query_one("#message").render())
+
+
+async def test_login_unreachable_mode():
+    st = _st(
+        is_authenticated=lambda: False,
+        auth_mode=lambda: "unreachable",
+        current_url=lambda: "https://x.example",
+        email=lambda: None,
+        token=lambda: None,
+    )
+    app = KlangkApp(st)
+    async with app.run_test():
+        assert "Cannot reach" in str(app.screen.query_one("#notice").render())
+
+
+async def test_logout_returns_to_login(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    called = {"out": False}
+
+    def fake_logout():
+        called["out"] = True
+        st.is_authenticated = lambda: False
+        st.token = lambda: None
+
+    st = _authed_state(logout=fake_logout)
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        assert isinstance(app.screen, MainScreen)
+        app.do_logout()
+        await pilot.pause()
+        assert isinstance(app.screen, LoginScreen)
+    assert called["out"] is True
+
+
+async def test_server_switch_and_add(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+
+    # switch screen with servers -> selecting one switches + returns to main
+    st = _authed_state(
+        known_servers=lambda: [
+            tui_state_mod.ServerInfo("a", "https://a.example"),
+            tui_state_mod.ServerInfo("b", "https://b.example"),
+        ],
+        current_url=lambda: "https://a.example",
+    )
+    switched = {}
+    st.switch_server = lambda url: switched.setdefault("url", url)
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(ServerSwitchScreen())
+        await pilot.pause()
+        assert isinstance(app.screen, ServerSwitchScreen)
+        app.screen.on_option_list_option_selected(
+            FakeOptionSelected("https://b.example")
+        )
+        await pilot.pause()
+        assert switched["url"] == "https://b.example"
+        assert isinstance(app.screen, MainScreen)
+
+    # switch screen with no servers -> hint message
+    app2 = KlangkApp(_authed_state(known_servers=lambda: []))
+    async with app2.run_test() as pilot:
+        app2.push_screen(ServerSwitchScreen())
+        await pilot.pause()
+        assert "No servers" in str(
+            app2.screen.query_one("#switch_msg").render()
+        )
+
+    # add server screen -> add succeeds, returns to main
+    st3 = _authed_state()
+    added = {}
+    st3.add_server = lambda alias, url, user=None: added.setdefault(
+        "a", (alias, url)
+    )
+    app3 = KlangkApp(st3)
+    async with app3.run_test() as pilot:
+        app3.push_screen(AddServerScreen())
+        await pilot.pause()
+        add_screen = app3.screen
+        add_screen.query_one("#alias", Input).value = "prod"
+        add_screen.query_one("#url", Input).value = "https://p.example"
+        add_screen._add()
+        await pilot.pause()
+        assert added["a"] == ("prod", "https://p.example")
+        assert isinstance(app3.screen, MainScreen)
+
+    # add server with empty fields -> error message
+    app4 = KlangkApp(_authed_state())
+    async with app4.run_test() as pilot:
+        app4.push_screen(AddServerScreen())
+        await pilot.pause()
+        app4.screen._add()
+        await pilot.pause()
+        assert "required" in str(app4.screen.query_one("#add_msg").render())
+
+
+# ---------------------------------------------------------------------------
+# run_tui + bare-klangk launch wiring
+# ---------------------------------------------------------------------------
+
+
+async def test_login_button_dispatch_and_oidc_incomplete(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+
+    # password success routed through on_button_pressed (#login)
+    def fake_login(identifier, password):
+        st.is_authenticated = lambda: True
+        st.email = lambda: identifier
+        st.token = lambda: "tok"
+        return identifier
+
+    st = _st(
+        is_authenticated=lambda: False,
+        auth_mode=lambda: "password",
+        current_url=lambda: "https://x.example",
+        email=lambda: None,
+        token=lambda: None,
+        known_servers=lambda: [],
+        login_password=fake_login,
+    )
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        login = app.screen
+        login.query_one("#identifier", Input).value = "me@x"
+        login.query_one("#password", Input).value = "pw"
+        login.on_button_pressed(FakeBtnPress("login"))
+        await pilot.pause()
+        assert isinstance(app.screen, MainScreen)
+
+    # oidc button dispatch + "did not complete" (oidc_login no-op)
+    st2 = _st(
+        is_authenticated=lambda: False,
+        auth_mode=lambda: "oidc",
+        current_url=lambda: "https://x.example",
+        email=lambda: None,
+        token=lambda: None,
+        oidc_providers=lambda: [{"id": "google"}],
+        oidc_login=lambda pid: None,
+    )
+    app2 = KlangkApp(st2)
+    async with app2.run_test() as pilot:
+        app2.screen.on_button_pressed(FakeBtnPress("oidc"))
+        await pilot.pause()
+        assert "did not complete" in str(
+            app2.screen.query_one("#message").render()
+        )
+
+
+async def test_main_screen_actions(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    out = {"o": False}
+
+    def fake_logout():
+        out["o"] = True
+        st.is_authenticated = lambda: False
+        st.token = lambda: None
+
+    st = _authed_state(logout=fake_logout)
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        main = app.screen
+        main.action_switch_server()
+        await pilot.pause()
+        assert isinstance(app.screen, ServerSwitchScreen)
+        app.pop_screen()
+        await pilot.pause()
+        main.action_add_server()
+        await pilot.pause()
+        assert isinstance(app.screen, AddServerScreen)
+        app.pop_screen()
+        await pilot.pause()
+        main.action_logout()
+        await pilot.pause()
+        assert isinstance(app.screen, LoginScreen)
+    assert out["o"] is True
+
+
+async def test_add_server_event_handlers(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    st = _authed_state()
+    added = {}
+    st.add_server = lambda alias, url, user=None: added.setdefault(
+        "a", (alias, url)
+    )
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(AddServerScreen())
+        await pilot.pause()
+        add_screen = app.screen
+        add_screen.query_one("#alias", Input).value = "prod"
+        url_in = add_screen.query_one("#url", Input)
+        url_in.value = "https://p.example"
+        # button press dispatch
+        add_screen.on_button_pressed(FakeBtnPress("add"))
+        await pilot.pause()
+        assert added["a"] == ("prod", "https://p.example")
+        assert isinstance(app.screen, MainScreen)
+
+    # input-submitted dispatch
+    st2 = _authed_state()
+    added2 = {}
+    st2.add_server = lambda alias, url, user=None: added2.setdefault(
+        "a", (alias, url)
+    )
+    app2 = KlangkApp(st2)
+    async with app2.run_test() as pilot:
+        app2.push_screen(AddServerScreen())
+        await pilot.pause()
+        add_screen = app2.screen
+        url_in = add_screen.query_one("#url", Input)
+        url_in.value = "https://q.example"
+        add_screen.query_one("#alias", Input).value = "qa"
+        add_screen.on_input_submitted(Input.Submitted(url_in, url_in.value))
+        await pilot.pause()
+        assert added2["a"] == ("qa", "https://q.example")
+
+
+# ---------------------------------------------------------------------------
+# run_tui + bare-klangk launch wiring (original section follows)
+# ---------------------------------------------------------------------------
+
+
+def test_is_interactive_returns_bool():
+    from klangk.cli import main as cli_main
+
+    assert isinstance(cli_main._is_interactive(), bool)
+
+
+def test_run_tui_invokes_app_run(monkeypatch):
+    seen = {}
+
+    def fake_run(self):
+        seen["ran"] = True
+
+    monkeypatch.setattr(KlangkApp, "run", fake_run)
+    run_tui()
+    assert seen["ran"] is True
+
+
+def test_bare_klangk_non_tty_prints_help(monkeypatch):
+    from typer.testing import CliRunner
+
+    from klangk.cli import main as cli_main
+    from klangk.cli.main import app
+
+    launched = {"v": False}
+    monkeypatch.setattr(
+        tui_pkg,
+        "run_tui",
+        lambda server_url=None: launched.__setitem__("v", True),
+    )
+    monkeypatch.setattr(cli_main, "_is_interactive", lambda: False)
+
+    result = CliRunner().invoke(app, [])
+    assert result.exit_code == 0
+    assert "Usage:" in result.output
+    assert launched["v"] is False
+
+
+def test_bare_klangk_tty_launches_tui(monkeypatch):
+    from typer.testing import CliRunner
+
+    from klangk.cli import main as cli_main
+    from klangk.cli.main import app
+
+    seen = {}
+    monkeypatch.setattr(
+        tui_pkg,
+        "run_tui",
+        lambda server_url=None: seen.__setitem__("s", server_url),
+    )
+    monkeypatch.setattr(cli_main, "_is_interactive", lambda: True)
+
+    result = CliRunner().invoke(app, [])
+    assert result.exit_code == 0
+    assert seen["s"] is None
+
+
+def test_bare_klangk_tty_crash_surfaces_error(monkeypatch):
+    from typer.testing import CliRunner
+
+    from klangk.cli import main as cli_main
+    from klangk.cli.main import app
+
+    def boom(server_url=None):
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(tui_pkg, "run_tui", boom)
+    monkeypatch.setattr(cli_main, "_is_interactive", lambda: True)
+
+    result = CliRunner().invoke(app, [])
+    assert result.exit_code == 1
+    assert "TUI error" in result.output
+
+
+def test_subcommand_does_not_launch_tui(monkeypatch):
+    from typer.testing import CliRunner
+
+    from klangk.cli.main import app
+
+    launched = {"v": False}
+    monkeypatch.setattr(
+        tui_pkg,
+        "run_tui",
+        lambda server_url=None: launched.__setitem__("v", True),
+    )
+    CliRunner().invoke(app, ["logout"])
+    assert launched["v"] is False

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -9,11 +9,16 @@ from __future__ import annotations
 
 import httpx
 import pytest
-from textual.widgets import Input
+from textual.widgets import Button, Input
 
 from klangk.cli import config as cfgmod
 from klangk.cli import tui as tui_pkg
-from klangk.cli.config import CLIConfig, CLIState, add_server_to_config
+from klangk.cli.config import (
+    CLIConfig,
+    CLIState,
+    ServerEntry,
+    add_server_to_config,
+)
 from klangk.cli.tui import screens as scr
 from klangk.cli.tui import state as tui_state_mod
 from klangk.cli.tui import ws as ws_mod
@@ -391,7 +396,8 @@ async def test_app_none_mode_auto_logs_in():
         known_servers=lambda: [],
     )
     app = KlangkApp(st)
-    async with app.run_test():
+    async with app.run_test() as pilot:
+        await pilot.pause()  # let the deferred no-auth login run
         assert isinstance(app.screen, MainScreen)
     assert flag["ok"] is True
 
@@ -409,8 +415,12 @@ async def test_app_none_mode_failure_falls_back_to_login():
         token=lambda: None,
     )
     app = KlangkApp(st)
-    async with app.run_test():
+    async with app.run_test() as pilot:
+        await pilot.pause()  # deferred no-auth attempt runs + fails
         assert isinstance(app.screen, LoginScreen)
+        assert "No-auth login failed" in str(
+            app.screen.query_one("#message").render()
+        )
 
 
 async def test_main_screen_renders_status(monkeypatch):
@@ -717,6 +727,114 @@ async def test_server_switch_and_add(monkeypatch):
 
 # ---------------------------------------------------------------------------
 # run_tui + bare-klangk launch wiring
+# ---------------------------------------------------------------------------
+
+
+def test_current_url_and_default_uds_pick_up_udsk(
+    monkeypatch, redirect_xdg, tmp_path
+):
+    sock = tmp_path / "klangk.sock"
+    sock.touch()
+    monkeypatch.setattr(
+        tui_state_mod, "default_server_uds_path", lambda: str(sock)
+    )
+    # no active server + no override -> the co-located UDS is used
+    assert TuiState().current_url() == str(sock)
+    assert TuiState().default_uds() == str(sock)
+    # override still wins over the UDS fallback
+    assert TuiState("https://other").current_url() == "https://other"
+
+
+def test_derive_alias():
+    assert (
+        LoginScreen._derive_alias("https://newhost.example/x")
+        == "newhost.example"
+    )
+    # scheme but no host -> falls back to the path tail
+    assert LoginScreen._derive_alias("file:///some/path") == "path"
+    # bare socket path -> tail
+    assert LoginScreen._derive_alias("/a/b/sock") == "sock"
+    # bare name -> itself
+    assert LoginScreen._derive_alias("justname") == "justname"
+    # empty after strip -> generic fallback
+    assert LoginScreen._derive_alias("/") == "server"
+
+
+async def test_login_server_picker(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+
+    cfg = CLIConfig()
+    cfg.servers = {"prod": ServerEntry(url="https://prod.example")}
+    calls = {}
+
+    st = _st(
+        current_url=lambda: None,
+        known_servers=lambda: [
+            tui_state_mod.ServerInfo("prod", "https://prod.example")
+        ],
+        default_uds=lambda: "/tmp/klangk.sock",
+        cfg=lambda: cfg,
+        auth_mode=lambda: "password",
+        email=lambda: None,
+        token=lambda: None,
+        is_authenticated=lambda: False,
+        switch_server=lambda url: calls.__setitem__("switch", url),
+        add_server=lambda alias, url, user=None: calls.__setitem__(
+            "add", (alias, url)
+        ),
+    )
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        login = app.screen
+        # no-server branch: prompt + disabled credentials
+        assert "No server selected" in str(
+            login.query_one("#server_line").render()
+        )
+        assert login.query_one("#login", Button).disabled
+
+        # empty choice -> error message
+        login._choose_server("   ")
+        await pilot.pause()
+        assert "Enter a server URL" in str(
+            login.query_one("#message").render()
+        )
+
+        # known alias -> switch (routed through the option-selected handler)
+        login.on_option_list_option_selected(FakeOptionSelected("prod"))
+        await pilot.pause()
+        assert calls.get("switch") == "https://prod.example"
+
+        # new URL -> added as an alias derived from its host
+        login._choose_server("https://newhost.example/x")
+        await pilot.pause()
+        assert calls.get("add") == (
+            "newhost.example",
+            "https://newhost.example/x",
+        )
+
+        # UDS path -> switch without persisting an alias
+        srv_input = login.query_one("#server_input", Input)
+        srv_input.value = "/tmp/klangk.sock"
+        login.on_input_submitted(Input.Submitted(srv_input, srv_input.value))
+        await pilot.pause()
+        assert calls.get("switch") == "/tmp/klangk.sock"
+
+        # "Use server" button also dispatches
+        srv_input.value = "prod"
+        login.on_button_pressed(FakeBtnPress("use_server"))
+        await pilot.pause()
+        assert calls.get("switch") == "https://prod.example"
+
+        # after a successful pick the server line + enabled creds reflect it
+        assert "Server:" in str(login.query_one("#server_line").render())
+        assert not login.query_one("#login", Button).disabled
+
+
+# ---------------------------------------------------------------------------
+# run_tui + bare-klangk launch wiring (continued)
 # ---------------------------------------------------------------------------
 
 

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import httpx
 import pytest
-from textual.widgets import Button, Input
+from textual.widgets import Button, Input, OptionList
 
 from klangk.cli import config as cfgmod
 from klangk.cli import tui as tui_pkg
@@ -815,12 +815,12 @@ async def test_login_server_picker(monkeypatch):
             "https://newhost.example/x",
         )
 
-        # UDS path -> switch without persisting an alias
+        # UDS path -> also persisted as an alias (basename)
         srv_input = login.query_one("#server_input", Input)
-        srv_input.value = "/tmp/klangk.sock"
+        srv_input.value = "/var/run/other.sock"
         login.on_input_submitted(Input.Submitted(srv_input, srv_input.value))
         await pilot.pause()
-        assert calls.get("switch") == "/tmp/klangk.sock"
+        assert calls.get("add") == ("other.sock", "/var/run/other.sock")
 
         # "Use server" button also dispatches
         srv_input.value = "prod"
@@ -831,6 +831,31 @@ async def test_login_server_picker(monkeypatch):
         # after a successful pick the server line + enabled creds reflect it
         assert "Server:" in str(login.query_one("#server_line").render())
         assert not login.query_one("#login", Button).disabled
+
+
+async def test_populate_servers_dedups_default_udsk(monkeypatch):
+    """The auto-detected default UDS isn't double-listed when an alias
+    already points at it (after the user persisted it)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    uds = "/tmp/klangk.sock"
+    st = _st(
+        current_url=lambda: None,
+        known_servers=lambda: [tui_state_mod.ServerInfo("local", uds)],
+        default_uds=lambda: uds,
+        auth_mode=lambda: "password",
+        email=lambda: None,
+        token=lambda: None,
+        is_authenticated=lambda: False,
+    )
+    app = KlangkApp(st)
+    async with app.run_test():
+        ol = app.screen.query_one("#server_options", OptionList)
+        # only the persisted alias row; no separate "Local klangkd (UDS)" row
+        assert len(ol._options) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -853,7 +853,7 @@ async def test_login_server_picker(monkeypatch):
         await pilot.pause()
         assert calls.get("add") == ("other.sock", "/var/run/other.sock")
 
-        # "Use server" button also dispatches
+        # "Add server" button also dispatches
         srv_input.value = "prod"
         login.on_button_pressed(FakeBtnPress("use_server"))
         await pilot.pause()

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import httpx
 import pytest
-from textual.widgets import Button, Input, OptionList
+from textual.widgets import Button, Input, OptionList, Static
 
 from klangk.cli import config as cfgmod
 from klangk.cli import tui as tui_pkg
@@ -26,6 +26,7 @@ from klangk.cli.tui import ws as ws_mod
 from klangk.cli.tui.app import KlangkApp, run_tui
 from klangk.cli.tui.screens import (
     AddServerScreen,
+    ConfirmScreen,
     LoginScreen,
     MainScreen,
     ServerSwitchScreen,
@@ -888,6 +889,35 @@ async def test_populate_servers_dedups_default_udsk(monkeypatch):
         assert len(ol._options) == 1
 
 
+async def test_confirm_screen(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    captured = {}
+    app = KlangkApp(_authed_state())
+    async with app.run_test() as pilot:
+        app.push_screen(
+            ConfirmScreen("Delete X?"),
+            lambda r: captured.__setitem__("r", r),
+        )
+        await pilot.pause()
+        assert isinstance(app.screen, ConfirmScreen)
+        # Cancel -> False
+        app.screen.on_button_pressed(FakeBtnPress("no"))
+        await pilot.pause()
+        assert captured.get("r") is False
+        # Delete -> True
+        app.push_screen(
+            ConfirmScreen("Delete X?"),
+            lambda r: captured.__setitem__("r2", r),
+        )
+        await pilot.pause()
+        app.screen.on_button_pressed(FakeBtnPress("yes"))
+        await pilot.pause()
+        assert captured.get("r2") is True
+
+
 async def test_login_delete_server(monkeypatch):
     async def noop(*a, **k):
         return None
@@ -913,21 +943,38 @@ async def test_login_delete_server(monkeypatch):
     async with app.run_test() as pilot:
         login = app.screen
         ol = login.query_one("#server_options", OptionList)
-        # nothing highlighted -> prompt to select
+        # nothing highlighted -> prompt to select (no dialog)
         ol.highlighted = None
         login.action_delete_server()
         await pilot.pause()
         assert "Select a server" in str(login.query_one("#message").render())
-        # highlight + delete -> delete_server called, success message
+        # highlight + action -> confirm dialog (not yet deleted)
         ol.highlighted = 0
         login.action_delete_server()
         await pilot.pause()
+        assert isinstance(app.screen, ConfirmScreen)
+        assert "https://prod.example" in str(
+            app.screen.query_one(Static).render()
+        )
+        assert "u" not in deleted
+        # cancel -> not deleted
+        app.screen.dismiss(False)
+        await pilot.pause()
+        assert "u" not in deleted
+        # confirm -> deleted
+        ol.highlighted = 0
+        login.action_delete_server()
+        await pilot.pause()
+        app.screen.dismiss(True)
+        await pilot.pause()
         assert deleted.get("u") == "https://prod.example"
         assert "Server deleted" in str(login.query_one("#message").render())
-        # delete returns False -> "Not a saved alias"
+        # confirm but delete returns False -> "Not a saved alias"
         st.delete_server = lambda url: False
         ol.highlighted = 0
         login.action_delete_server()
+        await pilot.pause()
+        app.screen.dismiss(True)
         await pilot.pause()
         assert "Not a saved alias" in str(login.query_one("#message").render())
 
@@ -963,7 +1010,8 @@ async def test_login_delete_clears_to_no_server(monkeypatch):
         ol.highlighted = 0
         login.action_delete_server()
         await pilot.pause()
-        # current_url now None -> no-server state
+        app.screen.dismiss(True)
+        await pilot.pause()
         assert "No server selected" in str(
             login.query_one("#server_line").render()
         )
@@ -987,14 +1035,25 @@ async def test_switch_screen_delete_server(monkeypatch):
         await pilot.pause()
         switch = app.screen
         ol = switch.query_one("#server_options", OptionList)
-        # nothing highlighted -> no-op
+        # nothing highlighted -> no dialog, no delete
         ol.highlighted = None
         switch.action_delete_server()
         await pilot.pause()
+        assert app.screen is switch
         assert "u" not in deleted
-        # highlight + delete
+        # highlight + action -> dialog; cancel -> not deleted
         ol.highlighted = 0
         switch.action_delete_server()
+        await pilot.pause()
+        assert isinstance(app.screen, ConfirmScreen)
+        app.screen.dismiss(False)
+        await pilot.pause()
+        assert "u" not in deleted
+        # confirm -> deleted
+        ol.highlighted = 0
+        switch.action_delete_server()
+        await pilot.pause()
+        app.screen.dismiss(True)
         await pilot.pause()
         assert deleted.get("u") == "https://prod.example"
 

--- a/src/klangk/pyproject.toml
+++ b/src/klangk/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "logfire[fastapi]>=3.0.0",
     "pyyaml>=6.0",
     "httpx>=0.28.0",
+    "textual>=0.86.0",
 ]
 
 # Test toolchain — opt in via `pip install klangk[test]` or

--- a/uv.lock
+++ b/uv.lock
@@ -656,6 +656,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "starlette" },
+    { name = "textual" },
     { name = "typer" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "websockets" },
@@ -691,11 +692,24 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0" },
     { name = "starlette", specifier = ">=1.3.1" },
+    { name = "textual", specifier = ">=0.86.0" },
     { name = "typer", specifier = ">=0.12.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
     { name = "websockets", specifier = ">=14.0" },
 ]
 provides-extras = ["test"]
+
+[[package]]
+name = "linkify-it-py"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "uc-micro-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2e/c9/06ea13676ef354f0af6169587ae292d3e2406e212876a413bf9eece4eb23/linkify_it_py-2.1.0.tar.gz", hash = "sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b", size = 29158, upload-time = "2026-03-01T07:48:47.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/de/88b3be5c31b22333b3ca2f6ff1de4e863d8fe45aaea7485f591970ec1d3e/linkify_it_py-2.1.0-py3-none-any.whl", hash = "sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e", size = 19878, upload-time = "2026-03-01T07:48:46.098Z" },
+]
 
 [[package]]
 name = "logfire"
@@ -730,6 +744,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[package.optional-dependencies]
+linkify = [
+    { name = "linkify-it-py" },
 ]
 
 [[package]]
@@ -793,6 +812,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114, upload-time = "2026-05-13T09:03:38.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl", hash = "sha256:214c82fb2ac524472ab6a5bcab1de80f73b50443e187f401bfd77efbc7c6481d", size = 66663, upload-time = "2026-05-13T09:03:37.76Z" },
 ]
 
 [[package]]
@@ -948,6 +979,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/9b/560e4be8e26f6fd133a03630a8df0c663b9e8d61b4ade152b72005aec83b/platformdirs-4.11.0.tar.gz", hash = "sha256:0555d18370482847566ffabcaa53ad7c6c1c29f195989ae1ed634a05f76ea1e0", size = 31953, upload-time = "2026-07-21T13:09:36.565Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/68/d8d58938dfb1370b266a1a729e6d77a985be23689a0496498ee17b2cbf90/platformdirs-4.11.0-py3-none-any.whl", hash = "sha256:360ccded2b7fce0af0ff80cc8f5942a1c5d99b0e856033acb030bfc634709e74", size = 23247, upload-time = "2026-07-21T13:09:35.422Z" },
 ]
 
 [[package]]
@@ -1374,6 +1414,23 @@ wheels = [
 ]
 
 [[package]]
+name = "textual"
+version = "8.2.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py", extra = ["linkify"] },
+    { name = "mdit-py-plugins" },
+    { name = "platformdirs" },
+    { name = "pygments" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/21/39a76b01bd5eea82a04baaca7580e105d8c59450df03998345bb2cfb307b/textual-8.2.8.tar.gz", hash = "sha256:3f106a9fbc73e39dd266c9712432087de78a6d644084c7c241d6a25c3169115b", size = 1860502, upload-time = "2026-06-30T06:51:24.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/be/35261223d9416a0751cdff1c7b4a6f881387218a12d439fe22fefebc8c04/textual-8.2.8-py3-none-any.whl", hash = "sha256:267375fd402dc8d981457212efa71f0e3365fd17bba144ba9bb3ed7563cb374a", size = 731418, upload-time = "2026-06-30T06:51:26.364Z" },
+]
+
+[[package]]
 name = "typer"
 version = "0.26.7"
 source = { registry = "https://pypi.org/simple" }
@@ -1407,6 +1464,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uc-micro-py"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/67/9a363818028526e2d4579334460df777115bdec1bb77c08f9db88f6389f2/uc_micro_py-2.0.0.tar.gz", hash = "sha256:c53691e495c8db60e16ffc4861a35469b0ba0821fe409a8a7a0a71864d33a811", size = 6611, upload-time = "2026-03-01T06:31:27.526Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/73/d21edf5b204d1467e06500080a50f79d49ef2b997c79123a536d4a17d97c/uc_micro_py-2.0.0-py3-none-any.whl", hash = "sha256:3603a3859af53e5a39bc7677713c78ea6589ff188d70f4fee165db88e22b242c", size = 6383, upload-time = "2026-03-01T06:31:26.257Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements the **TUI foundation** for the `klangk` client (#1746) — the prerequisite for every other sub-issue under the tracking epic #1743. A bare `klangk` invocation on a real terminal now opens a textual app shell; all subcommands keep working exactly as before.

## What's in this PR

- **Entry point**: `invoke_without_command` + a TTY-gated `_maybe_launch_tui`. Bare `klangk` on a terminal launches the TUI; in non-interactive contexts (pipes, CI, `CliRunner`) it keeps printing help. The `textual` import is deferred (`# noqa: allow-deferred-import`) so it never loads on subcommand paths (`klangk ls`, `klangk shell`, …).
- **`cli/tui/` package**:
  - `KlangkApp` (textual) pushing `LoginScreen` or `MainScreen` depending on auth state.
  - `LoginScreen` adapting to the server's auth mode — local/password form, no-auth auto-login, OIDC hand-off to `klangk login`, and an unreachable diagnostic.
  - `MainScreen` shell with `StatusBar` + `Sidebar` and keybindings for switch/add server and logout.
  - `ServerSwitchScreen` / `AddServerScreen` — switch among known aliases **and** add a new one in-app.
  - `TuiState` — a live bridge that re-reads `CLIConfig`/`CLIState` on every access (no stale snapshots, mirroring the server's `app`-ownership discipline).
  - `ws.listen_for_status` — a lean worker that streams the same `/ws` broadcasts the web UI and `klangk monitor` consume, updating the status bar live.
- **`config.add_server_to_config`** — merges a new alias into `klangk.yaml` for the add-server flow.
- **`textual`** added as a runtime dependency.

Stays within `klangk.cli` (isolation rule): only stdlib, third-party deps, and sibling `cli` modules.

## Acceptance criteria (#1746)

- [x] Bare `klangk` opens a navigable TUI; subcommands behave exactly as today.
- [x] In-TUI login (local/password); OIDC servers hand off to `klangk login`.
- [x] Live server switching + add-alias.
- [x] Live workspace/container status via WebSocket subscription.
- [x] Pilot test harness in place.

## Testing

New code is fully covered — the full `klangkd` + `klangkc` suite passes at **100% coverage** (`python -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -n auto`). The TUI screens are driven with textual's `Pilot.run_test()` against a stubbed client/state (no live network).

`ruff check` / `ruff format` clean; pre-commit hooks pass.

## Out of scope (later sub-issues)

Workspace list/create/edit, account settings, membership, shell hand-off, management panels, sandbox, import/export, and admin — those are tracked under #1743 (and #1744 for admin). This PR lands only the app shell they hang off.

Closes #1746.
