### PR TITLE
TUI: validate server connectivity and credentials before switching

### DIFF
--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -227,6 +227,16 @@ class KlangkApp(App):
         if isinstance(top, MainScreen):
             top.refresh_lists()
 
+    def server_changed_needs_login(self) -> None:
+        """Switch server then show LoginScreen (invalid/missing creds)."""
+        while self.screen_stack and not isinstance(
+            self.screen_stack[-1], MainScreen
+        ):
+            self.pop_screen()
+        if self.screen_stack and isinstance(self.screen_stack[-1], MainScreen):
+            self.pop_screen()
+        self.push_screen(LoginScreen())
+
     def refresh_workspaces(self) -> None:
         """Refresh the workspace list on the MainScreen (if present)."""
         for screen in reversed(self.screen_stack):

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -2265,7 +2265,21 @@ class ServerSwitchScreen(Screen):
             self.app.server_changed()
 
     async def _do_switch_server(self, url: str) -> None:
+        msg = self.query_one("#switch_msg", Static)
+        msg.update("Checking server…")
+        status = await asyncio.to_thread(
+            self.app.tui_state.validate_server_for_switch, url
+        )
+        if status == "unreachable":
+            msg.update(
+                "[red]Cannot reach the server. "
+                "Check that klangkd is running.[/red]"
+            )
+            return
         await asyncio.to_thread(self.app.tui_state.switch_server, url)
+        if status == "auth_required":
+            self.app.server_changed_needs_login()
+            return
         self.app.server_changed()
 
 

--- a/src/klangk/klangk/cli/tui/state.py
+++ b/src/klangk/klangk/cli/tui/state.py
@@ -283,6 +283,36 @@ class TuiState:
 
     # --- server switching / adding ---
 
+    def validate_server_for_switch(self, url: str) -> str:
+        """Pre-flight check before switching to *url*.
+
+        Returns ``"ok"``, ``"unreachable"``, or ``"auth_required"``.
+        """
+        config = fetch_config(url)
+        if config == _UNREACHABLE:
+            return "unreachable"
+        if not isinstance(config, dict):
+            return "unreachable"
+        auth_mode = config.get("auth_modes", "password")
+        if auth_mode == "none":
+            return "ok"
+        token = self.state().get_token(url)
+        if token is None:
+            return "auth_required"
+        try:
+            resp = http_request(
+                url,
+                "GET",
+                "/api/v1/auth/me",
+                headers={"Authorization": f"Bearer {token}"},
+                timeout=5.0,
+            )
+            if resp.status_code == 401:
+                return "auth_required"
+        except httpx.HTTPError:
+            return "unreachable"
+        return "ok"
+
     def switch_server(self, url: str) -> None:
         state = self.state()
         state.active_server = url

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -1145,7 +1145,7 @@ async def test_server_switch_unreachable(monkeypatch):
     app = KlangkApp(st)
     async with app.run_test() as pilot:
         app.push_screen(ServerSwitchScreen())
-        await pilot.pause()
+        await pilot.wait_for_scheduled_animations()
         app.screen.on_list_view_selected(FakeSelected("https://b.example"))
         await app.workers.wait_for_complete()
         # switch_server should NOT have been called
@@ -1175,10 +1175,10 @@ async def test_server_switch_auth_required(monkeypatch):
     app = KlangkApp(st)
     async with app.run_test(size=(80, 24)) as pilot:
         app.push_screen(ServerSwitchScreen())
-        await pilot.pause()
+        await pilot.wait_for_scheduled_animations()
         app.screen.on_list_view_selected(FakeSelected("https://b.example"))
         await app.workers.wait_for_complete()
-        await pilot.pause()
+        await pilot.wait_for_scheduled_animations()
         # switch_server IS called (server changed)
         assert switched["url"] == "https://b.example"
         # should land on LoginScreen

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -357,6 +357,97 @@ def test_auth_mode_variants(monkeypatch, redirect_xdg):
     assert TuiState().auth_mode() == "password"
 
 
+def test_validate_server_for_switch_unreachable(monkeypatch, redirect_xdg):
+    t = TuiState("https://x.example")
+    monkeypatch.setattr(
+        tui_state_mod, "fetch_config", lambda url: tui_state_mod._UNREACHABLE
+    )
+    assert t.validate_server_for_switch("https://x.example") == "unreachable"
+
+
+def test_validate_server_for_switch_not_klangk(monkeypatch, redirect_xdg):
+    t = TuiState("https://x.example")
+    monkeypatch.setattr(tui_state_mod, "fetch_config", lambda url: None)
+    assert t.validate_server_for_switch("https://x.example") == "unreachable"
+
+
+def test_validate_server_for_switch_none_auth(monkeypatch, redirect_xdg):
+    t = TuiState("https://x.example")
+    monkeypatch.setattr(
+        tui_state_mod,
+        "fetch_config",
+        lambda url: {"auth_modes": "none"},
+    )
+    assert t.validate_server_for_switch("https://x.example") == "ok"
+
+
+def test_validate_server_for_switch_no_token(monkeypatch, redirect_xdg):
+    t = TuiState("https://x.example")
+    monkeypatch.setattr(
+        tui_state_mod,
+        "fetch_config",
+        lambda url: {"auth_modes": "password"},
+    )
+    assert t.validate_server_for_switch("https://x.example") == "auth_required"
+
+
+def test_validate_server_for_switch_token_valid(monkeypatch, redirect_xdg):
+    add_server_to_config("x", "https://x.example")
+    st = CLIState()
+    st.set_credentials("https://x.example", "me@test", "tok123")
+    st.save()
+    t = TuiState("https://x.example")
+    monkeypatch.setattr(
+        tui_state_mod,
+        "fetch_config",
+        lambda url: {"auth_modes": "password"},
+    )
+    monkeypatch.setattr(
+        tui_state_mod,
+        "http_request",
+        lambda *a, **kw: FakeResp(200, {"email": "me@test"}),
+    )
+    assert t.validate_server_for_switch("https://x.example") == "ok"
+
+
+def test_validate_server_for_switch_token_expired(monkeypatch, redirect_xdg):
+    add_server_to_config("x", "https://x.example")
+    st = CLIState()
+    st.set_credentials("https://x.example", "me@test", "old-tok")
+    st.save()
+    t = TuiState("https://x.example")
+    monkeypatch.setattr(
+        tui_state_mod,
+        "fetch_config",
+        lambda url: {"auth_modes": "password"},
+    )
+    monkeypatch.setattr(
+        tui_state_mod,
+        "http_request",
+        lambda *a, **kw: FakeResp(401, {}),
+    )
+    assert t.validate_server_for_switch("https://x.example") == "auth_required"
+
+
+def test_validate_server_for_switch_http_error(monkeypatch, redirect_xdg):
+    add_server_to_config("x", "https://x.example")
+    st = CLIState()
+    st.set_credentials("https://x.example", "me@test", "tok123")
+    st.save()
+    t = TuiState("https://x.example")
+    monkeypatch.setattr(
+        tui_state_mod,
+        "fetch_config",
+        lambda url: {"auth_modes": "password"},
+    )
+
+    def raise_error(*a, **kw):
+        raise httpx.ConnectError("fail")
+
+    monkeypatch.setattr(tui_state_mod, "http_request", raise_error)
+    assert t.validate_server_for_switch("https://x.example") == "unreachable"
+
+
 def test_oidc_providers(monkeypatch, redirect_xdg):
     monkeypatch.setattr(
         tui_state_mod,
@@ -948,6 +1039,7 @@ async def test_server_switch_and_add(monkeypatch):
     )
     switched = {}
     st.switch_server = lambda url: switched.setdefault("url", url)
+    st.validate_server_for_switch = lambda url: "ok"
     app = KlangkApp(st)
     async with app.run_test() as pilot:
         app.push_screen(ServerSwitchScreen())
@@ -1029,6 +1121,68 @@ async def test_server_switch_and_add(monkeypatch):
         await app5.workers.wait_for_complete()
         await pilot.pause()
         assert added5["a"] == ("staging", "https://s.example")
+
+
+# --- server switch validation (#1842) ---
+
+
+async def test_server_switch_unreachable(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+
+    st = _authed_state(
+        known_servers=lambda: [
+            tui_state_mod.ServerInfo("a", "https://a.example"),
+            tui_state_mod.ServerInfo("b", "https://b.example"),
+        ],
+        current_url=lambda: "https://a.example",
+    )
+    switched = {}
+    st.switch_server = lambda url: switched.setdefault("url", url)
+    st.validate_server_for_switch = lambda url: "unreachable"
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(ServerSwitchScreen())
+        await pilot.pause()
+        app.screen.on_list_view_selected(FakeSelected("https://b.example"))
+        await app.workers.wait_for_complete()
+        # switch_server should NOT have been called
+        assert switched == {}
+        # should still be on ServerSwitchScreen with error message
+        assert isinstance(app.screen, ServerSwitchScreen)
+        msg = str(app.screen.query_one("#switch_msg").render())
+        assert "Cannot reach" in msg
+
+
+async def test_server_switch_auth_required(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+
+    st = _authed_state(
+        known_servers=lambda: [
+            tui_state_mod.ServerInfo("a", "https://a.example"),
+            tui_state_mod.ServerInfo("b", "https://b.example"),
+        ],
+        current_url=lambda: "https://a.example",
+    )
+    switched = {}
+    st.switch_server = lambda url: switched.setdefault("url", url)
+    st.validate_server_for_switch = lambda url: "auth_required"
+    app = KlangkApp(st)
+    async with app.run_test(size=(80, 24)) as pilot:
+        app.push_screen(ServerSwitchScreen())
+        await pilot.pause()
+        app.screen.on_list_view_selected(FakeSelected("https://b.example"))
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        # switch_server IS called (server changed)
+        assert switched["url"] == "https://b.example"
+        # should land on LoginScreen
+        assert isinstance(app.screen, scr.LoginScreen)
 
 
 # --- edit server (#1762) ---


### PR DESCRIPTION
## Summary
- Add `validate_server_for_switch()` to `TuiState` — probes `/api/v1/config` for reachability and `/api/v1/auth/me` for token validity
- If server is unreachable, show error message and stay on the switch screen
- If credentials are missing or expired, switch server but redirect to the login screen
- If everything is OK, switch normally as before
- Add `server_changed_needs_login()` to `KlangkApp` for the auth-required flow

Fixes #1842

## Test plan
- [x] 7 new unit tests for `validate_server_for_switch` (unreachable, not-klangk, none-auth, no-token, valid-token, expired-token, http-error)
- [x] 2 new TUI integration tests (unreachable blocks switch, auth-required redirects to login)
- [x] Existing server switch test updated with validation mock
- [x] All 3666 backend tests pass with 100% coverage