### PR TITLE
fix: login page URL input switches to existing server instead of erroring (#1849)

### DIFF
--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -341,15 +341,23 @@ class LoginScreen(SpatialNavScreen):
                 self.app.tui_state.switch_server, cfg.servers[raw].url
             )
         elif is_valid_server_spec(raw):
-            try:
+            # If a server with the derived alias already exists, switch to it
+            # instead of trying to add a duplicate (#1849).
+            alias = self._derive_alias(raw)
+            if alias in cfg.servers:
                 await asyncio.to_thread(
-                    self.app.tui_state.add_server,
-                    self._derive_alias(raw),
-                    raw,
+                    self.app.tui_state.switch_server, cfg.servers[alias].url
                 )
-            except AliasConflictError as exc:
-                self._set_message(str(exc), error=True)
-                return
+            else:
+                try:
+                    await asyncio.to_thread(
+                        self.app.tui_state.add_server,
+                        alias,
+                        raw,
+                    )
+                except AliasConflictError as exc:
+                    self._set_message(str(exc), error=True)
+                    return
         else:
             self._set_message(
                 "Enter a server URL (https://host), a socket path"

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -4350,6 +4350,44 @@ async def test_login_choose_server_duplicate_alias(monkeypatch):
         assert "already exists" in rendered
 
 
+async def test_login_url_switches_to_existing_alias(monkeypatch):
+    """Entering a URL whose derived alias already exists switches to it (#1849)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+
+    cfg = CLIConfig()
+    cfg.servers = {"prod.example": ServerEntry(url="https://prod.example")}
+    calls = {}
+
+    st = _st(
+        current_url=lambda: None,
+        known_servers=lambda: [
+            tui_state_mod.ServerInfo("prod.example", "https://prod.example")
+        ],
+        default_uds=lambda: None,
+        cfg=lambda: cfg,
+        auth_mode=lambda: "password",
+        email=lambda: None,
+        token=lambda: None,
+        is_authenticated=lambda: False,
+        switch_server=lambda url: calls.__setitem__("switch", url),
+        add_server=lambda alias, url, user=None: calls.__setitem__(
+            "add", (alias, url)
+        ),
+    )
+    app = KlangkApp(st)
+    async with app.run_test():
+        login = app.screen
+        # Entering the URL should switch, not try to add a duplicate.
+        login._choose_server("https://prod.example")
+        await app.workers.wait_for_complete()
+        assert calls.get("switch") == "https://prod.example"
+        assert "add" not in calls
+
+
 async def test_login_choose_invalid_server(monkeypatch):
     async def noop(*a, **k):
         return None


### PR DESCRIPTION
## Summary

- When entering a URL like `https://prod.example` on the login page, if a server with the derived alias (`prod.example`) already exists, the TUI now switches to that server instead of raising "Alias already exists"
- The `_do_choose_server` method now checks `cfg.servers` for the derived alias before attempting to add

## Test plan

- [x] New test `test_login_url_switches_to_existing_alias` verifies the switch-instead-of-error behavior
- [x] All 198 TUI tests pass

Closes #1849