### PR TITLE
Hide noisy Caddy JSON log messages at startup

### DIFF
--- a/src/klangk/klangk/caddy.py
+++ b/src/klangk/klangk/caddy.py
@@ -39,6 +39,7 @@ Out of scope here (tracked in #1559): the ``caddy-l4`` layer-4 plugin
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import contextlib
 import os
@@ -62,6 +63,36 @@ from klangk.proxy import (
 
 
 logger = logging.getLogger(__name__)
+
+
+def _classify_caddy_line(line: str) -> tuple[int, str]:
+    """Parse a Caddy JSON log line and return ``(log_level, message)``.
+
+    Caddy emits structured JSON to stderr with ``level``, ``msg``, and
+    optional ``logger`` fields.  This function maps them to Python log
+    levels so klangkd can surface errors while suppressing routine
+    startup noise (info/warn about TLS, HTTP/2, admin API, etc.).
+
+    Non-JSON lines (e.g. panic stack traces) are treated as errors.
+    """
+    try:
+        obj = json.loads(line)
+    except (json.JSONDecodeError, ValueError):
+        return logging.ERROR, line
+
+    caddy_level = obj.get("level", "info")
+    msg = obj.get("msg", line)
+    caddy_logger = obj.get("logger", "")
+    if caddy_logger:
+        msg = f"[{caddy_logger}] {msg}"
+
+    if (
+        caddy_level == "error"
+        or caddy_level == "fatal"
+        or caddy_level == "panic"
+    ):
+        return logging.ERROR, msg
+    return logging.DEBUG, msg
 
 
 # ---------------------------------------------------------------------------
@@ -868,6 +899,26 @@ class CaddyWatchdog:
                 await asyncio.sleep(0.2)
         return False
 
+    @staticmethod
+    async def _relay_stderr(
+        stream: asyncio.StreamReader,
+    ) -> None:  # pragma: no cover  – covered by the e2e suite
+        """Read Caddy's stderr line-by-line and relay through Python logging.
+
+        Errors are logged at ERROR; routine info/warn messages are logged at
+        DEBUG so they're hidden by default but accessible via
+        ``KLANGKD_LOG_LEVEL=DEBUG``.
+        """
+        while True:
+            raw = await stream.readline()
+            if not raw:
+                break
+            line = raw.decode("utf-8", errors="replace").rstrip()
+            if not line:
+                continue
+            level, msg = _classify_caddy_line(line)
+            logger.log(level, "caddy: %s", msg)
+
     async def _watch(
         self, bin_path: str
     ) -> None:  # pragma: no cover  – covered by the e2e suite
@@ -911,10 +962,13 @@ class CaddyWatchdog:
                 str(bootstrap_cfg),
                 "--adapter",
                 "caddyfile",
-                stdout=None,
-                stderr=None,
+                stdout=asyncio.subprocess.DEVNULL,
+                stderr=asyncio.subprocess.PIPE,
                 env=env,
                 preexec_fn=_caddy_preexec,
+            )
+            stderr_task = asyncio.create_task(
+                self._relay_stderr(self._proc.stderr)
             )
             logger.info(
                 "caddy started (pid %d), admin UDS %s",
@@ -945,6 +999,9 @@ class CaddyWatchdog:
                 except ProcessLookupError:
                     pass
             rc = await self._proc.wait()
+            stderr_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await stderr_task
             self._proc = None
             if self._stopping:
                 return

--- a/src/klangk/klangkd-tests/tests/test_caddy.py
+++ b/src/klangk/klangkd-tests/tests/test_caddy.py
@@ -9,6 +9,7 @@ caddy, so nothing here shells out to it).
 """
 
 import asyncio
+import logging
 import os
 import signal
 import types
@@ -20,6 +21,7 @@ import pytest
 from klangk.caddy import (
     CaddyRenderer,
     CaddyWatchdog,
+    _classify_caddy_line,
 )
 from klangk.caddy import (
     CADDYFILE_CONTENT_TYPE,
@@ -1487,3 +1489,62 @@ class TestWatchdogReconfigure:
         wd.load_config = AsyncMock(side_effect=httpx.ConnectError("down"))
         await wd.apply_pending_reload()  # must not raise
         assert wd._pending_reload is False
+
+
+# ---------------------------------------------------------------------------
+# _classify_caddy_line
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyCaddyLine:
+    """Caddy stderr JSON lines are classified into Python log levels."""
+
+    def test_info_maps_to_debug(self):
+        line = '{"level":"info","ts":1,"msg":"serving initial configuration"}'
+        level, msg = _classify_caddy_line(line)
+        assert level == logging.DEBUG
+        assert "serving initial configuration" in msg
+
+    def test_warn_maps_to_debug(self):
+        line = '{"level":"warn","ts":1,"msg":"HTTP/2 skipped because it requires TLS"}'
+        level, msg = _classify_caddy_line(line)
+        assert level == logging.DEBUG
+
+    def test_error_maps_to_error(self):
+        line = '{"level":"error","ts":1,"msg":"listener closed"}'
+        level, msg = _classify_caddy_line(line)
+        assert level == logging.ERROR
+        assert "listener closed" in msg
+
+    def test_fatal_maps_to_error(self):
+        line = '{"level":"fatal","ts":1,"msg":"caddy process crash"}'
+        level, msg = _classify_caddy_line(line)
+        assert level == logging.ERROR
+
+    def test_panic_maps_to_error(self):
+        line = '{"level":"panic","ts":1,"msg":"unexpected nil pointer"}'
+        level, msg = _classify_caddy_line(line)
+        assert level == logging.ERROR
+
+    def test_logger_field_included_in_message(self):
+        line = '{"level":"info","ts":1,"logger":"admin.api","msg":"received request"}'
+        level, msg = _classify_caddy_line(line)
+        assert level == logging.DEBUG
+        assert "[admin.api] received request" == msg
+
+    def test_non_json_treated_as_error(self):
+        line = "panic: runtime error: index out of range"
+        level, msg = _classify_caddy_line(line)
+        assert level == logging.ERROR
+        assert msg == line
+
+    def test_missing_level_defaults_to_debug(self):
+        line = '{"ts":1,"msg":"something"}'
+        level, msg = _classify_caddy_line(line)
+        assert level == logging.DEBUG
+
+    def test_missing_msg_falls_back_to_raw_line(self):
+        line = '{"level":"error","ts":1}'
+        level, msg = _classify_caddy_line(line)
+        assert level == logging.ERROR
+        assert msg == line


### PR DESCRIPTION
## Summary

- Pipe Caddy's stderr through a JSON log classifier that routes error/fatal/panic to `logger.error` and everything else to `logger.debug`
- Caddy's stdout is sent to `/dev/null` (it duplicates stderr)
- Routine startup noise (admin API requests, TLS/HTTP2/HTTP3 warnings, autosave messages) is hidden by default
- All Caddy output is still accessible via `KLANGKD_LOG_LEVEL=DEBUG`

Closes #1807

## Test plan

- [x] Unit tests for `_classify_caddy_line` covering info, warn, error, fatal, panic, non-JSON, missing fields, and logger-field formatting
- [x] 100% coverage maintained
- [ ] E2E: verify `klangkd` startup no longer prints Caddy JSON noise
- [ ] E2E: verify Caddy errors still surface
- [ ] E2E: verify `KLANGKD_LOG_LEVEL=DEBUG` shows all Caddy output