### PR TITLE
TUI: minor nits batch (#1814, #1826, #1827)

### DIFF
--- a/src/klangk/klangk/api/workspaces.py
+++ b/src/klangk/klangk/api/workspaces.py
@@ -116,6 +116,9 @@ def _annotate_running(items: list[dict], container_registry) -> list[dict]:
         if state is not None:
             ws["health"] = state.health_status
             ws["health_message"] = state.health_message
+            ws["service_started_at"] = state.service_started_at
+        else:
+            ws["service_started_at"] = None
     return items
 
 

--- a/src/klangk/klangk/cli/client.py
+++ b/src/klangk/klangk/cli/client.py
@@ -179,6 +179,7 @@ class Workspace:
     running: bool = False
     health: str | None = None
     health_message: str | None = None
+    service_started_at: float | None = None
 
 
 def get_terminal_size() -> tuple[int, int]:
@@ -427,6 +428,7 @@ class KlangkClient:
             health=w.get("health"),
             health_message=w.get("health_message"),
             allowed_domains=w.get("allowed_domains"),
+            service_started_at=w.get("service_started_at"),
         )
 
     def create_workspace(

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -11,6 +11,7 @@ import asyncio
 import datetime
 import subprocess
 import sys
+import time
 from urllib.parse import urlparse
 
 import logging
@@ -310,6 +311,11 @@ class LoginScreen(SpatialNavScreen):
                 no_wrap=True,
             )
             lv.append(ListItem(Label(label), name=uds))
+        # Autofocus the first server entry (#1826).
+        if lv.query(ListItem):
+            lv.focus()
+            if lv.index is None:
+                lv.index = 0
 
     @staticmethod
     def _derive_alias(raw: str) -> str:
@@ -843,7 +849,6 @@ class WorkspaceDetailScreen(Screen):
     def compose(self) -> ComposeResult:
         yield Header(show_clock=False)
         yield Vertical(
-            Static("", id="detail_title"),
             Static("Terminals", id="term_label"),
             SpatialListView(id="term_list"),
             Static("", id="detail_body"),
@@ -854,6 +859,7 @@ class WorkspaceDetailScreen(Screen):
 
     def on_mount(self) -> None:
         self.run_worker(self._mount_async, exit_on_error=False)
+        self._uptime_timer = self.set_interval(5, self._tick_uptime)
 
     async def _mount_async(self) -> None:
         await self._load()
@@ -914,9 +920,6 @@ class WorkspaceDetailScreen(Screen):
         ]
 
     def _display(self) -> None:
-        self.query_one("#detail_title", Static).update(
-            Text(f"Workspace: {self._name}")
-        )
         ws = self._ws
         body = self.query_one("#detail_body", Static)
         if ws is None:
@@ -932,6 +935,19 @@ class WorkspaceDetailScreen(Screen):
             f"running: {'yes' if ws.running else 'no'}",
             f"health: {ws.health or '-'}",
         ]
+        if ws.running and ws.service_started_at:
+            elapsed = int(time.time() - ws.service_started_at)
+            if elapsed >= 0:
+                parts = []
+                days, rem = divmod(elapsed, 86400)
+                hours, rem = divmod(rem, 3600)
+                minutes, _ = divmod(rem, 60)
+                if days:
+                    parts.append(f"{days}d")
+                if hours:
+                    parts.append(f"{hours}h")
+                parts.append(f"{minutes}m")
+                lines.append(f"uptime: {' '.join(parts)}")
         if ws.health_message:
             lines.append(f"health note: {ws.health_message}")
         if ws.image:
@@ -953,6 +969,15 @@ class WorkspaceDetailScreen(Screen):
         if ws.owner_email:
             lines.append(f"owner: {ws.owner_email}")
         body.update(Text("\n".join(lines)))
+
+    def _tick_uptime(self) -> None:
+        """Refresh the display periodically to update the uptime counter."""
+        if (
+            self._ws is not None
+            and self._ws.running
+            and self._ws.service_started_at
+        ):
+            self._display()
 
     def _msg(self, text: str, *, error: bool = False) -> None:
         self.query_one("#detail_msg", Static).update(
@@ -1018,6 +1043,8 @@ class WorkspaceDetailScreen(Screen):
             return
         if etype == "container_status":
             self._ws.running = bool(event.get("running"))
+            if "service_started_at" in event:
+                self._ws.service_started_at = event["service_started_at"]
         elif etype == "service_health":
             self._ws.running = bool(event.get("running", self._ws.running))
             self._ws.health = (
@@ -1131,6 +1158,9 @@ class WorkspaceDetailScreen(Screen):
         except Exception as exc:
             self._msg(f"Restart failed: {exc}", error=True)
             return
+        if self._ws is not None:
+            self._ws.service_started_at = time.time()
+            self._display()
         self._msg("Restart requested.")
         self.app.refresh_workspaces()
 
@@ -1165,6 +1195,10 @@ class WorkspaceDetailScreen(Screen):
         except Exception as exc:
             self._msg(f"Stop failed: {exc}", error=True)
             return
+        if self._ws is not None:
+            self._ws.running = False
+            self._ws.service_started_at = None
+            self._display()
         self._msg("Stop requested.")
         self.app.refresh_workspaces()
 
@@ -1176,6 +1210,10 @@ class WorkspaceDetailScreen(Screen):
         except Exception as exc:
             self._msg(f"Start failed: {exc}", error=True)
             return
+        if self._ws is not None:
+            self._ws.running = True
+            self._ws.service_started_at = time.time()
+            self._display()
         self._msg("Start requested.")
         self.app.refresh_workspaces()
 

--- a/src/klangk/klangk/container.py
+++ b/src/klangk/klangk/container.py
@@ -901,7 +901,9 @@ class ContainerRegistry:
 
     def _notify_status_changed(self, workspace_id: str, running: bool) -> None:
         if self.on_container_status_changed:
-            self.on_container_status_changed(workspace_id, running)
+            state = self.states.get(workspace_id)
+            started_at = state.service_started_at if state else None
+            self.on_container_status_changed(workspace_id, running, started_at)
 
     async def remove_state(self, workspace_id: str) -> None:
         """Remove tracked state for a workspace.

--- a/src/klangk/klangk/wshandler/session.py
+++ b/src/klangk/klangk/wshandler/session.py
@@ -593,18 +593,23 @@ class WebSocketState:
         await self.app.state.agents.stop_session(workspace_id)
 
     def notify_container_status(
-        self, workspace_id: str, running: bool
+        self,
+        workspace_id: str,
+        running: bool,
+        service_started_at: float | None = None,
     ) -> None:
         """Broadcast container running/stopped status to all connections.
 
         Sent when a workspace container starts or is killed so the
         workspace list page can update status icons in real time.
         """
-        message = {
+        message: dict = {
             "type": "container_status",
             "workspace_id": workspace_id,
             "running": running,
         }
+        if service_started_at is not None:
+            message["service_started_at"] = service_started_at
         dead = []
         for sock, conn in self.connections.items():
             if conn.user.get("id") is None:

--- a/src/klangk/klangkc-tests/e2e-tests/test_tui_e2e.py
+++ b/src/klangk/klangkc-tests/e2e-tests/test_tui_e2e.py
@@ -324,8 +324,6 @@ class TestTuiE2E:
                 await pilot.pause()
                 await pilot.pause()
                 assert isinstance(app.screen, WorkspaceDetailScreen)
-                title = str(app.screen.query_one("#detail_title").render())
-                assert ws_name in title
         finally:
             _api_delete_workspace(base_url, token, ws_id)
 

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -1633,7 +1633,6 @@ async def test_detail_loads_and_renders(monkeypatch):
         app.push_screen(WorkspaceDetailScreen("alpha"))
         await pilot.pause()
         d = app.screen
-        assert "alpha" in str(d.query_one("#detail_title").render())
         body = str(d.query_one("#detail_body").render())
         for s in [
             "running: yes",
@@ -1669,6 +1668,45 @@ async def test_detail_renders_allowed_domains(monkeypatch):
         assert "allowed domains:" in body
         assert "github.com:443" in body
         assert "pypi.org" in body
+
+
+async def test_detail_shows_uptime(monkeypatch):
+    """#1814: uptime is shown when the container is running."""
+    import time as _time
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    # service_started_at 1 day 2 hours 30 minutes ago
+    started = _time.time() - (86400 + 7200 + 1800)
+    a = _wsobj("alpha", running=True, service_started_at=started)
+    st = _ws()
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        body = str(app.screen.query_one("#detail_body").render())
+        assert "uptime: 1d 2h 30m" in body
+
+
+async def test_detail_no_uptime_when_stopped(monkeypatch):
+    """#1814: uptime is not shown when the container is stopped."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    a = _wsobj("alpha", running=False)
+    st = _ws()
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        body = str(app.screen.query_one("#detail_body").render())
+        assert "uptime" not in body
 
 
 async def test_detail_action_edit_opens_form_and_refreshes(monkeypatch):
@@ -1779,6 +1817,8 @@ async def test_detail_restart_confirm_cancel_error(monkeypatch):
         assert "Restart requested" in str(
             app.screen.query_one("#detail_msg").render()
         )
+        # service_started_at reset on restart (#1814).
+        assert a.service_started_at is not None
         # error
         st.restart_workspace = lambda n: (_ for _ in ()).throw(
             RuntimeError("boom")
@@ -1857,7 +1897,7 @@ async def test_detail_stop_when_running(monkeypatch):
         return None
 
     monkeypatch.setattr(scr, "listen_for_status", noop)
-    a = _wsobj("alpha", running=True)
+    a = _wsobj("alpha", running=True, service_started_at=1000.0)
     stopped = {}
     st = _ws()
     st.find_workspace = lambda n: a
@@ -1875,6 +1915,14 @@ async def test_detail_stop_when_running(monkeypatch):
         assert stopped.get("s") == "alpha"
         assert "Stop requested" in str(
             app.screen.query_one("#detail_msg").render()
+        )
+        # After stop, binding label should toggle to "Start".
+        labels = [b.description for b in app.screen.BINDINGS if b.key == "s"]
+        assert labels == ["Start"]
+        # service_started_at cleared on stop (#1814).
+        assert a.service_started_at is None
+        assert "uptime" not in str(
+            app.screen.query_one("#detail_body").render()
         )
 
 
@@ -1898,6 +1946,58 @@ async def test_detail_start_when_stopped(monkeypatch):
         assert started.get("s") == "alpha"
         assert "Start requested" in str(
             app.screen.query_one("#detail_msg").render()
+        )
+        # After start, binding label should toggle to "Stop".
+        labels = [b.description for b in app.screen.BINDINGS if b.key == "s"]
+        assert labels == ["Stop"]
+        # service_started_at reset on start (#1814).
+        assert a.service_started_at is not None
+        assert "uptime:" in str(app.screen.query_one("#detail_body").render())
+
+
+async def test_detail_uptime_ticks(monkeypatch):
+    """#1814: uptime display refreshes via the periodic timer."""
+    import time as _time
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    started = _time.time() - 60
+    a = _wsobj("alpha", running=True, service_started_at=started)
+    st = _ws()
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        body1 = str(app.screen.query_one("#detail_body").render())
+        assert "uptime:" in body1
+        # Simulate time passing and trigger the tick.
+        a.service_started_at = _time.time() - 180
+        app.screen._tick_uptime()
+        body2 = str(app.screen.query_one("#detail_body").render())
+        assert "uptime: 3m" in body2
+
+
+async def test_detail_uptime_tick_noop_when_stopped(monkeypatch):
+    """#1814: tick does not crash or re-render when container is stopped."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    a = _wsobj("alpha", running=False)
+    st = _ws()
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        # Should be a no-op, no crash.
+        app.screen._tick_uptime()
+        assert "uptime" not in str(
+            app.screen.query_one("#detail_body").render()
         )
 
 
@@ -2168,9 +2268,7 @@ async def test_detail_markup_name_safe(monkeypatch):
     async with app.run_test() as pilot:
         app.push_screen(WorkspaceDetailScreen("x[red]y"))
         await pilot.pause()
-        title = str(app.screen.query_one("#detail_title").render())
         body = str(app.screen.query_one("#detail_body").render())
-        assert "x[red]y" in title  # literal, not markup-parsed
         assert "[img]" in body
         assert "[bad]" in body
 
@@ -2190,15 +2288,20 @@ async def test_detail_apply_status_event(monkeypatch):
         app.push_screen(WorkspaceDetailScreen("alpha"))
         await pilot.pause()
         d = app.screen
-        # container_status flips running
+        # container_status flips running and carries service_started_at
+        import time as _time
+
+        started = _time.time() - 120
         d.apply_status_event(
             {
                 "type": "container_status",
                 "workspace_id": "id-alpha",
                 "running": True,
+                "service_started_at": started,
             }
         )
         assert a.running is True
+        assert a.service_started_at == started
         assert "running: yes" in str(d.query_one("#detail_body").render())
         # service_health updates health + message
         d.apply_status_event(
@@ -4130,6 +4233,52 @@ async def test_populate_servers_dedups_default_udsk(monkeypatch):
         ol = app.screen.query_one("#server_options", ListView)
         # only the persisted alias row; no separate "Local klangkd (UDS)" row
         assert len(ol.query(ListItem)) == 1
+
+
+async def test_login_server_list_autofocused(monkeypatch):
+    """#1826: first server in the list is focused on initial display."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    st = _st(
+        current_url=lambda: None,
+        known_servers=lambda: [
+            tui_state_mod.ServerInfo("prod", "https://prod.example")
+        ],
+        default_uds=lambda: None,
+        auth_mode=lambda: "password",
+        email=lambda: None,
+        token=lambda: None,
+        is_authenticated=lambda: False,
+    )
+    app = KlangkApp(st)
+    async with app.run_test():
+        lv = app.screen.query_one("#server_options", ListView)
+        assert lv.index == 0
+
+
+async def test_login_server_list_empty_no_crash(monkeypatch):
+    """#1826: no servers → no crash, focus degrades gracefully."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    st = _st(
+        current_url=lambda: None,
+        known_servers=lambda: [],
+        default_uds=lambda: None,
+        auth_mode=lambda: "password",
+        email=lambda: None,
+        token=lambda: None,
+        is_authenticated=lambda: False,
+    )
+    app = KlangkApp(st)
+    async with app.run_test():
+        lv = app.screen.query_one("#server_options", ListView)
+        assert lv.index is None
 
 
 async def test_login_choose_invalid_server(monkeypatch):

--- a/src/klangk/klangkd-tests/tests/test_container.py
+++ b/src/klangk/klangkd-tests/tests/test_container.py
@@ -243,7 +243,9 @@ class TestActivityTracking:
     def test_track_activity_fires_status_changed_on_new(self):
         calls = []
         self.registry.set_on_container_status_changed(
-            lambda ws_id, running: calls.append((ws_id, running))
+            lambda ws_id, running, started_at=None: calls.append(
+                (ws_id, running)
+            )
         )
         try:
             self.registry.track_activity("cid-new", "ws-new")

--- a/src/klangk/klangkd-tests/tests/test_wshandler.py
+++ b/src/klangk/klangkd-tests/tests/test_wshandler.py
@@ -4043,6 +4043,19 @@ class TestNotifyContainerStatus:
         sock_a.send_json.assert_called_once_with(expected)
         sock_b.send_json.assert_called_once_with(expected)
 
+    def test_includes_service_started_at(self, app_state):
+        app_state = _make_app_state()
+        sockets = app_state.state.sockets
+        sock = _mock_sock()
+        try:
+            self._register(sock, {"id": "uid-1", "email": "a@x"}, app_state)
+            sockets.notify_container_status("ws-789", True, 1000.0)
+        finally:
+            sockets.connections.pop(sock, None)
+        msg = sock.send_json.call_args[0][0]
+        assert msg["service_started_at"] == 1000.0
+        assert msg["running"] is True
+
     def test_sends_stopped(self, app_state):
         app_state = _make_app_state()
         sockets = app_state.state.sockets


### PR DESCRIPTION
## Summary

- **#1827**: Stop/Start binding label in detail page footer toggles immediately after action; removed redundant "Workspace: foo" title line
- **#1826**: Autofocus first server in login screen server list on initial display
- **#1814**: Show container uptime on workspace detail page, refreshing every 5s; resets on start/restart, clears on stop

## Test plan

- [x] All 3654 backend tests pass with 100% coverage
- [ ] Manual: stop a container via "s" on detail page → footer shows "Start", uptime disappears
- [ ] Manual: start a stopped container → footer shows "Stop", uptime starts from 0m
- [ ] Manual: restart → uptime resets
- [ ] Manual: login screen autofocuses first server entry

Closes #1814, closes #1826, closes #1827