### PR TITLE
TUI: shell hand-off on terminal select

### DIFF
--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import asyncio
 import datetime
+import subprocess
+import sys
 from urllib.parse import urlparse
 
 import logging
@@ -1040,6 +1042,19 @@ class WorkspaceDetailScreen(Screen):
             idx = w.get("index", "")
             name = w.get("name") or idx
             lv.append(ListItem(Label(Text(f"{idx}  {name}")), name=str(idx)))
+
+    def on_list_view_selected(self, event: ListView.Selected) -> None:
+        """Suspend the TUI and spawn ``klangk shell`` for the selected terminal."""
+        terminal = getattr(event.item, "name", "") or ""
+        if not terminal or self._ws is None:
+            return
+        cmd = [sys.executable, "-m", "klangk.cli.main"]
+        server = self.app.tui_state.current_url()
+        if server:
+            cmd += ["--server", server]
+        cmd += ["shell", self._name, terminal]
+        with self.app.suspend():
+            subprocess.run(cmd)
 
     def action_delete_terminal(self) -> None:
         lv = self.query_one("#term_list", ListView)

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -2058,6 +2058,67 @@ async def test_detail_delete_terminal_failure(monkeypatch):
         assert "Delete failed" in str(d.query_one("#detail_msg").render())
 
 
+async def test_detail_terminal_select_spawns_shell(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    a = _wsobj("alpha", running=True)
+    st = _ws(list_terminals=_async_terms)
+    st.find_workspace = lambda n: a
+    st.current_url = lambda: "https://x.example"
+    spawned = []
+    monkeypatch.setattr(
+        scr.subprocess, "run", lambda cmd, **k: spawned.append(cmd)
+    )
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def fake_suspend():
+        yield
+
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.screen._load_terminals()
+        await pilot.pause()
+        monkeypatch.setattr(app, "suspend", fake_suspend)
+        app.screen.on_list_view_selected(FakeSelected("0"))
+        assert len(spawned) == 1
+        assert spawned[0] == [
+            scr.sys.executable,
+            "-m",
+            "klangk.cli.main",
+            "--server",
+            "https://x.example",
+            "shell",
+            "alpha",
+            "0",
+        ]
+
+
+async def test_detail_terminal_select_empty_name_ignored(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    a = _wsobj("alpha", running=True)
+    st = _ws(list_terminals=_async_terms)
+    st.find_workspace = lambda n: a
+    spawned = []
+    monkeypatch.setattr(
+        scr.subprocess, "run", lambda cmd, **k: spawned.append(cmd)
+    )
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        app.screen.on_list_view_selected(FakeSelected(""))
+        assert spawned == []
+
+
 async def test_main_screen_title(monkeypatch):
     async def noop(*a, **k):
         return None


### PR DESCRIPTION
## Summary
- Selecting a terminal from the workspace detail screen suspends the TUI and spawns `klangk shell` in the same terminal
- Uses `sys.executable -m klangk.cli.main` to ensure the same Python/package is used
- Passes `--server` to target the same server the TUI is connected to
- TUI resumes in place when the shell session exits

Fixes #1755

## Test plan
- [x] All 165 TUI tests pass (2 new: spawn verification + empty-name guard)