### PR TITLE
feat(cli/tui): workspace create form (#1748)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -78,6 +78,18 @@ operators or integrators to act when upgrading.
   field on the workspace create/update API. See
   [Egress Filtering](https://klangk.dev/features/egress-filtering).
 
+- **The `klangk` TUI can create workspaces from a full create form (#1748).**
+  Press `n` on the workspace list to open a form mirroring the Flutter
+  `CreateWorkspaceDialog`: name, a container-image picker populated from
+  `/api/v1/images`, add/remove mounts and environment-variable editors, an
+  optional service shell command and health-check command, and an auto-start
+  checkbox (shown only when the server permits it, off by default). Mounts
+  (`source:/container[:opts]`) and env (`KEY=VALUE`) are validated client-side
+  with the same rules as the CLI `create` command. If the image list can't be
+  fetched the form still works (the server applies its default image). After a
+  successful create the list refreshes and the TUI offers to open the new
+  workspace; a live in-TUI shell session is a future step.
+
 - **The `features_config:` block now accepts the stripped, lowercased key form
   (`soliplex_url`) in addition to the full declared name
   (`KLANGKWS_FEATURE_SOLIPLEX_URL`) (#1737).** The short form matches the key the

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -84,11 +84,20 @@ operators or integrators to act when upgrading.
   `/api/v1/images`, add/remove mounts and environment-variable editors, an
   optional service shell command and health-check command, and an auto-start
   checkbox (shown only when the server permits it, off by default). Mounts
-  (`source:/container[:opts]`) and env (`KEY=VALUE`) are validated client-side
-  with the same rules as the CLI `create` command. If the image list can't be
-  fetched the form still works (the server applies its default image). After a
+  (`source:/container[:opts]`) and env (`KEY=VALUE`) are validated client-side,
+  matching the Flutter create dialog (the CLI `create` is marginally looser
+  on env keys). All user-facing text — including the image-picker entries
+  (sourced from the server) and the create-result message — renders via rich
+  `Text`, so a name/image/message containing bracket characters can't crash
+  the TUI; a non-JSON server error body is handled gracefully instead of
+  crashing. If the image list can't be
+  fetched the form still works (the server applies its default image; if the
+  server's default isn't in the allowed list the picker starts unselected and
+  an untouched picker omits the image, matching the Flutter dialog). After a
   successful create the list refreshes and the TUI offers to open the new
-  workspace; a live in-TUI shell session is a future step.
+  workspace's detail screen (where its terminals are listed); a live in-TUI
+  PTY shell session is a future step, so #1748's "open shell now" bullet is
+  satisfied as "open workspace" for now.
 
 - **The `features_config:` block now accepts the stripped, lowercased key form
   (`soliplex_url`) in addition to the full declared name

--- a/src/klangk/klangk/cli/client.py
+++ b/src/klangk/klangk/cli/client.py
@@ -174,6 +174,7 @@ class Workspace:
     mounts: list[str] | None = None
     env: dict[str, str] | None = None
     health_check: str | None = None
+    allowed_domains: list[str] | None = None
     owner_email: str | None = None
     running: bool = False
     health: str | None = None
@@ -425,6 +426,7 @@ class KlangkClient:
             running=bool(w.get("running", False)),
             health=w.get("health"),
             health_message=w.get("health_message"),
+            allowed_domains=w.get("allowed_domains"),
         )
 
     def create_workspace(
@@ -437,6 +439,7 @@ class KlangkClient:
         env: dict[str, str] | None = None,
         setup_state: str | None = None,
         health_check: str | None = None,
+        allowed_domains: list[str] | None = None,
     ) -> Workspace:
         body: dict = {"name": name}
         if image:
@@ -453,6 +456,8 @@ class KlangkClient:
             body["setup_state"] = setup_state
         if health_check:
             body["health_check"] = health_check
+        if allowed_domains:
+            body["allowed_domains"] = allowed_domains
         resp = self.post("/api/v1/workspaces", json=body)
         self.check_auth(resp)
         self._raise_for_status(resp)
@@ -460,6 +465,18 @@ class KlangkClient:
         return Workspace(
             id=w["id"], name=w["name"], created_at=w["created_at"]
         )
+
+    def update_workspace(self, workspace_id: str, **fields) -> None:
+        """Partial-update workspace fields (``PUT /api/v1/workspaces/<id>``).
+
+        Only the provided keyword fields are sent. Returns ``None``; raises
+        :class:`httpx.HTTPStatusError` on a non-2xx so callers (TUI/CLI) can
+        surface the server's ``detail``. Used by the TUI edit form (#1778);
+        the CLI ``edit`` command still PUTs inline (#1779 will adopt this).
+        """
+        resp = self.put(f"/api/v1/workspaces/{workspace_id}", json=fields)
+        self.check_auth(resp)
+        self._raise_for_status(resp)
 
     def set_setup_state(self, workspace_id: str, setup_state: str) -> None:
         """Update a workspace's setup_state lifecycle field (#1033).

--- a/src/klangk/klangk/cli/env.py
+++ b/src/klangk/klangk/cli/env.py
@@ -1,0 +1,17 @@
+"""Client-side environment variable entry validation."""
+
+
+def validate_env_entry(spec: str) -> str | None:
+    """Validate a ``KEY=VALUE`` environment variable entry.
+
+    Returns None if valid, or an error message string if invalid.
+    Mirrors the Flutter ``CreateWorkspaceDialog`` rule: the entry must
+    contain ``=`` and have a non-empty key (the part before the first
+    ``=``). The value may be empty.
+    """
+    if "=" not in spec:
+        return f"Invalid env {spec!r}: expected KEY=VALUE"
+    key, _, _ = spec.partition("=")
+    if not key:
+        return f"Invalid env {spec!r}: key cannot be empty"
+    return None

--- a/src/klangk/klangk/cli/mount.py
+++ b/src/klangk/klangk/cli/mount.py
@@ -17,22 +17,6 @@ _VALID_MOUNT_OPTIONS = {
 }
 
 
-def validate_env_entry(spec: str) -> str | None:
-    """Validate a ``KEY=VALUE`` environment variable entry.
-
-    Returns None if valid, or an error message string if invalid.
-    Mirrors the Flutter ``CreateWorkspaceDialog`` rule: the entry must
-    contain ``=`` and have a non-empty key (the part before the first
-    ``=``). The value may be empty.
-    """
-    if "=" not in spec:
-        return f"Invalid env {spec!r}: expected KEY=VALUE"
-    key, _, _ = spec.partition("=")
-    if not key:
-        return f"Invalid env {spec!r}: key cannot be empty"
-    return None
-
-
 def validate_mount_spec(spec: str) -> str | None:
     """Validate a container mount spec string.
 

--- a/src/klangk/klangk/cli/mount.py
+++ b/src/klangk/klangk/cli/mount.py
@@ -17,6 +17,22 @@ _VALID_MOUNT_OPTIONS = {
 }
 
 
+def validate_env_entry(spec: str) -> str | None:
+    """Validate a ``KEY=VALUE`` environment variable entry.
+
+    Returns None if valid, or an error message string if invalid.
+    Mirrors the Flutter ``CreateWorkspaceDialog`` rule: the entry must
+    contain ``=`` and have a non-empty key (the part before the first
+    ``=``). The value may be empty.
+    """
+    if "=" not in spec:
+        return f"Invalid env {spec!r}: expected KEY=VALUE"
+    key, _, _ = spec.partition("=")
+    if not key:
+        return f"Invalid env {spec!r}: key cannot be empty"
+    return None
+
+
 def validate_mount_spec(spec: str) -> str | None:
     """Validate a container mount spec string.
 

--- a/src/klangk/klangk/cli/mount.py
+++ b/src/klangk/klangk/cli/mount.py
@@ -5,6 +5,8 @@ by the backend.  This module only catches obvious format errors
 before sending the spec to the API.
 """
 
+import re
+
 _VALID_MOUNT_OPTIONS = {
     "ro",
     "rw",
@@ -43,4 +45,38 @@ def validate_mount_spec(spec: str) -> str | None:
         for opt in options.split(","):
             if opt and opt not in _VALID_MOUNT_OPTIONS:
                 return f"Invalid mount {spec!r}: unknown option {opt!r}"
+    return None
+
+
+# An egress allowed-domain entry: ``host`` or ``host:port`` (DNS name or
+# IPv4), or a bracketed IPv6 literal (``[::1]`` / ``[2001:db8::1]:443``).
+# This catches gross typos client-side; the server
+# (:func:`klangk.netfilter.parse_allowed_domains`) does the authoritative
+# check (#1365, #1745).
+_ALLOWED_DOMAIN_RE = re.compile(
+    r"^(?:"
+    r"\[[0-9a-fA-F:.]+\](?::\d{1,5})?"  # [ipv6] or [ipv6]:port
+    r"|"
+    r"[^\[\]/\s:]+(?::\d{1,5})?"  # host or host:port
+    r")$"
+)
+
+
+def validate_allowed_domain_spec(spec: str) -> str | None:
+    """Validate an egress allowed-domain entry (``host`` or ``host:port``).
+
+    Returns None if valid, or an error message. Accepts a DNS name or IP
+    (IPv4, or a bracketed IPv6 literal like ``[::1]`` / ``[::1]:443``),
+    optionally followed by ``:port``. Empty / whitespace / stray slashes
+    are rejected. Mirrors the Flutter ``validateAllowedDomainSpec`` and the
+    TUI editor; the server does the authoritative validation (#1365, #1745).
+    """
+    s = spec.strip()
+    if not s:
+        return f"Invalid allowed-domain {spec!r}: empty"
+    if not _ALLOWED_DOMAIN_RE.match(s):
+        return (
+            f"Invalid allowed-domain {spec!r}: "
+            "expected host or host:port (IPv6 in brackets)"
+        )
     return None

--- a/src/klangk/klangk/cli/transport.py
+++ b/src/klangk/klangk/cli/transport.py
@@ -35,8 +35,14 @@ class ServerTransport:
 def resolve_transport(server_spec: str) -> ServerTransport:
     """Classify *server_spec* as TCP (URL) or UDS (socket path).
 
-    Raises ``ValueError`` on a relative / bare non-URL value.
+    Raises ``ValueError`` on a relative / bare non-URL value, or when no
+    server is configured (``None`` / empty) — so callers' ``except ValueError``
+    handlers catch the no-server case instead of crashing on ``None.startswith``.
     """
+    if not isinstance(server_spec, str) or not server_spec:
+        raise ValueError(
+            "no server configured — run `klangk login` or pass --server."
+        )
     if server_spec.startswith("http://") or server_spec.startswith("https://"):
         # TCP — derive WS URI from the URL.
         if server_spec.startswith("http://"):

--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -6,6 +6,7 @@ from textual.app import App
 
 from .screens import (
     AddServerScreen,
+    CreateWorkspaceScreen,
     LoginScreen,
     MainScreen,
     ServerSwitchScreen,
@@ -25,7 +26,7 @@ class KlangkApp(App):
     Screen {
         align: center top;
     }
-    #login_box, #switch_box, #add_box, #detail_box, #dup_box {
+    #login_box, #switch_box, #add_box, #detail_box, #dup_box, #create_box {
         width: 96;
         max-width: 90%;
         padding: 0 2;
@@ -116,6 +117,7 @@ def run_tui(server_url: str | None = None) -> None:
 # Re-export for convenience / tests.
 __all__ = [
     "AddServerScreen",
+    "CreateWorkspaceScreen",
     "KlangkApp",
     "LoginScreen",
     "MainScreen",

--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -7,6 +7,7 @@ from textual.app import App
 from .screens import (
     AddServerScreen,
     CreateWorkspaceScreen,
+    EditWorkspaceScreen,
     LoginScreen,
     MainScreen,
     ServerSwitchScreen,
@@ -26,7 +27,7 @@ class KlangkApp(App):
     Screen {
         align: center top;
     }
-    #login_box, #switch_box, #add_box, #detail_box, #dup_box, #create_box {
+    #login_box, #switch_box, #add_box, #detail_box, #dup_box, #create_box, #edit_box {
         width: 96;
         max-width: 90%;
         padding: 0 2;
@@ -118,6 +119,7 @@ def run_tui(server_url: str | None = None) -> None:
 __all__ = [
     "AddServerScreen",
     "CreateWorkspaceScreen",
+    "EditWorkspaceScreen",
     "KlangkApp",
     "LoginScreen",
     "MainScreen",

--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -11,6 +11,7 @@ from .screens import (
     LoginScreen,
     MainScreen,
     ServerSwitchScreen,
+    WorkspaceDetailScreen,
 )
 from .state import TuiState
 
@@ -79,6 +80,33 @@ class KlangkApp(App):
             self.push_screen(MainScreen())
         else:
             self.push_screen(LoginScreen())
+
+    def _sync_title(self) -> None:
+        """Mirror the active screen in the window title (#1778).
+
+        "Klangk: workspace <name>" on the detail/edit screen, "Klangk:
+        Workspaces" on the list. Run after every push/pop (via the overrides
+        below) so returning from detail/edit to the list resets it too —
+        textual fires no show hook on pop-back, so the App owns the sync.
+        Other screens (login, server switch, …) leave the title unchanged.
+        """
+        screen = self.screen
+        if isinstance(screen, WorkspaceDetailScreen):
+            self.title = f"Klangk: workspace {screen._name}"
+        elif isinstance(screen, EditWorkspaceScreen):
+            self.title = f"Klangk: workspace {screen._ws.name}"
+        elif isinstance(screen, MainScreen):
+            self.title = "Klangk: Workspaces"
+
+    def push_screen(self, screen, *args, **kwargs):
+        result = super().push_screen(screen, *args, **kwargs)
+        self.call_after_refresh(self._sync_title)
+        return result
+
+    def pop_screen(self):
+        result = super().pop_screen()
+        self.call_after_refresh(self._sync_title)
+        return result
 
     # --- navigation hooks used by screens ---
 

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from urllib.parse import urlparse
 
+import logging
+
 import httpx
 
 from rich.text import Text
@@ -32,10 +34,13 @@ from textual.widgets.option_list import Option
 
 from .state import LoginError
 from ..client import AuthError, WorkspaceNotFoundError
-from ..mount import validate_env_entry, validate_mount_spec
+from ..env import validate_env_entry
+from ..mount import validate_mount_spec
 from ..transport import is_valid_server_spec
 from .widgets import StatusBar
 from .ws import listen_for_status
+
+logger = logging.getLogger(__name__)
 
 
 class ConfirmScreen(ModalScreen[bool]):
@@ -369,11 +374,13 @@ class MainScreen(Screen):
             data = state.list_images()
             default = data.get("default", "") or ""
             allowed = list(data.get("allowed") or [])
-        except Exception:
+        except (httpx.HTTPError, OSError, ValueError) as exc:
+            logger.debug("Could not fetch image list: %s", exc)
             default, allowed = "", []
         try:
             allow_autostart = state.allow_autostart()
-        except Exception:
+        except (httpx.HTTPError, OSError, ValueError) as exc:
+            logger.debug("Could not fetch autostart config: %s", exc)
             allow_autostart = False
         self.app.push_screen(
             CreateWorkspaceScreen(
@@ -991,13 +998,15 @@ class CreateWorkspaceScreen(Screen):
         # Send only a real, non-default selection. When the server's default
         # isn't in the allowed list we start unselected (Select.BLANK), so an
         # untouched picker omits the image — matching the Flutter dialog.
-        image = (
-            val
-            if (
-                self._allowed and val != self._default and val in self._allowed
-            )
-            else None
-        )
+        if (
+            val is Select.BLANK
+            or val is Select.NULL
+            or not self._allowed
+            or val == self._default
+        ):
+            image = None
+        else:
+            image = val
         command = self.query_one("#command", Input).value.strip() or None
         health_check = (
             self.query_one("#health_check", Input).value.strip() or None
@@ -1027,7 +1036,7 @@ class CreateWorkspaceScreen(Screen):
             # crash the TUI from inside this handler.
             try:
                 detail = exc.response.json().get("detail", exc.response.text)
-            except Exception:
+            except (ValueError, KeyError):
                 detail = exc.response.text or str(exc)
             self._msg(f"Failed to create: {detail}", error=True)
             return

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -33,9 +33,12 @@ from textual.widgets import (
 from textual.widgets.option_list import Option
 
 from .state import LoginError
-from ..client import AuthError, WorkspaceNotFoundError
+from ..client import AuthError, Workspace, WorkspaceNotFoundError
 from ..env import validate_env_entry
-from ..mount import validate_mount_spec
+from ..mount import (
+    validate_allowed_domain_spec,
+    validate_mount_spec,
+)
 from ..transport import is_valid_server_spec
 from .widgets import StatusBar
 from .ws import listen_for_status
@@ -519,6 +522,7 @@ class WorkspaceDetailScreen(Screen):
 
     BINDINGS = [
         ("escape", "app.pop_screen", "Back"),
+        ("e", "edit", "Edit"),
         ("r", "restart", "Restart"),
         ("d", "duplicate", "Duplicate"),
         ("x", "delete", "Delete"),
@@ -603,6 +607,9 @@ class WorkspaceDetailScreen(Screen):
         if ws.env:
             lines.append("environment:")
             lines.extend(f"  {k}={v}" for k, v in ws.env.items())
+        if ws.allowed_domains:
+            lines.append("allowed domains:")
+            lines.extend(f"  {d}" for d in ws.allowed_domains)
         if ws.owner_email:
             lines.append(f"owner: {ws.owner_email}")
         body.update(Text("\n".join(lines)))
@@ -611,6 +618,39 @@ class WorkspaceDetailScreen(Screen):
         self.query_one("#detail_msg", Static).update(
             Text(text, style="red" if error else "")
         )
+
+    def action_edit(self) -> None:
+        # Open the edit form pre-populated from this workspace (#1778).
+        # Images + allow_autostart are fetched here (sync, #1766 debt) so the
+        # form has them at mount time.
+        if self._ws is None:
+            return
+        state = self.app.tui_state
+        try:
+            data = state.list_images()
+            default = data.get("default", "") or ""
+            allowed = list(data.get("allowed") or [])
+        except Exception:
+            default, allowed = "", []
+        try:
+            allow_autostart = state.allow_autostart()
+        except Exception:
+            allow_autostart = False
+        self.app.push_screen(
+            EditWorkspaceScreen(
+                workspace=self._ws,
+                allowed=allowed,
+                default=default,
+                allow_autostart=allow_autostart,
+            ),
+            self._on_edited,
+        )
+
+    def _on_edited(self, saved: bool | None) -> None:
+        # Refresh the workspace after a successful edit (fields may have
+        # changed; create-time changes need a restart, offered in the form).
+        if saved:
+            self._load()
 
     def apply_status_event(self, event: dict) -> None:
         """Update running/health from a live status broadcast.
@@ -835,6 +875,7 @@ class CreateWorkspaceScreen(Screen):
         self._allow_autostart = bool(allow_autostart)
         self._mounts: list[str] = []
         self._env: dict[str, str] = {}
+        self._allowed_domains: list[str] = []
         if self._allowed:
             # Select tuples are (prompt, value). Prompts are rich Text so an
             # image name containing brackets can't trigger markup parsing.
@@ -884,6 +925,15 @@ class CreateWorkspaceScreen(Screen):
                 Button("Add", id="add_env"),
                 Button("Remove", id="rm_env"),
             ),
+            Static(
+                "Allowed Domains  (host or host:port; empty = unrestricted)"
+            ),
+            OptionList(id="allow_list"),
+            Horizontal(
+                Input(id="allow_input", placeholder="github.com:443"),
+                Button("Add", id="add_allow"),
+                Button("Remove", id="rm_allow"),
+            ),
             Static("Service shell command (optional)"),
             Input(id="command"),
             Static("Health check command (optional)"),
@@ -912,6 +962,7 @@ class CreateWorkspaceScreen(Screen):
         self.query_one("#auto_caption", Static).display = shown
         self._render_mounts()
         self._render_env()
+        self._render_allowed_domains()
 
     def _msg(self, text: str, *, error: bool = False) -> None:
         self.query_one("#create_msg", Static).update(
@@ -986,6 +1037,40 @@ class CreateWorkspaceScreen(Screen):
         del self._env[keys[idx]]
         self._render_env()
 
+    # --- allowed-domains list editor (#1745) ---
+
+    def _render_allowed_domains(self) -> None:
+        ol = self.query_one("#allow_list", OptionList)
+        ol.clear_options()
+        if not self._allowed_domains:
+            ol.add_option(Option(Text("(unrestricted)"), id="", disabled=True))
+            return
+        for i, d in enumerate(self._allowed_domains):
+            ol.add_option(Option(Text(d), id=f"a{i}"))
+
+    def _add_allowed_domain(self) -> None:
+        inp = self.query_one("#allow_input", Input)
+        v = inp.value.strip()
+        if not v:
+            return
+        err = validate_allowed_domain_spec(v)
+        if err:
+            self._msg(err, error=True)
+            return
+        if v not in self._allowed_domains:
+            self._allowed_domains.append(v)
+        inp.value = ""
+        self._msg("")
+        self._render_allowed_domains()
+
+    def _remove_allowed_domain(self) -> None:
+        ol = self.query_one("#allow_list", OptionList)
+        idx = ol.highlighted
+        if idx is None or not 0 <= idx < len(self._allowed_domains):
+            return
+        del self._allowed_domains[idx]
+        self._render_allowed_domains()
+
     # --- create ---
 
     def _create(self) -> None:
@@ -1017,6 +1102,7 @@ class CreateWorkspaceScreen(Screen):
         )
         mounts = list(self._mounts) or None
         env = dict(self._env) or None
+        allowed_domains = list(self._allowed_domains) or None
         try:
             ws = self.app.tui_state.create_workspace(
                 name,
@@ -1026,6 +1112,7 @@ class CreateWorkspaceScreen(Screen):
                 mounts=mounts,
                 env=env,
                 health_check=health_check,
+                allowed_domains=allowed_domains,
             )
         except AuthError:
             self._msg("Session expired — please log in again.", error=True)
@@ -1061,6 +1148,10 @@ class CreateWorkspaceScreen(Screen):
             self._add_env()
         elif bid == "rm_env":
             self._remove_env()
+        elif bid == "add_allow":
+            self._add_allowed_domain()
+        elif bid == "rm_allow":
+            self._remove_allowed_domain()
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
         eid = event.input.id
@@ -1068,8 +1159,346 @@ class CreateWorkspaceScreen(Screen):
             self._add_mount()
         elif eid == "env_input":
             self._add_env()
+        elif eid == "allow_input":
+            self._add_allowed_domain()
         elif eid in ("name", "command", "health_check"):
             self._create()
+
+
+class EditWorkspaceScreen(Screen):
+    """Full-screen workspace edit form (parity with Flutter
+    ``WorkspaceSettingsPanel``).
+
+    Like :class:`CreateWorkspaceScreen` but pre-populated from an existing
+    workspace, saving via a partial ``PUT``. Saving a change to a
+    container-create-time field (image / mounts / env / service_command /
+    allowed_domains) on a *running* workspace prompts a "restart needed to
+    apply" offer (#1778, #1749); ``setup_state`` / ``health_check`` propagate
+    live and never trigger it.
+    """
+
+    BINDINGS = [("escape", "app.pop_screen", "Back")]
+
+    def __init__(
+        self,
+        *,
+        workspace: Workspace,
+        allowed: list[str],
+        default: str,
+        allow_autostart: bool,
+    ) -> None:
+        super().__init__()
+        self._ws = workspace
+        self._allow_autostart = bool(allow_autostart)
+        self._default = default or ""
+        self._mounts: list[str] = list(workspace.mounts or [])
+        self._env: dict[str, str] = dict(workspace.env or {})
+        self._allowed_domains: list[str] = list(
+            workspace.allowed_domains or []
+        )
+        # Image picker: include the workspace's current image even if it
+        # isn't in the server's allowed list, pre-selected (untouched = no
+        # change). Prompts are rich Text so bracket-laden names can't crash.
+        cur = workspace.image or ""
+        opts = list(allowed)
+        if cur and cur not in opts:
+            opts.append(cur)
+        if opts:
+            self._select_options = [(Text(i), i) for i in opts]
+            self._select_value = cur if cur in opts else None
+        else:
+            self._select_options = [(Text("(none)"), "(none)")]
+            self._select_value = "(none)"
+
+    def compose(self) -> ComposeResult:
+        if self._select_value is not None:
+            image_select = Select(
+                self._select_options, value=self._select_value, id="image"
+            )
+        else:
+            image_select = Select(self._select_options, id="image")
+        yield Header(show_clock=False)
+        yield Vertical(
+            Static(Text(f"Edit workspace: {self._ws.name}"), classes="title"),
+            Static("", id="edit_msg"),
+            Static("Name"),
+            Input(value=self._ws.name or "", id="name"),
+            Static("Container image"),
+            image_select,
+            Static("Mounts  (source:/container/path[:opts])"),
+            OptionList(id="mount_list"),
+            Horizontal(
+                Input(
+                    id="mount_input",
+                    placeholder="/host/path:/container/path",
+                ),
+                Button("Add", id="add_mount"),
+                Button("Remove", id="rm_mount"),
+            ),
+            Static("Environment  (KEY=VALUE)"),
+            OptionList(id="env_list"),
+            Horizontal(
+                Input(id="env_input", placeholder="KEY=VALUE"),
+                Button("Add", id="add_env"),
+                Button("Remove", id="rm_env"),
+            ),
+            Static(
+                "Allowed Domains  (host or host:port; empty = unrestricted)"
+            ),
+            OptionList(id="allow_list"),
+            Horizontal(
+                Input(id="allow_input", placeholder="github.com:443"),
+                Button("Add", id="add_allow"),
+                Button("Remove", id="rm_allow"),
+            ),
+            Static("Service shell command (optional)"),
+            Input(value=self._ws.service_command or "", id="command"),
+            Static("Health check command (optional)"),
+            Input(value=self._ws.health_check or "", id="health_check"),
+            Checkbox("Auto start", value=self._ws.auto_start, id="auto_start"),
+            Static(
+                Text("(start this workspace when the server starts)"),
+                id="auto_caption",
+            ),
+            Horizontal(
+                Button("Cancel", id="cancel"),
+                Button("Save", id="save", variant="primary"),
+                classes="actions",
+            ),
+            id="edit_box",
+        )
+        yield Footer()
+
+    def on_mount(self) -> None:
+        shown = self._allow_autostart
+        cb = self.query_one("#auto_start", Checkbox)
+        cb.display = shown
+        cb.disabled = not shown
+        self.query_one("#auto_caption", Static).display = shown
+        self._render_mounts()
+        self._render_env()
+        self._render_allowed_domains()
+
+    def _msg(self, text: str, *, error: bool = False) -> None:
+        self.query_one("#edit_msg", Static).update(
+            Text(text, style="red" if error else "")
+        )
+
+    # --- list editors (same pattern as CreateWorkspaceScreen) ---
+
+    def _render_mounts(self) -> None:
+        ol = self.query_one("#mount_list", OptionList)
+        ol.clear_options()
+        if not self._mounts:
+            ol.add_option(Option(Text("(no mounts)"), id="", disabled=True))
+            return
+        for i, m in enumerate(self._mounts):
+            ol.add_option(Option(Text(m), id=f"m{i}"))
+
+    def _add_mount(self) -> None:
+        inp = self.query_one("#mount_input", Input)
+        v = inp.value.strip()
+        if not v:
+            return
+        err = validate_mount_spec(v)
+        if err:
+            self._msg(err, error=True)
+            return
+        self._mounts.append(v)
+        inp.value = ""
+        self._msg("")
+        self._render_mounts()
+
+    def _remove_mount(self) -> None:
+        ol = self.query_one("#mount_list", OptionList)
+        idx = ol.highlighted
+        if idx is None or not 0 <= idx < len(self._mounts):
+            return
+        del self._mounts[idx]
+        self._render_mounts()
+
+    def _render_env(self) -> None:
+        ol = self.query_one("#env_list", OptionList)
+        ol.clear_options()
+        if not self._env:
+            ol.add_option(Option(Text("(no env vars)"), id="", disabled=True))
+            return
+        for i, (k, val) in enumerate(self._env.items()):
+            ol.add_option(Option(Text(f"{k}={val}"), id=f"e{i}"))
+
+    def _add_env(self) -> None:
+        inp = self.query_one("#env_input", Input)
+        v = inp.value.strip()
+        if not v:
+            return
+        err = validate_env_entry(v)
+        if err:
+            self._msg(err, error=True)
+            return
+        key, _, value = v.partition("=")
+        self._env[key] = value
+        inp.value = ""
+        self._msg("")
+        self._render_env()
+
+    def _remove_env(self) -> None:
+        ol = self.query_one("#env_list", OptionList)
+        idx = ol.highlighted
+        keys = list(self._env)
+        if idx is None or not 0 <= idx < len(keys):
+            return
+        del self._env[keys[idx]]
+        self._render_env()
+
+    def _render_allowed_domains(self) -> None:
+        ol = self.query_one("#allow_list", OptionList)
+        ol.clear_options()
+        if not self._allowed_domains:
+            ol.add_option(Option(Text("(unrestricted)"), id="", disabled=True))
+            return
+        for i, d in enumerate(self._allowed_domains):
+            ol.add_option(Option(Text(d), id=f"a{i}"))
+
+    def _add_allowed_domain(self) -> None:
+        inp = self.query_one("#allow_input", Input)
+        v = inp.value.strip()
+        if not v:
+            return
+        err = validate_allowed_domain_spec(v)
+        if err:
+            self._msg(err, error=True)
+            return
+        if v not in self._allowed_domains:
+            self._allowed_domains.append(v)
+        inp.value = ""
+        self._msg("")
+        self._render_allowed_domains()
+
+    def _remove_allowed_domain(self) -> None:
+        ol = self.query_one("#allow_list", OptionList)
+        idx = ol.highlighted
+        if idx is None or not 0 <= idx < len(self._allowed_domains):
+            return
+        del self._allowed_domains[idx]
+        self._render_allowed_domains()
+
+    # --- save ---
+
+    def _save(self) -> None:
+        name = self.query_one("#name", Input).value.strip()
+        if not name:
+            self._msg("Name is required.", error=True)
+            return
+        sel = self.query_one("#image", Select)
+        val = sel.value
+        image = val if (val and val != "(none)") else None
+        command = self.query_one("#command", Input).value.strip() or None
+        health_check = (
+            self.query_one("#health_check", Input).value.strip() or None
+        )
+        auto = (
+            self._allow_autostart
+            and self.query_one("#auto_start", Checkbox).value
+        )
+        mounts = list(self._mounts) or None
+        env = dict(self._env) or None
+        allowed_domains = list(self._allowed_domains) or None
+        body = {
+            "name": name,
+            "image": image,
+            "service_command": command,
+            "health_check": health_check,
+            "auto_start": auto,
+            "mounts": mounts,
+            "env": env,
+            "allowed_domains": allowed_domains,
+        }
+        # Restart needed iff a container-create-time field changed on a
+        # running workspace (#1749). setup_state/health_check propagate
+        # live and are intentionally excluded from this check.
+        ws = self._ws
+        orig_mounts = list(ws.mounts or []) or None
+        orig_env = dict(ws.env or {}) or None
+        orig_domains = list(ws.allowed_domains or []) or None
+        restart_needed = bool(ws.running) and (
+            (image or None) != (ws.image or None)
+            or mounts != orig_mounts
+            or env != orig_env
+            or (command or None) != (ws.service_command or None)
+            or allowed_domains != orig_domains
+        )
+        try:
+            self.app.tui_state.update_workspace(ws.id, **body)
+        except AuthError:
+            self._msg("Session expired — please log in again.", error=True)
+            return
+        except httpx.HTTPStatusError as exc:
+            try:
+                detail = exc.response.json().get("detail", exc.response.text)
+            except Exception:
+                detail = exc.response.text or str(exc)
+            self._msg(f"Failed to save: {detail}", error=True)
+            return
+        except Exception as exc:
+            self._msg(f"Failed to save: {exc}", error=True)
+            return
+        if restart_needed:
+
+            def _after(restart: bool) -> None:
+                if restart:
+                    try:
+                        self.app.tui_state.restart_workspace(ws.name)
+                    except Exception as exc:
+                        self._msg(
+                            f"Saved, but restart failed: {exc}", error=True
+                        )
+                        return
+                self.dismiss(True)
+
+            self.app.push_screen(
+                ConfirmScreen(
+                    "A running container is not affected by this edit. "
+                    "Restart now to apply?",
+                    yes_label="Restart",
+                    yes_variant="warning",
+                    no_label="Skip",
+                ),
+                _after,
+            )
+        else:
+            self.dismiss(True)
+
+    # --- event handlers ---
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        bid = event.button.id
+        if bid == "cancel":
+            self.dismiss(False)
+        elif bid == "save":
+            self._save()
+        elif bid == "add_mount":
+            self._add_mount()
+        elif bid == "rm_mount":
+            self._remove_mount()
+        elif bid == "add_env":
+            self._add_env()
+        elif bid == "rm_env":
+            self._remove_env()
+        elif bid == "add_allow":
+            self._add_allowed_domain()
+        elif bid == "rm_allow":
+            self._remove_allowed_domain()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        eid = event.input.id
+        if eid == "mount_input":
+            self._add_mount()
+        elif eid == "env_input":
+            self._add_env()
+        elif eid == "allow_input":
+            self._add_allowed_domain()
+        elif eid in ("name", "command", "health_check"):
+            self._save()
 
 
 class ServerSwitchScreen(Screen):

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from urllib.parse import urlparse
 
+import httpx
+
 from rich.text import Text
 
 from textual.app import ComposeResult
@@ -16,10 +18,12 @@ from textual.containers import Horizontal, Vertical
 from textual.screen import ModalScreen, Screen
 from textual.widgets import (
     Button,
+    Checkbox,
     Footer,
     Header,
     Input,
     OptionList,
+    Select,
     Static,
     TabbedContent,
     TabPane,
@@ -28,6 +32,7 @@ from textual.widgets.option_list import Option
 
 from .state import LoginError
 from ..client import AuthError, WorkspaceNotFoundError
+from ..mount import validate_env_entry, validate_mount_spec
 from ..transport import is_valid_server_spec
 from .widgets import StatusBar
 from .ws import listen_for_status
@@ -324,6 +329,7 @@ class MainScreen(Screen):
 
     BINDINGS = [
         ("s", "switch_server", "Switch server"),
+        ("n", "create", "New"),
         ("l", "logout", "Logout"),
     ]
 
@@ -346,6 +352,43 @@ class MainScreen(Screen):
 
     def action_logout(self) -> None:
         self.app.do_logout()
+
+    def action_create(self) -> None:
+        state = self.app.tui_state
+        try:
+            data = state.list_images()
+            default = data.get("default", "") or ""
+            allowed = list(data.get("allowed") or [])
+        except Exception:
+            default, allowed = "", []
+        try:
+            allow_autostart = state.allow_autostart()
+        except Exception:
+            allow_autostart = False
+        self.app.push_screen(
+            CreateWorkspaceScreen(
+                allowed=allowed,
+                default=default,
+                allow_autostart=allow_autostart,
+            ),
+            self._on_created,
+        )
+
+    def _on_created(self, name: str | None) -> None:
+        """Refresh the list after a create, then offer to open the new
+        workspace (the TUI's shell entry point — a live in-TUI PTY shell is
+        a future step; the detail screen hosts the terminal list)."""
+        if not name:
+            return
+        self.refresh_lists()
+
+        def _offer(open_it: bool) -> None:
+            if open_it:
+                self.app.push_screen(WorkspaceDetailScreen(name))
+
+        self.app.push_screen(
+            ConfirmScreen(f"Created '{name}'. Open it now?"), _offer
+        )
 
     # --- list population ---
 
@@ -732,6 +775,250 @@ class DuplicateScreen(ModalScreen):
     def on_input_submitted(self, event: Input.Submitted) -> None:
         if event.input.id == "dup_name":
             self._commit()
+
+
+class CreateWorkspaceScreen(Screen):
+    """Full-screen workspace create form (parity with Flutter
+    ``CreateWorkspaceDialog``).
+
+    Fields, top to bottom: name, container image (``Select`` populated
+    from ``/api/v1/images``), a mounts list editor, an env list editor,
+    an optional service shell command, an optional health-check command,
+    and — only when the server permits it — an auto-start checkbox.
+    Mounts/env are validated client-side (``validate_mount_spec`` /
+    ``validate_env_entry``) exactly as the Flutter dialog and the CLI
+    ``create`` command do.
+
+    Images and the ``allow_autostart`` flag are fetched by the caller
+    (``MainScreen.action_create``) and passed in, because ``self.app`` is
+    not available until the screen is mounted.
+    """
+
+    BINDINGS = [("escape", "app.pop_screen", "Back")]
+
+    def __init__(
+        self,
+        *,
+        allowed: list[str],
+        default: str,
+        allow_autostart: bool,
+    ) -> None:
+        super().__init__()
+        self._allowed = list(allowed)
+        self._default = default or ""
+        self._allow_autostart = bool(allow_autostart)
+        self._mounts: list[str] = []
+        self._env: dict[str, str] = {}
+        if self._allowed:
+            self._select_options = [(img, img) for img in self._allowed]
+            self._select_value = (
+                self._default
+                if self._default in self._allowed
+                else self._allowed[0]
+            )
+        else:
+            # Couldn't list images — offer a single inert placeholder so the
+            # user can still create; the server applies its default image.
+            # Select tuples are (prompt, value).
+            self._select_options = [("(server default)", "(server default)")]
+            self._select_value = "(server default)"
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=False)
+        yield Vertical(
+            Static("New workspace", classes="title"),
+            Static("", id="create_msg"),
+            Static("Name"),
+            Input(id="name"),
+            Static("Container image"),
+            Select(
+                self._select_options,
+                value=self._select_value,
+                id="image",
+            ),
+            Static("Mounts  (source:/container/path[:opts])"),
+            OptionList(id="mount_list"),
+            Horizontal(
+                Input(
+                    id="mount_input",
+                    placeholder="/host/path:/container/path",
+                ),
+                Button("Add", id="add_mount"),
+                Button("Remove", id="rm_mount"),
+            ),
+            Static("Environment  (KEY=VALUE)"),
+            OptionList(id="env_list"),
+            Horizontal(
+                Input(id="env_input", placeholder="KEY=VALUE"),
+                Button("Add", id="add_env"),
+                Button("Remove", id="rm_env"),
+            ),
+            Static("Service shell command (optional)"),
+            Input(id="command"),
+            Static("Health check command (optional)"),
+            Input(id="health_check"),
+            Checkbox("Auto start", id="auto_start"),
+            Horizontal(
+                Button("Cancel", id="cancel"),
+                Button("Create", id="create", variant="primary"),
+                classes="actions",
+            ),
+            id="create_box",
+        )
+        yield Footer()
+
+    def on_mount(self) -> None:
+        # Only show the auto-start checkbox when the server allows it;
+        # ``auto_start`` defaults to off either way.
+        cb = self.query_one("#auto_start", Checkbox)
+        cb.display = self._allow_autostart
+        cb.disabled = not self._allow_autostart
+        self._render_mounts()
+        self._render_env()
+
+    def _msg(self, text: str, *, error: bool = False) -> None:
+        self.query_one("#create_msg", Static).update(
+            Text(text, style="red" if error else "")
+        )
+
+    # --- mounts list editor ---
+
+    def _render_mounts(self) -> None:
+        ol = self.query_one("#mount_list", OptionList)
+        ol.clear_options()
+        if not self._mounts:
+            ol.add_option(Option(Text("(no mounts)"), id="", disabled=True))
+            return
+        for i, m in enumerate(self._mounts):
+            ol.add_option(Option(Text(m), id=f"m{i}"))
+
+    def _add_mount(self) -> None:
+        inp = self.query_one("#mount_input", Input)
+        v = inp.value.strip()
+        if not v:
+            return
+        err = validate_mount_spec(v)
+        if err:
+            self._msg(err, error=True)
+            return
+        self._mounts.append(v)
+        inp.value = ""
+        self._msg("")
+        self._render_mounts()
+
+    def _remove_mount(self) -> None:
+        ol = self.query_one("#mount_list", OptionList)
+        idx = ol.highlighted
+        if idx is None or not 0 <= idx < len(self._mounts):
+            return
+        del self._mounts[idx]
+        self._render_mounts()
+
+    # --- env list editor ---
+
+    def _render_env(self) -> None:
+        ol = self.query_one("#env_list", OptionList)
+        ol.clear_options()
+        if not self._env:
+            ol.add_option(Option(Text("(no env vars)"), id="", disabled=True))
+            return
+        for i, (k, val) in enumerate(self._env.items()):
+            ol.add_option(Option(Text(f"{k}={val}"), id=f"e{i}"))
+
+    def _add_env(self) -> None:
+        inp = self.query_one("#env_input", Input)
+        v = inp.value.strip()
+        if not v:
+            return
+        err = validate_env_entry(v)
+        if err:
+            self._msg(err, error=True)
+            return
+        key, _, value = v.partition("=")
+        self._env[key] = value
+        inp.value = ""
+        self._msg("")
+        self._render_env()
+
+    def _remove_env(self) -> None:
+        ol = self.query_one("#env_list", OptionList)
+        idx = ol.highlighted
+        keys = list(self._env)
+        if idx is None or not 0 <= idx < len(keys):
+            return
+        del self._env[keys[idx]]
+        self._render_env()
+
+    # --- create ---
+
+    def _create(self) -> None:
+        name = self.query_one("#name", Input).value.strip()
+        if not name:
+            self._msg("Name is required.", error=True)
+            return
+        sel = self.query_one("#image", Select)
+        image = (
+            sel.value
+            if (self._allowed and sel.value != self._default)
+            else None
+        )
+        command = self.query_one("#command", Input).value.strip() or None
+        health_check = (
+            self.query_one("#health_check", Input).value.strip() or None
+        )
+        auto = (
+            self._allow_autostart
+            and self.query_one("#auto_start", Checkbox).value
+        )
+        mounts = list(self._mounts) or None
+        env = dict(self._env) or None
+        try:
+            ws = self.app.tui_state.create_workspace(
+                name,
+                image=image,
+                service_command=command,
+                auto_start=auto,
+                mounts=mounts,
+                env=env,
+                health_check=health_check,
+            )
+        except AuthError:
+            self._msg("Session expired — please log in again.", error=True)
+            return
+        except httpx.HTTPStatusError as exc:
+            detail = exc.response.json().get("detail", exc.response.text)
+            self._msg(f"Failed to create: {detail}", error=True)
+            return
+        except Exception as exc:
+            self._msg(f"Failed to create: {exc}", error=True)
+            return
+        self.dismiss(ws.name)
+
+    # --- event handlers ---
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        bid = event.button.id
+        if bid == "cancel":
+            self.dismiss(None)
+        elif bid == "create":
+            self._create()
+        elif bid == "add_mount":
+            self._add_mount()
+        elif bid == "rm_mount":
+            self._remove_mount()
+        elif bid == "add_env":
+            self._add_env()
+        elif bid == "rm_env":
+            self._remove_env()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        eid = event.input.id
+        if eid == "mount_input":
+            self._add_mount()
+        elif eid == "env_input":
+            self._add_env()
+        elif eid in ("name", "command", "health_check"):
+            self._create()
 
 
 class ServerSwitchScreen(Screen):

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -57,16 +57,26 @@ class ConfirmScreen(ModalScreen[bool]):
     }
     """
 
-    def __init__(self, message: str) -> None:
+    def __init__(
+        self,
+        message: str,
+        *,
+        yes_label: str = "Delete",
+        yes_variant: str = "error",
+        no_label: str = "Cancel",
+    ) -> None:
         super().__init__()
         self.message = message
+        self._yes_label = yes_label
+        self._yes_variant = yes_variant
+        self._no_label = no_label
 
     def compose(self) -> ComposeResult:
         yield Vertical(
             Static(Text(self.message)),
             Horizontal(
-                Button("Cancel", id="no"),
-                Button("Delete", id="yes", variant="error"),
+                Button(self._no_label, id="no"),
+                Button(self._yes_label, id="yes", variant=self._yes_variant),
             ),
         )
 
@@ -376,8 +386,9 @@ class MainScreen(Screen):
 
     def _on_created(self, name: str | None) -> None:
         """Refresh the list after a create, then offer to open the new
-        workspace (the TUI's shell entry point — a live in-TUI PTY shell is
-        a future step; the detail screen hosts the terminal list)."""
+        workspace's detail screen (its terminal list lives there). A live
+        in-TUI PTY shell is a future step — #1748's 'open shell' bullet is
+        satisfied here as 'open workspace', not a live shell."""
         if not name:
             return
         self.refresh_lists()
@@ -387,7 +398,13 @@ class MainScreen(Screen):
                 self.app.push_screen(WorkspaceDetailScreen(name))
 
         self.app.push_screen(
-            ConfirmScreen(f"Created '{name}'. Open it now?"), _offer
+            ConfirmScreen(
+                f"Created '{name}'. Open workspace now?",
+                yes_label="Open",
+                yes_variant="primary",
+                no_label="Later",
+            ),
+            _offer,
         )
 
     # --- list population ---
@@ -693,7 +710,9 @@ class WorkspaceDetailScreen(Screen):
         self.app.push_screen(
             ConfirmScreen(
                 f"Restart '{self._name}'? This ends active terminal"
-                " sessions and recreates the container."
+                " sessions and recreates the container.",
+                yes_label="Restart",
+                yes_variant="warning",
             ),
             _on_confirm,
         )
@@ -810,20 +829,29 @@ class CreateWorkspaceScreen(Screen):
         self._mounts: list[str] = []
         self._env: dict[str, str] = {}
         if self._allowed:
-            self._select_options = [(img, img) for img in self._allowed]
+            # Select tuples are (prompt, value). Prompts are rich Text so an
+            # image name containing brackets can't trigger markup parsing.
+            self._select_options = [(Text(img), img) for img in self._allowed]
             self._select_value = (
-                self._default
-                if self._default in self._allowed
-                else self._allowed[0]
+                self._default if self._default in self._allowed else None
             )
         else:
             # Couldn't list images — offer a single inert placeholder so the
             # user can still create; the server applies its default image.
-            # Select tuples are (prompt, value).
-            self._select_options = [("(server default)", "(server default)")]
+            self._select_options = [
+                (Text("(server default)"), "(server default)")
+            ]
             self._select_value = "(server default)"
 
     def compose(self) -> ComposeResult:
+        if self._select_value is not None:
+            image_select = Select(
+                self._select_options, value=self._select_value, id="image"
+            )
+        else:
+            # No valid default to preselect — leave the picker unselected
+            # (the server applies its default image if none is chosen).
+            image_select = Select(self._select_options, id="image")
         yield Header(show_clock=False)
         yield Vertical(
             Static("New workspace", classes="title"),
@@ -831,11 +859,7 @@ class CreateWorkspaceScreen(Screen):
             Static("Name"),
             Input(id="name"),
             Static("Container image"),
-            Select(
-                self._select_options,
-                value=self._select_value,
-                id="image",
-            ),
+            image_select,
             Static("Mounts  (source:/container/path[:opts])"),
             OptionList(id="mount_list"),
             Horizontal(
@@ -858,6 +882,10 @@ class CreateWorkspaceScreen(Screen):
             Static("Health check command (optional)"),
             Input(id="health_check"),
             Checkbox("Auto start", id="auto_start"),
+            Static(
+                Text("(start this workspace when the server starts)"),
+                id="auto_caption",
+            ),
             Horizontal(
                 Button("Cancel", id="cancel"),
                 Button("Create", id="create", variant="primary"),
@@ -868,11 +896,13 @@ class CreateWorkspaceScreen(Screen):
         yield Footer()
 
     def on_mount(self) -> None:
-        # Only show the auto-start checkbox when the server allows it;
-        # ``auto_start`` defaults to off either way.
+        # Only show the auto-start checkbox (and its caption) when the server
+        # allows it; ``auto_start`` defaults to off either way.
+        shown = self._allow_autostart
         cb = self.query_one("#auto_start", Checkbox)
-        cb.display = self._allow_autostart
-        cb.disabled = not self._allow_autostart
+        cb.display = shown
+        cb.disabled = not shown
+        self.query_one("#auto_caption", Static).display = shown
         self._render_mounts()
         self._render_env()
 
@@ -957,9 +987,15 @@ class CreateWorkspaceScreen(Screen):
             self._msg("Name is required.", error=True)
             return
         sel = self.query_one("#image", Select)
+        val = sel.value
+        # Send only a real, non-default selection. When the server's default
+        # isn't in the allowed list we start unselected (Select.BLANK), so an
+        # untouched picker omits the image — matching the Flutter dialog.
         image = (
-            sel.value
-            if (self._allowed and sel.value != self._default)
+            val
+            if (
+                self._allowed and val != self._default and val in self._allowed
+            )
             else None
         )
         command = self.query_one("#command", Input).value.strip() or None
@@ -986,7 +1022,13 @@ class CreateWorkspaceScreen(Screen):
             self._msg("Session expired — please log in again.", error=True)
             return
         except httpx.HTTPStatusError as exc:
-            detail = exc.response.json().get("detail", exc.response.text)
+            # The error body may not be JSON (proxy HTML page, empty body,
+            # plaintext) — parse defensively so a malformed response can't
+            # crash the TUI from inside this handler.
+            try:
+                detail = exc.response.json().get("detail", exc.response.text)
+            except Exception:
+                detail = exc.response.text or str(exc)
             self._msg(f"Failed to create: {detail}", error=True)
             return
         except Exception as exc:

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -17,6 +17,7 @@ from rich.text import Text
 
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
+from textual.dom import NoMatches
 from textual.screen import ModalScreen, Screen
 from textual.widgets import (
     Button,
@@ -646,11 +647,19 @@ class WorkspaceDetailScreen(Screen):
             self._on_edited,
         )
 
-    def _on_edited(self, saved: bool | None) -> None:
-        # Refresh the workspace after a successful edit (fields may have
-        # changed; create-time changes need a restart, offered in the form).
-        if saved:
+    def _on_edited(self, result: str | bool | None) -> None:
+        # The edit form dismisses with the workspace's (possibly new) name on
+        # save, or False/None on cancel. A rename leaves self._name stale —
+        # adopt the new name before reloading so _load() resolves, and refresh
+        # the list so the rename shows up there too (#1778).
+        if isinstance(result, str):
+            self._name = result
+        if result:
             self._load()
+            try:
+                self.app.query_one(MainScreen).refresh_lists()
+            except NoMatches:
+                pass
 
     def apply_status_event(self, event: dict) -> None:
         """Update running/health from a live status broadcast.
@@ -1177,7 +1186,11 @@ class EditWorkspaceScreen(Screen):
     live and never trigger it.
     """
 
-    BINDINGS = [("escape", "app.pop_screen", "Back")]
+    BINDINGS = [
+        ("escape", "app.pop_screen", "Back"),
+        ("delete", "remove_item", "Remove"),
+        ("e", "edit_item", "Edit"),
+    ]
 
     def __init__(
         self,
@@ -1196,6 +1209,11 @@ class EditWorkspaceScreen(Screen):
         self._allowed_domains: list[str] = list(
             workspace.allowed_domains or []
         )
+        # In-place editor state (#1778): when set, the next Add *replaces*
+        # the item at this index/key instead of appending. Cleared on Add.
+        self._editing_mount: int | None = None
+        self._editing_env: str | None = None
+        self._editing_allow: int | None = None
         # Image picker: include the workspace's current image even if it
         # isn't in the server's allowed list, pre-selected (untouched = no
         # change). Prompts are rich Text so bracket-laden names can't crash.
@@ -1284,7 +1302,7 @@ class EditWorkspaceScreen(Screen):
             Text(text, style="red" if error else "")
         )
 
-    # --- list editors (same pattern as CreateWorkspaceScreen) ---
+    # --- list editors: add / remove / in-place edit (#1778) ---
 
     def _render_mounts(self) -> None:
         ol = self.query_one("#mount_list", OptionList)
@@ -1304,7 +1322,12 @@ class EditWorkspaceScreen(Screen):
         if err:
             self._msg(err, error=True)
             return
-        self._mounts.append(v)
+        idx = self._editing_mount
+        if idx is not None and 0 <= idx < len(self._mounts):
+            self._mounts[idx] = v
+            self._editing_mount = None
+        else:
+            self._mounts.append(v)
         inp.value = ""
         self._msg("")
         self._render_mounts()
@@ -1315,6 +1338,7 @@ class EditWorkspaceScreen(Screen):
         if idx is None or not 0 <= idx < len(self._mounts):
             return
         del self._mounts[idx]
+        self._editing_mount = None
         self._render_mounts()
 
     def _render_env(self) -> None:
@@ -1336,6 +1360,10 @@ class EditWorkspaceScreen(Screen):
             self._msg(err, error=True)
             return
         key, _, value = v.partition("=")
+        old = self._editing_env
+        if old is not None:
+            self._env.pop(old, None)
+            self._editing_env = None
         self._env[key] = value
         inp.value = ""
         self._msg("")
@@ -1348,6 +1376,7 @@ class EditWorkspaceScreen(Screen):
         if idx is None or not 0 <= idx < len(keys):
             return
         del self._env[keys[idx]]
+        self._editing_env = None
         self._render_env()
 
     def _render_allowed_domains(self) -> None:
@@ -1368,7 +1397,11 @@ class EditWorkspaceScreen(Screen):
         if err:
             self._msg(err, error=True)
             return
-        if v not in self._allowed_domains:
+        idx = self._editing_allow
+        if idx is not None and 0 <= idx < len(self._allowed_domains):
+            self._allowed_domains[idx] = v
+            self._editing_allow = None
+        elif v not in self._allowed_domains:
             self._allowed_domains.append(v)
         inp.value = ""
         self._msg("")
@@ -1380,7 +1413,65 @@ class EditWorkspaceScreen(Screen):
         if idx is None or not 0 <= idx < len(self._allowed_domains):
             return
         del self._allowed_domains[idx]
+        self._editing_allow = None
         self._render_allowed_domains()
+
+    # --- in-place edit: load the highlighted item into the input (#1778) ---
+
+    def _edit_mount(self) -> None:
+        ol = self.query_one("#mount_list", OptionList)
+        idx = ol.highlighted
+        if idx is None or not 0 <= idx < len(self._mounts):
+            return
+        self._editing_mount = idx
+        inp = self.query_one("#mount_input", Input)
+        inp.value = self._mounts[idx]
+        inp.focus()
+        self._msg("Editing mount — press Add to update.")
+
+    def _edit_env(self) -> None:
+        ol = self.query_one("#env_list", OptionList)
+        idx = ol.highlighted
+        keys = list(self._env)
+        if idx is None or not 0 <= idx < len(keys):
+            return
+        key = keys[idx]
+        self._editing_env = key
+        inp = self.query_one("#env_input", Input)
+        inp.value = f"{key}={self._env[key]}"
+        inp.focus()
+        self._msg("Editing env var — press Add to update.")
+
+    def _edit_allowed_domain(self) -> None:
+        ol = self.query_one("#allow_list", OptionList)
+        idx = ol.highlighted
+        if idx is None or not 0 <= idx < len(self._allowed_domains):
+            return
+        self._editing_allow = idx
+        inp = self.query_one("#allow_input", Input)
+        inp.value = self._allowed_domains[idx]
+        inp.focus()
+        self._msg("Editing allowed-domain — press Add to update.")
+
+    # --- keyboard remove/edit of the focused OptionList (#1778) ---
+
+    def action_remove_item(self) -> None:
+        fid = getattr(self.focused, "id", None) if self.focused else None
+        if fid == "mount_list":
+            self._remove_mount()
+        elif fid == "env_list":
+            self._remove_env()
+        elif fid == "allow_list":
+            self._remove_allowed_domain()
+
+    def action_edit_item(self) -> None:
+        fid = getattr(self.focused, "id", None) if self.focused else None
+        if fid == "mount_list":
+            self._edit_mount()
+        elif fid == "env_list":
+            self._edit_env()
+        elif fid == "allow_list":
+            self._edit_allowed_domain()
 
     # --- save ---
 
@@ -1453,7 +1544,7 @@ class EditWorkspaceScreen(Screen):
                             f"Saved, but restart failed: {exc}", error=True
                         )
                         return
-                self.dismiss(True)
+                self.dismiss(name)
 
             self.app.push_screen(
                 ConfirmScreen(
@@ -1466,7 +1557,7 @@ class EditWorkspaceScreen(Screen):
                 _after,
             )
         else:
-            self.dismiss(True)
+            self.dismiss(name)
 
     # --- event handlers ---
 

--- a/src/klangk/klangk/cli/tui/state.py
+++ b/src/klangk/klangk/cli/tui/state.py
@@ -127,6 +127,29 @@ class TuiState:
     def duplicate_workspace(self, name: str, new_name: str) -> dict:
         return self.client().duplicate_workspace(name, new_name)
 
+    def create_workspace(
+        self,
+        name: str,
+        image: str | None = None,
+        service_command: str | None = None,
+        auto_start: bool = False,
+        mounts: list[str] | None = None,
+        env: dict[str, str] | None = None,
+        health_check: str | None = None,
+    ) -> Workspace:
+        return self.client().create_workspace(
+            name,
+            image=image,
+            service_command=service_command,
+            auto_start=auto_start,
+            mounts=mounts,
+            env=env,
+            health_check=health_check,
+        )
+
+    def list_images(self) -> dict:
+        return self.client().list_images()
+
     async def list_terminals(self, name: str) -> list[dict]:
         return await self.client().list_terminals(name)
 
@@ -155,6 +178,21 @@ class TuiState:
         if not isinstance(config, dict):
             return []
         return list(config.get("oidc_providers") or [])
+
+    def allow_autostart(self) -> bool:
+        """Whether the server permits per-workspace auto-start.
+
+        Derived from ``allow_autostart`` in ``/api/v1/config`` (the same
+        field the Flutter UI gates its checkbox on). Defaults to False on
+        any failure so the TUI never offers a setting the server rejects.
+        """
+        url = self.current_url()
+        if url is None:
+            return False
+        config = fetch_config(url)
+        if not isinstance(config, dict):
+            return False
+        return bool(config.get("allow_autostart"))
 
     # --- login arms ---
 

--- a/src/klangk/klangk/cli/tui/state.py
+++ b/src/klangk/klangk/cli/tui/state.py
@@ -136,6 +136,7 @@ class TuiState:
         mounts: list[str] | None = None,
         env: dict[str, str] | None = None,
         health_check: str | None = None,
+        allowed_domains: list[str] | None = None,
     ) -> Workspace:
         return self.client().create_workspace(
             name,
@@ -145,7 +146,12 @@ class TuiState:
             mounts=mounts,
             env=env,
             health_check=health_check,
+            allowed_domains=allowed_domains,
         )
+
+    def update_workspace(self, workspace_id: str, **fields) -> None:
+        """Partial-update a workspace's fields (used by the TUI edit form, #1778)."""
+        self.client().update_workspace(workspace_id, **fields)
 
     def list_images(self) -> dict:
         return self.client().list_images()

--- a/src/klangk/klangk/cli/tui/state.py
+++ b/src/klangk/klangk/cli/tui/state.py
@@ -192,7 +192,9 @@ class TuiState:
         config = fetch_config(url)
         if not isinstance(config, dict):
             return False
-        return bool(config.get("allow_autostart"))
+        # Strict: the server serializes a Python bool, so require True exactly
+        # (a string like "false" must not coerce to True).
+        return config.get("allow_autostart") is True
 
     # --- login arms ---
 

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -1059,6 +1059,56 @@ class TestKlangkClient:
                 json={"name": "src-copy"},
             )
 
+    def test_create_workspace_includes_allowed_domains(self):
+        client = KlangkClient("http://test:8995", "token")
+        mock_resp = MagicMock(status_code=200)
+        mock_resp.json.return_value = {
+            "id": "ws-1",
+            "name": "n",
+            "created_at": "x",
+        }
+        with patch.object(client, "post", return_value=mock_resp):
+            client.create_workspace(
+                "n", allowed_domains=["github.com:443", "pypi.org"]
+            )
+            body = client.post.call_args.kwargs["json"]
+            assert body["allowed_domains"] == ["github.com:443", "pypi.org"]
+            # Omitted when not provided (server applies no default list).
+            client.create_workspace("n2")
+            assert (
+                "allowed_domains" not in client.post.call_args.kwargs["json"]
+            )
+
+    def test_update_workspace_puts_fields(self):
+        client = KlangkClient("http://test:8995", "token")
+        with patch.object(
+            client, "put", return_value=MagicMock(status_code=200)
+        ):
+            client.update_workspace(
+                "ws-1", name="renamed", allowed_domains=["a.com"]
+            )
+            client.put.assert_called_once_with(
+                "/api/v1/workspaces/ws-1",
+                json={"name": "renamed", "allowed_domains": ["a.com"]},
+            )
+
+    def test_workspace_from_json_parses_allowed_domains(self):
+        ws = KlangkClient._workspace_from_json(
+            {
+                "id": "ws-1",
+                "name": "n",
+                "created_at": "x",
+                "allowed_domains": ["github.com:443"],
+            },
+            shared=False,
+        )
+        assert ws.allowed_domains == ["github.com:443"]
+        # Absent key -> None (unrestricted).
+        ws2 = KlangkClient._workspace_from_json(
+            {"id": "ws-2", "name": "n2", "created_at": "x"}, shared=False
+        )
+        assert ws2.allowed_domains is None
+
     def test_list_terminals(self):
         client = KlangkClient("http://test:8995", "token")
         ws = Workspace(id="ws" + "0" * 60, name="alpha", created_at="x")

--- a/src/klangk/klangkc-tests/tests/test_mount.py
+++ b/src/klangk/klangkc-tests/tests/test_mount.py
@@ -1,7 +1,10 @@
 """Tests for client-side mount spec validation."""
 
 from klangk.cli.env import validate_env_entry
-from klangk.cli.mount import validate_mount_spec
+from klangk.cli.mount import (
+    validate_allowed_domain_spec,
+    validate_mount_spec,
+)
 
 
 class TestValidateMountSpec:
@@ -61,3 +64,38 @@ class TestValidateEnvEntry:
         result = validate_env_entry("=val")
         assert result is not None
         assert "key cannot be empty" in result
+
+
+class TestValidateAllowedDomainSpec:
+    def test_valid_host(self):
+        assert validate_allowed_domain_spec("github.com") is None
+
+    def test_valid_host_port(self):
+        assert validate_allowed_domain_spec("github.com:443") is None
+        assert validate_allowed_domain_spec("pypi.org:80") is None
+
+    def test_valid_ipv4(self):
+        assert validate_allowed_domain_spec("10.0.0.1") is None
+        assert validate_allowed_domain_spec("10.0.0.1:53") is None
+
+    def test_valid_bracketed_ipv6(self):
+        assert validate_allowed_domain_spec("[::1]") is None
+        assert validate_allowed_domain_spec("[2001:db8::1]:443") is None
+
+    def test_rejects_empty(self):
+        assert validate_allowed_domain_spec("") is not None
+        assert "empty" in validate_allowed_domain_spec("")
+        assert validate_allowed_domain_spec("   ") is not None
+
+    def test_rejects_whitespace(self):
+        assert validate_allowed_domain_spec("bad spec") is not None
+
+    def test_rejects_slash(self):
+        # no CIDR yet (#1365)
+        assert validate_allowed_domain_spec("10.0.0.0/24") is not None
+
+    def test_rejects_non_numeric_port(self):
+        assert validate_allowed_domain_spec("a.com:abc") is not None
+
+    def test_strips_whitespace(self):
+        assert validate_allowed_domain_spec("  github.com:443  ") is None

--- a/src/klangk/klangkc-tests/tests/test_mount.py
+++ b/src/klangk/klangkc-tests/tests/test_mount.py
@@ -1,6 +1,7 @@
 """Tests for client-side mount spec validation."""
 
-from klangk.cli.mount import validate_env_entry, validate_mount_spec
+from klangk.cli.env import validate_env_entry
+from klangk.cli.mount import validate_mount_spec
 
 
 class TestValidateMountSpec:

--- a/src/klangk/klangkc-tests/tests/test_mount.py
+++ b/src/klangk/klangkc-tests/tests/test_mount.py
@@ -1,6 +1,6 @@
 """Tests for client-side mount spec validation."""
 
-from klangk.cli.mount import validate_mount_spec
+from klangk.cli.mount import validate_env_entry, validate_mount_spec
 
 
 class TestValidateMountSpec:
@@ -38,3 +38,25 @@ class TestValidateMountSpec:
         result = validate_mount_spec("/host:/container:bogus")
         assert result is not None
         assert "unknown option" in result
+
+
+class TestValidateEnvEntry:
+    def test_valid_key_value(self):
+        assert validate_env_entry("FOO=bar") is None
+
+    def test_valid_empty_value(self):
+        assert validate_env_entry("EMPTY=") is None
+
+    def test_value_may_contain_equals(self):
+        # only the first '=' splits key from value
+        assert validate_env_entry("PATH=/usr:/bin") is None
+
+    def test_missing_equals(self):
+        result = validate_env_entry("NOEQUALS")
+        assert result is not None
+        assert "KEY=VALUE" in result
+
+    def test_empty_key(self):
+        result = validate_env_entry("=val")
+        assert result is not None
+        assert "key cannot be empty" in result

--- a/src/klangk/klangkc-tests/tests/test_transport.py
+++ b/src/klangk/klangkc-tests/tests/test_transport.py
@@ -65,6 +65,14 @@ class TestResolveTransport:
         with pytest.raises(ValueError, match="socket path must be absolute"):
             resolve_transport("example.com")
 
+    def test_none_or_empty_raises_valueerror(self):
+        # No server configured must raise ValueError (caught by callers'
+        # `except ValueError`) rather than crashing on None.startswith.
+        with pytest.raises(ValueError, match="no server configured"):
+            resolve_transport(None)
+        with pytest.raises(ValueError, match="no server configured"):
+            resolve_transport("")
+
 
 class TestHttpRequest:
     def test_tcp_delegates_to_httpx_request(self):

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -31,6 +31,7 @@ from klangk.cli.tui.screens import (
     ConfirmScreen,
     CreateWorkspaceScreen,
     DuplicateScreen,
+    EditWorkspaceScreen,
     LoginScreen,
     MainScreen,
     ServerSwitchScreen,
@@ -848,8 +849,15 @@ def test_tui_state_workspace_methods(monkeypatch, redirect_xdg):
         mounts=["/h:/c"],
         env=None,
         health_check=None,
+        allowed_domains=None,
     )
     fake.list_images.assert_called_once_with()
+
+    # #1778: update_workspace forwards to the client.
+    st.update_workspace("id-x", name="renamed", allowed_domains=["a.com"])
+    fake.update_workspace.assert_called_once_with(
+        "id-x", name="renamed", allowed_domains=["a.com"]
+    )
 
 
 def test_tui_state_terminal_methods(monkeypatch, redirect_xdg):
@@ -1002,6 +1010,53 @@ async def test_detail_loads_and_renders(monkeypatch):
             "owner: o@x",
         ]:
             assert s in body, s
+
+
+async def test_detail_renders_allowed_domains(monkeypatch):
+    # #1745: the current allowlist is shown in the detail view.
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    a = _wsobj("alpha", allowed_domains=["github.com:443", "pypi.org"])
+    st = _ws()
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        body = str(app.screen.query_one("#detail_body").render())
+        assert "allowed domains:" in body
+        assert "github.com:443" in body
+        assert "pypi.org" in body
+
+
+async def test_detail_action_edit_opens_form_and_refreshes(monkeypatch):
+    # #1778: 'e' on the detail opens the edit form; a successful save
+    # refreshes the detail (re-fetches the workspace).
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    a = _wsobj("alpha", image="base")
+    finds = []
+    st = _ws(
+        list_images=lambda: {"default": "base", "allowed": ["base", "py:3"]},
+        allow_autostart=lambda: True,
+    )
+    st.find_workspace = lambda n: finds.append(n) or a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        app.screen.action_edit()
+        await pilot.pause()
+        assert isinstance(app.screen, EditWorkspaceScreen)
+        # Simulate a successful save/disdismiss -> _on_edited refreshes.
+        app.screen.dismiss(True)
+        await pilot.pause()
+        assert isinstance(app.screen, WorkspaceDetailScreen)
+        assert finds.count("alpha") >= 2  # initial load + post-edit reload
 
 
 async def test_detail_load_failure(monkeypatch):
@@ -1985,6 +2040,11 @@ async def test_create_screen_input_submit_routing(monkeypatch):
         e.value = "K=V"
         cs.on_input_submitted(Input.Submitted(e, e.value))
         assert cs._env == {"K": "V"}
+        # allow input submit -> add
+        a = cs.query_one("#allow_input")
+        a.value = "github.com:443"
+        cs.on_input_submitted(Input.Submitted(a, a.value))
+        assert cs._allowed_domains == ["github.com:443"]
 
 
 async def test_create_flow_offer_opens_detail(monkeypatch):
@@ -2101,6 +2161,14 @@ async def test_create_button_routing(monkeypatch):
         cs.query_one("#env_list").highlighted = 0
         cs.on_button_pressed(FakeBtnPress("rm_env"))
         assert cs._env == {}
+        # add allowed-domain via button
+        cs.query_one("#allow_input").value = "github.com:443"
+        cs.on_button_pressed(FakeBtnPress("add_allow"))
+        assert cs._allowed_domains == ["github.com:443"]
+        # remove allowed-domain via button
+        cs.query_one("#allow_list").highlighted = 0
+        cs.on_button_pressed(FakeBtnPress("rm_allow"))
+        assert cs._allowed_domains == []
         # create via button -> success -> offer
         cs.query_one("#name").value = "ws"
         cs.on_button_pressed(FakeBtnPress("create"))
@@ -2206,6 +2274,563 @@ async def test_create_screen_default_not_in_allowed(monkeypatch):
         cs._create()  # nothing picked -> image omitted
         await pilot.pause()
         assert captured["k"]["image"] is None
+
+
+# ---------------------------------------------------------------------------
+# Edit workspace form (#1778) + allowed_domains (#1745)
+# ---------------------------------------------------------------------------
+
+
+def _edit_state(ws, *, update=None, restart=None, **extra):
+    """Authed state with image/autostart/update/restart stubs for edit tests."""
+    base = dict(
+        list_images=lambda: {"default": "base", "allowed": ["base", "py:3"]},
+        allow_autostart=lambda: True,
+        update_workspace=update or (lambda *a, **k: None),
+        restart_workspace=restart or (lambda *a, **k: None),
+    )
+    base.update(extra)
+    return _ws(**base)
+
+
+def _edit_screen(app, ws, **kw):
+    app.push_screen(
+        EditWorkspaceScreen(
+            workspace=ws,
+            allowed=kw.get("allowed", ["base", "py:3"]),
+            default=kw.get("default", "base"),
+            allow_autostart=kw.get("allow_autostart", True),
+        )
+    )
+
+
+async def test_create_screen_allowed_domains_editor(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    app = KlangkApp(_create_state())
+    async with app.run_test() as pilot:
+        app.screen.action_create()
+        await pilot.pause()
+        cs = app.screen
+        # valid add
+        cs.query_one("#allow_input").value = "github.com:443"
+        cs._add_allowed_domain()
+        assert cs._allowed_domains == ["github.com:443"]
+        assert cs.query_one("#allow_input").value == ""
+        # invalid rejected
+        cs.query_one("#allow_input").value = "bad spec"
+        cs._add_allowed_domain()
+        assert cs._allowed_domains == ["github.com:443"]
+        assert "host:port" in str(cs.query_one("#create_msg").render())
+        # duplicate add is a no-op; empty input is a no-op
+        cs.query_one("#allow_input").value = "github.com:443"
+        cs._add_allowed_domain()
+        cs._add_allowed_domain()  # empty input
+        assert cs._allowed_domains == ["github.com:443"]
+        # remove with nothing highlighted is a no-op
+        cs.query_one("#allow_list").highlighted = None
+        cs._remove_allowed_domain()
+        assert cs._allowed_domains == ["github.com:443"]
+        # remove
+        cs.query_one("#allow_list").highlighted = 0
+        cs._remove_allowed_domain()
+        assert cs._allowed_domains == []
+
+
+async def test_edit_screen_pre_populates(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    ws = _wsobj(
+        "alpha",
+        image="py:3",
+        mounts=["/h:/c"],
+        env={"A": "1"},
+        service_command="sh",
+        health_check="hc",
+        auto_start=True,
+        allowed_domains=["github.com:443"],
+    )
+    app = KlangkApp(_edit_state(ws))
+    async with app.run_test() as pilot:
+        _edit_screen(app, ws)
+        await pilot.pause()
+        es = app.screen
+        assert es.query_one("#name").value == "alpha"
+        assert es.query_one("#image", Select).value == "py:3"
+        assert es.query_one("#command").value == "sh"
+        assert es.query_one("#health_check").value == "hc"
+        assert es.query_one("#auto_start", Checkbox).value is True
+        assert es._mounts == ["/h:/c"]
+        assert es._env == {"A": "1"}
+        assert es._allowed_domains == ["github.com:443"]
+
+
+async def test_edit_screen_allowed_domains_editor(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    ws = _wsobj("alpha", allowed_domains=["github.com:443"])
+    app = KlangkApp(_edit_state(ws))
+    async with app.run_test() as pilot:
+        _edit_screen(app, ws)
+        await pilot.pause()
+        es = app.screen
+        # duplicate add is a no-op
+        es.query_one("#allow_input").value = "github.com:443"
+        es._add_allowed_domain()
+        assert es._allowed_domains == ["github.com:443"]
+        # new entry
+        es.query_one("#allow_input").value = "pypi.org:443"
+        es._add_allowed_domain()
+        assert es._allowed_domains == ["github.com:443", "pypi.org:443"]
+        # invalid rejected
+        es.query_one("#allow_input").value = "bad spec"
+        es._add_allowed_domain()
+        assert len(es._allowed_domains) == 2
+        assert "host:port" in str(es.query_one("#edit_msg").render())
+        # remove highlighted
+        es.query_one("#allow_list").highlighted = 0
+        es._remove_allowed_domain()
+        assert es._allowed_domains == ["pypi.org:443"]
+
+
+async def test_edit_screen_save_calls_update(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    captured = {}
+
+    def update(wid, **f):
+        captured["id"] = wid
+        captured.update(f)
+
+    ws = _wsobj("alpha", image="base", running=False)
+    app = KlangkApp(_edit_state(ws, update=update))
+    async with app.run_test() as pilot:
+        _edit_screen(app, ws)
+        await pilot.pause()
+        es = app.screen
+        es.query_one("#name").value = "renamed"
+        es.query_one("#allow_input").value = "github.com:443"
+        es._add_allowed_domain()
+        es._save()
+        await pilot.pause()
+        assert captured["id"] == ws.id
+        assert captured["name"] == "renamed"
+        assert captured["allowed_domains"] == ["github.com:443"]
+        # No restart offer: workspace not running.
+        assert not isinstance(app.screen, ConfirmScreen)
+        assert not isinstance(app.screen, EditWorkspaceScreen)  # dismissed
+
+
+async def test_edit_screen_restart_needed_when_running_and_changed(
+    monkeypatch,
+):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    restarted = []
+    ws = _wsobj("alpha", image="base", running=True)
+    app = KlangkApp(
+        _edit_state(ws, restart=lambda *a, **k: restarted.append(a))
+    )
+    async with app.run_test() as pilot:
+        _edit_screen(app, ws)
+        await pilot.pause()
+        es = app.screen
+        es.query_one("#image", Select).value = "py:3"  # create-time change
+        es._save()
+        await pilot.pause()
+        assert isinstance(app.screen, ConfirmScreen)  # restart offered
+        # accept -> restart_workspace called + edit screen dismissed
+        app.screen.dismiss(True)
+        await pilot.pause()
+        assert restarted
+        assert not isinstance(app.screen, EditWorkspaceScreen)
+
+
+async def test_edit_screen_no_restart_when_create_field_unchanged(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    ws = _wsobj("alpha", image="base", running=True)
+    app = KlangkApp(_edit_state(ws))
+    async with app.run_test() as pilot:
+        _edit_screen(app, ws)
+        await pilot.pause()
+        es = app.screen
+        # No create-time field changed (only a live-propagating field).
+        es.query_one("#health_check").value = "curl x"
+        es._save()
+        await pilot.pause()
+        assert not isinstance(app.screen, ConfirmScreen)
+        assert not isinstance(app.screen, EditWorkspaceScreen)
+
+
+async def test_edit_screen_name_required(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    updated = []
+    ws = _wsobj("alpha")
+    app = KlangkApp(_edit_state(ws, update=lambda *a, **k: updated.append(k)))
+    async with app.run_test() as pilot:
+        _edit_screen(app, ws)
+        await pilot.pause()
+        es = app.screen
+        es.query_one("#name").value = ""
+        es._save()
+        assert updated == []
+        assert "required" in str(es.query_one("#edit_msg").render()).lower()
+
+
+async def test_edit_screen_save_http_error_shows_detail(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    resp = httpx.Response(
+        400,
+        json={"detail": "name taken"},
+        request=httpx.Request("PUT", "https://x.example"),
+    )
+
+    def update(wid, **f):
+        raise httpx.HTTPStatusError(
+            "boom", request=resp.request, response=resp
+        )
+
+    ws = _wsobj("alpha")
+    app = KlangkApp(_edit_state(ws, update=update))
+    async with app.run_test() as pilot:
+        _edit_screen(app, ws)
+        await pilot.pause()
+        es = app.screen
+        es._save()
+        assert "name taken" in str(es.query_one("#edit_msg").render())
+        assert isinstance(app.screen, EditWorkspaceScreen)  # still on form
+
+
+async def test_edit_screen_cancel_dismisses(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    updated = []
+    ws = _wsobj("alpha")
+    app = KlangkApp(_edit_state(ws, update=lambda *a, **k: updated.append(k)))
+    async with app.run_test() as pilot:
+        _edit_screen(app, ws)
+        await pilot.pause()
+        es = app.screen
+        es.on_button_pressed(Button.Pressed(button=es.query_one("#cancel")))
+        await pilot.pause()
+        assert updated == []
+        assert not isinstance(app.screen, EditWorkspaceScreen)
+
+
+async def test_edit_screen_current_image_not_in_allowed(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    # The workspace's image isn't in the server's allowed list — the picker
+    # still shows + pre-selects it (untouched = no change).
+    ws = _wsobj("alpha", image="custom:latest")
+    app = KlangkApp(_edit_state(ws))
+    async with app.run_test() as pilot:
+        _edit_screen(app, ws)
+        await pilot.pause()
+        es = app.screen
+        assert es.query_one("#image", Select).value == "custom:latest"
+
+
+async def test_edit_screen_mount_editor(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    ws = _wsobj("alpha")
+    app = KlangkApp(_edit_state(ws))
+    async with app.run_test() as pilot:
+        _edit_screen(app, ws)
+        await pilot.pause()
+        es = app.screen
+        es.query_one("#mount_input").value = "/host:/c:ro"
+        es._add_mount()
+        assert es._mounts == ["/host:/c:ro"]
+        es.query_one("#mount_list").highlighted = 0
+        es._remove_mount()
+        assert es._mounts == []
+
+
+async def test_edit_screen_editors_edge_cases(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    ws = _wsobj("alpha")  # no mounts/env/allowed_domains
+    app = KlangkApp(_edit_state(ws))
+    async with app.run_test() as pilot:
+        _edit_screen(app, ws)
+        await pilot.pause()
+        es = app.screen
+        # empty input is a no-op for each editor
+        es._add_mount()
+        es._add_env()
+        es._add_allowed_domain()
+        assert es._mounts == [] and es._env == {} and es._allowed_domains == []
+        # invalid rejected
+        es.query_one("#mount_input").value = "badmount"
+        es._add_mount()
+        assert "source:dest" in str(es.query_one("#edit_msg").render())
+        es.query_one("#env_input").value = "NOEQ"
+        es._add_env()
+        assert "KEY=VALUE" in str(es.query_one("#edit_msg").render())
+        # remove with nothing highlighted is a no-op
+        es._remove_mount()
+        es._remove_env()
+        es._remove_allowed_domain()
+        # env dup overwrites
+        es.query_one("#env_input").value = "K=1"
+        es._add_env()
+        es.query_one("#env_input").value = "K=2"
+        es._add_env()
+        assert es._env == {"K": "2"}
+
+
+async def test_edit_button_and_input_routing(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    ws = _wsobj("alpha", running=False)
+    app = KlangkApp(_edit_state(ws))
+    async with app.run_test() as pilot:
+        _edit_screen(app, ws)
+        await pilot.pause()
+        es = app.screen
+        # button routing: add/rm for each editor
+        es.query_one("#mount_input").value = "/h:/c"
+        es.on_button_pressed(FakeBtnPress("add_mount"))
+        es.query_one("#mount_list").highlighted = 0
+        es.on_button_pressed(FakeBtnPress("rm_mount"))
+        assert es._mounts == []
+        es.query_one("#env_input").value = "K=V"
+        es.on_button_pressed(FakeBtnPress("add_env"))
+        es.query_one("#env_list").highlighted = 0
+        es.on_button_pressed(FakeBtnPress("rm_env"))
+        assert es._env == {}
+        es.query_one("#allow_input").value = "github.com:443"
+        es.on_button_pressed(FakeBtnPress("add_allow"))
+        es.query_one("#allow_list").highlighted = 0
+        es.on_button_pressed(FakeBtnPress("rm_allow"))
+        assert es._allowed_domains == []
+        # input submit routing
+        m = es.query_one("#mount_input")
+        m.value = "/h:/c"
+        es.on_input_submitted(Input.Submitted(m, m.value))
+        assert es._mounts == ["/h:/c"]
+        e = es.query_one("#env_input")
+        e.value = "K=V"
+        es.on_input_submitted(Input.Submitted(e, e.value))
+        assert es._env == {"K": "V"}
+        a = es.query_one("#allow_input")
+        a.value = "pypi.org"
+        es.on_input_submitted(Input.Submitted(a, a.value))
+        assert es._allowed_domains == ["pypi.org"]
+        # save via button + name submit
+        es.on_button_pressed(FakeBtnPress("save"))
+        await pilot.pause()
+        assert not isinstance(app.screen, EditWorkspaceScreen)
+
+
+async def test_edit_screen_save_auth_error(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    ws = _wsobj("alpha")
+    app = KlangkApp(
+        _edit_state(
+            ws,
+            update=lambda *a, **k: (_ for _ in ()).throw(AuthError("expired")),
+        )
+    )
+    async with app.run_test() as pilot:
+        _edit_screen(app, ws)
+        await pilot.pause()
+        es = app.screen
+        es._save()
+        assert "Session expired" in str(es.query_one("#edit_msg").render())
+
+
+async def test_edit_screen_save_generic_error(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+
+    def update(wid, **f):
+        raise RuntimeError("boom")
+
+    ws = _wsobj("alpha")
+    app = KlangkApp(_edit_state(ws, update=update))
+    async with app.run_test() as pilot:
+        _edit_screen(app, ws)
+        await pilot.pause()
+        es = app.screen
+        es._save()
+        assert "Failed to save: boom" in str(
+            es.query_one("#edit_msg").render()
+        )
+
+
+async def test_edit_screen_save_http_error_non_json(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    resp = httpx.Response(
+        502,
+        text="<html>proxy</html>",
+        request=httpx.Request("PUT", "https://x.example"),
+    )
+
+    def update(wid, **f):
+        raise httpx.HTTPStatusError(
+            "boom", request=resp.request, response=resp
+        )
+
+    ws = _wsobj("alpha")
+    app = KlangkApp(_edit_state(ws, update=update))
+    async with app.run_test() as pilot:
+        _edit_screen(app, ws)
+        await pilot.pause()
+        es = app.screen
+        es._save()
+        assert "proxy" in str(es.query_one("#edit_msg").render())
+
+
+async def test_edit_screen_field_submit_saves(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    updated = []
+    ws = _wsobj("alpha", running=False)
+    app = KlangkApp(_edit_state(ws, update=lambda *a, **k: updated.append(k)))
+    async with app.run_test() as pilot:
+        _edit_screen(app, ws)
+        await pilot.pause()
+        es = app.screen
+        name = es.query_one("#name")
+        es.on_input_submitted(Input.Submitted(name, name.value))  # -> _save
+        await pilot.pause()
+        assert updated  # update_workspace called
+        assert not isinstance(app.screen, EditWorkspaceScreen)
+
+
+async def test_edit_screen_restart_declined(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    restarted = []
+    ws = _wsobj("alpha", image="base", running=True)
+    app = KlangkApp(
+        _edit_state(ws, restart=lambda *a, **k: restarted.append(1))
+    )
+    async with app.run_test() as pilot:
+        _edit_screen(app, ws)
+        await pilot.pause()
+        es = app.screen
+        es.query_one("#image", Select).value = "py:3"
+        es._save()
+        await pilot.pause()
+        assert isinstance(app.screen, ConfirmScreen)
+        app.screen.dismiss(False)  # decline restart
+        await pilot.pause()
+        assert restarted == []
+        assert not isinstance(app.screen, EditWorkspaceScreen)
+
+
+async def test_edit_screen_restart_failure(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+
+    def boom(*a, **k):
+        raise RuntimeError("restart down")
+
+    ws = _wsobj("alpha", image="base", running=True)
+    app = KlangkApp(_edit_state(ws, restart=boom))
+    async with app.run_test() as pilot:
+        _edit_screen(app, ws)
+        await pilot.pause()
+        es = app.screen
+        es.query_one("#image", Select).value = "py:3"
+        es._save()
+        await pilot.pause()
+        assert isinstance(app.screen, ConfirmScreen)
+        app.screen.dismiss(True)  # accept restart -> fails
+        await pilot.pause()
+        assert "restart failed" in str(es.query_one("#edit_msg").render())
+
+
+async def test_detail_action_edit_no_workspace(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    a = _wsobj("alpha")
+    st = _ws(
+        list_images=lambda: {"default": "base", "allowed": ["base"]},
+        allow_autostart=lambda: True,
+    )
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        d = app.screen
+        d._ws = None  # nothing loaded
+        d.action_edit()  # early no-op
+        await pilot.pause()
+        assert isinstance(app.screen, WorkspaceDetailScreen)
+
+
+async def test_detail_action_edit_fetch_failure(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    a = _wsobj("alpha")
+
+    def boom():
+        raise RuntimeError("down")
+
+    st = _ws(list_images=boom, allow_autostart=boom)
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        app.screen.action_edit()
+        await pilot.pause()
+        # form still opens, with no images + autostart off
+        assert isinstance(app.screen, EditWorkspaceScreen)
+        assert app.screen._select_value == "(none)"
 
 
 async def test_confirm_screen_button_labels(monkeypatch):

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -1930,7 +1930,7 @@ async def test_create_screen_images_unavailable(monkeypatch):
         return _wsobj(name)
 
     def boom():
-        raise RuntimeError("images endpoint down")
+        raise OSError("images endpoint down")
 
     app = KlangkApp(
         _create_state(create=create, list_images=boom, allow_autostart=boom)

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -1712,6 +1712,7 @@ async def test_create_screen_renders_defaults(monkeypatch):
         cb = cs.query_one("#auto_start", Checkbox)
         assert cb.display is True  # shown (autostart allowed)
         assert cb.value is False  # off by default
+        assert cs.query_one("#auto_caption", Static).display is True
         assert cs.query_one("#image", Select).value == "base"  # server default
 
 
@@ -1727,6 +1728,7 @@ async def test_create_screen_autostart_hidden_when_not_allowed(monkeypatch):
         cb = app.screen.query_one("#auto_start", Checkbox)
         assert cb.display is False
         assert cb.disabled is True
+        assert app.screen.query_one("#auto_caption", Static).display is False
 
 
 async def test_create_screen_mount_editor(monkeypatch):
@@ -2104,6 +2106,136 @@ async def test_create_button_routing(monkeypatch):
         cs.on_button_pressed(FakeBtnPress("create"))
         await pilot.pause()
         assert isinstance(app.screen, ConfirmScreen)
+
+
+async def test_create_screen_image_names_markup_safe(monkeypatch):
+    """Image names from the server flow into the Select as rich Text, so a
+    name containing brackets can't raise MarkupError and crash the TUI."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    evil = "py[/]3"
+    app = KlangkApp(
+        _ws(
+            list_images=lambda: {
+                "default": "base",
+                "allowed": ["base", evil, "[red]bad[/]"],
+            },
+            allow_autostart=lambda: False,
+            create_workspace=lambda *a, **k: _wsobj("z"),
+        )
+    )
+    async with app.run_test() as pilot:
+        app.screen.action_create()
+        await pilot.pause()
+        # mounted + initial render without MarkupError
+        assert isinstance(app.screen, CreateWorkspaceScreen)
+        sel = app.screen.query_one("#image", Select)
+        # selecting each evil name renders its prompt (Text) literally — a bare
+        # markup string here would raise MarkupError and fail the test.
+        for name in (evil, "[red]bad[/]"):
+            sel.value = name
+            await pilot.pause()
+        assert sel.value == "[red]bad[/]"  # survived without crashing
+
+
+async def test_create_screen_http_error_non_json(monkeypatch):
+    """A non-JSON error body (proxy HTML page / empty) must not crash the
+    create handler — it should surface a failure message instead."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    resp = httpx.Response(
+        502,
+        text="<html>Bad Gateway</html>",
+        request=httpx.Request("POST", "https://x.example"),
+    )
+
+    def create(name, **k):
+        raise httpx.HTTPStatusError(
+            "boom", request=resp.request, response=resp
+        )
+
+    app = KlangkApp(_create_state(create=create))
+    async with app.run_test() as pilot:
+        app.screen.action_create()
+        await pilot.pause()
+        cs = app.screen
+        cs.query_one("#name").value = "ws"
+        cs._create()
+        assert "Failed to create" in str(cs.query_one("#create_msg").render())
+        assert isinstance(app.screen, CreateWorkspaceScreen)  # no crash
+
+
+async def test_create_screen_default_not_in_allowed(monkeypatch):
+    """When the server's default image isn't in the allowed list the picker
+    starts unselected, and an untouched picker omits the image (matching the
+    Flutter dialog); an explicit pick sends that image."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    captured = {}
+
+    def create(name, **k):
+        captured["k"] = k
+        return _wsobj(name)
+
+    app = KlangkApp(
+        _ws(
+            list_images=lambda: {
+                "default": "ghost",
+                "allowed": ["base", "py:3"],
+            },
+            allow_autostart=lambda: False,
+            create_workspace=create,
+        )
+    )
+    async with app.run_test() as pilot:
+        app.screen.action_create()
+        await pilot.pause()
+        cs = app.screen
+        # default not in allowed -> picker is unselected
+        assert cs.query_one("#image", Select).value is Select.NULL
+        cs.query_one("#name").value = "ws"
+        cs._create()  # nothing picked -> image omitted
+        await pilot.pause()
+        assert captured["k"]["image"] is None
+
+
+async def test_confirm_screen_button_labels(monkeypatch):
+    """ConfirmScreen's affirmative label/variant are parameterizable so the
+    create-offer doesn't show a red 'Delete' button for 'Open'.'"""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    app = KlangkApp(_ws())
+    async with app.run_test() as pilot:
+        # default (delete actions) -> 'Delete'
+        app.push_screen(ConfirmScreen("sure?"))
+        await pilot.pause()
+        btns = {b.id: b for b in app.screen.query(Button)}
+        assert "Delete" in str(btns["yes"].label)
+        # parameterized -> custom labels
+        app.push_screen(
+            ConfirmScreen(
+                "open?",
+                yes_label="Open",
+                yes_variant="primary",
+                no_label="Later",
+            )
+        )
+        await pilot.pause()
+        btns = {b.id: b for b in app.screen.query(Button)}
+        assert "Open" in str(btns["yes"].label)
+        assert "Later" in str(btns["no"].label)
 
 
 # ---------------------------------------------------------------------------

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import httpx
 import pytest
 from rich.text import Text
-from textual.widgets import Button, Input, OptionList, Static
+from textual.widgets import Button, Checkbox, Input, OptionList, Select, Static
 
 from klangk.cli import config as cfgmod
 from klangk.cli import tui as tui_pkg
@@ -29,6 +29,7 @@ from klangk.cli.config import (
 from klangk.cli.tui.screens import (
     AddServerScreen,
     ConfirmScreen,
+    CreateWorkspaceScreen,
     DuplicateScreen,
     LoginScreen,
     MainScreen,
@@ -235,6 +236,27 @@ def test_oidc_providers(monkeypatch, redirect_xdg):
     monkeypatch.setattr(tui_state_mod, "fetch_config", lambda url: None)
     assert TuiState("https://x.example").oidc_providers() == []
     assert TuiState().oidc_providers() == []
+
+
+def test_allow_autostart(monkeypatch, redirect_xdg):
+    monkeypatch.setattr(
+        tui_state_mod,
+        "fetch_config",
+        lambda url: {"allow_autostart": True},
+    )
+    assert TuiState("https://x.example").allow_autostart() is True
+    monkeypatch.setattr(
+        tui_state_mod,
+        "fetch_config",
+        lambda url: {"allow_autostart": False},
+    )
+    assert TuiState("https://x.example").allow_autostart() is False
+    # missing field / non-dict / no server -> safe default False
+    monkeypatch.setattr(tui_state_mod, "fetch_config", lambda url: {})
+    assert TuiState("https://x.example").allow_autostart() is False
+    monkeypatch.setattr(tui_state_mod, "fetch_config", lambda url: None)
+    assert TuiState("https://x.example").allow_autostart() is False
+    assert TuiState().allow_autostart() is False
 
 
 def test_login_password_success(monkeypatch, redirect_xdg):
@@ -812,6 +834,22 @@ def test_tui_state_workspace_methods(monkeypatch, redirect_xdg):
     fake.restart_workspace.assert_called_once_with("a")
     fake.delete_workspace.assert_called_once_with("a")
     fake.duplicate_workspace.assert_called_once_with("a", "c")
+
+    fake.create_workspace.return_value = _wsobj("new")
+    fake.list_images.return_value = {"default": "base", "allowed": ["base"]}
+    created = st.create_workspace("new", image="base", mounts=["/h:/c"])
+    assert created.name == "new"
+    assert st.list_images() == {"default": "base", "allowed": ["base"]}
+    fake.create_workspace.assert_called_once_with(
+        "new",
+        image="base",
+        service_command=None,
+        auto_start=False,
+        mounts=["/h:/c"],
+        env=None,
+        health_check=None,
+    )
+    fake.list_images.assert_called_once_with()
 
 
 def test_tui_state_terminal_methods(monkeypatch, redirect_xdg):
@@ -1639,6 +1677,433 @@ async def test_detail_delete_terminal_empty_result(monkeypatch):
         await pilot.pause()
         assert "Delete failed" in str(d.query_one("#detail_msg").render())
         assert d.query_one("#term_list").option_count == 2  # unchanged
+
+
+# ---------------------------------------------------------------------------
+# Create workspace form (#1748)
+# ---------------------------------------------------------------------------
+
+
+def _create_state(create=None, **extra):
+    """Authed state with image/autostart/create stubs for create-screen tests."""
+    base = dict(
+        list_images=lambda: {
+            "default": "base",
+            "allowed": ["base", "py:3"],
+        },
+        allow_autostart=lambda: True,
+        create_workspace=create or (lambda *a, **k: _wsobj("zzz")),
+    )
+    base.update(extra)
+    return _ws(**base)
+
+
+async def test_create_screen_renders_defaults(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    app = KlangkApp(_create_state())
+    async with app.run_test() as pilot:
+        app.screen.action_create()
+        await pilot.pause()
+        cs = app.screen
+        assert isinstance(cs, CreateWorkspaceScreen)
+        cb = cs.query_one("#auto_start", Checkbox)
+        assert cb.display is True  # shown (autostart allowed)
+        assert cb.value is False  # off by default
+        assert cs.query_one("#image", Select).value == "base"  # server default
+
+
+async def test_create_screen_autostart_hidden_when_not_allowed(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    app = KlangkApp(_create_state(allow_autostart=lambda: False))
+    async with app.run_test() as pilot:
+        app.screen.action_create()
+        await pilot.pause()
+        cb = app.screen.query_one("#auto_start", Checkbox)
+        assert cb.display is False
+        assert cb.disabled is True
+
+
+async def test_create_screen_mount_editor(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    app = KlangkApp(_create_state())
+    async with app.run_test() as pilot:
+        app.screen.action_create()
+        await pilot.pause()
+        cs = app.screen
+        # valid add
+        cs.query_one("#mount_input").value = "/host:/c:ro"
+        cs._add_mount()
+        assert cs._mounts == ["/host:/c:ro"]
+        assert cs.query_one("#mount_input").value == ""
+        # invalid rejected, message shown
+        cs.query_one("#mount_input").value = "badmount"
+        cs._add_mount()
+        assert cs._mounts == ["/host:/c:ro"]
+        assert "source:dest" in str(cs.query_one("#create_msg").render())
+        # empty input is a no-op
+        cs._add_mount()
+        # remove the highlighted entry
+        cs.query_one("#mount_list").highlighted = 0
+        cs._remove_mount()
+        assert cs._mounts == []
+
+
+async def test_create_screen_env_editor(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    app = KlangkApp(_create_state())
+    async with app.run_test() as pilot:
+        app.screen.action_create()
+        await pilot.pause()
+        cs = app.screen
+        cs.query_one("#env_input").value = "FOO=bar"
+        cs._add_env()
+        assert cs._env == {"FOO": "bar"}
+        # invalid rejected
+        cs.query_one("#env_input").value = "NOEQ"
+        cs._add_env()
+        assert cs._env == {"FOO": "bar"}
+        assert "KEY=VALUE" in str(cs.query_one("#create_msg").render())
+        # duplicate key overwrites
+        cs.query_one("#env_input").value = "FOO=baz"
+        cs._add_env()
+        assert cs._env == {"FOO": "baz"}
+        # remove
+        cs.query_one("#env_list").highlighted = 0
+        cs._remove_env()
+        assert cs._env == {}
+
+
+async def test_create_screen_name_required(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    called = []
+    app = KlangkApp(
+        _create_state(create=lambda *a, **k: called.append(k) or _wsobj("z"))
+    )
+    async with app.run_test() as pilot:
+        app.screen.action_create()
+        await pilot.pause()
+        app.screen._create()  # name empty
+        assert called == []
+        assert (
+            "required"
+            in str(app.screen.query_one("#create_msg").render()).lower()
+        )
+
+
+async def test_create_screen_submit_omits_default_image(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    captured = {}
+
+    def create(name, **k):
+        captured["name"] = name
+        captured["k"] = k
+        return _wsobj(name)
+
+    app = KlangkApp(
+        _create_state(create=create, allow_autostart=lambda: False)
+    )
+    async with app.run_test() as pilot:
+        app.screen.action_create()
+        await pilot.pause()
+        cs = app.screen
+        cs.query_one("#name").value = "myws"
+        cs._create()  # default image kept -> omitted
+        await pilot.pause()
+        assert captured["name"] == "myws"
+        assert captured["k"]["image"] is None
+        assert captured["k"]["auto_start"] is False
+        assert captured["k"]["mounts"] is None
+        assert captured["k"]["env"] is None
+
+
+async def test_create_screen_submit_custom_fields(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    captured = {}
+
+    def create(name, **k):
+        captured["name"] = name
+        captured["k"] = k
+        return _wsobj(name)
+
+    app = KlangkApp(_create_state(create=create))
+    async with app.run_test() as pilot:
+        app.screen.action_create()
+        await pilot.pause()
+        cs = app.screen
+        cs.query_one("#name").value = "myws"
+        cs.query_one("#image", Select).value = "py:3"
+        cs.query_one("#command").value = "sleep 1"
+        cs.query_one("#health_check").value = "curl localhost"
+        cs.query_one("#mount_input").value = "/h:/c"
+        cs._add_mount()
+        cs.query_one("#env_input").value = "A=1"
+        cs._add_env()
+        cs.query_one("#auto_start", Checkbox).value = True
+        cs._create()
+        await pilot.pause()
+        assert captured["k"]["image"] == "py:3"
+        assert captured["k"]["service_command"] == "sleep 1"
+        assert captured["k"]["health_check"] == "curl localhost"
+        assert captured["k"]["mounts"] == ["/h:/c"]
+        assert captured["k"]["env"] == {"A": "1"}
+        assert captured["k"]["auto_start"] is True
+
+
+async def test_create_screen_http_error_shows_detail(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    resp = httpx.Response(
+        400,
+        json={"detail": "name taken"},
+        request=httpx.Request("POST", "https://x.example"),
+    )
+
+    def create(name, **k):
+        raise httpx.HTTPStatusError(
+            "boom", request=resp.request, response=resp
+        )
+
+    app = KlangkApp(_create_state(create=create))
+    async with app.run_test() as pilot:
+        app.screen.action_create()
+        await pilot.pause()
+        cs = app.screen
+        cs.query_one("#name").value = "dup"
+        cs._create()
+        assert "name taken" in str(cs.query_one("#create_msg").render())
+        assert isinstance(app.screen, CreateWorkspaceScreen)  # still on form
+
+
+async def test_create_screen_auth_error(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+
+    def create(name, **k):
+        raise AuthError("expired")
+
+    app = KlangkApp(_create_state(create=create))
+    async with app.run_test() as pilot:
+        app.screen.action_create()
+        await pilot.pause()
+        cs = app.screen
+        cs.query_one("#name").value = "ws"
+        cs._create()
+        assert "Session expired" in str(cs.query_one("#create_msg").render())
+
+
+async def test_create_screen_images_unavailable(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    captured = {}
+
+    def create(name, **k):
+        captured["k"] = k
+        return _wsobj(name)
+
+    def boom():
+        raise RuntimeError("images endpoint down")
+
+    app = KlangkApp(
+        _create_state(create=create, list_images=boom, allow_autostart=boom)
+    )
+    async with app.run_test() as pilot:
+        app.screen.action_create()
+        await pilot.pause()
+        cs = app.screen
+        assert cs._allowed == []
+        assert cs.query_one("#auto_start", Checkbox).display is False
+        cs.query_one("#name").value = "ws"
+        cs._create()
+        await pilot.pause()
+        assert captured["k"]["image"] is None  # omitted
+
+
+async def test_create_screen_cancel_button(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    app = KlangkApp(_create_state())
+    async with app.run_test() as pilot:
+        app.screen.action_create()
+        await pilot.pause()
+        app.screen.on_button_pressed(FakeBtnPress("cancel"))
+        await pilot.pause()
+        assert isinstance(app.screen, MainScreen)  # back to the list
+
+
+async def test_create_screen_input_submit_routing(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    app = KlangkApp(_create_state())
+    async with app.run_test() as pilot:
+        app.screen.action_create()
+        await pilot.pause()
+        cs = app.screen
+        # empty name submit -> required error (no dismiss)
+        name = cs.query_one("#name")
+        cs.on_input_submitted(Input.Submitted(name, ""))
+        assert "required" in str(cs.query_one("#create_msg").render()).lower()
+        # mount input submit -> add
+        m = cs.query_one("#mount_input")
+        m.value = "/h:/c"
+        cs.on_input_submitted(Input.Submitted(m, m.value))
+        assert cs._mounts == ["/h:/c"]
+        # env input submit -> add
+        e = cs.query_one("#env_input")
+        e.value = "K=V"
+        cs.on_input_submitted(Input.Submitted(e, e.value))
+        assert cs._env == {"K": "V"}
+
+
+async def test_create_flow_offer_opens_detail(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    app = KlangkApp(_create_state(create=lambda *a, **k: _wsobj("new")))
+    async with app.run_test() as pilot:
+        app.screen.action_create()
+        await pilot.pause()
+        cs = app.screen
+        cs.query_one("#name").value = "new"
+        cs._create()
+        await pilot.pause()
+        assert isinstance(app.screen, ConfirmScreen)  # "Open it now?"
+        app.screen.dismiss(True)
+        await pilot.pause()
+        assert isinstance(app.screen, WorkspaceDetailScreen)
+        assert app.screen._name == "new"
+
+
+async def test_create_flow_offer_declined(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    app = KlangkApp(_create_state(create=lambda *a, **k: _wsobj("new")))
+    async with app.run_test() as pilot:
+        app.screen.action_create()
+        await pilot.pause()
+        cs = app.screen
+        cs.query_one("#name").value = "new"
+        cs._create()
+        await pilot.pause()
+        assert isinstance(app.screen, ConfirmScreen)
+        app.screen.dismiss(False)
+        await pilot.pause()
+        assert isinstance(app.screen, MainScreen)
+
+
+async def test_create_editor_guards(monkeypatch):
+    """Empty input + nothing-highlighted are no-ops (guard returns)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    app = KlangkApp(_create_state())
+    async with app.run_test() as pilot:
+        app.screen.action_create()
+        await pilot.pause()
+        cs = app.screen
+        # empty input -> no-op for both editors
+        cs._add_mount()
+        assert cs._mounts == []
+        cs._add_env()
+        assert cs._env == {}
+        # nothing highlighted -> remove is a no-op
+        cs.query_one("#mount_list").highlighted = None
+        cs._remove_mount()
+        cs.query_one("#env_list").highlighted = None
+        cs._remove_env()
+        assert cs._mounts == []
+        assert cs._env == {}
+
+
+async def test_create_screen_generic_error(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+
+    def create(name, **k):
+        raise RuntimeError("boom")
+
+    app = KlangkApp(_create_state(create=create))
+    async with app.run_test() as pilot:
+        app.screen.action_create()
+        await pilot.pause()
+        cs = app.screen
+        cs.query_one("#name").value = "ws"
+        cs._create()
+        assert "Failed to create: boom" in str(
+            cs.query_one("#create_msg").render()
+        )
+
+
+async def test_create_button_routing(monkeypatch):
+    """on_button_pressed routes add/rm/create to the editor + create paths."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    app = KlangkApp(_create_state(create=lambda *a, **k: _wsobj("ws")))
+    async with app.run_test() as pilot:
+        app.screen.action_create()
+        await pilot.pause()
+        cs = app.screen
+        # add mount via button
+        cs.query_one("#mount_input").value = "/h:/c"
+        cs.on_button_pressed(FakeBtnPress("add_mount"))
+        assert cs._mounts == ["/h:/c"]
+        # remove mount via button
+        cs.query_one("#mount_list").highlighted = 0
+        cs.on_button_pressed(FakeBtnPress("rm_mount"))
+        assert cs._mounts == []
+        # add env via button
+        cs.query_one("#env_input").value = "K=V"
+        cs.on_button_pressed(FakeBtnPress("add_env"))
+        assert cs._env == {"K": "V"}
+        # remove env via button
+        cs.query_one("#env_list").highlighted = 0
+        cs.on_button_pressed(FakeBtnPress("rm_env"))
+        assert cs._env == {}
+        # create via button -> success -> offer
+        cs.query_one("#name").value = "ws"
+        cs.on_button_pressed(FakeBtnPress("create"))
+        await pilot.pause()
+        assert isinstance(app.screen, ConfirmScreen)
 
 
 # ---------------------------------------------------------------------------

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -1059,6 +1059,36 @@ async def test_detail_action_edit_opens_form_and_refreshes(monkeypatch):
         assert finds.count("alpha") >= 2  # initial load + post-edit reload
 
 
+async def test_detail_and_edit_set_window_title(monkeypatch):
+    # The app/window title reflects the active screen: "Klangk: Workspaces"
+    # on the list, "Klangk: workspace <name>" on detail/edit, restored on pop.
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    a = _wsobj("alpha", image="base")
+    st = _ws(
+        list_images=lambda: {"default": "base", "allowed": ["base", "py:3"]},
+        allow_autostart=lambda: True,
+    )
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        assert app.title == "Klangk: Workspaces"
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        assert app.title == "Klangk: workspace alpha"
+        app.screen.action_edit()
+        await pilot.pause()
+        assert app.title == "Klangk: workspace alpha"  # edit (same workspace)
+        app.pop_screen()  # edit -> detail
+        await pilot.pause()
+        assert app.title == "Klangk: workspace alpha"
+        app.pop_screen()  # detail -> main
+        await pilot.pause()
+        assert app.title == "Klangk: Workspaces"
+
+
 async def test_detail_load_failure(monkeypatch):
     async def noop(*a, **k):
         return None

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -2863,6 +2863,151 @@ async def test_detail_action_edit_fetch_failure(monkeypatch):
         assert app.screen._select_value == "(none)"
 
 
+async def test_edit_screen_keyboard_remove(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    ws = _wsobj(
+        "alpha",
+        mounts=["/h:/c"],
+        env={"K": "v"},
+        allowed_domains=["github.com:443"],
+    )
+    app = KlangkApp(_edit_state(ws))
+    async with app.run_test() as pilot:
+        _edit_screen(app, ws)
+        await pilot.pause()
+        es = app.screen
+        # Delete/remove dispatches to the focused OptionList.
+        for lid, attr in (
+            ("#mount_list", "_mounts"),
+            ("#env_list", "_env"),
+            ("#allow_list", "_allowed_domains"),
+        ):
+            ol = es.query_one(lid)
+            ol.focus()
+            await pilot.pause()
+            ol.highlighted = 0
+            es.action_remove_item()
+            assert not getattr(es, attr)  # [] or {}
+        # Not focused on a list -> no-op.
+        es.query_one("#name").focus()
+        await pilot.pause()
+        es.action_remove_item()
+
+
+async def test_edit_screen_edit_in_place(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    ws = _wsobj(
+        "alpha",
+        mounts=["/h:/c"],
+        env={"K": "v"},
+        allowed_domains=["github.com:443"],
+    )
+    app = KlangkApp(_edit_state(ws))
+    async with app.run_test() as pilot:
+        _edit_screen(app, ws)
+        await pilot.pause()
+        es = app.screen
+        # 'e' on the focused mount loads it into the input (edit mode).
+        ol = es.query_one("#mount_list")
+        ol.focus()
+        await pilot.pause()
+        ol.highlighted = 0
+        es.action_edit_item()
+        assert es.query_one("#mount_input").value == "/h:/c"
+        assert es._editing_mount == 0
+        es.query_one("#mount_input").value = "/h:/c2"
+        es._add_mount()  # replaces, not appends
+        assert es._mounts == ["/h:/c2"]
+        assert es._editing_mount is None
+        # env edit (key tracked)
+        ol = es.query_one("#env_list")
+        ol.focus()
+        await pilot.pause()
+        ol.highlighted = 0
+        es.action_edit_item()
+        assert es.query_one("#env_input").value == "K=v"
+        es.query_one("#env_input").value = "K=changed"
+        es._add_env()
+        assert es._env == {"K": "changed"}
+        # allowed-domain edit
+        ol = es.query_one("#allow_list")
+        ol.focus()
+        await pilot.pause()
+        ol.highlighted = 0
+        es.action_edit_item()
+        assert es.query_one("#allow_input").value == "github.com:443"
+        es.query_one("#allow_input").value = "pypi.org"
+        es._add_allowed_domain()
+        assert es._allowed_domains == ["pypi.org"]
+        # nothing highlighted -> each _edit_* is a no-op (guard returns)
+        es.query_one("#mount_list").highlighted = None
+        es._edit_mount()
+        es.query_one("#env_list").highlighted = None
+        es._edit_env()
+        es.query_one("#allow_list").highlighted = None
+        es.action_edit_item()
+
+
+async def test_edit_rename_propagates_to_detail_and_list(monkeypatch):
+    # #1778/#1768: renaming via the edit form must update the detail screen's
+    # name (so it doesn't 404) and refresh the list (so the new name shows).
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    original = _wsobj("alpha", image="base", running=False)
+    renamed = _wsobj("renamed", image="base")
+    returns = [original, renamed]
+    finds = []
+    st = _ws(
+        list_images=lambda: {"default": "base", "allowed": ["base", "py:3"]},
+        allow_autostart=lambda: True,
+        update_workspace=lambda wid, **f: None,
+    )
+    st.find_workspace = lambda n: finds.append(n) or returns.pop(0)
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        assert app.screen._name == "alpha"
+        app.screen.action_edit()
+        await pilot.pause()
+        es = app.screen
+        es.query_one("#name").value = "renamed"
+        es._save()
+        await pilot.pause()
+        # back on detail; name adopted + reloaded by the new name
+        assert isinstance(app.screen, WorkspaceDetailScreen)
+        assert app.screen._name == "renamed"
+        assert finds[-1] == "renamed"  # _load resolved the new name
+
+
+async def test_create_screen_no_server_does_not_crash(monkeypatch):
+    # `klangk` with no server configured: pressing `n` must not crash the TUI
+    # (list_images raises ValueError, caught -> form opens with no images).
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+
+    def boom():
+        raise ValueError("no server configured")
+
+    app = KlangkApp(_create_state(list_images=boom, allow_autostart=boom))
+    async with app.run_test() as pilot:
+        app.screen.action_create()  # must not raise
+        await pilot.pause()
+        cs = app.screen
+        assert isinstance(cs, CreateWorkspaceScreen)
+        assert cs._allowed == []
+
+
 async def test_confirm_screen_button_labels(monkeypatch):
     """ConfirmScreen's affirmative label/variant are parameterizable so the
     create-offer doesn't show a red 'Delete' button for 'Open'.'"""


### PR DESCRIPTION
> **Update:** this PR now also adds the TUI **workspace edit form** (#1778) and the `allowed_domains` editor across the TUI create/edit/detail flows (#1745, TUI portions).

- **Edit form** — `EditWorkspaceScreen`, parity with the Flutter settings panel, reached via **`e`** on the detail screen. Pre-populated from the workspace; saves via a partial `PUT` (new `client.update_workspace`). A create-time field change (image / mounts / env / service_command / allowed_domains) on a *running* workspace offers a "restart needed to apply"; `setup_state` / `health_check` propagate live and are excluded.
- **allowed_domains** — editor added to the create form + shown in the detail view; validated client-side with a new CLI-isolated `validate_allowed_domain_spec` (no `klangk.netfilter` import).
- HTTP stays synchronous (consistent with the create form); the UI-thread freeze is tracked by #1766.

Remaining for full #1749 / #1745 parity: CLI (#1779) and Flutter (#1780).

Closes #1778.

---

Closes #1748.

## Summary

Adds a full-screen workspace **create form** to the textual TUI, mirroring the Flutter `CreateWorkspaceDialog` and reusing the CLI's validation. Press **`n`** on the workspace list to open it.

### Fields (parity order with Flutter)
- **Name** (required)
- **Container image** — a `Select` populated from `/api/v1/images`; defaults to the server's default image, which is omitted from the create body (the server applies its default). If the server's default isn't in the allowed list the picker starts unselected (matching Flutter).
- **Mounts** — add/remove list editor, validated with `cli.mount.validate_mount_spec` (`source:/container[:opts]`)
- **Environment** — add/remove list editor, validated with a new `validate_env_entry` (`KEY=VALUE`, key required) — matches the Flutter dialog (the CLI's env parsing is marginally looser)
- **Service shell command** (optional)
- **Health check command** (optional)
- **Auto start** — `Checkbox`, **off by default**, rendered (with a caption) only when the server permits it (`allow_autostart` from `/api/v1/config`)

### Behavior
- Identical validation to the Flutter dialog (mount/env).
- All user-facing text — including the **image-picker entries sourced from the server** and the create-result message — renders via rich `Text`, so bracket-laden names/messages can't crash the TUI. A non-JSON server error body (proxy HTML page, empty body) is handled gracefully rather than crashing.
- If the image list can't be fetched, the form still works via an inert "(server default)" placeholder.
- Create errors surface the server's `detail` (HTTP, parsed defensively), an auth-expired message (`AuthError`), or a generic failure.
- On success the workspace list refreshes and the TUI **offers to open the new workspace's detail screen** (where its terminals are listed).

### Notes / honest caveats
- **"Open shell now" (#1748 acceptance bullet):** the TUI cannot yet launch a live in-TUI PTY shell (`klangk shell` attaches the terminal; in-TUI shell is a future step). So the post-create offer **opens the workspace detail screen**, not a live shell — i.e. the bullet is satisfied as **"open workspace"** for now. The commit message, changelog, and an inline docstring say so explicitly. If a live shell is required to close #1748, that's a separate follow-up.
- **UI-thread blocking:** `MainScreen.action_create` does two synchronous fetches (`list_images` + `allow_autostart`) and the create itself is sync HTTP — the same class of event-loop work already filed as **#1766** (which will cover this path too). Consistent with the existing `refresh_lists` pattern; not a new class of debt.

## Review history
An adversarial `/review` found two reproducible crashes and several parity/UX gaps; all addressed in a follow-up commit (6e9c72eb):
- **B1 (fixed):** non-JSON error body crashed `_create` from inside the `except` — now parsed defensively (+ test).
- **B2 (fixed):** image names in the `Select` were markup-parsed bare strings → `MarkupError` crash — now `Text` prompts (+ test selecting bracket-laden names).
- **I3/I4 (fixed):** the post-create offer reused `ConfirmScreen`, whose affirmative button was hard-labeled **"Delete"** — `ConfirmScreen` is now parameterizable; the offer says **"Open"** and the restart confirm now says **"Restart"** (was also "Delete").
- **I6 (fixed):** default-image omission diverged from Flutter when the server default is empty/not-in-allowed — picker now starts unselected and an untouched picker omits the image (+ test).
- **Nits (fixed):** `allow_autostart` now strict `is True`; auto-start caption added for parity; changelog wording corrected.

## Acceptance criteria
- [x] Create form with image picker + mounts/env list editors + auto-start toggle
- [x] `auto_start` off by default; toggle gated by server `allow_autostart`
- [~] Post-create "open shell" offer — **implemented as "open workspace"** (opens the detail screen); a live in-TUI shell is a future step
- [x] Identical validation to Flutter (mount `host:container`, env `KEY=VALUE`)

## Testing
- 100% coverage on the `klangk` package; full suite **3439 tests** green (`-n auto`).
- 21 pilot/unit tests for the create flow (render/defaults, autostart gating + caption, mount/env add+validate+remove, name-required, default-image omission incl. default-not-in-allowed, custom-field submit, HTTP **and non-JSON** errors, auth/generic errors, images-unavailable, **markup-safe image names**, cancel, input/button routing, confirm-button labels, and the post-create offer accept/decline).

