### PR TITLE
Fix: auth re-entry debug logging + persistence tests (#1813)

### DIFF
--- a/src/klangk/klangk/cli/tui/state.py
+++ b/src/klangk/klangk/cli/tui/state.py
@@ -10,6 +10,7 @@ deps, and sibling ``cli`` modules.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -30,6 +31,8 @@ from ..config import (
     remove_server_from_config,
 )
 from ..transport import http_request
+
+logger = logging.getLogger(__name__)
 
 
 class LoginError(Exception):
@@ -102,7 +105,15 @@ class TuiState:
         return self.state().get_email(url)
 
     def is_authenticated(self) -> bool:
-        return self.token() is not None
+        url = self.current_url()
+        tok = self.token()
+        if tok is None:
+            logger.debug(
+                "is_authenticated=False: url=%s, token=%s",
+                url,
+                "present" if tok else "None",
+            )
+        return tok is not None
 
     def client(self) -> KlangkClient:
         return KlangkClient(self.current_url(), self.token())

--- a/src/klangk/klangkc-tests/e2e-tests/test_tui_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_tui_e2e.py
@@ -189,6 +189,39 @@ class TestTuiE2E:
             msg = str(app.screen.query_one("#message").render())
             assert "required" in msg.lower()
 
+    async def test_reentry_preserves_auth(
+        self, base_url, token, tmp_path, monkeypatch
+    ):
+        """Quitting and re-launching skips the login screen (#1813)."""
+        config_path = tmp_path / "klangk.yaml"
+        state_path = tmp_path / "state.yaml"
+        monkeypatch.setattr("klangk.cli.config._CONFIG_PATH", config_path)
+        monkeypatch.setattr("klangk.cli.config._STATE_PATH", state_path)
+
+        # First launch: seed credentials (simulates a prior login session).
+        add_server_to_config("e2e", base_url)
+        st = CLIState.load()
+        st.set_credentials(base_url, "tuiuser@example.com", token)
+        st.save()
+
+        # First TUI instance: should go straight to MainScreen.
+        state1 = TuiState()
+        app1 = KlangkApp(state1)
+        async with app1.run_test() as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            assert isinstance(app1.screen, MainScreen)
+
+        # Second TUI instance (simulates re-entry): new TuiState reads
+        # persisted state — should also skip login.
+        state2 = TuiState()
+        assert state2.is_authenticated()
+        app2 = KlangkApp(state2)
+        async with app2.run_test() as pilot:
+            await pilot.pause()
+            await pilot.pause()
+            assert isinstance(app2.screen, MainScreen)
+
     # -- workspace list --
 
     async def test_authenticated_shows_workspace_list(self, tui_state):

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -210,6 +210,26 @@ def test_current_url_none_when_unconfigured(redirect_xdg):
     assert t.is_authenticated() is False
 
 
+def test_reentry_auth_persists(redirect_xdg):
+    """Credentials survive TuiState re-creation (#1813)."""
+    add_server_to_config("srv", "https://srv.example")
+    st = CLIState()
+    st.set_credentials("https://srv.example", "me@x", "tok123")
+    st.save()
+
+    # First TuiState instance — authenticated.
+    t1 = TuiState()
+    assert t1.is_authenticated()
+    assert t1.current_url() == "https://srv.example"
+    assert t1.token() == "tok123"
+
+    # New TuiState reads persisted state — should also be authenticated.
+    t2 = TuiState()
+    assert t2.is_authenticated()
+    assert t2.current_url() == "https://srv.example"
+    assert t2.token() == "tok123"
+
+
 def test_known_servers_roundtrip(redirect_xdg):
     add_server_to_config("alpha", "https://a.example")
     add_server_to_config("beta", "https://b.example")


### PR DESCRIPTION
## Summary

Investigated #1813 (login screen shown on re-entry). The auth persistence chain works correctly — `set_credentials()` → `save()` → `CLIState.load()` → `get_token()` round-trips properly. Verified against a real klangkd instance.

The reported issue was caused by an empty state file (`{}`), meaning credentials were never stored in the first place — not lost between sessions. This can happen when:
- The user quits the TUI before login completes
- The CLI `klangk login` was used with a different URL than what the TUI resolves

**Changes:**
- Debug logging in `is_authenticated()` when token is None — logs `url` and `token` status to help diagnose future occurrences
- Unit test `test_reentry_auth_persists` — verifies TuiState re-creation finds persisted credentials
- E2E test `test_reentry_preserves_auth` — two sequential KlangkApp instances against a real server

Closes #1813

## Test plan

- [ ] `devenv shell -- test-backend` passes
- [ ] `devenv shell -- test-cli-e2e -k test_reentry_preserves_auth` passes