### PR TITLE
Fix: omit Authorization header when token is absent

### DIFF
--- a/src/klangk/klangk/cli/client.py
+++ b/src/klangk/klangk/cli/client.py
@@ -258,8 +258,9 @@ class KlangkClient:
     def _headers(self) -> dict[str, str]:
         if self.token and token_expires_soon(self.token):
             self._try_refresh()
-        token = self.token or ""
-        return {"Authorization": f"Bearer {token}"}
+        if self.token:
+            return {"Authorization": f"Bearer {self.token}"}
+        return {}
 
     def _request(self, method: str, path: str, **kwargs) -> httpx.Response:
         resp = request_with_retry(

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -1544,10 +1544,10 @@ class TestKlangkClient:
         resp.status_code = 200
         client._raise_for_status(resp)  # should not raise
 
-    def test_no_token_uses_empty_string(self):
+    def test_no_token_omits_authorization(self):
         client = KlangkClient("http://test:8995")
         headers = client._headers()
-        assert headers["Authorization"] == "Bearer "
+        assert "Authorization" not in headers
 
 
 # --- Token refresh ---


### PR DESCRIPTION
## Summary
- `KlangkClient._headers()` produced `"Bearer "` (trailing space, no token) when the client had no stored credentials
- h11 rejects trailing whitespace in header values, causing `Illegal header value b'Bearer'` instead of a clean 401
- Now omits the `Authorization` header entirely when no token is available
- This surfaces in the TUI after switching servers — the new server may have no stored credentials

Closes #1835

## Test plan
- [x] Updated `test_no_token_omits_authorization` to verify no Authorization header when token is None
- [x] Full backend suite passes (3654 passed, 100% coverage)