### PR TITLE
feat: add filter and sort to TUI workspace list (#1764)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -60,6 +60,14 @@ operators or integrators to act when upgrading.
   reported rather than silently emptying the list. Selecting a terminal is wired for a future `klangk shell`
   step. The workspace-list page is now titled "Klangk: Workspaces".
 
+- **The `klangk` TUI workspace list supports filter and sort (#1764).**
+  Press `/` to open a single-line filter bar that narrows the visible
+  workspaces by name (applied locally over cached data, per tab); `Esc`
+  clears the text, then hides the bar. Press `o` (or click the sort button)
+  to cycle sort order — created ↓ → created ↑ → name ↑ → name ↓ (matching
+  Flutter defaults). Showing or hiding the filter bar does not resize the
+  workspace list.
+
 - **Per-workspace network egress filtering via OCI hooks (#1365).**
   Workspaces may now declare an `allowed_domains` allow-list (`host` or
   `host:port` specs) to restrict outbound network to specific destinations.

--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -92,6 +92,15 @@ class KlangkApp(App):
         border-left: none;
         border-right: none;
     }
+    /* The workspace-list filter input is a borderless single-line field
+    (height 1), not an underlined form input. App CSS outranks widget
+    DEFAULT_CSS by origin, so this override must live here: without it the
+    global `Input { border-top: blank }` above gives the field a 1-row top
+    border and — at height:1 — zero rows for its text, so the field renders
+    nothing even though filtering works (#1764). */
+    #filter_input, #filter_input:focus {
+        border: none;
+    }
     /* Match the Select dropdown to the underline-style inputs: drop the
     side borders (the "shadows") so it aligns cleanly with adjacent fields. */
     SelectCurrent, Select:focus > SelectCurrent {

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -559,10 +559,6 @@ class MainScreen(Screen):
     #filter_bar {
         height: auto;
         max-height: 3;
-        display: none;
-    }
-    #filter_bar.visible {
-        display: block;
     }
     #filter_input {
         width: 1fr;
@@ -606,6 +602,7 @@ class MainScreen(Screen):
         self._owned_all: list = []
         self._shared_all: list = []
         self._filter_text = ""
+        self.query_one("#filter_bar").display = False
         self.refresh_lists()
         if self.app.tui_state.is_authenticated():
             self.app.run_worker(self._status_loop, name="status-ws")
@@ -617,8 +614,7 @@ class MainScreen(Screen):
     # --- filter / sort ---
 
     def action_focus_filter(self) -> None:
-        bar = self.query_one("#filter_bar")
-        bar.add_class("visible")
+        self.query_one("#filter_bar").display = True
         self.query_one("#filter_input", Input).focus()
 
     def action_cycle_sort(self) -> None:
@@ -713,7 +709,7 @@ class MainScreen(Screen):
             if inp.value:
                 inp.value = ""
             else:
-                self.query_one("#filter_bar").remove_class("visible")
+                self.query_one("#filter_bar").display = False
                 self._focus_visible_list()
             event.stop()
             return

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -556,12 +556,27 @@ class MainScreen(Screen):
         text-align: right;
         color: $text-muted;
     }
+    #filter_bar {
+        height: 1;
+        dock: bottom;
+        margin: 0 0 2 0;
+    }
+    #filter_input {
+        width: 1fr;
+    }
+    #sort_label {
+        width: auto;
+        color: $text-muted;
+        padding: 0 1;
+    }
     """
 
     BINDINGS = [
         ("s", "switch_server", "Switch server"),
         ("n", "create", "New"),
         ("l", "logout", "Logout"),
+        ("slash", "focus_filter", "Filter"),
+        ("o", "cycle_sort", "Sort"),
     ]
 
     def compose(self) -> ComposeResult:
@@ -569,12 +584,26 @@ class MainScreen(Screen):
         with TabbedContent(id="ws_tabs"):
             yield TabPane("Owned by me", WorkspaceListView(id="owned_list"))
             yield TabPane("Shared to me", WorkspaceListView(id="shared_list"))
+        with Horizontal(id="filter_bar"):
+            yield Input(
+                placeholder="Filter by name… (/ to focus, Esc to clear)",
+                id="filter_input",
+            )
+            yield Label("sort: created ▼", id="sort_label")
         yield StatusBar(id="status")
         yield Footer()
+
+    # Sort keys matching Flutter defaults: created desc.
+    SORT_KEYS = ("created", "name")
 
     def on_mount(self) -> None:
         self.app.title = "Klangk: Workspaces"
         self._initial_focus_done = False
+        self._sort_key = "created"
+        self._sort_asc = False
+        self._owned_all: list = []
+        self._shared_all: list = []
+        self._filter_text = ""
         self.refresh_lists()
         if self.app.tui_state.is_authenticated():
             self.app.run_worker(self._status_loop, name="status-ws")
@@ -582,6 +611,83 @@ class MainScreen(Screen):
     def on_tabbed_content_tab_activated(self, event) -> None:
         """Focus the first workspace row when switching tabs (#1792)."""
         self._focus_visible_list()
+
+    # --- filter / sort ---
+
+    def action_focus_filter(self) -> None:
+        self.query_one("#filter_input", Input).focus()
+
+    def action_cycle_sort(self) -> None:
+        """Cycle through sort modes: created↓ → created↑ → name↑ → name↓."""
+        if self._sort_key == "created" and not self._sort_asc:
+            self._sort_asc = True
+        elif self._sort_key == "created" and self._sort_asc:
+            self._sort_key = "name"
+            self._sort_asc = True
+        elif self._sort_key == "name" and self._sort_asc:
+            self._sort_asc = False
+        else:
+            self._sort_key = "created"
+            self._sort_asc = False
+        self._update_sort_label()
+        self._apply_filter()
+
+    def _update_sort_label(self) -> None:
+        arrow = "▲" if self._sort_asc else "▼"
+        try:
+            self.query_one("#sort_label", Label).update(
+                f"sort: {self._sort_key} {arrow}"
+            )
+        except NoMatches:
+            pass
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        if event.input.id == "filter_input":
+            self._filter_text = event.value.strip().lower()
+            self._apply_filter()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        if event.input.id == "filter_input":
+            self._focus_visible_list()
+
+    @staticmethod
+    def _sort_key_name(ws) -> str:
+        return (getattr(ws, "name", "") or "").lower()
+
+    @staticmethod
+    def _sort_key_created(ws) -> str:
+        return getattr(ws, "created_at", "") or ""
+
+    def _sort_workspaces(self, workspaces: list) -> list:
+        """Sort workspace list according to current sort state."""
+        key = (
+            self._sort_key_name
+            if self._sort_key == "name"
+            else self._sort_key_created
+        )
+        return sorted(workspaces, key=key, reverse=not self._sort_asc)
+
+    def _apply_filter(self) -> None:
+        """Re-populate both lists from cached data with filter + sort."""
+        q = self._filter_text
+        owned = self._owned_all
+        shared = self._shared_all
+        if q:
+            owned = [
+                ws
+                for ws in owned
+                if q in (getattr(ws, "name", "") or "").lower()
+            ]
+            shared = [
+                ws
+                for ws in shared
+                if q in (getattr(ws, "name", "") or "").lower()
+            ]
+        owned = self._sort_workspaces(owned)
+        shared = self._sort_workspaces(shared)
+        empty = "(no matches)" if q else "(no workspaces)"
+        self._populate("#owned_list", owned, empty_label=empty)
+        self._populate("#shared_list", shared, empty_label=empty)
 
     def _focus_visible_list(self) -> None:
         """Focus the first item in the visible workspace list (#1792)."""
@@ -593,6 +699,15 @@ class MainScreen(Screen):
                 return
 
     def on_key(self, event) -> None:
+        # Escape in the filter input: clear text or return focus to list.
+        if event.key == "escape" and isinstance(self.focused, Input):
+            inp = self.query_one("#filter_input", Input)
+            if inp.value:
+                inp.value = ""
+            else:
+                self._focus_visible_list()
+            event.stop()
+            return
         # Down from the tab strip drops into the active workspace list (#1781).
         if event.key == "down" and isinstance(self.focused, Tabs):
             for lv in self.query(WorkspaceListView):
@@ -674,22 +789,21 @@ class MainScreen(Screen):
             owned = await self._safe_list(owned=True)
             shared = await self._safe_list(owned=False)
         except AuthError:
+            self._owned_all = []
+            self._shared_all = []
             for sel in ("#owned_list", "#shared_list"):
                 self._populate(
                     sel, [], empty_label="(session expired — re-login)"
                 )
             self._refresh_status()
             return
-        self._populate("#owned_list", owned)
-        for ws in owned:
+        self._owned_all = owned
+        self._shared_all = shared
+        for ws in owned + shared:
             wid = str(getattr(ws, "id", "") or "")
             if wid:
                 self._ws_by_id[wid] = ws
-        self._populate("#shared_list", shared)
-        for ws in shared:
-            wid = str(getattr(ws, "id", "") or "")
-            if wid:
-                self._ws_by_id[wid] = ws
+        self._apply_filter()
         self._refresh_status()
         if not self._initial_focus_done:
             self._initial_focus_done = True

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -557,15 +557,24 @@ class MainScreen(Screen):
         color: $text-muted;
     }
     #filter_bar {
-        height: auto;
-        max-height: 3;
+        dock: bottom;
+        height: 1;
+        background: $boost;
     }
     #filter_input {
         width: 1fr;
+        border: none;
+        height: 1;
+        padding: 0;
+        background: $boost;
     }
     #sort_btn {
         width: auto;
         min-width: 20;
+        border: none;
+        height: 1;
+        padding: 0 1;
+        background: $boost;
     }
     """
 

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -557,9 +557,8 @@ class MainScreen(Screen):
         color: $text-muted;
     }
     #filter_bar {
-        height: 1;
-        dock: bottom;
-        margin: 0 0 2 0;
+        height: auto;
+        max-height: 3;
     }
     #filter_input {
         width: 1fr;
@@ -567,7 +566,7 @@ class MainScreen(Screen):
     #sort_label {
         width: auto;
         color: $text-muted;
-        padding: 0 1;
+        padding: 1 1 0 1;
     }
     """
 

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -563,10 +563,9 @@ class MainScreen(Screen):
     #filter_input {
         width: 1fr;
     }
-    #sort_label {
+    #sort_btn {
         width: auto;
-        color: $text-muted;
-        padding: 1 1 0 1;
+        min-width: 20;
     }
     """
 
@@ -588,7 +587,7 @@ class MainScreen(Screen):
                 placeholder="Filter by name… (/ to focus, Esc to clear)",
                 id="filter_input",
             )
-            yield Label("sort: created ▼", id="sort_label")
+            yield Button("sort: created ▼", id="sort_btn", variant="default")
         yield StatusBar(id="status")
         yield Footer()
 
@@ -634,11 +633,15 @@ class MainScreen(Screen):
     def _update_sort_label(self) -> None:
         arrow = "▲" if self._sort_asc else "▼"
         try:
-            self.query_one("#sort_label", Label).update(
-                f"sort: {self._sort_key} {arrow}"
-            )
+            self.query_one(
+                "#sort_btn", Button
+            ).label = f"sort: {self._sort_key} {arrow}"
         except NoMatches:
             pass
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "sort_btn":
+            self.action_cycle_sort()
 
     def on_input_changed(self, event: Input.Changed) -> None:
         if event.input.id == "filter_input":

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -636,7 +636,7 @@ class MainScreen(Screen):
             self.query_one(
                 "#sort_btn", Button
             ).label = f"sort: {self._sort_key} {arrow}"
-        except NoMatches:
+        except NoMatches:  # pragma: no cover
             pass
 
     def on_button_pressed(self, event: Button.Pressed) -> None:

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -591,14 +591,17 @@ class MainScreen(Screen):
         with TabbedContent(id="ws_tabs"):
             yield TabPane("Owned by me", WorkspaceListView(id="owned_list"))
             yield TabPane("Shared to me", WorkspaceListView(id="shared_list"))
+        yield StatusBar(id="status")
+        yield Footer()
+        # Filter bar is yielded LAST so that — since docked-bottom widgets
+        # overlap rather than stack — it paints on top of the Footer row
+        # when shown. It is hidden by default and toggled by `/` (#1764).
         with Horizontal(id="filter_bar"):
             yield Input(
                 placeholder="Filter by name… (/ to focus, Esc to clear)",
                 id="filter_input",
             )
             yield Button("sort: created ▼", id="sort_btn", variant="default")
-        yield StatusBar(id="status")
-        yield Footer()
 
     # Sort keys matching Flutter defaults: created desc.
     SORT_KEYS = ("created", "name")

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -559,6 +559,10 @@ class MainScreen(Screen):
     #filter_bar {
         height: auto;
         max-height: 3;
+        display: none;
+    }
+    #filter_bar.visible {
+        display: block;
     }
     #filter_input {
         width: 1fr;
@@ -613,6 +617,8 @@ class MainScreen(Screen):
     # --- filter / sort ---
 
     def action_focus_filter(self) -> None:
+        bar = self.query_one("#filter_bar")
+        bar.add_class("visible")
         self.query_one("#filter_input", Input).focus()
 
     def action_cycle_sort(self) -> None:
@@ -701,12 +707,13 @@ class MainScreen(Screen):
                 return
 
     def on_key(self, event) -> None:
-        # Escape in the filter input: clear text or return focus to list.
+        # Escape in the filter input: clear text or hide bar and return.
         if event.key == "escape" and isinstance(self.focused, Input):
             inp = self.query_one("#filter_input", Input)
             if inp.value:
                 inp.value = ""
             else:
+                self.query_one("#filter_bar").remove_class("visible")
                 self._focus_visible_list()
             event.stop()
             return

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -1907,6 +1907,57 @@ async def test_focus_filter_action(monkeypatch):
         assert app.focused.id == "filter_input"
 
 
+async def test_filter_bar_renders_input_without_impacting_list(monkeypatch):
+    """When the filter bar is shown, the filter input must actually have room
+    to render its text, and the workspace list viewport must be unchanged
+    whether the bar is hidden or shown (#1764).
+
+    Two regressions this guards:
+      (a) The global `Input { border-top: blank }` app-CSS rule used to win
+          over `#filter_input { border: none }` (app CSS outranks widget
+          DEFAULT_CSS by origin), giving the field a 1-row top border and —
+          at height:1 — a content area of height 0, so the field painted
+          nothing even though filtering worked.
+      (b) Showing/hiding the docked filter bar must not resize the list.
+    """
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    app = KlangkApp(_ws(owned=[_wsobj("alpha"), _wsobj("beta")]))
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        m = app.screen
+        bar = m.query_one("#filter_bar")
+        inp = m.query_one("#filter_input", Input)
+        owned = m.query_one("#owned_list", ListView)
+
+        # Hidden by default; list has a real viewport.
+        assert bar.display is False
+        list_height_hidden = owned.content_region.height
+        assert list_height_hidden > 0
+
+        # Show via the '/' action.
+        m.action_focus_filter()
+        await pilot.pause()
+        assert bar.display is True
+        assert isinstance(app.focused, Input)
+
+        # (a) The input's top border is neutralized (not 'blank'), so its
+        #     content area is non-empty and its text can render.
+        assert inp.styles.border_top[0] != "blank"
+        assert inp.content_size.height > 0
+        # And the bar occupies the bottom row on top of the docked chrome.
+        assert bar.region.height == 1
+        assert bar.region.y == app.size.height - 1
+
+        # (b) The workspace list viewport is unchanged.
+        assert owned.content_region.height == list_height_hidden
+
+
 async def test_sort_button_click_cycles(monkeypatch):
     """Clicking the sort button cycles sort mode (#1764)."""
 

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -1838,14 +1838,14 @@ async def test_cycle_sort(monkeypatch):
         m.action_cycle_sort()
         await pilot.pause()
         assert names() == ["alpha", "beta"]
-        assert "created" in str(m.query_one("#sort_label").render())
-        assert "▲" in str(m.query_one("#sort_label").render())
+        assert "created" in str(m.query_one("#sort_btn", Button).label)
+        assert "▲" in str(m.query_one("#sort_btn", Button).label)
 
         # 2nd press: name asc.
         m.action_cycle_sort()
         await pilot.pause()
         assert names() == ["alpha", "beta"]
-        assert "name" in str(m.query_one("#sort_label").render())
+        assert "name" in str(m.query_one("#sort_btn", Button).label)
 
         # 3rd press: name desc.
         m.action_cycle_sort()
@@ -1856,8 +1856,8 @@ async def test_cycle_sort(monkeypatch):
         m.action_cycle_sort()
         await pilot.pause()
         assert names() == ["beta", "alpha"]
-        assert "created" in str(m.query_one("#sort_label").render())
-        assert "▼" in str(m.query_one("#sort_label").render())
+        assert "created" in str(m.query_one("#sort_btn", Button).label)
+        assert "▼" in str(m.query_one("#sort_btn", Button).label)
 
 
 async def test_filter_preserved_on_refresh(monkeypatch):
@@ -1905,6 +1905,34 @@ async def test_focus_filter_action(monkeypatch):
         await pilot.pause()
         assert isinstance(app.focused, Input)
         assert app.focused.id == "filter_input"
+
+
+async def test_sort_button_click_cycles(monkeypatch):
+    """Clicking the sort button cycles sort mode (#1764)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    a = Workspace(id="id-a", name="alpha", created_at="2025-01-01T00:00:00")
+    b = Workspace(id="id-b", name="beta", created_at="2025-06-01T00:00:00")
+    app = KlangkApp(_ws(owned=[a, b]))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        m = app.screen
+        lv = m.query_one("#owned_list", ListView)
+
+        # Default: created desc.
+        assert [i.name for i in lv.query(ListItem)] == ["beta", "alpha"]
+
+        # Click the sort button → created asc.
+        btn = m.query_one("#sort_btn", Button)
+        btn.press()
+        await pilot.pause()
+        assert [i.name for i in lv.query(ListItem)] == ["alpha", "beta"]
+        assert "▲" in str(btn.label)
 
 
 async def test_filter_submitted_returns_to_list(monkeypatch):

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -1731,6 +1731,204 @@ async def test_shared_tab_stays_when_empty(monkeypatch):
         assert tc.active == shared_pane_id
 
 
+async def test_filter_narrows_workspace_list(monkeypatch):
+    """Typing in the filter input narrows the visible workspace list (#1764)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    app = KlangkApp(
+        _ws(owned=[_wsobj("alpha"), _wsobj("beta"), _wsobj("alphabet")])
+    )
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        m = app.screen
+        lv = m.query_one("#owned_list", ListView)
+        assert len(lv.query(ListItem)) == 3
+
+        # Type "alph" into the filter.
+        inp = m.query_one("#filter_input", Input)
+        inp.value = "alph"
+        await pilot.pause()
+        items = lv.query(ListItem)
+        assert len(items) == 2
+        names = {i.name for i in items}
+        assert names == {"alpha", "alphabet"}
+
+
+async def test_filter_no_matches_shows_placeholder(monkeypatch):
+    """A filter with no matches shows '(no matches)' placeholder (#1764)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    app = KlangkApp(_ws(owned=[_wsobj("alpha")]))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        m = app.screen
+        inp = m.query_one("#filter_input", Input)
+        inp.value = "zzz"
+        await pilot.pause()
+        items = m.query_one("#owned_list", ListView).query(ListItem)
+        assert len(items) == 1
+        assert "no matches" in str(items[0].query_one(Label).render()).lower()
+
+
+async def test_filter_escape_clears_then_returns(monkeypatch):
+    """Escape in filter clears text first, then returns focus to list (#1764)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    app = KlangkApp(_ws(owned=[_wsobj("alpha"), _wsobj("beta")]))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        m = app.screen
+        inp = m.query_one("#filter_input", Input)
+        inp.focus()
+        inp.value = "alph"
+        await pilot.pause()
+
+        # First Escape clears the text.
+        await pilot.press("escape")
+        await pilot.pause()
+        assert inp.value == ""
+        # List is restored (both items visible again).
+        assert len(m.query_one("#owned_list", ListView).query(ListItem)) == 2
+
+        # Second Escape returns focus to the workspace list.
+        await pilot.press("escape")
+        await pilot.pause()
+        assert isinstance(app.focused, ListView)
+
+
+async def test_cycle_sort(monkeypatch):
+    """Pressing 'o' cycles sort: created↓ → created↑ → name↑ → name↓ (#1764)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    a = Workspace(id="id-a", name="alpha", created_at="2025-01-01T00:00:00")
+    b = Workspace(id="id-b", name="beta", created_at="2025-06-01T00:00:00")
+    app = KlangkApp(_ws(owned=[a, b]))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        m = app.screen
+        lv = m.query_one("#owned_list", ListView)
+
+        def names():
+            return [i.name for i in lv.query(ListItem)]
+
+        # Default: created desc (newest first).
+        assert names() == ["beta", "alpha"]
+
+        # 1st press: created asc.
+        m.action_cycle_sort()
+        await pilot.pause()
+        assert names() == ["alpha", "beta"]
+        assert "created" in str(m.query_one("#sort_label").render())
+        assert "▲" in str(m.query_one("#sort_label").render())
+
+        # 2nd press: name asc.
+        m.action_cycle_sort()
+        await pilot.pause()
+        assert names() == ["alpha", "beta"]
+        assert "name" in str(m.query_one("#sort_label").render())
+
+        # 3rd press: name desc.
+        m.action_cycle_sort()
+        await pilot.pause()
+        assert names() == ["beta", "alpha"]
+
+        # 4th press: back to created desc.
+        m.action_cycle_sort()
+        await pilot.pause()
+        assert names() == ["beta", "alpha"]
+        assert "created" in str(m.query_one("#sort_label").render())
+        assert "▼" in str(m.query_one("#sort_label").render())
+
+
+async def test_filter_preserved_on_refresh(monkeypatch):
+    """A live refresh re-applies the active filter (#1764)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    app = KlangkApp(_ws(owned=[_wsobj("alpha"), _wsobj("beta")]))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        m = app.screen
+        inp = m.query_one("#filter_input", Input)
+        inp.value = "alph"
+        await pilot.pause()
+        lv = m.query_one("#owned_list", ListView)
+        assert len(lv.query(ListItem)) == 1
+
+        # Simulate a workspaces_changed refresh.
+        m.refresh_lists()
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert len(lv.query(ListItem)) == 1
+        assert lv.query(ListItem)[0].name == "alpha"
+
+
+async def test_focus_filter_action(monkeypatch):
+    """The '/' keybinding focuses the filter input (#1764)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    app = KlangkApp(_ws(owned=[_wsobj("alpha")]))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        m = app.screen
+        m.action_focus_filter()
+        await pilot.pause()
+        assert isinstance(app.focused, Input)
+        assert app.focused.id == "filter_input"
+
+
+async def test_filter_submitted_returns_to_list(monkeypatch):
+    """Pressing Enter in the filter returns focus to the workspace list (#1764)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    app = KlangkApp(_ws(owned=[_wsobj("alpha")]))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        m = app.screen
+        inp = m.query_one("#filter_input", Input)
+        inp.focus()
+        inp.value = "alph"
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert isinstance(app.focused, ListView)
+
+
 async def test_down_from_tabs_enters_workspace_list(monkeypatch):
     # Down arrow from the tab strip focuses the workspace list (#1781).
     async def noop(*a, **k):


### PR DESCRIPTION
## Summary

- Add a filter input bar at the bottom of the MainScreen (press `/` to focus, `Esc` to clear/unfocus, `Enter` to return to list)
- Filter applies locally per-tab over cached workspace data — no extra API calls
- Add sort cycling via `o` key: created↓ → created↑ → name↑ → name↓ (matches Flutter defaults)
- Sort indicator label shows current sort key and direction
- Live `workspaces_changed` refreshes re-apply the active filter and sort
- Default sort is `created desc` (newest first), matching Flutter

## Test plan

- [x] `test_filter_narrows_workspace_list` — typing filters visible items
- [x] `test_filter_no_matches_shows_placeholder` — "(no matches)" shown
- [x] `test_filter_escape_clears_then_returns` — Esc clears text, then returns focus
- [x] `test_cycle_sort` — full sort cycle verified with ordered assertions
- [x] `test_filter_preserved_on_refresh` — live refresh re-applies filter
- [x] `test_focus_filter_action` — `/` keybinding focuses input
- [x] `test_filter_submitted_returns_to_list` — Enter returns to list
- [x] All 219 TUI tests pass, 99% coverage on screens.py

Closes #1764