### PR TITLE
Fix port conflict retry on container restart

### DIFF
--- a/src/klangk/klangk/container.py
+++ b/src/klangk/klangk/container.py
@@ -1375,12 +1375,26 @@ class ContainerRegistry:
         try:
             await self.app.state.podman.start_container(cid)
         except podman.PodmanError as exc:
-            if "port is already allocated" not in exc.message:
+            if not self._is_port_conflict(exc):
                 raise
             await self._resolve_port_conflict(
                 cid, container_name, publish, self.app.state.podman
             )
-            await self.app.state.podman.start_container(cid)
+            # Retry with back-off; ports may linger in TIME_WAIT after
+            # the previous container's pasta process exits.
+            last_exc = exc
+            for delay in (0.5, 1.5):
+                await asyncio.sleep(delay)
+                try:
+                    await self.app.state.podman.start_container(cid)
+                    last_exc = None
+                    break
+                except podman.PodmanError as retry_exc:
+                    if not self._is_port_conflict(retry_exc):
+                        raise
+                    last_exc = retry_exc
+            if last_exc is not None:
+                raise last_exc
         logger.info(
             "workspace-open: boot container (podman start): %.3fs",
             time.monotonic() - t_podman_start,
@@ -1414,6 +1428,14 @@ class ContainerRegistry:
         await self.app.state.podman.wait_for_container_ready(cid)
 
         return cid
+
+    @staticmethod
+    def _is_port_conflict(exc: podman.PodmanError) -> bool:
+        """True if the error indicates a port bind / allocation conflict."""
+        if exc.status == 409:
+            return True
+        low = exc.message.lower()
+        return "port" in low and "already" in low
 
     async def _resolve_port_conflict(
         self,

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -1456,6 +1456,97 @@ class TestStartContainerPortConflict:
                 workspace["id"], "/tmp/ws", "/tmp/home"
             )
 
+    async def test_port_conflict_pasta_bind_error(self, workspace, app_state):
+        """Pasta-style 'Address already in use' errors trigger retry (#1810)."""
+        allocated = await app_state.state.model.ports.find_and_allocate_ports(
+            workspace["id"], 5, self.registry.port_range_start
+        )
+        conflict_port = allocated[0]
+
+        start_calls = []
+
+        async def start_side_effect(cid):
+            start_calls.append(cid)
+            if len(start_calls) == 1:
+                raise podman.PodmanError(
+                    409,
+                    f"Failed to bind port {conflict_port} "
+                    "(Address already in use)",
+                )
+
+        with patch_podman(
+            self.registry,
+            start_container=AsyncMock(side_effect=start_side_effect),
+            list_containers=AsyncMock(return_value=[]),
+            inspect_container=AsyncMock(return_value=None),
+        ):
+            cid, status = await self.registry.start_container(
+                workspace["id"], "/tmp/ws", "/tmp/home"
+            )
+        assert status == "created"
+        assert len(start_calls) == 2
+
+    async def test_port_conflict_retries_exhausted(self, workspace, app_state):
+        """All retries exhausted re-raises the last PodmanError."""
+        allocated = await app_state.state.model.ports.find_and_allocate_ports(
+            workspace["id"], 5, self.registry.port_range_start
+        )
+        conflict_port = allocated[0]
+
+        async def always_fail(cid):
+            raise podman.PodmanError(
+                409,
+                f"Failed to bind port {conflict_port} "
+                "(Address already in use)",
+            )
+
+        with (
+            patch_podman(
+                self.registry,
+                start_container=AsyncMock(side_effect=always_fail),
+                list_containers=AsyncMock(return_value=[]),
+                inspect_container=AsyncMock(return_value=None),
+            ),
+            pytest.raises(podman.PodmanError, match="Address already in use"),
+        ):
+            await self.registry.start_container(
+                workspace["id"], "/tmp/ws", "/tmp/home"
+            )
+
+    async def test_port_conflict_retry_non_conflict_error(
+        self, workspace, app_state
+    ):
+        """Non-port-conflict error during retry is raised immediately."""
+        allocated = await app_state.state.model.ports.find_and_allocate_ports(
+            workspace["id"], 5, self.registry.port_range_start
+        )
+        conflict_port = allocated[0]
+
+        start_calls = []
+
+        async def start_side_effect(cid):
+            start_calls.append(cid)
+            if len(start_calls) == 1:
+                raise podman.PodmanError(
+                    409,
+                    f"Failed to bind port {conflict_port} "
+                    "(Address already in use)",
+                )
+            raise podman.PodmanError(500, "container vanished")
+
+        with (
+            patch_podman(
+                self.registry,
+                start_container=AsyncMock(side_effect=start_side_effect),
+                list_containers=AsyncMock(return_value=[]),
+                inspect_container=AsyncMock(return_value=None),
+            ),
+            pytest.raises(podman.PodmanError, match="container vanished"),
+        ):
+            await self.registry.start_container(
+                workspace["id"], "/tmp/ws", "/tmp/home"
+            )
+
 
 class TestValidateMountSpec:
     def setup_method(self):


### PR DESCRIPTION
## Summary

- Broaden port-conflict detection: the previous check only matched `"port is already allocated"` (podman's internal tracker). Pasta/slirp4netns bind failures produce `"Address already in use"` with status 409, which was not caught — causing unrecoverable crashes on workspace reopen.
- New `_is_port_conflict()` helper checks both status 409 and the `"port...already"` pattern in error messages.
- Retry with back-off (0.5s, 1.5s) after stale container cleanup, giving OS TIME_WAIT sockets time to release.
- If all retries fail, the last `PodmanError` is re-raised (not swallowed).
- 3 new tests: pasta-style bind error, retries exhausted, non-conflict error during retry.

Closes #1810

## Test plan

- [ ] `devenv shell -- test-backend` passes
- [ ] Reopen a stopped workspace — container starts without port conflict
- [ ] All 10 port-conflict tests pass