### PR TITLE
feat(cli,tui): account self-service (password/handle/email)

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -27,6 +27,19 @@ operators or integrators to act when upgrading.
 
 ### Added
 
+- **Account self-service from the CLI and TUI (#1753).** A new
+  `klangk account` group (`show`, `passwd`, `handle`, `email`) changes your
+  password, handle, or email from the command line, and a new TUI **Account**
+  screen (press `a` from the workspace list) offers the same operations with
+  inline validation. Both surfaces mirror the Flutter `SettingsPage`: current
+  `@handle` + email from `GET /api/v1/auth/me`, the same client-side checks
+  (handle lowercase `[a-z0-9._-]+` charset, email format, password minimum
+  read from `/api/v1/config`), and password confirmation for handle/email
+  changes (plus a confirm dialog for the handle, which affects your terminal
+  home directory). The CLI re-keys your cached token under the new email
+  after a change — the JWT subject is your user id, so the token stays valid;
+  only the key it's filed under changes.
+
 - **`klangk stop` and `klangk start` commands** stop and (re)start a
   workspace container (#1750), closing the CLI parity gap with the TUI and
   Flutter app (which already reach shutdown via `POST /api/v1/workspaces/{id}/stop`).

--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -58,6 +58,36 @@ the SSO flow and receives the token via a temporary localhost callback.
 
 See [OIDC Configuration](../reference/oidc.md) for setup instructions.
 
+## Account self-service
+
+Logged-in users can change their own **password**, **handle**, and
+**email** without an admin. All three are available from:
+
+- the web UI **Settings** page,
+- the TUI **Account** screen (press `a` from the workspace list), and
+- the CLI `klangk account` group (`show`, `passwd`, `handle`, `email`).
+
+Handle and email changes require your current password to confirm; a
+password change requires your current password. Validation is enforced the
+same way on every surface (and again, authoritatively, on the server):
+
+- **handle** — lowercase, `[a-z0-9._-]+`, at most 32 characters. Changing
+  it affects your terminal home directory and how others see you in chat,
+  so the TUI and CLI confirm before applying it.
+- **email** — must be a well-formed address. The account is marked
+  unverified and a verification email is sent to the new address; verify it
+  to fully activate the change. The address must not already be in use.
+- **password** — must meet the server's minimum length
+  (`KLANGKD_MIN_PASSWORD_LENGTH`, default 8).
+
+Because the session JWT's subject is your user id (not your email), an
+email change does **not** invalidate your current session — the CLI simply
+re-files its cached token under the new address.
+
+> Accounts with no password (OIDC-only users, whose credentials are
+> managed by their identity provider) cannot use these routes — change
+> your password, handle, and email through your IdP instead.
+
 ## Sessions
 
 Klangk uses JWT tokens for sessions. Token lifetime defaults to 24

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -149,6 +149,12 @@ klangk logout                               # logout from active server
 klangk logout prod                          # logout from a specific server
 klangk status                               # show active server and user
 
+# Account self-service (change password / handle / email)
+klangk account show                         # show your current handle and email
+klangk account passwd                       # change your password (prompts for current + new)
+klangk account handle                       # change your handle (prompts for new handle + password)
+klangk account email                        # change your email (prompts for new email + password)
+
 # Non-interactive login (for scripts)
 klangk login prod admin --password-file /path/to/pwfile
 echo "secret" | klangk login prod admin --password-file -

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -229,6 +229,18 @@ klangk volumes rm nix-store         # delete a volume (must be yours)
 you hold site-wide admin privileges (derived from the server's
 `/my-permissions` — the same source the web UI uses).
 
+The `klangk account` group lets a logged-in user manage their own
+credentials: `klangk account show` prints your current handle and email;
+`passwd`, `handle`, and `email` prompt for the new value plus a password
+confirmation (handle and email changes) or your current password (password
+change). Validation matches the web UI: handles are lowercase
+`[a-z0-9._-]+` (≤32 chars), emails must be well-formed, and the password
+minimum is read from the server (`KLANGKD_MIN_PASSWORD_LENGTH`, surfaced at
+`/api/v1/config`) rather than hardcoded. After an email change the CLI
+re-keys your cached token under the new address — the token's subject is
+your user id, so it stays valid. See
+[Authentication § Account self-service](../features/authentication.md#account-self-service).
+
 The CLI connects to the running Klangk backend over HTTP + WebSocket — it works locally and against remote servers.
 
 ## Exiting the shell

--- a/src/klangk/klangk/cli/account.py
+++ b/src/klangk/klangk/cli/account.py
@@ -1,0 +1,73 @@
+"""Account self-service: validation helpers shared by the CLI and TUI.
+
+Mirrors the Flutter ``SettingsPage`` client-side checks (handle charset,
+email format, password minimum) so both terminal surfaces reject the same
+input before round-tripping to the server. The server re-validates
+authoritatively in ``klangk.api.auth``; these functions are a fast-fail
+UX layer only.
+
+Stays within ``klangk.cli`` (CLI subpackage isolation rule): no imports
+from the server package.
+"""
+
+from __future__ import annotations
+
+import re
+
+from .auth import fetch_config
+
+# Mirror klangk.model.users (server). Duplicated here rather than imported
+# because the CLI must not depend on the server package.
+HANDLE_RE = re.compile(r"^[a-z0-9._-]+$")
+MAX_HANDLE_LEN = 32
+EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+_DEFAULT_MIN_PASSWORD = 8
+
+
+def validate_handle(handle: str) -> str | None:
+    """Return an error message if *handle* is invalid, else ``None``.
+
+    Same rules as the Flutter client and the server's static check:
+    non-empty, lowercase, ``[a-z0-9._-]+``, and within the length cap.
+    """
+    handle = (handle or "").strip()
+    if not handle:
+        return "Handle cannot be empty"
+    if handle != handle.lower():
+        return "Handle must be lowercase"
+    if len(handle) > MAX_HANDLE_LEN:
+        return f"Handle must be {MAX_HANDLE_LEN} characters or fewer"
+    if not HANDLE_RE.match(handle):
+        return (
+            "Handle may only contain lowercase letters, digits,"
+            " dots, dashes, and underscores"
+        )
+    return None
+
+
+def validate_email(email: str) -> str | None:
+    """Return an error message if *email* is invalid, else ``None``."""
+    email = (email or "").strip()
+    if not email:
+        return "Email cannot be empty"
+    if not EMAIL_RE.match(email):
+        return "Enter a valid email address"
+    return None
+
+
+def password_min_length(server_url: str) -> int:
+    """Server-configured minimum password length, from ``/api/v1/config``.
+
+    Falls back to ``_DEFAULT_MIN_PASSWORD`` (8) when the server doesn't
+    advertise one — an unreachable/old server, or an unparseable value.
+    The server still enforces its own floor authoritatively.
+    """
+    config = fetch_config(server_url)
+    if isinstance(config, dict):
+        try:
+            return int(
+                config.get("min_password_length") or _DEFAULT_MIN_PASSWORD
+            )
+        except (TypeError, ValueError):
+            return _DEFAULT_MIN_PASSWORD
+    return _DEFAULT_MIN_PASSWORD

--- a/src/klangk/klangk/cli/account.py
+++ b/src/klangk/klangk/cli/account.py
@@ -20,6 +20,7 @@ from .auth import fetch_config
 # because the CLI must not depend on the server package.
 HANDLE_RE = re.compile(r"^[a-z0-9._-]+$")
 MAX_HANDLE_LEN = 32
+RESERVED_HANDLES = frozenset({"work", ".users"})
 EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 _DEFAULT_MIN_PASSWORD = 8
 
@@ -27,16 +28,23 @@ _DEFAULT_MIN_PASSWORD = 8
 def validate_handle(handle: str) -> str | None:
     """Return an error message if *handle* is invalid, else ``None``.
 
-    Same rules as the Flutter client and the server's static check:
-    non-empty, lowercase, ``[a-z0-9._-]+``, and within the length cap.
+    Same rules as the Flutter client and the server's static check
+    (``klangk.model.users.validate_handle``): non-empty, length cap, no
+    leading dot, not reserved, lowercase, ``[a-z0-9._-]+``. The checks are
+    applied in the same order as the server so the error message for any
+    given input matches.
     """
     handle = (handle or "").strip()
     if not handle:
         return "Handle cannot be empty"
-    if handle != handle.lower():
-        return "Handle must be lowercase"
     if len(handle) > MAX_HANDLE_LEN:
         return f"Handle must be {MAX_HANDLE_LEN} characters or fewer"
+    if handle.startswith("."):
+        return "Handle cannot start with a dot"
+    if handle in RESERVED_HANDLES:
+        return f"'{handle}' is reserved"
+    if handle != handle.lower():
+        return "Handle must be lowercase"
     if not HANDLE_RE.match(handle):
         return (
             "Handle may only contain lowercase letters, digits,"

--- a/src/klangk/klangk/cli/client.py
+++ b/src/klangk/klangk/cli/client.py
@@ -331,6 +331,54 @@ class KlangkClient:
         self._raise_for_status(resp)
         return resp.json()["handle"]
 
+    def get_me(self) -> dict:
+        """Return the current user's profile via ``GET /auth/me``.
+
+        A dict with ``id``, ``email`` and ``handle``.
+        """
+        resp = self.get("/api/v1/auth/me")
+        self._raise_for_status(resp)
+        return resp.json()
+
+    def change_password(
+        self, current_password: str, new_password: str
+    ) -> None:
+        """Change the current user's password via ``POST /auth/change-password``.
+
+        Note: ``check_auth`` is intentionally skipped — this endpoint returns
+        401 for a wrong current password, and we want the server's ``detail``
+        ("Current password is incorrect") to surface rather than the generic
+        session-expired message.
+        """
+        resp = self.post(
+            "/api/v1/auth/change-password",
+            json={
+                "current_password": current_password,
+                "new_password": new_password,
+            },
+        )
+        self._raise_for_status(resp)
+
+    def change_email(self, email: str, password: str) -> None:
+        """Change the current user's email via ``POST /auth/change-email``."""
+        resp = self.post(
+            "/api/v1/auth/change-email",
+            json={"email": email, "password": password},
+        )
+        self._raise_for_status(resp)
+
+    def change_handle(self, handle: str, password: str) -> str:
+        """Change the current user's handle via ``POST /auth/change-handle``.
+
+        Returns the handle the server accepted.
+        """
+        resp = self.post(
+            "/api/v1/auth/change-handle",
+            json={"handle": handle, "password": password},
+        )
+        self._raise_for_status(resp)
+        return resp.json().get("handle", handle)
+
     def list_workspaces(
         self,
         limit: int = 10,

--- a/src/klangk/klangk/cli/client.py
+++ b/src/klangk/klangk/cli/client.py
@@ -334,9 +334,13 @@ class KlangkClient:
     def get_me(self) -> dict:
         """Return the current user's profile via ``GET /auth/me``.
 
-        A dict with ``id``, ``email`` and ``handle``.
+        A dict with ``id``, ``email`` and ``handle``. Unlike the
+        ``change_*`` methods, a 401 here genuinely means the session has
+        expired, so ``check_auth`` maps it to the friendly
+        "Session expired" error (mirroring ``get_handle``).
         """
         resp = self.get("/api/v1/auth/me")
+        self.check_auth(resp)
         self._raise_for_status(resp)
         return resp.json()
 

--- a/src/klangk/klangk/cli/config.py
+++ b/src/klangk/klangk/cli/config.py
@@ -356,6 +356,22 @@ class CLIState:
         ss.active_user = user
         self.active_server = server_url
 
+    def rename_user(
+        self, server_url: str, old_user: str, new_user: str
+    ) -> None:
+        """Re-key cached credentials after a self-service email change.
+
+        The JWT's subject is the user id (not the email), so the stored
+        token stays valid across an email change — only the key it's filed
+        under changes. No parallel store: the entry moves in place (#1753).
+        """
+        ss = self.servers.get(server_url)
+        if not ss or old_user not in ss.users:
+            return
+        ss.users[new_user] = ss.users.pop(old_user)
+        if ss.active_user == old_user:
+            ss.active_user = new_user
+
     def clear_credentials(self, server_url: str) -> None:
         """Clear all credentials for a server."""
         if server_url in self.servers:

--- a/src/klangk/klangk/cli/config.py
+++ b/src/klangk/klangk/cli/config.py
@@ -364,6 +364,9 @@ class CLIState:
         The JWT's subject is the user id (not the email), so the stored
         token stays valid across an email change — only the key it's filed
         under changes. No parallel store: the entry moves in place (#1753).
+
+        Mutates the in-memory state only; the caller must ``save()`` to
+        persist (same convention as ``set_credentials``).
         """
         ss = self.servers.get(server_url)
         if not ss or old_user not in ss.users:

--- a/src/klangk/klangk/cli/main.py
+++ b/src/klangk/klangk/cli/main.py
@@ -381,8 +381,15 @@ def account_passwd() -> None:
     try:
         client.change_password(current, new)
     except httpx.HTTPStatusError as exc:
+        # The server surfaces a 401 for a wrong current password and a 400
+        # for policy violations (e.g. too short) — the detail is printed
+        # verbatim. change-password doesn't itself trigger the /auth/login
+        # brute-force lockout; a future global rate limit (429) would show
+        # up here as a raw HTTP error until given dedicated handling.
         _err.print(f"[red]{exc}[/red]")
         raise typer.Exit(code=1) from exc
+    # Success goes to stdout (scripting-friendly: `klangk account passwd &&
+    # ...`); errors above go to stderr via _err.
     Console().print("[green]Password updated.[/green]")
 
 

--- a/src/klangk/klangk/cli/main.py
+++ b/src/klangk/klangk/cli/main.py
@@ -18,7 +18,7 @@ import typer
 import websockets
 from rich.console import Console
 from rich.live import Live
-from rich.prompt import Prompt
+from rich.prompt import Confirm, Prompt
 from rich.progress import (
     BarColumn,
     DownloadColumn,
@@ -37,6 +37,7 @@ from .auth import (
     refresh_token,
     _UNREACHABLE,
 )
+from . import account
 from .client import (
     AuthError,
     KlangkClient,
@@ -335,6 +336,109 @@ def status(
     else:
         table.add_row("Status", "[yellow]not logged in[/yellow]")
     console.print(table)
+
+
+# ---------------------------------------------------------------------
+# Account self-service (change password / handle / email)
+# ---------------------------------------------------------------------
+
+account_app = typer.Typer(
+    help="Account self-service: change your password, handle, or email."
+)
+app.add_typer(account_app, name="account")
+
+
+@account_app.command("show")
+def account_show() -> None:
+    """Show your current handle and email."""
+    require_auth()
+    me = _client().get_me()
+    handle = me.get("handle") or "(none)"
+    email = me.get("email") or "(unknown)"
+    Console().print(
+        f"Email:  [bold]{email}[/bold]\nHandle: [bold]@{handle}[/bold]"
+    )
+
+
+@account_app.command("passwd")
+def account_passwd() -> None:
+    """Change your password."""
+    require_auth()
+    url = server_url()
+    client = _client()
+    current = Prompt.ask("[bold]Current password[/bold]", password=True)
+    new = Prompt.ask("[bold]New password[/bold]", password=True)
+    confirm = Prompt.ask("[bold]Confirm new password[/bold]", password=True)
+    if new != confirm:
+        _err.print("[red]Passwords do not match[/red]")
+        raise typer.Exit(code=1)
+    min_len = account.password_min_length(url)
+    if len(new) < min_len:
+        _err.print(
+            f"[red]Password must be at least {min_len} characters[/red]"
+        )
+        raise typer.Exit(code=1)
+    try:
+        client.change_password(current, new)
+    except httpx.HTTPStatusError as exc:
+        _err.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1) from exc
+    Console().print("[green]Password updated.[/green]")
+
+
+@account_app.command("handle")
+def account_handle() -> None:
+    """Change your handle (requires password confirmation)."""
+    require_auth()
+    client = _client()
+    current = client.get_me().get("handle") or ""
+    new = Prompt.ask("[bold]New handle[/bold]").strip()
+    err = account.validate_handle(new)
+    if err:
+        _err.print(f"[red]{err}[/red]")
+        raise typer.Exit(code=1)
+    if not Confirm.ask(
+        f"Change your handle from @{current} to @{new}?", default=False
+    ):
+        _err.print("[yellow]Cancelled.[/yellow]")
+        raise typer.Exit(code=0)
+    password = Prompt.ask("[bold]Password (to confirm)[/bold]", password=True)
+    try:
+        client.change_handle(new, password)
+    except httpx.HTTPStatusError as exc:
+        _err.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1) from exc
+    Console().print(f"[green]Handle updated to @{new}.[/green]")
+
+
+@account_app.command("email")
+def account_email() -> None:
+    """Change your email (requires password confirmation)."""
+    require_auth()
+    url = server_url()
+    client = _client()
+    new = Prompt.ask("[bold]New email[/bold]").strip()
+    err = account.validate_email(new)
+    if err:
+        _err.print(f"[red]{err}[/red]")
+        raise typer.Exit(code=1)
+    password = Prompt.ask("[bold]Password (to confirm)[/bold]", password=True)
+    try:
+        client.change_email(new, password)
+    except httpx.HTTPStatusError as exc:
+        _err.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1) from exc
+    # The JWT subject is the user id, so the cached token stays valid; only
+    # the key it's filed under changes. Re-key it rather than dropping it.
+    state = _state()
+    old = state.get_email(url)
+    if old is not None and old != new:
+        state.rename_user(url, old, new)
+        state.save()
+    Console().print(
+        "[green]Email updated.[/green] Check your inbox to verify the new"
+        " address."
+    )
 
 
 def workspace_status(ws) -> tuple[str, str]:

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -54,6 +54,7 @@ from ..mount import (
 )
 from ..transport import is_valid_server_spec
 from .widgets import StatusBar
+from .. import account
 from .ws import listen_for_status
 
 logger = logging.getLogger(__name__)
@@ -549,6 +550,295 @@ class WorkspaceListView(SpatialListView):
     SPATIAL_UP_TARGET = Tabs
 
 
+class AccountScreen(SpatialNavScreen):
+    """Account self-service: change password / handle / email (#1753).
+
+    Mirrors the Flutter ``SettingsPage`` — current @handle + email from
+    ``GET /auth/me``, the same client-side validation (handle charset, email
+    format, password minimum from ``/api/v1/config``), and a confirm dialog
+    for the handle change (it affects the terminal home directory and how
+    others see you in chat).
+    """
+
+    BINDINGS = [
+        Binding("up", "spatial_up", show=False),
+        Binding("down", "spatial_down", show=False),
+        Binding("escape", "app.pop_screen", "Back", show=True),
+    ]
+
+    # Focus chain for spatial Up/Down (reading order).
+    SPATIAL_CHAIN = [
+        "pw_current",
+        "pw_new",
+        "pw_confirm",
+        "pw_submit",
+        "handle_new",
+        "handle_pw",
+        "handle_submit",
+        "email_new",
+        "email_pw",
+        "email_submit",
+    ]
+
+    DEFAULT_CSS = """
+    AccountScreen { align: center top; }
+    #account_box {
+        width: 96;
+        max-width: 90%;
+        height: auto;
+        padding: 0 2;
+    }
+    #account_scroll { padding: 0 0 1 0; }
+    #profile { padding: 1 0; text-style: bold; color: $text-secondary; }
+    .acct-section {
+        height: auto;
+        padding: 1 0;
+        border-top: solid $border-blurred;
+    }
+    .acct-title {
+        text-style: bold;
+        color: $primary;
+        padding: 0 0 1 0;
+    }
+    .acct-msg {
+        height: 1;
+        color: $text-muted;
+    }
+    .acct-msg.error { color: $error; }
+    .acct-actions { align-horizontal: right; height: auto; }
+    """
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=False)
+        with NonFocusableVerticalScroll(id="account_scroll"):
+            yield Vertical(
+                Static("", id="profile"),
+                # --- Change password ---
+                Vertical(
+                    Static("Change password", classes="acct-title"),
+                    Input(
+                        placeholder="Current password",
+                        id="pw_current",
+                        password=True,
+                    ),
+                    Input(
+                        placeholder="New password",
+                        id="pw_new",
+                        password=True,
+                    ),
+                    Input(
+                        placeholder="Confirm new password",
+                        id="pw_confirm",
+                        password=True,
+                    ),
+                    Static("", id="pw_msg", classes="acct-msg"),
+                    Horizontal(
+                        Button("Update password", id="pw_submit"),
+                        classes="acct-actions",
+                    ),
+                    classes="acct-section",
+                ),
+                # --- Change handle ---
+                Vertical(
+                    Static("Change handle", classes="acct-title"),
+                    Input(placeholder="New handle", id="handle_new"),
+                    Input(
+                        placeholder="Password (to confirm)",
+                        id="handle_pw",
+                        password=True,
+                    ),
+                    Static("", id="handle_msg", classes="acct-msg"),
+                    Horizontal(
+                        Button("Update handle", id="handle_submit"),
+                        classes="acct-actions",
+                    ),
+                    classes="acct-section",
+                ),
+                # --- Change email ---
+                Vertical(
+                    Static("Change email", classes="acct-title"),
+                    Input(placeholder="New email", id="email_new"),
+                    Input(
+                        placeholder="Password (to confirm)",
+                        id="email_pw",
+                        password=True,
+                    ),
+                    Static("", id="email_msg", classes="acct-msg"),
+                    Horizontal(
+                        Button("Update email", id="email_submit"),
+                        classes="acct-actions",
+                    ),
+                    classes="acct-section",
+                ),
+                id="account_box",
+            )
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self.app.title = "Klangk: Account"
+        self._current_handle = ""
+        self._current_email = ""
+        self.run_worker(self._load_profile, exit_on_error=False)
+
+    async def _load_profile(self) -> None:
+        try:
+            me = await asyncio.to_thread(self.app.tui_state.get_me)
+        except LoginError as exc:
+            self.query_one("#profile", Static).update(
+                Text(str(exc), style="red")
+            )
+            return
+        self._current_handle = me.get("handle") or ""
+        self._current_email = me.get("email") or ""
+        self._render_profile()
+
+    def _render_profile(self) -> None:
+        self.query_one("#profile", Static).update(
+            Text(f"{self._current_email}  @{self._current_handle}")
+        )
+
+    def _set_msg(
+        self, section: str, text: str, *, error: bool = False
+    ) -> None:
+        msg = self.query_one(f"#{section}_msg", Static)
+        msg.update(Text(text, style="red" if error else ""))
+        msg.set_class(error, "error")
+
+    # --- event handlers ---
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        actions = {
+            "pw_submit": self._submit_password,
+            "handle_submit": self._submit_handle,
+            "email_submit": self._submit_email,
+        }
+        action = actions.get(event.button.id)
+        if action:
+            action()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        # Enter in a section's last field submits that section.
+        routes = {
+            "pw_confirm": self._submit_password,
+            "handle_pw": self._submit_handle,
+            "email_pw": self._submit_email,
+        }
+        action = routes.get(event.input.id)
+        if action:
+            action()
+
+    # --- password ---
+
+    def _submit_password(self) -> None:
+        current = self.query_one("#pw_current", Input).value
+        new = self.query_one("#pw_new", Input).value
+        confirm = self.query_one("#pw_confirm", Input).value
+        if not current or not new:
+            self._set_msg(
+                "pw", "Current and new password are required.", error=True
+            )
+            return
+        if new != confirm:
+            self._set_msg("pw", "Passwords do not match.", error=True)
+            return
+        url = self.app.tui_state.current_url() or ""
+        min_len = account.password_min_length(url)
+        if len(new) < min_len:
+            self._set_msg(
+                "pw",
+                f"Password must be at least {min_len} characters.",
+                error=True,
+            )
+            return
+        self.run_worker(
+            self._do_change_password(current, new), exit_on_error=False
+        )
+
+    async def _do_change_password(self, current: str, new: str) -> None:
+        try:
+            await asyncio.to_thread(
+                self.app.tui_state.change_password, current, new
+            )
+        except LoginError as exc:
+            self._set_msg("pw", str(exc), error=True)
+            return
+        for wid in ("pw_current", "pw_new", "pw_confirm"):
+            self.query_one(f"#{wid}", Input).value = ""
+        self._set_msg("pw", "Password updated.")
+
+    # --- handle ---
+
+    def _submit_handle(self) -> None:
+        new = self.query_one("#handle_new", Input).value.strip()
+        pw = self.query_one("#handle_pw", Input).value
+        err = account.validate_handle(new)
+        if err:
+            self._set_msg("handle", err, error=True)
+            return
+        if not pw:
+            self._set_msg("handle", "Password is required.", error=True)
+            return
+        self.app.push_screen(
+            ConfirmScreen(
+                f"Change your handle from @{self._current_handle} to @{new}?",
+                yes_label="Change",
+                yes_variant="warning",
+            ),
+            lambda confirmed: self._on_handle_confirmed(confirmed, new, pw),
+        )
+
+    def _on_handle_confirmed(
+        self, confirmed: bool, new: str, password: str
+    ) -> None:
+        if not confirmed:
+            return
+        self.run_worker(
+            self._do_change_handle(new, password), exit_on_error=False
+        )
+
+    async def _do_change_handle(self, new: str, password: str) -> None:
+        try:
+            accepted = await asyncio.to_thread(
+                self.app.tui_state.change_handle, new, password
+            )
+        except LoginError as exc:
+            self._set_msg("handle", str(exc), error=True)
+            return
+        self._current_handle = accepted or new
+        self.query_one("#handle_new", Input).value = ""
+        self.query_one("#handle_pw", Input).value = ""
+        self._set_msg("handle", f"Handle updated to @{self._current_handle}.")
+        self._render_profile()
+
+    # --- email ---
+
+    def _submit_email(self) -> None:
+        new = self.query_one("#email_new", Input).value.strip()
+        pw = self.query_one("#email_pw", Input).value
+        err = account.validate_email(new)
+        if err:
+            self._set_msg("email", err, error=True)
+            return
+        if not pw:
+            self._set_msg("email", "Password is required.", error=True)
+            return
+        self.run_worker(self._do_change_email(new, pw), exit_on_error=False)
+
+    async def _do_change_email(self, new: str, password: str) -> None:
+        try:
+            await asyncio.to_thread(
+                self.app.tui_state.change_email, new, password
+            )
+        except LoginError as exc:
+            self._set_msg("email", str(exc), error=True)
+            return
+        self._current_email = new
+        self.query_one("#email_new", Input).value = ""
+        self.query_one("#email_pw", Input).value = ""
+        self._set_msg("email", "Email updated. Check your inbox to verify it.")
+        self._render_profile()
+
+
 class MainScreen(Screen):
     """The TUI home: a two-page workspace list (owned / shared) + status bar,
     with a live WS feed. Selecting a workspace opens its detail screen."""
@@ -590,6 +880,7 @@ class MainScreen(Screen):
     BINDINGS = [
         ("s", "switch_server", "Switch server"),
         ("n", "create", "New"),
+        ("a", "account", "Account"),
         ("l", "logout", "Logout"),
         ("slash", "focus_filter", "Filter"),
         ("o", "cycle_sort", "Sort"),
@@ -746,6 +1037,9 @@ class MainScreen(Screen):
 
     def action_switch_server(self) -> None:
         self.app.push_screen(ServerSwitchScreen())
+
+    def action_account(self) -> None:
+        self.app.push_screen(AccountScreen())
 
     def action_logout(self) -> None:
         self.app.do_logout()

--- a/src/klangk/klangk/cli/tui/screens.py
+++ b/src/klangk/klangk/cli/tui/screens.py
@@ -741,8 +741,15 @@ class AccountScreen(SpatialNavScreen):
         if new != confirm:
             self._set_msg("pw", "Passwords do not match.", error=True)
             return
+        # The minimum-length check needs /api/v1/config (a network call),
+        # so it runs in the worker rather than blocking the event loop (#1869).
+        self.run_worker(
+            self._do_change_password(current, new), exit_on_error=False
+        )
+
+    async def _do_change_password(self, current: str, new: str) -> None:
         url = self.app.tui_state.current_url() or ""
-        min_len = account.password_min_length(url)
+        min_len = await asyncio.to_thread(account.password_min_length, url)
         if len(new) < min_len:
             self._set_msg(
                 "pw",
@@ -750,11 +757,6 @@ class AccountScreen(SpatialNavScreen):
                 error=True,
             )
             return
-        self.run_worker(
-            self._do_change_password(current, new), exit_on_error=False
-        )
-
-    async def _do_change_password(self, current: str, new: str) -> None:
         try:
             await asyncio.to_thread(
                 self.app.tui_state.change_password, current, new
@@ -778,20 +780,23 @@ class AccountScreen(SpatialNavScreen):
         if not pw:
             self._set_msg("handle", "Password is required.", error=True)
             return
+        # Don't capture the password in the closure — re-read it in the
+        # callback so it isn't held while the confirm dialog is open, and
+        # clear the field if the user cancels (#1869).
         self.app.push_screen(
             ConfirmScreen(
                 f"Change your handle from @{self._current_handle} to @{new}?",
                 yes_label="Change",
                 yes_variant="warning",
             ),
-            lambda confirmed: self._on_handle_confirmed(confirmed, new, pw),
+            lambda confirmed: self._on_handle_confirmed(confirmed, new),
         )
 
-    def _on_handle_confirmed(
-        self, confirmed: bool, new: str, password: str
-    ) -> None:
+    def _on_handle_confirmed(self, confirmed: bool, new: str) -> None:
         if not confirmed:
+            self.query_one("#handle_pw", Input).value = ""
             return
+        password = self.query_one("#handle_pw", Input).value
         self.run_worker(
             self._do_change_handle(new, password), exit_on_error=False
         )

--- a/src/klangk/klangk/cli/tui/state.py
+++ b/src/klangk/klangk/cli/tui/state.py
@@ -277,6 +277,66 @@ class TuiState:
         except SystemExit as exc:
             raise LoginError("OIDC login failed") from exc
 
+    # --- account self-service (#1753) ---
+
+    def get_me(self) -> dict:
+        """Return the current user's profile ({id, email, handle})."""
+        url = self.current_url()
+        if url is None:
+            raise LoginError("No server configured")
+        try:
+            return self.client().get_me()
+        except httpx.HTTPStatusError as exc:
+            raise LoginError(str(exc)) from None
+        except httpx.HTTPError as exc:
+            raise LoginError(f"could not reach server: {exc}") from None
+
+    def change_password(
+        self, current_password: str, new_password: str
+    ) -> None:
+        """Change the current user's password."""
+        if self.current_url() is None:
+            raise LoginError("No server configured")
+        try:
+            self.client().change_password(current_password, new_password)
+        except httpx.HTTPStatusError as exc:
+            raise LoginError(str(exc)) from None
+        except httpx.HTTPError as exc:
+            raise LoginError(f"could not reach server: {exc}") from None
+
+    def change_handle(self, handle: str, password: str) -> str:
+        """Change the current user's handle; returns the accepted handle."""
+        if self.current_url() is None:
+            raise LoginError("No server configured")
+        try:
+            accepted = self.client().change_handle(handle, password)
+        except httpx.HTTPStatusError as exc:
+            raise LoginError(str(exc)) from None
+        except httpx.HTTPError as exc:
+            raise LoginError(f"could not reach server: {exc}") from None
+        return accepted
+
+    def change_email(self, email: str, password: str) -> None:
+        """Change the current user's email and re-key cached credentials.
+
+        The JWT subject is the user id, so the stored token stays valid;
+        only the key it's filed under in klangk-state.yaml changes.
+        """
+        url = self.current_url()
+        if url is None:
+            raise LoginError("No server configured")
+        try:
+            self.client().change_email(email, password)
+        except httpx.HTTPStatusError as exc:
+            raise LoginError(str(exc)) from None
+        except httpx.HTTPError as exc:
+            raise LoginError(f"could not reach server: {exc}") from None
+        old = self.state().get_email(url)
+        if old is not None and old != email:
+            state = self.state()
+            state.rename_user(url, old, email)
+            state.save()
+
     def logout(self) -> None:
         url = self.current_url()
         state = self.state()

--- a/src/klangk/klangk/cli/tui/state.py
+++ b/src/klangk/klangk/cli/tui/state.py
@@ -22,7 +22,7 @@ from ..auth import (
     fetch_config,
     local_login,
 )
-from ..client import KlangkClient, Workspace
+from ..client import AuthError, KlangkClient, Workspace
 from ..config import (
     CLIConfig,
     CLIState,
@@ -286,6 +286,10 @@ class TuiState:
             raise LoginError("No server configured")
         try:
             return self.client().get_me()
+        except AuthError as exc:
+            # /auth/me 401 means the session has expired (client.get_me uses
+            # check_auth, unlike the change_* methods where 401 = wrong pw).
+            raise LoginError(str(exc)) from None
         except httpx.HTTPStatusError as exc:
             raise LoginError(str(exc)) from None
         except httpx.HTTPError as exc:

--- a/src/klangk/klangkc-tests/tests/test_account.py
+++ b/src/klangk/klangkc-tests/tests/test_account.py
@@ -28,8 +28,23 @@ class TestValidateHandle:
     def test_invalid_chars_rejected(self):
         assert "lowercase letters" in account.validate_handle("me!")
 
-    def test_too_long(self):
-        msg = account.validate_handle("a" * (account.MAX_HANDLE_LEN + 1))
+    def test_leading_dot_rejected(self):
+        assert (
+            account.validate_handle(".hidden")
+            == "Handle cannot start with a dot"
+        )
+
+    def test_reserved_rejected(self):
+        # "work" reaches the reserved check; ".users" is caught first by the
+        # leading-dot rule (same order as the server).
+        msg = account.validate_handle("work")
+        assert msg is not None and "reserved" in msg
+        assert "dot" in account.validate_handle(".users")
+
+    def test_too_long_beats_lowercase_check(self):
+        # Server checks length before casing; the CLI copy matches that order
+        # so an over-long mixed-case handle reports length, not casing.
+        msg = account.validate_handle("A" * (account.MAX_HANDLE_LEN + 1))
         assert msg is not None and "characters" in msg
 
     def test_strips_whitespace(self):

--- a/src/klangk/klangkc-tests/tests/test_account.py
+++ b/src/klangk/klangkc-tests/tests/test_account.py
@@ -1,0 +1,79 @@
+"""Tests for klangk.cli.account (shared account-self-service validation)."""
+
+from __future__ import annotations
+
+import pytest
+
+from klangk.cli import account
+
+
+class TestValidateHandle:
+    @pytest.mark.parametrize(
+        "handle",
+        ["me", "me.too", "me-too", "me_too", "a1", "x" * 32],
+    )
+    def test_valid(self, handle):
+        assert account.validate_handle(handle) is None
+
+    @pytest.mark.parametrize(
+        "handle",
+        ["", "   "],
+    )
+    def test_empty(self, handle):
+        assert account.validate_handle(handle) == "Handle cannot be empty"
+
+    def test_uppercase_rejected(self):
+        assert account.validate_handle("Me") == "Handle must be lowercase"
+
+    def test_invalid_chars_rejected(self):
+        assert "lowercase letters" in account.validate_handle("me!")
+
+    def test_too_long(self):
+        msg = account.validate_handle("a" * (account.MAX_HANDLE_LEN + 1))
+        assert msg is not None and "characters" in msg
+
+    def test_strips_whitespace(self):
+        # Surrounding whitespace is trimmed before checking.
+        assert account.validate_handle("  me  ") is None
+
+
+class TestValidateEmail:
+    @pytest.mark.parametrize(
+        "email",
+        ["a@b.com", "me.you@sub.example.org", "x+tag@y.co"],
+    )
+    def test_valid(self, email):
+        assert account.validate_email(email) is None
+
+    @pytest.mark.parametrize(
+        "email",
+        ["", "   ", "notanemail", "a@b", "a b@c.com", "@c.com", "a@.com"],
+    )
+    def test_invalid(self, email):
+        assert account.validate_email(email) is not None
+
+
+class TestPasswordMinLength:
+    def test_reads_from_config(self, monkeypatch):
+        monkeypatch.setattr(
+            account, "fetch_config", lambda url: {"min_password_length": 12}
+        )
+        assert account.password_min_length("http://x") == 12
+
+    def test_defaults_when_unreachable(self, monkeypatch):
+        monkeypatch.setattr(account, "fetch_config", lambda url: "unreachable")
+        assert account.password_min_length("http://x") == 8
+
+    def test_defaults_when_none(self, monkeypatch):
+        monkeypatch.setattr(account, "fetch_config", lambda url: None)
+        assert account.password_min_length("http://x") == 8
+
+    def test_defaults_when_missing_field(self, monkeypatch):
+        monkeypatch.setattr(account, "fetch_config", lambda url: {})
+        assert account.password_min_length("http://x") == 8
+
+    def test_defaults_when_unparseable(self, monkeypatch):
+        monkeypatch.setattr(
+            account, "fetch_config", lambda url: {"min_password_length": "abc"}
+        )
+        assert account.password_min_length("http://x") == 8

--- a/src/klangk/klangkc-tests/tests/test_cli.py
+++ b/src/klangk/klangkc-tests/tests/test_cli.py
@@ -440,6 +440,24 @@ class TestCLIState:
         state = CLIState()
         state.clear_credentials("http://nope:8995")  # should not raise
 
+    def test_rename_user_moves_token_and_active(self):
+        state = CLIState()
+        state.set_credentials("http://s:8995", "old@t.com", "tok")
+        state.rename_user("http://s:8995", "old@t.com", "new@t.com")
+        ss = state.servers["http://s:8995"]
+        assert "old@t.com" not in ss.users
+        assert ss.users["new@t.com"].token == "tok"  # token preserved
+        assert ss.active_user == "new@t.com"
+        assert state.get_token("http://s:8995") == "tok"
+
+    def test_rename_user_unknown_is_noop(self):
+        state = CLIState()
+        state.set_credentials("http://s:8995", "old@t.com", "tok")
+        state.rename_user("http://s:8995", "ghost@t.com", "new@t.com")
+        # unchanged
+        assert state.get_email("http://s:8995") == "old@t.com"
+        assert state.get_token("http://s:8995") == "tok"
+
 
 # --- Auth tests ---
 

--- a/src/klangk/klangkc-tests/tests/test_cli_integration.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_integration.py
@@ -1193,6 +1193,62 @@ class TestClientLines:
         assert params["order"] == "asc"
         assert params["q"] == "gamma"
 
+    def test_get_me_returns_profile(self):
+        from klangk.cli.client import KlangkClient
+
+        client = KlangkClient("http://test:8995", "tok")
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "id": "u1",
+            "email": "me@x.example",
+            "handle": "me",
+        }
+        with patch.object(client, "get", return_value=resp):
+            me = client.get_me()
+        assert me == {"id": "u1", "email": "me@x.example", "handle": "me"}
+
+    def test_change_password_posts_payload(self):
+        from klangk.cli.client import KlangkClient
+
+        client = KlangkClient("http://test:8995", "tok")
+        resp = MagicMock()
+        resp.status_code = 200
+        with patch.object(client, "post", return_value=resp) as mock_post:
+            client.change_password("old", "new")
+        mock_post.assert_called_once_with(
+            "/api/v1/auth/change-password",
+            json={"current_password": "old", "new_password": "new"},
+        )
+
+    def test_change_email_posts_payload(self):
+        from klangk.cli.client import KlangkClient
+
+        client = KlangkClient("http://test:8995", "tok")
+        resp = MagicMock()
+        resp.status_code = 200
+        with patch.object(client, "post", return_value=resp) as mock_post:
+            client.change_email("new@x.example", "pw")
+        mock_post.assert_called_once_with(
+            "/api/v1/auth/change-email",
+            json={"email": "new@x.example", "password": "pw"},
+        )
+
+    def test_change_handle_returns_accepted_handle(self):
+        from klangk.cli.client import KlangkClient
+
+        client = KlangkClient("http://test:8995", "tok")
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"status": "updated", "handle": "newhandle"}
+        with patch.object(client, "post", return_value=resp) as mock_post:
+            accepted = client.change_handle("newhandle", "pw")
+        mock_post.assert_called_once_with(
+            "/api/v1/auth/change-handle",
+            json={"handle": "newhandle", "password": "pw"},
+        )
+        assert accepted == "newhandle"
+
 
 class TestImagesCommand:
     def test_images_lists_allowed(self, monkeypatch):

--- a/src/klangk/klangkc-tests/tests/test_cli_integration.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_integration.py
@@ -1208,6 +1208,18 @@ class TestClientLines:
             me = client.get_me()
         assert me == {"id": "u1", "email": "me@x.example", "handle": "me"}
 
+    def test_get_me_raises_auth_error_on_401(self):
+        # /auth/me 401 means the session expired — get_me uses check_auth so
+        # it surfaces as AuthError (the global CLI handler prints it nicely).
+        from klangk.cli.client import AuthError, KlangkClient
+
+        client = KlangkClient("http://test:8995", "tok")
+        resp = MagicMock()
+        resp.status_code = 401
+        with patch.object(client, "get", return_value=resp):
+            with pytest.raises(AuthError):
+                client.get_me()
+
     def test_change_password_posts_payload(self):
         from klangk.cli.client import KlangkClient
 

--- a/src/klangk/klangkc-tests/tests/test_cli_main.py
+++ b/src/klangk/klangkc-tests/tests/test_cli_main.py
@@ -4771,3 +4771,230 @@ class TestAdminUsersCLI:
             ],
         )
         assert result.exit_code == 1
+
+
+class TestAccountCommands:
+    """klangk account {show,passwd,handle,email} — self-service (#1753)."""
+
+    def test_account_show(self, logged_in_cfg, monkeypatch):
+        from klangk.cli import main
+        from typer.testing import CliRunner
+
+        client = MagicMock()
+        client.get_me.return_value = {
+            "id": "u1",
+            "email": "me@x.example",
+            "handle": "me",
+        }
+        monkeypatch.setattr(main, "_client", lambda: client)
+        result = CliRunner().invoke(main.app, ["account", "show"])
+        assert result.exit_code == 0
+        out = result.output
+        assert "me@x.example" in out
+        assert "@me" in out
+
+    def test_account_passwd_success(self, logged_in_cfg, monkeypatch):
+        from klangk.cli import main
+        from typer.testing import CliRunner
+
+        client = MagicMock()
+        monkeypatch.setattr(main, "_client", lambda: client)
+        monkeypatch.setattr(main.account, "password_min_length", lambda url: 4)
+        answers = iter(["oldpw", "newpw12", "newpw12"])
+        monkeypatch.setattr(
+            "klangk.cli.main.Prompt.ask", lambda *a, **k: next(answers)
+        )
+        result = CliRunner().invoke(main.app, ["account", "passwd"])
+        assert result.exit_code == 0
+        client.change_password.assert_called_once_with("oldpw", "newpw12")
+
+    def test_account_passwd_mismatch(self, logged_in_cfg, monkeypatch):
+        from klangk.cli import main
+        from typer.testing import CliRunner
+
+        client = MagicMock()
+        monkeypatch.setattr(main, "_client", lambda: client)
+        answers = iter(["oldpw", "newpw12", "different"])
+        monkeypatch.setattr(
+            "klangk.cli.main.Prompt.ask", lambda *a, **k: next(answers)
+        )
+        result = CliRunner().invoke(main.app, ["account", "passwd"])
+        assert result.exit_code == 1
+        client.change_password.assert_not_called()
+
+    def test_account_passwd_too_short(self, logged_in_cfg, monkeypatch):
+        from klangk.cli import main
+        from typer.testing import CliRunner
+
+        client = MagicMock()
+        monkeypatch.setattr(main, "_client", lambda: client)
+        monkeypatch.setattr(
+            main.account, "password_min_length", lambda url: 12
+        )
+        answers = iter(["oldpw", "short", "short"])
+        monkeypatch.setattr(
+            "klangk.cli.main.Prompt.ask", lambda *a, **k: next(answers)
+        )
+        result = CliRunner().invoke(main.app, ["account", "passwd"])
+        assert result.exit_code == 1
+        client.change_password.assert_not_called()
+
+    def test_account_passwd_backend_error(self, logged_in_cfg, monkeypatch):
+        import httpx
+
+        from klangk.cli import main
+        from typer.testing import CliRunner
+
+        client = MagicMock()
+        req = httpx.Request("POST", "https://x")
+        bad = httpx.Response(401, text="bad", request=req)
+        client.change_password.side_effect = httpx.HTTPStatusError(
+            "401: Current password is incorrect", request=req, response=bad
+        )
+        monkeypatch.setattr(main, "_client", lambda: client)
+        monkeypatch.setattr(main.account, "password_min_length", lambda url: 4)
+        answers = iter(["oldpw", "newpw12", "newpw12"])
+        monkeypatch.setattr(
+            "klangk.cli.main.Prompt.ask", lambda *a, **k: next(answers)
+        )
+        result = CliRunner().invoke(main.app, ["account", "passwd"])
+        assert result.exit_code == 1
+
+    def test_account_handle_backend_error(self, logged_in_cfg, monkeypatch):
+        import httpx
+
+        from klangk.cli import main
+        from typer.testing import CliRunner
+
+        client = MagicMock()
+        client.get_me.return_value = {
+            "id": "u1",
+            "email": "me@x.example",
+            "handle": "old",
+        }
+        req = httpx.Request("POST", "https://x")
+        bad = httpx.Response(400, text="bad", request=req)
+        client.change_handle.side_effect = httpx.HTTPStatusError(
+            "400: Handle taken", request=req, response=bad
+        )
+        monkeypatch.setattr(main, "_client", lambda: client)
+        answers = iter(["newhandle", "pw"])
+        monkeypatch.setattr(
+            "klangk.cli.main.Prompt.ask", lambda *a, **k: next(answers)
+        )
+        monkeypatch.setattr(
+            "klangk.cli.main.Confirm.ask", lambda *a, **k: True
+        )
+        result = CliRunner().invoke(main.app, ["account", "handle"])
+        assert result.exit_code == 1
+
+    def test_account_email_backend_error(self, logged_in_cfg, monkeypatch):
+        import httpx
+
+        from klangk.cli import main
+        from typer.testing import CliRunner
+
+        client = MagicMock()
+        req = httpx.Request("POST", "https://x")
+        bad = httpx.Response(400, text="bad", request=req)
+        client.change_email.side_effect = httpx.HTTPStatusError(
+            "400: Email already in use", request=req, response=bad
+        )
+        monkeypatch.setattr(main, "_client", lambda: client)
+        answers = iter(["new@x.example", "pw"])
+        monkeypatch.setattr(
+            "klangk.cli.main.Prompt.ask", lambda *a, **k: next(answers)
+        )
+        result = CliRunner().invoke(main.app, ["account", "email"])
+        assert result.exit_code == 1
+
+    def test_account_handle_success(self, logged_in_cfg, monkeypatch):
+        from klangk.cli import main
+        from typer.testing import CliRunner
+
+        client = MagicMock()
+        client.get_me.return_value = {
+            "id": "u1",
+            "email": "me@x.example",
+            "handle": "old",
+        }
+        client.change_handle.return_value = "newhandle"
+        monkeypatch.setattr(main, "_client", lambda: client)
+        answers = iter(["newhandle", "pw"])
+        monkeypatch.setattr(
+            "klangk.cli.main.Prompt.ask", lambda *a, **k: next(answers)
+        )
+        monkeypatch.setattr(
+            "klangk.cli.main.Confirm.ask", lambda *a, **k: True
+        )
+        result = CliRunner().invoke(main.app, ["account", "handle"])
+        assert result.exit_code == 0
+        client.change_handle.assert_called_once_with("newhandle", "pw")
+
+    def test_account_handle_invalid(self, logged_in_cfg, monkeypatch):
+        from klangk.cli import main
+        from typer.testing import CliRunner
+
+        client = MagicMock()
+        monkeypatch.setattr(main, "_client", lambda: client)
+        monkeypatch.setattr(
+            "klangk.cli.main.Prompt.ask", lambda *a, **k: "Bad Handle!"
+        )
+        result = CliRunner().invoke(main.app, ["account", "handle"])
+        assert result.exit_code == 1
+        client.change_handle.assert_not_called()
+
+    def test_account_handle_cancelled(self, logged_in_cfg, monkeypatch):
+        from klangk.cli import main
+        from typer.testing import CliRunner
+
+        client = MagicMock()
+        client.get_me.return_value = {
+            "id": "u1",
+            "email": "me@x.example",
+            "handle": "old",
+        }
+        monkeypatch.setattr(main, "_client", lambda: client)
+        monkeypatch.setattr(
+            "klangk.cli.main.Prompt.ask", lambda *a, **k: "newhandle"
+        )
+        monkeypatch.setattr(
+            "klangk.cli.main.Confirm.ask", lambda *a, **k: False
+        )
+        result = CliRunner().invoke(main.app, ["account", "handle"])
+        assert result.exit_code == 0
+        client.change_handle.assert_not_called()
+
+    def test_account_email_success_rekeys_state(
+        self, logged_in_cfg, monkeypatch
+    ):
+        from klangk.cli.config import CLIState
+        from klangk.cli import main
+        from typer.testing import CliRunner
+
+        client = MagicMock()
+        monkeypatch.setattr(main, "_client", lambda: client)
+        answers = iter(["new@x.example", "pw"])
+        monkeypatch.setattr(
+            "klangk.cli.main.Prompt.ask", lambda *a, **k: next(answers)
+        )
+        result = CliRunner().invoke(main.app, ["account", "email"])
+        assert result.exit_code == 0
+        client.change_email.assert_called_once_with("new@x.example", "pw")
+        # Cached credentials re-keyed: token preserved, active user updated.
+        state = CLIState.load()
+        assert state.get_email("http://localhost:8995") == "new@x.example"
+        assert state.get_token("http://localhost:8995") == "test-token"
+
+    def test_account_email_invalid(self, logged_in_cfg, monkeypatch):
+        from klangk.cli import main
+        from typer.testing import CliRunner
+
+        client = MagicMock()
+        monkeypatch.setattr(main, "_client", lambda: client)
+        monkeypatch.setattr(
+            "klangk.cli.main.Prompt.ask", lambda *a, **k: "not-an-email"
+        )
+        result = CliRunner().invoke(main.app, ["account", "email"])
+        assert result.exit_code == 1
+        client.change_email.assert_not_called()

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -5964,6 +5964,22 @@ def test_tuistate_get_me_success():
     assert st.get_me() == {"id": "u1", "email": "e", "handle": "h"}
 
 
+def test_tuistate_get_me_session_expired():
+    # get_me uses check_auth, so a 401 surfaces as AuthError — the wrapper
+    # converts it to a friendly LoginError (not a raw traceback).
+    from unittest.mock import MagicMock
+
+    from klangk.cli.client import AuthError
+
+    client = MagicMock()
+    client.get_me.side_effect = AuthError(
+        "Session expired — run `klangk login`"
+    )
+    st = _tuistate_with_client(client)
+    with pytest.raises(LoginError, match="Session expired"):
+        st.get_me()
+
+
 def test_tuistate_change_password_success():
     from unittest.mock import MagicMock
 
@@ -6113,6 +6129,8 @@ async def test_account_screen_password_too_short(monkeypatch):
         s.query_one("#pw_new", Input).value = "short"
         s.query_one("#pw_confirm", Input).value = "short"
         s.on_button_pressed(FakeBtnPress("pw_submit"))
+        # min-length is now checked in the worker (off the event loop).
+        await app.workers.wait_for_complete()
         await pilot.pause()
         assert "at least 12" in str(s.query_one("#pw_msg").render())
 
@@ -6173,8 +6191,33 @@ async def test_account_screen_change_handle_success(monkeypatch):
         assert "Handle updated to @newhandle" in str(
             s.query_one("#handle_msg").render()
         )
-        # Profile refreshed with the new handle.
-        assert "@newhandle" in str(s.query_one("#profile").render())
+
+
+async def test_account_screen_handle_uses_server_accepted(monkeypatch):
+    """#1869 review: the TUI must adopt the server's accepted handle, not
+    the user's input, when they differ (e.g. uniqueness suffixing)."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    st = _account_state(change_handle=lambda handle, pw: "accepted")
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(AccountScreen())
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        s = app.screen
+        s.query_one("#handle_new", Input).value = "newhandle"
+        s.query_one("#handle_pw", Input).value = "pw"
+        s.on_button_pressed(FakeBtnPress("handle_submit"))
+        await pilot.pause()
+        app.screen.dismiss(True)
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        # Server returned "accepted", not the requested "newhandle".
+        assert "@accepted" in str(s.query_one("#handle_msg").render())
+        assert "@accepted" in str(s.query_one("#profile").render())
 
 
 async def test_account_screen_handle_invalid(monkeypatch):

--- a/src/klangk/klangkc-tests/tests/test_tui.py
+++ b/src/klangk/klangkc-tests/tests/test_tui.py
@@ -39,6 +39,7 @@ from klangk.cli.config import (
     update_server_in_config,
 )
 from klangk.cli.tui.screens import (
+    AccountScreen,
     AddServerScreen,
     ConfirmScreen,
     CreateWorkspaceScreen,
@@ -5883,3 +5884,542 @@ async def test_tab_skip_cycles_fields(monkeypatch):
         await pilot.press("tab")
         await pilot.pause()
         assert app.focused.id != "name"
+
+
+# ---------------------------------------------------------------------------
+# TuiState account wrappers (#1753) — real methods, not stubbed
+# ---------------------------------------------------------------------------
+
+
+def _tuistate_with_client(
+    client, *, url="https://x.example", email="me@x.example"
+):
+    from klangk.cli.config import CLIState
+
+    st = TuiState()
+    st.current_url = lambda: url
+    st.client = lambda: client
+    cli_state = CLIState()
+    if url is not None and email is not None:
+        cli_state.set_credentials(url, email, "tok")
+    cli_state.save = lambda: None
+    st.state = lambda: cli_state
+    return st
+
+
+def _status_err(msg, status=400):
+    req = httpx.Request("POST", "https://x")
+    return httpx.HTTPStatusError(
+        msg, request=req, response=httpx.Response(status, request=req)
+    )
+
+
+_ACCOUNT_METHODS = [
+    ("get_me", ()),
+    ("change_password", ("old", "new")),
+    ("change_handle", ("h", "pw")),
+    ("change_email", ("e@x.example", "pw")),
+]
+
+
+@pytest.mark.parametrize("method,args", _ACCOUNT_METHODS)
+def test_tuistate_account_no_server(method, args):
+    from unittest.mock import MagicMock
+
+    st = TuiState()
+    st.current_url = lambda: None
+    st.client = lambda: MagicMock()
+    with pytest.raises(LoginError, match="No server"):
+        getattr(st, method)(*args)
+
+
+@pytest.mark.parametrize("method,args", _ACCOUNT_METHODS)
+def test_tuistate_account_http_status_error(method, args):
+    from unittest.mock import MagicMock
+
+    client = MagicMock()
+    getattr(client, method).side_effect = _status_err("409: conflict")
+    st = _tuistate_with_client(client)
+    with pytest.raises(LoginError, match="409"):
+        getattr(st, method)(*args)
+
+
+@pytest.mark.parametrize("method,args", _ACCOUNT_METHODS)
+def test_tuistate_account_http_error(method, args):
+    from unittest.mock import MagicMock
+
+    client = MagicMock()
+    getattr(client, method).side_effect = httpx.ConnectError("down")
+    st = _tuistate_with_client(client)
+    with pytest.raises(LoginError, match="could not reach"):
+        getattr(st, method)(*args)
+
+
+def test_tuistate_get_me_success():
+    from unittest.mock import MagicMock
+
+    client = MagicMock()
+    client.get_me.return_value = {"id": "u1", "email": "e", "handle": "h"}
+    st = _tuistate_with_client(client)
+    assert st.get_me() == {"id": "u1", "email": "e", "handle": "h"}
+
+
+def test_tuistate_change_password_success():
+    from unittest.mock import MagicMock
+
+    client = MagicMock()
+    st = _tuistate_with_client(client)
+    st.change_password("old", "new")
+    client.change_password.assert_called_once_with("old", "new")
+
+
+def test_tuistate_change_handle_success():
+    from unittest.mock import MagicMock
+
+    client = MagicMock()
+    client.change_handle.return_value = "newh"
+    st = _tuistate_with_client(client)
+    assert st.change_handle("newh", "pw") == "newh"
+
+
+def test_tuistate_change_email_rekeys_state():
+    from unittest.mock import MagicMock
+
+    client = MagicMock()
+    st = _tuistate_with_client(client, email="old@x.example")
+    st.change_email("new@x.example", "pw")
+    client.change_email.assert_called_once_with("new@x.example", "pw")
+    # Token preserved, active user re-keyed to the new address.
+    assert st.state().get_email("https://x.example") == "new@x.example"
+    assert st.state().get_token("https://x.example") == "tok"
+
+
+def test_tuistate_change_email_same_address_no_rekey():
+    from unittest.mock import MagicMock
+
+    client = MagicMock()
+    st = _tuistate_with_client(client, email="same@x.example")
+    st.change_email("same@x.example", "pw")
+    client.change_email.assert_called_once_with("same@x.example", "pw")
+
+
+# ---------------------------------------------------------------------------
+# Account self-service screen (#1753)
+# ---------------------------------------------------------------------------
+
+
+def _account_state(**extra):
+    """Authed TuiState with account methods stubbed for AccountScreen tests."""
+    base = dict(
+        is_authenticated=lambda: True,
+        current_url=lambda: "https://x.example",
+        email=lambda: "me@x.example",
+        token=lambda: "tok",
+        known_servers=lambda: [],
+        list_owned_workspaces=lambda: [],
+        list_shared_workspaces=lambda: [],
+        get_me=lambda: {
+            "id": "u1",
+            "email": "me@x.example",
+            "handle": "me",
+        },
+        change_password=lambda current, new: None,
+        change_handle=lambda handle, pw: handle,
+        change_email=lambda email, pw: None,
+    )
+    base.update(extra)
+    return _st(**base)
+
+
+async def test_account_screen_loads_profile(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    app = KlangkApp(_account_state())
+    async with app.run_test() as pilot:
+        app.push_screen(AccountScreen())
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        profile = str(app.screen.query_one("#profile").render())
+        assert "me@x.example" in profile
+        assert "@me" in profile
+
+
+async def test_account_screen_change_password_success(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    calls = {}
+    st = _account_state(
+        change_password=lambda current, new: calls.__setitem__(
+            "pw", (current, new)
+        )
+    )
+    monkeypatch.setattr(scr.account, "password_min_length", lambda url: 4)
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(AccountScreen())
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        s = app.screen
+        s.query_one("#pw_current", Input).value = "oldpw"
+        s.query_one("#pw_new", Input).value = "newpw12"
+        s.query_one("#pw_confirm", Input).value = "newpw12"
+        s.on_button_pressed(FakeBtnPress("pw_submit"))
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert calls.get("pw") == ("oldpw", "newpw12")
+        assert "Password updated" in str(s.query_one("#pw_msg").render())
+        # Fields cleared on success.
+        assert s.query_one("#pw_current", Input).value == ""
+
+
+async def test_account_screen_password_mismatch(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    st = _account_state(change_password=lambda c, n: None)
+    monkeypatch.setattr(scr.account, "password_min_length", lambda url: 4)
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(AccountScreen())
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        s = app.screen
+        s.query_one("#pw_current", Input).value = "oldpw"
+        s.query_one("#pw_new", Input).value = "newpw12"
+        s.query_one("#pw_confirm", Input).value = "different"
+        s.on_button_pressed(FakeBtnPress("pw_submit"))
+        await pilot.pause()
+        assert "do not match" in str(s.query_one("#pw_msg").render())
+
+
+async def test_account_screen_password_too_short(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    monkeypatch.setattr(scr.account, "password_min_length", lambda url: 12)
+    app = KlangkApp(_account_state(change_password=lambda c, n: None))
+    async with app.run_test() as pilot:
+        app.push_screen(AccountScreen())
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        s = app.screen
+        s.query_one("#pw_current", Input).value = "oldpw"
+        s.query_one("#pw_new", Input).value = "short"
+        s.query_one("#pw_confirm", Input).value = "short"
+        s.on_button_pressed(FakeBtnPress("pw_submit"))
+        await pilot.pause()
+        assert "at least 12" in str(s.query_one("#pw_msg").render())
+
+
+async def test_account_screen_password_backend_error(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    def boom(current, new):
+        raise LoginError("401: Current password is incorrect")
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    monkeypatch.setattr(scr.account, "password_min_length", lambda url: 4)
+    app = KlangkApp(_account_state(change_password=boom))
+    async with app.run_test() as pilot:
+        app.push_screen(AccountScreen())
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        s = app.screen
+        s.query_one("#pw_current", Input).value = "oldpw"
+        s.query_one("#pw_new", Input).value = "newpw12"
+        s.query_one("#pw_confirm", Input).value = "newpw12"
+        s.on_button_pressed(FakeBtnPress("pw_submit"))
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert "Current password is incorrect" in str(
+            s.query_one("#pw_msg").render()
+        )
+
+
+async def test_account_screen_change_handle_success(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    calls = {}
+    st = _account_state(
+        change_handle=lambda handle, pw: (
+            calls.__setitem__("h", (handle, pw)) or "newhandle"
+        )
+    )
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(AccountScreen())
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        s = app.screen
+        s.query_one("#handle_new", Input).value = "newhandle"
+        s.query_one("#handle_pw", Input).value = "pw"
+        s.on_button_pressed(FakeBtnPress("handle_submit"))
+        await pilot.pause()
+        # Confirm dialog pushed.
+        assert isinstance(app.screen, ConfirmScreen)
+        app.screen.dismiss(True)
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert calls.get("h") == ("newhandle", "pw")
+        assert "Handle updated to @newhandle" in str(
+            s.query_one("#handle_msg").render()
+        )
+        # Profile refreshed with the new handle.
+        assert "@newhandle" in str(s.query_one("#profile").render())
+
+
+async def test_account_screen_handle_invalid(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    app = KlangkApp(_account_state(change_handle=lambda h, pw: h))
+    async with app.run_test() as pilot:
+        app.push_screen(AccountScreen())
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        s = app.screen
+        s.query_one("#handle_new", Input).value = "Bad Handle!"
+        s.query_one("#handle_pw", Input).value = "pw"
+        s.on_button_pressed(FakeBtnPress("handle_submit"))
+        await pilot.pause()
+        assert "lowercase" in str(s.query_one("#handle_msg").render())
+
+
+async def test_account_screen_handle_cancelled(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    called = {}
+    st = _account_state(change_handle=lambda h, pw: called.__setitem__("h", h))
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(AccountScreen())
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        s = app.screen
+        s.query_one("#handle_new", Input).value = "newhandle"
+        s.query_one("#handle_pw", Input).value = "pw"
+        s.on_button_pressed(FakeBtnPress("handle_submit"))
+        await pilot.pause()
+        assert isinstance(app.screen, ConfirmScreen)
+        app.screen.dismiss(False)
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert "h" not in called  # not invoked
+
+
+async def test_account_screen_change_email_success(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    calls = {}
+    st = _account_state(
+        change_email=lambda email, pw: calls.__setitem__("e", (email, pw))
+    )
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(AccountScreen())
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        s = app.screen
+        s.query_one("#email_new", Input).value = "new@x.example"
+        s.query_one("#email_pw", Input).value = "pw"
+        s.on_button_pressed(FakeBtnPress("email_submit"))
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert calls.get("e") == ("new@x.example", "pw")
+        assert "Email updated" in str(s.query_one("#email_msg").render())
+        assert "new@x.example" in str(s.query_one("#profile").render())
+
+
+async def test_account_screen_email_invalid(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    app = KlangkApp(_account_state(change_email=lambda e, pw: None))
+    async with app.run_test() as pilot:
+        app.push_screen(AccountScreen())
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        s = app.screen
+        s.query_one("#email_new", Input).value = "not-an-email"
+        s.query_one("#email_pw", Input).value = "pw"
+        s.on_button_pressed(FakeBtnPress("email_submit"))
+        await pilot.pause()
+        assert "valid email" in str(s.query_one("#email_msg").render())
+
+
+async def test_account_screen_password_required_fields(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    monkeypatch.setattr(scr.account, "password_min_length", lambda url: 4)
+    app = KlangkApp(_account_state(change_password=lambda c, n: None))
+    async with app.run_test() as pilot:
+        app.push_screen(AccountScreen())
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        s = app.screen
+        # Empty current/new -> rejected before any request.
+        s.query_one("#pw_current", Input).value = ""
+        s.query_one("#pw_new", Input).value = ""
+        s.query_one("#pw_confirm", Input).value = ""
+        s.on_button_pressed(FakeBtnPress("pw_submit"))
+        await pilot.pause()
+        assert "required" in str(s.query_one("#pw_msg").render())
+
+
+async def test_account_screen_handle_requires_password(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    app = KlangkApp(_account_state(change_handle=lambda h, pw: h))
+    async with app.run_test() as pilot:
+        app.push_screen(AccountScreen())
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        s = app.screen
+        s.query_one("#handle_new", Input).value = "newhandle"
+        s.query_one("#handle_pw", Input).value = ""
+        s.on_button_pressed(FakeBtnPress("handle_submit"))
+        await pilot.pause()
+        assert "Password is required" in str(
+            s.query_one("#handle_msg").render()
+        )
+
+
+async def test_account_screen_handle_backend_error(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    def boom(handle, pw):
+        raise LoginError("400: Handle taken")
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    app = KlangkApp(_account_state(change_handle=boom))
+    async with app.run_test() as pilot:
+        app.push_screen(AccountScreen())
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        s = app.screen
+        s.query_one("#handle_new", Input).value = "newhandle"
+        s.query_one("#handle_pw", Input).value = "pw"
+        s.on_button_pressed(FakeBtnPress("handle_submit"))
+        await pilot.pause()
+        app.screen.dismiss(True)  # confirm
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert "Handle taken" in str(s.query_one("#handle_msg").render())
+
+
+async def test_account_screen_email_requires_password(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    app = KlangkApp(_account_state(change_email=lambda e, pw: None))
+    async with app.run_test() as pilot:
+        app.push_screen(AccountScreen())
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        s = app.screen
+        s.query_one("#email_new", Input).value = "new@x.example"
+        s.query_one("#email_pw", Input).value = ""
+        s.on_button_pressed(FakeBtnPress("email_submit"))
+        await pilot.pause()
+        assert "Password is required" in str(
+            s.query_one("#email_msg").render()
+        )
+
+
+async def test_account_screen_email_backend_error(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    def boom(email, pw):
+        raise LoginError("400: Email already in use")
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    app = KlangkApp(_account_state(change_email=boom))
+    async with app.run_test() as pilot:
+        app.push_screen(AccountScreen())
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        s = app.screen
+        s.query_one("#email_new", Input).value = "new@x.example"
+        s.query_one("#email_pw", Input).value = "pw"
+        s.on_button_pressed(FakeBtnPress("email_submit"))
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert "already in use" in str(s.query_one("#email_msg").render())
+
+
+async def test_account_screen_enter_submits_section(monkeypatch):
+    """Enter in a section's last field submits that section."""
+
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    called = {}
+    st = _account_state(change_email=lambda e, pw: called.__setitem__("e", e))
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(AccountScreen())
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        s = app.screen
+        s.query_one("#email_new", Input).value = "new@x.example"
+        email_pw = s.query_one("#email_pw", Input)
+        email_pw.value = "pw"
+        s.on_input_submitted(Input.Submitted(email_pw, email_pw.value))
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert called.get("e") == "new@x.example"
+
+
+async def test_account_screen_load_profile_error(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    st = _account_state(
+        get_me=lambda: (_ for _ in ()).throw(LoginError("nope"))
+    )
+    app = KlangkApp(st)
+    async with app.run_test() as pilot:
+        app.push_screen(AccountScreen())
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert "nope" in str(app.screen.query_one("#profile").render())
+
+
+async def test_main_screen_action_account_opens_screen(monkeypatch):
+    async def noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(scr, "listen_for_status", noop)
+    monkeypatch.setattr(scr.account, "password_min_length", lambda url: 4)
+    app = KlangkApp(_account_state())
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        app.screen.action_account()
+        await pilot.pause()
+        assert isinstance(app.screen, AccountScreen)


### PR DESCRIPTION
## Summary

Closes #1753. Account self-service — change password / handle / email —
from **both** the CLI and the TUI, at parity with the Flutter
`SettingsPage`.

## CLI

New `klangk account` group:

```
klangk account show    # current handle + email (GET /auth/me)
klangk account passwd  # change password (prompts current + new + confirm)
klangk account handle  # change handle (prompts new handle + password, confirms)
klangk account email   # change email (prompts new email + password)
```

## TUI

New `AccountScreen` — press **`a`** from the workspace list. Three sections
(password / handle / email) with inline validation and a status line each;
profile (email + `@handle`) loaded from `/auth/me` and refreshed after a
change. Handle change goes through a confirm dialog (it affects the terminal
home directory). Spatial up/down navigates the field chain; Enter in a
section's last field submits it.

## Validation parity

Both surfaces share `klangk/cli/account.py` and apply the same client-side
checks the Flutter app does (server re-validates authoritatively):

- **handle** — non-empty, lowercase, `[a-z0-9._-]+`, ≤32 chars
- **email** — `^[^@\s]+@[^@\s]+\.[^@\s]+$`
- **password** — minimum length read from `/api/v1/config`
  (`min_password_length`), not hardcoded

## Credential re-keying

The JWT subject is the user id, not the email, so the cached token stays
valid across an email change — only the key it's filed under in
`klangk-state.yaml` changes. `CLIState.rename_user` moves the entry in
place (no parallel store); the CLI `account email` command and the
`TuiState.change_email` wrapper both call it.

## Notable detail

The `change_password` / `change_email` / `change_handle` client methods
**skip `check_auth`**: those endpoints return 401 for a wrong current
password, and `check_auth` would mask that as "Session expired". Relying on
`_raise_for_status` surfaces the server's real `detail`
("Current password is incorrect").

## Test plan

- [x] New `test_account.py` — validation module (handle/email/password-min).
- [x] `test_cli_main.py::TestAccountCommands` — all four commands incl. mismatch / too-short / invalid / cancelled / backend-error paths.
- [x] `test_cli_integration.py` — client payload assertions for `get_me` / `change_password` / `change_email` / `change_handle`.
- [x] `test_cli.py` — `CLIState.rename_user` (move + noop).
- [x] `test_tui.py` — `AccountScreen` flows (load, all three changes success + validation + backend-error + cancelled), the MainScreen `a` entry point, and the real `TuiState` account wrappers (success / no-server / HTTPStatusError / HTTPError / email re-key).
- [x] Full Python suite (CI invocation): `pytest src/klangk/klangkd-tests/tests src/klangk/klangkc-tests/tests -v -n auto` — **3785 passed, 100% coverage**, clean under `-W error`.
- [x] Rebased onto latest `main`; pre-commit (markdownlint, prettier, ruff, trufflehog) all pass.

Closes #1753
