### PR TITLE
TUI: auto-start stopped workspace containers on visit

### DIFF
--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -710,6 +710,8 @@ class WorkspaceDetailScreen(Screen):
 
     def on_mount(self) -> None:
         self._load()
+        if self._ws is not None and not self._ws.running:
+            self.run_worker(self._start_if_stopped, exit_on_error=False)
         self.run_worker(self._load_terminals, exit_on_error=False)
 
     def _load(self) -> None:
@@ -730,6 +732,22 @@ class WorkspaceDetailScreen(Screen):
             self._missing = False
             self._load_error = None
         self._display()
+
+    async def _start_if_stopped(self) -> None:
+        """Auto-start a stopped workspace container on visit.
+
+        The Flutter UI does this via its WebSocket ``connectWorkspace``
+        call; the TUI replicates the behaviour with a restart request.
+        """
+        self._msg("Starting container…")
+        try:
+            self.app.tui_state.restart_workspace(self._name)
+        except Exception as exc:
+            self._msg(f"Auto-start failed: {exc}", error=True)
+            return
+        self._load()
+        self._msg("Container started.")
+        self.app.refresh_workspaces()
 
     def _display(self) -> None:
         self.query_one("#detail_title", Static).update(

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -120,6 +120,7 @@ def _authed_state(**extra):
         list_shared_workspaces=lambda: [],
         list_terminals=_async_empty,
         close_terminal=_async_empty,
+        restart_workspace=lambda n: None,
     )
     base.update(extra)
     return _st(**base)
@@ -137,6 +138,7 @@ def _ws(owned=None, shared=None, **extra):
         list_shared_workspaces=lambda: shared or [],
         list_terminals=_async_empty,
         close_terminal=_async_empty,
+        restart_workspace=lambda n: None,
     )
     base.update(extra)
     return _st(**base)
@@ -1170,7 +1172,7 @@ async def test_detail_restart_confirm_cancel_error(monkeypatch):
         return None
 
     monkeypatch.setattr(scr, "listen_for_status", noop)
-    a = _wsobj("alpha")
+    a = _wsobj("alpha", running=True)
     restarted = {}
     st = _ws()
     st.find_workspace = lambda n: a
@@ -1206,6 +1208,43 @@ async def test_detail_restart_confirm_cancel_error(monkeypatch):
         assert "Restart failed" in str(
             app.screen.query_one("#detail_msg").render()
         )
+
+
+async def test_detail_auto_starts_stopped_workspace(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    a = _wsobj("alpha", running=False)
+    started = []
+    st = _ws()
+    st.find_workspace = lambda n: a
+    st.restart_workspace = lambda n: started.append(n)
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        assert started == ["alpha"]
+        assert "Container started" in str(
+            app.screen.query_one("#detail_msg").render()
+        )
+
+
+async def test_detail_auto_start_skipped_when_running(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    a = _wsobj("alpha", running=True)
+    started = []
+    st = _ws()
+    st.find_workspace = lambda n: a
+    st.restart_workspace = lambda n: started.append(n)
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        assert started == []
 
 
 async def test_detail_delete_confirm_cancel_error(monkeypatch):
@@ -1784,7 +1823,7 @@ async def test_detail_pops_when_workspace_deleted(monkeypatch):
         return None
 
     monkeypatch.setattr(scr, "listen_for_status", noop)
-    a = _wsobj("alpha")
+    a = _wsobj("alpha", running=True)
     st = _ws(owned=[a])
     calls = {"n": 0}
 


### PR DESCRIPTION
## Summary
- The Flutter UI auto-starts stopped containers via its WebSocket `connectWorkspace` call, but the TUI detail screen only displayed workspace info without triggering a start
- Added `_start_if_stopped` async worker to `WorkspaceDetailScreen` that calls `restart_workspace` when mounting a stopped workspace, matching Flutter behavior
- Shows "Starting container…" / "Container started." status messages during the process

## Test plan
- [x] `test_detail_auto_starts_stopped_workspace` — verifies restart is called for stopped workspaces
- [x] `test_detail_auto_start_skipped_when_running` — verifies no restart for already-running workspaces
- [x] All 145 existing TUI tests pass