### PR TITLE
fix(tui): hide SSO button when server lacks OIDC

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -931,6 +931,13 @@ set-password <email>` (set a known password for the default user — whose
   "Creating terminal …" feedback), instead of the screen appearing hung
   until the list updates.
 
+- **The `klangk` TUI login screen only shows the "Log in via browser (SSO)"
+  button when the selected server actually offers OIDC (#1864).**
+  Previously the button was always rendered — disabled (greyed-out) for
+  `password`/`both` servers and still clickable for `none`/`unreachable` ones
+  with no SSO backend behind it. It now hides entirely (via `display`, not
+  just `disabled`) unless the server's auth mode is `oidc` or `both`.
+
 - **The nginx proxy engine stays up under a plain `systemctl start` with no
   operator log workaround (#1550).** nginx's `access_log` directive has no
   `stdout` keyword, so it always `open(2)`s its destination by path; under

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -283,6 +283,7 @@ class LoginScreen(SpatialNavScreen):
         self.query_one("#server_line", Static).update(
             "No server selected — pick one or enter a URL below."
         )
+        self._set_oidc_visible(False)
         self._disable_credentials()
 
     # --- server picker ---
@@ -403,6 +404,9 @@ class LoginScreen(SpatialNavScreen):
     # --- auth-mode setup ---
 
     def _setup_auth(self) -> None:
+        # Hide the SSO button during the probe so it doesn't flash on then
+        # off when the server turns out not to offer OIDC (#1864).
+        self._set_oidc_visible(False)
         self.run_worker(self._setup_auth_async, exit_on_error=False)
 
     async def _setup_auth_async(self) -> None:
@@ -413,6 +417,8 @@ class LoginScreen(SpatialNavScreen):
         )
         self._enable_credentials()
         notice = self.query_one("#notice", Static)
+        # The SSO button is only meaningful when the server offers OIDC.
+        self._set_oidc_visible(mode in {"oidc", "both"})
         if mode == "none":
             notice.update("No-auth server — logging in…")
             self.call_after_refresh(self._attempt_none)
@@ -431,7 +437,11 @@ class LoginScreen(SpatialNavScreen):
             return
         # password / both
         notice.update("Enter your credentials.")
-        self.query_one("#oidc", Button).disabled = True
+
+    def _set_oidc_visible(self, visible: bool) -> None:
+        # Show/hide the SSO button. Hidden entirely (not just disabled) when
+        # the server doesn't offer OIDC, so it takes no layout space (#1864).
+        self.query_one("#oidc", Button).display = visible
 
     def _disable_credentials(self) -> None:
         # No server chosen: disable the whole credential area.

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -1023,6 +1023,59 @@ async def test_login_unreachable_mode():
         assert "Cannot reach" in str(app.screen.query_one("#notice").render())
 
 
+async def test_login_oidc_button_visibility_by_auth_mode(monkeypatch):
+    """#1864: the "Log in via browser" button renders only when the server
+    offers OIDC (auth mode ``oidc`` or ``both``); otherwise it's hidden
+    entirely (``display``, not just ``disabled``)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+
+    async def oidc_display(mode, **extra):
+        st = _st(
+            is_authenticated=lambda: False,
+            auth_mode=lambda: mode,
+            current_url=lambda: "https://x.example",
+            email=lambda: None,
+            token=lambda: None,
+            **extra,
+        )
+        app = KlangkApp(st)
+        async with app.run_test() as pilot:
+            await pilot.pause()  # let the deferred no-auth attempt schedule
+            await app.workers.wait_for_complete()
+            await pilot.pause()
+            return app.screen.query_one("#oidc", Button).display
+
+    assert await oidc_display("oidc") is True
+    assert await oidc_display("both") is True
+    assert await oidc_display("password") is False
+    assert await oidc_display("unreachable") is False
+    # none: force the deferred no-auth attempt to fail so the screen stays on
+    # LoginScreen and the button can be read.
+    assert (
+        await oidc_display(
+            "none",
+            login_none=lambda: (_ for _ in ()).throw(LoginError("nope")),
+        )
+        is False
+    )
+
+    # No server selected at all -> hidden too.
+    st = _st(
+        is_authenticated=lambda: False,
+        current_url=lambda: None,
+        known_servers=lambda: [],
+        email=lambda: None,
+        token=lambda: None,
+    )
+    app = KlangkApp(st)
+    async with app.run_test():
+        assert app.screen.query_one("#oidc", Button).display is False
+
+
 async def test_logout_returns_to_login(monkeypatch):
     async def noop(*a, **k):
         return None


### PR DESCRIPTION
## Summary

The **"Log in via browser (SSO)"** button on the TUI login screen was
always rendered, even when the selected server's auth configuration
doesn't include SSO. Against a `password`/`both` server it was disabled
(greyed, taking layout space); against a `none`/`unreachable` server it
was left enabled and clickable with no SSO backend behind it.

The button now hides entirely (`display`, not just `disabled`) unless the
server actually offers OIDC.

## Changes

`src/klangk/klangk/cli/tui/screens.py` — `LoginScreen`:

- New `_set_oidc_visible(visible)` helper toggles `#oidc`'s `.display`.
- `_setup_auth_async` sets it from the resolved auth mode:
  `mode in {"oidc", "both"}` → visible; `password`/`none`/`unreachable`
  → hidden. The redundant `#oidc.disabled = True` in the password/both
  branch is removed (visibility now governs presence; for `both` the
  button stays enabled and usable, which the old disable was wrongly
  preventing).
- `_setup_auth` hides the button synchronously before the async probe, so
  it doesn't flash on-then-off while `auth_mode` is being fetched.
- `_show_no_server` hides it too (no server ⇒ no SSO to offer).

All re-entry points (`_do_choose_server`, `_do_delete_server`) funnel
through `_setup_auth` / `_show_no_server`, so every flow is covered.

## Test plan

- [x] New `test_login_oidc_button_visibility_by_auth_mode` asserts
  `#oidc.display` for `oidc`/`both` (True) and `password`/`none`/
  `unreachable` + no-server (False).
- [x] Full Python suite (CI invocation): `pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -v -n auto` — **3705 passed, 100% coverage** (after rebasing on latest `main`, which merged #1863 in flight).
- [x] Rebased onto latest `main`; conflict in `docs/changes.md` resolved (kept both independent `Fixed` bullets).

Closes #1864
