### PR TITLE
Rename caddy log label from 'browser' to 'ingress'

### DIFF
--- a/src/klangk/klangk/caddy.py
+++ b/src/klangk/klangk/caddy.py
@@ -924,7 +924,7 @@ class CaddyWatchdog:
         """Log which addresses Caddy is serving after a successful config load."""
         s = self.app.state.settings
         if s.port is not None:
-            logger.info("caddy browser listening on %s:%s", s.listen, s.port)
+            logger.info("caddy ingress listening on %s:%s", s.listen, s.port)
         logger.info(
             "caddy egress listening on %s:%s", s.egress_listen, s.egress_port
         )

--- a/src/klangk/klangkd-tests/tests/test_caddy.py
+++ b/src/klangk/klangkd-tests/tests/test_caddy.py
@@ -1585,7 +1585,7 @@ class TestLogListeners:
         wd = self._make_watchdog(port="8997", egress_port="8995")
         with caplog.at_level(logging.INFO, logger="klangk.caddy"):
             wd._log_listeners()
-        assert "caddy browser listening on 127.0.0.1:8997" in caplog.text
+        assert "caddy ingress listening on 127.0.0.1:8997" in caplog.text
         assert "caddy egress listening on 0.0.0.0:8995" in caplog.text
 
     def test_logs_egress_only_when_port_is_none(self, caplog):


### PR DESCRIPTION
## Summary
- Change "caddy browser listening" to "caddy ingress listening" to match the existing terminology