### PR TITLE
fix: don't auto-shell after creating terminal on detail page

### DIFF
--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -1182,23 +1182,7 @@ class WorkspaceDetailScreen(Screen):
             return
         self._terminals = windows
         self._render_terminals()
-
-        # Find the index of the newly created terminal and shell into it.
-        match = next((w for w in windows if w.get("name") == candidate), None)
-        if match is None:  # pragma: no cover
-            self._msg(f"Created terminal '{candidate}'.")
-            return
-        terminal_index = str(match.get("index", ""))
-        if not terminal_index:  # pragma: no cover
-            self._msg(f"Created terminal '{candidate}'.")
-            return
-        cmd = [sys.executable, "-m", "klangk.cli.main"]
-        server = self.app.tui_state.current_url()
-        if server:
-            cmd += ["--server", server]
-        cmd += ["shell", self._name, terminal_index]
-        with self.app.suspend():
-            subprocess.run(cmd)
+        self._msg(f"Created terminal '{candidate}'.")
 
     # --- actions ---
 

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -2878,25 +2878,12 @@ async def test_detail_new_terminal(monkeypatch):
         create_terminal=_create,
     )
     st.find_workspace = lambda n: a
-    st.current_url = lambda: "https://x.example"
-    spawned = []
-    monkeypatch.setattr(
-        scr.subprocess, "run", lambda cmd, **k: spawned.append(cmd)
-    )
-
-    from contextlib import contextmanager
-
-    @contextmanager
-    def fake_suspend():
-        yield
-
     app = KlangkApp(st)
     async with app.run_test() as pilot:
         app.push_screen(WorkspaceDetailScreen("alpha"))
         await pilot.pause()
         await app.screen._load_terminals()
         await pilot.pause()
-        monkeypatch.setattr(app, "suspend", fake_suspend)
         d = app.screen
         d.action_new_terminal()
         for _ in range(5):
@@ -2904,17 +2891,7 @@ async def test_detail_new_terminal(monkeypatch):
         await app.workers.wait_for_complete()
         assert created["name"] == "term-2"
         assert len(d.query_one("#term_list", ListView).query(ListItem)) == 3
-        assert len(spawned) == 1
-        assert spawned[0] == [
-            scr.sys.executable,
-            "-m",
-            "klangk.cli.main",
-            "--server",
-            "https://x.example",
-            "shell",
-            "alpha",
-            "2",
-        ]
+        assert "Created terminal" in str(d.query_one("#detail_msg").render())
 
 
 async def test_detail_new_terminal_failure(monkeypatch):


### PR DESCRIPTION
## Summary

- After pressing `n` to create a new terminal on the workspace detail page, just refresh the terminal list and show a success message instead of auto-shelling into it
- User can select the terminal from the list to shell into it when ready

Closes #1853