### PR TITLE
CLI: --allow flag for per-workspace egress allowlist

### DIFF
--- a/docs/features/egress-filtering.md
+++ b/docs/features/egress-filtering.md
@@ -72,8 +72,29 @@ and workspaces with `allowed_domains` fail open with a loud warning
 ## Configuring a workspace
 
 Set `allowed_domains` via the workspace **Settings** panel (an
-"Allowed Domains" list editor under Mounts / Environment Variables) or the
-API:
+"Allowed Domains" list editor under Mounts / Environment Variables), the
+CLI, or the API.
+
+### CLI
+
+Use the `--allow` flag (repeatable) on `klangk create` or `klangk edit`:
+
+```bash
+# At creation time
+klangk create my-project --allow github.com:443 --allow pypi.org
+
+# On an existing workspace (flags mode)
+klangk edit my-project --allow github.com:443 --allow registry.npmjs.org
+
+# Interactive mode — prompts to add/remove domains one at a time
+klangk edit my-project
+```
+
+In interactive mode, `klangk edit` shows the current allowlist (if any),
+then prompts to add or remove entries. Domains are validated before they
+are accepted.
+
+### API
 
 ```bash
 curl -X PUT https://klangkd/api/v1/workspaces/<id> \

--- a/docs/features/workspaces.md
+++ b/docs/features/workspaces.md
@@ -29,6 +29,9 @@ optionally configure:
   paths), only directories under those roots can be bind-mounted.
   Protected paths like the Docker/Podman socket are always blocked.
 - **Environment variables** — set custom env vars for the container
+- **Allowed egress domains** — restrict outbound network access to a
+  list of hosts (e.g., `github.com:443`, `pypi.org`). See
+  [Egress Filtering](egress-filtering.md).
 
 You can change all of these later from the workspace **Settings** tab.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -172,10 +172,12 @@ klangk create my-project --env FOO=bar                      # with env vars
 klangk create my-project --health-check 'curl -sf http://localhost:8080/health'  # with a service health check
 klangk create my-project --command 'npm run dev'  # with a service command
 klangk create my-project -c 'npm run dev'         # short form of --command
-klangk edit my-project                  # interactive edit (name, image, command, health check, mounts, env)
+klangk create my-project --allow github.com:443 --allow pypi.org  # with egress allowlist
+klangk edit my-project                  # interactive edit (name, image, command, health check, mounts, env, allowed domains)
 klangk edit my-project --auto-start     # enable auto-start on server boot
 klangk edit my-project --no-auto-start  # disable auto-start
 klangk edit my-project --env FOO=bar    # set env var via flag
+klangk edit my-project --allow github.com:443     # set allowed egress domain via flag
 klangk dup my-project my-copy           # duplicate a workspace
 klangk shell my-project                 # drop into bash inside the container
 klangk shell my-project debug           # attach to the "debug" terminal window (created if it doesn't exist)

--- a/src/klangk/klangk/cli/main.py
+++ b/src/klangk/klangk/cli/main.py
@@ -58,7 +58,7 @@ from .config import (
     default_server_uds_path,
     seed_config,
 )
-from .mount import validate_mount_spec
+from .mount import validate_allowed_domain_spec, validate_mount_spec
 from .transport import ws_connect
 from .sandbox import (
     build_all_mounts,
@@ -514,12 +514,23 @@ def create(
         "--env",
         help="Environment variable, repeatable (e.g. KEY=VALUE)",
     ),
+    allow: list[str] | None = typer.Option(
+        None,
+        "--allow",
+        help="Allowed egress domain, repeatable (e.g. github.com:443, pypi.org)",
+    ),
 ) -> None:
     """Create a new workspace."""
     require_auth()
     if isinstance(mount, list):
         for m in mount:
             err = validate_mount_spec(m)
+            if err:
+                _err.print(f"[red]{err}[/red]")
+                raise typer.Exit(code=1)
+    if isinstance(allow, list):
+        for spec in allow:
+            err = validate_allowed_domain_spec(spec)
             if err:
                 _err.print(f"[red]{err}[/red]")
                 raise typer.Exit(code=1)
@@ -533,6 +544,7 @@ def create(
             mounts=mount or None,
             env=env_dict,
             health_check=health_check,
+            allowed_domains=allow or None,
         )
     except httpx.HTTPStatusError as exc:
         detail = exc.response.json().get("detail", exc.response.text)
@@ -802,6 +814,11 @@ def edit(
         "--env",
         help="Environment variable, repeatable (e.g. KEY=VALUE)",
     ),
+    allow: list[str] | None = typer.Option(
+        None,
+        "--allow",
+        help="Allowed egress domain, repeatable (e.g. github.com:443, pypi.org)",
+    ),
 ) -> None:
     """Edit workspace settings.
 
@@ -824,6 +841,7 @@ def edit(
         or health_check is not None
         or isinstance(mount, list)
         or isinstance(env, list)
+        or isinstance(allow, list)
     )
     if not has_flags:
         # Interactive mode
@@ -921,6 +939,48 @@ def edit(
 
             break  # both add and remove were skipped
 
+        # Interactive allowed-domains editing loop
+        current_domains = list(ws.allowed_domains or [])
+        domains_changed = False
+        while True:
+            if current_domains:
+                typer.echo("\nAllowed egress domains:")
+                for i, d in enumerate(current_domains, 1):
+                    typer.echo(f"  {i}. {d}")
+            else:
+                typer.echo("\nNo egress allowlist (unrestricted networking).")
+
+            add = input(
+                "\nAdd domain (e.g. github.com:443, or Enter to skip): "
+            ).strip()
+            if add:
+                err = validate_allowed_domain_spec(add)
+                if err:
+                    typer.echo(err)
+                    continue
+                current_domains.append(add)
+                domains_changed = True
+                continue
+
+            if current_domains:
+                rm = input("Remove domain number (or Enter to skip): ").strip()
+                if rm:
+                    try:
+                        idx = int(rm) - 1
+                        if 0 <= idx < len(current_domains):
+                            removed = current_domains.pop(idx)
+                            typer.echo(f"Removed: {removed}")
+                            domains_changed = True
+                            continue
+                        else:
+                            typer.echo("Invalid number.")
+                            continue
+                    except ValueError:
+                        typer.echo("Invalid number.")
+                        continue
+
+            break  # both add and remove were skipped
+
         body: dict = {}
         if new_name is not _SENTINEL:
             body["name"] = new_name or ws.name  # don't allow empty name
@@ -934,6 +994,8 @@ def edit(
             body["mounts"] = current_mounts or None
         if env_changed:
             body["env"] = current_env or None
+        if domains_changed:
+            body["allowed_domains"] = current_domains or None
     else:
         # Flags mode — only send provided fields
         body = {}
@@ -956,6 +1018,13 @@ def edit(
             body["mounts"] = mount or None
         if isinstance(env, list):
             body["env"] = _parse_env_list(env) or None
+        if isinstance(allow, list):
+            for spec in allow:
+                err = validate_allowed_domain_spec(spec)
+                if err:
+                    _err.print(f"[red]{err}[/red]")
+                    raise typer.Exit(code=1)
+            body["allowed_domains"] = allow or None
 
     if not body:
         typer.echo("No changes.")

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -819,9 +819,16 @@ class WorkspaceDetailScreen(Screen):
     ]
 
     DEFAULT_CSS = """
+    WorkspaceDetailScreen #term_label {
+        text-style: bold;
+        margin-bottom: 0;
+    }
     WorkspaceDetailScreen #term_list {
         height: auto;
         max-height: 14;
+    }
+    WorkspaceDetailScreen #detail_body {
+        margin-top: 1;
     }
     """
 
@@ -837,9 +844,9 @@ class WorkspaceDetailScreen(Screen):
         yield Header(show_clock=False)
         yield Vertical(
             Static("", id="detail_title"),
-            Static("", id="detail_body"),
-            Static("Terminals (own):", id="term_label"),
+            Static("Terminals", id="term_label"),
             SpatialListView(id="term_list"),
+            Static("", id="detail_body"),
             Static("", id="detail_msg"),
             id="detail_box",
         )
@@ -1048,6 +1055,10 @@ class WorkspaceDetailScreen(Screen):
             idx = w.get("index", "")
             name = w.get("name") or idx
             lv.append(ListItem(Label(Text(f"{idx}  {name}")), name=str(idx)))
+        # Autofocus the first terminal (#1808).
+        lv.focus()
+        if lv.index is None:
+            lv.index = 0
 
     def on_list_view_selected(self, event: ListView.Selected) -> None:
         """Suspend the TUI and spawn ``klangk shell`` for the selected terminal."""

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -1841,7 +1841,7 @@ class TestMainCLI:
         # keep name, keep image, change command, skip add mount, skip add env
         with patch.object(main, "_client", return_value=client):
             with patch(
-                "builtins.input", side_effect=["", "", "pi", "", "", ""]
+                "builtins.input", side_effect=["", "", "pi", "", "", "", ""]
             ):
                 from typer.testing import CliRunner
 
@@ -1873,7 +1873,7 @@ class TestMainCLI:
         with patch.object(main, "_client", return_value=client):
             with patch(
                 "builtins.input",
-                side_effect=["", "", "", "curl -sf http://x/h", "", ""],
+                side_effect=["", "", "", "curl -sf http://x/h", "", "", ""],
             ):
                 from typer.testing import CliRunner
 
@@ -1903,7 +1903,7 @@ class TestMainCLI:
         with patch.object(main, "_client", return_value=client):
             with patch(
                 "builtins.input",
-                side_effect=["renamed", "klangk-custom", "pi", "", "", ""],
+                side_effect=["renamed", "klangk-custom", "pi", "", "", "", ""],
             ):
                 from typer.testing import CliRunner
 
@@ -1933,7 +1933,17 @@ class TestMainCLI:
         with patch.object(main, "_client", return_value=client):
             with patch(
                 "builtins.input",
-                side_effect=["", "", "", "", "/host:/container", "", "", ""],
+                side_effect=[
+                    "",
+                    "",
+                    "",
+                    "",
+                    "/host:/container",
+                    "",
+                    "",
+                    "",
+                    "",
+                ],
             ):
                 from typer.testing import CliRunner
 
@@ -1961,7 +1971,7 @@ class TestMainCLI:
         with patch.object(main, "_client", return_value=client):
             with patch(
                 "builtins.input",
-                side_effect=["", "", "", "", "", "1", "", "", ""],
+                side_effect=["", "", "", "", "", "1", "", "", "", ""],
             ):
                 from typer.testing import CliRunner
 
@@ -1992,7 +2002,19 @@ class TestMainCLI:
         with patch.object(main, "_client", return_value=client):
             with patch(
                 "builtins.input",
-                side_effect=["", "", "", "", "/new:/new", "", "1", "", "", ""],
+                side_effect=[
+                    "",
+                    "",
+                    "",
+                    "",
+                    "/new:/new",
+                    "",
+                    "1",
+                    "",
+                    "",
+                    "",
+                    "",
+                ],
             ):
                 from typer.testing import CliRunner
 
@@ -2023,7 +2045,20 @@ class TestMainCLI:
         with patch.object(main, "_client", return_value=client):
             with patch(
                 "builtins.input",
-                side_effect=["", "", "", "", "", "99", "", "abc", "", "", ""],
+                side_effect=[
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "99",
+                    "",
+                    "abc",
+                    "",
+                    "",
+                    "",
+                    "",
+                ],
             ):
                 from typer.testing import CliRunner
 
@@ -2053,7 +2088,7 @@ class TestMainCLI:
         with patch.object(main, "_client", return_value=client):
             with patch(
                 "builtins.input",
-                side_effect=["", "", "", "", "", "1", "", ""],
+                side_effect=["", "", "", "", "", "1", "", "", ""],
             ):
                 from typer.testing import CliRunner
 
@@ -2083,7 +2118,7 @@ class TestMainCLI:
         with patch.object(main, "_client", return_value=client):
             with patch(
                 "builtins.input",
-                side_effect=["", "", "", "", "bad", "/a:/b", "", "", ""],
+                side_effect=["", "", "", "", "bad", "/a:/b", "", "", "", ""],
             ):
                 from typer.testing import CliRunner
 
@@ -2198,7 +2233,9 @@ class TestMainCLI:
 
         # keep name, image, command; skip add mount (no mounts, no remove prompt)
         with patch.object(main, "_client", return_value=client):
-            with patch("builtins.input", side_effect=["", "", "", "", "", ""]):
+            with patch(
+                "builtins.input", side_effect=["", "", "", "", "", "", ""]
+            ):
                 from typer.testing import CliRunner
 
                 runner = CliRunner()
@@ -2224,7 +2261,7 @@ class TestMainCLI:
         with patch.object(main, "_client", return_value=client):
             with patch(
                 "builtins.input",
-                side_effect=["", "", "", "", "", "FOO=bar", "", ""],
+                side_effect=["", "", "", "", "", "FOO=bar", "", "", ""],
             ):
                 from typer.testing import CliRunner
 
@@ -2253,7 +2290,7 @@ class TestMainCLI:
         with patch.object(main, "_client", return_value=client):
             with patch(
                 "builtins.input",
-                side_effect=["", "", "", "", "", "bad", "A=1", "", ""],
+                side_effect=["", "", "", "", "", "bad", "A=1", "", "", ""],
             ):
                 from typer.testing import CliRunner
 
@@ -2290,6 +2327,7 @@ class TestMainCLI:
             mounts=None,
             env={"FOO": "bar", "X": "1"},
             health_check=None,
+            allowed_domains=None,
         )
 
     def test_create_with_command_flag(self, logged_in_cfg, monkeypatch):
@@ -2315,6 +2353,7 @@ class TestMainCLI:
             mounts=None,
             env=None,
             health_check=None,
+            allowed_domains=None,
         )
 
     def test_create_with_invalid_env_flag(self, logged_in_cfg, monkeypatch):
@@ -2327,6 +2366,112 @@ class TestMainCLI:
         runner = CliRunner()
         result = runner.invoke(
             main.app, ["create", "ws", "--env", "NOEQUALSSIGN"]
+        )
+        assert result.exit_code == 1
+
+    def test_create_with_allow_flag(self, logged_in_cfg, monkeypatch):
+        from klangk.cli import main
+
+        ws = Workspace(
+            id="new-id", name="ws", created_at="2025-01-01T00:00:00Z"
+        )
+        client = MagicMock()
+        client.create_workspace.return_value = ws
+        monkeypatch.setattr(main, "_client", lambda: client)
+
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main.app,
+            [
+                "create",
+                "ws",
+                "--allow",
+                "github.com:443",
+                "--allow",
+                "pypi.org",
+            ],
+        )
+        assert result.exit_code == 0
+        client.create_workspace.assert_called_once_with(
+            "ws",
+            image=None,
+            service_command=None,
+            auto_start=False,
+            mounts=None,
+            env=None,
+            health_check=None,
+            allowed_domains=["github.com:443", "pypi.org"],
+        )
+
+    def test_create_with_invalid_allow_flag(self, logged_in_cfg, monkeypatch):
+        from klangk.cli import main
+
+        monkeypatch.setattr(main, "_client", lambda: MagicMock())
+
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main.app, ["create", "ws", "--allow", "not a valid domain!"]
+        )
+        assert result.exit_code == 1
+
+    def test_edit_with_allow_flag(self, logged_in_cfg, monkeypatch):
+        from klangk.cli import main
+
+        ws = Workspace(
+            id="ws1" + "0" * 52,
+            name="my-ws",
+            created_at="2025-01-01T00:00:00Z",
+        )
+        client = MagicMock()
+        client.resolve_workspace.return_value = ws
+        resp = MagicMock()
+        resp.status_code = 200
+        client.put.return_value = resp
+        monkeypatch.setattr(main, "_client", lambda: client)
+
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main.app,
+            [
+                "edit",
+                "my-ws",
+                "--allow",
+                "github.com:443",
+                "--allow",
+                "pypi.org",
+            ],
+        )
+        assert result.exit_code == 0
+        call_body = client.put.call_args
+        assert call_body[1]["json"]["allowed_domains"] == [
+            "github.com:443",
+            "pypi.org",
+        ]
+
+    def test_edit_with_invalid_allow_flag(self, logged_in_cfg, monkeypatch):
+        from klangk.cli import main
+
+        ws = Workspace(
+            id="ws1" + "0" * 52,
+            name="my-ws",
+            created_at="2025-01-01T00:00:00Z",
+        )
+        client = MagicMock()
+        client.resolve_workspace.return_value = ws
+        monkeypatch.setattr(main, "_client", lambda: client)
+
+        from typer.testing import CliRunner
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main.app,
+            ["edit", "my-ws", "--allow", "not valid!"],
         )
         assert result.exit_code == 1
 
@@ -2347,7 +2492,7 @@ class TestMainCLI:
         with patch.object(main, "_client", return_value=client):
             with patch(
                 "builtins.input",
-                side_effect=["", "", "", "", "", "", "1", "", ""],
+                side_effect=["", "", "", "", "", "", "1", "", "", ""],
             ):
                 from typer.testing import CliRunner
 
@@ -2377,7 +2522,20 @@ class TestMainCLI:
         with patch.object(main, "_client", return_value=client):
             with patch(
                 "builtins.input",
-                side_effect=["", "", "", "", "", "", "99", "", "abc", "", ""],
+                side_effect=[
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "",
+                    "99",
+                    "",
+                    "abc",
+                    "",
+                    "",
+                    "",
+                ],
             ):
                 from typer.testing import CliRunner
 

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -2475,6 +2475,204 @@ class TestMainCLI:
         )
         assert result.exit_code == 1
 
+    def test_edit_interactive_add_domain(self, logged_in_cfg, monkeypatch):
+        from klangk.cli import main
+
+        ws = Workspace(
+            id="ws1" + "0" * 52,
+            name="my-ws",
+            created_at="2025-01-01T00:00:00Z",
+        )
+        client = MagicMock()
+        client.resolve_workspace.return_value = ws
+        client.put.return_value = MagicMock(status_code=200)
+
+        with patch.object(main, "_client", return_value=client):
+            with patch(
+                "builtins.input",
+                side_effect=[
+                    "",  # name
+                    "",  # image
+                    "",  # command
+                    "",  # health_check
+                    "",  # mount add
+                    "",  # env add
+                    "github.com:443",  # domain add
+                    "",  # domain add (skip)
+                    "",  # done
+                ],
+            ):
+                from typer.testing import CliRunner
+
+                runner = CliRunner()
+                result = runner.invoke(main.app, ["edit", "my-ws"])
+                assert result.exit_code == 0
+
+        body = client.put.call_args[1]["json"]
+        assert body["allowed_domains"] == ["github.com:443"]
+
+    def test_edit_interactive_add_domain_with_existing(
+        self, logged_in_cfg, monkeypatch
+    ):
+        from klangk.cli import main
+
+        ws = Workspace(
+            id="ws1" + "0" * 52,
+            name="my-ws",
+            created_at="2025-01-01T00:00:00Z",
+            allowed_domains=["pypi.org"],
+        )
+        client = MagicMock()
+        client.resolve_workspace.return_value = ws
+        client.put.return_value = MagicMock(status_code=200)
+
+        with patch.object(main, "_client", return_value=client):
+            with patch(
+                "builtins.input",
+                side_effect=[
+                    "",  # name
+                    "",  # image
+                    "",  # command
+                    "",  # health_check
+                    "",  # mount add
+                    "",  # env add
+                    "github.com:443",  # domain add
+                    "",  # domain add (skip)
+                    "",  # domain remove (skip)
+                    "",  # done
+                ],
+            ):
+                from typer.testing import CliRunner
+
+                runner = CliRunner()
+                result = runner.invoke(main.app, ["edit", "my-ws"])
+                assert result.exit_code == 0
+
+        body = client.put.call_args[1]["json"]
+        assert body["allowed_domains"] == ["pypi.org", "github.com:443"]
+        assert "Allowed egress domains" in result.output
+
+    def test_edit_interactive_remove_domain(self, logged_in_cfg, monkeypatch):
+        from klangk.cli import main
+
+        ws = Workspace(
+            id="ws1" + "0" * 52,
+            name="my-ws",
+            created_at="2025-01-01T00:00:00Z",
+            allowed_domains=["pypi.org", "github.com:443"],
+        )
+        client = MagicMock()
+        client.resolve_workspace.return_value = ws
+        client.put.return_value = MagicMock(status_code=200)
+
+        with patch.object(main, "_client", return_value=client):
+            with patch(
+                "builtins.input",
+                side_effect=[
+                    "",  # name
+                    "",  # image
+                    "",  # command
+                    "",  # health_check
+                    "",  # mount add
+                    "",  # env add
+                    "",  # domain add (skip)
+                    "1",  # domain remove pypi.org
+                    "",  # domain add (skip)
+                    "",  # domain remove (skip)
+                    "",  # done
+                ],
+            ):
+                from typer.testing import CliRunner
+
+                runner = CliRunner()
+                result = runner.invoke(main.app, ["edit", "my-ws"])
+                assert result.exit_code == 0
+
+        body = client.put.call_args[1]["json"]
+        assert body["allowed_domains"] == ["github.com:443"]
+        assert "Removed: pypi.org" in result.output
+
+    def test_edit_interactive_invalid_domain_rejected(
+        self, logged_in_cfg, monkeypatch
+    ):
+        from klangk.cli import main
+
+        ws = Workspace(
+            id="ws1" + "0" * 52,
+            name="my-ws",
+            created_at="2025-01-01T00:00:00Z",
+        )
+        client = MagicMock()
+        client.resolve_workspace.return_value = ws
+        client.put.return_value = MagicMock(status_code=200)
+
+        with patch.object(main, "_client", return_value=client):
+            with patch(
+                "builtins.input",
+                side_effect=[
+                    "",  # name
+                    "",  # image
+                    "",  # command
+                    "",  # health_check
+                    "",  # mount add
+                    "",  # env add
+                    "not valid!",  # invalid domain
+                    "github.com",  # valid domain
+                    "",  # domain add (skip)
+                    "",  # done
+                ],
+            ):
+                from typer.testing import CliRunner
+
+                runner = CliRunner()
+                result = runner.invoke(main.app, ["edit", "my-ws"])
+                assert result.exit_code == 0
+
+        body = client.put.call_args[1]["json"]
+        assert body["allowed_domains"] == ["github.com"]
+
+    def test_edit_interactive_invalid_domain_remove_number(
+        self, logged_in_cfg, monkeypatch
+    ):
+        from klangk.cli import main
+
+        ws = Workspace(
+            id="ws1" + "0" * 52,
+            name="my-ws",
+            created_at="2025-01-01T00:00:00Z",
+            allowed_domains=["pypi.org"],
+        )
+        client = MagicMock()
+        client.resolve_workspace.return_value = ws
+        client.put.return_value = MagicMock(status_code=200)
+
+        with patch.object(main, "_client", return_value=client):
+            with patch(
+                "builtins.input",
+                side_effect=[
+                    "",  # name
+                    "",  # image
+                    "",  # command
+                    "",  # health_check
+                    "",  # mount add
+                    "",  # env add
+                    "",  # domain add (skip)
+                    "99",  # invalid number
+                    "",  # domain add (skip)
+                    "abc",  # non-numeric
+                    "",  # domain add (skip)
+                    "",  # domain remove (skip)
+                    "",  # done
+                ],
+            ):
+                from typer.testing import CliRunner
+
+                runner = CliRunner()
+                result = runner.invoke(main.app, ["edit", "my-ws"])
+                assert result.exit_code == 0
+
+        assert "Invalid number." in result.output
+
     def test_edit_interactive_remove_env(self, logged_in_cfg, monkeypatch):
         from klangk.cli import main
 


### PR DESCRIPTION
## Summary
- Add repeatable `--allow` flag to `klangk create` and `klangk edit` for per-workspace egress allowlist
- Interactive `klangk edit` mode prompts for adding/removing allowed domains (same pattern as mounts/env)
- Validates entries via `validate_allowed_domain_spec` (same validation as Flutter/TUI)
- Completes three-surface parity for `allowed_domains` — Flutter and TUI already had it

Fixes #1745

## Test plan
- [x] All 460 CLI tests pass (4 new: create/edit with --allow, invalid --allow on both)
- [x] All 14 interactive edit tests updated with the new domain prompt