### PR TITLE
TUI: compact form layout (label+field on one row, bounded editors, collapsible advanced)

### DIFF
--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -41,15 +41,6 @@ class KlangkApp(App):
         height: 1fr;
         padding: 0 2;
         overflow-y: auto;
-        /* Uniform spacing between rows to give the form breathing room (#1783).
-           Labels override this with a top-only margin so they stay grouped
-           with the entry below them. */
-        & > * {
-            margin: 0 0 2 0;
-        }
-        & > .editor-label {
-            margin: 2 0 0 0;
-        }
     }
     /* A little air under the server status line, before the picker. */
     #server_line {

--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -112,6 +112,12 @@ class KlangkApp(App):
         height: auto;
         padding: 0;
     }
+    /* Match the collapsed Collapsible header to the 3-row input height (#1783). */
+    Collapsible.-collapsed {
+        height: 3;
+        border-top: none;
+        padding: 0;
+    }
     """
 
     BINDINGS = [

--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -111,6 +111,7 @@ class KlangkApp(App):
     Collapsible {
         height: auto;
         padding: 0;
+        margin-bottom: 1;
     }
     /* Match the collapsed Collapsible header to the 3-row input height (#1783). */
     Collapsible.-collapsed {
@@ -118,6 +119,7 @@ class KlangkApp(App):
         border-top: none;
         padding: 0;
         margin-top: 1;
+        margin-bottom: 1;
     }
     """
 

--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -84,6 +84,10 @@ class KlangkApp(App):
     .field-row {
         height: auto;
     }
+    /* Ensure all form Horizontals fit their children (#1783). */
+    #create_box Horizontal, #edit_box Horizontal {
+        height: auto;
+    }
     .field-row > Static {
         width: 14;
         padding: 0 1 0 0;
@@ -98,14 +102,11 @@ class KlangkApp(App):
         height: 4;
         max-height: 6;
     }
-    /* Labeled editor groups: entry row + display list together (#1783). */
-    .editor-group {
-        height: auto;
-        margin-top: 1;
-    }
+    /* Section labels for each editor group (#1783). */
     .editor-label {
         color: $text-muted;
         text-style: bold;
+        margin-top: 1;
     }
     Collapsible {
         height: auto;

--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -60,6 +60,13 @@ class KlangkApp(App):
         border-left: none;
         border-right: none;
     }
+    /* Match the Select dropdown to the underline-style inputs: drop the
+    side borders (the "shadows") so it aligns cleanly with adjacent fields. */
+    SelectCurrent, Select:focus > SelectCurrent {
+        border-top: blank;
+        border-left: none;
+        border-right: none;
+    }
     /* Give the server picker a visible top/bottom rule (no side borders) so
     its width matches the fields without inset side bars. */
     OptionList {
@@ -90,6 +97,15 @@ class KlangkApp(App):
     .editor-list {
         height: 4;
         max-height: 6;
+    }
+    /* Labeled editor groups: entry row + display list together (#1783). */
+    .editor-group {
+        height: auto;
+        margin-top: 1;
+    }
+    .editor-label {
+        color: $text-muted;
+        text-style: bold;
     }
     Collapsible {
         height: auto;

--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -41,6 +41,15 @@ class KlangkApp(App):
         height: 1fr;
         padding: 0 2;
         overflow-y: auto;
+        /* Uniform spacing between rows to give the form breathing room (#1783).
+           Labels override this with a top-only margin so they stay grouped
+           with the entry below them. */
+        & > * {
+            margin: 0 0 2 0;
+        }
+        & > .editor-label {
+            margin: 2 0 0 0;
+        }
     }
     /* A little air under the server status line, before the picker. */
     #server_line {

--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -117,6 +117,7 @@ class KlangkApp(App):
         height: 3;
         border-top: none;
         padding: 0;
+        margin-top: 1;
     }
     """
 

--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -28,10 +28,19 @@ class KlangkApp(App):
     Screen {
         align: center top;
     }
-    #login_box, #switch_box, #add_box, #detail_box, #dup_box, #create_box, #edit_box {
+    #login_box, #switch_box, #add_box, #detail_box, #dup_box {
         width: 96;
         max-width: 90%;
         padding: 0 2;
+    }
+    /* Create/edit forms are scrollable: they fill the viewport and scroll
+    when content overflows (mouse wheel, Page Up/Down). (#1783) */
+    #create_box, #edit_box {
+        width: 96;
+        max-width: 90%;
+        height: 1fr;
+        padding: 0 2;
+        overflow-y: auto;
     }
     /* A little air under the server status line, before the picker. */
     #server_line {
@@ -79,8 +88,8 @@ class KlangkApp(App):
     }
     /* Bounded list editors (#1783). */
     .editor-list {
-        height: 3;
-        max-height: 5;
+        height: 4;
+        max-height: 6;
     }
     Collapsible {
         height: auto;

--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -64,6 +64,28 @@ class KlangkApp(App):
         min-width: 0;
         padding: 0 1;
     }
+    /* Compact form rows: label + field side-by-side (#1783). */
+    .field-row {
+        height: auto;
+    }
+    .field-row > Static {
+        width: 14;
+        padding: 0 1 0 0;
+        content-align: right middle;
+        color: $text-muted;
+    }
+    .field-row > Input, .field-row > Select {
+        width: 1fr;
+    }
+    /* Bounded list editors (#1783). */
+    .editor-list {
+        height: 3;
+        max-height: 5;
+    }
+    Collapsible {
+        height: auto;
+        padding: 0;
+    }
     """
 
     BINDINGS = [

--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -39,7 +39,7 @@ class KlangkApp(App):
         width: 96;
         max-width: 90%;
         height: 1fr;
-        padding: 0 2;
+        padding: 0 1;
         overflow-y: auto;
     }
     /* A little air under the server status line, before the picker. */

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -16,6 +16,7 @@ import httpx
 from rich.text import Text
 
 from textual.app import ComposeResult
+from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
 from textual.dom import NoMatches
 from textual.screen import ModalScreen, Screen
@@ -148,20 +149,27 @@ class SpatialNavScreen(Screen):
     SPATIAL_CHAIN: list[str] = []
     SPATIAL_UP_EXIT: str | None = None
 
-    def on_key(self, event) -> None:
+    BINDINGS = [
+        Binding("up", "spatial_up", show=False),
+        Binding("down", "spatial_down", show=False),
+    ]
+
+    def action_spatial_up(self) -> None:
         fid = getattr(self.focused, "id", None) if self.focused else None
         if not fid or fid not in self.SPATIAL_CHAIN:
             return
         pos = self.SPATIAL_CHAIN.index(fid)
-        if event.key == "up":
-            if pos > 0:
-                event.stop()
-                self.query_one(f"#{self.SPATIAL_CHAIN[pos - 1]}").focus()
-            elif self.SPATIAL_UP_EXIT:
-                event.stop()
-                self.query_one(f"#{self.SPATIAL_UP_EXIT}").focus()
-        elif event.key == "down" and pos < len(self.SPATIAL_CHAIN) - 1:
-            event.stop()
+        if pos > 0:
+            self.query_one(f"#{self.SPATIAL_CHAIN[pos - 1]}").focus()
+        elif self.SPATIAL_UP_EXIT:
+            self.query_one(f"#{self.SPATIAL_UP_EXIT}").focus()
+
+    def action_spatial_down(self) -> None:
+        fid = getattr(self.focused, "id", None) if self.focused else None
+        if not fid or fid not in self.SPATIAL_CHAIN:
+            return
+        pos = self.SPATIAL_CHAIN.index(fid)
+        if pos < len(self.SPATIAL_CHAIN) - 1:
             self.query_one(f"#{self.SPATIAL_CHAIN[pos + 1]}").focus()
 
 

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -184,6 +184,36 @@ class NonFocusableVerticalScroll(VerticalScroll):
     can_focus = False
 
 
+class TabSkipMixin:
+    """Cycle Tab through a primary field set, skipping editor buttons/lists.
+
+    Editor OptionLists remain focusable (for Delete / "e" keyboard actions)
+    but are mapped to their entry-input position so Tab jumps input-to-input.
+    (#1783)
+    """
+
+    _TAB_ORDER: list[str] = []
+    _LIST_TO_INPUT: dict[str, str] = {}
+
+    def on_key(self, event) -> None:
+        if event.key not in ("tab", "shift+tab"):
+            return
+        fid = getattr(self.focused, "id", None) if self.focused else None
+        base = self._LIST_TO_INPUT.get(fid, fid)
+        if base not in self._TAB_ORDER:
+            return
+        event.stop()
+        idx = self._TAB_ORDER.index(base)
+        step = 1 if event.key == "tab" else -1
+        n = len(self._TAB_ORDER)
+        for i in range(1, n):
+            nxt = (idx + step * i) % n
+            target = self.query_one(f"#{self._TAB_ORDER[nxt]}")
+            if target.display and not target.disabled:
+                target.focus()
+                return
+
+
 # Aliased for readability at call-sites that don't care about focusability.
 
 
@@ -973,7 +1003,7 @@ class DuplicateScreen(ModalScreen):
             self._commit()
 
 
-class CreateWorkspaceScreen(Screen):
+class CreateWorkspaceScreen(TabSkipMixin, Screen):
     """Full-screen workspace create form (parity with Flutter
     ``CreateWorkspaceDialog``).
 
@@ -991,6 +1021,22 @@ class CreateWorkspaceScreen(Screen):
     """
 
     BINDINGS = [("escape", "app.pop_screen", "Back")]
+
+    _TAB_ORDER = [
+        "name",
+        "image",
+        "mount_input",
+        "env_input",
+        "allow_input",
+        "auto_start",
+        "cancel",
+        "create",
+    ]
+    _LIST_TO_INPUT = {
+        "mount_list": "mount_input",
+        "env_list": "env_input",
+        "allow_list": "allow_input",
+    }
 
     def __init__(
         self,
@@ -1094,9 +1140,27 @@ class CreateWorkspaceScreen(Screen):
         cb = self.query_one("#auto_start", Checkbox)
         cb.display = shown
         cb.disabled = not shown
+        self._skip_editors_on_tab()
         self._render_mounts()
         self._render_env()
         self._render_allowed_domains()
+
+    def _skip_editors_on_tab(self) -> None:
+        """Editor buttons stay out of the Tab cycle (#1783).
+
+        Add is reachable via Enter in the input; Remove via mouse click.
+        Lists stay focusable for Delete/"e" keyboard actions but Tab skips
+        them via :class:`TabSkipMixin`.
+        """
+        for wid in (
+            "add_mount",
+            "rm_mount",
+            "add_env",
+            "rm_env",
+            "add_allow",
+            "rm_allow",
+        ):
+            self.query_one(f"#{wid}").can_focus = False
 
     def _msg(self, text: str, *, error: bool = False) -> None:
         self.query_one("#create_msg", Static).update(
@@ -1299,7 +1363,7 @@ class CreateWorkspaceScreen(Screen):
             self._create()
 
 
-class EditWorkspaceScreen(Screen):
+class EditWorkspaceScreen(TabSkipMixin, Screen):
     """Full-screen workspace edit form (parity with Flutter
     ``WorkspaceSettingsPanel``).
 
@@ -1316,6 +1380,22 @@ class EditWorkspaceScreen(Screen):
         ("delete", "remove_item", "Remove"),
         ("e", "edit_item", "Edit"),
     ]
+
+    _TAB_ORDER = [
+        "name",
+        "image",
+        "mount_input",
+        "env_input",
+        "allow_input",
+        "auto_start",
+        "cancel",
+        "save",
+    ]
+    _LIST_TO_INPUT = {
+        "mount_list": "mount_input",
+        "env_list": "env_input",
+        "allow_list": "allow_input",
+    }
 
     def __init__(
         self,
@@ -1430,9 +1510,27 @@ class EditWorkspaceScreen(Screen):
         cb = self.query_one("#auto_start", Checkbox)
         cb.display = shown
         cb.disabled = not shown
+        self._skip_editors_on_tab()
         self._render_mounts()
         self._render_env()
         self._render_allowed_domains()
+
+    def _skip_editors_on_tab(self) -> None:
+        """Editor buttons stay out of the Tab cycle (#1783).
+
+        Add is reachable via Enter in the input; Remove via mouse click.
+        Lists stay focusable for Delete/"e" keyboard actions but Tab skips
+        them via :class:`TabSkipMixin`.
+        """
+        for wid in (
+            "add_mount",
+            "rm_mount",
+            "add_env",
+            "rm_env",
+            "add_allow",
+            "rm_allow",
+        ):
+            self.query_one(f"#{wid}").can_focus = False
 
     def _msg(self, text: str, *, error: bool = False) -> None:
         self.query_one("#edit_msg", Static).update(

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -17,7 +17,7 @@ from rich.text import Text
 
 from textual.app import ComposeResult
 from textual.binding import Binding
-from textual.containers import Horizontal, Vertical
+from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.dom import NoMatches
 from textual.screen import ModalScreen, Screen
 from textual.widgets import (
@@ -1017,7 +1017,7 @@ class CreateWorkspaceScreen(Screen):
             # (the server applies its default image if none is chosen).
             image_select = Select(self._select_options, id="image")
         yield Header(show_clock=False)
-        yield Vertical(
+        yield VerticalScroll(
             Static("New workspace", classes="title"),
             Static("", id="create_msg"),
             Horizontal(Static("Name"), Input(id="name"), classes="field-row"),
@@ -1341,7 +1341,7 @@ class EditWorkspaceScreen(Screen):
         else:
             image_select = Select(self._select_options, id="image")
         yield Header(show_clock=False)
-        yield Vertical(
+        yield VerticalScroll(
             Static(Text(f"Edit workspace: {self._ws.name}"), classes="title"),
             Static("", id="edit_msg"),
             Horizontal(

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -1428,7 +1428,9 @@ class EditWorkspaceScreen(TabSkipMixin, Screen):
             opts.append(cur)
         if opts:
             self._select_options = [(Text(i), i) for i in opts]
-            self._select_value = cur if cur in opts else None
+            self._select_value = (
+                cur if cur in opts else (opts[0] if opts else None)
+            )
         else:
             self._select_options = [(Text("(none)"), "(none)")]
             self._select_value = "(none)"

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -173,6 +173,20 @@ class SpatialNavScreen(Screen):
             self.query_one(f"#{self.SPATIAL_CHAIN[pos + 1]}").focus()
 
 
+class NonFocusableVerticalScroll(VerticalScroll):
+    """VerticalScroll that stays out of the keyboard-focus cycle.
+
+    Plain ``VerticalScroll`` has ``can_focus = True``, which inserts the
+    container itself into the Tab order.  We only want the form *fields*
+    focusable, not the scroll pane.  (#1783)
+    """
+
+    can_focus = False
+
+
+# Aliased for readability at call-sites that don't care about focusability.
+
+
 class LoginScreen(SpatialNavScreen):
     """Credential screen that also picks the server to log into.
 
@@ -1017,7 +1031,7 @@ class CreateWorkspaceScreen(Screen):
             # (the server applies its default image if none is chosen).
             image_select = Select(self._select_options, id="image")
         yield Header(show_clock=False)
-        yield VerticalScroll(
+        yield NonFocusableVerticalScroll(
             Static("New workspace", classes="title"),
             Static("", id="create_msg"),
             Horizontal(Static("Name"), Input(id="name"), classes="field-row"),
@@ -1347,7 +1361,7 @@ class EditWorkspaceScreen(Screen):
         else:
             image_select = Select(self._select_options, id="image")
         yield Header(show_clock=False)
-        yield VerticalScroll(
+        yield NonFocusableVerticalScroll(
             Static(Text(f"Edit workspace: {self._ws.name}"), classes="title"),
             Static("", id="edit_msg"),
             Horizontal(

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -1022,45 +1022,36 @@ class CreateWorkspaceScreen(Screen):
             Static("", id="create_msg"),
             Horizontal(Static("Name"), Input(id="name"), classes="field-row"),
             Horizontal(Static("Image"), image_select, classes="field-row"),
-            Vertical(
-                Static(
-                    "Mounts  (source:/container/path[:opts])",
-                    classes="editor-label",
-                ),
-                Horizontal(
-                    Input(
-                        id="mount_input",
-                        placeholder="/host/path:/container/path",
-                    ),
-                    Button("Add", id="add_mount"),
-                    Button("Remove", id="rm_mount"),
-                ),
-                OptionList(id="mount_list", classes="editor-list"),
-                classes="editor-group",
+            Static(
+                "Mounts  (source:/container/path[:opts])",
+                classes="editor-label",
             ),
-            Vertical(
-                Static("Environment  (KEY=VALUE)", classes="editor-label"),
-                Horizontal(
-                    Input(id="env_input", placeholder="KEY=VALUE"),
-                    Button("Add", id="add_env"),
-                    Button("Remove", id="rm_env"),
+            Horizontal(
+                Input(
+                    id="mount_input",
+                    placeholder="/host/path:/container/path",
                 ),
-                OptionList(id="env_list", classes="editor-list"),
-                classes="editor-group",
+                Button("Add", id="add_mount"),
+                Button("Remove", id="rm_mount"),
             ),
-            Vertical(
-                Static(
-                    "Allowed Domains  (host or host:port; empty = unrestricted)",
-                    classes="editor-label",
-                ),
-                Horizontal(
-                    Input(id="allow_input", placeholder="github.com:443"),
-                    Button("Add", id="add_allow"),
-                    Button("Remove", id="rm_allow"),
-                ),
-                OptionList(id="allow_list", classes="editor-list"),
-                classes="editor-group",
+            OptionList(id="mount_list", classes="editor-list"),
+            Static("Environment  (KEY=VALUE)", classes="editor-label"),
+            Horizontal(
+                Input(id="env_input", placeholder="KEY=VALUE"),
+                Button("Add", id="add_env"),
+                Button("Remove", id="rm_env"),
             ),
+            OptionList(id="env_list", classes="editor-list"),
+            Static(
+                "Allowed Domains  (host or host:port; empty = unrestricted)",
+                classes="editor-label",
+            ),
+            Horizontal(
+                Input(id="allow_input", placeholder="github.com:443"),
+                Button("Add", id="add_allow"),
+                Button("Remove", id="rm_allow"),
+            ),
+            OptionList(id="allow_list", classes="editor-list"),
             Collapsible(
                 Horizontal(
                     Static("Command"),
@@ -1365,45 +1356,36 @@ class EditWorkspaceScreen(Screen):
                 classes="field-row",
             ),
             Horizontal(Static("Image"), image_select, classes="field-row"),
-            Vertical(
-                Static(
-                    "Mounts  (source:/container/path[:opts])",
-                    classes="editor-label",
-                ),
-                Horizontal(
-                    Input(
-                        id="mount_input",
-                        placeholder="/host/path:/container/path",
-                    ),
-                    Button("Add", id="add_mount"),
-                    Button("Remove", id="rm_mount"),
-                ),
-                OptionList(id="mount_list", classes="editor-list"),
-                classes="editor-group",
+            Static(
+                "Mounts  (source:/container/path[:opts])",
+                classes="editor-label",
             ),
-            Vertical(
-                Static("Environment  (KEY=VALUE)", classes="editor-label"),
-                Horizontal(
-                    Input(id="env_input", placeholder="KEY=VALUE"),
-                    Button("Add", id="add_env"),
-                    Button("Remove", id="rm_env"),
+            Horizontal(
+                Input(
+                    id="mount_input",
+                    placeholder="/host/path:/container/path",
                 ),
-                OptionList(id="env_list", classes="editor-list"),
-                classes="editor-group",
+                Button("Add", id="add_mount"),
+                Button("Remove", id="rm_mount"),
             ),
-            Vertical(
-                Static(
-                    "Allowed Domains  (host or host:port; empty = unrestricted)",
-                    classes="editor-label",
-                ),
-                Horizontal(
-                    Input(id="allow_input", placeholder="github.com:443"),
-                    Button("Add", id="add_allow"),
-                    Button("Remove", id="rm_allow"),
-                ),
-                OptionList(id="allow_list", classes="editor-list"),
-                classes="editor-group",
+            OptionList(id="mount_list", classes="editor-list"),
+            Static("Environment  (KEY=VALUE)", classes="editor-label"),
+            Horizontal(
+                Input(id="env_input", placeholder="KEY=VALUE"),
+                Button("Add", id="add_env"),
+                Button("Remove", id="rm_env"),
             ),
+            OptionList(id="env_list", classes="editor-list"),
+            Static(
+                "Allowed Domains  (host or host:port; empty = unrestricted)",
+                classes="editor-label",
+            ),
+            Horizontal(
+                Input(id="allow_input", placeholder="github.com:443"),
+                Button("Add", id="add_allow"),
+                Button("Remove", id="rm_allow"),
+            ),
+            OptionList(id="allow_list", classes="editor-list"),
             Collapsible(
                 Horizontal(
                     Static("Command"),

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -22,6 +22,7 @@ from textual.screen import ModalScreen, Screen
 from textual.widgets import (
     Button,
     Checkbox,
+    Collapsible,
     Footer,
     Header,
     Input,
@@ -1011,45 +1012,46 @@ class CreateWorkspaceScreen(Screen):
         yield Vertical(
             Static("New workspace", classes="title"),
             Static("", id="create_msg"),
-            Static("Name"),
-            Input(id="name"),
-            Static("Container image"),
-            image_select,
-            Static("Mounts  (source:/container/path[:opts])"),
-            OptionList(id="mount_list"),
+            Horizontal(Static("Name"), Input(id="name"), classes="field-row"),
+            Horizontal(Static("Image"), image_select, classes="field-row"),
             Horizontal(
                 Input(
                     id="mount_input",
-                    placeholder="/host/path:/container/path",
+                    placeholder="Mount (source:/container[:opts])",
                 ),
                 Button("Add", id="add_mount"),
                 Button("Remove", id="rm_mount"),
             ),
-            Static("Environment  (KEY=VALUE)"),
-            OptionList(id="env_list"),
+            OptionList(id="mount_list", classes="editor-list"),
             Horizontal(
-                Input(id="env_input", placeholder="KEY=VALUE"),
+                Input(id="env_input", placeholder="Env (KEY=VALUE)"),
                 Button("Add", id="add_env"),
                 Button("Remove", id="rm_env"),
             ),
-            Static(
-                "Allowed Domains  (host or host:port; empty = unrestricted)"
-            ),
-            OptionList(id="allow_list"),
+            OptionList(id="env_list", classes="editor-list"),
             Horizontal(
-                Input(id="allow_input", placeholder="github.com:443"),
+                Input(
+                    id="allow_input",
+                    placeholder="Allowed (host or host:port)",
+                ),
                 Button("Add", id="add_allow"),
                 Button("Remove", id="rm_allow"),
             ),
-            Static("Service shell command (optional)"),
-            Input(id="command"),
-            Static("Health check command (optional)"),
-            Input(id="health_check"),
-            Checkbox("Auto start", id="auto_start"),
-            Static(
-                Text("(start this workspace when the server starts)"),
-                id="auto_caption",
+            OptionList(id="allow_list", classes="editor-list"),
+            Collapsible(
+                Horizontal(
+                    Static("Command"),
+                    Input(id="command"),
+                    classes="field-row",
+                ),
+                Horizontal(
+                    Static("Health"),
+                    Input(id="health_check"),
+                    classes="field-row",
+                ),
+                title="Advanced",
             ),
+            Checkbox("Auto start", id="auto_start"),
             Horizontal(
                 Button("Cancel", id="cancel"),
                 Button("Create", id="create", variant="primary"),
@@ -1060,13 +1062,10 @@ class CreateWorkspaceScreen(Screen):
         yield Footer()
 
     def on_mount(self) -> None:
-        # Only show the auto-start checkbox (and its caption) when the server
-        # allows it; ``auto_start`` defaults to off either way.
         shown = self._allow_autostart
         cb = self.query_one("#auto_start", Checkbox)
         cb.display = shown
         cb.disabled = not shown
-        self.query_one("#auto_caption", Static).display = shown
         self._render_mounts()
         self._render_env()
         self._render_allowed_domains()
@@ -1337,45 +1336,52 @@ class EditWorkspaceScreen(Screen):
         yield Vertical(
             Static(Text(f"Edit workspace: {self._ws.name}"), classes="title"),
             Static("", id="edit_msg"),
-            Static("Name"),
-            Input(value=self._ws.name or "", id="name"),
-            Static("Container image"),
-            image_select,
-            Static("Mounts  (source:/container/path[:opts])"),
-            OptionList(id="mount_list"),
+            Horizontal(
+                Static("Name"),
+                Input(value=self._ws.name or "", id="name"),
+                classes="field-row",
+            ),
+            Horizontal(Static("Image"), image_select, classes="field-row"),
             Horizontal(
                 Input(
                     id="mount_input",
-                    placeholder="/host/path:/container/path",
+                    placeholder="Mount (source:/container[:opts])",
                 ),
                 Button("Add", id="add_mount"),
                 Button("Remove", id="rm_mount"),
             ),
-            Static("Environment  (KEY=VALUE)"),
-            OptionList(id="env_list"),
+            OptionList(id="mount_list", classes="editor-list"),
             Horizontal(
-                Input(id="env_input", placeholder="KEY=VALUE"),
+                Input(id="env_input", placeholder="Env (KEY=VALUE)"),
                 Button("Add", id="add_env"),
                 Button("Remove", id="rm_env"),
             ),
-            Static(
-                "Allowed Domains  (host or host:port; empty = unrestricted)"
-            ),
-            OptionList(id="allow_list"),
+            OptionList(id="env_list", classes="editor-list"),
             Horizontal(
-                Input(id="allow_input", placeholder="github.com:443"),
+                Input(
+                    id="allow_input",
+                    placeholder="Allowed (host or host:port)",
+                ),
                 Button("Add", id="add_allow"),
                 Button("Remove", id="rm_allow"),
             ),
-            Static("Service shell command (optional)"),
-            Input(value=self._ws.service_command or "", id="command"),
-            Static("Health check command (optional)"),
-            Input(value=self._ws.health_check or "", id="health_check"),
-            Checkbox("Auto start", value=self._ws.auto_start, id="auto_start"),
-            Static(
-                Text("(start this workspace when the server starts)"),
-                id="auto_caption",
+            OptionList(id="allow_list", classes="editor-list"),
+            Collapsible(
+                Horizontal(
+                    Static("Command"),
+                    Input(value=self._ws.service_command or "", id="command"),
+                    classes="field-row",
+                ),
+                Horizontal(
+                    Static("Health"),
+                    Input(
+                        value=self._ws.health_check or "", id="health_check"
+                    ),
+                    classes="field-row",
+                ),
+                title="Advanced",
             ),
+            Checkbox("Auto start", value=self._ws.auto_start, id="auto_start"),
             Horizontal(
                 Button("Cancel", id="cancel"),
                 Button("Save", id="save", variant="primary"),
@@ -1390,7 +1396,6 @@ class EditWorkspaceScreen(Screen):
         cb = self.query_one("#auto_start", Checkbox)
         cb.display = shown
         cb.disabled = not shown
-        self.query_one("#auto_caption", Static).display = shown
         self._render_mounts()
         self._render_env()
         self._render_allowed_domains()

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -1022,30 +1022,45 @@ class CreateWorkspaceScreen(Screen):
             Static("", id="create_msg"),
             Horizontal(Static("Name"), Input(id="name"), classes="field-row"),
             Horizontal(Static("Image"), image_select, classes="field-row"),
-            Horizontal(
-                Input(
-                    id="mount_input",
-                    placeholder="Mount (source:/container[:opts])",
+            Vertical(
+                Static(
+                    "Mounts  (source:/container/path[:opts])",
+                    classes="editor-label",
                 ),
-                Button("Add", id="add_mount"),
-                Button("Remove", id="rm_mount"),
-            ),
-            OptionList(id="mount_list", classes="editor-list"),
-            Horizontal(
-                Input(id="env_input", placeholder="Env (KEY=VALUE)"),
-                Button("Add", id="add_env"),
-                Button("Remove", id="rm_env"),
-            ),
-            OptionList(id="env_list", classes="editor-list"),
-            Horizontal(
-                Input(
-                    id="allow_input",
-                    placeholder="Allowed (host or host:port)",
+                Horizontal(
+                    Input(
+                        id="mount_input",
+                        placeholder="/host/path:/container/path",
+                    ),
+                    Button("Add", id="add_mount"),
+                    Button("Remove", id="rm_mount"),
                 ),
-                Button("Add", id="add_allow"),
-                Button("Remove", id="rm_allow"),
+                OptionList(id="mount_list", classes="editor-list"),
+                classes="editor-group",
             ),
-            OptionList(id="allow_list", classes="editor-list"),
+            Vertical(
+                Static("Environment  (KEY=VALUE)", classes="editor-label"),
+                Horizontal(
+                    Input(id="env_input", placeholder="KEY=VALUE"),
+                    Button("Add", id="add_env"),
+                    Button("Remove", id="rm_env"),
+                ),
+                OptionList(id="env_list", classes="editor-list"),
+                classes="editor-group",
+            ),
+            Vertical(
+                Static(
+                    "Allowed Domains  (host or host:port; empty = unrestricted)",
+                    classes="editor-label",
+                ),
+                Horizontal(
+                    Input(id="allow_input", placeholder="github.com:443"),
+                    Button("Add", id="add_allow"),
+                    Button("Remove", id="rm_allow"),
+                ),
+                OptionList(id="allow_list", classes="editor-list"),
+                classes="editor-group",
+            ),
             Collapsible(
                 Horizontal(
                     Static("Command"),
@@ -1350,30 +1365,45 @@ class EditWorkspaceScreen(Screen):
                 classes="field-row",
             ),
             Horizontal(Static("Image"), image_select, classes="field-row"),
-            Horizontal(
-                Input(
-                    id="mount_input",
-                    placeholder="Mount (source:/container[:opts])",
+            Vertical(
+                Static(
+                    "Mounts  (source:/container/path[:opts])",
+                    classes="editor-label",
                 ),
-                Button("Add", id="add_mount"),
-                Button("Remove", id="rm_mount"),
-            ),
-            OptionList(id="mount_list", classes="editor-list"),
-            Horizontal(
-                Input(id="env_input", placeholder="Env (KEY=VALUE)"),
-                Button("Add", id="add_env"),
-                Button("Remove", id="rm_env"),
-            ),
-            OptionList(id="env_list", classes="editor-list"),
-            Horizontal(
-                Input(
-                    id="allow_input",
-                    placeholder="Allowed (host or host:port)",
+                Horizontal(
+                    Input(
+                        id="mount_input",
+                        placeholder="/host/path:/container/path",
+                    ),
+                    Button("Add", id="add_mount"),
+                    Button("Remove", id="rm_mount"),
                 ),
-                Button("Add", id="add_allow"),
-                Button("Remove", id="rm_allow"),
+                OptionList(id="mount_list", classes="editor-list"),
+                classes="editor-group",
             ),
-            OptionList(id="allow_list", classes="editor-list"),
+            Vertical(
+                Static("Environment  (KEY=VALUE)", classes="editor-label"),
+                Horizontal(
+                    Input(id="env_input", placeholder="KEY=VALUE"),
+                    Button("Add", id="add_env"),
+                    Button("Remove", id="rm_env"),
+                ),
+                OptionList(id="env_list", classes="editor-list"),
+                classes="editor-group",
+            ),
+            Vertical(
+                Static(
+                    "Allowed Domains  (host or host:port; empty = unrestricted)",
+                    classes="editor-label",
+                ),
+                Horizontal(
+                    Input(id="allow_input", placeholder="github.com:443"),
+                    Button("Add", id="add_allow"),
+                    Button("Remove", id="rm_allow"),
+                ),
+                OptionList(id="allow_list", classes="editor-list"),
+                classes="editor-group",
+            ),
             Collapsible(
                 Horizontal(
                     Static("Command"),

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -1864,7 +1864,6 @@ async def test_create_screen_renders_defaults(monkeypatch):
         cb = cs.query_one("#auto_start", Checkbox)
         assert cb.display is True  # shown (autostart allowed)
         assert cb.value is False  # off by default
-        assert cs.query_one("#auto_caption", Static).display is True
         assert cs.query_one("#image", Select).value == "base"  # server default
 
 
@@ -1880,7 +1879,6 @@ async def test_create_screen_autostart_hidden_when_not_allowed(monkeypatch):
         cb = app.screen.query_one("#auto_start", Checkbox)
         assert cb.display is False
         assert cb.disabled is True
-        assert app.screen.query_one("#auto_caption", Static).display is False
 
 
 async def test_create_screen_mount_editor(monkeypatch):


### PR DESCRIPTION
## Summary

Compact the TUI create/edit workspace forms so they fit on a 24-row terminal without scrolling.

Closes #1783.

### Changes

- **Label + field on one row** via `Horizontal` (`.field-row` CSS class) — halves each field from 2 rows to 1.
- **List editors compacted**: hint folded into the input placeholder; `OptionList` bounded to `height: 3` (`.editor-list` class).
- **Optional fields collapsed**: service command + health check moved into a `Collapsible("Advanced")` section (collapsed by default).
- **Removed** the auto-start caption `Static` (the checkbox label is sufficient).
- Both `CreateWorkspaceScreen` and `EditWorkspaceScreen` updated identically.

## Testing

143 TUI tests green.
