### PR TITLE
TUI login: remove blank row under status line; accent+bold the headers (#1865)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -407,6 +407,11 @@ invitations send` stay email-only (a deliverable address is required);
 
 ### Changed
 
+- **TUI login headers recolored as accent + bold (#1865).** The
+  "Server: …" status line and the notice line beneath it (e.g.
+  "Cannot reach the server…") now render in the theme accent color, bold,
+  so they read as headers rather than body text.
+
 - **TUI workspace detail: terminal-scoped keybindings moved inline (#1860).**
   The `n` (new terminal) and `delete` (delete terminal) keys no longer appear
   in the bottom Footer — their hints now render on the Terminals list header
@@ -924,6 +929,10 @@ set-password <email>` (set a known password for the default user — whose
   over TCP directly but are unused under `klangkd`.
 
 ### Fixed
+
+- **TUI login: no blank row between the server status line and the server
+  list (#1865).** Dropped a 1-row bottom margin on the "Server: …"
+  status line so the server picker renders directly beneath it.
 
 - **TUI workspace detail: terminal delete now shows in-flight feedback (#1863).**
   Pressing `delete` on a selected terminal now shows a `Deleting terminal …`

--- a/src/klangk/klangk/cli/tui/app.py
+++ b/src/klangk/klangk/cli/tui/app.py
@@ -74,9 +74,15 @@ class KlangkApp(App):
         padding: 0 1;
         overflow-y: auto;
     }
-    /* A little air under the server status line, before the picker. */
-    #server_line {
-        margin-bottom: 1;
+    /* Login-screen headers: the server status line and the notice line
+    below it. Formerly #server_line had a 1-row bottom margin that left a
+    blank row between it and the server picker — dropped so the list hugs
+    the status line (#1865). Emphasized with the theme accent + bold so
+    they read as headers. CSS (not markup) is used because "Server: {url}"
+    carries a dynamic URL that must not be markup-parsed. */
+    #server_line, #notice {
+        color: $accent;
+        text-style: bold;
     }
     /* Right-align button rows; don't let them expand vertically (avoids a
     large gap below the button before the next field). */

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -4945,6 +4945,47 @@ async def test_login_server_list_autofocused(monkeypatch):
         assert lv.index == 0
 
 
+async def test_login_server_line_hugs_list_and_headers_styled(monkeypatch):
+    """#1865: no blank row between the 'Server:' status line and the server
+    picker, and the 'Server:' / notice headers are emphasized (accent color +
+    bold) so they read as headers."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    st = _st(
+        current_url=lambda: "http://localhost:8997",
+        known_servers=lambda: [],
+        default_uds=lambda: None,
+        auth_mode=lambda: "password",
+        email=lambda: None,
+        token=lambda: None,
+        is_authenticated=lambda: False,
+    )
+    app = KlangkApp(st)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        login = app.screen
+        line = login.query_one("#server_line")
+        notice = login.query_one("#notice")
+        opts = login.query_one("#server_options", ListView)
+        message = login.query_one("#message")
+
+        # No blank row: the picker's top edge meets the status line's bottom.
+        assert opts.region.y == line.region.y + line.region.height
+
+        # Both headers are emphasized as headers (bold + a non-default,
+        # accent-derived color; exact rgb is fragile because Textual rounds
+        # the resolved design token, so compare against the unstyled line).
+        assert line.styles.text_style.bold
+        assert notice.styles.text_style.bold
+        assert line.styles.color != message.styles.color
+        assert notice.styles.color != message.styles.color
+
+
 async def test_login_server_list_empty_no_crash(monkeypatch):
     """#1826: no servers → no crash, focus degrades gracefully."""
 


### PR DESCRIPTION
Closes #1865.

## What

- **Remove the blank row** between the "Server: …" status line and the server-picker list on the TUI login screen. The `#server_line { margin-bottom: 1 }` rule produced the gap; dropping it makes the list hug the status line.
- **Recolor the login headers** — `#server_line` ("Server: …") and `#notice` (the status line beneath it, incl. "Cannot reach the server…") — with the theme **accent color + bold** so they read as headers. Styled via CSS (not markup) because `Server: {url}` carries a dynamic URL that must not be markup-parsed.

## Verification

- Reproduced the layout before/after: gap is now `0` (`server_options.region.y == server_line.region.y + server_line.region.height`).
- New test `test_login_server_line_hugs_list_and_headers_styled` guards both the zero gap and the header styling (bold + a non-default, accent-derived color).
- Full suite: **3705 passed, 100% coverage**.

## Scope note

`#notice` is a single widget that also holds the other auth-mode status lines ("Enter your credentials.", "No-auth server — logging in…", "This server uses single sign-on…"). Styling it gives all of them the accent + bold treatment, not just the "Cannot reach the server…" message. Easy to narrow with a class toggle if you'd prefer only the unreachable message emphasized.
