### PR TITLE
TUI: apply klangk theme (GitHub-dark palette)

### DIFF
--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 
 from textual.app import App
+from textual.theme import Theme
 
 from .screens import (
     AddServerScreen,
@@ -16,6 +17,35 @@ from .screens import (
     WorkspaceDetailScreen,
 )
 from .state import TuiState
+
+# ---------------------------------------------------------------------------
+# Klangk theme — echoes the Flutter web UI's GitHub-dark-inspired palette
+# (src/frontend/lib/theme/colors.dart).
+#
+# Tokens:
+#   primary   — green (#238636): primary actions (login, create, start)
+#   secondary — blue (#58A6FF): links, focus, informational
+#   accent    — yellow (#F5C518): brand highlight
+#   warning   — amber (#D29922): caution actions (restart, stop)
+#   error     — red (#F85149): destructive actions (delete), errors
+#   success   — green (#238636): healthy / running indicators
+#   background — dark canvas (#0D1117)
+#   surface   — card/panel surface (#161B22)
+#   panel     — overlay panels (#1C2128)
+# ---------------------------------------------------------------------------
+KLANGK_THEME = Theme(
+    name="klangk",
+    primary="#238636",
+    secondary="#58A6FF",
+    accent="#F5C518",
+    warning="#D29922",
+    error="#F85149",
+    success="#238636",
+    background="#0D1117",
+    surface="#161B22",
+    panel="#1C2128",
+    dark=True,
+)
 
 
 class KlangkApp(App):
@@ -134,8 +164,9 @@ class KlangkApp(App):
     def __init__(self, state: TuiState) -> None:
         super().__init__()
         self.tui_state = state
-        # Latest live-status annotation shown in the status bar.
         self.live_extra = ""
+        self.register_theme(KLANGK_THEME)
+        self.theme = "klangk"
 
     def on_mount(self) -> None:
         self.title = "Klangk"

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -823,6 +823,22 @@ async def test_server_switch_and_add(monkeypatch):
         assert switched["url"] == "https://b.example"
         assert isinstance(app.screen, MainScreen)
 
+    # selecting an item with empty name is a no-op (no switch_server call)
+    st1b = _authed_state(
+        known_servers=lambda: [
+            tui_state_mod.ServerInfo("a", "https://a.example"),
+        ],
+    )
+    switched1b = {}
+    st1b.switch_server = lambda url: switched1b.setdefault("url", url)
+    app1b = KlangkApp(st1b)
+    async with app1b.run_test() as pilot:
+        app1b.push_screen(ServerSwitchScreen())
+        await pilot.pause()
+        app1b.screen.on_list_view_selected(FakeSelected(""))
+        await pilot.pause()
+        assert switched1b == {}
+
     # switch screen with no servers -> hint message
     app2 = KlangkApp(_authed_state(known_servers=lambda: []))
     async with app2.run_test() as pilot:


### PR DESCRIPTION
## Summary
- Register a custom Textual theme derived from the Flutter web UI's `KColors` palette (GitHub dark-inspired)
- Green primary (#238636), blue secondary (#58A6FF), yellow accent (#F5C518), amber warning, red error
- Dark backgrounds matching the Flutter UI: canvas #0D1117, surface #161B22, panel #1C2128
- All existing CSS already uses Textual's design tokens ($primary, $panel, $text-muted, etc.) so the theme propagates automatically

Fixes #1791

## Test plan
- [x] All 163 TUI tests pass
- [x] Theme tokens documented in comment block above the Theme definition