### PR TITLE
fix(tui): shorten no-server login hint to one line

### DIFF
--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -281,8 +281,7 @@ class LoginScreen(SpatialNavScreen):
 
     def _show_no_server(self) -> None:
         self.query_one("#server_line", Static).update(
-            "No server selected. Pick one below or enter a URL,"
-            " then press 'Use server'."
+            "No server selected — pick one or enter a URL below."
         )
         self._disable_credentials()
 


### PR DESCRIPTION
## Summary

The placeholder hint shown at the top of the TUI login screen when no
server is selected wrapped across two lines, leaving the screen looking
crammed. Rephrase it so it fits on a single line.

## Changes

`src/klangk/klangk/cli/tui/screens.py` — `_show_no_server()`:

```
- "No server selected. Pick one below or enter a URL,"
- " then press 'Use server'."
+ "No server selected — pick one or enter a URL below."
```

71 chars → 51 chars.

## Test plan

- [x] Full Python suite (CI invocation): `pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -v -n auto` — 3702 passed, 100% coverage.
- [x] The two `test_tui.py` assertions that check `"No server selected"` is a substring of `#server_line` still hold (the phrase is preserved).

Closes #1861
