### PR TITLE
Fix: pre-flight PID check prevents dual klangkd UDS destruction

### DIFF
--- a/src/klangk/klangk/launcher.py
+++ b/src/klangk/klangk/launcher.py
@@ -33,6 +33,7 @@ proxy ownership), and #1645 (first-run generation) for the full rationale.
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
 
 import typer
@@ -98,6 +99,43 @@ def _resolve_config_path(config: str | None) -> str:
     return str(path)
 
 
+def _check_pid_preflight(settings: KlangkSettings) -> int | None:
+    """Return the PID of a live klangkd for this instance, or ``None``.
+
+    Mirrors :meth:`Util.check_pid_file` but runs *before* the app is
+    built so the launcher can abort before touching the UDS (#1837).
+    """
+    # Read the instance ID the same way Util.resolve_instance_id does,
+    # but read-only — don't generate one; if the file is missing there
+    # is no running instance to collide with.
+    instance_id_path = Path(settings.data_dir) / "instance-id"
+    try:
+        instance_id = instance_id_path.read_text().strip()
+    except (FileNotFoundError, ValueError):
+        return None
+    if not instance_id:
+        return None
+
+    pid_path = Path(settings.state_dir) / f"klangk-{instance_id}.pid"
+    try:
+        pid = int(pid_path.read_text().strip())
+    except (FileNotFoundError, ValueError):
+        return None
+
+    try:
+        os.kill(pid, 0)
+    except (ProcessLookupError, OverflowError):
+        # Stale PID file — clean it up.
+        pid_path.unlink(missing_ok=True)
+        return None
+    except PermissionError:
+        return pid
+
+    if pid == os.getpid():
+        return None
+    return pid
+
+
 @app.command()
 def main(  # pragma: no cover
     config: str | None = typer.Option(
@@ -134,6 +172,21 @@ def main(  # pragma: no cover
 
     # Read ws_max_size through the typed config (default 16 MiB, #1394/#1395).
     ws_max_size = int(settings.websocket_msg_size_max)
+
+    # Pre-flight PID check: abort *before* touching the UDS so a second
+    # klangkd doesn't destroy the first instance's socket (#1837).
+    # The lifespan has its own authoritative check, but that runs after
+    # uvicorn binds — too late to protect the socket file.
+    existing = _check_pid_preflight(settings)
+    if existing is not None:
+        from klangk.logger import logger  # noqa: allow-deferred-import
+
+        logger.error(
+            "Another klangk instance (PID %d) is already running — "
+            "refusing to start",
+            existing,
+        )
+        sys.exit(1)
 
     # Bind the UDS. A stale socket from a kill -9'd process makes the
     # bind fail with EADDRINUSE — unlink first (the pidfile guard in the

--- a/src/klangk/klangkd-tests/tests/test_main.py
+++ b/src/klangk/klangkd-tests/tests/test_main.py
@@ -1722,6 +1722,139 @@ class TestPidFile:
         assert path.name == f"klangk-{monkeypatch_id}.pid"
 
 
+class TestCheckPidPreflight:
+    """Tests for launcher._check_pid_preflight (#1837)."""
+
+    def test_no_instance_id_file(self, tmp_path):
+        from klangk.launcher import _check_pid_preflight
+
+        settings = make_settings(
+            {
+                "KLANGKD_STATE_DIR": str(tmp_path / "state"),
+                "KLANGKD_DATA_DIR": str(tmp_path / "data"),
+            }
+        )
+        assert _check_pid_preflight(settings) is None
+
+    def test_empty_instance_id(self, tmp_path):
+        from klangk.launcher import _check_pid_preflight
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        (data_dir / "instance-id").write_text("")
+        settings = make_settings(
+            {
+                "KLANGKD_STATE_DIR": str(tmp_path / "state"),
+                "KLANGKD_DATA_DIR": str(data_dir),
+            }
+        )
+        assert _check_pid_preflight(settings) is None
+
+    def test_no_pid_file(self, tmp_path):
+        from klangk.launcher import _check_pid_preflight
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        (data_dir / "instance-id").write_text("test-id")
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        settings = make_settings(
+            {
+                "KLANGKD_STATE_DIR": str(state_dir),
+                "KLANGKD_DATA_DIR": str(data_dir),
+            }
+        )
+        assert _check_pid_preflight(settings) is None
+
+    def test_stale_pid(self, tmp_path):
+        from klangk.launcher import _check_pid_preflight
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        (data_dir / "instance-id").write_text("test-id")
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        pid_file = state_dir / "klangk-test-id.pid"
+        pid_file.write_text("2000000")
+        settings = make_settings(
+            {
+                "KLANGKD_STATE_DIR": str(state_dir),
+                "KLANGKD_DATA_DIR": str(data_dir),
+            }
+        )
+        assert _check_pid_preflight(settings) is None
+        assert not pid_file.exists()
+
+    def test_own_pid(self, tmp_path):
+        from klangk.launcher import _check_pid_preflight
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        (data_dir / "instance-id").write_text("test-id")
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        (state_dir / "klangk-test-id.pid").write_text(str(os.getpid()))
+        settings = make_settings(
+            {
+                "KLANGKD_STATE_DIR": str(state_dir),
+                "KLANGKD_DATA_DIR": str(data_dir),
+            }
+        )
+        assert _check_pid_preflight(settings) is None
+
+    def test_live_foreign_pid(self, tmp_path):
+        from klangk.launcher import _check_pid_preflight
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        (data_dir / "instance-id").write_text("test-id")
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        ppid = os.getppid()
+        (state_dir / "klangk-test-id.pid").write_text(str(ppid))
+        settings = make_settings(
+            {
+                "KLANGKD_STATE_DIR": str(state_dir),
+                "KLANGKD_DATA_DIR": str(data_dir),
+            }
+        )
+        assert _check_pid_preflight(settings) == ppid
+
+    def test_permission_error_pid(self, tmp_path):
+        from klangk.launcher import _check_pid_preflight
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        (data_dir / "instance-id").write_text("test-id")
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        (state_dir / "klangk-test-id.pid").write_text("1")
+        settings = make_settings(
+            {
+                "KLANGKD_STATE_DIR": str(state_dir),
+                "KLANGKD_DATA_DIR": str(data_dir),
+            }
+        )
+        assert _check_pid_preflight(settings) == 1
+
+    def test_invalid_pid_content(self, tmp_path):
+        from klangk.launcher import _check_pid_preflight
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        (data_dir / "instance-id").write_text("test-id")
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        (state_dir / "klangk-test-id.pid").write_text("not-a-number")
+        settings = make_settings(
+            {
+                "KLANGKD_STATE_DIR": str(state_dir),
+                "KLANGKD_DATA_DIR": str(data_dir),
+            }
+        )
+        assert _check_pid_preflight(settings) is None
+
+
 class TestBuildApp:
     """Tests for build_app() composition root (#1426)."""
 


### PR DESCRIPTION
## Summary
- Add `_check_pid_preflight()` in the launcher that reads the PID file *before* the UDS is unlinked
- A second `klangkd` with the same config now aborts cleanly without touching the first instance's socket
- The lifespan's authoritative PID check remains as a belt-and-suspenders guard

**Root cause**: the launcher unconditionally called `os.unlink(uds_path)` before uvicorn started (and thus before the lifespan's PID check ran), so a second process would destroy the first instance's socket — causing Caddy to lose its upstream and killing both processes.

Fixes #1837

## Test plan
- [x] 8 new unit tests for `_check_pid_preflight` covering: no instance-id file, empty instance-id, no PID file, stale PID, own PID, live foreign PID, permission error, invalid PID content
- [x] All 3662 backend tests pass with 100% coverage