### PR TITLE
feat(tui): inline terminal-scoped keybindings on workspace detail (#1860)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -925,6 +925,12 @@ set-password <email>` (set a known password for the default user — whose
 
 ### Fixed
 
+- **TUI workspace detail: terminal delete now shows in-flight feedback (#1863).**
+  Pressing `delete` on a selected terminal now shows a `Deleting terminal …`
+  status message while the close request is in flight (mirroring the existing
+  "Creating terminal …" feedback), instead of the screen appearing hung
+  until the list updates.
+
 - **The nginx proxy engine stays up under a plain `systemctl start` with no
   operator log workaround (#1550).** nginx's `access_log` directive has no
   `stdout` keyword, so it always `open(2)`s its destination by path; under

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -407,6 +407,13 @@ invitations send` stay email-only (a deliverable address is required);
 
 ### Changed
 
+- **TUI workspace detail: terminal-scoped keybindings moved inline (#1860).**
+  The `n` (new terminal) and `delete` (delete terminal) keys no longer appear
+  in the bottom Footer — their hints now render on the Terminals list header
+  (`[n] new  [⌫] delete`), next to the list they act on. The Footer is now
+  workspace-scoped only. The workspace-delete key `x` is relabeled `Delete` →
+  `Del ws` to disambiguate it from deleting a terminal.
+
 - **Environment variables are now split into four prefixed families
   (#1653).** The single `KLANGK_` prefix is repointed at the component each
   var targets:

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -963,20 +963,31 @@ class WorkspaceDetailScreen(Screen):
     """Read-only workspace detail + restart / duplicate / delete actions."""
 
     BINDINGS = [
-        ("escape", "app.pop_screen", "Back"),
-        ("e", "edit", "Edit"),
-        ("r", "restart", "Restart"),
-        ("s", "stop", "Stop"),
-        ("d", "duplicate", "Duplicate"),
-        ("x", "delete", "Delete"),
-        ("n", "new_terminal", "New term"),
-        ("delete", "delete_terminal", "Del term"),
+        Binding("escape", "app.pop_screen", "Back"),
+        Binding("e", "edit", "Edit"),
+        Binding("r", "restart", "Restart"),
+        Binding("s", "stop", "Stop"),
+        Binding("d", "duplicate", "Duplicate"),
+        Binding("x", "delete", "Del ws"),
+        # Terminal-scoped keys are hidden from the Footer — their hints
+        # are shown inline on the Terminals list header instead (#1860).
+        Binding("n", "new_terminal", "New term", show=False),
+        Binding("delete", "delete_terminal", "Del term", show=False),
     ]
 
     DEFAULT_CSS = """
+    WorkspaceDetailScreen #term_header {
+        height: 1;
+        margin-bottom: 0;
+    }
     WorkspaceDetailScreen #term_label {
         text-style: bold;
-        margin-bottom: 0;
+        width: auto;
+    }
+    WorkspaceDetailScreen #term_hints {
+        width: 1fr;
+        text-align: right;
+        color: $text-muted;
     }
     WorkspaceDetailScreen #term_list {
         height: auto;
@@ -998,7 +1009,11 @@ class WorkspaceDetailScreen(Screen):
     def compose(self) -> ComposeResult:
         yield Header(show_clock=False)
         yield Vertical(
-            Static("Terminals", id="term_label"),
+            Horizontal(
+                Static("Terminals", id="term_label"),
+                Static("[n] new  [⌿] delete", id="term_hints", markup=False),
+                id="term_header",
+            ),
             SpatialListView(id="term_list"),
             Static("", id="detail_body"),
             Static("", id="detail_msg"),
@@ -1056,17 +1071,22 @@ class WorkspaceDetailScreen(Screen):
         self.app.refresh_workspaces()
 
     @staticmethod
-    def _bindings_list(stop_label: str = "Stop") -> list:
-        """Bindings with a dynamic label for the stop/start key (#1791)."""
+    def _bindings_list(stop_label: str = "Stop") -> list[Binding]:
+        """Workspace-scoped keybindings for the Footer.
+
+        The ``s`` label toggles Stop/Start (#1791). Terminal-scoped keys
+        (new / delete term) are hidden here — their hints render inline on
+        the Terminals list header instead (#1860).
+        """
         return [
-            ("escape", "app.pop_screen", "Back"),
-            ("e", "edit", "Edit"),
-            ("r", "restart", "Restart"),
-            ("s", "stop", stop_label),
-            ("d", "duplicate", "Duplicate"),
-            ("x", "delete", "Delete"),
-            ("n", "new_terminal", "New term"),
-            ("delete", "delete_terminal", "Del term"),
+            Binding("escape", "app.pop_screen", "Back"),
+            Binding("e", "edit", "Edit"),
+            Binding("r", "restart", "Restart"),
+            Binding("s", "stop", stop_label),
+            Binding("d", "duplicate", "Duplicate"),
+            Binding("x", "delete", "Del ws"),
+            Binding("n", "new_terminal", "New term", show=False),
+            Binding("delete", "delete_terminal", "Del term", show=False),
         ]
 
     def _display(self) -> None:
@@ -1076,10 +1096,7 @@ class WorkspaceDetailScreen(Screen):
             body.update(Text(self._load_error or "Could not load workspace."))
             return
         # Toggle the 's' binding label between Stop / Start.
-        self.BINDINGS = [
-            Binding(*b)
-            for b in self._bindings_list("Stop" if ws.running else "Start")
-        ]
+        self.BINDINGS = self._bindings_list("Stop" if ws.running else "Start")
         self.refresh_bindings()
         lines = [
             f"running: {'yes' if ws.running else 'no'}",

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -1281,6 +1281,7 @@ class WorkspaceDetailScreen(Screen):
         self.run_worker(self._do_delete_terminal(index), exit_on_error=False)
 
     async def _do_delete_terminal(self, index: int) -> None:
+        self._msg(f"Deleting terminal {index}…")
         try:
             windows = await self.app.tui_state.close_terminal(
                 self._name, index

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -2448,6 +2448,46 @@ async def test_detail_start_when_stopped(monkeypatch):
         assert "uptime:" in str(app.screen.query_one("#detail_body").render())
 
 
+async def test_detail_terminal_actions_inline_not_in_footer(monkeypatch):
+    """#1860: terminal-scoped keys are hinted inline on the list header and
+    hidden from the Footer; the workspace-delete key is labeled 'Del ws'."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    st = _ws()
+    st.find_workspace = lambda n: _wsobj("alpha", running=True)
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+        # (a) Terminal action hints render on the list header, with the
+        # literal `[n]` keycap intact (not eaten as Rich markup).
+        hints = str(app.screen.query_one("#term_hints").render())
+        assert "[n]" in hints
+        assert "new" in hints
+        assert "delete" in hints
+
+        bindings = {b.key: b for b in app.screen.BINDINGS}
+
+        # (b) Terminal keys still exist (so the keys work) but are hidden
+        # from the Footer.
+        assert "n" in bindings and "delete" in bindings
+        assert bindings["n"].show is False
+        assert bindings["delete"].show is False
+
+        # (c) Workspace-scoped keys remain visible ...
+        for key in ("e", "r", "s", "d", "x"):
+            assert bindings[key].show is True
+
+        # (d) ... and the workspace-delete key is labeled 'Del ws' (#1860).
+        assert bindings["x"].description == "Del ws"
+
+
 async def test_detail_uptime_ticks(monkeypatch):
     """#1814: uptime display refreshes via the periodic timer."""
     import time as _time

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -3104,6 +3104,48 @@ async def test_detail_delete_terminal(monkeypatch):
         assert len(d.query_one("#term_list", ListView).query(ListItem)) == 1
 
 
+async def test_detail_delete_terminal_shows_inflight_msg(monkeypatch):
+    """A 'Deleting terminal …' message shows while the close call is in
+    flight, so the screen doesn't appear hung (#1863)."""
+
+    import asyncio
+
+    async def noop(*a, **k):
+        return None
+
+    gate = asyncio.Event()
+
+    async def _close(name, index):
+        await gate.wait()
+        return [{"index": 0, "name": "main", "id": "@0"}]
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    a = _wsobj("alpha")
+    st = _ws(list_terminals=_async_terms, close_terminal=_close)
+    st.find_workspace = lambda n: a
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(WorkspaceDetailScreen("alpha"))
+        await pilot.pause()
+        await app.screen._load_terminals()
+        await pilot.pause()
+        d = app.screen
+        d.query_one("#term_list").index = 1
+        d.action_delete_terminal()
+        # While close_terminal is blocked on the gate, the in-flight
+        # message must already be visible.
+        for _ in range(3):
+            await pilot.pause()
+        assert "Deleting terminal 1" in str(
+            d.query_one("#detail_msg").render()
+        )
+        # Releasing the close call replaces it with the success message.
+        gate.set()
+        for _ in range(3):
+            await pilot.pause()
+        assert "Deleted terminal 1" in str(d.query_one("#detail_msg").render())
+
+
 async def test_detail_delete_terminal_failure(monkeypatch):
     async def noop(*a, **k):
         return None


### PR DESCRIPTION
Closes #1860.

## What & why

The workspace detail Footer listed every keybinding in one flat, unlabeled row,
mixing workspace-scoped actions (Edit / Restart / Stop / Duplicate / Delete)
with terminal-scoped ones (New term / Del term). The bare `Delete` label — `x`,
which deletes the **workspace** — sat next to `New term` and read like it could
delete the selected terminal; the actual terminal-delete binding (`⌫`) wasn't
even visible at common widths.

Separately, deleting a terminal showed **no in-flight feedback** — the delete
worker went straight into the `close_terminal` await with no status message, so
the screen appeared hung until the list updated (while `New term` already showed
"Creating terminal …"). This PR fixes both.

## Change

**Scope grouping (terminal keybindings → inline on the list header).** Pattern
used by file-manager TUIs; validated against lazygit's context-scoped footers
and wave's labeled two-zone status bar (discussion in the issue).

- `WorkspaceDetailScreen`: the term header is now a `Horizontal` carrying
  inline hints `[n] new  [⌫] delete` (right-aligned; `markup=False` so the
  literal `[n]` keycap isn't parsed as Rich markup).
- `n` / `delete` bindings retained with `show=False` — the keys still work,
  they just no longer appear in the Footer.
- `x` label: `Delete` → `Del ws` to disambiguate from deleting a terminal.

Resulting Footer: `Back · Edit · Restart · Stop · Duplicate · Del ws`.

**Delete in-flight feedback.** `_do_delete_terminal` now sets
`"Deleting terminal {index}…"` before the await (mirroring `_do_new_terminal`),
overwritten by the existing success/failure message on resolution.

## Verification

- Full Python suite (klangkd + klangkc), `-n auto`: **3699 passed, 100% coverage.**
- Added `test_detail_terminal_actions_inline_not_in_footer` (inline hints,
  hidden bindings, `Del ws` label — caught the `[n]`-as-Rich-markup bug in dev).
- Added `test_detail_delete_terminal_shows_inflight_msg` (gated on an
  `asyncio.Event`) asserting the message shows while the close call is pending.
