### PR TITLE
Add start/stop endpoints to API fuzzer

### DIFF
--- a/scripts/fuzz-api.py
+++ b/scripts/fuzz-api.py
@@ -341,6 +341,8 @@ ENDPOINTS: list[tuple[str, str, dict | None, dict | None]] = [
         None,
     ),
     ("POST", f"{P}/workspaces/{{workspace_id}}/restart", None, None),
+    ("POST", f"{P}/workspaces/{{workspace_id}}/start", None, None),
+    ("POST", f"{P}/workspaces/{{workspace_id}}/stop", None, None),
     ("GET", f"{P}/workspaces/{{workspace_id}}/status", None, None),
     ("GET", f"{P}/workspaces/{{workspace_id}}/export", None, None),
     (


### PR DESCRIPTION
## Summary
- Add `POST /workspaces/{workspace_id}/start` and `POST /workspaces/{workspace_id}/stop` to the fuzzer's `ENDPOINTS` list

Fixes #1795