### PR TITLE
TUI: replace OptionList with ListView + spatial navigation + ctrl+c quit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,24 @@ the same wheel but runs in the user's environment against a remote backend;
 it has no access to the server's `app.state`, settings, or process-local
 singletons.
 
+## TUI spatial navigation (no focus traps)
+
+The textual TUI must use **spatial navigation** — arrow keys move focus
+between logical areas (tab strips, lists, form fields) without requiring
+Tab/Shift-Tab to cross boundaries. Never create **focus traps** (a
+composite widget that swallows all keys and won't release focus without
+Tab). Specifically:
+
+- Down from a tab strip or section header enters the list/pane below it.
+- Up from the first row of a list returns focus to the tab strip above.
+- Left/Right move between sibling columns or tab pages.
+- Tab/Shift-Tab still works as a fallback, but arrows must always be
+  sufficient to reach any element in reading order (top-to-bottom,
+  left-to-right).
+- When implementing a new screen or widget, add the key bridges that let
+  arrows cross its boundaries (see `WorkspaceListView.action_cursor_up`
+  and `MainScreen.on_key` for the pattern).
+
 Practical consequence: anything centralized on the server side as an
 `app.state.*` object (e.g. logging via a `Logger(app)` state object) is
 **not** shared with the CLI — the client keeps its own setup and reaches the

--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -66,7 +66,11 @@ class KlangkApp(App):
     }
     """
 
-    BINDINGS = [("q", "quit", "Quit")]
+    BINDINGS = [
+        ("q", "quit", "Quit"),
+        ("ctrl+q", "quit", "Quit"),
+        ("ctrl+c", "quit", "Quit"),
+    ]
 
     def __init__(self, state: TuiState) -> None:
         super().__init__()

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -159,15 +159,31 @@ class LoginScreen(Screen):
             self._show_no_server()
 
     def on_key(self, event) -> None:
-        # Spatial nav: Up from the server-input field returns focus to the
-        # server list above it (#1781).
-        if (
-            event.key == "up"
-            and isinstance(self.focused, Input)
-            and self.focused.id == "server_input"
-        ):
+        # Spatial navigation: Up/Down traverse the login form in reading
+        # order — server list → URL → Use server → email → password →
+        # Log in — without Tab/Shift-Tab (#1781).
+        fid = getattr(self.focused, "id", None) if self.focused else None
+        if not fid:
+            return
+        _chain = [
+            "server_input",
+            "use_server",
+            "identifier",
+            "password",
+            "login",
+        ]
+        if fid not in _chain:
+            return
+        pos = _chain.index(fid)
+        if event.key == "up":
             event.stop()
-            self.query_one("#server_options", ServerListView).focus()
+            if pos == 0:
+                self.query_one("#server_options", ServerListView).focus()
+            else:
+                self.query_one(f"#{_chain[pos - 1]}").focus()
+        elif event.key == "down" and pos < len(_chain) - 1:
+            event.stop()
+            self.query_one(f"#{_chain[pos + 1]}").focus()
 
     def _show_no_server(self) -> None:
         self.query_one("#server_line", Static).update(

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -104,15 +104,42 @@ class ServerListView(ListView):
     def action_cursor_down(self) -> None:
         items = list(self.query(ListItem))
         if self.index is not None and items and self.index >= len(items) - 1:
-            try:
-                self.screen.query_one("#server_input", Input).focus()
-                return
-            except NoMatches:
-                pass
-        super().action_cursor_down()
+            self.screen.query_one("#server_input", Input).focus()
+        else:
+            super().action_cursor_down()
 
 
-class LoginScreen(Screen):
+class SpatialNavScreen(Screen):
+    """Screen mixin for spatial Up/Down navigation between a chain of
+    widgets (inputs, buttons) in reading order (#1781).
+
+    Declare ``SPATIAL_CHAIN`` (widget ids, top-to-bottom) and optionally
+    ``SPATIAL_UP_EXIT`` (the widget id to focus when Up is pressed at the
+    top of the chain). The mixin handles the rest — no per-screen
+    ``on_key`` body needed.
+    """
+
+    SPATIAL_CHAIN: list[str] = []
+    SPATIAL_UP_EXIT: str | None = None
+
+    def on_key(self, event) -> None:
+        fid = getattr(self.focused, "id", None) if self.focused else None
+        if not fid or fid not in self.SPATIAL_CHAIN:
+            return
+        pos = self.SPATIAL_CHAIN.index(fid)
+        if event.key == "up":
+            if pos > 0:
+                event.stop()
+                self.query_one(f"#{self.SPATIAL_CHAIN[pos - 1]}").focus()
+            elif self.SPATIAL_UP_EXIT:
+                event.stop()
+                self.query_one(f"#{self.SPATIAL_UP_EXIT}").focus()
+        elif event.key == "down" and pos < len(self.SPATIAL_CHAIN) - 1:
+            event.stop()
+            self.query_one(f"#{self.SPATIAL_CHAIN[pos + 1]}").focus()
+
+
+class LoginScreen(SpatialNavScreen):
     """Credential screen that also picks the server to log into.
 
     A fresh user with no server configured can pick a known alias, select
@@ -123,7 +150,17 @@ class LoginScreen(Screen):
     password form; ``unreachable`` → diagnostic.
     """
 
-    BINDINGS = [("d", "delete_server", "Delete server")]
+    BINDINGS = [
+        ("d", "delete_server", "Delete server")
+    ]  # spatial nav via SpatialNavScreen mixin
+    SPATIAL_CHAIN = [
+        "server_input",
+        "use_server",
+        "identifier",
+        "password",
+        "login",
+    ]
+    SPATIAL_UP_EXIT = "server_options"
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=False)
@@ -157,33 +194,6 @@ class LoginScreen(Screen):
             self._setup_auth()
         else:
             self._show_no_server()
-
-    def on_key(self, event) -> None:
-        # Spatial navigation: Up/Down traverse the login form in reading
-        # order — server list → URL → Use server → email → password →
-        # Log in — without Tab/Shift-Tab (#1781).
-        fid = getattr(self.focused, "id", None) if self.focused else None
-        if not fid:
-            return
-        _chain = [
-            "server_input",
-            "use_server",
-            "identifier",
-            "password",
-            "login",
-        ]
-        if fid not in _chain:
-            return
-        pos = _chain.index(fid)
-        if event.key == "up":
-            event.stop()
-            if pos == 0:
-                self.query_one("#server_options", ServerListView).focus()
-            else:
-                self.query_one(f"#{_chain[pos - 1]}").focus()
-        elif event.key == "down" and pos < len(_chain) - 1:
-            event.stop()
-            self.query_one(f"#{_chain[pos + 1]}").focus()
 
     def _show_no_server(self) -> None:
         self.query_one("#server_line", Static).update(
@@ -400,12 +410,9 @@ class WorkspaceListView(ListView):
 
     def action_cursor_up(self) -> None:
         if self.index in (0, None):
-            try:
-                self.screen.query_one(Tabs).focus()
-                return
-            except NoMatches:
-                pass
-        super().action_cursor_up()
+            self.screen.query_one(Tabs).focus()
+        else:
+            super().action_cursor_up()
 
 
 class MainScreen(Screen):

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -25,11 +25,15 @@ from textual.widgets import (
     Footer,
     Header,
     Input,
+    Label,
+    ListItem,
+    ListView,
     OptionList,
     Select,
     Static,
     TabbedContent,
     TabPane,
+    Tabs,
 )
 from textual.widgets.option_list import Option
 
@@ -110,7 +114,7 @@ class LoginScreen(Screen):
         yield Header(show_clock=False)
         yield Vertical(
             Static("", id="server_line"),
-            OptionList(id="server_options"),
+            ListView(id="server_options"),
             Input(
                 placeholder=("Server URL or alias (e.g. https://host, prod)"),
                 id="server_input",
@@ -149,19 +153,23 @@ class LoginScreen(Screen):
     # --- server picker ---
 
     def _populate_servers(self) -> None:
-        ol = self.query_one("#server_options", OptionList)
-        ol.clear_options()
+        lv = self.query_one("#server_options", ListView)
+        lv.clear()
         current = self.app.tui_state.current_url()
         known = self.app.tui_state.known_servers()
         known_urls = {s.url for s in known}
         for s in known:
             mark = "*" if s.url == current else " "
-            ol.add_option(Option(f"{mark} {s.alias}  ({s.url})", id=s.url))
+            lv.append(
+                ListItem(Label(f"{mark} {s.alias}  ({s.url})"), name=s.url)
+            )
         uds = self.app.tui_state.default_uds()
         # Only offer the auto-detected default UDS if no alias already covers
         # it (otherwise it would duplicate the persisted alias row).
         if uds and uds != current and uds not in known_urls:
-            ol.add_option(Option(f"  Local klangkd (UDS)  ({uds})", id=uds))
+            lv.append(
+                ListItem(Label(f"  Local klangkd (UDS)  ({uds})"), name=uds)
+            )
 
     @staticmethod
     def _derive_alias(raw: str) -> str:
@@ -198,12 +206,12 @@ class LoginScreen(Screen):
         self._setup_auth()
 
     def action_delete_server(self) -> None:
-        ol = self.query_one("#server_options", OptionList)
-        idx = ol.highlighted
-        if idx is None:
+        lv = self.query_one("#server_options", ListView)
+        child = lv.highlighted_child
+        if child is None:
             self._set_message("Select a server to delete.", error=True)
             return
-        url = ol.get_option_at_index(idx).id
+        url = child.name
 
         def _on_confirm(confirmed: bool) -> None:
             if not confirmed:
@@ -322,10 +330,8 @@ class LoginScreen(Screen):
 
     # --- event handlers ---
 
-    def on_option_list_option_selected(
-        self, event: OptionList.OptionSelected
-    ) -> None:
-        self._choose_server(event.option.id)
+    def on_list_view_selected(self, event: ListView.Selected) -> None:
+        self._choose_server(getattr(event.item, "name", "") or "")
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if event.button.id == "use_server":
@@ -342,6 +348,24 @@ class LoginScreen(Screen):
             self._attempt_password()
 
 
+class WorkspaceListView(ListView):
+    """A workspace list that hands focus back to the tab strip when the
+    cursor is at the top and Up is pressed (#1781).
+
+    This lets the user move between the “Owned by me” / “Shared to me” tabs
+    and the workspace list with just Up/Down — no Tab/Shift-Tab needed.
+    """
+
+    def action_cursor_up(self) -> None:
+        if self.index in (0, None):
+            try:
+                self.screen.query_one(Tabs).focus()
+                return
+            except NoMatches:
+                pass
+        super().action_cursor_up()
+
+
 class MainScreen(Screen):
     """The TUI home: a two-page workspace list (owned / shared) + status bar,
     with a live WS feed. Selecting a workspace opens its detail screen."""
@@ -355,8 +379,8 @@ class MainScreen(Screen):
     def compose(self) -> ComposeResult:
         yield Header(show_clock=False)
         with TabbedContent(id="ws_tabs"):
-            yield TabPane("Owned by me", OptionList(id="owned_list"))
-            yield TabPane("Shared to me", OptionList(id="shared_list"))
+            yield TabPane("Owned by me", WorkspaceListView(id="owned_list"))
+            yield TabPane("Shared to me", WorkspaceListView(id="shared_list"))
         yield StatusBar(id="status")
         yield Footer()
 
@@ -365,6 +389,17 @@ class MainScreen(Screen):
         self.refresh_lists()
         if self.app.tui_state.is_authenticated():
             self.app.run_worker(self._status_loop, name="status-ws")
+
+    def on_key(self, event) -> None:
+        # Down from the tab strip drops into the active workspace list (#1781).
+        if event.key == "down" and isinstance(self.focused, Tabs):
+            for lv in self.query(WorkspaceListView):
+                if lv.display:
+                    event.stop()
+                    lv.focus()
+                    if lv.index is None:
+                        lv.index = 0
+                    break
 
     def action_switch_server(self) -> None:
         self.app.push_screen(ServerSwitchScreen())
@@ -464,13 +499,13 @@ class MainScreen(Screen):
         *,
         empty_label: str = "(no workspaces)",
     ) -> None:
-        ol = self.query_one(selector, OptionList)
-        ol.clear_options()
+        lv = self.query_one(selector, ListView)
+        lv.clear()
         if not workspaces:
-            ol.add_option(Option(Text(empty_label), id="", disabled=True))
+            lv.append(ListItem(Label(Text(empty_label)), name=""))
             return
         for ws in workspaces:
-            ol.add_option(Option(self._fmt(ws), id=ws.name))
+            lv.append(ListItem(Label(self._fmt(ws)), name=ws.name))
 
     def _refresh_status(self) -> None:
         state = self.app.tui_state
@@ -480,10 +515,8 @@ class MainScreen(Screen):
             extra=self.app.live_extra,
         )
 
-    def on_option_list_option_selected(
-        self, event: OptionList.OptionSelected
-    ) -> None:
-        name = event.option.id
+    def on_list_view_selected(self, event: ListView.Selected) -> None:
+        name = getattr(event.item, "name", "") or ""
         if name:
             self.app.push_screen(WorkspaceDetailScreen(name))
 
@@ -551,7 +584,7 @@ class WorkspaceDetailScreen(Screen):
             Static("", id="detail_title"),
             Static("", id="detail_body"),
             Static("Terminals (own):", id="term_label"),
-            OptionList(id="term_list"),
+            ListView(id="term_list"),
             Static("", id="detail_msg"),
             id="detail_box",
         )
@@ -707,27 +740,27 @@ class WorkspaceDetailScreen(Screen):
         self._render_terminals()
 
     def _render_terminals(self) -> None:
-        ol = self.query_one("#term_list", OptionList)
-        ol.clear_options()
+        lv = self.query_one("#term_list", ListView)
+        lv.clear()
         if not self._terminals:
-            ol.add_option(Option(Text("(no terminals)"), id="", disabled=True))
+            lv.append(ListItem(Label(Text("(no terminals)")), name=""))
             return
         for w in self._terminals:
             idx = w.get("index", "")
             name = w.get("name") or idx
-            ol.add_option(Option(Text(f"{idx}  {name}"), id=str(idx)))
+            lv.append(ListItem(Label(Text(f"{idx}  {name}")), name=str(idx)))
 
     def action_delete_terminal(self) -> None:
-        ol = self.query_one("#term_list", OptionList)
-        if ol.highlighted is None:
+        lv = self.query_one("#term_list", ListView)
+        child = lv.highlighted_child
+        if child is None:
             return
-        opt = ol.get_option_at_index(ol.highlighted)
-        if not opt.id:
+        if not child.name:
             return
         if len(self._terminals) <= 1:
             self._msg("Can't delete the last terminal.", error=True)
             return
-        index = int(opt.id)
+        index = int(child.name)
         self.run_worker(self._do_delete_terminal(index), exit_on_error=False)
 
     async def _do_delete_terminal(self, index: int) -> None:
@@ -1605,7 +1638,7 @@ class ServerSwitchScreen(Screen):
         yield Vertical(
             Static("Switch server", classes="title"),
             Static("", id="switch_msg"),
-            OptionList(id="server_options"),
+            ListView(id="server_options"),
             id="switch_box",
         )
         yield Footer()
@@ -1614,8 +1647,8 @@ class ServerSwitchScreen(Screen):
         self._populate()
 
     def _populate(self) -> None:
-        ol = self.query_one("#server_options", OptionList)
-        ol.clear_options()
+        lv = self.query_one("#server_options", ListView)
+        lv.clear()
         servers = self.app.tui_state.known_servers()
         msg = self.query_one("#switch_msg", Static)
         if not servers:
@@ -1625,14 +1658,16 @@ class ServerSwitchScreen(Screen):
         current = self.app.tui_state.current_url()
         for s in servers:
             mark = "*" if s.url == current else " "
-            ol.add_option(Option(f"{mark} {s.alias}  ({s.url})", id=s.url))
+            lv.append(
+                ListItem(Label(f"{mark} {s.alias}  ({s.url})"), name=s.url)
+            )
 
     def action_delete_server(self) -> None:
-        ol = self.query_one("#server_options", OptionList)
-        idx = ol.highlighted
-        if idx is None:
+        lv = self.query_one("#server_options", ListView)
+        child = lv.highlighted_child
+        if child is None:
             return
-        url = ol.get_option_at_index(idx).id
+        url = child.name
 
         def _on_confirm(confirmed: bool) -> None:
             if not confirmed:
@@ -1644,10 +1679,8 @@ class ServerSwitchScreen(Screen):
             ConfirmScreen(f"Delete server {url}?"), _on_confirm
         )
 
-    def on_option_list_option_selected(
-        self, event: OptionList.OptionSelected
-    ) -> None:
-        url = event.option.id
+    def on_list_view_selected(self, event: ListView.Selected) -> None:
+        url = getattr(event.item, "name", "") or ""
         if url:
             self.app.tui_state.switch_server(url)
         self.app.server_changed()

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -97,16 +97,41 @@ class ConfirmScreen(ModalScreen[bool]):
         self.dismiss(event.button.id == "yes")
 
 
-class ServerListView(ListView):
-    """Server picker that releases focus downward at the last row, so the
-    user can continue with Down into the URL/input fields without Tab (#1781)."""
+class SpatialListView(ListView):
+    """A ListView that releases focus at its top/bottom boundaries to a
+    target widget, enabling spatial navigation without Tab (#1781).
+
+    Subclasses (or instances) declare ``SPATIAL_UP_TARGET`` and/or
+    ``SPATIAL_DOWN_TARGET`` — a widget type or CSS selector that receives
+    focus when Up is pressed at the first row or Down at the last.
+    """
+
+    SPATIAL_UP_TARGET = None
+    SPATIAL_DOWN_TARGET = None
+
+    def action_cursor_up(self) -> None:
+        if self.index in (0, None) and self.SPATIAL_UP_TARGET:
+            self.screen.query_one(self.SPATIAL_UP_TARGET).focus()
+        else:
+            super().action_cursor_up()
 
     def action_cursor_down(self) -> None:
         items = list(self.query(ListItem))
-        if self.index is not None and items and self.index >= len(items) - 1:
-            self.screen.query_one("#server_input", Input).focus()
+        if (
+            self.index is not None
+            and items
+            and self.index >= len(items) - 1
+            and self.SPATIAL_DOWN_TARGET
+        ):
+            self.screen.query_one(self.SPATIAL_DOWN_TARGET).focus()
         else:
             super().action_cursor_down()
+
+
+class ServerListView(SpatialListView):
+    """Server picker — Down from the last row enters the URL input."""
+
+    SPATIAL_DOWN_TARGET = "#server_input"
 
 
 class SpatialNavScreen(Screen):
@@ -400,19 +425,10 @@ class LoginScreen(SpatialNavScreen):
             self._attempt_password()
 
 
-class WorkspaceListView(ListView):
-    """A workspace list that hands focus back to the tab strip when the
-    cursor is at the top and Up is pressed (#1781).
+class WorkspaceListView(SpatialListView):
+    """Workspace list — Up from the first row returns to the tab strip."""
 
-    This lets the user move between the “Owned by me” / “Shared to me” tabs
-    and the workspace list with just Up/Down — no Tab/Shift-Tab needed.
-    """
-
-    def action_cursor_up(self) -> None:
-        if self.index in (0, None):
-            self.screen.query_one(Tabs).focus()
-        else:
-            super().action_cursor_up()
+    SPATIAL_UP_TARGET = Tabs
 
 
 class MainScreen(Screen):
@@ -633,7 +649,7 @@ class WorkspaceDetailScreen(Screen):
             Static("", id="detail_title"),
             Static("", id="detail_body"),
             Static("Terminals (own):", id="term_label"),
-            ListView(id="term_list"),
+            SpatialListView(id="term_list"),
             Static("", id="detail_msg"),
             id="detail_box",
         )
@@ -1687,7 +1703,7 @@ class ServerSwitchScreen(Screen):
         yield Vertical(
             Static("Switch server", classes="title"),
             Static("", id="switch_msg"),
-            ListView(id="server_options"),
+            SpatialListView(id="server_options"),
             id="switch_box",
         )
         yield Footer()

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -97,6 +97,21 @@ class ConfirmScreen(ModalScreen[bool]):
         self.dismiss(event.button.id == "yes")
 
 
+class ServerListView(ListView):
+    """Server picker that releases focus downward at the last row, so the
+    user can continue with Down into the URL/input fields without Tab (#1781)."""
+
+    def action_cursor_down(self) -> None:
+        items = list(self.query(ListItem))
+        if self.index is not None and items and self.index >= len(items) - 1:
+            try:
+                self.screen.query_one("#server_input", Input).focus()
+                return
+            except NoMatches:
+                pass
+        super().action_cursor_down()
+
+
 class LoginScreen(Screen):
     """Credential screen that also picks the server to log into.
 
@@ -114,7 +129,7 @@ class LoginScreen(Screen):
         yield Header(show_clock=False)
         yield Vertical(
             Static("", id="server_line"),
-            ListView(id="server_options"),
+            ServerListView(id="server_options"),
             Input(
                 placeholder=("Server URL or alias (e.g. https://host, prod)"),
                 id="server_input",
@@ -143,9 +158,20 @@ class LoginScreen(Screen):
         else:
             self._show_no_server()
 
+    def on_key(self, event) -> None:
+        # Spatial nav: Up from the server-input field returns focus to the
+        # server list above it (#1781).
+        if (
+            event.key == "up"
+            and isinstance(self.focused, Input)
+            and self.focused.id == "server_input"
+        ):
+            event.stop()
+            self.query_one("#server_options", ServerListView).focus()
+
     def _show_no_server(self) -> None:
         self.query_one("#server_line", Static).update(
-            "No server selected. Pick one above or enter a URL,"
+            "No server selected. Pick one below or enter a URL,"
             " then press 'Use server'."
         )
         self._disable_credentials()

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -3538,6 +3538,62 @@ async def test_login_spatial_nav_full_chain(monkeypatch):
         assert app.focused.id == "use_server"
 
 
+async def test_workspace_list_up_from_nonzero_stays(monkeypatch):
+    # Up from index 1 moves to index 0 (within the list — super path).
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    app = KlangkApp(_ws(owned=[_wsobj("alpha"), _wsobj("beta")]))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        lv = app.screen.query_one("#owned_list", ListView)
+        lv.focus()
+        lv.index = 1
+        await pilot.pause()
+        await pilot.press("up")
+        await pilot.pause()
+        assert lv.index == 0
+        assert isinstance(app.focused, ListView)
+
+
+async def test_login_server_down_from_nonlast_stays(monkeypatch):
+    # Down from index 0 (of 2) stays in the list — super path.
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    cfg = CLIConfig()
+    cfg.servers = {
+        "prod": ServerEntry(url="https://prod.example"),
+        "staging": ServerEntry(url="https://staging.example"),
+    }
+    st = _st(
+        current_url=lambda: None,
+        known_servers=lambda: [
+            tui_state_mod.ServerInfo("prod", "https://prod.example"),
+            tui_state_mod.ServerInfo("staging", "https://staging.example"),
+        ],
+        default_uds=lambda: None,
+        cfg=lambda: cfg,
+        auth_mode=lambda: "password",
+        email=lambda: None,
+        token=lambda: None,
+        is_authenticated=lambda: False,
+    )
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        login = app.screen
+        lv = login.query_one("#server_options", ListView)
+        lv.focus()
+        lv.index = 0
+        await pilot.pause()
+        await pilot.press("down")
+        await pilot.pause()
+        assert lv.index == 1
+        assert isinstance(app.focused, ListView)
+
+
 async def test_switch_screen_delete_server(monkeypatch):
     async def noop(*a, **k):
         return None

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -10,7 +10,17 @@ from __future__ import annotations
 import httpx
 import pytest
 from rich.text import Text
-from textual.widgets import Button, Checkbox, Input, OptionList, Select, Static
+from textual.widgets import (
+    Button,
+    Checkbox,
+    Input,
+    Label,
+    ListItem,
+    ListView,
+    Select,
+    Static,
+    Tabs,
+)
 
 from klangk.cli import config as cfgmod
 from klangk.cli import tui as tui_pkg
@@ -70,6 +80,18 @@ class FakeOptionSelected:
 
     def __init__(self, option_id):
         self.option = type("Opt", (), {"id": option_id})()
+
+
+class FakeSelected:
+    """Stand-in for ListView.Selected carrying an item name."""
+
+    def __init__(self, name):
+        self.item = type("Item", (), {"name": name})()
+
+
+def _lv_texts(list_view):
+    """Rendered text of each Label in a ListView (content assertions)."""
+    return [str(lab.render()) for lab in list_view.query(Label)]
 
 
 class FakeBtnPress:
@@ -769,9 +791,7 @@ async def test_server_switch_and_add(monkeypatch):
         app.push_screen(ServerSwitchScreen())
         await pilot.pause()
         assert isinstance(app.screen, ServerSwitchScreen)
-        app.screen.on_option_list_option_selected(
-            FakeOptionSelected("https://b.example")
-        )
+        app.screen.on_list_view_selected(FakeSelected("https://b.example"))
         await pilot.pause()
         assert switched["url"] == "https://b.example"
         assert isinstance(app.screen, MainScreen)
@@ -892,8 +912,8 @@ async def test_main_screen_lists_and_status(monkeypatch):
     )
     async with app.run_test():
         m = app.screen
-        assert m.query_one("#owned_list").option_count == 2
-        assert m.query_one("#shared_list").option_count == 1
+        assert len(m.query_one("#owned_list", ListView).query(ListItem)) == 2
+        assert len(m.query_one("#shared_list", ListView).query(ListItem)) == 1
         status = str(m.query_one("#status").render())
         assert "https://x.example" in status
         assert "me@x.example" in status
@@ -913,8 +933,48 @@ async def test_main_screen_list_error_shows_placeholder(monkeypatch):
     )
     async with app.run_test():
         m = app.screen
-        assert m.query_one("#owned_list").option_count == 1
-        assert m.query_one("#shared_list").option_count == 1
+        assert len(m.query_one("#owned_list", ListView).query(ListItem)) == 1
+        assert len(m.query_one("#shared_list", ListView).query(ListItem)) == 1
+
+
+async def test_down_from_tabs_enters_workspace_list(monkeypatch):
+    # Down arrow from the tab strip focuses the workspace list (#1781).
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    a = _wsobj("alpha")
+    b = _wsobj("beta")
+    app = KlangkApp(_ws(owned=[a, b]))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        m = app.screen
+        m.query_one(Tabs).focus()
+        await pilot.pause()
+        await pilot.press("down")
+        await pilot.pause()
+        assert isinstance(app.focused, ListView)
+        assert app.focused.index == 0  # first row, not the second
+
+
+async def test_up_from_list_returns_to_tabs(monkeypatch):
+    # Up arrow from the first workspace row returns focus to the tab strip.
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    a = _wsobj("alpha")
+    app = KlangkApp(_ws(owned=[a]))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        m = app.screen
+        lv = m.query_one("#owned_list", ListView)
+        lv.focus()
+        lv.index = 0
+        await pilot.pause()
+        await pilot.press("up")
+        await pilot.pause()
+        assert isinstance(app.focused, Tabs)
 
 
 async def test_main_screen_select_opens_detail(monkeypatch):
@@ -927,7 +987,7 @@ async def test_main_screen_select_opens_detail(monkeypatch):
     st.find_workspace = lambda n: a
     app = KlangkApp(st)
     async with app.run_test() as pilot:
-        app.screen.on_option_list_option_selected(FakeOptionSelected("alpha"))
+        app.screen.on_list_view_selected(FakeSelected("alpha"))
         await pilot.pause()
         assert isinstance(app.screen, WorkspaceDetailScreen)
 
@@ -939,7 +999,7 @@ async def test_main_screen_select_empty_no_push(monkeypatch):
     monkeypatch.setattr(scr, "listen_for_status", noop)
     app = KlangkApp(_ws())  # empty lists -> placeholder rows
     async with app.run_test() as pilot:
-        app.screen.on_option_list_option_selected(FakeOptionSelected(""))
+        app.screen.on_list_view_selected(FakeSelected(""))
         await pilot.pause()
         assert isinstance(app.screen, MainScreen)
 
@@ -1290,8 +1350,8 @@ async def test_main_screen_markup_name_safe(monkeypatch):
     a = _wsobj("x[red]y")
     app = KlangkApp(_ws(owned=[a]))
     async with app.run_test():
-        ol = app.screen.query_one("#owned_list")
-        assert ol.option_count == 1
+        lv = app.screen.query_one("#owned_list", ListView)
+        assert len(lv.query(ListItem)) == 1
         prompt = app.screen._fmt(a)
         assert isinstance(prompt, Text)
         assert "x[red]y" in str(prompt)  # literal, not markup-parsed
@@ -1459,10 +1519,10 @@ async def test_detail_terminals_listed(monkeypatch):
         await pilot.pause()
         await app.screen._load_terminals()  # deterministic render
         await pilot.pause()
-        tl = app.screen.query_one("#term_list")
-        assert tl.option_count == 2
-        assert "main" in str(tl.get_option_at_index(0).prompt)
-        assert "build" in str(tl.get_option_at_index(1).prompt)
+        tl = app.screen.query_one("#term_list", ListView)
+        assert len(tl.query(ListItem)) == 2
+        assert "main" in _lv_texts(tl)[0]
+        assert "build" in _lv_texts(tl)[1]
 
 
 async def test_detail_terminals_empty_placeholder(monkeypatch):
@@ -1479,8 +1539,8 @@ async def test_detail_terminals_empty_placeholder(monkeypatch):
         await pilot.pause()
         await app.screen._load_terminals()
         await pilot.pause()
-        tl = app.screen.query_one("#term_list")
-        assert tl.option_count == 1  # the (no terminals) placeholder
+        tl = app.screen.query_one("#term_list", ListView)
+        assert len(tl.query(ListItem)) == 1  # the (no terminals) placeholder
 
 
 async def test_detail_terminal_load_failure(monkeypatch):
@@ -1500,7 +1560,10 @@ async def test_detail_terminal_load_failure(monkeypatch):
         await pilot.pause()
         await app.screen._load_terminals()  # swallows the error
         await pilot.pause()
-        assert app.screen.query_one("#term_list").option_count == 1
+        assert (
+            len(app.screen.query_one("#term_list", ListView).query(ListItem))
+            == 1
+        )
 
 
 async def test_detail_delete_terminal_guard_last(monkeypatch):
@@ -1521,7 +1584,7 @@ async def test_detail_delete_terminal_guard_last(monkeypatch):
         await app.screen._load_terminals()
         await pilot.pause()
         d = app.screen
-        d.query_one("#term_list").highlighted = 0
+        d.query_one("#term_list").index = 0
         d.action_delete_terminal()  # only terminal -> refused
         await pilot.pause()
         assert "Can't delete the last terminal" in str(
@@ -1545,10 +1608,12 @@ async def test_detail_delete_terminal_no_selection(monkeypatch):
         await pilot.pause()
         d = app.screen
         # nothing highlighted -> no-op
-        d.query_one("#term_list").highlighted = None
+        d.query_one("#term_list").index = None
         d.action_delete_terminal()
         await pilot.pause()
-        assert d.query_one("#term_list").option_count == 2  # unchanged
+        assert (
+            len(d.query_one("#term_list", ListView).query(ListItem)) == 2
+        )  # unchanged
 
 
 async def test_detail_delete_terminal_placeholder(monkeypatch):
@@ -1566,10 +1631,12 @@ async def test_detail_delete_terminal_placeholder(monkeypatch):
         await app.screen._load_terminals()
         await pilot.pause()
         d = app.screen
-        d.query_one("#term_list").highlighted = 0  # the placeholder
+        d.query_one("#term_list").index = 0  # the placeholder
         d.action_delete_terminal()  # opt.id == "" -> no-op
         await pilot.pause()
-        assert d.query_one("#term_list").option_count == 1  # unchanged
+        assert (
+            len(d.query_one("#term_list", ListView).query(ListItem)) == 1
+        )  # unchanged
 
 
 async def test_detail_delete_terminal(monkeypatch):
@@ -1593,13 +1660,13 @@ async def test_detail_delete_terminal(monkeypatch):
         await app.screen._load_terminals()
         await pilot.pause()
         d = app.screen
-        d.query_one("#term_list").highlighted = 1
+        d.query_one("#term_list").index = 1
         d.action_delete_terminal()
         for _ in range(3):
             await pilot.pause()
         assert closed.get("i") == 1
         assert "Deleted terminal 1" in str(d.query_one("#detail_msg").render())
-        assert d.query_one("#term_list").option_count == 1
+        assert len(d.query_one("#term_list", ListView).query(ListItem)) == 1
 
 
 async def test_detail_delete_terminal_failure(monkeypatch):
@@ -1691,11 +1758,9 @@ async def test_main_screen_auth_expired_placeholder(monkeypatch):
         _ws(list_owned_workspaces=boom, list_shared_workspaces=boom)
     )
     async with app.run_test():
-        ol = app.screen.query_one("#owned_list")
-        assert ol.option_count == 1
-        assert (
-            "session expired" in str(ol.get_option_at_index(0).prompt).lower()
-        )
+        lv = app.screen.query_one("#owned_list", ListView)
+        assert len(lv.query(ListItem)) == 1
+        assert "session expired" in _lv_texts(lv)[0].lower()
 
 
 async def test_detail_auth_expired_message(monkeypatch):
@@ -1761,7 +1826,9 @@ async def test_detail_delete_terminal_empty_result(monkeypatch):
         await d._do_delete_terminal(1)
         await pilot.pause()
         assert "Delete failed" in str(d.query_one("#detail_msg").render())
-        assert d.query_one("#term_list").option_count == 2  # unchanged
+        assert (
+            len(d.query_one("#term_list", ListView).query(ListItem)) == 2
+        )  # unchanged
 
 
 # ---------------------------------------------------------------------------
@@ -3116,7 +3183,7 @@ async def test_login_server_picker(monkeypatch):
         )
 
         # known alias -> switch (routed through the option-selected handler)
-        login.on_option_list_option_selected(FakeOptionSelected("prod"))
+        login.on_list_view_selected(FakeSelected("prod"))
         await pilot.pause()
         assert calls.get("switch") == "https://prod.example"
 
@@ -3166,9 +3233,9 @@ async def test_populate_servers_dedups_default_udsk(monkeypatch):
     )
     app = KlangkApp(st)
     async with app.run_test():
-        ol = app.screen.query_one("#server_options", OptionList)
+        ol = app.screen.query_one("#server_options", ListView)
         # only the persisted alias row; no separate "Local klangkd (UDS)" row
-        assert len(ol._options) == 1
+        assert len(ol.query(ListItem)) == 1
 
 
 async def test_login_choose_invalid_server(monkeypatch):
@@ -3277,14 +3344,14 @@ async def test_login_delete_server(monkeypatch):
     app = KlangkApp(st)
     async with app.run_test() as pilot:
         login = app.screen
-        ol = login.query_one("#server_options", OptionList)
+        ol = login.query_one("#server_options", ListView)
         # nothing highlighted -> prompt to select (no dialog)
-        ol.highlighted = None
+        ol.index = None
         login.action_delete_server()
         await pilot.pause()
         assert "Select a server" in str(login.query_one("#message").render())
         # highlight + action -> confirm dialog (not yet deleted)
-        ol.highlighted = 0
+        ol.index = 0
         login.action_delete_server()
         await pilot.pause()
         assert isinstance(app.screen, ConfirmScreen)
@@ -3297,7 +3364,7 @@ async def test_login_delete_server(monkeypatch):
         await pilot.pause()
         assert "u" not in deleted
         # confirm -> deleted
-        ol.highlighted = 0
+        ol.index = 0
         login.action_delete_server()
         await pilot.pause()
         app.screen.dismiss(True)
@@ -3306,7 +3373,7 @@ async def test_login_delete_server(monkeypatch):
         assert "Server deleted" in str(login.query_one("#message").render())
         # confirm but delete returns False -> "Not a saved alias"
         st.delete_server = lambda url: False
-        ol.highlighted = 0
+        ol.index = 0
         login.action_delete_server()
         await pilot.pause()
         app.screen.dismiss(True)
@@ -3341,8 +3408,8 @@ async def test_login_delete_clears_to_no_server(monkeypatch):
     app = KlangkApp(st)
     async with app.run_test() as pilot:
         login = app.screen
-        ol = login.query_one("#server_options", OptionList)
-        ol.highlighted = 0
+        ol = login.query_one("#server_options", ListView)
+        ol.index = 0
         login.action_delete_server()
         await pilot.pause()
         app.screen.dismiss(True)
@@ -3369,15 +3436,15 @@ async def test_switch_screen_delete_server(monkeypatch):
         app.push_screen(ServerSwitchScreen())
         await pilot.pause()
         switch = app.screen
-        ol = switch.query_one("#server_options", OptionList)
+        ol = switch.query_one("#server_options", ListView)
         # nothing highlighted -> no dialog, no delete
-        ol.highlighted = None
+        ol.index = None
         switch.action_delete_server()
         await pilot.pause()
         assert app.screen is switch
         assert "u" not in deleted
         # highlight + action -> dialog; cancel -> not deleted
-        ol.highlighted = 0
+        ol.index = 0
         switch.action_delete_server()
         await pilot.pause()
         assert isinstance(app.screen, ConfirmScreen)
@@ -3385,7 +3452,7 @@ async def test_switch_screen_delete_server(monkeypatch):
         await pilot.pause()
         assert "u" not in deleted
         # confirm -> deleted
-        ol.highlighted = 0
+        ol.index = 0
         switch.action_delete_server()
         await pilot.pause()
         app.screen.dismiss(True)

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -3487,6 +3487,57 @@ async def test_login_up_from_input_to_server_list(monkeypatch):
         assert isinstance(app.focused, ListView)
 
 
+async def test_login_spatial_nav_full_chain(monkeypatch):
+    # Down/Up traverses the entire login form including buttons (#1781):
+    # server_input → use_server → identifier → password → login.
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    cfg = CLIConfig()
+    cfg.servers = {"prod": ServerEntry(url="https://prod.example")}
+    st = _st(
+        current_url=lambda: "https://prod.example",
+        known_servers=lambda: [
+            tui_state_mod.ServerInfo("prod", "https://prod.example"),
+        ],
+        default_uds=lambda: None,
+        cfg=lambda: cfg,
+        auth_mode=lambda: "password",
+        email=lambda: None,
+        token=lambda: None,
+        is_authenticated=lambda: False,
+    )
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        login = app.screen
+        await pilot.pause()
+        login.query_one("#server_input", Input).focus()
+        await pilot.pause()
+        await pilot.press("down")
+        await pilot.pause()
+        assert app.focused.id == "use_server"
+        await pilot.press("down")
+        await pilot.pause()
+        assert app.focused.id == "identifier"
+        await pilot.press("down")
+        await pilot.pause()
+        assert app.focused.id == "password"
+        await pilot.press("down")
+        await pilot.pause()
+        assert app.focused.id == "login"
+        # Up back
+        await pilot.press("up")
+        await pilot.pause()
+        assert app.focused.id == "password"
+        await pilot.press("up")
+        await pilot.pause()
+        assert app.focused.id == "identifier"
+        await pilot.press("up")
+        await pilot.pause()
+        assert app.focused.id == "use_server"
+
+
 async def test_switch_screen_delete_server(monkeypatch):
     async def noop(*a, **k):
         return None

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -3419,6 +3419,74 @@ async def test_login_delete_clears_to_no_server(monkeypatch):
         )
 
 
+async def test_login_down_from_last_server_to_input(monkeypatch):
+    # Spatial nav: Down at the last server row moves focus to the URL input.
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    cfg = CLIConfig()
+    cfg.servers = {
+        "prod": ServerEntry(url="https://prod.example"),
+        "staging": ServerEntry(url="https://staging.example"),
+    }
+    st = _st(
+        current_url=lambda: None,
+        known_servers=lambda: [
+            tui_state_mod.ServerInfo("prod", "https://prod.example"),
+            tui_state_mod.ServerInfo("staging", "https://staging.example"),
+        ],
+        default_uds=lambda: None,
+        cfg=lambda: cfg,
+        auth_mode=lambda: "password",
+        email=lambda: None,
+        token=lambda: None,
+        is_authenticated=lambda: False,
+    )
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        login = app.screen
+        lv = login.query_one("#server_options", ListView)
+        lv.focus()
+        lv.index = 1  # last of 2 servers
+        await pilot.pause()
+        await pilot.press("down")
+        await pilot.pause()
+        assert isinstance(app.focused, Input)
+        assert app.focused.id == "server_input"
+
+
+async def test_login_up_from_input_to_server_list(monkeypatch):
+    # Spatial nav: Up from the server-input field returns focus to the list.
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    cfg = CLIConfig()
+    cfg.servers = {"prod": ServerEntry(url="https://prod.example")}
+    st = _st(
+        current_url=lambda: None,
+        known_servers=lambda: [
+            tui_state_mod.ServerInfo("prod", "https://prod.example"),
+        ],
+        default_uds=lambda: None,
+        cfg=lambda: cfg,
+        auth_mode=lambda: "password",
+        email=lambda: None,
+        token=lambda: None,
+        is_authenticated=lambda: False,
+    )
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        login = app.screen
+        srv_input = login.query_one("#server_input", Input)
+        srv_input.focus()
+        await pilot.pause()
+        await pilot.press("up")
+        await pilot.pause()
+        assert isinstance(app.focused, ListView)
+
+
 async def test_switch_screen_delete_server(monkeypatch):
     async def noop(*a, **k):
         return None


### PR DESCRIPTION
## Summary

Replace `OptionList` with `ListView` for all navigable pick-lists in the TUI, add spatial navigation (arrow-key bridge between the tab strip and the workspace list), and add `ctrl+q` / `ctrl+c` quit.

Closes #1782.

### OptionList → ListView (mouse-click focus + cursor-key navigation)

Migrated the workspace list (`#owned_list` / `#shared_list`), the terminals list (`#term_list`), and both server pickers (`#server_options` ×2) from `OptionList` to `ListView`. This gives:
- `↑` / `↓` to move the highlight, `Enter` to select — built in, no Tab-to-enter required.
- Mouse click to focus and select any item.
- `ListView.Selected` / `ListView.Highlighted` messages (replacing `OptionList.OptionSelected`).

Form editors (`#mount_list` / `#env_list` / `#allow_list`) stay `OptionList` (manage-a-collection UX, not navigate-and-pick).

### Spatial navigation (#1781)

`WorkspaceListView` overrides `action_cursor_up` to release focus to the tab strip when at the first row. `MainScreen.on_key` intercepts Down from the tab strip to enter the active list. This means:
- **Down** from the tab strip → first workspace in the list.
- **Up** from the first workspace → back to the tab strip.
- No Tab/Shift-Tab needed (but they still work as a fallback).

### Quit keys

`q`, `ctrl+q`, and `ctrl+c` all exit the TUI.

### AGENTS.md

Added a "TUI spatial navigation (no focus traps)" section: the TUI must use spatial navigation, never focus traps, with Tab as fallback only.

## Testing

Python 3566 @ 100%.


Closes #1787.
