### PR TITLE
TUI: edit existing server entry (alias / URL)

### DIFF
--- a/src/klangk/klangk/cli/config.py
+++ b/src/klangk/klangk/cli/config.py
@@ -232,10 +232,10 @@ def update_server_in_config(
     existing = servers[old_alias]
     if isinstance(existing, dict):
         entry = dict(existing)
-    else:  # pragma: no cover
+    else:
         entry = {}
     entry["url"] = server_url
-    if user is not None:
+    if user:
         entry["user"] = user
     if old_alias != new_alias:
         del servers[old_alias]

--- a/src/klangk/klangk/cli/config.py
+++ b/src/klangk/klangk/cli/config.py
@@ -232,7 +232,7 @@ def update_server_in_config(
     existing = servers[old_alias]
     if isinstance(existing, dict):
         entry = dict(existing)
-    else:
+    else:  # pragma: no cover
         entry = {}
     entry["url"] = server_url
     if user is not None:

--- a/src/klangk/klangk/cli/config.py
+++ b/src/klangk/klangk/cli/config.py
@@ -203,6 +203,34 @@ def add_server_to_config(
     _CONFIG_PATH.write_text(yaml.dump(data, default_flow_style=False))
 
 
+def update_server_in_config(
+    old_alias: str,
+    new_alias: str,
+    server_url: str,
+    user: str | None = None,
+) -> bool:
+    """Update an existing server entry in klangk.yaml.
+
+    If *old_alias* differs from *new_alias* the entry is renamed.
+    Returns True if the alias was found and updated, False otherwise.
+    """
+    if not _CONFIG_PATH.exists():
+        return False
+    data = yaml.safe_load(_CONFIG_PATH.read_text()) or {}
+    servers = data.get("servers") or {}
+    if old_alias not in servers:
+        return False
+    if old_alias != new_alias:
+        del servers[old_alias]
+    entry: dict = {"url": server_url}
+    if user:
+        entry["user"] = user
+    servers[new_alias] = entry
+    data["servers"] = servers
+    _CONFIG_PATH.write_text(yaml.dump(data, default_flow_style=False))
+    return True
+
+
 def remove_server_from_config(alias: str) -> bool:
     """Remove a named server entry from klangk.yaml.
 

--- a/src/klangk/klangk/cli/config.py
+++ b/src/klangk/klangk/cli/config.py
@@ -203,6 +203,10 @@ def add_server_to_config(
     _CONFIG_PATH.write_text(yaml.dump(data, default_flow_style=False))
 
 
+class AliasConflictError(Exception):
+    """Raised when renaming a server alias to one that already exists."""
+
+
 def update_server_in_config(
     old_alias: str,
     new_alias: str,
@@ -213,6 +217,8 @@ def update_server_in_config(
 
     If *old_alias* differs from *new_alias* the entry is renamed.
     Returns True if the alias was found and updated, False otherwise.
+    Raises ``AliasConflictError`` if *new_alias* already exists under
+    a different key.
     """
     if not _CONFIG_PATH.exists():
         return False
@@ -220,11 +226,19 @@ def update_server_in_config(
     servers = data.get("servers") or {}
     if old_alias not in servers:
         return False
+    if old_alias != new_alias and new_alias in servers:
+        raise AliasConflictError(f"Alias '{new_alias}' already exists.")
+    # Preserve fields not shown in the edit form (forward_agent, ws_max_size).
+    existing = servers[old_alias]
+    if isinstance(existing, dict):
+        entry = dict(existing)
+    else:
+        entry = {}
+    entry["url"] = server_url
+    if user is not None:
+        entry["user"] = user
     if old_alias != new_alias:
         del servers[old_alias]
-    entry: dict = {"url": server_url}
-    if user:
-        entry["user"] = user
     servers[new_alias] = entry
     data["servers"] = servers
     _CONFIG_PATH.write_text(yaml.dump(data, default_flow_style=False))

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -2171,16 +2171,18 @@ class ServerSwitchScreen(Screen):
         if child is None:
             return
         url = child.name
-
-        def _on_confirm(confirmed: bool) -> None:
-            if confirmed:
-                self.run_worker(
-                    self._do_delete_and_refresh(url), exit_on_error=False
-                )
-
+        self._pending_delete_url = url
         self.app.push_screen(
-            ConfirmScreen(f"Delete server {url}?"), _on_confirm
+            ConfirmScreen(f"Delete server {url}?"),
+            self._on_delete_confirmed,
         )
+
+    def _on_delete_confirmed(self, confirmed: bool) -> None:
+        if confirmed:
+            self.run_worker(
+                self._do_delete_and_refresh(self._pending_delete_url),
+                exit_on_error=False,
+            )
 
     async def _do_delete_and_refresh(self, url: str) -> None:
         await asyncio.to_thread(self.app.tui_state.delete_server, url)

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -2171,18 +2171,16 @@ class ServerSwitchScreen(Screen):
         if child is None:
             return
         url = child.name
-        self._pending_delete_url = url
-        self.app.push_screen(
-            ConfirmScreen(f"Delete server {url}?"),
-            self._on_delete_confirmed,
-        )
 
-    def _on_delete_confirmed(self, confirmed: bool) -> None:
-        if confirmed:
-            self.run_worker(
-                self._do_delete_and_refresh(self._pending_delete_url),
-                exit_on_error=False,
-            )
+        def _on_confirm(confirmed: bool) -> None:
+            if confirmed:
+                self.run_worker(
+                    self._do_delete_and_refresh(url), exit_on_error=False
+                )
+
+        self.app.push_screen(
+            ConfirmScreen(f"Delete server {url}?"), _on_confirm
+        )
 
     async def _do_delete_and_refresh(self, url: str) -> None:
         await asyncio.to_thread(self.app.tui_state.delete_server, url)
@@ -2319,7 +2317,9 @@ class EditServerScreen(ModalScreen):
                 url,
             )
         except Exception as exc:
-            self.query_one("#edit_srv_msg", Static).update(f"[red]{exc}[/red]")
+            self.query_one("#edit_srv_msg", Static).update(
+                Text(str(exc), style="red")
+            )
             return
         if not ok:
             self.query_one("#edit_srv_msg", Static).update(

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -292,16 +292,22 @@ class LoginScreen(SpatialNavScreen):
         known_urls = {s.url for s in known}
         for s in known:
             mark = "*" if s.url == current else " "
-            lv.append(
-                ListItem(Label(f"{mark} {s.alias}  ({s.url})"), name=s.url)
+            label = Text(
+                f"{mark} {s.alias}  ({s.url})",
+                overflow="ellipsis",
+                no_wrap=True,
             )
+            lv.append(ListItem(Label(label), name=s.url))
         uds = self.app.tui_state.default_uds()
         # Only offer the auto-detected default UDS if no alias already covers
         # it (otherwise it would duplicate the persisted alias row).
         if uds and uds != current and uds not in known_urls:
-            lv.append(
-                ListItem(Label(f"  Local klangkd (UDS)  ({uds})"), name=uds)
+            label = Text(
+                f"  Local klangkd (UDS)  ({uds})",
+                overflow="ellipsis",
+                no_wrap=True,
             )
+            lv.append(ListItem(Label(label), name=uds))
 
     @staticmethod
     def _derive_alias(raw: str) -> str:
@@ -2132,7 +2138,12 @@ class ServerSwitchScreen(Screen):
         current = self.app.tui_state.current_url()
         for s in servers:
             mark = "*" if s.url == current else " "
-            item = ListItem(Label(f"{mark} {s.alias}  ({s.url})"), name=s.url)
+            label = Text(
+                f"{mark} {s.alias}  ({s.url})",
+                overflow="ellipsis",
+                no_wrap=True,
+            )
+            item = ListItem(Label(label), name=s.url)
             item.server_alias = s.alias
             lv.append(item)
 
@@ -2248,7 +2259,7 @@ class EditServerScreen(ModalScreen):
 
     def compose(self) -> ComposeResult:
         yield Vertical(
-            Static(f"Edit server: {self._old_alias}", classes="title"),
+            Static(Text(f"Edit server: {self._old_alias}"), classes="title"),
             Horizontal(
                 Static("Alias"),
                 Input(value=self._old_alias, id="alias"),
@@ -2297,15 +2308,22 @@ class EditServerScreen(ModalScreen):
         self.run_worker(self._do_save(alias, url), exit_on_error=False)
 
     async def _do_save(self, alias: str, url: str) -> None:
-        ok = await asyncio.to_thread(
-            self.app.tui_state.update_server,
-            self._old_alias,
-            alias,
-            url,
-        )
+        try:
+            ok = await asyncio.to_thread(
+                self.app.tui_state.update_server,
+                self._old_alias,
+                alias,
+                url,
+            )
+        except Exception as exc:
+            self.query_one("#edit_srv_msg", Static).update(f"[red]{exc}[/red]")
+            return
         if not ok:
             self.query_one("#edit_srv_msg", Static).update(
                 "[red]Server not found.[/red]"
             )
             return
+        url_changed = url != self._old_url
         self.dismiss(True)
+        if url_changed:
+            self.app.server_changed()

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -2157,8 +2157,10 @@ class ServerSwitchScreen(Screen):
         if not alias:
             return
 
-        def _on_edit(changed: bool) -> None:
-            if changed:
+        def _on_edit(result: str | bool) -> None:
+            if result == "url_changed":
+                self.app.server_changed()
+            elif result:
                 self._populate()
 
         self.app.push_screen(EditServerScreen(alias=alias, url=url), _on_edit)
@@ -2323,7 +2325,6 @@ class EditServerScreen(ModalScreen):
                 "[red]Server not found.[/red]"
             )
             return
-        url_changed = url != self._old_url
-        self.dismiss(True)
-        if url_changed:
-            self.app.server_changed()
+        # Signal whether server_changed() should follow (URL changed →
+        # the server list and main screen need a full refresh).
+        self.dismiss("url_changed" if url != self._old_url else True)

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -2173,11 +2173,10 @@ class ServerSwitchScreen(Screen):
         url = child.name
 
         def _on_confirm(confirmed: bool) -> None:
-            if not confirmed:
-                return
-            self.run_worker(
-                self._do_delete_and_refresh(url), exit_on_error=False
-            )
+            if confirmed:
+                self.run_worker(
+                    self._do_delete_and_refresh(url), exit_on_error=False
+                )
 
         self.app.push_screen(
             ConfirmScreen(f"Delete server {url}?"), _on_confirm

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -2103,6 +2103,7 @@ class ServerSwitchScreen(Screen):
 
     BINDINGS = [
         ("escape", "app.pop_screen", "Back"),
+        ("e", "edit_server", "Edit"),
         ("d", "delete_server", "Delete"),
     ]
 
@@ -2131,9 +2132,25 @@ class ServerSwitchScreen(Screen):
         current = self.app.tui_state.current_url()
         for s in servers:
             mark = "*" if s.url == current else " "
-            lv.append(
-                ListItem(Label(f"{mark} {s.alias}  ({s.url})"), name=s.url)
-            )
+            item = ListItem(Label(f"{mark} {s.alias}  ({s.url})"), name=s.url)
+            item.server_alias = s.alias
+            lv.append(item)
+
+    def action_edit_server(self) -> None:
+        lv = self.query_one("#server_options", ListView)
+        child = lv.highlighted_child
+        if child is None:
+            return
+        alias = getattr(child, "server_alias", "") or ""
+        url = child.name or ""
+        if not alias:
+            return
+
+        def _on_edit(changed: bool) -> None:
+            if changed:
+                self._populate()
+
+        self.app.push_screen(EditServerScreen(alias=alias, url=url), _on_edit)
 
     def action_delete_server(self) -> None:
         lv = self.query_one("#server_options", ListView)
@@ -2217,3 +2234,78 @@ class AddServerScreen(Screen):
     async def _do_add_server(self, alias: str, url: str) -> None:
         await asyncio.to_thread(self.app.tui_state.add_server, alias, url)
         self.app.server_changed()
+
+
+class EditServerScreen(ModalScreen):
+    """Edit an existing server alias and/or URL (#1762)."""
+
+    BINDINGS = [("escape", "cancel", "Cancel")]
+
+    def __init__(self, *, alias: str, url: str) -> None:
+        super().__init__()
+        self._old_alias = alias
+        self._old_url = url
+
+    def compose(self) -> ComposeResult:
+        yield Vertical(
+            Static(f"Edit server: {self._old_alias}", classes="title"),
+            Horizontal(
+                Static("Alias"),
+                Input(value=self._old_alias, id="alias"),
+                classes="field-row",
+            ),
+            Horizontal(
+                Static("URL"),
+                Input(value=self._old_url, id="url"),
+                classes="field-row",
+            ),
+            Static("", id="edit_srv_msg"),
+            Horizontal(
+                Button("Cancel", id="cancel"),
+                Button("Save", id="save", variant="primary"),
+                classes="actions",
+            ),
+            id="edit_srv_box",
+        )
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "save":
+            self._save()
+        elif event.button.id == "cancel":
+            self.dismiss(False)
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        if event.input.id in ("alias", "url"):
+            self._save()
+
+    def action_cancel(self) -> None:
+        self.dismiss(False)
+
+    def _save(self) -> None:
+        alias = self.query_one("#alias", Input).value.strip()
+        url = self.query_one("#url", Input).value.strip()
+        msg = self.query_one("#edit_srv_msg", Static)
+        if not alias or not url:
+            msg.update("[red]Alias and URL are required.[/red]")
+            return
+        if not is_valid_server_spec(url):
+            msg.update(
+                "[red]URL must be http(s)://host or an absolute socket"
+                " path (/...).[/red]"
+            )
+            return
+        self.run_worker(self._do_save(alias, url), exit_on_error=False)
+
+    async def _do_save(self, alias: str, url: str) -> None:
+        ok = await asyncio.to_thread(
+            self.app.tui_state.update_server,
+            self._old_alias,
+            alias,
+            url,
+        )
+        if not ok:
+            self.query_one("#edit_srv_msg", Static).update(
+                "[red]Server not found.[/red]"
+            )
+            return
+        self.dismiss(True)

--- a/src/klangk/klangk/cli/tui/state.py
+++ b/src/klangk/klangk/cli/tui/state.py
@@ -28,6 +28,7 @@ from ..config import (
     add_server_to_config,
     default_server_uds_path,
     remove_server_from_config,
+    update_server_in_config,
 )
 from ..transport import http_request
 
@@ -283,6 +284,29 @@ class TuiState:
         state = self.state()
         state.active_server = url
         state.save()
+
+    def update_server(
+        self,
+        old_alias: str,
+        new_alias: str,
+        url: str,
+        user: str | None = None,
+    ) -> bool:
+        """Update an existing server entry.
+
+        Returns True if the alias was found and updated. If the URL changed
+        and this was the active server, the active pointer is updated too.
+        """
+        cfg = self.cfg()
+        old_entry = cfg.servers.get(old_alias)
+        old_url = old_entry.url if old_entry else None
+        if not update_server_in_config(old_alias, new_alias, url, user):
+            return False
+        state = self.state()
+        if old_url and state.active_server == old_url:
+            state.active_server = url
+            state.save()
+        return True
 
     def delete_server(self, url: str) -> bool:
         """Delete the alias pointing at *url*.

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -228,6 +228,16 @@ def test_update_server_preserves_fields(redirect_xdg):
     assert loaded.servers["a"].user == "me@x"
 
 
+def test_update_server_sets_user(redirect_xdg):
+    add_server_to_config("a", "https://a.example")
+    assert (
+        update_server_in_config("a", "a", "https://a.example", user="new@x")
+        is True
+    )
+    loaded = CLIConfig.load()
+    assert loaded.servers["a"].user == "new@x"
+
+
 def test_update_server_no_config_file(monkeypatch, tmp_path):
     monkeypatch.setattr(cfgmod, "_CONFIG_PATH", tmp_path / "nope.yaml")
     assert update_server_in_config("a", "a", "https://x.example") is False

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -724,6 +724,7 @@ async def test_login_password_flow_success(monkeypatch):
         login.query_one("#identifier", Input).value = "me@x"
         login.query_one("#password", Input).value = "pw"
         login._attempt_password()
+        await app.workers.wait_for_complete()
         await pilot.pause()
         assert isinstance(app.screen, MainScreen)
 
@@ -737,10 +738,10 @@ async def test_login_password_flow_empty_and_fail():
         token=lambda: None,
     )
     app = KlangkApp(st)
-    async with app.run_test() as pilot:
+    async with app.run_test() as _pilot:
         login = app.screen
         login._attempt_password()  # empty fields
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert "required" in str(login.query_one("#message").render())
 
         st.login_password = lambda a, b: (_ for _ in ()).throw(
@@ -749,7 +750,7 @@ async def test_login_password_flow_empty_and_fail():
         login.query_one("#identifier", Input).value = "me@x"
         login.query_one("#password", Input).value = "pw"
         login._attempt_password()
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert "bad creds" in str(login.query_one("#message").render())
         assert isinstance(app.screen, LoginScreen)
 
@@ -782,6 +783,7 @@ async def test_login_input_submitted_triggers_password(monkeypatch):
         ident.value = "me@x"
         login.query_one("#password", Input).value = "pw"
         login.on_input_submitted(Input.Submitted(ident, ident.value))
+        await app.workers.wait_for_complete()
         await pilot.pause()
         assert isinstance(app.screen, MainScreen)
 
@@ -810,6 +812,7 @@ async def test_login_oidc_flow(monkeypatch):
     app = KlangkApp(st)
     async with app.run_test() as pilot:
         app.screen._attempt_oidc()
+        await app.workers.wait_for_complete()
         await pilot.pause()
         assert isinstance(app.screen, MainScreen)
 
@@ -825,7 +828,7 @@ async def test_login_oidc_flow(monkeypatch):
     app2 = KlangkApp(st2)
     async with app2.run_test() as pilot:
         app2.screen._attempt_oidc()
-        await pilot.pause()
+        await app2.workers.wait_for_complete()
         assert "SSO provider" in str(
             app2.screen.query_one("#message").render()
         )
@@ -843,7 +846,7 @@ async def test_login_oidc_flow(monkeypatch):
     app3 = KlangkApp(st3)
     async with app3.run_test() as pilot:
         app3.screen._attempt_oidc()
-        await pilot.pause()
+        await app3.workers.wait_for_complete()
         assert "SSO failed" in str(app3.screen.query_one("#message").render())
 
 
@@ -904,7 +907,7 @@ async def test_server_switch_and_add(monkeypatch):
         await pilot.pause()
         assert isinstance(app.screen, ServerSwitchScreen)
         app.screen.on_list_view_selected(FakeSelected("https://b.example"))
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert switched["url"] == "https://b.example"
         assert isinstance(app.screen, MainScreen)
 
@@ -921,7 +924,7 @@ async def test_server_switch_and_add(monkeypatch):
         app1b.push_screen(ServerSwitchScreen())
         await pilot.pause()
         app1b.screen.on_list_view_selected(FakeSelected(""))
-        await pilot.pause()
+        await app1b.workers.wait_for_complete()
         assert switched1b == {}
 
     # switch screen with no servers -> hint message
@@ -947,7 +950,7 @@ async def test_server_switch_and_add(monkeypatch):
         add_screen.query_one("#alias", Input).value = "prod"
         add_screen.query_one("#url", Input).value = "https://p.example"
         add_screen._add()
-        await pilot.pause()
+        await app3.workers.wait_for_complete()
         assert added["a"] == ("prod", "https://p.example")
         assert isinstance(app3.screen, MainScreen)
 
@@ -957,7 +960,7 @@ async def test_server_switch_and_add(monkeypatch):
         app4.push_screen(AddServerScreen())
         await pilot.pause()
         app4.screen._add()
-        await pilot.pause()
+        await app4.workers.wait_for_complete()
         assert "required" in str(app4.screen.query_one("#add_msg").render())
 
     # add server via input submit (Enter key in either field)
@@ -976,7 +979,7 @@ async def test_server_switch_and_add(monkeypatch):
         url_input = s.query_one("#url", Input)
         url_input.value = "https://s.example"
         s.on_input_submitted(Input.Submitted(url_input, url_input.value))
-        await pilot.pause()
+        await app5.workers.wait_for_complete()
         await pilot.pause()
         assert added5["a"] == ("staging", "https://s.example")
 
@@ -1013,7 +1016,7 @@ async def test_edit_server_saves(monkeypatch):
         app.screen.query_one("#alias", Input).value = "production"
         # Keep URL unchanged — no server_changed() call.
         app.screen._save()
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         await pilot.pause()
         assert updated["u"] == (
             "prod",
@@ -1035,7 +1038,7 @@ async def test_edit_server_empty_fields(monkeypatch):
         await pilot.pause()
         app.screen.query_one("#alias", Input).value = ""
         app.screen._save()
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert "required" in str(
             app.screen.query_one("#edit_srv_msg").render()
         )
@@ -1052,7 +1055,7 @@ async def test_edit_server_invalid_url(monkeypatch):
         await pilot.pause()
         app.screen.query_one("#url", Input).value = "not-a-url"
         app.screen._save()
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert "http(s)://" in str(
             app.screen.query_one("#edit_srv_msg").render()
         )
@@ -1093,7 +1096,7 @@ async def test_edit_server_not_found(monkeypatch):
         )
         await pilot.pause()
         app.screen._save()
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         await pilot.pause()
         assert (
             "not found"
@@ -1122,7 +1125,7 @@ async def test_edit_server_alias_conflict(monkeypatch):
         await pilot.pause()
         app.screen.query_one("#alias", Input).value = "b"
         app.screen._save()
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         await pilot.pause()
         assert (
             "already exists"
@@ -1159,7 +1162,7 @@ async def test_edit_server_url_change_triggers_server_changed(monkeypatch):
         await pilot.pause()
         app.screen.query_one("#url", Input).value = "https://new.example"
         app.screen._save()
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         await pilot.pause()
         assert changed == [True]
 
@@ -1201,7 +1204,7 @@ async def test_edit_server_via_input_submit(monkeypatch):
             Input.Submitted(url_input, url_input.value)
         )
         await pilot.pause()
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert updated["u"] == ("a", "a", "https://new.example")
 
 
@@ -1272,7 +1275,7 @@ async def test_edit_server_via_button(monkeypatch):
         s = app.screen
         save_btn = s.query_one("#save", Button)
         s.on_button_pressed(Button.Pressed(save_btn))
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         await pilot.pause()
         assert "u" in updated
 
@@ -1457,7 +1460,7 @@ async def test_focus_visible_list_on_mount(monkeypatch):
     app = KlangkApp(_ws(owned=[_wsobj("alpha"), _wsobj("beta")]))
     async with app.run_test() as pilot:
         await pilot.pause()
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert isinstance(app.focused, ListView)
         assert app.focused.index == 0
 
@@ -1650,11 +1653,13 @@ async def test_detail_action_edit_opens_form_and_refreshes(monkeypatch):
         app.push_screen(WorkspaceDetailScreen("alpha"))
         await pilot.pause()
         app.screen.action_edit()
+        await app.workers.wait_for_complete()
         await pilot.pause()
         assert isinstance(app.screen, EditWorkspaceScreen)
         # Simulate a successful save/disdismiss -> _on_edited refreshes.
         app.screen.dismiss(True)
         await pilot.pause()
+        await app.workers.wait_for_complete()
         assert isinstance(app.screen, WorkspaceDetailScreen)
         assert finds.count("alpha") >= 2  # initial load + post-edit reload
 
@@ -1679,6 +1684,7 @@ async def test_detail_and_edit_set_window_title(monkeypatch):
         await pilot.pause()
         assert app.title == "Klangk: workspace alpha"
         app.screen.action_edit()
+        await app.workers.wait_for_complete()
         await pilot.pause()
         assert app.title == "Klangk: workspace alpha"  # edit (same workspace)
         app.pop_screen()  # edit -> detail
@@ -1731,6 +1737,7 @@ async def test_detail_restart_confirm_cancel_error(monkeypatch):
         await pilot.pause()
         app.screen.dismiss(True)
         await pilot.pause()
+        await app.workers.wait_for_complete()
         assert restarted.get("r") == "alpha"
         assert "Restart requested" in str(
             app.screen.query_one("#detail_msg").render()
@@ -1743,6 +1750,7 @@ async def test_detail_restart_confirm_cancel_error(monkeypatch):
         await pilot.pause()
         app.screen.dismiss(True)
         await pilot.pause()
+        await app.workers.wait_for_complete()
         assert "Restart failed" in str(
             app.screen.query_one("#detail_msg").render()
         )
@@ -1826,6 +1834,7 @@ async def test_detail_stop_when_running(monkeypatch):
         assert isinstance(app.screen, ConfirmScreen)
         app.screen.dismiss(True)  # confirm stop
         await pilot.pause()
+        await app.workers.wait_for_complete()
         assert stopped.get("s") == "alpha"
         assert "Stop requested" in str(
             app.screen.query_one("#detail_msg").render()
@@ -1848,7 +1857,7 @@ async def test_detail_start_when_stopped(monkeypatch):
         await pilot.pause()
         # No confirm dialog for start — goes straight through.
         app.screen.action_stop()
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert started.get("s") == "alpha"
         assert "Start requested" in str(
             app.screen.query_one("#detail_msg").render()
@@ -1870,7 +1879,7 @@ async def test_detail_stop_ws_none(monkeypatch):
         await pilot.pause()
         # _ws is None because find_workspace returned None.
         app.screen.action_stop()
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         # No crash, still on detail screen.
         assert isinstance(app.screen, WorkspaceDetailScreen)
 
@@ -1924,6 +1933,7 @@ async def test_detail_stop_error(monkeypatch):
         assert isinstance(app.screen, ConfirmScreen)
         app.screen.dismiss(True)  # confirm
         await pilot.pause()
+        await app.workers.wait_for_complete()
         assert "Stop failed" in str(
             app.screen.query_one("#detail_msg").render()
         )
@@ -1949,7 +1959,7 @@ async def test_detail_start_error(monkeypatch):
         app.push_screen(WorkspaceDetailScreen("alpha"))
         await pilot.pause()
         app.screen.action_stop()  # ws not running → _do_start
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert "Start failed" in str(
             app.screen.query_one("#detail_msg").render()
         )
@@ -1982,6 +1992,7 @@ async def test_detail_delete_confirm_cancel_error(monkeypatch):
         await pilot.pause()
         app.screen.dismiss(True)
         await pilot.pause()
+        await app.workers.wait_for_complete()
         assert deleted.get("d") == "alpha"
         assert isinstance(app.screen, MainScreen)
 
@@ -2003,6 +2014,7 @@ async def test_detail_delete_error(monkeypatch):
         await pilot.pause()
         app.screen.dismiss(True)
         await pilot.pause()
+        await app.workers.wait_for_complete()
         assert "Delete failed" in str(
             app.screen.query_one("#detail_msg").render()
         )
@@ -2035,6 +2047,7 @@ async def test_detail_duplicate_ok_cancel_input_error(monkeypatch):
         await pilot.pause()
         app.screen.on_button_pressed(FakeBtnPress("ok"))
         await pilot.pause()
+        await app.workers.wait_for_complete()
         assert duped.get("d") == ("alpha", "alpha-copy")
         assert "Duplicated" in str(
             app.screen.query_one("#detail_msg").render()
@@ -2046,6 +2059,7 @@ async def test_detail_duplicate_ok_cancel_input_error(monkeypatch):
         di.value = "alpha-copy2"
         app.screen.on_input_submitted(Input.Submitted(di, di.value))
         await pilot.pause()
+        await app.workers.wait_for_complete()
         assert duped.get("d") == ("alpha", "alpha-copy2")
         # empty name -> treated as cancel
         app.screen.action_duplicate()
@@ -2062,6 +2076,7 @@ async def test_detail_duplicate_ok_cancel_input_error(monkeypatch):
         await pilot.pause()
         app.screen.on_button_pressed(FakeBtnPress("ok"))
         await pilot.pause()
+        await app.workers.wait_for_complete()
         assert "Duplicate failed" in str(
             app.screen.query_one("#detail_msg").render()
         )
@@ -2082,10 +2097,10 @@ async def test_refresh_workspaces_refreshes_main(monkeypatch):
     st = _ws(owned=[a])
     st.list_owned_workspaces = owned
     app = KlangkApp(st)
-    async with app.run_test() as pilot:
+    async with app.run_test() as _pilot:
         before = calls["n"]
         app.refresh_workspaces()
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert calls["n"] > before
 
 
@@ -2333,7 +2348,7 @@ async def test_detail_delete_terminal_guard_last(monkeypatch):
         d = app.screen
         d.query_one("#term_list").index = 0
         d.action_delete_terminal()  # only terminal -> refused
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert "Can't delete the last terminal" in str(
             d.query_one("#detail_msg").render()
         )
@@ -2357,7 +2372,7 @@ async def test_detail_delete_terminal_no_selection(monkeypatch):
         # nothing highlighted -> no-op
         d.query_one("#term_list").index = None
         d.action_delete_terminal()
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert (
             len(d.query_one("#term_list", ListView).query(ListItem)) == 2
         )  # unchanged
@@ -2380,7 +2395,7 @@ async def test_detail_delete_terminal_placeholder(monkeypatch):
         d = app.screen
         d.query_one("#term_list").index = 0  # the placeholder
         d.action_delete_terminal()  # opt.id == "" -> no-op
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert (
             len(d.query_one("#term_list", ListView).query(ListItem)) == 1
         )  # unchanged
@@ -2435,7 +2450,7 @@ async def test_detail_delete_terminal_failure(monkeypatch):
         await pilot.pause()
         d = app.screen
         await d._do_delete_terminal(1)  # close raises
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert "Delete failed" in str(d.query_one("#detail_msg").render())
 
 
@@ -2571,7 +2586,7 @@ async def test_detail_delete_terminal_empty_result(monkeypatch):
         await pilot.pause()
         d = app.screen
         await d._do_delete_terminal(1)
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert "Delete failed" in str(d.query_one("#detail_msg").render())
         assert (
             len(d.query_one("#term_list", ListView).query(ListItem)) == 2
@@ -2605,6 +2620,7 @@ async def test_create_screen_renders_defaults(monkeypatch):
     app = KlangkApp(_create_state())
     async with app.run_test() as pilot:
         app.screen.action_create()
+        await app.workers.wait_for_complete()
         await pilot.pause()
         cs = app.screen
         assert isinstance(cs, CreateWorkspaceScreen)
@@ -2622,6 +2638,7 @@ async def test_create_screen_autostart_hidden_when_not_allowed(monkeypatch):
     app = KlangkApp(_create_state(allow_autostart=lambda: False))
     async with app.run_test() as pilot:
         app.screen.action_create()
+        await app.workers.wait_for_complete()
         await pilot.pause()
         cb = app.screen.query_one("#auto_start", Checkbox)
         assert cb.display is False
@@ -2636,6 +2653,7 @@ async def test_create_screen_mount_editor(monkeypatch):
     app = KlangkApp(_create_state())
     async with app.run_test() as pilot:
         app.screen.action_create()
+        await app.workers.wait_for_complete()
         await pilot.pause()
         cs = app.screen
         # valid add
@@ -2664,6 +2682,7 @@ async def test_create_screen_env_editor(monkeypatch):
     app = KlangkApp(_create_state())
     async with app.run_test() as pilot:
         app.screen.action_create()
+        await app.workers.wait_for_complete()
         await pilot.pause()
         cs = app.screen
         cs.query_one("#env_input").value = "FOO=bar"
@@ -2695,6 +2714,7 @@ async def test_create_screen_name_required(monkeypatch):
     )
     async with app.run_test() as pilot:
         app.screen.action_create()
+        await app.workers.wait_for_complete()
         await pilot.pause()
         app.screen._create()  # name empty
         assert called == []
@@ -2721,11 +2741,12 @@ async def test_create_screen_submit_omits_default_image(monkeypatch):
     )
     async with app.run_test() as pilot:
         app.screen.action_create()
+        await app.workers.wait_for_complete()
         await pilot.pause()
         cs = app.screen
         cs.query_one("#name").value = "myws"
         cs._create()  # default image kept -> omitted
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert captured["name"] == "myws"
         assert captured["k"]["image"] is None
         assert captured["k"]["auto_start"] is False
@@ -2748,6 +2769,7 @@ async def test_create_screen_submit_custom_fields(monkeypatch):
     app = KlangkApp(_create_state(create=create))
     async with app.run_test() as pilot:
         app.screen.action_create()
+        await app.workers.wait_for_complete()
         await pilot.pause()
         cs = app.screen
         cs.query_one("#name").value = "myws"
@@ -2760,7 +2782,7 @@ async def test_create_screen_submit_custom_fields(monkeypatch):
         cs._add_env()
         cs.query_one("#auto_start", Checkbox).value = True
         cs._create()
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert captured["k"]["image"] == "py:3"
         assert captured["k"]["service_command"] == "sleep 1"
         assert captured["k"]["health_check"] == "curl localhost"
@@ -2788,12 +2810,12 @@ async def test_create_screen_http_error_shows_detail(monkeypatch):
     app = KlangkApp(_create_state(create=create))
     async with app.run_test() as pilot:
         app.screen.action_create()
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         await pilot.pause()
         cs = app.screen
         cs.query_one("#name").value = "dup"
         cs._create()
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert "name taken" in str(cs.query_one("#create_msg").render())
         assert isinstance(app.screen, CreateWorkspaceScreen)  # still on form
 
@@ -2810,12 +2832,12 @@ async def test_create_screen_auth_error(monkeypatch):
     app = KlangkApp(_create_state(create=create))
     async with app.run_test() as pilot:
         app.screen.action_create()
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         await pilot.pause()
         cs = app.screen
         cs.query_one("#name").value = "ws"
         cs._create()
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert "Session expired" in str(cs.query_one("#create_msg").render())
 
 
@@ -2838,13 +2860,14 @@ async def test_create_screen_images_unavailable(monkeypatch):
     )
     async with app.run_test() as pilot:
         app.screen.action_create()
+        await app.workers.wait_for_complete()
         await pilot.pause()
         cs = app.screen
         assert cs._allowed == []
         assert cs.query_one("#auto_start", Checkbox).display is False
         cs.query_one("#name").value = "ws"
         cs._create()
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert captured["k"]["image"] is None  # omitted
 
 
@@ -2856,6 +2879,7 @@ async def test_create_screen_cancel_button(monkeypatch):
     app = KlangkApp(_create_state())
     async with app.run_test() as pilot:
         app.screen.action_create()
+        await app.workers.wait_for_complete()
         await pilot.pause()
         app.screen.on_button_pressed(FakeBtnPress("cancel"))
         await pilot.pause()
@@ -2870,6 +2894,7 @@ async def test_create_screen_input_submit_routing(monkeypatch):
     app = KlangkApp(_create_state())
     async with app.run_test() as pilot:
         app.screen.action_create()
+        await app.workers.wait_for_complete()
         await pilot.pause()
         cs = app.screen
         # empty name submit -> required error (no dismiss)
@@ -2901,14 +2926,16 @@ async def test_create_flow_offer_opens_detail(monkeypatch):
     app = KlangkApp(_create_state(create=lambda *a, **k: _wsobj("new")))
     async with app.run_test() as pilot:
         app.screen.action_create()
+        await app.workers.wait_for_complete()
         await pilot.pause()
         cs = app.screen
         cs.query_one("#name").value = "new"
         cs._create()
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert isinstance(app.screen, ConfirmScreen)  # "Open it now?"
         app.screen.dismiss(True)
         await pilot.pause()
+        await app.workers.wait_for_complete()
         assert isinstance(app.screen, WorkspaceDetailScreen)
         assert app.screen._name == "new"
 
@@ -2921,11 +2948,12 @@ async def test_create_flow_offer_declined(monkeypatch):
     app = KlangkApp(_create_state(create=lambda *a, **k: _wsobj("new")))
     async with app.run_test() as pilot:
         app.screen.action_create()
+        await app.workers.wait_for_complete()
         await pilot.pause()
         cs = app.screen
         cs.query_one("#name").value = "new"
         cs._create()
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert isinstance(app.screen, ConfirmScreen)
         app.screen.dismiss(False)
         await pilot.pause()
@@ -2942,6 +2970,7 @@ async def test_create_editor_guards(monkeypatch):
     app = KlangkApp(_create_state())
     async with app.run_test() as pilot:
         app.screen.action_create()
+        await app.workers.wait_for_complete()
         await pilot.pause()
         cs = app.screen
         # empty input -> no-op for both editors
@@ -2970,12 +2999,12 @@ async def test_create_screen_generic_error(monkeypatch):
     app = KlangkApp(_create_state(create=create))
     async with app.run_test() as pilot:
         app.screen.action_create()
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         await pilot.pause()
         cs = app.screen
         cs.query_one("#name").value = "ws"
         cs._create()
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert "Failed to create: boom" in str(
             cs.query_one("#create_msg").render()
         )
@@ -2991,6 +3020,7 @@ async def test_create_button_routing(monkeypatch):
     app = KlangkApp(_create_state(create=lambda *a, **k: _wsobj("ws")))
     async with app.run_test() as pilot:
         app.screen.action_create()
+        await app.workers.wait_for_complete()
         await pilot.pause()
         cs = app.screen
         # add mount via button
@@ -3020,7 +3050,7 @@ async def test_create_button_routing(monkeypatch):
         # create via button -> success -> offer
         cs.query_one("#name").value = "ws"
         cs.on_button_pressed(FakeBtnPress("create"))
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert isinstance(app.screen, ConfirmScreen)
 
 
@@ -3045,6 +3075,7 @@ async def test_create_screen_image_names_markup_safe(monkeypatch):
     )
     async with app.run_test() as pilot:
         app.screen.action_create()
+        await app.workers.wait_for_complete()
         await pilot.pause()
         # mounted + initial render without MarkupError
         assert isinstance(app.screen, CreateWorkspaceScreen)
@@ -3079,12 +3110,12 @@ async def test_create_screen_http_error_non_json(monkeypatch):
     app = KlangkApp(_create_state(create=create))
     async with app.run_test() as pilot:
         app.screen.action_create()
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         await pilot.pause()
         cs = app.screen
         cs.query_one("#name").value = "ws"
         cs._create()
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert "Failed to create" in str(cs.query_one("#create_msg").render())
         assert isinstance(app.screen, CreateWorkspaceScreen)  # no crash
 
@@ -3116,13 +3147,14 @@ async def test_create_screen_default_not_in_allowed(monkeypatch):
     )
     async with app.run_test() as pilot:
         app.screen.action_create()
+        await app.workers.wait_for_complete()
         await pilot.pause()
         cs = app.screen
         # default not in allowed -> picker is unselected
         assert cs.query_one("#image", Select).value is Select.NULL
         cs.query_one("#name").value = "ws"
         cs._create()  # nothing picked -> image omitted
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert captured["k"]["image"] is None
 
 
@@ -3162,6 +3194,7 @@ async def test_create_screen_allowed_domains_editor(monkeypatch):
     app = KlangkApp(_create_state())
     async with app.run_test() as pilot:
         app.screen.action_create()
+        await app.workers.wait_for_complete()
         await pilot.pause()
         cs = app.screen
         # valid add
@@ -3270,7 +3303,7 @@ async def test_edit_screen_save_calls_update(monkeypatch):
         es.query_one("#allow_input").value = "github.com:443"
         es._add_allowed_domain()
         es._save()
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert captured["id"] == ws.id
         assert captured["name"] == "renamed"
         assert captured["allowed_domains"] == ["github.com:443"]
@@ -3297,11 +3330,12 @@ async def test_edit_screen_restart_needed_when_running_and_changed(
         es = app.screen
         es.query_one("#image", Select).value = "py:3"  # create-time change
         es._save()
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert isinstance(app.screen, ConfirmScreen)  # restart offered
         # accept -> restart_workspace called + edit screen dismissed
         app.screen.dismiss(True)
         await pilot.pause()
+        await app.workers.wait_for_complete()
         assert restarted
         assert not isinstance(app.screen, EditWorkspaceScreen)
 
@@ -3320,7 +3354,7 @@ async def test_edit_screen_no_restart_when_create_field_unchanged(monkeypatch):
         # No create-time field changed (only a live-propagating field).
         es.query_one("#health_check").value = "curl x"
         es._save()
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert not isinstance(app.screen, ConfirmScreen)
         assert not isinstance(app.screen, EditWorkspaceScreen)
 
@@ -3366,7 +3400,7 @@ async def test_edit_screen_save_http_error_shows_detail(monkeypatch):
         await pilot.pause()
         es = app.screen
         es._save()
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert "name taken" in str(es.query_one("#edit_msg").render())
         assert isinstance(app.screen, EditWorkspaceScreen)  # still on form
 
@@ -3501,7 +3535,7 @@ async def test_edit_button_and_input_routing(monkeypatch):
         assert es._allowed_domains == ["pypi.org"]
         # save via button + name submit
         es.on_button_pressed(FakeBtnPress("save"))
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert not isinstance(app.screen, EditWorkspaceScreen)
 
 
@@ -3522,7 +3556,7 @@ async def test_edit_screen_save_auth_error(monkeypatch):
         await pilot.pause()
         es = app.screen
         es._save()
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert "Session expired" in str(es.query_one("#edit_msg").render())
 
 
@@ -3542,7 +3576,7 @@ async def test_edit_screen_save_generic_error(monkeypatch):
         await pilot.pause()
         es = app.screen
         es._save()
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert "Failed to save: boom" in str(
             es.query_one("#edit_msg").render()
         )
@@ -3571,7 +3605,7 @@ async def test_edit_screen_save_http_error_non_json(monkeypatch):
         await pilot.pause()
         es = app.screen
         es._save()
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert "proxy" in str(es.query_one("#edit_msg").render())
 
 
@@ -3589,7 +3623,7 @@ async def test_edit_screen_field_submit_saves(monkeypatch):
         es = app.screen
         name = es.query_one("#name")
         es.on_input_submitted(Input.Submitted(name, name.value))  # -> _save
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert updated  # update_workspace called
         assert not isinstance(app.screen, EditWorkspaceScreen)
 
@@ -3610,7 +3644,7 @@ async def test_edit_screen_restart_declined(monkeypatch):
         es = app.screen
         es.query_one("#image", Select).value = "py:3"
         es._save()
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert isinstance(app.screen, ConfirmScreen)
         app.screen.dismiss(False)  # decline restart
         await pilot.pause()
@@ -3635,10 +3669,11 @@ async def test_edit_screen_restart_failure(monkeypatch):
         es = app.screen
         es.query_one("#image", Select).value = "py:3"
         es._save()
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert isinstance(app.screen, ConfirmScreen)
         app.screen.dismiss(True)  # accept restart -> fails
         await pilot.pause()
+        await app.workers.wait_for_complete()
         assert "restart failed" in str(es.query_one("#edit_msg").render())
 
 
@@ -3660,6 +3695,7 @@ async def test_detail_action_edit_no_workspace(monkeypatch):
         d = app.screen
         d._ws = None  # nothing loaded
         d.action_edit()  # early no-op
+        await app.workers.wait_for_complete()
         await pilot.pause()
         assert isinstance(app.screen, WorkspaceDetailScreen)
 
@@ -3681,6 +3717,7 @@ async def test_detail_action_edit_fetch_failure(monkeypatch):
         app.push_screen(WorkspaceDetailScreen("alpha"))
         await pilot.pause()
         app.screen.action_edit()
+        await app.workers.wait_for_complete()
         await pilot.pause()
         # form still opens, with no images + autostart off
         assert isinstance(app.screen, EditWorkspaceScreen)
@@ -3801,11 +3838,12 @@ async def test_edit_rename_propagates_to_detail_and_list(monkeypatch):
         await pilot.pause()
         assert app.screen._name == "alpha"
         app.screen.action_edit()
+        await app.workers.wait_for_complete()
         await pilot.pause()
         es = app.screen
         es.query_one("#name").value = "renamed"
         es._save()
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         # back on detail; name adopted + reloaded by the new name
         assert isinstance(app.screen, WorkspaceDetailScreen)
         assert app.screen._name == "renamed"
@@ -3826,6 +3864,7 @@ async def test_create_screen_no_server_does_not_crash(monkeypatch):
     app = KlangkApp(_create_state(list_images=boom, allow_autostart=boom))
     async with app.run_test() as pilot:
         app.screen.action_create()  # must not raise
+        await app.workers.wait_for_complete()
         await pilot.pause()
         cs = app.screen
         assert isinstance(cs, CreateWorkspaceScreen)
@@ -3924,7 +3963,7 @@ async def test_login_server_picker(monkeypatch):
         ),
     )
     app = KlangkApp(st)
-    async with app.run_test() as pilot:
+    async with app.run_test() as _pilot:
         login = app.screen
         # no-server branch: prompt + disabled credentials
         assert "No server selected" in str(
@@ -3934,19 +3973,19 @@ async def test_login_server_picker(monkeypatch):
 
         # empty choice -> error message
         login._choose_server("   ")
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert "Enter a server URL" in str(
             login.query_one("#message").render()
         )
 
         # known alias -> switch (routed through the option-selected handler)
         login.on_list_view_selected(FakeSelected("prod"))
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert calls.get("switch") == "https://prod.example"
 
         # new URL -> added as an alias derived from its host
         login._choose_server("https://newhost.example/x")
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert calls.get("add") == (
             "newhost.example",
             "https://newhost.example/x",
@@ -3956,13 +3995,13 @@ async def test_login_server_picker(monkeypatch):
         srv_input = login.query_one("#server_input", Input)
         srv_input.value = "/var/run/other.sock"
         login.on_input_submitted(Input.Submitted(srv_input, srv_input.value))
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert calls.get("add") == ("other.sock", "/var/run/other.sock")
 
         # "Use server" button also dispatches
         srv_input.value = "prod"
         login.on_button_pressed(FakeBtnPress("use_server"))
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert calls.get("switch") == "https://prod.example"
 
         # after a successful pick the server line + enabled creds reflect it
@@ -4015,10 +4054,10 @@ async def test_login_choose_invalid_server(monkeypatch):
         ),
     )
     app = KlangkApp(st)
-    async with app.run_test() as pilot:
+    async with app.run_test() as _pilot:
         login = app.screen
         login._choose_server("sdfsdf")
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         # not persisted, and a sensible message is shown
         assert added.get("a") is None
         assert "URL" in str(login.query_one("#message").render())
@@ -4043,7 +4082,7 @@ async def test_add_server_rejects_invalid_url(monkeypatch):
         s.query_one("#alias", Input).value = "x"
         s.query_one("#url", Input).value = "sdfsdf"
         s._add()
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert added.get("a") is None
         assert "http" in str(s.query_one("#add_msg").render()).lower()
 
@@ -4126,6 +4165,7 @@ async def test_login_delete_server(monkeypatch):
         await pilot.pause()
         app.screen.dismiss(True)
         await pilot.pause()
+        await app.workers.wait_for_complete()
         assert deleted.get("u") == "https://prod.example"
         assert "Server deleted" in str(login.query_one("#message").render())
         # confirm but delete returns False -> "Not a saved alias"
@@ -4135,6 +4175,7 @@ async def test_login_delete_server(monkeypatch):
         await pilot.pause()
         app.screen.dismiss(True)
         await pilot.pause()
+        await app.workers.wait_for_complete()
         assert "Not a saved alias" in str(login.query_one("#message").render())
 
 
@@ -4171,6 +4212,7 @@ async def test_login_delete_clears_to_no_server(monkeypatch):
         await pilot.pause()
         app.screen.dismiss(True)
         await pilot.pause()
+        await app.workers.wait_for_complete()
         assert "No server selected" in str(
             login.query_one("#server_line").render()
         )
@@ -4389,6 +4431,7 @@ async def test_switch_screen_delete_server(monkeypatch):
         await pilot.pause()
         app.screen.dismiss(True)
         await pilot.pause()
+        await app.workers.wait_for_complete()
         await pilot.pause()
         assert deleted.get("u") == "https://prod.example"
 
@@ -4426,6 +4469,7 @@ async def test_login_button_dispatch_and_oidc_incomplete(monkeypatch):
         login.query_one("#identifier", Input).value = "me@x"
         login.query_one("#password", Input).value = "pw"
         login.on_button_pressed(FakeBtnPress("login"))
+        await app.workers.wait_for_complete()
         await pilot.pause()
         assert isinstance(app.screen, MainScreen)
 
@@ -4442,7 +4486,7 @@ async def test_login_button_dispatch_and_oidc_incomplete(monkeypatch):
     app2 = KlangkApp(st2)
     async with app2.run_test() as pilot:
         app2.screen.on_button_pressed(FakeBtnPress("oidc"))
-        await pilot.pause()
+        await app2.workers.wait_for_complete()
         assert "did not complete" in str(
             app2.screen.query_one("#message").render()
         )
@@ -4495,7 +4539,7 @@ async def test_add_server_event_handlers(monkeypatch):
         url_in.value = "https://p.example"
         # button press dispatch
         add_screen.on_button_pressed(FakeBtnPress("add"))
-        await pilot.pause()
+        await app.workers.wait_for_complete()
         assert added["a"] == ("prod", "https://p.example")
         assert isinstance(app.screen, MainScreen)
 
@@ -4514,7 +4558,7 @@ async def test_add_server_event_handlers(monkeypatch):
         url_in.value = "https://q.example"
         add_screen.query_one("#alias", Input).value = "qa"
         add_screen.on_input_submitted(Input.Submitted(url_in, url_in.value))
-        await pilot.pause()
+        await app2.workers.wait_for_complete()
         assert added2["a"] == ("qa", "https://q.example")
 
 

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -1148,9 +1148,15 @@ async def test_edit_server_url_change_triggers_server_changed(monkeypatch):
     async with app.run_test() as pilot:
         app.push_screen(ServerSwitchScreen())
         await pilot.pause()
-        app.push_screen(EditServerScreen(alias="a", url="https://a.example"))
-        await pilot.pause()
+        # Use the callback-wired push path (action_edit_server flow).
         app.server_changed = lambda: changed.append(True)
+        app.push_screen(
+            EditServerScreen(alias="a", url="https://a.example"),
+            lambda result: (
+                app.server_changed() if result == "url_changed" else None
+            ),
+        )
+        await pilot.pause()
         app.screen.query_one("#url", Input).value = "https://new.example"
         app.screen._save()
         await pilot.pause()

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -66,6 +66,12 @@ def redirect_xdg(monkeypatch, tmp_path):
     spath = tmp_path / "klangk-state.yaml"
     monkeypatch.setattr(cfgmod, "_CONFIG_PATH", cpath)
     monkeypatch.setattr(cfgmod, "_STATE_PATH", spath)
+    # Prevent the local klangkd UDS socket from being detected.
+    monkeypatch.setattr(
+        tui_state_mod,
+        "default_server_uds_path",
+        lambda: str(tmp_path / "nonexistent.sock"),
+    )
     return cpath, spath
 
 
@@ -1151,15 +1157,14 @@ async def test_edit_server_url_change_triggers_server_changed(monkeypatch):
     async with app.run_test() as pilot:
         app.push_screen(ServerSwitchScreen())
         await pilot.pause()
-        # Use the callback-wired push path (action_edit_server flow).
         app.server_changed = lambda: changed.append(True)
-        app.push_screen(
-            EditServerScreen(alias="a", url="https://a.example"),
-            lambda result: (
-                app.server_changed() if result == "url_changed" else None
-            ),
-        )
+        # Go through action_edit_server so the real _on_edit callback is wired.
+        lv = app.screen.query_one("#server_options", ListView)
+        lv.index = 0
         await pilot.pause()
+        app.screen.action_edit_server()
+        await pilot.pause()
+        assert isinstance(app.screen, EditServerScreen)
         app.screen.query_one("#url", Input).value = "https://new.example"
         app.screen._save()
         await app.workers.wait_for_complete()

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -4389,6 +4389,7 @@ async def test_switch_screen_delete_server(monkeypatch):
         await pilot.pause()
         app.screen.dismiss(True)
         await pilot.pause()
+        await pilot.pause()
         assert deleted.get("u") == "https://prod.example"
 
 

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -30,6 +30,7 @@ from klangk.cli.tui import state as tui_state_mod
 from klangk.cli.tui import ws as ws_mod
 from klangk.cli.tui.app import KlangkApp, run_tui
 from klangk.cli.config import (
+    AliasConflictError,
     CLIConfig,
     CLIState,
     ServerEntry,
@@ -206,6 +207,25 @@ def test_update_server_not_found(redirect_xdg):
     assert (
         update_server_in_config("missing", "m", "https://m.example") is False
     )
+
+
+def test_update_server_alias_collision(redirect_xdg):
+    add_server_to_config("a", "https://a.example")
+    add_server_to_config("b", "https://b.example")
+    with pytest.raises(AliasConflictError):
+        update_server_in_config("a", "b", "https://a.example")
+    # Both entries untouched.
+    loaded = CLIConfig.load()
+    assert loaded.servers["a"].url == "https://a.example"
+    assert loaded.servers["b"].url == "https://b.example"
+
+
+def test_update_server_preserves_fields(redirect_xdg):
+    add_server_to_config("a", "https://a.example", user="me@x")
+    assert update_server_in_config("a", "a", "https://a2.example") is True
+    loaded = CLIConfig.load()
+    assert loaded.servers["a"].url == "https://a2.example"
+    assert loaded.servers["a"].user == "me@x"
 
 
 def test_update_server_no_config_file(monkeypatch, tmp_path):
@@ -459,13 +479,14 @@ def test_update_server(redirect_xdg):
     assert loaded.servers["a"].url == "https://a2.example"
     assert TuiState().state().active_server == "https://a2.example"
 
-    # rename alias -> old gone, new present
+    # rename alias -> old gone, new present, active pointer preserved
     assert (
         TuiState().update_server("a", "renamed", "https://a2.example") is True
     )
     loaded = CLIConfig.load()
     assert "a" not in loaded.servers
     assert loaded.servers["renamed"].url == "https://a2.example"
+    assert TuiState().state().active_server == "https://a2.example"
 
     # not found
     assert (
@@ -980,12 +1001,16 @@ async def test_edit_server_saves(monkeypatch):
         await pilot.pause()
         assert isinstance(app.screen, EditServerScreen)
         app.screen.query_one("#alias", Input).value = "production"
-        app.screen.query_one("#url", Input).value = "https://new.example"
+        # Keep URL unchanged — no server_changed() call.
         app.screen._save()
         await pilot.pause()
         await pilot.pause()
-        assert updated["u"] == ("prod", "production", "https://new.example")
-        # Dismissed back to ServerSwitchScreen.
+        assert updated["u"] == (
+            "prod",
+            "production",
+            "https://prod.example",
+        )
+        # Dismissed back to ServerSwitchScreen (URL unchanged).
         assert isinstance(app.screen, ServerSwitchScreen)
 
 
@@ -1064,6 +1089,63 @@ async def test_edit_server_not_found(monkeypatch):
             "not found"
             in str(app.screen.query_one("#edit_srv_msg").render()).lower()
         )
+
+
+async def test_edit_server_alias_conflict(monkeypatch):
+    """Renaming to an existing alias shows an error."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    st = _authed_state()
+
+    def conflict(*a, **k):
+        from klangk.cli.config import AliasConflictError
+
+        raise AliasConflictError("Alias 'b' already exists.")
+
+    st.update_server = conflict
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(EditServerScreen(alias="a", url="https://a.example"))
+        await pilot.pause()
+        app.screen.query_one("#alias", Input).value = "b"
+        app.screen._save()
+        await pilot.pause()
+        await pilot.pause()
+        assert (
+            "already exists"
+            in str(app.screen.query_one("#edit_srv_msg").render()).lower()
+        )
+
+
+async def test_edit_server_url_change_triggers_server_changed(monkeypatch):
+    """Changing the URL of a server calls server_changed()."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    st = _authed_state(
+        known_servers=lambda: [
+            tui_state_mod.ServerInfo("a", "https://a.example"),
+        ],
+    )
+    st.update_server = lambda *a, **k: True
+    changed = []
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(ServerSwitchScreen())
+        await pilot.pause()
+        app.push_screen(EditServerScreen(alias="a", url="https://a.example"))
+        await pilot.pause()
+        app.server_changed = lambda: changed.append(True)
+        app.screen.query_one("#url", Input).value = "https://new.example"
+        app.screen._save()
+        await pilot.pause()
+        await pilot.pause()
+        assert changed == [True]
 
 
 async def test_edit_server_no_highlight(monkeypatch):

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -35,12 +35,14 @@ from klangk.cli.config import (
     ServerEntry,
     add_server_to_config,
     remove_server_from_config,
+    update_server_in_config,
 )
 from klangk.cli.tui.screens import (
     AddServerScreen,
     ConfirmScreen,
     CreateWorkspaceScreen,
     DuplicateScreen,
+    EditServerScreen,
     EditWorkspaceScreen,
     LoginScreen,
     MainScreen,
@@ -182,6 +184,33 @@ def test_remove_server_from_config(redirect_xdg):
     assert set(CLIConfig.load().servers) == {"b"}
     # removing an absent alias is a no-op (False)
     assert remove_server_from_config("zzz") is False
+
+
+def test_update_server_in_config(redirect_xdg):
+    add_server_to_config("a", "https://a.example")
+    assert update_server_in_config("a", "a", "https://a2.example") is True
+    loaded = CLIConfig.load()
+    assert loaded.servers["a"].url == "https://a2.example"
+
+
+def test_update_server_rename(redirect_xdg):
+    add_server_to_config("old", "https://old.example")
+    assert update_server_in_config("old", "new", "https://new.example") is True
+    loaded = CLIConfig.load()
+    assert "old" not in loaded.servers
+    assert loaded.servers["new"].url == "https://new.example"
+
+
+def test_update_server_not_found(redirect_xdg):
+    add_server_to_config("a", "https://a.example")
+    assert (
+        update_server_in_config("missing", "m", "https://m.example") is False
+    )
+
+
+def test_update_server_no_config_file(monkeypatch, tmp_path):
+    monkeypatch.setattr(cfgmod, "_CONFIG_PATH", tmp_path / "nope.yaml")
+    assert update_server_in_config("a", "a", "https://x.example") is False
 
 
 def test_remove_server_no_config_file(monkeypatch, tmp_path):
@@ -417,6 +446,31 @@ def test_delete_server(redirect_xdg):
 
     # not found
     assert TuiState().delete_server("https://nope.example") is False
+
+
+def test_update_server(redirect_xdg):
+    add_server_to_config("a", "https://a.example")
+    TuiState().switch_server("https://a.example")  # make 'a' active
+    assert TuiState().state().active_server == "https://a.example"
+
+    # update URL -> alias stays, active pointer updated
+    assert TuiState().update_server("a", "a", "https://a2.example") is True
+    loaded = CLIConfig.load()
+    assert loaded.servers["a"].url == "https://a2.example"
+    assert TuiState().state().active_server == "https://a2.example"
+
+    # rename alias -> old gone, new present
+    assert (
+        TuiState().update_server("a", "renamed", "https://a2.example") is True
+    )
+    loaded = CLIConfig.load()
+    assert "a" not in loaded.servers
+    assert loaded.servers["renamed"].url == "https://a2.example"
+
+    # not found
+    assert (
+        TuiState().update_server("missing", "m", "https://m.example") is False
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -894,6 +948,235 @@ async def test_server_switch_and_add(monkeypatch):
         await pilot.pause()
         await pilot.pause()
         assert added5["a"] == ("staging", "https://s.example")
+
+
+# --- edit server (#1762) ---
+
+
+async def test_edit_server_saves(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    st = _authed_state(
+        known_servers=lambda: [
+            tui_state_mod.ServerInfo("prod", "https://prod.example"),
+        ],
+        current_url=lambda: "https://prod.example",
+    )
+    updated = {}
+    st.update_server = lambda old, new, url, user=None: (
+        updated.__setitem__("u", (old, new, url)) or True
+    )
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(ServerSwitchScreen())
+        await pilot.pause()
+        # Highlight the first server and edit it.
+        lv = app.screen.query_one("#server_options", ListView)
+        lv.index = 0
+        await pilot.pause()
+        app.screen.action_edit_server()
+        await pilot.pause()
+        assert isinstance(app.screen, EditServerScreen)
+        app.screen.query_one("#alias", Input).value = "production"
+        app.screen.query_one("#url", Input).value = "https://new.example"
+        app.screen._save()
+        await pilot.pause()
+        await pilot.pause()
+        assert updated["u"] == ("prod", "production", "https://new.example")
+        # Dismissed back to ServerSwitchScreen.
+        assert isinstance(app.screen, ServerSwitchScreen)
+
+
+async def test_edit_server_empty_fields(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    app = KlangkApp(_authed_state())
+    async with app.run_test() as pilot:
+        app.push_screen(EditServerScreen(alias="a", url="https://a.example"))
+        await pilot.pause()
+        app.screen.query_one("#alias", Input).value = ""
+        app.screen._save()
+        await pilot.pause()
+        assert "required" in str(
+            app.screen.query_one("#edit_srv_msg").render()
+        )
+
+
+async def test_edit_server_invalid_url(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    app = KlangkApp(_authed_state())
+    async with app.run_test() as pilot:
+        app.push_screen(EditServerScreen(alias="a", url="https://a.example"))
+        await pilot.pause()
+        app.screen.query_one("#url", Input).value = "not-a-url"
+        app.screen._save()
+        await pilot.pause()
+        assert "http(s)://" in str(
+            app.screen.query_one("#edit_srv_msg").render()
+        )
+
+
+async def test_edit_server_cancel(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    st = _authed_state(
+        known_servers=lambda: [
+            tui_state_mod.ServerInfo("a", "https://a.example"),
+        ],
+    )
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(ServerSwitchScreen())
+        await pilot.pause()
+        app.push_screen(EditServerScreen(alias="a", url="https://a.example"))
+        await pilot.pause()
+        app.screen.action_cancel()
+        await pilot.pause()
+        assert isinstance(app.screen, ServerSwitchScreen)
+
+
+async def test_edit_server_not_found(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    st = _authed_state()
+    st.update_server = lambda *a, **k: False
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(
+            EditServerScreen(alias="gone", url="https://g.example")
+        )
+        await pilot.pause()
+        app.screen._save()
+        await pilot.pause()
+        await pilot.pause()
+        assert (
+            "not found"
+            in str(app.screen.query_one("#edit_srv_msg").render()).lower()
+        )
+
+
+async def test_edit_server_no_highlight(monkeypatch):
+    """action_edit_server is a no-op when no server is highlighted."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    app = KlangkApp(_authed_state(known_servers=lambda: []))
+    async with app.run_test() as pilot:
+        app.push_screen(ServerSwitchScreen())
+        await pilot.pause()
+        app.screen.action_edit_server()
+        await pilot.pause()
+        # Still on switch screen — no crash, no edit screen.
+        assert isinstance(app.screen, ServerSwitchScreen)
+
+
+async def test_edit_server_via_input_submit(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    st = _authed_state()
+    updated = {}
+    st.update_server = lambda old, new, url, user=None: (
+        updated.__setitem__("u", (old, new, url)) or True
+    )
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(EditServerScreen(alias="a", url="https://a.example"))
+        await pilot.pause()
+        url_input = app.screen.query_one("#url", Input)
+        url_input.value = "https://new.example"
+        app.screen.on_input_submitted(
+            Input.Submitted(url_input, url_input.value)
+        )
+        await pilot.pause()
+        await pilot.pause()
+        assert updated["u"] == ("a", "a", "https://new.example")
+
+
+async def test_edit_server_cancel_button(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    st = _authed_state(
+        known_servers=lambda: [
+            tui_state_mod.ServerInfo("a", "https://a.example"),
+        ],
+    )
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(ServerSwitchScreen())
+        await pilot.pause()
+        app.push_screen(EditServerScreen(alias="a", url="https://a.example"))
+        await pilot.pause()
+        cancel_btn = app.screen.query_one("#cancel", Button)
+        app.screen.on_button_pressed(Button.Pressed(cancel_btn))
+        await pilot.pause()
+        assert isinstance(app.screen, ServerSwitchScreen)
+
+
+async def test_edit_server_no_alias_on_item(monkeypatch):
+    """action_edit_server is a no-op when the item has no server_alias."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    st = _authed_state(
+        known_servers=lambda: [
+            tui_state_mod.ServerInfo("a", "https://a.example"),
+        ],
+    )
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(ServerSwitchScreen())
+        await pilot.pause()
+        lv = app.screen.query_one("#server_options", ListView)
+        lv.index = 0
+        await pilot.pause()
+        # Remove the server_alias attribute to hit the early return.
+        child = lv.highlighted_child
+        if hasattr(child, "server_alias"):
+            del child.server_alias
+        app.screen.action_edit_server()
+        await pilot.pause()
+        assert isinstance(app.screen, ServerSwitchScreen)
+
+
+async def test_edit_server_via_button(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    st = _authed_state()
+    updated = {}
+    st.update_server = lambda old, new, url, user=None: (
+        updated.__setitem__("u", (old, new, url)) or True
+    )
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(EditServerScreen(alias="a", url="https://a.example"))
+        await pilot.pause()
+        s = app.screen
+        save_btn = s.query_one("#save", Button)
+        s.on_button_pressed(Button.Pressed(save_btn))
+        await pilot.pause()
+        await pilot.pause()
+        assert "u" in updated
 
 
 # --- workspace list / detail / actions (#1747) ---

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -249,6 +249,18 @@ def test_update_server_no_config_file(monkeypatch, tmp_path):
     assert update_server_in_config("a", "a", "https://x.example") is False
 
 
+def test_update_server_bare_string_entry(redirect_xdg):
+    """A hand-edited YAML with a bare-string entry is promoted to a dict."""
+    cpath, _ = redirect_xdg
+    cpath.write_text("servers:\n  legacy: https://old.example\n")
+    assert (
+        update_server_in_config("legacy", "legacy", "https://new.example")
+        is True
+    )
+    loaded = CLIConfig.load()
+    assert loaded.servers["legacy"].url == "https://new.example"
+
+
 def test_remove_server_no_config_file(monkeypatch, tmp_path):
     monkeypatch.setattr(cfgmod, "_CONFIG_PATH", tmp_path / "nope.yaml")
     assert remove_server_from_config("a") is False


### PR DESCRIPTION
## Summary

- `update_server_in_config(old_alias, new_alias, url, user)` in `config.py` — rename alias and/or change URL in one atomic write
- `TuiState.update_server()` — delegates to config, updates active pointer if the edited server was active
- `EditServerScreen` modal — pre-populated alias/URL fields with validation (same rules as `AddServerScreen`)
- `"e"` binding on `ServerSwitchScreen` opens edit for the highlighted server
- 15 new tests; 100% `screens.py` coverage (178 total TUI tests)

Closes #1762

## Test plan

- [ ] `devenv shell -- test-backend` passes
- [ ] On server switch screen, `e` opens edit modal for highlighted server
- [ ] Editing alias renames the entry; editing URL updates active pointer if active
- [ ] Empty fields / invalid URLs show validation errors
- [ ] Cancel (Escape or Cancel button) dismisses without changes
- [ ] Editing a server that was deleted concurrently shows "not found" error