### PR TITLE
feat: add new-terminal command to workspace detail page

### DIFF
--- a/src/klangk/klangk/cli/client.py
+++ b/src/klangk/klangk/cli/client.py
@@ -596,8 +596,16 @@ class KlangkClient:
         """Close terminal window *index* in *name*; return the updated list."""
         return await self._terminals(name, close_index=index)
 
+    async def create_terminal(self, name: str, window_name: str) -> list[dict]:
+        """Create a new terminal window in workspace *name*; return updated list."""
+        return await self._terminals(name, new_window=window_name)
+
     async def _terminals(
-        self, name: str, *, close_index: int | None = None
+        self,
+        name: str,
+        *,
+        close_index: int | None = None,
+        new_window: str | None = None,
     ) -> list[dict]:
         try:
             ws = self.resolve_workspace(name)
@@ -624,6 +632,16 @@ class KlangkClient:
                             {
                                 "cmd": "terminal_close_window",
                                 "index": close_index,
+                            }
+                        )
+                    )
+                    windows = await self._recv_windows(conn)
+                if new_window is not None:
+                    await conn.send(
+                        json.dumps(
+                            {
+                                "cmd": "terminal_new_window",
+                                "name": new_window,
                             }
                         )
                     )

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -828,6 +828,7 @@ class WorkspaceDetailScreen(Screen):
         ("s", "stop", "Stop"),
         ("d", "duplicate", "Duplicate"),
         ("x", "delete", "Delete"),
+        ("n", "new_terminal", "New term"),
         ("delete", "delete_terminal", "Del term"),
     ]
 
@@ -923,6 +924,7 @@ class WorkspaceDetailScreen(Screen):
             ("s", "stop", stop_label),
             ("d", "duplicate", "Duplicate"),
             ("x", "delete", "Delete"),
+            ("n", "new_terminal", "New term"),
             ("delete", "delete_terminal", "Del term"),
         ]
 
@@ -1138,6 +1140,54 @@ class WorkspaceDetailScreen(Screen):
         self._terminals = windows
         self._render_terminals()
         self._msg(f"Deleted terminal {index}.")
+
+    def action_new_terminal(self) -> None:
+        if self._ws is None:
+            return
+        self.run_worker(self._do_new_terminal, exit_on_error=False)
+
+    async def _do_new_terminal(self) -> None:
+        # Pick a name that doesn't collide with existing terminal names.
+        existing = {w.get("name", "") for w in self._terminals}
+        for i in range(len(self._terminals), 100):
+            candidate = f"term-{i}"
+            if candidate not in existing:
+                break
+        else:
+            candidate = f"term-{len(self._terminals)}"  # pragma: no cover
+
+        self._msg(f"Creating terminal '{candidate}'…")
+        try:
+            windows = await self.app.tui_state.create_terminal(
+                self._name, candidate
+            )
+        except Exception as exc:
+            self._msg(f"Create failed: {exc}", error=True)
+            return
+        if not windows:
+            self._msg(
+                "Create failed — could not refresh terminals.", error=True
+            )
+            return
+        self._terminals = windows
+        self._render_terminals()
+
+        # Find the index of the newly created terminal and shell into it.
+        match = next((w for w in windows if w.get("name") == candidate), None)
+        if match is None:  # pragma: no cover
+            self._msg(f"Created terminal '{candidate}'.")
+            return
+        terminal_index = str(match.get("index", ""))
+        if not terminal_index:  # pragma: no cover
+            self._msg(f"Created terminal '{candidate}'.")
+            return
+        cmd = [sys.executable, "-m", "klangk.cli.main"]
+        server = self.app.tui_state.current_url()
+        if server:
+            cmd += ["--server", server]
+        cmd += ["shell", self._name, terminal_index]
+        with self.app.suspend():
+            subprocess.run(cmd)
 
     # --- actions ---
 

--- a/src/klangk/klangk/cli/tui/state.py
+++ b/src/klangk/klangk/cli/tui/state.py
@@ -180,6 +180,9 @@ class TuiState:
     async def close_terminal(self, name: str, index: int) -> list[dict]:
         return await self.client().close_terminal(name, index)
 
+    async def create_terminal(self, name: str, window_name: str) -> list[dict]:
+        return await self.client().create_terminal(name, window_name)
+
     # --- auth mode (probed live via /config) ---
 
     def auth_mode(self) -> str:

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -1208,6 +1208,51 @@ class TestKlangkClient:
         ):
             assert asyncio.run(client.close_terminal("alpha", 0)) == []
 
+    def test_create_terminal(self):
+        client = KlangkClient("http://test:8995", "token")
+        ws = Workspace(id="ws" + "0" * 60, name="alpha", created_at="x")
+        client.resolve_workspace = MagicMock(return_value=ws)
+        messages = [
+            json.dumps({"type": "container_ready"}),
+            json.dumps(
+                {"type": "event", "event": {"name": "container_ready"}}
+            ),
+            json.dumps(
+                {
+                    "type": "terminal_windows",
+                    "windows": [
+                        {"index": 0, "name": "main", "id": "@0"},
+                    ],
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "terminal_windows",
+                    "windows": [
+                        {"index": 0, "name": "main", "id": "@0"},
+                        {"index": 1, "name": "term-1", "id": "@1"},
+                    ],
+                }
+            ),
+        ]
+        mock_ws = AsyncMock()
+        mock_ws.recv = AsyncMock(side_effect=messages)
+        mock_ws.send = AsyncMock()
+        mock_ws.__aenter__ = AsyncMock(return_value=mock_ws)
+        mock_ws.__aexit__ = AsyncMock(return_value=False)
+        with patch(
+            "klangk.cli.transport.websockets.connect",
+            return_value=mock_ws,
+        ):
+            windows = asyncio.run(client.create_terminal("alpha", "term-1"))
+        assert len(windows) == 2
+        assert windows[1]["name"] == "term-1"
+        # Verify terminal_new_window was sent
+        sent = [json.loads(c.args[0]) for c in mock_ws.send.call_args_list]
+        new_cmds = [s for s in sent if s.get("cmd") == "terminal_new_window"]
+        assert len(new_cmds) == 1
+        assert new_cmds[0]["name"] == "term-1"
+
     def test_list_workspaces_parses_response(self):
         client = KlangkClient("http://test:8995", "valid-token")
         mock_resp = MagicMock()

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -390,6 +390,28 @@ def test_allow_autostart(monkeypatch, redirect_xdg):
     assert TuiState().allow_autostart() is False
 
 
+async def test_create_terminal_delegates(monkeypatch, redirect_xdg):
+
+    created = {}
+
+    async def fake_create(name, window_name):
+        created.update(name=name, window=window_name)
+        return [
+            {"index": 0, "name": "main"},
+            {"index": 1, "name": window_name},
+        ]
+
+    from unittest.mock import MagicMock
+
+    fake_client = MagicMock()
+    fake_client.create_terminal = fake_create
+    t = TuiState("https://x.example")
+    monkeypatch.setattr(t, "client", lambda: fake_client)
+    result = await t.create_terminal("ws1", "term-1")
+    assert created == {"name": "ws1", "window": "term-1"}
+    assert len(result) == 2
+
+
 def test_login_password_success(monkeypatch, redirect_xdg):
     captured = {}
 
@@ -2801,6 +2823,140 @@ async def test_detail_delete_terminal_empty_result(monkeypatch):
         assert (
             len(d.query_one("#term_list", ListView).query(ListItem)) == 2
         )  # unchanged
+
+
+async def test_detail_new_terminal(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    created = {}
+
+    async def _create(name, window_name):
+        created["name"] = window_name
+        return [
+            {"index": 0, "name": "main", "id": "@0"},
+            {"index": 1, "name": "build", "id": "@1"},
+            {"index": 2, "name": window_name, "id": "@2"},
+        ]
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    a = _wsobj("alpha")
+    st = _ws(
+        list_terminals=_async_terms,
+        close_terminal=_async_empty,
+        create_terminal=_create,
+    )
+    st.find_workspace = lambda n: a
+    st.current_url = lambda: "https://x.example"
+    spawned = []
+    monkeypatch.setattr(
+        scr.subprocess, "run", lambda cmd, **k: spawned.append(cmd)
+    )
+
+    from contextlib import contextmanager
+
+    @contextmanager
+    def fake_suspend():
+        yield
+
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.screen._load_terminals()
+        await pilot.pause()
+        monkeypatch.setattr(app, "suspend", fake_suspend)
+        d = app.screen
+        d.action_new_terminal()
+        for _ in range(5):
+            await pilot.pause()
+        await app.workers.wait_for_complete()
+        assert created["name"] == "term-2"
+        assert len(d.query_one("#term_list", ListView).query(ListItem)) == 3
+        assert len(spawned) == 1
+        assert spawned[0] == [
+            scr.sys.executable,
+            "-m",
+            "klangk.cli.main",
+            "--server",
+            "https://x.example",
+            "shell",
+            "alpha",
+            "2",
+        ]
+
+
+async def test_detail_new_terminal_failure(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    async def _create(name, window_name):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    a = _wsobj("alpha")
+    st = _ws(
+        list_terminals=_async_terms,
+        close_terminal=_async_empty,
+        create_terminal=_create,
+    )
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.screen._load_terminals()
+        await pilot.pause()
+        d = app.screen
+        await d._do_new_terminal()
+        await app.workers.wait_for_complete()
+        assert "Create failed" in str(d.query_one("#detail_msg").render())
+
+
+async def test_detail_new_terminal_empty_result(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    async def _create(name, window_name):
+        return []
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    a = _wsobj("alpha")
+    st = _ws(
+        list_terminals=_async_terms,
+        close_terminal=_async_empty,
+        create_terminal=_create,
+    )
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.screen._load_terminals()
+        await pilot.pause()
+        d = app.screen
+        await d._do_new_terminal()
+        await app.workers.wait_for_complete()
+        assert "Create failed" in str(d.query_one("#detail_msg").render())
+
+
+async def test_detail_new_terminal_no_workspace(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    def _raise(n):
+        raise RuntimeError("gone")
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    st = _ws(list_terminals=_async_terms, close_terminal=_async_empty)
+    st.find_workspace = _raise
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        d = app.screen
+        d.action_new_terminal()  # _ws is None -> no-op
+        await app.workers.wait_for_complete()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `n` keybinding on workspace detail page to create a new terminal and immediately shell into it
- Auto-generates terminal name (`term-N`) avoiding collisions with existing names
- After creation, refreshes terminal list and opens a shell session in the new terminal

Closes #1831