### PR TITLE
feat(cli): add klangk stop/start commands (#1750)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -27,6 +27,12 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **`klangk stop` and `klangk start` commands** stop and (re)start a
+  workspace container (#1750), closing the CLI parity gap with the TUI and
+  Flutter app (which already reach shutdown via `POST /api/v1/workspaces/{id}/stop`).
+  Both are thin wrappers over the existing REST endpoints, mirroring
+  `klangk restart`.
+
 - **Bare `klangk` (no subcommand) launches an interactive textual TUI on a
   real terminal (#1746).** The TUI is the foundation of the terminal client:
   in-TUI login (local/password, with no-auth auto-login and OIDC hand-off to

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -191,6 +191,8 @@ klangk monitor --type service_health | jq .           # pretty-print health tran
 klangk monitor --type service_health -- sh -c '[ "$KLANGK_HEALTHY" = false ] && notify-send "klangk" "$KLANGK_HEALTH_MESSAGE"'  # alert with the failure reason
 klangk sync ~/src my-project:/home/klangk/work      # sync files to/from the container
 klangk rm my-project                # delete a workspace
+klangk stop my-project              # stop the container for a workspace
+klangk start my-project             # start the container for a workspace
 klangk restart my-project           # restart the container for a workspace (owner only)
 klangk export my-project            # export workspace to my-project.tar.gz (admin only)
 klangk export my-project -o bak.tar.gz  # export to specific file

--- a/src/klangk/klangk/cli/README.md
+++ b/src/klangk/klangk/cli/README.md
@@ -26,6 +26,7 @@ klangk shell my-project               # drop into a shell
 - `exec` — run a command in a container
 - `sync` — sync files to/from a container
 - `create` / `rm` / `edit` / `dup` — manage workspaces
+- `stop` / `start` / `restart` — stop, start, or restart a workspace container
 - `export` / `import` — archive and restore workspaces
 - `terminals` / `share` / `unshare` — shared terminal management
 - `volumes` — manage named volumes

--- a/src/klangk/klangk/cli/main.py
+++ b/src/klangk/klangk/cli/main.py
@@ -643,6 +643,34 @@ def restart(
     typer.echo(f"Restarted workspace {name}")
 
 
+@app.command("stop")
+def stop(
+    name: str = typer.Argument(..., help="Workspace name"),
+) -> None:
+    """Stop the container for a workspace."""
+    require_auth()
+    try:
+        _client().stop_workspace(name)
+    except WorkspaceNotFoundError:
+        _err.print(f"[red]No workspace named[/red] '{name}'")
+        raise typer.Exit(code=1) from None
+    typer.echo(f"Stopped workspace {name}")
+
+
+@app.command("start")
+def start(
+    name: str = typer.Argument(..., help="Workspace name"),
+) -> None:
+    """Start the container for a workspace."""
+    require_auth()
+    try:
+        _client().start_workspace(name)
+    except WorkspaceNotFoundError:
+        _err.print(f"[red]No workspace named[/red] '{name}'")
+        raise typer.Exit(code=1) from None
+    typer.echo(f"Started workspace {name}")
+
+
 @app.command("export")
 def export_workspace(
     name: str = typer.Argument(..., help="Workspace name"),

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -978,6 +978,52 @@ class TestMainCLI:
         with pytest.raises(typer.Exit):
             main.restart("nope")
 
+    def test_stop_workspace(self, logged_in_cfg, monkeypatch):
+        from klangk.cli import main
+
+        client = MagicMock()
+        monkeypatch.setattr(main, "_client", lambda: client)
+
+        with patch("typer.echo"):
+            main.stop("my-ws")
+        client.stop_workspace.assert_called_once_with("my-ws")
+
+    def test_stop_workspace_not_found(self, logged_in_cfg, monkeypatch):
+        import typer
+
+        from klangk.cli.client import WorkspaceNotFoundError
+        from klangk.cli import main
+
+        client = MagicMock()
+        client.stop_workspace.side_effect = WorkspaceNotFoundError("nope")
+        monkeypatch.setattr(main, "_client", lambda: client)
+
+        with pytest.raises(typer.Exit):
+            main.stop("nope")
+
+    def test_start_workspace(self, logged_in_cfg, monkeypatch):
+        from klangk.cli import main
+
+        client = MagicMock()
+        monkeypatch.setattr(main, "_client", lambda: client)
+
+        with patch("typer.echo"):
+            main.start("my-ws")
+        client.start_workspace.assert_called_once_with("my-ws")
+
+    def test_start_workspace_not_found(self, logged_in_cfg, monkeypatch):
+        import typer
+
+        from klangk.cli.client import WorkspaceNotFoundError
+        from klangk.cli import main
+
+        client = MagicMock()
+        client.start_workspace.side_effect = WorkspaceNotFoundError("nope")
+        monkeypatch.setattr(main, "_client", lambda: client)
+
+        with pytest.raises(typer.Exit):
+            main.start("nope")
+
     def test_shell_requires_auth(self, tmp_path, monkeypatch):
         import typer
         from klangk.cli import main

--- a/src/klangk/klangkd-tests/tests/test_api.py
+++ b/src/klangk/klangkd-tests/tests/test_api.py
@@ -2049,6 +2049,11 @@ class TestWorkspaceRoutes:
                 "notify_workspace_killed",
                 new_callable=AsyncMock,
             ) as mock_killed,
+            patch.object(
+                app.state.agents,
+                "stop_session",
+                new_callable=AsyncMock,
+            ) as mock_stop_session,
         ):
             resp = await client.post(
                 f"/api/v1/workspaces/{ws_id}/stop", headers=headers
@@ -2057,6 +2062,9 @@ class TestWorkspaceRoutes:
         assert resp.json()["status"] == "stopped"
         mock_killed.assert_awaited_once_with(ws_id)
         mock_stop.assert_awaited_once_with("cid-stop")
+        # REST /stop tears down the Pi RPC subprocess for the workspace
+        # (via reset_workspace_state -> reset_workspace); lock the contract.
+        mock_stop_session.assert_awaited_once_with(ws_id)
         registry.states.pop(ws_id, None)
 
     async def test_start_workspace(self, client, app, user):


### PR DESCRIPTION
## Summary

Adds `klangk stop <workspace>` and `klangk start <workspace>` Typer commands, mirroring the existing `klangk restart`, backed by the already-implemented `KlangkClient.stop_workspace` / `start_workspace` REST methods. Closes the CLI parity gap with the TUI and Flutter app, which already reach shutdown via `POST /api/v1/workspaces/{id}/stop`.

Part of #1750 (Stage 1). The convergence cleanup — retiring the redundant WS `shutdown_container` handler and migrating the Flutter UI to REST — is tracked in #1858.

## What's in this PR

- **`cli/main.py`** — `stop` and `start` commands, grouped right after `restart` in `--help`:
  ```
  restart   Restart the container for a workspace.
  stop      Stop the container for a workspace.
  start     Start the container for a workspace.
  ```
- **`test_cli_main.py`** — 4 command tests (stop/start × happy-path + not-found), mirroring the `restart` tests.
- **`test_api.py`** — locks the REST `/stop` agent-teardown contract: asserts `agents.stop_session` is awaited with the workspace id. The teardown already happened (via `reset_workspace_state → reset_workspace`, which calls `agents.stop_session`); this is a regression guard, not a behavior change.
- **`docs/changes.md`** — `Added` entry under `[Unreleased]`.

## What's deliberately not in this PR

- Retiring the WS `shutdown_container` handler — it's still the path the Flutter `WorkspaceSettingsPanel` uses, so deleting it here would break the Flutter button. That retirement + the Flutter migration land together in #1858 (they're coupled).
- The #1743 locked-decision amendment (also #1858).

## Verification

- `klangk --help` shows `stop` / `start` after `restart`.
- Full Python suite, the way CI runs it:
  ```
  devenv --quiet -O dotenv.enable:bool false shell -- \
    python -m pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -v -n auto
  ```
  → **3689 passed, 100% coverage.**

## Context

#1750 was rewritten to match the as-shipped code before this work: shutdown was already implemented everywhere *except* the CLI command layer (the TUI action, the REST `/stop` endpoint, and the client methods all pre-existed), and the semantics are stop-and-remove everywhere (not stop-but-retain, as the original issue assumed). The "REST vs WS" question raised in #1750 is resolved in favor of REST; the WS retirement is the follow-up (#1858).

Refs #1750, #1858.
