### PR TITLE
fix: prevent "Shared to me" tab redirect when empty (#1843)

### DIFF
--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -566,6 +566,7 @@ class MainScreen(Screen):
 
     def on_mount(self) -> None:
         self.app.title = "Klangk: Workspaces"
+        self._initial_focus_done = False
         self.refresh_lists()
         if self.app.tui_state.is_authenticated():
             self.app.run_worker(self._status_loop, name="status-ws")
@@ -682,7 +683,9 @@ class MainScreen(Screen):
             if wid:
                 self._ws_by_id[wid] = ws
         self._refresh_status()
-        self._focus_visible_list()
+        if not self._initial_focus_done:
+            self._initial_focus_done = True
+            self._focus_visible_list()
 
     async def _safe_list(self, *, owned: bool) -> list:
         state = self.app.tui_state

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -1524,6 +1524,37 @@ async def test_focus_visible_list_empty(monkeypatch):
         # No crash — focus stays elsewhere (not on a list with no items).
 
 
+async def test_shared_tab_stays_when_empty(monkeypatch):
+    """Switching to 'Shared to me' stays there even when the list is empty (#1843)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    app = KlangkApp(_ws(owned=[_wsobj("alpha")], shared=[]))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+        tc = app.screen.query_one("#ws_tabs")
+
+        # Switch to the "Shared to me" tab by finding its pane ID.
+        panes = list(tc.query("TabPane"))
+        shared_pane_id = panes[1].id
+        tc.active = shared_pane_id
+        await pilot.pause()
+        assert tc.active == shared_pane_id
+
+        # A subsequent refresh must not drag focus back to "Owned by me".
+        app.screen.refresh_lists()
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert tc.active == shared_pane_id
+
+
 async def test_down_from_tabs_enters_workspace_list(monkeypatch):
     # Down arrow from the tab strip focuses the workspace list (#1781).
     async def noop(*a, **k):


### PR DESCRIPTION
## Summary

- `_focus_visible_list()` was called after every async workspace list refresh, stealing focus back to the "Owned by me" tab (first in DOM order) even when the user had switched to "Shared to me"
- Now auto-focus only runs on the initial mount; subsequent refreshes (live status events, workspace changes) no longer interfere with tab selection

## Test plan

- [x] New test `test_shared_tab_stays_when_empty` verifies the shared tab remains active after a refresh
- [x] All 197 existing TUI tests pass

Closes #1843