### PR TITLE
Tidy klangkd.yaml.example

### DIFF
--- a/klangkd.yaml.example
+++ b/klangkd.yaml.example
@@ -6,22 +6,25 @@
 # klangkd reads this via: klangkd --config klangkd.yaml
 # devenv's backend process does this automatically.
 
-# --- Deployment shape ---
-# port: the browser/proxy port. Set it for full/browser mode (UI at http://localhost:8997).
-# Leave unset for headless mode (no browser listener; container-egress only).
+# port: the browser/proxy port. Set it for full/browser mode (UI at
+# http://localhost:8997). Leave unset for headless mode (no browser listener;
+# container-egress only).
 port: "8997"
-# listen: the browser interface address (rendered only when port is set).
+
+# listen: the ingress interface IP address (used only when port is set).
 listen: "127.0.0.1"
+
+# container ingress port and container idle timeout seconds
+egress_port: "8995"
+idle_timeout_seconds: "300"
+
+# "none", "password", "oidc", or "both" for UI (TUI/web) access
 auth_modes: password
 
 # --- Auth / identity ---
-jwt_secret: bark-dev-secret-change-in-production
+jwt_secret: secret-change-in-production
 default_user: admin@example.com
 default_password: admin
-
-# --- Server / network ---
-egress_port: "8995"
-idle_timeout_seconds: "300"
 
 # --- Storage ---
 # state_dir/data_dir are required (no defaults, #1461). In dev these resolve
@@ -29,6 +32,7 @@ idle_timeout_seconds: "300"
 # here or via the env vars.
 state_dir: "cmd:echo $DEVENV_STATE/klangk"
 data_dir: "cmd:echo $DEVENV_STATE/klangk/data"
+
 # The built Flutter web UI is served from here. In dev (editable source tree)
 # the in-package default (klangk/frontend) doesn't exist, so point at the
 # repo build output; an installed wheel leaves this unset for the in-package
@@ -43,7 +47,7 @@ image_name: klangk-workspace
 # allowed_domains enforcement. Unset (default) = unrestricted egress.
 # netfilter_hooks_dir: /var/lib/klangk/netfilter-hooks
 
-# --- Uncomment to enable OIDC ---
+# --- Uncomment to enable OIDC authentication ---
 # auth_modes: both
 # oidc_providers:
 #   - id: my-provider


### PR DESCRIPTION
## Summary
- Regroup settings for clarity (port/listen/egress together, auth together)
- Add `egress_port` explicitly so new users see both ports
- Improve comments (shorter lines, clearer descriptions)