### PR TITLE
Fix: always log egress port after caddy config load

### DIFF
--- a/src/klangk/klangk/caddy.py
+++ b/src/klangk/klangk/caddy.py
@@ -920,6 +920,15 @@ class CaddyWatchdog:
             level, msg = _classify_caddy_line(line)
             logger.log(level, "caddy: %s", msg)
 
+    def _log_listeners(self) -> None:
+        """Log which addresses Caddy is serving after a successful config load."""
+        s = self.app.state.settings
+        if s.port is not None:
+            logger.info("caddy browser listening on %s:%s", s.listen, s.port)
+        logger.info(
+            "caddy egress listening on %s:%s", s.egress_listen, s.egress_port
+        )
+
     async def _watch(
         self, bin_path: str
     ) -> None:  # pragma: no cover  – covered by the e2e suite
@@ -981,14 +990,7 @@ class CaddyWatchdog:
                 try:
                     await self.load_config()
                     load_ok = True
-                    port = self.app.state.settings.port
-                    if port is not None:
-                        listen = self.app.state.settings.listen
-                        logger.info(
-                            "caddy ingress listening on %s:%s",
-                            listen,
-                            port,
-                        )
+                    self._log_listeners()
                 except Exception as exc:  # noqa: BLE001
                     logger.error(
                         "caddy POST /load failed (killing for respawn): %s",

--- a/src/klangk/klangkd-tests/tests/test_caddy.py
+++ b/src/klangk/klangkd-tests/tests/test_caddy.py
@@ -1556,3 +1556,41 @@ class TestClassifyCaddyLine:
         )
         level, msg = _classify_caddy_line(line)
         assert level == logging.DEBUG
+
+
+# ---------------------------------------------------------------------------
+# CaddyWatchdog._log_listeners
+# ---------------------------------------------------------------------------
+
+
+class TestLogListeners:
+    """_log_listeners logs browser and/or egress ports at INFO."""
+
+    def _make_watchdog(
+        self,
+        *,
+        port=None,
+        listen="127.0.0.1",
+        egress_port="8995",
+        egress_listen="0.0.0.0",
+    ):
+        app = Mock()
+        app.state.settings.port = port
+        app.state.settings.listen = listen
+        app.state.settings.egress_port = egress_port
+        app.state.settings.egress_listen = egress_listen
+        return CaddyWatchdog(app)
+
+    def test_logs_both_ports(self, caplog):
+        wd = self._make_watchdog(port="8997", egress_port="8995")
+        with caplog.at_level(logging.INFO, logger="klangk.caddy"):
+            wd._log_listeners()
+        assert "caddy browser listening on 127.0.0.1:8997" in caplog.text
+        assert "caddy egress listening on 0.0.0.0:8995" in caplog.text
+
+    def test_logs_egress_only_when_port_is_none(self, caplog):
+        wd = self._make_watchdog(port=None, egress_port="8995")
+        with caplog.at_level(logging.INFO, logger="klangk.caddy"):
+            wd._log_listeners()
+        assert "browser" not in caplog.text
+        assert "caddy egress listening on 0.0.0.0:8995" in caplog.text


### PR DESCRIPTION
## Summary
- The browser port log from #1832 was gated on `settings.port` being non-None, which is only set in full/browser mode — so the log never fired in egress-only configs
- Now always logs the egress listener after config load; also logs the browser listener when `settings.port` is set
- Extracted `_log_listeners()` from `_watch()` for testability

Closes #1845

## Test plan
- [x] `test_logs_both_ports` — verifies both browser and egress lines when port is set
- [x] `test_logs_egress_only_when_port_is_none` — verifies only egress logged when port is None
- [x] Full backend suite passes (3667 passed, 100% coverage)